### PR TITLE
allow prometheus.yaml to be extended by the regional values.yaml

### DIFF
--- a/system/kube-monitoring/charts/prometheus-collector/templates/_prometheus.yaml.tpl
+++ b/system/kube-monitoring/charts/prometheus-collector/templates/_prometheus.yaml.tpl
@@ -1,3 +1,4 @@
+{{- define "prometheus_yaml" -}}
 rule_files:
   - ./*.rules
 
@@ -236,3 +237,7 @@ scrape_configs:
 - job_name: 'prometheus-collector'
   static_configs:
     - targets: ['localhost:9090']
+
+{{ .Values.additional_scrape_configs }}
+
+{{- end -}}

--- a/system/kube-monitoring/charts/prometheus-collector/templates/config.yaml
+++ b/system/kube-monitoring/charts/prometheus-collector/templates/config.yaml
@@ -5,7 +5,10 @@ metadata:
 
 data:
   {{- $files := .Files }}
-  {{ range tuple "aggregation.rules" "prometheus.yaml" }}
+  {{ range tuple "aggregation.rules" }}
   {{ . }}: |
 {{ $files.Get . | indent 4 }}
   {{- end }}
+
+  prometheus.yaml: |
+{{ include "prometheus_yaml" . | indent 4 }}

--- a/system/kube-monitoring/charts/prometheus-collector/values.yaml
+++ b/system/kube-monitoring/charts/prometheus-collector/values.yaml
@@ -2,3 +2,7 @@ image: prom/prometheus:v1.4.1
 retention: 1h0m0s
 memory_chunks: "262144"
 max_chunks_to_persist: "131072"
+
+# This can be provided by the regional values.yaml to connect Prometheus to
+# legacy systems in this region.
+additional_scrape_configs: ""


### PR DESCRIPTION
I need this to make Prometheus scrape our legacy Swift nodes.