### PR TITLE
add some alert definitions for node health (CPU usage, TCP connections)

### DIFF
--- a/global/prometheus-alertmanager/templates/config.yaml
+++ b/global/prometheus-alertmanager/templates/config.yaml
@@ -31,7 +31,7 @@ data:
       - receiver: kubernetes-info
         continue: true
         match_re:
-          service: k8s|etcd|prometheus|dns
+          service: k8s|etcd|prometheus|dns|node
         routes:
         - receiver: 'kubernetes-warning'
           match:
@@ -47,7 +47,7 @@ data:
       {{- range tuple "staging" "eu-de-1" "ap-au-1" "na-us-1" }}
       - receiver: region_{{ . }}
         match_re:
-          service: k8s|etcd|prometheus|dns
+          service: k8s|etcd|prometheus|dns|node
           cluster: {{ . }}
           severity: critical
       {{- end }}

--- a/system/kube-monitoring/charts/prometheus-frontend/node.alerts
+++ b/system/kube-monitoring/charts/prometheus-frontend/node.alerts
@@ -1,0 +1,46 @@
+### General node health ###
+
+ALERT NodeHighCpuUsage
+  IF avg by(instance)(irate(node_cpu{mode="idle"}[5m])) < 0.2
+  FOR 3m
+  LABELS {
+    service   = "node",
+    severity  = "warning",
+    context   = "availability",
+    dashboard = "kubernetes-node?var-server={{$labels.instance}}"
+  }
+  ANNOTATIONS {
+    summary = "High load on node",
+    description = "The node {{ $labels.instance }} has more than 80% CPU load.",
+  }
+
+### Network health ###
+
+ALERT NodeHighNumberOfOpenConnections
+  IF node_netstat_Tcp_CurrEstab{instance!~"master.*"} > 1000
+  FOR 3m
+  LABELS {
+    service = "node",
+    severity = "warning",
+    context = "availability",
+    dashboard = "kubernetes-node?var-server={{$labels.instance}}"
+  }
+  ANNOTATIONS {
+    summary = "High number of open TCP connections",
+    description = "The node {{ $labels.instance }} has more than 1000 active TCP connections.",
+  }
+
+# master nodes get a bit more headspace for all the open connections to the kube-proxy
+ALERT NodeHighNumberOfOpenConnections
+  IF node_netstat_Tcp_CurrEstab{instance=~"master.*"} > 1500
+  FOR 3m
+  LABELS {
+    service = "node",
+    severity = "warning",
+    context = "availability",
+    dashboard = "kubernetes-node?var-server={{$labels.instance}}"
+  }
+  ANNOTATIONS {
+    summary = "High number of open TCP connections",
+    description = "The master node {{ $labels.instance }} has more than 1500 active TCP connections.",
+  }

--- a/system/kube-monitoring/charts/prometheus-frontend/templates/config.yaml
+++ b/system/kube-monitoring/charts/prometheus-frontend/templates/config.yaml
@@ -5,7 +5,7 @@ metadata:
 
 data:
   {{- $files := .Files }}
-  {{ range tuple "ca.crt" "etcd.alerts" "kubernetes.alerts" "dns.alerts" "cluster.rules" }}
+  {{ range tuple "ca.crt" "etcd.alerts" "kubernetes.alerts" "node.alerts" "dns.alerts" "cluster.rules" }}
   {{ . }}: |
 {{ $files.Get . | indent 4 }}
   {{- end }}


### PR DESCRIPTION
These alert definitions come from the legacy Swift, but since they apply to the control plane rather than the Swift service, I feel more comfortable putting them in here than into the Swift chart etc.