### PR TITLE
unify swift-drive-autopilot config across clusters

### DIFF
--- a/openstack/swift/charts/swift_drive_autopilot/templates/configmap.yaml
+++ b/openstack/swift/charts/swift_drive_autopilot/templates/configmap.yaml
@@ -13,7 +13,8 @@ data:
     chroot: /coreos
 
     drives:
-      - {{.Values.drive_glob}}
+      - /dev/sd[a-z]
+      - /dev/sd[a-z][a-z]
 
     # the Swift user and group is UID/GID 1000 in the Kolla containers
     chown:
@@ -25,9 +26,6 @@ data:
       - secret: {{.Values.encryption_key}}
     {{ end }}
 
-    {{- if .Values.drive_count -}}
-    {{ $cnt := int .Values.drive_count }}
-    swift-id-pool: {{ range $idx := until $cnt }}
+    swift-id-pool: {{ range $idx := until 99 }}
       - swift-{{ $idx | add1 | printf "%02d" -}}
     {{ end -}}
-    {{- end -}}

--- a/openstack/swift/charts/swift_drive_autopilot/values.yaml
+++ b/openstack/swift/charts/swift_drive_autopilot/values.yaml
@@ -1,4 +1,2 @@
-drive_count: DEFINED_IN_REGION_CHART
-drive_glob: DEFINED_IN_REGION_CHART
 encryption_key: DEFINED_IN_REGION_CHART
 image_version: DEFINED_IN_REGION_CHART


### PR DESCRIPTION
This simplification is made possible by two changes:

1. The autopilot will not complain about an unmatching glob on
`/dev/sd[a-z][a-z]` when there are fewer than 26 drives.

2. The autopilot guarantees (both by documentation and by test coverage)
that swift-ids will always be assigned in order, so we can just put
`swift-01` through `swift-99` into the pool, and it will only use the
lowest-numbered IDs (e.g. `swift-01` through `swift-12` if there are 12
eligible drives).

@d044166 You okay with this? If so, I will merge. (Please don't merge yourself, I need to bump the image version on the autopilot in all regions.)