### PR TITLE
Content Repo - Client SSL auth support

### DIFF
--- a/openstack/content-repo/templates/_scheduledjob.yaml
+++ b/openstack/content-repo/templates/_scheduledjob.yaml
@@ -19,17 +19,25 @@ spec:
             - name: config
               configMap:
                 name: swift-http-import
+            - name: secret
+              secret:
+                secretName: swift-http-import
+                optional: true
           containers:
           - name: swift-http-import
             image: {{$.Values.global.docker_repo}}/swift-http-import:{{$.Values.image_version}}
             args:
-              - /etc/http-import/{{$repo}}.yaml
-            # env:
-            #   - name: 'DEBUG'
-            #     value: '1'
+              - /etc/http-import/config/{{$repo}}.yaml
+            {{- if $.Values.debug}}
+            env:
+              - name: 'DEBUG'
+                value: '1'
+            {{- end}}
             volumeMounts:
-              - mountPath: /etc/http-import
+              - mountPath: /etc/http-import/config
                 name: config
+              - mountPath: /etc/http-import/secret
+                name: secret
 
 ---
 {{end}}

--- a/openstack/content-repo/templates/configmap.yaml
+++ b/openstack/content-repo/templates/configmap.yaml
@@ -23,6 +23,12 @@ data:
       {{- range $index, $job := $config.jobs}}
       - from: {{$job.source}}
         to:   {{$job.target}}
+        {{- if $job.cert}}
+        cert: {{$job.cert}}
+        key:  {{$job.key}}
+        {{- end}}
+        {{- if $job.ca}}
+        ca:   {{$job.ca}}
+        {{- end}}
       {{- end}}
-
-{{end}}
+{{- end}}

--- a/openstack/content-repo/templates/job.yaml
+++ b/openstack/content-repo/templates/job.yaml
@@ -15,17 +15,25 @@ spec:
         - name: config
           configMap:
             name: swift-http-import
+        - name: secret
+          secret:
+            secretName: swift-http-import
+            optional: true
       containers:
       - name: swift-http-import
         image: {{$.Values.global.docker_repo}}/swift-http-import:{{$.Values.image_version}}
         args:
-          - /etc/http-import/{{$repo}}.yaml
-        # env:
-        #   - name: 'DEBUG'
-        #     value: '1'
+          - /etc/http-import/config/{{$repo}}.yaml
+        {{- if $.Values.debug}}
+        env:
+          - name: 'DEBUG'
+            value: '1'
+        {{- end}}
         volumeMounts:
-          - mountPath: /etc/http-import
+          - mountPath: /etc/http-import/config
             name: config
+          - mountPath: /etc/http-import/secret
+            name: secret
 
 ---
 {{end}}

--- a/openstack/content-repo/templates/secrets.yaml
+++ b/openstack/content-repo/templates/secrets.yaml
@@ -1,0 +1,15 @@
+kind: Secret
+apiVersion: v1
+
+metadata:
+  name: swift-http-import
+  labels:
+    system: openstack
+    component: content-repo
+
+data:
+{{- range $name, $config := .Values.client_certs }}
+  {{- range $file, $data := $config }}
+  {{$name}}-{{$file}}: {{ $data | b64enc }}
+  {{- end}}
+{{- end}}

--- a/openstack/content-repo/values.yaml
+++ b/openstack/content-repo/values.yaml
@@ -1,3 +1,6 @@
+image_version: DEFINED_IN_REGION_CHART
+debug: false
+
 auth_url: DEFINED_IN_REGION_CHART
 user_name: DEFINED_IN_REGION_CHART
 user_domain_name: DEFINED_IN_REGION_CHART
@@ -5,10 +8,24 @@ project_name: DEFINED_IN_REGION_CHART
 project_domain_name: DEFINED_IN_REGION_CHART
 password: DEFINED_IN_REGION_CHART
 region_name: DEFINED_IN_REGION_CHART
+
 repos:
   ubuntu:
     run_hour: 6
     jobs:
       - source: DEFINED_IN_REGION_CHART
         target: DEFINED_IN_REGION_CHART
-image_version: DEFINED_IN_REGION_CHART
+  rhel:
+    run_hour: 8
+    jobs:
+      - source: DEFINED_IN_REGION_CHART
+        target: DEFINED_IN_REGION_CHART
+        cert:   DEFINED_IN_REGION_CHART
+        key:    DEFINED_IN_REGION_CHART
+        ca:     DEFINED_IN_REGION_CHART
+
+client_certs:
+  rhel:
+    entitlement.pem: DEFINED_IN_REGION_CHART
+    entitlement-key.pem: DEFINED_IN_REGION_CHART
+    ca.pem: DEFINED_IN_REGION_CHART


### PR DESCRIPTION
* Adding support for client ssl auth
* Certs go to secrets
* Config will no be mounted to /etc/http-import/config
* certs can be found in /etc/http-import/secret