### PR TITLE
add spare disks to swift-drive-autopilot config

### DIFF
--- a/openstack/swift/charts/swift_drive_autopilot/templates/configmap.yaml
+++ b/openstack/swift/charts/swift_drive_autopilot/templates/configmap.yaml
@@ -27,5 +27,8 @@ data:
     {{ end }}
 
     swift-id-pool: {{ range $idx := until 99 }}
-      - swift-{{ $idx | add1 | printf "%02d" -}}
+      - swift-{{ printf "%02d" (add1 $idx) }}
+      {{- if eq 0 (mod (add1 $idx) $.Values.one_spare_disk_every) }}
+      - spare
+      {{- end -}}
     {{ end -}}

--- a/openstack/swift/charts/swift_drive_autopilot/values.yaml
+++ b/openstack/swift/charts/swift_drive_autopilot/values.yaml
@@ -1,2 +1,7 @@
 encryption_key: DEFINED_IN_REGION_CHART
 image_version: DEFINED_IN_REGION_CHART
+
+# This setting means that after every 20 disks allocated on one node, one disk
+# will be set aside as spare capacity. (See swift-drive-autopilot docs for
+# details.)
+one_spare_disk_every: 20


### PR DESCRIPTION
The `drive-autopilot.yaml` now renders like this:

```yaml
chroot: /coreos

drives:
  - /dev/sd[a-z]
  - /dev/sd[a-z][a-z]

# the Swift user and group is UID/GID 1000 in the Kolla containers
chown:
  user: "1000"
  group: "1000"

keys:
  - secret: DEFINED_IN_REGION_CHART


swift-id-pool: 
  - swift-01
  - swift-02
  - swift-03
  - swift-04
  - swift-05
  - swift-06
  - swift-07
  - swift-08
  - swift-09
  - swift-10
  - swift-11
  - swift-12
  - swift-13
  - swift-14
  - swift-15
  - swift-16
  - swift-17
  - swift-18
  - swift-19
  - swift-20
  - spare
  - swift-21
  - swift-22
  - swift-23
  - swift-24
  - swift-25
  - swift-26
  - swift-27
  - swift-28
  - swift-29
  - swift-30
  - swift-31
  - swift-32
  - swift-33
  - swift-34
  - swift-35
  - swift-36
  - swift-37
  - swift-38
  - swift-39
  - swift-40
  - spare
  - swift-41
  - swift-42
  - swift-43
  - swift-44
  - swift-45
  - swift-46
  - swift-47
  - swift-48
  - swift-49
  - swift-50
  - swift-51
  - swift-52
  - swift-53
  - swift-54
  - swift-55
  - swift-56
  - swift-57
  - swift-58
  - swift-59
  - swift-60
  - spare
  - swift-61
  - swift-62
  - swift-63
  - swift-64
  - swift-65
  - swift-66
  - swift-67
  - swift-68
  - swift-69
  - swift-70
  - swift-71
  - swift-72
  - swift-73
  - swift-74
  - swift-75
  - swift-76
  - swift-77
  - swift-78
  - swift-79
  - swift-80
  - spare
  - swift-81
  - swift-82
  - swift-83
  - swift-84
  - swift-85
  - swift-86
  - swift-87
  - swift-88
  - swift-89
  - swift-90
  - swift-91
  - swift-92
  - swift-93
  - swift-94
  - swift-95
  - swift-96
  - swift-97
  - swift-98
  - swift-99
```