### PR TITLE
move swift rule to sep. file in prom frontend

### DIFF
--- a/system/kube-monitoring/charts/prometheus-collector/aggregation.rules
+++ b/system/kube-monitoring/charts/prometheus-collector/aggregation.rules
@@ -1,3 +1,4 @@
 aggregated:container_cpu_system_seconds_total{} = sum(container_cpu_system_seconds_total) by (id) keep_common
 aggregated:container_cpu_usage_seconds_total{} = sum(container_cpu_usage_seconds_total) by (id) keep_common
 aggregated:container_cpu_user_seconds_total{} = sum(container_cpu_user_seconds_total) by (id) keep_common
+aggregated:swift_cluster_storage_used_percent_gauge_average{} = avg(swift_cluster_storage_used_percent_gauge) by (cluster) keep_common

--- a/system/kube-monitoring/charts/prometheus-collector/aggregation.rules
+++ b/system/kube-monitoring/charts/prometheus-collector/aggregation.rules
@@ -1,4 +1,3 @@
 aggregated:container_cpu_system_seconds_total{} = sum(container_cpu_system_seconds_total) by (id) keep_common
 aggregated:container_cpu_usage_seconds_total{} = sum(container_cpu_usage_seconds_total) by (id) keep_common
 aggregated:container_cpu_user_seconds_total{} = sum(container_cpu_user_seconds_total) by (id) keep_common
-avg:swift_cluster_storage_used_percent_gauge{} = avg(swift_cluster_storage_used_percent_gauge) by (cluster) keep_common

--- a/system/kube-monitoring/charts/prometheus-frontend/swift.rules
+++ b/system/kube-monitoring/charts/prometheus-frontend/swift.rules
@@ -1,1 +1,0 @@
-avg:swift_cluster_storage_used_percent_gauge{} = avg(swift_cluster_storage_used_percent_gauge) by (cluster) keep_common

--- a/system/kube-monitoring/charts/prometheus-frontend/swift.rules
+++ b/system/kube-monitoring/charts/prometheus-frontend/swift.rules
@@ -1,0 +1,1 @@
+avg:swift_cluster_storage_used_percent_gauge{} = avg(swift_cluster_storage_used_percent_gauge) by (cluster) keep_common


### PR DESCRIPTION
move rule avg:swift_cluster_storage_used_percent_gauge{} to separate swift.rules in prom. frontend
Looks good @majewsky?

/cc @reimannf More swift rules could go here `system/kube-monitoring/charts/prometheus-frontend/swift.rules`