### PR TITLE
Prometheus v1.5.1

### DIFF
--- a/global/prometheus/values.yaml
+++ b/global/prometheus/values.yaml
@@ -1,4 +1,4 @@
-image: prom/prometheus:v1.5.0
+image: prom/prometheus:v1.5.1
 retention: 168h0m0s
 memory_chunks: "4194304"
 max_chunks_to_persist: "2097152"

--- a/system/kube-monitoring/charts/prometheus-collector/values.yaml
+++ b/system/kube-monitoring/charts/prometheus-collector/values.yaml
@@ -1,4 +1,4 @@
-image: prom/prometheus:v1.5.0
+image: prom/prometheus:v1.5.1
 retention: 1h0m0s
 memory_chunks: "262144"
 max_chunks_to_persist: "131072"

--- a/system/kube-monitoring/charts/prometheus-frontend/values.yaml
+++ b/system/kube-monitoring/charts/prometheus-frontend/values.yaml
@@ -1,4 +1,4 @@
-image: prom/prometheus:v1.5.0
+image: prom/prometheus:v1.5.1
 retention: 168h0m0s
 memory_chunks: "4194304"
 max_chunks_to_persist: "2097152"


### PR DESCRIPTION
Use [latest Prometheus](https://github.com/prometheus/prometheus/releases/tag/v1.5.1). It already runs happily in staging. 
Ok @majewsky?