### PR TITLE
[swift] reduce code duplication among daemonset yamls

### DIFF
--- a/openstack/swift/templates/_utils.tpl
+++ b/openstack/swift/templates/_utils.tpl
@@ -5,3 +5,95 @@
         objectstore.{{.Values.global.region}}.{{.Values.global.domain}}
     {{- end -}}
 {{- end -}}
+
+{{- /**********************************************************************************/ -}}
+{{- define "swift_daemonset_annotations" }}
+scheduler.alpha.kubernetes.io/tolerations: '[{"key":"species","value":"swift-storage"}]'
+{{- if .Values.enable_statsd }}
+prometheus.io/scrape: "true"
+prometheus.io/port: "9102"
+{{- end }}
+{{- end -}}
+
+{{- /**********************************************************************************/ -}}
+{{- define "swift_daemonset_volumes" }}
+- name: swift-bin
+  configMap:
+    name: swift-bin
+- name: swift-etc
+  configMap:
+    name: swift-etc
+- name: swift-account-ring
+  configMap:
+    name: swift-account-ring
+- name: swift-container-ring
+  configMap:
+    name: swift-container-ring
+- name: swift-object-ring
+  configMap:
+    name: swift-object-ring
+- name: swift-drives
+  hostPath:
+    path: /srv/node
+- name: swift-cache
+  hostPath:
+    path: /var/cache/swift
+- name: swift-drive-state
+  hostPath:
+    path: /run/swift-storage/state
+{{- end -}}
+
+{{- /**********************************************************************************/ -}}
+{{- define "swift_standard_container" -}}
+{{- $image   := index . 0 -}}
+{{- $name    := index . 1 -}}
+{{- $service := index . 2 -}}
+{{- $context := index . 3 }}
+- name: {{ $name }}
+  image: {{$context.Values.global.docker_repo}}/ubuntu-source-swift-{{ $image }}-m3:{{ printf "image_version_swift_%s" $image | index $context.Values }}
+  command:
+    - /usr/bin/dumb-init
+  args:
+    - /bin/bash
+    - /swift-bin/swift-start
+    - {{ $service }}
+  # privileged access required for /swift-bin/unmount-helper (TODO: use shared/slave mount namespace instead)
+  securityContext:
+    privileged: true
+  env:
+    - name: DEBUG_CONTAINER
+      value: "false"
+  volumeMounts:
+    - mountPath: /swift-bin
+      name: swift-bin
+    - mountPath: /swift-etc
+      name: swift-etc
+    - mountPath: /swift-rings/account
+      name: swift-account-ring
+    - mountPath: /swift-rings/container
+      name: swift-container-ring
+    - mountPath: /swift-rings/object
+      name: swift-object-ring
+    - mountPath: /srv/node
+      name: swift-drives
+    - mountPath: /var/cache/swift
+      name: swift-cache
+    - mountPath: /swift-drive-state
+      name: swift-drive-state
+{{- end -}}
+
+{{- /**********************************************************************************/ -}}
+{{- define "swift_statsd_exporter_container" }}
+- name: statsd
+  image: prom/statsd-exporter:{{.Values.image_version_auxiliary_statsd_exporter}}
+  args: [ -statsd.mapping-config=/swift-etc/statsd-exporter.conf ]
+  ports:
+    - name: statsd
+      containerPort: 9125
+      protocol: UDP
+    - name: metrics
+      containerPort: 9102
+  volumeMounts:
+    - mountPath: /swift-etc
+      name: swift-etc
+{{- end -}}

--- a/openstack/swift/templates/account-daemonset.yaml
+++ b/openstack/swift/templates/account-daemonset.yaml
@@ -14,147 +14,17 @@ spec:
       labels:
         component: swift-account
         from: daemonset
-      annotations:
-        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"species","value":"swift-storage"}]'
-        {{- if .Values.enable_statsd }}
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9102"
-        {{- end }}
+      annotations: {{ include "swift_daemonset_annotations" . | indent 8 }}
     spec:
       nodeSelector:
         species: swift-storage
-      volumes:
-        - name: swift-bin
-          configMap:
-            name: swift-bin
-        - name: swift-etc
-          configMap:
-            name: swift-etc
-        - name: swift-account-ring
-          configMap:
-            name: swift-account-ring
-        - name: swift-container-ring
-          configMap:
-            name: swift-container-ring
-        - name: swift-object-ring
-          configMap:
-            name: swift-object-ring
-        - name: swift-drives
-          hostPath:
-            path: /srv/node
-        - name: swift-cache
-          hostPath:
-            path: /var/cache/swift
-        - name: swift-drive-state
-          hostPath:
-            path: /run/swift-storage/state
+      volumes: {{ include "swift_daemonset_volumes" . | indent 8 }}
       containers:
-        - name: server
-          image: {{.Values.global.docker_repo}}/ubuntu-source-swift-account-m3:{{.Values.image_version_swift_account}}
-          command:
-            - /usr/bin/dumb-init
-          args:
-            - /bin/bash
-            - /swift-bin/swift-start
-            - account-server
-          # privileged access required for /swift-bin/unmount-helper (TODO: use shared/slave mount namespace instead)
-          securityContext:
-            privileged: true
-          env:
-            - name: DEBUG_CONTAINER
-              value: "false"
-          volumeMounts:
-            - mountPath: /swift-bin
-              name: swift-bin
-            - mountPath: /swift-etc
-              name: swift-etc
-            - mountPath: /swift-rings/account
-              name: swift-account-ring
-            - mountPath: /swift-rings/container
-              name: swift-container-ring
-            - mountPath: /swift-rings/object
-              name: swift-object-ring
-            - mountPath: /srv/node
-              name: swift-drives
-            - mountPath: /var/cache/swift
-              name: swift-cache
-            - mountPath: /swift-drive-state
-              name: swift-drive-state
+        {{- tuple "account" "server"  "account-server"  . | include "swift_standard_container" | indent 8 }}
           ports:
             - name: swift-account
               hostPort: 6002
               containerPort: 6002
-        - name: auditor
-          image: {{.Values.global.docker_repo}}/ubuntu-source-swift-account-m3:{{.Values.image_version_swift_account}}
-          command:
-            - /usr/bin/dumb-init
-          args:
-            - /bin/bash
-            - /swift-bin/swift-start
-            - account-auditor
-          # privileged access required for /swift-bin/unmount-helper (TODO: use shared/slave mount namespace instead)
-          securityContext:
-            privileged: true
-          env:
-            - name: DEBUG_CONTAINER
-              value: "false"
-          volumeMounts:
-            - mountPath: /swift-bin
-              name: swift-bin
-            - mountPath: /swift-etc
-              name: swift-etc
-            - mountPath: /swift-rings/account
-              name: swift-account-ring
-            - mountPath: /swift-rings/container
-              name: swift-container-ring
-            - mountPath: /swift-rings/object
-              name: swift-object-ring
-            - mountPath: /srv/node
-              name: swift-drives
-            - mountPath: /var/cache/swift
-              name: swift-cache
-            - mountPath: /swift-drive-state
-              name: swift-drive-state
-        - name: reaper
-          image: {{.Values.global.docker_repo}}/ubuntu-source-swift-account-m3:{{.Values.image_version_swift_account}}
-          command:
-            - /usr/bin/dumb-init
-          args:
-            - /bin/bash
-            - /swift-bin/swift-start
-            - account-reaper
-          # privileged access required for /swift-bin/unmount-helper (TODO: use shared/slave mount namespace instead)
-          securityContext:
-            privileged: true
-          env:
-            - name: DEBUG_CONTAINER
-              value: "false"
-          volumeMounts:
-            - mountPath: /swift-bin
-              name: swift-bin
-            - mountPath: /swift-etc
-              name: swift-etc
-            - mountPath: /swift-rings/account
-              name: swift-account-ring
-            - mountPath: /swift-rings/container
-              name: swift-container-ring
-            - mountPath: /swift-rings/object
-              name: swift-object-ring
-            - mountPath: /srv/node
-              name: swift-drives
-            - mountPath: /var/cache/swift
-              name: swift-cache
-            - mountPath: /swift-drive-state
-              name: swift-drive-state
-        - name: statsd
-          image: prom/statsd-exporter:{{.Values.image_version_auxiliary_statsd_exporter}}
-          args: [ -statsd.mapping-config=/swift-etc/statsd-exporter.conf ]
-          ports:
-            - name: statsd
-              containerPort: 9125
-              protocol: UDP
-            - name: metrics
-              containerPort: 9102
-          volumeMounts:
-            - mountPath: /swift-etc
-              name: swift-etc
+        {{- tuple "account" "auditor" "account-auditor" . | include "swift_standard_container" | indent 8 }}
+        {{- tuple "account" "reaper"  "account-reaper"  . | include "swift_standard_container" | indent 8 }}
+        {{- include "swift_statsd_exporter_container" . | indent 8 }}

--- a/openstack/swift/templates/container-daemonset.yaml
+++ b/openstack/swift/templates/container-daemonset.yaml
@@ -14,147 +14,17 @@ spec:
       labels:
         component: swift-container
         from: daemonset
-      annotations:
-        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"species","value":"swift-storage"}]'
-        {{- if .Values.enable_statsd }}
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9102"
-        {{- end }}
+      annotations: {{ include "swift_daemonset_annotations" . | indent 8 }}
     spec:
       nodeSelector:
         species: swift-storage
-      volumes:
-        - name: swift-bin
-          configMap:
-            name: swift-bin
-        - name: swift-etc
-          configMap:
-            name: swift-etc
-        - name: swift-account-ring
-          configMap:
-            name: swift-account-ring
-        - name: swift-container-ring
-          configMap:
-            name: swift-container-ring
-        - name: swift-object-ring
-          configMap:
-            name: swift-object-ring
-        - name: swift-drives
-          hostPath:
-            path: /srv/node
-        - name: swift-cache
-          hostPath:
-            path: /var/cache/swift
-        - name: swift-drive-state
-          hostPath:
-            path: /run/swift-storage/state
+      volumes: {{ include "swift_daemonset_volumes" . | indent 8 }}
       containers:
-        - name: server
-          image: {{.Values.global.docker_repo}}/ubuntu-source-swift-container-m3:{{.Values.image_version_swift_container}}
-          command:
-            - /usr/bin/dumb-init
-          args:
-            - /bin/bash
-            - /swift-bin/swift-start
-            - container-server
-          # privileged access required for /swift-bin/unmount-helper (TODO: use shared/slave mount namespace instead)
-          securityContext:
-            privileged: true
-          env:
-            - name: DEBUG_CONTAINER
-              value: "false"
-          volumeMounts:
-            - mountPath: /swift-bin
-              name: swift-bin
-            - mountPath: /swift-etc
-              name: swift-etc
-            - mountPath: /swift-rings/account
-              name: swift-account-ring
-            - mountPath: /swift-rings/container
-              name: swift-container-ring
-            - mountPath: /swift-rings/object
-              name: swift-object-ring
-            - mountPath: /srv/node
-              name: swift-drives
-            - mountPath: /var/cache/swift
-              name: swift-cache
-            - mountPath: /swift-drive-state
-              name: swift-drive-state
+        {{- tuple "container" "server"  "container-server"  . | include "swift_standard_container" | indent 8 }}
           ports:
             - name: swift-container
               hostPort: 6001
               containerPort: 6001
-        - name: auditor
-          image: {{.Values.global.docker_repo}}/ubuntu-source-swift-container-m3:{{.Values.image_version_swift_container}}
-          command:
-            - /usr/bin/dumb-init
-          args:
-            - /bin/bash
-            - /swift-bin/swift-start
-            - container-auditor
-          # privileged access required for /swift-bin/unmount-helper (TODO: use shared/slave mount namespace instead)
-          securityContext:
-            privileged: true
-          env:
-            - name: DEBUG_CONTAINER
-              value: "false"
-          volumeMounts:
-            - mountPath: /swift-bin
-              name: swift-bin
-            - mountPath: /swift-etc
-              name: swift-etc
-            - mountPath: /swift-rings/account
-              name: swift-account-ring
-            - mountPath: /swift-rings/container
-              name: swift-container-ring
-            - mountPath: /swift-rings/object
-              name: swift-object-ring
-            - mountPath: /srv/node
-              name: swift-drives
-            - mountPath: /var/cache/swift
-              name: swift-cache
-            - mountPath: /swift-drive-state
-              name: swift-drive-state
-        - name: updater
-          image: {{.Values.global.docker_repo}}/ubuntu-source-swift-container-m3:{{.Values.image_version_swift_container}}
-          command:
-            - /usr/bin/dumb-init
-          args:
-            - /bin/bash
-            - /swift-bin/swift-start
-            - container-updater
-          # privileged access required for /swift-bin/unmount-helper (TODO: use shared/slave mount namespace instead)
-          securityContext:
-            privileged: true
-          env:
-            - name: DEBUG_CONTAINER
-              value: "false"
-          volumeMounts:
-            - mountPath: /swift-bin
-              name: swift-bin
-            - mountPath: /swift-etc
-              name: swift-etc
-            - mountPath: /swift-rings/account
-              name: swift-account-ring
-            - mountPath: /swift-rings/container
-              name: swift-container-ring
-            - mountPath: /swift-rings/object
-              name: swift-object-ring
-            - mountPath: /srv/node
-              name: swift-drives
-            - mountPath: /var/cache/swift
-              name: swift-cache
-            - mountPath: /swift-drive-state
-              name: swift-drive-state
-        - name: statsd
-          image: prom/statsd-exporter:{{.Values.image_version_auxiliary_statsd_exporter}}
-          args: [ -statsd.mapping-config=/swift-etc/statsd-exporter.conf ]
-          ports:
-            - name: statsd
-              containerPort: 9125
-              protocol: UDP
-            - name: metrics
-              containerPort: 9102
-          volumeMounts:
-            - mountPath: /swift-etc
-              name: swift-etc
+        {{- tuple "container" "auditor" "container-auditor" . | include "swift_standard_container" | indent 8 }}
+        {{- tuple "container" "updater" "container-updater" . | include "swift_standard_container" | indent 8 }}
+        {{- include "swift_statsd_exporter_container" . | indent 8 }}

--- a/openstack/swift/templates/object-daemonset.yaml
+++ b/openstack/swift/templates/object-daemonset.yaml
@@ -14,147 +14,17 @@ spec:
       labels:
         component: swift-object
         from: daemonset
-      annotations:
-        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"species","value":"swift-storage"}]'
-        {{- if .Values.enable_statsd }}
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9102"
-        {{- end }}
+      annotations: {{ include "swift_daemonset_annotations" . | indent 8 }}
     spec:
       nodeSelector:
         species: swift-storage
-      volumes:
-        - name: swift-bin
-          configMap:
-            name: swift-bin
-        - name: swift-etc
-          configMap:
-            name: swift-etc
-        - name: swift-account-ring
-          configMap:
-            name: swift-account-ring
-        - name: swift-container-ring
-          configMap:
-            name: swift-container-ring
-        - name: swift-object-ring
-          configMap:
-            name: swift-object-ring
-        - name: swift-drives
-          hostPath:
-            path: /srv/node
-        - name: swift-cache
-          hostPath:
-            path: /var/cache/swift
-        - name: swift-drive-state
-          hostPath:
-            path: /run/swift-storage/state
+      volumes: {{ include "swift_daemonset_volumes" . | indent 8 }}
       containers:
-        - name: server
-          image: {{.Values.global.docker_repo}}/ubuntu-source-swift-object-m3:{{.Values.image_version_swift_object}}
-          command:
-            - /usr/bin/dumb-init
-          args:
-            - /bin/bash
-            - /swift-bin/swift-start
-            - object-server
-          # privileged access required for /swift-bin/unmount-helper (TODO: use shared/slave mount namespace instead)
-          securityContext:
-            privileged: true
-          env:
-            - name: DEBUG_CONTAINER
-              value: "false"
-          volumeMounts:
-            - mountPath: /swift-bin
-              name: swift-bin
-            - mountPath: /swift-etc
-              name: swift-etc
-            - mountPath: /swift-rings/account
-              name: swift-account-ring
-            - mountPath: /swift-rings/container
-              name: swift-container-ring
-            - mountPath: /swift-rings/object
-              name: swift-object-ring
-            - mountPath: /srv/node
-              name: swift-drives
-            - mountPath: /var/cache/swift
-              name: swift-cache
-            - mountPath: /swift-drive-state
-              name: swift-drive-state
+        {{- tuple "object" "server"  "object-server"  . | include "swift_standard_container" | indent 8 }}
           ports:
             - name: swift-object
               hostPort: 6000
               containerPort: 6000
-        - name: auditor
-          image: {{.Values.global.docker_repo}}/ubuntu-source-swift-object-m3:{{.Values.image_version_swift_object}}
-          command:
-            - /usr/bin/dumb-init
-          args:
-            - /bin/bash
-            - /swift-bin/swift-start
-            - object-auditor
-          # privileged access required for /swift-bin/unmount-helper (TODO: use shared/slave mount namespace instead)
-          securityContext:
-            privileged: true
-          env:
-            - name: DEBUG_CONTAINER
-              value: "false"
-          volumeMounts:
-            - mountPath: /swift-bin
-              name: swift-bin
-            - mountPath: /swift-etc
-              name: swift-etc
-            - mountPath: /swift-rings/account
-              name: swift-account-ring
-            - mountPath: /swift-rings/container
-              name: swift-container-ring
-            - mountPath: /swift-rings/object
-              name: swift-object-ring
-            - mountPath: /srv/node
-              name: swift-drives
-            - mountPath: /var/cache/swift
-              name: swift-cache
-            - mountPath: /swift-drive-state
-              name: swift-drive-state
-        - name: updater
-          image: {{.Values.global.docker_repo}}/ubuntu-source-swift-object-m3:{{.Values.image_version_swift_object}}
-          command:
-            - /usr/bin/dumb-init
-          args:
-            - /bin/bash
-            - /swift-bin/swift-start
-            - object-updater
-          # privileged access required for /swift-bin/unmount-helper (TODO: use shared/slave mount namespace instead)
-          securityContext:
-            privileged: true
-          env:
-            - name: DEBUG_CONTAINER
-              value: "false"
-          volumeMounts:
-            - mountPath: /swift-bin
-              name: swift-bin
-            - mountPath: /swift-etc
-              name: swift-etc
-            - mountPath: /swift-rings/account
-              name: swift-account-ring
-            - mountPath: /swift-rings/container
-              name: swift-container-ring
-            - mountPath: /swift-rings/object
-              name: swift-object-ring
-            - mountPath: /srv/node
-              name: swift-drives
-            - mountPath: /var/cache/swift
-              name: swift-cache
-            - mountPath: /swift-drive-state
-              name: swift-drive-state
-        - name: statsd
-          image: prom/statsd-exporter:{{.Values.image_version_auxiliary_statsd_exporter}}
-          args: [ -statsd.mapping-config=/swift-etc/statsd-exporter.conf ]
-          ports:
-            - name: statsd
-              containerPort: 9125
-              protocol: UDP
-            - name: metrics
-              containerPort: 9102
-          volumeMounts:
-            - mountPath: /swift-etc
-              name: swift-etc
+        {{- tuple "object" "auditor" "object-auditor" . | include "swift_standard_container" | indent 8 }}
+        {{- tuple "object" "updater" "object-updater" . | include "swift_standard_container" | indent 8 }}
+        {{- include "swift_statsd_exporter_container" . | indent 8 }}

--- a/openstack/swift/templates/recon-cron-daemonset.yaml
+++ b/openstack/swift/templates/recon-cron-daemonset.yaml
@@ -19,60 +19,6 @@ spec:
     spec:
       nodeSelector:
         species: swift-storage
-      volumes:
-        - name: swift-bin
-          configMap:
-            name: swift-bin
-        - name: swift-etc
-          configMap:
-            name: swift-etc
-        - name: swift-account-ring
-          configMap:
-            name: swift-account-ring
-        - name: swift-container-ring
-          configMap:
-            name: swift-container-ring
-        - name: swift-object-ring
-          configMap:
-            name: swift-object-ring
-        - name: swift-drives
-          hostPath:
-            path: /srv/node
-        - name: swift-cache
-          hostPath:
-            path: /var/cache/swift
-        - name: swift-drive-state
-          hostPath:
-            path: /run/swift-storage/state
+      volumes: {{ include "swift_daemonset_volumes" . | indent 8 }}
       containers:
-        - name: recon
-          image: {{.Values.global.docker_repo}}/ubuntu-source-swift-object-m3:{{.Values.image_version_swift_object}}
-          command:
-            - /usr/bin/dumb-init
-          args:
-            - /bin/bash
-            - /swift-bin/swift-start
-            - recon-cron
-          # privileged access required for /swift-bin/unmount-helper (TODO: use shared/slave mount namespace instead)
-          securityContext:
-            privileged: true
-          env:
-            - name: DEBUG_CONTAINER
-              value: "false"
-          volumeMounts:
-            - mountPath: /swift-bin
-              name: swift-bin
-            - mountPath: /swift-etc
-              name: swift-etc
-            - mountPath: /swift-rings/account
-              name: swift-account-ring
-            - mountPath: /swift-rings/container
-              name: swift-container-ring
-            - mountPath: /swift-rings/object
-              name: swift-object-ring
-            - mountPath: /srv/node
-              name: swift-drives
-            - mountPath: /var/cache/swift
-              name: swift-cache
-            - mountPath: /swift-drive-state
-              name: swift-drive-state
+        {{- tuple "object" "recon" "recon-cron" . | include "swift_standard_container" | indent 8 }}

--- a/openstack/swift/templates/replicators-daemonset.yaml
+++ b/openstack/swift/templates/replicators-daemonset.yaml
@@ -14,12 +14,7 @@ spec:
       labels:
         component: swift-replicators
         from: daemonset
-      annotations:
-        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"species","value":"swift-storage"}]'
-        {{- if .Values.enable_statsd }}
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9102"
-        {{- end }}
+      annotations: {{ include "swift_daemonset_annotations" . | indent 8 }}
     spec:
       # replicators need to discover their own IP, and it needs to match the
       # node IP in the ring file (this extra permission is why the replicators
@@ -27,134 +22,9 @@ spec:
       hostNetwork: true
       nodeSelector:
         species: swift-storage
-      volumes:
-        - name: swift-bin
-          configMap:
-            name: swift-bin
-        - name: swift-etc
-          configMap:
-            name: swift-etc
-        - name: swift-account-ring
-          configMap:
-            name: swift-account-ring
-        - name: swift-container-ring
-          configMap:
-            name: swift-container-ring
-        - name: swift-object-ring
-          configMap:
-            name: swift-object-ring
-        - name: swift-drives
-          hostPath:
-            path: /srv/node
-        - name: swift-cache
-          hostPath:
-            path: /var/cache/swift
-        - name: swift-drive-state
-          hostPath:
-            path: /run/swift-storage/state
+      volumes: {{ include "swift_daemonset_volumes" . | indent 8 }}
       containers:
-        - name: account
-          image: {{.Values.global.docker_repo}}/ubuntu-source-swift-account-m3:{{.Values.image_version_swift_account}}
-          command:
-            - /usr/bin/dumb-init
-          args:
-            - /bin/bash
-            - /swift-bin/swift-start
-            - account-replicator
-          # privileged access required for /swift-bin/unmount-helper (TODO: use shared/slave mount namespace instead)
-          securityContext:
-            privileged: true
-          env:
-            - name: DEBUG_CONTAINER
-              value: "false"
-          volumeMounts:
-            - mountPath: /swift-bin
-              name: swift-bin
-            - mountPath: /swift-etc
-              name: swift-etc
-            - mountPath: /swift-rings/account
-              name: swift-account-ring
-            - mountPath: /swift-rings/container
-              name: swift-container-ring
-            - mountPath: /swift-rings/object
-              name: swift-object-ring
-            - mountPath: /srv/node
-              name: swift-drives
-            - mountPath: /var/cache/swift
-              name: swift-cache
-            - mountPath: /swift-drive-state
-              name: swift-drive-state
-        - name: container
-          image: {{.Values.global.docker_repo}}/ubuntu-source-swift-container-m3:{{.Values.image_version_swift_container}}
-          command:
-            - /usr/bin/dumb-init
-          args:
-            - /bin/bash
-            - /swift-bin/swift-start
-            - container-replicator
-          # privileged access required for /swift-bin/unmount-helper (TODO: use shared/slave mount namespace instead)
-          securityContext:
-            privileged: true
-          env:
-            - name: DEBUG_CONTAINER
-              value: "false"
-          volumeMounts:
-            - mountPath: /swift-bin
-              name: swift-bin
-            - mountPath: /swift-etc
-              name: swift-etc
-            - mountPath: /swift-rings/account
-              name: swift-account-ring
-            - mountPath: /swift-rings/container
-              name: swift-container-ring
-            - mountPath: /swift-rings/object
-              name: swift-object-ring
-            - mountPath: /srv/node
-              name: swift-drives
-            - mountPath: /var/cache/swift
-              name: swift-cache
-            - mountPath: /swift-drive-state
-              name: swift-drive-state
-        - name: object
-          image: {{.Values.global.docker_repo}}/ubuntu-source-swift-object-m3:{{.Values.image_version_swift_object}}
-          command:
-            - /usr/bin/dumb-init
-          args:
-            - /bin/bash
-            - /swift-bin/swift-start
-            - object-replicator
-          # privileged access required for /swift-bin/unmount-helper (TODO: use shared/slave mount namespace instead)
-          securityContext:
-            privileged: true
-          env:
-            - name: DEBUG_CONTAINER
-              value: "false"
-          volumeMounts:
-            - mountPath: /swift-bin
-              name: swift-bin
-            - mountPath: /swift-etc
-              name: swift-etc
-            - mountPath: /swift-rings/account
-              name: swift-account-ring
-            - mountPath: /swift-rings/container
-              name: swift-container-ring
-            - mountPath: /swift-rings/object
-              name: swift-object-ring
-            - mountPath: /srv/node
-              name: swift-drives
-            - mountPath: /var/cache/swift
-              name: swift-cache
-            - mountPath: /swift-drive-state
-              name: swift-drive-state
-        - name: statsd
-          image: prom/statsd-exporter:{{.Values.image_version_auxiliary_statsd_exporter}}
-          args: [ -statsd.mapping-config=/swift-etc/statsd-exporter.conf ]
-          ports:
-            - name: statsd
-              containerPort: 9125
-              protocol: UDP
-            - name: metrics
-              containerPort: 9102
-          volumeMounts:
-            - mountPath: /swift-etc
-              name: swift-etc
+        {{- tuple "account"   "account"   "account-replicator"   . | include "swift_standard_container" | indent 8 }}
+        {{- tuple "container" "container" "container-replicator" . | include "swift_standard_container" | indent 8 }}
+        {{- tuple "object"    "object"    "object-replicator"    . | include "swift_standard_container" | indent 8 }}
+        {{- include "swift_statsd_exporter_container" . | indent 8 }}


### PR DESCRIPTION
This should make it easier to reorder the services into new daemonsets in the next step.