### PR TITLE
Swift used percentage to prometheus global

### DIFF
--- a/global/prometheus/prometheus.yaml
+++ b/global/prometheus/prometheus.yaml
@@ -21,6 +21,7 @@ scrape_configs:
       - '{__name__=~"^datapath_.+"}'
       - '{__name__=~"^kube_.+"}'
       - '{__name__=~"up"}'
+      - '{__name__=~"^swift_cluster_storage_used_percent_gauge$"}'
 
   relabel_configs:
     - action: replace


### PR DESCRIPTION
Background is, that prometheus global keeps metrics for a longer time frame, which allows a better prediction of the swift cluster utilisation like here https://grafana.eu-de-1.cloud.sap/dashboard/db/swift-capacity, which is currently only one week.