### PR TITLE
update ingress controller to 0.9.0-beta.2 and add prometheus scrape annotations to service

### DIFF
--- a/system/kube-system/charts/ingress/templates/default-backend-deployment.yaml
+++ b/system/kube-system/charts/ingress/templates/default-backend-deployment.yaml
@@ -23,7 +23,8 @@ spec:
         # Any image is permissable as long as:
         # 1. It serves a 404 page at /
         # 2. It serves 200 on a /healthz endpoint
-        image: gcr.io/google_containers/defaultbackend:1.0
+        image: "{{ .Values.defaultBackend.image.repository }}:{{ .Values.defaultBackend.image.tag }}"
+        imagePullPolicy: {{ default "" .Values.defaultBackend.image.pullPolicy | quote }} 
         livenessProbe:
           httpGet:
             path: /healthz

--- a/system/kube-system/charts/ingress/templates/ingress-controller-configmap.yaml
+++ b/system/kube-system/charts/ingress/templates/ingress-controller-configmap.yaml
@@ -3,5 +3,5 @@ kind: ConfigMap
 metadata:
   name: ingress-controller-configmap 
 data:
-  body-size: '0' #disable request size checking
+  proxy-body-size: '0' #disable request size checking
   worker-processes: '40' #default is runtime.NumCPU()

--- a/system/kube-system/charts/ingress/templates/ingress-controller-daemonset.yaml
+++ b/system/kube-system/charts/ingress/templates/ingress-controller-daemonset.yaml
@@ -44,4 +44,4 @@ spec:
         args:
         - /nginx-ingress-controller
         - --default-backend-service={{.Release.Namespace}}/ingress-default-backend
-        - --nginx-configmap={{.Release.Namespace}}/ingress-controller-configmap
+        - --configmap={{.Release.Namespace}}/ingress-controller-configmap

--- a/system/kube-system/charts/ingress/templates/ingress-controller-daemonset.yaml
+++ b/system/kube-system/charts/ingress/templates/ingress-controller-daemonset.yaml
@@ -11,7 +11,7 @@ spec:
         app: ingress-controller
       annotations:
             prometheus.io/scrape: "true"
-            prometheus.io/port: "9091"
+            prometheus.io/port: "9101"
     spec:
       nodeSelector:
         zone: farm
@@ -47,7 +47,7 @@ spec:
           - name: https
             containerPort: 443
           - name: request-metrics
-            containerPort: 9091
+            containerPort: 9101
           - name: metrics
             containerPort: 10254
         args:

--- a/system/kube-system/charts/ingress/templates/ingress-controller-daemonset.yaml
+++ b/system/kube-system/charts/ingress/templates/ingress-controller-daemonset.yaml
@@ -13,10 +13,12 @@ spec:
             prometheus.io/scrape: "true"
             prometheus.io/port: "9091"
     spec:
+      nodeSelector:
+        zone: farm
       terminationGracePeriodSeconds: 60
       containers:
-        image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
-        imagePullPolicy: {{ default "" .Values.controller.image.pullPolicy | quote }} 
+      - image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
+        imagePullPolicy: {{ default "" .Values.controller.image.pullPolicy | quote }}
         name: nginx-ingress-lb
         livenessProbe:
           httpGet:
@@ -44,7 +46,7 @@ spec:
             containerPort: 80
           - name: https
             containerPort: 443
-          - name: request_metrics
+          - name: request-metrics
             containerPort: 9091
           - name: metrics
             containerPort: 10254

--- a/system/kube-system/charts/ingress/templates/ingress-controller-daemonset.yaml
+++ b/system/kube-system/charts/ingress/templates/ingress-controller-daemonset.yaml
@@ -41,6 +41,8 @@ spec:
             containerPort: 80
           - name: https
             containerPort: 443
+          - name: metrics
+            containerPort: 10254
         args:
         - /nginx-ingress-controller
         - --default-backend-service={{.Release.Namespace}}/ingress-default-backend

--- a/system/kube-system/charts/ingress/templates/ingress-controller-daemonset.yaml
+++ b/system/kube-system/charts/ingress/templates/ingress-controller-daemonset.yaml
@@ -8,7 +8,10 @@ spec:
   template:
     metadata:
       labels:
-        app: ingress-controller 
+        app: ingress-controller
+      annotations:
+            prometheus.io/scrape: "true"
+            prometheus.io/port: "10254"
     spec:
       terminationGracePeriodSeconds: 60
       containers:

--- a/system/kube-system/charts/ingress/templates/ingress-controller-daemonset.yaml
+++ b/system/kube-system/charts/ingress/templates/ingress-controller-daemonset.yaml
@@ -11,7 +11,7 @@ spec:
         app: ingress-controller
       annotations:
             prometheus.io/scrape: "true"
-            prometheus.io/port: "10254"
+            prometheus.io/port: "9091"
     spec:
       terminationGracePeriodSeconds: 60
       containers:
@@ -44,6 +44,8 @@ spec:
             containerPort: 80
           - name: https
             containerPort: 443
+          - name: request_metrics
+            containerPort: 9091
           - name: metrics
             containerPort: 10254
         args:

--- a/system/kube-system/charts/ingress/templates/ingress-controller-daemonset.yaml
+++ b/system/kube-system/charts/ingress/templates/ingress-controller-daemonset.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.8.3
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.1
         name: nginx-ingress-lb
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/system/kube-system/charts/ingress/templates/ingress-controller-daemonset.yaml
+++ b/system/kube-system/charts/ingress/templates/ingress-controller-daemonset.yaml
@@ -12,9 +12,9 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.1
+        image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
+        imagePullPolicy: {{ default "" .Values.controller.image.pullPolicy | quote }} 
         name: nginx-ingress-lb
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
             path: /healthz

--- a/system/kube-system/charts/ingress/templates/ingress-service.yaml
+++ b/system/kube-system/charts/ingress/templates/ingress-service.yaml
@@ -5,7 +5,7 @@ metadata:
   name: ingress-controller
   annotations:
       prometheus.io/scrape: "true"
-      prometheus.io/port: "9101"
+      prometheus.io/port: "10254"
 spec:
   type: ClusterIP 
   selector:
@@ -17,7 +17,5 @@ spec:
     - name: https 
       port: 443 
       targetPort: https
-    - name: metrics
-      port: 9101
   externalIPs: 
     - {{.Values.external_service_ip}}

--- a/system/kube-system/charts/ingress/templates/ingress-service.yaml
+++ b/system/kube-system/charts/ingress/templates/ingress-service.yaml
@@ -5,7 +5,7 @@ metadata:
   name: ingress-controller
   annotations:
       prometheus.io/scrape: "true"
-      prometheus.io/port: "10254"
+      prometheus.io/port: "9101"
 spec:
   type: ClusterIP 
   selector:
@@ -16,6 +16,8 @@ spec:
       targetPort: http
     - name: https 
       port: 443 
-      targetPort: https 
+      targetPort: https
+    - name: metrics
+      port: 9101
   externalIPs: 
     - {{.Values.external_service_ip}}

--- a/system/kube-system/charts/ingress/templates/ingress-service.yaml
+++ b/system/kube-system/charts/ingress/templates/ingress-service.yaml
@@ -5,7 +5,7 @@ metadata:
   name: ingress-controller
   annotations:
       prometheus.io/scrape: "true"
-      prometheus.io/port: "9101"
+      prometheus.io/port: "10254"
 spec:
   type: ClusterIP 
   selector:

--- a/system/kube-system/charts/ingress/templates/ingress-service.yaml
+++ b/system/kube-system/charts/ingress/templates/ingress-service.yaml
@@ -2,8 +2,10 @@ kind: Service
 apiVersion: v1
 
 metadata:
-  name: ingress-controller 
-
+  name: ingress-controller
+  annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "9101"
 spec:
   type: ClusterIP 
   selector:

--- a/system/kube-system/charts/ingress/values.yaml
+++ b/system/kube-system/charts/ingress/values.yaml
@@ -1,1 +1,11 @@
+controller:
+  image:
+    repository: gcr.io/google_containers/nginx-ingress-controller
+    tag: '0.9.0-beta.2'
+    #pullPolicy: IfNotPresent
+defaultBackend:
+  image:
+    repository: gcr.io/google_containers/defaultbackend
+    tag: '1.3'
+    #pullPolicy: IfNotPresent
 external_service_ip: DEFINED-IN-REGION

--- a/system/kube-system/charts/ingress/values.yaml
+++ b/system/kube-system/charts/ingress/values.yaml
@@ -1,11 +1,1 @@
-controller:
-  image:
-    repository: gcr.io/google_containers/nginx-ingress-controller
-    tag: '0.9.0-beta.2'
-    #pullPolicy: IfNotPresent
-defaultBackend:
-  image:
-    repository: gcr.io/google_containers/defaultbackend
-    tag: '1.3'
-    #pullPolicy: IfNotPresent
 external_service_ip: DEFINED-IN-REGION


### PR DESCRIPTION
***WIP - DO NOT MERGE***

Does it make sense to try [0.9.0-beta.1](https://github.com/kubernetes/ingress/blob/master/controllers/nginx/Changelog.md#09-beta1) of the ingress controller as this version includes https://github.com/kubernetes/ingress/pull/36,
@databus23?
Would test in staging after lunch if you agree.