### PR TITLE
enable afterburner

### DIFF
--- a/openstack/swift/templates/etc/_nginx.conf.tpl
+++ b/openstack/swift/templates/etc/_nginx.conf.tpl
@@ -33,7 +33,7 @@ http {
     types_hash_max_size 2048;
 
     server {
-        listen 443 default_server;
+        listen 443 default_server ssl http2;
         server_name {{tuple $cluster $context | include "swift_endpoint_host"}};
         ssl on;
 


### PR DESCRIPTION
All the other OpenStack services already have HTTP/2 courtesy of Kubernetes' ingress-controller, and it apparently gives a nice free speed boost when the client understands and advertises HTTP/2.

BTW, I know that this change looks suspiciously small, but it's really all that's needed. I rolled out [an identical change](https://github.com/majewsky/system-configuration/commit/7b34ebcee09ad0510d96ad7853e8c901a4241b80) on my private systems last week.