### PR TITLE
expand Limes chart to deploy limes-collect and limes-migrate

### DIFF
--- a/openstack/limes/charts/postgresql/Chart.yaml
+++ b/openstack/limes/charts/postgresql/Chart.yaml
@@ -1,0 +1,16 @@
+name: postgresql
+version: 0.3.0
+description: Chart for PostgreSQL
+keywords:
+- postgresql
+- postgres
+- database
+- sql
+home: https://www.postgresql.org/
+sources:
+- https://github.com/kubernetes/charts
+- https://github.com/docker-library/postgres
+maintainers:
+- name: swordbeta
+- name: databus23
+engine: gotpl

--- a/openstack/limes/charts/postgresql/README.md
+++ b/openstack/limes/charts/postgresql/README.md
@@ -1,0 +1,93 @@
+# PostgreSQL
+
+[PostgreSQL](https://postgresql.org) is a powerful, open source object-relational database system. It has more than 15 years of active development and a proven architecture that has earned it a strong reputation for reliability, data integrity, and correctness.
+
+## TL;DR;
+
+```bash
+$ helm install stable/postgresql
+```
+
+## Introduction
+
+This chart bootstraps a [PostgreSQL](https://github.com/docker-library/postgres) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.4+ with Beta APIs enabled
+- PV provisioner support in the underlying infrastructure (Only when persisting data)
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release stable/postgresql
+```
+
+The command deploys PostgreSQL on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following tables lists the configurable parameters of the PostgresSQL chart and their default values.
+
+| Parameter                  | Description                                | Default                                                    |
+| -----------------------    | ----------------------------------         | ---------------------------------------------------------- |
+| `image`                    | `postgres` image repository                | `postgres`                                                 |
+| `imageTag`                 | `postgres` image tag                       | `9.5.4`                                                    |
+| `imagePullPolicy`          | Image pull policy                          | `Always` if `imageTag` is `latest`, else `IfNotPresent`    |
+| `postgresUser`             | Username of new user to create.            | `postgres`                                                 |
+| `postgresPassword`         | Password for the new user.                 | random 10 characters                                       |
+| `postgresDatabase`         | Name for new database to create.           | `postgres`                                                 |
+| `persistence.enabled`      | Use a PVC to persist data                  | `true`                                                     |
+| `persistence.storageClass` | Storage class of backing PVC               | `generic`                                                  |
+| `persistence.accessMode`   | Use volume as ReadOnly or ReadWrite        | `ReadWriteMany`                                            |
+| `persistence.size`         | Size of data volume                        | `10Gi`                                                     |
+| `persistence.existingClaim`| Re-Use existing PVC                        |                                                            |
+| `resources`                | CPU/Memory resource requests/limits        | Memory: `256Mi`, CPU: `100m`                               |
+| `metrics.enabled`          | Start a side-car prometheus exporter       | `false`                                                    |
+| `metrics.image`            | Exporter image                             | `wrouesnel/postgres_exporter`                              |
+| `metrics.imageTag`         | Exporter image                             | `v0.1.1`                                                   |
+| `metrics.imagePullPolicy`  | Exporter image pull policy                 | `IfNotPresent`                                             |
+| `metrics.resources`        | Exporter resource requests/limit           | Memory: `256Mi`, CPU: `100m`                               |
+
+The above parameters map to the env variables defined in [postgres](http://github.com/docker-library/postgres). For more information please refer to the [postgres](http://github.com/docker-library/postgres) image documentation.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install --name my-release \
+  --set postgresUser=my-user,postgresPassword=secretpassword,postgresDatabase=my-database \
+    stable/postgresql
+```
+
+The above command creates a PostgresSQL user named `root` with password `secretpassword`. Additionally it creates a database named `my-database`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml stable/postgresql
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Persistence
+
+The [postgres](https://github.com/docker-library/postgres) image stores the PostgreSQL data and configurations at the `/var/lib/postgresql/data/pgdata` path of the container.
+
+The chart mounts a [Persistent Volume](http://kubernetes.io/docs/user-guide/persistent-volumes/) volume at this location. The volume is created using dynamic volume provisioning.
+
+## Metrics
+The chart optionally can start a metrics exporter for [prometheus](https://prometheus.io). The metrics endpoint (port 9187) is not exposed and it is expected that the metrics are collected from inside the k8s cluster using something similar as the described in the [example Prometheus scrape configuration](https://github.com/prometheus/prometheus/blob/master/documentation/examples/prometheus-kubernetes.yml).

--- a/openstack/limes/charts/postgresql/templates/NOTES.txt
+++ b/openstack/limes/charts/postgresql/templates/NOTES.txt
@@ -1,0 +1,14 @@
+PostgreSQL can be accessed via port 5432 on the following DNS name from within your cluster:
+{{ template "fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+
+To get your user password run:
+
+    PGPASSWORD=$(printf $(printf '\%o' `kubectl get secret --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath="{.data.postgres-password[*]}"`);echo)
+
+To connect to your database run the following command (using the env variable from above):
+
+   kubectl run {{ template "fullname" . }}-client --rm --tty -i --image postgres \
+   --env "PGPASSWORD=$PGPASSWORD" \
+   --command -- psql -U {{ default "postgres" .Values.postgresUser }} \
+   -h {{ template "fullname" . }} {{ default "postgres" .Values.postgresDatabase }}
+

--- a/openstack/limes/charts/postgresql/templates/_helpers.tpl
+++ b/openstack/limes/charts/postgresql/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 24 -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- end -}}

--- a/openstack/limes/charts/postgresql/templates/deployment.yaml
+++ b/openstack/limes/charts/postgresql/templates/deployment.yaml
@@ -1,0 +1,130 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  revisionHistoryLimit: 5
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+    spec:
+      containers:
+      - name: {{ template "fullname" . }}
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
+        env:
+        - name: POSTGRES_USER
+          value: {{ default "postgres" .Values.postgresUser | quote }}
+          # Required for pg_isready in the health probes.
+        - name: PGUSER
+          value: {{ default "postgres" .Values.postgresUser | quote }}
+        - name: POSTGRES_DB
+          value: {{ default "" .Values.postgresDatabase | quote }}
+        - name: PGDATA
+          value: /postgresql/data
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}
+              key: postgres-password
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        ports:
+        - name: postgresql
+          containerPort: 5432
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - exec pg_isready --host $POD_IP
+          initialDelaySeconds: 120
+          timeoutSeconds: 3
+          failureThreshold: 6
+        # We use the POD_IP to not have the pod become ready during the inital database setup
+        # where the docker image briefly starts the db  for creating the user,
+        # running custom setup scripts etc.
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - exec pg_isready --host $POD_IP
+          initialDelaySeconds: 5
+          timeoutSeconds: 3
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        volumeMounts:
+        - name: data
+          mountPath: /postgresql
+{{- if .Values.backup.enabled }}
+      - image: {{.Values.backup.repository}}:{{.Values.backup.image_version}}
+        name: backup
+        env:
+          - name: MY_POD_NAME
+            value: {{ template "fullname" . }}
+          - name: MY_POD_NAMESPACE
+            value: {{.Release.Namespace}}
+          - name: OS_AUTH_URL
+            value: {{.Values.backup.os_auth_url}}
+          - name: OS_AUTH_VERSION
+            value: {{.Values.backup.os_auth_version | quote}}
+          - name: OS_USERNAME
+            value: {{.Values.backup.os_username}}
+          - name: OS_USER_DOMAIN_NAME
+            value: {{.Values.backup.os_user_domain}}
+          - name: OS_PROJECT_NAME
+            value: {{.Values.backup.os_project_name}}
+          - name: OS_PROJECT_DOMAIN_NAME
+            value: {{.Values.backup.os_project_domain}}
+          - name: OS_REGION_NAME
+            value: {{.Values.backup.os_region_name}}
+          - name: OS_PASSWORD
+            value: {{.Values.backup.os_password | quote}}
+          - name: BACKUP_PGSQL_FULL
+            value: {{.Values.backup.interval_full | quote}}
+{{- end }}
+{{- if .Values.metrics.enabled }}
+      - name: metrics
+        image: "{{ .Values.metrics.image }}:{{ .Values.metrics.imageTag }}"
+        imagePullPolicy: {{ default "" .Values.metrics.imagePullPolicy | quote }}
+        env:
+        - name: DATA_SOURCE_NAME
+          value: postgresql://postgres@localhost:5432?sslmode=disable
+        ports:
+        - name: metrics
+          containerPort: 9187
+        {{- if .Values.metrics.customMetrics }}
+        args: ["-extend.query-path", "/conf/custom-metrics.yaml"]
+        volumeMounts:
+          - name: custom-metrics
+            mountPath: /conf
+            readOnly: true
+        {{- end }}
+        resources:
+{{ toYaml .Values.metrics.resources | indent 10 }}
+{{- end }}
+      volumes:
+      - name: data
+      {{- if .Values.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ template "fullname" . }}{{- end }}
+      {{- else }}
+        emptyDir: {}
+      {{- end }}
+      {{- if and .Values.metrics.enabled .Values.metrics.customMetrics }}
+      - name: custom-metrics
+        secret:
+          secretName: {{ template "fullname" . }}
+          items:
+            - key: custom-metrics.yaml
+              path: custom-metrics.yaml
+      {{- end }}

--- a/openstack/limes/charts/postgresql/templates/pvc.yaml
+++ b/openstack/limes/charts/postgresql/templates/pvc.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.persistence.enabled }}
+{{- if not .Values.persistence.existingClaim -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- end }}
+{{- end }}

--- a/openstack/limes/charts/postgresql/templates/secrets.yaml
+++ b/openstack/limes/charts/postgresql/templates/secrets.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  {{ if .Values.postgresPassword }}
+  postgres-password:  {{ .Values.postgresPassword | b64enc | quote }}
+  {{ else }}
+  postgres-password: {{ randAlphaNum 10 | b64enc | quote }}
+  {{ end }} 
+  {{- if .Values.metrics.customMetrics }}
+  custom-metrics.yaml: {{ toYaml .Values.metrics.customMetrics | b64enc | quote }}
+  {{- end}}

--- a/openstack/limes/charts/postgresql/templates/svc.yaml
+++ b/openstack/limes/charts/postgresql/templates/svc.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+{{- if .Values.metrics.enabled }}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9187"
+{{- end }}
+spec:
+  ports:
+  - name: postgresql
+    port: 5432
+    targetPort: postgresql
+  selector:
+    app: {{ template "fullname" . }}

--- a/openstack/limes/charts/postgresql/values.yaml
+++ b/openstack/limes/charts/postgresql/values.yaml
@@ -1,0 +1,72 @@
+## postgres image repository
+image: "postgres"
+## postgres image version
+## ref: https://hub.docker.com/r/library/postgres/tags/
+##
+imageTag: "9.5.4"
+
+## Specify a imagePullPolicy
+## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'
+## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+##
+# imagePullPolicy:
+
+## Create a database user
+## Default: postgres
+# postgresUser:
+## Default: random 10 character string
+# postgresPassword:
+
+## Create a database
+## Default: the postgres user
+# postgresDatabase:
+
+## Persist data to a persitent volume
+persistence:
+  enabled: true
+  accessMode: ReadWriteMany
+  size: 10Gi
+  # Re-use existing (unmanged) PVC
+  # existingClaim: claimName
+
+metrics:
+  enabled: false
+  image: wrouesnel/postgres_exporter
+  imageTag: v0.1.1
+  imagePullPolicy: IfNotPresent
+  customMetrics:
+    pg_database:
+      query: "SELECT d.datname AS name, CASE WHEN pg_catalog.has_database_privilege(d.datname, 'CONNECT') THEN pg_catalog.pg_database_size(d.datname) ELSE 0 END AS size FROM pg_catalog.pg_database d where datname not in ('template0', 'template1', 'postgres')"
+      metrics:
+        - name:
+            usage: "LABEL"
+            description: "Name of the database"
+        - size:
+            usage: "GAUGE"
+            description: "Size of the database in bytes"
+  resources:
+    requests:
+      memory: 256Mi
+      cpu: 100m
+
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources:
+  requests:
+    memory: 256Mi
+    cpu: 100m
+
+backup:
+  enabled: false
+  repository: sapcc/backup-tools
+  image_version: v0.4.7.1
+  interval_full: "3 hours"
+  os_auth_url: DEFINED-IN-REGION-SECRETS
+  os_auth_version: "3"
+  os_username: DEFINED-IN-REGION-SECRETS
+  os_user_domain: DEFINED-IN-REGION-SECRETS
+  os_project_name: DEFINED-IN-REGION-SECRETS
+  os_project_domain: DEFINED-IN-REGION-SECRETS
+  os_region_name: DEFINED-IN-REGION-SECRETS
+  os_password: DEFINED-IN-REGION-SECRETS

--- a/openstack/limes/charts/postgresql/values.yaml
+++ b/openstack/limes/charts/postgresql/values.yaml
@@ -60,8 +60,8 @@ resources:
 backup:
   enabled: false
   repository: sapcc/backup-tools
-  image_version: v0.4.7.1
-  interval_full: "3 hours"
+  image_version: v0.5.3
+  interval_full: "1 hour"
   os_auth_url: DEFINED-IN-REGION-SECRETS
   os_auth_version: "3"
   os_username: DEFINED-IN-REGION-SECRETS

--- a/openstack/limes/templates/collect-deployment.yaml
+++ b/openstack/limes/templates/collect-deployment.yaml
@@ -1,0 +1,48 @@
+{{ range $cluster_id, $config := .Values.limes.clusters }}
+kind: Deployment
+apiVersion: extensions/v1beta1
+
+metadata:
+  name: limes-collect-{{$cluster_id}}
+  labels:
+    app: limes-collect
+
+spec:
+  revisionHistoryLimit: 5
+  replicas: 1
+  strategy:
+    type: Replace
+  selector:
+    matchLabels:
+      name: limes-collect-{{$cluster_id}}
+  template:
+    metadata:
+      labels:
+        name: limes-collect-{{$cluster_id}}
+        app: limes-collect
+      annotations:
+        checksum: {{ include "limes/templates/configmap.yaml" $ | sha256sum }}
+    spec:
+      volumes:
+        - name: config
+          configMap:
+            name: limes
+      containers:
+        - name: collect
+          image: {{$.Values.limes.image}}:{{$.Values.limes.image_tag}}
+          imagePullPolicy: {{$.Values.limes.image_pull_policy}}
+          command:
+            - /usr/bin/limes-collect
+          args:
+            - /etc/limes/limes.yaml
+            - {{$cluster_id}}
+          env:
+            - name: LIMES_DEBUG
+              value: 0
+            - name: LIMES_DEBUG_SQL
+              value: 0
+          volumeMounts:
+            - mountPath: /etc/limes
+              name: config
+---
+{{end}}

--- a/openstack/limes/templates/collect-deployment.yaml
+++ b/openstack/limes/templates/collect-deployment.yaml
@@ -11,7 +11,7 @@ spec:
   revisionHistoryLimit: 5
   replicas: 1
   strategy:
-    type: Replace
+    type: Recreate
   selector:
     matchLabels:
       name: limes-collect-{{$cluster_id}}
@@ -38,9 +38,9 @@ spec:
             - {{$cluster_id}}
           env:
             - name: LIMES_DEBUG
-              value: 0
+              value: '0'
             - name: LIMES_DEBUG_SQL
-              value: 0
+              value: '0'
           volumeMounts:
             - mountPath: /etc/limes
               name: config

--- a/openstack/limes/templates/configmap.yaml
+++ b/openstack/limes/templates/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
 data:
   limes.yaml: |
     database:
-      location: "postgres://postgres:{{.Values.postgresql.postgresPassword}}@postgres.{{.Release.Namespace}}.svc/limes?sslmode=prefer"
+      location: "postgres://postgres:{{.Values.postgresql.postgresPassword}}@limes-postgresql.{{.Release.Namespace}}.svc/limes?sslmode=disable"
       migrations: /usr/share/limes/migrations
 
     clusters:
@@ -29,6 +29,5 @@ data:
   migrate.sh: |
     #!/bin/sh
     set -euo pipefail
-    env PGPASSWORD='{{.Values.postgresql.postgresPassword}}' psql -U postgres -h postgres.{{.Release.Namespace}}.svc -c 'CREATE DATABASE IF NOT EXISTS limes;'
     limes-migrate /etc/limes/limes.yaml
     exec tail -f /dev/null

--- a/openstack/limes/templates/configmap.yaml
+++ b/openstack/limes/templates/configmap.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ConfigMap
+
+metadata:
+  name: limes
+
+data:
+  limes.yaml: |
+    database:
+      location: "postgres://postgres:{{.Values.postgresql.postgresPassword}}@postgres.{{.Release.Namespace}}.svc/limes?sslmode=prefer"
+      migrationsPath: /usr/share/limes/migrations
+
+    clusters:
+      {{- range $cluster_id, $config := .Values.limes.clusters }}
+      {{ $cluster_id }}:
+        auth_url:            {{ quote $config.auth_url }}
+        user_name:           {{ quote $config.user_name }}
+        user_domain_name:    {{ quote $config.user_domain_name }}
+        project_name:        {{ quote $config.project_name }}
+        project_domain_name: {{ quote $config.project_domain_name }}
+        password:            {{ quote $config.password }}
+        region_name:         {{ quote $config.region_name }}
+        services:
+          {{- range $service := $config.services }}
+          - type: {{ $service.type }}
+            shared: {{ $service.shared | default false }}
+          {{- end }}
+      {{- end }}
+  migrate.sh: |
+    #!/bin/sh
+    set -euo pipefail
+    env PGPASSWORD='{{.Values.postgresql.postgresPassword}}' psql -U postgres -h postgres.{{.Release.Namespace}}.svc -c 'CREATE DATABASE IF NOT EXISTS limes;'
+    limes-migrate /etc/limes/limes.yaml
+    exec tail -f /dev/null

--- a/openstack/limes/templates/configmap.yaml
+++ b/openstack/limes/templates/configmap.yaml
@@ -8,7 +8,7 @@ data:
   limes.yaml: |
     database:
       location: "postgres://postgres:{{.Values.postgresql.postgresPassword}}@postgres.{{.Release.Namespace}}.svc/limes?sslmode=prefer"
-      migrationsPath: /usr/share/limes/migrations
+      migrations: /usr/share/limes/migrations
 
     clusters:
       {{- range $cluster_id, $config := .Values.limes.clusters }}

--- a/openstack/limes/templates/migrate-deployment.yaml
+++ b/openstack/limes/templates/migrate-deployment.yaml
@@ -10,7 +10,7 @@ spec:
   revisionHistoryLimit: 5
   replicas: 1
   strategy:
-    type: Replace
+    type: Recreate
   selector:
     matchLabels:
       name: limes-migrate

--- a/openstack/limes/templates/migrate-deployment.yaml
+++ b/openstack/limes/templates/migrate-deployment.yaml
@@ -1,0 +1,39 @@
+kind: Deployment
+apiVersion: extensions/v1beta1
+
+metadata:
+  name: limes-migrate
+  labels:
+    app: limes-migrate
+
+spec:
+  revisionHistoryLimit: 5
+  replicas: 1
+  strategy:
+    type: Replace
+  selector:
+    matchLabels:
+      name: limes-migrate
+  template:
+    metadata:
+      labels:
+        name: limes-migrate
+        app: limes-migrate
+      annotations:
+        checksum: {{ include "limes/templates/configmap.yaml" $ | sha256sum }}
+    spec:
+      volumes:
+        - name: config
+          configMap:
+            name: limes
+      containers:
+        - name: collect
+          image: {{$.Values.limes.image}}:{{$.Values.limes.image_tag}}
+          imagePullPolicy: {{$.Values.limes.image_pull_policy}}
+          command:
+            - sh
+          args:
+            - /etc/limes/migrate.sh
+          volumeMounts:
+            - mountPath: /etc/limes
+              name: config

--- a/openstack/limes/templates/seed.yaml
+++ b/openstack/limes/templates/seed.yaml
@@ -13,14 +13,14 @@ spec:
       users:
         - name: limes
           description: Limes Service
-          password: '{{.Values.limes_service_password}}'
+          password: '{{.Values.limes.clusters.ccloud.password}}'
           roles:
             - project: service
               role:    service
             # permission to enumerate all projects and domains
             - project: cloud_admin@ccadmin
               role:    admin
-            # permission to manage all service's quotas
+            # permission to manage all services' quotas
             - project: cloud_admin@ccadmin
               role:    cloud_network_admin
             - project: cloud_admin@ccadmin

--- a/openstack/limes/values.yaml
+++ b/openstack/limes/values.yaml
@@ -1,4 +1,4 @@
-lobal:
+global:
   region: DEFINED_IN_VALUES_FILE
 
 limes:

--- a/openstack/limes/values.yaml
+++ b/openstack/limes/values.yaml
@@ -9,6 +9,4 @@ limes:
   # This section of the YAML must be identical to the "clusters" section of the
   # Limes configuration file.
   # <https://github.com/sapcc/limes/blob/master/docs/example-config.yaml>
-  additional_clusters: DEFINED_IN_VALUES_FILE
-
-  servicePassword: DEFINED_IN_VALUES_FILE
+  clusters: DEFINED_IN_VALUES_FILE

--- a/openstack/limes/values.yaml
+++ b/openstack/limes/values.yaml
@@ -1,4 +1,14 @@
-global:
+lobal:
   region: DEFINED_IN_VALUES_FILE
 
-limes_service_password: DEFINED_IN_VALUES_FILE
+limes:
+  image: sapcc/limes
+  image_tag: latest
+  image_pull_policy: Always
+
+  # This section of the YAML must be identical to the "clusters" section of the
+  # Limes configuration file.
+  # <https://github.com/sapcc/limes/blob/master/docs/example-config.yaml>
+  additional_clusters: DEFINED_IN_VALUES_FILE
+
+  servicePassword: DEFINED_IN_VALUES_FILE


### PR DESCRIPTION
The API part is not yet deployed because it is not yet implemented.

The PostgreSQL subchart is a direct copy of `common/postgresql`. (I couldn't figure out yet how to include that directory as a subchart directly.)