### PR TITLE
[swift] account-caretaker support for multiple keystone backends

### DIFF
--- a/openstack/swift/bin/swift-start
+++ b/openstack/swift/bin/swift-start
@@ -119,10 +119,10 @@ function _start_application {
             ;;
         account-caretaker-collect)
             bash /swift-bin/unmount-helper "${MARKER}" &
-            every 86400 swift-account-caretaker -l info collect
+            every 86400 swift-account-caretaker -c /caretaker-etc/config.yaml -l info collect
             ;;
         account-caretaker-mergify)
-            every 86400 swift-account-caretaker -l info mergify --history=30
+            every 86400 swift-account-caretaker -c /caretaker-etc/config.yaml -l info mergify --history=30
             ;;
         account-*)
             start_rsyslog

--- a/openstack/swift/templates/account-caretaker-collect-daemonset.yaml
+++ b/openstack/swift/templates/account-caretaker-collect-daemonset.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.enable_caretaker }}
+{{- if .Values.swift_account_caretaker.enable }}
 kind: DaemonSet
 apiVersion: extensions/v1beta1
 
@@ -18,19 +18,20 @@ spec:
         restart: directly
       annotations:
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"species","value":"swift-storage"}]'
-        {{- include "swift_conf_annotations" . | indent 8 }}
+        checksum/swift.bin: {{ include "swift/templates/bin-configmap.yaml" . | sha256sum }}
+        checksum/caretaker.etc: {{ include "swift/templates/caretaker-configmap.yaml" . | sha256sum }}
     spec:
       # Run daemonset in Hostnetwork to get the real hostname
       hostNetwork: true
       nodeSelector:
         species: swift-storage
       volumes:
+        - name: caretaker-etc
+          configMap:
+            name: swift-account-caretaker
         - name: swift-bin
           configMap:
             name: swift-bin
-        - name: swift-etc
-          configMap:
-            name: swift-etc
         - name: swift-drives
           hostPath:
             path: /srv/node
@@ -52,23 +53,11 @@ spec:
           env:
             - name: DEBUG_CONTAINER
               value: "false"
-            - name: OS_AUTH_URL
-              value: "{{.Values.caretaker_ks_auth_url}}"
-            - name: OS_PROJECT_NAME
-              value: "swift_test"
-            - name: OS_USERNAME
-              value: "test_admin"
-            - name: OS_PROJECT_DOMAIN_NAME
-              value: "cc3test"
-            - name: OS_USER_DOMAIN_NAME
-              value: "cc3test"
-            - name: OS_PASSWORD
-              value: "{{.Values.cc3test_admin_password}}"
           volumeMounts:
+            - mountPath: /caretaker-etc
+              name: caretaker-etc
             - mountPath: /swift-bin
               name: swift-bin
-            - mountPath: /swift-etc
-              name: swift-etc
             - mountPath: /srv/node
               name: swift-drives
             - mountPath: /swift-drive-state

--- a/openstack/swift/templates/account-caretaker-mergify-deployment.yaml
+++ b/openstack/swift/templates/account-caretaker-mergify-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.enable_caretaker }}
+{{- if .Values.swift_account_caretaker.enable }}
 kind: Deployment
 apiVersion: extensions/v1beta1
 
@@ -23,15 +23,16 @@ spec:
       labels:
         component: swift-account-caretaker-mergify
       annotations:
-        {{- include "swift_conf_annotations" . | indent 8 }}
+        checksum/swift.bin: {{ include "swift/templates/bin-configmap.yaml" . | sha256sum }}
+        checksum/caretaker.etc: {{ include "swift/templates/caretaker-configmap.yaml" . | sha256sum }}
     spec:
       volumes:
+        - name: caretaker-etc
+          configMap:
+            name: swift-account-caretaker
         - name: swift-bin
           configMap:
             name: swift-bin
-        - name: swift-etc
-          configMap:
-            name: swift-etc
       containers:
         - name: caretaker
           image: {{.Values.global.docker_repo}}/ubuntu-source-swift-account-m3:{{.Values.image_version_swift_account}}
@@ -44,31 +45,9 @@ spec:
           env:
             - name: DEBUG_CONTAINER
               value: "false"
-            - name: OS_AUTH_URL
-              value: "{{.Values.caretaker_ks_auth_url}}"
-            - name: OS_PROJECT_NAME
-              value: "swift_test"
-            - name: OS_USERNAME
-              value: "test_admin"
-            - name: OS_PROJECT_DOMAIN_NAME
-              value: "cc3test"
-            - name: OS_USER_DOMAIN_NAME
-              value: "cc3test"
-            - name: OS_PASSWORD
-              value: "{{.Values.cc3test_admin_password}}"
-            - name: OS_KS_ADMIN_USERNAME
-              value: "dashboard"
-            - name: OS_KS_ADMIN_USER_DOMAIN_NAME
-              value: "Default"
-            - name: OS_KS_ADMIN_PASSWORD
-              value: "{{.Values.dashboard_service_password}}"
-            {{- if .Values.caretaker_ks_scrape_auth_url }}
-            - name: OS_KS_SCRAPE_AUTH_URL
-              value: "{{.Values.caretaker_ks_scrape_auth_url}}"
-            {{- end }}
           volumeMounts:
+            - mountPath: /caretaker-etc
+              name: caretaker-etc
             - mountPath: /swift-bin
               name: swift-bin
-            - mountPath: /swift-etc
-              name: swift-etc
 {{- end }}

--- a/openstack/swift/templates/caretaker-configmap.yaml
+++ b/openstack/swift/templates/caretaker-configmap.yaml
@@ -28,4 +28,5 @@ data:
         os_project_domain_name: {{ $config.os_project_domain_name }}
         os_project_name: {{ $config.os_project_name }}
         scrape: {{ $config.scrape | default false }}
+        insecure: {{ $config.insecure | default false }}
       {{- end }}

--- a/openstack/swift/templates/caretaker-configmap.yaml
+++ b/openstack/swift/templates/caretaker-configmap.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ConfigMap
+
+metadata:
+  name: swift-account-caretaker
+  labels:
+    system: openstack
+    service: objectstore
+    component: configuration
+
+data:
+  config.yaml: |
+    {{- $caretaker := .Values.swift_account_caretaker }}
+    common:
+      os_auth_url: {{ $caretaker.common.os_auth_url }}
+      os_user_domain_name: {{ $caretaker.common.os_user_domain_name }}
+      os_username: {{ $caretaker.common.os_username }}
+      os_password: {{ $caretaker.common.os_password }}
+      os_project_domain_name: {{ $caretaker.common.os_project_domain_name }}
+      os_project_name: {{ $caretaker.common.os_project_name }}
+    verify:
+      {{- range $index, $config := $caretaker.verify }}
+      - cluster_name: {{ $config.cluster_name }}
+        os_auth_url: {{ $config.os_auth_url }}
+        os_user_domain_name: {{ $config.os_user_domain_name }}
+        os_username: {{ $config.os_username }}
+        os_password: {{ $config.os_password }}
+        os_project_domain_name: {{ $config.os_project_domain_name }}
+        os_project_name: {{ $config.os_project_name }}
+        {{- if $config.scrape }}
+        scrape: true
+        {{- end }}
+      {{- end }}

--- a/openstack/swift/templates/caretaker-configmap.yaml
+++ b/openstack/swift/templates/caretaker-configmap.yaml
@@ -27,7 +27,5 @@ data:
         os_password: {{ $config.os_password }}
         os_project_domain_name: {{ $config.os_project_domain_name }}
         os_project_name: {{ $config.os_project_name }}
-        {{- if $config.scrape }}
-        scrape: true
-        {{- end }}
+        scrape: {{ $config.scrape | default false }}
       {{- end }}

--- a/openstack/swift/values.yaml
+++ b/openstack/swift/values.yaml
@@ -56,15 +56,23 @@ enable_statsd: true
 
 # health check only
 dispersion_auth_url: DEFINED_IN_REGION_CHART
-
-# account-caretaker and health-statsd only
 cc3test_admin_password: DEFINED_IN_REGION_CHART
 
 # Deploy swift-account-caretaker
-enable_caretaker: true
-# account-caretaker only
-dashboard_service_password: DEFINED_IN_REGION_CHART
-# Auth url used for caretaker if different than in swift env
-caretaker_ks_auth_url: ""
-# Auth URL for scraping domains and urls
-caretaker_ks_scrape_auth_url: ""
+swift_account_caretaker:
+  enable: true
+  common:
+    os_auth_url: DEFINED_IN_REGION_CHART
+    os_user_domain_name: DEFINED_IN_REGION_CHART
+    os_username: DEFINED_IN_REGION_CHART
+    os_password: DEFINED_IN_REGION_CHART
+    os_project_domain_name: DEFINED_IN_REGION_CHART
+    os_project_name: DEFINED_IN_REGION_CHART
+  verify:
+    - cluster_name: DEFINED_IN_REGION_CHART
+      os_auth_url: DEFINED_IN_REGION_CHART
+      os_user_domain_name: DEFINED_IN_REGION_CHART
+      os_username: DEFINED_IN_REGION_CHART
+      os_password: DEFINED_IN_REGION_CHART
+      os_project_domain_name: DEFINED_IN_REGION_CHART
+      os_project_name: DEFINED_IN_REGION_CHART


### PR DESCRIPTION
Support `swift-account-caretaker` with multiple keystone backends in a shared swift cluster approach