### PR TITLE
ingress controller: enable virtual host traffic status module

### DIFF
--- a/system/kube-system/charts/ingress/values.yaml
+++ b/system/kube-system/charts/ingress/values.yaml
@@ -11,6 +11,7 @@ controller:
     worker-processes: '8'
     disable-ipv6: 'true'
     ssl-redirect: 'false'
+    enable-vts-status: 'true'
 defaultBackend:
   image:
     repository: gcr.io/google_containers/defaultbackend


### PR DESCRIPTION
No longer region-specific. OK @databus23? 