### PR TITLE
collect Prometheus HTTP metrics to limes-serve

### DIFF
--- a/openstack/limes/templates/api-service.yaml
+++ b/openstack/limes/templates/api-service.yaml
@@ -6,6 +6,9 @@ metadata:
   name: limes-api-{{$cluster_id}}
   labels:
     app: limes-api
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "80"
 
 spec:
   selector:


### PR DESCRIPTION
Requires latest Limes image. Will test and merge this when I have time.