### PR TITLE
Renaming service to service_type

### DIFF
--- a/openstack/monasca/templates/etc/monasca-agent/conf.d/_prometheus.yaml.tpl
+++ b/openstack/monasca/templates/etc/monasca-agent/conf.d/_prometheus.yaml.tpl
@@ -109,7 +109,7 @@ instances:
              dimensions:
                  component: kubernetes_name
                  hostname:  host
-                 service:   component
+                 service_type:   hypervisor_type
 
  - name: Prometheus-Aggregated
    url: '{{.Values.monasca_agent_config_prometheus_aggr_url}}/federate'


### PR DESCRIPTION
Adding service_type : hypervisor_type, this will helps us distinguish between KVM, QEMU, VMWare.