### PR TITLE
bump prometheus to v1.6.1

### DIFF
--- a/global/prometheus/templates/petset.yaml
+++ b/global/prometheus/templates/petset.yaml
@@ -20,8 +20,7 @@ spec:
           args:
             - -config.file=/etc/prometheus/prometheus.yaml
             - -storage.local.path=/prometheus
-            - -storage.local.memory-chunks={{.Values.memory_chunks}}
-            - -storage.local.max-chunks-to-persist={{.Values.max_chunks_to_persist}}
+            - -storage.local.target-heap-size=={{.Values.target_heap_size}}
             - -storage.local.retention={{.Values.retention}}
             - -web.console.libraries=/etc/prometheus/console_libraries
             - -web.console.templates=/etc/prometheus/consoles

--- a/global/prometheus/values.yaml
+++ b/global/prometheus/values.yaml
@@ -1,4 +1,3 @@
-image: prom/prometheus:v1.5.2
+image: prom/prometheus:v1.6.1
 retention: 2160h0m0s # 90 days
-memory_chunks: "4194304"
-max_chunks_to_persist: "2097152"
+target_heap_size: "53687091200"

--- a/system/kube-monitoring/charts/prometheus-collector/templates/deployment.yaml
+++ b/system/kube-monitoring/charts/prometheus-collector/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
           args:
             - -config.file=/etc/prometheus/prometheus.yaml
             - -storage.local.path=/prometheus
-            - -storage.local.target-heap-size=={{.Values.target_heap_size}}
+            - -storage.local.target-heap-size={{.Values.target_heap_size}}
             - -storage.local.retention={{.Values.retention}}
             - -web.console.libraries=/etc/prometheus/console_libraries
             - -web.console.templates=/etc/prometheus/consoles

--- a/system/kube-monitoring/charts/prometheus-collector/templates/deployment.yaml
+++ b/system/kube-monitoring/charts/prometheus-collector/templates/deployment.yaml
@@ -23,8 +23,7 @@ spec:
           args:
             - -config.file=/etc/prometheus/prometheus.yaml
             - -storage.local.path=/prometheus
-            - -storage.local.memory-chunks={{.Values.memory_chunks}}
-            - -storage.local.max-chunks-to-persist={{.Values.max_chunks_to_persist}}
+            - -storage.local.target-heap-size=={{.Values.target_heap_size}}
             - -storage.local.retention={{.Values.retention}}
             - -web.console.libraries=/etc/prometheus/console_libraries
             - -web.console.templates=/etc/prometheus/consoles

--- a/system/kube-monitoring/charts/prometheus-collector/values.yaml
+++ b/system/kube-monitoring/charts/prometheus-collector/values.yaml
@@ -1,4 +1,4 @@
 image: prom/prometheus:v1.6.1
 retention: 1h0m0s
-# 10 Gib
-target_heap_size: "10737418240"
+# 5 Gib
+target_heap_size: "5368709120"

--- a/system/kube-monitoring/charts/prometheus-collector/values.yaml
+++ b/system/kube-monitoring/charts/prometheus-collector/values.yaml
@@ -1,3 +1,4 @@
 image: prom/prometheus:v1.6.1
 retention: 1h0m0s
-target_heap_size: "4294967296"
+# 10 Gib
+target_heap_size: "10737418240"

--- a/system/kube-monitoring/charts/prometheus-collector/values.yaml
+++ b/system/kube-monitoring/charts/prometheus-collector/values.yaml
@@ -1,4 +1,3 @@
-image: prom/prometheus:v1.5.2
+image: prom/prometheus:v1.6.1
 retention: 1h0m0s
-memory_chunks: "262144"
-max_chunks_to_persist: "131072"
+target_heap_size: "4294967296"

--- a/system/kube-monitoring/charts/prometheus-frontend/templates/petset.yaml
+++ b/system/kube-monitoring/charts/prometheus-frontend/templates/petset.yaml
@@ -20,7 +20,7 @@ spec:
           args:
             - -config.file=/etc/prometheus/prometheus.yaml
             - -storage.local.path=/prometheus
-            - -storage.local.target-heap-size=={{.Values.target_heap_size}}
+            - -storage.local.target-heap-size={{.Values.target_heap_size}}
             - -storage.local.retention={{.Values.retention}}
             - -web.console.libraries=/etc/prometheus/console_libraries
             - -web.console.templates=/etc/prometheus/consoles

--- a/system/kube-monitoring/charts/prometheus-frontend/templates/petset.yaml
+++ b/system/kube-monitoring/charts/prometheus-frontend/templates/petset.yaml
@@ -20,8 +20,7 @@ spec:
           args:
             - -config.file=/etc/prometheus/prometheus.yaml
             - -storage.local.path=/prometheus
-            - -storage.local.memory-chunks={{.Values.memory_chunks}}
-            - -storage.local.max-chunks-to-persist={{.Values.max_chunks_to_persist}}
+            - -storage.local.target-heap-size=={{.Values.target_heap_size}}
             - -storage.local.retention={{.Values.retention}}
             - -web.console.libraries=/etc/prometheus/console_libraries
             - -web.console.templates=/etc/prometheus/consoles

--- a/system/kube-monitoring/charts/prometheus-frontend/values.yaml
+++ b/system/kube-monitoring/charts/prometheus-frontend/values.yaml
@@ -1,7 +1,6 @@
-image: prom/prometheus:v1.5.2
+image: prom/prometheus:v1.6.1
 retention: 168h0m0s
-memory_chunks: "4194304"
-max_chunks_to_persist: "2097152"
+target_heap_size: "53687091200"
 
 # if defined in values.yaml, enables playbook links on alerts
 ops_docu_url: ""

--- a/system/kube-monitoring/charts/prometheus-frontend/values.yaml
+++ b/system/kube-monitoring/charts/prometheus-frontend/values.yaml
@@ -1,7 +1,6 @@
 image: prom/prometheus:v1.6.1
 retention: 168h0m0s
-# 60 Gib
-target_heap_size: "64424509440"
+target_heap_size: "26843545600"
 
 # if defined in values.yaml, enables playbook links on alerts
 ops_docu_url: ""

--- a/system/kube-monitoring/charts/prometheus-frontend/values.yaml
+++ b/system/kube-monitoring/charts/prometheus-frontend/values.yaml
@@ -1,6 +1,7 @@
 image: prom/prometheus:v1.6.1
 retention: 168h0m0s
-target_heap_size: "53687091200"
+# 60 Gib
+target_heap_size: "64424509440"
 
 # if defined in values.yaml, enables playbook links on alerts
 ops_docu_url: ""


### PR DESCRIPTION
**WIP - DO NOT MERGE**

Prometheus v1.6.x deprecated the flags `-storage.local.memory-chunks` & `-storage.local.max-chunks-to-persist` in favor of `-storage.local.target-heap-size`.
https://prometheus.eu-de-1.cloud.sap/graph?g0.range_input=1h&g0.expr=container_memory_usage_bytes%7Bpod_name%3D~%22prometheus-.*%22%7D%2F1024%2F1024%2F1024&g0.tab=1 could give us an indication what could be reasonable values here. 
What do you think @BugRoger?