### PR TITLE
[swift] statsd_exporter daemonset and HostNetwork

### DIFF
--- a/openstack/swift/templates/_utils.tpl
+++ b/openstack/swift/templates/_utils.tpl
@@ -19,10 +19,12 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this 
 {{- /**********************************************************************************/ -}}
 {{- define "swift_daemonset_annotations" }}
 scheduler.alpha.kubernetes.io/tolerations: '[{"key":"species","value":"swift-storage"}]'
-{{- if .Values.enable_statsd }}
+{{- end -}}
+
+{{- /**********************************************************************************/ -}}
+{{- define "swift_prometheus_annotations" }}
 prometheus.io/scrape: "true"
 prometheus.io/port: "9102"
-{{- end }}
 {{- end -}}
 
 {{- /**********************************************************************************/ -}}

--- a/openstack/swift/templates/account-caretaker-collect-daemonset.yaml
+++ b/openstack/swift/templates/account-caretaker-collect-daemonset.yaml
@@ -17,7 +17,7 @@ spec:
         from: daemonset
         restart: directly
       annotations:
-        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"species","value":"swift-storage"}]'
+        {{- include "swift_daemonset_annotations" . | indent 8 }}
         checksum/swift.bin: {{ include "swift/templates/bin-configmap.yaml" . | sha256sum }}
         checksum/caretaker.etc: {{ include "swift/templates/caretaker-configmap.yaml" . | sha256sum }}
     spec:

--- a/openstack/swift/templates/etc/_rsyncd.conf.tpl
+++ b/openstack/swift/templates/etc/_rsyncd.conf.tpl
@@ -5,9 +5,6 @@ log file = /dev/stdout
 pid file = /var/log/swift/rsyncd.pid
 # TODO: set the replication IP here (or pass on cmdline with --address)
 address = 0.0.0.0
-# rsyncd is not running as root and thus cannot bind the standard port 873;
-# bind on 8873 instead and map to the standard port in the daemonset.yaml
-port = 8873
 
 # /etc/rsyncd: configuration file for rsync daemon mode
 
@@ -50,4 +47,3 @@ max connections = 30
 path = /srv/node
 read only = false
 lock file = /var/lock/object.lock
-

--- a/openstack/swift/templates/memcached-service.yaml
+++ b/openstack/swift/templates/memcached-service.yaml
@@ -7,11 +7,9 @@ metadata:
   labels:
     system: openstack
     component: objectstore
-{{ if .Values.enable_statsd }}
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "9150"
-{{ end }}
 
 spec:
   type: NodePort

--- a/openstack/swift/templates/proxy-deployment.yaml
+++ b/openstack/swift/templates/proxy-deployment.yaml
@@ -127,17 +127,7 @@ spec:
               name: swift-container-ring
             - mountPath: /swift-rings/object
               name: swift-object-ring
-        - name: statsd
-          image: prom/statsd-exporter:{{$.Values.image_version_auxiliary_statsd_exporter}}
-          args: [ -statsd.mapping-config=/swift-etc/statsd-exporter.conf ]
-          ports:
-            - name: statsd
-              containerPort: 9125
-              protocol: UDP
-            - name: metrics
-              containerPort: 9102
-          volumeMounts:
-            - mountPath: /swift-etc
-              name: swift-etc
+        {{- include "swift_statsd_exporter_container" $ | indent 8 }}
+
 ---
 {{end}}

--- a/openstack/swift/templates/proxy-service.yaml
+++ b/openstack/swift/templates/proxy-service.yaml
@@ -8,11 +8,8 @@ metadata:
     system: openstack
     component: objectstore
     os-cluster: {{$cluster.name}}
-{{ if $.Values.enable_statsd }}
   annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9102"
-{{ end }}
+    {{- include "swift_prometheus_annotations" . | indent 4 }}
 spec:
   selector:
     component: swift-proxy-{{$cluster.name}}

--- a/openstack/swift/templates/replicators-daemonset.yaml
+++ b/openstack/swift/templates/replicators-daemonset.yaml
@@ -31,4 +31,3 @@ spec:
         {{- tuple "account"   "account-replicator"   . | include "swift_standard_container" | indent 8 }}
         {{- tuple "container" "container-replicator" . | include "swift_standard_container" | indent 8 }}
         {{- tuple "object"    "object-replicator"    . | include "swift_standard_container" | indent 8 }}
-        {{- include "swift_statsd_exporter_container" . | indent 8 }}

--- a/openstack/swift/templates/rsyncd-daemonset.yaml
+++ b/openstack/swift/templates/rsyncd-daemonset.yaml
@@ -58,7 +58,3 @@ spec:
               name: swift-drives
             - mountPath: /swift-drive-state
               name: swift-drive-state
-          ports:
-            - name: rsyncd
-              hostPort: 873
-              containerPort: 8873

--- a/openstack/swift/templates/rsyncd-daemonset.yaml
+++ b/openstack/swift/templates/rsyncd-daemonset.yaml
@@ -16,9 +16,10 @@ spec:
         from: daemonset
         restart: directly
       annotations:
-        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"species","value":"swift-storage"}]'
+        {{- include "swift_daemonset_annotations" . | indent 8 }}
         {{- include "swift_conf_annotations" . | indent 8 }}
     spec:
+      hostNetwork: true
       nodeSelector:
         species: swift-storage
       volumes:

--- a/openstack/swift/templates/servers-daemonset.yaml
+++ b/openstack/swift/templates/servers-daemonset.yaml
@@ -26,17 +26,5 @@ spec:
       volumes: {{ include "swift_daemonset_volumes" . | indent 8 }}
       containers:
         {{- tuple "object"    "object-server"    . | include "swift_standard_container" | indent 8 }}
-          ports:
-            - name: swift-object
-              hostPort: 6000
-              containerPort: 6000
         {{- tuple "container" "container-server" . | include "swift_standard_container" | indent 8 }}
-          ports:
-            - name: swift-container
-              hostPort: 6001
-              containerPort: 6001
         {{- tuple "account"   "account-server"   . | include "swift_standard_container" | indent 8 }}
-          ports:
-            - name: swift-account
-              hostPort: 6002
-              containerPort: 6002

--- a/openstack/swift/templates/servers-daemonset.yaml
+++ b/openstack/swift/templates/servers-daemonset.yaml
@@ -26,5 +26,17 @@ spec:
       volumes: {{ include "swift_daemonset_volumes" . | indent 8 }}
       containers:
         {{- tuple "object"    "object-server"    . | include "swift_standard_container" | indent 8 }}
+          ports:
+            - name: swift-object
+              hostPort: 6000
+              containerPort: 6000
         {{- tuple "container" "container-server" . | include "swift_standard_container" | indent 8 }}
+          ports:
+            - name: swift-container
+              hostPort: 6001
+              containerPort: 6001
         {{- tuple "account"   "account-server"   . | include "swift_standard_container" | indent 8 }}
+          ports:
+            - name: swift-account
+              hostPort: 6002
+              containerPort: 6002

--- a/openstack/swift/templates/statsd-exporter-daemonset.yaml
+++ b/openstack/swift/templates/statsd-exporter-daemonset.yaml
@@ -1,0 +1,30 @@
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+
+metadata:
+  name: swift-statsd-exporter
+  namespace: swift
+  labels:
+    system: openstack
+    component: objectstore
+
+spec:
+  template:
+    metadata:
+      labels:
+        component: swift-statsd-exporter
+        from: daemonset
+        restart: directly
+      annotations:
+        {{- include "swift_daemonset_annotations" . | indent 8 }}
+        {{- include "swift_conf_annotations" . | indent 8 }}
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        species: swift-storage
+      volumes:
+        - name: swift-etc
+          configMap:
+            name: swift-etc
+      containers:
+        {{- include "swift_statsd_exporter_container" . | indent 8 }}

--- a/openstack/swift/templates/statsd-exporter-daemonset.yaml
+++ b/openstack/swift/templates/statsd-exporter-daemonset.yaml
@@ -17,7 +17,8 @@ spec:
         restart: directly
       annotations:
         {{- include "swift_daemonset_annotations" . | indent 8 }}
-        {{- include "swift_conf_annotations" . | indent 8 }}
+        {{- include "swift_prometheus_annotations" . | indent 8 }}
+        checksum/swift.etc: {{ include "swift/templates/etc/configmap.yaml" . | sha256sum }}
     spec:
       hostNetwork: true
       nodeSelector:

--- a/openstack/swift/templates/workers-daemonset.yaml
+++ b/openstack/swift/templates/workers-daemonset.yaml
@@ -20,6 +20,7 @@ spec:
         {{- include "swift_conf_annotations" . | indent 8 }}
         {{- include "swift_ring_annotations" . | indent 8 }}
     spec:
+      hostNetwork: true
       nodeSelector:
         species: swift-storage
       volumes: {{ include "swift_daemonset_volumes" . | indent 8 }}
@@ -31,4 +32,3 @@ spec:
         {{- tuple "object"    "object-auditor"    . | include "swift_standard_container" | indent 8 }}
         {{- tuple "object"    "object-updater"    . | include "swift_standard_container" | indent 8 }}
         {{- tuple "object"    "recon-cron"        . | include "swift_standard_container" | indent 8 }}
-        {{- include "swift_statsd_exporter_container" . | indent 8 }}

--- a/openstack/swift/values.yaml
+++ b/openstack/swift/values.yaml
@@ -52,10 +52,6 @@ account_ring_base64: DEFINED_IN_REGION_CHART
 container_ring_base64: DEFINED_IN_REGION_CHART
 object_ring_base64: DEFINED_IN_REGION_CHART
 
-# temporarily required to avoid mixing of statsd metrics from multiple clusters
-# in the same region (TODO: remove when legacy systems have been migrated)
-enable_statsd: true
-
 # health check only
 dispersion_auth_url: DEFINED_IN_REGION_CHART
 cc3test_admin_password: DEFINED_IN_REGION_CHART


### PR DESCRIPTION
* statsd_exporter daemonset
* all daemonsets use HostNetwork
* template daemonset_annotation for tolerations
* template statsd_annotation for prometheus scraping
* use prometheus annotation and std container also for proxy
* Remove enable_statsd flag