### PR TITLE
Keystone: disable "identity.authenticate" CADF notifications

### DIFF
--- a/openstack/keystone/templates/etc/_keystone.conf.tpl
+++ b/openstack/keystone/templates/etc/_keystone.conf.tpl
@@ -11,6 +11,9 @@ logging_exception_prefix = %(process)d ERROR %(name)s %(instance)s
 
 notification_format = {{ .Values.notifications.format | default "basic" | quote }}
 driver = messaging
+{{ range $message_type := .Values.notifications.opt_out }}
+notification_opt_out = {{ $message_type }}
+{{ end }}
 
 [cache]
 backend = oslo_cache.memcache_pool

--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -108,6 +108,8 @@ services:
 notifications:
   enabled: true
   format: cadf
+  opt_out:
+    - identity.authenticate
 
 rabbitmq:
   host: rabbitmq


### PR DESCRIPTION
See https://docs.openstack.org/developer/keystone/event_notifications.html#opting-out-of-certain-notifications

Automatically excluded are:
"identity.authenticate.success"
"identity.authenticate.pending"
"identity.authenticate.failed"

However, we see that a large number of messages are coming
 through with type "identity.authenticate" and status "success",
  which are not automatically excluded. This commit fixes that.