### PR TITLE
Adding networking-dvs.alerts

### DIFF
--- a/system/kube-monitoring/charts/prometheus-frontend/networking-dvs.alerts
+++ b/system/kube-monitoring/charts/prometheus-frontend/networking-dvs.alerts
@@ -7,11 +7,11 @@ ALERT DVSPolling
     service = "dvs",
     severity = "critical",
     context = "availability",
-    dashboard = "networking-dvs"
+    dashboard = "neutron-dvs-agent"
   }
   ANNOTATIONS {
     summary = "Polling iterations fall below 1 per minute",
-    description = "Polling iterations of DVS Agent {{kubernetes_pod_name}} is below 1 per minute.",
+    description = "Polling iterations of DVS Agent {{ $labels.kubernetes_pod_name }} is below 1 per minute.",
   }
   
 ALERT DVSSecGroup
@@ -21,10 +21,10 @@ ALERT DVSSecGroup
     service = "dvs",
     severity = "critical",
     context = "availability",
-    dashboard = "networking-dvs"
+    dashboard = "neutron-dvs-agent"
   }
   ANNOTATIONS {
     summary = "security group latency goes over 1 minute",
-    description = "Security Group latency of DVS Agent {{kubernetes_pod_name}} is over 1 minute.",
+    description = "Security Group latency of DVS Agent {{ $labels.kubernetes_pod_name }} is over 1 minute.",
   }
   

--- a/system/kube-monitoring/charts/prometheus-frontend/networking-dvs.alerts
+++ b/system/kube-monitoring/charts/prometheus-frontend/networking-dvs.alerts
@@ -1,0 +1,30 @@
+### Networking-DVS Alerts ###
+
+ALERT DVSPolling
+  IF min(irate(openstack_networking_dvs_plugins_ml2_drivers_mech_dvs_agent_dvs_agent_process_ports_timer_count[5m])) < 1
+  FOR 5m
+  LABELS {
+    service = "dvs",
+    severity = "critical",
+    context = "availability",
+    dashboard = "networking-dvs"
+  }
+  ANNOTATIONS {
+    summary = "Polling iterations fall below 1 per minute",
+    description = "Polling iterations of DVS Agent {{kubernetes_pod_name}} is below 1 per minute.",
+  }
+  
+ALERT DVSSecGroup
+  IF max(openstack_networking_dvs_security_group_updates_timer{quantile="0.99"}) > 60
+  FOR 5m
+  LABELS {
+    service = "dvs",
+    severity = "critical",
+    context = "availability",
+    dashboard = "networking-dvs"
+  }
+  ANNOTATIONS {
+    summary = "security group latency goes over 1 minute",
+    description = "Security Group latency of DVS Agent {{kubernetes_pod_name}} is over 1 minute.",
+  }
+  


### PR DESCRIPTION
@auhlig 

Please confirm the below : 

1. Would the region name show-up in the alarm ?
2. I am not sure if $label has to be prefixed to {{kubernetes_pod_name}} lable ?
3. How to add grafana networking-dvs dashboard to the descriptions as created for ALERT KubernetesApiServerLatency.

The staging networking-dvs link is : https://grafana.staging.cloud.sap/dashboard/db/neutron-dvs-agent