### PR TITLE
Adding Tier, Context labels to the nova alerts

### DIFF
--- a/system/kube-monitoring/charts/prometheus-frontend/openstack-nova.alerts
+++ b/system/kube-monitoring/charts/prometheus-frontend/openstack-nova.alerts
@@ -1,12 +1,12 @@
 ### Networking-DVS Alerts ###
 
 ALERT OpenstackDVSPolling
-  IF (min(rate(openstack_networking_dvs_plugins_ml2_drivers_mech_dvs_agent_dvs_agent_process_ports_timer_count[5m])) by (cluster) *60) < 1
+  IF (min(rate(openstack_networking_dvs_plugins_ml2_drivers_mech_dvs_agent_dvs_agent_process_ports_timer_count[5m]))) by (cluster,kubernetes_pod_name) *60) < 1
   FOR 5m
   LABELS {
     service = "nova",
     severity = "info",
-    context = "openstack",
+    tier = "openstack",
     dashboard = "neutron-dvs-agent"
   }
   ANNOTATIONS {
@@ -19,8 +19,8 @@ ALERT OpenstackDVSSecGroup
   FOR 5m
   LABELS {
     service = "nova",
-    severity = "critical",
-    context = "openstack",
+    severity = "info",
+    tier = "openstack",
     dashboard = "neutron-dvs-agent"
   }
   ANNOTATIONS {
@@ -36,12 +36,13 @@ ALERT OpenstackNovaMaxDiskUsagePerc
   LABELS {
     service = "nova",
     severity = "critical",
-    context = "openstack",
+    context= "diskspace",
+    tier = "openstack",
     dashboard = "nova-hypervisor"
   }
   ANNOTATIONS {
     summary = "Nova Maximum Disk Usage percentage metric",
-    description = "Nova Maximum Disk Usage is above 90%",
+    description = "Nova Maximum Disk Usage is above 95%",
   }
   
   ALERT OpenstackNovaMaxRAMUsagePerc
@@ -49,11 +50,12 @@ ALERT OpenstackNovaMaxDiskUsagePerc
   FOR 5m
   LABELS {
     service = "nova",
-    severity = "critical",
-    context = "openstack",
+    severity = "warning",
+    context= "diskspace",
+    tier = "openstack",
     dashboard = "nova-hypervisor"
   }
   ANNOTATIONS {
     summary = "Nova Maximum RAM Usage percentage metric",
-    description = "Nova Maximum RAM Usage is above 95%.",
+    description = "Nova Maximum RAM Usage is above 90%.",
   }

--- a/system/kube-monitoring/charts/prometheus-frontend/openstack-nova.alerts
+++ b/system/kube-monitoring/charts/prometheus-frontend/openstack-nova.alerts
@@ -32,7 +32,7 @@ ALERT OpenstackDVSSecGroup
 
 ALERT OpenstackNovaMaxDiskUsagePerc
   IF 1.0 - min(openstack_compute_nodes_free_disk_gb_gauge{host!~".*ironic.*"}/openstack_compute_nodes_local_gb_gauge) by (cluster,host) > .90
-  FOR 5m
+  FOR 15m
   LABELS {
     service = "nova",
     severity = "critical",


### PR DESCRIPTION
@auhlig 

Below are the changes:

1. Adding kubernetes_pod_name to by clause for DVSPolling Alert, does this confirm the DVS Agent Name will be seen in description as defined ?
2.(min(rate(openstack_networking_dvs_plugins_ml2_drivers_mech_dvs_agent_dvs_agent_process_ports_timer_count[5m]))) had a missing left parenthesis while executing this in prometheus. will this execute fine now ?
3. is there a hierarchal flow for labels ?is the nova labels file ?
4. Can an alert have both severity as critical & warning ? else do i need to create 2 alerts ?