### PR TITLE
Hermes: Make logstash resilient to RabbitMQ connection errors

### DIFF
--- a/openstack/hermes/templates/etc/_logstash.conf.tpl
+++ b/openstack/hermes/templates/etc/_logstash.conf.tpl
@@ -7,7 +7,9 @@ rabbitmq {
     queue => "{{.Values.hermes_rabbitmq_queue_name}}"
     subscription_retry_interval_seconds => 60
     id => "logstash_hermes"
-    automatic_recovery => false
+    # From https://www.elastic.co/guide/en/logstash/current/plugins-inputs-rabbitmq.html#plugins-inputs-rabbitmq-automatic_recovery:
+    #  Set this to automatically recover from a broken connection. You almost certainly don’t want to override this!!!
+    automatic_recovery => true
   }
 }
 


### PR DESCRIPTION
@Kuckkuck are you OK with this? Hopefully means we don't have to keep restarting the pod when there's a RabbitMQ glitch...