### PR TITLE
[swift] Drive glob value for swift-drive-autopilot

### DIFF
--- a/openstack/swift/charts/swift_drive_autopilot/templates/configmap.yaml
+++ b/openstack/swift/charts/swift_drive_autopilot/templates/configmap.yaml
@@ -13,8 +13,14 @@ data:
     chroot: /coreos
 
     drives:
+    {{- if .Values.drives }}
+      {{- range $drives := .Values.drives }}
+      - {{ $drives }}
+      {{- end -}}
+    {{ else }}
       - /dev/sd[a-z]
       - /dev/sd[a-z][a-z]
+    {{ end }}
 
     # the Swift user and group is UID/GID 1000 in the Kolla containers
     chown:

--- a/openstack/swift/charts/swift_drive_autopilot/values.yaml
+++ b/openstack/swift/charts/swift_drive_autopilot/values.yaml
@@ -5,3 +5,8 @@ image_version: DEFINED_IN_REGION_CHART
 # will be set aside as spare capacity. (See swift-drive-autopilot docs for
 # details.)
 one_spare_disk_every: 20
+
+# Drive glob, if not provided it defaults to
+# drives:
+#  - /dev/sd[a-z]
+#  - /dev/sd[a-z][a-z]


### PR DESCRIPTION
Allows specifying non default drive globs like:

```
drives:
    - "/dev/mapper/mpath[a-z]"
    - "/dev/mapper/mpath[a-z][a-z]"
```