### PR TITLE
Prometheus v1.7.1 and Prom AM v0.7.1

### DIFF
--- a/global/prometheus-alertmanager/templates/deployment.yaml
+++ b/global/prometheus-alertmanager/templates/deployment.yaml
@@ -3,9 +3,6 @@ kind: Deployment
 
 metadata:
   name: prometheus-alertmanager
-  annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9093"
 
 spec:
   replicas: 1 

--- a/global/prometheus-alertmanager/templates/service.yaml
+++ b/global/prometheus-alertmanager/templates/service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: prometheus-alertmanager
+  annotations:
+      prometheus.io/scrape: "true"
 spec:
   selector:
     app: prometheus

--- a/global/prometheus-alertmanager/values.yaml
+++ b/global/prometheus-alertmanager/values.yaml
@@ -1,1 +1,1 @@
-image: prom/alertmanager:v0.6.2
+image: prom/alertmanager:v0.7.1

--- a/global/prometheus/values.yaml
+++ b/global/prometheus/values.yaml
@@ -1,3 +1,3 @@
-image: prom/prometheus:v1.7.0
+image: prom/prometheus:v1.7.1
 retention: 2160h0m0s # 90 days
 target_heap_size: "12884901888" # 12 GiB

--- a/global/prometheus/values.yaml
+++ b/global/prometheus/values.yaml
@@ -1,3 +1,3 @@
-image: prom/prometheus:v1.6.2
+image: prom/prometheus:v1.7.0
 retention: 2160h0m0s # 90 days
 target_heap_size: "12884901888" # 12 GiB

--- a/openstack/maia/values.yaml
+++ b/openstack/maia/values.yaml
@@ -6,7 +6,7 @@ maia:
   endpoint_host_public: DEFINED-IN-REGION-SECRETS
 
 prometheus:
-  image: prom/prometheus:v1.7.0
+  image: prom/prometheus:v1.7.1
   retention: 168h0m0s
   target_heap_size: "26843545600"
   listen_port: 9090

--- a/openstack/maia/values.yaml
+++ b/openstack/maia/values.yaml
@@ -6,7 +6,7 @@ maia:
   endpoint_host_public: DEFINED-IN-REGION-SECRETS
 
 prometheus:
-  image: prom/prometheus:v1.6.2
+  image: prom/prometheus:v1.7.0
   retention: 168h0m0s
   target_heap_size: "26843545600"
   listen_port: 9090

--- a/system/kube-monitoring/charts/prometheus-collector/values.yaml
+++ b/system/kube-monitoring/charts/prometheus-collector/values.yaml
@@ -1,4 +1,4 @@
-image: prom/prometheus:v1.7.0
+image: prom/prometheus:v1.7.1
 retention: 1h0m0s
 # 5 Gib
 target_heap_size: "5368709120"

--- a/system/kube-monitoring/charts/prometheus-collector/values.yaml
+++ b/system/kube-monitoring/charts/prometheus-collector/values.yaml
@@ -1,4 +1,4 @@
-image: prom/prometheus:v1.6.2
+image: prom/prometheus:v1.7.0
 retention: 1h0m0s
 # 5 Gib
 target_heap_size: "5368709120"

--- a/system/kube-monitoring/charts/prometheus-frontend/values.yaml
+++ b/system/kube-monitoring/charts/prometheus-frontend/values.yaml
@@ -1,4 +1,4 @@
-image: prom/prometheus:v1.6.2
+image: prom/prometheus:v1.7.0
 retention: 168h0m0s
 target_heap_size: "26843545600"
 

--- a/system/kube-monitoring/charts/prometheus-frontend/values.yaml
+++ b/system/kube-monitoring/charts/prometheus-frontend/values.yaml
@@ -1,4 +1,4 @@
-image: prom/prometheus:v1.7.0
+image: prom/prometheus:v1.7.1
 retention: 168h0m0s
 target_heap_size: "26843545600"
 


### PR DESCRIPTION
Will take care next week.

Maybe the update of the AM also solves the issue with the HA setup (**keeps fingers crossed**)

Prometheus 1.7 also introduces (beta) Openstack service discovery which also allows us to discover and scrape targets from Nova instances. [Prometheus docs](https://prometheus.io/docs/operating/configuration/#openstack_sd_config) Do we want to try that @BugRoger? I suggest to do that in the maia prometheus.