### PR TITLE
federate snmp exporter metrics from maia prometheus

### DIFF
--- a/system/kube-monitoring/charts/prometheus-frontend/templates/config.yaml
+++ b/system/kube-monitoring/charts/prometheus-frontend/templates/config.yaml
@@ -111,6 +111,33 @@ data:
         - targets:
           - 'prometheus-collector.{{ .Release.Namespace }}:9090'
 
+    - job_name: 'prometheus-maia-federation'
+      scrape_interval: 30s
+      scrape_timeout: 25s
+
+      honor_labels: true
+      metrics_path: '/federate'
+
+      params:
+        'match[]':
+          - '{__name__=~"^snmp_asr_.+"}'
+
+      relabel_configs:
+        - action: replace
+          target_label: region
+          replacement: {{ .Values.global.region }}
+
+      metric_relabel_configs:
+        - action: replace
+          source_labels: [__name__]
+          target_label: __name__
+          regex: aggregated:(.+)
+          replacement: $1
+
+      static_configs:
+        - targets:
+          - 'prometheus-maia.maia:9090'
+
     alerting:
       alertmanagers:
       - scheme: https


### PR DESCRIPTION
@BugRoger @Kuckkuck - can you please double check and pull if it looks ok to you?

i'm federating the snmp_asr_* metrics from the maia prometheus, as the snmp exporter is a bit special in that it requires some arguments in the exporter url (the snmp machine to get the data from and the corresponding config name) and does some special rewriting (so that the snmp host appears as the instance of the resulting metrics and not the snmp exporter itself) - all this is default snmp-exporter mode. in case we would want to scrape it from the normal prometheus collector, we would need the required info about the snmp parameters, which lives in the maia secret. thus for now it is easier to scrape the snmp-exporter via the maia prometheus and federate from there to the prometheus frontend.