### PR TITLE
convert maia prometheus to deployment

### DIFF
--- a/openstack/maia/templates/prometheus-deployment.yaml
+++ b/openstack/maia/templates/prometheus-deployment.yaml
@@ -1,13 +1,15 @@
 {{- if .Values.prometheus.enabled }}
-apiVersion: apps/v1alpha1
-kind: PetSet
+apiVersion: extensions/v1beta1
+kind: Deployment
 
 metadata:
   name: prometheus-maia
 
 spec:
   replicas: 1
-  serviceName: prometheus-maia
+  minReadySeconds: 10
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
@@ -39,16 +41,8 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: data
+            claimName: {{ .Values.prometheus.persistence.name | quote }}
         - name: config
           configMap:
             name: prometheus-maia
-  volumeClaimTemplates:
-    - metadata:
-        name: data
-      spec:
-        accessModes: [ "ReadWriteMany" ]
-        resources:
-          requests:
-            storage: 100Gi
 {{- end }}

--- a/openstack/maia/templates/prometheus-pvc.yaml
+++ b/openstack/maia/templates/prometheus-pvc.yaml
@@ -1,0 +1,13 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ .Values.prometheus.persistence.name | quote }}
+  labels:
+    app: prometheus
+    type: maia
+spec:
+  accessModes:
+    - {{ .Values.prometheus.persistence.access_mode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.prometheus.persistence.size | quote }}

--- a/openstack/maia/values.yaml
+++ b/openstack/maia/values.yaml
@@ -33,6 +33,10 @@ prometheus:
   retention: 168h0m0s
   target_heap_size: "26843545600"
   listen_port: 9090
+  persistence:
+    name: data-prometheus-maia-0
+    access_mode: ReadWriteMany
+    size: 100GiB
 
 vcenter_exporter:
   listen_port: 9102


### PR DESCRIPTION
Here you go @jobrs, @thgrs.
Do **not** roll out via the pipeline but via a manual `helm upgrade`, since the pod of the maia-prometheus petset needs to be deleted manually before introducing the deployment. This should recycle the existing pvc. 