### PR TITLE
Dirty Fix for rsync incompatibility (legacy/k8s)

### DIFF
--- a/openstack/swift/bin/rsyncd-start
+++ b/openstack/swift/bin/rsyncd-start
@@ -15,16 +15,17 @@ MARKER="/swift-drive-state/service-startup-time/rsyncd"
 touch "${MARKER}"
 
 function _start_application {
-    apt-get update && apt-get -y install build-essential && apt-get clean
-    cd /tmp
-    curl http://rsync.samba.org/ftp/rsync/src/rsync-3.1.1.tar.gz | tar xz
-    cd *rsync*
-    ./configure
-    make
-    cp rsync /usr/bin/rsync
-    chmod +x /usr/bin/rsync
-    make clean
-    #rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    if [ "$RSYNC_COMPAT" = "true" ]; then
+      apt-get update && apt-get -y install build-essential && apt-get clean
+      cd /tmp
+      curl http://rsync.samba.org/ftp/rsync/src/rsync-3.1.1.tar.gz | tar xz
+      cd *rsync*
+      ./configure
+      make
+      cp rsync /usr/bin/rsync
+      chmod +x /usr/bin/rsync
+      make clean
+    fi
 
     bash /swift-bin/unmount-helper "${MARKER}" &
     /usr/bin/rsync --daemon --config=/swift-etc/rsyncd.conf --no-detach

--- a/openstack/swift/bin/rsyncd-start
+++ b/openstack/swift/bin/rsyncd-start
@@ -15,6 +15,17 @@ MARKER="/swift-drive-state/service-startup-time/rsyncd"
 touch "${MARKER}"
 
 function _start_application {
+    apt-get update && apt-get -y install build-essential && apt-get clean
+    cd /tmp
+    curl http://rsync.samba.org/ftp/rsync/src/rsync-3.1.1.tar.gz | tar xz
+    cd *rsync*
+    ./configure
+    make
+    cp rsync /usr/bin/rsync
+    chmod +x /usr/bin/rsync
+    make clean
+    #rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
     bash /swift-bin/unmount-helper "${MARKER}" &
     /usr/bin/rsync --daemon --config=/swift-etc/rsyncd.conf --no-detach
 }

--- a/openstack/swift/templates/rsyncd-daemonset.yaml
+++ b/openstack/swift/templates/rsyncd-daemonset.yaml
@@ -50,6 +50,8 @@ spec:
           env:
             - name: DEBUG_CONTAINER
               value: "false"
+            - name: RSYNC_COMPAT
+              value: {{ default "false" .Values.rsync_compat | quote }}
           volumeMounts:
             - mountPath: /swift-bin
               name: swift-bin


### PR DESCRIPTION
We are hit by that https://bugs.launchpad.net/ubuntu/+source/rsync/+bug/1300367
Did not occur on changing, because we seem to not hit the size boundary.

As we are currently not getting a working new container image (see my tries
at https://github.wdf.sap.corp/monsoon/kolla-containers/tree/master/m3-containers/docker/swift/swift-rsyncd-m3)
I decided for that dirty hack. Lets discuss this asap.