### PR TITLE
Introduce the meta label for alerts

### DIFF
--- a/system/kube-monitoring/charts/prometheus-frontend/blackbox.alerts
+++ b/system/kube-monitoring/charts/prometheus-frontend/blackbox.alerts
@@ -8,6 +8,7 @@ ALERT OpenstackApiDown
     tier = "openstack",
     service = "{{ $labels.check }}",
     context = "{{ $labels.check }}",
+    meta = "{{ $labels.check }}",
     dashboard = "ccloud-health-blackbox-details",
     sentry = "blackbox"
   }
@@ -23,6 +24,7 @@ ALERT OpenstackApiFlapping
     tier = "openstack",
     service = "{{ $labels.check }}",
     context = "{{ $labels.check }}",
+    meta = "{{ $labels.check }}",
     dashboard = "ccloud-health-blackbox-details",
     sentry = "blackbox"
   }
@@ -40,6 +42,7 @@ ALERT OpenstackDatapathDown
     severity = "critical",
     tier = "openstack",
     context = "{{ $labels.check }}",
+    meta = "{{ $labels.check }}",
     dashboard = "ccloud-health-datapath-details",
     sentry = "blackbox"
   }
@@ -54,6 +57,7 @@ ALERT OpenstackDatapathFlapping
     severity = "warning",
     tier = "openstack",
     context = "{{ $labels.check }}",
+    meta = "{{ $labels.check }}",
     dashboard = "ccloud-health-datapath-details",
     sentry = "blackbox"
   }
@@ -71,6 +75,7 @@ ALERT OpenstackCanaryHealthCheckFailing
     severity = "warning",
     tier = "openstack",
     context = "{{ $labels.check }}",
+    meta = "{{ $labels.check }}",
     dashboard = "ccloud-health-canary-details",
     sentry = "blackbox"
   }
@@ -85,6 +90,7 @@ ALERT OpenstackCanaryHealthCheckFlapping
     severity = "warning",
     tier = "openstack",
     context = "{{ $labels.check }}",
+    meta = "{{ $labels.check }}",
     dashboard = "ccloud-health-canary-details",
     sentry = "blackbox"
   }
@@ -100,6 +106,7 @@ ALERT OpenstackCertificateExpires
   LABELS {
     severity = "warning",
     tier = "openstack",
+    meta = "{{ $labels.check }}",
     context = "{{ $labels.check }}",
     sentry = "blackbox"
   }
@@ -114,6 +121,7 @@ ALERT OpenstackCertificateExpiresSoon
     severity = "critical",
     tier = "openstack",
     context = "{{ $labels.check }}",
+    meta = "{{ $labels.check }}",
     sentry = "blackbox"
   }
   ANNOTATIONS {

--- a/system/kube-monitoring/charts/prometheus-frontend/openstack-swift.alerts
+++ b/system/kube-monitoring/charts/prometheus-frontend/openstack-swift.alerts
@@ -156,6 +156,7 @@ ALERT OpenstackSwiftRepo
     service = "swift",
     severity = "warning",
     context = "repo",
+    meta = "{{ $labels.repo }}",
     dashboard = "repo-sync?var-repo={{ $labels.repo }}",
   }
   ANNOTATIONS {

--- a/system/kube-monitoring/charts/prometheus-frontend/templates/_kubernetes.alerts.tpl
+++ b/system/kube-monitoring/charts/prometheus-frontend/templates/_kubernetes.alerts.tpl
@@ -6,7 +6,8 @@ ALERT KubernetesKubeletDown
     service = "kubelet",
     severity = "critical",
     context = "kubelet",
-    dashboard = "kubernetes-health"
+    meta = "{{ $labels.instance }}",
+    dashboard = "kubernetes-health",
   }
   ANNOTATIONS {
     summary = "A Kubelet is DOWN",
@@ -52,7 +53,8 @@ ALERT KubernetesKubeletTooManyPods
     service = "kubelet",
     severity = "warning",
     context = "kubelet",
-    dashboard = "kubernetes-node?var-server={{`{{$labels.instance}}`}}"
+    meta = "{{ $labels.instance }}",
+    dashboard = "kubernetes-node?var-server={{`{{$labels.instance}}`}}",
   }
   ANNOTATIONS {
     summary = "Kubelet is close to pod limit",
@@ -67,7 +69,8 @@ ALERT KubernetesKubeletFull
     service = "k8s",
     severity = "critical",
     context = "kubelet",
-    dashboard = "kubernetes-node?var-server={{`{{$labels.instance}}`}}"
+    meta = "{{ $labels.instance }}",
+    dashboard = "kubernetes-node?var-server={{`{{$labels.instance}}`}}",
   }
   ANNOTATIONS {
     summary = "Kubelet is full",
@@ -82,6 +85,7 @@ ALERT KubernetesNodeNotReady
     service = "k8s",
     severity = "critical",
     context = "node",
+    meta = "{{ $labels.node }}",
     dashboard = "kubernetes-node?var-server={{`{{$labels.node}}`}}",
     {{ if .Values.ops_docu_url -}}
         playbook = "{{.Values.ops_docu_url}}/docs/support/playbook/k8s_node_not_ready.html",
@@ -115,7 +119,8 @@ ALERT KubernetesNodeNotReady
     service = "k8s",
     severity = "warning",
     context = "node",
-    dashboard = "kubernetes-node?var-server={{`{{$labels.instance}}`}}"
+    meta = "{{ $labels.node }}",
+    dashboard = "kubernetes-node?var-server={{`{{$labels.instance}}`}}",
   }
   ANNOTATIONS {
     summary = "Node Readyness is flapping",
@@ -145,6 +150,7 @@ ALERT KubernetesPodRestartingTooMuch
     service = "resources",
     severity = "info",
     context = "pod",
+    meta = "{{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}}",
   }
   ANNOTATIONS {
     summary = "Pod is in a restart loop",
@@ -160,7 +166,8 @@ ALERT KubernetesKubeletDockerHangs
     service = "kubelet",
     severity = "warning",
     context = "docker",
-    dashboard = "kubernetes-node?var-server={{`{{$labels.instance}}`}}"
+    meta = "{{ $labels.instance }}",
+    dashboard = "kubernetes-node?var-server={{`{{$labels.instance}}`}}",
   }
   ANNOTATIONS {
     summary = "Docker hangs!",
@@ -175,7 +182,8 @@ ALERT KubernetesApiServerDown
     service = "k8s",
     severity = "warning",
     context = "apiserver",
-    dashboard = "kubernetes-kubelet?var-node={{`{{$labels.instance}}`}}"
+    meta = "{{ $labels.instance }}",
+    dashboard = "kubernetes-kubelet?var-node={{`{{$labels.instance}}`}}",
   }
   ANNOTATIONS {
     summary = "An ApiServer is DOWN",
@@ -317,7 +325,8 @@ ALERT KubernetesTooManyOpenFiles
     service = "k8s",
     severity = "warning",
     context = "system",
-    dashboard = "kubernetes-node?var-server={{`{{$labels.instance}}`}}"
+    meta = "{{ $labels.instance }}",
+    dashboard = "kubernetes-node?var-server={{`{{$labels.instance}}`}}",
   }
   ANNOTATIONS {
     summary = "Too many open file descriptors",
@@ -332,7 +341,8 @@ ALERT KubernetesTooManyOpenFiles
     service = "k8s",
     severity = "critical",
     context = "system",
-    dashboard = "kubernetes-node?var-server={{`{{$labels.instance}}`}}"
+    meta = "{{ $labels.instance }}",
+    dashboard = "kubernetes-node?var-server={{`{{$labels.instance}}`}}",
   }
   ANNOTATIONS {
     summary = "Too many open file descriptors",
@@ -346,7 +356,8 @@ ALERT KubernetesHighNumberOfGoRoutines
     tier = "kubernetes",
     service = "kubelet",
     severity = "warning",
-    context = "kubelet"
+    context = "kubelet",
+    meta = "{{ $labels.instance }}",
   }
   ANNOTATIONS {
     summary = "High number of Go routines",
@@ -360,7 +371,8 @@ ALERT KubernetesPredictHighNumberOfGoRoutines
     tier = "kubernetes",
     service = "kubelet",
     severity = "warning",
-    context = "kubelet"
+    context = "kubelet",
+    meta = "{{ $labels.instance }}",
   }
   ANNOTATIONS {
     summary = "Predicting high number of Go routines",
@@ -374,7 +386,8 @@ ALERT KubernetesNodeDiskPressure
     tier = "kubernetes",
     service = "node",
     severity = "warning",
-    context = "kubelet"
+    context = "kubelet",
+    meta = "{{ $labels.instance }}",
   }
   ANNOTATIONS {
     summary = "Insufficient disk space",
@@ -388,10 +401,10 @@ ALERT KubernetesNodeMemoryPressure
     tier = "kubernetes",
     service = "node",
     severity = "warning",
-    context = "kubelet"
+    context = "kubelet",
+    meta = "{{ $labels.instance }}",
   }
   ANNOTATIONS {
     summary = "Insufficient memory",
     description = "Kublet on {{`{{$labels.instance}}`}} under pressure due to insufficient available memory.",
   }
-

--- a/system/kube-monitoring/charts/prometheus-frontend/templates/_node.alerts.tpl
+++ b/system/kube-monitoring/charts/prometheus-frontend/templates/_node.alerts.tpl
@@ -4,10 +4,11 @@ ALERT KubernetesHostHighCPUUsage
   IF avg(irate(node_cpu{mode="idle"}[5m])) by(instance, region) < 0.2
   FOR 3m
   LABELS {
-    tier = "kubernetes",
+    tier      = "kubernetes",
     service   = "node",
     severity  = "warning",
     context   = "availability",
+    meta      = "{{$labels.instance}}",
     dashboard = "kubernetes-node?var-server={{`{{$labels.instance}}`}}"
   }
   ANNOTATIONS {
@@ -19,10 +20,11 @@ ALERT KubernetesNodeClockDrift
   IF abs(ntp_drift_seconds) > 0.3
   FOR 10m
   LABELS {
-    tier = "kubernetes",
-    service = "node",
-    severity = "info",
-    context = "availability",
+    tier      = "kubernetes",
+    service   = "node",
+    severity  = "info",
+    context   = "availability",
+    meta      = "{{$labels.instance}}",
     dashboard = "kubernetes-node?var-server={{`{{$labels.instance}}`}}"
   }
   ANNOTATIONS {
@@ -34,10 +36,11 @@ ALERT KubernetesNodeKernelDeadlock
   IF kube_node_status_condition{condition="KernelDeadlock",status="true"} == 1
   FOR 96h
   LABELS {
-    tier = "kubernetes",
-    service = "k8s",
+    tier     = "kubernetes",
+    service  = "k8s",
     severity = "info",
-    context = "availability",
+    context  = "availability",
+    meta     = "{{$labels.instance}}",
     {{ if .Values.ops_docu_url -}}
     playbook = "{{.Values.ops_docu_url}}/docs/support/playbook/k8s_node_safe_rebooting.html",
     {{- end }}
@@ -53,10 +56,11 @@ ALERT KubernetesNodeHighNumberOfOpenConnections
   IF node_netstat_Tcp_CurrEstab > 20000
   FOR 15m
   LABELS {
-    tier = "kubernetes",
-    service = "node",
-    severity = "warning",
-    context = "availability",
+    tier      = "kubernetes",
+    service   = "node",
+    severity  = "warning",
+    context   = "availability",
+    meta      = "{{$labels.instance}}",
     dashboard = "kubernetes-node?var-server={{`{{$labels.instance}}`}}",
     {{ if .Values.ops_docu_url -}}
     playbook = "{{.Values.ops_docu_url}}/docs/support/playbook/k8s_high_tcp_connections.html",
@@ -71,10 +75,11 @@ ALERT KubernetesNodeHighRiseOfOpenConnections
   IF predict_linear(node_netstat_Tcp_CurrEstab[20m], 3600) > 32768
   FOR 15m
   LABELS {
-    tier = "kubernetes",
-    service = "node",
-    severity = "critical",
-    context = "availability",
+    tier      = "kubernetes",
+    service   = "node",
+    severity  = "critical",
+    context   = "availability",
+    meta      = "{{$labels.instance}}",
     dashboard = "kubernetes-node?var-server={{`{{$labels.instance}}`}}",
     {{ if .Values.ops_docu_url -}}
     playbook = "{{.Values.ops_docu_url}}/docs/support/playbook/k8s_high_tcp_connections.html",


### PR DESCRIPTION
Allows to specify more detailed information in addtion to the alert name,
which can be evaluated later, e.g. in the Alert Overview Dashboard.

That should make the label_remapping in the grafana health overview dashboard obsolete.
I think I found most of the relabels:
- pod
- kubernetes_io_hostname
- check

I could also not find anything obvious, which needs to be done in the alert manager.