### PR TITLE
Prom collector alerting

### DIFF
--- a/global/prometheus/prometheus.alerts
+++ b/global/prometheus/prometheus.alerts
@@ -14,7 +14,7 @@ ALERT KubernetesPrometheusFrontendDown
   }
 
 ALERT KubernetesPrometheusCollectorDown
-  IF count(up{job="prometheus-regions-federation"}) by (region) unless count(up{job="prometheus-collector"}) by (region)
+  IF count(up{job="prometheus-collector-regions-federation"}) by (region) unless count(up{job="prometheus-collector"}) by (region)
   FOR 15m
   LABELS {
     service = "prometheus",

--- a/global/prometheus/templates/config.yaml
+++ b/global/prometheus/templates/config.yaml
@@ -5,7 +5,9 @@ metadata:
 
 data:
   {{- $files := .Files }}
-  {{ range tuple "prometheus.rules" "prometheus.yaml" "ca.crt" }}
+  {{ range tuple "prometheus.rules" "ca.crt" }}
   {{ . }}: |
 {{ $files.Get . | indent 4 }}
   {{- end }}
+  prometheus.yaml: |
+{{ include "prometheus/templates/_prometheus.yaml.tpl" . | indent 4 }}

--- a/global/prometheus/templates/config.yaml
+++ b/global/prometheus/templates/config.yaml
@@ -5,7 +5,7 @@ metadata:
 
 data:
   {{- $files := .Files }}
-  {{ range tuple "prometheus.rules" "ca.crt" }}
+  {{ range tuple "prometheus.alerts" "ca.crt" }}
   {{ . }}: |
 {{ $files.Get . | indent 4 }}
   {{- end }}

--- a/global/prometheus/values.yaml
+++ b/global/prometheus/values.yaml
@@ -5,3 +5,14 @@ persistence:
   name: data-prometheus-global-0
   access_mode: ReadWriteMany
   size: 300Gi
+regions:
+  - "staging"
+  - "ap-au-1"
+  - "ap-cn-1"
+  - "ap-jp-1"
+  - "eu-de-1"
+  - "eu-nl-1"
+  - "la-br-1"
+  - "na-ca-1"
+  - "na-us-1"
+  - "na-us-3"


### PR DESCRIPTION
Currently the `up`-metric from the collector are federated through the frontend to the global prometheus. The alerting rule is triggered by this metric.
If the frontend is down, but the collector is still up, this will cause an alert, because the federation chain is broken.
Fix: Scrape (only) the up metric from the collector itself and alert on this.
Makes sense @BugRoger?