### PR TITLE
Inauguration round 1

### DIFF
--- a/openstack/arc/templates/api-ingress.yaml
+++ b/openstack/arc/templates/api-ingress.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.api.ingress.enabled }}
+{{- if .Values.api.ingress.tlsCertificate }}
 kind: Secret
 apiVersion: v1
 
@@ -10,12 +11,17 @@ data:
   tls.crt: {{ .Values.api.ingress.tlsCertificate | b64enc }}
   tls.key: {{ .Values.api.ingress.tlsKey | b64enc }}
 ---
+{{- end }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: arc-api
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  {{- if .Values.api.ingress.vice_president }}
+  annotations:
+    vice-president: "true"
+  {{- end }}
 spec:
   {{- if .Values.api.ingress.tlsCertificate }}
   tls:

--- a/openstack/elektra/templates/ingress.yaml
+++ b/openstack/elektra/templates/ingress.yaml
@@ -19,6 +19,11 @@ metadata:
     ingress.kubernetes.io/auth-tls-verify-client: "optional"
     ingress.kubernetes.io/auth-tls-verify-depth: "1"
     {{- end }}
+    {{- if .Values.ingress.vice_president }}
+    annoations:
+      vice-president: "true"
+    {{- end }}
+
 spec:
   tls:
      - secretName: elektra

--- a/openstack/elektra/templates/ingress.yaml
+++ b/openstack/elektra/templates/ingress.yaml
@@ -20,10 +20,8 @@ metadata:
     ingress.kubernetes.io/auth-tls-verify-depth: "1"
     {{- end }}
     {{- if .Values.ingress.vice_president }}
-    annoations:
-      vice-president: "true"
-    {{- end }}
-
+    vice-president: "true"
+    {{- end}}
 spec:
   tls:
      - secretName: elektra

--- a/openstack/elektra/templates/secrets.yaml
+++ b/openstack/elektra/templates/secrets.yaml
@@ -11,7 +11,7 @@ data:
   sentryDSN: {{ .Values.sentryDSN | b64enc }}
 {{- end }}
 {{- end }}{{ end }}
-{{- if .Values.ingress.enabled }}
+{{- if and .Values.ingress.enabled .Values.ingress.tls_crt }}
   tls.crt: {{ .Values.ingress.tls_crt | b64enc }}
   tls.key: {{ .Values.ingress.tls_key | b64enc }}
 {{- end }}

--- a/openstack/hermes/templates/api-ingress.yaml
+++ b/openstack/hermes/templates/api-ingress.yaml
@@ -4,6 +4,10 @@ apiVersion: extensions/v1beta1
 
 metadata:
   name: hermes-api
+  {{- if .Values.hermes.vice_president }}
+  annotations:
+    vice-president: "true"
+  {{- end}}
 
 spec:
   tls:

--- a/openstack/hermes/templates/api-secret.yaml
+++ b/openstack/hermes/templates/api-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.hermes.certs }}
 {{ $config := .Values.hermes.certs }}
 apiVersion: v1
 kind: Secret
@@ -12,3 +13,4 @@ data:
   tls.key: {{ b64enc $config.tls_key }}
 
 ---
+{{- end }}

--- a/openstack/limes/templates/api-ingress.yaml
+++ b/openstack/limes/templates/api-ingress.yaml
@@ -6,6 +6,10 @@ metadata:
   name: limes-api-{{$cluster_id}}
   labels:
     app: limes-api
+  {{- if .Values.limes.vice_president }}
+  annotations:
+    vice-president: "true"
+  {{- end }}
 
 spec:
   tls:

--- a/openstack/limes/templates/api-secret.yaml
+++ b/openstack/limes/templates/api-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.limes.certs }}
 {{ range $cluster_id, $config := .Values.limes.certs }}
 apiVersion: v1
 kind: Secret
@@ -10,6 +11,6 @@ metadata:
 data:
   tls.crt: {{ b64enc $config.tls_crt }}
   tls.key: {{ b64enc $config.tls_key }}
-
 ---
 {{end}}
+{{- end }}

--- a/openstack/lyra/templates/ingress.yaml
+++ b/openstack/lyra/templates/ingress.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ .Release.Name }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  {{- if .Values.ingress.vice_president }}
+  annotations:
+    vice-president: "true"
+  {{- end }}
 spec:
   {{- if .Values.ingress.tlsCertificate }}
   tls:

--- a/openstack/maia/templates/maia-ingress.yaml
+++ b/openstack/maia/templates/maia-ingress.yaml
@@ -5,6 +5,10 @@ kind: Ingress
 metadata:
   name: maia
   namespace: maia
+  {{- if .Values.maia.vice_president }}
+  annotations:
+    vice-president: "true"
+  {{- end}}
 
 spec:
   tls:

--- a/openstack/maia/templates/maia-secrets.yaml
+++ b/openstack/maia/templates/maia-secrets.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.maia.enabled }}
+{{- if .Values.maia.tls_crt }}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -9,4 +10,5 @@ metadata:
 data:
   tls.crt: {{ default "" .Values.maia.tls_crt | b64enc | quote }} 
   tls.key: {{ default "" .Values.maia.tls_key | b64enc | quote }}
+{{- end }}
 {{- end }}

--- a/system/kube-system/charts/vice-president/values.yaml
+++ b/system/kube-system/charts/vice-president/values.yaml
@@ -7,3 +7,4 @@ metrics_port: 9091
 president:
   resync_period_minutes: 4
   certificate_check_interval_minutes: 10
+


### PR DESCRIPTION
Prepare transition to the vice president by annotating the ingress and, if the secret contains only the tls key,cert, by making it optional. 
Adding the annotation and removing the cert/key from the values in cc/secrets will actually switch the service to the vice-president. I will take care if none of the reviewers objects to the below changes.