### PR TITLE
Adding support for CronJobs

### DIFF
--- a/openstack/content-repo/README.md
+++ b/openstack/content-repo/README.md
@@ -12,7 +12,7 @@ See https://github.com/sapcc/swift-http-import
 
 ## Deactivated features
 
-If your kubernetes cluster supports ScheduledJobs you can enable that via specifying a schedule:
+If your kubernetes cluster supports CronJobs you can enable that via specifying a schedule:
 
 ```yaml
 repos:

--- a/openstack/content-repo/templates/job.yaml
+++ b/openstack/content-repo/templates/job.yaml
@@ -1,7 +1,7 @@
 {{- range $repo, $config := .Values.repos }}
-{{- if $config.schedule }}
-apiVersion: batch/v2alpha1
-kind: ScheduledJob
+{{- if and ($.Capabilities.APIVersions.Has "batch/v1beta1") $config.schedule }}
+apiVersion: batch/v1beta1
+kind: CronJob
 metadata:
   name: content-repo-import-{{$repo}}
   namespace: content-repo
@@ -11,6 +11,8 @@ metadata:
 spec:
   schedule: {{$config.schedule}}
   concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
   jobTemplate:
     {{- tuple $repo $.Values | include "job_spec" | indent 4 }}
 


### PR DESCRIPTION
With Kubernetes 1.8 there is the improved version of ScheduledJobs
available. The main advantage is that finished (succesful or failed)
jobs are deleted (successfulJobsHistoryLimit, successfulJobsHistoryLimit)

Only deploy them when the capability is available within the cluster and a schedule is specified