### PR TITLE
Inauguration round 2: barbican

### DIFF
--- a/openstack/barbican/templates/ingress.yaml
+++ b/openstack/barbican/templates/ingress.yaml
@@ -35,6 +35,9 @@ metadata:
     {{- if .Values.services.ingress.limitConnections }}
     ingress.kubernetes.io/limit-connections: {{ .Values.services.ingress.limitConnections | quote }}
     {{- end }}
+    {{- if .Values.services.ingress.vice_president }}
+    vice-president: "true"
+    {{- end}}
 spec:
   tls:
   {{- if .Values.services.api.tlsCertificate }}


### PR DESCRIPTION
let barbican take advantage of the vice president certificate operator. create secret only if cert,key are found in values. set annotation. Can we try this in staging @ruvr ?

Or did I confuse this with https://github.com/sapcc/openstack-helm/tree/master/barbican ?