### PR TITLE
adjust labels on consolidated Limes metrics

### DIFF
--- a/system/kube-monitoring/charts/prometheus-frontend/aggregation.rules
+++ b/system/kube-monitoring/charts/prometheus-frontend/aggregation.rules
@@ -4,6 +4,6 @@ swift_cluster_storage_used_percent_average{} = avg(swift_cluster_prostorage_used
 # consolidated resource consumption metrics for submission to prometheus-global:
 # max() flattens the metrics from different generations of Limes pods into one series,
 # so that any subsequent sum() does not double-count
-limes_consolidated_cluster_capacity{} = max(limes_cluster_capacity) by (service,resource,os_cluster)
-limes_consolidated_domain_quota{} = max(limes_domain_quota) by (service,resource,os_cluster,domain)
-limes_consolidated_domain_usage{} = sum(max(limes_project_usage) by (service,resource,os_cluster,domain,project)) by (service,resource,os_cluster,domain)
+limes_consolidated_cluster_capacity{} = max(label_join(limes_cluster_capacity, "full_resource", "/", "service", "resource")) by (full_resource,os_cluster)
+limes_consolidated_domain_quota{} = max(label_join(limes_domain_quota, "full_resource", "/", "service", "resource")) by (full_resource,os_cluster,domain)
+limes_consolidated_domain_usage{} = sum(max(label_join(limes_project_usage, "full_resource", "/", "service", "resource")) by (full_resource,os_cluster,domain,project)) by (full_resource,os_cluster,domain)


### PR DESCRIPTION
@auhlig Can you please merge this when all the frontend Promethei have been updated to 1.8.0? This only works on the newer version because of the usage of the `label_join()` function.