### PR TITLE
Revert "Adding openstack_compute_instances metric to prometheus-global"

### DIFF
--- a/global/prometheus/templates/_prometheus.yaml.tpl
+++ b/global/prometheus/templates/_prometheus.yaml.tpl
@@ -27,7 +27,6 @@ scrape_configs:
       - '{__name__=~"^swift_cluster_storage_used_percent_.+"}'
       - '{__name__=~"^pg_database_size_bytes_gauge_average$"}'
       - '{__name__=~"^limes_consolidated_.+"}'
-      - '{__name__=~"^openstack_compute_instances_gauge$"}'
 
   relabel_configs:
     - action: replace

--- a/system/kube-monitoring/charts/prometheus-frontend/aggregation.rules
+++ b/system/kube-monitoring/charts/prometheus-frontend/aggregation.rules
@@ -7,4 +7,3 @@ swift_cluster_storage_used_percent_average{} = avg(swift_cluster_prostorage_used
 limes_consolidated_cluster_capacity{} = max(label_join(limes_cluster_capacity, "full_resource", "/", "service", "resource")) by (full_resource,os_cluster)
 limes_consolidated_domain_quota{} = max(label_join(limes_domain_quota, "full_resource", "/", "service", "resource")) by (full_resource,os_cluster,domain)
 limes_consolidated_domain_usage{} = sum(max(label_join(limes_project_usage, "full_resource", "/", "service", "resource")) by (full_resource,os_cluster,domain,project)) by (full_resource,os_cluster,domain)
-openstack_compute_instances{} = sum(openstack_compute_instances_gauge) by (region,vm_state,host,flavor_name)


### PR DESCRIPTION
Reverts sapcc/helm-charts#213

This federates unaggregated timeseries. Please fix.