### PR TITLE
Do not propagate log messages

### DIFF
--- a/openstack/utils/templates/_helpers.tpl
+++ b/openstack/utils/templates/_helpers.tpl
@@ -11,6 +11,7 @@ keys={{ include "joinKey" $value | trimAll "," }}
 [{{ $top_level_key | trimSuffix "s" }}_{{ $item | replace "." "_" }}]
 {{- if and (eq $top_level_key "loggers") (ne $item "root")}}
 qualname={{ $item }}
+propagate=0
 {{- end}}
 {{- range $key, $value := $values }}
 {{ $key }}={{ $value }}


### PR DESCRIPTION
By default, log messages are propagated from a child to parent logger, so the root-logger logs everything a second time.