### PR TITLE
Adding openstack_neutron_monitor_sec_grp metric

### DIFF
--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -210,6 +210,15 @@ pgmetrics:
         - gauge:
             usage: "GAUGE"
             description: "Internet IPs used per subnet"
+    openstack_neutron_monitor_sec_grp:
+     query: "select securitygroupportbindings.security_group_id AS security_group_id, count(*) as count from securitygroupportbindings join securitygrouprules on securitygroupportbindings.security_group_id = securitygrouprules.security_group_id group by securitygroupportbindings.security_group_id order by count desc limit 10"
+     metrics:
+        - security_group_id:
+            usage: "LABEL"
+            description: "security group id details"
+        - count:
+            usage: "GAUGE"
+            description: "Estimate on number of filter rules"            
 
 postgresql:
   postgresDatabase: neutron


### PR DESCRIPTION
Hi @fwiesel 

As Neutron chart is independent of openstack-helm now, raising another PR.