### PR TITLE
remove Swift dependency from Elektra seed

### DIFF
--- a/openstack/elektra/templates/seed.yaml
+++ b/openstack/elektra/templates/seed.yaml
@@ -9,7 +9,6 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   requires:
-  - swift/swift-seed
   - monsoon3/domain-default-seed
   - monsoon3/domain-bn-seed
   - monsoon3/domain-bs-seed
@@ -31,8 +30,6 @@ spec:
       roles:
       - project: service
         role: service
-      - project: service
-        role: swiftreseller
       - project: cloud_admin@ccadmin
         role: admin
       - project: cloud_admin@ccadmin
@@ -51,8 +48,6 @@ spec:
         role: cloud_sharedfilesystem_admin
       - project: cloud_admin@ccadmin
         role: cloud_volume_admin
-      - project: cloud_admin@ccadmin
-        role: swiftreseller
       - domain: Default
         role: admin
       - domain: ccadmin
@@ -74,4 +69,4 @@ spec:
       - domain: cc3test
         role: admin
       - domain: cc3test2
-        role: admin        
+        role: admin


### PR DESCRIPTION
As far as I know, this was only used by the legacy resource management implementation and to create Swift accounts. Since Limes now handles both, I don't think anything else in Elektra needs to be a swiftreseller anymore.

@edda Are the above assumptions correct?

@abattye FYI (since your inquiry triggered the line of thought leading to this PR)