### PR TITLE
Swiftoperator role for ironic

### DIFF
--- a/openstack/swift/templates/seeds.yaml
+++ b/openstack/swift/templates/seeds.yaml
@@ -126,6 +126,8 @@ spec:
         role: swiftoperator
       - user: quay@Default
         role: swiftoperator
+      - user: ironic@Default
+        role: swiftoperator
       swift:
         enabled: true
         containers:


### PR DESCRIPTION
The ironic user needs swiftoperator role in all the projects the baremetal images are loaded from.