### PR TITLE
add designate vp annotation

### DIFF
--- a/openstack/designate/templates/api-ingress.yaml
+++ b/openstack/designate/templates/api-ingress.yaml
@@ -7,6 +7,10 @@ metadata:
     system: openstack
     type: api
     component: designate
+  {{- if .Values.vice_president }}
+  annotations:
+    vice-president: "true"
+  {{- end}}
 spec:
   tls:
     - secretName: tls-{{include "designate_api_endpoint_host_public" . | replace "." "-"}}


### PR DESCRIPTION
vice president won't pickup designate ingress until it's annotated. did designate move out of openstack-helm already in all regions? @dhoeller /cc @Carthaca 