### PR TITLE
fix rabbit storage leak+dataloss

### DIFF
--- a/common/rabbitmq/templates/bin/_rabbitmq-start.tpl
+++ b/common/rabbitmq/templates/bin/_rabbitmq-start.tpl
@@ -30,7 +30,11 @@ function bootstrap {
 
 
 function start_application {
-   exec rabbitmq-server
+  echo "Starting RabbitMQ with lock /var/lib/rabbitmq/rabbitmq-server.lock"
+  LOCKFILE=/var/lib/rabbitmq/rabbitmq-server.lock
+  exec 9>${LOCKFILE}
+  /usr/bin/flock -n 9
+  exec gosu rabbitmq rabbitmq-server
 }
 
 bootstrap

--- a/common/rabbitmq/templates/deployment.yaml
+++ b/common/rabbitmq/templates/deployment.yaml
@@ -14,11 +14,16 @@ spec:
   replicas: {{ .Values.replicas }}
   revisionHistoryLimit: {{ .Values.upgrades.revisionHistory }}
   strategy:
+    {{- if .Values.persistence.enabled }}
+    # rolling update is not possible since RabbitMQ does not support shared data files
+    type: Recreate
+    {{- else }}
     type: {{ .Values.upgrades.podReplacementStrategy }}
     {{ if eq .Values.upgrades.podReplacementStrategy "RollingUpdate" }}
     rollingUpdate:
       maxUnavailable: {{ .Values.upgrades.rollingUpdate.maxUnavailable }}
       maxSurge: {{ .Values.upgrades.rollingUpdate.maxSurge }}
+    {{ end }}
     {{ end }}
   selector:
     matchLabels:
@@ -28,6 +33,7 @@ spec:
       labels:
         app: {{ template "fullname" . }}
     spec:
+      hostname: {{ template "fullname" . }}
       containers:
       - name: rabbitmq
         image: "{{ .Values.image }}:{{.Values.imageTag }}"

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -242,4 +242,5 @@ audit:
   mem_queue_size: 1000
 
 rabbitmq_notifications:
-  name: neutron
+  persistence:
+    enabled: true


### PR DESCRIPTION
RabbitMQ stores its data files in a directory named like the hostname.

Since in Kubernetes the hostname is set to the pod-name by default, every re-deployment will make RabbitMQ loose data and leave behind an orphaned data directory on disk.

Setting the hostname to a fixed value solves the problem. Rolling-Updates are of course not possible then.

Fix is already implemented for `rabbitmq_notifications` chart. We should apply it to `openstack-helm/rabbitmq` as well and possibly merge it with `rabbitmq_notifications` on that occasion.  
  