### PR TITLE
Prometheus v2.1.0, AM v0.13.0

### DIFF
--- a/global/prometheus-alertmanager/values.yaml
+++ b/global/prometheus-alertmanager/values.yaml
@@ -1,1 +1,1 @@
-image: prom/alertmanager:v0.11.0
+image: prom/alertmanager:v0.13.0

--- a/system/kube-monitoring/charts/prometheus-collector/values.yaml
+++ b/system/kube-monitoring/charts/prometheus-collector/values.yaml
@@ -1,5 +1,5 @@
 prometheus:
   image: prom/prometheus
-  tag: v2.0.0
+  tag: v2.1.0
 
 retention: 1h

--- a/system/kube-monitoring/charts/prometheus-frontend/cluster.rules
+++ b/system/kube-monitoring/charts/prometheus-frontend/cluster.rules
@@ -44,7 +44,7 @@ groups:
     expr: 100 * sum(container_memory_usage_bytes{pod_name!=""}) / sum(machine_memory_bytes)
 
   - record: cluster:cpu_allocation:percent
-    expr: 100 * sum(container_spec_cpu_shares{pod_name!=""}) / sum(container_spec_cpu_shares{id="/"} * ON(instance) machine_cpu_cores)
+    expr: 100 * sum(container_spec_cpu_shares{pod_name!=""}) / sum(container_spec_cpu_shares{id="/"} * ON(instance) group_left machine_cpu_cores)
 
   - record: cluster_resource_verb:apiserver_latency:quantile_seconds
     expr: histogram_quantile(0.99, sum(apiserver_request_latencies_bucket) BY (le, job, resource, verb)) / 1e+06

--- a/system/kube-monitoring/charts/prometheus-frontend/values.yaml
+++ b/system/kube-monitoring/charts/prometheus-frontend/values.yaml
@@ -1,6 +1,6 @@
 prometheus:
   image: prom/prometheus
-  tag: v2.0.0
+  tag: v2.1.0
 
 retention: 7d
 
@@ -8,3 +8,11 @@ persistence:
   name: prometheus-frontend-data
   accessMode: ReadWriteMany
   size: 300Gi
+
+alerting:
+  # disable all alerts by setting `false` here
+  enabled: true
+  # disable kubernetes alerts by setting `false` here
+  kubernetes: true
+  # disable openstack alerts by setting `false` here
+  openstack: true

--- a/system/kube-monitoring/values.yaml
+++ b/system/kube-monitoring/values.yaml
@@ -3,5 +3,5 @@ global:
   domain: DEFINED-AS-VALUE
 
   prometheus:
-    image: sapcc/prometheus
-    tag: v2.0.0-65-ge4df16e
+    image: prom/prometheus
+    tag: v2.1.0


### PR DESCRIPTION
prom v2.1.0 contains the fix for the nfs retention issue, so let's move back to the official img. also upgrade alertmanager. will test in staging on monday before rolling out further