### PR TITLE
[rabbitmq] Protect boostrap too with lock

### DIFF
--- a/common/rabbitmq/templates/bin/_rabbitmq-start.tpl
+++ b/common/rabbitmq/templates/bin/_rabbitmq-start.tpl
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
+LOCKFILE=/var/lib/rabbitmq/rabbitmq-server.lock
+echo "Starting RabbitMQ with lock ${LOCKFILE}"
+exec 9>${LOCKFILE}
+/usr/bin/flock -n 9
+
 function bootstrap {
    #Not especially proud of this, but it works (unlike the environment variable approach in the docs)
    chown -R rabbitmq:rabbitmq /var/lib/rabbitmq
@@ -30,10 +35,6 @@ function bootstrap {
 
 
 function start_application {
-  echo "Starting RabbitMQ with lock /var/lib/rabbitmq/rabbitmq-server.lock"
-  LOCKFILE=/var/lib/rabbitmq/rabbitmq-server.lock
-  exec 9>${LOCKFILE}
-  /usr/bin/flock -n 9
   exec gosu rabbitmq rabbitmq-server
 }
 


### PR DESCRIPTION
The bootstrap also starts a rabbitmq-server, which will concurrently write on the same files as a possibly still running rabbitmq.