### PR TITLE
Enables SSL Client Certificate Authentication for Grafana

### DIFF
--- a/openstack/grafana/templates/_grafana.ini.tpl
+++ b/openstack/grafana/templates/_grafana.ini.tpl
@@ -150,7 +150,7 @@ verify_email_enabled = false
 # Background text for the user field on the login page
 login_hint = UserID[@domain]
 
-{{- if .Values.grafana.tls_client_auth.enabled}}
+{{- if .Values.grafana.auth.tls_client_auth.enabled}}
 [auth.proxy]
 enabled = true
 header_name = X-REMOTE-USER
@@ -158,10 +158,7 @@ header_property = username
 auto_sign_up = false
 
 [auth.basic]
-enabled = false 
-{{- else }}
-[auth.basic]
-enabled = true 
+enabled = {{ default true .Values.grafana.auth.basic_auth.enabled }}
 {{- end }}
 
 

--- a/openstack/grafana/templates/_grafana.ini.tpl
+++ b/openstack/grafana/templates/_grafana.ini.tpl
@@ -150,8 +150,20 @@ verify_email_enabled = false
 # Background text for the user field on the login page
 login_hint = UserID[@domain]
 
-[auth.basic]
+{{- if .Values.grafana.tls_client_auth.enabled}}
+[auth.proxy]
 enabled = true
+header_name = X-REMOTE-USER
+header_property = username
+auto_sign_up = false
+
+[auth.basic]
+enabled = false 
+{{- else }}
+[auth.basic]
+enabled = true 
+{{- end }}
+
 
 #################################### Auth LDAP ##########################
 [auth.ldap]

--- a/openstack/grafana/templates/grafana-ingress.yaml
+++ b/openstack/grafana/templates/grafana-ingress.yaml
@@ -4,10 +4,15 @@ kind: Ingress
 
 metadata:
   name: grafana
-  {{- if .Values.grafana.vice_president }}
   annotations:
+  {{- if .Values.grafana.vice_president }}
     vice-president: "true"
   {{- end}}
+  {{- if .Values.grafana.tls_client_auth.enabled}}
+    nginx.ingress.kubernetes.io/auth-tls-secret: "{{.Release.Namespace}}/ca-{{.Values.grafana.endpoint.host.public | replace "." "-"}}"
+    nginx.ingress.kubernetes.io/auth-tls-verify-depth: "3"
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: "on"
+  {{ end }}
 
 spec:
   tls:

--- a/openstack/grafana/templates/grafana-ingress.yaml
+++ b/openstack/grafana/templates/grafana-ingress.yaml
@@ -9,9 +9,9 @@ metadata:
     vice-president: "true"
   {{- end}}
   {{- if .Values.grafana.tls_client_auth.enabled}}
-    nginx.ingress.kubernetes.io/auth-tls-secret: "{{.Release.Namespace}}/ca-{{.Values.grafana.endpoint.host.public | replace "." "-"}}"
-    nginx.ingress.kubernetes.io/auth-tls-verify-depth: "3"
-    nginx.ingress.kubernetes.io/auth-tls-verify-client: "on"
+    ingress.kubernetes.io/auth-tls-secret: "kube-system/ingress-cacrt"
+    ingress.kubernetes.io/auth-tls-verify-depth: "3"
+    ingress.kubernetes.io/auth-tls-verify-client: "on"
   {{ end }}
 
 spec:

--- a/openstack/grafana/templates/grafana-ingress.yaml
+++ b/openstack/grafana/templates/grafana-ingress.yaml
@@ -5,13 +5,11 @@ kind: Ingress
 metadata:
   name: grafana
   annotations:
-  {{- if .Values.grafana.vice_president }}
-    vice-president: "true"
-  {{- end}}
-  {{- if .Values.grafana.tls_client_auth.enabled}}
-    ingress.kubernetes.io/auth-tls-secret: "kube-system/ingress-cacrt"
+    vice-president: {{ default false .Values.grafana.vice_president | quote }}
+  {{- if .Values.grafana.auth.tls_client_auth.enabled}}
+    ingress.kubernetes.io/auth-tls-secret: {{ default "" .Values.grafana.auth.tls_client_auth.secret }}
     ingress.kubernetes.io/auth-tls-verify-depth: "3"
-    ingress.kubernetes.io/auth-tls-verify-client: "on"
+    ingress.kubernetes.io/auth-tls-verify-client: "optional"
   {{ end }}
 
 spec:

--- a/openstack/grafana/values.yaml
+++ b/openstack/grafana/values.yaml
@@ -44,8 +44,10 @@ persistence:
   name: storage-grafana-postgres-0
   accessMode: ReadWriteMany
   size: 10Gi
+
 ingress:
   enabled: false
+
 service:
   externalPort: 3000
 
@@ -65,8 +67,6 @@ grafana:
   image_version: 4.6.3
   seeding_enabled: true
   log_level: 'Info'
-  tls_client_auth:
-    enabled: false
   admin:
     user: 'grafana_admin'
     password: '@/cc/secrets'
@@ -89,5 +89,9 @@ grafana:
       public: '3000'
     host:
       public: '@/cc/secrets'
-# tls_client_auth:
-#   enabled: true
+  auth:
+    basic_auth:
+      enabled: true
+    tls_client_auth:
+      enabled: false
+      secret: "kube-system/ingress-cacrt"

--- a/openstack/grafana/values.yaml
+++ b/openstack/grafana/values.yaml
@@ -87,3 +87,5 @@ grafana:
       public: '3000'
     host:
       public: '@/cc/secrets'
+# tls_client_auth:
+#   enabled: true

--- a/openstack/grafana/values.yaml
+++ b/openstack/grafana/values.yaml
@@ -65,6 +65,8 @@ grafana:
   image_version: 4.6.3
   seeding_enabled: true
   log_level: 'Info'
+  tls_client_auth:
+    enabled: false
   admin:
     user: 'grafana_admin'
     password: '@/cc/secrets'

--- a/system/kube-system/charts/ingress/templates/ingress-cacrt-secret.yaml
+++ b/system/kube-system/charts/ingress/templates/ingress-cacrt-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.grafana.tls_client_auth.enabled }}
+{{- if .Values.tls_client_auth.enabled }}
 apiVersion: v1
 kind: Secret
 type: Opaque

--- a/system/kube-system/charts/ingress/templates/ingress-cacrt-secret.yaml
+++ b/system/kube-system/charts/ingress/templates/ingress-cacrt-secret.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.grafana.tls_client_auth.enabled }}
+apiVersion: v1
+kind: Secret
+type: Opaque
+
+metadata:
+  name: ingress-cacrt
+
+data:
+  ca.crt: {{ default "" .Values.tls_client_auth.cacrt | b64enc | quote }} 
+{{- end }}

--- a/system/kube-system/charts/ingress/values.yaml
+++ b/system/kube-system/charts/ingress/values.yaml
@@ -12,6 +12,13 @@ controller:
     disable-ipv6: 'true'
     ssl-redirect: 'false'
     enable-vts-status: 'true'
+    http-snippet: |
+      map $ssl_client_s_dn $ssl_client_s_dn_cn {
+          default "anonymous";
+          ~CN=(?<CN>[^/,\"]+) $CN;
+      }
+    location-snippet: |
+      proxy_set_header X-REMOTE-USER $ssl_client_s_dn_cn;
   # nodeSelector for the controller DaemonSet
   nodeSelector:
     species: master
@@ -23,3 +30,11 @@ defaultBackend:
 external_service_ip: DEFINED-IN-REGION
 public_service: False
 external_public_service_ip: DEFINED-IN-REGION
+tls_client_auth:
+  enabled: true
+  #cacrt: |
+  #  -----BEGIN CERTIFICATE-----
+  #  MIIB+jCCAWOgAwIBAgIEAQAAADANBgkqhkiG9w0BAQUFADAvMQswCQYDVQQGEwJE
+  #  ...
+  #  vrEcgtBVIuzM+sVEp7RRM6Y+fL9u+69krtndZ8Ft
+  #  -----END CERTIFICATE-----


### PR DESCRIPTION
This PR enables authentication to Grafana via SSL client certificates. It subs out
the basic auth with proxy auth. Grafana now expects the user to be
passed in via the `X-Remote-User` header. This can be toggled with the
`tls_client_auth.enabled` flag in the Helm values. It defaults to off
and keeps things as they are.

The ingress is configured to verify SSL certificates using the
`nginx.ingress.kubernetes.io/auth-tls-*` annotations. This can be turned
on/off per ingress spec.

Additionally, this PR injects a bit of logic into the ingress config, to
copy the relevant part (the user-id) into the `X-Remote-User` header.