### PR TITLE
fix sso with new ing ctrl

### DIFF
--- a/openstack/elektra/templates/ingress.yaml
+++ b/openstack/elektra/templates/ingress.yaml
@@ -15,7 +15,7 @@ metadata:
   name: elektra
   annotations:
     {{- if .Values.ingress.ca }}
-    ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: {{ default false .Values.ingress.pass_certificate_to_upstream | quote }}
+    ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: {{ default true .Values.ingress.pass_certificate_to_upstream | quote }}
     ingress.kubernetes.io/auth-tls-secret: {{ .Release.Namespace }}/elektra-x509-ca
     ingress.kubernetes.io/auth-tls-verify-client: "optional"
     ingress.kubernetes.io/auth-tls-verify-depth: "1"

--- a/openstack/elektra/templates/ingress.yaml
+++ b/openstack/elektra/templates/ingress.yaml
@@ -15,6 +15,7 @@ metadata:
   name: elektra
   annotations:
     {{- if .Values.ingress.ca }}
+    ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: {{ default false .Values.ingress.pass_certificate_to_upstream | quote }}
     ingress.kubernetes.io/auth-tls-secret: {{ .Release.Namespace }}/elektra-x509-ca
     ingress.kubernetes.io/auth-tls-verify-client: "optional"
     ingress.kubernetes.io/auth-tls-verify-depth: "1"

--- a/openstack/elektra/values.yaml
+++ b/openstack/elektra/values.yaml
@@ -38,4 +38,5 @@ ingress:
 #  host: dashboard.staging.cloud.sap
 #  tls_crt:
 #  tls_key:
+#  pass_certificate_to_upstream:
 #  ca: <your sso ca>


### PR DESCRIPTION
obviously we have to turn on `ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream` using the new ingress controller to enable sso again. off by default. enable only via regional values. i'll take care.
objections @edda?
/cc @ruvr 