### PR TITLE
[swift] changed image_version handling

### DIFF
--- a/openstack/swift/templates/_utils.tpl
+++ b/openstack/swift/templates/_utils.tpl
@@ -121,9 +121,9 @@ When passed via `helm upgrade --set`, the image_version is misinterpreted as a f
   {{- end -}}
 {{- end }}
 
-{{- define "swift_release_first_char" -}}
-{{- if ne .Values.image_version "DEFINED_BY_PIPELINE" -}}
-    {{ $v := .image_version | split "-"}}{{ $v._0 | trunc 1 | upper }}
+{{- define "swift_release" -}}
+{{- if ne .image_version "DEFINED_BY_PIPELINE" -}}
+    {{ $v := .image_version | split "-"}}{{ $v._0 | lower }}
   {{- end -}}
 {{- end }}
 

--- a/openstack/swift/templates/_utils.tpl
+++ b/openstack/swift/templates/_utils.tpl
@@ -114,7 +114,7 @@ checksum/object.ring: {{ include "swift/templates/object-ring.yaml" . | sha256su
 {{- /**********************************************************************************/ -}}
 When passed via `helm upgrade --set`, the image_version is misinterpreted as a float64. So special care is needed to render it correctly.
 {{- define "swift_image" -}}
-  {{- if and (typeIs "string" .Values.image_version) (ne .Values.image_version "DEFINED_BY_PIPELINE") -}}
+  {{- if ne .Values.image_version "DEFINED_BY_PIPELINE" -}}
     {{ .Values.global.imageRegistry }}/{{ .Values.imageRegistry_org }}/{{ .Values.imageRegistry_repo }}:{{ .Values.image_version }}
   {{- else -}}
     {{ required "This release should be installed by the deployment pipeline!" "" }}
@@ -122,7 +122,7 @@ When passed via `helm upgrade --set`, the image_version is misinterpreted as a f
 {{- end }}
 
 {{- define "swift_release_first_char" -}}
-  {{- if and (typeIs "string" .image_version) (ne .image_version "DEFINED_BY_PIPELINE") -}}
+{{- if ne .Values.image_version "DEFINED_BY_PIPELINE" -}}
     {{ $v := .image_version | split "-"}}{{ $v._0 | trunc 1 | upper }}
   {{- end -}}
 {{- end }}

--- a/openstack/swift/templates/_utils.tpl
+++ b/openstack/swift/templates/_utils.tpl
@@ -114,14 +114,16 @@ checksum/object.ring: {{ include "swift/templates/object-ring.yaml" . | sha256su
 {{- /**********************************************************************************/ -}}
 When passed via `helm upgrade --set`, the image_version is misinterpreted as a float64. So special care is needed to render it correctly.
 {{- define "swift_image" -}}
-  {{- if typeIs "string" .Values.image_version -}}
-    {{ required "This release should be installed by the deployment pipeline!" "" }}
+  {{- if and (typeIs "string" .Values.image_version) (ne .Values.image_version "DEFINED_BY_PIPELINE") -}}
+    {{ .Values.global.imageRegistry }}/{{ .Values.imageRegistry_org }}/{{ .Values.imageRegistry_repo }}:{{ .Values.image_version }}
   {{- else -}}
-    {{- if typeIs "float64" .Values.image_version -}}
-      {{.Values.global.imageRegistry}}/monsoon/swift-{{.Values.release}}:{{.Values.image_version | printf "%0.f"}}
-    {{- else -}}
-      {{.Values.global.imageRegistry}}/monsoon/swift-{{.Values.release}}:{{.Values.image_version}}
-    {{- end -}}
+    {{ required "This release should be installed by the deployment pipeline!" "" }}
+  {{- end -}}
+{{- end }}
+
+{{- define "swift_release_first_char" -}}
+  {{- if and (typeIs "string" .image_version) (ne .image_version "DEFINED_BY_PIPELINE") -}}
+    {{ $v := .image_version | split "-"}}{{ $v._0 | trunc 1 | upper }}
   {{- end -}}
 {{- end }}
 

--- a/openstack/swift/templates/etc/_proxy-server.conf.tpl
+++ b/openstack/swift/templates/etc/_proxy-server.conf.tpl
@@ -2,7 +2,7 @@
 {{- $cluster := index . 0 -}}
 {{- $context := index . 1 -}}
 {{- $helm_release := index . 2 -}}
-{{- $swift_release := include "swift_release_first_char" $context -}}
+{{- $swift_release := include "swift_release" $context -}}
 [DEFAULT]
 bind_port = 8080
 # NOTE: value for prod, was 4 in staging before
@@ -24,13 +24,13 @@ log_level = INFO
 {{- end }}
 
 [pipeline:main]
-{{- if le $swift_release "M" }}
+{{- if le $swift_release "mitaka" }}
 # Mitaka pipeline
 pipeline = catch_errors gatekeeper healthcheck proxy-logging cache cname_lookup domain_remap bulk tempurl ratelimit authtoken keystone sysmeta-domain-override staticweb container-quotas account-quotas slo dlo versioned_writes proxy-logging proxy-server
-{{- else if eq $swift_release "P" }}
+{{- else if eq $swift_release "pike" }}
 # Pike pipeline
 pipeline = catch_errors gatekeeper healthcheck proxy-logging cache cname_lookup domain_remap bulk tempurl ratelimit authtoken keystone sysmeta-domain-override staticweb copy container-quotas account-quotas slo dlo versioned_writes proxy-logging proxy-server
-{{- else if ge $swift_release "Q" }}
+{{- else if ge $swift_release "queens" }}
 # Queens or > pipeline
 pipeline = catch_errors gatekeeper healthcheck proxy-logging cache cname_lookup domain_remap bulk tempurl ratelimit authtoken keystone sysmeta-domain-override staticweb copy container-quotas account-quotas slo dlo versioned_writes symlink proxy-logging proxy-server
 {{- end }}
@@ -166,13 +166,13 @@ use = egg:swift#container_quotas
 [filter:account-quotas]
 use = egg:swift#account_quotas
 
-{{- if ge $swift_release "P" }}
+{{- if ge $swift_release "pike" }}
 
 [filter:copy]
 use = egg:swift#copy
 {{- end}}
 
-{{- if ge $swift_release "Q" }}
+{{- if ge $swift_release "queens" }}
 
 [filter:symlink]
 use = egg:swift#symlink

--- a/openstack/swift/values.yaml
+++ b/openstack/swift/values.yaml
@@ -11,7 +11,7 @@ imageRegistry_org: monsoon
 imageRegistry_repo: swift
 
 # image version of Swift image
-# the version should follow the format oprenstackreleasename-versionnumber
+# the version should follow the format openstackreleasename-versionnumber
 # e.g. mitaka-12345
 image_version: DEFINED_BY_PIPELINE
 

--- a/openstack/swift/values.yaml
+++ b/openstack/swift/values.yaml
@@ -5,11 +5,14 @@ global:
 
 debug: false
 
-# Supported releases are: mitaka, pike
-release: mitaka
 species: swift-storage
 
+imageRegistry_org: monsoon
+imageRegistry_repo: swift
+
 # image version of Swift image
+# the version should follow the format oprenstackreleasename-versionnumber
+# e.g. mitaka-12345
 image_version: DEFINED_BY_PIPELINE
 
 # image version of auxiliary nginx bundled with dumb-init


### PR DESCRIPTION
The image_version value is now be expected following that format:
`<openstack_release_name>-<image_version>`
Based on the OpenStack release name the intended pipeline and needed
filters are defined in `templates/etc/_proxy-server.conf.tpl`