### PR TITLE
Skip tcp probe if targets are not set

### DIFF
--- a/system/kube-monitoring/charts/prometheus-collector/templates/_prometheus.yaml.tpl
+++ b/system/kube-monitoring/charts/prometheus-collector/templates/_prometheus.yaml.tpl
@@ -312,6 +312,8 @@ scrape_configs:
     replacement: {{ $region }}
 {{ end }}
 
+{{ if .Values.blackbox_exporter }}
+{{ if .Values.blackbox_exporter.tcp_probe_targets }}
 {{ range $region := .Values.global.regions }}
 - job_name: 'blackbox-tcp-{{ $region }}'
   metrics_path: /probe
@@ -333,6 +335,8 @@ scrape_configs:
     replacement: prober.{{ $region }}.cloud.sap
   - target_label: region_probed_from
     replacement: {{ $region }}
+{{ end }}
+{{ end }}
 {{ end }}
 
 # Static Targets 


### PR DESCRIPTION
The two phased check is necessary because the evaluation fails if `blackbox_exporter` does not exist.
Solves this https://github.com/sapcc/helm-charts/pull/269#discussion_r176355664