### PR TITLE
add module label to probe metrics

### DIFF
--- a/system/kube-monitoring/charts/prometheus-collector/templates/_prometheus.yaml.tpl
+++ b/system/kube-monitoring/charts/prometheus-collector/templates/_prometheus.yaml.tpl
@@ -308,6 +308,8 @@ scrape_configs:
     target_label: kubernetes_namespace
   - source_labels: [__meta_kubernetes_ingress_name]
     target_label: ingress_name
+  - source_labels: [__param_module]
+    target_label: module
   - target_label: region_probed_from
     replacement: {{ $region }}
 {{ end }}
@@ -333,6 +335,8 @@ scrape_configs:
     target_label: instance
   - target_label: __address__
     replacement: prober.{{ $region }}.cloud.sap
+  - source_labels: [__param_module]
+    target_label: module
   - target_label: region_probed_from
     replacement: {{ $region }}
 {{ end }}


### PR DESCRIPTION
This is to quickly filter through the probes without using the
jobname as the source of truth for the kind of query that happened.
Because it might be outdated and not reflecting the actual module used,
limits potential names for probe jobs and it uncomfortable query by regex.