### PR TITLE
[swift, elk, kube-mon.] use native k8s rolling update for daemonsets

### DIFF
--- a/openstack/elk/templates/fluent-daemonset.yaml
+++ b/openstack/elk/templates/fluent-daemonset.yaml
@@ -7,6 +7,10 @@ metadata:
   annotations:
     kubernetes.io/change-cause: {{.Values.cluster_deployment_reason}}
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      minReadySeconds: 15
   template:
     metadata:
       labels:

--- a/openstack/elk/templates/fluent-daemonset.yaml
+++ b/openstack/elk/templates/fluent-daemonset.yaml
@@ -7,10 +7,9 @@ metadata:
   annotations:
     kubernetes.io/change-cause: {{.Values.cluster_deployment_reason}}
 spec:
+  minReadySeconds: 15
   updateStrategy:
     type: RollingUpdate
-    rollingUpdate:
-      minReadySeconds: 15
   template:
     metadata:
       labels:

--- a/openstack/elk/templates/fluent-systemd-daemonset.yaml
+++ b/openstack/elk/templates/fluent-systemd-daemonset.yaml
@@ -8,10 +8,9 @@ metadata:
   annotations:
     kubernetes.io/change-cause: {{.Values.cluster_deployment_reason}}
 spec:
+  minReadySeconds: 15
   updateStrategy:
     type: RollingUpdate
-    rollingUpdate:
-      minReadySeconds: 15
   template:
     metadata:
       labels:

--- a/openstack/elk/templates/fluent-systemd-daemonset.yaml
+++ b/openstack/elk/templates/fluent-systemd-daemonset.yaml
@@ -8,6 +8,10 @@ metadata:
   annotations:
     kubernetes.io/change-cause: {{.Values.cluster_deployment_reason}}
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      minReadySeconds: 15
   template:
     metadata:
       labels:

--- a/openstack/swift/templates/replicators-daemonset.yaml
+++ b/openstack/swift/templates/replicators-daemonset.yaml
@@ -8,6 +8,11 @@ metadata:
     on-upgrade: recreate
 
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      minReadySeconds: 15
   template:
     metadata:
       labels:

--- a/openstack/swift/templates/replicators-daemonset.yaml
+++ b/openstack/swift/templates/replicators-daemonset.yaml
@@ -8,11 +8,9 @@ metadata:
     on-upgrade: recreate
 
 spec:
+  minReadySeconds: 15
   updateStrategy:
     type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 1
-      minReadySeconds: 15
   template:
     metadata:
       labels:

--- a/openstack/swift/templates/rsyncd-daemonset.yaml
+++ b/openstack/swift/templates/rsyncd-daemonset.yaml
@@ -8,6 +8,11 @@ metadata:
     on-upgrade: recreate
 
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      minReadySeconds: 15
   template:
     metadata:
       labels:

--- a/openstack/swift/templates/rsyncd-daemonset.yaml
+++ b/openstack/swift/templates/rsyncd-daemonset.yaml
@@ -8,11 +8,9 @@ metadata:
     on-upgrade: recreate
 
 spec:
+  minReadySeconds: 15
   updateStrategy:
     type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 1
-      minReadySeconds: 15
   template:
     metadata:
       labels:

--- a/openstack/swift/templates/servers-daemonset.yaml
+++ b/openstack/swift/templates/servers-daemonset.yaml
@@ -8,11 +8,9 @@ metadata:
     on-upgrade: rolling-recreate
 
 spec:
+  minReadySeconds: 60 # longer wait here to be extra sure that the new servers are operational
   updateStrategy:
     type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 1
-      minReadySeconds: 60 # longer wait here to be extra sure that the new servers are operational
   template:
     metadata:
       labels:

--- a/openstack/swift/templates/servers-daemonset.yaml
+++ b/openstack/swift/templates/servers-daemonset.yaml
@@ -8,6 +8,11 @@ metadata:
     on-upgrade: rolling-recreate
 
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      minReadySeconds: 60 # longer wait here to be extra sure that the new servers are operational
   template:
     metadata:
       labels:

--- a/openstack/swift/templates/statsd-exporter-daemonset.yaml
+++ b/openstack/swift/templates/statsd-exporter-daemonset.yaml
@@ -8,6 +8,11 @@ metadata:
     on-upgrade: recreate
 
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      minReadySeconds: 15
   template:
     metadata:
       labels:

--- a/openstack/swift/templates/statsd-exporter-daemonset.yaml
+++ b/openstack/swift/templates/statsd-exporter-daemonset.yaml
@@ -8,11 +8,9 @@ metadata:
     on-upgrade: recreate
 
 spec:
+  minReadySeconds: 15
   updateStrategy:
     type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 1
-      minReadySeconds: 15
   template:
     metadata:
       labels:

--- a/openstack/swift/templates/workers-daemonset.yaml
+++ b/openstack/swift/templates/workers-daemonset.yaml
@@ -8,6 +8,11 @@ metadata:
     on-upgrade: recreate
 
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      minReadySeconds: 15
   template:
     metadata:
       labels:

--- a/openstack/swift/templates/workers-daemonset.yaml
+++ b/openstack/swift/templates/workers-daemonset.yaml
@@ -8,11 +8,9 @@ metadata:
     on-upgrade: recreate
 
 spec:
+  minReadySeconds: 15
   updateStrategy:
     type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 1
-      minReadySeconds: 15
   template:
     metadata:
       labels:

--- a/system/kube-monitoring/charts/node-exporter/templates/daemonset.yaml
+++ b/system/kube-monitoring/charts/node-exporter/templates/daemonset.yaml
@@ -11,6 +11,9 @@ spec:
     spec:
       updateStrategy:
         type: RollingUpdate
+        rollingUpdate:
+          maxUnavailable: 1
+          minReadySeconds: 5
       tolerations:
       - key: "species"
         operator: "Exists"

--- a/system/kube-monitoring/charts/node-exporter/templates/daemonset.yaml
+++ b/system/kube-monitoring/charts/node-exporter/templates/daemonset.yaml
@@ -9,12 +9,12 @@ spec:
         app: node-exporter
       name: node-exporter
     spec:
-      {{- if ge .Capabilities.KubeVersion.Minor "7" }}
+      updateStrategy:
+        type: RollingUpdate
       tolerations:
       - key: "species"
         operator: "Exists"
         effect: "NoSchedule"
-      {{- end }}
       hostNetwork: true
       hostPID: true
       containers:

--- a/system/kube-monitoring/charts/ntp-exporter/templates/daemonset.yaml
+++ b/system/kube-monitoring/charts/ntp-exporter/templates/daemonset.yaml
@@ -11,6 +11,9 @@ spec:
     spec:
       updateStrategy:
         type: RollingUpdate
+        rollingUpdate:
+          maxUnavailable: 1
+          minReadySeconds: 5
       tolerations:
       - key: "species"
         operator: "Exists"

--- a/system/kube-monitoring/charts/ntp-exporter/templates/daemonset.yaml
+++ b/system/kube-monitoring/charts/ntp-exporter/templates/daemonset.yaml
@@ -9,12 +9,12 @@ spec:
       labels:
         app: ntp-exporter
     spec:
-      {{- if ge .Capabilities.KubeVersion.Minor "7" }}
+      updateStrategy:
+        type: RollingUpdate
       tolerations:
       - key: "species"
         operator: "Exists"
         effect: "NoSchedule"
-      {{- end }}
       containers:
         - name:  ntp-exporter
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}

--- a/system/kube-system/charts/container-linux-update-orchestrator/templates/update-agent.yaml
+++ b/system/kube-system/charts/container-linux-update-orchestrator/templates/update-agent.yaml
@@ -4,6 +4,8 @@ metadata:
   name: container-linux-update-agent
   namespace: kube-system
 spec:
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -12,11 +14,6 @@ spec:
       annotations:
         container-linux-update.v1.coreos.com/agent-version: v0.2.1
     spec:
-      updateStrategy:
-        type: RollingUpdate
-        rollingUpdate:
-          maxUnavailable: 1
-          minReadySeconds: 5
       tolerations:
       - key: "species"
         operator: "Exists"

--- a/system/kube-system/charts/container-linux-update-orchestrator/templates/update-agent.yaml
+++ b/system/kube-system/charts/container-linux-update-orchestrator/templates/update-agent.yaml
@@ -12,12 +12,15 @@ spec:
       annotations:
         container-linux-update.v1.coreos.com/agent-version: v0.2.1
     spec:
-      {{- if ge .Capabilities.KubeVersion.Minor "7" }}
+      updateStrategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxUnavailable: 1
+          minReadySeconds: 5
       tolerations:
       - key: "species"
         operator: "Exists"
         effect: "NoSchedule"
-      {{- end }}
       containers:
       - name: update-agent
         image: quay.io/coreos/container-linux-update-operator:v0.2.1

--- a/system/kube-system/charts/node-problem-detector/templates/daemonset.yaml
+++ b/system/kube-system/charts/node-problem-detector/templates/daemonset.yaml
@@ -3,16 +3,13 @@ kind: DaemonSet
 metadata:
   name: node-problem-detector
 spec:
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:
         app: node-problem-detector
     spec:
-      updateStrategy:
-        type: RollingUpdate
-        rollingUpdate:
-          maxUnavailable: 1
-          minReadySeconds: 5
       tolerations:
       - key: "species"
         operator: "Exists"

--- a/system/kube-system/charts/node-problem-detector/templates/daemonset.yaml
+++ b/system/kube-system/charts/node-problem-detector/templates/daemonset.yaml
@@ -8,12 +8,15 @@ spec:
       labels:
         app: node-problem-detector
     spec:
-      {{- if ge .Capabilities.KubeVersion.Minor "7" }}
+      updateStrategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxUnavailable: 1
+          minReadySeconds: 5
       tolerations:
       - key: "species"
         operator: "Exists"
         effect: "NoSchedule"
-      {{- end }}
       containers:
       - name: node-problem-detector
         command:

--- a/system/kube-system/charts/sysctl/templates/sysctl_ds.yaml
+++ b/system/kube-system/charts/sysctl/templates/sysctl_ds.yaml
@@ -9,13 +9,16 @@ spec:
       labels:
         app: sysctl
     spec:
-      {{- if ge .Capabilities.KubeVersion.Minor "7" }}
+      updateStrategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxUnavailable: 1
+          minReadySeconds: 5
       tolerations:
       - key: "species"
         operator: "Equal"
         value: "network"
         effect: "NoSchedule"
-      {{- end }}
       containers:
         - image: sapcc/sysctl:latest
           name: sysctl

--- a/system/kube-system/charts/sysctl/templates/sysctl_ds.yaml
+++ b/system/kube-system/charts/sysctl/templates/sysctl_ds.yaml
@@ -4,16 +4,13 @@ metadata:
   name: sysctl
   namespace: kube-system
 spec:
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:
         app: sysctl
     spec:
-      updateStrategy:
-        type: RollingUpdate
-        rollingUpdate:
-          maxUnavailable: 1
-          minReadySeconds: 5
       tolerations:
       - key: "species"
         operator: "Equal"


### PR DESCRIPTION
Now possible since we are on k8s 1.7 in all regions.

To roll this out:
1. Merge this PR.
2. Deploy all regions once with the old Concourse task (the one that does rolling upgrade manually).
3. When deployed, adjust the Concourse task to not do its own rolling upgrade, but use `k rollout status` instead. This needs coordination with @auhlig who is also using the Concourse task with daemonsets in kube-monitoring.