### PR TITLE
move the swift-dispersion user into Default

### DIFF
--- a/openstack/swift-utils/templates/seed.yaml
+++ b/openstack/swift-utils/templates/seed.yaml
@@ -70,7 +70,7 @@ spec:
         - name: swift_dispersion
           description: 'dispersion of objects and containers'
           roles:
-            - user: swift_dispersion
+            - user: swift_dispersion@Default
               role: swiftoperator
           swift:
             enabled: true
@@ -93,7 +93,7 @@ spec:
               role: admin
             - project: swift_test
               role: swiftoperator
-            - project: swift_dispersion
+            - project: swift_dispersion@Default
               role: admin
-            - project: swift_dispersion
+            - project: swift_dispersion@Default
               role: swiftoperator

--- a/openstack/swift-utils/templates/seed.yaml
+++ b/openstack/swift-utils/templates/seed.yaml
@@ -93,7 +93,7 @@ spec:
               role: admin
             - project: swift_test
               role: swiftoperator
-            - project: swift_dispersion@Default
+            - project: swift_dispersion
               role: admin
-            - project: swift_dispersion@Default
+            - project: swift_dispersion
               role: swiftoperator

--- a/openstack/swift/templates/etc/_dispersion.conf.tpl
+++ b/openstack/swift/templates/etc/_dispersion.conf.tpl
@@ -1,6 +1,6 @@
 [dispersion]
 auth_user = swift_dispersion
-user_domain_name = cc3test
+user_domain_name = Default
 project_name = swift_dispersion
 project_domain_name = cc3test
 auth_key = {{.Values.dispersion_password}}

--- a/openstack/swift/templates/seeds.yaml
+++ b/openstack/swift/templates/seeds.yaml
@@ -57,6 +57,9 @@ spec:
       roles:
       - project: service
         role: service
+    - name: swift_dispersion
+      description: 'Swift Dispersion'
+      password: {{ $.Values.dispersion_password }}
     - name: ironic
       roles:
       - project: service
@@ -103,11 +106,5 @@ spec:
       roles:
       - group: MONSOON3_DOMAIN_ADMINS
         role: swiftoperator
-
-  - name: cc3test
-    users:
-    - name: swift_dispersion
-      description: 'Swift Dispersion'
-      password: {{ $.Values.dispersion_password }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
cc3test will be taken over by CAM, so we cannot provision users into there anymore.