### PR TITLE
deploy secgroup-entanglement-exporter

### DIFF
--- a/openstack/neutron/templates/deployment-secgroup-entanglement-exporter.yaml
+++ b/openstack/neutron/templates/deployment-secgroup-entanglement-exporter.yaml
@@ -1,0 +1,38 @@
+kind: Deployment
+apiVersion: extensions/v1beta1
+
+metadata:
+  name: neutron-server
+  labels:
+    system: openstack
+    type: api
+    component: neutron
+spec:
+  replicas: 1
+  revisionHistoryLimit: {{ .Values.pod.lifecycle.upgrades.deployments.revision_history }}
+  strategy:
+    type: Recreate # not a critical component
+  selector:
+    matchLabels:
+      name: secgroup-entanglement-exporter
+  template:
+    metadata:
+      labels:
+        name: secgroup-entanglement-exporter
+{{ tuple . "neutron" "secgroup-entanglement-exporter" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9102"
+    spec:
+      containers:
+        - name: exporter
+          image: {{ default "hub.global.cloud.sap" .Values.global.imageRegistry }}/{{ default "secgroup-entanglement-exporter" .Values.secgroup_entanglement_exporter.image_name }}:{{.Values.secgroup_entanglement_exporter.image_tag}}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: POSTGRES_URI
+              value: "postgresql://{{ default .Release.Name .Values.global.dbUser }}:{{ .Values.global.dbPassword }}@{{include "neutron_db_host" .}}:{{.Values.global.postgres_port_public | default 5432}}/{{ default .Release.Name .Values.postgresql.postgresDatabase}}?sslmode=disable"
+            - name: LISTEN_ADDRESS
+              value: ":9102"
+          ports:
+            - name: metrics
+              containerPort: 9102


### PR DESCRIPTION
This adds the [security group entanglement exporter](https://github.com/sapcc/secgroup-entanglement-exporter) to the Neutron chart. The exporter generates a metric called "security group entanglement" that can be used to alert customers with security group setups that strain the DVS agent.

- The image for the exporter is produced by the openstack-neutron pipeline which I extended for this purpose.
- I added `.Values.secgroup_entanglement_exporter.image_tag` to all values files for all regions in cc/secrets, so no further action is required; this can be merged and deployed directly if you like.

cc @fwiesel to make him aware of the existence of the exporter