### PR TITLE
Add "client_timeout" option

### DIFF
--- a/openstack/swift/templates/_utils.tpl
+++ b/openstack/swift/templates/_utils.tpl
@@ -145,6 +145,7 @@ checksum/object.ring: {{ include "swift/templates/object-ring.yaml" . | sha256su
 
 {{- /**********************************************************************************/ -}}
 {{- define "swift_nginx_location" }}
+{{- $context := index . 0 }}
 location / {
     # NOTE: It's imperative that the argument to proxy_pass does not
     # have a trailing slash. Swift needs to see the original request
@@ -165,6 +166,10 @@ location / {
     proxy_request_buffering off;
     # accept large PUT requests (5 GiB is the limit for a single object in Swift)
     client_max_body_size    5g;
+{{- if $context.swift_client_timeout }}
+    proxy_send_timeout      {{ $context.swift_client_timeout }};
+    proxy_read_timeout      {{ $context.swift_client_timeout }};
+{{- end }}
 }
 {{- end -}}
 

--- a/openstack/swift/templates/etc/_object-server.conf.tpl
+++ b/openstack/swift/templates/etc/_object-server.conf.tpl
@@ -9,6 +9,9 @@ bind_port = 6000
 workers = 12
 max_clients = 1024
 backlog = 8192
+{{- if .Values.swift_client_timeout }}
+client_timeout = {{ .Values.swift_client_timeout }}
+{{- end }}
 log_statsd_host = localhost
 log_statsd_port = 9125
 log_statsd_default_sample_rate = 1.0

--- a/openstack/swift/templates/etc/_proxy-server.conf.tpl
+++ b/openstack/swift/templates/etc/_proxy-server.conf.tpl
@@ -12,6 +12,9 @@ expose_info = true
 # NOTE: value for prod, was 512 in staging before
 max_clients = 1024
 backlog = 4096
+{{- if $context.swift_client_timeout }}
+client_timeout = {{ $context.swift_client_timeout }}
+{{- end }}
 log_statsd_host = localhost
 log_statsd_port = 9125
 log_statsd_default_sample_rate = 1.0

--- a/openstack/swift/values.yaml
+++ b/openstack/swift/values.yaml
@@ -41,6 +41,10 @@ probing: true
 object_replicator_concurrency: 2
 object_updater_concurrency: 2
 
+# Swift client timeout in seconds.
+# Allows to avoid 408 client timeout occurred by VMware snapshot creation process
+# swift_client_timeout: 420 # 7 minutes, default is 60 seconds
+
 # If the swift cluster is shared across multiple openstack clusters, one can
 # start multiple proxy deployments connecting to the different keystone backends
 clusters:


### PR DESCRIPTION
Allows to avoid 408 client timeout occured by VMware snapshot creation process