### PR TITLE
Add more fields for nginx access log

### DIFF
--- a/openstack/swift/templates/etc/_nginx.conf.tpl
+++ b/openstack/swift/templates/etc/_nginx.conf.tpl
@@ -19,9 +19,12 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+    log_format  main  '$remote_addr:$remote_port - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
-                      '"$http_user_agent" "$http_x_forwarded_for"';
+                      '"$http_user_agent" "$http_x_forwarded_for" '
+                      'connection=$connection connection_requests=$connection_requests '
+                      'content_length=$content_length request_length=$request_length '
+                      'request_time=$request_time';
 
     access_log  /var/log/nginx/access.log  main;
 


### PR DESCRIPTION
Log format is negotiable.
JFYI: Since [nginx 1.11.8](https://nginx.org/en/docs/http/ngx_http_log_module.html#log_format) it is possible to use pure json format with proper escaping.