### PR TITLE
[swift] S3 API - Additional object server headers

### DIFF
--- a/openstack/swift/templates/etc/_object-server.conf.tpl
+++ b/openstack/swift/templates/etc/_object-server.conf.tpl
@@ -28,7 +28,12 @@ pipeline = healthcheck recon object-server
 
 [app:object-server]
 use = egg:swift#object
-allowed_headers = Content-Disposition, Content-Encoding, X-Delete-At, X-Object-Manifest, X-Static-Large-Object, Cache-Control
+
+{{- if .Values.s3api_enabled }}
+allowed_headers = Cache-Control, Content-Disposition, Content-Encoding, Content-Language, Expires, X-Delete-At, X-Object-Manifest, X-Robots-Tag, X-Static-Large-Object
+{{- else}}
+allowed_headers = Content-Disposition, Content-Encoding, X-Delete-At, X-Object-Manifest, X-Static-Large-Object
+{{- end}}
 
 [object-replicator]
 concurrency = {{ .Values.object_replicator_concurrency }}

--- a/openstack/swift/templates/etc/_object-server.conf.tpl
+++ b/openstack/swift/templates/etc/_object-server.conf.tpl
@@ -28,7 +28,6 @@ pipeline = healthcheck recon object-server
 
 [app:object-server]
 use = egg:swift#object
-
 {{- if .Values.s3api_enabled }}
 allowed_headers = Cache-Control, Content-Disposition, Content-Encoding, Content-Language, Expires, X-Delete-At, X-Object-Manifest, X-Robots-Tag, X-Static-Large-Object
 {{- else}}

--- a/openstack/swift/templates/etc/_proxy-server.conf.tpl
+++ b/openstack/swift/templates/etc/_proxy-server.conf.tpl
@@ -29,13 +29,13 @@ log_level = INFO
 [pipeline:main]
 {{- if le $swift_release "mitaka" }}
 # Mitaka pipeline
-pipeline = catch_errors gatekeeper healthcheck proxy-logging cache cname_lookup domain_remap bulk tempurl ratelimit authtoken{{ if $cluster.s3api_enabled }} swift3 s3token{{ end }} keystoneauth sysmeta-domain-override staticweb container-quotas account-quotas slo dlo versioned_writes proxy-logging proxy-server
+pipeline = catch_errors gatekeeper healthcheck proxy-logging cache cname_lookup domain_remap bulk tempurl ratelimit authtoken{{ if and $context.s3api_enabled $cluster.seed }} swift3 s3token{{ end }} keystoneauth sysmeta-domain-override staticweb container-quotas account-quotas slo dlo versioned_writes proxy-logging proxy-server
 {{- else if eq $swift_release "pike" }}
 # Pike pipeline
-pipeline = catch_errors gatekeeper healthcheck proxy-logging cache cname_lookup domain_remap bulk tempurl ratelimit authtoken{{ if $cluster.s3api_enabled }} swift3 s3token{{ end }} keystoneauth sysmeta-domain-override staticweb copy container-quotas account-quotas slo dlo versioned_writes proxy-logging proxy-server
+pipeline = catch_errors gatekeeper healthcheck proxy-logging cache cname_lookup domain_remap bulk tempurl ratelimit authtoken{{ if and $context.s3api_enabled $cluster.seed }} swift3 s3token{{ end }} keystoneauth sysmeta-domain-override staticweb copy container-quotas account-quotas slo dlo versioned_writes proxy-logging proxy-server
 {{- else if ge $swift_release "queens" }}
 # Queens or > pipeline
-pipeline = catch_errors gatekeeper healthcheck proxy-logging cache cname_lookup domain_remap bulk tempurl ratelimit authtoken{{ if $cluster.s3api_enabled }} swift3 s3token{{ end }} keystoneauth sysmeta-domain-override staticweb copy container-quotas account-quotas slo dlo versioned_writes symlink proxy-logging proxy-server
+pipeline = catch_errors gatekeeper healthcheck proxy-logging cache cname_lookup domain_remap bulk tempurl ratelimit authtoken{{ if and $context.s3api_enabled $cluster.seed }} swift3 s3token{{ end }} keystoneauth sysmeta-domain-override staticweb copy container-quotas account-quotas slo dlo versioned_writes symlink proxy-logging proxy-server
 {{- end }}
 # TODO: sentry middleware (between "proxy-logging" and "proxy-server") disabled temporarily because of weird exceptions tracing into raven, need to check further
 

--- a/openstack/swift/values.yaml
+++ b/openstack/swift/values.yaml
@@ -27,6 +27,9 @@ image_version_auxiliary_statsd_exporter: 'v0.5.0'
 hash_path_prefix: DEFINED_IN_REGION_CHART
 hash_path_suffix: DEFINED_IN_REGION_CHART
 
+# S3 API Emulation for seed cluster
+s3api_enabled: false
+
 # health check only
 dispersion_auth_url: DEFINED_IN_REGION_CHART
 dispersion_password: DEFINED_IN_REGION_CHART
@@ -79,9 +82,6 @@ clusters:
     # Offer optional HTTP port only for special domains like repo.region.tld
     # proxy_public_http_port: 8080
     # sans_http: [repo]
-
-    # S3 API Emulation
-    #s3api_enabled: true
 
 # rings (TODO: having the rings in here is insane, but --values is currently
 # the only way to supply region-specific data; figure out a better way)


### PR DESCRIPTION
* Increase S3 compatibility by additional allowed object headers
* bubble up s3 api switch and only deploy it on the seed cluster