### PR TITLE
Add vcenter templates to elasticsearch

### DIFF
--- a/openstack/elk/templates/bin/_wall-e-start.tpl
+++ b/openstack/elk/templates/bin/_wall-e-start.tpl
@@ -45,6 +45,10 @@ function start_application {
   curl -s -u {{.Values.elk_elasticsearch_admin_user}}:{{.Values.elk_elasticsearch_admin_password}} -XPUT "http://{{.Values.elk_elasticsearch_endpoint_host_internal}}:{{.Values.elk_elasticsearch_port_internal}}/_template/jump" -d "@/wall-e-etc/jump.json"
 
   echo ""
+  echo "INFO: creating index for fluentd/vcenter server logs"
+  curl -s -u {{.Values.elk_elasticsearch_admin_user}}:{{.Values.elk_elasticsearch_admin_password}} -XPUT "http://{{.Values.elk_elasticsearch_endpoint_host_internal}}:{{.Values.elk_elasticsearch_port_internal}}/_template/vcenter" -d "@/wall-e-etc/vcenter.json"
+
+  echo ""
   echo "INFO: setting up the discover panel"
   /node_modules/elasticdump/bin/elasticdump \
       --input=/search.json \

--- a/openstack/elk/templates/etc/_elasticsearch.yml.tpl
+++ b/openstack/elk/templates/etc/_elasticsearch.yml.tpl
@@ -36,6 +36,11 @@ readonlyrest:
       actions: ["indices:admin/types/exists","indices:data/read/*","indices:data/write/*","indices:admin/template/*","indices:admin/create","cluster:monitor/*"]
       indices: ["jump-*"]
       auth_key: {{.Values.elk_elasticsearch_jump_user}}:{{.Values.elk_elasticsearch_jump_password}}
+       
+    - name: vcenter
+      actions: ["indices:admin/types/exists","indices:data/read/*","indices:data/write/*","indices:admin/template/*","indices:admin/create","cluster:monitor/*"]
+      indices: ["vcenter-*"]
+      auth_key: {{.Values.elk_elasticsearch_vcenter_user}}:{{.Values.elk_elasticsearch_vcenter_password}}
 
     - name: Monsoon (read only, but can create dashboards)
       kibana_access: ro

--- a/openstack/elk/templates/etc/_vcenter.json.tpl
+++ b/openstack/elk/templates/etc/_vcenter.json.tpl
@@ -1,0 +1,18 @@
+{
+  "order": 0,
+  "template": "vcenter-*",
+  "settings": {
+    "index": {
+      "refresh_interval": "10s",
+      "unassigned": {
+        "node_left": {
+          "delayed_timeout": "10m"
+        }
+      },
+      "number_of_shards": "3",
+      "number_of_replicas": "1"
+    }
+  },
+  "mappings": {},
+  "aliases": {}
+}

--- a/openstack/elk/templates/wall-e-etc-configmap.yaml
+++ b/openstack/elk/templates/wall-e-etc-configmap.yaml
@@ -15,6 +15,8 @@ data:
 {{ include "elk/templates/etc/_delete_indices.yml.tpl" . | indent 4 }}
    logstash.json: |
 {{ include "elk/templates/etc/_logstash.json.tpl" . | indent 4 }}
+   vcenter.json: |
+{{ include "elk/templates/etc/_vcenter.json.tpl" . | indent 4 }}
    systemd.json: |
 {{ include "elk/templates/etc/_systemd.json.tpl" . | indent 4 }}
    jump.json: |


### PR DESCRIPTION
In preparation for the fluentd-vcenter pod forwarding ESXi and vCenter logs these are the configurations to add the template for the logs to elasticsearch.  This was tested and working in qa-de-1.