### PR TITLE
[swift] Increase client timeout by default

### DIFF
--- a/openstack/swift/values.yaml
+++ b/openstack/swift/values.yaml
@@ -46,7 +46,7 @@ object_updater_concurrency: 2
 
 # Swift client timeout in seconds.
 # Allows to avoid 408 client timeout occurred by VMware snapshot creation process
-# swift_client_timeout: 420 # 7 minutes, default is 60 seconds
+swift_client_timeout: 420 # 7 minutes, default is 60 seconds
 
 # If the swift cluster is shared across multiple openstack clusters, one can
 # start multiple proxy deployments connecting to the different keystone backends


### PR DESCRIPTION
Allows to avoid 408 client timeout occurred by VMware snapshot creation process