### PR TITLE
[swift] support team seed

### DIFF
--- a/openstack/swift/templates/support_seed.yaml
+++ b/openstack/swift/templates/support_seed.yaml
@@ -1,0 +1,75 @@
+{{- $domains := list "ccadmin" "bs" "hcm" "hcp03" "hec" "monsoon3" "s4" "wbs"}}
+{{- range $index, $cluster := .Values.clusters }}
+{{- if $cluster.seed }}
+apiVersion: "openstack.stable.sap.cc/v1"
+kind: "OpenstackSeed"
+metadata:
+  name: swift-support-seed
+  labels:
+    app: {{ tuple $.Release $.Chart $.Values | include "fullname" }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
+    component: objectstore
+    type: seed
+spec:
+  requires:
+  - swift/swift-seed
+  {{- range $domains }}
+  - monsoon3/domain-{{ . | lower }}-seed
+  {{- end }}
+
+  domains:
+    {{- range $domains }}
+    - name: {{ . | lower }}
+      groups:
+      - name: {{ . | upper }}_API_SUPPORT
+        roles:
+        - project: api_support
+          role: swiftoperator
+        {{- if eq . "ccadmin" }}
+        - project: api_tools
+          role: swiftoperator
+        {{- end }}
+        # Inherit admin role within domain
+        - domain: {{ . | lower }}
+          role: swiftoperator
+          inherited: true
+      - name: {{ . | upper }}_COMPUTE_SUPPORT
+        roles:
+        - project: compute_support
+          role: swiftoperator
+        {{- if eq . "ccadmin" }}
+        - project: compute_tools
+          role: swiftoperator
+        {{- end }}
+        # No readonly role to inherit within domain
+      - name: {{ . | upper }}_NETWORK_SUPPORT
+        roles:
+        - project: network_support
+          role: swiftoperator
+        {{- if eq . "ccadmin" }}
+        - project: network_tools
+          role: swiftoperator
+        {{- end }}
+        # No readonly role to inherit within domain
+      - name: {{ . | upper }}_STORAGE_SUPPORT
+        roles:
+        - project: storage_support
+          role: swiftoperator
+        {{- if eq . "ccadmin" }}
+        - project: storage_tools
+          role: swiftoperator
+        {{- end }}
+        # Inherit admin role within domain
+        - domain: {{ . | lower }}
+          role: swiftoperator
+          inherited: true
+      - name: {{ . | upper }}_SERVICE_DESK
+        roles:
+        - project: service_desk
+          role: swiftoperator
+        # No readonly role to inherit within domain
+    {{- end }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
* Externalize seeding of support team permissions into seperate seed
  to keep the main seed clear
* As the seeding looks more or less equal acroos the domains, do
  some templating around it

//cc @ruvr 