### PR TITLE
[openstack][elektra] bump backup image version

### DIFF
--- a/openstack/elektra/charts/postgresql/values.yaml
+++ b/openstack/elektra/charts/postgresql/values.yaml
@@ -60,7 +60,7 @@ resources:
 backup:
   enabled: false
   repository: sapcc/backup-tools
-  image_version: v0.5.14
+  image_version: v0.5.15
   interval_full: 1 hours
   os_auth_url: DEFINED-IN-REGION-SECRETS
   os_region_name: DEFINED-IN-REGION-SECRETS

--- a/openstack/elektra/charts/postgresql/values.yaml
+++ b/openstack/elektra/charts/postgresql/values.yaml
@@ -60,7 +60,7 @@ resources:
 backup:
   enabled: false
   repository: sapcc/backup-tools
-  image_version: v0.5.12
+  image_version: v0.5.14
   interval_full: 1 hours
   os_auth_url: DEFINED-IN-REGION-SECRETS
   os_region_name: DEFINED-IN-REGION-SECRETS


### PR DESCRIPTION
backup-tools:v0.5.15 has the following improvements for the backup-restore utility:
* backup-restore does not connect itself to the to be restored database anymore, which
  caused the `DROP DATABASE IF EXISTS` statement to fail
* backup-restore prints out the executed statements from the dump file, 
  allowing to track down possible issues
* backup-restore keeps the restored dumpfile in `/tmp/newbackup<random> for possible 
  manual reexecution

backup-tools:v0.5.15 has the following improvements for the backup utility:
* only write success timestamps to prometheus if there was actually a success

Please merge and deploy on your own. Consider the postgres pod restart caused by that.