### PR TITLE
[common][mariadb] bump backup image version

### DIFF
--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -15,7 +15,7 @@ backup:
   enabled: false
   interval_full: 1 days
   interval_incr: 1 hours
-  image_version: v0.5.7
+  image_version: v0.5.14
   os_password: DEFINED-IN-REGION-SECRETS
   os_username: db_backup
   os_user_domain: Default

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -15,7 +15,7 @@ backup:
   enabled: false
   interval_full: 1 days
   interval_incr: 1 hours
-  image_version: v0.5.14
+  image_version: v0.5.15
   os_password: DEFINED-IN-REGION-SECRETS
   os_username: db_backup
   os_user_domain: Default


### PR DESCRIPTION
backup-tools:v0.5.15 has the following improvements for the backup-restore utility:
* backup-restore does not connect itself to the to be restored database anymore, which
  caused the `DROP DATABASE IF EXISTS` statement to fail
* backup-restore prints out the executed statements from the dump file, 
  allowing to track down possible issues
* backup-restore keeps the restored dumpfile in `/tmp/newbackup<random> for possible 
  manual reexecution

backup-tools:v0.5.15 has the following improvements for the backup utility:
* only write success timestamps to prometheus if there was actually a success

Please merge and deploy on your own. Consider the mariadb pod restart caused by that.