### PR TITLE
Add watcher middleware to swift

### DIFF
--- a/openstack/swift/etc/watcher.yaml
+++ b/openstack/swift/etc/watcher.yaml
@@ -1,0 +1,16 @@
+custom_actions:
+  account:
+    - method: GET
+      action_type: 'read/list'
+    - method: POST
+      action_type: 'update'
+
+    - container:
+        - method: GET
+          action_type: 'read/list'
+        - method: POST
+          action_type: 'update'
+
+        - object:
+            - method: POST
+              action_type: 'update'

--- a/openstack/swift/templates/etc/_proxy-server.conf.tpl
+++ b/openstack/swift/templates/etc/_proxy-server.conf.tpl
@@ -195,14 +195,14 @@ use = egg:swift3#s3token
 auth_uri = {{$cluster.keystone_auth_uri}}
 auth_version = 3
 
-{{ if $cluster.watcher_enabled }}
+{{ if $cluster.watcher_enabled -}}
 [filter:watcher]
 use = egg:watcher-middleware#watcher
 service_type = object-store
 cadf_service_name = service/storage/object
 target_project_id_from_path = {{$cluster.watcher_project_id_from_path | default true}}
 config_file = /swift-etc/watcher.yaml
-{{ end }}
+{{- end }}
 
 # [filter:statsd]
 # use = egg:ops-middleware#statsd

--- a/openstack/swift/templates/etc/configmap.yaml
+++ b/openstack/swift/templates/etc/configmap.yaml
@@ -37,3 +37,6 @@ data:
   # prometheus
   statsd-exporter.yaml: |
 {{ .Files.Get "etc/statsd-exporter.yaml" | indent 4 }}
+  # openstack request watcher and classifier
+  watcher.yaml: |
+{{ .Files.Get "etc/watcher.yaml" | indent 4 }}

--- a/openstack/swift/values.yaml
+++ b/openstack/swift/values.yaml
@@ -83,6 +83,8 @@ clusters:
     # proxy_public_http_port: 8080
     # sans_http: [repo]
 
+    watcher_enabled: false
+
 # rings (TODO: having the rings in here is insane, but --values is currently
 # the only way to supply region-specific data; figure out a better way)
 account_ring_base64: DEFINED_IN_REGION_CHART


### PR DESCRIPTION
Add watcher middleware to pipeline once installed. Watcher is turned off by default and enabled via regional/cluster values.