### PR TITLE
add "meta" attribute all Swift alerts

### DIFF
--- a/system/kube-monitoring/charts/prometheus-frontend/openstack-swift.alerts
+++ b/system/kube-monitoring/charts/prometheus-frontend/openstack-swift.alerts
@@ -10,6 +10,7 @@ groups:
       service: swift
       severity: info
       tier: openstack
+      meta: first byte timing for {{ $labels.type }} in {{ $labels.os_cluster }} increased
     annotations:
       description: This alert indicates the latency in token validation.
       summary: first byte timing for {{ $labels.type }} in {{ $labels.os_cluster }}
@@ -24,6 +25,7 @@ groups:
       service: swift
       severity: warning
       tier: openstack
+      meta: 503 responses from Swift in {{ $labels.os_cluster }} (check Keystone availability)
     annotations:
       description: Swift is responding with 503 in {{ $labels.os_cluster }}. Usually the root cause is a broken
         token validation
@@ -38,6 +40,7 @@ groups:
       service: swift
       severity: warning
       tier: openstack
+      meta: some health checks for Swift are failing
     annotations:
       description: Swift health check failures. Run kubectl log swift-proxy-... collector to get details
       summary: swift-health-check
@@ -51,6 +54,7 @@ groups:
       service: swift
       severity: warning
       tier: openstack
+      meta: Rings are not equal on all Swift nodes
     annotations:
       description: Rings are not equal on all nodes
       summary: swift-mismatched-rings
@@ -64,6 +68,7 @@ groups:
       service: swift
       severity: warning
       tier: openstack
+      meta: Configuration is not equal on all Swift nodes
     annotations:
       description: Configuration is not equal on all nodes
       summary: swift-mismatched-config
@@ -77,6 +82,7 @@ groups:
       service: swift
       severity: warning
       tier: openstack
+      meta: {{ $value }} Swift nodes not reachable
     annotations:
       description: Swift node error. {{ $value }} Node(s) not reachable.
       summary: swift-node-error
@@ -90,6 +96,7 @@ groups:
       service: swift
       severity: warning
       tier: openstack
+      meta: {{ $value }} Swift drives not mounted
     annotations:
       description: Swift drives not mounted. Run swift-recon --unmounted to get details
       summary: swift disks unmounted on the server IP {{ $labels.storage_ip }}
@@ -103,6 +110,7 @@ groups:
       service: swift
       severity: warning
       tier: openstack
+      meta: {{ $value }} Swift drive failures
     annotations:
       description: Swift drive failures. Run swift-recon --driveaudit to get details
       summary: swift disk failures on the server IP {{ $labels.storage_ip }}
@@ -116,6 +124,7 @@ groups:
       service: swift
       severity: warning
       tier: openstack
+      meta: Async Pendings indicate an overload scenario or faulty device(s)
     annotations:
       description: Async Pendings indicate an overload scenario or faulty device(s)
       summary: swift object server async pendings reached 3000
@@ -129,6 +138,7 @@ groups:
       service: swift
       severity: info
       tier: openstack
+      meta: Some accounts/containers are being rate-limited in {{ $labels.os_cluster }}
     annotations:
       description: Check kibana for the causing account and container
       summary: swift rate limit hit in {{ $labels.os_cluster }}
@@ -142,6 +152,7 @@ groups:
       service: swift
       severity: warning
       tier: openstack
+      meta: Some accounts/containers are being rate-limited in {{ $labels.os_cluster }}
     annotations:
       description: Check kibana for the causing account and container
       summary: swift rate limit hit in {{ $labels.os_cluster }}
@@ -155,6 +166,7 @@ groups:
       service: swift
       severity: info
       tier: openstack
+      meta: Swift storage usage will reach 80% in 30 days. Order hardware now!
     annotations:
       description: Swift storage usage will reach 80% in 30 days. Order hardware now!
       summary: Swift storage expected to be full soon
@@ -168,6 +180,7 @@ groups:
       service: swift
       severity: warning
       tier: openstack
+      meta: {{ $labels.kubernetes_pod_name }} not performing consistency checks on schedule
     annotations:
       description: Autopilot {{ $labels.kubernetes_pod_name }} does not perform its
         consistency checks on schedule. Please check if it's having a bad time.
@@ -181,6 +194,7 @@ groups:
       service: swift
       severity: warning
       tier: openstack
+      meta: Account replication getting stuck on {{ $labels.storage_ip }}
     annotations:
       description: "The last successful account replication age on {{ $labels.storage_ip }}
         is older than 1 hour. Check the affected node. A restart of the replicator pod
@@ -195,6 +209,7 @@ groups:
       service: swift
       severity: warning
       tier: openstack
+      meta: Container replication getting stuck on {{ $labels.storage_ip }}
     annotations:
       description: "The last successful container replication age on {{ $labels.storage_ip }}
         is older than 1 hour. Check the affected node. A restart of the replicator pod might


### PR DESCRIPTION
The "meta" attribute is shown on the alert dashboard, but summary/description are not shown. I adjusted phrasing in some placed to be more succinct because of the limited space in the alert dashboard's table.