### PR TITLE
[barbican]: Make sure to use keystone auth_version 3

### DIFF
--- a/openstack/barbican/templates/etc/_barbican-api-paste.ini.tpl
+++ b/openstack/barbican/templates/etc/_barbican-api-paste.ini.tpl
@@ -51,7 +51,7 @@ identity_uri = {{.Values.global.keystone_api_endpoint_protocol_admin | default "
 admin_tenant_name = {{.Values.global.keystone_service_project | default "service"}}
 admin_user = {{ .Release.Name }}{{ .Values.global.user_suffix }}
 admin_password = {{ .Values.global.barbican_service_password | default (tuple . .Release.Name | include "identity.password_for_user") | replace "$" "$$" }}
-auth_version = 3
+auth_version = v3
 #delay failing perhaps to log the unauthorized request in barbican ..
 #delay_auth_decision = true
 # signing_dir is configurable, but the default behavior of the authtoken

--- a/openstack/barbican/templates/etc/_barbican-api-paste.ini.tpl
+++ b/openstack/barbican/templates/etc/_barbican-api-paste.ini.tpl
@@ -51,7 +51,7 @@ identity_uri = {{.Values.global.keystone_api_endpoint_protocol_admin | default "
 admin_tenant_name = {{.Values.global.keystone_service_project | default "service"}}
 admin_user = {{ .Release.Name }}{{ .Values.global.user_suffix }}
 admin_password = {{ .Values.global.barbican_service_password | default (tuple . .Release.Name | include "identity.password_for_user") | replace "$" "$$" }}
-auth_version = v3.0
+auth_version = 3
 #delay failing perhaps to log the unauthorized request in barbican ..
 #delay_auth_decision = true
 # signing_dir is configurable, but the default behavior of the authtoken

--- a/openstack/barbican/templates/etc/_barbican-api-paste.ini.tpl
+++ b/openstack/barbican/templates/etc/_barbican-api-paste.ini.tpl
@@ -52,6 +52,7 @@ admin_tenant_name = {{.Values.global.keystone_service_project | default "service
 admin_user = {{ .Release.Name }}{{ .Values.global.user_suffix }}
 admin_password = {{ .Values.global.barbican_service_password | default (tuple . .Release.Name | include "identity.password_for_user") | replace "$" "$$" }}
 auth_version = v3
+auth_url = {{.Values.global.keystone_api_endpoint_protocol_admin | default "http"}}://{{include "keystone_api_endpoint_host_admin" .}}:{{ .Values.global.keystone_api_port_admin | default 35357 }}/v3
 #delay failing perhaps to log the unauthorized request in barbican ..
 #delay_auth_decision = true
 # signing_dir is configurable, but the default behavior of the authtoken


### PR DESCRIPTION
Barbican still uses auth version 2:
2018-07-09 08:48:10,837.837 7 WARNING keystonemiddleware.auth_token [-] Identity response: {"error": {"message": "(http://keystone.monsoon3.svc.kubernetes.staging.cloud.sap:35357/v2.0/tokens): The resource could not be found.", "code": 404, "title": "Not Found"}}