### PR TITLE
[neutron] Configure olso.cache

### DIFF
--- a/openstack/neutron/templates/etc/_neutron.conf.tpl
+++ b/openstack/neutron/templates/etc/_neutron.conf.tpl
@@ -129,3 +129,5 @@ quota_security_group_rule = 4
 {{- include "osprofiler" . }}
 
 {{- include "ini_sections.audit_middleware_notifications" . }}
+
+{{- include "ini_sections.cache" . }}


### PR DESCRIPTION
This will configure the olso.cache module, which isn't directly used in neutron, but I would like to make use of it to avoid calls in the arista driver.
