### PR TITLE
[designate] Enable oslo.cache

### DIFF
--- a/openstack/designate/templates/etc/_designate.conf.tpl
+++ b/openstack/designate/templates/etc/_designate.conf.tpl
@@ -466,3 +466,5 @@ topics = notifications
 driver = messagingv2
 transport_url = rabbit://rabbitmq:{{ .Values.rabbitmq_notifications.users.default.password }}@designate-rabbitmq-notifications:5672/
 mem_queue_size = 1000
+
+{{- include "ini_sections.cache" . }}


### PR DESCRIPTION
As far as I can see, it isn't directly used, but belongs to the standard set of libraries and might be indirectly used.
