### PR TITLE
[manila] Configure oslo.cache

### DIFF
--- a/openstack/manila/templates/etc/_manila.conf.tpl
+++ b/openstack/manila/templates/etc/_manila.conf.tpl
@@ -95,3 +95,5 @@ insecure = True
 {{- include "osprofiler" . }}
 
 {{- include "ini_sections.audit_middleware_notifications" . }}
+
+{{- include "ini_sections.cache" . }}


### PR DESCRIPTION
As far as I can see, it isn't directly used, but belongs to the standard set of libraries and might be indirectly used.
