### PR TITLE
[keystone] Switch to common cache template

### DIFF
--- a/openstack/keystone/requirements.lock
+++ b/openstack/keystone/requirements.lock
@@ -11,5 +11,8 @@ dependencies:
 - name: pgmetrics
   repository: file://../../common/pgmetrics
   version: 0.1.0
-digest: sha256:eaa169742b77c4034eb3d9b41c5acddbfed140ae329c5903041bfdaabeaa29ff
-generated: 2017-11-24T14:55:08.235099+01:00
+- name: utils
+  repository: file://../../openstack/utils
+  version: 0.1.1
+digest: sha256:573f85d50745eb6981998d3c2e2e11e6624418f5ac89a634fca267901b10a6ab
+generated: 2018-07-19T10:14:52.221956926+02:00

--- a/openstack/keystone/requirements.yaml
+++ b/openstack/keystone/requirements.yaml
@@ -11,3 +11,6 @@ dependencies:
   - name: pgmetrics
     repository: file://../../common/pgmetrics
     version: 0.1.0
+  - name: utils
+    repository: file://../../openstack/utils
+    version: 0.1.1

--- a/openstack/keystone/templates/etc/_keystone.conf.tpl
+++ b/openstack/keystone/templates/etc/_keystone.conf.tpl
@@ -66,15 +66,7 @@ request_token_duration = {{ .Values.api.oauth1.request_token_duration | default 
 access_token_duration = {{ .Values.api.oauth1.access_token_duration | default "0" }}
 {{- end }}
 
-[cache]
-backend = oslo_cache.memcache_pool
-{{- if .Values.memcached.host }}
-memcache_servers = {{ .Values.memcached.host }}:{{.Values.memcached.port | default 11211}}
-{{ else }}
-memcache_servers = {{ include "memcached_host" . }}:{{.Values.memcached.port | default 11211}}
-{{- end }}
-config_prefix = cache.keystone
-enabled = true
+{{- include "ini_sections.cache" . }}
 
 # Directory containing Fernet keys used to encrypt and decrypt credentials
 # stored in the credential backend. Fernet keys used to encrypt credentials


### PR DESCRIPTION
I've copied the section to the "ini_sections.cache" template (deriving the config_prefix from the chart-name) in order to avoid duplication.
