### PR TITLE
add watcher middleware to designate. disabled by default.

### DIFF
--- a/openstack/designate/templates/etc-configmap.yaml
+++ b/openstack/designate/templates/etc-configmap.yaml
@@ -38,4 +38,9 @@ data:
 {{ include (print .Template.BasePath "/etc/_tempest_deployment_config.json.tpl") . | indent 4 }}
   tempest_extra_options: |
 {{ include (print .Template.BasePath "/etc/_tempest_extra_options.tpl") . | indent 4 }}
-{{- end }} 
+{{- end }}
+
+{{- if .Values.watcher.enabled }}
+  watcher.yaml: |
+{{ include (print .Template.BasePath "/etc/_watcher.yaml.tpl") . | indent 4 }}
+{{- end }}

--- a/openstack/designate/templates/etc/_api-paste.ini.tpl
+++ b/openstack/designate/templates/etc/_api-paste.ini.tpl
@@ -15,8 +15,8 @@ paste.app_factory = designate.api.versions:factory
 
 [composite:osapi_dns_v1]
 use = call:designate.api.middleware:auth_pipeline_factory
-noauth = http_proxy_to_wsgi cors request_id noauthcontext statsd maintenance validation_API_v1 faultwrapper_v1 sentry normalizeuri osapi_dns_app_v1
-keystone = http_proxy_to_wsgi cors request_id authtoken statsd keystonecontext maintenance validation_API_v1 faultwrapper_v1 sentry normalizeuri osapi_dns_app_v1
+noauth = http_proxy_to_wsgi cors request_id noauthcontext statsd {{ if .Values.watcher.enabled }}watcher {{ end }}maintenance validation_API_v1 faultwrapper_v1 sentry normalizeuri osapi_dns_app_v1
+keystone = http_proxy_to_wsgi cors request_id authtoken statsd keystonecontext {{ if .Values.watcher.enabled }}watcher {{ end }}maintenance validation_API_v1 faultwrapper_v1 sentry normalizeuri osapi_dns_app_v1
 
 
 [app:osapi_dns_app_v1]
@@ -24,16 +24,16 @@ paste.app_factory = designate.api.v1:factory
 
 [composite:osapi_dns_v2]
 use = call:designate.api.middleware:auth_pipeline_factory
-noauth = http_proxy_to_wsgi cors request_id statsd faultwrapper sentry validation_API_v2 noauthcontext maintenance normalizeuri audit osapi_dns_app_v2
-keystone = http_proxy_to_wsgi cors request_id statsd faultwrapper sentry validation_API_v2 authtoken keystonecontext maintenance normalizeuri audit osapi_dns_app_v2
+noauth = http_proxy_to_wsgi cors request_id statsd faultwrapper sentry validation_API_v2 noauthcontext {{ if .Values.watcher.enabled }}watcher {{ end }}maintenance normalizeuri audit osapi_dns_app_v2
+keystone = http_proxy_to_wsgi cors request_id statsd faultwrapper sentry validation_API_v2 authtoken keystonecontext {{ if .Values.watcher.enabled }}watcher {{ end }}maintenance normalizeuri audit osapi_dns_app_v2
 
 [app:osapi_dns_app_v2]
 paste.app_factory = designate.api.v2:factory
 
 [composite:osapi_dns_admin]
 use = call:designate.api.middleware:auth_pipeline_factory
-noauth = http_proxy_to_wsgi cors request_id statsd faultwrapper sentry noauthcontext maintenance normalizeuri osapi_dns_app_admin
-keystone = http_proxy_to_wsgi cors request_id statsd faultwrapper sentry authtoken keystonecontext maintenance normalizeuri osapi_dns_app_admin
+noauth = http_proxy_to_wsgi cors request_id statsd faultwrapper sentry noauthcontext {{ if .Values.watcher.enabled }}watcher {{ end }}maintenance normalizeuri osapi_dns_app_admin
+keystone = http_proxy_to_wsgi cors request_id statsd faultwrapper sentry authtoken keystonecontext {{ if .Values.watcher.enabled }}watcher {{ end }}maintenance normalizeuri osapi_dns_app_admin
 
 [app:osapi_dns_app_admin]
 paste.app_factory = designate.api.admin:factory
@@ -91,4 +91,11 @@ audit_map_file = /etc/designate/designate_audit_map.yaml
 ignore_req_list = GET
 record_payloads = {{ if .Values.audit.record_payloads -}}True{{- else -}}False{{- end }}
 metrics_enabled = {{ if .Values.audit.metrics_enabled -}}True{{- else -}}False{{- end }}
+{{- end }}
+
+{{- if .Values.watcher.enabled }}
+[filter:watcher]
+use = egg:watcher-middleware#watcher
+service_type = dns
+config_file = /etc/designate/watcher.yaml
 {{- end }}

--- a/openstack/designate/templates/etc/_watcher.yaml.tpl
+++ b/openstack/designate/templates/etc/_watcher.yaml.tpl
@@ -1,0 +1,64 @@
+custom_actions:
+  zones:
+    - method: GET
+      action_type: read/list
+
+    - tasks:
+        - imports:
+            - method: GET
+              action_type: read/list
+
+        - transfer_requests:
+            - method: GET
+              action_type: read/list
+
+        - transfer_accepts:
+            - method: GET
+              action_type: read/list
+
+    - zone:
+        - tasks:
+            - imports:
+                - method: GET
+                  action_type: read/list
+
+            - exports:
+                - method: GET
+                  action_type: read/list
+
+        - recordsets:
+            - method: GET
+              action_type: read/list
+
+        - nameservers:
+            - method: GET
+              action_type: read/list
+
+  recordsets:
+    - method: GET
+      action_type: read/list
+
+  pools:
+    - method: GET
+      action_type: read/list
+
+  tlds:
+    - method: GET
+      action_type: read/list
+
+  tsigkeys:
+    - method: GET
+      action_type: read/list
+
+  blacklists:
+    - method: GET
+      action_type: read/list
+
+  service_status:
+    - method: GET
+      action_type: read/list
+
+  reverse:
+    - floatingips:
+        - method: GET
+          action_type: read/list

--- a/openstack/designate/values.yaml
+++ b/openstack/designate/values.yaml
@@ -208,3 +208,6 @@ rabbitmq_notifications:
     admin:
       user: admin
       password: DEFINED-IN-SECRETS
+
+watcher:
+  enabled: false


### PR DESCRIPTION
Activated via regional values. prerequisite: installed watcher middleware. 
Looks good to you @dhoeller?