### PR TITLE
adds support for the pg_stat_statements extension

### DIFF
--- a/common/pgmetrics/templates/deployment.yaml
+++ b/common/pgmetrics/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
           - name: metrics
             containerPort: {{ default 9187 .Values.port }}
         {{- if .Values.customMetrics }}
-        args: ["-extend.query-path", "/conf/custom-metrics.yaml", "-log.level", {{ .Values.log_level }}]
+        args: ["--extend.query-path", "/conf/custom-metrics.yaml", "--log.level", {{ .Values.log_level }}]
         volumeMounts:
           - name: custom-metrics
             mountPath: /conf

--- a/common/pgmetrics/values.yaml
+++ b/common/pgmetrics/values.yaml
@@ -10,10 +10,10 @@ global:
 ## image repository
 image: "wrouesnel/postgres_exporter"
 ## image version
-imageTag: "v0.2.1"
+imageTag: "v0.4.6"
 
 ## log level, valid values are: debug, info, warn, error, fatal
-log_level: warn
+log_level: info
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'
@@ -49,6 +49,87 @@ customMetrics:
       - size_bytes:
           usage: "GAUGE"
           description: "Size of the database in bytes"
+
+  pg_stat_user_tables:
+    query: "SELECT schemaname, relname, seq_scan, seq_tup_read, idx_scan, idx_tup_fetch, n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup, n_mod_since_analyze, last_vacuum, last_autovacuum, last_analyze, last_autoanalyze, vacuum_count, autovacuum_count, analyze_count, autoanalyze_count FROM pg_stat_user_tables"
+    metrics:
+      - schemaname:
+          usage: "LABEL"
+          description: "Name of the schema that this table is in"
+      - relname:
+          usage: "LABEL"
+          description: "Name of this table"
+      - seq_scan:
+          usage: "COUNTER"
+          description: "Number of sequential scans initiated on this table"
+      - seq_tup_read:
+          usage: "COUNTER"
+          description: "Number of live rows fetched by sequential scans"
+      - idx_scan:
+          usage: "COUNTER"
+          description: "Number of index scans initiated on this table"
+      - idx_tup_fetch:
+          usage: "COUNTER"
+          description: "Number of live rows fetched by index scans"
+      - n_tup_ins:
+          usage: "COUNTER"
+          description: "Number of rows inserted"
+      - n_tup_upd:
+          usage: "COUNTER"
+          description: "Number of rows updated"
+      - n_tup_del:
+          usage: "COUNTER"
+          description: "Number of rows deleted"
+      - n_tup_hot_upd:
+          usage: "COUNTER"
+          description: "Number of rows HOT updated (i.e., with no separate index update required)"
+      - n_live_tup:
+          usage: "GAUGE"
+          description: "Estimated number of live rows"
+      - n_dead_tup:
+          usage: "GAUGE"
+          description: "Estimated number of dead rows"
+      - n_mod_since_analyze:
+          usage: "GAUGE"
+          description: "Estimated number of rows changed since last analyze"
+      - last_vacuum:
+          usage: "GAUGE"
+          description: "Last time at which this table was manually vacuumed (not counting VACUUM FULL)"
+      - last_autovacuum:
+          usage: "GAUGE"
+          description: "Last time at which this table was vacuumed by the autovacuum daemon"
+      - last_analyze:
+          usage: "GAUGE"
+          description: "Last time at which this table was manually analyzed"
+      - last_autoanalyze:
+          usage: "GAUGE"
+          description: "Last time at which this table was analyzed by the autovacuum daemon"
+      - vacuum_count:
+          usage: "COUNTER"
+          description: "Number of times this table has been manually vacuumed (not counting VACUUM FULL)"
+      - autovacuum_count:
+          usage: "COUNTER"
+          description: "Number of times this table has been vacuumed by the autovacuum daemon"
+      - analyze_count:
+          usage: "COUNTER"
+          description: "Number of times this table has been manually analyzed"
+      - autoanalyze_count:
+          usage: "COUNTER"
+          description: "Number of times this table has been analyzed by the autovacuum daemon"
+
+  pg_replication:
+    query: "SELECT EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp()))::INT as lag"
+    metrics:
+      - lag:
+          usage: "GAUGE"
+          description: "Replication lag behind master in seconds"
+
+  pg_postmaster:
+    query: "SELECT pg_postmaster_start_time as start_time_seconds from pg_postmaster_start_time()"
+    metrics:
+      - start_time_seconds:
+          usage: "GAUGE"
+          description: "Time at which postmaster started"
 
 replicas: 1
 

--- a/common/postgresql/templates/deployment.yaml
+++ b/common/postgresql/templates/deployment.yaml
@@ -147,7 +147,7 @@ spec:
         - name: metrics
           containerPort: {{ default 9187 .Values.metrics.port }}
         {{- if .Values.metrics.customMetrics }}
-        args: ["-extend.query-path", "/conf/custom-metrics.yaml"]
+        args: ["--extend.query-path", "/conf/custom-metrics.yaml"]
         volumeMounts:
           - name: custom-metrics
             mountPath: /conf

--- a/common/postgresql/templates/etc/_postgresql.conf.tpl
+++ b/common/postgresql/templates/etc/_postgresql.conf.tpl
@@ -148,7 +148,14 @@ dynamic_shared_memory_type = posix	# the default is the first option
 
 #max_files_per_process = 1000		# min 25
                     # (change requires restart)
-shared_preload_libraries = {{ .Values.shared_preload_libraries | squote }}	# (change requires restart)
+
+shared_preload_libraries = '{{ keys .Values.extensions | join ","}}'		# (change requires restart)
+
+{{- range $k, $v := .Values.extensions }}
+{{- range $k2, $v2 := $v }}
+{{$k}}.{{$k2}} = {{$v2}}
+{{- end }}
+{{- end }}
 
 # - Cost-Based Vacuum Delay -
 

--- a/common/postgresql/values.yaml
+++ b/common/postgresql/values.yaml
@@ -37,7 +37,12 @@ global:
       application_name_add_host: 1
 
 custom_configmap: false
-shared_preload_libraries: ""
+
+extensions:
+  pg_stat_statements:
+    max: 1000
+    track: all
+
 ## postgres image repository
 image: "postgres"
 ## postgres image version
@@ -111,7 +116,7 @@ resources:
 metrics:
   enabled: false
   image: "wrouesnel/postgres_exporter"
-  imageTag: v0.2.1
+  imageTag: v0.4.6
   imagePullPolicy: IfNotPresent
 
   port: 9187


### PR DESCRIPTION
updates the metrics exporter to current version
exposes replication metrics for the clustered instances