### PR TITLE
add statsd container to manila api

### DIFF
--- a/openstack/manila/templates/api-deployment.yaml
+++ b/openstack/manila/templates/api-deployment.yaml
@@ -93,6 +93,15 @@ spec:
               subPath: watcher.yaml
               readOnly: true
             {{- end }}
+        - name: statsd
+          image: prom/statsd-exporter:v0.6.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: statsd
+              containerPort: 9125
+              protocol: UDP
+            - name: metrics
+              containerPort: {{ .Values.global.metrics_port }}
       volumes:
         - name: etcmanila
           emptyDir: {}

--- a/openstack/manila/templates/api-service.yaml
+++ b/openstack/manila/templates/api-service.yaml
@@ -7,6 +7,9 @@ metadata:
     system: openstack
     type: api
     component: manila
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: {{ .Values.global.metrics_port | quote }}
 spec:
   selector:
     name: manila-api

--- a/openstack/manila/values.yaml
+++ b/openstack/manila/values.yaml
@@ -10,6 +10,7 @@ global:
   master_password: ""
   pgbouncer:
     enabled: true
+  metrics_port: 9102
 
 api_port_internal: '8786'
 debug: "True"


### PR DESCRIPTION
Else metrics of {ops, watcher, audit}-middleware are sent into nirvana. LGTY @Carthaca?