### PR TITLE
add openstack-watcher-middleware to ironic. disabled by default

### DIFF
--- a/openstack/ironic/templates/api-deployment.yaml
+++ b/openstack/ironic/templates/api-deployment.yaml
@@ -88,6 +88,12 @@ spec:
           name: ironic-etc
           subPath: logging.ini
           readOnly: true
+        {{- if .Values.watcher.enabled }}
+        - name: ironic-etc
+          mountPath: /etc/ironic/watcher.yaml
+          subPath: watcher.yaml
+          readOnly: true
+        {{- end }}
 {{- tuple . .Values.api.override "ironic-api" | include "utils.snippets.debug.debug_port_container" | indent 8 }}
       volumes:
       - name: etcironic

--- a/openstack/ironic/templates/etc-configmap.yaml
+++ b/openstack/ironic/templates/etc-configmap.yaml
@@ -31,3 +31,7 @@ data:
   tempest_extra_options: |
 {{ include (print .Template.BasePath "/etc/_tempest_extra_options.tpl") . | indent 4 }}
 {{- end }}
+{{- if .Values.watcher.enabled }}
+  watcher.yaml: |
+{{ include (print .Template.BasePath "/etc/_watcher.yaml.tpl") . | indent 4 }}
+{{- end }}

--- a/openstack/ironic/templates/etc/_ironic.conf.tpl
+++ b/openstack/ironic/templates/etc/_ironic.conf.tpl
@@ -90,6 +90,13 @@ port_setup_delay = {{ .Values.neutron_port_setup_delay }}
 [oslo_middleware]
 enable_proxy_headers_parsing = True
 
+{{- if .Values.watcher.enabled }}
+[watcher]
+enabled = true
+service_type = baremetal
+config_file = /etc/ironic/watcher.yaml
+{{ end }}
+
 {{- include "osprofiler" . }}
 
 {{- include "ini_sections.cache" . }}

--- a/openstack/ironic/templates/etc/_watcher.yaml.tpl
+++ b/openstack/ironic/templates/etc/_watcher.yaml.tpl
@@ -1,0 +1,20 @@
+path_keywords:
+  - bios: setting
+  - chassis: chassis
+  - connectors
+  - drivers
+  - heartbeat: node
+  - methods
+  - nodes
+  - ports
+  - portgroups
+  - targets
+  - traits
+  - volume
+  - vifs
+
+custom_actions:
+  chassis:
+    chassis:
+      - method: GET
+        action_type: read

--- a/openstack/ironic/values.yaml
+++ b/openstack/ironic/values.yaml
@@ -151,3 +151,6 @@ logging:
     auditmiddleware:
       handlers: stdout, sentry
       level: INFO
+
+watcher:
+  enabled: false


### PR DESCRIPTION
**NOTE:** requires https://github.com/sapcc/ironic/pull/3 before the watcher can be enabled. /cc @fwiesel 