### PR TITLE
configurable pagerduty routing and channels via values

### DIFF
--- a/global/prometheus-alertmanager/templates/config.yaml
+++ b/global/prometheus-alertmanager/templates/config.yaml
@@ -66,32 +66,28 @@ data:
         continue: false
         match_re:
           region: qa-de-1
-      - receiver: pagerduty_hypervisor
-        continue: false
-        match:
-          severity: critical
-          service: vcenter
-      - receiver: pagerduty_baremetal
-        continue: false
-        match:
-          severity: critical
-          service: ironic
-          tier: baremetal
-          
-#block kubernikus and interconnect alerts away from pagerduty          
+
+      # block kubernikus and interconnect alerts away from pagerduty
       - receiver: dev-null
         continue: false
         match:
           tier: kubernikus
       - receiver: dev-null
         continue: false
-        match:          
+        match:
           service: interconnect
-          
-      - receiver: pagerduty
-        continue: true
+
+      {{- range $pd := .Values.pagerduty_services }}
+      - receiver: pagerduty-{{ $pd.name }}
+        continue: false
         match:
           severity: critical
+          {{- if $pd.match }}
+          {{- range $key, $value := $pd.match }}
+          {{ $key }}: {{ $value }}
+          {{- end }}
+          {{- end }}
+      {{- end }}
 
     receivers:
     - name: dev-null
@@ -137,9 +133,11 @@ data:
         icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
         send_resolved: true
     {{- end }}
-    - name: pagerduty
+
+    {{- range $pd := .Values.pagerduty_services }}
+    - name: pagerduty-{{ $pd.name }}
       pagerduty_configs:
-      - service_key: {{ default "" .Values.pagerduty.service_key }}
+      - service_key: {{ default "" $pd.service_key }}
         description: {{"'{{ template \"pagerduty.sapcc.description\" . }}'"}}
         component: {{"'{{template \"pagerduty.sapcc.tier\" . }}'"}}
         group: {{"'{{template \"pagerduty.sapcc.service\" . }}'"}}
@@ -154,40 +152,7 @@ data:
           Sentry: {{"'{{template \"pagerduty.sapcc.sentry\" . }}'"}}
           Playbook: {{"'{{template \"pagerduty.sapcc.playbook\" . }}'"}}
           firing: {{"'{{ template \"pagerduty.sapcc.firing\" . }}'"}}
-    - name: pagerduty_hypervisor
-      pagerduty_configs:
-      - service_key: {{ default "" .Values.pagerduty_hypervisor.service_key }}
-        description: {{"'{{ template \"pagerduty.sapcc.description\" . }}'"}}
-        component: {{"'{{template \"pagerduty.sapcc.tier\" . }}'"}}
-        group: {{"'{{template \"pagerduty.sapcc.service\" . }}'"}}
-        details:
-          Details: {{"'{{template \"pagerduty.sapcc.details\" . }}'"}}
-          Region: {{"'{{template \"pagerduty.sapcc.region\" . }}'"}}
-          Tier: {{"'{{template \"pagerduty.sapcc.tier\" . }}'"}}
-          Service: {{"'{{template \"pagerduty.sapcc.service\" . }}'"}}
-          Context: {{"'{{template \"pagerduty.sapcc.context\" . }}'"}}
-          Prometheus: {{"'{{template \"pagerduty.sapcc.prometheus\" . }}'"}}
-          Dashboard: {{"'{{template \"pagerduty.sapcc.dashboard\" . }}'"}}
-          Sentry: {{"'{{template \"pagerduty.sapcc.sentry\" . }}'"}}
-          Playbook: {{"'{{template \"pagerduty.sapcc.playbook\" . }}'"}}
-          firing: {{"'{{ template \"pagerduty.sapcc.firing\" . }}'"}}
-    - name: pagerduty_baremetal
-      pagerduty_configs:
-      - service_key: {{ default "" .Values.pagerduty_baremetal.service_key }}
-        description: {{"'{{ template \"pagerduty.sapcc.description\" . }}'"}}
-        component: {{"'{{template \"pagerduty.sapcc.tier\" . }}'"}}
-        group: {{"'{{template \"pagerduty.sapcc.service\" . }}'"}}
-        details:
-          Details: {{"'{{template \"pagerduty.sapcc.details\" . }}'"}}
-          Region: {{"'{{template \"pagerduty.sapcc.region\" . }}'"}}
-          Tier: {{"'{{template \"pagerduty.sapcc.tier\" . }}'"}}
-          Service: {{"'{{template \"pagerduty.sapcc.service\" . }}'"}}
-          Context: {{"'{{template \"pagerduty.sapcc.context\" . }}'"}}
-          Prometheus: {{"'{{template \"pagerduty.sapcc.prometheus\" . }}'"}}
-          Dashboard: {{"'{{template \"pagerduty.sapcc.dashboard\" . }}'"}}
-          Sentry: {{"'{{template \"pagerduty.sapcc.sentry\" . }}'"}}
-          Playbook: {{"'{{template \"pagerduty.sapcc.playbook\" . }}'"}}
-          firing: {{"'{{ template \"pagerduty.sapcc.firing\" . }}'"}}
+    {{- end }}
 
   {{- $files := .Files }}
   {{ range tuple "slack.tmpl" "pagerduty.tmpl" }}

--- a/global/prometheus-alertmanager/values.yaml
+++ b/global/prometheus-alertmanager/values.yaml
@@ -27,12 +27,6 @@ configmap_reload:
 slack:
   webhook_url: DEFINED-IN-SECRETS
 
-pagerduty:
-  service_key: DEFINED-IN-SECRETS
-
-pagerduty_hypervisor:
-  service_key: DEFINED-IN-SECRETS
-
 # creates <tier>-{info, warning, critical} routing and receivers
 tiers:
   - kubernetes
@@ -58,3 +52,18 @@ openstack_services:
   - neutron
   - nova
   - swift
+
+# creates routing and channel for pagerduty
+# the order matters, as an alert is only send to the first matching pagerduty instance (matches by service, tier label)
+pagerduty_services:
+  # name of the pagerduty receiver
+  - name: pagerduty
+    # pagerduty service key
+    service_key: DEFINED-IN-SECRETS
+    # limit alerts to this receiver to the following labels
+    # `severity: critical` is always set
+    match:
+      # limit to alerts with this service label (optional)
+      service: SERVICE-TYPE
+      # limit to alerts with this tier label (optional)
+      tier: SERVICE-TIER


### PR DESCRIPTION
Will merge tomorrow to avoid retriggering alerts during the night.

Routing and channels would for a pagerduty receiver would be generated by a snippet like:
```yaml
pagerduty_services:
  - name: baremetal
    service_key: DEFINED-IN-SECRETS
    match:
      service: ironic
      tier: baremetal
```