### PR TITLE
Reduce routing complexity

### DIFF
--- a/global/prometheus-alertmanager/templates/config.yaml
+++ b/global/prometheus-alertmanager/templates/config.yaml
@@ -61,6 +61,7 @@ data:
           service: {{ $service }}
           tier: openstack
       {{- end }}
+      # Don’t page for qa-de-1
       - receiver: dev-null
         continue: false
         match_re:

--- a/global/prometheus-alertmanager/templates/config.yaml
+++ b/global/prometheus-alertmanager/templates/config.yaml
@@ -34,7 +34,7 @@ data:
 
       routes:
       - receiver: dev-null
-        continue: true
+        continue: false
         match_re:
           region: staging
       # routing per tier to <tier>-{info, warning, critical}
@@ -43,7 +43,6 @@ data:
         continue: true
         match_re:
           tier: {{ $tier }}
-          region: ([a-zA-Z]\-)?[a-zA-Z]+\-[a-zA-Z]+\-[0-9]|admin
         routes:
         - receiver: '{{ $tier }}-warning'
           continue: true
@@ -61,19 +60,16 @@ data:
         match_re:
           service: {{ $service }}
           tier: openstack
-          region: ^[a-zA-Z]+\-[a-zA-Z]+\-[0-9]$|admin
       {{- end }}
       - receiver: pagerduty_hypervisor
         continue: false
         match_re:
-          region: ^[a-p,r-zA-P,R-Z]+\-[a-zA-Z]+\-[0-9]$|admin
         match:
           severity: critical
           service: vcenter
       - receiver: pagerduty_baremetal
         continue: false
         match_re:
-          region: ^[a-p,r-zA-P,R-Z]+\-[a-zA-Z]+\-[0-9]$|admin
         match:
           severity: critical
           service: ironic
@@ -81,7 +77,6 @@ data:
       - receiver: pagerduty
         continue: true
         match_re:
-          region: ^[a-p,r-zA-P,R-Z]+\-[a-zA-Z]+\-[0-9]$|admin
         match:
           severity: critical
 

--- a/global/prometheus-alertmanager/templates/config.yaml
+++ b/global/prometheus-alertmanager/templates/config.yaml
@@ -61,22 +61,23 @@ data:
           service: {{ $service }}
           tier: openstack
       {{- end }}
-      - receiver: pagerduty_hypervisor
+      - receiver: dev-null
         continue: false
         match_re:
+          region: qa-de-1
+      - receiver: pagerduty_hypervisor
+        continue: false
         match:
           severity: critical
           service: vcenter
       - receiver: pagerduty_baremetal
         continue: false
-        match_re:
         match:
           severity: critical
           service: ironic
           tier: baremetal
       - receiver: pagerduty
         continue: true
-        match_re:
         match:
           severity: critical
 


### PR DESCRIPTION
We avoid the double filter, have much less complexity and we avoid accidental loss if we introduce new regions or clusters.
Please double check if you also think it will work as intended, I am not completely sure if I overlooked something.