### PR TITLE
Enable underscores in headers in ingress controller

### DIFF
--- a/system/kube-system/charts/ingress/values.yaml
+++ b/system/kube-system/charts/ingress/values.yaml
@@ -20,6 +20,7 @@ controller:
       }
     location-snippet: |
       proxy_set_header X-REMOTE-USER $ssl_client_s_dn_cn;
+    enable-underscores-in-headers: "true"
   # nodeSelector for the controller DaemonSet
   nodeSelector:
     species: master


### PR DESCRIPTION
glance v1 api uses underscores in header names, e.g. `x-image-meta-is_public`