### PR TITLE
generic name 'baremetal/ironic' for ipmi job

### DIFF
--- a/system/kube-monitoring/charts/prometheus-collector/templates/_prometheus.yaml.tpl
+++ b/system/kube-monitoring/charts/prometheus-collector/templates/_prometheus.yaml.tpl
@@ -440,7 +440,7 @@ scrape_configs:
 {{- end }}
 
 {{- if .Values.global.ipmi_exporter.enabled }}
-- job_name: 'ipmi-{{ .Values.global.region }}'
+- job_name: 'baremetal/ironic'
   scrape_interval: 60s
   scrape_timeout: 55s
   file_sd_configs:


### PR DESCRIPTION
This PR was mostly made to ensure that there are no typos.

The beforehand used name was anyway overwritten by the value 'baremetal/ironic' provided by the ipmi_sd service discovery.
Because we want to drop the label there, we have to change it here so that nothing changes for the metric’s consumers.
This change is necessary to unblock this PR:
https://github.com/sapcc/ipmi_sd/pull/7