### PR TITLE
MetalLB

### DIFF
--- a/system/kube-system/requirements.lock
+++ b/system/kube-system/requirements.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: nginx-ingress
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.28.2
-digest: sha256:6926070d4fe7dc46ba0cbe18fc090211c4a1700f4b6138179008c3aa0ca4d534
-generated: 2018-09-10T18:51:08.894448047+02:00
+- name: metallb
+  repository: file://vendor/metallb
+  version: 0.6.0
+digest: sha256:0bbb8ff8f6cde12c752161ef60260d5bcf7d7e46924b3b13d01ad056da172d41
+generated: 2018-09-12T19:56:51.564798644+02:00

--- a/system/kube-system/requirements.lock
+++ b/system/kube-system/requirements.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.28.2
 - name: metallb
   repository: file://vendor/metallb
-  version: 0.7.0
-digest: sha256:a9df1c39e938e59a087d2db29eb247071aa988d1baf12e2e16767b9986f05e8d
-generated: 2018-09-12T19:57:26.013051075+02:00
+  version: 0.7.3
+digest: sha256:cbdf4c19f43b8a16de59f41d80051f72613fc43557558b96d5800ce88d7068d2
+generated: 2018-09-12T19:57:48.521967895+02:00

--- a/system/kube-system/requirements.lock
+++ b/system/kube-system/requirements.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: metallb
   repository: file://vendor/metallb
   version: 0.7.3
-digest: sha256:cbdf4c19f43b8a16de59f41d80051f72613fc43557558b96d5800ce88d7068d2
-generated: 2018-09-12T19:57:48.521967895+02:00
+digest: sha256:c579deda07903ce0a41d6d3641107a0e1c5d47752033547949c942df8065096e
+generated: 2018-10-23T10:49:19.507057017+02:00

--- a/system/kube-system/requirements.lock
+++ b/system/kube-system/requirements.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.28.2
 - name: metallb
   repository: file://vendor/metallb
-  version: 0.6.0
-digest: sha256:0bbb8ff8f6cde12c752161ef60260d5bcf7d7e46924b3b13d01ad056da172d41
-generated: 2018-09-12T19:56:51.564798644+02:00
+  version: 0.7.0
+digest: sha256:a9df1c39e938e59a087d2db29eb247071aa988d1baf12e2e16767b9986f05e8d
+generated: 2018-09-12T19:57:26.013051075+02:00

--- a/system/kube-system/requirements.yaml
+++ b/system/kube-system/requirements.yaml
@@ -3,5 +3,6 @@ dependencies:
     repository: https://kubernetes-charts.storage.googleapis.com/
     version: 0.28.2
   - name: metallb
+    condition: metallb.enabled
     repository: file://vendor/metallb
     version: 0.7.3

--- a/system/kube-system/requirements.yaml
+++ b/system/kube-system/requirements.yaml
@@ -4,4 +4,4 @@ dependencies:
     version: 0.28.2
   - name: metallb
     repository: file://vendor/metallb
-    version: 0.6.0
+    version: 0.7.0

--- a/system/kube-system/requirements.yaml
+++ b/system/kube-system/requirements.yaml
@@ -4,4 +4,4 @@ dependencies:
     version: 0.28.2
   - name: metallb
     repository: file://vendor/metallb
-    version: 0.7.0
+    version: 0.7.3

--- a/system/kube-system/requirements.yaml
+++ b/system/kube-system/requirements.yaml
@@ -2,3 +2,6 @@ dependencies:
   - name: nginx-ingress
     repository: https://kubernetes-charts.storage.googleapis.com/
     version: 0.28.2
+  - name: metallb
+    repository: file://vendor/metallb
+    version: 0.6.0

--- a/system/kube-system/values.yaml
+++ b/system/kube-system/values.yaml
@@ -192,5 +192,21 @@ metallb:
     nodeSelector:
       species: master
 
+    affinity:
+      # don't co-locate replicas of the speaker on the same node
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - app: metallb
+                key: component
+                operator: In
+                values:
+                - speaker
+
   # configInline:
   # defined in region secrets

--- a/system/kube-system/values.yaml
+++ b/system/kube-system/values.yaml
@@ -180,8 +180,12 @@ metallb:
       name: default
 
   controller:
-    nodeSelector:
-      species: master
+    image:
+      tag: v0.7.3
+
+  speaker:
+    image:
+      tag: v0.7.3
 
   # configInline:
   # defined in region secrets

--- a/system/kube-system/values.yaml
+++ b/system/kube-system/values.yaml
@@ -187,14 +187,10 @@ metallb:
     image:
       tag: v0.7.3
 
-    affinity:
-      nodeAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          nodeSelectorTerms:
-            - matchExpressions:
-              - key: "species"
-                operator: NotIn
-                values: ["master"]
+    # if speaker is run on master nodes the metallb may only be run in l2 mode.
+    # bgp announcements are done by the sapcc/kube-parrot.
+    nodeSelector:
+      species: master
 
   # configInline:
   # defined in region secrets

--- a/system/kube-system/values.yaml
+++ b/system/kube-system/values.yaml
@@ -187,5 +187,14 @@ metallb:
     image:
       tag: v0.7.3
 
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+              - key: "species"
+                operator: NotIn
+                values: ["master"]
+
   # configInline:
   # defined in region secrets

--- a/system/kube-system/values.yaml
+++ b/system/kube-system/values.yaml
@@ -179,5 +179,9 @@ metallb:
       create: false
       name: default
 
+  controller:
+    nodeSelector:
+      species: master
+
   # configInline:
   # defined in region secrets

--- a/system/kube-system/values.yaml
+++ b/system/kube-system/values.yaml
@@ -165,6 +165,9 @@ nginx-ingress:
 #        memory: 20Mi
 
 metallb:
+  rbac:
+    create: false
+
   prometheus:
     scrapeAnnotations: true
 

--- a/system/kube-system/values.yaml
+++ b/system/kube-system/values.yaml
@@ -165,6 +165,8 @@ nginx-ingress:
 #        memory: 20Mi
 
 metallb:
+  enabled: false
+
   rbac:
     create: false
 

--- a/system/kube-system/values.yaml
+++ b/system/kube-system/values.yaml
@@ -163,3 +163,18 @@ nginx-ingress:
 #      requests:
 #        cpu: 10m
 #        memory: 20Mi
+
+metallb:
+  prometheus:
+    scrapeAnnotations: true
+
+  serviceAccounts:
+    controller:
+      create: false
+      name: default
+    speaker:
+      create: false
+      name: default
+
+  # configInline:
+  # defined in region secrets

--- a/system/kube-system/vendor/metallb/.helmignore
+++ b/system/kube-system/vendor/metallb/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/system/kube-system/vendor/metallb/Chart.yaml
+++ b/system/kube-system/vendor/metallb/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+appVersion: 0.6.2
+description: MetalLB is a load-balancer implementation for bare metal Kubernetes clusters
+home: https://metallb.universe.tf
+icon: https://metallb.universe.tf/images/logo.png
+keywords:
+- load-balancer
+- balancer
+- lb
+- bgp
+- arp
+- vrrp
+- vip
+maintainers:
+- email: dave@natulte.net
+  name: danderson
+name: metallb
+version: 0.6.0

--- a/system/kube-system/vendor/metallb/Chart.yaml
+++ b/system/kube-system/vendor/metallb/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 - email: dave@natulte.net
   name: danderson
 name: metallb
-version: 0.6.0
+version: 0.7.0

--- a/system/kube-system/vendor/metallb/Chart.yaml
+++ b/system/kube-system/vendor/metallb/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.6.2
+appVersion: 0.7.3
 description: MetalLB is a load-balancer implementation for bare metal Kubernetes clusters
 home: https://metallb.universe.tf
 icon: https://metallb.universe.tf/images/logo.png
@@ -15,4 +15,4 @@ maintainers:
 - email: dave@natulte.net
   name: danderson
 name: metallb
-version: 0.7.0
+version: 0.7.3

--- a/system/kube-system/vendor/metallb/README.md
+++ b/system/kube-system/vendor/metallb/README.md
@@ -1,0 +1,125 @@
+MetalLB
+-------
+
+MetalLB is a load-balancer implementation for bare metal [Kubernetes][k8s-home]
+clusters, using standard routing protocols.
+
+TL;DR;
+------
+
+```console
+$ helm install --name metallb stable/metallb
+```
+
+Introduction
+------------
+
+This chart bootstraps a [MetalLB][metallb-home] installation on
+a [Kubernetes][k8s-home] cluster using the [Helm][helm-home] package manager.
+This chart provides an implementation for LoadBalancer Service objects.
+
+MetalLB is a cluster service, and as such can only be deployed as a
+cluster singleton. Running multiple installations of MetalLB in a
+single cluster is not supported.
+
+Prerequisites
+-------------
+
+-  Kubernetes 1.9+
+
+Installing the Chart
+--------------------
+
+The chart can be installed as follows:
+
+```console
+$ helm install --name metallb stable/metallb
+```
+
+The command deploys MetalLB on the Kubernetes cluster. This chart does
+not provide a default configuration; MetalLB will not act on your
+Kubernetes Services until you provide
+one. The [configuration](#configuration) section lists various ways to
+provide this configuration.
+
+Uninstalling the Chart
+----------------------
+
+To uninstall/delete the `metallb` deployment:
+
+```console
+$ helm delete metallb
+```
+
+The command removes all the Kubernetes components associated with the
+chart, but will not remove the release metadata from `helm` — this will prevent
+you, for example, if you later try to create a release also named `metallb`). To
+fully delete the release and release history, simply [include the `--purge`
+flag][helm-usage]:
+
+```console
+$ helm delete --purge metallb
+```
+
+Configuration
+-------------
+
+See `values.yaml` for configuration notes. Specify each parameter
+using the `--set key=value[,key=value]` argument to `helm
+install`. For example,
+
+```console
+$ helm install --name metallb \
+  --set rbac.create=false \
+    stable/metallb
+```
+
+The above command disables the use of RBAC rules.
+
+Alternatively, a YAML file that specifies the values for the above
+parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install --name metallb -f values.yaml stable/metallb
+```
+
+By default, this chart does not install a configuration for MetalLB, and simply
+warns you that you must follow [the configuration instructions on MetalLB's
+website][metallb-config] to create an appropriate ConfigMap.
+
+For simple setups that only use MetalLB's [ARP mode][metallb-arpndp-concepts],
+you can specify a single IP range using the `arpAddresses` parameter to have the
+chart install a working configuration for you:
+
+```console
+$ helm install --name metallb \
+  --set arpAddresses=192.168.16.240/30 \
+  stable/metallb
+```
+
+If you have a more complex configuration and want Helm to manage it for you, you
+can provide it in the `config` parameter. The configuration format is
+[documented on MetalLB's website][metallb-config].
+
+```console
+$ cat values.yaml
+config:
+  peers:
+  - peer-address: 10.0.0.1
+    peer-asn: 64512
+    my-asn: 64512
+  address-pools:
+  - name: default
+    protocol: bgp
+    cidr:
+    - 198.51.100.0/24
+
+$ helm install --name metallb -f values.yaml stable/metallb
+```
+
+[helm-home]: https://helm.sh
+[helm-usage]: https://docs.helm.sh/using_helm/
+[k8s-home]: https://kubernetes.io
+[metallb-arpndp-concepts]: https://metallb.universe.tf/concepts/arp-ndp/
+[metallb-config]: https://metallb.universe.tf/configuration/
+[metallb-home]: https://metallb.universe.tf

--- a/system/kube-system/vendor/metallb/templates/NOTES.txt
+++ b/system/kube-system/vendor/metallb/templates/NOTES.txt
@@ -1,0 +1,11 @@
+
+MetalLB is now running in the cluster.
+{{- if .Values.configInline }}
+LoadBalancer Services in your cluster are now available on the IPs you
+defined in MetalLB's configuration. To see IP assignments,
+try `kubectl get services`.
+{{- else }}
+WARNING: you specified a ConfigMap that isn't managed by
+Helm. LoadBalancer services will not function until you add that
+ConfigMap to your cluster yourself.
+{{- end }}

--- a/system/kube-system/vendor/metallb/templates/_helpers.tpl
+++ b/system/kube-system/vendor/metallb/templates/_helpers.tpl
@@ -1,0 +1,65 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "metallb.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "metallb.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "metallb.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the controller service account to use
+*/}}
+{{- define "metallb.controllerServiceAccountName" -}}
+{{- if .Values.serviceAccounts.controller.create -}}
+    {{ default (printf "%s-controller" (include "metallb.fullname" .)) .Values.serviceAccounts.controller.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccounts.controller.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the speaker service account to use
+*/}}
+{{- define "metallb.speakerServiceAccountName" -}}
+{{- if .Values.serviceAccounts.speaker.create -}}
+    {{ default (printf "%s-speaker" (include "metallb.fullname" .)) .Values.serviceAccounts.speaker.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccounts.speaker.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the settings ConfigMap to use.
+*/}}
+{{- define "metallb.configMapName" -}}
+{{- if .Values.configInline -}}
+    {{ include "metallb.fullname" . }}
+{{- else -}}
+    {{ .Values.existingConfigMap }}
+{{- end -}}
+{{- end -}}

--- a/system/kube-system/vendor/metallb/templates/config.yaml
+++ b/system/kube-system/vendor/metallb/templates/config.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.configInline }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "metallb.fullname" . }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+data:
+  config: |
+{{ toYaml .Values.configInline | indent 4 }}
+{{- end }}

--- a/system/kube-system/vendor/metallb/templates/controller.yaml
+++ b/system/kube-system/vendor/metallb/templates/controller.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "metallb.fullname" . }}-controller
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+    component: controller
+spec:
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: {{ template "metallb.name" . }}
+      component: controller
+      release: {{ .Release.Name | quote }}
+  template:
+    metadata:
+      labels:
+        heritage: {{ .Release.Service | quote }}
+        release: {{ .Release.Name | quote }}
+        chart: {{ template "metallb.chart" . }}
+        app: {{ template "metallb.name" . }}
+        component: controller
+{{- if .Values.prometheus.scrapeAnnotations }}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "7472"
+{{- end }}
+    spec:
+      serviceAccountName: {{ template "metallb.controllerServiceAccountName" . }}
+      terminationGracePeriodSeconds: 0
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534 # nobody
+      containers:
+      - name: controller
+        image: {{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}
+        imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
+        args:
+        - --port=7472
+        - --config={{ template "metallb.configMapName" . }}
+        ports:
+        - name: monitoring
+          containerPort: 7472
+        resources:
+{{ toYaml .Values.controller.resources | indent 10 }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          readOnlyRootFilesystem: true

--- a/system/kube-system/vendor/metallb/templates/controller.yaml
+++ b/system/kube-system/vendor/metallb/templates/controller.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: {{ template "metallb.fullname" . }}-controller

--- a/system/kube-system/vendor/metallb/templates/controller.yaml
+++ b/system/kube-system/vendor/metallb/templates/controller.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: {{ template "metallb.fullname" . }}-controller
@@ -34,6 +34,18 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534 # nobody
+    {{- with .Values.controller.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.controller.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.controller.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
       containers:
       - name: controller
         image: {{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}

--- a/system/kube-system/vendor/metallb/templates/controller.yaml
+++ b/system/kube-system/vendor/metallb/templates/controller.yaml
@@ -53,6 +53,11 @@ spec:
         args:
         - --port=7472
         - --config={{ template "metallb.configMapName" . }}
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         ports:
         - name: monitoring
           containerPort: 7472

--- a/system/kube-system/vendor/metallb/templates/rbac.yaml
+++ b/system/kube-system/vendor/metallb/templates/rbac.yaml
@@ -1,0 +1,146 @@
+{{- if .Values.rbac.create -}}
+
+# Roles
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "metallb.fullname" . }}:controller
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+rules:
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list", "watch", "update"]
+- apiGroups: [""]
+  resources: ["services/status"]
+  verbs: ["update"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "metallb.fullname" . }}:speaker
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+rules:
+- apiGroups: [""]
+  resources: ["services", "endpoints", "nodes"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "metallb.fullname" . }}-leader-election
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+rules:
+- apiGroups: [""]
+  resources: ["endpoints"]
+  resourceNames: ["metallb-speaker"]
+  verbs: ["get", "update"]
+- apiGroups: [""]
+  resources: ["endpoints"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "metallb.fullname" . }}-config-watcher
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create"]
+---
+
+## Role bindings
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "metallb.fullname" . }}:controller
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "metallb.controllerServiceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "metallb.fullname" . }}:controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "metallb.fullname" . }}:speaker
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "metallb.speakerServiceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "metallb.fullname" . }}:speaker
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "metallb.fullname" . }}-config-watcher
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "metallb.controllerServiceAccountName" . }}
+- kind: ServiceAccount
+  name: {{ template "metallb.speakerServiceAccountName" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "metallb.fullname" . }}-config-watcher
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "metallb.fullname" . }}-leader-election
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "metallb.speakerServiceAccountName" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "metallb.fullname" . }}-leader-election
+{{- end -}}

--- a/system/kube-system/vendor/metallb/templates/service-accounts.yaml
+++ b/system/kube-system/vendor/metallb/templates/service-accounts.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.serviceAccounts.controller.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "metallb.controllerServiceAccountName" . }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+{{- end }}
+---
+{{- if .Values.serviceAccounts.speaker.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "metallb.speakerServiceAccountName" . }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+{{- end }}

--- a/system/kube-system/vendor/metallb/templates/speaker.yaml
+++ b/system/kube-system/vendor/metallb/templates/speaker.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1beta2
+kind: DaemonSet
+metadata:
+  name: {{ template "metallb.fullname" . }}-speaker
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+    component: speaker
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "metallb.name" . }}
+      component: speaker
+      release: {{ .Release.Name | quote }}
+  template:
+    metadata:
+      labels:
+        heritage: {{ .Release.Service | quote }}
+        release: {{ .Release.Name | quote }}
+        chart: {{ template "metallb.chart" . }}
+        app: {{ template "metallb.name" . }}
+        component: speaker
+{{- if .Values.prometheus.scrapeAnnotations }}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "7472"
+{{- end }}
+    spec:
+      serviceAccountName: {{ template "metallb.speakerServiceAccountName" . }}
+      terminationGracePeriodSeconds: 0
+      hostNetwork: true
+      containers:
+      - name: speaker
+        image: {{ .Values.speaker.image.repository }}:{{ .Values.speaker.image.tag }}
+        imagePullPolicy: {{ .Values.speaker.image.pullPolicy }}
+        args:
+        - --port=7472
+        - --config={{ template "metallb.configMapName" . }}
+        env:
+        - name: METALLB_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        ports:
+        - name: monitoring
+          containerPort: 7472
+        resources:
+{{ toYaml .Values.speaker.resources | indent 10 }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - all
+            add:
+            - net_raw

--- a/system/kube-system/vendor/metallb/templates/speaker.yaml
+++ b/system/kube-system/vendor/metallb/templates/speaker.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: {{ template "metallb.fullname" . }}-speaker

--- a/system/kube-system/vendor/metallb/templates/speaker.yaml
+++ b/system/kube-system/vendor/metallb/templates/speaker.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
   name: {{ template "metallb.fullname" . }}-speaker
@@ -56,3 +56,15 @@ spec:
             - all
             add:
             - net_raw
+    {{- with .Values.speaker.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.speaker.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.speaker.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/system/kube-system/vendor/metallb/templates/speaker.yaml
+++ b/system/kube-system/vendor/metallb/templates/speaker.yaml
@@ -39,6 +39,10 @@ spec:
         - --port=7472
         - --config={{ template "metallb.configMapName" . }}
         env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: METALLB_NODE_NAME
           valueFrom:
             fieldRef:

--- a/system/kube-system/vendor/metallb/values.yaml
+++ b/system/kube-system/vendor/metallb/values.yaml
@@ -1,0 +1,73 @@
+# Default values for metallb.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# To configure MetalLB, you must specify ONE of the following two
+# options.
+
+# existingConfigMap specifies the name of an externally-defined
+# ConfigMap to use as the configuration. Helm will not manage the
+# contents of this ConfigMap, it is your responsibility to create it.
+existingConfigMap: metallb-config
+
+# configInline specifies MetalLB's configuration directly, in yaml
+# format. When configInline is used, Helm manages MetalLB's
+# configuration ConfigMap as part of the release, and
+# existingConfigMap is ignored.
+#
+# Refer to https://metallb.universe.tf/configuration/ for
+# available options.
+configInline:
+
+rbac:
+  # create specifies whether to install and use RBAC rules.
+  create: true
+
+prometheus:
+  # scrape annotations specifies whether to add Prometheus metric
+  # auto-collection annotations to pods. See
+  # https://github.com/prometheus/prometheus/blob/release-2.1/documentation/examples/prometheus-kubernetes.yml
+  # for a corresponding Prometheus configuration. Alternatively, you
+  # may want to use the Prometheus Operator
+  # (https://github.com/coreos/prometheus-operator) for more powerful
+  # monitoring configuration. If you use the Prometheus operator, this
+  # can be left at false.
+  scrapeAnnotations: false
+
+serviceAccounts:
+  controller:
+    # Specifies whether a ServiceAccount should be created
+    create: true
+    # The name of the ServiceAccount to use.  If not set and create is
+    # true, a name is generated using the fullname template
+    name:
+  speaker:
+    # Specifies whether a ServiceAccount should be created
+    create: true
+    # The name of the ServiceAccount to use.  If not set and create is
+    # true, a name is generated using the fullname template
+    name:
+
+# controller contains configuration specific to the MetalLB cluster
+# controller.
+controller:
+  image:
+    repository: metallb/controller
+    tag: v0.6.2
+    pullPolicy: IfNotPresent
+  resources:
+    # limits:
+      # cpu: 100m
+      # memory: 100Mi
+
+# speaker contains configuration specific to the MetalLB speaker
+# daemonset.
+speaker:
+  image:
+    repository: metallb/speaker
+    tag: v0.6.2
+    pullPolicy: IfNotPresent
+  resources:
+    # limits:
+      # cpu: 100m
+      # memory: 100Mi

--- a/system/kube-system/vendor/metallb/values.yaml
+++ b/system/kube-system/vendor/metallb/values.yaml
@@ -40,13 +40,13 @@ serviceAccounts:
     create: true
     # The name of the ServiceAccount to use.  If not set and create is
     # true, a name is generated using the fullname template
-    name:
+    name: ""
   speaker:
     # Specifies whether a ServiceAccount should be created
     create: true
     # The name of the ServiceAccount to use.  If not set and create is
     # true, a name is generated using the fullname template
-    name:
+    name: ""
 
 # controller contains configuration specific to the MetalLB cluster
 # controller.
@@ -55,10 +55,13 @@ controller:
     repository: metallb/controller
     tag: v0.6.2
     pullPolicy: IfNotPresent
-  resources:
+  resources: {}
     # limits:
       # cpu: 100m
       # memory: 100Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 # speaker contains configuration specific to the MetalLB speaker
 # daemonset.
@@ -67,7 +70,10 @@ speaker:
     repository: metallb/speaker
     tag: v0.6.2
     pullPolicy: IfNotPresent
-  resources:
+  resources: {}
     # limits:
       # cpu: 100m
       # memory: 100Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}

--- a/system/kube-system/vendor/metallb/values.yaml
+++ b/system/kube-system/vendor/metallb/values.yaml
@@ -17,7 +17,7 @@ existingConfigMap: metallb-config
 #
 # Refer to https://metallb.universe.tf/configuration/ for
 # available options.
-configInline:
+configInline: {}
 
 rbac:
   # create specifies whether to install and use RBAC rules.
@@ -53,7 +53,7 @@ serviceAccounts:
 controller:
   image:
     repository: metallb/controller
-    tag: v0.6.2
+    tag: 0.7.3
     pullPolicy: IfNotPresent
   resources: {}
     # limits:
@@ -68,7 +68,7 @@ controller:
 speaker:
   image:
     repository: metallb/speaker
-    tag: v0.6.2
+    tag: 0.7.3
     pullPolicy: IfNotPresent
   resources: {}
     # limits:


### PR DESCRIPTION
Just so we're on the same page @SchwarzM: This is the chart currently deployed to qa.
Based on [stable/metallb helm chart](https://github.com/helm/charts/tree/master/stable/metallb) and adjusted for k8s 1.7. We should be able to switch back to the official one once, we're on k8s1.8+ and don't need to do [this](https://github.com/sapcc/helm-charts/commit/59a74aac24659e38d052bb076a3dd21c0ac26f76) anymore.
Values are in $secrets.git/qa-de-1/values/kube-system.yaml