### PR TITLE
dial up the swift-object-expirer concurrency

### DIFF
--- a/openstack/swift/templates/etc/_object-expirer.conf.tpl
+++ b/openstack/swift/templates/etc/_object-expirer.conf.tpl
@@ -6,7 +6,7 @@ log_level = INFO
 {{- end }}
 
 [object-expirer]
-concurrency = 2
+concurrency = {{ .Values.object_expirer_concurrency }}
 # auto_create_account_prefix = .
 
 [pipeline:main]

--- a/openstack/swift/values.yaml
+++ b/openstack/swift/values.yaml
@@ -44,6 +44,7 @@ health_statsd: true
 probing: true
 
 # Object Server Configurations
+object_expirer_concurrency: 5
 object_replicator_concurrency: 2
 object_replicator_workers: 0           # Availably since Rocky
 object_updater_concurrency: 2


### PR DESCRIPTION
We're seeing backup replication failures with source = eu-de-1 because expired objects are not cleaned up from the object listing in a timely manner.