### PR TITLE
Change liveness of pg_bouncer

### DIFF
--- a/common/postgresql/templates/pgbouncer-deployment.yaml
+++ b/common/postgresql/templates/pgbouncer-deployment.yaml
@@ -68,8 +68,7 @@ spec:
             failureThreshold: 5
           readinessProbe:
             exec:
-              command:
-              - pgbouncer-k8s-readiness
+              command: ["pgbouncer-k8s-readiness", "&&", "test (ps -p 1 -T | wc -l) -lt 100000"]
             initialDelaySeconds: 3
             periodSeconds: 1
             failureThreshold: 5


### PR DESCRIPTION
PG_Bouncer currently leaks threads and while the root cause is not found / fixed we need 
to prevent it from locking up nodes.