### PR TITLE
[octobus] regional service user

### DIFF
--- a/openstack/octobus/templates/seeds.yaml
+++ b/openstack/octobus/templates/seeds.yaml
@@ -39,6 +39,8 @@ spec:
 
     groups:
     - name: CCADMIN_OCTOBUS-ADM
+      users:
+      - {{ .Values.technicalUserPerRegion }}
       roles:
       - project: octobus
         role: admin

--- a/openstack/octobus/templates/seeds.yaml
+++ b/openstack/octobus/templates/seeds.yaml
@@ -36,11 +36,34 @@ spec:
       #  type: PRIMARY
       #  ttl: 7200
       #  description: Octobus productive domain.
+      roles:
+      - user: {{ .Values.technicalUserPerRegion }}
+        role: admin
+      - user: {{ .Values.technicalUserPerRegion }}
+        role: compute_admin
+      - user: {{ .Values.technicalUserPerRegion }}
+        role: dns_zonemaster
+      - user: {{ .Values.technicalUserPerRegion }}
+        role: keymanager_admin
+      - user: {{ .Values.technicalUserPerRegion }}
+        role: kubernetes_admin
+      - user: {{ .Values.technicalUserPerRegion }}
+        role: member
+      - user: {{ .Values.technicalUserPerRegion }}
+        role: monitoring_viewer
+      - user: {{ .Values.technicalUserPerRegion }}
+        role: network_admin
+      - user: {{ .Values.technicalUserPerRegion }}
+        role: resource_admin
+      - user: {{ .Values.technicalUserPerRegion }}
+        role: sharedfilesystem_admin
+      - user: {{ .Values.technicalUserPerRegion }}
+        role: swiftoperator
+      - user: {{ .Values.technicalUserPerRegion }}
+        role: volume_admin
 
     groups:
     - name: CCADMIN_OCTOBUS-ADM
-      users:
-      - {{ .Values.technicalUserPerRegion }}
       roles:
       - project: octobus
         role: admin

--- a/openstack/octobus/templates/seeds.yaml
+++ b/openstack/octobus/templates/seeds.yaml
@@ -47,7 +47,7 @@ spec:
       - project: octobus
         role: compute_admin
       - project: octobus
-        role: dns_webmaster
+        role: dns_zonemaster
       - project: octobus
         role: keymanager_admin
       - project: octobus


### PR DESCRIPTION
- [Roles definition](https://github.com/businessbean/helm-charts/blob/5f849a48a98f6593921a6eccefef0fa8fd2736b7/openstack/octobus/templates/seeds.yaml#L39) for a regional service user based on CAM technical users
- use dns_zonemaster instead of dns_webmaster for self service sub domain management