### PR TITLE
Rework alertmanager routing

### DIFF
--- a/global/prometheus-alertmanager/templates/config.yaml
+++ b/global/prometheus-alertmanager/templates/config.yaml
@@ -93,7 +93,6 @@ data:
         - channel: "{{.CommonLabels.tier}}-{{.CommonLabels.severity}}"
           api_url: {{ default "MISSING" .Values.slack.webhook_url | quote }}
           username: "Kubernetes Control Plane"
-          channel: "#dev-null"
           title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
           title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
           text: {{"'{{template \"slack.sapcc.text\" . }}'"}}
@@ -106,7 +105,6 @@ data:
         - channel: "{{.CommonLabels.tier}}-{{.CommonLabels.service}}"
           api_url: {{ default "MISSING" .Values.slack.webhook_url | quote }}
           username: "Kubernetes Control Plane"
-          channel: "#dev-null"
           title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
           title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
           text: {{"'{{template \"slack.sapcc.text\" . }}'"}}

--- a/global/prometheus-alertmanager/templates/config.yaml
+++ b/global/prometheus-alertmanager/templates/config.yaml
@@ -33,60 +33,45 @@ data:
       receiver: dev-null
 
       routes:
-
-      # staging, lab alerts > /dev/null
       - receiver: dev-null
         continue: false
         match_re:
-<<<<<<< HEAD
-          region: staging|k-staging|s-staging|lab|i-eu-de-2
-
-      # routing per tier to <tier>-{info, warning, critical}
-=======
           region: .*staging|lab
 
-      # routing per tier to <tier>-{info, warning, critical} channel
->>>>>>> page based on alert name
-      {{- range $tier := .Values.tiers }}
-      - receiver: {{ $tier }}-info
-        continue: true
+      - receiver: slack_by_tier_and_severity
         match_re:
-          tier: {{ $tier }}
-        routes:
-        - receiver: '{{ $tier }}-warning'
-          continue: true
-          match:
-            severity: warning
-        - receiver: '{{ $tier }}-critical'
-          continue: true
-          match:
-            severity: critical
-      {{- end }}
+          tier: openstack|kubernetes|kubernikus|baremetal
+          severity: info|warning|critical
 
-      # routing per service to openstack-<service> channel
-      {{- range $service := .Values.openstack_services }}
-      - receiver: openstack-{{ $service }}
-        continue: true
+      - receiver: slack_by_tier_and_service
         match_re:
-          service: {{ $service }}
           tier: openstack
-      {{- end }}
+          severity: info|warning|critical
+          service: arc|backup|barbican|cinder|designate|elektra|elk|ironic|keystone|limes|lyra|maia|manila|neutron|nova|swift
 
-      # staging, qa-de-1, lab, scaleout, internet cluster alerts > /dev/null
-      - receiver: dev-null
-        continue: false
+      - receiver: pagerduty_baremetal
         match_re:
-          region: .*staging|.*qa-de-1|lab|s-.*|i-.*
+          severity: critical
+          region: ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
+          tier: baremetal
 
-      # routing to pagerduty channels
-      {{- range $pd := .Values.pagerduty }}
-      - receiver: pagerduty-{{ $pd.name }}
-        continue: false
-        {{- if $pd.alerts }}
+      - receiver: pagerduty_hypervisor
         match_re:
-          alertname: {{ join "|" $pd.alerts -}}
-        {{- end }}
-      {{- end }}
+          severity: critical
+          region: [^.*qa-de-1]
+          service: vcenter
+
+      - receiver: pagerduty
+        match_re:
+          severity: critical
+          region: ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
+          tier: openstack|kubernetes
+
+      - receiver: pagerduty
+        match_re:
+          severity: warning
+          region: ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
+          alertname: KubernetesNodeBond.*|KubernetesNodeNotReady
 
     receivers:
     - name: dev-null
@@ -101,57 +86,85 @@ data:
         icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
         send_resolved: true
 
-    # <tier>-{info, warning, critical} receiver
-    {{- range $tier := .Values.tiers }}
-    {{- range $severtity := tuple "info" "warning" "critical" }}
-    - name: {{ $tier }}-{{ $severtity }}
+    - name: slack_by_tier_and_severity
       slack_configs:
-      - api_url: {{ default "MISSING" $.Values.slack.webhook_url | quote }}
-        username: "{{ $tier | title }} Control Plane"
-        channel: "#{{ $tier }}-{{ $severtity }}"
-        title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
-        title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
-        text: {{"'{{template \"slack.sapcc.text\" . }}'"}}
-        pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
-        icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
-        send_resolved: true
-    {{- end }}
-    {{- end }}
+        - channel: "{{.CommonLabels.tier}}-{{.CommonLabels.severity}}"
+          api_url: {{ default "MISSING" .Values.slack.webhook_url | quote }}
+          username: "Kubernetes Control Plane"
+          channel: "#dev-null"
+          title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
+          title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
+          text: {{"'{{template \"slack.sapcc.text\" . }}'"}}
+          pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
+          icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
+          send_resolved: true
 
-    # openstack-<service> receivers
-    {{- range .Values.openstack_services }}
-    - name: openstack-{{ . }}
+    - name: slack_by_tier_and_service
       slack_configs:
-      - api_url: {{ default "MISSING" $.Values.slack.webhook_url | quote }}
-        username: "OpenStack Control Plane"
-        channel: "#openstack-{{ . }}"
-        title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
-        title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
-        text: {{"'{{template \"slack.sapcc.text\" . }}'"}}
-        pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
-        icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
-        send_resolved: true
-    {{- end }}
+        - channel: "{{.CommonLabels.tier}}-{{.CommonLabels.service}}"
+          api_url: {{ default "MISSING" .Values.slack.webhook_url | quote }}
+          username: "Kubernetes Control Plane"
+          channel: "#dev-null"
+          title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
+          title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
+          text: {{"'{{template \"slack.sapcc.text\" . }}'"}}
+          pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
+          icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
+          send_resolved: true
 
-    {{- range $pd := .Values.pagerduty_services }}
-    - name: pagerduty-{{ $pd.name }}
+    - name: pagerduty
       pagerduty_configs:
-      - service_key: {{ default "" $pd.service_key }}
-        description: {{"'{{ template \"pagerduty.sapcc.description\" . }}'"}}
-        component: {{"'{{template \"pagerduty.sapcc.tier\" . }}'"}}
-        group: {{"'{{template \"pagerduty.sapcc.service\" . }}'"}}
-        details:
-          Details: {{"'{{template \"pagerduty.sapcc.details\" . }}'"}}
-          Region: {{"'{{template \"pagerduty.sapcc.region\" . }}'"}}
-          Tier: {{"'{{template \"pagerduty.sapcc.tier\" . }}'"}}
-          Service: {{"'{{template \"pagerduty.sapcc.service\" . }}'"}}
-          Context: {{"'{{template \"pagerduty.sapcc.context\" . }}'"}}
-          Prometheus: {{"'{{template \"pagerduty.sapcc.prometheus\" . }}'"}}
-          Dashboard: {{"'{{template \"pagerduty.sapcc.dashboard\" . }}'"}}
-          Sentry: {{"'{{template \"pagerduty.sapcc.sentry\" . }}'"}}
-          Playbook: {{"'{{template \"pagerduty.sapcc.playbook\" . }}'"}}
-          firing: {{"'{{ template \"pagerduty.sapcc.firing\" . }}'"}}
-    {{- end }}
+        - service_key: {{ default "MISSING" .Values.pagerduty.default.service_key | quote }}
+          description: {{"'{{ template \"pagerduty.sapcc.description\" . }}'"}}
+          component: {{"'{{template \"pagerduty.sapcc.tier\" . }}'"}}
+          group: {{"'{{template \"pagerduty.sapcc.service\" . }}'"}}
+          details:
+            Details: {{"'{{template \"pagerduty.sapcc.details\" . }}'"}}
+            Region: {{"'{{template \"pagerduty.sapcc.region\" . }}'"}}
+            Tier: {{"'{{template \"pagerduty.sapcc.tier\" . }}'"}}
+            Service: {{"'{{template \"pagerduty.sapcc.service\" . }}'"}}
+            Context: {{"'{{template \"pagerduty.sapcc.context\" . }}'"}}
+            Prometheus: {{"'{{template \"pagerduty.sapcc.prometheus\" . }}'"}}
+            Dashboard: {{"'{{template \"pagerduty.sapcc.dashboard\" . }}'"}}
+            Sentry: {{"'{{template \"pagerduty.sapcc.sentry\" . }}'"}}
+            Playbook: {{"'{{template \"pagerduty.sapcc.playbook\" . }}'"}}
+            firing: {{"'{{ template \"pagerduty.sapcc.firing\" . }}'"}}
+
+    - name: pagerduty_baremetal
+      pagerduty_configs:
+        - service_key: {{ default "MISSING" .Values.pagerduty.baremetal.service_key | quote }}
+          description: {{"'{{ template \"pagerduty.sapcc.description\" . }}'"}}
+          component: {{"'{{template \"pagerduty.sapcc.tier\" . }}'"}}
+          group: {{"'{{template \"pagerduty.sapcc.service\" . }}'"}}
+          details:
+            Details: {{"'{{template \"pagerduty.sapcc.details\" . }}'"}}
+            Region: {{"'{{template \"pagerduty.sapcc.region\" . }}'"}}
+            Tier: {{"'{{template \"pagerduty.sapcc.tier\" . }}'"}}
+            Service: {{"'{{template \"pagerduty.sapcc.service\" . }}'"}}
+            Context: {{"'{{template \"pagerduty.sapcc.context\" . }}'"}}
+            Prometheus: {{"'{{template \"pagerduty.sapcc.prometheus\" . }}'"}}
+            Dashboard: {{"'{{template \"pagerduty.sapcc.dashboard\" . }}'"}}
+            Sentry: {{"'{{template \"pagerduty.sapcc.sentry\" . }}'"}}
+            Playbook: {{"'{{template \"pagerduty.sapcc.playbook\" . }}'"}}
+            firing: {{"'{{ template \"pagerduty.sapcc.firing\" . }}'"}}
+
+    - name: pagerduty_hypervisor
+      pagerduty_configs:
+        - service_key: {{ default "MISSING" .Values.pagerduty.hypervisor.service_key | quote }}
+          description: {{"'{{ template \"pagerduty.sapcc.description\" . }}'"}}
+          component: {{"'{{template \"pagerduty.sapcc.tier\" . }}'"}}
+          group: {{"'{{template \"pagerduty.sapcc.service\" . }}'"}}
+          details:
+            Details: {{"'{{template \"pagerduty.sapcc.details\" . }}'"}}
+            Region: {{"'{{template \"pagerduty.sapcc.region\" . }}'"}}
+            Tier: {{"'{{template \"pagerduty.sapcc.tier\" . }}'"}}
+            Service: {{"'{{template \"pagerduty.sapcc.service\" . }}'"}}
+            Context: {{"'{{template \"pagerduty.sapcc.context\" . }}'"}}
+            Prometheus: {{"'{{template \"pagerduty.sapcc.prometheus\" . }}'"}}
+            Dashboard: {{"'{{template \"pagerduty.sapcc.dashboard\" . }}'"}}
+            Sentry: {{"'{{template \"pagerduty.sapcc.sentry\" . }}'"}}
+            Playbook: {{"'{{template \"pagerduty.sapcc.playbook\" . }}'"}}
+            firing: {{"'{{ template \"pagerduty.sapcc.firing\" . }}'"}}
 
   {{- $files := .Files }}
   {{ range tuple "slack.tmpl" "pagerduty.tmpl" }}

--- a/global/prometheus-alertmanager/templates/config.yaml
+++ b/global/prometheus-alertmanager/templates/config.yaml
@@ -33,12 +33,20 @@ data:
       receiver: dev-null
 
       routes:
+
+      # staging, lab alerts > /dev/null
       - receiver: dev-null
         continue: false
         match_re:
+<<<<<<< HEAD
           region: staging|k-staging|s-staging|lab|i-eu-de-2
 
       # routing per tier to <tier>-{info, warning, critical}
+=======
+          region: .*staging|lab
+
+      # routing per tier to <tier>-{info, warning, critical} channel
+>>>>>>> page based on alert name
       {{- range $tier := .Values.tiers }}
       - receiver: {{ $tier }}-info
         continue: true
@@ -54,7 +62,8 @@ data:
           match:
             severity: critical
       {{- end }}
-      # routing per service to openstack-<service>
+
+      # routing per service to openstack-<service> channel
       {{- range $service := .Values.openstack_services }}
       - receiver: openstack-{{ $service }}
         continue: true
@@ -62,32 +71,21 @@ data:
           service: {{ $service }}
           tier: openstack
       {{- end }}
-      # Don’t page for qa-de-1
+
+      # staging, qa-de-1, lab, scaleout, internet cluster alerts > /dev/null
       - receiver: dev-null
         continue: false
         match_re:
-          region: qa-de-1|k-qa-de-1|s-qa-de-1|lab
+          region: .*staging|.*qa-de-1|lab|s-.*|i-.*
 
-      # block kubernikus and interconnect alerts away from pagerduty
-      - receiver: dev-null
-        continue: false
-        match:
-          tier: kubernikus
-      - receiver: dev-null
-        continue: false
-        match:
-          service: interconnect
-
-      {{- range $pd := .Values.pagerduty_services }}
+      # routing to pagerduty channels
+      {{- range $pd := .Values.pagerduty }}
       - receiver: pagerduty-{{ $pd.name }}
         continue: false
-        match:
-          severity: critical
-          {{- if $pd.match }}
-          {{- range $key, $value := $pd.match }}
-          {{ $key }}: {{ $value }}
-          {{- end }}
-          {{- end }}
+        {{- if $pd.alerts }}
+        match_re:
+          alertname: {{ join "|" $pd.alerts -}}
+        {{- end }}
       {{- end }}
 
     receivers:

--- a/global/prometheus-alertmanager/templates/config.yaml
+++ b/global/prometheus-alertmanager/templates/config.yaml
@@ -90,7 +90,7 @@ data:
 
     - name: slack_by_tier_and_severity
       slack_configs:
-        - channel: "{{.CommonLabels.tier}}-{{.CommonLabels.severity}}"
+        - channel: {{"{{ .CommonLabels.tier }}"}}-{{"{{ .CommonLabels.severity }}"}}
           api_url: {{ default "MISSING" .Values.slack.webhook_url | quote }}
           username: "Kubernetes Control Plane"
           title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
@@ -102,7 +102,7 @@ data:
 
     - name: slack_by_tier_and_service
       slack_configs:
-        - channel: "{{.CommonLabels.tier}}-{{.CommonLabels.service}}"
+        - channel: {{"{{ .CommonLabels.tier }}"}}-{{"{{ .CommonLabels.service }}"}}
           api_url: {{ default "MISSING" .Values.slack.webhook_url | quote }}
           username: "Kubernetes Control Plane"
           title: {{"'{{template \"slack.sapcc.title\" . }}'"}}

--- a/global/prometheus-alertmanager/templates/config.yaml
+++ b/global/prometheus-alertmanager/templates/config.yaml
@@ -58,7 +58,7 @@ data:
       - receiver: pagerduty_hypervisor
         match_re:
           severity: critical
-          region: [^.*qa-de-1]
+          region: ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
           service: vcenter
 
       - receiver: pagerduty

--- a/global/prometheus-alertmanager/templates/config.yaml
+++ b/global/prometheus-alertmanager/templates/config.yaml
@@ -50,12 +50,14 @@ data:
           service: arc|backup|barbican|cinder|designate|elektra|elk|ironic|keystone|limes|lyra|maia|manila|neutron|nova|swift
 
       - receiver: pagerduty_baremetal
+        continue: false
         match_re:
           severity: critical
           region: ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
           tier: baremetal
 
       - receiver: pagerduty_hypervisor
+        continue: false
         match_re:
           severity: critical
           region: ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3

--- a/global/prometheus-alertmanager/values.yaml
+++ b/global/prometheus-alertmanager/values.yaml
@@ -53,17 +53,12 @@ openstack_services:
   - nova
   - swift
 
-# creates routing and channel for pagerduty
-# the order matters, as an alert is only send to the first matching pagerduty instance (matches by service, tier label)
-pagerduty_services:
+pagerduty:
   # name of the pagerduty receiver
   - name: pagerduty
     # pagerduty service key
     service_key: DEFINED-IN-SECRETS
-    # limit alerts to this receiver to the following labels
-    # `severity: critical` is always set
-    match:
-      # limit to alerts with this service label (optional)
-      service: SERVICE-TYPE
-      # limit to alerts with this tier label (optional)
-      tier: SERVICE-TIER
+    # limit alerts to this receiver to the following names. regex possible.
+    alerts:
+      - KubernetesKubeletManyDown
+      - KubernetesNodeNetworkBond.*

--- a/global/prometheus-alertmanager/values.yaml
+++ b/global/prometheus-alertmanager/values.yaml
@@ -1,10 +1,15 @@
+global:
+  region: DEFINED-IN-SECRETS
+  domain: DEFINED-IN-SECRETS
+
 image:
   repository: prom/alertmanager
   tag: v0.15.2
 
-global:
-  region: DEFINED-IN-SECRETS
-  domain: DEFINED-IN-SECRETS
+configmap_reload:
+  image:
+    repository: jimmidyson/configmap-reload
+    tag: v0.2.2
 
 cluster:
   listen_address: DEFINED-IN-SECRETS
@@ -19,46 +24,15 @@ persistence:
   access_mode: ReadWriteMany
   size: 1Gi
 
-configmap_reload:
-  image:
-    repository: jimmidyson/configmap-reload
-    tag: v0.2.2
-
 slack:
   webhook_url: DEFINED-IN-SECRETS
 
-# creates <tier>-{info, warning, critical} routing and receivers
-tiers:
-  - kubernetes
-  - kubernikus
-  - openstack
-  - baremetal
-
-# creates openstack-<service> routing and receivers
-openstack_services:
-  - arc
-  - backup
-  - barbican
-  - cinder
-  - designate
-  - elektra
-  - elk
-  - ironic
-  - keystone
-  - limes
-  - lyra
-  - maia
-  - manila
-  - neutron
-  - nova
-  - swift
-
 pagerduty:
-  # name of the pagerduty receiver
-  - name: pagerduty
-    # pagerduty service key
+  default:
     service_key: DEFINED-IN-SECRETS
-    # limit alerts to this receiver to the following names. regex possible.
-    alerts:
-      - KubernetesKubeletManyDown
-      - KubernetesNodeNetworkBond.*
+
+  baremetal:
+    service_key: DEFINED-IN-SECRETS
+
+  hypervisor:
+    service_key: DEFINED-IN-SECRETS


### PR DESCRIPTION
**Do not merge**

Changes pagerduty alerts from `severity: critical` to a set of alertnames. Also allows regexes. 
Example: Only alert when many things are down
```
alerts:
  - .*ManyDown
```

As discussed - WDYT @BugRoger?

TODO before merging:
- [x] complete list of alert
- [x] adjust secrets/values