### PR TITLE
added kiosk mode (nginx sidecar) for digital signage displays

### DIFF
--- a/openstack/grafana-new/templates/_nginx.conf.tpl
+++ b/openstack/grafana-new/templates/_nginx.conf.tpl
@@ -1,0 +1,40 @@
+user  nginx;
+worker_processes  1;
+
+error_log  /dev/stdout warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /dev/stdout  main;
+    sendfile        on;
+    keepalive_timeout  65;
+
+    server {
+    	listen {{ .Values.nginx.port.public }} default_server;
+    
+    	server_name _;
+
+      location /public {
+        allow all;
+        proxy_pass http://127.0.0.1:{{ .Values.grafana.port.public }};
+      }
+
+      location ~ /(api|d) {
+        proxy_set_header Authorization "Basic {{ printf "%s:%s" .Values.grafana.local.user .Values.grafana.local.password | b64enc }}";
+        proxy_pass http://127.0.0.1:{{ .Values.grafana.port.public }};
+      }
+    }
+}

--- a/openstack/grafana-new/templates/grafana-deployment.yaml
+++ b/openstack/grafana-new/templates/grafana-deployment.yaml
@@ -47,3 +47,17 @@ spec:
               mountPath: /grafana-bin
             - name: grafana-etc
               mountPath: /grafana-etc
+{{- if .Values.nginx.enabled }}
+        - name: nginx
+          image: "{{ .Values.nginx.image }}:{{ .Values.nginx.image_version }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+            - name: grafana-etc
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+              readOnly: true
+          ports:
+            - name: http
+              containerPort: {{ .Values.nginx.port.public }}
+              protocol: TCP
+{{- end }}

--- a/openstack/grafana-new/templates/grafana-etc-configmap.yaml
+++ b/openstack/grafana-new/templates/grafana-etc-configmap.yaml
@@ -15,3 +15,5 @@ data:
 {{ include "grafana-new/templates/_ldap.toml.tpl" . | indent 4 }}
   create-session-table.sql: |
 {{ include "grafana-new/templates/_create-session-table.sql.tpl" . | indent 4 }}
+  nginx.conf: |
+{{ include "grafana-new/templates/_nginx.conf.tpl" . | indent 4 }}

--- a/openstack/grafana-new/templates/grafana-service.yaml
+++ b/openstack/grafana-new/templates/grafana-service.yaml
@@ -12,3 +12,8 @@ spec:
     component: grafana
   ports:
     - port: {{.Values.grafana.port.public}}
+      name: public
+{{- if .Values.nginx.enabled }}
+    - port: {{.Values.nginx.port.public}}
+      name: kiosk
+{{- end -}}

--- a/openstack/grafana-new/templates/nginx-ingress.yaml
+++ b/openstack/grafana-new/templates/nginx-ingress.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.nginx.enabled }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+
+metadata:
+  name: grafana-kiosk
+  annotations:
+    vice-president: {{ default false .Values.grafana.vice_president | quote }}
+spec:
+  tls:
+    - secretName: tls-grafana-kiosk
+      hosts: ["{{.Values.nginx.endpoint.host.public}}"]
+  rules:
+    - host: "{{.Values.nginx.endpoint.host.public}}"
+      http:
+        paths:
+        - path: /
+          backend:
+            serviceName: grafana
+            servicePort: {{.Values.nginx.endpoint.port.public}}
+{{- end }}

--- a/openstack/grafana-new/values.yaml
+++ b/openstack/grafana-new/values.yaml
@@ -95,3 +95,16 @@ grafana:
     tls_client_auth:
       enabled: true
       secret: "kube-system/ingress-cacrt"
+
+# For kiosk mode
+nginx:
+  enabled: false
+  image: nginx
+  image_version: 1.15-alpine
+  port:
+    public: '3001'
+  endpoint:
+    port:
+      public: '3001'
+    host:
+      public: '@/cc/secrets'


### PR DESCRIPTION
This allows (optional) deployment of a grafana sidecar that contains a nginx server, that allows authentication-less display of dashboards.

the new ingress can be used for digital signage displays.