### PR TITLE
[nova][neutron] Add vcenter-operator templates for respective services

### DIFF
--- a/openstack/neutron/templates/vct-dvs-agent-configmap.yaml
+++ b/openstack/neutron/templates/vct-dvs-agent-configmap.yaml
@@ -1,8 +1,8 @@
-{{- if .Capabilities.APIVersions.Has "vcenter-operator.stable.sap.cc/v1" }}
+{{- if and (.Capabilities.APIVersions.Has "vcenter-operator.stable.sap.cc/v1") (contains ",dvs" .Values.ml2_mechanismdrivers )}}
 apiVersion: vcenter-operator.stable.sap.cc/v1
 kind: VCenterTemplate
 metadata:
-  name: 'vcenter-cluster-neutron-ml2-vmware-configmap'
+  name: 'neutron-ml2-vmware-configmap'
   scope: 'cluster'
   jinja2_options:
     variable_start_string: '{='
@@ -19,8 +19,9 @@ template: |
   data:
     ml2-vmware.ini: |
       [DEFAULT]
+      # The agent binds only port with the same host
       host = nova-compute-{= name =}
-      backdoor_socket=/var/lib/neutron/eventlet_backdoor.socket
+      backdoor_socket = /var/lib/neutron/eventlet_backdoor.socket
 
       [securitygroup]
       firewall_driver = networking_dvs.plugins.ml2.drivers.mech_dvs.agent.dvs_firewall.DvsSecurityGroupsDriver

--- a/openstack/neutron/templates/vct-dvs-agent-deployment.yaml
+++ b/openstack/neutron/templates/vct-dvs-agent-deployment.yaml
@@ -1,0 +1,111 @@
+{{- if and (.Capabilities.APIVersions.Has "vcenter-operator.stable.sap.cc/v1") (contains ",dvs" .Values.ml2_mechanismdrivers )}}
+apiVersion: vcenter-operator.stable.sap.cc/v1
+kind: VCenterTemplate
+metadata:
+  name: 'neutron-dvs-agent-deployment'
+  scope: 'cluster'
+  jinja2_options:
+    variable_start_string: '{='
+    variable_end_string: '=}'
+template: |
+  apiVersion: extensions/v1beta1
+  kind: Deployment
+  metadata:
+    name: neutron-dvs-agent-{= name =}
+    labels:
+      system: openstack
+      type: backend
+      component: neutron
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 5
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 0
+        maxSurge: 1
+    selector:
+      matchLabels:
+          name: neutron-dvs-agent-{= name =}
+    template:
+      metadata:
+        labels:
+          application: neutron
+          component: agent
+          name: neutron-dvs-agent-{= name =}
+        annotations:
+          configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") . | sha256sum }}
+          prometheus.io/scrape: "true"
+          prometheus.io/port: "9102"
+      spec:
+        containers:
+        - name: neutron-dvs-agent
+          image: {{ default "hub.global.cloud.sap" .Values.global.imageRegistry }}/{{.Values.image_name}}:{{.Values.image_tag}}
+          imagePullPolicy: IfNotPresent
+          command: ["dumb-init"]
+          args: ["neutron-dvs-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/plugins/ml2/ml2-conf.ini", "--config-file", "/etc/neutron/plugins/ml2/ml2-vmware.ini"]
+          env:
+          - name: SENTRY_DSN
+            value: {{ .Values.sentry_dsn | quote }}
+          - name: STATSD_HOST
+            value: "localhost"
+          - name: STATSD_PORT
+            value: "9125"
+          - name: PYTHONWARNINGS
+            value: "ignore:Unverified HTTPS request"
+          - name: PGAPPNAME
+            value: neutron-dvs-agent-{= name =}
+          livenessProbe:
+            initialDelaySeconds: 300
+            periodSeconds: 5
+            exec:
+              command:
+              - bash
+              - -c
+              - "[ -f /tmp/neutron-dvs-agent.alive ] && [ $(($(date +%s) - $(date -r /tmp/neutron-dvs-agent.alive +%s))) -lt 300 ]"
+          volumeMounts:
+          - mountPath: /etc/neutron
+            name: etcneutron
+          - mountPath: /etc/neutron/neutron.conf
+            name: neutron-etc
+            subPath: neutron.conf
+            readOnly: true
+          - mountPath: /etc/neutron/api-paste.ini
+            name: neutron-etc
+            subPath: api-paste.ini
+            readOnly: true
+          - mountPath: /etc/neutron/policy.json
+            name: neutron-etc
+            subPath: neutron-policy.json
+            readOnly: true
+          - mountPath: /etc/neutron/logging.conf
+            name: neutron-etc
+            subPath: logging.conf
+            readOnly: true
+          - mountPath: /etc/neutron/plugins/ml2/ml2-conf.ini
+            name: neutron-etc
+            subPath: ml2-conf.ini
+            readOnly: true
+          - mountPath: /etc/neutron/plugins/ml2/ml2-vmware.ini
+            name: ml2-conf-vmware
+            subPath: ml2-vmware.ini
+            readOnly: true
+        - name: statsd
+          image: prom/statsd-exporter:v0.5.0
+          imagePullPolicy: IfNotPresent
+          ports:
+          - name: statsd
+            containerPort: 9125
+            protocol: UDP
+          - name: metrics
+            containerPort: 9102
+        volumes:
+        - name: etcneutron
+          emptyDir: {}
+        - name: neutron-etc
+          configMap:
+            name: neutron-etc
+        - name: ml2-conf-vmware
+          configMap:
+            name: neutron-ml2-vmware-{= name =}
+{{- end }}

--- a/openstack/nova/templates/hypervisors/hypervisors-vmware-deployment-vct.yaml
+++ b/openstack/nova/templates/hypervisors/hypervisors-vmware-deployment-vct.yaml
@@ -93,57 +93,6 @@ template: |
             name: nova-etc
             subPath: compute.filters
             readOnly: true
-        - name: neutron-dvs-agent
-          image: {{.Values.global.imageRegistry}}/{{.Values.global.image_namespace}}/loci-neutron:{{.Values.imageVersionNeutron | required "Please set nova.imageVersionNeutron or similar" }}
-          imagePullPolicy: IfNotPresent
-          command: ["dumb-init"]
-          args: ["neutron-dvs-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/plugins/ml2/ml2-conf.ini", "--config-file", "/etc/neutron/plugins/ml2/ml2-vmware.ini"]
-          env:
-          - name: SENTRY_DSN
-            value: {{ .Values.neutron.sentry_dsn | quote }}
-          - name: STATSD_HOST
-            value: "localhost"
-          - name: STATSD_PORT
-            value: "9125"
-          - name: PYTHONWARNINGS
-            value: "ignore:Unverified HTTPS request"
-          - name: PGAPPNAME
-            value: neutron-dvs-agent-{= name =}
-          livenessProbe:
-            initialDelaySeconds: 300
-            periodSeconds: 5
-            exec:
-              command:
-              - bash
-              - -c
-              - "[ -f /tmp/neutron-dvs-agent.alive ] && [ $(($(date +%s) - $(date -r /tmp/neutron-dvs-agent.alive +%s))) -lt 300 ]"
-          volumeMounts:
-          - mountPath: /etc/neutron
-            name: etcneutron
-          - mountPath: /etc/neutron/neutron.conf
-            name: neutron-etc
-            subPath: neutron.conf
-            readOnly: true
-          - mountPath: /etc/neutron/api-paste.ini
-            name: neutron-etc
-            subPath: api-paste.ini
-            readOnly: true
-          - mountPath: /etc/neutron/policy.json
-            name: neutron-etc
-            subPath: neutron-policy.json
-            readOnly: true
-          - mountPath: /etc/neutron/logging.conf
-            name: neutron-etc
-            subPath: logging.conf
-            readOnly: true
-          - mountPath: /etc/neutron/plugins/ml2/ml2-conf.ini
-            name: neutron-etc
-            subPath: ml2-conf.ini
-            readOnly: true
-          - mountPath: /etc/neutron/plugins/ml2/ml2-vmware.ini
-            name: ml2-conf-vmware
-            subPath: ml2-vmware.ini
-            readOnly: true
         - name: statsd
           image: prom/statsd-exporter:v0.5.0
           imagePullPolicy: IfNotPresent
@@ -162,12 +111,4 @@ template: |
         - name: hypervisor-config
           configMap:
             name: nova-compute-vmware-{= name =}
-        - name: etcneutron
-          emptyDir: {}
-        - name: neutron-etc
-          configMap:
-            name: neutron-etc
-        - name: ml2-conf-vmware
-          configMap:
-            name: neutron-ml2-vmware-{= name =}
 {{- end }}


### PR DESCRIPTION
I would like to move the neutron-dvs-agent and the nova-compute-agent to each their own deployment triggered out of the respective service charts.

Case in point is, that we deploy now the services in separate charts, leading to the issue that a deployment of either nova, or neutron might cause changes to the configuration of either the nova-compute agent or the neutron dvs-agent respectively, which might require a restart of either agent.

With separate template, this can simply be done by a checksum of the template:
(E.g. https://github.com/sapcc/helm-charts/compare/vct_nova_neutron?expand=1#diff-34b226228729bdfa2b5c1985a95265dbR37)


