### PR TITLE
Manila policy: restrict quota updates to Limes user

### DIFF
--- a/openstack/manila/templates/etc/_manila-policy.json.tpl
+++ b/openstack/manila/templates/etc/_manila-policy.json.tpl
@@ -1,5 +1,6 @@
 {
   "context_is_cloud_admin":  "role:cloud_sharedfilesystem_admin",
+  "context_is_quota_admin":  "role:resource_service",
   "context_is_admin":  "rule:context_is_cloud_admin",
   "owner": "project_id:%(project_id)s",
   "member": "role:member and rule:owner",
@@ -12,12 +13,12 @@
 
   "availability_zone:index": "rule:context_is_viewer",
 
-  "quota_set:update": "rule:context_is_admin",
-  "quota_set:show": "rule:context_is_viewer",
-  "quota_set:delete": "rule:context_is_admin",
+  "quota_set:update": "rule:context_is_quota_admin",
+  "quota_set:show": "rule:context_is_viewer or rule:context_is_quota_admin",
+  "quota_set:delete": "rule:context_is_quota_admin",
 
-  "quota_class_set:show": "rule:context_is_viewer",
-  "quota_class_set:update": "rule:context_is_admin",
+  "quota_class_set:show": "rule:context_is_viewer or rule:context_is_quota_admin",
+  "quota_class_set:update": "rule:context_is_quota_admin",
 
   "service:index": "rule:context_is_admin",
   "service:update": "rule:context_is_admin",


### PR DESCRIPTION
The "resource_service" role is designed to *only ever* be assigned to the Limes user, to ensure that backend quotas are always consistent with the Limes database. The role is created by the Limes seed and already exists in all regions, so this can be deployed immediately.

**Please roll this out with priority, until early December.** We have a lot of cases of `usage > quota` that are most likely caused by cloud admins messing around with the quotas manually. Up until now, this was only slightly annoying. But starting in January, when we change our billing model to allow quota bursting, `usage > quota` is going to cost actual money. Therefore we need to ensure that this does not happen inadvertently anymore. If you have any concerns, please address them to me or @reimannf.