### PR TITLE
Designate policy: restrict quota updates to Limes user

### DIFF
--- a/openstack/designate/templates/etc/_designate-policy.json.tpl
+++ b/openstack/designate/templates/etc/_designate-policy.json.tpl
@@ -1,5 +1,6 @@
 {
     "context_is_cloud_admin": "role:cloud_dns_admin",
+    "context_is_quota_admin": "role:resource_service",
     "admin": "rule:context_is_cloud_admin or is_admin:True",
     "primary_zone": "target.zone_type:SECONDARY",
     "owner": "tenant:%(tenant_id)s",
@@ -26,10 +27,10 @@
     "edit_managed_records" : "rule:admin",
     "use_low_ttl": "rule:admin",
 
-    "get_quotas": "rule:context_is_viewer",
-    "get_quota": "rule:context_is_viewer",
-    "set_quota": "rule:admin",
-    "reset_quotas": "rule:admin",
+    "get_quotas": "rule:context_is_viewer or rule:context_is_quota_admin",
+    "get_quota": "rule:context_is_viewer or rule:context_is_quota_admin",
+    "set_quota": "rule:context_is_quota_admin",
+    "reset_quotas": "rule:context_is_quota_admin",
     "create_tld": "rule:admin",
     "find_tlds": "rule:admin",
     "get_tld": "rule:admin",


### PR DESCRIPTION
The "resource_service" role is designed to *only ever* be assigned to the Limes user, to ensure that backend quotas are always consistent with the Limes database. The role is created by the Limes seed and already exists in all regions, so this can be deployed immediately.

**Please roll this out with priority, until early December.** We have a lot of cases of `usage > quota` that are most likely caused by cloud admins messing around with the quotas manually. Up until now, this was only slightly annoying. But starting in January, when we change our billing model to allow quota bursting, `usage > quota` is going to cost actual money. Therefore we need to ensure that this does not happen inadvertently anymore. If you have any concerns, please address them to me or @reimannf.
