### PR TITLE
Neutron policy: restrict quota updates to Limes user

### DIFF
--- a/openstack/neutron/templates/etc/_neutron-policy.json.tpl
+++ b/openstack/neutron/templates/etc/_neutron-policy.json.tpl
@@ -1,5 +1,6 @@
 {
     "context_is_cloud_admin":  "role:cloud_network_admin",
+    "context_is_quota_admin":  "role:resource_service",
     "context_is_admin":  "rule:context_is_cloud_admin",
     "owner": "tenant_id:%(tenant_id)s",
     "member": "role:member and rule:owner",
@@ -31,6 +32,11 @@
     "default": "rule:context_is_editor or rule:shared",
     "default_viewer": "rule:context_is_viewer or rule:shared",
     "default_network_viewer": "rule:context_is_network_viewer or rule:shared",
+
+    "get_quota": "rule:context_is_viewer or rule:context_is_quota_admin",
+    "create_quota": "rule:context_is_quota_admin",
+    "update_quota": "rule:context_is_quota_admin",
+    "delete_quota": "rule:context_is_quota_admin",
 
     "create_subnet": "rule:context_is_admin or (rule:network_admin and rule:network_owner and rule:dhcp_enabled)",
     "create_subnet:segment_id": "rule:context_is_admin",


### PR DESCRIPTION
The "resource_service" role is designed to *only ever* be assigned to the Limes user, to ensure that backend quotas are always consistent with the Limes database. The role is created by the Limes seed and already exists in all regions, so this can be deployed immediately.

**Please roll this out with priority, until early December.** We have a lot of cases of `usage > quota` that are most likely caused by cloud admins messing around with the quotas manually. Up until now, this was only slightly annoying. But starting in January, when we change our billing model to allow quota bursting, `usage > quota` is going to cost actual money. Therefore we need to ensure that this does not happen inadvertently anymore. If you have any concerns, please address them to me or @reimannf.
