### PR TITLE
Cinder policy: restrict quota updates to Limes user

### DIFF
--- a/openstack/cinder/templates/etc/_cinder-policy.json.tpl
+++ b/openstack/cinder/templates/etc/_cinder-policy.json.tpl
@@ -1,5 +1,6 @@
 {
   "context_is_cloud_admin":  "role:cloud_volume_admin",
+  "context_is_quota_admin":  "role:resource_service",
   "context_is_admin":  "rule:context_is_cloud_admin",
   "owner": "project_id:%(project_id)s",
   "member": "role:member and rule:owner",
@@ -52,11 +53,11 @@
   "volume_extension:extended_snapshot_attributes": "rule:context_is_editor",
   "volume_extension:volume_image_metadata": "rule:context_is_editor",
 
-  "volume_extension:quotas:show": "rule:context_is_viewer",
-  "volume_extension:quotas:update": "rule:context_is_admin",
-  "volume_extension:quotas:delete": "rule:context_is_admin",
-  "volume_extension:quota_classes": "rule:context_is_admin",
-  "volume_extension:quota_classes:validate_setup_for_nested_quota_use": "rule:context_is_admin",
+  "volume_extension:quotas:show": "rule:context_is_viewer or rule:context_is_quota_admin",
+  "volume_extension:quotas:update": "rule:context_is_quota_admin",
+  "volume_extension:quotas:delete": "rule:context_is_quota_admin",
+  "volume_extension:quota_classes": "rule:context_is_admin or rule:context_is_quota_admin",
+  "volume_extension:quota_classes:validate_setup_for_nested_quota_use": "rule:context_is_quota_admin",
 
   "volume_extension:volume_admin_actions:reset_status": "rule:context_is_volume_admin",
   "volume_extension:snapshot_admin_actions:reset_status": "rule:context_is_volume_admin",

--- a/openstack/cinder/templates/etc/_cinder-policy.json.tpl
+++ b/openstack/cinder/templates/etc/_cinder-policy.json.tpl
@@ -57,7 +57,7 @@
   "volume_extension:quotas:update": "rule:context_is_quota_admin",
   "volume_extension:quotas:delete": "rule:context_is_quota_admin",
   "volume_extension:quota_classes": "rule:context_is_admin or rule:context_is_quota_admin",
-  "volume_extension:quota_classes:validate_setup_for_nested_quota_use": "rule:context_is_quota_admin",
+  "volume_extension:quota_classes:validate_setup_for_nested_quota_use": "rule:context_is_admin",
 
   "volume_extension:volume_admin_actions:reset_status": "rule:context_is_volume_admin",
   "volume_extension:snapshot_admin_actions:reset_status": "rule:context_is_volume_admin",


### PR DESCRIPTION
The "resource_service" role is designed to *only ever* be assigned to the Limes user, to ensure that backend quotas are always consistent with the Limes database. The role is created by the Limes seed and already exists in all regions, so this can be deployed immediately.

**Please roll this out with priority, until early December.** We have a lot of cases of `usage > quota` that are most likely caused by cloud admins messing around with the quotas manually. Up until now, this was only slightly annoying. But starting in January, when we change our billing model to allow quota bursting, `usage > quota` is going to cost actual money. Therefore we need to ensure that this does not happen inadvertently anymore. If you have any concerns, please address them to me or @reimannf.
