### PR TITLE
add openstack_assignments_per_role metric to Keystone pgmetrics

### DIFF
--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -283,6 +283,15 @@ pgmetrics:
         - gauge:
             usage: "GAUGE"
             description: "Total keystone token revocation count"
+    openstack_assignments_per_role:
+      query: "SELECT r.name AS name, COUNT(*) AS gauge FROM assignment a JOIN role r ON r.id = a.role_id GROUP BY r.name"
+      metrics:
+        - name:
+            usage: "LABEL"
+            description: "Name of assigned role"
+        - gauge:
+            usage: "GAUGE"
+            description: "Total keystone role-assignment count per role"
 
 rbac:
   enabled: false


### PR DESCRIPTION
I would like to monitor that restricted roles like `resource_service` and `swiftreseller` do not get assigned to users and groups that I'm not aware of. I thought about writing an exporter that queries the Keystone API
for role assignments, but I guess it's way more efficient to just add a rule to the pgmetrics exporter of the Keystone DB.

@ruvr Opinions?