### PR TITLE
added three new flavors with 1:4 ratio

### DIFF
--- a/openstack/sap-seeds/templates/flavor-seed.yaml
+++ b/openstack/sap-seeds/templates/flavor-seed.yaml
@@ -186,3 +186,4 @@ spec:
      extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
+      

--- a/openstack/sap-seeds/templates/flavor-seed.yaml
+++ b/openstack/sap-seeds/templates/flavor-seed.yaml
@@ -159,3 +159,30 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
+    name: "m5.16xlarge"
+    id: "220"
+    vcpus: "64"
+    ram: "262128"
+    disk: "64"
+    is_public: True
+     extra_specs:
+      "vmware:hv_enabled": "True"
+      "hw_video:ram_max_mb": "16"
+    name: "m5.32xlarge"
+    id: "230"
+    vcpus: "128"
+    ram: "524272"
+    disk: "64"
+    is_public: True
+     extra_specs:
+      "vmware:hv_enabled": "True"
+      "hw_video:ram_max_mb": "16"
+    name: "m5.64xlarge"
+    id: "240"
+    vcpus: "256"
+    ram: "1048560"
+    disk: "64"
+    is_public: True
+     extra_specs:
+      "vmware:hv_enabled": "True"
+      "hw_video:ram_max_mb": "16"


### PR DESCRIPTION
Added the following flavors with 1:4 ratio:

m5.16xlarge
vCPU: 64
RAM: 256

m5.32xlarge
vCPU: 128
RAM: 512

m5.64xlarge
vCPU: 256
RAM 1024

Bye,

Frank