### PR TITLE
[neutron] Add rabbitmq to neutron-chart

### DIFF
--- a/openstack/neutron/requirements.lock
+++ b/openstack/neutron/requirements.lock
@@ -5,6 +5,9 @@ dependencies:
 - name: pgmetrics
   repository: file://../../common/pgmetrics
   version: 0.1.0
+- name: rabbitmq
+  repository: file://../../common/rabbitmq
+  version: 0.1.0
 - name: memcached
   repository: file://../../common/memcached
   version: 0.0.1
@@ -14,5 +17,5 @@ dependencies:
 - name: utils
   repository: file://../../openstack/utils
   version: 0.1.1
-digest: sha256:3212bae437a9dd470e471b6b7bccd429a1bed7d9c71beb230b66f02b833bb50d
-generated: 2018-07-19T11:13:30.016319797+02:00
+digest: sha256:e06bde553b60c3d9606710683ceb232cc7fe0c301a1f0f8c6a8c7153a33bb81c
+generated: 2018-12-10T09:39:03.039792+01:00

--- a/openstack/neutron/requirements.yaml
+++ b/openstack/neutron/requirements.yaml
@@ -5,6 +5,9 @@ dependencies:
   - name: pgmetrics
     repository: file://../../common/pgmetrics
     version: 0.1.0
+  - name: rabbitmq
+    repository: file://../../common/rabbitmq
+    version: 0.1.0
   - name: memcached
     repository: file://../../common/memcached
     version: 0.0.1

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -296,6 +296,17 @@ audit:
   # how many messages to buffer before dumping to log (when rabbit is down or too slow)
   mem_queue_size: 1000
 
+rabbitmq:
+  users:
+    default:
+      password: null
+    admin:
+      password: null
+  persistence:
+    enabled: false
+  metrics:
+    password: null
+
 rabbitmq_notifications:
   name: neutron
 


### PR DESCRIPTION
In order to migrate away from the openstack-helm rabbitmq,
first create a rabbitmq to be used.
As a next step, the service entry of the central rabbitmq will point
to this rabbit.
Then we can configure everything to use the new rabbitmq directly.
Finally, we can tear down the central rabbitmq.