### PR TITLE
cleanup deployment for expired slo backup segments

### DIFF
--- a/openstack/backup-cleanup/Chart.yaml
+++ b/openstack/backup-cleanup/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: backup-cleanup
+name: backup-cleanup
+version: 0.1.0

--- a/openstack/backup-cleanup/README.md
+++ b/openstack/backup-cleanup/README.md
@@ -1,0 +1,7 @@
+# Backup Cleanup Chart
+
+Simple cleanup deployment for expired backup segments.
+
+The periodic triggered script, will cleanup backup segments of static large
+objects in Swift, because the segments are not marked for expirations. The
+object expirer only remover the manifest files of the SLOs.

--- a/openstack/backup-cleanup/bin/cleanup
+++ b/openstack/backup-cleanup/bin/cleanup
@@ -2,8 +2,9 @@
 
 set -euo pipefail
 
-# Check credentials
-eval "swift stat ${SEGMENTS_CONTAINER_NAME}" || exit 1
+eval "$(swift auth)"
+# This will fail and cause the exit if credentials are not correct
+swift stat ${CONTAINER_NAME} > /dev/null
 
 for slo in $(swift list ${SEGMENTS_CONTAINER_NAME} -p ${OS_REGION_NAME} | awk -F '/slo' '{print $1}' | uniq); do
   if ! swift --quiet stat ${CONTAINER_NAME} ${slo} >/dev/null 2>&1; then

--- a/openstack/backup-cleanup/bin/cleanup
+++ b/openstack/backup-cleanup/bin/cleanup
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Check credentials
+eval "swift stat ${SEGMENTS_CONTAINER_NAME}" || exit 1
+
+for slo in $(swift list ${SEGMENTS_CONTAINER_NAME} -p ${OS_REGION_NAME} | awk -F '/slo' '{print $1}' | uniq); do
+  if ! swift --quiet stat ${CONTAINER_NAME} ${slo} >/dev/null 2>&1; then
+    swift delete ${SEGMENTS_CONTAINER_NAME} -p ${slo}
+  fi
+done

--- a/openstack/backup-cleanup/bin/exponential-backoff
+++ b/openstack/backup-cleanup/bin/exponential-backoff
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+timeout=1
+attempt=1
+
+# Run the command immediately
+# Run until completed succesful or 10 failed attempts in a row
+until "$@"; do
+  if [ $attempt -gt 10 ]; then
+    echo "Too many failed attempts. Exiting..."
+    exit 1
+  fi
+  attempt=$(( attempt + 1 ))
+
+  # Exponential Backoff
+  timeout=$(( timeout * 2 ))
+  echo "Retry in $timeout seconds..."
+  sleep $timeout
+done

--- a/openstack/backup-cleanup/bin/sleep-for
+++ b/openstack/backup-cleanup/bin/sleep-for
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -euo pipefail
+
+sleep_for=$1
+shift
+
+# Run forever
+# Execute the provided command
+# Exit in case the command fails
+# Sleep X seconds, provided as first param
+while :; do
+  eval "$@" || exit 1
+  echo "Sleeping for $sleep_for seconds..."
+  sleep $sleep_for
+done

--- a/openstack/backup-cleanup/templates/bin-configmap.yaml
+++ b/openstack/backup-cleanup/templates/bin-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bin-backup-cleanup
+
+data:
+  sleep-for: |
+{{ .Files.Get "bin/sleep-for" | indent 4 }}
+  exponential-backoff: |
+{{ .Files.Get "bin/exponential-backoff" | indent 4 }}
+  cleanup: |
+{{ .Files.Get "bin/cleanup" | indent 4 }}

--- a/openstack/backup-cleanup/templates/cleanup-deployment.yaml
+++ b/openstack/backup-cleanup/templates/cleanup-deployment.yaml
@@ -1,0 +1,63 @@
+kind: Deployment
+apiVersion: extensions/v1beta1
+
+metadata:
+  name: backup-cleanup
+  namespace: backup
+  labels:
+    system: openstack
+    component: backup-cleanup
+
+spec:
+  revisionHistoryLimit: 5
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      component: backup-cleanup
+  template:
+    metadata:
+      labels:
+        component: backup-cleanup
+      annotations:
+        checksum/check.bin: {{ include "backup-cleanup/templates/bin-configmap.yaml" . | sha256sum }}
+    spec:
+      volumes:
+      - name: bin
+        configMap:
+          name: bin-backup-cleanup
+          defaultMode: 0550
+      containers:
+      - name: cleanup
+        image: {{ $.Values.global.imageRegistry }}/{{ $.Values.global.image_namespace }}/swift:{{ $.Values.image_tag }}
+        imagePullPolicy: {{ $.Values.image_pull_policy | default "IfNotPresent" }}
+        command:
+          - /usr/bin/dumb-init
+        args:
+          - /bin-cleanup/sleep-for
+          - {{ $.Values.sleep_for | quote }}
+          - /bin-cleanup/exponential-backoff
+          - /bin-cleanup/cleanup
+        env:
+          - name: OS_REGION_NAME
+            value: {{ $.Values.global.region | quote }}
+          - name: OS_AUTH_URL
+            value: {{ $.Values.auth.auth_url | quote }}
+          - name: OS_USER_DOMAIN_NAME
+            value: {{ $.Values.auth.user_domain_name | quote }}
+          - name: OS_USERNAME
+            value: {{ $.Values.auth.username | quote }}
+          - name: OS_PASSWORD
+            value: {{ $.Values.auth.password | quote }}
+          - name: OS_PROJECT_DOMAIN_NAME
+            value: {{ $.Values.auth.project_domain_name | quote }}
+          - name: OS_PROJECT_NAME
+            value: {{ $.Values.auth.project_name | quote }}
+          - name: CONTAINER_NAME
+            value: {{ $.Values.destination.container_name | quote }}
+          - name: SEGMENTS_CONTAINER_NAME
+            value: {{ $.Values.destination.segments_container_name | quote }}
+        volumeMounts:
+          - mountPath: /bin-cleanup
+            name: bin

--- a/openstack/backup-cleanup/values.yaml
+++ b/openstack/backup-cleanup/values.yaml
@@ -1,0 +1,14 @@
+image_tag: latest
+sleep_for: 3600
+
+auth:
+  auth_url: DEFINED-IN-REGION-SECRETS
+  user_domain_name: DEFINED-IN-REGION-SECRETS
+  username: DEFINED-IN-REGION-SECRETS
+  password: DEFINED-IN-REGION-SECRETS
+  project_domain_name: DEFINED-IN-REGION-SECRETS
+  project_name: DEFINED-IN-REGION-SECRETS
+
+destination:
+  container_name: db_backup
+  segments_container_name: db_backup_segments

--- a/openstack/backup-cleanup/values.yaml
+++ b/openstack/backup-cleanup/values.yaml
@@ -3,11 +3,11 @@ sleep_for: 3600
 
 auth:
   auth_url: DEFINED-IN-REGION-SECRETS
-  user_domain_name: DEFINED-IN-REGION-SECRETS
-  username: DEFINED-IN-REGION-SECRETS
+  user_domain_name: Default
+  username: db_backup
   password: DEFINED-IN-REGION-SECRETS
-  project_domain_name: DEFINED-IN-REGION-SECRETS
-  project_name: DEFINED-IN-REGION-SECRETS
+  project_domain_name: ccadmin
+  project_name: master
 
 destination:
   container_name: db_backup


### PR DESCRIPTION
The periodic triggered script, will cleanup backup segments of static large
objects in Swift, because the segments are not marked for expirations. The
object expirer only remover the manifest files of the SLOs.