### PR TITLE
[neutron] Log dnsmasq to stdout

### DIFF
--- a/openstack/neutron/templates/etc/_dnsmasq.conf.tpl
+++ b/openstack/neutron/templates/etc/_dnsmasq.conf.tpl
@@ -1,1 +1,1 @@
-log-facility=/var/log/neutron/dnsmasq.log
+


### PR DESCRIPTION
Logging the dhcp request allows us to debug if the vm/baremetal node at least managed to get network connectivity.
The file is also not rotated, so we end up with hundreds of MBs of log-files