### PR TITLE
openstack services now bring their own rabbits - the k8s dependencies…

### DIFF
--- a/openstack/cinder/templates/api-deployment.yaml
+++ b/openstack/cinder/templates/api-deployment.yaml
@@ -49,7 +49,7 @@ spec:
             - name: DEPENDENCY_JOBS
               value: "cinder-migration"
             - name: DEPENDENCY_SERVICE
-              value: "cinder-postgresql,rabbitmq"
+              value: "cinder-postgresql,{{ .Release.Name }}-rabbitmq"
             - name: STATSD_HOST
               value: "localhost"
             - name: STATSD_PORT

--- a/openstack/cinder/templates/scheduler-deployment.yaml
+++ b/openstack/cinder/templates/scheduler-deployment.yaml
@@ -48,7 +48,7 @@ spec:
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
             - name: DEPENDENCY_SERVICE
-              value: "cinder-api,rabbitmq"
+              value: "cinder-api,{{ .Release.Name }}-rabbitmq"
             - name: SENTRY_DSN
               value: {{.Values.sentry_dsn | quote}}
             - name: PGAPPNAME

--- a/openstack/neutron/templates/deployment-server.yaml
+++ b/openstack/neutron/templates/deployment-server.yaml
@@ -65,7 +65,7 @@ spec:
             - name: DEPENDENCY_JOBS
               value: "neutron-migration"
             - name: DEPENDENCY_SERVICE
-              value: "neutron-postgresql,rabbitmq"
+              value: "neutron-postgresql,{{ .Release.Name }}-rabbitmq"
             - name: STATSD_HOST
               value: "localhost"
             - name: STATSD_PORT

--- a/openstack/nova/templates/api-deployment.yaml
+++ b/openstack/nova/templates/api-deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - name: DEPENDENCY_JOBS
               value: "nova-migration"
             - name: DEPENDENCY_SERVICE
-              value: "nova-postgresql,rabbitmq"
+              value: "nova-postgresql,{{ .Release.Name }}-rabbitmq"
               # plus soft-dependency to nova-rabbitmq-notifications
             - name: STATSD_HOST
               value: "localhost"

--- a/openstack/nova/templates/api-metadata-deployment.yaml
+++ b/openstack/nova/templates/api-metadata-deployment.yaml
@@ -51,7 +51,7 @@ spec:
             - name: DEPENDENCY_JOBS
               value: "nova-migration"
             - name: DEPENDENCY_SERVICE
-              value: "nova-postgresql,rabbitmq"
+              value: "nova-postgresql,{{ .Release.Name }}-rabbitmq"
               # plus soft-dependency to nova-rabbitmq-notifications
             - name: STATSD_HOST
               value: "localhost"

--- a/openstack/nova/templates/conductor-deployment.yaml
+++ b/openstack/nova/templates/conductor-deployment.yaml
@@ -51,7 +51,7 @@ spec:
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
             - name: DEPENDENCY_SERVICE
-              value: "nova-api,rabbitmq"
+              value: "nova-api,{{ .Release.Name }}-rabbitmq"
 {{- if .Values.python_warnings}}
             - name: PYTHONWARNINGS
               value: {{ .Values.python_warnings | quote }}

--- a/openstack/nova/templates/placement-api-deployment.yaml
+++ b/openstack/nova/templates/placement-api-deployment.yaml
@@ -50,7 +50,7 @@ spec:
             - name: DEPENDENCY_JOBS
               value: "nova-migration"
             - name: DEPENDENCY_SERVICE
-              value: "nova-postgresql,rabbitmq"
+              value: "nova-postgresql,{{ .Release.Name }}-rabbitmq"
               # plus soft-dependency to nova-rabbitmq-notifications
 {{- if .Values.python_warnings }}
             - name: PYTHONWARNINGS

--- a/openstack/nova/templates/scheduler-deployment.yaml
+++ b/openstack/nova/templates/scheduler-deployment.yaml
@@ -51,7 +51,7 @@ spec:
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
             - name: DEPENDENCY_SERVICE
-              value: "nova-api,rabbitmq"
+              value: "nova-api,{{ .Release.Name }}-rabbitmq"
 {{- if .Values.python_warnings}}
             - name: PYTHONWARNINGS
               value: {{ .Values.python_warnings | quote }}


### PR DESCRIPTION
… should respect that

I believe nova & neutron now bring their own rabbitmq, right?