### PR TITLE
[nova] add support for sentry DSN from secret

### DIFF
--- a/openstack/nova/templates/_console_deployment.yaml.tpl
+++ b/openstack/nova/templates/_console_deployment.yaml.tpl
@@ -68,6 +68,13 @@ spec:
         - name: OS_AUTH_URL
           value: {{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3
 {{- end }}
+        {{- if and .Values.sentry.enabled (.Capabilities.APIVersions.Has "sentry.sap.cc/v1") }}
+        - name: SENTRY_DSN
+          valueFrom:
+            secretKeyRef:
+              name: sentry
+              key: {{ .Chart.Name }}.DSN.python
+        {{- end }}
         ports:
         - name: {{ $name }}
           containerPort: {{ index .Values.consoles $name "portInternal" }}

--- a/openstack/nova/templates/_console_deployment.yaml.tpl
+++ b/openstack/nova/templates/_console_deployment.yaml.tpl
@@ -68,7 +68,7 @@ spec:
         - name: OS_AUTH_URL
           value: {{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3
 {{- end }}
-        {{- if and .Values.sentry.enabled (.Capabilities.APIVersions.Has "sentry.sap.cc/v1") }}
+        {{- if .Values.sentry.enabled }}
         - name: SENTRY_DSN
           valueFrom:
             secretKeyRef:

--- a/openstack/nova/templates/api-deployment.yaml
+++ b/openstack/nova/templates/api-deployment.yaml
@@ -61,16 +61,12 @@ spec:
               value: "localhost"
             - name: STATSD_PORT
               value: "9125"
-            {{- if .Values.sentry.enabled }}
+            {{- if and .Values.sentry.enabled (.Capabilities.APIVersions.Has "sentry.sap.cc/v1") }}
             - name: SENTRY_DSN
-            {{- if .Values.sentry.dsn }}
-              value: {{ .Values.sentry.dsn | quote}}
-            {{ else }}
               valueFrom:
                 secretKeyRef:
                   name: sentry
-                  key: nova.DSN.python
-            {{- end }}
+                  key: {{ .Chart.Name }}.DSN.python
             {{- end }}
 {{- if .Values.python_warnings }}
             - name: PYTHONWARNINGS

--- a/openstack/nova/templates/api-deployment.yaml
+++ b/openstack/nova/templates/api-deployment.yaml
@@ -61,8 +61,17 @@ spec:
               value: "localhost"
             - name: STATSD_PORT
               value: "9125"
+            {{- if .Values.sentry.enabled }}
             - name: SENTRY_DSN
-              value: {{.Values.sentry_dsn | quote}}
+            {{- if .Values.sentry.dsn }}
+              value: {{ .Values.sentry.dsn | quote}}
+            {{ else }}
+              valueFrom:
+                secretKeyRef:
+                  name: sentry
+                  key: nova.DSN.python
+            {{- end }}
+            {{- end }}
 {{- if .Values.python_warnings }}
             - name: PYTHONWARNINGS
               value: {{ .Values.python_warnings | quote }}

--- a/openstack/nova/templates/api-deployment.yaml
+++ b/openstack/nova/templates/api-deployment.yaml
@@ -61,7 +61,7 @@ spec:
               value: "localhost"
             - name: STATSD_PORT
               value: "9125"
-            {{- if and .Values.sentry.enabled (.Capabilities.APIVersions.Has "sentry.sap.cc/v1") }}
+            {{- if .Values.sentry.enabled }}
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:

--- a/openstack/nova/templates/api-metadata-deployment.yaml
+++ b/openstack/nova/templates/api-metadata-deployment.yaml
@@ -57,8 +57,17 @@ spec:
               value: "localhost"
             - name: STATSD_PORT
               value: "9125"
+            {{- if .Values.sentry.enabled }}
             - name: SENTRY_DSN
-              value: {{.Values.sentry_dsn | quote}}
+            {{- if .Values.sentry.dsn }}
+              value: {{ .Values.sentry.dsn | quote}}
+            {{ else }}
+              valueFrom:
+                secretKeyRef:
+                  name: sentry
+                  key: nova.DSN.python
+            {{- end }}
+            {{- end }}
 {{- if .Values.python_warnings }}
             - name: PYTHONWARNINGS
               value: {{ .Values.python_warnings | quote }}

--- a/openstack/nova/templates/api-metadata-deployment.yaml
+++ b/openstack/nova/templates/api-metadata-deployment.yaml
@@ -57,16 +57,12 @@ spec:
               value: "localhost"
             - name: STATSD_PORT
               value: "9125"
-            {{- if .Values.sentry.enabled }}
+            {{- if and .Values.sentry.enabled (.Capabilities.APIVersions.Has "sentry.sap.cc/v1") }}
             - name: SENTRY_DSN
-            {{- if .Values.sentry.dsn }}
-              value: {{ .Values.sentry.dsn | quote}}
-            {{ else }}
               valueFrom:
                 secretKeyRef:
                   name: sentry
-                  key: nova.DSN.python
-            {{- end }}
+                  key: {{ .Chart.Name }}.DSN.python
             {{- end }}
 {{- if .Values.python_warnings }}
             - name: PYTHONWARNINGS

--- a/openstack/nova/templates/api-metadata-deployment.yaml
+++ b/openstack/nova/templates/api-metadata-deployment.yaml
@@ -57,7 +57,7 @@ spec:
               value: "localhost"
             - name: STATSD_PORT
               value: "9125"
-            {{- if and .Values.sentry.enabled (.Capabilities.APIVersions.Has "sentry.sap.cc/v1") }}
+            {{- if .Values.sentry.enabled }}
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:

--- a/openstack/nova/templates/conductor-deployment.yaml
+++ b/openstack/nova/templates/conductor-deployment.yaml
@@ -51,6 +51,17 @@ spec:
               value: {{ .Release.Namespace }}
             - name: DEPENDENCY_SERVICE
               value: "nova-api,{{ .Release.Name }}-rabbitmq"
+            {{- if .Values.sentry.enabled }}
+            - name: SENTRY_DSN
+            {{- if .Values.sentry.dsn }}
+              value: {{ .Values.sentry.dsn | quote}}
+            {{ else }}
+              valueFrom:
+                secretKeyRef:
+                  name: sentry
+                  key: nova.DSN.python
+            {{- end }}
+            {{- end }}
 {{- if .Values.python_warnings}}
             - name: PYTHONWARNINGS
               value: {{ .Values.python_warnings | quote }}

--- a/openstack/nova/templates/conductor-deployment.yaml
+++ b/openstack/nova/templates/conductor-deployment.yaml
@@ -51,16 +51,12 @@ spec:
               value: {{ .Release.Namespace }}
             - name: DEPENDENCY_SERVICE
               value: "nova-api,{{ .Release.Name }}-rabbitmq"
-            {{- if .Values.sentry.enabled }}
+            {{- if and .Values.sentry.enabled (.Capabilities.APIVersions.Has "sentry.sap.cc/v1") }}
             - name: SENTRY_DSN
-            {{- if .Values.sentry.dsn }}
-              value: {{ .Values.sentry.dsn | quote}}
-            {{ else }}
               valueFrom:
                 secretKeyRef:
                   name: sentry
-                  key: nova.DSN.python
-            {{- end }}
+                  key: {{ .Chart.Name }}.DSN.python
             {{- end }}
 {{- if .Values.python_warnings}}
             - name: PYTHONWARNINGS

--- a/openstack/nova/templates/conductor-deployment.yaml
+++ b/openstack/nova/templates/conductor-deployment.yaml
@@ -51,7 +51,7 @@ spec:
               value: {{ .Release.Namespace }}
             - name: DEPENDENCY_SERVICE
               value: "nova-api,{{ .Release.Name }}-rabbitmq"
-            {{- if and .Values.sentry.enabled (.Capabilities.APIVersions.Has "sentry.sap.cc/v1") }}
+            {{- if .Values.sentry.enabled }}
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:

--- a/openstack/nova/templates/consoleauth-deployment.yaml
+++ b/openstack/nova/templates/consoleauth-deployment.yaml
@@ -50,7 +50,7 @@ spec:
           value: {{ .Release.Namespace }}
         - name: DEPENDENCY_SERVICE
           value: "nova-api"
-        {{- if and .Values.sentry.enabled (.Capabilities.APIVersions.Has "sentry.sap.cc/v1") }}
+        {{- if .Values.sentry.enabled }}
         - name: SENTRY_DSN
           valueFrom:
             secretKeyRef:

--- a/openstack/nova/templates/consoleauth-deployment.yaml
+++ b/openstack/nova/templates/consoleauth-deployment.yaml
@@ -50,16 +50,12 @@ spec:
           value: {{ .Release.Namespace }}
         - name: DEPENDENCY_SERVICE
           value: "nova-api"
-        {{- if .Values.sentry.enabled }}
+        {{- if and .Values.sentry.enabled (.Capabilities.APIVersions.Has "sentry.sap.cc/v1") }}
         - name: SENTRY_DSN
-        {{- if .Values.sentry.dsn }}
-          value: {{ .Values.sentry.dsn | quote}}
-        {{ else }}
           valueFrom:
             secretKeyRef:
               name: sentry
-              key: nova.DSN.python
-        {{- end }}
+              key: {{ .Chart.Name }}.DSN.python
         {{- end }}
 {{- if .Values.python_warnings }}
         - name: PYTHONWARNINGS

--- a/openstack/nova/templates/consoleauth-deployment.yaml
+++ b/openstack/nova/templates/consoleauth-deployment.yaml
@@ -50,6 +50,17 @@ spec:
           value: {{ .Release.Namespace }}
         - name: DEPENDENCY_SERVICE
           value: "nova-api"
+        {{- if .Values.sentry.enabled }}
+        - name: SENTRY_DSN
+        {{- if .Values.sentry.dsn }}
+          value: {{ .Values.sentry.dsn | quote}}
+        {{ else }}
+          valueFrom:
+            secretKeyRef:
+              name: sentry
+              key: nova.DSN.python
+        {{- end }}
+        {{- end }}
 {{- if .Values.python_warnings }}
         - name: PYTHONWARNINGS
           value: {{ .Values.python_warnings | quote }}

--- a/openstack/nova/templates/hypervisors/_ironic-deployment.yaml.tpl
+++ b/openstack/nova/templates/hypervisors/_ironic-deployment.yaml.tpl
@@ -43,7 +43,7 @@ spec:
               value: "nova-compute"
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
-            {{- if and .Values.sentry.enabled (.Capabilities.APIVersions.Has "sentry.sap.cc/v1") }}
+            {{- if .Values.sentry.enabled }}
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:

--- a/openstack/nova/templates/hypervisors/_ironic-deployment.yaml.tpl
+++ b/openstack/nova/templates/hypervisors/_ironic-deployment.yaml.tpl
@@ -43,16 +43,12 @@ spec:
               value: "nova-compute"
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
-            {{- if .Values.sentry.enabled }}
+            {{- if and .Values.sentry.enabled (.Capabilities.APIVersions.Has "sentry.sap.cc/v1") }}
             - name: SENTRY_DSN
-            {{- if .Values.sentry.dsn }}
-              value: {{ .Values.sentry.dsn | quote}}
-            {{ else }}
               valueFrom:
                 secretKeyRef:
                   name: sentry
-                  key: nova.DSN.python
-            {{- end }}
+                  key: {{ .Chart.Name }}.DSN.python
             {{- end }}
 {{- if or $hypervisor.python_warnings .Values.python_warnings }}
             - name: PYTHONWARNINGS

--- a/openstack/nova/templates/hypervisors/_ironic-deployment.yaml.tpl
+++ b/openstack/nova/templates/hypervisors/_ironic-deployment.yaml.tpl
@@ -43,8 +43,17 @@ spec:
               value: "nova-compute"
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
+            {{- if .Values.sentry.enabled }}
             - name: SENTRY_DSN
-              value: {{.Values.sentry_dsn | quote}}
+            {{- if .Values.sentry.dsn }}
+              value: {{ .Values.sentry.dsn | quote}}
+            {{ else }}
+              valueFrom:
+                secretKeyRef:
+                  name: sentry
+                  key: nova.DSN.python
+            {{- end }}
+            {{- end }}
 {{- if or $hypervisor.python_warnings .Values.python_warnings }}
             - name: PYTHONWARNINGS
               value: {{ or $hypervisor.python_warnings .Values.python_warnings | quote }}

--- a/openstack/nova/templates/hypervisors/_kvm-deployment.yaml.tpl
+++ b/openstack/nova/templates/hypervisors/_kvm-deployment.yaml.tpl
@@ -63,8 +63,17 @@ spec:
               value: "nova-compute"
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
+            {{- if .Values.sentry.enabled }}
             - name: SENTRY_DSN
-              value: {{.Values.sentry_dsn | quote}}
+            {{- if .Values.sentry.dsn }}
+              value: {{ .Values.sentry.dsn | quote}}
+            {{ else }}
+              valueFrom:
+                secretKeyRef:
+                  name: sentry
+                  key: nova.DSN.python
+            {{- end }}
+            {{- end }}
 {{- if or $hypervisor.python_warnings .Values.python_warnings }}
             - name: PYTHONWARNINGS
               value: {{ or $hypervisor.python_warnings .Values.python_warnings | quote }}

--- a/openstack/nova/templates/hypervisors/_kvm-deployment.yaml.tpl
+++ b/openstack/nova/templates/hypervisors/_kvm-deployment.yaml.tpl
@@ -63,7 +63,7 @@ spec:
               value: "nova-compute"
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
-            {{- if and .Values.sentry.enabled (.Capabilities.APIVersions.Has "sentry.sap.cc/v1") }}
+            {{- if .Values.sentry.enabled }}
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:
@@ -120,8 +120,13 @@ spec:
               value: /container.init/nova-libvirt-start
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
+            {{- if .Values.sentry.enabled }}
             - name: SENTRY_DSN
-              value: {{.Values.sentry_dsn | quote}}
+              valueFrom:
+                secretKeyRef:
+                  name: sentry
+                  key: {{ .Chart.Name }}.DSN.python
+            {{- end }}
           volumeMounts:
             - mountPath: /var/lib/nova/instances
               name: instances
@@ -166,8 +171,13 @@ spec:
               value: /usr/sbin/virtlogd
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
+            {{- if .Values.sentry.enabled }}
             - name: SENTRY_DSN
-              value: {{ .Values.sentry_dsn | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: sentry
+                  key: {{ .Chart.Name }}.DSN.python
+            {{- end }}
           volumeMounts:
             - mountPath: /var/lib/nova/instances
               name: instances

--- a/openstack/nova/templates/hypervisors/_kvm-deployment.yaml.tpl
+++ b/openstack/nova/templates/hypervisors/_kvm-deployment.yaml.tpl
@@ -63,16 +63,12 @@ spec:
               value: "nova-compute"
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
-            {{- if .Values.sentry.enabled }}
+            {{- if and .Values.sentry.enabled (.Capabilities.APIVersions.Has "sentry.sap.cc/v1") }}
             - name: SENTRY_DSN
-            {{- if .Values.sentry.dsn }}
-              value: {{ .Values.sentry.dsn | quote}}
-            {{ else }}
               valueFrom:
                 secretKeyRef:
                   name: sentry
-                  key: nova.DSN.python
-            {{- end }}
+                  key: {{ .Chart.Name }}.DSN.python
             {{- end }}
 {{- if or $hypervisor.python_warnings .Values.python_warnings }}
             - name: PYTHONWARNINGS

--- a/openstack/nova/templates/hypervisors/hypervisors-vmware-deployment-vct.yaml
+++ b/openstack/nova/templates/hypervisors/hypervisors-vmware-deployment-vct.yaml
@@ -51,7 +51,7 @@ template: |
             value: "nova-compute"
           - name: NAMESPACE
             value: {{ .Release.Namespace }}
-            {{- if and .Values.sentry.enabled (.Capabilities.APIVersions.Has "sentry.sap.cc/v1") }}
+            {{- if .Values.sentry.enabled }}
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:

--- a/openstack/nova/templates/hypervisors/hypervisors-vmware-deployment-vct.yaml
+++ b/openstack/nova/templates/hypervisors/hypervisors-vmware-deployment-vct.yaml
@@ -51,17 +51,13 @@ template: |
             value: "nova-compute"
           - name: NAMESPACE
             value: {{ .Release.Namespace }}
-          {{- if .Values.sentry.enabled }}
-          - name: SENTRY_DSN
-          {{- if .Values.sentry.dsn }}
-            value: {{ .Values.sentry.dsn | quote}}
-          {{ else }}
-            valueFrom:
-              secretKeyRef:
-                name: sentry
-                key: nova.DSN.python
-          {{- end }}
-          {{- end }}
+            {{- if and .Values.sentry.enabled (.Capabilities.APIVersions.Has "sentry.sap.cc/v1") }}
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: sentry
+                  key: {{ .Chart.Name }}.DSN.python
+            {{- end }}
           - name: STATSD_HOST
             value: "localhost"
           - name: STATSD_PORT

--- a/openstack/nova/templates/hypervisors/hypervisors-vmware-deployment-vct.yaml
+++ b/openstack/nova/templates/hypervisors/hypervisors-vmware-deployment-vct.yaml
@@ -51,8 +51,17 @@ template: |
             value: "nova-compute"
           - name: NAMESPACE
             value: {{ .Release.Namespace }}
+          {{- if .Values.sentry.enabled }}
           - name: SENTRY_DSN
-            value: {{ .Values.sentry_dsn | quote }}
+          {{- if .Values.sentry.dsn }}
+            value: {{ .Values.sentry.dsn | quote}}
+          {{ else }}
+            valueFrom:
+              secretKeyRef:
+                name: sentry
+                key: nova.DSN.python
+          {{- end }}
+          {{- end }}
           - name: STATSD_HOST
             value: "localhost"
           - name: STATSD_PORT
@@ -103,8 +112,17 @@ template: |
           command: ["dumb-init"]
           args: ["neutron-dvs-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/plugins/ml2/ml2-conf.ini", "--config-file", "/etc/neutron/plugins/ml2/ml2-vmware.ini"]
           env:
-          - name: SENTRY_DSN
-            value: {{ .Values.neutron.sentry_dsn | quote }}
+            {{- if .Values.sentry.enabled }}
+            - name: SENTRY_DSN
+            {{- if .Values.neutron.sentry_dsn }}
+              value: {{ .Values.neutron.sentry_dsn | quote}}
+            {{ else }}
+              valueFrom:
+                secretKeyRef:
+                  name: sentry
+                  key: neutron.DSN.python
+            {{- end }}
+            {{- end }}
           - name: STATSD_HOST
             value: "localhost"
           - name: STATSD_PORT

--- a/openstack/nova/templates/placement-api-deployment.yaml
+++ b/openstack/nova/templates/placement-api-deployment.yaml
@@ -52,6 +52,13 @@ spec:
             - name: DEPENDENCY_SERVICE
               value: "nova-postgresql,{{ .Release.Name }}-rabbitmq"
               # plus soft-dependency to nova-rabbitmq-notifications
+            {{- if and .Values.sentry.enabled (.Capabilities.APIVersions.Has "sentry.sap.cc/v1") }}
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: sentry
+                  key: {{ .Chart.Name }}.DSN.python
+            {{- end }}
 {{- if .Values.python_warnings }}
             - name: PYTHONWARNINGS
               value: {{ .Values.python_warnings | quote }}

--- a/openstack/nova/templates/placement-api-deployment.yaml
+++ b/openstack/nova/templates/placement-api-deployment.yaml
@@ -52,7 +52,7 @@ spec:
             - name: DEPENDENCY_SERVICE
               value: "nova-postgresql,{{ .Release.Name }}-rabbitmq"
               # plus soft-dependency to nova-rabbitmq-notifications
-            {{- if and .Values.sentry.enabled (.Capabilities.APIVersions.Has "sentry.sap.cc/v1") }}
+            {{- if .Values.sentry.enabled }}
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:

--- a/openstack/nova/templates/scheduler-deployment.yaml
+++ b/openstack/nova/templates/scheduler-deployment.yaml
@@ -52,7 +52,7 @@ spec:
               value: {{ .Release.Namespace }}
             - name: DEPENDENCY_SERVICE
               value: "nova-api,{{ .Release.Name }}-rabbitmq"
-            {{- if and .Values.sentry.enabled (.Capabilities.APIVersions.Has "sentry.sap.cc/v1") }}
+            {{- if .Values.sentry.enabled }}
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:

--- a/openstack/nova/templates/scheduler-deployment.yaml
+++ b/openstack/nova/templates/scheduler-deployment.yaml
@@ -52,6 +52,17 @@ spec:
               value: {{ .Release.Namespace }}
             - name: DEPENDENCY_SERVICE
               value: "nova-api,{{ .Release.Name }}-rabbitmq"
+            {{- if .Values.sentry.enabled }}
+            - name: SENTRY_DSN
+            {{- if .Values.sentry.dsn }}
+              value: {{ .Values.sentry.dsn | quote}}
+            {{ else }}
+              valueFrom:
+                secretKeyRef:
+                  name: sentry
+                  key: nova.DSN.python
+            {{- end }}
+            {{- end }}
 {{- if .Values.python_warnings}}
             - name: PYTHONWARNINGS
               value: {{ .Values.python_warnings | quote }}

--- a/openstack/nova/templates/scheduler-deployment.yaml
+++ b/openstack/nova/templates/scheduler-deployment.yaml
@@ -52,16 +52,12 @@ spec:
               value: {{ .Release.Namespace }}
             - name: DEPENDENCY_SERVICE
               value: "nova-api,{{ .Release.Name }}-rabbitmq"
-            {{- if .Values.sentry.enabled }}
+            {{- if and .Values.sentry.enabled (.Capabilities.APIVersions.Has "sentry.sap.cc/v1") }}
             - name: SENTRY_DSN
-            {{- if .Values.sentry.dsn }}
-              value: {{ .Values.sentry.dsn | quote}}
-            {{ else }}
               valueFrom:
                 secretKeyRef:
                   name: sentry
-                  key: nova.DSN.python
-            {{- end }}
+                  key: {{ .Chart.Name }}.DSN.python
             {{- end }}
 {{- if .Values.python_warnings}}
             - name: PYTHONWARNINGS

--- a/openstack/nova/templates/sentry.yaml
+++ b/openstack/nova/templates/sentry.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.sentry.enabled (.Capabilities.APIVersions.Has "sentry.sap.cc/v1") -}}
+{{- if .Values.sentry.enabled -}}
 apiVersion: "sentry.sap.cc/v1"
 kind: "SentryProject"
 metadata:

--- a/openstack/nova/templates/sentry.yaml
+++ b/openstack/nova/templates/sentry.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.sentry.enabled }}
+{{- if not .Values.sentry.dsn }}
+apiVersion: "sentry.sap.cc/v1"
+kind: "SentryProject"
+metadata:
+  name: nova-sentry
+
+spec:
+  name: nova #slug of the project you want to use (or create
+  team: openstack #slug of the team where the project should be created (if it doesn't exist)
+{{- end }}
+{{- end }}

--- a/openstack/nova/templates/sentry.yaml
+++ b/openstack/nova/templates/sentry.yaml
@@ -1,12 +1,10 @@
-{{- if .Values.sentry.enabled }}
-{{- if not .Values.sentry.dsn }}
+{{- if and .Values.sentry.enabled (.Capabilities.APIVersions.Has "sentry.sap.cc/v1") -}}
 apiVersion: "sentry.sap.cc/v1"
 kind: "SentryProject"
 metadata:
-  name: nova-sentry
+  name: {{ .Chart.Name }}-sentry
 
 spec:
-  name: nova #slug of the project you want to use (or create
+  name: {{ .Chart.Name }} #slug of the project you want to use (or create)
   team: openstack #slug of the team where the project should be created (if it doesn't exist)
-{{- end }}
 {{- end }}

--- a/openstack/nova/templates/vspc-deployment.yaml
+++ b/openstack/nova/templates/vspc-deployment.yaml
@@ -36,7 +36,7 @@ spec:
           env:
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
-            {{- if and .Values.sentry.enabled (.Capabilities.APIVersions.Has "sentry.sap.cc/v1") }}
+            {{- if .Values.sentry.enabled }}
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:

--- a/openstack/nova/templates/vspc-deployment.yaml
+++ b/openstack/nova/templates/vspc-deployment.yaml
@@ -36,16 +36,12 @@ spec:
           env:
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
-            {{- if .Values.sentry.enabled }}
+            {{- if and .Values.sentry.enabled (.Capabilities.APIVersions.Has "sentry.sap.cc/v1") }}
             - name: SENTRY_DSN
-            {{- if .Values.sentry.dsn }}
-              value: {{ .Values.sentry.dsn | quote}}
-            {{ else }}
               valueFrom:
                 secretKeyRef:
                   name: sentry
-                  key: nova.DSN.python
-            {{- end }}
+                  key: {{ .Chart.Name }}.DSN.python
             {{- end }}
 {{- if .Values.python_warnings }}
             - name: PYTHONWARNINGS

--- a/openstack/nova/templates/vspc-deployment.yaml
+++ b/openstack/nova/templates/vspc-deployment.yaml
@@ -36,8 +36,17 @@ spec:
           env:
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
+            {{- if .Values.sentry.enabled }}
             - name: SENTRY_DSN
-              value: {{.Values.sentry_dsn | quote}}
+            {{- if .Values.sentry.dsn }}
+              value: {{ .Values.sentry.dsn | quote}}
+            {{ else }}
+              valueFrom:
+                secretKeyRef:
+                  name: sentry
+                  key: nova.DSN.python
+            {{- end }}
+            {{- end }}
 {{- if .Values.python_warnings }}
             - name: PYTHONWARNINGS
               value: {{ .Values.python_warnings | quote }}

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -92,7 +92,6 @@ portMetrics: '9102'
 
 sentry:
   enabled: true
-  #dsn: DEFINE_IN_REGION_CHART
 
 loci:
   nova: false

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -90,7 +90,9 @@ apidbPassword: null
 
 portMetrics: '9102'
 
-sentry_dsn: DEFINE_IN_REGION_CHART
+sentry:
+  enabled: true
+  #dsn: DEFINE_IN_REGION_CHART
 
 loci:
   nova: false


### PR DESCRIPTION
@fwiesel This could save you maintaining 4 fresh nova sentry DSN's..
just drop the former sentry_dsn from values.yaml in the regions where sentry has been re-installed..