### PR TITLE
alerting: add cloudops link; region should always be the openstack region

### DIFF
--- a/global/prometheus-alertmanager/pagerduty.tmpl
+++ b/global/prometheus-alertmanager/pagerduty.tmpl
@@ -57,3 +57,6 @@
 {{- if .CommonLabels.playbook }} https://operations.global.cloud.sap/{{ .CommonLabels.playbook }} {{ end -}}
 {{ end }}
 
+{{ define "pagerduty.sapcc.cloudops" }}
+{{- if .CommonLabels.cloudops }} https://dashboard.{{ .CommonLabels.region }}.cloud.sap/ccadmin/cloud_admin/cloudops#/universal-search/{{ .CommonLabels.cloudops }} {{ end -}}
+{{ end }}

--- a/global/prometheus-alertmanager/slack.tmpl
+++ b/global/prometheus-alertmanager/slack.tmpl
@@ -6,7 +6,7 @@
 {{ define "slack.sapcc.text" }}
 {{ if eq .Status "firing" }}*[{{ .CommonLabels.severity | toUpper }}{{ if gt (len .Alerts.Firing) 1 }} - {{ .Alerts.Firing | len }}{{ end }}]* {{ end -}}
 {{ if eq .Status "resolved" }}*[RESOLVED{{ if gt (len .Alerts.Resolved) 1 }} - {{ .Alerts.Resolved | len }}{{ end }}]* {{ end -}}
-  *[{{ .CommonLabels.region | toUpper }}]* {{ if .CommonLabels.dashboard }}*<{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}|{{ .GroupLabels.alertname }}>*{{ else }}{{ .GroupLabels.alertname }}{{ end }} - {{ .CommonAnnotations.summary }}
+  {{ if .CommonLabels.cluster }}*[{{ .CommonLabels.cluster | toUpper }}]*{{ else }}*[{{ .CommonLabels.region | toUpper }}]*{{ end }} {{ if .CommonLabels.dashboard }}*<{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}|{{ .GroupLabels.alertname }}>*{{ else }}{{ .GroupLabels.alertname }}{{ end }} - {{ .CommonAnnotations.summary }}
 
 {{ if eq .Status "firing" -}}
 {{ range .Alerts.Firing -}}

--- a/global/prometheus-alertmanager/slack.tmpl
+++ b/global/prometheus-alertmanager/slack.tmpl
@@ -12,7 +12,7 @@
 {{ range .Alerts.Firing -}}
   {{ if eq .Labels.severity "warning" }}:warning: {{ end -}}
   {{ if eq .Labels.severity "critical" }}:fire: {{ end -}}
-  {{ .Annotations.description }} (<{{ .GeneratorURL }}|Graph>)
+  {{ .Annotations.description }} {{ if .Labels.sentry }}*<https://sentry.{{ .CommonLabels.region }}.cloud.sap/monsoon/{{ .Labels.sentry }}|Sentry>*{{ end }} {{ if .Labels.cloudops }}*<https://dashboard.{{ .CommonLabels.region }}.cloud.sap/ccadmin/cloud_admin/cloudops#/universal-search/{{ .Labels.cloudops }}|CloudOps>*{{ end }} (<{{ .GeneratorURL }}|Graph>)
 {{ end -}}
 {{ end -}}
 {{ if eq .Status "resolved" -}}
@@ -22,10 +22,8 @@
 {{ end -}}
 
 {{ if .CommonLabels.dashboard }}*<https://grafana.{{ .CommonLabels.region }}.cloud.sap/dashboard/db/{{ .CommonLabels.dashboard }}|Grafana>* {{ end -}}
-{{ if .CommonLabels.sentry }}*<https://sentry.{{ .CommonLabels.region }}.cloud.sap/monsoon/{{ .CommonLabels.sentry }}|Sentry>* {{ end -}}
 {{ if .CommonLabels.playbook }}*<https://operations.global.cloud.sap/{{ .CommonLabels.playbook }}|Playbook>* {{ end -}}
 {{ if .CommonLabels.kibana }}*<https://logs.{{ .CommonLabels.region }}.cloud.sap/{{ .CommonLabels.kibana }}|Kibana>* {{ end -}}
-{{ if .CommonLabels.cloudops }}*https://dashboard.{{ .CommonLabels.region }}.cloud.sap/ccadmin/cloud_admin/cloudops#/universal-search/{{ .CommonLabels.cloudops }}|CloudOps>* {{ end -}}
 {{ end }}
 
 {{ define "slack.sapcc.actionName" }}{{ if eq .Status "firing" }}reaction{{ end }}{{ end }}

--- a/global/prometheus-alertmanager/slack.tmpl
+++ b/global/prometheus-alertmanager/slack.tmpl
@@ -25,6 +25,7 @@
 {{ if .CommonLabels.sentry }}*<https://sentry.{{ .CommonLabels.region }}.cloud.sap/monsoon/{{ .CommonLabels.sentry }}|Sentry>* {{ end -}}
 {{ if .CommonLabels.playbook }}*<https://operations.global.cloud.sap/{{ .CommonLabels.playbook }}|Playbook>* {{ end -}}
 {{ if .CommonLabels.kibana }}*<https://logs.{{ .CommonLabels.region }}.cloud.sap/{{ .CommonLabels.kibana }}|Kibana>* {{ end -}}
+{{ if .CommonLabels.cloudops }}*https://dashboard.{{ .CommonLabels.region }}.cloud.sap/ccadmin/cloud_admin/cloudops#/universal-search/{{ .CommonLabels.cloudops }}|CloudOps>* {{ end -}}
 {{ end }}
 
 {{ define "slack.sapcc.actionName" }}{{ if eq .Status "firing" }}reaction{{ end }}{{ end }}

--- a/global/prometheus-alertmanager/templates/config.yaml
+++ b/global/prometheus-alertmanager/templates/config.yaml
@@ -43,35 +43,35 @@ data:
         match_re:
           tier: metal
           severity: critical
-          region: admin|ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3|k-qa-de-1|k-ap-ae-1|k-ap-au-1|k-ap-cn-1|k-ap-jp-1|k-ap-jp-2|k-ap-sa-1|k-eu-de-1|k-eu-de-2|k-eu-nl-1|k-eu-ru-1|k-la-br-1|k-na-ca-1|k-na-us-1|k-na-us-3
+          region: admin|ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
 
       - receiver: slack_os_critical
         continue: true
         match_re:
           tier: os
           severity: critical
-          region: admin|ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3|k-qa-de-1|k-ap-ae-1|k-ap-au-1|k-ap-cn-1|k-ap-jp-1|k-ap-jp-2|k-ap-sa-1|k-eu-de-1|k-eu-de-2|k-eu-nl-1|k-eu-ru-1|k-la-br-1|k-na-ca-1|k-na-us-1|k-na-us-3
+          region: admin|ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
 
       - receiver: slack_k8s_critical
         continue: true
         match_re:
           tier: k8s
           severity: critical
-          region: admin|ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3|k-qa-de-1|k-ap-ae-1|k-ap-au-1|k-ap-cn-1|k-ap-jp-1|k-ap-jp-2|k-ap-sa-1|k-eu-de-1|k-eu-de-2|k-eu-nl-1|k-eu-ru-1|k-la-br-1|k-na-ca-1|k-na-us-1|k-na-us-3
+          region: admin|ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
 
       - receiver: slack_kks_critical
         continue: true
         match_re:
           tier: kks
           severity: critical
-          region: admin|ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3|k-qa-de-1|k-ap-ae-1|k-ap-au-1|k-ap-cn-1|k-ap-jp-1|k-ap-jp-2|k-ap-sa-1|k-eu-de-1|k-eu-de-2|k-eu-nl-1|k-eu-ru-1|k-la-br-1|k-na-ca-1|k-na-us-1|k-na-us-3
+          region: admin|ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
 
       - receiver: slack_by_tier_and_severity
         continue: true
         match_re:
           tier: os|k8s|kks|metal
           severity: info|warning
-          region: admin|qa-de-1|ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3|k-qa-de-1|k-ap-ae-1|k-ap-au-1|k-ap-cn-1|k-ap-jp-1|k-ap-jp-2|k-ap-sa-1|k-eu-de-1|k-eu-de-2|k-eu-nl-1|k-eu-ru-1|k-la-br-1|k-na-ca-1|k-na-us-1|k-na-us-3
+          region: admin|qa-de-1|ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
 
       - receiver: slack_by_tier_and_service
         continue: true
@@ -85,6 +85,12 @@ data:
         match_re:
           severity: info|warning|critical
           service: concourse
+
+      # do not page for kubernikus controlplane
+      - receiver: dev-null
+        continue: false
+        match_re:
+          cluster_type: kubernikus-controlplane
 
       - receiver: pagerduty_metal
         continue: false

--- a/system/kube-monitoring/charts/prometheus-frontend/README.md
+++ b/system/kube-monitoring/charts/prometheus-frontend/README.md
@@ -9,12 +9,16 @@ The naming convention for alert files is `<tier>-<whatever>.alert`.
 Prometheus alerts can be enriched with metadata using labels. Using these labels Prometheus can be configured to route, group and inhibit alerts. The labels are then again used to render the alerting notification you see in Slack. The configuration depends on the following labels:
 
   * Region
+  * ClusterType
+  * Cluster
   * Severity
   * Tier
   * Service
   * Context
   * Dashboard
   * Playbook
+  * Kibana
+  * CloudOps
   * Meta
 
 **Note**: Label and annotation values are strings. If they contain special characters like `{` the whole string has to be quoted: `meta: "meta information for instance {{ $labels.instance}}"`
@@ -23,7 +27,20 @@ We are using the following conventions.
 
 ### Region
 
-Region is an implicit label that is automatically set by Prometheus. Do not overwrite.
+The `region` label is automatically set by Prometheus and is equivalent to the OpenStack region. **Do not overwrite.**
+
+### ClusterType
+
+The `cluster_type` label is automatically set by Prometheus and helps distinguishing the various cluster types. **Do not overwrite.**
+Valid types are:
+- controlplane
+- kubernikus-controlplane
+- scaleout
+- scaleout-internet
+
+### Cluster
+
+The `cluster` label is an optional label used to differentiate multiple clusters of the same type in a region.
 
 ### Severity
 
@@ -89,6 +106,27 @@ If there is a Sentry project relevant for this alert, you can add its name in th
 ```sentry = "Blackbox"```
 
 The regional Sentry prefix will be added automatically to the URL.
+
+## Kibana
+
+If there are logs relevant for this alert, you can add a Kibana search query via the `kibana` label.
+
+Shortend link:
+```kibana = "goto/8ef06b0edac2513a5ff237d17b9f62d5"```
+
+Alertnatively, the longer, verbose link can be used:
+```kibana = "/app/kibana#/discover?_g=()&_a=(columns:!(_source),index:'logstash-*',interval:auto,query:(query_string:(query:ingress)),sort:!(time,desc))"```
+
+The regional Kibana prefix will be added automatically to the URL.
+
+## CloudOps
+
+If there is an OpenStack entity related to this alert it can be referenced using the CloudOps universal search to show further information.
+The search term can be passed via the `cloudops` label.
+
+```cloudops = "?searchTerm={{ $labels.node }}"```
+
+The regional CloudOps prefix will be added automatically to the URL.
 
 ## Routing
 


### PR DESCRIPTION
- add cloudops link
- region should always be the openstack region
- introduce `cluster_type` to distinguish between bm, kubernikus, scaleout, .. clusters. no paging for kubernikus, scaleout clusters
