### PR TITLE
removed referrals to outdated openstack-ops-middleware which has been…

### DIFF
--- a/openstack/cinder/templates/etc/_api-paste.ini.tpl
+++ b/openstack/cinder/templates/etc/_api-paste.ini.tpl
@@ -24,21 +24,21 @@ use = call:cinder.api:root_app_factory
 [composite:openstack_volume_api_v1]
 use = call:cinder.api.middleware.auth:pipeline_factory
 noauth = cors http_proxy_to_wsgi request_id faultwrap sizelimit {{- include "osprofiler_pipe" . }} noauth apiv1
-keystone = cors http_proxy_to_wsgi request_id statsd faultwrap sentry sizelimit {{- include "osprofiler_pipe" . }} authtoken keystonecontext {{- include "watcher_pipe" . }} {{- include "audit_pipe" . }} apiv1
-keystone_nolimit = cors http_proxy_to_wsgi request_id statsd faultwrap sentry sizelimit {{- include "osprofiler_pipe" . }} authtoken keystonecontext {{- include "watcher_pipe" . }} {{- include "audit_pipe" . }} apiv1
+keystone = cors http_proxy_to_wsgi request_id faultwrap sentry sizelimit {{- include "osprofiler_pipe" . }} authtoken keystonecontext {{- include "watcher_pipe" . }} {{- include "audit_pipe" . }} apiv1
+keystone_nolimit = cors http_proxy_to_wsgi request_id faultwrap sentry sizelimit {{- include "osprofiler_pipe" . }} authtoken keystonecontext {{- include "watcher_pipe" . }} {{- include "audit_pipe" . }} apiv1
 {{ end }}
 
 [composite:openstack_volume_api_v2]
 use = call:cinder.api.middleware.auth:pipeline_factory
-noauth = cors http_proxy_to_wsgi request_id {{- include "watcher_pipe" . }} statsd faultwrap sentry sizelimit {{- include "osprofiler_pipe" . }} noauth apiv2
-keystone = cors http_proxy_to_wsgi request_id statsd faultwrap sentry sizelimit {{- include "osprofiler_pipe" . }} authtoken keystonecontext {{- include "watcher_pipe" . }} {{- include "audit_pipe" . }} apiv2
-keystone_nolimit = cors http_proxy_to_wsgi request_id statsd faultwrap sentry sizelimit {{- include "osprofiler_pipe" . }} authtoken keystonecontext {{- include "watcher_pipe" . }} {{- include "audit_pipe" . }} apiv2
+noauth = cors http_proxy_to_wsgi request_id {{- include "watcher_pipe" . }} faultwrap sentry sizelimit {{- include "osprofiler_pipe" . }} noauth apiv2
+keystone = cors http_proxy_to_wsgi request_id faultwrap sentry sizelimit {{- include "osprofiler_pipe" . }} authtoken keystonecontext {{- include "watcher_pipe" . }} {{- include "audit_pipe" . }} apiv2
+keystone_nolimit = cors http_proxy_to_wsgi request_id faultwrap sentry sizelimit {{- include "osprofiler_pipe" . }} authtoken keystonecontext {{- include "watcher_pipe" . }} {{- include "audit_pipe" . }} apiv2
 
 [composite:openstack_volume_api_v3]
 use = call:cinder.api.middleware.auth:pipeline_factory
-noauth = cors http_proxy_to_wsgi request_id {{- include "watcher_pipe" . }} statsd faultwrap sentry sizelimit {{- include "osprofiler_pipe" . }} noauth apiv3
-keystone = cors http_proxy_to_wsgi request_id statsd faultwrap sentry sizelimit {{- include "osprofiler_pipe" . }} authtoken keystonecontext {{- include "watcher_pipe" . }} {{- include "audit_pipe" . }} apiv3
-keystone_nolimit = cors http_proxy_to_wsgi request_id statsd faultwrap sentry sizelimit {{- include "osprofiler_pipe" . }} authtoken keystonecontext {{- include "watcher_pipe" . }} {{- include "audit_pipe" . }} apiv3
+noauth = cors http_proxy_to_wsgi request_id {{- include "watcher_pipe" . }} faultwrap sentry sizelimit {{- include "osprofiler_pipe" . }} noauth apiv3
+keystone = cors http_proxy_to_wsgi request_id faultwrap sentry sizelimit {{- include "osprofiler_pipe" . }} authtoken keystonecontext {{- include "watcher_pipe" . }} {{- include "audit_pipe" . }} apiv3
+keystone_nolimit = cors http_proxy_to_wsgi request_id faultwrap sentry sizelimit {{- include "osprofiler_pipe" . }} authtoken keystonecontext {{- include "watcher_pipe" . }} {{- include "audit_pipe" . }} apiv3
 
 [filter:request_id]
 paste.filter_factory = oslo_middleware.request_id:RequestId.factory
@@ -94,12 +94,8 @@ paste.filter_factory = cinder.api.middleware.auth:CinderKeystoneContext.factory
 [filter:authtoken]
 paste.filter_factory = keystonemiddleware.auth_token:filter_factory
 
-# Converged Cloud statsd & sentry middleware
-[filter:statsd]
-use = egg:ops-middleware#statsd
-
 [filter:sentry]
-use = egg:ops-middleware#sentry
+use = egg:raven#raven
 level = ERROR
 
 {{ if .Values.audit.enabled }}

--- a/openstack/designate/templates/etc/_api-paste.ini.tpl
+++ b/openstack/designate/templates/etc/_api-paste.ini.tpl
@@ -14,16 +14,16 @@ paste.app_factory = designate.api.versions:factory
 
 [composite:osapi_dns_v2]
 use = call:designate.api.middleware:auth_pipeline_factory
-noauth = http_proxy_to_wsgi cors request_id statsd faultwrapper sentry validation_API_v2 noauthcontext {{ if .Values.watcher.enabled }}watcher {{ end }}maintenance normalizeuri {{ if .Values.audit.enabled }}audit {{ end }}osapi_dns_app_v2
-keystone = http_proxy_to_wsgi cors request_id statsd faultwrapper sentry validation_API_v2 authtoken keystonecontext {{ if .Values.watcher.enabled }}watcher {{ end }}maintenance normalizeuri {{ if .Values.audit.enabled }}audit {{ end }}osapi_dns_app_v2
+noauth = http_proxy_to_wsgi cors request_id faultwrapper sentry validation_API_v2 noauthcontext {{ if .Values.watcher.enabled }}watcher {{ end }}maintenance normalizeuri {{ if .Values.audit.enabled }}audit {{ end }}osapi_dns_app_v2
+keystone = http_proxy_to_wsgi cors request_id faultwrapper sentry validation_API_v2 authtoken keystonecontext {{ if .Values.watcher.enabled }}watcher {{ end }}maintenance normalizeuri {{ if .Values.audit.enabled }}audit {{ end }}osapi_dns_app_v2
 
 [app:osapi_dns_app_v2]
 paste.app_factory = designate.api.v2:factory
 
 [composite:osapi_dns_admin]
 use = call:designate.api.middleware:auth_pipeline_factory
-noauth = http_proxy_to_wsgi cors request_id statsd faultwrapper sentry noauthcontext {{ if .Values.watcher.enabled }}watcher {{ end }}maintenance normalizeuri {{ if .Values.audit.enabled }}audit {{ end }}osapi_dns_app_admin
-keystone = http_proxy_to_wsgi cors request_id statsd faultwrapper sentry authtoken keystonecontext {{ if .Values.watcher.enabled }}watcher {{ end }}maintenance normalizeuri {{ if .Values.audit.enabled }}audit {{ end }} osapi_dns_app_admin
+noauth = http_proxy_to_wsgi cors request_id faultwrapper sentry noauthcontext {{ if .Values.watcher.enabled }}watcher {{ end }}maintenance normalizeuri {{ if .Values.audit.enabled }}audit {{ end }}osapi_dns_app_admin
+keystone = http_proxy_to_wsgi cors request_id faultwrapper sentry authtoken keystonecontext {{ if .Values.watcher.enabled }}watcher {{ end }}maintenance normalizeuri {{ if .Values.audit.enabled }}audit {{ end }} osapi_dns_app_admin
 
 [app:osapi_dns_app_admin]
 paste.app_factory = designate.api.admin:factory
@@ -59,12 +59,8 @@ paste.filter_factory = designate.api.middleware:FaultWrapperMiddleware.factory
 [filter:validation_API_v2]
 paste.filter_factory = designate.api.middleware:APIv2ValidationErrorMiddleware.factory
 
-# Converged Cloud statsd & sentry middleware
-[filter:statsd]
-use = egg:ops-middleware#statsd
-
 [filter:sentry]
-use = egg:ops-middleware#sentry
+use = egg:raven#raven
 level = ERROR
 
 # Converged Cloud audit middleware

--- a/openstack/nova/templates/etc/_api-paste.ini.tpl
+++ b/openstack/nova/templates/etc/_api-paste.ini.tpl
@@ -6,7 +6,7 @@ use = egg:Paste#urlmap
 /: meta
 
 [pipeline:meta]
-pipeline = healthcheck cors statsd {{- include "osprofiler_pipe" . }} {{- include "watcher_pipe" . }} sentry metaapp
+pipeline = healthcheck cors {{- include "osprofiler_pipe" . }} {{- include "watcher_pipe" . }} sentry metaapp
 
 [app:metaapp]
 paste.app_factory = nova.api.metadata.handler:MetadataRequestHandler.factory
@@ -46,19 +46,19 @@ use = call:nova.api.openstack.urlmap:urlmap_factory
 # NOTE: this is deprecated in favor of openstack_compute_api_v21_legacy_v2_compatible
 [composite:openstack_compute_api_legacy_v2]
 use = call:nova.api.auth:pipeline_factory
-noauth2 = cors compute_req_id {{- include "osprofiler_pipe" . }} statsd faultwrap sizelimit noauth2 {{- include "watcher_pipe" . }} legacy_ratelimit sentry osapi_compute_app_legacy_v2
-keystone = cors compute_req_id {{- include "osprofiler_pipe" . }} statsd faultwrap sizelimit authtoken keystonecontext {{- include "watcher_pipe" . }} legacy_ratelimit sentry {{- include "audit_pipe" . }} osapi_compute_app_legacy_v2
-keystone_nolimit = cors compute_req_id {{- include "osprofiler_pipe" . }} statsd faultwrap sizelimit authtoken keystonecontext {{- include "watcher_pipe" . }} sentry {{- include "audit_pipe" . }} osapi_compute_app_legacy_v2
+noauth2 = cors compute_req_id {{- include "osprofiler_pipe" . }} faultwrap sizelimit noauth2 {{- include "watcher_pipe" . }} legacy_ratelimit sentry osapi_compute_app_legacy_v2
+keystone = cors compute_req_id {{- include "osprofiler_pipe" . }} faultwrap sizelimit authtoken keystonecontext {{- include "watcher_pipe" . }} legacy_ratelimit sentry {{- include "audit_pipe" . }} osapi_compute_app_legacy_v2
+keystone_nolimit = cors compute_req_id {{- include "osprofiler_pipe" . }} faultwrap sizelimit authtoken keystonecontext {{- include "watcher_pipe" . }} sentry {{- include "audit_pipe" . }} osapi_compute_app_legacy_v2
 
 [composite:openstack_compute_api_v21]
 use = call:nova.api.auth:pipeline_factory_v21
-noauth2 = cors healthcheck http_proxy_to_wsgi compute_req_id {{- include "osprofiler_pipe" . }} statsd faultwrap sizelimit noauth2 {{- include "watcher_pipe" . }} sentry {{- include "audit_pipe" . }} osapi_compute_app_v21
-keystone = cors compute_req_id {{- include "osprofiler_pipe" . }} statsd faultwrap sizelimit authtoken keystonecontext {{- include "watcher_pipe" . }} sentry {{- include "audit_pipe" . }} osapi_compute_app_v21
+noauth2 = cors healthcheck http_proxy_to_wsgi compute_req_id {{- include "osprofiler_pipe" . }} faultwrap sizelimit noauth2 {{- include "watcher_pipe" . }} sentry {{- include "audit_pipe" . }} osapi_compute_app_v21
+keystone = cors compute_req_id {{- include "osprofiler_pipe" . }} faultwrap sizelimit authtoken keystonecontext {{- include "watcher_pipe" . }} sentry {{- include "audit_pipe" . }} osapi_compute_app_v21
 
 [composite:openstack_compute_api_v21_legacy_v2_compatible]
 use = call:nova.api.auth:pipeline_factory_v21
-noauth2 = cors healthcheck http_proxy_to_wsgi compute_req_id {{- include "osprofiler_pipe" . }} statsd faultwrap sizelimit noauth2 legacy_v2_compatible {{- include "watcher_pipe" . }} sentry {{- include "audit_pipe" . }} osapi_compute_app_v21
-keystone = cors healthcheck http_proxy_to_wsgi compute_req_id {{- include "osprofiler_pipe" . }} statsd faultwrap sizelimit authtoken keystonecontext legacy_v2_compatible {{- include "watcher_pipe" . }} sentry {{- include "audit_pipe" . }} osapi_compute_app_v21
+noauth2 = cors healthcheck http_proxy_to_wsgi compute_req_id {{- include "osprofiler_pipe" . }} faultwrap sizelimit noauth2 legacy_v2_compatible {{- include "watcher_pipe" . }} sentry {{- include "audit_pipe" . }} osapi_compute_app_v21
+keystone = cors healthcheck http_proxy_to_wsgi compute_req_id {{- include "osprofiler_pipe" . }} faultwrap sizelimit authtoken keystonecontext legacy_v2_compatible {{- include "watcher_pipe" . }} sentry {{- include "audit_pipe" . }} osapi_compute_app_v21
 
 [filter:request_id]
 paste.filter_factory = oslo_middleware:RequestId.factory
@@ -118,12 +118,8 @@ paste.filter_factory = nova.api.auth:NovaKeystoneContext.factory
 [filter:authtoken]
 paste.filter_factory = keystonemiddleware.auth_token:filter_factory
 
-# Converged Cloud statsd & sentry middleware
-[filter:statsd]
-use = egg:ops-middleware#statsd
-
 [filter:sentry]
-use = egg:ops-middleware#sentry
+use = egg:raven#raven
 level = ERROR
 
 {{ if .Values.audit.enabled }}

--- a/openstack/swift/templates/etc/_proxy-server.conf.tpl
+++ b/openstack/swift/templates/etc/_proxy-server.conf.tpl
@@ -212,14 +212,8 @@ target_project_id_from_path = {{$context.watcher_project_id_from_path | default 
 config_file = /swift-etc/watcher.yaml
 {{- end }}
 
-# [filter:statsd]
-# use = egg:ops-middleware#statsd
-# statsd_host = localhost
-# statsd_port = 9125
-# statsd_replace = swift
-#
 # [filter:sentry]
-# use = egg:ops-middleware#sentry
+# use = egg:raven#raven
 # dsn = {{$cluster.sentry_dsn}}
 # level = ERROR
 {{end}}


### PR DESCRIPTION
… replaced by openstack-watcher-middleware

Any objections against finally removing this outdated dependency (it has been replaced by Openstack-watcher-middleware and plain python-raven)?

I'ld like to merge this on Monday, unless one of you objects..