### PR TITLE
enforce usage of the internal keystone endpoint (needs https://github…

### DIFF
--- a/openstack/barbican/templates/etc/_barbican.conf.tpl
+++ b/openstack/barbican/templates/etc/_barbican.conf.tpl
@@ -46,6 +46,7 @@ max_overflow = {{ .Values.max_overflow | default .Values.global.max_overflow | d
 [keystone_authtoken]
 auth_type = v3password
 auth_version = v3
+auth_interface = internal
 www_authenticate_uri = https://{{include "keystone_api_endpoint_host_public" .}}/v3
 auth_url = {{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3
 username = {{ .Release.Name }}{{ .Values.global.user_suffix }}
@@ -53,7 +54,10 @@ password = {{ .Values.global.barbican_service_password | default (tuple . .Relea
 user_domain_id = default
 project_name = service
 project_domain_id = default
+region_name = {{.Values.global.region}}
 memcached_servers = {{ .Chart.Name }}-memcached.{{ include "svc_fqdn" . }}:{{ .Values.memcached.memcached.port | default 11211 }}
 service_token_roles_required = True
+token_cache_time = 600
+include_service_catalog = false
 
 {{- include "ini_sections.cache" . }}

--- a/openstack/cinder/templates/etc/_cinder.conf.tpl
+++ b/openstack/cinder/templates/etc/_cinder.conf.tpl
@@ -47,6 +47,7 @@ use_default_quota_class=false
 [keystone_authtoken]
 auth_plugin = v3password
 auth_version = v3
+auth_interface = internal
 www_authenticate_uri = https://{{include "keystone_api_endpoint_host_public" .}}/v3
 auth_url = {{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3
 username = {{ .Values.global.cinder_service_user | default "cinder"}}{{ .Values.global.user_suffix }}
@@ -54,8 +55,11 @@ password = {{ .Values.global.cinder_service_password | default (tuple . .Values.
 user_domain_name = {{.Values.global.keystone_service_domain | default "Default"}}
 project_name = {{.Values.global.keystone_service_project | default "service"}}
 project_domain_name = {{.Values.global.keystone_service_domain | default "Default"}}
+region_name = {{.Values.global.region}}
 memcached_servers = {{ .Chart.Name }}-memcached.{{ include "svc_fqdn" . }}:{{ .Values.memcached.memcached.port | default 11211 }}
+service_token_roles_required = True
 insecure = True
+token_cache_time = 600
 
 [oslo_policy]
 policy_file = /etc/cinder/policy.json
@@ -68,6 +72,7 @@ lock_path = /var/lib/cinder/tmp
 {{- include "ini_sections.cache" . }}
 
 [barbican]
+barbican_endpoint = internal
 auth_endpoint = {{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3
 
 [key_manager]

--- a/openstack/designate/templates/etc/_designate.conf.tpl
+++ b/openstack/designate/templates/etc/_designate.conf.tpl
@@ -189,6 +189,7 @@ enabled_extensions_v2 = quotas, reports
 [keystone_authtoken]
 auth_plugin = v3password
 auth_version = v3
+auth_interface = internal
 www_authenticate_uri = https://{{include "keystone_api_endpoint_host_public" .}}/v3
 auth_url = {{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3
 username = {{ .Values.global.designate_service_user }}
@@ -196,8 +197,11 @@ password = {{ .Values.global.designate_service_password }}
 user_domain_name = {{.Values.global.keystone_service_domain | default "Default"}}
 project_name = {{.Values.global.keystone_service_project |  default "service"}}
 project_domain_name = {{.Values.global.keystone_service_domain | default "Default"}}
+region_name = {{.Values.global.region}}
 memcached_servers = {{.Release.Name}}-memcached.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.region}}.{{.Values.global.tld}}:{{.Values.global.memcached_port_public | default 11211}}
 insecure = True
+token_cache_time = 600
+include_service_catalog = false
 
 #-----------------------
 

--- a/openstack/glance/templates/etc/_glance-api.conf.tpl
+++ b/openstack/glance/templates/etc/_glance-api.conf.tpl
@@ -20,6 +20,7 @@ wsgi_default_pool_size = {{ .Values.wsgi_default_pool_size | default 100 }}
 [keystone_authtoken]
 auth_plugin = v3password
 auth_version = v3
+auth_interface = internal
 www_authenticate_uri = https://{{include "keystone_api_endpoint_host_public" .}}/v3
 auth_url = {{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3
 username = {{ .Values.global.glance_service_user | default "glance" | replace "$" "$$"}}
@@ -30,6 +31,8 @@ project_name = {{.Values.global.keystone_service_project |  default "service"}}
 project_domain_name = {{.Values.global.keystone_service_domain | default "Default"}}
 memcached_servers = {{ .Chart.Name }}-memcached.{{ include "svc_fqdn" . }}:{{ .Values.memcached.memcached.port | default 11211 }}
 insecure = True
+token_cache_time = 600
+service_token_roles_required = True
 
 [paste_deploy]
 flavor = keystone

--- a/openstack/glance/templates/etc/_glance-registry.conf.tpl
+++ b/openstack/glance/templates/etc/_glance-registry.conf.tpl
@@ -16,6 +16,7 @@ wsgi_default_pool_size = {{ .Values.wsgi_default_pool_size | default 100 }}
 [keystone_authtoken]
 auth_plugin = v3password
 auth_version = v3
+auth_interface = internal
 www_authenticate_uri = https://{{include "keystone_api_endpoint_host_public" .}}/v3
 auth_url = {{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3
 username = {{ .Values.global.glance_service_user | default "glance" | replace "$" "$$"}}
@@ -26,6 +27,9 @@ project_name = {{.Values.global.keystone_service_project |  default "service"}}
 project_domain_name = {{.Values.global.keystone_service_domain | default "Default"}}
 memcached_servers = {{ .Chart.Name }}-memcached.{{ include "svc_fqdn" . }}:{{ .Values.memcached.memcached.port | default 11211 }}
 insecure = True
+token_cache_time = 600
+include_service_catalog = false
+service_token_roles_required = True
 
 [paste_deploy]
 flavor = keystone

--- a/openstack/ironic/templates/etc/_ironic.conf.tpl
+++ b/openstack/ironic/templates/etc/_ironic.conf.tpl
@@ -41,7 +41,7 @@ auth_section = service_catalog
 
 [service_catalog]
 auth_section = service_catalog
-# ?? valid_interfaces = public {{- /* Public, so that the ironic-python-agent doesn't get a private url */}}
+valid_interfaces = public {{- /* Public, so that the ironic-python-agent doesn't get a private url */}}
 auth_type = v3password
 auth_interface = internal
 auth_version = v3

--- a/openstack/ironic/templates/etc/_ironic.conf.tpl
+++ b/openstack/ironic/templates/etc/_ironic.conf.tpl
@@ -33,20 +33,17 @@ public_endpoint = https://{{ include "ironic_api_endpoint_host_public" .}}
 
 [keystone]
 auth_section = service_catalog
-region = {{ .Values.global.region }}
 
 [keystone_authtoken]
 auth_section = service_catalog
-memcached_servers = {{ .Chart.Name }}-memcached.{{ include "svc_fqdn" . }}:{{ .Values.memcached.memcached.port | default 11211 }}
 
 {{- include "ini_sections.audit_middleware_notifications" . }}
 
 [service_catalog]
 auth_section = service_catalog
-valid_interfaces = public {{- /* Public, so that the ironic-python-agent doesn't get a private url */}}
-region_name = {{ .Values.global.region }}
-# auth_section
+# ?? valid_interfaces = public {{- /* Public, so that the ironic-python-agent doesn't get a private url */}}
 auth_type = v3password
+auth_interface = internal
 auth_version = v3
 www_authenticate_uri = https://{{include "keystone_api_endpoint_host_public" .}}/v3
 auth_url = {{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3
@@ -55,7 +52,11 @@ username = {{ .Values.global.ironicServiceUser }}{{ .Values.global.user_suffix }
 password = {{ .Values.global.ironicServicePassword | default (tuple . .Values.global.ironicServiceUser | include "identity.password_for_user")  | replace "$" "$$" }}
 project_domain_name = {{.Values.global.keystone_service_domain | default "Default"}}
 project_name = {{.Values.global.keystone_service_project | default "service"}}
+region_name = {{ .Values.global.region }}
 insecure = True
+service_token_roles_required = True
+memcached_servers = {{ .Chart.Name }}-memcached.{{ include "svc_fqdn" . }}:{{ .Values.memcached.memcached.port | default 11211 }}
+token_cache_time = 600
 
 [glance]
 auth_section = service_catalog

--- a/openstack/ironic/templates/etc/_ironic_inspector.conf.tpl
+++ b/openstack/ironic/templates/etc/_ironic_inspector.conf.tpl
@@ -3,14 +3,7 @@ log_config_append = /etc/ironic-inspector/logging.ini
 {{- include "ini_sections.default_transport_url" . }}
 
 [ironic]
-region_name = {{.Values.global.region}}
-auth_url = {{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3
-auth_type = v3password
-username = {{ .Values.global.ironicServiceUser }}{{ .Values.global.user_suffix }}
-password = {{ .Values.global.ironicServicePassword | default (tuple . .Values.global.ironicServiceUser | include "identity.password_for_user")  | replace "$" "$$" }}
-user_domain_name = {{.Values.global.keystone_service_domain | default "Default"}}
-project_name = {{.Values.global.keystone_service_project | default "service"}}
-project_domain_name = {{.Values.global.keystone_service_domain | default "Default"}}
+auth_section = keystone_authtoken
 
 [api]
 host_ip = 0.0.0.0
@@ -43,9 +36,10 @@ connection = {{ tuple . "ironic_inspector" "ironic_inspector" .Values.inspectord
 {{- include "ini_sections.audit_middleware_notifications" . }}
 
 [keystone_authtoken]
-www_authenticate_uri = {{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}
+www_authenticate_uri = https://{{include "keystone_api_endpoint_host_public" .}}/v3
 auth_url = {{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3
 auth_type = v3password
+auth_interface = internal
 username = {{ .Values.global.ironicServiceUser }}{{ .Values.global.user_suffix }}
 password = {{ .Values.global.ironicServicePassword | default (tuple . .Values.global.ironicServiceUser| include "identity.password_for_user") }}
 user_domain_name = {{.Values.global.keystone_service_domain | default "Default"}}
@@ -55,6 +49,7 @@ memcached_servers = {{ .Chart.Name }}-memcached.{{ include "svc_fqdn" . }}:{{ .V
 region_name = {{.Values.global.region}}
 service_token_roles_required = True
 insecure = True
+token_cache_time = 600
 
 [oslo_middleware]
 enable_proxy_headers_parsing = True

--- a/openstack/manila/templates/etc/_manila.conf.tpl
+++ b/openstack/manila/templates/etc/_manila.conf.tpl
@@ -85,6 +85,7 @@ lock_path = /var/lib/manila/tmp
 [keystone_authtoken]
 auth_type = v3password
 auth_version = v3
+auth_interface = internal
 www_authenticate_uri = https://{{include "keystone_api_endpoint_host_public" .}}/v3
 auth_url = {{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3
 username = {{ .Values.global.manila_service_user | default "manila" | replace "$" "$$" }}
@@ -97,6 +98,8 @@ memcached_servers = {{ .Chart.Name }}-memcached.{{ include "svc_fqdn" . }}:{{ .V
 service_token_roles_required = True
 service_token_roles = service
 insecure = True
+token_cache_time = 600
+include_service_catalog = false
 
 {{- include "ini_sections.audit_middleware_notifications" . }}
 

--- a/openstack/neutron/templates/etc/_neutron.conf.tpl
+++ b/openstack/neutron/templates/etc/_neutron.conf.tpl
@@ -102,6 +102,7 @@ max_overflow = {{ .Values.max_overflow | default .Values.global.max_overflow | d
 [keystone_authtoken]
 auth_plugin = v3password
 auth_version = v3
+auth_interface = internal
 www_authenticate_uri = https://{{include "keystone_api_endpoint_host_public" .}}/v3
 auth_url = {{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3
 username = {{ .Values.global.neutron_service_user | default "neutron" | replace "$" "$$" }}
@@ -109,8 +110,11 @@ password = {{ .Values.global.neutron_service_password | default "" | replace "$"
 user_domain_name = {{.Values.global.keystone_service_domain | default "Default"}}
 project_name = {{.Values.global.keystone_service_project |  default "service"}}
 project_domain_name = {{.Values.global.keystone_service_domain | default "Default"}}
+region_name = {{.Values.global.region}}
 memcached_servers = {{ .Chart.Name }}-memcached.{{ include "svc_fqdn" . }}:{{ .Values.memcached.memcached.port | default 11211 }}
+service_token_roles_required = True
 insecure = True
+token_cache_time = 600
 
 [oslo_messaging_notifications]
 driver = noop

--- a/openstack/nova/templates/etc/_nova.conf.tpl
+++ b/openstack/nova/templates/etc/_nova.conf.tpl
@@ -113,6 +113,7 @@ project_domain_name = {{.Values.global.keystone_service_domain | default "Defaul
 [keystone_authtoken]
 auth_plugin = v3password
 auth_version = v3
+auth_interface = internal
 www_authenticate_uri = https://{{include "keystone_api_endpoint_host_public" .}}/v3
 auth_url = {{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3
 username = {{ .Values.global.nova_service_user | default "nova" }}{{ .Values.global.user_suffix }}
@@ -120,8 +121,10 @@ password = {{ .Values.global.nova_service_password | default (tuple . .Values.gl
 user_domain_name = "{{.Values.global.keystone_service_domain | default "Default" }}"
 project_name = "{{.Values.global.keystone_service_project | default "service" }}"
 project_domain_name = "{{.Values.global.keystone_service_domain | default "Default" }}"
+region_name = {{.Values.global.region}}
 memcached_servers = {{ .Chart.Name }}-memcached.{{ include "svc_fqdn" . }}:{{ .Values.memcached.memcached.port | default 11211 }}
 insecure = True
+token_cache_time = 600
 
 #[upgrade_levels]
 #compute = auto
@@ -133,7 +136,8 @@ driver = noop
 enable_proxy_headers_parsing = true
 
 [placement]
-auth_type = password
+auth_type = v3password
+auth_version = v3
 auth_url = http://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default "5000" }}/v3
 username = {{.Values.global.placement_service_user}}
 password = {{ .Values.global.placement_service_password | default (tuple . .Values.global.placement_service_user | include "identity.password_for_user") | replace "$" "$$" }}


### PR DESCRIPTION
….com/sapcc/keystonemiddleware to be functional) and enable or extend token caching times.

In order to bring down the keystone token validation request rates, I'ld like to extend token caching times client side and also make sure that service->keystone traffic takes a direct (internal) route.
This will offload ingress and also paves the way for easier source-ip based rate throttling for keystone, since all internal traffic will originate on the internal endpoint, leaving the public endpoint to be throttled without risking throttling our internal traffic.

Please note that this will only start working once all services use https://github.com/sapcc/keystonemiddleware, which does away with the hardcoded use of the 'admin' endpoint (as in upstream code) and the lacking possibility to hand down the desired endpoint to the keystone-client layer.
