### PR TITLE
[neutron] Add nsxv3 agent

### DIFF
--- a/openstack/neutron/templates/vct-nsxv3-agent-configmap.yaml
+++ b/openstack/neutron/templates/vct-nsxv3-agent-configmap.yaml
@@ -1,0 +1,45 @@
+{{- if and (.Capabilities.APIVersions.Has "vcenter-operator.stable.sap.cc/v1") (contains ",nsxv3" .Values.ml2_mechanismdrivers ) }}
+apiVersion: vcenter-operator.stable.sap.cc/v1
+kind: VCenterTemplate
+metadata:
+  name: 'neutron-ml2-nsxv3-configmap'
+  scope: 'cluster'
+  jinja2_options:
+    variable_start_string: '{='
+    variable_end_string: '=}'
+template: |
+  {% if nsx_t_enabled is defined and nsx_t_enabled -%}
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: neutron-ml2-nsxv3-{= name =}
+    labels:
+      system: openstack
+      type: configuration
+      component: neutron
+  data:
+    ml2-nsxv3.ini: |
+      [DEFAULT]
+      # The agent binds only port with the same host
+      host = nova-compute-{= name =}
+      backdoor_socket = /var/lib/neutron/eventlet_backdoor.socket
+
+      [securitygroup]
+      firewall_driver = networking_nsxv3.plugins.ml2.drivers.nsxv3.agent.extensions.firewall.NsxV3SecurityGroupsDriver
+
+      [AGENT]
+      {{- range $k, $v := .Values.drivers.nsxv3.defaults.AGENT }}
+      {{ $k }} = {{ $v }}
+      {{- end }}
+
+      [NSXV3]
+      nsxv3_login_user = {= username | quote =}
+      {%- set hostname = "nsx-ctl-" + name + "." + domain %}
+      nsxv3_login_hostname = {= hostname =}
+      nsxv3_login_password = {= username | derive_password(hostname) | quote =}
+
+      {{- range $k, $v := .Values.drivers.nsxv3.defaults.NSXV3 }}
+      {{ $k }} = {{ $v }}
+      {{- end }}
+  {% endif %}
+{{ end }}

--- a/openstack/neutron/templates/vct-nsxv3-agent-deployment.yaml
+++ b/openstack/neutron/templates/vct-nsxv3-agent-deployment.yaml
@@ -1,0 +1,105 @@
+{{- if and (.Capabilities.APIVersions.Has "vcenter-operator.stable.sap.cc/v1") (contains ",nsxv3" .Values.ml2_mechanismdrivers ) }}
+apiVersion: vcenter-operator.stable.sap.cc/v1
+kind: VCenterTemplate
+metadata:
+  name: 'neutron-nsxv3-agent-deployment'
+  scope: 'cluster'
+  jinja2_options:
+    variable_start_string: '{='
+    variable_end_string: '=}'
+template: |
+  {% if nsx_t_enabled is defined and nsx_t_enabled -%}
+  apiVersion: extensions/v1beta1
+  kind: Deployment
+  metadata:
+    name: neutron-nsxv3-agent-{= name =}
+    labels:
+      system: openstack
+      type: backend
+      component: neutron
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 5
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 0
+        maxSurge: 1
+    selector:
+      matchLabels:
+          name: neutron-nsxv3-agent-{= name =}
+    template:
+      metadata:
+        labels:
+          application: neutron
+          component: agent
+          name: neutron-nsxv3-agent-{= name =}
+        annotations:
+          configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") . | sha256sum }}
+          prometheus.io/scrape: "true"
+          prometheus.io/port: "9102"
+      spec:
+        containers:
+        - name: neutron-nsxv3-agent
+          image: {{ default "hub.global.cloud.sap" .Values.global.imageRegistry }}/{{.Values.image_name}}:{{.Values.image_tag}}
+          imagePullPolicy: IfNotPresent
+          command: ["dumb-init"]
+          args: ["neutron-nsxv3-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/plugins/ml2/ml2-conf.ini", "--config-file", "/etc/neutron/plugins/ml2/ml2-nsxv3.ini"]
+          env:
+          - name: SENTRY_DSN
+            value: {{ .Values.sentry_dsn | quote }}
+          - name: STATSD_HOST
+            value: "localhost"
+          - name: STATSD_PORT
+            value: "9125"
+          - name: PYTHONWARNINGS
+            value: "ignore:Unverified HTTPS request"
+          - name: PGAPPNAME
+            value: neutron-nsxv3-agent-{= name =}
+          volumeMounts:
+          - mountPath: /etc/neutron
+            name: etcneutron
+          - mountPath: /etc/neutron/neutron.conf
+            name: neutron-etc
+            subPath: neutron.conf
+            readOnly: true
+          - mountPath: /etc/neutron/api-paste.ini
+            name: neutron-etc
+            subPath: api-paste.ini
+            readOnly: true
+          - mountPath: /etc/neutron/policy.json
+            name: neutron-etc
+            subPath: neutron-policy.json
+            readOnly: true
+          - mountPath: /etc/neutron/logging.conf
+            name: neutron-etc
+            subPath: logging.conf
+            readOnly: true
+          - mountPath: /etc/neutron/plugins/ml2/ml2-conf.ini
+            name: neutron-etc
+            subPath: ml2-conf.ini
+            readOnly: true
+          - mountPath: /etc/neutron/plugins/ml2/ml2-nsxv3.ini
+            name: ml2-conf-nsxv3
+            subPath: ml2-nsxv3.ini
+            readOnly: true
+        - name: statsd
+          image: prom/statsd-exporter:v0.5.0
+          imagePullPolicy: IfNotPresent
+          ports:
+          - name: statsd
+            containerPort: 9125
+            protocol: UDP
+          - name: metrics
+            containerPort: 9102
+        volumes:
+        - name: etcneutron
+          emptyDir: {}
+        - name: neutron-etc
+          configMap:
+            name: neutron-etc
+        - name: ml2-conf-nsxv3
+          configMap:
+            name: neutron-ml2-nsxv3-{= name =}
+  {% endif %}
+{{- end }}

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -104,6 +104,19 @@ cisco_ucsm_bm:
     physical_network: DEFINED-IN-REGION-CHART
     vnic_paths: DEFINED-IN-REGION-CHART
 
+drivers:
+  nsxv3:
+    defaults:
+      AGENT:
+        sync_pool_size: 10
+        db_max_records_per_query: 2000
+      NSXV3:
+        nsxv3_connection_retry_count: 10
+        nsxv3_connection_retry_sleep: 5
+        nsxv3_login_port: 443
+        nsxv3_transport_zone_name: openstack-tz
+        nsxv3_suppress_ssl_wornings: True
+        nsxv3_max_records_per_query: 2000
 
 logging:
     formatters:


### PR DESCRIPTION
Two things need to happen, before the agent activated:
1. ml2_mechanismdrivers must contain ,nsxv3. No point in even trying, if it is not used
2. The vcenter-operator must detect an OpaqueSwitch, which is a switch managed outside of vcenter (in our case an nsx-t switch)

NSX-T must be reachable under name nsx-ctl-<bb-name>.<domain> with the m3apiuser0 and the derived password from the master-password.
The bb-name must not contain leading zeros in the number