### PR TITLE
Adds oomkill exporter

### DIFF
--- a/system/kube-monitoring/charts/oomkill-exporter/Chart.yaml
+++ b/system/kube-monitoring/charts/oomkill-exporter/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: OOMKill exporter for Kubernetes
+name: oomkill-exporter
+version: 0.1.0

--- a/system/kube-monitoring/charts/oomkill-exporter/templates/_helpers.tpl
+++ b/system/kube-monitoring/charts/oomkill-exporter/templates/_helpers.tpl
@@ -1,0 +1,7 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/system/kube-monitoring/charts/oomkill-exporter/templates/daemonset.yaml
+++ b/system/kube-monitoring/charts/oomkill-exporter/templates/daemonset.yaml
@@ -1,0 +1,51 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: {{ template "name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "name" . }}
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: {{ template "name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "name" . }}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "{{ default 9102 .Values.metrics.port }}"
+    spec:
+      containers:
+      - name: {{ template "name" . }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+        - -logtostderr
+        - -listen-address=:{{ default 9102 .Values.metrics.port }}
+        - -v=0
+        securityContext:
+          privileged: true
+{{ toYaml .Values.resources | indent 8 }}
+        env:
+        - name: DOCKER_HOST
+          value: "unix:///var/run/docker.sock"
+        volumeMounts:
+        - name: kmsg
+          mountPath: /dev/kmsg
+          readOnly: true
+        - name: docker
+          mountPath: /var/run/docker.sock 
+        ports:
+        - name: metrics
+          containerPort: {{ default 9102 .Values.metrics.port }}
+      volumes:
+      - name: kmsg
+        hostPath:
+          path: /dev/kmsg
+      - name: docker
+        hostPath:
+          path: /var/run/docker.sock

--- a/system/kube-monitoring/charts/oomkill-exporter/values.yaml
+++ b/system/kube-monitoring/charts/oomkill-exporter/values.yaml
@@ -1,0 +1,13 @@
+image:
+  repository: sapcc/kubernetes-oomkill-exporter
+  tag: 0.2.0
+  pullPolicy: IfNotPresent
+resources:
+  limits:
+    cpu: 100m
+    memory: 100Mi
+  requests:
+    cpu: 20m
+    memory: 20Mi
+metrics:
+  port: "9102"

--- a/system/kube-monitoring/charts/prometheus-frontend/kubernetes-oomkill.alerts
+++ b/system/kube-monitoring/charts/prometheus-frontend/kubernetes-oomkill.alerts
@@ -1,0 +1,28 @@
+groups:
+- name: oomkill.alerts
+  rules:
+  - alert: PodOOMKilled
+    expr: sum(changes(klog_pod_oomkill[24h]) > 0 or ((klog_pod_oomkill == 1) unless (klog_pod_oomkill offset 24h == 1))) by (namespace, pod_name)
+    for: 5m
+    labels:
+      tier: k8s
+      service: resources
+      severity: warning
+      context: memory
+      meta: "{{ $labels.namespace }}/{{ $labels.pod_name }}"
+    annotations:
+      summary: Pod was oomkilled recently
+      description: The pod {{ $labels.namespace }}/{{ $labels.pod_name }} was hit at least once by the oom killer within 24h
+
+  - alert: PodConstantlyOOMKilled
+    expr: sum(changes(klog_pod_oomkill[30m]) ) by (namespace, pod_name) > 2
+    for: 5m
+    labels:
+      tier: k8s
+      service: resources
+      severity: critical
+      context: memory
+      meta: "{{ $labels.namespace }}/{{ $labels.pod_name }}"
+    annotations:
+      summary: Pod was oomkilled more then 2 times in 30 minutes
+      description: The pod {{ $labels.namespace }}/{{ $labels.pod_name }} killed several times in short succession. This could be due to wrong resource limits.


### PR DESCRIPTION
This PR adds the oomkill exporter chart to kube-monitoring. See https://github.com/sapcc/kubernetes-oomkill-exporter for more details on the exporter.