### PR TITLE
Add event exporter chart

### DIFF
--- a/system/kube-monitoring/charts/event-exporter/Chart.yaml
+++ b/system/kube-monitoring/charts/event-exporter/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: Eventexporter for Kubernetes
+name: eventexporter
+version: 0.1.0

--- a/system/kube-monitoring/charts/event-exporter/templates/_helpers.tpl
+++ b/system/kube-monitoring/charts/event-exporter/templates/_helpers.tpl
@@ -1,0 +1,7 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/system/kube-monitoring/charts/event-exporter/templates/clusterrole.yaml
+++ b/system/kube-monitoring/charts/event-exporter/templates/clusterrole.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ template "name" . }}
+rules:
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get"]

--- a/system/kube-monitoring/charts/event-exporter/templates/clusterrolebinding.yaml
+++ b/system/kube-monitoring/charts/event-exporter/templates/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "name" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "name" . }}
+  namespace: {{ .Release.Namespace }}

--- a/system/kube-monitoring/charts/event-exporter/templates/configmap.yaml
+++ b/system/kube-monitoring/charts/event-exporter/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "name" . }}
+  namespace: {{ .Release.Namespace }}
+data:
+  {{- if .Values.metrics.config }}
+{{ toYaml .Values.metrics.config | indent 2 }}
+  {{ end }}

--- a/system/kube-monitoring/charts/event-exporter/templates/deployment.yaml
+++ b/system/kube-monitoring/charts/event-exporter/templates/deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "name" . }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "name" . }}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "{{ default 9102 .Values.metrics.port }}"
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+      containers:
+      - name: {{ template "name" . }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+        - -discard=60s
+        - -logtostderr
+        - -listen-address=:{{ default 9102 .Values.metrics.port }}
+        - -v=0
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/eventexporter
+        ports:
+        - name: metrics
+          containerPort: {{ default 9102 .Values.metrics.port }}
+{{ toYaml .Values.resources | indent 8 }}
+      serviceAccount: {{ template "name" . }}
+      volumes:
+      - name: config-volume
+        configMap:
+          name: {{ template "name" . }}

--- a/system/kube-monitoring/charts/event-exporter/templates/serviceaccount.yaml
+++ b/system/kube-monitoring/charts/event-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "name" . }}
+  namespace: {{ .Release.Namespace }}

--- a/system/kube-monitoring/charts/event-exporter/values.yaml
+++ b/system/kube-monitoring/charts/event-exporter/values.yaml
@@ -1,0 +1,28 @@
+image:
+  repository: sapcc/kubernetes-eventexporter
+  tag: 0.3.0
+  pullPolicy: IfNotPresent
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 20Mi
+  limits:
+    cpu: 200m
+    memory: 100Mi
+
+metrics:
+  port: "9102"
+  config:
+    config.yaml: |-
+      metrics:
+      - name: kube_pod_image_pull_backoff_total
+        event_matcher:
+        - key: InvolvedObject.Kind
+          expr: Pod
+        - key: Message
+          expr: Back-off pulling image "(.*)"
+        labels:
+          image: Message[1]
+          namespace: InvolvedObject.Namespace
+          pod_name: InvolvedObject.Name


### PR DESCRIPTION
This PR adds kubernetes event exporter chart to kube-monitoring. See https://github.com/sapcc/kubernetes-eventexporter for details.