### PR TITLE
Make rbac roles in eventexporter optional

### DIFF
--- a/system/kube-monitoring/charts/event-exporter/templates/clusterrole.yaml
+++ b/system/kube-monitoring/charts/event-exporter/templates/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -9,3 +10,4 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get"]
+{{- end }}

--- a/system/kube-monitoring/charts/event-exporter/templates/clusterrolebinding.yaml
+++ b/system/kube-monitoring/charts/event-exporter/templates/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -10,3 +11,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "name" . }}
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/system/kube-monitoring/charts/event-exporter/values.yaml
+++ b/system/kube-monitoring/charts/event-exporter/values.yaml
@@ -26,3 +26,6 @@ metrics:
           image: Message[1]
           namespace: InvolvedObject.Namespace
           pod_name: InvolvedObject.Name
+
+rbac:
+  create: false


### PR DESCRIPTION
With this PR rbac rules can be disabled in values file for eventexporter.