### PR TITLE
exports events that indicate scheduling failures

### DIFF
--- a/system/kube-monitoring/charts/event-exporter/values.yaml
+++ b/system/kube-monitoring/charts/event-exporter/values.yaml
@@ -26,6 +26,28 @@ metrics:
           image: Message[1]
           namespace: InvolvedObject.Namespace
           pod_name: InvolvedObject.Name
-
+      - name: kube_pod_failed_scheduling_cpu_total
+        event_matcher:
+        - key: Reason
+          expr: FailedScheduling
+        - key: InvolvedObject.Kind
+          expr: Pod
+        - key: Message
+          expr: No nodes are available that match all of the predicates: .*Insufficient cpu.*
+        labels:
+          namespace: InvolvedObject.Namespace
+          pod_name: InvolvedObject.Name          
+      - name: kube_pod_failed_scheduling_memory_total
+        event_matcher:
+        - key: Reason
+          expr: FailedScheduling
+        - key: InvolvedObject.Kind
+          expr: Pod
+        - key: Message
+          expr: No nodes are available that match all of the predicates: .*Insufficient memory.*
+        labels:
+          namespace: InvolvedObject.Namespace
+          pod_name: InvolvedObject.Name       
+          
 rbac:
   create: false


### PR DESCRIPTION
This commit exports events that indicate a failure in scheduling pods due to insufficient CPU or memory. Either because requests are set too hight to fit at all or the cluster not being able to full-fill the request anymore.

The intention is to provide an alert that bubbles up scheduling failures due to miss-configuration or resource constraints being exceeded.

An actual event looks like this:
```
Name:             resource-test-bdfcd9f5-g8jq5.157e0a42f7ead471
Namespace:        default
Labels:           <none>
Annotations:      <none>
API Version:      v1
Count:            12
First Timestamp:  2019-01-28T14:43:24Z
Involved Object:
  API Version:       v1
  Kind:              Pod
  Name:              resource-test-bdfcd9f5-g8jq5
  Namespace:         default
  Resource Version:  158624276
  UID:               10dafd77-230b-11e9-8472-22d09ddc4668
Kind:                Event
Last Timestamp:      2019-01-28T14:45:34Z
Message:             No nodes are available that match all of the predicates: Insufficient cpu (19), Insufficient memory (19), PodToleratesNodeTaints (10).
Metadata:
  Creation Timestamp:  2019-01-28T14:43:24Z
  Resource Version:    158624791
  Self Link:           /api/v1/namespaces/default/events/resource-test-bdfcd9f5-g8jq5.157e0a42f7ead471
  UID:                 10dd4b2d-230b-11e9-8472-22d09ddc4668
Reason:                FailedScheduling
Source:
  Component:  default-scheduler
Type:         Warning
Events:       <none>
```