### PR TITLE
[prometheus] save container cpu metrics of pods

### DIFF
--- a/system/kube-monitoring/charts/prometheus-collector/aggregation.rules
+++ b/system/kube-monitoring/charts/prometheus-collector/aggregation.rules
@@ -2,13 +2,13 @@ groups:
 - name: cpu
   rules:
   - record: aggregated:container_cpu_system_seconds_total
-    expr: sum(container_cpu_system_seconds_total) by (id,namespace,pod_name,container_name)
+    expr: sum(container_cpu_system_seconds_total{container_name!="POD"}) by (id,namespace,pod_name,container_name)
 
   - record: aggregated:container_cpu_usage_seconds_total
-    expr: sum(container_cpu_usage_seconds_total) by (id,namespace,pod_name,container_name)
+    expr: sum(container_cpu_usage_seconds_total{container_name!="POD"}) by (id,namespace,pod_name,container_name)
 
   - record: aggregated:container_cpu_user_seconds_total
-    expr: sum(container_cpu_user_seconds_total) by (id,namespace,pod_name,container_name)
+    expr: sum(container_cpu_user_seconds_total{container_name!="POD"}) by (id,namespace,pod_name,container_name)
 
 - name: swift
   rules:

--- a/system/kube-monitoring/charts/prometheus-collector/aggregation.rules
+++ b/system/kube-monitoring/charts/prometheus-collector/aggregation.rules
@@ -2,16 +2,13 @@ groups:
 - name: cpu
   rules:
   - record: aggregated:container_cpu_system_seconds_total
-    expr: sum(container_cpu_system_seconds_total) by (id,namespace,pod_name)
+    expr: sum(container_cpu_system_seconds_total) by (id,namespace,pod_name,container_name)
 
   - record: aggregated:container_cpu_usage_seconds_total
-    expr: sum(container_cpu_usage_seconds_total) by (id,namespace,pod_name)
+    expr: sum(container_cpu_usage_seconds_total) by (id,namespace,pod_name,container_name)
 
   - record: aggregated:container_cpu_user_seconds_total
-    expr: sum(container_cpu_user_seconds_total) by (id,namespace,pod_name)
-
-  - record: aggregated:container_cpu_user_seconds_total
-    expr: sum(container_cpu_user_seconds_total) by (id,namespace,pod_name)
+    expr: sum(container_cpu_user_seconds_total) by (id,namespace,pod_name,container_name)
 
 - name: swift
   rules:


### PR DESCRIPTION
It would be nice to have some longer period of cpu metrics also sliced by containers within a pod.

Please deny this PR if it is as it is for a reason...

