### PR TITLE
[kube-monitoring] adds ironic exporter

### DIFF
--- a/system/kube-monitoring/charts/ironic-exporter/Chart.yaml
+++ b/system/kube-monitoring/charts/ironic-exporter/Chart.yaml
@@ -1,0 +1,3 @@
+description: OpenStack ironic exporter
+name: ironic-exporter
+version: 1.0.0

--- a/system/kube-monitoring/charts/ironic-exporter/templates/deployment.yaml
+++ b/system/kube-monitoring/charts/ironic-exporter/templates/deployment.yaml
@@ -1,0 +1,36 @@
+{{ if .Values.enabled -}}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: ironic_exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ironic_exporter
+      type: exporter
+  template:
+    metadata:
+      labels:
+        app: ironic_port_exporter
+        type: exporter
+    spec:
+      containers:
+      - name: ironic-exporter
+        image: "{{ .Values.global.imageRegistry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        env:
+        - name: LOGLEVEL
+          value: "{{ .Values.log_level }}"
+        - name: OS_VERSION
+          value: "{{ .Values.tag }}"
+        - name: OS_IRONIC_USERNAME
+          value: "{{ .Values.global.ipmi_exporter_user }}"
+        - name: OS_IRONIC_PASSWORD
+          value: "{{ .Values.global.ipmi_exporter_user_passwd }}"
+        - name: OS_USER_DOMAIN_NAME
+          value: "{{ .Values.os_user_domain_name }}"
+        - name: OS_PROJECT_NAME
+          value: "{{ .Values.os_project_name }}"
+        - name: OS_PROJECT_DOMAIN_NAME
+          value: "{{ .Values.os_project_domain_name }}"
+{{ end }}

--- a/system/kube-monitoring/charts/ironic-exporter/values.yaml
+++ b/system/kube-monitoring/charts/ironic-exporter/values.yaml
@@ -1,0 +1,7 @@
+image:
+  repository: monsoon/ironic-exporter
+  tag: d4147666
+
+os_user_domain_name: "Default"
+os_project_name: "master"
+os_project_domain_name: "ccadmin"


### PR DESCRIPTION
First version:

watches for ports that are still in use