### PR TITLE
[openstack/keystone] rate limit

### DIFF
--- a/openstack/keystone/requirements.lock
+++ b/openstack/keystone/requirements.lock
@@ -2,6 +2,9 @@ dependencies:
 - name: memcached
   repository: file://../../common/memcached
   version: 0.0.1
+- name: memcached
+  repository: file://../../common/memcached
+  version: 0.0.1
 - name: rabbitmq
   repository: file://../../common/rabbitmq
   version: 0.1.0
@@ -11,5 +14,5 @@ dependencies:
 - name: pgmetrics
   repository: file://../../common/pgmetrics
   version: 0.1.0
-digest: sha256:eaa169742b77c4034eb3d9b41c5acddbfed140ae329c5903041bfdaabeaa29ff
-generated: 2017-11-24T14:55:08.235099+01:00
+digest: sha256:7cbc91d9b21a3faf3f7001583893927b2be84eddf88cd42576a370f8a31eb174
+generated: 2019-02-05T14:06:15.371731+01:00

--- a/openstack/keystone/requirements.yaml
+++ b/openstack/keystone/requirements.yaml
@@ -2,6 +2,10 @@ dependencies:
   - name: memcached
     repository: file://../../common/memcached
     version: 0.0.1
+  - name: memcached
+    alias: memcached-ratelimit
+    repository: file://../../common/memcached
+    version: 0.0.1
   - name: rabbitmq
     repository: file://../../common/rabbitmq
     version: 0.1.0

--- a/openstack/keystone/templates/configmap-etc.yaml
+++ b/openstack/keystone/templates/configmap-etc.yaml
@@ -31,6 +31,10 @@ data:
 {{- if .Values.watcher.enabled }}
   watcher.yaml: |
 {{ include (print .Template.BasePath "/etc/_watcher.yaml.tpl") . | indent 4 }}
+{{- end }}
+{{- if .Values.sapcc_ratelimit.enabled }}
+  ratelimit.yaml: |
+{{ include (print .Template.BasePath "/etc/_ratelimit.yaml.tpl") . | indent 4 }}
+{{- end }}
   statsd_exporter_mapping.yaml: |
 {{ include (print .Template.BasePath "/etc/_statsd_exporter_mapping.yaml.tpl") . | indent 4 }}
-{{- end }}

--- a/openstack/keystone/templates/deployment-api.yaml
+++ b/openstack/keystone/templates/deployment-api.yaml
@@ -166,6 +166,12 @@ spec:
               subPath: watcher.yaml
               readOnly: true
             {{- end }}
+            {{- if .Values.sapcc_ratelimit.enabled }}
+            - name: keystone-etc
+              mountPath: /etc/keystone/ratelimit.yaml
+              subPath: ratelimit.yaml
+              readOnly: true
+            {{- end }}
             - name: keystone-etc
               mountPath: /etc/apache2/conf-enabled/wsgi-keystone.conf
               subPath: wsgi-keystone.conf

--- a/openstack/keystone/templates/etc/_keystone.conf.tpl
+++ b/openstack/keystone/templates/etc/_keystone.conf.tpl
@@ -166,3 +166,10 @@ allow_credentials = true
 expose_headers = Content-Type,Cache-Control,Content-Language,Expires,Last-Modified,Pragma,X-Auth-Token,X-Openstack-Request-Id,X-Subject-Token
 allow_headers = Content-Type,Cache-Control,Content-Language,Expires,Last-Modified,Pragma,X-Auth-Token,X-Openstack-Request-Id,X-Subject-Token,X-Project-Id,X-Project-Name,X-Project-Domain-Id,X-Project-Domain-Name,X-Domain-Id,X-Domain-Name,X-User-Id,X-User-Name,X-User-Domain-name
 {{- end }}
+
+{{- if .Values.sapcc_ratelimit.enabled }}
+[sapcc_ratelimit]
+backend = {{ .Values.backend | default memcache }}
+memcache_host = {{ .Values.memcached.host }}
+memcache_port = {{ .Values.memcached.port | default 11211 }}
+{{- end }}

--- a/openstack/keystone/templates/etc/_ratelimit.yaml.tpl
+++ b/openstack/keystone/templates/etc/_ratelimit.yaml.tpl
@@ -1,0 +1,12 @@
+rates:
+  # global rate limits counted across all projects
+  global:
+    auth/tokens:
+      - action: authenticate
+        limit: 2000r/m
+
+  # default local rate limits counted per project
+  default:
+    auth/tokens:
+      - action: authenticate
+        limit: 200r/m

--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -337,6 +337,15 @@ rbac:
 watcher:
   enabled: true
 
+sapcc_ratelimit:
+  # will enable the rate limit middleware and a dedicated memcache for rate limits
+  enabled: false
+  # choose memcache (default) or redis
+  backend: memcache
+  memcached:
+    host: DEFINED-IN-SECRETS
+    port: 11211
+
 lifesaver:
   enabled: true
 


### PR DESCRIPTION
Hey @ruvr,
Can you take a look? - especially at [the rates](https://github.com/sapcc/helm-charts/compare/ratelimit_keystone?expand=1#diff-e33696e96d527431f5e8390e1d9bd8dfR1)

Introduces:
- rate limit middleware. disabled by default
- 2nd memcache for rate limits to avoid negative impact on keystone memcache
- initial global, local rate limit for authenticaton requests

Thanks