### PR TITLE
Add cluster_type to alert routing

### DIFF
--- a/global/prometheus-alertmanager/templates/config.yaml
+++ b/global/prometheus-alertmanager/templates/config.yaml
@@ -8,7 +8,7 @@ data:
     global:
       resolve_timeout: 16m
 
-    templates: 
+    templates:
       - ./*.tmpl
 
     inhibit_rules:
@@ -44,6 +44,7 @@ data:
         match_re:
           tier: os|k8s
           severity: critical
+          cluster_type: controlplane
           region: ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
 
       - receiver: slack_api_warning
@@ -51,6 +52,7 @@ data:
         match_re:
           tier: os|k8s
           severity: warning
+          cluster_type: controlplane
           region: ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
 
       - receiver: slack_api_critical
@@ -58,6 +60,7 @@ data:
         match_re:
           tier: os|k8s
           severity: critical
+          cluster_type: controlplane
           region: ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
 
       # ---- DUTY Metal ----
@@ -80,8 +83,8 @@ data:
         match_re:
           tier: metal
           severity: critical
-          region: ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3 
-      
+          region: ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
+
       # ---- DUTY VMware ----
       - receiver: pagerduty_vmware
         continue: true
@@ -104,7 +107,7 @@ data:
           severity: critical
           region: ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
 
-      # ---- DUTY network ----     
+      # ---- DUTY network ----
       - receiver: pagerduty_network
         continue: true
         match_re:
@@ -139,6 +142,7 @@ data:
         match_re:
           tier: k8s
           severity: critical
+          cluster_type: controlplane
           region: admin|ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
 
       - receiver: slack_kks_critical


### PR DESCRIPTION
This should avoid reporting kubernikus alerts in the channels used for the baremetal control plane for now.

