### PR TITLE
[kube-monitoring] bumps ironic-exporter version

### DIFF
--- a/system/kube-monitoring/charts/ironic-exporter/templates/deployment.yaml
+++ b/system/kube-monitoring/charts/ironic-exporter/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if and (ne .Values.global.region "na-us-3") (ne .Values.global.region "la-br-1") }}
+{{- if and (ne .Values.global.region "na-us-3") (ne .Values.global.region "la-br-1") (ne .Values.global.region "ap-jp-2") }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/system/kube-monitoring/charts/ironic-exporter/values.yaml
+++ b/system/kube-monitoring/charts/ironic-exporter/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: monsoon/ironic-exporter
-  tag: 5b2b4b88
+  tag: ec3ad5eb
 port_number: 9191
 
 log_level: "INFO"


### PR DESCRIPTION
adds ap-jp-2 to list of ignored regions