### PR TITLE
add context inhibition

### DIFF
--- a/global/prometheus-alertmanager/templates/config.yaml
+++ b/global/prometheus-alertmanager/templates/config.yaml
@@ -18,7 +18,7 @@ data:
       target_match:
         severity: 'warning'
       equal: ['region', 'alertname']
-    - source_match:
+    - source_match_re:
         severity: 'critical|warning'
       target_match:
         severity: 'info'

--- a/global/prometheus-alertmanager/templates/config.yaml
+++ b/global/prometheus-alertmanager/templates/config.yaml
@@ -17,12 +17,26 @@ data:
         severity: 'critical'
       target_match:
         severity: 'warning'
-      equal: ['region', 'alertname', 'context']
+      equal: ['region', 'alertname']
     - source_match:
         severity: 'critical|warning'
       target_match:
         severity: 'info'
-      equal: ['region', 'alertname', 'context']
+      equal: ['region', 'alertname']
+    - source_match_re:
+        severity: 'critical'
+        context: '.+'
+      target_match_re:
+        severity: 'warning'
+        context: '.+'
+      equal: ['region', 'context']
+    - source_match_re:
+        severity: 'critical|warning'
+        context: '.+'
+      target_match_re:
+        severity: 'info'
+        context: '.+'
+      equal: ['region', 'context']
 
     route:
       group_by: ['region', 'alertname']


### PR DESCRIPTION
Reintroduces the functionality to inhibit on `context`. Here we are guarding the inhibition of alerts without `context` by using a regex matcher for a non-empty `context`.

Additionally, I removed the `context` from `alertname` inihibition, as this didn't work. The point of `context` is to group alerts with different names. So, by definition that did nothing.

I also noticed that the `info` inhibition should not work at all. There's an regex for `severity` in a non-regex matcher.