### PR TITLE
Added device and availability_zone label for snmp

### DIFF
--- a/system/kube-monitoring/charts/prometheus-collector/templates/_prometheus.yaml.tpl
+++ b/system/kube-monitoring/charts/prometheus-collector/templates/_prometheus.yaml.tpl
@@ -46,6 +46,15 @@ scrape_configs:
   - action: labelmap
     replacement: __param_$1
     regex: __meta_kubernetes_service_annotation_prometheus_io_scrape_param_(.+)
+  metric_relabel_configs:
+  - source_labels: [component]
+    regex: 'snmp-exporter-(\w*-\w*-\w*)-(\S*)'
+    replacement: '$1'
+    target_label: availability_zone
+  - source_labels: [component]
+    regex: 'snmp-exporter-(\w*-\w*-\w*)-(\S*)'
+    replacement: '$2'
+    target_label: device
 
 # Scrape config for endpoints with an additional port for metrics via `prometheus.io/port_1` annotation.
 #


### PR DESCRIPTION
Requested by Martin Vossen.

In a second step it would be good to overwrite the value of the label
component for the snmp-exporter source with the actual component
involved, e.g. "f5", or an abstract category, e.g. "loadbalancer".