### PR TITLE
Default cluster label to region, remove unused regionPrefix

### DIFF
--- a/system/kube-monitoring/charts/prometheus-frontend/templates/config.yaml
+++ b/system/kube-monitoring/charts/prometheus-frontend/templates/config.yaml
@@ -63,9 +63,9 @@ data:
       # The labels to add to any time series or alerts when communicating with
       # external systems (federation, remote storage, Alertmanager).
       external_labels:
-        region: {{ if .Values.regionPrefix }}{{ .Values.regionPrefix }}{{- end -}}{{ .Values.global.region }}
+        region: {{ .Values.global.region }}
         cluster_type: {{ .Values.global.clusterType }}
-        cluster: {{ .Values.global.cluster }}
+        cluster: {{if .Values.global.cluster }}{{ .Values.global.cluster }}{{ else }}{{ .Values.global.region }}{{ end }}
 
     rule_files:
       - ./*.rules
@@ -187,11 +187,6 @@ data:
           - '{__name__=~"^success"}'
           - '{__name__=~"^latency"}'
           - '{job="dns-sd"}'
-
-      relabel_configs:
-        - action: replace
-          target_label: region
-          replacement: {{ if .Values.regionPrefix }}{{ .Values.regionPrefix }}{{- end -}}{{ .Values.global.region }}
 
       metric_relabel_configs:
         - action: replace

--- a/system/kube-monitoring/charts/prometheus-frontend/templates/config.yaml
+++ b/system/kube-monitoring/charts/prometheus-frontend/templates/config.yaml
@@ -63,7 +63,7 @@ data:
       # The labels to add to any time series or alerts when communicating with
       # external systems (federation, remote storage, Alertmanager).
       external_labels:
-        region: {{ .Values.global.region }}
+        region: {{ required ".Values.global.region undefined" .Values.global.region }}
         cluster_type: {{ .Values.global.clusterType }}
         cluster: {{if .Values.global.cluster }}{{ .Values.global.cluster }}{{ else }}{{ .Values.global.region }}{{ end }}
 

--- a/system/kube-monitoring/charts/prometheus-frontend/templates/deployment.yaml
+++ b/system/kube-monitoring/charts/prometheus-frontend/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
             - --storage.tsdb.retention={{.Values.retention}}
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
-            - --web.external-url=https://{{.Values.ingress.host}}.{{.Values.global.region}}.{{.Values.global.domain}}
+            - --web.external-url=https://{{required ".Values.ingress.host undefined" .Values.ingress.host }}.{{ require ".Values.global.region undefined" .Values.global.region}}.{{ required "Values.global.domain undefined" .Values.global.domain }}
             - --web.enable-admin-api
             - --web.enable-lifecycle
             - --log.level={{ default "info" .Values.log_level }}


### PR DESCRIPTION
This change defaults the `cluster` label to `region`. With this change every deployment of `tube-monitoring` has three labels: `region`, `cluster_type`, and `cluster`.

I also removed the `regionPrefix` annotations which we are not using anymore.