### PR TITLE
Add cluster label to inhibition rules and grouping

### DIFF
--- a/global/prometheus-alertmanager/templates/config.yaml
+++ b/global/prometheus-alertmanager/templates/config.yaml
@@ -17,29 +17,29 @@ data:
         severity: 'critical'
       target_match:
         severity: 'warning'
-      equal: ['region', 'alertname']
+      equal: ['region', 'alertname', 'cluster']
     - source_match_re:
         severity: 'critical|warning'
       target_match:
         severity: 'info'
-      equal: ['region', 'alertname']
+      equal: ['region', 'alertname', 'cluster']
     - source_match_re:
         severity: 'critical'
         context: '.+'
       target_match_re:
         severity: 'warning'
         context: '.+'
-      equal: ['region', 'context']
+      equal: ['region', 'context', 'cluster']
     - source_match_re:
         severity: 'critical|warning'
         context: '.+'
       target_match_re:
         severity: 'info'
         context: '.+'
-      equal: ['region', 'context']
+      equal: ['region', 'context', 'cluster']
 
     route:
-      group_by: ['region', 'alertname']
+      group_by: ['region', 'alertname', 'cluster']
       group_wait: 1m
       group_interval: 7m
       repeat_interval: 12h


### PR DESCRIPTION
This should seperate the alerts by kubernetes cluster now that we have more than one per region.