### PR TITLE
[hermes] move to monthly indexes

### DIFF
--- a/openstack/hermes/templates/etc/_logstash.conf.tpl
+++ b/openstack/hermes/templates/etc/_logstash.conf.tpl
@@ -156,7 +156,7 @@ filter {
 output {
   if ([@metadata][index]) {
     elasticsearch {
-        index => "audit-%{[@metadata][index]}-%{+YYYY.MM.dd}"
+        index => "audit-%{[@metadata][index]}-%{+YYYY.MM}"
         template => "/hermes-etc/audit.json"
         template_name => "audit"
         template_overwrite => true
@@ -167,7 +167,7 @@ output {
     }
   } else {
     elasticsearch {
-        index => "audit-default-%{+YYYY.MM.dd}"
+        index => "audit-default-%{+YYYY.MM}"
         template => "/hermes-etc/audit.json"
         template_name => "audit"
         template_overwrite => true
@@ -180,7 +180,7 @@ output {
   # cc the target tenant
   if ([@metadata][index2] and [@metadata][index2] != [@metadata][index]) {
     elasticsearch {
-        index => "audit-%{[@metadata][index2]}-%{+YYYY.MM.dd}"
+        index => "audit-%{[@metadata][index2]}-%{+YYYY.MM}"
         template => "/hermes-etc/audit.json"
         template_name => "audit"
         template_overwrite => true

--- a/system/kube-monitoring/charts/prometheus-frontend/openstack-hermes.alerts
+++ b/system/kube-monitoring/charts/prometheus-frontend/openstack-hermes.alerts
@@ -73,7 +73,7 @@ groups:
       summary: 'RabbitMQ unacknowledged messages count'
 
   - alert: OpenstackElkPredictOutOfDiskSpace
-    expr: elasticsearch_data_diskspace_used_percentage{cluster="hermes",mount=~"/data \\(10.*"} > 75
+    expr: elasticsearch_data_diskspace_used_percentage{cluster="hermes",mount=~"/data \\(10.*"} > 65
     for: 30m
     labels:
       context: elkdiskspace
@@ -82,7 +82,7 @@ groups:
       tier: os
       playbook: docs/support/playbook/elk_kibana_issues.html
     annotations:
-      description: The disk usage on {{ $labels.host }}:{{ $labels.mount }} in the {{ $labels.cluster }} cluster is above 75% now.
+      description: The disk usage on {{ $labels.host }}:{{ $labels.mount }} in the {{ $labels.cluster }} cluster is above 65% now.
                    Elasticsearch will run out of disk space, and fail to start at 85%
       summary: Elastic Search will soon run out of disk space
 


### PR DESCRIPTION
Moving to monthly indexes. The currently daily indexes provide us no value, and cause significant problems around number of shards. We cannot backup properly in this situation, we cannot do a mass export successfully. 

The biggest negative of monthly is that if we need to delete older data to fit into volume sizes, we will always need to be ahead of the need by 2 months. In our largest regions we are making it to 7+ months before this. It will still need to be watched, alerted on, and acted on in a timely manner to make sure we don't get into a bad state. But I think the need for proper backups is a larger concern in this context. 