### PR TITLE
[blackbox][manila] add OS_MANILA_ENDPOINT_TYPE with default internal

### DIFF
--- a/openstack/blackbox/charts/blackbox-tests-canary/templates/deployment.yaml
+++ b/openstack/blackbox/charts/blackbox-tests-canary/templates/deployment.yaml
@@ -1,5 +1,5 @@
 kind: Deployment
-apiVersion: extensions/v1beta1 
+apiVersion: extensions/v1beta1
 
 metadata:
   name: blackbox-tests-canary
@@ -326,8 +326,8 @@ spec:
               value: {{ .Values.global.openstack.auth_url | quote }}
             - name: OS_IDENTITY_API_VERSION
               value: {{ .Values.global.openstack.identity_api_version | quote }}
-            - name: OS_VOLUME_API_VERSION
-              value: {{ .Values.global.openstack.volume_api_version | quote }}
+            - name: OS_MANILA_ENDPOINT_TYPE
+              value: {{ .Values.global.openstack.manila_endpoint_type | quote }}
             - name: OS_USERNAME
               value: {{ .Values.global.openstack.users.admin.username | quote }}
             - name: OS_USER_DOMAIN_NAME

--- a/openstack/blackbox/values.yaml
+++ b/openstack/blackbox/values.yaml
@@ -11,6 +11,7 @@ global:
     region_name: DEFINED-IN-REGION-SECRETS
     identity_api_version: 3
     volume_api_version: 2
+    manila_endpoint_type: internal
     users:
       admin:
         username: DEFINED-IN-REGION-SECRETS


### PR DESCRIPTION
Hi, I suggest to use the internal endpoint for the tests to remove the extra hop over ingress.
We don't want to test ingress, only manila api.

I replaced OS_VOLUME_API_VERSION, which is not used in this context