### PR TITLE
[nova-compute-node] disable integration bridge

### DIFF
--- a/openstack/nova/templates/hypervisors/hypervisors-vmware-configmap-vct.yaml
+++ b/openstack/nova/templates/hypervisors/hypervisors-vmware-configmap-vct.yaml
@@ -37,7 +37,7 @@ template: |
       {% endif %}
 
       [vmware]
-      integration_bridge = {= bridge | quote =}
+      # integration_bridge = {= bridge | quote =}
       cache_prefix= "{= name | ini_escape =}-images"
       host_ip = {= host =}
       host_username = {= username | quote =}


### PR DESCRIPTION
since it's not used by the DVS driver and breaks the NSX-T driver

@joker-official @Scsabiii