### PR TITLE
Reintroduce GeneratorURL

### DIFF
--- a/global/prometheus-alertmanager/slack.tmpl
+++ b/global/prometheus-alertmanager/slack.tmpl
@@ -8,23 +8,26 @@
 {{ if eq .Status "resolved" }}*[RESOLVED{{ if gt (len .Alerts.Resolved) 1 }} - {{ .Alerts.Resolved | len }}{{ end }}]* {{ end -}}
   {{ if .CommonLabels.cluster }}*[{{ .CommonLabels.cluster | toUpper }}]*{{ else }}*[{{ .CommonLabels.region | toUpper }}]*{{ end }} {{ if .CommonLabels.dashboard }}*<{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}|{{ .GroupLabels.alertname }}>*{{ else }}{{ .GroupLabels.alertname }}{{ end }} - {{ .CommonAnnotations.summary }}
 
+{{- $generatorURL := "" }}
 {{ if eq .Status "firing" -}}
 {{ range .Alerts.Firing -}}
   {{ if eq .Labels.severity "warning" }}:warning: {{ end -}}
   {{ if eq .Labels.severity "critical" }}:fire: {{ end -}}
   {{ .Annotations.description }} {{ if .Labels.sentry }}*<https://sentry.{{ .Labels.region }}.cloud.sap/monsoon/{{ .Labels.sentry }}|Sentry>*{{ end }} {{ if .Labels.cloudops }}*<https://dashboard.{{ .Labels.region }}.cloud.sap/ccadmin/cloud_admin/cloudops#/universal-search/{{ .Labels.cloudops }}|CloudOps>*{{ end }}
+{{- $generatorURL = .GeneratorURL }}
 {{ end -}}
 {{ end -}}
 {{ if eq .Status "resolved" -}}
 {{ range .Alerts.Resolved -}}
   :white_check_mark: {{ .Annotations.description }}
+{{- if not $generatorURL }}{{ $generatorURL = .GeneratorURL }}{{ end }}
 {{ end -}}
 {{ end -}}
 
 {{ if .CommonLabels.dashboard }}*<https://grafana.{{ .CommonLabels.region }}.cloud.sap/dashboard/db/{{ .CommonLabels.dashboard }}|Grafana>* {{ end -}}
 {{ if .CommonLabels.playbook }}*<https://operations.global.cloud.sap/{{ .CommonLabels.playbook }}|Playbook>* {{ end -}}
 {{ if .CommonLabels.kibana }}*<https://logs.{{ .CommonLabels.region }}.cloud.sap/{{ .CommonLabels.kibana }}|Kibana>* {{ end -}}
-*<https://prometheus.{{- if eq .CommonLabels.tier "kks" -}}kubernikus.{{- end -}}{{ .CommonLabels.region }}.cloud.sap/graph?g0.range_input=1h&g0.expr=ALERTS%7Balertname%3D%22{{ .GroupLabels.alertname }}%22%2Calertstate%3D%22firing%22%7D&g0.tab=0|Prometheus>*
+*<{{ $generatorURL }}|Prometheus>*
 {{ end }}
 
 {{ define "slack.sapcc.actionName" }}{{ if eq .Status "firing" }}reaction{{ end }}{{ end }}


### PR DESCRIPTION
With go 1.11 its possible to re-assign template variables from higher scopes. This allows us to copy the GeneratorURL from the alerts to the outer template.