### PR TITLE
Use yellow color for mixed notifications

### DIFF
--- a/global/prometheus-alertmanager/slack.tmpl
+++ b/global/prometheus-alertmanager/slack.tmpl
@@ -1,3 +1,4 @@
+{{ define "slack.sapcc.color" }}{{ if .Alerts.Firing | and .Alerts.Resolved }}warning{{ else if .Alerts.Firing }}danger{{ else }}good{{ end }}{{ end }}
 {{ define "slack.sapcc.iconemoji" }}:fire_engine:{{ end }}
 {{ define "slack.sapcc.title" }}{{ end }}
 {{ define "slack.sapcc.titlelink" }}{{ end }}
@@ -12,6 +13,7 @@
 {{ range .Alerts.Firing -}}
   {{ if eq .Labels.severity "warning" }}:warning: {{ end -}}
   {{ if eq .Labels.severity "critical" }}:fire: {{ end -}}
+  {{ if eq .Labels.severity "info" }}:information_source: {{ end -}}
   {{ .Annotations.description }} {{ if .Labels.sentry }}*<https://sentry.{{ .Labels.region }}.cloud.sap/monsoon/{{ .Labels.sentry }}|Sentry>*{{ end }} {{ if .Labels.cloudops }}*<https://dashboard.{{ .Labels.region }}.cloud.sap/ccadmin/cloud_admin/cloudops#/universal-search/{{ .Labels.cloudops }}|CloudOps>*{{ end }}
 {{- $generatorURL = .GeneratorURL }}
 {{ end -}}

--- a/global/prometheus-alertmanager/templates/config.yaml
+++ b/global/prometheus-alertmanager/templates/config.yaml
@@ -204,7 +204,7 @@ data:
     receivers:
     - name: dev-null
       slack_configs:
-        - api_url: {{ default "MISSING" .Values.slack.webhook_url | quote }}
+        - api_url: {{ required "slack.webhook_url undefined" .Values.slack.webhook_url | quote }}
           username: "Control Plane"
           channel: "#dev-null"
           title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
@@ -213,6 +213,7 @@ data:
           pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
           icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
           callback_id: "alertmanager"
+          color: {{`'{{template "slack.sapcc.color" . }}'`}}
           send_resolved: true
           actions:
             - name: {{"'{{template \"slack.sapcc.actionName\" . }}'"}}
@@ -235,7 +236,7 @@ data:
     - name: slack_metal_warning
       slack_configs:
         - channel: '#alert-{{"{{ .CommonLabels.tier }}"}}-{{"{{ .CommonLabels.severity }}"}}'
-          api_url: {{ default "MISSING" .Values.slack.metal_warning_webhook_url | quote }}
+          api_url: {{ required "slack.metal_warning_webhook_url undefined" .Values.slack.metal_warning_webhook_url | quote }}
           username: "Control Plane"
           title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
           title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
@@ -243,6 +244,7 @@ data:
           pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
           icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
           callback_id: "alertmanager"
+          color: {{`'{{template "slack.sapcc.color" . }}'`}}
           send_resolved: true
           actions:
             - name: {{"'{{template \"slack.sapcc.actionName\" . }}'"}}
@@ -265,7 +267,7 @@ data:
     - name: slack_metal_critical
       slack_configs:
         - channel: '#alert-{{"{{ .CommonLabels.tier }}"}}-{{"{{ .CommonLabels.severity }}"}}'
-          api_url: {{ default "MISSING" .Values.slack.metal_critical_webhook_url | quote }}
+          api_url: {{ required "slack.metal_critical_webhook_url undefined" .Values.slack.metal_critical_webhook_url | quote }}
           username: "Control Plane"
           title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
           title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
@@ -273,6 +275,7 @@ data:
           pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
           icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
           callback_id: "alertmanager"
+          color: {{`'{{template "slack.sapcc.color" . }}'`}}
           send_resolved: true
           actions:
             - name: {{"'{{template \"slack.sapcc.actionName\" . }}'"}}
@@ -296,31 +299,33 @@ data:
     - name: slack_os_critical
       slack_configs:
         - channel: '#alert-{{"{{ .CommonLabels.tier }}"}}-{{"{{ .CommonLabels.severity }}"}}'
-          api_url: {{ default "MISSING" .Values.slack.webhook_url | quote }}
+          api_url: {{ required "slack.webhook_url undefined" .Values.slack.webhook_url | quote }}
           username: "Control Plane"
           title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
           title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
           text: {{"'{{template \"slack.sapcc.text\" . }}'"}}
           pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
           icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
+          color: {{`'{{template "slack.sapcc.color" . }}'`}}
           send_resolved: true
 
     - name: slack_k8s_critical
       slack_configs:
         - channel: '#alert-{{"{{ .CommonLabels.tier }}"}}-{{"{{ .CommonLabels.severity }}"}}'
-          api_url: {{ default "MISSING" .Values.slack.webhook_url | quote }}
+          api_url: {{ required "slack.webhook_url undefined" .Values.slack.webhook_url | quote }}
           username: "Control Plane"
           title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
           title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
           text: {{"'{{template \"slack.sapcc.text\" . }}'"}}
           pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
           icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
+          color: {{`'{{template "slack.sapcc.color" . }}'`}}
           send_resolved: true
 
     - name: slack_kks_critical
       slack_configs:
         - channel: '#alert-{{"{{ .CommonLabels.tier }}"}}-{{"{{ .CommonLabels.severity }}"}}'
-          api_url: {{ default "MISSING" .Values.slack.kubernikus_critical_webhook_url | quote }}
+          api_url: {{ required "slack.kubernikus_critical_webhook_url undefined" .Values.slack.kubernikus_critical_webhook_url | quote }}
           username: "Control Plane"
           title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
           title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
@@ -328,6 +333,7 @@ data:
           pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
           icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
           callback_id: "alertmanager"
+          color: {{`'{{template "slack.sapcc.color" . }}'`}}
           send_resolved: true
           actions:
             - name: {{"'{{template \"slack.sapcc.actionName\" . }}'"}}
@@ -350,7 +356,7 @@ data:
     - name: slack_net_warning
       slack_configs:
         - channel: '#alert-{{"{{ .CommonLabels.tier }}"}}-{{"{{ .CommonLabels.severity }}"}}'
-          api_url: {{ default "MISSING" .Values.slack.network_warning_webhook_url | quote }}
+          api_url: {{ required "slack.network_warning_webhook_url undefined" .Values.slack.network_warning_webhook_url | quote }}
           username: "Control Plane"
           title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
           title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
@@ -358,6 +364,7 @@ data:
           pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
           icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
           callback_id: "alertmanager"
+          color: {{`'{{template "slack.sapcc.color" . }}'`}}
           send_resolved: true
           actions:
             - name: {{"'{{template \"slack.sapcc.actionName\" . }}'"}}
@@ -380,7 +387,7 @@ data:
     - name: slack_net_critical
       slack_configs:
         - channel: '#alert-{{"{{ .CommonLabels.tier }}"}}-{{"{{ .CommonLabels.severity }}"}}'
-          api_url: {{ default "MISSING" .Values.slack.network_critical_webhook_url | quote }}
+          api_url: {{ required "slack.network_critical_webhook_url undefined" .Values.slack.network_critical_webhook_url | quote }}
           username: "Control Plane"
           title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
           title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
@@ -388,6 +395,7 @@ data:
           pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
           icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
           callback_id: "alertmanager"
+          color: {{`'{{template "slack.sapcc.color" . }}'`}}
           send_resolved: true
           actions:
             - name: {{"'{{template \"slack.sapcc.actionName\" . }}'"}}
@@ -410,7 +418,7 @@ data:
     - name: slack_vmware_warning
       slack_configs:
         - channel: '#alert-{{"{{ .CommonLabels.tier }}"}}-{{"{{ .CommonLabels.severity }}"}}'
-          api_url: {{ default "MISSING" .Values.slack.vmware_warning_webhook_url | quote }}
+          api_url: {{ required "slack.vmware_warning_webhook_url undefined" .Values.slack.vmware_warning_webhook_url | quote }}
           username: "Control Plane"
           title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
           title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
@@ -418,6 +426,7 @@ data:
           pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
           icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
           callback_id: "alertmanager"
+          color: {{`'{{template "slack.sapcc.color" . }}'`}}
           send_resolved: true
           actions:
             - name: {{"'{{template \"slack.sapcc.actionName\" . }}'"}}
@@ -440,7 +449,7 @@ data:
     - name: slack_vmware_critical
       slack_configs:
         - channel: '#alert-{{"{{ .CommonLabels.tier }}"}}-{{"{{ .CommonLabels.severity }}"}}'
-          api_url: {{ default "MISSING" .Values.slack.vmware_critical_webhook_url | quote }}
+          api_url: {{ required "slack.vmware_critical_webhook_url undefined" .Values.slack.vmware_critical_webhook_url | quote }}
           username: "Control Plane"
           title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
           title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
@@ -448,6 +457,7 @@ data:
           pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
           icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
           callback_id: "alertmanager"
+          color: {{`'{{template "slack.sapcc.color" . }}'`}}
           send_resolved: true
           actions:
             - name: {{"'{{template \"slack.sapcc.actionName\" . }}'"}}
@@ -471,25 +481,27 @@ data:
     - name: slack_by_tier_and_severity
       slack_configs:
         - channel: '#alert-{{"{{ .CommonLabels.tier }}"}}-{{"{{ .CommonLabels.severity }}"}}'
-          api_url: {{ default "MISSING" .Values.slack.webhook_url | quote }}
+          api_url: {{ required "slack.webhook_url undefined" .Values.slack.webhook_url | quote }}
           username: "Control Plane"
           title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
           title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
           text: {{"'{{template \"slack.sapcc.text\" . }}'"}}
           pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
           icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
+          color: {{`'{{template "slack.sapcc.color" . }}'`}}
           send_resolved: true
 
     - name: slack_by_tier
       slack_configs:
         - channel: '#alert-{{"{{ .CommonLabels.tier }}"}}'
-          api_url: {{ default "MISSING" .Values.slack.webhook_url | quote }}
+          api_url: {{ required "slack.webhook_url undefined" .Values.slack.webhook_url | quote }}
           username: "Control Plane"
           title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
           title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
           text: {{"'{{template \"slack.sapcc.text\" . }}'"}}
           pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
           icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
+          color: {{`'{{template "slack.sapcc.color" . }}'`}}
           send_resolved: true
 
     - name: slack_by_tier_and_service
@@ -502,6 +514,7 @@ data:
           text: {{"'{{template \"slack.sapcc.text\" . }}'"}}
           pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
           icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
+          color: {{`'{{template "slack.sapcc.color" . }}'`}}
           send_resolved: true
 
     - name: slack_api_warning
@@ -515,6 +528,7 @@ data:
           pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
           icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
           callback_id: "alertmanager"
+          color: {{`'{{template "slack.sapcc.color" . }}'`}}
           send_resolved: true
           actions:
             - name: {{"'{{template \"slack.sapcc.actionName\" . }}'"}}
@@ -545,6 +559,7 @@ data:
           pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
           icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
           callback_id: "alertmanager"
+          color: {{`'{{template "slack.sapcc.color" . }}'`}}
           send_resolved: true
           actions:
             - name: {{"'{{template \"slack.sapcc.actionName\" . }}'"}}


### PR DESCRIPTION
This commit changes the color of the slack notification when it contains both firing and resolved alerts from read (danger) to yellow (warning).
In a lot of cases a notification that carries a "resolved" and "firing" alert is an improvment: Some alerts have cleared while others are still firing. Marking them as yellow makes them easily distingushibale from alerts that only contain "firing" alerts which are never good.