### PR TITLE
Add additional exporters outside of kube-monitoring as it is currently refactored

### DIFF
--- a/system/exporter/nfs-exporter/Chart.yaml
+++ b/system/exporter/nfs-exporter/Chart.yaml
@@ -1,0 +1,3 @@
+description: NFS Exporter
+name: nfs-exporter
+version: 1.0.0

--- a/system/exporter/nfs-exporter/templates/deployment.yaml
+++ b/system/exporter/nfs-exporter/templates/deployment.yaml
@@ -1,4 +1,3 @@
-{{ if .Values.enabled }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -54,4 +53,3 @@ spec:
             port: 8087
           initialDelaySeconds: 5
           timeoutSeconds: 3
-{{ end -}}

--- a/system/exporter/nfs-exporter/templates/deployment.yaml
+++ b/system/exporter/nfs-exporter/templates/deployment.yaml
@@ -1,0 +1,57 @@
+{{ if .Values.enabled }}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nfs-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nfs-exporter
+      type: exporter
+  template:
+    metadata:
+      labels:
+        app: nfs-exporter
+        type: exporter
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: "8086"
+    spec:
+      containers:
+      - name: nfs-exporter
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag}}"
+        env:
+          - name: ACI_USER
+            valueFrom:
+              secretKeyRef:
+                name: nfs-exporter
+                key: aciUser
+          - name: ACI_PASS
+            valueFrom:
+              secretKeyRef:
+                name: nfs-exporter
+                key: aciPass
+        args:
+          - --aci={{ .Values.aci.apic_hosts }}
+          {{- range $i, $ip := .Values.ips }}
+          - --ip={{ $ip }}
+          {{- end }}
+        ports:
+          - name: health
+            containerPort: 8087
+          - name: metrics
+            containerPort: 8086
+        livenessProbe:
+          httpGet:
+            path: /live
+            port: 8087
+          initialDelaySeconds: 20
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8087
+          initialDelaySeconds: 5
+          timeoutSeconds: 3
+{{ end -}}

--- a/system/exporter/nfs-exporter/templates/secret.yaml
+++ b/system/exporter/nfs-exporter/templates/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nfs-exporter
+  labels:
+    app: nfs-exporter
+type: Opaque
+data:
+  aciUser: {{ .Values.aci.apic_user | b64enc | quote }}
+  aciPass: {{ .Values.aci.apic_password | b64enc | quote }}

--- a/system/exporter/nfs-exporter/values.yaml
+++ b/system/exporter/nfs-exporter/values.yaml
@@ -1,0 +1,3 @@
+image:
+  repository: hub.global.cloud.sap/d062260/nfs-exporter
+  tag: v0.0.10

--- a/system/exporter/systemd-lldp-exporter/Chart.yaml
+++ b/system/exporter/systemd-lldp-exporter/Chart.yaml
@@ -1,0 +1,3 @@
+description: Systemd LLDP Exporter
+name: systemd-lldp-exporter
+version: 1.0.0

--- a/system/exporter/systemd-lldp-exporter/templates/deployment.yaml
+++ b/system/exporter/systemd-lldp-exporter/templates/deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: systemd-lldp-exporter
+spec:
+  selector:
+    matchLabels:
+      app: systemd-lldp-exporter
+      type: exporter
+  template:
+    metadata:
+      labels:
+        app: systemd-lldp-exporter
+        type: exporter
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: "8081"
+    spec:
+      volumes:
+      - name: systemd
+        hostPath:
+          path: /run/systemd/netif/lldp
+      containers:
+      - name: systemd-lldp-exporter
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag}}"
+        args:
+          -  /lldp
+        ports:
+          - name: metrics
+            containerPort: 8081
+        volumeMounts:
+        - name: systemd
+          mountPath: /lldp

--- a/system/exporter/systemd-lldp-exporter/values.yaml
+++ b/system/exporter/systemd-lldp-exporter/values.yaml
@@ -1,0 +1,3 @@
+image:
+  repository: hub.global.cloud.sap/d062260/systemd-lldp-exporter
+  tag: v0.0.1


### PR DESCRIPTION
I did not know the correct location please advise if this looks good to you and we reference these with requirements in the future