### PR TITLE
[manila] add resources requests

### DIFF
--- a/openstack/manila/templates/api-deployment.yaml
+++ b/openstack/manila/templates/api-deployment.yaml
@@ -97,6 +97,10 @@ spec:
               subPath: watcher.yaml
               readOnly: true
             {{- end }}
+          {{- if .Values.pod.resources.api }}
+          resources:
+{{ toYaml .Values.pod.resources.api | indent 13 }}
+          {{- end }}
         - name: statsd
           image: prom/statsd-exporter:v0.8.1
           imagePullPolicy: IfNotPresent
@@ -112,6 +116,10 @@ spec:
               mountPath: /etc/statsd/statsd-exporter.yaml
               subPath: statsd-exporter.yaml
               readOnly: true
+          resources:
+            requests:
+              cpu: 1m
+              memory: 32Mi
       volumes:
         - name: etcmanila
           emptyDir: {}

--- a/openstack/manila/templates/nanny-deployment.yaml
+++ b/openstack/manila/templates/nanny-deployment.yaml
@@ -64,6 +64,10 @@ spec:
           volumeMounts:
             - mountPath: /manila-etc
               name: manila-etc
+          {{- if .Values.pod.resources.nanny }}
+          resources:
+{{ toYaml .Values.pod.resources.nanny | indent 13 }}
+          {{- end }}
 {{- end }}
 {{- if .Values.nanny.quota_sync.enabled }}
         - name: quota-sync
@@ -90,6 +94,10 @@ spec:
           volumeMounts:
             - mountPath: /manila-etc
               name: manila-etc
+          {{- if .Values.pod.resources.nanny_quota }}
+          resources:
+{{ toYaml .Values.pod.resources.nanny_quota | indent 13 }}
+          {{- end }}
 {{- end }}
 {{- if .Values.nanny.db_cleanup.enabled }}
         - name: db-cleanup
@@ -116,6 +124,10 @@ spec:
           volumeMounts:
             - mountPath: /manila-etc
               name: manila-etc
+          {{- if .Values.pod.resources.nanny }}
+          resources:
+{{ toYaml .Values.pod.resources.nanny | indent 13 }}
+          {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/openstack/manila/templates/scheduler-deployment.yaml
+++ b/openstack/manila/templates/scheduler-deployment.yaml
@@ -78,6 +78,10 @@ spec:
               mountPath: /etc/manila/logging.ini
               subPath: logging.ini
               readOnly: true
+          {{- if .Values.pod.resources.scheduler }}
+          resources:
+{{ toYaml .Values.pod.resources.scheduler | indent 13 }}
+          {{- end }}
       hostname: manila-scheduler
       volumes:
         - name: etcmanila

--- a/openstack/manila/templates/shares/_netapp-deployment.yaml.tpl
+++ b/openstack/manila/templates/shares/_netapp-deployment.yaml.tpl
@@ -69,6 +69,10 @@ spec:
               mountPath: /etc/manila/backend.conf
               subPath: backend.conf
               readOnly: true
+          {{- if .Values.pod.resources.share }}
+          resources:
+{{ toYaml .Values.pod.resources.share | indent 13 }}
+          {{- end }}
           livenessProbe:
             exec:
               command:

--- a/openstack/manila/templates/shares/_netapp-nanny-deployment.yaml.tpl
+++ b/openstack/manila/templates/shares/_netapp-nanny-deployment.yaml.tpl
@@ -71,6 +71,10 @@ spec:
               mountPath: /etc/manila/backend.conf
               subPath: backend.conf
               readOnly: true
+          {{- if .Values.pod.resources.netapp_nanny }}
+          resources:
+{{ toYaml .Values.pod.resources.netapp_nanny | indent 13 }}
+          {{- end }}
       volumes:
         - name: etcmanila
           emptyDir: {}

--- a/openstack/manila/values.yaml
+++ b/openstack/manila/values.yaml
@@ -217,6 +217,34 @@ pod:
         rolling_update:
            max_unavailable: 0
            max_surge: 1
+  resources:
+    api:
+      requests:
+        memory: "1Gi"
+        cpu: "1000m"
+    scheduler:
+      requests:
+        memory: "256Mi"
+        cpu: "1000m"
+    netapp_nanny:
+      requests:
+        memory: "2Gi"
+        cpu: "500m"
+    nanny_quota:
+      requests:
+        memory: "64Mi"
+        cpu: "300m"
+    nanny:
+      requests:
+        memory: "64Mi"
+        cpu: "50m"
+    share: # is not scalable -> qosClass: guaranteed
+      requests:
+        memory: "256Mi"
+        cpu: "100m"
+      limits:
+        memory: "1Gi"
+        cpu: "400m"
 
 postgresql:
   custom_configmap: false


### PR DESCRIPTION
values defined by looking at our GOLD regions

all deployments but manila-share can scale horizontally with the number of pods