### PR TITLE
Adds OpenstackSeed for DISCO (Designate IngresS Cname Operator) user

### DIFF
--- a/system/kube-system/charts/disco/templates/clusterrolebinding.yaml
+++ b/system/kube-system/charts/disco/templates/clusterrolebinding.yaml
@@ -11,6 +11,6 @@ roleRef:
   name: {{ template "name" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.rbac.serviceAccountName }}
+    name: {{ required ".Values.rbac.serviceAccountName missing" .Values.rbac.serviceAccountName }}
     namespace: kube-system
 {{- end }}

--- a/system/kube-system/charts/disco/templates/config.yaml
+++ b/system/kube-system/charts/disco/templates/config.yaml
@@ -7,11 +7,11 @@ metadata:
     app: disco
 data:
   disco.conf: |
-    auth_url: {{ .Values.openstack.authURL }}
-    region_name: {{ .Values.openstack.regionName }}
-    username: {{ .Values.openstack.username }}
-    user_domain_name: {{ .Values.openstack.userDomainName }}
-    password: {{ .Values.openstack.password }}
-    project_name: {{ .Values.openstack.projectName }}
-    project_domain_name: {{ .Values.openstack.projectDomainName }}
+    auth_url: {{ required ".Values.openstack.authURL missing" .Values.openstack.authURL }}
+    region_name: {{ required ".Values.openstack.regionName missing" .Values.openstack.regionName }}
+    username: {{ required ".Values.openstack.username missing" .Values.openstack.username }}
+    user_domain_name: {{ required ".Values.openstack.userDomainName missing" .Values.openstack.userDomainName }}
+    password: {{ required ".Values.openstack.password missing" .Values.openstack.password }}
+    project_name: {{ required ".Values.openstack.projectName missing" .Values.openstack.projectName }}
+    project_domain_name: {{ required ".Values.openstack.projectDomainName missing" .Values.openstack.projectDomainName }}
 {{- end }}

--- a/system/kube-system/charts/disco/templates/deployment.yaml
+++ b/system/kube-system/charts/disco/templates/deployment.yaml
@@ -14,20 +14,20 @@ spec:
         app: disco
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: {{ .Values.metricPort | quote }}
+        prometheus.io/port: {{ default 9091 .Values.metricPort | quote }}
     spec:
       containers:
         - name: disco
           image: "{{.Values.image.repository}}:{{.Values.image.tag}}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
           args:
             - disco
-            - --ingress-annotation={{ .Values.ingressAnnotation }}
+            - --ingress-annotation={{ default "disco" .Values.ingressAnnotation }}
             - --config=/etc/disco/config/disco.conf
             - --metric-port={{ default 9091 .Values.metricPort }}
             - --recordset-ttl={{ default 1800 .Values.recordsetTTL }}
-            - --record={{ required "missing record" .Values.record }}
-            - --zone-name={{ required "missing zone name" .Values.openstack.zoneName }}
+            - --record={{ required ".Values.record missing" .Values.record }}
+            - --zone-name={{ required ".Values.openstack.zoneName missing" .Values.openstack.zoneName }}
             - --recheck-period={{ default 5 .Values.recheckPeriod }}
             - --resync-period={{ default 2 .Values.resyncPeriod }}
             - --threadiness={{ default 1 .Values.threadiness }}
@@ -37,7 +37,7 @@ spec:
               mountPath: /etc/disco/config/
           ports:
             - name: metrics
-              containerPort: {{ .Values.metricPort }}
+              containerPort: {{ default 9091 .Values.metricPort }}
       volumes:
         - name: config
           configMap:

--- a/system/kube-system/charts/disco/templates/rolebinding.yaml
+++ b/system/kube-system/charts/disco/templates/rolebinding.yaml
@@ -11,6 +11,6 @@ roleRef:
   name: {{ template "name" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.rbac.serviceAccountName }}
+    name: {{ required ".Values.rbac.serviceAccountName missing" .Values.rbac.serviceAccountName }}
     namespace: kube-system
 {{- end -}}

--- a/system/kube-system/charts/disco/templates/seed.yaml
+++ b/system/kube-system/charts/disco/templates/seed.yaml
@@ -1,0 +1,34 @@
+{{- if and .Values.enabled .Values.seed.enabled }}
+
+apiVersion: "openstack.stable.sap.cc/v1"
+kind: OpenstackSeed
+metadata:
+  name: disco-seed
+
+spec:
+  requires:
+    - monsoon3/keystone-seed
+    - monsoon3/designate-seed
+
+  domains:
+    - name: {{ required ".Values.openstack.userDomainName missing" .Values.openstack.userDomainName }}
+      users:
+        - name: {{ required ".Values.openstack.username missing" .Values.openstack.username }}
+          description: DISCO (Designate IngresS Cname Operator)
+          password: {{ required ".Values.openstack.password missing" .Values.openstack.password }}
+          roles:
+            - project: service
+              role:    service
+
+    - name: {{ required ".Values.openstack.projectDomainName missing" .Values.openstack.projectDomainName }}
+      projects:
+        - name: {{ required ".Values.openstack.projectName missing" .Values.openstack.projectName }}
+          roles:
+            # Permission to enumerate all projects and domains.
+            - user: {{ required ".Values.openstack.username missing" .Values.openstack.username }}@{{ required ".Values.openstack.userDomainName missing" .Values.openstack.userDomainName }}
+              role: admin
+            # Permissions to create, read, update, delete records.
+            - user: {{ required ".Values.openstack.username missing" .Values.openstack.username }}@{{ required ".Values.openstack.userDomainName missing" .Values.openstack.userDomainName }}
+              role: cloud_dns_admin
+
+{{- end }}

--- a/system/kube-system/charts/disco/values.yaml
+++ b/system/kube-system/charts/disco/values.yaml
@@ -1,3 +1,6 @@
+# Enable the DISCO operator.
+enabled: true
+
 image:
   repository: sapcc/disco
   tag: v201810062033
@@ -6,19 +9,23 @@ rbac:
   create: false
   serviceAccountName: default
 
-# port to expose metrics on
+# Port to expose metrics on.
 metricPort: 9091
 
-# TTL for the recordsets
+# TTL for the recordsets.
 recordsetTTL: 1800
 
-# only an ingress' with this annotation will be considered
+# Only an ingress' with this annotation will be considered.
 ingressAnnotation: "disco"
 
-# record which should be used. e.g.: 'ingress.domain.tld.'
+# Record which should be used. e.g.: 'ingress.domain.tld.' .
 record: #DEFINED-IN-SECRETS
 
-# credentials of the service user who creates the recordsets in openstack designate
+# Enable the OpenStack seed for the service user described in the openstack section below.
+seed:
+  enabled: true
+
+# Credentials of the service user who creates the recordsets in OpenStack Designate.
 openstack:
   authURL:            DEFINED-IN-SECRETS
   regionName:         DEFINED-IN-SECRETS

--- a/system/kube-system/charts/disco/values.yaml
+++ b/system/kube-system/charts/disco/values.yaml
@@ -1,5 +1,5 @@
 # Enable the DISCO operator.
-enabled: true
+enabled: false
 
 image:
   repository: sapcc/disco
@@ -23,7 +23,7 @@ record: #DEFINED-IN-SECRETS
 
 # Enable the OpenStack seed for the service user described in the openstack section below.
 seed:
-  enabled: true
+  enabled: false
 
 # Credentials of the service user who creates the recordsets in OpenStack Designate.
 openstack:

--- a/system/kube-system/charts/disco/values.yaml
+++ b/system/kube-system/charts/disco/values.yaml
@@ -27,12 +27,12 @@ seed:
 
 # Credentials of the service user who creates the recordsets in OpenStack Designate.
 openstack:
-  authURL:            DEFINED-IN-SECRETS
-  regionName:         DEFINED-IN-SECRETS
-  username:           DEFINED-IN-SECRETS
-  userDomainName:     DEFINED-IN-SECRETS
-  password:           DEFINED-IN-SECRETS
-  projectName:        DEFINED-IN-SECRETS
-  projectDomainName:  DEFINED-IN-SECRETS
+  # authURL:            DEFINED-IN-SECRETS
+  # regionName:         DEFINED-IN-SECRETS
+  # username:           DEFINED-IN-SECRETS
+  # userDomainName:     DEFINED-IN-SECRETS
+  # password:           DEFINED-IN-SECRETS
+  # projectName:        DEFINED-IN-SECRETS
+  # projectDomainName:  DEFINED-IN-SECRETS
   # the name of the zone in which the record should be created
-  zoneName:           DEFINED-IN-SECRETS
+  # zoneName:           DEFINED-IN-SECRETS


### PR DESCRIPTION
The Disco operator is currently deployed in the scaleout clusters and requires an OpenStack user that is able to manage Designate records. This user shall be created via an OpenstackSeed.
However, AFAIK there's no openstack-seeder there to do the magic.

So there's a more general question for which I see 2 options:
(1) Deploy the Openstack seeder to the scaleout clusters.
(2) Openstack seeder just in controlplane. Means: One has to split charts. Seeds only in baremetal. Rest of the deployment in scaleout.

What do you think @ruvr, @BugRoger, @databus23?