### PR TITLE
[kube-monitoring] Add fluent-bit chart

### DIFF
--- a/system/kube-monitoring/requirements.lock
+++ b/system/kube-monitoring/requirements.lock
@@ -8,5 +8,8 @@ dependencies:
 - name: ironic-exporter
   repository: file://vendor/ironic-exporter
   version: 1.0.0
-digest: sha256:458dae07b6a2141364f77e209d2883e147996027a041b8c11d2f623d65845317
-generated: 2019-03-12T14:56:25.594519+01:00
+- name: fluent-bit
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 1.8.0
+digest: sha256:6fa678f74f0fc468a8d2b88649efbfa9d2f995e792545aadaad70832763d469b
+generated: 2019-03-13T16:46:18.650444304+01:00

--- a/system/kube-monitoring/requirements.yaml
+++ b/system/kube-monitoring/requirements.yaml
@@ -9,3 +9,7 @@ dependencies:
     repository: file://vendor/ironic-exporter
     version: 1.0.0
     condition: ironic-exporter.enabled
+  - name: fluent-bit
+    repository: https://kubernetes-charts.storage.googleapis.com/
+    version: 1.8.0
+    condition: fluent-bit.enabled

--- a/system/kube-monitoring/templates/fluent-bit-config.yaml
+++ b/system/kube-monitoring/templates/fluent-bit-config.yaml
@@ -1,0 +1,89 @@
+{{ if .Values.fluent-bit.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluent-bit-config
+  labels:
+    app: fluent-bit-fluent-bit
+    release: fluent-bit
+data:
+  fluent-bit.conf: |-
+      [SERVICE]
+          Flush        1
+          Daemon       Off
+          Log_Level    info
+          Parsers_File parsers.conf
+
+      [INPUT]
+          Name             tail
+          Path             /var/log/containers/*.log
+          Parser           docker
+          Tag              kube.*
+          Refresh_Interval 5
+          Mem_Buf_Limit    5MB
+          Skip_Long_Lines  Off
+
+      [INPUT]
+          Name          systemd
+          Path          /var/log/journal
+          Tag           systemd.*
+          Mem_Buf_Limit 5MB
+
+      [FILTER]
+          Name          record_modifier
+          Match         systemd.*
+          Whitelist_key _SYSTEMD_UNIT
+          Whitelist_key MESSAGE
+          Whitelist_key _PID
+          Whitelist_key _PRIORITY
+          Whitelist_key _COMM
+          Whitelist_key _HOSTNAME
+
+      [FILTER]
+          Name   modify
+          Match  systemd.*
+          Rename _SYSTEMD_UNIT unit
+          Rename MESSAGE log
+          Rename _PID pid
+          Rename _PRIORITY priority
+          Rename _COMM cmd
+          Rename _HOSTNAME hostname
+
+      [FILTER]
+          Name       record_modifier
+          Match      kube.*
+          Remove_key time
+
+      [FILTER]
+          Name               kubernetes
+          Match              kube.*
+          Kube_URL           https://kubernetes.default.svc:443
+          Kube_CA_File       /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          Kube_Token_File    /var/run/secrets/kubernetes.io/serviceaccount/token
+
+{{ if index .Values "fluent-bit" "filter" "additionalValues" }}
+      [FILTER]
+          Name record_modifier
+          Match *
+{{- range index .Values "fluent-bit" "filter" "additionalValues" }}
+          Record {{ .key }} {{ .value }}
+{{- end }}
+{{- end }}
+
+      [OUTPUT]
+          Name  es
+          Match *
+          Host  {{ index .Values "fluent-bit" "backend" "es" "host" }}
+          Port  443
+          Logstash_Format On
+          Retry_Limit False
+          Type  flb_type
+          Time_Key @timestamp
+          Logstash_Prefix {{ .Values "fluent-bit" "backend" "es" "logstash_prefix" }}
+          HTTP_User {{ index .Values "fluent-bit" "backend" "es" "http_user" }}
+          HTTP_Passwd {{ index .Values "fluent-bit" "backend" "es" "http_passwd" }}
+          tls on
+          tls.verify on
+          tls.debug 1
+  parsers.conf: ""
+{{ end }}

--- a/system/kube-monitoring/values.yaml
+++ b/system/kube-monitoring/values.yaml
@@ -77,3 +77,46 @@ kube-state-metrics:
     cronjobs: false
     # not available in k8s1.7
     horizontalpodautoscalers: false
+
+fluent-bit:
+  enabled: false
+
+  image:
+    fluent_bit:
+      repository: fluent/fluent-bit
+      tag: 1.0.4
+    pullPolicy: IfNotPresent
+
+  backend:
+    es:
+      tls_ca: ""
+      # host:
+      # http_user:
+      # http_passwd:
+      # logstash_prefix:
+
+  # filter:
+  # list of additional static values added to each log entry
+  #  additionalValues:
+  #  - key: some-key
+  #    value: some-value
+
+  podAnnotations:
+    # manual versioning, raise if configmap changes
+    versioning: "1"
+
+  existingConfigMap: fluent-bit-config
+
+  resources:
+    limits:
+      cpu: 500m
+      memory: 200Mi
+    requests:
+      cpu: 100m
+      memory: 100Mi
+
+  rbac:
+    create: true
+
+  serviceAccount:
+    create: true


### PR DESCRIPTION
This PR adds the fluent-bit chart to kube-monitoring. It is for logging container and systemd messages into elasticsearch. For now this is focused on the scaleout klusters but should work everywhere.