### PR TITLE
merge prometheusv2 and prometheus config trees and make P8S volume RWO

### DIFF
--- a/openstack/maia/templates/maia-ingress.yaml
+++ b/openstack/maia/templates/maia-ingress.yaml
@@ -24,5 +24,5 @@ spec:
             servicePort: {{.Values.maia.listen_port}}
 # uncomment to expose Prometheus UI instead of Maia
 #            serviceName: prometheus-maia
-#            servicePort: {{.Values.prometheusv2.listen_port}}
+#            servicePort: {{.Values.prometheus.listen_port}}
 {{- end }}

--- a/openstack/maia/templates/prometheus-deployment.yaml
+++ b/openstack/maia/templates/prometheus-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.prometheusv2.enabled }}
+{{- if .Values.prometheus.enabled }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 
@@ -25,31 +25,31 @@ spec:
         runAsUser: 0
       terminationGracePeriodSeconds: 600
       containers:
-        - name: prometheusv2
-          image: "{{ .Values.prometheusv2.image.repository }}:{{ .Values.prometheusv2.image.tag }}"
+        - name: prometheus
+          image: "{{ .Values.prometheus.image.repository }}:{{ .Values.prometheus.image.tag }}"
           args:
             - --config.file=/etc/prometheus/prometheus.yaml
             - --storage.tsdb.path=/prometheus/v2
-            - --storage.tsdb.retention={{ .Values.prometheusv2.retention }}
+            - --storage.tsdb.retention={{ .Values.prometheus.retention }}
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
-            - --web.listen-address=0.0.0.0:{{ .Values.prometheusv2.listen_port }}
+            - --web.listen-address=0.0.0.0:{{ .Values.prometheus.listen_port }}
             - --web.enable-admin-api
             - --web.enable-lifecycle
-            - --log.level={{ default "info" .Values.prometheusv2.log_level }}
+            - --log.level={{ default "info" .Values.prometheus.log_level }}
           ports:
             - name: http
-              containerPort: {{ .Values.prometheusv2.listen_port }}
+              containerPort: {{ .Values.prometheus.listen_port }}
           volumeMounts:
             - name: data
               mountPath: /prometheus
             - name: config
               mountPath: /etc/prometheus
         - name: prometheus-configmap-reloader
-          image: "{{ .Values.prometheusv2.configmap_reload.image.repository }}:{{ .Values.prometheusv2.configmap_reload.image.tag }}"
+          image: "{{ .Values.prometheus.configmap_reload.image.repository }}:{{ .Values.prometheus.configmap_reload.image.tag }}"
           args:
             - --volume-dir=/etc/prometheus
-            - --webhook-url=http://localhost:{{ .Values.prometheusv2.listen_port }}/-/reload
+            - --webhook-url=http://localhost:{{ .Values.prometheus.listen_port }}/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/prometheus

--- a/openstack/maia/templates/prometheus-service.yaml
+++ b/openstack/maia/templates/prometheus-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.prometheusv2.enabled }}
+{{- if .Values.prometheus.enabled }}
 kind: Service
 apiVersion: v1
 metadata:
@@ -10,11 +10,11 @@ metadata:
     component: prometheus
   annotations:
     prometheus.io/scrape: "true"
-    prometheus.io/port: "{{ .Values.prometheusv2.listen_port }}"
+    prometheus.io/port: "{{ .Values.prometheus.listen_port }}"
 spec:
   selector:
     component: prometheus-maia
   ports:
     - name: http
-      port: {{ .Values.prometheusv2.listen_port }}
+      port: {{ .Values.prometheus.listen_port }}
 {{- end }}

--- a/openstack/maia/values.yaml
+++ b/openstack/maia/values.yaml
@@ -34,17 +34,6 @@ openstack:
   domain_name: DEFINED-IN-REGION-SECRETS
 
 prometheus:
-  enabled: False
-  image: prom/prometheus:v1.8.2
-  retention: 168h0m0s
-  target_heap_size: "26843545600"
-  listen_port: 9092
-  persistence:
-    name: data-prometheus-maia-0
-    access_mode: ReadWriteMany
-    size: 100Gi
-
-prometheusv2:
   enabled: True
   vice_president: true
   image:
@@ -56,11 +45,10 @@ prometheusv2:
     image:
       repository: jimmidyson/configmap-reload
       tag: v0.2.2
-
-  # persistence:
-    # name: data-prometheus-maia-0
-    # access_mode: ReadWriteMany
-    # size: 100Gi
+  persistence:
+    name: data-prometheus-maia-0
+    access_mode: ReadWriteOnce
+    size: 100Gi
 
 vcenter_exporter:
   listen_port: 9102


### PR DESCRIPTION
To avoid confusion I merged the "prometheusv2" config section with the "prometheus" one. On that occasion I switched the volume type to RWO (less error prone).

For upcoming Prometheus versions, we will use another approach for upgrading Prometheus based on Arnos work on the P8S operator.