### PR TITLE
Allow sentry admin user to read events when seeding sentry

### DIFF
--- a/system/sentry/templates/_seed.py.tpl
+++ b/system/sentry/templates/_seed.py.tpl
@@ -67,7 +67,7 @@ def ensure_api_token(user, token):
     except ApiToken.DoesNotExist:
         token = ApiToken.objects.create(
              user=user,
-             scope_list=["project:read", "project:write", "project:delete", "team:read", "team:write", "org:read", "org:write", "member:read", "member:write"],
+             scope_list=["project:read", "project:write", "project:delete", "team:read", "team:write", "org:read", "org:write", "member:read", "member:write", "event:read"],
              token=token,
              refresh_token=None,
              expires_at=None,


### PR DESCRIPTION
I'd like the admin user to also be able to view events and issues. Note that I didn't run a test-deployment with this.