### PR TITLE
Larger channel clean up and restructuring

### DIFF
--- a/global/prometheus-alertmanager/templates/config.yaml
+++ b/global/prometheus-alertmanager/templates/config.yaml
@@ -45,13 +45,75 @@ data:
       repeat_interval: 12h
       receiver: dev-null
 
+      # Route Hierarchie:
+      # - execution is top down (check here: https://prometheus.io/webtools/alerting/routing-tree-editor/)
+      # - 1. custom setup for alerts with duty receivers, always 'continue: true'
+      # - 2. duty setup blocks must end with 'continue: false' - it shall grep all relevant alerts
+      # - 3. qa/staging/labs (should be non congruent to duty channels), must end with 'continue: false'
+      # - 4. specific custom setup for alerts NOT covered in Duty, must end with 'continue: false'
+      # - all undefined routes should be routed to dev_null (if too many: fix alert focus or duty filter)
       routes:
-      - receiver: dev-null
+
+      # ======= CUSTOM ALERT NOTIFICATION ON DUTY RELEVANT ALERTS ======= 
+
+      # owner: Thomas Grainchen
+      - receiver: slack_nannies
+        continue: true
+        match_re:
+          context: nanny 
+
+      # owner: Michael Schmidt / Fabian Ruff
+      - receiver: slack_k8s
+        continue: true
+        match_re:
+          tier: k8s
+          severity: critical|warning|info
+          cluster_type: controlplane
+          region: admin|qa-de-1|ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
+      
+      # owner: Michael Schmidt / Fabian Ruff
+      # critical channel has the action buttons
+      - receiver: slack_kks_default
+        continue: true
+        match_re:
+          tier: kks
+          severity: warning|info
+          region: admin|ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
+      
+      - receiver: slack_kks_critical
+        continue: true
+        match_re:
+          tier: kks
+          severity: critical
+          region: admin|ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
+
+      # owner: Fabian Ruff
+      - receiver: slack_concourse
+        continue: true
+        match_re:
+          severity: info|warning|critical
+          service: concourse
+
+      # owner: Tilo Geissler
+      - receiver: pagerduty_alertchain_test
         continue: false
         match_re:
-          region: .*staging|lab
+          tier: test-tier
+          severity: test
+          region: area51
 
-      # ---- DUTY API ----
+      # owner: Tilo Geissler
+      - receiver: slack_by_os_service
+        continue: true
+        match_re:
+          tier: os
+          severity: info|warning|critical
+          service: arc|backup|barbican|cinder|cfm|designate|elektra|elk|glance|hermes|ironic|keystone|limes|lyra|maia|manila|neutron|nova|sentry|swift
+
+
+      # ======= DUTY ROUTING =======
+
+      # ---- API  ----
       - receiver: pagerduty_api
         continue: true
         match_re:
@@ -60,19 +122,27 @@ data:
           cluster_type: controlplane
           region: ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
 
+      - receiver: slack_api_critical
+        continue: false
+        match_re:
+          tier: os|k8s
+          severity: critical
+          cluster_type: controlplane
+          region: ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
+
       - receiver: slack_api_warning
-        continue: true
+        continue: false
         match_re:
           tier: os|k8s
           severity: warning
           cluster_type: controlplane
           region: ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
 
-      - receiver: slack_api_critical
-        continue: true
+      - receiver: slack_api_info
+        continue: false
         match_re:
           tier: os|k8s
-          severity: critical
+          severity: info
           cluster_type: controlplane
           region: ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
 
@@ -84,18 +154,25 @@ data:
           severity: critical
           region: ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
 
+      - receiver: slack_metal_critical
+        continue: false
+        match_re:
+          tier: metal
+          severity: critical
+          region: ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
+
       - receiver: slack_metal_warning
-        continue: true
+        continue: false
         match_re:
           tier: metal
           severity: warning
           region: ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
 
-      - receiver: slack_metal_critical
+      - receiver: slack_metal_info
         continue: true
         match_re:
           tier: metal
-          severity: critical
+          severity: info
           region: ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
 
       # ---- DUTY VMware ----
@@ -106,18 +183,25 @@ data:
           severity: critical
           region: ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
 
+      - receiver: slack_vmware_critical
+        continue: false
+        match_re:
+          tier: vmware
+          severity: critical
+          region: ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
+
       - receiver: slack_vmware_warning
-        continue: true
+        continue: false
         match_re:
           tier: vmware
           severity: warning
           region: ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
 
-      - receiver: slack_vmware_critical
-        continue: true
+      - receiver: slack_vmware_info
+        continue: false
         match_re:
           tier: vmware
-          severity: critical
+          severity: info
           region: ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
 
       # ---- DUTY network ----
@@ -128,78 +212,47 @@ data:
           severity: critical
           region: admin|ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
 
+      - receiver: slack_net_critical
+        continue: false
+        match_re:
+          tier: net
+          severity: critical
+          region: admin|ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
+
       - receiver: slack_net_warning
-        continue: true
+        continue: false
         match_re:
           tier: net
           severity: warning
           region: admin|ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
 
-      - receiver: slack_net_critical
-        continue: true
-        match_re:
-          tier: net
-          severity: critical
-          region: admin|ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
-
-      # ----  Just Notification Slack Channels ----
-      - receiver: slack_os_critical
-        continue: true
-        match_re:
-          tier: os
-          severity: critical
-          region: admin|ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
-
-      - receiver: slack_k8s_critical
-        continue: true
-        match_re:
-          tier: k8s
-          severity: critical
-          cluster_type: controlplane
-          region: admin|ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
-
-      - receiver: slack_kks_critical
-        continue: true
-        match_re:
-          tier: kks
-          severity: critical
-          region: admin|ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
-
-      - receiver: slack_by_tier_and_severity
-        continue: true
-        match_re:
-          tier: os|kks|metal|net
-          severity: info|warning
-          region: admin|qa-de-1|ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
-
-      # limit tier k8s to controlplane for now
-      # should be merged with the above block as soon as we sorted out kube-monitoring
-      - receiver: slack_by_tier_and_severity
-        continue: true
-        match_re:
-          tier: k8s
-          cluster_type: controlplane
-          severity: info|warning
-          region: admin|qa-de-1|ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
-
-      - receiver: slack_by_tier_and_service
-        continue: true
-        match_re:
-          tier: os
-          severity: info|warning|critical
-          service: arc|backup|barbican|cinder|cfm|designate|elektra|elk|hermes|ironic|keystone|limes|lyra|maia|manila|neutron|nova|sentry|swift
-
-      - receiver: slack_by_tier
-        continue: true
-        match_re:
-          severity: info|warning|critical
-          service: concourse
-
-      # do not page for kubernikus controlplane
-      - receiver: dev-null
+      - receiver: slack_net_info
         continue: false
         match_re:
-          cluster_type: kubernikus-controlplane|kubernikus-scaleout
+          tier: net
+          severity: info
+          region: admin|ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3
+
+      # =======  QA / DEV & Labs ======= 
+      - receiver: slack_qa
+        continue: false
+        match_re:
+          severity: critical | warning | info
+          region: qa-de-1
+
+      - receiver: slack_dev
+        continue: false
+        match_re:
+          severity: critical | warning | info
+          region: staging | lab-1
+
+      # ======= SPECIFIC ALERT NOTIFICATION  ======= 
+
+
+      # ======= all unrouted should end here ======= 
+      - receiver: dev-null
+        continue: false
+
 
     receivers:
     - name: dev-null
@@ -233,9 +286,25 @@ data:
               text: {{"'{{template \"slack.sapcc.silence1Month.actionText\" . }}'"}}
               value: {{"'{{template \"slack.sapcc.silence1Month.actionValue\" . }}'"}}
 
+    # ---- Slack Duty (Alert)Channels ----
+    # slack duty metal
+    - name: slack_metal_info
+      slack_configs:
+        - channel: '#alert-metal-info'
+          api_url: {{ required "slack.webhook_url undefined" .Values.slack.webhook_url | quote }}
+          username: "Control Plane"
+          title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
+          title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
+          text: {{"'{{template \"slack.sapcc.text\" . }}'"}}
+          pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
+          icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
+          callback_id: "alertmanager"
+          color: {{`'{{template "slack.sapcc.color" . }}'`}}
+          send_resolved: true
+          
     - name: slack_metal_warning
       slack_configs:
-        - channel: '#alert-{{"{{ .CommonLabels.tier }}"}}-{{"{{ .CommonLabels.severity }}"}}'
+        - channel: '#alert-metal-warning'
           api_url: {{ required "slack.metal_warning_webhook_url undefined" .Values.slack.metal_warning_webhook_url | quote }}
           username: "Control Plane"
           title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
@@ -266,7 +335,7 @@ data:
 
     - name: slack_metal_critical
       slack_configs:
-        - channel: '#alert-{{"{{ .CommonLabels.tier }}"}}-{{"{{ .CommonLabels.severity }}"}}'
+        - channel: '#alert-metal-critical'
           api_url: {{ required "slack.metal_critical_webhook_url undefined" .Values.slack.metal_critical_webhook_url | quote }}
           username: "Control Plane"
           title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
@@ -295,37 +364,11 @@ data:
               text: {{"'{{template \"slack.sapcc.silence1Month.actionText\" . }}'"}}
               value: {{"'{{template \"slack.sapcc.silence1Month.actionValue\" . }}'"}}
 
-
-    - name: slack_os_critical
+    # slack duty net
+    - name: slack_net_info
       slack_configs:
-        - channel: '#alert-{{"{{ .CommonLabels.tier }}"}}-{{"{{ .CommonLabels.severity }}"}}'
+        - channel: '#alert-net-info'
           api_url: {{ required "slack.webhook_url undefined" .Values.slack.webhook_url | quote }}
-          username: "Control Plane"
-          title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
-          title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
-          text: {{"'{{template \"slack.sapcc.text\" . }}'"}}
-          pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
-          icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
-          color: {{`'{{template "slack.sapcc.color" . }}'`}}
-          send_resolved: true
-
-    - name: slack_k8s_critical
-      slack_configs:
-        - channel: '#alert-{{"{{ .CommonLabels.tier }}"}}-{{"{{ .CommonLabels.severity }}"}}'
-          api_url: {{ required "slack.webhook_url undefined" .Values.slack.webhook_url | quote }}
-          username: "Control Plane"
-          title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
-          title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
-          text: {{"'{{template \"slack.sapcc.text\" . }}'"}}
-          pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
-          icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
-          color: {{`'{{template "slack.sapcc.color" . }}'`}}
-          send_resolved: true
-
-    - name: slack_kks_critical
-      slack_configs:
-        - channel: '#alert-{{"{{ .CommonLabels.tier }}"}}-{{"{{ .CommonLabels.severity }}"}}'
-          api_url: {{ required "slack.kubernikus_critical_webhook_url undefined" .Values.slack.kubernikus_critical_webhook_url | quote }}
           username: "Control Plane"
           title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
           title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
@@ -335,27 +378,10 @@ data:
           callback_id: "alertmanager"
           color: {{`'{{template "slack.sapcc.color" . }}'`}}
           send_resolved: true
-          actions:
-            - name: {{"'{{template \"slack.sapcc.actionName\" . }}'"}}
-              type: {{"'{{template \"slack.sapcc.actionType\" . }}'"}}
-              text: {{"'{{template \"slack.sapcc.acknowledge.actionText\" . }}'"}}
-              value: {{"'{{template \"slack.sapcc.acknowledge.actionValue\" . }}'"}}
-            - name: {{"'{{template \"slack.sapcc.actionName\" . }}'"}}
-              type: {{"'{{template \"slack.sapcc.actionType\" . }}'"}}
-              text: {{"'{{template \"slack.sapcc.silence1Day.actionText\" . }}'"}}
-              value: {{"'{{template \"slack.sapcc.silence1Day.actionValue\" . }}'"}}
-            - name: {{"'{{template \"slack.sapcc.actionName\" . }}'"}}
-              type: {{"'{{template \"slack.sapcc.actionType\" . }}'"}}
-              text: {{"'{{template \"slack.sapcc.silenceUntilMonday.actionText\" . }}'"}}
-              value: {{"'{{template \"slack.sapcc.silenceUntilMonday.actionValue\" . }}'"}}
-            - name: {{"'{{template \"slack.sapcc.actionName\" . }}'"}}
-              type: {{"'{{template \"slack.sapcc.actionType\" . }}'"}}
-              text: {{"'{{template \"slack.sapcc.silence1Month.actionText\" . }}'"}}
-              value: {{"'{{template \"slack.sapcc.silence1Month.actionValue\" . }}'"}}
 
     - name: slack_net_warning
       slack_configs:
-        - channel: '#alert-{{"{{ .CommonLabels.tier }}"}}-{{"{{ .CommonLabels.severity }}"}}'
+        - channel: '#alert-net-warning'
           api_url: {{ required "slack.network_warning_webhook_url undefined" .Values.slack.network_warning_webhook_url | quote }}
           username: "Control Plane"
           title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
@@ -386,7 +412,7 @@ data:
 
     - name: slack_net_critical
       slack_configs:
-        - channel: '#alert-{{"{{ .CommonLabels.tier }}"}}-{{"{{ .CommonLabels.severity }}"}}'
+        - channel: '#alert-net-critical'
           api_url: {{ required "slack.network_critical_webhook_url undefined" .Values.slack.network_critical_webhook_url | quote }}
           username: "Control Plane"
           title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
@@ -415,9 +441,24 @@ data:
               text: {{"'{{template \"slack.sapcc.silence1Month.actionText\" . }}'"}}
               value: {{"'{{template \"slack.sapcc.silence1Month.actionValue\" . }}'"}}
 
+    # slack duty vmware
+    - name: slack_vmware_info
+      slack_configs:
+        - channel: '#alert-vmware-info'
+          api_url: {{ required "slack.webhook_url undefined" .Values.slack.webhook_url | quote }}
+          username: "Control Plane"
+          title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
+          title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
+          text: {{"'{{template \"slack.sapcc.text\" . }}'"}}
+          pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
+          icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
+          callback_id: "alertmanager"
+          color: {{`'{{template "slack.sapcc.color" . }}'`}}
+          send_resolved: true
+
     - name: slack_vmware_warning
       slack_configs:
-        - channel: '#alert-{{"{{ .CommonLabels.tier }}"}}-{{"{{ .CommonLabels.severity }}"}}'
+        - channel: '#alert-vmware-warning'
           api_url: {{ required "slack.vmware_warning_webhook_url undefined" .Values.slack.vmware_warning_webhook_url | quote }}
           username: "Control Plane"
           title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
@@ -448,7 +489,7 @@ data:
 
     - name: slack_vmware_critical
       slack_configs:
-        - channel: '#alert-{{"{{ .CommonLabels.tier }}"}}-{{"{{ .CommonLabels.severity }}"}}'
+        - channel: '#alert-vmware-critical'
           api_url: {{ required "slack.vmware_critical_webhook_url undefined" .Values.slack.vmware_critical_webhook_url | quote }}
           username: "Control Plane"
           title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
@@ -477,10 +518,10 @@ data:
               text: {{"'{{template \"slack.sapcc.silence1Month.actionText\" . }}'"}}
               value: {{"'{{template \"slack.sapcc.silence1Month.actionValue\" . }}'"}}
 
-
-    - name: slack_by_tier_and_severity
+    # slack duty api
+    - name: slack_api_info
       slack_configs:
-        - channel: '#alert-{{"{{ .CommonLabels.tier }}"}}-{{"{{ .CommonLabels.severity }}"}}'
+        - channel: '#alert-api-info'
           api_url: {{ required "slack.webhook_url undefined" .Values.slack.webhook_url | quote }}
           username: "Control Plane"
           title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
@@ -488,39 +529,14 @@ data:
           text: {{"'{{template \"slack.sapcc.text\" . }}'"}}
           pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
           icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
+          callback_id: "alertmanager"
           color: {{`'{{template "slack.sapcc.color" . }}'`}}
           send_resolved: true
-
-    - name: slack_by_tier
-      slack_configs:
-        - channel: '#alert-{{"{{ .CommonLabels.tier }}"}}'
-          api_url: {{ required "slack.webhook_url undefined" .Values.slack.webhook_url | quote }}
-          username: "Control Plane"
-          title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
-          title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
-          text: {{"'{{template \"slack.sapcc.text\" . }}'"}}
-          pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
-          icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
-          color: {{`'{{template "slack.sapcc.color" . }}'`}}
-          send_resolved: true
-
-    - name: slack_by_tier_and_service
-      slack_configs:
-        - channel: '#alert-{{"{{ .CommonLabels.tier }}"}}-{{"{{ .CommonLabels.service }}"}}'
-          api_url: {{ default "MISSING" .Values.slack.webhook_url | quote }}
-          username: "Control Plane"
-          title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
-          title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
-          text: {{"'{{template \"slack.sapcc.text\" . }}'"}}
-          pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
-          icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
-          color: {{`'{{template "slack.sapcc.color" . }}'`}}
-          send_resolved: true
-
+          
     - name: slack_api_warning
       slack_configs:
-        - channel: '#alert-api-{{"{{ .CommonLabels.severity }}"}}'
-          api_url: {{ default "MISSING" .Values.slack.api_warning_webhook_url | quote }}
+        - channel: '#alert-api-warning'
+          api_url: {{ required "slack.api_warning_webhook_url undefined" .Values.slack.api_warning_webhook_url | quote }}
           username: "Control Plane"
           title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
           title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
@@ -550,8 +566,8 @@ data:
 
     - name: slack_api_critical
       slack_configs:
-        - channel: '#alert-api-{{"{{ .CommonLabels.severity }}"}}'
-          api_url: {{ default "MISSING" .Values.slack.api_critical_webhook_url | quote }}
+        - channel: '#alert-api-critical'
+          api_url: {{ required "slack.api_critical_webhook_url undefined" .Values.slack.api_critical_webhook_url | quote }}
           username: "Control Plane"
           title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
           title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
@@ -579,9 +595,137 @@ data:
               text: {{"'{{template \"slack.sapcc.silence1Month.actionText\" . }}'"}}
               value: {{"'{{template \"slack.sapcc.silence1Month.actionValue\" . }}'"}}
 
+    # Slack QA && Dev systems
+    - name: slack_qa
+      slack_configs:
+        - channel: '#alert-qa-{{"{{ .CommonLabels.severity }}"}}'
+          api_url: {{ required "slack.webhook_url undefined" .Values.slack.webhook_url | quote }}
+          username: "Control Plane"
+          title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
+          title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
+          text: {{"'{{template \"slack.sapcc.text\" . }}'"}}
+          pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
+          icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
+          callback_id: "alertmanager"
+          color: {{`'{{template "slack.sapcc.color" . }}'`}}
+          send_resolved: true
+ 
+    - name: slack_dev
+      slack_configs:
+        - channel: '#alert-dev-{{"{{ .CommonLabels.severity }}"}}'
+          api_url: {{ required "slack.webhook_url undefined" .Values.slack.webhook_url | quote }}
+          username: "Control Plane"
+          title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
+          title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
+          text: {{"'{{template \"slack.sapcc.text\" . }}'"}}
+          pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
+          icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
+          callback_id: "alertmanager"
+          color: {{`'{{template "slack.sapcc.color" . }}'`}}
+          send_resolved: true
+
+    # ---- Slack Notification Channels - pls do not use prefix 'alert' ----
+    - name: slack_by_os_service
+      slack_configs:
+        - channel: '#cc-os-{{"{{ .CommonLabels.service }}"}}'
+          api_url: {{ required "slack.webhook_url undefined" .Values.slack.webhook_url | quote }}
+          username: "Control Plane"
+          title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
+          title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
+          text: {{"'{{template \"slack.sapcc.text\" . }}'"}}
+          pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
+          icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
+          color: {{`'{{template "slack.sapcc.color" . }}'`}}
+          send_resolved: true
+
+    - name: slack_k8s
+      slack_configs:
+        - channel: '#cc-k8s-{{"{{ .CommonLabels.severity }}"}}'
+          api_url: {{ required "slack.webhook_url undefined" .Values.slack.webhook_url | quote }}
+          username: "Control Plane"
+          title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
+          title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
+          text: {{"'{{template \"slack.sapcc.text\" . }}'"}}
+          pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
+          icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
+          color: {{`'{{template "slack.sapcc.color" . }}'`}}
+          send_resolved: true
+
+    - name: slack_kks_default
+      slack_configs:
+        - channel: '#cc-kks-{{"{{ .CommonLabels.severity }}"}}'
+          api_url: {{ required "slack.kubernikus_critical_webhook_url undefined" .Values.slack.kubernikus_critical_webhook_url | quote }}
+          username: "Control Plane"
+          title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
+          title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
+          text: {{"'{{template \"slack.sapcc.text\" . }}'"}}
+          pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
+          icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
+          callback_id: "alertmanager"
+          color: {{`'{{template "slack.sapcc.color" . }}'`}}
+          send_resolved: true
+      
+    - name: slack_kks_critical
+      slack_configs:
+        - channel: '#cc-kks-critical'
+          api_url: {{ required "slack.kubernikus_critical_webhook_url undefined" .Values.slack.kubernikus_critical_webhook_url | quote }}
+          username: "Control Plane"
+          title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
+          title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
+          text: {{"'{{template \"slack.sapcc.text\" . }}'"}}
+          pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
+          icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
+          callback_id: "alertmanager"
+          color: {{`'{{template "slack.sapcc.color" . }}'`}}
+          send_resolved: true
+          actions:
+            - name: {{"'{{template \"slack.sapcc.actionName\" . }}'"}}
+              type: {{"'{{template \"slack.sapcc.actionType\" . }}'"}}
+              text: {{"'{{template \"slack.sapcc.acknowledge.actionText\" . }}'"}}
+              value: {{"'{{template \"slack.sapcc.acknowledge.actionValue\" . }}'"}}
+            - name: {{"'{{template \"slack.sapcc.actionName\" . }}'"}}
+              type: {{"'{{template \"slack.sapcc.actionType\" . }}'"}}
+              text: {{"'{{template \"slack.sapcc.silence1Day.actionText\" . }}'"}}
+              value: {{"'{{template \"slack.sapcc.silence1Day.actionValue\" . }}'"}}
+            - name: {{"'{{template \"slack.sapcc.actionName\" . }}'"}}
+              type: {{"'{{template \"slack.sapcc.actionType\" . }}'"}}
+              text: {{"'{{template \"slack.sapcc.silenceUntilMonday.actionText\" . }}'"}}
+              value: {{"'{{template \"slack.sapcc.silenceUntilMonday.actionValue\" . }}'"}}
+            - name: {{"'{{template \"slack.sapcc.actionName\" . }}'"}}
+              type: {{"'{{template \"slack.sapcc.actionType\" . }}'"}}
+              text: {{"'{{template \"slack.sapcc.silence1Month.actionText\" . }}'"}}
+              value: {{"'{{template \"slack.sapcc.silence1Month.actionValue\" . }}'"}}
+
+    - name: slack_concourse
+      slack_configs:
+        - channel: '#cc-concourse'
+          api_url: {{ required "slack.webhook_url undefined" .Values.slack.webhook_url | quote }}
+          username: "Control Plane"
+          title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
+          title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
+          text: {{"'{{template \"slack.sapcc.text\" . }}'"}}
+          pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
+          icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
+          color: {{`'{{template "slack.sapcc.color" . }}'`}}
+          send_resolved: true
+
+    - name: slack_nannies
+      slack_configs:
+        - channel: '#cc-nannies'
+          api_url: {{ required "slack.webhook_url undefined" .Values.slack.webhook_url | quote }}
+          username: "Control Plane"
+          title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
+          title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
+          text: {{"'{{template \"slack.sapcc.text\" . }}'"}}
+          pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
+          icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
+          color: {{`'{{template "slack.sapcc.color" . }}'`}}
+          send_resolved: true
+
+    # ----  PagerDuty Setup ---- Hint: service_key causes using api v1, check internet ----
     - name: pagerduty_api
       pagerduty_configs:
-        - service_key: {{ default "MISSING" .Values.pagerduty.api.service_key | quote }}
+        - service_key: {{ required "pagerduty.api.service_key undefined" .Values.pagerduty.api.service_key | quote }}
           description: {{"'{{ template \"pagerduty.sapcc.description\" . }}'"}}
           component: {{"'{{template \"pagerduty.sapcc.tier\" . }}'"}}
           group: {{"'{{template \"pagerduty.sapcc.service\" . }}'"}}
@@ -599,7 +743,7 @@ data:
 
     - name: pagerduty_metal
       pagerduty_configs:
-        - service_key: {{ default "MISSING" .Values.pagerduty.metal.service_key | quote }}
+        - service_key: {{ required "pagerduty.metal.service_key undefined" .Values.pagerduty.metal.service_key | quote }}
           description: {{"'{{ template \"pagerduty.sapcc.description\" . }}'"}}
           component: {{"'{{template \"pagerduty.sapcc.tier\" . }}'"}}
           group: {{"'{{template \"pagerduty.sapcc.service\" . }}'"}}
@@ -617,7 +761,7 @@ data:
 
     - name: pagerduty_network
       pagerduty_configs:
-        - service_key: {{ default "MISSING" .Values.pagerduty.network.service_key | quote }}
+        - service_key: {{ required "pagerduty.network.service_key undefined" .Values.pagerduty.network.service_key | quote }}
           description: {{"'{{ template \"pagerduty.sapcc.description\" . }}'"}}
           component: {{"'{{template \"pagerduty.sapcc.tier\" . }}'"}}
           group: {{"'{{template \"pagerduty.sapcc.service\" . }}'"}}
@@ -635,7 +779,7 @@ data:
 
     - name: pagerduty_vmware
       pagerduty_configs:
-        - service_key: {{ default "MISSING" .Values.pagerduty.vmware.service_key | quote }}
+        - service_key: {{ required "pagerduty.vmware.service_key undefined" .Values.pagerduty.vmware.service_key | quote }}
           description: {{"'{{ template \"pagerduty.sapcc.description\" . }}'"}}
           component: {{"'{{template \"pagerduty.sapcc.tier\" . }}'"}}
           group: {{"'{{template \"pagerduty.sapcc.service\" . }}'"}}
@@ -650,6 +794,25 @@ data:
             Sentry: {{"'{{template \"pagerduty.sapcc.sentry\" . }}'"}}
             Playbook: {{"'{{template \"pagerduty.sapcc.playbook\" . }}'"}}
             firing: {{"'{{ template \"pagerduty.sapcc.firing\" . }}'"}}
+
+    - name: pagerduty_alertchain_test
+      pagerduty_configs:
+        - service_key: {{ required "pagerduty.alerttest.service_key undefined" .Values.pagerduty.alerttest.service_key | quote }}
+          description: {{"'{{ template \"pagerduty.sapcc.description\" . }}'"}}
+          component: {{"'{{template \"pagerduty.sapcc.tier\" . }}'"}}
+          group: {{"'{{template \"pagerduty.sapcc.service\" . }}'"}}
+          details:
+            Details: {{"'{{template \"pagerduty.sapcc.details\" . }}'"}}
+            Region: {{"'{{template \"pagerduty.sapcc.region\" . }}'"}}
+            Tier: {{"'{{template \"pagerduty.sapcc.tier\" . }}'"}}
+            Service: {{"'{{template \"pagerduty.sapcc.service\" . }}'"}}
+            Context: {{"'{{template \"pagerduty.sapcc.context\" . }}'"}}
+            Prometheus: {{"'{{template \"pagerduty.sapcc.prometheus\" . }}'"}}
+            Dashboard: {{"'{{template \"pagerduty.sapcc.dashboard\" . }}'"}}
+            Sentry: {{"'{{template \"pagerduty.sapcc.sentry\" . }}'"}}
+            Playbook: {{"'{{template \"pagerduty.sapcc.playbook\" . }}'"}}
+            firing: {{"'{{ template \"pagerduty.sapcc.firing\" . }}'"}}
+
 
   {{- $files := .Files }}
   {{ range tuple "slack.tmpl" "pagerduty.tmpl" }}


### PR DESCRIPTION
# In basic the changes follow 3 principles

0. stricter structure
1. less dynamic channel naming - why: simply reduce risk of non delivered messages (metric: alertmanager_notifications_failed_total)
2. Differ between Duty (alert) Channels and Notification Channels (some clean up needed to have no overlap)
3. Notification channels should have an owner which also defines filter on labels - contact if you wanna adopt something
4. dev-null get’s all the non-configured stuff

# In addition:
- add a alertchain test routing for pager duty
- add a cc-nanny channel
- concourse routes now to an existing channel
- made the webhooks required

# Note:
- Discussion on changes were done on previous pull request https://github.com/sapcc/helm-charts/pull/634 (unfortunately killed by rebase on old master) 
- Second PullRequest is formal 
- want to merge on 22nd of March by my own

