### PR TITLE
init prometheus operator

### DIFF
--- a/system/prometheus-operator/.helmignore
+++ b/system/prometheus-operator/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/system/prometheus-operator/Chart.yaml
+++ b/system/prometheus-operator/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: The pure Prometheus Operator
+name: prometheus-operator
+version: 1.0.0

--- a/system/prometheus-operator/requirements.lock
+++ b/system/prometheus-operator/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: prometheus-operator
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 5.0.1
+digest: sha256:5ee2976968e453f017e80f71d19bc6cde03730787b6f12fc8a51d284f0002775
+generated: 2019-03-22T12:50:48.767835312+01:00

--- a/system/prometheus-operator/requirements.yaml
+++ b/system/prometheus-operator/requirements.yaml
@@ -1,0 +1,5 @@
+dependencies:
+  - name: prometheus-operator
+    repository: https://kubernetes-charts.storage.googleapis.com/
+    version: 5.0.1
+    condition: prometheus-operator.enabled

--- a/system/prometheus-operator/values.yaml
+++ b/system/prometheus-operator/values.yaml
@@ -1,0 +1,111 @@
+global:
+  rbac:
+    create: false
+    # Disable PodSecurityPolicy for k8s 1.7 .
+    pspEnabled: false
+
+# Disable Grafana sub-chart. We deploy independently.
+grafana:
+  enabled: false
+
+# Disable the kube-state-metrics sub-chart. We deploy independently.
+kubeStateMetrics:
+  enabled: false
+
+# Disable the node-exporter sub-chart. We deploy independently.
+nodeExporter:
+  enabled: false
+
+prometheus-operator:
+  # Disable the prometheus operator by default.
+  # Enable via regional values.
+  enabled: false
+
+  # Just `prometheus`. The operator appends `-operator`.
+  nameOverride: prometheus
+  fullnameOverride: prometheus
+
+  prometheusOperator:
+    image:
+      repository: quay.io/coreos/prometheus-operator
+      tag: v0.29.0
+
+    serviceAccount:
+      create: false
+
+    # Enable creation of CRDs used by the Prometheus operator.
+    createCustomResource: true
+
+  operator:
+    serviceAccountName: default
+
+  # Disable creation of default aggregation and alerting rules.
+  defaultRules:
+    create: false
+
+  # Disable the Prometheus instance. We deploy our own Prometheis.
+  prometheus:
+    enabled: false
+
+  # Disable the Grafana configuration and dashboards.
+  grafana:
+    enabled: false
+
+  alertmanager:
+    enabled: false
+    image:
+      repository: prom/alertmanager
+      tag: v0.16.1
+    # Alertmanager template files
+    templateFiles: {}
+    ingress:
+      enabled: false
+      annotations:
+        vice-president: "true"
+        disco: "true"
+      # hosts:
+      #   - alertmanager.tld
+      # tls:
+      #   - secretName:
+      #     hosts:
+      #       - alertmanager.tld
+
+  # Disable the configuration for kube state metrics.
+  kube-state-metrics:
+    enabled: false
+
+  # Disable the configuration for the node exporter.
+  prometheus-node-exporter:
+    enabled: false
+
+  # Exporter section:
+  # Enable/Disable exporters.
+  # Deploys the service and servicemonitor.
+  kubeApiServer:
+    enabled: true
+    serviceMonitor:
+      jobLabel: kube-apiserver
+
+  kubelet:
+    enabled: false
+
+  kubeControllerManager:
+    enabled: false
+
+  coreDns:
+    enabled: false
+
+  kubeDns:
+    enabled: false
+
+  kubeEtcd:
+    enabled: false
+
+  kubeScheduler:
+    enabled: false
+
+  kubeStateMetrics:
+    enabled: false
+
+  nodeExporter:
+    enabled: false


### PR DESCRIPTION
Chart for prometheus operator. Allows deployment independent from kube-monitoring. 
Prometheis, Rule CRDs and config will be a separate PR
