### PR TITLE
P8s monitor cpulimits

### DIFF
--- a/system/kube-monitoring/charts/prometheus-collector/aggregation.rules
+++ b/system/kube-monitoring/charts/prometheus-collector/aggregation.rules
@@ -1,6 +1,7 @@
 groups:
 - name: cpu
   rules:
+  # TODO: remove with K8S 1.10+ / cAdvisor 0.29.0 (https://github.com/google/cadvisor/blob/master/CHANGELOG.md#0290-2018-02-20)
   - record: aggregated:container_cpu_system_seconds_total
     expr: sum(container_cpu_system_seconds_total{container_name!="POD"}) by (id,namespace,pod_name,container_name)
 

--- a/system/kube-monitoring/charts/prometheus-frontend/templates/config.yaml
+++ b/system/kube-monitoring/charts/prometheus-frontend/templates/config.yaml
@@ -101,7 +101,7 @@ data:
           - '{__name__=~"^canary_.+"}'
           - '{__name__=~"^concourse_.+"}'
           - '{__name__=~"^cinder_nanny_.+"}'
-          - '{__name__=~"^container_cpu_cfs_throttled.+"}'
+          - '{__name__=~"^container_cpu_cfs_.+"}'
           - '{__name__=~"^container_fs.+"}'
           - '{__name__=~"^container_memory_.+"}'
           - '{__name__=~"^container_network_.+"}'

--- a/system/kube-monitoring/charts/prometheus-frontend/templates/config.yaml
+++ b/system/kube-monitoring/charts/prometheus-frontend/templates/config.yaml
@@ -101,6 +101,7 @@ data:
           - '{__name__=~"^canary_.+"}'
           - '{__name__=~"^concourse_.+"}'
           - '{__name__=~"^cinder_nanny_.+"}'
+          - '{__name__=~"^container_cpu_cfs_throttled.+"}'
           - '{__name__=~"^container_fs.+"}'
           - '{__name__=~"^container_memory_.+"}'
           - '{__name__=~"^container_network_.+"}'


### PR DESCRIPTION
Federate completely-fair-scheduler metrics from prometheus-collector to frontend, so that you can visualize CPU utilization and limits in Grafana. This helps fine-tuning those limits and may later be used  to discover starvation caused by outdated limits.