### PR TITLE
Maia resource limits

### DIFF
--- a/openstack/maia/templates/maia-deployment.yaml
+++ b/openstack/maia/templates/maia-deployment.yaml
@@ -44,9 +44,11 @@ spec:
               value: {{ $.Values.maia.debug | quote }}
           resources:
               requests:
-                  memory: "50Mi"
+                  memory: {{ .Values.maia.resources.memory.expected }}
+                  cpu: {{ .Values.maia.resources.cpu.expected }}
               limits:
-                  memory: "100Mi"
+                  memory: {{ .Values.maia.resources.memory.tolerated }}
+                  cpu: {{ .Values.maia.resources.cpu.tolerated }}
           volumeMounts:
             - mountPath: /etc/maia
               name: maia-etc

--- a/openstack/maia/values.yaml
+++ b/openstack/maia/values.yaml
@@ -33,8 +33,8 @@ maia:
       tolerated: 400Mi
     cpu:
       # currently maia is used by very few concurrent users
-      expected: "5m"
-      tolerated: "10m"
+      expected: "10m"
+      tolerated: "500m"
 
 prometheus:
   enabled: True

--- a/openstack/maia/values.yaml
+++ b/openstack/maia/values.yaml
@@ -26,6 +26,15 @@ maia:
     user_domain_name:    Default
     project_name:        service
     project_domain_name: Default
+  resources:
+    # reasonable defaults, should be reduced for small regions
+    memory:
+      expected: 100Mi
+      tolerated: 400Mi
+    cpu:
+      # currently maia is used by very few concurrent users
+      expected: "5m"
+      tolerated: "10m"
 
 prometheus:
   enabled: True


### PR DESCRIPTION
for the maia app

lessons learned
- memory spikes can be shorter than the sampling interval not just in theory
- once throttling kicks in, the _throttled_ cpu seconds metrics is orders of magnitude higher than the cpu seconds metric (is this a problem with the measurement?)