### PR TITLE
Two new roles for security group administration:

### DIFF
--- a/openstack/neutron/templates/etc/_neutron-policy.json.tpl
+++ b/openstack/neutron/templates/etc/_neutron-policy.json.tpl
@@ -21,6 +21,8 @@
 
     "compute_admin": "role:compute_admin and rule:owner",
     "context_is_compute_admin": "role:cloud_compute_admin or rule:compute_admin",
+    "context_is_securitygroup_admin": "role:securitygroup_admin or rule:context_is_compute_admin or rule:context_is_network_admin",
+    "context_is_securitygroup_viewer": "role:securitygroup_viewer or rule:context_is_viewer or rule:context_is_securitygroup_admin or rule:context_is_network_viewer",
 
     "shared": "field:networks:shared=True",
     "shared_firewalls": "field:firewalls:shared=True",
@@ -139,17 +141,17 @@
     "create_router:external_gateway_info:external_fixed_ips": "rule:context_is_network_admin",
     "update_router:external_gateway_info:external_fixed_ips": "rule:context_is_network_admin",
 
-    "create_security_group": "rule:context_is_compute_admin or rule:context_is_network_admin",
-    "get_security_group": "rule:context_is_viewer",
-    "get_security_groups": "rule:context_is_viewer",
-    "update_security_group": "rule:context_is_compute_admin or rule:context_is_network_admin",
-    "delete_security_group": "rule:context_is_compute_admin or rule:context_is_network_admin",
+    "create_security_group": "rule:context_is_securitygroup_admin",
+    "get_security_group": "rule:context_is_securitygroup_viewer",
+    "get_security_groups": "rule:context_is_securitygroup_viewer",
+    "update_security_group": "rule:context_is_securitygroup_admin",
+    "delete_security_group": "rule:context_is_securitygroup_admin",
 
-    "create_security_group_rule": "rule:context_is_compute_admin or rule:context_is_network_admin",
-    "get_security_group_rule": "rule:context_is_viewer",
-    "get_security_group_rules": "rule:context_is_viewer",
-    "update_security_group_rule": "rule:context_is_compute_admin or rule:context_is_network_admin",
-    "delete_security_group_rule": "rule:context_is_compute_admin or rule:context_is_network_admin",
+    "create_security_group_rule": "rule:context_is_securitygroup_admin",
+    "get_security_group_rule": "rule:context_is_securitygroup_viewer",
+    "get_security_group_rules": "rule:context_is_securitygroup_viewer",
+    "update_security_group_rule": "rule:context_is_securitygroup_admin",
+    "delete_security_group_rule": "rule:context_is_securitygroup_admin",
 
     "create_firewall": "rule:context_is_admin",
     "get_firewall": "rule:context_is_admin",

--- a/openstack/neutron/templates/etc/_neutron-policy.json.tpl
+++ b/openstack/neutron/templates/etc/_neutron-policy.json.tpl
@@ -21,8 +21,8 @@
 
     "compute_admin": "role:compute_admin and rule:owner",
     "context_is_compute_admin": "role:cloud_compute_admin or rule:compute_admin",
-    "context_is_securitygroup_admin": "role:securitygroup_admin or rule:context_is_compute_admin or rule:context_is_network_admin",
-    "context_is_securitygroup_viewer": "role:securitygroup_viewer or rule:context_is_viewer or rule:context_is_securitygroup_admin or rule:context_is_network_viewer",
+    "context_is_securitygroup_admin": "(role:securitygroup_admin and rule:owner) or rule:context_is_compute_admin or rule:context_is_network_admin",
+    "context_is_securitygroup_viewer": "(role:securitygroup_viewer and rule:owner) or rule:context_is_viewer or rule:context_is_securitygroup_admin",
 
     "shared": "field:networks:shared=True",
     "shared_firewalls": "field:firewalls:shared=True",

--- a/openstack/neutron/templates/seed.yaml
+++ b/openstack/neutron/templates/seed.yaml
@@ -28,6 +28,8 @@ spec:
   - network_viewer
   - cloud_network_admin
   - cloud_compute_admin
+  - securitygroup_viewer
+  - securitygroup_admin
 
   services:
   - name: neutron


### PR DESCRIPTION
securitygroup_viewer -> can show / list security groups and their rules
securitygroup_admin -> can create / update / delete security groups and security group rules


I have modified our initial config. 