### PR TITLE
[kube-monitoring] updates ironic hw alerts

### DIFF
--- a/system/kube-monitoring/charts/prometheus-frontend/metal-ironic.alerts
+++ b/system/kube-monitoring/charts/prometheus-frontend/metal-ironic.alerts
@@ -30,7 +30,7 @@ groups:
       summary: "Hardware error for instance: {{ $labels.instance }}"
       
   - alert: MetalIronicSensorInfo
-    expr: count(ipmi_sensor_state{type=~"(Memory|Drive Slot|Processor|Power Supply|Critical Interrupt|Version Change|Cable/Interconnect)", maintenance="true", job="baremetal/ironic"} == 2) by (instance, type, name, manufacturer, model, provision_state, server_id, project_id)
+    expr: count(ipmi_sensor_state{type=~"(Memory|Processor|Critical Interrupt|Version Change|Drive Slot|Power Supply|Cable/Interconnect)", job="baremetal/ironic"} == 2) by (instance, type, name, manufacturer, model, provision_state, server_id, project_id)
     for: 10m
     labels:
       severity: info


### PR DESCRIPTION
info alerts now catch all the error types independent from maintenance state