### PR TITLE
elektra shall use kube-system/ingress-cacrt like other services

### DIFF
--- a/openstack/elektra/templates/ingress.yaml
+++ b/openstack/elektra/templates/ingress.yaml
@@ -16,7 +16,7 @@ metadata:
   annotations:
     {{- if .Values.ingress.ca }}
     ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: {{ default true .Values.ingress.pass_certificate_to_upstream | quote }}
-    ingress.kubernetes.io/auth-tls-secret: {{ .Release.Namespace }}/elektra-x509-ca
+    ingress.kubernetes.io/auth-tls-secret: kube-system/ingress-cacrt
     ingress.kubernetes.io/auth-tls-verify-client: "optional"
     ingress.kubernetes.io/auth-tls-verify-depth: "3"
     {{- end }}


### PR DESCRIPTION
This is a left-over from the stoneage. Other services use the SSO CA(s) found in secret `kube-system/ingress-cacrt`, so should elektra. 
Are you okay with this @edda, @andypf?