### PR TITLE
Infra prometheus alignment

### DIFF
--- a/system/infra-monitoring/requirements.yaml
+++ b/system/infra-monitoring/requirements.yaml
@@ -1,21 +1,25 @@
 dependencies:
   - name: prometheus-server
     alias: prometheus_server
-    repository: file://../../system/prometheus-server
-    version: 1.0.10
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 1.0.12
     condition: prometheus_server.enabled
+
   - name: cloudprober-exporter
     repository: file://vendor/cloudprober-exporter
     version: 1.0.0
     condition: cloudprober-exporter.enabled
+
   - name: netapp-exporter
     repository: file://vendor/netapp-exporter
     version: 0.0.1
     condition: netapp-exporter.enabled
+
   - name: apic_exporters
     repository: file://vendor/apic_exporters
     version: 1.0.0
     condition: apic_exporters.enabled
+
   - name: snmp-exporter
     alias: snmp_exporter
     repository: file://vendor/snmp-exporter

--- a/system/infra-monitoring/templates/_prometheus.yaml.tpl
+++ b/system/infra-monitoring/templates/_prometheus.yaml.tpl
@@ -17,6 +17,9 @@
     source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
     regex: true
   - action: keep
+    source_labels: [__meta_kubernetes_service_annotation_prometheus_io_targets]
+    regex: infra-prometheus
+  - action: keep
     source_labels: [__meta_kubernetes_pod_container_port_number, __meta_kubernetes_pod_container_port_name, __meta_kubernetes_service_annotation_prometheus_io_port]
     regex: (9102;.*;.*)|(.*;metrics;.*)|(.*;.*;\d+)
   - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
@@ -74,6 +77,9 @@
     source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
     regex: true
   - action: keep
+    source_labels: [__meta_kubernetes_service_annotation_prometheus_io_targets]
+    regex: infra-prometheus
+  - action: keep
     source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port_1]
     regex: \d+
   - action: keep
@@ -112,6 +118,9 @@
     source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
     regex: true
   - action: keep
+    source_labels: [__meta_kubernetes_service_annotation_prometheus_io_targets]
+    regex: infra-prometheus
+  - action: keep
     source_labels: [__meta_kubernetes_pod_container_port_number, __meta_kubernetes_pod_container_port_name, __meta_kubernetes_pod_annotation_prometheus_io_port]
     regex: (9102;.*;.*)|(.*;metrics;.*)|(.*;.*;\d+)
   - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
@@ -140,6 +149,9 @@
   - action: keep
     source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
     regex: true
+  - action: keep
+    source_labels: [__meta_kubernetes_service_annotation_prometheus_io_targets]
+    regex: infra-prometheus
   - action: keep
     source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port_1]
     regex: \d+

--- a/system/infra-monitoring/values.yaml
+++ b/system/infra-monitoring/values.yaml
@@ -1,10 +1,6 @@
 prometheus_server:
   enabled: false
 
-  image:
-    repository: prom/prometheus
-    tag: v2.8.0
-
   name: infra-prometheus
 
   retentionTime: 7d


### PR DESCRIPTION
- The file repository doesn't support versioning. Switch to charts.eu-de-2.cloud.sap for prometheus-server chart. 
**NOTE**: Pipelines need to do a `helm repo add sapcc https://charts.eu-de-2.cloud.sap` before updating dependencies.
- Prometheus server image is defined in base chart. Removed setting here to avoid fragmentation. Prometheus should be updated via the chart version.
- The annotation `__meta_kubernetes_service_annotation_prometheus_io_targets` shall be used to define a target prometheus for k8s resources discovered via service discovery. It's value is a comma-separated list of names of prometheus server instances. The idea to have a Prometheus server only scrape metrics that are deemed relevant for the intended use.
Example: `__meta_kubernetes_service_annotation_prometheus_io_targets="k8s-collector, infra-prometheus"`