### PR TITLE
use prometheus-server@charts.eu-de-2.cloud.sap

### DIFF
--- a/openstack/maia/requirements.lock
+++ b/openstack/maia/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: prometheus-server
+  repository: https://charts.eu-de-2.cloud.sap
+  version: 1.0.12
+digest: sha256:7af2346688ff120ab556d594a8ab97dfd3d85d0287b978c59b6abf7a992ef6ca
+generated: 2019-04-23T14:02:52.231210383+02:00

--- a/openstack/maia/requirements.yaml
+++ b/openstack/maia/requirements.yaml
@@ -2,6 +2,6 @@ dependencies:
   - name: prometheus-server
     alias: prometheus_server
     condition: prometheus_server.enabled
-    repository: file://../../system/prometheus-server
+    repository: https://charts.eu-de-2.cloud.sap
     version: 1.0.12
 


### PR DESCRIPTION
- The file repository doesn't support versioning. Switch to charts.eu-de-2.cloud.sap for prometheus-server chart. 
**NOTE**: Pipelines need to do a `helm repo add sapcc https://charts.eu-de-2.cloud.sap` before updating dependencies.