### PR TITLE
Concourse fixes

### DIFF
--- a/global/concourse/templates/cleanup-cronjob.yaml
+++ b/global/concourse/templates/cleanup-cronjob.yaml
@@ -5,7 +5,7 @@ metadata:
   name: concourse-ci-cleanup
   namespace: {{ .Release.Namespace }}
 spec:
-  schedule: "50 * * * *"
+  schedule: "*/10 * * * *"
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 1
   jobTemplate:

--- a/global/concourse/templates/daemonset.yaml
+++ b/global/concourse/templates/daemonset.yaml
@@ -105,10 +105,12 @@ spec:
           VOLUME_ID=`openstack volume show ${VOLUME_NAME} -f value -c id`
           VOLUME_PATH=/root/dev/disk/by-id/wwn-0x${VOLUME_ID//-/}
           MOUNT_PATH=/root{{ $.Values.concourse.concourse.worker.workDir }}
-          if [ ! $(df -h | grep ${MOUNT_PATH}) ]; then
-            mkfs.btrfs -f ${VOLUME_PATH} &&
-            mkdir -p /root{{ $.Values.concourse.concourse.worker.workDir }} &&
-            mount -t btrfs ${VOLUME_PATH} ${MOUNT_PATH}
+          if ! blkid $VOLUME_PATH | grep -q btrfs ; then
+            mkfs.btrfs -f $VOLUME_PATH
+          fi
+          if ! df -h | grep $MOUNT_PATH ; then
+            mkdir -p $MOUNT_PATH
+            mount -t btrfs $VOLUME_PATH $MOUNT_PATH
           fi
         env:
         - name: NODE_NAME

--- a/global/concourse/templates/daemonset.yaml
+++ b/global/concourse/templates/daemonset.yaml
@@ -136,10 +136,10 @@ spec:
         command:
         - /bin/sh
         args:
-        - -ce
+        - -ec
         - |-
-          update-ca-certificates &&
-          /usr/local/concourse/bin/concourse worker --name=${NODE_NAME}
+          update-ca-certificates
+          exec /usr/local/concourse/bin/concourse worker --name=${NODE_NAME}
         livenessProbe:
           failureThreshold: 5
           initialDelaySeconds: 10


### PR DESCRIPTION
Currently when a worker node is rebootet the init containers reformat the disk (because it is not mounted anymore) which causes inconsistencies when the worker comes back with the same name and no volumes.