### PR TITLE
independent limes alerts

### DIFF
--- a/openstack/limes/aggregations/consolidation.rules
+++ b/openstack/limes/aggregations/consolidation.rules
@@ -1,0 +1,22 @@
+groups:
+- name: limes
+  rules:
+    - record: limes_consolidated_cluster_capacity
+      expr: max(label_join(limes_cluster_capacity, "full_resource", "/", "service", "resource"))
+          by (full_resource,os_cluster)
+
+    - record: limes_consolidated_domain_quota
+      expr: max(label_join(limes_domain_quota, "full_resource", "/", "service", "resource"))
+          by (full_resource,os_cluster,domain)
+
+    - record: limes_consolidated_domain_usage
+      expr: sum(max(label_join(limes_project_usage, "full_resource", "/", "service", "resource"))
+          by (full_resource,os_cluster,domain,project)) by (full_resource,os_cluster,domain)
+
+    - record: limes_consolidated_domain_physical_usage
+      expr: sum(max(label_join(limes_project_physical_usage, "full_resource", "/", "service", "resource"))
+          by (full_resource,os_cluster,domain,project)) by (full_resource,os_cluster,domain)
+
+    - record: limes_consolidated_unit_multiplier
+      expr: max(label_join(limes_unit_multiplier, "full_resource", "/", "service", "resource"))
+          by (full_resource)

--- a/openstack/limes/alerts/api.alerts
+++ b/openstack/limes/alerts/api.alerts
@@ -1,0 +1,167 @@
+groups:
+- name: openstack-limes.alerts
+  rules:
+
+  - alert: OpenstackLimesHttpErrors
+    expr: sum(increase(http_requests_total{kubernetes_namespace="limes",code=~"5.*"}[1h])) by (kubernetes_name) > 0
+    for: 5m
+    labels:
+      context: api
+      dashboard: limes-overview
+      service: limes
+      severity: info
+      tier: os
+    annotations:
+      description: "{{ $labels.kubernetes_name }} is producing HTTP responses with 5xx status codes."
+      summary: Server errors on {{ $labels.kubernetes_name }}
+
+  - alert: OpenstackLimesNotScraping
+    expr: absent(rate(limes_successful_scrapes{os_cluster="ccloud"}[30m]) > 0)
+    for: 5m
+    labels:
+      context: failedscrapes
+      dashboard: limes-overview
+      service: limes
+      severity: warning
+      tier: os
+    annotations:
+      description: There have been no successful scrapes in the last hour in
+        the ccloud cluster, so limes-collect-ccloud is probably dead.
+      summary: Limes is not scraping
+
+  - alert: OpenstackLimesFailedCapacityScrapes
+    expr: sum(increase(limes_failed_capacity_scrapes[5m])) BY (os_cluster, capacitor) > 0
+    for: 1h
+    labels:
+      context: failedcapacityscrapes
+      dashboard: limes-overview
+      service: limes
+      severity: warning
+      tier: os
+    annotations:
+      description: Limes cannot scrape capapcity from {{ title $labels.capacitor }}
+        for more than an hour.
+        The `kubectl logs` for limes-collect-{{ $labels.os_cluster }} contain additional info.
+      summary: Limes cannot scrape capacity {{ title $labels.capacitor }}
+
+  - alert: OpenstackLimesMissingCapacity
+    # note: this ignores baremetal capacity ("compute/instances_<flavorname>")
+    # since many of these are zero legitimately (we do not have all BM server
+    # types in all regions)
+    expr: limes_consolidated_cluster_capacity{full_resource!~"compute/instances_.*"} == 0
+    for: 1h
+    labels:
+      context: failedcapacityscrapes
+      dashboard: limes-overview
+      service: limes
+      severity: info
+      meta: 'no capacity for {{ $labels.full_resource }}'
+      tier: os
+    annotations:
+      description: Limes reports no capacity for {{ $labels.full_resource }}.
+        This usually means that the backend service reported weirdly-shaped data
+        to Limes' capacity scanner.
+        The `kubectl logs` for limes-collect-{{ $labels.os_cluster }} may contain additional info.
+      summary: Limes reports zero capacity for {{ $labels.full_resource }}
+
+  - alert: OpenstackLimesFailedScrapes
+    expr: sum(increase(limes_failed_scrapes[5m])) BY (os_cluster, service, service_name) > 0
+    for: 1h
+    labels:
+      context: failedscrapes
+      dashboard: limes-overview
+      service: '{{ $labels.service_name }}'
+      severity: warning
+      tier: os
+    annotations:
+      description: Limes cannot scrape data from {{ title $labels.service_name }}
+        for more than an hour. Please check if {{ title $labels.service_name }} is working.
+        The `kubectl logs` for limes-collect-{{ $labels.os_cluster }} contain additional info.
+      summary: Limes cannot scrape {{ title $labels.service_name }}
+
+  - alert: OpenstackLimesFailedDomainDiscoveries
+    expr: sum(increase(limes_failed_domain_discoveries[5m])) BY (os_cluster) > 0
+    for: 30m
+    labels:
+      context: faileddiscoveries
+      dashboard: limes-overview
+      service: limes
+      severity: warning
+      tier: os
+    annotations:
+      description: Limes cannot discover domains for cluster {{ $labels.os_cluster }}.
+        Please check if "openstack domain list" is working.
+      summary: Limes cannot discover domains.
+
+  - alert: OpenstackLimesFailedProjectDiscoveries
+    expr: sum(increase(limes_failed_project_discoveries[5m])) BY (os_cluster, domain) > 0
+    for: 30m
+    labels:
+      context: faileddiscoveries
+      dashboard: limes-overview
+      service: limes
+      severity: warning
+      tier: os
+    annotations:
+      description: Limes cannot discover project in domain {{ $labels.domain }}
+        of cluster {{ $labels.os_cluster }}. Please check if "openstack project
+        list --domain {{ $labels.domain }}" is working.
+      summary: Limes cannot discover projects.
+
+  - alert: OpenstackLimesApiDown
+    expr: blackbox_api_status_gauge{check=~"limes"} == 1
+    for: 20m
+    labels:
+      severity: critical
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-blackbox-details
+      meta: '{{ $labels.check }} API is down. See Sentry for details.'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}/#{{ $labels.check }}'
+    annotations:
+      description: '{{ $labels.check }} API is down for 20 min. See Sentry for details.'
+      summary: '{{ $labels.check }} API down'
+
+  - alert: OpenstackLimesApiFlapping
+    expr: changes(blackbox_api_status_gauge{check=~"limes"}[30m]) > 8
+    labels:
+      severity: warning
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-blackbox-details
+      meta: '{{ $labels.check }} API is flapping'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}/#{{ $labels.check }}'
+    annotations:
+      description: '{{ $labels.check }} API is flapping for 30 minutes.'
+      summary: '{{ $labels.check }} API flapping'
+
+  - alert: OpenstackLimesAuditEventPublishFailing
+    expr: sum(increase(limes_failed_auditevent_publish[10m])) > 0
+    for: 1h
+    labels:
+      context: auditeventpublish
+      dashboard: limes-overview
+      service: limes
+      severity: info
+      tier: os
+    annotations:
+      description: "Audit events could not be published to the RabbitMQ server."
+      summary: "Audit events publish failing"
+
+  - alert: OpenstackLimesPodSchedulingFailedInsufficientCPU
+    expr: sum(rate(kube_pod_failed_scheduling_cpu_total{pod_name=~"limes-.+"}[30m])) by (pod_name) > 0
+    for: 15m
+    labels:
+      severity: warning
+      tier: os
+      service: limes
+      context: cpu
+      dashboard: limes-overview
+      meta: "{{ $labels.pod_name }}"
+    annotations:
+      summary: Scheduling failed due to insufficient cpu
+      description: The pod {{ $labels.pod_name }} failed to be scheduled. Insuffient CPU!

--- a/openstack/limes/alerts/pod.alerts
+++ b/openstack/limes/alerts/pod.alerts
@@ -1,0 +1,44 @@
+groups:
+- name: openstack-limes-pod.alerts
+  rules:
+      - alert: OpenstackLimesPodSchedulingInsufficientMemory
+        expr: sum(rate(kube_pod_failed_scheduling_memory_total{pod_name=~"limes-.+"}[30m])) by (pod_name) > 0
+        for: 15m
+        labels:
+          severity: warning
+          tier: os
+          service: limes
+          context: memory
+          dashboard: limes-overview
+          meta: "{{ $labels.pod_name }}"
+        annotations:
+          summary: Scheduling failed due to insufficient memory
+          description: The pod {{ $labels.pod_name }} failed to be scheduled. Insuffient memory!
+
+      - alert: OpenstackLimesPodOOMKilled
+        expr: sum(rate(klog_pod_oomkill{pod_name=~"limes-.+"}[30m])) by (pod_name) > 0
+        for: 5m
+        labels:
+          tier: os
+          service: limes
+          severity: info
+          context: memory
+          dashboard: limes-overview
+          meta: "{{ $labels.pod_name }}"
+        annotations:
+          summary: Pod was oomkilled
+          description: The pod {{ $labels.pod_name }} was oomkilled recently
+
+      - alert: OpenstackLimesPodOOMExceedingLimits
+        expr: predict_linear(container_memory_usage_bytes{pod_name=~"limes-.+"}[1h], 8* 3600) > ON (pod_name, namespace) label_replace(kube_pod_container_resource_limits_memory_bytes{pod=~"limes-.+"}, "pod_name", "$1", "pod", "(.*)")
+        for: 30m
+        labels:
+          tier: os
+          service: limes
+          severity: info
+          context: memory
+          dashboard: limes-overview
+          meta: "{{ $labels.pod_name }}"
+        annotations:
+          summary: Exceeding memory limits in 8h
+          description: The pod {{ $labels.pod_name }} will exceed its memory limit in 8h.

--- a/openstack/limes/alerts/roleassignment.alerts
+++ b/openstack/limes/alerts/roleassignment.alerts
@@ -1,0 +1,65 @@
+groups:
+- name: openstack-limes-roleassignment.alerts
+  rules:
+      # allowed role assignments for the `resource_service` role:
+      # - user limes@Default in project cloud_admin@ccadmin
+      - alert: OpenstackLimesUnexpectedServiceRoleAssignments
+        expr: max(openstack_assignments_per_role_gauge{name="resource_service"}) > 1
+        for: 10m
+        labels:
+          tier: os
+          service: limes
+          severity: info
+          playbook: 'docs/support/playbook/unexpected-role-assignments'
+          meta: 'Unexpected role assignments found for Keystone role "resource_service"'
+        annotations:
+          summary: 'Unexpected role assignments'
+          description: 'The Keystone role "resource_service" is assigned to more users/groups than expected.'
+
+      # allowed role assignments for the `cloud_resource_admin` role:
+      # - group CCADMIN_CLOUD_ADMINS@ccadmin in project cloud_admin@ccadmin
+      # - user dashboard@Default             in project cloud_admin@ccadmin (for request workflows in Elektra)
+      # - user limes@Default                 in project cloud_admin@ccadmin (TODO: looks unnecessary, remove?)
+      # - user kubernikus@Default            in project cloud_admin@ccadmin
+      # - user kubernikus-terraform@Default  in project cloud_admin@ccadmin
+      # ONLY EU-DE-1 AND EU-NL-1:
+      # - user kubernikus-staging@Default    in project cloud_admin@ccadmin
+      # ONLY EU-NL-1:
+      # - user kubernikus-feature@Default    in project cloud_admin@ccadmin
+      # - user kubernikus-master@Default     in project cloud_admin@ccadmin
+      - alert: OpenstackLimesUnexpectedCloudAdminRoleAssignments1
+        expr: max(openstack_assignments_per_role_gauge{name="cloud_resource_admin",region!="eu-de-1",region!="eu-nl-1"}) > 5
+        for: 10m
+        labels:
+          tier: os
+          service: limes
+          severity: info
+          playbook: 'docs/support/playbook/unexpected-role-assignments'
+          meta: 'Unexpected role assignments found for Keystone role "cloud_resource_admin"'
+        annotations:
+          summary: 'Unexpected role assignments'
+          description: 'The Keystone role "cloud_resource_admin" is assigned to more users/groups than expected.'
+      - alert: OpenstackLimesUnexpectedCloudAdminRoleAssignments2
+        expr: max(openstack_assignments_per_role_gauge{name="cloud_resource_admin",region="eu-de-1"}) > 6
+        for: 10m
+        labels:
+          tier: os
+          service: limes
+          severity: info
+          playbook: 'docs/support/playbook/unexpected-role-assignments'
+          meta: 'Unexpected role assignments found for Keystone role "cloud_resource_admin"'
+        annotations:
+          summary: 'Unexpected role assignments'
+          description: 'The Keystone role "cloud_resource_admin" is assigned to more users/groups than expected.'
+      - alert: OpenstackLimesUnexpectedCloudAdminRoleAssignments3
+        expr: max(openstack_assignments_per_role_gauge{name="cloud_resource_admin",region="eu-nl-1"}) > 8
+        for: 10m
+        labels:
+          tier: os
+          service: limes
+          severity: info
+          playbook: 'docs/support/playbook/unexpected-role-assignments'
+          meta: 'Unexpected role assignments found for Keystone role "cloud_resource_admin"'
+        annotations:
+          summary: 'Unexpected role assignments'
+          description: 'The Keystone role "cloud_resource_admin" is assigned to more users/groups than expected.'

--- a/openstack/limes/templates/api-service.yaml
+++ b/openstack/limes/templates/api-service.yaml
@@ -10,6 +10,8 @@ metadata:
     # uncomment to have Maia scape as well: maia.io/scrape: "true"
     prometheus.io/scrape: "true"
     prometheus.io/port: "80"
+    # The `openstack` Prometheus shall scrape metrics of OpenStack services.
+    prometheus.io/targets: "openstack"
 
 spec:
   selector:

--- a/openstack/limes/templates/api-service.yaml
+++ b/openstack/limes/templates/api-service.yaml
@@ -11,7 +11,7 @@ metadata:
     prometheus.io/scrape: "true"
     prometheus.io/port: "80"
     # The `openstack` Prometheus shall scrape metrics of OpenStack services.
-    prometheus.io/targets: "openstack"
+    prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
 
 spec:
   selector:

--- a/openstack/limes/templates/prometheus-aggregations.yaml
+++ b/openstack/limes/templates/prometheus-aggregations.yaml
@@ -1,0 +1,20 @@
+{{- $values := .Values }}
+{{- if $values.alerts.enabled }}
+{{- range $path, $bytes := .Files.Glob "aggregations/*.rules" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: {{ printf "%s" $path | replace "/" "-" }}
+  labels:
+    app: limes-api
+    tier: os
+    type: aggregation-rules
+    prometheus: {{ required "$values.alerts.prometheus missing" $values.alerts.prometheus }}
+
+spec:
+{{ printf "%s" $bytes | indent 2 }}
+
+{{- end }}
+{{- end }}

--- a/openstack/limes/templates/prometheus-alerts.yaml
+++ b/openstack/limes/templates/prometheus-alerts.yaml
@@ -1,0 +1,20 @@
+{{- $values := .Values }}
+{{- if $values.alerts.enabled }}
+{{- range $path, $bytes := .Files.Glob "alerts/*.alerts" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: {{ printf "%s" $path | replace "/" "-" }}
+  labels:
+    app: limes-api
+    tier: os
+    type: alerting-rules
+    prometheus: {{ required ".Values.alerts.prometheus missing" $values.alerts.prometheus }}
+
+spec:
+{{ printf "%s" $bytes | indent 2 }}
+
+{{- end }}
+{{- end }}

--- a/openstack/limes/values.yaml
+++ b/openstack/limes/values.yaml
@@ -39,3 +39,9 @@ limes:
   # Whether to apply resource requests/limits to containers.
   resources:
     enabled: false
+
+# Deploy limes Prometheus alerts.
+alerts:
+  enabled: true
+  # Name of the Prometheus to which the alerts should be assigned to.
+  prometheus: openstack


### PR DESCRIPTION
Our new monitoring architecture allows independent deployment of Prometheus alerts and aggregation rules rather than having them in a crowded central pipeline.
This PR uses a `PrometheusRule` to deploy limes specific alerts and aggregations.
For now it will deploy the alerts, rules in addition to the existing ones (but without double alerting). 

Will contact you on thursday @majewsky 