### PR TITLE
independent swift alerts

### DIFF
--- a/global/prometheus-openstack/templates/_prometheus.yaml.tpl
+++ b/global/prometheus-openstack/templates/_prometheus.yaml.tpl
@@ -9,9 +9,9 @@
   params:
     'match[]':
       - '{__name__=~"^ALERTS$"}'
+      - '{__name__=~"^global:.+"}'
       - '{__name__=~"up"}'
       - '{__name__=~"^openstack_.+"}'
-      - '{__name__=~"^swift_cluster_storage_used_percent_.+"}'
 
   relabel_configs:
     - action: replace

--- a/global/prometheus-openstack/templates/_prometheus.yaml.tpl
+++ b/global/prometheus-openstack/templates/_prometheus.yaml.tpl
@@ -11,6 +11,15 @@
       - '{__name__=~"^ALERTS$"}'
       - '{__name__=~"up"}'
       - '{__name__=~"^openstack_.+"}'
+      - '{__name__=~"^limes_consolidated_.+"}'
+      - '{__name__=~"^limes_domain_quota$", resource=~"instances_z.*"}'
+      - '{__name__=~"^limes_project_.+$", resource=~"instances_z.*"}'
+      - '{__name__=~"^swift_cluster_storage_used_percent_.+"}'
+      - '{__name__=~"^openstack_compute_instances_total$"}'
+      - '{__name__=~"^blackbox_.+"}'
+      - '{__name__=~"^canary_.+"}'
+      - '{__name__=~"^datapath_.+"}'
+      - '{__name__=~"^elektra_open_inquiry_metrics$"}'
 
   relabel_configs:
     - action: replace

--- a/global/prometheus-openstack/templates/_prometheus.yaml.tpl
+++ b/global/prometheus-openstack/templates/_prometheus.yaml.tpl
@@ -11,15 +11,7 @@
       - '{__name__=~"^ALERTS$"}'
       - '{__name__=~"up"}'
       - '{__name__=~"^openstack_.+"}'
-      - '{__name__=~"^limes_consolidated_.+"}'
-      - '{__name__=~"^limes_domain_quota$", resource=~"instances_z.*"}'
-      - '{__name__=~"^limes_project_.+$", resource=~"instances_z.*"}'
       - '{__name__=~"^swift_cluster_storage_used_percent_.+"}'
-      - '{__name__=~"^openstack_compute_instances_total$"}'
-      - '{__name__=~"^blackbox_.+"}'
-      - '{__name__=~"^canary_.+"}'
-      - '{__name__=~"^datapath_.+"}'
-      - '{__name__=~"^elektra_open_inquiry_metrics$"}'
 
   relabel_configs:
     - action: replace

--- a/openstack/swift/aggregations/swift-usage.rules
+++ b/openstack/swift/aggregations/swift-usage.rules
@@ -3,3 +3,9 @@ groups:
   rules:
   - record: swift_cluster_storage_used_percent_average
     expr: avg(swift_cluster_prostorage_used_percent_gauge_average < inf)
+
+  - record: swift_cluster_storage_used_percent_gauge_average
+    expr: (avg(swift_cluster_storage_used_percent_gauge) by (kubernetes_namespace, system, component) OR avg(swift_cluster_storage_used_percent) by (kubernetes_namespace, system, component))
+
+  - record: swift_async_pendings_rate
+    expr: (sum(increase(swift_object_server_async_pendings_counter[5m])) by (kubernetes_namespace) OR sum(increase(swift_object_server_async_pendings[5m])) by (kubernetes_namespace))

--- a/openstack/swift/aggregations/swift-usage.rules
+++ b/openstack/swift/aggregations/swift-usage.rules
@@ -1,10 +1,10 @@
 groups:
 - name: swift-usage
   rules:
-  - record: swift_cluster_storage_used_percent_average
+  - record: global:swift_cluster_storage_used_percent_average
     expr: avg(swift_cluster_prostorage_used_percent_gauge_average < inf)
 
-  - record: swift_cluster_storage_used_percent_gauge_average
+  - record: global:swift_cluster_storage_used_percent_gauge_average
     expr: (avg(swift_cluster_storage_used_percent_gauge) by (kubernetes_namespace, system, component) OR avg(swift_cluster_storage_used_percent) by (kubernetes_namespace, system, component))
 
   - record: swift_async_pendings_rate

--- a/openstack/swift/aggregations/swift-usage.rules
+++ b/openstack/swift/aggregations/swift-usage.rules
@@ -1,0 +1,5 @@
+groups:
+- name: swift-usage
+  rules:
+  - record: swift_cluster_storage_used_percent_average
+    expr: avg(swift_cluster_prostorage_used_percent_gauge_average < inf)

--- a/openstack/swift/alerts/swift-api.alerts
+++ b/openstack/swift/alerts/swift-api.alerts
@@ -1,0 +1,299 @@
+groups:
+- name: openstack-swift-api.alerts
+  rules:
+  - alert: OpenstackSwiftFirstByteTiming
+    expr: max(swift_proxy_firstbyte{type!="container",quantile="0.5",status="200"}) BY (os_cluster, type, instance) > 1000
+    for: 15m
+    labels:
+      context: firtsbytetiming
+      dashboard: swift-proxy?var-cluster={{ $labels.os_cluster }}&var-proxy={{ $labels.instance }}
+      service: swift
+      severity: info
+      tier: os
+      meta: first byte timing for {{ $labels.type }} in {{ $labels.os_cluster }} increased
+    annotations:
+      description: This alert indicates the latency in token validation.
+      summary: first byte timing for {{ $labels.type }} in {{ $labels.os_cluster }}
+        increased
+
+  - alert: OpenstackSwiftServiceUnavailable
+    expr: sum(irate(swift_proxy_sum{policy="all",status="503"}[5m])) BY (os_cluster) > 100
+    for: 5m
+    labels:
+      context: serviceunavailable
+      dashboard: swift-proxy?var-cluster={{ $labels.os_cluster }}
+      service: swift
+      severity: warning
+      tier: os
+      meta: 503 responses from Swift in {{ $labels.os_cluster }} (check Keystone availability)
+    annotations:
+      description: Swift is responding with 503 in {{ $labels.os_cluster }}. Usually the root cause is a broken
+        token validation
+      summary: swift-service-unavailable
+
+  - alert: OpenstackSwiftHealthCheck
+    expr: avg(swift_health_statsd_exit_code) BY (region) > 0.2
+    for: 5m
+    labels:
+      context: health
+      dashboard: swift-overview
+      service: swift
+      severity: warning
+      tier: os
+      meta: some health checks for Swift are failing
+    annotations:
+      description: Swift health check failures. Run kubectl log swift-proxy-... collector to get details
+      summary: swift-health-check
+
+  - alert: OpenstackSwiftMismatchedRings
+    expr: (swift_cluster_md5_ring_not_matched - swift_cluster_md5_ring_errors) > 0
+    for: 15m
+    labels:
+      context: mismatchedrings
+      dashboard: swift-overview
+      service: swift
+      severity: warning
+      tier: os
+      meta: Rings are not equal on all Swift nodes
+    annotations:
+      description: Rings are not equal on all nodes
+      summary: swift-mismatched-rings
+
+  - alert: OpenstackSwiftMismatchedConfig
+    expr: (swift_cluster_md5_swiftconf_not_matched - swift_cluster_md5_swiftconf_errors) > 0
+    for: 15m
+    labels:
+      context: mismatchedconf
+      dashboard: swift-overview
+      service: swift
+      severity: warning
+      tier: os
+      meta: Configuration is not equal on all Swift nodes
+    annotations:
+      description: Configuration is not equal on all nodes
+      summary: swift-mismatched-config
+
+  - alert: OpenstackSwiftNodeError
+    expr: max(swift_cluster_md5_ring_errors) by (region) > 0
+    for: 15m
+    labels:
+      context: nodeerror
+      dashboard: swift-overview
+      service: swift
+      severity: warning
+      tier: os
+      meta: '{{ $value }} Swift nodes not reachable'
+    annotations:
+      description: Swift node error. {{ $value }} Node(s) not reachable.
+      summary: swift-node-error
+
+  - alert: OpenstackSwiftDisksUnmounted
+    expr: max(swift_cluster_drives_unmounted) BY (storage_ip) > 0
+    for: 3m
+    labels:
+      context: drivesunmounted
+      dashboard: swift-overview
+      service: swift
+      severity: warning
+      tier: os
+      meta: '{{ $value }} Swift drives not mounted'
+    annotations:
+      description: Swift drives not mounted. Run swift-recon --unmounted to get details
+      summary: swift disks unmounted on the server IP {{ $labels.storage_ip }}
+
+  - alert: OpenstackSwiftDiskFailures
+    expr: max(swift_cluster_drives_audit_errors) BY (storage_ip) > 0
+    for: 3m
+    labels:
+      context: drivefailures
+      dashboard: swift-overview
+      service: swift
+      severity: warning
+      tier: os
+      meta: '{{ $value }} Swift drive failures'
+    annotations:
+      description: Swift drive failures. Run swift-recon --driveaudit to get details
+      summary: swift disk failures on the server IP {{ $labels.storage_ip }}
+
+  - alert: OpenstackSwiftAsyncPendings
+    expr: sum(increase(swift_object_server_async_pendings[5m])) > 5000
+    for: 15m
+    labels:
+      context: asyncpendings
+      dashboard: swift-overview
+      service: swift
+      severity: info
+      tier: os
+      meta: Async Pendings indicate an overload scenario or faulty device(s)
+    annotations:
+      description: Async Pendings indicate an overload scenario or faulty device(s)
+      summary: swift object server async pendings reached 5000
+
+  - alert: OpenstackSwiftRateLimit1000
+    expr: sum(increase(swift_proxy_count{status="498"}[5m])) BY (os_cluster) > 1000
+    for: 3m
+    labels:
+      context: ratelimit
+      dashboard: swift-overview
+      service: swift
+      severity: info
+      tier: os
+      meta: Some accounts/containers are being rate-limited in {{ $labels.os_cluster }}
+    annotations:
+      description: Check kibana for the causing account and container
+      summary: swift rate limit hit in {{ $labels.os_cluster }}
+
+  - alert: OpenstackSwiftRateLimit5000
+    expr: sum(increase(swift_proxy_count{status="498"}[5m])) BY (os_cluster) > 5000
+    for: 3m
+    labels:
+      context: ratelimit
+      dashboard: swift-overview
+      service: swift
+      severity: warning
+      tier: os
+      meta: Some accounts/containers are being rate-limited in {{ $labels.os_cluster }}
+    annotations:
+      description: Check kibana for the causing account and container
+      summary: swift rate limit hit in {{ $labels.os_cluster }}
+
+  - alert: OpenstackSwiftUsedSpace
+    expr: max(predict_linear(swift_cluster_storage_used_percent_gauge_average[1w], 60 * 60 * 24 * 30)) > 0.8
+    for: 1d
+    labels:
+      context: usedcapacity
+      dashboard: swift-capacity-global?var-region={{ $labels.region }}
+      service: swift
+      severity: info
+      tier: os
+      meta: Swift storage usage will reach 80% in 30 days. Order hardware now!
+    annotations:
+      description: Swift storage usage will reach 80% in 30 days. Order hardware now!
+      summary: Swift storage expected to be full soon
+
+  - alert: OpenstackSwiftDriveAutopilotConsistencyCheck
+    expr: irate(swift_drive_autopilot_events{type="consistency-check"}[5m]) < 0.02
+    for: 10m
+    labels:
+      context: autopilot
+      dashboard: swift-overview
+      service: swift
+      severity: warning
+      tier: os
+      meta: '{{ $labels.kubernetes_pod_name }} not performing consistency checks on schedule'
+    annotations:
+      description: Autopilot {{ $labels.kubernetes_pod_name }} does not perform its
+        consistency checks on schedule. Please check if it's having a bad time.
+      summary: No consistency checks performed
+
+  - alert: OpenstackSwiftAccountReplicationCheck
+    expr: max(swift_cluster_accounts_replication_age) by (storage_ip) > 3*3600
+    labels:
+      context: accountrepl
+      dashboard: swift-overview
+      service: swift
+      severity: warning
+      tier: os
+      meta: Account replication getting stuck on {{ $labels.storage_ip }}
+    annotations:
+      description: "The last successful account replication age on {{ $labels.storage_ip }}
+        is older than 3 hours. Check the affected node. A restart of the replicator pod
+        might be necessary."
+      summary: Account replication on {{ $labels.storage_ip }} older than 3 hours
+
+  - alert: OpenstackSwiftContainerReplicationCheck
+    expr: max(swift_cluster_containers_replication_age) by (storage_ip) > 3*3600
+    labels:
+      context: containerrepl
+      dashboard: swift-overview
+      service: swift
+      severity: warning
+      tier: os
+      meta: Container replication getting stuck on {{ $labels.storage_ip }}
+    annotations:
+      description: "The last successful container replication age on {{ $labels.storage_ip }}
+        is older than 3 hours. Check the affected node. A restart of the replicator pod might
+        be necessary."
+      summary: Container replication on {{ $labels.storage_ip }} older than 3 hours
+
+  - alert: OpenstackSwiftApiDown
+    expr: blackbox_api_status_gauge{check=~"swift"} == 1
+    for: 20m
+    labels:
+      severity: critical
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-blackbox-details
+      meta: '{{ $labels.check }} API is down. See Sentry for details.'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}/#{{ $labels.check }}'
+    annotations:
+      description: '{{ $labels.check }} API is down for 20 min. See Sentry for details.'
+      summary: '{{ $labels.check }} API down'
+
+  - alert: OpenstackSwiftApiFlapping
+    expr: changes(blackbox_api_status_gauge{check=~"swift"}[30m]) > 8
+    labels:
+      severity: warning
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-blackbox-details
+      meta: '{{ $labels.check }} API is flapping'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}/#{{ $labels.check }}'
+    annotations:
+      description: '{{ $labels.check }} API is flapping for 30 minutes.'
+      summary: '{{ $labels.check }} API flapping'
+
+  - alert: OpenstackSwiftCanaryDown
+    expr: blackbox_canary_status_gauge{service=~"swift"} == 1
+    for: 1h
+    labels:
+      severity: warning
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-canary-details
+      meta: 'Canary {{ $labels.service }} {{ $labels.check }} is down for 1 hour. See Sentry for details'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}'
+    annotations:
+      description: 'Canary {{ $labels.service }} {{ $labels.check }} is down for 1 hour. See Sentry for details'
+      summary: 'Canary {{ $labels.service }} {{ $labels.check }} is down'
+
+  - alert: OpenstackSwiftCanaryTimeout
+    expr: blackbox_canary_status_gauge{service=~"swift"} == 0.5
+    for: 1h
+    labels:
+      severity: info
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-canary-details
+      meta: 'Canary {{ $labels.service }} {{ $labels.check }} is timing out for 1 hour. See Sentry for details'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}'
+    annotations:
+      description: 'Canary {{ $labels.service }} {{ $labels.check }} is timing out for 1 hour. See Sentry for details'
+      summary: 'Canary {{ $labels.service }} {{ $labels.check }} is timing out'
+
+  - alert: OpenstackSwiftCanaryFlapping
+    expr: changes(blackbox_canary_status_gauge{service=~"swift"}[2h]) > 8
+    labels:
+      severity: warning
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-canary-details
+      meta: 'Canary {{ $labels.service }} {{ $labels.check }} is flapping for 2 hours. See Sentry for details'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}'
+    annotations:
+      description: 'Canary {{ $labels.service }} {{ $labels.check }} is flapping for 2 hours. See Sentry for details'
+      summary: 'Canary {{ $labels.service }} {{ $labels.check }} is flapping'
+
+
+
+

--- a/openstack/swift/alerts/swift-pod.alerts
+++ b/openstack/swift/alerts/swift-pod.alerts
@@ -1,0 +1,54 @@
+groups:
+- name: openstack-swift-pod.alerts
+  rules:
+    - alert: OpenstackSwiftPodSchedulingFailedInsufficientCPU
+      expr: sum(rate(kube_pod_failed_scheduling_cpu_total{pod_name=~"swift-.+"}[30m])) by (pod_name) > 0
+      for: 15m
+      labels:
+        severity: warning
+        tier: os
+        service: swift
+        context: cpu
+        meta: "{{ $labels.pod_name }}"
+      annotations:
+        summary: Scheduling failed due to insufficient cpu
+        description: The pod {{ $labels.pod_name }} failed to be scheduled. Insuffient CPU!
+
+    - alert: OpenstackSwiftPodSchedulingInsufficientMemory
+      expr: sum(rate(kube_pod_failed_scheduling_memory_total{pod_name=~"swift-.+"}[30m])) by (pod_name) > 0
+      for: 15m
+      labels:
+        severity: warning
+        tier: os
+        service: swift
+        context: memory
+        meta: "{{ $labels.pod_name }}"
+      annotations:
+        summary: Scheduling failed due to insufficient memory
+        description: The pod {{ $labels.pod_name }} failed to be scheduled. Insuffient memory!
+
+    - alert: OpenstackSwiftPodOOMKilled
+      expr: sum(rate(klog_pod_oomkill{pod_name=~"swift-.+"}[30m])) by (pod_name) > 0
+      for: 5m
+      labels:
+        tier: os
+        service: swift
+        severity: info
+        context: memory
+        meta: "{{ $labels.pod_name }}"
+      annotations:
+        summary: Pod was oomkilled
+        description: The pod {{ $labels.pod_name }} was oomkilled recently
+
+    - alert: OpenstackSwiftPodOOMExceedingLimits
+      expr: predict_linear(container_memory_usage_bytes{pod_name=~"swift-.+"}[1h], 8* 3600) > ON (pod_name, namespace) label_replace(kube_pod_container_resource_limits_memory_bytes{pod=~"swift-.+"}, "pod_name", "$1", "pod", "(.*)")
+      for: 5m
+      labels:
+        tier: os
+        service: swift
+        severity: info
+        context: memory
+        meta: "{{ $labels.pod_name }}"
+      annotations:
+        summary: Exceeding memory limits in 8h
+        description: The pod {{ $labels.pod_name }} will exceed its memory limit in 8h.

--- a/openstack/swift/alerts/swift-roleassignments.alerts
+++ b/openstack/swift/alerts/swift-roleassignments.alerts
@@ -1,0 +1,36 @@
+groups:
+- name: openstack-swift-roleassignments.alerts
+  rules:
+    # allowed role assignments for the `swiftreseller` role:
+    # - group CCADMIN_CLOUD_ADMINS@ccadmin           in project cloud_admin@ccadmin
+    # - user admin@Default                           in project admin@Default (for openstackseeder to create Swift accounts)
+    # - user ironic@Default                          in project service@Default (to read private OS images)
+    # - user limes@Default                           in project cloud_admin@ccadmin (for Limes to get/set quotas)
+    # - user kubernikus@Default                      in project cloud_admin@ccadmin
+    # - ONLY EU-NL-1: user kubernikus-master@Default in project cloud_admin@ccadmin
+
+    - alert: OpenstackSwiftUnexpectedCloudAdminRoleAssignments1
+      expr: max(openstack_assignments_per_role_gauge{name="swiftreseller",region!="eu-nl-1"}) > 5
+      for: 10m
+      labels:
+        tier: os
+        service: swift
+        severity: info
+        playbook: 'docs/support/playbook/unexpected-role-assignments'
+        meta: 'Unexpected role assignments found for Keystone role "swiftreseller"'
+      annotations:
+        summary: 'Unexpected role assignments'
+        description: 'The Keystone role "swiftreseller" is assigned to more users/groups than expected.'
+
+    - alert: OpenstackSwiftUnexpectedCloudAdminRoleAssignments2
+      expr: max(openstack_assignments_per_role_gauge{name="swiftreseller",region="eu-nl-1"}) > 6
+      for: 10m
+      labels:
+        tier: os
+        service: swift
+        severity: info
+        playbook: 'docs/support/playbook/unexpected-role-assignments'
+        meta: 'Unexpected role assignments found for Keystone role "swiftreseller"'
+      annotations:
+        summary: 'Unexpected role assignments'
+        description: 'The Keystone role "swiftreseller" is assigned to more users/groups than expected.'

--- a/openstack/swift/templates/_utils.tpl
+++ b/openstack/swift/templates/_utils.tpl
@@ -36,7 +36,7 @@ tolerations:
 {{- define "swift_prometheus_annotations" }}
 prometheus.io/scrape: "true"
 prometheus.io/port: "9102"
-prometheus.io/targets: "openstack"
+prometheus.io/targets: {{ .Values.alerts.prometheus | quote }}
 {{- end -}}
 
 {{- /**********************************************************************************/ -}}

--- a/openstack/swift/templates/_utils.tpl
+++ b/openstack/swift/templates/_utils.tpl
@@ -36,6 +36,7 @@ tolerations:
 {{- define "swift_prometheus_annotations" }}
 prometheus.io/scrape: "true"
 prometheus.io/port: "9102"
+prometheus.io/targets: "openstack"
 {{- end -}}
 
 {{- /**********************************************************************************/ -}}

--- a/openstack/swift/templates/prometheus-aggregations.yaml
+++ b/openstack/swift/templates/prometheus-aggregations.yaml
@@ -1,0 +1,20 @@
+{{- $values := .Values }}
+{{- if $values.alerts.enabled }}
+{{- range $path, $bytes := .Files.Glob "aggregations/*.rules" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: {{ printf "%s" $path | replace "/" "-" }}
+  labels:
+    app: swift
+    tier: os
+    type: aggregation-rules
+    prometheus: {{ required "$values.alerts.prometheus missing" $values.alerts.prometheus }}
+
+spec:
+{{ printf "%s" $bytes | indent 2 }}
+
+{{- end }}
+{{- end }}

--- a/openstack/swift/templates/prometheus-alerts.yaml
+++ b/openstack/swift/templates/prometheus-alerts.yaml
@@ -1,0 +1,20 @@
+{{- $values := .Values }}
+{{- if $values.alerts.enabled }}
+{{- range $path, $bytes := .Files.Glob "alerts/*.alerts" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: {{ printf "%s" $path | replace "/" "-" }}
+  labels:
+    app: swift
+    tier: os
+    type: alerting-rules
+    prometheus: {{ required ".Values.alerts.prometheus missing" $values.alerts.prometheus }}
+
+spec:
+{{ printf "%s" $bytes | indent 2 }}
+
+{{- end }}
+{{- end }}

--- a/openstack/swift/values.yaml
+++ b/openstack/swift/values.yaml
@@ -116,3 +116,9 @@ clusters:
 account_ring_base64: DEFINED_IN_REGION_CHART
 container_ring_base64: DEFINED_IN_REGION_CHART
 object_ring_base64: DEFINED_IN_REGION_CHART
+
+# Deploy Swift Prometheus alerts.
+alerts:
+  enabled: true
+  # Name of the Prometheus to which the alerts should be assigned to.
+  prometheus: openstack


### PR DESCRIPTION
Our new monitoring architecture allows independent deployment of Prometheus alerts and aggregation rules rather than having them in a crowded central pipeline.
This PR uses a PrometheusRule to deploy swift specific alerts and aggregations.
For now it will deploy the alerts, rules in addition to the existing ones (but without double alerting).
Will contact you on thursday @reimannf.