### PR TITLE
Improve PGBouncer Alert

### DIFF
--- a/system/kube-monitoring/charts/prometheus-frontend/openstack-pgbouncer.alerts
+++ b/system/kube-monitoring/charts/prometheus-frontend/openstack-pgbouncer.alerts
@@ -16,15 +16,15 @@ groups:
       summary: Clients waiting connections > 100 since 5 minutes
   
   - alert: OpenstackPgBouncerNotReady
-    expr: count(kube_pod_container_status_ready{container="pgbouncer"} == 0) by (pod)
+    expr: sum(label_replace(kube_pod_container_status_ready{container="pgbouncer"}, "backend", "$1", "pod", "^(.*-pgbouncer)-.*")) by (backend,namespace) < 3
     for: 5m
     labels:
       dashboard: PgBouncer
       service: monsoon3
-      meta: "pgbouncer pod {{ $labels.pod }} failing readiness probe"
+      meta: "Less than 3 pgbouncer pods for {{ $labels.backend }} are ready"
       playbook: "docs/devops/alert/pgbouncer/#openstackpgbouncernotready"
       severity: warning
       tier: os
     annotations:
-      description: "pgbouncer pod {{ $labels.pod }} failing readiness probe"
-      summary: "pgbouncer pod {{ $labels.pod }} failing readiness probe"
+      description: "Less than 3 pgbouncer pods for {{ $labels.backend }} are ready. Investigate the missing replicas."
+      summary: "Less than 3 pgbouncer pods for {{ $labels.backend }} are ready"


### PR DESCRIPTION
This alert used to create an event for any pod with a container `pgbouncer` that is not `running`. This causes false alarms even when all required `pgbouncer` replicas are running. For example, when there are beign `unknown` pods.

This refinement will only fire an alert if there are less than 3 replicas `ready`. 