### PR TITLE
federate global metrics

### DIFF
--- a/global/prometheus-infra/README.md
+++ b/global/prometheus-infra/README.md
@@ -1,0 +1,11 @@
+Global Prometheus for monitoring the infrastructure
+---------------------------------------------------
+
+This chart contains the configuration, alerts and rules for the global Infra Prometheus.
+The global Infra Prometheus federates selected metrics from the regional Infra Prometheis and stores them for 90 days.  
+
+## Federation
+
+Per convention all metrics prefixed with `global:` found in a regional Infra Prometheus are automatically federated to the global Infra Prometheus.
+Moreover, all `ALERTS` and `up` metrics are federated.
+Further metrics can be added as needed.

--- a/global/prometheus-infra/templates/_prometheus.yaml.tpl
+++ b/global/prometheus-infra/templates/_prometheus.yaml.tpl
@@ -10,6 +10,7 @@
     'match[]':
       - '{__name__=~"^ALERTS$"}'
       - '{__name__=~"up"}'
+      - '{__name__=~"^global:.+"}'
       - '{__name__=~"^snmp_.+"}'
 
   relabel_configs:
@@ -21,6 +22,13 @@
     - action: replace
       target_label: cluster_type
       replacement: controlplane
+
+  metric_relabel_configs:
+    - action: replace
+      source_labels: [__name__]
+      target_label: __name__
+      regex: global:(.+)
+      replacement: $1
 
   {{ if .Values.authentication.enabled }}
   tls_config:


### PR DESCRIPTION
Instead of maintaining the list of metrics that are federated from the regional prometheis to the global infra prometheus, this PR adds support for automatic federation of all metrics prefixed with `global:`. 
also adds basic documentation.
LGTY @artherd42 