### PR TITLE
revert max_surge settings back to 1

### DIFF
--- a/common/postgresql/values.yaml
+++ b/common/postgresql/values.yaml
@@ -14,7 +14,7 @@ global:
       admin_users: "admin_user"
       autodb_idle_timeout: 3600
       max_client_conn: 16384
-      reserve_pool_size: 25
+      reserve_pool_size: 20
       min_pool_size: 1
       default_pool_size: 25 # per user and database
       max_db_connections: 50 # max_connections / dbs / pgbouncers
@@ -98,7 +98,7 @@ pod:
         pod_replacement_strategy: "RollingUpdate"
         rolling_update:
           max_unavailable: 1
-          max_surge: 0
+          max_surge: 1
 
 upgrades:
   revisionHistory: 3


### PR DESCRIPTION
The previous change turned this to 0 out of the fear of connection exhaustion against the postgres. This had the unintended side-effect that pgbouncers won't be restarted automatically if a node was lost and its pods are set to state `unknown`. Without manual intervention the pgbouncer would not be rescheduled until an admin deletes the `unknown` pod or the offline node rejoins the cluster. 

The default connection limit is 500 with 50+25 connections per pgbouncer. In `eu-de-2` we have a max configuration of 6 pgbouncers. With a `maxsurge` setting of 1 we are therefore looking at 7 * 75 = 525 connections max.

To avoid exhaustion, this PR reduces the reserved pool to 20 for a total of 7*(50+20)=490 connections.
