### PR TITLE
sso support for prom federation

### DIFF
--- a/global/prometheus-infra/requirements.yaml
+++ b/global/prometheus-infra/requirements.yaml
@@ -2,4 +2,4 @@ dependencies:
   - name: prometheus-server
     alias: prometheus-infra-global
     repository: https://charts.eu-de-2.cloud.sap
-    version: 1.0.18
+    version: 1.0.21

--- a/global/prometheus-infra/templates/_prometheus.yaml.tpl
+++ b/global/prometheus-infra/templates/_prometheus.yaml.tpl
@@ -22,6 +22,12 @@
       target_label: cluster_type
       replacement: controlplane
 
+  {{ if .Values.authentication.enabled }}
+  tls_config:
+    cert_file: /etc/prometheus/secrets/prometheus-sso-cert/sso.crt
+    key_file: /etc/prometheus/secrets/prometheus-sso-cert/sso.key
+  {{ end }}
+
   static_configs:
     - targets:
 {{- range $region := .Values.regionList }}

--- a/global/prometheus-infra/templates/prometheus-sso-cert.yaml
+++ b/global/prometheus-infra/templates/prometheus-sso-cert.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.authentication.enabled }}
+apiVersion: v1
+kind: Secret
+
+metadata:
+  name: prometheus-sso-cert
+
+data:
+  sso.crt: {{ required ".Values.authentication.ssoCert missing" .Values.authentication.ssoCert | b64enc | quote }}
+  sso.key: {{ required ".Values.authentication.ssoKey missing" .Values.authentication.ssoKey | b64enc | quote }}
+{{ end }}

--- a/global/prometheus-infra/values.yaml
+++ b/global/prometheus-infra/values.yaml
@@ -22,13 +22,13 @@ prometheus-infra-global:
     enabled: true
     size: 300Gi
 
-  serviceAccount:
-    create: false
-    name: default
-
   serviceDiscoveries:
     endpoints:
       enabled: false
+
+  # Comment the `prometheus-sso-cert` if SSO is not used (aka authentication.enabled=false)
+  secrets:
+    - prometheus-sso-cert
 
   # Disable alerting until the transition to the operated Prometheus was done in all regions.
   # alertmanagers:
@@ -42,3 +42,10 @@ alerts:
 # List of regions to which the prometheus-openstack is deployed.
 regionList:
   - "qa-de-1"
+
+# Regional Prometheis are only accessible after presenting a valid SSO certificate.
+authentication:
+  enabled: true
+  # Defined via secrets.
+  # ssoCert:
+  # ssoKey:


### PR DESCRIPTION
Access to an regional Prometheus requires a valid SSO certificate. 
This PR fixes the Prometheus federation by providing a valid client certificate which was generated for the Prometheus federation use case.