### PR TITLE
Fix node exporter filesystem

### DIFF
--- a/system/kube-monitoring/values.yaml
+++ b/system/kube-monitoring/values.yaml
@@ -119,7 +119,8 @@ prometheus-node-exporter:
     create: false
 
   extraArgs:
-    - --collector.filesystem.ignored-mount-points=\"^/(sys|proc|dev|host|etc)($|/)\"
+    - --collector.filesystem.ignored-mount-points=^/(sys|proc|dev|host|etc)($$|/)
+    - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|bpf|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tmpfs|tracefs)$$
     - --collector.processes
     - --path.rootfs=/rootfs
     # enabled by default. flag didn't make it to prom/node-exporter:v0.17.0 .

--- a/system/kube-monitoring/values.yaml
+++ b/system/kube-monitoring/values.yaml
@@ -121,6 +121,7 @@ prometheus-node-exporter:
   extraArgs:
     - --collector.filesystem.ignored-mount-points=\"^/(sys|proc|dev|host|etc)($|/)\"
     - --collector.processes
+    - --path.rootfs=/rootfs
     # enabled by default. flag didn't make it to prom/node-exporter:v0.17.0 .
     #- --collector.systemd.enable-task-metrics
 
@@ -129,6 +130,11 @@ prometheus-node-exporter:
       hostPath: /var/run/dbus/system_bus_socket
       mountPath: /var/run/dbus/system_bus_socket
       readOnly: true
+    - name: rootfs
+      hostPath: /
+      mountPath: /rootfs
+      readOnly: true
+      mountPropagation: HostToContainer
 
   resources:
     requests:


### PR DESCRIPTION
This PR fixes exposure of filesystems within node exporter and adds `tmpfs` to ignored fs types. Without this not all devices/partitions are exposed. It also fixes an argument escaping issue.