### PR TITLE
Add dns_domain config option

### DIFF
--- a/openstack/neutron/templates/etc/_dhcp-agent.ini.tpl
+++ b/openstack/neutron/templates/etc/_dhcp-agent.ini.tpl
@@ -9,6 +9,7 @@ enable_isolated_metadata=True
 metadata_proxy_socket=/run/metadata_proxy
 dnsmasq_dns_servers = {{required "A valid .Values.dns_forwarders required!" .Values.dns_forwarders}}
 dhcp_domain = {{required "A valid .Values.dns_local_domain required!" .Values.dns_local_domain}}
+dns_domain = {{required "A valid .Values.dns_local_domain required!" .Values.dns_local_domain}}
 num_sync_threads = {{.Values.agent.dhcp.num_sync_threads | default 4 }}
 
 rpc_response_timeout = {{ .Values.rpc_response_timeout | default .Values.global.rpc_response_timeout | default 50 }}


### PR DESCRIPTION
The dhcp_domain option has been deprecated and now dns_domain is used.
We'll keep dhcp_domain in the helm charts until all regions are
upgraded to our newest neutron release.