### PR TITLE
add castellum to alertmanager config

### DIFF
--- a/global/prometheus-alertmanager/templates/config.yaml
+++ b/global/prometheus-alertmanager/templates/config.yaml
@@ -109,7 +109,7 @@ data:
         match_re:
           tier: os
           severity: info|warning|critical
-          service: arc|backup|barbican|cinder|cfm|designate|elektra|elk|glance|hermes|ironic|keystone|limes|lyra|maia|manila|neutron|nova|sentry|swift
+          service: arc|backup|barbican|castellum|cinder|cfm|designate|elektra|elk|glance|hermes|ironic|keystone|limes|lyra|maia|manila|neutron|nova|sentry|swift
 
 
       # ======= DUTY ROUTING =======


### PR DESCRIPTION
The corresponding Slack channel (`#cc-os-castellum`) was already created.