### PR TITLE
[NS-exporter] Move Prometheus alerts to CRD

### DIFF
--- a/system/kube-monitoring/charts/ns-exporter/alerts/probe.alerts
+++ b/system/kube-monitoring/charts/ns-exporter/alerts/probe.alerts
@@ -1,0 +1,17 @@
+groups:
+- name: namespace-probe.alerts
+  rules:
+  - alert: NetworkNamespaceProbesFailed
+    expr: sum(changes(ns_exporter_probe_failure_total[10m])) by (network_id, network_name, region, router) > 0 unless sum(changes(ns_exporter_probe_success_total[5m])) by (network_id, network_name, region, router) > 0
+    for: 5m
+    labels:
+      context: availability
+      service: neutron
+      severity: critical
+      tier: os
+      playbook: 'docs/support/playbook/neutron/asr1k.html'
+      meta: 'Network {{ $labels.network_name }} failed all probes'
+      cloudops: "?searchTerm={{ $labels.network_id }}&type=network"
+    annotations:
+      description: 'The network `{{ $labels.network_name }}` failed all dns probes for more then 5 minutes. (<https://dashboard.{{ $labels.region }}.cloud.sap/ccadmin/cloud_admin/cloudops#/universal-search/?searchTerm={{ $labels.router }}&type=router|Router>)'
+      summary: Network probes failed

--- a/system/kube-monitoring/charts/ns-exporter/templates/daemonset.yaml
+++ b/system/kube-monitoring/charts/ns-exporter/templates/daemonset.yaml
@@ -19,7 +19,8 @@ spec:
         app: ns-exporter
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "9191"
+        prometheus.io/port: {{ required ".Values.metrics.port missing" .Values.metrics.port | quote }}
+        prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
       name: ns-exporter
     spec:
       hostPID: true
@@ -29,7 +30,7 @@ spec:
           - -concurrency={{ default 1  .Values.concurrency }}
           - -interval={{ default "1m" .Values.interval }}
         ports:
-        - containerPort: 9191
+        - containerPort: {{ required ".Values.metrics.port missing" .Values.metrics.port }}
           name: metrics
           protocol: TCP
         env:

--- a/system/kube-monitoring/charts/ns-exporter/templates/prometheus-alerts.yaml
+++ b/system/kube-monitoring/charts/ns-exporter/templates/prometheus-alerts.yaml
@@ -1,0 +1,18 @@
+{{- $values := .Values }}
+{{- if and $values.enabled $values.alerts.enabled }}
+{{- range $path, $bytes := .Files.Glob "alerts/*.alerts" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: {{ printf "ns-exporter-%s" $path | replace "/" "-" }}
+  labels:
+    app: ns-exporter
+    prometheus: {{ required ".Values.alerts.prometheus missing" $values.alerts.prometheus }}
+
+spec:
+{{ printf "%s" $bytes | indent 2 }}
+
+{{- end }}
+{{- end }}

--- a/system/kube-monitoring/charts/ns-exporter/values.yaml
+++ b/system/kube-monitoring/charts/ns-exporter/values.yaml
@@ -11,3 +11,12 @@ userDomainName: Default
 #password:
 projectName: cloud_admin
 projectDomainName: ccadmin
+
+metrics:
+  port: 9191
+
+# Deploy Namespace exporters Prometheus alerts.
+alerts:
+  enabled: true
+  # Name of the Prometheus to which the alerts should be assigned to.
+  prometheus: openstack


### PR DESCRIPTION
Makes the ns-exporter ready for the new prometheus setup. LGTY @databus23?

Note: Changing the annotations will restart the exporter. Will that cause foo/needs coordination?