### PR TITLE
Common Postgresql chart with default Prometheus alerts

### DIFF
--- a/common/postgresql/Chart.yaml
+++ b/common/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.3.0
+version: 0.3.1
 description: Chart for PostgreSQL
 keywords:
 - postgresql

--- a/common/postgresql/Chart.yaml
+++ b/common/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.3.1
+version: 0.3.0
 description: Chart for PostgreSQL
 keywords:
 - postgresql

--- a/common/postgresql/templates/_helpers.tpl
+++ b/common/postgresql/templates/_helpers.tpl
@@ -37,3 +37,12 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this 
     {{- $user := index . 1 }}
     {{- tuple $envAll ( $envAll.Values.global.user_suffix | default "" | print $user ) | include "postgres.password_for_fixed_user" }}
 {{- end }}
+
+{{/* Generate the service label for the templated Prometheus alerts. */}}
+{{- define "alerts.service" -}}
+{{- if .Values.alerts.service -}}
+{{- .Values.alerts.service -}}
+{{- else -}}
+{{- .Release.Name -}}
+{{- end -}}
+{{- end -}}

--- a/common/postgresql/templates/alerts/_backup.alerts.tpl
+++ b/common/postgresql/templates/alerts/_backup.alerts.tpl
@@ -1,7 +1,7 @@
 groups:
 - name: backup.alerts
   rules:
-  - alert: {{ include "alerts.service" . | upper }}PostgresDatabaseBackupMissing
+  - alert: {{ include "alerts.service" . | title }}PostgresDatabaseBackupMissing
     expr: absent(backup_last_success{app=~"{{ template "fullname" . }}"})
     for: 1h
     labels:
@@ -14,7 +14,7 @@ groups:
       description: {{ template "fullname" . }} Backup missing. Please check backup container.
       summary: {{ template "fullname" . }} Backup missing
 
-  - alert: {{ include "alerts.service" . | upper }}PostgresDatabaseBackupAge2Hours
+  - alert: {{ include "alerts.service" . | title }}PostgresDatabaseBackupAge2Hours
     expr: floor((time() - backup_last_success{app=~"{{ template "fullname" . }}"}) / 60 / 60) >= 2
     for: 10m
     labels:
@@ -29,7 +29,7 @@ groups:
       description: The last successful database backup for {{`{{ $labels.app }}`}} is {{`{{ $value }}`}} hours old.
       summary: Database Backup too old
 
-  - alert: {{ include "alerts.service" . | upper }}PostgresDatabaseBackupAge4Hours
+  - alert: {{ include "alerts.service" . | title }}PostgresDatabaseBackupAge4Hours
     expr: floor((time() - backup_last_success{app=~"{{ template "fullname" . }}"}) / 60 / 60) >= 4
     for: 10m
     labels:

--- a/common/postgresql/templates/alerts/_backup.alerts.tpl
+++ b/common/postgresql/templates/alerts/_backup.alerts.tpl
@@ -43,17 +43,3 @@ groups:
     annotations:
       description: The last successful database backup for {{`{{ $labels.app }}`}} is {{`{{ $value }}`}} hours old.
       summary: Database Backup too old
-
-  - alert: OpenstackDatabaseBackupReplicationFailure
-    expr: backup_replication_last_run{kind="success", app=~"{{ template "fullname" . }}"} == 0
-    for: 24h
-    labels:
-      context: replicationage
-      dashboard: db-backup-replication
-      meta: "{{`{{ $labels.source_region }}`}} > {{`{{ $labels.region }}`}}"
-      service: {{ template "alerts.service" . }}
-      severity: warning
-      tier: {{ required ".Values.alerts.tier missing" .Values.alerts.tier }}
-    annotations:
-      description: Database backup failed to replicate from {{`{{ $labels.source_region }}`}} to {{`{{ $labels.region }}`}}.
-      summary: Database Backup Replication Failed in {{`{{ $labels.region }}`}}

--- a/common/postgresql/templates/alerts/_backup.alerts.tpl
+++ b/common/postgresql/templates/alerts/_backup.alerts.tpl
@@ -1,7 +1,7 @@
 groups:
 - name: backup.alerts
   rules:
-  - alert: {{ include "alerts.service" . | upper }}DatabaseBackupMissing
+  - alert: {{ include "alerts.service" . | upper }}PostgresDatabaseBackupMissing
     expr: absent(backup_last_success{app=~"{{ template "fullname" . }}"})
     for: 1h
     labels:
@@ -14,7 +14,7 @@ groups:
       description: {{ template "fullname" . }} Backup missing. Please check backup container.
       summary: {{ template "fullname" . }} Backup missing
 
-  - alert: {{ include "alerts.service" . | upper }}DatabaseBackupAge2Hours
+  - alert: {{ include "alerts.service" . | upper }}PostgresDatabaseBackupAge2Hours
     expr: floor((time() - backup_last_success{app=~"{{ template "fullname" . }}"}) / 60 / 60) >= 2
     for: 10m
     labels:
@@ -29,7 +29,7 @@ groups:
       description: The last successful database backup for {{`{{ $labels.app }}`}} is {{`{{ $value }}`}} hours old.
       summary: Database Backup too old
 
-  - alert: {{ include "alerts.service" . | upper }}DatabaseBackupAge4Hours
+  - alert: {{ include "alerts.service" . | upper }}PostgresDatabaseBackupAge4Hours
     expr: floor((time() - backup_last_success{app=~"{{ template "fullname" . }}"}) / 60 / 60) >= 4
     for: 10m
     labels:

--- a/common/postgresql/templates/alerts/_backup.alerts.tpl
+++ b/common/postgresql/templates/alerts/_backup.alerts.tpl
@@ -1,0 +1,59 @@
+groups:
+- name: backup.alerts
+  rules:
+  - alert: OpenstackDatabaseBackupMissing
+    expr: absent(backup_last_success{app=~"{{ template "fullname" . }}"})
+    for: 1h
+    labels:
+      context: backupage
+      dashboard: db-backup
+      service: {{ template "alerts.service" . }}
+      severity: warning
+      tier: {{ required ".Values.alerts.tier missing" .Values.alerts.tier }}
+    annotations:
+      description: Cinder Backup missing. Please check backup container.
+      summary: Cinder Backup missing
+
+  - alert: OpenstackDatabaseBackupAge2Hours
+    expr: floor((time() - backup_last_success{app=~"{{ template "fullname" . }}"}) / 60 / 60) >= 2
+    for: 10m
+    labels:
+      context: backupage
+      dashboard: db-backup
+      meta: "{{`{{ $labels.app }}`}}"
+      service: {{ template "alerts.service" . }}
+      severity: info
+      tier: {{ required ".Values.alerts.tier missing" .Values.alerts.tier }}
+      playbook: docs/support/playbook/db_backup_issues.html
+    annotations:
+      description: The last successful database backup for {{`{{ $labels.app }}`}} is {{`{{ $value }}`}} hours old.
+      summary: Database Backup too old
+
+  - alert: OpenstackDatabaseBackupAge4Hours
+    expr: floor((time() - backup_last_success{app=~"{{ template "fullname" . }}"}) / 60 / 60) >= 4
+    for: 10m
+    labels:
+      context: backupage
+      dashboard: db-backup
+      meta: "{{`{{ $labels.app }}`}}"
+      service: {{ template "alerts.service" . }}
+      severity: warning
+      tier: {{ required ".Values.alerts.tier missing" .Values.alerts.tier }}
+      playbook: docs/support/playbook/db_backup_issues.html
+    annotations:
+      description: The last successful database backup for {{`{{ $labels.app }}`}} is {{`{{ $value }}`}} hours old.
+      summary: Database Backup too old
+
+  - alert: OpenstackDatabaseBackupReplicationFailure
+    expr: backup_replication_last_run{kind="success", app=~"{{ template "fullname" . }}"} == 0
+    for: 24h
+    labels:
+      context: replicationage
+      dashboard: db-backup-replication
+      meta: "{{`{{ $labels.source_region }}`}} > {{`{{ $labels.region }}`}}"
+      service: {{ template "alerts.service" . }}
+      severity: warning
+      tier: {{ required ".Values.alerts.tier missing" .Values.alerts.tier }}
+    annotations:
+      description: Database backup failed to replicate from {{`{{ $labels.source_region }}`}} to {{`{{ $labels.region }}`}}.
+      summary: Database Backup Replication Failed in {{`{{ $labels.region }}`}}

--- a/common/postgresql/templates/alerts/_backup.alerts.tpl
+++ b/common/postgresql/templates/alerts/_backup.alerts.tpl
@@ -6,7 +6,6 @@ groups:
     for: 1h
     labels:
       context: backupage
-      dashboard: db-backup
       service: {{ include "alerts.service" . }}
       severity: warning
       tier: {{ required ".Values.alerts.tier missing" .Values.alerts.tier }}
@@ -19,7 +18,6 @@ groups:
     for: 10m
     labels:
       context: backupage
-      dashboard: db-backup
       meta: "{{`{{ $labels.app }}`}}"
       service: {{ include "alerts.service" . }}
       severity: info
@@ -34,7 +32,6 @@ groups:
     for: 10m
     labels:
       context: backupage
-      dashboard: db-backup
       meta: "{{`{{ $labels.app }}`}}"
       service: {{ include "alerts.service" . }}
       severity: warning

--- a/common/postgresql/templates/alerts/_backup.alerts.tpl
+++ b/common/postgresql/templates/alerts/_backup.alerts.tpl
@@ -11,8 +11,8 @@ groups:
       severity: warning
       tier: {{ required ".Values.alerts.tier missing" .Values.alerts.tier }}
     annotations:
-      description: Cinder Backup missing. Please check backup container.
-      summary: Cinder Backup missing
+      description: {{ template "fullname" . }} Backup missing. Please check backup container.
+      summary: {{ template "fullname" . }} Backup missing
 
   - alert: OpenstackDatabaseBackupAge2Hours
     expr: floor((time() - backup_last_success{app=~"{{ template "fullname" . }}"}) / 60 / 60) >= 2

--- a/common/postgresql/templates/alerts/_backup.alerts.tpl
+++ b/common/postgresql/templates/alerts/_backup.alerts.tpl
@@ -1,27 +1,27 @@
 groups:
 - name: backup.alerts
   rules:
-  - alert: OpenstackDatabaseBackupMissing
+  - alert: {{ include "alerts.service" . | upper }}DatabaseBackupMissing
     expr: absent(backup_last_success{app=~"{{ template "fullname" . }}"})
     for: 1h
     labels:
       context: backupage
       dashboard: db-backup
-      service: {{ template "alerts.service" . }}
+      service: {{ include "alerts.service" . }}
       severity: warning
       tier: {{ required ".Values.alerts.tier missing" .Values.alerts.tier }}
     annotations:
       description: {{ template "fullname" . }} Backup missing. Please check backup container.
       summary: {{ template "fullname" . }} Backup missing
 
-  - alert: OpenstackDatabaseBackupAge2Hours
+  - alert: {{ include "alerts.service" . | upper }}DatabaseBackupAge2Hours
     expr: floor((time() - backup_last_success{app=~"{{ template "fullname" . }}"}) / 60 / 60) >= 2
     for: 10m
     labels:
       context: backupage
       dashboard: db-backup
       meta: "{{`{{ $labels.app }}`}}"
-      service: {{ template "alerts.service" . }}
+      service: {{ include "alerts.service" . }}
       severity: info
       tier: {{ required ".Values.alerts.tier missing" .Values.alerts.tier }}
       playbook: docs/support/playbook/db_backup_issues.html
@@ -29,14 +29,14 @@ groups:
       description: The last successful database backup for {{`{{ $labels.app }}`}} is {{`{{ $value }}`}} hours old.
       summary: Database Backup too old
 
-  - alert: OpenstackDatabaseBackupAge4Hours
+  - alert: {{ include "alerts.service" . | upper }}DatabaseBackupAge4Hours
     expr: floor((time() - backup_last_success{app=~"{{ template "fullname" . }}"}) / 60 / 60) >= 4
     for: 10m
     labels:
       context: backupage
       dashboard: db-backup
       meta: "{{`{{ $labels.app }}`}}"
-      service: {{ template "alerts.service" . }}
+      service: {{ include "alerts.service" . }}
       severity: warning
       tier: {{ required ".Values.alerts.tier missing" .Values.alerts.tier }}
       playbook: docs/support/playbook/db_backup_issues.html

--- a/common/postgresql/templates/backup-alerts.yaml
+++ b/common/postgresql/templates/backup-alerts.yaml
@@ -1,5 +1,4 @@
 {{- if and .Values.backup.enabled .Values.alerts.enabled }}
----
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 

--- a/common/postgresql/templates/backup-alerts.yaml
+++ b/common/postgresql/templates/backup-alerts.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.backup.enabled .Values.alerts.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: {{ template "fullname" . }}-backup-alerts
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    prometheus: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
+
+spec:
+{{ include (print .Template.BasePath "/alerts/_backup.alerts.tpl") . | indent 2 }}
+
+{{- end }}

--- a/common/postgresql/templates/pgbouncer-deployment.yaml
+++ b/common/postgresql/templates/pgbouncer-deployment.yaml
@@ -30,6 +30,7 @@ spec:
         {{- if $opts.prometheus }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "9200"
+        prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
         {{- end }}
     spec:
 {{ tuple . .Values.postgresDatabase "pgbouncer" | include "kubernetes_pod_anti_affinity" | indent 6 }}

--- a/common/postgresql/templates/svc.yaml
+++ b/common/postgresql/templates/svc.yaml
@@ -13,6 +13,7 @@ metadata:
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: {{ required ".Values.metrics.port missing" .Values.metrics.port | quote }}
+    prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
 {{- end }}
 spec:
   selector:

--- a/common/postgresql/templates/svc.yaml
+++ b/common/postgresql/templates/svc.yaml
@@ -12,7 +12,7 @@ metadata:
 {{- if .Values.metrics.enabled }}
   annotations:
     prometheus.io/scrape: "true"
-    prometheus.io/port: "{{default 9187 .Values.metrics.port }}"
+    prometheus.io/port: {{ required ".Values.metrics.port missing" .Values.metrics.port | quote }}
 {{- end }}
 spec:
   selector:
@@ -40,6 +40,7 @@ metadata:
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "9188"
+    prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
 spec:
   clusterIP: None
   ports:

--- a/common/postgresql/values.yaml
+++ b/common/postgresql/values.yaml
@@ -120,6 +120,7 @@ metrics:
   imagePullPolicy: IfNotPresent
 
   port: 9187
+
   customMetrics:
     pg_database:
       query: "SELECT d.datname AS datname, CASE WHEN pg_catalog.has_database_privilege(d.datname, 'CONNECT') THEN pg_catalog.pg_database_size(d.datname) ELSE 0 END AS size_bytes FROM pg_catalog.pg_database d where datname not in ('template0', 'template1', 'postgres')"
@@ -157,3 +158,16 @@ pgbouncer:
 
 cdc:
   enabled: false
+
+# Default Prometheus alerts and rules.
+alerts:
+  enabled: true
+
+  # Name of the Prometheus supposed to scrape the metrics and to which alerts are assigned.
+  prometheus: openstack
+
+  # The tier of the alert.
+  tier: os
+
+  # Configurable service label of the alerts. Defaults to `.Release.Name`.
+  # service:


### PR DESCRIPTION
As discussed @reimannf. Let's review tomorrow.

The postgresql chart should provide a set of generic Prometheus alerts via `PrometheusRule` custom resource. Alerts are templated and tied to the application using this chart.