### PR TITLE
Mariadb chart with backup alerts

### DIFF
--- a/common/mariadb/templates/_helpers.tpl
+++ b/common/mariadb/templates/_helpers.tpl
@@ -1,0 +1,13 @@
+{{/* Generate the full name. */}}
+{{- define "fullName" -}}
+{{- required ".Values.name missing" .Values.name -}}-mariadb
+{{- end -}}
+
+{{/* Generate the service label for the templated Prometheus alerts. */}}
+{{- define "alerts.service" -}}
+{{- if .Values.alerts.service -}}
+{{- .Values.alerts.service -}}
+{{- else -}}
+{{- .Release.Name -}}
+{{- end -}}
+{{- end -}}

--- a/common/mariadb/templates/alerts/_backup.alerts.tpl
+++ b/common/mariadb/templates/alerts/_backup.alerts.tpl
@@ -1,0 +1,45 @@
+groups:
+- name: backup.alerts
+  rules:
+  - alert: {{ include "alerts.service" . | title }}MariaDatabaseBackupMissing
+    expr: absent(backup_last_success{app=~"{{ include "fullName" . }}"})
+    for: 1h
+    labels:
+      context: backupage
+      dashboard: db-backup
+      service: {{ include "alerts.service" . }}
+      severity: warning
+      tier: {{ required ".Values.alerts.tier missing" .Values.alerts.tier }}
+    annotations:
+      description: {{ include "fullName" . }} backup missing. Please check the backup container.
+      summary: {{ include "fullName" . }} backup missing
+
+  - alert: {{ include "alerts.service" . | title }}MariaDatabaseBackupAge2Hours
+    expr: floor((time() - backup_last_success{app=~"{{ include "fullName" . }}"}) / 60 / 60) >= 2
+    for: 10m
+    labels:
+      context: backupage
+      dashboard: db-backup
+      meta: "{{`{{ $labels.app }}`}}"
+      service: {{ include "alerts.service" . }}
+      severity: info
+      tier: {{ required ".Values.alerts.tier missing" .Values.alerts.tier }}
+      playbook: docs/support/playbook/db_backup_issues.html
+    annotations:
+      description: The last successful database backup for {{`{{ $labels.app }}`}} is {{`{{ $value }}`}} hours old.
+      summary: Database Backup too old
+
+  - alert: {{ include "alerts.service" . | title }}MariaDatabaseBackupAge4Hours
+    expr: floor((time() - backup_last_success{app=~"{{ include "fullName" . }}"}) / 60 / 60) >= 4
+    for: 10m
+    labels:
+      context: backupage
+      dashboard: db-backup
+      meta: "{{`{{ $labels.app }}`}}"
+      service: {{ include "alerts.service" . }}
+      severity: warning
+      tier: {{ required ".Values.alerts.tier missing" .Values.alerts.tier }}
+      playbook: docs/support/playbook/db_backup_issues.html
+    annotations:
+      description: The last successful database backup for {{`{{ $labels.app }}`}} is {{`{{ $value }}`}} hours old.
+      summary: Database Backup too old

--- a/common/mariadb/templates/alerts/_backup.alerts.tpl
+++ b/common/mariadb/templates/alerts/_backup.alerts.tpl
@@ -6,7 +6,6 @@ groups:
     for: 1h
     labels:
       context: backupage
-      dashboard: db-backup
       service: {{ include "alerts.service" . }}
       severity: warning
       tier: {{ required ".Values.alerts.tier missing" .Values.alerts.tier }}
@@ -19,7 +18,6 @@ groups:
     for: 10m
     labels:
       context: backupage
-      dashboard: db-backup
       meta: "{{`{{ $labels.app }}`}}"
       service: {{ include "alerts.service" . }}
       severity: info
@@ -34,7 +32,6 @@ groups:
     for: 10m
     labels:
       context: backupage
-      dashboard: db-backup
       meta: "{{`{{ $labels.app }}`}}"
       service: {{ include "alerts.service" . }}
       severity: warning

--- a/common/mariadb/templates/backup-alerts.yaml
+++ b/common/mariadb/templates/backup-alerts.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.alerts.enabled .Values.backup.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: {{ include "fullName" . }}-alerts
+  labels:
+    app: {{ include "fullName" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    prometheus: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
+
+spec:
+{{ include (print .Template.BasePath "/alerts/_backup.alerts.tpl") . | indent 2 }}
+
+{{- end }}

--- a/common/mariadb/templates/deployment.yaml
+++ b/common/mariadb/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{.Values.name}}-mariadb
+  name: {{ include "fullName" . }}
   labels:
     system: openstack
     type: database
@@ -13,11 +13,11 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      app: {{.Values.name}}-mariadb
+      app: {{ include "fullName" . }}
   template:
     metadata:
       labels:
-        app: {{.Values.name}}-mariadb
+        app: {{ include "fullName" . }}
       annotations:
         checksum/secrets: {{ include (print $.Template.BasePath  "/secret.yaml") . | sha256sum }}
         checksum/etc: {{ include (print $.Template.BasePath  "/etc-configmap.yaml") . | sha256sum }}

--- a/common/mariadb/templates/secret.yaml
+++ b/common/mariadb/templates/secret.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: mariadb-{{.Values.name}} 
+  name: {{ include "fullName" . }}
   labels:
     system: openstack
     type: database
-    component: mariadb-{{.Values.name}}
+    component: {{ include "fullName" . }}
 type: Opaque
 data:
   root-password: {{ default "" .Values.root_password | b64enc | quote }}

--- a/common/mariadb/templates/service.yaml
+++ b/common/mariadb/templates/service.yaml
@@ -2,7 +2,7 @@ kind: Service
 apiVersion: v1
 
 metadata:
-  name: {{.Values.name}}-mariadb
+  name: {{ include "fullName" . }}
   namespace:  {{.Release.Namespace}}
   labels:
     system: openstack
@@ -12,9 +12,9 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    app: {{.Values.name}}-mariadb
+    app: {{ include "fullName" . }}
   ports:
-    - name: {{.Values.name}}-mariadb
+    - name: {{ include "fullName" . }}
       port: {{.Values.port_public}}
 
 {{- if .Values.backup.enabled }}
@@ -22,15 +22,16 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{.Values.name}}-mariadb-backup-metrics
+  name: {{ include "fullName" . }}-backup-metrics
   labels:
-    app: {{.Values.name}}-mariadb
+    app: {{ include "fullName" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "9188"
+    prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
 spec:
   clusterIP: None
   ports:
@@ -38,5 +39,5 @@ spec:
       port: 9188
       protocol: TCP
   selector:
-    app: {{.Values.name}}-mariadb
+    app: {{ include "fullName" . }}
 {{- end }}

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -42,3 +42,16 @@ backup:
   os_user_domain: Default
   os_project_name: master
   os_project_domain: ccadmin
+
+# Default Prometheus alerts and rules.
+alerts:
+  enabled: true
+
+  # Name of the Prometheus supposed to scrape the metrics and to which alerts are assigned.
+  prometheus: openstack
+
+  # The tier of the alert.
+  tier: os
+
+  # Configurable service label of the alerts. Defaults to `.Release.Name`.
+  # service:


### PR DESCRIPTION
This PR does:
(1) Introduce backup alerts for maria db. Same as in #784.
(2) The alert condition depends on the `app` label, thus it must be consistent and is now generated via a helper.

LGTY @reimannf?