### PR TITLE
Move Quay alerts from to new Prometheus

### DIFF
--- a/global/quay/alerts/quay.alerts
+++ b/global/quay/alerts/quay.alerts
@@ -1,0 +1,41 @@
+groups:
+- name: quay.alerts
+  rules:
+  - alert: KubernetesQuayHighNumberOfDatabaseConnections
+    expr: sum by (datname) (pg_stat_activity_count{kubernetes_namespace="quay-enterprise", datname="quay"}) >= 500
+    for: 5m
+    labels:
+      tier: k8s
+      service: quay
+      severity: warning
+      context: quay
+      meta: "{{ $labels.datname }} has a high number of database connections"
+    annotations:
+      description: High number of database connections
+      summary: "Quay has {{ $labels.value }} database connections and might be unavailable soon"
+
+  - alert: KubernetesQuayPredictHighNumberOfDatabaseConnections
+    expr: predict_linear(pg_stat_activity_count{kubernetes_namespace="quay-enterprise", datname="quay"}[1h], 3*3600) >= 2000
+    for: 5m
+    labels:
+      tier: k8s
+      service: quay
+      severity: warning
+      context: quay
+      meta: "Predicting a high number of database connections for {{ $labels.datname }}"
+    annotations:
+      description: High number of database connections
+      summary: Predicting more than 2000 database connections for quay within the next 3 hours and might be unavailable soon.
+
+  - alert: QuayPostgresDatabaseSize
+    expr: pg_database_size_bytes{datname="quay"} >= 200 * 1024^3
+    for: 5m
+    labels:
+      tier: k8s
+      service: quay
+      severity: warning
+      context: quay
+      meta: "Database {{ $labels.datname }} to large"
+    annotations:
+      description: "The quay database size is greater than 160GB and will exceed the PV limits eventually"
+      summary: Quay database is too large

--- a/global/quay/templates/alerts.yaml
+++ b/global/quay/templates/alerts.yaml
@@ -1,0 +1,21 @@
+{{- $values := .Values }}
+{{- if $values.alerts.enabled }}
+{{- range $path, $bytes := .Files.Glob "alerts/*.alerts" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: {{ printf "%s" $path | replace "/" "-" }}
+  labels:
+    app: {{ template "quay.name" . }}
+    chart: {{ template "quay.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    prometheus: {{ required ".Values.alerts.prometheus missing" $values.alerts.prometheus }}
+
+spec:
+{{ printf "%s" $bytes | indent 2 }}
+
+{{- end }}
+{{- end }}

--- a/global/quay/templates/deployment.yaml
+++ b/global/quay/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9092'
+        prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
     spec:
       volumes:
         - name: configvolume

--- a/global/quay/values.yaml
+++ b/global/quay/values.yaml
@@ -21,4 +21,15 @@ postgresql:
     enabled: true
     size: 300Gi
 
+  # Disable default Postgres alerts. Quay uses its own.
+  alerts:
+    enabled: false
+
 #pullSecret:
+
+# Default Prometheus alerts and rules.
+alerts:
+  enabled: true
+
+  # Name of the Prometheus supposed to scrape the metrics and to which alerts are assigned.
+  prometheus: kubernetes


### PR DESCRIPTION
Moves the quay alerts from the kube-monitoring swamp.
The pipeline (if there's one) might need to be extended by a alert validation step a la `promtool check rules helm-charts.git/global/quay/alerts/*.alerts`.
LGTY @databus23?