### PR TITLE
[common/mariadb] fix root password from secret

### DIFF
--- a/common/mariadb/templates/deployment.yaml
+++ b/common/mariadb/templates/deployment.yaml
@@ -28,9 +28,11 @@ spec:
         image: {{.Values.image}}
         imagePullPolicy: IfNotPresent
         env:
-        - name: MYSQL_ROOT_PASSWORD
-          value:
-            {{.Values.root_password}}
+        - name:  MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mariadb-{{.Values.name}}
+              key: root-password
         ports:
           - name: mariadb
             containerPort: 3306


### PR DESCRIPTION
Currently the secret contains the root password of the maria db but isn't used. What this PR fixes: Uses the maria db root password from the secret.
