### PR TITLE
Add etcd backup alert for admin cluster

### DIFF
--- a/system/kube-monitoring/charts/prometheus-frontend/admin-etcd-backup.alerts
+++ b/system/kube-monitoring/charts/prometheus-frontend/admin-etcd-backup.alerts
@@ -1,0 +1,15 @@
+groups:
+- name: etcd-backup.alerts
+  rules:
+  - alert: KubernikusEtcdBackupFailed
+    expr: sum(etcdbr_snapshot_duration_seconds_count{kind="Full", succeeded="false"}) without (succeeded) unless (time() - etcdbr_snapshot_latest_timestamp{kind="Full"} < 2 * 3600)
+    for: 5m
+    labels:
+      tier: kks
+      service: kubernikus
+      severity: warning
+      context: kluster
+      meta: "Latest etcd backup for kluster {{ $labels.release }} older than 2h"
+    annotations:
+      description: Backup of etcd is failing for kluster {{ $labels.release }}. Latest full backup is older then 2 hours.
+      summary: Etcd backup error for kluster {{ $labels.release }}

--- a/system/kube-monitoring/charts/prometheus-frontend/templates/config.yaml
+++ b/system/kube-monitoring/charts/prometheus-frontend/templates/config.yaml
@@ -51,6 +51,13 @@ data:
 {{ printf "%s" $bytes | indent 4 }}
   {{- end }}
   {{- end }}
+  # add admin cluster alerts
+  {{- if eq .Values.global.region "admin" }}
+  {{- range $path, $bytes := .Files.Glob "admin-*.alerts" }}
+  {{ printf "%s" $path }}: |
+{{ printf "%s" $bytes | indent 4 }}
+  {{- end }}
+  {{- end }}
 {{- end }}
 
 {{- if .Values.additional_alerts }}


### PR DESCRIPTION
This PR adds an alert if any etcd backup is failing in admin cluster.