### PR TITLE
Limes: make the pod OOM alert less trigger-happy

### DIFF
--- a/openstack/limes/aggregations/consolidation.rules
+++ b/openstack/limes/aggregations/consolidation.rules
@@ -2,8 +2,7 @@ groups:
 - name: limes
   rules:
     - record: global:limes_consolidated_cluster_capacity
-      expr: max(label_join(limes_cluster_capacity, "full_resource", "/", "service", "resource"))
-          by (full_resource,os_cluster)
+      expr: max(label_join(limes_cluster_capacity, "full_resource", "/", "service", "resource")) by (full_resource,os_cluster)
 
     - record: global:limes_consolidated_domain_quota
       expr: max(label_join(limes_domain_quota, "full_resource", "/", "service", "resource"))

--- a/openstack/limes/aggregations/consolidation.rules
+++ b/openstack/limes/aggregations/consolidation.rules
@@ -20,3 +20,6 @@ groups:
     - record: global:limes_consolidated_unit_multiplier
       expr: max(label_join(limes_unit_multiplier, "full_resource", "/", "service", "resource"))
           by (full_resource)
+
+    - record: aggregated:limes_container_memory_usage_percent
+      expr: '100 * max by (namespace,pod_name) (container_memory_usage_bytes{pod_name=~"limes-.+"}) / max by (pod_name, namespace) (label_replace(kube_pod_container_resource_limits_memory_bytes{pod=~"limes-.+"}, "pod_name", "$1", "pod", "(.*)"))'

--- a/openstack/limes/aggregations/consolidation.rules
+++ b/openstack/limes/aggregations/consolidation.rules
@@ -21,5 +21,5 @@ groups:
       expr: max(label_join(limes_unit_multiplier, "full_resource", "/", "service", "resource"))
           by (full_resource)
 
-    - record: aggregated:limes_container_memory_usage_percent
-      expr: '100 * max by (namespace,pod_name) (container_memory_usage_bytes{pod_name=~"limes-.+"}) / max by (pod_name, namespace) (label_replace(kube_pod_container_resource_limits_memory_bytes{pod=~"limes-.+"}, "pod_name", "$1", "pod", "(.*)"))'
+    - record: limes_container_memory_usage_percent
+      expr: '100 * max by (namespace,pod_name) (container_memory_working_set_bytes{pod_name=~"limes-.+",container_name!="POD"}) / max by (pod_name, namespace) (label_replace(kube_pod_container_resource_limits_memory_bytes{pod=~"limes-.+"}, "pod_name", "$1", "pod", "(.*)"))'

--- a/openstack/limes/alerts/pod.alerts
+++ b/openstack/limes/alerts/pod.alerts
@@ -30,7 +30,7 @@ groups:
           description: The pod {{ $labels.pod_name }} was oomkilled recently
 
       - alert: OpenstackLimesPodOOMExceedingLimits
-        expr: aggregated:limes_container_memory_usage_percent > 70 and predict_linear(aggregated:limes_container_memory_usage_percent[1h], 8*3600) > 100
+        expr: limes_container_memory_usage_percent > 70 and predict_linear(limes_container_memory_usage_percent[0h], 7*3600) > 100
         for: 30m
         labels:
           tier: os

--- a/openstack/limes/alerts/pod.alerts
+++ b/openstack/limes/alerts/pod.alerts
@@ -30,7 +30,7 @@ groups:
           description: The pod {{ $labels.pod_name }} was oomkilled recently
 
       - alert: OpenstackLimesPodOOMExceedingLimits
-        expr: predict_linear(container_memory_usage_bytes{pod_name=~"limes-.+"}[1h], 8* 3600) > ON (pod_name, namespace) label_replace(kube_pod_container_resource_limits_memory_bytes{pod=~"limes-.+"}, "pod_name", "$1", "pod", "(.*)")
+        expr: aggregated:limes_container_memory_usage_percent > 70 and predict_linear(aggregated:limes_container_memory_usage_percent[1h], 8*3600) > 100
         for: 30m
         labels:
           tier: os

--- a/system/kube-monitoring/charts/prometheus-collector/aggregation.rules
+++ b/system/kube-monitoring/charts/prometheus-collector/aggregation.rules
@@ -31,8 +31,8 @@ groups:
 
 - name: limes
   rules:
-  - record: aggregated:limes_failed_scrapes_rate
-    expr: sum(increase(limes_failed_scrapes[5m])) by (cluster,service,kubernetes_namespace) + sum(0 * limes_successful_scrapes) by (cluster,service,kubernetes_namespace)
+  - record: limes_container_memory_usage_percent
+    expr: '100 * max by (namespace,pod_name) (container_memory_working_set_bytes{pod_name=~"limes-.+",container_name!="POD"}) / max by (pod_name, namespace) (label_replace(kube_pod_container_resource_limits_memory_bytes{pod=~"limes-.+"}, "pod_name", "$1", "pod", "(.*)"))'
 
 - name: elasticsearch
   rules:

--- a/system/kube-monitoring/charts/prometheus-frontend/openstack-limes.alerts
+++ b/system/kube-monitoring/charts/prometheus-frontend/openstack-limes.alerts
@@ -195,7 +195,7 @@ groups:
       description: The pod {{ $labels.pod_name }} was oomkilled recently
 
   - alert: OpenstackLimesPodOOMExceedingLimits
-    expr: predict_linear(container_memory_usage_bytes{pod_name=~"limes-.+"}[1h], 8* 3600) > ON (pod_name, namespace) label_replace(kube_pod_container_resource_limits_memory_bytes{pod=~"limes-.+"}, "pod_name", "$1", "pod", "(.*)")
+    expr: limes_container_memory_usage_percent > 70 and predict_linear(limes_container_memory_usage_percent[0h], 7*3600) > 100
     for: 30m
     labels:
       tier: os


### PR DESCRIPTION
The old alert just checked if `predict_linear(memory usage, 8h) > 100%`. This often fires directly after deployments when pods' memory usage quickly rises during their startup, but then flattens out.

To avoid these misfirings, the alert now has a second condition, triggering only for current `memory usage > 70%`. Because the alert expresssion got quite unwieldy, I refactored part of it out into an aggregation rule.

@auhlig I'd appreciate a second pair of eyes checking the alert expressions.

One thing that I'm not sure about is if we want to move the aggregation rule to a more generic place, and have it apply to all containers. These pod-OOM alerts are just copy-pasted all over the place anyway, so it may be helpful to have this aggregated metric available for everyone.