### PR TITLE
Add apiserver alerts in admin cluster

### DIFF
--- a/system/kube-monitoring/charts/prometheus-frontend/admin-apiserver.alerts
+++ b/system/kube-monitoring/charts/prometheus-frontend/admin-apiserver.alerts
@@ -1,0 +1,14 @@
+groups:
+- name: apiserver.alerts
+  rules:
+  - alert: KubernikusAPIDown
+    expr: count by (instance) (probe_success{ingress_name="kubernikus-api"} != 1) >= count by (instance) (probe_success{ingress_name="kubernikus-api"} == 1)
+    for: 5m
+    labels:
+      tier: kks
+      service: kubernikus
+      severity: critical
+      context: availability
+    annotations:
+      description: "{{ $labels.instance }} is unavailable"
+      summary: "{{ $labels.instance }} is unavailable"


### PR DESCRIPTION
This PR adds an alert to blackbox apiserver monitoring in admin cluster.