### PR TITLE
split swift-drive-autopilot into two daemonsets for plain and multipath

### DIFF
--- a/openstack/swift-drive-autopilot/templates/_utils.tpl
+++ b/openstack/swift-drive-autopilot/templates/_utils.tpl
@@ -11,3 +11,25 @@ When passed via `helm upgrade --set`, the image tag is misinterpreted as a float
     {{- end -}}
   {{- end -}}
 {{- end -}}
+
+{{- define "shared_config" }}
+  chroot: /coreos
+  metrics-listen-address: ":9102"
+
+  # the Swift user and group is UID/GID 1000 in the Kolla containers
+  chown:
+    user: "1000"
+    group: "1000"
+
+  {{ if $.Values.encryption_key -}}
+  keys:
+    - secret: {{$.Values.encryption_key}}
+  {{ end }}
+
+  swift-id-pool: {{ range $idx := until 99 }}
+    - swift-{{ printf "%02d" (add1 $idx) }}
+    {{- if eq 0 (mod (add1 $idx) $.Values.one_spare_disk_every) }}
+    - spare
+    {{- end -}}
+  {{ end -}}
+{{- end -}}

--- a/openstack/swift-drive-autopilot/templates/configmap.yaml
+++ b/openstack/swift-drive-autopilot/templates/configmap.yaml
@@ -10,32 +10,12 @@ metadata:
 
 data:
   config.yaml: |
-    chroot: /coreos
-    metrics-listen-address: ":9102"
-
+    {{- include "shared_config" . | indent 2 }}
     drives:
-    {{- if .Values.drives }}
-      {{- range $drives := .Values.drives }}
-      - {{ $drives }}
-      {{- end -}}
-    {{ else }}
       - /dev/sd[a-z]
       - /dev/sd[a-z][a-z]
-    {{ end }}
-
-    # the Swift user and group is UID/GID 1000 in the Kolla containers
-    chown:
-      user: "1000"
-      group: "1000"
-
-    {{ if .Values.encryption_key -}}
-    keys:
-      - secret: {{.Values.encryption_key}}
-    {{ end }}
-
-    swift-id-pool: {{ range $idx := until 99 }}
-      - swift-{{ printf "%02d" (add1 $idx) }}
-      {{- if eq 0 (mod (add1 $idx) $.Values.one_spare_disk_every) }}
-      - spare
-      {{- end -}}
-    {{ end -}}
+  config-multipath.yaml: |
+    {{- include "shared_config" . | indent 2 }}
+    drives:
+      - /dev/mapper/mpath[a-z]
+      - /dev/mapper/mpath[a-z][a-z]

--- a/openstack/swift-drive-autopilot/templates/daemonset.yaml
+++ b/openstack/swift-drive-autopilot/templates/daemonset.yaml
@@ -1,10 +1,12 @@
+{{- range $suffix := list "" "-multipath" }}
+---
 kind: DaemonSet
 apiVersion: extensions/v1beta1
 
 metadata:
-  name: swift-drive-autopilot
+  name: swift-drive-autopilot{{$suffix}}
   labels:
-    release: "{{.Release.Name}}"
+    release: "{{$.Release.Name}}"
 
 spec:
   minReadySeconds: 15
@@ -13,9 +15,9 @@ spec:
   template:
     metadata:
       labels:
-        component: swift-drive-autopilot
+        component: swift-drive-autopilot{{$suffix}}
         from: daemonset
-        release: "{{.Release.Name}}"
+        release: "{{$.Release.Name}}"
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9102"
@@ -23,14 +25,19 @@ spec:
       tolerations:
       - key: "species"
         operator: "Equal"
-        value: "{{.Values.species}}"
+        value: "{{$.Values.species}}"
         effect: "NoSchedule"
+      {{- if eq $suffix "-multipath" }}
       - key: "species"
         operator: "Equal"
-        value: "{{.Values.species}}-multipath"
+        value: "{{$.Values.species}}-multipath"
         effect: "NoSchedule"
+      {{- end }}
       nodeSelector:
-        species: {{quote .Values.species}}
+        species: {{quote $.Values.species}}
+        {{- if eq $suffix "-multipath" }}
+        multipath-disks: "true"
+        {{- end }}
       volumes:
         - name: config
           configMap:
@@ -40,11 +47,11 @@ spec:
             path: /
       containers:
         - name: boot
-          image: {{.Values.global.imageRegistry}}/monsoon/swift-drive-autopilot:{{include "image_version" .}}
+          image: {{$.Values.global.imageRegistry}}/monsoon/swift-drive-autopilot:{{include "image_version" $}}
           securityContext:
             privileged: true
           args:
-            - /etc/drive-autopilot/config.yaml
+            - /etc/drive-autopilot/config{{$suffix}}.yaml
           # env:
           #   - name: 'DEBUG'
           #     value: '1'
@@ -56,3 +63,4 @@ spec:
           ports:
             - name: metrics
               containerPort: 9102
+{{- end }}

--- a/openstack/swift-drive-autopilot/values.yaml
+++ b/openstack/swift-drive-autopilot/values.yaml
@@ -9,8 +9,3 @@ species: swift-storage
 # will be set aside as spare capacity. (See swift-drive-autopilot docs for
 # details.)
 one_spare_disk_every: 20
-
-# Drive glob, if not provided it defaults to
-# drives:
-#  - /dev/sd[a-z]
-#  - /dev/sd[a-z][a-z]


### PR DESCRIPTION
The `multipath-disks: true` node label constraints `swift-drive-autopilot-multipath` onto these nodes in particular. The `species: swift-storage-multipath` taint forces `swift-drive-autopilot` without `-multipath` off these nodes.