### PR TITLE
[nova] Make dvs-agent inclusion configurable

### DIFF
--- a/openstack/nova/templates/hypervisors/hypervisors-vmware-deployment-vct.yaml
+++ b/openstack/nova/templates/hypervisors/hypervisors-vmware-deployment-vct.yaml
@@ -97,6 +97,7 @@ template: |
             name: nova-etc
             subPath: compute.filters
             readOnly: true
+        {{- if .Values.neutron_dvs_agent_enabled }}
         - name: neutron-dvs-agent
           image: {{.Values.global.imageRegistry}}/{{.Values.global.image_namespace}}/loci-neutron:{{.Values.imageVersionNeutron | required "Please set nova.imageVersionNeutron or similar" }}
           imagePullPolicy: IfNotPresent
@@ -152,6 +153,7 @@ template: |
             name: ml2-conf-vmware
             subPath: ml2-vmware.ini
             readOnly: true
+        {{- end }}
         - name: statsd
           image: prom/statsd-exporter:v0.8.1
           imagePullPolicy: IfNotPresent
@@ -176,6 +178,7 @@ template: |
         - name: hypervisor-config
           configMap:
             name: nova-compute-vmware-{= name =}
+       {{- if .Values.neutron_dvs_agent_enabled }}
         - name: etcneutron
           emptyDir: {}
         - name: neutron-etc
@@ -184,4 +187,5 @@ template: |
         - name: ml2-conf-vmware
           configMap:
             name: neutron-ml2-vmware-{= name =}
+        {{- end }}
 {{- end }}

--- a/openstack/nova/templates/hypervisors/hypervisors-vmware-neutron-configmap-vct.yaml
+++ b/openstack/nova/templates/hypervisors/hypervisors-vmware-neutron-configmap-vct.yaml
@@ -1,4 +1,4 @@
-{{- if or (.Capabilities.APIVersions.Has "vcenter-operator.stable.sap.cc/v1") (.Values.isImageTransportTemplating | default false) }}
+{{- if and .Values.neutron_dvs_agent_enabled (or (.Capabilities.APIVersions.Has "vcenter-operator.stable.sap.cc/v1") (.Values.isImageTransportTemplating | default false)) }}
 apiVersion: vcenter-operator.stable.sap.cc/v1
 kind: VCenterTemplate
 metadata:

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -147,6 +147,7 @@ vspc:
 
 # I would move all that to the neutron deployment
 neutron: {}
+neutron_dvs_agent_enabled: True
 
 cross_az_attach: 'False'
 


### PR DESCRIPTION
With the switch to nsx-t, which is deployed by the neutron helm-chart,
we can get rid of the dvs-agent deployment in nova. Setting the variable
`neutron_dvs_agent_enabled` to `False` for a region, removes the
dvs-agent deployment. One might have to manuall delete the deployment of
the nova-compute pod though, because the vcenter-operator is not
supposed to delete stuff and most probably cannot update the deployment.

---

I rendered the template locally and it seems ok to me and also loads via `yaml.load_all()`. Still, I'd like to have someone have another look.