### PR TITLE
Securitygroup admin

### DIFF
--- a/openstack/nova/templates/etc/_nova-policy.json.tpl
+++ b/openstack/nova/templates/etc/_nova-policy.json.tpl
@@ -10,6 +10,7 @@
     "context_is_editor": "rule:context_is_compute_admin or rule:member",
     "context_is_viewer":  "rule:context_is_editor or rule:viewer",
     "compute_admin_all": "role:compute_admin or role:cloud_compute_admin",
+    "context_is_securitygroup_admin": "(role:securitygroup_admin and rule:owner) or rule:context_is_compute_admin or rule:context_is_network_admin",
     "default": "rule:context_is_admin",
 
     "network_admin": "role:network_admin and rule:owner",
@@ -92,8 +93,8 @@
     "compute:soft_delete": "rule:context_is_editor",
     "compute:force_delete": "rule:context_is_editor",
 
-    "compute:security_groups:add_to_instance": "rule:context_is_compute_admin or rule:context_is_network_admin",
-    "compute:security_groups:remove_from_instance": "rule:context_is_compute_admin or rule:context_is_network_admin",
+    "compute:security_groups:add_to_instance": "rule:context_is_securitygroup_admin",
+    "compute:security_groups:remove_from_instance": "rule:context_is_securitygroup_admin",
 
     "compute:restore": "rule:context_is_editor",
 


### PR DESCRIPTION
This enables the securitygroup_admin role to
attach and detach securitygroups from a compute
instance.