### PR TITLE
[Designate] Move Prometheus alerts to CRD

### DIFF
--- a/openstack/designate/alerts/api.alerts
+++ b/openstack/designate/alerts/api.alerts
@@ -1,0 +1,127 @@
+groups:
+- name: designate-api.alerts
+  rules:
+  - alert: OpenstackDesignateApiDown
+    expr: blackbox_api_status_gauge{check=~"designate"} == 1
+    for: 20m
+    labels:
+      severity: critical
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-blackbox-details
+      meta: '{{ $labels.check }} API is down. See Sentry for details.'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}/#{{ $labels.check }}'
+    annotations:
+      description: '{{ $labels.check }} API is down for 20 min. See Sentry for details.'
+      summary: '{{ $labels.check }} API down'
+
+  - alert: OpenstackDesignateApiFlapping
+    expr: changes(blackbox_api_status_gauge{check=~"designate"}[30m]) > 8
+    labels:
+      severity: critical
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-blackbox-details
+      meta: '{{ $labels.check }} API is flapping'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}/#{{ $labels.check }}'
+    annotations:
+      description: '{{ $labels.check }} API is flapping for 30 minutes.'
+      summary: '{{ $labels.check }} API flapping'
+
+  - alert: OpenstackDesignateCanaryDown
+    expr: blackbox_canary_status_gauge{service=~"designate"} == 1
+    for: 1h
+    labels:
+      severity: warning
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-canary-details
+      meta: 'Canary {{ $labels.service }} {{ $labels.check }} is down for 1 hour. See Sentry for details'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}'
+    annotations:
+      description: 'Canary {{ $labels.service }} {{ $labels.check }} is down for 1 hour. See Sentry for details'
+      summary: 'Canary {{ $labels.service }} {{ $labels.check }} is down'
+
+  - alert: OpenstackDesignateCanaryTimeout
+    expr: blackbox_canary_status_gauge{service=~"designate"} == 0.5
+    for: 1h
+    labels:
+      severity: info
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-canary-details
+      meta: 'Canary {{ $labels.service }} {{ $labels.check }} is timing out for 1 hour. See Sentry for details'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}'
+    annotations:
+      description: 'Canary {{ $labels.service }} {{ $labels.check }} is timing out for 1 hour. See Sentry for details'
+      summary: 'Canary {{ $labels.service }} {{ $labels.check }} is timing out'
+
+  - alert: OpenstackDesignateCanaryFlapping
+    expr: changes(blackbox_canary_status_gauge{service=~"designate"}[2h]) > 8
+    labels:
+      severity: warning
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-canary-details
+      meta: 'Canary {{ $labels.service }} {{ $labels.check }} is flapping for 2 hours. See Sentry for details'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}'
+    annotations:
+      description: 'Canary {{ $labels.service }} {{ $labels.check }} is flapping for 2 hours. See Sentry for details'
+      summary: 'Canary {{ $labels.service }} {{ $labels.check }} is flapping'
+
+  - alert: OpenstackDesignateDatapathDown
+    expr: blackbox_datapath_status_gauge{service=~"designate"} == 1
+    for: 15m
+    labels:
+      severity: critical
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-datapath-details
+      meta: 'Datapath {{ $labels.service }} {{ $labels.check }} is down for 15 minutes. See Sentry for details'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}/#{{ $labels.check }}'
+    annotations:
+      description: 'Datapath {{ $labels.service }} {{ $labels.check }} is down for 15 minutes. See Sentry for details'
+      summary: 'Datapath {{ $labels.service }} {{ $labels.check }} is down'
+
+  - alert: OpenstackDesignateDatapathHalfDown
+    expr: blackbox_datapath_status_gauge{service=~"designate"} == 0.5
+    for: 15m
+    labels:
+      severity: critical
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-datapath-details
+      meta: 'Datapath {{ $labels.service }} {{ $labels.check }} is half down for 15 minutes. See Sentry for details'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}/#{{ $labels.check }}'
+    annotations:
+      description: 'Datapath {{ $labels.service }} {{ $labels.check }} is half down for 15 minutes. See Sentry for details'
+      summary: 'Datapath {{ $labels.service }} {{ $labels.check }} is half down'
+
+  - alert: OpenstackDesignateDatapathFlapping
+    expr: changes(blackbox_datapath_status_gauge{service=~"designate"}[30m]) > 8
+    labels:
+      severity: warning
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-datapath-details
+      meta: 'Datapath {{ $labels.service }} {{ $labels.check }} is flapping for 30 minutes. See Sentry for details'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}/#{{ $labels.check }}'
+    annotations:
+      description: 'Datapath {{ $labels.service }} {{ $labels.check }} is flapping for 30 minutes. See Sentry for details'
+      summary: 'Datapath {{ $labels.service }} {{ $labels.check }} is flapping'

--- a/openstack/designate/alerts/unbound.alerts
+++ b/openstack/designate/alerts/unbound.alerts
@@ -1,0 +1,61 @@
+groups:
+- name: designate-unbound.alerts
+  rules:
+  - alert: OpenstackDesignateDnsBindDown
+    expr: max(bind_up) BY (region, kubernetes_name) < 1
+    for: 10m
+    labels:
+      context: bind
+      dashboard: designate-bind
+      meta: '{{ $labels.kubernetes_name }}'
+      service: designate
+      severity: critical
+      tier: os
+    annotations:
+      description: DNS Bind server {{ $labels.kubernetes_name }} down in region {{ $labels.region }}.
+      summary: DNS Bind server {{ $labels.kubernetes_name }} down.
+
+  - alert: OpenstackDesignateDnsUnboundEndpointNotAvailable
+    expr: max(kube_endpoint_address_available{namespace=~"dns-recursor"})by(region,endpoint) < 1
+    for: 15m
+    labels:
+      context: unbound
+      dashboard: designate-unbound
+      meta: '{{ $labels.endpoint }}'
+      service: designate
+      severity: warning
+      tier: os
+      playbook: 'docs/devops/alert/designate/#test_unbound_endpoint'
+    annotations:
+      description: 'DNS Unbound endpoint {{ $labels.endpoint }} not available in {{ $labels.region }} region.'
+      summary: 'DNS Unbound endpoint {{ $labels.endpoint }} is not available. DNS resolution might be handled by another region.'
+
+  - alert: OpenstackDesignateDnsUnbound1Down
+    expr: absent(unbound_time_up{kubernetes_name=~"unbound1"}) == 1
+    for: 60m
+    labels:
+      context: unbound
+      dashboard: designate-unbound
+      meta: unbound1
+      service: designate
+      severity: warning
+      tier: os
+      playbook: 'docs/devops/alert/designate/#test_unbound_endpoint'
+    annotations:
+      description: 'DNS Unbound1 recursor is down.'
+      summary: DNS Unbound1 recursor is down. DNS resolution might be handled by another region.
+
+  - alert: OpenstackDesignateDnsUnbound2Down
+    expr: absent(unbound_time_up{kubernetes_name=~"unbound2"}) == 1
+    for: 60m
+    labels:
+      context: unbound
+      dashboard: designate-unbound
+      meta: unbound2
+      service: designate
+      severity: warning
+      tier: os
+      playbook: 'docs/devops/alert/designate/#test_unbound_endpoint'
+    annotations:
+      description: 'DNS Unbound2 recursor is down.'
+      summary: DNS Unbound2 recursor is down. DNS resolution might be handled by another region.

--- a/openstack/designate/alerts/zone.alerts
+++ b/openstack/designate/alerts/zone.alerts
@@ -1,0 +1,30 @@
+groups:
+- name: designate-zone.alerts
+  rules:
+  - alert: OpenstackDesignateZoneError
+    expr: sum(sql_openstack_designate_zones{status="ERROR"}) BY (zone_name) > 0
+    for: 15m
+    labels:
+      context: zone_replication
+      dashboard: designate
+      meta: 'Designate zone {{ $labels.zone_name }} in Error State.'
+      service: designate
+      severity: info
+      tier: os
+    annotations:
+      description: '{{ $labels.zone_name }} in Error State.'
+      summary: Designate Zone in Error State
+
+  - alert: OpenstackDesignateMultipleZoneErrors
+    expr: sum(sql_openstack_designate_zones{status="ERROR"}) > 1
+    for: 5m
+    labels:
+      context: zone_replication
+      dashboard: designate
+      meta: '{{ $value }} Designate Zones in Error State.'
+      service: designate
+      severity: warning
+      tier: os
+    annotations:
+      description: '{{ $value }} Designate Zones in Error State.'
+      summary: Designate Zones in Error State

--- a/openstack/designate/templates/api-service.yaml
+++ b/openstack/designate/templates/api-service.yaml
@@ -10,7 +10,8 @@ metadata:
     component: api
   annotations:
     prometheus.io/scrape: "true"
-    prometheus.io/port: "{{.Values.global.designate_metrics_port}}"
+    prometheus.io/port: {{ required ".Values.global.designate_metrics_port missing" .Values.global.designate_metrics_port | quote }}
+    prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
 spec:
   selector:
     app: designate-api

--- a/openstack/designate/templates/prometheus-alerts.yaml
+++ b/openstack/designate/templates/prometheus-alerts.yaml
@@ -1,0 +1,20 @@
+{{- $values := .Values }}
+{{- if $values.alerts.enabled }}
+{{- range $path, $bytes := .Files.Glob "alerts/*.alerts" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: {{ printf "desginate-%s" $path | replace "/" "-" }}
+  labels:
+    app: designate
+    tier: os
+    type: alerting-rules
+    prometheus: {{ required ".Values.alerts.prometheus missing" $values.alerts.prometheus | quote }}
+
+spec:
+{{ printf "%s" $bytes | indent 2 }}
+
+{{- end }}
+{{- end }}

--- a/openstack/designate/values.yaml
+++ b/openstack/designate/values.yaml
@@ -207,3 +207,9 @@ rabbitmq_notifications:
 # openstack-watcher-middleware
 watcher:
   enabled: true
+
+# Deploy Designate Prometheus alerts.
+alerts:
+  enabled: true
+  # Name of the Prometheus to which the alerts should be assigned to.
+  prometheus: openstack


### PR DESCRIPTION
Move Designates [existing alerts](https://github.com/sapcc/helm-charts/blob/master/system/kube-monitoring/charts/prometheus-frontend/openstack-designate.alerts) to the PrometheusRule custom resource and adds the `prometheus.io/targets` annotation to the service. Validated manually.

Can you take a look @frr2018?