### PR TITLE
[Elektra] Move Prometheus alerts to CRD

### DIFF
--- a/openstack/elektra/alerts/api.alerts
+++ b/openstack/elektra/alerts/api.alerts
@@ -1,0 +1,46 @@
+groups:
+- name: api.alerts
+  rules:
+  - alert: OpenstackElektraPostgresDatabasesize
+    expr: max(pg_database_size_bytes{app="elektra-postgresql"}) BY (region) >= 8.589934592e+09
+    for: 3m
+    labels:
+      context: databasesize
+      dashboard: elektra-postgres-capacity
+      service: elektra
+      severity: warning
+      tier: os
+    annotations:
+      description: 'The database size for Elektra >= 8 Gb : {{ $value }} bytes.'
+      summary: Elektra Database size too large
+
+  - alert: OpenstackElektraApiDown
+    expr: blackbox_api_status_gauge{check=~"elektra"} == 1
+    for: 20m
+    labels:
+      severity: critical
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-blackbox-details
+      meta: '{{ $labels.check }} API is down. See Sentry for details.'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}/#{{ $labels.check }}'
+    annotations:
+      description: '{{ $labels.check }} API is down for 20 min. See Sentry for details.'
+      summary: '{{ $labels.check }} API down'
+
+  - alert: OpenstackElektraApiFlapping
+    expr: changes(blackbox_api_status_gauge{check=~"elektra"}[30m]) > 8
+    labels:
+      severity: warning
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-blackbox-details
+      meta: '{{ $labels.check }} API is flapping'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}/#{{ $labels.check }}'
+    annotations:
+      description: '{{ $labels.check }} API is flapping for 30 minutes.'
+      summary: '{{ $labels.check }} API flapping'

--- a/openstack/elektra/alerts/puma.alerts
+++ b/openstack/elektra/alerts/puma.alerts
@@ -1,0 +1,15 @@
+groups:
+- name: puma.alerts
+  rules:
+  - alert: OpenstackElektraPumaRequestBacklog
+    expr: sum(puma_request_backlog{name="elektra"}) BY (region) > 1
+    for: 3m
+    labels:
+      context: openstack
+      dashboard: elektra-details
+      service: elektra
+      severity: warning
+      tier: os
+    annotations:
+      description: 'Number of puma waiting requests for Elektra > 0 : {{ $value }}.'
+      summary: Elektra puma waiting requests

--- a/openstack/elektra/templates/deployment.yaml
+++ b/openstack/elektra/templates/deployment.yaml
@@ -21,6 +21,7 @@ spec:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9235"
+        prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
     spec:
       # The preStop hook below sleeps 30 seconds, extend the gracePeriod accordingly
       terminationGracePeriodSeconds: 60

--- a/openstack/elektra/templates/prometheus-alerts.yaml
+++ b/openstack/elektra/templates/prometheus-alerts.yaml
@@ -1,0 +1,20 @@
+{{- $values := .Values }}
+{{- if $values.alerts.enabled }}
+{{- range $path, $bytes := .Files.Glob "alerts/*.alerts" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: {{ printf "elektra-%s" $path | replace "/" "-" }}
+  labels:
+    app: elektra
+    tier: os
+    type: alerting-rules
+    prometheus: {{ required ".Values.alerts.prometheus missing" $values.alerts.prometheus | quote }}
+
+spec:
+{{ printf "%s" $bytes | indent 2 }}
+
+{{- end }}
+{{- end }}

--- a/openstack/elektra/templates/service.yaml
+++ b/openstack/elektra/templates/service.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "80"
+    prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
   name: elektra
 
 spec:

--- a/openstack/elektra/values.yaml
+++ b/openstack/elektra/values.yaml
@@ -38,3 +38,9 @@ ingress:
 #  ca: <your sso ca>
 tempest:
   enabled: false
+
+# Deploy Elektra Prometheus alerts.
+alerts:
+  enabled: true
+  # Name of the Prometheus to which the alerts should be assigned to.
+  prometheus: openstack


### PR DESCRIPTION
Move Elektras [existing alerts](https://github.com/sapcc/helm-charts/blob/master/system/kube-monitoring/charts/prometheus-frontend/openstack-elektra.alerts) to the PrometheusRule custom resource and adds the prometheus.io/targets annotation to the service, deployment.
Note that changing the annotation on the deployment causes a restart.
Validated manually.

LGTY @edda, @andypf?