### PR TITLE
Nanny alerts to PrometheusRule CRD

### DIFF
--- a/openstack/nannies/alerts/cinder/nanny-cinder.alerts
+++ b/openstack/nannies/alerts/cinder/nanny-cinder.alerts
@@ -1,0 +1,26 @@
+groups:
+- name: nanny-cinder.alerts
+  rules:
+  - alert: OpenstackCinderNannyVolumeWithoutValidProject
+    expr: sum(cinder_nanny_delete_volume{kind="plan"}) > 0
+    for: 5m
+    labels:
+      context: nanny
+      service: nanny
+      severity: info
+      tier: os
+    annotations:
+      description: The cinder-nanny discovered a volume without a valid project id - this should not happen and be investigated ...
+      summary: Cinder nanny detected a volume without a valid project id
+
+  - alert: OpenstackCinderNannySnapshotWithoutValidProject
+    expr: sum(cinder_nanny_delete_snapshot{kind="plan"}) > 0
+    for: 5m
+    labels:
+      context: nanny
+      service: nanny
+      severity: info
+      tier: os
+    annotations:
+      description: The cinder-nanny discovered a snapshot without a valid project id - this should not happen and be investigated ...
+      summary: Cinder nanny detected a snapshot without a valid project id

--- a/openstack/nannies/alerts/nova/nanny-nova.alerts
+++ b/openstack/nannies/alerts/nova/nanny-nova.alerts
@@ -1,0 +1,14 @@
+groups:
+- name: nanny-nova.alerts
+  rules:
+  - alert: OpenstackNovaNannyServerWithoutValidProject
+    expr: sum(nova_nanny_delete_server{kind="plan"}) > 0
+    for: 5m
+    labels:
+      context: nanny
+      service: nanny
+      severity: info
+      tier: os
+    annotations:
+      description: The nova-nanny discovered an instance without a valid project id - this should not happen and be investigated ...
+      summary: Nova nanny detected an instance without a valid project id

--- a/openstack/nannies/alerts/vcenter/nanny-vcenter.alerts
+++ b/openstack/nannies/alerts/vcenter/nanny-vcenter.alerts
@@ -1,0 +1,153 @@
+groups:
+- name: openstack-nanny.alerts
+  rules:
+  - alert: OpenstackVcenterNannyGhostVolume
+    expr: sum(vcenter_nanny_ghost_volumes) by (kubernetes_name) > 0
+    for: 5m
+    labels:
+      context: nanny
+      service: nanny
+      severity: ignore_info
+      tier: os
+    annotations:
+      description: "The {{ $labels.kubernetes_name }} discovered a ghost volume. a good opportunity to search for the underlying bug now ..."
+      summary: Vcenter nanny detected a ghost volume
+
+  - alert: OpenstackVcenterNannyVolumeAttachmentInconsistency
+    expr: sum(vcenter_nanny_volume_attachment_inconsistencies{region=~"staging|qa-de-1|ap-au-1|ap-ae-1|ap-jp-1|ap-jp-2|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-3"}) > 1000
+    for: 60m
+    labels:
+      context: nanny
+      service: nanny
+      severity: ignore_info
+      tier: os
+    annotations:
+      description: "The {{ $labels.kubernetes_name }} discovered a volume with an inconsistent state across nova, cinder and the vcenter - please ignore for now, inconsistencies are now primarily handled by the vcenter-nanny-consistency"
+      summary:  "The {{ $labels.kubernetes_name }} discovered a volume with an inconsistent state across nova, cinder and the vcenter - please ignore for now"
+
+  - alert: OpenstackVcenterNannyConsistencyVolumeAttachingForTooLong
+    expr: vcenter_nanny_consistency_cinder_volume_attaching_for_too_long > 0
+    for: 30m
+    labels:
+      context: nanny
+      service: nanny
+      severity: info
+      tier: os
+      playbook: 'docs/support/playbook/cinder/error_deleting.html'
+    annotations:
+      description: "The {{ $labels.kubernetes_name }} discovered a volume, which is for too long in the state 'attaching' - this problem should be gone automatically in the next nanny run"
+      summary: "The {{ $labels.kubernetes_name }} discovered a volume, which is for too long in the state 'attaching' - should fix itself"
+
+  - alert: OpenstackVcenterNannyConsistencyVolumeDetachingForTooLong
+    expr: vcenter_nanny_consistency_cinder_volume_detaching_for_too_long > 0
+    for: 30m
+    labels:
+      context: nanny
+      service: nanny
+      severity: info
+      tier: os
+      playbook: 'docs/support/playbook/cinder/error_deleting.html'
+    annotations:
+      description: "The {{ $labels.kubernetes_name }} discovered a volume, which is for too long in the state 'detaching' - this problem should be gone automatically in the next nanny run"
+      summary: "The {{ $labels.kubernetes_name }} discovered a volume, which is for too long in the state 'detaching' - should fix itself"
+
+  - alert: OpenstackVcenterNannyConsistencyVolumeCreatingForTooLong
+    expr: vcenter_nanny_consistency_cinder_volume_creating_for_too_long > 0
+    for: 30m
+    labels:
+      context: nanny
+      service: nanny
+      severity: info
+      tier: os
+      playbook: 'docs/support/playbook/cinder/error_deleting.html'
+    annotations:
+      description: "The {{ $labels.kubernetes_name }} discovered a volume, which is for too long in the state 'creating' - this problem should be gone automatically in the next nanny run"
+      summary: "The {{ $labels.kubernetes_name }} discovered a volume, which is for too long in the state 'creating' - should fix itself"
+
+  - alert: OpenstackVcenterNannyConsistencyVolumeDeletingForTooLong
+    expr: vcenter_nanny_consistency_cinder_volume_deleting_for_too_long > 0
+    for: 30m
+    labels:
+      context: nanny
+      service: nanny
+      severity: info
+      tier: os
+      playbook: 'docs/support/playbook/cinder/error_deleting.html'
+    annotations:
+      description: "The {{ $labels.kubernetes_name }} discovered a volume, which is for too long in the state 'deleting' - this problem should be gone automatically in the next nanny run"
+      summary: "The {{ $labels.kubernetes_name }} discovered a volume, which is for too long in the state 'deleting' - should fix itself"
+
+  - alert: OpenstackVcenterNannyConsistencyVolumeIsInStateReserved
+    expr: vcenter_nanny_consistency_cinder_volume_is_in_state_reserved > 0
+    for: 30m
+    labels:
+      context: nanny
+      service: nanny
+      severity: info
+      tier: os
+      playbook: 'docs/support/playbook/cinder/error_deleting.html'
+    annotations:
+      description: "The {{ $labels.kubernetes_name }} discovered a volume, which is for too long in the state 'reserved' - this problem should be gone automatically in the next nanny run"
+      summary: "The {{ $labels.kubernetes_name }} discovered a volume, which is for too long in the state 'reserved' - should fix itself"
+
+  - alert: OpenstackVcenterNannyConsistencyVolumeAvailableWithAttachments
+    expr: vcenter_nanny_consistency_cinder_volume_available_with_attachments > 0
+    for: 30m
+    labels:
+      context: nanny
+      service: nanny
+      severity: info
+      tier: os
+      playbook: 'docs/support/playbook/cinder/error_deleting.html'
+    annotations:
+      description: "The {{ $labels.kubernetes_name }} discovered a volume, which is for too long in the state 'available' with attachments - this problem should be gone automatically in the next nanny run"
+      summary: "The {{ $labels.kubernetes_name }} discovered a volume, which is for too long in the state 'available' with attachments - should fix itself"
+
+  - alert: OpenstackVcenterNannyConsistencyVolumeInUseWithoutSomeAttachments
+    expr: vcenter_nanny_consistency_cinder_volume_in_use_without_some_attachments > 0
+    for: 30m
+    labels:
+      context: nanny
+      service: nanny
+      severity: info
+      tier: os
+    annotations:
+      description: "The {{ $labels.kubernetes_name }} discovered a volume, which is for too long in the state 'in-use' with some attachments missing - this should be investigated ..."
+      summary: "The {{ $labels.kubernetes_name }} discovered a volume, which is for too long in the state 'in-use' with some attachments missing - should be investigated ..."
+
+  - alert: OpenstackVcenterNannyConsistencyVolumeInUseWithoutAttachments
+    expr: vcenter_nanny_consistency_cinder_volume_in_use_without_attachments > 0
+    for: 30m
+    labels:
+      context: nanny
+      service: nanny
+      severity: info
+      tier: os
+      playbook: 'docs/support/playbook/cinder/error_deleting.html'
+    annotations:
+      description: "The {{ $labels.kubernetes_name }} discovered a volume, which is for too long in the state 'in-use' with all attachments missing - this problem should be gone automatically in the next nanny run"
+      summary: "The {{ $labels.kubernetes_name }} discovered a volume, which is for too long in the state 'in-use' with some attachments missing - should fix itself"
+
+  - alert: OpenstackVcenterNannyConsistencyTooMuchToFix
+    expr: vcenter_nanny_consistency_cinder_volume_attachment_fix_count > vcenter_nanny_consistency_cinder_volume_attachment_max_fix_count
+    for: 30m
+    labels:
+      context: nanny
+      service: nanny
+      severity: info
+      tier: os
+    annotations:
+      description: "The {{ $labels.kubernetes_name }} denied to fix some problems as there are too many of them - this should be investigated ..."
+      summary: "The {{ $labels.kubernetes_name }} denied to fix some problems - should be investigated ..."
+
+  - alert: OpenstackVcenterNannyConsistencyTooMuchToFixByHand
+    expr: sum(vcenter_nanny_consistency_cinder_volume_in_use_without_some_attachments) > vcenter_nanny_consistency_cinder_volume_attachment_max_fix_count
+    for: 30m
+    labels:
+      context: nanny
+      service: nanny
+      severity: info
+      tier: os
+    annotations:
+      description: "The {{ $labels.kubernetes_name }} found a lot of problems which will have to be fixed by hand - this should be investigated ..."
+      summary: "The {{ $labels.kubernetes_name }} lots of problems to manually fix - should be investigated ..."

--- a/openstack/nannies/templates/_neutron-nanny-service.yaml
+++ b/openstack/nannies/templates/_neutron-nanny-service.yaml
@@ -11,6 +11,7 @@ metadata:
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "9456"
+    prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
 spec:
   selector:
     component: neutron-nanny

--- a/openstack/nannies/templates/cinder-nanny-service.yaml
+++ b/openstack/nannies/templates/cinder-nanny-service.yaml
@@ -11,6 +11,7 @@ metadata:
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "9456"
+    prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
 spec:
   selector:
     component: cinder-nanny

--- a/openstack/nannies/templates/nova-nanny-service.yaml
+++ b/openstack/nannies/templates/nova-nanny-service.yaml
@@ -11,6 +11,7 @@ metadata:
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "9456"
+    prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
 spec:
   selector:
     component: nova-nanny

--- a/openstack/nannies/templates/prometheus-alerts.yaml
+++ b/openstack/nannies/templates/prometheus-alerts.yaml
@@ -1,0 +1,66 @@
+{{- $values := .Values }}
+{{- if $values.alerts.enabled }}
+
+# Check cinder nanny alerts
+{{- if $values.cinder_nanny.enabled}}
+{{- range $path, $bytes := .Files.Glob "alerts/cinder/*.alerts" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: {{ printf "%s" $path | replace "/" "-" }}
+  labels:
+    app: cinder-nanny
+    tier: os
+    type: alerting-rules
+    prometheus: {{ required ".Values.alerts.prometheus missing" $values.alerts.prometheus }}
+
+spec:
+{{ printf "%s" $bytes | indent 2 }}
+
+{{- end }}
+{{- end }}
+
+# Check nova nanny alerts.
+{{- if $values.nova_nanny.enabled}}
+{{- range $path, $bytes := .Files.Glob "alerts/nova/*.alerts" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: {{ printf "%s" $path | replace "/" "-" }}
+  labels:
+    app: cinder-nanny
+    tier: os
+    type: alerting-rules
+    prometheus: {{ required ".Values.alerts.prometheus missing" $values.alerts.prometheus }}
+
+spec:
+{{ printf "%s" $bytes | indent 2 }}
+
+{{- end }}
+{{- end }}
+
+# Check Vcenter nanny alerts.
+{{- if $values.vcenter_nanny.enabled}}
+{{- range $path, $bytes := .Files.Glob "alerts/vcenter/*.alerts" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: {{ printf "%s" $path | replace "/" "-" }}
+  labels:
+    app: cinder-nanny
+    tier: os
+    type: alerting-rules
+    prometheus: {{ required ".Values.alerts.prometheus missing" $values.alerts.prometheus }}
+
+spec:
+{{ printf "%s" $bytes | indent 2 }}
+
+{{- end }}
+{{- end }}
+{{- end }}

--- a/openstack/nannies/templates/vcenter-nanny-consistency-service.yaml
+++ b/openstack/nannies/templates/vcenter-nanny-consistency-service.yaml
@@ -17,6 +17,7 @@ template: |{{`
     annotations:
       prometheus.io/scrape: "true"
       prometheus.io/port: "9456"
+      prometheus.io/targets: "openstack"
   spec:
     selector:
       component: vcenter-nanny-consistency-{{ name }}

--- a/openstack/nannies/templates/vcenter-nanny-service.yaml
+++ b/openstack/nannies/templates/vcenter-nanny-service.yaml
@@ -17,6 +17,7 @@ template: |{{`
     annotations:
       prometheus.io/scrape: "true"
       prometheus.io/port: "9456"
+      prometheus.io/targets: "openstack"
   spec:
     selector:
       component: vcenter-nanny-{{ name }}

--- a/openstack/nannies/values.yaml
+++ b/openstack/nannies/values.yaml
@@ -188,3 +188,9 @@ manila_nanny:
     dry_run: true
   netapp:
     interval: 240
+
+# Deploy Nanny Prometheus alerts.
+alerts:
+  enabled: true
+  # Name of the Prometheus to which the alerts should be assigned to.
+  prometheus: openstack


### PR DESCRIPTION
Move Nanny [existing alerts](https://github.com/sapcc/helm-charts/blob/master/system/kube-monitoring/charts/prometheus-frontend/openstack-nanny.alerts) to the PrometheusRule custom resource and adds the prometheus.io/targets annotation to the service.

EDIT: In the CI the nanny should check if the alerts are valid. See other pipelines for inspiration. It's basically just a `promtool check rules alerts/**/*.alerts`

Please make any changes you need @thgrs.