### PR TITLE
[Neutron] Move Prometheus alerts to CRD

### DIFF
--- a/openstack/neutron/alerts/api.alerts
+++ b/openstack/neutron/alerts/api.alerts
@@ -1,0 +1,33 @@
+groups:
+- name: neutron-api.alerts
+  rules:
+  - alert: OpenstackNeutronApiDown
+    expr: blackbox_api_status_gauge{check=~"neutron"} == 1
+    for: 20m
+    labels:
+      severity: critical
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-blackbox-details
+      meta: '{{ $labels.check }} API is down. See Sentry for details.'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}/#{{ $labels.check }}'
+    annotations:
+      description: '{{ $labels.check }} API is down for 20 min. See Sentry for details.'
+      summary: '{{ $labels.check }} API down'
+
+  - alert: OpenstackNeutronApiFlapping
+    expr: changes(blackbox_api_status_gauge{check=~"neutron"}[30m]) > 8
+    labels:
+      severity: critical
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-blackbox-details
+      meta: '{{ $labels.check }} API is flapping'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}/#{{ $labels.check }}'
+    annotations:
+      description: '{{ $labels.check }} API is flapping for 30 minutes.'
+      summary: '{{ $labels.check }} API flapping'

--- a/openstack/neutron/alerts/canary.alerts
+++ b/openstack/neutron/alerts/canary.alerts
@@ -1,0 +1,49 @@
+groups:
+- name: neutron-canary.alerts
+  rules:
+  - alert: OpenstackNeutronCanaryDown
+    expr: blackbox_canary_status_gauge{service=~"neutron"} == 1
+    for: 1h
+    labels:
+      severity: warning
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-canary-details
+      meta: 'Canary {{ $labels.service }} {{ $labels.check }} is down for 1 hour. See Sentry for details'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}'
+    annotations:
+      description: 'Canary {{ $labels.service }} {{ $labels.check }} is down for 1 hour. See Sentry for details'
+      summary: 'Canary {{ $labels.service }} {{ $labels.check }} is down'
+
+  - alert: OpenstackNeutronCanaryTimeout
+    expr: blackbox_canary_status_gauge{service=~"neutron"} == 0.5
+    for: 1h
+    labels:
+      severity: info
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-canary-details
+      meta: 'Canary {{ $labels.service }} {{ $labels.check }} is timing out for 1 hour. See Sentry for details'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}'
+    annotations:
+      description: 'Canary {{ $labels.service }} {{ $labels.check }} is timing out for 1 hour. See Sentry for details'
+      summary: 'Canary {{ $labels.service }} {{ $labels.check }} is timing out'
+
+  - alert: OpenstackNeutronCanaryFlapping
+    expr: changes(blackbox_canary_status_gauge{service=~"neutron"}[2h]) > 8
+    labels:
+      severity: warning
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-canary-details
+      meta: 'Canary {{ $labels.service }} {{ $labels.check }} is flapping for 2 hours. See Sentry for details'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}'
+    annotations:
+      description: 'Canary {{ $labels.service }} {{ $labels.check }} is flapping for 2 hours. See Sentry for details'
+      summary: 'Canary {{ $labels.service }} {{ $labels.check }} is flapping'

--- a/openstack/neutron/alerts/datapath.alerts
+++ b/openstack/neutron/alerts/datapath.alerts
@@ -1,0 +1,49 @@
+groups:
+- name: neutron-datapath.alerts
+  rules:
+  - alert: OpenstackNeutronDatapathDown
+    expr: blackbox_datapath_status_gauge{service=~"neutron"} == 1
+    for: 15m
+    labels:
+      severity: critical
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-datapath-details
+      meta: 'Datapath {{ $labels.service }} {{ $labels.check }} is down for 15 minutes. See Sentry for details'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}/#{{ $labels.check }}'
+    annotations:
+      description: 'Datapath {{ $labels.service }} {{ $labels.check }} is down for 15 minutes. See Sentry for details'
+      summary: 'Datapath {{ $labels.service }} {{ $labels.check }} is down'
+
+  - alert: OpenstackNeutronDatapathHalfDown
+    expr: blackbox_datapath_status_gauge{service=~"neutron"} == 0.5
+    for: 15m
+    labels:
+      severity: critical
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-datapath-details
+      meta: 'Datapath {{ $labels.service }} {{ $labels.check }} is half down for 15 minutes. See Sentry for details'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}/#{{ $labels.check }}'
+    annotations:
+      description: 'Datapath {{ $labels.service }} {{ $labels.check }} is half down for 15 minutes. See Sentry for details'
+      summary: 'Datapath {{ $labels.service }} {{ $labels.check }} is half down'
+
+  - alert: OpenstackNeutronDatapathFlapping
+    expr: changes(blackbox_datapath_status_gauge{service=~"neutron"}[30m]) > 8
+    labels:
+      severity: warning
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-datapath-details
+      meta: 'Datapath {{ $labels.service }} {{ $labels.check }} is flapping for 30 minutes. See Sentry for details'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}/#{{ $labels.check }}'
+    annotations:
+      description: 'Datapath {{ $labels.service }} {{ $labels.check }} is flapping for 30 minutes. See Sentry for details'
+      summary: 'Datapath {{ $labels.service }} {{ $labels.check }} is flapping'

--- a/openstack/neutron/alerts/neutron.alerts
+++ b/openstack/neutron/alerts/neutron.alerts
@@ -1,0 +1,93 @@
+groups:
+- name: neutron.alerts
+  rules:
+  - alert: OpenstackNeutronIntegrityOutOfFIPs
+    expr: blackbox_integrity_status_gauge{context="Floating-IP"} == 1
+    for: 15m
+    labels:
+      severity: info
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.context }}'
+      meta: 'Floating IPs network: {{ $labels.check }} exhausted soon'
+      sentry: blackbox/?query=test_{{ $labels.check }}
+      playbook: docs/support/playbook/neutron/fip_exhausted.html
+    annotations:
+      description: 'The Floating IPs on {{ $labels.check }} might
+        get exhausted soon as utilized more than 90% of fips. This is heads up
+        to check the current FIPs network situation and add new subnet to network soon'
+      summary: Floating IPs possibly soon exhausted
+
+  - alert: OpenstackNeutronPredictOutOfFIP
+    expr: predict_linear(snmp_asr_cnatAddrBindNumberOfEntries[1d], 3600 * 24 * 4) > 800
+    for: 10m
+    labels:
+      context: floatingip
+      dashboard: maia-asr-info
+      service: neutron
+      severity: warning
+      tier: os
+    annotations:
+      description: 'STILL IN TEST MODE: The Floating IP''s on {{ $labels.job }} might
+        possibly get exhausted soon. This is not an exact warning, but a heads up
+        to check the current FIP situation.'
+      summary: 'STILL IN TEST MODE: Floating IP''s possibly soon exhausted'
+
+  - alert: OpenstackNeutronDhcpAgentLostNetworks
+    expr: blackbox_integrity_status_gauge{check=~"dhcp_agent-.+"} == 1
+    for: 15m
+    labels:
+      severity: warning
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.context }}'
+      meta: 'DHCP agent has less subnets than subnets with dhcp enabled: {{ $labels.check }}'
+      sentry: blackbox/?query=test_{{ $labels.check }}
+      playbook: docs/support/playbook/neutron/dhcp_down.html
+    annotations:
+      description: 'DHCP agent has less subnets than subnets with dhcp enabled for 15 min: {{ $labels.check }}'
+      summary: Openstack Neutron DHCP Agent lost private networks
+
+  - alert: OpenstackNeutronMonitorAgentHeartbeat
+    expr: max(openstack_neutron_monitor_agents_heartbeat_seconds) by (agent_type) > 75
+    for: 10m
+    labels:
+      context: Agent Heartbeat
+      dashboard: Neutron
+      service: Neutron
+      severity: warning
+      tier: os
+      meta: 'Agent {{ $labels.agent_type }} Heartbeat is above 75secs in {{ $labels.host }}'
+      playbook: docs/support/playbook/neutron/agent_heartbeat.html
+    annotations:
+      description: Agent {{ $labels.agent_type }} Heartbeat is above 75secs in {{ $labels.host }}
+      summary: Openstack Neutron Metric to monitor Agents Heartbeat
+
+  - alert: OpenstackNeutronNetworkCountAsync
+    expr: kube_pod_container_status_ready{container="neutron-dhcp-agent"} == 0
+    for: 5m
+    labels:
+      severity: warning
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.context }}'
+      meta: 'Not all networks have been synced by agent: {{ $labels.pod }}'
+      playbook: docs/support/playbook/neutron/dhcp_down.html
+    annotations:
+      description: 'Not all networks have been synced by agent for 5 min: {{ $labels.pod }}'
+      summary: Openstack Neutron DHCP Agent lost private networks
+
+  - alert: OpenstackNeutronWaitingDatabaseConnections
+    expr: sum by (application) (pgbouncer_pools_client_waiting_connections{application=~"neutron"}) > 10
+    for: 15m
+    labels:
+      severity: info
+      tier: os
+      service: '{{ $labels.application }}'
+      context: '{{ $labels.application }}'
+      dashboard: pgbouncer
+      meta: '{{ $labels.application }} has waiting database connections for 15 min'
+#      playbook: 'docs/devops/alert/{{ $labels.application }}'
+    annotations:
+      description: '{{ $labels.application }} has more than 10 waiting database connections for 15 min, please check pgbouncer logs'
+      summary: '{{ $labels.application }} waiting db connections'

--- a/openstack/neutron/templates/asr_config_agents/_deployment-asr1k.yaml.tpl
+++ b/openstack/neutron/templates/asr_config_agents/_deployment-asr1k.yaml.tpl
@@ -32,6 +32,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{$context.Values.port_l3_metrics |  default 9103}}"
         prometheus.io/port_1: "{{$context.Values.port_l2_metrics |  default 9102}}"
+        prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" $context.Values.alerts.prometheus | quote }}
     spec:
       {{- if ge $context.Capabilities.KubeVersion.Minor "7" }}
       hostname:  {{ $config_agent.hostname }}

--- a/openstack/neutron/templates/asr_config_agents/_deployment-asr1k.yaml.tpl
+++ b/openstack/neutron/templates/asr_config_agents/_deployment-asr1k.yaml.tpl
@@ -30,8 +30,8 @@ spec:
       annotations:
         pod.beta.kubernetes.io/hostname:  {{ $config_agent.hostname }}
         prometheus.io/scrape: "true"
-        prometheus.io/port: "{{$context.Values.port_l3_metrics |  default 9103}}"
-        prometheus.io/port_1: "{{$context.Values.port_l2_metrics |  default 9102}}"
+        prometheus.io/port: "{{$context.Values.l3_port_metrics |  default 9103}}"
+        prometheus.io/port_1: "{{$context.Values.l2_port_metrics |  default 9102}}"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" $context.Values.alerts.prometheus | quote }}
     spec:
       {{- if ge $context.Capabilities.KubeVersion.Minor "7" }}

--- a/openstack/neutron/templates/deployment-secgroup-entanglement-exporter.yaml
+++ b/openstack/neutron/templates/deployment-secgroup-entanglement-exporter.yaml
@@ -23,6 +23,7 @@ spec:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9102"
+        prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
     spec:
       containers:
         - name: exporter

--- a/openstack/neutron/templates/nanny-service.yaml
+++ b/openstack/neutron/templates/nanny-service.yaml
@@ -11,6 +11,7 @@ metadata:
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "9456"
+    prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
 spec:
   selector:
     component: neutron-nanny

--- a/openstack/neutron/templates/prometheus-alerts.yaml
+++ b/openstack/neutron/templates/prometheus-alerts.yaml
@@ -1,0 +1,20 @@
+{{- $values := .Values }}
+{{- if $values.alerts.enabled }}
+{{- range $path, $bytes := .Files.Glob "alerts/*.alerts" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: {{ printf "neutron-%s" $path | replace "/" "-" }}
+  labels:
+    app: neutron
+    tier: os
+    type: alerting-rules
+    prometheus: {{ required ".Values.alerts.prometheus missing" $values.alerts.prometheus | quote }}
+
+spec:
+{{ printf "%s" $bytes | indent 2 }}
+
+{{- end }}
+{{- end }}

--- a/openstack/neutron/templates/service-server.yaml
+++ b/openstack/neutron/templates/service-server.yaml
@@ -10,7 +10,8 @@ metadata:
   annotations:
     prometheus.io/scrape: "true"
     maia.io/scrape: "true"
-    prometheus.io/port: "{{.Values.port_metrics}}"
+    prometheus.io/port: {{ required ".Values.port_metrics missing" .Values.port_metrics | quote }}
+    prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
 spec:
   selector:
     name: neutron-server

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -375,3 +375,9 @@ nanny:
 
 unittest:
   enabled: false
+
+# Deploy Neutron Prometheus alerts.
+alerts:
+  enabled: true
+  # Name of the Prometheus to which the alerts should be assigned to.
+  prometheus: openstack


### PR DESCRIPTION
Move Neutrons [existing alerts](https://github.com/sapcc/helm-charts/blob/master/system/kube-monitoring/charts/prometheus-frontend/openstack-neutron.alerts) to the PrometheusRule custom resource and adds the prometheus.io/targets annotation to the service. Validated manually.

Also fix naming of values in [asr1k deployment](https://github.com/sapcc/helm-charts/compare/neutron-alerts?expand=1#diff-7c604d3458cf5b88c166956f9a1f6e5d).

LGTY @abattye @notandy? 