### PR TITLE
[Billing] Move Prometheus alerts to CRD

### DIFF
--- a/openstack/billing/alerts/api.alerts
+++ b/openstack/billing/alerts/api.alerts
@@ -1,0 +1,33 @@
+groups:
+- name: openstack-billing.alerts
+  rules:
+  - alert: OpenstackBillingApiDown
+    expr: blackbox_api_status_gauge{check=~"billing"} == 1
+    for: 20m
+    labels:
+      severity: critical
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-blackbox-details
+      meta: '{{ $labels.check }} API is down. See Sentry for details.'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}/#{{ $labels.check }}'
+    annotations:
+      description: '{{ $labels.check }} API is down for 20 min. See Sentry for details.'
+      summary: '{{ $labels.check }} API down'
+
+  - alert: OpenstackBillingApiFlapping
+    expr: changes(blackbox_api_status_gauge{check=~"billing"}[30m]) > 8
+    labels:
+      severity: warning
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-blackbox-details
+      meta: '{{ $labels.check }} API is flapping'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}/#{{ $labels.check }}'
+    annotations:
+      description: '{{ $labels.check }} API is flapping for 30 minutes.'
+      summary: '{{ $labels.check }} API flapping'

--- a/openstack/billing/templates/prometheus-alerts.yaml
+++ b/openstack/billing/templates/prometheus-alerts.yaml
@@ -1,0 +1,20 @@
+{{- $values := .Values }}
+{{- if $values.alerts.enabled }}
+{{- range $path, $bytes := .Files.Glob "alerts/*.alerts" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: {{ printf "billing-%s" $path | replace "/" "-" }}
+  labels:
+    app: billing
+    tier: os
+    type: alerting-rules
+    prometheus: {{ required ".Values.alerts.prometheus missing" $values.alerts.prometheus }}
+
+spec:
+{{ printf "%s" $bytes | indent 2 }}
+
+{{- end }}
+{{- end }}

--- a/openstack/billing/values.yaml
+++ b/openstack/billing/values.yaml
@@ -12,3 +12,9 @@ cc3testBillingDomainAdmUser: DEFINE_IN_REGION_VALUES
 cc3testBillingDomainUsrUser: DEFINE_IN_REGION_VALUES
 cc3testBillingProjectAdmUser: DEFINE_IN_REGION_VALUES
 cc3testBillingProjectUsrUser: DEFINE_IN_REGION_VALUES
+
+# Deploy Billing Prometheus alerts.
+alerts:
+  enabled: true
+  # Name of the Prometheus to which the alerts should be assigned to.
+  prometheus: openstack


### PR DESCRIPTION
Move Billing [existing alerts](https://github.com/sapcc/helm-charts/blob/master/system/kube-monitoring/charts/prometheus-frontend/openstack-billing.alerts) to the PrometheusRule custom resource. Validated manually.