### PR TITLE
[Arc] Move Prometheus alerts to CRD

### DIFF
--- a/openstack/arc/alerts/api.alerts
+++ b/openstack/arc/alerts/api.alerts
@@ -1,0 +1,33 @@
+groups:
+- name: openstack-arc.alerts
+  rules:
+  - alert: OpenstackArcApiDown
+    expr: blackbox_api_status_gauge{check=~"arc"} == 1
+    for: 20m
+    labels:
+      severity: critical
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-blackbox-details
+      meta: '{{ $labels.check }} API is down. See Sentry for details.'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}/#{{ $labels.check }}'
+    annotations:
+      description: '{{ $labels.check }} API is down for 20 min. See Sentry for details.'
+      summary: '{{ $labels.check }} API down'
+
+  - alert: OpenstackArcApiFlapping
+    expr: changes(blackbox_api_status_gauge{check=~"arc"}[30m]) > 8
+    labels:
+      severity: warning
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-blackbox-details
+      meta: '{{ $labels.check }} API is flapping'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}/#{{ $labels.check }}'
+    annotations:
+      description: '{{ $labels.check }} API is flapping for 30 minutes.'
+      summary: '{{ $labels.check }} API flapping'

--- a/openstack/arc/alerts/canary.alerts
+++ b/openstack/arc/alerts/canary.alerts
@@ -1,0 +1,49 @@
+groups:
+- name: openstack-arc.alerts
+  rules:
+  - alert: OpenstackArcCanaryDown
+    expr: blackbox_canary_status_gauge{service=~"arc"} == 1
+    for: 1h
+    labels:
+      severity: warning
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-canary-details
+      meta: 'Canary {{ $labels.service }} {{ $labels.check }} is down for 1 hour. See Sentry for details'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}'
+    annotations:
+      description: 'Canary {{ $labels.service }} {{ $labels.check }} is down for 1 hour. See Sentry for details'
+      summary: 'Canary {{ $labels.service }} {{ $labels.check }} is down'
+
+  - alert: OpenstackArcCanaryTimeout
+    expr: blackbox_canary_status_gauge{service=~"arc"} == 0.5
+    for: 1h
+    labels:
+      severity: info
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-canary-details
+      meta: 'Canary {{ $labels.service }} {{ $labels.check }} is timing out for 1 hour. See Sentry for details'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}'
+    annotations:
+      description: 'Canary {{ $labels.service }} {{ $labels.check }} is timing out for 1 hour. See Sentry for details'
+      summary: 'Canary {{ $labels.service }} {{ $labels.check }} is timing out'
+
+  - alert: OpenstackArcCanaryFlapping
+    expr: changes(blackbox_canary_status_gauge{service=~"arc"}[2h]) > 8
+    labels:
+      severity: warning
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-canary-details
+      meta: 'Canary {{ $labels.service }} {{ $labels.check }} is flapping for 2 hours. See Sentry for details'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}'
+    annotations:
+      description: 'Canary {{ $labels.service }} {{ $labels.check }} is flapping for 2 hours. See Sentry for details'
+      summary: 'Canary {{ $labels.service }} {{ $labels.check }} is flapping'

--- a/openstack/arc/alerts/postgres.alerts
+++ b/openstack/arc/alerts/postgres.alerts
@@ -1,0 +1,15 @@
+groups:
+- name: openstack-arc.alerts
+  rules:
+  - alert: OpenstackArcPostgresDatabasesize
+    expr: max(pg_database_size_bytes{app="arc-postgresql"}) >= 4.294967296e+10
+    for: 3m
+    labels:
+      context: databasesize
+      dashboard: arc-postgres-capacity
+      service: arc
+      severity: warning
+      tier: os
+    annotations:
+      description: 'The database size for Arc >= 40 Gb : {{ $value }} bytes.'
+      summary: Arc Database size too large

--- a/openstack/arc/charts/mosquitto/templates/service.yaml
+++ b/openstack/arc/charts/mosquitto/templates/service.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "{{ .Values.metrics.port }}"
+    prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
 {{- end }}
 spec:
   type: {{ .Values.service.type }}

--- a/openstack/arc/charts/postgresql/templates/svc.yaml
+++ b/openstack/arc/charts/postgresql/templates/svc.yaml
@@ -11,6 +11,7 @@ metadata:
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "9187"
+    prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
 {{- end }}
 spec:
   ports:
@@ -35,6 +36,7 @@ metadata:
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "9188"
+    prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
 spec:
   clusterIP: None
   ports:

--- a/openstack/arc/templates/api-service.yaml
+++ b/openstack/arc/templates/api-service.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "{{ .Values.api.service.internalPort }}"
+    prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 spec:

--- a/openstack/arc/templates/prometheus-alerts.yaml
+++ b/openstack/arc/templates/prometheus-alerts.yaml
@@ -1,0 +1,20 @@
+{{- $values := .Values }}
+{{- if $values.alerts.enabled }}
+{{- range $path, $bytes := .Files.Glob "alerts/*.alerts" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: {{ printf "arc-%s" $path | replace "/" "-" }}
+  labels:
+    app: arc
+    tier: os
+    type: alerting-rules
+    prometheus: {{ required ".Values.alerts.prometheus missing" $values.alerts.prometheus }}
+
+spec:
+{{ printf "%s" $bytes | indent 2 }}
+
+{{- end }}
+{{- end }}

--- a/openstack/arc/values.yaml
+++ b/openstack/arc/values.yaml
@@ -58,3 +58,16 @@ postgresql:
               usage: LABEL
           - os:
               usage: LABEL
+
+  alerts:
+    prometheus: openstack
+
+mosquitto:
+  alerts:
+    prometheus: openstack
+
+# Deploy Arc Prometheus alerts.
+alerts:
+  enabled: true
+  # Name of the Prometheus to which the alerts should be assigned to.
+  prometheus: openstack


### PR DESCRIPTION
Move Arcs [existing alerts](https://github.com/sapcc/helm-charts/blob/master/system/kube-monitoring/charts/prometheus-frontend/openstack-arc.alerts) to the PrometheusRule custom resource and adds the prometheus.io/targets annotation to the services. Validated manually.

While @databus23 is on vacation: Can you take a look @ArtieReus?