### PR TITLE
[Lyra] Move Prometheus alerts to CRD

### DIFF
--- a/openstack/lyra/alerts/lyra.alerts
+++ b/openstack/lyra/alerts/lyra.alerts
@@ -1,0 +1,58 @@
+groups:
+- name: lyra.alerts
+  rules:
+  - alert: OpenstackLyraPostgresDatabasesize
+    expr: max(pg_database_size_bytes{app="lyra-postgresql"}) >= 8.589934592e+09
+    for: 3m
+    labels:
+      context: databasesize
+      dashboard: lyra-postgres-capacity
+      service: lyra
+      severity: warning
+      tier: os
+    annotations:
+      description: 'The database size for Lyra >= 8 Gb : {{ $value }} bytes.'
+      summary: Lyra Database size too large
+
+  - alert: OpenstackLyraPumaRequestBacklog
+    expr: sum(puma_request_backlog{app="lyra-api"}) > 1
+    for: 3m
+    labels:
+      context: pumarequestbacklog
+      dashboard: lyra-api-details
+      service: lyra
+      severity: warning
+    annotations:
+      description: 'Number of puma waiting requests for Lyra > 0 : {{ $value }}.'
+      summary: Lyra puma waiting requests
+
+  - alert: OpenstackLyraApiDown
+    expr: blackbox_api_status_gauge{check=~"lyra"} == 1
+    for: 20m
+    labels:
+      severity: critical
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-blackbox-details
+      meta: '{{ $labels.check }} API is down. See Sentry for details.'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}/#{{ $labels.check }}'
+    annotations:
+      description: '{{ $labels.check }} API is down for 20 min. See Sentry for details.'
+      summary: '{{ $labels.check }} API down'
+
+  - alert: OpenstackLyraApiFlapping
+    expr: changes(blackbox_api_status_gauge{check=~"lyra"}[30m]) > 8
+    labels:
+      severity: warning
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-blackbox-details
+      meta: '{{ $labels.check }} API is flapping'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}/#{{ $labels.check }}'
+    annotations:
+      description: '{{ $labels.check }} API is flapping for 30 minutes.'
+      summary: '{{ $labels.check }} API flapping'

--- a/openstack/lyra/charts/postgresql/templates/svc.yaml
+++ b/openstack/lyra/charts/postgresql/templates/svc.yaml
@@ -11,6 +11,7 @@ metadata:
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "9187"
+    prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
 {{- end }}
 spec:
   ports:
@@ -35,6 +36,7 @@ metadata:
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "9188"
+    prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
 spec:
   clusterIP: None
   ports:

--- a/openstack/lyra/templates/api-deployment.yaml
+++ b/openstack/lyra/templates/api-deployment.yaml
@@ -24,6 +24,7 @@ spec:
         checksum/secrets: {{ include (print $.Template.BasePath  "/secrets.yaml") . | sha256sum }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "9235"
+        prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
     spec:
       containers:
         - name: api

--- a/openstack/lyra/templates/prometheus-alerts.yaml
+++ b/openstack/lyra/templates/prometheus-alerts.yaml
@@ -1,0 +1,20 @@
+{{- $values := .Values }}
+{{- if $values.alerts.enabled }}
+{{- range $path, $bytes := .Files.Glob "alerts/*.alerts" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: {{ printf "lyra-%s" $path | replace "/" "-" }}
+  labels:
+    app: lyra
+    tier: os
+    type: alerting-rules
+    prometheus: {{ required ".Values.alerts.prometheus missing" $values.alerts.prometheus }}
+
+spec:
+{{ printf "%s" $bytes | indent 2 }}
+
+{{- end }}
+{{- end }}

--- a/openstack/lyra/templates/service.yaml
+++ b/openstack/lyra/templates/service.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "{{ .Values.service.internalPort }}"
+    prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 spec:

--- a/openstack/lyra/templates/worker-deployment.yaml
+++ b/openstack/lyra/templates/worker-deployment.yaml
@@ -22,6 +22,7 @@ spec:
         checksum/secrets: {{ include (print $.Template.BasePath  "/secrets.yaml") . | sha256sum }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "9100"
+        prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
     spec:
       containers:
         - name: worker

--- a/openstack/lyra/values.yaml
+++ b/openstack/lyra/values.yaml
@@ -46,3 +46,13 @@ omnitruck:
     pullPolicy: IfNotPresent
   internalPort: 8080
   #host:
+
+postgresql:
+  alerts:
+    prometheus: openstack
+
+# Deploy Lyra Prometheus alerts.
+alerts:
+  enabled: true
+  # Name of the Prometheus to which the alerts should be assigned to.
+  prometheus: openstack


### PR DESCRIPTION
Move Lyras [existing alerts](https://github.com/sapcc/helm-charts/blob/master/system/kube-monitoring/charts/prometheus-frontend/openstack-lyra.alerts) to the PrometheusRule custom resource and adds the prometheus.io/targets annotation to the service. Validated manually.