### PR TITLE
[Maia] Move Prometheus alerts to CRD

### DIFF
--- a/openstack/maia/alerts/api.alerts
+++ b/openstack/maia/alerts/api.alerts
@@ -1,0 +1,33 @@
+groups:
+- name: maia.alerts
+  rules:
+  - alert: OpenstackMaiaApiDown
+    expr: blackbox_api_status_gauge{check=~"maia"} == 1
+    for: 20m
+    labels:
+      severity: critical
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-blackbox-details
+      meta: '{{ $labels.check }} API is down. See Sentry for details.'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}/#{{ $labels.check }}'
+    annotations:
+      description: '{{ $labels.check }} API is down for 20 min. See Sentry for details.'
+      summary: '{{ $labels.check }} API down'
+
+  - alert: OpenstackMaiaApiFlapping
+    expr: changes(blackbox_api_status_gauge{check=~"maia"}[30m]) > 8
+    labels:
+      severity: warning
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      dashboard: ccloud-health-blackbox-details
+      meta: '{{ $labels.check }} API is flapping'
+      sentry: 'blackbox/?query=test_{{ $labels.check }}'
+      playbook: 'docs/devops/alert/{{ $labels.service }}/#{{ $labels.check }}'
+    annotations:
+      description: '{{ $labels.check }} API is flapping for 30 minutes.'
+      summary: '{{ $labels.check }} API flapping'

--- a/openstack/maia/alerts/maia.alerts
+++ b/openstack/maia/alerts/maia.alerts
@@ -1,0 +1,77 @@
+groups:
+- name: maia.alerts
+  rules:
+  - alert: OpenstackMaiaExportersLag
+    expr: predict_linear(scrape_duration_seconds{service="metrics"}[1h], 7 * 24 * 60 * 60) > 60
+    for: 1h
+    labels:
+      component: '{{ $labels.component }}'
+      context: latency
+      dashboard: Maia-Details
+      service: '{{ $labels.service }}'
+      severity: info
+      tier: os
+      meta: 'Maia exporters lagging'
+    annotations:
+      description: Maia exporter {{ $labels.component }} is predicted to break the 60s limit for data collection 7 days from now.
+      summary: Maia exporters lagging
+
+  - alert: OpenstackMaiaResponsiveness
+    expr: maia_request_duration_seconds{quantile="0.99",service="metrics"} > 3
+    for: 1h
+    labels:
+      component: '{{ $labels.component }}'
+      context: latency
+      dashboard: Maia-Details
+      service: '{{ $labels.service }}'
+      severity: info
+      tier: os
+      meta: 'Maia API lags'
+    annotations:
+      description: Maia API does not fulfill the responsiveness goals (99% responses within 3 seconds)
+      summary: Maia API lags
+
+  - alert: OpenstackMaiaPrometheusAvail
+    expr: sum(irate(maia_tsdb_errors_count{service="metrics"}[5m])) > 0
+    for: 15m
+    labels:
+      component: '{{ $labels.component }}'
+      context: availability
+      dashboard: Maia-Details
+      service: '{{ $labels.service }}'
+      severity: info
+      tier: os
+      meta: 'Maia availability affected by Prometheus issues'
+    annotations:
+      description: Maia API is affected by errors when accessing the underlying Prometheus installation
+      summary: Maia availability affected by Prometheus issues
+
+  - alert: OpenstackMaiaKeystoneAvail
+    expr: sum(irate(maia_logon_errors_count{service="metrics"}[5m])) > 0
+    for: 15m
+    labels:
+      component: '{{ $labels.component }}'
+      context: availability
+      dashboard: Maia-Details
+      service: '{{ $labels.service }}'
+      severity: info
+      tier: os
+      meta: 'Maia availability affected by Prometheus issues'
+    annotations:
+      description: Maia API is affected by errors when accessing Keystone
+      summary: Maia availability affected by Keystone issues
+
+  - alert: OpenstackMaiaUp
+    expr: up{component="maia",service="metrics"} < 1
+    for: 15m
+    labels:
+      component: '{{ $labels.component }}'
+      context: availability
+      dashboard: Maia-Details
+      service: '{{ $labels.service }}'
+      severity: warn
+      tier: os
+      meta: "Maia Is not available"
+    annotations:
+      description: Maia monitoring endpoint is down => Maia is down
+      summary: Maia is not available

--- a/openstack/maia/templates/jumpserver-deployment.yaml
+++ b/openstack/maia/templates/jumpserver-deployment.yaml
@@ -16,6 +16,7 @@ spec:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ .Values.jumpserver.port_number | quote }}
+        prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
     spec:
       containers:
          - name: jumpserver-exporter

--- a/openstack/maia/templates/maia-service.yaml
+++ b/openstack/maia/templates/maia-service.yaml
@@ -11,6 +11,7 @@ metadata:
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "{{ .Values.maia.listen_port }}"
+    prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
 spec:
   selector:
     component: maia

--- a/openstack/maia/templates/prometheus-alerts.yaml
+++ b/openstack/maia/templates/prometheus-alerts.yaml
@@ -1,0 +1,20 @@
+{{- $values := .Values }}
+{{- if $values.alerts.enabled }}
+{{- range $path, $bytes := .Files.Glob "alerts/*.alerts" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: {{ printf "maia-%s" $path | replace "/" "-" }}
+  labels:
+    app: maia
+    tier: os
+    type: alerting-rules
+    prometheus: {{ required ".Values.alerts.prometheus missing" $values.alerts.prometheus }}
+
+spec:
+{{ printf "%s" $bytes | indent 2 }}
+
+{{- end }}
+{{- end }}

--- a/openstack/maia/templates/prometheus-service.yaml
+++ b/openstack/maia/templates/prometheus-service.yaml
@@ -11,6 +11,7 @@ metadata:
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "{{ .Values.prometheus.listen_port }}"
+    prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
 spec:
   selector:
     component: prometheus-maia

--- a/openstack/maia/templates/snmp-exporter-service.yaml
+++ b/openstack/maia/templates/snmp-exporter-service.yaml
@@ -1,3 +1,4 @@
+{{- $values := .Values }}
 {{- if .Values.snmp_exporter.enabled }}
 {{- range $i, $config := .Values.snmp_exporter.maia_snmp_config -}}
 {{ if ne $i 0 }}---{{ end }}
@@ -21,6 +22,7 @@ metadata:
     prometheus.io/scrape_param_module: "{{$config.configname}}"
     prometheus.io/port: "{{$.Values.snmp_exporter.listen_port}}"
     prometheus.io/path: "/snmp"
+    prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" $values.alerts.prometheus | quote }}
 
 spec:
   selector:
@@ -54,6 +56,7 @@ metadata:
     prometheus.io/scrape_param_module: "arista"
     prometheus.io/port: "{{$.Values.snmp_exporter.listen_port}}"
     prometheus.io/path: "/snmp"
+    prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" $values.alerts.prometheus | quote }}
 
 spec:
   selector:

--- a/openstack/maia/values.yaml
+++ b/openstack/maia/values.yaml
@@ -127,3 +127,9 @@ jumpserver:
       tag: 1.3
 #   radius_secret: DEFINED-IN-REGION-SECRETS
    port_number: 9150
+
+# Deploy Maia Prometheus alerts.
+alerts:
+  enabled: true
+  # Name of the Prometheus to which the alerts should be assigned to.
+  prometheus: openstack


### PR DESCRIPTION
Move Maias [existing alerts](https://github.com/sapcc/helm-charts/blob/master/system/kube-monitoring/charts/prometheus-frontend/openstack-maia.alerts) to the PrometheusRule custom resource and adds the prometheus.io/targets annotation to the service. Validated manually.

LGTY @thgrs?