### PR TITLE
[Concourse] Move Prometheus alerts to CRD

### DIFF
--- a/global/concourse/alerts/concourse.alerts
+++ b/global/concourse/alerts/concourse.alerts
@@ -1,0 +1,28 @@
+groups:
+- name: concourse.alerts
+  rules:
+  - alert: ConcoursePostgresDatabaseSize
+    expr: pg_database_size_bytes{datname="concourse"} >= 40 * 1024^3
+    for: 5m
+    labels:
+      tier: ci
+      service: concourse
+      severity: warning
+      context: concourse
+      meta: "Database {{ $labels.datname }} to large"
+    annotations:
+      description: "The concourse database size is greater than 40GB and will exceed the PV limits eventually"
+      summary: Concourse database is too large
+
+  - alert: ConcourseWorkerStalled
+    expr: changes(concourse_workers_containers{platform="linux", worker=~"mo-.*"}[5m])==0
+    for: 30m
+    labels:
+      tier: ci
+      service: concourse
+      severity: warning
+      context: concourse
+      meta: "Worker {{ $labels.name }} has a stale container metric."
+    annotations:
+      description: "The workers container count seems to be stuck indicating that the worker might by stalled."
+      summary: Worker has stale container count

--- a/global/concourse/templates/prometheus-alerts.yaml
+++ b/global/concourse/templates/prometheus-alerts.yaml
@@ -1,0 +1,19 @@
+{{- $values := .Values }}
+{{- if $values.alerts.enabled }}
+{{- range $path, $bytes := .Files.Glob "alerts/*.alerts" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: {{ printf "%s" $path | replace "/" "-" }}
+  labels:
+    app: concourse
+    type: alerting-rules
+    prometheus: {{ required ".Values.alerts.prometheus missing" $values.alerts.prometheus }}
+
+spec:
+{{ printf "%s" $bytes | indent 2 }}
+
+{{- end }}
+{{- end }}

--- a/global/concourse/values.yaml
+++ b/global/concourse/values.yaml
@@ -142,3 +142,9 @@ cleanup:
   # worker_prefix:
   # enable_volume_cleanup: false
   # volume_prefix:
+
+# Deploy Concourse Prometheus alerts.
+alerts:
+  enabled: true
+  # Name of the Prometheus to which the alerts should be assigned to.
+  prometheus: kubernetes

--- a/global/concourse/values.yaml
+++ b/global/concourse/values.yaml
@@ -54,7 +54,7 @@ concourse:
 
       kubernetes:
         enabled: true
-        
+
         createTeamNamespaces: true
         keepNamespaces: true
         # teams:
@@ -87,7 +87,7 @@ concourse:
       requests:
         cpu: "500m"
         memory: "512Mi"
-    
+
     ingress:
       enabled: false
 


### PR DESCRIPTION
Move Concourse' [existing alerts](https://github.com/sapcc/helm-charts/blob/master/system/kube-monitoring/charts/prometheus-frontend/concourse.alerts) to the PrometheusRule custom resource. `prometheus.io/targets` annotation already present on service.
LGTY @jknipper?