### PR TITLE
Swift ratelimit

### DIFF
--- a/openstack/swift/etc/sapcc-ratelimit.yaml
+++ b/openstack/swift/etc/sapcc-ratelimit.yaml
@@ -8,7 +8,7 @@ ratelimit_response:
 blacklist_response:
   status: 497 Blacklisted
   status_code: 497
-  body: "You have been blacklisted. Please contact and administrator."
+  body: "Your account has been blacklisted"
 
 # Group multiple CADF actions to one rate limit action.
 groups:
@@ -16,17 +16,13 @@ groups:
     - update
     - delete
 
-  read:
-    - read
-    - read/list
-
 rates:
   # Global rate limits are counted across all projects and
   # are meant to protect the backend from being overloaded.
   global:
     account/container:
       - action: write
-        limit: 10000r/s
+        limit: 500r/s
 
   # Default rate limits apply to each project.
   # Rate limits specific to a project can only be set via Limes.
@@ -36,7 +32,7 @@ rates:
         limit: 10r/s
 
     account/container:
-      - action: read
+      - action: read/list
         limit: 100r/s
 
       - action: write

--- a/openstack/swift/etc/sapcc-ratelimit.yaml
+++ b/openstack/swift/etc/sapcc-ratelimit.yaml
@@ -1,0 +1,24 @@
+# Override default ratelimit response.
+ratelimit_response:
+  status: 498 Rate Limited
+  body: "Rate Limit Exceeded"
+
+# Override default blacklist response.
+blacklist_response:
+  status: 497 Blacklisted
+  body: "You have been blacklisted. Please contact and administrator."
+
+rates:
+  # Global rate limits are counted across all projects and
+  # are meant to protect the backend from being overloaded.
+  global:
+    account/container:
+      - action: create
+        limit: 1000r/m
+
+  # Default rate limits on project level.
+  # Apply to each project unless overridden via Limes.
+  default:
+    account/container:
+      - action: create
+        limit: 100r/m

--- a/openstack/swift/etc/sapcc-ratelimit.yaml
+++ b/openstack/swift/etc/sapcc-ratelimit.yaml
@@ -1,24 +1,43 @@
 # Override default ratelimit response.
 ratelimit_response:
   status: 498 Rate Limited
+  status_code: 498
   body: "Rate Limit Exceeded"
 
 # Override default blacklist response.
 blacklist_response:
   status: 497 Blacklisted
+  status_code: 497
   body: "You have been blacklisted. Please contact and administrator."
+
+# Group multiple CADF actions to one rate limit action.
+groups:
+  write:
+    - update
+    - delete
+
+  read:
+    - read
+    - read/list
 
 rates:
   # Global rate limits are counted across all projects and
   # are meant to protect the backend from being overloaded.
   global:
     account/container:
-      - action: create
-        limit: 1000r/m
+      - action: write
+        limit: 10000r/s
 
-  # Default rate limits on project level.
-  # Apply to each project unless overridden via Limes.
+  # Default rate limits apply to each project.
+  # Rate limits specific to a project can only be set via Limes.
   default:
+    account:
+      - action: write
+        limit: 10r/s
+
     account/container:
-      - action: create
-        limit: 100r/m
+      - action: read
+        limit: 100r/s
+
+      - action: write
+        limit: 50r/s

--- a/openstack/swift/requirements.lock
+++ b/openstack/swift/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: redis
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 8.0.5
+digest: sha256:7a92db4b0d4b9194ffd8580907e54a0e57969461d14a4984044bd34392317672
+generated: 2019-06-04T12:07:35.841197696+02:00

--- a/openstack/swift/requirements.yaml
+++ b/openstack/swift/requirements.yaml
@@ -1,0 +1,6 @@
+dependencies:
+  - name: redis
+    alias: sapcc-ratelimit-redis
+    repository: https://kubernetes-charts.storage.googleapis.com/
+    version: 8.0.5
+    condition: sapcc_ratelimit.enabled

--- a/openstack/swift/templates/_utils.tpl
+++ b/openstack/swift/templates/_utils.tpl
@@ -168,3 +168,14 @@ limit_req zone=req_limit burst={{ $cluster.rate_limit_burst }} nodelay;
 limit_req_status 429;
 {{- end }}
 {{- end -}}
+
+{{- /* Generate backend host for sapcc/openstack-ratelimit-middleware */ -}}
+{{- define "sapcc_ratelimit_backend_host" -}}
+{{- $release := index . 0 -}}
+{{- $context := index . 1 -}}
+{{- if $context.sapcc_ratelimit.backend.host -}}
+{{- $context.sapcc_ratelimit.backend.host -}}
+{{- else -}}
+{{- $release.Name -}}-sapcc-ratelimit-redis-headless
+{{- end -}}
+{{- end -}}

--- a/openstack/swift/templates/etc/_proxy-server.conf.tpl
+++ b/openstack/swift/templates/etc/_proxy-server.conf.tpl
@@ -227,7 +227,8 @@ config_file = /swift-etc/sapcc-ratelimit.yaml
 service_type = {{ required ".Values.global.serviceType missing" $context.global.serviceType }}
 cadf_service_name = {{ required ".Values.global.serviceName missing" $context.global.serviceName }}
 rate_limit_by = {{ required ".Values.sapcc_ratelimit.rateLimitBy missing" $context.sapcc_ratelimit.rateLimitBy }}
-backend = {{ required ".Values.sapcc_ratelimit.backend.type missing" $context.sapcc_ratelimit.backend.type }}
+max_sleep_time_seconds = {{ required ".Values.sapcc_ratelimit.maxSleepTimeSeconds missing" $context.sapcc_ratelimit.maxSleepTimeSeconds }}
+log_sleep_time_seconds = {{ required ".Values.sapcc_ratelimit.logSleepTimeSeconds missing" $context.sapcc_ratelimit.logSleepTimeSeconds }}
 backend_host = {{ tuple $helm_release $context | include "sapcc_ratelimit_backend_host" }}
 backend_port = {{ required ".Values.sapcc_ratelimit.backend.port missing" $context.sapcc_ratelimit.backend.port }}
 {{- end }}

--- a/openstack/swift/templates/etc/_proxy-server.conf.tpl
+++ b/openstack/swift/templates/etc/_proxy-server.conf.tpl
@@ -30,10 +30,10 @@ log_custom_handlers = swift_sentry.sentry_logger
 [pipeline:main]
 {{- if le $swift_release "queens" }}
 # Queens pipeline
-pipeline = catch_errors gatekeeper healthcheck proxy-logging cache listing_formats cname_lookup domain_remap bulk tempurl ratelimit authtoken{{ if and $context.s3api_enabled $cluster.seed }} swift3 s3token{{ end }} {{if $context.watcher_enabled }}watcher {{ end }}{{ if $context.sapcc_ratelimit.enabled }}sapcc_ratelimit {{ end }}keystoneauth sysmeta-domain-override staticweb copy container-quotas account-quotas slo dlo versioned_writes symlink proxy-logging proxy-server
+pipeline = catch_errors gatekeeper healthcheck proxy-logging cache listing_formats cname_lookup domain_remap bulk tempurl {{ if not $context.sapcc_ratelimit.enabled }}ratelimit {{ end }}authtoken{{ if and $context.s3api_enabled $cluster.seed }} swift3 s3token{{ end }} {{if $context.watcher_enabled }}watcher {{ end }}{{ if $context.sapcc_ratelimit.enabled }}sapcc_ratelimit {{ end }}keystoneauth sysmeta-domain-override staticweb copy container-quotas account-quotas slo dlo versioned_writes symlink proxy-logging proxy-server
 {{- else }}
 # Rocky or higher pipeline
-pipeline = catch_errors gatekeeper healthcheck proxy-logging cache listing_formats cname_lookup domain_remap bulk tempurl ratelimit authtoken{{ if and $context.s3api_enabled $cluster.seed }} s3api s3token{{ end }} {{if $context.watcher_enabled }}watcher {{ end }}{{ if $context.sapcc_ratelimit.enabled }}sapcc_ratelimit {{ end }}keystoneauth sysmeta-domain-override staticweb copy container-quotas account-quotas slo dlo versioned_writes symlink proxy-logging proxy-server
+pipeline = catch_errors gatekeeper healthcheck proxy-logging cache listing_formats cname_lookup domain_remap bulk tempurl {{ if not $context.sapcc_ratelimit.enabled }}ratelimit {{ end }}authtoken{{ if and $context.s3api_enabled $cluster.seed }} s3api s3token{{ end }} {{if $context.watcher_enabled }}watcher {{ end }}{{ if $context.sapcc_ratelimit.enabled }}sapcc_ratelimit {{ end }}keystoneauth sysmeta-domain-override staticweb copy container-quotas account-quotas slo dlo versioned_writes symlink proxy-logging proxy-server
 {{- end }}
 
 [app:proxy-server]
@@ -131,6 +131,7 @@ set log_level = DEBUG
 [filter:sysmeta-domain-override]
 use = egg:sapcc-swift-addons#sysmeta_domain_override
 
+{{ if not $context.sapcc_ratelimit.enabled }}
 [filter:ratelimit]
 use = egg:swift#ratelimit
 set log_name = proxy-ratelimit
@@ -141,6 +142,7 @@ container_ratelimit_0 = 50
 container_ratelimit_100 = 50
 container_listing_ratelimit_0 = 100
 container_listing_ratelimit_100 = 100
+{{ end }}
 
 [filter:cname_lookup]
 use = egg:swift#cname_lookup

--- a/openstack/swift/templates/etc/_proxy-server.conf.tpl
+++ b/openstack/swift/templates/etc/_proxy-server.conf.tpl
@@ -214,19 +214,22 @@ secret_cache_duration = {{$cluster.token_cache_time | default 600}}
 {{ if $context.watcher_enabled -}}
 [filter:watcher]
 use = egg:watcher-middleware#watcher
-service_type = object-store
-cadf_service_name = service/storage/object
-target_project_id_from_path = {{$context.watcher_project_id_from_path | default true}}
 config_file = /swift-etc/watcher.yaml
+service_type = {{ required ".Values.global.serviceType" $context.global.serviceType }}
+cadf_service_name = {{ required ".Values.global.serviceName" $context.global.serviceName }}
+target_project_id_from_path = {{ $context.watcher_project_id_from_path | default true }}
 {{- end }}
 
-{{ if $context.sapcc_ratelimit.enabled }}
+{{ if $context.sapcc_ratelimit.enabled -}}
 [filter:sapcc_ratelimit]
 use = egg:rate_limit_middleware#rate-limit
-service_type = object-store
-cadf_service_name = service/storage/object
-rate_limit_by = initiator_project_id
 config_file = /swift-etc/sapcc-ratelimit.yaml
-{{ end }}
-{{end}}
+service_type = {{ required ".Values.global.serviceType missing" $context.global.serviceType }}
+cadf_service_name = {{ required ".Values.global.serviceName missing" $context.global.serviceName }}
+rate_limit_by = {{ required ".Values.sapcc_ratelimit.rateLimitBy missing" $context.sapcc_ratelimit.rateLimitBy }}
+backend = {{ required ".Values.sapcc_ratelimit.backend.type missing" $context.sapcc_ratelimit.backend.type }}
+backend_host = {{ tuple $helm_release $context | include "sapcc_ratelimit_backend_host" }}
+backend_port = {{ required ".Values.sapcc_ratelimit.backend.port missing" $context.sapcc_ratelimit.backend.port }}
+{{- end }}
 
+{{ end }}

--- a/openstack/swift/templates/etc/configmap.yaml
+++ b/openstack/swift/templates/etc/configmap.yaml
@@ -37,6 +37,11 @@ data:
   # prometheus
   statsd-exporter.yaml: |
 {{ .Files.Get "etc/statsd-exporter.yaml" | indent 4 }}
-  # openstack request watcher and classifier
+  # OpenStack watcher middleware for request tracking.
   watcher.yaml: |
 {{ .Files.Get "etc/watcher.yaml" | indent 4 }}
+{{- if .Values.sapcc_ratelimit.enabled }}
+  # OpenStack ratelimit middleware.
+  sapcc-ratelimit.yaml: |
+{{ .Files.Get "etc/sapcc-ratelimit.yaml" | indent 4 }}
+{{- end }}

--- a/openstack/swift/values.yaml
+++ b/openstack/swift/values.yaml
@@ -122,3 +122,29 @@ clusters:
 account_ring_base64: DEFINED_IN_REGION_CHART
 container_ring_base64: DEFINED_IN_REGION_CHART
 object_ring_base64: DEFINED_IN_REGION_CHART
+
+# Use https://github.com/sapcc/openstack-rate-limit-middleware for watcher based rate limiting.
+sapcc_ratelimit:
+  enabled: false
+
+# Redis datastore for sapcc ratelimit middleware.
+# Only deployed if sapcc_ratelimit.enabled=true.
+sapcc-ratelimit-redis:
+  image:
+    repository: redis
+    tag: 5.0.5-alpine3.9
+    pullPolicy: IfNotPresent
+
+  # Require a password for the redis.
+  # Defined in secrets.
+  usePassword: false
+  # password:
+
+  # Prometheus metrics via oliver006/redis_exporter sidecar.
+  metrics:
+    enabled: true
+
+    service:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/targets: "openstack"

--- a/openstack/swift/values.yaml
+++ b/openstack/swift/values.yaml
@@ -136,14 +136,14 @@ sapcc_ratelimit:
   # - initiator_host_address
   rateLimitBy: initiator_project_id
 
+  # The maximal time a request can be suspended.
+  maxSleepTimeSeconds: 20
+
+  # Log requests that are going to be suspended for logSleepTimeSeconds <= t <= maxSleepTimeSeconds.
+  logSleepTimeSeconds: 18
+
   # The backend used to store rate limits.
   backend:
-    # Backend type. Defaults to redis.
-    # Can be one of:
-    # - redis
-    # - memcached
-    type: redis
-
     # Backend port. Defaults to redis port.
     port: 6379
 
@@ -163,6 +163,11 @@ sapcc-ratelimit-redis:
   # Use a single redis.
   cluster:
     enabled: false
+
+  # Minimal possible PV.
+  master:
+    persistence:
+      size: 1Gi
 
   # No password required for redis.
   usePassword: false

--- a/openstack/swift/values.yaml
+++ b/openstack/swift/values.yaml
@@ -2,6 +2,8 @@ global:
   tld: DEFINED_IN_REGION_CHART
   region: DEFINED_IN_REGION_CHART
   imageRegistry: DEFINED_IN_REGION_CHART
+  serviceType: object-store
+  serviceName: "service/storage/object"
 
 debug: false
 
@@ -127,23 +129,51 @@ object_ring_base64: DEFINED_IN_REGION_CHART
 sapcc_ratelimit:
   enabled: false
 
+  # Rate limit by tuple of target type URI, action and scope.
+  # The scope can be one of:
+  # - initiator_project_id
+  # - target_project_id
+  # - initiator_host_address
+  rateLimitBy: initiator_project_id
+
+  # The backend used to store rate limits.
+  backend:
+    # Backend type. Defaults to redis.
+    # Can be one of:
+    # - redis
+    # - memcached
+    type: redis
+
+    # Backend port. Defaults to redis port.
+    port: 6379
+
+    # Backend host. Defaults to redis headless service using `{{ .Release.Name }}-sapcc-ratelimit-redis-headless`.
+    # Can be overwritten using the following parameter.
+    # host:
+
 # Redis datastore for sapcc ratelimit middleware.
 # Only deployed if sapcc_ratelimit.enabled=true.
 sapcc-ratelimit-redis:
   image:
-    repository: redis
-    tag: 5.0.5-alpine3.9
+    registry: docker.io
+    repository: bitnami/redis
+    tag: 5.0.5-debian-9-r14
     pullPolicy: IfNotPresent
 
-  # Require a password for the redis.
-  # Defined in secrets.
+  # Use a single redis.
+  cluster:
+    enabled: false
+
+  # No password required for redis.
   usePassword: false
-  # password:
+
+  # Enable init container that changes volume permissions in the registry.
+  volumePermissions:
+    enabled: true
 
   # Prometheus metrics via oliver006/redis_exporter sidecar.
   metrics:
     enabled: true
-
     service:
       annotations:
         prometheus.io/scrape: "true"

--- a/openstack/swift/values.yaml
+++ b/openstack/swift/values.yaml
@@ -164,17 +164,13 @@ sapcc-ratelimit-redis:
   cluster:
     enabled: false
 
-  # Minimal possible PV.
+  # No persistence. Just memory.
   master:
     persistence:
-      size: 1Gi
+      enabled: false
 
   # No password required for redis.
   usePassword: false
-
-  # Enable init container that changes volume permissions in the registry.
-  volumePermissions:
-    enabled: true
 
   # Prometheus metrics via oliver006/redis_exporter sidecar.
   metrics:


### PR DESCRIPTION
- Introduce [sapcc/openstack-rate-limit-middleware](https://github.com/sapcc/openstack-rate-limit-middleware). Disabled by default. 
- Uses redis backend. No persistence. Only memory. Will be deployed if above middleware is enabled.
-  There shall only be one rate limit middleware: If sapcc rate limit enabled the swift rate limit middleware will be disabled. 
- Rate limits as per [config](https://github.com/sapcc/helm-charts/compare/master...swift-ratelimit?expand=1#diff-a3ed9f52e02b1b6c2848c420565256c6)

**Requires**: https://github.com/sapcc/swift/pull/16

Next steps:
- `staging`, `qa-de-1` rollout + final test

Are you ok with this @reimannf?