### PR TITLE
[Swift] Redis for ratelimit based on common/redis

### DIFF
--- a/openstack/swift/requirements.lock
+++ b/openstack/swift/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: redis
   repository: file://../../common/redis
-  version: 1.0.0
-digest: sha256:ca92d8571e2a27854349e801ed38efdd88692535c05f269683a69a1fe07e6adb
-generated: 2019-07-09T10:54:46.348535351+02:00
+  version: 1.0.1
+digest: sha256:f9f317c60b6238a0d794f0dd2733268177c8f9384348173be3307686c15ecae6
+generated: 2019-07-09T17:05:14.06956698+02:00

--- a/openstack/swift/requirements.lock
+++ b/openstack/swift/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: redis
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 8.0.5
-digest: sha256:7a92db4b0d4b9194ffd8580907e54a0e57969461d14a4984044bd34392317672
-generated: 2019-06-04T12:07:35.841197696+02:00
+  repository: file://../../common/redis
+  version: 1.0.0
+digest: sha256:ca92d8571e2a27854349e801ed38efdd88692535c05f269683a69a1fe07e6adb
+generated: 2019-07-09T10:54:46.348535351+02:00

--- a/openstack/swift/requirements.yaml
+++ b/openstack/swift/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: redis
     alias: sapcc-ratelimit-redis
-    repository: https://kubernetes-charts.storage.googleapis.com/
-    version: 8.0.5
+    repository: file://../../common/redis
+    version: 1.0.0
     condition: sapcc_ratelimit.enabled

--- a/openstack/swift/requirements.yaml
+++ b/openstack/swift/requirements.yaml
@@ -2,5 +2,5 @@ dependencies:
   - name: redis
     alias: sapcc-ratelimit-redis
     repository: file://../../common/redis
-    version: 1.0.0
+    version: 1.0.1
     condition: sapcc_ratelimit.enabled

--- a/openstack/swift/templates/_utils.tpl
+++ b/openstack/swift/templates/_utils.tpl
@@ -176,6 +176,6 @@ limit_req_status 429;
 {{- if $context.sapcc_ratelimit.backend.host -}}
 {{- $context.sapcc_ratelimit.backend.host -}}
 {{- else -}}
-{{- $release.Name -}}-sapcc-ratelimit-redis-headless
+{{- $release.Name -}}-sapcc-ratelimit-redis
 {{- end -}}
 {{- end -}}

--- a/openstack/swift/values.yaml
+++ b/openstack/swift/values.yaml
@@ -154,28 +154,11 @@ sapcc_ratelimit:
 # Redis datastore for sapcc ratelimit middleware.
 # Only deployed if sapcc_ratelimit.enabled=true.
 sapcc-ratelimit-redis:
-  image:
-    registry: docker.io
-    repository: bitnami/redis
-    tag: 5.0.5-debian-9-r14
-    pullPolicy: IfNotPresent
 
-  # Use a single redis.
-  cluster:
+  # Memory is sufficient.
+  persistence:
     enabled: false
-
-  # No persistence. Just memory.
-  master:
-    persistence:
-      enabled: false
-
-  # No password required for redis.
-  usePassword: false
 
   # Prometheus metrics via oliver006/redis_exporter sidecar.
   metrics:
     enabled: true
-    service:
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/targets: "openstack"


### PR DESCRIPTION
Redis is not longer a `apps/v1beta2.StatefulSet` but a`Deployment` which allows us to use staging with k8s 1.7.7 again. Common redis chart was updated in #848. 

Test with `rocky` and `stein`.