### PR TITLE
Fix double scraping of metrics

### DIFF
--- a/system/kube-monitoring/requirements.lock
+++ b/system/kube-monitoring/requirements.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.3.2
 - name: kube-state-metrics
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.16.0
+  version: 1.5.0
 - name: ironic-exporter
   repository: file://vendor/ironic-exporter
   version: 1.0.0
@@ -17,5 +17,5 @@ dependencies:
 - name: prometheus-server
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.1.14
-digest: sha256:95d4d942b7574ee9d17b942a7c37942e7d6b05ba3f73578f124e9b20824d159d
-generated: 2019-06-21T11:11:45.297287253+02:00
+digest: sha256:993fb26ae5682bf65810860ca969381f4dedc684481ceb3b030924ae113dd6fb
+generated: 2019-07-10T16:59:00.010140661+02:00

--- a/system/kube-monitoring/requirements.yaml
+++ b/system/kube-monitoring/requirements.yaml
@@ -5,7 +5,7 @@ dependencies:
 
   - name: kube-state-metrics
     repository: https://kubernetes-charts.storage.googleapis.com/
-    version: 0.16.0
+    version: 1.5.0
 
   - name: ironic-exporter
     repository: file://vendor/ironic-exporter

--- a/system/kube-monitoring/values.yaml
+++ b/system/kube-monitoring/values.yaml
@@ -153,12 +153,19 @@ kube-state-metrics:
     prometheus.io/port_1: "8081"
     prometheus.io/targets: "kubernetes,openstack"
 
+  # This avoid double scraping of metrics caused by setting the `prometheus.io/scrape: "true"` annotation on the service.
+  # We already have the annotations on the kube-state-metrics pod.
+  prometheusScrape: false
+
   image:
     repository: sapcc/kube-state-metrics
 
   rbac:
     create: false
     serviceAccountName: default
+
+  serviceAccount:
+    create: false
 
   collectors:
     # not useful


### PR DESCRIPTION
Not deploying this in the evening. To be done tomorrow morning. Also bumps `kube-state-metrics` to [v1.6.0](https://github.com/kubernetes/kube-state-metrics/releases/tag/v1.6.0).