### PR TITLE
Policyadjustement for BSO

### DIFF
--- a/openstack/nova/templates/etc/_nova-policy.json.tpl
+++ b/openstack/nova/templates/etc/_nova-policy.json.tpl
@@ -5,7 +5,7 @@
     "owner": "project_id:%(project_id)s",
     "member": "role:member and rule:owner",
     "viewer": "role:compute_viewer and rule:owner",
-    "admin": "role:compute_admin and rule:owner",
+    "admin": "(role:compute_admin or role:compute_admin_wsg) and rule:owner",
     "context_is_compute_admin": "rule:context_is_admin or rule:admin",
     "context_is_editor": "rule:context_is_compute_admin or rule:member",
     "context_is_viewer":  "rule:context_is_editor or rule:viewer",


### PR DESCRIPTION
They need a compute_admin_wsg role which
doest have the right to edit securitygroups and rules
but inherits all the other rights from the standard compute_admin role.