### PR TITLE
Activate alertmanagers for new Prometheis

### DIFF
--- a/global/prometheus-infra/values.yaml
+++ b/global/prometheus-infra/values.yaml
@@ -30,10 +30,9 @@ prometheus-infra-global:
   secrets:
     - prometheus-infra-sso-cert
 
-  # Disable alerting until the transition to the operated Prometheus was done in all regions.
-  # alertmanagers:
-  #  - alertmanager.eu-de-1.cloud.sap
-  #  - alertmanager.eu-nl-1.cloud.sap
+  # Send alerts to these alertmanagers.
+  alertmanagers:
+    - alertmanager.eu-de-1.cloud.sap
 
 # Basic alerts for global Prometheus.
 alerts:

--- a/global/prometheus-kubernetes/values.yaml
+++ b/global/prometheus-kubernetes/values.yaml
@@ -36,10 +36,9 @@ prometheus-kubernetes-global:
   secrets:
     - prometheus-sso-cert
 
-  # Disable alerting until the transition to the operated Prometheus was done in all regions.
-  # alertmanagers:
-  #  - alertmanager.eu-de-1.cloud.sap
-  #  - alertmanager.eu-nl-1.cloud.sap
+  # Send alerts to these alertmanagers.
+  alertmanagers:
+    - alertmanager.eu-de-1.cloud.sap
 
 # List of metrics that get federated from the regional Prometheis.
 # Per convention all metrics with the `global:` prefix are federated.

--- a/global/prometheus-kubernikus/values.yaml
+++ b/global/prometheus-kubernikus/values.yaml
@@ -30,10 +30,9 @@ prometheus-kubernikus-global:
   secrets:
     - prometheus-kubernikus-sso-cert
 
-  # Disable alerting until the transition to the operated Prometheus was done in all regions.
-  # alertmanagers:
-  #  - alertmanager.eu-de-1.cloud.sap
-  #  - alertmanager.eu-nl-1.cloud.sap
+  # Send alerts to these alertmanagers.
+  alertmanagers:
+    - alertmanager.eu-de-1.cloud.sap
 
 # Basic alerts for global Prometheus.
 alerts:

--- a/global/prometheus-openstack/values.yaml
+++ b/global/prometheus-openstack/values.yaml
@@ -30,10 +30,9 @@ prometheus-openstack-global:
   secrets:
     - prometheus-openstack-sso-cert
 
-  # Disable alerting until the transition to the operated Prometheus was done in all regions.
-  # alertmanagers:
-  #  - alertmanager.eu-de-1.cloud.sap
-  #  - alertmanager.eu-nl-1.cloud.sap
+  # Send alerts to these alertmanagers.
+  alertmanagers:
+    - alertmanager.eu-de-1.cloud.sap
 
 # Basic alerts for global Prometheus.
 alerts:

--- a/system/kube-monitoring/charts/prometheus-frontend/values.yaml
+++ b/system/kube-monitoring/charts/prometheus-frontend/values.yaml
@@ -36,7 +36,7 @@ persistence:
 
 alerting:
   # disable all alerts by setting `false` here
-  enabled: true
+  enabled: false
   # disable kubernetes alerts by setting `false` here
   kubernetes: true
   # disable openstack alerts by setting `false` here

--- a/system/kube-monitoring/values.yaml
+++ b/system/kube-monitoring/values.yaml
@@ -129,10 +129,9 @@ prometheus-frontend-operated:
     endpoints:
       enabled: false
 
-  # Disable alerting until the transition to the operated Prometheus was done in all regions.
-  # alertmanagers:
-  #  - alertmanager.eu-de-1.cloud.sap
-  #  - alertmanager.eu-nl-1.cloud.sap
+  # Send alerts to these alertmanagers.
+  alertmanagers:
+    - alertmanager.eu-de-1.cloud.sap
 
 # Deploy basic set of Prometheus alert and aggregation rules for monitoring Kubernetes.
 prometheus-kubernetes-rules:


### PR DESCRIPTION
This PR hooks the new Prometheis to the Alertmanagers and retires our legacy ones. 