### PR TITLE
enable quota autoscaling in prod regions

### DIFF
--- a/openstack/castellum/templates/_utils.tpl
+++ b/openstack/castellum/templates/_utils.tpl
@@ -16,7 +16,7 @@ When passed via `helm upgrade --set`, the image tag is misinterpreted as a float
 - name: CASTELLUM_DEBUG
   value: "false"
 - name: CASTELLUM_ASSET_MANAGERS
-  value: "nfs-shares{{if eq .Values.global.region "qa-de-1"}},project-quota{{end}}"
+  value: "nfs-shares,project-quota"
 - name: CASTELLUM_DB_URI
   value: "postgres://postgres:{{ .Values.postgresql.postgresPassword }}@castellum-postgresql.{{ .Release.Namespace }}.svc/castellum?sslmode=disable"
 - name: CASTELLUM_HTTP_LISTEN_ADDRESS


### PR DESCRIPTION
With https://github.com/sapcc/castellum/commit/e59409179fc3adb495d0c55e0e5cc85a5fe314b3 rolled out, this is good to go from my side (except for the UI which I will work on next).