### PR TITLE
[nova] Conditionally spawn api-metadata pods

### DIFF
--- a/openstack/nova/templates/api-metadata-deployment.yaml
+++ b/openstack/nova/templates/api-metadata-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if not (contains "metadata" .Values.api.DEFAULT.enabled_apis) }}
 kind: Deployment
 apiVersion: extensions/v1beta1
 
@@ -158,3 +159,4 @@ spec:
           configMap:
             name: nova-bin
             defaultMode: 0755
+{{- end }}

--- a/openstack/nova/templates/api-metadata-service.yaml
+++ b/openstack/nova/templates/api-metadata-service.yaml
@@ -1,3 +1,4 @@
+{{- if not (contains "metadata" .Values.api.DEFAULT.enabled_apis) }}
 kind: Service
 apiVersion: v1
 
@@ -19,3 +20,4 @@ spec:
   ports:
     - name: nova-api-metadata
       port: {{.Values.global.novaApiMetadataPortInternal}}
+{{- end }}

--- a/openstack/nova/templates/etc-configmap.yaml
+++ b/openstack/nova/templates/etc-configmap.yaml
@@ -12,8 +12,10 @@ data:
 {{ include (print .Template.BasePath "/etc/_nova.conf.tpl") . | indent 4 }}
   nova-api.conf: |
 {{ include "util.helpers.valuesToIni" .Values.api | indent 4 }}
+{{- if not (contains "metadata" .Values.api.DEFAULT.enabled_apis) }}
   nova-api-metadata.conf: |
 {{ include "util.helpers.valuesToIni" .Values.api_metadata | indent 4 }}
+{{- end }}
   nova-conductor.conf: |
 {{ include "util.helpers.valuesToIni" .Values.conductor | indent 4 }}
   nova-scheduler.conf: |

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -154,7 +154,8 @@ cross_az_attach: 'False'
 api:
   DEFAULT:
     api_paste_config: /etc/nova/api-paste.ini
-    enabled_apis: osapi_compute,metadata
+    # adding metadata here will disable spawning of separate api-metadata pods
+    enabled_apis: osapi_compute
     use_forwarded_for: true
 
   api:


### PR DESCRIPTION
If the metadata APIs are enabled via setting `enabled_apis` including
"metadata", we don't have to spawn separate nova-api-metadata pods. This
is currently true in `eu-de-1` only, where we scaled down the deployment
of nova-api-metadata. To support the `eu-de-1` use-case, we were still
spawning metadata API workers in all other regions' nova-api pods. These
workers idled, but wasted memory.  This commit disables the idling
metadata workers in nova-api pods by default.