### PR TITLE
Bump concourse to 5.4.1

### DIFF
--- a/global/concourse/requirements.lock
+++ b/global/concourse/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: concourse
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 6.2.1
-digest: sha256:5d8b7be07b34c41cfd12555d0ce90a86b3cd0eff531d79868f425df8b347c493
-generated: 2019-05-29T11:34:01.791468234+02:00
+  version: 8.2.2
+digest: sha256:eaf64ab71cf45176bea7adb22e64ff1fc16f41c61d723ee3beea775d2e953e98
+generated: 2019-08-20T11:37:19.242414324+02:00

--- a/global/concourse/requirements.yaml
+++ b/global/concourse/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: concourse
-  version: "6.2.1"
+  version: "8.2.2"
   repository: "https://kubernetes-charts.storage.googleapis.com/"

--- a/global/concourse/values.yaml
+++ b/global/concourse/values.yaml
@@ -109,14 +109,15 @@ concourse:
 
   postgresql:
     enabled: true
-    postgresUser: concourse
-    # postgresPassword:
-    postgresDatabase: concourse
+    postgresqlUsername: concourse
+    # postgresqlPassword:
+    postgresqlDatabase: concourse
 
     persistence:
       enabled: true
       storageClass: cinder-default
-      accessMode: ReadWriteOnce
+      accessModes:
+        - ReadWriteOnce
       size: 50Gi
 
   rbac:

--- a/global/concourse/values.yaml
+++ b/global/concourse/values.yaml
@@ -11,7 +11,7 @@ worker:
 
 concourse:
   image: concourse/concourse
-  imageTag: "5.2.0"
+  imageTag: "5.4.1"
   pullPolicy: IfNotPresent
 
   concourse:


### PR DESCRIPTION
This PR updates concourse to version 5.4.1 and hopefully fixes some issues we have with stale pipelines.