### PR TITLE
[nova] Automate initial cellv2 setup

### DIFF
--- a/openstack/nova/templates/_helpers.tpl
+++ b/openstack/nova/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{- define "cell0_db_path" -}}
-{{.Values.cell0dbUser}}:{{.Values.cell0dbPassword | default (tuple . .Values.cell0dbUser | include "postgres.password_for_user") | urlquery}}@{{.Chart.Name}}-postgresql.{{include "svc_fqdn" .}}:5432/{{.Values.cell0dbName}}
+postgresql+psycopg2://{{.Values.cell0dbUser}}:{{.Values.cell0dbPassword | default (tuple . .Values.cell0dbUser | include "postgres.password_for_user") | urlquery }}@{{.Chart.Name}}-postgresql.{{include "svc_fqdn" .}}:5432/{{.Values.cell0dbName}}
 {{- end -}}
 
 {{- define "cell2_db_path" -}}

--- a/openstack/nova/templates/bin/_db-update-cells.tpl
+++ b/openstack/nova/templates/bin/_db-update-cells.tpl
@@ -2,56 +2,97 @@
 
 set -e
 
+
+update_cell() {
+  cell_name="${1}"; shift
+  cell_uuid="${1}"; shift
+  transport_url="${1}"; shift
+  wanted_transport_url="${1}"; shift
+  database_connection="${1}"; shift
+  wanted_database_connection="${1}"; shift
+
+  needs_update="false"
+  if [ "${transport_url}" != "${wanted_transport_url}" ]; then
+    needs_update="true"
+    echo "Updating ${cell_name} transport-url..."
+  fi
+  if [ "${database_connection}" != "${wanted_database_connection}" ]; then
+    needs_update="true"
+    echo "Updating ${cell_name} database_connection..."
+  fi
+  if [ "${needs_update}" = "true" ]; then
+    nova-manage cell_v2 update_cell \
+        --cell_uuid ${cell_uuid} \
+        --transport-url "${wanted_transport_url}" \
+        --database_connection "${wanted_database_connection}"
+  fi
+}
+
+
 IFS=$'\n'
+found_cell0="false"
+found_cell1="false"
 found_cell2="false"
-for line in $(nova-manage cell_v2 list_cells --verbose | grep 'rabbit://'); do
+for line in $(nova-manage cell_v2 list_cells --verbose | grep ':/'); do
   cell_name=$(echo "$line" | cut -d'|' -f2 | tr -d '[:space:]')
   cell_uuid=$(echo "$line" | cut -d'|' -f3 | tr -d '[:space:]')
   transport_url=$(echo "$line" | cut -d'|' -f4 | tr -d '[:space:]')
   database_connection=$(echo "$line" | cut -d'|' -f5 | tr -d '[:space:]')
   echo "Processing Cell $cell_uuid"
 
-  if [ "$cell_name" = "None" ]; then
+  if [ "${cell_name}" = "None" ]; then
     echo "Renaming default cell to cell1"
     nova-manage cell_v2 update_cell --cell_uuid $cell_uuid --name "cell1"
-    cell_name=cell1
+    cell_name="cell1"
   fi
 
-  if [ "$cell_name" = "cell1" ]; then
-    if [ "$transport_url" != "{{ tuple . .Values.rabbitmq | include "rabbitmq._transport_url" }}" ]; then
-      echo "Updating $cell_name transport-url..."
-      nova-manage cell_v2 update_cell --cell_uuid $cell_uuid --transport-url "{{ tuple . .Values.rabbitmq | include "rabbitmq._transport_url" }}" --database_connection "{{ include "db_url" . }}"
-    fi
-    if [ "$database_connection" != "{{ include "db_url" . }}" ]; then
-      echo "Updating $cell_name database_connection..."
-      nova-manage cell_v2 update_cell --cell_uuid $cell_uuid --transport-url "{{ tuple . .Values.rabbitmq | include "rabbitmq._transport_url" }}" --database_connection "{{ include "db_url" . }}"
-    fi
-  fi
-
+  case "${cell_name}" in
+    cell0)
+      found_cell0="true"
+      update_cell "${cell_name}" "${cell_uuid}" \
+            "${transport_url}" "none:/" \
+            "${database_connection}" "{{ include "cell0_db_path" . }}"
+      ;;
+    cell1)
+      found_cell1="true"
+      update_cell "${cell_name}" "${cell_uuid}" \
+            "${transport_url}" "{{ tuple . .Values.rabbitmq | include "rabbitmq._transport_url" }}" \
+            "${database_connection}" "{{ include "db_url" . }}"
+      ;;
 {{ if .Values.cell2.enabled }}
-  if [ "$cell_name" = "{{.Values.cell2.name}}" ]; then
-    found_cell2="true"
-    echo "Found existing cell2..."
-    if [ "$transport_url" != "{{ include "cell2_transport_url" . }}" ]; then
-      echo "Updating $cell_name transport-url..."
-      nova-manage cell_v2 update_cell --cell_uuid $cell_uuid --transport-url "{{ include "cell2_transport_url" . }}" --database_connection "{{ include "cell2_db_path" . }}"
-    fi
-    if [ "$database_connection" != "" ]; then
-      echo "Updating $cell_name database_connection..."
-      nova-manage cell_v2 update_cell --cell_uuid $cell_uuid --transport-url "{{ include "cell2_transport_url" . }}" --database_connection "{{ include "cell2_db_path" . }}"
-    fi
-  fi
+    {{.Values.cell2.name}})
+      found_cell2="true"
+      echo "Found existing cell2..."
+      update_cell "${cell_name}" "${cell_uuid}" \
+            "${transport_url}" "{{ include "cell2_transport_url" . }}" \
+            "${database_connection}" "{{ include "cell2_db_path" . }}"
+      ;;
 {{- end }}
+  esac
 done
+
+if [ "${found_cell0}" = "false" ]; then
+  echo "Creating cell0..."
+  nova-manage cell_v2 map_cell0 \
+      --database_connection "{{ include "cell0_db_path" . }}"
+fi
+if [ "${found_cell1}" = "false" ]; then
+  echo "Creating cell1..."
+  nova-manage cell_v2 create_cell --verbose \
+      --name "cell1" \
+      --transport-url "{{ tuple . .Values.rabbitmq | include "rabbitmq._transport_url" }}" \
+      --database_connection "{{ include "db_url" . }}"
+  nova-manage cell_v2 discover_hosts
+fi
 
 {{ if .Values.cell2.enabled }}
 if [ "$found_cell2" = "false" ]; then
-  echo "Creating cell2"
-  nova-manage cell_v2 create_cell --name "{{.Values.cell2.name}}" --transport-url "{{ include "cell2_transport_url" . }}" --database_connection "{{ include "cell2_db_path" . }}" --verbose
+  echo "Creating cell2..."
+  nova-manage cell_v2 create_cell --verbose \
+      --name "{{.Values.cell2.name}}" \
+      --transport-url "{{ include "cell2_transport_url" . }}" \
+      --database_connection "{{ include "cell2_db_path" . }}"
 fi
 {{- end }}
-
-
-
 
 exit


### PR DESCRIPTION
This wasn't necessary before, because we just recently changed to cellv2
and had to migrate the old setup. But for new regions and the new labs,
we need this automated.

This also refactors the script a bit to re-use common functionality and
extends the for-loop to also include cell into the `grep`. This also
means, that the cell0 `database_connection` will now be updated if it
changes as well. This was already the case for cell1 and cell2.

Additionally, this commit updates the `cell0_db_path`-helper, but it was
unused before, so nothing needs changing.