### PR TITLE
[infra-monitoring] vasa-exporter: changed federation regex

### DIFF
--- a/system/prometheus-infra/templates/_prometheus-infra.yaml.tpl
+++ b/system/prometheus-infra/templates/_prometheus-infra.yaml.tpl
@@ -12,7 +12,7 @@
       - '{app="thousandeyes-exporter"}'
       - '{app="netapp-harvest"}'
       - '{app="netapp-api-exporter"}'
-      - '{app="vasa-exporter"}'
+      - '{instance="vasa-exporter:9202"}'
       - '{app="ping-exporter"}'
       - '{job="baremetal/arista"}'
       - '{job="bios/ironic"}'


### PR DESCRIPTION
Since the vasa-exporter has no label `app`, I've choosen the label `instance`, 'cause it is consistent in all regions.