### PR TITLE
slack_by_os_service without staging alerts

### DIFF
--- a/global/prometheus-alertmanager/templates/config.yaml
+++ b/global/prometheus-alertmanager/templates/config.yaml
@@ -111,6 +111,7 @@ data:
           tier: os
           severity: info|warning|critical
           service: arc|backup|barbican|castellum|cinder|cfm|designate|elektra|elk|glance|hermes|ironic|keystone|limes|lyra|maia|manila|neutron|nova|sentry|swift
+          region: qa-de-1|ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-2|na-us-3
 
       # owner: Martin Vossen / Tilo Geissler
       - receiver: slack_sre


### PR DESCRIPTION
The `slack_by_os_service` includes with this commit only productive regions and `qa-de-1` to avoid spamming the service specific channels with alerts from `staging`, which is in trouble most of the time.
If one is interested in `staging` alerts, join Slack channels `#alert-dev-[info|warning|critical]`