### PR TITLE
[infra-monitoring] Scrape netapp capacity exporter

### DIFF
--- a/system/infra-monitoring/vendor/netapp-cap-exporter/templates/secret.yaml
+++ b/system/infra-monitoring/vendor/netapp-cap-exporter/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.enabled }}
+{{- if .Values.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/system/infra-monitoring/vendor/netapp-cap-exporter/templates/service.yaml
+++ b/system/infra-monitoring/vendor/netapp-cap-exporter/templates/service.yaml
@@ -1,4 +1,7 @@
-{{ if .Values.enabled }}
+{{- if .Values.enabled }}
+{{- $scrape := .Values.metrics.scrape -}}
+{{- $targets := .Values.metrics.targets -}}
+{{- $port := .Values.service.port -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -8,11 +11,15 @@ metadata:
     helm.sh/chart: {{ include "netapp-cap-exporter.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    prometheus.io/scrape: {{ $scrape | quote }}
+    prometheus.io/targets: {{ $targets | quote }}
+    prometheus.io/port: {{ $port | quote }}
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
-      targetPort: {{ .Values.service.port }}
+    - port: {{ $port }}
+      targetPort: {{ $port }}
       protocol: TCP
       name: prometheus
   selector:

--- a/system/infra-monitoring/vendor/netapp-cap-exporter/values.yaml
+++ b/system/infra-monitoring/vendor/netapp-cap-exporter/values.yaml
@@ -29,3 +29,6 @@ service:
   type: ClusterIP
   port: 9108
 
+metrics:
+  scrape: true
+  targets: infra-collector


### PR DESCRIPTION
Add annotation to the exporter's service, so that prometheus can scrape data.