### PR TITLE
Swift: use histogram for first-byte-timings

### DIFF
--- a/openstack/swift/alerts/swift-api.alerts
+++ b/openstack/swift/alerts/swift-api.alerts
@@ -2,7 +2,7 @@ groups:
 - name: openstack-swift-api.alerts
   rules:
   - alert: OpenstackSwiftFirstByteTiming
-    expr: max(swift_proxy_firstbyte{type!="container",quantile="0.5",status="200"}) BY (os_cluster, type, instance) > 1000
+    expr: min(sum(irate(swift_proxy_firstbyte_bucket{le="1",type!="container",status=~"20[0-9]"}[5m])) by (os_cluster, type, instance) / sum(irate(swift_proxy_firstbyte_bucket{le="+Inf",type!="container",status=~"20[0-9]"}[5m])) by (os_cluster, type, instance)) by (os_cluster, type, instance) < 0.5
     for: 15m
     labels:
       context: firtsbytetiming

--- a/openstack/swift/etc/statsd-exporter.yaml
+++ b/openstack/swift/etc/statsd-exporter.yaml
@@ -3,13 +3,8 @@
 # Reference for this file's format:
 # <https://github.com/prometheus/statsd_exporter#metric-mapping-and-configuration>
 
-# Activate once dashborads and alerts are adopted
 defaults:
   ttl: 3h
-#  timer_type: histogram
-#  buckets: [.025, .1, .25, 1, 2.5]
-#  match_type: glob
-#  glob_disable_ordering: false
 
 mappings:
 
@@ -24,6 +19,8 @@ mappings:
     status: $4
     type: $1
 - match: swift.proxy-server.*.policy.*.GET.*.first-byte.timing
+  timer_type: histogram
+  buckets: [0.025, 0.1, 0.25, 1, 2.5]
   name: swift_proxy_firstbyte
   labels:
     policy: $2
@@ -44,6 +41,8 @@ mappings:
     status: $3
     type: $1
 - match: swift.proxy-server.*.GET.*.first-byte.timing
+  timer_type: histogram
+  buckets: [0.025, 0.1, 0.25, 1, 2.5]
   name: swift_proxy_firstbyte
   labels:
     policy: all


### PR DESCRIPTION
`timer_type` setting has been set for the individual metrics rather than as one of the `defaults` so that the other timing metrics don't get affected.