### PR TITLE
fix maia catalog entry

### DIFF
--- a/openstack/maia/templates/seed.yaml
+++ b/openstack/maia/templates/seed.yaml
@@ -32,7 +32,7 @@ spec:
     endpoints:
     - interface: public
       region: {{.Values.global.region}}
-      url: '{{.Values.maia.endpoint_protocol_public}}://{{.Values.maia.endpoint_host_public}}:{{.Values.maia.endpoint_port_public}}/api/v1'
+      url: '{{.Values.maia.endpoint_protocol_public}}://{{.Values.maia.endpoint_host_public}}:{{.Values.maia.endpoint_port_public}}'
 
   domains:
   - name: {{.Values.maia.service_user.user_domain_name}}


### PR DESCRIPTION
* remove `/api/v1` path from the registered URL (since there are other possible prefixes)
* issue did not show up because Maia CLI always threw away that part (accidentally, fixed with Thanos switch)
* that Maia CLI fix will create issues if the catalog URL is not fixed, too
* tested that the change to the catalog does not break older Maia CLIs