### PR TITLE
Increased timeout for liveness probe

### DIFF
--- a/openstack/manila/templates/api-deployment.yaml
+++ b/openstack/manila/templates/api-deployment.yaml
@@ -56,7 +56,7 @@ spec:
               path: /
               port: {{.Values.api_port_internal}}
             initialDelaySeconds: 15
-            timeoutSeconds: 5
+            timeoutSeconds: 15
           readinessProbe:
             httpGet:
               path: /healthcheck


### PR DESCRIPTION
During the loadtests i have seen that the timeout
for the liveness probe is not long enough. Therefore
kubernetes is constantly restarting the pod.