### PR TITLE
[arista] tcam efp alert

### DIFF
--- a/system/infra-monitoring/vendor/arista-exporter/aggregations/network-arista.rules
+++ b/system/infra-monitoring/vendor/arista-exporter/aggregations/network-arista.rules
@@ -7,8 +7,11 @@ groups:
   - record: MetalIronicAristaMonTotalWarn
     expr: count(arista_tcam{feature=~"|ACL", table=~"TCAM|EFP|IFP"} > 90)  by (instance, model, serial, table)
       
+  - record: MetalIronicAristaMonEFPCritical
+    expr: count(arista_tcam{feature=~"|ACL", table=~"TCAM|EFP|IFP"} > 90)  by (instance, model, serial, table)
+      
   - record: MetalIronicAristaMonSwitchDownCritical
-    expr: count(arista_up == 0) by (instance)
+    expr: sum(arista_tcam{table=~"EFP", feature !~ ""}) by (instance, model, serial, chip, table)  > 275
 
   - record: MetalIronicAristaMonDiscoveryWar
     expr: count(up{job="baremetal/arista"} == 0) by (instance)

--- a/system/infra-monitoring/vendor/arista-exporter/alerts/network-arista.alerts
+++ b/system/infra-monitoring/vendor/arista-exporter/alerts/network-arista.alerts
@@ -11,14 +11,14 @@ groups:
       service: arista
       context: "{{ $labels.instance }}"
       meta: "Switch {{ $labels.instance }}: Table {{ $labels.table }} usage"
-      playbook: /docs/devops/alert/network/switch.html
+      playbook: /docs/devops/alert/network/switch.html#arista
       dashboard: arista-monitoring-tcam-details?var-instance={{ $labels.instance }}
     annotations:
-      description: "Switch {{ $labels.instance }} TCAM usage of table {{ $labels.table }} above 50% for 30 min"
+      description: "Switch {{ $labels.instance }} TCAM usage of table {{ $labels.table }} above 50% for 60 min"
       summary: "TCAM usage info for switch {{ $labels.instance }}"
       
   - alert: MetalIronicAristaMonTotalWarn
-    # Total of ACL, IFP or EFP table is above 80%
+    # Total of ACL, IFP or EFP table is above 90%
     expr: count(arista_tcam{feature=~"|ACL", table=~"TCAM|EFP|IFP"} > 90)  by (instance, model, serial, table)
     for: 60m
     labels:
@@ -27,11 +27,27 @@ groups:
       service: arista
       context: "{{ $labels.instance }}"
       meta: "Switch {{ $labels.instance }}: Table {{ $labels.table }} usage"
-      playbook: /docs/devops/alert/network/switch.html
+      playbook: /docs/devops/alert/network/switch.html#arista
       dashboard: arista-monitoring-tcam-details?var-instance={{ $labels.instance }}
     annotations:
-      description: "Switch {{ $labels.instance }} TCAM usage of table {{ $labels.table }} above 80% for 30 min"
+      description: "Switch {{ $labels.instance }} TCAM usage of table {{ $labels.table }} above 80% for 60 min"
       summary: "TCAM usage warning for switch {{ $labels.instance }}"
+      
+  - alert: MetalIronicAristaMonEFPCritical
+    # sum of EFP Slices per chip is above 275%
+    expr: sum(arista_tcam{table=~"EFP", feature !~ ""}) by (instance, model, serial, chip, table)  > 275
+    for: 30m
+    labels:
+      severity: critical
+      tier: api
+      service: arista
+      context: "{{ $labels.instance }}"
+      meta: "Switch {{ $labels.instance }}: Table {{ $labels.table }}, Chip {{ $labels.chip }} usage"
+      playbook: /docs/devops/alert/network/switch.html#arista
+      dashboard: arista-monitoring-tcam-details?var-instance={{ $labels.instance }}&var-table={{ $labels.table }}
+    annotations:
+      description: "Switch {{ $labels.instance }}: Sum of {{ $labels.table }} TCAM Slice usage of {{ $labels.chip }} above 260% for 30 min"
+      summary: "TCAM {{ $labels.table }} Slice usage alert for switch {{ $labels.instance }}"
       
   - alert: MetalIronicAristaMonSwitchDownCritical
     # No metrics could be retrieved from the switch. Means API is not reachable.
@@ -43,7 +59,7 @@ groups:
       service: arista
       context: "{{ $labels.instance }}"
       meta: "Arista metrics cannot be fetched from switch {{ $labels.instance }}"
-      playbook: /docs/devops/alert/network/switch.html
+      playbook: /docs/devops/alert/network/switch.html#arista
       dashboard: arista-monitoring-overview?var-instance={{ $labels.instance }}
     annotations:
       description: "Arista metrics cannot be fetched from switch {{ $labels.instance }}"
@@ -59,7 +75,7 @@ groups:
       service: arista
       context: "{{ $labels.instance }}"
       meta: "Arista metrics cannot be fetched from switch {{ $labels.instance }}"
-      playbook: /docs/devops/alert/network/switch.html
+      playbook: /docs/devops/alert/network/switch.html#arista
       dashboard: arista-monitoring-overview?var-instance={{ $labels.instance }}
     annotations:
       description: "Arista metrics cannot be fetched from switch {{ $labels.instance }}"
@@ -75,7 +91,7 @@ groups:
       service: arista
       context: "{{ $labels.instance }}"
       meta: "Arista switch {{ $labels.instance }} slow response"
-      playbook: /docs/devops/alert/network/switch.html
+      playbook: /docs/devops/alert/network/switch.html#arista
       dashboard: arista-monitoring-overview?panelId=7&fullscreen&orgId=1&var-instance={{ $labels.instance }}
     annotations:
       description: "Arista switch {{ $labels.instance }} responding slower than 2 seconds."
@@ -91,7 +107,7 @@ groups:
       service: arista
       context: "{{ $labels.instance }}"
       meta: "Arista switch {{ $labels.instance }} slow response"
-      playbook: /docs/devops/alert/network/switch.html
+      playbook: /docs/devops/alert/network/switch.html#arista
       dashboard: arista-monitoring-overview?panelId=7&fullscreen&orgId=1&var-instance={{ $labels.instance }}
     annotations:
       description: "Arista switch {{ $labels.instance }} responding slower than 5 seconds."


### PR DESCRIPTION
A playbook has to be added to this document for this alert:
https://operations.global.cloud.sap/docs/devops/alert/network/switch.html#arista

Critical Alert will be fired into alert-api-critical after 30min if sum of EFP slices is above 275%.



