### PR TITLE
[maia] enable app. cred. support in all regions

### DIFF
--- a/openstack/maia/Chart.yaml
+++ b/openstack/maia/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Expose Prometheus as multi-tenant OpenStack service
 name: maia
-version: 1.0.1
+version: 1.0.2

--- a/openstack/maia/requirements.yaml
+++ b/openstack/maia/requirements.yaml
@@ -3,5 +3,5 @@ dependencies:
     alias: prometheus_server
     condition: prometheus_server.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 2.2.2
+    version: 2.2.3
 

--- a/openstack/maia/values.yaml
+++ b/openstack/maia/values.yaml
@@ -13,7 +13,7 @@ maia:
   endpoint_port_public: 443
   endpoint_protocol_public: https
   # docker_repo: DEFINED-IN-REGION-SECRETS
-  image_version: '20191010133522'
+  image_version: '20191024103753'
   debug: "0"
   listen_port: 9091
   # how long will label values be listed by the API (keep minimal)


### PR DESCRIPTION
use latest image with application credentials support by default i.e. in all regions (that do not specify another image version explicitly)