### PR TITLE
Increased timeout send and receive

### DIFF
--- a/openstack/manila/templates/api-ingress.yaml
+++ b/openstack/manila/templates/api-ingress.yaml
@@ -9,6 +9,8 @@ metadata:
     component: manila
   {{- if .Values.vice_president }}
   annotations:
+    ingress.kubernetes.io/proxy-read-timeout: "720"
+    ingress.kubernetes.io/proxy-send-timeout: "720"
     vice-president: "true"
   {{- end }}
 spec:


### PR DESCRIPTION
Increased timeout in ingress because the manila-api
takes sometimes to long to respond. If this happens
ingress is killing the connection and reports http
504 to the client back.