### PR TITLE
common/rabbitmq: add .Values.externalIPs attribute

### DIFF
--- a/common/rabbitmq/templates/service.yaml
+++ b/common/rabbitmq/templates/service.yaml
@@ -22,3 +22,9 @@ spec:
       port: {{ default 15672 .Values.ports.management }}
   selector:
     app: {{ template "fullname" . }}
+  {{- if .Values.externalIPs }}
+  externalIPs:
+    {{- range .Values.externalIPs }}
+    - {{ quote . }}
+    {{- end }}
+  {{- end }}

--- a/common/rabbitmq/values.yaml
+++ b/common/rabbitmq/values.yaml
@@ -19,6 +19,9 @@ ports:
   public: 5672
   management: 15672
 
+# when not empty, exposes the RabbitMQ service to the outside of the cluster on these IPs
+externalIPs: []
+
 users:
   default:
     user: rabbitmq


### PR DESCRIPTION
For CCM-12155. I validated the template syntax by adding an external IP to qa-de-1/values/hermes.yaml, running `helm diff upgrade` and checking the output.