### PR TITLE
[infra-monitoring]ipmi_exporter: increases img version

### DIFF
--- a/system/infra-monitoring/vendor/ipmi-exporter/values.yaml
+++ b/system/infra-monitoring/vendor/ipmi-exporter/values.yaml
@@ -1,7 +1,7 @@
 enabled: false
 app_env: "production"
 image: monsoon/ipmi-exporter
-tag: 1.6.3
+tag: 1.6.4.1
 fullnameOverride: ipmi-exporter
 listen_port: 9290
 ironic:


### PR DESCRIPTION
- adds support for memory error metrics
- increases free-ipmi version to 1.6.4 (from 1.6.3)
- increases base img to ubuntu 19.04
- increases go image to go 1.11