### PR TITLE
[infra-monitoring] increases cablecheck exporter image

### DIFF
--- a/system/infra-monitoring/vendor/cablecheck-exporter/values.yaml
+++ b/system/infra-monitoring/vendor/cablecheck-exporter/values.yaml
@@ -1,2 +1,2 @@
 image: d073495/cc-cablecheck
-tag: v6
+tag: v8


### PR DESCRIPTION
some improvements on cc-cablechecker - low noice on logfiles , can now handle multiple asw switches with repeating interface names