### PR TITLE
Increase blockdevice mapping timeout in nova to 15 mins

### DIFF
--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -197,6 +197,7 @@ compute:
       max_concurrent_builds_per_project: 3
       ram_allocation_ratio: 1.0
       cpu_allocation_ratio: 8.0
+      block_device_allocate_retries: 300
     vmware:
       insecure: true
       use_linked_clone: false


### PR DESCRIPTION
In case of cinder booted rootdisk the default 180 sec too few in case of big OS images, like windows
This setting will increase the timeout to 300 *3 = 900 sec = 15 mins