### PR TITLE
improve specificity of Kubernikus object-store quota alert

### DIFF
--- a/system/kubernikus-monitoring/alerts/kluster.alerts
+++ b/system/kubernikus-monitoring/alerts/kluster.alerts
@@ -50,7 +50,7 @@ groups:
       summary: "{{ $labels.kubernetes_name }} is unavailable"
 
   - alert: KubernikusKlusterLowOnObjectStoreQuota
-    expr: label_replace(max(kubernikus_kluster_info{phase="Running"}) by (kluster_name, creator, project_id), "shortname", "$1", "kluster_name", "(.*)-[a-f0-9]{32}") * on(project_id) group_left(project, domain) (min(limes_project_quota{service="object-store"} - limes_project_usage{service="object-store"}) by (project_id, project, domain) < 90 * 1024 * 1024)
+    expr: label_replace(max(kubernikus_kluster_info{phase="Running"}) by (kluster_name, creator, project_id), "shortname", "$1", "kluster_name", "(.*)-[a-f0-9]{32}") * on(project_id) group_left(project, domain) (min(limes_project_backendquota{service="object-store"} - limes_project_usage{service="object-store"}) by (project_id, project, domain) < 90 * 1024 * 1024)
     for: 10m
     labels:
       tier: kks


### PR DESCRIPTION
We have reports of false-positive alerts here when projects use quota autoscaling. Quota tracks usage closely in this case, so this alert may fire even though no manual intervention is required.

The fix uses that most projects have quota bursting enabled, so the backend quota (in Swift) will actually be 10% higher than the nominal quota (in Limes). Therefore there will be ample margin between backend quota and actual usage in projects with quota autoscaling.

@databus23 What do you think? Does this fix the problem for you, or do we still need CCM-12045 regardless?