### PR TITLE
bump ntp-exporter to v1.1.0

### DIFF
--- a/prometheus-exporters/ntp-exporter/Chart.yaml
+++ b/prometheus-exporters/ntp-exporter/Chart.yaml
@@ -1,3 +1,3 @@
 description: Prometheus NTP Exporter
 name: ntp-exporter
-version: 1.0.2
+version: 1.1.0

--- a/prometheus-exporters/ntp-exporter/templates/daemonset.yaml
+++ b/prometheus-exporters/ntp-exporter/templates/daemonset.yaml
@@ -30,7 +30,6 @@ spec:
           ports:
             - name: metrics
               containerPort: {{ required ".Values.metrics.port missing" .Values.metrics.port }}
-              hostPort: {{ required ".Values.metrics.hostPort missing" .Values.metrics.hostPort }}
 
           {{- if .Values.resources }}
           resources:

--- a/prometheus-exporters/ntp-exporter/values.yaml
+++ b/prometheus-exporters/ntp-exporter/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: sapcc/ntp-exporter
-  tag: v1.0-7-gf28483e
+  tag: v1.1.0
 
 ntp:
   server: timehost1.cc.cloud.sap
@@ -14,7 +14,7 @@ resources:
     cpu: 20m
 
 metrics:
-  port: 9100
+  port: 9559
 
 # Deploy Namespace exporters Prometheus alerts.
 alerts:

--- a/prometheus-exporters/ntp-exporter/values.yaml
+++ b/prometheus-exporters/ntp-exporter/values.yaml
@@ -15,7 +15,6 @@ resources:
 
 metrics:
   port: 9100
-  hostPort: 9101
 
 # Deploy Namespace exporters Prometheus alerts.
 alerts:


### PR DESCRIPTION
Container port changes from 9100 to 9559 because of this.

Since at least d015d5b, we use regular annotation-based service discovery for the ntp-exporter pods (instead of node-based service discovery) and thus don't need to bind to a host port anymore.