### PR TITLE
Raise garden max containers for concourse workers

### DIFF
--- a/global/concourse/templates/worker-daemonset.yaml
+++ b/global/concourse/templates/worker-daemonset.yaml
@@ -196,10 +196,12 @@ spec:
         - name: CONCOURSE_GARDEN_DNS_PROXY_ENABLE
           value: "false"
 {{- if $.Values.worker.env }}
-{{ toYaml $.Values.worker.env | indent 12 }}
-{{- end }}
+{{ toYaml $.Values.worker.env | indent 8 }}
+{{- end -}}
+{{ if $.Values.worker.resources }}
         resources:
-{{ toYaml $.Values.worker.resources | indent 12 }}
+{{ toYaml $.Values.worker.resources | indent 10 }}
+{{- end -}}
         securityContext:
           privileged: true
         volumeMounts:

--- a/global/concourse/values.yaml
+++ b/global/concourse/values.yaml
@@ -8,6 +8,13 @@
 worker:
   nameOverride: ""
   name: concourse-worker
+  env:
+  # default is 250
+  - name: CONCOURSE_GARDEN_MAX_CONTAINERS
+    value: "500"
+  # default is 10.254.0.0/22
+  - name: CONCOURSE_GARDEN_NETWORK_POOL
+    value: "10.254.0.0/16"
 
 concourse:
   image: concourse/concourse


### PR DESCRIPTION
This PR changes max. garden containers per worker to 500, default is currently 250. It also changes netmask of used network to 10.254.0.0/16.