### PR TITLE
Add pid into backdoor socket path

### DIFF
--- a/openstack/utils/templates/snippets/_debug.tpl
+++ b/openstack/utils/templates/snippets/_debug.tpl
@@ -100,5 +100,5 @@ data:
 
 
 {{ define "utils.snippets.debug.eventlet_backdoor_ini" }}
-backdoor_socket=/var/lib/{{.}}/eventlet_backdoor.socket
+backdoor_socket=/var/lib/{{.}}/eventlet_backdoor-{pid}.socket
 {{ end }}


### PR DESCRIPTION
For this to work properly, a patch to oslo.service is necessary. We've
got our own fork of oslo.service that includes that patch already in the
upper-constraints for queens.

---
Services not having the patch will have socket path of `eventlet_backdoor-{pid}.socket` instead of `eventlet_backdoor.socket`.