### PR TITLE
Add alerts for kubelet bug and pods not ready

### DIFF
--- a/prometheus-rules/prometheus-kubernetes-rules/Chart.yaml
+++ b/prometheus-rules/prometheus-kubernetes-rules/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A collection of Prometheus alerting and aggregation rules for Kubernetes.
 name: prometheus-kubernetes-rules
-version: 1.0.13
+version: 1.0.14


### PR DESCRIPTION
This hopefully alerts us if this bug hits us: https://github.com/kubernetes/kubernetes/issues/84931.

I'm wondering if those alerts should be inhibited if the kubelet is down but couldn't figure out how to do it.