### PR TITLE
[mariadb] makes initdb configmap a default

### DIFF
--- a/common/mariadb/templates/initdb-configmap.yaml
+++ b/common/mariadb/templates/initdb-configmap.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.initdb_configmap }}
+{{- if .Values.initdb_default }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.name }}-initdb
+  name: {{ .Values.initdb_configmap }}
   labels:
     app: {{ template "fullName" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"


### PR DESCRIPTION
- So services could provide their own intidb configmap!
- fixes initdb naming