### PR TITLE
[kube-monitoring-admin] updating dependencies

### DIFF
--- a/system/kube-monitoring-admin/Chart.yaml
+++ b/system/kube-monitoring-admin/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Kubernetes admin cluster monitoring.
 name: kube-monitoring-admin
-version: 1.0.7
+version: 1.0.8

--- a/system/kube-monitoring-admin/requirements.lock
+++ b/system/kube-monitoring-admin/requirements.lock
@@ -1,48 +1,48 @@
 dependencies:
-- name: prometheus-operator
-  repository: https://charts.eu-de-2.cloud.sap
-  version: 1.0.1
-- name: blackbox-exporter
-  repository: https://charts.eu-de-2.cloud.sap
-  version: 1.0.5
-- name: event-exporter
-  repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.2
-- name: kube-state-metrics
-  repository: https://kubernetes-charts.storage.googleapis.com
-  version: 1.5.0
-- name: k8s-secrets-certificate-exporter
-  repository: https://charts.eu-de-2.cloud.sap
-  version: 1.0.0
-- name: ntp-exporter
-  repository: https://charts.eu-de-2.cloud.sap
-  version: 1.1.0
-- name: oomkill-exporter
-  repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.4
-- name: prometheus-node-exporter
-  repository: https://kubernetes-charts.storage.googleapis.com
-  version: 1.6.0
-- name: prometheus-server
-  repository: https://charts.eu-de-2.cloud.sap
-  version: 3.0.4
-- name: prometheus-server
-  repository: https://charts.eu-de-2.cloud.sap
-  version: 3.0.0
-- name: prometheus-kubernetes-legacy-rules
-  repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.0
-- name: prometheus-kubernetes-rules
-  repository: https://charts.eu-de-2.cloud.sap
-  version: 1.1.1
-- name: prometheus-controlplane-rules
-  repository: https://charts.eu-de-2.cloud.sap
-  version: 1.0.4
-- name: grafana-dashboards-kubernetes
-  repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.3
-- name: prometheus-crds
-  repository: https://charts.eu-de-2.cloud.sap
-  version: 1.0.0
+  - name: prometheus-operator
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 1.0.1
+  - name: blackbox-exporter
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 1.0.5
+  - name: event-exporter
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 0.1.2
+  - name: kube-state-metrics
+    repository: https://kubernetes-charts.storage.googleapis.com
+    version: 1.5.0
+  - name: k8s-secrets-certificate-exporter
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 1.0.0
+  - name: ntp-exporter
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 1.1.0
+  - name: oomkill-exporter
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 0.1.4
+  - name: prometheus-node-exporter
+    repository: https://kubernetes-charts.storage.googleapis.com
+    version: 1.6.0
+  - name: prometheus-server
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 3.0.4
+  - name: prometheus-server
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 3.0.0
+  - name: prometheus-kubernetes-legacy-rules
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 0.1.0
+  - name: prometheus-kubernetes-rules
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 1.1.1
+  - name: prometheus-controlplane-rules
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 1.0.4
+  - name: grafana-dashboards-kubernetes
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 0.1.3
+  - name: prometheus-crds
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 1.0.0
 digest: sha256:216395d5aed0b5ef077902ad0ebf177fdd77ba537f606cd492bfabddbbb0b2eb
-generated: 2019-12-16T17:15:36.17701+01:00
+generated: "2019-12-16T17:15:36.17701+01:00"

--- a/system/kube-monitoring-admin/requirements.yaml
+++ b/system/kube-monitoring-admin/requirements.yaml
@@ -1,63 +1,49 @@
 dependencies:
-  - name: prometheus-operator
-    repository: https://charts.eu-de-2.cloud.sap
-    version: 1.0.1
-
   - name: blackbox-exporter
     repository: https://charts.eu-de-2.cloud.sap
     version: 1.0.5
-
   - name: event-exporter
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.1.2
-
-  - name: kube-state-metrics
-    repository: https://kubernetes-charts.storage.googleapis.com
-    version: 1.5.0
-
+  - name: grafana-dashboards-kubernetes
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 0.1.4
   - name: k8s-secrets-certificate-exporter
     repository: https://charts.eu-de-2.cloud.sap
     version: 1.0.0
-
+  - name: kube-state-metrics
+    repository: https://kubernetes-charts.storage.googleapis.com
+    version: 2.4.1
   - name: ntp-exporter
     repository: https://charts.eu-de-2.cloud.sap
     version: 1.1.0
-
   - name: oomkill-exporter
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.4
-
-  - name: prometheus-node-exporter
-    repository: https://kubernetes-charts.storage.googleapis.com
-    version: 1.6.0
-
-  - name: prometheus-server
-    alias: prometheus-frontend
-    repository: https://charts.eu-de-2.cloud.sap
-    version: 3.0.4
-
-  - name: prometheus-server
-    alias: prometheus-collector
-    repository: https://charts.eu-de-2.cloud.sap
-    version: 3.0.0
-
-  - name: prometheus-kubernetes-legacy-rules
-    repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.0
-    condition: isStaticPodsScrapeConfig
-
-  - name: prometheus-kubernetes-rules
-    repository: https://charts.eu-de-2.cloud.sap
-    version: 1.1.1
-
+    version: 0.1.5
   - name: prometheus-controlplane-rules
     repository: https://charts.eu-de-2.cloud.sap
-    version: 1.0.4
-
-  - name: grafana-dashboards-kubernetes
-    repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.3
-
+    version: 1.0.5
   - name: prometheus-crds
     repository: https://charts.eu-de-2.cloud.sap
     version: 1.0.0
+  - condition: isStaticPodsScrapeConfig
+    name: prometheus-kubernetes-legacy-rules
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 0.1.1
+  - name: prometheus-kubernetes-rules
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 1.1.2
+  - name: prometheus-node-exporter
+    repository: https://kubernetes-charts.storage.googleapis.com
+    version: 1.8.1
+  - name: prometheus-operator
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 2.0.0
+  - alias: prometheus-collector
+    name: prometheus-server
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 3.3.3
+  - alias: prometheus-frontend
+    name: prometheus-server
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 3.3.3


### PR DESCRIPTION
[kube-monitoring-admin] updated dependency to grafana-dashboards-kubernetes@0.1.3, kube-state-metrics@1.5.0, oomkill-exporter@0.1.4, prometheus-controlplane-rules@1.0.4, prometheus-kubernetes-legacy-rules@0.1.0, prometheus-kubernetes-rules@1.1.1, prometheus-node-exporter@1.6.0, prometheus-operator@1.0.1, prometheus-server@3.0.4, prometheus-server@3.0.0