### PR TITLE
[neutron] ACI bindings rework

### DIFF
--- a/openstack/neutron/templates/etc/_ml2-conf-aci.ini.tpl
+++ b/openstack/neutron/templates/etc/_ml2-conf-aci.ini.tpl
@@ -36,6 +36,14 @@ segment_type  = {{ $global.Values.aci.aci_hostgroups.segment_type }}
 segment_range = {{ default $global.Values.aci.aci_hostgroups.segment_range $aci_hostgroup.segment_range }}
 {{ end }}
 
+{{- range $i, $fixed_binding := .Values.aci.fixed_bindings }}
+[fixed-binding:{{ $fixed_binding.name }}]
+description = {{ $fixed_binding.description }}
+bindings = {{ $fixed_binding.bindings | join "," }}
+physical_domain = {{ $global.Values.aci.aci_hostgroups.physical_domain }}
+segment_type  = {{ $global.Values.aci.aci_hostgroups.segment_type }}
+segment_id = {{ $fixed_binding.segment_id }}
+{{ end }}
 
 #AddressScope
 {{- range $i, $address_scope := .Values.aci.address_scopes }}
@@ -45,15 +53,6 @@ l3_outs = {{ $address_scope.l3_outs }}
 contracts = {{ $address_scope.contracts }}
 scope = {{ default "public" $address_scope.scope }}
 vrf={{ $address_scope.vrf }}
-{{ end }}
-
-{{- range $i, $fixed_binding := .Values.aci.fixed_bindings }}
-[fixed-binding:{{ $fixed_binding.name }}]
-description = {{ $fixed_binding.description }}
-bindings = {{ $fixed_binding.bindings | join "," }}
-physical_domain = {{ $global.Values.aci.aci_hostgroups.physical_domain }}
-segment_type  = {{ $global.Values.aci.aci_hostgroups.segment_type }}
-segment_id={{ $fixed_binding.segment_id }}
 {{ end }}
 
 {{ else }}

--- a/openstack/neutron/templates/etc/_ml2-conf-aci.ini.tpl
+++ b/openstack/neutron/templates/etc/_ml2-conf-aci.ini.tpl
@@ -18,6 +18,7 @@ apic_password = {{required "A valid .Values.aci required!" .Values.aci.apic_pass
 apic_use_ssl = True
 apic_application_profile = {{required "A valid .Values.aci required!" .Values.aci.apic_application_profile}}
 
+{{- if .Values.aci.aci_hostgroups }}
 tenant_default_vrf = {{.Values.aci.tenant_default_vrf}}
 flat_vlan_range={{.Values.aci.flat_vlan_range}}
 
@@ -25,15 +26,15 @@ flat_vlan_range={{.Values.aci.flat_vlan_range}}
 # VMs or devices to the ACI fabric i.e. each hypervisor or L3 node.
 
 
-{{- range $i, $aci_hostgroup := .Values.aci.bindings.aci_hostgroups }}
+{{- range $i, $aci_hostgroup := .Values.aci.aci_hostgroups.hostgroups }}
 [aci-hostgroup:{{ $aci_hostgroup.name }}]
 hosts = {{ $aci_hostgroup.hosts | join "," }}
 bindings = {{ $aci_hostgroup.bindings | join "," }}
-physical_domain = {{ $global.Values.aci.bindings.physical_domain }}
+physical_domain = {{ $global.Values.aci.aci_hostgroups.physical_domain }}
 physical_network = {{ $aci_hostgroup.name }}
-segment_type  = {{ $global.Values.aci.bindings.segment_type }}
-segment_range = {{ $global.Values.aci.bindings.segment_range }}
-{{- end }}
+segment_type  = {{ $global.Values.aci.aci_hostgroups.segment_type }}
+segment_range = {{ default $global.Values.aci.aci_hostgroups.segment_range $aci_hostgroup.segment_range }}
+{{ end }}
 
 
 #AddressScope
@@ -41,7 +42,20 @@ segment_range = {{ $global.Values.aci.bindings.segment_range }}
 {{ $address_scope.description }}
 [address-scope:{{ $address_scope.name }}]
 l3_outs = {{ $address_scope.l3_outs }}
-contracts = {{ $address_scope.contracts | toJson }}
+contracts = {{ $address_scope.contracts }}
 scope = {{ default "public" $address_scope.scope }}
 vrf={{ $address_scope.vrf }}
-{{- end }}
+{{ end }}
+
+{{- range $i, $fixed_binding := .Values.aci.fixed_bindings }}
+[fixed-binding:{{ $fixed_binding.name }}]
+description = {{ $fixed_binding.description }}
+bindings = {{ $fixed_binding.bindings | join "," }}
+physical_domain = {{ $global.Values.aci.aci_hostgroups.physical_domain }}
+segment_type  = {{ $global.Values.aci.aci_hostgroups.segment_type }}
+segment_id={{ $fixed_binding.segment_id }}
+{{ end }}
+
+{{ else }}
+{{required "A valid .Values.aci required!" .Values.aci.bindings}}
+{{ end }}

--- a/openstack/neutron/templates/etc/_ml2-conf-aci.ini.tpl
+++ b/openstack/neutron/templates/etc/_ml2-conf-aci.ini.tpl
@@ -1,4 +1,3 @@
-{{ $global := . }}
 [ml2_aci]
 sync_allocations =  {{.Values.aci.sync_allocations | default "True"}}
 tenant_manager = hash_ring
@@ -30,18 +29,18 @@ flat_vlan_range={{.Values.aci.flat_vlan_range}}
 [aci-hostgroup:{{ $aci_hostgroup.name }}]
 hosts = {{ $aci_hostgroup.hosts | join "," }}
 bindings = {{ $aci_hostgroup.bindings | join "," }}
-physical_domain = {{ $global.Values.aci.aci_hostgroups.physical_domain }}
+physical_domain = {{ $.Values.aci.aci_hostgroups.physical_domain }}
 physical_network = {{ $aci_hostgroup.name }}
-segment_type  = {{ $global.Values.aci.aci_hostgroups.segment_type }}
-segment_range = {{ default $global.Values.aci.aci_hostgroups.segment_range $aci_hostgroup.segment_range }}
+segment_type  = {{ $.Values.aci.aci_hostgroups.segment_type }}
+segment_range = {{ default $.Values.aci.aci_hostgroups.segment_range $aci_hostgroup.segment_range }}
 {{ end }}
 
 {{- range $i, $fixed_binding := .Values.aci.fixed_bindings }}
 [fixed-binding:{{ $fixed_binding.name }}]
 description = {{ $fixed_binding.description }}
 bindings = {{ $fixed_binding.bindings | join "," }}
-physical_domain = {{ $global.Values.aci.aci_hostgroups.physical_domain }}
-segment_type  = {{ $global.Values.aci.aci_hostgroups.segment_type }}
+physical_domain = {{ $.Values.aci.aci_hostgroups.physical_domain }}
+segment_type  = {{ $.Values.aci.aci_hostgroups.segment_type }}
 segment_id = {{ $fixed_binding.segment_id }}
 {{ end }}
 

--- a/openstack/neutron/templates/etc/_ml2-conf-aci.ini.tpl
+++ b/openstack/neutron/templates/etc/_ml2-conf-aci.ini.tpl
@@ -1,3 +1,4 @@
+{{ $global := . }}
 [ml2_aci]
 sync_allocations =  {{.Values.aci.sync_allocations | default "True"}}
 tenant_manager = hash_ring
@@ -17,4 +18,30 @@ apic_password = {{required "A valid .Values.aci required!" .Values.aci.apic_pass
 apic_use_ssl = True
 apic_application_profile = {{required "A valid .Values.aci required!" .Values.aci.apic_application_profile}}
 
-{{required "A valid .Values.aci required!" .Values.aci.bindings}}
+tenant_default_vrf = {{.Values.aci.tenant_default_vrf}}
+flat_vlan_range={{.Values.aci.flat_vlan_range}}
+
+# Set up host specific configuration needs to be one for each host that physically connects
+# VMs or devices to the ACI fabric i.e. each hypervisor or L3 node.
+
+
+{{- range $i, $aci_hostgroup := .Values.aci.bindings.aci_hostgroups }}
+[aci-hostgroup:{{ $aci_hostgroup.name }}]
+hosts = {{ $aci_hostgroup.hosts | join "," }}
+bindings = {{ $aci_hostgroup.bindings | join "," }}
+physical_domain = {{ $global.Values.aci.bindings.physical_domain }}
+physical_network = {{ $aci_hostgroup.name }}
+segment_type  = {{ $global.Values.aci.bindings.segment_type }}
+segment_range = {{ $global.Values.aci.bindings.segment_range }}
+{{- end }}
+
+
+#AddressScope
+{{- range $i, $address_scope := .Values.aci.address_scopes }}
+{{ $address_scope.description }}
+[address-scope:{{ $address_scope.name }}]
+l3_outs = {{ $address_scope.l3_outs }}
+contracts = {{ $address_scope.contracts | toJson }}
+scope = {{ default "public" $address_scope.scope }}
+vrf={{ $address_scope.vrf }}
+{{- end }}


### PR DESCRIPTION
Introduce templating to support yaml configuration of ACI bindings and address scopes . Has backward compatibility with old configuration format