### PR TITLE
[neutron] Mount nsxv3-agent volumes from projected configMap

### DIFF
--- a/openstack/neutron/templates/vct-nsxv3-agent-deployment.yaml
+++ b/openstack/neutron/templates/vct-nsxv3-agent-deployment.yaml
@@ -71,29 +71,8 @@ template: |
               cpu: "128m"
               memory: "512Mi"
           volumeMounts:
-          - mountPath: /etc/neutron/neutron.conf
-            name: neutron-etc
-            subPath: neutron.conf
-            readOnly: true
-          - mountPath: /etc/neutron/api-paste.ini
-            name: neutron-etc
-            subPath: api-paste.ini
-            readOnly: true
-          - mountPath: /etc/neutron/policy.json
-            name: neutron-etc
-            subPath: neutron-policy.json
-            readOnly: true
-          - mountPath: /etc/neutron/logging.conf
-            name: neutron-etc
-            subPath: logging.conf
-            readOnly: true
-          - mountPath: /etc/neutron/plugins/ml2/ml2-conf.ini
-            name: neutron-etc
-            subPath: ml2-conf.ini
-            readOnly: true
-          - mountPath: /etc/neutron/plugins/ml2/ml2-nsxv3.ini
-            name: ml2-conf-nsxv3
-            subPath: ml2-nsxv3.ini
+          - mountPath: /etc/neutron
+            name: etc-neutron
             readOnly: true
         - name: exporter
           image: {{ default "hub.global.cloud.sap" .Values.global.imageRegistry }}/monsoon/nsx-t-exporter:{{.Values.imageVersionNSXTExporter | required "Please set neutron.imageVersionNSXTExporter"}}
@@ -121,11 +100,27 @@ template: |
             - name: SCRAP_SCHEDULE_SECONDS
               values: "300"
         volumes:
-        - name: neutron-etc
-          configMap:
-            name: neutron-etc
-        - name: ml2-conf-nsxv3
-          configMap:
-            name: neutron-ml2-nsxv3-{= name =}
+        - name: etc-neutron
+          projected:
+            defaultMode: 420
+            sources:
+            - configMap:
+                items:
+                - key: neutron.conf
+                  path: neutron.conf
+                - key: api-paste.ini
+                  path: api-paste.ini
+                - key: neutron-policy.json
+                  path: policy.json
+                - key: logging.conf
+                  path: logging.conf
+                - key: ml2-conf.ini
+                  path: plugins/ml2/ml2-conf.ini
+                name: neutron-etc
+            - configMap:
+                items:
+                - key: ml2-nsxv3.ini
+                  path: plugins/ml2/ml2-nsxv3.ini
+                name: neutron-ml2-nsxv3-{= name =}
   {% endif %}
 {{- end }}


### PR DESCRIPTION
We still have crashlooping nsxv3-agent pods when the neutron-nsxv3-agent
container exits (e.g. when the process is killed manually or by
exception). Fabian Ruff found a bug, that should explain the behavior:
  https://github.com/kubernetes/kubernetes/issues/68211#issuecomment-467032048

This bug also contains a workaround, that's implemented here: use a
projected configMap instead of mounting directly from the original ones.
This way, an updated configMap will not be seen by the restarting
container and thus will not lead to the crashloop we've seen.