### PR TITLE
Revert "[neutron] Mount nsxv3-agent volumes from projected configMap"

### DIFF
--- a/openstack/neutron/templates/vct-nsxv3-agent-deployment.yaml
+++ b/openstack/neutron/templates/vct-nsxv3-agent-deployment.yaml
@@ -71,8 +71,29 @@ template: |
               cpu: "128m"
               memory: "512Mi"
           volumeMounts:
-          - mountPath: /etc/neutron
-            name: etc-neutron
+          - mountPath: /etc/neutron/neutron.conf
+            name: neutron-etc
+            subPath: neutron.conf
+            readOnly: true
+          - mountPath: /etc/neutron/api-paste.ini
+            name: neutron-etc
+            subPath: api-paste.ini
+            readOnly: true
+          - mountPath: /etc/neutron/policy.json
+            name: neutron-etc
+            subPath: neutron-policy.json
+            readOnly: true
+          - mountPath: /etc/neutron/logging.conf
+            name: neutron-etc
+            subPath: logging.conf
+            readOnly: true
+          - mountPath: /etc/neutron/plugins/ml2/ml2-conf.ini
+            name: neutron-etc
+            subPath: ml2-conf.ini
+            readOnly: true
+          - mountPath: /etc/neutron/plugins/ml2/ml2-nsxv3.ini
+            name: ml2-conf-nsxv3
+            subPath: ml2-nsxv3.ini
             readOnly: true
         - name: exporter
           image: {{ default "hub.global.cloud.sap" .Values.global.imageRegistry }}/monsoon/nsx-t-exporter:{{.Values.imageVersionNSXTExporter | required "Please set neutron.imageVersionNSXTExporter"}}
@@ -100,27 +121,11 @@ template: |
             - name: SCRAP_SCHEDULE_SECONDS
               values: "300"
         volumes:
-        - name: etc-neutron
-          projected:
-            defaultMode: 420
-            sources:
-            - configMap:
-                items:
-                - key: neutron.conf
-                  path: neutron.conf
-                - key: api-paste.ini
-                  path: api-paste.ini
-                - key: neutron-policy.json
-                  path: policy.json
-                - key: logging.conf
-                  path: logging.conf
-                - key: ml2-conf.ini
-                  path: plugins/ml2/ml2-conf.ini
-                name: neutron-etc
-            - configMap:
-                items:
-                - key: ml2-nsxv3.ini
-                  path: plugins/ml2/ml2-nsxv3.ini
-                name: neutron-ml2-nsxv3-{= name =}
+        - name: neutron-etc
+          configMap:
+            name: neutron-etc
+        - name: ml2-conf-nsxv3
+          configMap:
+            name: neutron-ml2-nsxv3-{= name =}
   {% endif %}
 {{- end }}


### PR DESCRIPTION
Reverts sapcc/helm-charts#1094

  Warning  Failed                 2m               kubelet, minion7.cc.qa-de-1.cloud.sap  Error: failed to start container "neutron-nsxv3-agent": Error response from daemon: OCI runtime create failed: container_linux.go:348: starting container process caused "process_linux.go:402: container init caused \"rootfs_linux.go:58: mounting \\\"/var/lib/kubelet/pods/72570950-4739-11ea-9aa7-0a580ab4030f/volume-subpaths/etc-neutron/neutron-nsxv3-agent/0\\\" to rootfs \\\"/var/lib/docker/overlay2/94e6b613aae8d62480a753984c9239d5a44861bc0ea490347521e66b72b5dcc4/merged\\\" at \\\"/var/lib/docker/overlay2/94e6b613aae8d62480a753984c9239d5a44861bc0ea490347521e66b72b5dcc4/merged/etc/neutron\\\" caused \\\"not a directory\\\"\"": unknown: Are you trying to mount a directory onto a file (or vice-versa)? Check if the specified host path exists and is the expected type