### PR TITLE
added esxi-exporter to prometheus-infra-collector & federation

### DIFF
--- a/system/infra-monitoring/templates/_prometheus-infra-collector.yaml.tpl
+++ b/system/infra-monitoring/templates/_prometheus-infra-collector.yaml.tpl
@@ -432,3 +432,23 @@
     - target_label: __address__
       replacement: vrops-exporter:9160
 {{- end }}
+
+#exporter is leveraging service discovery but not part of infrastructure monitoring project itself.
+{{- $values := .Values.esxi_exporter -}}
+{{- if $values.enabled }}
+- job_name: 'esxi-config'
+  scrape_interval: {{$values.scrapeInterval}}
+  scrape_timeout: {{$values.scrapeTimeout}}
+  file_sd_configs:
+      - files :
+        - /etc/prometheus/configmaps/atlas-sd/netbox.json
+  metrics_path: /
+  relabel_configs:
+    - source_labels: [job]
+      regex: vcenter
+      action: keep
+    - source_labels: [server_name]
+      target_label: __param_target
+    - target_label: __address__
+      replacement: esxi-exporter:9203
+{{- end }}

--- a/system/infra-monitoring/values.yaml
+++ b/system/infra-monitoring/values.yaml
@@ -177,3 +177,8 @@ vrops_exporter:
 
 px_exporter:
   enabled: false
+
+esxi_exporter:
+  enabled: false
+  scrapeInterval: 60m
+  scrapeTimeout: 3595s

--- a/system/prometheus-infra/templates/_prometheus-infra.yaml.tpl
+++ b/system/prometheus-infra/templates/_prometheus-infra.yaml.tpl
@@ -23,6 +23,7 @@
       - '{job="snmp"}'
       - '{job="infra-monitoring-atlas-sd"}'
       - '{job="vrops"}'
+      - '{job="esxi-config"}'
       - '{__name__=~"^vcenter_.+",job!~"[a-z0-9-]*-vccustomervmmetrics$"}'
       - '{__name__=~"^network_apic_.+"}'
       - '{__name__=~"^ipmi_sensor_state$",type=~"Memory|Drive Slot|Processor|Power Supply|Critical Interrupt|Version Change|Event Logging Disabled|System Event"}'


### PR DESCRIPTION
CPO esxi-exporter is deployed with its own pipeline.
The exporter is using atlas and therefore needs to be added to the prometheus config.