### PR TITLE
ntp_exporter: bump version

### DIFF
--- a/prometheus-exporters/ntp-exporter/Chart.yaml
+++ b/prometheus-exporters/ntp-exporter/Chart.yaml
@@ -1,3 +1,3 @@
 description: Prometheus NTP Exporter
 name: ntp-exporter
-version: 1.1.0
+version: 1.1.1

--- a/prometheus-exporters/ntp-exporter/values.yaml
+++ b/prometheus-exporters/ntp-exporter/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: sapcc/ntp-exporter
-  tag: v1.1.0
+  tag: v1.1.1
 
 ntp:
   server: timehost1.cc.cloud.sap


### PR DESCRIPTION
Dependencies were updated on the upstream repo, hence the bump.

/cc @majewsky