### PR TITLE
prometheus-openstack uses kube-state-metrics-exporter

### DIFF
--- a/openstack/prometheus-openstack/Chart.yaml
+++ b/openstack/prometheus-openstack/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A helm chart for OpenStack monitoring tools.
 name: openstack-prometheus
-version: 0.1.2
+version: 0.1.3

--- a/openstack/prometheus-openstack/requirements.lock
+++ b/openstack/prometheus-openstack/requirements.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: prometheus-server
   repository: https://charts.eu-de-2.cloud.sap
   version: 3.3.4
-digest: sha256:71218c3555ec9fe88887363dfc7eb0e334bd6a4cdc61b4a2a0b26ea9aa3a0177
-generated: 2020-01-27T14:36:21.9866+01:00
+- name: kube-state-metrics-exporter
+  repository: https://charts.eu-de-2.cloud.sap
+  version: 0.1.6
+digest: sha256:ae5e3a886361445cd044291a7f42d4d42c6edaa6f47b02519b52f4241b70f280
+generated: 2020-02-10T15:07:18.182021083+01:00

--- a/openstack/prometheus-openstack/requirements.lock
+++ b/openstack/prometheus-openstack/requirements.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 3.3.4
 - name: kube-state-metrics-exporter
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.6
-digest: sha256:ae5e3a886361445cd044291a7f42d4d42c6edaa6f47b02519b52f4241b70f280
-generated: 2020-02-10T15:07:18.182021083+01:00
+  version: 0.1.7
+digest: sha256:554abbcfc39bedaf5e6a816fe1b6f7fd5637a47ad701cae0cb9b59a2c3a3667d
+generated: 2020-02-12T13:07:39.643569175+01:00

--- a/openstack/prometheus-openstack/requirements.yaml
+++ b/openstack/prometheus-openstack/requirements.yaml
@@ -5,4 +5,4 @@ dependencies:
     version: 3.3.4
   - name: kube-state-metrics-exporter
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.6
+    version: 0.1.7

--- a/openstack/prometheus-openstack/requirements.yaml
+++ b/openstack/prometheus-openstack/requirements.yaml
@@ -3,3 +3,6 @@ dependencies:
     alias: openstack-prometheus
     repository: https://charts.eu-de-2.cloud.sap
     version: 3.3.4
+  - name: kube-state-metrics-exporter
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 0.1.6

--- a/openstack/prometheus-openstack/values.yaml
+++ b/openstack/prometheus-openstack/values.yaml
@@ -43,3 +43,6 @@ openstack-prometheus:
       - alertmanager.eu-de-1.cloud.sap
       - alertmanager.scaleout.eu-de-1.cloud.sap
       - alertmanager.scaleout.eu-nl-1.cloud.sap
+
+kube-state-metrics-exporter:
+  prometheusName: openstack

--- a/prometheus-exporters/kube-state-metrics-exporter/Chart.yaml
+++ b/prometheus-exporters/kube-state-metrics-exporter/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Helm chart for collecting metrics from kube-state-metrics.
 name: kube-state-metrics-exporter
-version: 0.1.6
+version: 0.1.7

--- a/prometheus-exporters/kube-state-metrics-exporter/templates/servicemonitor.yaml
+++ b/prometheus-exporters/kube-state-metrics-exporter/templates/servicemonitor.yaml
@@ -10,7 +10,10 @@ metadata:
 spec:
   selector:
     matchLabels:
-{{ required ".Values.labelSelector missing" .Values.labelSelector | toYaml | indent 6 }}
+      {{ required ".Values.labelSelector missing" .Values.labelSelector | toYaml | nindent 6 }}
+
+  namespaceSelector:
+    any: true
 
   endpoints:
     - port: http

--- a/system/kube-monitoring-metal/Chart.yaml
+++ b/system/kube-monitoring-metal/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Kubernetes metal controlplane monitoring.
 name: kube-monitoring-metal
-version: 1.4.3
+version: 1.4.4

--- a/system/kube-monitoring-metal/values.yaml
+++ b/system/kube-monitoring-metal/values.yaml
@@ -164,14 +164,6 @@ kube-state-metrics:
 
   prometheusScrape: false
 
-  # The annotations can be removed once the openstack prometheus consumes kube-state-metrics via the
-  # kube-state-metrics-exporter dependency.
-  podAnnotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "8080"
-    prometheus.io/port_1: "8081"
-    prometheus.io/targets: "openstack"
-
   collectors:
     # Not useful.
     configmaps: false


### PR DESCRIPTION
Using the [kube-state-metrics-exporter](https://github.com/sapcc/helm-charts/tree/master/prometheus-exporters/kube-state-metrics-exporter) the OpenStack Prometheus can use the normalized metrics introduced in today's presentation.