### PR TITLE
[mariadb] refine backup alerts

### DIFF
--- a/common/mariadb/templates/alerts/_backup.alerts.tpl
+++ b/common/mariadb/templates/alerts/_backup.alerts.tpl
@@ -13,8 +13,8 @@
       summary: {{ include "fullName" . }} backup missing
 
   - alert: {{ include "alerts.service" . | title }}MariaDatabaseBackupAge2Hours
-    expr: floor((time() - backup_last_success{app=~"{{ include "fullName" . }}"}) / 60 / 60) >= 2
-    for: 10m
+    expr: floor((time() - backup_last_success{app=~"{{ include "fullName" . }}"}) / 60 / 60) >= 1
+    for: 1h
     labels:
       context: backupage
       meta: "{{`{{ $labels.app }}`}}"
@@ -27,8 +27,8 @@
       summary: Database Backup too old
 
   - alert: {{ include "alerts.service" . | title }}MariaDatabaseBackupAge4Hours
-    expr: floor((time() - backup_last_success{app=~"{{ include "fullName" . }}"}) / 60 / 60) >= 4
-    for: 10m
+    expr: floor((time() - backup_last_success{app=~"{{ include "fullName" . }}"}) / 60 / 60) >= 3
+    for: 1h
     labels:
       context: backupage
       meta: "{{`{{ $labels.app }}`}}"


### PR DESCRIPTION
Longer range to remove false positives due to backup container restart.
If the backup age has been older than 3 hours for 1 hour, it is 4 hours old now.