### PR TITLE
[neutron] set rpc_response_timeout to default value (60 sec) and set higher…

### DIFF
--- a/openstack/neutron/templates/etc/_dhcp-agent.ini.tpl
+++ b/openstack/neutron/templates/etc/_dhcp-agent.ini.tpl
@@ -19,3 +19,4 @@ interface_driver = openvswitch
 
 rpc_response_timeout = {{ .Values.rpc_response_timeout | default .Values.global.rpc_response_timeout | default 50 }}
 rpc_workers = {{ .Values.rpc_workers | default .Values.global.rpc_workers | default 5 }}
+rpc_conn_pool_size = {{ .Values.rpc_conn_pool_size | default .Values.global.rpc_conn_pool_size | default 100 }}

--- a/openstack/neutron/templates/etc/_l3-agent.ini.tpl
+++ b/openstack/neutron/templates/etc/_l3-agent.ini.tpl
@@ -11,3 +11,4 @@ ovs_use_veth = False
 
 rpc_response_timeout = {{ .Values.rpc_response_timeout | default .Values.global.rpc_response_timeout | default 50 }}
 rpc_workers = {{ .Values.rpc_workers | default .Values.global.rpc_workers | default 5 }}
+rpc_conn_pool_size = {{ .Values.rpc_conn_pool_size | default .Values.global.rpc_conn_pool_size | default 100 }}

--- a/openstack/neutron/templates/etc/_metadata-agent.ini.tpl
+++ b/openstack/neutron/templates/etc/_metadata-agent.ini.tpl
@@ -23,6 +23,7 @@ metadata_proxy_socket = /run/metadata_proxy
 
 rpc_response_timeout = {{ .Values.metadata_rpc_response_timeout | default .Values.global.rpc_response_timeout | default 50 }}
 rpc_workers = {{ .Values.rpc_workers | default .Values.global.rpc_workers | default 5 }}
+rpc_conn_pool_size = {{ .Values.rpc_conn_pool_size | default .Values.global.rpc_conn_pool_size | default 100 }}
 metadata_workers = {{ .Values.agent.metadata_workers | default .Values.global.metadata_workers | default 1 }}
 
 [cache]

--- a/openstack/neutron/templates/etc/_neutron-lbaas.conf.tpl
+++ b/openstack/neutron/templates/etc/_neutron-lbaas.conf.tpl
@@ -3,6 +3,7 @@ log_config_append = /etc/neutron/logging.conf
 
 rpc_response_timeout = {{ .Values.rpc_response_timeout | default .Values.global.rpc_response_timeout | default 50 }}
 rpc_workers = {{ .Values.rpc_workers | default .Values.global.rpc_workers | default 5 }}
+rpc_conn_pool_size = {{ .Values.rpc_conn_pool_size | default .Values.global.rpc_conn_pool_size | default 100 }}
 
 [service_providers]
 service_provider = LOADBALANCERV2:F5Networks:neutron_lbaas.drivers.f5.driver_v2.F5LBaaSV2Driver:default

--- a/openstack/neutron/templates/etc/_neutron.conf.tpl
+++ b/openstack/neutron/templates/etc/_neutron.conf.tpl
@@ -51,6 +51,7 @@ advertise_mtu = True
 rpc_response_timeout = {{ .Values.rpc_response_timeout | default .Values.global.rpc_response_timeout | default 50 }}
 rpc_workers = {{ .Values.rpc_workers | default .Values.global.rpc_workers | default 5 }}
 rpc_state_report_workers = {{ .Values.rpc_state_workers | default .Values.global.rpc_state_workers | default 5 }}
+rpc_conn_pool_size = {{ .Values.rpc_conn_pool_size | default .Values.global.rpc_conn_pool_size | default 100 }}
 
 wsgi_default_pool_size = {{ .Values.wsgi_default_pool_size | default .Values.global.wsgi_default_pool_size | default 100 }}
 

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -10,6 +10,7 @@ global:
   # dbPassword:
   # imageRegistry:
   metadata_workers: 1
+  rpc_response_timeout: 60
 
 pod:
   replicas:


### PR DESCRIPTION
… rpc_conn_pool_size as some resources suggest:
https://docs.mirantis.com/mcp/q4-18/mcp-deployment-guide/advanced-config/tune-rabbitmq-perf.html 