### PR TITLE
[mariadb] warning alters when # of running threads is more than 15.

### DIFF
--- a/common/mariadb/templates/alerts/_mysql.alerts.tpl
+++ b/common/mariadb/templates/alerts/_mysql.alerts.tpl
@@ -37,13 +37,13 @@
       summary: {{ include "fullName" . }} has queries waiting for lock.
 
   - alert: {{ include "alerts.service" . | title }}MariaDBHighRunningThreads
-    expr: (mysql_global_status_threads_running{app=~"{{ include "fullName" . }}"} > 15)
-    for: 5m
+    expr: (mysql_global_status_threads_running{app=~"{{ include "fullName" . }}"} > 20)
+    for: 10m
     labels:
       context: database
       service: {{ include "alerts.service" . }}
       severity: warning
       tier: {{ required ".Values.alerts.tier missing" .Values.alerts.tier }}
     annotations:
-      description: {{ include "fullName" . }} has more than 15 running threads.
+      description: {{ include "fullName" . }} has more than 20 running threads.
       summary: {{ include "fullName" . }} running threads high.

--- a/common/mariadb/templates/alerts/_mysql.alerts.tpl
+++ b/common/mariadb/templates/alerts/_mysql.alerts.tpl
@@ -35,3 +35,15 @@
     annotations:
       description: {{ include "fullName" . }} has queries waiting for lock more than 15 sec. Deadlock possible.
       summary: {{ include "fullName" . }} has queries waiting for lock.
+
+  - alert: {{ include "alerts.service" . | title }}MariaDBHighRunningThreads
+    expr: (mysql_global_status_threads_running{app=~"{{ include "fullName" . }}"} > 15)
+    for: 5m
+    labels:
+      context: database
+      service: {{ include "alerts.service" . }}
+      severity: warning
+      tier: {{ required ".Values.alerts.tier missing" .Values.alerts.tier }}
+    annotations:
+      description: {{ include "fullName" . }} has more than 15 running threads.
+      summary: {{ include "fullName" . }} running threads high.


### PR DESCRIPTION
To detect the mysqldump issues earlier. The MariaDBWaitingForLock alert will fire only when other writing queries  take place and time out. But the threshold 15, might be aggressive. 