### PR TITLE
cinder:  update liveness probe for backup

### DIFF
--- a/openstack/cinder/templates/backup_deployment.yaml
+++ b/openstack/cinder/templates/backup_deployment.yaml
@@ -55,14 +55,10 @@ template: |{{`
             value: cinder-volume-backup-vmware-{{ name }}
           livenessProbe:
             exec:
-              command:
-              - bash
-              - -e
-              - -c
-              - source <(grep -Pzo '\[keystone_authtoken\][^[]*' /etc/cinder/cinder.conf | tr -d '\000' | while read var equal val; do test "$equal" = "=" && echo export OS_${var^^}=${val} ; done); export OS_IDENTITY_API_VERSION=3; test "$(openstack volume service list -f value --host "cinder-backup-{{ name }}" -c State)" = "up"
+              command: ["openstack-agent-liveness", "--component", "cinder", "--config-file", "/etc/cinder/cinder.conf", "--config-file", "/etc/cinder/cinder-backup.conf"]
             initialDelaySeconds: 60
-            periodSeconds: 10
-            failureThreshold: 3
+            periodSeconds: 60
+            timeoutSeconds: 20
           volumeMounts:
           - name: etccinder
             mountPath: /etc/cinder


### PR DESCRIPTION
This patch changes the liveness probe for cinder backup container.

After we changed the base image from kolla to loci, the existing
liveness probe command for cinder backup failed.  This patch updates
the liveness probe command to work the same way as the cinder volume
container, which uses openstack-agent-liveness.