### PR TITLE
[seeds] glance and ironic depend on swift

### DIFF
--- a/openstack/glance/ci/test-values.yaml
+++ b/openstack/glance/ci/test-values.yaml
@@ -5,3 +5,8 @@ global:
   imageRegistry: myRegistry
 
 imageVersionGlanceApi: rocky
+
+rabbitmq_notifications:
+  users:
+    default:
+      password: secret!

--- a/openstack/glance/templates/seeds.yaml
+++ b/openstack/glance/templates/seeds.yaml
@@ -15,6 +15,7 @@ spec:
 {{- if .Values.tempest.enabled }}
   - monsoon3/domain-tempest-seed
 {{- end }}
+  - swift/swift-seed
 
   roles:
   - name: cloud_image_admin
@@ -62,6 +63,8 @@ spec:
       role_assignments:
       - user: image-build@Default
         role: cloud_image_admin
+      - user: glance@Default
+        role: swiftoperator
     - name: BaremetalMonitoring
       description: 'Appliances used for monitoring bare metal servers'
       role_assignments:

--- a/openstack/ironic/ci/test-values.yaml
+++ b/openstack/ironic/ci/test-values.yaml
@@ -1,0 +1,19 @@
+global:
+  pgbouncer:
+    imageTag: "20190123.2"
+  master_password: topSecret
+  dbPassword: secret
+
+imageVersion: train
+
+postgresql:
+  postgresPassword: secret123
+inspectordbPassword: secret!
+console:
+  secret: another-secret
+
+swift_tempurl: my-swift-url
+swift_account: my-swift-acc
+
+network_cleaning_uuid: some-uuid
+network_management_uuid: another-uuid

--- a/openstack/ironic/templates/seed.yaml
+++ b/openstack/ironic/templates/seed.yaml
@@ -320,6 +320,8 @@ spec:
         role: cloud_baremetal_admin
       - user: ipmi_exporter@Default
         role: cloud_compute_admin
+      - user: ironic@Default
+        role: swiftoperator
     groups:
     - name: CCADMIN_CLOUD_ADMINS
       role_assignments:

--- a/openstack/swift/templates/seeds.yaml
+++ b/openstack/swift/templates/seeds.yaml
@@ -72,13 +72,9 @@ spec:
         role: swiftoperator
       - user: docker_registry@Default
         role: swiftoperator
-      - user: glance@Default
-        role: swiftoperator
       - user: image-build@Default
         role: swiftoperator
       - user: quay@Default
-        role: swiftoperator
-      - user: ironic@Default
         role: swiftoperator
 
   - name: monsoon3


### PR DESCRIPTION
The recent region buildup showed these dependencies, so I move the ccadmin/master swiftoperator role_assignment from the swift seed to the dependent service seeds