### PR TITLE
cinder: Add missing path for rootwrap and sudoer

### DIFF
--- a/openstack/cinder/templates/backup_deployment.yaml
+++ b/openstack/cinder/templates/backup_deployment.yaml
@@ -82,6 +82,10 @@ template: |{{`
             mountPath: /etc/cinder/logging.ini
             subPath: logging.ini
             readOnly: true
+          - name: cinder-etc
+            mountPath: /etc/sudoers
+            subPath: sudoers
+            readOnly: true
           - name: backup-config
             mountPath: /etc/cinder/cinder-backup.conf
             subPath: cinder-backup.conf

--- a/openstack/cinder/templates/etc-configmap.yaml
+++ b/openstack/cinder/templates/etc-configmap.yaml
@@ -23,6 +23,8 @@ data:
 {{- if .Values.audit.enabled }}
   cinder_audit_map.yaml: |
 {{ include (print .Template.BasePath "/etc/_cinder_audit_map.yaml.tpl") . | indent 4 }}
+  sudoers: |
+{{ include (print .Template.BasePath "/etc/_sudoers.conf.tpl") . | indent 4 }}
 {{- end }}
   logging.ini: |
 {{ include "loggerIni" .Values.logging | indent 4 }}

--- a/openstack/cinder/templates/etc/_rootwrap.conf.tpl
+++ b/openstack/cinder/templates/etc/_rootwrap.conf.tpl
@@ -10,7 +10,7 @@ filters_path=/etc/cinder/rootwrap.d,/usr/share/cinder/rootwrap
 # explicitely specify a full path (separated by ',')
 # If not specified, defaults to system PATH environment variable.
 # These directories MUST all be only writeable by root !
-exec_dirs=/var/lib/kolla/venv/bin,/sbin,/usr/sbin,/bin,/usr/bin,/usr/local/bin,/usr/local/sbin
+exec_dirs=/sbin,/usr/sbin,/bin,/usr/bin,/usr/local/bin,/usr/local/sbin,/var/lib/openstack/bin
 
 # Enable logging to syslog
 # Default value is False

--- a/openstack/cinder/templates/etc/_sudoers.tpl
+++ b/openstack/cinder/templates/etc/_sudoers.tpl
@@ -1,0 +1,30 @@
+#
+# This file MUST be edited with the 'visudo' command as root.
+#
+# Please consider adding local content in /etc/sudoers.d/ instead of
+# directly modifying this file.
+#
+# See the man page for details on how to write a sudoers file.
+#
+Defaults	env_reset
+Defaults	mail_badpass
+Defaults	secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:/var/lib/openstack/bin"
+
+# Host alias specification
+
+# User alias specification
+
+# Cmnd alias specification
+
+# User privilege specification
+root	ALL=(ALL:ALL) ALL
+
+# Members of the admin group may gain root privileges
+%admin ALL=(ALL) ALL
+
+# Allow members of group sudo to execute any command
+%sudo	ALL=(ALL:ALL) ALL
+
+# See sudoers(5) for more information on "#include" directives:
+
+#includedir /etc/sudoers.d


### PR DESCRIPTION
This patch adds the /var/lib/openstack/bin directory to cinder rootwrap.conf
and adds a new volume mount to /etc/sudoers, which also adds the same
dir to the secure_path so that sudo commands has the openstack bin path
in the environment.