### PR TITLE
cinder: fix etc-configmap

### DIFF
--- a/openstack/cinder/templates/etc-configmap.yaml
+++ b/openstack/cinder/templates/etc-configmap.yaml
@@ -24,7 +24,7 @@ data:
   cinder_audit_map.yaml: |
 {{ include (print .Template.BasePath "/etc/_cinder_audit_map.yaml.tpl") . | indent 4 }}
   sudoers: |
-{{ include (print .Template.BasePath "/etc/_sudoers.conf.tpl") . | indent 4 }}
+{{ include (print .Template.BasePath "/etc/_sudoers.tpl") . | indent 4 }}
 {{- end }}
   logging.ini: |
 {{ include "loggerIni" .Values.logging | indent 4 }}


### PR DESCRIPTION
This patch fixes an issue with the naming of the _sudoers.tpl file.