### PR TITLE
Revert "Added exception for bb95 to use NSX-T from bb91"

### DIFF
--- a/openstack/neutron/templates/vct-nsxv3-agent-configmap.yaml
+++ b/openstack/neutron/templates/vct-nsxv3-agent-configmap.yaml
@@ -38,9 +38,6 @@ template: |
       nsxv3_login_user = admin
       {%- set bb = name | replace( "bb", "") | int %}
       {%- set hostname = "nsx-ctl-" + "bb" + ( '%03d' % bb ) + "." + domain %}
-      {% if name == "bb95" %}
-      {%- set hostname = "nsx-ctl-bb091.cc.qa-de-1.cloud.sap" %}
-      {% endif %}
       nsxv3_login_hostname = {= hostname =}
       nsxv3_login_password = {= username | derive_password(hostname) | quote =}
       {%- set tzname = "bb" + ( '%03d' % bb ) + "-vlan" %}


### PR DESCRIPTION
BB095's NSX Manager moves to it's own manager node