### PR TITLE
cinder: fix sudoers for cinder-volume

### DIFF
--- a/openstack/cinder/templates/volumes/_volume-deployment.yaml.tpl
+++ b/openstack/cinder/templates/volumes/_volume-deployment.yaml.tpl
@@ -73,6 +73,10 @@ spec:
           mountPath: /etc/cinder/cinder-volume.conf
           subPath: cinder-volume.conf
           readOnly: true
+        - name: cinder-etc
+          mountPath: /etc/sudoers
+          subPath: sudoers
+          readOnly: true
       volumes:
       - name: etccinder
         emptyDir: {}


### PR DESCRIPTION
This patch adds the /etc/sudoers to the cinder-volume-*
containers.  This is needed for privsep to be able to call
cinder-rootwrap during volume migration.