### PR TITLE
Fix export backup policy typo

### DIFF
--- a/openstack/cinder/templates/etc/_cinder-policy.json.tpl
+++ b/openstack/cinder/templates/etc/_cinder-policy.json.tpl
@@ -100,7 +100,7 @@
   "backup:get_all": "rule:context_is_editor",
   "backup:restore": "rule:context_is_editor",
   "backup:backup-import": "rule:context_is_editor",
-  "backup:backup-export": "rule:context_is_editor",
+  "backup:export-import": "rule:context_is_editor",
 
   "snapshot_extension:snapshot_actions:update_snapshot_status": "rule:context_is_admin",
   "snapshot_extension:snapshot_manage": "rule:context_is_admin",


### PR DESCRIPTION
https://github.com/openstack/cinder/blob/4ea245640b0421246eef0cae1dd4fa11d31fc6ae/cinder/policies/backups.py#L28