### PR TITLE
[openstack][nova] Fix typo in bigvm antiaff. host group name

### DIFF
--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -240,7 +240,7 @@ compute:
       pbm_enabled: false
       pbm_default_policy: "nova-ephemeral"
       smbios_asset_tag: "SAP CCloud VM"
-      bigvm_deployment_free_host_hostgroup_name: "bigvm_free_host_antiaffinity_hostroup"
+      bigvm_deployment_free_host_hostgroup_name: "bigvm_free_host_antiaffinity_hostgroup"
 
 conductor: {}
 


### PR DESCRIPTION
Probably didn't break anything, but might avoid some confusion later.