### PR TITLE
move swift-http-import image to Keppel

### DIFF
--- a/openstack/backup-replication/templates/_utils.tpl
+++ b/openstack/backup-replication/templates/_utils.tpl
@@ -5,9 +5,9 @@ When passed via `helm upgrade --set`, the image tag is misinterpreted as a float
     {{ required "This release should be installed by the deployment pipeline!" "" }}
   {{- else -}}
     {{- if typeIs "float64" .Values.swift_http_import.image_tag -}}
-      {{$.Values.swift_http_import.image}}:{{$.Values.swift_http_import.image_tag | printf "%0.f"}}
+      {{$.Values.global.registry}}/swift-http-import:{{$.Values.swift_http_import.image_tag | printf "%0.f"}}
     {{- else -}}
-      {{$.Values.swift_http_import.image}}:{{$.Values.swift_http_import.image_tag}}
+      {{$.Values.global.registry}}/swift-http-import:{{$.Values.swift_http_import.image_tag}}
     {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/openstack/backup-replication/templates/replication-deployment.yaml
+++ b/openstack/backup-replication/templates/replication-deployment.yaml
@@ -32,7 +32,7 @@ spec:
       containers:
       - name: swift-http-import
         image: {{include "swift_http_import_image" $}}
-        imagePullPolicy: {{ $.Values.swift_http_import.image_pull_policy }}
+        imagePullPolicy: IfNotPresent
         command:
         - /sbin/tini
         args:

--- a/openstack/backup-replication/values.yaml
+++ b/openstack/backup-replication/values.yaml
@@ -1,10 +1,9 @@
 global:
   region: DEFINED_IN_VALUES_FILE
+  registry: DEFINED_IN_VALUES_FILE
 
 swift_http_import:
-  image: sapcc/swift-http-import
-  image_tag: latest
-  image_pull_policy: IfNotPresent
+  image_tag: DEFINED_IN_VALUES_FILE
   debug: 'false'
   sleep_for: 3600
   transfer_workers: 3

--- a/openstack/content-repo/ci/test-values.yaml
+++ b/openstack/content-repo/ci/test-values.yaml
@@ -1,3 +1,4 @@
 global:
   tld: example.com
   region: regionOne
+  registry: registry.example.com/ccloud

--- a/openstack/content-repo/templates/mirror-cronjob.yaml
+++ b/openstack/content-repo/templates/mirror-cronjob.yaml
@@ -28,7 +28,7 @@ spec:
             secretName: swift-http-import
       containers:
       - name: swift-http-import
-        image: {{$.Values.global.docker_repo}}/swift-http-import:{{ include "image_version" $.Values }}
+        image: {{$.Values.global.registry}}/swift-http-import:{{ include "image_version" $.Values }}
         args:
           - /etc/http-import/config/{{$repo}}.yaml
         {{- if or $.Values.debug $config.debug }}

--- a/openstack/content-repo/templates/mirror-deployment.yaml
+++ b/openstack/content-repo/templates/mirror-deployment.yaml
@@ -41,7 +41,7 @@ spec:
           secretName: swift-http-import
       containers:
       - name: swift-http-import
-        image: {{$.Values.global.docker_repo}}/swift-http-import:{{ include "image_version" $.Values }}
+        image: {{$.Values.global.registry}}/swift-http-import:{{ include "image_version" $.Values }}
         command:
           - /sbin/tini
         args:

--- a/openstack/content-repo/values.yaml
+++ b/openstack/content-repo/values.yaml
@@ -1,13 +1,18 @@
-image_version: DEFINED_IN_REGION_CHART
+global:
+  tld: DEFINED_IN_VALUES_FILE
+  region: DEFINED_IN_VALUES_FILE
+  registry: DEFINED_IN_VALUES_FILE
+
+image_version: DEFINED_IN_VALUES_FILE
 debug: false
 
 image_version_auxiliary_statsd_exporter: 'v0.8.1'
 image_version_auxiliary_alpine: '3.5'
 
-auth_url: DEFINED_IN_REGION_CHART
-password: DEFINED_IN_REGION_CHART
+auth_url: DEFINED_IN_VALUES_FILE
+password: DEFINED_IN_VALUES_FILE
 
-statsd_hostname: DEFINED_IN_REGION_CHART
+statsd_hostname: DEFINED_IN_VALUES_FILE
 
 alerts:
   enabled: true
@@ -20,45 +25,45 @@ alerts:
 #     #sleep_until: "23:59:59" --> default sleep until midnight
 #     jobs:
 #       - from:
-#           url: DEFINED_IN_REGION_CHART
+#           url: DEFINED_IN_VALUES_FILE
 #         to:
-#           container:     DEFINED_IN_REGION_CHART
-#           object_prefix: DEFINED_IN_REGION_CHART
+#           container:     DEFINED_IN_VALUES_FILE
+#           object_prefix: DEFINED_IN_VALUES_FILE
 #   rhel:
 #     #sleep_for: 900 --> sleep for 900 seconds after successful mirror job before starting again
 #     transfer_workers: 2
 #     cleanup_strategy: report
 #     jobs:
 #       - from:
-#           url:  DEFINED_IN_REGION_CHART
-#           cert: DEFINED_IN_REGION_CHART
-#           key:  DEFINED_IN_REGION_CHART
-#           ca:   DEFINED_IN_REGION_CHART
+#           url:  DEFINED_IN_VALUES_FILE
+#           cert: DEFINED_IN_VALUES_FILE
+#           key:  DEFINED_IN_VALUES_FILE
+#           ca:   DEFINED_IN_VALUES_FILE
 #         to:
-#           container:     DEFINED_IN_REGION_CHART
-#           object_prefix: DEFINED_IN_REGION_CHART
+#           container:     DEFINED_IN_VALUES_FILE
+#           object_prefix: DEFINED_IN_VALUES_FILE
 #   swift-source:
 #     transfer_workers: 2
 #     cleanup_strategy: report
 #     jobs:
 #       - from:
-#           auth_url: DEFINED_IN_REGION_CHART
-#           user_name: DEFINED_IN_REGION_CHART
-#           user_domain_name: DEFINED_IN_REGION_CHART
-#           project_name: DEFINED_IN_REGION_CHART
-#           project_domain_name: DEFINED_IN_REGION_CHART
-#           password: DEFINED_IN_REGION_CHART
-#           container: DEFINED_IN_REGION_CHART
-#           object_prefix: DEFINED_IN_REGION_CHART
+#           auth_url: DEFINED_IN_VALUES_FILE
+#           user_name: DEFINED_IN_VALUES_FILE
+#           user_domain_name: DEFINED_IN_VALUES_FILE
+#           project_name: DEFINED_IN_VALUES_FILE
+#           project_domain_name: DEFINED_IN_VALUES_FILE
+#           password: DEFINED_IN_VALUES_FILE
+#           container: DEFINED_IN_VALUES_FILE
+#           object_prefix: DEFINED_IN_VALUES_FILE
 #         to:
-#           container:     DEFINED_IN_REGION_CHART
-#           object_prefix: DEFINED_IN_REGION_CHART
+#           container:     DEFINED_IN_VALUES_FILE
+#           object_prefix: DEFINED_IN_VALUES_FILE
 #         expiration:
-#           delay_seconds: DEFINED_IN_REGION_CHART
+#           delay_seconds: DEFINED_IN_VALUES_FILE
 #
 #
 # client_certs:
 #   rhel:
-#     entitlement.pem: DEFINED_IN_REGION_CHART
-#     entitlement-key.pem: DEFINED_IN_REGION_CHART
-#     ca.pem: DEFINED_IN_REGION_CHART
+#     entitlement.pem: DEFINED_IN_VALUES_FILE
+#     entitlement-key.pem: DEFINED_IN_VALUES_FILE
+#     ca.pem: DEFINED_IN_VALUES_FILE


### PR DESCRIPTION
By using `.Values.global.registry` in the backup-replication and content-repo charts.

Please only approve. I will merge this together with the corresponding PR on secrets.