### PR TITLE
[bm-cablecheck-exporter] new image v6, modified metric names target_n…

### DIFF
--- a/system/infra-monitoring/vendor/bm-cablecheck-exporter/values.yaml
+++ b/system/infra-monitoring/vendor/bm-cablecheck-exporter/values.yaml
@@ -1,2 +1,2 @@
 image: csm/cc-cablecheck-exporter
-tag: v5
+tag: v6


### PR DESCRIPTION
…ame to more specific node names