### PR TITLE
[vrops-exporter] Adjust thresholds and severity for datastore alerts

### DIFF
--- a/prometheus-exporters/vrops-exporter/alerts/datastore.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/datastore.alerts
@@ -2,28 +2,28 @@ groups:
 - name: datastore.alerts
   rules:
   - alert: DataStoreCapacityLeftCritical
-    expr: vrops_datastore_stats{vccluster=~".+",statkey="diskspace_total_usage_gigabytes"} / ignoring (statkey) vrops_datastore_stats{vccluster=~".+",statkey="diskspace_capacity_gigabytes"} > 0.9
+    expr: vrops_datastore_stats{vccluster=~".+",statkey="diskspace_total_usage_gigabytes"} / ignoring (statkey) vrops_datastore_stats{vccluster=~".+",statkey="diskspace_capacity_gigabytes"} > 0.95
+    for: 20m
+    labels:
+      severity: critical
+      tier: vmware
+      service: storage
+      context: "vrops-exporter"
+      meta: "Datastore {{ $labels.datastore }} utilization > 95% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      playbook: docs/support/playbook/datastore/datastorediskusagealarm.html
+    annotations:
+      description: "Datastore {{ $labels.datastore }} utilization > 95% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      summary: "Datastore {{ $labels.datastore }} utilization > 95% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+  - alert: DataStoreCapacityLeftWarning
+    expr: vrops_datastore_stats{vccluster=~".+",statkey="diskspace_total_usage_gigabytes"} / ignoring (statkey) vrops_datastore_stats{vccluster=~".+",statkey="diskspace_capacity_gigabytes"} > 0.8
     for: 20m
     labels:
       severity: warning
       tier: vmware
       service: storage
       context: "vrops-exporter"
-      meta: "Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      meta: "Datastore {{ $labels.datastore }} utilization > 80% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
       playbook: docs/support/playbook/datastore/datastorediskusagealarm.html
     annotations:
-      description: "Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
-      summary: "Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
-  - alert: DataStoreCapacityLeftWarning
-    expr: vrops_datastore_stats{vccluster=~".+",statkey="diskspace_total_usage_gigabytes"} / ignoring (statkey) vrops_datastore_stats{vccluster=~".+",statkey="diskspace_capacity_gigabytes"} > 0.75
-    for: 20m
-    labels:
-      severity: info
-      tier: vmware
-      service: storage
-      context: "vrops-exporter"
-      meta: "Datastore {{ $labels.datastore }} utilization > 75% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
-      playbook: docs/support/playbook/datastore/datastorediskusagealarm.html
-    annotations:
-      description: "Datastore {{ $labels.datastore }} utilization > 75% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
-      summary: "Datastore {{ $labels.datastore }} utilization > 75% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      description: "Datastore {{ $labels.datastore }} utilization > 80% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      summary: "Datastore {{ $labels.datastore }} utilization > 80% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"

--- a/prometheus-exporters/vrops-exporter/alerts/datastore.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/datastore.alerts
@@ -2,23 +2,23 @@ groups:
 - name: datastore.alerts
   rules:
   - alert: DataStoreCapacityLeftCritical
-    expr: vrops_datastore_stats{vccluster=~".+",statkey="diskspace_total_usage_gigabytes"} / ignoring (statkey) vrops_datastore_stats{vccluster=~".+",statkey="diskspace_capacity_gigabytes"} > 0.95
+    expr: vrops_datastore_stats{vccluster=~".+",statkey="diskspace_total_usage_gigabytes"} / ignoring (statkey) vrops_datastore_stats{vccluster=~".+",statkey="diskspace_capacity_gigabytes"} > 0.9
     for: 20m
     labels:
       severity: critical
       tier: vmware
       service: storage
       context: "vrops-exporter"
-      meta: "Datastore {{ $labels.datastore }} utilization > 95% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      meta: "Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
       playbook: docs/support/playbook/datastore/datastorediskusagealarm.html
     annotations:
-      description: "Datastore {{ $labels.datastore }} utilization > 95% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
-      summary: "Datastore {{ $labels.datastore }} utilization > 95% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      description: "Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      summary: "Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
   - alert: DataStoreCapacityLeftWarning
     expr: vrops_datastore_stats{vccluster=~".+",statkey="diskspace_total_usage_gigabytes"} / ignoring (statkey) vrops_datastore_stats{vccluster=~".+",statkey="diskspace_capacity_gigabytes"} > 0.8
     for: 20m
     labels:
-      severity: warning
+      severity: info
       tier: vmware
       service: storage
       context: "vrops-exporter"


### PR DESCRIPTION
Increased the severity and changed the thresholds to 80%/95%. Approved by Martin Pink.