### PR TITLE
[Nova] Add prefer_same_host_resize weigher & multiplier

### DIFF
--- a/openstack/nova/templates/etc/_nova-scheduler.conf.tpl
+++ b/openstack/nova/templates/etc/_nova-scheduler.conf.tpl
@@ -10,6 +10,7 @@ ram_weight_multiplier = {{ .Values.scheduler.ram_weight_multiplier }}
 disk_weight_multiplier =  {{ .Values.scheduler.disk_weight_multiplier }}
 io_ops_weight_multiplier = {{ .Values.scheduler.io_ops_weight_multiplier }}
 soft_affinity_weight_multiplier = {{ .Values.scheduler.soft_affinity_weight_multiplier | default (mul .Values.quota.server_group_members 2) }}
+prefer_same_host_resize_weight_multiplier = {{ .Values.scheduler.prefer_same_host_resize_weight_multiplier }}
 scheduler_tracks_instance_changes = {{ .Values.scheduler.scheduler_tracks_instance_changes }}
 
 [scheduler]

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -223,6 +223,7 @@ scheduler:
   ram_weight_multiplier: 1.0
   disk_weight_multiplier: 1.0
   io_ops_weight_multiplier: 0.0
+  prefer_same_host_resize_weight_multiplier: 1.0
 
 compute:
   defaults:


### PR DESCRIPTION
When scheduling a resizing instance prefer the host it's already running on. This hopes to reduce resource re-allocation.

Set the weigher multiplier to 1, enabled by default.

See sapcc/nova#141.