### PR TITLE
Keppel: add redis for token caching, rate limit tracking

### DIFF
--- a/openstack/keppel/requirements.lock
+++ b/openstack/keppel/requirements.lock
@@ -5,5 +5,8 @@ dependencies:
 - name: pgmetrics
   repository: file://../../common/pgmetrics
   version: 0.1.0
-digest: sha256:5a170a7dfb1d20cbf88a04e62d49ffcf68c2fcf6db31e0664bc54ea5bc263d35
-generated: 2018-08-02T15:11:39.283405362+02:00
+- name: redis
+  repository: file://../../common/redis
+  version: 1.0.1
+digest: sha256:c57ca1aa82dd9e32dee10bccf130d266df0159e82af3c9185dc173a41f5ec6bc
+generated: 2020-04-01T16:36:38.088127249+02:00

--- a/openstack/keppel/requirements.yaml
+++ b/openstack/keppel/requirements.yaml
@@ -5,3 +5,6 @@ dependencies:
   - name: pgmetrics
     repository: file://../../common/pgmetrics
     version: 0.1.0
+  - name: redis
+    repository: file://../../common/redis
+    version: 1.0.1

--- a/openstack/keppel/templates/_utils.tpl
+++ b/openstack/keppel/templates/_utils.tpl
@@ -33,8 +33,8 @@ When passed via `helm upgrade --set`, the image tag is misinterpreted as a float
   value: 'keystone'
 - name:  KEPPEL_DRIVER_NAMECLAIM
   value: 'openstack-basic'
-- name:  KEPPEL_DRIVER_ORCHESTRATION
-  value: 'kubernetes'
+- name:  KEPPEL_DRIVER_RATELIMIT
+  value: 'basic'
 - name:  KEPPEL_DRIVER_STORAGE
   value: 'swift'
 - name:  KEPPEL_ISSUER_KEY
@@ -47,6 +47,16 @@ When passed via `helm upgrade --set`, the image tag is misinterpreted as a float
   value: '/etc/keppel/policy.json'
 - name:  KEPPEL_PEERS
   value: {{ $.Values.keppel.peer_hostnames | join "," | quote }}
+- name:  KEPPEL_RATELIMIT_BLOB_PULLS
+  value: '1000r/m' # per account
+- name:  KEPPEL_RATELIMIT_BLOB_PUSHES
+  value: '100r/m'  # per account
+- name:  KEPPEL_RATELIMIT_MANIFEST_PULLS
+  value: '100r/m'  # per account
+- name:  KEPPEL_RATELIMIT_MANIFEST_PUSHES
+  value: '10r/m'   # per account
+- name:  KEPPEL_REDIS_URI
+  value: 'redis://:{{$.Values.redis.redisPassword}}@{{.Release.Name}}-redis/1'
 - name:  OS_AUTH_URL
   value: "http://keystone.{{ $.Values.global.keystoneNamespace }}.svc.kubernetes.{{ $.Values.global.region }}.{{ $.Values.global.tld }}:5000/v3"
 - name:  OS_AUTH_VERSION

--- a/openstack/keppel/values.yaml
+++ b/openstack/keppel/values.yaml
@@ -23,6 +23,15 @@ keppel:
     uri: ""
     queue_name: ""
 
+# Redis is used for caching user's Keystone tokens and for tracking the
+# consumption of rate limits. Both usecases are ephemeral, so we don't need
+# persistence.
+redis:
+  persistence:
+    enabled: false
+
+  redisPassword: DEFINED_IN_VALUES_FILE
+
 pgmetrics:
   db_name: keppel
 


### PR DESCRIPTION
The only controversial part of this is the default rate limits (the `KEPPEL_RATELIMIT_...` variables).