### PR TITLE
[neutron] Remove outdated kubernetes version checks

### DIFF
--- a/openstack/neutron/templates/asr_config_agents/_deployment-asr1k.yaml.tpl
+++ b/openstack/neutron/templates/asr_config_agents/_deployment-asr1k.yaml.tpl
@@ -34,9 +34,7 @@ spec:
         prometheus.io/port_1: "{{$context.Values.l2_port_metrics |  default 9102}}"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" $context.Values.alerts.prometheus | quote }}
     spec:
-      {{- if ge $context.Capabilities.KubeVersion.Minor "7" }}
       hostname:  {{ $config_agent.hostname }}
-      {{- end }}
       containers:
         - name: neutron-asr1k
           image: {{ default "hub.global.cloud.sap" $context.Values.global.imageRegistry }}/monsoon/loci-neutron:{{$context.Values.imageVersionASR1k | default $context.Values.imageVersion | required "Please set neutron.imageVersionASR1k or similar"}}

--- a/openstack/neutron/templates/deployment-aci-agent.yaml
+++ b/openstack/neutron/templates/deployment-aci-agent.yaml
@@ -28,9 +28,7 @@ spec:
         configmap-etc-region-hash: {{ include (print $.Template.BasePath "/configmap-etc-region.yaml") . | sha256sum }}
         configmap-etc-vendor-hash: {{ include (print $.Template.BasePath "/configmap-etc-vendor.yaml") . | sha256sum }}
     spec:
-      {{- if ge .Capabilities.KubeVersion.Minor "7" }}
       hostname:  aci-agent-pet
-      {{- end }}
       containers:
         - name: neutron-aci-agent
           image: {{ default "hub.global.cloud.sap" .Values.global.imageRegistry }}/monsoon/loci-neutron:{{.Values.imageVersionACI | default .Values.imageVersion | required "Please set neutron.imageVersionACI or similar"}}

--- a/openstack/neutron/templates/deployment-f5-agent.yaml
+++ b/openstack/neutron/templates/deployment-f5-agent.yaml
@@ -31,9 +31,7 @@ spec:
         prometheus.io/port: "8000"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" $.Values.alerts.prometheus | quote }}
     spec:
-      {{- if ge $.Capabilities.KubeVersion.Minor "7" }}
       hostname: neutron-f5-{{ $lb.name }}
-      {{- end }}
       containers:
         - name: neutron-f5-agent
           image: {{ default "hub.global.cloud.sap" $.Values.global.imageRegistry }}/monsoon/loci-neutron:{{ $.Values.imageVersion | required "Please set neutron.imageVersion or similar"}}

--- a/openstack/neutron/templates/deployment-ucs-bm-ml2-agent.yaml
+++ b/openstack/neutron/templates/deployment-ucs-bm-ml2-agent.yaml
@@ -26,9 +26,7 @@ spec:
       annotations:
         pod.beta.kubernetes.io/hostname: cisco-ml2-ucsm-bm
     spec:
-      {{- if ge .Capabilities.KubeVersion.Minor "7" }}
       hostname:  cisco-ml2-ucsm-bm
-      {{- end }}
       containers:
         - name: neutron-cisco-ml2-ucsm-bm-agent
           image: {{ default "hub.global.cloud.sap" .Values.global.imageRegistry }}/monsoon/loci-neutron:{{default .Values.imageVersionUCSM | default .Values.imageVersion | required "Please set neutron.imageVersion or similar"}}

--- a/openstack/neutron/templates/loadbalancers/_deployment-f5.yaml.tpl
+++ b/openstack/neutron/templates/loadbalancers/_deployment-f5.yaml.tpl
@@ -28,9 +28,7 @@ spec:
       annotations:
         pod.beta.kubernetes.io/hostname:  f5-{{ $loadbalancer.name }}
     spec:
-      {{- if ge $context.Capabilities.KubeVersion.Minor "7" }}
       hostname:  {{ $loadbalancer.name }}
-      {{- end }}
       containers:
         - name: neutron-f5agent-{{ $loadbalancer.name }}
           image: {{ default "hub.global.cloud.sap" $context.Values.global.imageRegistry }}/monsoon/loci-neutron:{{ $context.Values.imageVersionF5 | default $context.Values.imageVersion | required "Please set neutron.imageVersionF5 or similar"}}


### PR DESCRIPTION
All our clusters run kubernetes >= 1.8. We don't need to safeguard for
older versions anymore. While the ifs didn't matter before, with helm
2.16 they started to matter, as our comparison between Float and String
broke and we would have to adapat the ifs with an integer cast anyways.
Therefore, we opted for removal.