### PR TITLE
CINDER: set max_over_subscription_ratio for vmware

### DIFF
--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -55,6 +55,7 @@ backend_defaults:
   vmware_insecure: True
   vmware_storage_profile: cinder-vvol
   vmware_profile_check_on_attach: False
+  max_over_subscription_ratio: 2
 
 cinderApiPortPublic: 443
 cinderApiPortInternal: 8776


### PR DESCRIPTION
This patch overrides the default value for max_over_subscription_ratio
for the vmware volume driver from 20 to 2.