### PR TITLE
[nova] Turn on debug logging for scheduler

### DIFF
--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -680,6 +680,9 @@ logging:
     nova:
       handlers: stdout, sentry
       level: INFO
+    nova.scheduler:
+      handlers: stdout, sentry
+      level: DEBUG
     nova.scheduler.host_manager: # You might get problems with unicodedecode errors if you decrease that
       handlers: stdout, sentry
       level: INFO


### PR DESCRIPTION
We need to see in detail what the scheduler is doing in all regions.