### PR TITLE
[cinder] update the max_over_subscription_ratio to 1.5

### DIFF
--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -55,7 +55,7 @@ backend_defaults:
   vmware_insecure: True
   vmware_storage_profile: cinder-vvol
   vmware_profile_check_on_attach: False
-  max_over_subscription_ratio: 2
+  max_over_subscription_ratio: 1.5
 
 cinderApiPortPublic: 443
 cinderApiPortInternal: 8776


### PR DESCRIPTION
After discussions of the current status in eu-de-1, we
agreed to update the max_over_subscription_ratio to 1.5
to limit the already overcommited netapp.