### PR TITLE
bump ntp-exporter to 1.1.2

### DIFF
--- a/prometheus-exporters/ntp-exporter/Chart.yaml
+++ b/prometheus-exporters/ntp-exporter/Chart.yaml
@@ -1,3 +1,3 @@
 description: Prometheus NTP Exporter
 name: ntp-exporter
-version: 1.1.1
+version: 1.1.2

--- a/prometheus-exporters/ntp-exporter/values.yaml
+++ b/prometheus-exporters/ntp-exporter/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: sapcc/ntp-exporter
-  tag: v1.1.1
+  tag: v1.1.2
 
 ntp:
   server: timehost1.cc.cloud.sap


### PR DESCRIPTION
My scheduled task for upgrading all the things came up, so ntp-exporter got the "upgrading all the things" treatment.