### PR TITLE
[cinder][tempest]  Do cleanup for all projects 1 through 18

### DIFF
--- a/openstack/tempest/cinder-tempest/templates/bin/_tempest-start-and-cleanup.sh.tpl
+++ b/openstack/tempest/cinder-tempest/templates/bin/_tempest-start-and-cleanup.sh.tpl
@@ -70,7 +70,7 @@ function cleanup_tempest_leftovers() {
     delete_groups
   done
 
-  for i in $(seq 1 8); do
+  for i in $(seq 1 18); do
     export OS_USERNAME=nova-tempestadmin${i}
     export OS_PROJECT_NAME=nova-tempest-admin${i}
     delete_groups
@@ -84,7 +84,7 @@ function cleanup_tempest_leftovers() {
     delete_volumes
   done
   
-  for i in $(seq 1 8); do
+  for i in $(seq 1 18); do
     export OS_USERNAME=nova-tempestadmin${i}
     export OS_PROJECT_NAME=nova-tempest-admin${i}
     delete_volumes


### PR DESCRIPTION
This patch changes the loop from 1 to 8 to 1 to 18 for tempest project
names to ensure cleaning up cinder related resources after a tempest
run finishes.  This cleanup script was missing cleaning up for
project names like nova-tempest16.