### PR TITLE
[cinder][tempest] non admins can't delete types or groups

### DIFF
--- a/openstack/tempest/cinder-tempest/templates/bin/_tempest-start-and-cleanup.sh.tpl
+++ b/openstack/tempest/cinder-tempest/templates/bin/_tempest-start-and-cleanup.sh.tpl
@@ -84,8 +84,6 @@ function cleanup_tempest_leftovers() {
     export OS_USERNAME=nova-tempestuser${i}
     export OS_PROJECT_NAME=nova-tempest${i}
     delete_volumes
-    delete_group_types
-    delete_volume_types
   done
   
   for i in $(seq 1 8); do


### PR DESCRIPTION
Don't ask non admin accounts to delete group_types or volume types