### PR TITLE
[manila] Make requested memory of mariadb match buffer pool size

### DIFF
--- a/openstack/manila/values.yaml
+++ b/openstack/manila/values.yaml
@@ -338,8 +338,9 @@ mariadb:
   initdb_configmap: manila-initdb
   persistence_claim:
     name: db-manila-pvclaim
-  requests:
-    memory: 6144Mi
+  resources:
+    requests:
+      memory: 6144Mi
   backup:
     enabled: true
     os_password: null # use dbBackupServicePassword from globals

--- a/openstack/manila/values.yaml
+++ b/openstack/manila/values.yaml
@@ -332,14 +332,14 @@ db_name: manila
 mariadb:
   enabled: true
   root_password: null # define in region or use master_password mechanism
-  buffer_pool_size: "8192M"
+  buffer_pool_size: "4096M"
   log_file_size: "2048M"
   name: manila
   initdb_configmap: manila-initdb
   persistence_claim:
     name: db-manila-pvclaim
   requests:
-    memory: 10240Mi
+    memory: 6144Mi
   backup:
     enabled: true
     os_password: null # use dbBackupServicePassword from globals

--- a/openstack/manila/values.yaml
+++ b/openstack/manila/values.yaml
@@ -338,6 +338,8 @@ mariadb:
   initdb_configmap: manila-initdb
   persistence_claim:
     name: db-manila-pvclaim
+  requests:
+    memory: 10240Mi
   backup:
     enabled: true
     os_password: null # use dbBackupServicePassword from globals


### PR DESCRIPTION
Manila mariadb consumes at least 8G memory, since buffer_pool_size is
set to 8192M. And according to the doc, the total allocated memory is
about 10% larger than specified buffer pool size.

cf: https://mariadb.com/kb/en/innodb-buffer-pool/