### PR TITLE
[manila] fix share network metrics

### DIFF
--- a/openstack/manila/values.yaml
+++ b/openstack/manila/values.yaml
@@ -87,17 +87,17 @@ mysql_metrics:
     - help: Manila Share servers count
       labels:
       - "manila_host"
-      - "share_network_id"
+      - "share_network_subnet_id"
       - "status"
       name: openstack_manila_share_servers_count_gauge
       query: |
         SELECT
           host AS manila_host,
-          share_network_id,
+          share_network_subnet_id,
           status,
           COUNT(*) AS count_gauge
         FROM share_servers
-        GROUP BY manila_host, share_network_id, status;
+        GROUP BY manila_host, share_network_subnet_id, status;
       values:
       - "count_gauge"
     - help: Manila Shares count


### PR DESCRIPTION
In train release, the column share_network_id of share_servers table is
renamed to share_network_subset_id.