### PR TITLE
[cinder] Add new vmware_low_iops backend

### DIFF
--- a/openstack/cinder/templates/vcenter_datacenter_cinder_configmap.yaml
+++ b/openstack/cinder/templates/vcenter_datacenter_cinder_configmap.yaml
@@ -20,7 +20,7 @@ template: |
   data:
     cinder-volume.conf: |
       [DEFAULT]
-      enabled_backends = vmware
+      enabled_backends = vmware,vmware_low_iops
 
       [backend_defaults]
       vmware_host_ip = {= host =}
@@ -39,7 +39,15 @@ template: |
       [vmware]
       volume_driver = cinder.volume.drivers.vmware.vmdk.VMwareVcVmdkDriver
       volume_backend_name = vmware
+      vmware_storage_profile = {{ .Values.backends.vmware.vmware_storage_profile  }}
       extra_capabilities = '{"vcenter-shard": "{= host.split(".")[0] =}"}'
+
+      [vmware_low_iops]
+      volume_driver = cinder.volume.drivers.vmware.vmdk.VMwareVcVmdkDriver
+      volume_backend_name = vmware_low_iops
+      vmware_storage_profile = {{ .Values.backends.vmware_low_iops.vmware_storage_profile }}
+      extra_capabilities = '{"vcenter-shard": "{= host.split(".")[0] =}"}'
+
 
       [vstorageobject]
       volume_driver = cinder.volume.drivers.vmware.fcd.VMwareVStorageObjectDriver

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -53,9 +53,14 @@ backend_defaults:
   suppress_requests_ssl_warnings: True
   vmware_connection_pool_size: 10
   vmware_insecure: True
-  vmware_storage_profile: cinder-vvol
   vmware_profile_check_on_attach: False
   max_over_subscription_ratio: 1.5
+
+backends:
+    vmware:
+        vmware_storage_profile: cinder-vvol
+    vmware_low_iops:
+        vmware_storage_profile: cinder-low-iops
 
 cinderApiPortPublic: 443
 cinderApiPortInternal: 8776


### PR DESCRIPTION
This patch adds a new cinder backend labelled vmware_low_iops
that will service the slower performing iops volumes.  By adding
this backend to the existing cinder-volume.conf, cinder will
fork another cinder volume service in the same container that will
service provisioning requests.   Since the default volume type is
vmware, this new backend won't get any provisioning requests unless
there is a new volume type associated with it's volume_backend_name.

With this patch we need a new cinder volume type created, named
'standard_hdd' with the following extra specs:

vmware:storage_profile : cinder_low_iops                                                          
vmware:vmdk_type : thick                                                                          
volume_backend_name : vmware_low_iops                                                                                                                                                   

There needs to be a new storage profile created in vcenter named
'cinder_low_iops' that has SIOC enabled and a value of 1000 iops
specified.  We need to ensure this is populated on all systems before
this rolls out.