### PR TITLE
extended ironic_scrapeInterval in bios exporter

### DIFF
--- a/system/infra-monitoring/values.yaml
+++ b/system/infra-monitoring/values.yaml
@@ -138,8 +138,8 @@ vpod_cablecheck_exporter:
 
 bios_exporter:
   enabled: false
-  ironic_scrapeInterval: 140s
-  ironic_scrapeTimeout: 135s
+  ironic_scrapeInterval: 60m
+  ironic_scrapeTimeout: 59m
   vpod_scrapeInterval: 300s
   vpod_scrapeTimeout: 290s
   cisco_cp_scrapeInterval: 120s


### PR DESCRIPTION
In order to reduce the query rate by the bios exporter I set the scrape interval to 1h.