### PR TITLE
Extend Cinder API filtering for non-admin users:

### DIFF
--- a/openstack/cinder/templates/etc/_resource_filters.json.tpl
+++ b/openstack/cinder/templates/etc/_resource_filters.json.tpl
@@ -1,9 +1,9 @@
 {
-    "volume": ["name", "status", "metadata",
+    "volume": ["name~", "status", "metadata",
                "bootable", "migration_status", "availability_zone",
-               "group_id"],
+               "group_id", "user_id"],
     "backup": ["name", "status", "volume_id"],
-    "snapshot": ["name", "status", "volume_id", "metadata",
+    "snapshot": ["name~", "status", "volume_id", "metadata",
                  "availability_zone"],
     "group": [],
     "group_snapshot": ["status", "group_id"],


### PR DESCRIPTION
- volumes - enable partial match for name; enable filter user_id;
- snapshots - enable partial match for name.