### PR TITLE
[cinder] rename the new low_iops backend

### DIFF
--- a/openstack/cinder/templates/vcenter_datacenter_cinder_configmap.yaml
+++ b/openstack/cinder/templates/vcenter_datacenter_cinder_configmap.yaml
@@ -42,9 +42,9 @@ template: |
       vmware_storage_profile = {{ .Values.backends.vmware.vmware_storage_profile  }}
       extra_capabilities = '{"vcenter-shard": "{= host.split(".")[0] =}"}'
 
-      [vmware_low_iops]
+      [standard_hdd]
       volume_driver = cinder.volume.drivers.vmware.vmdk.VMwareVcVmdkDriver
-      volume_backend_name = vmware_low_iops
+      volume_backend_name = standard_hdd
       vmware_storage_profile = {{ .Values.backends.vmware_low_iops.vmware_storage_profile }}
       extra_capabilities = '{"vcenter-shard": "{= host.split(".")[0] =}"}'
 

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -60,7 +60,7 @@ backends:
     vmware:
         vmware_storage_profile: cinder-vvol
     vmware_low_iops:
-        vmware_storage_profile: cinder-low-iops
+        vmware_storage_profile: cinder-standard-hdd
 
 cinderApiPortPublic: 443
 cinderApiPortInternal: 8776


### PR DESCRIPTION
This patch renames the new vmware_low_iops backend to 'standard_hdd'
Have to update the volume type