### PR TITLE
[cinder] fix the backend name in enabled_backends

### DIFF
--- a/openstack/cinder/templates/vcenter_datacenter_cinder_configmap.yaml
+++ b/openstack/cinder/templates/vcenter_datacenter_cinder_configmap.yaml
@@ -20,7 +20,7 @@ template: |
   data:
     cinder-volume.conf: |
       [DEFAULT]
-      enabled_backends = vmware,vmware_low_iops
+      enabled_backends = vmware,standard_hdd
 
       [backend_defaults]
       vmware_host_ip = {= host =}


### PR DESCRIPTION
This patch fixes the incorrect name used in enabled_backends
to the new backend name of 'standard_hdd'