### PR TITLE
[cinder] fix the backend name usage for standard_hdd

### DIFF
--- a/openstack/cinder/templates/vcenter_datacenter_cinder_configmap.yaml
+++ b/openstack/cinder/templates/vcenter_datacenter_cinder_configmap.yaml
@@ -20,7 +20,7 @@ template: |
   data:
     cinder-volume.conf: |
       [DEFAULT]
-      enabled_backends = vmware,vmware_low_iops
+      enabled_backends = vmware,standard_hdd
 
       [backend_defaults]
       vmware_host_ip = {= host =}
@@ -45,7 +45,7 @@ template: |
       [standard_hdd]
       volume_driver = cinder.volume.drivers.vmware.vmdk.VMwareVcVmdkDriver
       volume_backend_name = standard_hdd
-      vmware_storage_profile = {{ .Values.backends.vmware_low_iops.vmware_storage_profile }}
+      vmware_storage_profile = {{ .Values.backends.standard_hdd.vmware_storage_profile }}
       extra_capabilities = '{"vcenter-shard": "{= host.split(".")[0] =}"}'
 
 

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -59,7 +59,7 @@ backend_defaults:
 backends:
     vmware:
         vmware_storage_profile: cinder-vvol
-    vmware_low_iops:
+    standard_hdd:
         vmware_storage_profile: cinder-standard-hdd
 
 cinderApiPortPublic: 443


### PR DESCRIPTION
This patch updates the usage of the new backend name of
'standard_hdd' for all references, including enabled_backends
and the configmap dictionary.