### PR TITLE
[mariadb][backupv2] runs backup service via independent pod

### DIFF
--- a/common/mariadb/templates/backup-etc-configmap.yaml
+++ b/common/mariadb/templates/backup-etc-configmap.yaml
@@ -13,7 +13,8 @@ data:
   config.yaml: |
     namespace: {{ .Release.Namespace }}
     service_name: {{ .Values.name }}
-    backup_service:
+    sidecar: false
+    backup:
       full_backup_cron_schedule: {{ .Values.backup_v2.full_backup_cron_schedule }}
       incremental_backup_in_minutes: {{ .Values.backup_v2.incremental_backup_in_minutes }}
       backup_dir: {{ .Values.backup_v2.backup_dir }}
@@ -22,23 +23,24 @@ data:
         enabled: {{ default true .Values.backup_v2.oauth.enabled}}
         provider_url: "https://auth.mariabackup.{{ .Values.global.region }}.cloud.sap"
         redirect_url: "https://{{ .Values.name }}.mariabackup.{{ .Values.global.region }}.cloud.sap"
-      maria_db:
-        user: root
-        version: {{ .Values.backup_v2.maria_db.version }}
-        password: {{ include "mariadb.root_password" . }}
-        host: {{ include "fullName" . }}
-        port: 3306
-        data_dir: ./db_prod
-        log_bin: mysqld-bin
-        databases:
-        {{- range $db := .Values.backup_v2.databases }}
-          - "{{$db}}"
-        {{- end }}
-        verify_tables:
-        {{- range $tl := .Values.backup_v2.verify_tables }}
-          - "{{$tl}}"
-        {{- end }}
-    storage_services:
+    database:
+      type: "mariadb"
+      user: root
+      version: {{ .Values.backup_v2.maria_db.version }}
+      password: {{ include "mariadb.root_password" . }}
+      host: {{ include "fullName" . }}
+      port: 3306
+      data_dir: /var/lib/mysql
+      log_name_format: mysqld-bin
+      databases:
+      {{- range $db := .Values.backup_v2.databases }}
+        - "{{$db}}"
+      {{- end }}
+      verify_tables:
+      {{- range $tl := .Values.backup_v2.verify_tables }}
+        - "{{$tl}}"
+      {{- end }}
+    storage:
       s3:
         - name: aws-{{ .Values.global.mariadb.backup_v2.aws.region }}
           aws_access_key_id: {{ .Values.global.backup_v2.aws_access_key_id }}
@@ -58,6 +60,6 @@ data:
           password: {{ .Values.backup_v2.swift.password | default .Values.global.dbBackupServicePassword | required "Please set Values.global.dbBackupServicePassword or .Values.backup.os_password" | quote }}
           region: {{ .Values.global.region }}
           container_name: "mariadb-backup-{{ .Values.global.region }}"
-    verification_services:
+    verification:
       interval_in_minutes: {{ .Values.backup_v2.verification_interval }}
 {{- end }}

--- a/common/mariadb/templates/backup-v2-deployment.yaml
+++ b/common/mariadb/templates/backup-v2-deployment.yaml
@@ -1,0 +1,101 @@
+{{- if .Values.backup_v2.enabled }}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ include "fullName" . }}-backup
+  labels:
+    system: openstack
+    type: database
+    component: {{ .Values.name }}
+spec:
+  replicas: 1
+  revisionHistoryLimit: 5
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: {{ include "fullName" . }}-backup
+  template:
+    metadata:
+      labels:
+        app: {{ include "fullName" . }}-backup
+        name: {{ template "fullName" . }}-backup
+      annotations:
+        checksum/etc: {{ include (print $.Template.BasePath  "/backup-etc-configmap.yaml") . | sha256sum }}
+{{- if .Values.metrics.enabled }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8082"
+        prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
+{{- end }}
+    spec:
+      affinity:
+{{- if .Values.nodeAffinity }}
+      {{- with .Values.nodeAffinity }}
+        nodeAffinity:
+{{ toYaml . | indent 10 }}
+      {{- end }}
+{{- else }}
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            preference:
+              matchExpressions:
+                - key: "failure-domain.beta.kubernetes.io/zone"
+                  operator: In
+                  values:
+                  - {{.Values.global.region}}a
+{{- end }}
+      containers:
+      - name: backup
+        image: "{{ default "hub.global.cloud.sap" .Values.global.imageRegistry}}/{{.Values.global.image_namespace}}/maria-back-me-up:{{ .Values.backup_v2.image_version }}"
+        command:
+          - backup
+        ports:
+          - containerPort: 8081
+            name: http
+            protocol: TCP
+          - containerPort: 8082
+            name: metrics
+            protocol: TCP
+        env:
+{{- if .Values.backup_v2.oauth.enabled }}
+        - name: OAUTH_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: mariadb-{{.Values.name}}
+              key: OAUTH_CLIENT_ID
+        - name: OAUTH_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: mariadb-{{.Values.name}}
+              key: OAUTH_CLIENT_SECRET
+        - name: OAUTH_COOKIE_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: mariadb-{{.Values.name}}
+              key: OAUTH_COOKIE_SECRET
+{{- end }}
+        - name: CONFIG_FILE
+          value: "/etc/config/config.yaml"
+        volumeMounts:
+{{- if .Values.persistence_claim.enabled }}
+        - name: mariadb-persistent-storage
+          mountPath: /var/lib/mysql
+          readOnly: false
+{{- end }}
+        - name: mariadb-backup-etc
+          mountPath: /etc/config
+          readOnly: true
+      volumes:
+        - name: mariadb-etc
+          configMap:
+            name: mariadb-{{.Values.name}}-etc
+{{- if .Values.persistence_claim.enabled }}
+        - name: mariadb-persistent-storage
+          persistentVolumeClaim:
+           claimName: {{ .Values.persistence_claim.name |  default (include "fullName" . ) }}
+{{- end }}
+        - name: mariadb-backup-etc
+          configMap:
+            name:  mariadb-backup-{{.Values.name}}-etc
+{{- end }}

--- a/common/mariadb/templates/deployment.yaml
+++ b/common/mariadb/templates/deployment.yaml
@@ -141,55 +141,23 @@ spec:
           name: db-socket
 {{- end }}
 {{- if .Values.backup_v2.enabled }}
-      - name: mariabackup
-        image: "{{ default "hub.global.cloud.sap" .Values.global.imageRegistry}}/{{.Values.global.image_namespace}}/maria-back-me-up:{{ .Values.backup_v2.image_version }}"
+      - name: readiness
+        image: "{{ default "hub.global.cloud.sap" .Values.global.imageRegistry}}/{{.Values.global.image_namespace}}/pod-readiness:{{ .Values.readiness.image_version }}"
         command:
-          - backup
+          - pod_readiness
         readinessProbe:
           httpGet:
-            path: /health/readiness
-            port: 8082
+            path: /healthy
+            port: 8080
             scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 3
           failureThreshold: 1
           successThreshold: 1
         ports:
-          - containerPort: 8081
+          - containerPort: 8080
             name: http
             protocol: TCP
-          - containerPort: 8082
-            name: metrics
-            protocol: TCP
-        env:
-{{- if .Values.backup_v2.oauth.enabled }}
-        - name: OAUTH_CLIENT_ID
-          valueFrom:
-            secretKeyRef:
-              name: mariadb-{{.Values.name}}
-              key: OAUTH_CLIENT_ID
-        - name: OAUTH_CLIENT_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: mariadb-{{.Values.name}}
-              key: OAUTH_CLIENT_SECRET
-        - name: OAUTH_COOKIE_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: mariadb-{{.Values.name}}
-              key: OAUTH_COOKIE_SECRET
-{{- end }}
-        - name: CONFIG_FILE
-          value: "/etc/config/config.yaml"
-        volumeMounts:
-{{- if .Values.persistence_claim.enabled }}
-        - name: mariadb-persistent-storage
-          mountPath: /var/lib/mysql
-          readOnly: false
-{{- end }}
-        - name: mariadb-backup-etc
-          mountPath: /etc/config
-          readOnly: true
 {{- end }}
 {{- if .Values.metrics.enabled }}
       - name: metrics
@@ -243,11 +211,6 @@ spec:
 {{- if .Values.backup.enabled }}
         - name: db-socket
           emptyDir: {}
-{{- end }}
-{{- if .Values.backup_v2.enabled }}
-        - name: mariadb-backup-etc
-          configMap:
-            name:  mariadb-backup-{{.Values.name}}-etc
 {{- end }}
 {{- if .Values.initdb_configmap }}
         - name: initdb

--- a/common/mariadb/templates/service.yaml
+++ b/common/mariadb/templates/service.yaml
@@ -58,7 +58,7 @@ metadata:
     prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
 spec:
   selector:
-    app: {{ include "fullName" . }}
+    app: {{ include "fullName" . }}-backup
   ports:
     - port: 8081
       name: http

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -77,7 +77,7 @@ readiness:
 backup_v2:
   enabled: false
   image: monsoon/maria-back-me-up
-  image_version: c39fafe4
+  image_version: a421e6ec
   full_backup_cron_schedule: "0 0 * * *"
   incremental_backup_in_minutes: 5
   verification_interval: 30

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -70,10 +70,14 @@ backup:
   os_project_name: master
   os_project_domain: ccadmin
 
+readiness:
+  image: monsoon/pod-readiness
+  image_version: ffb61ca4
+
 backup_v2:
   enabled: false
   image: monsoon/maria-back-me-up
-  image_version: 8e88c21b
+  image_version: c39fafe4
   full_backup_cron_schedule: "0 0 * * *"
   incremental_backup_in_minutes: 5
   verification_interval: 30


### PR DESCRIPTION
- backup runs in an own pod (no longer as mariadb sidecar)
- adds readiness api to mariadb (via sidecar)
  - this allows to set the mariadb pod into "not ready" while performing a restore
