### PR TITLE
[cinder] make enabled_backends configurable

### DIFF
--- a/openstack/cinder/templates/vcenter_datacenter_cinder_configmap.yaml
+++ b/openstack/cinder/templates/vcenter_datacenter_cinder_configmap.yaml
@@ -20,7 +20,7 @@ template: |
   data:
     cinder-volume.conf: |
       [DEFAULT]
-      enabled_backends = vmware,standard_hdd
+      enabled_backends = {{ .Values.backends.enabled }}
 
       [backend_defaults]
       vmware_host_ip = {= host =}

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -57,6 +57,7 @@ backend_defaults:
   max_over_subscription_ratio: 1.5
 
 backends:
+    enabled: vmware
     vmware:
         vmware_storage_profile: cinder-vvol
     standard_hdd:


### PR DESCRIPTION
This patch makes the cinder-volume.conf enabled_backends
configurable.   This allows each region to optionally enable
the standard_hdd backend along with vmware backend.  This patch
makes the default value for enabled_backends=vmware.

If you want to enable the slow performing cinder backend,
then edit the secrets <region>/values/cinder.yml and add
backends:
  enabled: vmware,standard_hdd