### PR TITLE
[ipmi-exporter][alerts] sets MetalIronicSensorCritical to 1s

### DIFF
--- a/system/infra-monitoring/vendor/ipmi-exporter/alerts/metal-ironic.alerts
+++ b/system/infra-monitoring/vendor/ipmi-exporter/alerts/metal-ironic.alerts
@@ -3,7 +3,7 @@ groups:
   rules:      
   - alert: MetalIronicSensorCritical
     expr: count(ipmi_sensor_state{job="ipmi/ironic", type=~"(Memory|Processor|Critical Interrupt)", maintenance="false", provision_state=~"(deploy|active)"} == 2) by (instance, type, name, manufacturer, model, provision_state, server_id, project_id)
-    for: 10m
+    for: 1s
     labels:
       severity: critical
       tier: metal


### PR DESCRIPTION
As requested by Ronny Werner, Martin Kautz, Christopher Mast

Since they need to get alerts for these types of failures right away.