### PR TITLE
[cablecheck-exporter] added cache mode

### DIFF
--- a/system/infra-monitoring/values.yaml
+++ b/system/infra-monitoring/values.yaml
@@ -133,13 +133,13 @@ snmp_exporter:
 
 bm_cablecheck_exporter:
   enabled: false
-  scrapeInterval: 15m
-  scrapeTimeout: 14m
+  scrapeInterval: 1m
+  scrapeTimeout: 55s
 
 vpod_cablecheck_exporter:
   enabled: false
-  scrapeInterval: 15m
-  scrapeTimeout: 14m
+  scrapeInterval: 1m
+  scrapeTimeout: 55s
 
 bios_exporter:
   enabled: false
@@ -206,7 +206,4 @@ redfish_exporter:
   bm_scrapeTimeout: 230s
   cp_scrapeInterval: 4m
   cp_scrapeTimeout: 230s
-
-vpod-cablecheck-exporter:
-  enabled: false
 

--- a/system/infra-monitoring/vendor/bm-cablecheck-exporter/values.yaml
+++ b/system/infra-monitoring/vendor/bm-cablecheck-exporter/values.yaml
@@ -1,2 +1,2 @@
 image: csm/cc-cablecheck-exporter
-tag: v10
+tag: v11

--- a/system/infra-monitoring/vendor/vpod-cablecheck-exporter/values.yaml
+++ b/system/infra-monitoring/vendor/vpod-cablecheck-exporter/values.yaml
@@ -1,2 +1,2 @@
 image: csm/cc-cablecheck-exporter-vpod
-tag: v8
+tag: v9


### PR DESCRIPTION
[bm-cablecheck-exporter] V11
[vpod-cablecheck-exporter] V9
reduced polling time from 15m to 1m (collector provides now cached metrics, internally cablecheck will queried every 30m to reduct netbox/switch api load)