### PR TITLE
Revert "[cablecheck-exporter] added cache mode"

### DIFF
--- a/system/infra-monitoring/values.yaml
+++ b/system/infra-monitoring/values.yaml
@@ -133,13 +133,13 @@ snmp_exporter:
 
 bm_cablecheck_exporter:
   enabled: false
-  scrapeInterval: 1m
-  scrapeTimeout: 55s
+  scrapeInterval: 15m
+  scrapeTimeout: 14m
 
 vpod_cablecheck_exporter:
   enabled: false
-  scrapeInterval: 1m
-  scrapeTimeout: 55s
+  scrapeInterval: 15m
+  scrapeTimeout: 14m
 
 bios_exporter:
   enabled: false
@@ -206,4 +206,7 @@ redfish_exporter:
   bm_scrapeTimeout: 230s
   cp_scrapeInterval: 4m
   cp_scrapeTimeout: 230s
+
+vpod-cablecheck-exporter:
+  enabled: false
 

--- a/system/infra-monitoring/vendor/bm-cablecheck-exporter/values.yaml
+++ b/system/infra-monitoring/vendor/bm-cablecheck-exporter/values.yaml
@@ -1,2 +1,2 @@
 image: csm/cc-cablecheck-exporter
-tag: v11
+tag: v10

--- a/system/infra-monitoring/vendor/vpod-cablecheck-exporter/values.yaml
+++ b/system/infra-monitoring/vendor/vpod-cablecheck-exporter/values.yaml
@@ -1,2 +1,2 @@
 image: csm/cc-cablecheck-exporter-vpod
-tag: v9
+tag: v8


### PR DESCRIPTION
Reverts sapcc/helm-charts#1502

Aligned with @stefanhipfel due to wrong usage of caching. To decrease load on Netbox we further need to increase the scrapeInterval in the first place and switch over to our overall cache as in Atlas or a complete service discovery oriented approach.