### PR TITLE
[Elastiflow] Settings to configure ES cluster formation

### DIFF
--- a/openstack/elastiflow/requirements.lock
+++ b/openstack/elastiflow/requirements.lock
@@ -2,11 +2,14 @@ dependencies:
 - name: elasticsearch
   repository: file://vendor/elasticsearch
   version: 7.6.1
+- name: elasticsearch
+  repository: file://vendor/elasticsearch
+  version: 7.6.1
 - name: kibana
   repository: file://vendor/kibana
   version: 7.6.1
 - name: logstash
   repository: file://vendor/logstash
   version: 7.6.1
-digest: sha256:7ee62fd95e2f15e01a5aed6173762f36c31372f548f803382584aed61cdd57d3
-generated: 2020-03-31T07:19:11.654814024-07:00
+digest: sha256:f5edf81052085e26336c70cce9fb181ffc2d004eae18829e10093973affb42c4
+generated: "2020-05-21T18:12:45.934083732Z"

--- a/openstack/elastiflow/requirements.lock
+++ b/openstack/elastiflow/requirements.lock
@@ -5,11 +5,14 @@ dependencies:
 - name: elasticsearch
   repository: file://vendor/elasticsearch
   version: 7.6.1
+- name: elasticsearch-curator
+  repository: https://kubernetes-charts.storage.googleapis.com
+  version: 2.0.0
 - name: kibana
   repository: file://vendor/kibana
   version: 7.6.1
 - name: logstash
   repository: file://vendor/logstash
   version: 7.6.1
-digest: sha256:f5edf81052085e26336c70cce9fb181ffc2d004eae18829e10093973affb42c4
-generated: "2020-05-21T18:12:45.934083732Z"
+digest: sha256:d639cddb1d1baebe892b051e2d72ac43aeb5f7ed1d83cbf00b79af459020a210
+generated: "2020-05-26T18:11:59.939742781Z"

--- a/openstack/elastiflow/requirements.yaml
+++ b/openstack/elastiflow/requirements.yaml
@@ -4,6 +4,11 @@ dependencies:
     version: 7.6.1
     repository: file://vendor/elasticsearch
 
+  - name: elasticsearch
+    alias: elasticsearch-data
+    version: 7.6.1
+    repository: file://vendor/elasticsearch
+
   - name: kibana
     repository: file://vendor/kibana
     version: 7.6.1

--- a/openstack/elastiflow/requirements.yaml
+++ b/openstack/elastiflow/requirements.yaml
@@ -8,6 +8,11 @@ dependencies:
     alias: elasticsearch-data
     version: 7.6.1
     repository: file://vendor/elasticsearch
+  
+  - name: elasticsearch-curator
+    alias: curator
+    version: 2.0.0
+    repository: https://kubernetes-charts.storage.googleapis.com
 
   - name: kibana
     repository: file://vendor/kibana

--- a/openstack/elastiflow/templates/query-exporter-configmap.yaml
+++ b/openstack/elastiflow/templates/query-exporter-configmap.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: query-exporter-{{ .Values.queryExporter.name }}-config
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}"
+    app: "{{ template "elasticsearch.uname" . }}"
+data:
+  exporter.cfg: |
+    # This section defines default settings for how queries should be run.
+    # All settings can be overridden for any given query in its own section.
+    # The values shown in this example are also the fallback values used if
+    # a setting is not specified in the DEFAULT section or a query's section.
+    [DEFAULT]
+    # How often to run queries.
+    QueryIntervalSecs = 15
+    # How long to wait for a query to return before timing out.
+    QueryTimeoutSecs = 10
+    # The indices to run the query on.
+    # Any way of specifying indices supported by your Elasticsearch version can be used.
+    QueryIndices = _all
+    # What to do if a query throws an error. One of:
+    # * preserve - keep the metrics/values from the last successful run.
+    # * drop - remove metrics previously produced by the query.
+    # * zero - keep metrics previously produced by the query, but reset their values to 0.
+    QueryOnError = drop
+    # What to do if a metric produced by the previous run of a query is not present
+    # in the current run. One of:
+    # * preserve - keep the value of the metric from the last run it was present in.
+    # * drop - remove the metric.
+    # * zero - keep the metric, but reset its value to 0.
+    QueryOnMissing = drop
+    
+    # Queries are defined in sections beginning with 'query_'.
+    # Characters following this prefix will be used as a prefix for all metrics
+    # generated for this query
+    [query_all]
+    # Settings that are not specified are inherited from the DEFAULT section.
+    # The search query to run.
+    QueryJson = {
+        "size": 0,
+        "query": {
+            "match_all": {}
+        }
+    }
+
+  

--- a/openstack/elastiflow/templates/query-exporter-configmap.yaml
+++ b/openstack/elastiflow/templates/query-exporter-configmap.yaml
@@ -1,49 +1,16 @@
+{{- if .Values.queryExporter.config }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: query-exporter-{{ .Values.queryExporter.name }}-config
+  name: query-exporter-config
   labels:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
     chart: "{{ .Chart.Name }}"
-    app: "{{ template "elasticsearch.uname" . }}"
+    app: query-exporter-{{ .Values.queryExporter.name }}
 data:
-  exporter.cfg: |
-    # This section defines default settings for how queries should be run.
-    # All settings can be overridden for any given query in its own section.
-    # The values shown in this example are also the fallback values used if
-    # a setting is not specified in the DEFAULT section or a query's section.
-    [DEFAULT]
-    # How often to run queries.
-    QueryIntervalSecs = 15
-    # How long to wait for a query to return before timing out.
-    QueryTimeoutSecs = 10
-    # The indices to run the query on.
-    # Any way of specifying indices supported by your Elasticsearch version can be used.
-    QueryIndices = _all
-    # What to do if a query throws an error. One of:
-    # * preserve - keep the metrics/values from the last successful run.
-    # * drop - remove metrics previously produced by the query.
-    # * zero - keep metrics previously produced by the query, but reset their values to 0.
-    QueryOnError = drop
-    # What to do if a metric produced by the previous run of a query is not present
-    # in the current run. One of:
-    # * preserve - keep the value of the metric from the last run it was present in.
-    # * drop - remove the metric.
-    # * zero - keep the metric, but reset its value to 0.
-    QueryOnMissing = drop
-    
-    # Queries are defined in sections beginning with 'query_'.
-    # Characters following this prefix will be used as a prefix for all metrics
-    # generated for this query
-    [query_all]
-    # Settings that are not specified are inherited from the DEFAULT section.
-    # The search query to run.
-    QueryJson = {
-        "size": 0,
-        "query": {
-            "match_all": {}
-        }
-    }
-
-  
+{{- range $path, $config := .Values.queryExporter.config }}
+  {{ $path }}: |
+{{ $config | indent 4 -}}
+{{- end -}}
+{{- end -}}

--- a/openstack/elastiflow/templates/query-exporter-deployment.yaml
+++ b/openstack/elastiflow/templates/query-exporter-deployment.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.queryExporter.enabled }}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: query-exporter-{{ .Values.queryExporter.name }}
+  namespace: elastiflow
+  labels:
+    system: openstack
+    service: audit
+
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        component: query-exporter-{{ .Values.queryExporter.name }}
+    spec:
+      nodeSelector:
+        zone: farm
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+      containers:
+        - name: elasticsearch-exporter
+          image: "{{ .Values.queryExporter.image.repo }}:{{ .Values.queryExporter.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          command: [ "-e", "{{ .Values.queryExporter.es.uri }}", ]
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.queryExporter.listen_port }}
+          volumeMounts:
+            - name: exporter.cfg
+              mountPath: /usr/src/app
+      volumes:
+        - name: exporter.cfg
+          configMap:
+            name: query-exporter-{{ .Values.queryExporter.name }}-config
+            items:
+              - key: exporter.cfg
+                path: exporter.cfg
+{{ end -}}

--- a/openstack/elastiflow/templates/query-exporter-deployment.yaml
+++ b/openstack/elastiflow/templates/query-exporter-deployment.yaml
@@ -30,17 +30,23 @@ spec:
         - name: elasticsearch-exporter
           image: "{{ .Values.queryExporter.image.repo }}:{{ .Values.queryExporter.image.tag }}"
           imagePullPolicy: IfNotPresent
-          command: [ "-e", "{{ .Values.queryExporter.es.uri }}", ]
+          #command: [ "--es-cluster", "{{ .Values.queryExporter.es.uri }}", "--config-file", "/tmp/exporter/exporter.cfg" ]
+          command: ["/bin/sh", "-c"]
+          args:
+            - >-
+              exec /usr/local/bin/prometheus-es-exporter
+              --es-cluster {{ .Values.queryExporter.es.uri }}
+              --config-file /tmp/exporter/exporter.cfg
           ports:
             - name: metrics
               containerPort: {{ .Values.queryExporter.listen_port }}
           volumeMounts:
-            - name: exporter.cfg
-              mountPath: /usr/src/app
+            - name: exporter-config
+              mountPath: /tmp/exporter
       volumes:
-        - name: exporter.cfg
+        - name: exporter-config
           configMap:
-            name: query-exporter-{{ .Values.queryExporter.name }}-config
+            name: query-exporter-config
             items:
               - key: exporter.cfg
                 path: exporter.cfg

--- a/openstack/elastiflow/templates/query-exporter-service.yaml
+++ b/openstack/elastiflow/templates/query-exporter-service.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.queryExporter.enabled }}
+kind: Service
+apiVersion: v1
+metadata:
+  name: query-exporter-{{ .Values.queryExporter.name }}
+  namespace: elastiflow
+  labels:
+    system: openstack
+    service: audit
+    component: query-exporter-{{ .Values.queryExporter.name }}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "{{ .Values.queryExporter.listen_port }}"
+    prometheus.io/targets: "{{ .Values.queryExporter.targets }}"
+
+spec:
+  selector:
+    component: query-exporter-{{ .Values.queryExporter.name }}
+  ports:
+    - name: metrics
+      port: {{$.Values.queryExporter.listen_port}}
+{{ end -}}

--- a/openstack/elastiflow/values.yaml
+++ b/openstack/elastiflow/values.yaml
@@ -142,3 +142,14 @@ alerts:
   enabled: true
   # Name of the Prometheus to which the alerts should be assigned to.
   prometheus: openstack
+
+queryExporter:
+  name: elastiflow
+  enabled: true
+  image:
+    repo: braedon/prometheus-es-exporter
+    tag: 0.9.0
+  es:
+    uri: "http://elasticsearch-master:9200"
+  listen_port: 9206
+  targets: prometheus-openstack

--- a/openstack/elastiflow/values.yaml
+++ b/openstack/elastiflow/values.yaml
@@ -1,3 +1,36 @@
+curator:
+  configMaps:
+    config_yml: |-
+      ---
+      client:
+        hosts:
+          - elasticsearch-master
+          - elasticsearch-data
+        port: 9200
+    # Delete indices older than 3 months
+    action_file_yml: |-
+      ---
+      actions:
+        1:
+          action: delete_indices
+          description: "Clean up ES by deleting old indices"
+          options:
+            timeout_override:
+            continue_if_exception: False
+            disable_action: False
+            ignore_empty_list: True
+          filters:
+          - filtertype: age
+            source: name
+            direction: older
+            timestring: '%Y.%m.%d'
+            unit: months
+            unit_count: 3
+            field:
+            stats_result:
+            epoch:
+            exclude: False
+
 # master node configs
 elasticsearch:
   enabled: true

--- a/openstack/elastiflow/values.yaml
+++ b/openstack/elastiflow/values.yaml
@@ -33,6 +33,7 @@ elasticsearch-data:
     master: "false"
     ingest: "true"
     data: "true"
+  replicas: 2
   esJavaOpts: "-Xmx4G -Xms4G"
   esConfig:
     elasticsearch.yml: |
@@ -153,3 +154,14 @@ queryExporter:
     uri: "http://elasticsearch-master:9200"
   listen_port: 9206
   targets: prometheus-openstack
+  config:
+    exporter.cfg: |
+      [DEFAULT]
+      QueryIntervalSecs = 15
+      QueryTimeoutSecs = 10
+      QueryIndices = _all
+      QueryOnError = drop
+      QueryOnMissing = drop
+
+      [query_all]
+      QueryJson = {"size": 0, "query": {"match_all": {}}}

--- a/openstack/elastiflow/values.yaml
+++ b/openstack/elastiflow/values.yaml
@@ -1,10 +1,13 @@
+# master node configs
 elasticsearch:
   enabled: true
   image: "docker.elastic.co/elasticsearch/elasticsearch"
 
-  replicas: 1
-  minimumMasterNodes: 1
-
+  roles:
+    master: "true"
+    ingest: "false"
+    data: "false"
+    
   esJavaOpts: "-Xmx4G -Xms4G"
   esConfig:
     elasticsearch.yml: |
@@ -17,6 +20,29 @@ elasticsearch:
       requests:
         storage: 100G
 
+  resources:
+    requests:
+      memory: "4G"
+    limits:
+      memory: "6G"
+
+elasticsearch-data:
+  nodeGroup: data
+  masterService: elasticsearch-master
+  roles:
+    master: "false"
+    ingest: "true"
+    data: "true"
+  esJavaOpts: "-Xmx4G -Xms4G"
+  esConfig:
+    elasticsearch.yml: |
+      indices.query.bool.max_clause_count: 8192
+      search.max_buckets: 100000
+  volumeClaimTemplate:
+    accessModes: [ "ReadWriteMany" ]
+    resources:
+      requests:
+        storage: 100G
   resources:
     requests:
       memory: "4G"


### PR DESCRIPTION
elasticsearch master settings changed ;
- nodes to 3 replicasets from 1
- roles: master (only)
elasticsearch dedicated data notes;
- replicasets defaulted to 3
- roles: data + ingestion

resources used:
[blog post](https://medium.com/@thulasya/deploy-elasticsearch-on-kubernetes-via-helm-in-google-kubernetes-cluster-da722f3a8883)
[ES documentation](https://github.com/elastic/helm-charts/blob/master/elasticsearch/README.md)