### PR TITLE
[neutron] rework network-agent anti-affinity

### DIFF
--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Openstack Neutron
 name: neutron
-version: 0.1.2
+version: 0.1.3

--- a/openstack/neutron/templates/statefulset-network-agent.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent.yaml
@@ -51,15 +51,15 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
               labelSelector:
                 matchExpressions:
                 - key: component
                   operator: In
                   values:
                   - agent
-              topologyKey: kubernetes.io/hostname
-            weight: 100
       nodeSelector:
         multus: bond1
         failure-domain.beta.kubernetes.io/zone: {{ $az_long }}

--- a/openstack/neutron/templates/statefulset-network-agent.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent.yaml
@@ -48,7 +48,18 @@ spec:
         name: neutron-network-agent-{{ $az }}
 {{ tuple $ "neutron" "agent" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
     spec:
-{{ tuple $ "neutron" "agent" | include "kubernetes_pod_anti_affinity" | indent 6 }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: component
+                  operator: In
+                  values:
+                  - agent
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       nodeSelector:
         multus: bond1
         failure-domain.beta.kubernetes.io/zone: {{ $az_long }}


### PR DESCRIPTION
Proposal to use only `component=agent` label for Pod anti affinity. 

Current approach takes into account all neutron pods which ends up in cases where scheduler assigns 3 network agents to the same node. 