### PR TITLE
fixing Netbox queries, adding - to make it more specific

### DIFF
--- a/system/infra-monitoring/requirements.lock
+++ b/system/infra-monitoring/requirements.lock
@@ -71,5 +71,9 @@ dependencies:
 - name: vpod-cablecheck-exporter
   repository: file://vendor/vpod-cablecheck-exporter
   version: 0.0.1
+- name: firmware-exporter
+  alias: firmware_exporter
+  repository: file://vendor/firmware-exporter
+  version: 0.1.0
 digest: sha256:f10d4bea60254f5e8819abb7dfc7bb401aeb56f01e19ddd57b558b2e2f2b7767
 generated: 2020-04-09T13:55:35.07651+02:00

--- a/system/infra-monitoring/requirements.yaml
+++ b/system/infra-monitoring/requirements.yaml
@@ -141,3 +141,9 @@ dependencies:
     repository: file://vendor/vpod-cablecheck-exporter
     version: 0.0.1
     condition: vpod_cablecheck_exporter.enabled
+
+  - name: firmware-exporter
+    alias: firmware_exporter
+    repository: file://vendor/firmware-exporter
+    version: 0.1.0
+    condition: firmware_exporter.enabled

--- a/system/infra-monitoring/templates/_prometheus-infra-collector.yaml.tpl
+++ b/system/infra-monitoring/templates/_prometheus-infra-collector.yaml.tpl
@@ -609,3 +609,22 @@
     - target_label: __address__
       replacement: esxi-exporter:9203
 {{- end }}
+
+{{- $values := .Values.firmware-exporter -}}
+{{- if $values.enabled }}
+- job_name: 'firmware-exporter'
+  params:
+    job: [firmware-exporter]
+  scrape_interval: {{$values.scrapeInterval}}
+  scrape_timeout: {{$values.scrapeTimeout}}
+  file_sd_configs:
+      - files :
+        - /etc/prometheus/configmaps/atlas-sd/netbox.json  
+  static_configs:
+    - targets : ['firmware-exporter:9100']
+  metrics_path: /
+  relabel_configs:
+    - source_labels: [job]
+      regex: firmware-exporter
+      action: keep
+{{- end }}

--- a/system/infra-monitoring/values.yaml
+++ b/system/infra-monitoring/values.yaml
@@ -126,6 +126,11 @@ snmp_exporter:
     snmpv3:
       enabled: false
 
+firmware-exporter:
+  enabled: false
+  scrapeInterval: 15m
+  scrapeTimeout: 14m
+
 bm_cablecheck_exporter:
   enabled: false
   scrapeInterval: 15m

--- a/system/infra-monitoring/vendor/atlas/templates/configmap.yaml
+++ b/system/infra-monitoring/vendor/atlas/templates/configmap.yaml
@@ -257,7 +257,7 @@ data:
               target: 2
               region: "{{ .Values.global.region }}"
               status: "active"
-              q: "cp"
+              q: "-cp"
               role: "server"
               management_ip: true
               has_primary_ip: true
@@ -267,7 +267,7 @@ data:
               metrics_label: "cisco"
               region: "{{ .Values.global.region }}"
               status: "active"
-              q: "bb"
+              q: "-bb"
               role: "server"
               target: 1
               platform: "vmware-esxi"
@@ -277,7 +277,7 @@ data:
               target: 2
               region: "{{ .Values.global.region }}"
               status: "active"
-              q: "cp"
+              q: "-cp"
               role: "server"
               manufacturer: "cisco"
               management_ip: true

--- a/system/infra-monitoring/vendor/firmware-exporter/Chart.yaml
+++ b/system/infra-monitoring/vendor/firmware-exporter/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: firmware-exporter
+version: 0.1.0
+maintainers:
+  - name: Luis Garcia (I503201)

--- a/system/infra-monitoring/vendor/firmware-exporter/templates/deployment.yaml
+++ b/system/infra-monitoring/vendor/firmware-exporter/templates/deployment.yaml
@@ -1,0 +1,70 @@
+{{- if .Capabilities.APIVersions.Has "apps/v1" }}
+apiVersion: apps/v1
+{{- else }}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Deployment
+metadata:
+  name: {{ include "infraMonitoring.fullname" . }}
+  labels:
+    app: {{ include "infraMonitoring.name" . }}
+    chart: {{ include "infraMonitoring.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    system: infra_monitoring
+
+spec:
+  revisionHistoryLimit: 5
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        app: {{ include "infraMonitoring.name" . }}
+        release: {{ .Release.Name }}
+        component: firmware
+    spec:
+      containers:
+         - name: {{ include "infraMonitoring.name" . }}
+           image: {{ .Values.global.imageRegistry }}
+           imagePullPolicy: IfNotPresent
+           ports:
+             - name: metrics
+               containerPort: {{ .Values.listen_port }}
+               protocol: TCP
+           command:
+             - ./exporter.py
+           args:
+             - -o {{ .Values.listen_port }}
+           env:
+             - name: USER
+               value: {{ .Values.user }}
+             - name: PASSWORD
+               value: {{ .Values.userpw }}
+             - name: CISCOUSER
+               value: {{ .Values.cisco_user }}
+             - name: CISCOPW
+               value: {{ .Values.cisco_pw }}
+             - name: CISCOALTPWS
+               value: {{ .Values.cisco_alternative_pws }}
+             - name: REGION
+               value: {{ .Values.region }}
+           livenessProbe:
+             httpGet:
+               path: /
+               port: {{ .Values.listen_port }}
+             initialDelaySeconds: 5
+             timeoutSeconds: 5
+             periodSeconds: 10
+           volumeMounts:
+             - mountPath: /atlas
+               name: atlas-output
+               readOnly: true
+      volumes:
+        - configMap:
+            name: {{ .Values.atlas_configmap }}
+          name: atlas-output

--- a/system/infra-monitoring/vendor/firmware-exporter/templates/service.yaml
+++ b/system/infra-monitoring/vendor/firmware-exporter/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "infraMonitoring.name" . }}
+  labels:
+    app: {{ include "infraMonitoring.name" . }}
+    chart: {{ include "infraMonitoring.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    system: infra_monitoring
+spec:
+  selector:
+    app: {{ include "infraMonitoring.name" . }}
+  ports:
+    - name: metrics
+      port: 9100

--- a/system/infra-monitoring/vendor/firmware-exporter/values.yaml
+++ b/system/infra-monitoring/vendor/firmware-exporter/values.yaml
@@ -1,0 +1,10 @@
+image: csm-docker/fw_exporter
+tag: v1.0
+listen_port: 9001
+user: DEFINED-IN-REGION
+password: DEFINED-IN-REGION
+region: DEFINED-IN-REGION
+cisco_user: DEFINED-IN-REGION
+cisco_pw: DEFINED-IN-REGION
+cisco_alternative_pws: DEFINED-IN-REGION
+atlas_configmap: atlas-sd

--- a/system/prometheus-infra/templates/_prometheus-infra.yaml.tpl
+++ b/system/prometheus-infra/templates/_prometheus-infra.yaml.tpl
@@ -28,6 +28,7 @@
       - '{job="redfish/bm"}'
       - '{job="redfish/cp"}'
       - '{job="vrops"}'
+      - '{job="firmware-exporter"}'      
       - '{__name__=~"^vcenter_.+",job!~"[a-z0-9-]*-vccustomervmmetrics$"}'
       - '{__name__=~"^network_apic_.+"}'
       - '{__name__=~"^ipmi_sensor_state$",type=~"Memory|Drive Slot|Processor|Power Supply|Critical Interrupt|Version Change|Event Logging Disabled|System Event"}'


### PR DESCRIPTION
There was an issue with alerts being routed to the metal slack channel instead of the vpod slack channel (https://convergedcloud.slack.com/archives/CC8AS1UAC/p1589447980168200), we find out that some BB servers were being pulled as control plane servers, this was because the query was not specific and it was also querying the serial number of the servers, if it has "CP" it was considered as control plane server, this change will fix that.