### PR TITLE
[Glance] enabling swift object size and object chunk size

### DIFF
--- a/openstack/glance/templates/etc/_glance-api.conf.tpl
+++ b/openstack/glance/templates/etc/_glance-api.conf.tpl
@@ -61,6 +61,8 @@ swift_store_auth_insecure = True
 swift_store_create_container_on_put = True
 {{- if .Values.swift.multi_tenant }}
 swift_store_multi_tenant = True
+swift_store_large_object_size = 5120
+swift_store_large_object_chunk_size = 512
 # the following are deprecated but needed here https://github.com/openstack/glance_store/blob/stable/queens/glance_store/_drivers/swift/utils.py#L128-L145
 swift_store_user = service:{{ .Values.global.glance_service_user | default "glance" | replace "$" "$$"}}
 swift_store_key = {{ .Values.global.glance_service_password | default (tuple . .Values.global.glance_service_user | include "identity.password_for_user") | replace "$" "$$" }}


### PR DESCRIPTION
Hi @reimannf 

wrt 230 Gb server sizes, i found :

1. the chunk count reduced from 1219 to 477
2. upload speeds are up by 7Mbps
3. upload time reduced by ~30mins

I would like to know, if enabling these flags would impact swift ? swift-ratelimiting document explains operations per second only.

Regards,
Rajiv