### PR TITLE
[cinder] add volume type seeding

### DIFF
--- a/openstack/cinder/templates/type-seeds.yaml
+++ b/openstack/cinder/templates/type-seeds.yaml
@@ -1,0 +1,30 @@
+{{- if .Capabilities.APIVersions.Has "openstack.stable.sap.cc/v1" }}
+apiVersion: "openstack.stable.sap.cc/v1"
+kind: "OpenstackSeed"
+metadata:
+  name: cinder-type-seed
+  labels:
+    component: cinder
+    app: cinder
+    type: seed
+spec:
+  requires:
+  - monsoon3/cinder-seed
+
+  volume_types:
+  - name: vmware
+    is_public: true
+    description: "premium_ssd"
+    extra_specs:
+      volume_backend_name: "vmware"
+      "vmware:storage_profile": "cinder-vvol"
+
+  - name: standard_hdd
+    is_public: true
+    description: "standard_hdd"
+    extra_specs:
+      volume_backend_name: "standard_hdd"
+      "provisioning:min_vol_size": "500"
+      "vmware:storage_profile": "cinder-standard-hdd"
+      "vmware:vmdk_type": "thick"
+{{- end }}


### PR DESCRIPTION
This patch adds the 2 volume types to seed every deployment of
cinder with. This adds vmware and standard_hdd volume types and
all the extra specs for each volume type.