### PR TITLE
[dynomite] set read and write consistency

### DIFF
--- a/system/dynomite/templates/etc/_dynomite.yaml.tpl
+++ b/system/dynomite/templates/etc/_dynomite.yaml.tpl
@@ -34,6 +34,8 @@ dyn_o_mite:
   auto_eject_hosts: true
   server_retry_timeout: 30000
   server_failure_limit: 3
+  read_consistency: dc_quorum
+  write_consistency: dc_quorum
   {{- if $context.Values.redis.password }}
   requirepass: {{ $context.Values.redis.password }}
   {{- end }}


### PR DESCRIPTION
There were issues with read and write consistency set to DC_ONE
esp. in DEL cases if the DELETE requests does not hit the dynomite
server responsible for the corresponding token.
Could be mitigated by setting the consistency to DC_QUORUM
https://github.com/Netflix/dynomite/wiki/Consistency