### PR TITLE
elk: add the "deployments-*" index for tracking Helm releases

### DIFF
--- a/system/elk/values.yaml
+++ b/system/elk/values.yaml
@@ -24,6 +24,7 @@ logstash:
   input_syslog_port: 514
   input_bigiplogs_port: 1513
   input_alertmanager_port: 1515
+  input_deployments_port: 1516
 
 fluent:
   enabled: false

--- a/system/elk/vendor/es-client/templates/_readonlyrest.yml.tpl
+++ b/system/elk/vendor/es-client/templates/_readonlyrest.yml.tpl
@@ -8,7 +8,7 @@ readonlyrest:
       # access for logstash to write to the logstash indexes
       - name: data
         actions: ["indices:admin/types/exists","indices:data/read/*","indices:data/write/*","indices:admin/template/*","indices:admin/create","cluster:monitor/*"]
-        indices: ["logstash-*", "netflow", "systemd-*", "syslog-*", ".kibana*", "kubernikus-*", "scaleout-*", "virtual-*", "bigiplogs-*", "alerts-*"]
+        indices: ["logstash-*", "netflow", "systemd-*", "syslog-*", ".kibana*", "kubernikus-*", "scaleout-*", "virtual-*", "bigiplogs-*", "alerts-*", "deployments-*"]
         auth_key: {{.Values.global.data_user}}:{{.Values.global.data_password}}
 
       # access to write to the jump server log indexes

--- a/system/elk/vendor/es-data/templates/_readonlyrest.yml.tpl
+++ b/system/elk/vendor/es-data/templates/_readonlyrest.yml.tpl
@@ -8,7 +8,7 @@ readonlyrest:
       # access for logstash to write to the logstash indexes
       - name: data
         actions: ["indices:admin/types/exists","indices:data/read/*","indices:data/write/*","indices:admin/template/*","indices:admin/create","cluster:monitor/*"]
-        indices: ["logstash-*", "netflow", "systemd-*", "syslog-*", ".kibana*", "kubernikus-*", "scaleout-*", "virtual-*", "bigiplogs-*", "alerts-*"]
+        indices: ["logstash-*", "netflow", "systemd-*", "syslog-*", ".kibana*", "kubernikus-*", "scaleout-*", "virtual-*", "bigiplogs-*", "alerts-*", "deployments-*"]
         auth_key: {{.Values.global.data_user}}:{{.Values.global.data_password}}
 
       # access to write to the jump server log indexes

--- a/system/elk/vendor/es-master/templates/_readonlyrest.yml.tpl
+++ b/system/elk/vendor/es-master/templates/_readonlyrest.yml.tpl
@@ -8,7 +8,7 @@ readonlyrest:
       # access for logstash to write to the logstash indexes
       - name: data
         actions: ["indices:admin/types/exists","indices:data/read/*","indices:data/write/*","indices:admin/template/*","indices:admin/create","cluster:monitor/*"]
-        indices: ["logstash-*", "netflow", "systemd-*", "syslog-*", ".kibana*", "kubernikus-*", "scaleout-*", "virtual-*", "bigiplogs-*", "alerts-*"]
+        indices: ["logstash-*", "netflow", "systemd-*", "syslog-*", ".kibana*", "kubernikus-*", "scaleout-*", "virtual-*", "bigiplogs-*", "alerts-*", "deployments-*"]
         auth_key: {{.Values.global.data_user}}:{{.Values.global.data_password}}
 
       # access to write to the jump server log indexes

--- a/system/elk/vendor/logstash/templates/_deployments.json.tpl
+++ b/system/elk/vendor/logstash/templates/_deployments.json.tpl
@@ -1,0 +1,18 @@
+{
+  "order": 0,
+  "template": "deployments-*",
+  "settings": {
+    "index": {
+      "refresh_interval": "10s",
+      "unassigned": {
+        "node_left": {
+          "delayed_timeout": "10m"
+        }
+      },
+      "number_of_shards": "3",
+      "number_of_replicas": "1"
+    }
+  },
+  "mappings": {},
+  "aliases": {}
+}

--- a/system/elk/vendor/logstash/templates/configmap.yaml
+++ b/system/elk/vendor/logstash/templates/configmap.yaml
@@ -21,3 +21,5 @@ data:
 {{ include (print .Template.BasePath "/_bigiplogs.json.tpl") . | indent 4 }}
   alerts.json: |
 {{ include (print .Template.BasePath "/_alerts.json.tpl") . | indent 4 }}
+  deployments.json: |
+{{ include (print .Template.BasePath "/_deployments.json.tpl") . | indent 4 }}

--- a/system/elk/vendor/logstash/templates/deployment.yaml
+++ b/system/elk/vendor/logstash/templates/deployment.yaml
@@ -48,6 +48,9 @@ spec:
             - name: alertmanagertcp
               containerPort: {{.Values.input_alertmanager_port}}
               protocol: TCP
+            - name: deploymentstcp
+              containerPort: {{.Values.input_deployments_port}}
+              protocol: TCP
           command:
             - /usr/share/logstash/bin/logstash
           args:

--- a/system/elk/vendor/logstash/templates/service.yaml
+++ b/system/elk/vendor/logstash/templates/service.yaml
@@ -30,4 +30,8 @@ spec:
       protocol: TCP
       port: {{.Values.input_alertmanager_port}}
       targetPort: {{.Values.input_alertmanager_port}}
+    - name: deploymentstcp
+      protocol: TCP
+      port: {{.Values.input_deployments_port}}
+      targetPort: {{.Values.input_deployments_port}}
   externalIPs: ["{{.Values.external_ip}}"]

--- a/system/elk/vendor/wall-e/templates/_delete_indices.yml.tpl
+++ b/system/elk/vendor/wall-e/templates/_delete_indices.yml.tpl
@@ -38,6 +38,10 @@ actions:
       kind: prefix
       value: alerts
       exclude: True
+    - filtertype: pattern
+      kind: prefix
+      value: deployments
+      exclude: True
   2:
     action: delete_indices
     description: >-
@@ -70,4 +74,8 @@ actions:
     - filtertype: pattern
       kind: prefix
       value: alerts
+      exclude: True
+    - filtertype: pattern
+      kind: prefix
+      value: deployments
       exclude: True


### PR DESCRIPTION
The setup is mostly a carbon copy of the existing `alerts-*` index. If you don't like the index name `deployments-*`, feel free to suggest a better one. Also, please have a look if I missed anything.