### PR TITLE
[cinder] update the rabbitq message wait queue time

### DIFF
--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -255,8 +255,8 @@ rabbitmq:
   alerts:
     # unacked/ready messages in rabbitmq
     rabbit_queue_length: 50
-    unacknowledged_total_wait_for: 10m
-    ready_total_wait_for: 10m
+    unacknowledged_total_wait_for: 60m
+    ready_total_wait_for: 60m
 
 rabbitmq_notifications:
   name: cinder


### PR DESCRIPTION
This patch updates the unacknowledged_total_wait_for to 1 hour
from 10 minutes to help combat the infrequent alerts about
rpc messages not being collected.