### PR TITLE
[cinder]  Add optional allow_migration_on_attach setting

### DIFF
--- a/openstack/cinder/templates/etc/_cinder.conf.tpl
+++ b/openstack/cinder/templates/etc/_cinder.conf.tpl
@@ -53,6 +53,7 @@ scheduler_default_filters = {{ .Values.scheduler_default_filters }}
 
 {{- include "osprofiler" . }}
 
+allow_migration_on_attach = {{ .Values.cinder_api_allow_migration_on_attach }}
 
 [keystone_authtoken]
 auth_plugin = v3password

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -71,6 +71,8 @@ db_name: cinder
 
 scheduler_default_filters: 'AvailabilityZoneFilter,CapacityFilter,CapabilitiesFilter'
 
+cinder_api_allow_migration_on_attach: True
+
 mariadb:
   enabled: true
   buffer_pool_size: "2048M"


### PR DESCRIPTION
This patch adds the new cinder.conf option for enabling soft sharding
migration of a volume on attach (allow_migration_on_attach)
setting configurable by secrets.  By default it's set to True.