### PR TITLE
oomkill-exporter to be scrapped by additional Prometheus

### DIFF
--- a/prometheus-exporters/oomkill-exporter/values.yaml
+++ b/prometheus-exporters/oomkill-exporter/values.yaml
@@ -14,7 +14,7 @@ resources:
 metrics:
   port: 9102
   # Name of the Prometheus supposed to scrape the metrics.
-  prometheus: kubernetes
+  prometheus: 'kubernetes, openstack, infra-collector'
 
 # Enable Prometheus alerts.
 alerts:


### PR DESCRIPTION
Get the klog_pod_oomkill metric into openstack and infra-collector Prometheus.