### PR TITLE
**DO NOT MERGE** update prometheus-operator to 8.13.2

### DIFF
--- a/system/kube-monitoring-metal/Chart.yaml
+++ b/system/kube-monitoring-metal/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Kubernetes metal controlplane monitoring.
 name: kube-monitoring-metal
-version: 1.5.5
+version: 1.6.0

--- a/system/kube-monitoring-metal/requirements.lock
+++ b/system/kube-monitoring-metal/requirements.lock
@@ -28,7 +28,7 @@ dependencies:
   version: 1.0.5
 - name: prometheus-crds
   repository: https://charts.eu-de-2.cloud.sap
-  version: 1.0.0
+  version: 1.1.0
 - name: prometheus-kubernetes-rules
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.2.4
@@ -37,7 +37,7 @@ dependencies:
   version: 1.6.0
 - name: prometheus-operator
   repository: https://charts.eu-de-2.cloud.sap
-  version: 2.0.1
+  version: 8.13.2
 - name: prometheus-server
   repository: https://charts.eu-de-2.cloud.sap
   version: 3.4.1
@@ -47,5 +47,5 @@ dependencies:
 - name: watchcache-exporter
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.2
-digest: sha256:f7e1581b7a6ae7d43de6660081a19d6ac66da38f2762c6e2b7495ca3b8be7945
-generated: "2020-06-17T14:24:26.885975652Z"
+digest: sha256:c5af05993100f21cbcd665b8a52cda81eb6db9a3747e9ab1478d13682c82efc7
+generated: 2020-06-22T21:30:41.47511934+02:00

--- a/system/kube-monitoring-metal/requirements.yaml
+++ b/system/kube-monitoring-metal/requirements.yaml
@@ -28,7 +28,7 @@ dependencies:
     version: 1.0.5
   - name: prometheus-crds
     repository: https://charts.eu-de-2.cloud.sap
-    version: 1.0.0
+    version: 1.1.0
   - name: prometheus-kubernetes-rules
     repository: https://charts.eu-de-2.cloud.sap
     version: 1.2.4
@@ -37,7 +37,7 @@ dependencies:
     version: 1.6.0
   - name: prometheus-operator
     repository: https://charts.eu-de-2.cloud.sap
-    version: 2.0.1
+    version: 8.13.2
   - alias: prometheus-frontend
     name: prometheus-server
     repository: https://charts.eu-de-2.cloud.sap


### PR DESCRIPTION
**DO NOT MERGE** 
This updates the prometheus operator in the baremetal clusters to `8.13.2`, which creates `apps/v1.Statefulset` instead of the current `extensions/v1beta1.Statefulset`.
In other words: This will recreate and restart all Prometheis.

Regarding the thanos sidecar memory-leak issue I need to follow up and adjust its [version](https://github.com/sapcc/helm-charts/blob/master/common/prometheus-server/values.yaml#L195). 

Both components are quite entangled due to various changes and our k8s lagging behind requiring a 2-step update of the Prometheus operator.

I'm going to deploy this is one of the qa's, in which the maia guinea pig is available. Which one would that be @notque @artherd42?