### PR TITLE
Update snmp-n9k.alerts

### DIFF
--- a/system/infra-monitoring/vendor/snmp-exporter/alerts/snmp-n9k.alerts
+++ b/system/infra-monitoring/vendor/snmp-exporter/alerts/snmp-n9k.alerts
@@ -2,7 +2,7 @@ groups:
 - name: n9k.alerts
   rules:
   - alert: NetworkN9kSpineInterfaceInErrorRateReachesCriticalThreshold
-    expr: rate(snmp_acispine_ifInErrors{device!~"^mgmt.+", device!~"^gmp.+"}[1h]) > 0.28
+    expr: rate(snmp_acispine_ifInErrors{device!~"^mgmt.+", device!~"^gmp.+"}[30m]) > 0.28
     labels:
       severity: critical
       tier: net
@@ -15,7 +15,7 @@ groups:
       summary: 'N9K acispine network interface In error rate check'
 
   - alert: NetworkN9kSpineInterfaceOutErrorRateReachesCriticalThreshold
-    expr: rate(snmp_acispine_ifOutErrors{device!~"^mgmt.+", device!~"^gmp.+"}[1h]) > 0.28
+    expr: rate(snmp_acispine_ifOutErrors{device!~"^mgmt.+", device!~"^gmp.+"}[30m]) > 0.28
     labels:
       severity: critical
       tier: net
@@ -28,9 +28,9 @@ groups:
       summary: 'N9K acispine network interface Out error rate check'
 
   - alert: NetworkN9kLeafInterfaceInErrorRateReachesCriticalThreshold
-    expr: rate(snmp_acileaf_ifInErrors{device!~"^mgmt.+", device!~"^gmp.+"}[1h]) > 0.28
+    expr: rate(snmp_acileaf_ifInErrors{device!~"^mgmt.+", device!~"^gmp.+"}[30m]) > 0.28
     labels:
-      severity: warning
+      severity: critical
       tier: net
       service: n9k
       context: network_n9k_interface_error_rate
@@ -41,9 +41,9 @@ groups:
       summary: 'N9K acileaf network interface In error check'
 
   - alert: NetworkN9kLeafInterfaceOutErrorRateReachesCriticalThreshold
-    expr: rate(snmp_acileaf_ifOutErrors{device!~"^mgmt.+", device!~"^gmp.+"}[1h]) > 0.28
+    expr: rate(snmp_acileaf_ifOutErrors{device!~"^mgmt.+", device!~"^gmp.+"}[30m]) > 0.28
     labels:
-      severity: warning
+      severity: critical
       tier: net
       service: n9k
       context: network_n9k_interface_error_rate


### PR DESCRIPTION
putting critical alerts in critical channel for NetworkN9kSpine and NetworkN9kLeaf interface errors