### PR TITLE
cp alerts query fix

### DIFF
--- a/system/infra-monitoring/vendor/atlas/templates/configmap.yaml
+++ b/system/infra-monitoring/vendor/atlas/templates/configmap.yaml
@@ -270,7 +270,7 @@ data:
               target: 2
               region: "{{ .Values.global.region }}"
               status: "active"
-              q: "cp"
+              q: "-cp"
               role: "server"
               management_ip: true
               has_primary_ip: true
@@ -280,7 +280,7 @@ data:
               metrics_label: "cisco"
               region: "{{ .Values.global.region }}"
               status: "active"
-              q: "bb"
+              q: "-bb"
               role: "server"
               target: 1
               platform: "vmware-esxi"
@@ -290,7 +290,7 @@ data:
               target: 2
               region: "{{ .Values.global.region }}"
               status: "active"
-              q: "cp"
+              q: "-cp"
               role: "server"
               manufacturer: "cisco"
               management_ip: true


### PR DESCRIPTION
There was an issue reported that some alerts on the vpod channel where from not vpod servers, it was found that the query for the alerts was pulling some server which serial number coincided with the query 'CP' and those server were routed to the wrong slack channel, this will fix the issue by adding '-' to the atlas query so it ignores serial numbers.