### PR TITLE
[nova] Always start metadata service in own pod

### DIFF
--- a/openstack/nova/templates/api-deployment.yaml
+++ b/openstack/nova/templates/api-deployment.yaml
@@ -90,6 +90,7 @@ spec:
           ports:
             - name: nova-api
               containerPort: {{.Values.global.novaApiPortInternal}}
+            # TODO remove this after migrating neutron to always use the explicit metadata service
             - name: nova-metdata
               containerPort: {{.Values.global.novaApiMetadataPortInternal}}
           volumeMounts:

--- a/openstack/nova/templates/api-metadata-deployment.yaml
+++ b/openstack/nova/templates/api-metadata-deployment.yaml
@@ -1,4 +1,3 @@
-{{- if not (contains "metadata" .Values.api.DEFAULT.enabled_apis) }}
 kind: Deployment
 {{- if .Capabilities.APIVersions.Has "apps/v1" }}
 apiVersion: apps/v1
@@ -44,7 +43,7 @@ spec:
             - kubernetes-entrypoint
           env:
             - name: COMMAND
-              value: "nova-api-metadata"
+              value: "nova-api"
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
             - name: DEPENDENCY_JOBS
@@ -157,4 +156,3 @@ spec:
           configMap:
             name: nova-bin
             defaultMode: 0755
-{{- end }}

--- a/openstack/nova/templates/api-metadata-service.yaml
+++ b/openstack/nova/templates/api-metadata-service.yaml
@@ -1,4 +1,3 @@
-{{- if not (contains "metadata" .Values.api.DEFAULT.enabled_apis) }}
 kind: Service
 apiVersion: v1
 
@@ -20,4 +19,3 @@ spec:
   ports:
     - name: nova-api-metadata
       port: {{.Values.global.novaApiMetadataPortInternal}}
-{{- end }}

--- a/openstack/nova/templates/api-service.yaml
+++ b/openstack/nova/templates/api-service.yaml
@@ -19,6 +19,7 @@ spec:
   ports:
     - name: nova-api
       port: {{.Values.global.novaApiPortInternal}}
+    # TODO remove this after migrating neutron to always use the explicit metadata service
     - name: nova-metadata
       port: {{.Values.global.novaApiMetadataPortInternal}}
 #    - name: statsd-listen

--- a/openstack/nova/templates/etc-configmap.yaml
+++ b/openstack/nova/templates/etc-configmap.yaml
@@ -12,10 +12,8 @@ data:
 {{ include (print .Template.BasePath "/etc/_nova.conf.tpl") . | indent 4 }}
   nova-api.conf: |
 {{ include "util.helpers.valuesToIni" .Values.api | indent 4 }}
-{{- if not (contains "metadata" .Values.api.DEFAULT.enabled_apis) }}
   nova-api-metadata.conf: |
 {{ include "util.helpers.valuesToIni" .Values.api_metadata | indent 4 }}
-{{- end }}
   nova-conductor.conf: |
 {{ include "util.helpers.valuesToIni" .Values.conductor | indent 4 }}
   nova-scheduler.conf: |

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -190,7 +190,6 @@ cross_az_attach: 'False'
 api:
   DEFAULT:
     api_paste_config: /etc/nova/api-paste.ini
-    # adding metadata here will disable spawning of separate api-metadata pods
     enabled_apis: osapi_compute
     use_forwarded_for: true
 


### PR DESCRIPTION
When having multiple cells, we disabled the standalone metadata service,
because that's not supported. Instead, one has to run the metadata
service "globally" as an api service. But this only means, one should
not use the "nova-api-metadata" executable to run the metadata service.

Therefore, we now run the metadata service in its own pod with the
nova-api executable.

We need to make sure we switch neutron to using the standalone api
endpoint everywhere before completely removing metadata from the api
service.

Afterwards, we should be able to switch both api and metadata to using
uwsgi. This is not possible with nova-api also having to spawn the
metadata service on a different port.