### PR TITLE
[Sentry][Alert] OpenstackSentryPostgresIsAlmostFull is already present.

### DIFF
--- a/common/pgmetrics/templates/alerts/_database.alerts.tpl
+++ b/common/pgmetrics/templates/alerts/_database.alerts.tpl
@@ -2,7 +2,7 @@ groups:
 - name: pg-database.alerts
   rules:
   - alert: {{ include "alerts.service" . | title }}PostgresDatabaseTooLarge
-    expr: max(pg_database_size_bytes{datname="{{ default .Release.Name .Values.db_name }}"}) by (app,datname) >= 8.589934592e+09
+    expr: max(pg_database_size_bytes{datname="{{ default .Release.Name .Values.db_name }}",app!~"sentry-postgresql"}) by (app,datname) >= 8.589934592e+09
     for: 5m
     labels:
       context: database


### PR DESCRIPTION
https://github.com/sapcc/helm-charts/blob/3ecf881b98448d6a62d3124476b51b7ef4ac74c3/system/sentry/alerts/openstack-sentry.alerts#L19-L32