### PR TITLE
openstack/blackbox: simplify interpolation of .Values.global.image.tag

### DIFF
--- a/openstack/blackbox/charts/blackbox-tests-api/templates/deployment.yaml
+++ b/openstack/blackbox/charts/blackbox-tests-api/templates/deployment.yaml
@@ -36,11 +36,7 @@ spec:
             name: blackbox-tests-api-statsd-mapping-config
       containers:
         - name: pytest
-{{- if typeIs "float64" .Values.global.image.tag  }}{{/* https://github.com/kubernetes/helm/issues/1707 */}}
-          image: {{.Values.global.image.repository}}:{{.Values.global.image.tag | printf "%0.f" }}
-{{- else }}
           image: {{.Values.global.image.repository}}:{{.Values.global.image.tag}}
-{{- end }}
           args:
             - "iterate"
             - "pytest"

--- a/openstack/blackbox/charts/blackbox-tests-canary/templates/deployment.yaml
+++ b/openstack/blackbox/charts/blackbox-tests-canary/templates/deployment.yaml
@@ -46,11 +46,7 @@ spec:
                 mode: 0600
       containers:
         - name: nova
-{{- if typeIs "float64" .Values.global.image.tag  }}{{/* https://github.com/kubernetes/helm/issues/1707 */}}
-          image: {{.Values.global.image.repository}}:{{.Values.global.image.tag | printf "%0.f" }}
-{{- else }}
           image: {{.Values.global.image.repository}}:{{.Values.global.image.tag}}
-{{- end }}
           args:
             - "iterate"
             - "pytest"
@@ -180,11 +176,7 @@ spec:
             initialDelaySeconds: 15
 
         - name: nova-create-server
-{{- if typeIs "float64" .Values.global.image.tag  }}{{/* https://github.com/kubernetes/helm/issues/1707 */}}
-          image: {{.Values.global.image.repository}}:{{.Values.global.image.tag | printf "%0.f" }}
-{{- else }}
           image: {{.Values.global.image.repository}}:{{.Values.global.image.tag}}
-{{- end }}
           args:
             - "iterate"
             - "pytest"
@@ -317,11 +309,7 @@ spec:
 
 
         - name: cinder
-{{- if typeIs "float64" .Values.global.image.tag  }}{{/* https://github.com/kubernetes/helm/issues/1707 */}}
-          image: {{.Values.global.image.repository}}:{{.Values.global.image.tag | printf "%0.f" }}
-{{- else }}
           image: {{.Values.global.image.repository}}:{{.Values.global.image.tag}}
-{{- end }}
           args:
             - "iterate"
             - "pytest"
@@ -451,11 +439,7 @@ spec:
             initialDelaySeconds: 15
 
         - name: manila
-{{- if typeIs "float64" .Values.global.image.tag  }}{{/* https://github.com/kubernetes/helm/issues/1707 */}}
-          image: {{.Values.global.image.repository}}:{{.Values.global.image.tag | printf "%0.f" }}
-{{- else }}
           image: {{.Values.global.image.repository}}:{{.Values.global.image.tag}}
-{{- end }}
           args:
             - "iterate"
             - "pytest"
@@ -585,11 +569,7 @@ spec:
             initialDelaySeconds: 15
 
         - name: neutron
-{{- if typeIs "float64" .Values.global.image.tag  }}{{/* https://github.com/kubernetes/helm/issues/1707 */}}
-          image: {{.Values.global.image.repository}}:{{.Values.global.image.tag | printf "%0.f" }}
-{{- else }}
           image: {{.Values.global.image.repository}}:{{.Values.global.image.tag}}
-{{- end }}
           args:
             - "iterate"
             - "pytest"
@@ -719,11 +699,7 @@ spec:
             initialDelaySeconds: 15
 
         - name: other
-{{- if typeIs "float64" .Values.global.image.tag  }}{{/* https://github.com/kubernetes/helm/issues/1707 */}}
-          image: {{.Values.global.image.repository}}:{{.Values.global.image.tag | printf "%0.f" }}
-{{- else }}
           image: {{.Values.global.image.repository}}:{{.Values.global.image.tag}}
-{{- end }}
           args:
             - "iterate"
             - "pytest"
@@ -853,11 +829,7 @@ spec:
             initialDelaySeconds: 15
 
         - name: kubernikus
-{{- if typeIs "float64" .Values.global.image.tag  }}{{/* https://github.com/kubernetes/helm/issues/1707 */}}
-          image: {{.Values.global.image.repository}}:{{.Values.global.image.tag | printf "%0.f" }}
-{{- else }}
           image: {{.Values.global.image.repository}}:{{.Values.global.image.tag}}
-{{- end }}
           args:
             - "iterate"
             - "pytest"
@@ -992,11 +964,7 @@ spec:
             initialDelaySeconds: 15
 
         - name: serial
-{{- if typeIs "float64" .Values.global.image.tag  }}{{/* https://github.com/kubernetes/helm/issues/1707 */}}
-          image: {{.Values.global.image.repository}}:{{.Values.global.image.tag | printf "%0.f" }}
-{{- else }}
           image: {{.Values.global.image.repository}}:{{.Values.global.image.tag}}
-{{- end }}
           args:
             - "iterate"
             - "pytest"
@@ -1131,11 +1099,7 @@ spec:
             initialDelaySeconds: 15
 
         - name: purger
-{{- if typeIs "float64" .Values.global.image.tag  }}{{/* https://github.com/kubernetes/helm/issues/1707 */}}
-          image: {{.Values.global.image.repository}}:{{.Values.global.image.tag | printf "%0.f" }}
-{{- else }}
           image: {{.Values.global.image.repository}}:{{.Values.global.image.tag}}
-{{- end }}
           args:
             - "purge"
             - "python helper/purge_resources.py"

--- a/openstack/blackbox/charts/blackbox-tests-certificates/templates/deployment.yaml
+++ b/openstack/blackbox/charts/blackbox-tests-certificates/templates/deployment.yaml
@@ -36,11 +36,7 @@ spec:
             name: blackbox-tests-certificates-statsd-mapping-config
       containers:
         - name: pytest
-{{- if typeIs "float64" .Values.global.image.tag  }}{{/* https://github.com/kubernetes/helm/issues/1707 */}}
-          image: {{.Values.global.image.repository}}:{{.Values.global.image.tag | printf "%0.f" }}
-{{- else }}
           image: {{.Values.global.image.repository}}:{{.Values.global.image.tag}}
-{{- end }}
           args:
             - "iterate"
             - "pytest"

--- a/openstack/blackbox/charts/blackbox-tests-datapath/templates/deployment.yaml
+++ b/openstack/blackbox/charts/blackbox-tests-datapath/templates/deployment.yaml
@@ -43,11 +43,7 @@ spec:
                 mode: 0600
       containers:
         - name: pytest
-{{- if typeIs "float64" .Values.global.image.tag  }}{{/* https://github.com/kubernetes/helm/issues/1707 */}}
-          image: {{.Values.global.image.repository}}:{{.Values.global.image.tag | printf "%0.f" }}
-{{- else }}
           image: {{.Values.global.image.repository}}:{{.Values.global.image.tag}}
-{{- end }}
           args:
             - "iterate"
             - "pytest"

--- a/openstack/blackbox/charts/blackbox-tests-integrity/templates/deployment.yaml
+++ b/openstack/blackbox/charts/blackbox-tests-integrity/templates/deployment.yaml
@@ -43,11 +43,7 @@ spec:
             name: blackbox-tests-integrity-statsd-mapping-config
       containers:
         - name: pytest
-{{- if typeIs "float64" .Values.global.image.tag  }}{{/* https://github.com/kubernetes/helm/issues/1707 */}}
-          image: {{.Values.global.image.repository}}:{{.Values.global.image.tag | printf "%0.f" }}
-{{- else }}
           image: {{.Values.global.image.repository}}:{{.Values.global.image.tag}}
-{{- end }}
           args:
             - "iterate"
             - "pytest"

--- a/openstack/blackbox/charts/blackbox-tests-regression/templates/deployment.yaml
+++ b/openstack/blackbox/charts/blackbox-tests-regression/templates/deployment.yaml
@@ -39,11 +39,7 @@ spec:
                 mode: 0600
       containers:
         - name: pytest
-{{- if typeIs "float64" .Values.global.image.tag  }}{{/* https://github.com/kubernetes/helm/issues/1707 */}}
-          image: {{.Values.global.image.repository}}:{{.Values.global.image.tag | printf "%0.f" }}
-{{- else }}
           image: {{.Values.global.image.repository}}:{{.Values.global.image.tag}}
-{{- end }}
           args:
             - "iterate"
             - "pytest"
@@ -152,11 +148,7 @@ spec:
             initialDelaySeconds: 15
 
         - name: purger
-{{- if typeIs "float64" .Values.global.image.tag  }}{{/* https://github.com/kubernetes/helm/issues/1707 */}}
-          image: {{.Values.global.image.repository}}:{{.Values.global.image.tag | printf "%0.f" }}
-{{- else }}
           image: {{.Values.global.image.repository}}:{{.Values.global.image.tag}}
-{{- end }}
           args:
             - "purge"
             - "python helper/purge_resources.py"


### PR DESCRIPTION
This can be merged after merging pull request no. 3611 on the secrets repo, which switches the Concourse pipeline to the shared Helm tasks. The shared Helm tasks correctly use `--set-string` instead of `--set` and thus aren't vulnerable to misparsing of image versions as floats.