### PR TITLE
split supernova-incident-contact-list chart from supernova chart

### DIFF
--- a/global/supernova/templates/contact-list-configmap.yaml
+++ b/global/supernova/templates/contact-list-configmap.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-
-metadata:
-  name: incident-contact-list
-
-data:
-  incident_contact_list.json: |
-{{ toPrettyJson .Values.services | indent 4}}

--- a/global/supernova/templates/deployment.yaml
+++ b/global/supernova/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
             secretName: alertmanager-sso-cert
         - name: incident-contact-list
           configMap:
-            name: incident-contact-list    
+            name: supernova-incident-contact-list
       # The preStop hook below sleeps 30 seconds, extend the gracePeriod accordingly
       terminationGracePeriodSeconds: 60
       containers:


### PR DESCRIPTION
By putting this ConfigMap in a separate chart, we can use our standard deployment tooling, as explained in the new chart's README.

The new chart uses a different name for the ConfigMap, so as not to cause a collision when we first install it.

Please only approve, don't merge yet. I'm still preparing the requisite changes for the Concourse pipeline.