### PR TITLE
[Designate-seeds] Adding cloud_identity_viewer and cloud_resource_vie…

### DIFF
--- a/openstack/designate/templates/seeds.yaml
+++ b/openstack/designate/templates/seeds.yaml
@@ -38,8 +38,9 @@ spec:
   - name: dns_webmaster
   - name: dns_admin
   - name: dns_viewer
-  - name: cloud_identity_viewer
-  - name: cloud_resource_viewer
+  - name: role_viewer
+  - name: resource_viewer
+  - name: audit_viewer
 
   services:
   - name: designate
@@ -172,11 +173,14 @@ spec:
         role: cloud_dns_ops
         inherited: true
       - domain: ccadmin
-        role: cloud_identity_viewer
+        role: role_viewer
         inherited: true
       - domain: ccadmin
-        role: cloud_resource_viewer
+        role: resource_viewer
         inherited: true        
+      - domain: ccadmin
+        role: audit_viewer
+        inherited: true          
     role_assignments:
     - user: admin@Default
       role: cloud_dns_admin
@@ -195,11 +199,14 @@ spec:
         role: cloud_dns_ops
         inherited: true
       - domain: cc3test
-        role: cloud_identity_viewer
+        role: role_viewer
         inherited: true
       - domain: cc3test
-        role: cloud_resource_viewer
+        role: resource_viewer
         inherited: true
+      - domain: cc3test
+        role: audit_viewer
+        inherited: true      
     role_assignments:
     - user: admin@Default
       role: cloud_dns_admin
@@ -218,11 +225,14 @@ spec:
         role: cloud_dns_ops
         inherited: true
       - domain: bs
-        role: cloud_identity_viewer
+        role: role_viewer
         inherited: true
       - domain: bs
-        role: cloud_resource_viewer
+        role: resource_viewer
         inherited: true
+      - domain: bs
+        role: audit_viewer
+        inherited: true      
     - name: BS_API_SUPPORT
       role_assignments:
       - domain: bs
@@ -266,11 +276,14 @@ spec:
         role: cloud_dns_ops
         inherited: true
       - domain: cp
-        role: cloud_identity_viewer
+        role: role_viewer
         inherited: true
       - domain: cp
-        role: cloud_resource_viewer
+        role: resource_viewer
         inherited: true
+      - domain: cp
+        role: audit_viewer
+        inherited: true      
     - name: CP_API_SUPPORT
       role_assignments:
       - domain: cp
@@ -314,11 +327,14 @@ spec:
         role: cloud_dns_ops
         inherited: true
       - domain: fsn
-        role: cloud_identity_viewer
+        role: role_viewer
         inherited: true
       - domain: fsn
-        role: cloud_resource_viewer
+        role: resource_viewer
         inherited: true
+      - domain: fsn
+        role: audit_viewer
+        inherited: true      
     - name: FSN_API_SUPPORT
       role_assignments:
       - domain: fsn
@@ -362,11 +378,14 @@ spec:
         role: cloud_dns_ops
         inherited: true
       - domain: hcm
-        role: cloud_identity_viewer
+        role: role_viewer
         inherited: true
       - domain: hcm
-        role: cloud_resource_viewer
+        role: resource_viewer
         inherited: true
+      - domain: hcm
+        role: audit_viewer
+        inherited: true      
     - name: HCM_API_SUPPORT
       role_assignments:
       - domain: hcm
@@ -410,11 +429,14 @@ spec:
         role: cloud_dns_ops
         inherited: true
       - domain: hcp03
-        role: cloud_identity_viewer
+        role: role_viewer
         inherited: true
       - domain: hcp03
-        role: cloud_resource_viewer
+        role: resource_viewer
         inherited: true
+      - domain: hcp03
+        role: audit_viewer
+        inherited: true      
     - name: HCP03_API_SUPPORT
       role_assignments:
       - domain: hcp03
@@ -458,11 +480,14 @@ spec:
         role: cloud_dns_ops
         inherited: true
       - domain: hec
-        role: cloud_identity_viewer
+        role: role_viewer
         inherited: true
       - domain: hec
-        role: cloud_resource_viewer
+        role: resource_viewer
         inherited: true
+      - domain: hec
+        role: audit_viewer
+        inherited: true      
     - name: HEC_API_SUPPORT
       role_assignments:
       - domain: hec
@@ -506,11 +531,14 @@ spec:
         role: cloud_dns_ops
         inherited: true
       - domain: monsoon3
-        role: cloud_identity_viewer
+        role: role_viewer
         inherited: true
       - domain: monsoon3
-        role: cloud_resource_viewer
+        role: resource_viewer
         inherited: true
+      - domain: monsoon3
+        role: audit_viewer
+        inherited: true      
     - name: MONSOON3_API_SUPPORT
       role_assignments:
       - domain: monsoon3
@@ -554,11 +582,14 @@ spec:
         role: cloud_dns_ops
         inherited: true
       - domain: neo
-        role: cloud_identity_viewer
+        role: role_viewer
         inherited: true
       - domain: neo
-        role: cloud_resource_viewer
+        role: resource_viewer
         inherited: true
+      - domain: neo
+        role: audit_viewer
+        inherited: true      
     - name: NEO_API_SUPPORT
       role_assignments:
       - domain: neo
@@ -602,11 +633,14 @@ spec:
         role: cloud_dns_ops
         inherited: true
       - domain: s4
-        role: cloud_identity_viewer
+        role: role_viewer
         inherited: true
       - domain: s4
-        role: cloud_resource_viewer
+        role: resource_viewer
         inherited: true
+      - domain: s4
+        role: audit_viewer
+        inherited: true      
     - name: S4_API_SUPPORT
       role_assignments:
       - domain: s4
@@ -650,11 +684,14 @@ spec:
         role: cloud_dns_ops
         inherited: true
       - domain: wbs
-        role: cloud_identity_viewer
+        role: role_viewer
         inherited: true
       - domain: wbs
-        role: cloud_resource_viewer
+        role: resource_viewer
         inherited: true
+      - domain: wbs
+        role: audit_viewer
+        inherited: true      
     - name: WBS_API_SUPPORT
       role_assignments:
       - domain: wbs

--- a/openstack/designate/templates/seeds.yaml
+++ b/openstack/designate/templates/seeds.yaml
@@ -38,9 +38,6 @@ spec:
   - name: dns_webmaster
   - name: dns_admin
   - name: dns_viewer
-  - name: role_viewer
-  - name: resource_viewer
-  - name: audit_viewer
 
   services:
   - name: designate

--- a/openstack/designate/templates/seeds.yaml
+++ b/openstack/designate/templates/seeds.yaml
@@ -38,6 +38,8 @@ spec:
   - name: dns_webmaster
   - name: dns_admin
   - name: dns_viewer
+  - name: cloud_identity_viewer
+  - name: cloud_resource_viewer
 
   services:
   - name: designate
@@ -169,6 +171,12 @@ spec:
       - domain: ccadmin
         role: cloud_dns_ops
         inherited: true
+      - domain: ccadmin
+        role: cloud_identity_viewer
+        inherited: true
+      - domain: ccadmin
+        role: cloud_resource_viewer
+        inherited: true        
     role_assignments:
     - user: admin@Default
       role: cloud_dns_admin
@@ -186,6 +194,12 @@ spec:
       - domain: cc3test
         role: cloud_dns_ops
         inherited: true
+      - domain: cc3test
+        role: cloud_identity_viewer
+        inherited: true
+      - domain: cc3test
+        role: cloud_resource_viewer
+        inherited: true
     role_assignments:
     - user: admin@Default
       role: cloud_dns_admin
@@ -202,6 +216,12 @@ spec:
       role_assignments:
       - domain: bs
         role: cloud_dns_ops
+        inherited: true
+      - domain: bs
+        role: cloud_identity_viewer
+        inherited: true
+      - domain: bs
+        role: cloud_resource_viewer
         inherited: true
     - name: BS_API_SUPPORT
       role_assignments:
@@ -245,6 +265,12 @@ spec:
       - domain: cp
         role: cloud_dns_ops
         inherited: true
+      - domain: cp
+        role: cloud_identity_viewer
+        inherited: true
+      - domain: cp
+        role: cloud_resource_viewer
+        inherited: true
     - name: CP_API_SUPPORT
       role_assignments:
       - domain: cp
@@ -286,6 +312,12 @@ spec:
       role_assignments:
       - domain: fsn
         role: cloud_dns_ops
+        inherited: true
+      - domain: fsn
+        role: cloud_identity_viewer
+        inherited: true
+      - domain: fsn
+        role: cloud_resource_viewer
         inherited: true
     - name: FSN_API_SUPPORT
       role_assignments:
@@ -329,6 +361,12 @@ spec:
       - domain: hcm
         role: cloud_dns_ops
         inherited: true
+      - domain: hcm
+        role: cloud_identity_viewer
+        inherited: true
+      - domain: hcm
+        role: cloud_resource_viewer
+        inherited: true
     - name: HCM_API_SUPPORT
       role_assignments:
       - domain: hcm
@@ -370,6 +408,12 @@ spec:
       role_assignments:
       - domain: hcp03
         role: cloud_dns_ops
+        inherited: true
+      - domain: hcp03
+        role: cloud_identity_viewer
+        inherited: true
+      - domain: hcp03
+        role: cloud_resource_viewer
         inherited: true
     - name: HCP03_API_SUPPORT
       role_assignments:
@@ -413,6 +457,12 @@ spec:
       - domain: hec
         role: cloud_dns_ops
         inherited: true
+      - domain: hec
+        role: cloud_identity_viewer
+        inherited: true
+      - domain: hec
+        role: cloud_resource_viewer
+        inherited: true
     - name: HEC_API_SUPPORT
       role_assignments:
       - domain: hec
@@ -454,6 +504,12 @@ spec:
       role_assignments:
       - domain: monsoon3
         role: cloud_dns_ops
+        inherited: true
+      - domain: monsoon3
+        role: cloud_identity_viewer
+        inherited: true
+      - domain: monsoon3
+        role: cloud_resource_viewer
         inherited: true
     - name: MONSOON3_API_SUPPORT
       role_assignments:
@@ -497,6 +553,12 @@ spec:
       - domain: neo
         role: cloud_dns_ops
         inherited: true
+      - domain: neo
+        role: cloud_identity_viewer
+        inherited: true
+      - domain: neo
+        role: cloud_resource_viewer
+        inherited: true
     - name: NEO_API_SUPPORT
       role_assignments:
       - domain: neo
@@ -539,6 +601,12 @@ spec:
       - domain: s4
         role: cloud_dns_ops
         inherited: true
+      - domain: s4
+        role: cloud_identity_viewer
+        inherited: true
+      - domain: s4
+        role: cloud_resource_viewer
+        inherited: true
     - name: S4_API_SUPPORT
       role_assignments:
       - domain: s4
@@ -580,6 +648,12 @@ spec:
       role_assignments:
       - domain: wbs
         role: cloud_dns_ops
+        inherited: true
+      - domain: wbs
+        role: cloud_identity_viewer
+        inherited: true
+      - domain: wbs
+        role: cloud_resource_viewer
         inherited: true
     - name: WBS_API_SUPPORT
       role_assignments:

--- a/openstack/designate/templates/seeds.yaml
+++ b/openstack/designate/templates/seeds.yaml
@@ -173,7 +173,7 @@ spec:
         role: role_viewer
         inherited: true
       - domain: ccadmin
-        role: resource_viewer
+        role: resource_admin
         inherited: true        
       - domain: ccadmin
         role: audit_viewer
@@ -199,7 +199,7 @@ spec:
         role: role_viewer
         inherited: true
       - domain: cc3test
-        role: resource_viewer
+        role: resource_admin
         inherited: true
       - domain: cc3test
         role: audit_viewer
@@ -225,7 +225,7 @@ spec:
         role: role_viewer
         inherited: true
       - domain: bs
-        role: resource_viewer
+        role: resource_admin
         inherited: true
       - domain: bs
         role: audit_viewer
@@ -276,7 +276,7 @@ spec:
         role: role_viewer
         inherited: true
       - domain: cp
-        role: resource_viewer
+        role: resource_admin
         inherited: true
       - domain: cp
         role: audit_viewer
@@ -327,7 +327,7 @@ spec:
         role: role_viewer
         inherited: true
       - domain: fsn
-        role: resource_viewer
+        role: resource_admin
         inherited: true
       - domain: fsn
         role: audit_viewer
@@ -378,7 +378,7 @@ spec:
         role: role_viewer
         inherited: true
       - domain: hcm
-        role: resource_viewer
+        role: resource_admin
         inherited: true
       - domain: hcm
         role: audit_viewer
@@ -429,7 +429,7 @@ spec:
         role: role_viewer
         inherited: true
       - domain: hcp03
-        role: resource_viewer
+        role: resource_admin
         inherited: true
       - domain: hcp03
         role: audit_viewer
@@ -480,7 +480,7 @@ spec:
         role: role_viewer
         inherited: true
       - domain: hec
-        role: resource_viewer
+        role: resource_admin
         inherited: true
       - domain: hec
         role: audit_viewer
@@ -531,7 +531,7 @@ spec:
         role: role_viewer
         inherited: true
       - domain: monsoon3
-        role: resource_viewer
+        role: resource_admin
         inherited: true
       - domain: monsoon3
         role: audit_viewer
@@ -582,7 +582,7 @@ spec:
         role: role_viewer
         inherited: true
       - domain: neo
-        role: resource_viewer
+        role: resource_admin
         inherited: true
       - domain: neo
         role: audit_viewer
@@ -633,7 +633,7 @@ spec:
         role: role_viewer
         inherited: true
       - domain: s4
-        role: resource_viewer
+        role: resource_admin
         inherited: true
       - domain: s4
         role: audit_viewer
@@ -684,7 +684,7 @@ spec:
         role: role_viewer
         inherited: true
       - domain: wbs
-        role: resource_viewer
+        role: resource_admin
         inherited: true
       - domain: wbs
         role: audit_viewer


### PR DESCRIPTION
…wer to *_domain_dns_ops access level

@Carthaca 

CAM profile :  CC Converged Cloud DNS Operations has *_domain_dns_ops and *_domain_users access levels, i have added cloud_identity_viewer and cloud_resource_viewer roles to designate/seeds.yaml do i need to create *_domain_dns_ops spec in domain-seeds.yaml 