### PR TITLE
[sre] Update alerts

### DIFF
--- a/openstack/sre/templates/prometheus-alerts.yaml
+++ b/openstack/sre/templates/prometheus-alerts.yaml
@@ -40,7 +40,7 @@ spec:
 
     # rolling 7 days
     - alert: ApiAvailabilityWarningLast7days
-      expr: (1 - global:api_errors_per_request_sli:ratio_rate7d) *100 <= on (ingress,region) global:api_availability_critical_slo:percent
+      expr: (1 - global:api_errors_per_request_sli:ratio_rate7d) *100 <= on (ingress,region) global:api_availability_warning_slo:percent
       labels:
         context: availability
         service: "{{`{{$labels.ingress}}`}}"

--- a/openstack/sre/templates/prometheus-alerts.yaml
+++ b/openstack/sre/templates/prometheus-alerts.yaml
@@ -22,10 +22,10 @@ spec:
         )
         + ignoring(slo) group_right count_values without() ("slo", global:api_availability_warning_slo:percent) * 0
       labels:
-        context: availability
+        context: sre
         service: "{{`{{$labels.ingress}}`}}"
         severity: info
-        tier: sre
+        tier: os
         playbook: 'docs/devops/alert/sre-alerts.html'
       annotations:
         summary: "API availability warning SLO hit: 2h"
@@ -39,10 +39,10 @@ spec:
         )
         + ignoring(slo) group_right count_values without() ("slo", global:api_availability_critical_slo:percent) * 0
       labels:
-        context: availability
+        context: sre
         service: "{{`{{$labels.ingress}}`}}"
         severity: info
-        tier: sre
+        tier: os
         playbook: 'docs/devops/alert/sre-alerts.html'
       annotations:
         summary: "API availability critical SLO hit: 2h"
@@ -57,7 +57,7 @@ spec:
         )
         + ignoring(slo) group_right count_values without() ("slo", global:api_availability_warning_slo:percent) * 0
       labels:
-        context: availability
+        context: sre
         service: "{{`{{$labels.ingress}}`}}"
         severity: info
         tier: os
@@ -74,7 +74,7 @@ spec:
         )
         + ignoring(slo) group_right count_values without() ("slo", global:api_availability_critical_slo:percent) * 0
       labels:
-        context: availability
+        context: sre
         service: "{{`{{$labels.ingress}}`}}"
         severity: info
         tier: os
@@ -88,10 +88,10 @@ spec:
       expr: absent(global:api_errors_per_request_sli:ratio_rate2h) or absent(global:api_availability_critical_slo:percent)
       for: 1h
       labels:
-        context: availability
+        context: sre
         service: "{{`{{$labels.ingress}}`}}"
         severity: info
-        tier: sre
+        tier: moni
         playbook: 'docs/devops/alert/sre-alerts.html'
       annotations:
         summary: "Aggregated metric is missing."

--- a/openstack/sre/templates/prometheus-alerts.yaml
+++ b/openstack/sre/templates/prometheus-alerts.yaml
@@ -15,7 +15,12 @@ spec:
     rules:
     # quick availability check - target updates
     - alert: ApiAvailabilityWarning2Hour
-      expr: (1 - global:api_errors_per_request_sli:ratio_rate2h) *100 <= on (ingress,region) global:api_availability_warning_slo:percent
+      expr: |
+        (
+          (1 - global:api_errors_per_request_sli:ratio_rate2h) * 100
+          <= on (ingress,region) global:api_availability_warning_slo:percent
+        )
+        + ignoring(slo) group_right count_values without() ("slo", global:api_availability_warning_slo:percent) * 0
       labels:
         context: availability
         service: "{{`{{$labels.ingress}}`}}"
@@ -24,10 +29,15 @@ spec:
         playbook: 'docs/devops/alert/sre-alerts.html'
       annotations:
         summary: "API availability warning SLO hit: 2h"
-        description: "{{`{{$labels.ingress}}`}} fell below availability warning SLO in the last 2 hours (default:  *99.8%*)."
+        description: "{{`{{$labels.ingress}}`}} fell below availability warning SLO {{`{{$labels.slo}}`}} in the last 2 hours."
 
     - alert: ApiAvailabilityCritical2Hour
-      expr: (1 - global:api_errors_per_request_sli:ratio_rate2h) *100 <= on (ingress,region) global:api_availability_critical_slo:percent
+      expr: |
+        (
+          (1 - global:api_errors_per_request_sli:ratio_rate2h) * 100
+          <= on (ingress,region) global:api_availability_critical_slo:percent
+        )
+        + ignoring(slo) group_right count_values without() ("slo", global:api_availability_critical_slo:percent) * 0
       labels:
         context: availability
         service: "{{`{{$labels.ingress}}`}}"
@@ -36,11 +46,16 @@ spec:
         playbook: 'docs/devops/alert/sre-alerts.html'
       annotations:
         summary: "API availability critical SLO hit: 2h"
-        description: "{{`{{$labels.ingress}}`}} fell below availability critical SLO in the last 2 hours (default:  *99.6%*)."
+        description: "{{`{{$labels.ingress}}`}} fell below availability critical SLO {{`{{$labels.slo}}`}} in the last 2 hours."
 
     # rolling 7 days
     - alert: ApiAvailabilityWarningLast7days
-      expr: (1 - global:api_errors_per_request_sli:ratio_rate7d) *100 <= on (ingress,region) global:api_availability_warning_slo:percent
+      expr: |
+        (
+          (1 - global:api_errors_per_request_sli:ratio_rate7d) * 100
+          <= on (ingress,region) global:api_availability_warning_slo:percent
+        )
+        + ignoring(slo) group_right count_values without() ("slo", global:api_availability_warning_slo:percent) * 0
       labels:
         context: availability
         service: "{{`{{$labels.ingress}}`}}"
@@ -49,10 +64,15 @@ spec:
         playbook: 'docs/devops/alert/sre-alerts.html'
       annotations:
         summary: "API availability warning SLO hit: 7d"
-        description: "{{`{{$labels.ingress}}`}} fell below weekly availability warning SLO (default:  *99.8%*)."
+        description: "{{`{{$labels.ingress}}`}} fell below weekly availability warning SLO {{`{{$labels.slo}}`}}."
 
     - alert: ApiAvailabilityCriticalLast7days
-      expr: (1 - global:api_errors_per_request_sli:ratio_rate7d) *100 <= on (ingress,region) global:api_availability_critical_slo:percent
+      expr: |
+        (
+          (1 - global:api_errors_per_request_sli:ratio_rate7d) * 100
+          <= on (ingress,region) global:api_availability_critical_slo:percent
+        )
+        + ignoring(slo) group_right count_values without() ("slo", global:api_availability_critical_slo:percent) * 0
       labels:
         context: availability
         service: "{{`{{$labels.ingress}}`}}"
@@ -61,7 +81,7 @@ spec:
         playbook: 'docs/devops/alert/sre-alerts.html'
       annotations:
         summary: "API availability critical SLO hit: 7d"
-        description: "{{`{{$labels.ingress}}`}} ffell below weekly availability warning SLO (default:  *99.6%*)."
+        description: "{{`{{$labels.ingress}}`}} fell below weekly availability critical SLO {{`{{$labels.slo}}`}}."
 
     # meta alert
     - alert: SRE-MetricAbsent

--- a/openstack/sre/templates/prometheus-alerts.yaml
+++ b/openstack/sre/templates/prometheus-alerts.yaml
@@ -64,7 +64,7 @@ spec:
         description: "{{`{{$labels.ingress}}`}} ffell below weekly availability warning SLO (default:  *99.6%*)."
 
     # meta alert
-    - alert: SRE-MetricAbesent
+    - alert: SRE-MetricAbsent
       expr: absent(global:api_errors_per_request_sli:ratio_rate2h) or absent(global:api_availability_critical_slo:percent)
       for: 1h
       labels:


### PR DESCRIPTION
This PR fixes one minor and one major problem and introduces the services' SLOs as a label to use it in the alert description.

---
I haven't tested it, I just templated the helm-chart.

To see the query in action, take a look at [prometheus](https://prometheus-openstack.eu-de-1.cloud.sap/graph?g0.range_input=1h&g0.expr=(1%20-%20global%3Aapi_errors_per_request_sli%3Aratio_rate2h)%20*10%20%3C%3D%20on%20(ingress%2Cregion)%20global%3Aapi_availability_warning_slo%3Apercent&g0.tab=1&g1.range_input=1h&g1.expr=(%20(1%20-%20global%3Aapi_errors_per_request_sli%3Aratio_rate2h)%20*%2010%20%20%3C%3D%20on%20(ingress%2C%20region)%20global%3Aapi_availability_warning_slo%3Apercent)%2B%20ignoring(slo)%20group_right%20count_values%20without()%20(%22slo%22%2C%20global%3Aapi_availability_warning_slo%3Apercent)%20*%200&g1.tab=1)
