### PR TITLE
add readiness probe to swift-proxy pods

### DIFF
--- a/openstack/swift/templates/proxy-deployment.yaml
+++ b/openstack/swift/templates/proxy-deployment.yaml
@@ -142,6 +142,17 @@ spec:
             initialDelaySeconds: 10
             timeoutSeconds: 1
             periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: {{$cluster.proxy_public_port}}
+              scheme: HTTPS
+              httpHeaders:
+                - name: Host
+                  value: {{tuple $cluster $.Values | include "swift_endpoint_host"}}
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+            periodSeconds: 10
         {{- if $.Values.health_exporter }}
         - name: collector
           image: {{ include "swift_image" $ }}


### PR DESCRIPTION
A quick look at the `git log` suggests that we never had readiness probes here. The liveness probe has already existed in 2016. IMO the most likely explanation is that we didn't understand the difference between liveness and readiness probes way back when.