### PR TITLE
[swift] liveness checks for proxy and nginx container

### DIFF
--- a/openstack/swift/templates/etc/_nginx.conf.tpl
+++ b/openstack/swift/templates/etc/_nginx.conf.tpl
@@ -87,5 +87,15 @@ http {
         {{ tuple $context | include "swift_nginx_location" | indent 8 }}
     }
     {{- end }}
+
+    # Healthcheck for Nginx, nothing else
+    server {
+        listen 1080 default_server;
+
+        location /nginx-health {
+            access_log off;
+            return 200 "healthy\n";
+        }
+    }
 }
 {{end}}

--- a/openstack/swift/templates/proxy-deployment.yaml
+++ b/openstack/swift/templates/proxy-deployment.yaml
@@ -105,6 +105,14 @@ spec:
               name: swift-container-ring
             - mountPath: /swift-rings/object
               name: swift-object-ring
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+            periodSeconds: 10
         - name: nginx
           image: {{$.Values.global.imageRegistry}}/monsoon/swift-nginx:{{$.Values.image_version_nginx}}
           command:
@@ -133,12 +141,9 @@ spec:
               name: tls-secret
           livenessProbe:
             httpGet:
-              path: /healthcheck
-              port: {{$cluster.proxy_public_port}}
-              scheme: HTTPS
-              httpHeaders:
-                - name: Host
-                  value: {{tuple $cluster $.Values | include "swift_endpoint_host"}}
+              path: /nginx-health
+              port: 1080
+              scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
             periodSeconds: 10


### PR DESCRIPTION
Previous liveness check on nginx container did not ensure that the proxy container is restarted when stalled. So move it to
proxy. 
But nginx is also essential - introducing a new liveness check for nginx only.