### PR TITLE
add support for UEFI in ironic conductor

### DIFF
--- a/openstack/ironic/templates/etc-configmap.yaml
+++ b/openstack/ironic/templates/etc-configmap.yaml
@@ -14,6 +14,8 @@ data:
 {{ include (print .Template.BasePath "/etc/_policy.json.tpl") . | indent 4 }}
   ipxe_config.template: |
 {{ include (print .Template.BasePath "/etc/_ipxe_config.template.tpl") . | indent 4 }}
+  uefi_pxe_config.template: |
+{{ include (print .Template.BasePath "/etc/_uefi_pxe_config.template.tpl") . | indent 4 }}
   logging.ini: |
 {{ include "loggerIni" .Values.logging | indent 4 }}
   rootwrap.conf: |

--- a/openstack/ironic/templates/etc/_ironic_conductor.conf.tpl
+++ b/openstack/ironic/templates/etc/_ironic_conductor.conf.tpl
@@ -57,7 +57,7 @@ pxe_config_template = /etc/ironic/ipxe_config.template
 pxe_config_template = /etc/ironic/pxe_config.template
 {{- end }}
 uefi_pxe_bootfile_name = ipxe.efi
-uefi_pxe_config_template = /etc/ironic/ipxe_config.template
+uefi_pxe_config_template = /etc/ironic/uefi_pxe_config.template
 
 {{- if $conductor.jinja2 }}
 {{`

--- a/openstack/ironic/templates/etc/_uefi_pxe_config.template.tpl
+++ b/openstack/ironic/templates/etc/_uefi_pxe_config.template.tpl
@@ -1,0 +1,69 @@
+{{- define "uefi_pxe_config_template" -}}
+{{- $conductor := index . 1 -}}
+{{- with index . 0 -}}
+#!ipxe
+
+set attempts:int32 10
+set i:int32 0
+
+goto deploy
+
+:deploy
+imgfree
+kernel {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ "{{" }} pxe_options.ipxe_timeout {{ "}}" }} {% endif %}{{ "{{" }} pxe_options.deployment_aki_path {{ "}}" }} selinux=0 troubleshoot=0 text {{ "{{" }} pxe_options.pxe_append_params|default("", true) {{ "}}" }} BOOTIF=${mac} ipa-api-url={{ "{{" }} pxe_options['ipa-api-url'] {{ "}}" }} initrd={{ "{{" }} pxe_options.initrd_filename|default("deploy_ramdisk", true) {{ "}}" }} coreos.configdrive=0 || chain {{ printf "http://%v:%v/%v" .Values.global.ironic_tftp_ip .Values.conductor.deploy.port $conductor.pxe.uefi_pxe_bootfile_name }} || goto retry
+
+initrd --name {{ "{{" }} pxe_options.initrd_filename|default("deploy_ramdisk", true) {{ "}}" }} {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ "{{" }} pxe_options.ipxe_timeout {{ "}}" }} {% endif %}{{ "{{" }} pxe_options.deployment_ari_path {{ "}}" }} || goto retry
+boot
+
+:retry
+iseq ${i} ${attempts} && goto fail ||
+inc i
+echo No response, retrying in ${i} seconds.
+sleep ${i}
+goto deploy
+
+:fail
+echo Failed to get a response after ${attempts} attempts
+echo Powering off in 30 seconds.
+sleep 30
+poweroff
+
+:boot_partition
+imgfree
+kernel {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ "{{" }} pxe_options.ipxe_timeout {{ "}}" }} {% endif %}{{ "{{" }} pxe_options.aki_path {{ "}}" }} root={{ "{{" }} ROOT {{ "}}" }} ro text {{ "{{" }} pxe_options.pxe_append_params|default("", true) {{ "}}" }} initrd=ramdisk || goto boot_partition
+initrd --name ramdisk {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ "{{" }} pxe_options.ipxe_timeout {{ "}}" }} {% endif %}{{ "{{" }} pxe_options.ari_path {{ "}}" }} || goto boot_partition
+boot
+
+:boot_ramdisk
+imgfree
+kernel {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ "{{" }} pxe_options.ipxe_timeout {{ "}}" }} {% endif %}{{ "{{" }} pxe_options.aki_path {{ "}}" }} root=/dev/ram0 text {{ "{{" }} pxe_options.pxe_append_params|default("", true) {{ "}}" }} {{ "{{" }} pxe_options.ramdisk_opts|default('', true) {{ "}}" }} initrd=ramdisk || goto boot_ramdisk
+initrd --name ramdisk {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ "{{" }} pxe_options.ipxe_timeout {{ "}}" }} {% endif %}{{ "{{" }} pxe_options.ari_path {{ "}}" }} || goto boot_ramdisk
+boot
+{%- if pxe_options.boot_from_volume %}
+
+:boot_iscsi
+imgfree
+{% if pxe_options.username %}set username {{ "{{" }} pxe_options.username {{ "}}" }}{% endif %}
+{% if pxe_options.password %}set password {{ "{{" }} pxe_options.password {{ "}}" }}{% endif %}
+{% if pxe_options.iscsi_initiator_iqn %}set initiator-iqn {{ "{{" }} pxe_options.iscsi_initiator_iqn {{ "}}" }}{% endif %}
+sanhook --drive 0x80 {{ "{{" }} pxe_options.iscsi_boot_url {{ "}}" }} || goto fail_iscsi_retry
+{%- if pxe_options.iscsi_volumes %}{% for i, volume in enumerate(pxe_options.iscsi_volumes) %}
+set username {{ "{{" }} volume.username {{ "}}" }}
+set password {{ "{{" }} volume.password {{ "}}" }}
+{%- set drive_id = 129 + i %}
+sanhook --drive {{ "{{" }} '0x%x' % drive_id }} {{ "{{" }} volume.url {{ "}}" }} || goto fail_iscsi_retry
+{%- endfor %}{% endif %}
+{% if pxe_options.iscsi_volumes %}set username {{ "{{" }} pxe_options.username {{ "}}" }}{% endif %}
+{% if pxe_options.iscsi_volumes %}set password {{ "{{" }} pxe_options.password {{ "}}" }}{% endif %}
+sanboot --no-describe || goto fail_iscsi_retry
+
+:fail_iscsi_retry
+echo Failed to attach iSCSI volume(s), retrying in 10 seconds.
+sleep 10
+goto boot_iscsi
+{%- endif %}
+
+:boot_whole_disk
+sanboot --no-describe
+{{- end }}
+{{- end }}

--- a/openstack/ironic/values.yaml
+++ b/openstack/ironic/values.yaml
@@ -138,6 +138,7 @@ conductor:
       ipxe_enabled: true
       ipxe_use_swift: true
       pxe_bootfile_name: "undionly.kpxe"
+      uefi_pxe_bootfile_name: "ipxe.efi"
 
 agent:
   deploy_logs:


### PR DESCRIPTION
To boot UEFI systems, ironic needs a special configuration This includes
a different PXE template and an additional boot file.