### PR TITLE
[nova] Alert on task_state no vm_state

### DIFF
--- a/openstack/nova/alerts/openstack-nova.alerts
+++ b/openstack/nova/alerts/openstack-nova.alerts
@@ -71,7 +71,7 @@ groups:
       summary: Nova Maximum RAM Usage percentage metric
 
   - alert: OpenstackNovaInstanceInErrorState
-    expr: sum(openstack_compute_instance_created_in_24hrs_gauge{vm_state='error'})by(uuid,host) > 0
+    expr: sum(openstack_compute_instance_created_in_24hrs_gauge{task_state='error'})by(uuid,host) > 0
     for: 5m
     labels:
       dashboard: nova-hypervisor
@@ -85,7 +85,7 @@ groups:
       summary: Openstack Nova Instance In Error State
 
   - alert: OpenstackNovaInstanceStuckBuilding
-    expr: sum(openstack_compute_stuck_instances_count_gauge{host!~"nova-compute-ironic.*",vm_state="building"}) BY (host) > 0
+    expr: sum(openstack_compute_stuck_instances_count_gauge{host!~"nova-compute-ironic.*",task_state="building"}) BY (host) > 0
     for: 5m
     labels:
       dashboard: nova-hypervisor
@@ -99,7 +99,7 @@ groups:
       summary: Openstack Nova Instance Stuck in Building state metric
 
   - alert: OpenstackNovaInstanceStuckDeleting
-    expr: sum(openstack_compute_stuck_instances_count_gauge{vm_state="deleting"}) BY (host) > 0
+    expr: sum(openstack_compute_stuck_instances_count_gauge{task_state="deleting"}) BY (host) > 0
     for: 5m
     labels:
       dashboard: nova-hypervisor
@@ -113,7 +113,7 @@ groups:
       summary: Openstack Nova Instance Stuck in Deleting state metric
 
   - alert: OpenstackNovaInstanceStuckStopping
-    expr: sum(openstack_compute_stuck_instances_count_gauge{vm_state="stopping"}) BY (host) > 0
+    expr: sum(openstack_compute_stuck_instances_count_gauge{task_state="stopping"}) BY (host) > 0
     for: 5m
     labels:
       dashboard: nova-hypervisor
@@ -126,7 +126,7 @@ groups:
       summary: Openstack Nova Instance Stuck in Stopping state metric
 
   - alert: OpenstackNovaInstanceStuckStarting
-    expr: sum(openstack_compute_stuck_instances_count_gauge{vm_state="starting"})
+    expr: sum(openstack_compute_stuck_instances_count_gauge{task_state="starting"})
       BY (host) > 0
     for: 5m
     labels:
@@ -140,7 +140,7 @@ groups:
       summary: Openstack Nova Instance Stuck in Starting state metric
 
   - alert: OpenstackNovaInstanceStuckSpawning
-    expr: sum(openstack_compute_stuck_instances_count_gauge{vm_state="spawning"}) BY (host) > 0
+    expr: sum(openstack_compute_stuck_instances_count_gauge{task_state="spawning"}) BY (host) > 0
     for: 5m
     labels:
       dashboard: nova-hypervisor
@@ -153,7 +153,7 @@ groups:
       summary: Openstack Nova Instance Stuck in Spawning state metric
 
   - alert: OpenstackNovaInstanceStuckRebooting
-    expr: sum(openstack_compute_stuck_instances_count_gauge{vm_state="rebooting"}) BY (host) > 0
+    expr: sum(openstack_compute_stuck_instances_count_gauge{task_state="rebooting"}) BY (host) > 0
     for: 5m
     labels:
       dashboard: nova-hypervisor

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -296,12 +296,12 @@ pgmetrics:
             usage: "GAUGE"
             description: "VM Count"
     openstack_compute_stuck_instances:
-      query: "SELECT coalesce(host, 'N/A') AS host, project_id, uuid, availability_zone, vm_state, COUNT(*) FILTER (WHERE updated_at < now() - interval '15 minutes') AS count_gauge, MAX(EXTRACT(epoch FROM now() - updated_at)) AS max_duration_gauge FROM instances WHERE vm_state IN ('scheduling','pausing','unpausing','suspending','resuming','rescuing','unrescuing','rebuilding','migrating','deleting','restoring','shelving','unshelving','building','deleting','stopping','starting','spawning','rebooting') AND deleted=0 GROUP BY host, project_id, uuid, availability_zone, vm_state"
+      query: "SELECT coalesce(host, 'N/A') AS host, project_id, uuid, availability_zone, task_state, COUNT(*) FILTER (WHERE updated_at < now() - interval '15 minutes') AS count_gauge, MAX(EXTRACT(epoch FROM now() - updated_at)) AS max_duration_gauge FROM instances WHERE task_state IN ('scheduling','pausing','unpausing','suspending','resuming','rescuing','unrescuing','rebuilding','migrating','deleting','restoring','shelving','unshelving','building','deleting','stopping','starting','spawning','rebooting') AND deleted=0 GROUP BY host, project_id, uuid, availability_zone, task_state"
       metrics:
         - project_id:
             usage: "LABEL"
             description: "Project ID"
-        - vm_state:
+        - task_state:
             usage: "LABEL"
             description: "State of the VM"
         - host:


### PR DESCRIPTION
vm_state for an instance stuck in "deleting" is "active". Instead, we
have to alert on an instance having the task_state "deleting" for too
long.