### PR TITLE
[cinder] Add initial alert based on openstack-exporter

### DIFF
--- a/prometheus-exporters/openstack-exporter/alerts/service.alerts
+++ b/prometheus-exporters/openstack-exporter/alerts/service.alerts
@@ -1,0 +1,16 @@
+groups:
+- name: service.alerts
+  rules:
+  - alert: CinderBackendShardLowOvercommitWarning
+    expr: >
+      sum(cinder_max_oversubscription_ratio - cinder_overcommit_ratio) by (backend, shard) < .5
+    for: 5m
+    labels:
+      severity: info
+      tier: os
+      service: cinder
+      context: "openstack-exporter"
+      meta: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} max over commit is almost reached (< 0.5). Shard needs to be increased."
+    annotations:
+      description: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} max over commit is almost reached (< 0.5). Shard needs to be increased."
+      summary: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} max over commit is almost reached (< 0.5). Shard needs to be increased."


### PR DESCRIPTION
This patch adds a simple info alert for now for cinder.
The alert watches the amount of overcommit ratio left is
less than 0.5.

The amount of overcommit left is the difference between
the cinder configured max over subscription ratio and the
calculated overcommit ratio from allocated storage.

Typically the max oversubscription ratio is set to 1.5.