### PR TITLE
[Cinder] Update max_oversubscription_ratio default

### DIFF
--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -54,7 +54,7 @@ backend_defaults:
   vmware_connection_pool_size: 10
   vmware_insecure: True
   vmware_profile_check_on_attach: False
-  max_over_subscription_ratio: 1.5
+  max_over_subscription_ratio: 2.0
 
 backends:
     enabled: vmware


### PR DESCRIPTION
This updates the default max_oversubscription_ratio from 1.5
to 2.0