### PR TITLE
[Cinder]  This change removes jaeger components from cinder

### DIFF
--- a/openstack/cinder/requirements.lock
+++ b/openstack/cinder/requirements.lock
@@ -20,8 +20,5 @@ dependencies:
 - name: region_check
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.1
-- name: jaeger
-  repository: file://../../system/jaeger-operator
-  version: 0.1.0
 digest: sha256:8ade0a1154372ced9914e23fa946cdfd4651f4fd8913feba747cec570912d7c4
 generated: 2020-07-22T16:03:35.175903+02:00

--- a/openstack/cinder/requirements.yaml
+++ b/openstack/cinder/requirements.yaml
@@ -23,9 +23,3 @@ dependencies:
   - name: region_check
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.1.1
-  - name: jaeger
-    repository: file://../../system/jaeger-operator
-    version: 0.1.0
-    import-values:
-      - child: jaeger
-        parent: osprofiler.jaeger

--- a/openstack/cinder/templates/api-deployment.yaml
+++ b/openstack/cinder/templates/api-deployment.yaml
@@ -130,7 +130,6 @@ spec:
               mountPath: /etc/statsd/statsd-exporter.yaml
               subPath: statsd-exporter.yaml
               readOnly: true
-{{- include "jaeger_agent_sidecar" . | indent 8 }}
       volumes:
         - name: etccinder
           emptyDir: {}

--- a/openstack/cinder/templates/scheduler-deployment.yaml
+++ b/openstack/cinder/templates/scheduler-deployment.yaml
@@ -83,7 +83,6 @@ spec:
               mountPath: /etc/cinder/logging.ini
               subPath: logging.ini
               readOnly: true
-{{- include "jaeger_agent_sidecar" . | indent 8 }}
       volumes:
         - name: etccinder
           emptyDir: {}


### PR DESCRIPTION
This patch reverts the changes to the cinder charts that includes
support for jaeger.

I have to do a rollout on Monday of Cinder to all regions to update the max_oversubscription_ratio.
The diff on qa-de-1 shows a lot of changes regarding jaeger, which hasn't been fully vetted.
This patch removes the cinder changes that support jaeger for now.