### PR TITLE
Atlas Netbox Service Discovery for neutron router

### DIFF
--- a/system/infra-monitoring/vendor/atlas/templates/configmap.yaml
+++ b/system/infra-monitoring/vendor/atlas/templates/configmap.yaml
@@ -189,7 +189,7 @@ data:
               target: 1
               manufacturer: "cisco"
               region: "{{ .Values.global.region }}"
-              q: "asr1"
+              role: "neutron-router"
               status: "active"
 
             - custom_labels: 


### PR DESCRIPTION
This sets the matching for neutron routers to role based rather than
name-based in order to stay independent from changing naming convention.
E.g. the naming convention for network devices has been changes, in such
matter that newly built devices will carry the tag 'rt' compared to
'asr' in the old convention.