### PR TITLE
openstack/maia: add service label to PromRule

### DIFF
--- a/openstack/maia/templates/prometheus-alerts.yaml
+++ b/openstack/maia/templates/prometheus-alerts.yaml
@@ -10,6 +10,7 @@ metadata:
   labels:
     app: maia
     tier: os
+    service: maia
     type: alerting-rules
     prometheus: {{ required ".Values.alerts.prometheus missing" $values.alerts.prometheus }}
 


### PR DESCRIPTION
This will ensure that the corresponding absent alerts will _always_ get routed to the appropriate Slack channel. More info [here](https://github.com/sapcc/absent-metrics-operator/blob/master/doc/playbook.md#tier-and-service-labels).