### PR TITLE
[Cinder] Enable standard_hdd backend

### DIFF
--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -57,7 +57,7 @@ backend_defaults:
   max_over_subscription_ratio: 2.0
 
 backends:
-    enabled: vmware
+    enabled: vmware,standard_hdd
     vmware:
         vmware_storage_profile: cinder-vvol
     standard_hdd:


### PR DESCRIPTION
This patch enables the low performance cinder backend named
'standard_hdd' everywhere.  We still have several regions
that have storage profiles that don't have datastores, due to
a bug in vmware.  Once the cinder-standard-hdd profile is fixed in
those regions, then the driver will report space available for
provisioning.  While the storage profile doesn't have datastores, the
cinder driver will simply report have 0 bytes available for
provisioning and the cinder scheduler will never pick that backend
for a new volume.