### PR TITLE
[Cinder] Allow image tranfers of 6 hours

### DIFF
--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -54,6 +54,7 @@ backend_defaults:
   vmware_connection_pool_size: 10
   vmware_insecure: True
   vmware_profile_check_on_attach: False
+  vmware_image_transfer_timeout_secs: 21600
   max_over_subscription_ratio: 2.0
 
 backends:


### PR DESCRIPTION
This patch updates the vmware_image_transfer_timeout_secs from
7200 seconds (2 hours) to 21600 seconds (6 hours).

Some large image -> volume tranfers can take a long time.