### PR TITLE
[Cinder] Integrate jaeger with cinder

### DIFF
--- a/openstack/cinder/requirements.lock
+++ b/openstack/cinder/requirements.lock
@@ -20,5 +20,8 @@ dependencies:
 - name: region_check
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.1
-digest: sha256:54adc37c814be280177b9da8a70361c138274e87a7e2bdcb7a5e531d58c634c5
-generated: "2020-08-19T12:07:17.26702+02:00"
+- name: jaeger
+  repository: file://../../system/jaeger-operator
+  version: 0.1.0
+digest: sha256:100e8dc31bba28654d983e3432b9b2824c7099cdb3c4c171147930ccd1b62a2b
+generated: 2020-08-25T13:40:53.835948+02:00

--- a/openstack/cinder/requirements.yaml
+++ b/openstack/cinder/requirements.yaml
@@ -23,3 +23,10 @@ dependencies:
   - name: region_check
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.1.1
+  - name: jaeger
+    repository: file://../../system/jaeger-operator
+    version: 0.1.0
+    condition: osprofiler.jaeger.enabled
+    import-values:
+      - child: jaeger
+        parent: osprofiler.jaeger

--- a/openstack/cinder/templates/api-deployment.yaml
+++ b/openstack/cinder/templates/api-deployment.yaml
@@ -130,6 +130,7 @@ spec:
               mountPath: /etc/statsd/statsd-exporter.yaml
               subPath: statsd-exporter.yaml
               readOnly: true
+ {{- include "jaeger_agent_sidecar" . | indent 8 }}
       volumes:
         - name: etccinder
           emptyDir: {}

--- a/openstack/cinder/templates/scheduler-deployment.yaml
+++ b/openstack/cinder/templates/scheduler-deployment.yaml
@@ -83,6 +83,7 @@ spec:
               mountPath: /etc/cinder/logging.ini
               subPath: logging.ini
               readOnly: true
+ {{- include "jaeger_agent_sidecar" . | indent 8 }}
       volumes:
         - name: etccinder
           emptyDir: {}

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -13,7 +13,9 @@ global:
   pgbouncer:
     enabled: false
 
-osprofiler: {}
+osprofiler:
+  jaeger:
+    enabled: false
 
 pod:
   replicas:


### PR DESCRIPTION
This commit adds jaeger agent to cinder-api and cinder-scheduler pods as
side containers, and set the agents as the osprofiler's backend. The
jaeger operator is added as dependency in the requirements.yaml file,
with condition `osprofiler.jaeger.enabled`.