### PR TITLE
HostWithRunningVMsNotResponding increased severity to warning.

### DIFF
--- a/prometheus-exporters/vrops-exporter/alerts/host.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/host.alerts
@@ -7,12 +7,13 @@ groups:
       and on (hostsystem) vrops_hostsystem_runtime_powerstate{state="Unknown"}
       and on (hostsystem) count(vrops_virtualmachine_runtime_powerstate{state="Powered On"}) by (hostsystem) > 0
     labels:
-      severity: info
+      severity: warning
       tier: vmware
       service: compute
       context: "vrops-exporter"
       meta: "Host {{ $labels.hostsystem }} with running vm's not responding ({{ $labels.datacenter }}, {{ $labels.vccluster }})"
       dashboard: esxi-host-disconnected/esxi-host-disconnected?&var-host={{ $labels.hostsystem }}
+      playbook: docs/devops/alert/vcenter/#test_esxi_hs_1
     annotations:
       description: "Host {{ $labels.hostsystem }} with {{ $labels.value }} running vm's not responding ({{ $labels.datacenter }}, {{ $labels.vccluster }})"
       summary: "Host {{ $labels.hostsystem }} with {{ $labels.value }} running vm's not responding ({{ $labels.datacenter }}, {{ $labels.vccluster }})"


### PR DESCRIPTION
- added playbook
- increased severity to warning
- action identical to alert EsxiHostWithAssociatedVMsNotResponding