### PR TITLE
system/kube-monitoring*: bump event-exporter

### DIFF
--- a/system/kube-monitoring-admin-k3s/Chart.lock
+++ b/system/kube-monitoring-admin-k3s/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.6.0
 - name: event-exporter
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.2.1
+  version: 0.2.4
 - name: fluent-bit
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 2.7.2
@@ -44,5 +44,5 @@ dependencies:
 - name: prometheus-server
   repository: https://charts.eu-de-2.cloud.sap
   version: 3.6.0
-digest: sha256:2528dda95b51217a4ec60f3144019dd13939510aa27aaf169e644ff4987bc8da
-generated: "2020-09-02T16:53:15.46709+02:00"
+digest: sha256:3e112b7232d4e620ffa2842187bcd6eb1e0b513277bf41b5699403fe5737940e
+generated: "2020-09-02T17:36:26.203099+02:00"

--- a/system/kube-monitoring-admin-k3s/Chart.yaml
+++ b/system/kube-monitoring-admin-k3s/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes admin k3s cluster monitoring.
 name: kube-monitoring-admin-k3s
-version: 0.3.0
+version: 0.3.1
 dependencies:
   - condition: absent-metrics-operator.enabled
     name: absent-metrics-operator
@@ -10,7 +10,7 @@ dependencies:
     version: 0.6.0
   - name: event-exporter
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.2.1
+    version: 0.2.4
   - name: fluent-bit
     repository: https://kubernetes-charts.storage.googleapis.com
     version: 2.7.2

--- a/system/kube-monitoring-admin/Chart.lock
+++ b/system/kube-monitoring-admin/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 1.0.5
 - name: event-exporter
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.2.0
+  version: 0.2.4
 - name: fluent-bit
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 2.7.1
@@ -53,5 +53,5 @@ dependencies:
 - name: prometheus-server
   repository: https://charts.eu-de-2.cloud.sap
   version: 3.4.1
-digest: sha256:51260fc7e896422ba279e1d48358886259af9e66b74ab05459cacff5adc0cfe3
-generated: "2020-09-02T16:57:52.620744+02:00"
+digest: sha256:34a49498c707d0bbfbcccec37d6eca7b0736819b6ff5714474fa589d20d453a0
+generated: "2020-09-02T17:36:19.490268+02:00"

--- a/system/kube-monitoring-admin/Chart.yaml
+++ b/system/kube-monitoring-admin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes admin cluster monitoring.
 name: kube-monitoring-admin
-version: 1.5.0
+version: 1.5.1
 dependencies:
   - condition: absent-metrics-operator.enabled
     name: absent-metrics-operator
@@ -13,7 +13,7 @@ dependencies:
     version: 1.0.5
   - name: event-exporter
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.2.0
+    version: 0.2.4
   - name: fluent-bit
     repository: https://kubernetes-charts.storage.googleapis.com
     version: 2.7.1

--- a/system/kube-monitoring-kubernikus/Chart.lock
+++ b/system/kube-monitoring-kubernikus/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.6.0
 - name: event-exporter
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.2.0
+  version: 0.2.4
 - name: fluent-bit
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 2.7.2
@@ -59,5 +59,5 @@ dependencies:
 - name: watchcache-exporter
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.2
-digest: sha256:0add16a834aee3927c04b2fb8197945529e77d735984139a262abde1879a7567
-generated: "2020-09-02T16:59:42.278676+02:00"
+digest: sha256:fa48c2655c185a345636fb7d6423951e1484028bb469d361b10c8d913d4caac6
+generated: "2020-09-02T17:36:10.76694+02:00"

--- a/system/kube-monitoring-kubernikus/Chart.yaml
+++ b/system/kube-monitoring-kubernikus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for monitoring Kubernikus.
 name: kube-monitoring-kubernikus
-version: 1.2.0
+version: 1.2.1
 dependencies:
   - condition: absent-metrics-operator.enabled
     name: absent-metrics-operator
@@ -10,7 +10,7 @@ dependencies:
     version: 0.6.0
   - name: event-exporter
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.2.0
+    version: 0.2.4
   - name: fluent-bit
     repository: https://kubernetes-charts.storage.googleapis.com
     version: 2.7.2

--- a/system/kube-monitoring-metal/Chart.lock
+++ b/system/kube-monitoring-metal/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 1.0.5
 - name: event-exporter
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.2.0
+  version: 0.2.4
 - name: grafana-dashboards-kubernetes
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.6
@@ -50,5 +50,5 @@ dependencies:
 - name: watchcache-exporter
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.2
-digest: sha256:9885a0dd461f9a4716dc29b5f4d6c734712e1a26edbba561c941c54514ef8ee8
-generated: "2020-09-02T15:42:01.408794+02:00"
+digest: sha256:8f8a407edce1e000500b153665420dd3c473879d1175a17f3c48eccbd516bdd7
+generated: "2020-09-02T17:36:00.745143+02:00"

--- a/system/kube-monitoring-metal/Chart.yaml
+++ b/system/kube-monitoring-metal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes metal controlplane monitoring.
 name: kube-monitoring-metal
-version: 1.6.13
+version: 1.6.14
 dependencies:
   - condition: absent-metrics-operator.enabled
     name: absent-metrics-operator
@@ -13,7 +13,7 @@ dependencies:
     version: 1.0.5
   - name: event-exporter
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.2.0
+    version: 0.2.4
   - name: grafana-dashboards-kubernetes
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.1.6

--- a/system/kube-monitoring-scaleout/Chart.lock
+++ b/system/kube-monitoring-scaleout/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 1.0.5
 - name: event-exporter
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.2.0
+  version: 0.2.4
 - name: fluent-bit
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 2.7.1
@@ -50,5 +50,5 @@ dependencies:
 - name: watchcache-exporter
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.2
-digest: sha256:ddeb0180528f860bfd6780a07f91225e04b2cd0e9631162bb58380e3afc1876c
-generated: "2020-09-02T17:03:04.897346+02:00"
+digest: sha256:a4af088bece32727ede181e55cb4e1cafcf0a0c939d3cd905713c89ced01b7b7
+generated: "2020-09-02T17:38:06.381602+02:00"

--- a/system/kube-monitoring-scaleout/Chart.yaml
+++ b/system/kube-monitoring-scaleout/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes scaleout cluster monitoring.
 name: kube-monitoring-scaleout
-version: 0.5.0
+version: 0.5.1
 dependencies:
   - condition: absent-metrics-operator.enabled
     name: absent-metrics-operator
@@ -13,7 +13,7 @@ dependencies:
     version: 1.0.5
   - name: event-exporter
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.2.0
+    version: 0.2.4
   - name: fluent-bit
     repository: https://kubernetes-charts.storage.googleapis.com
     version: 2.7.1

--- a/system/kube-monitoring-virtual/Chart.lock
+++ b/system/kube-monitoring-virtual/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.6.0
 - name: event-exporter
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.2.0
+  version: 0.2.4
 - name: fluent-bit
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 2.7.2
@@ -50,5 +50,5 @@ dependencies:
 - name: prometheus-virtual-rules
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.1
-digest: sha256:85b07c30df6829cdce718707359ba1a4a538498ac2a70ba1075e661f883896b5
-generated: "2020-09-02T17:03:12.937924+02:00"
+digest: sha256:fc7e5de90bf60a4151b90e229bb6e8b239042a17326dbc41ced276d2eb452ecf
+generated: "2020-09-02T17:35:39.844193+02:00"

--- a/system/kube-monitoring-virtual/Chart.yaml
+++ b/system/kube-monitoring-virtual/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes virtual cluster monitoring.
 name: kube-monitoring-virtual
-version: 0.10.0
+version: 0.10.1
 dependencies:
   - condition: absent-metrics-operator.enabled
     name: absent-metrics-operator
@@ -10,7 +10,7 @@ dependencies:
     version: 0.6.0
   - name: event-exporter
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.2.0
+    version: 0.2.4
   - name: fluent-bit
     repository: https://kubernetes-charts.storage.googleapis.com
     version: 2.7.2


### PR DESCRIPTION
event-exporter has been bumped in all cluster types to deploy 0834de63ebb541f1c121733a00708dccc50b89c6.