### PR TITLE
[Neutron][Blackbox] explicit service + context in OpenstackNeutronDhc…

### DIFF
--- a/openstack/blackbox/charts/blackbox-tests-integrity/alerts/neutron-integrity.alerts
+++ b/openstack/blackbox/charts/blackbox-tests-integrity/alerts/neutron-integrity.alerts
@@ -24,8 +24,8 @@ groups:
     labels:
       severity: warning
       tier: os
-      service: '{{ $labels.service }}'
-      context: '{{ $labels.context }}'
+      service: blackbox
+      context: blackbox
       meta: 'DHCP agent has less subnets than subnets with dhcp enabled: {{ $labels.check }}'
       sentry: blackbox/?query=test_{{ $labels.check }}
       playbook: docs/support/playbook/neutron/dhcp_down.html

--- a/openstack/neutron/alerts/neutron.alerts
+++ b/openstack/neutron/alerts/neutron.alerts
@@ -39,8 +39,8 @@ groups:
     labels:
       severity: warning
       tier: os
-      service: '{{ $labels.service }}'
-      context: '{{ $labels.context }}'
+      service: neutron
+      context: neutron
       meta: 'DHCP agent has less subnets than subnets with dhcp enabled: {{ $labels.check }}'
       sentry: blackbox/?query=test_{{ $labels.check }}
       playbook: docs/support/playbook/neutron/dhcp_down.html


### PR DESCRIPTION
…pAgentLostNetworks alert to improve routing

Hi @notandy @Abhishekkumar17 

OpenstackNeutronDhcpAgentLostNetworks alert is firing in keystone channel post implementing absent-metrics-operator https://convergedcloud.slack.com/archives/C5JKSDDQE/p1599632503005300

Regards,
Rajiv