### PR TITLE
[common][mariadb] use custom images from keppel

### DIFF
--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.1.21
+version: 0.2.0

--- a/common/mariadb/ci/test-values.yaml
+++ b/common/mariadb/ci/test-values.yaml
@@ -2,6 +2,7 @@ global:
   dbUser: admin
   dbPassword: secret!
   master_password: topSecret!
+  registry: my.docker.registry
 
 test_db_host: testRelease-mariadb.svc
 root_password: secret123

--- a/common/mariadb/templates/_helpers.tpl
+++ b/common/mariadb/templates/_helpers.tpl
@@ -47,6 +47,14 @@
 {{.Values.global.dbPassword | default (tuple . .Values.global.dbUser | include "mariadb.password_for_user")}}
 {{- end -}}
 
+{{- define "registry" -}}
+{{- if .Values.use_alternate_registry -}}
+{{- .Values.global.registryAlternateRegion -}}
+{{- else -}}
+{{- .Values.global.registry -}}
+{{- end -}}
+{{- end -}}
+
 {{/* Needed for testing purposes only. */}}
 {{define "RELEASE-NAME_db_host"}}testRelease-mariadb.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.region}}.{{.Values.global.tld}}{{end}}
 {{define "testRelease_db_host"}}testRelease-mariadb.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.region}}.{{.Values.global.tld}}{{end}}

--- a/common/mariadb/templates/backup-v2-deployment.yaml
+++ b/common/mariadb/templates/backup-v2-deployment.yaml
@@ -51,7 +51,7 @@ spec:
 {{- end }}
       containers:
       - name: backup
-        image: "{{ default "hub.global.cloud.sap" .Values.global.imageRegistry}}/{{.Values.global.image_namespace}}/maria-back-me-up:{{ .Values.backup_v2.image_version }}"
+        image: "{{ include "registry" . }}/{{ .Values.backup_v2.image }}:{{ .Values.backup_v2.image_version }}"
         command:
           - backup
         ports:

--- a/common/mariadb/templates/backup-verify-deploy.yaml
+++ b/common/mariadb/templates/backup-verify-deploy.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: {{ .Values.name }}-db-backup-v2
       containers:
       - name: mariabackup-verification
-        image: "{{ default "hub.global.cloud.sap" .Values.global.imageRegistry}}/{{.Values.global.image_namespace}}/maria-back-me-up:{{ .Values.backup_v2.image_version }}"
+        image: "{{ include "registry" . }}/{{ .Values.backup_v2.image }}:{{ .Values.backup_v2.image_version }}"
         command:
           - verification
         ports:

--- a/common/mariadb/templates/deployment.yaml
+++ b/common/mariadb/templates/deployment.yaml
@@ -104,7 +104,7 @@ spec:
           - name: db-socket
             mountPath: /var/run/mysqld
       - name: backup
-        image: {{ default "hub.global.cloud.sap" .Values.global.imageRegistry}}/{{.Values.global.image_namespace}}/backup-tools:{{ .Values.backup.image_version }}
+        image: {{ include "registry" . }}/{{ .Values.backup.image }}:{{ .Values.backup.image_version }}
         imagePullPolicy: IfNotPresent
         env:
           - name: MYSQL_ROOT_PASSWORD
@@ -149,7 +149,7 @@ spec:
 {{- end }}
 {{- if .Values.backup_v2.enabled }}
       - name: readiness
-        image: "{{ default "hub.global.cloud.sap" .Values.global.imageRegistry}}/{{.Values.global.image_namespace}}/pod-readiness:{{ .Values.readiness.image_version }}"
+        image: "{{ include "registry" . }}//{{ .Values.readiness.image }}:{{ .Values.readiness.image_version }}"
         command:
           - pod_readiness
         readinessProbe:

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -61,11 +61,13 @@ resources:
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 ##
 nodeAffinity: {}
+# set to true to use .Values.global.registryAlternateRegion instead of .Values.global.registry
+use_alternate_registry: false
 
 backup:
   enabled: false
-  image: monsoon/backup-tools
-  image_version: v0.6.4
+  image: ccloud/backup-tools
+  image_version: v0.6.5
   interval_full: 1 days
   interval_incr: 1 hours
   os_password: DEFINED-IN-REGION-SECRETS
@@ -75,14 +77,14 @@ backup:
   os_project_domain: ccadmin
 
 readiness:
-  image: monsoon/pod-readiness
+  image: ccloud/pod-readiness
   image_version: ffb61ca4
 
 backup_v2:
   enabled: false
   backup_dir: "./backup"
-  image: monsoon/maria-back-me-up
-  image_version: 73b9c96a
+  image: ccloud/maria-back-me-up
+  image_version: e43686d8
   full_backup_cron_schedule: "0 0 * * *"
   incremental_backup_in_minutes: 5
   verification_interval: 30


### PR DESCRIPTION
possibility to use alternate registry, e.g. for keystone

pod-readiness has just been copied (just added a source_repo label) for now - I would prefer to do a fresh build