### PR TITLE
[keystone] inetgrate osprofiler/jaeger

### DIFF
--- a/openstack/keystone/ci/test-values.yaml
+++ b/openstack/keystone/ci/test-values.yaml
@@ -3,6 +3,9 @@ global:
   db_region: local
   region: test
   master_password: test
+  osprofiler:
+    jager:
+      enabled: true
 
 api:
   cloudAdminProjectId: default

--- a/openstack/keystone/ci/test-values.yaml
+++ b/openstack/keystone/ci/test-values.yaml
@@ -11,3 +11,7 @@ api:
 
 cron:
   imageTag: myTag
+
+osprofiler:
+  jager:
+    enabled: true

--- a/openstack/keystone/requirements.lock
+++ b/openstack/keystone/requirements.lock
@@ -17,5 +17,8 @@ dependencies:
 - name: utils
   repository: file://../../openstack/utils
   version: 0.1.1
-digest: sha256:1ee1e92560d2441560d10a122f9663cc13ede545ae0aa72cc8ff0e8e40012cdd
-generated: 2020-08-27T12:40:21.412170134+05:30
+- name: jaeger-operator
+  repository: https://charts.eu-de-2.cloud.sap
+  version: 0.1.0
+digest: sha256:352eeb4284693e4154ef312d3c803bf88273fd422802a7d7938630a515620b62
+generated: 2020-09-14T12:42:19.270362+02:00

--- a/openstack/keystone/requirements.yaml
+++ b/openstack/keystone/requirements.yaml
@@ -20,3 +20,10 @@ dependencies:
   - name: utils
     repository: file://../../openstack/utils
     version: 0.1.1
+  - name: jaeger-operator
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 0.1.0
+    condition: osprofiler.jaeger.enabled
+    import-values:
+      - child: jaeger
+        parent: osprofiler.jaeger

--- a/openstack/keystone/templates/deployment-api.yaml
+++ b/openstack/keystone/templates/deployment-api.yaml
@@ -235,6 +235,7 @@ spec:
 {{ toYaml .Values.api.metrics.resources | indent 12 }}
           {{- end }}
         {{- end }}
+{{- include "jaeger_agent_sidecar" . | indent 8 }}
       volumes:
         - name: etc-keystone
           emptyDir: {}

--- a/openstack/keystone/templates/etc/_keystone.conf.tpl
+++ b/openstack/keystone/templates/etc/_keystone.conf.tpl
@@ -230,3 +230,5 @@ allow_credentials = true
 expose_headers = Content-Type,Cache-Control,Content-Language,Expires,Last-Modified,Pragma,X-Auth-Token,X-Openstack-Request-Id,X-Subject-Token
 allow_headers = Content-Type,Cache-Control,Content-Language,Expires,Last-Modified,Pragma,X-Auth-Token,X-Openstack-Request-Id,X-Subject-Token,X-Project-Id,X-Project-Name,X-Project-Domain-Id,X-Project-Domain-Name,X-Domain-Id,X-Domain-Name,X-User-Id,X-User-Name,X-User-Domain-name
 {{- end }}
+
+{{- include "osprofiler" . }}


### PR DESCRIPTION
This PR integrates osprofiler with jaeger into keystone service. When enabled (via secrete values), the api pods will be running with a sidecar container jaeger-agent, which is responsible to send the collected profiling spans to the jaeger system.