### PR TITLE
removed ballooning alert

### DIFF
--- a/prometheus-exporters/vrops-exporter/alerts/host.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/host.alerts
@@ -32,14 +32,3 @@ groups:
     annotations:
       description: "Host {{ $labels.hostsystem }} not responding ({{ $labels.datacenter }}, {{ $labels.vccluster }})"
       summary: "Host {{ $labels.hostsystem }} not responding ({{ $labels.datacenter }}, {{ $labels.vccluster }})"
-  - alert: HostMemoryBallooning
-    expr: vrops_hostsystem_memory_ballooning_kilobytes > 0
-    labels:
-      severity: info
-      tier: vmware
-      service: compute
-      context: "vrops-exporter"
-      meta: "Host {{ $labels.hostsystem }} in {{ $labels.datacenter }} has memory ballooning."
-    annotations:
-      description: "Host {{ $labels.hostsystem }} in {{ $labels.datacenter }} has memory ballooning."
-      summary: "Host {{ $labels.hostsystem }} in {{ $labels.datacenter }} has memory ballooning."


### PR DESCRIPTION
Removed HostMemoryBallooning alert. The alert is no longer needed according to David Hoeller.