### PR TITLE
[cinder] Upgrade the low overcommit alert to warning

### DIFF
--- a/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
+++ b/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
@@ -6,11 +6,12 @@ groups:
       sum(cinder_free_until_overcommit_gib) by (region, shard, backend) / 1024 + sum(cinder_free_until_overcommit_gib / cinder_total_capacity_gib * 100 < 20) by (region, shard, backend) * 0
     for: 15m
     labels:
-      severity: info
+      severity: warning
       tier: os
       service: cinder
       context: "openstack-exporter"
       meta: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 20% storage left before overcommit is reached."
+      playbook: docs/support/playbook/cinder/cinder_low_overcommit_ratio.html
     annotations:
       description: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 20% storage left before overcommit is reached."
       summary: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 20% storage left before overcommit is reached."


### PR DESCRIPTION
This patch updates the cinder low overcommit ration alert from
info to warning.  Also adds the link to the playbook.