### PR TITLE
[keystone] added image puller ds for keppel

### DIFF
--- a/openstack/keystone/templates/daemonset-keep-image-pulled.yaml
+++ b/openstack/keystone/templates/daemonset-keep-image-pulled.yaml
@@ -1,0 +1,85 @@
+# Because Keppel depends on Keystone and the other way around the Docker images
+# for Keystone should be pre-pulled to able to start in case keppel is down.
+# This daemonset (through its existence) keeps required images permanently
+# pulled on all nodes.
+
+kind: DaemonSet
+{{- if .Capabilities.APIVersions.Has "apps/v1" }}
+apiVersion: apps/v1
+{{- else }}
+apiVersion: extensions/v1beta1
+{{- end }}
+
+metadata:
+  name: {{ .Release.Name }}-keep-image-pulled
+
+spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 5
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-keep-image-pulled
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-keep-image-pulled
+    spec:
+      containers:
+        - name: mariadb
+          image: "{{ .Values.mariadb.image }}"
+          imagePullPolicy: IfNotPresent
+          command: [ '/bin/sleep', 'inf' ]
+          resources:
+            requests:
+              cpu: "1m"
+              memory: "16Mi"
+            limits:
+              cpu: "1m"
+              memory: "16Mi"
+        - name: readiness
+          image: {{ required ".Values.global.registryAlternateRegion is missing" .Values.global.registryAlternateRegion }}/{{ .Values.mariadb.readiness.image }}:{{ .Values.mariadb.readiness.image_version }}
+          imagePullPolicy: IfNotPresent
+          command: [ '/bin/sleep', 'inf' ]
+          resources:
+            requests:
+              cpu: "1m"
+              memory: "16Mi"
+            limits:
+              cpu: "1m"
+              memory: "16Mi"
+        - name: metrics
+          image: "{{ .Values.mariadb.metrics.image }}:{{ .Values.mariadb.metrics.image_version }}"
+          imagePullPolicy: IfNotPresent
+          command: [ '/bin/sleep', 'inf' ]
+          resources:
+            requests:
+              cpu: "1m"
+              memory: "16Mi"
+            limits:
+              cpu: "1m"
+              memory: "16Mi"
+        - name: keystone
+          image: {{ required ".Values.global.registryAlternateRegion is missing" .Values.global.registryAlternateRegion }}/{{ .Values.api.image }}:{{ required ".Values.api.imageTag is missing" .Values.api.imageTag }}
+          imagePullPolicy: IfNotPresent
+          command: [ '/bin/sleep', 'inf' ]
+          resources:
+            requests:
+              cpu: "1m"
+              memory: "16Mi"
+            limits:
+              cpu: "1m"
+              memory: "16Mi"
+        - name: check
+          image: {{ required ".Values.global.registryAlternateRegion is missing" .Values.global.registryAlternateRegion}}/kube-python:1.0.1
+          imagePullPolicy: IfNotPresent
+          command: [ '/bin/sleep', 'inf' ]
+          resources:
+            requests:
+              cpu: "1m"
+              memory: "16Mi"
+            limits:
+              cpu: "1m"
+              memory: "16Mi"
+      terminationGracePeriodSeconds: 1


### PR DESCRIPTION
similar to what keppel has for postgres.
technically only db readiness image is stored in keppel, but theoretically db restarts will be a bit faster if mariadb and metrics are pre-pulled on all nodes.