### PR TITLE
[Cinder] Add critical alert for overcommit <10% left

### DIFF
--- a/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
+++ b/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
@@ -15,3 +15,17 @@ groups:
     annotations:
       description: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 20% storage left before overcommit is reached."
       summary: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 20% storage left before overcommit is reached."
+  - alert: CinderBackendShardLowOvercommitCritical
+    expr: >
+      sum(cinder_free_until_overcommit_gib) by (region, shard, backend) / 1024 + sum(cinder_free_until_overcommit_gib / cinder_total_capacity_gib * 100 < 10) by (region, shard, backend) * 0
+    for: 15m
+    labels:
+      severity: info
+      tier: os
+      service: cinder
+      context: "openstack-exporter"
+      meta: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 10% storage left before overcommit is reached."
+      playbook: docs/support/playbook/cinder/cinder_low_overcommit_ratio.html
+    annotations:
+      description: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 10% storage left before overcommit is reached."
+      summary: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 10% storage left before overcommit is reached."


### PR DESCRIPTION
This patch adds a new critical alert for cinder pool storage
overcommit ratio reaching 10% or less leftover.