### PR TITLE
Fix hermes playbook link

### DIFF
--- a/openstack/hermes/alerts/hermes.alerts
+++ b/openstack/hermes/alerts/hermes.alerts
@@ -81,7 +81,7 @@ groups:
       service: hermes
       dashboard: rabbitmq
       meta: '{{ $labels.service }} {{ $labels.check }} has over 2000 ready messages in {{ $labels.kubernetes_name }}. Logstash has disconnected from the RabbitMQ.'
-      playbook: 'docs/devops/alert/hermes/#{{ $labels.check }}'
+      playbook: 'docs/devops/alert/rabbitmq/#ready'
     annotations:
       description: '{{ $labels.service }} {{ $labels.check }} has over 2000 unacknowledged messages in {{ $labels.kubernetes_name }}. Logstash has disconnected from the RabbitMQ.'
       summary: 'RabbitMQ unacknowledged messages count'


### PR DESCRIPTION
The old link is wrong the new one is working
It also seems that `{{ $labels.service }} {{ $labels.check }}`  are empty but I don't know what should be there and what should be there instead.