### PR TITLE
[cinder] Enable select random best datastore

### DIFF
--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -58,6 +58,7 @@ backend_defaults:
   vmware_profile_check_on_attach: False
   vmware_image_transfer_timeout_secs: 21600
   max_over_subscription_ratio: 2.0
+  vmware_select_random_best_datastore: True
 
 backends:
     enabled: vmware,standard_hdd


### PR DESCRIPTION
This patch enables the new custom setting for selecting
the best datastore via random method.