### PR TITLE
[swift] bump memory for the collector

### DIFF
--- a/openstack/swift/templates/proxy-deployment.yaml
+++ b/openstack/swift/templates/proxy-deployment.yaml
@@ -174,14 +174,14 @@ spec:
               containerPort: 9520
           {{- if $.Values.resources.enabled }}
           resources:
-            # observed usage: CPU = ~10m, RAM = 40-60 MiB
+            # observed usage: CPU = ~10m, RAM = 70-100 MiB
             # low cpu allocation results in performance degradation
             requests:
               cpu: "100m"
-              memory: "100Mi"
+              memory: "150Mi"
             limits:
               cpu: "100m"
-              memory: "100Mi"
+              memory: "150Mi"
           {{- end }}
           volumeMounts:
             - mountPath: /swift-etc


### PR DESCRIPTION
Seems the base line has been raised after py3 conversion