### PR TITLE
Revert "[prometheus-infra] decreased scrape interval"

### DIFF
--- a/system/infra-monitoring/values.yaml
+++ b/system/infra-monitoring/values.yaml
@@ -184,8 +184,8 @@ cablecheck_exporter:
 
 vrops_exporter:
   enabled: false
-  scrapeInterval: 5m
-  scrapeTimeout: 255s
+  scrapeInterval: 10m
+  scrapeTimeout: 595s
 
 px_exporter:
   enabled: false


### PR DESCRIPTION
Reverts sapcc/helm-charts#1911

Needs to be specified per region until we are rolled out.