### PR TITLE
[nova] add workaround for keeping consoleauth enabled

### DIFF
--- a/openstack/nova/templates/etc/_nova.conf.tpl
+++ b/openstack/nova/templates/etc/_nova.conf.tpl
@@ -182,3 +182,7 @@ user_domain_name = "{{.Values.global.keystone_service_domain | default "Default"
 project_name = "{{.Values.global.keystone_service_project | default "service" }}"
 project_domain_name = "{{.Values.global.keystone_service_domain | default "Default" }}"
 region_name = {{.Values.global.region}}
+
+[workarounds]
+# This has to be removed when we also remove the deployment of nova-consoleauth
+enable_consoleauth = True


### PR DESCRIPTION
Starting with Rocky, nova-consoleauth gets deprecated and there is
an option `[workaround]enable_consoleauth = True` which needs to be
set in order to keep nova using it. This is mainly needed for
shellinaboxproxy which is not yet adapted to use db tokens.