### PR TITLE
[nova] Set scheduler workers to 1

### DIFF
--- a/openstack/nova/templates/etc/_nova-scheduler.conf.tpl
+++ b/openstack/nova/templates/etc/_nova-scheduler.conf.tpl
@@ -15,6 +15,7 @@ scheduler_tracks_instance_changes = {{ .Values.scheduler.scheduler_tracks_instan
 
 [scheduler]
 discover_hosts_in_cells_interval = 60
+workers = {{ .Values.scheduler.workers | default 1 }}
 
 [filter_scheduler]
 bigvm_host_size_filter_uses_flavor_extra_specs = true


### PR DESCRIPTION
We default to 1, because parallel scheduling can make things
problematic, but leave it configurable in case we see performance
problems.

This is a new setting in rocky.