### PR TITLE
[cinder] update cinder requirements for keppel

### DIFF
--- a/openstack/cinder/requirements.lock
+++ b/openstack/cinder/requirements.lock
@@ -4,24 +4,24 @@ dependencies:
   version: 0.1.1
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.20
+  version: 0.2.4
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.4
+  version: 0.2.2
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.0.2
+  version: 0.0.3
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.4
+  version: 0.1.9
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.4
+  version: 0.1.9
 - name: region_check
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.1
+  version: 0.1.2
 - name: jaeger-operator
   repository: file://../../system/jaeger-operator
   version: 0.1.0
-digest: sha256:48fe6b2cc77419200ad39ef581232a833518a672cca7f51397d87c86a6e9d68a
-generated: 2020-09-14T12:35:46.650288+02:00
+digest: sha256:7074e9dd4f26b2f453c728ec6f348825b9b57a95c12cefff4a70bc52cdece142
+generated: 2020-10-08T07:21:02.045741843-07:00

--- a/openstack/cinder/requirements.yaml
+++ b/openstack/cinder/requirements.yaml
@@ -4,25 +4,25 @@ dependencies:
     version: 0.1.1
   - name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.20
+    version: 0.2.4
     condition: mariadb.enabled
   - name: mysql_metrics
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.4
+    version: 0.2.2
     condition: mariadb.enabled
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.0.2
+    version: 0.0.3
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.4
+    version: 0.1.9
   - name: rabbitmq
     alias: rabbitmq_notifications
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.4
+    version: 0.1.9
   - name: region_check
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.1
+    version: 0.1.2
   - name: jaeger-operator
     repository: file://../../system/jaeger-operator
     version: 0.1.0


### PR DESCRIPTION
This patch updates some of cinder's dependencies to versions
that use keppel instead of quay.