### PR TITLE
[nova] add cpu_weight_multiplier

### DIFF
--- a/openstack/nova/templates/etc/_nova-scheduler.conf.tpl
+++ b/openstack/nova/templates/etc/_nova-scheduler.conf.tpl
@@ -6,6 +6,7 @@ scheduler_driver = {{ .Values.scheduler.driver }}
 scheduler_available_filters = {{ .Values.scheduler.available_filters | default "nova.scheduler.filters.all_filters" }}
 scheduler_default_filters = {{ .Values.scheduler.default_filters}}
 
+cpu_weight_multiplier = {{ .Values.scheduler.cpu_weight_multiplier }}
 ram_weight_multiplier = {{ .Values.scheduler.ram_weight_multiplier }}
 disk_weight_multiplier =  {{ .Values.scheduler.disk_weight_multiplier }}
 io_ops_weight_multiplier = {{ .Values.scheduler.io_ops_weight_multiplier }}

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -232,6 +232,7 @@ scheduler:
   scheduler_instance_sync_interval: 120
   default_filters: "AvailabilityZoneFilter, ShardFilter, AggregateMultiTenancyIsolation, RamFilter, DiskFilter, ComputeFilter, ComputeCapabilitiesFilter, BigVmFlavorHostSizeFilter, ImagePropertiesFilter, ServerGroupAntiAffinityFilter, ServerGroupAffinityFilter, BaremetalExactRamFilter, BaremetalExactCoreFilter, BaremetalExactDiskFilter"
   ram_weight_multiplier: 1.0
+  cpu_weight_multiplier: 1.0
   disk_weight_multiplier: 1.0
   io_ops_weight_multiplier: 0.0
   soft_affinity_weight_multiplier: 1.0


### PR DESCRIPTION
There is a new CPUWeigher introduced in Rocky, so we add a configuration
in case we need to use it somewhere.
Defaults to 1.0 so that it doesn't have any effect by default.