### PR TITLE
CNMP: Big root disk sized flavor for HANA nodes

### DIFF
--- a/openstack/sap-seeds/templates/flavor-seed.yaml
+++ b/openstack/sap-seeds/templates/flavor-seed.yaml
@@ -312,6 +312,15 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
+  - name: "m5.64xlarge5hdd"
+    id: "241"
+    vcpus: 128
+    ram: 1048560
+    disk: 550
+    is_public: false
+    extra_specs:
+      "vmware:hv_enabled": "True"
+      "hw_video:ram_max_mb": "16"
   - name: "m5.96xlarge"
     id: "270"
     vcpus: 90


### PR DESCRIPTION
For kubernikus clusters running node pools in the CNMP context
there is the need of huge flavors for HANA nodes. The bigger root
disk is needed to pull container images carrying the hana content.

It is made explicit private.