### PR TITLE
new cable-checker version

### DIFF
--- a/system/infra-monitoring/vendor/bm-cablecheck-exporter/values.yaml
+++ b/system/infra-monitoring/vendor/bm-cablecheck-exporter/values.yaml
@@ -1,5 +1,5 @@
 image: cc-cablecheck-exporter
-tag: v17
+tag: v18
 
 global:
    csm_swift_user:


### PR DESCRIPTION
In na-us-1 the cable-checker for baremetal has been stuck for some time. I had a look at it and found out that at a node different mac addresses are used than the ones in netbox for the host.

I had also checked if the macs are different on the hardware, but negative.

A fix deployed in the new image version I uploaded.