### PR TITLE
[cinder] reduce the workers per pod, but increase replicas;

### DIFF
--- a/openstack/cinder/templates/etc/_cinder.conf.tpl
+++ b/openstack/cinder/templates/etc/_cinder.conf.tpl
@@ -29,7 +29,7 @@ auth_strategy = keystone
 rpc_response_timeout = {{ .Values.rpc_response_timeout | default .Values.global.rpc_response_timeout | default 300 }}
 rpc_workers = {{ .Values.rpc_workers | default .Values.global.rpc_workers | default 1 }}
 
-osapi_volume_workers = {{ .Values.osapi_volume_workers | default 16 }}
+osapi_volume_workers = {{ .Values.osapi_volume_workers | default 10 }}
 
 wsgi_default_pool_size = {{ .Values.wsgi_default_pool_size | default .Values.global.wsgi_default_pool_size | default 100 }}
 

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -19,7 +19,7 @@ osprofiler:
 
 pod:
   replicas:
-    api: 2
+    api: 4
     scheduler: 1
   lifecycle:
     upgrades:
@@ -33,7 +33,7 @@ pod:
     api:
       requests:
         cpu: "1500m"
-        memory: "5Gi"
+        memory: "3Gi"
     scheduler:
       requests:
         cpu: "100m"
@@ -79,14 +79,19 @@ cinder_api_allow_migration_on_attach: True
 
 mariadb:
   enabled: true
+  max_connections: 2048
   buffer_pool_size: "2048M"
   log_file_size: "512M"
   name: cinder
   initdb_configmap: cinder-initdb
   persistence_claim:
     name: db-cinder-pvclaim
+  extraConfigFiles:
+    cinder.cnf: |+
+      [mysqld]
+      connect_timeout = 15
 
-max_pool_size: 20
+max_pool_size: 15
 max_overflow: 5
 
 mysql_metrics:


### PR DESCRIPTION
also adjust max_connections & connect_timeout for mariadb and pool_size for sqlalchemy;