### PR TITLE
Revert "[prometheus-infra.scaleout] just ignore vrops_virtualmachine production metrics"

### DIFF
--- a/system/prometheus-infra/templates/_prometheus-infra.yaml.tpl
+++ b/system/prometheus-infra/templates/_prometheus-infra.yaml.tpl
@@ -27,7 +27,7 @@
       - '{job="redfish/bb"}'
       - '{job="redfish/bm"}'
       - '{job="redfish/cp"}'
-      - '{job="vrops",__name__!~"^vrops_virtualmachine_.*", vccluster=~"prod.*"}'
+      - '{job="vrops",__name__!~"^vrops_virtualmachine_.*"}'
       - '{job="netbox"}'
       - '{job="firmware-exporter"}'      
       - '{job=~"^netapp-capacity-exporter.*"}'


### PR DESCRIPTION
Reverts sapcc/helm-charts#1948