### PR TITLE
[cinder] Optionally run cinder-api via uWSGI

### DIFF
--- a/openstack/cinder/templates/api-deployment.yaml
+++ b/openstack/cinder/templates/api-deployment.yaml
@@ -37,7 +37,7 @@ spec:
             - kubernetes-entrypoint
           env:
             - name: COMMAND
-              value: "cinder-api"
+              value: "{{ if .Values.api.use_uwsgi }}uwsgi --ini /etc/cinder/api_uwsgi.ini{{ else }}cinder-api{{ end }}"
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
             - name: DEPENDENCY_JOBS
@@ -93,6 +93,12 @@ spec:
               mountPath: /etc/cinder/api-paste.ini
               subPath: api-paste.ini
               readOnly: true
+           {{- if .Values.api.use_uwsgi }}
+            - mountPath: /etc/cinder/api_uwsgi.ini
+              name: cinder-etc
+              subPath: api_uwsgi.ini
+              readOnly: true
+           {{- end }}
             - name: cinder-etc
               mountPath: /etc/cinder/policy.json
               subPath: policy.json

--- a/openstack/cinder/templates/etc-configmap.yaml
+++ b/openstack/cinder/templates/etc-configmap.yaml
@@ -10,6 +10,10 @@ metadata:
 data:
   api-paste.ini: |
 {{ include (print $.Template.BasePath "/etc/_api-paste.ini.tpl") . | indent 4 }}
+{{- if .Values.api.use_uwsgi }}
+  api_uwsgi.ini: |
+{{ include (print .Template.BasePath "/etc/_api_uwsgi.ini.tpl") . | indent 4 }}
+{{- end }}
   cinder.conf: |
 {{ include (print $.Template.BasePath "/etc/_cinder.conf.tpl") . | indent 4 }}
   rootwrap.conf: |

--- a/openstack/cinder/templates/etc/_api_uwsgi.ini.tpl
+++ b/openstack/cinder/templates/etc/_api_uwsgi.ini.tpl
@@ -1,0 +1,18 @@
+[uwsgi]
+need-app = true
+http-socket = :{{ .Values.cinderApiPortInternal }}
+uid = root
+gid = root
+lazy-apps = true
+add-header = Connection: close
+buffer-size = 65535
+hook-master-start = unix_signal:15	# gracefully_kill_them_all
+thunder-lock = true
+enable-threads = true
+worker-reload-mercy = 90
+exit-on-reload = false
+die-on-term = true
+master = true
+memory-report = true
+processes = {{ .Values.api.workers }}
+wsgi-file = /var/lib/openstack/bin/cinder-wsgi

--- a/openstack/cinder/templates/etc/_cinder.conf.tpl
+++ b/openstack/cinder/templates/etc/_cinder.conf.tpl
@@ -29,9 +29,10 @@ auth_strategy = keystone
 rpc_response_timeout = {{ .Values.rpc_response_timeout | default .Values.global.rpc_response_timeout | default 300 }}
 rpc_workers = {{ .Values.rpc_workers | default .Values.global.rpc_workers | default 1 }}
 
-osapi_volume_workers = {{ .Values.osapi_volume_workers | default 10 }}
-
+{{- if not .Values.api.use_uwsgi }}
+osapi_volume_workers = {{ .Values.osapi_volume_workers | default .Values.api.workers }}
 wsgi_default_pool_size = {{ .Values.wsgi_default_pool_size | default .Values.global.wsgi_default_pool_size | default 100 }}
+{{- end }}
 
 # all default quotas are 0 to enforce usage of the Resource Management tool in Elektra
 quota_volumes = 0

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -71,6 +71,12 @@ cinderApiPortPublic: 443
 cinderApiPortInternal: 8776
 cinderApiPortAdmin: 8776
 
+api:
+  use_uwsgi: false
+  # bare in mind, that with use_uwsgi=false, these workers also have
+  # greenthreads
+  workers: 10
+
 db_name: cinder
 
 scheduler_default_filters: 'AvailabilityZoneFilter,ShardFilter,CapacityFilter,CapabilitiesFilter'


### PR DESCRIPTION
By setting "api.use_uwgi = true" in a region, we can run cinder-api via
uWSGI instead of the eventlet WSGI server. This can be more performant,
but when choosing the number of workers, we have to bear in mind, that
there are no greenthreads in them - in the eventlet server, there were
100 greenthreads in each process.

This also means, that the number of DB connections required per worker
should decrease significantly - in theory to the number of workers, but
we've seen manila-api use 2 connections per worker, so this needs to be
tested.