### PR TITLE
[Octavia] Fix alert octavia_loadbalancers_pending

### DIFF
--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -53,14 +53,15 @@ mysql_metrics:
       - "loadbalancer_name"
       name: octavia_loadbalancers_pending
       query: |
-        SELECT
-          COUNT(*) AS count_gauge,
+        (SELECT
+          '1' AS count_gauge,
           name AS loadbalancer_name,
           provisioning_status AS status,
           id AS loadbalancer_id,
           server_group_id AS octavia_host
         FROM load_balancer
-        WHERE provisioning_status LIKE "PENDING_%";
+        WHERE provisioning_status LIKE "PENDING_%")
+        UNION (select '0', '', '', '', '');
       values:
       - "count_gauge"
     - help: Worker agent seconds since the last heartbeat

--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -54,7 +54,7 @@ mysql_metrics:
       name: octavia_loadbalancers_pending
       query: |
         SELECT
-          '1' AS count_gauge,
+          COUNT(*) AS count_gauge,
           name AS loadbalancer_name,
           provisioning_status AS status,
           id AS loadbalancer_id,


### PR DESCRIPTION
Returning an empty set is an error for the mysql metrics collector.
Therefore, if there is no PENDING load balancer we need _some_ result that doesn't add to the count of PENDING load balancers but makes for a valid result that doesn't trip up the mysql metrics collector.