### PR TITLE
[cinder] Switch from vice-president to tls-acme

### DIFF
--- a/openstack/cinder/templates/api-ingress.yaml
+++ b/openstack/cinder/templates/api-ingress.yaml
@@ -7,9 +7,9 @@ metadata:
     system: openstack
     type: api
     component: cinder
-  {{- if .Values.vice_president }}
+  {{- if .Values.use_tls_acme }}
   annotations:
-    vice-president: "true"
+    kubernetes.io/tls-acme: "true"
   {{- end }}
 spec:
   tls:

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -77,6 +77,8 @@ api:
   # greenthreads
   workers: 10
 
+use_tls_acme: true
+
 db_name: cinder
 
 scheduler_default_filters: 'AvailabilityZoneFilter,ShardFilter,CapacityFilter,CapabilitiesFilter'


### PR DESCRIPTION
The Vice-API and functionality of vice-president will be shut down by
30th September 2020. There's a new solution based on cert-manager for
certificate issuance.