### PR TITLE
[Cinder] Update the image copy timeout to 20 hours

### DIFF
--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -56,7 +56,7 @@ backend_defaults:
   vmware_connection_pool_size: 10
   vmware_insecure: True
   vmware_profile_check_on_attach: False
-  vmware_image_transfer_timeout_secs: 21600
+  vmware_image_transfer_timeout_secs: 72000
   max_over_subscription_ratio: 2.0
   vmware_select_random_best_datastore: True
 


### PR DESCRIPTION
Customers are seeing create volume from image failures for
large volumes of 2Tb.   The current timeout is set to 6 hours, but
that is insufficient for a 2Tb volume, which should take around 18.5
hours.

This patch updates the timeout to 20 hours.