### PR TITLE
[atlas] moves from configmap to pvc

### DIFF
--- a/system/infra-monitoring/vendor/atlas/templates/configmap.yaml
+++ b/system/infra-monitoring/vendor/atlas/templates/configmap.yaml
@@ -4,23 +4,19 @@ apiVersion: v1
 kind: ConfigMap
 
 metadata:
-  name:  {{ include "atlas.fullname" . }}
+  name:  atlas-etc
   labels:
-    app: {{ include "atlas.name" . }}
+    app: atlas
     chart: {{ include "atlas.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  #annotations:
-    #"helm.sh/hook": "pre-install"
-    #"helm.sh/hook": "pre-upgrade"
 data:
   atlas.yaml: |
     discoveries:
       ironic:
         refresh_interval: 1200
-        targets_file_name: "ironic.json"
+        targets_file_name: "./targets/ironic.json"
         metrics_label: "ironic"
-        configmap_name: {{ .Values.configmap.ironic }}
         mgmt_interface_ips: true
         {{- if eq .Values.global.region "qa-de-2" }}
         netbox_host: "{{ .Values.global.netbox_host_staging }}"
@@ -37,8 +33,8 @@ data:
           domain_name: "{{ .Values.os_project_domain_name }}"
       netbox:
         refresh_interval: 3600
-        targets_file_name: "netbox.json"
-        configmap_name: {{ .Values.configmap.netbox }}
+        rate_limit: 0
+        targets_file_name: "./targets/netbox.json"
         {{- if eq .Values.global.region "qa-de-2" }}
         netbox_host: "{{ .Values.global.netbox_host_staging }}"
         {{- else }}

--- a/system/infra-monitoring/vendor/atlas/templates/deployment.yml
+++ b/system/infra-monitoring/vendor/atlas/templates/deployment.yml
@@ -5,9 +5,9 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Deployment
 metadata:
-    name: {{ include "atlas.fullname" . }}
+    name: atlas
     labels:
-      app: {{ include "atlas.name" . }}
+      app: atlas
       chart: {{ include "atlas.chart" . }}
       release: {{ .Release.Name }}
       heritage: {{ .Release.Service }}
@@ -18,18 +18,18 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ include "atlas.name" . }}
+      app: atlas
       release: {{ .Release.Name }}
       component: service_discovery
   template:
     metadata:
       labels:
-        app: {{ include "atlas.name" . }}
+        app: atlas
         release: {{ .Release.Name }}
         component: service_discovery
     spec:
       containers:
-      - name: {{ include "atlas.name" . }}
+      - name: atlas
         image: "{{ .Values.global.registry }}/{{ .Values.image }}:{{ .Values.tag }}"
         ports:
         - name: metrics
@@ -55,12 +55,13 @@ spec:
           value: {{ .Values.global.region }}
         - name: CONFIG_FILE
           value: "{{ .Values.config_file }}"
-        - name: WRITE_TO
-          value: "{{ .Values.write_to }}"
         volumeMounts:
         - name: config
           mountPath: /etc/config
           readOnly: true
+        - name: {{ .Values.pvc.name }}
+          mountPath: /targets
+          readOnly: false
       - name: atlas-config-reloader
         args:
         - -volume-dir=/etc/config
@@ -74,4 +75,7 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: {{ include "atlas.fullname" . }}
+            name: atlas-etc
+        - name: {{ .Values.pvc.name }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.pvc.name }}

--- a/system/infra-monitoring/vendor/atlas/templates/promtheus-configmap-ironic.yaml
+++ b/system/infra-monitoring/vendor/atlas/templates/promtheus-configmap-ironic.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ .Values.configmap.ironic }}
-  #annotations:
-    #"helm.sh/hook": "pre-install"
-    #"helm.sh/hook": "pre-upgrade"
-

--- a/system/infra-monitoring/vendor/atlas/templates/promtheus-configmap-netbox.yaml
+++ b/system/infra-monitoring/vendor/atlas/templates/promtheus-configmap-netbox.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ .Values.configmap.netbox }}
-  #annotations:
-    #"helm.sh/hook": "pre-install"
-    #"helm.sh/hook": "pre-upgrade"

--- a/system/infra-monitoring/vendor/atlas/templates/pvc.yaml
+++ b/system/infra-monitoring/vendor/atlas/templates/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "{{ .Values.pvc.name }}"
+  namespace: infra-monitoring
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi

--- a/system/infra-monitoring/vendor/atlas/values.yaml
+++ b/system/infra-monitoring/vendor/atlas/values.yaml
@@ -1,14 +1,13 @@
 image: atlas
-tag: "20200928130519"
+tag: "20201029110900"
 
-#enabled: "false"
 log_level: "debug"
 configmap:
   namespace: "infra-monitoring"
-  ironic: "atlas-ironic-sd"
-  netbox: "atlas-netbox-sd"
 config_file: "/etc/config/atlas.yaml"
-write_to: "configmap"
+
+pvc:
+  name: atlas-targets
 
 os_user_domain_name: "Default"
 os_project_name: "master"


### PR DESCRIPTION
- in some regions the list of targets already exceeds the configmap size (limited by etcd)