### PR TITLE
[cinder] Add CinderBackendShardLowFreeSpaceWarning

### DIFF
--- a/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
+++ b/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
@@ -29,6 +29,34 @@ groups:
     annotations:
       description: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 10% storage left before overcommit is reached."
       summary: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 10% storage left before overcommit is reached."
+  - alert: CinderBackendShardLowFreeSpaceWarning
+    expr: >
+      sum(cinder_free_capacity_gib) by (region, shard, backend) / 1024 + sum(cinder_free_capacity_gib == 0 or cinder_free_capacity_gib / cinder_total_capacity_gib * 100 < 25) by (region, shard, backend)
+    for: 15m
+    labels:
+      severity: info
+      tier: os
+      service: cinder
+      context: "openstack-exporter"
+      meta: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 25% free storage left."
+      playbook: docs/support/playbook/cinder/cinder_low_overcommit_ratio.html
+    annotations:
+      description: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 25% free storage left."
+      summary: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 25% free storage left."
+  - alert: CinderBackendShardLowFreeSpaceCritical
+    expr: >
+      sum(cinder_free_capacity_gib) by (region, shard, backend) / 1024 + sum(cinder_free_capacity_gib == 0 or cinder_free_capacity_gib / cinder_total_capacity_gib * 100 < 10) by (region, shard, backend)
+    for: 15m
+    labels:
+      severity: info
+      tier: os
+      service: cinder
+      context: "openstack-exporter"
+      meta: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 10% free storage left."
+      playbook: docs/support/playbook/cinder/cinder_low_overcommit_ratio.html
+    annotations:
+      description: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 10% free storage left."
+      summary: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 10% free storage left."
   - alert: CinderBackendStorageEmptyCritical
     expr: >
       sum(cinder_free_capacity_gib == 0) by (region, shard, backend) or sum(cinder_total_capacity_gib == 0) by (region, shard, backend)


### PR DESCRIPTION
This patch adds new CinderBackendShardLowFreeSpaceWarning
alert.  This alerts when the amount of free space is less
than 25% remaning.  This should cover both thin provisioned
and thick provisioned backends.