### PR TITLE
[openstack-exporter]  Add collectors section to config

### DIFF
--- a/prometheus-exporters/openstack-exporter/templates/openstack-exporter-openstack-config.yaml
+++ b/prometheus-exporters/openstack-exporter/templates/openstack-exporter-openstack-config.yaml
@@ -15,3 +15,7 @@ data:
       project_domain_name: {{ required ".Values.openstack.project_domain_name missing" .Values.openstack.project_domain_name }}
       project_name: {{ required ".Values.openstack.project_name missing" .Values.openstack.project_name }}
       region: {{ required ".Values.global.region missing" .Values.global.region }}
+    collectors:
+      cinderbackend:
+        collector: openstack_exporter.collectors.cinderbackend.CinderBackendCollector
+        enabled: True


### PR DESCRIPTION
When openstack-exporter added dynamic loading of collectors,
 we need to add the collectors entry in the config, so it loads
 the collectors we want to run.

This patch adds in the cinder collector in the config.