### PR TITLE
nova db-migrate: remove --local_cell parameter

### DIFF
--- a/openstack/nova/templates/bin/_db-migrate.tpl
+++ b/openstack/nova/templates/bin/_db-migrate.tpl
@@ -3,7 +3,7 @@ set -e
 set -x
 
 nova-manage api_db sync
-nova-manage db sync --local_cell
+nova-manage db sync
 nova-manage db null_instance_uuid_scan --delete
 
 # online data migration run by online-migration-job


### PR DESCRIPTION
The --local_cell parameter was initially introduced [1] to help
upgrading nova to cellv2.
That's been done since a while ago, so we need to remove this
parameter again so that db migrations will run against all the
cells databases and cell0.

[1] https://github.com/sapcc/helm-charts/commit/34943d0ecb260d76dd50c451a27d3d6139eebb26