### PR TITLE
common/prometheus-server: fix deprecated API versions

### DIFF
--- a/common/prometheus-server/CHANGELOG.md
+++ b/common/prometheus-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.7.2
+
+* Fix deprecated apiVersions for Thanos components, Prometheus ingress.
+
 ## 3.6.2
 
 * Added annotation triggering certificate automation: `kubernetes.io/tls-acme: "true"`.

--- a/common/prometheus-server/Chart.yaml
+++ b/common/prometheus-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus via operator.
 name: prometheus-server
-version: 3.7.1
+version: 3.7.2
 appVersion: v2.21.0
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
 maintainers:

--- a/common/prometheus-server/templates/ingress.yaml
+++ b/common/prometheus-server/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled }}
 {{- $root := . }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 
 metadata:

--- a/common/prometheus-server/templates/thanos/prometheus-thanosCompactorStatefulset.yaml
+++ b/common/prometheus-server/templates/thanos/prometheus-thanosCompactorStatefulset.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.thanos.enabled }}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "prometheus.fullName" . }}-thanos-compactor

--- a/common/prometheus-server/templates/thanos/prometheus-thanosQueryDeployment.yaml
+++ b/common/prometheus-server/templates/thanos/prometheus-thanosQueryDeployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.thanos.enabled }}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "prometheus.fullName" . }}-thanos-query

--- a/common/prometheus-server/templates/thanos/prometheus-thanosStoreStatefulset.yaml
+++ b/common/prometheus-server/templates/thanos/prometheus-thanosStoreStatefulset.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.thanos.enabled }}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "prometheus.fullName" . }}-thanos-store


### PR DESCRIPTION
We need to remove all references to [deprecated API versions](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/) in order to be able to upgrade Kubernetes to 1.16 and newer, so I'm sending a PR like this for all affected charts.

After applying this patch, the next `helm diff` will show the affected resources as being deleted and recreated. Don't panic, `helm upgrade` knows better and won't do a deletion and recreation. But still, the output of `helm diff` obscures smaller diffs inside the affected resources, so it might be wise to apply this patch while no other big changes are going through your pipeline.

If you're on Helm 3, make sure that you're using at least Helm 3.2.4. Version 3.1 in particular seems to have problems with changing API versions. Most pipeline tasks using Helm print `helm version` at the start, so you can check your Helm version by looking at the log of a previous pipeline job run.

Also, if you upgraded to Helm 3 recently, make sure that you have run at least one `helm3 upgrade` in all regions before applying this patch. Otherwise Helm 3 gets very confused and will refuse to upgrade. If you run into this situation, I can help you maneuver out of it, but it's better to avoid it by running at least one deployment in all regions after `helm3 2to3` is done. The deployment doesn't have to contain any changes, what matters is that `helm3 upgrade` runs.