### PR TITLE
openstack/elastiflow: fix deprecated API versions

### DIFF
--- a/system/elastiflow/templates/elasticsearch-exporter-deployment.yaml
+++ b/system/elastiflow/templates/elasticsearch-exporter-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.elasticsearchExporter.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: es-exporter-{{ .Values.elasticsearchExporter.name }}

--- a/system/elastiflow/templates/logstash-exporter-deployment.yaml
+++ b/system/elastiflow/templates/logstash-exporter-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.logstashExporter.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ls-exporter-{{ .Values.logstashExporter.name }}

--- a/system/elastiflow/templates/query-exporter-deployment.yaml
+++ b/system/elastiflow/templates/query-exporter-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.queryExporter.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: query-exporter-{{ .Values.queryExporter.name }}

--- a/system/elastiflow/vendor/elasticsearch-exporter/templates/deployment.yaml
+++ b/system/elastiflow/vendor/elasticsearch-exporter/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "elasticsearch-exporter.fullname" . }}

--- a/system/elastiflow/vendor/elasticsearch/templates/_helpers.tpl
+++ b/system/elastiflow/vendor/elasticsearch/templates/_helpers.tpl
@@ -63,25 +63,3 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
   {{- end -}}
 {{- end -}}
 {{- end -}}
-
-{{/*
-Return the appropriate apiVersion for statefulset.
-*/}}
-{{- define "elasticsearch.statefulset.apiVersion" -}}
-{{- if semverCompare "<1.9-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "apps/v1beta2" -}}
-{{- else -}}
-{{- print "apps/v1" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Return the appropriate apiVersion for ingress.
-*/}}
-{{- define "elasticsearch.ingress.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "extensions/v1beta1" -}}
-{{- else -}}
-{{- print "networking.k8s.io/v1beta1" -}}
-{{- end -}}
-{{- end -}}

--- a/system/elastiflow/vendor/elasticsearch/templates/ingress.yaml
+++ b/system/elastiflow/vendor/elasticsearch/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "elasticsearch.uname" . -}}
 {{- $servicePort := .Values.httpPort -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: {{ template "elasticsearch.ingress.apiVersion" . }}
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/system/elastiflow/vendor/elasticsearch/templates/statefulset.yaml
+++ b/system/elastiflow/vendor/elasticsearch/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: {{ template "elasticsearch.statefulset.apiVersion" . }}
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "elasticsearch.uname" . }}

--- a/system/elastiflow/vendor/kibana/templates/_helpers.tpl
+++ b/system/elastiflow/vendor/kibana/templates/_helpers.tpl
@@ -18,14 +18,3 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" $name .Chart.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
-
-{{/*
-Return the appropriate apiVersion for ingress.
-*/}}
-{{- define "kibana.ingress.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "extensions/v1beta1" -}}
-{{- else -}}
-{{- print "networking.k8s.io/v1beta1" -}}
-{{- end -}}
-{{- end -}}

--- a/system/elastiflow/vendor/kibana/templates/deployment.yaml
+++ b/system/elastiflow/vendor/kibana/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "kibana.fullname" . }}

--- a/system/elastiflow/vendor/kibana/templates/ingress.yaml
+++ b/system/elastiflow/vendor/kibana/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "kibana.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: {{ template "kibana.ingress.apiVersion" . }}
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/system/elastiflow/vendor/logstash/templates/_helpers.tpl
+++ b/system/elastiflow/vendor/logstash/templates/_helpers.tpl
@@ -18,14 +18,3 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
-
-{{/*
-Return the appropriate apiVersion for statefulset.
-*/}}
-{{- define "logstash.statefulset.apiVersion" -}}
-{{- if semverCompare "<1.9-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "apps/v1beta2" -}}
-{{- else -}}
-{{- print "apps/v1" -}}
-{{- end -}}
-{{- end -}}

--- a/system/elastiflow/vendor/logstash/templates/statefulset.yaml
+++ b/system/elastiflow/vendor/logstash/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: {{ template "logstash.statefulset.apiVersion" . }}
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "logstash.fullname" . }}


### PR DESCRIPTION
We need to remove all references to [deprecated API versions](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/) in order to be able to upgrade Kubernetes to 1.16 and newer, so I'm sending a PR like this for all affected charts.

After applying this patch, the next `helm diff` will show the affected resources as being deleted and recreated. Don't panic, `helm upgrade` knows better and won't do a deletion and recreation. But still, the output of `helm diff` obscures smaller diffs inside the affected resources, so it might be wise to apply this patch while no other big changes are going through your pipeline.

If you're on Helm 3, make sure that you're using at least Helm 3.2.4. Version 3.1 in particular seems to have problems with changing API versions. Most pipeline tasks using Helm print `helm version` at the start, so you can check your Helm version by looking at the log of a previous pipeline job run.

Also, if you upgraded to Helm 3 recently, make sure that you have run at least one `helm3 upgrade` in all regions before applying this patch. Otherwise Helm 3 gets very confused and will refuse to upgrade. If you run into this situation, I can help you maneuver out of it, but it's better to avoid it by running at least one deployment in all regions after `helm3 2to3` is done. The deployment doesn't have to contain any changes, what matters is that `helm3 upgrade` runs.