### PR TITLE
system/elk: fix deprecated API versions

### DIFF
--- a/system/elk/vendor/es-client/templates/deployment.yaml
+++ b/system/elk/vendor/es-client/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: es-client

--- a/system/elk/vendor/es-client/templates/ingress.yaml
+++ b/system/elk/vendor/es-client/templates/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 
 metadata:

--- a/system/elk/vendor/es-data/templates/deployment.yaml
+++ b/system/elk/vendor/es-data/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: es-data

--- a/system/elk/vendor/es-exporter/templates/deployment.yaml
+++ b/system/elk/vendor/es-exporter/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- range $i, $config := .Values.elasticsearch_config -}}
 {{ if ne $i 0 }}---{{ end }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: es-exporter-{{$config.name}}

--- a/system/elk/vendor/es-manager/templates/deployment.yaml
+++ b/system/elk/vendor/es-manager/templates/deployment.yaml
@@ -1,5 +1,5 @@
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: es-manager
   namespace: elk

--- a/system/elk/vendor/es-manager/templates/ingress.yaml
+++ b/system/elk/vendor/es-manager/templates/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 
 metadata:

--- a/system/elk/vendor/es-master/templates/deployment.yaml
+++ b/system/elk/vendor/es-master/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: es-master

--- a/system/elk/vendor/es-query-exporter/templates/deployment.yaml
+++ b/system/elk/vendor/es-query-exporter/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: es-query-exporter

--- a/system/elk/vendor/fluent-scaleout/templates/daemonset.yaml
+++ b/system/elk/vendor/fluent-scaleout/templates/daemonset.yaml
@@ -1,5 +1,5 @@
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 
 metadata:
   name: fluent

--- a/system/elk/vendor/fluent-systemd/templates/daemonset.yaml
+++ b/system/elk/vendor/fluent-systemd/templates/daemonset.yaml
@@ -1,5 +1,5 @@
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 
 metadata:
   name: fluent-systemd

--- a/system/elk/vendor/fluent-vcenter/templates/deployment.yaml
+++ b/system/elk/vendor/fluent-vcenter/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fluent-vcenter

--- a/system/elk/vendor/fluent/templates/daemonset.yaml
+++ b/system/elk/vendor/fluent/templates/daemonset.yaml
@@ -1,5 +1,5 @@
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 
 metadata:
   name: fluent

--- a/system/elk/vendor/kibana/templates/deployment.yaml
+++ b/system/elk/vendor/kibana/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kibana

--- a/system/elk/vendor/kibana/templates/ingress.yaml
+++ b/system/elk/vendor/kibana/templates/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 
 metadata:

--- a/system/elk/vendor/logstash/templates/deployment.yaml
+++ b/system/elk/vendor/logstash/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: logstash-external

--- a/system/elk/vendor/wall-e/templates/deployment.yaml
+++ b/system/elk/vendor/wall-e/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: wall-e


### PR DESCRIPTION
We need to remove all references to [deprecated API versions](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/) in order to be able to upgrade Kubernetes to 1.16 and newer, so I'm sending a PR like this for all affected charts.

After applying this patch, the next `helm diff` will show the affected resources as being deleted and recreated. Don't panic, `helm upgrade` knows better and won't do a deletion and recreation. But still, the output of `helm diff` obscures smaller diffs inside the affected resources, so it might be wise to apply this patch while no other big changes are going through your pipeline.

If you're on Helm 3, make sure that you're using at least Helm 3.2.4. Version 3.1 in particular seems to have problems with changing API versions. Most pipeline tasks using Helm print `helm version` at the start, so you can check your Helm version by looking at the log of a previous pipeline job run.

Also, if you upgraded to Helm 3 recently, make sure that you have run at least one `helm3 upgrade` in all regions before applying this patch. Otherwise Helm 3 gets very confused and will refuse to upgrade. If you run into this situation, I can help you maneuver out of it, but it's better to avoid it by running at least one deployment in all regions after `helm3 2to3` is done. The deployment doesn't have to contain any changes, what matters is that `helm3 upgrade` runs.