### PR TITLE
system/jaeger: fix deprecated API versions

### DIFF
--- a/system/jaeger/templates/agent-ds.yaml
+++ b/system/jaeger/templates/agent-ds.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.agent.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "jaeger.agent.name" . }}

--- a/system/jaeger/templates/collector-deploy.yaml
+++ b/system/jaeger/templates/collector-deploy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.collector.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "jaeger.collector.name" . }}

--- a/system/jaeger/templates/hotrod-deploy.yaml
+++ b/system/jaeger/templates/hotrod-deploy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.hotrod.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "jaeger.fullname" . }}-hotrod

--- a/system/jaeger/templates/hotrod-ing.yaml
+++ b/system/jaeger/templates/hotrod-ing.yaml
@@ -2,7 +2,7 @@
 {{- if .Values.hotrod.ingress.enabled -}}
 {{- $serviceName := include "jaeger.fullname" . -}}
 {{- $servicePort := .Values.hotrod.service.externalPort -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "jaeger.fullname" . }}-hotrod

--- a/system/jaeger/templates/query-deploy.yaml
+++ b/system/jaeger/templates/query-deploy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.query.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "jaeger.query.name" . }}

--- a/system/jaeger/templates/query-ing.yaml
+++ b/system/jaeger/templates/query-ing.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.query.ingress.enabled -}}
 {{- $servicePort := .Values.query.service.queryPort -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "jaeger.query.name" . }}


### PR DESCRIPTION
We need to remove all references to [deprecated API versions](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/) in order to be able to upgrade Kubernetes to 1.16 and newer, so I'm sending a PR like this for all affected charts.

After applying this patch, the next `helm diff` will show the affected resources as being deleted and recreated. Don't panic, `helm upgrade` knows better and won't do a deletion and recreation. But still, the output of `helm diff` obscures smaller diffs inside the affected resources, so it might be wise to apply this patch while no other big changes are going through your pipeline.

If you're on Helm 3, make sure that you're using at least Helm 3.2.4. Version 3.1 in particular seems to have problems with changing API versions. Most pipeline tasks using Helm print `helm version` at the start, so you can check your Helm version by looking at the log of a previous pipeline job run.

Also, if you upgraded to Helm 3 recently, make sure that you have run at least one `helm3 upgrade` in all regions before applying this patch. Otherwise Helm 3 gets very confused and will refuse to upgrade. If you run into this situation, I can help you maneuver out of it, but it's better to avoid it by running at least one deployment in all regions after `helm3 2to3` is done. The deployment doesn't have to contain any changes, what matters is that `helm3 upgrade` runs.