### PR TITLE
system/sentry: fix deprecated API versions

### DIFF
--- a/system/sentry/charts/postgresql/templates/deployment.yaml
+++ b/system/sentry/charts/postgresql/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}

--- a/system/sentry/charts/redis/templates/deployment.yaml
+++ b/system/sentry/charts/redis/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}

--- a/system/sentry/ci/test-values.yaml
+++ b/system/sentry/ci/test-values.yaml
@@ -1,0 +1,3 @@
+global:
+  pgbouncer:
+    enabled: False

--- a/system/sentry/templates/cron-deployment.yaml
+++ b/system/sentry/templates/cron-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}-cron

--- a/system/sentry/templates/ingress.yaml
+++ b/system/sentry/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "fullname" . }}

--- a/system/sentry/templates/operator-deployment.yaml
+++ b/system/sentry/templates/operator-deployment.yaml
@@ -1,6 +1,6 @@
 {{ if .Values.operator.enabled -}}
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 
 metadata:
   name: {{ template "fullname" . }}-operator

--- a/system/sentry/templates/pruning-deployment.yaml
+++ b/system/sentry/templates/pruning-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}-pruning

--- a/system/sentry/templates/server-deployment.yaml
+++ b/system/sentry/templates/server-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}

--- a/system/sentry/templates/worker-deployment.yaml
+++ b/system/sentry/templates/worker-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}-worker

--- a/system/sentry/values.yaml
+++ b/system/sentry/values.yaml
@@ -93,9 +93,9 @@ pgmetrics:
          WHERE gm.status = 0
          GROUP BY o.slug, p.slug
       metrics:
-        - organization: { usage: LABEL, description: "Sentry organization" }
-        - project:      { usage: LABEL, description: "Sentry project" }
-        - gauge:        { usage: GAUGE, description: "Number of unresolved issues in project" }
+        - organization: {usage: LABEL, description: "Sentry organization"}
+        - project:      {usage: LABEL, description: "Sentry project"}
+        - gauge:        {usage: GAUGE, description: "Number of unresolved issues in project"}
 
     sentry_unresolved_issues_nova:
       query: >
@@ -105,7 +105,7 @@ pgmetrics:
          WHERE gm.status = 0 AND p.slug = 'nova'
          GROUP BY o.slug, p.slug, message
       metrics:
-        - organization: { usage: LABEL, description: "Sentry organization" }
-        - project:      { usage: LABEL, description: "Sentry project" }
-        - message:      { usage: LABEL, description: "Issue message"}
-        - gauge:        { usage: GAUGE, description: "Number of unresolved issues in project" }
+        - organization: {usage: LABEL, description: "Sentry organization"}
+        - project:      {usage: LABEL, description: "Sentry project"}
+        - message:      {usage: LABEL, description: "Issue message"}
+        - gauge:        {usage: GAUGE, description: "Number of unresolved issues in project"}


### PR DESCRIPTION
We need to remove all references to [deprecated API versions](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/) in order to be able to upgrade Kubernetes to 1.16 and newer, so I'm sending a PR like this for all affected charts.

After applying this patch, the next `helm diff` will show the affected resources as being deleted and recreated. Don't panic, `helm upgrade` knows better and won't do a deletion and recreation. But still, the output of `helm diff` obscures smaller diffs inside the affected resources, so it might be wise to apply this patch while no other big changes are going through your pipeline.

If you're on Helm 3, make sure that you're using at least Helm 3.2.4. Version 3.1 in particular seems to have problems with changing API versions. Most pipeline tasks using Helm print `helm version` at the start, so you can check your Helm version by looking at the log of a previous pipeline job run.

Also, if you upgraded to Helm 3 recently, make sure that you have run at least one `helm3 upgrade` in all regions before applying this patch. Otherwise Helm 3 gets very confused and will refuse to upgrade. If you run into this situation, I can help you maneuver out of it, but it's better to avoid it by running at least one deployment in all regions after `helm3 2to3` is done. The deployment doesn't have to contain any changes, what matters is that `helm3 upgrade` runs.