### PR TITLE
[nova] Increase http_retries for cinder

### DIFF
--- a/openstack/nova/templates/etc/_nova.conf.tpl
+++ b/openstack/nova/templates/etc/_nova.conf.tpl
@@ -102,6 +102,7 @@ num_retries = 10
 [cinder]
 os_region_name = {{.Values.global.region}}
 cross_az_attach={{.Values.cross_az_attach}}
+http_retries = {{.Values.cinder_http_retries}}
 
 [neutron]
 metadata_proxy_shared_secret = {{ .Values.global.nova_metadata_secret }}

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -194,6 +194,8 @@ neutron: {}
 neutron_dvs_agent_enabled: true
 
 cross_az_attach: 'False'
+# for a total of 11 tries with 0.5s sleep in between we could get away with < 5s of problems
+cinder_http_retries: 10
 
 api:
   config_file:


### PR DESCRIPTION
If we fail to connect to cinder, we might get into an invalid state the
nanny has to fix. Let's retry a couple more times to try and keep these
inconsistencies to a minimum. Default is 3.

The specific inconsistency we've seen is that a volume was set to state
"detaching" by nova-api, but then nova-compute failed to actually get
the volume from cinder and thus couldn't update or roll back the state.