### PR TITLE
bump most kube-monitoring/kube-system deps to latest

### DIFF
--- a/system/kube-monitoring-admin-k3s/Chart.lock
+++ b/system/kube-monitoring-admin-k3s/Chart.lock
@@ -22,7 +22,7 @@ dependencies:
   version: 0.1.7
 - name: ntp-exporter
   repository: https://charts.eu-de-2.cloud.sap
-  version: 2.0.0
+  version: 2.1.0
 - name: oomkill-exporter
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.9
@@ -50,5 +50,5 @@ dependencies:
 - name: blackbox-exporter
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.0.8
-digest: sha256:52eb8e976406aa9ac57d42b119361a96ec27a89822e1bac2f54af6abe8cb0f51
-generated: "2020-11-09T14:44:04.025091563+01:00"
+digest: sha256:e88f26af108ff66d60300d4881853449047fdd9fd40da6748c106a002f167f76
+generated: "2020-11-12T12:17:59.53166833+01:00"

--- a/system/kube-monitoring-admin-k3s/Chart.yaml
+++ b/system/kube-monitoring-admin-k3s/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes admin k3s cluster monitoring.
 name: kube-monitoring-admin-k3s
-version: 0.3.18
+version: 0.3.19
 dependencies:
   - condition: absent-metrics-operator.enabled
     name: absent-metrics-operator
@@ -28,7 +28,7 @@ dependencies:
     version: 0.1.7
   - name: ntp-exporter
     repository: https://charts.eu-de-2.cloud.sap
-    version: 2.0.0
+    version: 2.1.0
   - name: oomkill-exporter
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.1.9

--- a/system/kube-monitoring-kubernikus/Chart.lock
+++ b/system/kube-monitoring-kubernikus/Chart.lock
@@ -31,7 +31,7 @@ dependencies:
   version: 0.25.1
 - name: ntp-exporter
   repository: https://charts.eu-de-2.cloud.sap
-  version: 2.0.0
+  version: 2.1.0
 - name: oomkill-exporter
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.9
@@ -59,5 +59,5 @@ dependencies:
 - name: watchcache-exporter
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.2
-digest: sha256:763a66dac95a443e78a5febdb2e18310e33062d0e7a82c0432495bc7667f3b13
-generated: "2020-11-09T19:05:37.571613+01:00"
+digest: sha256:3fc0734a15c18053506ed0da63030853e188058d373d117dfced8b6b26c2ae17
+generated: "2020-11-12T12:19:25.13510351+01:00"

--- a/system/kube-monitoring-kubernikus/Chart.yaml
+++ b/system/kube-monitoring-kubernikus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for monitoring Kubernikus.
 name: kube-monitoring-kubernikus
-version: 1.2.8
+version: 1.2.9
 dependencies:
   - condition: absent-metrics-operator.enabled
     name: absent-metrics-operator
@@ -37,7 +37,7 @@ dependencies:
     version: 0.25.1
   - name: ntp-exporter
     repository: https://charts.eu-de-2.cloud.sap
-    version: 2.0.0
+    version: 2.1.0
   - name: oomkill-exporter
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.1.9

--- a/system/kube-monitoring-metal/Chart.lock
+++ b/system/kube-monitoring-metal/Chart.lock
@@ -22,7 +22,7 @@ dependencies:
   version: 0.1.7
 - name: ntp-exporter
   repository: https://charts.eu-de-2.cloud.sap
-  version: 2.0.0
+  version: 2.1.0
 - name: oomkill-exporter
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.9
@@ -50,5 +50,5 @@ dependencies:
 - name: watchcache-exporter
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.2
-digest: sha256:95cec1eaad4beb73baec5d024583434a0100b56f62a5e180bc6121b0ed22fd3a
-generated: "2020-11-09T19:05:07.159146+01:00"
+digest: sha256:74827d0cc6137ec284dbcefb91bcb51d2b1e65525116f7916c3fc13ae8b92c0d
+generated: "2020-11-12T12:21:29.263893841+01:00"

--- a/system/kube-monitoring-metal/Chart.yaml
+++ b/system/kube-monitoring-metal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes metal controlplane monitoring.
 name: kube-monitoring-metal
-version: 1.6.22
+version: 1.6.23
 dependencies:
   - condition: absent-metrics-operator.enabled
     name: absent-metrics-operator
@@ -28,7 +28,7 @@ dependencies:
     version: 0.1.7
   - name: ntp-exporter
     repository: https://charts.eu-de-2.cloud.sap
-    version: 2.0.0
+    version: 2.1.0
   - name: oomkill-exporter
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.1.9

--- a/system/kube-monitoring-scaleout/Chart.lock
+++ b/system/kube-monitoring-scaleout/Chart.lock
@@ -25,7 +25,7 @@ dependencies:
   version: 0.1.7
 - name: ntp-exporter
   repository: https://charts.eu-de-2.cloud.sap
-  version: 2.0.0
+  version: 2.1.0
 - name: oomkill-exporter
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.9
@@ -50,5 +50,5 @@ dependencies:
 - name: watchcache-exporter
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.2
-digest: sha256:1d69710b3aeb89d3d3a62808d2e72553056ecf0f49ef90651ec4c7f12208f6c4
-generated: "2020-11-09T19:00:27.066226+01:00"
+digest: sha256:eac3dd121858a56268e4c110087cb285e150cfa84db03c6fd387f4a8f0a8fc79
+generated: "2020-11-12T12:22:42.159132509+01:00"

--- a/system/kube-monitoring-scaleout/Chart.yaml
+++ b/system/kube-monitoring-scaleout/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes scaleout cluster monitoring.
 name: kube-monitoring-scaleout
-version: 0.5.8
+version: 0.5.9
 dependencies:
   - condition: absent-metrics-operator.enabled
     name: absent-metrics-operator
@@ -31,7 +31,7 @@ dependencies:
     version: 0.1.7
   - name: ntp-exporter
     repository: https://charts.eu-de-2.cloud.sap
-    version: 2.0.0
+    version: 2.1.0
   - name: oomkill-exporter
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.1.9

--- a/system/kube-monitoring-virtual/Chart.lock
+++ b/system/kube-monitoring-virtual/Chart.lock
@@ -25,7 +25,7 @@ dependencies:
   version: 1.1.7
 - name: ntp-exporter
   repository: https://charts.eu-de-2.cloud.sap
-  version: 2.0.0
+  version: 2.1.0
 - name: oomkill-exporter
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.9
@@ -50,5 +50,5 @@ dependencies:
 - name: prometheus-virtual-rules
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.1
-digest: sha256:76bcf9019bc146560732868a3631c622d6b45e516094f5c5a7e6e8c4a339e07d
-generated: "2020-11-09T19:02:18.986028+01:00"
+digest: sha256:6ac0256f75c795d70d8d2b098f88b4261f071005df327a399366218afe52d61c
+generated: "2020-11-12T12:23:56.523934379+01:00"

--- a/system/kube-monitoring-virtual/Chart.yaml
+++ b/system/kube-monitoring-virtual/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes virtual cluster monitoring.
 name: kube-monitoring-virtual
-version: 0.10.8
+version: 0.10.9
 dependencies:
   - condition: absent-metrics-operator.enabled
     name: absent-metrics-operator
@@ -31,7 +31,7 @@ dependencies:
     version: 1.1.7
   - name: ntp-exporter
     repository: https://charts.eu-de-2.cloud.sap
-    version: 2.0.0
+    version: 2.1.0
   - name: oomkill-exporter
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.1.9

--- a/system/kube-system-admin-k3s/Chart.lock
+++ b/system/kube-system-admin-k3s/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.6.2
 - name: node-problem-detector
   repository: https://charts.eu-de-2.cloud.sap
-  version: 1.3.5
+  version: 1.3.6
 - name: prometheus-crds
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.0.0
@@ -25,12 +25,12 @@ dependencies:
   version: 1.0.4
 - name: cert-manager
   repository: https://charts.eu-de-2.cloud.sap
-  version: v0.15.2
+  version: 0.15.2
 - name: digicert-issuer
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.0.34
 - name: pull-secret-injector
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.4
-digest: sha256:256d3eedb16ff7a18f9e61dddfe29d6ceb9c475338fce37d63545237de0c1ebd
-generated: "2020-11-11T17:46:34.214758+02:00"
+digest: sha256:2e21b355ec96f0c50ef1cd1147aae7479c56fd167deff39e95ec423cabbfff9a
+generated: "2020-11-12T12:25:22.001900334+01:00"

--- a/system/kube-system-admin-k3s/Chart.yaml
+++ b/system/kube-system-admin-k3s/Chart.yaml
@@ -2,14 +2,14 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kube-System relevant Service collection for the new admin clusters.
 name: kube-system-admin-k3s
-version: 0.4.5
+version: 0.4.6
 dependencies:
   - name: disco
     repository: https://charts.eu-de-2.cloud.sap
     version: 1.6.2
   - name: node-problem-detector
     repository: https://charts.eu-de-2.cloud.sap
-    version: 1.3.5
+    version: 1.3.6
   - name: prometheus-crds
     repository: https://charts.eu-de-2.cloud.sap
     version: 1.0.0

--- a/system/kube-system-kubernikus/Chart.lock
+++ b/system/kube-system-kubernikus/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 1.23.0
 - name: node-problem-detector
   repository: https://charts.eu-de-2.cloud.sap
-  version: 1.3.5
+  version: 1.3.6
 - name: prometheus-crds
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.0.0
@@ -19,12 +19,12 @@ dependencies:
   version: 1.0.4
 - name: cert-manager
   repository: https://charts.eu-de-2.cloud.sap
-  version: v0.15.2
+  version: 0.15.2
 - name: digicert-issuer
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.0.34
 - name: pull-secret-injector
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.3
-digest: sha256:610bb86ee95d44c423052b571f11c1b17fbcbe074562af937dae7d8418693e37
-generated: "2020-11-09T15:49:23.776983+01:00"
+digest: sha256:1d62b76867690b7b488baa80387eb2c743ce2dce7152b43c1f678b8117301437
+generated: "2020-11-12T12:25:45.820863771+01:00"

--- a/system/kube-system-kubernikus/Chart.yaml
+++ b/system/kube-system-kubernikus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for Kubernikus control-plane clusters.
 name: kube-system-kubernikus
-version: 0.7.14
+version: 0.7.15
 dependencies:
   - name: cc-rbac
     repository: https://charts.eu-de-2.cloud.sap
@@ -14,7 +14,7 @@ dependencies:
     version: 1.23.0
   - name: node-problem-detector
     repository: https://charts.eu-de-2.cloud.sap
-    version: 1.3.5
+    version: 1.3.6
   - name: prometheus-crds
     repository: https://charts.eu-de-2.cloud.sap
     version: 1.0.0

--- a/system/kube-system-metal/Chart.yaml
+++ b/system/kube-system-metal/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for metal clusters.
 name: kube-system-metal
-version: 0.11.6
+version: 0.11.7
 dependencies:
   - name: cc-rbac
     repository: https://charts.eu-de-2.cloud.sap
@@ -15,14 +15,14 @@ dependencies:
     version: 0.2.3
   - name: kube-dns
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.3
+    version: 0.3.4
   - condition: kube-fip-controller.enabled
     name: kube-fip-controller
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.10
+    version: 0.1.12
   - name: kube-proxy
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.6.23
+    version: 0.6.24
   - name: kubernikus-rbac
     repository: https://charts.eu-de-2.cloud.sap
     version: 1.2.1
@@ -34,7 +34,7 @@ dependencies:
     version: 1.0.0
   - name: sysctl
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.0.1
+    version: 0.0.2
   - name: cert-manager-crds
     repository: https://charts.eu-de-2.cloud.sap
     version: 1.0.4

--- a/system/kube-system-scaleout/Chart.lock
+++ b/system/kube-system-scaleout/Chart.lock
@@ -4,19 +4,19 @@ dependencies:
   version: 0.1.6
 - name: ccauth
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.0
+  version: 0.1.1
 - name: disco
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.6.2
 - name: kube-fip-controller
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.10
+  version: 0.1.12
 - name: nginx-ingress
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 1.24.1
 - name: node-problem-detector
   repository: https://charts.eu-de-2.cloud.sap
-  version: 1.3.5
+  version: 1.3.6
 - name: prometheus-crds
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.0.0
@@ -25,12 +25,12 @@ dependencies:
   version: 1.0.2
 - name: cert-manager
   repository: https://charts.eu-de-2.cloud.sap
-  version: v0.15.2
+  version: 0.15.2
 - name: digicert-issuer
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.0.34
 - name: pull-secret-injector
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.3
-digest: sha256:d0903a7e55f0eb8a8d8b24fed389c5d74ad06bac8e61a5c40908032834d05753
-generated: "2020-11-09T15:50:14.483214+01:00"
+digest: sha256:f7296b7372248e1487b356a52deaee8ab4b5d285895c77330c1def9b1c223ebf
+generated: "2020-11-12T12:45:31.990762984+01:00"

--- a/system/kube-system-scaleout/Chart.yaml
+++ b/system/kube-system-scaleout/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kube-System relevant Service collection for scaleout clusters.
 name: kube-system-scaleout
-version: 0.5.4
+version: 0.5.5
 dependencies:
   - name: cc-rbac
     repository: https://charts.eu-de-2.cloud.sap
@@ -10,20 +10,20 @@ dependencies:
   - condition: ccauth.enabled
     name: ccauth
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.0
+    version: 0.1.1
   - name: disco
     repository: https://charts.eu-de-2.cloud.sap
     version: 1.6.2
   - condition: kube-fip-controller.enabled
     name: kube-fip-controller
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.10
+    version: 0.1.12
   - name: nginx-ingress
     repository: https://kubernetes-charts.storage.googleapis.com
     version: 1.24.1
   - name: node-problem-detector
     repository: https://charts.eu-de-2.cloud.sap
-    version: 1.3.5
+    version: 1.3.6
   - name: prometheus-crds
     repository: https://charts.eu-de-2.cloud.sap
     version: 1.0.0

--- a/system/kube-system-virtual/Chart.lock
+++ b/system/kube-system-virtual/Chart.lock
@@ -10,13 +10,13 @@ dependencies:
   version: 0.12.1
 - name: kube-proxy
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.6.23
+  version: 0.6.24
 - name: nginx-ingress
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 1.24.1
 - name: node-problem-detector
   repository: https://charts.eu-de-2.cloud.sap
-  version: 1.3.5
+  version: 1.3.6
 - name: prometheus-crds
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.0.0
@@ -31,12 +31,12 @@ dependencies:
   version: 1.0.4
 - name: cert-manager
   repository: https://charts.eu-de-2.cloud.sap
-  version: v0.15.2
+  version: 0.15.2
 - name: digicert-issuer
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.0.34
 - name: pull-secret-injector
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.3
-digest: sha256:ffae03fe4d4b05c86138c95845d930656dc06e368bbc4500889e2e5c343a5243
-generated: "2020-11-09T15:50:36.124994+01:00"
+digest: sha256:0f82cc38f894db7db976ecb507faa13f5aeca26873aac2b7aa7338df7610ebe5
+generated: "2020-11-12T12:26:35.02576628+01:00"

--- a/system/kube-system-virtual/Chart.yaml
+++ b/system/kube-system-virtual/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for virtual clusters.
 name: kube-system-virtual
-version: 0.7.11
+version: 0.7.12
 dependencies:
   - name: cc-rbac
     repository: https://charts.eu-de-2.cloud.sap
@@ -14,13 +14,13 @@ dependencies:
     version: 0.12.1
   - name: kube-proxy
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.6.23
+    version: 0.6.24
   - name: nginx-ingress
     repository: https://kubernetes-charts.storage.googleapis.com
     version: 1.24.1
   - name: node-problem-detector
     repository: https://charts.eu-de-2.cloud.sap
-    version: 1.3.5
+    version: 1.3.6
   - name: prometheus-crds
     repository: https://charts.eu-de-2.cloud.sap
     version: 1.0.0


### PR DESCRIPTION
I went through all the deps once again and there are already some new changes in that we might want to push through, particularly because of images moving away from Docker Hub, and of course, because of the deprecated API versions:

* **kube-monitoring**
  * ntp-exporter 2.0.0 -> 2.1.0 switches the image from Docker Hub to the mirror in Keppel.
* **kube-system**
  * ccauth 0.1.0 -> 0.1.1 switches the API version on the Ingress, but nothing else, so Helm should not touch it.
  * kube-dns 0.3.3 -> 0.3.4 removes an API version conditional for older Kubernetes. No diff on k8s 1.15.
  * kube-fip-controller 0.1.10 -> 0.1.12 switches the API version on the Deployment. To make the Deployment compliant with `apps/v1`, I added an explicit `spec.selector`. (This field used to be optional on `extensions/v1beta1`.) The value is the same as the one that was autofilled, so this could be a no-op, but Helm might still choose to touch this Deployment.
  * kube-proxy 0.6.23 -> 0.6.24 removes an API version conditional for older Kubernetes. No diff on k8s 1.15.
  * node-problem-detector 1.3.5 -> 1.3.6 switches the image from Docker Hub to the mirror in Keppel.
  * sysctl 0.0.1 -> 0.0.2 switches the API version on the DaemonSet, but nothing else, so Helm should not touch it.