### PR TITLE
more sophisticated pod handling

### DIFF
--- a/system/multicloudtest/templates/cronjob.yaml
+++ b/system/multicloudtest/templates/cronjob.yaml
@@ -15,6 +15,9 @@ spec:
   concurrencyPolicy: Replace
   jobTemplate:
     spec:
+      backoffLimit: 1
+      activeDeadLineSeconds: {{ $.Values.multicloudtest.pod_timeout_seconds }}
+      restartPolicy: Never
       template:
         spec:
           containers:

--- a/system/multicloudtest/values.yaml
+++ b/system/multicloudtest/values.yaml
@@ -1,4 +1,5 @@
 multicloudtest:
+  pod_timeout_seconds: 300
   enabled: false
   # if spawn_pod is enabled, pods are deployed INSTEAD of cronjobs
   spawn_pod: false


### PR DESCRIPTION
should avoid more than one running pod
cleanup of errored jobs