### PR TITLE
Promoting F5 memory drop alert to Critical

### DIFF
--- a/prometheus-exporters/snmp-exporter/alerts/f5.alerts
+++ b/prometheus-exporters/snmp-exporter/alerts/f5.alerts
@@ -92,7 +92,7 @@ groups:
           meta: "Big-IP device {{ $labels.devicename }} reports major drop in memory utilization."
           playbook: 'docs/devops/alert/network/f5.html#f5_memory_drop'
           service: f5
-          severity: info
+          severity: critical
           tier: net
         annotations:
           description: Big-IP device {{ $labels.devicename }} reports major drop in memory utilization, usually caused by API failure. Proceed with playbook instructions.


### PR DESCRIPTION
@artherd42 
Requesting approval to promote the “NetworkF5MemoryDrop” alert to level “Critical”
Playbook is published and handover to Accenture for 24x7 support completed earlier today.
