### PR TITLE
stats to get vrops-vm db disk size

### DIFF
--- a/prometheus-exporters/vrops-exporter/templates/collector-configmap.yaml
+++ b/prometheus-exporters/vrops-exporter/templates/collector-configmap.yaml
@@ -167,6 +167,13 @@ data:
             statkey: "summary|number_datastore"
           - metric_suffix: "datastore_outstanding_io_requests"
             statkey: "datastore|demand_oio"
+          - metric_suffix: "vrops_db_disk_usage_gigabytes"
+            statkey: "guestfilesystem:/storage/db|usage"
+          - metric_suffix: "vrops_db_disk_capacity_gigabytes"
+            statkey: "guestfilesystem:/storage/db|capacity"
+          - metric_suffix: "vrops_db_disk_usage_percent"
+            statkey: "guestfilesystem:/storage/db|percentage"
+
       ClusterStatsCollector:
         - metric_suffix: "cluster_running_hosts"
           statkey: "summary|number_running_hosts"

--- a/prometheus-exporters/vrops-exporter/templates/collector-configmap.yaml
+++ b/prometheus-exporters/vrops-exporter/templates/collector-configmap.yaml
@@ -173,7 +173,6 @@ data:
             statkey: "guestfilesystem:/storage/db|capacity"
           - metric_suffix: "vrops_db_disk_usage_percent"
             statkey: "guestfilesystem:/storage/db|percentage"
-
       ClusterStatsCollector:
         - metric_suffix: "cluster_running_hosts"
           statkey: "summary|number_running_hosts"


### PR DESCRIPTION
Added 3 stats to get vrops db partition disk size
"vrops_db_disk_usage_gigabytes" , "vrops_db_disk_capacity_gigabytes" and "vrops_db_disk_usage_percent"
Requesting for a review -Thanks