### PR TITLE
Upgrade the alerts for cinder storage

### DIFF
--- a/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
+++ b/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
@@ -20,7 +20,7 @@ groups:
       sum(cinder_free_until_overcommit_gib) by (region, shard, backend) / 1024 + sum(cinder_free_until_overcommit_gib / cinder_total_capacity_gib * 100 < 10) by (region, shard, backend) * 0
     for: 15m
     labels:
-      severity: info
+      severity: critical
       tier: os
       service: cinder
       context: "openstack-exporter"
@@ -34,7 +34,7 @@ groups:
       sum(cinder_free_capacity_gib) by (region, shard, backend) / 1024 + sum(cinder_free_capacity_gib == 0 or cinder_free_capacity_gib / cinder_total_capacity_gib * 100 < 25) by (region, shard, backend)
     for: 15m
     labels:
-      severity: info
+      severity: warning
       tier: os
       service: cinder
       context: "openstack-exporter"
@@ -48,7 +48,7 @@ groups:
       sum(cinder_free_capacity_gib) by (region, shard, backend) / 1024 + sum(cinder_free_capacity_gib == 0 or cinder_free_capacity_gib / cinder_total_capacity_gib * 100 < 10) by (region, shard, backend)
     for: 15m
     labels:
-      severity: info
+      severity: critical
       tier: os
       service: cinder
       context: "openstack-exporter"
@@ -62,7 +62,7 @@ groups:
       sum(cinder_free_capacity_gib == 0) by (region, shard, backend) or sum(cinder_total_capacity_gib == 0) by (region, shard, backend)
     for: 15m
     labels:
-      severity: info
+      severity: critical
       tier: os
       service: cinder
       context: "openstack-exporter"


### PR DESCRIPTION
This patch updates the alerts for several of the
cinder low storage / empty storage alerts from info
to warning/critical

TODO:
The empty storage playbook is being updated by Gergely