### PR TITLE
[Cinder] Add required resource filter for volume type

### DIFF
--- a/openstack/cinder/templates/etc/_resource_filters.json.tpl
+++ b/openstack/cinder/templates/etc/_resource_filters.json.tpl
@@ -10,5 +10,6 @@
     "attachment": ["volume_id", "status", "instance_id", "attach_status"],
     "message": ["resource_uuid", "resource_type", "event_id",
                 "request_id", "message_level"],
-    "pool": ["name", "volume_type"]
+    "pool": ["name", "volume_type"],
+    "volume_type": ["is_public"]
 }


### PR DESCRIPTION
For Cinder train the /etc/cinder/resource_filters.json file
needs the entry for volume type, otherwise end users can't
even get a list of volume types.

Without it non admins that run "cinder type-list" get the
following error.
ERROR: Invalid filters is_public are found in query options.

The feature/requirement was backported to train
https://github.com/openstack/cinder/blob/stable/train/etc/cinder/resource_filters.json#L14