### PR TITLE
[swift] don't log requests to backend server anymore

### DIFF
--- a/openstack/swift/templates/etc/_account-server.conf.tpl
+++ b/openstack/swift/templates/etc/_account-server.conf.tpl
@@ -31,6 +31,7 @@ pipeline = healthcheck recon account-server
 
 [app:account-server]
 use = egg:swift#account
+set log_requests = {{ .Values.log_requests }}
 
 [account-replicator]
 # If the account is reaped after deletion, means no conatiners belong to that

--- a/openstack/swift/templates/etc/_container-server.conf.tpl
+++ b/openstack/swift/templates/etc/_container-server.conf.tpl
@@ -31,6 +31,7 @@ pipeline = healthcheck recon container-server
 
 [app:container-server]
 use = egg:swift#container
+set log_requests = {{ .Values.log_requests }}
 allow_versions = true
 
 [container-replicator]

--- a/openstack/swift/templates/etc/_object-server.conf.tpl
+++ b/openstack/swift/templates/etc/_object-server.conf.tpl
@@ -32,6 +32,7 @@ pipeline = healthcheck recon object-server
 
 [app:object-server]
 use = egg:swift#object
+set log_requests = {{ .Values.log_requests }}
 {{- if .Values.s3api_enabled }}
 allowed_headers = Cache-Control, Content-Disposition, Content-Encoding, Content-Language, Expires, X-Delete-At, X-Object-Manifest, X-Robots-Tag, X-Static-Large-Object
 {{- else}}

--- a/openstack/swift/values.yaml
+++ b/openstack/swift/values.yaml
@@ -52,11 +52,14 @@ object_updater_concurrency: 2
 object_updater_workers: 2              # Availably since Rocky
 
 # Prevent disks getting 100% full
-fallocate_reserve: 1%                  # Availably since Rocky for all servers
+fallocate_reserve: 2%                  # Availably since Rocky for all servers
 
 # Swift client timeout in seconds.
 # Allows to avoid 408 client timeout occurred by VMware snapshot creation process
 client_timeout: 420 # 7 minutes, default is 60 seconds
+
+# Don't log requests to object, container or account servers
+log_requests: false
 
 # Add additional memcached deployments here
 memcached_servers:


### PR DESCRIPTION
* Disabling of request logging for account, container and object server is disabled by default now
* Double `fallocate_reserve` to 2%