### PR TITLE
[neutron][nsxv3] add --agent-type to the liveness probe command

### DIFF
--- a/openstack/neutron/templates/vct-nsxv3-agent-deployment.yaml
+++ b/openstack/neutron/templates/vct-nsxv3-agent-deployment.yaml
@@ -60,7 +60,7 @@ template: |
             value: ""
           livenessProbe:
             exec:
-              command: ["neutron-agent-liveness", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/plugins/ml2/ml2-nsxv3.ini"]
+              command: ["neutron-agent-liveness", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/plugins/ml2/ml2-nsxv3.ini", "--agent-type", "NSXv3 Agent"]
             initialDelaySeconds: 30
             periodSeconds: 30
             timeoutSeconds: 10


### PR DESCRIPTION
The neutron-agent-liveness requires --agent-type to be specified.
Currently it exits with an error message and exit code 0.