### PR TITLE
update thanos

### DIFF
--- a/common/prometheus-server/CHANGELOG.md
+++ b/common/prometheus-server/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 4.0.0
 
 * **[Breaking]** ChartVersion is now v2.
+* Remove `vice-president` annotation from Ingress.
 * Bump Prometheus to `v2.23.0`.
 * Switch from sapcc fork to upstream and upgrade Thanos components to `v0.17.1`. 
 This includes the Thanos sidecar to the Prometheus server, resolving the memory leak.

--- a/common/prometheus-server/CHANGELOG.md
+++ b/common/prometheus-server/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 4.0.0
+
+* **[Breaking]** ChartVersion is now v2.
+* Bump Prometheus to `v2.23.0`.
+* Switch from sapcc fork to upstream and upgrade Thanos components to `v0.17.1`. 
+This includes the Thanos sidecar to the Prometheus server, resolving the memory leak.
+
+
 ## 3.7.2
 
 * Fix deprecated apiVersions for Thanos components, Prometheus ingress.

--- a/common/prometheus-server/Chart.yaml
+++ b/common/prometheus-server/Chart.yaml
@@ -1,8 +1,8 @@
-apiVersion: v1
+apiVersion: v2
 description: Prometheus via operator.
 name: prometheus-server
-version: 3.7.3
-appVersion: v2.21.0
+version: 4.0.0
+appVersion: v2.23.0
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
 maintainers:
   - name: auhlig

--- a/common/prometheus-server/templates/ingress.yaml
+++ b/common/prometheus-server/templates/ingress.yaml
@@ -8,7 +8,6 @@ metadata:
   labels:
     prometheus: {{ include "prometheus.name" . }}
   annotations:
-    vice-president: {{ required ".Values.ingress.vicePresident missing" .Values.ingress.vicePresident | quote }}
     kubernetes.io/tls-acme: "true"
     disco: {{ required ".Values.ingress.disco missing" .Values.ingress.disco | quote }}
     {{- if .Values.ingress.authentication.enabled}}

--- a/common/prometheus-server/templates/podmonitors/kube-dns.yaml
+++ b/common/prometheus-server/templates/podmonitors/kube-dns.yaml
@@ -23,7 +23,7 @@ spec:
     - interval: {{ required ".Values.serviceDiscoveries.scrapeInterval  missing" .Values.serviceDiscoveries.scrapeInterval }}
       scrapeTimeout: {{ required ".Values.serviceDiscoveries.scrapeTimeout  missing" .Values.serviceDiscoveries.scrapeTimeout }}
       scheme: http
-      targetPort: 10055
+      port: 10055
       relabelings:
         - targetLabel: component
           replacement: dns
@@ -35,7 +35,7 @@ spec:
     - interval: {{ required ".Values.serviceDiscoveries.scrapeInterval  missing" .Values.serviceDiscoveries.scrapeInterval }}
       scrapeTimeout: {{ required ".Values.serviceDiscoveries.scrapeTimeout  missing" .Values.serviceDiscoveries.scrapeTimeout }}
       scheme: http
-      targetPort: 10054
+      port: 10054
       relabelings:
         - targetLabel: component
           replacement: dnsmasq

--- a/common/prometheus-server/values.yaml
+++ b/common/prometheus-server/values.yaml
@@ -19,7 +19,7 @@ global:
 # The repository and tag of the Prometheus image.
 image:
   repository: keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/prom/prometheus
-  tag: v2.21.0
+  tag: v2.23.0
 
 # Mandatory name for this Prometheus.
 # The name is used to find relevant aggregation and alerting rules.
@@ -187,17 +187,13 @@ thanos:
   # Specification for Thanos sidecar to Prometheus server.
   # See https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#thanosspec .
   spec:
-    baseImage: sapcc/thanos
-    # Contains fix for cross-domain authentication (user in different domain than Swift container).
-    # See https://github.com/thanos-io/thanos/pull/1118, which is part of >=v0.5.0 .
-    # Cannot upgrade to anything newer as the below given value as the Prometheus operator has hardcoded the deprecated `--cluster` flags for the sidecar.
-    # So the operator needs to be upgraded first, but requires newer k8s versions supporting apps/v1.StatefulSet -.-
-    version: v0.4.0-2-ga680c93
+    baseImage: thanosio/thanos
+    version: v0.17.1
 
   # Image for Thanos components.
   components:
     baseImage: thanosio/thanos
-    version: v0.8.1
+    version: v0.17.1
 
   # Specification for Thanos components.
   compactor:


### PR DESCRIPTION
- Prerequisite: Prometheus operator to `v0.44.0`
- Removes our fork for identity v3 cross-domain authentication in thanos components. It's now upstream
- Updated all Thanos components to `v0.17.1`
- Update Prometheus to `v2.23.0`

TODO:
- [ ] testing with maia in one of the qa landscapes. could use your help @notque
        pre-requisite: prometheus-operator updated

// cc @artherd42 