### PR TITLE
[elk] Capture Swift S3 request paths as well

### DIFF
--- a/system/elk/vendor/fluent/templates/_pattern.tpl
+++ b/system/elk/vendor/fluent/templates/_pattern.tpl
@@ -1,6 +1,6 @@
 MONTH (?:[Jj]an(?:uary|uar)?|[Ff]eb(?:ruary|ruar)?|[Mm](?:a)?r(?:ch|z)?|[Aa]pr(?:il)?|[Mm]a(?:y|i)?|[Jj]un(?:e|i)?|[Jj]ul(?:y)?|[Aa]ug(?:ust)?|[Ss]ep(?:tember)?|[Oo](?:c|k)?t(?:ober)?|[Nn]ov(?:ember)?|[Dd]e(?:c|z)(?:ember)?)
 REQUESTID [0-9A-Za-z-]+
-SWIFTREQPATH /info|(?:/v1/AUTH_)(?<account>(p-)?[0-9A-Fa-f]+)(?:/)?(?<container>[0-9A-Za-z$.+!*'(){},~:;=@#_\-]+)?(?:/)?(?<object>[0-9A-Za-z$.+!*'(){},~:;=@#_/\-]+)?
+SWIFTREQPATH /info|((?:/v1/AUTH_)(?<account>(p-)?[0-9A-Fa-f]+))?(?:/)?(?<container>[0-9A-Za-z$.+!*'(){},~:;=@#_\-]+)?(?:/)?(?<object>[0-9A-Za-z$.+!*'(){},~:;=@#_/\-]+)?
 SWIFTREQPARAM (\?|%[0-9A-Fa-f]{2})[A-Za-z0-9$.+!*'|(){},~@#%&/=:;_?\-\[\]]*
 SNMP_ERROR [a-zA-Z0-9 ]+
 METHOD (GET|POST|PUT)


### PR DESCRIPTION
Unauthenticated or Rate limit rejected requests to S3 are logged with
the following requestpath: `/container/object` instead of Swift usual
pattern `/v1/AUTH_123/container/object`

To not loose the specific fields, adopt the match.