### PR TITLE
[swift] Capability externalTrafficPolicy: Local

### DIFF
--- a/openstack/swift/templates/proxy-deployment.yaml
+++ b/openstack/swift/templates/proxy-deployment.yaml
@@ -39,6 +39,11 @@ spec:
         prometheus.io/targets: {{ required ".Values.alerts.prometheus.openstack missing" $.Values.alerts.prometheus.openstack }}
         {{- end }}
     spec:
+      {{- if $.Values.proxy_on_nodes }}
+      {{- include "swift_daemonset_tolerations" $ | indent 6 }}
+      nodeSelector:
+        species: {{ $.Values.species }}
+      {{- end }}
       volumes:
         - name: tls-secret
           secret:

--- a/openstack/swift/templates/proxy-service.yaml
+++ b/openstack/swift/templates/proxy-service.yaml
@@ -2,25 +2,29 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: swift-proxy-{{$cluster_id}}
+  name: swift-proxy-{{ $cluster_id }}
   labels:
-    release: "{{$.Release.Name}}"
-    os-cluster: {{$cluster_id}}
+    release: "{{ $.Release.Name }}"
+    os-cluster: {{ $cluster_id }}
   annotations:
     {{- include "swift_prometheus_annotations" $ | indent 4 }}
 spec:
+  {{- if $.Values.external_traffic_policy_local }}
+  type: NodePort
+  externalTrafficPolicy: Local
+  {{- end }}
   selector:
-    component: swift-proxy-{{$cluster_id}}
+    component: swift-proxy-{{ $cluster_id }}
   ports:
     - name: api
-      port: {{$cluster.proxy_public_port}}
+      port: {{ $cluster.proxy_public_port }}
       targetPort: 443
     {{- if and $cluster.proxy_public_http_port $cluster.sans_http }}
     - name: api-http
-      port: {{$cluster.proxy_public_http_port}}
+      port: {{ $cluster.proxy_public_http_port }}
       targetPort: 80
-    {{- end}}
+    {{- end }}
   externalIPs:
-    - {{$cluster.proxy_public_ip}}
+    - {{ $cluster.proxy_public_ip }}
 ---
 {{- end }}

--- a/openstack/swift/values.yaml
+++ b/openstack/swift/values.yaml
@@ -61,6 +61,13 @@ client_timeout: 420 # 7 minutes, default is 60 seconds
 # Don't log requests to object, container or account servers
 log_requests: false
 
+# Proxy pods should run on storage nodes
+proxy_on_nodes: false
+
+# Local to advertise the ExternalIP only on nodes that run the pod
+# Only works with ServiceType NodePort
+external_traffic_policy_local: false
+
 # Add additional memcached deployments here
 memcached_servers:
   - memcached


### PR DESCRIPTION
1. Enable `externalTrafficPolicy: Local` for swift proxy services
   to announce routes to service only on nodes which run the pods.
   This requires a service of `Type: NodePort`.
2. Pin swift-proxy pods to storage nodes to bring traffic closer
   to the storage nodes (in case the replica resides on the same
   node as the proxy pod).