### PR TITLE
[cinder] prepare rate-limiting middleware:

### DIFF
--- a/openstack/cinder/requirements.lock
+++ b/openstack/cinder/requirements.lock
@@ -23,5 +23,8 @@ dependencies:
 - name: jaeger-operator
   repository: file://../../system/jaeger-operator
   version: 0.1.0
-digest: sha256:291add047d0572120bcc544c20fc31c7edfe7faf7ba2ab6de6db2b7527dce092
-generated: 2020-10-22T07:24:28.238839287-07:00
+- name: redis
+  repository: file://../../common/redis
+  version: 1.0.1
+digest: sha256:05e013e6feb54e51fe808cb4735ef6cc0a9796905b91c353b9f9b5de3b368a42
+generated: 2020-12-18T14:13:10.641689383+01:00

--- a/openstack/cinder/requirements.yaml
+++ b/openstack/cinder/requirements.yaml
@@ -30,3 +30,8 @@ dependencies:
     import-values:
       - child: jaeger
         parent: osprofiler.jaeger
+  - name: redis
+    alias: api-ratelimit-redis
+    repository: file://../../common/redis
+    version: 1.0.1
+    condition: api_rate_limit.enabled

--- a/openstack/cinder/templates/api-deployment.yaml
+++ b/openstack/cinder/templates/api-deployment.yaml
@@ -115,6 +115,12 @@ spec:
               mountPath: /etc/cinder/resource_filters.json
               subPath: resource_filters.json
               readOnly: true
+            {{- if .Values.api_rate_limit.enabled }}
+            - name: cinder-etc
+              mountPath: /etc/cinder/ratelimit.yaml
+              subPath: ratelimit.yaml
+              readOnly: true
+            {{- end }}
             {{- if .Values.watcher.enabled }}
             - name: cinder-etc
               mountPath: /etc/cinder/watcher.yaml

--- a/openstack/cinder/templates/etc-configmap.yaml
+++ b/openstack/cinder/templates/etc-configmap.yaml
@@ -32,6 +32,10 @@ data:
 {{ include (print .Template.BasePath "/etc/_sudoers.tpl") . | indent 4 }}
   logging.ini: |
 {{ include "loggerIni" .Values.logging | indent 4 }}
+{{- if .Values.api_rate_limit.enabled }}
+  ratelimit.yaml: |
+{{ include (print .Template.BasePath "/etc/_ratelimit.yaml.tpl") . | indent 4 }}
+{{- end }}
 {{- if .Values.watcher.enabled }}
   watcher.yaml: |
 {{ include (print .Template.BasePath "/etc/_watcher.yaml.tpl") . | indent 4 }}

--- a/openstack/cinder/templates/etc/_ratelimit.yaml.tpl
+++ b/openstack/cinder/templates/etc/_ratelimit.yaml.tpl
@@ -7,21 +7,27 @@ whitelist: {{ .Values.api_rate_limit.project_whitelist }}
 
 # Override default ratelimit response.
 ratelimit_response:
-  status: 498 Rate Limited
-  status_code: 498
+  status: 429 Too Many Requests
+  status_code: 429
   json_body: { "message": "Rate limit exceeded" }
 
 # Override default blacklist response.
 blacklist_response:
-  status: 497 Blacklisted
-  status_code: 497
-  json_body: { "message": "You have been blacklisted. Please contact administrator." }
+  status: 403 Forbidden
+  status_code: 403
+  json_body: { "message": "Blacklisted" }
 
 # Group multiple CADF actions to one rate limit action.
 groups:
   write:
+    - create
     - update
     - delete
+    - update/os-begin_detaching
+    - update/os-complete
+    - update/os-extend
+    - update/os-force_delete
+    - update/os-reset_status
   read:
     - read
     - read/list

--- a/openstack/cinder/templates/etc/_ratelimit.yaml.tpl
+++ b/openstack/cinder/templates/etc/_ratelimit.yaml.tpl
@@ -1,0 +1,99 @@
+{{ if .Values.api_rate_limit.enabled -}}
+{{ if .Values.api_rate_limit.project_whitelist -}}
+# List of whitelisted scopes keys (domainName/projectName).
+whitelist: {{ .Values.api_rate_limit.project_whitelist }}
+{{- end }}
+{{- end }}
+
+# Override default ratelimit response.
+ratelimit_response:
+  status: 498 Rate Limited
+  status_code: 498
+  json_body: { "message": "Rate limit exceeded" }
+
+# Override default blacklist response.
+blacklist_response:
+  status: 497 Blacklisted
+  status_code: 497
+  json_body: { "message": "You have been blacklisted. Please contact administrator." }
+
+# Group multiple CADF actions to one rate limit action.
+groups:
+  write:
+    - update
+    - delete
+  read:
+    - read
+    - read/list
+
+rates:
+  # local rate limits below applied to each project
+  default:
+    attachments:
+      - action: read
+        limit: 3000r/m
+    attachments:
+      - action: write
+        limit: 100r/m
+
+    attachments/attachment:
+      - action: read
+        limit: 3000r/m
+    attachments/attachment:
+      - action: write
+        limit: 100r/m
+
+    attachments/attachment/action:
+      - action: write
+        limit: 100r/m
+
+    snapshots:
+      - action: read
+        limit: 3000r/m
+    snapshots:
+      - action: write
+        limit: 100r/m
+
+    snapshots/detail:
+      - action: read
+        limit: 3000r/m
+
+    snapshots/snapshot:
+      - action: read
+        limit: 3000r/m
+    snapshots/snapshot:
+      - action: write
+        limit: 100r/m
+
+    snapshots/snapshot/action:
+      - action: write
+        limit: 100r/m
+
+    types:
+      - action: read
+        limit: 3000r/m
+    types:
+      - action: write
+        limit: 100r/m
+
+    volumes:
+      - action: read
+        limit: 3000r/m
+    volumes:
+      - action: write
+        limit: 100r/m
+
+    volumes/detail:
+      - action: read
+        limit: 3000r/m
+
+    volumes/volume:
+      - action: read
+        limit: 3000r/m
+    volumes/volume:
+      - action: write
+        limit: 100r/m
+
+    volumes/volume/action:
+      - action: write
+        limit: 100r/m

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -323,6 +323,15 @@ logging:
             handlers: "null"
             level: ERROR
 
+# openstack-rate-limit-middleware
+api_rate_limit:
+  enabled: false
+  rate_limit_by: "target_project_id"
+  max_sleep_time_seconds: 15
+  log_sleep_time_seconds: 10
+  backend_timeout_seconds: 15
+  project_whitelist: []
+
 # openstack-watcher-middleware
 watcher:
   enabled: true


### PR DESCRIPTION
- no global limits at the moment; only (target-) project limits now.
- each individual endpoint has to be specified, no support for wildcards
- http 429 is returned when limit is hit; or 403 if blacklisted.
- json message is returned when limiting takes place
- rate-limiting settings ignored when backend (redis) is not reachable