### PR TITLE
Update logs.alerts

### DIFF
--- a/prometheus-exporters/elastic-query-exporter/alerts/logs.alerts
+++ b/prometheus-exporters/elastic-query-exporter/alerts/logs.alerts
@@ -6,7 +6,7 @@ groups:
         for: 15m
         labels:
           severity: info
-          tier: api
+          tier: os
           service: audit
           context: logging
           meta: "No keystone logs shipping to Octobus"


### PR DESCRIPTION
tier must be os to send keystone alert to slack_api_* channels