### PR TITLE
[Cinder] Allow for defining a custom cinder backend

### DIFF
--- a/openstack/cinder/templates/vcenter_datacenter_cinder_configmap.yaml
+++ b/openstack/cinder/templates/vcenter_datacenter_cinder_configmap.yaml
@@ -48,6 +48,7 @@ template: |
       vmware_storage_profile = {{ .Values.backends.standard_hdd.vmware_storage_profile }}
       extra_capabilities = '{"vcenter-shard": "{= host.split(".")[0] =}"}'
 
+      {{ .Values.backends.custom_backend }}
 
       [vstorageobject]
       volume_driver = cinder.volume.drivers.vmware.fcd.VMwareVStorageObjectDriver

--- a/openstack/cinder/templates/vcenter_datacenter_cinder_configmap.yaml
+++ b/openstack/cinder/templates/vcenter_datacenter_cinder_configmap.yaml
@@ -48,7 +48,12 @@ template: |
       vmware_storage_profile = {{ .Values.backends.standard_hdd.vmware_storage_profile }}
       extra_capabilities = '{"vcenter-shard": "{= host.split(".")[0] =}"}'
 
-      {{ .Values.backends.custom_backend }}
+      {{- range $backend, $kvs := .Values.backends.additional_backends }}
+      [{{ $backend }}]
+      {{- range $key, $value := $kvs }}
+      {{ $key }} = {{ $value }}
+      {{- end }}
+      {{- end }}
 
       [vstorageobject]
       volume_driver = cinder.volume.drivers.vmware.fcd.VMwareVStorageObjectDriver

--- a/openstack/cinder/templates/vcenter_datacenter_cinder_configmap.yaml
+++ b/openstack/cinder/templates/vcenter_datacenter_cinder_configmap.yaml
@@ -48,12 +48,12 @@ template: |
       vmware_storage_profile = {{ .Values.backends.standard_hdd.vmware_storage_profile }}
       extra_capabilities = '{"vcenter-shard": "{= host.split(".")[0] =}"}'
 
-      {{- range $backend, $kvs := .Values.backends.additional_backends }}
+      {{ range $backend, $kvs := .Values.backends.additional_backends }}
       [{{ $backend }}]
       {{- range $key, $value := $kvs }}
       {{ $key }} = {{ $value }}
       {{- end }}
-      {{- end }}
+      {{ end }}
 
       [vstorageobject]
       volume_driver = cinder.volume.drivers.vmware.fcd.VMwareVStorageObjectDriver


### PR DESCRIPTION
This patch adds a section to the cinder backends definitions
to allow creating a custom backend define for a region.

The region's values/cinder.yml would contain

backends:
    custom_backend: |
    [custom_backend_name]
    volume_backend_name = my_custom_backend
    volume_driver = cinder.volume.drivers.something.custom


This will allow us to add custom backends against qa-de-1 for example to enable the pure storage driver.