### PR TITLE
[vcenter-exporter] Increased failover node limit to 2

### DIFF
--- a/system/infra-monitoring/vendor/vcenter-exporters/alerts/vcenter-host.alerts
+++ b/system/infra-monitoring/vendor/vcenter-exporters/alerts/vcenter-host.alerts
@@ -50,17 +50,17 @@ groups:
       description: "VC {{ $labels.hostname }} {{ $labels.vccluster }} has a faulty AdmissionControlPolicy. Failover will not work."
       summary: "VC {{ $labels.hostname }} {{ $labels.vccluster }} has a faulty AdmissionControlPolicy. Failover will not work."
   - alert: VCenterWrongHALevelConfiguration
-    expr: vcenter_failover_nodes_set > 1
+    expr: vcenter_failover_nodes_set > 2
     for: 30m
     labels:
       severity: warning
       tier: vmware
       service: compute
-      meta: "VC {{ $labels.hostname }} {{ $labels.vccluster }} has more than one failover host configured, it should be 1"
+      meta: "VC {{ $labels.hostname }} {{ $labels.vccluster }} has more than two failover host configured, it should be 1"
       playbook: docs/devops/alert/vcenter/#restore-ha-redundancy-in-vcenter
     annotations:
-      description: "VC {{ $labels.hostname }} {{ $labels.vccluster }} has more than one failover host configured, it should be 1"
-      summary: "VC {{ $labels.hostname }} {{ $labels.vccluster }} has more than one failover host configured, it should be 1"
+      description: "VC {{ $labels.hostname }} {{ $labels.vccluster }} has more than two failover host configured, it should be no more than 2."
+      summary: "VC {{ $labels.hostname }} {{ $labels.vccluster }} has more than two failover host configured, it should be no more than 2."
   - alert: VCenterRedundancyLostHALevelNotSet
     expr: vcenter_failover_nodes_set == 0
     for: 30m

--- a/system/infra-monitoring/vendor/vcenter-exporters/alerts/vcenter-host.alerts
+++ b/system/infra-monitoring/vendor/vcenter-exporters/alerts/vcenter-host.alerts
@@ -56,7 +56,7 @@ groups:
       severity: warning
       tier: vmware
       service: compute
-      meta: "VC {{ $labels.hostname }} {{ $labels.vccluster }} has more than two failover host configured, it should be 1"
+      meta: "VC {{ $labels.hostname }} {{ $labels.vccluster }} has more than two failover host configured, it should be no more than 2."
       playbook: docs/devops/alert/vcenter/#restore-ha-redundancy-in-vcenter
     annotations:
       description: "VC {{ $labels.hostname }} {{ $labels.vccluster }} has more than two failover host configured, it should be no more than 2."


### PR DESCRIPTION
With the new policy the cluster can now have 2 failover hosts.