### PR TITLE
[elastic-query-exporter] Add alert for unexpected VM power down

### DIFF
--- a/prometheus-exporters/elastic-query-exporter/alerts/logs.alerts
+++ b/prometheus-exporters/elastic-query-exporter/alerts/logs.alerts
@@ -41,3 +41,16 @@ groups:
         annotations:
           description: "VCSA logs missing in Octobus for vCenter {{ $labels.vcenter }}."
           summary: "VCSA logs missing in Octobus for vCenter {{ $labels.vcenter }}."
+      - alert: VMPoweredDownDuringFailedHostMigration
+        expr: elasticsearch_octobus_vmdown_doc_count
+        for: 5m
+        labels:
+          severity: info
+          tier: vmware
+          service: audit
+          context: logging
+          no_alert_on_absence: "true"
+          meta: "A VM on host {{ $labels.hostsystem }} unexpectedly powered down during a failed host migration (vMotion or Storage vMotion)."
+        annotations:
+          description: "A VM on host {{ $labels.hostsystem }} unexpectedly powered down during a failed host migration (vMotion or Storage vMotion)."
+          summary: "A VM unexpectedly powered down during a failed host migration (vMotion or Storage vMotion)."

--- a/prometheus-exporters/elastic-query-exporter/alerts/logs.alerts
+++ b/prometheus-exporters/elastic-query-exporter/alerts/logs.alerts
@@ -47,7 +47,7 @@ groups:
         labels:
           severity: info
           tier: vmware
-          service: audit
+          service: compute
           context: logging
           no_alert_on_absence: "true"
           meta: "A VM on host {{ $labels.hostsystem }} unexpectedly powered down during a failed host migration (vMotion or Storage vMotion)."

--- a/prometheus-exporters/elastic-query-exporter/alerts/logs.alerts
+++ b/prometheus-exporters/elastic-query-exporter/alerts/logs.alerts
@@ -51,6 +51,7 @@ groups:
           context: logging
           no_alert_on_absence: "true"
           meta: "A VM on host {{ $labels.hostsystem }} unexpectedly powered down during a failed host migration (vMotion or Storage vMotion)."
+          playbook: docs/devops/alert/vcenter/#VM%20powered%20off%20during%20vMotion
         annotations:
           description: "A VM on host {{ $labels.hostsystem }} unexpectedly powered down during a failed host migration (vMotion or Storage vMotion)."
           summary: "A VM unexpectedly powered down during a failed host migration (vMotion or Storage vMotion)."

--- a/prometheus-exporters/elastic-query-exporter/files/exporter.cfg
+++ b/prometheus-exporters/elastic-query-exporter/files/exporter.cfg
@@ -155,3 +155,24 @@ QueryJson = {
           }
         }
     }
+
+[query_elasticsearch_octobus_vmdown]
+QueryIntervalSecs = 300
+QueryTimeoutSecs = 15
+QueryIndices = c0001_log-*
+QueryJson = {
+    "query": {
+      "bool": {
+        "must": [
+          { "exists": { "field": "node.nodename" }},
+          { "match_phrase": { "message": "An operation required the virtual machine to quiesce and the virtual machine was unable to continue running." }}
+        ],
+        "filter": [
+          { "range": { "@timestamp": { "gte": "now-1h" }}}
+        ]
+      }
+    },
+    "aggs": {
+      "hostsystem": { "terms": { "field": "node.nodename.keyword" }}
+    }
+  }

--- a/prometheus-exporters/elastic-query-exporter/files/exporter.cfg
+++ b/prometheus-exporters/elastic-query-exporter/files/exporter.cfg
@@ -30,7 +30,6 @@ QueryOnMissing = zero
 # generated for this query
 
 [query_elasticsearch_octobus_keystone]
-# The DEFAULT settings can be overridden.
 QueryIntervalSecs = 300
 QueryTimeoutSecs = 15
 QueryIndices = c0001_log_keystone*


### PR DESCRIPTION
Loglevel INFO, playbook needs to be added, no VM info in alert