### PR TITLE
[Cinder] Update the cinder storage tier to vmware

### DIFF
--- a/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
+++ b/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
@@ -7,7 +7,7 @@ groups:
     for: 15m
     labels:
       severity: warning
-      tier: os
+      tier: vmware
       service: cinder
       context: "openstack-exporter"
       meta: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 20% storage left before overcommit is reached."
@@ -21,7 +21,7 @@ groups:
     for: 15m
     labels:
       severity: critical
-      tier: os
+      tier: vmware
       service: cinder
       context: "openstack-exporter"
       meta: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 10% storage left before overcommit is reached."
@@ -35,7 +35,7 @@ groups:
     for: 15m
     labels:
       severity: warning
-      tier: os
+      tier: vmware
       service: cinder
       context: "openstack-exporter"
       meta: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 25% free storage left."
@@ -49,7 +49,7 @@ groups:
     for: 15m
     labels:
       severity: critical
-      tier: os
+      tier: vmware
       service: cinder
       context: "openstack-exporter"
       meta: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 10% free storage left."
@@ -63,7 +63,7 @@ groups:
     for: 15m
     labels:
       severity: critical
-      tier: os
+      tier: vmware
       service: cinder
       context: "openstack-exporter"
       meta: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has no storage capacity."


### PR DESCRIPTION
The alerts that the openstack-exporter is sending goes to the
os tier currently.  Changing them all to the vmware tier.