### PR TITLE
[vrops-exporter] only powered on VMs for alert VMsOnFailoverHost

### DIFF
--- a/prometheus-exporters/vrops-exporter/alerts/datastore.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/datastore.alerts
@@ -51,12 +51,12 @@ groups:
       tier: vmware
       service: storage
       context: "vrops-exporter"
-      meta: "Datastore {{ $labels.datastore }} utilization > 80% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      meta: "Datastore {{ $labels.datastore }} utilization > 80%. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
       dashboard: vcenter-datastore-utilization
       playbook: docs/support/playbook/datastore/datastorediskusagealarm.html
     annotations:
-      description: "Datastore {{ $labels.datastore }} utilization > 80% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
-      summary: "Datastore {{ $labels.datastore }} utilization > 80% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      description: "Datastore {{ $labels.datastore }} utilization > 80%. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      summary: "Datastore {{ $labels.datastore }} utilization > 80%. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
   - alert: DataStoreCapacityCritical
     expr: >
       max_over_time(vrops_datastore_diskspace_total_usage_gigabytes{type=~"Management|ephemeral|vmfs.*"}[10m]) / max_over_time(vrops_datastore_diskspace_capacity_gigabytes[10m]) >=  0.9
@@ -66,12 +66,12 @@ groups:
       tier: vmware
       service: storage
       context: "vrops-exporter"
-      meta: "Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      meta: "Datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
       dashboard: vcenter-datastore-utilization
       playbook: docs/support/playbook/datastore/datastorediskusagealarm.html
     annotations:
-      description: "Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
-      summary: "Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      description: "Datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      summary: "Datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
   - alert: VVolDataStoreCapacityWarning
     expr: >
       max_over_time(vrops_datastore_diskspace_total_usage_gigabytes{type="vVOL"}[10m]) / max_over_time(vrops_datastore_diskspace_capacity_gigabytes[10m]) >= 0.8
@@ -81,12 +81,12 @@ groups:
       tier: vmware
       service: storage
       context: "vrops-exporter"
-      meta: "vVOL Datastore {{ $labels.datastore }} utilization > 80% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      meta: "vVOL Datastore {{ $labels.datastore }} utilization > 80%. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
       dashboard: vcenter-datastore-utilization
       playbook: docs/devops/alert/vcenter/vvol_datastore.html#vvol_5
     annotations:
-      description: "vVOL Datastore {{ $labels.datastore }} utilization > 80% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
-      summary: "vVOL Datastore {{ $labels.datastore }} utilization > 80% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      description: "vVOL Datastore {{ $labels.datastore }} utilization > 80%. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      summary: "vVOL Datastore {{ $labels.datastore }} utilization > 80%. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
   - alert: VVolDataStoreCapacityCritical
     expr: >
       max_over_time(vrops_datastore_diskspace_total_usage_gigabytes{type="vVOL"}[10m]) / max_over_time(vrops_datastore_diskspace_capacity_gigabytes[10m]) >=  0.9
@@ -96,12 +96,12 @@ groups:
       tier: vmware
       service: storage
       context: "vrops-exporter"
-      meta: "vVOL Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      meta: "vVOL Datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
       dashboard: vcenter-datastore-utilization
       playbook: docs/devops/alert/vcenter/vvol_datastore.html#vvol_5
     annotations:
-      description: "vVOL Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
-      summary: "vVOL Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      description: "vVOL Datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      summary: "vVOL Datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
   - alert: DataStoreCapacityCritical
     expr: >
       max_over_time(vrops_datastore_diskspace_total_usage_gigabytes{type="vVOL"}[10m]) / max_over_time(vrops_datastore_diskspace_capacity_gigabytes[10m]) >=  0.9
@@ -111,12 +111,12 @@ groups:
       tier: os
       service: storage
       context: "vrops-exporter"
-      meta: "Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      meta: "Datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
       dashboard: vcenter-datastore-utilization
       playbook: docs/support/playbook/cinder/cinder_storage_aggregate_full.html
     annotations:
-      description: "Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
-      summary: "Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      description: "Datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      summary: "Datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
   - alert: DataStoreCapacityCritical
     expr: >
       max_over_time(vrops_datastore_diskspace_total_usage_gigabytes{type!~"Management|ephemeral|local|vVOL"}[10m]) / max_over_time(vrops_datastore_diskspace_capacity_gigabytes[10m]) >=  0.9
@@ -126,12 +126,12 @@ groups:
       tier: os
       service: storage
       context: "vrops-exporter"
-      meta: "Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      meta: "Datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
       dashboard: vcenter-datastore-utilization
       playbook: docs/support/playbook/cinder/cinder_storage_aggregate_full.html
     annotations:
-      description: "Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
-      summary: "Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      description: "Datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      summary: "Datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
   - alert: DatastoreDisconnectedWithVmsOnIt
     expr: >
       max_over_time(vrops_datastore_summary_total_number_vms[10m]) > 0

--- a/prometheus-exporters/vrops-exporter/alerts/datastore.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/datastore.alerts
@@ -142,11 +142,11 @@ groups:
       tier: vmware
       service: storage
       context: "vrops-exporter"
-      meta: "Datastore {{ $labels.datastore }} is disconnected and has virtual machines on it ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      meta: "Datastore {{ $labels.datastore }} is disconnected and has virtual machines on it. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
       playbook: docs/devops/alert/vcenter/#test_eph_ds_1
     annotations:
-      description: "Datastore {{ $labels.datastore }} is disconnected and has virtual machines on it ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
-      summary: "Datastore {{ $labels.datastore }} is disconnected and has virtual machines on it ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      description: "Datastore {{ $labels.datastore }} is disconnected and has virtual machines on it. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      summary: "Datastore {{ $labels.datastore }} is disconnected and has virtual machines on it. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
   - alert: DatastoreDisconnectedWithoutVmsOnIt
     expr: >
       max_over_time(vrops_datastore_summary_total_number_vms[10m]) == 0
@@ -157,8 +157,8 @@ groups:
       tier: vmware
       service: storage
       context: "vrops-exporter"
-      meta: "Datastore {{ $labels.datastore }} is disconnected without virtual machines on it ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      meta: "Datastore {{ $labels.datastore }} is disconnected without virtual machines on it. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
       playbook: docs/devops/alert/vcenter/#test_eph_ds_2
     annotations:
-      description: "Datastore {{ $labels.datastore }} is disconnected without virtual machines on it ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
-      summary: "Datastore {{ $labels.datastore }} is disconnected without virtual machines on it ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      description: "Datastore {{ $labels.datastore }} is disconnected without virtual machines on it. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      summary: "Datastore {{ $labels.datastore }} is disconnected without virtual machines on it. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"

--- a/prometheus-exporters/vrops-exporter/alerts/datastore.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/datastore.alerts
@@ -9,11 +9,11 @@ groups:
       severity: critical
       tier: vmware
       service: compute
-      meta: 'Datastore {{ $labels.datastore }} is not accessible'
+      meta: 'Datastore {{ $labels.datastore }} is not accessible. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})'
       playbook: docs/devops/alert/vcenter/vvol_datastore.html#vvol_1
     annotations:
-      description: 'Datastore {{ $labels.datastore }} is not accessible'
-      summary: 'Datastore {{ $labels.datastore }} is not accessible'
+      description: 'Datastore {{ $labels.datastore }} is not accessible. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})'
+      summary: 'Datastore {{ $labels.datastore }} is not accessible. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})'
   - alert: VVolDatastoreZeroFreeSpace
     expr: |
       vrops_datastore_diskspace_freespace_gigabytes{type="vVOL"} == 0
@@ -22,12 +22,12 @@ groups:
       severity: critical
       tier: vmware
       service: compute
-      meta: 'Datastore {{ $labels.datastore }} has no free space'
+      meta: 'Datastore {{ $labels.datastore }} has no free space. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})'
       dashboard: vcenter-datastore-utilization
       playbook: docs/devops/alert/vcenter/vvol_datastore.html#vvol_4
     annotations:
-      description: 'Datastore {{ $labels.datastore }} has no free space'
-      summary: 'Datastore {{ $labels.datastore }} has no free space'
+      description: 'Datastore {{ $labels.datastore }} has no free space. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})'
+      summary: 'Datastore {{ $labels.datastore }} has no free space. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})'
   - alert: VVolDatastoreZeroCapacity
     expr: |
       vrops_datastore_diskspace_capacity_gigabytes{type="vVOL"} == 0
@@ -36,12 +36,12 @@ groups:
       severity: critical
       tier: vmware
       service: compute
-      meta: 'Datastore {{ $labels.datastore }} has zero capacity'
+      meta: 'Datastore {{ $labels.datastore }} has zero capacity. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})'
       dashboard: vcenter-datastore-utilization
       playbook: docs/devops/alert/vcenter/vvol_datastore.html#vvol_3
     annotations:
-      description: 'Datastore {{ $labels.datastore }} has zero capacity'
-      summary: 'Datastore {{ $labels.datastore }} has zero capacity'
+      description: 'Datastore {{ $labels.datastore }} has zero capacity. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})'
+      summary: 'Datastore {{ $labels.datastore }} has zero capacity. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})'
   - alert: DataStoreCapacityWarning
     expr: >
       max_over_time(vrops_datastore_diskspace_total_usage_gigabytes{type=~"Management|ephemeral|vmfs.*"}[10m]) / max_over_time(vrops_datastore_diskspace_capacity_gigabytes[10m]) >= 0.8
@@ -51,12 +51,12 @@ groups:
       tier: vmware
       service: storage
       context: "vrops-exporter"
-      meta: "Datastore {{ $labels.datastore }} utilization > 80% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      meta: "Datastore {{ $labels.datastore }} utilization > 80% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
       dashboard: vcenter-datastore-utilization
       playbook: docs/support/playbook/datastore/datastorediskusagealarm.html
     annotations:
-      description: "Datastore {{ $labels.datastore }} utilization > 80% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
-      summary: "Datastore {{ $labels.datastore }} utilization > 80% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      description: "Datastore {{ $labels.datastore }} utilization > 80% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      summary: "Datastore {{ $labels.datastore }} utilization > 80% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
   - alert: DataStoreCapacityCritical
     expr: >
       max_over_time(vrops_datastore_diskspace_total_usage_gigabytes{type=~"Management|ephemeral|vmfs.*"}[10m]) / max_over_time(vrops_datastore_diskspace_capacity_gigabytes[10m]) >=  0.9
@@ -66,12 +66,12 @@ groups:
       tier: vmware
       service: storage
       context: "vrops-exporter"
-      meta: "Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      meta: "Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
       dashboard: vcenter-datastore-utilization
       playbook: docs/support/playbook/datastore/datastorediskusagealarm.html
     annotations:
-      description: "Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
-      summary: "Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      description: "Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      summary: "Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
   - alert: VVolDataStoreCapacityWarning
     expr: >
       max_over_time(vrops_datastore_diskspace_total_usage_gigabytes{type="vVOL"}[10m]) / max_over_time(vrops_datastore_diskspace_capacity_gigabytes[10m]) >= 0.8
@@ -81,12 +81,12 @@ groups:
       tier: vmware
       service: storage
       context: "vrops-exporter"
-      meta: "vVOL Datastore {{ $labels.datastore }} utilization > 80% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      meta: "vVOL Datastore {{ $labels.datastore }} utilization > 80% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
       dashboard: vcenter-datastore-utilization
       playbook: docs/devops/alert/vcenter/vvol_datastore.html#vvol_5
     annotations:
-      description: "vVOL Datastore {{ $labels.datastore }} utilization > 80% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
-      summary: "vVOL Datastore {{ $labels.datastore }} utilization > 80% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      description: "vVOL Datastore {{ $labels.datastore }} utilization > 80% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      summary: "vVOL Datastore {{ $labels.datastore }} utilization > 80% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
   - alert: VVolDataStoreCapacityCritical
     expr: >
       max_over_time(vrops_datastore_diskspace_total_usage_gigabytes{type="vVOL"}[10m]) / max_over_time(vrops_datastore_diskspace_capacity_gigabytes[10m]) >=  0.9
@@ -96,12 +96,12 @@ groups:
       tier: vmware
       service: storage
       context: "vrops-exporter"
-      meta: "vVOL Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      meta: "vVOL Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
       dashboard: vcenter-datastore-utilization
       playbook: docs/devops/alert/vcenter/vvol_datastore.html#vvol_5
     annotations:
-      description: "vVOL Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
-      summary: "vVOL Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      description: "vVOL Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      summary: "vVOL Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
   - alert: DataStoreCapacityCritical
     expr: >
       max_over_time(vrops_datastore_diskspace_total_usage_gigabytes{type="vVOL"}[10m]) / max_over_time(vrops_datastore_diskspace_capacity_gigabytes[10m]) >=  0.9
@@ -111,12 +111,12 @@ groups:
       tier: os
       service: storage
       context: "vrops-exporter"
-      meta: "Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      meta: "Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
       dashboard: vcenter-datastore-utilization
       playbook: docs/support/playbook/cinder/cinder_storage_aggregate_full.html
     annotations:
-      description: "Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
-      summary: "Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      description: "Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      summary: "Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
   - alert: DataStoreCapacityCritical
     expr: >
       max_over_time(vrops_datastore_diskspace_total_usage_gigabytes{type!~"Management|ephemeral|local|vVOL"}[10m]) / max_over_time(vrops_datastore_diskspace_capacity_gigabytes[10m]) >=  0.9
@@ -126,12 +126,12 @@ groups:
       tier: os
       service: storage
       context: "vrops-exporter"
-      meta: "Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      meta: "Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
       dashboard: vcenter-datastore-utilization
       playbook: docs/support/playbook/cinder/cinder_storage_aggregate_full.html
     annotations:
-      description: "Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
-      summary: "Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      description: "Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      summary: "Datastore {{ $labels.datastore }} utilization > 90% ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
   - alert: DatastoreDisconnectedWithVmsOnIt
     expr: >
       max_over_time(vrops_datastore_summary_total_number_vms[10m]) > 0
@@ -142,11 +142,11 @@ groups:
       tier: vmware
       service: storage
       context: "vrops-exporter"
-      meta: "Datastore {{ $labels.datastore }} is disconnected and has virtual machines on it ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      meta: "Datastore {{ $labels.datastore }} is disconnected and has virtual machines on it ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
       playbook: docs/devops/alert/vcenter/#test_eph_ds_1
     annotations:
-      description: "Datastore {{ $labels.datastore }} is disconnected and has virtual machines on it ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
-      summary: "Datastore {{ $labels.datastore }} is disconnected and has virtual machines on it ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      description: "Datastore {{ $labels.datastore }} is disconnected and has virtual machines on it ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      summary: "Datastore {{ $labels.datastore }} is disconnected and has virtual machines on it ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
   - alert: DatastoreDisconnectedWithoutVmsOnIt
     expr: >
       max_over_time(vrops_datastore_summary_total_number_vms[10m]) == 0
@@ -157,8 +157,8 @@ groups:
       tier: vmware
       service: storage
       context: "vrops-exporter"
-      meta: "Datastore {{ $labels.datastore }} is disconnected without virtual machines on it ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      meta: "Datastore {{ $labels.datastore }} is disconnected without virtual machines on it ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
       playbook: docs/devops/alert/vcenter/#test_eph_ds_2
     annotations:
-      description: "Datastore {{ $labels.datastore }} is disconnected without virtual machines on it ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
-      summary: "Datastore {{ $labels.datastore }} is disconnected without virtual machines on it ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      description: "Datastore {{ $labels.datastore }} is disconnected without virtual machines on it ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      summary: "Datastore {{ $labels.datastore }} is disconnected without virtual machines on it ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"

--- a/prometheus-exporters/vrops-exporter/alerts/host.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/host.alerts
@@ -13,12 +13,12 @@ groups:
       tier: vmware
       service: compute
       context: "vrops-exporter"
-      meta: "Host {{ $labels.hostsystem }} with running VMs not responding ({{ $labels.vcenter }}, {{ $labels.vccluster }})"
+      meta: "Host {{ $labels.hostsystem }} with running VMs not responding. ({{ $labels.vcenter }}, {{ $labels.vccluster }})"
       dashboard: esxi-host-disconnected/esxi-host-disconnected?&var-host={{ $labels.hostsystem }}
       playbook: docs/devops/alert/vcenter/#test_esxi_hs_1
     annotations:
-      description: "Host {{ $labels.hostsystem }} with running VMs not responding ({{ $labels.vcenter }}, {{ $labels.vccluster }})"
-      summary: "Host {{ $labels.hostsystem }} with running VMs not responding ({{ $labels.vcenter }}, {{ $labels.vccluster }})"
+      description: "Host {{ $labels.hostsystem }} with running VMs not responding. ({{ $labels.vcenter }}, {{ $labels.vccluster }})"
+      summary: "Host {{ $labels.hostsystem }} with running VMs not responding. ({{ $labels.vcenter }}, {{ $labels.vccluster }})"
   - alert: HostNotResponding
     expr: |
       vrops_hostsystem_summary_running_vms_number == 0 and 
@@ -30,12 +30,12 @@ groups:
       tier: vmware
       service: compute
       context: "vrops-exporter"
-      meta: "Host {{ $labels.hostsystem }} not responding ({{ $labels.vcenter }}, {{ $labels.vccluster }})"
+      meta: "Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter }}, {{ $labels.vccluster }})"
       dashboard: esxi-host-disconnected/esxi-host-disconnected?&var-host={{ $labels.hostsystem }}
       playbook: docs/devops/alert/vcenter/#test_esxi_hs_2
     annotations:
-      description: "Host {{ $labels.hostsystem }} not responding ({{ $labels.vcenter }}, {{ $labels.vccluster }})"
-      summary: "Host {{ $labels.hostsystem }} not responding ({{ $labels.vcenter }}, {{ $labels.vccluster }})"
+      description: "Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter }}, {{ $labels.vccluster }})"
+      summary: "Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter }}, {{ $labels.vccluster }})"
   - alert: HostInMaintenanceWithoutCustomAttribute
     expr: |
       ((max_over_time(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}[10m]) == 0)

--- a/prometheus-exporters/vrops-exporter/alerts/host.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/host.alerts
@@ -13,12 +13,12 @@ groups:
       tier: vmware
       service: compute
       context: "vrops-exporter"
-      meta: "Host {{ $labels.hostsystem }} with running VMs not responding ({{ $labels.datacenter }}, {{ $labels.vccluster }})"
+      meta: "Host {{ $labels.hostsystem }} with running VMs not responding ({{ $labels.vcenter }}, {{ $labels.vccluster }})"
       dashboard: esxi-host-disconnected/esxi-host-disconnected?&var-host={{ $labels.hostsystem }}
       playbook: docs/devops/alert/vcenter/#test_esxi_hs_1
     annotations:
-      description: "Host {{ $labels.hostsystem }} with running VMs not responding ({{ $labels.datacenter }}, {{ $labels.vccluster }})"
-      summary: "Host {{ $labels.hostsystem }} with running VMs not responding ({{ $labels.datacenter }}, {{ $labels.vccluster }})"
+      description: "Host {{ $labels.hostsystem }} with running VMs not responding ({{ $labels.vcenter }}, {{ $labels.vccluster }})"
+      summary: "Host {{ $labels.hostsystem }} with running VMs not responding ({{ $labels.vcenter }}, {{ $labels.vccluster }})"
   - alert: HostNotResponding
     expr: |
       vrops_hostsystem_summary_running_vms_number == 0 and 
@@ -30,12 +30,12 @@ groups:
       tier: vmware
       service: compute
       context: "vrops-exporter"
-      meta: "Host {{ $labels.hostsystem }} not responding ({{ $labels.datacenter }}, {{ $labels.vccluster }})"
+      meta: "Host {{ $labels.hostsystem }} not responding ({{ $labels.vcenter }}, {{ $labels.vccluster }})"
       dashboard: esxi-host-disconnected/esxi-host-disconnected?&var-host={{ $labels.hostsystem }}
       playbook: docs/devops/alert/vcenter/#test_esxi_hs_2
     annotations:
-      description: "Host {{ $labels.hostsystem }} not responding ({{ $labels.datacenter }}, {{ $labels.vccluster }})"
-      summary: "Host {{ $labels.hostsystem }} not responding ({{ $labels.datacenter }}, {{ $labels.vccluster }})"
+      description: "Host {{ $labels.hostsystem }} not responding ({{ $labels.vcenter }}, {{ $labels.vccluster }})"
+      summary: "Host {{ $labels.hostsystem }} not responding ({{ $labels.vcenter }}, {{ $labels.vccluster }})"
   - alert: HostInMaintenanceWithoutCustomAttribute
     expr: |
       ((max_over_time(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}[10m]) == 0)
@@ -53,14 +53,16 @@ groups:
       description: "Host {{ $labels.hostsystem }} is in maintenance without a custom attribute. Please provide detailed information in the Custom Attribute HW field."
       summary: "Host {{ $labels.hostsystem }} is in maintenance without a custom attribute."
   - alert: VMsOnFailoverHost
-    expr: vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost == 1 AND ON(hostsystem) vrops_hostsystem_summary_number_vms_total > 0
+    expr: |
+      vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost == 1
+      and on (hostsystem) count(vrops_virtualmachine_runtime_powerstate{state="Powered On"}) by (hostsystem) > 0
     for: 10m
     labels:
       severity: info
       tier: vmware
       service: compute
       context: "vrops-exporter"
-      meta: "Failover Host {{ $labels.hostsystem }} has Virtual Machines on it."
+      meta: "Failover Host {{ $labels.hostsystem }} has Virtual Machines on it. ({{ $labels.vcenter }}, {{ $labels.vccluster }})"
     annotations:
-      description: "Failover Host {{ $labels.hostsystem }} has Virtual Machines on it. Free up the host."
-      summary: "Failover Host {{ $labels.hostsystem }} has Virtual Machines on it."
+      description: "Failover Host {{ $labels.hostsystem }} has Virtual Machines on it. Free up the host. ({{ $labels.vcenter }}, {{ $labels.vccluster }})"
+      summary: "Failover Host {{ $labels.hostsystem }} has Virtual Machines on it. ({{ $labels.vcenter }}, {{ $labels.vccluster }})"

--- a/prometheus-exporters/vrops-exporter/alerts/virtualmachine.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/virtualmachine.alerts
@@ -13,11 +13,11 @@ groups:
       tier: vmware
       service: compute
       context: "vrops-exporter"
-      meta: "Shadow VM {{ $labels.virtualmachine }} is inaccessible. ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      meta: "Shadow VM {{ $labels.virtualmachine }} is inaccessible. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
       playbook: docs/devops/alert/vcenter/#test_vvol_ds_7
     annotations:
-      description: "Shadow VM {{ $labels.virtualmachine }} is inaccessible. ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
-      summary: "Shadow VM {{ $labels.virtualmachine }} is inaccessible. ({{ $labels.datacenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      description: "Shadow VM {{ $labels.virtualmachine }} is inaccessible. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
+      summary: "Shadow VM {{ $labels.virtualmachine }} is inaccessible. ({{ $labels.vcenter }}, {{ $labels.vccluster }}, {{ $labels.hostsystem }})"
   - alert: VROpsDiskpaceUsageCritical
     expr: >
       vrops_virtualmachine_database_disk_usage_percent{virtualmachine=~"vrops-vc.*"} > 90


### PR DESCRIPTION
+ better information on alerts (vcenter instead of datacenter)