### PR TITLE
[alertmanager] rm tier from generic service routing

### DIFF
--- a/global/prometheus-alertmanager-operated/Chart.yaml
+++ b/global/prometheus-alertmanager-operated/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: "1.0"
 type: application
 description: Prometheus Alertmanager via operator.
 name: prometheus-alertmanager-operated
-version: 1.0.0
+version: 1.0.1

--- a/global/prometheus-alertmanager-operated/templates/_alertmanager.yaml.tpl
+++ b/global/prometheus-alertmanager-operated/templates/_alertmanager.yaml.tpl
@@ -102,7 +102,6 @@ route:
   - receiver: slack_by_os_service
     continue: true
     match_re:
-      tier: os
       severity: info|warning|critical
       service: arc|backup|barbican|castellum|cinder|cfm|cronus|designate|elektra|elk|glance|hermes|ironic|keppel|keystone|limes|lyra|maia|manila|neutron|nova|octavia|sentry|swift
       region: qa-de-1|ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-2|na-us-3


### PR DESCRIPTION
this is mainly to handle multi-tier alerts by service