### PR TITLE
[elastic-query-exporter] Switch to search result based metric

### DIFF
--- a/prometheus-exporters/elastic-query-exporter/alerts/logs.alerts
+++ b/prometheus-exporters/elastic-query-exporter/alerts/logs.alerts
@@ -56,16 +56,15 @@ groups:
           description: "VCSA logs missing in Octobus for vCenter {{ $labels.vcenter }}."
           summary: "VCSA logs missing in Octobus for vCenter {{ $labels.vcenter }}."
       - alert: VMPoweredDownDuringFailedHostMigration
-        expr: elasticsearch_octobus_vmdown_hostsystem_doc_count
-        for: 5m
+        expr: elasticsearch_octobus_vmdown_hit
         labels:
           severity: info
           tier: vmware
           service: compute
           context: logging
           no_alert_on_absence: "true"
-          meta: "A VM on host {{ $labels.hostsystem }} unexpectedly powered down during a failed host migration (vMotion or Storage vMotion)."
+          meta: "A VM on unexpectedly powered down during a failed host migration (vMotion or Storage vMotion)."
           playbook: docs/devops/alert/vcenter/#VM%20powered%20off%20during%20vMotion
         annotations:
-          description: "A VM on host {{ $labels.hostsystem }} unexpectedly powered down during a failed host migration (vMotion or Storage vMotion)."
+          description: "A VM unexpectedly powered down during a failed host migration: {{ $labels.message }}"
           summary: "A VM unexpectedly powered down during a failed host migration (vMotion or Storage vMotion)."

--- a/prometheus-exporters/elastic-query-exporter/files/exporter.cfg
+++ b/prometheus-exporters/elastic-query-exporter/files/exporter.cfg
@@ -160,6 +160,8 @@ QueryJson = {
 QueryIntervalSecs = 300
 QueryTimeoutSecs = 15
 QueryIndices = c0001_log-*
+QueryOnMissing = drop
+LabelsFromHits = [ "message" ]
 QueryJson = {
     "query": {
       "bool": {
@@ -171,9 +173,6 @@ QueryJson = {
           { "range": { "@timestamp": { "gte": "now-1h" }}}
         ]
       }
-    },
-    "aggs": {
-      "hostsystem": { "terms": { "field": "node.nodename.keyword" }}
     }
   }
 


### PR DESCRIPTION
* adjust alert expression
* remove alert timeout as this is an event based alert
* add syslog message in alert description
* node.nodename removed from alert description
  as exporter can't parse out nested fields yet
  ESXi name will be in syslog message, as will affected VM
* remove aggs from query needed before for aggs based metric