### PR TITLE
[neutron] Add NSXTExporterNoMetrics alert

### DIFF
--- a/openstack/neutron/alerts/nsxt.alerts
+++ b/openstack/neutron/alerts/nsxt.alerts
@@ -90,6 +90,18 @@ groups:
       description:  'NSX-T Exporter has no data'
       summary:  'NSX-T Exporter has no data'
 
+  - alert: NSXTExporterNoMetrics
+    expr: label_replace(kube_pod_info{created_by_name=~'neutron-nsxv3-agent-bb.*'}, 'nsxv3_agent', '$1', 'created_by_name', '^(neutron-nsxv3-agent-bb[^-]+)-.*') unless on (nsxv3_agent) label_replace(nsxv3_cluster_management_last_successful_data_fetch{name=~"neutron-nsxv3-agent-bb.*"}, 'nsxv3_agent', '$1', 'name', '(.*)')
+    for: 60m
+    labels:
+      severity: info
+      tier: vmware
+      meta: 'NSX-T Exporter has no metrics'
+      dashboard: nsx-t
+    annotations:
+      description:  'NSX-T pod {{ $labels.nsxv3_agent }} is running, but we do not have metrics for it in prometheus.'
+      summary:  'NSX-T Exporter has no metrics'
+
   - alert: NSXTPodNotReady
     expr: kube_pod_status_phase_normalized{phase="Running", pod=~"neutron-nsxv3-agent-.+"}
       * on(pod, node) kube_pod_status_ready_normalized{condition="false", pod=~"neutron-nsxv3-agent-.+"} * on(node)


### PR DESCRIPTION
The NSXTExporterNoData alert doesn't work, if the exporter stopped
exporting for a longer period of time, because prometheus can only see
things as absent, if they ever reported.

We now build a query matching all running nsxv3-agent pods to one
nsxv3_agent of the nsxv3_cluster_management_last_successful_data_fetch
metric. If we can't find a metric reported by a running pod, we fire an
alert.