### PR TITLE
[swift] Deployment options for Proxy: Deployment, Daemonset or Both

### DIFF
--- a/openstack/swift/templates/_utils.tpl
+++ b/openstack/swift/templates/_utils.tpl
@@ -100,7 +100,7 @@ checksum/object.ring: {{ include "swift/templates/object-ring.yaml" . | sha256su
 {{- end }}
 
 {{- /**********************************************************************************/ -}}
-{{- define "swift_proxy_container" }}
+{{- define "swift_proxy_containers" }}
 {{- $cluster := index . 0 -}}
 {{- $context := index . 1 -}}
 - name: proxy

--- a/openstack/swift/templates/_utils.tpl
+++ b/openstack/swift/templates/_utils.tpl
@@ -74,6 +74,187 @@ checksum/object.ring: {{ include "swift/templates/object-ring.yaml" . | sha256su
 {{- end -}}
 
 {{- /**********************************************************************************/ -}}
+{{- define "swift_proxy_volumes" }}
+{{- $cluster := index . 0 -}}
+- name: tls-secret
+  secret:
+    secretName: tls-swift-{{ $cluster }}
+- name: swift-bin
+  configMap:
+    name: swift-bin
+- name: swift-etc
+  configMap:
+    name: swift-etc
+- name: swift-etc-cluster
+  configMap:
+    name: swift-etc-{{ $cluster }}
+- name: swift-account-ring
+  configMap:
+    name: swift-account-ring
+- name: swift-container-ring
+  configMap:
+    name: swift-container-ring
+- name: swift-object-ring
+  configMap:
+    name: swift-object-ring
+{{- end }}
+
+{{- /**********************************************************************************/ -}}
+{{- define "swift_proxy_container" }}
+{{- $cluster := index . 0 -}}
+{{- $context := index . 1 -}}
+- name: proxy
+  image: {{ include "swift_image" $context }}
+  command:
+    - /usr/bin/dumb-init
+  args:
+    - /bin/bash
+    - /usr/bin/swift-start
+    - proxy-server
+  env:
+    - name: DEBUG_CONTAINER
+      value: "false"
+    {{- if $context.Values.sentry.enabled }}
+    - name: SENTRY_DSN
+      valueFrom:
+        secretKeyRef:
+          name: sentry
+          key: swift.DSN.public
+    {{- end }}
+  {{- if $context.Values.resources.enabled }}
+  resources:
+    # observed usage: CPU = 300m-2500m, RAM = 450-800 MiB
+    requests:
+      cpu: "2500m"
+      memory: "1500Mi"
+    limits:
+      cpu: "2500m"
+      memory: "1500Mi"
+  {{- end }}
+  volumeMounts:
+    - mountPath: /swift-etc
+      name: swift-etc
+    - mountPath: /swift-etc-cluster
+      name: swift-etc-cluster
+    - mountPath: /swift-rings/account
+      name: swift-account-ring
+    - mountPath: /swift-rings/container
+      name: swift-container-ring
+    - mountPath: /swift-rings/object
+      name: swift-object-ring
+  livenessProbe:
+    httpGet:
+      path: /healthcheck
+      port: 8080
+      scheme: HTTP
+    initialDelaySeconds: 10
+    timeoutSeconds: 1
+    periodSeconds: 10
+- name: nginx
+  image: {{ $context.Values.global.registryAlternateRegion }}/swift-nginx:{{ $context.Values.image_version_nginx }}
+  command:
+    - /usr/bin/dumb-init
+  args:
+    - /bin/sh
+    - /swift-bin/nginx-start
+  {{- if $context.Values.resources.enabled }}
+  resources:
+    # observed usage: CPU = 10m-500m, RAM = 50-100 MiB
+    requests:
+      cpu: "1000m"
+      memory: "200Mi"
+    limits:
+      cpu: "1000m"
+      memory: "200Mi"
+  {{- end }}
+  volumeMounts:
+    - mountPath: /swift-bin
+      name: swift-bin
+    - mountPath: /swift-etc
+      name: swift-etc
+    - mountPath: /swift-etc-cluster
+      name: swift-etc-cluster
+    - mountPath: /tls-secret
+      name: tls-secret
+  livenessProbe:
+    httpGet:
+      path: /nginx-health
+      port: 1080
+      scheme: HTTP
+    initialDelaySeconds: 10
+    timeoutSeconds: 1
+    periodSeconds: 10
+  readinessProbe:
+    httpGet:
+      path: /healthcheck
+      port: {{ $cluster.proxy_public_port }}
+      scheme: HTTPS
+      httpHeaders:
+        - name: Host
+          value: {{ tuple $cluster $context.Values | include "swift_endpoint_host" }}
+    initialDelaySeconds: 10
+    timeoutSeconds: 1
+    periodSeconds: 5
+{{- if $context.Values.health_exporter }}
+- name: collector
+  image: {{ include "swift_image" $context }}
+  command:
+    - /usr/bin/dumb-init
+  args:
+    - /bin/bash
+    - /usr/bin/swift-start
+    - health-exporter
+    - --recon.timeout=20
+    - --recon.timeout-host=2
+  ports:
+    - name: metrics
+      containerPort: 9520
+  {{- if $context.Values.resources.enabled }}
+  resources:
+    # observed usage: CPU = ~10m, RAM = 70-100 MiB
+    # low cpu allocation results in performance degradation
+    requests:
+      cpu: "100m"
+      memory: "150Mi"
+    limits:
+      cpu: "100m"
+      memory: "150Mi"
+  {{- end }}
+  volumeMounts:
+    - mountPath: /swift-etc
+      name: swift-etc
+    - mountPath: /swift-rings/account
+      name: swift-account-ring
+    - mountPath: /swift-rings/container
+      name: swift-container-ring
+    - mountPath: /swift-rings/object
+      name: swift-object-ring
+{{- end}}
+- name: statsd
+  image: prom/statsd-exporter:{{ $context.Values.image_version_auxiliary_statsd_exporter }}
+  args: [ --statsd.mapping-config=/swift-etc/statsd-exporter.yaml ]
+  {{- if $context.Values.resources.enabled }}
+  resources:
+    # observed usage: CPU = 10m-100m, RAM = 550-950 MiB
+    requests:
+      cpu: "120m"
+      memory: "1024Mi"
+    limits:
+      cpu: "120m"
+      memory: "1024Mi"
+  {{- end }}
+  ports:
+    - name: statsd
+      containerPort: 9125
+      protocol: UDP
+    - name: metrics
+      containerPort: 9102
+  volumeMounts:
+    - mountPath: /swift-etc
+      name: swift-etc
+{{- end }}
+
+{{- /**********************************************************************************/ -}}
 {{- define "swift_standard_container" -}}
 {{- $image   := index . 0 -}}
 {{- $service := index . 1 -}}

--- a/openstack/swift/templates/health-exporter-deployment.yaml
+++ b/openstack/swift/templates/health-exporter-deployment.yaml
@@ -64,13 +64,11 @@ spec:
           ports:
             - name: metrics
               containerPort: 9520
-          {{- if $.Values.resources.enabled }}
           resources:
             # observed usage: CPU = ~70m, RAM = 80-110 MiB
             requests:
               cpu: "100m"
               memory: "200Mi"
-          {{- end }}
           volumeMounts:
             - mountPath: /swift-etc
               name: swift-etc

--- a/openstack/swift/templates/memcached-deployment.yaml
+++ b/openstack/swift/templates/memcached-deployment.yaml
@@ -29,7 +29,6 @@ spec:
             - name: memcached
               containerPort: 11211
           command: ["memcached", "-m", "1024", "-c", "16384"]
-          {{- if $.Values.resources.enabled }}
           resources:
             # observed usage: CPU = 15m-100m, RAM = 25-70 MiB
             requests:
@@ -38,13 +37,11 @@ spec:
             limits:
               cpu: '200m'
               memory: '2048Mi'
-          {{- end }}
         - name: metrics
           image: prom/memcached-exporter:{{ $.Values.image_version_auxiliary_memcached_exporter }}
           ports:
             - name: metrics
               containerPort: 9150
-          {{- if $.Values.resources.enabled }}
           resources:
             # observed usage: CPU <= 2m-4m, RAM = 18-20 MiB
             requests:
@@ -53,6 +50,5 @@ spec:
             limits:
               cpu: '50m'
               memory: '64Mi'
-          {{- end }}
 ---
 {{end}}

--- a/openstack/swift/templates/object-expirer-deployment.yaml
+++ b/openstack/swift/templates/object-expirer-deployment.yaml
@@ -55,7 +55,6 @@ spec:
                   name: sentry
                   key: swift.DSN.public
             {{- end }}
-          {{- if .Values.resources.enabled }}
           resources:
             # observed usage: CPU = 1m-300m, RAM = 50-180 MiB
             requests:
@@ -64,7 +63,6 @@ spec:
             limits:
               cpu: '400m'
               memory: '400Mi'
-          {{- end }}
           volumeMounts:
             - mountPath: /swift-etc
               name: swift-etc

--- a/openstack/swift/templates/proxy-daemonset.yaml
+++ b/openstack/swift/templates/proxy-daemonset.yaml
@@ -1,5 +1,5 @@
 {{- range $cluster_id, $cluster := .Values.clusters }}
-{{- if $cluster.daemonset }}
+{{- if $cluster.proxy_daemonset_enabled }}
 kind: DaemonSet
 apiVersion: apps/v1
 

--- a/openstack/swift/templates/proxy-daemonset.yaml
+++ b/openstack/swift/templates/proxy-daemonset.yaml
@@ -40,7 +40,7 @@ spec:
       volumes:
         {{- tuple $cluster_id | include "swift_proxy_volumes" | nindent 8 }}
       containers:
-        {{- tuple $cluster $ | include "swift_proxy_container" | nindent 8 }}
+        {{- tuple $cluster $ | include "swift_proxy_containers" | nindent 8 }}
 
 ---
 {{- end }}

--- a/openstack/swift/templates/proxy-daemonset.yaml
+++ b/openstack/swift/templates/proxy-daemonset.yaml
@@ -1,31 +1,26 @@
 {{- range $cluster_id, $cluster := .Values.clusters }}
-kind: Deployment
+kind: DaemonSet
 apiVersion: apps/v1
 
 metadata:
-  name: swift-proxy-{{$cluster_id}}
+  name: swift-proxy-{{ $cluster_id }}
   labels:
-    release: "{{$.Release.Name}}"
-    os-cluster: {{$cluster_id}}
+    release: "{{ $.Release.Name }}"
+    os-cluster: {{ $cluster_id }}
+
 spec:
-  revisionHistoryLimit: 5
-  replicas: {{$cluster.replicas}}
-  strategy:
+  minReadySeconds: 60 # longer wait here to be extra sure that the new servers are operational
+  updateStrategy:
     type: RollingUpdate
-    rollingUpdate:
-      {{- if eq $cluster.replicas 1.0 }}
-      maxUnavailable: 0
-      {{- else }}
-      maxUnavailable: 1
-      {{- end }}
-      maxSurge: 2
   selector:
     matchLabels:
-      component: swift-proxy-{{$cluster_id}}
+      component: swift-proxy-{{ $cluster_id }}
   template:
     metadata:
       labels:
-        component: swift-proxy-{{$cluster_id}}
+        component: swift-proxy-{{ $cluster_id }}
+        from: daemonset
+        restart: carefully
       annotations:
         checksum/swift-cluster.etc: {{ include "swift/templates/etc/cluster-configmap.yaml" $ | sha256sum }}
         {{- include "swift_conf_annotations" $ | indent 8 }}
@@ -39,21 +34,9 @@ spec:
         prometheus.io/targets: {{ required ".Values.alerts.prometheus.openstack missing" $.Values.alerts.prometheus.openstack }}
         {{- end }}
     spec:
-      {{- if $.Values.proxy_on_nodes }}
       {{- include "swift_daemonset_tolerations" $ | indent 6 }}
       nodeSelector:
         species: {{ $.Values.species }}
-      {{- end }}
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: component
-                operator: In
-                values:
-                - swift-proxy-{{$cluster_id}}
-            topologyKey: "kubernetes.io/hostname"
       volumes:
         {{- tuple $cluster_id | include "swift_proxy_volumes" | nindent 8 }}
       containers:

--- a/openstack/swift/templates/proxy-daemonset.yaml
+++ b/openstack/swift/templates/proxy-daemonset.yaml
@@ -1,4 +1,5 @@
 {{- range $cluster_id, $cluster := .Values.clusters }}
+{{- if $cluster.daemonset }}
 kind: DaemonSet
 apiVersion: apps/v1
 
@@ -38,9 +39,10 @@ spec:
       nodeSelector:
         species: {{ $.Values.species }}
       volumes:
-        {{- tuple $cluster_id | include "swift_proxy_volumes" | nindent 8 }}
+        {{- tuple $cluster_id | include "swift_proxy_volumes" | indent 8 }}
       containers:
-        {{- tuple $cluster $ | include "swift_proxy_containers" | nindent 8 }}
+        {{- tuple "daemonset" $cluster $ | include "swift_proxy_containers" | indent 8 }}
 
 ---
+{{- end }}
 {{- end }}

--- a/openstack/swift/templates/proxy-deployment.yaml
+++ b/openstack/swift/templates/proxy-deployment.yaml
@@ -57,7 +57,7 @@ spec:
       volumes:
         {{- tuple $cluster_id | include "swift_proxy_volumes" | nindent 8 }}
       containers:
-        {{- tuple $cluster $ | include "swift_proxy_container" | nindent 8 }}
+        {{- tuple $cluster $ | include "swift_proxy_containers" | nindent 8 }}
 
 ---
 {{- end }}

--- a/openstack/swift/templates/proxy-deployment.yaml
+++ b/openstack/swift/templates/proxy-deployment.yaml
@@ -1,4 +1,5 @@
 {{- range $cluster_id, $cluster := .Values.clusters }}
+{{- if $cluster.deployment }}
 kind: Deployment
 apiVersion: apps/v1
 
@@ -9,11 +10,11 @@ metadata:
     os-cluster: {{$cluster_id}}
 spec:
   revisionHistoryLimit: 5
-  replicas: {{$cluster.replicas}}
+  replicas: {{ required "deployment.replicas is required" $cluster.deployment.replicas }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      {{- if eq $cluster.replicas 1.0 }}
+      {{- if eq $cluster.deployment.replicas 1.0 }}
       maxUnavailable: 0
       {{- else }}
       maxUnavailable: 1
@@ -55,9 +56,10 @@ spec:
                 - swift-proxy-{{$cluster_id}}
             topologyKey: "kubernetes.io/hostname"
       volumes:
-        {{- tuple $cluster_id | include "swift_proxy_volumes" | nindent 8 }}
+        {{- tuple $cluster_id | include "swift_proxy_volumes" | indent 8 }}
       containers:
-        {{- tuple $cluster $ | include "swift_proxy_containers" | nindent 8 }}
+        {{- tuple "deployment" $cluster $ | include "swift_proxy_containers" | indent 8 }}
 
 ---
+{{- end }}
 {{- end }}

--- a/openstack/swift/templates/proxy-deployment.yaml
+++ b/openstack/swift/templates/proxy-deployment.yaml
@@ -1,5 +1,5 @@
 {{- range $cluster_id, $cluster := .Values.clusters }}
-{{- if $cluster.deployment }}
+{{- if $cluster.proxy_deployment_enabled }}
 kind: Deployment
 apiVersion: apps/v1
 
@@ -10,11 +10,11 @@ metadata:
     os-cluster: {{$cluster_id}}
 spec:
   revisionHistoryLimit: 5
-  replicas: {{ required "deployment.replicas is required" $cluster.deployment.replicas }}
+  replicas: {{ required "proxy_deployment_replicas is required" $cluster.proxy_deployment_replicas }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      {{- if eq $cluster.deployment.replicas 1.0 }}
+      {{- if eq $cluster.proxy_deployment_replicas 1.0 }}
       maxUnavailable: 0
       {{- else }}
       maxUnavailable: 1
@@ -40,7 +40,7 @@ spec:
         prometheus.io/targets: {{ required ".Values.alerts.prometheus.openstack missing" $.Values.alerts.prometheus.openstack }}
         {{- end }}
     spec:
-      {{- if $.Values.proxy_on_nodes }}
+      {{- if $cluster.proxy_deployment_to_storage_nodes }}
       {{- include "swift_daemonset_tolerations" $ | indent 6 }}
       nodeSelector:
         species: {{ $.Values.species }}

--- a/openstack/swift/templates/s3-cache-prewarmer-deployment.yaml
+++ b/openstack/swift/templates/s3-cache-prewarmer-deployment.yaml
@@ -40,12 +40,10 @@ spec:
           ports:
             - name: metrics
               containerPort: 8080
-          {{- if $.Values.resources.enabled }}
           resources:
             requests:
               cpu: "20m"
               memory: "50Mi"
-          {{- end }}
           env:
             - name: OS_AUTH_URL
               value: {{ $cluster.keystone_auth_url }}

--- a/openstack/swift/values.yaml
+++ b/openstack/swift/values.yaml
@@ -60,9 +60,6 @@ client_timeout: 60 # same as default, but also sets nginx timeout to a similar v
 # Don't log requests to object, container or account servers
 log_requests: false
 
-# Proxy pods should run on storage nodes
-proxy_on_nodes: false
-
 # Local to advertise the ExternalIP only on nodes that run the pod
 # Only works with ServiceType NodePort
 external_traffic_policy_local: false
@@ -74,9 +71,6 @@ memcached_servers:
 
 sentry:
   enabled: false
-
-resources:
-  enabled: true
 
 # Deploy Swift Prometheus alerts.
 alerts:
@@ -105,27 +99,15 @@ alerts:
 #     swift_service_password: DEFINED_IN_REGION_CHART
 
 #     Swift proxies can be deployed as Deployment, Daemonset or both
-#
-#     Swift proxies are deployed as Deployment if key deployment is specified
-#     deployment:
-#       replicas: 2
-#       resources:
-#         requests:
-#           cpu: "2500m"
-#           memory: "1500Mi"
-#         limits:
-#           cpu: "2500m"
-#           memory: "1500Mi"
+#     proxy_deployment_enabled: true
+#     proxy_deployment_replicas: 2
+#     proxy_deployment_to_storage_nodes: true
+#     proxy_deployment_resources_cpu: "2500m"
+#     proxy_deployment_resources_memory: "1500Mi"
 
-#     Swift proxies are deployed as Daemonset if key daemonset is specified
-#     daemonset:
-#       resources:
-#         requests:
-#           cpu: "2500m"
-#           memory: "1500Mi"
-#         limits:
-#           cpu: "2500m"
-#           memory: "1500Mi"
+#     proxy_daemonset_enabled: true
+#     proxy_daemonset_resources_cpu: "2500m"
+#     proxy_daemonset_resources_memory: "1500Mi"
 
     # The default is using the cache.swift for token caching
     # Specifing a memcached server name here will overrule that, see .Values.memcached_servers

--- a/openstack/swift/values.yaml
+++ b/openstack/swift/values.yaml
@@ -103,7 +103,29 @@ alerts:
 #     swift_service_project: service
 #     swift_service_project_domain: Default
 #     swift_service_password: DEFINED_IN_REGION_CHART
-#     replicas: 2
+
+#     Swift proxies can be deployed as Deployment, Daemonset or both
+#
+#     Swift proxies are deployed as Deployment if key deployment is specified
+#     deployment:
+#       replicas: 2
+#       resources:
+#         requests:
+#           cpu: "2500m"
+#           memory: "1500Mi"
+#         limits:
+#           cpu: "2500m"
+#           memory: "1500Mi"
+
+#     Swift proxies are deployed as Daemonset if key daemonset is specified
+#     daemonset:
+#       resources:
+#         requests:
+#           cpu: "2500m"
+#           memory: "1500Mi"
+#         limits:
+#           cpu: "2500m"
+#           memory: "1500Mi"
 
     # The default is using the cache.swift for token caching
     # Specifing a memcached server name here will overrule that, see .Values.memcached_servers


### PR DESCRIPTION
Swift proxies can be deployed as
* Deployment
* Daemonset
* Both

New value sets:
* proxy_deployment_*
* proxy_daemonset_* 

Resource request and limits have to be specified per swift cluster

Other changes
* Remove `resources.enabled` value
* Move `proxy_on_nodes` to flatten 