### PR TITLE
[openstack-exporter]  Change default log level to DEBUG

### DIFF
--- a/prometheus-exporters/openstack-exporter/values.yaml
+++ b/prometheus-exporters/openstack-exporter/values.yaml
@@ -1,6 +1,6 @@
 exporter:
    prometheus_port: 9102
-   log_level: "INFO"
+   log_level: "DEBUG"
 openstack:
    enabled: false
    image:


### PR DESCRIPTION
The info log level is overly quiet.  This patch ups the loglevel
to DEBUG