### PR TITLE
[Octavia] Add housekeeping

### DIFF
--- a/openstack/octavia/requirements.lock
+++ b/openstack/octavia/requirements.lock
@@ -20,5 +20,8 @@ dependencies:
 - name: utils
   repository: file://../../openstack/utils
   version: 0.1.1
-digest: sha256:76b4af7d2005c3d433a9f2eef664241c56bd57b59371338c94a675da8712fd90
-generated: "2020-10-29T17:25:47.750818+01:00"
+- name: jaeger-operator
+  repository: https://charts.eu-de-2.cloud.sap
+  version: 0.1.0
+digest: sha256:f2df1f1d408d3bbc6097f374467de16240d35817e64656a2786cd5cd23f33122
+generated: "2021-02-04T10:08:37.014437223+01:00"

--- a/openstack/octavia/templates/etc/_octavia.conf.tpl
+++ b/openstack/octavia/templates/etc/_octavia.conf.tpl
@@ -38,6 +38,12 @@ network_driver = {{ .Values.network_driver  | default "network_noop_driver" }}
 [status_manager]
 health_check_interval = 60
 
+{{ if .Values.house_keeping }}
+[house_keeping]
+cleanup_interval = {{ .Values.house_keeping.cleanup_interval }}
+load_balancer_expiry_age = {{ .Values.house_keeping.expiry_age }}
+{{- end }}
+
 {{ if .Values.network_segment_physical_network }}
 [networking]
 f5_network_segment_physical_network = {{ .Values.network_segment_physical_network }}


### PR DESCRIPTION
The housekeeping pod exists but housekeeping is never configured in the config. That's why we have many thousands of deleted load balancers just lying around.

Edit: There are in fact default values, but the expiry age is one week.