### PR TITLE
[backupv2] adjusted the alerts.

### DIFF
--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.3.3
+version: 0.3.4

--- a/common/mariadb/templates/alerts/_backup-v2.alerts.tpl
+++ b/common/mariadb/templates/alerts/_backup-v2.alerts.tpl
@@ -1,7 +1,7 @@
 - name: backup-v2.alerts
   rules:
   - alert: {{ include "alerts.service" . | title }}MariaDatabaseFullBackupMissing
-    expr: count(maria_backup_status{kind="full_backup", release={{ include "alerts.service" . | quote }} } == 0) == 2
+    expr: maria_backup_status{kind="full_backup", release={{ include "alerts.service" . | quote }} } != 1
     for: 15m
     labels:
       context: "{{ .Release.Name }}"
@@ -13,7 +13,7 @@
       summary: {{ include "fullName" . }} full backup missing
 
   - alert: {{ include "alerts.service" . | title }}MariaDatabaseIncBackupMissing
-    expr: count(maria_backup_status{kind="inc_backup", release={{ include "alerts.service" . | quote }} } == 0) == 2
+    expr: maria_backup_status{kind="inc_backup", release={{ include "alerts.service" . | quote }} } != 1
     for: {{ mul .Values.backup_v2.incremental_backup_in_minutes 5 }}m
     labels:
       context: "{{ .Release.Name }}"
@@ -24,26 +24,14 @@
       description: {{ include "fullName" . }} incremental backup missing. Please check the backup container.
       summary: {{ include "fullName" . }} incremental backup missing
 
-  - alert: {{ include "alerts.service" . | title }}MariaDatabaseFullBackupStorageError
-    expr: count(maria_backup_status{kind="full_backup", release={{  include "alerts.service" . | quote }} } == 0) == 1
-    for: 15m
+  - alert: {{ include "alerts.service" . | title }}MariaDatabaseBackupVerifyRestoreFailed
+    expr: maria_backup_verify_status{kind="verify_restore", service=~"{{  include "alerts.service" . }}.*", storage=~"swift.*" } != 1
+    for: 12h
     labels:
       context: "{{ .Release.Name }}"
       service: {{ include "alerts.service" . }}
       severity: info
       tier: {{ required ".Values.alerts.tier missing" .Values.alerts.tier }}
     annotations:
-      description: {{ include "fullName" . }} full backup storage error. Please check the backup container.
-      summary: {{ include "fullName" . }} backup storage error
-
-  - alert: {{ include "alerts.service" . | title }}MariaDatabaseIncBackupStorageError
-    expr: count(maria_backup_status{kind="inc_backup", release={{  include "alerts.service" . | quote }} } == 0) == 1
-    for: {{ mul .Values.backup_v2.incremental_backup_in_minutes 5 }}m
-    labels:
-      context: "{{ .Release.Name }}"
-      service: {{ include "alerts.service" . }}
-      severity: info
-      tier: {{ required ".Values.alerts.tier missing" .Values.alerts.tier }}
-    annotations:
-      description: {{ include "fullName" . }} incremental backup storage error. Please check the backup container.
-      summary: {{ include "fullName" . }} incremental backup storage error
+      description: {{ include "fullName" . }} backup restore verification from Swift failed. Please check the backup container.
+      summary: {{ include "fullName" . }} backup restore failed to verify


### PR DESCRIPTION
- we currently have nova with up to 3, soon 4 db instances and existing
count alerts did not fire as expected due to multiple instances in use.
- replace storage error alerts with verify restore failed.