### PR TITLE
[swift] proxy deplyoment per Availabilty Zone

### DIFF
--- a/openstack/swift/templates/proxy-deployment.yaml
+++ b/openstack/swift/templates/proxy-deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     os-cluster: {{ $cluster_id }}
 spec:
   revisionHistoryLimit: 5
-  {{- $replicas_az := default 1.0 (index $cluster (printf "proxy_deployment_replicas_%s" $az)) }}
+  {{- $replicas_az := default 0.0 (index $cluster (printf "proxy_deployment_replicas_%s" $az)) }}
   replicas: {{ $replicas_az }}
   strategy:
     type: RollingUpdate
@@ -43,28 +43,10 @@ spec:
         prometheus.io/targets: {{ required ".Values.alerts.prometheus.openstack missing" $.Values.alerts.prometheus.openstack }}
         {{- end }}
     spec:
-      {{- if $cluster.proxy_deployment_to_storage_nodes }}
-      {{- include "swift_daemonset_tolerations" $ | indent 6 }}
-      {{- end }}
+      # No tolerations for swift nodes
+      nodeSelector:
+        failure-domain.beta.kubernetes.io/zone: {{ $az }}
       affinity:
-        nodeAffinity:
-          # Only schedule on nodes in this az
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: failure-domain.beta.kubernetes.io/zone
-                operator: In
-                values:
-                - {{ $az }}
-          # Prefere non storage nodes for scheduling
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            preference:
-              matchExpressions:
-              - key: species
-                operator: NotIn
-                values:
-                - {{ $.Values.species }}
         podAntiAffinity:
           # Prefere to be scheduled on nodes not yet running this proxy from a deplyoment
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/openstack/swift/templates/proxy-deployment.yaml
+++ b/openstack/swift/templates/proxy-deployment.yaml
@@ -1,20 +1,22 @@
 {{- range $cluster_id, $cluster := .Values.clusters }}
 {{- if $cluster.proxy_deployment_enabled }}
+{{- range $az := $.Values.global.availability_zones }}
 kind: Deployment
 apiVersion: apps/v1
 
 metadata:
-  name: swift-proxy-{{$cluster_id}}
+  name: swift-proxy-{{ $cluster_id }}-{{ $az }}
   labels:
-    release: "{{$.Release.Name}}"
-    os-cluster: {{$cluster_id}}
+    release: "{{ $.Release.Name }}"
+    os-cluster: {{ $cluster_id }}
 spec:
   revisionHistoryLimit: 5
-  replicas: {{ required "proxy_deployment_replicas is required" $cluster.proxy_deployment_replicas }}
+  {{- $replicas_az := default 1.0 (index $cluster (printf "proxy_deployment_replicas_%s" $az)) }}
+  replicas: {{ $replicas_az }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      {{- if eq $cluster.proxy_deployment_replicas 1.0 }}
+      {{- if eq $replicas_az 1.0 }}
       maxUnavailable: 0
       {{- else }}
       maxUnavailable: 1
@@ -22,11 +24,11 @@ spec:
       maxSurge: 2
   selector:
     matchLabels:
-      component: swift-proxy-{{$cluster_id}}
+      component: swift-proxy-{{ $cluster_id }}
   template:
     metadata:
       labels:
-        component: swift-proxy-{{$cluster_id}}
+        component: swift-proxy-{{ $cluster_id }}
         from: deployment
       annotations:
         checksum/swift-cluster.etc: {{ include "swift/templates/etc/cluster-configmap.yaml" $ | sha256sum }}
@@ -43,28 +45,48 @@ spec:
     spec:
       {{- if $cluster.proxy_deployment_to_storage_nodes }}
       {{- include "swift_daemonset_tolerations" $ | indent 6 }}
-      nodeSelector:
-        species: {{ $.Values.species }}
       {{- end }}
       affinity:
-        podAntiAffinity:
+        nodeAffinity:
+          # Only schedule on nodes in this az
           requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: failure-domain.beta.kubernetes.io/zone
+                operator: In
+                values:
+                - {{ $az }}
+          # Prefere non storage nodes for scheduling
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            preference:
               matchExpressions:
-              - key: component
-                operator: In
+              - key: species
+                operator: NotIn
                 values:
-                - swift-proxy-{{$cluster_id}}
-              - key: from
-                operator: In
-                values:
-                - deployment
-            topologyKey: "kubernetes.io/hostname"
+                - {{ $.Values.species }}
+        podAntiAffinity:
+          # Prefere to be scheduled on nodes not yet running this proxy from a deplyoment
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: component
+                  operator: In
+                  values:
+                  - swift-proxy-{{ $cluster_id }}
+                - key: from
+                  operator: In
+                  values:
+                  - deployment
+              topologyKey: "kubernetes.io/hostname"
       volumes:
         {{- tuple $cluster_id | include "swift_proxy_volumes" | indent 8 }}
       containers:
         {{- tuple "deployment" $cluster $ | include "swift_proxy_containers" | indent 8 }}
 
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/openstack/swift/values.yaml
+++ b/openstack/swift/values.yaml
@@ -101,7 +101,6 @@ alerts:
 #     Swift proxies can be deployed as Deployment, Daemonset or both
 #     proxy_deployment_enabled: true
 #     proxy_deployment_replicas_az-b: 2           # replicas in availability zone, default 0
-#     proxy_deployment_to_storage_nodes: true
 #     proxy_deployment_resources_cpu: "2500m"
 #     proxy_deployment_resources_memory: "1500Mi"
 

--- a/openstack/swift/values.yaml
+++ b/openstack/swift/values.yaml
@@ -100,7 +100,7 @@ alerts:
 
 #     Swift proxies can be deployed as Deployment, Daemonset or both
 #     proxy_deployment_enabled: true
-#     proxy_deployment_replicas_az-b: 2           # replicas in availability zone, default 1
+#     proxy_deployment_replicas_az-b: 2           # replicas in availability zone, default 0
 #     proxy_deployment_to_storage_nodes: true
 #     proxy_deployment_resources_cpu: "2500m"
 #     proxy_deployment_resources_memory: "1500Mi"

--- a/openstack/swift/values.yaml
+++ b/openstack/swift/values.yaml
@@ -100,7 +100,7 @@ alerts:
 
 #     Swift proxies can be deployed as Deployment, Daemonset or both
 #     proxy_deployment_enabled: true
-#     proxy_deployment_replicas: 2
+#     proxy_deployment_replicas_az-b: 2           # replicas in availability zone, default 1
 #     proxy_deployment_to_storage_nodes: true
 #     proxy_deployment_resources_cpu: "2500m"
 #     proxy_deployment_resources_memory: "1500Mi"


### PR DESCRIPTION
Option to create swift proxy deployments per AZ.
The initial amount of replicas per AZ can be specified, otherwise default to 0.

Scheduling
* Only schedule on nodes current az
* Do not schedule to storage nodes (missing tolerations)
* Prefere to be scheduled on nodes not yet running this proxy from a deplyoment