### PR TITLE
[osprofiler] clean up helper functions

### DIFF
--- a/openstack/utils/templates/_helpers.tpl
+++ b/openstack/utils/templates/_helpers.tpl
@@ -31,30 +31,22 @@ propagate=0
 {{- end }}
 
 {{- define "osprofiler" }}
-    {{- $options := merge .Values.osprofiler .Values.global.osprofiler }}
-    {{- if $options.enabled }}
-
+{{- if .Values.osprofiler.enabled }}
 [profiler]
 enabled = true
 connection_string = jaeger://localhost:6831
-hmac_keys = {{ $options.hmac_keys }}
-trace_sqlalchemy = {{ $options.trace_sqlalchemy }}
-    {{- else }}
-
-[profiler]
-enabled = false
-    {{- end }}
+hmac_keys = {{ .Values.global.osprofiler.hmac_keys }}
+trace_sqlalchemy = {{ .Values.global.osprofiler.trace_sqlalchemy }}
+{{- end }}
 {{- end }}
 
 {{- define "osprofiler_pipe" }}
-    {{- $options := merge .Values.osprofiler .Values.global.osprofiler }}
-    {{- if $options.enabled }} osprofiler{{ end -}}
+    {{- if .Values.osprofiler.enabled }} osprofiler{{ end -}}
 {{- end }}
 
 {{- define "jaeger_agent_sidecar" }}
-    {{- $options := merge .Values.osprofiler .Values.global.osprofiler }}
-    {{- if $options.enabled }}
-- image: jaegertracing/jaeger-agent:{{ $options.jaeger.version }}
+{{- if .Values.osprofiler.enabled }}
+- image: jaegertracing/jaeger-agent:{{ .Values.global.osprofiler.jaeger.version }}
   name: jaeger-agent
   ports:
     - containerPort: 5775
@@ -75,5 +67,5 @@ enabled = false
   args:
     - --reporter.grpc.host-port=openstack-jaeger-collector.{{ .Release.Namespace }}.svc:14250
     - --log-level=debug
-    {{- end }}
+{{- end }}
 {{- end }}

--- a/system/jaeger-operator/ci/test-values.yaml
+++ b/system/jaeger-operator/ci/test-values.yaml
@@ -1,3 +1,6 @@
 global:
   region: regionOne
   domain: evil.corp
+  osprofiler:
+    jaeger:
+      version: 0.0.0

--- a/system/jaeger-operator/templates/operator.yaml
+++ b/system/jaeger-operator/templates/operator.yaml
@@ -1,3 +1,4 @@
+{{- $options := merge .Values.global.osprofiler .Values }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -15,7 +16,7 @@ spec:
       serviceAccountName: jaeger-operator
       containers:
       - name: jaeger-operator
-        image: jaegertracing/jaeger-operator:{{ .Values.jaeger.version }}
+        image: jaegertracing/jaeger-operator:{{ $options.jaeger.version }}
         ports:
         - containerPort: 8383
           name: metrics


### PR DESCRIPTION
This PR clears old osprofiler setup with flamegraph-redis.

Also in the old setup, both global value `global.osprofiler.enabled` and service local `osprofiler.enabled` are checked in the helper function definition. It is bit confusing to control the integration of osprofiler, since osporfiler is not enabled for all services and one has to edit different places. **With this PR, osprofiler integration can only be enabled explicitly by the service local value `osprofiler.enabled`.**

This change will affect number of services with osprofiler integration in helm chart: `keystone`, `cinder`, `nova`, `nuetron` and `ironic`. Therefore I am asking the service owners to review this PR and be aware of the changes. 

