### PR TITLE
[elastic-query-exporter] Raise severity to critical for 2 alerts

### DIFF
--- a/openstack/swift/aggregations/openstack/consolidation.rules
+++ b/openstack/swift/aggregations/openstack/consolidation.rules
@@ -13,4 +13,7 @@ groups:
     expr: sum(rate(openstack_watcher_api_requests_total{service="object-store"}[5m]) * 60) by (action, target_type_uri)
 
   - record: swift_opm_top10
-    expr: topk(10, sum(rate(openstack_watcher_api_requests_total{service="object-store"}[5m]) * 60) by (action, target_project_id) > 15)
+    expr: topk(10, sum(rate(openstack_watcher_api_requests_total{service="object-store"}[5m]) * 60) by (target_project_id) > 15)
+
+  - record: swift_opm_top10_by_action
+    expr: topk(10, sum(rate(openstack_watcher_api_requests_total{service="object-store"}[5m]) * 60) by (target_project_id, action) > 15)

--- a/prometheus-exporters/elastic-query-exporter/alerts/logs.alerts
+++ b/prometheus-exporters/elastic-query-exporter/alerts/logs.alerts
@@ -63,7 +63,7 @@ groups:
           service: compute
           context: logging
           no_alert_on_absence: "true"
-          meta: "A VM on unexpectedly powered down during a failed host migration (vMotion or Storage vMotion)."
+          meta: "A VM unexpectedly powered down during a failed host migration (vMotion or Storage vMotion)."
           playbook: docs/devops/alert/vcenter/#VM%20powered%20off%20during%20vMotion
         annotations:
           description: "A VM unexpectedly powered down during a failed host migration: {{ $labels.message }}"

--- a/prometheus-exporters/elastic-query-exporter/alerts/logs.alerts
+++ b/prometheus-exporters/elastic-query-exporter/alerts/logs.alerts
@@ -58,7 +58,7 @@ groups:
       - alert: VMPoweredDownDuringFailedHostMigration
         expr: elasticsearch_octobus_vmdown_hit
         labels:
-          severity: info
+          severity: critical
           tier: vmware
           service: compute
           context: logging


### PR DESCRIPTION
Raise severity to critical for 
* VMPoweredDownDuringFailedHostMigration
* OctobusVCSALogShippingNotWorking