### PR TITLE
Update collector-configmap.yaml

### DIFF
--- a/prometheus-exporters/vrops-exporter/templates/collector-configmap.yaml
+++ b/prometheus-exporters/vrops-exporter/templates/collector-configmap.yaml
@@ -258,6 +258,9 @@ data:
           - metric_suffix: "summary_datastore_accessible"
             expected: "PoweredOn"
             property: "summary|accessible"
+        number_metrics:
+          - metric_suffix: "datastore_hostcount"
+            property: "datastore|hostcount"
       VMPropertiesCollector:
         enum_metrics:
           - metric_suffix: "runtime_powerState"


### PR DESCRIPTION
Added property metric for datastore :
"datastore|hostcount"
If datastore|hostcount does not match host  property: "config|storageDevice|multipathInfo|numberofActivePath" we have a host to datastore connection issue.