### PR TITLE
[cronus]: introduce a dedicated cronus_monitoring user

### DIFF
--- a/openstack/cronus-seed/templates/seed.yaml
+++ b/openstack/cronus-seed/templates/seed.yaml
@@ -43,11 +43,16 @@ spec:
         - name: cronus
           description: Cronus Service
           password: '{{ $.Values.global.cronus_service_password }}'
+    - name: Default
+      users:
+        - name: cronus_monitoring
+          description: Cronus Monitoring
+          password: '{{ $.Values.global.cronus_monitoring_password }}'
     - name: monsoon3
       projects:
       - name: cronus-simulator
         role_assignments:
-        - user: cronus@Default
+        - user: cronus_monitoring@Default
           role: email_admin # for monitoring
     - name: ccadmin
       projects:
@@ -55,7 +60,7 @@ spec:
         role_assignments:
         - user: cronus@Default
           role: keymanager_admin # to manage Barbican secrets
-        - user: cronus@Default
+        - user: cronus_monitoring@Default
           role: email_admin # for monitoring and system accounts
         swift:
           enabled: true


### PR DESCRIPTION
We'd like to have a dedicated system user for functional tests, monitoring and alerts. This user should work in ccadmin/master scope and be a credentials owner for sentry/netbox notification. We don't want to use an AD technical user, since its password may be expired and the whole monitoring system will crash.

Let me know if you have objections or suggestions.