### PR TITLE
[hermes]: introduce a new policy for cluster scope

### DIFF
--- a/openstack/hermes/files/policy.json
+++ b/openstack/hermes/files/policy.json
@@ -2,9 +2,10 @@
   "project_scope": "project_id:%(project_id)s",
   "domain_scope": "domain_id:%(domain_id)s",
 
+  "cluster_viewer": "project_domain_name:ccadmin and project_name:cloud_admin",
   "domain_viewer":  "rule:domain_scope and role:audit_viewer",
-  "project_viewer": "rule:domain_viewer or (rule:project_scope and role:audit_viewer)",
+  "project_viewer": "rule:project_scope and role:audit_viewer",
 
-  "event:list":     "rule:project_viewer",
-  "event:show":     "rule:project_viewer"
+  "event:list":     "rule:project_viewer or rule:domain_viewer or rule:cluster_viewer",
+  "event:show":     "rule:project_viewer or rule:domain_viewer or rule:cluster_viewer"
 }


### PR DESCRIPTION
Implements the indexID override, introduced in https://github.com/sapcc/hermes/pull/51