### PR TITLE
[cronus]: enable PROXY protocol support

### DIFF
--- a/openstack/cronus/files/nginx.tmpl
+++ b/openstack/cronus/files/nginx.tmpl
@@ -723,9 +723,30 @@ stream {
         }
     }
 
+    # TCP services
+    {{ range $tcpServer := .TCPBackends }}
     server {
-        listen                465 ssl;
-        proxy_pass            cronus-service:1025;
+        preread_by_lua_block {
+            ngx.var.proxy_upstream_name="tcp-{{ $tcpServer.Backend.Namespace }}-{{ $tcpServer.Backend.Name }}-{{ $tcpServer.Backend.Port }}";
+        }
+
+        {{ range $address := $all.Cfg.BindAddressIpv4 }}
+        listen                  {{ $address }}:{{ $tcpServer.Port }}{{ if $tcpServer.Backend.ProxyProtocol.Decode }} proxy_protocol{{ end }} ssl;
+        {{ else }}
+        listen                  {{ $tcpServer.Port }}{{ if $tcpServer.Backend.ProxyProtocol.Decode }} proxy_protocol{{ end }} ssl;
+        {{ end }}
+        {{ if $IsIPV6Enabled }}
+        {{ range $address := $all.Cfg.BindAddressIpv6 }}
+        listen                  {{ $address }}:{{ $tcpServer.Port }}{{ if $tcpServer.Backend.ProxyProtocol.Decode }} proxy_protocol{{ end }} ssl;
+        {{ else }}
+        listen                  [::]:{{ $tcpServer.Port }}{{ if $tcpServer.Backend.ProxyProtocol.Decode }} proxy_protocol{{ end }} ssl;
+        {{ end }}
+        {{ end }}
+        proxy_timeout           {{ $cfg.ProxyStreamTimeout }};
+        proxy_pass              upstream_balancer;
+        {{ if $tcpServer.Backend.ProxyProtocol.Encode }}
+        proxy_protocol          on;
+        {{ end }}
 
         ssl_certificate         /etc/ingress-controller/ssl/cronus/tls.crt;
         ssl_certificate_key     /etc/ingress-controller/ssl/cronus/tls.key;
@@ -751,32 +772,6 @@ stream {
         {{ end }}
 
         ssl_ecdh_curve {{ $cfg.SSLECDHCurve }};
-    }
-
-    # TCP services
-    {{ range $tcpServer := .TCPBackends }}
-    server {
-        preread_by_lua_block {
-            ngx.var.proxy_upstream_name="tcp-{{ $tcpServer.Backend.Namespace }}-{{ $tcpServer.Backend.Name }}-{{ $tcpServer.Backend.Port }}";
-        }
-
-        {{ range $address := $all.Cfg.BindAddressIpv4 }}
-        listen                  {{ $address }}:{{ $tcpServer.Port }}{{ if $tcpServer.Backend.ProxyProtocol.Decode }} proxy_protocol{{ end }};
-        {{ else }}
-        listen                  {{ $tcpServer.Port }}{{ if $tcpServer.Backend.ProxyProtocol.Decode }} proxy_protocol{{ end }};
-        {{ end }}
-        {{ if $IsIPV6Enabled }}
-        {{ range $address := $all.Cfg.BindAddressIpv6 }}
-        listen                  {{ $address }}:{{ $tcpServer.Port }}{{ if $tcpServer.Backend.ProxyProtocol.Decode }} proxy_protocol{{ end }};
-        {{ else }}
-        listen                  [::]:{{ $tcpServer.Port }}{{ if $tcpServer.Backend.ProxyProtocol.Decode }} proxy_protocol{{ end }};
-        {{ end }}
-        {{ end }}
-        proxy_timeout           {{ $cfg.ProxyStreamTimeout }};
-        proxy_pass              upstream_balancer;
-        {{ if $tcpServer.Backend.ProxyProtocol.Encode }}
-        proxy_protocol          on;
-        {{ end }}
     }
     {{ end }}
 

--- a/openstack/cronus/templates/cronus/_config.yaml.tpl
+++ b/openstack/cronus/templates/cronus/_config.yaml.tpl
@@ -12,6 +12,9 @@ cronus:
   listenAddr:
     http: :{{ .Values.cronus.http }} # default :5000
     smtp: :{{ .Values.cronus.smtp }} # default :1025
+{{- if .Values.cronus.listenProxyProtocol }}
+    proxyProtocol: {{ .Values.cronus.listenProxyProtocol }}
+{{- end }}
   keystone:
 {{- if .Values.config.keystone }}
 {{- range $key, $value := .Values.config.keystone }}

--- a/openstack/cronus/values.yaml
+++ b/openstack/cronus/values.yaml
@@ -4,6 +4,7 @@ cronus:
   cacheSize: 256
   http: 5000
   smtp: 1025
+  listenProxyProtocol: false
   debug: true
   tls: tls-secret
   image:
@@ -157,8 +158,11 @@ service:
 # nginx values
 ingress-nginx:
   tcp:
-    465: ""
+    465: cronus/cronus-service:1025
   controller:
+    # pod annotations are needed to recreate nginx pods on template update
+    podAnnotations:
+      recreate: proxyProtocol
     containerPort:
       http: 80
       https: 443
@@ -175,7 +179,6 @@ ingress-nginx:
       nodePorts:
         http: ""
         https: ""
-        465-tcp: ""
     ingressClass: cronus-nginx
     admissionWebhooks:
       enabled: false


### PR DESCRIPTION
This will enable cronus SMTP listener to get an info about the real client IP address