### PR TITLE
[Octavia] Don't fall back to deriving master password

### DIFF
--- a/openstack/octavia/ci/test-values.yaml
+++ b/openstack/octavia/ci/test-values.yaml
@@ -1,7 +1,7 @@
 global:
   registry: myRegistry
   dbPassword: secret!
-  master_password: topSecret!
+  octavia_service_password: topSecret!
 
 imageVersion: train
 

--- a/openstack/octavia/ci/test-values.yaml
+++ b/openstack/octavia/ci/test-values.yaml
@@ -1,7 +1,8 @@
 global:
   registry: myRegistry
   dbPassword: secret!
-  octavia_service_password: topSecret!
+  master_password: topSecret!
+  octavia_service_password: topSecret!!
 
 imageVersion: train
 

--- a/openstack/octavia/templates/etc/_octavia.conf.tpl
+++ b/openstack/octavia/templates/etc/_octavia.conf.tpl
@@ -73,7 +73,7 @@ project_name = service
 project_domain_id = default
 user_domain_id = default
 username = {{ .Release.Name }}{{ .Values.global.user_suffix }}
-password = {{ .Values.global.octavia_service_password | default (tuple . .Release.Name | include "identity.password_for_user") | replace "$" "" }}
+password = {{ .Values.global.octavia_service_password | replace "$" "" }}
 
 [keystone_authtoken]
 auth_type = v3password
@@ -82,7 +82,7 @@ auth_interface = internal
 www_authenticate_uri = https://{{include "keystone_api_endpoint_host_public" .}}/v3
 auth_url = {{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3
 username = {{ .Release.Name }}{{ .Values.global.user_suffix }}
-password = {{ .Values.global.octavia_service_password | default (tuple . .Release.Name | include "identity.password_for_user") | replace "$" "" }}
+password = {{ .Values.global.octavia_service_password | replace "$" "" }}
 user_domain_id = default
 project_name = service
 project_domain_id = default

--- a/openstack/octavia/templates/octavia-seed.yaml
+++ b/openstack/octavia/templates/octavia-seed.yaml
@@ -39,7 +39,7 @@ spec:
     users:
     - name: octavia
       description: 'Octavia Service'
-      password: {{ .Values.global.octavia_service_password | default (tuple . .Release.Name | include "identity.password_for_user") | replace "$" "" | quote }}
+      password: {{ .Values.global.octavia_service_password | replace "$" "" | quote }}
       role_assignments:
       - project: service
         role: service


### PR DESCRIPTION
Octavia didn't use service passwords before, but derived its passwords from the master password.