### PR TITLE
[nova] Prepare accessing Ironic via nova user

### DIFF
--- a/openstack/nova/templates/seed.yaml
+++ b/openstack/nova/templates/seed.yaml
@@ -25,6 +25,7 @@ spec:
   - name: cloud_compute_admin
   - name: cloud_network_admin
   - name: cloud_volume_admin
+  - name: cloud_baremetal_admin
 
   services:
   - name: nova
@@ -89,6 +90,8 @@ spec:
         role: cloud_network_admin
       - project: service
         role: cloud_compute_admin
+      - project: service
+        role: cloud_baremetal_admin
     - name: nova_nanny{{ .Values.global.user_suffix | default "" }}
       description: Nova Nanny
       password: {{ tuple . "nova_nanny" | include "identity.password_for_user" | quote }}


### PR DESCRIPTION
Instead of using the ironic service user to access Ironic, we want to
use the nova service, because that makes it easier to deploy new ironic
user passwords. This will be done in 2 steps:
1) give the nova service user the appropirate roles to be baremetal admin
2) change the username/password to use the nova user

This is step 1).