### PR TITLE
Monitor configured NTP servers (fqdn) for audit purposes

### DIFF
--- a/prometheus-exporters/network-generic-ssh-exporter/templates/_config.yaml.tpl
+++ b/prometheus-exporters/network-generic-ssh-exporter/templates/_config.yaml.tpl
@@ -192,6 +192,26 @@ metrics:
     command: show platform hardware qfp active classification class-group-manager class-Group client nat 1001 | include ^class-group
     timeout_secs: 5
 
+  nx_ntp_configured:
+    regex: >-
+      ^ntp server (\S+) .+?$
+    multi_value: true
+    value: $1
+    description: Configured DNS Severs by dns name.
+    metric_type_name: string
+    command: show running-config ntp | include "ntp server"
+    timeout_secs: 5
+
+  xe_ntp_configured:
+    regex: >-
+      ^\s+ntp server vrf \S+ (\S+) .+?$
+    multi_value: true
+    value: $1
+    description: Configured DNS Severs by dns name.
+    metric_type_name: string
+    command: show ntp config
+    timeout_secs: 5
+
 batches:
   neutron-router:
     - nat_dynamic
@@ -215,7 +235,17 @@ batches:
     - qfp_classification_ce_data_nat_1001_classes
     - qfp_classification_client_nat_1001_classes
 
+  cisco-nx-os_core-router:
+    - nx_ntp_configured
+
+  cisco-ios-xe_core-router:
+    - xe_ntp_configured
+
+
 devices:
   cisco-ios-xe:
     prompt_regex: ^\S+\#$
+    init_command: terminal length 0
+  cisco-nx-os:
+    prompt_regex: ^\S+\# $
     init_command: terminal length 0

--- a/system/infra-monitoring/vendor/atlas/templates/configmap.yaml
+++ b/system/infra-monitoring/vendor/atlas/templates/configmap.yaml
@@ -73,7 +73,7 @@ data:
             - custom_labels: 
                 batch: "cisco-nx-os_core-router"  
                 job: "network/ssh"
-                credential: "radius"
+                credential: "default"
                 device: "cisco-nx-os"
               metrics_label: "corerouter"
               role: "core-router"

--- a/system/infra-monitoring/vendor/atlas/templates/configmap.yaml
+++ b/system/infra-monitoring/vendor/atlas/templates/configmap.yaml
@@ -59,6 +59,30 @@ data:
               status: "active"
 
             - custom_labels: 
+                batch: "cisco-ios-xe_core-router"  
+                job: "network/ssh"
+                credential: "default"
+                device: "cisco-ios-xe"
+              metrics_label: "corerouter"
+              role: "core-router"
+              platform: "cisco-ios-xe"
+              target: 1
+              region: "{{ .Values.global.region }}"
+              status: "active"
+
+            - custom_labels: 
+                batch: "cisco-nx-os_core-router"  
+                job: "network/ssh"
+                credential: "radius"
+                device: "cisco-nx-os"
+              metrics_label: "corerouter"
+              role: "core-router"
+              platform: "cisco-nx-os"
+              target: 1
+              region: "{{ .Values.global.region }}"
+              status: "active"
+
+            - custom_labels: 
                 module: "vmware-esxi"
                 job: "vmware-esxi"
               target: 2


### PR DESCRIPTION
For audit purposes there needs to be a continuous monitoring of the configured NTP servers. We do that utilising OS specific commands on the ssh_exporter. The atlas SD has to be expanded to include core routers, with different parameters per OS.
