### PR TITLE
[Cinder]  Remove the cinder nanny from seed

### DIFF
--- a/openstack/cinder/templates/seed.yaml
+++ b/openstack/cinder/templates/seed.yaml
@@ -56,9 +56,6 @@ spec:
   domains:
   - name: Default
     users:
-    - name: cinder_nanny{{ .Values.global.user_suffix | default "" }}
-      description: Cinder Nanny
-      password: {{ derivePassword 1 "long" .Values.global.master_password "cinder_nanny" (include "keystone_api_endpoint_host_public" .) | quote }}
     - name: cinder
       description: Cinder Service
       password: '{{.Values.global.cinder_service_password}}'


### PR DESCRIPTION
This patch removes the cinder nanny from the cinder seed template
as it already exists in the nannies chart.