### PR TITLE
[Cinder] remove cinder_nanny seeder roles

### DIFF
--- a/openstack/cinder/templates/seed.yaml
+++ b/openstack/cinder/templates/seed.yaml
@@ -85,13 +85,6 @@ spec:
       - user: admin@Default
         role: cloud_volume_admin
       # permission to enumerate all projects and domains
-      - user: cinder_nanny{{ .Values.global.user_suffix | default "" }}@Default
-        role: admin
-      # permission to manage all ressources checked by the nanny
-      - user: cinder_nanny{{ .Values.global.user_suffix | default "" }}@Default
-        role: cloud_volume_admin
-      - user: cinder_nanny{{ .Values.global.user_suffix | default "" }}@Default
-        role: cloud_compute_admin
     groups:
     - name: CCADMIN_CLOUD_ADMINS
       role_assignments:


### PR DESCRIPTION
This patch removes the dependent cinder_nanny user role assignments
for the seeder.  These are done in the nannies charts now.