### PR TITLE
[cinder] Add configmap hashes as annotations

### DIFF
--- a/openstack/cinder/templates/vcenter_datacenter_cinder_deployment.yaml
+++ b/openstack/cinder/templates/vcenter_datacenter_cinder_deployment.yaml
@@ -34,6 +34,9 @@ template: |
           application: cinder
           component: volume-vmware
           name: cinder-volume-vmware-{= name =}
+        annotations:
+          configmap-etc-hash: {{ include (print .Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
+          configmap-cinder-volume-hash: {= "vcenter_datacenter/{{ .Release.Namespace }}/vcenter-datacenter-cinder-configmap.yaml.j2" | render | sha256sum =}
       spec:
         hostname: cinder-volume-vmware-{= name =}
 {{ tuple "{= availability_zone =}" | include "kubernetes_pod_az_affinity" | indent 8 }}


### PR DESCRIPTION
This should make the cinder-volume pods restart if one of their
configmaps changes, but the deployment doesn't. This follows the
principle already in use by Nova.