### PR TITLE
[swift] increase nginx proxy timeout

### DIFF
--- a/openstack/swift/templates/_utils.tpl
+++ b/openstack/swift/templates/_utils.tpl
@@ -339,8 +339,8 @@ location / {
     proxy_request_buffering off;
     # accept large PUT requests (5 GiB is the limit for a single object in Swift)
     client_max_body_size    5g;
-    proxy_send_timeout      {{ add $context.client_timeout 5 }};
-    proxy_read_timeout      {{ add $context.client_timeout 5 }};
+    proxy_send_timeout      {{ add $context.client_timeout $context.node_timeout 5 }};
+    proxy_read_timeout      {{ add $context.client_timeout $context.node_timeout 5 }};
 }
 {{- end -}}
 

--- a/openstack/swift/templates/etc/_proxy-server.conf.tpl
+++ b/openstack/swift/templates/etc/_proxy-server.conf.tpl
@@ -34,8 +34,8 @@ pipeline = catch_errors gatekeeper healthcheck proxy-logging cache listing_forma
 use = egg:swift#proxy
 allow_account_management = true
 account_autocreate = false
-node_timeout = 60
-recoverable_node_timeout = 10
+node_timeout = {{ $context.node_timeout }}
+recoverable_node_timeout = {{ $context.recoverable_node_timeout }}
 conn_timeout = 0.5
 sorting_method = shuffle
 {{- if $context.debug }}

--- a/openstack/swift/values.yaml
+++ b/openstack/swift/values.yaml
@@ -61,6 +61,12 @@ fallocate_reserve: 2%                  # Availably since Rocky for all servers
 # Swift client timeout in seconds.
 client_timeout: 60 # same as default, but also sets nginx timeout to a similar value
 
+# Swift node timeout in seconds, default 10
+node_timeout: 60
+
+# Swift node timeout in seconds for GET and HEAD, default 10
+recoverable_node_timeout: 10
+
 # Don't log requests to object, container or account servers
 log_requests: false
 


### PR DESCRIPTION
Esp. during high load situations, e.g. replication, there can be situations
where a proxy request calling out to its backend servers running in the
node_timeout. This leads to long runners and nginx timeout kicked in too
early. The result was a 504 for the client and a swift proxy request finishing
after that timeout.