### PR TITLE
[Swift] Split swift-etc-cluster ConfigMap

### DIFF
--- a/openstack/swift/templates/_utils.tpl
+++ b/openstack/swift/templates/_utils.tpl
@@ -49,6 +49,33 @@ checksum/object.ring: {{ include "swift/templates/object-ring.yaml" . | sha256su
 {{- end -}}
 
 {{- /**********************************************************************************/ -}}
+{{- define "swift_cluster_configmap" }}
+{{- $context := index . 0 -}}
+{{- $cluster_id := index . 1 -}}
+{{- $kind := index . 2 -}}
+{{- $cluster := index $context.Values.clusters $cluster_id -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: swift-etc-{{ $cluster_id }}-{{ $kind }}
+  labels:
+    system: openstack
+    service: objectstore
+    component: configuration
+
+data:
+  # nginx
+  nginx.conf: |
+{{ tuple $cluster $context.Values | include "nginx.conf" | indent 4 }}
+
+  # swift
+  container-sync-realms.conf: |
+{{ tuple $cluster $context.Values | include "container-sync-realms.conf" | indent 4 }}
+  proxy-server.conf: |
+{{ tuple $cluster $kind $context.Values $context.Release | include "proxy-server.conf" | indent 4 }}
+{{- end -}}
+
+{{- /**********************************************************************************/ -}}
 {{- define "swift_daemonset_volumes" }}
 - name: swift-etc
   configMap:
@@ -75,7 +102,8 @@ checksum/object.ring: {{ include "swift/templates/object-ring.yaml" . | sha256su
 
 {{- /**********************************************************************************/ -}}
 {{- define "swift_proxy_volumes" }}
-{{- $cluster := index . 0 }}
+{{- $kind := index . 0 -}}
+{{- $cluster := index . 1 }}
 - name: tls-secret
   secret:
     secretName: tls-swift-{{ $cluster }}
@@ -87,7 +115,7 @@ checksum/object.ring: {{ include "swift/templates/object-ring.yaml" . | sha256su
     name: swift-etc
 - name: swift-etc-cluster
   configMap:
-    name: swift-etc-{{ $cluster }}
+    name: swift-etc-{{ $cluster }}-{{ $kind }}
 - name: swift-account-ring
   configMap:
     name: swift-account-ring

--- a/openstack/swift/templates/etc/_proxy-server.conf.tpl
+++ b/openstack/swift/templates/etc/_proxy-server.conf.tpl
@@ -1,11 +1,12 @@
 {{- define "proxy-server.conf" -}}
 {{- $cluster := index . 0 -}}
-{{- $context := index . 1 -}}
-{{- $helm_release := index . 2 -}}
+{{- $kind := index . 1 -}}
+{{- $context := index . 2 -}}
+{{- $helm_release := index . 3 -}}
 [DEFAULT]
 bind_port = 8080
 # NOTE: value for prod, was 4 in staging before
-workers = 8
+workers = {{ (index $cluster (printf "proxy_%s_workers" $kind)) | default 4 }}
 user = swift
 expose_info = true
 # NOTE: value for prod, was 512 in staging before

--- a/openstack/swift/templates/etc/cluster-configmap.yaml
+++ b/openstack/swift/templates/etc/cluster-configmap.yaml
@@ -1,23 +1,6 @@
 {{- range $cluster_id, $cluster := .Values.clusters }}
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: swift-etc-{{$cluster_id}}
-  labels:
-    system: openstack
-    service: objectstore
-    component: configuration
-
-data:
-  # nginx
-  nginx.conf: |
-{{ tuple $cluster $.Values | include "nginx.conf" | indent 4 }}
-
-  # swift
-  container-sync-realms.conf: |
-{{ tuple $cluster $.Values | include "container-sync-realms.conf" | indent 4 }}
-  proxy-server.conf: |
-{{ tuple $cluster $.Values $.Release | include "proxy-server.conf" | indent 4 }}
-
+{{ tuple $ $cluster_id "daemonset" | include "swift_cluster_configmap" }}
+---
+{{ tuple $ $cluster_id "deployment" | include "swift_cluster_configmap" }}
 ---
 {{- end }}

--- a/openstack/swift/templates/proxy-daemonset.yaml
+++ b/openstack/swift/templates/proxy-daemonset.yaml
@@ -24,7 +24,7 @@ spec:
         restart: carefully
         os-cluster: {{ $cluster_id }}
       annotations:
-        checksum/swift-cluster.etc: {{ include "swift/templates/etc/cluster-configmap.yaml" $ | sha256sum }}
+        checksum/swift-cluster.etc: {{ tuple $ $cluster_id "daemonset" | include "swift_cluster_configmap" | sha256sum }}
         {{- include "swift_conf_annotations" $ | indent 8 }}
         checksum/swift.bin: {{ include "swift/templates/bin-configmap.yaml" $ | sha256sum }}
         {{- include "swift_ring_annotations" $ | indent 8 }}
@@ -39,7 +39,7 @@ spec:
       nodeSelector:
         species: {{ $.Values.species }}
       volumes:
-        {{- tuple $cluster_id | include "swift_proxy_volumes" | indent 8 }}
+        {{- tuple "daemonset" $cluster_id | include "swift_proxy_volumes" | indent 8 }}
       containers:
         {{- tuple "daemonset" $cluster $ | include "swift_proxy_containers" | indent 8 }}
 

--- a/openstack/swift/templates/proxy-deployment.yaml
+++ b/openstack/swift/templates/proxy-deployment.yaml
@@ -32,7 +32,7 @@ spec:
         from: deployment
         os-cluster: {{ $cluster_id }}
       annotations:
-        checksum/swift-cluster.etc: {{ include "swift/templates/etc/cluster-configmap.yaml" $ | sha256sum }}
+        checksum/swift-cluster.etc: {{ tuple $ $cluster_id "deployment" | include "swift_cluster_configmap" | sha256sum }}
         {{- include "swift_conf_annotations" $ | indent 8 }}
         checksum/swift.bin: {{ include "swift/templates/bin-configmap.yaml" $ | sha256sum }}
         {{- include "swift_ring_annotations" $ | indent 8 }}
@@ -64,7 +64,7 @@ spec:
                   - deployment
               topologyKey: "kubernetes.io/hostname"
       volumes:
-        {{- tuple $cluster_id | include "swift_proxy_volumes" | indent 8 }}
+        {{- tuple "deployment" $cluster_id | include "swift_proxy_volumes" | indent 8 }}
       containers:
         {{- tuple "deployment" $cluster $ | include "swift_proxy_containers" | indent 8 }}
 

--- a/openstack/swift/values.yaml
+++ b/openstack/swift/values.yaml
@@ -110,11 +110,13 @@ alerts:
 
 #     Swift proxies can be deployed as Deployment, Daemonset or both
 #     proxy_deployment_enabled: true
+#     proxy_deployment_workers: 4
 #     proxy_deployment_replicas_az-b: 2           # replicas in availability zone, default 0
 #     proxy_deployment_resources_cpu: "2500m"
 #     proxy_deployment_resources_memory: "1500Mi"
 
 #     proxy_daemonset_enabled: true
+#     proxy_daemonset_workers: 4
 #     proxy_daemonset_resources_cpu: "2500m"
 #     proxy_daemonset_resources_memory: "1500Mi"
 


### PR DESCRIPTION
Split swift-etc-cluster ConfigMap per OpenStack cluster and distinguish
between Deployment and Daemonset deploement option.
This allows to specify amount of workers to match the resource requests
and limits for Deployments and Daemonsets.

Calculated Checksum considers cluster and deplyoment option.