### PR TITLE
[cinder] Update the default rpc_response_timeout to 600

### DIFF
--- a/openstack/cinder/templates/etc/_cinder.conf.tpl
+++ b/openstack/cinder/templates/etc/_cinder.conf.tpl
@@ -26,7 +26,7 @@ api_paste_config = /etc/cinder/api-paste.ini
 
 auth_strategy = keystone
 
-rpc_response_timeout = {{ .Values.rpc_response_timeout | default .Values.global.rpc_response_timeout | default 300 }}
+rpc_response_timeout = {{ .Values.rpc_response_timeout | default .Values.global.rpc_response_timeout | default 600 }}
 rpc_workers = {{ .Values.rpc_workers | default .Values.global.rpc_workers | default 1 }}
 
 {{- if not .Values.api.use_uwsgi }}


### PR DESCRIPTION
This patch doubles the rpc_response_timeout.   All regions have
already been updated manually to 600.