### PR TITLE
[na cap exp] add critical alert for flexvols

### DIFF
--- a/prometheus-exporters/netapp-exporter/charts/netapp-cap-exporter/alerts/netapp-capacity.alerts
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-cap-exporter/alerts/netapp-capacity.alerts
@@ -108,10 +108,10 @@ groups:
           service: cinder
           context: netapp-usage
           dashboard: netapp-capacity-vpods?&var-region={{$labels.region}}&var-node={{$labels.node}}
-          meta: '{{ $value }}% used'
+          meta: 'Aggregate usage above the high usage level for this region'
           playbook: 'docs/support/playbook/cinder/balancing/cinder_balance_alert.html'
         annotations:
-          description: 'Storage Capacity Usage on node {{$labels.node}} in az {{$labels.availability_zone}} is high'
+          description: 'Storage Capacity Usage on node {{$labels.node}} in az {{$labels.availability_zone}} is above the high usage level for this region - currently at {{ $value }}%'
           summary: 'High Capacity Usage on {{$labels.filer}}'
 
       - alert: CinderStorageAggregateFull
@@ -122,50 +122,11 @@ groups:
           service: cinder
           context: netapp-usage
           dashboard: netapp-capacity-vpods?&var-region={{$labels.region}}&var-node={{$labels.node}}
-          meta: '{{ $value }}% used'
+          meta: 'Aggregate usage above 95%'
           playbook: 'docs/support/playbook/cinder/balancing/cinder_balance_alert.html'
         annotations:
-          description: 'Storage Capacity Usage on node {{$labels.node}} in az {{$labels.availability_zone}} is full'
+          description: 'Storage Capacity Usage on node {{$labels.node}} in az {{$labels.availability_zone}} is above 95% - currently at {{ $value }}%'
           summary: 'Nearly Full Capacity Usage on {{$labels.filer}}'
-
-#      - alert: CinderStorageAggregateGrowingFastTestAlertA
-#        expr: deriv(netapp_aggregate_used_percentage{aggregate="aggr_ssd_bb036_1"}[120m]) > 0.00025
-#        for: 30m
-#        labels:
-#          severity: info
-#          tier: os
-#          service: nanny
-#          context: nanny
-#          meta: 'TestalertA: Usage of aggregate {{$labels.aggregate}} is growing very fast'
-#        annotations:
-#          description: 'TestalertA: Usage of aggregate {{$labels.aggregate}} on filer {{$labels.filer}} in az {{$labels.availability_zone}} is growing very fast'
-#          summary: 'TestalertA: Aggregate {{$labels.filer}}/{{$labels.aggregate}} usage is growing very fast'
-
-#      - alert: CinderStorageAggregateGrowingFastTestAlertB
-#        expr: netapp_aggregate_used_percentage > 10 + min_over_time(netapp_aggregate_used_percentage[24h])
-#        for: 30m
-#        labels:
-#          severity: info
-#          tier: os
-#          service: nanny
-#          context: nanny
-#          meta: 'TestalertB: Usage of aggregate {{$labels.aggregate}} is growing very fast'
-#        annotations:
-#          description: 'TestalertB: Usage of aggregate {{$labels.aggregate}} on filer {{$labels.filer}} in az {{$labels.availability_zone}} is growing very fast'
-#          summary: 'TestalertB: Aggregate {{$labels.filer}}/{{$labels.aggregate}} usage is growing very fast'
-
-#      - alert: CinderStorageAggregateGettingFullFastTestAlert
-#        expr: predict_linear(netapp_aggregate_used_percentage[120m], 14400) > 90
-#        for: 30m
-#        labels:
-#          severity: info
-#          tier: os
-#          service: nanny
-#          context: nanny
-#          meta: 'Testalert: Usage of aggregate {{$labels.aggregate}} is growing very fast towards 90 percent'
-#        annotations:
-#          description: 'Testalert: Usage of aggregate {{$labels.aggregate}} on filer {{$labels.filer}} in az {{$labels.availability_zone}} is growing very fast and will reach 90 percent soon'
-#          summary: 'Testalert: Aggregate {{$labels.filer}}/{{$labels.aggregate}} will reach a usage of 90 percent soon'
 
       - alert: VVolDatastoreFlexvolHighUsage
         expr: netapp_volume_used_bytes{app="netapp-capacity-exporter-cinder", volume=~"vv.*"} / 1024/1024/1024 > 4600

--- a/prometheus-exporters/netapp-exporter/charts/netapp-cap-exporter/alerts/netapp-capacity.alerts
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-cap-exporter/alerts/netapp-capacity.alerts
@@ -109,7 +109,7 @@ groups:
           context: netapp-usage
           dashboard: netapp-capacity-vpods?&var-region={{$labels.region}}&var-node={{$labels.node}}
           meta: '{{ $value }}% used'
-          playbook: 'docs/support/playbook/cinder/cinder_storage_aggregate_full.html'
+          playbook: 'docs/support/playbook/cinder/balancing/cinder_balance_alert.html'
         annotations:
           description: 'Storage Capacity Usage on node {{$labels.node}} in az {{$labels.availability_zone}} is high'
           summary: 'High Capacity Usage on {{$labels.filer}}'
@@ -123,7 +123,7 @@ groups:
           context: netapp-usage
           dashboard: netapp-capacity-vpods?&var-region={{$labels.region}}&var-node={{$labels.node}}
           meta: '{{ $value }}% used'
-          playbook: 'docs/support/playbook/cinder/cinder_storage_aggregate_full.html'
+          playbook: 'docs/support/playbook/cinder/balancing/cinder_balance_alert.html'
         annotations:
           description: 'Storage Capacity Usage on node {{$labels.node}} in az {{$labels.availability_zone}} is full'
           summary: 'Nearly Full Capacity Usage on {{$labels.filer}}'
@@ -175,7 +175,20 @@ groups:
           tier: os
           service: nanny
           meta: 'VVol flex-volume usage over 90 percent of 5 TB'
-          playbook: 'docs/support/playbook/cinder/cinder_storage_aggregate_full.html'
+          playbook: 'docs/support/playbook/cinder/balancing/cinder_balance_alert.html'
         annotations:
           description: 'Usage of VVol flex-volume {{$labels.volume}} on filer {{$labels.filer}} in az {{$labels.availability_zone}} is {{ $value }} GiB'
           summary: 'Flex-volume {{$labels.filer}}/{{$labels.volume}} usage larger than 90 percent of 5TB'
+          
+      - alert: VVolDatastoreFlexvolCriticalUsage
+        expr: netapp_volume_used_bytes{app="netapp-capacity-exporter-cinder", volume=~"vv.*"} / 1024/1024/1024 > 8700
+        for: 3h
+        labels:
+          severity: critical
+          tier: os
+          service: nanny
+          meta: 'VVol flex-volume usage over 8.5TB'
+          playbook: 'docs/support/playbook/cinder/balancing/cinder_balance_alert.html'
+        annotations:
+          description: 'Usage of VVol flex-volume {{$labels.volume}} on filer {{$labels.filer}} in az {{$labels.availability_zone}} is {{ $value }} GiB'
+          summary: 'Flex-volume {{$labels.filer}}/{{$labels.volume}} usage larger than 8.5TB'


### PR DESCRIPTION
add a critical alert when flexvols reach 8.5tb usage and use a new playbook

@chuan137 - please wait with pulling this in and rolling it out