### PR TITLE
[cinder] add name to resource filter

### DIFF
--- a/openstack/cinder/templates/etc/_resource_filters.json.tpl
+++ b/openstack/cinder/templates/etc/_resource_filters.json.tpl
@@ -1,5 +1,5 @@
 {
-    "volume": ["name~", "status", "metadata",
+    "volume": ["name", "name~", "status", "metadata",
                "bootable", "migration_status", "availability_zone",
                "group_id", "user_id"],
     "backup": ["name", "status", "volume_id"],

--- a/openstack/cinder/templates/etc/_resource_filters.json.tpl
+++ b/openstack/cinder/templates/etc/_resource_filters.json.tpl
@@ -3,7 +3,7 @@
                "bootable", "migration_status", "availability_zone",
                "group_id", "user_id"],
     "backup": ["name", "status", "volume_id"],
-    "snapshot": ["name~", "status", "volume_id", "metadata",
+    "snapshot": ["name", "name~", "status", "volume_id", "metadata",
                  "availability_zone"],
     "group": [],
     "group_snapshot": ["status", "group_id"],


### PR DESCRIPTION
This patch updates cinder's resource_filters.json
file to include name in the volume filter keys.
The train release removed a deprecated feature
that causes the openstack client to not filter
volumes correctly as it doesn't support microversions
in the cinder api.