### PR TITLE
[Multicloudtest] Adds regional test configuration

### DIFF
--- a/system/multicloudtest/templates/config.yaml
+++ b/system/multicloudtest/templates/config.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: multicloudtest-config
+data:
+  config.yaml: |
+    log_level: INFO
+    hyperscalers:
+      gcp:
+        path: modules.hyperscalers.gcp.GCP
+        specifics:
+          region: {{.Values.multicloudtest.clouds.gcp.region | quote}}
+          zone: {{.Values.multicloudtest.clouds.gcp.zone | quote}}
+          vm_username: "ubuntu"
+          project: "sap-gcs-cc-rdqual-qa"
+          image_project: "ubuntu-os-cloud"
+          image: "ubuntu-2004-lts"
+          machine_type: "e2-micro"
+      azure:
+        path: modules.hyperscalers.azure.Azure
+        specifics:
+          resource_group_name_base: "cc-multicloudtest"
+          source_ip_ranges: {{ toYaml  .Values.multicloudtest.nat_ip_ranges | nindent 12}}
+          storage_device_name: 12
+          location: {{.Values.multicloudtest.clouds.azure.region | quote}}
+          vm_username : "multicloudtest_user"
+          ubuntu_image_version: 20_04-lts-gen2
+          vm_profile: Standard_DS1_v2
+      aws:
+        path: modules.hyperscalers.aws.AWS
+        specifics:
+          ami_image_id: {{.Values.multicloudtest.clouds.aws.ami_id | quote}}
+          instance_type: "t2.micro"
+          region_name: {{.Values.multicloudtest.clouds.aws.region | quote}}
+          availability_zone: {{.Values.multicloudtest.clouds.aws.zone | quote}}
+          vm_username : "ubuntu"
+          storage_device_name: "xvdf"

--- a/system/multicloudtest/templates/cronjob.yaml
+++ b/system/multicloudtest/templates/cronjob.yaml
@@ -29,7 +29,7 @@ spec:
             - tests/test_{{ $test }}.py
             - --backend={{ $cloud.name }}
             - --config
-            - testconfig.yaml
+            - /config/testconfig.yaml
             - --pushgateway
             - {{ $mct.pushgateway }}:9091
             env:
@@ -45,10 +45,17 @@ spec:
               - mountPath: /config
                 name: creds
                 readOnly: true
+              - mountPath: /config
+                name: config
+                subpath: testconfig.yaml
           volumes:
             - secret:
                 secretName: multicloudtest-creds-{{ $cloud.name }}
               name: creds
+            - configMap:
+                name: multicloudtest-config
+              name: config
+
           restartPolicy: Never
 {{- end }}
 {{- end }}

--- a/system/multicloudtest/templates/cronjob.yaml
+++ b/system/multicloudtest/templates/cronjob.yaml
@@ -29,7 +29,7 @@ spec:
             - tests/test_{{ $test }}.py
             - --backend={{ $cloud.name }}
             - --config
-            - /config/testconfig.yaml
+            - /config/config.yaml
             - --pushgateway
             - {{ $mct.pushgateway }}:9091
             env:
@@ -47,7 +47,7 @@ spec:
                 readOnly: true
               - mountPath: /config
                 name: config
-                subpath: testconfig.yaml
+                subpath: config.yaml
           volumes:
             - secret:
                 secretName: multicloudtest-creds-{{ $cloud.name }}
@@ -55,7 +55,6 @@ spec:
             - configMap:
                 name: multicloudtest-config
               name: config
-
           restartPolicy: Never
 {{- end }}
 {{- end }}

--- a/system/multicloudtest/values.yaml
+++ b/system/multicloudtest/values.yaml
@@ -19,6 +19,7 @@ multicloudtest:
   clouds:
     azure:
       name: azure
+      region: DEFINED-IN-REGION
       tests: DEFINED-IN-REGION
       creds_json: DEFINED-IN-REGION
       env:
@@ -26,6 +27,8 @@ multicloudtest:
           value: "/config/creds.json"
     gcp:
       name: gcp
+      region: DEFINED-IN-REGION
+      zone: DEFINED-IN-REGION
       tests: DEFINED-IN-REGION
       creds_json: DEFINED-IN-REGION
       env:
@@ -33,6 +36,8 @@ multicloudtest:
           value: "/config/creds.json"
     aws:
       name: aws
+      region: DEFINED-IN-REGION
+      zone: DEFINED-IN-REGION
       tests: DEFINED-IN-REGION
       creds_json: DEFINED-IN-REGION
       env:
@@ -40,6 +45,9 @@ multicloudtest:
           value: DEFINED-IN-REGION
         - name: AWS_ACCESS_KEY_ID
           value: DEFINED-IN-REGION
+      ami_id: DEFINED-IN-REGION
+  nat_ip_ranges:
+    - DEFINED-IN-REGION
 global:
   domain: cloud.sap
   region: DEFINED-IN-REGION


### PR DESCRIPTION
- Additional config map that holds the test configuration for all hyperscaler in one region.
- Regions, Zone, NAT IPs and other region specifics are configured via secrets
- Mounted into the same directory as other config files, adapted the run command