### PR TITLE
nova/flavors: Introduce new g/c/m naming scheme

### DIFF
--- a/openstack/nova/templates/flavor-seed.yaml
+++ b/openstack/nova/templates/flavor-seed.yaml
@@ -4,50 +4,5 @@ kind: "OpenstackSeed"
 metadata:
   name: nova-flavor-seed
 spec:
-  flavors:
-  - name: "m1.tiny"
-    id: "10"
-    vcpus: 1
-    ram: 508
-    disk: 1
-    is_public: true
-    extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "4"
-  - name: "m1.small"
-    id: "20"
-    vcpus: 2
-    ram: 2032
-    disk: 16
-    is_public: true
-    extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
-  - name: "m1.medium"
-    id: "30"
-    vcpus: 4
-    ram: 4080
-    disk: 64
-    is_public: true
-    extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
-  - name: "m1.large"
-    id: "40"
-    vcpus: 4
-    ram: 8176
-    disk: 64
-    is_public: true
-    extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
-  - name: "m1.xlarge"
-    id: "50"
-    vcpus: 4
-    ram: 16368
-    disk: 64
-    is_public: true
-    extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
+  flavors: []  # see ../../sap-seeds/templates/flavor-seed.yaml instead
 {{- end }}

--- a/openstack/sap-seeds/templates/flavor-seed.yaml
+++ b/openstack/sap-seeds/templates/flavor-seed.yaml
@@ -6,6 +6,15 @@ spec:
   requires:
   - monsoon3/nova-flavor-seed
   flavors:
+  - name: "m1.tiny"
+    id: "10"
+    vcpus: 1
+    ram: 508
+    disk: 1
+    is_public: true
+    extra_specs:
+      "vmware:hv_enabled": "True"
+      "hw_video:ram_max_mb": "4"
   - name: "m1.xsmallcpuhdd"
     id: "19"
     vcpus: 1
@@ -64,6 +73,33 @@ spec:
     id: "32"
     vcpus: 2
     ram: 8176
+    disk: 64
+    is_public: true
+    extra_specs:
+      "vmware:hv_enabled": "True"
+      "hw_video:ram_max_mb": "16"
+  - name: "m1.medium"
+    id: "30"
+    vcpus: 4
+    ram: 4080
+    disk: 64
+    is_public: true
+    extra_specs:
+      "vmware:hv_enabled": "True"
+      "hw_video:ram_max_mb": "16"
+  - name: "m1.large"
+    id: "40"
+    vcpus: 4
+    ram: 8176
+    disk: 64
+    is_public: true
+    extra_specs:
+      "vmware:hv_enabled": "True"
+      "hw_video:ram_max_mb": "16"
+  - name: "m1.xlarge"
+    id: "50"
+    vcpus: 4
+    ram: 16368
     disk: 64
     is_public: true
     extra_specs:

--- a/openstack/sap-seeds/templates/flavor-seed.yaml
+++ b/openstack/sap-seeds/templates/flavor-seed.yaml
@@ -15,51 +15,36 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "4"
-  - name: "m1.xsmallcpuhdd"
+  - name: "g_c1_m2"
     id: "19"
     vcpus: 1
     ram: 2032
-    disk: 40
+    disk: 64
     is_public: true
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-  - name: "m1.small"
+      "catalog:alias": "m1.xsmallcpuhdd"
+  - name: "c_c2_m2"
     id: "20"
     vcpus: 2
     ram: 2032
-    disk: 16
+    disk: 64
     is_public: true
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-  - name: "m1.smallhdd"
-    id: "21"
-    vcpus: 2
-    ram: 2032
-    disk: 40
-    is_public: true
-    extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
-  - name: "m1.xsmall"
+      "catalog:alias": "m1.small,m1.smallhdd"
+  - name: "g_c2_m4"
     id: "22"
     vcpus: 2
     ram: 4080
-    disk: 32
+    disk: 64
     is_public: true
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-  - name: "m1.xsmallhdd"
-    id: "23"
-    vcpus: 2
-    ram: 4080
-    disk: 40
-    is_public: true
-    extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
+      "catalog:alias": "m1.xsmall,m1.xsmallhdd"
   - name: "g_c1_m3"
     id: "24"
     vcpus: 1
@@ -69,7 +54,7 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-  - name: "m1.xmedium"
+  - name: "g_c2_m8"
     id: "32"
     vcpus: 2
     ram: 8176
@@ -78,7 +63,8 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-  - name: "m1.medium"
+      "catalog:alias": "m1.xmedium"
+  - name: "c_c4_m4"
     id: "30"
     vcpus: 4
     ram: 4080
@@ -87,7 +73,8 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-  - name: "m1.large"
+      "catalog:alias": "m1.medium"
+  - name: "g_c4_m8"
     id: "40"
     vcpus: 4
     ram: 8176
@@ -96,7 +83,8 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-  - name: "m1.xlarge"
+      "catalog:alias": "m1.large"
+  - name: "g_c4_m16"
     id: "50"
     vcpus: 4
     ram: 16368
@@ -105,7 +93,8 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-  - name: "m1.xlarge_cpu"
+      "catalog:alias": "m1.xlarge"
+  - name: "c_c16_m16"
     id: "52"
     vcpus: 16
     ram: 16368
@@ -114,7 +103,8 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-  - name: "m1.2xlarge"
+      "catalog:alias": "m1.xlarge_cpu"
+  - name: "g_c8_m32"
     id: "60"
     vcpus: 8
     ram: 32752
@@ -123,7 +113,8 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-  - name: "m1.2xlargecpu"
+      "catalog:alias": "g_c8_m32"
+  - name: "g_c16_m32"
     id: "61"
     vcpus: 16
     ram: 32752
@@ -132,6 +123,7 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
+      "catalog:alias": "m1.2xlargecpu"
   - name: "g_c12_m48"
     id: "62"
     vcpus: 12
@@ -141,7 +133,7 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-  - name: "m1.4xlarge"
+  - name: "g_c16_m64"
     id: "70"
     vcpus: 16
     ram: 65520
@@ -150,6 +142,7 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
+      "catalog:alias": "m1.4xlarge"
   - name: "m1.10xlarge"
     id: "80"
     vcpus: 40
@@ -204,7 +197,7 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-  - name: "m2.large"
+  - name: "m_c4_m64"
     id: "100"
     vcpus: 4
     ram: 65520
@@ -213,7 +206,8 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-  - name: "m2.xlarge"
+      "catalog:alias": "m2.large"
+  - name: "g_c8_m16"
     id: "110"
     vcpus: 8
     ram: 16368
@@ -222,6 +216,7 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
+      "catalog:alias": "m2.xlarge"
   - name: "m2.2xlarge"
     id: "120"
     vcpus: 8
@@ -276,7 +271,7 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-  - name: "m2.4xlarge"
+  - name: "m_c8_m64"
     id: "140"
     vcpus: 8
     ram: 65520
@@ -285,7 +280,8 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-  - name: "m2.8xlarge"
+      "catalog:alias": "m2.4xlarge"
+  - name: "m_c16_m128"
     id: "160"
     vcpus: 16
     ram: 131056
@@ -294,6 +290,7 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
+      "catalog:alias": "m2.8xlarge"
   - name: "m2.16xlarge"
     id: "161"
     vcpus: 16
@@ -316,7 +313,7 @@ spec:
     id: "210"
     vcpus: 4
     ram: 16368
-    disk: 150
+    disk: 64
     is_public: false
     extra_specs:
       "vmware:hv_enabled": "True"
@@ -339,7 +336,7 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-  - name: "m5.16xlarge"
+  - name: "g_c64_m256"
     id: "220"
     vcpus: 64
     ram: 262128
@@ -348,7 +345,8 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-  - name: "m5.32xlarge"
+      "catalog:alias": "m5.16xlarge"
+  - name: "g_c128_m512"
     id: "230"
     vcpus: 128
     ram: 524272
@@ -357,6 +355,7 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
+      "catalog:alias": "m5.32xlarge"
   - name: "m5.48xlarge"
     id: "231"
     vcpus: 96

--- a/openstack/sap-seeds/templates/flavor-seed.yaml
+++ b/openstack/sap-seeds/templates/flavor-seed.yaml
@@ -374,6 +374,8 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
+
+  ### Deprecated BigVM flavors
   - name: "m5.96xlarge"
     id: "270"
     vcpus: 90
@@ -462,3 +464,123 @@ spec:
       "hw_video:ram_max_mb": "16"
       "host_fraction": "1"
       "resources:CUSTOM_BIGVM": "2"
+
+  ### HANA flavors
+  - name: "hana_c24_m365"
+    id: "200"
+    vcpus: 24
+    ram: 373744
+    disk: 64
+    extra_specs:
+      "vmware:hv_enabled": "True"
+      "hw_video:ram_max_mb": "16"
+      "resources:CUSTOM_MEMORY_RESERVABLE_MB": "373744"
+      "trait:CUSTOM_NUMASIZE_C48_M729": "required"
+  - name: "hana_c48_m729"
+    id: "201"
+    vcpus: 48
+    ram: 746480
+    disk: 64
+    extra_specs:
+      "vmware:hv_enabled": "True"
+      "hw_video:ram_max_mb": "16"
+      "resources:CUSTOM_MEMORY_RESERVABLE_MB": "746480"
+      "trait:CUSTOM_NUMASIZE_C48_M729": "required"
+  - name: "hana_c96_m1458"
+    id: "202"
+    vcpus: 96
+    ram: 1492976
+    disk: 64
+    extra_specs:
+      "vmware:hv_enabled": "True"
+      "hw_video:ram_max_mb": "16"
+      "resources:CUSTOM_MEMORY_RESERVABLE_MB": "1492976"
+      "resources:CUSTOM_BIGVM": "2"
+      "trait:CUSTOM_NUMASIZE_C48_M729": "required"
+  - name: "hana_c144_m2188"
+    id: "203"
+    vcpus: 144
+    ram: 2240496
+    disk: 64
+    extra_specs:
+      "vmware:hv_enabled": "True"
+      "hw_video:ram_max_mb": "16"
+      "resources:CUSTOM_MEMORY_RESERVABLE_MB": "2240496"
+      "resources:CUSTOM_BIGVM": "2"
+      "trait:CUSTOM_NUMASIZE_C48_M729": "required"
+  - name: "hana_c192_m2917"
+    id: "204"
+    vcpus: 192
+    ram: 2986992
+    disk: 64
+    extra_specs:
+      "vmware:hv_enabled": "True"
+      "hw_video:ram_max_mb": "16"
+      "resources:CUSTOM_MEMORY_RESERVABLE_MB": "2986992"
+      "resources:CUSTOM_BIGVM": "2"
+      "trait:CUSTOM_NUMASIZE_C48_M729": "required"
+  # - name: "hana_c384_m5835"
+  #   id: "205"
+  #   vcpus: 384
+  #   ram: 5975024
+  #   disk: 64
+  #   extra_specs:
+  #     "vmware:hv_enabled": "True"
+  #     "hw_video:ram_max_mb": "16"
+  #     "resources:CUSTOM_MEMORY_RESERVABLE_MB": "5975024"
+  #     "resources:CUSTOM_BIGVM": "2"
+  #     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
+  - name: "hana_c24_m729"
+    id: "206"
+    vcpus: 24
+    ram: 746480
+    disk: 64
+    extra_specs:
+      "vmware:hv_enabled": "True"
+      "hw_video:ram_max_mb": "16"
+      "resources:CUSTOM_MEMORY_RESERVABLE_MB": "746480"
+      "trait:CUSTOM_NUMASIZE_C48_M1459": "required"
+  - name: "hana_c48_m1459"
+    id: "207"
+    vcpus: 48
+    ram: 1494000
+    disk: 64
+    extra_specs:
+      "vmware:hv_enabled": "True"
+      "hw_video:ram_max_mb": "16"
+      "resources:CUSTOM_MEMORY_RESERVABLE_MB": "1494000"
+      "resources:CUSTOM_BIGVM": "2"
+      "trait:CUSTOM_NUMASIZE_C48_M1459": "required"
+  - name: "hana_c96_m2918"
+    id: "208"
+    vcpus: 96
+    ram: 2988016
+    disk: 64
+    extra_specs:
+      "vmware:hv_enabled": "True"
+      "hw_video:ram_max_mb": "16"
+      "resources:CUSTOM_MEMORY_RESERVABLE_MB": "2988016"
+      "resources:CUSTOM_BIGVM": "2"
+      "trait:CUSTOM_NUMASIZE_C48_M1459": "required"
+  - name: "hana_c144_m4377"
+    id: "209"
+    vcpus: 144
+    ram: 4482032
+    disk: 64
+    extra_specs:
+      "vmware:hv_enabled": "True"
+      "hw_video:ram_max_mb": "16"
+      "resources:CUSTOM_MEMORY_RESERVABLE_MB": "4482032"
+      "resources:CUSTOM_BIGVM": "2"
+      "trait:CUSTOM_NUMASIZE_C48_M1459": "required"
+  - name: "hana_c192_m5835"
+    id: "210"
+    vcpus: 192
+    ram: 5975024
+    disk: 64
+    extra_specs:
+      "vmware:hv_enabled": "True"
+      "hw_video:ram_max_mb": "16"
+      "resources:CUSTOM_MEMORY_RESERVABLE_MB": "5975024"
+      "resources:CUSTOM_BIGVM": "2"
+      "trait:CUSTOM_NUMASIZE_C48_M1459": "required"


### PR DESCRIPTION
**nova/flavors: Remove 15 discontinued flavors**

The discontinued BigVM flavors remain, until replaced with matching HANA flavors.

Some of the removed flavors will be replaced with new flavors in a later commit.

---

**nova/flavors: Move OS default flavors to sap-seed**

Move "m1.medium", "m1.large", "m1.xlarge" from nova to sap-seeds flavor-seed list, unifying the lists into one.

Two flavors where not moved but removed:
  - `m1.tiny` is discontinued
  - `m1.small` was a duplicate and already existed in the sap-seed.

---

**nova/flavors: Rename & alias flavors to g/c/m scheme**

Rename all public, non-hana-used flavors to the new naming scheme and add the old name(s) as "config:alias" extra_spec.

This effectively deprecates the old flavor names, however they will still appear in `openstack flavor list` but with a `flavorid` starting with `x_deprecated_`, and they will deploy as the new flavors. This allows automation to continue using the old names for now.

---

**nova/flavors: Add new HANA flavors with NUMA traits**

HANA flavors require a fitting `CUSTOM_NUMASIZE_*` trait, that can be applied to hosts that provide the appropriate NUMA node size.

`hana_c384_m5835` is commented out because it is dependent on an updated VSphere for supporting more than 256 vCPUs.