### PR TITLE
[Swift] support HAProxy builtin load balancing 

### DIFF
--- a/openstack/swift/templates/_utils.tpl
+++ b/openstack/swift/templates/_utils.tpl
@@ -400,7 +400,7 @@ limit_req_status 429;
 {{- $cluster := index . 1 }}
 option http-server-close
 
-{{ if and $cluster.upstreams -}}
+{{ if $cluster.upstreams -}}
 balance roundrobin
 option httpchk HEAD /healthcheck
 default-server check downinter 30s maxconn 500

--- a/openstack/swift/templates/_utils.tpl
+++ b/openstack/swift/templates/_utils.tpl
@@ -393,3 +393,23 @@ limit_req_status 429;
 {{- $release.Name -}}-sapcc-ratelimit-redis
 {{- end -}}
 {{- end -}}
+
+{{- /**********************************************************************************/ -}}
+{{- define "swift_haproxy_backend" -}}
+{{- $cluster_id := index . 0 -}}
+{{- $cluster := index . 1 }}
+option http-server-close
+
+{{ if and $cluster.upstreams -}}
+balance roundrobin
+option httpchk HEAD /healthcheck
+default-server check downinter 30s maxconn 500
+
+{{ range $index, $upstream := $cluster.upstreams -}}
+{{- $short_name := splitn "." 2  $upstream.name -}}
+server {{ printf "%9s" $short_name._0 }} {{ $upstream.target }}:{{ default 8080 $cluster.svc_node_port }} # {{ $upstream.name }}
+{{ end -}}
+{{- else -}}
+server swift-svc swift-proxy-internal-{{ $cluster_id }}:8080
+{{- end }}
+{{- end -}}

--- a/openstack/swift/templates/envoy-bin-configmap.yaml
+++ b/openstack/swift/templates/envoy-bin-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if $.Values.envoy_external }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,3 +11,4 @@ metadata:
 data:
   envoy-start: |
 {{ .Files.Get "bin/envoy-start" | indent 4 }}
+{{- end }}

--- a/openstack/swift/templates/envoy-deployment.yaml
+++ b/openstack/swift/templates/envoy-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if $.Values.envoy_external }}
 {{- range $cluster_id, $cluster := .Values.clusters }}
 {{- range $az := $.Values.global.availability_zones }}
 kind: Deployment
@@ -119,5 +120,6 @@ spec:
               containerPort: 9902
 
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/openstack/swift/templates/etc/_haproxy.cfg.tpl
+++ b/openstack/swift/templates/etc/_haproxy.cfg.tpl
@@ -1,7 +1,7 @@
 {{- define "haproxy.cfg" -}}
-{{- $cluster := index . 0 -}}
-{{- $context := index . 1 -}}
-{{- $upstream := index . 2 -}}
+{{- $cluster_id := index . 0 -}}
+{{- $cluster    := index . 1 -}}
+{{- $context    := index . 2 -}}
 global
   log stdout format raw local0 info
   zero-warning
@@ -9,6 +9,7 @@ global
   maxconn 2000
 
   # TODO: Should be replaced by https://ssl-config.mozilla.org/#server=haproxy&version=2.3&config=intermediate&openssl=1.1.1d&guideline=5.6
+  # AES256-SHA256 seems to be needed for iPXE with tlsv1.2
 
   # https://ssl-config.mozilla.org/#server=haproxy&version=2.3&config=old&openssl=1.1.1d&guideline=5.6
   # old configuration - this is for backward compatibility with nginx based deplyoments and poor clients like iPXE
@@ -66,13 +67,9 @@ frontend api-http
 # metrics. (The backend name shows up as a metric label.)
 
 backend swift_proxy
-  option http-server-close
-
-  server swift-svc {{ $upstream }}:8080
+{{- tuple $cluster_id $cluster | include "swift_haproxy_backend" | indent 2 }}
 
 backend swift_proxy_s3
-  option http-server-close
-
-  server swift-svc {{ $upstream }}:8080
+{{- tuple $cluster_id $cluster | include "swift_haproxy_backend" | indent 2 }}
 
 {{ end }}

--- a/openstack/swift/templates/etc/envoy-cluster-configmap.yaml
+++ b/openstack/swift/templates/etc/envoy-cluster-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if $.Values.envoy_external }}
 {{- range $cluster_id, $cluster := .Values.clusters }}
 apiVersion: v1
 kind: ConfigMap
@@ -13,4 +14,5 @@ data:
 {{ tuple $cluster $.Values (printf "swift-proxy-internal-%s.swift.svc" $cluster_id) | include "envoy.yaml" | indent 4 }}
 
 ---
+{{- end }}
 {{- end }}

--- a/openstack/swift/templates/etc/haproxy-cluster-configmap.yaml
+++ b/openstack/swift/templates/etc/haproxy-cluster-configmap.yaml
@@ -13,7 +13,7 @@ data:
 {{ include "swift/templates/etc/_dhparam.pem.tpl" . | indent 4 }}
 
   haproxy.cfg: |
-{{ tuple $cluster $.Values (printf "swift-proxy-internal-%s.swift.svc" $cluster_id) | include "haproxy.cfg" | indent 4 }}
+{{ tuple $cluster_id $cluster $.Values | include "haproxy.cfg" | indent 4 }}
 
 ---
 {{- end }}

--- a/openstack/swift/templates/proxy-deployment.yaml
+++ b/openstack/swift/templates/proxy-deployment.yaml
@@ -52,6 +52,17 @@ spec:
         failure-domain.beta.kubernetes.io/zone: {{ $az }}
       affinity:
         podAntiAffinity:
+          {{- if $cluster.svc_node_port }}
+          # Swift proxy is exposed as NodePort, do not run multiple proxies on one node
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: component
+                operator: In
+                values:
+                - swift-proxy-{{ $cluster_id }}
+            topologyKey: "kubernetes.io/hostname"
+          {{- else }}
           # Prefere to be scheduled on nodes not yet running this proxy from a deplyoment
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 1
@@ -67,6 +78,7 @@ spec:
                   values:
                   - deployment
               topologyKey: "kubernetes.io/hostname"
+          {{- end }}
       volumes:
         {{- tuple $cluster_id | include "swift_proxy_volumes" | indent 8 }}
       containers:

--- a/openstack/swift/templates/proxy-internal-service.yaml
+++ b/openstack/swift/templates/proxy-internal-service.yaml
@@ -7,11 +7,18 @@ metadata:
     release: "{{ $.Release.Name }}"
     os-cluster: {{ $cluster_id }}
 spec:
+  {{- if $cluster.svc_node_port }}
+  type: NodePort
+  externalTrafficPolicy: Local
+  {{- end }}
   selector:
     component: swift-proxy-{{ $cluster_id }}
   ports:
     - name: proxy
       port: 8080
       targetPort: 8080
+      {{- if $cluster.svc_node_port }}
+      nodePort: {{ $cluster.svc_node_port }}
+      {{- end }}
 ---
 {{- end }}

--- a/openstack/swift/values.yaml
+++ b/openstack/swift/values.yaml
@@ -121,6 +121,11 @@ alerts:
 #     swift_service_project_domain: Default
 #     swift_service_password: DEFINED_IN_REGION_CHART
 
+#     svc_node_port: expose swift internal proxy svc via NodePort, can be used to loadbalance between k8s nodes
+#     upstreams:
+#       -target: xxx.xxx.xxx.xxx
+#        name: node1
+
 #     Swift proxies can be deployed as Deployment, Daemonset or both
 #     proxy_deployment_enabled: true
 #     proxy_deployment_replicas_az-b: 2           # replicas in availability zone, default 0


### PR DESCRIPTION
Add support for NodePort on proxy-internal-service
* Optional NodePort for proxy internal service
* Proxy Deployment AntiAffinity will recognize this
* Mention option in `values.yaml`

HAProxy config to loadbalance swift proxies
* If multiple upstreams are defined, loadbalance them
* `/healthcheck` removes unavailable upstreams from loadbalancing
* check down servers only every 30s (allows specifying all k8s nodes in the cluster if NodePort is active on service)
* If none are defined, use k8s cluster internal DNS for the swift-proxy-internal service
* make upstream consumption a `define`

//cc @majewsky 