### PR TITLE
[keystone] Increase KeepAliveTimeout to fix keepalive requests

### DIFF
--- a/openstack/keystone/templates/etc/_wsgi-keystone.conf.tpl
+++ b/openstack/keystone/templates/etc/_wsgi-keystone.conf.tpl
@@ -39,6 +39,8 @@ CustomLog /dev/stdout proxy env=forwarded
     SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
     CustomLog /dev/stdout combined env=!forwarded
     CustomLog /dev/stdout proxy env=forwarded
+
+    KeepAliveTimeout 101
 </VirtualHost>
 
 Alias /identity /var/www/cgi-bin/keystone/keystone-wsgi-public


### PR DESCRIPTION
According to CCM-18723, sometimes keystone fails to respond, with the
following message logged at the ingress controller:

upstream prematurely closed connection while reading response header from upstream

As per https://trac.nginx.org/nginx/ticket/1484#comment:4, it
might be a known issue and increasing KeepAliveTimeout for
keystone-api's apache might help.