### PR TITLE
[neutron] create network agents per aPod

### DIFF
--- a/openstack/neutron/templates/configmap-etc-apod.yaml
+++ b/openstack/neutron/templates/configmap-etc-apod.yaml
@@ -13,53 +13,9 @@ metadata:
 data:
 {{ range $az_long, $apods := .Values.global.apods }}
 {{ range $k, $apod := $apods }}
-  ml2-conf-apod-{{ $apod }}.ini: |
-    [ml2]
-
-    # Changing type_drivers after bootstrap can lead to database inconsistencies
-    type_drivers = vlan,vxlan
-    tenant_network_types = vxlan,vlan
-    
-    mechanism_drivers = {{required "A valid .Values.ml2_mechanismdrivers required!" $.Values.ml2_mechanismdrivers}}
-
-    # Designate configuration
-    extension_drivers = {{required "A valid .Values.dns_ml2_extension required!" $.Values.dns_ml2_extension}}
-
-    path_mtu = {{ $.Values.global.default_mtu | default 9000 }}
-
-    [ml2_type_vlan]
-    network_vlan_ranges = {{ range $i, $aci_hostgroup := $.Values.aci.aci_hostgroups.hostgroups }}
-        {{- $physical_network := default $aci_hostgroup.name $aci_hostgroup.physical_network -}}
-        {{- $network_ranges := default $.Values.aci.aci_hostgroups.segment_ranges $aci_hostgroup.segment_ranges -}}
-
-        {{- if ne $i 0 }},{{ end -}}
-        {{- range $x, $range := $network_ranges -}}
-            {{- if ne $x 0 }},{{ end -}}
-            {{ $physical_network }}:{{ $range }}
-        {{- end -}}
-    {{- end }}
-
-    [ml2_type_vxlan]
-    vni_ranges = 10000:20000
-
-
-    [securitygroup]
-    firewall_driver = iptables_hybrid
-    enable_security_group=True
-    enable_ipset=True
-
-    [agent]
-    polling_interval=5
-    prevent_arp_spoofing = False
-
+  apod-{{ $apod }}.conf: |
     [linux_bridge]
     physical_interface_mappings = {{ $apod }}:{{required "A valid .Values.cp_network_interface required!" $.Values.cp_network_interface}}
-
-    [vxlan]
-    enable_vxlan = false
-
-    [ovs]
-    enable_tunneling=False
 {{- end }}
 {{- end }}
 {{- end }}

--- a/openstack/neutron/templates/configmap-etc-apod.yaml
+++ b/openstack/neutron/templates/configmap-etc-apod.yaml
@@ -1,0 +1,66 @@
+{{- if .Values.agent.apod | default false }}
+{{- if .Values.global.apods | default false }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: neutron-etc-apod
+  labels:
+    system: openstack
+    type: configuration
+    component: neutron
+
+
+data:
+{{ range $az_long, $apods := .Values.global.apods }}
+{{ range $k, $apod := $apods }}
+  ml2-conf-apod-{{ $apod }}.ini: |
+    [ml2]
+
+    # Changing type_drivers after bootstrap can lead to database inconsistencies
+    type_drivers = vlan,vxlan
+    tenant_network_types = vxlan,vlan
+    
+    mechanism_drivers = {{required "A valid .Values.ml2_mechanismdrivers required!" $.Values.ml2_mechanismdrivers}}
+
+    # Designate configuration
+    extension_drivers = {{required "A valid .Values.dns_ml2_extension required!" $.Values.dns_ml2_extension}}
+
+    path_mtu = {{ $.Values.global.default_mtu | default 9000 }}
+
+    [ml2_type_vlan]
+    network_vlan_ranges = {{ range $i, $aci_hostgroup := $.Values.aci.aci_hostgroups.hostgroups }}
+        {{- $physical_network := default $aci_hostgroup.name $aci_hostgroup.physical_network -}}
+        {{- $network_ranges := default $.Values.aci.aci_hostgroups.segment_ranges $aci_hostgroup.segment_ranges -}}
+
+        {{- if ne $i 0 }},{{ end -}}
+        {{- range $x, $range := $network_ranges -}}
+            {{- if ne $x 0 }},{{ end -}}
+            {{ $physical_network }}:{{ $range }}
+        {{- end -}}
+    {{- end }}
+
+    [ml2_type_vxlan]
+    vni_ranges = 10000:20000
+
+
+    [securitygroup]
+    firewall_driver = iptables_hybrid
+    enable_security_group=True
+    enable_ipset=True
+
+    [agent]
+    polling_interval=5
+    prevent_arp_spoofing = False
+
+    [linux_bridge]
+    physical_interface_mappings = {{ $apod }}:{{required "A valid .Values.cp_network_interface required!" $.Values.cp_network_interface}}
+
+    [vxlan]
+    enable_vxlan = false
+
+    [ovs]
+    enable_tunneling=False
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/openstack/neutron/templates/etc/_ml2-conf.ini.tpl
+++ b/openstack/neutron/templates/etc/_ml2-conf.ini.tpl
@@ -40,14 +40,7 @@ polling_interval=5
 prevent_arp_spoofing = False
 
 [linux_bridge]
-{{ if .Values.global.apods -}}
-physical_interface_mappings = {{ range $k, $apod := .Values.global.apods -}}
-    {{- if ne $k 0 -}},{{- end -}}
-    {{- $apod -}}:{{required "A valid .Values.cp_network_interface required!" $.Values.cp_network_interface }}
-    {{- end }}{{- if .Values.cp_network_interface }},{{- $.Values.cp_physical_network -}}:{{required "A valid .Values.cp_network_interface required!" $.Values.cp_network_interface }}{{- end -}}
-{{- else -}}
 physical_interface_mappings = {{required "A valid .Values.cp_physical_network required!" .Values.cp_physical_network}}:{{required "A valid .Values.cp_network_interface required!" .Values.cp_network_interface}}
-{{- end }}
 
 [vxlan]
 enable_vxlan = false

--- a/openstack/neutron/templates/statefulset-network-agent-apod.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent-apod.yaml
@@ -1,0 +1,260 @@
+{{- if .Values.agent.apod | default false }}
+{{- if .Values.global.apods | default false }}
+{{- $ussuri := hasPrefix "ussuri" (default .Values.imageVersion .Values.imageVersionServerAPI) -}}
+{{ range $az_long, $apods := .Values.global.apods }}
+{{ range $k, $apod := $apods }}
+{{- $az := trimPrefix $.Values.global.region $az_long }}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: neutron-network-agent-{{ $apod }}
+  labels:
+    system: openstack
+    application: neutron
+    component: agent
+spec:
+  updateStrategy:
+{{- if or (eq $.Values.global.region "qa-de-1") (eq $.Values.global.region "qa-de-2") }}
+    type: RollingUpdate
+{{- else }}
+    type: OnDelete
+{{- end }}
+  selector:
+    matchLabels:
+      name: neutron-network-agent-{{ $apod }}
+  serviceName: neutron-network-agent
+  podManagementPolicy: "Parallel"
+{{- if $.Values.pod.replicas.network_agent_apod }}
+  replicas: {{ $.Values.pod.replicas.network_agent_apod}} 
+{{- else }}
+  replicas: 5
+{{- end }}
+  template:
+    metadata:
+      annotations:
+        k8s.v1.cni.cncf.io/networks: '[{ "name": "cbr1-bridge", "interface":"{{$.Values.cp_network_interface}}" }]'
+        configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") $ | sha256sum }}
+        configmap-etc-apod-hash: {{ include (print $.Template.BasePath "/configmap-etc-apod.yaml") $ | sha256sum }}
+      labels:
+        name: neutron-network-agent-{{ $apod }}
+{{ tuple $ "neutron" "agent" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchExpressions:
+                - key: component
+                  operator: In
+                  values:
+                  - agent
+      nodeSelector:
+        multus: bond1
+        failure-domain.beta.kubernetes.io/zone: {{ $az_long }}
+        kubernetes.cloud.sap/apod: {{ $apod }}
+      containers:
+        - name: neutron-dhcp-agent
+          image: {{$.Values.global.registry}}/loci-neutron:{{$.Values.imageVersionNetworkAgentDHCP | default $.Values.imageVersionNetworkAgent | default $.Values.imageVersion | required "Please set neutron.imageVersionNetworkAgentDHCP or similar"}}
+          imagePullPolicy: IfNotPresent
+          command: ["dumb-init", "neutron-dhcp-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/dhcp-agent.ini", "--config-file", "/etc/neutron/linux-bridge.ini", "--config-file", "/etc/neutron/az-{{ $az }}.conf"]
+          env:
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: sentry
+                  key: neutron.DSN.python
+            - name: DEBUG_CONTAINER
+              value: "false"
+          readinessProbe:
+            exec:
+              command: ["neutron-dhcp-readiness", "-config-file", "/etc/neutron/neutron.conf"]
+            initialDelaySeconds: 30
+            periodSeconds: 60
+            timeoutSeconds: 10
+          securityContext:
+            privileged: true
+          resources:
+{{ toYaml $.Values.pod.resources.dhcp_agent | indent 12 }}
+          volumeMounts:
+            - name: metadata-proxy
+              mountPath: /run/metadata_proxy
+            - name: modules
+              mountPath: /lib/modules
+              readOnly: true
+            - name: neutron-etc
+              mountPath: /etc/neutron/neutron.conf
+              subPath: neutron.conf
+              readOnly: true
+            - name: neutron-etc
+              mountPath: /etc/neutron/dhcp-agent.ini
+              subPath: dhcp-agent.ini
+              readOnly: true
+            - name: neutron-etc
+              mountPath: /etc/neutron/linux-bridge.ini
+              subPath: linux-bridge.ini
+              readOnly: true
+            - name: neutron-etc
+              mountPath: /etc/neutron/az-{{$az}}.conf
+              subPath: az-{{$az}}.conf
+              readOnly: true
+            - name: neutron-etc
+              mountPath: /etc/neutron/dnsmasq.conf
+              subPath: dnsmasq.conf
+              readOnly: true
+            - name: neutron-etc
+              mountPath: /etc/neutron/logging.conf
+              subPath: logging.conf
+              readOnly: true
+            - name: neutron-etc
+              mountPath: /etc/neutron/rootwrap.conf
+              subPath: rootwrap.conf
+              readOnly: true
+            - name: neutron-etc
+              mountPath: /etc/neutron/rootwrap.d/dhcp.filters
+              subPath: dhcp.filters
+              readOnly: true
+            - name: neutron-etc
+              mountPath: /etc/sudoers
+              subPath: sudoers
+              readOnly: true
+            - name: logvol
+              mountPath: /dev/log
+              readOnly: false
+{{- if $.Values.agent.neutron_l3 | default false }}
+        - name: neutron-l3-agent
+          image: {{$.Values.global.registry}}/loci-neutron:{{$.Values.imageVersionNetworkAgentL3 | default $.Values.imageVersionNetworkAgent | default $.Values.imageVersion | required "Please set neutron.imageVersionNetworkAgentL3 or similar"}}
+          imagePullPolicy: IfNotPresent
+          command: ["dumb-init", "neutron-l3-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/l3-agent.ini", "--config-file", "/etc/neutron/plugins/ml2/ml2-conf.ini", "--config-file", "/etc/neutron/linux-bridge.ini", "--config-file", "/etc/neutron/az-{{ $az }}.conf"]
+          env:
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: sentry
+                  key: neutron.DSN.python
+            - name: DEBUG_CONTAINER
+              value: "false"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: modules
+              readOnly: true
+            - name: neutron-etc
+              mountPath: /etc/neutron/neutron.conf
+              subPath: neutron.conf
+              readOnly: true
+            - name: neutron-etc
+              mountPath: /etc/neutron/l3-agent.ini
+              subPath: l3-agent.ini
+              readOnly: true
+            - name: neutron-apod
+              mountPath: /etc/neutron/plugins/ml2/ml2-conf.ini
+              subPath: ml2-conf-apod-{{ $apod }}.ini
+              readOnly: true
+            - name: neutron-etc
+              mountPath: /etc/neutron/linux-bridge.ini
+              subPath: linux-bridge.ini
+              readOnly: true
+            - name: neutron-etc
+              mountPath: /etc/neutron/logging.conf
+              subPath: logging.conf
+              readOnly: true
+            - name: neutron-etc
+              mountPath: /etc/neutron/rootwrap.conf
+              subPath: rootwrap.conf
+              readOnly: true
+            - name: neutron-etc
+              mountPath: /etc/neutron/rootwrap.d/l3.filters
+              subPath: l3.filters
+              readOnly: true
+            - name: neutron-etc
+              mountPath: /etc/neutron/az-{{$az}}.conf
+              subPath: az-{{$az}}.conf
+              readOnly: true
+            - name: neutron-etc
+              mountPath: /etc/sudoers
+              subPath: sudoers
+              readOnly: true
+{{- end }}
+        - name: neutron-linuxbridge-agent
+          image: {{$.Values.global.registry}}/loci-neutron:{{$.Values.imageVersionNetworkAgentLinuxBridge | default $.Values.imageVersionNetworkAgent | default $.Values.imageVersion | required "Please set neutron.imageVersionNetworkAgentLinuxBridge or similar"}}
+          imagePullPolicy: IfNotPresent
+          command: ["dumb-init", "neutron-linuxbridge-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/plugins/ml2/ml2_conf.ini", "--config-file", "/etc/neutron/linux-bridge.ini"]
+          env:
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: sentry
+                  key: neutron.DSN.python
+            - name: DEBUG_CONTAINER
+              value: "false"
+          readinessProbe:
+            exec:
+              command: ["neutron-linuxbridge-readiness", "-config-file", "/etc/neutron/neutron.conf"]
+            initialDelaySeconds: 30
+            periodSeconds: 60
+            timeoutSeconds: 10
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+{{- if $ussuri }}
+                - SYS_ADMIN
+                - DAC_OVERRIDE
+                - DAC_READ_SEARCH
+                - SYS_PTRACE
+{{ end }}
+          resources:
+{{ toYaml $.Values.pod.resources.linuxbridge_agent | indent 12 }}
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: modules
+              readOnly: true
+            - name: neutron-etc
+              mountPath: /etc/neutron/neutron.conf
+              subPath: neutron.conf
+              readOnly: true
+            - name: neutron-apod
+              mountPath: /etc/neutron/plugins/ml2/ml2_conf.ini
+              subPath: ml2-conf-apod-{{ $apod }}.ini
+              readOnly: true
+            - name: neutron-etc
+              mountPath: /etc/neutron/linux-bridge.ini
+              subPath: linux-bridge.ini
+              readOnly: true
+            - name: neutron-etc
+              mountPath: /etc/neutron/logging.conf
+              subPath: logging.conf
+              readOnly: true
+            - name: neutron-etc
+              mountPath: /etc/neutron/rootwrap.conf
+              subPath: rootwrap.conf
+              readOnly: true
+            - name: neutron-etc
+              mountPath: /etc/sudoers
+              subPath: sudoers
+              readOnly: true
+      volumes:
+        - name: metadata-proxy
+          hostPath:
+            path: /run/metadata-proxy
+        - name : modules
+          hostPath:
+            path: /lib/modules
+        - name: neutron-etc
+          configMap:
+            name: neutron-etc
+        - name: neutron-apod
+          configMap:
+            name: neutron-etc-apod
+        - name: logvol
+          hostPath:
+            path: /dev/log
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/openstack/neutron/templates/statefulset-network-agent-apod.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent-apod.yaml
@@ -85,105 +85,20 @@ spec:
             - name: modules
               mountPath: /lib/modules
               readOnly: true
-            - name: neutron-etc
-              mountPath: /etc/neutron/neutron.conf
-              subPath: neutron.conf
-              readOnly: true
-            - name: neutron-etc
-              mountPath: /etc/neutron/dhcp-agent.ini
-              subPath: dhcp-agent.ini
-              readOnly: true
-            - name: neutron-etc
-              mountPath: /etc/neutron/linux-bridge.ini
-              subPath: linux-bridge.ini
-              readOnly: true
-            - name: neutron-etc
-              mountPath: /etc/neutron/az-{{$az}}.conf
-              subPath: az-{{$az}}.conf
-              readOnly: true
-            - name: neutron-etc
-              mountPath: /etc/neutron/dnsmasq.conf
-              subPath: dnsmasq.conf
-              readOnly: true
-            - name: neutron-etc
-              mountPath: /etc/neutron/logging.conf
-              subPath: logging.conf
-              readOnly: true
-            - name: neutron-etc
-              mountPath: /etc/neutron/rootwrap.conf
-              subPath: rootwrap.conf
-              readOnly: true
-            - name: neutron-etc
-              mountPath: /etc/neutron/rootwrap.d/dhcp.filters
-              subPath: dhcp.filters
-              readOnly: true
-            - name: neutron-etc
-              mountPath: /etc/sudoers
-              subPath: sudoers
-              readOnly: true
             - name: logvol
               mountPath: /dev/log
               readOnly: false
-{{- if $.Values.agent.neutron_l3 | default false }}
-        - name: neutron-l3-agent
-          image: {{$.Values.global.registry}}/loci-neutron:{{$.Values.imageVersionNetworkAgentL3 | default $.Values.imageVersionNetworkAgent | default $.Values.imageVersion | required "Please set neutron.imageVersionNetworkAgentL3 or similar"}}
-          imagePullPolicy: IfNotPresent
-          command: ["dumb-init", "neutron-l3-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/l3-agent.ini", "--config-file", "/etc/neutron/plugins/ml2/ml2-conf.ini", "--config-file", "/etc/neutron/linux-bridge.ini", "--config-file", "/etc/neutron/az-{{ $az }}.conf"]
-          env:
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: sentry
-                  key: neutron.DSN.python
-            - name: DEBUG_CONTAINER
-              value: "false"
-          securityContext:
-            privileged: true
-          volumeMounts:
-            - mountPath: /lib/modules
-              name: modules
-              readOnly: true
-            - name: neutron-etc
-              mountPath: /etc/neutron/neutron.conf
-              subPath: neutron.conf
-              readOnly: true
-            - name: neutron-etc
-              mountPath: /etc/neutron/l3-agent.ini
-              subPath: l3-agent.ini
-              readOnly: true
-            - name: neutron-apod
-              mountPath: /etc/neutron/plugins/ml2/ml2-conf.ini
-              subPath: ml2-conf-apod-{{ $apod }}.ini
-              readOnly: true
-            - name: neutron-etc
-              mountPath: /etc/neutron/linux-bridge.ini
-              subPath: linux-bridge.ini
-              readOnly: true
-            - name: neutron-etc
-              mountPath: /etc/neutron/logging.conf
-              subPath: logging.conf
-              readOnly: true
-            - name: neutron-etc
-              mountPath: /etc/neutron/rootwrap.conf
-              subPath: rootwrap.conf
-              readOnly: true
-            - name: neutron-etc
-              mountPath: /etc/neutron/rootwrap.d/l3.filters
-              subPath: l3.filters
-              readOnly: true
-            - name: neutron-etc
-              mountPath: /etc/neutron/az-{{$az}}.conf
-              subPath: az-{{$az}}.conf
+            - name: etc-neutron-dhcp-agent
+              mountPath: /etc/neutron
               readOnly: true
             - name: neutron-etc
               mountPath: /etc/sudoers
               subPath: sudoers
               readOnly: true
-{{- end }}
         - name: neutron-linuxbridge-agent
           image: {{$.Values.global.registry}}/loci-neutron:{{$.Values.imageVersionNetworkAgentLinuxBridge | default $.Values.imageVersionNetworkAgent | default $.Values.imageVersion | required "Please set neutron.imageVersionNetworkAgentLinuxBridge or similar"}}
           imagePullPolicy: IfNotPresent
-          command: ["dumb-init", "neutron-linuxbridge-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/plugins/ml2/ml2_conf.ini", "--config-file", "/etc/neutron/linux-bridge.ini"]
+          command: ["dumb-init", "neutron-linuxbridge-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/plugins/ml2/ml2_conf.ini", "--config-file", "/etc/neutron/linux-bridge.ini", "--config-file", "/etc/neutron/apod-{{ $apod }}.conf"]
           env:
             - name: SENTRY_DSN
               valueFrom:
@@ -214,25 +129,8 @@ spec:
             - mountPath: /lib/modules
               name: modules
               readOnly: true
-            - name: neutron-etc
-              mountPath: /etc/neutron/neutron.conf
-              subPath: neutron.conf
-              readOnly: true
-            - name: neutron-apod
-              mountPath: /etc/neutron/plugins/ml2/ml2_conf.ini
-              subPath: ml2-conf-apod-{{ $apod }}.ini
-              readOnly: true
-            - name: neutron-etc
-              mountPath: /etc/neutron/linux-bridge.ini
-              subPath: linux-bridge.ini
-              readOnly: true
-            - name: neutron-etc
-              mountPath: /etc/neutron/logging.conf
-              subPath: logging.conf
-              readOnly: true
-            - name: neutron-etc
-              mountPath: /etc/neutron/rootwrap.conf
-              subPath: rootwrap.conf
+            - name: etc-neutron-linuxbridge-agent
+              mountPath: /etc/neutron
               readOnly: true
             - name: neutron-etc
               mountPath: /etc/sudoers
@@ -242,18 +140,60 @@ spec:
         - name: metadata-proxy
           hostPath:
             path: /run/metadata-proxy
-        - name : modules
+        - name: modules
           hostPath:
             path: /lib/modules
-        - name: neutron-etc
-          configMap:
-            name: neutron-etc
-        - name: neutron-apod
-          configMap:
-            name: neutron-etc-apod
         - name: logvol
           hostPath:
             path: /dev/log
+        - name: neutron-etc
+          configMap:
+            name: neutron-etc
+        - name: etc-neutron-dhcp-agent
+          projected:
+            defaultMode: 420
+            sources:
+            - configMap:
+                name: neutron-etc
+                items:
+                - key: neutron.conf
+                  path: neutron.conf
+                - key: logging.conf
+                  path: logging.conf
+                - key: rootwrap.conf
+                  path: rootwrap.conf
+                - key: dnsmasq.conf
+                  path: dnsmasq.conf
+                - key: dhcp.filters
+                  path: rootwrap.d/dhcp.filters
+                - key: linux-bridge.ini
+                  path: linux-bridge.ini
+                - key: dhcp-agent.ini
+                  path: dhcp-agent.ini
+                - key: az-{{$az}}.conf
+                  path: az-{{$az}}.conf
+        - name: etc-neutron-linuxbridge-agent
+          projected:
+            defaultMode: 420
+            sources:
+            - configMap:
+                name: neutron-etc
+                items:
+                - key: neutron.conf
+                  path: neutron.conf
+                - key: logging.conf
+                  path: logging.conf
+                - key: rootwrap.conf
+                  path: rootwrap.conf
+                - key: linux-bridge.ini
+                  path: linux-bridge.ini
+                - key: ml2-conf.ini
+                  path: plugins/ml2/ml2_conf.ini
+            - configMap:
+                name: neutron-etc-apod
+                items:
+                - key: apod-{{ $apod }}.conf
+                  path: apod-{{ $apod }}.conf
 {{- end }}
 {{- end }}
 {{- end }}

--- a/openstack/neutron/templates/statefulset-network-agent.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent.yaml
@@ -56,6 +56,14 @@ spec:
                   operator: In
                   values:
                   - agent
+{{- if $.Values.agent.apod | default false }}
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.cloud.sap/apod
+                operator: DoesNotExist
+{{- end }}
       nodeSelector:
         multus: bond1
         failure-domain.beta.kubernetes.io/zone: {{ $az_long }}


### PR DESCRIPTION
This PR implements the following logic to support aPods:

- Enables per-apod network-agents Statefulset if `.Values.agent.apod` is true and aPods are provided in values, eg:
```
  apods:
    qa-az-1a:
      - apXXX
    qa-az-1b:
      - apYYY
```

- `neutron-etc-apod` configmap contains config files for each aPod
- Existing agents will not be scheduled on aPod VMs (based on node label)
