### PR TITLE
[keystone] Use default MaxRequestsPerChild (0)

### DIFF
--- a/openstack/keystone/templates/etc/_mpm_event.conf.tpl
+++ b/openstack/keystone/templates/etc/_mpm_event.conf.tpl
@@ -18,6 +18,5 @@
   MinSpareThreads     32
   MaxSpareThreads     256
   ThreadsPerChild     25
-  MaxRequestsPerChild 128
   ThreadLimit         720
 </IfModule>


### PR DESCRIPTION
Fixes CCM-18723

Listener process serves MaxRequestsPerChild requests, shuts down,
closes all open connections, we run into the race condition described
in the bugreport. Using the default value will remove this limitation