### PR TITLE
[Swift] HAProxy - Modified server list

### DIFF
--- a/openstack/swift/bin/haproxy-start
+++ b/openstack/swift/bin/haproxy-start
@@ -4,6 +4,19 @@ CFG_DIR=/usr/local/etc/haproxy
 cp -f /haproxy-etc-cluster/haproxy.cfg ${CFG_DIR}/haproxy.cfg
 cp -f /haproxy-etc-cluster/dhparam.pem ${CFG_DIR}/dhparam.pem
 
+# Remove the K8S Node hosting this HAProxy from the server list
+# Reason: Healthchecks against the NodePort on the local machine will use kube-proxy
+# and therefor end up on swift-proxy annouced by the Endpoint for the NodePort Service.
+# This leads to the situation that the server running this haproxy is considered healthy
+# and all subsequent request with that target will also use kube-proxy, which obfuscates
+# the real target for a request.
+# Worst case, the HAProxy looses one swift-proxy target to load balance to, if a
+# swift-proxy runs on the same K8S node as HAProxy does. Soft anti-affinity rules try
+# to avoid sceduling HAProxy to a node with swift-proxy and vice versa.
+#
+# All servers have a comment at the end with the FQDN --> delete complete line
+[ -n "$NODE_NAME" ] && sed -i "/# $NODE_NAME/d" ${CFG_DIR}/haproxy.cfg
+
 SSL_DIR=${CFG_DIR}/ssl
 mkdir -p ${SSL_DIR}
 cp -f /tls-secret/tls.crt ${SSL_DIR}

--- a/openstack/swift/templates/haproxy-deployment.yaml
+++ b/openstack/swift/templates/haproxy-deployment.yaml
@@ -60,6 +60,16 @@ spec:
                   values:
                   - deployment
               topologyKey: "kubernetes.io/hostname"
+          # Prefere to be scheduled on nodes not yet running swift-proxy. See bin/haproxy-start for explanation
+          - weight: 5
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: component
+                  operator: In
+                  values:
+                  - swift-proxy-{{ $cluster_id }}
+              topologyKey: "kubernetes.io/hostname"
       volumes:
         - name: tls-secret
           secret:
@@ -81,6 +91,11 @@ spec:
           env:
             - name: DEBUG_CONTAINER
               value: "false"
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
           resources:
             requests:
               cpu: "1000m"

--- a/openstack/swift/templates/proxy-deployment.yaml
+++ b/openstack/swift/templates/proxy-deployment.yaml
@@ -67,6 +67,16 @@ spec:
                   values:
                   - deployment
               topologyKey: "kubernetes.io/hostname"
+          # Prefere to be scheduled on nodes not yet running haproxy. See bin/haproxy-start for explanation
+          - weight: 5
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: component
+                  operator: In
+                  values:
+                  - swift-haproxy-{{ $cluster_id }}
+              topologyKey: "kubernetes.io/hostname"
       volumes:
         {{- tuple $cluster_id | include "swift_proxy_volumes" | indent 8 }}
       containers:


### PR DESCRIPTION
Remove the K8S Node hosting this HAProxy from the server list
Reason: Healthchecks against the NodePort on the local machine will use kube-proxy
and therefor end up on swift-proxy annouced by the Endpoint for the NodePort Service.
This leads to the situation that the server running this haproxy is considered healthy
and all subsequent request with that target will also use kube-proxy, which obfuscates
the real target for a request.
Worst case, the HAProxy looses one swift-proxy target to load balance to, if a
swift-proxy runs on the same K8S node as HAProxy does. Soft anti-affinity rules try
to avoid sceduling HAProxy to a node with swift-proxy and vice versa.