### PR TITLE
nova/flavors: Revert "Rename & alias flavors to g/c/m scheme"

### DIFF
--- a/openstack/sap-seeds/templates/flavor-seed.yaml
+++ b/openstack/sap-seeds/templates/flavor-seed.yaml
@@ -15,36 +15,51 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "4"
-  - name: "g_c1_m2"
+  - name: "m1.xsmallcpuhdd"
     id: "19"
     vcpus: 1
     ram: 2032
-    disk: 64
+    disk: 40
     is_public: true
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-      "catalog:alias": "m1.xsmallcpuhdd"
-  - name: "c_c2_m2"
+  - name: "m1.small"
     id: "20"
     vcpus: 2
     ram: 2032
-    disk: 64
+    disk: 16
     is_public: true
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-      "catalog:alias": "m1.small,m1.smallhdd"
-  - name: "g_c2_m4"
+  - name: "m1.smallhdd"
+    id: "21"
+    vcpus: 2
+    ram: 2032
+    disk: 40
+    is_public: true
+    extra_specs:
+      "vmware:hv_enabled": "True"
+      "hw_video:ram_max_mb": "16"
+  - name: "m1.xsmall"
     id: "22"
     vcpus: 2
     ram: 4080
-    disk: 64
+    disk: 32
     is_public: true
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-      "catalog:alias": "m1.xsmall,m1.xsmallhdd"
+  - name: "m1.xsmallhdd"
+    id: "23"
+    vcpus: 2
+    ram: 4080
+    disk: 40
+    is_public: true
+    extra_specs:
+      "vmware:hv_enabled": "True"
+      "hw_video:ram_max_mb": "16"
   - name: "g_c1_m3"
     id: "24"
     vcpus: 1
@@ -54,7 +69,7 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-  - name: "g_c2_m8"
+  - name: "m1.xmedium"
     id: "32"
     vcpus: 2
     ram: 8176
@@ -63,8 +78,7 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-      "catalog:alias": "m1.xmedium"
-  - name: "c_c4_m4"
+  - name: "m1.medium"
     id: "30"
     vcpus: 4
     ram: 4080
@@ -73,8 +87,7 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-      "catalog:alias": "m1.medium"
-  - name: "g_c4_m8"
+  - name: "m1.large"
     id: "40"
     vcpus: 4
     ram: 8176
@@ -83,8 +96,7 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-      "catalog:alias": "m1.large"
-  - name: "g_c4_m16"
+  - name: "m1.xlarge"
     id: "50"
     vcpus: 4
     ram: 16368
@@ -93,8 +105,7 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-      "catalog:alias": "m1.xlarge"
-  - name: "c_c16_m16"
+  - name: "m1.xlarge_cpu"
     id: "52"
     vcpus: 16
     ram: 16368
@@ -103,8 +114,7 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-      "catalog:alias": "m1.xlarge_cpu"
-  - name: "g_c8_m32"
+  - name: "m1.2xlarge"
     id: "60"
     vcpus: 8
     ram: 32752
@@ -113,8 +123,7 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-      "catalog:alias": "m1.2xlarge"
-  - name: "g_c16_m32"
+  - name: "m1.2xlargecpu"
     id: "61"
     vcpus: 16
     ram: 32752
@@ -123,7 +132,6 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-      "catalog:alias": "m1.2xlargecpu"
   - name: "g_c12_m48"
     id: "62"
     vcpus: 12
@@ -133,7 +141,7 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-  - name: "g_c16_m64"
+  - name: "m1.4xlarge"
     id: "70"
     vcpus: 16
     ram: 65520
@@ -142,7 +150,6 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-      "catalog:alias": "m1.4xlarge"
   - name: "m1.10xlarge"
     id: "80"
     vcpus: 40
@@ -197,7 +204,7 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-  - name: "m_c4_m64"
+  - name: "m2.large"
     id: "100"
     vcpus: 4
     ram: 65520
@@ -206,8 +213,7 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-      "catalog:alias": "m2.large"
-  - name: "g_c8_m16"
+  - name: "m2.xlarge"
     id: "110"
     vcpus: 8
     ram: 16368
@@ -216,7 +222,6 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-      "catalog:alias": "m2.xlarge"
   - name: "m2.2xlarge"
     id: "120"
     vcpus: 8
@@ -271,7 +276,7 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-  - name: "m_c8_m64"
+  - name: "m2.4xlarge"
     id: "140"
     vcpus: 8
     ram: 65520
@@ -280,8 +285,7 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-      "catalog:alias": "m2.4xlarge"
-  - name: "m_c16_m128"
+  - name: "m2.8xlarge"
     id: "160"
     vcpus: 16
     ram: 131056
@@ -290,7 +294,6 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-      "catalog:alias": "m2.8xlarge"
   - name: "m2.16xlarge"
     id: "161"
     vcpus: 16
@@ -313,7 +316,7 @@ spec:
     id: "210"
     vcpus: 4
     ram: 16368
-    disk: 64
+    disk: 150
     is_public: false
     extra_specs:
       "vmware:hv_enabled": "True"
@@ -336,7 +339,7 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-  - name: "g_c64_m256"
+  - name: "m5.16xlarge"
     id: "220"
     vcpus: 64
     ram: 262128
@@ -345,8 +348,7 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-      "catalog:alias": "m5.16xlarge"
-  - name: "g_c128_m512"
+  - name: "m5.32xlarge"
     id: "230"
     vcpus: 128
     ram: 524272
@@ -355,7 +357,6 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-      "catalog:alias": "m5.32xlarge"
   - name: "m5.48xlarge"
     id: "231"
     vcpus: 96


### PR DESCRIPTION
We want to deploy the HANA flavors more urgently to prod than the aliases. Gardener is still testing aliases in qa-de-1.

Revert commits:
  - 8aa311a294301a636b5f190bbea772733a18c660
  - 3cfbe46c250acd1c40610e4ee3aa078948f013af
