### PR TITLE
[glance] set the number of threads for glance_store and set number of

### DIFF
--- a/openstack/glance/templates/etc/_glance-api.conf.tpl
+++ b/openstack/glance/templates/etc/_glance-api.conf.tpl
@@ -14,6 +14,7 @@ admin_role = ''
 
 rpc_response_timeout = {{ .Values.rpc_response_timeout | default 300 }}
 rpc_workers = {{ .Values.rpc_workers | default 1 }}
+workers = {{ .Values.workers | default 4 }}
 
 wsgi_default_pool_size = {{ .Values.wsgi_default_pool_size | default 100 }}
 
@@ -61,6 +62,7 @@ swift_store_create_container_on_put = True
 swift_buffer_on_upload = True
 swift_upload_buffer_dir = /upload
 swift_store_expire_soon_interval = 1800
+swift_store_thread_pool_size = 10
 {{- if .Values.swift.multi_tenant }}
 swift_store_multi_tenant = True
 # swift_store_large_object_size = 5120

--- a/openstack/glance/values.yaml
+++ b/openstack/glance/values.yaml
@@ -34,7 +34,7 @@ swift:
 
 api_port_internal: '9292'
 
-replicas: 2
+replicas: 3
 
 upgrades:
   revisionHistory: 3


### PR DESCRIPTION
workers.

- needed for https://github.com/sapcc/glance_store/pull/2
- set 4 workers per replica as 10 by default caused issues
- increase number of replicas as number of workers was reduced.