### PR TITLE
vrops-exporter: HostWithRunningVMsNotResponding changed running VM metric

### DIFF
--- a/prometheus-exporters/vrops-exporter/alerts/host.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/host.alerts
@@ -6,7 +6,7 @@ groups:
       vrops_hostsystem_runtime_connectionstate{state="notResponding"}
       and on (hostsystem) vrops_hostsystem_runtime_powerstate{state="Unknown"}
       and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"}
-      and on (hostsystem) count(vrops_virtualmachine_runtime_powerstate{state="Powered On"}) by (hostsystem) > 0
+      and on (hostsystem) vrops_hostsystem_summary_running_vms_number > 0
     for: 10m
     labels:
       severity: critical


### PR DESCRIPTION
Changed the count of powered on VMs (VM collector) to the amount of running VMs on the host (host collector). This metric only considers powered on VMs. 

https://docs.vmware.com/en/vRealize-Operations-Manager/8.3/com.vmware.vcom.core.doc/GUID-C3CAAE15-2E83-431F-8F2D-C5297A3B6EA9.html : `This excludes powered off VMs as they do not impact ESXi performance.`

In that way we don't miss the critical alert, in case the VM collector doesn't work as expected.