### PR TITLE
Allow updating imagePullPolicy

### DIFF
--- a/openstack/cinder/templates/api-deployment.yaml
+++ b/openstack/cinder/templates/api-deployment.yaml
@@ -32,7 +32,7 @@ spec:
       containers:
         - name: cinder-api
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{.Values.imageVersionCinderApi | default .Values.imageVersion | required "Please set cinder.imageVersion or similar" }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{ required ".Values.global.imagePullPolicy is missing" .Values.global.imagePullPolicy }}
           command:
             - kubernetes-entrypoint
           env:

--- a/openstack/cinder/templates/backup_deployment.yaml
+++ b/openstack/cinder/templates/backup_deployment.yaml
@@ -36,7 +36,7 @@ template: |{{`
         containers:
         - name: cinder-volume-backup-vmware-{{ name }}
           image: `}}{{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{.Values.imageVersionCinderVolumeBackup | default .Values.imageVersion | required "Please set cinder.imageVersion or similar" }}{{`
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{ required ".Values.global.imagePullPolicy is missing" .Values.global.imagePullPolicy }}
           securityContext:
             capabilities:
               add: ["SYS_ADMIN"]

--- a/openstack/cinder/templates/scheduler-deployment.yaml
+++ b/openstack/cinder/templates/scheduler-deployment.yaml
@@ -33,7 +33,7 @@ spec:
       containers:
         - name: cinder-scheduler
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{.Values.imageVersionCinderScheduler | default .Values.imageVersion | required "Please set cinder.imageVersion or similar" }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{ required ".Values.global.imagePullPolicy is missing" .Values.global.imagePullPolicy }}
           command:
             - kubernetes-entrypoint
           env:

--- a/openstack/cinder/templates/vcenter_datacenter_cinder_deployment.yaml
+++ b/openstack/cinder/templates/vcenter_datacenter_cinder_deployment.yaml
@@ -43,7 +43,7 @@ template: |
         containers:
         - name: cinder-volume-vmware-{= name =}
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{.Values.imageVersionCinderScheduler | default .Values.imageVersion | required "Please set cinder.imageVersion or similar" }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{ required ".Values.global.imagePullPolicy is missing" .Values.global.imagePullPolicy }}
           securityContext:
             capabilities:
               add: ["SYS_ADMIN"]

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -12,6 +12,7 @@ global:
   osprofiler: {}
   pgbouncer:
     enabled: false
+  imagePullPolicy: IfNotPresent
 
 osprofiler:
   enabled: false


### PR DESCRIPTION
This patch parameterizes the imagePullPolicy to allow a region to
change the default of 'IfNotPresent' to something else.  This allows
for testing patches against qa-de-3 and have the deployment always pull
the image, thus avoiding stale cached images.