### PR TITLE
nova/memoryreservation: Set reservation-limits config defaults

### DIFF
--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -277,6 +277,8 @@ compute:
       full_clone_snapshots: true
       # maximum of vSphere 6.5
       default_hw_version: vmx-13
+      memory_reservation_cluster_hosts_max_fail: 2
+      memory_reservation_max_ratio_fallback: 0.8
 
 conductor:
   config_file:


### PR DESCRIPTION
A maximum of two hosts can fail before memory reservations start to
prevent memory-reserved VMs from spawning.

If the max-hosts setting fails for some reason, the fallback config
says that spawning reserved-memory VMs is prohibited after 80% of
_available_ memory is used up.
