### PR TITLE
[cinder] Fix the cinder backup_deployment template

### DIFF
--- a/openstack/cinder/templates/backup_deployment.yaml
+++ b/openstack/cinder/templates/backup_deployment.yaml
@@ -36,7 +36,7 @@ template: |{{`
         containers:
         - name: cinder-volume-backup-vmware-{{ name }}
           image: `}}{{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{.Values.imageVersionCinderVolumeBackup | default .Values.imageVersion | required "Please set cinder.imageVersion or similar" }}{{`
-          imagePullPolicy: {{ required ".Values.global.imagePullPolicy is missing" .Values.global.imagePullPolicy }}
+          imagePullPolicy: `}}{{ required ".Values.global.imagePullPolicy is missing" .Values.global.imagePullPolicy }}{{`
           securityContext:
             capabilities:
               add: ["SYS_ADMIN"]


### PR DESCRIPTION
After trying this in qa-de-3, the backup service didn't deploy. I
believe it's due to this templating format.