### PR TITLE
[openstack-exporter][cinder] Alter cinder alerts no absense

### DIFF
--- a/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
+++ b/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
@@ -9,6 +9,7 @@ groups:
       severity: warning
       tier: vmware
       service: cinder
+      no_alert_on_absence: "true"
       context: "openstack-exporter"
       meta: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 20% storage left before overcommit is reached."
       playbook: docs/support/playbook/cinder/cinder_low_overcommit_ratio.html
@@ -23,6 +24,7 @@ groups:
       severity: critical
       tier: vmware
       service: cinder
+      no_alert_on_absence: "true"
       context: "openstack-exporter"
       meta: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 10% storage left before overcommit is reached."
       playbook: docs/support/playbook/cinder/cinder_low_overcommit_ratio.html


### PR DESCRIPTION
This patch adds the no_alert_on_absence: "true" to 2 of the cinder
alerts for thin provisioning.   Cinder has migrated many of the
volume types for regions to thick provisioning and those regions
will not have the thin provisioning metrics.  This patch ignores
those missing metrics as they are expected.

Once all the regions have migrated to thick provisioning, then these
2 alerts will be removed/replaced.