### PR TITLE
[alertmanager] merge inhibition rules

### DIFF
--- a/global/prometheus-alertmanager-operated/Chart.yaml
+++ b/global/prometheus-alertmanager-operated/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: "1.0"
 type: application
 description: Prometheus Alertmanager via operator.
 name: prometheus-alertmanager-operated
-version: 1.0.4
+version: 1.0.5

--- a/global/prometheus-alertmanager-operated/templates/_alertmanager.yaml.tpl
+++ b/global/prometheus-alertmanager-operated/templates/_alertmanager.yaml.tpl
@@ -9,29 +9,13 @@ inhibit_rules:
       severity: 'critical'
     target_match:
       severity: 'warning'
-    equal: ['region', 'alertname', 'cluster']
+    equal: ['region', 'alertname', 'cluster', 'context']
 
   - source_match_re:
       severity: 'critical|warning'
     target_match:
       severity: 'info'
-    equal: ['region', 'alertname', 'cluster']
-
-  - source_match_re:
-      severity: 'critical'
-      context: '.+'
-    target_match_re:
-      severity: 'warning'
-      context: '.+'
-    equal: ['region', 'context', 'cluster']
-
-  - source_match_re:
-      severity: 'critical|warning'
-      context: '.+'
-    target_match_re:
-      severity: 'info'
-      context: '.+'
-    equal: ['region', 'context', 'cluster']
+    equal: ['region', 'alertname', 'cluster', 'context']
 
   - source_match_re:
       alertname: '.*KubeletDown'


### PR DESCRIPTION
**issue**: alerts with different name, but same context (often used) are inhibit - alertname should key if severity is in

comment: ["Semantically, a missing label and a label with an empty value are the same thing. Therefore, if all the label names listed in equal are missing from both the source and target alerts, the inhibition rule will apply."](https://prometheus.io/docs/alerting/latest/configuration/#:~:text=An%20inhibition%20rule%20mutes%20an,names%20in%20the%20equal%20list)

issue-owner: @christopherhans @max-len 