### PR TITLE
[alertmanager] qa routing fix

### DIFF
--- a/global/prometheus-alertmanager-operated/templates/_alertmanager.yaml.tpl
+++ b/global/prometheus-alertmanager-operated/templates/_alertmanager.yaml.tpl
@@ -591,7 +591,7 @@ receivers:
 
   - name: slack_qa
     slack_configs:
-      - channel: '#alert-qa-{{"{{ .severity }}"}}'
+      - channel: '#alert-qa-{{"{{ .Labels.severity }}"}}'
         api_url: {{ required ".Values.slack.webhookURL undefined" .Values.slack.webhookURL | quote }}
         username: "Pulsar"
         title: {{"'{{template \"slack.sapcc.title\" . }}'"}}


### PR DESCRIPTION
First shot was a fail.

Guess there qa alerts without severity killing the CommonLabels approach.
This seems to me dangerous that this happens in prod, too -- so propose: if this works well we should always use .Labels.severity

In parallel I will do a alert inventory asap.