### PR TITLE
[swift-proxy] enable 'delete_container_retry_count' for bulk operations.

### DIFF
--- a/openstack/swift/templates/etc/_proxy-server.conf.tpl
+++ b/openstack/swift/templates/etc/_proxy-server.conf.tpl
@@ -169,6 +169,7 @@ url_base = https:
 
 [filter:bulk]
 use = egg:swift#bulk
+delete_container_retry_count = 3
 
 [filter:container-quotas]
 use = egg:swift#container_quotas

--- a/openstack/swift/templates/etc/_proxy-server.conf.tpl
+++ b/openstack/swift/templates/etc/_proxy-server.conf.tpl
@@ -169,7 +169,7 @@ url_base = https:
 
 [filter:bulk]
 use = egg:swift#bulk
-delete_container_retry_count = 3
+delete_container_retry_count = {{ $context.bulk_delete_container_retry_count }}
 
 [filter:container-quotas]
 use = egg:swift#container_quotas

--- a/openstack/swift/values.yaml
+++ b/openstack/swift/values.yaml
@@ -80,6 +80,9 @@ node_timeout: 60
 # Swift node timeout in seconds for GET and HEAD, default 10
 recoverable_node_timeout: 10
 
+# Retry container delete in case of bulk deletes, default 0
+bulk_delete_container_retry_count: 3
+
 # Don't log requests to object, container or account servers
 log_requests: false
 


### PR DESCRIPTION
Large Glance images may include 100s of segments per container.
Deletion of such images sometimes often fails with 'HTTP 409 Conflict'
response from Swift. Enabling this option seem to resolve the problem.

The delete_container_retry_count parameter is used during a bulk delete of objects
and their container. This would frequently fail because it is very likely that
all replicated objects have not been deleted by the time the middleware got a
successful response. It can be configured the number of retries. And the
number of seconds to wait between each retry will be 1.5**retry