### PR TITLE
[neutron] run metadata agent as sidecar on apod nodes

### DIFF
--- a/openstack/neutron/templates/daemonset-metadata-agent.yaml
+++ b/openstack/neutron/templates/daemonset-metadata-agent.yaml
@@ -25,6 +25,15 @@ spec:
         name: neutron-metadata-agent
 {{ tuple . "neutron" "metadata-agent" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
     spec:
+{{- if $.Values.agent.apod | default false }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.cloud.sap/apod
+                operator: DoesNotExist
+{{- end }}
       nodeSelector:
         multus: bond1
       containers:

--- a/openstack/neutron/templates/statefulset-network-agent-apod.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent-apod.yaml
@@ -136,6 +136,37 @@ spec:
               mountPath: /etc/sudoers
               subPath: sudoers
               readOnly: true
+        - name: neutron-metadata-agent
+          image: {{$.Values.global.registry}}/loci-neutron:{{$.Values.imageVersionNetworkAgentMetadata | default $.Values.imageVersionNetworkAgent | default $.Values.imageVersion | required "Please set neutron.imageVersionNetworkAgentMetadata or similar"}}
+          imagePullPolicy: IfNotPresent
+          command: ["dumb-init", "bash", "-c", "echo -e \"[DEFAULT]\\nhost = $NODE_NAME\\n\" > /run/hostname.conf && exec neutron-metadata-agent --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/metadata-agent.ini --config-file /run/hostname.conf"]
+          env:
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: sentry
+                  key: neutron.DSN.python
+            - name: DEBUG_CONTAINER
+              value: "false"
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          livenessProbe:
+            exec:
+              command: ["neutron-agent-liveness", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/hostname.conf", "--agent-type", "Metadata agent"]
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 10
+          resources:
+{{  toYaml $.Values.pod.resources.metadata_agent | indent 12 }}
+          volumeMounts:
+            - name: metadata-proxy
+              mountPath: /run/metadata_proxy
+            - name: etc-neutron-metadata-agent
+              mountPath: /etc/neutron
+              readOnly: true
       volumes:
         - name: metadata-proxy
           hostPath:
@@ -194,6 +225,19 @@ spec:
                 items:
                 - key: apod-{{ $apod }}.conf
                   path: apod-{{ $apod }}.conf
+        - name: etc-neutron-metadata-agent
+          projected:
+            defaultMode: 420
+            sources:
+            - configMap:
+                name: neutron-etc
+                items:
+                - key: neutron.conf
+                  path: neutron.conf
+                - key: logging.conf
+                  path: logging.conf
+                - key: metadata-agent.ini
+                  path: metadata-agent.ini
 {{- end }}
 {{- end }}
 {{- end }}

--- a/openstack/neutron/templates/statefulset-network-agent-apod.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent-apod.yaml
@@ -169,8 +169,7 @@ spec:
               readOnly: true
       volumes:
         - name: metadata-proxy
-          hostPath:
-            path: /run/metadata-proxy
+          emptyDir: {}
         - name: modules
           hostPath:
             path: /lib/modules


### PR DESCRIPTION
* with aPod setup amount of cp nodes will increase drastically, and it does not make sense to run metadata agents as DaemonSet there, hence it will run as a sidecar
* if apod is enabled in the region, metadata agents are not scheduled on apod nodes