### PR TITLE
vrops-exporter: nvme datastore utilization alert

### DIFF
--- a/prometheus-exporters/vrops-exporter/alerts/datastore.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/datastore.alerts
@@ -47,7 +47,7 @@ groups:
 
   - alert: EphemeralDataStoreCapacityWarning
     expr: >
-      vrops_datastore_diskspace_total_usage_gigabytes{type=~"ephemeral"}/ vrops_datastore_diskspace_capacity_gigabytes >= 0.8
+      vrops_datastore_diskspace_total_usage_gigabytes{type=~"ephemeral"} / vrops_datastore_diskspace_capacity_gigabytes >= 0.8
     for: 20m
     labels:
       severity: warning

--- a/prometheus-exporters/vrops-exporter/alerts/datastore.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/datastore.alerts
@@ -143,7 +143,7 @@ groups:
 
   - alert: DataStoreCapacityWarning
     expr: >
-      max_over_time(vrops_datastore_diskspace_total_usage_gigabytes{type!~"ephemeral|vVOL|vfms.+"}[10m]) / max_over_time(vrops_datastore_diskspace_capacity_gigabytes[10m]) >=  0.8
+      max_over_time(vrops_datastore_diskspace_total_usage_gigabytes{type!~"ephemeral|vVOL|vfms.+", datastore!~".+swap"}[10m]) / max_over_time(vrops_datastore_diskspace_capacity_gigabytes[10m]) >=  0.8
     for: 20m
     labels:
       severity: warning
@@ -159,7 +159,7 @@ groups:
 
   - alert: DataStoreCapacityCritical
     expr: >
-      max_over_time(vrops_datastore_diskspace_total_usage_gigabytes{type!~"ephemeral|vVOL|vfms.+"}[10m]) / max_over_time(vrops_datastore_diskspace_capacity_gigabytes[10m]) >=  0.9
+      max_over_time(vrops_datastore_diskspace_total_usage_gigabytes{type!~"ephemeral|vVOL|vfms.+", datastore!~".+swap"}[10m]) / max_over_time(vrops_datastore_diskspace_capacity_gigabytes[10m]) >=  0.9
     for: 20m
     labels:
       severity: critical
@@ -172,6 +172,22 @@ groups:
     annotations:
       description: "{{ $labels.type }} datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})"
       summary: "{{ $labels.type }} datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})"
+
+  - alert: NVMeDataStoreCapacityWarning
+    expr: >
+      max_over_time(vrops_datastore_diskspace_total_usage_gigabytes{datastore=~".+swap"}[10m]) / max_over_time(vrops_datastore_diskspace_capacity_gigabytes[10m]) >=  0.85
+    for: 20m
+    labels:
+      severity: warning
+      tier: vmware
+      service: storage
+      context: "NVMe-Datastore"
+      meta: "NVMe datastore {{ $labels.datastore }} utilization >= 85%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})"
+      dashboard: vcenter-datastore-utilization
+      playbook: docs/support/playbook/datastore/datastorediskusagealarm.html
+    annotations:
+      description: "NVMe datastore {{ $labels.datastore }} utilization >= 85%. Consider to move VMs. ({{ $labels.vcenter }}, {{ $labels.datacenter }})"
+      summary: "NVMe datastore {{ $labels.datastore }} utilization >= 85%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})"
 
   - alert: DatastoreDisconnectedWithVmsOnIt
     expr: >

--- a/prometheus-exporters/vrops-exporter/alerts/datastore.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/datastore.alerts
@@ -47,13 +47,13 @@ groups:
 
   - alert: EphemeralDataStoreCapacityWarning
     expr: >
-      max_over_time(vrops_datastore_diskspace_total_usage_gigabytes{type=~"ephemeral"}[10m]) / max_over_time(vrops_datastore_diskspace_capacity_gigabytes[10m]) >= 0.8
+      vrops_datastore_diskspace_total_usage_gigabytes{type=~"ephemeral"}/ vrops_datastore_diskspace_capacity_gigabytes >= 0.8
     for: 20m
     labels:
       severity: warning
       tier: vmware
       service: storage
-      context: "vrops-exporter"
+      context: "ephemeral-datastore"
       meta: "Eph Datastore {{ $labels.datastore }} utilization > 80%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})"
       dashboard: vcenter-datastore-utilization
       playbook: docs/support/playbook/datastore/datastorediskusagealarm.html
@@ -61,15 +61,15 @@ groups:
       description: "Eph Datastore {{ $labels.datastore }} utilization > 80%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})"
       summary: "Eph Datastore {{ $labels.datastore }} utilization > 80%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})"
 
-  - alert: EphemralDataStoreCapacityCritical
+  - alert: EphemeralDataStoreCapacityCritical
     expr: >
-      max_over_time(vrops_datastore_diskspace_total_usage_gigabytes{type=~"ephemeral"}[10m]) / max_over_time(vrops_datastore_diskspace_capacity_gigabytes[10m]) >=  0.9
+      vrops_datastore_diskspace_total_usage_gigabytes{type=~"ephemeral"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.9
     for: 20m
     labels:
       severity: critical
       tier: vmware
       service: storage
-      context: "vrops-exporter"
+      context: "ephemeral-datastore"
       meta: "Eph Datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})"
       dashboard: vcenter-datastore-utilization
       playbook: docs/support/playbook/datastore/datastorediskusagealarm.html
@@ -79,13 +79,13 @@ groups:
 
   - alert: VVolDataStoreCapacityWarning
     expr: >
-      max_over_time(vrops_datastore_diskspace_total_usage_gigabytes{type="vVOL"}[10m]) / max_over_time(vrops_datastore_diskspace_capacity_gigabytes[10m]) >= 0.8
+      vrops_datastore_diskspace_total_usage_gigabytes{type="vVOL"} / vrops_datastore_diskspace_capacity_gigabytes >= 0.8
     for: 20m
     labels:
       severity: warning
       tier: os
       service: storage
-      context: "vrops-exporter"
+      context: "vvol-datastore"
       meta: "vVOL Datastore {{ $labels.datastore }} utilization > 80%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})"
       dashboard: vcenter-datastore-utilization
       playbook: docs/support/playbook/cinder/balancing/cinder_balance_alert.html
@@ -95,13 +95,13 @@ groups:
 
   - alert: VVolDataStoreCapacityCritical
     expr: >
-      max_over_time(vrops_datastore_diskspace_total_usage_gigabytes{type="vVOL"}[10m]) / max_over_time(vrops_datastore_diskspace_capacity_gigabytes[10m]) >=  0.9
+      vrops_datastore_diskspace_total_usage_gigabytes{type="vVOL"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.9
     for: 20m
     labels:
       severity: critical
       tier: os
       service: storage
-      context: "vrops-exporter"
+      context: "vvol-datastore"
       meta: "vVOL Datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})"
       dashboard: vcenter-datastore-utilization
       playbook: docs/support/playbook/cinder/balancing/cinder_balance_alert.html
@@ -111,13 +111,13 @@ groups:
 
   - alert: VmfsDataStoreCapacityWarning
     expr: >
-      max_over_time(vrops_datastore_diskspace_total_usage_gigabytes{type=~"vmfs.+"}[10m]) / max_over_time(vrops_datastore_diskspace_capacity_gigabytes[10m]) >= 0.8
+      vrops_datastore_diskspace_total_usage_gigabytes{type=~"vmfs.+"} / vrops_datastore_diskspace_capacity_gigabytes >= 0.8
     for: 20m
     labels:
       severity: warning
       tier: os
       service: storage
-      context: "vrops-exporter"
+      context: "vmfs-datastore"
       meta: "VMFS Datastore {{ $labels.datastore }} utilization > 80%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})"
       dashboard: vcenter-datastore-utilization
       playbook: docs/support/playbook/cinder/balancing/cinder_balance_alert.html
@@ -127,13 +127,13 @@ groups:
 
   - alert: VmfsDataStoreCapacityCritical
     expr: >
-      max_over_time(vrops_datastore_diskspace_total_usage_gigabytes{type=~"vmfs.+"}[10m]) / max_over_time(vrops_datastore_diskspace_capacity_gigabytes[10m]) >=  0.9
+      vrops_datastore_diskspace_total_usage_gigabytes{type=~"vmfs.+"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.9
     for: 20m
     labels:
       severity: critical
       tier: os
       service: storage
-      context: "vrops-exporter"
+      context: "vmfs-datastore"
       meta: "VMFS Datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})"
       dashboard: vcenter-datastore-utilization
       playbook: docs/support/playbook/cinder/balancing/cinder_balance_alert.html
@@ -143,13 +143,13 @@ groups:
 
   - alert: DataStoreCapacityWarning
     expr: >
-      max_over_time(vrops_datastore_diskspace_total_usage_gigabytes{type!~"ephemeral|vVOL|vfms.+", datastore!~".+swap"}[10m]) / max_over_time(vrops_datastore_diskspace_capacity_gigabytes[10m]) >=  0.8
+      vrops_datastore_diskspace_total_usage_gigabytes{type!~"ephemeral|vVOL|vfms.+", datastore!~".+swap"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.8
     for: 20m
     labels:
       severity: warning
       tier: vmware
       service: storage
-      context: "vrops-exporter"
+      context: "datastore"
       meta: "{{ $labels.type }} datastore {{ $labels.datastore }} utilization > 80%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})"
       dashboard: vcenter-datastore-utilization
       playbook: docs/support/playbook/datastore/datastorediskusagealarm.html
@@ -159,13 +159,13 @@ groups:
 
   - alert: DataStoreCapacityCritical
     expr: >
-      max_over_time(vrops_datastore_diskspace_total_usage_gigabytes{type!~"ephemeral|vVOL|vfms.+", datastore!~".+swap"}[10m]) / max_over_time(vrops_datastore_diskspace_capacity_gigabytes[10m]) >=  0.9
+      vrops_datastore_diskspace_total_usage_gigabytes{type!~"ephemeral|vVOL|vfms.+", datastore!~".+swap"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.9
     for: 20m
     labels:
       severity: critical
       tier: vmware
       service: storage
-      context: "vrops-exporter"
+      context: "datastore"
       meta: "{{ $labels.type }} datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})"
       dashboard: vcenter-datastore-utilization
       playbook: docs/support/playbook/datastore/datastorediskusagealarm.html
@@ -175,7 +175,7 @@ groups:
 
   - alert: NVMeDataStoreCapacityWarning
     expr: >
-      max_over_time(vrops_datastore_diskspace_total_usage_gigabytes{datastore=~".+swap"}[10m]) / max_over_time(vrops_datastore_diskspace_capacity_gigabytes[10m]) >=  0.85
+      vrops_datastore_diskspace_total_usage_gigabytes{datastore=~".+swap"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.85
     for: 20m
     labels:
       severity: warning
@@ -191,14 +191,14 @@ groups:
 
   - alert: DatastoreDisconnectedWithVmsOnIt
     expr: >
-      max_over_time(vrops_datastore_summary_total_number_vms[10m]) > 0
-      and on (datastore) max_over_time(vrops_datastore_summary_datastore_accessible{type!~"local", state="PoweredOff"}[10m])
+      vrops_datastore_summary_total_number_vms > 0
+      and on (datastore) vrops_datastore_summary_datastore_accessible{type!~"local", state="PoweredOff"}
     for: 20m
     labels:
       severity: critical
       tier: vmware
       service: storage
-      context: "vrops-exporter"
+      context: "datastore-disconnected"
       meta: "Datastore {{ $labels.datastore }} is disconnected and has virtual machines on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})"
       playbook: docs/devops/alert/vcenter/#test_eph_ds_1
     annotations:
@@ -207,14 +207,14 @@ groups:
 
   - alert: DatastoreDisconnectedWithoutVmsOnIt
     expr: >
-      max_over_time(vrops_datastore_summary_total_number_vms[10m]) == 0
-      and on (datastore) max_over_time(vrops_datastore_summary_datastore_accessible{type!~"local", state="PoweredOff"}[10m])
+      vrops_datastore_summary_total_number_vms == 0
+      and on (datastore) vrops_datastore_summary_datastore_accessible{type!~"local", state="PoweredOff"}
     for: 20m
     labels:
       severity: warning
       tier: vmware
       service: storage
-      context: "vrops-exporter"
+      context: "datastore-disconnected"
       meta: "Datastore {{ $labels.datastore }} is disconnected without virtual machines on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})"
       playbook: docs/devops/alert/vcenter/#test_eph_ds_2
     annotations:


### PR DESCRIPTION
New (local) NVMe swap datastore. According to Thomas Thimm no critical alert needed. As requested, created separate alert with 85% threshold.