### PR TITLE
[swift-utils] Collect metrics from caretaker

### DIFF
--- a/openstack/swift-utils/alerts/caretaker.alerts
+++ b/openstack/swift-utils/alerts/caretaker.alerts
@@ -10,7 +10,7 @@ groups:
       service: swift
       severity: info
       tier: os
-      meta: '{{ $value }} orphan Swift Accounts'
+      meta: '{{ $value }} orphaned Swift accounts'
     annotations:
-      description: '{{ $value }} Swift Accounts are orphan. An in proper project deletion can cause this. Check the logs of pod swift-account-caretaker-mergify-XXX and the <https://dashboard.{{ $labels.region }}.cloud.sap/cc3test/swift_test/object-storage/containers/caretaker/raw/accounts_orphan.csv?inline=1|list> of orphan Accounts.'
-      summary: More than 10 Swift Accounts are orphan
+      description: '{{ $value }} Swift accounts are orphaned. An improper project deletion can cause this. Check the logs of pod swift-account-caretaker-mergify-XXX and the <https://dashboard.{{ $labels.region }}.cloud.sap/cc3test/swift_test/object-storage/containers/caretaker/raw/accounts_orphan.csv?inline=1|list of orphaned accounts>.'
+      summary: More than 10 Swift accounts are orphaned

--- a/openstack/swift-utils/alerts/caretaker.alerts
+++ b/openstack/swift-utils/alerts/caretaker.alerts
@@ -10,8 +10,8 @@ groups:
       service: swift
       severity: info
       tier: os
-      meta: more than 10 Swift Accounts are orphan
+      meta: {{ $value }} orphan Swift Accounts
     annotations:
-      description: An in proper project deletion can cause this. Check the logs of pod
-        swift-account-caretaker-mergify-XXX.
+      description: {{ $value }} Swift Accounts are orphan. An in proper project deletion can cause this. Check the logs of pod
+        swift-account-caretaker-mergify-XXX and the <https://dashboard.{{ labels.region }}.cloud.sap/cc3test/swift_test/object-storage/containers/caretaker/raw/accounts_orphan.csv?inline=1|list> of orphan Accounts.
       summary: More than 10 Swift Accounts are orphan

--- a/openstack/swift-utils/alerts/caretaker.alerts
+++ b/openstack/swift-utils/alerts/caretaker.alerts
@@ -12,5 +12,5 @@ groups:
       tier: os
       meta: '{{ $value }} orphan Swift Accounts'
     annotations:
-      description: '{{ $value }} Swift Accounts are orphan. An in proper project deletion can cause this. Check the logs of pod swift-account-caretaker-mergify-XXX and the <https://dashboard.{{ $externalLabels.region }}.cloud.sap/cc3test/swift_test/object-storage/containers/caretaker/raw/accounts_orphan.csv?inline=1|list> of orphan Accounts.'
+      description: '{{ $value }} Swift Accounts are orphan. An in proper project deletion can cause this. Check the logs of pod swift-account-caretaker-mergify-XXX and the <https://dashboard.{{ $labels.region }}.cloud.sap/cc3test/swift_test/object-storage/containers/caretaker/raw/accounts_orphan.csv?inline=1|list> of orphan Accounts.'
       summary: More than 10 Swift Accounts are orphan

--- a/openstack/swift-utils/alerts/caretaker.alerts
+++ b/openstack/swift-utils/alerts/caretaker.alerts
@@ -1,0 +1,17 @@
+groups:
+- name: openstack-swift-caretaker.alerts
+  rules:
+  - alert: OpenstackSwiftOrphanAccounts
+    expr: max(swift_cluster_accounts_orphan) > 10
+    for: 15m
+    labels:
+      context: orphanaccounts
+      dashboard: swift-overview
+      service: swift
+      severity: info
+      tier: os
+      meta: more than 10 Swift Accounts are orphan
+    annotations:
+      description: An in proper project deletion can cause this. Check the logs of pod
+        swift-account-caretaker-mergify-XXX.
+      summary: More than 10 Swift Accounts are orphan

--- a/openstack/swift-utils/alerts/caretaker.alerts
+++ b/openstack/swift-utils/alerts/caretaker.alerts
@@ -13,5 +13,5 @@ groups:
       meta: {{ $value }} orphan Swift Accounts
     annotations:
       description: {{ $value }} Swift Accounts are orphan. An in proper project deletion can cause this. Check the logs of pod
-        swift-account-caretaker-mergify-XXX and the <https://dashboard.{{ labels.region }}.cloud.sap/cc3test/swift_test/object-storage/containers/caretaker/raw/accounts_orphan.csv?inline=1|list> of orphan Accounts.
+        swift-account-caretaker-mergify-XXX and the <https://dashboard.{{ $externalLabels.region }}.cloud.sap/cc3test/swift_test/object-storage/containers/caretaker/raw/accounts_orphan.csv?inline=1|list> of orphan Accounts.
       summary: More than 10 Swift Accounts are orphan

--- a/openstack/swift-utils/alerts/caretaker.alerts
+++ b/openstack/swift-utils/alerts/caretaker.alerts
@@ -10,8 +10,7 @@ groups:
       service: swift
       severity: info
       tier: os
-      meta: {{ $value }} orphan Swift Accounts
+      meta: '{{ $value }} orphan Swift Accounts'
     annotations:
-      description: {{ $value }} Swift Accounts are orphan. An in proper project deletion can cause this. Check the logs of pod
-        swift-account-caretaker-mergify-XXX and the <https://dashboard.{{ $externalLabels.region }}.cloud.sap/cc3test/swift_test/object-storage/containers/caretaker/raw/accounts_orphan.csv?inline=1|list> of orphan Accounts.
+      description: '{{ $value }} Swift Accounts are orphan. An in proper project deletion can cause this. Check the logs of pod swift-account-caretaker-mergify-XXX and the <https://dashboard.{{ $externalLabels.region }}.cloud.sap/cc3test/swift_test/object-storage/containers/caretaker/raw/accounts_orphan.csv?inline=1|list> of orphan Accounts.'
       summary: More than 10 Swift Accounts are orphan

--- a/openstack/swift-utils/ci/test-values.yaml
+++ b/openstack/swift-utils/ci/test-values.yaml
@@ -1,0 +1,6 @@
+global:
+  tld: example.com
+  region: regionOne
+  registryAlternateRegion: registry.example.com
+
+image_version: stein-20190101094554

--- a/openstack/swift-utils/templates/account-caretaker-mergify-deployment.yaml
+++ b/openstack/swift-utils/templates/account-caretaker-mergify-deployment.yaml
@@ -23,6 +23,8 @@ spec:
       annotations:
         checksum/caretaker.etc: {{ include "swift-utils/templates/caretaker-configmap.yaml" . | sha256sum }}
         checksum/secret: {{ include "swift-utils/templates/secret.yaml" . | sha256sum }}
+        prometheus.io/scrape: "true"
+        prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus }}
     spec:
       volumes:
         - name: caretaker-etc
@@ -64,5 +66,28 @@ spec:
             limits:
               cpu: '100m'
               memory: '128Mi'
+          {{- end }}
+        - name: statsd
+          image: {{ .Values.global.dockerHubMirrorAlternateRegion }}/prom/statsd-exporter:{{ .Values.image_version_auxiliary_statsd_exporter }}
+          args:
+            - --statsd.mapping-config=/caretaker-etc/statsd-exporter.yaml
+            - --statsd.listen-udp=:8125
+          ports:
+            - name: statsd
+              containerPort: 8125
+              protocol: UDP
+            - name: metrics
+              containerPort: 9102
+          volumeMounts:
+            - mountPath: /caretaker-etc
+              name: caretaker-etc
+          {{- if .Values.resources.enabled }}
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "100Mi"
+            limits:
+              cpu: "50m"
+              memory: "100Mi"
           {{- end }}
 {{- end }}

--- a/openstack/swift-utils/templates/caretaker-configmap.yaml
+++ b/openstack/swift-utils/templates/caretaker-configmap.yaml
@@ -41,3 +41,14 @@ data:
         {{- end }}
         insecure: {{ $config.insecure | default false }}
       {{- end }}
+
+  statsd-exporter.yaml: |
+    defaults:
+      timer_type: histogram
+      buckets: [.025, .1, .25, 1, 2.5]
+      match_type: glob
+      glob_disable_ordering: false
+      ttl: 0 # metrics do not expire
+    mappings:
+    - match: caretaker.accounts.*
+      name: "swift_cluster_accounts_${1}"

--- a/openstack/swift-utils/templates/prometheus-alerts.yaml
+++ b/openstack/swift-utils/templates/prometheus-alerts.yaml
@@ -1,0 +1,20 @@
+{{- $values := .Values }}
+{{- if $values.alerts.enabled }}
+{{- range $path, $bytes := .Files.Glob "alerts/*.alerts" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: {{ printf "%s" $path | replace "/" "-" }}
+  labels:
+    app: swift
+    tier: os
+    type: alerting-rules
+    prometheus: {{ required ".Values.alerts.prometheus missing" $values.alerts.prometheus }}
+
+spec:
+{{ printf "%s" $bytes | indent 2 }}
+
+{{- end }}
+{{- end }}

--- a/openstack/swift-utils/values.yaml
+++ b/openstack/swift-utils/values.yaml
@@ -13,9 +13,14 @@ imageRegistry_repo: swift
 # the version should follow the format openstackreleasename-versionnumber
 # e.g. mitaka-12345
 image_version: DEFINED_BY_PIPELINE
+image_version_auxiliary_statsd_exporter: 'v0.8.1'
 
 resources:
   enabled: true
+
+alerts:
+  enabled: true
+  prometheus: openstack
 
 # Deploy swift-account-caretaker
 swift_account_caretaker:

--- a/openstack/swift-utils/values.yaml
+++ b/openstack/swift-utils/values.yaml
@@ -16,25 +16,25 @@ image_version: DEFINED_BY_PIPELINE
 image_version_auxiliary_statsd_exporter: 'v0.8.1'
 
 resources:
-  enabled: true
+    enabled: true
 
 alerts:
-  enabled: true
-  prometheus: openstack
+    enabled: true
+    prometheus: openstack
 
 # Deploy swift-account-caretaker
 swift_account_caretaker:
-  enable: true
-  auth_url: DEFINED_IN_REGION_CHART
-  password: DEFINED_IN_REGION_CHART
-  # additional_clusters:
-  #   cluster-X:
-  #     os_auth_url: DEFINED_IN_REGION_CHART
-  #     os_user_domain_name: DEFINED_IN_REGION_CHART
-  #     os_username: DEFINED_IN_REGION_CHART
-  #     os_password: DEFINED_IN_REGION_CHART
-  #     os_project_domain_name: DEFINED_IN_REGION_CHART
-  #     os_project_name: DEFINED_IN_REGION_CHART
-  #     #scrape:
-  #     #os_interface:
-  #     #insecure:
+    enable: true
+    auth_url: DEFINED_IN_REGION_CHART
+    password: DEFINED_IN_REGION_CHART
+    # additional_clusters:
+    #   cluster-X:
+    #     os_auth_url: DEFINED_IN_REGION_CHART
+    #     os_user_domain_name: DEFINED_IN_REGION_CHART
+    #     os_username: DEFINED_IN_REGION_CHART
+    #     os_password: DEFINED_IN_REGION_CHART
+    #     os_project_domain_name: DEFINED_IN_REGION_CHART
+    #     os_project_name: DEFINED_IN_REGION_CHART
+    #     #scrape:
+    #     #os_interface:
+    #     #insecure:

--- a/openstack/swift-utils/values.yaml
+++ b/openstack/swift-utils/values.yaml
@@ -27,14 +27,14 @@ swift_account_caretaker:
     enable: true
     auth_url: DEFINED_IN_REGION_CHART
     password: DEFINED_IN_REGION_CHART
-    # additional_clusters:
-    #   cluster-X:
-    #     os_auth_url: DEFINED_IN_REGION_CHART
-    #     os_user_domain_name: DEFINED_IN_REGION_CHART
-    #     os_username: DEFINED_IN_REGION_CHART
-    #     os_password: DEFINED_IN_REGION_CHART
-    #     os_project_domain_name: DEFINED_IN_REGION_CHART
-    #     os_project_name: DEFINED_IN_REGION_CHART
-    #     #scrape:
-    #     #os_interface:
-    #     #insecure:
+#   additional_clusters:
+#       cluster-X:
+#           os_auth_url: DEFINED_IN_REGION_CHART
+#           os_user_domain_name: DEFINED_IN_REGION_CHART
+#           os_username: DEFINED_IN_REGION_CHART
+#           os_password: DEFINED_IN_REGION_CHART
+#           os_project_domain_name: DEFINED_IN_REGION_CHART
+#           os_project_name: DEFINED_IN_REGION_CHART
+#           #scrape:
+#           #os_interface:
+#           #insecure:


### PR DESCRIPTION
With https://github.com/sapcc/swift-account-caretaker/pull/18 swift-account-caretaker
can emit statsd metrics for the number of Swift Accounts which are orphan.

Collect them with the statsd-exporter and create alerting for it.