### PR TITLE
[cinder] Added the memcached coordination config

### DIFF
--- a/openstack/cinder/templates/etc/_cinder.conf.tpl
+++ b/openstack/cinder/templates/etc/_cinder.conf.tpl
@@ -103,3 +103,6 @@ user_domain_name = "{{.Values.global.keystone_service_domain | default "Default"
 project_name = "{{.Values.global.keystone_service_project | default "service" }}"
 project_domain_name = "{{.Values.global.keystone_service_domain | default "Default" }}"
 region_name = {{.Values.global.region}}
+
+[coordination]
+backend_url = memcached://{{ .Chart.Name }}-memcached.{{ include "svc_fqdn" . }}:{{ .Values.memcached.memcached.port | default 11211 }}


### PR DESCRIPTION
This patch adds the coordination section to the cinder.conf
to enable tooz memcached based coordinated locks for each cinder
service.