### PR TITLE
Fixing odd RAM values to even RAM values

### DIFF
--- a/openstack/sap-seeds/templates/flavor-seed.yaml
+++ b/openstack/sap-seeds/templates/flavor-seed.yaml
@@ -470,12 +470,12 @@ spec:
   - name: "hana_c24_m365"
     id: "200"
     vcpus: 24
-    ram: 373353
+    ram: 373352
     disk: 64
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-      "resources:CUSTOM_MEMORY_RESERVABLE_MB": "373353"
+      "resources:CUSTOM_MEMORY_RESERVABLE_MB": "373352"
       "trait:CUSTOM_NUMASIZE_C48_M729": "required"
   - name: "hana_c48_m729"
     id: "201"
@@ -501,23 +501,23 @@ spec:
   - name: "hana_c144_m2188"
     id: "203"
     vcpus: 144
-    ram: 2240199
+    ram: 2240198
     disk: 64
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-      "resources:CUSTOM_MEMORY_RESERVABLE_MB": "2240199"
+      "resources:CUSTOM_MEMORY_RESERVABLE_MB": "2240198"
       "resources:CUSTOM_BIGVM": "2"
       "trait:CUSTOM_NUMASIZE_C48_M729": "required"
   - name: "hana_c192_m2917"
     id: "204"
     vcpus: 192
-    ram: 2986937
+    ram: 2986936
     disk: 64
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-      "resources:CUSTOM_MEMORY_RESERVABLE_MB": "2986937"
+      "resources:CUSTOM_MEMORY_RESERVABLE_MB": "2986936"
       "resources:CUSTOM_BIGVM": "2"
       "trait:CUSTOM_NUMASIZE_C48_M729": "required"
   # - name: "hana_c384_m5835"
@@ -544,23 +544,23 @@ spec:
   - name: "hana_c48_m1459"
     id: "207"
     vcpus: 48
-    ram: 1493833
+    ram: 1493832
     disk: 64
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-      "resources:CUSTOM_MEMORY_RESERVABLE_MB": "1493833"
+      "resources:CUSTOM_MEMORY_RESERVABLE_MB": "1493832"
       "resources:CUSTOM_BIGVM": "2"
       "trait:CUSTOM_NUMASIZE_C48_M1459": "required"
   - name: "hana_c96_m2918"
     id: "208"
     vcpus: 96
-    ram: 2987681
+    ram: 2987680
     disk: 64
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-      "resources:CUSTOM_MEMORY_RESERVABLE_MB": "2987681"
+      "resources:CUSTOM_MEMORY_RESERVABLE_MB": "2987680"
       "resources:CUSTOM_BIGVM": "2"
       "trait:CUSTOM_NUMASIZE_C48_M1459": "required"
   - name: "hana_c144_m4377"
@@ -577,11 +577,11 @@ spec:
   - name: "hana_c192_m5835"
     id: "210"
     vcpus: 192
-    ram: 5975379
+    ram: 5975378
     disk: 64
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-      "resources:CUSTOM_MEMORY_RESERVABLE_MB": "5975379"
+      "resources:CUSTOM_MEMORY_RESERVABLE_MB": "5975378"
       "resources:CUSTOM_BIGVM": "2"
       "trait:CUSTOM_NUMASIZE_C48_M1459": "required"


### PR DESCRIPTION
Looks like Flavor do not work in vSphere with odd RAM numbers