### PR TITLE
[kube-system-kubernikus] adds metrics-server, vpa in recommendation mode

### DIFF
--- a/system/kube-system-kubernikus/Chart.lock
+++ b/system/kube-system-kubernikus/Chart.lock
@@ -26,5 +26,11 @@ dependencies:
 - name: pull-secret-injector
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.3
-digest: sha256:c538586e59202842aa6ad4bf3c58b0a19859cfa790e6578737efa2e63575a07d
-generated: "2021-05-06T18:17:03.397174+03:00"
+- name: metrics-server
+  repository: https://charts.eu-de-2.cloud.sap
+  version: 1.0.4
+- name: vertical-pod-autoscaler
+  repository: https://charts.eu-de-2.cloud.sap
+  version: 1.0.1
+digest: sha256:fae062b919642477a393c8883f865a4aa7694238cfb579a739a828af41f54405
+generated: "2021-05-17T10:41:53.047788+02:00"

--- a/system/kube-system-kubernikus/Chart.yaml
+++ b/system/kube-system-kubernikus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for Kubernikus control-plane clusters.
 name: kube-system-kubernikus
-version: 0.7.19
+version: 0.8.0
 dependencies:
   - name: cc-rbac
     repository: https://charts.eu-de-2.cloud.sap
@@ -30,3 +30,9 @@ dependencies:
   - name: pull-secret-injector
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.1.3
+  - name: metrics-server
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 1.0.4
+  - name: vertical-pod-autoscaler
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 1.0.1


### PR DESCRIPTION
This PR adds the [metrics-server](https://github.com/sapcc/helm-charts/tree/master/system/metrics-server) and [vertical pod autoscaler](https://github.com/sapcc/helm-charts/tree/master/system/vertical-pod-autoscaler) to the kube-system-kubernikus chart.