### PR TITLE
[common][pgmetrics] use metrics image from dockerhub mirror

### DIFF
--- a/common/pgmetrics/Chart.yaml
+++ b/common/pgmetrics/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Postgres Metrics
 name: pgmetrics
-version: 0.1.1
+version: 0.1.0

--- a/common/pgmetrics/Chart.yaml
+++ b/common/pgmetrics/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Postgres Metrics
 name: pgmetrics
-version: 0.1.0
+version: 0.1.1

--- a/common/pgmetrics/templates/deployment.yaml
+++ b/common/pgmetrics/templates/deployment.yaml
@@ -37,10 +37,10 @@ spec:
     spec:
       containers:
       - name: metrics
-        {{- if hasKey .Values.global "dockerHubMirror"}}
-        image: {{.Values.global.dockerHubMirror}}/{{ .Values.image }}:{{ .Values.imageTag }}
-        {{- else }}
+        {{- if contains "." .Values.image }}
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        {{- else }}
+        image: "{{ required ".Values.global.dockerHubMirror missing" .Values.global.dockerHubMirror }}/{{ .Values.image }}:{{ .Values.imageTag }}"
         {{- end }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.imagePullPolicy | quote }}
         env:

--- a/common/pgmetrics/templates/deployment.yaml
+++ b/common/pgmetrics/templates/deployment.yaml
@@ -37,7 +37,11 @@ spec:
     spec:
       containers:
       - name: metrics
+        {{- if hasKey .Values.global "dockerHubMirror"}}
+        image: {{.Values.global.dockerHubMirror}}/{{ .Values.image }}:{{ .Values.imageTag }}
+        {{- else }}
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        {{- end }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.imagePullPolicy | quote }}
         env:
         - name: DATA_SOURCE_NAME


### PR DESCRIPTION
Hi @majewsky 

Please validate this PR, i saw sentry mentioned in the DOOP dashboard. Later i found few of your services still use pgmetrics.

Regards,
Rajiv