### PR TITLE
[Cinder] Update cinder.conf to use admin endpoint

### DIFF
--- a/openstack/cinder/templates/etc/_cinder.conf.tpl
+++ b/openstack/cinder/templates/etc/_cinder.conf.tpl
@@ -106,3 +106,6 @@ region_name = {{.Values.global.region}}
 
 [coordination]
 backend_url = memcached://{{ .Chart.Name }}-memcached.{{ include "svc_fqdn" . }}:{{ .Values.memcached.memcached.port | default 11211 }}
+
+[nova]
+interface = admin


### PR DESCRIPTION
This patch adds the nova section to cinder.conf to
tell cinder to use the nova admin interface when making
callbacks to nova.   This is so we don't get message notification
errors due to policy permissions.