### PR TITLE
Adding three new flavors for Neo

### DIFF
--- a/openstack/sap-seeds/templates/flavor-seed.yaml
+++ b/openstack/sap-seeds/templates/flavor-seed.yaml
@@ -371,6 +371,16 @@ spec:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
       "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+  - name: "m_c32_m256"
+    id: "163"
+    vcpus: 32
+    ram: 262128
+    disk: 64
+    is_public: true
+    extra_specs:
+      "vmware:hv_enabled": "True"
+      "hw_video:ram_max_mb": "16"
+      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
   - name: "g_c64_m256"
     id: "220"
     vcpus: 64
@@ -381,6 +391,16 @@ spec:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
       "catalog:alias": "m5.16xlarge"
+      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+  - name: "m_c48_m512"
+    id: "221"
+    vcpus: 48
+    ram: 524272
+    disk: 64
+    is_public: true
+    extra_specs:
+      "vmware:hv_enabled": "True"
+      "hw_video:ram_max_mb": "16"
       "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
   - name: "g_c128_m512"
     id: "230"
@@ -403,7 +423,7 @@ spec:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
       "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
-  - name: "m5.64xlarge"
+  - name: "m_c128_m1000"
     id: "240"
     vcpus: 128
     ram: 1048560
@@ -412,6 +432,8 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
+      "catalog:alias": "m5.64xlarge"
+      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
 
   ### Deprecated BigVM flavors
   - name: "m5.96xlarge"


### PR DESCRIPTION
One alias for m5.64xlarge flavor to m_c128_m1000 and two new flavors which are needed from NEO: m_c32_m256 and m_c48_m512.