### PR TITLE
[nova] Set Openstack Request Id in Ingress

### DIFF
--- a/openstack/nova/templates/api-ingress.yaml
+++ b/openstack/nova/templates/api-ingress.yaml
@@ -7,8 +7,10 @@ metadata:
     system: openstack
     type: api
     component: nova
-  {{- if .Values.use_tls_acme }}
   annotations:
+    ingress.kubernetes.io/configuration-snippet: |
+      {{- include "utils.snippets.set_openstack_request_id" . | indent 6 }}
+  {{- if .Values.use_tls_acme }}
     kubernetes.io/tls-acme: "true"
   {{- end }}
 spec:

--- a/openstack/nova/templates/etc/_nova.conf.tpl
+++ b/openstack/nova/templates/etc/_nova.conf.tpl
@@ -5,6 +5,7 @@
 {{- end }}
 
 log_config_append = /etc/nova/logging.ini
+logging_context_format_string = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [%(request_id)s g%(global_request_id)s %(user_identity)s] %(instance)s%(message)s
 state_path = /var/lib/nova
 
 # we patched this to be treated as force_resize_to_same_host for mitaka

--- a/openstack/nova/templates/placement-ingress.yaml
+++ b/openstack/nova/templates/placement-ingress.yaml
@@ -7,8 +7,10 @@ metadata:
     system: openstack
     type: api
     component: nova
-  {{- if .Values.use_tls_acme }}
   annotations:
+    ingress.kubernetes.io/configuration-snippet: |
+      {{- include "utils.snippets.set_openstack_request_id" . | indent 6 }}
+  {{- if .Values.use_tls_acme }}
     kubernetes.io/tls-acme: "true"
   {{- end }}
 spec:


### PR DESCRIPTION
Various openstack services support forwarding a global request id since Pike.
This sets the value in the ingress and log it with a g-prefix to differentiate
it from the normal request id.