### PR TITLE
[Cinder] Set Openstack Request Id in Ingress

### DIFF
--- a/openstack/cinder/templates/api-ingress.yaml
+++ b/openstack/cinder/templates/api-ingress.yaml
@@ -7,8 +7,10 @@ metadata:
     system: openstack
     type: api
     component: cinder
-  {{- if .Values.use_tls_acme }}
   annotations:
+    ingress.kubernetes.io/configuration-snippet: |
+      {{- include "utils.snippets.set_openstack_request_id" . | indent 6 }}
+  {{- if .Values.use_tls_acme }}
     kubernetes.io/tls-acme: "true"
   {{- end }}
 spec:

--- a/openstack/cinder/templates/etc/_cinder.conf.tpl
+++ b/openstack/cinder/templates/etc/_cinder.conf.tpl
@@ -1,5 +1,7 @@
 [DEFAULT]
 log_config_append = /etc/cinder/logging.ini
+logging_context_format_string = %(process)d %(levelname)s %(name)s [%(request_id)s g%(global_request_id)s %(user_identity)s] %(instance)s%(message)s
+
 backup_swift_url = https://objectstore-3.{{.Values.global.region}}.{{.Values.global.tld}}:443/v1/AUTH_
 backup_swift_auth_version = 2
 backup_driver = cinder.backup.drivers.swift.SwiftBackupDriver


### PR DESCRIPTION
This sets the value in the ingress and log it with a g-prefix to differentiate
it from the normal request id. If the request comes over nova-api, nova will forward the request-id to cinder.
Cinder should forward the very same id then to other services (e.g. glance, or back to nova in case of call-backs)

It has been added after the normal logging-context string:
logging_context_format_string = %(process)d %(levelname)s %(name)s [%(request_id)s %(user_identity)s] %(instance)s%(message)s

If the request did not came in over ingress (e.g. internally by the service) it will render to gNone