### PR TITLE
[Neutron] Set Openstack Request Id in Ingress

### DIFF
--- a/openstack/neutron/templates/etc/_neutron.conf.tpl
+++ b/openstack/neutron/templates/etc/_neutron.conf.tpl
@@ -4,6 +4,8 @@ debug = {{.Values.debug}}
 verbose = True
 
 log_config_append = /etc/neutron/logging.conf
+logging_context_format_string = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [%(request_id)s g%(global_request_id)s %(user_identity)s] %(instance)s%(message)s
+
 api_paste_config = /etc/neutron/api-paste.ini
 {{ include "ini_sections.default_transport_url" . }}
 

--- a/openstack/neutron/templates/ingress-server.yaml
+++ b/openstack/neutron/templates/ingress-server.yaml
@@ -10,6 +10,8 @@ metadata:
     component: neutron
   annotations:
     kubernetes.io/tls-acme: "true"
+    ingress.kubernetes.io/configuration-snippet: |
+      {{- include "utils.snippets.set_openstack_request_id" . | indent 6 }}
 spec:
   tls:
      - secretName: tls-{{include "neutron_api_endpoint_host_public" . | replace "." "-" }}


### PR DESCRIPTION
Nova (and hopefully other services) forward a global request id since Pike.
This sets the value in the ingress and log it with a g-prefix to differentiate
it from the normal request id.

It has been added after the normal logging-context string:
logging_context_format_string = %(process)d %(levelname)s %(name)s [%(request_id)s %(user_identity)s] %(instance)s%(message)s

If the request did not came in over ingress (e.g. internally by the service) it will render to gNone