### PR TITLE
[Ironic] Set Openstack Request Id in Ingress

### DIFF
--- a/openstack/ironic/templates/api-ingress.yaml
+++ b/openstack/ironic/templates/api-ingress.yaml
@@ -7,8 +7,10 @@ metadata:
     system: openstack
     type: api
     component: ironic
-  {{- if .Values.tls_acme }}
   annotations:
+    ingress.kubernetes.io/configuration-snippet: |
+      {{- include "utils.snippets.set_openstack_request_id" . | indent 6 }}
+  {{- if .Values.use_tls_acme }}
     kubernetes.io/tls-acme: "true"
   {{- end }}
 spec:

--- a/openstack/ironic/templates/etc/_ironic.conf.tpl
+++ b/openstack/ironic/templates/etc/_ironic.conf.tpl
@@ -1,5 +1,7 @@
 [DEFAULT]
 log_config_append = /etc/ironic/logging.ini
+logging_context_format_string =%(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [%(request_id)s g%(global_request_id)s %(user_identity)s] %(instance)s%(message)s
+
 {{- if contains "train" .Values.imageVersion }}
 pybasedir = /var/lib/openstack/lib/python3.6/site-packages/ironic
 {{- else }}


### PR DESCRIPTION
Nova (and hopefully other services) forward a global request id since Pike.
This sets the value in the ingress and log it with a g-prefix to differentiate
it from the normal request id.

It has been added after the normal logging-context string:
logging_context_format_string = %(process)d %(levelname)s %(name)s [%(request_id)s %(user_identity)s] %(instance)s%(message)s

If the request did not came in over ingress (e.g. internally by the service) it will render to gNone