### PR TITLE
Revert "vrops-exporter: HostWithRunningVMsNotResponding changed running VM metric"

### DIFF
--- a/prometheus-exporters/vrops-exporter/alerts/host.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/host.alerts
@@ -6,7 +6,7 @@ groups:
       vrops_hostsystem_runtime_connectionstate{state="notResponding"}
       and on (hostsystem) vrops_hostsystem_runtime_powerstate{state="Unknown"}
       and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"}
-      and on (hostsystem) vrops_hostsystem_summary_running_vms_number > 0
+      and on (hostsystem) count(vrops_virtualmachine_runtime_powerstate{state="Powered On"}) by (hostsystem) > 0
     for: 10m
     labels:
       severity: critical


### PR DESCRIPTION
Reverts sapcc/helm-charts#2408 because vROps returns the last number of virtual machines on the host despite disconnected host.