### PR TITLE
[ELK] Optionally parse global_request_id and duplicate msecs

### DIFF
--- a/system/elk/vendor/fluent/templates/_fluent.conf.tpl
+++ b/system/elk/vendor/fluent/templates/_fluent.conf.tpl
@@ -67,7 +67,7 @@
   reserve_data true
   <parse>
     @type grok
-    grok_pattern %{TIMESTAMP_ISO8601:timestamp}.%{NUMBER} %{NUMBER:pid} %{WORD:loglevel} %{NOTSPACE:logger} (\[)?(req-)?(%{REQUESTID:requestid})
+    grok_pattern %{TIMESTAMP_ISO8601:timestamp}(.%{NUMBER})? %{NUMBER:pid} %{WORD:loglevel} %{NOTSPACE:logger} (\[)?(req-)?%{NOTSPACE:requestid} (greq-%{UUID:global_requestid})?
     custom_pattern_path /fluent-bin/pattern
   </parse>
 </filter>


### PR DESCRIPTION
The log format for many openstack applications has been changed
to print a global request id, which is fairly strict in its format (req-<uuid>).
To be sure, that we do not parse something else as the global request id, the expression is equally strict.

The value is stored in global_requestid instead of adding it as another request id.
This allows us to easily identify the global request id in the search as it is its own field.

The logs are currently still printing the msecs twice. E.g. time,msecs.msecs.
In order to be able to remove that redundancy, make the .number field optional