### PR TITLE
Add rules create_port:fixed_ips:ip_address and create_port:fixed_ips:subnet_id to fix 403 error in Ussuri release

### DIFF
--- a/openstack/neutron/templates/etc/_neutron-policy.json.tpl
+++ b/openstack/neutron/templates/etc/_neutron-policy.json.tpl
@@ -94,6 +94,8 @@
     "create_port:device_owner": "(not rule:network_device and not rule:share_device) or rule:context_is_admin",
     "create_port:mac_address": "rule:context_is_network_editor",
     "create_port:fixed_ips": "rule:default",
+    "create_port:fixed_ips:ip_address": "rule:default",
+    "create_port:fixed_ips:subnet_id": "rule:default",
     "create_port:port_security_enabled": "rule:context_is_network_editor",
     "create_port:binding:host_id": "rule:context_is_network_admin",
     "create_port:binding:profile": "rule:context_is_network_admin",


### PR DESCRIPTION
This PR adds rules `create_port:fixed_ips:ip_address` and `create_port:fixed_ips:subnet_id` to fix 403 error when you try to create port in RBAC shared network:

```
HttpException: 403: Client Error for url: https://network-3.qa-de-1.cloud.sap/v2.0/ports, (rule:create_port and (rule:create_port:fixed_ips and (rule:create_port:fixed_ips:subnet_id and rule:create_port:fixed_ips:ip_address))) is disallowed by policy
```

These rules exist before but only in Ussuri release they were fixed and start working. As result we had problem with default value of rule `create_port:fixed_ips:ip_address` because by default it does not allow `ip_address` (https://github.com/openstack/neutron/blob/master/neutron/conf/policies/port.py#L124)