### PR TITLE
flavors: Make HANA RAM sizes multiple-of-4

### DIFF
--- a/openstack/sap-seeds/templates/flavor-seed.yaml
+++ b/openstack/sap-seeds/templates/flavor-seed.yaml
@@ -539,7 +539,7 @@ spec:
   - name: "hana_c48_m729"
     id: "301"
     vcpus: 48
-    ram: 746722
+    ram: 746720
     disk: 64
     extra_specs:
       "vmware:hv_enabled": "True"
@@ -560,7 +560,7 @@ spec:
   - name: "hana_c144_m2188"
     id: "303"
     vcpus: 144
-    ram: 2240198
+    ram: 2240196
     disk: 64
     extra_specs:
       "vmware:hv_enabled": "True"
@@ -629,7 +629,7 @@ spec:
   - name: "hana_c144_m4377"
     id: "309"
     vcpus: 144
-    ram: 4481530
+    ram: 4481528
     disk: 64
     extra_specs:
       "vmware:hv_enabled": "True"
@@ -642,7 +642,7 @@ spec:
   - name: "hana_c192_m5835"
     id: "310"
     vcpus: 192
-    ram: 5975378
+    ram: 5975376
     disk: 64
     extra_specs:
       "vmware:hv_enabled": "True"


### PR DESCRIPTION
VMware requires flavor RAM sizes to be a multiple of four MiB.
