### PR TITLE
nova/flavors: Add attrs for hana_c384_m5835 & ID update

### DIFF
--- a/openstack/sap-seeds/templates/flavor-seed.yaml
+++ b/openstack/sap-seeds/templates/flavor-seed.yaml
@@ -584,7 +584,7 @@ spec:
       "hw:cpu_cores": "2"
       "vmware:hw_version": "vmx-15"
   # - name: "hana_c384_m5835"
-  #   id: "205"
+  #   id: "305"
   #   vcpus: 384
   #   ram: 5975024
   #   disk: 64
@@ -594,6 +594,8 @@ spec:
   #     "resources:CUSTOM_MEMORY_RESERVABLE_MB": "5975024"
   #     "resources:CUSTOM_BIGVM": "2"
   #     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
+  #     "hw:cpu_cores": "3"
+  #     "vmware:hw_version": "vmx-15"
   - name: "hana_c24_m729"
     id: "306"
     vcpus: 24


### PR DESCRIPTION
IDs were changed to 300s.

Flavors with >128 vCPUs need socket setting and newer vmware version.

This is the first flavor with "hw:cpu_cores" set to 3.
