### PR TITLE
[cronus]: seed cloud_email_admin for all domains

### DIFF
--- a/openstack/cronus-seed/templates/seed.yaml
+++ b/openstack/cronus-seed/templates/seed.yaml
@@ -65,3 +65,100 @@ spec:
             metadata:
               read: keymanager_admin
               write: keymanager_admin
+
+    # cloud admin role assignment
+    - name: ccadmin
+      groups:
+      - name: CCADMIN_API_SUPPORT
+        role_assignments:
+        - domain: ccadmin
+          role: cloud_email_admin
+          inherited: true
+
+    - name: bs
+      groups:
+      - name: BS_API_SUPPORT
+        role_assignments:
+        - domain: bs
+          role: cloud_email_admin
+          inherited: true
+
+    - name: cis
+      groups:
+      - name: CIS_API_SUPPORT
+        role_assignments:
+        - domain: cis
+          role: cloud_email_admin
+          inherited: true
+
+    - name: cp
+      groups:
+      - name: CP_API_SUPPORT
+        role_assignments:
+        - domain: cp
+          role: cloud_email_admin
+          inherited: true
+
+    - name: hcm
+      groups:
+      - name: HCM_API_SUPPORT
+        role_assignments:
+        - domain: hcm
+          role: cloud_email_admin
+          inherited: true
+
+    - name: hcp03
+      groups:
+      - name: HCP03_API_SUPPORT
+        role_assignments:
+        - domain: hcp03
+          role: cloud_email_admin
+          inherited: true
+
+    - name: hec
+      groups:
+      - name: HEC_API_SUPPORT
+        role_assignments:
+        - domain: hec
+          role: cloud_email_admin
+          inherited: true
+
+    - name: monsoon3
+      groups:
+      - name: MONSOON3_API_SUPPORT
+        role_assignments:
+        - domain: monsoon3
+          role: cloud_email_admin
+          inherited: true
+
+    - name: neo
+      groups:
+      - name: NEO_API_SUPPORT
+        role_assignments:
+        - domain: neo
+          role: cloud_email_admin
+          inherited: true
+
+    - name: s4
+      groups:
+      - name: S4_API_SUPPORT
+        role_assignments:
+        - domain: s4
+          role: cloud_email_admin
+          inherited: true
+
+    - name: wbs
+      groups:
+      - name: WBS_API_SUPPORT
+        role_assignments:
+        - domain: wbs
+          role: cloud_email_admin
+          inherited: true
+
+    - name: cc3test
+      groups:
+      - name: CC3TEST_API_SUPPORT
+        role_assignments:
+        - domain: cc3test
+          role: cloud_email_admin
+          inherited: true


### PR DESCRIPTION
Adding inherited `cloud_email_admin` role for API support group in each domain.