### PR TITLE
Add new policies for Ussuri release

### DIFF
--- a/openstack/neutron/requirements.lock
+++ b/openstack/neutron/requirements.lock
@@ -21,7 +21,7 @@ dependencies:
   repository: file://../../openstack/utils
   version: 0.2.2
 - name: redis
-  repository: https://charts.eu-de-2.cloud.sap
+  repository: file://../../common/redis
   version: 1.0.1
-digest: sha256:3b7bd21dab5c89fae4bacafdfb3773f30487ac0c62b8d6f5cce81d234c04db80
-generated: 2021-06-14T16:20:18.867435944+02:00
+digest: sha256:a792d94c9a953481c43e58410d497c8cf9fab4ebf77b3f8c5eac305213644497
+generated: "2021-06-18T15:25:50.368817+03:00"

--- a/openstack/neutron/templates/etc/_neutron-policy.json.tpl
+++ b/openstack/neutron/templates/etc/_neutron-policy.json.tpl
@@ -121,7 +121,7 @@
     "update_port:binding:vnic_type": "rule:context_is_network_admin",
     "update_port:mac_learning_enabled": "rule:context_is_network_editor",
     "update_port:allowed_address_pairs": "rule:context_is_network_editor",
-    "update_port:allowed_address_pairs:ip_address": "rule:context_is_network_editor"
+    "update_port:allowed_address_pairs:ip_address": "rule:context_is_network_editor",
     "delete_port": "(not rule:network_device and not rule:share_device and rule:context_is_network_editor) or rule:context_is_admin",
 
     "get_router:ha": "rule:context_is_admin",

--- a/openstack/neutron/templates/etc/_neutron-policy.json.tpl
+++ b/openstack/neutron/templates/etc/_neutron-policy.json.tpl
@@ -30,6 +30,7 @@
     "shared_firewall_policies": "field:firewall_policies:shared=True",
     "shared_subnetpools": "field:subnetpools:shared=True",
     "shared_address_scopes": "field:address_scopes:shared=True",
+    "shared_security_groups": "field:security_groups:shared=True",
     "dhcp_enabled": "field:subnets:enable_dhcp=True",
     "default": "rule:context_is_editor or rule:shared",
     "default_viewer": "rule:context_is_viewer or rule:shared",
@@ -148,8 +149,8 @@
     "update_router:external_gateway_info:external_fixed_ips": "rule:context_is_network_admin",
 
     "create_security_group": "rule:context_is_securitygroup_admin",
-    "get_security_group": "rule:context_is_securitygroup_viewer",
-    "get_security_groups": "rule:context_is_securitygroup_viewer",
+    "get_security_group": "rule:context_is_securitygroup_viewer or rule:shared_security_groups",
+    "get_security_groups": "rule:context_is_securitygroup_viewer or rule:shared_security_groups",
     "update_security_group": "rule:context_is_securitygroup_admin",
     "delete_security_group": "rule:context_is_securitygroup_admin",
 

--- a/openstack/neutron/templates/etc/_neutron-policy.json.tpl
+++ b/openstack/neutron/templates/etc/_neutron-policy.json.tpl
@@ -102,6 +102,7 @@
     "create_port:binding:vnic_type": "rule:context_is_network_admin",
     "create_port:mac_learning_enabled": "rule:context_is_network_editor",
     "create_port:allowed_address_pairs": "rule:context_is_network_editor",
+    "create_port:allowed_address_pairs:ip_address": "rule:context_is_network_editor",
     "get_port": "rule:context_is_network_viewer",
     "get_port:queue_id": "rule:context_is_admin",
     "get_port:binding:vif_type": "rule:context_is_network_viewer",
@@ -120,6 +121,7 @@
     "update_port:binding:vnic_type": "rule:context_is_network_admin",
     "update_port:mac_learning_enabled": "rule:context_is_network_editor",
     "update_port:allowed_address_pairs": "rule:context_is_network_editor",
+    "update_port:allowed_address_pairs:ip_address": "rule:context_is_network_editor"
     "delete_port": "(not rule:network_device and not rule:share_device and rule:context_is_network_editor) or rule:context_is_admin",
 
     "get_router:ha": "rule:context_is_admin",


### PR DESCRIPTION
This PR adds new policies that were added in Ussuri release. Without this fix, `allowed_address_pairs` will not work.