### PR TITLE
[Swift] application credential access rules

### DIFF
--- a/openstack/swift/templates/etc/_proxy-server.conf.tpl
+++ b/openstack/swift/templates/etc/_proxy-server.conf.tpl
@@ -95,7 +95,8 @@ allow_overrides = true
 [filter:authtoken]
 paste.filter_factory = keystonemiddleware.auth_token:filter_factory
 delay_auth_decision = true
-include_service_catalog = false
+include_service_catalog = true
+service_type = object-store
 auth_plugin = v3password
 auth_version = 3
 www_authenticate_uri = {{$cluster.keystone_auth_uri}}


### PR DESCRIPTION
This enables support for application credential access rules available since Keystone Train.
This has the benefit, that you can create for the same user, multiple credentials which allow only access to a certain container within Swift. One can hand out access to different containers to different application, without entering the User in the container ACL

Example for allow container listing in container test and download of all objects in container test:

```
openstack application credential create ac1 --role swiftoperator --access-rules '[
    {
        "method": "GET",
        "path": "/v1/AUTH_<PROJECT_ID>/test",
        "service": "object-store"
    },
    {
        "method": "GET",
        "path": "/v1/AUTH_<PROJECT_ID>/test/**",
        "service": "object-store"
    }
]'
```