### PR TITLE
Add option thread_pool_size for neutron to decrease number of threads for privsep library.

### DIFF
--- a/openstack/neutron/templates/etc/_neutron.conf.tpl
+++ b/openstack/neutron/templates/etc/_neutron.conf.tpl
@@ -140,6 +140,12 @@ quota_security_group = 1
 # need 4 secgrouprule quota for "default" secgroup
 quota_security_group_rule = 4
 
+[privsep]
+# The number of threads available for privsep to concurrently run processes.
+# Defaults to the number of CPU cores in the system (integer value)
+# Minimum value: 1
+thread_pool_size = 1
+
 {{- include "osprofiler" . }}
 
 {{- include "ini_sections.audit_middleware_notifications" . }}


### PR DESCRIPTION
This PR temporarily decreases the number of threads for `oslo.privsep` library to `1` (defaults to the number of CPU cores in the system). Full description of option here: https://docs.openstack.org/neutron/ussuri/configuration/neutron.html#privsep
This option was added in the commit: https://github.com/openstack/oslo.privsep/commit/f368430f13183c3d09d68c80184d854449da2e87 and we updated the library with Ussuri release. 

Need to check will this fix resolves the problem with `OSError: Premature eof waiting for privileged process` or not. Example of error:

```
OSError: Premature eof waiting for privileged process
  File "oslo_messaging/rpc/server.py", line 165, in _process_incoming
    res = self.dispatcher.dispatch(message)
  File "oslo_messaging/rpc/dispatcher.py", line 276, in dispatch
    return self._do_dispatch(endpoint, method, ctxt, args)
  File "oslo_messaging/rpc/dispatcher.py", line 196, in _do_dispatch
    result = func(ctxt, **new_args)
  File "neutron/plugins/ml2/drivers/linuxbridge/agent/linuxbridge_neutron_agent.py", line 912, in network_delete
    self.agent.mgr.delete_bridge(bridge_name)
  File "neutron/plugins/ml2/drivers/linuxbridge/agent/linuxbridge_neutron_agent.py", line 598, in delete_bridge
    if bridge_device.exists():
  File "neutron/agent/linux/ip_lib.py", line 328, in exists
    return privileged.interface_exists(self.name, self.namespace)
  File "oslo_privsep/priv_context.py", line 247, in _wrap
    return self.channel.remote_call(name, args, kwargs)
  File "oslo_privsep/daemon.py", line 214, in remote_call
    result = self.send_recv((Message.CALL.value, name, args, kwargs))
  File "oslo_privsep/comm.py", line 172, in send_recv
    reply = future.result()
  File "oslo_privsep/comm.py", line 111, in result
    raise self.error
```