### PR TITLE
[Swift] max_header_size = 16384

### DIFF
--- a/openstack/swift/templates/etc/_proxy-server.conf.tpl
+++ b/openstack/swift/templates/etc/_proxy-server.conf.tpl
@@ -95,8 +95,7 @@ allow_overrides = true
 [filter:authtoken]
 paste.filter_factory = keystonemiddleware.auth_token:filter_factory
 delay_auth_decision = true
-# TODO this needs to false after that https://bugs.launchpad.net/keystonemiddleware/+bug/1933356 is fixed
-#      also revert the patch in keystonemiddleware: https://github.com/sapcc/swift/commit/9456e54e2e2449699c20f5b311bb6bcbaa2e2544
+# TODO this can be set to false after that https://bugs.launchpad.net/keystonemiddleware/+bug/1933356 is fixed
 include_service_catalog = true
 service_type = object-store
 auth_plugin = v3password

--- a/openstack/swift/templates/etc/_swift.conf.tpl
+++ b/openstack/swift/templates/etc/_swift.conf.tpl
@@ -5,3 +5,6 @@ swift_hash_path_suffix = { fromEnv: HASH_PATH_SUFFIX }
 [storage-policy:0]
 name = default
 default = yes
+
+[swift-constraints]
+max_header_size = {{ .Values.max_header_size }}

--- a/openstack/swift/values.yaml
+++ b/openstack/swift/values.yaml
@@ -31,6 +31,12 @@ image_version_auxiliary_statsd_exporter: 'v0.8.1'
 hash_path_prefix: DEFINED_IN_REGION_CHART
 hash_path_suffix: DEFINED_IN_REGION_CHART
 
+# swift-constraints
+# If keystonemiddleware is configured with `include_service_catalog: true`
+# The header size can become an issue with large catalogs
+# See https://github.com/sapcc/swift/blob/master/etc/swift.conf-sample#L133-L140
+max_header_size: 16384   # default 8192
+
 # BEGIN Temporary Flags, to be removed
 envoy_external: false
 # END Temporary Flags, to be removed


### PR DESCRIPTION
If `X-System-Catalog` is retrieved from `keystonemiddleware`, the default 8KB allowed header size might be an issue in regions with larger catalogs.