### PR TITLE
[neutron] Add opt to disable controlplane agents

### DIFF
--- a/openstack/neutron/templates/statefulset-network-agent.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent.yaml
@@ -1,5 +1,5 @@
 {{- $ussuri := hasPrefix "ussuri" (default .Values.imageVersion .Values.imageVersionServerAPI) -}}
-{{- if .Values.agent.multus | default false }}
+{{- if and (.Values.agent.multus | default false) (.Values.agent.controlplane | default true) }}
 {{- $az_count := len .Values.global.availability_zones -}}
 {{ range $i, $az_long := .Values.global.availability_zones | default (list (printf "%sa" $.Values.global.region) (printf "%sb" $.Values.global.region)) }}
 {{- $az := trimPrefix $.Values.global.region $az_long }}


### PR DESCRIPTION
This option will allow us to distinctively disable the controlplane
agents. Required for regions where we have fully switched to the apod
design.

---
Dictated but not read.