### PR TITLE
[neutron] Don't override controlplane value

### DIFF
--- a/openstack/neutron/templates/statefulset-network-agent.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent.yaml
@@ -1,5 +1,5 @@
 {{- $ussuri := hasPrefix "ussuri" (default .Values.imageVersion .Values.imageVersionServerAPI) -}}
-{{- if and (.Values.agent.multus | default false) (.Values.agent.controlplane | default true) }}
+{{- if and (.Values.agent.multus | default false) .Values.agent.controlplane }}
 {{- $az_count := len .Values.global.availability_zones -}}
 {{ range $i, $az_long := .Values.global.availability_zones | default (list (printf "%sa" $.Values.global.region) (printf "%sb" $.Values.global.region)) }}
 {{- $az := trimPrefix $.Values.global.region $az_long }}

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -466,3 +466,6 @@ logger:
 logger-redis:
   persistence:
     enabled: false
+
+agent:
+  controlplane: true


### PR DESCRIPTION
With a defaultfilter the controlplane will be set to true whenever it's
false, essentially taking away the option to set it to false. Therefore
we now add it to our default values andset it to true. Now we should be
able to override it.