### PR TITLE
[nova] Put metadata labels under labels key

### DIFF
--- a/openstack/nova/templates/migration-job.yaml
+++ b/openstack/nova/templates/migration-job.yaml
@@ -9,7 +9,8 @@ metadata:
 spec:
   template:
     metadata:
-{{ tuple . "nova" "migration" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 6 }}
+      labels:
+{{ tuple . "nova" "migration" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
       annotations:
         configmap-bin-hash: {{ include (print $.Template.BasePath "/bin-configmap.yaml") . | sha256sum }}
     spec:

--- a/openstack/nova/templates/online-migration-job.yaml
+++ b/openstack/nova/templates/online-migration-job.yaml
@@ -9,7 +9,8 @@ metadata:
 spec:
   template:
     metadata:
-{{ tuple . "nova" "online-migration" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 6 }}
+      labels:
+{{ tuple . "nova" "online-migration" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
       annotations:
         configmap-bin-hash: {{ include (print $.Template.BasePath "/bin-configmap.yaml") . | sha256sum }}
     spec:

--- a/openstack/nova/templates/update-cells-job.yaml
+++ b/openstack/nova/templates/update-cells-job.yaml
@@ -9,7 +9,8 @@ metadata:
 spec:
   template:
     metadata:
-{{ tuple . "nova" "online-migration" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 6 }}
+      labels:
+{{ tuple . "nova" "online-migration" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
       annotations:
         configmap-bin-hash: {{ include (print $.Template.BasePath "/bin-configmap.yaml") . | sha256sum }}
     spec:


### PR DESCRIPTION
This fixes a problem, where the labels where put directly under metadata
instead of a metadata.labels in all our Jobs.