### PR TITLE
[swift] add configurable 'delete_concurrency' for bulk deletions.

### DIFF
--- a/openstack/swift/templates/etc/_proxy-server.conf.tpl
+++ b/openstack/swift/templates/etc/_proxy-server.conf.tpl
@@ -169,6 +169,7 @@ url_base = https:
 [filter:bulk]
 use = egg:swift#bulk
 delete_container_retry_count = {{ $context.bulk_delete_container_retry_count }}
+delete_concurrency = {{ $context.delete_concurrency }}
 
 [filter:container-quotas]
 use = egg:swift#container_quotas

--- a/openstack/swift/values.yaml
+++ b/openstack/swift/values.yaml
@@ -82,6 +82,9 @@ recoverable_node_timeout: 10
 # Retry container delete in case of bulk deletes, default 0
 bulk_delete_container_retry_count: 3
 
+# Number of bulk deletes that can be executed in parallel, default 2
+bulk_delete_concurrency: 5
+
 # Don't log requests to object, container or account servers
 log_requests: false
 


### PR DESCRIPTION
As per doc:
To speed up the bulk delete process, multiple deletes may be executed in
parallel. Avoid setting this too high, as it gives clients a force multiplier
which may be used in DoS attacks. The suggested range is between 2 and 10.

Glance image deletion logic was rewritten to use bulk deletions along
with retry mechanism: https://github.com/sapcc/glance_store/commit/467a09a93ae1421949d0b6c62f060141307d8f71

While this has reduced the number of conflict errors, there are still
some cases happening in regions with the most load.