### PR TITLE
Define new Neutron ASR alerts

### DIFF
--- a/prometheus-exporters/network-generic-ssh-exporter/alerts/asr.alerts
+++ b/prometheus-exporters/network-generic-ssh-exporter/alerts/asr.alerts
@@ -114,3 +114,60 @@ groups:
         description: "Gatekeeper cache on `{{ $labels.devicename }}` is almost full."
         summary: "Gatekeeper cache on `{{ $labels.devicename }}` is almost full."
     
+    - alert: NetworkAsrBgpFabricPeerDown
+      expr: >-
+        # Filter on active devices
+        ((ssh_redundancy_state == 3 ) * 0)
+        # Join the BGP state on them
+        + on (server_name) group_right() ssh_bgp_sessions{vrf!=""} != 8
+      for: 5m
+      labels:
+        severity: critical
+        tier: net
+        service: asr
+        context: asr
+        meta: "BGP on `{{ $labels.devicename }}` to `{{ $labels.peer_ip }}` in VRF `{{ $labels.vrf }}` went down. DAPnets in this VRF are at risk."
+        playbook: 'docs/devops/alert/network/router.html#NetworkAsrBgpFabricPeerDown'
+        dashboard: neutron-router-bgp
+      annotations:
+        description: "BGP on `{{ $labels.devicename }}` to `{{ $labels.peer_ip }}` in VRF `{{ $labels.vrf }}` went down. DAPnets in this VRF are at risk."
+        summary: "BGP on `{{ $labels.devicename }}` to `{{ $labels.peer_ip }}` in VRF `{{ $labels.vrf }}` went down. DAPnets in this VRF are at risk."
+
+    
+    - alert: NetworkAsrBgpNeutronPeerDown
+      expr: >-
+        # Filter on active devices
+        ((ssh_redundancy_state == 3 ) * 0)
+        # Join the BGP state on them
+        + on (server_name) group_right() ssh_bgp_sessions{vrf="", peer_type="internal"} != 8
+      for: 5m
+      labels:
+        severity: critical
+        tier: net
+        service: asr
+        context: asr
+        meta: "Neutron Router mesh BGP peering on `{{ $labels.devicename }}` to `{{ $labels.peer_ip }}` went down. L3VPN outage!" 
+        playbook: 'docs/devops/alert/network/router.html#NetworkAsrBgpNeutronPeerDown'
+        dashboard: neutron-router-bgp
+      annotations:
+        description: "Neutron Router mesh BGP peering on `{{ $labels.devicename }}` to `{{ $labels.peer_ip }}` went down. L3VPN outage!" 
+        summary: "Neutron Router mesh BGP peering on `{{ $labels.devicename }}` to `{{ $labels.peer_ip }}` went down. L3VPN outage!" 
+    
+    - alert: NetworkAsrBgpCorePeerDown
+      expr: >-
+        # Filter on active devices
+        ((ssh_redundancy_state == 3 ) * 0)
+        # Join the BGP state on them
+        + on (server_name) group_right() ssh_bgp_sessions{vrf="", peer_type="external"} != 8
+      for: 5m
+      labels:
+        severity: critical
+        tier: net
+        service: asr
+        context: asr
+        meta: "BGP peering on `{{ $labels.devicename }}` to `{{ $labels.peer_ip }}` ) (core) went down. L3VPN impacted.
+        playbook: 'docs/devops/alert/network/router.html#NetworkAsrBgpCorePeerDown'
+        dashboard: neutron-router-bgp
+      annotations:
+        description: "BGP peering on `{{ $labels.devicename }}` to `{{ $labels.peer_ip }}` ) (core) went down. L3VPN impacted.
+        summary: "BGP peering on `{{ $labels.devicename }}` to `{{ $labels.peer_ip }}` ) (core) went down. L3VPN impacted.

--- a/prometheus-exporters/network-generic-ssh-exporter/alerts/asr.alerts
+++ b/prometheus-exporters/network-generic-ssh-exporter/alerts/asr.alerts
@@ -16,20 +16,7 @@ groups:
         description: "Neutron Router `{{ $labels.model }}` `{{ $labels.name }}` is reporting ARP punt policer drops"
         summary: "Neutron Router  `{{ $labels.name }}` is reporting ARP punt policer drops"
         
-    - alert: NetworkAsrNatSpike
-      expr: increase(((ssh_redundancy_send_queue ==bool 1 ) * ssh_redundancy_send_fails_delete)[5m:]) > 0
-      for: 5m
-      labels:
-        severity: critical
-        tier: net
-        service: asr
-        context: asr
-        playbook: 'docs/devops/alert/network/router.html#asr_nat_spike'
-        dashboard: network-asr-nat-table 
-      annotations:
-        description: "ASR devicename `{{ $labels.devicename }}` is experiencing a stuck queue-full bit. Risk of outage is present, peer-sync is not working. Immediate action required"
-        summary: "ASR devicename `{{ $labels.devicename }}` risk of NAT spikes and table overflow."
-        
+
     - alert: NetworkAsrDeviceIsDown
       expr: (ssh_nat_static + ssh_nat_dynamic) > 3500000
       for: 15m
@@ -46,7 +33,7 @@ groups:
         summary: "ASR devicename `{{ $labels.devicename }}` is DOWN for 15 min. Immediate devicename failure-over required."
 
     - alert: NetworkAsrNatTableIsNearlyFull
-      expr: (ssh_nat_static + ssh_nat_dynamic) > 2000000
+      expr: (ssh_nat_static + ssh_nat_dynamic) > 3000000
       for: 15m
       labels:
         severity: critical
@@ -104,7 +91,7 @@ groups:
         service: asr
         context: asr
         meta: "Policy download failure, Dynamic Interface NAT stops working for `{{ $labels.devicename }}`."
-        playbook: 'docs/devops/alert/network/router.html##asr-nat-class-diff-datapath-drops'
+        playbook: 'docs/devops/alert/network/router.html#asr-nat-class-diff-datapath-drops'
         dashboard: neutron-router
       annotations:
         description: "Policy download failure, Dynamic Interface NAT stops working for `{{ $labels.devicename }}`."

--- a/prometheus-exporters/network-generic-ssh-exporter/alerts/asr.alerts
+++ b/prometheus-exporters/network-generic-ssh-exporter/alerts/asr.alerts
@@ -84,7 +84,7 @@ groups:
     
     - alert: NetworkAsrRedundancyReplicationErrors
       expr: >-
-        (rate(ssh_redundancy_send_fails_add[5m]) + rate(ssh_redundancy_send_fails_add[5m])) > 0
+        (rate(ssh_redundancy_send_fails_add[5m]) + rate(ssh_redundancy_send_fails_del[5m])) > 0
       for: 20m
       labels:
         severity: critical

--- a/prometheus-exporters/network-generic-ssh-exporter/alerts/asr.alerts
+++ b/prometheus-exporters/network-generic-ssh-exporter/alerts/asr.alerts
@@ -82,3 +82,18 @@ groups:
         description: "Policy download failure, Dynamic Interface NAT stops working for `{{ $labels.devicename }}`."
         summary: "Policy download failure, Dynamic Interface NAT stops working for `{{ $labels.devicename }}`."
     
+    - alert: NetworkAsrRedundancyReplicationErrors
+      expr: >-
+        (rate(ssh_redundancy_send_fails_add[5m]) + rate(ssh_redundancy_send_fails_add[5m])) > 0
+      for: 20m
+      labels:
+        severity: critical
+        tier: net
+        service: asr
+        context: asr
+        meta: "Redundancy synchronization errors on `{{ $labels.devicename }}`."
+        playbook: 'docs/devops/alert/network/router.html#NetworkAsrRedundancyReplicationErrors'
+        dashboard: neutron-router
+      annotations:
+        description: "Redundancy synchronization errors on `{{ $labels.devicename }}`."
+        summary: "Redundancy synchronization errors on `{{ $labels.devicename }}`."

--- a/prometheus-exporters/network-generic-ssh-exporter/alerts/asr.alerts
+++ b/prometheus-exporters/network-generic-ssh-exporter/alerts/asr.alerts
@@ -17,22 +17,7 @@ groups:
         summary: "Neutron Router  `{{ $labels.name }}` is reporting ARP punt policer drops"
         
 
-    - alert: NetworkAsrDeviceIsDown
-      expr: (ssh_nat_static + ssh_nat_dynamic) > 3500000
-      for: 15m
-      labels:
-        severity: critical
-        tier: net
-        service: asr
-        context: asr
-        meta: "ASR devicename `{{ $labels.devicename }}` is DOWN for 15 min. Immediate devicename failure-over required."
-        playbook: 'docs/devops/alert/network/router.html#asr_nat_table_overflow'
-        dashboard: neutron-router
-      annotations:
-        description: "ASR devicename `{{ $labels.devicename }}` is DOWN for 15 min. Immediate devicename failure-over required."
-        summary: "ASR devicename `{{ $labels.devicename }}` is DOWN for 15 min. Immediate devicename failure-over required."
-
-    - alert: NetworkAsrNatTableIsNearlyFull
+    - alert: NetworkAsrNatTableFull
       expr: (ssh_nat_static + ssh_nat_dynamic) > 3000000
       for: 15m
       labels:
@@ -40,13 +25,13 @@ groups:
         tier: net
         service: asr
         context: asr
-        meta: "NAT table on ASR devicename `{{ $labels.devicename }}` is nearly full for 15 min with more than 2M NAT translations. This will stop creating new NAT sessions soon."
+        meta: "NAT table on Neutron Router `{{ $labels.devicename }}` has 3M translations for 15 mins. The device will stop creating new sessions soon."
         playbook: 'docs/devops/alert/network/router.html#asr_nat_table_overflow'
         dashboard: neutron-router
         spc: "ServiceAreaCode=04&TicketType=01&Priority=1&ServiceName=NW_CLOUD_CC&ServiceUnit=10&Subject=NetworkAsrNatTableIsNearlyFull+-+devicename%3A+{{ $labels.devicename }}&Description=NAT+table+on+ASR+devicename+{{ $labels.devicename }}+is+nearly+full+for+15+min+with+more+than+2M+NAT+translations.+This+will+stop+creating+new+NAT+sessions+soon."
       annotations:
-        description: "NAT table on ASR devicename `{{ $labels.devicename }}` is nearly full for 15 min with more than 2M NAT translations. This will stop creating new NAT sessions soon."
-        summary: "NAT table on ASR devicename `{{ $labels.devicename }}` is nearly full for 15 min with more than 2M NAT translations. This will stop creating new NAT sessions soon."
+        description: "NAT table on Neutron Router `{{ $labels.devicename }}` has 3M translations for 15 mins. The device will stop creating new sessions soon."
+        summary: "NAT table on Neutron Router `{{ $labels.devicename }}` has 3M translations for 15 mins. The device will stop creating new sessions soon."
 
     - alert: NetworkAsrRedundancyGroupBothDevicesDown
       expr: >-
@@ -96,3 +81,4 @@ groups:
       annotations:
         description: "Policy download failure, Dynamic Interface NAT stops working for `{{ $labels.devicename }}`."
         summary: "Policy download failure, Dynamic Interface NAT stops working for `{{ $labels.devicename }}`."
+    

--- a/prometheus-exporters/network-generic-ssh-exporter/alerts/asr.alerts
+++ b/prometheus-exporters/network-generic-ssh-exporter/alerts/asr.alerts
@@ -97,3 +97,20 @@ groups:
       annotations:
         description: "Redundancy synchronization errors on `{{ $labels.devicename }}`."
         summary: "Redundancy synchronization errors on `{{ $labels.devicename }}`."
+    
+    - alert: NetworkAsrNatGatekeeperCacheOverflow
+      expr: >-
+        (sum (ssh_qfp_nat_datapath_gatein {type=~"Active"}) by (server_name))*100/(sum (ssh_qfp_nat_datapath_gatein {type=~"Size"}) by (server_name)) >90
+      for: 5m
+      labels:
+        severity: critical
+        tier: net
+        service: asr
+        context: asr
+        meta: "Gatekeeper cache on `{{ $labels.devicename }}` is almost full."
+        playbook: 'docs/devops/alert/network/router.html#NetworkAsrNatGatekeeperCacheOverflow'
+        dashboard: neutron-router
+      annotations:
+        description: "Gatekeeper cache on `{{ $labels.devicename }}` is almost full."
+        summary: "Gatekeeper cache on `{{ $labels.devicename }}` is almost full."
+    

--- a/prometheus-exporters/network-generic-ssh-exporter/alerts/asr.alerts
+++ b/prometheus-exporters/network-generic-ssh-exporter/alerts/asr.alerts
@@ -142,7 +142,7 @@ groups:
         + on (server_name) group_right() ssh_bgp_sessions{vrf="", peer_type="internal"} != 8
       for: 5m
       labels:
-        severity: critical
+        severity: info
         tier: net
         service: asr
         context: asr
@@ -161,7 +161,7 @@ groups:
         + on (server_name) group_right() ssh_bgp_sessions{vrf="", peer_type="external"} != 8
       for: 5m
       labels:
-        severity: critical
+        severity: info
         tier: net
         service: asr
         context: asr

--- a/prometheus-exporters/snmp-exporter/alerts/snmp-asr.alerts
+++ b/prometheus-exporters/snmp-exporter/alerts/snmp-asr.alerts
@@ -16,7 +16,38 @@ groups:
       annotations:
         description: "Interface `{{ $labels.ifDescr }}` of ASR devicename `{{ $labels.devicename }}` experiencing high bandwidth utilization.Immediate action required"
         summary: "Interface `{{ $labels.ifDescr }}` of ASR devicename `{{ $labels.devicename }}` crossed bandwidth threshold"
+    
+    - alert: NetworkAsrHighIosdCpuUtilization
+      expr: >-
+        snmp_asr_cpmProcExtUtil1Min{cpmProcessName=~".*iosd.*"} >= 80
+      for: 20m
+      labels:
+        severity: critical
+        tier: net
+        service: asr
+        context: asr
+        meta: "IOSD process on `{{ $labels.devicename }}` is using a lot of CPU."
+        playbook: 'docs/devops/alert/network/router.html#NetworkAsrHighIosdCpuUtilization'
+        dashboard: neutron-router
+      annotations:
+        description: "IOSD process on `{{ $labels.devicename }}` is using a lot of CPU."
+        summary: "IOSD process on `{{ $labels.devicename }}` is using a lot of CPU."
 
+    - alert: NetworkAsrHighCpuUtilization
+      expr: >-
+        snmp_asr_cpmCPULoadAvg1min > 300
+      for: 20m
+      labels:
+        severity: critical
+        tier: net
+        service: asr
+        context: asr
+        meta: "The Control Processor CPU on `{{ $labels.devicename }}` is very busy."
+        playbook: 'docs/devops/alert/network/router.html#NetworkAsrHighCpuUtilization'
+        dashboard: neutron-router
+      annotations:
+        description: "The Control Processor CPU on `{{ $labels.devicename }}` is very busy."
+        summary: "The Control Processor CPU on `{{ $labels.devicename }}` is very busy."
 #    - alert: OpenstackNeutronPredictOutOfFIP
 #      expr: predict_linear(ssh_nat_static[1d], 3600 * 24 * 4) > 800
 #      for: 10m

--- a/prometheus-exporters/snmp-exporter/alerts/snmp-asr.alerts
+++ b/prometheus-exporters/snmp-exporter/alerts/snmp-asr.alerts
@@ -20,7 +20,7 @@ groups:
     - alert: NetworkAsrHighIosdCpuUtilization
       expr: >-
         snmp_asr_cpmProcExtUtil1Min{cpmProcessName=~".*iosd.*"} >= 80
-      for: 20m
+      for: 10m
       labels:
         severity: critical
         tier: net
@@ -36,7 +36,7 @@ groups:
     - alert: NetworkAsrHighCpuUtilization
       expr: >-
         snmp_asr_cpmCPULoadAvg1min > 300
-      for: 20m
+      for: 10m
       labels:
         severity: critical
         tier: net
@@ -60,3 +60,19 @@ groups:
 #      annotations:
 #        description: 'STILL IN TEST MODE: The Floating IP''s on {{ $labels.devicename }} might possibly get exhausted soon. This is not an exact warning, but a heads up to check the current FIP situation.'
 #        summary: 'STILL IN TEST MODE: Floating IP''s possibly soon exhausted'
+    
+    - alert: NetworkAsrHighQfpCpuUtilization
+      expr: >-
+        snmp_asr_ceqfpUtilProcessingLoad{ceqfpUtilTimeInterval="2"} >= 80
+      for: 5m
+      labels:
+        severity: critical
+        tier: net
+        service: asr
+        context: asr
+        meta: "A high QFP utilization is seen on `{{ $labels.devicename }}`. This may impact forwarding.
+        playbook: 'docs/devops/alert/network/router.html#NetworkAsrHighQfpCpuUtilization'
+        dashboard: neutron-router
+      annotations:
+        description: "A high QFP utilization is seen on `{{ $labels.devicename }}`. This may impact forwarding.
+        summary: "A high QFP utilization is seen on `{{ $labels.devicename }}`. This may impact forwarding.

--- a/prometheus-exporters/snmp-exporter/alerts/snmp-asr.alerts
+++ b/prometheus-exporters/snmp-exporter/alerts/snmp-asr.alerts
@@ -11,7 +11,7 @@ groups:
         service: asr
         context: asr
         meta: "Interface `{{ $labels.ifDescr }}` of ASR devicename `{{ $labels.devicename }}` experiencing high bandwidth utilization."
-        playbook: 'docs/support/playbook/network/control_plane_router/interface_util.html'
+        playbook: 'docs/devops/alert/network/router.html#NetworkAsrInterfaceOverUtilization'
         dashboard: neutron-datapath-bandwith
       annotations:
         description: "Interface `{{ $labels.ifDescr }}` of ASR devicename `{{ $labels.devicename }}` experiencing high bandwidth utilization.Immediate action required"

--- a/prometheus-exporters/snmp-exporter/alerts/snmp-asr.alerts
+++ b/prometheus-exporters/snmp-exporter/alerts/snmp-asr.alerts
@@ -3,7 +3,7 @@ groups:
     rules:
     
     - alert: NetworkAsrInterfaceOverUtilization
-      expr: rate(snmp_asr_ifHCOutOctets{ifDescr=~"TenGigabitEthernet.*"}[90m]) * 8 / 1000 ^ 3 > bool 8.5 == 1 or rate(snmp_asr_ifHCOutOctets{ifDescr=~"TenGigabitEthernet.*"}[15m]) * 8 / 1000 ^ 3 > bool 9.5 == 1
+      expr: (rate(snmp_asr_ifHCOutOctets{ifAlias=~"NEUTRON-UPLINK.*"}[5m])  * 8 /1000^ 2) /snmp_asr_ifHighSpeed
       for: 15m
       labels:
         severity: critical


### PR DESCRIPTION
NetworkAsrRedundancyReplicationErrors: Measures if there are failures observed when replicating NAT sessions.
NetworkAsrHighCpuUtilization: Indicated >80% CPU Utilization for more than 20mi
NetworkAsrBgpPeerDown: Alerts if a peering to the Core routers, to ACI or within the Neutron Mesh went down
NetworkAsrNatGatekeeperCacheOverflow: Alerts if the Gatekeeper Cache is exhausted
NetworkAsrInterfaceOverUtilization: Playbook to be moved
NetworkAsrHighQfpCpuUtilization
