### PR TITLE
[nginx-ingress] Log global_request_id variable

### DIFF
--- a/system/kube-system-metal/Chart.yaml
+++ b/system/kube-system-metal/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for metal clusters.
 name: kube-system-metal
-version: 1.0.11
+version: 1.1.0
 dependencies:
   - name: cc-rbac
     repository: https://charts.eu-de-2.cloud.sap

--- a/system/kube-system-metal/values.yaml
+++ b/system/kube-system-metal/values.yaml
@@ -141,7 +141,8 @@ nginx-ingress:
       worker-shutdown-timeout: "18000s"
       worker-processes: "8"
       use-forwarded-headers: "false"
-
+      log-format-upstream: >-
+        $remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" $request_length $request_time [$proxy_upstream_name] [$proxy_alternative_upstream_name] $upstream_addr $upstream_response_length $upstream_response_time $upstream_status $req_id $global_request_id
 
     affinity:
       # don't co-locate replicas of the ingress controller on the same node
@@ -265,7 +266,8 @@ nginx-ingress-external:
       worker-shutdown-timeout: "18000s"
       worker-processes: "8"
       use-forwarded-headers: "false"
-
+      log-format-upstream: >-
+        $remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" $request_length $request_time [$proxy_upstream_name] [$proxy_alternative_upstream_name] $upstream_addr $upstream_response_length $upstream_response_time $upstream_status $req_id $global_request_id
 
     affinity:
       # don't co-locate replicas of the ingress controller on the same node


### PR DESCRIPTION
The value can be set in each ingress where required, otherwise it will print a hypen '-'
It is currently set in various openstack services, and allows us to correlated more easily the request
between the nginx and the upstream service