### PR TITLE
[nginx-ingress] proxy_alternative_upstream_name is not yet a variable

### DIFF
--- a/system/kube-system-metal/values.yaml
+++ b/system/kube-system-metal/values.yaml
@@ -142,7 +142,7 @@ nginx-ingress:
       worker-processes: "8"
       use-forwarded-headers: "false"
       log-format-upstream: >-
-        $remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" $request_length $request_time [$proxy_upstream_name] [$proxy_alternative_upstream_name] $upstream_addr $upstream_response_length $upstream_response_time $upstream_status $req_id $global_request_id
+        $remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" $request_length $request_time [$proxy_upstream_name] $upstream_addr $upstream_response_length $upstream_response_time $upstream_status $req_id $global_request_id
 
     affinity:
       # don't co-locate replicas of the ingress controller on the same node
@@ -267,8 +267,7 @@ nginx-ingress-external:
       worker-processes: "8"
       use-forwarded-headers: "false"
       log-format-upstream: >-
-        $remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" $request_length $request_time [$proxy_upstream_name] [$proxy_alternative_upstream_name] $upstream_addr $upstream_response_length $upstream_response_time $upstream_status $req_id $global_request_id
-
+        $remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" $request_length $request_time [$proxy_upstream_name] $upstream_addr $upstream_response_length $upstream_response_time $upstream_status $req_id $global_request_id
     affinity:
       # don't co-locate replicas of the ingress controller on the same node
       podAntiAffinity:


### PR DESCRIPTION
This fixes 4d1707fe8c7347c17b6b1765ed7cba638cf862d1