### PR TITLE
[ELK] Parse nginx ingress access logs and global-request-id

### DIFF
--- a/system/elk/vendor/fluent/templates/_fluent.conf.tpl
+++ b/system/elk/vendor/fluent/templates/_fluent.conf.tpl
@@ -120,7 +120,8 @@
   reserve_data true
   <parse>
     @type grok
-    grok_pattern %{IPV4:remote_addr} %{GREEDYDATA}] "%{WORD:method} %{IMAGE_METHOD:path}%{GREEDYDATA}1" %{NUMBER:response} %{GREEDYDATA}
+    grok_pattern
+%{IPORHOST:remote_addr} - %{USERNAME:remote_user} \[%{HTTPDATE:time_local}\] \"%{DATA:request}\" %{INT:status} %{NUMBER:bytes_sent} \"%{DATA:http_referer}\" \"%{DATA:http_user_agent}\" %{NUMBER:request_length} %{NUMBER:request_time} \[%{DATA:proxy_upstream_name}\] %{IPORHOST:upstream_addr}:%{NUMBER:upstream_port} %{NUMBER:upstream_response_length} %{NUMBER:upstream_response_time} %{INT:upstream_status} %{WORD:req_id} ?(?:(?:req-)?%{GREEDYDATA:global_request_id})?
     custom_pattern_path /fluent-bin/pattern
   </parse>
 </filter>


### PR DESCRIPTION
The previous version was buggy due to a '1' at the end of the request path,
so it is rather unlikely that we rely on the nameing of the values here.

The new version parses all the fields defined in the default access-logs
as they are named in the ingress nginx definition.

Additionally the global_request_id will be parsed, if set.
It strips the prefix "req-" in case it is there, so we can search just for the uuid,
and ensure that it matches the openstack logs, where we strip the "greq-" prefix.