### PR TITLE
[octavia] use tags and session_persistence tables for db backup

### DIFF
--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -28,7 +28,8 @@ mariadb:
       - octavia
     verify_tables:
       # DB is locked for checksum verification, so don't use too many tables here
-      - octavia.load_balancer
+      - octavia.tags
+      - octavia.session_persistence
     oauth:
       client_id: octavia
 


### PR DESCRIPTION
verification.

The load_balancer table is big and changes a lot.
This should reduce the number of failed backup verifications.