### PR TITLE
[nova] Configure authentication to Cinder

### DIFF
--- a/openstack/nova/templates/etc/_nova.conf.tpl
+++ b/openstack/nova/templates/etc/_nova.conf.tpl
@@ -99,6 +99,14 @@ num_retries = 10
 [cinder]
 os_region_name = {{.Values.global.region}}
 cross_az_attach={{.Values.cross_az_attach}}
+auth_url = http://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default "5000" }}/v3
+auth_type = v3password
+username = {{ .Values.global.nova_service_user | default "nova" }}{{ .Values.global.user_suffix }}
+password = {{ required ".Values.global.nova_service_password is missing" .Values.global.nova_service_password }}
+user_domain_name = {{.Values.global.keystone_service_domain | default "Default" }}
+region_name = {{.Values.global.region}}
+project_name = {{.Values.global.keystone_service_project | default "service" }}
+project_domain_name = {{.Values.global.keystone_service_domain | default "Default" }}
 http_retries = {{.Values.cinder_http_retries}}
 
 [neutron]


### PR DESCRIPTION
Starting with queens, it's possible to configure authentication values
in the [cinder] section of nova.conf. We didn't do that until know,
because we didn't notice until recently, where some sentry events told
us about this.

Usually, these auth values are not necessary as volume operations happen
with the user token and thus its auth or the [service_user] section's
auth value if the user-token expired. But there are situations where
Nova has to act without user-token e.g. on startup where Nova continues
interrupted deletions of instances and might have to detach volumes.