### PR TITLE
[nginx-ingress] Set a default for global_request_id

### DIFF
--- a/system/kube-system-metal/values.yaml
+++ b/system/kube-system-metal/values.yaml
@@ -128,6 +128,11 @@ nginx-ingress:
             default "anonymous";
             ~CN=(?<CN>[^/,\"]+) $CN;
         }
+
+        # Ensure there is a global_request_id for logging
+        map '' $global_request_id {
+            default '-';
+        }
       location-snippet: |
         proxy_set_header X-REMOTE-USER $ssl_client_s_dn_cn;
       proxy-send-timeout: "300"
@@ -252,6 +257,11 @@ nginx-ingress-external:
         map $ssl_client_s_dn $ssl_client_s_dn_cn {
             default "anonymous";
             ~CN=(?<CN>[^/,\"]+) $CN;
+        }
+
+        # Ensure there is a global_request_id for logging
+        map '' $global_request_id {
+            default '-';
         }
       location-snippet: |
         proxy_set_header X-REMOTE-USER $ssl_client_s_dn_cn;


### PR DESCRIPTION
nginx-ingress-external-controller seems to be more strict with unset variables,
so we simply set the global_request_id to a default '-'