### PR TITLE
Add labels for filtering neutron agents

### DIFF
--- a/openstack/neutron/templates/asr_config_agents/_deployment-asr1k.yaml.tpl
+++ b/openstack/neutron/templates/asr_config_agents/_deployment-asr1k.yaml.tpl
@@ -27,6 +27,7 @@ spec:
     metadata:
       labels:
         name: neutron-asr1k-{{ $config_agent.name }}
+{{ tuple . "neutron" "asr1k-agent" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
       annotations:
         pod.beta.kubernetes.io/hostname:  {{ $config_agent.hostname }}
         prometheus.io/scrape: "true"

--- a/openstack/neutron/templates/deployment-aci-agent.yaml
+++ b/openstack/neutron/templates/deployment-aci-agent.yaml
@@ -22,6 +22,7 @@ spec:
     metadata:
       labels:
         name: neutron-aci-agent
+{{ tuple . "neutron" "aci-agent" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
       annotations:
         pod.beta.kubernetes.io/hostname:  aci-agent-pet
         configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") . | sha256sum }}

--- a/openstack/neutron/templates/deployment-f5-agent.yaml
+++ b/openstack/neutron/templates/deployment-f5-agent.yaml
@@ -26,6 +26,7 @@ spec:
     metadata:
       labels:
         name: neutron-f5-{{ $lb.name }}
+{{ tuple . "neutron" "f5-agent" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
       annotations:
         pod.beta.kubernetes.io/hostname: neutron-f5-{{ $lb.name }}
         prometheus.io/scrape: "true"


### PR DESCRIPTION
This PR will add additional labels for neutron `asr1k`, `f5`, `aci` agents. How it was before:
```
name=neutron-asr1k-agent-01,pod-template-hash=7d57f7c4d7
name=neutron-asr1k-agent-02,pod-template-hash=6d98fc7c85
name=neutron-asr1k-agent-03,pod-template-hash=77487554d9
```

How it will be:

```
application=neutron,component=asr1k-agent,name=neutron-asr1k-agent-01,pod-template-hash=7d57f7c4d7
application=neutron,component=asr1k-agent,name=neutron-asr1k-agent-02,pod-template-hash=6d98fc7c85
application=neutron,component=asr1k-agent,name=neutron-asr1k-agent-03,pod-template-hash=77487554d9
```

So we will be able to filter pods by type of agent.