### PR TITLE
[neutron] Introduce option to run neutron-api in uwsgi

### DIFF
--- a/openstack/neutron/alerts/api.alerts
+++ b/openstack/neutron/alerts/api.alerts
@@ -31,3 +31,33 @@ groups:
     annotations:
       description: '{{ $labels.check }} API is flapping for 30 minutes.'
       summary: '{{ $labels.check }} API flapping'
+
+  - alert: OpenstackNeutronApiOverloaded
+    expr: rate(uwsgi_core_overloaded[10m]) > 0
+    for: 5m
+    labels:
+      no_alert_on_absence: "true"
+      severity: info
+      tier: os
+      service: Neutron
+      context: 'neutron-server'
+      dashboard: uwsgi
+      meta: 'Neutron API is overloaded'
+    annotations:
+      description: 'Neutron API is overloaded, increase neutron-server pod replicas'
+      summary: 'Neutron API is overloaded'
+
+  - alert: OpenstackNeutronApiOverloaded
+    expr: uwsgi_socket_listen_queue > 1
+    for: 5m
+    labels:
+      no_alert_on_absence: "true"
+      severity: info
+      tier: os
+      service: Neutron
+      context: 'neutron-server'
+      dashboard: uwsgi
+      meta: 'Neutron API request queue is not clearing up'
+    annotations:
+      description: 'Neutron API request queue is not clearing up, increase neutron-server pod replicas'
+      summary: 'Neutron API request queue is not clearing up'

--- a/openstack/neutron/templates/configmap-etc-api.yaml
+++ b/openstack/neutron/templates/configmap-etc-api.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.api.uwsgi }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: neutron-etc-api
+  labels:
+    system: openstack
+    type: configuration
+    component: neutron
+
+data:
+  uwsgi.ini: |
+{{ include (print .Template.BasePath "/etc/_uwsgi.ini.tpl") . | indent 4 }}
+{{- end }}

--- a/openstack/neutron/templates/configmap-etc.yaml
+++ b/openstack/neutron/templates/configmap-etc.yaml
@@ -44,8 +44,6 @@ data:
 {{ include (print .Template.BasePath "/etc/_sudoers.tpl") . | indent 4 }}
   logging.conf: |
 {{ include "loggerIni" .Values.logging | indent 4 }}
-  uwsgi.ini: |
-{{ include (print .Template.BasePath "/etc/_uwsgi.ini.tpl") . | indent 4 }}
 {{- if .Values.audit.enabled }}
   neutron_audit_map.yaml: |
 {{ include (print .Template.BasePath "/etc/_neutron_audit_map.yaml") . | indent 4 }}

--- a/openstack/neutron/templates/deployment-rpc-server.yaml
+++ b/openstack/neutron/templates/deployment-rpc-server.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.wsgi }}
+{{- if .Values.api.uwsgi }}
 kind: Deployment
 apiVersion: apps/v1
 
@@ -25,13 +25,13 @@ spec:
     metadata:
       labels:
         name: neutron-rpc-server
-{{ tuple . "neutron" "api" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
+{{ tuple . "neutron" "rpc" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
       annotations:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") . | sha256sum }}
         configmap-etc-region-hash: {{ include (print $.Template.BasePath "/configmap-etc-region.yaml") . | sha256sum }}
         configmap-bin-hash: {{ include (print $.Template.BasePath "/configmap-bin.yaml") . | sha256sum }}
     spec:
-{{ tuple . "neutron" "api" | include "kubernetes_pod_anti_affinity" | indent 6 }}
+{{ tuple . "neutron" "rpc" | include "kubernetes_pod_anti_affinity" | indent 6 }}
       containers:
         - name: neutron-server
           image: {{.Values.global.registry}}/loci-neutron:{{.Values.imageVersionServerRPC | default .Values.imageVersionServer | default .Values.imageVersion | required "Please set neutron.imageVersion or similar"}}
@@ -39,7 +39,7 @@ spec:
           command: ['dumb-init', 'kubernetes-entrypoint']
           env:
             - name: COMMAND
-              value: "neutron-rpc-server --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/ml2-conf.ini --config-file /etc/neutron/plugins/ml2/ml2-conf-aci.ini --config-file /etc/neutron/plugins/ml2/ml2-conf-manila.ini --config-file /etc/neutron/plugins/ml2/ml2-conf-arista.ini --config-file /etc/neutron/plugins/ml2/ml2-conf-asr1k.ini"
+              value: "neutron-rpc-server --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/ml2-conf.ini --config-file /etc/neutron/plugins/ml2/ml2-conf-aci.ini --config-file /etc/neutron/plugins/ml2/ml2-conf-manila.ini --config-file /etc/neutron/plugins/ml2/ml2-conf-arista.ini --config-file /etc/neutron/plugins/ml2/ml2-conf-asr1k.ini {{- if .Values.bgp_vpn.enabled }} --config-file /etc/neutron/networking-bgpvpn.conf{{- end }}{{- if .Values.fwaas.enabled }} --config-file /etc/neutron/neutron-fwaas.ini{{- end }}"
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
             - name: DEPENDENCY_JOBS
@@ -61,6 +61,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: PYTHONWARNINGS
+              value: "ignore:Unverified HTTPS request"
+          resources:
+{{ toYaml .Values.pod.resources.rpc_server | indent 12 }}
           volumeMounts:
             - mountPath: /etc/neutron
               name: empty-dir
@@ -92,6 +96,18 @@ spec:
               name: neutron-etc-vendor
               subPath: ml2-conf-asr1k.ini
               readOnly: true
+            {{- if .Values.bgp_vpn.enabled }}
+            - mountPath: /etc/neutron/networking-bgpvpn.conf
+              name: neutron-etc
+              subPath: networking-bgpvpn.conf
+              readOnly: true
+            {{- end}}
+            {{- if .Values.fwaas.enabled }}
+            - mountPath: /etc/neutron/neutron-fwaas.ini
+              name: neutron-etc
+              subPath: neutron-fwaas.ini
+              readOnly: true
+            {{- end}}
         - name: statsd
           image: {{.Values.global.dockerHubMirror}}/prom/statsd-exporter:v0.8.1
           imagePullPolicy: IfNotPresent

--- a/openstack/neutron/templates/deployment-server.yaml
+++ b/openstack/neutron/templates/deployment-server.yaml
@@ -28,7 +28,15 @@ spec:
       annotations:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") . | sha256sum }}
         configmap-etc-region-hash: {{ include (print $.Template.BasePath "/configmap-etc-region.yaml") . | sha256sum }}
+{{- if .Values.api.uwsgi }}
+        configmap-etc-api-hash: {{ include (print $.Template.BasePath "/configmap-etc-api.yaml") . | sha256sum }}
+{{- else }}
         configmap-bin-hash: {{ include (print $.Template.BasePath "/configmap-bin.yaml") . | sha256sum }}
+{{- end }}
+        prometheus.io/scrape: "true"
+        maia.io/scrape: "true"
+        prometheus.io/port: {{ required ".Values.port_metrics missing" .Values.port_metrics | quote }}
+        prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
     spec:
 {{ tuple . "neutron" "api" | include "kubernetes_pod_anti_affinity" | indent 6 }}
       containers:
@@ -42,6 +50,7 @@ spec:
               port: {{.Values.global.neutron_api_port_internal | default 9696}}
             initialDelaySeconds: 120
             timeoutSeconds: 5
+            periodSeconds: 30
           readinessProbe:
             httpGet:
               path: /
@@ -52,8 +61,8 @@ spec:
           command: ['dumb-init', 'kubernetes-entrypoint']
           env:
             - name: COMMAND
-{{- if .Values.wsgi }}
-              value: "uwsgi --procname-prefix neutron-api --ini /etc/neutron/uwsgi.ini"
+{{- if .Values.api.uwsgi }}
+              value: "uwsgi --ini /etc/neutron/uwsgi.ini"
 {{- else }}
               value: "/container.init/neutron-server-start"
 {{- end }}
@@ -92,16 +101,12 @@ spec:
             - name: neutron-api
               containerPort: {{.Values.global.neutron_api_port_internal | default 9696}}
           volumeMounts:
-{{- if .Values.wsgi }}
+{{- if .Values.api.uwsgi }}
             - mountPath: /etc/neutron
               name: empty-dir
             - mountPath: /etc/neutron/neutron.conf
               name: neutron-etc
               subPath: neutron.conf
-              readOnly: true
-            - mountPath: /etc/neutron/uwsgi.ini
-              name: neutron-etc
-              subPath: uwsgi.ini
               readOnly: true
             - mountPath: /etc/neutron/policy.json
               name: neutron-etc
@@ -167,7 +172,12 @@ spec:
             - mountPath: /development
               name: development
             {{- end }}
-
+            {{- if .Values.api.uwsgi }}
+            - mountPath: /etc/neutron/uwsgi.ini
+              name: neutron-etc-api
+              subPath: uwsgi.ini
+              readOnly: true
+            {{- end }}
 {{- else }}
             - mountPath: /neutron-etc
               name: neutron-etc
@@ -214,6 +224,11 @@ spec:
         - name: development
           persistentVolumeClaim:
             claimName: development-pvclaim
+{{- end }}
+{{- if .Values.api.uwsgi }}
+        - name: neutron-etc-api
+          configMap:
+            name: neutron-etc-api
 {{- end }}
         - name: container-init
           configMap:

--- a/openstack/neutron/templates/etc/_api-paste.ini.tpl
+++ b/openstack/neutron/templates/etc/_api-paste.ini.tpl
@@ -64,6 +64,9 @@ pipeline = http_proxy_to_wsgi healthcheck neutronversionsapp
 [filter:osprofiler]
 paste.filter_factory = osprofiler.web:WsgiMiddleware.factory
 
+[filter:debug]
+paste.filter_factory = oslo_middleware:Debug.factory
+
 {{- if .Values.sentry.enabled }}
 [filter:raven]
 use = egg:raven#raven

--- a/openstack/neutron/templates/etc/_neutron.conf.tpl
+++ b/openstack/neutron/templates/etc/_neutron.conf.tpl
@@ -89,6 +89,7 @@ lock_path = /var/lib/neutron/tmp
 
 {{include "ini_sections.oslo_messaging_rabbit" .}}
 rpc_conn_pool_size = {{ .Values.rpc_conn_pool_size | default .Values.global.rpc_conn_pool_size | default 100 }}
+heartbeat_in_pthread = true
 
 [oslo_middleware]
 enable_proxy_headers_parsing = true

--- a/openstack/neutron/templates/etc/_uwsgi.ini.tpl
+++ b/openstack/neutron/templates/etc/_uwsgi.ini.tpl
@@ -1,28 +1,46 @@
 [uwsgi]
-strict = true
-need-app = true
-http-socket = :{{.Values.global.neutron_api_port_internal | default 9696}}
+# This is running standalone
+master = true
+pyargv = --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/ml2-conf.ini --config-file /etc/neutron/plugins/ml2/ml2-conf-aci.ini --config-file /etc/neutron/plugins/ml2/ml2-conf-manila.ini --config-file /etc/neutron/plugins/ml2/ml2-conf-arista.ini --config-file /etc/neutron/plugins/ml2/ml2-conf-asr1k.ini {{- if .Values.bgp_vpn.enabled }} --config-file /etc/neutron/networking-bgpvpn.conf{{- end }}{{- if .Values.fwaas.enabled }} --config-file /etc/neutron/neutron-fwaas.ini{{- end }}
+wsgi-file = /var/lib/openstack/bin/neutron-api
+enable-threads = true
+processes = {{.Values.api.processes}}
+auto-procname = true
+procname-prefix = neutron-api-
 uid = neutron
 gid = neutron
+http-socket = :{{.Values.global.neutron_api_port_internal | default 9696}}
+
+# Connection tuning
+vacuum = true
 lazy-apps = true
-add-header = Connection: close
-buffer-size = 65535
-hook-master-start = unix_signal:15 gracefully_kill_them_all
+need-app = true
 thunder-lock = true
-enable-threads = true
+buffer-size = 65535
+add-header = Connection: close
+single-interpreter = true
 worker-reload-mercy = 90
+
+# Set die-on-term & exit-on-reload so that uwsgi shuts down
 exit-on-reload = false
 die-on-term = true
-master = true
+hook-master-start = unix_signal:15 gracefully_kill_them_all
+
+# logging and metrics
+log-format = [pid: %(pid)] %(addr) {%(vars) vars in %(pktsize) bytes} [%(ctime)] %(method) %(uri) => generated %(rsize) bytes in %(msecs) msecs (%(proto) %(status)) %(headers) headers in %(hsize) bytes
+plugin = dogstatsd
+stats-push = dogstatsd:127.0.0.1:9125
+dogstatsd-all-gauges = true
 memory-report = true
-processes = {{.Values.wsgi_processes | default 4}}
-wsgi-file = /var/lib/openstack/bin/neutron-api
-stats-push = statsd:127.0.0.1:9125
-statsd-no-workers = true
-auto-procname = true
-procname-prefix = "neutron "
-single-interpreter = true
-disable-logging = true
-log-4xx = true
-log-5xx = true
-pyargv = --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/ml2-conf.ini --config-file /etc/neutron/plugins/ml2/ml2-conf-aci.ini --config-file /etc/neutron/plugins/ml2/ml2-conf-manila.ini --config-file /etc/neutron/plugins/ml2/ml2-conf-arista.ini --config-file /etc/neutron/plugins/ml2/ml2-conf-asr1k.ini {{- if .Values.bgp_vpn.enabled }} --config-file /etc/neutron/networking-bgpvpn.conf{{- end }}{{- if .Values.fwaas.enabled }} --config-file /etc/neutron/neutron-fwaas.ini{{- end }}
+
+# Limits, Kill requests after 120 seconds
+harakiri = 120
+harakiri-verbose = true
+post-buffering = 4096
+backlog-status = true
+
+# Automatic scaling of workers
+cheaper = {{.Values.api.cheaper}}
+cheaper-initial = {{.Values.api.cheaper}}
+workers = {{.Values.api.processes}}
+cheaper-step = 1

--- a/openstack/neutron/templates/service-server.yaml
+++ b/openstack/neutron/templates/service-server.yaml
@@ -8,10 +8,7 @@ metadata:
     type: api
     component: neutron
   annotations:
-    prometheus.io/scrape: "true"
     maia.io/scrape: "true"
-    prometheus.io/port: {{ required ".Values.port_metrics missing" .Values.port_metrics | quote }}
-    prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
 spec:
   selector:
     name: neutron-server

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -15,6 +15,7 @@ global:
 pod:
   replicas:
     server: 2
+    rpc_server: 2
   lifecycle:
     upgrades:
       deployments:
@@ -47,6 +48,10 @@ pod:
         cpu: '250m'
         memory: '512Mi'
     server:
+      requests:
+        cpu: "4000m"
+        memory: "8Gi"
+    rpc_server:
       requests:
         cpu: "4000m"
         memory: "8Gi"
@@ -118,6 +123,12 @@ imageVersionLogstash: 7.10.1
 imageVersionNSXTNanny: "1.5"
 imageVersionNetworkAgentDHCPInit: 3.8
 
+api:
+  processes: 10
+  # minimum number of workers to keep at all times
+  cheaper: 5
+  uwsgi: false
+
 service_plugins: asr1k_l3_routing
 default_router_type: ASR1k_router
 router_scheduler_driver: neutron.scheduler.l3_agent_scheduler.LeastRoutersScheduler
@@ -151,7 +162,6 @@ fwaas:
   enabled: false
 
 asr:
-
   config_agents: []
 
 f5:
@@ -230,9 +240,6 @@ logging:
     neutron:
       handlers: stdout, sentry
       level: WARNING
-    neutron_lbaas:
-      handlers: stdout, sentry
-      level: WARNING
     neutron.pecan_wsgi.hooks.policy_enforcement:
       handlers: stdout, sentry
       level: INFO
@@ -240,6 +247,9 @@ logging:
       handlers: "null"
       level: ERROR
     eventlet.wsgi.server:
+      handlers: stdout, sentry
+      level: INFO
+    neutron.wsgi:
       handlers: stdout, sentry
       level: INFO
     auditmiddleware:


### PR DESCRIPTION
This PR adds the ability to run neutron-server in uWSGI application server
* Exports uwsgi metrics with memory, request, worker details to the statsd exporter to be ingested via prometheus
* Adds overloaded and socket queue congestion alerts
* neutron is configured to use heartbeat_in_pthread
  * https://opendev.org/openstack/oslo.messaging/commit/22f240b82fffbd62be8568a7d0d3369134596ace
  * This is to improve the `AMQP server on neutron-rabbitmq is unreachable` errors, it causes the oslo.messaging to run the regular heartbeat messages in a python thread instead on depending to be scheduled by eventlet.
  * supported since train: https://docs.openstack.org/releasenotes/puppet-oslo/train.html
  * enabled by default since wallaby: https://docs.openstack.org/releasenotes/oslo.messaging/wallaby.html, so the feature is consided safe also by upstream
* enables neutron-rpc-server instances when uWSGI is enabled (including resource limits)

Current improvements observed by running uWSGI
* Much better resource utilization (uWSGI just needs 10% memory _and_ cpu of eventlet based neutron-server)
* Much better performance during times of huge amount of request
* Auto-scaling workers (by default 5, can scale up to 10 workers if needed)
* More insight into API request times, data transmitted, oversaturation etc.

I plan to adapt the resource-limits after rollout since they are not templatable.
