### PR TITLE
[blackbox-test-integrity] removed ESXiHostWithAssociatedVMsNotResponding alert

### DIFF
--- a/openstack/blackbox/charts/blackbox-tests-integrity/alerts/vmware-host.alerts
+++ b/openstack/blackbox/charts/blackbox-tests-integrity/alerts/vmware-host.alerts
@@ -1,20 +1,6 @@
 groups:
 - name: vmware-host.alerts
   rules:
-  - alert: ESXiHostWithAssociatedVMsNotResponding
-    expr: blackbox_integrity_status_gauge{check=~"esxi_hs-.+"} == 1
-    labels:
-      severity: critical
-      tier: vmware
-      service: '{{ $labels.service }}'
-      context: '{{ $labels.context }}'
-      meta: 'ESXi host with associated VMs is not responding: {{ $labels.check }}. See Sentry for details. ACTIONS: Fix remaining VMs on host, restore HA/Reduncancy, set host in maintenance and repair host'
-      sentry: blackbox/?query=test_{{ $labels.check }}
-      playbook: docs/devops/alert/vcenter/#test_esxi_hs_1
-    annotations:
-      description: 'ESXi host {{ $labels.check }}. See Sentry for details.'
-      summary: ESXi Host has associated VMs and is not responding for 5 min
-
   - alert: ESXiHostNoAssociatedVMsNotResponding
     expr: blackbox_integrity_status_gauge{check=~"esxi_hs-.+"} == 2
     for: 10m


### PR DESCRIPTION
covered by a vrops alert called `HostWithRunningVMsNotResponding`

https://github.com/sapcc/helm-charts/blob/0abc46b82f29c4de50a1317f930cc7fd695c3e87/prometheus-exporters/vrops-exporter/alerts/host.alerts#L4-L21