### PR TITLE
Swift readiness probe for swift_server pods

### DIFF
--- a/openstack/swift/requirements.lock
+++ b/openstack/swift/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.1.1
-digest: sha256:6016c415e4da08481faf386e4a1cccbe416588b3dc736fbac0060d6e2bc612b0
-generated: 2021-07-12T13:42:30.089403+02:00
+digest: sha256:eb54b7a69d03052cd7230a0bd5afee8219a33fefcd4579f76ffc5fe3d6d753d4
+generated: "2021-07-15T11:36:15.920882+02:00"

--- a/openstack/swift/templates/servers-daemonset.yaml
+++ b/openstack/swift/templates/servers-daemonset.yaml
@@ -8,7 +8,6 @@ metadata:
     on-upgrade: rolling-recreate
 
 spec:
-  minReadySeconds: 60 # longer wait here to be extra sure that the new servers are operational
   updateStrategy:
     type: RollingUpdate
   selector:
@@ -31,16 +30,40 @@ spec:
       volumes: {{ include "swift_daemonset_volumes" . | indent 8 }}
       containers:
         {{- tuple "object"    "object-server"    . | include "swift_standard_container" | indent 8 }}
+          # TODO Consider switching to startupProbe once available 1.16
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: swift-object
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
           ports:
             - name: swift-object
               hostPort: 6000
               containerPort: 6000
         {{- tuple "container" "container-server" . | include "swift_standard_container" | indent 8 }}
+          # TODO Consider switching to startupProbe once available 1.16
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: swift-container
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
           ports:
             - name: swift-container
               hostPort: 6001
               containerPort: 6001
         {{- tuple "account"   "account-server"   . | include "swift_standard_container" | indent 8 }}
+          # TODO Consider switching to startupProbe once available 1.16
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: swift-account
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
           ports:
             - name: swift-account
               hostPort: 6002


### PR DESCRIPTION
* Adding readiness probe for server pods to speed up deployments w/o general 60s wait time
* update redis chart requirement