### PR TITLE
[nova]kos: activates auto-assign-aggregates

### DIFF
--- a/openstack/nova/templates/auto-assign-aggregates-kq.yaml
+++ b/openstack/nova/templates/auto-assign-aggregates-kq.yaml
@@ -4,10 +4,12 @@ kind: KosQuery
 metadata:
   name: nova-auto-assign-aggregates
   namespace: monsoon3
+  annotations:
+    execute: "True"
+    context: "nova@Default/service"
 requirements:
 - name: nova-seed
   kind: OpenstackSeed
-context: nova@Default/service
 python: |
     endpoint_filter={'service_type': 'compute', 'interface': 'public'}
     resp = os.session.get('/os-aggregates', endpoint_filter=endpoint_filter).json()


### PR DESCRIPTION
execute and context metadata params moved to annotations.