### PR TITLE
[vrops-exporter] added NSXTManagementServiceHasFailed

### DIFF
--- a/prometheus-exporters/vrops-exporter/alerts/nsxt.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/nsxt.alerts
@@ -113,3 +113,14 @@ groups:
     annotations:
       description: "NSX-T cluster {{ $labels.nsxt_mgmt_cluster }} count of groups based in IP exceeded the supported limit."
       summary: "NSX-T cluster {{ $labels.nsxt_mgmt_cluster }} count of groups based in IP exceeded the supported limit."
+  - alert: NSXTManagementServiceHasFailed
+    expr: |
+        vrops_nsxt_mgmt_service_alert{alert_name="NSX-T Management service has failed"}
+    for: 5m
+    labels:
+      severity: critical
+      tier: qa
+      meta: "NSX-T management service {{ $labels.nsxt_mgmt_service }} has failed. {{ $labels.nsxt_mgmt_cluster }}"
+    annotations:
+      description: "Recommendation: {{ $labels.recommendation_1 }}"
+      summary: "{{ $labels.symptom_1_name }}"

--- a/prometheus-exporters/vrops-exporter/alerts/nsxt.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/nsxt.alerts
@@ -118,7 +118,7 @@ groups:
         vrops_nsxt_mgmt_service_alert{alert_name="NSX-T Management service has failed"}
     for: 5m
     labels:
-      severity: critical
+      severity: info
       tier: vmware
       meta: "NSX-T management service {{ $labels.nsxt_mgmt_service }} has failed. {{ $labels.nsxt_mgmt_cluster }}"
     annotations:

--- a/prometheus-exporters/vrops-exporter/alerts/nsxt.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/nsxt.alerts
@@ -119,7 +119,7 @@ groups:
     for: 5m
     labels:
       severity: critical
-      tier: qa
+      tier: vmware
       meta: "NSX-T management service {{ $labels.nsxt_mgmt_service }} has failed. {{ $labels.nsxt_mgmt_cluster }}"
     annotations:
       description: "Recommendation: {{ $labels.recommendation_1 }}"


### PR DESCRIPTION
This is the first proof of concept to cover pre-made alerts from vrops. 