### PR TITLE
HostWithRunningVMsNotResponding alert set to warning

### DIFF
--- a/prometheus-exporters/vrops-exporter/alerts/host.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/host.alerts
@@ -9,7 +9,7 @@ groups:
       and on (hostsystem) vrops_hostsystem_summary_running_vms_number > 0
     for: 10m
     labels:
-      severity: critical
+      severity: info
       tier: vmware
       service: compute
       context: "ESXi not responding"

--- a/prometheus-exporters/vrops-exporter/alerts/host.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/host.alerts
@@ -9,7 +9,7 @@ groups:
       and on (hostsystem) vrops_hostsystem_summary_running_vms_number > 0
     for: 10m
     labels:
-      severity: info
+      severity: warning
       tier: vmware
       service: compute
       context: "ESXi not responding"


### PR DESCRIPTION
We must set HostWithRunningVMsNotResponding alert to info for now to solve an inconsistency.