### PR TITLE
Excluded vCLS agent VMs

### DIFF
--- a/prometheus-exporters/vrops-exporter/alerts/host.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/host.alerts
@@ -6,7 +6,7 @@ groups:
       vrops_hostsystem_runtime_connectionstate{state="notResponding"}
       and on (hostsystem) vrops_hostsystem_runtime_powerstate{state="Unknown"}
       and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"}
-      and on (hostsystem) vrops_hostsystem_summary_running_vms_number > 0
+      and on (hostsystem) count(vrops_virtualmachine_runtime_powerstate{virtualmachine!~"vCLS.*", state="Powered On"}) by (hostsystem) > 0
     for: 10m
     labels:
       severity: warning


### PR DESCRIPTION
Excluded vCLS agent VMs for HostWithRunningVMsNotResponding alert. 

https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vcenterhost.doc/GUID-96BD6016-4BE7-4B1C-8269-568D1555B08C.html