### PR TITLE
[nova] Don't snapshot a VM before cloning its disk

### DIFF
--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -273,7 +273,7 @@ compute:
       pbm_default_policy: "nova-ephemeral"
       smbios_asset_tag: "SAP CCloud VM"
       bigvm_deployment_free_host_hostgroup_name: "bigvm_free_host_antiaffinity_hostroup"
-      clone_from_snapshot: true
+      clone_from_snapshot: false
       full_clone_snapshots: true
       # maximum of vSphere 6.5
       default_hw_version: vmx-13


### PR DESCRIPTION
There are multiple problems we want to fix by not snapshotting a VM
before cloning its root disk.
1) Snapshotting with volumes attached can fail, because there's not
enough space for the full snapshot on the vVOL backend.
2) Snapshotting an instance can fail, if there's an old/buggy
VMware-tools version running inside a Windows guest.
3) Snapshotting can fail, if one of the volumes is on a storage having
IO profiles.

Most of the problems stem from the fact, that we attach volumes in
dependent mode, which means they are snapshotted together with the
instance.

Since Cinder only does a clone without snapshot and we haven't seen
problems with that, we will switch Nova to do the same.