### PR TITLE
[nova] Disable KVM hypervisor templates

### DIFF
--- a/openstack/nova/templates/hypervisors/hypervisors-kvm-kq.yaml
+++ b/openstack/nova/templates/hypervisors/hypervisors-kvm-kq.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Capabilities.APIVersions.Has "kos-operator.stable.sap.cc/v1") (not .Values.hypervisors_kvm)  }}
+{{- if and (.Values.global.enable_kvm) (and (.Capabilities.APIVersions.Has "kos-operator.stable.sap.cc/v1") (not .Values.hypervisors_kvm) ) }}
 apiVersion: kos-operator.stable.sap.cc/v1
 kind: KosQuery
 metadata:

--- a/openstack/nova/templates/hypervisors/hypervisors-kvm-kt.yaml
+++ b/openstack/nova/templates/hypervisors/hypervisors-kvm-kt.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Capabilities.APIVersions.Has "kos-operator.stable.sap.cc/v1") (not .Values.hypervisors_kvm)  }}
+{{- if and (.Values.global.enable_kvm) (and (or (.Capabilities.APIVersions.Has "kos-operator.stable.sap.cc/v1") (.Values.isImageTransportTemplating | default false)) (not .Values.hypervisors_kvm) ) }}
 apiVersion: kos-operator.stable.sap.cc/v1
 kind: KosTemplate
 metadata:

--- a/openstack/nova/templates/hypervisors/hypervisors-kvm.yaml
+++ b/openstack/nova/templates/hypervisors/hypervisors-kvm.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.enable_kvm }}
 {{- $envAll := . }}
 {{- range $i, $hypervisor := .Values.hypervisors_kvm }}
   {{- $hypervisor := merge $hypervisor $envAll.Values.defaults.hypervisor.kvm $envAll.Values.defaults.hypervisor.common }}
@@ -7,4 +8,5 @@
 {{- tuple $envAll $hypervisor | include "kvm_deployment" }}
 ---
 {{ tuple $envAll $hypervisor | include "kvm_configmap" }}
+{{- end }}
 {{- end }}

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -19,6 +19,8 @@ global:
   placement_service_user: placement
 
   hypervisors: []
+  enable_kvm: false
+  # this being an empty list means autodetection by KosOperator
   hypervisors_kvm: []
   hypervisors_ironic: []
   osprofiler: {}


### PR DESCRIPTION
We currently don't have the capacity to run any KVM hypervisors and thus
don't have to include the templates into our charts. It also hurts us,
as helm-diff finds changes for images, which the image-cache in the CI
tries to cache, but that are no longer updated/built and thus caching
never completes.

This commit also enables finding images for the CI entrypoint in the
kos-template for KVM hypervisors via the isImageTransportTemplating
value.