### PR TITLE
Increate default RabbitMQ cpu limit to 5.

### DIFF
--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 0.2.1
+version: 0.2.2
 description: A Helm chart for RabbitMQ
 sources:
 - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/values.yaml
+++ b/common/rabbitmq/values.yaml
@@ -45,7 +45,7 @@ resources:
     memory: 512Mi
     cpu: 800m
   limits:
-    cpu: 1000m
+    cpu: 5000m
 
 ## Affinity for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity


### PR DESCRIPTION
Default RabbitMQ cpu limit seems not to be enough sometimes as
we see container_cpu_cfs_throttled_seconds_total metric
accumulating for several Openstack services.