### PR TITLE
[esxi-host-exporter] Increased scrape time

### DIFF
--- a/system/infra-monitoring/values.yaml
+++ b/system/infra-monitoring/values.yaml
@@ -694,5 +694,5 @@ network_generic_ssh_exporter:
 
 esxi_host_exporter:
   enabled: false
-  scrapeInterval: 2m
-  scrapeTimeout: 115s
+  scrapeInterval: 5m
+  scrapeTimeout: 295s


### PR DESCRIPTION
Query times out in Prometheus. Tested the scrape time locally via port-forwarding.