### PR TITLE
add a sentry link to NetworkNS alert

### DIFF
--- a/prometheus-exporters/ns-exporter/alerts/probe.alerts
+++ b/prometheus-exporters/ns-exporter/alerts/probe.alerts
@@ -10,6 +10,7 @@ groups:
       severity: critical
       tier: os
       playbook: 'docs/support/playbook/neutron/networknamespaceprobesfailed.html'
+      sentry: blackbox/?query=InconsistentModelException
       meta: 'Network {{ $labels.network_name }} failed all probes'
       cloudops: "?searchTerm={{ $labels.network_id }}&type=network"
     annotations:


### PR DESCRIPTION
We learned today that the InconsistentModelException can sometimes give more hints when there is a NetworkNamespaceProbesFailed issue