### PR TITLE
[Cinder] Enable AffinityFilter

### DIFF
--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -80,7 +80,7 @@ use_tls_acme: true
 
 db_name: cinder
 
-scheduler_default_filters: "AvailabilityZoneFilter,ShardFilter,CapacityFilter,CapabilitiesFilter"
+scheduler_default_filters: "AvailabilityZoneFilter,AffinityFilter,ShardFilter,CapacityFilter,CapabilitiesFilter"
 
 cinder_api_allow_migration_on_attach: True
 


### PR DESCRIPTION
This patch enables the Cinder Affinity/AntiAffinity filter.
This enables users to ensure that volumes can be created on the same
cinder host as another cinder volume, or opposite of another cinder
volume.

cinder create --hint same_host=<volume UUID> ....
cinder create --hint different_host=<volume UUID> ...