### PR TITLE
[elastic-query-exporter] Exclude Swift ESX nodes

### DIFF
--- a/prometheus-exporters/elastic-query-exporter/alerts/logs.alerts
+++ b/prometheus-exporters/elastic-query-exporter/alerts/logs.alerts
@@ -54,7 +54,7 @@ groups:
           description: "Octobus Jumpserver endpoint: `in-beats` is down in region `{{ $labels.region }}`"
           summary: "Octobus Jumpserver  endpoint: `in-beats` is down in region `{{ $labels.region }}`"
       - alert: OctobusESXiHostLogShippingNotWorking
-        expr: vrops_hostsystem_runtime_connectionstate{state="connected"} unless on(hostsystem) elasticsearch_octobus_esx_hostsystem_doc_count
+        expr: vrops_hostsystem_runtime_connectionstate{state="connected", hostsystem!~"nodeswift.*"} unless on(hostsystem) elasticsearch_octobus_esx_hostsystem_doc_count
         for: 15m
         labels:
           severity: critical


### PR DESCRIPTION
Better syslog field parsing is requested from Octobus team.
Until then we have to exclude these hosts from logshipping monitoring.