### PR TITLE
[Cinder] Fix migration job naming

### DIFF
--- a/openstack/cinder/templates/migration-job.yaml
+++ b/openstack/cinder/templates/migration-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: cinder-migration
+  name: cinder-migration-{{.Values.imageVersion | required "Please set cinder.imageVersion or similar"}}
   labels:
     system: openstack
     type: configuration


### PR DESCRIPTION
This patch adds the image version to the cinder migration
metadata job name.  This enables migration job to run only
when the image version changes.