### PR TITLE
[common/promServer] Enables podMonitorSelector by default

### DIFF
--- a/common/prometheus-server/CHANGELOG.md
+++ b/common/prometheus-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.2.2
+
+* Enables podMonitorSelector by default. Previously it was toggled by `.Values.serviceDiscoveries.pods.enabled` or `.Values.serviceDiscoveries.kubeDNS.enabled`
+
 ## 4.2.1
 
 * Ensure kubelet and cAdvisor metrics have labels `pod`, `pod_name`, `container`, `container_name` present for compatibility reasons.   

--- a/common/prometheus-server/Chart.yaml
+++ b/common/prometheus-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus via operator.
 name: prometheus-server
-version: 4.2.1
+version: 4.2.2
 appVersion: v2.28.1
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
 maintainers:

--- a/common/prometheus-server/templates/prometheus-server.yaml
+++ b/common/prometheus-server/templates/prometheus-server.yaml
@@ -20,12 +20,10 @@ spec:
     matchLabels:
       prometheus: {{ include "prometheus.name" . }}
 
-  {{ if or .Values.serviceDiscoveries.pods.enabled .Values.serviceDiscoveries.kubeDNS.enabled -}}
   # Select all PodMonitors with the label 'prometheus: <name>'.
   podMonitorSelector:
     matchLabels:
       prometheus: {{ include "prometheus.name" . }}
-  {{- end }}
 
   {{ if .Values.serviceDiscoveries.probes.enabled }}
   # Select all Probes with the label 'prometheus: <name>'.


### PR DESCRIPTION
In our control plane Infra-Collector prometheus PodMonitors are not being scraped. Enabling the pod service discovery does not work, as we already have a job for this. Enabling the SD would cause pods being scraped twice.
Thus I would like to enable the podMonitorSelector by default. 