### PR TITLE
[cronus]: sync the nginx template from upstream

### DIFF
--- a/openstack/cronus/Chart.yaml
+++ b/openstack/cronus/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: cronus
 description: proxying hyperscaler statless services
 type: application
-version: 0.1.9
+version: 0.1.10
 appVersion: v0.0.1
 dependencies:
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx
-  version: 3.33.0
+  version: 3.36.0

--- a/openstack/cronus/files/nginx.tmpl
+++ b/openstack/cronus/files/nginx.tmpl
@@ -149,14 +149,16 @@ http {
     {{ if $all.Cfg.EnableModsecurity }}
     modsecurity on;
 
+    {{ if (not (empty $all.Cfg.ModsecuritySnippet)) }}
+    modsecurity_rules '
+      {{ $all.Cfg.ModsecuritySnippet }}
+    ';
+    {{ end }}
+
     modsecurity_rules_file /etc/nginx/modsecurity/modsecurity.conf;
 
     {{ if $all.Cfg.EnableOWASPCoreRules }}
     modsecurity_rules_file /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf;
-    {{ else if (not (empty $all.Cfg.ModsecuritySnippet)) }}
-    modsecurity_rules '
-      {{ $all.Cfg.ModsecuritySnippet }}
-    ';
     {{ end }}
 
     {{ end }}
@@ -674,8 +676,8 @@ http {
         }
 
         location /configuration {
-            client_max_body_size                    {{ luaConfigurationRequestBodySize $cfg }}m;
-            client_body_buffer_size                 {{ luaConfigurationRequestBodySize $cfg }}m;
+            client_max_body_size                    {{ luaConfigurationRequestBodySize $cfg }};
+            client_body_buffer_size                 {{ luaConfigurationRequestBodySize $cfg }};
             proxy_buffering                         off;
 
             content_by_lua_block {
@@ -1258,7 +1260,7 @@ mail {
             auth_request        {{ $authPath }};
             auth_request_set    $auth_cookie $upstream_http_set_cookie;
             add_header          Set-Cookie $auth_cookie;
-            {{- range $line := buildAuthResponseHeaders $externalAuth.ResponseHeaders }}
+            {{- range $line := buildAuthResponseHeaders $proxySetHeader $externalAuth.ResponseHeaders }}
             {{ $line }}
             {{- end }}
             {{ end }}
@@ -1276,7 +1278,7 @@ mail {
             auth_digest {{ $location.BasicDigestAuth.Realm | quote }};
             auth_digest_user_file {{ $location.BasicDigestAuth.File }};
             {{ end }}
-            proxy_set_header Authorization "";
+            {{ $proxySetHeader }} Authorization "";
             {{ end }}
             {{ end }}
 

--- a/openstack/cronus/files/nginx.tmpl
+++ b/openstack/cronus/files/nginx.tmpl
@@ -892,7 +892,6 @@ mail {
     {{ range $tcpServer := .TCPBackends }}
     server {
         listen 587 {{ if $tcpServer.Backend.ProxyProtocol.Decode }} proxy_protocol{{ end }};
-        server_name cronus;
 
         protocol smtp;
 

--- a/openstack/cronus/values.yaml
+++ b/openstack/cronus/values.yaml
@@ -216,10 +216,11 @@ ingress-nginx:
       # ARCH=amd64 PLATFORMS=amd64 REGISTRY=keppel.eu-de-1.cloud.sap/ccloud TAG="$(cat TAG)-helo" BASE_IMAGE=keppel.eu-de-1.cloud.sap/ccloud/nginx:v1.20.1-helo make release
       registry: keppel.eu-de-1.cloud.sap/ccloud
       image: controller
-      tag: "v0.47.0-helo"
+      tag: "v0.49.0-helo"
       digest: ""
     config:
       http-snippet: |
+        # this snippet is used to resolve the cronus service to an address
         server {
           listen 127.0.0.1:8025;
           server_name _;


### PR DESCRIPTION
Reuse the latest ingress-nginx 3.36.0 helm-chart to set the regional hostname returned by nginx SMTP proxy on EHLO.

Was:

```
$ openssl s_client -crlf -quiet -connect cronus.qa-de-1.cloud.sap:587 -starttls smtp
EHLO localhost
250-cronus
```

Now:

```
$ openssl s_client -crlf -quiet -connect cronus.qa-de-1.cloud.sap:587 -starttls smtp
EHLO localhost
250-cronus-qa-de-1-cloud-sap
```

