### PR TITLE
maintenance-controller: enable metrics scraping

### DIFF
--- a/system/maintenance-controller/Chart.yaml
+++ b/system/maintenance-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: maintenance-controller
 description: A controller to manage node maintenance
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: "0.3"
 home: https://github.com/sapcc/maintenance-controller
 dependencies:

--- a/system/maintenance-controller/templates/manager.yaml
+++ b/system/maintenance-controller/templates/manager.yaml
@@ -55,11 +55,11 @@ spec:
           readOnly: true
         resources:
           limits:
-            cpu: 100m
-            memory: 30Mi
+            cpu: 200m
+            memory: 256Mi
           requests:
-            cpu: 100m
-            memory: 20Mi
+            cpu: 200m
+            memory: 128Mi
         livenessProbe:
           httpGet:
             path: /healthz

--- a/system/maintenance-controller/templates/manager.yaml
+++ b/system/maintenance-controller/templates/manager.yaml
@@ -24,6 +24,9 @@ spec:
     metadata:
       labels:
         app: maintenance-controller
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/targets: kubernetes
     spec:
       affinity:
         podAntiAffinity:
@@ -63,6 +66,9 @@ spec:
             port: 8081
           initialDelaySeconds: 3
           periodSeconds: 3
+        ports:
+          - name: metrics
+            containerPort: 8080
       volumes:
       - name: config
         secret:


### PR DESCRIPTION
controller-runtime exposes go runtime/app metrics by default on port 8080