### PR TITLE
[elastic-query-exporter] Adjust Octobus logshipping alert

### DIFF
--- a/prometheus-exporters/elastic-query-exporter/alerts/logs.alerts
+++ b/prometheus-exporters/elastic-query-exporter/alerts/logs.alerts
@@ -54,7 +54,10 @@ groups:
           description: "Octobus Jumpserver endpoint: `in-beats` is down in region `{{ $labels.region }}`"
           summary: "Octobus Jumpserver  endpoint: `in-beats` is down in region `{{ $labels.region }}`"
       - alert: OctobusESXiHostLogShippingNotWorking
-        expr: vrops_hostsystem_runtime_connectionstate{state="connected", hostsystem!~"nodeswift.*"} unless on(hostsystem) elasticsearch_octobus_esx_hostsystem_doc_count
+        expr: |
+                vrops_hostsystem_runtime_connectionstate{state="connected"} and
+                on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"} unless
+                on (hostsystem) elasticsearch_octobus_esx_hostsystem_doc_count
         for: 15m
         labels:
           severity: critical


### PR DESCRIPTION
* Add monitoring swift nodes as they're now parsed to node.nodename
* Only alert when host is not in maintenance mode
* Use block scalar style for better readability