### PR TITLE
kube-system-*: Remove pull secret injector

### DIFF
--- a/system/kube-monitoring-scaleout/values.yaml
+++ b/system/kube-monitoring-scaleout/values.yaml
@@ -278,7 +278,3 @@ prometheus-kubernetes-rules:
 
 prometheus-scaleout-rules:
   prometheusName: kubernetes
-
-pull-secret-injector:
-  image:
-    tag: 0.4.1

--- a/system/kube-system-admin-k3s/Chart.lock
+++ b/system/kube-system-admin-k3s/Chart.lock
@@ -29,8 +29,5 @@ dependencies:
 - name: digicert-issuer
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.0.34
-- name: pull-secret-injector
-  repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.4
-digest: sha256:6dc529ff9d1355a8561e7df8ec3050feb5b1db1078e302980d6e52a50912ceae
-generated: "2021-05-06T18:07:36.491147+03:00"
+digest: sha256:4631ee350961819524368f7bd58c51cf1088504056015a155cf79551e03e1bd5
+generated: "2021-09-21T07:55:32.358634+02:00"

--- a/system/kube-system-admin-k3s/Chart.yaml
+++ b/system/kube-system-admin-k3s/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kube-System relevant Service collection for the new admin clusters.
 name: kube-system-admin-k3s
-version: 0.4.11
+version: 0.4.12
 dependencies:
   - name: disco
     repository: https://charts.eu-de-2.cloud.sap
@@ -34,6 +34,3 @@ dependencies:
   - name: digicert-issuer
     repository: https://charts.eu-de-2.cloud.sap
     version: 1.0.34
-  - name: pull-secret-injector
-    repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.4

--- a/system/kube-system-kubernikus/Chart.lock
+++ b/system/kube-system-kubernikus/Chart.lock
@@ -23,14 +23,11 @@ dependencies:
 - name: digicert-issuer
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.0.34
-- name: pull-secret-injector
-  repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.3
 - name: metrics-server
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.0.4
 - name: vertical-pod-autoscaler
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.0.7
-digest: sha256:e5925786e0c2dfba86be179ad6e6b9266a8409ad6e3aca1196f0bf53d953413f
-generated: "2021-08-12T11:16:21.962767+02:00"
+digest: sha256:2f939a472979164b566b728f4e23a01a4d346c10acd5362a1a5aa4a3555e9af0
+generated: "2021-09-21T07:57:47.652568+02:00"

--- a/system/kube-system-kubernikus/Chart.yaml
+++ b/system/kube-system-kubernikus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for Kubernikus control-plane clusters.
 name: kube-system-kubernikus
-version: 0.8.4
+version: 0.8.5
 dependencies:
   - name: cc-rbac
     repository: https://charts.eu-de-2.cloud.sap
@@ -27,9 +27,6 @@ dependencies:
   - name: digicert-issuer
     repository: https://charts.eu-de-2.cloud.sap
     version: 1.0.34
-  - name: pull-secret-injector
-    repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.3
   - name: metrics-server
     repository: https://charts.eu-de-2.cloud.sap
     version: 1.0.4

--- a/system/kube-system-kubernikus/values.yaml
+++ b/system/kube-system-kubernikus/values.yaml
@@ -32,6 +32,3 @@ cert-manager:
 
 digicert-issuer:
   enableLeaderElection: "false"
-pull-secret-injector:
-  image:
-    tag: 0.4.1

--- a/system/kube-system-metal/Chart.lock
+++ b/system/kube-system-metal/Chart.lock
@@ -50,9 +50,6 @@ dependencies:
 - name: nodecidr-controller
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.0.4
-- name: pull-secret-injector
-  repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.3
 - name: kube-parrot
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
@@ -80,5 +77,5 @@ dependencies:
 - name: aws-ecr-creds-helper
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.0.1
-digest: sha256:a2a00965c4ed58c95dd3807d17fe4b79273c98f44648d4b3163b7d60c7abbea2
-generated: "2021-09-20T18:39:54.117446+03:00"
+digest: sha256:1b8f60ca9e018c353fa57e285458bc877c59d3f56871b202f8ca0dae96e2cc23
+generated: "2021-09-21T07:58:13.431843+02:00"

--- a/system/kube-system-metal/Chart.yaml
+++ b/system/kube-system-metal/Chart.yaml
@@ -59,9 +59,6 @@ dependencies:
   - name: nodecidr-controller
     repository: https://charts.eu-de-2.cloud.sap
     version: 1.0.4
-  - name: pull-secret-injector
-    repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.3
   - name: kube-parrot
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0

--- a/system/kube-system-metal/values.yaml
+++ b/system/kube-system-metal/values.yaml
@@ -328,12 +328,6 @@ nginx-ingress-external:
                   values:
                     - default-backend
 
-pull-secret-injector:
-  resources:
-    limits:
-      cpu: 200m
-      memory: 256Mi
-
 # For now enabled via regional values.
 vertical-pod-autoscaler:
   enabled: false

--- a/system/kube-system-scaleout/Chart.lock
+++ b/system/kube-system-scaleout/Chart.lock
@@ -29,14 +29,11 @@ dependencies:
 - name: digicert-issuer
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.0.34
-- name: pull-secret-injector
-  repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.3
 - name: metrics-server
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.0.4
 - name: vertical-pod-autoscaler
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.0.5
-digest: sha256:6350607987bdf1e0e0f14c17323d214ef30573a49eff97f4a945fdb8378e24cb
-generated: "2021-05-27T11:15:39.262135+02:00"
+digest: sha256:59badf67fe755fc5dcae44cfdba86d8ed1f4d42d0678a3c9d768feaf3b0e240f
+generated: "2021-09-21T07:59:06.298945+02:00"

--- a/system/kube-system-scaleout/Chart.yaml
+++ b/system/kube-system-scaleout/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kube-System relevant Service collection for scaleout clusters.
 name: kube-system-scaleout
-version: 0.7.1
+version: 0.7.2
 dependencies:
   - name: cc-rbac
     repository: https://charts.eu-de-2.cloud.sap
@@ -36,9 +36,6 @@ dependencies:
   - name: digicert-issuer
     repository: https://charts.eu-de-2.cloud.sap
     version: 1.0.34
-  - name: pull-secret-injector
-    repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.3
   - name: metrics-server
     repository: https://charts.eu-de-2.cloud.sap
     version: 1.0.4

--- a/system/kube-system-virtual/Chart.lock
+++ b/system/kube-system-virtual/Chart.lock
@@ -35,14 +35,11 @@ dependencies:
 - name: digicert-issuer
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.0.34
-- name: pull-secret-injector
-  repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.3
 - name: toolbox-prepull
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.0.7
 - name: metrics-server
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.0.4
-digest: sha256:9e70d526792f1a5e447048891964202655bba678b57f7a6541c4f7806a468de3
-generated: "2021-05-17T10:15:05.321767+02:00"
+digest: sha256:864ee7a688e47645999fb7da4aecb39b07cfd22c01185b06b0ea7d94519a3c64
+generated: "2021-09-21T07:59:25.941772+02:00"

--- a/system/kube-system-virtual/Chart.yaml
+++ b/system/kube-system-virtual/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for virtual clusters.
 name: kube-system-virtual
-version: 0.9.0
+version: 0.9.1
 dependencies:
   - name: cc-rbac
     repository: https://charts.eu-de-2.cloud.sap
@@ -39,9 +39,6 @@ dependencies:
   - name: digicert-issuer
     repository: https://charts.eu-de-2.cloud.sap
     version: 1.0.34
-  - name: pull-secret-injector
-    repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.3
   - name: toolbox-prepull
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.0.7


### PR DESCRIPTION
The payed docker hub accounts are expired and we are not supposed to use docker hub anymore.