### PR TITLE
[kube-system-scaleout] ingress-nginx to 3.36.0

### DIFF
--- a/ci/config.yaml
+++ b/ci/config.yaml
@@ -25,3 +25,4 @@ chart-repos:
   - grafana=https://grafana.github.io/helm-charts
   - prometheus-community=https://prometheus-community.github.io/helm-charts
   - fluent=https://fluent.github.io/helm-charts
+  - ingress-nginx=https://kubernetes.github.io/ingress-nginx

--- a/system/kube-system-scaleout/Chart.lock
+++ b/system/kube-system-scaleout/Chart.lock
@@ -11,9 +11,9 @@ dependencies:
 - name: kube-fip-controller
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.12
-- name: nginx-ingress
-  repository: https://charts.helm.sh/stable
-  version: 1.24.1
+- name: ingress-nginx
+  repository: https://kubernetes.github.io/ingress-nginx
+  version: 3.36.0
 - name: node-problem-detector
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.3.8
@@ -35,5 +35,5 @@ dependencies:
 - name: vertical-pod-autoscaler
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.0.5
-digest: sha256:59badf67fe755fc5dcae44cfdba86d8ed1f4d42d0678a3c9d768feaf3b0e240f
-generated: "2021-09-21T07:59:06.298945+02:00"
+digest: sha256:ad0452fe281be55482e66aab06b8fc7d21658a05b674301da17c8840625a6ea4
+generated: "2021-09-22T11:42:19.202129+02:00"

--- a/system/kube-system-scaleout/Chart.yaml
+++ b/system/kube-system-scaleout/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kube-System relevant Service collection for scaleout clusters.
 name: kube-system-scaleout
-version: 0.7.2
+version: 1.0.0
 dependencies:
   - name: cc-rbac
     repository: https://charts.eu-de-2.cloud.sap
@@ -18,9 +18,9 @@ dependencies:
     name: kube-fip-controller
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.1.12
-  - name: nginx-ingress
-    repository: https://charts.helm.sh/stable
-    version: 1.24.1
+  - name: ingress-nginx
+    repository: https://kubernetes.github.io/ingress-nginx
+    version: 3.36.0
   - name: node-problem-detector
     repository: https://charts.eu-de-2.cloud.sap
     version: 1.3.8

--- a/system/kube-system-scaleout/values.yaml
+++ b/system/kube-system-scaleout/values.yaml
@@ -1,6 +1,7 @@
-ingress:
-  tls_client_auth:
-    ca_cert:
+# The
+#ingress:
+#  tls_client_auth:
+#    ca_cert:
 
 disco:
   rbac:


### PR DESCRIPTION
**DO NOT MERGE**

This PR catapults our ingress controllers in scaleout clusters into 2021. 
We can only go for `3.36.0` though as this is the last version supporting k8s 1.19 clusters.

Messy: The chart was renamed from `nginx-ingress` to `ingress-nginx` 🤷  which causes some value foo and requires careful deployment coordination. 
