### PR TITLE
[vrops-exporter] nsxt metric mapping removed

### DIFF
--- a/prometheus-exporters/vrops-exporter/templates/collector-configmap.yaml
+++ b/prometheus-exporters/vrops-exporter/templates/collector-configmap.yaml
@@ -431,26 +431,6 @@ data:
       - metric_suffix: "sys_capacity_groups_based_in_ip_usage_count"
         key: "System Capacity|Groups Based on IP Sets|UsageCount"
 
-     # NSX-T 2.5
-      - metric_suffix: "sys_capacity_logical_switch_ports_usage_count"
-        key: "System Capacity|System Wide Logical Switch Ports|UsageCount"
-      - metric_suffix: "sys_capacity_logical_switch_ports_max_supported_count"
-        key: "System Capacity|System Wide Logical Switch Ports|MaxSupportedCount"
-
-     # NSX-T 2.4
-      - metric_suffix: "sys_capacity_distributed_firewall_rules_usage_count"
-        key: "System Capacity|System Wide Firewall Rules|UsageCount"
-      - metric_suffix: "sys_capacity_distributed_firewall_rules_max_supported_count"
-        key: "System Capacity|System Wide Firewall Rules|MaxSupportedCount"
-      - metric_suffix: "sys_capacity_distributed_firewall_section_max_supported_count"
-        key: "System Capacity|Firewall Sections|MaxSupportedCount"
-      - metric_suffix: "sys_capacity_distributed_firewall_section_usage_count"
-        key: "System Capacity|Firewall Sections|UsageCount"
-      - metric_suffix: "sys_capacity_nsgroups_max_supported_count"
-        key: "System Capacity|Network and Security Groups|MaxSupportedCount"
-      - metric_suffix: "sys_capacity_nsgroups_usage_count"
-        key: "System Capacity|Network and Security Groups|UsageCount"
-
     NSXTMgmtClusterPropertiesCollector:
     # INFO - Prefix: vrops_nsxt_mgmt_cluster_
       - metric_suffix: "product_version"


### PR DESCRIPTION
All NSX-T are upgraded to 3.x. The metric mapping for the older versions 2.4.x and 2.5.x are not needed anymore.