### PR TITLE
[nova] Enable live migration to old hypervisors

### DIFF
--- a/openstack/nova/templates/etc/_nova.conf.tpl
+++ b/openstack/nova/templates/etc/_nova.conf.tpl
@@ -190,3 +190,4 @@ default_pool_size = {{ .Values.wsgi_default_pool_size | default .Values.global.w
 [workarounds]
 # This has to be removed when we also remove the deployment of nova-consoleauth
 enable_consoleauth = True
+enable_live_migration_to_old_hypervisor = True


### PR DESCRIPTION
This flag has been introduced in 3653f528906 merged sometime in August 2021.
So we should be safe to roll out the flag without much impact