### PR TITLE
[castellum] increase nfs auto scaling maximum to 16 TiB

### DIFF
--- a/openstack/castellum/templates/_utils.tpl
+++ b/openstack/castellum/templates/_utils.tpl
@@ -25,7 +25,7 @@
 - name: CASTELLUM_LOG_SCRAPES
   value: "true"
 - name: CASTELLUM_MAX_ASSET_SIZES
-  value: "nfs-shares=8192" # 8192 GiB = 8 TiB
+  value: "nfs-shares=16384" # 16384 GiB = 16 TiB
 - name: CASTELLUM_NFS_PROMETHEUS_URL
   value: "http://prometheus-infra-collector.infra-monitoring.svc:9090"
 - name: CASTELLUM_OSLO_POLICY_PATH


### PR DESCRIPTION
Customer demand when operating large HANAs with 6 TB RAM, the manila share can now easily grow beyond 8TiB.
The maximum is also confirmed by Manila service owner.