### PR TITLE
[nova] Increase minimum large VM size

### DIFF
--- a/openstack/nova/templates/etc/_nova.conf.tpl
+++ b/openstack/nova/templates/etc/_nova.conf.tpl
@@ -33,6 +33,8 @@ prepare_empty_host_for_spawning_interval = 600
 
 dhcp_domain = openstack.{{ required ".Values.global.region is missing" .Values.global.region }}.{{ required ".Values.global.tld is missing" .Values.global.tld }}
 
+largevm_mb = {{ .Values.largevm_mb | default "524288" }}
+
 {{ include "ini_sections.default_transport_url" . }}
 
 {{ template "utils.snippets.debug.eventlet_backdoor_ini" "nova" }}


### PR DESCRIPTION
We disable DRS for all large VMs, but don't want to do it anymore for
VMs < 512 GiB. Therefore, we increase the largevm_mb setting to 512 GiB,
so that only VMs between >= 512 GiB (large VMs + big VMs) get DRS
disabled.