### PR TITLE
[nova] Reduce VM/HV size for vm-size-threshold filter

### DIFF
--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -249,8 +249,8 @@ scheduler:
   scheduler_tracks_instance_changes: false
   scheduler_instance_sync_interval: 120
   default_filters: "AvailabilityZoneFilter, ShardFilter, AggregateMultiTenancyIsolation, RamFilter, DiskFilter, ComputeFilter, ComputeCapabilitiesFilter, BigVmFlavorHostSizeFilter, VmSizeThresholdFilter, ImagePropertiesFilter, ServerGroupAntiAffinityFilter, ServerGroupAffinityFilter"
-  vm_size_threshold_vm_size_mb: 32768
-  vm_size_threshold_hv_size_mb: "1536000"
+  vm_size_threshold_vm_size_mb: "8193"
+  vm_size_threshold_hv_size_mb: "819200"
   ram_weight_multiplier: 1.0
   cpu_weight_multiplier: 1.0
   disk_weight_multiplier: 1.0


### PR DESCRIPTION
We'd like to redefine the VMs landing on our smallest hypervisors to
an including maximum of 8 GiB VMs - and thus have to set the setting one
MB further, because otherwise recreation of currently-running VMs would
already fill up those HVs and we want them to be available for the very
small VMs.

Since the HV setting would prohibit spawning a lot of VMs on older HVs
with ~ 1.5 TiB in size would not work anymore and thus we also decrease
the definition for "small" HVs to < 800 GiB.