### PR TITLE
Revert "[nova] Increase minimum large VM size"

### DIFF
--- a/openstack/nova/templates/etc/_nova.conf.tpl
+++ b/openstack/nova/templates/etc/_nova.conf.tpl
@@ -33,8 +33,6 @@ prepare_empty_host_for_spawning_interval = 600
 
 dhcp_domain = openstack.{{ required ".Values.global.region is missing" .Values.global.region }}.{{ required ".Values.global.tld is missing" .Values.global.tld }}
 
-largevm_mb = {{ .Values.largevm_mb | default "524288" }}
-
 {{ include "ini_sections.default_transport_url" . }}
 
 {{ template "utils.snippets.debug.eventlet_backdoor_ini" "nova" }}


### PR DESCRIPTION
This reverts commit a52588b095fd1b7d3c963b7bbaecd79da7d2158f.

We don't want to enable those smaller large VMs in DRS afterall, because
we are going to enable Cerebro for balancing those large VMs in
production and there shouldn't be two balancing algorithms fighting over
where a VM is supposed to be running.