### PR TITLE
[nova] Add a readinessProbe to placement-api pod

### DIFF
--- a/openstack/nova/templates/placement-api-deployment.yaml
+++ b/openstack/nova/templates/placement-api-deployment.yaml
@@ -68,6 +68,12 @@ spec:
             initialDelaySeconds: 60
             timeoutSeconds: 30
             periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{.Values.global.placementApiPortInternal}}
+            initialDelaySeconds: 15
+            timeoutSeconds: 5
 {{- end }}
           {{- if .Values.pod.resources.placement }}
           resources:


### PR DESCRIPTION
Without a readinessProbe, the pod is seen as able to serving requests
right after it started. This is actually not the case and leads to a
short downtime in the placement service on every deployment.