### PR TITLE
[redfish-exporter] adding default resources

### DIFF
--- a/prometheus-exporters/redfish-exporter/values.yaml
+++ b/prometheus-exporters/redfish-exporter/values.yaml
@@ -17,3 +17,5 @@ redfish:
   resources:
     memory: 100Mi
     cpu: 200m
+global:
+  registry: DEFINED-IN-GLOBAL-SECRETS


### PR DESCRIPTION
Chart should have all variables set by default. Adding missing resource constraints to not rely on externally feeded files'
