### PR TITLE
[octobus] support for custom router subnet added 

### DIFF
--- a/openstack/octobus/Chart.yaml
+++ b/openstack/octobus/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Octobus monitoring infrastructure
 name: octobus
-version: 0.1.1
+version: 0.1.2

--- a/openstack/octobus/templates/seeds.yaml
+++ b/openstack/octobus/templates/seeds.yaml
@@ -27,7 +27,7 @@ spec:
         external_gateway_info:
           network: FloatingIP-external-ccadmin-monitoring@ccadmin-net-infra@ccadmin
           external_fixed_ips:
-          - subnet: FloatingIP-sap-ccadmin-monitoring-01@ccadmin-net-infra@ccadmin
+          - subnet: {{ .Values.routerExternalSubnet | default "FloatingIP-sap-ccadmin-monitoring-01@ccadmin-net-infra@ccadmin" }}
         interfaces:
         - subnet: octobus_private
       role_assignments:


### PR DESCRIPTION
- new variable + default fallback added
- to be able to define an external subnet for the router per project