### PR TITLE
[MariaDB] Makes priorityClass optional

### DIFF
--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.3.24
+version: 0.3.25

--- a/common/mariadb/templates/deployment.yaml
+++ b/common/mariadb/templates/deployment.yaml
@@ -210,7 +210,7 @@ spec:
             memory: {{ .Values.metrics.resources.requests.memory | quote }}
         {{- end }}
 {{- end }}
-      priorityClassName: {{ default "openstack-service-critical" .Values.priority_class | quote }}
+      priorityClassName: {{ .Values.priority_class | quote }}
       volumes:
         - name: mariadb-etc
           configMap:

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -22,7 +22,7 @@ expire_logs_days: 10
 #custom_initdb_configmap:
 
 # name of priorityClass to influence scheduling priority
-#priority_class:
+priority_class: "openstack-service-critical"
 
 persistence_claim:
   enabled: true


### PR DESCRIPTION
Not all deployments using MariaDB have a priorityClass, thus I propose setting the default in the values so that it can be omitted if not required