### PR TITLE
system/doop-central: update format reference link

### DIFF
--- a/system/doop-central/templates/configmap.yaml
+++ b/system/doop-central/templates/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
 {{- $tld := $.Values.global.tld | required ".Values.global.tld not found" }}
 
 data:
-  # The format definition for this file is in the sapcc/gatekeeper-addons repository at <doop-central/README.md>.
+  # The format definition for this file is in the sapcc/gatekeeper-addons repository at <https://github.com/sapcc/gatekeeper-addons/blob/main/doop-central/README.md>.
   docs.html.yaml: |
     Header: |
       <p>To perform automatic validations on Kubernetes objects, we run a deployment of <a href="https://github.com/open-policy-agent/gatekeeper">OPA Gatekeeper</a> in each cluster (in audit-only mode). This dashboard aggregates all policy violations reported by those Gatekeeper instances.</p>


### PR DESCRIPTION
Some people might not know that `doop-central` is under `sapcc/gatekeeper-addons`. An explicit link will help.