### PR TITLE
[vrops-exporter] adjust datastore alerts to exclude hosts in MM

### DIFF
--- a/prometheus-exporters/vrops-exporter/alerts/datastore.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/datastore.alerts
@@ -226,8 +226,8 @@ groups:
 
   - alert: DatastoreDisconnectedWithVmsOnIt
     expr: >
-      label_replace(vrops_datastore_summary_total_number_vms, "hostsystem", "$1", "datastore", "(node.*)(-.*)") > 0 and on(datastore) 
-      vrops_datastore_summary_datastore_accessible{state="PoweredOff",type!~"local"} unless on (hostsystem)
+      (label_replace(vrops_datastore_summary_total_number_vms, "hostsystem", "$1", "datastore", "(node.*)(-.*)") > 0 and on(datastore) 
+      vrops_datastore_summary_datastore_accessible{state="PoweredOff",type!~"local"}) unless on (hostsystem)
       label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
     for: 20m
     labels:
@@ -243,8 +243,8 @@ groups:
 
   - alert: DatastoreDisconnectedWithoutVmsOnIt
     expr: >
-      label_replace(vrops_datastore_summary_total_number_vms, "hostsystem", "$1", "datastore", "(node.*)(-.*)") == 0 and on(datastore) 
-      vrops_datastore_summary_datastore_accessible{state="PoweredOff",type!~"local"} unless on (hostsystem)
+      (label_replace(vrops_datastore_summary_total_number_vms, "hostsystem", "$1", "datastore", "(node.*)(-.*)") == 0 and on(datastore) 
+      vrops_datastore_summary_datastore_accessible{state="PoweredOff",type!~"local"}) unless on (hostsystem)
       label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
     for: 20m
     labels:

--- a/prometheus-exporters/vrops-exporter/alerts/datastore.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/datastore.alerts
@@ -226,8 +226,9 @@ groups:
 
   - alert: DatastoreDisconnectedWithVmsOnIt
     expr: >
-      vrops_datastore_summary_total_number_vms > 0
-      and on (datastore) vrops_datastore_summary_datastore_accessible{type!~"local", state="PoweredOff"}
+      label_replace(vrops_datastore_summary_total_number_vms, "hostsystem", "$1", "datastore", "(node.*)(-.*)") > 0 and on(datastore) 
+      vrops_datastore_summary_datastore_accessible{state="PoweredOff",type!~"local"} unless on (hostsystem)
+      label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
     for: 20m
     labels:
       severity: critical
@@ -242,8 +243,9 @@ groups:
 
   - alert: DatastoreDisconnectedWithoutVmsOnIt
     expr: >
-      vrops_datastore_summary_total_number_vms == 0
-      and on (datastore) vrops_datastore_summary_datastore_accessible{type!~"local", state="PoweredOff"}
+      label_replace(vrops_datastore_summary_total_number_vms, "hostsystem", "$1", "datastore", "(node.*)(-.*)") == 0 and on(datastore) 
+      vrops_datastore_summary_datastore_accessible{state="PoweredOff",type!~"local"} unless on (hostsystem)
+      label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
     for: 20m
     labels:
       severity: warning

--- a/prometheus-exporters/vrops-exporter/alerts/datastore.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/datastore.alerts
@@ -260,7 +260,8 @@ groups:
 
   - alert: DatastoreHasLostConnectivityToAStorageDevice
     expr: >
-      vrops_datastore_alert_info{alert_name="Datastore has lost connectivity to a storage device"}
+      label_replace(vrops_datastore_alert_info{alert_name="Datastore has lost connectivity to a storage device"}, "hostsystem", "$1", "datastore", "(node.*)(-.*)") 
+      unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
     labels:
       severity: warning
       tier: vmware
@@ -275,7 +276,8 @@ groups:
 
   - alert: DatastoreHasHostsThatHaveLostRedundantPathsToAStorageDevice
     expr: >
-      vrops_datastore_alert_info{alert_name="Datastore has one or more hosts that have lost redundant paths to a storage device"}
+      label_replace(vrops_datastore_alert_info{alert_name="Datastore has one or more hosts that have lost redundant paths to a storage device"}, "hostsystem", "$1", "datastore", "(node.*)(-.*)") 
+      unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
     labels:
       severity: warning
       tier: vmware


### PR DESCRIPTION
Exclude local datastore from alerting if host is in maintenance. 