### PR TITLE
[Glance] Bumps mariadb chart to increase binlog file retention

### DIFF
--- a/openstack/glance/requirements.lock
+++ b/openstack/glance/requirements.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.24
+  version: 0.3.26
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.0.6
@@ -20,5 +20,5 @@ dependencies:
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.1.5
-digest: sha256:6017dedc8323c289cdc8e65c6542ee22fc3a6c5f0d060acafa5a745c0ce942a7
-generated: "2021-10-06T16:39:20.357421+05:30"
+digest: sha256:8673d88b24aea896e42a2e8acf2bbf0a722de51069f3e7873a10a721fe5addff
+generated: "2021-11-03T17:56:50.274323+01:00"

--- a/openstack/glance/requirements.yaml
+++ b/openstack/glance/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.24
+    version: 0.3.26
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.0.6


### PR DESCRIPTION
Binlog files are now purged after 60 minutes instead of directly after rotation. This is required for the database replication into the datahubdb to work.