### PR TITLE
[Keystone] Bumps mariadb requirement to increase binlog file retention

### DIFF
--- a/openstack/keystone/requirements.lock
+++ b/openstack/keystone/requirements.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.24
+  version: 0.3.26
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.0.6
@@ -20,5 +20,5 @@ dependencies:
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.1.4
-digest: sha256:733bbaa4378ed8f2015f7c333843c0d76fcfe5b2f8892b954102557a550b21b4
-generated: "2021-10-06T16:35:00.29759+05:30"
+digest: sha256:c4295513fb6366d3d69c960d53bf07f34f89c6bbbb13e2706616add9880221ac
+generated: "2021-11-03T18:03:45.107044+01:00"

--- a/openstack/keystone/requirements.yaml
+++ b/openstack/keystone/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.24
+    version: 0.3.26
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.0.6


### PR DESCRIPTION
Binlog files are now purged after 60 minutes instead of directly after rotation. This is required for the database replication into the datahubdb to work.