### PR TITLE
[Neutron] Bumps mariadb requirement to increase binlog file retention

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.24
+  version: 0.3.26
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.0.6
@@ -23,5 +23,5 @@ dependencies:
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.1.4
-digest: sha256:b9115fe6646471ee7ebc6f8ae5f9ffdb0f2dfd5e07fe786fb0cf5c2ad515d648
-generated: "2021-10-12T13:28:07.509762+02:00"
+digest: sha256:e266e3d92dba27388054d1a871eb39c63a0bbf1d04fafe79778106f2572d01eb
+generated: "2021-11-03T18:07:11.473184+01:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -6,7 +6,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.24
+    version: 0.3.26
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.0.6


### PR DESCRIPTION
Binlog files are now purged after 60 minutes instead of directly after rotation. This is required for the database replication into the datahubdb to work.