### PR TITLE
[Nova] Bumps mariadb requirement to increase binlog retention

### DIFF
--- a/openstack/nova/requirements.lock
+++ b/openstack/nova/requirements.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.22
+  version: 0.3.26
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.22
+  version: 0.3.26
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.7
@@ -22,12 +22,12 @@ dependencies:
   version: 0.3.0
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.22
+  version: 0.3.26
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
 - name: region_check
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.2
-digest: sha256:4206dbdf928a1386a11d10f1339a933dabede987cc32f2b19c1903e6a96328cd
-generated: "2021-10-04T11:43:05.697569+02:00"
+digest: sha256:31161a91f2e41619d76e7844a34fd6c7dbe91940639851bf10b2c7b36bff963f
+generated: "2021-11-03T18:10:29.062666+01:00"

--- a/openstack/nova/requirements.yaml
+++ b/openstack/nova/requirements.yaml
@@ -2,12 +2,12 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.22
+    version: 0.3.26
   - name: mariadb
     alias: mariadb_api
     condition: mariadb_api.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.22
+    version: 0.3.26
   - condition: mariadb.enabled
     name: mysql_metrics
     repository: https://charts.eu-de-2.cloud.sap
@@ -30,7 +30,7 @@ dependencies:
     alias: mariadb_cell2
     condition: mariadb_cell2.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.22
+    version: 0.3.26
   - name: rabbitmq
     alias: rabbitmq_cell2
     condition: cell2.enabled


### PR DESCRIPTION
Binlog files are now purged after 60 minutes instead of directly after rotation. This is required for the database replication into the datahubdb to work.

Also brings 
* [mariadb] reduce readiness probe initial delay
* [mariadb] change lifecycle pod script to sleep 1 between db pings.
