### PR TITLE
added custom flavor for cc3test server create(regular/hana)

### DIFF
--- a/openstack/sap-seeds/templates/flavor-seed.yaml
+++ b/openstack/sap-seeds/templates/flavor-seed.yaml
@@ -38,6 +38,16 @@ spec:
       "hw_video:ram_max_mb": "16"
       "catalog:alias": "m1.small,m1.smallhdd"
       "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+  - name: "c_c2_m2_cc3test"
+    id: "21"
+    vcpus: 2
+    ram: 2032
+    disk: 64
+    is_public: false
+    extra_specs:
+      "vmware:hv_enabled": "True"
+      "hw_video:ram_max_mb": "16"
+      "catalog:alias": "m1.xsmall_cc3test"
   - name: "g_c2_m4"
     id: "22"
     vcpus: 2

--- a/openstack/sap-seeds/templates/flavor-seed.yaml
+++ b/openstack/sap-seeds/templates/flavor-seed.yaml
@@ -38,15 +38,6 @@ spec:
       "hw_video:ram_max_mb": "16"
       "catalog:alias": "m1.small,m1.smallhdd"
       "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
-  - name: "hana_cc3test"
-    id: "21"
-    vcpus: 2
-    ram: 2032
-    disk: 64
-    is_public: false
-    extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
   - name: "g_c2_m4"
     id: "22"
     vcpus: 2
@@ -630,3 +621,13 @@ spec:
       "trait:CUSTOM_NUMASIZE_C48_M729": "required"
       "hw:cpu_cores": "3"
       "vmware:hw_version": "vmx-18"
+  # HANA flavor for testing
+  - name: "hana_cc3test"
+    id: "21"
+    vcpus: 2
+    ram: 2032
+    disk: 64
+    is_public: false
+    extra_specs:
+      "vmware:hv_enabled": "True"
+      "hw_video:ram_max_mb": "16"

--- a/openstack/sap-seeds/templates/flavor-seed.yaml
+++ b/openstack/sap-seeds/templates/flavor-seed.yaml
@@ -623,7 +623,7 @@ spec:
       "vmware:hw_version": "vmx-18"
   # HANA flavor for testing
   - name: "hana_cc3test"
-    id: "21"
+    id: "312"
     vcpus: 2
     ram: 2032
     disk: 64

--- a/openstack/sap-seeds/templates/flavor-seed.yaml
+++ b/openstack/sap-seeds/templates/flavor-seed.yaml
@@ -38,7 +38,7 @@ spec:
       "hw_video:ram_max_mb": "16"
       "catalog:alias": "m1.small,m1.smallhdd"
       "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
-  - name: "c_c2_m2_cc3test"
+  - name: "hana_cc3test"
     id: "21"
     vcpus: 2
     ram: 2032
@@ -47,7 +47,6 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
-      "catalog:alias": "m1.xsmall_cc3test"
   - name: "g_c2_m4"
     id: "22"
     vcpus: 2


### PR DESCRIPTION
@dhoeller @joker-at-work cc3test required custom flavor for server create (regular/hana) reasons : 
1. with hana flavor required to increase cc3test project quota as we spawning large VMs for checking new server create. 
2. with hana flavor putting load on BB with new test server create with large VMs ( which will got double after adding mount_volume check for BB) 
3. with hana/regular flavour lots of logic to put in code to pickup as smallest flavor as possible.