### PR TITLE
[Swift] haproxy deployemnts per AZ/aPod

### DIFF
--- a/openstack/swift/templates/haproxy-deployment.yaml
+++ b/openstack/swift/templates/haproxy-deployment.yaml
@@ -1,10 +1,25 @@
 {{- range $cluster_id, $cluster := .Values.clusters }}
+{{- $az_apods := dict }}
+{{- /*
+If aPod design is available take availability zones from there, with a list of aPods
+Else construct the same structure from the AZ list
+This and the affinities for 'cp' can go if aPod rollout is completed globally
+*/ -}}
+{{- if $.Values.global.apods }}
+{{- $az_apods = $.Values.global.apods }}
+{{- else }}
 {{- range $az := $.Values.global.availability_zones }}
+{{- $az_apods = set $az_apods $az list }}
+{{- end }}
+{{- end }}
+{{- range $az, $apods := $az_apods }}
+{{- $apods := append $apods "cp" }}
+{{- range $apod := $apods }}
 kind: Deployment
 apiVersion: apps/v1
 
 metadata:
-  name: swift-haproxy-{{ $cluster_id }}-{{ $az }}
+  name: swift-haproxy-{{ $cluster_id }}-{{ $az }}-{{ $apod }}
   labels:
     release: "{{ $.Release.Name }}"
     os-cluster: {{ $cluster_id }}
@@ -32,16 +47,28 @@ spec:
         os-cluster: {{ $cluster_id }}
         for-service: swift-proxy-{{ $cluster_id }}
         availability-zone: {{ $az }}
+        apod: {{ $apod }}
       annotations:
         checksum/haproxy.bin: {{ include "swift/templates/haproxy-bin-configmap.yaml" $ | sha256sum }}
         checksum/haproxy-cluster.etc: {{ include "swift/templates/etc/haproxy-cluster-configmap.yaml" $ | sha256sum }}
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus.openstack missing" $.Values.alerts.prometheus.openstack }}
     spec:
-      # No tolerations for swift nodes
       nodeSelector:
+        {{- if eq $apod "cp" }}
         failure-domain.beta.kubernetes.io/zone: {{ $az }}
+        {{- else }}
+        kubernetes.cloud.sap/apod: {{ $apod }}
+        {{- end }}
       affinity:
+        {{- if eq $apod "cp" }}
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.cloud.sap/apod
+                operator: DoesNotExist
+        {{- end }}
         podAntiAffinity:
           # Prefere to be scheduled on nodes not yet running this proxy from a deplyoment
           # kubernetes.io/hostname legacy control plane
@@ -147,5 +174,6 @@ spec:
               containerPort: 8404
 
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/openstack/swift/templates/haproxy-deployment.yaml
+++ b/openstack/swift/templates/haproxy-deployment.yaml
@@ -13,7 +13,9 @@ This and the affinities for 'cp' can go if aPod rollout is completed globally
 {{- end }}
 {{- end }}
 {{- range $az, $apods := $az_apods }}
-{{- $apods := append $apods "cp" }}
+{{- if $.Values.global.cp }}
+{{- $apods = append $apods "cp" }}
+{{- end }}
 {{- range $apod := $apods }}
 kind: Deployment
 apiVersion: apps/v1

--- a/openstack/swift/templates/haproxy-deployment.yaml
+++ b/openstack/swift/templates/haproxy-deployment.yaml
@@ -21,7 +21,7 @@ kind: Deployment
 apiVersion: apps/v1
 
 metadata:
-  name: swift-haproxy-{{ $cluster_id }}-{{ $az }}-{{ $apod }}
+  name: swift-haproxy-{{ $cluster_id }}-{{ $az }}{{ if ne $apod "cp" }}-{{ $apod }}{{ end }}
   labels:
     release: "{{ $.Release.Name }}"
     os-cluster: {{ $cluster_id }}


### PR DESCRIPTION
This introduces one haproxy deployment per AZ and per aPod.
Addtionally it creates a deployemnt per AZ for controlplane nodes for the transition period.
haproxy which should be scheduled to aPods, use nodeSelector `kubernetes.cloud.sap/apod`.
haproxy which should be scheduled to ControlPlane nodes use nodeSelector `failure-domain.beta.kubernetes.io/zone` and nodeAffinity not having label `kubernetes.cloud.sap/apod`.

The controlplane node handling should be removed after aPod Design is globally established.

Sceanrio 1 (aPod only)
```
haproxy_deploy_az1_apod1
haproxy_deploy_az1_apod2
haproxy_deploy_az2_apod3
```

Sceanrio 2 (aPod and ControlPlane)
```
haproxy_deploy_az1_apod1
haproxy_deploy_az1_cp
haproxy_deploy_az2_apod2
haproxy_deploy_az2_cp
```

Sceanrio 2 (ControlPlane only)
```
haproxy_deploy_az1_cp
haproxy_deploy_az2_cp
```