### PR TITLE
Update openstack-manila.alerts

### DIFF
--- a/openstack/manila/alerts/openstack-manila.alerts
+++ b/openstack/manila/alerts/openstack-manila.alerts
@@ -211,23 +211,6 @@ groups:
       description: 'Canary {{ $labels.service }} {{ $labels.check }} is flapping for 2 hours. See Sentry for details'
       summary: 'Canary {{ $labels.service }} {{ $labels.check }} is flapping'
 
-# alerts for other cert checks are in blackbox chart, this is filer cert only
-  - alert: OpenstackManilaFilerCertificateExpires
-    expr: blackbox_certificates_status_gauge{check=~".*stnpca.*cc"} == 1
-    # starts firing on expiration in 30 days (CERTS_ALERT_PERIOD) -> we want a warning 14 days before (30-16)
-    for: 16d
-    labels:
-      context: '{{ $labels.check }}'
-      meta: '{{ $labels.check }}'
-      sentry: blackbox/?query=test_{{ $labels.check }}
-      severity: warning
-      tier: os
-      playbook: 'docs/support/playbook/manila/filer_cert_expired.html'
-      support_component: manila_netapp
-    annotations:
-      description: Certificate {{ $labels.check }} expires in less than 14 days. See Sentry for details
-      summary: Certificates
-
 # row locks
   - alert: OpenstackManilaMariadbRowLocks
     expr: mysql_global_status_innodb_row_lock_current_waits{app="manila-mariadb"} > 0


### PR DESCRIPTION
since cc3tests are on scaleout cluster this alert move to scaleout promethus too. https://github.com/sapcc/helm-charts/blob/master/openstack/cc3test/alerts/file-shares.alerts#L60-L88