### PR TITLE
system/gatekeeper: validate value of service label on Pods

### DIFF
--- a/system/doop-central/templates/configmap.yaml
+++ b/system/doop-central/templates/configmap.yaml
@@ -134,7 +134,7 @@ data:
       <dl>
         <dt>Why is this a problem?</dt>
         <dd>
-          Each Pod should define at least a <code>tier</code> or <code>service</code> label that correspond to an alert channel (similar to the labels on your <code>PrometheusRule</code>) to enable delivery of generic Kubernetes-level alerts like <code>KubernetesPodRestartingTooMuch</code> to the more specific channels that the service owners observe.<br>
+          Each Pod should define at least a <code>tier</code> or <code>service</code> label that correspond to an alert channel (similar to the labels on your alert definitions) to enable delivery of generic Kubernetes-level alerts like <code>KubernetesPodRestartingTooMuch</code> to the more specific channels that the service owners observe.<br>
           When value of <code>tier</code> label is <code>os</code> then <code>service</code> label is also required and must have a value as per the Alertmanager config.
         </dd>
         <dt>How to fix?</dt>

--- a/system/doop-central/templates/configmap.yaml
+++ b/system/doop-central/templates/configmap.yaml
@@ -130,10 +130,13 @@ data:
         </dd>
       </dl>
     GkPodLabels: |
-      <p>This check finds Pods that that do not have all required labels.</p>
+      <p>This check validates required labels on Pods.</p>
       <dl>
         <dt>Why is this a problem?</dt>
-        <dd>Each Pod should have <code>service</code> and <code>tier</code> labels that correspond to an alert channel (similar to the labels on your <code>PrometheusRule</code>) to enable delivery of generic Kubernetes-level alerts like <code>KubernetesPodRestartingTooMuch</code> to the more specific channels that the service owners observe.</dd>
+        <dd>
+          Each Pod should define at least a <code>tier</code> or <code>service</code> label that correspond to an alert channel (similar to the labels on your <code>PrometheusRule</code>) to enable delivery of generic Kubernetes-level alerts like <code>KubernetesPodRestartingTooMuch</code> to the more specific channels that the service owners observe.<br>
+          When value of <code>tier</code> label is <code>os</code> then <code>service</code> label is also required and must have a value as per the Alertmanager config.
+        </dd>
         <dt>How to fix?</dt>
         <dd>Add the missing labels, as reported.</dd>
       </dl>

--- a/system/gatekeeper-config/ci/test-values.yaml
+++ b/system/gatekeeper-config/ci/test-values.yaml
@@ -4,3 +4,5 @@ global:
   registryAlternateRegion: keppel2.example.com/example
 
 cluster_type: "scaleout"
+
+osServices: one|two|three

--- a/system/gatekeeper-config/templates/config-pod-labels.yaml
+++ b/system/gatekeeper-config/templates/config-pod-labels.yaml
@@ -6,7 +6,8 @@ metadata:
     on-prod-ui: 'true'
 spec:
   enforcementAction: dryrun
-  parameters: {}
+  parameters:
+    osServices: {{.Values.osServices | required ".Values.osServices not found"}}
   match:
     kinds:
       - apiGroups: [""]

--- a/system/gatekeeper-config/values.yaml
+++ b/system/gatekeeper-config/values.yaml
@@ -1,1 +1,5 @@
 enforcement_mode: false
+
+# These values have been copied over from route.routes[].match_re.service, where tier == os and receiver == slack_by_os_service,
+# in helm-charts.git/global/prometheus-alertmanager-operated/templates/_alertmanager.yaml.tpl
+osServices: arc|backup|barbican|castellum|cinder|cfm|cronus|designate|documentation|elektra|elk|glance|hermes|ironic|keppel|keystone|limes|lyra|maia|manila|neutron|nova|octavia|sentry|swift

--- a/system/gatekeeper/templates/constraint-pod-labels.yaml
+++ b/system/gatekeeper/templates/constraint-pod-labels.yaml
@@ -49,8 +49,8 @@ spec:
         violation[{"msg": msg}] {
           input.review.object.kind == "Pod"
           count(pod_belongs_to) == 0 # otherwise the violation will be reported on the DaemonSet or Deployment instead
-          count(missing_labels_on_pod) > 1
-          msg := sprintf("pod does not have either one of the required labels: %s", [missing_labels_on_pod])
+          count(missing_labels_on_pod) == 2
+          msg := sprintf("pod does not have either one of the required labels: %s", [json.marshal(required_labels)])
         }
 
         violation[{"msg": msg}] {
@@ -72,8 +72,8 @@ spec:
 
         violation[{"msg": msg}] {
           input.review.object.kind == violation_owners[_]
-          count(missing_labels_on_pod_template) > 1
-          msg := sprintf("pod does not have either one of the required labels: %s", [missing_labels_on_pod_template])
+          count(missing_labels_on_pod_template) == 2
+          msg := sprintf("pod does not have either one of the required labels: %s", [json.marshal(required_labels)])
         }
 
         violation[{"msg": msg}] {

--- a/system/gatekeeper/templates/constraint-pod-labels.yaml
+++ b/system/gatekeeper/templates/constraint-pod-labels.yaml
@@ -28,9 +28,14 @@ spec:
         # Either tier or service label is required. However, when tier == os then service is also required.
         required_labels = {"tier", "service"}
 
-        missing_labels = [l |
+        missing_labels_on_pod = [l |
           required_labels[l]
           not input.review.object.metadata.labels[l]
+        ]
+
+        missing_labels_on_pod_template = [l |
+          required_labels[l]
+          not input.review.object.spec.template.metadata.labels[l]
         ]
 
         pod_owners = {"ReplicaSet", "DaemonSet", "StatefulSet"}
@@ -44,8 +49,8 @@ spec:
         violation[{"msg": msg}] {
           input.review.object.kind == "Pod"
           count(pod_belongs_to) == 0 # otherwise the violation will be reported on the DaemonSet or Deployment instead
-          count(missing_labels) > 1
-          msg := sprintf("pod does not have either one of the required labels: %s", [missing_labels])
+          count(missing_labels_on_pod) > 1
+          msg := sprintf("pod does not have either one of the required labels: %s", [missing_labels_on_pod])
         }
 
         violation[{"msg": msg}] {
@@ -67,16 +72,16 @@ spec:
 
         violation[{"msg": msg}] {
           input.review.object.kind == violation_owners[_]
-          count(missing_labels) > 1
-          msg := sprintf("pod does not have either one of the required labels: %s", [missing_labels])
+          count(missing_labels_on_pod_template) > 1
+          msg := sprintf("pod does not have either one of the required labels: %s", [missing_labels_on_pod_template])
         }
 
         violation[{"msg": msg}] {
           obj := input.review.object
           obj.kind == violation_owners[_]
 
-          obj.metadata.labels.tier == "os"
-          srv := object.get(obj.metadata.labels, "service", "")
+          obj.spec.template.metadata.labels.tier == "os"
+          srv := object.get(obj.spec.template.metadata.labels, "service", "")
           found := {f | srv == os_services[_]; f = true}
           count(found) == 0
           msg := sprintf(

--- a/system/gatekeeper/templates/constraint-pod-labels.yaml
+++ b/system/gatekeeper/templates/constraint-pod-labels.yaml
@@ -8,8 +8,11 @@ spec:
       names:
         kind: GkPodLabels
       validation:
+        # Schema for the `parameters` field
         openAPIV3Schema:
-          properties: {}
+          properties:
+            osServices:
+              type: string
 
   targets:
     - target: admission.k8s.gatekeeper.sh
@@ -19,18 +22,18 @@ spec:
         # Since we are going to have a lot of violations initially therefore we report on the
         # Deployment/DaemonSet level, where possible, to avoid useless duplication of violations.
 
-        required_labels["service"]
-        required_labels["tier"]
+        default os_services = []
+        os_services = sort(split(input.parameters.osServices, "|"))
 
-        missing_labels[l] {
-          obj := input.review.object
+        # Either tier or service label is required. However, when tier == os then service is also required.
+        required_labels = {"tier", "service"}
+
+        missing_labels = [l |
           required_labels[l]
-          not obj.metadata.labels[l]
-        }
+          not input.review.object.metadata.labels[l]
+        ]
 
-        pod_owners["ReplicaSet"]
-        pod_owners["DaemonSet"]
-        pod_owners["StatefulSet"]
+        pod_owners = {"ReplicaSet", "DaemonSet", "StatefulSet"}
 
         pod_belongs_to[kind] {
           ref := input.review.object.metadata.ownerReferences[_]
@@ -41,16 +44,43 @@ spec:
         violation[{"msg": msg}] {
           input.review.object.kind == "Pod"
           count(pod_belongs_to) == 0 # otherwise the violation will be reported on the DaemonSet or Deployment instead
-          count(missing_labels) > 0
-          msg := sprintf("pod does not have required labels: %s", [json.marshal(missing_labels)])
+          count(missing_labels) > 1
+          msg := sprintf("pod does not have either one of the required labels: %s", [missing_labels])
         }
 
-        violation_owners["Deployment"]
-        violation_owners["DaemonSet"]
-        violation_owners["StatefulSet"]
+        violation[{"msg": msg}] {
+          obj := input.review.object
+          obj.kind == "Pod"
+          count(pod_belongs_to) == 0 # otherwise the violation will be reported on the DaemonSet or Deployment instead
+
+          obj.metadata.labels.tier == "os"
+          srv := object.get(obj.metadata.labels, "service", "")
+          found := {f | srv == os_services[_]; f = true}
+          count(found) == 0
+          msg := sprintf(
+            "pod has %q label, but %q label is missing or does not have a valid value (got: %s, valid: %s)",
+            ["tier: os", "service", json.marshal(srv), os_services],
+          )
+        }
+
+        violation_owners = {"Deployment", "DaemonSet", "StatefulSet"}
 
         violation[{"msg": msg}] {
           input.review.object.kind == violation_owners[_]
-          count(missing_labels) > 0
-          msg := sprintf("pod does not have required labels: %s", [json.marshal(missing_labels)])
+          count(missing_labels) > 1
+          msg := sprintf("pod does not have either one of the required labels: %s", [missing_labels])
+        }
+
+        violation[{"msg": msg}] {
+          obj := input.review.object
+          obj.kind == violation_owners[_]
+
+          obj.metadata.labels.tier == "os"
+          srv := object.get(obj.metadata.labels, "service", "")
+          found := {f | srv == os_services[_]; f = true}
+          count(found) == 0
+          msg := sprintf(
+            "pod has %q label, but %q label is missing or does not have a valid value (got: %s, valid: %s)",
+            ["tier: os", "service", json.marshal(srv), os_services],
+          )
         }


### PR DESCRIPTION
Since there is [some Slack routing](https://github.com/sapcc/helm-charts/blob/master/global/prometheus-alertmanager-operated/templates/_alertmanager.yaml.tpl) that matches on `tier` or `service` only. I have made the policy such that only one of these labels is required.

However, when `tier == os` then service is also required and its value must be valid. 