### PR TITLE
[nova] Increase max_concurrent_live_migrations

### DIFF
--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -39,6 +39,9 @@ cell2:
   conductor:
     config_file: {}
 
+default:
+  max_concurrent_live_migrations: 4
+
 defaults:
   default:
     graceful_shutdown_timeout: 60


### PR DESCRIPTION
Only one migration per vcenter is quite conservative and it would take too much time
to empty a whole cluster when draining a cluster.