### PR TITLE
[system][bind] adding the ability to remove podAntiAffinity for bind3

### DIFF
--- a/system/bind/templates/deployment.yaml
+++ b/system/bind/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
         checksum/bind.config: {{ include "bind/templates/config.yaml" . | sha256sum }}
     spec:
       affinity:
+        {{ if not .Values.anti_affinity_disabled }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
@@ -42,6 +43,7 @@ spec:
                     {{ if eq .Values.name (printf "bind1-global-%s" (.Values.global.region)) }}- bind2-global-{{.Values.global.region}}{{ end }}
                     {{ if eq .Values.name (printf "bind2-global-%s" (.Values.global.region)) }}- bind1-global-{{.Values.global.region}}{{ end }}
               topologyKey: "failure-domain.beta.kubernetes.io/zone"
+        {{ end }} 
       containers:
       - name: {{ .Release.Name }}
         image: {{.Values.image_bind}}:{{ .Values.image_bind_tag}}


### PR DESCRIPTION
We do not want to set the podAntiAffinity to tie it to bind1/2 since it is for a different region. 