### PR TITLE
Create snmp exporter module for OS independent MIBs

### DIFF
--- a/global/prometheus-infra/templates/_prometheus.yaml.tpl
+++ b/global/prometheus-infra/templates/_prometheus.yaml.tpl
@@ -34,6 +34,7 @@
       - '{__name__=~"^snmp_n7k_cntpSysRootDispersion"}'
       - '{__name__=~"^snmp_pxdlrouternxos_sysDescr"}'
       - '{__name__=~"^snmp_pxdlrouternxos_rttMon.+"}'
+      - '{__name__=~"^snmp_pxgeneric.+"}'
       - '{__name__=~"^snmp_pxdlrouternxos_if.+"}'
       - '{__name__=~"^snmp_n9kpx_ciscoImageString"}'
       - '{__name__=~"^snmp_ipn_sysDescr"}'

--- a/prometheus-exporters/snmp-exporter/_snmp-exporter-pxgeneric.yaml
+++ b/prometheus-exporters/snmp-exporter/_snmp-exporter-pxgeneric.yaml
@@ -1,0 +1,1337 @@
+# WARNING: This file was auto-generated using snmp_exporter generator, manual changes will be lost.
+pxgeneric:
+  walk:
+  - 1.3.6.1.2.1.15.3.1.7
+  - 1.3.6.1.2.1.2.2.1.13
+  - 1.3.6.1.2.1.2.2.1.14
+  - 1.3.6.1.2.1.2.2.1.15
+  - 1.3.6.1.2.1.2.2.1.19
+  - 1.3.6.1.2.1.2.2.1.2
+  - 1.3.6.1.2.1.2.2.1.20
+  - 1.3.6.1.2.1.2.2.1.21
+  - 1.3.6.1.2.1.2.2.1.3
+  - 1.3.6.1.2.1.2.2.1.4
+  - 1.3.6.1.2.1.2.2.1.6
+  - 1.3.6.1.2.1.2.2.1.7
+  - 1.3.6.1.2.1.2.2.1.8
+  - 1.3.6.1.2.1.2.2.1.9
+  - 1.3.6.1.2.1.31.1.1.1.10
+  - 1.3.6.1.2.1.31.1.1.1.11
+  - 1.3.6.1.2.1.31.1.1.1.15
+  - 1.3.6.1.2.1.31.1.1.1.18
+  - 1.3.6.1.2.1.31.1.1.1.6
+  - 1.3.6.1.2.1.31.1.1.1.7
+  - 1.3.6.1.2.1.47.1.1.1.1.2
+  - 1.3.6.1.2.1.47.1.1.1.1.7
+  - 1.3.6.1.4.1.9.9.117.1.1.2.1.1
+  - 1.3.6.1.4.1.9.9.117.1.1.2.1.2
+  - 1.3.6.1.4.1.9.9.187.1.2.3.1.1
+  - 1.3.6.1.4.1.9.9.187.1.2.3.1.2
+  - 1.3.6.1.4.1.9.9.187.1.2.4.1.1
+  - 1.3.6.1.4.1.9.9.187.1.2.4.1.2
+  - 1.3.6.1.4.1.9.9.187.1.2.4.1.6
+  - 1.3.6.1.4.1.9.9.187.1.2.4.1.7
+  - 1.3.6.1.4.1.9.9.187.1.2.4.1.8
+  - 1.3.6.1.4.1.9.9.187.1.2.5.1.19
+  - 1.3.6.1.4.1.9.9.187.1.2.5.1.3
+  - 1.3.6.1.4.1.9.9.187.1.2.5.1.4
+  - 1.3.6.1.4.1.9.9.42.1.2.1.1.2
+  - 1.3.6.1.4.1.9.9.42.1.2.1.1.3
+  - 1.3.6.1.4.1.9.9.42.1.2.10.1.2
+  - 1.3.6.1.4.1.9.9.42.1.2.10.1.5
+  - 1.3.6.1.4.1.9.9.42.1.2.2.1.30
+  - 1.3.6.1.4.1.9.9.42.1.3.5.1.1
+  - 1.3.6.1.4.1.9.9.42.1.3.5.1.2
+  - 1.3.6.1.4.1.9.9.42.1.3.5.1.34
+  - 1.3.6.1.4.1.9.9.42.1.3.5.1.35
+  - 1.3.6.1.4.1.9.9.42.1.3.5.1.36
+  - 1.3.6.1.4.1.9.9.42.1.3.5.1.4
+  - 1.3.6.1.4.1.9.9.42.1.3.5.1.5
+  - 1.3.6.1.4.1.9.9.42.1.3.5.1.62
+  - 1.3.6.1.4.1.9.9.91.1.1.1.1.1
+  - 1.3.6.1.4.1.9.9.91.1.1.1.1.4
+  - 1.3.6.1.4.1.9.9.91.1.2.1.1.2
+  - 1.3.6.1.4.1.9.9.91.1.2.1.1.4
+  get:
+  - 1.3.6.1.2.1.1.1.0
+  - 1.3.6.1.2.1.1.3.0
+  - 1.3.6.1.4.1.9.9.43.1.1.1.0
+  - 1.3.6.1.4.1.9.9.43.1.1.2.0
+  metrics:
+  - name: snmp_pxgeneric_sysDescr
+    oid: 1.3.6.1.2.1.1.1
+    type: DisplayString
+    help: A textual description of the entity - 1.3.6.1.2.1.1.1
+  - name: snmp_pxgeneric_sysUpTime
+    oid: 1.3.6.1.2.1.1.3
+    type: gauge
+    help: The time (in hundredths of a second) since the network management portion
+      of the system was last re-initialized. - 1.3.6.1.2.1.1.3
+  - name: snmp_pxgeneric_bgpPeerRemoteAddr
+    oid: 1.3.6.1.2.1.15.3.1.7
+    type: InetAddressIPv4
+    help: The remote IP address of this entry's BGP peer. - 1.3.6.1.2.1.15.3.1.7
+    indexes:
+    - labelname: bgpPeerRemoteAddr
+      type: InetAddressIPv4
+  - name: snmp_pxgeneric_ifInDiscards
+    oid: 1.3.6.1.2.1.2.2.1.13
+    type: counter
+    help: The number of inbound packets which were chosen to be discarded even though
+      no errors had been detected to prevent their being deliverable to a higher-layer
+      protocol - 1.3.6.1.2.1.2.2.1.13
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+    lookups:
+    - labels:
+      - ifIndex
+      labelname: ifAlias
+      oid: 1.3.6.1.2.1.31.1.1.1.18
+      type: DisplayString
+    - labels:
+      - ifIndex
+      labelname: ifDescr
+      oid: 1.3.6.1.2.1.2.2.1.2
+      type: DisplayString
+    - labels:
+      - ifIndex
+      labelname: ifType
+      oid: 1.3.6.1.2.1.2.2.1.3
+      type: EnumAsInfo
+    - labels:
+      - ifIndex
+      labelname: ifMtu
+      oid: 1.3.6.1.2.1.2.2.1.4
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifHighSpeed
+      oid: 1.3.6.1.2.1.31.1.1.1.15
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifPhysAddress
+      oid: 1.3.6.1.2.1.2.2.1.6
+      type: PhysAddress48
+    - labels:
+      - ifIndex
+      labelname: ifAdminStatus
+      oid: 1.3.6.1.2.1.2.2.1.7
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifOperStatus
+      oid: 1.3.6.1.2.1.2.2.1.8
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifAlias
+      oid: 1.3.6.1.2.1.31.1.1.1.18
+      type: DisplayString
+  - name: snmp_pxgeneric_ifInErrors
+    oid: 1.3.6.1.2.1.2.2.1.14
+    type: counter
+    help: The number of inbound packets that contained errors preventing them from
+      being deliverable to a higher-layer protocol. - 1.3.6.1.2.1.2.2.1.14
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+    lookups:
+    - labels:
+      - ifIndex
+      labelname: ifAlias
+      oid: 1.3.6.1.2.1.31.1.1.1.18
+      type: DisplayString
+    - labels:
+      - ifIndex
+      labelname: ifDescr
+      oid: 1.3.6.1.2.1.2.2.1.2
+      type: DisplayString
+    - labels:
+      - ifIndex
+      labelname: ifType
+      oid: 1.3.6.1.2.1.2.2.1.3
+      type: EnumAsInfo
+    - labels:
+      - ifIndex
+      labelname: ifMtu
+      oid: 1.3.6.1.2.1.2.2.1.4
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifHighSpeed
+      oid: 1.3.6.1.2.1.31.1.1.1.15
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifPhysAddress
+      oid: 1.3.6.1.2.1.2.2.1.6
+      type: PhysAddress48
+    - labels:
+      - ifIndex
+      labelname: ifAdminStatus
+      oid: 1.3.6.1.2.1.2.2.1.7
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifOperStatus
+      oid: 1.3.6.1.2.1.2.2.1.8
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifAlias
+      oid: 1.3.6.1.2.1.31.1.1.1.18
+      type: DisplayString
+  - name: snmp_pxgeneric_ifInUnknownProtos
+    oid: 1.3.6.1.2.1.2.2.1.15
+    type: counter
+    help: The number of packets received via the interface which were discarded because
+      of an unknown or unsupported protocol. - 1.3.6.1.2.1.2.2.1.15
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+    lookups:
+    - labels:
+      - ifIndex
+      labelname: ifAlias
+      oid: 1.3.6.1.2.1.31.1.1.1.18
+      type: DisplayString
+    - labels:
+      - ifIndex
+      labelname: ifDescr
+      oid: 1.3.6.1.2.1.2.2.1.2
+      type: DisplayString
+    - labels:
+      - ifIndex
+      labelname: ifType
+      oid: 1.3.6.1.2.1.2.2.1.3
+      type: EnumAsInfo
+    - labels:
+      - ifIndex
+      labelname: ifMtu
+      oid: 1.3.6.1.2.1.2.2.1.4
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifHighSpeed
+      oid: 1.3.6.1.2.1.31.1.1.1.15
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifPhysAddress
+      oid: 1.3.6.1.2.1.2.2.1.6
+      type: PhysAddress48
+    - labels:
+      - ifIndex
+      labelname: ifAdminStatus
+      oid: 1.3.6.1.2.1.2.2.1.7
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifOperStatus
+      oid: 1.3.6.1.2.1.2.2.1.8
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifAlias
+      oid: 1.3.6.1.2.1.31.1.1.1.18
+      type: DisplayString
+  - name: snmp_pxgeneric_ifOutDiscards
+    oid: 1.3.6.1.2.1.2.2.1.19
+    type: counter
+    help: The number of outbound packets which were chosen to be discarded even though
+      no errors had been detected to prevent their being transmitted - 1.3.6.1.2.1.2.2.1.19
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+    lookups:
+    - labels:
+      - ifIndex
+      labelname: ifAlias
+      oid: 1.3.6.1.2.1.31.1.1.1.18
+      type: DisplayString
+    - labels:
+      - ifIndex
+      labelname: ifDescr
+      oid: 1.3.6.1.2.1.2.2.1.2
+      type: DisplayString
+    - labels:
+      - ifIndex
+      labelname: ifType
+      oid: 1.3.6.1.2.1.2.2.1.3
+      type: EnumAsInfo
+    - labels:
+      - ifIndex
+      labelname: ifMtu
+      oid: 1.3.6.1.2.1.2.2.1.4
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifHighSpeed
+      oid: 1.3.6.1.2.1.31.1.1.1.15
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifPhysAddress
+      oid: 1.3.6.1.2.1.2.2.1.6
+      type: PhysAddress48
+    - labels:
+      - ifIndex
+      labelname: ifAdminStatus
+      oid: 1.3.6.1.2.1.2.2.1.7
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifOperStatus
+      oid: 1.3.6.1.2.1.2.2.1.8
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifAlias
+      oid: 1.3.6.1.2.1.31.1.1.1.18
+      type: DisplayString
+  - name: snmp_pxgeneric_ifOutErrors
+    oid: 1.3.6.1.2.1.2.2.1.20
+    type: counter
+    help: The number of outbound packets that could not be transmitted because of
+      errors. - 1.3.6.1.2.1.2.2.1.20
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+    lookups:
+    - labels:
+      - ifIndex
+      labelname: ifAlias
+      oid: 1.3.6.1.2.1.31.1.1.1.18
+      type: DisplayString
+    - labels:
+      - ifIndex
+      labelname: ifDescr
+      oid: 1.3.6.1.2.1.2.2.1.2
+      type: DisplayString
+    - labels:
+      - ifIndex
+      labelname: ifType
+      oid: 1.3.6.1.2.1.2.2.1.3
+      type: EnumAsInfo
+    - labels:
+      - ifIndex
+      labelname: ifMtu
+      oid: 1.3.6.1.2.1.2.2.1.4
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifHighSpeed
+      oid: 1.3.6.1.2.1.31.1.1.1.15
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifPhysAddress
+      oid: 1.3.6.1.2.1.2.2.1.6
+      type: PhysAddress48
+    - labels:
+      - ifIndex
+      labelname: ifAdminStatus
+      oid: 1.3.6.1.2.1.2.2.1.7
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifOperStatus
+      oid: 1.3.6.1.2.1.2.2.1.8
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifAlias
+      oid: 1.3.6.1.2.1.31.1.1.1.18
+      type: DisplayString
+  - name: snmp_pxgeneric_ifOutQLen
+    oid: 1.3.6.1.2.1.2.2.1.21
+    type: gauge
+    help: The length of the output packet queue (in packets). - 1.3.6.1.2.1.2.2.1.21
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+    lookups:
+    - labels:
+      - ifIndex
+      labelname: ifAlias
+      oid: 1.3.6.1.2.1.31.1.1.1.18
+      type: DisplayString
+    - labels:
+      - ifIndex
+      labelname: ifDescr
+      oid: 1.3.6.1.2.1.2.2.1.2
+      type: DisplayString
+    - labels:
+      - ifIndex
+      labelname: ifType
+      oid: 1.3.6.1.2.1.2.2.1.3
+      type: EnumAsInfo
+    - labels:
+      - ifIndex
+      labelname: ifMtu
+      oid: 1.3.6.1.2.1.2.2.1.4
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifHighSpeed
+      oid: 1.3.6.1.2.1.31.1.1.1.15
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifPhysAddress
+      oid: 1.3.6.1.2.1.2.2.1.6
+      type: PhysAddress48
+    - labels:
+      - ifIndex
+      labelname: ifAdminStatus
+      oid: 1.3.6.1.2.1.2.2.1.7
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifOperStatus
+      oid: 1.3.6.1.2.1.2.2.1.8
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifAlias
+      oid: 1.3.6.1.2.1.31.1.1.1.18
+      type: DisplayString
+  - name: snmp_pxgeneric_ifLastChange
+    oid: 1.3.6.1.2.1.2.2.1.9
+    type: gauge
+    help: The value of sysUpTime at the time the interface entered its current operational
+      state - 1.3.6.1.2.1.2.2.1.9
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+    lookups:
+    - labels:
+      - ifIndex
+      labelname: ifAlias
+      oid: 1.3.6.1.2.1.31.1.1.1.18
+      type: DisplayString
+    - labels:
+      - ifIndex
+      labelname: ifDescr
+      oid: 1.3.6.1.2.1.2.2.1.2
+      type: DisplayString
+    - labels:
+      - ifIndex
+      labelname: ifType
+      oid: 1.3.6.1.2.1.2.2.1.3
+      type: EnumAsInfo
+    - labels:
+      - ifIndex
+      labelname: ifMtu
+      oid: 1.3.6.1.2.1.2.2.1.4
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifHighSpeed
+      oid: 1.3.6.1.2.1.31.1.1.1.15
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifPhysAddress
+      oid: 1.3.6.1.2.1.2.2.1.6
+      type: PhysAddress48
+    - labels:
+      - ifIndex
+      labelname: ifAdminStatus
+      oid: 1.3.6.1.2.1.2.2.1.7
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifOperStatus
+      oid: 1.3.6.1.2.1.2.2.1.8
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifAlias
+      oid: 1.3.6.1.2.1.31.1.1.1.18
+      type: DisplayString
+  - name: snmp_pxgeneric_ifHCOutOctets
+    oid: 1.3.6.1.2.1.31.1.1.1.10
+    type: counter
+    help: The total number of octets transmitted out of the interface, including framing
+      characters - 1.3.6.1.2.1.31.1.1.1.10
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+    lookups:
+    - labels:
+      - ifIndex
+      labelname: ifAlias
+      oid: 1.3.6.1.2.1.31.1.1.1.18
+      type: DisplayString
+    - labels:
+      - ifIndex
+      labelname: ifDescr
+      oid: 1.3.6.1.2.1.2.2.1.2
+      type: DisplayString
+    - labels:
+      - ifIndex
+      labelname: ifType
+      oid: 1.3.6.1.2.1.2.2.1.3
+      type: EnumAsInfo
+    - labels:
+      - ifIndex
+      labelname: ifMtu
+      oid: 1.3.6.1.2.1.2.2.1.4
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifHighSpeed
+      oid: 1.3.6.1.2.1.31.1.1.1.15
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifPhysAddress
+      oid: 1.3.6.1.2.1.2.2.1.6
+      type: PhysAddress48
+    - labels:
+      - ifIndex
+      labelname: ifAdminStatus
+      oid: 1.3.6.1.2.1.2.2.1.7
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifOperStatus
+      oid: 1.3.6.1.2.1.2.2.1.8
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifAlias
+      oid: 1.3.6.1.2.1.31.1.1.1.18
+      type: DisplayString
+  - name: snmp_pxgeneric_ifHCOutUcastPkts
+    oid: 1.3.6.1.2.1.31.1.1.1.11
+    type: counter
+    help: The total number of packets that higher-level protocols requested be transmitted,
+      and which were not addressed to a multicast or broadcast address at this sub-layer,
+      including those that were discarded or not sent - 1.3.6.1.2.1.31.1.1.1.11
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+    lookups:
+    - labels:
+      - ifIndex
+      labelname: ifAlias
+      oid: 1.3.6.1.2.1.31.1.1.1.18
+      type: DisplayString
+    - labels:
+      - ifIndex
+      labelname: ifDescr
+      oid: 1.3.6.1.2.1.2.2.1.2
+      type: DisplayString
+    - labels:
+      - ifIndex
+      labelname: ifType
+      oid: 1.3.6.1.2.1.2.2.1.3
+      type: EnumAsInfo
+    - labels:
+      - ifIndex
+      labelname: ifMtu
+      oid: 1.3.6.1.2.1.2.2.1.4
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifHighSpeed
+      oid: 1.3.6.1.2.1.31.1.1.1.15
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifPhysAddress
+      oid: 1.3.6.1.2.1.2.2.1.6
+      type: PhysAddress48
+    - labels:
+      - ifIndex
+      labelname: ifAdminStatus
+      oid: 1.3.6.1.2.1.2.2.1.7
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifOperStatus
+      oid: 1.3.6.1.2.1.2.2.1.8
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifAlias
+      oid: 1.3.6.1.2.1.31.1.1.1.18
+      type: DisplayString
+  - name: snmp_pxgeneric_ifHCInOctets
+    oid: 1.3.6.1.2.1.31.1.1.1.6
+    type: counter
+    help: The total number of octets received on the interface, including framing
+      characters - 1.3.6.1.2.1.31.1.1.1.6
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+    lookups:
+    - labels:
+      - ifIndex
+      labelname: ifAlias
+      oid: 1.3.6.1.2.1.31.1.1.1.18
+      type: DisplayString
+    - labels:
+      - ifIndex
+      labelname: ifDescr
+      oid: 1.3.6.1.2.1.2.2.1.2
+      type: DisplayString
+    - labels:
+      - ifIndex
+      labelname: ifType
+      oid: 1.3.6.1.2.1.2.2.1.3
+      type: EnumAsInfo
+    - labels:
+      - ifIndex
+      labelname: ifMtu
+      oid: 1.3.6.1.2.1.2.2.1.4
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifHighSpeed
+      oid: 1.3.6.1.2.1.31.1.1.1.15
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifPhysAddress
+      oid: 1.3.6.1.2.1.2.2.1.6
+      type: PhysAddress48
+    - labels:
+      - ifIndex
+      labelname: ifAdminStatus
+      oid: 1.3.6.1.2.1.2.2.1.7
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifOperStatus
+      oid: 1.3.6.1.2.1.2.2.1.8
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifAlias
+      oid: 1.3.6.1.2.1.31.1.1.1.18
+      type: DisplayString
+  - name: snmp_pxgeneric_ifHCInUcastPkts
+    oid: 1.3.6.1.2.1.31.1.1.1.7
+    type: counter
+    help: The number of packets, delivered by this sub-layer to a higher (sub-)layer,
+      which were not addressed to a multicast or broadcast address at this sub-layer
+      - 1.3.6.1.2.1.31.1.1.1.7
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+    lookups:
+    - labels:
+      - ifIndex
+      labelname: ifAlias
+      oid: 1.3.6.1.2.1.31.1.1.1.18
+      type: DisplayString
+    - labels:
+      - ifIndex
+      labelname: ifDescr
+      oid: 1.3.6.1.2.1.2.2.1.2
+      type: DisplayString
+    - labels:
+      - ifIndex
+      labelname: ifType
+      oid: 1.3.6.1.2.1.2.2.1.3
+      type: EnumAsInfo
+    - labels:
+      - ifIndex
+      labelname: ifMtu
+      oid: 1.3.6.1.2.1.2.2.1.4
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifHighSpeed
+      oid: 1.3.6.1.2.1.31.1.1.1.15
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifPhysAddress
+      oid: 1.3.6.1.2.1.2.2.1.6
+      type: PhysAddress48
+    - labels:
+      - ifIndex
+      labelname: ifAdminStatus
+      oid: 1.3.6.1.2.1.2.2.1.7
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifOperStatus
+      oid: 1.3.6.1.2.1.2.2.1.8
+      type: gauge
+    - labels:
+      - ifIndex
+      labelname: ifAlias
+      oid: 1.3.6.1.2.1.31.1.1.1.18
+      type: DisplayString
+  - name: snmp_pxgeneric_entPhysicalDescr
+    oid: 1.3.6.1.2.1.47.1.1.1.1.2
+    type: DisplayString
+    help: A textual description of physical entity - 1.3.6.1.2.1.47.1.1.1.1.2
+    indexes:
+    - labelname: entPhysicalIndex
+      type: gauge
+    lookups:
+    - labels:
+      - entPhysicalIndex
+      labelname: entPhysicalName
+      oid: 1.3.6.1.2.1.47.1.1.1.1.7
+      type: DisplayString
+    - labels:
+      - entPhysicalIndex
+      labelname: entPhysicalDescr
+      oid: 1.3.6.1.2.1.47.1.1.1.1.2
+      type: DisplayString
+  - name: snmp_pxgeneric_entPhysicalName
+    oid: 1.3.6.1.2.1.47.1.1.1.1.7
+    type: DisplayString
+    help: The textual name of the physical entity - 1.3.6.1.2.1.47.1.1.1.1.7
+    indexes:
+    - labelname: entPhysicalIndex
+      type: gauge
+    lookups:
+    - labels:
+      - entPhysicalIndex
+      labelname: entPhysicalName
+      oid: 1.3.6.1.2.1.47.1.1.1.1.7
+      type: DisplayString
+    - labels:
+      - entPhysicalIndex
+      labelname: entPhysicalDescr
+      oid: 1.3.6.1.2.1.47.1.1.1.1.2
+      type: DisplayString
+  - name: snmp_pxgeneric_cefcFRUPowerAdminStatus
+    oid: 1.3.6.1.4.1.9.9.117.1.1.2.1.1
+    type: gauge
+    help: Administratively desired FRU power state. - 1.3.6.1.4.1.9.9.117.1.1.2.1.1
+    indexes:
+    - labelname: entPhysicalIndex
+      type: gauge
+    lookups:
+    - labels:
+      - entPhysicalIndex
+      labelname: entPhysicalName
+      oid: 1.3.6.1.2.1.47.1.1.1.1.7
+      type: DisplayString
+    - labels:
+      - entPhysicalIndex
+      labelname: entPhysicalDescr
+      oid: 1.3.6.1.2.1.47.1.1.1.1.2
+      type: DisplayString
+    enum_values:
+      1: "on"
+      2: "off"
+      3: inlineAuto
+      4: inlineOn
+      5: powerCycle
+  - name: snmp_pxgeneric_cefcFRUPowerOperStatus
+    oid: 1.3.6.1.4.1.9.9.117.1.1.2.1.2
+    type: gauge
+    help: Operational FRU power state. - 1.3.6.1.4.1.9.9.117.1.1.2.1.2
+    indexes:
+    - labelname: entPhysicalIndex
+      type: gauge
+    lookups:
+    - labels:
+      - entPhysicalIndex
+      labelname: entPhysicalName
+      oid: 1.3.6.1.2.1.47.1.1.1.1.7
+      type: DisplayString
+    - labels:
+      - entPhysicalIndex
+      labelname: entPhysicalDescr
+      oid: 1.3.6.1.2.1.47.1.1.1.1.2
+      type: DisplayString
+    enum_values:
+      1: offEnvOther
+      2: "on"
+      3: offAdmin
+      4: offDenied
+      5: offEnvPower
+      6: offEnvTemp
+      7: offEnvFan
+      8: failed
+      9: onButFanFail
+      10: offCooling
+      11: offConnectorRating
+      12: onButInlinePowerFail
+  - name: snmp_pxgeneric_cbgpPeerAddrFamilyAfi
+    oid: 1.3.6.1.4.1.9.9.187.1.2.3.1.1
+    type: gauge
+    help: The AFI index of the entry - 1.3.6.1.4.1.9.9.187.1.2.3.1.1
+    indexes:
+    - labelname: bgpPeerRemoteAddr
+      type: InetAddressIPv4
+    - labelname: cbgpPeerAddrFamilyAfi
+      type: gauge
+      enum_values:
+        0: unknown
+        1: ipv4
+        2: ipv6
+        3: ipv4z
+        4: ipv6z
+        16: dns
+    - labelname: cbgpPeerAddrFamilySafi
+      type: gauge
+      enum_values:
+        1: unicast
+        2: multicast
+        3: unicastAndMulticast
+        128: vpn
+    enum_values:
+      0: unknown
+      1: ipv4
+      2: ipv6
+      3: ipv4z
+      4: ipv6z
+      16: dns
+  - name: snmp_pxgeneric_cbgpPeerAddrFamilySafi
+    oid: 1.3.6.1.4.1.9.9.187.1.2.3.1.2
+    type: gauge
+    help: The SAFI index of the entry - 1.3.6.1.4.1.9.9.187.1.2.3.1.2
+    indexes:
+    - labelname: bgpPeerRemoteAddr
+      type: InetAddressIPv4
+    - labelname: cbgpPeerAddrFamilyAfi
+      type: gauge
+      enum_values:
+        0: unknown
+        1: ipv4
+        2: ipv6
+        3: ipv4z
+        4: ipv6z
+        16: dns
+    - labelname: cbgpPeerAddrFamilySafi
+      type: gauge
+      enum_values:
+        1: unicast
+        2: multicast
+        3: unicastAndMulticast
+        128: vpn
+    enum_values:
+      1: unicast
+      2: multicast
+      3: unicastAndMulticast
+      128: vpn
+  - name: snmp_pxgeneric_cbgpPeerAcceptedPrefixes
+    oid: 1.3.6.1.4.1.9.9.187.1.2.4.1.1
+    type: counter
+    help: Number of accepted route prefixes on this connection, which belong to an
+      address family. - 1.3.6.1.4.1.9.9.187.1.2.4.1.1
+    indexes:
+    - labelname: bgpPeerRemoteAddr
+      type: InetAddressIPv4
+    - labelname: cbgpPeerAddrFamilyAfi
+      type: gauge
+      enum_values:
+        0: unknown
+        1: ipv4
+        2: ipv6
+        3: ipv4z
+        4: ipv6z
+        16: dns
+    - labelname: cbgpPeerAddrFamilySafi
+      type: gauge
+      enum_values:
+        1: unicast
+        2: multicast
+        3: unicastAndMulticast
+        128: vpn
+  - name: snmp_pxgeneric_cbgpPeerDeniedPrefixes
+    oid: 1.3.6.1.4.1.9.9.187.1.2.4.1.2
+    type: gauge
+    help: This counter is incremented when a route prefix, which belongs to an address
+      family, received on this connection is denied - 1.3.6.1.4.1.9.9.187.1.2.4.1.2
+    indexes:
+    - labelname: bgpPeerRemoteAddr
+      type: InetAddressIPv4
+    - labelname: cbgpPeerAddrFamilyAfi
+      type: gauge
+      enum_values:
+        0: unknown
+        1: ipv4
+        2: ipv6
+        3: ipv4z
+        4: ipv6z
+        16: dns
+    - labelname: cbgpPeerAddrFamilySafi
+      type: gauge
+      enum_values:
+        1: unicast
+        2: multicast
+        3: unicastAndMulticast
+        128: vpn
+  - name: snmp_pxgeneric_cbgpPeerAdvertisedPrefixes
+    oid: 1.3.6.1.4.1.9.9.187.1.2.4.1.6
+    type: gauge
+    help: This counter is incremented when a route prefix, which belongs to an address
+      family is advertised on this connection - 1.3.6.1.4.1.9.9.187.1.2.4.1.6
+    indexes:
+    - labelname: bgpPeerRemoteAddr
+      type: InetAddressIPv4
+    - labelname: cbgpPeerAddrFamilyAfi
+      type: gauge
+      enum_values:
+        0: unknown
+        1: ipv4
+        2: ipv6
+        3: ipv4z
+        4: ipv6z
+        16: dns
+    - labelname: cbgpPeerAddrFamilySafi
+      type: gauge
+      enum_values:
+        1: unicast
+        2: multicast
+        3: unicastAndMulticast
+        128: vpn
+  - name: snmp_pxgeneric_cbgpPeerSuppressedPrefixes
+    oid: 1.3.6.1.4.1.9.9.187.1.2.4.1.7
+    type: gauge
+    help: This counter is incremented when a route prefix, which belongs to an address
+      family is suppressed from being sent on this connection - 1.3.6.1.4.1.9.9.187.1.2.4.1.7
+    indexes:
+    - labelname: bgpPeerRemoteAddr
+      type: InetAddressIPv4
+    - labelname: cbgpPeerAddrFamilyAfi
+      type: gauge
+      enum_values:
+        0: unknown
+        1: ipv4
+        2: ipv6
+        3: ipv4z
+        4: ipv6z
+        16: dns
+    - labelname: cbgpPeerAddrFamilySafi
+      type: gauge
+      enum_values:
+        1: unicast
+        2: multicast
+        3: unicastAndMulticast
+        128: vpn
+  - name: snmp_pxgeneric_cbgpPeerWithdrawnPrefixes
+    oid: 1.3.6.1.4.1.9.9.187.1.2.4.1.8
+    type: gauge
+    help: This counter is incremented when a route prefix, which belongs to an address
+      family, is withdrawn on this connection - 1.3.6.1.4.1.9.9.187.1.2.4.1.8
+    indexes:
+    - labelname: bgpPeerRemoteAddr
+      type: InetAddressIPv4
+    - labelname: cbgpPeerAddrFamilyAfi
+      type: gauge
+      enum_values:
+        0: unknown
+        1: ipv4
+        2: ipv6
+        3: ipv4z
+        4: ipv6z
+        16: dns
+    - labelname: cbgpPeerAddrFamilySafi
+      type: gauge
+      enum_values:
+        1: unicast
+        2: multicast
+        3: unicastAndMulticast
+        128: vpn
+  - name: snmp_pxgeneric_cbgpPeer2FsmEstablishedTime
+    oid: 1.3.6.1.4.1.9.9.187.1.2.5.1.19
+    type: gauge
+    help: This timer indicates how long (in seconds) this peer has been in the established
+      state or how long since this peer was last in the established state - 1.3.6.1.4.1.9.9.187.1.2.5.1.19
+    indexes:
+    - labelname: cbgpPeer2RemoteAddr
+      type: InetAddress
+  - name: snmp_pxgeneric_cbgpPeer2State
+    oid: 1.3.6.1.4.1.9.9.187.1.2.5.1.3
+    type: gauge
+    help: The BGP peer connection state. - 1.3.6.1.4.1.9.9.187.1.2.5.1.3
+    indexes:
+    - labelname: cbgpPeer2RemoteAddr
+      type: InetAddress
+    enum_values:
+      1: idle
+      2: connect
+      3: active
+      4: opensent
+      5: openconfirm
+      6: established
+  - name: snmp_pxgeneric_cbgpPeer2AdminStatus
+    oid: 1.3.6.1.4.1.9.9.187.1.2.5.1.4
+    type: gauge
+    help: The desired state of the BGP connection - 1.3.6.1.4.1.9.9.187.1.2.5.1.4
+    indexes:
+    - labelname: cbgpPeer2RemoteAddr
+      type: InetAddress
+    enum_values:
+      1: stop
+      2: start
+  - name: snmp_pxgeneric_rttMonLatestRttOperSense
+    oid: 1.3.6.1.4.1.9.9.42.1.2.10.1.2
+    type: gauge
+    help: A sense code for the completion status of the latest RTT operation. - 1.3.6.1.4.1.9.9.42.1.2.10.1.2
+    indexes:
+    - labelname: rttMonCtrlAdminIndex
+      type: gauge
+    lookups:
+    - labels:
+      - rttMonCtrlAdminIndex
+      labelname: rttMonCtrlAdminOwner
+      oid: 1.3.6.1.4.1.9.9.42.1.2.1.1.2
+      type: OctetString
+    - labels:
+      - rttMonCtrlAdminIndex
+      labelname: rttMonCtrlAdminTag
+      oid: 1.3.6.1.4.1.9.9.42.1.2.1.1.3
+      type: DisplayString
+    enum_values:
+      0: other
+      1: ok
+      2: disconnected
+      3: overThreshold
+      4: timeout
+      5: busy
+      6: notConnected
+      7: dropped
+      8: sequenceError
+      9: verifyError
+      10: applicationSpecific
+      11: dnsServerTimeout
+      12: tcpConnectTimeout
+      13: httpTransactionTimeout
+      14: dnsQueryError
+      15: httpError
+      16: error
+      17: mplsLspEchoTxError
+      18: mplsLspUnreachable
+      19: mplsLspMalformedReq
+      20: mplsLspReachButNotFEC
+      21: enableOk
+      22: enableNoConnect
+      23: enableVersionFail
+      24: enableInternalError
+      25: enableAbort
+      26: enableFail
+      27: enableAuthFail
+      28: enableFormatError
+      29: enablePortInUse
+      30: statsRetrieveOk
+      31: statsRetrieveNoConnect
+      32: statsRetrieveVersionFail
+      33: statsRetrieveInternalError
+      34: statsRetrieveAbort
+      35: statsRetrieveFail
+      36: statsRetrieveAuthFail
+      37: statsRetrieveFormatError
+      38: statsRetrievePortInUse
+  - name: snmp_pxgeneric_rttMonLatestRttOperTime
+    oid: 1.3.6.1.4.1.9.9.42.1.2.10.1.5
+    type: gauge
+    help: The value of the agent system time at the time of the latest RTT operation.
+      - 1.3.6.1.4.1.9.9.42.1.2.10.1.5
+    indexes:
+    - labelname: rttMonCtrlAdminIndex
+      type: gauge
+    lookups:
+    - labels:
+      - rttMonCtrlAdminIndex
+      labelname: rttMonCtrlAdminOwner
+      oid: 1.3.6.1.4.1.9.9.42.1.2.1.1.2
+      type: OctetString
+    - labels:
+      - rttMonCtrlAdminIndex
+      labelname: rttMonCtrlAdminTag
+      oid: 1.3.6.1.4.1.9.9.42.1.2.1.1.3
+      type: DisplayString
+  - name: snmp_pxgeneric_rttMonEchoAdminCodecNumPackets
+    oid: 1.3.6.1.4.1.9.9.42.1.2.2.1.30
+    type: gauge
+    help: This value represents the number of packets that need to be transmitted
+      - 1.3.6.1.4.1.9.9.42.1.2.2.1.30
+    indexes:
+    - labelname: rttMonCtrlAdminIndex
+      type: gauge
+    lookups:
+    - labels:
+      - rttMonCtrlAdminIndex
+      labelname: rttMonCtrlAdminOwner
+      oid: 1.3.6.1.4.1.9.9.42.1.2.1.1.2
+      type: OctetString
+    - labels:
+      - rttMonCtrlAdminIndex
+      labelname: rttMonCtrlAdminTag
+      oid: 1.3.6.1.4.1.9.9.42.1.2.1.1.3
+      type: DisplayString
+  - name: snmp_pxgeneric_rttMonJitterStatsStartTimeIndex
+    oid: 1.3.6.1.4.1.9.9.42.1.3.5.1.1
+    type: gauge
+    help: The time when this row was created. - 1.3.6.1.4.1.9.9.42.1.3.5.1.1
+    indexes:
+    - labelname: rttMonCtrlAdminIndex
+      type: gauge
+    - labelname: rttMonJitterStatsStartTimeIndex
+      type: gauge
+    lookups:
+    - labels:
+      - rttMonCtrlAdminIndex
+      labelname: rttMonCtrlAdminOwner
+      oid: 1.3.6.1.4.1.9.9.42.1.2.1.1.2
+      type: OctetString
+    - labels:
+      - rttMonCtrlAdminIndex
+      labelname: rttMonCtrlAdminTag
+      oid: 1.3.6.1.4.1.9.9.42.1.2.1.1.3
+      type: DisplayString
+  - name: snmp_pxgeneric_rttMonJitterStatsCompletions
+    oid: 1.3.6.1.4.1.9.9.42.1.3.5.1.2
+    type: counter
+    help: The number of jitter operation that have completed successfully. - 1.3.6.1.4.1.9.9.42.1.3.5.1.2
+    indexes:
+    - labelname: rttMonCtrlAdminIndex
+      type: gauge
+    - labelname: rttMonJitterStatsStartTimeIndex
+      type: gauge
+    lookups:
+    - labels:
+      - rttMonCtrlAdminIndex
+      labelname: rttMonCtrlAdminOwner
+      oid: 1.3.6.1.4.1.9.9.42.1.2.1.1.2
+      type: OctetString
+    - labels:
+      - rttMonCtrlAdminIndex
+      labelname: rttMonCtrlAdminTag
+      oid: 1.3.6.1.4.1.9.9.42.1.2.1.1.3
+      type: DisplayString
+  - name: snmp_pxgeneric_rttMonJitterStatsPacketLossSD
+    oid: 1.3.6.1.4.1.9.9.42.1.3.5.1.34
+    type: counter
+    help: The number of packets lost when sent from source to destination. - 1.3.6.1.4.1.9.9.42.1.3.5.1.34
+    indexes:
+    - labelname: rttMonCtrlAdminIndex
+      type: gauge
+    - labelname: rttMonJitterStatsStartTimeIndex
+      type: gauge
+    lookups:
+    - labels:
+      - rttMonCtrlAdminIndex
+      labelname: rttMonCtrlAdminOwner
+      oid: 1.3.6.1.4.1.9.9.42.1.2.1.1.2
+      type: OctetString
+    - labels:
+      - rttMonCtrlAdminIndex
+      labelname: rttMonCtrlAdminTag
+      oid: 1.3.6.1.4.1.9.9.42.1.2.1.1.3
+      type: DisplayString
+  - name: snmp_pxgeneric_rttMonJitterStatsPacketLossDS
+    oid: 1.3.6.1.4.1.9.9.42.1.3.5.1.35
+    type: counter
+    help: The number of packets lost when sent from destination to source. - 1.3.6.1.4.1.9.9.42.1.3.5.1.35
+    indexes:
+    - labelname: rttMonCtrlAdminIndex
+      type: gauge
+    - labelname: rttMonJitterStatsStartTimeIndex
+      type: gauge
+    lookups:
+    - labels:
+      - rttMonCtrlAdminIndex
+      labelname: rttMonCtrlAdminOwner
+      oid: 1.3.6.1.4.1.9.9.42.1.2.1.1.2
+      type: OctetString
+    - labels:
+      - rttMonCtrlAdminIndex
+      labelname: rttMonCtrlAdminTag
+      oid: 1.3.6.1.4.1.9.9.42.1.2.1.1.3
+      type: DisplayString
+  - name: snmp_pxgeneric_rttMonJitterStatsPacketOutOfSequence
+    oid: 1.3.6.1.4.1.9.9.42.1.3.5.1.36
+    type: counter
+    help: The number of packets arrived out of sequence. - 1.3.6.1.4.1.9.9.42.1.3.5.1.36
+    indexes:
+    - labelname: rttMonCtrlAdminIndex
+      type: gauge
+    - labelname: rttMonJitterStatsStartTimeIndex
+      type: gauge
+    lookups:
+    - labels:
+      - rttMonCtrlAdminIndex
+      labelname: rttMonCtrlAdminOwner
+      oid: 1.3.6.1.4.1.9.9.42.1.2.1.1.2
+      type: OctetString
+    - labels:
+      - rttMonCtrlAdminIndex
+      labelname: rttMonCtrlAdminTag
+      oid: 1.3.6.1.4.1.9.9.42.1.2.1.1.3
+      type: DisplayString
+  - name: snmp_pxgeneric_rttMonJitterStatsNumOfRTT
+    oid: 1.3.6.1.4.1.9.9.42.1.3.5.1.4
+    type: counter
+    help: The number of RTT's that are successfully measured. - 1.3.6.1.4.1.9.9.42.1.3.5.1.4
+    indexes:
+    - labelname: rttMonCtrlAdminIndex
+      type: gauge
+    - labelname: rttMonJitterStatsStartTimeIndex
+      type: gauge
+    lookups:
+    - labels:
+      - rttMonCtrlAdminIndex
+      labelname: rttMonCtrlAdminOwner
+      oid: 1.3.6.1.4.1.9.9.42.1.2.1.1.2
+      type: OctetString
+    - labels:
+      - rttMonCtrlAdminIndex
+      labelname: rttMonCtrlAdminTag
+      oid: 1.3.6.1.4.1.9.9.42.1.2.1.1.3
+      type: DisplayString
+  - name: snmp_pxgeneric_rttMonJitterStatsRTTSum
+    oid: 1.3.6.1.4.1.9.9.42.1.3.5.1.5
+    type: counter
+    help: The sum of RTT's that are successfully measured (low order 32 bits) - 1.3.6.1.4.1.9.9.42.1.3.5.1.5
+    indexes:
+    - labelname: rttMonCtrlAdminIndex
+      type: gauge
+    - labelname: rttMonJitterStatsStartTimeIndex
+      type: gauge
+    lookups:
+    - labels:
+      - rttMonCtrlAdminIndex
+      labelname: rttMonCtrlAdminOwner
+      oid: 1.3.6.1.4.1.9.9.42.1.2.1.1.2
+      type: OctetString
+    - labels:
+      - rttMonCtrlAdminIndex
+      labelname: rttMonCtrlAdminTag
+      oid: 1.3.6.1.4.1.9.9.42.1.2.1.1.3
+      type: DisplayString
+  - name: snmp_pxgeneric_rttMonJitterStatsAvgJitter
+    oid: 1.3.6.1.4.1.9.9.42.1.3.5.1.62
+    type: gauge
+    help: The average of positive and negative jitter values for SD and DS direction.
+      - 1.3.6.1.4.1.9.9.42.1.3.5.1.62
+    indexes:
+    - labelname: rttMonCtrlAdminIndex
+      type: gauge
+    - labelname: rttMonJitterStatsStartTimeIndex
+      type: gauge
+    lookups:
+    - labels:
+      - rttMonCtrlAdminIndex
+      labelname: rttMonCtrlAdminOwner
+      oid: 1.3.6.1.4.1.9.9.42.1.2.1.1.2
+      type: OctetString
+    - labels:
+      - rttMonCtrlAdminIndex
+      labelname: rttMonCtrlAdminTag
+      oid: 1.3.6.1.4.1.9.9.42.1.2.1.1.3
+      type: DisplayString
+  - name: snmp_pxgeneric_ccmHistoryRunningLastChanged
+    oid: 1.3.6.1.4.1.9.9.43.1.1.1
+    type: gauge
+    help: The value of sysUpTime when the running configuration was last changed -
+      1.3.6.1.4.1.9.9.43.1.1.1
+  - name: snmp_pxgeneric_ccmHistoryRunningLastSaved
+    oid: 1.3.6.1.4.1.9.9.43.1.1.2
+    type: gauge
+    help: The value of sysUpTime when the running configuration was last saved (written)
+      - 1.3.6.1.4.1.9.9.43.1.1.2
+  - name: snmp_pxgeneric_entSensorType
+    oid: 1.3.6.1.4.1.9.9.91.1.1.1.1.1
+    type: gauge
+    help: This variable indicates the type of data reported by the entSensorValue
+      - 1.3.6.1.4.1.9.9.91.1.1.1.1.1
+    indexes:
+    - labelname: entPhysicalIndex
+      type: gauge
+    lookups:
+    - labels:
+      - entPhysicalIndex
+      labelname: entPhysicalName
+      oid: 1.3.6.1.2.1.47.1.1.1.1.7
+      type: DisplayString
+    - labels:
+      - entPhysicalIndex
+      labelname: entPhysicalDescr
+      oid: 1.3.6.1.2.1.47.1.1.1.1.2
+      type: DisplayString
+    enum_values:
+      1: other
+      2: unknown
+      3: voltsAC
+      4: voltsDC
+      5: amperes
+      6: watts
+      7: hertz
+      8: celsius
+      9: percentRH
+      10: rpm
+      11: cmm
+      12: truthvalue
+      13: specialEnum
+      14: dBm
+  - name: snmp_pxgeneric_entSensorValue
+    oid: 1.3.6.1.4.1.9.9.91.1.1.1.1.4
+    type: gauge
+    help: This variable reports the most recent measurement seen by the sensor - 1.3.6.1.4.1.9.9.91.1.1.1.1.4
+    indexes:
+    - labelname: entPhysicalIndex
+      type: gauge
+    lookups:
+    - labels:
+      - entPhysicalIndex
+      labelname: entPhysicalName
+      oid: 1.3.6.1.2.1.47.1.1.1.1.7
+      type: DisplayString
+    - labels:
+      - entPhysicalIndex
+      labelname: entPhysicalDescr
+      oid: 1.3.6.1.2.1.47.1.1.1.1.2
+      type: DisplayString
+  - name: snmp_pxgeneric_entSensorThresholdSeverity
+    oid: 1.3.6.1.4.1.9.9.91.1.2.1.1.2
+    type: gauge
+    help: This variable indicates the severity of this threshold. - 1.3.6.1.4.1.9.9.91.1.2.1.1.2
+    indexes:
+    - labelname: entPhysicalIndex
+      type: gauge
+    - labelname: entSensorThresholdIndex
+      type: gauge
+    lookups:
+    - labels:
+      - entPhysicalIndex
+      labelname: entPhysicalName
+      oid: 1.3.6.1.2.1.47.1.1.1.1.7
+      type: DisplayString
+    - labels:
+      - entPhysicalIndex
+      labelname: entPhysicalDescr
+      oid: 1.3.6.1.2.1.47.1.1.1.1.2
+      type: DisplayString
+    enum_values:
+      1: other
+      10: minor
+      20: major
+      30: critical
+  - name: snmp_pxgeneric_entSensorThresholdValue
+    oid: 1.3.6.1.4.1.9.9.91.1.2.1.1.4
+    type: gauge
+    help: This variable indicates the value of the threshold - 1.3.6.1.4.1.9.9.91.1.2.1.1.4
+    indexes:
+    - labelname: entPhysicalIndex
+      type: gauge
+    - labelname: entSensorThresholdIndex
+      type: gauge
+    lookups:
+    - labels:
+      - entPhysicalIndex
+      labelname: entPhysicalName
+      oid: 1.3.6.1.2.1.47.1.1.1.1.7
+      type: DisplayString
+    - labels:
+      - entPhysicalIndex
+      labelname: entPhysicalDescr
+      oid: 1.3.6.1.2.1.47.1.1.1.1.2
+      type: DisplayString

--- a/prometheus-exporters/snmp-exporter/generator/pxgeneric-generator.yaml
+++ b/prometheus-exporters/snmp-exporter/generator/pxgeneric-generator.yaml
@@ -1,0 +1,104 @@
+modules:
+  pxgeneric:
+    walk:
+      - bgpPeerRemoteAddr
+      - cbgpPeer2AdminStatus
+      - cbgpPeer2FsmEstablishedTime
+      - cbgpPeer2State
+      - cbgpPeerAcceptedPrefixes
+      - cbgpPeerAddrFamilyAfi
+      - cbgpPeerAddrFamilySafi
+      - cbgpPeerAdvertisedPrefixes
+      - cbgpPeerDeniedPrefixes
+      - cbgpPeerSuppressedPrefixes
+      - cbgpPeerWithdrawnPrefixes
+      - ccmHistoryRunningLastChanged
+      - ccmHistoryRunningLastSaved
+      - cefcFRUPowerAdminStatus
+      - cefcFRUPowerOperStatus
+      - entPhysicalName
+      - entPhysicalDescr
+      - entSensorThresholdSeverity
+      - entSensorThresholdValue
+      - entSensorType
+      - entSensorValue
+      - ifInDiscards
+      - ifInErrors
+      - ifHCInOctets
+      - ifHCInUcastPkts
+      - ifInUnknownProtos
+      - ifLastChange
+      - ifOutDiscards
+      - ifOutErrors
+      - ifHCOutOctets
+      - ifOutQLen
+      - ifHCOutUcastPkts
+      - rttMonJitterStatsPacketLossDS
+      - rttMonJitterStatsPacketLossSD
+      - rttMonJitterStatsPacketOutOfSequence
+      - rttMonJitterStatsCompletions
+      - rttMonJitterStatsStartTimeIndex
+      - rttMonJitterStatsNumOfRTT
+      - rttMonJitterStatsRTTSum
+      - rttMonJitterStatsAvgJitter
+      - rttMonLatestRttOperSense
+      - rttMonLatestRttOperTime
+      - rttMonEchoAdminCodecNumPackets
+      - sysUpTime
+      - sysDescr
+    lookups:
+      - source_indexes: [ifIndex]
+        lookup: ifAlias
+      - source_indexes: [ifIndex]
+        lookup: ifDescr
+      - source_indexes: [ifIndex]
+        lookup: ifType
+      - source_indexes: [ifIndex]
+        lookup: ifMtu
+      - source_indexes: [ifIndex]
+        lookup: ifHighSpeed
+      - source_indexes: [ifIndex]
+        lookup: ifPhysAddress
+      - source_indexes: [ifIndex]
+        lookup: ifAdminStatus
+      - source_indexes: [ifIndex]
+        lookup: ifOperStatus
+      - source_indexes: [ifIndex]
+        lookup: ifAlias
+      - source_indexes: [rttMonCtrlAdminIndex]
+        lookup: rttMonCtrlAdminOwner
+      - source_indexes: [rttMonCtrlAdminIndex]
+        lookup: rttMonCtrlAdminTag
+      - source_indexes: [entPhysicalIndex]
+        lookup: entPhysicalName
+      - source_indexes: [entPhysicalIndex]
+        lookup: entPhysicalDescr
+    overrides:
+      rttMonJitterStatsStartTimeIndex:
+        ignore: false
+      ifAlias:
+        ignore: true # Lookup metric
+      ifDescr:
+        ignore: true
+      ifName:
+        ignore: true
+      ifType:
+        type: EnumAsInfo
+      ifMtu:
+        ignore: true
+      ifHighSpeed:
+        ignore: true
+      ifPhysAddress:
+        type: PhysAddress48
+      ifAdminStatus:
+        ignore: true
+      ifOperStatus:
+        ignore: true
+      rttMonCtrlAdminOwner:
+        ignore: true
+      rttMonCtrlAdminTag:
+        ignore: true
+      FeatureName:
+        ignore: true
+      entPhyscalName:
+        ignore: true

--- a/prometheus-exporters/snmp-exporter/px.alerts/snmp-pxdlrouternxos.alerts
+++ b/prometheus-exporters/snmp-exporter/px.alerts/snmp-pxdlrouternxos.alerts
@@ -1,0 +1,28 @@
+groups:
+  - alert: PXTransportRouterLTcamLimit
+    expr: max(snmp_pxdlrouternxos_cshcProtocolFibTcamLogicalTotal{cshcProtocolFibTcamProtocol="2"}) by (devicename) > 400000
+    for: 5m
+    labels:
+      severity: warning
+      tier: net
+      service: px
+      context: px
+      dashboard: px-wan-data-plane
+      playbook: '/docs/devops/alert/network/px.html##PXTransportRouterTcamLimit'
+    annotations:
+      description: PX Direct Link router {{ $labels.devicename }} has installed 400k routes in its (L)FIB. This is unusual behaviour and must be investigated.
+      summary: PX Direct Link router {{ $labels.devicename }} has installed 400k routes in its (L)FIB. This is unusual behaviour and must be investigated.
+
+  - alert: PXTransportRouterLTcamLimit
+    expr: max(snmp_pxdlrouternxos_cshcProtocolFibTcamLogicalTotal{cshcProtocolFibTcamProtocol="2"}) by (devicename) > 500000
+    for: 5m
+    labels:
+      severity: critical
+      tier: net
+      service: px
+      context: px
+      dashboard: px-wan-data-plane
+      playbook: '/docs/devops/alert/network/px.html#PXTransportRouterTcamLimit'
+    annotations:
+      description: PX Direct Link router {{ $labels.devicename }} has installed 500k routes in its (L)FIB. This is unusual behaviour and must be investigated.
+      summary: PX Direct Link router {{ $labels.devicename }} has installed 500k routes in its (L)FIB. This is unusual behaviour and must be investigated.

--- a/prometheus-exporters/snmp-exporter/px.alerts/snmp-pxgeneric.alerts
+++ b/prometheus-exporters/snmp-exporter/px.alerts/snmp-pxgeneric.alerts
@@ -3,8 +3,8 @@ groups:
   rules:
   - alert: PXTransportDlWanLinkProbesFailing
     expr: |
-      snmp_pxdlrouternxos_rttMonLatestRttOperSense{rttMonCtrlAdminIndex=~"4.."} != 1
-      or increase(sum(snmp_pxdlrouternxos_rttMonJitterStatsRTTSum{rttMonCtrlAdminIndex=~"4.."}) without (rttMonJitterStatsStartTimeIndex)[5m:]) == 0
+      snmp_pxgeneric_rttMonLatestRttOperSense{rttMonCtrlAdminIndex=~"4.."} != 1
+      or increase(sum(snmp_pxgeneric_rttMonJitterStatsRTTSum{rttMonCtrlAdminIndex=~"4.."}) without (rttMonJitterStatsStartTimeIndex)[5m:]) == 0
     for: 2m
     labels:
       severity: critical
@@ -16,17 +16,17 @@ groups:
     annotations:
       description: SLA {{ $labels.rttMonCtrlAdminIndex }} on {{ $labels.devicename }} is failing. This indicates problems with the underlying WAN link.
       summary: SLA {{ $labels.rttMonCtrlAdminIndex }} on {{ $labels.devicename }} is failing. This indicates problems with the underlying WAN link.
-  
+
   - alert: PXTransportDlWanLinkProbesHighLatency
     expr: |
-      (sum(increase(snmp_pxdlrouternxos_rttMonJitterStatsRTTSum{rttMonCtrlAdminTag=~"^RTT5.*"}[5m])) without(rttMonJitterStatsStartTimeIndex))
-        / (sum(increase(snmp_pxdlrouternxos_rttMonJitterStatsNumOfRTT[5m])) without(rttMonJitterStatsStartTimeIndex)) > 5
+      (sum(increase(snmp_pxgeneric_rttMonJitterStatsRTTSum{rttMonCtrlAdminTag=~"^RTT5.*"}[5m])) without(rttMonJitterStatsStartTimeIndex))
+        / (sum(increase(snmp_pxgeneric_rttMonJitterStatsNumOfRTT[5m])) without(rttMonJitterStatsStartTimeIndex)) > 5
       OR
-      (sum(increase(snmp_pxdlrouternxos_rttMonJitterStatsRTTSum{rttMonCtrlAdminTag=~"^RTT10.*"}[5m])) without(rttMonJitterStatsStartTimeIndex))
-        / (sum(increase(snmp_pxdlrouternxos_rttMonJitterStatsNumOfRTT[5m])) without(rttMonJitterStatsStartTimeIndex)) > 10
+      (sum(increase(snmp_pxgeneric_rttMonJitterStatsRTTSum{rttMonCtrlAdminTag=~"^RTT10.*"}[5m])) without(rttMonJitterStatsStartTimeIndex))
+        / (sum(increase(snmp_pxgeneric_rttMonJitterStatsNumOfRTT[5m])) without(rttMonJitterStatsStartTimeIndex)) > 10
       OR
-      (sum(increase(snmp_pxdlrouternxos_rttMonJitterStatsRTTSum{rttMonCtrlAdminTag=~"^RTT15.*"}[5m])) without(rttMonJitterStatsStartTimeIndex))
-        / (sum(increase(snmp_pxdlrouternxos_rttMonJitterStatsNumOfRTT[5m])) without(rttMonJitterStatsStartTimeIndex)) > 15
+      (sum(increase(snmp_pxgeneric_rttMonJitterStatsRTTSum{rttMonCtrlAdminTag=~"^RTT15.*"}[5m])) without(rttMonJitterStatsStartTimeIndex))
+        / (sum(increase(snmp_pxgeneric_rttMonJitterStatsNumOfRTT[5m])) without(rttMonJitterStatsStartTimeIndex)) > 15
     for: 5m
     labels:
       severity: critical
@@ -38,9 +38,9 @@ groups:
     annotations:
       description: SLA {{ $labels.rttMonCtrlAdminIndex }} on {{ $labels.devicename }} is measuring more then 20ms RTT on the link. This indicates problems with the underlying WAN link.
       summary: SLA {{ $labels.rttMonCtrlAdminIndex }} on {{ $labels.devicename }} is measuring more then 20ms RTT on the link. This indicates problems with the underlying WAN link.
-  
+
   - alert: PXTransportDlWanLinkInterfaceDown
-    expr: snmp_pxdlrouternxos_ifLastChange{ifAdminStatus="1", ifType="6", ifAlias=~"WAN.*", ifOperStatus!="1"}
+    expr: snmp_pxgeneric_ifLastChange{ifAdminStatus="1", ifType="6", ifAlias=~"WAN.*", ifOperStatus!="1"}
     for: 5m
     labels:
       severity: critical
@@ -52,9 +52,9 @@ groups:
     annotations:
       description: "{{ $labels.ifDescr }} on {{ $labels.devicename }} which terminates a WAN circuit went down."
       summary: "{{ $labels.ifDescr }} on {{ $labels.devicename }} which terminates a WAN circuit went down."
-  
+
   - alert: PXTransportDlWanLinkInterfaceFlapping
-    expr: resets((snmp_pxdlrouternxos_sysUpTime - on (server_id) group_right(server_name, interface) (snmp_pxdlrouternxos_ifLastChange{ifDescr=~"Ethernet1/11|Ethernet1/12"}))[10m:]) > 1
+    expr: resets((snmp_pxgeneric_sysUpTime - on (server_id) group_right(server_name, interface) (snmp_pxgeneric_ifLastChange{ifDescr=~"Ethernet1/11|Ethernet1/12"}))[10m:]) > 1
     for: 5m
     labels:
       severity: critical
@@ -70,8 +70,8 @@ groups:
 
   - alert: PXTransportDlWanLinkProbesPacketLosses
     expr: |
-      ((sum(increase(snmp_pxdlrouternxos_rttMonJitterStatsPacketLossSD[5m]) + increase(snmp_pxdlrouternxos_rttMonJitterStatsPacketLossDS[5m])) without(rttMonJitterStatsStartTimeIndex))
-       / (sum(increase(snmp_pxdlrouternxos_rttMonJitterStatsNumOfRTT[5m])) without(rttMonJitterStatsStartTimeIndex)))
+      ((sum(increase(snmp_pxgeneric_rttMonJitterStatsPacketLossSD[5m]) + increase(snmp_pxgeneric_rttMonJitterStatsPacketLossDS[5m])) without(rttMonJitterStatsStartTimeIndex))
+       / (sum(increase(snmp_pxgeneric_rttMonJitterStatsNumOfRTT[5m])) without(rttMonJitterStatsStartTimeIndex)))
        > 0.03
     for: 5m
     labels:
@@ -84,31 +84,3 @@ groups:
     annotations:
       description: SLA {{ $labels.rttMonCtrlAdminIndex }} on {{ $labels.devicename }} is measuring more than 3% packet loss on the link. This indicates problems with the underlying WAN link.
       summary:  SLA {{ $labels.rttMonCtrlAdminIndex }} on {{ $labels.devicename }} is measuring more than 3% packet loss on the link. This indicates problems with the underlying WAN link.
-
-  - alert: PXTransportRouterLTcamLimit
-    expr: max(snmp_pxdlrouternxos_cshcProtocolFibTcamLogicalTotal{cshcProtocolFibTcamProtocol="2"}) by (devicename) > 400000
-    for: 5m
-    labels:
-      severity: warning
-      tier: net
-      service: px
-      context: px
-      dashboard: px-wan-data-plane
-      playbook: '/docs/devops/alert/network/px.html##PXTransportRouterTcamLimit'
-    annotations:
-      description: PX Direct Link router {{ $labels.devicename }} has installed 400k routes in its (L)FIB. This is unusual behaviour and must be investigated.
-      summary: PX Direct Link router {{ $labels.devicename }} has installed 400k routes in its (L)FIB. This is unusual behaviour and must be investigated.
-
-  - alert: PXTransportRouterLTcamLimit
-    expr: max(snmp_pxdlrouternxos_cshcProtocolFibTcamLogicalTotal{cshcProtocolFibTcamProtocol="2"}) by (devicename) > 500000
-    for: 5m
-    labels:
-      severity: critical
-      tier: net
-      service: px
-      context: px
-      dashboard: px-wan-data-plane
-      playbook: '/docs/devops/alert/network/px.html#PXTransportRouterTcamLimit'
-    annotations:
-      description: PX Direct Link router {{ $labels.devicename }} has installed 500k routes in its (L)FIB. This is unusual behaviour and must be investigated.
-      summary: PX Direct Link router {{ $labels.devicename }} has installed 500k routes in its (L)FIB. This is unusual behaviour and must be investigated.

--- a/prometheus-exporters/snmp-exporter/templates/alerts.yaml
+++ b/prometheus-exporters/snmp-exporter/templates/alerts.yaml
@@ -16,15 +16,17 @@ spec:
 
 {{- end }}
 {{- end }}
-{{- $values := .Values -}}
-{{- if $values.snmp_exporter.pxdlrouternxos.alerts.enabled }}
-{{- range $path, $bytes := .Files.Glob "pxdl.alerts/*.alerts" }}
+
+{{- range $path, $bytes := .Files.Glob "px.alerts/*.alerts" }}
+{{- $module_name :=  mustRegexReplaceAll ".*\\/snmp-(\\S+).alerts$" $path "$1" }}
+{{- $module_config := get $values.snmp_exporter $module_name }}
+{{- if default false $module_config.alerts.enabled }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 
 metadata:
-  name: {{ printf "snmp-exporter-%s" $path | replace "/" "-" }}
+  name: {{ printf "snmp-exporter-%s" $module_name }}
   labels:
     app: snmp-exporter
     prometheus: {{ required ".Values.snmp_exporter.alerts.prometheus missing" $values.snmp_exporter.alerts.prometheus }}

--- a/prometheus-exporters/snmp-exporter/templates/configmap.yaml
+++ b/prometheus-exporters/snmp-exporter/templates/configmap.yaml
@@ -205,6 +205,20 @@ data:
         community: {{ .Values.snmp_exporter.n7k.community }}
 {{- end }}
 {{- end }}
+{{- if .Values.snmp_exporter.pxgeneric.enabled }}
+{{ .Files.Get "_snmp-exporter-pxgeneric.yaml" | indent 4}}
+      version: {{ .Values.snmp_exporter.pxgeneric.version }}
+      max_repetitions: 25
+      retries: 3
+      timeout: 10s
+      auth:
+        security_level: {{ .Values.snmp_exporter.pxgeneric.security_level }}
+        username: {{ .Values.snmp_exporter.pxgeneric.username }}
+        password: {{ .Values.snmp_exporter.pxgeneric.password }}
+        auth_protocol: {{ .Values.snmp_exporter.pxgeneric.auth_protocol }}
+        priv_protocol: {{ .Values.snmp_exporter.pxgeneric.priv_protocol }}
+        priv_password: {{ .Values.snmp_exporter.pxgeneric.priv_password }}
+{{- end }}
 {{- if .Values.snmp_exporter.pxdlrouternxos.enabled }}
 {{ .Files.Get "_snmp-exporter-pxdlrouternxos.yaml" | indent 4}}
       version: {{ .Values.snmp_exporter.pxdlrouternxos.version }}

--- a/prometheus-exporters/snmp-exporter/values.yaml
+++ b/prometheus-exporters/snmp-exporter/values.yaml
@@ -106,6 +106,17 @@ snmp_exporter:
       password: DEFINED-IN-REGION-SECRECTS
       auth_protocol: DEFINED-IN-REGION-SECRECTS
       priv_protocol: DEFINED-IN-REGION-SECRECTS
+  pxgeneric:
+    alerts:
+      enabled: false
+    snmpv3:
+      enabled: false
+      version: DEFINED-IN-REGION-SECRECTS
+      security_level: DEFINED-IN-REGION-SECRECTS
+      username: DEFINED-IN-REGION-SECRECTS
+      password: DEFINED-IN-REGION-SECRECTS
+      auth_protocol: DEFINED-IN-REGION-SECRECTS
+      priv_protocol: DEFINED-IN-REGION-SECRECTS
   acileaf:
     enabled: false
     version: DEFINED-IN-REGION-SECRECTS
@@ -174,7 +185,6 @@ snmp_exporter:
     enabled: false
     version: DEFINED-IN-REGION-SECRECTS
     community: DEFINED-IN-REGION-SECRECTS
-    version: DEFINED-IN-REGION-SECRECTS
     security_level: DEFINED-IN-REGION-SECRECTS
     username: DEFINED-IN-REGION-SECRECTS
     password: DEFINED-IN-REGION-SECRECTS

--- a/system/infra-monitoring/templates/_prometheus-infra-collector.yaml.tpl
+++ b/system/infra-monitoring/templates/_prometheus-infra-collector.yaml.tpl
@@ -263,8 +263,8 @@
       regex: 'snmp_n3k_sysDescr;(?s)(.*)(Version )([0-9().a-zIU]*)(,.*)'
       replacement: '$3'
       target_label: image_version
-    - source_labels: [__name__, snmp_pxdlrouternxos_sysDescr]
-      regex: 'snmp_pxdlrouternxos_sysDescr;(?s)(.*)(Version )([0-9().a-zIU]*)(,.*)'
+    - source_labels: [__name__, snmp_pxgeneric_sysDescr]
+      regex: 'snmp_pxgeneric_sysDescr;(?s)(.*)(Version )([0-9().a-zIU]*)(,.*)'
       replacement: '$3'
       target_label: image_version
     - source_labels: [__name__, snmp_n9kpx_ciscoImageString]
@@ -556,7 +556,7 @@
       replacement: '$1'
       target_label: 'service_state'
 {{- end }}
-        
+
 {{- $values := .Values.vasa_exporter -}}
 {{- if $values.enabled }}
 - job_name: 'vasa'

--- a/system/infra-monitoring/vendor/atlas/templates/configmap.yaml
+++ b/system/infra-monitoring/vendor/atlas/templates/configmap.yaml
@@ -294,6 +294,15 @@ data:
               status: "active"
 
             - custom_labels:
+                module: "pxgeneric"
+                job: "snmp"
+              target: 1
+              metrics_label: "pxgeneric"
+              role: "directlink-router"
+              region: "{{ .Values.global.region }}"
+              status: "active"
+
+            - custom_labels:
                 module: "n3k"
                 job: "snmp"
               target: 1


### PR DESCRIPTION
We are getting IOS XR devices in PX. Some MIBs are equal over NXOS, IOS
XE and IOS XR. I am creating a new SNMP exporter module that covers
these MIBs, move all alerts and dashboard to the new metric and then
keep only the OS specific MIBs to the according OS specific snmp
exporter modules.