### PR TITLE
metrics moved from cp to scaleout cluster

### DIFF
--- a/openstack/ironic/alerts/openstack-ironic.alerts
+++ b/openstack/ironic/alerts/openstack-ironic.alerts
@@ -16,37 +16,6 @@ groups:
         are set correctly, and that there is a flavor for each type of server."
       summary: "{{ $value }} Ironic nodes do not match any Nova baremetal flavor."
 
-  - alert: OpenstackIronicApiDown
-    expr: blackbox_api_status_gauge{check=~"ironic"} == 1
-    for: 20m
-    labels:
-      severity: critical
-      tier: os
-      service: '{{ $labels.service }}'
-      context: '{{ $labels.service }}'
-      dashboard: ccloud-health-blackbox-details
-      meta: '{{ $labels.check }} API is down. See Sentry for details.'
-      sentry: 'blackbox/?query=test_{{ $labels.check }}'
-      playbook: 'docs/devops/alert/{{ $labels.service }}/#{{ $labels.check }}'
-    annotations:
-      description: '{{ $labels.check }} API is down for 20 min. See Sentry for details.'
-      summary: '{{ $labels.check }} API down'
-
-  - alert: OpenstackIronicApiFlapping
-    expr: changes(blackbox_api_status_gauge{check=~"ironic"}[30m]) > 8
-    labels:
-      severity: warning
-      tier: os
-      service: '{{ $labels.service }}'
-      context: '{{ $labels.service }}'
-      dashboard: ccloud-health-blackbox-details
-      meta: '{{ $labels.check }} API is flapping'
-      sentry: 'blackbox/?query=test_{{ $labels.check }}'
-      playbook: 'docs/devops/alert/{{ $labels.service }}/#{{ $labels.check }}'
-    annotations:
-      description: '{{ $labels.check }} API is flapping for 30 minutes.'
-      summary: '{{ $labels.check }} API flapping'
-
   - alert: OpenstackIronicCanaryDown
     expr: blackbox_regression_status_gauge{service=~"ironic"} == 1
     for: 5m


### PR DESCRIPTION
@BerndKue @geisslet : metrics moved from cp to scaleout cluster,  please deploy it to get rid of absent metrics alerts