### PR TITLE
[ironic]conductor: uses recreate strategy

### DIFF
--- a/openstack/ironic/templates/_conductor-deployment.yaml.tpl
+++ b/openstack/ironic/templates/_conductor-deployment.yaml.tpl
@@ -13,12 +13,7 @@ spec:
   replicas: 1
   revisionHistoryLimit: {{ .Values.pod.lifecycle.upgrades.deployments.revisionHistory }}
   strategy:
-    type: {{ .Values.pod.lifecycle.upgrades.deployments.podReplacementStrategy }}
-    {{ if eq .Values.pod.lifecycle.upgrades.deployments.podReplacementStrategy "RollingUpdate" }}
-    rollingUpdate:
-      maxUnavailable: {{ .Values.pod.lifecycle.upgrades.deployments.rollingupdate.maxUnavailable }}
-      maxSurge: {{ .Values.pod.lifecycle.upgrades.deployments.rollingupdate.maxSurge }}
-    {{ end }}
+    type: Recreate
   selector:
     matchLabels:
       name: ironic-conductor-{{$conductor.name}}
@@ -79,7 +74,7 @@ spec:
             - bash
             - -c
             - eval $(cat /etc/ironic/ironic.conf | grep -Pzo '\[service_catalog\][^[]*' | tr -d '\000' | grep '='  | while read LINE; do var="${LINE% =*}" ; val="${LINE#*= }" ; echo export OS_${var^^}=${val} ; done); OS_IDENTITY_API_VERSION=3 openstack baremetal driver list -f csv | grep 'ironic-conductor-{{$conductor.name}}[,"]' >/dev/null
-          initialDelaySeconds: 300
+          initialDelaySeconds: 60
           periodSeconds: 10
           failureThreshold: 3
         {{- end }}

--- a/openstack/ironic/templates/_conductor-deployment.yaml.tpl
+++ b/openstack/ironic/templates/_conductor-deployment.yaml.tpl
@@ -77,6 +77,7 @@ spec:
           initialDelaySeconds: 60
           periodSeconds: 10
           failureThreshold: 3
+          timeoutSeconds: 2
         {{- end }}
         volumeMounts:
         - mountPath: /etc/ironic


### PR DESCRIPTION
- With rollingupdate, the new conductor pod will register itself as a new host in ironic db. Once it is up and running the old conductor pod will be terminated, and calls unregister host.
- increases timeout for liveness check


