### PR TITLE
Disable absent metric alert for apicequipments

### DIFF
--- a/prometheus-exporters/apic-exporter/templates/alerts.yaml
+++ b/prometheus-exporters/apic-exporter/templates/alerts.yaml
@@ -10,6 +10,9 @@ metadata:
   labels:
     app: apic-exporter
     prometheus: {{ required "$values.prometheus missing" $values.prometheus }}
+    {{- if eq $path "alerts/apicequipments" }}
+    absent-metrics-operator/disable: "true"
+    {{- end }}
 
 spec:
 {{ printf "%s" $bytes | indent 2 }}

--- a/prometheus-exporters/apic-exporter/templates/alerts.yaml
+++ b/prometheus-exporters/apic-exporter/templates/alerts.yaml
@@ -11,8 +11,9 @@ metadata:
     app: apic-exporter
     prometheus: {{ required "$values.prometheus missing" $values.prometheus }}
     {{- if eq $path "alerts/apicequipments" }}
-    {{ - if or ( eq $values.globals.region "ap-sa-2" ) ( eq $values.globals.region "qa-de-1" )
+    {{ - if or ( eq $values.globals.region "ap-sa-2" ) ( eq $values.globals.region "qa-de-1" ) }}
     absent-metrics-operator/disable: "true"
+    {{- end }}
     {{- end }}
 
 spec:

--- a/prometheus-exporters/apic-exporter/templates/alerts.yaml
+++ b/prometheus-exporters/apic-exporter/templates/alerts.yaml
@@ -11,6 +11,7 @@ metadata:
     app: apic-exporter
     prometheus: {{ required "$values.prometheus missing" $values.prometheus }}
     {{- if eq $path "alerts/apicequipments" }}
+    {{ - if or ( eq $values.globals.region "ap-sa-2" ) ( eq $values.globals.region "qa-de-1" )
     absent-metrics-operator/disable: "true"
     {{- end }}
 

--- a/prometheus-exporters/apic-exporter/templates/alerts.yaml
+++ b/prometheus-exporters/apic-exporter/templates/alerts.yaml
@@ -11,7 +11,7 @@ metadata:
     app: apic-exporter
     prometheus: {{ required "$values.prometheus missing" $values.prometheus }}
     {{- if eq $path "alerts/apicequipments" }}
-    {{ - if or ( eq $values.globals.region "ap-sa-2" ) ( eq $values.globals.region "qa-de-1" ) }}
+    {{- if or ( eq $values.globals.region "ap-sa-2" ) ( eq $values.globals.region "qa-de-1" ) }}
     absent-metrics-operator/disable: "true"
     {{- end }}
     {{- end }}


### PR DESCRIPTION
because we don't have these ACI devices in all regions