### PR TITLE
neutron: Increase dhcp-agent cpu limits to 1 cpu

### DIFF
--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -84,7 +84,7 @@ pod:
         cpu: "256m"
         memory: "1Gi"
       limits:
-        cpu: "512m"
+        cpu: "1000m"
         memory: "2.5Gi"
     linuxbridge_agent:
       requests:


### PR DESCRIPTION
In at least one region, the dhcp-agent is regularly throttled a lot,
which makes ports hang in DOWN state for a longer period of time until
they are finally provisioned on the dhcp-agent.