### PR TITLE
Use tier and service labels from Pod for KubernetesPodRestartingTooMuch

### DIFF
--- a/prometheus-rules/prometheus-kubernetes-rules/Chart.yaml
+++ b/prometheus-rules/prometheus-kubernetes-rules/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A collection of Prometheus alerting and aggregation rules for Kubernetes.
 name: prometheus-kubernetes-rules
-version: 1.2.9
+version: 1.2.10

--- a/prometheus-rules/prometheus-kubernetes-rules/alerts/health.alerts.tpl
+++ b/prometheus-rules/prometheus-kubernetes-rules/alerts/health.alerts.tpl
@@ -63,8 +63,8 @@ groups:
     expr: (sum by(pod, namespace, container) (rate(kube_pod_container_status_restarts_total[15m]))) * on (pod) group_left(label_tier, label_service) kube_pod_labels{} > 0
     for: 1h
     labels:
-      tier: {{ include "tierLabelOrDefault" (dict "default" .Values.tier) }}
-      service: {{ include "serviceLabelOrDefault" (dict "default" "resources") }}
+      tier: {{ include "tierLabelOrDefault" .Values.tier }}
+      service: {{ include "serviceLabelOrDefault" "resources" }}
       severity: warning
       context: pod
       meta: "Pod {{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}} is restarting constantly"

--- a/prometheus-rules/prometheus-kubernetes-rules/alerts/health.alerts.tpl
+++ b/prometheus-rules/prometheus-kubernetes-rules/alerts/health.alerts.tpl
@@ -60,11 +60,11 @@ groups:
       summary: Kube state metrics scrape failed
 
   - alert: KubernetesPodRestartingTooMuch
-    expr: sum(rate(kube_pod_container_status_restarts_total[15m])) by (pod, namespace, container) > 0
+    expr: (sum by(pod, namespace, container) (rate(kube_pod_container_status_restarts_total[15m]))) * on (pod) group_left(label_tier, label_service) kube_pod_labels{} > 0
     for: 1h
     labels:
-      tier: {{ required ".Values.tier missing" .Values.tier }}
-      service: resources
+      tier: "{{`{{ if $labels.label_tier }}`}}{{`{{ $labels.label_tier}}`}}{{`{{ else }}`}}{{ required ".Values.tier missing" .Values.tier }}{{`{{ end }}`}}"
+      service: "{{`{{ if $labels.label_service }}`}}{{`{{ $labels.label_service}}`}}{{`{{ else }}`}}resources{{`{{ end }}`}}"
       severity: warning
       context: pod
       meta: "Pod {{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}} is restarting constantly"

--- a/prometheus-rules/prometheus-kubernetes-rules/alerts/health.alerts.tpl
+++ b/prometheus-rules/prometheus-kubernetes-rules/alerts/health.alerts.tpl
@@ -63,8 +63,8 @@ groups:
     expr: (sum by(pod, namespace, container) (rate(kube_pod_container_status_restarts_total[15m]))) * on (pod) group_left(label_tier, label_service) kube_pod_labels{} > 0
     for: 1h
     labels:
-      tier: "{{`{{ if $labels.label_tier }}`}}{{`{{ $labels.label_tier}}`}}{{`{{ else }}`}}{{ required ".Values.tier missing" .Values.tier }}{{`{{ end }}`}}"
-      service: "{{`{{ if $labels.label_service }}`}}{{`{{ $labels.label_service}}`}}{{`{{ else }}`}}resources{{`{{ end }}`}}"
+      tier: {{ include "tierLabelOrDefault" (dict "default" .Values.tier) }}
+      service: {{ include "serviceLabelOrDefault" (dict "default" "resources") }}
       severity: warning
       context: pod
       meta: "Pod {{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}} is restarting constantly"

--- a/prometheus-rules/prometheus-kubernetes-rules/templates/_helpers.tpl
+++ b/prometheus-rules/prometheus-kubernetes-rules/templates/_helpers.tpl
@@ -5,10 +5,10 @@
 
 {{/* Use the 'label_tier', if it exists on the time series, otherwise use the given default. */}}
 {{- define "tierLabelOrDefault" -}}
-"{{`{{ if $labels.label_tier }}`}}{{`{{ $labels.label_tier}}`}}{{`{{ else }}`}}{{ required ".default" .default }}{{`{{ end }}`}}"
+"{{`{{ if $labels.label_tier }}`}}{{`{{ $labels.label_tier}}`}}{{`{{ else }}`}}{{ required "default value is missing" . }}{{`{{ end }}`}}"
 {{- end -}}
 
 {{/* Use the 'label_service', if it exists on the time series, otherwise use the given default. */}}
 {{- define "serviceLabelOrDefault" -}}
-"{{`{{ if $labels.label_service }}`}}{{`{{ $labels.label_service}}`}}{{`{{ else }}`}}{{ required ".default" .default }}{{`{{ end }}`}}"
+"{{`{{ if $labels.label_service }}`}}{{`{{ $labels.label_service}}`}}{{`{{ else }}`}}{{ required "default value is missing" . }}{{`{{ end }}`}}"
 {{- end -}}

--- a/prometheus-rules/prometheus-kubernetes-rules/templates/_helpers.tpl
+++ b/prometheus-rules/prometheus-kubernetes-rules/templates/_helpers.tpl
@@ -2,3 +2,13 @@
 {{- define "prefix" -}}
 {{ if .Values.prometheusCollectorName -}}aggregated:{{- end }}
 {{- end -}}
+
+{{/* Use the 'label_tier', if it exists on the time series, otherwise use the given default. */}}
+{{- define "tierLabelOrDefault" -}}
+"{{`{{ if $labels.label_tier }}`}}{{`{{ $labels.label_tier}}`}}{{`{{ else }}`}}{{ required ".default" .default }}{{`{{ end }}`}}"
+{{- end -}}
+
+{{/* Use the 'label_service', if it exists on the time series, otherwise use the given default. */}}
+{{- define "serviceLabelOrDefault" -}}
+"{{`{{ if $labels.label_service }}`}}{{`{{ $labels.label_service}}`}}{{`{{ else }}`}}{{ required ".default" .default }}{{`{{ end }}`}}"
+{{- end -}}


### PR DESCRIPTION
I checked the helm template rendering using:

```sh
helm template --dry-run prometheus-kubernetes-rules ./prometheus-rules/prometheus-kubernetes-rules
```

and it gave the expected output:

```yaml
labels:
  tier: "{{ if $labels.label_tier }}{{ $labels.label_tier}}{{ else }}k8s{{ end }}"
  service: "{{ if $labels.label_service }}{{ $labels.label_service}}{{ else }}resources{{ end }}"
```

/cc @majewsky 