### PR TITLE
[common][mariadb] promote DBNotReady alert to critical.

### DIFF
--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.3.27
+version: 0.3.28

--- a/common/mariadb/templates/alerts.yaml
+++ b/common/mariadb/templates/alerts.yaml
@@ -36,4 +36,6 @@ metadata:
 
 spec:
   groups:
+{{- if .Values.alerts.alert_db_not_ready }}
 {{ include (print .Template.BasePath "/alerts/_health.alerts.tpl") . | indent 2 }}
+{{- end }}

--- a/common/mariadb/templates/alerts/_health.alerts.tpl
+++ b/common/mariadb/templates/alerts/_health.alerts.tpl
@@ -6,9 +6,9 @@
     labels:
       context: availability
       service: {{ include "alerts.service" . }}
-      severity: warning
+      severity: critical
       tier: {{ required ".Values.alerts.tier missing" .Values.alerts.tier }}
       playbook: 'docs/support/playbook/db_crashloop.html'
     annotations:
       description: {{ include "fullName" . }} database is not ready for 5 minutes.
-      summary: {{ include "fullName" . }} is not ready for 5 minutes.
+      summary: {{ include "fullName" . }} is not ready for 5 minutes. Please check the pod.

--- a/common/mariadb/templates/alerts/_health.alerts.tpl
+++ b/common/mariadb/templates/alerts/_health.alerts.tpl
@@ -10,5 +10,5 @@
       tier: {{ required ".Values.alerts.tier missing" .Values.alerts.tier }}
       playbook: 'docs/support/playbook/db_crashloop.html'
     annotations:
-      description: {{ include "fullName" . }} database is not ready for 5 minutes.
-      summary: {{ include "fullName" . }} is not ready for 5 minutes. Please check the pod.
+      description: {{ include "fullName" . }} database is not ready for 10 minutes.
+      summary: {{ include "fullName" . }} is not ready for 10 minutes. Please check the pod.

--- a/common/mariadb/templates/alerts/_health.alerts.tpl
+++ b/common/mariadb/templates/alerts/_health.alerts.tpl
@@ -2,7 +2,7 @@
   rules:
   - alert: {{ include "alerts.service" . | title }}MariaDBNotReady
     expr: (kube_pod_status_ready_normalized{condition="true", pod=~"{{ include "fullName" . }}.*", pod!~"{{ include "fullName" . }}-backup.*", pod!~"{{ include "fullName" . }}-verification.*"} < 1)
-    for: 5m
+    for: 10m
     labels:
       context: availability
       service: {{ include "alerts.service" . }}

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -129,6 +129,8 @@ metrics:
 # Default Prometheus alerts and rules.
 alerts:
   enabled: true
+  # this enables alert of level Critical, could wake somebody at night!
+  alert_db_not_ready: true
 
   # Name of the Prometheus supposed to scrape the metrics and to which alerts are assigned.
   prometheus: openstack


### PR DESCRIPTION
We need this alert to be reacted on with high priority.
In most cases not ready DB means the respective service/API is
completely down.