### PR TITLE
[Cinder] Enable datastores as spools by default

### DIFF
--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -58,6 +58,7 @@ backend_defaults:
   vmware_image_transfer_timeout_secs: 72000
   max_over_subscription_ratio: 2.0
   vmware_select_random_best_datastore: True
+  vmware_datastores_as_pools: True
 
 backends:
   enabled: vmware,standard_hdd


### PR DESCRIPTION
This patch adds the cinder config option to enable
datastores as pools.