### PR TITLE
[neutron] Increase network agent resource requests

### DIFF
--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -81,17 +81,17 @@ pod:
         memory: "128Mi"
     dhcp_agent:
       requests:
-        cpu: "256m"
+        cpu: "1000m"
         memory: "1Gi"
       limits:
-        cpu: "1000m"
+        cpu: "4000m"
         memory: "2.5Gi"
     linuxbridge_agent:
       requests:
         cpu: "256m"
         memory: "512Mi"
       limits:
-        cpu: "1000m"
+        cpu: "2000m"
         memory: "1Gi"
     nsxv3_agent:
       requests:


### PR DESCRIPTION
Network agents still suffer under slow buildup, therefore we add more
resources to them. The dhcp-agent should have at least 1 core, but can
consume up to 4, depending on how much is being used (they still run one
dnsmasq and haproxy per network). We also increase the limit of the
linuxbridge-agent to get it to build up faster.