### PR TITLE
Image Usage: bump version

### DIFF
--- a/prometheus-exporters/image-usage-exporter/Chart.yaml
+++ b/prometheus-exporters/image-usage-exporter/Chart.yaml
@@ -20,7 +20,7 @@ version: 0.0.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.0.6
+appVersion: 0.0.7
 
 maintainers:
   - name: DL CC-1 image workgroup (External) <DL_5D7B5C59700BE20280D63EC3@global.corp.sap>


### PR DESCRIPTION
There was an update to the exporter switching the image filter logic from whitelist to blacklist.