### PR TITLE
[Cinder] Set an overall reserved_percentage to 20%

### DIFF
--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -51,6 +51,7 @@ port_metrics: 9102
 
 vmware_host_username: m3cinderapiuser
 backend_defaults:
+  reserved_percentage: 20
   suppress_requests_ssl_warnings: True
   vmware_connection_pool_size: 10
   vmware_insecure: True


### PR DESCRIPTION
We want to have cinder enforce that 20% of the overall storage
on a backend is reserved.  This means that cinder will only allow
allocating up to 80% of the total storage on a backend.  This will
be more meaningful when datastores as pools is rolled out as then
each datastore can only be allocated to a max of 80% capacity.