### PR TITLE
keppel: replace URL parameters with FQDN parameters

### DIFF
--- a/openstack/keppel/templates/_utils.tpl
+++ b/openstack/keppel/templates/_utils.tpl
@@ -12,8 +12,8 @@
 - name:  KEPPEL_API_LISTEN_ADDRESS
   value: ':80'
 {{- if $.Values.keppel.anycast_domain_name }}
-- name:  KEPPEL_API_ANYCAST_URL
-  value: 'https://{{$.Values.keppel.anycast_domain_name}}'
+- name:  KEPPEL_API_ANYCAST_FQDN
+  value: '{{$.Values.keppel.anycast_domain_name}}'
 {{- end }}
 {{- if (index $.Values.keppel "anycast_issuer_key.pem") }}
 - name:  KEPPEL_ANYCAST_ISSUER_KEY
@@ -23,8 +23,8 @@
 - name:  KEPPEL_ANYCAST_PREVIOUS_ISSUER_KEY
   value: '/etc/keppel-keys/anycast-previous-issuer-key.pem'
 {{- end }}
-- name:  KEPPEL_API_PUBLIC_URL
-  value: 'https://keppel.{{$.Values.global.region}}.{{$.Values.global.tld}}'
+- name:  KEPPEL_API_PUBLIC_FQDN
+  value: 'keppel.{{$.Values.global.region}}.{{$.Values.global.tld}}'
 - name:  KEPPEL_AUDIT_SILENT
   value: "{{ ne $.Values.keppel.rabbitmq.queue_name "" }}"
 - name:  KEPPEL_AUDIT_RABBITMQ_QUEUE_NAME


### PR DESCRIPTION
To match the respective code change in
sapcc/keppel#26.