### PR TITLE
Added support in atlas for asr9k

### DIFF
--- a/system/infra-monitoring/vendor/atlas/templates/configmap.yaml
+++ b/system/infra-monitoring/vendor/atlas/templates/configmap.yaml
@@ -244,6 +244,18 @@ data:
               status: "active"
 
             - custom_labels:
+                module: "asr9k"
+                job: "ntp"
+              metrics_label: "asr9k"
+              target: 1
+              manufacturer: "cisco"
+              region: "{{ .Values.global.region }}"
+              role: "core-router"
+              tenant: "converged-cloud"
+              q: "rt"
+              status: "active"
+
+            - custom_labels:
                 module: "asr"
                 job: "snmp"
               metrics_label: "asr"


### PR DESCRIPTION
I'm adding a new atlas discovery config for the new ASR9K routers.
The netbox url is this one [here](https://netbox.global.cloud.sap/dcim/devices/?q=rt&status=active&role=core-router&mac_address=&has_primary_ip=&local_context_data=&virtual_chassis_member=&console_ports=&console_server_ports=&power_ports=&power_outlets=&interfaces=&pass_through_ports=&cf_DC+Label=).

This config is tested and can discover both ASR9901 and ASR9902 routers in all regions.
