### PR TITLE
[neutron] Set search domain as local in dnsmasq

### DIFF
--- a/openstack/neutron/templates/etc/_dnsmasq.conf.tpl
+++ b/openstack/neutron/templates/etc/_dnsmasq.conf.tpl
@@ -6,3 +6,4 @@ no-negcache
 {{- range .Values.dnsmasq.dhcp_options }}
 dhcp-option={{ . }}
 {{- end }}
+local=/{{required "A valid .Values.dns_local_domain is required!" .Values.dns_local_domain }}/


### PR DESCRIPTION
We don't expose openstack.$region.cloud.sap or its subdomains for
customers to register, but only use it locally in the current network
and on the local dnsmasq. Therefore, we want to configure dnsmasq to
also not recurse queries for this domain if they cannot be answered
locally.

This is supposed to fix a problem one of gardener's customers has, as
they use the search-domain for everything with less than 5 dots (i.e.
ndots 5 setting) and thus do multiple queries to the network's DNS
server for a "normal" domain like "www.googleapis.com".