### PR TITLE
Added support for asr9k (not peers) in ssh-exporter

### DIFF
--- a/prometheus-exporters/network-generic-ssh-exporter/templates/_config.yaml.tpl
+++ b/prometheus-exporters/network-generic-ssh-exporter/templates/_config.yaml.tpl
@@ -455,6 +455,132 @@ metrics:
     command: show ntp config
     timeout_secs: 5
   
+  xr_ntp_peer0_delay:
+    regex: >-
+      ^.*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})
+    multi_value: false
+    value: $5
+    labels:
+      address: $2
+      vrf: $3
+      reference_clock: $4
+    description: Configured peer 0 delay.
+    metric_type_name: gauge
+    command: show ntp associations
+    timeout_secs: 5
+  
+  xr_ntp_peer0_offset:
+    regex: >-
+      ^.*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})
+    multi_value: false
+    value: $6
+    labels:
+      address: $2
+      vrf: $3
+      reference_clock: $4
+    description: Configured peer 0 offset.
+    metric_type_name: gauge
+    command: show ntp associations
+    timeout_secs: 5
+  
+  xr_ntp_peer0_dispersion:
+    regex: >-
+      ^.*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})
+    multi_value: false
+    value: $7
+    labels:
+      address: $2
+      vrf: $3
+      reference_clock: $4
+    description: Configured peer 0 dispersion.
+    metric_type_name: gauge
+    command: show ntp associations
+    timeout_secs: 5
+  
+  xr_ntp_peer1_delay:
+    regex: >-
+      ^.*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})
+    multi_value: false
+    value: $5
+    labels:
+      address: $2
+      vrf: $3
+      reference_clock: $4
+    description: Configured peer 0 delay.
+    metric_type_name: gauge
+    command: show ntp associations
+    timeout_secs: 5
+  
+  xr_ntp_peer1_offset:
+    regex: >-
+      ^.*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})
+    multi_value: false
+    value: $6
+    labels:
+      address: $2
+      vrf: $3
+      reference_clock: $4
+    description: Configured peer 0 offset.
+    metric_type_name: gauge
+    command: show ntp associations
+    timeout_secs: 5
+  
+  xr_ntp_peer1_dispersion:
+    regex: >-
+      ^.*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})
+    multi_value: false
+    value: $7
+    labels:
+      address: $2
+      vrf: $3
+      reference_clock: $4
+    description: Configured peer 0 dispersion.
+    metric_type_name: gauge
+    command: show ntp associations
+    timeout_secs: 5
+  
+  xr_ntp_peer2_delay:
+    regex: >-
+      ^.*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})
+    multi_value: false
+    value: $5
+    labels:
+      address: $2
+      vrf: $3
+      reference_clock: $4
+    description: Configured peer 0 delay.
+    metric_type_name: gauge
+    command: show ntp associations
+    timeout_secs: 5
+  
+  xr_ntp_peer2_offset:
+    regex: >-
+      ^.*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})
+    multi_value: false
+    value: $6
+    labels:
+      address: $2
+      vrf: $3
+      reference_clock: $4
+    description: Configured peer 0 offset.
+    metric_type_name: gauge
+    command: show ntp associations
+    timeout_secs: 5
+  
+  xr_ntp_peer2_dispersion:
+    regex: >-
+      ^.*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})
+    multi_value: false
+    value: $7
+    labels:
+      address: $2
+      vrf: $3
+      reference_clock: $4
+    description: Configured peer 0 dispersion.
+    metric_type_name: gauge
+    command: show ntp associations
+    timeout_secs: 5
+  
   xr_ntp_offset:
     regex: >-
       ^.*(reference is)\s(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}).*(clock offset is)\s(-?\d{1,3}\.\d{1,3})\s(msec).*$
@@ -556,6 +682,15 @@ batches:
     - xr_ntp_root_delay
     - xr_ntp_root_dispersion
     - xr_ntp_drift
+    - xr_ntp_peer0_delay
+    - xr_ntp_peer0_offset
+    - xr_ntp_peer0_dispersion
+    - xr_ntp_peer1_delay
+    - xr_ntp_peer1_offset
+    - xr_ntp_peer1_dispersion
+    - xr_ntp_peer2_delay
+    - xr_ntp_peer2_offset
+    - xr_ntp_peer2_dispersion
 
 devices:
   cisco-ios-xe:

--- a/prometheus-exporters/network-generic-ssh-exporter/templates/_config.yaml.tpl
+++ b/prometheus-exporters/network-generic-ssh-exporter/templates/_config.yaml.tpl
@@ -501,11 +501,11 @@ metrics:
     regex: >-
       ^.*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})
     multi_value: false
-    value: $5
+    value: $12
     labels:
-      address: $2
-      vrf: $3
-      reference_clock: $4
+      address: $9
+      vrf: $10
+      reference_clock: $11
     description: Configured peer 0 delay.
     metric_type_name: gauge
     command: show ntp associations
@@ -515,11 +515,11 @@ metrics:
     regex: >-
       ^.*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})
     multi_value: false
-    value: $6
+    value: $13
     labels:
-      address: $2
-      vrf: $3
-      reference_clock: $4
+      address: $9
+      vrf: $10
+      reference_clock: $11
     description: Configured peer 0 offset.
     metric_type_name: gauge
     command: show ntp associations
@@ -529,11 +529,11 @@ metrics:
     regex: >-
       ^.*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})
     multi_value: false
-    value: $7
+    value: $14
     labels:
-      address: $2
-      vrf: $3
-      reference_clock: $4
+      address: $9
+      vrf: $10
+      reference_clock: $11
     description: Configured peer 0 dispersion.
     metric_type_name: gauge
     command: show ntp associations
@@ -543,11 +543,11 @@ metrics:
     regex: >-
       ^.*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})
     multi_value: false
-    value: $5
+    value: $19
     labels:
-      address: $2
-      vrf: $3
-      reference_clock: $4
+      address: $16
+      vrf: $17
+      reference_clock: $18
     description: Configured peer 0 delay.
     metric_type_name: gauge
     command: show ntp associations
@@ -557,11 +557,11 @@ metrics:
     regex: >-
       ^.*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})
     multi_value: false
-    value: $6
+    value: $20
     labels:
-      address: $2
-      vrf: $3
-      reference_clock: $4
+      address: $16
+      vrf: $17
+      reference_clock: $18
     description: Configured peer 0 offset.
     metric_type_name: gauge
     command: show ntp associations
@@ -571,11 +571,11 @@ metrics:
     regex: >-
       ^.*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})
     multi_value: false
-    value: $7
+    value: $21
     labels:
-      address: $2
-      vrf: $3
-      reference_clock: $4
+      address: $16
+      vrf: $17
+      reference_clock: $18
     description: Configured peer 0 dispersion.
     metric_type_name: gauge
     command: show ntp associations

--- a/prometheus-exporters/network-generic-ssh-exporter/templates/_config.yaml.tpl
+++ b/prometheus-exporters/network-generic-ssh-exporter/templates/_config.yaml.tpl
@@ -454,129 +454,48 @@ metrics:
     metric_type_name: string
     command: show ntp config
     timeout_secs: 5
-  
-  xr_ntp_peer0_delay:
-    regex: >-
-      ^.*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})
-    multi_value: false
-    value: $5
+
+  xr_ntp_peer_delay:
+    regex: |
+      ^\s*?(\*|#|\+|-|x|~)+(\S+)\s+vrf\s(\S+)\s*?$
+      ^\s+((\.\S+\s*\.)|(\d+|\.)+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+(\.\d+)*)\s+(-?\d+(\.\d+)*)\s+(-?\d+(\.\d+)*)
+    multi_value: true
+    value: $11
     labels:
       address: $2
       vrf: $3
       reference_clock: $4
-    description: Configured peer 0 delay.
+    description: NTP server delay
     metric_type_name: gauge
     command: show ntp associations
     timeout_secs: 5
-  
-  xr_ntp_peer0_offset:
-    regex: >-
-      ^.*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})
-    multi_value: false
-    value: $6
-    labels:
-      address: $2
-      vrf: $3
-      reference_clock: $4
-    description: Configured peer 0 offset.
-    metric_type_name: gauge
-    command: show ntp associations
-    timeout_secs: 5
-  
-  xr_ntp_peer0_dispersion:
-    regex: >-
-      ^.*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})
-    multi_value: false
-    value: $7
-    labels:
-      address: $2
-      vrf: $3
-      reference_clock: $4
-    description: Configured peer 0 dispersion.
-    metric_type_name: gauge
-    command: show ntp associations
-    timeout_secs: 5
-  
-  xr_ntp_peer1_delay:
-    regex: >-
-      ^.*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})
-    multi_value: false
-    value: $12
-    labels:
-      address: $9
-      vrf: $10
-      reference_clock: $11
-    description: Configured peer 0 delay.
-    metric_type_name: gauge
-    command: show ntp associations
-    timeout_secs: 5
-  
-  xr_ntp_peer1_offset:
-    regex: >-
-      ^.*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})
-    multi_value: false
+
+  xr_ntp_peer_offset:
+    regex: |
+      ^\s*?(\*|#|\+|-|x|~)+(\S+)\s+vrf\s(\S+)\s*?$
+      ^\s+((\.\S+\s*\.)|(\d+|\.)+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+(\.\d+)*)\s+(-?\d+(\.\d+)*)\s+(-?\d+(\.\d+)*)
+    multi_value: true
     value: $13
     labels:
-      address: $9
-      vrf: $10
-      reference_clock: $11
-    description: Configured peer 0 offset.
+      address: $2
+      vrf: $3
+      reference_clock: $4
+    description: NTP server delay
     metric_type_name: gauge
     command: show ntp associations
     timeout_secs: 5
-  
-  xr_ntp_peer1_dispersion:
-    regex: >-
-      ^.*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})
-    multi_value: false
-    value: $14
+
+  xr_ntp_peer_dispersion:
+    regex: |
+      ^\s*?(\*|#|\+|-|x|~)+(\S+)\s+vrf\s(\S+)\s*?$
+      ^\s+((\.\S+\s*\.)|(\d+|\.)+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+(\.\d+)*)\s+(-?\d+(\.\d+)*)\s+(-?\d+(\.\d+)*)
+    multi_value: true
+    value: $15
     labels:
-      address: $9
-      vrf: $10
-      reference_clock: $11
-    description: Configured peer 0 dispersion.
-    metric_type_name: gauge
-    command: show ntp associations
-    timeout_secs: 5
-  
-  xr_ntp_peer2_delay:
-    regex: >-
-      ^.*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})
-    multi_value: false
-    value: $19
-    labels:
-      address: $16
-      vrf: $17
-      reference_clock: $18
-    description: Configured peer 0 delay.
-    metric_type_name: gauge
-    command: show ntp associations
-    timeout_secs: 5
-  
-  xr_ntp_peer2_offset:
-    regex: >-
-      ^.*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})
-    multi_value: false
-    value: $20
-    labels:
-      address: $16
-      vrf: $17
-      reference_clock: $18
-    description: Configured peer 0 offset.
-    metric_type_name: gauge
-    command: show ntp associations
-    timeout_secs: 5
-  
-  xr_ntp_peer2_dispersion:
-    regex: >-
-      ^.*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})..*?(\*|#|\+|-|x|~)+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\svrf\s(\S*)\s*(\.\S*\s*\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})\s.*?(-?\d{1,2}\.\d{1,3})
-    multi_value: false
-    value: $21
-    labels:
-      address: $16
-      vrf: $17
-      reference_clock: $18
-    description: Configured peer 0 dispersion.
+      address: $2
+      vrf: $3
+      reference_clock: $4
+    description: NTP server delay
     metric_type_name: gauge
     command: show ntp associations
     timeout_secs: 5
@@ -682,15 +601,9 @@ batches:
     - xr_ntp_root_delay
     - xr_ntp_root_dispersion
     - xr_ntp_drift
-    - xr_ntp_peer0_delay
-    - xr_ntp_peer0_offset
-    - xr_ntp_peer0_dispersion
-    - xr_ntp_peer1_delay
-    - xr_ntp_peer1_offset
-    - xr_ntp_peer1_dispersion
-    - xr_ntp_peer2_delay
-    - xr_ntp_peer2_offset
-    - xr_ntp_peer2_dispersion
+    - xr_ntp_peer_delay
+    - xr_ntp_peer_offset
+    - xr_ntp_peer_dispersion
 
 devices:
   cisco-ios-xe:

--- a/prometheus-exporters/network-generic-ssh-exporter/templates/_config.yaml.tpl
+++ b/prometheus-exporters/network-generic-ssh-exporter/templates/_config.yaml.tpl
@@ -454,6 +454,54 @@ metrics:
     metric_type_name: string
     command: show ntp config
     timeout_secs: 5
+  
+  xr_ntp_offset:
+    regex: >-
+      ^.*(reference is)\s(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}).*(clock offset is)\s(-?\d{1,3}\.\d{1,3})\s(msec).*$
+    multi_value: false
+    value: $4
+    labels:
+      reference_clock: $2
+    description: The offset of the router
+    metric_type_name: gauge
+    command: show ntp status
+    timeout_secs: 5
+    
+  xr_ntp_root_delay:
+    regex: >-
+      ^.*(reference is)\s(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}).*(root delay is)\s(-?\d{1,3}\.\d{1,3})\s(msec).*$
+    multi_value: false
+    value: $4
+    labels:
+      reference_clock: $2
+    description: The root delay of the router
+    metric_type_name: gauge
+    command: show ntp status
+    timeout_secs: 5
+    
+  xr_ntp_root_dispersion:
+    regex: >-
+      ^.*(reference is)\s(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}).*(root dispersion is)\s(-?\d{1,3}\.\d{1,3})\s(msec).*$
+    multi_value: false
+    value: $4
+    labels:
+      reference_clock: $2
+    description: The root dispersion of the router
+    metric_type_name: gauge
+    command: show ntp status
+    timeout_secs: 5
+    
+  xr_ntp_drift:
+    regex: >-
+      ^.*(reference is)\s(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}).*(drift is)\s(-?\d{1,3}\.\d{1,112})\s.*$
+    multi_value: false
+    value: $4
+    labels:
+      reference_clock: $2
+    description: The drift of the router in seconds
+    metric_type_name: gauge
+    command: show ntp status
+    timeout_secs: 5
 
 batches:
   test:
@@ -503,10 +551,19 @@ batches:
   cisco-ios-xe_core-router:
     - xe_ntp_configured
 
+  cisco-ios-xr_core-router:
+    - xr_ntp_offset
+    - xr_ntp_root_delay
+    - xr_ntp_root_dispersion
+    - xr_ntp_drift
+
 devices:
   cisco-ios-xe:
     prompt_regex: ^\S+\#$
     init_command: terminal length 0
   cisco-nx-os:
     prompt_regex: ^\S+\# $
+    init_command: terminal length 0
+  cisco-ios-xr:
+    prompt_regex: ^\S+\#$
     init_command: terminal length 0

--- a/prometheus-exporters/network-generic-ssh-exporter/values.yaml
+++ b/prometheus-exporters/network-generic-ssh-exporter/values.yaml
@@ -6,3 +6,10 @@ log_format: 'logfmt'
 alerts:
   enabled: false
   prometheus: infra-collector
+global:
+  registry: DEFINED-IN-GLOBAL-SECRETS
+network_generic_ssh_exporter:
+  alerts:
+    enabled: false
+  user: DEFINED-IN-REGION-SECRETS
+  password: DEFINED-IN-REGION-SECRETS

--- a/system/infra-monitoring/vendor/atlas/templates/configmap.yaml
+++ b/system/infra-monitoring/vendor/atlas/templates/configmap.yaml
@@ -92,12 +92,11 @@ data:
                 credential: "default"
                 device: "cisco-ios-xr"
               metrics_label: "corerouter"
-              target: 1
-              manufacturer: "cisco"
-              region: "{{ .Values.global.region }}"
               role: "core-router"
+              platform: "cisco-ios-xr"
               tenant: "converged-cloud"
-              q: "rt"
+              target: 1
+              region: "{{ .Values.global.region }}"
               status: "active"
 
             - custom_labels:

--- a/system/infra-monitoring/vendor/atlas/templates/configmap.yaml
+++ b/system/infra-monitoring/vendor/atlas/templates/configmap.yaml
@@ -87,6 +87,20 @@ data:
               status: "active"
 
             - custom_labels:
+                batch: "cisco-ios-xr_core-router"
+                job: "network/ssh"
+                credential: "default"
+                device: "cisco-ios-xr"
+              metrics_label: "corerouter"
+              target: 1
+              manufacturer: "cisco"
+              region: "{{ .Values.global.region }}"
+              role: "core-router"
+              tenant: "converged-cloud"
+              q: "rt"
+              status: "active"
+
+            - custom_labels:
                 module: "vmware-esxi"
                 job: "vmware-esxi"
               target: 2
@@ -241,18 +255,6 @@ data:
               role: "core-router"
               tenant: "converged-cloud"
               platform: "cisco-ios-xe"
-              status: "active"
-
-            - custom_labels:
-                module: "asr9k"
-                job: "ntp"
-              metrics_label: "asr9k"
-              target: 1
-              manufacturer: "cisco"
-              region: "{{ .Values.global.region }}"
-              role: "core-router"
-              tenant: "converged-cloud"
-              q: "rt"
               status: "active"
 
             - custom_labels:


### PR DESCRIPTION
@swagner-de can you please have a look at this PR. This works only for the router stats (not peers) using the `show ntp stats` results. This doesn't need any changes to the ssh-exporter.