### PR TITLE
[keystone][hermes] enable authenticate events success fail

### DIFF
--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -69,8 +69,8 @@ api:
       # ignore all authentication events since the scope (project_id/domain_id) is missing
       # Note: exception for *authenticate* event types: the outcome has to be added as suffix to make this work
       # see https://github.com/openstack/keystone/blob/af4e98c770d771144463e6dd49cb4b559d48c403/keystone/notifications.py#L743
-      - identity.authenticate.success
-      - identity.authenticate.failed
+      #- identity.authenticate.success
+      #- identity.authenticate.failed
       - identity.authenticate.pending
 
   token:


### PR DESCRIPTION
Enable success, and failure events for authenticate. Unsure if we want to do pending.