### PR TITLE
[Glance] Introduce image_publicize_admin role

### DIFF
--- a/openstack/glance/templates/etc/_glance-policy.yaml.tpl
+++ b/openstack/glance/templates/etc/_glance-policy.yaml.tpl
@@ -9,7 +9,7 @@
 "get_image": "rule:context_is_viewer"
 "get_images": "rule:context_is_viewer"
 "modify_image": "rule:context_is_image_admin"
-"publicize_image": "rule:context_is_cloud_admin"
+"publicize_image": "rule:context_is_cloud_admin" or "role:image_publicize_admin"
 "communitize_image": "rule:context_is_editor"
 
 "download_image": "rule:context_is_editor"

--- a/openstack/glance/templates/etc/_glance-policy.yaml.tpl
+++ b/openstack/glance/templates/etc/_glance-policy.yaml.tpl
@@ -9,7 +9,7 @@
 "get_image": "rule:context_is_viewer"
 "get_images": "rule:context_is_viewer"
 "modify_image": "rule:context_is_image_admin"
-"publicize_image": "rule:context_is_cloud_admin" or "role:image_publicize_admin"
+"publicize_image": "rule:context_is_cloud_admin or role:image_publicize_admin"
 "communitize_image": "rule:context_is_editor"
 
 "download_image": "rule:context_is_editor"

--- a/openstack/glance/templates/seeds.yaml
+++ b/openstack/glance/templates/seeds.yaml
@@ -30,7 +30,8 @@ spec:
   - name: cloud_image_admin
   - name: image_admin
   - name: image_viewer
-
+  - name: image_publicize_admin
+  
   services:
   - name: glance
     type: image


### PR DESCRIPTION
This role explicitly allows user to set image visibility to public.