### PR TITLE
[nova] Add option to disable nova-bigvm deployment

### DIFF
--- a/openstack/nova/templates/bigvm-deployment.yaml
+++ b/openstack/nova/templates/bigvm-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.nova_bigvm_enabled -}}
 kind: Deployment
 apiVersion: apps/v1
 
@@ -87,3 +88,4 @@ spec:
         - name: nova-etc
           configMap:
             name: nova-etc
+{{- end }}

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -864,3 +864,5 @@ alerts:
 
 sentry:
   enabled: true
+
+nova_bigvm_enabled: true


### PR DESCRIPTION
We're going to phase out nova-bigvm in favor of HANA-only clusters and
thus need to selectively disable nova-bigvm deployments in certain
regions where this is already the case.