### PR TITLE
give technical users also the 'swiftoperator' role within octobus...

### DIFF
--- a/openstack/octobus/templates/seeds.yaml
+++ b/openstack/octobus/templates/seeds.yaml
@@ -53,6 +53,8 @@ spec:
         role: sharedfilesystem_viewer
       - user: {{ .Values.technicalUserPerRegion }}
         role: volume_viewer
+      - user: {{ .Values.technicalUserPerRegion }}
+        role: swiftoperator
 
 
     groups:


### PR DESCRIPTION
... projects.

The technical user needs the **swiftoperator** role to be able to do `multipart` uploads with the `S3` protocol.

cc @viennaa , @businessbean 