### PR TITLE
[sap-seeds] Deprecated bigVM flavors in non-exclusive list

### DIFF
--- a/openstack/sap-seeds/templates/_flavors_hana_no_exclusive.tpl
+++ b/openstack/sap-seeds/templates/_flavors_hana_no_exclusive.tpl
@@ -139,3 +139,29 @@
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "3"
     "vmware:hw_version": "vmx-18"
+
+### Deprecated BigVM flavors
+- name: "m5.96xlarge"
+  id: "270"
+  vcpus: 90
+  ram: 1468416
+  disk: 64
+  is_public: true
+  extra_specs:
+    "vmware:hv_enabled": "True"
+    "hw_video:ram_max_mb": "16"
+    "host_fraction": "1/4,3/4,1/2,1"
+    "resources:CUSTOM_BIGVM": "2"
+    "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+- name: "x1.32xlarge"
+  id: "250"
+  vcpus: 128
+  ram: 1991680
+  disk: 64
+  is_public: true
+  extra_specs:
+    "vmware:hv_enabled": "True"
+    "hw_video:ram_max_mb": "16"
+    "host_fraction": "1,0.67,0.34"
+    "resources:CUSTOM_BIGVM": "2"
+    "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"

--- a/openstack/sap-seeds/templates/flavor-seed.yaml
+++ b/openstack/sap-seeds/templates/flavor-seed.yaml
@@ -455,32 +455,6 @@ spec:
       "catalog:alias": "m5.64xlarge"
       "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
 
-  ### Deprecated BigVM flavors
-  - name: "m5.96xlarge"
-    id: "270"
-    vcpus: 90
-    ram: 1468416
-    disk: 64
-    is_public: true
-    extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
-      "host_fraction": "1/4,3/4,1/2,1"
-      "resources:CUSTOM_BIGVM": "2"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
-  - name: "x1.32xlarge"
-    id: "250"
-    vcpus: 128
-    ram: 1991680
-    disk: 64
-    is_public: true
-    extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
-      "host_fraction": "1,0.67,0.34"
-      "resources:CUSTOM_BIGVM": "2"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
-
   ### HANA flavors
 {{- if .Values.use_hana_exclusive }}
 {{ include (print .Template.BasePath "/_flavors_hana_exclusive.tpl") . | indent 2 }}


### PR DESCRIPTION
We only want the deprecated bigVM flavors availabe in regions, where we
don't have BBs marked as exclusively for HANAs, because we don't run
nova-bigvm in those regions anymore and thus those flavor, which depend
on the CUSTOM_BIGVM resource, will never be deployable.