### PR TITLE
[Cinder] Update rabbitmq from 0.2.0 to 0.2.6

### DIFF
--- a/openstack/cinder/requirements.lock
+++ b/openstack/cinder/requirements.lock
@@ -13,15 +13,15 @@ dependencies:
   version: 0.0.3
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.2.0
+  version: 0.2.6
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.2.0
+  version: 0.2.6
 - name: region_check
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.2
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.1.1
-digest: sha256:9c59651ff89b306ca37a9c9fc3e5877dcdecf56a29840fe25fa09afd403f00b3
-generated: "2021-12-13T17:16:38.431762+01:00"
+digest: sha256:d4e4d120df21e65d62330168f5475641993380496c4a1d6e270dd4c92e49b8fb
+generated: "2021-12-23T12:31:57.422973-05:00"

--- a/openstack/cinder/requirements.yaml
+++ b/openstack/cinder/requirements.yaml
@@ -15,11 +15,11 @@ dependencies:
     version: 0.0.3
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.2.0
+    version: 0.2.6
   - name: rabbitmq
     alias: rabbitmq_notifications
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.2.0
+    version: 0.2.6
   - name: region_check
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.1.2


### PR DESCRIPTION
This patch updates the cinder helm chart to use rabbitmq chart 0.2.6