### PR TITLE
[Swift] do not expire async pending metrics

### DIFF
--- a/openstack/swift/etc/statsd-exporter.yaml
+++ b/openstack/swift/etc/statsd-exporter.yaml
@@ -117,8 +117,12 @@ mappings:
   name: swift_object_replicator
   labels:
     action: $1
+- match: swift.object_server.async_pendings
+  name: swift_object_server_async_pendings
+  ttl: 0
 - match: swift.object-server.async_pendings.project.*.*
   name: swift_async_pendings_detail
+  ttl: 0
   labels:
     project_id: $1
     container:  $2

--- a/openstack/swift/etc/statsd-exporter.yaml
+++ b/openstack/swift/etc/statsd-exporter.yaml
@@ -119,10 +119,12 @@ mappings:
     action: $1
 - match: swift.object_server.async_pendings
   name: swift_object_server_async_pendings
-  ttl: 0
+  # ttl: 0 does not work, take 60d instead
+  ttl: 1440h
 - match: swift.object-server.async_pendings.project.*.*
   name: swift_async_pendings_detail
-  ttl: 0
+  # ttl: 0 does not work, take 60d instead
+  ttl: 1440h
   labels:
     project_id: $1
     container:  $2


### PR DESCRIPTION
With `statsd_exporter` 0.9.0 TTLs per mapping were introduced. This leads now to expiration of counters, which was not the case previously although we had the global TTL setting.
https://github.com/prometheus/statsd_exporter/blob/master/CHANGELOG.md#090--2019-03-11

To avoid absent alert flapping in underutilized regions, the async pending metrics do not expire with this setting.