### PR TITLE
[manila] reduce default number of volumes per svm

### DIFF
--- a/openstack/manila/templates/shares/_share-netapp.conf.tpl
+++ b/openstack/manila/templates/shares/_share-netapp.conf.tpl
@@ -70,7 +70,7 @@ netapp_delete_retention_hours = {{ $context.Values.delete_retention_hours | defa
 max_over_subscription_ratio = {{ $share.max_over_subscription_ratio | default $context.Values.max_over_subscription_ratio | default 3.0 }}
 
 # maximum number of volumes created in a SVM
-max_shares_per_share_server = {{ $share.max_shares_per_share_server | default $context.Values.max_shares_per_share_server | default 100 }}
+max_shares_per_share_server = {{ $share.max_shares_per_share_server | default $context.Values.max_shares_per_share_server | default 20 }}
 # maximum sum of gigabytes a SVM can have considering all its share instances and snapshots
 max_share_server_size  = {{ $share.max_share_server_size | default $context.Values.max_share_server_size | default 10240 }}
 


### PR DESCRIPTION
20 is the sweet spot for us.
Roughly calculated out of:
max 5000 volumes (NetApp limit on certain models)
max 256 SVMs (due to 2 lifs per svm and max 512 lifs NetApp limit)

@frr2018 fyi

to be deployed after xena upgrade