### PR TITLE
Raise HADetectedAPossibleHostFailure to critical

### DIFF
--- a/prometheus-exporters/vrops-exporter/alerts/host.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/host.alerts
@@ -188,7 +188,7 @@ groups:
   - alert: HADetectedAPossibleHostFailure
     expr: vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) has detected a possible host failure"}
     labels:
-      severity: warning
+      severity: critical
       tier: vmware
       service: compute
       context: "{{ $labels.hostsystem }} failure"


### PR DESCRIPTION
As requested by operations team.

- Playbook linked
- InfraOps informed