### PR TITLE
[manila] helm outdated-dependencies update

### DIFF
--- a/openstack/manila/requirements.lock
+++ b/openstack/manila/requirements.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.6
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.2.4
+  version: 0.2.7
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.8
@@ -20,5 +20,5 @@ dependencies:
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.3.0
-digest: sha256:5949c5091bd8ddb57a3082d0a26aaf9ed5e1a69d69c30efde1be9b9dc6941f40
-generated: "2022-01-25T16:36:34.670793+01:00"
+digest: sha256:fd3739eb3f7ab59f70cac01f203233055c081ed49e405aee7a8190aff1b8516c
+generated: "2022-02-01T14:04:00.305229+01:00"

--- a/openstack/manila/requirements.yaml
+++ b/openstack/manila/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mysql_metrics
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.2.4
+    version: 0.2.7
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.8


### PR DESCRIPTION
most likely to be done after xena upgrade

[rabbitmq] increase timeout for readiness probe to 3 sec
[rabbitmq] harmonize component label across charts
[mysql_exporter] remove mysql_database_size default metric as there is
pvc_exporter and respective alert now
[sql_exporter] allow to define additional custom metric sources in
values
[common][mysql_exporter] an attempt to add nova cell2 as a second
source for querying.