### PR TITLE
[vcf] mount config files to production pod 

### DIFF
--- a/openstack/vcf/configs/.gitignore
+++ b/openstack/vcf/configs/.gitignore
@@ -1,0 +1,1 @@
+!.gitignore

--- a/openstack/vcf/templates/configmap.yaml
+++ b/openstack/vcf/templates/configmap.yaml
@@ -5,5 +5,5 @@ metadata:
   name: vcf
 
 data:
-  config.yaml: |
-    dummy: test
+{{ (.Files.Glob "configs/**.yaml").AsConfig | indent 2 }}
+

--- a/openstack/vcf/templates/deployment.yaml
+++ b/openstack/vcf/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         - name: pvc
           persistentVolumeClaim:
             claimName: vcf-workspace
-        - name: config
+        - name: vcf-configs
           configMap:
             name: vcf
       containers:
@@ -36,8 +36,8 @@ spec:
             - mountPath: /pulumi/automation/etc
               subPath: etc
               name: pvc
-            - mountPath: /etc/config
-              name: config
+            - mountPath: /pulumi/automation/etc/configs
+              name: vcf-configs
           resources:
             requests:
               cpu: "500m"


### PR DESCRIPTION
The config files for every pulumi stack is read from secrets repo and imported to a configmap. They are then mounted into the production pod. Each time the config file is modified, run pipeline to populate the changes to production pod.