### PR TITLE
[common][rabbitmq] use keppel for rabbit images

### DIFF
--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 0.2.6
+version: 0.2.7
 description: A Helm chart for RabbitMQ
 sources:
 - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/ci/test-values.yaml
+++ b/common/rabbitmq/ci/test-values.yaml
@@ -3,6 +3,7 @@
 global:
   user_suffix: ""
   master_password: ""
+  dockerHubMirrorAlternateRegion: "other.dockerhub.mirror"
 
 ports:
   public: 5672

--- a/common/rabbitmq/templates/_helpers.tpl
+++ b/common/rabbitmq/templates/_helpers.tpl
@@ -37,3 +37,11 @@ rabbit://{{ default "" $envAll.Values.global.user_suffix | print $rabbitmq.users
 {{- .Release.Name -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "dockerHubMirror" -}}
+{{- if .Values.use_alternate_registry -}}
+{{- .Values.global.dockerHubMirrorAlternateRegion -}}
+{{- else -}}
+{{- .Values.global.dockerHubMirror -}}
+{{- end -}}
+{{- end -}}

--- a/common/rabbitmq/templates/deployment.yaml
+++ b/common/rabbitmq/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
       hostname: {{ template "fullname" . }}
       containers:
       - name: rabbitmq
-        image: "{{ .Values.image }}:{{.Values.imageTag }}"
+        image: "{{include "dockerHubMirror" .}}/{{ .Values.image }}:{{.Values.imageTag }}"
         imagePullPolicy: {{ default "IfNotPresent" .Values.imagePullPolicy | quote }}
         command:
           - bash
@@ -72,11 +72,7 @@ spec:
             name: container-init
 {{- if .Values.metrics.enabled }}
       - name: metrics
-        {{- if hasKey .Values.global "dockerHubMirror"}}
-        image: {{.Values.global.dockerHubMirror}}/{{ .Values.metrics.image }}:{{ .Values.metrics.imageTag }}
-        {{- else }}
-        image: "{{ .Values.metrics.image }}:{{ .Values.metrics.imageTag }}"
-        {{- end }}
+        image: {{include "dockerHubMirror" .}}/{{ .Values.metrics.image }}:{{ .Values.metrics.imageTag }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.metrics.imagePullPolicy | quote }}
         env:
           - name: PUBLISH_PORT

--- a/common/rabbitmq/values.yaml
+++ b/common/rabbitmq/values.yaml
@@ -16,7 +16,7 @@ imageTag: 3.6-management
 # imagePullPolicy:
 
 # name of priorityClass to influence scheduling priority
-#priority_class:
+# priority_class: "openstack-service-critical"
 
 ports:
   public: 5672

--- a/openstack/designate/values.yaml
+++ b/openstack/designate/values.yaml
@@ -266,6 +266,7 @@ audit:
   mem_queue_size: 1000
 
 rabbitmq:
+  use_alternate_registry: true
   users:
     default:
       user: openstack
@@ -275,6 +276,7 @@ rabbitmq:
       password: secret
 
 rabbitmq_notifications:
+  use_alternate_registry: true
   name: designate
   users:
     default:

--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -235,6 +235,8 @@ services:
 rabbitmq:
   ## default: {{.Release.Name}}-rabbitmq.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.region}}.{{.Values.global.tld}}
   # host: rabbitmq
+  # fetch rabbit keppel images from another region
+  use_alternate_registry: true
   users:
     default:
       password: ""


### PR DESCRIPTION
images.

Alternate region is used in a similar way like for keystone or mariadb
charts. In case Keppel down in the region - the service won't be able to
start.

Also bump chart.