### PR TITLE
[Rabbitmq] Add ability to unset priority-class

### DIFF
--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 0.2.6
+version: 0.2.7
 description: A Helm chart for RabbitMQ
 sources:
 - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/templates/deployment.yaml
+++ b/common/rabbitmq/templates/deployment.yaml
@@ -93,7 +93,11 @@ spec:
           - name: metrics
             containerPort: {{ default "9150" .Values.metrics.port }}
 {{- end }}
-      priorityClassName: {{ default "openstack-service-critical" .Values.priority_class | quote }}
+{{- if kindIs "invalid" .Values.priority_class }}
+      priorityClassName: "openstack-service-critical"
+{{- else }}
+      priorityClassName: {{ quote .Values.priority_class }}
+{{ end }}
       volumes:
         - name: rabbitmq-persistent-storage
         {{- if .Values.persistence.enabled }}


### PR DESCRIPTION
The default-function interpretes empty strings also as unset,
thereby not differentiating between an unset value and a priority-class
set explicity to an empty string.