### PR TITLE
[cronus]: change backends map to a slice

### DIFF
--- a/openstack/cronus/templates/cronus/_config.yaml.tpl
+++ b/openstack/cronus/templates/cronus/_config.yaml.tpl
@@ -84,8 +84,8 @@ cronus:
 {{- if .Values.config.smtpBackends }}
   # extra SMTP backends and a list of recipient domains
   smtpBackends:
-{{- range $k, $v := .Values.config.smtpBackends }}
-    {{ $k }}:
+{{- range $v := .Values.config.smtpBackends }}
+    - name: {{ $v.name }}
 {{- if $v.host }}
       host: {{$v.host }}
 {{- end }}

--- a/openstack/cronus/values.yaml
+++ b/openstack/cronus/values.yaml
@@ -226,7 +226,7 @@ config:
     email: email-region
   # extra SMTP backends and a list of recipient domains
   smtpBackends:
-    int:
+    - name: int
       # backend hostname. scheme specifies the encryption method: none, tls, starttls
       hosts:
         10:
@@ -234,7 +234,7 @@ config:
       # a list of recipient domains, which will be redirected to this backend
       domains:
         - corp.int
-        - int
+        - int.corp
   workQueue:
     enabled: false
     queueName: cronus_work_queue


### PR DESCRIPTION
since golang doesn't preserve map's order