### PR TITLE
[manila] enforce max share size

### DIFF
--- a/openstack/manila/templates/_helpers.tpl
+++ b/openstack/manila/templates/_helpers.tpl
@@ -16,4 +16,5 @@ netapp:thin_provisioned: "True"
 create_share_from_snapshot_support: "True"
 revert_to_snapshot_support: "True"
 replication_type: "dr"
+provisioning:max_share_size: "16384"  # 16 TB
 {{- end }}

--- a/openstack/manila/templates/type-seeds.yaml
+++ b/openstack/manila/templates/type-seeds.yaml
@@ -40,6 +40,7 @@ spec:
     extra_specs:
       share_backend_name: {{ $shareTypeName | quote }}
     {{- include "manila_type_seed.extra_specs" . | indent 6 }}
+      provisioning:max_share_size: "65536"  # 64 TB
   {{- end }}
   {{- end }}
   {{- end }}


### PR DESCRIPTION
16TB for normal types
64TB for hypervisor storage

DRAFT: we need to check what we have currently in the system already
documentation already states this limit, but it was not enforced