### PR TITLE
drop some metrics from pod-sd and endpoint-sd

### DIFF
--- a/common/prometheus-server/CHANGELOG.md
+++ b/common/prometheus-server/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.5.4
+
+* [endpoint/service SD] Exclude set of metrics from being scrapped.
+* [pod/service SD] Exclude set of metrics from being scrapped.
+
 ## 4.5.3
 
 * [endpoint/service SD] Fix scraping of ports declared by the pod but not the service

--- a/common/prometheus-server/Chart.yaml
+++ b/common/prometheus-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus via operator.
 name: prometheus-server
-version: 4.5.3
+version: 4.5.4
 appVersion: v2.32.1
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
 maintainers:

--- a/common/prometheus-server/templates/_helpers.tpl
+++ b/common/prometheus-server/templates/_helpers.tpl
@@ -135,3 +135,9 @@ prometheus-{{- (include "prometheus.name" .) -}}
   regex: ^({{ . | join "|" }})$
   action: keep
 {{- end -}}
+
+{{- define "prometheus.drop-metrics.metric-relabel-config" -}}
+- sourceLabels: [ __name__ ]
+  regex: ^({{ . | join "|" }})$
+  action: drop
+{{- end -}}

--- a/common/prometheus-server/templates/podmonitors/pod-sd.yaml
+++ b/common/prometheus-server/templates/podmonitors/pod-sd.yaml
@@ -66,6 +66,11 @@ spec:
           targetLabel: kubernetes_pod_name
 {{ include "prometheus.defaultRelabelConfig" . | indent 8 }}
 
+{{ if .Values.serviceDiscoveries.pods.forbiddenMetrics }}
+      metricRelabelings:
+{{ include "prometheus.drop-metrics.metric-relabel-config" .Values.serviceDiscoveries.pods.forbiddenMetrics | indent 8 }}
+{{ end }}
+
     - interval: {{ required ".Values.serviceDiscoveries.scrapeInterval  missing" .Values.serviceDiscoveries.scrapeInterval }}
       scrapeTimeout: {{ required ".Values.serviceDiscoveries.scrapeTimeout  missing" .Values.serviceDiscoveries.scrapeTimeout }}
       scheme: http
@@ -112,4 +117,9 @@ spec:
             - __meta_kubernetes_pod_name
           targetLabel: kubernetes_pod_name
 {{ include "prometheus.defaultRelabelConfig" . | indent 8 }}
+
+{{ if .Values.serviceDiscoveries.pods.forbiddenMetrics }}
+      metricRelabelings:
+{{ include "prometheus.drop-metrics.metric-relabel-config" .Values.serviceDiscoveries.pods.forbiddenMetrics | indent 8 }}
+{{ end }}
 {{ end }}

--- a/common/prometheus-server/templates/servicemonitors/endpoint-sd.yaml
+++ b/common/prometheus-server/templates/servicemonitors/endpoint-sd.yaml
@@ -73,6 +73,11 @@ spec:
           regex: '__meta_kubernetes_service_annotation_prometheus_io_scrape_param_(.+)'
 {{ include "prometheus.defaultRelabelConfig" . | indent 8 }}
 
+{{ if .Values.serviceDiscoveries.endpoints.forbiddenMetrics }}
+      metricRelabelings:
+{{ include "prometheus.drop-metrics.metric-relabel-config" .Values.serviceDiscoveries.endpoints.forbiddenMetrics | indent 8 }}
+{{ end }}
+
     - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       interval: {{ required ".Values.serviceDiscoveries.scrapeInterval  missing" .Values.serviceDiscoveries.scrapeInterval }}
       scrapeTimeout: {{ required ".Values.serviceDiscoveries.scrapeTimeout  missing" .Values.serviceDiscoveries.scrapeTimeout }}
@@ -122,4 +127,9 @@ spec:
           replacement: __param_$1
           regex: '__meta_kubernetes_service_annotation_prometheus_io_scrape_param_(.+)'
 {{ include "prometheus.defaultRelabelConfig" . | indent 8 }}
+
+{{ if .Values.serviceDiscoveries.endpoints.forbiddenMetrics }}
+      metricRelabelings:
+{{ include "prometheus.drop-metrics.metric-relabel-config" .Values.serviceDiscoveries.endpoints.forbiddenMetrics | indent 8 }}
+{{ end }}
 {{- end }}

--- a/common/prometheus-server/values.yaml
+++ b/common/prometheus-server/values.yaml
@@ -290,6 +290,8 @@ serviceDiscoveries:
     # Only scrape services and endpoints with annotation prometheus.io/targets: $prometheusName.
     # If set to false, all targets are scraped.
     limitToPrometheusTargets: true
+    # Scrape all metrics by default.
+    forbiddenMetrics: []
 
   # SD for Kubernetes Pods. See https://github.com/coreos/prometheus-operator/issues/38.
   pods:
@@ -297,6 +299,8 @@ serviceDiscoveries:
     # Only scrape pods with annotation prometheus.io/targets: $prometheusName.
     # If set to false, all targets are scraped.
     limitToPrometheusTargets: true
+    # Scrape all metrics by default.
+    forbiddenMetrics: []
 
   # SD for Kubernetes Probes.
   probes:


### PR DESCRIPTION
prep to drop high cardinality openstack_http_response_* metrics