### PR TITLE
[manila] add hypervisor_storage_hanalytics in share type seeds

### DIFF
--- a/openstack/manila/templates/type-seeds.yaml
+++ b/openstack/manila/templates/type-seeds.yaml
@@ -38,17 +38,13 @@ spec:
     extra_specs:
       share_backend_name: "hypervisor_storage"
     {{- include "manila_type_seed.extra_specs" . | indent 6 }}
-{{- end }}
-{{- if .Values.share_types.btp_backup}}
-  - name: btp_backup
+  - name: hypervisor_storage_hanalytics
     is_public: false
     specs:
     {{- include "manila_type_seed.specs" . | indent 6 }}
     extra_specs:
-      share_backend_name: "netapp-multi"
+      share_backend_name: "hypervisor_storage_hanalytics"
     {{- include "manila_type_seed.extra_specs" . | indent 6 }}
-      netapp:snapshot_policy: "BTP_Backup"
-      netapp:hide_snapdir: "False"
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Also remove share type BTP_Backup, it's not used in production.