### PR TITLE
[Cinder] set default max_oversubscription to 1

### DIFF
--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -57,7 +57,7 @@ backend_defaults:
   vmware_insecure: True
   vmware_profile_check_on_attach: False
   vmware_image_transfer_timeout_secs: 72000
-  max_over_subscription_ratio: 2.0
+  max_over_subscription_ratio: 1
   vmware_select_random_best_datastore: True
   vmware_datastores_as_pools: True
 


### PR DESCRIPTION
This will force all thin provisioned regions to not allow
overprovisioning as compared to free space available.