### PR TITLE
[snmp-exporter] add f5 customer oid for cluster name

### DIFF
--- a/prometheus-exporters/snmp-exporter/generator/f5customer-generator.yaml
+++ b/prometheus-exporters/snmp-exporter/generator/f5customer-generator.yaml
@@ -29,6 +29,7 @@ modules:
       - sysCmFailoverStatusStatus
       - sysCmSyncStatusStatus
       - sysCmSyncStatusColor
+      - 1.3.6.1.4.1.3375.2.1.14.2.2.1.2.2
       - sysGlobalTmmStatMemoryTotalKb
       - sysGlobalTmmStatMemoryUsedKb
       - sysGlobalHostOtherMemTotalKb


### PR DESCRIPTION
1.3.6.1.4.1.3375.2.1.14.2.2.1.2.2 is the second index of sysCmSyncStatusDetailsDetails, which looks like this:
`SNMPv2-SMI::enterprises.3375.2.1.14.2.2.1.2.2 = STRING: "cluster-02-qa-de-1 (In Sync): All devices in the device group are in sync"`
This allows us to use the cluster id string as a label for all metrics in the scrape config.