### PR TITLE
[Cinder] Add the SAPLargeVolumeFilter

### DIFF
--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -82,7 +82,7 @@ use_tls_acme: true
 
 db_name: cinder
 
-scheduler_default_filters: "AvailabilityZoneFilter,DifferentBackendFilter,SameBackendFilter,ShardFilter,CapacityFilter,CapabilitiesFilter"
+scheduler_default_filters: "AvailabilityZoneFilter,DifferentBackendFilter,SameBackendFilter,ShardFilter,CapacityFilter,CapabilitiesFilter,SAPLargeVolumeFilter"
 
 cinder_api_allow_migration_on_attach: True
 


### PR DESCRIPTION
This patch adds the SAPLargeVolumeFilter to the list of cinder
scheduler filters.  This forces all volumes > 2TB to not land
on vvol datastores.