### PR TITLE
[Cinder] Remove the backend shard low overcommit critical

### DIFF
--- a/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
+++ b/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
@@ -15,20 +15,6 @@ groups:
     annotations:
       description: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 20% storage left before overcommit is reached."
       summary: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 20% storage left before overcommit is reached."
-  - alert: CinderBackendShardLowOvercommitCritical
-    expr: >
-      sum(cinder_free_until_overcommit_gib) by (region, shard, backend) / 1024 + sum(cinder_free_until_overcommit_gib / cinder_total_capacity_gib * 100 < 10) by (region, shard, backend) * 0
-    for: 15m
-    labels:
-      severity: critical
-      tier: vmware
-      service: cinder
-      context: "openstack-exporter"
-      meta: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 10% storage left before overcommit is reached."
-      playbook: docs/support/playbook/cinder/cinder_low_overcommit_ratio.html
-    annotations:
-      description: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 10% storage left before overcommit is reached."
-      summary: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 10% storage left before overcommit is reached."
   - alert: CinderBackendShardLowFreeSpaceWarning
     expr: >
       sum(cinder_free_capacity_gib) by (region, shard, backend) / 1024 + sum(cinder_free_capacity_gib == 0 or cinder_free_capacity_gib / cinder_total_capacity_gib * 100 < 25) by (region, shard, backend)

--- a/prometheus-exporters/openstack-exporter/requirements.lock
+++ b/prometheus-exporters/openstack-exporter/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: utils
   repository: file://../../openstack/utils
-  version: 0.2.2
-digest: sha256:4e814ba6f3c8995c6fb210c56b13902f17e0c5424a7b8aef87d2cc7825f085ce
-generated: 2021-06-14T16:20:39.94488267+02:00
+  version: 0.3.0
+digest: sha256:b2afc45e30f460abd589db38807ad1ee921091794dddcfb7fa0fd06ef14ad365
+generated: "2022-02-01T08:31:56.805944-05:00"

--- a/prometheus-exporters/openstack-exporter/requirements.yaml
+++ b/prometheus-exporters/openstack-exporter/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: utils
   repository: file://../../openstack/utils
-  version: 0.2.2
+  version: 0.3.0


### PR DESCRIPTION
Since we moved to datastores as pools, this alert doesn't
make much sense.