### PR TITLE
[HSM] Add Slack routing

### DIFF
--- a/global/prometheus-alertmanager-operated/templates/_alertmanager.yaml.tpl
+++ b/global/prometheus-alertmanager-operated/templates/_alertmanager.yaml.tpl
@@ -47,6 +47,14 @@ route:
   receiver: dev-null
 
   routes:
+  - receiver: slack_hsm
+    continue: false
+    match_re:
+      service: barbican
+      context: hsm
+      severity: info
+      region: ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|ap-sa-2|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-2|na-us-3|qa-de-1
+
   - receiver: slack_barbican_certificate
     continue: false
     match_re:
@@ -784,6 +792,19 @@ receivers:
   - name: slack_barbican_certificate
     slack_configs:
       - channel: '#cc-os-barbican-cert-expiry'
+        api_url: {{ required ".Values.slack.webhookURL undefined" .Values.slack.webhookURL | quote }}
+        username: "Pulsar"
+        title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
+        title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
+        text: {{"'{{template \"slack.sapcc.text\" . }}'"}}
+        pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
+        icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
+        color: {{`'{{template "slack.sapcc.color" . }}'`}}
+        send_resolved: true
+
+  - name: slack_hsm
+    slack_configs:
+      - channel: '#cc-os-hsm'
         api_url: {{ required ".Values.slack.webhookURL undefined" .Values.slack.webhookURL | quote }}
         username: "Pulsar"
         title: {{"'{{template \"slack.sapcc.title\" . }}'"}}


### PR DESCRIPTION
Hi @auhlig 

HSM Metrics are created by snmp exporter. I intend to create hsm.alerts file [here](https://github.com/sapcc/helm-charts/tree/master/prometheus-exporters/snmp-exporter/alerts)  post this PR is merged.
Please validate if this PR.

Regards,
Rajiv