### PR TITLE
Prometheus: metric to measure L3 port utilisation

### DIFF
--- a/prometheus-exporters/network-generic-ssh-exporter/templates/_config.yaml.tpl
+++ b/prometheus-exporters/network-generic-ssh-exporter/templates/_config.yaml.tpl
@@ -455,6 +455,30 @@ metrics:
     command: show ntp config
     timeout_secs: 5
 
+  port_utilization_TCP:
+    regex: >-
+      \s*(\d+)\s{3}TCP\sIPv4
+    multi_value: true
+    metric_type_name: gauge
+    value: $1
+    labels:
+        port: $1
+    command: show ip ports reservation | ex TPM
+    description: Plot the number of reserved TPA ports (UDP/TCP) to check if unused ports get released again.
+    timeout_secs: 3
+
+  port_utilization_UDP:
+    regex: >-
+      \s*(\d+)\s{3}.*\s+UDP\sIPv4
+    multi_value: true
+    metric_type_name: gauge
+    value: $1
+    labels:
+        port: $1
+    command: show ip ports reservation | ex TPM
+    description: Plot the number of reserved TPA ports (UDP/TCP) to check if unused ports get released again.
+    timeout_secs: 3
+
 batches:
   test:
     - redundancy_send_queue
@@ -495,8 +519,10 @@ batches:
     - firewall_vrf_stats_half_open_udp
     - firewall_vrf_stats_half_open_tcp
     - firewall_vrf_stats_half_open_icmp
-
-
+  {{- if (hasPrefix "qa-de-".Values.global.region) }}
+    - port_utilization_TCP
+    - port_utilization_TCP
+  {{- end }}
   cisco-nx-os_core-router:
     - nx_ntp_configured
 


### PR DESCRIPTION
Adding a check to generic-ssh-exporter in prometheus to measure the number of
reserved transport ports on ASR routers in qa-de-* regions.