### PR TITLE
reinstate the "alert-tier" and "alert-service" labels for pod alerts

### DIFF
--- a/prometheus-rules/prometheus-kubernetes-rules/Chart.yaml
+++ b/prometheus-rules/prometheus-kubernetes-rules/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A collection of Prometheus alerting and aggregation rules for Kubernetes.
 name: prometheus-kubernetes-rules
-version: 1.2.16
+version: 1.2.17

--- a/prometheus-rules/prometheus-kubernetes-rules/alerts/health.alerts.tpl
+++ b/prometheus-rules/prometheus-kubernetes-rules/alerts/health.alerts.tpl
@@ -60,7 +60,7 @@ groups:
       summary: Kube state metrics scrape failed
 
   - alert: KubernetesPodRestartingTooMuch
-    expr: (sum by(pod, namespace, container, ) (rate(kube_pod_container_status_restarts_total[15m]))) * on (pod, container) group_left(label_tier, label_service) kube_pod_labels{} > 0
+    expr: (sum by(pod, namespace, container, ) (rate(kube_pod_container_status_restarts_total[15m]))) * on (pod, container) group_left(label_alert_tier, label_alert_service) kube_pod_labels{} > 0
     for: 1h
     labels:
       tier: {{ include "alertTierLabelOrDefault" .Values.tier }}


### PR DESCRIPTION
As discussed 1:1 with Arno, it's true that these are inconsistent with the "tier" and "service" labels already present on alerts. But since we already have lots of metrics with a "service" label, setting "service" as a pod label would either break the existing metrics or vice versa.