### PR TITLE
[mariadb-backup] removes unnecessary prometheus port scrape

### DIFF
--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.3.33
+version: 0.3.34

--- a/common/mariadb/templates/backup-v2-deployment.yaml
+++ b/common/mariadb/templates/backup-v2-deployment.yaml
@@ -24,7 +24,6 @@ spec:
         checksum/etc: {{ include (print $.Template.BasePath  "/backup-etc-configmap.yaml") . | sha256sum }}
 {{- if .Values.metrics.enabled }}
         prometheus.io/scrape: "true"
-        prometheus.io/port: "8082"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
 {{- end }}
     spec:

--- a/common/mariadb/templates/service.yaml
+++ b/common/mariadb/templates/service.yaml
@@ -56,10 +56,6 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "8082"
-    prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
 spec:
   selector:
     app: {{ include "fullName" . }}-backup


### PR DESCRIPTION
to remove multiple targets warnings.

Also put scrape annotations only to the deployment