### PR TITLE
[vrops-exporter] Add source vrops collector to nsxt alerts

### DIFF
--- a/prometheus-exporters/vrops-exporter/alerts/nsxt.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/nsxt.alerts
@@ -15,8 +15,8 @@ groups:
       playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
       no_alert_on_absence: "true"
     annotations:
-      description: "NSX-T cluster {{ $labels.nsxt_adapter }} firewall sections usage exceeded the supported limit."
-      summary: "NSX-T cluster {{ $labels.nsxt_adapter }} firewall sections usage exceeded the supported limit."
+      description: "NSX-T cluster {{ $labels.nsxt_adapter }} firewall sections usage exceeded the supported limit. ({{ $labels.collector }})"
+      summary: "NSX-T cluster {{ $labels.nsxt_adapter }} firewall sections usage exceeded the supported limit. ({{ $labels.collector }})"
 
   - alert: NSXTDistributedFirewallRulesUsageLimitExceeded
     expr: |
@@ -32,8 +32,8 @@ groups:
       playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
       no_alert_on_absence: "true"
     annotations:
-      description: "NSX-T cluster {{ $labels.nsxt_adapter }} firewall rules usage exceeded the supported limit."
-      summary: "NSX-T cluster {{ $labels.nsxt_adapter }} firewall sections rules exceeded the supported limit."
+      description: "NSX-T cluster {{ $labels.nsxt_adapter }} firewall rules usage exceeded the supported limit. ({{ $labels.collector }})"
+      summary: "NSX-T cluster {{ $labels.nsxt_adapter }} firewall sections rules exceeded the supported limit. ({{ $labels.collector }})"
 
   - alert: NSXTLogicalSwitchesUsageLimitExceeded
     expr: |
@@ -49,8 +49,8 @@ groups:
       playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
       no_alert_on_absence: "true"
     annotations:
-      description: "NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switches exceeded the supported limit."
-      summary: "NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switches exceeded the supported limit."
+      description: "NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switches exceeded the supported limit. ({{ $labels.collector }})"
+      summary: "NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switches exceeded the supported limit. ({{ $labels.collector }})"
 
   - alert: NSXTLogicalSwitchPortsUsageWarningLimitExceeded
     expr: |
@@ -66,8 +66,8 @@ groups:
       playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
       no_alert_on_absence: "true"
     annotations:
-      description: "NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switch ports exceeded the supported limit."
-      summary: "NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switch ports exceeded the supported limit."
+      description: "NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switch ports exceeded the supported limit. ({{ $labels.collector }})"
+      summary: "NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switch ports exceeded the supported limit. ({{ $labels.collector }})"
 
   - alert: NSXTGroupsUsageLimitExceeded
     expr: |
@@ -83,8 +83,8 @@ groups:
       playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
       no_alert_on_absence: "true"
     annotations:
-      description: "NSX-T cluster {{ $labels.nsxt_adapter }} count of NSGroups exceeded the supported limit."
-      summary: "NSX-T cluster {{ $labels.nsxt_adapter }} count of NSGroups exceeded the supported limit."
+      description: "NSX-T cluster {{ $labels.nsxt_adapter }} count of NSGroups exceeded the supported limit. ({{ $labels.collector }})"
+      summary: "NSX-T cluster {{ $labels.nsxt_adapter }} count of NSGroups exceeded the supported limit. ({{ $labels.collector }})"
 
   - alert: NSXTIPSetsUsageLimitExceeded
     expr: |
@@ -100,8 +100,8 @@ groups:
       playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
       no_alert_on_absence: "true"
     annotations:
-      description: "NSX-T cluster {{ $labels.nsxt_adapter }} count of IP sets exceeded the supported limit."
-      summary: "NSX-T cluster {{ $labels.nsxt_adapter }} count of IP sets exceeded the supported limit."
+      description: "NSX-T cluster {{ $labels.nsxt_adapter }} count of IP sets exceeded the supported limit. ({{ $labels.collector }})"
+      summary: "NSX-T cluster {{ $labels.nsxt_adapter }} count of IP sets exceeded the supported limit. ({{ $labels.collector }})"
 
   - alert: NSXTGroupsBasedInIPUsageLimitExceeded
     expr: |
@@ -117,8 +117,8 @@ groups:
       playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
       no_alert_on_absence: "true"
     annotations:
-      description: "NSX-T cluster {{ $labels.nsxt_adapter }} count of groups based in IP exceeded the supported limit."
-      summary: "NSX-T cluster {{ $labels.nsxt_adapter }} count of groups based in IP exceeded the supported limit."
+      description: "NSX-T cluster {{ $labels.nsxt_adapter }} count of groups based in IP exceeded the supported limit. ({{ $labels.collector }})"
+      summary: "NSX-T cluster {{ $labels.nsxt_adapter }} count of groups based in IP exceeded the supported limit. ({{ $labels.collector }})"
 
   - alert: NSXTMgmtNodeImageFilesystemCapacityCritical
     expr: vrops_nsxt_mgmt_node_filesystems_image_usedpercentage > 80
@@ -130,8 +130,8 @@ groups:
       meta: "NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage `/image` > 80%. {{ $labels.nsxt_adapter}}"
       playbook: docs/devops/alert/nsxt/#NSXTMgmtNodeImageFilesystemCapacityCritical
     annotations:
-      description: "NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage `/image` > 80%. {{ $labels.nsxt_adapter}}"
-      summary: "NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage `/image` > 80%. {{ $labels.nsxt_adapter}}"
+      description: "NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage `/image` > 80%. ({{ $labels.nsxt_adapter}}, {{ $labels.collector }})"
+      summary: "NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage `/image` > 80%. ({{ $labels.nsxt_adapter}}, {{ $labels.collector }})"
 
   - alert: NSXTMgmtNodeLogFilesystemCapacityCritical
     expr: vrops_nsxt_mgmt_node_filesystems_var_log_usedpercentage > 80
@@ -143,8 +143,8 @@ groups:
       meta: "NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage `/var/log` > 80%. {{ $labels.nsxt_adapter}}"
       playbook: "."
     annotations:
-      description: "NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage `/var/log` > 80%. {{ $labels.nsxt_adapter}}"
-      summary: "NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage `/var/log` > 80%. {{ $labels.nsxt_adapter}}"
+      description: "NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage `/var/log` > 80%. ({{ $labels.nsxt_adapter}}, {{ $labels.collector }})"
+      summary: "NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage `/var/log` > 80%. ({{ $labels.nsxt_adapter}}, {{ $labels.collector }})"
 
   - alert: NSXTClusterControlStatusNoControllers
     expr: vrops_nsxt_mgmt_cluster_controller_cluster_connectivity_status{state="NO_CONTROLLERS"}
@@ -156,8 +156,8 @@ groups:
       meta: "NSX-T management cluster {{ $labels.nsxt_adapter }} has connectivity status `{{ $labels.state }}`"
       playbook: docs/devops/alert/nsxt/#cluster_control_status_no_controllers
     annotations:
-      description: "NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status is `{{ $labels.state }}`"
-      summary: "NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status is `{{ $labels.state }}`"
+      description: "NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status is `{{ $labels.state }}`. ({{ $labels.collector }})"
+      summary: "NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status is `{{ $labels.state }}`. ({{ $labels.collector }})"
 
   - alert: NSXTClusterControlStatusUnstable
     expr: vrops_nsxt_mgmt_cluster_controller_cluster_connectivity_status{state="UNSTABLE"}
@@ -169,8 +169,8 @@ groups:
       meta: "NSX-T management cluster {{ $labels.nsxt_adapter }} has connectivity status `{{ $labels.state }}`"
       playbook: docs/devops/alert/nsxt/#cluster_control_status_unstable
     annotations:
-      description: "NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status is `{{ $labels.state }}`"
-      summary: "NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status is `{{ $labels.state }}`"
+      description: "NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status is `{{ $labels.state }}`. ({{ $labels.collector }})"
+      summary: "NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status is `{{ $labels.state }}`. ({{ $labels.collector }})"
 
   - alert: NSXTClusterControlStatusDegraded
     expr: vrops_nsxt_mgmt_cluster_controller_cluster_connectivity_status{state="DEGRADED"}
@@ -182,8 +182,8 @@ groups:
       meta: "NSX-T management cluster {{ $labels.nsxt_adapter }} has connectivity status `{{ $labels.state }}`"
       playbook: docs/devops/alert/nsxt/#cluster_control_status_degraded
     annotations:
-      description: "NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status is `{{ $labels.state }}`"
-      summary: "NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status is `{{ $labels.state }}`"
+      description: "NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status is `{{ $labels.state }}`. ({{ $labels.collector }})"
+      summary: "NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status is `{{ $labels.state }}`. ({{ $labels.collector }})"
 
   - alert: NSXTClusterControlStatusUnkown
     expr: vrops_nsxt_mgmt_cluster_controller_cluster_connectivity_status{state="UNKNOWN"}
@@ -195,8 +195,8 @@ groups:
       meta: "NSX-T management cluster {{ $labels.nsxt_adapter }} has connectivity status `{{ $labels.state }}`"
       playbook: docs/devops/alert/nsxt/#cluster_control_status_unkown
     annotations:
-      description: "NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status is `{{ $labels.state }}`"
-      summary: "NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status is `{{ $labels.state }}`"
+      description: "NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status is `{{ $labels.state }}`. ({{ $labels.collector }})"
+      summary: "NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status is `{{ $labels.state }}`. ({{ $labels.collector }})"
 
   - alert: NSXTNodeMemoryUsageOver95
     expr: vrops_nsxt_mgmt_node_memory_used / vrops_nsxt_mgmt_node_memory_total > 0.95
@@ -208,8 +208,8 @@ groups:
       meta: "NSX-T Node {{ $labels.nsxt_mgmt_node }} of cluster {{ $labels.nsxt_adapter }} has memory usage of over 95%"
       playbook: docs/devops/alert/nsxt/#NSXT_Memory_Usage_Over95
     annotations:
-      description: "NSX-T Node {{ $labels.nsxt_mgmt_node }} of cluster {{ $labels.nsxt_adapter }} has memory usage of over 95%"
-      summary: "NSX-T Node {{ $labels.nsxt_mgmt_node }} of cluster {{ $labels.nsxt_adapter }} has memory usage of over 95%"
+      description: "NSX-T Node {{ $labels.nsxt_mgmt_node }} of cluster {{ $labels.nsxt_adapter }} has memory usage of over 95%. ({{ $labels.collector }})"
+      summary: "NSX-T Node {{ $labels.nsxt_mgmt_node }} of cluster {{ $labels.nsxt_adapter }} has memory usage of over 95%. ({{ $labels.collector }})"
 
   - alert: NSXTNodeConnectivityBroken
     expr: vrops_nsxt_mgmt_node_connectivity_status{state="DISCONNECTED"}
@@ -221,8 +221,8 @@ groups:
       meta: "NSX-T Node `{{ $labels.nsxt_mgmt_node }}` connectivity is broken. ({{ $labels.nsxt_adapter }})"
       playbook: docs/devops/alert/nsxt
     annotations:
-      description: "NSX-T Node {{ $labels.nsxt_mgmt_node }} connectivity is broken. ({{ $labels.nsxt_adapter }})"
-      summary: "NSX-T Node {{ $labels.nsxt_mgmt_node }} connectivity is broken. ({{ $labels.nsxt_adapter }})"
+      description: "NSX-T Node {{ $labels.nsxt_mgmt_node }} connectivity is broken. ({{ $labels.nsxt_adapter }}). ({{ $labels.collector }})"
+      summary: "NSX-T Node {{ $labels.nsxt_mgmt_node }} connectivity is broken. ({{ $labels.nsxt_adapter }}). ({{ $labels.collector }})"
 
   - alert: NSXTManagementServiceHasFailed
     expr: |
@@ -234,8 +234,8 @@ groups:
       meta: "Critical NSX-T management service `{{ $labels.nsxt_mgmt_service }}` has failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }})."
       no_alert_on_absence: "true"
     annotations:
-      description: "CRITICAL: NSX-T management service `{{ $labels.nsxt_mgmt_service }}` has failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }})"
-      summary: "CRITICAL: NSX-T management service `{{ $labels.nsxt_mgmt_service }}` has failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }})."
+      description: "CRITICAL: NSX-T management service `{{ $labels.nsxt_mgmt_service }}` has failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }}). ({{ $labels.collector }})"
+      summary: "CRITICAL: NSX-T management service `{{ $labels.nsxt_mgmt_service }}` has failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }}). ({{ $labels.collector }})"
 
   - alert: NSXTManagementServiceHasFailed
     expr: |
@@ -247,8 +247,8 @@ groups:
       meta: "NSX-T management service `{{ $labels.nsxt_mgmt_service }}` has failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }})."
       no_alert_on_absence: "true"
     annotations:
-      description: "WARNING: NSX-T management service `{{ $labels.nsxt_mgmt_service }}` has failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }})"
-      summary: "WARNING: NSX-T management service `{{ $labels.nsxt_mgmt_service }}` has failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }})."
+      description: "WARNING: NSX-T management service `{{ $labels.nsxt_mgmt_service }}` has failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }}). ({{ $labels.collector }})"
+      summary: "WARNING: NSX-T management service `{{ $labels.nsxt_mgmt_service }}` has failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }}). ({{ $labels.collector }})"
 
   - alert: NSXTTransportNodeConnectivityNotUP
     expr: |
@@ -263,8 +263,8 @@ groups:
       playbook: docs/devops/alert/nsxt/#Transport_node_status_not_UP_in_NSXT
       no_alert_on_absence: "true"
     annotations:
-      description: "Transport node {{ $labels.nsxt_transport_node }} Controller/Manager Connectivity status is not UP. {{ $labels.recommendation_1 }}."
-      summary: "Transport node {{ $labels.nsxt_transport_node }} Controller/Manager Connectivity status is not UP. {{ $labels.recommendation_1 }}."
+      description: "Transport node {{ $labels.nsxt_transport_node }} Controller/Manager Connectivity status is not UP. {{ $labels.recommendation_1 }}. ({{ $labels.collector }})"
+      summary: "Transport node {{ $labels.nsxt_transport_node }} Controller/Manager Connectivity status is not UP. {{ $labels.recommendation_1 }}. ({{ $labels.collector }})"
 
   - alert: VROpsNSXTAdapterNotReceivingData
     expr: vrops_nsxt_adapter_alert_info{alert_name="Adapter instance is not receiving data"}
@@ -276,8 +276,8 @@ groups:
       meta: "vROPs NSX-T adapter is not receiving data for `{{ $labels.nsxt_adapter }}`. {{ $labels.recommendation_2 }}"
       no_alert_on_absence: "true"
     annotations:
-      description: "vROPs NSX-T adapter is not receiving data for `{{ $labels.nsxt_adapter }}`. {{ $labels.recommendation_2 }}"
-      summary: "vROPs NSX-T adapter is not receiving data for `{{ $labels.nsxt_adapter }}`. {{ $labels.recommendation_2 }}"
+      description: "vROPs NSX-T adapter is not receiving data for `{{ $labels.nsxt_adapter }}`. {{ $labels.recommendation_2 }}. ({{ $labels.collector }})"
+      summary: "vROPs NSX-T adapter is not receiving data for `{{ $labels.nsxt_adapter }}`. {{ $labels.recommendation_2 }}. ({{ $labels.collector }})"
 
   - alert: NSXTLogicalSwitchStateFailed
     expr: vrops_nsxt_logical_switch_state{state="FAILED"}
@@ -288,5 +288,5 @@ groups:
       meta: "NSX-T logical switch `{{ $labels.nsxt_logical_switch }}` state is {{ $labels.state }}. ({{ $labels.nsxt_adapter }})."
       no_alert_on_absence: "true"
     annotations:
-      description: "NSX-T logical switch `{{ $labels.nsxt_logical_switch }}` state is {{ $labels.state }}. ({{ $labels.nsxt_adapter }})."
-      summary: "NSX-T logical switch `{{ $labels.nsxt_logical_switch }}` state is {{ $labels.state }}. ({{ $labels.nsxt_adapter }})."
+      description: "NSX-T logical switch `{{ $labels.nsxt_logical_switch }}` state is {{ $labels.state }}. ({{ $labels.nsxt_adapter }}). ({{ $labels.collector }})"
+      summary: "NSX-T logical switch `{{ $labels.nsxt_logical_switch }}` state is {{ $labels.state }}. ({{ $labels.nsxt_adapter }}). ({{ $labels.collector }})"


### PR DESCRIPTION
The operations team requested to have to source vROps listed at every NSX-T alert. I picked the collector label, cause it is the closest to what we need without much label handling needed.