### PR TITLE
Change severity of few NSXT alerts.

### DIFF
--- a/prometheus-exporters/vrops-exporter/alerts/nsxt.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/nsxt.alerts
@@ -141,7 +141,7 @@ groups:
       tier: vmware
       service: compute
       meta: "NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage `/var/log` > 80%. {{ $labels.nsxt_adapter}}"
-      playbook: "."
+      playbook: docs/devops/alert/nsxt/#NSXTMgmtNodeLogFilesystemCapacityCritical
     annotations:
       description: "NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage `/var/log` > 80%. {{ $labels.nsxt_adapter}}"
       summary: "NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage `/var/log` > 80%. {{ $labels.nsxt_adapter}}"

--- a/prometheus-exporters/vrops-exporter/alerts/nsxt.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/nsxt.alerts
@@ -137,7 +137,7 @@ groups:
     expr: vrops_nsxt_mgmt_node_filesystems_var_log_usedpercentage > 80
     for: 10m
     labels:
-      severity: vmware
+      severity: warning
       tier: vmware
       service: compute
       meta: "NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage `/var/log` > 80%. {{ $labels.nsxt_adapter}}"

--- a/prometheus-exporters/vrops-exporter/alerts/nsxt.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/nsxt.alerts
@@ -124,7 +124,7 @@ groups:
     expr: vrops_nsxt_mgmt_node_filesystems_image_usedpercentage > 80
     for: 10m
     labels:
-      severity: warning
+      severity: critical
       tier: vmware
       service: compute
       meta: "NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage `/image` > 80%. {{ $labels.nsxt_adapter}}"
@@ -137,7 +137,7 @@ groups:
     expr: vrops_nsxt_mgmt_node_filesystems_var_log_usedpercentage > 80
     for: 10m
     labels:
-      severity: info
+      severity: vmware
       tier: vmware
       service: compute
       meta: "NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage `/var/log` > 80%. {{ $labels.nsxt_adapter}}"
@@ -257,7 +257,7 @@ groups:
         AND on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"}
         AND on (hostsystem) vrops_hostsystem_runtime_powerstate{state="Powered On"}
     labels:
-      severity: warning
+      severity: critical
       tier: vmware
       meta: "Transport node {{ $labels.nsxt_transport_node }} Controller/Manager Connectivity status is not UP. {{ $labels.recommendation_1 }}."
       playbook: docs/devops/alert/nsxt/#Transport_node_status_not_UP_in_NSXT


### PR DESCRIPTION
1.  NSXTMgmtNodeImageFilesystemCapacityCritical uplifted to critical.
2. NSXTMgmtNodeLogFilesystemCapacityCritical uplifted to warning.
3. NSXTTransportNodeConnectivityNotUP uplifted to critical.

Above alerts are verified and discussed in global infraops meeting.