### PR TITLE
[common][rabbitmq] add critical alert on rabbitmq not ready for 10

### DIFF
--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 0.2.8
+version: 0.2.9
 description: A Helm chart for RabbitMQ
 sources:
 - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/templates/alerts.yaml
+++ b/common/rabbitmq/templates/alerts.yaml
@@ -16,4 +16,25 @@ metadata:
 spec:
 {{ include (print .Template.BasePath "/alerts/_rabbitmq.alerts.tpl") . | indent 2 }}
 
+{{- if .Values.alerts.critical_readiness_enabled }}
+---
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: {{ include "fullName" . }}-health-alerts
+  labels:
+    app: {{ include "fullName" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    component: rabbitmq
+    prometheus: "kubernetes"
+
+spec:
+  groups:
+{{ include (print .Template.BasePath "/alerts/_health.alerts.tpl") . | indent 2 }}
+{{- end }}
+
 {{- end }}

--- a/common/rabbitmq/templates/alerts/_health.alerts.tpl
+++ b/common/rabbitmq/templates/alerts/_health.alerts.tpl
@@ -1,0 +1,15 @@
+- name: health.alerts
+  rules:
+  - alert: {{ include "alerts.service" . | title }}RabbitMQNotReady
+    expr: (kube_pod_status_ready_normalized{condition="true", pod=~"{{ include "fullName" . }}.*"} < 1)
+    for: 10m
+    labels:
+      severity: critical
+      context: availability
+      service: {{ include "alerts.service" . }}
+      dashboard: rabbitmq
+      tier: {{ required ".Values.alerts.tier missing" .Values.alerts.tier }}
+      playbook: 'docs/devops/alert/rabbitmq/'
+    annotations:
+      description: {{ include "fullName" . }} is not ready for 10 minutes.
+      summary: {{ include "fullName" . }} is not ready for 10 minutes. Please check the pod.

--- a/common/rabbitmq/values.yaml
+++ b/common/rabbitmq/values.yaml
@@ -70,6 +70,8 @@ metrics:
 # Default Prometheus alerts and rules.
 alerts:
   enabled: true
+  # Enables Critical alert if pod not ready for 10 mins.
+  critical_readiness_enabled: true
 
   # Name of the Prometheus supposed to scrape the metrics and to which alerts are assigned.
   prometheus: openstack


### PR DESCRIPTION
minutes.

Enabled by default, can be disabled optionally.