### PR TITLE
[vrops-exporter] no alerting for hosts in maintenance

### DIFF
--- a/prometheus-exporters/vrops-exporter/alerts/host.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/host.alerts
@@ -99,7 +99,9 @@ groups:
       summary: "Disk space usage of host {{ $labels.hostsystem }} is above 90%. ({{ $labels.vcenter }}, {{ $labels.vccluster }})"
 
   - alert: HostHasLostConnectivityToDVPort
-    expr: vrops_hostsystem_alert_info{alert_name="The host has lost connectivity to a dvPort"}
+    expr: |
+      vrops_hostsystem_alert_info{alert_name="The host has lost connectivity to a dvPort"}
+      and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!~"inMaintenance"}
     labels:
       severity: warning
       tier: vmware
@@ -113,7 +115,9 @@ groups:
       summary: "Host `{{ $labels.hostsystem }}` has lost connectivity to a dvPort. ({{ $labels.vcenter }})."
 
   - alert: HostHasLostRedundantConnectivityToDVPort
-    expr: vrops_hostsystem_alert_info{alert_name="The host has lost redundant connectivity to a dvPort"}
+    expr: |
+      vrops_hostsystem_alert_info{alert_name="The host has lost redundant connectivity to a dvPort"}
+      and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!~"inMaintenance"}
     labels:
       severity: warning
       tier: vmware
@@ -144,7 +148,9 @@ groups:
       summary: "`{{ $labels.hostsystem }}` has been unexpectedly disconnected from vCenter Server {{ $labels.vcenter }}."
 
   - alert: HostHasLostConnectivityToPhysicalNetwork
-    expr: vrops_hostsystem_alert_info{alert_name="The host has lost connectivity to physical network"}
+    expr: |
+      vrops_hostsystem_alert_info{alert_name="The host has lost connectivity to physical network"}
+      and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!~"inMaintenance"}
     labels:
       severity: warning
       tier: vmware
@@ -158,7 +164,9 @@ groups:
       summary: "Host `{{ $labels.hostsystem }}` has lost connectivity to physical network. ({{ $labels.vcenter }})."
 
   - alert: HostHasLostRedundantUplinksToTheNetwork
-    expr: vrops_hostsystem_alert_info{alert_name="The host has lost redundant uplinks to the network"}
+    expr: |
+      vrops_hostsystem_alert_info{alert_name="The host has lost redundant uplinks to the network"}
+      and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!~"inMaintenance"}
     labels:
       severity: warning
       tier: vmware
@@ -172,7 +180,9 @@ groups:
       summary: "Host `{{ $labels.hostsystem }}` has lost redundant uplinks to the network. ({{ $labels.vcenter }})."
 
   - alert: HostInMaintenanceModeForAtLeast72h
-    expr: vrops_hostsystem_alert_info{alert_name="Host is in maintenance mode for at least 72 hours"}
+    expr: |
+      vrops_hostsystem_alert_info{alert_name="Host is in maintenance mode for at least 72 hours"}
+      and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!~"inMaintenance"}
     labels:
       severity: info
       tier: vmware


### PR DESCRIPTION
Most alerts are for hosts in maintenance. This PR should reduce the noisy alert channels.