### PR TITLE
[Openstack-exporter]  upgraded the cinder alerts for pools

### DIFF
--- a/prometheus-exporters/openstack-exporter/Chart.yaml
+++ b/prometheus-exporters/openstack-exporter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: openstack-exporter
-version: 0.0.2
+version: 0.0.3
 description: Exporter for openstack information 
 maintainers:
   - name: Tommy Sauer (D066607)

--- a/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
+++ b/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
@@ -1,48 +1,39 @@
 groups:
 - name: cinder
   rules:
-  - alert: CinderBackendShardLowOvercommitWarning
-    expr: >
-      sum(cinder_free_until_overcommit_gib) by (region, shard, backend) / 1024 + sum(cinder_free_until_overcommit_gib / cinder_total_capacity_gib * 100 < 20) by (region, shard, backend) * 0
+  - alert: CinderReservedPercentLow
+    expr: sum(cinder_reserved_percent_available) by (shard, backend, pool) < 30
+    for: 15m
+    labels:
+      severity: info
+      tier: os
+      service: cinder
+      playbook: docs/support/playbook/cinder/cinder_reserved_percent_low.html
+    annotations:
+      description: 'Cinder backend {{ $labels.backend }}, pool {{ $labels.pool }}, shard {{ $labels.shard }}'
+      summary: 'Cinder reserved percentage is low'
+  - alert: CinderShardWarning
+    expr: count (sum(cinder_reserved_percent_available) by (shard, backend, pool) < 30) by (backend,shard) == 2
     for: 15m
     labels:
       severity: warning
-      tier: vmware
+      tier: os
       service: cinder
-      context: "openstack-exporter"
-      meta: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 20% storage left before overcommit is reached."
-      playbook: docs/support/playbook/cinder/cinder_low_overcommit_ratio.html
+      playbook: docs/support/playbook/cinder/cinder_reserved_percent_low.html
     annotations:
-      description: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 20% storage left before overcommit is reached."
-      summary: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 20% storage left before overcommit is reached."
-  - alert: CinderBackendShardLowFreeSpaceWarning
-    expr: >
-      sum(cinder_free_capacity_gib) by (region, shard, backend) / 1024 + sum(cinder_free_capacity_gib == 0 or cinder_free_capacity_gib / cinder_total_capacity_gib * 100 < 25) by (region, shard, backend)
+      description: 'Cinder backend {{ $labels.backend }}, shard {{ $labels.shard }}'
+      summary: 'Cinder Shard reserved space available count warning'
+  - alert: CinderShardCritical
+    expr: count (sum(cinder_reserved_percent_available) by (shard, backend, pool) < 30) by (backend,shard) < 2
     for: 15m
     labels:
       severity: warning
-      tier: vmware
+      tier: os
       service: cinder
-      context: "openstack-exporter"
-      meta: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 25% free storage left."
-      playbook: docs/support/playbook/cinder/cinder_low_overcommit_ratio.html
+      playbook: docs/support/playbook/cinder/cinder_reserved_percent_low.html
     annotations:
-      description: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 25% free storage left."
-      summary: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 25% free storage left."
-  - alert: CinderBackendShardLowFreeSpaceCritical
-    expr: >
-      sum(cinder_free_capacity_gib) by (region, shard, backend) / 1024 + sum(cinder_free_capacity_gib == 0 or cinder_free_capacity_gib / cinder_total_capacity_gib * 100 < 10) by (region, shard, backend)
-    for: 15m
-    labels:
-      severity: critical
-      tier: vmware
-      service: cinder
-      context: "openstack-exporter"
-      meta: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 10% free storage left."
-      playbook: docs/support/playbook/cinder/cinder_low_overcommit_ratio.html
-    annotations:
-      description: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 10% free storage left."
-      summary: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 10% free storage left."
+      description: 'Cinder backend {{ $labels.backend }}, shard {{ $labels.shard }}'
+      summary: 'Cinder Shard reserved space available count critical'
   - alert: CinderBackendStorageEmptyCritical
     expr: >
       sum(cinder_free_capacity_gib == 0) by (region, shard, backend) or sum(cinder_total_capacity_gib == 0) by (region, shard, backend)

--- a/prometheus-exporters/openstack-exporter/requirements.lock
+++ b/prometheus-exporters/openstack-exporter/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: utils
   repository: file://../../openstack/utils
-  version: 0.3.0
-digest: sha256:b2afc45e30f460abd589db38807ad1ee921091794dddcfb7fa0fd06ef14ad365
-generated: "2022-02-01T08:31:56.805944-05:00"
+  version: 0.3.3
+digest: sha256:4e3ca790e67ee3c4f245e11e70f4bfa9fa60c7942b0091cde1848e90c757f040
+generated: "2022-02-18T08:37:23.198059-05:00"

--- a/prometheus-exporters/openstack-exporter/requirements.yaml
+++ b/prometheus-exporters/openstack-exporter/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: utils
   repository: file://../../openstack/utils
-  version: 0.3.0
+  version: 0.3.3


### PR DESCRIPTION
This patch rewrites the cinder alerts for low storage available.

The new alerts rely on the newer openstack exporter that reports
on each individual datastore and how much free space is available
leftover until the reserved percentage is met.