### PR TITLE
swift: deliver metrics/alerts for s3-cache-prewarmer

### DIFF
--- a/openstack/swift/templates/prometheus-alerts.yaml
+++ b/openstack/swift/templates/prometheus-alerts.yaml
@@ -61,3 +61,38 @@ spec:
           description: 'The Keystone role "swiftreseller" is assigned to more users/groups than expected.'
 
 {{- end }}
+
+{{- if .Values.s3_cred_cache_prewarm_credentials }}
+---
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+# This rule is in here, rather than in a file in alerts/, because we need to use templating.
+metadata:
+  name: alerts-swift-s3-cache-prewarmer.alerts
+  labels:
+    app: swift
+    tier: os
+    type: alerting-rules
+    prometheus: {{ required ".Values.alerts.prometheus.openstack missing" $.Values.alerts.prometheus.openstack }}
+
+spec:
+  groups:
+  - name: openstack-swift-s3-cache-prewarmer.alerts
+    rules:
+      - alert: OpenstackSwiftS3CachePrewarmerNotWorking
+        # The cutoff is 10 minutes (600 seconds) here because cache entries
+        # have a TTL of 10 minutes, so if the prewarming cycle takes longer
+        # than that, it's going to be ineffective.
+        expr: max(time() - swift_s3_cache_prewarm_last_run_secs) > 600
+        for: 5m
+        labels:
+          tier: os
+          service: swift
+          severity: info
+          meta: 'Prewarming of S3 credential cache not working'
+        annotations:
+          summary: 'Prewarming of S3 credential cache not working'
+          description: 'The S3 credential cache is not getting prewarmed correctly. Check the logs of the swift-s3-cache-prewarmer-{{ .Values.cluster_name }} pod for details.'
+{{- end }}

--- a/openstack/swift/templates/s3-cache-prewarmer-deployment.yaml
+++ b/openstack/swift/templates/s3-cache-prewarmer-deployment.yaml
@@ -32,6 +32,8 @@ spec:
           command:
             - /usr/bin/swift-s3-cache-prewarmer
             - 'prewarm'
+            - '--listen'
+            - ':8080'
             - '--conservative'
             - '--expiry'
             - "{{ .Values.s3_cred_cache_time }}s"


### PR DESCRIPTION
Last week's prewarming issues in Amsterdam made me wonder why we did not see any alerts. Turns out, not only did we not define an alert, the metric delivery was not working either. The default for `-listen` is `localhost:8080` instead of `:8080`, so Prometheus could not reach the metrics endpoint.