### PR TITLE
Update openstack exporter requirements

### DIFF
--- a/prometheus-exporters/openstack-exporter/requirements.lock
+++ b/prometheus-exporters/openstack-exporter/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: utils
-  repository: file://../../openstack/utils
+  repository: https://charts.eu-de-2.cloud.sap
   version: 0.3.3
-digest: sha256:4e3ca790e67ee3c4f245e11e70f4bfa9fa60c7942b0091cde1848e90c757f040
-generated: "2022-02-18T08:37:23.198059-05:00"
+digest: sha256:191d2e7981cac55b288fa563de82541d96780af198cdf54058481c1d3c52f904
+generated: "2022-02-23T09:07:59.239206-05:00"

--- a/prometheus-exporters/openstack-exporter/requirements.yaml
+++ b/prometheus-exporters/openstack-exporter/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: utils
-  repository: file://../../openstack/utils
+  repository: https://charts.eu-de-2.cloud.sap
   version: 0.3.3


### PR DESCRIPTION
The requirements.yaml had a local path to the openstack utils
dependency, which was causing CI to fail.  This patch updates
the requirements.yaml to point to a real url for the repository