### PR TITLE
[keystone] Tolerate more errors in the lifesaver

### DIFF
--- a/openstack/keystone/templates/etc/_keystone.conf.tpl
+++ b/openstack/keystone/templates/etc/_keystone.conf.tpl
@@ -203,11 +203,11 @@ domain_allowlist = {{ .Values.lifesaver.domain_allowlist | default "Default, tem
 user_allowlist = {{ .Values.lifesaver.user_allowlist | default "admin, keystone, nova, neutron, cinder, glance, designate, barbican, dashboard, manila, swift" }}
 user_blocklist = {{ .Values.lifesaver.user_blocklist | default "" }}
 # initial user credit
-initial_credit = {{ .Values.lifesaver.initial_credit | default 100 }}
+initial_credit = {{ .Values.lifesaver.initial_credit | default 500 }}
 # how often do we refill credit
 refill_seconds = {{ .Values.lifesaver.refill_seconds | default 60 }}
 # and with what amount
-refill_amount = {{ .Values.lifesaver.refill_amount | default 1 }}
+refill_amount = {{ .Values.lifesaver.refill_amount | default 5 }}
 # cost of each status
 status_cost = {{ .Values.lifesaver.status_cost | default "default:1,401:10,403:5,404:0,429:0" }}
 


### PR DESCRIPTION
Currently the lifesaver middleware grants 100 credits to a user and
takes 5-10 per failed operation, which allows only 10-20 failed
operations per minute. We can easily handle more than that, and some
failed operations are generated by cli, non-perfect terraform scripts
and just by simple small errors, that users should not be punished for.

Raise the amount of credits that the user is granted and make refill of
the credits faster. This will allow 5 times failed operations per minute
more.