### PR TITLE
[glance] Change job name between versions

### DIFF
--- a/openstack/glance/templates/migration-job.yaml
+++ b/openstack/glance/templates/migration-job.yaml
@@ -1,7 +1,10 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: glance-migration-job
+  # since this name changes with every image change, removal and creation of
+  # this Job happens on nearly every deployment. Check the helm-chart changes
+  # to see if this needs more review.
+  name: glance-migration-job-{{ required "Please set glance.imageVersion or similar" .Values.imageVersion }}
   labels:
     app: {{ template "name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -12,7 +15,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "name" . }}
+{{ tuple . "glance" "migration" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
       annotations:
         chart-version: {{.Chart.Version}}
         checksum/etc-configmap.conf: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}


### PR DESCRIPTION
Helm doesn't handle an update of jobs graciously as
it tries to change immutable fields.
The workaround is to change the name of the resource,
which results in the deletion and recreation
of said job, which causes it to run on
more often