### PR TITLE
[nova] Reduce workers in api and increase replicas

### DIFF
--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -63,7 +63,7 @@ defaults:
 
 pod:
   replicas:
-    api: 3
+    api: 6
     metadata: 2
     console: 2
     consoleauth: 2
@@ -84,8 +84,8 @@ pod:
   resources:
     api:
       requests:
-        cpu: "8000m"
-        memory: "13Gi"
+        cpu: "4000m"
+        memory: "6Gi"
     metadata:
       requests:
         cpu: "500m"
@@ -206,7 +206,7 @@ api:
       api_paste_config: /etc/nova/api-paste.ini
       enabled_apis: osapi_compute
       use_forwarded_for: true
-      osapi_compute_workers: 8
+      osapi_compute_workers: 4
 
     api:
       list_records_by_skipping_down_cells: false
@@ -216,7 +216,7 @@ api:
       api_paste_config: /etc/nova/api-paste.ini
 
   use_uwsgi: false
-  wsgi_processes: 16
+  wsgi_processes: 8
 
 api_metadata:
   config_file:


### PR DESCRIPTION
We want our pods to be easier to schedule onto nodes by only requesting
4 instead of 8 CPUs. For that to work, we reduce the number of spawned
worker processes inside the pods. To still achieve the same amount of
resources, we double the number of pods.