### PR TITLE
Remove HA related OIDs form f5physical generator

### DIFF
--- a/prometheus-exporters/snmp-exporter/generator/f5physical-generator.yaml
+++ b/prometheus-exporters/snmp-exporter/generator/f5physical-generator.yaml
@@ -1,9 +1,6 @@
 modules:
   f5physical:
     walk:
-      - sysCmFailoverStatusStatus
-      - sysCmSyncStatusStatus
-      - sysCmSyncStatusColor
       - sysGlobalTmmStatMemoryTotalKb
       - sysGlobalTmmStatMemoryUsedKb
       - sysGlobalHostOtherMemTotalKb


### PR DESCRIPTION
The physical F5s do not run HA, they are standalone devices, no failover, no config sync.