### PR TITLE
[octavia] Remove .html from playbook links

### DIFF
--- a/openstack/octavia/alerts/octavia.alerts
+++ b/openstack/octavia/alerts/octavia.alerts
@@ -11,7 +11,7 @@ groups:
       severity: info
       tier: os
       meta: 'The active Octavia Agent `{{ $labels.agent }}` is not scheduable'
-      playbook: docs/support/playbook/octavia/agent_heartbeat.html
+      playbook: docs/support/playbook/octavia/agent_heartbeat
     annotations:
       description: 'The active Octavia Agent `{{ $labels.agent }}` is not scheduable'
       summary: Openstack Octavia Metric to check agent availability
@@ -25,7 +25,7 @@ groups:
       severity: warning
       tier: os
       meta: 'Agent Heartbeat is above 120secs in {{ $labels.octavia_host }}'
-      playbook: docs/support/playbook/octavia/agent_heartbeat.html
+      playbook: docs/support/playbook/octavia/agent_heartbeat
     annotations:
       description: Agent Heartbeat is above 120secs in {{ $labels.octavia_host }}
       summary: Openstack Octavia Metric to monitor Agents Heartbeat
@@ -79,7 +79,7 @@ groups:
       severity: critical
       tier: os
       meta: 'Load Balancer for agent {{ $labels.octavia_host }} stuck in `{{ $labels.current_status }}` state'
-      playbook: docs/support/playbook/octavia/stuck_pending.html
+      playbook: docs/support/playbook/octavia/stuck_pending
       cloudops: "?searchTerm={{ $labels.loadbalancer_id }}&type=loadbalancer"
     annotations:
       description: 'The Load Balancer `{{ $labels.loadbalancer_name }}` of agent `{{ $labels.octavia_host }}` stuck in {{ $labels.current_status }} state (<https://dashboard.{{ $externalLabels.region }}.cloud.sap/ccadmin/cloud_admin/cloudops#/universal-search/?searchTerm={{ $labels.loadbalancer_id }}&type=loadbalancer|{{ $labels.loadbalancer_id }}>)'


### PR DESCRIPTION
With the new documentation system (hugo), playbook links with html at the end
usually work, but for some reason they don't for the stuck_pending link.

In order to enforce a uniform format (and not confuse future contributors), I
remove .html on every octavia playbook link.