### PR TITLE
[openstack-exporter] update latest openstack utils chart

### DIFF
--- a/prometheus-exporters/openstack-exporter/Chart.yaml
+++ b/prometheus-exporters/openstack-exporter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: openstack-exporter
-version: 0.0.3
+version: 0.0.4
 description: Exporter for openstack information 
 maintainers:
   - name: Tommy Sauer (D066607)

--- a/prometheus-exporters/openstack-exporter/requirements.lock
+++ b/prometheus-exporters/openstack-exporter/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.3
-digest: sha256:191d2e7981cac55b288fa563de82541d96780af198cdf54058481c1d3c52f904
-generated: "2022-02-23T09:07:59.239206-05:00"
+  version: 0.3.4
+digest: sha256:f51e88a81a6d7072ed3d494060c7fe4f7131604f79c4e4e29563017bdb88ca67
+generated: "2022-03-01T15:36:12.115116-05:00"

--- a/prometheus-exporters/openstack-exporter/requirements.yaml
+++ b/prometheus-exporters/openstack-exporter/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.3
+  version: 0.3.4


### PR DESCRIPTION
This patch updates the openstack-exporter requirement for openstack
utils chart to 0.3.4