### PR TITLE
[manila] improvements for stability due to maintenance/restarts

### DIFF
--- a/openstack/manila/requirements.lock
+++ b/openstack/manila/requirements.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.34
+  version: 0.3.40
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.0.6
@@ -10,15 +10,15 @@ dependencies:
   version: 0.2.7
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.2.12
+  version: 0.2.17
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.2.12
+  version: 0.2.17
 - name: region_check
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.2
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.3
-digest: sha256:4e02896f7aff17ea9c03f40986f3cd2c8c38d9c10c9a8540ba232c85609e11ac
-generated: "2022-02-18T20:48:58.373491+01:00"
+  version: 0.3.4
+digest: sha256:ada8a263c96da6e3760c63be33883b0e2a08b38377507b7156c4039116011d47
+generated: "2022-03-02T14:57:21.241906+01:00"

--- a/openstack/manila/requirements.yaml
+++ b/openstack/manila/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.34
+    version: 0.3.40
   - condition: memcached.enabled
     name: memcached
     repository: https://charts.eu-de-2.cloud.sap
@@ -13,15 +13,15 @@ dependencies:
     version: 0.2.7
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.2.12
+    version: 0.2.17
   - alias: rabbitmq_notifications
     condition: audit.enabled
     name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.2.12
+    version: 0.2.17
   - name: region_check
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.1.2
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.3
+    version: 0.3.4

--- a/openstack/manila/templates/etc/_manila.conf.tpl
+++ b/openstack/manila/templates/etc/_manila.conf.tpl
@@ -30,6 +30,9 @@ periodic_interval = {{ .Values.periodic_interval | default 300 }}
 rpc_response_timeout = {{ .Values.rpc_response_timeout | default .Values.global.rpc_response_timeout | default 300 }}
 rpc_workers = {{ .Values.rpc_workers | default .Values.global.rpc_workers | default 1 }}
 
+# time to live in sec of idle connections in the pool:
+conn_pool_ttl = {{ .Values.rpc_conn_pool_ttl | default 600 }}
+
 netapp_volume_snapshot_reserve_percent = {{ .Values.netapp_volume_snapshot_reserve_percent | default 50 }}
 
 wsgi_default_pool_size = {{ .Values.wsgi_default_pool_size | default .Values.global.wsgi_default_pool_size | default 100 }}
@@ -81,6 +84,7 @@ policy_file = /etc/manila/policy.yaml
 [oslo_messaging_rabbit]
 rabbit_ha_queues = {{ .Values.rabbitmq.ha_queues | default "true" }}
 rabbit_transient_queues_ttl={{ .Values.rabbit_transient_queues_ttl | default .Values.global.rabbit_transient_queues_ttl | default 60 }}
+rabbit_interval_max = {{ .Values.rabbitmq.max_reconnect_interval | default 3 }}
 
 [oslo_concurrency]
 lock_path = /var/lib/manila/tmp

--- a/openstack/manila/templates/shares/_netapp-deployment.yaml.tpl
+++ b/openstack/manila/templates/shares/_netapp-deployment.yaml.tpl
@@ -28,6 +28,9 @@ spec:
         configmap-etc-hash: {{ include (print .Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
         configmap-netapp-hash: {{ list . $share | include "share_netapp_configmap" | sha256sum }}
     spec:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+{{- include "kubernetes_maintenance_affinity" . }}
       containers:
         - name: manila-share-netapp-{{$share.name}}
           image: {{.Values.global.registry}}/loci-manila:{{.Values.loci.imageVersion}}


### PR DESCRIPTION
bump rabbit, maria and utils requirements with new affinity
add maintenance affinity for manila shares
reduce rpc pool connection ttl to 10 mins from default 20 mins
reduce the max time between rabbit reconnections from 30 sec to 3 sec