### PR TITLE
[vrops-exporter] Adding Cluster Metrics for vMotion Monitoring

### DIFF
--- a/prometheus-exporters/vrops-exporter/templates/collector-configmap.yaml
+++ b/prometheus-exporters/vrops-exporter/templates/collector-configmap.yaml
@@ -103,6 +103,12 @@ data:
         key: "summary|total_number_vms"
       - metric_suffix: "cpu_contention_percentage"
         key: "cpu|capacity_contentionPct"
+      - metric_suffix: "summary_drs_unhappy_vms"
+        key: "summary|drs_unhappy_vms"
+      - metric_suffix: "badge_efficiency_percentage"
+        key: "badge|efficiency"
+      - metric_suffix: "badge_health_percentage"
+        key: "badge|health"
 
     DistributedvSwitchPropertiesCollector:
     # INFO - Prefix: vrops_distributed_virtual_switch_


### PR DESCRIPTION
Additional metrics request bei VMware to monitor vMotion activities and correlations.