### PR TITLE
[manila] make sure manila-share is bound to rabbitmq

### DIFF
--- a/openstack/manila/templates/shares/_netapp-deployment.yaml.tpl
+++ b/openstack/manila/templates/shares/_netapp-deployment.yaml.tpl
@@ -93,6 +93,22 @@ spec:
             timeoutSeconds: 3
             periodSeconds: 5
             initialDelaySeconds: 5
+        - name: rabbit-liveness
+          image: {{.Values.global.dockerHubMirror}}/activatedgeek/rabbitmqadmin:latest
+          imagePullPolicy: IfNotPresent
+          command: [ '/bin/sleep', '365d' ]
+          env:
+            - name: RABBIT_HOST
+              value: {{ include "rabbitmq.release_host" .}}
+            - name: RABBIT_PASSWORD
+              value: {{ .Values.rabbitmq.users.admin.password }}
+          livenessProbe:
+            exec:
+              command: ["rabbitmqadmin", "-H", "$RABBIT_HOST", "-u", "admin", "-p" , "$RABBIT_PASSWORD", "list", "bindings", "|", "grep", "manila-share-netapp-{{$share.name}}"]
+            initialDelaySeconds: 60
+            periodSeconds: 60
+            timeoutSeconds: 20
+
       hostname: manila-share-netapp-{{$share.name}}
       volumes:
         - name: etcmanila


### PR DESCRIPTION
```
/ # rabbitmqadmin -H $RABBIT_HOST -u admin -p $RABBIT_PASSWORD list bindings | grep manila-share-netapp-abc123
|                         | manila-share.manila-share-netapp-abc123@abc123             | manila-share.manila-share-netapp-abc123@abc123             |
| openstack               | manila-share.manila-share-netapp-abc123@abc123             | manila-share.manila-share-netapp-abc123@abc123             |
```

- activatedgeek/rabbitmqadmin:latest is for rabbit 3.6, we should probably in-house this
- I manually tried this in our staging region