### PR TITLE
[manila] share service liveness via rabbitmqadmin

### DIFF
--- a/openstack/manila/templates/bin-configmap.yaml
+++ b/openstack/manila/templates/bin-configmap.yaml
@@ -14,5 +14,7 @@ data:
   manila-api.sh: |
 {{ include (print .Template.BasePath "/bin/_manila_api.sh.tpl") . | indent 4 }}
 {{- end }}
+  fetch-rabbitmqadmin.sh: |
+{{ include (print .Template.BasePath "/bin/_fetch_rabbitmqadmin.sh.tpl") . | indent 4 }}
   common.sh: |
 {{ include "common.sh" .| indent 4 }}

--- a/openstack/manila/templates/bin/_fetch_rabbitmqadmin.sh.tpl
+++ b/openstack/manila/templates/bin/_fetch_rabbitmqadmin.sh.tpl
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+
+wget http://manila-rabbitmq:15672/cli/rabbitmqadmin
+chmod +x rabbitmqadmin
+mv rabbitmqadmin /shared


### PR DESCRIPTION
fetches the rabbitmqadmin command directly from the running rabbit instance on init

followup to 5080b1eae46911b97dc2d010cb3b29afb0cdb420
which does not work, because in a deployment if the sidecar container liveness fails
only the affected container is restarted, not all of them (which is true only for
kind pod)