### PR TITLE
[nova] Bump mariadb requirement to 0.3.40

### DIFF
--- a/openstack/nova/requirements.lock
+++ b/openstack/nova/requirements.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.34
+  version: 0.3.40
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.34
+  version: 0.3.40
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.7
@@ -22,12 +22,12 @@ dependencies:
   version: 0.3.0
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.34
+  version: 0.3.40
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.12
 - name: region_check
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.2
-digest: sha256:18db249f0aac77c42ec49ec2332512577f84a9d131163ad952b7146874dd450c
-generated: "2022-03-04T17:48:56.06038+01:00"
+digest: sha256:88de5c806dc258d267ffb00ffc08fdde872e96599e46c6ca05fbff66161cb7b1
+generated: "2022-03-09T14:25:31.449514772+01:00"

--- a/openstack/nova/requirements.yaml
+++ b/openstack/nova/requirements.yaml
@@ -2,12 +2,12 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.34
+    version: 0.3.40
   - name: mariadb
     alias: mariadb_api
     condition: mariadb_api.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.34
+    version: 0.3.40
   - condition: mariadb.enabled
     name: mysql_metrics
     repository: https://charts.eu-de-2.cloud.sap
@@ -30,7 +30,7 @@ dependencies:
     alias: mariadb_cell2
     condition: mariadb_cell2.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.34
+    version: 0.3.40
   - name: rabbitmq
     alias: rabbitmq_cell2
     condition: cell2.enabled


### PR DESCRIPTION
This bump is for getting the nodeAffinity setting to prevent frequent
restarts during k8s node upgrades.