### PR TITLE
[nova] Reduce nova-compute restart during k8s node maintenance

### DIFF
--- a/openstack/nova/requirements.lock
+++ b/openstack/nova/requirements.lock
@@ -19,7 +19,7 @@ dependencies:
   version: 0.2.12
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.0
+  version: 0.3.4
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.3.40
@@ -29,5 +29,5 @@ dependencies:
 - name: region_check
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.2
-digest: sha256:88de5c806dc258d267ffb00ffc08fdde872e96599e46c6ca05fbff66161cb7b1
-generated: "2022-03-09T14:25:31.449514772+01:00"
+digest: sha256:b679005d3c05225f058a4157975bac4459917a2fbc4d720c1e5890090ee1e664
+generated: "2022-03-09T14:43:19.620075134+01:00"

--- a/openstack/nova/requirements.yaml
+++ b/openstack/nova/requirements.yaml
@@ -25,7 +25,7 @@ dependencies:
     version: 0.2.12
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.0
+    version: 0.3.4
   - name: mariadb
     alias: mariadb_cell2
     condition: mariadb_cell2.enabled

--- a/openstack/nova/templates/hypervisors/hypervisors-vmware-deployment-vct.yaml
+++ b/openstack/nova/templates/hypervisors/hypervisors-vmware-deployment-vct.yaml
@@ -42,6 +42,7 @@ template: |
           configmap-nova-compute-hash: {= "vcenter_cluster/{{ .Release.Namespace }}/vcenter-cluster-nova-compute-configmap.yaml.j2" | render | sha256sum =}
       spec:
 {{ tuple "{= availability_zone =}" | include "kubernetes_pod_az_affinity" | indent 8 }}
+{{- include "kubernetes_maintenance_affinity" . | indent 4 }}
         containers:
         - name: nova-compute
           image: {{ required ".Values.global.registry is missing" .Values.global.registry}}/ubuntu-source-nova-compute:{{ .Values.imageVersionNovaCompute | default .Values.imageVersionNova | default .Values.imageVersion | required "Please set .imageVersion or similar" }}


### PR DESCRIPTION
We bump the utils chart here to get the
"kubernetes_maintenance_affinity" helper, so we can easily define the
affinity to operational nodes (compared to nodes waiting to upgrade) for
starts/restarts during k8s node maintenance.