### PR TITLE
[rabbitmq] improve too broad matching of health alert

### DIFF
--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 0.2.18
+version: 0.2.19
 description: A Helm chart for RabbitMQ
 sources:
 - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/templates/alerts/_health.alerts.tpl
+++ b/common/rabbitmq/templates/alerts/_health.alerts.tpl
@@ -1,7 +1,7 @@
 - name: health.alerts
   rules:
   - alert: {{ include "alerts.service" . | title }}RabbitMQNotReady
-    expr: (kube_pod_status_ready_normalized{condition="true", pod=~"{{ include "fullname" . }}.*"} < 1)
+    expr: (kube_pod_status_ready_normalized{condition="true", pod=~"{{ include "fullname" . }}.*", pod!~"{{ include "fullName" . }}-notifications.*"} < 1)
     for: 10m
     labels:
       severity: critical


### PR DESCRIPTION
most openstack services deploy for auditing an aliased version
with 'notifications' suffix. This change prevents the alert for the
rabbitmq without 'notifications' from firing if the 'notifications'
rabbitmq is not ready.

e.g.
```
(kube_pod_status_ready_normalized{condition="true",pod=~"manila-rabbitmq-notifications.*",pod!~"manila-rabbitmq-notifications-notifications.*"} < 1)
```

ugly, because this depends on the domain knowledge of how we usually name the audit alias