### PR TITLE
Nova: Switch for standalone placement

### DIFF
--- a/openstack/nova/templates/etc-configmap.yaml
+++ b/openstack/nova/templates/etc-configmap.yaml
@@ -63,5 +63,7 @@ data:
       match_type: glob
       glob_disable_ordering: false
       ttl: 0 # metrics do not expire
+{{- if .Values.placement.enabled }}
   placement_uwsgi.ini: |
 {{ include (print .Template.BasePath "/etc/_placement_uwsgi.ini.tpl") . | indent 4 }}
+{{- end }}

--- a/openstack/nova/templates/placement-api-deployment.yaml
+++ b/openstack/nova/templates/placement-api-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.placement.enabled }}
 kind: Deployment
 apiVersion: apps/v1
 
@@ -107,3 +108,4 @@ spec:
         - name: nova-etc
           configMap:
             name: nova-etc
+{{- end }}

--- a/openstack/nova/templates/placement-api-service.yaml
+++ b/openstack/nova/templates/placement-api-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.placement.enabled }}
 kind: Service
 apiVersion: v1
 
@@ -13,3 +14,4 @@ spec:
   ports:
     - name: nova-placement-api
       port: {{.Values.global.placementApiPortInternal}}
+{{- end }}

--- a/openstack/nova/templates/placement-ingress.yaml
+++ b/openstack/nova/templates/placement-ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.placement.enabled }}
 kind: Ingress
 apiVersion: networking.k8s.io/v1beta1
 
@@ -25,3 +26,4 @@ spec:
           backend:
             serviceName: nova-placement-api
             servicePort: {{.Values.global.placementApiPortInternal}}
+{{- end }}

--- a/openstack/nova/templates/seed.yaml
+++ b/openstack/nova/templates/seed.yaml
@@ -56,6 +56,7 @@ spec:
     - interface: public
       region: '{{ .Values.global.region }}'
       url: 'https://{{include "nova_api_endpoint_host_public" .}}:{{.Values.global.novaApiPortPublic}}/v2/%(tenant_id)s'
+{{- if .Values.placement.enabled }}
   - name: placement
     type: placement
     description: Openstack Placement API
@@ -69,7 +70,7 @@ spec:
     - interface: public
       region: '{{ .Values.global.region }}'
       url: 'https://{{include "placement_api_endpoint_host_public" .}}:{{.Values.global.placementApiPortPublic}}'
-
+{{ end }}
   domains:
   - name: Default
     users:

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -312,7 +312,7 @@ quota:
 
 
 placement:
-  enabled: false
+  enabled: true
   wsgi_processes: 10
 
 mysql_metrics:


### PR DESCRIPTION
Unless specifically opted-in (by setting placement.enabled=False)
this PR doesn't change single line / checksum.

To migrate, deploy first the standalone placement chart
(different changeset).
This will update the endpoint in keystone, so all request
should be routed through the new deployment.

Then deploy this chart with placement.enabled=False,
which will undeploy nova internal placement.

The dependency of the data in the nova_api database needs
to be solved separately.