### PR TITLE
sentry: update pgmetrics chart to 0.3.0

### DIFF
--- a/system/sentry/charts/postgresql/README.md
+++ b/system/sentry/charts/postgresql/README.md
@@ -57,11 +57,6 @@ The following tables lists the configurable parameters of the PostgresSQL chart 
 | `persistence.size`         | Size of data volume                        | `10Gi`                                                     |
 | `persistence.existingClaim`| Re-Use existing PVC                        |                                                            |
 | `resources`                | CPU/Memory resource requests/limits        | Memory: `256Mi`, CPU: `100m`                               |
-| `metrics.enabled`          | Start a side-car prometheus exporter       | `false`                                                    |
-| `metrics.image`            | Exporter image                             | `wrouesnel/postgres_exporter`                              |
-| `metrics.imageTag`         | Exporter image                             | `v0.1.1`                                                   |
-| `metrics.imagePullPolicy`  | Exporter image pull policy                 | `IfNotPresent`                                             |
-| `metrics.resources`        | Exporter resource requests/limit           | Memory: `256Mi`, CPU: `100m`                               |
 
 The above parameters map to the env variables defined in [postgres](http://github.com/docker-library/postgres). For more information please refer to the [postgres](http://github.com/docker-library/postgres) image documentation.
 
@@ -88,6 +83,3 @@ $ helm install --name my-release -f values.yaml stable/postgresql
 The [postgres](https://github.com/docker-library/postgres) image stores the PostgreSQL data and configurations at the `/var/lib/postgresql/data/pgdata` path of the container.
 
 The chart mounts a [Persistent Volume](http://kubernetes.io/docs/user-guide/persistent-volumes/) volume at this location. The volume is created using dynamic volume provisioning.
-
-## Metrics
-The chart optionally can start a metrics exporter for [prometheus](https://prometheus.io). The metrics endpoint (port 9187) is not exposed and it is expected that the metrics are collected from inside the k8s cluster using something similar as the described in the [example Prometheus scrape configuration](https://github.com/prometheus/prometheus/blob/master/documentation/examples/prometheus-kubernetes.yml).

--- a/system/sentry/charts/postgresql/templates/deployment.yaml
+++ b/system/sentry/charts/postgresql/templates/deployment.yaml
@@ -98,30 +98,6 @@ spec:
           - name: BACKUP_PGSQL_FULL
             value: {{.Values.backup.interval_full | quote}}
 {{- end }}
-{{- if .Values.metrics.enabled }}
-      - name: metrics
-        {{- if hasKey .Values.global "dockerHubMirror"}}
-        image: {{.Values.global.dockerHubMirror}}/{{ .Values.metrics.image }}:{{ .Values.metrics.imageTag }}
-        {{- else }}
-        image: "{{ .Values.metrics.image }}:{{ .Values.metrics.imageTag }}"
-        {{- end }}
-        imagePullPolicy: {{ default "" .Values.metrics.imagePullPolicy | quote }}
-        env:
-        - name: DATA_SOURCE_NAME
-          value: postgresql://postgres@localhost:5432?sslmode=disable
-        ports:
-        - name: metrics
-          containerPort: 9187
-        {{- if .Values.metrics.customMetrics }}
-        args: ["-extend.query-path", "/conf/custom-metrics.yaml"]
-        volumeMounts:
-          - name: custom-metrics
-            mountPath: /conf
-            readOnly: true
-        {{- end }}
-        resources:
-{{ toYaml .Values.metrics.resources | indent 10 }}
-{{- end }}
       volumes:
       - name: postgres-etc
         configMap:
@@ -132,12 +108,4 @@ spec:
           claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ template "fullname" . }}{{- end }}
       {{- else }}
         emptyDir: {}
-      {{- end }}
-      {{- if and .Values.metrics.enabled .Values.metrics.customMetrics }}
-      - name: custom-metrics
-        secret:
-          secretName: {{ template "fullname" . }}
-          items:
-            - key: custom-metrics.yaml
-              path: custom-metrics.yaml
       {{- end }}

--- a/system/sentry/charts/postgresql/templates/secrets.yaml
+++ b/system/sentry/charts/postgresql/templates/secrets.yaml
@@ -14,6 +14,3 @@ data:
   {{ else }}
   postgres-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{ end }} 
-  {{- if .Values.metrics.customMetrics }}
-  custom-metrics.yaml: {{ toYaml .Values.metrics.customMetrics | b64enc | quote }}
-  {{- end}}

--- a/system/sentry/charts/postgresql/templates/svc.yaml
+++ b/system/sentry/charts/postgresql/templates/svc.yaml
@@ -7,12 +7,6 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-{{- if .Values.metrics.enabled }}
-  annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9187"
-    prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
-{{- end }}
 spec:
   ports:
   - name: postgresql

--- a/system/sentry/charts/postgresql/values.yaml
+++ b/system/sentry/charts/postgresql/values.yaml
@@ -29,26 +29,6 @@ persistence:
   # Re-use existing (unmanged) PVC
   # existingClaim: claimName
 
-metrics:
-  enabled: false
-  image: wrouesnel/postgres_exporter
-  imageTag: v0.1.1
-  imagePullPolicy: IfNotPresent
-  customMetrics:
-    pg_database:
-      query: "SELECT d.datname AS datname, CASE WHEN pg_catalog.has_database_privilege(d.datname, 'CONNECT') THEN pg_catalog.pg_database_size(d.datname) ELSE 0 END AS size_bytes FROM pg_catalog.pg_database d where datname not in ('template0', 'template1', 'postgres')"
-      metrics:
-        - datname:
-            usage: "LABEL"
-            description: "Name of the database"
-        - size_bytes:
-            usage: "GAUGE"
-            description: "Size of the database in bytes"
-  resources:
-    requests:
-      memory: 256Mi
-      cpu: 100m
-
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##

--- a/system/sentry/requirements.lock
+++ b/system/sentry/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: pgmetrics
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.2.0
+  version: 0.3.0
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.2
-digest: sha256:2388013e9f27675be6fce5930f0c3199a2a7bb508b2c543ccfe9496ad8e9501a
-generated: "2022-03-15T14:42:51.365202252+01:00"
+digest: sha256:e8cb0b51c2a096643acead765636d53e3b13a47f14daaae97700776fca17e50d
+generated: "2022-03-15T16:19:52.574862842+01:00"

--- a/system/sentry/requirements.yaml
+++ b/system/sentry/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
   - name: pgmetrics
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.2.0
+    version: 0.3.0
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.1.2


### PR DESCRIPTION
Besides cleaning up the chart a bit, the primary motivation is to upgrade the postgres-exporter. There are two separate metrics pods in Sentry, both on ancient postgres-exporter versions:

- the pgmetrics chart includes the sentry-pgmetrics deployment using postgres-exporter v0.4.6 (the current version is v0.10.1)
- the postgres chart includes a sidecar container in the sentry-postgresql deployment at postgres-exporter v0.1.1 (!)

Since it's a bad idea anyway to stuff too many sidecars into the Postgres pod (since then every change to the sidecar requires restarting the DB), this PR gets rid of the second postgres-exporter entirely. Note that this causes a DB restart at deploy time.

There will be a separate PR in the secrets repo for the respective values.yaml change.