### PR TITLE
openstack.utils.db_url_mysql: Use dbUser credentials instead of root

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.3.8
+version: 0.3.9

--- a/openstack/utils/templates/_hosts.tpl
+++ b/openstack/utils/templates/_hosts.tpl
@@ -21,7 +21,7 @@ postgresql+psycopg2://{{$user}}:{{$password | urlquery}}@{{.Chart.Name}}-postgre
 
 {{define "db_url_mysql" }}
     {{- if kindIs "map" . -}}
-mysql+pymysql://root:{{.Values.mariadb.root_password | required ".Values.mariadb.root_password is required!" }}@{{include "db_host_mysql" .}}/{{.Values.db_name}}
+mysql+pymysql://{{ coalesce .Values.dbUser .Values.global.dbUser "root" }}:{{ coalesce .Values.dbPassword .Values.global.dbPassword .Values.mariadb.root_password | required ".Values.mariadb.root_password is required!" }}@{{ include "db_host_mysql" . }}/{{.Values.db_name}}
     {{- else }}
         {{- $envAll := index . 0 }}
         {{- $name := index . 1 }}


### PR DESCRIPTION
We have (at least) two users in the mariadbs.
The root user and the service specific user

This change makes the service use the service-specific
user, and leaves the root user for administrative tasks