### PR TITLE
Inhibit alerts for nodes in maintenance

### DIFF
--- a/global/prometheus-alertmanager-operated/Chart.yaml
+++ b/global/prometheus-alertmanager-operated/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 description: Prometheus Alertmanager via operator.
 name: prometheus-alertmanager-operated
-version: 1.2.7
+version: 1.2.8
 
 dependencies:
   - alias: prometheus-alertmanager

--- a/global/prometheus-alertmanager-operated/Chart.yaml
+++ b/global/prometheus-alertmanager-operated/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 description: Prometheus Alertmanager via operator.
 name: prometheus-alertmanager-operated
-version: 1.2.8
+version: 1.2.9
 
 dependencies:
   - alias: prometheus-alertmanager

--- a/global/prometheus-alertmanager-operated/ci/test-values.yaml
+++ b/global/prometheus-alertmanager-operated/ci/test-values.yaml
@@ -3,32 +3,32 @@ global:
   domain: evil.corp
 
 slack:
-  devnullWebhookURL: topSecret!
-  webhookURL: topSecret!
+  devnullWebhookURL: https://web.hook
+  webhookURL: https://web.hook
 
   api:
-    warningWebhookURL: topSecret!
-    criticalWebhookURL: topSecret!
+    warningWebhookURL: https://web.hook
+    criticalWebhookURL: https://web.hook
 
   kubernikus:
-    warningWebhookURL: topSecret!
-    criticalWebhookURL: topSecret!
+    warningWebhookURL: https://web.hook
+    criticalWebhookURL: https://web.hook
 
   metal:
-    warningWebhookURL: topSecret!
-    criticalWebhookURL: topSecret!
+    warningWebhookURL: https://web.hook
+    criticalWebhookURL: https://web.hook
 
   vpod:
-    warningWebhookURL: topSecret!
-    criticalWebhookURL: topSecret!
+    warningWebhookURL: https://web.hook
+    criticalWebhookURL: https://web.hook
 
   network:
-    warningWebhookURL: topSecret!
-    criticalWebhookURL: topSecret!
+    warningWebhookURL: https://web.hook
+    criticalWebhookURL: https://web.hook
 
   vmware:
-    warningWebhookURL: topSecret!
-    criticalWebhookURL: topSecret!
+    warningWebhookURL: https://web.hook
+    criticalWebhookURL: https://web.hook
 
 pagerduty:
   api:

--- a/global/prometheus-alertmanager-operated/templates/_alertmanager.yaml.tpl
+++ b/global/prometheus-alertmanager-operated/templates/_alertmanager.yaml.tpl
@@ -39,6 +39,13 @@ inhibit_rules:
       alertname: 'PodNotReady|ManyPodsNotReadyOnNode'
     equal: ['node']
 
+  # Inhibit kubelet alerts for nodes that are in maintenance.
+  - source_match:
+      'cloud.sap/maintenance-state': 'in-maintenance'
+    target_matchers:
+      alertname: '.*KubeletDown'
+    equal: ['node']
+
 route:
   group_by: ['region', 'service', 'alertname', 'cluster']
   group_wait: 1m

--- a/global/prometheus-alertmanager-operated/templates/_alertmanager.yaml.tpl
+++ b/global/prometheus-alertmanager-operated/templates/_alertmanager.yaml.tpl
@@ -39,11 +39,11 @@ inhibit_rules:
       alertname: 'PodNotReady|ManyPodsNotReadyOnNode'
     equal: ['node']
 
-  # Inhibit kubelet alerts for nodes that are in maintenance.
+  # If the alert NodeInMaintenance is firing other alerts with the label inhibited-by: node-maintenance are being inhibited on the same node.
   - source_match:
-      'cloud.sap/maintenance-state': 'in-maintenance'
-    target_matchers:
-      alertname: '.*KubeletDown'
+      alertname: NodeInMaintenance
+    target_match:
+      inhibited-by: node-maintenance
     equal: ['node']
 
 route:

--- a/prometheus-rules/prometheus-kubernetes-rules/Chart.yaml
+++ b/prometheus-rules/prometheus-kubernetes-rules/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A collection of Prometheus alerting and aggregation rules for Kubernetes.
 name: prometheus-kubernetes-rules
-version: 1.2.17
+version: 1.2.18

--- a/prometheus-rules/prometheus-kubernetes-rules/alerts/health.alerts.tpl
+++ b/prometheus-rules/prometheus-kubernetes-rules/alerts/health.alerts.tpl
@@ -3,7 +3,7 @@ groups:
 - name: kubernetes.alerts
   rules:
   - alert: KubernetesNodeManyNotReady
-    expr: count(kube_node_status_condition{condition="Ready",status="true"} == 0) > 2
+    expr: count((kube_node_status_condition{condition="Ready",status="true"} unless on (node) kube_node_labels{label_cloud_sap_maintenance_state="in-maintenance"}) == 0) > 2
     for: 1h
     labels:
       tier: {{ required ".Values.tier missing" .Values.tier }}
@@ -28,6 +28,7 @@ groups:
       meta: "{{`{{ $labels.node }}`}} is NotReady"
       dashboard: nodes?var-server={{`{{$labels.node}}`}}
       playbook: docs/support/playbook/kubernetes/k8s_node_not_ready.html
+      inhibited-by: node-maintenance
     annotations:
       summary: Node status is NotReady
       description: Node {{`{{ $labels.node }}`}} is NotReady for more than an hour

--- a/prometheus-rules/prometheus-kubernetes-rules/alerts/kubelet.alerts.tpl
+++ b/prometheus-rules/prometheus-kubernetes-rules/alerts/kubelet.alerts.tpl
@@ -12,6 +12,7 @@ groups:
       context: kubelet
       dashboard: kubernetes-health
       playbook: docs/support/playbook/kubernetes/k8s_node_not_ready.html
+      inhibited-by: node-maintenance
     annotations:
       description: Many Kubelets are DOWN
       summary: More than 2 Kubelets are DOWN
@@ -27,6 +28,7 @@ groups:
       meta: "{{`{{ $labels.node }}`}}"
       dashboard: kubernetes-health
       playbook: docs/support/playbook/kubernetes/k8s_node_not_ready.html
+      inhibited-by: node-maintenance
     annotations:
       description: Kublet on {{`{{ $labels.node }}`}} is DOWN.
       summary: A Kubelet is DOWN

--- a/prometheus-rules/prometheus-kubernetes-rules/alerts/kubelet.alerts.tpl
+++ b/prometheus-rules/prometheus-kubernetes-rules/alerts/kubelet.alerts.tpl
@@ -3,7 +3,7 @@ groups:
 - name: kubelet.alerts
   rules:
   - alert: ManyKubeletDown
-    expr: count(up{job="kubernetes-kubelet"}) - sum(up{job="kubernetes-kubelet"}) > 2
+    expr: count(up{job="kubernetes-kubelet"} unless on (node) kube_node_labels{label_cloud_sap_maintenance_state="in-maintenance"}) - sum(up{job="kubernetes-kubelet"} unless on (node) kube_node_labels{label_cloud_sap_maintenance_state="in-maintenance"})
     for: 10m
     labels:
       tier: {{ required ".Values.tier missing" .Values.tier }}
@@ -12,7 +12,6 @@ groups:
       context: kubelet
       dashboard: kubernetes-health
       playbook: docs/support/playbook/kubernetes/k8s_node_not_ready.html
-      inhibited-by: node-maintenance
     annotations:
       description: Many Kubelets are DOWN
       summary: More than 2 Kubelets are DOWN

--- a/prometheus-rules/prometheus-kubernetes-rules/alerts/maintenance.alerts.tpl
+++ b/prometheus-rules/prometheus-kubernetes-rules/alerts/maintenance.alerts.tpl
@@ -5,7 +5,7 @@ groups:
   rules:
   - alert: NodeInMaintenance
     expr: kube_node_labels{label_cloud_sap_maintenance_state="in-maintenance"} == 1
-    for: 15m
+    for: 2m
     labels:
       tier: {{ required ".Values.tier missing" .Values.tier }}
       service: node

--- a/prometheus-rules/prometheus-kubernetes-rules/alerts/maintenance.alerts.tpl
+++ b/prometheus-rules/prometheus-kubernetes-rules/alerts/maintenance.alerts.tpl
@@ -1,0 +1,17 @@
+### Maintenance inhibition alerts ###
+
+groups:
+- name: maintenance.alerts
+  rules:
+  - alert: NodeInMaintenance
+    expr: kube_node_labels{label_cloud_sap_maintenance_state="in-maintenance"} == 1
+    for: 15m
+    labels:
+      tier: {{ required ".Values.tier missing" .Values.tier }}
+      service: node
+      severity: none
+      context: node
+      meta: "Node {{`{{ $labels.node }}`}} is in maintenance."
+    annotations:
+      summary: Node in maintenance
+      description: "Node {{`{{ $labels.node }}`}} is in scheduled maintenance. This inhibits other alerts for the duration of the maintenance."

--- a/prometheus-rules/prometheus-kubernetes-rules/alerts/maintenance.alerts.tpl
+++ b/prometheus-rules/prometheus-kubernetes-rules/alerts/maintenance.alerts.tpl
@@ -14,4 +14,4 @@ groups:
       meta: "Node {{`{{ $labels.node }}`}} is in maintenance."
     annotations:
       summary: Node in maintenance
-      description: "Node {{`{{ $labels.node }}`}} is in scheduled maintenance. This inhibits other alerts for the duration of the maintenance."
+      description: "Node {{`{{ $labels.node }}`}} is in scheduled maintenance. Add the label `inhibited-by: node-maintenance` to alerts that should be inhibited while a node is in maintenance"

--- a/prometheus-rules/prometheus-kubernetes-rules/alerts/maintenance.alerts.tpl
+++ b/prometheus-rules/prometheus-kubernetes-rules/alerts/maintenance.alerts.tpl
@@ -4,7 +4,7 @@ groups:
 - name: maintenance.alerts
   rules:
   - alert: NodeInMaintenance
-    expr: kube_node_labels{label_cloud_sap_maintenance_state="in-maintenance"} == 1
+    expr: max by (node) (kube_node_labels{label_cloud_sap_maintenance_state="in-maintenance"}) == 1
     for: 2m
     labels:
       tier: {{ required ".Values.tier missing" .Values.tier }}


### PR DESCRIPTION
This PR introduces a new inhibition rule to prevent alerts for nodes in maintenance.
This is opt-in, by setting the label `inhibited-by: node-maintenance` on the alert that should be inhibited.