### PR TITLE
Nova: Derive name from job-script hash

### DIFF
--- a/openstack/nova/templates/_helpers.tpl
+++ b/openstack/nova/templates/_helpers.tpl
@@ -52,3 +52,21 @@ rabbit://{{ default "" .Values.global.user_suffix | print .Values.rabbitmq_cell2
 
   {{- end -}}
 {{- end -}}
+
+{{- define "job_metadata" }}
+  {{- $name := index . 1 }}
+  {{- with index . 0 }}
+labels:
+{{ tuple . .Release.Name $name | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 2 }}
+annotations:
+  bin-hash: {{ include (print .Template.BasePath "/bin/_" $name ".tpl") . | sha256sum }}
+  {{- end }}
+{{- end }}
+
+{{- define "job_name" }}
+  {{- $name := index . 1 }}
+  {{- with index . 0 }}
+    {{- $hash := include (print .Template.BasePath "/bin/_" $name ".tpl") . | sha256sum }}
+{{- .Release.Name }}-{{ $name }}-{{ substr 0 4 $hash }}-{{ .Values.imageVersion | required "Please set nova.imageVersion or similar"}}
+  {{- end }}
+{{- end }}

--- a/openstack/nova/templates/api-deployment.yaml
+++ b/openstack/nova/templates/api-deployment.yaml
@@ -48,7 +48,7 @@ spec:
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
             - name: DEPENDENCY_JOBS
-              value: nova-migration-{{.Values.imageVersion | required "Please set nova.imageVersion or similar"}}
+              value: {{ tuple . "db-migrate" | include "job_name" }}
             - name: DEPENDENCY_SERVICE
               value: "{{ .Release.Name }}-mariadb,{{ .Release.Name }}-api-mariadb,{{ .Release.Name }}-rabbitmq"
             - name: STATSD_HOST

--- a/openstack/nova/templates/api-metadata-deployment.yaml
+++ b/openstack/nova/templates/api-metadata-deployment.yaml
@@ -44,7 +44,7 @@ spec:
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
             - name: DEPENDENCY_JOBS
-              value: nova-migration-{{.Values.imageVersion | required "Please set nova.imageVersion or similar"}}
+              value: {{ tuple . "db-migrate" | include "job_name" }}
             - name: DEPENDENCY_SERVICE
               value: "{{ .Release.Name }}-mariadb,{{ .Release.Name }}-api-mariadb,{{ .Release.Name }}-rabbitmq"
             - name: STATSD_HOST

--- a/openstack/nova/templates/migration-job.yaml
+++ b/openstack/nova/templates/migration-job.yaml
@@ -4,7 +4,7 @@ metadata:
   # since this name changes with every image change, removal and creation of
   # this Job happens on nearly every deployment. Check the helm-chart changes
   # to see if this needs more review.
-  name: nova-migration-{{.Values.imageVersion | required "Please set nova.imageVersion or similar"}}
+  name: {{ tuple . "db-migrate" | include "job_name" }}
   labels:
     system: openstack
     type: configuration
@@ -12,10 +12,7 @@ metadata:
 spec:
   template:
     metadata:
-      labels:
-{{ tuple . "nova" "migration" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
-      annotations:
-        configmap-bin-hash: {{ include (print $.Template.BasePath "/bin-configmap.yaml") . | sha256sum }}
+      {{- tuple . "db-migrate" | include "job_metadata" | indent 6 }}
     spec:
       restartPolicy: OnFailure
       containers:

--- a/openstack/nova/templates/online-migration-job.yaml
+++ b/openstack/nova/templates/online-migration-job.yaml
@@ -4,7 +4,7 @@ metadata:
   # since this name changes with every image change, removal and creation of
   # this Job happens on nearly every deployment. Check the helm-chart changes
   # to see if this needs more review.
-  name: nova-online-migration-{{.Values.imageVersion | required "Please set nova.imageVersion or similar"}}
+  name: {{ tuple . "db-online-migrate" | include "job_name" }}
   labels:
     system: openstack
     type: configuration
@@ -12,14 +12,11 @@ metadata:
 spec:
   template:
     metadata:
-      labels:
-{{ tuple . "nova" "online-migration" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
-      annotations:
-        configmap-bin-hash: {{ include (print $.Template.BasePath "/bin-configmap.yaml") . | sha256sum }}
+      {{- tuple . "db-online-migrate" | include "job_metadata" | indent 6 }}
     spec:
       restartPolicy: OnFailure
       containers:
-      - name: nova-migration
+      - name: nova-migrate
         image: {{ required ".Values.global.registry is missing" .Values.global.registry}}/ubuntu-source-nova-api:{{.Values.imageVersionNovaApi | default .Values.imageVersionNova | default .Values.imageVersion | required "Please set nova.imageVersion or similar"}}
         imagePullPolicy: IfNotPresent
         command:
@@ -30,7 +27,7 @@ spec:
         - name: NAMESPACE
           value: {{ .Release.Namespace }}
         - name: DEPENDENCY_JOBS
-          value: nova-migration-{{.Values.imageVersion | required "Please set nova.imageVersion or similar"}}
+          value: {{ tuple . "db-migrate" | include "job_name" }}
         - name: DEPENDENCY_SERVICE
           value: "{{ .Release.Name }}-mariadb,{{ .Release.Name }}-api-mariadb{{ if eq .Values.cell2.enabled true }},{{ .Values.mariadb_cell2.name }}-mariadb{{ end }}"
         - name: PGAPPNAME

--- a/openstack/nova/templates/placement-api-deployment.yaml
+++ b/openstack/nova/templates/placement-api-deployment.yaml
@@ -42,7 +42,7 @@ spec:
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
             - name: DEPENDENCY_JOBS
-              value: nova-migration-{{.Values.imageVersion | required "Please set nova.imageVersion or similar"}}
+              value: {{ tuple . "db-migrate" | include "job_name" }}
             - name: DEPENDENCY_SERVICE
               value: "{{ .Release.Name }}-api-mariadb,{{ .Release.Name }}-rabbitmq"
             {{- if .Values.sentry.enabled }}

--- a/openstack/nova/templates/update-cells-job.yaml
+++ b/openstack/nova/templates/update-cells-job.yaml
@@ -12,10 +12,7 @@ metadata:
 spec:
   template:
     metadata:
-      labels:
-{{ tuple . "nova" "online-migration" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
-      annotations:
-        configmap-bin-hash: {{ include (print $.Template.BasePath "/bin-configmap.yaml") . | sha256sum }}
+      {{- tuple . "db-update-cells" | include "job_metadata" | indent 6 }}
     spec:
       restartPolicy: OnFailure
       containers:
@@ -30,7 +27,7 @@ spec:
         - name: NAMESPACE
           value: {{ .Release.Namespace }}
         - name: DEPENDENCY_JOBS
-          value: nova-migration-{{.Values.imageVersion | required "Please set nova.imageVersion or similar"}}
+          value: {{ tuple . "db-migrate" | include "job_name" }}
         - name: DEPENDENCY_SERVICE
           value: "{{ .Release.Name }}-mariadb,{{ .Release.Name }}-api-mariadb,{{ .Release.Name }}-rabbitmq"
         - name: PGAPPNAME


### PR DESCRIPTION
Scripts can change partly due to code change or configuration
values (cells), which would result in an annotation change.
But k8s doesn't do updates of jobs, so we end up with a deployment
failure.

By deriving the name from the hashed script (instead of the config)
we run the job newly on each change of the script or the image version.