### PR TITLE
[Cinder] Add the resource entry to log context

### DIFF
--- a/openstack/cinder/templates/etc/_cinder.conf.tpl
+++ b/openstack/cinder/templates/etc/_cinder.conf.tpl
@@ -1,6 +1,6 @@
 [DEFAULT]
 log_config_append = /etc/cinder/logging.ini
-logging_context_format_string = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [%(request_id)s g%(global_request_id)s %(user_identity)s] %(instance)s%(message)s
+logging_context_format_string = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [%(request_id)s g%(global_request_id)s %(user_identity)s] %(resource)s%(instance)s%(message)s
 
 backup_swift_url = https://objectstore-3.{{.Values.global.region}}.{{.Values.global.tld}}:443/v1/AUTH_
 backup_swift_auth_version = 2


### PR DESCRIPTION
This patch adds the %(resource)s to the log context in each cinder log
entry.  Various places in cinder debug log entries adds the
resource=volume_ref attribute.  For example:
https://github.com/sapcc/cinder/blob/stable/train-m3/cinder/volume/manager.py#L332-L333

https://github.com/sapcc/cinder/blob/stable/train-m3/cinder/volume/drivers/vmware/vmdk.py#L1201-L1202
https://github.com/sapcc/cinder/blob/stable/train-m3/cinder/volume/drivers/vmware/vmdk.py#L2900

This will result in the volume id being added to the log entry whenever
the LOG.debug() has the kwarg of resource=volume.  This will help
with tracking down what volume was being operated on in the logs.