### PR TITLE
VMsOnFailoverHost alert uplifted to critical

### DIFF
--- a/prometheus-exporters/vrops-exporter/alerts/host.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/host.alerts
@@ -62,7 +62,7 @@ groups:
       and on (hostsystem) count(vrops_virtualmachine_runtime_powerstate{virtualmachine!~"vCLS.*", state="Powered On"}) by (hostsystem) > 0
     for: 10m
     labels:
-      severity: warning
+      severity: critical
       tier: vmware
       service: compute
       context: "Failover host"


### PR DESCRIPTION
TARS no longer monitoring this alert hence alert moved to critical channel so Infraops colleagues can free-up failover hosts from running VMs. 