### PR TITLE
[infra-monitoring] update prometheus-server; add api-only ingress

### DIFF
--- a/system/infra-monitoring/Chart.yaml
+++ b/system/infra-monitoring/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: infra-monitoring
-version: 1.0.2
+version: 2.0.0
 description: Prometheus Infrastructure Monitoring and Metrics Collection
 maintainers:
   - name: Martin Vossen (D021500)

--- a/system/infra-monitoring/requirements.lock
+++ b/system/infra-monitoring/requirements.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: prometheus-server
   repository: https://charts.eu-de-2.cloud.sap
-  version: 4.2.2
+  version: 5.3.2
 - name: kube-state-metrics-exporter
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.7
@@ -53,5 +53,5 @@ dependencies:
 - name: prober-exporter
   repository: file://vendor/prober-exporter
   version: 0.1.0
-digest: sha256:f06fbea39d1db8cf007974836dad25bc4d045ed5c26ada4d5a289d2f31b9fda9
-generated: "2022-02-10T15:43:47.142486+01:00"
+digest: sha256:409aee60b8a7b62ad97c17dde86fb6b0ededef2f4eedcf416e65b376d7c452e9
+generated: "2022-03-22T12:07:43.930768+01:00"

--- a/system/infra-monitoring/requirements.yaml
+++ b/system/infra-monitoring/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
   - name: prometheus-server
     alias: prometheus_infra_collector
     repository: https://charts.eu-de-2.cloud.sap
-    version: 4.2.2
+    version: 5.3.2
     condition: prometheus_infra_collector.enabled
 
   - name: kube-state-metrics-exporter

--- a/system/infra-monitoring/values.yaml
+++ b/system/infra-monitoring/values.yaml
@@ -414,6 +414,11 @@ prometheus_infra_collector:
     hosts:
       - prometheus-infra-collector
 
+  internalIngress:
+    enabled: true
+    hosts:
+      - prometheus-infra-collector-internal
+
   persistence:
     enabled: true
     # prom-operator does not support other accessModes than RWO


### PR DESCRIPTION
This PR updates the openstack prometheus in preparation for the mandated OAUTH protection of the UI.
A second, internal ingress is added limited to the federation API endpoint.
Once this is rolled out, Prometheis further up in the federation chain must switch to the API ingress.
Please check this PR and deploy