### PR TITLE
[keystone-rabbitmq] use the default limits

### DIFF
--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -253,8 +253,6 @@ rabbitmq:
     requests:
       memory: 512Mi
       cpu: 1000m
-    limits:
-      cpu: 2000m
 
   nodeAffinity: {}
 


### PR DESCRIPTION
The load is higher now and the default limits are now used instead