### PR TITLE
[vrops-exporter] host alert severity increased

### DIFF
--- a/prometheus-exporters/vrops-exporter/alerts/host.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/host.alerts
@@ -9,7 +9,7 @@ groups:
       and on (hostsystem) count(vrops_virtualmachine_runtime_powerstate{virtualmachine!~"vCLS.*", state="Powered On"}) by (hostsystem) > 0
     for: 10m
     labels:
-      severity: warning
+      severity: critical
       tier: vmware
       service: compute
       context: "ESXi not responding"


### PR DESCRIPTION
re-increase the severity of `HostWithRunningVMsNotResponding`. Back after a problem.