### PR TITLE
Rabbitmq: Option for statefulSet without clustering

### DIFF
--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 0.2.20
+version: 0.3.0
 description: A Helm chart for RabbitMQ
 sources:
 - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/templates/headless-service.yaml
+++ b/common/rabbitmq/templates/headless-service.yaml
@@ -1,0 +1,19 @@
+{{- if eq .Values.kind "statefulset" }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}-pods
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    type: rabbitmq
+    component: {{ .Release.Name }}
+    system: openstack
+spec:
+  selector:
+    app: {{ template "fullname" . }}
+  publishNotReadyAddresses: true  # See https://www.rabbitmq.com/cluster-formation.html#peer-discovery-k8s
+  clusterIP: None
+{{- end }}

--- a/common/rabbitmq/templates/poddisruptionbudget.yml
+++ b/common/rabbitmq/templates/poddisruptionbudget.yml
@@ -1,0 +1,19 @@
+{{- if and (gt (int .Values.replicas) 1) .Values.pdr.enabled }}
+apiVersion: {{ if .Capabilities.APIVersions.Has "policy/v1" }}policy/v1{{ else }}policy/v1beta1{{ end }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    type: rabbitmq
+    component: {{ .Release.Name }}
+    system: openstack
+spec:
+  minAvailable: {{ .Values.pdr.minAvailable | quote }}
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
+{{- end }}

--- a/common/rabbitmq/templates/pvc.yaml
+++ b/common/rabbitmq/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+{{- if and (eq .Values.kind "deployment") .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/common/rabbitmq/templates/statefulset.yaml
+++ b/common/rabbitmq/templates/statefulset.yaml
@@ -1,6 +1,6 @@
-{{- if eq .Values.kind "deployment" }}
+{{- if eq .Values.kind "statefulset" }}
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ template "fullname" . }}
   labels:
@@ -14,13 +14,7 @@ metadata:
 spec:
   replicas: {{ .Values.replicas }}
   revisionHistoryLimit: {{ .Values.upgrades.revisionHistory }}
-  strategy:
-    type: {{ .Values.upgrades.podReplacementStrategy }}
-    {{ if eq .Values.upgrades.podReplacementStrategy "RollingUpdate" }}
-    rollingUpdate:
-      maxUnavailable: {{ .Values.upgrades.rollingUpdate.maxUnavailable }}
-      maxSurge: {{ .Values.upgrades.rollingUpdate.maxSurge }}
-    {{ end }}
+  serviceName: {{ template "fullname" . }}
   selector:
     matchLabels:
       app: {{ template "fullname" . }}
@@ -100,17 +94,31 @@ spec:
 {{- end }}
       priorityClassName: {{ default "openstack-service-critical" .Values.priority_class | quote }}
       volumes:
+      {{- if not .Values.persistence.enabled }}
         - name: rabbitmq-persistent-storage
-        {{- if .Values.persistence.enabled }}
-          persistentVolumeClaim:
-            claimName: {{ .Values.persistence.existingClaim | default (include "fullname" .) }}
-          {{- if gt (int .Values.replicas) 1 }}
-            {{- fail "Persistence doesn't work with kind Deployment, and more than one replica" }}
-          {{- end}}
-        {{- else }}
           emptyDir: {}
-        {{- end }}
+      {{- end }}
         - name: container-init
           configMap:
             name: {{ template "fullname" . }}-bin
+  {{- if .Values.persistence.enabled }}
+  volumeClaimTemplates:
+  - metadata:
+      name: rabbitmq-persistent-storage
+      labels:
+        app: {{ template "fullname" . }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+        heritage: "{{ .Release.Service }}"
+        component: rabbitmq
+    spec:
+      accessModes:
+      - {{ .Values.persistence.accessMode | quote }}
+      {{- if .Values.persistence.storageClass }}
+      storageClassName: {{ .Values.persistence.storageClass | quote }}
+      {{- end }}
+      resources:
+        requests:
+          storage: {{ .Values.persistence.size | quote }}
+  {{- end }}
 {{- end }}

--- a/common/rabbitmq/values.yaml
+++ b/common/rabbitmq/values.yaml
@@ -82,7 +82,11 @@ alerts:
   # Configurable service label of the alerts. Defaults to `.Release.Name`.
   # service:
 
-replicas: 1
+kind: deployment  # needs to be statefulset with persistence.enabled and ...
+replicas: 1       # replicas more than one. Clustering is currently not implemented
+pdr:
+  enabled: true
+  minAvailable: "51%" # 50% should technically be enough, but just to be safe
 
 upgrades:
   revisionHistory: 3


### PR DESCRIPTION
By default, this change doesn't change anything, except it
will raise an error when a deployment with more than one
replica with persistence enabled is requested, as this doesn't work.

One has to use a statefulset for that, but it is *not* a clustered
setup. The use-case is a special one for notifications:

We currently create for each service a single independent
rabbitmq, and the consumer connects to each of them.

If one goes down, no notifications can be send (over rabbitmq).

This allows us to spin up a statefulset with several independent
on the consumer side, let the producers connect to any of them,
and the consumer to all of them.

When one instance is down, the producer(s) can reconnect to
any of the remaining ones.
A Pod disruption budget ensures that at least one is up.

Clustering is not needed, as we do not need a consistent
state within rabbitmq, as we didn't have that before either.
We only need to ensure, that all messages put on the queues
will be delivered to the consumer.