### PR TITLE
[rabbitmq] Do not set hostname for statefulset

### DIFF
--- a/common/rabbitmq/templates/statefulset.yaml
+++ b/common/rabbitmq/templates/statefulset.yaml
@@ -38,7 +38,6 @@ spec:
 {{- include "rabbitmq_maintenance_affinity" . }}
 {{- include "rabbitmq_node_reinstall_affinity" . }}
 {{- end }}
-      hostname: {{ template "fullname" . }}
       containers:
       - name: rabbitmq
         image: "{{include "dockerHubMirror" .}}/{{ .Values.image }}:{{.Values.imageTag }}"


### PR DESCRIPTION
We (partly) use the statefulset to get predictable unique
hostnames, and all having the same one is breaking things