### PR TITLE
[nova] Support setting datastore_hagroup_regex for vmware

### DIFF
--- a/openstack/nova/templates/hypervisors/hypervisors-vmware-configmap-vct.yaml
+++ b/openstack/nova/templates/hypervisors/hypervisors-vmware-configmap-vct.yaml
@@ -64,6 +64,9 @@ template: |
       {{- if (or (not (hasKey .Values.compute.defaults.vmware "pbm_enabled")) (not .Values.compute.defaults.vmware.pbm_enabled)) }}
       datastore_regex = {= datastore_regex | quote =}
       {{- end }}
+      {%- if datastore_hagroup_regex %}
+      datastore_hagroup_regex = {= datastore_hagroup_regex | quote =}
+      {%- endif %}
       image_as_template = {{ .Values.compute.defaults.enable_image_as_template | default "False" }}
       {{- if .Values.vspc.nodeIP }}
       serial_port_service_uri = vmware-vspc


### PR DESCRIPTION
The vcenter-operator exposes the variable datastore_hagroup_regex if a
cluster contains datastores matching its regex. We use this to enable
the functionality in Nova, that splits ephemeral root disks between
hagroups.