### PR TITLE
[Cinder] Update cinder chart's requirements

### DIFF
--- a/openstack/cinder/requirements.lock
+++ b/openstack/cinder/requirements.lock
@@ -4,24 +4,24 @@ dependencies:
   version: 0.3.0
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.34
+  version: 0.3.49
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.2.3
+  version: 0.2.7
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.0.7
+  version: 0.0.10
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.2.17
+  version: 0.3.2
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.2.17
+  version: 0.3.2
 - name: region_check
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.2
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
-  version: 1.1.1
-digest: sha256:084233c24d7b089bf0ca594e33f0b40e63dd600ecbcf5060e5bd514d500bb2e6
-generated: "2022-03-04T17:18:37.585576+01:00"
+  version: 1.1.7
+digest: sha256:5d3b94edade2f97b48075224ca1d5c9c76f9f40fc10d6c7a554c001ba45a34b3
+generated: "2022-03-29T16:32:53.552869-04:00"

--- a/openstack/cinder/requirements.yaml
+++ b/openstack/cinder/requirements.yaml
@@ -4,27 +4,27 @@ dependencies:
     version: 0.3.0
   - name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.34
+    version: 0.3.49
     condition: mariadb.enabled
   - name: mysql_metrics
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.2.3
+    version: 0.2.7
     condition: mariadb.enabled
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.0.7
+    version: 0.0.10
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.2.17
+    version: 0.3.2
   - name: rabbitmq
     alias: rabbitmq_notifications
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.2.17
+    version: 0.3.2
   - name: region_check
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.1.2
   - name: redis
     alias: api-ratelimit-redis
     repository: https://charts.eu-de-2.cloud.sap
-    version: 1.1.1
+    version: 1.1.7
     condition: api_rate_limit.enabled


### PR DESCRIPTION
This patch updates the helm chart for cinder.  It updates
the requirements for
mariadb to 0.3.49
mysql_metrics to 0.2.7
memcached to 0.0.10
rabbitmq to 0.3.2
rabbitmq_notifications to 0.3.2