### PR TITLE
[nova] Bump memcached dependency

### DIFF
--- a/openstack/nova/requirements.lock
+++ b/openstack/nova/requirements.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 0.2.12
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.0.7
+  version: 0.0.10
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.12
@@ -29,5 +29,5 @@ dependencies:
 - name: region_check
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.2
-digest: sha256:b679005d3c05225f058a4157975bac4459917a2fbc4d720c1e5890090ee1e664
-generated: "2022-03-09T14:43:19.620075134+01:00"
+digest: sha256:0625d584b87925f3da468db3eb57b236e881ab9dc84ea4e5e5871ceb39630296
+generated: "2022-03-30T08:50:59.594947025+02:00"

--- a/openstack/nova/requirements.yaml
+++ b/openstack/nova/requirements.yaml
@@ -17,7 +17,7 @@ dependencies:
     version: 0.2.12
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.0.7
+    version: 0.0.10
   - name: rabbitmq
     alias: rabbitmq_notifications
     condition: audit.enabled


### PR DESCRIPTION
This brings us an image pulled from Keppel instead of dockerhub and adds
node reinstall affinity in addition to the already existing meintancne
node affinity.