### PR TITLE
[nova] Bump rabbitmq dependency to 0.3.2

### DIFF
--- a/openstack/nova/requirements.lock
+++ b/openstack/nova/requirements.lock
@@ -10,13 +10,13 @@ dependencies:
   version: 0.2.7
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.2.12
+  version: 0.3.2
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.0.10
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.2.12
+  version: 0.3.2
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.3.4
@@ -25,9 +25,9 @@ dependencies:
   version: 0.3.40
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.2.12
+  version: 0.3.2
 - name: region_check
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.2
-digest: sha256:0625d584b87925f3da468db3eb57b236e881ab9dc84ea4e5e5871ceb39630296
-generated: "2022-03-30T08:50:59.594947025+02:00"
+digest: sha256:5bd0b8d35a9e65a399f167b5efc2bbf12a548326dd40c48108d0142386be7e9d
+generated: "2022-03-30T10:46:46.021052541+02:00"

--- a/openstack/nova/requirements.yaml
+++ b/openstack/nova/requirements.yaml
@@ -14,7 +14,7 @@ dependencies:
     version: 0.2.7
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.2.12
+    version: 0.3.2
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.0.10
@@ -22,7 +22,7 @@ dependencies:
     alias: rabbitmq_notifications
     condition: audit.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.2.12
+    version: 0.3.2
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.3.4
@@ -35,7 +35,7 @@ dependencies:
     alias: rabbitmq_cell2
     condition: cell2.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.2.12
+    version: 0.3.2
   - name: region_check
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.1.2


### PR DESCRIPTION
Update to get affinity settings for k8s node reinstall.

With that we also get a faster readiness-check, relaxed probe timeouts
and RabbitMQNotReady alert updates to not trigger on the
notifications-rabbitmq being down.