### PR TITLE
[nova] Bump mariadb dependency to 0.3.50

### DIFF
--- a/openstack/nova/requirements.lock
+++ b/openstack/nova/requirements.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.40
+  version: 0.3.50
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.40
+  version: 0.3.50
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.7
@@ -22,12 +22,12 @@ dependencies:
   version: 0.3.4
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.40
+  version: 0.3.50
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.3.2
 - name: region_check
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.2
-digest: sha256:5bd0b8d35a9e65a399f167b5efc2bbf12a548326dd40c48108d0142386be7e9d
-generated: "2022-03-30T10:46:46.021052541+02:00"
+digest: sha256:b2d95121fd9a67ca9a0553beacc1cef0e8980d923f2c64bd5153b3c2c25b1359
+generated: "2022-03-30T11:22:15.032825407+02:00"

--- a/openstack/nova/requirements.yaml
+++ b/openstack/nova/requirements.yaml
@@ -2,12 +2,12 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.40
+    version: 0.3.50
   - name: mariadb
     alias: mariadb_api
     condition: mariadb_api.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.40
+    version: 0.3.50
   - condition: mariadb.enabled
     name: mysql_metrics
     repository: https://charts.eu-de-2.cloud.sap
@@ -30,7 +30,7 @@ dependencies:
     alias: mariadb_cell2
     condition: mariadb_cell2.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.40
+    version: 0.3.50
   - name: rabbitmq
     alias: rabbitmq_cell2
     condition: cell2.enabled


### PR DESCRIPTION
We update to get affinity settings for k8s nodes getting reinstalled.

By upgrading, we also get more warning logs to help in optimizing the
DBs and remove the DEX dependency for maridb-backup by using sap_id
oauth.