### PR TITLE
VcsaSslCertificateExpiry closing small gaps

### DIFF
--- a/prometheus-exporters/vrops-exporter/alerts/vcenter.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/vcenter.alerts
@@ -2,7 +2,7 @@ groups:
 - name: vcenter.alerts
   rules:
   - alert: VcsaSslCertificateExpiryWarning
-    expr: 15 > round(((vrops_vcenter_summary_certificate_expiry_date / 1000) - time()) / 86400) < 31
+    expr: 15 > round(((avg_over_time(vrops_vcenter_summary_certificate_expiry_date[10m]) / 1000) - time()) / 86400) < 31
     for: 20m
     labels:
       severity: warning
@@ -16,7 +16,7 @@ groups:
       summary: "SSL Certificate of vCSA {{ $labels.vcenter}} expires in {{ $value }} days. ({{ $labels.vcenter }}, {{ $labels.datacenter }})"
 
   - alert: VcsaSslCertificateExpiryCritical
-    expr: round(((vrops_vcenter_summary_certificate_expiry_date / 1000) - time()) / 86400) < 16
+    expr: round(((avg_over_time(vrops_vcenter_summary_certificate_expiry_date[10m]) / 1000) - time()) / 86400) < 16
     for: 20m
     labels:
       severity: critical


### PR DESCRIPTION
We encountered a small gap in the vrops_vcenter_summary_certificate_expiry_date metric, which caused a false resolve message.