### PR TITLE
[Cinder] Upgrade mariadb to 0.3.50

### DIFF
--- a/openstack/cinder/requirements.lock
+++ b/openstack/cinder/requirements.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.3.5
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.49
+  version: 0.3.50
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.7
@@ -23,5 +23,5 @@ dependencies:
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.1.7
-digest: sha256:e2b784fe5406bb41f70ba722febb9c66f873eeb4eeb5316c834d75eebe206ff8
-generated: "2022-04-01T15:47:43.323505664+02:00"
+digest: sha256:9b282ca030741869b4b1e7b220d96ece46da50f00b3001b98584739873308053
+generated: "2022-04-01T13:11:07.153539-04:00"

--- a/openstack/cinder/requirements.yaml
+++ b/openstack/cinder/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
     version: 0.3.5
   - name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.49
+    version: 0.3.50
     condition: mariadb.enabled
   - name: mysql_metrics
     repository: https://charts.eu-de-2.cloud.sap


### PR DESCRIPTION
This patch updates cinder requirement for Mariadb 0.3.50