### PR TITLE
lyra: migrate ingress to v1

### DIFF
--- a/openstack/lyra/templates/ingress.yaml
+++ b/openstack/lyra/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}
@@ -22,9 +22,12 @@ spec:
       http:
         paths:
         - path: /
+          pathType: Prefix
           backend:
-            serviceName: {{ $.Release.Name }} 
-            servicePort: {{ $.Values.service.externalPort }}
+            service:
+              name: {{ $.Release.Name }}
+              port:
+                number: {{ $.Values.service.externalPort }}
 {{- end }}
 {{- end }}
 

--- a/openstack/lyra/templates/omnitruck-ingress.yaml
+++ b/openstack/lyra/templates/omnitruck-ingress.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.omnitruck.enabled .Values.ingress.enabled }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-omnitruck
@@ -18,8 +18,11 @@ spec:
       http:
         paths:
         - path: /
+          pathType: Prefix
           backend:
-            serviceName: {{ .Release.Name }}-omnitruck
-            servicePort: {{ .Values.omnitruck.internalPort }}
+            service:
+              name: {{ .Release.Name }}-omnitruck
+              port:
+                number: {{ .Values.omnitruck.internalPort }}
 {{- end }}
 


### PR DESCRIPTION
In preparation for the next upgrade of our kubernetes clusters we
need to remove references to api versions that are no longer supported.

The next version of kubernetes 1.22 removes support for the `Ingress` resource
in version `networking.k8s.io/v1beta1`.

There are actually some minor structural changes to the `Ingress` object that
need to happen when migrating to `networking.k8s.io/v1`

This blog post goes into some detail about what changes are required:
https://awstip.com/upgrading-kubernetes-ingresses-from-v1beta1-to-v1-7f9235765332

This PR should contain the necesarry changes for the chart in question.

Please review and them them at you own discretion. Happy hacking!

Note: This PR was mass created so please validate and test the changes before rolling it to production.
