### PR TITLE
[cypress-dashboard]: migrate ingress to v1

### DIFF
--- a/common/cypress-dashboard/templates/ingress.yaml
+++ b/common/cypress-dashboard/templates/ingress.yaml
@@ -1,12 +1,12 @@
 # prettier-ignore
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: cypress-ingress
   annotations:
-    kubernetes.io/ingress.class: nginx
     kubernetes.io/tls-acme: "true"
 spec:
+  ingressClassName: nginx
   tls:
     - hosts:
         - "*.cypress.{{ .Values.region }}.cloud.sap"
@@ -16,27 +16,39 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: cypress-service
-              servicePort: 4000
+              service:
+                name: cypress-service
+                port:
+                  number: 4000
     - host: dashboard.cypress.{{ .Values.region }}.cloud.sap
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: cypress-service
-              servicePort: 8080
+              service:
+                name: cypress-service
+                port:
+                  number: 8080
     - host: director.cypress.{{ .Values.region }}.cloud.sap
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: cypress-service
-              servicePort: 1234
+              service:
+                name: cypress-service
+                port:
+                  number: 1234
     - host: storage.cypress.{{ .Values.region }}.cloud.sap
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: cypress-service
-              servicePort: 9000
+              service:
+                name: cypress-service
+                port:
+                  number: 9000


### PR DESCRIPTION
In preparation for the next upgrade of our kubernetes clusters we
need to remove references to api versions that are no longer supported.

The next version of kubernetes - 1.22 - removes support for the `Ingress` resource
in api version `networking.k8s.io/v1beta1`.

There are actually some minor structural changes to the `Ingress` object that
need to happen when migrating to `networking.k8s.io/v1`.

This blog post goes into some detail about what changes are required:
https://awstip.com/upgrading-kubernetes-ingresses-from-v1beta1-to-v1-7f9235765332

This PR should contain the necesarry changes for the chart in question.

Please review and merge at your own discretion. Happy hacking!

**Note: This PR was mass created, please validate and test the changes before rolling it to production.**
