### PR TITLE
[chartmuseum-sapcc]: migrate ingress to v1

### DIFF
--- a/global/chartmuseum-sapcc/vendor/chartmuseum/templates/ingress.yaml
+++ b/global/chartmuseum-sapcc/vendor/chartmuseum/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $serviceName := include "chartmuseum.fullname" . -}}
 {{- if .Values.ingress.enabled }}
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "chartmuseum.fullname" . }}
@@ -20,9 +20,12 @@ spec:
     http:
       paths:
       - path: {{ default "/" .path | quote }}
+        pathType: ImplementationSpecific
         backend:
-          serviceName: {{ default $serviceName .serviceName }}
-          servicePort: {{ default $servicePort .servicePort }}
+          service:
+            name: {{ default $serviceName .serviceName }}
+            port:
+              number: {{ default $servicePort .servicePort }}
   {{- end }}
   tls:
   {{- range .Values.ingress.hosts }}


### PR DESCRIPTION
In preparation for the next upgrade of our kubernetes clusters we
need to remove references to api versions that are no longer supported.

The next version of kubernetes - 1.22 - removes support for the `Ingress` resource
in api version `networking.k8s.io/v1beta1`.

There are actually some minor structural changes to the `Ingress` object that
need to happen when migrating to `networking.k8s.io/v1`.

This blog post goes into some detail about what changes are required:
https://awstip.com/upgrading-kubernetes-ingresses-from-v1beta1-to-v1-7f9235765332

This PR should contain the necesarry changes for the chart in question.

Please review and merge at your own discretion. Happy hacking!

**Note: This PR was mass created, please validate and test the changes before rolling it to production.**
