### PR TITLE
[concourse]: migrate ingress to v1

### DIFF
--- a/global/concourse/templates/git-resource-proxy.yaml
+++ b/global/concourse/templates/git-resource-proxy.yaml
@@ -47,21 +47,25 @@ spec:
         ports:
         - containerPort: 8080
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: git-resource-proxy
   annotations:
-    kubernetes.io/ingress.class: "git-proxy"
     nginx.ingress.kubernetes.io/load-balance: "least_conn"
 spec:
+  ingressClassName: "git-proxy"
   rules:
   - host: git-resource-proxy
     http:
       paths:
-      - backend:
-          serviceName: git-resource-proxy-svc
-          servicePort: 8080
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: git-resource-proxy-svc
+            port:
+              number: 8080
 ---
 apiVersion: v1
 kind: Service

--- a/global/concourse/templates/webhook-broadcaster-ingress.yaml
+++ b/global/concourse/templates/webhook-broadcaster-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: webhook-broadcaster
@@ -12,9 +12,13 @@ spec:
   - host: webhook.{{ .Values.concourse.concourse.web.externalDomain }}
     http:
       paths:
-      - backend:
-          serviceName: webhook-broadcaster
-          servicePort: 8080
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: webhook-broadcaster
+            port:
+              number: 8080
   tls:
   - hosts:
     - webhook.{{ .Values.concourse.concourse.web.externalDomain }}


### PR DESCRIPTION
In preparation for the next upgrade of our kubernetes clusters we
need to remove references to api versions that are no longer supported.

The next version of kubernetes - 1.22 - removes support for the `Ingress` resource
in api version `networking.k8s.io/v1beta1`.

There are actually some minor structural changes to the `Ingress` object that
need to happen when migrating to `networking.k8s.io/v1`.

This blog post goes into some detail about what changes are required:
https://awstip.com/upgrading-kubernetes-ingresses-from-v1beta1-to-v1-7f9235765332

This PR should contain the necesarry changes for the chart in question.

Please review and merge at your own discretion. Happy hacking!

**Note: This PR was mass created, please validate and test the changes before rolling it to production.**
