### PR TITLE
[supernova]: migrate ingress to v1

### DIFF
--- a/global/supernova/templates/ingress.yaml
+++ b/global/supernova/templates/ingress.yaml
@@ -1,21 +1,19 @@
 # prettier-ignore
 {{- if .Values.ingress.enabled }}
 kind: Ingress
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 
 metadata:
   name: supernova
   annotations:
     ingress.kubernetes.io/affinity: "cookie"
-
-{{- if .Values.ingress.internet_facing }}
-    ingress.kubernetes.io/ingress.class: "nginx-internet"
-    kubernetes.io/ingress.class: "nginx-internet"
-{{- end }}  
     ingress.kubernetes.io/ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 
 spec:
+{{- if .Values.ingress.internet_facing }}
+  ingressClassName: "nginx-internet"
+{{- end }}  
   tls:
      - secretName: supernova
        hosts: [{{ .Values.ingress.host }}]
@@ -24,7 +22,10 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: supernova
-          servicePort: 80
+          service:
+            name: supernova
+            port:
+              number: 80
 {{- end }}


### PR DESCRIPTION
In preparation for the next upgrade of our kubernetes clusters we
need to remove references to api versions that are no longer supported.

The next version of kubernetes - 1.22 - removes support for the `Ingress` resource
in api version `networking.k8s.io/v1beta1`.

There are actually some minor structural changes to the `Ingress` object that
need to happen when migrating to `networking.k8s.io/v1`.

This blog post goes into some detail about what changes are required:
https://awstip.com/upgrading-kubernetes-ingresses-from-v1beta1-to-v1-7f9235765332

This PR should contain the necesarry changes for the chart in question.

Please review and merge at your own discretion. Happy hacking!

**Note: This PR was mass created, please validate and test the changes before rolling it to production.**
