### PR TITLE
[blackbox]: migrate ingress to v1

### DIFF
--- a/openstack/blackbox/charts/blackbox-tests-certificates/templates/cc3test-ingress.yaml
+++ b/openstack/blackbox/charts/blackbox-tests-certificates/templates/cc3test-ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.cc3test_cert.enabled }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 
 metadata:
@@ -10,8 +10,10 @@ metadata:
 
 spec:
   backend:
-    serviceName: quay-enterprise
-    servicePort: 9090
+    service:
+      name: quay-enterprise
+      port:
+        number: 9090
   tls:
     - secretName: cc3test-digicert
       hosts: [cc3test.global.cloud.sap]


### PR DESCRIPTION
In preparation for the next upgrade of our kubernetes clusters we
need to remove references to api versions that are no longer supported.

The next version of kubernetes - 1.22 - removes support for the `Ingress` resource
in api version `networking.k8s.io/v1beta1`.

There are actually some minor structural changes to the `Ingress` object that
need to happen when migrating to `networking.k8s.io/v1`.

This blog post goes into some detail about what changes are required:
https://awstip.com/upgrading-kubernetes-ingresses-from-v1beta1-to-v1-7f9235765332

This PR should contain the necesarry changes for the chart in question.

Please review and merge at your own discretion. Happy hacking!

**Note: This PR was mass created, please validate and test the changes before rolling it to production.**
