### PR TITLE
[clair]: migrate ingress to v1

### DIFF
--- a/openstack/clair/templates/ingress.yaml
+++ b/openstack/clair/templates/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 
 metadata:
@@ -16,6 +16,9 @@ spec:
       http:
         paths:
         - path: /
+          pathType: Prefix
           backend:
-            serviceName: clair
-            servicePort: 8080
+            service:
+              name: clair
+              port:
+                number: 8080


### PR DESCRIPTION
In preparation for the next upgrade of our kubernetes clusters we
need to remove references to api versions that are no longer supported.

The next version of kubernetes - 1.22 - removes support for the `Ingress` resource
in api version `networking.k8s.io/v1beta1`.

There are actually some minor structural changes to the `Ingress` object that
need to happen when migrating to `networking.k8s.io/v1`.

This blog post goes into some detail about what changes are required:
https://awstip.com/upgrading-kubernetes-ingresses-from-v1beta1-to-v1-7f9235765332

This PR should contain the necesarry changes for the chart in question.

Please review and merge at your own discretion. Happy hacking!

**Note: This PR was mass created, please validate and test the changes before rolling it to production.**
