### PR TITLE
[cronus]: migrate ingress to v1

### DIFF
--- a/openstack/cronus/templates/cronus/ingress.yaml
+++ b/openstack/cronus/templates/cronus/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.cronus.enabled -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: cronus
@@ -16,9 +16,12 @@ spec:
       http:
         paths:
           - backend:
-              serviceName: cronus
-              servicePort: http
+              service:
+                name: cronus
+                port:
+                  name: http
             path: /
+            pathType: Prefix
   tls:
     - hosts:
       - cronus.{{ .Values.global.region }}.{{ .Values.global.tld }}

--- a/openstack/cronus/templates/nebula/ingress.yaml
+++ b/openstack/cronus/templates/nebula/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.nebula.enabled -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: nebula
@@ -16,9 +16,12 @@ spec:
       http:
         paths:
           - backend:
-              serviceName: nebula
-              servicePort: {{ .Values.nebula.http }}
+              service:
+                name: nebula
+                port:
+                  number: {{ .Values.nebula.http }}
             path: /
+            pathType: Prefix
   tls:
     - hosts:
       - nebula.{{ .Values.global.region }}.{{ .Values.global.tld }}


### PR DESCRIPTION
In preparation for the next upgrade of our kubernetes clusters we
need to remove references to api versions that are no longer supported.

The next version of kubernetes - 1.22 - removes support for the `Ingress` resource
in api version `networking.k8s.io/v1beta1`.

There are actually some minor structural changes to the `Ingress` object that
need to happen when migrating to `networking.k8s.io/v1`.

This blog post goes into some detail about what changes are required:
https://awstip.com/upgrading-kubernetes-ingresses-from-v1beta1-to-v1-7f9235765332

This PR should contain the necesarry changes for the chart in question.

Please review and merge at your own discretion. Happy hacking!

**Note: This PR was mass created, please validate and test the changes before rolling it to production.**
