### PR TITLE
[designate]: migrate ingress to v1

### DIFF
--- a/openstack/designate/templates/api-ingress.yaml
+++ b/openstack/designate/templates/api-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 
 metadata:
@@ -9,10 +9,10 @@ metadata:
     component: designate
   annotations:
     kubernetes.io/tls-acme: "true"
-{{- if .Values.global_setup }}
-    kubernetes.io/ingress.class: "nginx-external"
-{{- end }}
 spec:
+{{- if .Values.global_setup }}
+  ingressClasName: "nginx-external"
+{{- end }}
   tls:
 {{- if .Values.global.designate_public_api }}
     - secretName: tls-{{ .Values.global.designate_public_api | replace "." "-" }}
@@ -30,10 +30,9 @@ spec:
       http:
         paths:
         - path: /
+          pathType: Prefix
           backend:
-{{- if .Values.global_setup }}
-            serviceName: designate-global-api
-{{- else }}
-            serviceName: designate-api
-{{- end }}
-            servicePort: {{.Values.global.designate_api_port_internal}}
+            service:
+              name: {{ if .Values.global_setup }}designate-global-api{{ else }}designate-api{{ end }}
+              port:
+                number: {{.Values.global.designate_api_port_internal}}


### PR DESCRIPTION
In preparation for the next upgrade of our kubernetes clusters we
need to remove references to api versions that are no longer supported.

The next version of kubernetes - 1.22 - removes support for the `Ingress` resource
in api version `networking.k8s.io/v1beta1`.

There are actually some minor structural changes to the `Ingress` object that
need to happen when migrating to `networking.k8s.io/v1`.

This blog post goes into some detail about what changes are required:
https://awstip.com/upgrading-kubernetes-ingresses-from-v1beta1-to-v1-7f9235765332

This PR should contain the necesarry changes for the chart in question.

Please review and merge at your own discretion. Happy hacking!

**Note: This PR was mass created, please validate and test the changes before rolling it to production.**
