### PR TITLE
[elektra]: migrate ingress to v1

### DIFF
--- a/openstack/elektra/templates/ingress.yaml
+++ b/openstack/elektra/templates/ingress.yaml
@@ -11,7 +11,7 @@ data:
 {{- end }}
 
 kind: Ingress
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 
 metadata:
   name: elektra
@@ -39,14 +39,17 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: elektra
-          servicePort: 80
+          service:
+            name: elektra
+            port:
+              number: 80
 # additional domain for e2e tests
 {{- if .Values.ingress.e2e_domain }}
 ---
 kind: Ingress
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 
 metadata:
   name: elektra-e2e
@@ -71,8 +74,10 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: elektra
-          servicePort: 80
-{{- end }}     
+          service:
+            name: elektra
+            port:
+              number: 80
+{{- end }}
 
 {{- end }}

--- a/openstack/elektra/templates/ingress_rsa.yaml
+++ b/openstack/elektra/templates/ingress_rsa.yaml
@@ -2,7 +2,7 @@
 # instead it enables the builtin TFA method
 {{- if .Values.ingress.enabled }}
 kind: Ingress
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 
 metadata:
   name: elektra-rsa
@@ -28,8 +28,10 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: elektra
-          servicePort: 80
-    
+          service:
+            name: elektra
+            port:
+              number: 80
 {{- end }}


### PR DESCRIPTION
In preparation for the next upgrade of our kubernetes clusters we
need to remove references to api versions that are no longer supported.

The next version of kubernetes - 1.22 - removes support for the `Ingress` resource
in api version `networking.k8s.io/v1beta1`.

There are actually some minor structural changes to the `Ingress` object that
need to happen when migrating to `networking.k8s.io/v1`.

This blog post goes into some detail about what changes are required:
https://awstip.com/upgrading-kubernetes-ingresses-from-v1beta1-to-v1-7f9235765332

This PR should contain the necesarry changes for the chart in question.

Please review and merge at your own discretion. Happy hacking!

**Note: This PR was mass created, please validate and test the changes before rolling it to production.**
