### PR TITLE
[grafanasix]: migrate ingress to v1

### DIFF
--- a/openstack/grafanasix/templates/grafana-ingress.yaml
+++ b/openstack/grafanasix/templates/grafana-ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled }}
 kind: Ingress
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 
 metadata:
   name: grafana
@@ -22,13 +22,16 @@ spec:
       http:
         paths:
         - path: /
+          pathType: Prefix
           backend:
-            serviceName: grafana
-            servicePort: {{.Values.grafana.endpoint.port.public}}
+            service:
+              name: grafana
+              port:
+                number: {{.Values.grafana.endpoint.port.public}}
 {{- if .Values.ingress.global }}
---- 
+---
 kind: Ingress
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 
 metadata:
   name: grafana-global
@@ -51,8 +54,11 @@ spec:
       http:
         paths:
         - path: /
+          pathType: Prefix
           backend:
-            serviceName: grafana
-            servicePort: {{.Values.grafana.endpoint.port.public}}
+            service:
+              name: grafana
+              port:
+                number: {{.Values.grafana.endpoint.port.public}}
 {{- end }}
 {{- end }}

--- a/openstack/grafanasix/templates/nginx-ingress.yaml
+++ b/openstack/grafanasix/templates/nginx-ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.nginx.enabled }}
 kind: Ingress
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 
 metadata:
   name: grafana-kiosk
@@ -19,7 +19,10 @@ spec:
       http:
         paths:
         - path: /
+          pathType: Prefix
           backend:
-            serviceName: grafana
-            servicePort: {{.Values.nginx.endpoint.port.public}}
+            service:
+              name: grafana
+              port:
+                number: {{.Values.nginx.endpoint.port.public}}
 {{- end }}


### PR DESCRIPTION
In preparation for the next upgrade of our kubernetes clusters we
need to remove references to api versions that are no longer supported.

The next version of kubernetes - 1.22 - removes support for the `Ingress` resource
in api version `networking.k8s.io/v1beta1`.

There are actually some minor structural changes to the `Ingress` object that
need to happen when migrating to `networking.k8s.io/v1`.

This blog post goes into some detail about what changes are required:
https://awstip.com/upgrading-kubernetes-ingresses-from-v1beta1-to-v1-7f9235765332

This PR should contain the necesarry changes for the chart in question.

Please review and merge at your own discretion. Happy hacking!

**Note: This PR was mass created, please validate and test the changes before rolling it to production.**
