### PR TITLE
[keppel]: migrate ingress to v1

### DIFF
--- a/openstack/keppel/templates/ingress-api.yaml
+++ b/openstack/keppel/templates/ingress-api.yaml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 
 metadata:
   name: keppel-api
@@ -19,21 +19,27 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: keppel-api
-              servicePort: 80
+              service:
+                name: keppel-api
+                port:
+                  number: 80
     - host: '*.keppel.{{ .Values.global.region }}.{{ .Values.global.tld }}'
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: keppel-api
-              servicePort: 80
+              service:
+                name: keppel-api
+                port:
+                  number: 80
 
 {{- if .Values.keppel.anycast_domain_name }}
 ---
 kind: Ingress
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 
 metadata:
   name: keppel-api-san
@@ -52,14 +58,20 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: keppel-api
-              servicePort: 80
+              service:
+                name: keppel-api
+                port:
+                  number: 80
     - host: '*.{{ .Values.keppel.anycast_domain_name }}'
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: keppel-api
-              servicePort: 80
+              service:
+                name: keppel-api
+                port:
+                  number: 80
 {{ end }}


### PR DESCRIPTION
In preparation for the next upgrade of our kubernetes clusters we
need to remove references to api versions that are no longer supported.

The next version of kubernetes - 1.22 - removes support for the `Ingress` resource
in api version `networking.k8s.io/v1beta1`.

There are actually some minor structural changes to the `Ingress` object that
need to happen when migrating to `networking.k8s.io/v1`.

This blog post goes into some detail about what changes are required:
https://awstip.com/upgrading-kubernetes-ingresses-from-v1beta1-to-v1-7f9235765332

This PR should contain the necesarry changes for the chart in question.

Please review and merge at your own discretion. Happy hacking!

**Note: This PR was mass created, please validate and test the changes before rolling it to production.**
