### PR TITLE
[keystone]: migrate ingress to v1

### DIFF
--- a/openstack/keystone/templates/ingress-api.yaml
+++ b/openstack/keystone/templates/ingress-api.yaml
@@ -36,7 +36,7 @@ data:
 ---
 {{- end }}
 {{- end }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}
@@ -84,11 +84,9 @@ spec:
       http:
         paths:
         - path: /
+          pathType: Prefix
           backend:
-{{- if .Values.global_setup }}
-            serviceName: keystone-global
-{{- else }}
-            serviceName: keystone
-{{- end }}
-            servicePort: 5000
-{{- end }}
+            service:
+              name: "{{if .Values.global_setup }}keystone-global{{else}}keystone{{end}}"
+              port:
+                number: 5000

--- a/openstack/keystone/templates/ingress-api.yaml
+++ b/openstack/keystone/templates/ingress-api.yaml
@@ -90,3 +90,4 @@ spec:
               name: "{{if .Values.global_setup }}keystone-global{{else}}keystone{{end}}"
               port:
                 number: 5000
+{{- end }}


### PR DESCRIPTION
In preparation for the next upgrade of our kubernetes clusters we
need to remove references to api versions that are no longer supported.

The next version of kubernetes - 1.22 - removes support for the `Ingress` resource
in api version `networking.k8s.io/v1beta1`.

There are actually some minor structural changes to the `Ingress` object that
need to happen when migrating to `networking.k8s.io/v1`.

This blog post goes into some detail about what changes are required:
https://awstip.com/upgrading-kubernetes-ingresses-from-v1beta1-to-v1-7f9235765332

This PR should contain the necesarry changes for the chart in question.

Please review and merge at your own discretion. Happy hacking!

**Note: This PR was mass created, please validate and test the changes before rolling it to production.**
