### PR TITLE
[kos-operator]: migrate ingress to v1

### DIFF
--- a/openstack/kos-operator/templates/clusterrole.yaml
+++ b/openstack/kos-operator/templates/clusterrole.yaml
@@ -63,14 +63,12 @@ rules:
     verbs:
       - '*'
 {{- end }}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
   - apiGroups:
       - networking.k8s.io
     resources:
       - ingresses
     verbs:
       - '*'
-{{- end }}
 # KosQueries might use k8s to query stuff
   - apiGroups:
       - ""


### PR DESCRIPTION
In preparation for the next upgrade of our kubernetes clusters we
need to remove references to api versions that are no longer supported.

The next version of kubernetes - 1.22 - removes support for the `Ingress` resource
in api version `networking.k8s.io/v1beta1`.

There are actually some minor structural changes to the `Ingress` object that
need to happen when migrating to `networking.k8s.io/v1`.

This blog post goes into some detail about what changes are required:
https://awstip.com/upgrading-kubernetes-ingresses-from-v1beta1-to-v1-7f9235765332

This PR should contain the necesarry changes for the chart in question.

Please review and merge at your own discretion. Happy hacking!

**Note: This PR was mass created, please validate and test the changes before rolling it to production.**
