### PR TITLE
[limes]: migrate ingress to v1

### DIFF
--- a/openstack/limes/templates/api-ingress.yaml
+++ b/openstack/limes/templates/api-ingress.yaml
@@ -1,7 +1,7 @@
 {{- $domain := printf "limes-3.%s.%s" .Values.global.region .Values.global.tld -}}
 
 kind: Ingress
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 
 metadata:
   name: limes-api-ccloud
@@ -19,6 +19,9 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: limes-api-ccloud
-              servicePort: 80
+              service:
+                name: limes-api-ccloud
+                port:
+                  number: 80


### PR DESCRIPTION
In preparation for the next upgrade of our kubernetes clusters we
need to remove references to api versions that are no longer supported.

The next version of kubernetes - 1.22 - removes support for the `Ingress` resource
in api version `networking.k8s.io/v1beta1`.

There are actually some minor structural changes to the `Ingress` object that
need to happen when migrating to `networking.k8s.io/v1`.

This blog post goes into some detail about what changes are required:
https://awstip.com/upgrading-kubernetes-ingresses-from-v1beta1-to-v1-7f9235765332

This PR should contain the necesarry changes for the chart in question.

Please review and merge at your own discretion. Happy hacking!

**Note: This PR was mass created, please validate and test the changes before rolling it to production.**
