### PR TITLE
[maia]: migrate ingress to v1

### DIFF
--- a/openstack/maia/templates/maia-ingress.yaml
+++ b/openstack/maia/templates/maia-ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.maia.enabled }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 
 metadata:
@@ -19,9 +19,12 @@ spec:
       http:
         paths:
         - path: /
+          pathType: Prefix
           backend:
-            serviceName: maia
-            servicePort: {{.Values.maia.listen_port}}
+            service:
+              name: maia
+              port:
+                number: {{.Values.maia.listen_port}}
 # uncomment to expose Prometheus UI instead of Maia
 #            serviceName: prometheus-maia
 #            servicePort: 9090 


### PR DESCRIPTION
In preparation for the next upgrade of our kubernetes clusters we
need to remove references to api versions that are no longer supported.

The next version of kubernetes - 1.22 - removes support for the `Ingress` resource
in api version `networking.k8s.io/v1beta1`.

There are actually some minor structural changes to the `Ingress` object that
need to happen when migrating to `networking.k8s.io/v1`.

This blog post goes into some detail about what changes are required:
https://awstip.com/upgrading-kubernetes-ingresses-from-v1beta1-to-v1-7f9235765332

This PR should contain the necesarry changes for the chart in question.

Please review and merge at your own discretion. Happy hacking!

**Note: This PR was mass created, please validate and test the changes before rolling it to production.**
