### PR TITLE
[neutron]: migrate ingress to v1

### DIFF
--- a/openstack/neutron/templates/ingress-server.yaml
+++ b/openstack/neutron/templates/ingress-server.yaml
@@ -1,5 +1,5 @@
 {{- $ussuri := hasPrefix "ussuri" (default .Values.imageVersion .Values.imageVersionServerAPI) -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 
 metadata:
@@ -22,14 +22,17 @@ spec:
         paths:
         {{- if $ussuri }}
         - path: /v2.0/lbaas
-          {{- if ge (.Capabilities.KubeVersion.Minor | atoi) 18 }}
           pathType: Prefix
-          {{- end }}
           backend:
-            serviceName: octavia-api
-            servicePort: {{.Values.global.octavia_api_port_internal | default 9876}}
+            service:
+              name: octavia-api
+              port:
+                number: {{.Values.global.octavia_api_port_internal | default 9876}}
         {{- end }}
         - path: /
+          pathType: Prefix
           backend:
-            serviceName: neutron-server
-            servicePort: {{.Values.global.neutron_api_port_internal | default 9696}}
+            service:
+              name: neutron-server
+              port:
+                number: {{.Values.global.neutron_api_port_internal | default 9696}}

--- a/openstack/neutron/templates/sftp-ingress.yaml
+++ b/openstack/neutron/templates/sftp-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 
 metadata:
@@ -26,6 +26,9 @@ spec:
       http:
         paths:
         - path: /
+          pathType: Prefix
           backend:
-            serviceName: sftp
-            servicePort: 10022
+            service:
+              name: sftp
+              port:
+                name: 10022

--- a/openstack/neutron/templates/sftp-ingress.yaml
+++ b/openstack/neutron/templates/sftp-ingress.yaml
@@ -31,4 +31,4 @@ spec:
             service:
               name: sftp
               port:
-                name: 10022
+                number: 10022


### PR DESCRIPTION
In preparation for the next upgrade of our kubernetes clusters we
need to remove references to api versions that are no longer supported.

The next version of kubernetes - 1.22 - removes support for the `Ingress` resource
in api version `networking.k8s.io/v1beta1`.

There are actually some minor structural changes to the `Ingress` object that
need to happen when migrating to `networking.k8s.io/v1`.

This blog post goes into some detail about what changes are required:
https://awstip.com/upgrading-kubernetes-ingresses-from-v1beta1-to-v1-7f9235765332

This PR should contain the necesarry changes for the chart in question.

Please review and merge at your own discretion. Happy hacking!

**Note: This PR was mass created, please validate and test the changes before rolling it to production.**
