### PR TITLE
[nova]: migrate ingress to v1

### DIFF
--- a/openstack/nova/templates/api-ingress.yaml
+++ b/openstack/nova/templates/api-ingress.yaml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 
 metadata:
   name: nova-api
@@ -22,6 +22,9 @@ spec:
       http:
         paths:
         - path: /
+          pathType: Prefix
           backend:
-            serviceName: nova-api
-            servicePort: {{.Values.global.novaApiPortInternal}}
+            service:
+              name: nova-api
+              port:
+                number: {{.Values.global.novaApiPortInternal}}

--- a/openstack/nova/templates/console-ingress.yaml
+++ b/openstack/nova/templates/console-ingress.yaml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 
 metadata:
   name: nova-console
@@ -30,9 +30,12 @@ spec:
       {{- range $name, $config := .Values.consoles }}
         {{- if $config.enabled }}
       - path: /{{ $name }}/?(.*)
+        pathType: Prefix
         backend:
-          serviceName: nova-console-{{ $name }}
-          servicePort: {{ $name }}
+          service:
+            name: nova-console-{{ $name }}
+            port:
+              name: {{ $name }}
         {{- end }}
       {{- end }}
 

--- a/openstack/nova/templates/placement-ingress.yaml
+++ b/openstack/nova/templates/placement-ingress.yaml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 
 metadata:
   name: nova-placement-api
@@ -22,6 +22,9 @@ spec:
       http:
         paths:
         - path: /
+          pathType: Prefix
           backend:
-            serviceName: nova-placement-api
-            servicePort: {{.Values.global.placementApiPortInternal}}
+            service:
+              name: nova-placement-api
+              port:
+                number: {{.Values.global.placementApiPortInternal}}


### PR DESCRIPTION
In preparation for the next upgrade of our kubernetes clusters we
need to remove references to api versions that are no longer supported.

The next version of kubernetes - 1.22 - removes support for the `Ingress` resource
in api version `networking.k8s.io/v1beta1`.

There are actually some minor structural changes to the `Ingress` object that
need to happen when migrating to `networking.k8s.io/v1`.

This blog post goes into some detail about what changes are required:
https://awstip.com/upgrading-kubernetes-ingresses-from-v1beta1-to-v1-7f9235765332

This PR should contain the necesarry changes for the chart in question.

Please review and merge at your own discretion. Happy hacking!

**Note: This PR was mass created, please validate and test the changes before rolling it to production.**
