### PR TITLE
[audit-logs]: migrate ingress to v1

### DIFF
--- a/system/audit-logs/vendor/logstash-audit-external/templates/ingress.yaml
+++ b/system/audit-logs/vendor/logstash-audit-external/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{ if eq .Values.global.clusterType  "scaleout" -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 
 metadata:
@@ -17,7 +17,10 @@ spec:
       http:
         paths:
         - path: /
+          pathType: Prefix
           backend:
-            serviceName: logstash-audit-external
-            servicePort: {{.Values.input_http_port}}
+            service:
+              name: logstash-audit-external
+              port:
+                number: {{.Values.input_http_port}}
 {{- end }}


### PR DESCRIPTION
In preparation for the next upgrade of our kubernetes clusters we
need to remove references to api versions that are no longer supported.

The next version of kubernetes - 1.22 - removes support for the `Ingress` resource
in api version `networking.k8s.io/v1beta1`.

There are actually some minor structural changes to the `Ingress` object that
need to happen when migrating to `networking.k8s.io/v1`.

This blog post goes into some detail about what changes are required:
https://awstip.com/upgrading-kubernetes-ingresses-from-v1beta1-to-v1-7f9235765332

This PR should contain the necesarry changes for the chart in question.

Please review and merge at your own discretion. Happy hacking!

**Note: This PR was mass created, please validate and test the changes before rolling it to production.**
