### PR TITLE
[infra-monitoring]: migrate ingress to v1

### DIFF
--- a/system/infra-monitoring/vendor/blackbox-exporter/templates/ingress.yaml
+++ b/system/infra-monitoring/vendor/blackbox-exporter/templates/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 
 metadata:
@@ -22,6 +22,9 @@ spec:
       http:
         paths:
         - path: /
+          pathType: Prefix
           backend:
-            serviceName: {{ include "infraMonitoring.fullname" . }}
-            servicePort: {{ .Values.service.port }}
+            service:
+              name: {{ include "infraMonitoring.fullname" . }}
+              port:
+                number: {{ .Values.service.port }}

--- a/system/infra-monitoring/vendor/cloudprober-exporter/templates/ingress.yaml
+++ b/system/infra-monitoring/vendor/cloudprober-exporter/templates/ingress.yaml
@@ -4,7 +4,7 @@
 {{- range $i, $prober := .Values.probers }}
 {{ if ne $i 0 }}---{{ end }}
 
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 
 metadata:
@@ -25,17 +25,26 @@ spec:
       http:
         paths:
         - path: /metrics
+          pathType: Prefix
           backend:
-            serviceName: cloudprober-exporter-{{ $prober.name }}
-            servicePort: 9313
+            service:
+              name: cloudprober-exporter-{{ $prober.name }}
+              port:
+                number: 9313
         - path: /config
+          pathType: Prefix
           backend:
-            serviceName: cloudprober-exporter-{{ $prober.name }}
-            servicePort: 9313
+            service:
+              name: cloudprober-exporter-{{ $prober.name }}
+            port:
+              number: 9313
         - path: /web
+          pathType: Prefix
           backend:
-            serviceName: cloudprober-exporter-{{ $prober.name }}
-            servicePort: 1080
+            service:
+              name: cloudprober-exporter-{{ $prober.name }}
+              port:
+                number: 1080
 ---
 {{- end }}
 {{- end }}


### PR DESCRIPTION
In preparation for the next upgrade of our kubernetes clusters we
need to remove references to api versions that are no longer supported.

The next version of kubernetes - 1.22 - removes support for the `Ingress` resource
in api version `networking.k8s.io/v1beta1`.

There are actually some minor structural changes to the `Ingress` object that
need to happen when migrating to `networking.k8s.io/v1`.

This blog post goes into some detail about what changes are required:
https://awstip.com/upgrading-kubernetes-ingresses-from-v1beta1-to-v1-7f9235765332

This PR should contain the necesarry changes for the chart in question.

Please review and merge at your own discretion. Happy hacking!

**Note: This PR was mass created, please validate and test the changes before rolling it to production.**
