### PR TITLE
[sentry]: migrate ingress to v1

### DIFF
--- a/system/sentry/charts/postgresql/templates/svc.yaml
+++ b/system/sentry/charts/postgresql/templates/svc.yaml
@@ -14,29 +14,3 @@ spec:
     targetPort: postgresql
   selector:
     app: {{ template "fullname" . }}
-
-{{- if .Values.metrics.enabled }}
----
-
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ template "fullname" . }}-backup-metrics
-  labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
-  annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9188"
-    prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
-spec:
-  clusterIP: None
-  ports:
-    - name: backup-metrics
-      port: 9188
-      protocol: TCP
-  selector:
-    app: {{ template "fullname" . }}
-{{- end }}

--- a/system/sentry/templates/ingress.yaml
+++ b/system/sentry/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "fullname" . }}
@@ -22,7 +22,10 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: {{ template "fullname" . }}
-          servicePort: {{ .Values.service.externalPort }}
+          service:
+            name: {{ template "fullname" . }}
+            port:
+              number: {{ .Values.service.externalPort }}
 {{- end }}


### PR DESCRIPTION
In preparation for the next upgrade of our kubernetes clusters we
need to remove references to api versions that are no longer supported.

The next version of kubernetes - 1.22 - removes support for the `Ingress` resource
in api version `networking.k8s.io/v1beta1`.

There are actually some minor structural changes to the `Ingress` object that
need to happen when migrating to `networking.k8s.io/v1`.

This blog post goes into some detail about what changes are required:
https://awstip.com/upgrading-kubernetes-ingresses-from-v1beta1-to-v1-7f9235765332

This PR should contain the necesarry changes for the chart in question.

Please review and merge at your own discretion. Happy hacking!

**Note: This PR was mass created, please validate and test the changes before rolling it to production.**
