### PR TITLE
[mariadb] Opt-in for Graceful shutdown

### DIFF
--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -191,6 +191,11 @@ readinessProbe:
   successThreshold: 1
   failureThreshold: 3
 
+terminationGracePeriodSeconds: 30 # Thats the kubernetes default
+gracefulShutDown:
+  enabled: false
+  shutdownPeriodSeconds: 10  # Tradeoff: More canceled transactions vs longer restart time
+
 extraConfigFiles: {}
 #  extra.cnf: |+
 #    [mysqld]


### PR DESCRIPTION
When mariadb receives the term-signal, it will cancel all outstanding
transaction, which gives the clients no time to gracefully handle the situation

When enabled, the mariadb pod will poll in the preStop hook the
number of external non-replication connections, and shut down
when they are zero or when a timeout period has been reached.

Since that depends on the client behaviour, this is an opt-in