### PR TITLE
[kube-metrics-exporter] configurable namespace

### DIFF
--- a/prometheus-exporters/kube-state-metrics-exporter/Chart.yaml
+++ b/prometheus-exporters/kube-state-metrics-exporter/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Helm chart for collecting metrics from kube-state-metrics.
 name: kube-state-metrics-exporter
-version: 0.1.7
+version: 0.1.8

--- a/prometheus-exporters/kube-state-metrics-exporter/ci/test-values.yaml
+++ b/prometheus-exporters/kube-state-metrics-exporter/ci/test-values.yaml
@@ -4,3 +4,6 @@ global:
   clusterType: virtual
 
 prometheusName: kubernetes
+
+namespaces:
+  - default

--- a/prometheus-exporters/kube-state-metrics-exporter/templates/servicemonitor.yaml
+++ b/prometheus-exporters/kube-state-metrics-exporter/templates/servicemonitor.yaml
@@ -13,9 +13,9 @@ spec:
       {{ required ".Values.labelSelector missing" .Values.labelSelector | toYaml | nindent 6 }}
 
   namespaceSelector:
-  {{ if len .Values.nameSpaces -}}
+  {{ if len .Values.namespaces -}}
     matchNames:
-      {{- range $namespace := $.Values.nameSpaces }}
+      {{- range $namespace := $.Values.namespaces }}
       - {{ $namespace }}
       {{- end }}
   {{ else }}

--- a/prometheus-exporters/kube-state-metrics-exporter/templates/servicemonitor.yaml
+++ b/prometheus-exporters/kube-state-metrics-exporter/templates/servicemonitor.yaml
@@ -13,7 +13,14 @@ spec:
       {{ required ".Values.labelSelector missing" .Values.labelSelector | toYaml | nindent 6 }}
 
   namespaceSelector:
+  {{ if len .Values.nameSpaces -}}
+    matchNames:
+      {{- range $namespace := $.Values.nameSpaces }}
+      - {{ $namespace }}
+      {{- end }}
+  {{ else }}
     any: true
+  {{- end }}
 
   endpoints:
     - port: http

--- a/prometheus-exporters/kube-state-metrics-exporter/values.yaml
+++ b/prometheus-exporters/kube-state-metrics-exporter/values.yaml
@@ -6,6 +6,10 @@ global:
 # The name of the Prometheus instance which shall evaluate the alert and recording (aggregation) rules.
 prometheusName:
 
+# Select specific namespace, otherwise it will grab all namespaces
+nameSpaces:
+#   - namespace1
+
 # honorLabels controls how Prometheus handles conflicts between labels that are
 # already present in scraped data and labels that Prometheus would attach
 # server-side ("job" and "instance" labels, manually configured target

--- a/prometheus-exporters/kube-state-metrics-exporter/values.yaml
+++ b/prometheus-exporters/kube-state-metrics-exporter/values.yaml
@@ -7,8 +7,7 @@ global:
 prometheusName:
 
 # Select specific namespace, otherwise it will grab all namespaces
-nameSpaces:
-#   - namespace1
+namespaces:
 
 # honorLabels controls how Prometheus handles conflicts between labels that are
 # already present in scraped data and labels that Prometheus would attach

--- a/prometheus-exporters/kube-state-metrics-exporter/values.yaml
+++ b/prometheus-exporters/kube-state-metrics-exporter/values.yaml
@@ -7,7 +7,7 @@ global:
 prometheusName:
 
 # Select specific namespace, otherwise it will grab all namespaces
-namespaces:
+namespaces: []
 
 # honorLabels controls how Prometheus handles conflicts between labels that are
 # already present in scraped data and labels that Prometheus would attach


### PR DESCRIPTION
Namespace was always set to `any`. This leads to every prometheus pulling in the whole metrics of the cluster, even if they aren't needed. Instead of dropping it multiple times we should make this configurable here.

Still defaults to `any`, if nothing is set.