### PR TITLE
[cinder] Bump utils chart for format string

### DIFF
--- a/openstack/cinder/requirements.lock
+++ b/openstack/cinder/requirements.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.3
+  version: 0.3.5
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.3.49
@@ -23,5 +23,5 @@ dependencies:
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.1.7
-digest: sha256:66db846fd2819f8864455053e0ce1518c6c638661ce16c6c0c834b7226f5f45c
-generated: "2022-04-01T14:01:48.255729+02:00"
+digest: sha256:e2b784fe5406bb41f70ba722febb9c66f873eeb4eeb5316c834d75eebe206ff8
+generated: "2022-04-01T15:47:43.323505664+02:00"

--- a/openstack/cinder/requirements.yaml
+++ b/openstack/cinder/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.3
+    version: 0.3.5
   - name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.3.49


### PR DESCRIPTION
The utils chart got an update to include %(resource)s in the logging
format string, which we want for Cinder.