### PR TITLE
Migrate rbac.authorization.k8s.io to v1

### DIFF
--- a/global/concourse/ci/test-values.yaml
+++ b/global/concourse/ci/test-values.yaml
@@ -1,0 +1,6 @@
+concourse:
+  secrets:
+    create: false
+  concourse:
+    encryption:
+      enabled: false

--- a/global/concourse/templates/cleanup-role.yaml
+++ b/global/concourse/templates/cleanup-role.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.cleanup.enabled }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: concourse-ci-cleanup

--- a/global/concourse/templates/cleanup-rolebinding.yaml
+++ b/global/concourse/templates/cleanup-rolebinding.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.cleanup.enabled }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: concourse-ci-cleanup

--- a/openstack/db-backup-v2/ci/test-values.yaml
+++ b/openstack/db-backup-v2/ci/test-values.yaml
@@ -1,0 +1,2 @@
+global:
+  region: nase

--- a/openstack/db-backup-v2/templates/dex-clusterrole.yaml
+++ b/openstack/db-backup-v2/templates/dex-clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: db-backup-dex

--- a/openstack/db-backup-v2/templates/dex-clusterrolebinding.yaml
+++ b/openstack/db-backup-v2/templates/dex-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: db-backup-dex

--- a/openstack/designate/templates/rbac.yaml
+++ b/openstack/designate/templates/rbac.yaml
@@ -35,7 +35,7 @@ rules:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ .Release.Name }}

--- a/openstack/keystone/templates/rbac.yaml
+++ b/openstack/keystone/templates/rbac.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.enabled }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ .Release.Name }}-runtime
@@ -35,7 +35,7 @@ rules:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ .Release.Name }}

--- a/openstack/kos-operator/ci/test-values.yaml
+++ b/openstack/kos-operator/ci/test-values.yaml
@@ -1,0 +1,2 @@
+kos_operator:
+  image_tag: nase

--- a/openstack/kos-operator/templates/clusterrole.yaml
+++ b/openstack/kos-operator/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:

--- a/openstack/kos-operator/templates/clusterrolebinding.yaml
+++ b/openstack/kos-operator/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:

--- a/openstack/openstack-seeder/templates/rbac.yaml
+++ b/openstack/openstack-seeder/templates/rbac.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.enabled }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ .Release.Name }}
@@ -29,7 +29,7 @@ rules:
   - delete
   - patch
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ .Release.Name }}

--- a/openstack/vcenter-operator/ci/test-values.yaml
+++ b/openstack/vcenter-operator/ci/test-values.yaml
@@ -1,0 +1,4 @@
+global:
+  vcenter_operator_master_password: nase
+  registry: mund
+imageVersion: ohr

--- a/openstack/vcenter-operator/templates/clusterrole.yaml
+++ b/openstack/vcenter-operator/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:

--- a/openstack/vcenter-operator/templates/clusterrolebinding.yaml
+++ b/openstack/vcenter-operator/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:

--- a/prometheus-exporters/event-exporter/Chart.yaml
+++ b/prometheus-exporters/event-exporter/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Eventexporter for Kubernetes
 name: event-exporter
-version: 0.2.5
+version: 0.2.6

--- a/prometheus-exporters/event-exporter/templates/clusterrole.yaml
+++ b/prometheus-exporters/event-exporter/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "name" . }}

--- a/prometheus-exporters/event-exporter/templates/clusterrolebinding.yaml
+++ b/prometheus-exporters/event-exporter/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "name" . }}

--- a/prometheus-exporters/k8s-secrets-certificate-exporter/Chart.yaml
+++ b/prometheus-exporters/k8s-secrets-certificate-exporter/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 description: Kubernetes secrets certificate exporter.
 name: k8s-secrets-certificate-exporter
-version: 1.3.2
+version: 1.3.3

--- a/prometheus-exporters/k8s-secrets-certificate-exporter/templates/clusterrole.yaml
+++ b/prometheus-exporters/k8s-secrets-certificate-exporter/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:

--- a/prometheus-exporters/k8s-secrets-certificate-exporter/templates/clusterrolebinding.yaml
+++ b/prometheus-exporters/k8s-secrets-certificate-exporter/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: k8s-secrets-certificate-exporter

--- a/prometheus-exporters/watchcache-exporter/Chart.yaml
+++ b/prometheus-exporters/watchcache-exporter/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Watchcache exporter for Kubernetes
 name: watchcache-exporter
-version: 0.1.3
+version: 0.1.4

--- a/prometheus-exporters/watchcache-exporter/templates/clusterrole.yaml
+++ b/prometheus-exporters/watchcache-exporter/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "name" . }}

--- a/prometheus-exporters/watchcache-exporter/templates/clusterrolebinding.yaml
+++ b/prometheus-exporters/watchcache-exporter/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "name" . }}

--- a/system/disco/Chart.yaml
+++ b/system/disco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: The DISCO (Designate IngresS Cname Operator) creates CNAMEs based on an ingress spec in OpenStack Designate.
 name: disco
-version: 1.6.2
+version: 1.6.3
 maintainers:
   - name: auhlig

--- a/system/disco/templates/clusterrole.yaml
+++ b/system/disco/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:

--- a/system/disco/templates/clusterrolebinding.yaml
+++ b/system/disco/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:

--- a/system/disco/templates/rolebinding.yaml
+++ b/system/disco/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:

--- a/system/infra-monitoring/templates/rolebinding.yaml
+++ b/system/infra-monitoring/templates/rolebinding.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.rbac.create }}
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ .Values.rbac.name | quote }}

--- a/system/kube-fip-controller/Chart.yaml
+++ b/system/kube-fip-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: kube-fip-controller
 description: A Helm chart for the kube-fip-controller
 type: application
-version: 0.1.12
+version: 0.1.13
 appVersion: 0.1.0

--- a/system/kube-fip-controller/templates/clusterrole.yaml
+++ b/system/kube-fip-controller/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:

--- a/system/kube-fip-controller/templates/clusterrolebinding.yaml
+++ b/system/kube-fip-controller/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:

--- a/system/kube-fip-controller/templates/rolebinding.yaml
+++ b/system/kube-fip-controller/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:

--- a/system/kubernikus-rbac/Chart.yaml
+++ b/system/kubernikus-rbac/Chart.yaml
@@ -1,3 +1,4 @@
+apiVersion: v1
 description: Additional RBAC Rules 
 name: kubernikus-rbac
 version: 1.2.2

--- a/system/kubernikus-rbac/Chart.yaml
+++ b/system/kubernikus-rbac/Chart.yaml
@@ -1,3 +1,3 @@
 description: Additional RBAC Rules 
 name: kubernikus-rbac
-version: 1.2.1
+version: 1.2.2

--- a/system/kubernikus-rbac/templates/clusterrole--multus.yaml
+++ b/system/kubernikus-rbac/templates/clusterrole--multus.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: multus
 rules:

--- a/system/node-problem-detector/Chart.yaml
+++ b/system/node-problem-detector/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Node Problem Detector for Kubernetes
 name: node-problem-detector
-version: 1.3.8
+version: 1.3.9
 appVersion: v0.8.5

--- a/system/node-problem-detector/templates/clusterrole.yaml
+++ b/system/node-problem-detector/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 
 metadata:

--- a/system/node-problem-detector/templates/clusterrolebinding.yaml
+++ b/system/node-problem-detector/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: "{{ .Release.Namespace }}:node-problem-detector"

--- a/system/vice-president/Chart.yaml
+++ b/system/vice-president/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Automated certificate management by a kubernetes operator using the Symantec VICE API.
 name: vice-president
-version: 1.2.1
+version: 1.2.2
 maintainers:
   - name: auhlig

--- a/system/vice-president/templates/clusterrole.yaml
+++ b/system/vice-president/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.president.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:

--- a/system/vice-president/templates/clusterrolebinding.yaml
+++ b/system/vice-president/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.president.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:

--- a/system/vice-president/templates/rolebinding.yaml
+++ b/system/vice-president/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.president.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:


### PR DESCRIPTION
`rbac.authorization.k8s.io/v1beta1` is removed in 1.22 which is our next upgrade candidate.

According to the official documentation there are no structural or behavioural changes:

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#rbac-resources-v122

Hopefully `helm diff --find-renames` is keeping the diff noise minimal this time.

Can I please get a quick approve from all stakeholders?

