### PR TITLE
[Nova] Shutdown delay to avoid connection resets

### DIFF
--- a/openstack/nova/templates/api-deployment.yaml
+++ b/openstack/nova/templates/api-deployment.yaml
@@ -70,6 +70,15 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+          lifecycle:
+            preStop:
+              exec:
+                command: [
+                  # Introduce a delay to the shutdown sequence to wait for the
+                  # pod eviction event to propagate.
+                  "/bin/sleep",
+                  "{{ .Values.api.shutdownDelaySeconds }}"
+                ]
 {{- if not .Values.pod.debug.api }}
           livenessProbe:
             httpGet:

--- a/openstack/nova/templates/api-metadata-deployment.yaml
+++ b/openstack/nova/templates/api-metadata-deployment.yaml
@@ -66,6 +66,15 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+          lifecycle:
+            preStop:
+              exec:
+                command: [
+                  # Introduce a delay to the shutdown sequence to wait for the
+                  # pod eviction event to propagate.
+                  "/bin/sleep",
+                  "{{ .Values.shutdownDelaySeconds }}"
+                ]
           livenessProbe:
             httpGet:
               path: /

--- a/openstack/nova/templates/consoleauth-deployment.yaml
+++ b/openstack/nova/templates/consoleauth-deployment.yaml
@@ -54,6 +54,15 @@ spec:
         - name: PYTHONWARNINGS
           value: {{ .Values.python_warnings | quote }}
 {{- end }}
+        lifecycle:
+          preStop:
+            exec:
+              command: [
+                # Introduce a delay to the shutdown sequence to wait for the
+                # pod eviction event to propagate.
+                "/bin/sleep",
+                "{{ .Values.shutdownDelaySeconds }}"
+              ]
         volumeMounts:
         - name: etcnova
           mountPath: /etc/nova

--- a/openstack/nova/templates/placement-api-deployment.yaml
+++ b/openstack/nova/templates/placement-api-deployment.yaml
@@ -60,6 +60,15 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+          lifecycle:
+            preStop:
+              exec:
+                command: [
+                  # Introduce a delay to the shutdown sequence to wait for the
+                  # pod eviction event to propagate.
+                  "/bin/sleep",
+                  "{{ .Values.shutdownDelaySeconds }}"
+                ]
 {{- if not .Values.pod.debug.api }}
           livenessProbe:
             httpGet:

--- a/openstack/nova/templates/vspc-deployment.yaml
+++ b/openstack/nova/templates/vspc-deployment.yaml
@@ -46,6 +46,15 @@ spec:
             - name: PYTHONWARNINGS
               value: {{ .Values.python_warnings | quote }}
 {{- end }}
+          lifecycle:
+            preStop:
+              exec:
+                command: [
+                  # Introduce a delay to the shutdown sequence to wait for the
+                  # pod eviction event to propagate.
+                  "/bin/sleep",
+                  "{{ .Values.shutdownDelaySeconds }}"
+                ]
           livenessProbe:
             exec:
               command: ["sh", "-c", "echo '' | curl -m 20 telnet://localhost:1333"]

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -200,6 +200,8 @@ cinder_http_retries: 10
 neutron_http_retries: 10
 neutron_timeout: 600
 
+shutdownDelaySeconds: 10
+
 api:
   config_file:
     DEFAULT:


### PR DESCRIPTION
The pod will receive the shutdown request at the same time as
the as the endpoint-controller, which will then propagate the
change to the kube-proxy.
That in turn means that the pod will still receive requests
from other clients while being in the process of being shut down.
This leads then to connection errors during the time that
event propagates through the network stack of kubernetes.
To avoid that, we delay the actual shutdown by a fixed period,
which should, if not eliminate, but reduce the number of those errors