### PR TITLE
[Barbican] Shutdown delay to avoid connection resets

### DIFF
--- a/openstack/barbican/templates/api-deployment.yaml
+++ b/openstack/barbican/templates/api-deployment.yaml
@@ -66,6 +66,15 @@ spec:
               cpu: {{ .Values.api.resources.requests.cpu | quote }}
               memory: {{ .Values.api.resources.requests.memory | quote }}
           {{- end }}
+          lifecycle:
+            preStop:
+              exec:
+                command: [
+                  # Introduce a delay to the shutdown sequence to wait for the
+                  # pod eviction event to propagate.
+                  "/bin/sleep",
+                  "{{ .Values.shutdownDelaySeconds }}"
+                ]
           livenessProbe:
             httpGet:
               path: /
@@ -123,7 +132,7 @@ spec:
           image: {{.Values.global.dockerHubMirror}}/{{ .Values.statsd.image.repository }}:{{ .Values.statsd.image.tag }}
           {{- else }}
           image: "{{ .Values.statsd.image.repository }}:{{ .Values.statsd.image.tag }}"
-          {{- end }}          
+          {{- end }}
           imagePullPolicy: IfNotPresent
           args: [ --statsd.mapping-config=/etc/statsd/statsd-exporter.yaml ]
           {{- if .Values.statsd.resources.enabled }}
@@ -134,7 +143,7 @@ spec:
             requests:
               cpu: {{ .Values.statsd.resources.requests.cpu | quote }}
               memory: {{ .Values.statsd.resources.requests.memory | quote }}
-          {{- end }}          
+          {{- end }}
           ports:
             - name: statsd
               containerPort: 9125

--- a/openstack/barbican/values.yaml
+++ b/openstack/barbican/values.yaml
@@ -27,6 +27,7 @@ pod:
 
 api_port_internal: '9311'
 debug: "True"
+shutdownDelaySeconds: 10
 
 statsd:
   port: 9102
@@ -187,7 +188,7 @@ sapcc_rate_limit:
   enabled: true
   persistence:
     enabled: false
-    
+
 # sapcc/openstack-watcher-middleware
 watcher:
   enabled: true


### PR DESCRIPTION
The pod will receive the shutdown request at the same time as
the as the endpoint-controller, which will then propagate the
change to the kube-proxy.
That in turn means that the pod will still receive requests
from other clients while being in the process of being shut down.
This leads then to connection errors during the time that
event propagates through the network stack of kubernetes.
To avoid that, we delay the actual shutdown by a fixed period,
which should, if not eliminate, but reduce the number of those errors