### PR TITLE
[Cinder] Shutdown delay to avoid connection resets

### DIFF
--- a/openstack/cinder/templates/api-deployment.yaml
+++ b/openstack/cinder/templates/api-deployment.yaml
@@ -63,6 +63,15 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+          lifecycle:
+            preStop:
+              exec:
+                command: [
+                  # Introduce a delay to the shutdown sequence to wait for the
+                  # pod eviction event to propagate.
+                  "/bin/sleep",
+                  "{{ .Values.api.shutdownDelaySeconds }}"
+                ]
           livenessProbe:
             httpGet:
               path: /

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -77,6 +77,7 @@ api:
   # bare in mind, that with use_uwsgi=false, these workers also have
   # greenthreads
   workers: 10
+  shutdownDelaySeconds: 10
 
 use_tls_acme: true
 


### PR DESCRIPTION
The pod will receive the shutdown request at the same time as
the as the endpoint-controller, which will then propagate the
change to the kube-proxy.
That in turn means that the pod will still receive requests
from other clients while being in the process of being shut down.
This leads then to connection errors during the time that
event propagates through the network stack of kubernetes.
To avoid that, we delay the actual shutdown by a fixed period,
which should, if not eliminate, but reduce the number of those errors