### PR TITLE
[Glance] Shutdown delay to avoid connection resets

### DIFF
--- a/openstack/glance/templates/deployment.yaml
+++ b/openstack/glance/templates/deployment.yaml
@@ -54,6 +54,15 @@ spec:
       - name: api
         image: {{ required ".Values.global.registry is missing" .Values.global.registry }}/loci-glance:{{.Values.imageVersionGlanceApi | default .Values.imageVersion | default .Values.image_version | required "Please set glance.imageVersion or similar"}}
         imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            exec:
+              command: [
+                # Introduce a delay to the shutdown sequence to wait for the
+                # pod eviction event to propagate.
+                "/bin/sleep",
+                "{{ .Values.api.shutdownDelaySeconds }}"
+              ]
         livenessProbe:
           httpGet:
             path: /
@@ -162,7 +171,7 @@ spec:
           subPath: ratelimit.yaml
           readOnly: true
         {{- end }}
-        
+
       {{- if .Values.imageVersionGlanceRegistry }}
       - name: registry
         image: {{ required ".Values.global.registry is missing" .Values.global.registry }}/ubuntu-source-glance-registry:{{ required "Please set glance.imageVersion or similar" .Values.imageVersion }}
@@ -170,6 +179,15 @@ spec:
         command:
         - dumb-init
         - kubernetes-entrypoint
+        lifecycle:
+          preStop:
+            exec:
+              command: [
+                # Introduce a delay to the shutdown sequence to wait for the
+                # pod eviction event to propagate.
+                "/bin/sleep",
+                "{{ .Values.api.shutdownDelaySeconds }}"
+              ]
         livenessProbe:
           httpGet:
             path: /healthcheck

--- a/openstack/glance/values.yaml
+++ b/openstack/glance/values.yaml
@@ -64,6 +64,7 @@ statsd:
 
 api:
   debug: false
+  shutdownDelaySeconds: 10
   resources:
     enabled: true
     limits:


### PR DESCRIPTION
The pod will receive the shutdown request at the same time as
the as the endpoint-controller, which will then propagate the
change to the kube-proxy.
That in turn means that the pod will still receive requests
from other clients while being in the process of being shut down.
This leads then to connection errors during the time that
event propagates through the network stack of kubernetes.
To avoid that, we delay the actual shutdown by a fixed period,
which should, if not eliminate, but reduce the number of those errors