### PR TITLE
[Designate] Shutdown delay to avoid connection resets

### DIFF
--- a/openstack/designate/templates/api-deployment.yaml
+++ b/openstack/designate/templates/api-deployment.yaml
@@ -80,6 +80,15 @@ spec:
                   name: sentry
                   key: {{ .Release.Name }}.DSN.python
             {{- end }}
+          lifecycle:
+            preStop:
+              exec:
+                command: [
+                  # Introduce a delay to the shutdown sequence to wait for the
+                  # pod eviction event to propagate.
+                  "/bin/sleep",
+                  "{{ .Values.shutdownDelaySeconds }}"
+                ]
           livenessProbe:
             httpGet:
               path: /
@@ -127,7 +136,7 @@ spec:
             name: designate-etc
         - name: designate-etc-wsgi
           configMap:
-            name: designate-etc-wsgi         
+            name: designate-etc-wsgi
         - name: wsgi-designate
           emptyDir: {}
         - name: container-init

--- a/openstack/designate/values.yaml
+++ b/openstack/designate/values.yaml
@@ -52,6 +52,7 @@ pod:
 
 # image_version_designate:  DEFINED-IN-REGION-CHART
 imageVersionTempest: "latest"
+shutdownDelaySeconds: 10
 
 bind_pools:
   - name: default


### PR DESCRIPTION
The pod will receive the shutdown request at the same time as
the as the endpoint-controller, which will then propagate the
change to the kube-proxy.
That in turn means that the pod will still receive requests
from other clients while being in the process of being shut down.
This leads then to connection errors during the time that
event propagates through the network stack of kubernetes.
To avoid that, we delay the actual shutdown by a fixed period,
which should, if not eliminate, but reduce the number of those errors