### PR TITLE
[Ironic] Shutdown delay to avoid connection resets

### DIFF
--- a/openstack/ironic/Chart.lock
+++ b/openstack/ironic/Chart.lock
@@ -17,5 +17,5 @@ dependencies:
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.7.0
-digest: sha256:08af657cd9858e299fa93cd055829c9ed964717104bbe4f34e219b8c82a0eedd
-generated: "2022-12-22T09:25:37.758145-05:00"
+digest: sha256:0cfd899e49704ab3c4bbf69b7d379cdb14cc7cdaf79c0b92ee757c3554c3534a
+generated: "2023-01-31T11:06:30.346296828+01:00"

--- a/openstack/ironic/templates/api-deployment.yaml
+++ b/openstack/ironic/templates/api-deployment.yaml
@@ -64,6 +64,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        lifecycle:
+          preStop:
+            {{- include "utils.snippets.pre_stop_graceful_shutdown" . | indent 12 }}
         livenessProbe:
           httpGet:
             path: /

--- a/openstack/ironic/templates/inspector-deployment.yaml
+++ b/openstack/ironic/templates/inspector-deployment.yaml
@@ -67,6 +67,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        lifecycle:
+          preStop:
+            {{- include "utils.snippets.pre_stop_graceful_shutdown" . | indent 12 }}
         resources:
 {{ toYaml .Values.pod.resources.inspector | indent 10 }}
         volumeMounts:

--- a/openstack/ironic/templates/pxe-deployment.yaml
+++ b/openstack/ironic/templates/pxe-deployment.yaml
@@ -54,6 +54,9 @@ spec:
           name: ironic-tftp
         - mountPath: /etc/nginx/conf.d
           name: ironic-pxe
+        lifecycle:
+          preStop:
+            {{- include "utils.snippets.pre_stop_graceful_shutdown" . | indent 12 }}
         livenessProbe:
           httpGet:
             path: /tftpboot/


### PR DESCRIPTION
The pod will receive the shutdown request at the same time as
the as the endpoint-controller, which will then propagate the
change to the kube-proxy.
That in turn means that the pod will still receive requests
from other clients while being in the process of being shut down.
This leads then to connection errors during the time that
event propagates through the network stack of kubernetes.
To avoid that, we delay the actual shutdown by a fixed period,
which should, if not eliminate, but reduce the number of those errors