### PR TITLE
[Keystone] Shutdown delay to avoid connection resets

### DIFF
--- a/openstack/keystone/templates/bin/_keystone_api.sh.tpl
+++ b/openstack/keystone/templates/bin/_keystone_api.sh.tpl
@@ -44,6 +44,7 @@ function start () {
 }
 
 function stop () {
+  sleep {{ .Values.api.shutdownDelaySeconds }}
   apachectl -k graceful-stop
 }
 

--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -46,6 +46,7 @@ osprofiler:
 api:
   image: "loci-keystone"
   #imageTag: latest
+  shutdownDelaySeconds: 10  # Time to wait between getting the shutdown signal and actually shutting down
 
   ## Specify a imagePullPolicy
   ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
The pod will receive the shutdown request at the same time as
the as the endpoint-controller, which will then propagate the
change to the kube-proxy.
That in turn means that the pod will still receive requests
from other clients while being in the process of being shut down.
This leads then to connection errors during the time that
event propagates through the network stack of kubernetes.
To avoid that, we delay the actual shutdown by a fixed period,
which should, if not eliminate, but reduce the number of those errors