### PR TITLE
[Manila] Shutdown delay to avoid connection resets

### DIFF
--- a/openstack/manila/templates/bin/_manila_api.sh.tpl
+++ b/openstack/manila/templates/bin/_manila_api.sh.tpl
@@ -44,6 +44,7 @@ function start () {
 }
 
 function stop () {
+  sleep {{ .Values.shutdownDelaySeconds }}
   apachectl -k graceful-stop
 }
 

--- a/openstack/manila/values.yaml
+++ b/openstack/manila/values.yaml
@@ -18,6 +18,7 @@ loci:
 api_port_internal: '8786'
 api_backdoor: false
 debug: "True"
+shutdownDelaySeconds: 10
 
 logging:
   formatters:


### PR DESCRIPTION
The pod will receive the shutdown request at the same time as
the as the endpoint-controller, which will then propagate the
change to the kube-proxy.
That in turn means that the pod will still receive requests
from other clients while being in the process of being shut down.
This leads then to connection errors during the time that
event propagates through the network stack of kubernetes.
To avoid that, we delay the actual shutdown by a fixed period,
which should, if not eliminate, but reduce the number of those errors