### PR TITLE
[Neutron] Shutdown delay to avoid connection resets

### DIFF
--- a/openstack/neutron/templates/deployment-server.yaml
+++ b/openstack/neutron/templates/deployment-server.yaml
@@ -40,6 +40,15 @@ spec:
         - name: neutron-server
           image: {{.Values.global.registry}}/loci-neutron:{{.Values.imageVersionServerAPI | default .Values.imageVersionServer | default .Values.imageVersion | required "Please set neutron.imageVersion or similar"}}
           imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              exec:
+                command: [
+                  # Introduce a delay to the shutdown sequence to wait for the
+                  # pod eviction event to propagate.
+                  "/bin/sleep",
+                  "{{ .Values.api.shutdownDelaySeconds }}"
+                ]
 {{- if not .Values.pod.debug.server }}
 {{- if not .Values.api.uwsgi }}
           livenessProbe:

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -138,6 +138,7 @@ api:
   # minimum number of workers to keep at all times
   cheaper: 0
   uwsgi: false
+  shutdownDelaySeconds: 10
 
 service_plugins: asr1k_l3_routing
 default_router_type: ASR1k_router


### PR DESCRIPTION
The pod will receive the shutdown request at the same time as
the as the endpoint-controller, which will then propagate the
change to the kube-proxy.
That in turn means that the pod will still receive requests
from other clients while being in the process of being shut down.
This leads then to connection errors during the time that
event propagates through the network stack of kubernetes.
To avoid that, we delay the actual shutdown by a fixed period,
which should, if not eliminate, but reduce the number of those errors