### PR TITLE
[openstack/utils] Add pre_stop_graceful_shutdown snippet

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.3.5
+version: 0.3.6

--- a/openstack/utils/templates/snippets/_pre_stop_graceful_shutdown.tpl
+++ b/openstack/utils/templates/snippets/_pre_stop_graceful_shutdown.tpl
@@ -1,0 +1,9 @@
+{{- define "utils.snippets.pre_stop_graceful_shutdown" }}
+exec:
+  command: [
+    # Introduce a delay to the shutdown sequence to wait for the
+    # pod eviction event to propagate.
+    "/bin/sleep",
+    "{{ coalesce .Values.shutdownDelaySeconds .Values.global.shutdownDelaySeconds }}"
+  ]
+{{- end }}

--- a/openstack/utils/values.yaml
+++ b/openstack/utils/values.yaml
@@ -6,3 +6,4 @@
 global:
   user_suffix: ""
   master_password: ""
+  shutdownDelaySeconds: 10


### PR DESCRIPTION
Add a common way to handle the propagation delay of a pod termination
gracefully.
In order to get around the race between the kubernetes stop sending
new connections to a pod, and the pod accepting them,
add a delay to the shutdown of the pod.
Ideally, this would be replaced with some insight into the actual
state of forwarding, but until then we have to wait