### PR TITLE
[Neutron] Use shutdown delay snippet to avoid connection failures

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -19,9 +19,9 @@ dependencies:
   version: 0.1.2
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.4
+  version: 0.3.7
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.1.7
-digest: sha256:aa6db5d225efb2a94bb2d3d3e75c50320ad91714dbace843b54ab215e52792b2
-generated: "2022-03-30T13:18:38.892648+02:00"
+digest: sha256:b6ba1126d53c15a3db24e3f989013f14ff69fcbd293e0c57f3220a58381943c5
+generated: "2022-04-05T13:17:40.962818966+02:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -28,7 +28,7 @@ dependencies:
     version: 0.1.2
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.4
+    version: 0.3.7
   - alias: logger-redis
     condition: logger.enabled
     name: redis

--- a/openstack/neutron/templates/deployment-server.yaml
+++ b/openstack/neutron/templates/deployment-server.yaml
@@ -40,6 +40,9 @@ spec:
         - name: neutron-server
           image: {{.Values.global.registry}}/loci-neutron:{{.Values.imageVersionServerAPI | default .Values.imageVersionServer | default .Values.imageVersion | required "Please set neutron.imageVersion or similar"}}
           imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              {{- include "utils.snippets.pre_stop_graceful_shutdown" . | indent 14 }}
 {{- if not .Values.pod.debug.server }}
 {{- if not .Values.api.uwsgi }}
           livenessProbe:


### PR DESCRIPTION
Make use of the common snippet, which delays the actual shutdown
in order to allow for new incoming requests to give k8s time
to stop sending new traffic to a terminating pod