### PR TITLE
[Barbican] Use shutdown delay snippet to avoid connection failures

### DIFF
--- a/openstack/barbican/requirements.lock
+++ b/openstack/barbican/requirements.lock
@@ -19,12 +19,12 @@ dependencies:
   version: 0.1.2
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.3
+  version: 0.3.7
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.1.5
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.2
-digest: sha256:3ab64bcc1a1202d30d28861c5113004e627bfdc962e4524b05b6b625e5216135
-generated: "2022-03-30T13:42:58.50166+05:30"
+digest: sha256:505e7613c9daba8294c5430b0ade40fad37d5548d32285185e7ab47f62e40b29
+generated: "2022-04-05T12:40:54.963808211+02:00"

--- a/openstack/barbican/requirements.yaml
+++ b/openstack/barbican/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.50 
+    version: 0.3.50
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.0.10
@@ -22,7 +22,7 @@ dependencies:
     version: 0.1.2
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.3
+    version: 0.3.7
   - name: redis
     alias: sapcc_rate_limit
     repository: https://charts.eu-de-2.cloud.sap

--- a/openstack/barbican/templates/api-deployment.yaml
+++ b/openstack/barbican/templates/api-deployment.yaml
@@ -68,13 +68,7 @@ spec:
           {{- end }}
           lifecycle:
             preStop:
-              exec:
-                command: [
-                  # Introduce a delay to the shutdown sequence to wait for the
-                  # pod eviction event to propagate.
-                  "/bin/sleep",
-                  "{{ .Values.shutdownDelaySeconds }}"
-                ]
+              {{- include "utils.snippets.pre_stop_graceful_shutdown" . | indent 14 }}
           livenessProbe:
             httpGet:
               path: /

--- a/openstack/barbican/values.yaml
+++ b/openstack/barbican/values.yaml
@@ -27,7 +27,6 @@ pod:
 
 api_port_internal: '9311'
 debug: "True"
-shutdownDelaySeconds: 10
 
 statsd:
   port: 9102


### PR DESCRIPTION
Make use of the common snippet, which delays the actual shutdown
in order to allow for new incoming requests to give k8s time
to stop sending new traffic to a terminating pod