### PR TITLE
[Cinder] Use shutdown delay snippet to avoid connection failures

### DIFF
--- a/openstack/cinder/requirements.lock
+++ b/openstack/cinder/requirements.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.5
+  version: 0.3.7
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.3.50
@@ -23,5 +23,5 @@ dependencies:
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.1.7
-digest: sha256:9b282ca030741869b4b1e7b220d96ece46da50f00b3001b98584739873308053
-generated: "2022-04-01T13:11:07.153539-04:00"
+digest: sha256:e56e08204d5a9ed6d077249d91cddc67faacb487148b937d41cf94855b50ac59
+generated: "2022-04-05T12:43:01.281738381+02:00"

--- a/openstack/cinder/requirements.yaml
+++ b/openstack/cinder/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.5
+    version: 0.3.7
   - name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.3.50

--- a/openstack/cinder/templates/api-deployment.yaml
+++ b/openstack/cinder/templates/api-deployment.yaml
@@ -63,6 +63,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+          lifecycle:
+            preStop:
+              {{- include "utils.snippets.pre_stop_graceful_shutdown" . | indent 14 }}
           livenessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
Make use of the common snippet, which delays the actual shutdown
in order to allow for new incoming requests to give k8s time
to stop sending new traffic to a terminating pod