### PR TITLE
[Designate] Use shutdown delay snippet to avoid connection failures

### DIFF
--- a/openstack/designate/requirements.lock
+++ b/openstack/designate/requirements.lock
@@ -22,6 +22,6 @@ dependencies:
   version: 0.1.2
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.4
-digest: sha256:55a950bd2e93d28757040d9983e0e440caebc98c5e38343a772bbf094f4b02d9
-generated: "2022-03-31T18:35:58.942069+02:00"
+  version: 0.3.7
+digest: sha256:3b39951a8f48f66854c091eb1c5bcc9deee7999432db38a4288b401d082d05a0
+generated: "2022-04-05T12:44:41.070281762+02:00"

--- a/openstack/designate/requirements.yaml
+++ b/openstack/designate/requirements.yaml
@@ -27,4 +27,4 @@ dependencies:
     version: 0.1.2
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.4
+    version: 0.3.7

--- a/openstack/designate/templates/api-deployment.yaml
+++ b/openstack/designate/templates/api-deployment.yaml
@@ -80,6 +80,9 @@ spec:
                   name: sentry
                   key: {{ .Release.Name }}.DSN.python
             {{- end }}
+          lifecycle:
+            preStop:
+              {{- include "utils.snippets.pre_stop_graceful_shutdown" . | indent 14 }}
           livenessProbe:
             httpGet:
               path: /
@@ -127,7 +130,7 @@ spec:
             name: designate-etc
         - name: designate-etc-wsgi
           configMap:
-            name: designate-etc-wsgi         
+            name: designate-etc-wsgi
         - name: wsgi-designate
           emptyDir: {}
         - name: container-init


### PR DESCRIPTION
Make use of the common snippet, which delays the actual shutdown
in order to allow for new incoming requests to give k8s time
to stop sending new traffic to a terminating pod