### PR TITLE
[openstack/utils] Fixup pre_stop_graceful_shutdown defaults

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.3.6
+version: 0.3.7

--- a/openstack/utils/templates/snippets/_pre_stop_graceful_shutdown.tpl
+++ b/openstack/utils/templates/snippets/_pre_stop_graceful_shutdown.tpl
@@ -4,6 +4,6 @@ exec:
     # Introduce a delay to the shutdown sequence to wait for the
     # pod eviction event to propagate.
     "/bin/sleep",
-    "{{ coalesce .Values.shutdownDelaySeconds .Values.global.shutdownDelaySeconds }}"
+    "{{ coalesce .Values.shutdownDelaySeconds .Values.global.shutdownDelaySeconds 10 }}"
   ]
 {{- end }}

--- a/openstack/utils/values.yaml
+++ b/openstack/utils/values.yaml
@@ -6,4 +6,3 @@
 global:
   user_suffix: ""
   master_password: ""
-  shutdownDelaySeconds: 10


### PR DESCRIPTION
The global default doesn't seem to take hold
reliably, so we have to put it as an argument
to the function