### PR TITLE
[Glance] Use shutdown delay snippet to avoid connection failures

### DIFF
--- a/openstack/glance/requirements.lock
+++ b/openstack/glance/requirements.lock
@@ -16,12 +16,12 @@ dependencies:
   version: 0.1.2
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.4
+  version: 0.3.7
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.1.5
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.2
-digest: sha256:b75671ce39c18cd357fb0305678293a19a686fd8d25d10b38d952cd0361dae6c
-generated: "2022-04-04T11:44:02.262743+05:30"
+digest: sha256:9db7a2c7e18085012982ad7d903a5de59f8b4750b59a0f9ae8310593ca04c985
+generated: "2022-04-05T12:48:16.249733038+02:00"

--- a/openstack/glance/requirements.yaml
+++ b/openstack/glance/requirements.yaml
@@ -20,9 +20,9 @@ dependencies:
     version: 0.1.2
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.4
+    version: 0.3.7
   - name: redis
-    alias: sapcc_rate_limit 
+    alias: sapcc_rate_limit
     repository: https://charts.eu-de-2.cloud.sap
     version: 1.1.5
     condition: sapcc_rate_limit.enabled

--- a/openstack/glance/templates/deployment.yaml
+++ b/openstack/glance/templates/deployment.yaml
@@ -56,13 +56,7 @@ spec:
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
-            exec:
-              command: [
-                # Introduce a delay to the shutdown sequence to wait for the
-                # pod eviction event to propagate.
-                "/bin/sleep",
-                "{{ .Values.api.shutdownDelaySeconds }}"
-              ]
+            {{- include "utils.snippets.pre_stop_graceful_shutdown" . | indent 12 }}
         livenessProbe:
           httpGet:
             path: /
@@ -181,13 +175,7 @@ spec:
         - kubernetes-entrypoint
         lifecycle:
           preStop:
-            exec:
-              command: [
-                # Introduce a delay to the shutdown sequence to wait for the
-                # pod eviction event to propagate.
-                "/bin/sleep",
-                "{{ .Values.api.shutdownDelaySeconds }}"
-              ]
+            {{- include "utils.snippets.pre_stop_graceful_shutdown" . | indent 12 }}
         livenessProbe:
           httpGet:
             path: /healthcheck

--- a/openstack/glance/values.yaml
+++ b/openstack/glance/values.yaml
@@ -64,7 +64,6 @@ statsd:
 
 api:
   debug: false
-  shutdownDelaySeconds: 10
   resources:
     enabled: true
     limits:


### PR DESCRIPTION
Make use of the common snippet, which delays the actual shutdown
in order to allow for new incoming requests to give k8s time
to stop sending new traffic to a terminating pod