### PR TITLE
[kube-parrot] support global region

### DIFF
--- a/system/kube-parrot/Chart.yaml
+++ b/system/kube-parrot/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 description: Kube Parrot
 name: kube-parrot
-version: 0.2.5
+version: 0.3.0

--- a/system/kube-parrot/templates/daemonset.yaml
+++ b/system/kube-parrot/templates/daemonset.yaml
@@ -1,4 +1,86 @@
 {{ if .Values.enabled -}}
+{{- if .Values.globalRegion.enabled }}
+{{ range $region, $regionValues := .Values.globalRegion.regions }}
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  annotations:
+  labels:
+    k8s-app: kube-parrot-{{ $region }}
+  name: kube-parrot-{{ $region }}
+spec:
+  selector:
+    matchLabels:
+      name: kube-parrot-{{ $region }}
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: kube-parrot-{{ $region }}
+        k8s-app: kube-parrot-{{ $region }}
+        service: kube-parrot-{{ $region }}
+      annotations:
+    spec:
+      priorityClassName: system-node-critical
+      {{- if $.Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
+      containers:
+      - name: parrot
+        image: "{{ required ".Values.global.registryAlternateRegion is missing" $.Values.global.registryAlternateRegion }}/{{ $.Values.images.parrot.image }}:{{ $.Values.images.parrot.tag }}"
+        imagePullPolicy: IfNotPresent
+        command:
+          - /parrot
+          - --as={{ $regionValues.as }}
+          - --remote-as={{ $regionValues.remoteAS }}
+          - --podsubnet={{ $.Values.podsubnet }}
+          - --nodename=$(NODE_NAME)
+          - --hostip=$(HOST_IP)
+          - --logtostderr
+          - --neighbor-count={{ $.Values.bgpNeighborCount }}
+{{- if $.Values.metricPort }}
+          - --metric-port={{ $.Values.metricPort }}
+{{- end }}
+        env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: HOST_IP 
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+        volumeMounts:
+          - name: etc-kubernetes-kube-parrot
+            mountPath: /etc/kubernetes/kube-parrot
+        {{ if $.Values.metricPort -}}
+        ports:
+          - name: parrot-metrics
+            containerPort: {{ $.Values.metricPort }}
+            hostPort: {{ $.Values.metricPort }}
+        {{- end }}
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.cloud.sap/region: {{ $region }}
+      serviceAccountName: kube-parrot
+      terminationGracePeriodSeconds: 5
+      tolerations:
+{{- if $.Values.toleration }}
+        - key: "kubernetes.cloud.sap/unification"
+          operator: "Exists"
+          effect: "NoSchedule"
+{{- else }}
+        - operator: Exists
+      volumes:
+        - name: etc-kubernetes-kube-parrot
+          hostPath:
+            path: /etc/kubernetes/kube-parrot
+{{- end }}
+{{- end }}
+{{- else }}
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -74,5 +156,6 @@ spec:
         - name: etc-kubernetes-kube-parrot
           hostPath:
             path: /etc/kubernetes/kube-parrot
+{{- end }}
 {{- end }}
 {{- end }}

--- a/system/kube-parrot/values.yaml
+++ b/system/kube-parrot/values.yaml
@@ -4,6 +4,11 @@ global:
 selector:   true 
 toleration: false 
 
+podsubnet: true
+
+globalRegion:
+  enabled: false
+
 images:
   parrot:
     repository: sapcc/kube-parrot


### PR DESCRIPTION
if globalRegion is enabled, creates Daemonset per region with specific BGP AS values