### PR TITLE
Migrate all PX k8s manifests to helm

### DIFF
--- a/px/bird/Chart.yaml
+++ b/px/bird/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+description: A Helm chart for a PX Bird deployment
+name: px-bird
+version: "0.1"

--- a/px/bird/templates/_configmap-bird.tpl
+++ b/px/bird/templates/_configmap-bird.tpl
@@ -1,0 +1,19 @@
+{{- define "configmap_bird" -}}
+{{- $files := index . 0 -}}
+{{- $bird_config_path := index . 1 | required "bird_config_path cannot be empty" }}
+{{- $config_name := index . 2 | required "config_name cannot be empty" }}
+
+{{- $config_path := printf "%s%s.conf" $bird_config_path $config_name -}}
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+    name: cfg-{{ $config_name }}
+data:
+    "{{ $config_name }}.conf": |
+{{- if not ($files.Glob $config_path) -}}
+{{- fail (printf "bird config file %s does not exist."  $config_path ) -}}
+{{- end }}
+{{ $files.Get $config_path | indent 6 }}
+
+{{ end }}

--- a/px/bird/templates/_deployment-bird.tpl
+++ b/px/bird/templates/_deployment-bird.tpl
@@ -1,0 +1,69 @@
+{{- define "deployment_bird" -}}
+{{- $values := index . 0 }}
+{{- $deployment_name := index . 1 | required "deployment_name cannot be empty" }}
+{{- $service_number := index . 2 }}
+{{- $service := index . 3 }}
+{{- $domain_number := index . 4}}
+{{- $domain_config := index . 5 }}
+initContainers:
+- name: {{ $deployment_name }}-init
+  image: busybox
+  command: ["sh", "-c", "ip link set vlan{{ $domain_config.multus_vlan }} promisc on"]
+  securityContext:
+    privileged: true
+containers:
+- name: {{ $deployment_name }}
+  image: keppel.{{ required "A registry mus be set" $values.registry }}.cloud.sap/{{ required "A bird_image must be set" $values.bird_image }}
+  securityContext:
+    capabilities:
+      add: ["NET_ADMIN"]
+  imagePullPolicy: Always
+  volumeMounts:
+  - name: vol-{{ $deployment_name }}
+    mountPath: /etc/bird
+  - name: bird-socket
+    mountPath: /var/run/bird
+  livenessProbe:
+    exec:
+      command: ["bird-command", "--liveness"]
+    initialDelaySeconds: 5
+    periodSeconds: 5
+- name: {{ $deployment_name }}-exporter
+  image: keppel.{{ $values.registry }}.cloud.sap/{{required "bird_exporter_image must be set" $values.bird_exporter_image}}
+  args: ["-format.new=true", "-bird.v2", "-bird.socket=/var/run/bird/bird.ctl", "-proto.ospf=false", "-proto.direct=false"]
+  volumeMounts:
+  - name: bird-socket
+    mountPath: /var/run/bird
+    readOnly: true
+  ports:
+  - containerPort: 9324
+    name: metrics
+- name: {{ $deployment_name }}-lgproxy
+  image: keppel.{{ $values.registry }}.cloud.sap/{{ required "lg_image must be set" $values.lg_image }}
+  command: ["python3"]
+  args: ["lgproxy.py"]
+  volumeMounts:
+  - name: bird-socket
+    mountPath: /var/run/bird
+    readOnly: true
+  ports:
+  - containerPort: 5000
+    name: lgproxy
+- name: {{ $deployment_name }}-lgadminproxy
+  image: keppel.{{ $values.registry }}.cloud.sap/{{ $values.lg_image }}
+  command: ["python3"]
+  args: ["lgproxy.py", "priv"]
+  volumeMounts:
+  - name: bird-socket
+    mountPath: /var/run/bird
+    readOnly: true
+  ports:
+  - containerPort: 5005
+    name: lgadminproxy
+volumes:
+  - name: vol-{{ $deployment_name }}
+    configMap:
+      name: cfg-{{ $values.region }}-pxrs-{{ $domain_number }}-s{{ $service_number }}
+  - name: bird-socket
+    emptyDir: {}
+{{- end }}

--- a/px/bird/templates/_deployment_header.tpl
+++ b/px/bird/templates/_deployment_header.tpl
@@ -1,0 +1,86 @@
+{{- define "deployment_header" -}}
+{{- $deployment_name := index . 0 | required "deployment_name cannot be empty"}}
+{{- $apod := index . 1 | required "apod must be set" }}
+{{- $scheduling_labels := index . 2 }}
+{{- $px_availability_zones := index . 3 }}
+{{- $multus_vlan := index . 4 | required "multus_vlan is required for every domain" }}
+{{- $service_number := index . 5 }}
+{{- $service := index . 6 }}
+{{- $domain_number := index . 7}}
+{{- $domain := index . 8}}
+{{- $instance_number := index . 9}}
+{{- $instance := index . 10}}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $deployment_name }}
+  namespace: px
+  labels:
+    app: {{ $deployment_name | quote }}
+    pxservice: '{{ $service_number }}'
+    pxdomain: '{{ $domain_number }}'
+    pxinstance: '{{ $instance_number }}'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ $deployment_name | quote }}
+      pxservice: '{{ $service_number }}'
+      pxdomain: '{{ $domain_number }}'
+      pxinstance: '{{ $instance_number }}'
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: {{ $deployment_name }}
+        pxservice: '{{ $service_number }}'
+        pxdomain: '{{ $domain_number }}'
+        pxinstance: '{{ $instance_number }}'
+      annotations:
+        k8s.v1.cni.cncf.io/networks: '[{ "name": "{{ $deployment_name }}", "interface": "vlan{{ $multus_vlan}}"}]'
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9324"
+        prometheus.io/targets: "infra-collector"
+    spec:
+{{- if $apod }}
+{{- if len $px_availability_zones | eq 0 -}}
+{{- fail "px_availability_zones must contain members if apod" -}}
+{{- end }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: failure-domain.beta.kubernetes.io/zone
+                operator: In
+                values:
+                - {{ index $px_availability_zones (mod (sub $domain_number 1) (len  $px_availability_zones)) }}                
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: pxservice
+                operator: In
+                values:
+                - {{ $service_number | quote }}
+            topologyKey: "kubernetes.cloud.sap/host"
+{{- else }}
+{{ $domain_scheduling_labels := get $scheduling_labels $domain }}
+{{- if $domain_scheduling_labels | len | eq 0 -}}
+{{- fail "scheduling_labels must be set if not apod" -}}
+{{- end }}
+      tolerations:
+        - key: species
+          operator: Equal
+          value: px
+          effect: NoSchedule
+      nodeSelector:
+          # This calculation only works if we have no more than 2 instances and no more than 2 scheduling labels per domain
+          pxdomain: "{{ index $domain_scheduling_labels (mod (sub $instance_number 1) (len $domain_scheduling_labels)) }}"
+{{- end }}
+{{- end }}

--- a/px/bird/templates/_nad_multus.tpl
+++ b/px/bird/templates/_nad_multus.tpl
@@ -1,0 +1,23 @@
+{{- define "nad_multus" -}}
+{{- $deployment_name := index . 0 | required "deployment_name cannot be empty" }}
+{{- $vlan:= index . 1 -}}
+{{- $ip:= index . 2 -}}
+---
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: {{ $deployment_name }}
+  namespace: px
+spec:
+  config: |
+    {
+        "cniVersion": "0.3.0",
+        "type": "macvlan",
+        "master": "vlan_{{ required "multus_vlan is required for every domai" $vlan }}",
+        "mode": "bridge",
+        "ipam": {
+        "type": "static",
+        "addresses": [{ "address": "{{ required "bird_ip or pxmon_ip must be set" $ip }}"}]
+        }
+    }
+{{ end }}

--- a/px/bird/templates/_service_pxrs.tpl
+++ b/px/bird/templates/_service_pxrs.tpl
@@ -1,0 +1,20 @@
+{{- define "service_pxrs" -}}
+{{- $deployment_name := index . 0 | required "deployment_name cannot be empty" }}
+{{- $looking_glass := index . 1 | required "looking_glass cannot be empty" }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $deployment_name }}
+  namespace: px
+spec:
+  ports:
+{{- range $lg, $lg_config := $looking_glass }}
+  - name: {{ $lg }}proxy
+    protocol: TCP
+    port: {{ required "proxy_port cannot be empty" $lg_config.proxy_port }}
+    targetPort: {{ $lg }}proxy
+{{- end }}
+  selector:
+    app: {{ $deployment_name }}
+{{ end }}

--- a/px/bird/templates/bird.yaml
+++ b/px/bird/templates/bird.yaml
@@ -1,0 +1,32 @@
+{{- range $service, $service_config := .Values.config -}}
+{{ if and (hasPrefix "service_" $service) (has $service $.Values.deploy) }}
+{{- $service_number := trimPrefix "service_" $service | int -}}
+
+{{- range $domain, $domain_config := $service_config -}}
+{{ if and (hasPrefix "domain_" $domain) (has $domain $.Values.deploy) }}
+{{- $domain_number := trimPrefix "domain_" $domain | int -}}
+{{- $config_name := printf "%s-pxrs-%d-s%d" $.Values.region $domain_number $service_number -}}
+
+{{ tuple $.Files $.Values.bird_config_path $config_name | include "configmap_bird" }}
+
+{{- range $instance, $instance_config := $domain_config -}}
+{{ if and (hasPrefix "instance_" $instance) (has $instance $.Values.deploy) }}
+{{- $instance_number := trimPrefix "instance_" $instance | int -}}
+{{- $deployment_name := printf "%s-pxrs-%d-s%d-%d" $.Values.region $domain_number $service_number $instance_number -}}
+
+---
+{{ tuple $deployment_name $domain_config.multus_vlan $instance_config.bird_ip | include "nad_multus"}}
+{{ tuple $deployment_name $.Values.apod $.Values.scheduling_labels $.Values.px_availability_zones $domain_config.multus_vlan $service_number $service $domain_number $domain $instance_number $instance | include "deployment_header" }}
+{{ tuple $.Values $deployment_name $service_number $service_config $domain_number $domain_config | include "deployment_bird" | indent 6 }}
+{{ tuple $deployment_name $.Values.looking_glass | include "service_pxrs" }}
+
+{{- if hasKey $instance_config "pxmon_ip" -}}
+{{- tuple (printf "%s-pxmon" $deployment_name) $domain_config.multus_vlan $instance_config.bird_ip | include "nad_multus"}}
+{{- end -}}
+
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/px/bird/values.yaml
+++ b/px/bird/values.yaml
@@ -1,0 +1,81 @@
+region: __DEFINED_AS_ARG__
+
+# to be set on the cli to specify the actual services, domains, instances to deploy
+# service_1, domain_1, instance_1, instance_2 will deploy all deployments in s1 d1
+deploy: []
+
+registry:
+
+apod: true
+#only required if apod == true
+px_availability_zones: []
+
+# only required if apod != true
+scheduling_labels:
+  domain_1: []
+  domain_2: []
+
+bird_config_path: bird_configs/
+
+bird_exporter_image:
+bird_image:
+lg_image:
+
+
+looking_glass:
+  lg:
+    proxy_port: 5000
+    authenticate: false
+    subdomain: px
+  lgadmin:
+    authenticate: true
+    proxy_port: 5005
+    subdomain: pxadmin
+
+probe_interval_ms: 5000
+probe_timeout_ms: 3000
+
+config:
+  service_1:
+    domain_1:
+      multus_vlan:
+      instance_1:
+        multus_ip:
+      instance_2:
+        multus_ip:
+    domain_2:
+      multus_vlan:
+      instance_1:
+        multus_ip:
+      instance_2:
+        multus_ip:
+
+
+  service_2:
+    domain_1:
+      multus_vlan:
+      instance_1:
+        multus_ip:
+      instance_2:
+        multus_ip:
+    domain_2:
+      multus_vlan:
+      instance_1:
+        multus_ip:
+      instance_2:
+        multus_ip:
+
+
+  service_3:
+    domain_1:
+      multus_vlan:
+      instance_1:
+        multus_ip:
+      instance_2:
+        multus_ip:
+    domain_2:
+      multus_vlan:
+      instance_1:
+        multus_ip:
+      instance_2:
+        multus_ip:


### PR DESCRIPTION
PX deployments, configmaps, nads, etc. were rendered by handcrafted
python scripts, in some cases k8s manifests were written by hand. In
order to abandon that script infrastructure, we move everything over to
helm and secrets.

Previous rendered manifests where these templates are based on can be
found here:
https://github.wdf.sap.corp/cc/px-cfg/tree/4da52beca51319b4ef2959751a72d881f3dd9388/kubernetes

Old pythonic templates are to be found here:
https://github.wdf.sap.corp/cc/px-cfg/tree/4da52beca51319b4ef2959751a72d881f3dd9388/kubernetes/template