### PR TITLE
Revert "avoid de-scheduling of databases"

### DIFF
--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.3.53
+version: 0.3.52

--- a/common/mariadb/templates/deployment.yaml
+++ b/common/mariadb/templates/deployment.yaml
@@ -20,7 +20,6 @@ spec:
         app: {{ include "fullName" . }}
         name: {{ template "fullName" . }}
       annotations:
-        descheduler.alpha.kubernetes.io/evict: "false"
         checksum/secrets: {{ include (print $.Template.BasePath  "/secret.yaml") . | sha256sum }}
         checksum/etc: {{ include (print $.Template.BasePath  "/etc-configmap.yaml") . | sha256sum }}
 {{- if .Values.metrics.enabled }}

--- a/common/memcached/Chart.yaml
+++ b/common/memcached/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: memcached
-version: 0.0.11
+version: 0.0.10
 description: Free & open source, high-performance, distributed memory object caching system.
 home: http://memcached.org/
 sources:

--- a/common/memcached/templates/deployment.yaml
+++ b/common/memcached/templates/deployment.yaml
@@ -22,8 +22,6 @@ spec:
       app: {{ template "fullname" . }}
   template:
     metadata:
-      annotations:
-        descheduler.alpha.kubernetes.io/evict: "false"
       labels:
         app: {{ template "fullname" . }}
         component: memcached

--- a/common/postgresql/templates/deployment.yaml
+++ b/common/postgresql/templates/deployment.yaml
@@ -31,7 +31,6 @@ spec:
         alert-service: {{ include "alerts.service" . }}
         {{- end }}
       annotations:
-        descheduler.alpha.kubernetes.io/evict: "false"
         checksum/secrets: {{ include (print $.Template.BasePath  "/secrets.yaml") . | sha256sum }}
         checksum/etc: {{ include (print $.Template.BasePath  "/etc-configmap.yaml") . | sha256sum }}
     spec:

--- a/common/redis/Chart.yaml
+++ b/common/redis/Chart.yaml
@@ -12,4 +12,4 @@ maintainers:
 name: redis
 sources:
 - https://github.com/bitnami/bitnami-docker-redis
-version: 1.1.8
+version: 1.1.7

--- a/common/redis/templates/deployment.yaml
+++ b/common/redis/templates/deployment.yaml
@@ -13,8 +13,6 @@ spec:
       app: {{ template "redis.fullname" . }}
   template:
     metadata:
-      annotations:
-        descheduler.alpha.kubernetes.io/evict: "false"
       labels:
         app: {{ template "redis.fullname" . }}
         {{- if .Values.alerts.enabled }}


### PR DESCRIPTION
An annotation change means a restart, which is currently not
well handled.

This reverts commit 6dbbc0d7c2accad0cb158de1c49a31566eadda68.