### PR TITLE
[nova] Optionally enable RPC metrics collection

### DIFF
--- a/openstack/nova/templates/cell2-conductor-deployment.yaml
+++ b/openstack/nova/templates/cell2-conductor-deployment.yaml
@@ -27,6 +27,11 @@ spec:
         name: nova-conductor
 {{ tuple . "nova" "conductor" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
       annotations:
+        {{- if .Values.cell2.conductor.config_file.DEFAULT.statsd_enabled }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9102"
+        prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
+        {{- end }}
         configmap-etc-hash: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
     spec:
 {{ tuple . "nova" "conductor" | include "kubernetes_pod_anti_affinity" | indent 6 }}
@@ -101,6 +106,23 @@ spec:
               name: nova-etc
               subPath: logging.ini
               readOnly: true
+        {{- if .Values.cell2.conductor.config_file.DEFAULT.statsd_enabled }}
+        - name: statsd
+          image: {{ required ".Values.global.dockerHubMirror is missing" .Values.global.dockerHubMirror}}/prom/statsd-exporter:v0.8.1
+          imagePullPolicy: IfNotPresent
+          args: [ --statsd.mapping-config=/etc/statsd/statsd-exporter.yaml ]
+          ports:
+          - name: statsd
+            containerPort: {{ .Values.conductor.config_file.DEFAULT.statsd_port }}
+            protocol: UDP
+          - name: metrics
+            containerPort: 9102
+          volumeMounts:
+            - name: nova-etc
+              mountPath: /etc/statsd/statsd-exporter.yaml
+              subPath: statsd-exporter.yaml
+              readOnly: true
+        {{- end }}
       volumes:
         - name: etcnova
           emptyDir: {}

--- a/openstack/nova/templates/conductor-deployment.yaml
+++ b/openstack/nova/templates/conductor-deployment.yaml
@@ -26,6 +26,11 @@ spec:
         name: nova-conductor
 {{ tuple . "nova" "conductor" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
       annotations:
+        {{- if .Values.conductor.config_file.DEFAULT.statsd_enabled }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9102"
+        prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
+        {{- end }}
         configmap-etc-hash: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
     spec:
 {{ tuple . "nova" "conductor" | include "kubernetes_pod_anti_affinity" | indent 6 }}
@@ -85,6 +90,23 @@ spec:
               name: nova-etc
               subPath: logging.ini
               readOnly: true
+        {{- if .Values.conductor.config_file.DEFAULT.statsd_enabled }}
+        - name: statsd
+          image: {{ required ".Values.global.dockerHubMirror is missing" .Values.global.dockerHubMirror}}/prom/statsd-exporter:v0.8.1
+          imagePullPolicy: IfNotPresent
+          args: [ --statsd.mapping-config=/etc/statsd/statsd-exporter.yaml ]
+          ports:
+          - name: statsd
+            containerPort: {{ .Values.conductor.config_file.DEFAULT.statsd_port }}
+            protocol: UDP
+          - name: metrics
+            containerPort: 9102
+          volumeMounts:
+            - name: nova-etc
+              mountPath: /etc/statsd/statsd-exporter.yaml
+              subPath: statsd-exporter.yaml
+              readOnly: true
+        {{- end }}
       volumes:
         - name: etcnova
           emptyDir: {}

--- a/openstack/nova/templates/etc/_nova-scheduler.conf.tpl
+++ b/openstack/nova/templates/etc/_nova-scheduler.conf.tpl
@@ -2,6 +2,8 @@
 # Scheduling
 scheduler_host_manager = {{ if .Values.global.hypervisors_ironic }}ironic_host_manager{{ else }}host_manager{{ end }}
 scheduler_driver = {{ .Values.scheduler.driver }}
+statsd_port = {{ .Values.scheduler.rpc_statsd_port }}
+statsd_enabled = {{ .Values.scheduler.rpc_statsd_enabled }}
 
 [scheduler]
 discover_hosts_in_cells_interval = 60

--- a/openstack/nova/templates/hypervisors/hypervisors-vmware-configmap-vct.yaml
+++ b/openstack/nova/templates/hypervisors/hypervisors-vmware-configmap-vct.yaml
@@ -31,6 +31,8 @@ template: |
       ram_allocation_ratio = {{ .Values.compute.defaults.default.ram_allocation_ratio }}
       cpu_allocation_ratio = {{ .Values.compute.defaults.default.cpu_allocation_ratio }}
       block_device_allocate_retries = {{ .Values.compute.defaults.default.block_device_allocate_retries }}
+      statsd_port = {{ .Values.compute.defaults.default.rpc_statsd_port }}
+      statsd_enabled = {{ .Values.compute.defaults.default.rpc_statsd_enabled }}
 
       scheduler_tracks_instance_changes = {{ .Values.scheduler.scheduler_tracks_instance_changes }}
       scheduler_instance_sync_interval = {{ .Values.scheduler.scheduler_instance_sync_interval }}

--- a/openstack/nova/templates/scheduler-deployment.yaml
+++ b/openstack/nova/templates/scheduler-deployment.yaml
@@ -26,6 +26,11 @@ spec:
         name: nova-scheduler
 {{ tuple . "nova" "scheduler" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
       annotations:
+        {{- if .Values.scheduler.rpc_statsd_enabled }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9102"
+        prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
+        {{- end }}
         configmap-etc-hash: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
     spec:
 {{ tuple . "nova" "scheduler" | include "kubernetes_pod_anti_affinity" | indent 6 }}
@@ -89,6 +94,23 @@ spec:
               mountPath: /etc/nova/logging.ini
               subPath: logging.ini
               readOnly: true
+        {{- if .Values.scheduler.rpc_statsd_enabled }}
+        - name: statsd
+          image: {{ required ".Values.global.dockerHubMirror is missing" .Values.global.dockerHubMirror}}/prom/statsd-exporter:v0.8.1
+          imagePullPolicy: IfNotPresent
+          args: [ --statsd.mapping-config=/etc/statsd/statsd-exporter.yaml ]
+          ports:
+          - name: statsd
+            containerPort: {{ .Values.scheduler.rpc_statsd_port }}
+            protocol: UDP
+          - name: metrics
+            containerPort: 9102
+          volumeMounts:
+            - name: nova-etc
+              mountPath: /etc/statsd/statsd-exporter.yaml
+              subPath: statsd-exporter.yaml
+              readOnly: true
+        {{- end }}
       volumes:
         - name: etcnova
           emptyDir: {}

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -37,7 +37,11 @@ cell2:
   name: cell2
   enabled: false
   conductor:
-    config_file: {}
+    config_file:
+      DEFAULT:
+        statsd_port: 9125
+        # enables collecting metrics for rpc calls
+        statsd_enabled: false
 
 defaults:
   default:
@@ -48,11 +52,14 @@ defaults:
         reserved_host_memory_mb: 512
         disk_allocation_ratio: "1.0"
         reserved_host_disk_mb: "0"
+        statsd_port: 9125
     ironic:
       default:
         reserved_host_memory_mb: "0"
         compute_driver: ironic.IronicDriver
         graceful_shutdown_timeout: 1800
+        # enables collecting metrics for RPC calls
+        statsd_enabled: false
       ironic:
         serial_console_state_timeout: 10
     kvm:
@@ -60,6 +67,8 @@ defaults:
         compute_driver: libvirt.LibvirtDriver
         firewall_driver: nova.virt.firewall.NoopFirewallDriver
         resume_guests_state_on_host_boot: true
+        # enables collecting metrics for RPC calls
+        statsd_enabled: false
 
 pod:
   replicas:
@@ -254,6 +263,9 @@ scheduler:
   driver: "filter_scheduler"
   scheduler_tracks_instance_changes: false
   scheduler_instance_sync_interval: 120
+  rpc_statsd_port: 9125
+  # enables collecting metrics for RPC calls
+  rpc_statsd_enabled: false
   default_filters: "AvailabilityZoneFilter, CpuInfoMigrationFilter, ShardFilter, AggregateMultiTenancyIsolation, RamFilter, DiskFilter, ComputeFilter, ComputeCapabilitiesFilter, BigVmFlavorHostSizeFilter, VmSizeThresholdFilter, ImagePropertiesFilter, ServerGroupAntiAffinityFilter, ServerGroupAffinityFilter"
   vm_size_threshold_vm_size_mb: "8193"
   vm_size_threshold_hv_size_mb: "819200"
@@ -280,6 +292,9 @@ compute:
       cpu_allocation_ratio: 4.0
       # this will set a 15 mins timeout for blockdevice mapping
       block_device_allocate_retries: 300
+      rpc_statsd_port: 9125
+      # enables collecting metrics for RPC calls
+      rpc_statsd_enabled: false
     vmware:
       insecure: true
       use_linked_clone: false
@@ -296,6 +311,10 @@ compute:
 
 conductor:
   config_file:
+    DEFAULT:
+      statsd_port: 9125
+      # enables collecting metrics for rpc calls
+      statsd_enabled: false
     conductor:
       workers: 8
 


### PR DESCRIPTION
We've added a patch to oslo.messaging, that allows us to track the
number of RPC calls per called function and also if this call errored
out. This functionality can be enabled by setting statsd_enabled in the
DEFAULT section.

This change adds the possibility to enable this functionality for
nova-scheduler, nova-conductor and nova-compute pods (both ironic and
vmware).