### PR TITLE
Raise VCClusterDRSNotFullyAutomated to critical

### DIFF
--- a/prometheus-exporters/vrops-exporter/alerts/vccluster.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/vccluster.alerts
@@ -79,7 +79,7 @@ groups:
     expr: vrops_cluster_configuration_drsconfig_defaultvmbehavior{state != "fullyAutomated"} == 0
     for: 10m
     labels:
-      severity: warning
+      severity: critical
       tier: vmware
       service: compute
       context: "Cluster DRS configuration"


### PR DESCRIPTION
As discussed in the InfraOps weekly call.
InfraOps is aware, alert is working as expected.