### PR TITLE
Add CC-fabric driver manifests

### DIFF
--- a/openstack/neutron/templates/configmap-etc-cc-fabric.yaml
+++ b/openstack/neutron/templates/configmap-etc-cc-fabric.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.cc_fabric.agent.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: neutron-etc-cc-fabric
+  labels:
+    system: openstack
+    type: configuration
+    component: neutron
+
+data:
+  ml2_conf_cc-fabric.ini: |
+    [ml2_cc_fabric]
+    driver_config_path = /etc/neutron/plugins/ml2/cc-fabric-driver-config.yaml
+  cc-fabric-driver-config.yaml: |
+{{ toYaml (required "cc_fabric.driver_config cannot be empty" .Values.cc_fabric.driver_config) | indent 4 }}
+{{- end }}

--- a/openstack/neutron/templates/deployment-cc-fabric-agent.yaml
+++ b/openstack/neutron/templates/deployment-cc-fabric-agent.yaml
@@ -1,0 +1,99 @@
+{{- if .Values.cc_fabric.agent.enabled }}
+{{- range $platform := .Values.cc_fabric.agent.platforms }}
+---
+kind: Deployment
+apiVersion: apps/v1
+
+metadata:
+  name: neutron-cc-fabric-{{ $platform }}-agent
+  labels:
+    system: openstack
+    type: backend
+    component: neutron
+spec:
+  replicas: 1
+  revisionHistoryLimit: 5
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 3
+  selector:
+    matchLabels:
+      name: neutron-cc-fabric-{{ $platform }}-agent
+  template:
+    metadata:
+      labels:
+        name: neutron-cc-fabric-{{ $platform }}-agent
+{{ tuple $ "neutron" (printf "cc-fabric-%s-agent" $platform) | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
+      annotations:
+        pod.beta.kubernetes.io/hostname:  cc-fabric-{{ $platform }}-agent
+        configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") $ | sha256sum }}
+        configmap-etc-cc-fabric: {{ include (print $.Template.BasePath "/configmap-etc-cc-fabric.yaml") $ | sha256sum }}
+    spec:
+      hostname: cc-fabric-{{ $platform }}-agent
+      containers:
+        - name: neutron-cc-fabric-{{ $platform }}-agent
+          image: {{$.Values.global.registry}}/loci-neutron:{{ $.Values.imageVersionCCFabric | default $.Values.imageVersion | required "Please set neutron.imageVersionCCFabric or similar"}}
+          imagePullPolicy: IfNotPresent
+          command:
+            - cc-{{ $platform }}-switch-agent
+          args:
+            - --config-file
+            - /etc/neutron/neutron.conf
+            - --config-file
+            - /etc/neutron/plugins/ml2/ml2-conf.ini
+            - --config-file
+            - /etc/neutron/plugins/ml2/ml2_conf_cc-fabric.ini
+          livenessProbe:
+            exec:
+              command: ["neutron-agent-liveness", "--agent-type", "CC fabric agent", "--config-file", "/etc/neutron/neutron.conf"]
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 10
+          resources:
+{{ toYaml $.Values.pod.resources.cc_fabric_agent | indent 12 }}
+          env:
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: sentry
+                  key: neutron.DSN.python
+          volumeMounts:
+            - mountPath: /etc/neutron/neutron.conf
+              name: neutron-etc
+              subPath: neutron.conf
+              readOnly: true
+            - mountPath: /etc/neutron/plugins/ml2/
+              name: empty-neutron-ml2
+            - mountPath: /etc/neutron/plugins/ml2/ml2_conf_cc-fabric.ini
+              name: neutron-etc-cc-fabric
+              subPath: ml2_conf_cc-fabric.ini
+              readOnly: true
+            - mountPath: /etc/neutron/plugins/ml2/cc-fabric-driver-config.yaml
+              name: neutron-etc-cc-fabric
+              subPath: cc-fabric-driver-config.yaml
+              readOnly: true
+            - mountPath: /etc/neutron/plugins/ml2/ml2-conf.ini
+              name: neutron-etc
+              subPath: ml2-conf.ini
+              readOnly: true
+            - mountPath: /etc/neutron/rootwrap.conf
+              name: neutron-etc
+              subPath: rootwrap.conf
+              readOnly: true
+            - mountPath: /etc/neutron/logging.conf
+              name: neutron-etc
+              subPath: logging.conf
+              readOnly: true
+      volumes:
+        - name: empty-neutron-ml2
+          emptyDir: {}
+        - name: neutron-etc
+          configMap:
+            name: neutron-etc
+        - name: neutron-etc-cc-fabric
+          configMap:
+            name: neutron-etc-cc-fabric
+{{- end }}
+{{- end }}

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -61,6 +61,13 @@ pod:
       limits:
         cpu: "128m"
         memory: "256Mi"
+    cc_fabric_agent:
+      limits:
+        cpu: '1000m'
+        memory: '1Gi'
+      requests:
+        cpu: '250m'
+        memory: '512Mi' 
     server:
       requests:
         cpu: "4000m"
@@ -145,6 +152,7 @@ imageNameNetworkAgentDHCPInit: alpine
 # imageVersionServerRPC:
 # imageVersionServerAPI:
 # imageVersionACI:
+# imageVersionCCFabric:
 # imageVersionASR1kML2:
 # imageVersionASR1k:
 # imageVersionUCSM:
@@ -178,6 +186,13 @@ aci:
   # apic_user: null
   # apic_password: null
   # apic_tenant_name: null
+
+cc_fabric:
+  agent:
+    enabled: false
+    platforms: ['eos', 'nxos']
+
+  driver_config:
 
 arista:
   api_type: nocvx


### PR DESCRIPTION
Adding deployments for driver pod, additional configmap for driver
specific configuration and adjusting value file to include platforms
running as well as actual driver configuration showing the fabric
layout.