### PR TITLE
swift: no VPA magic

### DIFF
--- a/openstack/swift/templates/_utils.tpl
+++ b/openstack/swift/templates/_utils.tpl
@@ -315,3 +315,26 @@ server {{ printf "%9s" $short_name._0 }} {{ $upstream.target }}:{{ default 8080 
 server swift-svc swift-proxy-internal-{{ .Values.cluster_name }}:8080
 {{- end }}
 {{- end -}}
+
+{{- /**********************************************************************************/ -}}
+{{- /* Generate a VerticalPodAutoscaler object that ensures that our daemonsets never get automated CPU/memory requests. */ -}}
+{{- define "swift_vpa_no_autoupdates" -}}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ . }}
+
+spec:
+  targetRef:
+    apiVersion: v1
+    kind: DaemonSet
+    name: {{ . }}
+  resourcePolicy:
+    containerPolicies:
+    - containerName: '*'
+      controlledResources:
+      - cpu
+      - memory
+  updatePolicy:
+    updateMode: 'Off'
+{{- end -}}

--- a/openstack/swift/templates/proxy-daemonset.yaml
+++ b/openstack/swift/templates/proxy-daemonset.yaml
@@ -43,4 +43,7 @@ spec:
       containers:
         {{- tuple "daemonset" . | include "swift_proxy_containers" | indent 8 }}
 
+---
+{{ include "swift_vpa_no_autoupdates" (printf "swift-proxy-%s" .Values.cluster_name) }}
+
 {{- end }}

--- a/openstack/swift/templates/replicators-daemonset.yaml
+++ b/openstack/swift/templates/replicators-daemonset.yaml
@@ -38,3 +38,6 @@ spec:
         {{- tuple "account"   "account-replicator"   . | include "swift_standard_container" | indent 8 }}
         {{- tuple "container" "container-replicator" . | include "swift_standard_container" | indent 8 }}
         {{- tuple "object"    "object-replicator"    . | include "swift_standard_container" | indent 8 }}
+
+---
+{{ include "swift_vpa_no_autoupdates" "swift-replicators" }}

--- a/openstack/swift/templates/rsyncd-daemonset.yaml
+++ b/openstack/swift/templates/rsyncd-daemonset.yaml
@@ -60,3 +60,6 @@ spec:
               name: swift-drives
             - mountPath: /swift-drive-state
               name: swift-drive-state
+
+---
+{{ include "swift_vpa_no_autoupdates" "swift-rsyncd" }}

--- a/openstack/swift/templates/servers-daemonset.yaml
+++ b/openstack/swift/templates/servers-daemonset.yaml
@@ -70,3 +70,6 @@ spec:
             - name: swift-account
               hostPort: 6002
               containerPort: 6002
+
+---
+{{ include "swift_vpa_no_autoupdates" "swift-servers" }}

--- a/openstack/swift/templates/statsd-exporter-daemonset.yaml
+++ b/openstack/swift/templates/statsd-exporter-daemonset.yaml
@@ -47,3 +47,6 @@ spec:
           volumeMounts:
             - mountPath: /swift-etc
               name: swift-etc
+
+---
+{{ include "swift_vpa_no_autoupdates" "swift-statsd-exporter" }}

--- a/openstack/swift/templates/workers-daemonset.yaml
+++ b/openstack/swift/templates/workers-daemonset.yaml
@@ -42,3 +42,6 @@ spec:
         {{- tuple "object"    "object-auditor"    . | include "swift_standard_container" | indent 8 }}
         {{- tuple "object"    "object-updater"    . | include "swift_standard_container" | indent 8 }}
         {{- tuple "object"    "recon-cron"        . | include "swift_standard_container" | indent 8 }}
+
+---
+{{ include "swift_vpa_no_autoupdates" "swift-workers" }}


### PR DESCRIPTION
Before rollout:
```
$ k label vpa swift-{proxy-cluster-3,replicators,rsyncd,servers,statsd-exporter,workers} app.kubernetes.io/managed-by=Helm
$ k annotate vpa swift-{proxy-cluster-3,replicators,rsyncd,servers,statsd-exporter,workers} meta.helm.sh/release-name=swift meta.helm.sh/release-namespace=swift
```