### PR TITLE
[nova] adds mapping for rpc metrics collection

### DIFF
--- a/openstack/nova/templates/cell2-conductor-deployment.yaml
+++ b/openstack/nova/templates/cell2-conductor-deployment.yaml
@@ -110,7 +110,7 @@ spec:
         - name: statsd
           image: {{ required ".Values.global.dockerHubMirror is missing" .Values.global.dockerHubMirror}}/prom/statsd-exporter:v0.8.1
           imagePullPolicy: IfNotPresent
-          args: [ --statsd.mapping-config=/etc/statsd/statsd-exporter.yaml ]
+          args: [ --statsd.mapping-config=/etc/statsd/statsd-rpc-mapping.yaml.yaml ]
           ports:
           - name: statsd
             containerPort: {{ .Values.conductor.config_file.DEFAULT.statsd_port }}
@@ -119,8 +119,8 @@ spec:
             containerPort: 9102
           volumeMounts:
             - name: nova-etc
-              mountPath: /etc/statsd/statsd-exporter.yaml
-              subPath: statsd-exporter.yaml
+              mountPath: /etc/statsd/statsd-rpc-mapping.yaml
+              subPath: statsd-rpc-mapping.yaml
               readOnly: true
         {{- end }}
       volumes:

--- a/openstack/nova/templates/cell2-conductor-deployment.yaml
+++ b/openstack/nova/templates/cell2-conductor-deployment.yaml
@@ -110,7 +110,7 @@ spec:
         - name: statsd
           image: {{ required ".Values.global.dockerHubMirror is missing" .Values.global.dockerHubMirror}}/prom/statsd-exporter:v0.8.1
           imagePullPolicy: IfNotPresent
-          args: [ --statsd.mapping-config=/etc/statsd/statsd-rpc-mapping.yaml.yaml ]
+          args: [ --statsd.mapping-config=/etc/statsd/statsd-rpc-exporter.yaml ]
           ports:
           - name: statsd
             containerPort: {{ .Values.conductor.config_file.DEFAULT.statsd_port }}
@@ -119,8 +119,8 @@ spec:
             containerPort: 9102
           volumeMounts:
             - name: nova-etc
-              mountPath: /etc/statsd/statsd-rpc-mapping.yaml
-              subPath: statsd-rpc-mapping.yaml
+              mountPath: /etc/statsd/statsd-rpc-exporter.yaml
+              subPath: statsd-rpc-exporter.yaml
               readOnly: true
         {{- end }}
       volumes:

--- a/openstack/nova/templates/conductor-deployment.yaml
+++ b/openstack/nova/templates/conductor-deployment.yaml
@@ -94,7 +94,7 @@ spec:
         - name: statsd
           image: {{ required ".Values.global.dockerHubMirror is missing" .Values.global.dockerHubMirror}}/prom/statsd-exporter:v0.8.1
           imagePullPolicy: IfNotPresent
-          args: [ --statsd.mapping-config=/etc/statsd/statsd-exporter.yaml ]
+          args: [ --statsd.mapping-config=/etc/statsd/statsd-rpc-mapping.yaml ]
           ports:
           - name: statsd
             containerPort: {{ .Values.conductor.config_file.DEFAULT.statsd_port }}
@@ -103,8 +103,8 @@ spec:
             containerPort: 9102
           volumeMounts:
             - name: nova-etc
-              mountPath: /etc/statsd/statsd-exporter.yaml
-              subPath: statsd-exporter.yaml
+              mountPath: /etc/statsd/statsd-rpc-mapping.yaml
+              subPath: statsd-rpc-mapping.yaml
               readOnly: true
         {{- end }}
       volumes:

--- a/openstack/nova/templates/conductor-deployment.yaml
+++ b/openstack/nova/templates/conductor-deployment.yaml
@@ -94,7 +94,7 @@ spec:
         - name: statsd
           image: {{ required ".Values.global.dockerHubMirror is missing" .Values.global.dockerHubMirror}}/prom/statsd-exporter:v0.8.1
           imagePullPolicy: IfNotPresent
-          args: [ --statsd.mapping-config=/etc/statsd/statsd-rpc-mapping.yaml ]
+          args: [ --statsd.mapping-config=/etc/statsd/statsd-rpc-exporter.yaml ]
           ports:
           - name: statsd
             containerPort: {{ .Values.conductor.config_file.DEFAULT.statsd_port }}
@@ -103,8 +103,8 @@ spec:
             containerPort: 9102
           volumeMounts:
             - name: nova-etc
-              mountPath: /etc/statsd/statsd-rpc-mapping.yaml
-              subPath: statsd-rpc-mapping.yaml
+              mountPath: /etc/statsd/statsd-rpc-exporter.yaml
+              subPath: statsd-rpc-exporter.yaml
               readOnly: true
         {{- end }}
       volumes:

--- a/openstack/nova/templates/etc-configmap.yaml
+++ b/openstack/nova/templates/etc-configmap.yaml
@@ -63,5 +63,12 @@ data:
       match_type: glob
       glob_disable_ordering: false
       ttl: 0 # metrics do not expire
+  statsd-rpc-mapping.yaml: |
+    mappings:
+    - match: "oslo.messaging.*.*"
+      name: "oslo_messaging_events"
+      labels:
+        method: "$1"
+        type: "$2"
   placement_uwsgi.ini: |
 {{ include (print .Template.BasePath "/etc/_placement_uwsgi.ini.tpl") . | indent 4 }}

--- a/openstack/nova/templates/etc-configmap.yaml
+++ b/openstack/nova/templates/etc-configmap.yaml
@@ -63,7 +63,7 @@ data:
       match_type: glob
       glob_disable_ordering: false
       ttl: 0 # metrics do not expire
-  statsd-rpc-mapping.yaml: |
+  statsd-rpc-exporter.yaml: |
     mappings:
     - match: "oslo.messaging.*.*"
       name: "oslo_messaging_events"

--- a/openstack/nova/templates/hypervisors/_ironic-deployment.yaml.tpl
+++ b/openstack/nova/templates/hypervisors/_ironic-deployment.yaml.tpl
@@ -92,7 +92,7 @@ spec:
         - name: statsd
           image: {{ required ".Values.global.dockerHubMirror is missing" .Values.global.dockerHubMirror}}/prom/statsd-exporter:v0.8.1
           imagePullPolicy: IfNotPresent
-          args: [ --statsd.mapping-config=/etc/statsd/statsd-exporter.yaml ]
+          args: [ --statsd.mapping-config=/etc/statsd/statsd-rpc-exporter.yaml ]
           ports:
           - name: statsd
             containerPort: {{ $hypervisor.default.statsd_port }}
@@ -101,8 +101,8 @@ spec:
             containerPort: 9102
           volumeMounts:
             - name: nova-etc
-              mountPath: /etc/statsd/statsd-exporter.yaml
-              subPath: statsd-exporter.yaml
+              mountPath: /etc/statsd/statsd-rpc-exporter.yaml
+              subPath: statsd-rpc-exporter.yaml
               readOnly: true
         {{- end }}
       volumes:

--- a/openstack/nova/templates/scheduler-deployment.yaml
+++ b/openstack/nova/templates/scheduler-deployment.yaml
@@ -98,7 +98,7 @@ spec:
         - name: statsd
           image: {{ required ".Values.global.dockerHubMirror is missing" .Values.global.dockerHubMirror}}/prom/statsd-exporter:v0.8.1
           imagePullPolicy: IfNotPresent
-          args: [ --statsd.mapping-config=/etc/statsd/statsd-exporter.yaml ]
+          args: [ --statsd.mapping-config=/etc/statsd/statsd-rpc-exporter.yaml ]
           ports:
           - name: statsd
             containerPort: {{ .Values.scheduler.rpc_statsd_port }}
@@ -107,8 +107,8 @@ spec:
             containerPort: 9102
           volumeMounts:
             - name: nova-etc
-              mountPath: /etc/statsd/statsd-exporter.yaml
-              subPath: statsd-exporter.yaml
+              mountPath: /etc/statsd/statsd-rpc-exporter.yaml
+              subPath: statsd-rpc-exporter.yaml
               readOnly: true
         {{- end }}
       volumes:


### PR DESCRIPTION
without a specific mapping every rpc method would create its own metric in prometheus. e.g.:
- oslo_messaging_attach_volume_event
- oslo_messaging_object_action_exception
- ...

we rather want one metric: 'oslo_messaging_events' with labels method and type e.g.:
- oslo_messaging_events{method: attach_volume, type: event}
- oslo_messaging_events{method: object_action, type: exception}