### PR TITLE
alertmanager - enabling email notification for barbican alert

### DIFF
--- a/global/prometheus-alertmanager-operated/templates/_alertmanager.yaml.tpl
+++ b/global/prometheus-alertmanager-operated/templates/_alertmanager.yaml.tpl
@@ -70,6 +70,14 @@ route:
       severity: info
       region: ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|ap-sa-2|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-2|na-us-3|qa-de-1
 
+  - receiver: email_barbican_certificate
+    continue: false
+    match_re:
+      service: barbican
+      context: certificate
+      severity: info
+      region: qa-de-1
+
   - receiver: slack_nannies
     continue: false
     match_re:
@@ -808,6 +816,44 @@ receivers:
         icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
         color: {{`'{{template "slack.sapcc.color" . }}'`}}
         send_resolved: true
+
+  - name: email_barbican_certificate
+    email_configs:
+    - to: "{{ .CommonLabels.email }}"
+      from: 'CCloud <noreply+ccloud@email.global.cloud.sap>'
+      require_tls: false
+      headers:
+        subject: "Your Barbican Certificate {{ .CommonLabels.certificate_name }} Is About To Expired"
+        cc: ""
+      html: |
+        <p>
+        Hi,
+        <br>
+        <b>{{ .CommonAnnotations.description }}</b>
+        <br>
+        Please take necessary actions to prevent possible service outage value 
+        <br>
+        If this certificate is no longer needed please remove it to prevent false alarms.
+        </p>
+
+    {{- range $key, $value := .Values.certificate.recipients }}
+    - to: {{ $value }}
+      from: 'CCloud <noreply+ccloud@email.global.cloud.sap>'
+      require_tls: false
+      headers:
+        subject: "Your Barbican Certificate {{ .CommonLabels.certificate_name }} Is About To Expired"
+        cc: ""
+      html: |
+        <p>
+        Hi,
+        <br>
+        <b>{{ .CommonAnnotations.description }}</b>
+        <br>
+        Please take necessary actions to prevent possible service outage value 
+        <br>
+        If this certificate is no longer needed please remove it to prevent false alarms.
+        </p>
+    {{- end }}
 
   - name: slack_hsm
     slack_configs:

--- a/global/prometheus-alertmanager-operated/values.yaml
+++ b/global/prometheus-alertmanager-operated/values.yaml
@@ -42,3 +42,7 @@ pagerduty_sap:
   vmware: {}
   osd_mom_network: {}
   osd_mom_compute: {}
+
+certificate:
+  recipients:
+    - something@example.com


### PR DESCRIPTION
Enabling email notification for  barbican certificate alert, new receiver name: email_barbican_certificate and enable it in qa-de-1