### PR TITLE
[Elastiflow] Adds alert routing in alertmanager

### DIFF
--- a/global/prometheus-alertmanager-operated/Chart.yaml
+++ b/global/prometheus-alertmanager-operated/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 description: Prometheus Alertmanager via operator.
 name: prometheus-alertmanager-operated
-version: 2.0.2
+version: 2.0.3
 
 dependencies:
   - alias: prometheus-alertmanager

--- a/global/prometheus-alertmanager-operated/templates/_alertmanager.yaml.tpl
+++ b/global/prometheus-alertmanager-operated/templates/_alertmanager.yaml.tpl
@@ -70,6 +70,12 @@ route:
       severity: info
       region: ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|ap-sa-2|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-2|na-us-3|qa-de-1
 
+  - receiver: slack_elastiflow
+    continue: false
+    match_re:
+      service: elastiflow
+      region: ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|ap-sa-2|eu-de-1|eu-de-2|eu-nl-1|eu-ru-1|la-br-1|na-ca-1|na-us-1|na-us-2|na-us-3
+
   - receiver: slack_nannies
     continue: false
     match_re:
@@ -716,6 +722,19 @@ receivers:
   - name: slack_cc-cp
     slack_configs:
       - channel: '#cc-cp'
+        api_url: {{ required ".Values.slack.webhookURL undefined" .Values.slack.webhookURL | quote }}
+        username: "Pulsar"
+        title: {{"'{{template \"slack.sapcc.title\" . }}'"}}
+        title_link: {{"'{{template \"slack.sapcc.titlelink\" . }}'"}}
+        text: {{"'{{template \"slack.sapcc.text\" . }}'"}}
+        pretext: {{"'{{template \"slack.sapcc.pretext\" . }}'"}}
+        icon_emoji: {{"'{{template \"slack.sapcc.iconemoji\" . }}'"}}
+        color: {{`'{{template "slack.sapcc.color" . }}'`}}
+        send_resolved: true
+
+  - name: slack_elastiflow
+    slack_configs:
+      - channel: '#cc-net-elastiflow'
         api_url: {{ required ".Values.slack.webhookURL undefined" .Values.slack.webhookURL | quote }}
         username: "Pulsar"
         title: {{"'{{template \"slack.sapcc.title\" . }}'"}}


### PR DESCRIPTION
- Routes all `service: elastiflow` alerts to cc-net-elastiflow
- Elastiflow alerts are no longer routed to cc-net-\<severity\> channels