### PR TITLE
[openstack-exporter]  Fix the tier for cinder alerts

### DIFF
--- a/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
+++ b/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
@@ -20,7 +20,7 @@ groups:
     for: 15m
     labels:
       severity: warning
-      tier: os
+      tier: vmware
       service: cinder
       playbook: docs/support/playbook/cinder/cinder_low_free_space.html
     annotations:
@@ -31,7 +31,7 @@ groups:
     for: 15m
     labels:
       severity: warning
-      tier: os
+      tier: vmware
       service: cinder
       playbook: docs/support/playbook/cinder/cinder_low_free_space.html
     annotations:


### PR DESCRIPTION
This patch changes the tier from os to vmware to send the
alerts to infraops