### PR TITLE
[Openstack-exporter] update the cinder playbook filenames

### DIFF
--- a/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
+++ b/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
@@ -11,7 +11,7 @@ groups:
       service: cinder
       context: "openstack-exporter"
       meta: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has no storage capacity."
-      playbook: docs/support/playbook/cinder/cinder_storage_profile_empty.html
+      playbook: docs/support/playbook/cinder/cinder-storage-profile-empty.html
     annotations:
       description: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has no storage capacity."
       summary: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has no storage capacity."
@@ -22,7 +22,7 @@ groups:
       severity: warning
       tier: vmware
       service: cinder
-      playbook: docs/support/playbook/cinder/cinder_low_free_space.html
+      playbook: docs/support/playbook/cinder/cinder-low-free-space.html
     annotations:
       description: 'Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has 3 or less datastores with > 30% free space left'
       summary: 'Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has 3 or less3 datastores with > 30% free space left'
@@ -33,7 +33,7 @@ groups:
       severity: warning
       tier: vmware
       service: cinder
-      playbook: docs/support/playbook/cinder/cinder_low_free_space.html
+      playbook: docs/support/playbook/cinder/cinder-low-free-space.html
     annotations:
       description: 'Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 2 datastores with > 30% free space left'
       summary: 'Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 2 datastores with > 30% free space left'
@@ -47,7 +47,7 @@ groups:
       service: cinder
       context: "openstack-exporter"
       meta: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has 3 or less datastores that can accept max volume size"
-      playbook: docs/support/playbook/cinder/cinder_low_free_space.html
+      playbook: docs/support/playbook/cinder/cinder-low-free-space.html
     annotations:
       description: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has 3 or less datastores that can accept max volume size"
       summary: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has 3 or less datastores that can accept max volume size"
@@ -61,7 +61,7 @@ groups:
       service: cinder
       context: "openstack-exporter"
       meta: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 2 datastores that can accept max volume size"
-      playbook: docs/support/playbook/cinder/cinder_low_free_space.html
+      playbook: docs/support/playbook/cinder/cinder-low-free-space.html
     annotations:
       description: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 2 datastores that can accept max volume size"
       summary: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 2 datastores that can accept max volume size"


### PR DESCRIPTION
This patch updates the paths of the cinder playbook filenames.
The playbook files were renamed to remove _ to -