### PR TITLE
[manila] disable nfs v4.0, enable nfs v4.1

### DIFF
--- a/openstack/manila/templates/shares/_share-netapp.conf.tpl
+++ b/openstack/manila/templates/shares/_share-netapp.conf.tpl
@@ -33,7 +33,7 @@ netapp_transport_type={{ $share.protocol | default "https" }}
 netapp_login={{$share.username}}
 netapp_password={{$share.password}}
 netapp_mtu={{$share.mtu | default 9000 }}
-netapp_enabled_share_protocols={{$share.enabled_protocols | default "nfs3, nfs4.0" }}
+netapp_enabled_share_protocols={{$share.enabled_protocols | default "nfs3, nfs4.1" }}
 
 netapp_root_volume_aggregate={{$share.root_volume_aggregate}}
 netapp_aggregate_name_search_pattern={{$share.aggregate_search_pattern}}


### PR DESCRIPTION
requires https://github.com/sapcc/manila/pull/31 to not disable v4.0
on existing share servers

SVM migrate is only working for v3 and v4.1, so we discourage the future use
of v4.0 to be able to move data