### PR TITLE
[Cinder] Enable SAP affinity/antiaffinity filters

### DIFF
--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -82,7 +82,7 @@ use_tls_acme: true
 
 db_name: cinder
 
-scheduler_default_filters: "AvailabilityZoneFilter,DifferentBackendFilter,SameBackendFilter,ShardFilter,CapacityFilter,CapabilitiesFilter,SAPLargeVolumeFilter"
+scheduler_default_filters: "AvailabilityZoneFilter,DifferentBackendFilter,SameBackendFilter,ShardFilter,CapacityFilter,CapabilitiesFilter,SAPLargeVolumeFilter,SAPDifferentBackendFilter,SAPSameBackendFilter"
 
 cinder_api_allow_migration_on_attach: True
 


### PR DESCRIPTION
This patch enables the SAPDifferentBackendFilter and
SameBackendFilter.  These filters use the custom attribute setting
of 'netapp_fqdn' on the datastores to ensure affinity/anti-affinity
to the netapps that house the datastore.