### PR TITLE
Increasing VMX-HW Version to 18 for all flavors

### DIFF
--- a/openstack/sap-seeds/templates/_flavors_hana_exclusive.tpl
+++ b/openstack/sap-seeds/templates/_flavors_hana_exclusive.tpl
@@ -43,7 +43,7 @@
     "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "required"
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "2"
-    "vmware:hw_version": "vmx-15"
+    "vmware:hw_version": "vmx-18"
 - name: "hana_c192_m2917"
   id: "304"
   vcpus: 192
@@ -56,7 +56,7 @@
     "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "required"
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "2"
-    "vmware:hw_version": "vmx-15"
+    "vmware:hw_version": "vmx-18"
 - name: "hana_c384_m5835"
   id: "305"
   vcpus: 384
@@ -115,7 +115,7 @@
     "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "required"
     "trait:CUSTOM_NUMASIZE_C48_M1459": "required"
     "hw:cpu_cores": "2"
-    "vmware:hw_version": "vmx-15"
+    "vmware:hw_version": "vmx-18"
 - name: "hana_c192_m5835"
   id: "310"
   vcpus: 192
@@ -128,7 +128,7 @@
     "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "required"
     "trait:CUSTOM_NUMASIZE_C48_M1459": "required"
     "hw:cpu_cores": "2"
-    "vmware:hw_version": "vmx-15"
+    "vmware:hw_version": "vmx-18"
 - name: "hana_c288_m4377"
   id: "311"
   vcpus: 288


### PR DESCRIPTION
We set the default VMX-HW Version in Nova for new VMs to 18. We do not change the VMX-HW Version if a VM gets resized in Nova, except the VMs which get resized from a Flavor with < 128 vCPUs to a Flavor with > 128 vCPUs. For them the resize will change the VMX-HW version to the defined one in the flavor because otherwise the VM would not start up.