### PR TITLE
[nova] Use ingress rewrite-target

### DIFF
--- a/openstack/nova/templates/console-ingress.yaml
+++ b/openstack/nova/templates/console-ingress.yaml
@@ -9,13 +9,7 @@ metadata:
     component: nova
   annotations:
     ingress.kubernetes.io/use-regex: "true"
-    ingress.kubernetes.io/configuration-snippet: |
-      {{- range $name, $config := .Values.consoles }}
-        {{- if $config.enabled }}
-      rewrite "(?i)/{{ $name }}/(.*)" /$1 break;
-      rewrite "(?i)/{{ $name }}$" / break;
-        {{- end }}
-      {{- end }}
+    ingress.kubernetes.io/rewrite-target: "/$1"
   {{- if .Values.use_tls_acme }}
     kubernetes.io/tls-acme: "true"
   {{- end }}


### PR DESCRIPTION
Instead of using a configuration-snippet,
we can use the rewrite-target as in the
example in the documentation:
https://kubernetes.github.io/ingress-nginx/examples/rewrite/

We need to replace nginx.ingress.kubernetes.io
with ingress.kubernetes.io as the ingress is configured
to take the latter non-default annotation prefix