### PR TITLE
neutron bgp alerts moved to critical channel

### DIFF
--- a/prometheus-exporters/network-generic-ssh-exporter/alerts/asr.alerts
+++ b/prometheus-exporters/network-generic-ssh-exporter/alerts/asr.alerts
@@ -138,7 +138,7 @@ groups:
         + on (server_name) group_right() ssh_bgp_sessions{vrf="", peer_type="internal"} != 8
       for: 5m
       labels:
-        severity: info
+        severity: critical
         tier: net
         service: asr
         context: asr
@@ -155,7 +155,7 @@ groups:
         + on (server_name) group_right() ssh_bgp_sessions{vrf="", peer_type="external"} != 8
       for: 5m
       labels:
-        severity: info
+        severity: critical
         tier: net
         service: asr
         context: asr


### PR DESCRIPTION
Neutron router to core and Neutron to Neutron peering alerts moved from info to critical channel 