### PR TITLE
[nova] Update default_hw_version to vmx-18

### DIFF
--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -304,8 +304,8 @@ compute:
       bigvm_deployment_free_host_hostgroup_name: "bigvm_free_host_antiaffinity_hostroup"
       clone_from_snapshot: false
       full_clone_snapshots: true
-      # maximum of vSphere 6.5
-      default_hw_version: vmx-13
+      # maximum of vSphere 7.0u1c
+      default_hw_version: vmx-18
       memory_reservation_cluster_hosts_max_fail: 2
       memory_reservation_max_ratio_fallback: 0.8
 


### PR DESCRIPTION
We introduced the default_hw_version to define a minimum version
supported by all ESXi during upgrade, so that vMotion between ESXis and
clusters is possible no matter if they are upgraded already or not. The
minimal supported version at the time was vmx-13. We now upgraded to
newer versions of ESXi and thus update default_hw_version to what the
ESXis would use as default currently: vmx-18.