### PR TITLE
[nova] Disable RamFilter and DiskFilter in scheduler

### DIFF
--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -266,7 +266,7 @@ scheduler:
   rpc_statsd_port: 9125
   # enables collecting metrics for RPC calls
   rpc_statsd_enabled: false
-  default_filters: "CpuInfoMigrationFilter, ShardFilter, AggregateMultiTenancyIsolation, RamFilter, DiskFilter, ComputeFilter, ComputeCapabilitiesFilter, BigVmFlavorHostSizeFilter, VmSizeThresholdFilter, ImagePropertiesFilter, ServerGroupAntiAffinityFilter, ServerGroupAffinityFilter"
+  default_filters: "CpuInfoMigrationFilter, ShardFilter, AggregateMultiTenancyIsolation, ComputeFilter, ComputeCapabilitiesFilter, BigVmFlavorHostSizeFilter, VmSizeThresholdFilter, ImagePropertiesFilter, ServerGroupAntiAffinityFilter, ServerGroupAffinityFilter"
   vm_size_threshold_vm_size_mb: "8193"
   vm_size_threshold_hv_size_mb: "819200"
   ram_weight_multiplier: 1.0


### PR DESCRIPTION
With filtering happing in placement, it's already ensured that the
resources in the flavor - MEMORY_MB and DISK_GB in placement - can be
fulfilled by the host. Therefore, we don't need these filters in the
scheduler anymore.

This came up because baremetal flavors use resource group based
scheduling and set MEMORY_MB, VCPU and DISK_GB to 0 in the request to
placement via flavor property. Still, a baremetal host could not be
scheduled because of 1 GiB difference between placement and the flavor's
disk setting.