### PR TITLE
[sap-seeds] Optionally add legacy bigvm flavors

### DIFF
--- a/openstack/sap-seeds/templates/_flavors_hana_exclusive.tpl
+++ b/openstack/sap-seeds/templates/_flavors_hana_exclusive.tpl
@@ -155,3 +155,29 @@
     "trait:CUSTOM_NUMASIZE_C56_M1459": "required"
     "hw:cpu_cores": "4"
     "vmware:hw_version": "vmx-18"
+
+{{- if .Values.hana_exclusive_contains_legacy_bigvm_flavors }}
+### Deprecated BigVM flavors
+- name: "m5.96xlarge"
+  id: "270"
+  vcpus: 90
+  ram: 1468416
+  disk: 64
+  is_public: true
+  extra_specs:
+    "vmware:hv_enabled": "True"
+    "hw_video:ram_max_mb": "16"
+    "host_fraction": "1/4,3/4,1/2,1"
+    "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+- name: "x1.32xlarge"
+  id: "250"
+  vcpus: 128
+  ram: 1991680
+  disk: 64
+  is_public: true
+  extra_specs:
+    "vmware:hv_enabled": "True"
+    "hw_video:ram_max_mb": "16"
+    "host_fraction": "1,0.67,0.34"
+    "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+{{- end }}

--- a/openstack/sap-seeds/values.yaml
+++ b/openstack/sap-seeds/values.yaml
@@ -1,3 +1,8 @@
 # whether to use the hana_exclusive list of flavors or the older
 # hana_no_exclusive list
 use_hana_exclusive: false
+
+# whether to include the legacy bigvm flavors when deploying the hana_exclusive
+# list - they are always included in the hana_no_exclusive list but are needed
+# in some regions where we don't have a hana-only BB for an AZ
+hana_exclusive_contains_legacy_bigvm_flavors: false


### PR DESCRIPTION
When deploying the sap-seeds with use_hana_exclusive set, we did not
include the legacy flavors that are not applicable to
CUSTOM_HANA_EXCLUSIVE_HOST-enabled hosts. But there's at least one
region where we now need to also include those flavors, because one of
the AZs will never get a CUSTOM_HANA_EXCLUSIVE_HOST-enabled host.

Therefore, we move the legacy flavors to their own template for
inclusion, include them unconditionally if the hana_no_exclusive list is
used and based on the setting
hana_exclusive_contains_legacy_bigvm_flavors also in the hana_exclusive
case.