### PR TITLE
[Nova] Set appVersion in chart

### DIFF
--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -3,3 +3,4 @@ description: A Helm chart for Kubernetes
 name: nova
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Nova/OpenStack_Project_Nova_mascot.png
 version: 0.1.2
+appVersion: "rocky"


### PR DESCRIPTION
Practically, we only support one version in the chart,
so we might as well be specific about it, which makes
the release tracking also more consistent with other
charts