### PR TITLE
[Nova] Bumps mariadb chart dependency

### DIFF
--- a/openstack/nova/requirements.lock
+++ b/openstack/nova/requirements.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.50
+  version: 0.3.53
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.50
+  version: 0.3.53
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.7
@@ -29,5 +29,5 @@ dependencies:
 - name: region_check
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.2
-digest: sha256:47eb86d4219760af788fae73533ecbe8507a296bb01971c1e683200019311603
-generated: "2022-04-05T13:19:22.672591508+02:00"
+digest: sha256:a85a93e2f58604dd0566bcaaac9345a75cb09f29e56e33717c336cb6c617ea3e
+generated: "2022-05-02T14:26:28.570025+02:00"

--- a/openstack/nova/requirements.yaml
+++ b/openstack/nova/requirements.yaml
@@ -2,12 +2,12 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.50
+    version: 0.3.53
   - name: mariadb
     alias: mariadb_api
     condition: mariadb_api.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.50
+    version: 0.3.53
   - condition: mariadb.enabled
     name: mysql_metrics
     repository: https://charts.eu-de-2.cloud.sap


### PR DESCRIPTION
  - Fixes OOMKill for backup pod during full restore
    Due to VPA Butler setting lower mem limits