### PR TITLE
[ironic] Change db pool params

### DIFF
--- a/openstack/ironic/values.yaml
+++ b/openstack/ironic/values.yaml
@@ -110,6 +110,9 @@ debug: "True"
 dbName: ironic
 #dbPassword: null
 
+max_pool_size: 1
+max_overflow: 50
+
 inspectordbName: ironic_inspector
 inspectordbUser: ironic_inspector
 


### PR DESCRIPTION
Ironic creates a lot of conductors, and each of them
keep a max_pool_size number of connections open.

By setting it to 1, the pool will be minimal,
and most connections will be short-lived