### PR TITLE
[openstack/utils] Change mysql db default settings

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.3.8
+version: 0.3.9

--- a/openstack/utils/templates/_ini_sections.tpl
+++ b/openstack/utils/templates/_ini_sections.tpl
@@ -17,8 +17,11 @@ max_overflow = -1
 {{- end }}
 
 {{- define "ini_sections.database_options_mysql" }}
-max_pool_size = {{ .Values.max_pool_size | default .Values.global.max_pool_size | default 50 }}
-max_overflow = {{ .Values.max_overflow | default .Values.global.max_overflow | default 5 }}
+connection_recycle_time = {{ .Values.connection_recycle_time | default .Values.global.connection_recycle_time | default 10 }}
+max_overflow = {{ .Values.max_overflow | default .Values.global.max_overflow | default 1000 }}
+max_pool_size = {{ .Values.max_pool_size | default .Values.global.max_pool_size | default 1 }}
+max_retries = {{ .Values.max_retries | default .Values.global.max_retries | default -1 }}
+
 {{- end }}
 
 {{- define "ini_sections.database" }}


### PR DESCRIPTION
Follow in the defaults the settings from ansible.
Creating connections to mariadb is not terribly costly,
but keeping a "large" pool of connections around
consumes a portion of max_connections of the server.