### PR TITLE
Do Not Merge YET [Cinder] Increase default max volume size to 10Tib

### DIFF
--- a/openstack/cinder/templates/etc/_cinder.conf.tpl
+++ b/openstack/cinder/templates/etc/_cinder.conf.tpl
@@ -44,7 +44,7 @@ quota_backups = -1
 quota_backup_gigabytes = -1
 
 # limit the volume size because it's limited by flexvols. in GB
-per_volume_size_limit = {{ .Values.volume_size_limit_gb | default 2048 }}
+per_volume_size_limit = {{ .Values.volume_size_limit_gb | default 10240 }}
 
 # don't use quota class
 use_default_quota_class=false


### PR DESCRIPTION
This patch increases the default for the max volume size
to 10Tib.