### PR TITLE
[sap-seeds] remove nova-seeds from requirements, deprecated according to [1]

### DIFF
--- a/openstack/sap-seeds/templates/flavor-seed.yaml
+++ b/openstack/sap-seeds/templates/flavor-seed.yaml
@@ -3,8 +3,6 @@ kind: "OpenstackSeed"
 metadata:
   name: sap-flavor-seed
 spec:
-  requires:
-  - monsoon3/nova-flavor-seed
   flavors:
   - name: "m1.tiny"
     id: "10"


### PR DESCRIPTION
1: https://github.com/sapcc/helm-charts/blob/master/openstack/nova/templates/flavor-seed.yaml#L7
