### PR TITLE
[keystone] Do not remove orphaned role assignments via cron

### DIFF
--- a/openstack/keystone/templates/bin/_cron.tpl
+++ b/openstack/keystone/templates/bin/_cron.tpl
@@ -3,6 +3,6 @@
 export STDOUT=${STDOUT:-/proc/1/fd/1}
 export STDERR=${STDERR:-/proc/1/fd/2}
 
-cat <(crontab -l) <(echo "{{ default "0 * * * *"  .Values.cron.cronSchedule }} PATH=${PATH}; {{- if .Values.sentry.enabled }} export SENTRY_DSN=${SENTRY_DSN}; {{- end }} . /scripts/repair_assignments > ${STDOUT} 2> ${STDERR}") | crontab -
+# note: currently there are no cron jobs, but they might appear in future, so keep the file
 
 exec cron -f

--- a/openstack/keystone/templates/bin/_repair_assignments.tpl
+++ b/openstack/keystone/templates/bin/_repair_assignments.tpl
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-export STDOUT=${STDOUT:-/proc/1/fd/1}
-export STDERR=${STDERR:-/proc/1/fd/2}
-
-# repair any role-assignments that point to orphaned objects (usually from users that have been deactivated by CAM)
-keystone-manage-extension --config-file=/etc/keystone/keystone.conf repair_assignments {{ if .Values.skipRepairRoleAssignments }} --dry-run {{ end }} > ${STDOUT} 2> ${STDERR}

--- a/openstack/keystone/templates/configmap-bin.yaml
+++ b/openstack/keystone/templates/configmap-bin.yaml
@@ -15,8 +15,6 @@ data:
 {{ include (print .Template.BasePath "/bin/_cron.tpl") . | indent 4 }}
   db-sync: |
 {{ include (print .Template.BasePath "/bin/_db-sync.tpl") . | indent 4 }}
-  repair_assignments: |
-{{ include (print .Template.BasePath "/bin/_repair_assignments.tpl") . | indent 4 }}
   keystone-api.sh: |
 {{ include (print .Template.BasePath "/bin/_keystone_api.sh.tpl") . | indent 4 }}
 {{- if .Values.tempest.enabled }}


### PR DESCRIPTION
Although removed role assignments sit in the database without use,
practice shows that the users often reappear, and it is not nice to
leave them without their prior assignments.