### PR TITLE
[nova] Query placement for AZ or AZ-Filter

### DIFF
--- a/openstack/nova/templates/etc/_nova-scheduler.conf.tpl
+++ b/openstack/nova/templates/etc/_nova-scheduler.conf.tpl
@@ -9,7 +9,7 @@ statsd_enabled = {{ .Values.scheduler.rpc_statsd_enabled }}
 discover_hosts_in_cells_interval = 60
 workers = {{ .Values.scheduler.workers | default 1 }}
 driver_task_period = {{ .Values.scheduler.driver_task_period | default 60 }}
-query_placement_for_availability_zone = True
+query_placement_for_availability_zone = {{ not (contains "AvailabilityZoneFilter" .Values.scheduler.default_filters) }}
 
 [filter_scheduler]
 available_filters = {{ .Values.scheduler.available_filters | default "nova.scheduler.filters.all_filters" }}


### PR DESCRIPTION
Instead of hard-coding query_placement_for_availability_zone,
decide it based on the default-filters configuration.
If there is no AvailabilityZone Filter, we need to use
placement for that.