### PR TITLE
[Cinder] Update CinderShardFreeSpaceWarning

### DIFF
--- a/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
+++ b/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
@@ -16,7 +16,7 @@ groups:
       description: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has no storage capacity."
       summary: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has no storage capacity."
   - alert: CinderShardFreeSpaceWarning
-    expr: count by (shard, backend) (sum(cinder_virtual_free_capacity_gib / cinder_available_capacity_gib) by (shard, backend, pool) > .30) < 2
+    expr: count by (shard, backend) (sum(cinder_available_capacity_gib) by (shard, backend, pool)) - (count by (shard,backend) (sum(cinder_virtual_free_capacity_gib / cinder_available_capacity_gib) by (shard, backend, pool) < .3)) < 2
     for: 15m
     labels:
       severity: warning
@@ -27,7 +27,7 @@ groups:
       description: 'Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has 3 or less datastores with > 30% free space left'
       summary: 'Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has 3 or less3 datastores with > 30% free space left'
   - alert: CinderShardFreeSpaceCritical
-    expr: count by (shard, backend) (sum(cinder_virtual_free_capacity_gib / cinder_available_capacity_gib) by (shard, backend, pool) > .30) < 1
+    expr: count by (shard, backend) (sum(cinder_available_capacity_gib) by (shard, backend, pool)) - (count by (shard,backend) (sum(cinder_virtual_free_capacity_gib / cinder_available_capacity_gib) by (shard, backend, pool) < .3)) < 1
     for: 15m
     labels:
       severity: warning


### PR DESCRIPTION
This patch updates the logic for the
CinderShardFreeSpaceWarning
CinderShardFreeSpaceCritical

alerts.   This new alert tracks the total number of pools vs the number
of pools left over that have < 30% of storage space left.  If there are
< 2 then we get a warning.  If there is < 1 then we get a critical.

Still need to update this to critical once ops approves.