### PR TITLE
[px/lg] Using local registry for images

### DIFF
--- a/px/lg/templates/deployment.yaml
+++ b/px/lg/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: {{ $.Values.global.region }}-pxrs-{{ $lg }}
-        image: {{ $.Values.global.registry }}/{{ $.Values.lg_image }}
+        image: keppel.{{ $.Values.registry }}.cloud.sap/{{ $.Values.lg_image }}
         imagePullPolicy: Always
         volumeMounts:
         - name: vol-{{ $.Values.global.region }}-pxrs-{{ $lg }}

--- a/px/lg/templates/deployment.yaml
+++ b/px/lg/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: {{ $.Values.global.region }}-pxrs-{{ $lg }}
-        image: keppel.eu-de-1.cloud.sap/{{ $.Values.lg_image }}
+        image: {{ $.Values.global.registry }}/{{ $.Values.lg_image }}
         imagePullPolicy: Always
         volumeMounts:
         - name: vol-{{ $.Values.global.region }}-pxrs-{{ $lg }}


### PR DESCRIPTION
In each region we use the respective registry instead of keppel in
eu-de-1