### PR TITLE
Mistakenly duplicated deployments

### DIFF
--- a/px/lg/templates/deployment.yaml
+++ b/px/lg/templates/deployment.yaml
@@ -39,7 +39,11 @@ spec:
         - name: vol-{{ $.Values.global.region }}-pxrs-lg-communities
           mountPath: /etc/bird-lg-communities
         command: ["python3"]
+{{- if $lg_config.privileged }}
+        args: ["lg.py", "{{ $.Values.global.region }}-pxrs-{{ $lg }}.cfg", "priv"]
+{{- else }}
         args: ["lg.py", "{{ $.Values.global.region }}-pxrs-{{ $lg }}.cfg"]
+{{- end }}
         ports:
         - containerPort: 80
           name: {{ $lg }}web

--- a/px/lg/values.yaml
+++ b/px/lg/values.yaml
@@ -18,7 +18,9 @@ looking_glass:
     proxy_port: 5000
     authenticate: false
     subdomain: px
+    privileged: false
   lgadmin:
     authenticate: true
     proxy_port: 5005
     subdomain: pxadmin
+    privileged: true


### PR DESCRIPTION
Both lg deployments were roughly the same, however one is supposed to be
started in privileged mode. Introduced the values attribute and consumed
it in a  simple condition in the deployment.