### PR TITLE
Update severity PXTransportRouterPrefixExportCountZero

### DIFF
--- a/system/infra-monitoring/vendor/px-exporter/px.alerts/px.alerts
+++ b/system/infra-monitoring/vendor/px-exporter/px.alerts/px.alerts
@@ -61,7 +61,7 @@ groups:
     expr: (sum(bird_protocol_up{peer_type="PL"}) by (app, ip_version, proto, pxdomain, pxinstance, pxservice) > 0 ) + on (app, ip_version, proto, pxdomain, pxinstance, pxservice) group_right() bird_protocol_prefix_import_count{name!~"kernel.", peer_type="TP"} <= 0 
     for: 3m
     labels:
-      severity: critical
+      severity: warning
       tier: net
       service: px
       context: px


### PR DESCRIPTION
Changed severity from critical to warning as this alert is redundant and not handeled by k8s.