### PR TITLE
Enable logging for image transfer modules

### DIFF
--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -324,6 +324,15 @@ logging:
     suds:
       handlers: "null"
       level: ERROR
+    oslo_vmware.rw_handles:
+      handlers: stdout, sentry
+      level: DEBUG
+    oslo_vmware.image_transfer:
+      handlers: stdout, sentry
+      level: DEBUG
+    os_brick:
+      handlers: stdout, sentry
+      level: DEBUG
 
 # openstack-rate-limit-middleware
 api_rate_limit:

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -846,6 +846,12 @@ logging:
     oslo_vmware.common.loopingcall:
       handlers: "null"
       level: ERROR
+    oslo_vmware.rw_handles:
+      handlers: stdout, sentry
+      level: DEBUG
+    oslo_vmware.image_transfer:
+      handlers: stdout, sentry
+      level: DEBUG
 
 # openstack-watcher-middleware
 watcher:


### PR DESCRIPTION
These modules have useful logs on calls to Vmware
for operations like:

* importing VM image
* creating volume from an image
* creating volume backup
* restoring volume backup