### PR TITLE
 Bump utils version

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.3.9
+version: 0.3.10

--- a/openstack/utils/templates/_helpers.tpl
+++ b/openstack/utils/templates/_helpers.tpl
@@ -46,7 +46,7 @@ trace_sqlalchemy = {{ .Values.global.osprofiler.trace_sqlalchemy }}
 
 {{- define "jaeger_agent_sidecar" }}
 {{- if .Values.osprofiler.enabled }}
-- image: jaegertracing/jaeger-agent:{{ .Values.global.osprofiler.jaeger.version }}
+- image: {{.Values.global.dockerHubMirrorAlternateRegion}}/jaegertracing/jaeger-agent:{{ .Values.global.osprofiler.jaeger.version }}
   name: jaeger-agent
   ports:
     - containerPort: 5775


### PR DESCRIPTION
 This is required because jaeger-agent was pointed to another image in the previous commit