### PR TITLE
[openstack/utils] Fix mariadb name

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.3.10
+version: 0.3.11

--- a/openstack/utils/templates/_hosts.tpl
+++ b/openstack/utils/templates/_hosts.tpl
@@ -17,7 +17,9 @@ postgresql+psycopg2://{{$user}}:{{$password | urlquery}}@{{.Chart.Name}}-postgre
 ?connect_timeout=10&keepalives_idle=5&keepalives_interval=5&keepalives_count=10
 {{- end}}
 
-{{define "db_host_mysql"}}{{.Release.Name}}-mariadb.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.region}}.{{.Values.global.tld}}{{end}}
+{{- define "db_host_mysql" -}}
+{{ .Values.mariadb.name }}-mariadb.{{ .Release.Namespace }}.svc.kubernetes.{{ .Values.global.region }}.{{ .Values.global.tld }}
+{{- end }}
 
 {{define "db_url_mysql" }}
     {{- if kindIs "map" . -}}


### PR DESCRIPTION
The host-name for mariadb is only by convention correct.
It is actually determined by .Values.mariadb.name as
can be verified by looking at the helpers.tpl macro named
'fullName', which is used as the name of the service