### PR TITLE
[Nova] Prevent double scraping of metrics

### DIFF
--- a/openstack/nova/templates/cell2-conductor-deployment.yaml
+++ b/openstack/nova/templates/cell2-conductor-deployment.yaml
@@ -31,7 +31,6 @@ spec:
       annotations:
         {{- if .Values.cell2.conductor.config_file.DEFAULT.statsd_enabled }}
         prometheus.io/scrape: "true"
-        prometheus.io/port: "9102"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
         {{- end }}
         configmap-etc-hash: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}

--- a/openstack/nova/templates/conductor-deployment.yaml
+++ b/openstack/nova/templates/conductor-deployment.yaml
@@ -30,7 +30,6 @@ spec:
       annotations:
         {{- if .Values.conductor.config_file.DEFAULT.statsd_enabled }}
         prometheus.io/scrape: "true"
-        prometheus.io/port: "9102"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
         {{- end }}
         configmap-etc-hash: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}

--- a/openstack/nova/templates/hypervisors/_ironic-deployment.yaml.tpl
+++ b/openstack/nova/templates/hypervisors/_ironic-deployment.yaml.tpl
@@ -31,7 +31,6 @@ spec:
       annotations:
         {{- if $hypervisor.default.statsd_enabled }}
         prometheus.io/scrape: "true"
-        prometheus.io/port: "9102"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
         {{- end }}
         configmap-etc-hash: {{ include (print .Template.BasePath "/etc-configmap.yaml") . | sha256sum }}

--- a/openstack/nova/templates/hypervisors/hypervisors-vmware-deployment-vct.yaml
+++ b/openstack/nova/templates/hypervisors/hypervisors-vmware-deployment-vct.yaml
@@ -38,7 +38,6 @@ template: |
           hypervisor: "vmware"
         annotations:
           prometheus.io/scrape: "true"
-          prometheus.io/port: "9102"
           prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
           configmap-etc-hash: {{ include (print .Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
           configmap-nova-compute-hash: {= "vcenter_cluster/{{ .Release.Namespace }}/vcenter-cluster-nova-compute-configmap.yaml.j2" | render | sha256sum =}

--- a/openstack/nova/templates/scheduler-deployment.yaml
+++ b/openstack/nova/templates/scheduler-deployment.yaml
@@ -30,7 +30,6 @@ spec:
       annotations:
         {{- if .Values.scheduler.rpc_statsd_enabled }}
         prometheus.io/scrape: "true"
-        prometheus.io/port: "9102"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
         {{- end }}
         configmap-etc-hash: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}


### PR DESCRIPTION
When we have prometheus.io/port annotation and multiple containers, then
prometheus will use that port for both containers and scrape the same
metrics just with different container labels. The solution is to remove
the annotation and rely on prometheus finding the right port by its name
"metrics", according to [0].

[0] https://operations.global.cloud.sap/docs/support/playbook/kubernetes/target_scraped_multiple_times.html#usage-or-prometheusioport-annotation-with-multiple-ports