### PR TITLE
[swift] Avoid multiple scrapes of prometheus targets

### DIFF
--- a/openstack/swift/templates/object-expirer-deployment.yaml
+++ b/openstack/swift/templates/object-expirer-deployment.yaml
@@ -24,7 +24,8 @@ spec:
       annotations:
         {{- include "swift_conf_annotations" . | indent 8 }}
         {{- include "swift_ring_annotations" . | indent 8 }}
-        {{- include "swift_prometheus_annotations" . | indent 8 }}
+        prometheus.io/scrape: "true"
+        prometheus.io/targets: {{ required ".Values.alerts.prometheus.openstack missing" $.Values.alerts.prometheus.openstack }}
     spec:
       volumes:
         - name: swift-etc


### PR DESCRIPTION
The service discovery is invoked for every endpoint port found in the correponding endpoints object and in both cases the port annotation is used to override the port. This will cause the same metrics to be collected twice with different container labels.

Solution: Remove the prometheus.io/port annotation from your pod or service spec and give the target port the name metrics.