### PR TITLE
Fix endpoints/service service discoery by port name

### DIFF
--- a/common/prometheus-server/Chart.yaml
+++ b/common/prometheus-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus via operator.
 name: prometheus-server
-version: 6.2.0
+version: 6.2.1
 appVersion: v2.34.0
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
 maintainers:

--- a/common/prometheus-server/templates/servicemonitors/endpoint-sd.yaml
+++ b/common/prometheus-server/templates/servicemonitors/endpoint-sd.yaml
@@ -43,7 +43,7 @@ spec:
           regex: '(.+)'
         - action: keep
           sourceLabels:
-            - __meta_kubernetes_service_port_name
+            - __meta_kubernetes_endpoint_port_name
             - __meta_kubernetes_service_annotation_prometheus_io_port
           regex: '(metrics;.*)|(.*;\d+)'
         - sourceLabels:
@@ -98,9 +98,8 @@ spec:
           regex: '\d+'
         - action: keep
           sourceLabels:
-            - __meta_kubernetes_service_port_name
             - __meta_kubernetes_service_annotation_prometheus_io_port_1
-          regex: '(metrics;.*)|(.*;\d+)'
+          regex: '\d+'
         - sourceLabels:
             - __meta_kubernetes_service_annotation_prometheus_io_scheme
           targetLabel: __scheme__


### PR DESCRIPTION
turns out the ` __meta_kubernetes_service_port_name` is not available when using endpoints sd.
We need to use `__meta_kubernetes_endpoint_port_name` instead