### PR TITLE
[manila] prevent double scraping of api

### DIFF
--- a/openstack/manila/templates/api-service.yaml
+++ b/openstack/manila/templates/api-service.yaml
@@ -9,7 +9,6 @@ metadata:
     component: manila
   annotations:
     prometheus.io/scrape: "true"
-    prometheus.io/port: {{ .Values.global.metrics_port | quote }}
     prometheus.io/targets: {{ required ".Values.alerts.prometheus.openstack" .Values.alerts.prometheus.openstack |  quote }}
 spec:
   selector:


### PR DESCRIPTION
prom is looking at the port named `metrics` and gets confused by
specifying a port annotation if the service has more than 2 ports

needs a go from @databus23, needs an underlying prom 'chart rodeo'