### PR TITLE
[px] use bird-refresh.sh as liveness probe

### DIFF
--- a/px/bird/templates/_deployment-bird.tpl
+++ b/px/bird/templates/_deployment-bird.tpl
@@ -25,7 +25,7 @@ containers:
     mountPath: /var/run/bird
   livenessProbe:
     exec:
-      command: ["bird-command", "--liveness"]
+      command: ["/usr/local/bin/bird-refresh.sh"]
     initialDelaySeconds: 5
     periodSeconds: 5
   resources:

--- a/px/bird/values.yaml
+++ b/px/bird/values.yaml
@@ -1,5 +1,5 @@
 global:
-  region:
+  region: qa-de-1
 
 owner-info:
   maintainers:

--- a/px/bird/values.yaml
+++ b/px/bird/values.yaml
@@ -1,5 +1,5 @@
 global:
-  region: qa-de-1
+  region: 
 
 owner-info:
   maintainers:


### PR DESCRIPTION
Update helm chart to use bird-refresh.sh as liveness probe, which changes method how new config is loaded to Bird.