### PR TITLE
[nova] Enable oslo.messaging metrics by default

### DIFF
--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -41,7 +41,7 @@ cell2:
       DEFAULT:
         statsd_port: 9125
         # enables collecting metrics for rpc calls
-        statsd_enabled: false
+        statsd_enabled: true
 
 defaults:
   default:
@@ -59,7 +59,7 @@ defaults:
         compute_driver: ironic.IronicDriver
         graceful_shutdown_timeout: 1800
         # enables collecting metrics for RPC calls
-        statsd_enabled: false
+        statsd_enabled: true
       ironic:
         serial_console_state_timeout: 10
     kvm:
@@ -68,7 +68,7 @@ defaults:
         firewall_driver: nova.virt.firewall.NoopFirewallDriver
         resume_guests_state_on_host_boot: true
         # enables collecting metrics for RPC calls
-        statsd_enabled: false
+        statsd_enabled: true
 
 pod:
   replicas:
@@ -265,7 +265,7 @@ scheduler:
   scheduler_instance_sync_interval: 120
   rpc_statsd_port: 9125
   # enables collecting metrics for RPC calls
-  rpc_statsd_enabled: false
+  rpc_statsd_enabled: true
   default_filters: "CpuInfoMigrationFilter, ShardFilter, AggregateMultiTenancyIsolation, ComputeFilter, ComputeCapabilitiesFilter, BigVmFlavorHostSizeFilter, VmSizeThresholdFilter, ImagePropertiesFilter, ServerGroupAntiAffinityFilter, ServerGroupAffinityFilter"
   vm_size_threshold_vm_size_mb: "8193"
   vm_size_threshold_hv_size_mb: "819200"
@@ -294,7 +294,7 @@ compute:
       block_device_allocate_retries: 300
       rpc_statsd_port: 9125
       # enables collecting metrics for RPC calls
-      rpc_statsd_enabled: false
+      rpc_statsd_enabled: true
     vmware:
       insecure: true
       use_linked_clone: false
@@ -314,7 +314,7 @@ conductor:
     DEFAULT:
       statsd_port: 9125
       # enables collecting metrics for rpc calls
-      statsd_enabled: false
+      statsd_enabled: true
     conductor:
       workers: 8
 


### PR DESCRIPTION
We've tested it a little on some regions and it looks fine, so we want
to have it everywhere.