### PR TITLE
[Nova] Remove faulty config value

### DIFF
--- a/openstack/nova/templates/api-deployment.yaml
+++ b/openstack/nova/templates/api-deployment.yaml
@@ -158,7 +158,7 @@ spec:
               containerPort: 9125
               protocol: UDP
             - name: metrics
-              containerPort: {{.Values.portMetrics}}
+              containerPort: 9102
           volumeMounts:
             - name: nova-etc
               mountPath: /etc/statsd/statsd-exporter.yaml

--- a/openstack/nova/templates/api-metadata-deployment.yaml
+++ b/openstack/nova/templates/api-metadata-deployment.yaml
@@ -146,7 +146,7 @@ spec:
               containerPort: 9125
               protocol: UDP
             - name: metrics
-              containerPort: {{.Values.portMetrics}}
+              containerPort: 9102
           volumeMounts:
             - name: nova-etc
               mountPath: /etc/statsd/statsd-exporter.yaml

--- a/openstack/nova/templates/api-metadata-service.yaml
+++ b/openstack/nova/templates/api-metadata-service.yaml
@@ -10,7 +10,7 @@ metadata:
   annotations:
     prometheus.io/scrape: "true"
     maia.io/scrape: "true"
-    prometheus.io/port: {{ required ".Values.portMetrics missing" .Values.portMetrics | quote }}
+    prometheus.io/port: "9102"
     prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
 
 spec:

--- a/openstack/nova/templates/api-service.yaml
+++ b/openstack/nova/templates/api-service.yaml
@@ -10,7 +10,7 @@ metadata:
   annotations:
     prometheus.io/scrape: "true"
     maia.io/scrape: "true"
-    prometheus.io/port: {{ required ".Values.portMetrics missing" .Values.portMetrics | quote }}
+    prometheus.io/port: "9102"
     prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
 
 spec:
@@ -19,7 +19,3 @@ spec:
   ports:
     - name: nova-api
       port: {{.Values.global.novaApiPortInternal}}
-#    - name: statsd-listen
-#      port: 9125
-#    - name: metrics-listen
-#      port: 9202

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -153,8 +153,6 @@ apidbName: nova_api
 apidbUser: nova_api
 apidbPassword: null
 
-portMetrics: '9102'
-
 loci:
   nova: false
   openvswitch: false


### PR DESCRIPTION
The config-value portMetrics suggests, that the port
is configurable. That is not the case, as it isn't
passed to the stats-exporter