### PR TITLE
[mariadb] Pre-upgrade hook for db/user creation

### DIFF
--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.4.0
+version: 0.5.0

--- a/common/mariadb/templates/db-exec-rbac.yaml
+++ b/common/mariadb/templates/db-exec-rbac.yaml
@@ -1,0 +1,46 @@
+{{- if or .Values.databases .Values.users }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.name }}-db-exec
+  annotations:
+    "helm.sh/hook": pre-upgrade,pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-50"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: monsoon3
+  name: {{ .Values.name }}-db-exec
+  annotations:
+    "helm.sh/hook": pre-upgrade,pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-40"
+rules:
+- apiGroups: ["extensions", "apps"]
+  resources: ["deployments"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["pods", "services"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: [""]
+  resources: ["pods/exec"]
+  verbs: ["create"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Values.name }}-db-exec
+  annotations:
+    "helm.sh/hook": pre-upgrade,pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-30"
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.name }}-db-exec
+roleRef:
+  kind: Role
+  name: {{ .Values.name }}-db-exec
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/common/mariadb/templates/pre-change-job.yaml
+++ b/common/mariadb/templates/pre-change-job.yaml
@@ -1,0 +1,41 @@
+{{- if or .Values.databases .Values.users }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ include "fullName" . }}-pre-change"
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ default "unknown" .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    "helm.sh/hook": pre-upgrade,pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      name: "{{ include "fullName" . }}-pre-change"
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ .Values.name }}-db-exec
+      containers:
+      - name: pre-change-job
+        image: "{{ required ".Values.global.dockerHubMirrorAlternateRegion is missing" .Values.global.dockerHubMirrorAlternateRegion }}/{{ .Values.pre_change_hook.image }}:{{ .Values.pre_change_hook.image_version }}"
+        command:
+        - kubectl-v{{ .Values.pre_change_hook.kubectl_version }}
+        - exec
+        - -c
+        - mariadb
+        - deploy/{{ include "fullName" . }}
+        - --
+        - mariadb
+        - -uroot
+        - --batch
+        - -e
+        - |
+          {{- include (print .Template.BasePath "/initdb/_init.sql.tpl") . | trim | nindent 10 }}
+{{- end }}

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -36,6 +36,10 @@ users:
 #    grants:
 #    - ALL ON example.*
 
+pre_change_hook:
+  image: "sapcc/unified-kubernetes-toolbox"
+  image_version: "20220613150453"
+  kubectl_version: "1.23"
 
 # name of priorityClass to influence scheduling priority
 priority_class: "openstack-service-critical"


### PR DESCRIPTION
The idea is to roll-out new users with new credentials in a pre-upgrade hook
so that they are available to the actual deployment making use of it.

Users (or databases) cannot be deleted this way (much less rolled back).
The cleanup is left to a later iteration, which may make use of an expiry policy.

Instead of having custom init scripts with slightly different patterns,
the fields `databases` and `users` are there to create and update them.

This also allows for uniform access to other macros, such as side-car
containers, which need knowledge about the users and the databases as well.

By using a job which executes the change within the container
of the database, we can change the credentials of any user
without fearing a lockout.

The job will be executed on upgrade and rollback and since it
gets the values from the previous deployment, it not only
will set the new credentials on upgrade, it also restores the old ones
on rollback.
