### PR TITLE
[mariadb] Undefine name field

### DIFF
--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -3,7 +3,7 @@
 # Declare name/value pairs to be passed into your templates.
 # name: value
 
-name: DEFINED-IN-COMPONENT-CHART
+name: null
 image: library/mariadb:10.5.12
 imagePullPolicy: IfNotPresent
 port_public: 3306
@@ -18,9 +18,9 @@ join_buffer_size: "4M"
 binlog_format: "MIXED"
 expire_logs_days: 10
 
-#root_password:
-#initdb_configmap:
-#custom_initdb_configmap:
+root_password: null
+initdb_configmap: null
+custom_initdb_configmap: null
 
 # name of priorityClass to influence scheduling priority
 priority_class: "openstack-service-critical"


### PR DESCRIPTION
The field is required to be set in the fullName macro,
but defining the value to 'DEFINED-IN-COMPONENT-CHART' will
simply cause that value to be used if it isn't defined.

Rather fail with a clean error message, then with a garbage
output