### PR TITLE
[mariadb] Require root_password to be set

### DIFF
--- a/common/mariadb/templates/_helpers.tpl
+++ b/common/mariadb/templates/_helpers.tpl
@@ -17,7 +17,7 @@
 {{- define "mariadb.db_host"}}{{.Release.Name}}-mariadb.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.region}}.{{.Values.global.tld}}{{- end}}
 
 {{- define "mariadb.root_password" -}}
-{{- .Values.root_password }}
+{{- required ".Values.root_password missing" .Values.root_password }}
 {{- end -}}
 
 {{- define "db_password" -}}


### PR DESCRIPTION
Prior to this change, helm would not complain about the value
to be unset, but mariadb would never start up, as the preStart
hook would never complete.

Hence require the password, as it won't work without it.