### PR TITLE
[unbound] config updates:

### DIFF
--- a/system/unbound/templates/config.yaml
+++ b/system/unbound/templates/config.yaml
@@ -16,12 +16,15 @@ data:
         access-control: 0.0.0.0/0 allow_snoop
 
         num-threads: 10
+        cache-max-negative-ttl: 100
+        cache-max-ttl: 28800
         
         root-hints: "/etc/unbound/root.hints"
 
         directory: "/etc/unbound"
         logfile: ""
         log-time-ascii: yes
+        log-servfail: yes
         include: /etc/unbound/hosts.conf
 
        # Remote control config section.


### PR DESCRIPTION
- log servfail responses
- max ttl for negative cache to 100 sec vs. 3600 by default
- cache max ttl to 8 hours vs. 24 hours by default