### PR TITLE
Pin PX on specific apods that are cabled to PX switches

### DIFF
--- a/px/bird/templates/bird.yaml
+++ b/px/bird/templates/bird.yaml
@@ -16,7 +16,7 @@
 
 ---
 {{ tuple $deployment_name $domain_config.multus_vlan $instance_config.bird_ip | include "nad_multus"}}
-{{ tuple $deployment_name $.Values.apod $.Values.scheduling_labels $.Values.px_availability_zones $domain_config.multus_vlan $service_number $service $domain_number $domain $instance_number $instance | include "deployment_header" }}
+{{ tuple $deployment_name $.Values.global.availability_zones $.Values.scheduling_labels $.Values.apods $domain_config.multus_vlan $service_number $service $domain_number $domain $instance_number $instance | include "deployment_header" }}
 {{ tuple $.Values $deployment_name $service_number $service_config $domain_number $domain_config | include "deployment_bird" | indent 6 }}
 {{ tuple $deployment_name $.Values.looking_glass | include "service_pxrs" }}
 

--- a/px/bird/values.yaml
+++ b/px/bird/values.yaml
@@ -1,5 +1,6 @@
 global:
   region:
+  availability_zones:
 
 owner-info:
   maintainers:
@@ -13,11 +14,9 @@ deploy: []
 
 registry:
 
-apod: true
-#only required if apod == true
-px_availability_zones: []
+apods: {}
 
-# only required if apod != true
+# only required if apods is empty
 scheduling_labels:
   domain_1: []
   domain_2: []


### PR DESCRIPTION
We used to pin PX to certain AZs where we knew the apods were cabled to
PX, however if more apods come in within an AZ and not all are cabled
to PX, this is going to break.

We now specify explicitly which apod to run on. We also moved some
logic regarding the placement in AZs from the chart to the k8s
scheduler. The intention is that we have one instance from each PX
domain running in each AZ. Subsequently, if we have more than 1 AZ in a
region we define an podAntiAffinity on the combined service and domain
label, so a service's domain will never be placed in the same AZ.