### PR TITLE
[nova] Disable console-auth

### DIFF
--- a/openstack/nova/templates/consoleauth-deployment.yaml
+++ b/openstack/nova/templates/consoleauth-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.pod.replicas.consoleauth }}
 kind: Deployment
 apiVersion: apps/v1
 
@@ -74,6 +75,7 @@ spec:
           mountPath: /etc/nova/logging.ini
           subPath: logging.ini
           readOnly: true
+{{- end }}
 {{ $envAll := . }}
 {{- range $name, $config := .Values.consoles }}
   {{- if $config.enabled }}

--- a/openstack/nova/templates/etc/_nova.conf.tpl
+++ b/openstack/nova/templates/etc/_nova.conf.tpl
@@ -197,6 +197,8 @@ region_name = {{.Values.global.region}}
 default_pool_size = {{ .Values.wsgi_default_pool_size | default .Values.global.wsgi_default_pool_size | default 100 }}
 
 [workarounds]
+{{- if .Values.pod.replicas.consoleauth }}
 # This has to be removed when we also remove the deployment of nova-consoleauth
 enable_consoleauth = True
+{{- end }}
 enable_live_migration_to_old_hypervisor = True

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -75,7 +75,7 @@ pod:
     api: 6
     metadata: 2
     console: 2
-    consoleauth: 2
+    consoleauth: 0
     conductor: 2
     scheduler: 1
     placement: 2


### PR DESCRIPTION
Console-auth is deprecated, so we disable it via
setting the replica count to zero (before removing
it eventually completely)