### PR TITLE
[prometheus] Allow -* suffix for named metrics ports

### DIFF
--- a/common/prometheus-server/templates/podmonitors/pod-sd.yaml
+++ b/common/prometheus-server/templates/podmonitors/pod-sd.yaml
@@ -41,7 +41,7 @@ spec:
             - __meta_kubernetes_pod_container_port_number
             - __meta_kubernetes_pod_container_port_name
             - __meta_kubernetes_pod_annotation_prometheus_io_port
-          regex: '(9102;.*;.*)|(.*;metrics;.*)|(\d+;.*;\d+)|(.*;.*;\d+)'
+          regex: '(9102;.*;.*)|(.*;metrics(-.*)?;.*)|(\d+;.*;\d+)|(.*;.*;\d+)'
         - sourceLabels:
             - __meta_kubernetes_pod_annotation_prometheus_io_scheme
           targetLabel: __scheme__
@@ -93,7 +93,7 @@ spec:
             - __meta_kubernetes_pod_container_port_number
             - __meta_kubernetes_pod_container_port_name
             - __meta_kubernetes_pod_annotation_prometheus_io_port_1
-          regex: '(9102;.*;.*)|(.*;metrics;.*)|(\d+;.*;\d+)|(.*;.*;\d+)'
+          regex: '(9102;.*;.*)|(.*;metrics(-.*)?;.*)|(\d+;.*;\d+)|(.*;.*;\d+)'
         - sourceLabels:
             - __meta_kubernetes_pod_annotation_prometheus_io_scheme
           targetLabel: __scheme__

--- a/common/prometheus-server/templates/servicemonitors/endpoint-sd.yaml
+++ b/common/prometheus-server/templates/servicemonitors/endpoint-sd.yaml
@@ -45,7 +45,7 @@ spec:
           sourceLabels:
             - __meta_kubernetes_endpoint_port_name
             - __meta_kubernetes_service_annotation_prometheus_io_port
-          regex: '(metrics;.*)|(.*;\d+)'
+          regex: '(metrics(-.*)?;.*)|(.*;\d+)'
         - sourceLabels:
             - __meta_kubernetes_service_annotation_prometheus_io_scheme
           targetLabel: __scheme__


### PR DESCRIPTION
In case there is more than one port with metrics,
we need to give them distinct names. This change takes all
ports either named `metrics` (as before), but also ports with a suffix separated by a hyphen as prometheus metrics ports.