### PR TITLE
[prometheus-global] memory requests for global prometheis

### DIFF
--- a/global/prometheus-kubernetes-global/values.yaml
+++ b/global/prometheus-kubernetes-global/values.yaml
@@ -25,6 +25,10 @@ prometheus-kubernetes-global:
     enabled: true
     size: 300Gi
 
+  resources:
+    requests:
+      memory: 35Gi
+
   rbac:
     create: true
 

--- a/global/prometheus-openstack/values.yaml
+++ b/global/prometheus-openstack/values.yaml
@@ -23,6 +23,10 @@ prometheus-openstack-global:
     enabled: false
     size: 300Gi
 
+  resources:
+    requests:
+      memory: 10Gi
+
   serviceDiscoveries:
     endpoints:
       enabled: false


### PR DESCRIPTION
to allow proper scheduling k8s should be aware of the memory load expected by these global prometheis instances.
Otherwise prometheus could end up running on a node with a very limited amount of memory available causing it to permanently crash.