### PR TITLE
[mariadb] Common user/db creation script

### DIFF
--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.3.55
+version: 0.4.0

--- a/common/mariadb/templates/deployment.yaml
+++ b/common/mariadb/templates/deployment.yaml
@@ -178,7 +178,7 @@ spec:
 {{- if .Values.initdb_configmap }}
         - name: initdb
           configMap:
-            name: {{ .Values.initdb_configmap }}
+            name: {{ .Values.name }}-initdb
             defaultMode: 0744
 {{- else if .Values.custom_initdb_configmap }}
         - name: initdb

--- a/common/mariadb/templates/initdb-configmap.yaml
+++ b/common/mariadb/templates/initdb-configmap.yaml
@@ -13,5 +13,5 @@ metadata:
 
 data:
   init.sql: |
-{{ include (print .Template.BasePath "/initdb/_init.sql.tpl") . | indent 4 }}
+{{ include (print .Template.BasePath "/initdb/_init.sql.tpl") . | trim | indent 4 }}
 {{- end }}

--- a/common/mariadb/templates/initdb/_init.sql.tpl
+++ b/common/mariadb/templates/initdb/_init.sql.tpl
@@ -1,3 +1,28 @@
-CREATE DATABASE IF NOT EXISTS {{.Values.name}} CHARACTER SET utf8 COLLATE utf8_general_ci;
-GRANT ALL PRIVILEGES ON {{.Values.name}}.* TO {{.Values.global.dbUser}}@localhost IDENTIFIED BY '{{include "db_password" .}}';
-GRANT ALL PRIVILEGES ON {{.Values.name}}.* TO {{.Values.global.dbUser}}@'%' IDENTIFIED BY '{{include "db_password" .}}';
+SET character_set_server = '{{ .Values.character_set_server }}';
+SET collation_server = '{{ .Values.collation_server }}';
+
+{{- if not .Values.databases }}
+CREATE DATABASE IF NOT EXISTS {{ .Values.name }};
+{{- else }}
+    {{- range .Values.databases }}
+CREATE DATABASE IF NOT EXISTS {{ . }};
+    {{- end }}
+{{- end }}
+
+{{- if and .Values.global.dbUser .Values.global.dbPassword }}
+CREATE USER IF NOT EXISTS {{ .Values.global.dbUser }};
+GRANT ALL PRIVILEGES ON {{ .Values.name }}.* TO {{ .Values.global.dbUser }} IDENTIFIED BY {{ include "db_password" . }};
+{{- end }}
+
+{{- range $username, $values := .Values.users }}
+    {{- $username := default $username $values.name }}
+    {{- if not $values.password }}
+-- Skipping user {{ $username }} without password
+    {{- else }}
+CREATE USER IF NOT EXISTS {{ $username }};
+ALTER USER {{ $username }} IDENTIFIED BY '{{ $values.password }}';
+        {{- range $values.grants }}
+GRANT {{ . }} TO {{ $username }};
+        {{- end }}
+    {{- end }}
+{{- end }}

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -17,10 +17,25 @@ query_cache_type: "0"
 join_buffer_size: "4M"
 binlog_format: "MIXED"
 expire_logs_days: 10
+character_set_server: 'utf8'  # Should be utf8mb4, but we started with this
+collation_server: 'utf8_general_ci'
 
 #root_password:
 #initdb_configmap:
 #custom_initdb_configmap:
+
+databases:
+# - example
+users:
+#  example:
+#    name: example1 # This looks repetitive, but the point is that they key is the name
+#                   # you refer to in your charts, while the field 'name' is the actual name
+#                   # used as credentials. It should be possible to change the latter,
+#                   # without having to change the first.
+#    password: null # Causes users not be be created, and even maybe to get locked
+#    grants:
+#    - ALL ON example.*
+
 
 # name of priorityClass to influence scheduling priority
 priority_class: "openstack-service-critical"


### PR DESCRIPTION
Instead of having repetitive free-form init.sql scripts,
provide the fields `databases` and `users`, which allow
the user of the script to create the databases and users
uniformly.