### PR TITLE
Adding cloud_objectstore_admin role to swift/limes/keppel seeds

### DIFF
--- a/openstack/keppel/templates/seed.yaml
+++ b/openstack/keppel/templates/seed.yaml
@@ -78,7 +78,9 @@ spec:
             - user: keppel@Default
               role: service       # to validate users' Keystone tokens
             - user: keppel@Default
-              role: swiftreseller # to read/write blobs and manifests from/into customer's Swift accounts
+              role: swiftreseller # TODO Remove - to read/write blobs and manifests from/into customer's Swift accounts
+            - user: keppel@Default
+              role: cloud_objectstore_admin # to read/write blobs and manifests from/into customer's Swift accounts
         - name: master
           role_assignments:
             - user: keppel@Default

--- a/openstack/limes/templates/seed.yaml
+++ b/openstack/limes/templates/seed.yaml
@@ -88,7 +88,9 @@ spec:
           - user: limes@Default
             role: cloud_dns_admin
           - user: limes@Default
-            role:  swiftreseller
+            role:  swiftreseller # TODO Remove
+          - user: limes@Default
+            role:  cloud_objectstore_admin
           # permission to inspect metadata for private images (to determine OS type)
           - user: limes@Default
             role: cloud_image_admin

--- a/openstack/swift/templates/prometheus-alerts.yaml
+++ b/openstack/swift/templates/prometheus-alerts.yaml
@@ -36,7 +36,32 @@ spec:
   groups:
   - name: openstack-swift-roleassignments.alerts
     rules:
-      # allowed role assignments for the `swiftreseller` role:
+      # allowed role assignments for the `cloud_objectstore_admin` role:
+      # - group CCADMIN_CLOUD_ADMINS@ccadmin           in project cloud_admin@ccadmin
+      # - user admin@Default                           in project admin@Default (for openstackseeder to create Swift accounts)
+      # - user ironic@Default                          in project service@Default (to read private OS images)
+      # - user keppel@Default                          in project cloud_admin@ccadmin (to access customers' Keppel containers)
+      # - user limes@Default                           in project cloud_admin@ccadmin (for Limes to get/set quotas)
+      # - user kubernikus@Default                      in project cloud_admin@ccadmin
+      # ONLY EU-NL-1:
+      # - user kubernikus-master@Default               in project cloud_admin@ccadmin
+
+      - alert: OpenstackSwiftUnexpectedCloudAdminRoleAssignments
+        {{- $r := $.Values.global.region }}
+        expr: absent(openstack_assignments_per_role{role_name="cloud_objectstore_admin"}) or max(openstack_assignments_per_role{role_name="cloud_objectstore_admin"}) > {{if eq $r "eu-nl-1"}} 7 {{ else }} 6 {{ end }}
+        for: 10m
+        labels:
+          tier: os
+          service: swift
+          severity: info
+          playbook: 'docs/support/playbook/unexpected-role-assignments.html'
+          meta: 'Unexpected role assignments found for Keystone role "cloud_objectstore_admin"'
+        annotations:
+          summary: 'Unexpected role assignments'
+          description: 'The Keystone role "cloud_objectstore_admin" is assigned to more users/groups than expected.'
+  - name: openstack-swift-roleassignments-old.alerts
+    rules:
+      # allowed role assignments for the `swiftreseller` role: # TODO Remove
       # - group CCADMIN_CLOUD_ADMINS@ccadmin           in project cloud_admin@ccadmin
       # - user admin@Default                           in project admin@Default (for openstackseeder to create Swift accounts)
       # - user ironic@Default                          in project service@Default (to read private OS images)

--- a/openstack/swift/templates/seeds.yaml
+++ b/openstack/swift/templates/seeds.yaml
@@ -47,7 +47,9 @@ spec:
     - name: admin
       role_assignments:
       - project: admin
-        role: swiftreseller # used by openstack-seeder to create Swift accounts
+        role: swiftreseller # TODO Remove - used by openstack-seeder to create Swift accounts
+      - project: admin
+        role: cloud_objectstore_admin # used by openstack-seeder to create Swift accounts
     - name: swift
       description: 'Swift Service'
       password: '{{ .Values.swift_service_password }}'
@@ -63,7 +65,9 @@ spec:
     - name: cloud_admin
       role_assignments:
       - group: CCADMIN_CLOUD_ADMINS
-        role: swiftreseller
+        role: swiftreseller # TODO Remove
+      - group: CCADMIN_CLOUD_ADMINS
+        role: cloud_objectstore_admin
     - name: master # Swift account is enabled in swift-utils-seed
       role_assignments:
       - group: CCADMIN_CLOUD_ADMINS


### PR DESCRIPTION
To be prepared for the swift reseller role rename, adding the new `cloud_objectstore_admin` role already to the service accounts and add a new alert.