### PR TITLE
[Ironic] Additional swift reseller role

### DIFF
--- a/openstack/ironic/templates/seed.yaml
+++ b/openstack/ironic/templates/seed.yaml
@@ -494,7 +494,9 @@ spec:
       - project: service
         role: cloud_image_admin
       - project: service
-        role: swiftreseller
+        role: swiftreseller # TODO Remove
+      - project: service
+        role: cloud_objectstore_admin
     - name: ipmi_exporter
       description: IPMI Exporter for MB Monitoring
       password: {{ required "ipmi_exporter_user_passwd is missing" .Values.global.ipmi_exporter_user_passwd | quote }}


### PR DESCRIPTION
We are migrating to CCloud conform role namings and introduced a new Swift reseller role:
`cloud_objectstore_admin`. To make the migration as smooth as possible, the new role will
be already assigned to the `service` user in the Default domain.
Removal off the old role assignment will happen later.