### PR TITLE
Re - federate cpu metrics

### DIFF
--- a/system/kube-monitoring-metal/templates/_frontend-prometheus.yaml.tpl
+++ b/system/kube-monitoring-metal/templates/_frontend-prometheus.yaml.tpl
@@ -18,7 +18,7 @@
       - '{__name__=~"^broker_.+"}'
       - '{__name__=~"^certmanager_.+"}'
       - '{__name__=~"^concourse_.+"}'
-      - '{__name__=~"^container_cpu_cfs_.+"}'
+      - '{__name__=~"^container_cpu.+"}'
       - '{__name__=~"^container_fs.+"}'
       - '{__name__=~"^container_memory_.+"}'
       - '{__name__=~"^container_network_.+"}'


### PR DESCRIPTION
after https://github.com/sapcc/helm-charts/commit/beb675c3eb0ba237d50c2cf956f0d4a1dbf81472 we do not aggregate cpu metrics anymore but also do not federate them thus they are not showing up in the prom.
this should re-enable the federation of the cpu metrics.