### PR TITLE
[nova] Split out placement database

### DIFF
--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 description: A Helm chart for Kubernetes
 name: nova
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Nova/OpenStack_Project_Nova_mascot.png
-version: 0.1.2
+version: 0.2.0
 appVersion: "rocky"

--- a/openstack/nova/templates/_helpers.tpl
+++ b/openstack/nova/templates/_helpers.tpl
@@ -72,3 +72,27 @@ annotations:
 {{- .Release.Name }}-{{ $name }}-{{ substr 0 4 $hash }}-{{ .Values.imageVersion | required "Please set nova.imageVersion or similar"}}
   {{- end }}
 {{- end }}
+
+{{- define "helpers.table_alias" }}
+{{- $envAll := first . }}
+{{- $tableName := last . }}
+DELIMITER $$
+IF EXISTS (SELECT *
+                     FROM information_schema.tables
+                     WHERE table_schema = '{{ $envAll.Values.apidbName }}'
+                     AND table_type <> 'VIEW'
+                     AND table_name = '{{ $tableName }}')
+THEN
+    RENAME TABLE {{ $envAll.Values.apidbName }}.{{ $tableName }} TO {{ $envAll.Values.placementdbName }}.{{ $tableName }};
+    CREATE OR REPLACE VIEW {{ $envAll.Values.apidbName }}.{{ $tableName }} AS SELECT * FROM {{ $envAll.Values.placementdbName }}.{{ $tableName }};
+END IF;
+$$
+DELIMITER ;
+{{- end }}
+
+{{- define "helpers.table_dealias" }}
+{{- $envAll := first . }}
+{{- $tableName := last . }}
+DROP VIEW IF EXISTS {{ $envAll.Values.apidbName }}.{{ $tableName }};
+RENAME TABLE IF EXISTS {{ $envAll.Values.placementdbName }}.{{ $tableName }} TO {{ $envAll.Values.apidbName }}.{{ $tableName }};
+{{- end }}

--- a/openstack/nova/templates/etc-configmap.yaml
+++ b/openstack/nova/templates/etc-configmap.yaml
@@ -67,4 +67,3 @@ data:
       labels:
         method: "$1"
         type: "$2"
-

--- a/openstack/nova/templates/placement-configmap.yaml
+++ b/openstack/nova/templates/placement-configmap.yaml
@@ -10,6 +10,14 @@ metadata:
 data:
   nova.conf: |
 {{ include (print .Template.BasePath "/etc/_nova.conf.tpl") . | indent 4 }}
+    [placement_database]
+    connection = mysql+pymysql://
+    {{- if .Values.placementdbPassword -}}
+    {{ .Values.placementdbUser }}:{{ .Values.placementdbPassword | urlquery }}@nova-api-mariadb/{{ .Values.placementdbName }}?charset=utf8
+    {{- else -}}
+    {{ .Values.apidbUser }}:{{ .Values.apidbPassword | urlquery }}@nova-api-mariadb/{{ .Values.apidbName }}?charset=utf8
+    {{- end }}
+    {{- include "ini_sections.database_options_mysql" . | indent 4 }}
   policy.json: |
 {{ include (print .Template.BasePath "/etc/_nova-policy.json.tpl") . | indent 4 }}
   logging.ini: |

--- a/openstack/nova/templates/placement-configmap.yaml
+++ b/openstack/nova/templates/placement-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.placement.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,6 +11,7 @@ metadata:
 data:
   nova.conf: |
 {{ include (print .Template.BasePath "/etc/_nova.conf.tpl") . | indent 4 }}
+{{- if not .Values.placement.unsplit }}
     [placement_database]
     connection = mysql+pymysql://
     {{- if .Values.placementdbPassword -}}
@@ -18,9 +20,9 @@ data:
     {{ .Values.apidbUser }}:{{ .Values.apidbPassword | urlquery }}@nova-api-mariadb/{{ .Values.apidbName }}?charset=utf8
     {{- end }}
     {{- include "ini_sections.database_options_mysql" . | indent 4 }}
-  policy.json: |
-{{ include (print .Template.BasePath "/etc/_nova-policy.json.tpl") . | indent 4 }}
+{{- end }}
   logging.ini: |
 {{ include "loggerIni" .Values.logging | indent 4 }}
   placement_uwsgi.ini: |
 {{ include (print .Template.BasePath "/etc/_placement_uwsgi.ini.tpl") . | indent 4 }}
+{{- end }}

--- a/openstack/nova/templates/placement-db-finalize-split-job.yaml
+++ b/openstack/nova/templates/placement-db-finalize-split-job.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.placement.finalize_split }}
+{{- $envAll := . }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-placement-db-finalize-split"
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ default "unknown" .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-placement-db-finalize-split"
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ .Release.Name }}-pod-exec
+      containers:
+      - name: placement-db-finalize-split
+        image: "{{ required ".Values.global.registry is missing" .Values.global.registry}}/{{ .Values.pre_change_hook.image }}:{{ .Values.pre_change_hook.image_version }}"
+        command:
+        - kubectl-v{{ .Values.pre_change_hook.kubectl_version }}
+        - exec
+        - -c
+        - mariadb
+        - deploy/nova-api-mariadb
+        - --
+        - mariadb
+        - -uroot
+        - --batch
+        - -e
+        - |
+          DROP VIEW IF EXISTS
+          {{- range mustInitial .Values.placement.tables }}
+            {{ $envAll.Values.apidbName }}.{{ . }},
+          {{- end }}
+            {{ $envAll.Values.apidbName }}.{{ last .Values.placement.tables }};
+{{- end }}
+

--- a/openstack/nova/templates/placement-db-split-job.yaml
+++ b/openstack/nova/templates/placement-db-split-job.yaml
@@ -1,0 +1,52 @@
+{{- if and .Values.placement.enabled (not .Values.placement.unsplit) .Values.placementdbUser .Values.placementdbPassword .Values.placementdbName }}
+{{- /* See: https://github.com/openstack/placement/blob/master/placement_db_tools/mysql-migrate-db.sh */}}
+{{- $envAll := . }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-placement-db-split"
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ default "unknown" .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-placement-db-split"
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ .Release.Name }}-pod-exec
+      containers:
+      - name: placement-db-split
+        image: "{{ required ".Values.global.registry is missing" .Values.global.registry}}/{{ .Values.pre_change_hook.image }}:{{ .Values.pre_change_hook.image_version }}"
+        command:
+        - kubectl-v{{ .Values.pre_change_hook.kubectl_version }}
+        - exec
+        - -c
+        - mariadb
+        - deploy/nova-api-mariadb
+        - --
+        - mariadb
+        - -uroot
+        - --batch
+        - -e
+        - |
+          SET character_set_server = 'utf8';
+          SET collation_server = 'utf8_general_ci';
+          CREATE DATABASE IF NOT EXISTS {{ .Values.placementdbName }};
+          CREATE USER IF NOT EXISTS {{ .Values.placementdbUser }};
+          ALTER USER {{ .Values.placementdbUser }} IDENTIFIED BY '{{ .Values.placementdbPassword }}';
+          GRANT ALL PRIVILEGES ON {{ .Values.placementdbName }}.* TO {{ .Values.placementdbUser }};
+
+          {{- range .Values.placement.tables }}
+            {{- list $envAll . | include "helpers.table_alias" | indent 10 }}
+          {{- end }}
+{{- end }}

--- a/openstack/nova/templates/placement-db-unsplit-job.yaml
+++ b/openstack/nova/templates/placement-db-unsplit-job.yaml
@@ -1,0 +1,48 @@
+{{- if and .Values.placement.enabled .Values.placement.unsplit }}
+{{- /* See: https://github.com/openstack/placement/blob/master/placement_db_tools/mysql-migrate-db.sh */}}
+{{- $envAll := . }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-placement-db-unsplit"
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ default "unknown" .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-placement-db-unsplit"
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ .Release.Name }}-pod-exec
+      containers:
+      - name: placement-db-unsplit
+        image: "{{ required ".Values.global.registry is missing" .Values.global.registry}}/{{ .Values.pre_change_hook.image }}:{{ .Values.pre_change_hook.image_version }}"
+        command:
+        - kubectl-v{{ .Values.pre_change_hook.kubectl_version }}
+        - exec
+        - -c
+        - mariadb
+        - deploy/nova-api-mariadb
+        - --
+        - mariadb
+        - -uroot
+        - --batch
+        - -e
+        - |
+          {{- range mustReverse .Values.placement.tables }}
+            {{- list $envAll . | include "helpers.table_dealias" | indent 10 }}
+          {{- end }}
+
+          DROP DATABASE IF EXISTS {{ .Values.placementdbName }};
+          DROP USER IF EXISTS {{ .Values.placementdbUser }};
+{{- end }}

--- a/openstack/nova/templates/pod-exec-rbac.yaml
+++ b/openstack/nova/templates/pod-exec-rbac.yaml
@@ -1,0 +1,46 @@
+{{- if and .Values.placement.enabled (or .Values.placement.unsplit (and .Values.placementdbUser .Values.placementdbPassword .Values.placementdbName)) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-pod-exec
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-50"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: monsoon3
+  name: {{ .Release.Name }}-pod-exec
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-40"
+rules:
+- apiGroups: ["extensions", "apps"]
+  resources: ["deployments"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["pods", "services"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: [""]
+  resources: ["pods/exec"]
+  verbs: ["create"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-pod-exec
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-30"
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-pod-exec
+roleRef:
+  kind: Role
+  name: {{ .Release.Name }}-pod-exec
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -153,6 +153,10 @@ apidbName: nova_api
 apidbUser: nova_api
 apidbPassword: null
 
+placementdbName: placement
+placementdbUser: placement
+placementdbPassword: null
+
 loci:
   nova: false
   openvswitch: false
@@ -331,6 +335,20 @@ quota:
 placement:
   enabled: true
   wsgi_processes: 10
+  unsplit: false  # True: Revert split triggered by setting placementdbPassword
+  finalize_split: false # True: Remove placement table views from nova (after a migration)
+  tables:   # Do not modify, this is the list of all tables
+  - allocations
+  - consumers
+  - inventories
+  - placement_aggregates
+  - projects
+  - resource_classes
+  - resource_provider_aggregates
+  - resource_provider_traits
+  - resource_providers
+  - traits
+  - users
 
 mysql_metrics:
   db_name: nova
@@ -859,3 +877,8 @@ sentry:
   enabled: true
 
 nova_bigvm_enabled: true
+
+pre_change_hook:
+  image: "sapcc/unified-kubernetes-toolbox"
+  image_version: "20220525082919"
+  kubectl_version: 1.21.8


### PR DESCRIPTION
Based on #3223

Moves all tables from `nova_api` to the one specified in `placementdbName` as soon as a `placementdbPassword` is specified.
The operations are idempotent, and can be reverted with a deployment with the value `placement.unsplit=true`.

No downtime required, as the alias is there practically immediately.

The backup still needs to be adjusted.