### PR TITLE
[openstack/utils] Do not require postgresql to be set

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.3.11
+version: 0.3.12

--- a/openstack/utils/templates/_ini_sections.tpl
+++ b/openstack/utils/templates/_ini_sections.tpl
@@ -24,7 +24,9 @@ max_overflow = {{ .Values.max_overflow | default .Values.global.max_overflow | d
 {{- define "ini_sections.database" }}
 
 [database]
-{{- if eq .Values.postgresql.enabled false }}
+{{- if not .Values.postgresql }}
+connection = {{ include "db_url_mysql" . }}
+{{- else if not .Values.postgresql.enabled }}
 connection = {{ include "db_url_mysql" . }}
 {{- include "ini_sections.database_options_mysql" . }}
 {{- else }}


### PR DESCRIPTION
The code now requires an explicit
```
postgresql:
  enabled: false
```
which is a bit annoying since everything is switched to mariadb