### PR TITLE
Use pod label to denote F5 model name for Limes

### DIFF
--- a/openstack/octavia/templates/octavia-worker-deployment.yaml
+++ b/openstack/octavia/templates/octavia-worker-deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: {{ include "octavia.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    f5-device-model: {{ index .Values.workers $name "model" }}
+    f5-device-model: {{ $v.model }}
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
This PR will be merged after the `model` helm value is added.
This code change exposes the `model` value as an Octavia worker pod label.
Limes will iterate over Octavia worker pods and map model names to capacity values, then sum them up per region.