### PR TITLE
[Cinder] remove prometheus.io/port

### DIFF
--- a/openstack/cinder/templates/api-service.yaml
+++ b/openstack/cinder/templates/api-service.yaml
@@ -10,7 +10,6 @@ metadata:
   annotations:
     prometheus.io/scrape: "true"
     maia.io/scrape: "true"
-    prometheus.io/port: {{.Values.port_metrics | quote }}
     prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
 spec:
   selector:
@@ -18,3 +17,5 @@ spec:
   ports:
     - name: cinder-api
       port: {{ .Values.cinderApiPortInternal }}
+    - name: metrics
+      port: {{.Values.port_metrics | quote }}


### PR DESCRIPTION
This removes the prometheus.io/port from the chart and changes it to
a spec named metrics.
This is related to discussion on slack:

https://operations.global.cloud.sap/docs/support/playbook/kubernetes/target_scraped_multiple_times/#usage-or-prometheusioport-annotation-with-multiple-ports