### PR TITLE
octavia: fix "f5-device-model" label

### DIFF
--- a/openstack/octavia/templates/octavia-worker-deployment.yaml
+++ b/openstack/octavia/templates/octavia-worker-deployment.yaml
@@ -10,7 +10,6 @@ metadata:
     helm.sh/chart: {{ include "octavia.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    f5-device-model: {{ $v.model }}
 spec:
   replicas: 1
   selector:
@@ -22,6 +21,7 @@ spec:
       labels:
         app.kubernetes.io/name: octavia-worker-{{ $name }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        f5-device-model: {{ $v.model }} # used by Limes for capacity discovery (via Prometheus metric "kube_pod_labels")
       annotations:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/octavia-etc-configmap.yaml") . | sha256sum }}
         configmap-worker-hash: {{ include (print $.Template.BasePath "/octavia-worker-configmap.yaml") . | sha256sum }}


### PR DESCRIPTION
It needs to be on the pod, not on the deployment, because only pod labels are exposed as a Prometheus metric. While I was at it, I added a comment to document the purpose of the label.