### PR TITLE
[nova] Remove duplicate sudoers key

### DIFF
--- a/openstack/nova/templates/etc-configmap.yaml
+++ b/openstack/nova/templates/etc-configmap.yaml
@@ -34,8 +34,6 @@ data:
 {{ include (print .Template.BasePath "/etc/_sudoers.tpl") . | indent 4 }}
   rootwrap.conf: |
 {{ include (print .Template.BasePath "/etc/_rootwrap.conf.tpl") . | indent 4 }}
-  sudoers: |
-    nova ALL = (root) NOPASSWD: /var/lib/kolla/venv/bin/nova-rootwrap /etc/nova/rootwrap.conf *
   api-metadata.filters: |
 {{ include (print .Template.BasePath "/etc/_api-metadata.filters.tpl") . | indent 4 }}
   compute.filters: |


### PR DESCRIPTION
The latter key is the one actually used, but the former
is a more complete sudoers config, so we rather go with that one