### PR TITLE
Stop federating ALERT metrics to global Prometheus to avoid duplicate…

### DIFF
--- a/global/prometheus-kubernetes-global/values.yaml
+++ b/global/prometheus-kubernetes-global/values.yaml
@@ -59,7 +59,6 @@ prometheus-kubernetes-global:
 # Per convention all metrics with the `global:` prefix are federated.
 allowedMetrics:
   - global:.+
-  - ALERTS
   - alertmanager_.+
   - kube_node_.+
   - kube_node_status_capacity

--- a/global/prometheus-kubernikus-global/templates/_prometheus.yaml.tpl
+++ b/global/prometheus-kubernikus-global/templates/_prometheus.yaml.tpl
@@ -8,7 +8,6 @@
 
   params:
     'match[]':
-      - '{__name__=~"^ALERTS$"}'
       - '{__name__=~"^kubernikus_kluster_status_phase"}'
       - '{__name__=~"^kubernikus_kluster_info"}'
       - '{__name__=~"^kubernikus_servicing_nodes.+"}'


### PR DESCRIPTION
… alerts. 
For pending and firing alerts, Prometheus also stores synthetic time series of the form ALERTS. If we federate these metrics into global Prometheus, we see alerts twice in the alert manager - from regional and global Prometheus.
