### PR TITLE
[nova] Add cloud_dns_admin role to nova service user

### DIFF
--- a/openstack/nova/templates/seed.yaml
+++ b/openstack/nova/templates/seed.yaml
@@ -27,6 +27,7 @@ spec:
   - name: cloud_volume_admin
   - name: cloud_baremetal_admin
   - name: swiftoperator
+  - name: cloud_dns_admin
 
   services:
   - name: nova
@@ -95,6 +96,8 @@ spec:
         role: cloud_baremetal_admin
       - project: service
         role: cloud_volume_admin
+      - project: service
+        role: cloud_dns_admin
     - name: placement
       description: Placement API Service User
       password: {{ required ".Values.global.placement_service_password is missing" .Values.global.placement_service_password }}


### PR DESCRIPTION
The nova service user is used e.g. when retrying to delete an instance
on nova-compute restart. If the customer has a DNS name assigned to
their port, deleting of the port and thus the server will fail, if the
nova service user doesn't have the appropriate role.