### PR TITLE
[Cinder]  Fix the port value for pod scrapes

### DIFF
--- a/openstack/cinder/templates/api-service.yaml
+++ b/openstack/cinder/templates/api-service.yaml
@@ -18,4 +18,4 @@ spec:
     - name: cinder-api
       port: {{ .Values.cinderApiPortInternal }}
     - name: metrics
-      port: {{.Values.port_metrics | quote }}
+      port: {{ .Values.port_metrics }}


### PR DESCRIPTION
This patch removes the quote from the value to ensure it's an int