### PR TITLE
[manila] update alert OpenstackManilaShareSnapshotsMissing

### DIFF
--- a/openstack/manila/alerts/openstack/manila.alerts
+++ b/openstack/manila/alerts/openstack/manila.alerts
@@ -30,7 +30,7 @@ groups:
       summary: Manila share snapshots in stuck state
 
   - alert: OpenstackManilaShareSnapshotsMissing
-    expr: sum(manila_nanny_missing_snapshot_instance) > 0
+    expr: sum(manila_nanny_missing_snapshot_instance{status!~"error|creating|deleting"}) > 0
     for: 30m
     labels:
       dashboard: manila


### PR DESCRIPTION
The snapshots with status 'error', 'creating', 'deleting' are not
interesting, alert only on those in 'available' and 'error_deleting'.