### PR TITLE
[cronus]: reject only unknown GET parameters

### DIFF
--- a/openstack/cronus/templates/cronus/_config.yaml.tpl
+++ b/openstack/cronus/templates/cronus/_config.yaml.tpl
@@ -146,15 +146,6 @@ cronus:
 {{- end }}
 {{- end }}
 {{- end }}
-{{- if .Values.config.blockedDomains }}
-  # blocked sender domains
-  # TODO: delete after upgrade
-  blockedDomains:
-{{- range $k, $v := .Values.config.blockedDomains }}
-    - {{ $v }}
-{{- end }}
-    - {{ .Values.config.verifyEmailDomain }}
-{{- end }}
 {{- $requestValidate := .Values.global.requestValidate }}
 {{- if not $requestValidate }}
 {{- $requestValidate = .Values.config.requestValidate }}
@@ -175,6 +166,12 @@ cronus:
     originatorHeaders:
 {{- range $k, $v := $requestValidate.originatorHeaders }}
       {{ $k }}: {{ $v }}
+{{- end }}
+{{- end }}
+{{- if $requestValidate.allowedGetParams }}
+    allowedGetParams:
+{{- range $k, $v := $requestValidate.allowedGetParams }}
+      - {{ $v }}
 {{- end }}
 {{- end }}
 {{- if $requestValidate.sesV1CheckKeys }}

--- a/openstack/cronus/values.yaml
+++ b/openstack/cronus/values.yaml
@@ -264,11 +264,6 @@ config:
       maxTTL: 1 # in days
       deadLetterExchange: cronus_work_queue_exchange
       deadLetterRoutingKey: cronus.job
-  # the list of domains to be blocked by a proxy server on ses email identity create/delete actions
-  blockedDomains:
-    - example.com # the exact domain
-    - .example.com # all subdomains
-    - sub.example.com # the exact subdomain
   requestValidate:
     # the list of domains to be blocked by a proxy server on ses email identity create/delete actions
     blockedDomains:
@@ -285,6 +280,17 @@ config:
     originatorHeaders:
       From: HeaderFrom
       Sender: HeaderSender
+    # needs a ceraful review since newer APIs may contain something like "Sender"
+    allowedGetParams:
+      - BlacklistItemNames
+      - EndDate
+      - NextToken
+      - PageSize
+      - PoolName
+      - Reason
+      - ResourceArn
+      - StartDate
+      - TagKeys
     # a map of SESv1 actions and identity field names to check
     sesV1CheckKeys:
       SendEmail: Source


### PR DESCRIPTION
new config option to whitelist a list of get params