### PR TITLE
swift: add role assignment alert for cloud_objectstore_viewer

### DIFF
--- a/openstack/swift/templates/prometheus-alerts.yaml
+++ b/openstack/swift/templates/prometheus-alerts.yaml
@@ -59,6 +59,24 @@ spec:
         annotations:
           summary: 'Unexpected role assignments'
           description: 'The Keystone role "cloud_objectstore_admin" is assigned to more users/groups than expected.'
+
+      # allowed role assignments for the `cloud_objectstore_viewer` role:
+      # - none so far
+
+      - alert: OpenstackSwiftUnexpectedCloudViewerRoleAssignments
+        expr: max(openstack_assignments_per_role{role_name="cloud_objectstore_viewer"}) > 0
+        for: 10m
+        labels:
+          no_alert_on_absence: "true" # Keystone does not generate a zero-valued metric, so this metric is actually absent until an alert happens (TODO: remove this once we add allowed role assignments)
+          tier: os
+          service: swift
+          severity: info
+          playbook: 'docs/support/playbook/unexpected-role-assignments.html'
+          meta: 'Unexpected role assignments found for Keystone role "cloud_objectstore_viewer"'
+        annotations:
+          summary: 'Unexpected role assignments'
+          description: 'The Keystone role "cloud_objectstore_viewer" is assigned to more users/groups than expected.'
+
   - name: openstack-swift-roleassignments-old.alerts
     rules:
       # allowed role assignments for the `swiftreseller` role: # TODO Remove


### PR DESCRIPTION
Same as for cloud_objectstore_admin/swiftreseller. For now, no assignments are known.