### PR TITLE
[keystone] Option for central hermes rabbitmq

### DIFF
--- a/openstack/keystone/templates/etc/_keystone.conf.tpl
+++ b/openstack/keystone/templates/etc/_keystone.conf.tpl
@@ -162,12 +162,26 @@ disable_user_account_days_inactive = {{ .Values.disable_user_account_days_inacti
 {{- end }}
 
 [oslo_messaging_notifications]
-{{- if .Values.rabbitmq.host }}
+driver = messaging
+{{- if and .Values.audit.central_service.user .Values.audit.central_service.password }}
+transport_url = rabbit://{{ .Values.audit.central_service.user }}:{{ .Values.audit.central_service.password | urlquery }}@{{ .Values.audit.central_service.host }}:{{ .Values.audit.central_service.port }}/
+
+[oslo_messaging_rabbit]
+rabbit_retry_interval = {{ .Values.audit.central_service.rabbit_retry_interval | default 1 }}
+kombu_reconnect_delay = {{ .Values.audit.central_service.kombu_reconnect_delay | default 0.1 }}
+rabbit_interval_max = {{ .Values.audit.central_service.rabbit_interval_max | default 1 }}
+rabbit_retry_backoff = {{ .Values.audit.central_service.rabbit_retry_backoff | default 0 }}
+heartbeat_timeout_threshold = {{ .Values.audit.central_service.heartbeat_timeout_threshold | default 0 }}
+{{/* The default values cause a one second delay
+      on the first try and a 0.1 second on all the other ones.
+      It is exploiting a bug in the logic which seems to be triggered
+      when rabbit_interval_max >= rabbit_retry_interval
+*/}}
+{{- else if .Values.rabbitmq.host }}
 transport_url = rabbit://{{ .Values.rabbitmq.users.default.user | default "rabbitmq" }}:{{ .Values.rabbitmq.users.default.password }}@{{ .Values.rabbitmq.host }}:{{ .Values.rabbitmq.port | default 5672 }}
 {{ else }}
 transport_url = rabbit://{{ .Values.rabbitmq.users.default.user | default "rabbitmq" }}:{{ .Values.rabbitmq.users.default.password }}@{{ include "rabbitmq_host" . }}:{{ .Values.rabbitmq.port | default 5672 }}
 {{- end }}
-driver = messaging
 
 [oslo_middleware]
 enable_proxy_headers_parsing = true

--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -237,6 +237,13 @@ services:
     #tlsCertificate:
     #tlsKey:
 
+audit:
+  central_service:
+    # user:
+    # password:
+    host: hermes-rabbitmq-notifications.hermes
+    port: 5672
+
 rabbitmq:
   ## default: {{.Release.Name}}-rabbitmq.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.region}}.{{.Values.global.tld}}
   # host: rabbitmq


### PR DESCRIPTION
This provides the option of using the HA setup rabbitmq from hermes
instead of the single non-ha one.

To ensure that no messages are dropped, one first needs to
supply audit.user and audit.password to enable
sending out the new events and after ensuring that
no messages are on the queue of the old rabbitmq,
one can disable the internal one.