### PR TITLE
[octavia] Pending LBs metric: Consolidate field names, add network ID

### DIFF
--- a/openstack/octavia/alerts/octavia.alerts
+++ b/openstack/octavia/alerts/octavia.alerts
@@ -56,7 +56,7 @@ groups:
       description: 'Failover detected for agent {{ $labels.app_kubernetes_io_name }}, AS3 target will be changed to active device.'
       summary: Openstack Octavia Metric to monitor F5 Worker Agent failover events
   - alert: OpenstackOctaviaLoadbalancerErrored
-    expr: rate(octavia_loadbalancers_count_gauge{status="ERROR"}[5m]) > 0
+    expr: rate(octavia_loadbalancers_count_gauge{loadbalancer_status="ERROR"}[5m]) > 0
     for: 10m
     labels:
       context: Loadbalancer go to ERROR
@@ -64,9 +64,9 @@ groups:
       service: octavia
       severity: info
       tier: os
-      meta: 'Load Balancers in {{ $labels.octavia_host }} gone to ERROR state'
+      meta: 'Load Balancers in {{ $labels.loadbalancer_host }} gone to ERROR state'
     annotations:
-      description: Loadbalancers in {{ $labels.octavia_host }} gone to ERROR state
+      description: Loadbalancers in {{ $labels.loadbalancer_host }} gone to ERROR state
       summary: Openstack Octavia Metric to monitor erroneous loadbalancers
   - alert: OctaviaLoadBalancerStuckInPending
     expr: octavia_seconds_since_last_nonpending_status > 30 * 60
@@ -78,9 +78,9 @@ groups:
       service: octavia
       severity: critical
       tier: os
-      meta: 'Load Balancer for agent {{ $labels.octavia_host }} stuck in `{{ $labels.current_status }}` state'
+      meta: 'Load Balancer for agent {{ $labels.loadbalancer_host }} stuck in `{{ $labels.loadbalancer_status }}` state'
       playbook: docs/support/playbook/octavia/stuck_pending
       cloudops: "?searchTerm={{ $labels.loadbalancer_id }}&type=loadbalancer"
     annotations:
-      description: 'The Load Balancer `{{ $labels.loadbalancer_name }}` of agent `{{ $labels.octavia_host }}` stuck in {{ $labels.current_status }} state (<https://dashboard.{{ $externalLabels.region }}.cloud.sap/ccadmin/cloud_admin/cloudops#/universal-search/?searchTerm={{ $labels.loadbalancer_id }}&type=loadbalancer|{{ $labels.loadbalancer_id }}>)'
+      description: 'The Load Balancer `{{ $labels.loadbalancer_name }}` of agent `{{ $labels.loadbalancer_host }}` stuck in {{ $labels.loadbalancer_status }} state (<https://dashboard.{{ $externalLabels.region }}.cloud.sap/ccadmin/cloud_admin/cloudops#/universal-search/?searchTerm={{ $labels.loadbalancer_id }}&type=loadbalancer|{{ $labels.loadbalancer_id }}>)'
       summary: Octavia Load-Balancer stuck in PENDING_* state

--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -133,17 +133,18 @@ mysql_metrics:
         - "count_gauge"
     - name: octavia_seconds_since_last_nonpending_status
       labels:
-        - "current_status"
-        - "octavia_host"
         - "loadbalancer_id"
+        - "loadbalancer_status"
         - "loadbalancer_name"
+        - "loadbalancer_host"
+        - "loadbalancer_network"
       help: Seconds since last non-pending state of LB
       query: |
         (SELECT
           UNIX_TIMESTAMP(now()) - UNIX_TIMESTAMP(coalesce(lb.updated_at, lb.created_at)) AS elapsed_time,
-          lb.name AS loadbalancer_name,
-          lb.provisioning_status AS loadbalancer_status,
           lb.id AS loadbalancer_id,
+          lb.provisioning_status AS loadbalancer_status,
+          lb.name AS loadbalancer_name,
           lb.server_group_id AS loadbalancer_host,
           v.network_id AS loadbalancer_network
         FROM load_balancer AS lb

--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -140,14 +140,16 @@ mysql_metrics:
       help: Seconds since last non-pending state of LB
       query: |
         (SELECT
-          UNIX_TIMESTAMP(now()) - UNIX_TIMESTAMP(coalesce(updated_at, created_at)) AS elapsed_time,
-          name AS loadbalancer_name,
-          provisioning_status AS current_status,
-          id AS loadbalancer_id,
-          server_group_id AS octavia_host
-        FROM load_balancer
-        WHERE provisioning_status LIKE "PENDING_%")
-        UNION (select '0', '', '', '', '');
+          UNIX_TIMESTAMP(now()) - UNIX_TIMESTAMP(coalesce(lb.updated_at, lb.created_at)) AS elapsed_time,
+          lb.name AS loadbalancer_name,
+          lb.provisioning_status AS loadbalancer_status,
+          lb.id AS loadbalancer_id,
+          lb.server_group_id AS loadbalancer_host,
+          v.network_id AS loadbalancer_network
+        FROM load_balancer AS lb
+        JOIN vip AS v ON v.load_balancer_id=lb.id
+        WHERE lb.provisioning_status LIKE "PENDING_%")
+        UNION (select '0', '', '', '', '', '');
       values:
         - "elapsed_time"
     - name: octavia_monitor_agents_heartbeat_seconds

--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -119,16 +119,16 @@ mysql_metrics:
         - "count_gauge"
     - name: octavia_loadbalancers_count_gauge
       labels:
-        - "status"
-        - "octavia_host"
+        - "loadbalancer_status"
+        - "loadbalancer_host"
       help: Total Load Balancer count
       query: |
         SELECT
           COUNT(*) AS count_gauge,
-          provisioning_status AS status,
-          server_group_id as octavia_host
+          provisioning_status AS loadbalancer_status,
+          server_group_id as loadbalancer_host
         FROM load_balancer
-        GROUP BY octavia_host, provisioning_status;
+        GROUP BY loadbalancer_host, loadbalancer_status;
       values:
         - "count_gauge"
     - name: octavia_seconds_since_last_nonpending_status


### PR DESCRIPTION
Change octavia_seconds_since_last_nonpending_status in two ways:
- Add `vip.network_id` field, so that it's more easily noticeable when one stuck LB clogs an entire tenant (tenants map to networks).
- Consolidate field names: Rename `octavia_host` to `loadbalancer_host` and `current_status` to `loadbalancer_status`, so that these related fields appear together in the metrics overview.

As far as I know the `octavia_seconds_since_last_nonpending_status` metric is not consumed by any automation.