### PR TITLE
[nova] Disable online migrations with placement

### DIFF
--- a/openstack/nova/templates/bin/_db-online-migrate.tpl
+++ b/openstack/nova/templates/bin/_db-online-migrate.tpl
@@ -6,7 +6,10 @@ set -e
 nova_manage="nova-manage --config-file /etc/nova/nova.conf"
 available_commands_text=$(nova-manage --help | awk '/Command categories/ {getline; print $0}')
 
+{{- if or .Values.placement.enabled (.Values.imageVersion | hasPrefix "rocky" | not) }}
+
 $nova_manage db online_data_migrations
+{{- end }}
 
 if echo "${available_commands_text}" | grep -q -E '[{,]placement[},]'; then
   $nova_manage placement sync_aggregates


### PR DESCRIPTION
If placement gets deployed by its own service,
we can't have nova mess with its tables