### PR TITLE
[neutron] add free/total segment count metric

### DIFF
--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -496,6 +496,32 @@ mysql_metrics:
         FROM networks;
       values:
       - "value"
+    - help: Neutron maximum possible segment allocations per hostgroup
+      labels:
+      - "hostgroup"
+      name: openstack_neutron_network_segments_total
+      query: |
+        SELECT
+          host AS hostgroup,
+          COUNT(*) AS value
+        FROM aci_port_binding_allocations
+        GROUP BY host;
+      values:
+      - "value"
+    - help: Neutron free available segment allocations per hostgroup
+      labels:
+      - "hostgroup"
+      name: openstack_neutron_network_segments_free
+      query: |
+        SELECT
+          host AS hostgroup,
+          COUNT(*) AS value
+        FROM aci_port_binding_allocations
+        WHERE
+          segment_id IS NULL
+        GROUP BY host;
+      values:
+      - "value"
 
 max_pool_size: 20
 max_overflow: 5


### PR DESCRIPTION
This metric can be used in a global dashboard and to alert on exhausting
segments.

Also checked if queries are optimized using indexes:
```
MariaDB [neutron]> explain select COUNT(*) from aci_port_binding_allocations GROUP BY host;
+------+-------------+------------------------------+-------+---------------+---------+---------+------+-------+-------------+
| id   | select_type | table                        | type  | possible_keys | key     | key_len | ref  | rows  | Extra       |
+------+-------------+------------------------------+-------+---------------+---------+---------+------+-------+-------------+
|    1 | SIMPLE      | aci_port_binding_allocations | index | NULL          | PRIMARY | 1542    | NULL | 88948 | Using index |
+------+-------------+------------------------------+-------+---------------+---------+---------+------+-------+-------------+
```

```
MariaDB [neutron]> explain select COUNT(*) from aci_port_binding_allocations WHERE segment_id IS NULL GROUP BY host;
+------+-------------+------------------------------+------+---------------+------------+---------+-------+-------+--------------------------+
| id   | select_type | table                        | type | possible_keys | key        | key_len | ref   | rows  | Extra                    |
+------+-------------+------------------------------+------+---------------+------------+---------+-------+-------+--------------------------+
|    1 | SIMPLE      | aci_port_binding_allocations | ref  | segment_id    | segment_id | 111     | const | 44474 | Using where; Using index |
+------+-------------+------------------------------+------+---------------+------------+---------+-------+-------+--------------------------+
1 row in set (0.000 sec)
```