### PR TITLE
[Cinder] Stack volumes instead of spreading out

### DIFF
--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -85,7 +85,7 @@ db_name: cinder
 scheduler_default_filters: "AvailabilityZoneFilter,ShardFilter,CapacityFilter,CapabilitiesFilter,SAPLargeVolumeFilter,SAPDifferentBackendFilter,SAPSameBackendFilter"
 scheduler_default_weighers: "CapacityWeigher"
 
-capacity_weight_multiplier: 1.0
+capacity_weight_multiplier: -1.0
 allocated_capacity_weight_multiplier: -1.0
 
 cinder_api_allow_migration_on_attach: True


### PR DESCRIPTION
This patch changes the default Capacity Weigher to
stack volumes on a datastore instead of spreading them out.
This will help prevent smaller volumes from landing on the
most free datastores in a shard.  This will help keep the
newer created/most free datastores for the largest of volumes.