### PR TITLE
[PX] Allow scheduling in a single AZ even if site is multi-AZ

### DIFF
--- a/px/bird/templates/_deployment_header.tpl
+++ b/px/bird/templates/_deployment_header.tpl
@@ -10,6 +10,7 @@
 {{- $domain := index . 8}}
 {{- $instance_number := index . 9}}
 {{- $instance := index . 10}}
+{{- $az_redundancy  := index . 11}}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -72,8 +73,8 @@ spec:
                 operator: In
                 values:
                 - {{ $service_number | quote }}
-{{- if ge (len $azs) 2 }}
-{{- if lt (len (keys $apods))  2  }}
+{{- if and (ge (len $azs) 2) $az_redundancy }}
+{{- if lt (len (keys $apods))  2 }}
 {{- fail "If the region consists of multiple AZs, PX must be scheduled in at least 2" -}}
 {{- end }}
           - topologyKey: failure-domain.beta.kubernetes.io/zone

--- a/px/bird/templates/bird.yaml
+++ b/px/bird/templates/bird.yaml
@@ -16,7 +16,7 @@
 
 ---
 {{ tuple $deployment_name $domain_config.multus_vlan $instance_config.bird_ip | include "nad_multus"}}
-{{ tuple $deployment_name $.Values.global.availability_zones $.Values.scheduling_labels $.Values.apods $domain_config.multus_vlan $service_number $service $domain_number $domain $instance_number $instance | include "deployment_header" }}
+{{ tuple $deployment_name $.Values.global.availability_zones $.Values.scheduling_labels $.Values.apods $domain_config.multus_vlan $service_number $service $domain_number $domain $instance_number $instance $.Values.az_redundancy | include "deployment_header" }}
 {{ tuple $.Values $deployment_name $service_number $service_config $domain_number $domain_config | include "deployment_bird" | indent 6 }}
 {{ tuple $deployment_name $.Values.looking_glass | include "service_pxrs" }}
 

--- a/px/bird/values.yaml
+++ b/px/bird/values.yaml
@@ -16,6 +16,8 @@ registry:
 
 apods: {}
 
+az_redundancy: True
+
 # only required if apods is empty
 scheduling_labels:
   domain_1: []


### PR DESCRIPTION
In cases were we have to tear down an AZ or simply apods are not
available in every AZ, we need to be able to explicitly tell the chart
to not care about disjunct AZ scheduling for the PX domains.
This commit introduces a flag that does just that.