### PR TITLE
[Cinder] Update charts to include standard metadata_labels

### DIFF
--- a/openstack/cinder/templates/backup_deployment.yaml
+++ b/openstack/cinder/templates/backup_deployment.yaml
@@ -28,9 +28,8 @@ template: |{{`
     template:
       metadata:
         labels:
-          application: cinder
-          component: volume-backup-vmware
           name: cinder-volume-backup-vmware-{{ name }}
+{{ tuple . "cinder" "volume-backup-vmware" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 10 }}
       spec:
         hostname: cinder-volume-backup-vmware-{{ name }}
         containers:

--- a/openstack/cinder/templates/vcenter_datacenter_cinder_deployment.yaml
+++ b/openstack/cinder/templates/vcenter_datacenter_cinder_deployment.yaml
@@ -31,9 +31,8 @@ template: |
     template:
       metadata:
         labels:
-          application: cinder
-          component: volume-vmware
           name: cinder-volume-vmware-{= name =}
+{{ tuple . "cinder" "volume-vmware" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 10 }}
         annotations:
           configmap-etc-hash: {{ include (print .Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
           configmap-cinder-volume-hash: {= "vcenter_datacenter/{{ .Release.Namespace }}/vcenter-datacenter-cinder-configmap.yaml.j2" | render | sha256sum =}


### PR DESCRIPTION
This patch updates the deployment for cinder backup and
cinder volume to import the k8s metadata labels, which
include application, component, release_name