### PR TITLE
[common/rabbitmq] update rabbitmq to 3.10.5-management version 

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -1,0 +1,13 @@
+Rabbitmq CHANGELOG
+==============
+
+This file is used to list changes made in each version of the common chart rabbitmq.
+
+0.4.0
+-----
+b.alkhateeb@sap.com
+ - Updating rabbitmq docker image to 3.10.5-management (release note: https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.10.5).
+ - using TCP socket check for the readinessProbe instead of deprecated rabbitmqctl node_health_check (resone: https://github.com/rabbitmq/cluster-operator/blob/43e7c05c4e5cf47322ef11b1b98b2bb70bf32a12/internal/resource/statefulset.go#L586-L604)
+ - adding CHANGELOG
+
+==============

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 0.3.3
+version: 0.4.0
 description: A Helm chart for RabbitMQ
 sources:
 - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/templates/bin/_rabbitmq-start.tpl
+++ b/common/rabbitmq/templates/bin/_rabbitmq-start.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -exuo pipefail
+set -euo pipefail
 
 LOCKFILE=/var/lib/rabbitmq/rabbitmq-server.lock
 echo "Starting RabbitMQ with lock ${LOCKFILE}"

--- a/common/rabbitmq/templates/deployment.yaml
+++ b/common/rabbitmq/templates/deployment.yaml
@@ -71,8 +71,8 @@ spec:
         {{- end }}
         {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
-          exec:
-            command: ["rabbitmqctl", "node_health_check"]
+          tcpSocket:
+            port: public
           failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}

--- a/common/rabbitmq/templates/statefulset.yaml
+++ b/common/rabbitmq/templates/statefulset.yaml
@@ -64,8 +64,8 @@ spec:
         {{- end }}
         {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
-          exec:
-            command: ["rabbitmqctl", "node_health_check"]
+          tcpSocket:
+            port: public 
           failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}

--- a/common/rabbitmq/values.yaml
+++ b/common/rabbitmq/values.yaml
@@ -8,7 +8,7 @@ global:
   master_password: ""
 
 image: library/rabbitmq
-imageTag: 3.6-management
+imageTag: 3.10.5-management
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
 - Updating rabbitmq docker image to 3.10.5-management 
        (release note: https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.10.5).
 - using TCP socket check for the readinessProbe instead of deprecated rabbitmqctl node_health_check 
         (resone: https://github.com/rabbitmq/cluster-operator/blob/43e7c05c4e5cf47322ef11b1b98b2bb70bf32a12/internal/resource/statefulset.go#L586-L604)
 - adding CHANGELOG