### PR TITLE
[Metis] Adds seeds for cloud_inventory_viewer

### DIFF
--- a/system/metis/templates/metis-api-seeds.yaml
+++ b/system/metis/templates/metis-api-seeds.yaml
@@ -4,7 +4,7 @@ kind: "OpenstackSeed"
 metadata:
   name: metis-seed
   labels:
-    app.kubernetes.io/name: {{ tuple .Release .Chart .Values | include "fullname" }}
+    app.kubernetes.io/name: metis
     helm.sh/chart: {{ include "metis.chart" $ }}
     app.kubernetes.io/instance: metis-{{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -34,14 +34,13 @@ spec:
       users:
         - name: metis
           description: Metis Service
-          password: '{{ .Values.metis-api.service_password | required ".Values.metis-api.service_password is missing"}}'
+          password: '{{ .Values.metisAPI.service_password | required ".Values.metisApi.service_password is missing" }}'
           role_assignments:
           - project: service
             role: service # for validating Keystone user tokens
         - name: sism-viewer
           description: Technical User for SISM to retrieve CCLoud Inventory Data
-          password: '{{ .Values.metis-api.sism_viewer_password | required ".Values.metis-api.sism_viewer_password is missing"}}'
-          role
+          password: '{{ .Values.metisAPI.sism_viewer_password | required ".Values.metisApi.sism_viewer_password is missing" }}'
 
     - name: ccadmin
       project:

--- a/system/metis/templates/metis-api-seeds.yaml
+++ b/system/metis/templates/metis-api-seeds.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.metisAPI.enabled }}
+apiVersion: "openstack.stable.sap.cc/v1"
+kind: "OpenstackSeed"
+metadata:
+  name: metis-seed
+  labels:
+    app.kubernetes.io/name: {{ tuple .Release .Chart .Values | include "fullname" }}
+    helm.sh/chart: {{ include "metis.chart" $ }}
+    app.kubernetes.io/instance: metis-{{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    type: seed
+spec:
+  requires:
+  - {{ .Values.global.keystoneNamespace }}/keystone-seed
+  - monsoon3/domain-default-seed
+  - monsoon3/domain-ccadmin-seed
+
+  roles:
+  - name: cloud_metis_inventory_viewer
+
+  services:
+  - name:          metis
+    type:          metis
+    description:   'Data source for inventory data'
+    enabled:       true
+    endpoints:
+      - region:    '{{ $.Values.global.region }}'
+        interface: public
+        enabled:   true
+        url:       'https://metis.{{ $.Values.global.region }}.{{ $.Values.global.tld }}'
+
+  domains:
+    - name: Default
+      users:
+        - name: metis
+          description: Metis Service
+          password: '{{ .Values.metis-api.service_password | required ".Values.metis-api.service_password is missing"}}'
+          role_assignments:
+          - project: service
+            role: service # for validating Keystone user tokens
+        - name: sism-viewer
+          description: Technical User for SISM to retrieve CCLoud Inventory Data
+          password: '{{ .Values.metis-api.sism_viewer_password | required ".Values.metis-api.sism_viewer_password is missing"}}'
+          role
+
+    - name: ccadmin
+      project:
+        - name: cloud_admin
+          role_assignments:
+            - group: CCADMIN_CLOUD_ADMINS
+              role: cloud_inventory_viewer
+            - user: sism-viewer@Default
+              role: cloud_inventory_viewer
+
+{{- end }}

--- a/system/metis/templates/metis-api-seeds.yaml
+++ b/system/metis/templates/metis-api-seeds.yaml
@@ -16,7 +16,7 @@ spec:
   - monsoon3/domain-ccadmin-seed
 
   roles:
-  - name: cloud_metis_inventory_viewer
+  - name: cloud_inventory_viewer
 
   services:
   - name:          metis


### PR DESCRIPTION
Role `cloud_inventory_user` is used to retrieve CCLoud Inventory data from Metis