### PR TITLE
[barbican] Enable proxysql-side-car for the api

### DIFF
--- a/openstack/barbican/templates/api-deployment.yaml
+++ b/openstack/barbican/templates/api-deployment.yaml
@@ -34,8 +34,13 @@ spec:
 {{ tuple . "barbican" "api" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
       annotations:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
+        {{- if .Values.proxysql.mode }}
+        prometheus.io/scrape: "true"
+        prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
+        {{- end }}
     spec:
 {{ tuple . "barbican" "api" | include "kubernetes_pod_anti_affinity" | indent 6 }}
+{{ include "utils.proxysql.pod_settings" . | indent 6 }}
       containers:
         - name: barbican-api
           image: {{required ".Values.global.registry is missing" .Values.global.registry }}/loci-barbican:{{required "Values.imageVersionBarbicanApi is missing" .Values.imageVersionBarbicanApi}}
@@ -130,6 +135,8 @@ spec:
         {{- if .Values.hsm.enabled }}
             - name: luna
               mountPath: /thales/
+            {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+        {{- include "utils.proxysql.container" . | indent 8 }}
         - name: lunaclient
           image: {{required ".Values.global.registry is missing" .Values.global.registry }}/loci-barbican:{{required "Values.hsm.luna.image is missing" .Values.hsm.luna.image }}
           imagePullPolicy: IfNotPresent
@@ -193,3 +200,4 @@ spec:
         - name: luna
           emptyDir: {}
         {{ end }}
+        {{- include "utils.proxysql.volumes" . | indent 8 }}

--- a/openstack/barbican/templates/proxysql-configmap.yaml
+++ b/openstack/barbican/templates/proxysql-configmap.yaml
@@ -1,0 +1,1 @@
+{{ include "proxysql_configmap" . }}

--- a/openstack/barbican/values.yaml
+++ b/openstack/barbican/values.yaml
@@ -47,10 +47,20 @@ db_name: barbican
 postgresql:
   enabled: false
 
+proxysql:
+  mode: "" # Cannot use unix_socket, as migration-job is a helm-hook which runs prior to the configmap creation/update
+
 mariadb:
   enabled: true
   name: barbican
   initdb_configmap: barbican-initdb
+  databases:
+  - barbican
+  users:
+    barbican:
+      name: barbican
+      grants:
+      - "ALL PRIVILEGES on barbican.*"
   persistence_claim:
     name: db-barbican-pvclaim
   backup_v2:


### PR DESCRIPTION
As the upgrade job runs as a helm-chart hook,
it cannot be combined with the unix_socket mode:
The hook runs before the required configuration change
is rolled out

This change requires the credentials for the
database user to be set under ".Values.mariadb.users..."