### PR TITLE
[designate] Add proxysql side-cars

### DIFF
--- a/openstack/designate/Chart.lock
+++ b/openstack/designate/Chart.lock
@@ -19,9 +19,9 @@ dependencies:
   version: 0.1.9
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.0
+  version: 0.11.1
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:e105babda701b2de3de0e03dc244f9ff6da9f3608d15b8f7fa081be21a21d88d
-generated: "2023-07-14T09:28:27.897464+02:00"
+digest: sha256:8a51a195bf115d193ced690dfe3bd8536290783afc84518e8085902f5f3c1c39
+generated: "2023-11-10T12:12:20.156241997+01:00"

--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -29,7 +29,7 @@ dependencies:
     version: 0.1.9
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.7.0
+    version: 0.11.1
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0

--- a/openstack/designate/bin/db-migrate
+++ b/openstack/designate/bin/db-migrate
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-set -ex
-
-# other configs
-cp /designate-etc/* /etc/designate/
-
-designate-manage database sync

--- a/openstack/designate/templates/_helpers.tpl
+++ b/openstack/designate/templates/_helpers.tpl
@@ -37,3 +37,8 @@ qualname={{$item}}
 {{- end}}
 {{end}}
 {{- end -}}
+
+
+{{- define "migration_job_name" -}}
+{{ .Release.Name }}-migration-{{ required ".Values.image_version_designate is missing" .Values.image_version_designate }}{{ if .Values.proxysql.mode }}-proxysql{{ end }}
+{{- end }}

--- a/openstack/designate/templates/api-deployment.yaml
+++ b/openstack/designate/templates/api-deployment.yaml
@@ -28,11 +28,16 @@ spec:
       annotations:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
         configmap-bin-hash: {{ include (print $.Template.BasePath "/bin-configmap.yaml") . | sha256sum }}
+        {{- if .Values.proxysql.mode }}
+        prometheus.io/scrape: "true"
+        prometheus.io/targets: {{ required ".Values.metrics.prometheus missing" .Values.metrics.prometheus | quote }}
+        {{- end }}
     spec:
 {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ .Release.Name }}
 {{- end }}
 {{ tuple . "designate" "api" | include "kubernetes_pod_anti_affinity" | indent 6 }}
+      {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       initContainers:
       - name: kubernetes-entrypoint
         image: {{ required ".Values.global.registry is missing" .Values.global.registry }}/loci-designate:{{ required ".Values.image_version_designate is missing" .Values.image_version_designate }}
@@ -43,7 +48,7 @@ spec:
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
             - name: DEPENDENCY_JOBS
-              value: {{ .Release.Name }}-migration-{{ required ".Values.image_version_designate is missing" .Values.image_version_designate }}
+              value: {{ include "migration_job_name" . }}
             - name: DEPENDENCY_SERVICE
 {{- if .Values.percona_cluster.enabled }}
               value: "{{ .Release.Name }}-percona-pxc,{{ .Release.Name }}-rabbitmq,{{ .Release.Name }}-memcached"
@@ -118,6 +123,8 @@ spec:
             - name: designate-etc-wsgi
               mountPath: /etc/apache2/conf-enabled/wsgi-designate.conf
               subPath: wsgi-designate.conf
+            {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+        {{- include "utils.proxysql.container" . | indent 8 }}
         - name: statsd
           image: {{ required ".Values.global.dockerHubMirror is missing" .Values.global.dockerHubMirror }}/prom/statsd-exporter:v0.8.1
           imagePullPolicy: IfNotPresent
@@ -147,3 +154,4 @@ spec:
           configMap:
             name: designate-bin
             defaultMode: 0755
+{{- include "utils.proxysql.volumes" . | indent 8 }}

--- a/openstack/designate/templates/bin-configmap.yaml
+++ b/openstack/designate/templates/bin-configmap.yaml
@@ -22,7 +22,7 @@ data:
   designate-producer-start: |
 {{ .Files.Get "bin/designate-producer-start" | indent 4 }}
   db-migrate: |
-{{ .Files.Get "bin/db-migrate" | indent 4 }}
+{{ include (print .Template.BasePath "/bin/_db-migrate.sh.tpl") . | indent 4 }}
   manage-pools: |
 {{ .Files.Get "bin/manage-pools" | indent 4 }}
 {{- if .Values.tempest_enabled }}

--- a/openstack/designate/templates/bin/_db-migrate.sh.tpl
+++ b/openstack/designate/templates/bin/_db-migrate.sh.tpl
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -ex
+
+designate-manage database sync
+
+{{ include "utils.proxysql.proxysql_signal_stop_script" . }}

--- a/openstack/designate/templates/central-deployment.yaml
+++ b/openstack/designate/templates/central-deployment.yaml
@@ -28,11 +28,16 @@ spec:
       annotations:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
         configmap-bin-hash: {{ include (print $.Template.BasePath "/bin-configmap.yaml") . | sha256sum }}
+        {{- if .Values.proxysql.mode }}
+        prometheus.io/scrape: "true"
+        prometheus.io/targets: {{ required ".Values.metrics.prometheus missing" .Values.metrics.prometheus | quote }}
+        {{- end }}
     spec:
 {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ .Release.Name }}
 {{- end }}
 {{ tuple . "designate" "central" | include "kubernetes_pod_anti_affinity" | indent 6 }}
+      {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       containers:
         - name: designate-central
           image: {{ required ".Values.global.registry is missing" .Values.global.registry }}/loci-designate:{{ required ".Values.global.image_version_designate is missing" .Values.image_version_designate }}
@@ -47,7 +52,7 @@ spec:
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
             - name: DEPENDENCY_JOBS
-              value: {{ .Release.Name }}-migration-{{ required ".Values.image_version_designate is missing" .Values.image_version_designate }}
+              value: {{ include "migration_job_name" . }}
             - name: DEPENDENCY_SERVICE
 {{- if .Values.percona_cluster.enabled }}
               value: "{{ .Release.Name }}-percona-pxc,{{ .Release.Name }}-rabbitmq"
@@ -75,7 +80,9 @@ spec:
               name: designate-etc
             - mountPath: /container.init
               name: container-init
- {{- include "jaeger_agent_sidecar" . | indent 8 }}
+            {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+        {{- include "utils.proxysql.container" . | indent 8 }}
+        {{- include "jaeger_agent_sidecar" . | indent 8 }}
       volumes:
         - name: designate-etc
           configMap:
@@ -84,3 +91,4 @@ spec:
           configMap:
             name: designate-bin
             defaultMode: 0755
+        {{- include "utils.proxysql.volumes" . | indent 8 }}

--- a/openstack/designate/templates/mdns-deployment.yaml
+++ b/openstack/designate/templates/mdns-deployment.yaml
@@ -28,6 +28,10 @@ spec:
       annotations:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
         configmap-bin-hash: {{ include (print $.Template.BasePath "/bin-configmap.yaml") . | sha256sum }}
+        {{- if .Values.proxysql.mode }}
+        prometheus.io/scrape: "true"
+        prometheus.io/targets: {{ required ".Values.metrics.prometheus missing" .Values.metrics.prometheus | quote }}
+        {{- end }}
     spec:
 {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ .Release.Name }}
@@ -36,6 +40,7 @@ spec:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
 {{- include "kubernetes_maintenance_affinity" . }}
+      {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       containers:
         - name: designate-mdns
           image: {{ required ".Values.global.registry is missing" .Values.global.registry }}/loci-designate:{{ required ".Values.image_version_designate is missing" .Values.image_version_designate }}
@@ -50,7 +55,7 @@ spec:
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
             - name: DEPENDENCY_JOBS
-              value: {{ .Release.Name }}-migration-{{ required ".Values.image_version_designate is missing" .Values.image_version_designate }}
+              value: {{ include "migration_job_name" . }}
             - name: DEPENDENCY_SERVICE
 {{- if .Values.percona_cluster.enabled }}
               value: "{{ .Release.Name }}-percona-pxc,{{ .Release.Name }}-rabbitmq"
@@ -86,6 +91,8 @@ spec:
               name: designate-etc
             - mountPath: /container.init
               name: container-init
+            {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+        {{- include "utils.proxysql.container" . | indent 8 }}
       volumes:
         - name: designate-etc
           configMap:
@@ -94,3 +101,4 @@ spec:
           configMap:
             name: designate-bin
             defaultMode: 0755
+{{- include "utils.proxysql.volumes" . | indent 8 }}

--- a/openstack/designate/templates/migration-job.yaml
+++ b/openstack/designate/templates/migration-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-migration-{{ required ".Values.image_version_designate is missing" .Values.image_version_designate }}
+  name: {{ include "migration_job_name" . }}
   labels:
     system: openstack
     type: configuration
@@ -13,6 +13,7 @@ spec:
       serviceAccountName: {{ .Release.Name }}
 {{- end }}
       restartPolicy: OnFailure
+      {{- include "utils.proxysql.job_pod_settings" . | indent 6 }}
       containers:
         - name: designate-migration
           image: {{ required ".Values.global.registry is missing" .Values.global.registry }}/loci-designate:{{ required ".Values.image_version_designate is missing" .Values.image_version_designate }}
@@ -31,10 +32,12 @@ spec:
               value: {{ .Release.Name }}-mariadb
 {{- end }}
           volumeMounts:
-            - mountPath: /designate-etc
+            - mountPath: /etc/designate
               name: designate-etc
             - mountPath: /container.init
               name: container-init
+            {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+        {{- include "utils.proxysql.container" . | indent 8 }}
       volumes:
         - name: designate-etc
           configMap:
@@ -43,3 +46,4 @@ spec:
           configMap:
             name: designate-bin
             defaultMode: 0755
+{{- include "utils.proxysql.volumes" . | indent 8 }}

--- a/openstack/designate/templates/producer-deployment.yaml
+++ b/openstack/designate/templates/producer-deployment.yaml
@@ -28,10 +28,15 @@ spec:
       annotations:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
         configmap-bin-hash: {{ include (print $.Template.BasePath "/bin-configmap.yaml") . | sha256sum }}
+        {{- if .Values.proxysql.mode }}
+        prometheus.io/scrape: "true"
+        prometheus.io/targets: {{ required ".Values.metrics.prometheus missing" .Values.metrics.prometheus | quote }}
+        {{- end }}
     spec:
 {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ .Release.Name }}
 {{- end }}
+      {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       containers:
         - name: designate-producer
           image: {{ required ".Values.global.registry is missing" .Values.global.registry }}/loci-designate:{{ required ".Values.global.image_version_designate is missing" .Values.image_version_designate }}
@@ -72,6 +77,8 @@ spec:
               name: designate-etc
             - mountPath: /container.init
               name: container-init
+            {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+        {{- include "utils.proxysql.container" . | indent 8 }}
       volumes:
         - name: designate-etc
           configMap:
@@ -80,4 +87,5 @@ spec:
           configMap:
             name: designate-bin
             defaultMode: 0755
+{{- include "utils.proxysql.volumes" . | indent 8 }}
 {{- end }}

--- a/openstack/designate/templates/proxysql-configmap.yaml
+++ b/openstack/designate/templates/proxysql-configmap.yaml
@@ -1,0 +1,1 @@
+{{ include "proxysql_configmap" . }}

--- a/openstack/designate/templates/sink-deployment.yaml
+++ b/openstack/designate/templates/sink-deployment.yaml
@@ -28,6 +28,10 @@ spec:
       annotations:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
         configmap-bin-hash: {{ include (print $.Template.BasePath "/bin-configmap.yaml") . | sha256sum }}
+        {{- if .Values.proxysql.mode }}
+        prometheus.io/scrape: "true"
+        prometheus.io/targets: {{ required ".Values.metrics.prometheus missing" .Values.metrics.prometheus | quote }}
+        {{- end }}
     spec:
 {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ .Release.Name }}
@@ -42,6 +46,7 @@ spec:
                 values:
                 - designate-sink
             topologyKey: "kubernetes.io/hostname"
+      {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       containers:
         - name: designate-sink
           image: {{ required ".Values.global.registry is missing" .Values.global.registry }}/loci-designate:{{ required ".Values.global.image_version_designate is missing" .Values.image_version_designate }}
@@ -67,6 +72,8 @@ spec:
               name: designate-etc
             - mountPath: /container.init
               name: container-init
+            {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+        {{- include "utils.proxysql.container" . | indent 8 }}
       volumes:
         - name: designate-etc
           configMap:
@@ -75,4 +82,5 @@ spec:
           configMap:
             name: designate-bin
             defaultMode: 0755
+        {{- include "utils.proxysql.volumes" . | indent 8 }}
 {{- end }}

--- a/openstack/designate/templates/worker-deployment.yaml
+++ b/openstack/designate/templates/worker-deployment.yaml
@@ -29,11 +29,16 @@ spec:
       annotations:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
         configmap-bin-hash: {{ include (print $.Template.BasePath "/bin-configmap.yaml") . | sha256sum }}
+        {{- if .Values.proxysql.mode }}
+        prometheus.io/scrape: "true"
+        prometheus.io/targets: {{ required ".Values.metrics.prometheus missing" .Values.metrics.prometheus | quote }}
+        {{- end }}
     spec:
 {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ .Release.Name }}
 {{- end }}
 {{ tuple . "designate" "worker" | include "kubernetes_pod_anti_affinity" | indent 6 }}
+      {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       containers:
         - name: designate-worker
           image: {{ required ".Values.global.registry is missing" .Values.global.registry }}/loci-designate:{{ required ".Values.global.image_version_designate is missing" .Values.image_version_designate }}
@@ -72,6 +77,8 @@ spec:
               name: designate-etc
             - mountPath: /container.init
               name: container-init
+            {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+        {{- include "utils.proxysql.container" . | indent 8 }}
       volumes:
         - name: designate-etc
           configMap:
@@ -80,4 +87,5 @@ spec:
           configMap:
             name: designate-bin
             defaultMode: 0755
+        {{- include "utils.proxysql.volumes" . | indent 8 }}
 {{- end }}

--- a/openstack/designate/values.yaml
+++ b/openstack/designate/values.yaml
@@ -106,6 +106,11 @@ percona_cluster:
   alerts:
     support_group: network-api
 
+proxysql:
+  connect_retries_delay: 1000
+  mode: unix_socket
+  max_connections_per_proc: 15
+
 mariadb:
   enabled: true
   name: designate
@@ -116,6 +121,8 @@ mariadb:
     support_group: network-api
   backup:
     enabled: false
+  databases:
+  - designate
   users:
     designate:
       name: designate


### PR DESCRIPTION
This change should route all db queries through a pod-local
side-car to handle the connection resets of a restarting
mariadb

It requires the credentials in .Values.mariadb.users