### PR TITLE
[glance] Add proxysql side-cars

### DIFF
--- a/openstack/glance/templates/deployment.yaml
+++ b/openstack/glance/templates/deployment.yaml
@@ -33,7 +33,12 @@ spec:
       annotations:
         chart-version: {{.Chart.Version}}
         checksum/etc-configmap.conf: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
+        {{- if .Values.proxysql.mode }}
+        prometheus.io/scrape: "true"
+        prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
+        {{- end }}
     spec:
+      {{ include "utils.proxysql.pod_settings" . | indent 6 }}
       {{- if .Values.file.persistence.enabled }}
       initContainers:
       - name: permissions
@@ -84,7 +89,7 @@ spec:
         - name: NAMESPACE
           value: {{ .Release.Namespace }}
         - name: DEPENDENCY_JOBS
-          value: "glance-migration-job-{{ required "Please set glance.imageVersion or similar" .Values.imageVersion }}"
+          value: "glance-migration-job-{{ required "Please set glance.imageVersion or similar" .Values.imageVersion }}{{ if .Values.proxysql.mode }}-proxysql{{ end }}"
         - name: DEPENDENCY_SERVICE
           value: {{ .Release.Name }}-mariadb,{{ .Release.Name }}-memcached
         - name: DEBUG_CONTAINER
@@ -167,7 +172,8 @@ spec:
           subPath: ratelimit.yaml
           readOnly: true
         {{- end }}
-
+        {{- include "utils.proxysql.volume_mount" . | indent 8 }}
+      {{- include "utils.proxysql.container" . | indent 6 }}
       {{- if .Values.imageVersionGlanceRegistry }}
       - name: registry
         image: {{ required ".Values.global.registry is missing" .Values.global.registry }}/ubuntu-source-glance-registry:{{ required "Please set glance.imageVersion or similar" .Values.imageVersion }}
@@ -292,3 +298,4 @@ spec:
       - name: glance-etc
         configMap:
           name: glance-etc
+      {{- include "utils.proxysql.volumes" . | indent 6 }}

--- a/openstack/glance/templates/migration-job.yaml
+++ b/openstack/glance/templates/migration-job.yaml
@@ -4,7 +4,7 @@ metadata:
   # since this name changes with every image change, removal and creation of
   # this Job happens on nearly every deployment. Check the helm-chart changes
   # to see if this needs more review.
-  name: glance-migration-job-{{ required "Please set glance.imageVersion or similar" .Values.imageVersion }}
+  name: glance-migration-job-{{ required "Please set glance.imageVersion or similar" .Values.imageVersion }}{{ if .Values.proxysql.mode }}-proxysql{{ end }}
   labels:
     app: {{ template "name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -23,23 +23,31 @@ spec:
         checksum/etc-configmap.conf: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
     spec:
       restartPolicy: OnFailure
-      containers:
-      - name: glance-migration
+{{ include "utils.proxysql.job_pod_settings" . | indent 6 }}
+      initContainers:
+      - name: glance-init
         image: {{ required ".Values.global.registry is missing" .Values.global.registry }}/loci-glance:{{ required "Please set glance.imageVersion or similar" .Values.imageVersion }}
         imagePullPolicy: IfNotPresent
         command:
         - kubernetes-entrypoint
         env:
         - name: COMMAND
-          value: "dumb-init glance-manage db_sync"
+          value: "true"
         - name: NAMESPACE
           value: {{ .Release.Namespace }}
         - name: DEPENDENCY_SERVICE
           value: {{ .Release.Name }}-mariadb
-        - name: PGAPPNAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
+      containers:
+      - name: glance-migration
+        image: {{ required ".Values.global.registry is missing" .Values.global.registry }}/loci-glance:{{ required "Please set glance.imageVersion or similar" .Values.imageVersion }}
+        imagePullPolicy: IfNotPresent
+        command:
+        - dumb-init
+        - bash
+        - -c
+        - |
+          trap "{{ include "utils.proxysql.proxysql_signal_stop_script" . | trim }}" EXIT
+          glance-manage db_sync
         volumeMounts:
           - mountPath: /etc/glance
             name: etcglance
@@ -57,9 +65,12 @@ spec:
             name: glance-etc
             subPath: logging.ini
             readOnly: true
+          {{- include "utils.proxysql.volume_mount" . | indent 10 }}
+      {{- include "utils.proxysql.container" . | indent 6 }}
       volumes:
       - name: etcglance
         emptyDir: {}
       - name: glance-etc
         configMap:
           name: glance-etc
+      {{- include "utils.proxysql.volumes" . | indent 6 }}

--- a/openstack/glance/templates/proxysql-configmap.yaml
+++ b/openstack/glance/templates/proxysql-configmap.yaml
@@ -1,0 +1,1 @@
+{{ include "proxysql_configmap" . }}

--- a/openstack/glance/values.yaml
+++ b/openstack/glance/values.yaml
@@ -120,12 +120,22 @@ unittest:
 
 db_name: glance
 
+proxysql:
+  mode: unix_socket
+
 mariadb:
   enabled: true
   name: glance
   initdb_configmap: glance-initdb
   persistence_claim:
     name: db-glance-pvclaim
+  databases:
+  - glance
+  users:
+    glance:
+      name: glance
+      grants:
+      - "ALL PRIVILEGES ON glance.*"
   metrics:
     resources:
       enabled: true


### PR DESCRIPTION
This change should route all db queries through a pod-local
side-car to handle the connection resets of a restarting
mariadb

It requires the credentials in .Values.mariadb.users