### PR TITLE
[keystone] Disable internal rabbitmq

### DIFF
--- a/openstack/keystone/requirements.lock
+++ b/openstack/keystone/requirements.lock
@@ -23,5 +23,5 @@ dependencies:
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.4.1
-digest: sha256:6929492058c15ab420a5b6efae13a46e581e129c4c854f7a10b3f3382fd5acdb
-generated: "2022-06-30T12:21:07.060564566+02:00"
+digest: sha256:58b700ac7148d6b11c6f173f9bda97226571b22d4fdb5b6ffbd1258dd1a993dc
+generated: "2022-07-04T08:52:31.293774728+02:00"

--- a/openstack/keystone/requirements.yaml
+++ b/openstack/keystone/requirements.yaml
@@ -17,7 +17,8 @@ dependencies:
     name: percona_cluster
     repository: https://charts.eu-de-2.cloud.sap
     version: 1.0.13
-  - name: rabbitmq
+  - condition: rabbitmq.enabled
+    name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.3.3
   - alias: sapcc_rate_limit

--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -245,6 +245,7 @@ audit:
     port: 5672
 
 rabbitmq:
+  enabled: false
   ## default: {{.Release.Name}}-rabbitmq.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.region}}.{{.Values.global.tld}}
   # host: rabbitmq
   # fetch rabbit keppel images from another region


### PR DESCRIPTION
We switched over to a central one in all regions.
Time to get rid of the now defunct service specific
rabbitmq