### PR TITLE
swift: make res reqs/limits configurable for haproxy, statsd-exporter

### DIFF
--- a/openstack/swift/templates/_utils.tpl
+++ b/openstack/swift/templates/_utils.tpl
@@ -201,14 +201,15 @@ checksum/object.ring: {{ include "swift/templates/object-ring.yaml" . | sha256su
 - name: statsd
   image: {{ $context.Values.global.dockerHubMirrorAlternateRegion }}/prom/statsd-exporter:{{ $context.Values.image_version_auxiliary_statsd_exporter }}
   args: [ --statsd.mapping-config=/swift-etc/statsd-exporter.yaml ]
+  {{- $resources_cpu := index $context.Values "proxy_statsd_exporter_resources_cpu" }}
+  {{- $resources_memory := index $context.Values "proxy_statsd_exporter_resources_memory" }}
   resources:
-    # observed usage: CPU = 10m-100m, RAM = 550-950 MiB
     requests:
-      cpu: "200m"
-      memory: "1024Mi"
+      cpu: {{ required "proxy_statsd_exporter_resources_cpu is required" $resources_cpu | quote }}
+      memory: {{ required "proxy_statsd_exporter_resources_memory is required" $resources_memory | quote }}
     limits:
-      cpu: "200m"
-      memory: "1024Mi"
+      cpu: {{ required "proxy_statsd_exporter_resources_cpu is required" $resources_cpu | quote }}
+      memory: {{ required "proxy_statsd_exporter_resources_memory is required" $resources_memory | quote }}
   ports:
     - name: statsd
       containerPort: 9125

--- a/openstack/swift/templates/haproxy-deployment.yaml
+++ b/openstack/swift/templates/haproxy-deployment.yaml
@@ -161,11 +161,11 @@ spec:
                   fieldPath: spec.nodeName
           resources:
             requests:
-              cpu: "1500m"
-              memory: "600Mi"
+              cpu: {{ $.Values.haproxy_deployment_resources_cpu | required "haproxy_deployment_resources_cpu is required" | quote }}
+              memory: {{ $.Values.haproxy_deployment_resources_memory | required "haproxy_deployment_resources_memory is required" | quote }}
             limits:
-              cpu: "1500m"
-              memory: "600Mi"
+              cpu: {{ $.Values.haproxy_deployment_resources_cpu | required "haproxy_deployment_resources_cpu is required" | quote }}
+              memory: {{ $.Values.haproxy_deployment_resources_memory | required "haproxy_deployment_resources_memory is required" | quote }}
           volumeMounts:
             - mountPath: /tls-secret
               name: tls-secret

--- a/openstack/swift/values.yaml
+++ b/openstack/swift/values.yaml
@@ -133,6 +133,10 @@ alerts:
 #   -target: xxx.xxx.xxx.xxx
 #    name: node1
 
+# haproxy nodes act as LBs in front of the Swift proxies
+haproxy_deployment_resources_cpu: "1500m"
+haproxy_deployment_resources_memory: "600Mi"
+
 # # Swift proxies can be deployed as Deployment, Daemonset or both
 # proxy_deployment_enabled: true
 # proxy_deployment_replicas_az-b: 2           # replicas in availability zone, default 0
@@ -142,6 +146,10 @@ alerts:
 # proxy_daemonset_enabled: true
 # proxy_daemonset_resources_cpu: "2500m"
 # proxy_daemonset_resources_memory: "1500Mi"
+
+# resource limits for the statsd-exporter container in each swift-proxy pod
+proxy_statsd_exporter_resources_cpu: "200m"      # observed: 10m-100m
+proxy_statsd_exporter_resources_memory: "1024Mi" # observed: 550-950 MiB
 
 # # The default is using the cache.swift for token caching
 # # Specifing a memcached server name here will overrule that, see .Values.memcached_servers


### PR DESCRIPTION
To enable downscaling in the lab regions.

I checked in qa-de-1 that the `helm diff` is empty (except for whitespace).