### PR TITLE
[keystone] Update rabbitmq to 3.10

### DIFF
--- a/openstack/keystone/requirements.lock
+++ b/openstack/keystone/requirements.lock
@@ -16,12 +16,12 @@ dependencies:
   version: 1.0.13
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.3
+  version: 0.4.0
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.2.0
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.4.1
-digest: sha256:58b700ac7148d6b11c6f173f9bda97226571b22d4fdb5b6ffbd1258dd1a993dc
-generated: "2022-07-04T08:52:31.293774728+02:00"
+digest: sha256:f5b7fd27ace978cfd01a8f5d3b17f039304b8c29f5366f12e23d0449d8a8839b
+generated: "2022-07-05T14:43:57.106854095+02:00"

--- a/openstack/keystone/requirements.yaml
+++ b/openstack/keystone/requirements.yaml
@@ -20,7 +20,7 @@ dependencies:
   - condition: rabbitmq.enabled
     name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.3
+    version: 0.4.0
   - alias: sapcc_rate_limit
     condition: sapcc_rate_limit.enabled
     name: redis


### PR DESCRIPTION
For compliance. Includes all security updates