### PR TITLE
[rabbitmq] Make volumeClaimTemplate labels fix

### DIFF
--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 0.4.0
+version: 0.4.1
 description: A Helm chart for RabbitMQ
 sources:
 - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/templates/statefulset.yaml
+++ b/common/rabbitmq/templates/statefulset.yaml
@@ -118,7 +118,9 @@ spec:
       name: rabbitmq-persistent-storage
       labels:
         app: {{ template "fullname" . }}
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        {{- if .Values.volumeClaimTemplatesChartVersion }}
+        chart: "{{ .Chart.Name }}-{{ .Values.volumeClaimTemplatesChartVersion }}"
+        {{- end }}
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
         component: rabbitmq


### PR DESCRIPTION
The statefulset only allows the template to be changed,
but not the volumeClaimTemplate. So we hard-code it to the
old value in order to avoid having to recreate everything