### PR TITLE
[cinder] Added proxysql side-cars

### DIFF
--- a/openstack/cinder/templates/api-deployment.yaml
+++ b/openstack/cinder/templates/api-deployment.yaml
@@ -27,8 +27,13 @@ spec:
 {{ tuple . "cinder" "api" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
       annotations:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
+        {{- if .Values.proxysql.mode }}
+        prometheus.io/scrape: "true"
+        prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
+        {{- end }}
     spec:
 {{ tuple . "cinder" "api" | include "kubernetes_pod_anti_affinity" | indent 6 }}
+{{ include "utils.proxysql.pod_settings" . | indent 6 }}
       containers:
         - name: cinder-api
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{.Values.imageVersionCinderApi | default .Values.imageVersion | required "Please set cinder.imageVersion or similar" }}
@@ -41,7 +46,7 @@ spec:
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
             - name: DEPENDENCY_JOBS
-              value: cinder-migration-{{.Values.imageVersion | required "Please set cinder.imageVersion or similar"}}
+              value: cinder-migration-{{.Values.imageVersion | required "Please set cinder.imageVersion or similar"}}{{- if .Values.proxysql.mode}}-{{ .Values.proxysql.mode | replace "_" "-" }}{{ end }}
             - name: DEPENDENCY_SERVICE
 {{- if eq .Values.mariadb.enabled true }}
               value: "{{ .Release.Name }}-mariadb,{{ .Release.Name }}-rabbitmq"
@@ -130,6 +135,8 @@ spec:
               subPath: watcher.yaml
               readOnly: true
             {{- end }}
+            {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+        {{- include "utils.proxysql.container" . | indent 8 }}
         - name: statsd
           image: {{ required ".Values.global.dockerHubMirror is missing" .Values.global.dockerHubMirror}}/prom/statsd-exporter:v0.8.1
           imagePullPolicy: IfNotPresent
@@ -152,3 +159,4 @@ spec:
         - name: cinder-etc
           configMap:
             name: cinder-etc
+        {{- include "utils.proxysql.volumes" . | indent 8 }}

--- a/openstack/cinder/templates/backup_deployment.yaml
+++ b/openstack/cinder/templates/backup_deployment.yaml
@@ -33,8 +33,14 @@ template: |
         labels:
           name: cinder-volume-backup-vmware-{= name =}
 {{ tuple . "cinder" "volume-backup-vmware" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 10 }}
+        annotations:
+          {{- if .Values.proxysql.mode }}
+          prometheus.io/scrape: "true"
+          prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
+          {{- end }}
       spec:
         hostname: cinder-volume-backup-vmware-{= name =}
+{{ include "utils.proxysql.pod_settings" . | indent 8 }}
         containers:
         - name: cinder-volume-backup-vmware-{= name =}
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{.Values.imageVersionCinderVolumeBackup | default .Values.imageVersion | required "Please set cinder.imageVersion or similar" }}
@@ -93,6 +99,8 @@ template: |
             mountPath: /etc/cinder/cinder-backup.conf
             subPath: cinder-backup.conf
             readOnly: true
+            {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+        {{- include "utils.proxysql.container" . | indent 8 }}
         volumes:
         - name: etccinder
           emptyDir: {}
@@ -102,4 +110,5 @@ template: |
         - name: backup-config
           configMap:
             name:  backup-vmware-{= name =}
+        {{- include "utils.proxysql.volumes" . | indent 8 }}
 {{- end }}

--- a/openstack/cinder/templates/migration-job.yaml
+++ b/openstack/cinder/templates/migration-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: cinder-migration-{{.Values.imageVersion | required "Please set cinder.imageVersion or similar"}}
+  name: cinder-migration-{{.Values.imageVersion | required "Please set cinder.imageVersion or similar"}}{{- if .Values.proxysql.mode}}-{{ .Values.proxysql.mode | replace "_" "-" }}{{ end }}
   labels:
     system: openstack
     type: configuration
@@ -10,15 +10,16 @@ spec:
   template:
     spec:
       restartPolicy: OnFailure
-      containers:
-        - name: cinder-migration
+{{ include "utils.proxysql.job_pod_settings" . | indent 6 }}
+      initContainers:
+        - name: dependencies
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{.Values.imageVersionCinderApi | default .Values.imageVersion | required "Please set cinder.imageVersion or similar" }}
           imagePullPolicy: IfNotPresent
           command:
             - kubernetes-entrypoint
           env:
             - name: COMMAND
-              value: "cinder-manage db sync"
+              value: "true"
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
             - name: DEPENDENCY_SERVICE
@@ -27,10 +28,16 @@ spec:
 {{- else }}
               value: "{{ .Release.Name }}-postgresql"
 {{- end }}
-            - name: PGAPPNAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
+      containers:
+        - name: cinder-migration
+          image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{.Values.imageVersionCinderApi | default .Values.imageVersion | required "Please set cinder.imageVersion or similar" }}
+          imagePullPolicy: IfNotPresent
+          command:
+            - bash
+            - -c
+            - |
+              trap "{{ include "utils.proxysql.proxysql_signal_stop_script" . | trim }}" EXIT
+              cinder-manage db sync
           volumeMounts:
             - name: etccinder
               mountPath: /etc/cinder
@@ -50,9 +57,12 @@ spec:
               mountPath: /etc/cinder/logging.ini
               subPath: logging.ini
               readOnly: true
+            {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+        {{- include "utils.proxysql.container" . | indent 8 }}
       volumes:
         - name: etccinder
           emptyDir: {}
         - name: cinder-etc
           configMap:
             name: cinder-etc
+      {{- include "utils.proxysql.volumes" . | indent 8 }}

--- a/openstack/cinder/templates/proxysql-configmap.yaml
+++ b/openstack/cinder/templates/proxysql-configmap.yaml
@@ -1,0 +1,1 @@
+{{ include "proxysql_configmap" . }}

--- a/openstack/cinder/templates/scheduler-deployment.yaml
+++ b/openstack/cinder/templates/scheduler-deployment.yaml
@@ -27,8 +27,13 @@ spec:
 {{ tuple . "cinder" "scheduler" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
       annotations:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
+        {{- if .Values.proxysql.mode }}
+        prometheus.io/scrape: "true"
+        prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
+        {{- end }}
     spec:
 {{ tuple . "cinder" "scheduler" | include "kubernetes_pod_anti_affinity" | indent 6 }}
+{{ include "utils.proxysql.pod_settings" . | indent 6 }}
       hostname: cinder-scheduler
       containers:
         - name: cinder-scheduler
@@ -83,10 +88,13 @@ spec:
               mountPath: /etc/cinder/logging.ini
               subPath: logging.ini
               readOnly: true
- {{- include "jaeger_agent_sidecar" . | indent 8 }}
+            {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+        {{- include "utils.proxysql.container" . | indent 8 }}
+        {{- include "jaeger_agent_sidecar" . | indent 8 }}
       volumes:
         - name: etccinder
           emptyDir: {}
         - name: cinder-etc
           configMap:
             name: cinder-etc
+        {{- include "utils.proxysql.volumes" . | indent 8 }}

--- a/openstack/cinder/templates/vcenter_datacenter_cinder_deployment.yaml
+++ b/openstack/cinder/templates/vcenter_datacenter_cinder_deployment.yaml
@@ -36,9 +36,14 @@ template: |
         annotations:
           configmap-etc-hash: {{ include (print .Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
           configmap-cinder-volume-hash: {= "vcenter_datacenter/{{ .Release.Namespace }}/vcenter-datacenter-cinder-configmap.yaml.j2" | render | sha256sum =}
+          {{- if .Values.proxysql.mode }}
+          prometheus.io/scrape: "true"
+          prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
+          {{- end }}
       spec:
         hostname: cinder-volume-vmware-{= name =}
 {{ tuple "{= availability_zone =}" | include "kubernetes_pod_az_affinity" | indent 8 }}
+{{ include "utils.proxysql.pod_settings" . | indent 8 }}
         containers:
         - name: cinder-volume-vmware-{= name =}
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{.Values.imageVersionCinderScheduler | default .Values.imageVersion | required "Please set cinder.imageVersion or similar" }}
@@ -106,6 +111,8 @@ template: |
             mountPath: /etc/sudoers
             subPath: sudoers
             readOnly: true
+          {{- include "utils.proxysql.volume_mount" . | indent 10 }}
+        {{- include "utils.proxysql.container" . | indent 8 }}
         volumes:
         - name: etccinder
           emptyDir: {}
@@ -115,4 +122,5 @@ template: |
         - name: volume-config
           configMap:
             name:  volume-vmware-{= name =}
+        {{- include "utils.proxysql.volumes" . | indent 8 }}
 {{- end }}

--- a/openstack/cinder/templates/volumes/_volume-deployment.yaml.tpl
+++ b/openstack/cinder/templates/volumes/_volume-deployment.yaml.tpl
@@ -30,8 +30,13 @@ spec:
       annotations:
         configmap-etc-hash: {{ include (print .Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
         configmap-volume-hash: {{ tuple . $volume | include "volume_configmap" | sha256sum }}
+        {{- if .Values.proxysql.mode }}
+        prometheus.io/scrape: "true"
+        prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
+        {{- end }}
     spec:
       hostname: cinder-volume-{{$volume.name}}
+{{ include "utils.proxysql.pod_settings" . | indent 6 }}
       containers:
       - name: cinder-volume-{{$volume.name}}
         image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{.Values.imageVersionCinderVolume | default .Values.imageVersion | required "Please set cinder.imageVersion or similar" }}
@@ -77,6 +82,8 @@ spec:
           mountPath: /etc/sudoers
           subPath: sudoers
           readOnly: true
+        {{- include "utils.proxysql.volume_mount" . | indent 10 }}
+      {{- include "utils.proxysql.container" . | indent 8 }}
       volumes:
       - name: etccinder
         emptyDir: {}
@@ -86,5 +93,6 @@ spec:
       - name: volume-config
         configMap:
           name:  volume-{{$volume.name}}
+      {{- include "utils.proxysql.volumes" . | indent 8 }}
 {{- end -}}
 {{- end -}}

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -90,12 +90,23 @@ allocated_capacity_weight_multiplier: -1.0
 
 cinder_api_allow_migration_on_attach: True
 
+proxysql:
+  mode: null # Disabled by default
+
 mariadb:
   enabled: true
   max_connections: 2048
   buffer_pool_size: "2048M"
   log_file_size: "512M"
   name: cinder
+  databases:
+  - cinder
+  users:
+    cinder:
+      name: cinder
+      password: null
+      grants:
+      - "ALL PRIVILEGES on cinder.*"
   initdb_configmap: cinder-initdb
   persistence_claim:
     name: db-cinder-pvclaim


### PR DESCRIPTION
This PR adds the necessary snippets to enable proxysql side-car pods, without enabling them by default.
Functionally, it should behave the same after the change has been merged, until the mode is activated by setting `proxysql.mode=unix_socket`