### PR TITLE
[openstack/utils] Add snippet for CORS annotations

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.4.1
+version: 0.4.2

--- a/openstack/utils/templates/snippets/_set_ingress_cors_annotations.tpl
+++ b/openstack/utils/templates/snippets/_set_ingress_cors_annotations.tpl
@@ -1,0 +1,10 @@
+{{ define "utils.snippets.set_ingress_cors_annotations" }}
+{{- if .Values.cors.enabled }}
+ingress.kubernetes.io/enable-cors: "true"
+ingress.kubernetes.io/cors-allow-headers: "{{ .Values.utils.cors.allow_headers }}{{ if .Values.cors.additional_allow_headers }},{{ .Values.cors.additional_allow_headers }}{{ end }}"
+ingress.kubernetes.io/cors-expose-headers: "{{ .Values.cors.expose_headers | default "*" }}"
+ingress.kubernetes.io/cors-allow-origin: "{{ required ".Values.utils.cors.allow_origin is missing" .Values.utils.cors.allow_origin }}{{if .Values.cors.additional_allow_origin }},{{ .Values.cors.additional_allow_origin }}{{ end }}"
+ingress.kubernetes.io/cors-allow-credentials: "{{ .Values.cors.allow_credentials | default "false" }}"
+ingress.kubernetes.io/cors-max-age: "{{ .Values.cors.max_age | default "1728000" }}"
+{{- end }}
+{{- end }}

--- a/openstack/utils/values.yaml
+++ b/openstack/utils/values.yaml
@@ -6,3 +6,8 @@
 global:
   user_suffix: ""
   master_password: ""
+
+cors:
+  # default headers. additional headers can be specified via {cors:
+  # {additional_allow_headers: "comma,separated,values"}} in the parent chart
+  allow_headers: 'Accept,Content-Type,OpenStack-API-Version,User-Agent,X-Auth-Token,X-Openstack-Request-Id'


### PR DESCRIPTION
Our dashboard wants to start talking to OpenStack services' APIs
directly from the user's browser. Since browsers don't allow
cross-origin requests without the server explicitly setting certain
headers, we configure our Nginx ingress to enable CORS headers and
configure them.

We use k8s annotations [0] and Nginx ingress instead of the
cors-middleware from oslo.middleware, because not having to call the
backend seems much more efficient.

[0] https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#enable-cors