### PR TITLE
[nova] Enable CORS headers for nova-api

### DIFF
--- a/openstack/nova/ci/test-values.yaml
+++ b/openstack/nova/ci/test-values.yaml
@@ -38,3 +38,11 @@ rabbitmq:
       password: defaultdefault
   metrics:
     password: metricsmetrics
+
+cors:
+  enabled: true
+  additional_allow_headers: 'X-No-Real-Header'
+
+utils:
+  cors:
+    allowed_origin: 'https://test.domain'

--- a/openstack/nova/requirements.lock
+++ b/openstack/nova/requirements.lock
@@ -19,7 +19,7 @@ dependencies:
   version: 0.4.0
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.4.1
+  version: 0.4.2
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.3.53
@@ -29,5 +29,5 @@ dependencies:
 - name: region_check
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.2
-digest: sha256:c9a79c682fe1fc555970daa2e7c324ec9c6ad0df4e8c0cdb6729c82807cae1a1
-generated: "2022-07-05T14:44:17.286018729+02:00"
+digest: sha256:a1b2317c7f0d385e8cd361a6b2bd96b2bf273183419723e8a421b1508cbecf2f
+generated: "2022-07-12T12:11:48.511230569+02:00"

--- a/openstack/nova/requirements.yaml
+++ b/openstack/nova/requirements.yaml
@@ -25,7 +25,7 @@ dependencies:
     version: 0.4.0
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.4.1
+    version: 0.4.2
   - name: mariadb
     alias: mariadb_cell2
     condition: mariadb_cell2.enabled

--- a/openstack/nova/templates/api-ingress.yaml
+++ b/openstack/nova/templates/api-ingress.yaml
@@ -10,6 +10,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/configuration-snippet: |
       {{- include "utils.snippets.set_openstack_request_id" . | indent 6 }}
+    {{- include "utils.snippets.set_ingress_cors_annotations" . | indent 4 }}
   {{- if .Values.use_tls_acme }}
     kubernetes.io/tls-acme: "true"
   {{- end }}

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -883,3 +883,7 @@ pre_change_hook:
   image: "sapcc/unified-kubernetes-toolbox"
   image_version: "20220525082919"
   kubectl_version: 1.21.8
+
+cors:
+  enabled: true
+  additional_allow_headers: 'X-OpenStack-Nova-API-Version'


### PR DESCRIPTION
The dashboard will start consuming Nova's API directly from the user's
browser and needs cross-origin requests to be allowed for that.