### PR TITLE
[cinder] Enable CORS headers for cinder-api

### DIFF
--- a/openstack/cinder/requirements.lock
+++ b/openstack/cinder/requirements.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.4.1
+  version: 0.4.2
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.3.55
@@ -23,5 +23,5 @@ dependencies:
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.2.1
-digest: sha256:33da26bac9ba0a923b8d0b2e6a76940cad062f64c4b0a702ef8c6be257b8a964
-generated: "2022-06-30T12:20:43.134661846+02:00"
+digest: sha256:4bb6dcc7f2a335799f310b38b52217b6c8adab1ef5df24982e25a242375517a0
+generated: "2022-07-12T12:16:53.170002934+02:00"

--- a/openstack/cinder/requirements.yaml
+++ b/openstack/cinder/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.4.1
+    version: 0.4.2
   - name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.3.55

--- a/openstack/cinder/templates/api-ingress.yaml
+++ b/openstack/cinder/templates/api-ingress.yaml
@@ -10,6 +10,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/configuration-snippet: |
       {{- include "utils.snippets.set_openstack_request_id" . | indent 6 }}
+    {{- include "utils.snippets.set_ingress_cors_annotations" . | indent 4 }}
   {{- if .Values.use_tls_acme }}
     kubernetes.io/tls-acme: "true"
   {{- end }}

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -358,3 +358,6 @@ alerts:
   enabled: true
   # Name of the Prometheus to which the alerts should be assigned to.
   prometheus: openstack
+
+cors:
+  enabled: true


### PR DESCRIPTION
The dashboard will start consuming Cinder's API directly from the user's
browser and needs cross-origin requests to be allowed for that.