### PR TITLE
owner-info: add "support-group" and "service" fields

### DIFF
--- a/common/owner-info/Chart.yaml
+++ b/common/owner-info/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: owner-info
 description: owner-info deploys a ConfigMap that contains info about chart's owner. It is meant to be used as a dependency by other charts.
-version: 0.1.2
+version: 0.2.0

--- a/common/owner-info/ci/test-values.yaml
+++ b/common/owner-info/ci/test-values.yaml
@@ -1,0 +1,2 @@
+helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/common/owner-info
+support-group: test

--- a/common/owner-info/templates/configmap.yaml
+++ b/common/owner-info/templates/configmap.yaml
@@ -1,18 +1,52 @@
+{{- if (index .Values "helm-chart-url" | regexMatch "^https?://" | not) -}}
+  {{- fail ".Values.owner-info.helm-chart-url is missing or not a HTTP(S) URL" -}}
+{{- end -}}
+{{- if (index .Values "support-group" | regexMatch "^[a-z0-9-]+$" | not) -}}
+  {{- fail ".Values.owner-info.support-group is missing or contains invalid characters" -}}
+{{- end -}}
+{{- if (.Values.service | regexMatch "^[a-z0-9-]*$" | not) -}}
+  {{- fail ".Values.owner-info.service contains invalid characters" -}}
+{{- end -}}
+
 kind: ConfigMap
 apiVersion: v1
 
 metadata:
   name: owner-of-{{ .Release.Name }}
   labels:
-    {{- if not (eq 0 (len .Values.maintainers)) }}
-    primary-maintainer: {{ index .Values.maintainers 0 | lower | replace " " "-" }}
-    {{- end }}
-
     # This can be used to validate via policy that everyone uses a reasonably up-to-date version of this chart.
     owner-info-version: {{ quote .Chart.Version }}
 
 data:
-  helm-chart-url: {{ if (index .Values "helm-chart-url" | hasPrefix "http") }}{{ quote (index .Values "helm-chart-url") }}{{ else }}{{ required "Please enter the GitHub URL for your chart into .Values.owner-info.helm-chart-url!" "" }}{{ end }}
+  helm-chart-url: {{ index .Values "helm-chart-url" | quote }}
   {{- if not (eq 0 (len .Values.maintainers)) }}
   maintainers: {{ join ", " .Values.maintainers | title | quote }}
+  {{- end }}
+
+  support-group: {{ index .Values "support-group" | quote }}
+  {{- if .Values.service }}
+  service: {{ .Values.service | quote }}
+  {{- end }}
+
+---
+
+kind: ConfigMap
+apiVersion: v1
+
+metadata:
+  # We need this configmap to be present early because it is used by a mutating webhook when the
+  # other objects in this Helm release are written into the Kubernetes DB.
+  name: early-owner-of-{{ .Release.Name }}
+  labels:
+    # This can be used to validate via policy that everyone uses a reasonably up-to-date version of this chart.
+    owner-info-version: {{ quote .Chart.Version }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-100"
+    "helm.sh/hook-delete-policy": before-hook-creation
+
+data:
+  support-group: {{ index .Values "support-group" | quote }}
+  {{- if .Values.service }}
+  service: {{ .Values.service | quote }}
   {{- end }}

--- a/common/owner-info/values.yaml
+++ b/common/owner-info/values.yaml
@@ -1,2 +1,13 @@
+# "helm-chart-url" must be a HTTP(S) URL describing where to find the Helm chart in GitHub etc.
+helm-chart-url: ''
+# "maintainers" is an optional list of names of all people who maintain the Helm chart. If
+# multiple people can help with issues regarding the chart, feel free to include as many names
+# as you like.
 maintainers: []
-helm-chart-url: WHERE-TO-FIND-THE-CHART-IN-GITHUB
+
+# "support-group" is required for routing alerts/tickets regarding this
+# deployment to the right support group
+support-group: ''
+# "service" is optional and allows sorting of alerts/tickets within the realm
+# of a single support group
+service: ''


### PR DESCRIPTION
To support the introduction of our new support structure.

@onuryilmaz I'm including you as reviewer since you will likely be the one consuming these fields. @BugRoger can tell you more when you talk next time.