### PR TITLE
Consult cc/support-group and cc/service pods labels for pod alerts

### DIFF
--- a/common/prometheus-server/CHANGELOG.md
+++ b/common/prometheus-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.0.2
+
+* Move PrometheusMultiplePodScrapes to prometheus-kubernetes-rules chart
+
 ## 7.0.1
 
 * Fix selector in service

--- a/common/prometheus-server/Chart.yaml
+++ b/common/prometheus-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus via operator.
 name: prometheus-server
-version: 7.0.1
+version: 7.0.2
 appVersion: v2.36.1
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
 maintainers:

--- a/prometheus-rules/prometheus-kubernetes-rules/Chart.yaml
+++ b/prometheus-rules/prometheus-kubernetes-rules/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A collection of Prometheus alerting and aggregation rules for Kubernetes.
 name: prometheus-kubernetes-rules
-version: 1.3.0
+version: 1.3.1

--- a/prometheus-rules/prometheus-kubernetes-rules/alerts/health.alerts.tpl
+++ b/prometheus-rules/prometheus-kubernetes-rules/alerts/health.alerts.tpl
@@ -142,12 +142,12 @@ groups:
     expr: sum by(pod, namespace, label_alert_service, label_alert_tier, label_cc_service, label_cc_support_group) (label_replace((up * on(instance) group_left() (sum by(instance) (up{job=~".*pod-sd"}) > 1)* on(pod) group_left(label_alert_tier, label_alert_service) (max without(uid) (kube_pod_labels))) , "pod", "$1", "kubernetes_pod_name", "(.*)-[0-9a-f]{8,10}-[a-z0-9]{5}"))
     for: 30m
     labels:
-      tier: {{ include "alertTierLabelOrDefault" (include "alerts.tier" .) }}
+      tier: {{ include "alertTierLabelOrDefault" .Values.tier }}
       service: {{ include "serviceLabelOrDefault" "prometheus" }}
-      support_group: {{ include "supportGroupOrDefault" "containers" }}
+      support_group: {{ include "supportGroupLabelOrDefault" "containers" }}
       severity: warning
       playbook: docs/support/playbook/kubernetes/target_scraped_multiple_times.html
       meta: 'Prometheus is scraping {{`{{ $labels.pod }}`}} pods more than once.'
     annotations:
-      description: Prometheus is scraping `{{`{{ $labels.pod }}`}}` pods in namespace `{{`{{ $labels.namespace }}`}}` multiple times. This is likely caused due to incorrectly placed scrape annotations.  <https://{{ include "prometheus.externalURL" . }}/graph?g0.expr={{ urlquery `up * on(instance) group_left() (sum by(instance) (up{kubernetes_pod_name=~"PLACEHOLDER.*"}) > 1)` | replace "PLACEHOLDER" "{{ $labels.pod }}"}}|Affected targets>
+      description: Prometheus is scraping `{{`{{ $labels.pod }}`}}` pods in namespace `{{`{{ $labels.namespace }}`}}` multiple times. This is likely caused due to incorrectly placed scrape annotations.
       summary: Prometheus scrapes pods multiple times

--- a/prometheus-rules/prometheus-kubernetes-rules/templates/_helpers.tpl
+++ b/prometheus-rules/prometheus-kubernetes-rules/templates/_helpers.tpl
@@ -15,6 +15,10 @@ Note: The pods define the 'alert-tier' label but Prometheus replaces the hyphen 
 Use the 'label_alert_service', if it exists on the time series, otherwise use the given default.
 Note: The pods define the 'alert-service' label but Prometheus replaces the hyphen with an underscore.
 */}}
-{{- define "alertServiceLabelOrDefault" -}}
-"{{`{{ if $labels.label_alert_service }}`}}{{`{{ $labels.label_alert_service}}`}}{{`{{ else }}`}}{{ required "default value is missing" . }}{{`{{ end }}`}}"
+{{- define "serviceLabelOrDefault" -}}
+"{{`{{ if $labels.label_cc_service }}`}}{{`{{ $labels.label_cc_service }}`}}{{ else if $labels.label_alert_service }}`}}{{`{{ $labels.label_alert_service }}`}}{{`{{ else }}`}}{{ required "default value is missing" . }}{{`{{ end }}`}}"
+{{- end -}}
+
+{{- define "supportGroupLabelOrDefault" -}}
+"{{`{{ if $labels.label_cc_support_group }}`}}{{`{{ $labels.label_cc_support_group }}`}}{{`{{ else }}`}}{{ required "default value is missing" . }}{{`{{ end }}`}}"
 {{- end -}}

--- a/prometheus-rules/prometheus-kubernetes-rules/templates/_helpers.tpl
+++ b/prometheus-rules/prometheus-kubernetes-rules/templates/_helpers.tpl
@@ -8,7 +8,7 @@ Use the 'label_alert_tier', if it exists on the time series, otherwise use the g
 Note: The pods define the 'alert-tier' label but Prometheus replaces the hyphen with an underscore.
 */}}
 {{- define "alertTierLabelOrDefault" -}}
-"{{`{{ if $labels.label_alert_tier }}`}}{{`{{ $labels.label_alert_tier}}`}}{{`{{ else }}`}}{{ required "default value is missing" . }}{{`{{ end }}`}}"
+"{{`{{ if $labels.label_alert_tier }}{{ $labels.label_alert_tier}}{{ else }}`}}{{ required "default value is missing" . }}{{`{{ end }}`}}"
 {{- end -}}
 
 {{- /*
@@ -16,9 +16,9 @@ Use the 'label_alert_service', if it exists on the time series, otherwise use th
 Note: The pods define the 'alert-service' label but Prometheus replaces the hyphen with an underscore.
 */}}
 {{- define "serviceLabelOrDefault" -}}
-"{{`{{ if $labels.label_cc_service }}`}}{{`{{ $labels.label_cc_service }}`}}{{ else if $labels.label_alert_service }}`}}{{`{{ $labels.label_alert_service }}`}}{{`{{ else }}`}}{{ required "default value is missing" . }}{{`{{ end }}`}}"
+"{{`{{ if $labels.label_cc_service }}{{ $labels.label_cc_service }}{{ else }}{{ if $labels.label_alert_service }}{{ $labels.label_alert_service }}{{ else }}`}}{{ required "default value is missing" . }}{{`{{ end }}`}}"
 {{- end -}}
 
 {{- define "supportGroupLabelOrDefault" -}}
-"{{`{{ if $labels.label_cc_support_group }}`}}{{`{{ $labels.label_cc_support_group }}`}}{{`{{ else }}`}}{{ required "default value is missing" . }}{{`{{ end }}`}}"
+"{{`{{ if $labels.label_cc_support_group }}{{ $labels.label_cc_support_group }}{{ else }}`}}{{ required "default value is missing" . }}{{`{{ end }}`}}"
 {{- end -}}


### PR DESCRIPTION
I propose that we use `cc/support-group` and `cc/service` label keys when annotating kubernetes resources to avoid any clashes with existing (pod) labels.
Those labels can then be used in alert definitions to populate `support_group` and `service` labels in alerts that can be used for alert routingin alertmanager

I adapted the generic alerts to support old `alert-service` and `alert-tier` labels as well with preference for the newer label keys.

Wdyt?