### PR TITLE
[common/rabbitmq] Validate input for users and escape "\"

### DIFF
--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 0.4.1
+version: 0.4.2
 description: A Helm chart for RabbitMQ
 sources:
 - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/templates/_helpers.tpl
+++ b/common/rabbitmq/templates/_helpers.tpl
@@ -26,7 +26,25 @@ rabbit://{{ default "" $envAll.Values.global.user_suffix | print $rabbitmq.users
 {{- end}}
 
 {{- define "rabbitmq.shell_quote" -}}
-"{{- replace `"` `\"`  . | replace `$` `\$` | replace "`" (print `\` "`") -}}"
+"{{ replace `\` `\\` . | replace `"` `\"` | replace `$` `\$` | replace "`" "\\`" }}"
+{{- end }}
+
+{{- define "rabbitmq.upsert_user" -}}
+    {{- $path := index . 0 -}}
+    {{- $v := index . 1 -}}
+    {{- if not $v.user }}
+        {{- fail (printf "%v.user missing" $path) }}
+    {{- else if hasPrefix "-" $v.user }}
+        {{- fail (printf "%v.user starts with hypen" $path) }}
+    {{- else if not $v.password }}
+        {{- fail (printf "%v.password missing" $path) }}
+    {{- else if hasPrefix "-" $v.password }}
+        {{- fail (printf "%v.password starts with hypen" $path) }}
+    {{- else -}}
+        upsert_user {{ $v.user | include "rabbitmq.shell_quote" }} {{ $v.password | include "rabbitmq.shell_quote" }}
+        {{- if $v.tag }} {{ $v.tag | include "rabbitmq.shell_quote" }}
+        {{- end }}
+    {{- end }}
 {{- end }}
 
 {{/* Generate the service label for the templated Prometheus alerts. */}}


### PR DESCRIPTION
In order to fails more cleanly, an invalid password (starting with '"')
will now fail to render.
The shell escape function was not escaping the backslash.