### PR TITLE
Octavia yoga config

### DIFF
--- a/openstack/octavia/Chart.yaml
+++ b/openstack/octavia/Chart.yaml
@@ -1,10 +1,8 @@
 apiVersion: v2
-appVersion: "1.0"
+appVersion: "yoga"
 description: A Helm chart for OpenStack Octavia
 home: https://docs.openstack.org/octavia/latest/
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Octavia/OpenStack_Project_Octavia_vertical.png
-maintainers:
-  - name: OpenStack-Helm Authors
 name: octavia
 sources:
   - https://git.openstack.org/cgit/openstack/octavia

--- a/openstack/octavia/templates/etc/_octavia.conf.tpl
+++ b/openstack/octavia/templates/etc/_octavia.conf.tpl
@@ -31,6 +31,9 @@ enabled_provider_drivers = {{ .Values.providers }}
 # Default provider driver
 default_provider_driver = {{ .Values.default_provider | default "noop_driver" }}
 
+# Enable/disable specific features
+allow_prometheus_listeners = False
+
 [healthcheck]
 backends = octavia_db_check
 


### PR DESCRIPTION
- Disable new Prometheus listener protocol (for now)
  The deactivation config option is defined [here](https://github.com/sapcc/octavia/blob/stable/yoga-m3/octavia/common/config.py#L87).
- Set appVersion to "yoga" so that helm releases with different Openstack releases can be distinguished