### PR TITLE
remove up metric federation

### DIFF
--- a/system/prometheus-infra/templates/_prometheus-infra.yaml.tpl
+++ b/system/prometheus-infra/templates/_prometheus-infra.yaml.tpl
@@ -126,7 +126,6 @@
       - '{__name__=~"^pxcloudprober_.+"}'
       - '{__name__=~"^vasa_.+"}'
       - '{__name__=~"^ssh_.+"}'
-      - '{__name__=~"^up"}'
       - '{__name__=~"^redfish_.+"}'
       - '{__name__=~"^nsxt_trim_exception"}'
       - '{__name__=~"^filebeat_.+"}'


### PR DESCRIPTION
federating up metrics into scaleout produces false-positive PrometheusMultipleTargetsScrapes alerts