### PR TITLE
[px/bird] Restricting maxUnavailable to 0

### DIFF
--- a/px/bird/templates/_deployment_header.tpl
+++ b/px/bird/templates/_deployment_header.tpl
@@ -34,7 +34,7 @@ spec:
     type: RollingUpdate
     rollingUpdate:
       maxSurge: 1
-      maxUnavailable: 1
+      maxUnavailable: 0
   template:
     metadata:
       labels:


### PR DESCRIPTION
Before we call a deployment successful we need to wait until 1/1 pod is running.