### PR TITLE
[placement] Stamp initial db version if not stamped

### DIFF
--- a/openstack/placement/ci/test-values.yaml
+++ b/openstack/placement/ci/test-values.yaml
@@ -2,7 +2,8 @@ global:
   region: regionOne
   domain: evil.corp
   registry: keppel.regionOne.cloud
-  dockerHubMirrorAlternateRegion: dockerhubmirror.example.com
+  dockerHubMirror: dockerhubmirror.example.com
+  dockerHubMirrorAlternateRegion: alternatedockerhubmirror.example.com
   tld: regionOne.cloud
 
   placement_service_password: verySecret

--- a/openstack/placement/templates/stamp-alembic-job.yaml
+++ b/openstack/placement/templates/stamp-alembic-job.yaml
@@ -1,0 +1,33 @@
+{{- if and (not .Values.mariadb.enabled) .Values.api_db.initial_stamp -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "placement-stamp-alembic"
+  labels:
+{{ tuple . "placement" "stamp-alembic" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  template:
+    metadata:
+      name: "placement-stamp-alembic"
+      labels:
+{{ tuple . "placement" "stamp-alembic" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: stamp
+        image: {{ required ".Values.global.dockerHubMirror is missing" .Values.global.dockerHubMirror }}/{{ .Values.mariadb.image | default "library/mariadb:10.5.12" }}
+        command:
+        - /usr/bin/env
+        - bash
+        - -c
+        - |
+          mariadb -v -hnova-api-mariadb -u{{ .Values.api_db.user }} --password='{{ .Values.api_db.password }}' '{{ .Values.api_db.name }}' -e '
+          CREATE TABLE IF NOT EXISTS alembic_version (version_num varchar(32) NOT NULL, PRIMARY KEY (version_num));
+          INSERT INTO alembic_version (version_num)
+              SELECT "b4ed3a175331" AS version_num
+              WHERE NOT EXISTS (SELECT * FROM alembic_version);
+          '
+{{- end }}

--- a/openstack/placement/values.yaml
+++ b/openstack/placement/values.yaml
@@ -50,6 +50,7 @@ api_db: # Only used when mariadb.enabled=False to connect to the nova-api-mariad
   name: placement
   user: placement
   password: null
+  initial_stamp: true
 
 mariadb:
   enabled: true


### PR DESCRIPTION
This corresponds to the placement db stamp step
in the migration step: https://github.com/openstack/placement/blob/master/placement_db_tools/mysql-migrate-db.sh#L302

The stamp job won't overwrite existing stamps,
so it can be removed after the first 'proper' deployment

It won't do that automatically by looking at the version
in order to allow to combine this change with an upgrade
in a later change