### PR TITLE
fix false-positive multiple scrape alerts

### DIFF
--- a/common/prometheus-server/templates/alerts/_prometheus.alerts.tpl
+++ b/common/prometheus-server/templates/alerts/_prometheus.alerts.tpl
@@ -128,7 +128,7 @@ groups:
     # we exclude cadvisor metrics because it has the same instance as the kubelet but a different path
     # e.g. 10.246.204.80:10250/metrics vs. 10.246.204.80:10250/metrics/cadvisor
     # We also exclude the pod service discovery job, we have a dedicated alert for that
-    expr: sum by (job) (up * on(instance) group_left() (sum by(instance) (up{job !~ "kubernetes-cadvisors|kubernetes-kubelet|.*-pod-sd"}) > 1))
+    expr: sum by (job) (up * on(instance) group_left() (sum by(instance, job) (up{job !~ "kubernetes-cadvisors|kubernetes-kubelet|.*-pod-sd"}) > 1))
     for: 30m
     labels:
       tier: {{ include "alerts.tier" . }}


### PR DESCRIPTION
Fixing false-positive alert for scrapes using prom service discovery. 

For example: 2 different jobs with same instance
https://prometheus-infra-collector.qa-de-1.cloud.sap/graph?g0.expr=sum%20by%20(job)%20(up%20*%20on(instance)%20group_left()%20(sum%20by(instance)%20(up%7Bjob%20!~%20%22kubernetes-cadvisors%7Ckubernetes-kubelet%7C.*-pod-sd%22%7D)%20%3E%201))&g0.tab=1&g0.stacked=0&g0.show_exemplars=0&g0.range_input=1h&g1.expr=up%7Bjob%20!~%20%22kubernetes-cadvisors%7Ckubernetes-kubelet%7C.*-pod-sd%22%2C%20instance%3D%2210.17.125.126%22%7D&g1.tab=1&g1.stacked=0&g1.show_exemplars=0&g1.range_input=1h

The proposed change for the alert expression does not break positive-positive alerts, e.g. same job, same instance

https://prometheus-openstack.qa-de-1.cloud.sap/graph?g0.expr=up%20*%20on(instance)%20group_left()%20(sum%20by(instance)%20(up%7Bjob%3D%22netbox-webhook-dist-client%22%7D)%20%3E%201)&g0.tab=1&g0.stacked=0&g0.show_exemplars=0&g0.range_input=1h&g1.expr=sum%20by%20(job)%20(up%20*%20on(instance)%20group_left()%20(sum%20by(job%2C%20instance)%20(up%7Bjob%3D%22netbox-webhook-dist-client%22%7D)%20%3E%201))&g1.tab=1&g1.stacked=0&g1.show_exemplars=0&g1.range_input=1h