### PR TITLE
[region_check] Delete before creation too

### DIFF
--- a/common/region_check/Chart.yaml
+++ b/common/region_check/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: region_check
-version: 0.1.2
+version: 0.1.3

--- a/common/region_check/templates/region-check-job.yaml
+++ b/common/region_check/templates/region-check-job.yaml
@@ -13,7 +13,7 @@ metadata:
   annotations:
     "helm.sh/hook": "pre-upgrade"
     "helm.sh/hook-weight": "-42"
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
 spec:
   backoffLimit: 2
   template:


### PR DESCRIPTION
If another hook fails, the region check won't get deleted
despite having succeeded, despite the hook-succeeded annotation.
A subsequent deployment will then fail due to the existing
region check job. Adding 'before-hook-creation' takes care of that.