### PR TITLE
[mariadb] Avoid old logic for new users

### DIFF
--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.5.1
+version: 0.5.2

--- a/common/mariadb/templates/initdb/_init.sql.tpl
+++ b/common/mariadb/templates/initdb/_init.sql.tpl
@@ -9,7 +9,7 @@ CREATE DATABASE IF NOT EXISTS {{ . }};
     {{- end }}
 {{- end }}
 
-{{- if and .Values.global.dbUser .Values.global.dbPassword }}
+{{- if and .Values.global.dbUser .Values.global.dbPassword (not (hasKey .Values.users .Values.global.dbUser)) }}
 CREATE USER IF NOT EXISTS {{ .Values.global.dbUser }};
 GRANT ALL PRIVILEGES ON {{ .Values.name }}.* TO {{ .Values.global.dbUser }} IDENTIFIED BY '{{ include "db_password" . }}';
 {{- end }}


### PR DESCRIPTION
The old code may be redundant if the user is already under
.Values.users.

This fixes a problem when he mariadb instance contains a hypen
(i.e. nova-api), which is not a valid database name.
It was previously not triggered as the init-code was replaced
by a custom-initmap.
