### PR TITLE
[mariadb] Avoid name=user=db convention with custom-initmap

### DIFF
--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.5.2
+version: 0.5.3

--- a/common/mariadb/templates/initdb/_init.sql.tpl
+++ b/common/mariadb/templates/initdb/_init.sql.tpl
@@ -9,7 +9,7 @@ CREATE DATABASE IF NOT EXISTS {{ . }};
     {{- end }}
 {{- end }}
 
-{{- if and .Values.global.dbUser .Values.global.dbPassword (not (hasKey .Values.users .Values.global.dbUser)) }}
+{{- if and .Values.global.dbUser .Values.global.dbPassword (not (hasKey .Values.users .Values.global.dbUser)) (not .Values.custom_initdb_configmap) }}
 CREATE USER IF NOT EXISTS {{ .Values.global.dbUser }};
 GRANT ALL PRIVILEGES ON {{ .Values.name }}.* TO {{ .Values.global.dbUser }} IDENTIFIED BY '{{ include "db_password" . }}';
 {{- end }}


### PR DESCRIPTION
If a custom-initmap has been provided,
then chances are the convention won't apply