### PR TITLE
[openstack/utils] Use first dbname & user as default

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.4.4
+version: 0.5.0


### PR DESCRIPTION
All services where setting a dbUser and dbName in the current
chart. That works for a single instance, but not in general.
Instead use the logic that the first database listed
under mariadb.databases is the default database,
and that there is user with the same key (but not necessarily
the same name) as the database.