### PR TITLE
[openstack/utils] Add coordination section and pvc

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.6.2
+version: 0.7.0

--- a/openstack/utils/templates/_coordination.tpl
+++ b/openstack/utils/templates/_coordination.tpl
@@ -1,0 +1,39 @@
+{{- define "utils.coordination.volume_name" -}}
+"{{ .Chart.Name }}-coordination"
+{{- end }}
+
+{{- define "utils.coordination.volume_mount" }}
+{{- if eq .Values.coordinationBackend "file" }}
+- name: coordination
+  # The parent dir of mountPath only matches by convention to $state_path in config and Dockerfile
+  mountPath: /var/lib/{{ .Chart.Name }}/coordination
+{{- end }}
+{{- end }}
+
+{{- define "utils.coordination.volumes" }}
+{{- if eq .Values.coordinationBackend "file" }}
+- name: coordination
+  persistentVolumeClaim:
+    claimName: {{ include "utils.coordination.volume_name" . }}
+{{- end }}
+{{- end }}
+
+
+{{- define "utils.coordination.persistent_volume_claim" }}
+{{- if eq .Values.coordinationBackend "file" }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ include "utils.coordination.volume_name" . }}
+  annotations:
+  {{- if .Values.coordinationBackendStorageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.coordinationBackendStorageClass | quote }}
+  {{- end }}
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.coordinationBackendStorageSize | default "1G" | quote }}
+{{- end }}
+{{- end }}

--- a/openstack/utils/templates/_ini_sections.tpl
+++ b/openstack/utils/templates/_ini_sections.tpl
@@ -66,3 +66,14 @@ logging_default_format_string = %(asctime)s %(process)d %(levelname)s %(name)s [
 logging_user_identity_format = %(user)s %(tenant)s %(domain)s %(user_domain)s %(project_domain)s
 logging_exception_prefix = %(asctime)s %(process)d ERROR %(name)s %(resource)s%(instance)s
 {{- end }}
+
+{{- define "ini_sections.coordination" -}}
+[coordination]
+backend_url = {{ if eq .Values.coordinationBackend "memcached" -}}
+    memcached://{{ .Chart.Name }}-memcached.{{ include "svc_fqdn" . }}:{{ .Values.memcached.memcached.port | default 11211 }}
+{{- else if eq .Values.coordinationBackend "file" -}}
+    file://$state_path/coordination
+{{- else }}
+    {{ fail ".Values.coordinationBackend needs to be either \"memcached\" or \"file\"" }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
Add a shared ini-section snippet and related snippets for volume
mounts, pvc, and volumes which may be activated
by setting coordinationBackend=file