### PR TITLE
[cinder] Integrate locking via pvc

### DIFF
--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.4.2
+  version: 0.7.0
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.7.1
@@ -20,5 +20,5 @@ dependencies:
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:66c372bd10d2f6ab12af71e1d67c3a88798d70b5f735c3701f5efed54fc855a7
-generated: "2022-10-24T10:04:41.776463357+02:00"
+digest: sha256:e802d6820a75192d90a85fa75e4b3ef71b0a70cba6222342abd44cd54b366072
+generated: "2022-12-15T14:51:10.762113752+01:00"

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.1.1
 dependencies:
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.4.2
+    version: 0.7.0
   - name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.7.1

--- a/openstack/cinder/templates/api-deployment.yaml
+++ b/openstack/cinder/templates/api-deployment.yaml
@@ -136,6 +136,7 @@ spec:
               readOnly: true
             {{- end }}
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+            {{- include "utils.coordination.volume_mount" . | indent 12 }}
         {{- include "utils.proxysql.container" . | indent 8 }}
         - name: statsd
           image: {{ required ".Values.global.dockerHubMirror is missing" .Values.global.dockerHubMirror}}/prom/statsd-exporter:v0.8.1
@@ -160,3 +161,4 @@ spec:
           configMap:
             name: cinder-etc
         {{- include "utils.proxysql.volumes" . | indent 8 }}
+        {{- include "utils.coordination.volumes" . | indent 8 }}

--- a/openstack/cinder/templates/backup_deployment.yaml
+++ b/openstack/cinder/templates/backup_deployment.yaml
@@ -100,6 +100,7 @@ template: |
             subPath: cinder-backup.conf
             readOnly: true
             {{- include "utils.proxysql.volume_mount" . | indent 10 }}
+            {{- include "utils.coordination.volume_mount" . | indent 10 }}
         {{- include "utils.proxysql.container" . | indent 8 }}
         {{- include "jaeger_agent_sidecar" . | indent 8 }}
         volumes:
@@ -112,4 +113,5 @@ template: |
           configMap:
             name:  backup-vmware-{= name =}
         {{- include "utils.proxysql.volumes" . | indent 8 }}
+        {{- include "utils.coordination.volumes" . | indent 8 }}
 {{- end }}

--- a/openstack/cinder/templates/coordination-pvc.yaml
+++ b/openstack/cinder/templates/coordination-pvc.yaml
@@ -1,0 +1,1 @@
+{{ include "utils.coordination.persistent_volume_claim" . }}

--- a/openstack/cinder/templates/etc/_cinder.conf.tpl
+++ b/openstack/cinder/templates/etc/_cinder.conf.tpl
@@ -112,8 +112,7 @@ project_name = "{{.Values.global.keystone_service_project | default "service" }}
 project_domain_name = "{{.Values.global.keystone_service_domain | default "Default" }}"
 region_name = {{.Values.global.region}}
 
-[coordination]
-backend_url = memcached://{{ .Chart.Name }}-memcached.{{ include "svc_fqdn" . }}:{{ .Values.memcached.memcached.port | default 11211 }}
+{{ include "ini_sections.coordination" . }}
 
 [nova]
 auth_type = v3password

--- a/openstack/cinder/templates/scheduler-deployment.yaml
+++ b/openstack/cinder/templates/scheduler-deployment.yaml
@@ -89,6 +89,7 @@ spec:
               subPath: logging.ini
               readOnly: true
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+            {{- include "utils.coordination.volume_mount" . | indent 12 }}
         {{- include "utils.proxysql.container" . | indent 8 }}
         {{- include "jaeger_agent_sidecar" . | indent 8 }}
       volumes:
@@ -98,3 +99,4 @@ spec:
           configMap:
             name: cinder-etc
         {{- include "utils.proxysql.volumes" . | indent 8 }}
+        {{- include "utils.coordination.volumes" . | indent 8 }}

--- a/openstack/cinder/templates/vcenter_datacenter_cinder_deployment.yaml
+++ b/openstack/cinder/templates/vcenter_datacenter_cinder_deployment.yaml
@@ -112,7 +112,8 @@ template: |
             subPath: sudoers
             readOnly: true
           {{- include "utils.proxysql.volume_mount" . | indent 10 }}
-        {{- include "utils.proxysql.container" . | indent 8 }}
+          {{- include "utils.coordination.volume_mount" . | indent 10 }}
+         {{- include "utils.proxysql.container" . | indent 8 }}
         {{- include "jaeger_agent_sidecar" . | indent 8 }}
         volumes:
         - name: etccinder
@@ -124,4 +125,5 @@ template: |
           configMap:
             name:  volume-vmware-{= name =}
         {{- include "utils.proxysql.volumes" . | indent 8 }}
+        {{- include "utils.coordination.volumes" . | indent 8 }}
 {{- end }}

--- a/openstack/cinder/templates/volumes/_netapp-deployment.yaml.tpl
+++ b/openstack/cinder/templates/volumes/_netapp-deployment.yaml.tpl
@@ -80,6 +80,7 @@ spec:
           subPath: cinder-volume.conf
           readOnly: true
         {{- include "utils.proxysql.volume_mount" . | indent 10 }}
+        {{- include "utils.coordination.volume_mount" . | indent 10 }}
       {{- include "utils.proxysql.container" . | indent 8 }}
       {{- include "jaeger_agent_sidecar" . | indent 8 }}
       volumes:
@@ -92,5 +93,6 @@ spec:
         configMap:
           name:  volume-netapp-{{$volume.name}}
       {{- include "utils.proxysql.volumes" . | indent 8 }}
+      {{- include "utils.coordination.volumes" . | indent 8 }}
 {{- end -}}
 {{- end -}}

--- a/openstack/cinder/templates/volumes/_volume-deployment.yaml.tpl
+++ b/openstack/cinder/templates/volumes/_volume-deployment.yaml.tpl
@@ -83,6 +83,7 @@ spec:
           subPath: sudoers
           readOnly: true
         {{- include "utils.proxysql.volume_mount" . | indent 10 }}
+        {{- include "utils.coordination.volume_mount" . | indent 10 }}
       {{- include "utils.proxysql.container" . | indent 8 }}
       {{- include "jaeger_agent_sidecar" . | indent 8 }}
       volumes:
@@ -95,5 +96,6 @@ spec:
         configMap:
           name:  volume-{{$volume.name}}
       {{- include "utils.proxysql.volumes" . | indent 8 }}
+      {{- include "utils.coordination.volumes" . | indent 8 }}
 {{- end -}}
 {{- end -}}

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -61,6 +61,8 @@ backend_defaults:
   vmware_select_random_best_datastore: True
   vmware_datastores_as_pools: True
 
+coordinationBackend: 'memcached'
+
 backends:
   enabled: vmware,standard_hdd
   vmware:


### PR DESCRIPTION
Instead of using the memcached driver, we can use
the PVC which should be more robust with respect
to restarts of the nodes
