### PR TITLE
[glance] Remove notification rabbitmq

### DIFF
--- a/openstack/glance/Chart.lock
+++ b/openstack/glance/Chart.lock
@@ -8,9 +8,6 @@ dependencies:
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.7
-- name: rabbitmq
-  repository: https://charts.eu-de-2.cloud.sap
-  version: 0.4.2
 - name: region_check
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.3
@@ -23,5 +20,5 @@ dependencies:
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.2
-digest: sha256:fdfd9df82e020c8cfb2de9e4e022d71b797f12ac418d46ad1d5ba5a4793eda0e
-generated: "2022-07-27T09:03:16.148982+05:30"
+digest: sha256:b45da5c10467fd3ed785c69653fdd0853283b1c3bf2fd4500318c3c1cdb413fc
+generated: "2022-07-27T10:19:50.00438538+02:00"

--- a/openstack/glance/Chart.yaml
+++ b/openstack/glance/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: yoga
-description: A Helm chart Opensatck Glance
+description: A Helm chart Openstack Glance
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Glance/OpenStack_Project_Glance_vertical.png
 name: glance
 version: 0.3.1
@@ -16,11 +16,6 @@ dependencies:
     name: mysql_metrics
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.7
-  - alias: rabbitmq_notifications
-    condition: audit.enabled
-    name: rabbitmq
-    repository: https://charts.eu-de-2.cloud.sap
-    version: 0.4.2
   - name: region_check
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.1.3

--- a/openstack/glance/values.yaml
+++ b/openstack/glance/values.yaml
@@ -299,6 +299,9 @@ watcher:
 audit:
   enabled: true
   mem_queue_size: 1000
+  central_service:
+    user: rabbitmq
+    password: null
 
 # Deploy Glance Prometheus alerts.
 alerts:


### PR DESCRIPTION
We migrated to a central one for notifications,
so we might as well remove the integrated one