### PR TITLE
[cinder] Remove notification rabbitmq

### DIFF
--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -14,14 +14,11 @@ dependencies:
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.4.2
-- name: rabbitmq
-  repository: https://charts.eu-de-2.cloud.sap
-  version: 0.4.2
 - name: region_check
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.2
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.2.1
-digest: sha256:24bb3505ba6a17fd6e1793e687c87059b7bde210bfc46a91210a59baaccd179c
-generated: "2022-07-19T10:40:14.873721959+02:00"
+digest: sha256:f778ea8ffe7f4beb8ffebecabcda6ee4bc01034b98b85e769b7281afad75a751
+generated: "2022-07-27T10:31:07.968744273+02:00"

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -21,10 +21,6 @@ dependencies:
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.4.2
-  - name: rabbitmq
-    alias: rabbitmq_notifications
-    repository: https://charts.eu-de-2.cloud.sap
-    version: 0.4.2
   - name: region_check
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.1.2

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -289,6 +289,9 @@ audit:
   mem_queue_size: 1000
   record_payloads: false
   metrics_enabled: true
+  central_service:
+    user: rabbitmq
+    password: null
 
 rabbitmq:
   name: cinder


### PR DESCRIPTION
We migrated to a central one for notifications,
so we might as well remove the integrated one