### PR TITLE
[designate] Remove notification rabbitmq

### DIFF
--- a/openstack/designate/Chart.lock
+++ b/openstack/designate/Chart.lock
@@ -17,14 +17,11 @@ dependencies:
 - name: rabbitmq_cluster
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.5
-- name: rabbitmq
-  repository: https://charts.eu-de-2.cloud.sap
-  version: 0.4.2
 - name: region_check
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.2
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.4.3
-digest: sha256:bd6068efd55f95cd5291d304786e715a45eea4aed13751468a4cb8b88d46101a
-generated: "2022-07-21T15:32:29.196794+02:00"
+digest: sha256:f3a13acbd501da3e031eb4b18e601154d2ad56314ebe6084516c0f650f5d335c
+generated: "2022-07-27T10:32:36.024743778+02:00"

--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -26,10 +26,6 @@ dependencies:
     condition: rabbitmq_cluster.enabled
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.1.5
-  - alias: rabbitmq_notifications
-    name: rabbitmq
-    repository: https://charts.eu-de-2.cloud.sap
-    version: 0.4.2
   - condition: mariadb.enabled
     name: region_check
     repository: https://charts.eu-de-2.cloud.sap

--- a/openstack/designate/values.yaml
+++ b/openstack/designate/values.yaml
@@ -263,6 +263,9 @@ audit:
   metrics_enabled: true
   # how many messages to buffer before dumping to log (when rabbit is down or too slow)
   mem_queue_size: 1000
+  central_service:
+    user: rabbitmq
+    password: null
 
 rabbitmq:
   enabled: true


### PR DESCRIPTION
We migrated to a central one for notifications,
so we might as well remove the integrated one