### PR TITLE
[barbican] Remove notification rabbitmq

### DIFF
--- a/openstack/barbican/Chart.lock
+++ b/openstack/barbican/Chart.lock
@@ -11,9 +11,6 @@ dependencies:
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.4.2
-- name: rabbitmq
-  repository: https://charts.eu-de-2.cloud.sap
-  version: 0.4.2
 - name: region_check
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.3
@@ -26,5 +23,5 @@ dependencies:
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.2
-digest: sha256:d41eab3392fe786698434915a5e1b6477e8807c30cc302d4d5167d16d4f54876
-generated: "2022-07-27T08:59:34.018125+05:30"
+digest: sha256:dc2ffabdb796261678042af0dcdc884fa9fede884011069d5fd56ef02b990dca
+generated: "2022-07-27T10:29:29.685401901+02:00"

--- a/openstack/barbican/Chart.yaml
+++ b/openstack/barbican/Chart.yaml
@@ -19,10 +19,6 @@ dependencies:
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.4.2
-  - alias: rabbitmq_notifications
-    name: rabbitmq
-    repository: https://charts.eu-de-2.cloud.sap
-    version: 0.4.2
   - name: region_check
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.1.3

--- a/openstack/barbican/values.yaml
+++ b/openstack/barbican/values.yaml
@@ -206,6 +206,9 @@ watcher:
 audit:
   enabled: true
   mem_queue_size: 1000
+  central_service:
+    user: rabbitmq
+    password: null
 
 # Deploy Barbican Prometheus alerts.
 alerts:


### PR DESCRIPTION
We migrated to a central one for notifications,
so we might as well remove the integrated one