### PR TITLE
[keystone] Remove notification rabbitmq

### DIFF
--- a/openstack/keystone/Chart.lock
+++ b/openstack/keystone/Chart.lock
@@ -14,14 +14,11 @@ dependencies:
 - name: percona_cluster
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.0.13
-- name: rabbitmq
-  repository: https://charts.eu-de-2.cloud.sap
-  version: 0.4.2
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.2.0
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.4.1
-digest: sha256:d91e6b246159439d93b8b64c0d7d6c2f19842478de49ce8df255cff5f2e766ad
-generated: "2022-07-19T10:41:58.432295815+02:00"
+digest: sha256:af8cb6ad6df0beb20b9b7327ff902330f70e14b838d33f32606869dadda0e46b
+generated: "2022-07-27T10:54:38.923536642+02:00"

--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -30,10 +30,6 @@ dependencies:
     name: percona_cluster
     repository: https://charts.eu-de-2.cloud.sap
     version: 1.0.13
-  - condition: rabbitmq.enabled
-    name: rabbitmq
-    repository: https://charts.eu-de-2.cloud.sap
-    version: 0.4.2
   - alias: sapcc_rate_limit
     condition: sapcc_rate_limit.enabled
     name: redis

--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -244,30 +244,6 @@ audit:
     host: hermes-rabbitmq-notifications.hermes
     port: 5672
 
-rabbitmq:
-  enabled: false
-  ## default: {{.Release.Name}}-rabbitmq.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.region}}.{{.Values.global.tld}}
-  # host: rabbitmq
-  # fetch rabbit keppel images from another region
-  name: keystone
-  use_alternate_registry: true
-  users:
-    default:
-      password: ""
-    admin:
-      password: ""
-
-  resources:
-    requests:
-      memory: 512Mi
-      cpu: 1000m
-
-  nodeAffinity: {}
-
-  metrics:
-    enabled: true
-    password: ""
-
 memcached:
   use_alternate_registry: true
   memcached:


### PR DESCRIPTION
We migrated to a central one for notifications,
so we might as well remove the integrated one