### PR TITLE
[Octavia] Add default HTTP2 profile

### DIFF
--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -242,6 +242,7 @@ default_tls_1_1: "false"
 default_tls_1_3: "true"
 default_profiles:
   profile_http: cc_http_profile
+  profile_http2: cc_http2_profile
   profile_http_compression: cc_httpcompression_profile
   profile_l4: cc_fastL4_profile
   profile_tcp: cc_tcp_profile


### PR DESCRIPTION
- [ ] Create HTTP2 profile on F5s with name given in this PR

This PR is a dependency for https://github.com/sapcc/octavia-f5-provider-driver/pull/170