### PR TITLE
[manila] Integrate locking via pvc

### DIFF
--- a/openstack/manila/Chart.lock
+++ b/openstack/manila/Chart.lock
@@ -16,6 +16,6 @@ dependencies:
   version: 0.4.2
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.4.1
-digest: sha256:0ff368efd5114e0ac4b1dd9f932dea2d607c1a43000b6b1d992a6daf2374a965
-generated: "2022-09-12T09:56:24.267291245+02:00"
+  version: 0.7.0
+digest: sha256:215a592df5fff7efd511d72392472a302a54740578f54a2cbba9a8a01f5341ec
+generated: "2022-10-13T11:43:51.987815136+02:00"

--- a/openstack/manila/Chart.yaml
+++ b/openstack/manila/Chart.yaml
@@ -31,4 +31,4 @@ dependencies:
     version: 0.4.2
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.4.1
+    version: 0.7.0

--- a/openstack/manila/templates/api-deployment.yaml
+++ b/openstack/manila/templates/api-deployment.yaml
@@ -167,6 +167,7 @@ spec:
             - name: manila-bin
               mountPath: /scripts
               readOnly: true
+            {{- include "utils.coordination.volume_mount" . | indent 12 }}
           {{- if .Values.pod.resources.api }}
           resources:
             {{ toYaml .Values.pod.resources.api | nindent 13 }}
@@ -207,3 +208,4 @@ spec:
           configMap:
             name: manila-bin
             defaultMode: 0555
+        {{- include "utils.coordination.volumes" . | indent 8 }}

--- a/openstack/manila/templates/coordination-pvc.yaml
+++ b/openstack/manila/templates/coordination-pvc.yaml
@@ -1,0 +1,1 @@
+{{ include "utils.coordination.persistent_volume_claim" . }}

--- a/openstack/manila/templates/etc/_manila.conf.tpl
+++ b/openstack/manila/templates/etc/_manila.conf.tpl
@@ -89,8 +89,7 @@ rabbit_interval_max = {{ .Values.rabbitmq.max_reconnect_interval | default 3 }}
 [oslo_concurrency]
 lock_path = /var/lib/manila/tmp
 
-[coordination]
-backend_url = memcached://{{ .Chart.Name }}-memcached.{{ include "svc_fqdn" . }}:{{ .Values.memcached.memcached.port | default 11211 }}
+{{ include "ini_sections.coordination" . }}
 
 {{- include "ini_sections.database" . }}
 

--- a/openstack/manila/templates/scheduler-deployment.yaml
+++ b/openstack/manila/templates/scheduler-deployment.yaml
@@ -113,6 +113,7 @@ spec:
               mountPath: /etc/manila/healthz
               subPath: healthz
               readOnly: true
+            {{- include "utils.coordination.volume_mount" . | indent 12 }}
           {{- if .Values.pod.resources.scheduler }}
           resources:
 {{ toYaml .Values.pod.resources.scheduler | indent 13 }}
@@ -146,3 +147,4 @@ spec:
         - name: manila-etc
           configMap:
             name: manila-etc
+        {{- include "utils.coordination.volumes" . | indent 8 }}

--- a/openstack/manila/values.yaml
+++ b/openstack/manila/values.yaml
@@ -20,6 +20,8 @@ api_port_internal: '8786'
 api_backdoor: false
 debug: "True"
 
+coordinationBackend: 'memcached'
+
 logging:
   formatters:
     context:


### PR DESCRIPTION
Instead of using the memcached driver, we can use
the PVC which should be more robust with respect
to restarts of the nodes