### PR TITLE
[manila] Add ProxySQL side-cars

### DIFF
--- a/openstack/manila/Chart.lock
+++ b/openstack/manila/Chart.lock
@@ -16,6 +16,6 @@ dependencies:
   version: 0.4.4
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.0
-digest: sha256:04895d46d5fdb804134e28d0f265a88a659e1f87eda4659a58e96a8e193abe35
-generated: "2022-12-12T15:25:33.340512+01:00"
+  version: 0.7.2
+digest: sha256:5b849e4326f0001af27dc9ec9845ab53deb8256beaec896bb29c07f7d83ed077
+generated: "2023-02-08T09:54:58.589640378+01:00"

--- a/openstack/manila/Chart.yaml
+++ b/openstack/manila/Chart.yaml
@@ -31,4 +31,4 @@ dependencies:
     version: 0.4.4
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.7.0
+    version: ~0.7.2

--- a/openstack/manila/ci/test-values.yaml
+++ b/openstack/manila/ci/test-values.yaml
@@ -1,5 +1,6 @@
 global:
   default_availability_zone: co-lu-1a
+  dockerHubMirror: earth
   dockerHubMirrorAlternateRegion: mars
   master_password: topSecret
   netapp:
@@ -27,7 +28,9 @@ mariadb:
   root_password: john
   backup_v2:
     enabled: false
-
+  users:
+    manila:
+      password: password
 
 rabbitmq:
   users:

--- a/openstack/manila/templates/api-deployment.yaml
+++ b/openstack/manila/templates/api-deployment.yaml
@@ -37,6 +37,7 @@ spec:
         kubectl.kubernetes.io/default-container: manila-api
     spec:
 {{ tuple . "manila" "api" | include "kubernetes_pod_anti_affinity" | indent 6 }}
+      {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       initContainers:
       - name: kubernetes-entrypoint
         image: {{.Values.global.registry}}/loci-manila:{{.Values.loci.imageVersion}}
@@ -168,6 +169,7 @@ spec:
               mountPath: /scripts
               readOnly: true
             {{- include "utils.coordination.volume_mount" . | indent 12 }}
+            {{- include "utils.proxysql.volume_mount" . | indent 12 }}
           {{- if .Values.pod.resources.api }}
           resources:
             {{ toYaml .Values.pod.resources.api | nindent 13 }}
@@ -191,6 +193,7 @@ spec:
           resources:
             {{- toYaml .Values.pod.resources.api_statsd | trim | nindent 12 }}
           {{- end }}
+        {{- tuple . .Values.wsgi_processes | include "utils.proxysql.container" | indent 8 }}
  {{- if .Values.osprofiler.enabled }}
  {{- include "jaeger_agent_sidecar" . | indent 8 }}
  {{- end }}
@@ -209,3 +212,4 @@ spec:
             name: manila-bin
             defaultMode: 0555
         {{- include "utils.coordination.volumes" . | indent 8 }}
+        {{- include "utils.proxysql.volumes" . | indent 8 }}

--- a/openstack/manila/templates/bin/_db_migrate.sh.tpl
+++ b/openstack/manila/templates/bin/_db_migrate.sh.tpl
@@ -7,3 +7,4 @@ set -e
 manila-status --config-file /etc/manila/manila.conf upgrade check
 manila-manage db sync
 manila-manage service cleanup
+{{ include "utils.proxysql.proxysql_signal_stop_script" . }}

--- a/openstack/manila/templates/etc/_wsgi-manila.conf.tpl
+++ b/openstack/manila/templates/etc/_wsgi-manila.conf.tpl
@@ -11,7 +11,7 @@ CustomLog /dev/stdout combined env=!forwarded
 CustomLog /dev/stdout proxy env=forwarded
 
 <VirtualHost *:{{.Values.api_port_internal}}>
-    WSGIDaemonProcess manila-api user=manila group=manila processes=8 threads=1 display-name=%{GROUP}
+    WSGIDaemonProcess manila-api user=manila group=manila processes={{ .Values.wsgi_processes }} threads=1 display-name=%{GROUP}
     WSGIScriptAlias / /var/www/cgi-bin/manila/manila-wsgi
     WSGIProcessGroup manila-api
     WSGIApplicationGroup %{GLOBAL}

--- a/openstack/manila/templates/migration-job.yaml
+++ b/openstack/manila/templates/migration-job.yaml
@@ -1,3 +1,10 @@
+{{/* As this runs as a pre-upgrade hook, we can only use the proxysql side-car if a previous
+     deployment has already deployed the corresponding configmap.
+     So if we want to switch to or from a proxysql.mode=unix_socket setting, we need
+     first to deploy with proxysql.mode=host_alias as an intermediate step,
+     so this script can still work with the previous setting
+*/}}
+{{- $proxysql := lookup "v1" "ConfigMap" .Release.Namespace (print .Release.Name "-proxysql-etc") -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -16,6 +23,9 @@ spec:
   template:
     spec:
       restartPolicy: OnFailure
+{{- if $proxysql }}
+      {{- include "utils.proxysql.job_pod_settings" . | indent 6 }}
+{{- end }}
       containers:
         - name: manila-migration
           image: {{.Values.global.registry}}/loci-manila:{{.Values.loci.imageVersion}}
@@ -55,6 +65,10 @@ spec:
               readOnly: true
             - mountPath: /container.init
               name: container-init
+{{- if $proxysql }}
+            {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+        {{- include "utils.proxysql.container" . | indent 8 }}
+{{- end }}
       volumes:
         - name: etcmanila
           emptyDir: {}
@@ -65,3 +79,6 @@ spec:
           configMap:
             name: manila-bin
             defaultMode: 0755
+{{- if $proxysql }}
+        {{- include "utils.proxysql.volumes" . | indent 8 }}
+{{- end }}

--- a/openstack/manila/templates/proxysql-configmap.yaml
+++ b/openstack/manila/templates/proxysql-configmap.yaml
@@ -1,0 +1,1 @@
+{{ include "proxysql_configmap" . }}

--- a/openstack/manila/templates/scheduler-deployment.yaml
+++ b/openstack/manila/templates/scheduler-deployment.yaml
@@ -25,13 +25,14 @@ spec:
         alert-tier: os
         alert-service: manila
       annotations:
-        {{- if .Values.rpc_statsd_enabled }}
+        {{- if or .Values.rpc_statsd_enabled .Values.proxysql.mode }}
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus.openstack missing" .Values.alerts.prometheus.openstack | quote }}
         {{- end }}
         kubectl.kubernetes.io/default-container: manila-scheduler
         configmap-etc-hash: {{ include (print .Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
     spec:
+      {{ include "utils.proxysql.pod_settings" . | indent 6 }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -114,6 +115,7 @@ spec:
               subPath: healthz
               readOnly: true
             {{- include "utils.coordination.volume_mount" . | indent 12 }}
+            {{- include "utils.proxysql.volume_mount" . | indent 12 }}
           {{- if .Values.pod.resources.scheduler }}
           resources:
 {{ toYaml .Values.pod.resources.scheduler | indent 13 }}
@@ -135,7 +137,8 @@ spec:
               subPath: statsd-rpc-exporter.yaml
               readOnly: true
         {{- end }}
- {{- include "jaeger_agent_sidecar" . | indent 8 }}
+        {{- include "jaeger_agent_sidecar" . | indent 8 }}
+        {{- tuple . .Values.rpc_workers | include "utils.proxysql.container" | indent 8 }}
       volumes:
         - name: etcmanila
           emptyDir: {}
@@ -147,3 +150,4 @@ spec:
           configMap:
             name: manila-etc
         {{- include "utils.coordination.volumes" . | indent 8 }}
+        {{- include "utils.proxysql.volumes" . | indent 8 }}

--- a/openstack/manila/templates/shares/_netapp-ensure-deployment.yaml.tpl
+++ b/openstack/manila/templates/shares/_netapp-ensure-deployment.yaml.tpl
@@ -86,6 +86,7 @@ spec:
               mountPath: /etc/manila/backend.conf
               subPath: backend.conf
               readOnly: true
+            {{- include "utils.proxysql.volume_mount" . | indent 12 }}
           {{- if .Values.pod.resources.share_ensure }}
           resources:
             {{ toYaml .Values.pod.resources.share_ensure | nindent 13 }}
@@ -106,7 +107,8 @@ spec:
             timeoutSeconds: 3
             periodSeconds: 5
             initialDelaySeconds: 5
- {{- include "jaeger_agent_sidecar" . | indent 8 }}
+        {{- include "jaeger_agent_sidecar" . | indent 8 }}
+        {{- include "utils.proxysql.container" . | indent 8 }}
       volumes:
         - name: etcmanila
           emptyDir: {}
@@ -116,5 +118,6 @@ spec:
         - name: backend-config
           configMap:
             name: share-netapp-{{$share.name}}
+        {{- include "utils.proxysql.volumes" . | indent 8 }}
 {{ end }}
 {{- end -}}

--- a/openstack/manila/values.yaml
+++ b/openstack/manila/values.yaml
@@ -23,6 +23,7 @@ api_backdoor: false
 debug: "True"
 
 coordinationBackend: 'file'
+wsgi_processes: 8
 
 logging:
   formatters:
@@ -86,6 +87,8 @@ memcached:
   metrics:
     enabled: true
 
+proxysql:
+  mode: ""
 
 mysql_metrics:
   db_name: manila
@@ -522,6 +525,12 @@ mariadb:
   query_cache_type: "1"
   name: manila
   initdb_configmap: manila-initdb
+  databases:
+  - manila
+  users:
+    manila:
+      name: manila
+      password: null
   persistence_claim:
     name: db-manila-pvclaim
   resources:


### PR DESCRIPTION
As this chart works with a pre-upgrade hook,
care has to be taken when using
proxysql.mode=unix_socket

The pre-upgrade hook works with the configmap using the old values,
while the chart would be rendered with the new values.
The only mode that works with both is
proxysql.mode=host_alias

So when either switching from no proxysql to unix_socket
or the other way around, a deployment in with the host_alias mode
is needed in between.