### PR TITLE
[keystone] Update dependencies

### DIFF
--- a/openstack/keystone/Chart.lock
+++ b/openstack/keystone/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.55
+  version: 0.5.4
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.0.10
@@ -19,9 +19,9 @@ dependencies:
   version: 0.4.2
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
-  version: 1.2.0
+  version: 1.2.6
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.4.1
-digest: sha256:d91e6b246159439d93b8b64c0d7d6c2f19842478de49ce8df255cff5f2e766ad
-generated: "2022-07-19T10:41:58.432295815+02:00"
+  version: 0.5.0
+digest: sha256:27e16ea1b4a5e77a3368f1eccfc5cf31af143444ac0824fa4eb3a752ff6d745d
+generated: "2022-07-29T13:41:04.015489251+02:00"

--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.55
+    version: 0.5.4
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.0.10
@@ -38,7 +38,7 @@ dependencies:
     condition: sapcc_rate_limit.enabled
     name: redis
     repository: https://charts.eu-de-2.cloud.sap
-    version: 1.2.0
+    version: 1.2.6
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.4.1
+    version: 0.5.0


### PR DESCRIPTION
Updates redis from 7.0.0 to 7.0.4
redis_exporter from v1.37.0 to v1.43.0
and proxysql from 2.4.1 to 2.4.2

Sets passowrd of keystone mariadb-user on upgrade