### PR TITLE
Update datastore.alerts

### DIFF
--- a/prometheus-exporters/vrops-exporter/alerts/datastore.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/datastore.alerts
@@ -128,23 +128,7 @@ groups:
       description: "Average utilization for `{{ $labels.type }}` Datastores per vCenter is above 70%. ({{ $labels.vcenter }})"
       summary: "Average utilization for `{{ $labels.type }}` Datastores per vCenter is above 70%. ({{ $labels.vcenter }})"
 
-  - alert: AverageVmfsDataStoreCapacityCritical
-    expr: >
-      avg by (type, vcenter) (vrops_datastore_diskspace_total_usage_gigabytes{type=~"vmfs_p_ssd|vmfs_s_hdd"} / vrops_datastore_diskspace_capacity_gigabytes) > 0.8
-    for: 20m
-    labels:
-      severity: critical
-      tier: os
-      service: storage
-      context: "vrops-exporter {{ $labels.type }}"
-      meta: "Average utilization for `{{ $labels.type }}` Datastores per vCenter is above 80%. ({{ $labels.vcenter }})"
-      dashboard: vcenter-datastore-utilization
-      playbook: docs/support/playbook/storage/new_storage_lun_request.html
-    annotations:
-      description: "Average utilization for `{{ $labels.type }}` Datastores per vCenter is above 80%. ({{ $labels.vcenter }})"
-      summary: "Average utilization for `{{ $labels.type }}` Datastores per vCenter is above 80%. ({{ $labels.vcenter }})"
-
-  - alert: DataStoreCapacityWarning
+    - alert: DataStoreCapacityWarning
     expr: >
       vrops_datastore_diskspace_total_usage_gigabytes{type!~"ephemeral|vVOL|vmfs.+", datastore!~".+swap"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.8
     for: 20m

--- a/prometheus-exporters/vrops-exporter/alerts/datastore.alerts
+++ b/prometheus-exporters/vrops-exporter/alerts/datastore.alerts
@@ -128,7 +128,7 @@ groups:
       description: "Average utilization for `{{ $labels.type }}` Datastores per vCenter is above 70%. ({{ $labels.vcenter }})"
       summary: "Average utilization for `{{ $labels.type }}` Datastores per vCenter is above 70%. ({{ $labels.vcenter }})"
 
-    - alert: DataStoreCapacityWarning
+  - alert: DataStoreCapacityWarning
     expr: >
       vrops_datastore_diskspace_total_usage_gigabytes{type!~"ephemeral|vVOL|vmfs.+", datastore!~".+swap"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.8
     for: 20m


### PR DESCRIPTION
This alert is not handled by b1 anymore as the storage workstream is in the process of insourcing. There is a related alert in slack channel  #alert-vmware-warning (CinderShardFreeSpaceWarning) which is handled by infraops team. See also this conversation: https://convergedcloud.slack.com/archives/CE5RCF7D4/p1659444894761919