### PR TITLE
[MariaDB] Enable Performance Schema for RCA and further perf improvements

### DIFF
--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.5.5
+version: 0.5.6

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -9,7 +9,7 @@ imagePullPolicy: IfNotPresent
 port_public: 3306
 max_connections: 1024
 buffer_pool_size: "1024M"
-performance_schema: "OFF"
+performance_schema: "ON"
 log_file_size: "256M"
 log_warnings: "2"
 query_cache_size: "0"


### PR DESCRIPTION
Enable performance schema required to get performance data from mariadb, and requires to do analysis.