### PR TITLE
[prom-infra-global] fallback prometheus-server chart

### DIFF
--- a/global/prometheus-infra/Chart.lock
+++ b/global/prometheus-infra/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
-- name: prometheus-server
+- name: prometheus-server-pre7
   repository: https://charts.eu-de-2.cloud.sap
-  version: 6.2.0
-digest: sha256:bd12ecb22af2b27455cfc43db343de703779a66cb2d694cec8489850f5904b9e
-generated: "2022-05-23T17:32:57.587855+02:00"
+  version: 6.3.3
+digest: sha256:3fd3edb546f46d0503108c9997aae7a255eb8a8901e0978b9770fce53db48dac
+generated: "2022-08-09T14:22:10.491683+02:00"

--- a/global/prometheus-infra/Chart.yaml
+++ b/global/prometheus-infra/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
 description: A Helm chart for the operated global Prometheus for monitoring infrastructure.
 name: prometheus-infra
-version: 1.0.0
+version: 1.1.0
 maintainers:
   - name: Tommy Sauer (viennaa)
   - name: Martin Vossen (artherd42)
 dependencies:
-  - name: prometheus-server
+  - name: prometheus-server-pre7
     alias: prometheus-infra-global
     repository: https://charts.eu-de-2.cloud.sap
-    version: 6.2.0
+    version: 6.3.3


### PR DESCRIPTION
Some Prometheis can't be ugpraded to 7.0.1 since they are relying on the old Thanos setup. Hence the prometheus operator can't be upgraded. To avoid being stuck on an old prometheus operator version these Prometheis can use this chart until they are phased out or renovated.
