### PR TITLE
maia prometheus server pre7

### DIFF
--- a/global/prometheus-infra/Chart.lock
+++ b/global/prometheus-infra/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
-- name: prometheus-server
+- name: prometheus-server-pre7
   repository: https://charts.eu-de-2.cloud.sap
-  version: 6.2.0
-digest: sha256:bd12ecb22af2b27455cfc43db343de703779a66cb2d694cec8489850f5904b9e
-generated: "2022-05-23T17:32:57.587855+02:00"
+  version: 6.3.3
+digest: sha256:3fd3edb546f46d0503108c9997aae7a255eb8a8901e0978b9770fce53db48dac
+generated: "2022-08-09T14:22:10.491683+02:00"

--- a/global/prometheus-infra/Chart.yaml
+++ b/global/prometheus-infra/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
 description: A Helm chart for the operated global Prometheus for monitoring infrastructure.
 name: prometheus-infra
-version: 1.0.0
+version: 1.1.0
 maintainers:
   - name: Tommy Sauer (viennaa)
   - name: Martin Vossen (artherd42)
 dependencies:
-  - name: prometheus-server
+  - name: prometheus-server-pre7
     alias: prometheus-infra-global
     repository: https://charts.eu-de-2.cloud.sap
-    version: 6.2.0
+    version: 6.3.3

--- a/openstack/maia/Chart.lock
+++ b/openstack/maia/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
-- name: prometheus-server
+- name: prometheus-server-pre7
   repository: https://charts.eu-de-2.cloud.sap
-  version: 6.2.0
-digest: sha256:4c15df19215b4cf9da24ff2dbbb65797ff1bf93fa0726ddeed35495f94b7ef62
-generated: "2022-05-19T13:59:19.201278+02:00"
+  version: 6.3.3
+digest: sha256:d3025ea091afaa8bb6d7bbe0940d35e7d192156f3555eb4ac5b67d9bd1f7d62e
+generated: "2022-08-10T10:12:35.614208+02:00"

--- a/openstack/maia/Chart.yaml
+++ b/openstack/maia/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
 description: Expose Prometheus as multi-tenant OpenStack service
 name: maia
-version: 1.1.0
+version: 1.2.0
 maintainers:
   - name: Martin Vossen (artherd42)
 dependencies:
-  - name: prometheus-server
+  - name: prometheus-server-pre7
     alias: prometheus_server
     condition: prometheus_server.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 6.2.0
+    version: 6.3.3


### PR DESCRIPTION
- [Maia] fallback prometheus-server chart
- [Maia] fallback prometheus-server chart Some Prometheis can't be ugpraded to 7.0.1 since they are relying on the old Thanos setup. Hence the prometheus operator can't be upgraded. To avoid being stuck on an old prometheus operator version these Prometheis can use this chart until they are phased out or renovated.
