### PR TITLE
[Cinder] Disable incremental backups

### DIFF
--- a/openstack/cinder/templates/etc/_cinder.conf.tpl
+++ b/openstack/cinder/templates/etc/_cinder.conf.tpl
@@ -55,6 +55,7 @@ capacity_weight_multiplier = {{ .Values.capacity_weight_multiplier }}
 allocated_capacity_weight_multiplier = {{ .Values.allocated_capacity_weight_multiplier }}
 
 allow_migration_on_attach = {{ .Values.cinder_api_allow_migration_on_attach }}
+sap_disable_incremental_backup = {{ .Values.sap_disable_incremental_backup }}
 
 {{- include "ini_sections.database" . }}
 

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -92,6 +92,8 @@ allocated_capacity_weight_multiplier: -1.0
 
 cinder_api_allow_migration_on_attach: True
 
+sap_disable_incremental_backup: True
+
 proxysql:
   mode: null # Disabled by default
 


### PR DESCRIPTION
This patch adds the ability to set the cinder option
to disable incremental backups.  The patch defaults
the option to On.