### PR TITLE
ironic (i)pxe templates: add kernel_append_params

### DIFF
--- a/openstack/ironic/templates/etc/_ipxe_config.template.tpl
+++ b/openstack/ironic/templates/etc/_ipxe_config.template.tpl
@@ -10,7 +10,7 @@ goto deploy
 
 :deploy
 imgfree
-kernel {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ "{{" }} pxe_options.ipxe_timeout {{ "}}" }} {% endif %}{{ "{{" }} pxe_options.deployment_aki_path {{ "}}" }} selinux=0 troubleshoot=0 text BOOTIF=${mac} initrd={{ "{{" }} pxe_options.initrd_filename|default("deploy_ramdisk", true) {{ "}}" }} || chain {{ printf "http://%v:%v/%v" .Values.global.ironic_tftp_ip .Values.conductor.deploy.port $conductor.pxe.pxe_bootfile_name }} || goto retry
+kernel {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ "{{" }} pxe_options.ipxe_timeout {{ "}}" }} {% endif %}{{ "{{" }} pxe_options.deployment_aki_path {{ "}}" }} selinux=0 troubleshoot=0 text {{ pxe_options.pxe_append_params|default("", true) }} BOOTIF=${mac} initrd={{ "{{" }} pxe_options.initrd_filename|default("deploy_ramdisk", true) {{ "}}" }} || chain {{ printf "http://%v:%v/%v" .Values.global.ironic_tftp_ip .Values.conductor.deploy.port $conductor.pxe.pxe_bootfile_name }} || goto retry
 
 initrd {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ "{{" }} pxe_options.ipxe_timeout {{ "}}" }} {% endif %}{{ "{{" }} pxe_options.deployment_ari_path {{ "}}" }} || goto retry
 boot

--- a/openstack/ironic/templates/etc/_ipxe_config.template.tpl
+++ b/openstack/ironic/templates/etc/_ipxe_config.template.tpl
@@ -10,7 +10,7 @@ goto deploy
 
 :deploy
 imgfree
-kernel {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ "{{" }} pxe_options.ipxe_timeout {{ "}}" }} {% endif %}{{ "{{" }} pxe_options.deployment_aki_path {{ "}}" }} selinux=0 troubleshoot=0 text {{ pxe_options.pxe_append_params|default("", true) }} BOOTIF=${mac} initrd={{ "{{" }} pxe_options.initrd_filename|default("deploy_ramdisk", true) {{ "}}" }} || chain {{ printf "http://%v:%v/%v" .Values.global.ironic_tftp_ip .Values.conductor.deploy.port $conductor.pxe.pxe_bootfile_name }} || goto retry
+kernel {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ "{{" }} pxe_options.ipxe_timeout {{ "}}" }} {% endif %}{{ "{{" }} pxe_options.deployment_aki_path {{ "}}" }} selinux=0 troubleshoot=0 text {{ "{{" }} pxe_options.pxe_append_params|default("", true)  {{ "}}" }} BOOTIF=${mac} initrd={{ "{{" }} pxe_options.initrd_filename|default("deploy_ramdisk", true) {{ "}}" }} || chain {{ printf "http://%v:%v/%v" .Values.global.ironic_tftp_ip .Values.conductor.deploy.port $conductor.pxe.pxe_bootfile_name }} || goto retry
 
 initrd {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ "{{" }} pxe_options.ipxe_timeout {{ "}}" }} {% endif %}{{ "{{" }} pxe_options.deployment_ari_path {{ "}}" }} || goto retry
 boot

--- a/openstack/ironic/templates/etc/_pxe_config.template.tpl
+++ b/openstack/ironic/templates/etc/_pxe_config.template.tpl
@@ -5,8 +5,8 @@
 default deploy
 
 label deploy
-kernel {{$prefix}}{{"{{"}} pxe_options.deployment_aki_path {{"}}"}}
-append initrd={{$prefix}}{{"{{"}} pxe_options.deployment_ari_path {{"}}"}} selinux=0 troubleshoot=0 text
+kernel {{$prefix}}{{"{{"}} pxe_options.deployment_aki_path {{"}}"}} 
+append initrd={{$prefix}}{{"{{"}} pxe_options.deployment_ari_path {{"}}"}} selinux=0 troubleshoot=0 text {{ pxe_options.pxe_append_params|default("", true) }}
 ipappend 3
 
 

--- a/openstack/ironic/templates/etc/_pxe_config.template.tpl
+++ b/openstack/ironic/templates/etc/_pxe_config.template.tpl
@@ -6,7 +6,7 @@ default deploy
 
 label deploy
 kernel {{$prefix}}{{"{{"}} pxe_options.deployment_aki_path {{"}}"}} 
-append initrd={{$prefix}}{{"{{"}} pxe_options.deployment_ari_path {{"}}"}} selinux=0 troubleshoot=0 text {{ pxe_options.pxe_append_params|default("", true) }}
+append initrd={{$prefix}}{{"{{"}} pxe_options.deployment_ari_path {{"}}"}} selinux=0 troubleshoot=0 text {{ "{{" }} pxe_options.pxe_append_params|default("", true)  {{ "}}" }}
 ipappend 3
 
 

--- a/openstack/ironic/templates/etc/_uefi_pxe_config.template.tpl
+++ b/openstack/ironic/templates/etc/_uefi_pxe_config.template.tpl
@@ -10,7 +10,7 @@ goto deploy
 
 :deploy
 imgfree
-kernel {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ "{{" }} pxe_options.ipxe_timeout {{ "}}" }} {% endif %}{{ "{{" }} pxe_options.deployment_aki_path {{ "}}" }} selinux=0 troubleshoot=0 text BOOTIF=${mac} initrd={{ "{{" }} pxe_options.initrd_filename|default("deploy_ramdisk", true) {{ "}}" }} || chain {{ printf "http://%v:%v/%v" .Values.global.ironic_tftp_ip .Values.conductor.deploy.port $conductor.pxe.uefi_pxe_bootfile_name }} || goto retry
+kernel {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ "{{" }} pxe_options.ipxe_timeout {{ "}}" }} {% endif %}{{ "{{" }} pxe_options.deployment_aki_path {{ "}}" }} selinux=0 troubleshoot=0 text {{ pxe_options.pxe_append_params|default("", true) }} BOOTIF=${mac} initrd={{ "{{" }} pxe_options.initrd_filename|default("deploy_ramdisk", true) {{ "}}" }} || chain {{ printf "http://%v:%v/%v" .Values.global.ironic_tftp_ip .Values.conductor.deploy.port $conductor.pxe.uefi_pxe_bootfile_name }} || goto retry
 
 initrd --name {{ "{{" }} pxe_options.initrd_filename|default("deploy_ramdisk", true) {{ "}}" }} {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ "{{" }} pxe_options.ipxe_timeout {{ "}}" }} {% endif %}{{ "{{" }} pxe_options.deployment_ari_path {{ "}}" }} || goto retry
 boot

--- a/openstack/ironic/templates/etc/_uefi_pxe_config.template.tpl
+++ b/openstack/ironic/templates/etc/_uefi_pxe_config.template.tpl
@@ -10,7 +10,7 @@ goto deploy
 
 :deploy
 imgfree
-kernel {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ "{{" }} pxe_options.ipxe_timeout {{ "}}" }} {% endif %}{{ "{{" }} pxe_options.deployment_aki_path {{ "}}" }} selinux=0 troubleshoot=0 text {{ pxe_options.pxe_append_params|default("", true) }} BOOTIF=${mac} initrd={{ "{{" }} pxe_options.initrd_filename|default("deploy_ramdisk", true) {{ "}}" }} || chain {{ printf "http://%v:%v/%v" .Values.global.ironic_tftp_ip .Values.conductor.deploy.port $conductor.pxe.uefi_pxe_bootfile_name }} || goto retry
+kernel {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ "{{" }} pxe_options.ipxe_timeout {{ "}}" }} {% endif %}{{ "{{" }} pxe_options.deployment_aki_path {{ "}}" }} selinux=0 troubleshoot=0 text {{ "{{" }} pxe_options.pxe_append_params|default("", true)  {{ "}}" }} BOOTIF=${mac} initrd={{ "{{" }} pxe_options.initrd_filename|default("deploy_ramdisk", true) {{ "}}" }} || chain {{ printf "http://%v:%v/%v" .Values.global.ironic_tftp_ip .Values.conductor.deploy.port $conductor.pxe.uefi_pxe_bootfile_name }} || goto retry
 
 initrd --name {{ "{{" }} pxe_options.initrd_filename|default("deploy_ramdisk", true) {{ "}}" }} {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ "{{" }} pxe_options.ipxe_timeout {{ "}}" }} {% endif %}{{ "{{" }} pxe_options.deployment_ari_path {{ "}}" }} || goto retry
 boot


### PR DESCRIPTION
templates now need to contain the pxe_append_params so that kernel
params including the ipa-api-url are set properly as part of the
deployment process