### PR TITLE
[prometheus-infra][neutron-routers] Add label to identify pair

### DIFF
--- a/system/prometheus-infra/templates/_prometheus-infra.yaml.tpl
+++ b/system/prometheus-infra/templates/_prometheus-infra.yaml.tpl
@@ -57,6 +57,12 @@
       target_label: uniqueident
       action: replace
 
+    - source_labels: [__name__, device]
+      regex: '^(snmp_asr|ssh)_[A-za-z0-9]+;((rt|asr)[0-9]+)[a|b]$'
+      replacement: '$2'
+      target_label: asr_pair
+      action: replace
+
   {{ if .Values.authentication.enabled }}
   tls_config:
     cert_file: /etc/prometheus/secrets/prometheus-infra-frontend-sso-cert/sso.crt


### PR DESCRIPTION
Neutron Routers form an active/standby pair. Often times we want to aggregate
metrics for the pair and I am tired of using `label_replace` in my queries so I
guess the more straightforoward approach is to define that label on metric
insertion.