### PR TITLE
system/gatekeeper: move support label rendering to a lib module

### DIFF
--- a/system/gatekeeper/lib/add-support-labels.rego
+++ b/system/gatekeeper/lib/add-support-labels.rego
@@ -1,0 +1,15 @@
+package lib.add_support_labels
+
+# `obj` must be a full Kubernetes object.
+from_k8s_object(obj, msg) = result {
+  support_group := object.get(obj, ["metadata", "labels", "cc/support-group"], "none")
+  service := object.get(obj, ["metadata", "labels", "cc/service"], "none")
+  result := sprintf("support-group=%s,service=%s: %s", [support_group, service, msg])
+}
+
+# `body` must be the response body from helm-manifest-parser
+from_helm_release(body, msg) = result {
+  support_group := object.get(body, ["values", "owner-info", "support-group"], "none")
+  service := object.get(body, ["values", "owner-info", "service"], "none")
+  result := sprintf("support-group=%s,service=%s: %s", [support_group, service, msg])
+}

--- a/system/gatekeeper/lib/helm-release.rego
+++ b/system/gatekeeper/lib/helm-release.rego
@@ -1,0 +1,57 @@
+package lib.helm_release
+
+# The public interface is the function parse_k8s_object(obj, baseURL). `obj`
+# must be a full Kubernetes object. A Secret containing a Helm release must be
+# given, otherwise an error will be returned. `baseURL` is where
+# helm-manifest-parser is running. This usually comes from the policy's
+# `input.parameters`.
+#
+# If parsing fails, an object with only the field "error" is returned.
+# This error message must be converted into a violation by the calling policy.
+# (This step is something that we cannot do in a library module.)
+#
+# If parsing succeeds, the parsed response body from helm-manifest-parser is
+# returned. Additionally, the returned object will have the field "error" set
+# to the empty string, in order to simplify error checks in the calling policy.
+
+parse_k8s_object(obj, baseURL) = result {
+  # NOTE: This branch is defense in depth. Constraints using this function
+  # should already be limited to suitable objects via their selectors.
+  not __is_helm_release(obj)
+  result = { "error": "Input to helm_manifest_parser.parse_release() is not a Helm release. This is an error in the policy implementation." }
+}
+parse_k8s_object(obj, baseURL) = result {
+  # This code is structured to ensure that http.send() is never executed more
+  # than once.
+  __is_helm_release(obj)
+  url := sprintf("%s/v3", [baseURL])
+  resp := http.send({"url": url, "method": "POST", "raise_error": false, "raw_body": obj.data.release, "timeout": "15s"})
+  result = __parse_response(resp)
+}
+
+################################################################################
+# private helper functions
+
+__is_helm_release(obj) = true {
+  obj.kind == "Secret"
+  obj.type == "helm.sh/release.v1"
+  obj.metadata.labels.status == "deployed"
+}
+__is_helm_release(obj) = false {
+  obj.kind != "Secret"
+}
+__is_helm_release(obj) = false {
+  obj.type != "helm.sh/release.v1"
+}
+__is_helm_release(obj) = false {
+  obj.metadata.labels.status != "deployed"
+}
+
+__parse_response(resp) = result {
+  resp.status_code == 200
+  result := object.union(resp.body, { "error": "" })
+}
+__parse_response(resp) = result {
+  resp.status_code != 200
+  result := {"error": "helm-manifest-parser did not return HTTP status 200. Please retry in ~5 minutes."}
+}

--- a/system/gatekeeper/templates/constrainttemplate-deprecated-api-version.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-deprecated-api-version.yaml
@@ -26,37 +26,29 @@ spec:
       libs:
         - |
           {{ .Files.Get "lib/add-support-labels.rego" | nindent 10 }}
+        - |
+          {{ .Files.Get "lib/helm-release.rego" | nindent 10 }}
       rego: |
         package deprecatedapiversion
         import data.lib.add_support_labels
+        import data.lib.helm_release
 
         iro := input.review.object
-
-        parser_url := sprintf("%s/v3", [input.parameters.helmManifestParserURL])
-        parser_resp := http.send({"url": parser_url, "method": "POST", "raise_error": false, "raw_body": iro.data.release, "timeout": "15s"})
+        release := helm_release.parse_k8s_object(iro, input.parameters.helmManifestParserURL)
+        violation[{"msg": release.error}] {
+          release.error != ""
+        }
 
         violation[{"msg": msg, "details": {"name": obj.metadata.name, "kind": obj.kind}}] {
-          # must be a Helm 3 release
-          iro.kind == "Secret"
-          iro.type == "helm.sh/release.v1"
-          iro.metadata.labels.status == "deployed"
-
-          # release manifest must have been parsed successfully
-          parser_resp.status_code == 200
+          release.error == ""
 
           # find objects in the manifest that use deprecated API versions
-          obj := parser_resp.body.items[_]
+          obj := release.items[_]
           input.parameters.apiVersions[_] == obj.apiVersion
 
           msgBase := sprintf(
             "%s %s declared with deprecated API version: %s (will break in k8s v%s)",
             [obj.kind, obj.metadata.name, obj.apiVersion, input.parameters.kubernetesVersion]
           )
-          msg := add_support_labels.from_helm_release(parser_resp.body, msgBase)
-        }
-
-        violation[{"msg": msg}] {
-          parser_resp.status_code != 200
-
-          msg := "helm-manifest-parser did not return HTTP status 200. Please retry in ~5 minutes."
+          msg := add_support_labels.from_helm_release(release, msgBase)
         }

--- a/system/gatekeeper/templates/constrainttemplate-deprecated-api-version.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-deprecated-api-version.yaml
@@ -39,16 +39,15 @@ spec:
           release.error != ""
         }
 
-        violation[{"msg": msg, "details": {"name": obj.metadata.name, "kind": obj.kind}}] {
+        violation[{"msg": add_support_labels.from_helm_release(release, msg)}] {
           release.error == ""
 
           # find objects in the manifest that use deprecated API versions
           obj := release.items[_]
           input.parameters.apiVersions[_] == obj.apiVersion
 
-          msgBase := sprintf(
+          msg := sprintf(
             "%s %s declared with deprecated API version: %s (will break in k8s v%s)",
             [obj.kind, obj.metadata.name, obj.apiVersion, input.parameters.kubernetesVersion]
           )
-          msg := add_support_labels.from_helm_release(release, msgBase)
         }

--- a/system/gatekeeper/templates/constrainttemplate-deprecated-api-version.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-deprecated-api-version.yaml
@@ -23,8 +23,12 @@ spec:
 
   targets:
     - target: admission.k8s.gatekeeper.sh
+      libs:
+        - |
+          {{ .Files.Get "lib/add-support-labels.rego" | nindent 10 }}
       rego: |
         package deprecatedapiversion
+        import data.lib.add_support_labels
 
         iro := input.review.object
 
@@ -43,12 +47,12 @@ spec:
           # find objects in the manifest that use deprecated API versions
           obj := parser_resp.body.items[_]
           input.parameters.apiVersions[_] == obj.apiVersion
-          owner_info := object.get(parser_resp.body, ["values", "owner-info"], {})
 
-          msg := sprintf(
-            "support-group=%s,service=%s: %s %s declared with deprecated API version: %s (will break in k8s v%s)",
-            [object.get(owner_info, "support-group", "none"), object.get(owner_info, "service", "none"), obj.kind, obj.metadata.name, obj.apiVersion, input.parameters.kubernetesVersion]
+          msgBase := sprintf(
+            "%s %s declared with deprecated API version: %s (will break in k8s v%s)",
+            [obj.kind, obj.metadata.name, obj.apiVersion, input.parameters.kubernetesVersion]
           )
+          msg := add_support_labels.from_helm_release(parser_resp.body, msgBase)
         }
 
         violation[{"msg": msg}] {

--- a/system/gatekeeper/templates/constrainttemplate-forbidden-clusterwide-objects.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-forbidden-clusterwide-objects.yaml
@@ -29,11 +29,10 @@ spec:
 
         # Violations act like a blocklist, but we want to have an allowlist, so
         # we go through `allowed_webhook` as an intermediate level.
-        violation[{"msg": msg}] {
+        violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
           webhook := iro.webhooks[_]
           count({ x | x := allowed_webhook[_]; x.name == webhook.name }) == 0
-          msgBase := sprintf("webhook %q does not match our allowlist", [webhook.name])
-          msg := add_support_labels.from_k8s_object(iro, msgBase)
+          msg := sprintf("webhook %q does not match our allowlist", [webhook.name])
         }
 
         # validating webhook: kube-system/gatekeeper (we don't have mutation enabled for Gatekeeper)

--- a/system/gatekeeper/templates/constrainttemplate-forbidden-clusterwide-objects.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-forbidden-clusterwide-objects.yaml
@@ -10,8 +10,12 @@ spec:
 
   targets:
     - target: admission.k8s.gatekeeper.sh
+      libs:
+        - |
+          {{ .Files.Get "lib/add-support-labels.rego" | nindent 10 }}
       rego: |
         package forbiddenclusterwideobjects
+        import data.lib.add_support_labels
 
         ########################################################################
         # admission webhooks
@@ -22,18 +26,14 @@ spec:
         }
 
         iro := input.review.object
-        iro_support_group := object.get(iro, ["metadata", "labels", "cc/support-group"], "none")
-        iro_service := object.get(iro, ["metadata", "labels", "cc/service"], "none")
 
         # Violations act like a blocklist, but we want to have an allowlist, so
         # we go through `allowed_webhook` as an intermediate level.
         violation[{"msg": msg}] {
           webhook := iro.webhooks[_]
           count({ x | x := allowed_webhook[_]; x.name == webhook.name }) == 0
-          msg := sprintf(
-            "support-group=%s,service=%s: webhook %q does not match our allowlist",
-            [iro_support_group, iro_service, webhook.name]
-          )
+          msgBase := sprintf("webhook %q does not match our allowlist", [webhook.name])
+          msg := add_support_labels.from_k8s_object(iro, msgBase)
         }
 
         # validating webhook: kube-system/gatekeeper (we don't have mutation enabled for Gatekeeper)

--- a/system/gatekeeper/templates/constrainttemplate-high-cpu-requests.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-high-cpu-requests.yaml
@@ -44,12 +44,11 @@ spec:
 
         cpu_requests = [canonify_cpu(c) | c = iro.spec.containers[_].resources.requests.cpu]
 
-        violation[{"msg": msg}] {
+        violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
           iro.kind == "Pod"
 
           total_cpu := sum(cpu_requests)
           total_cpu > input.parameters.maxCpu
 
-          msgBase := sprintf("requests %v CPU in total", [total_cpu])
-          msg := add_support_labels.from_k8s_object(iro, msgBase)
+          msg := sprintf("requests %v CPU in total", [total_cpu])
         }

--- a/system/gatekeeper/templates/constrainttemplate-high-cpu-requests.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-high-cpu-requests.yaml
@@ -17,8 +17,12 @@ spec:
 
   targets:
     - target: admission.k8s.gatekeeper.sh
+      libs:
+        - |
+          {{ .Files.Get "lib/add-support-labels.rego" | nindent 10 }}
       rego: |
         package highcpurequests
+        import data.lib.add_support_labels
 
         canonify_cpu(orig) = new {
           is_number(orig)
@@ -37,8 +41,6 @@ spec:
         }
 
         iro := input.review.object
-        iro_support_group := object.get(iro, ["metadata", "labels", "cc/support-group"], "none")
-        iro_service := object.get(iro, ["metadata", "labels", "cc/service"], "none")
 
         cpu_requests = [canonify_cpu(c) | c = iro.spec.containers[_].resources.requests.cpu]
 
@@ -47,8 +49,7 @@ spec:
 
           total_cpu := sum(cpu_requests)
           total_cpu > input.parameters.maxCpu
-          msg := sprintf(
-            "support-group=%s,service=%s: requests %v CPU in total",
-            [iro_support_group, iro_service, total_cpu]
-          )
+
+          msgBase := sprintf("requests %v CPU in total", [total_cpu])
+          msg := add_support_labels.from_k8s_object(iro, msgBase)
         }

--- a/system/gatekeeper/templates/constrainttemplate-images-from-correct-registry.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-images-from-correct-registry.yaml
@@ -53,7 +53,7 @@ spec:
           alternate_region = extract_keppel_region(input.parameters.registryAlternateRegion)
         }
 
-        violation[{"msg": msg}] {
+        violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
           iro.kind == "Pod"
           container := iro.spec.containers[_]
           image := container.image
@@ -64,6 +64,5 @@ spec:
           count(found) == 0
 
           image_name := extract_image_name_with_tag(image)
-          msgBase := sprintf("container %q uses incorrect regional registry for image: %s", [container.name, image_name])
-          msg := add_support_labels.from_k8s_object(iro, msgBase)
+          msg := sprintf("container %q uses incorrect regional registry for image: %s", [container.name, image_name])
         }

--- a/system/gatekeeper/templates/constrainttemplate-images-from-correct-registry.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-images-from-correct-registry.yaml
@@ -19,8 +19,12 @@ spec:
 
   targets:
     - target: admission.k8s.gatekeeper.sh
+      libs:
+        - |
+          {{ .Files.Get "lib/add-support-labels.rego" | nindent 10 }}
       rego: |
         package imagesfromcorrectregistry
+        import data.lib.add_support_labels
 
         extract_keppel_region(image) = region {
           matchList := regex.find_all_string_submatch_n(`^keppel\.([-\w]+)\.[a-zA-Z]+\.[a-zA-Z]+/`, image, 1)
@@ -40,8 +44,6 @@ spec:
         }
 
         iro := input.review.object
-        iro_support_group := object.get(iro, ["metadata", "labels", "cc/support-group"], "none")
-        iro_service := object.get(iro, ["metadata", "labels", "cc/service"], "none")
 
         correct_regions[region] {
           region = extract_keppel_region(input.parameters.registry)
@@ -62,8 +64,6 @@ spec:
           count(found) == 0
 
           image_name := extract_image_name_with_tag(image)
-          msg := sprintf(
-            "support-group=%s,service=%s: container %q uses incorrect regional registry for image: %s",
-            [iro_support_group, iro_service, container.name, image_name]
-          )
+          msgBase := sprintf("container %q uses incorrect regional registry for image: %s", [container.name, image_name])
+          msg := add_support_labels.from_k8s_object(iro, msgBase)
         }

--- a/system/gatekeeper/templates/constrainttemplate-images-from-non-keppel.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-images-from-non-keppel.yaml
@@ -53,12 +53,11 @@ spec:
           container := array.concat(pod_spec.containers, initCntrs)[_]
         }
 
-        violation[{"msg": msg, "details": {"container": container_name, "image": image}}] {
+        violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
           container := containers[_]
           container_name := container.name
           image := container.image
 
           not regex.match("^keppel\\.[^/.]*\\.cloud.sap/", image)
-          msgBase := sprintf("container %q uses an image that is not from a Keppel registry: %s", [container_name, image])
-          msg := add_support_labels.from_k8s_object(iro, msgBase)
+          msg := sprintf("container %q uses an image that is not from a Keppel registry: %s", [container_name, image])
         }

--- a/system/gatekeeper/templates/constrainttemplate-images-from-non-keppel.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-images-from-non-keppel.yaml
@@ -10,8 +10,12 @@ spec:
 
   targets:
     - target: admission.k8s.gatekeeper.sh
+      libs:
+        - |
+          {{ .Files.Get "lib/add-support-labels.rego" | nindent 10 }}
       rego: |
         package imagesfromnonkeppel
+        import data.lib.add_support_labels
 
         # This violation is usually only detectable on the
         # deployment/daemonset/statefulset level since Tugger will fix the
@@ -21,8 +25,6 @@ spec:
         pod_owners       = {"ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 
         iro := input.review.object
-        iro_support_group := object.get(iro, ["metadata", "labels", "cc/support-group"], "none")
-        iro_service := object.get(iro, ["metadata", "labels", "cc/service"], "none")
 
         pod_belongs_to[kind] {
           ref := iro.metadata.ownerReferences[_]
@@ -57,8 +59,6 @@ spec:
           image := container.image
 
           not regex.match("^keppel\\.[^/.]*\\.cloud.sap/", image)
-          msg := sprintf(
-            "support-group=%s,service=%s: container %q uses an image that is not from a Keppel registry: %s",
-            [iro_support_group, iro_service, container_name, image]
-          )
+          msgBase := sprintf("container %q uses an image that is not from a Keppel registry: %s", [container_name, image])
+          msg := add_support_labels.from_k8s_object(iro, msgBase)
         }

--- a/system/gatekeeper/templates/constrainttemplate-ingress-annotations.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-ingress-annotations.yaml
@@ -27,12 +27,11 @@ spec:
           "ingress.kubernetes.io/modsecurity-snippet",
         }
 
-        violation[{"msg": msg}] {
+        violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
           iro.kind == "Ingress"
 
           annotation := disabled_annotations[_]
           is_string(object.get(iro, ["metadata", "annotations", annotation], null))
 
-          msgBase := sprintf("has disabled annotation: %q", [annotation])
-          msg := add_support_labels.from_k8s_object(iro, msgBase)
+          msg := sprintf("has disabled annotation: %q", [annotation])
         }

--- a/system/gatekeeper/templates/constrainttemplate-ingress-annotations.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-ingress-annotations.yaml
@@ -10,12 +10,14 @@ spec:
 
   targets:
     - target: admission.k8s.gatekeeper.sh
+      libs:
+        - |
+          {{ .Files.Get "lib/add-support-labels.rego" | nindent 10 }}
       rego: |
         package ingressannotations
+        import data.lib.add_support_labels
 
         iro := input.review.object
-        iro_support_group := object.get(iro, ["metadata", "labels", "cc/support-group"], "none")
-        iro_service := object.get(iro, ["metadata", "labels", "cc/service"], "none")
 
         # These annotations have been disabled due to CVE-2021-25742
         disabled_annotations = {
@@ -31,8 +33,6 @@ spec:
           annotation := disabled_annotations[_]
           is_string(object.get(iro, ["metadata", "annotations", annotation], null))
 
-          msg := sprintf(
-            "support-group=%s,service=%s: has disabled annotation: %q",
-            [iro_support_group, iro_service, annotation]
-          )
+          msgBase := sprintf("has disabled annotation: %q", [annotation])
+          msg := add_support_labels.from_k8s_object(iro, msgBase)
         }

--- a/system/gatekeeper/templates/constrainttemplate-outdated-image-bases.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-outdated-image-bases.yaml
@@ -47,7 +47,7 @@ spec:
           msg := "doop-image-parser did not return HTTP status 200. Please retry in ~5 minutes."
         }
 
-        violation[{"msg": msg}] {
+        violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
           check := checks[_]
           check.response.status_code == 200
           createdAtAsUnixTime := to_number(trim_space(object.get(check.response.body, "X-Keppel-Min-Layer-Created-At", "Unclear")))
@@ -58,9 +58,8 @@ spec:
           ageInDays := ageInSeconds / 86400
           ageInDays > 365
 
-          msgBase := sprintf(
+          msg := sprintf(
             "image %s for container %q uses a very old base image (oldest layer is %.0f days old)",
             [check.container.image, check.container.name, ageInDays]
           )
-          msg := add_support_labels.from_k8s_object(iro, msgBase)
         }

--- a/system/gatekeeper/templates/constrainttemplate-outdated-image-bases.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-outdated-image-bases.yaml
@@ -17,12 +17,14 @@ spec:
 
   targets:
     - target: admission.k8s.gatekeeper.sh
+      libs:
+        - |
+          {{ .Files.Get "lib/add-support-labels.rego" | nindent 10 }}
       rego: |
         package outdatedimagebases
+        import data.lib.add_support_labels
 
         iro := input.review.object
-        iro_support_group := object.get(iro, ["metadata", "labels", "cc/support-group"], "none")
-        iro_service := object.get(iro, ["metadata", "labels", "cc/service"], "none")
 
         # check each pod container
         checks[{ "container": container, "response": resp }] {
@@ -55,8 +57,10 @@ spec:
           ageInSeconds := nowAsUnixTime - createdAtAsUnixTime
           ageInDays := ageInSeconds / 86400
           ageInDays > 365
-          msg := sprintf(
-            "support-group=%s,service=%s: image %s for container %q uses a very old base image (oldest layer is %.0f days old)",
-            [iro_support_group, iro_service, check.container.image, check.container.name, ageInDays]
+
+          msgBase := sprintf(
+            "image %s for container %q uses a very old base image (oldest layer is %.0f days old)",
+            [check.container.image, check.container.name, ageInDays]
           )
+          msg := add_support_labels.from_k8s_object(iro, msgBase)
         }

--- a/system/gatekeeper/templates/constrainttemplate-owner-info-on-helm-releases.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-owner-info-on-helm-releases.yaml
@@ -20,40 +20,39 @@ spec:
       libs:
         - |
           {{ .Files.Get "lib/add-support-labels.rego" | nindent 10 }}
+        - |
+          {{ .Files.Get "lib/helm-release.rego" | nindent 10 }}
       rego: |
         package ownerinfoonhelmreleases
         import data.lib.add_support_labels
+        import data.lib.helm_release
 
         iro := input.review.object
-        parser_url := sprintf("%s/v3", [input.parameters.helmManifestParserURL])
-        parser_resp := http.send({"url": parser_url, "method": "POST", "raise_error": false, "raw_body": iro.data.release, "timeout": "15s"})
-
-        violation[{"msg": msg}] {
-          parser_resp.status_code != 200
-          msg := "helm-manifest-parser did not return HTTP status 200. Please retry in ~5 minutes."
+        release := helm_release.parse_k8s_object(iro, input.parameters.helmManifestParserURL)
+        violation[{"msg": release.error}] {
+          release.error != ""
         }
 
         configmaps[obj] {
-          iro.kind == "Secret"
-          iro.type == "helm.sh/release.v1"
-          iro.metadata.labels.status == "deployed"
+          release.error == ""
 
-          parser_resp.status_code == 200
-
-          obj := parser_resp.body.items[_]
+          obj := release.items[_]
           obj.kind == "ConfigMap"
           startswith(obj.metadata.name, "owner-of-")
         }
 
         violation[{"msg": msg}] {
+          release.error == ""
+
           # Check if an 'owner-of-<release-name>' ConfigMap exists for this release.
           count(configmaps) == 0
           release_name := iro.metadata.labels.name
           msgBase := sprintf("could not find ConfigMap: owner-of-%s", [release_name])
-          msg := add_support_labels.from_helm_release(parser_resp.body, msgBase)
+          msg := add_support_labels.from_helm_release(release, msgBase)
         }
 
         violation[{"msg": msg}] {
+          release.error == ""
           count(configmaps) > 0
 
           # Check if 'primary-maintainer' label is defined. Existence of this label denotes that
@@ -66,5 +65,5 @@ spec:
             "ConfigMap %q does not have %q label: parent chart needs to define %q in its Values.yaml file with at least one maintainer",
             [obj.metadata.name, "primary-maintainer", "owner-info.maintainers"],
           )
-          msg := add_support_labels.from_helm_release(parser_resp.body, msgBase)
+          msg := add_support_labels.from_helm_release(release, msgBase)
         }

--- a/system/gatekeeper/templates/constrainttemplate-owner-info-on-helm-releases.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-owner-info-on-helm-releases.yaml
@@ -41,17 +41,16 @@ spec:
           startswith(obj.metadata.name, "owner-of-")
         }
 
-        violation[{"msg": msg}] {
+        violation[{"msg": add_support_labels.from_helm_release(release, msg)}] {
           release.error == ""
 
           # Check if an 'owner-of-<release-name>' ConfigMap exists for this release.
           count(configmaps) == 0
           release_name := iro.metadata.labels.name
-          msgBase := sprintf("could not find ConfigMap: owner-of-%s", [release_name])
-          msg := add_support_labels.from_helm_release(release, msgBase)
+          msg := sprintf("could not find ConfigMap: owner-of-%s", [release_name])
         }
 
-        violation[{"msg": msg}] {
+        violation[{"msg": add_support_labels.from_helm_release(release, msg)}] {
           release.error == ""
           count(configmaps) > 0
 
@@ -61,9 +60,8 @@ spec:
           pm := object.get(obj.metadata, ["labels", "primary-maintainer"], "")
           pm == ""
 
-          msgBase := sprintf(
+          msg := sprintf(
             "ConfigMap %q does not have %q label: parent chart needs to define %q in its Values.yaml file with at least one maintainer",
             [obj.metadata.name, "primary-maintainer", "owner-info.maintainers"],
           )
-          msg := add_support_labels.from_helm_release(release, msgBase)
         }

--- a/system/gatekeeper/templates/constrainttemplate-owner-info-on-helm-releases.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-owner-info-on-helm-releases.yaml
@@ -17,8 +17,12 @@ spec:
 
   targets:
     - target: admission.k8s.gatekeeper.sh
+      libs:
+        - |
+          {{ .Files.Get "lib/add-support-labels.rego" | nindent 10 }}
       rego: |
         package ownerinfoonhelmreleases
+        import data.lib.add_support_labels
 
         iro := input.review.object
         parser_url := sprintf("%s/v3", [input.parameters.helmManifestParserURL])
@@ -44,12 +48,9 @@ spec:
         violation[{"msg": msg}] {
           # Check if an 'owner-of-<release-name>' ConfigMap exists for this release.
           count(configmaps) == 0
-          owner_info := object.get(parser_resp.body, ["values", "owner-info"], {})
           release_name := iro.metadata.labels.name
-          msg := sprintf(
-            "support-group=%s,service=%s: could not find ConfigMap: owner-of-%s",
-            [object.get(owner_info, "support-group", "none"), object.get(owner_info, "service", "none"), release_name]
-          )
+          msgBase := sprintf("could not find ConfigMap: owner-of-%s", [release_name])
+          msg := add_support_labels.from_helm_release(parser_resp.body, msgBase)
         }
 
         violation[{"msg": msg}] {
@@ -61,9 +62,9 @@ spec:
           pm := object.get(obj.metadata, ["labels", "primary-maintainer"], "")
           pm == ""
 
-          owner_info := object.get(parser_resp.body, ["values", "owner-info"], {})
-          msg := sprintf(
-            "support-group=%s,service=%s: ConfigMap %q does not have %q label: parent chart needs to define %q in its Values.yaml file with at least one maintainer",
-            [object.get(owner_info, "support-group", "none"), object.get(owner_info, "service", "none"), obj.metadata.name, "primary-maintainer", "owner-info.maintainers"],
+          msgBase := sprintf(
+            "ConfigMap %q does not have %q label: parent chart needs to define %q in its Values.yaml file with at least one maintainer",
+            [obj.metadata.name, "primary-maintainer", "owner-info.maintainers"],
           )
+          msg := add_support_labels.from_helm_release(parser_resp.body, msgBase)
         }

--- a/system/gatekeeper/templates/constrainttemplate-pci-forbidden-images.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-pci-forbidden-images.yaml
@@ -21,12 +21,14 @@ spec:
 
   targets:
     - target: admission.k8s.gatekeeper.sh
+      libs:
+        - |
+          {{ .Files.Get "lib/add-support-labels.rego" | nindent 10 }}
       rego: |
         package pciforbiddenimages
+        import data.lib.add_support_labels
 
         iro := input.review.object
-        iro_support_group := object.get(iro, ["metadata", "labels", "cc/support-group"], "none")
-        iro_service := object.get(iro, ["metadata", "labels", "cc/service"], "none")
 
         violation[{"msg": msg}] {
           iro.kind == "Pod"
@@ -35,8 +37,6 @@ spec:
           pattern := input.parameters.patterns[_]
           regex.match(pattern, container.image)
 
-          msg := sprintf(
-            "support-group=%s,service=%s: container %q uses forbidden image: %s",
-            [iro_support_group, iro_service, container.name, container.image]
-          )
+          msgBase := sprintf("container %q uses forbidden image: %s", [container.name, container.image])
+          msg := add_support_labels.from_k8s_object(iro, msgBase)
         }

--- a/system/gatekeeper/templates/constrainttemplate-pci-forbidden-images.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-pci-forbidden-images.yaml
@@ -30,13 +30,12 @@ spec:
 
         iro := input.review.object
 
-        violation[{"msg": msg}] {
+        violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
           iro.kind == "Pod"
           container := iro.spec.containers[_]
 
           pattern := input.parameters.patterns[_]
           regex.match(pattern, container.image)
 
-          msgBase := sprintf("container %q uses forbidden image: %s", [container.name, container.image])
-          msg := add_support_labels.from_k8s_object(iro, msgBase)
+          msg := sprintf("container %q uses forbidden image: %s", [container.name, container.image])
         }

--- a/system/gatekeeper/templates/constrainttemplate-pod-labels.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-pod-labels.yaml
@@ -17,8 +17,12 @@ spec:
 
   targets:
     - target: admission.k8s.gatekeeper.sh
+      libs:
+        - |
+          {{ .Files.Get "lib/add-support-labels.rego" | nindent 10 }}
       rego: |
         package podlabels
+        import data.lib.add_support_labels
 
         iro := input.review.object
 
@@ -59,14 +63,11 @@ spec:
 
         violation[{"msg": msg}] {
           iro.kind == "Pod"
-          labels := object.get(iro.metadata, "labels", {})
           count(pod_belongs_to) == 0 # otherwise the violation will be reported on the DaemonSet or Deployment instead
           count(missing_labels_on_pod) == 2
 
-          msg := sprintf(
-            "support-group=%s,service=%s: pod does not have either one of the required labels: %s",
-            [object.get(labels, "cc/support-group", "none"), object.get(labels, "cc/service", "none"), sort(missing_labels_on_pod)]
-          )
+          msgBase := sprintf("pod does not have either one of the required labels: %s", [sort(missing_labels_on_pod)])
+          msg := add_support_labels.from_k8s_object(iro, msgBase)
         }
 
         violation[{"msg": msg}] {
@@ -74,28 +75,26 @@ spec:
           count(pod_belongs_to) == 0 # otherwise the violation will be reported on the DaemonSet or Deployment instead
 
           labels := object.get(iro.metadata, "labels", {})
-          object.get(labels, alert_tier, "")  == "os"
+          object.get(labels, alert_tier, "") == "os"
           srv := object.get(labels, alert_service, "")
           found := {f | srv == os_services[_]; f = true}
           count(found) == 0
 
-          msg := sprintf(
-            "support-group=%s,service=%s: pod has %q label with value: os, but %q label is missing or does not have a valid value (got: %s, valid: %s)",
-            [object.get(labels, "cc/support-group", "none"), object.get(labels, "cc/service", "none"), alert_tier, alert_service, json.marshal(srv), os_services],
+          msgBase := sprintf(
+            "pod has %q label with value: os, but %q label is missing or does not have a valid value (got: %s, valid: %s)",
+            [alert_tier, alert_service, json.marshal(srv), os_services],
           )
+          msg := add_support_labels.from_k8s_object(iro, msgBase)
         }
 
         violation_owners = {"Deployment", "DaemonSet", "StatefulSet"}
 
         violation[{"msg": msg}] {
           iro.kind == violation_owners[_]
-          labels := object.get(iro.metadata, "labels", {})
           count(missing_labels_on_pod_template) == 2
 
-          msg := sprintf(
-            "support-group=%s,service=%s: pod does not have either one of the required labels: %s",
-            [object.get(labels, "cc/support-group", "none"), object.get(labels, "cc/service", "none"), sort(missing_labels_on_pod_template)]
-          )
+          msgBase := sprintf("pod does not have either one of the required labels: %s", [sort(missing_labels_on_pod_template)])
+          msg := add_support_labels.from_k8s_object(iro, msgBase)
         }
 
         violation[{"msg": msg}] {
@@ -107,8 +106,10 @@ spec:
           srv := object.get(labels, alert_service, "")
           found := {f | srv == os_services[_]; f = true}
           count(found) == 0
-          msg := sprintf(
-            "support-group=%s,service=%s: pod has %q label with value: os, but %q label is missing or does not have a valid value (got: %s, valid: %s)",
-            [object.get(labels, "cc/support-group", "none"), object.get(labels, "cc/service", "none"), alert_tier, alert_service, json.marshal(srv), os_services],
+
+          msgBase := sprintf(
+            "pod has %q label with value: os, but %q label is missing or does not have a valid value (got: %s, valid: %s)",
+            [alert_tier, alert_service, json.marshal(srv), os_services],
           )
+          msg := add_support_labels.from_k8s_object(iro.spec.template, msgBase)
         }

--- a/system/gatekeeper/templates/constrainttemplate-pod-labels.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-pod-labels.yaml
@@ -61,16 +61,15 @@ spec:
         # policy appears to be inconsistent about whether to check the support
         # labels on the outer object or on the PodSpec within.
 
-        violation[{"msg": msg}] {
+        violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
           iro.kind == "Pod"
           count(pod_belongs_to) == 0 # otherwise the violation will be reported on the DaemonSet or Deployment instead
           count(missing_labels_on_pod) == 2
 
-          msgBase := sprintf("pod does not have either one of the required labels: %s", [sort(missing_labels_on_pod)])
-          msg := add_support_labels.from_k8s_object(iro, msgBase)
+          msg := sprintf("pod does not have either one of the required labels: %s", [sort(missing_labels_on_pod)])
         }
 
-        violation[{"msg": msg}] {
+        violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
           iro.kind == "Pod"
           count(pod_belongs_to) == 0 # otherwise the violation will be reported on the DaemonSet or Deployment instead
 
@@ -80,24 +79,22 @@ spec:
           found := {f | srv == os_services[_]; f = true}
           count(found) == 0
 
-          msgBase := sprintf(
+          msg := sprintf(
             "pod has %q label with value: os, but %q label is missing or does not have a valid value (got: %s, valid: %s)",
             [alert_tier, alert_service, json.marshal(srv), os_services],
           )
-          msg := add_support_labels.from_k8s_object(iro, msgBase)
         }
 
         violation_owners = {"Deployment", "DaemonSet", "StatefulSet"}
 
-        violation[{"msg": msg}] {
+        violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
           iro.kind == violation_owners[_]
           count(missing_labels_on_pod_template) == 2
 
-          msgBase := sprintf("pod does not have either one of the required labels: %s", [sort(missing_labels_on_pod_template)])
-          msg := add_support_labels.from_k8s_object(iro, msgBase)
+          msg := sprintf("pod does not have either one of the required labels: %s", [sort(missing_labels_on_pod_template)])
         }
 
-        violation[{"msg": msg}] {
+        violation[{"msg": add_support_labels.from_k8s_object(iro.spec.template, msg)}] {
           iro.kind == violation_owners[_]
           labels := object.get(iro.spec.template.metadata, "labels", {})
 
@@ -107,9 +104,8 @@ spec:
           found := {f | srv == os_services[_]; f = true}
           count(found) == 0
 
-          msgBase := sprintf(
+          msg := sprintf(
             "pod has %q label with value: os, but %q label is missing or does not have a valid value (got: %s, valid: %s)",
             [alert_tier, alert_service, json.marshal(srv), os_services],
           )
-          msg := add_support_labels.from_k8s_object(iro.spec.template, msgBase)
         }

--- a/system/gatekeeper/templates/constrainttemplate-prometheus-scrape-annotations.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-prometheus-scrape-annotations.yaml
@@ -10,12 +10,14 @@ spec:
 
   targets:
     - target: admission.k8s.gatekeeper.sh
+      libs:
+        - |
+          {{ .Files.Get "lib/add-support-labels.rego" | nindent 10 }}
       rego: |
         package prometheusscrapeannotations
+        import data.lib.add_support_labels
 
         iro := input.review.object
-        iro_support_group := object.get(iro, ["metadata", "labels", "cc/support-group"], "none")
-        iro_service := object.get(iro, ["metadata", "labels", "cc/service"], "none")
 
         is_valid_target[target] {
           target := data.inventory.namespace[_]["monitoring.coreos.com/v1"].Prometheus[_].metadata.name
@@ -34,8 +36,9 @@ spec:
 
           all_valid_targets := {t | is_valid_target[t]}
 
-          msg := sprintf(
-            "support-group=%s,service=%s: has prometheus.io/scrape annotation, but prometheus.io/targets annotation is missing or does not have a valid value (got: %s, valid: %s)",
-            [iro_support_group, iro_service, json.marshal(sort(targets)), json.marshal(sort(all_valid_targets))],
+          msgBase := sprintf(
+            "has prometheus.io/scrape annotation, but prometheus.io/targets annotation is missing or does not have a valid value (got: %s, valid: %s)",
+            [json.marshal(sort(targets)), json.marshal(sort(all_valid_targets))],
           )
+          msg := add_support_labels.from_k8s_object(iro, msgBase)
         }

--- a/system/gatekeeper/templates/constrainttemplate-prometheus-scrape-annotations.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-prometheus-scrape-annotations.yaml
@@ -23,7 +23,7 @@ spec:
           target := data.inventory.namespace[_]["monitoring.coreos.com/v1"].Prometheus[_].metadata.name
         }
 
-        violation[{"msg": msg}] {
+        violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
           # does this object have Prometheus scraping enabled at all?
           regex.match("^(?:Service|Pod)$", iro.kind)
           anno := object.get(iro, ["metadata", "annotations"], {})
@@ -36,9 +36,8 @@ spec:
 
           all_valid_targets := {t | is_valid_target[t]}
 
-          msgBase := sprintf(
+          msg := sprintf(
             "has prometheus.io/scrape annotation, but prometheus.io/targets annotation is missing or does not have a valid value (got: %s, valid: %s)",
             [json.marshal(sort(targets)), json.marshal(sort(all_valid_targets))],
           )
-          msg := add_support_labels.from_k8s_object(iro, msgBase)
         }

--- a/system/gatekeeper/templates/constrainttemplate-prometheusrule-alert-labels.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-prometheusrule-alert-labels.yaml
@@ -28,54 +28,49 @@ spec:
           rule := group.rules[_]
         }
 
-        violation[{"msg": msg}] {
+        violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
           alert := alert_rule[_]
           # warn if we don't have a valid labels.severity
           not regex.match("^(?:critical|warning|info)$", object.get(alert.rule, ["labels", "severity"], ""))
 
-          msgBase := sprintf(
+          msg := sprintf(
             "rule %s in group %s does not have a valid value for labels.severity (\"critical\", \"warning\" or \"info\")",
             [alert.rule.alert, alert.group_name]
           )
-          msg := add_support_labels.from_k8s_object(iro, msgBase)
         }
 
-        violation[{"msg": msg}] {
+        violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
           alert := alert_rule[_]
           # warn if we don't have a labels.playbook when labels.severity == "critical"
           object.get(alert.rule, ["labels", "severity"], "") == "critical"
           object.get(alert.rule, ["labels", "playbook"], "") == ""
 
-          msgBase := sprintf(
+          msg := sprintf(
             "rule %s in group %s does not have a valid value for labels.playbook (required for critical alerts)",
             [alert.rule.alert, alert.group_name]
           )
-          msg := add_support_labels.from_k8s_object(iro, msgBase)
         }
 
-        violation[{"msg": msg}] {
+        violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
           alert := alert_rule[_]
           # warn if we don't have something in labels.tier
           not regex.match("\\S", object.get(alert.rule, ["labels", "tier"], ""))
 
-          msgBase := sprintf("rule %s in group %s does not have labels.tier", [alert.rule.alert, alert.group_name])
-          msg := add_support_labels.from_k8s_object(iro, msgBase)
+          msg := sprintf("rule %s in group %s does not have labels.tier", [alert.rule.alert, alert.group_name])
         }
 
-        violation[{"msg": msg}] {
+        violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
           alert := alert_rule[_]
           # warn if we don't have something in annotations.description
           not regex.match("\\S", object.get(alert.rule, ["annotations", "description"], ""))
 
-          msgBase := sprintf("rule %s in group %s does not have annotations.description", [alert.rule.alert, alert.group_name])
-          msg := add_support_labels.from_k8s_object(iro, msgBase)
+          msg := sprintf("rule %s in group %s does not have annotations.description", [alert.rule.alert, alert.group_name])
         }
 
-        violation[{"msg": msg}] {
+        violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
           alert := alert_rule[_]
           # warn if we don't have something in annotations.summary
           not regex.match("\\S", object.get(alert.rule, ["annotations", "summary"], ""))
 
-          msgBase := sprintf("rule %s in group %s does not have annotations.summary", [alert.rule.alert, alert.group_name])
-          msg := add_support_labels.from_k8s_object(iro, msgBase)
+          msg := sprintf("rule %s in group %s does not have annotations.summary", [alert.rule.alert, alert.group_name])
         }

--- a/system/gatekeeper/templates/constrainttemplate-prometheusrule-alert-labels.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-prometheusrule-alert-labels.yaml
@@ -10,12 +10,14 @@ spec:
 
   targets:
     - target: admission.k8s.gatekeeper.sh
+      libs:
+        - |
+          {{ .Files.Get "lib/add-support-labels.rego" | nindent 10 }}
       rego: |
         package prometheusrulealertlabels
+        import data.lib.add_support_labels
 
         iro := input.review.object
-        iro_support_group := object.get(iro, ["metadata", "labels", "cc/support-group"], "none")
-        iro_service := object.get(iro, ["metadata", "labels", "cc/service"], "none")
 
         alert_rule[{"rule": rule, "group_name": group.name}] {
           # match on all rules that are alerts
@@ -30,10 +32,12 @@ spec:
           alert := alert_rule[_]
           # warn if we don't have a valid labels.severity
           not regex.match("^(?:critical|warning|info)$", object.get(alert.rule, ["labels", "severity"], ""))
-          msg := sprintf(
-            "support-group=%s,service=%s: rule %s in group %s does not have a valid value for labels.severity (\"critical\", \"warning\" or \"info\")",
-            [iro_support_group, iro_service, alert.rule.alert, alert.group_name]
+
+          msgBase := sprintf(
+            "rule %s in group %s does not have a valid value for labels.severity (\"critical\", \"warning\" or \"info\")",
+            [alert.rule.alert, alert.group_name]
           )
+          msg := add_support_labels.from_k8s_object(iro, msgBase)
         }
 
         violation[{"msg": msg}] {
@@ -41,38 +45,37 @@ spec:
           # warn if we don't have a labels.playbook when labels.severity == "critical"
           object.get(alert.rule, ["labels", "severity"], "") == "critical"
           object.get(alert.rule, ["labels", "playbook"], "") == ""
-          msg := sprintf(
-            "support-group=%s,service=%s: rule %s in group %s does not have a valid value for labels.playbook (required for critical alerts)",
-            [iro_support_group, iro_service, alert.rule.alert, alert.group_name]
+
+          msgBase := sprintf(
+            "rule %s in group %s does not have a valid value for labels.playbook (required for critical alerts)",
+            [alert.rule.alert, alert.group_name]
           )
+          msg := add_support_labels.from_k8s_object(iro, msgBase)
         }
 
         violation[{"msg": msg}] {
           alert := alert_rule[_]
           # warn if we don't have something in labels.tier
           not regex.match("\\S", object.get(alert.rule, ["labels", "tier"], ""))
-          msg := sprintf(
-            "support-group=%s,service=%s: rule %s in group %s does not have labels.tier",
-            [iro_support_group, iro_service, alert.rule.alert, alert.group_name]
-          )
+
+          msgBase := sprintf("rule %s in group %s does not have labels.tier", [alert.rule.alert, alert.group_name])
+          msg := add_support_labels.from_k8s_object(iro, msgBase)
         }
 
         violation[{"msg": msg}] {
           alert := alert_rule[_]
           # warn if we don't have something in annotations.description
           not regex.match("\\S", object.get(alert.rule, ["annotations", "description"], ""))
-          msg := sprintf(
-            "support-group=%s,service=%s: rule %s in group %s does not have annotations.description",
-            [iro_support_group, iro_service, alert.rule.alert, alert.group_name]
-          )
+
+          msgBase := sprintf("rule %s in group %s does not have annotations.description", [alert.rule.alert, alert.group_name])
+          msg := add_support_labels.from_k8s_object(iro, msgBase)
         }
 
         violation[{"msg": msg}] {
           alert := alert_rule[_]
           # warn if we don't have something in annotations.summary
           not regex.match("\\S", object.get(alert.rule, ["annotations", "summary"], ""))
-          msg := sprintf(
-            "support-group=%s,service=%s: rule %s in group %s does not have annotations.summary",
-            [iro_support_group, iro_service, alert.rule.alert, alert.group_name]
-          )
+
+          msgBase := sprintf("rule %s in group %s does not have annotations.summary", [alert.rule.alert, alert.group_name])
+          msg := add_support_labels.from_k8s_object(iro, msgBase)
         }

--- a/system/gatekeeper/templates/constrainttemplate-region-value-missing.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-region-value-missing.yaml
@@ -20,13 +20,18 @@ spec:
       libs:
         - |
           {{ .Files.Get "lib/add-support-labels.rego" | nindent 10 }}
+        - |
+          {{ .Files.Get "lib/helm-release.rego" | nindent 10 }}
       rego: |
         package gkregionvaluemissing
         import data.lib.add_support_labels
+        import data.lib.helm_release
 
         iro := input.review.object
-        parser_url := sprintf("%s/v3", [input.parameters.helmManifestParserURL])
-        parser_resp := http.send({"url": parser_url, "method": "POST", "raise_error": false, "raw_body": iro.data.release, "timeout": "15s"})
+        release := helm_release.parse_k8s_object(iro, input.parameters.helmManifestParserURL)
+        violation[{"msg": release.error}] {
+          release.error != ""
+        }
 
         is_region_name(region) = false {
           not is_string(region)
@@ -37,19 +42,9 @@ spec:
         }
 
         violation[{"msg": msg}] {
-          iro.kind == "Secret"
-          iro.type == "helm.sh/release.v1"
-          iro.metadata.labels.status == "deployed"
-
-          parser_resp.status_code == 200
-          not is_region_name(object.get(parser_resp.body, ["values", "global", "region"], ""))
+          release.error == ""
+          not is_region_name(object.get(release, ["values", "global", "region"], ""))
 
           msgBase := "missing or invalid .Values.global.region value"
-          msg := add_support_labels.from_helm_release(parser_resp.body, msgBase)
-        }
-
-        violation[{"msg": msg}] {
-          parser_resp.status_code != 200
-
-          msg := "helm-manifest-parser did not return HTTP status 200. Please retry in ~5 minutes."
+          msg := add_support_labels.from_helm_release(release, msgBase)
         }

--- a/system/gatekeeper/templates/constrainttemplate-region-value-missing.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-region-value-missing.yaml
@@ -41,10 +41,9 @@ spec:
           result := regex.match("^[a-z][a-z]-[a-z][a-z]-[0-9]$", region)
         }
 
-        violation[{"msg": msg}] {
+        violation[{"msg": add_support_labels.from_helm_release(release, msg)}] {
           release.error == ""
           not is_region_name(object.get(release, ["values", "global", "region"], ""))
 
-          msgBase := "missing or invalid .Values.global.region value"
-          msg := add_support_labels.from_helm_release(release, msgBase)
+          msg := "missing or invalid .Values.global.region value"
         }

--- a/system/gatekeeper/templates/constrainttemplate-region-value-missing.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-region-value-missing.yaml
@@ -17,8 +17,12 @@ spec:
 
   targets:
     - target: admission.k8s.gatekeeper.sh
+      libs:
+        - |
+          {{ .Files.Get "lib/add-support-labels.rego" | nindent 10 }}
       rego: |
         package gkregionvaluemissing
+        import data.lib.add_support_labels
 
         iro := input.review.object
         parser_url := sprintf("%s/v3", [input.parameters.helmManifestParserURL])
@@ -40,11 +44,8 @@ spec:
           parser_resp.status_code == 200
           not is_region_name(object.get(parser_resp.body, ["values", "global", "region"], ""))
 
-          owner_info := object.get(parser_resp.body, ["values", "owner-info"], {})
-          msg := sprintf(
-            "support-group=%s,service=%s: missing or invalid .Values.global.region value",
-            [object.get(owner_info, "support-group", "none"), object.get(owner_info, "service", "none")]
-          )
+          msgBase := "missing or invalid .Values.global.region value"
+          msg := add_support_labels.from_helm_release(parser_resp.body, msgBase)
         }
 
         violation[{"msg": msg}] {

--- a/system/gatekeeper/templates/constrainttemplate-resource-limits.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-resource-limits.yaml
@@ -50,17 +50,17 @@ spec:
           kind == pod_owners[_]
         }
 
-        violation[{"msg": msg}] {
+        violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
           iro.kind == "Pod"
           count(pod_belongs_to) == 0 # otherwise the violation will be reported on the DaemonSet or Deployment
           count(missing_limits_on_pod) > 0
-          msg := add_support_labels.from_k8s_object(iro, "cpu and memory limits not set on some or all containers")
+          msg := "cpu and memory limits not set on some or all containers"
         }
 
         violation_owners = {"Deployment", "DaemonSet", "StatefulSet"}
 
-        violation[{"msg": msg}] {
+        violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
           iro.kind == violation_owners[_]
           count(missing_limits_on_pod_template) > 0
-          msg := add_support_labels.from_k8s_object(iro, "cpu and memory limits not set on some or all containers")
+          msg := "cpu and memory limits not set on some or all containers"
         }

--- a/system/gatekeeper/templates/constrainttemplate-resource-limits.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-resource-limits.yaml
@@ -10,12 +10,14 @@ spec:
 
   targets:
     - target: admission.k8s.gatekeeper.sh
+      libs:
+        - |
+          {{ .Files.Get "lib/add-support-labels.rego" | nindent 10 }}
       rego: |
         package resourcelimits
+        import data.lib.add_support_labels
 
         iro := input.review.object
-        iro_support_group := object.get(iro, ["metadata", "labels", "cc/support-group"], "none")
-        iro_service := object.get(iro, ["metadata", "labels", "cc/service"], "none")
 
         # We have such a bafflingly large amount of violations that
         # Gatekeeper cannot report them all at once. I'd rather have
@@ -52,10 +54,7 @@ spec:
           iro.kind == "Pod"
           count(pod_belongs_to) == 0 # otherwise the violation will be reported on the DaemonSet or Deployment
           count(missing_limits_on_pod) > 0
-          msg := sprintf(
-            "support-group=%s,service=%s: cpu and memory limits not set on some or all containers",
-            [iro_support_group, iro_service]
-          )
+          msg := add_support_labels.from_k8s_object(iro, "cpu and memory limits not set on some or all containers")
         }
 
         violation_owners = {"Deployment", "DaemonSet", "StatefulSet"}
@@ -63,8 +62,5 @@ spec:
         violation[{"msg": msg}] {
           iro.kind == violation_owners[_]
           count(missing_limits_on_pod_template) > 0
-          msg := sprintf(
-            "support-group=%s,service=%s: cpu and memory limits not set on some or all containers",
-            [iro_support_group, iro_service]
-          )
+          msg := add_support_labels.from_k8s_object(iro, "cpu and memory limits not set on some or all containers")
         }

--- a/system/gatekeeper/templates/constrainttemplate-vulnerable-images.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-vulnerable-images.yaml
@@ -53,7 +53,7 @@ spec:
           msg := "doop-image-parser did not return HTTP status 200. Please retry in ~5 minutes."
         }
 
-        violation[{"msg": msg}] {
+        violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
           check := checks[_]
           check.response.status_code == 200
           status := trim_space(object.get(check.response.body, "X-Keppel-Vulnerability-Status", "Unclear"))
@@ -62,9 +62,8 @@ spec:
           status != "Clean"
           status != "Unknown"
 
-          msgBase := sprintf(
+          msg := sprintf(
             "image %s for container %q has vulnerability status %q",
             [check.container.image, check.container.name, status]
           )
-          msg := add_support_labels.from_k8s_object(iro, msgBase)
         }

--- a/system/gatekeeper/templates/constrainttemplate-vulnerable-images.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-vulnerable-images.yaml
@@ -24,12 +24,14 @@ spec:
 
   targets:
     - target: admission.k8s.gatekeeper.sh
+      libs:
+        - |
+          {{ .Files.Get "lib/add-support-labels.rego" | nindent 10 }}
       rego: |
         package vulnerableimages
+        import data.lib.add_support_labels
 
         iro := input.review.object
-        iro_support_group := object.get(iro, ["metadata", "labels", "cc/support-group"], "none")
-        iro_service := object.get(iro, ["metadata", "labels", "cc/service"], "none")
 
         checks[{ "container": container, "response": resp }] {
           iro.kind == "Pod"
@@ -59,8 +61,10 @@ spec:
           # report everything with a definite vulnerability
           status != "Clean"
           status != "Unknown"
-          msg := sprintf(
-            "support-group=%s,service=%s: image %s for container %q has vulnerability status %q",
-            [iro_support_group, iro_service, check.container.image, check.container.name, status]
+
+          msgBase := sprintf(
+            "image %s for container %q has vulnerability status %q",
+            [check.container.image, check.container.name, status]
           )
+          msg := add_support_labels.from_k8s_object(iro, msgBase)
         }

--- a/system/gatekeeper/tests/run.sh
+++ b/system/gatekeeper/tests/run.sh
@@ -14,13 +14,13 @@ trap "kill $pid_helm_manifest_parser $pid_doop_image_checker" INT TERM ERR EXIT
 
 (
   cd ..
-  ${HELM} dep up >/dev/null
+  [[ ! -d charts ]] && ${HELM} dep up >/dev/null
   ${HELM} template gatekeeper . --values ci/test-values.yaml --output-dir tests/rendered-chart >/dev/null
 )
 
 (
   cd ../../gatekeeper-config
-  ${HELM} dep up >/dev/null
+  [[ ! -d charts ]] && ${HELM} dep up >/dev/null
   ${HELM} template gatekeeper-config . --values ci/test-values.yaml --output-dir ../gatekeeper/tests/rendered-chart >/dev/null
 )
 


### PR DESCRIPTION
This serves as a proposal for how we may structure Rego library modules in this chart going forward.

- [x] new library method: `add_support_labels.from_k8s_object()`
- [x] new library method: `add_support_labels.from_helm_release()`

*Update:* In order to gauge how much we can do in library modules, I also moved the helm-manifest-parser calls into a module.

- [x] new library method: `helm_release.parse_k8s_object()`