### PR TITLE
[barbican] audit map exclude payload member for secrets endpoint

### DIFF
--- a/openstack/barbican/templates/etc/_barbican_audit_map.yaml
+++ b/openstack/barbican/templates/etc/_barbican_audit_map.yaml
@@ -6,8 +6,10 @@ prefix: '/v1'
 resources:
   secrets:
     payloads:
-      # Never record sercets payloads from barbican.
-      enabled: false
+      # Payload can include sensitive info
+      exclude:
+        - payload
+
     custom_id: secret_ref
     children:
       metadata:


### PR DESCRIPTION
@rajivmucheli here is the change requested from Anton. Please approve, then we can merge, deploy, and test. Thanks!