### PR TITLE
[kube-system-admin-k3s] ingress-cacrt added

### DIFF
--- a/system/kube-system-admin-k3s/Chart.yaml
+++ b/system/kube-system-admin-k3s/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kube-System relevant Service collection for the new admin clusters.
 name: kube-system-admin-k3s
-version: 1.0.18
+version: 1.0.19
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-admin-k3s
 dependencies:
   - name: disco

--- a/system/kube-system-admin-k3s/templates/ingress-cacrt-secret.yaml
+++ b/system/kube-system-admin-k3s/templates/ingress-cacrt-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+type: Opaque
+
+metadata:
+  name: ingress-cacrt
+
+data:
+  ca.crt: {{ required ".Values.ingress.tls_client_auth.cacrt" .Values.ingress.tls_client_auth.cacrt | b64enc | quote }}

--- a/system/kube-system-admin-k3s/values.yaml
+++ b/system/kube-system-admin-k3s/values.yaml
@@ -7,6 +7,10 @@ disco:
     create: true
     serviceAccountName: disco
 
+ingress:
+  tls_client_auth:
+    ca_cert:
+
 traefik:
   ingressRoute:
     dashboard:


### PR DESCRIPTION
Multiple Ingresses are annotated with `ingress.kubernetes.io/auth-tls-secret: kube-system/ingress-cacrt` but there is no secret `ingress-cacrt` deployed in admin-k3s cluster. This leads to TLS errors in the ingress controller `kube-system-traefik`.