### PR TITLE
[kube-system-admin-k3s] allowCrossNameSpace for IngressRoute CRD

### DIFF
--- a/system/kube-system-admin-k3s/Chart.yaml
+++ b/system/kube-system-admin-k3s/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kube-System relevant Service collection for the new admin clusters.
 name: kube-system-admin-k3s
-version: 1.0.19
+version: 1.0.20
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-admin-k3s
 dependencies:
   - name: disco

--- a/system/kube-system-admin-k3s/values.yaml
+++ b/system/kube-system-admin-k3s/values.yaml
@@ -16,7 +16,9 @@ traefik:
     dashboard:
       enabled: false
   providers:
-    kubernetesCRD: {}
+    kubernetesCRD:
+      enabled: true
+      allowCrossNamespace: true
     kubernetesIngress: {}
   ports:
     web:


### PR DESCRIPTION
By using the Traefik TLSOption resource in Kubernetes, we setup a default set of options that should apply to all ingresses. To achieve that, we created a TLSOption resource with the name default. There may exist only one TLSOption with the name default (across all namespaces) - otherwise they will be dropped. To explicitly use this TLSOption (and using the Kubernetes Ingress resources) we'll have to allow IngressRoute to reference resources in namespaces other than theirs.

https://doc.traefik.io/traefik/routing/providers/kubernetes-crd/#serverstransport-reference