### PR TITLE
[cronus]: add an ability to set GODEBUG env variable

### DIFF
--- a/openstack/cronus/templates/cronus/deployment.yaml
+++ b/openstack/cronus/templates/cronus/deployment.yaml
@@ -42,6 +42,9 @@ spec:
           imagePullPolicy: {{ .Values.cronus.image.pullPolicy }}
           args:
             - "-config=/cronus/config.yaml"
+          env:
+          - name: GODEBUG
+            value: {{ .Values.cronus.godebug | quote }}
           volumeMounts:
             - name: cronus
               mountPath: "/cronus/config.yaml"

--- a/openstack/cronus/templates/cronus/statefulset.yaml
+++ b/openstack/cronus/templates/cronus/statefulset.yaml
@@ -39,6 +39,9 @@ spec:
           imagePullPolicy: {{ .Values.cronus.image.pullPolicy }}
           args:
             - "-config=/cronus/config.yaml"
+          env:
+          - name: GODEBUG
+            value: {{ .Values.cronus.godebug | quote }}
           volumeMounts:
             - name: cronus
               mountPath: "/cronus/config.yaml"

--- a/openstack/cronus/values.yaml
+++ b/openstack/cronus/values.yaml
@@ -49,6 +49,7 @@ cronus:
       LvHPhNDM3rMsLu06agF4JTbO8ANYtWQTx0PVrZKJu+8fcIaUp7MVBIVZ
       -----END CERTIFICATE-----
   debug: true
+  godebug: netdns=cgo
   image:
     name: cronus-repository
     pullPolicy: IfNotPresent


### PR DESCRIPTION
This will give a flexibility to switch between CGO and GO resolvers.