### PR TITLE
Nova: Add a secret per cell

### DIFF
--- a/openstack/nova/templates/_cell_secret.yaml.tpl
+++ b/openstack/nova/templates/_cell_secret.yaml.tpl
@@ -1,0 +1,20 @@
+{{- define "nova.cell_secret" }}
+{{- $name := index . 1 }}
+{{- $transport_url := index . 2 }}
+{{- $database_connection := index . 3 }}
+{{- with index . 0 }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nova-cell-{{ $name }}
+  labels:
+    system: openstack
+    type: nova-cell
+    component: nova
+type: Opaque
+data: 
+  name: {{ $name | b64enc }}
+  database_connection: {{ $database_connection | b64enc }}
+  transport_url: {{ $transport_url | b64enc }}
+{{- end }}
+{{- end }}

--- a/openstack/nova/templates/cells-secrets.yaml
+++ b/openstack/nova/templates/cells-secrets.yaml
@@ -1,0 +1,8 @@
+{{- $envAll := . }}
+{{- $transport_url := tuple . .Values.rabbitmq | include "rabbitmq._transport_url" }}
+{{- $database_connection := tuple . .Values.dbName .Values.dbUser (default .Values.dbPassword .Values.global.dbPassword) | include "db_url_mysql" }}
+{{ tuple $envAll "cell1" $transport_url $database_connection | include "nova.cell_secret" }}
+{{- if .Values.cell2.enabled }}
+---
+{{ tuple $envAll .Values.cell2.name (include "cell2_transport_url" .) (include "cell2_db_path" .) | include "nova.cell_secret" }}
+{{- end }}


### PR DESCRIPTION
With the Xena upgrade, we lose the API endpoint os-cells as cells v1 are
getting removed. We had previously extended that endpoint to let the
vcenter-operator retrieve connection information per cell and expose
these to its templates for configured nova-compute-bb* into the right
cell.

Our new approach is to expose the same information as k8s Secret per
cell, identified by the appropriate labels. The information is basically
the same, only lacking information about the UUID of the cell, as that's
a Nova-runtime-internal and not a configurable.