### PR TITLE
[octavia] Fix migration job wrt. proxysql

### DIFF
--- a/openstack/octavia/templates/_helpers.tpl
+++ b/openstack/octavia/templates/_helpers.tpl
@@ -33,5 +33,5 @@ Create chart name and version as used by the chart label.
 
 
 {{- define "octavia.migration_job_name" -}}
-octavia-migration-{{ .Values.imageVersion }}{{- if .Values.proxysql.mode }}-{{ .Values.proxysql.mode | replace "_" "-" }}{{ end }}
+octavia-migration-{{ .Values.imageVersion }}-{{- if .Values.proxysql.mode }}{{ .Values.proxysql.mode | replace "_" "-" }}{{ else }}noproxysql{{ end }}
 {{- end }}

--- a/openstack/octavia/templates/octavia-migration-job.yaml
+++ b/openstack/octavia/templates/octavia-migration-job.yaml
@@ -39,8 +39,9 @@ spec:
             - bash
             - -c
             - |
-              trap "{{ include "utils.proxysql.proxysql_signal_stop_script" . | trim }}" EXIT
+              set -euo pipefail
               octavia-db-manage upgrade head
+              {{ include "utils.proxysql.proxysql_signal_stop_script" . | trim }}
           env:
             {{- if .Values.sentry.enabled }}
             - name: SENTRY_DSN


### PR DESCRIPTION
The job spec changed, so the name has to changed irregardless
if we enable proxysql or not to avoid an error in the helm deployment
(The spec of an existing job cannot be changed)

Also stop the proxysql sidecar only if the upgrade was successful