### PR TITLE
[common/mariadb] Use backup-user with connection limit

### DIFF
--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.5.5
+version: 0.6.0

--- a/common/mariadb/templates/backup-etc-configmap.yaml
+++ b/common/mariadb/templates/backup-etc-configmap.yaml
@@ -26,16 +26,16 @@ data:
         redirect_url: "https://{{ .Values.name }}.mariabackup.{{ .Values.global.region }}.cloud.sap"
     database:
       type: "mariadb"
-      user: root
+      user: {{ .Values.users.backup.name | required ".Values.users.backup.name is required" }}
       version: {{ .Values.backup_v2.maria_db.version }}
-      password: {{ include "mariadb.root_password" . }}
+      password: {{ .Values.users.backup.password | required ".Values.users.backup.password is required" }}
       host: {{ include "fullName" . }}
       port: 3306
       server_id: 999
       data_dir: /var/lib/mysql
       log_name_format: mysqld-bin
       databases:
-      {{- range $db := .Values.backup_v2.databases }}
+      {{- range $db := coalesce .Values.backup_v2.databases .Values.databases (list .Values.name) }}
         - "{{$db}}"
       {{- end }}
       verify_tables:

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -27,6 +27,11 @@ custom_initdb_configmap: null
 databases:
 # - example
 users:
+  backup:
+    name: backup
+    password: null
+    limits:
+      max_user_connections: 4
 #  example:
 #    name: example1 # This looks repetitive, but the point is that they key is the name
 #                   # you refer to in your charts, while the field 'name' is the actual name


### PR DESCRIPTION
Instead of using the root-user, use a dedicated user with
its own connection limit in order to isolate the
backup process from the main application