### PR TITLE
[alertmanager] gcp instance moves in datacenter

### DIFF
--- a/global/prometheus-alertmanager-operated/Chart.yaml
+++ b/global/prometheus-alertmanager-operated/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 description: Prometheus Alertmanager via operator.
 name: prometheus-alertmanager-operated
-version: 2.1.0
+version: 2.1.1
 
 dependencies:
   - alias: prometheus-alertmanager


### PR DESCRIPTION
bump version to get the new kube-secrets