### PR TITLE
[nova] Change API unexpected exception message

### DIFF
--- a/openstack/nova/templates/api-deployment.yaml
+++ b/openstack/nova/templates/api-deployment.yaml
@@ -144,6 +144,10 @@ spec:
               name: nova-etc
               subPath: api-metadata.filters
               readOnly: true
+            - mountPath: /etc/nova/release
+              name: nova-etc
+              subPath: release
+              readOnly: true
             - mountPath: /var/lib/kolla/venv/bin/iptables-restore
               name: nova-bin
               subPath: iptables-restore.mock

--- a/openstack/nova/templates/etc-configmap.yaml
+++ b/openstack/nova/templates/etc-configmap.yaml
@@ -65,3 +65,7 @@ data:
       labels:
         method: "$1"
         type: "$2"
+  release: |
+    [Nova]
+    vendor = SAP
+    support = If the issue persists, please contact us via https://documentation.global.cloud.sap/docs/support-contact-us


### PR DESCRIPTION
With Xena, we're easily able to configure the "API unexpected exception"
message by setting the "support" config option in the "release" file [0]. We
do this here and point to the "Contact Us" site of our documentation
instead of upstream's bug tracker.

We only have to do this for the nova-api Deployment, because that's the
only user-facing site. nova-api-metadata is called through Neutron and
shouldn't forward the messages of Nova directly.

[0] https://github.com/sapcc/nova/blob/b0efa22cd37073d49519ddff02bdb69e5df4d5a7/nova/version.py#L62-L63