### PR TITLE
[openstack-exporter] rename image.tag to imageVersion

### DIFF
--- a/prometheus-exporters/openstack-exporter/ci/test-values.yaml
+++ b/prometheus-exporters/openstack-exporter/ci/test-values.yaml
@@ -1,0 +1,8 @@
+global:
+  openstack_exporter_master_password: test
+  region: test-de-1
+  registry: registry.host
+openstack:
+  imageVersion: 1
+  alerts:
+    prometheus: alert

--- a/prometheus-exporters/openstack-exporter/templates/openstack-exporter-deployment.yaml
+++ b/prometheus-exporters/openstack-exporter/templates/openstack-exporter-deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
          - name: openstack-exporter
-           image: {{ required ".Values.global.registry missing" .Values.global.registry }}/{{ required ".Values.openstack.image.name missing" .Values.openstack.image.name }}:{{ required ".Values.openstack.image.tag missing" .Values.openstack.image.tag  }}
+           image: {{ required ".Values.global.registry missing" .Values.global.registry }}/{{ required ".Values.openstack.imageName missing" .Values.openstack.imageName }}:{{ required ".Values.openstack.imageVersion missing" .Values.openstack.imageVersion  }}
            ports:
              - name: metrics
                containerPort: {{ required ".Values.exporter.prometheus_port missing" .Values.exporter.prometheus_port }}

--- a/prometheus-exporters/openstack-exporter/values.yaml
+++ b/prometheus-exporters/openstack-exporter/values.yaml
@@ -8,12 +8,11 @@ exporter:
   log_level: "DEBUG"
 openstack:
   enabled: false
-  image:
-    name: openstack-exporter
-    tag: DEFINED-IN-REGION-SECRETS
+  imageName: openstack-exporter
+  # imageVersion:
   alerts:
     enabled: false
-    prometheus: DEFINED-IN-REGION-SECRETS
+    # prometheus: {}
   limits:
     memory: 200Mi
     cpu: 300m
@@ -24,7 +23,7 @@ openstack:
   user_domain_name: Default
   project_domain_name: ccadmin
   project_name: cloud_admin
-global:
-  region: DEFINED-IN-REGION-SECRETS
-  openstack_exporter_master_password: DEFINED-IN-REGION-SECRETS
-  registry: DEFINED-IN-REGION-SECRETS
+global: {}
+  # region:
+  # openstack_exporter_master_password:
+  # registry:


### PR DESCRIPTION
For the CI to work properly, the version needs to be specified
inside a property that contains `imageVersion` in its name.