### PR TITLE
[ci-lint-chart] Run linter as non-root user

### DIFF
--- a/ci/lint-chart.sh
+++ b/ci/lint-chart.sh
@@ -7,7 +7,7 @@ if [ ! -f "$HELM_CHARTS/$1/Chart.yaml" ]; then
   exit 1
 fi
 
-docker run --rm -v $HELM_CHARTS:/charts -w /charts sapcc/chart-testing:v3.0.0-rc.1-sapcc  ct lint \
-  --chart-yaml-schema ci/chart_schema.yaml \
-  --lint-conf ci/lintconf.yaml \
-  --config ci/config.yaml --charts $1
+docker run \
+  --rm --network host --env HOME=/tmp --user $(id -u):$(id -g) -v $HELM_CHARTS:/charts -w /charts \
+  sapcc/chart-testing:v3.0.0-rc.1-sapcc ct lint \
+  --chart-yaml-schema ci/chart_schema.yaml --lint-conf ci/lintconf.yaml --config ci/config.yaml --charts $1


### PR DESCRIPTION
While in general it is a good practice to avoid running
processes as root unless necessary, the main
gain of doing so here is that it won't place
files as the root user in the local chart
directory.

The script can be run by any user,
but then the user ends up with files
owned by root in their own directory.

Running it with the callers user
gives us downloaded charts owned
by the same user