### PR TITLE
gatekeeper: move doop-image-checker invocation to a lib module (WIP)

### DIFF
--- a/system/gatekeeper-config/templates/_utils.tpl
+++ b/system/gatekeeper-config/templates/_utils.tpl
@@ -11,3 +11,10 @@ labelSelector:
          superseded by a newer release. */}}
     - { key: "status", operator: "In", values: [ "pending-upgrade", "deployed" ]}
 {{- end -}}
+
+{{/* This match expression is only for checks that need to see the "status" section of the Pod. */}}
+{{- define "match_pods_only" }}
+kinds:
+  - apiGroups: [""]
+    kinds: ["Pod"]
+{{- end -}}

--- a/system/gatekeeper-config/templates/constraint-outdated-image-bases.yaml
+++ b/system/gatekeeper-config/templates/constraint-outdated-image-bases.yaml
@@ -6,9 +6,6 @@ metadata:
     on-prod-ui: 'true'
 spec:
   enforcementAction: dryrun # change to "deny" to enforce
-  match:
-    kinds:
-      - apiGroups: [""]
-        kinds: ["Pod"]
+  match: {{ include "match_pods_only" . | indent 4 }}
   parameters:
     doopImageCheckerURL: {{ quote .Values.doop_image_checker_url }}

--- a/system/gatekeeper-config/templates/constraint-vulnerable-images.yaml
+++ b/system/gatekeeper-config/templates/constraint-vulnerable-images.yaml
@@ -13,9 +13,6 @@ metadata:
     on-prod-ui: 'true'
 spec:
   enforcementAction: dryrun # change to "deny" to enforce
-  match:
-    kinds:
-      - apiGroups: [""]
-        kinds: ["Pod"]
+  match: {{ include "match_pods_only" . | indent 4 }}
   parameters:
     doopImageCheckerURL: {{ quote .Values.doop_image_checker_url }}

--- a/system/gatekeeper/lib/image-check.rego
+++ b/system/gatekeeper/lib/image-check.rego
@@ -1,0 +1,84 @@
+package lib.image_check
+
+# The public interface is the function for_pod(pod, baseURL). `pod` must be a
+# Pod object. `baseURL` is where doop-image-checker is running. This usually
+# comes from the policy's `input.parameters`.
+#
+# This function inspects the ContainerStatus of all containers and init
+# containers in this Pod by calling doop-image-checker. The response is a list
+# of check results.
+#
+# A failing check returns an object with only the field "error". This error
+# message must be converted into a violation by the calling policy. (This step
+# is something that we cannot do in a library module.)
+#
+# A successful check returns an object with the following fields:
+# - "containerName", "containerImage", "containerImageID" (values copied from `container`)
+# - "error" (empty string; having this simplifies error checks in the calling policy)
+# - "headers" (the parsed response body from doop-image-checker)
+
+for_pod(pod, baseURL) = result {
+  pod.kind != "Pod"
+  result = {}
+}
+for_pod(pod, baseURL) = result {
+  pod.kind == "Pod"
+
+  containerStatuses := array.concat(
+    object.get(pod, ["status", "containerStatuses"], []),
+    object.get(pod, ["status", "initContainerStatuses"], []),
+  )
+  result = [ __run_check(c, baseURL) | c := containerStatuses[_] ]
+}
+
+################################################################################
+# private helper functions
+
+__run_check(container, baseURL) = result {
+  not regex.match("^keppel\\.", container.image)
+
+  # For images not in Keppel, we return a synthetic result that does not generate
+  # any additional violations. Elsewhere, we have policies that complain about
+  # non-Keppel images in general, so we don't need to double-report this.
+  nowAsUnixTime := time.now_ns() / 1000000000
+  result = {
+    "error": "",
+    "containerName": container.name,
+    "containerImage": container.image,
+    "containerImageID": container.imageID,
+    "headers": {
+      "X-Keppel-Min-Layer-Created-At": format_int(nowAsUnixTime, 10),
+      "X-Keppel-Vulnerability-Status": "Clean",
+    },
+  }
+}
+__run_check(container, baseURL) = result {
+  regex.match("^keppel\\.", container.image)
+
+  imgID := trim_prefix(container.imageID, "docker-pullable://")
+  url := sprintf("%s/v1/headers?image=%s", [baseURL, imgID])
+  resp := http.send({"url": url, "method": "GET", "raise_error": false, "timeout": "15s"})
+  result = __parse_response(container, resp)
+}
+
+__parse_response(container, resp) = result {
+  resp.status_code == 200
+  result := {
+    "error": "",
+    "containerName": container.name,
+    "containerImage": container.image,
+    "containerImageID": container.imageID,
+    "headers": resp.body,
+  }
+}
+__parse_response(container, resp) = result {
+  resp.status_code != 200
+  object.get(resp, ["error", "message"], "") == ""
+  result := { "error": sprintf("doop-image-checker returned HTTP status %d, but we expected 200. Please retry in ~5 minutes.", [resp.status_code]) }
+}
+__parse_response(container, resp) = result {
+  resp.status_code != 200
+  msg := object.get(resp, ["error", "message"], "")
+  msg != ""
+  result := { "error": sprintf("Could not reach doop-image-checker (%q). Please retry in ~5 minutes.", [msg]) }
+}

--- a/system/gatekeeper/templates/constrainttemplate-outdated-image-bases.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-outdated-image-bases.yaml
@@ -20,37 +20,25 @@ spec:
       libs:
         - |
           {{ .Files.Get "lib/add-support-labels.rego" | nindent 10 }}
+        - |
+          {{ .Files.Get "lib/image-check.rego" | nindent 10 }}
       rego: |
         package outdatedimagebases
         import data.lib.add_support_labels
+        import data.lib.image_check
 
         iro := input.review.object
+        checks := image_check.for_pod(iro, input.parameters.doopImageCheckerURL)
 
-        # check each pod container
-        checks[{ "container": container, "response": resp }] {
-          iro.kind == "Pod"
-          container := iro.status.containerStatuses[_]
-
-          # only consider images stored in Keppel since we want to inspect the X-Keppel-Min-Layer-Created-At header
-          regex.match("^keppel", container.image)
-
-          # query vulnerability status through helper API
-          imgID := trim_prefix(container.imageID, "docker-pullable://")
-          url := sprintf("%s/v1/headers?image=%s", [input.parameters.doopImageCheckerURL, imgID])
-          resp := http.send({"url": url, "method": "GET", "raise_error": false, "timeout": "10s"})
-        }
-
-        violation[{"msg": msg}] {
+        violation[{"msg": check.result.error}] {
           check := checks[_]
-          check.response.status_code != 200
-
-          msg := "doop-image-parser did not return HTTP status 200. Please retry in ~5 minutes."
+          check.error != ""
         }
 
         violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
           check := checks[_]
-          check.response.status_code == 200
-          createdAtAsUnixTime := to_number(trim_space(object.get(check.response.body, "X-Keppel-Min-Layer-Created-At", "Unclear")))
+          check.error == ""
+          createdAtAsUnixTime := to_number(trim_space(object.get(check.headers, "X-Keppel-Min-Layer-Created-At", "Unclear")))
 
           # complain if it's older than one year
           nowAsUnixTime := time.now_ns() / 1000000000
@@ -60,6 +48,6 @@ spec:
 
           msg := sprintf(
             "image %s for container %q uses a very old base image (oldest layer is %.0f days old)",
-            [check.container.image, check.container.name, ageInDays]
+            [check.containerImage, check.containerName, ageInDays]
           )
         }

--- a/system/gatekeeper/templates/constrainttemplate-vulnerable-images.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-vulnerable-images.yaml
@@ -27,36 +27,25 @@ spec:
       libs:
         - |
           {{ .Files.Get "lib/add-support-labels.rego" | nindent 10 }}
+        - |
+          {{ .Files.Get "lib/image-check.rego" | nindent 10 }}
       rego: |
         package vulnerableimages
         import data.lib.add_support_labels
+        import data.lib.image_check
 
         iro := input.review.object
+        checks := image_check.for_pod(iro, input.parameters.doopImageCheckerURL)
 
-        checks[{ "container": container, "response": resp }] {
-          iro.kind == "Pod"
-          container := iro.status.containerStatuses[_]
-
-          # only consider images stored in Keppel since we want to inspect the X-Keppel-Vulnerability-Status header
-          regex.match("^keppel", container.image)
-
-          # query vulnerability status through helper API
-          imgID := trim_prefix(container.imageID, "docker-pullable://")
-          url := sprintf("%s/v1/headers?image=%s", [input.parameters.doopImageCheckerURL, imgID])
-          resp := http.send({"url": url, "method": "GET", "raise_error": false, "timeout": "10s"})
-        }
-
-        violation[{"msg": msg}] {
+        violation[{"msg": check.result.error}] {
           check := checks[_]
-          check.response.status_code != 200
-
-          msg := "doop-image-parser did not return HTTP status 200. Please retry in ~5 minutes."
+          check.error != ""
         }
 
         violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
           check := checks[_]
-          check.response.status_code == 200
-          status := trim_space(object.get(check.response.body, "X-Keppel-Vulnerability-Status", "Unclear"))
+          check.error == ""
+          status := trim_space(object.get(check.headers, "X-Keppel-Vulnerability-Status", "Unclear"))
 
           # report everything with a definite vulnerability
           status != "Clean"
@@ -64,6 +53,6 @@ spec:
 
           msg := sprintf(
             "image %s for container %q has vulnerability status %q",
-            [check.container.image, check.container.name, status]
+            [check.containerImage, check.containerName, status]
           )
         }


### PR DESCRIPTION
The structure of the new lib module mostly follows the helm-manifest-parser helper module that already exists. I'm also using the opportunity to make an improvement by covering init containers in addition to regular containers. This is WIP because I need to add test coverage for init containers.