### PR TITLE
gatekeeper: add "traversal" lib module for finding pod and container specs

### DIFF
--- a/system/gatekeeper-config/templates/_utils.tpl
+++ b/system/gatekeeper-config/templates/_utils.tpl
@@ -18,3 +18,14 @@ kinds:
   - apiGroups: [""]
     kinds: ["Pod"]
 {{- end -}}
+
+{{/* Use this for policies that call the traversal.find_pod() or traversal.find_container_specs() helper function. */}}
+{{- define "match_pods_and_pod_owners" }}
+kinds:
+  - apiGroups: [""]
+    kinds: ["Pod"]
+  - apiGroups: ["apps"]
+    kinds: ["DaemonSet", "Deployment", "StatefulSet"]
+  - apiGroups: ["batch"]
+    kinds: ["Job"]
+{{- end }}

--- a/system/gatekeeper-config/templates/constraint-high-cpu-requests.yaml
+++ b/system/gatekeeper-config/templates/constraint-high-cpu-requests.yaml
@@ -9,11 +9,8 @@ metadata:
     on-prod-ui: 'true'
 spec:
   enforcementAction: dryrun
+  match: {{ include "match_pods_and_pod_owners" . | indent 4 }}
   parameters:
     maxCpu: 6
-  match:
-    kinds:
-      - apiGroups: [""]
-        kinds: ["Pod"]
 
 {{- end -}}

--- a/system/gatekeeper-config/templates/constraint-images-from-correct-registry.yaml
+++ b/system/gatekeeper-config/templates/constraint-images-from-correct-registry.yaml
@@ -6,10 +6,7 @@ metadata:
     on-prod-ui: 'true'
 spec:
   enforcementAction: dryrun
+  match: {{ include "match_pods_and_pod_owners" . | indent 4 }}
   parameters:
     registry: {{.Values.global.registry | required ".Values.global.registry not found"}}
     registryAlternateRegion: {{.Values.global.registryAlternateRegion | required ".Values.global.registryAlternateRegion not found"}}
-  match:
-    kinds:
-      - apiGroups: [""]
-        kinds: ["Pod"]

--- a/system/gatekeeper-config/templates/constraint-images-from-non-keppel.yaml
+++ b/system/gatekeeper-config/templates/constraint-images-from-non-keppel.yaml
@@ -6,11 +6,4 @@ metadata:
     on-prod-ui: 'true'
 spec:
   enforcementAction: {{ if (eq .Values.cluster_type "baremetal" "scaleout") -}} deny {{- else -}} dryrun {{- end }}
-  match:
-    kinds:
-      - apiGroups: [""]
-        kinds: ["Pod"]
-      - apiGroups: ["apps"]
-        kinds: ["DaemonSet", "Deployment", "StatefulSet"]
-      - apiGroups: ["batch"]
-        kinds: ["Job"]
+  match: {{ include "match_pods_and_pod_owners" . | indent 4 }}

--- a/system/gatekeeper-config/templates/constraint-pci-forbidden-images.yaml
+++ b/system/gatekeeper-config/templates/constraint-pci-forbidden-images.yaml
@@ -6,6 +6,7 @@ metadata:
     on-prod-ui: 'true'
 spec:
   enforcementAction: deny
+  match: {{ include "match_pods_and_pod_owners" . | indent 4 }}
   parameters:
     patterns:
       {{- if contains "qa-" .Values.global.region }}
@@ -13,8 +14,3 @@ spec:
       {{- else }}
       - "/cc-ia/cc-readymade"
       {{- end }}
-  match:
-    kinds:
-      - apiGroups: [""]
-        kinds: ["Pod"]
-

--- a/system/gatekeeper-config/templates/constraint-pod-labels.yaml
+++ b/system/gatekeeper-config/templates/constraint-pod-labels.yaml
@@ -6,11 +6,6 @@ metadata:
     on-prod-ui: 'true'
 spec:
   enforcementAction: dryrun
+  match: {{ include "match_pods_and_pod_owners" . | indent 4 }}
   parameters:
     osServices: {{.Values.osServices | required ".Values.osServices not found"}}
-  match:
-    kinds:
-      - apiGroups: [""]
-        kinds: ["Pod"]
-      - apiGroups: ["apps"]
-        kinds: ["DaemonSet", "Deployment", "StatefulSet"]

--- a/system/gatekeeper-config/templates/constraint-resource-limits.yaml
+++ b/system/gatekeeper-config/templates/constraint-resource-limits.yaml
@@ -6,9 +6,4 @@ metadata:
     on-prod-ui: 'true'
 spec:
   enforcementAction: dryrun
-  match:
-    kinds:
-      - apiGroups: [""]
-        kinds: ["Pod"]
-      - apiGroups: ["apps"]
-        kinds: ["DaemonSet", "Deployment", "StatefulSet"]
+  match: {{ include "match_pods_and_pod_owners" . | indent 4 }}

--- a/system/gatekeeper/lib/traversal.rego
+++ b/system/gatekeeper/lib/traversal.rego
@@ -2,11 +2,11 @@ package lib.traversal
 
 ### find_pod(obj)
 #
-# Find a Pod object or template  within the given k8s object. For Pods, `obj`
+# Find a Pod object or template within the given k8s object. For Pods, `obj`
 # itself is returned; but e.g. for Deployments, `.spec.template` is returned.
 #
-# On success, the returned object will have {"found": true} added to it.
-# If no Pod is found, an object with just {"found": false} is returned.
+# On success, the returned object will have {"isFound": true} added to it.
+# If no Pod is found, an object with just {"isFound": false} is returned.
 #
 # Pods that are owned by a ReplicaSet etc. are ignored to avoid
 # double-reporting. (We report on the highest level possible to reduce the
@@ -22,13 +22,13 @@ find_pod(obj) = result {
 find_pod(obj) = result {
   # case 2: `obj` contains a PodSpec
   obj.kind == __violation_owners[_]
-  result := object.union(obj.spec.template, { "found": true })
+  result := object.union(obj.spec.template, { "isFound": true })
 }
 find_pod(obj) = result {
   # case 3: neither Pod nor PodSpec
   obj.kind != "Pod"
   count([kind | kind := __violation_owners[_]; obj.kind == kind ]) == 0
-  result := { "found": false }
+  result := { "isFound": false }
 }
 
 ### find_container_specs(obj)
@@ -50,21 +50,21 @@ __return_pod_unless_ignored(obj, owners) = result {
   # If a pod has ownerReferences to a pod owner that we recognize, we ignore
   # the pod and report violations only on the topmost owner.
   count(owners) > 0
-  result := { "found": false }
+  result := { "isFound": false }
 }
 __return_pod_unless_ignored(obj, owners) = result {
   count(owners) == 0
-  result := object.union(obj, { "found": true })
+  result := object.union(obj, { "isFound": true })
 }
 
 ################################################################################
 # private helper functions for find_container_specs()
 
 __extract_container_specs(pod) = [] {
-  not pod.found
+  not pod.isFound
 }
 __extract_container_specs(pod) = result {
-  pod.found
+  pod.isFound
   # We have to use object.get() to get a zero value in case the key doesn't exist
   # because array.concat() only works if both of its arguments are non-nil (i.e.
   # an array, even if it's empty).

--- a/system/gatekeeper/lib/traversal.rego
+++ b/system/gatekeeper/lib/traversal.rego
@@ -1,0 +1,75 @@
+package lib.traversal
+
+### find_pod(obj)
+#
+# Find a Pod object or template  within the given k8s object. For Pods, `obj`
+# itself is returned; but e.g. for Deployments, `.spec.template` is returned.
+#
+# On success, the returned object will have {"found": true} added to it.
+# If no Pod is found, an object with just {"found": false} is returned.
+#
+# Pods that are owned by a ReplicaSet etc. are ignored to avoid
+# double-reporting. (We report on the highest level possible to reduce the
+# number of total violations that are generated; there is no use in generating
+# 30 violations for 30 replicas of the same Deployment.)
+#
+find_pod(obj) = result {
+  # case 1: `obj` is a Pod itself
+  obj.kind == "Pod"
+  owners := [ref.kind | ref := obj.metadata.ownerReferences[_]; ref.kind == __pod_owners[_]]
+  result := __return_pod_unless_ignored(obj, owners)
+}
+find_pod(obj) = result {
+  # case 2: `obj` contains a PodSpec
+  obj.kind == __violation_owners[_]
+  result := object.union(obj.spec.template, { "found": true })
+}
+find_pod(obj) = result {
+  # case 3: neither Pod nor PodSpec
+  obj.kind != "Pod"
+  count([kind | kind := __violation_owners[_]; obj.kind == kind ]) == 0
+  result := { "found": false }
+}
+
+### find_container_specs(obj)
+#
+# Find all ContainerSpecs within the given k8s object. This looks for a
+# Pod using find_pod() and considers its containers as well as init containers.
+#
+find_container_specs(obj) = result {
+  result := __extract_container_specs(find_pod(obj))
+}
+
+################################################################################
+# private helper functions for find_pod_spec()
+
+__violation_owners = {"Deployment", "DaemonSet", "StatefulSet", "Job"}
+__pod_owners       = {"ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+
+__return_pod_unless_ignored(obj, owners) = result {
+  # If a pod has ownerReferences to a pod owner that we recognize, we ignore
+  # the pod and report violations only on the topmost owner.
+  count(owners) > 0
+  result := { "found": false }
+}
+__return_pod_unless_ignored(obj, owners) = result {
+  count(owners) == 0
+  result := object.union(obj, { "found": true })
+}
+
+################################################################################
+# private helper functions for find_container_specs()
+
+__extract_container_specs(pod) = [] {
+  not pod.found
+}
+__extract_container_specs(pod) = result {
+  pod.found
+  # We have to use object.get() to get a zero value in case the key doesn't exist
+  # because array.concat() only works if both of its arguments are non-nil (i.e.
+  # an array, even if it's empty).
+  result := array.concat(
+    object.get(pod.spec, "containers", []),
+    object.get(pod.spec, "initContainers", []),
+  )
+}

--- a/system/gatekeeper/templates/constrainttemplate-high-cpu-requests.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-high-cpu-requests.yaml
@@ -20,9 +20,12 @@ spec:
       libs:
         - |
           {{ .Files.Get "lib/add-support-labels.rego" | nindent 10 }}
+        - |
+          {{ .Files.Get "lib/traversal.rego" | nindent 10 }}
       rego: |
         package highcpurequests
         import data.lib.add_support_labels
+        import data.lib.traversal
 
         canonify_cpu(orig) = new {
           is_number(orig)
@@ -41,13 +44,12 @@ spec:
         }
 
         iro := input.review.object
-
-        cpu_requests = [canonify_cpu(c) | c = iro.spec.containers[_].resources.requests.cpu]
+        pod := traversal.find_pod(iro)
 
         violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
-          iro.kind == "Pod"
+          pod.found
 
-          total_cpu := sum(cpu_requests)
+          total_cpu := sum([canonify_cpu(c) | c = pod.spec.containers[_].resources.requests.cpu])
           total_cpu > input.parameters.maxCpu
 
           msg := sprintf("requests %v CPU in total", [total_cpu])

--- a/system/gatekeeper/templates/constrainttemplate-high-cpu-requests.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-high-cpu-requests.yaml
@@ -47,7 +47,7 @@ spec:
         pod := traversal.find_pod(iro)
 
         violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
-          pod.found
+          pod.isFound
 
           total_cpu := sum([canonify_cpu(c) | c = pod.spec.containers[_].resources.requests.cpu])
           total_cpu > input.parameters.maxCpu

--- a/system/gatekeeper/templates/constrainttemplate-images-from-correct-registry.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-images-from-correct-registry.yaml
@@ -22,9 +22,12 @@ spec:
       libs:
         - |
           {{ .Files.Get "lib/add-support-labels.rego" | nindent 10 }}
+        - |
+          {{ .Files.Get "lib/traversal.rego" | nindent 10 }}
       rego: |
         package imagesfromcorrectregistry
         import data.lib.add_support_labels
+        import data.lib.traversal
 
         extract_keppel_region(image) = region {
           matchList := regex.find_all_string_submatch_n(`^keppel\.([-\w]+)\.[a-zA-Z]+\.[a-zA-Z]+/`, image, 1)
@@ -44,6 +47,7 @@ spec:
         }
 
         iro := input.review.object
+        containers := traversal.find_container_specs(iro)
 
         correct_regions[region] {
           region = extract_keppel_region(input.parameters.registry)
@@ -54,8 +58,7 @@ spec:
         }
 
         violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
-          iro.kind == "Pod"
-          container := iro.spec.containers[_]
+          container := containers[_]
           image := container.image
 
           current_region = extract_keppel_region(image) # this will also check if image is using Keppel or not

--- a/system/gatekeeper/templates/constrainttemplate-images-from-non-keppel.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-images-from-non-keppel.yaml
@@ -13,51 +13,20 @@ spec:
       libs:
         - |
           {{ .Files.Get "lib/add-support-labels.rego" | nindent 10 }}
+        - |
+          {{ .Files.Get "lib/traversal.rego" | nindent 10 }}
       rego: |
         package imagesfromnonkeppel
         import data.lib.add_support_labels
-
-        # This violation is usually only detectable on the
-        # deployment/daemonset/statefulset level since Tugger will fix the
-        # image reference on the pod level.
-
-        violation_owners = {"Deployment", "DaemonSet", "StatefulSet", "Job"}
-        pod_owners       = {"ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+        import data.lib.traversal
 
         iro := input.review.object
-
-        pod_belongs_to[kind] {
-          ref := iro.metadata.ownerReferences[_]
-          kind := ref.kind
-          kind == pod_owners[_]
-        }
-
-        containers[container] {
-          iro.kind == "Pod"
-          count(pod_belongs_to) == 0 # otherwise the violation will be reported on the owning object (see `violation_owners`)
-          pod_spec := iro.spec
-
-          # We have to use object.get() to get a zero value in case the key doesn't exist
-          # because array.concat() only works if both of its arguments are non-nil (i.e.
-          # an array, even if it's empty).
-          initCntrs := object.get(pod_spec, "initContainers", [])
-          container := array.concat(pod_spec.containers, initCntrs)[_]
-        }
-
-        containers[container] {
-          iro.kind == violation_owners[_]
-          pod_spec := iro.spec.template.spec
-
-          # Same as above.
-          initCntrs := object.get(pod_spec, "initContainers", [])
-          container := array.concat(pod_spec.containers, initCntrs)[_]
-        }
+        containers := traversal.find_container_specs(iro)
 
         violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
           container := containers[_]
-          container_name := container.name
           image := container.image
 
           not regex.match("^keppel\\.[^/.]*\\.cloud.sap/", image)
-          msg := sprintf("container %q uses an image that is not from a Keppel registry: %s", [container_name, image])
+          msg := sprintf("container %q uses an image that is not from a Keppel registry: %s", [container.name, image])
         }

--- a/system/gatekeeper/templates/constrainttemplate-pci-forbidden-images.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-pci-forbidden-images.yaml
@@ -24,14 +24,17 @@ spec:
       libs:
         - |
           {{ .Files.Get "lib/add-support-labels.rego" | nindent 10 }}
+        - |
+          {{ .Files.Get "lib/traversal.rego" | nindent 10 }}
       rego: |
         package pciforbiddenimages
         import data.lib.add_support_labels
+        import data.lib.traversal
 
         iro := input.review.object
+        containers := traversal.find_container_specs(iro)
 
         violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
-          iro.kind == "Pod"
           container := iro.spec.containers[_]
 
           pattern := input.parameters.patterns[_]

--- a/system/gatekeeper/templates/constrainttemplate-pod-labels.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-pod-labels.yaml
@@ -41,7 +41,7 @@ spec:
         required_labels = {alert_tier, alert_service}
 
         violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
-          pod.found
+          pod.isFound
           missing_labels := [l | required_labels[l]; not pod.metadata.labels[l]]
           count(missing_labels) == 2
 
@@ -49,7 +49,7 @@ spec:
         }
 
         violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
-          pod.found
+          pod.isFound
 
           labels := object.get(iro.metadata, "labels", {})
           object.get(labels, alert_tier, "") == "os"

--- a/system/gatekeeper/templates/constrainttemplate-pod-labels.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-pod-labels.yaml
@@ -20,14 +20,15 @@ spec:
       libs:
         - |
           {{ .Files.Get "lib/add-support-labels.rego" | nindent 10 }}
+        - |
+          {{ .Files.Get "lib/traversal.rego" | nindent 10 }}
       rego: |
         package podlabels
         import data.lib.add_support_labels
+        import data.lib.traversal
 
         iro := input.review.object
-
-        # Since we are going to have a lot of violations initially therefore we report on the
-        # Deployment/DaemonSet level, where possible, to avoid useless duplication of violations.
+        pod := traversal.find_pod(iro)
 
         default os_services = []
         os_services = sort(split(input.parameters.osServices, "|"))
@@ -39,67 +40,19 @@ spec:
         # Either alert-tier or alert-service label is required. However, when alert-tier == os then alert-service is also required.
         required_labels = {alert_tier, alert_service}
 
-        missing_labels_on_pod = [l |
-          required_labels[l]
-          not iro.metadata.labels[l]
-        ]
-
-        missing_labels_on_pod_template = [l |
-          required_labels[l]
-          not iro.spec.template.metadata.labels[l]
-        ]
-
-        pod_owners = {"ReplicaSet", "DaemonSet", "StatefulSet"}
-
-        pod_belongs_to[kind] {
-          ref := iro.metadata.ownerReferences[_]
-          kind := ref.kind
-          kind == pod_owners[_]
-        }
-
-        # TODO FIXME: When reporting on an object containing a PodSpec, this
-        # policy appears to be inconsistent about whether to check the support
-        # labels on the outer object or on the PodSpec within.
-
         violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
-          iro.kind == "Pod"
-          count(pod_belongs_to) == 0 # otherwise the violation will be reported on the DaemonSet or Deployment instead
-          count(missing_labels_on_pod) == 2
+          pod.found
+          missing_labels := [l | required_labels[l]; not pod.metadata.labels[l]]
+          count(missing_labels) == 2
 
-          msg := sprintf("pod does not have either one of the required labels: %s", [sort(missing_labels_on_pod)])
+          msg := sprintf("pod does not have either one of the required labels: %s", [sort(missing_labels)])
         }
 
         violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
-          iro.kind == "Pod"
-          count(pod_belongs_to) == 0 # otherwise the violation will be reported on the DaemonSet or Deployment instead
+          pod.found
 
           labels := object.get(iro.metadata, "labels", {})
           object.get(labels, alert_tier, "") == "os"
-          srv := object.get(labels, alert_service, "")
-          found := {f | srv == os_services[_]; f = true}
-          count(found) == 0
-
-          msg := sprintf(
-            "pod has %q label with value: os, but %q label is missing or does not have a valid value (got: %s, valid: %s)",
-            [alert_tier, alert_service, json.marshal(srv), os_services],
-          )
-        }
-
-        violation_owners = {"Deployment", "DaemonSet", "StatefulSet"}
-
-        violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
-          iro.kind == violation_owners[_]
-          count(missing_labels_on_pod_template) == 2
-
-          msg := sprintf("pod does not have either one of the required labels: %s", [sort(missing_labels_on_pod_template)])
-        }
-
-        violation[{"msg": add_support_labels.from_k8s_object(iro.spec.template, msg)}] {
-          iro.kind == violation_owners[_]
-          labels := object.get(iro.spec.template.metadata, "labels", {})
-
-          t := object.get(labels, alert_tier, "")
-          t == "os"
           srv := object.get(labels, alert_service, "")
           found := {f | srv == os_services[_]; f = true}
           count(found) == 0

--- a/system/gatekeeper/templates/constrainttemplate-resource-limits.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-resource-limits.yaml
@@ -13,54 +13,34 @@ spec:
       libs:
         - |
           {{ .Files.Get "lib/add-support-labels.rego" | nindent 10 }}
+        - |
+          {{ .Files.Get "lib/traversal.rego" | nindent 10 }}
       rego: |
         package resourcelimits
         import data.lib.add_support_labels
+        import data.lib.traversal
 
         iro := input.review.object
+        pod := traversal.find_pod(iro)
 
         # We have such a bafflingly large amount of violations that
         # Gatekeeper cannot report them all at once. I'd rather have
         # *something* reported for as many things as possible, even if it
         # means sacrificing accuracy, so we report only one violation for
-        # each offending pod, and we report on the deployment/daemonset level
-        # if possible to avoid useless duplication of violations.
+        # each offending pod or pod owner.
 
         resource_types = {"cpu", "memory"}
 
-        missing_limits_on_pod[{"container": container.name, "type": resource_type}] {
-          container := iro.spec.containers[_]
+        missing_limits[{"container": container.name, "type": resource_type}] {
+          pod.found
+          container := pod.spec.containers[_]
           limits := object.get(container, ["resources", "limits"], {})
           resource_type := resource_types[_]
           object.get(limits, resource_type, "") == ""
         }
 
-        missing_limits_on_pod_template[{"container": container.name, "type": resource_type}] {
-          container := iro.spec.template.spec.containers[_]
-          limits := object.get(container, ["resources", "limits"], {})
-          resource_type := resource_types[_]
-          object.get(limits, resource_type, "") == ""
-        }
-
-        pod_owners = {"ReplicaSet", "DaemonSet", "StatefulSet"}
-
-        pod_belongs_to[kind] {
-          ref := iro.metadata.ownerReferences[_]
-          kind := ref.kind
-          kind == pod_owners[_]
-        }
-
         violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
-          iro.kind == "Pod"
-          count(pod_belongs_to) == 0 # otherwise the violation will be reported on the DaemonSet or Deployment
-          count(missing_limits_on_pod) > 0
-          msg := "cpu and memory limits not set on some or all containers"
-        }
-
-        violation_owners = {"Deployment", "DaemonSet", "StatefulSet"}
-
-        violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
-          iro.kind == violation_owners[_]
-          count(missing_limits_on_pod_template) > 0
+          pod.found
+          count(missing_limits) > 0
           msg := "cpu and memory limits not set on some or all containers"
         }

--- a/system/gatekeeper/templates/constrainttemplate-resource-limits.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-resource-limits.yaml
@@ -32,7 +32,7 @@ spec:
         resource_types = {"cpu", "memory"}
 
         missing_limits[{"container": container.name, "type": resource_type}] {
-          pod.found
+          pod.isFound
           container := pod.spec.containers[_]
           limits := object.get(container, ["resources", "limits"], {})
           resource_type := resource_types[_]
@@ -40,7 +40,7 @@ spec:
         }
 
         violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
-          pod.found
+          pod.isFound
           count(missing_limits) > 0
           msg := "cpu and memory limits not set on some or all containers"
         }

--- a/system/gatekeeper/tests/fixtures/images-from-non-keppel/deployment-mixed.yaml
+++ b/system/gatekeeper/tests/fixtures/images-from-non-keppel/deployment-mixed.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dummy
+  labels:
+    cc/support-group: foo-group
+    cc/service: dummy
+spec:
+  template:
+    spec:
+      initContainers:
+      - name: starter-bad
+        image: alpine:3
+        args: [ "sleep", "86400" ]
+      - name: starter-good
+        image: keppel.global.cloud.sap/alpine:3
+        args: [ "sleep", "86400" ]
+      containers:
+      - name: container-bad
+        image: alpine:3
+        args: [ "sleep", "86400" ]
+      - name: container-good
+        image: keppel.global.cloud.sap/alpine:3
+        args: [ "sleep", "86400" ]

--- a/system/gatekeeper/tests/fixtures/images-from-non-keppel/pod-owned.yaml
+++ b/system/gatekeeper/tests/fixtures/images-from-non-keppel/pod-owned.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dummy-10468171-f184g
+  labels:
+    cc/support-group: foo-group
+    cc/service: dummy
+  ownerReferences:
+  - apiVersion: apps/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: ReplicaSet
+    name: dummy-10468171
+    uid: 3ea510d7-9dde-45b0-9426-f06efe23a2de
+spec:
+  containers:
+  - name: dummy-big
+    image: alpine:3 # This is a violation, but it does not get reported here because of the owner reference.
+    args: [ "sleep", "86400" ]
+  - name: dummy-small
+    image: keppel.global.cloud.sap/alpine:3
+    args: [ "sleep", "86400" ]

--- a/system/gatekeeper/tests/suite.yaml
+++ b/system/gatekeeper/tests/suite.yaml
@@ -194,6 +194,18 @@ tests:
     object: fixtures/images-from-non-keppel/pod-pass.yaml
     assertions:
     - violations: no
+  # The test suite for this policy is a bit more expansive to check the logic in traversal.find_pod().
+  - name: pod-owned
+    object: fixtures/images-from-non-keppel/pod-owned.yaml
+    assertions:
+    - violations: no
+  - name: deployment-mixed
+    object: fixtures/images-from-non-keppel/deployment-mixed.yaml
+    assertions:
+    - violations: 1
+      message: '^support-group=foo-group,service=dummy: container "container-bad" uses an image that is not from a Keppel registry: alpine:3$'
+    - violations: 1
+      message: '^support-group=foo-group,service=dummy: container "starter-bad" uses an image that is not from a Keppel registry: alpine:3$'
 
 - name: ingress-annotations
   template: rendered-chart/gatekeeper/templates/constrainttemplate-ingress-annotations.yaml


### PR DESCRIPTION
The logic mostly comes from GkImagesFromNonKeppel, and is now generalized to all policies that check pod specs or container specs.

@SuperSandro2000 I want to get this topic done this week if possible, which means I would have to merge tomorrow. If you get the chance to look at this today, I'd be grateful. If you don't get the chance, I'll merge this tomorrow at my own risk. In any case, I will perform detailed verification in QA to check that the policy behavior does not change in unintended ways.