### PR TITLE
gatekeeper: parse owner-info of Helm releases from manifest instead of values

### DIFF
--- a/system/gatekeeper/lib/add-support-labels.rego
+++ b/system/gatekeeper/lib/add-support-labels.rego
@@ -9,7 +9,7 @@ from_k8s_object(obj, msg) = result {
 
 # `body` must be the response body from helm-manifest-parser
 from_helm_release(body, msg) = result {
-  support_group := object.get(body, ["values", "owner-info", "support-group"], "none")
-  service := object.get(body, ["values", "owner-info", "service"], "none")
+  support_group := object.get(body, ["owner_info", "support-group"], "none")
+  service := object.get(body, ["owner_info", "service"], "none")
   result := sprintf("support-group=%s,service=%s: %s", [support_group, service, msg])
 }

--- a/system/gatekeeper/tests/fixtures/deprecated-api-version/helm-release-clean.in.yaml
+++ b/system/gatekeeper/tests/fixtures/deprecated-api-version/helm-release-clean.in.yaml
@@ -1,12 +1,15 @@
-values:
-  - owner-info: {}
-    owner-info.support-group: foo-group
-    owner-info.service: dummy
-
 template: |
   kind: Deployment
   apiVersion: apps/v1
   metadata:
     name: dummy
+  ---
+  kind: ConfigMap
+  apiVersion: v1
+  metadata:
+    name: owner-of-almost-empty-chart
+  data:
+    support-group: foo-group
+    service: dummy
 
 status: deployed

--- a/system/gatekeeper/tests/fixtures/deprecated-api-version/helm-release-deprecated-1.16.in.yaml
+++ b/system/gatekeeper/tests/fixtures/deprecated-api-version/helm-release-deprecated-1.16.in.yaml
@@ -1,12 +1,15 @@
-values:
-  - owner-info: {}
-    owner-info.support-group: foo-group
-    owner-info.service: dummy
-
 template: |
   kind: Deployment
   apiVersion: extensions/v1beta1
   metadata:
     name: dummy
+  ---
+  kind: ConfigMap
+  apiVersion: v1
+  metadata:
+    name: owner-of-almost-empty-chart
+  data:
+    support-group: foo-group
+    service: dummy
 
 status: deployed

--- a/system/gatekeeper/tests/fixtures/deprecated-api-version/helm-release-deprecated-1.22.in.yaml
+++ b/system/gatekeeper/tests/fixtures/deprecated-api-version/helm-release-deprecated-1.22.in.yaml
@@ -1,12 +1,15 @@
-values:
-  - owner-info: {}
-    owner-info.support-group: foo-group
-    owner-info.service: dummy
-
 template: |
   kind: CustomResourceDefinition
   apiVersion: apiextensions.k8s.io/v1beta1
   metadata:
     name: dummy
+  ---
+  kind: ConfigMap
+  apiVersion: v1
+  metadata:
+    name: owner-of-almost-empty-chart
+  data:
+    support-group: foo-group
+    service: dummy
 
 status: deployed

--- a/system/gatekeeper/tests/fixtures/deprecated-api-version/helm-release-deprecated-1.25.in.yaml
+++ b/system/gatekeeper/tests/fixtures/deprecated-api-version/helm-release-deprecated-1.25.in.yaml
@@ -1,12 +1,15 @@
-values:
-  - owner-info: {}
-    owner-info.support-group: foo-group
-    owner-info.service: dummy
-
 template: |
   kind: CronJob
   apiVersion: batch/v1beta1
   metadata:
     name: dummy
+  ---
+  kind: ConfigMap
+  apiVersion: v1
+  metadata:
+    name: owner-of-almost-empty-chart
+  data:
+    support-group: foo-group
+    service: dummy
 
 status: deployed

--- a/system/gatekeeper/tests/fixtures/deprecated-api-version/helm-release-deprecated-1.26.in.yaml
+++ b/system/gatekeeper/tests/fixtures/deprecated-api-version/helm-release-deprecated-1.26.in.yaml
@@ -1,12 +1,15 @@
-values:
-  - owner-info: {}
-    owner-info.support-group: foo-group
-    owner-info.service: dummy
-
 template: |
   kind: FlowSchema
   apiVersion: flowcontrol.apiserver.k8s.io/v1beta1
   metadata:
     name: dummy
+  ---
+  kind: ConfigMap
+  apiVersion: v1
+  metadata:
+    name: owner-of-almost-empty-chart
+  data:
+    support-group: foo-group
+    service: dummy
 
 status: deployed

--- a/system/gatekeeper/tests/fixtures/libtest-add-support-labels/helm-release-filled.in.yaml
+++ b/system/gatekeeper/tests/fixtures/libtest-add-support-labels/helm-release-filled.in.yaml
@@ -1,12 +1,15 @@
-values:
-  - owner-info: {}
-    owner-info.support-group: foo-group
-    owner-info.service: dummy
-
 template: |
   kind: Deployment
   apiVersion: apps/v1
   metadata:
     name: dummy
+  ---
+  kind: ConfigMap
+  apiVersion: v1
+  metadata:
+    name: owner-of-almost-empty-chart
+  data:
+    support-group: foo-group
+    service: dummy
 
 status: deployed

--- a/system/gatekeeper/tests/fixtures/owner-info-on-helm-releases/configmap-no-owner-pending-upgrade.in.yaml
+++ b/system/gatekeeper/tests/fixtures/owner-info-on-helm-releases/configmap-no-owner-pending-upgrade.in.yaml
@@ -10,4 +10,4 @@ template: |
       owner-info-version: 0.1.2
     namespace: dummy
 
-status: deployed
+status: pending-upgrade

--- a/system/gatekeeper/tests/fixtures/owner-info-on-helm-releases/configmap-pass.in.yaml
+++ b/system/gatekeeper/tests/fixtures/owner-info-on-helm-releases/configmap-pass.in.yaml
@@ -9,7 +9,7 @@ template: |
     labels:
       owner-info-version: 0.1.2
       primary-maintainer: jon-doe
-    name: owner-of-dummy
+    name: owner-of-almost-empty-chart
     namespace: dummy
 
 status: deployed

--- a/system/gatekeeper/tests/fixtures/region-value-missing/helm-release-no-region.in.yaml
+++ b/system/gatekeeper/tests/fixtures/region-value-missing/helm-release-no-region.in.yaml
@@ -1,6 +1,10 @@
-values:
-  - owner-info: {}
-    owner-info.support-group: foo-group
-    owner-info.service: dummy
+template: |
+  kind: ConfigMap
+  apiVersion: v1
+  metadata:
+    name: owner-of-almost-empty-chart
+  data:
+    support-group: foo-group
+    service: dummy
 
 status: deployed

--- a/system/gatekeeper/tests/fixtures/region-value-missing/helm-release-pass.in.yaml
+++ b/system/gatekeeper/tests/fixtures/region-value-missing/helm-release-pass.in.yaml
@@ -1,7 +1,13 @@
 values:
   - global.region: qa-de-1
-  - owner-info: {}
-    owner-info.support-group: foo-group
-    owner-info.service: dummy
+
+template: |
+  kind: ConfigMap
+  apiVersion: v1
+  metadata:
+    name: owner-of-almost-empty-chart
+  data:
+    support-group: foo-group
+    service: dummy
 
 status: deployed


### PR DESCRIPTION
This requires the helm-manifest-parser change in <https://github.com/sapcc/gatekeeper-addons/commit/a57c7b037c729789ce7912b4a391111f7acd1cd6>.