### PR TITLE
[nova] Remove per-service notification rabbitmq

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -14,9 +14,6 @@ dependencies:
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.0.10
-- name: rabbitmq
-  repository: https://charts.eu-de-2.cloud.sap
-  version: 0.4.2
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.5.0
@@ -26,5 +23,5 @@ dependencies:
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.4.2
-digest: sha256:cc895f1185f27b475d3b9c3e55d14559dfa94ea5cf4ca20ae40fe73c5cc7b2de
-generated: "2022-09-12T09:41:51.679562725+02:00"
+digest: sha256:b5d6a328f90efc7a17f7fca25cfee7106ba0e2b450ad199086ef45156571305b
+generated: "2022-09-12T10:13:40.874097017+02:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -24,11 +24,6 @@ dependencies:
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.0.10
-  - name: rabbitmq
-    alias: rabbitmq_notifications
-    condition: audit.enabled
-    repository: https://charts.eu-de-2.cloud.sap
-    version: 0.4.2
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.5.0

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -769,6 +769,9 @@ rabbitmq_cell2:
     ready_total_wait_for: 10m
 
 audit:
+  central_service:
+    user: rabbitmq
+    password: null
   enabled: false
   # how many messages to buffer before dumping to log (when rabbit is down or too slow)
   mem_queue_size: 1000
@@ -797,11 +800,6 @@ rabbitmq:
     rabbit_queue_length: 50
     unacknowledged_total_wait_for: 10m
     ready_total_wait_for: 10m
-
-rabbitmq_notifications:
-  name: nova
-  persistence:
-    enabled: false
 
 logging:
   formatters:


### PR DESCRIPTION
We have already migrated in all regions
the services to the central audit rabbitmq
So we can now undeploy the now unused one