### PR TITLE
Increasing rrset cache from 4MB to 100MB

### DIFF
--- a/system/unbound/templates/config.yaml
+++ b/system/unbound/templates/config.yaml
@@ -19,6 +19,10 @@ data:
         cache-max-negative-ttl: 100
         cache-max-ttl: 28800
         
+        # more cache memory (default is 4m), rrset=msg*2
+        rrset-cache-size: 100m
+        msg-cache-size: 50m
+        
         root-hints: "/etc/unbound/root.hints"
 
         directory: "/etc/unbound"


### PR DESCRIPTION
Increasing the rrset and msg cache because we see in the bigger regions that the cache is evicted before the TTL runs out.