### PR TITLE
[nova] Scale max-connections with number of processes

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -16,12 +16,12 @@ dependencies:
   version: 0.0.10
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.5.0
+  version: 0.6.0
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.5.4
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.4.2
-digest: sha256:b5d6a328f90efc7a17f7fca25cfee7106ba0e2b450ad199086ef45156571305b
-generated: "2022-09-12T10:13:40.874097017+02:00"
+digest: sha256:638fe7ef6e69bb37f261d862842ff05d64c341be3cddc28827c6a5c7dfea4cf7
+generated: "2022-09-14T13:02:21.171062567+02:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     version: 0.0.10
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.5.0
+    version: 0.6.0
   - name: mariadb
     alias: mariadb_cell2
     condition: mariadb_cell2.enabled

--- a/openstack/nova/templates/api-deployment.yaml
+++ b/openstack/nova/templates/api-deployment.yaml
@@ -159,7 +159,7 @@ spec:
               readOnly: true
             {{- end }}
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
-        {{- include "utils.proxysql.container" . | indent 8 }}
+        {{- tuple . .Values.api.config_file.DEFAULT.osapi_compute_workers | include "utils.proxysql.container" | indent 8 }}
         - name: statsd
           image: {{ required ".Values.global.dockerHubMirror is missing" .Values.global.dockerHubMirror}}/prom/statsd-exporter:v0.8.1
           imagePullPolicy: IfNotPresent

--- a/openstack/nova/templates/api-metadata-deployment.yaml
+++ b/openstack/nova/templates/api-metadata-deployment.yaml
@@ -143,7 +143,7 @@ spec:
               readOnly: true
             {{- end }}
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
-        {{- include "utils.proxysql.container" . | indent 8 }}
+        {{- tuple . .Values.api_metadata.config_file.DEFAULT.metadata_workers | include "utils.proxysql.container" | indent 8 }}
         - name: statsd
           image: {{ required ".Values.global.dockerHubMirror is missing" .Values.global.dockerHubMirror}}/prom/statsd-exporter:v0.8.1
           imagePullPolicy: IfNotPresent

--- a/openstack/nova/templates/cell2-conductor-deployment.yaml
+++ b/openstack/nova/templates/cell2-conductor-deployment.yaml
@@ -111,7 +111,7 @@ spec:
               subPath: logging.ini
               readOnly: true
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
-        {{- include "utils.proxysql.container" . | indent 8 }}
+        {{- tuple . .Values.conductor.config_file.conductor.workers | include "utils.proxysql.container" | indent 8 }}
         {{- if .Values.cell2.conductor.config_file.DEFAULT.statsd_enabled }}
         - name: statsd
           image: {{ required ".Values.global.dockerHubMirror is missing" .Values.global.dockerHubMirror}}/prom/statsd-exporter:v0.8.1

--- a/openstack/nova/templates/conductor-deployment.yaml
+++ b/openstack/nova/templates/conductor-deployment.yaml
@@ -100,7 +100,7 @@ spec:
               subPath: logging.ini
               readOnly: true
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
-        {{- include "utils.proxysql.container" . | indent 8 }}
+        {{- tuple . .Values.conductor.config_file.conductor.workers | include "utils.proxysql.container" | indent 8 }}
         {{- if .Values.conductor.config_file.DEFAULT.statsd_enabled }}
         - name: statsd
           image: {{ required ".Values.global.dockerHubMirror is missing" .Values.global.dockerHubMirror}}/prom/statsd-exporter:v0.8.1

--- a/openstack/nova/templates/etc/_nova-scheduler.conf.tpl
+++ b/openstack/nova/templates/etc/_nova-scheduler.conf.tpl
@@ -7,7 +7,7 @@ statsd_enabled = {{ .Values.scheduler.rpc_statsd_enabled }}
 
 [scheduler]
 discover_hosts_in_cells_interval = 60
-workers = {{ .Values.scheduler.workers | default 1 }}
+workers = {{ .Values.scheduler.workers }}
 driver_task_period = {{ .Values.scheduler.driver_task_period | default 60 }}
 query_placement_for_availability_zone = {{ not (contains "AvailabilityZoneFilter" .Values.scheduler.default_filters) }}
 

--- a/openstack/nova/templates/etc/_nova.conf.tpl
+++ b/openstack/nova/templates/etc/_nova.conf.tpl
@@ -23,7 +23,6 @@ default_schedule_zone = {{.Values.global.default_availability_zone}}
 default_availability_zone = {{.Values.global.default_availability_zone}}
 
 rpc_response_timeout = {{ .Values.rpc_response_timeout | default .Values.global.rpc_response_timeout | default 60 }}
-rpc_workers = {{ .Values.rpc_workers | default .Values.global.rpc_workers | default 1 }}
 
 sync_power_state_pool_size = {{ .Values.sync_power_state_pool_size | default 500 }}
 sync_power_state_interval = {{ .Values.sync_power_state_interval | default 1200 }}

--- a/openstack/nova/templates/scheduler-deployment.yaml
+++ b/openstack/nova/templates/scheduler-deployment.yaml
@@ -98,7 +98,7 @@ spec:
               subPath: logging.ini
               readOnly: true
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
-        {{- include "utils.proxysql.container" . | indent 8 }}
+        {{- tuple . .Values.scheduler.workers | include "utils.proxysql.container" | indent 8 }}
         {{- if .Values.scheduler.rpc_statsd_enabled }}
         - name: statsd
           image: {{ required ".Values.global.dockerHubMirror is missing" .Values.global.dockerHubMirror}}/prom/statsd-exporter:v0.8.1

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -250,6 +250,7 @@ consoles:
 
 scheduler:
   driver: "filter_scheduler"
+  workers: 1
   track_instance_changes: false
   scheduler_instance_sync_interval: 120
   rpc_statsd_port: 9125


### PR DESCRIPTION
As sqlalchemy pool sets the limits per process,
we need to scale the number of connections with the number of
processes to have the same limit per pod.
