### PR TITLE
Reduce criticality of BillingAPI problems

### DIFF
--- a/openstack/cc3test/alerts/ccloud-billing.alerts
+++ b/openstack/cc3test/alerts/ccloud-billing.alerts
@@ -6,7 +6,7 @@ groups:
         cc3test_status{service="billing", type="api"} == 0
     for: 10m
     labels:
-      severity: critical
+      severity: warning
       tier: os
       service: '{{ $labels.service }}'
       context: '{{ $labels.service }}'


### PR DESCRIPTION
Support can't do anything here at all, except for highlighting the appropriate team. So no need to escalate during the night.