### PR TITLE
[rabbitmq]: fix cookie permissions

### DIFF
--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 0.4.2
+version: 0.4.3
 description: A Helm chart for RabbitMQ
 sources:
 - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/templates/deployment.yaml
+++ b/common/rabbitmq/templates/deployment.yaml
@@ -49,6 +49,7 @@ spec:
         runAsUser: 999
         runAsGroup: 999
         fsGroup: 999
+        fsGroupChangePolicy: "OnRootMismatch"
       containers:
       - name: rabbitmq
         image: "{{include "dockerHubMirror" .}}/{{ .Values.image }}:{{.Values.imageTag }}"


### PR DESCRIPTION
Fixes an issue when `/var/lib/rabbitmq/.cookie` is has 0660 permissions on container startup.

With a fix the `/var/lib/rabbitmq/.cookie` file has 0400 permissions and rabbitmq doesn't complain.

see https://github.com/docker-library/rabbitmq/issues/171