### PR TITLE
[Cinder] Add new SAPPoolDownFilter to default filters

### DIFF
--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -84,7 +84,7 @@ use_tls_acme: true
 
 db_name: cinder
 
-scheduler_default_filters: "AvailabilityZoneFilter,ShardFilter,CapacityFilter,CapabilitiesFilter,SAPLargeVolumeFilter,SAPDifferentBackendFilter,SAPSameBackendFilter"
+scheduler_default_filters: "AvailabilityZoneFilter,ShardFilter,SAPPoolDownFilter,CapabilitiesFilter,SAPLargeVolumeFilter,SAPDifferentBackendFilter,SAPSameBackendFilter,CapacityFilter"
 scheduler_default_weighers: "CapacityWeigher"
 
 capacity_weight_multiplier: -1.0


### PR DESCRIPTION
This patch moves the CapacityFilter to the last filter to run as well as adding a new SAPPoolDownFilter, which will filter out all pools that are not marked as 'up' by the vmware driver.