### PR TITLE
cronus - adding null backend config

### DIFF
--- a/openstack/cronus/templates/cronus/_config.yaml.tpl
+++ b/openstack/cronus/templates/cronus/_config.yaml.tpl
@@ -170,6 +170,9 @@ cronus:
         - {{ $vd }}
 {{- end }}
 {{- end }}
+{{- if $v.skipCredentials }}
+      skipCredentials: {{ $v.skipCredentials }}
+{{- end }}
 {{- if $v.smtpConnPool }}
       smtpConnPool:
 {{- if $v.smtpConnPool.maxConnGlobal }}

--- a/openstack/cronus/values.yaml
+++ b/openstack/cronus/values.yaml
@@ -230,7 +230,7 @@ config:
   # extra SMTP backends and a list of recipient domains
   smtpBackends:
     - name: int
-      # backend hostname. scheme specifies the encryption method: none, tls, starttls
+      # backend hostname. scheme specifies the encryption method: none, tls, starttls, sesv2, null
       hosts:
         10:
           - scheme://server:port
@@ -240,6 +240,7 @@ config:
         - .corp.int
         - int.corp
         - .int.corp
+      # skipCredentials: true # if credentials should not be mandatory (for null backends)
   workQueue:
     enabled: false
     queueName: cronus_work_queue


### PR DESCRIPTION
This PR adds a Cronus config for "null" backends, that accept and silently drop any incoming mail, usable for project setup testing.

see https://github.wdf.sap.corp/cc/secrets/pull/9858
and https://github.wdf.sap.corp/cronus/issues/issues/201