### PR TITLE
Add 2faproxy to keystone chart

### DIFF
--- a/openstack/keystone/templates/_helpers.tpl
+++ b/openstack/keystone/templates/_helpers.tpl
@@ -48,3 +48,18 @@ To satisfy common/mysql_metrics :(
 */}}
 
 {{define "keystone_db_host"}}{{- if .Values.global.clusterDomain }}{{.Release.Name}}-mariadb.{{.Release.Namespace}}.svc.{{.Values.global.clusterDomain}}{{ else }}{{.Release.Name}}-mariadb.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.region}}.{{.Values.global.tld}}{{- end -}}{{end}}
+
+
+{{- define "2faproxy.selectorLabels" -}}
+app.kubernetes.io/name: 2faproxy
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "2faproxy.labels" -}}
+helm.sh/chart: {{ include "name" . }}
+{{ include "2faproxy.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/openstack/keystone/templates/cronjob-2faproxy.yaml
+++ b/openstack/keystone/templates/cronjob-2faproxy.yaml
@@ -1,0 +1,40 @@
+{{- if and (index .Values "2fa" "crls") (index .Values "2fa" "enabled") }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-2faproxy-crls
+spec:
+  schedule: '*/5 * * * *'
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 1800 #30 minutes
+      template:
+        spec:
+          serviceAccountName: {{ .Release.Name }}-2faproxy-crls
+          containers:
+          - name: rotate-crls
+            image: keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/library/alpine
+            command:
+              - /bin/sh
+              - -ec
+              - |
+                set -o pipefail
+                apk add curl openssl
+                curl -Lo /usr/local/bin/kubectl https://dl.k8s.io/release/v1.23.10/bin/linux/amd64/kubectl
+                chmod +x /usr/local/bin/kubectl
+                kubectl get secret --namespace={{.Release.Namespace}} {{ .Release.Name }}-x509-ca -ojsonpath='{.data.ca\.crl}' |base64 -d > /tmp/current.crl
+            {{- range $crl := index .Values "2fa" "crls" }}
+            {{- if eq $crl.format "DER"}}
+                curl -sfL {{ $crl.url }} | openssl crl -inform DER -outform PEM >> /tmp/new.crl
+            {{- else }}
+                curl -sfL {{ $crl.url }} >> /tmp/new.crl
+            {{- end }}
+            {{- end }}
+                ls -l /tmp/*.crl
+                if ! cmp -s /tmp/current.crl /tmp/new.crl; then
+                  set -x
+                  kubectl patch secret --namespace={{.Release.Namespace}} {{ .Release.Name }}-x509-ca --type=json -p '[{"op":"replace", "path":"/data/ca.crl", "value":"'$(cat /tmp/new.crl | base64 -w 0)'"}]'
+                fi
+          restartPolicy: Never
+{{- end }}

--- a/openstack/keystone/templates/deployment-2faproxy.yaml
+++ b/openstack/keystone/templates/deployment-2faproxy.yaml
@@ -1,0 +1,80 @@
+{{- if (index .Values "2fa" "enabled") }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-2faproxy
+  labels:
+    {{- include "2faproxy.labels" . | nindent 4 }}
+spec:
+  replicas: {{ index .Values "2fa" "replicaCount" }}
+  selector:
+    matchLabels:
+      {{- include "2faproxy.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        config/secret: {{  include (print $.Template.BasePath "/secret-2faproxy.yaml") . | sha256sum  }}
+        {{- with (index .Values "2fa" "podAnnotations") }}
+        {{- toYaml . | nindent 8 }}
+        {{- end}}
+      labels:
+        {{- include "2faproxy.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ .Release.Name }}-2faproxy
+      containers:
+        - name: 2fa
+          image: {{ required ".Values.global.registryAlternateRegion is missing" .Values.global.registryAlternateRegion }}/{{ index .Values "2fa" "image" }}:{{ required ".Values.2fa.imageTag is missing" (index .Values "2fa" "imageTag") }}
+          imagePullPolicy: {{ index .Values "2fa" "imagePullPolicy" | default "IfNotPresent" | quote }}
+          command:
+            - 2faproxy
+            - -http-addr=0.0.0.0:8080
+            - -metrics-addr=0.0.0.0:8081
+            - -poll-interval={{ index .Values "2fa" "pollInterval" }}
+            - -issuer-dn={{ required "2fa.issuerDN missing" (index .Values "2fa" "issuerDN") }}
+          env:
+          {{- range $key, $value :=  index .Values "2fa" "openstack" }}
+            - name: {{ $key }}
+              valueFrom: { secretKeyRef: { name: {{ $.Release.Name }}-2faproxy, key: {{ $key }} } }
+          {{- end }}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  # wait 10 seconds before closing the http listener
+                  # o prevent final new connections from the nginx are not lost
+                  - sleep 10
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: metrics
+              containerPort: 8081
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /health/readiness
+              port: http
+          resources:
+            {{- index .Values "2fa" "resources" | toYaml | nindent 12 }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 10
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchExpressions:
+                # has to match include "2faproxy.selectorLabels"
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - 2faproxy
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - {{ .Release.Name }}
+      {{- with ( index .Values "2fa" "tolerations") }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/openstack/keystone/templates/ingress-api.yaml
+++ b/openstack/keystone/templates/ingress-api.yaml
@@ -86,6 +86,15 @@ spec:
     - host: {{ .Values.services.public.host }}.{{ .Values.global.region }}.{{ .Values.global.tld }}
       http:
         paths:
+        {{- if (index .Values "2fa" "enabled")}}
+        - path: /v3/auth/tokens
+          pathType: Prefix
+          backend:
+            service:
+              name: {{ .Release.Name }}-2faproxy
+              port:
+                number: 8080
+        {{- end }}
         - path: /
           pathType: Prefix
           backend:

--- a/openstack/keystone/templates/rbac-2faproxy.yaml
+++ b/openstack/keystone/templates/rbac-2faproxy.yaml
@@ -1,0 +1,34 @@
+{{- if and .Values.services.ingress.x509.ca (index .Values "2fa" "enabled") }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-2faproxy
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-2faproxy-crls
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-2faproxy-crls
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["secrets"]
+  resourceNames: ["{{ .Release.Name }}-x509-ca"]
+  verbs: ["patch", "get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-2faproxy-crls
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-2faproxy-crls
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ .Release.Name }}-2faproxy-crls
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/openstack/keystone/templates/secret-2faproxy.yaml
+++ b/openstack/keystone/templates/secret-2faproxy.yaml
@@ -1,0 +1,12 @@
+{{- if (index .Values "2fa" "enabled") }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-2faproxy
+  labels:
+    {{- include "2faproxy.labels" . | nindent 4 }}
+data:
+{{- range $key, $value :=  index .Values "2fa" "openstack" }}
+  {{ $key }}: {{ $value | b64enc }}
+{{- end }}
+{{- end }}

--- a/openstack/keystone/templates/service-2faproxy.yaml
+++ b/openstack/keystone/templates/service-2faproxy.yaml
@@ -1,0 +1,17 @@
+{{- if (index .Values "2fa" "enabled") }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-2faproxy
+  labels:
+    {{- include "2faproxy.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "2faproxy.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -464,3 +464,14 @@ sapcc_rate_limit:
   enabled: false
   persistence:
     enabled: false
+
+2fa:
+  enabled: false
+  replicaCount: 3
+  pollInterval: 1m #how often do we list projects
+  image: ccloud/2faproxy
+  imageTag: latest
+  imagePullPolicy: IfNotPresent
+  openstack: {}
+  resources: {}
+  podAnnotations: {}


### PR DESCRIPTION
Add an intermedite reverse proxy deployment to the keystone chart between ingress and the keystone api that processes /v3/auth/tokens requests and enforces opt-in 2fa authentication in the form of tls client certificates.

Unless `2fa.enabled` is set to `true` no changes during deployment are expected.