### PR TITLE
[kube-monitoring-metal] upping promstack

### DIFF
--- a/system/kube-monitoring-metal/Chart.lock
+++ b/system/kube-monitoring-metal/Chart.lock
@@ -40,7 +40,7 @@ dependencies:
   version: 1.7.0
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
-  version: 12.5.0
+  version: 39.0.0
 - name: prometheus-server
   repository: https://charts.eu-de-2.cloud.sap
   version: 7.0.4
@@ -56,5 +56,5 @@ dependencies:
 - name: prober-static
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.3
-digest: sha256:cf44cad52202b442602107fd1b14987033b3e7fb792c050eacd0086747f8e5c9
-generated: "2022-09-28T21:46:16.980631+02:00"
+digest: sha256:9637833ab30ebf26fbf8ae52c6c637cf7ab9a864c8e161f8c283bf3ece9001f5
+generated: "2022-10-05T11:06:44.384208+02:00"

--- a/system/kube-monitoring-metal/Chart.yaml
+++ b/system/kube-monitoring-metal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes metal controlplane monitoring.
 name: kube-monitoring-metal
-version: 4.1.28
+version: 4.1.29
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-metal
 dependencies:
   - name: pvc-exporter
@@ -47,7 +47,7 @@ dependencies:
     version: 1.7.0
   - name: kube-prometheus-stack
     repository: https://prometheus-community.github.io/helm-charts
-    version: 12.5.0
+    version: 39.0.0
   - alias: prometheus-frontend
     name: prometheus-server
     repository: https://charts.eu-de-2.cloud.sap


### PR DESCRIPTION
Checked all other versions and they are in pars with the other kube-monitoring Charts. Upping kube-monitoring-stack solely therefore.