### PR TITLE
[placement] Add db migration jobs

### DIFF
--- a/openstack/placement/templates/_helpers.tpl
+++ b/openstack/placement/templates/_helpers.tpl
@@ -1,3 +1,12 @@
 {{- define "placement_project" -}}
 {{ if contains "rocky" .Values.imageVersion }}nova{{ else }}placement{{ end }}
 {{- end -}}
+
+{{- define "job_name" }}
+  {{- $name := index . 1 }}
+  {{- with index . 0 }}
+    {{- $all := list (include "utils.proxysql.job_pod_settings" . ) (include "utils.proxysql.volume_mount" . ) (include "utils.proxysql.container" . ) (include "utils.proxysql.volumes" .) | join "\n" }}
+    {{- $hash := empty .Values.proxysql.mode | ternary "" $all | sha256sum }}
+{{- .Release.Name }}-{{ $name }}-{{ substr 0 4 $hash }}-{{ .Values.imageVersion | required "Please set .imageVersion or similar"}}
+  {{- end }}
+{{- end }}

--- a/openstack/placement/templates/db-migrate-job.yaml
+++ b/openstack/placement/templates/db-migrate-job.yaml
@@ -1,0 +1,75 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  # since this name changes with every image change, removal and creation of
+  # this Job happens on nearly every deployment. Check the helm-chart changes
+  # to see if this needs more review.
+  name: {{ tuple . "db-migrate" | include "job_name" }}
+  labels:
+    system: openstack
+    type: configuration
+    component: placement
+spec:
+  template:
+    metadata:
+      labels:
+        alert-tier: os
+        alert-service: placement
+{{ tuple . "placement" "db-migrate" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
+    spec:
+      restartPolicy: OnFailure
+      {{- include "utils.proxysql.job_pod_settings" . | indent 6 }}
+      initContainers:
+        - name: dependencies
+          image: {{ required ".Values.global.registry is missing" .Values.global.registry}}/ubuntu-source-nova-placement-api:{{.Values.imageVersion | required "Please set .imageVersion or similar" }}
+          imagePullPolicy: IfNotPresent
+          command:
+            - kubernetes-entrypoint
+          env:
+            - name: COMMAND
+              value: "true"
+            - name: NAMESPACE
+              value: {{ .Release.Namespace }}
+            - name: DEPENDENCY_SERVICE
+              value: {{ if .Values.mariadb.enabled -}}
+                "{{ .Values.mariadb.name }}-mariadb"
+                {{- else -}}
+                  "nova-api-mariadb"
+                {{- end }}
+      containers:
+      - name: db-migrate
+        image: {{ required ".Values.global.registry is missing" .Values.global.registry}}/ubuntu-source-nova-placement-api:{{.Values.imageVersion | required "Please set .imageVersion or similar" }}
+        imagePullPolicy: IfNotPresent
+        command:
+        - dumb-init
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+          if which placement-manage; then
+              placement-manage db sync
+          else
+              # wait for proxysql to start so we can properly kill it
+              sleep 5
+          fi
+          {{ include "utils.proxysql.proxysql_signal_stop_script" . | trim }}
+        env:
+          {{- if .Values.sentry.enabled }}
+        - name: SENTRY_DSN
+          valueFrom:
+            secretKeyRef:
+              name: sentry
+              key: {{ .Chart.Name }}.DSN.python
+          {{- end }}
+        - name: PYTHONWARNINGS
+          value: {{ .Values.python_warnings | quote }}
+        volumeMounts:
+        - mountPath: /etc/{{ include "placement_project" . }}
+          name: placement-etc
+        {{- include "utils.proxysql.volume_mount" . | indent 8 }}
+      {{- include "utils.proxysql.container" . | indent 6 }}
+      volumes:
+      - name: placement-etc
+        configMap:
+          name: placement-etc
+      {{- include "utils.proxysql.volumes" . | indent 6 }}

--- a/openstack/placement/templates/db-online-migrate-job.yaml
+++ b/openstack/placement/templates/db-online-migrate-job.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  # since this name changes with every image change, removal and creation of
+  # this Job happens on nearly every deployment. Check the helm-chart changes
+  # to see if this needs more review.
+  name: {{ tuple . "db-online-migrate" | include "job_name" }}
+  labels:
+    system: openstack
+    type: configuration
+    component: placement
+spec:
+  template:
+    metadata:
+      labels:
+        alert-tier: os
+        alert-service: placement
+{{ tuple . "placement" "db-online-migrate" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
+    spec:
+      restartPolicy: OnFailure
+      {{- include "utils.proxysql.job_pod_settings" . | indent 6 }}
+      initContainers:
+        - name: dependencies
+          image: {{ required ".Values.global.registry is missing" .Values.global.registry}}/ubuntu-source-nova-placement-api:{{.Values.imageVersion | required "Please set .imageVersion or similar" }}
+          imagePullPolicy: IfNotPresent
+          command:
+            - kubernetes-entrypoint
+          env:
+            - name: COMMAND
+              value: "true"
+            - name: NAMESPACE
+              value: {{ .Release.Namespace }}
+            - name: DEPENDENCY_JOBS
+              value: {{ tuple . "db-migrate" | include "job_name" }}
+            - name: DEPENDENCY_SERVICE
+              value: {{ if .Values.mariadb.enabled -}}
+                "{{ .Values.mariadb.name }}-mariadb"
+                {{- else -}}
+                  "nova-api-mariadb"
+                {{- end }}
+      containers:
+      - name: db-online-migrate
+        image: {{ required ".Values.global.registry is missing" .Values.global.registry}}/ubuntu-source-nova-placement-api:{{.Values.imageVersion | required "Please set .imageVersion or similar" }}
+        imagePullPolicy: IfNotPresent
+        command:
+        - dumb-init
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+          if which placement-manage; then
+              placement-manage db online_data_migrations
+          else
+              # wait for proxysql to start so we can properly kill it
+              sleep 5
+          fi
+          {{ include "utils.proxysql.proxysql_signal_stop_script" . | trim }}
+        env:
+          {{- if .Values.sentry.enabled }}
+        - name: SENTRY_DSN
+          valueFrom:
+            secretKeyRef:
+              name: sentry
+              key: {{ .Chart.Name }}.DSN.python
+          {{- end }}
+        - name: PYTHONWARNINGS
+          value: {{ .Values.python_warnings | quote }}
+        volumeMounts:
+        - mountPath: /etc/{{ include "placement_project" . }}
+          name: placement-etc
+        {{- include "utils.proxysql.volume_mount" . | indent 8 }}
+      {{- include "utils.proxysql.container" . | indent 6 }}
+      volumes:
+      - name: placement-etc
+        configMap:
+          name: placement-etc
+      {{- include "utils.proxysql.volumes" . | indent 6 }}


### PR DESCRIPTION
When running Placement on its own images, Placement is responsible for migrating the DB. This is done via the placement-manage command.

We add 2 Jobs here - one for migrated the schema and one for doing any necessary data migrations.

Both Jobs only run if they find "placement-manage" in the path and thus will only do any work once we upgrade Placement to Yoga and its own images.