### PR TITLE
[kube-monitoring-metal] kube-state-monitoring to dedicated chart

### DIFF
--- a/system/kube-monitoring-metal/Chart.lock
+++ b/system/kube-monitoring-metal/Chart.lock
@@ -17,6 +17,9 @@ dependencies:
 - name: k8s-secrets-certificate-exporter
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.4.1
+- name: kube-state-metrics
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 4.16.0
 - name: kube-state-metrics-exporter
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.7
@@ -56,5 +59,5 @@ dependencies:
 - name: prober-static
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.3
-digest: sha256:9637833ab30ebf26fbf8ae52c6c637cf7ab9a864c8e161f8c283bf3ece9001f5
-generated: "2022-10-05T11:06:44.384208+02:00"
+digest: sha256:73d7eae262f5a5a460f7b3a1c5a74395172ced959f9ab933d378dc23e8da69c3
+generated: "2022-10-06T10:53:07.647997+02:00"

--- a/system/kube-monitoring-metal/Chart.yaml
+++ b/system/kube-monitoring-metal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes metal controlplane monitoring.
 name: kube-monitoring-metal
-version: 4.1.29
+version: 4.2.0
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-metal
 dependencies:
   - name: pvc-exporter
@@ -24,6 +24,9 @@ dependencies:
   - name: k8s-secrets-certificate-exporter
     repository: https://charts.eu-de-2.cloud.sap
     version: 1.4.1
+  - name: kube-state-metrics
+    repository: https://prometheus-community.github.io/helm-charts
+    version: 4.16.0
   - name: kube-state-metrics-exporter
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.1.7

--- a/system/kube-monitoring-metal/values.yaml
+++ b/system/kube-monitoring-metal/values.yaml
@@ -6,6 +6,10 @@ global:
   rbac:
     create: true
 
+# Disable the prometheus-operator kube-state-metrics sub-chart. We deploy independently. See below.
+kubeStateMetrics:
+  enabled: false
+
 kube-prometheus-stack:
   nameOverride: prometheus
   fullnameOverride: prometheus
@@ -70,33 +74,6 @@ kube-prometheus-stack:
     enabled: false
 
   kube-state-metrics:
-    image:
-      repository: keppel.eu-de-1.cloud.sap/ccloud-quay-mirror/coreos/kube-state-metrics
-    podSecurityPolicy:
-      enabled: false
-
-    customLabels:
-      app: kube-state-metrics
-
-    prometheusScrape: false
-
-    collectors:
-      # Not useful.
-      configmaps: false
-      secrets: false
-      mutatingwebhookconfigurations: false
-      validatingwebhookconfigurations: false
-      certificatesigningrequests: false
-      ingresses: false
-      verticalpodautoscalers: true
-
-    prometheus:
-      monitor:
-        enabled: false
-        honorLabels: true
-        additionalLabels:
-          prometheus: collector-kubernetes
-
     resources:
       requests:
         memory: 150Mi
@@ -104,6 +81,61 @@ kube-prometheus-stack:
 
 absent-metrics-operator:
   enabled: true
+
+kube-state-metrics:
+  image:
+    repository: keppel.global.cloud.sap/ccloud-k8sgcr-mirror/kube-state-metrics/kube-state-metrics
+
+  podSecurityPolicy:
+    enabled: false
+
+  prometheusScrape: false
+
+  collectors:
+    # Not useful.
+    # - certificatesigningrequests
+    # - configmaps
+    - cronjobs
+    - daemonsets
+    - deployments
+    - endpoints
+    - horizontalpodautoscalers
+    # - ingresses
+    - jobs
+    - limitranges
+    # - mutatingwebhookconfigurations
+    - namespaces
+    - networkpolicies
+    - nodes
+    - persistentvolumeclaims
+    - persistentvolumes
+    - poddisruptionbudgets
+    - pods
+    - replicasets
+    - replicationcontrollers
+    - resourcequotas
+    # - secrets
+    - services
+    - statefulsets
+    - storageclasses
+    # - validatingwebhookconfigurations
+    - volumeattachments
+    - verticalpodautoscalers
+
+  customLabels:
+    app: kube-state-metrics
+
+  prometheus:
+    monitor:
+      enabled: false
+      honorLabels: true
+      additionalLabels:
+        prometheus: collector-kubernetes
+
+  resources:
+    requests:
+      memory: 150Mi
+      cpu: 100m
 
 # Values for operated Prometheus collector.
 prometheus-collector:


### PR DESCRIPTION
don't use kube-state-monitoring from kube-prometheus-stack anymore. Pulling in own version with dedicated config