### PR TITLE
Do not wait for neutron network agents

### DIFF
--- a/openstack/neutron/templates/statefulset-network-agent-apod.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent-apod.yaml
@@ -36,6 +36,7 @@ spec:
         k8s.v1.cni.cncf.io/networks: '[{ "name": "cbr1-bridge", "interface":"{{$.Values.cp_network_interface}}" }]'
         configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") $ | sha256sum }}
         configmap-etc-apod-hash: {{ include (print $.Template.BasePath "/configmap-etc-apod.yaml") $ | sha256sum }}
+        cloud.sap/wait-for-ready: 'false'
       labels:
         name: neutron-network-agent-{{ $apod }}
 {{ tuple $ "neutron" "agent" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}


### PR DESCRIPTION
cloud.sap/wait-for-ready will mark our network agents as something the CI does not have to wait for. The rolling rollout for the network agents can take quite long (depending on the amount up to 90 minutes) and we don't need to wait for all of them being done for a deployment to succeed.