### PR TITLE
[Octavia] Remove unused templating of bigip_urls

### DIFF
--- a/openstack/octavia/templates/etc/_octavia-worker.conf.tpl
+++ b/openstack/octavia/templates/etc/_octavia-worker.conf.tpl
@@ -18,7 +18,7 @@ override_vcmp_guest_names = {{ $loadbalancer.override_vcmp_guest_names | join ",
 
 
 [f5_agent]
-bigip_urls = {{ if $loadbalancer.devices -}}{{- tuple $envAll $loadbalancer.devices | include "utils.bigip_urls" -}}{{- else -}}{{ $loadbalancer.bigip_urls | join ", " }}{{- end }}
+bigip_urls = {{- tuple $envAll $loadbalancer.devices | include "utils.bigip_urls" -}}
 bigip_verify = false
 bigip_token = true
 esd_dir = /etc/octavia/esd


### PR DESCRIPTION
$loadbalancer.bigip_urls is old and deprecated and isn't used anymore anywhere. Instead, we use .devices everywhere.