### PR TITLE
[MariaDB] - Enable Performance Schema

### DIFF
--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.6.0
+version: 0.6.1

--- a/common/mariadb/templates/etc-configmap.yaml
+++ b/common/mariadb/templates/etc-configmap.yaml
@@ -34,6 +34,24 @@ data:
     performance_schema        = {{ .Values.performance_schema }}
     log_warnings              = {{ .Values.log_warnings }}
     general_log_file          = /var/log/mysql/mariadb_general.log
+{{- if .Values.db_performance_schema.enabled}}
+    performance_schema        = ON
+{{ else }}
+    performance_schema        = OFF
+{{- end }}  
+{{- if .Values.db_performance_schema.enabled }}
+{{- if .Values.db_performance_schema_instrument.enabled}}
+    performance-schema-instrument        = 'stage/%=ON'
+    performance_schema_consumer_global_instrumentation        = ON
+    performance_schema_consumer_thread_instrumentation        = ON
+    performance_schema_consumer_statements_digest        = ON
+{{ else }}
+    performance-schema-instrument        = 'stage/%=OFF'
+    performance_schema_consumer_global_instrumentation        = OFF
+    performance_schema_consumer_thread_instrumentation        = OFF
+    performance_schema_consumer_statements_digest        = OFF
+{{- end }}
+{{- end }} 
 {{- if .Values.backup_v2.enabled }}
     binlog_format             = {{ .Values.binlog_format }}
     expire_logs_days          = {{ .Values.expire_logs_days }}

--- a/common/mariadb/templates/etc-configmap.yaml
+++ b/common/mariadb/templates/etc-configmap.yaml
@@ -31,7 +31,6 @@ data:
     sql_mode                  = "TRADITIONAL"
     slow_query_log            = 1
     long_query_time           = 3
-    performance_schema        = {{ .Values.performance_schema }}
     log_warnings              = {{ .Values.log_warnings }}
     general_log_file          = /var/log/mysql/mariadb_general.log
 {{- if .Values.db_performance_schema.enabled}}

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -25,7 +25,7 @@ db_performance_schema: # Enabling performance schema only (without enabling inst
   enabled: true
   
 db_performance_schema_instrument: # Enabling performance schema instruments. 
-                                  # In order to enable it you need to enable the enable_ps.
+                                  # Please enable the db_performance_schema in order to enable the db_performance_schema_instrument.
   enabled: false
   # default : false
 

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -9,7 +9,6 @@ imagePullPolicy: IfNotPresent
 port_public: 3306
 max_connections: 1024
 buffer_pool_size: "1024M"
-performance_schema: "OFF"
 log_file_size: "256M"
 log_warnings: "2"
 query_cache_size: "0"
@@ -19,6 +18,17 @@ binlog_format: "MIXED"
 expire_logs_days: 10
 character_set_server: 'utf8'  # Should be utf8mb4, but we started with this
 collation_server: 'utf8_general_ci'
+
+db_performance_schema: # Enabling performance schema only (without enabling instruments for data collections).
+                       # Instrument can be enabled separately. Only Performance Schema Enablement does not cause any
+                       # overhead.
+  enabled: true
+  
+db_performance_schema_instrument: # Enabling performance schema instruments. 
+                                  # In order to enable it you need to enable the enable_ps.
+  enabled: false
+  # default : false
+
 
 root_password: null
 initdb_configmap: null


### PR DESCRIPTION
The Performance Schema is a feature for monitoring MariaDB/MYSQL Server execution at a low level. The Performance Schema has these characteristics:

The Performance Schema provides a way to inspect internal execution of the server at runtime. It is implemented using the [PERFORMANCE_SCHEMA](https://dev.mysql.com/doc/mysql-perfschema-excerpt/8.0/en/performance-schema.html) storage engine and the performance_schema database. The Performance Schema focuses primarily on performance data. This differs from INFORMATION_SCHEMA, which serves for inspection of metadata.

The Performance Schema monitors server events. An “event” is anything the server does that takes time and has been instrumented so that timing information can be collected. In general, an event could be a function call, a wait for the operating system, a stage of an SQL statement execution such as parsing or sorting, or an entire statement or group of statements. Event collection provides access to information about synchronization calls (such as for mutexes) file and table I/O, table locks, and so forth for the server and for several storage engines.

Performance Schema can be enabled by two settings by Helm:
1. Enable the PS only without instruments
2. Enable the instruments to collect the default PS metrics

Note: The collection has been disabled by default. It can be enabled by script or from mysql. Thus this settings do not cause performance overhead.

db_performance_schema: # Enabling performance schema only (without enabling instruments for data collections).
                       # Instrument can be enabled separately. Only Performance Schema Enablement does not cause any
                       # overhead.
  enabled: true
  
  db_performance_schema_instrument: # Enabling performance schema instruments. 
                                  # In order to enable it you need to enable the db_performance_schema.
  enabled: false
  # default : false