### PR TITLE
[MariaDB] - Security Patches upgrade to 10.5.17

### DIFF
--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.6.0
+version: 0.6.2

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -4,7 +4,7 @@
 # name: value
 
 name: null
-image: library/mariadb:10.5.12
+image: library/mariadb:10.5.17
 imagePullPolicy: IfNotPresent
 port_public: 3306
 max_connections: 1024


### PR DESCRIPTION
The PR contains official upgrade to MariaDB version 10.5.17. This is part of the Security Patch Lifecycle.

The version has been tested in qa-de-3.


Fixes for the following [security vulnerabilities](https://mariadb.com/kb/en/cve/):
[CVE-2022-32082](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-32082)
[CVE-2022-32089](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-32089)
[CVE-2022-32081](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-32081)
[CVE-2018-25032](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-25032)
[CVE-2022-32091](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-32091)
[CVE-2022-32084](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-32084)