### PR TITLE
[placement] Set policy file path

### DIFF
--- a/openstack/placement/templates/etc/_placement.conf.tpl
+++ b/openstack/placement/templates/etc/_placement.conf.tpl
@@ -46,6 +46,9 @@ driver = noop
 [oslo_middleware]
 enable_proxy_headers_parsing = true
 
+[oslo_policy]
+policy_file = /etc/placement/policy.yaml
+
 {{- include "ini_sections.cache" . }}
 
 {{- include "util.helpers.valuesToIni" .Values.placement_conf }}


### PR DESCRIPTION
Even though it looked like Placement would overwrite the oslo.policy's default to "policy.yaml" in [0], this doesn't seem to work. Therefore, we explicitly set the policy_file option now.

[0] https://github.com/sapcc/placement/blob/17cb78c072b2cd7d10b59194b0f167629858fda9/placement/conf/base.py#L38