### PR TITLE
[nova] Increase OpenstackNovaComputeIdle wait time

### DIFF
--- a/openstack/nova/alerts/kubernetes/nova.alerts
+++ b/openstack/nova/alerts/kubernetes/nova.alerts
@@ -3,7 +3,7 @@ groups:
   rules:
   - alert: OpenstackNovaComputeIdle
     expr: max(rate(container_cpu_usage_seconds_total{pod_name=~"nova-compute-bb.*"}[5m])) by (pod_name) * 1000 < 15
-    for: 20m
+    for: 60m
     labels:
       severity: warning
       tier: os


### PR DESCRIPTION
More often than not, the alert fires without real reason nowadays and thus produces alert-fatigue. We now increase the time the condition has to be true to make the alert fire to 60min. We won't get alerted early, but we will still get notified of persisting problems.

If this proves to be too long, we will probably remove the alert in the future. It's a very broad alert-condition and the cc3test suite should provide similar information.