### PR TITLE
[nova] Add console deployments back again

### DIFF
--- a/openstack/nova/templates/console-deployment.yaml
+++ b/openstack/nova/templates/console-deployment.yaml
@@ -1,0 +1,7 @@
+{{ $envAll := . }}
+{{- range $name, $config := .Values.consoles }}
+  {{- if $config.enabled }}
+---
+{{ tuple $envAll $name $config | include "nova.console_deployment" }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
With the commit "[nova] Remove consoleauth support" 996518a8 we removed the consoleauth-deployment.yaml - but contained not only the deployment for consoleauth, but also the deployments of the different consoles. Since we still need the consoles, we add them back now in their own file.