### PR TITLE
swift: roll daemonsets faster

### DIFF
--- a/openstack/swift/templates/proxy-daemonset.yaml
+++ b/openstack/swift/templates/proxy-daemonset.yaml
@@ -12,6 +12,8 @@ spec:
   minReadySeconds: 15
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: '10%' # in large clusters, allow rolling multiple proxies at once
   selector:
     matchLabels:
       component: swift-proxy-{{ .Values.cluster_name }}

--- a/openstack/swift/templates/replicators-daemonset.yaml
+++ b/openstack/swift/templates/replicators-daemonset.yaml
@@ -11,6 +11,8 @@ spec:
   minReadySeconds: 15
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: '20%' # these pods can be rolled rather quickly since they are not in the hot path
   selector:
     matchLabels:
       component: swift-replicators

--- a/openstack/swift/templates/rsyncd-daemonset.yaml
+++ b/openstack/swift/templates/rsyncd-daemonset.yaml
@@ -11,6 +11,8 @@ spec:
   minReadySeconds: 15
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: '20%' # these pods can be rolled rather quickly since they are not in the hot path
   selector:
     matchLabels:
       component: swift-rsyncd

--- a/openstack/swift/templates/servers-daemonset.yaml
+++ b/openstack/swift/templates/servers-daemonset.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 2 # each object has 3 replicas, so we can afford to have 2 servers missing at a time without causing outage
   selector:
     matchLabels:
       component: swift-servers

--- a/openstack/swift/templates/workers-daemonset.yaml
+++ b/openstack/swift/templates/workers-daemonset.yaml
@@ -11,6 +11,8 @@ spec:
   minReadySeconds: 15
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: '20%' # these pods can be rolled rather quickly since they are not in the hot path
   selector:
     matchLabels:
       component: swift-workers


### PR DESCRIPTION
This is based on my own experience driving deployments in a way that does not make them a huge time sink. The most controversial part is probably the `maxUnavailable: 2` on the swift-servers, but this is also the most important in terms of reducing the time required to complete a deployment.