### PR TITLE
[Cinder] Conditionally enable FCD driver

### DIFF
--- a/openstack/cinder/templates/vcenter_datacenter_cinder_configmap.yaml
+++ b/openstack/cinder/templates/vcenter_datacenter_cinder_configmap.yaml
@@ -20,7 +20,7 @@ template: |
   data:
     cinder-volume.conf: |
       [DEFAULT]
-      enabled_backends = {{ .Values.backends.enabled }}
+      enabled_backends = {{ .Values.backends.enabled }}{{ if .Values.backends.vmware_fcd.enabled | default false }},vmware_fcd {{- end }}
 
       [backend_defaults]
       vmware_host_ip = {= host =}
@@ -55,7 +55,11 @@ template: |
       {{- end }}
       {{ end }}
 
-      [vstorageobject]
+      {{ if .Values.backends.vmware_fcd.enabled | default false }}
+      [vmware_fcd]
       volume_driver = cinder.volume.drivers.vmware.fcd.VMwareVStorageObjectDriver
-      volume_backend_name = vstorageobject
+      volume_backend_name = vmware_fcd
+      vmware_storage_profile = {{ .Values.backends.vmware_fcd.vmware_storage_profile }}
+      extra_capabilities = '{"vcenter-shard": "{= host.split(".")[0] =}"}'
+      {{- end }}
 {{- end }}

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -67,6 +67,9 @@ backends:
     vmware_storage_profile: cinder-vvol
   standard_hdd:
     vmware_storage_profile: cinder-standard-hdd
+  vmware_fcd:
+    enabled: false
+    vmware_storage_profile: cinder-fcd
 
 cinderApiPortPublic: 443
 cinderApiPortInternal: 8776


### PR DESCRIPTION
This patch updates the helm-chart for cinder to conditionally enable the first class disk driver.  By default it's disabled.

This will allow me to enable it for qa for testing.