### PR TITLE
[designate] Integrate locking via pvc

### DIFF
--- a/openstack/designate/Chart.lock
+++ b/openstack/designate/Chart.lock
@@ -19,6 +19,6 @@ dependencies:
   version: 0.1.6
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.4.3
-digest: sha256:27ddd198c253864e29e75a2b846393ece131a11569dcb58ce6dcc499a9eaa387
-generated: "2022-10-04T18:48:06.594832+02:00"
+  version: 0.7.0
+digest: sha256:5a27bebf05e250a15410ee7698edd8a5d10af224a6dec6b5885eddd99f9fe2f0
+generated: "2022-10-13T12:25:32.950962155+02:00"

--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -28,4 +28,4 @@ dependencies:
     version: 0.1.6
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.4.3
+    version: 0.7.0


### PR DESCRIPTION
Instead of using the memcached driver, we can use
the PVC which should be more robust with respect
to restarts of the nodes.

By default, stay on memcached.