### PR TITLE
[nova] Allow 16 GiB VMs on small HVs

### DIFF
--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -252,7 +252,7 @@ scheduler:
   # enables collecting metrics for RPC calls
   rpc_statsd_enabled: true
   default_filters: "CpuInfoMigrationFilter, ShardFilter, AggregateMultiTenancyIsolation, ComputeFilter, ComputeCapabilitiesFilter, BigVmFlavorHostSizeFilter, VmSizeThresholdFilter, ImagePropertiesFilter, ServerGroupAntiAffinityFilter, ServerGroupAffinityFilter"
-  vm_size_threshold_vm_size_mb: "8193"
+  vm_size_threshold_vm_size_mb: "16385"
   vm_size_threshold_hv_size_mb: "819200"
   ram_weight_multiplier: 1.0
   cpu_weight_multiplier: 1.0


### PR DESCRIPTION
Instead of allowing only 8 GiB VMs on the small HVs, we now allow 16 GiB, too, because this currently fits in nearly all regions. In the regions it doesn't fit, we assume that most 16 GiB VMs will not be migrated in the near future and thus not clog the small HVs.