### PR TITLE
[Cinder] Rollback volume stacking on datastores

### DIFF
--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -85,7 +85,7 @@ db_name: cinder
 scheduler_default_filters: "AvailabilityZoneFilter,ShardFilter,SAPPoolDownFilter,CapabilitiesFilter,SAPLargeVolumeFilter,SAPDifferentBackendFilter,SAPSameBackendFilter,CapacityFilter"
 scheduler_default_weighers: "CapacityWeigher"
 
-capacity_weight_multiplier: -1.0
+capacity_weight_multiplier: 1.0
 allocated_capacity_weight_multiplier: -1.0
 
 cinder_api_allow_migration_on_attach: True


### PR DESCRIPTION
This patch changes the default capacity weigher to spread volumes out over datastores from stacking.  We have to do this short term to help buy time for allowing volume snapshots on datastores.  Stacking causes datastores to get full quickly.  When a datastore is full snapshotting fails due to not having space to do the snapshot, which is a full clone.