### PR TITLE
Add support_group label

### DIFF
--- a/openstack/cinder/alerts/openstack-cinder.alerts
+++ b/openstack/cinder/alerts/openstack-cinder.alerts
@@ -8,6 +8,7 @@ groups:
       dashboard: cinder
       meta: 'Volume {{ $labels.display_name }} in Deleting state since {{ $value }}s'
       playbook: docs/support/playbook/volumes.html
+      support_group: compute-storage-api
       service: cinder
       severity: info
       tier: os
@@ -22,6 +23,7 @@ groups:
       dashboard: cinder
       meta: 'Volume {{ $labels.display_name }} in Attaching state since {{ $value }}s'
       playbook: docs/support/playbook/volumes.html
+      support_group: compute-storage-api
       service: cinder
       severity: info
       tier: os
@@ -36,6 +38,7 @@ groups:
       dashboard: cinder
       meta: 'Volume {{ $labels.display_name }} in Detaching state since {{ $value }}s'
       playbook: docs/support/playbook/volumes.html
+      support_group: compute-storage-api
       service: cinder
       severity: info
       tier: os


### PR DESCRIPTION
This patch adds the new support_group label to the cinder alerts