### PR TITLE
[mariadb] support_group label added to alerts template

### DIFF
--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.6.1
+version: 0.7.0

--- a/common/mariadb/templates/alerts/_backup-v2.alerts.tpl
+++ b/common/mariadb/templates/alerts/_backup-v2.alerts.tpl
@@ -8,6 +8,7 @@
       service: {{ include "alerts.service" . }}
       severity: warning
       tier: {{ required ".Values.alerts.tier missing" .Values.alerts.tier }}
+      support_group: {{ required ".Values.alerts.support_group missing" .Values.alerts.support_group }}
     annotations:
       description: {{ include "fullName" . }} full backup missing. Please check the backup container.
       summary: {{ include "fullName" . }} full backup missing
@@ -20,6 +21,7 @@
       service: {{ include "alerts.service" . }}
       severity: warning
       tier: {{ required ".Values.alerts.tier missing" .Values.alerts.tier }}
+      support_group: {{ required ".Values.alerts.support_group missing" .Values.alerts.support_group }}
     annotations:
       description: {{ include "fullName" . }} incremental backup missing. Please check the backup container.
       summary: {{ include "fullName" . }} incremental backup missing
@@ -33,6 +35,7 @@
       service: {{ include "alerts.service" . }}
       severity: info
       tier: {{ required ".Values.alerts.tier missing" .Values.alerts.tier }}
+      support_group: {{ required ".Values.alerts.support_group missing" .Values.alerts.support_group }}
     annotations:
       description: All {{ include "fullName" . }} backup verifications failed for both storage backends. Check the backup container.
       summary: {{ include "fullName" . }} backup failed all verifications

--- a/common/mariadb/templates/alerts/_health.alerts.tpl
+++ b/common/mariadb/templates/alerts/_health.alerts.tpl
@@ -8,6 +8,7 @@
       service: {{ include "alerts.service" . }}
       severity: critical
       tier: {{ required ".Values.alerts.tier missing" .Values.alerts.tier }}
+      support_group: {{ required ".Values.alerts.support_group missing" .Values.alerts.support_group }}
       playbook: 'docs/support/playbook/db_crashloop.html'
     annotations:
       description: {{ include "fullName" . }} database is not ready for 10 minutes.

--- a/common/mariadb/templates/alerts/_mysql.alerts.tpl
+++ b/common/mariadb/templates/alerts/_mysql.alerts.tpl
@@ -8,6 +8,7 @@
       service: {{ include "alerts.service" . }}
       severity: info
       tier: {{ required ".Values.alerts.tier missing" .Values.alerts.tier }}
+      support_group: {{ required ".Values.alerts.support_group missing" .Values.alerts.support_group }}
     annotations:
       description: {{ include "fullName" . }} has too many connections open. Please check the service containers.
       summary: {{ include "fullName" . }} has too many connections open.
@@ -20,6 +21,7 @@
       service: {{ include "alerts.service" . }}
       severity: warning
       tier: {{ required ".Values.alerts.tier missing" .Values.alerts.tier }}
+      support_group: {{ required ".Values.alerts.support_group missing" .Values.alerts.support_group }}
       playbook: 'docs/support/playbook/database/MariaDBSlowQueries.html'
     annotations:
       description: {{ include "fullName" . }} has reported slow queries. Please check the DB.
@@ -33,6 +35,7 @@
       service: {{ include "alerts.service" . }}
       severity: warning
       tier: {{ required ".Values.alerts.tier missing" .Values.alerts.tier }}
+      support_group: {{ required ".Values.alerts.support_group missing" .Values.alerts.support_group }}
     annotations:
       description: {{ include "fullName" . }} has queries waiting for lock more than 15 sec. Deadlock possible.
       summary: {{ include "fullName" . }} has queries waiting for lock.
@@ -45,6 +48,7 @@
       service: {{ include "alerts.service" . }}
       severity: info
       tier: {{ required ".Values.alerts.tier missing" .Values.alerts.tier }}
+      support_group: {{ required ".Values.alerts.support_group missing" .Values.alerts.support_group }}
       playbook: 'docs/support/playbook/manila/mariadb_high_running_threads.html'
     annotations:
       description: {{ include "fullName" . }} has more than 20 running threads.

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -16,19 +16,18 @@ query_cache_type: "0"
 join_buffer_size: "4M"
 binlog_format: "MIXED"
 expire_logs_days: 10
-character_set_server: 'utf8'  # Should be utf8mb4, but we started with this
-collation_server: 'utf8_general_ci'
+character_set_server: "utf8" # Should be utf8mb4, but we started with this
+collation_server: "utf8_general_ci"
 
 db_performance_schema: # Enabling performance schema only (without enabling instruments for data collections).
-                       # Instrument can be enabled separately. Only Performance Schema Enablement does not cause any
-                       # overhead.
+  # Instrument can be enabled separately. Only Performance Schema Enablement does not cause any
+  # overhead.
   enabled: true
-  
-db_performance_schema_instrument: # Enabling performance schema instruments. 
-                                  # Please enable the db_performance_schema in order to enable the db_performance_schema_instrument.
+
+db_performance_schema_instrument: # Enabling performance schema instruments.
+  # Please enable the db_performance_schema in order to enable the db_performance_schema_instrument.
   enabled: false
   # default : false
-
 
 root_password: null
 initdb_configmap: null
@@ -64,9 +63,9 @@ persistence_claim:
   #name:
   size: "10Gi"
   access_modes:
-  - ReadWriteOnce
-  - ReadWriteMany
-  - ReadOnlyMany
+    - ReadWriteOnce
+    - ReadWriteMany
+    - ReadOnlyMany
   autoprovision: false
   #storage_class: default
 
@@ -138,7 +137,7 @@ metrics:
   enabled: true
   image: prom/mysqld-exporter
   image_version: v0.12.1
-  port: '9104'
+  port: "9104"
   flags:
     - collect.binlog_size
     - collect.info_schema.processlist
@@ -163,6 +162,9 @@ alerts:
 
   # The tier of the alert.
   tier: os
+
+  # The support group label of the alerts. Must be given in values.yaml of parent chart.
+  #support_group:
 
   # Configurable service label of the alerts. Defaults to `.Release.Name`.
   # service:


### PR DESCRIPTION
- it is required for the on-call alert routing
- service owners have to define that for their MariaDB instance
- chart version bumped