### PR TITLE
[memchached] add support info for alerts

### DIFF
--- a/common/memcached/Chart.yaml
+++ b/common/memcached/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: memcached
-version: 0.0.10
+version: 0.0.11
 description: Free & open source, high-performance, distributed memory object caching system.
 home: http://memcached.org/
 sources:

--- a/common/memcached/templates/alerts/_memcached.alerts.tpl
+++ b/common/memcached/templates/alerts/_memcached.alerts.tpl
@@ -9,6 +9,7 @@ groups:
       service: {{ include "alerts.service" . }}
       severity: warning
       tier: {{ required ".Values.alerts.tier missing" .Values.alerts.tier }}
+      support_group: {{ required ".Values.alerts.support_group missing" .Values.alerts.support_group }}
     annotations:
       description: 'Many client connections throttled in memcache of {{`{{ $labels.app }}`}}.'
       summary: Many throttled client connections


### PR DESCRIPTION
it is required for the on-call alert routing

- support information added to label
- chart version bumped
- chart must fail if the Values.alerts.support_group is not set in the parent chart