### PR TITLE
[nova] Bump rabbitmq to get support_group alert label

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 0.2.7
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.4.2
+  version: 0.4.4
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.0.10
@@ -22,6 +22,6 @@ dependencies:
   version: 0.5.4
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.4.2
-digest: sha256:638fe7ef6e69bb37f261d862842ff05d64c341be3cddc28827c6a5c7dfea4cf7
-generated: "2022-09-14T13:02:21.171062567+02:00"
+  version: 0.4.4
+digest: sha256:98dc9d78f90dc2ea16b4519a0def4978b07aba200bb25020cf05ee52823e541a
+generated: "2022-10-19T14:54:47.885003359+02:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -20,7 +20,7 @@ dependencies:
     version: 0.2.7
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.4.2
+    version: 0.4.4
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.0.10
@@ -36,4 +36,4 @@ dependencies:
     alias: rabbitmq_cell2
     condition: cell2.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.4.2
+    version: 0.4.4

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -763,6 +763,7 @@ rabbitmq_cell2:
     rabbit_queue_length: 50
     unacknowledged_total_wait_for: 10m
     ready_total_wait_for: 10m
+    support_group: compute-storage-api
 
 audit:
   central_service:
@@ -796,6 +797,7 @@ rabbitmq:
     rabbit_queue_length: 50
     unacknowledged_total_wait_for: 10m
     ready_total_wait_for: 10m
+    support_group: compute-storage-api
 
 logging:
   formatters:


### PR DESCRIPTION
With rabbitmq chart version 0.4.4 we get to set the support_group label on the alerts defined in the rabbitmq chart.