### PR TITLE
[cinder] Bump rabbitmq to get support_group alert label

### DIFF
--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -13,12 +13,12 @@ dependencies:
   version: 0.0.10
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.4.2
+  version: 0.4.4
 - name: region_check
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.2
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.2.1
-digest: sha256:f778ea8ffe7f4beb8ffebecabcda6ee4bc01034b98b85e769b7281afad75a751
-generated: "2022-07-27T10:31:07.968744273+02:00"
+digest: sha256:ae34c57780779d3d7da0d6e995d383358b29c6f13d050ec54866c02c1d0e73ce
+generated: "2022-10-19T14:59:03.42005518+02:00"

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -20,7 +20,7 @@ dependencies:
     version: 0.0.10
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.4.2
+    version: 0.4.4
   - name: region_check
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.1.2

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -302,6 +302,7 @@ rabbitmq:
     rabbit_queue_length: 50
     unacknowledged_total_wait_for: 60m
     ready_total_wait_for: 60m
+    support_group: compute-storage-api
 
 rabbitmq_notifications:
   name: cinder


### PR DESCRIPTION
With rabbitmq chart version 0.4.4 we get to set the support_group label on the alerts defined in the rabbitmq chart.