### PR TITLE
[openstack-exporter][cinder] Update cinder alerts

### DIFF
--- a/prometheus-exporters/openstack-exporter/Chart.lock
+++ b/prometheus-exporters/openstack-exporter/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.4
+  version: 0.4.2
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.2
-digest: sha256:5098ffed1817756c37b2a9bc9b195dd2c9f8e4cbbe4d859dedcde5ce443717f7
-generated: "2022-05-19T11:52:59.439358+02:00"
+  version: 0.2.0
+digest: sha256:97b91fdb0baad7c28fdd17ab0cbc55e2b648d0781380012e25eb5c16a9096cb9
+generated: "2022-10-20T11:09:26.0672-04:00"

--- a/prometheus-exporters/openstack-exporter/Chart.yaml
+++ b/prometheus-exporters/openstack-exporter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: openstack-exporter
-version: 0.0.4
+version: 0.0.5
 description: Exporter for openstack information
 maintainers:
   - name: Tommy Sauer (viennaa)
@@ -8,7 +8,7 @@ maintainers:
 dependencies:
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.4
+    version: 0.4.2
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.2
+    version: 0.2.0

--- a/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
+++ b/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
@@ -9,6 +9,7 @@ groups:
       severity: critical
       tier: vmware
       service: cinder
+      support_group: compute-storage-api
       context: "openstack-exporter"
       meta: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has no storage capacity."
       playbook: docs/support/playbook/cinder/cinder-storage-profile-empty.html
@@ -22,6 +23,7 @@ groups:
       severity: warning
       tier: vmware
       service: cinder
+      support_group: compute-storage-api
       playbook: docs/support/playbook/cinder/cinder-low-free-space.html
     annotations:
       description: 'Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has 1 or less datastores with > 30% free space left'
@@ -33,38 +35,26 @@ groups:
       severity: warning
       tier: vmware
       service: cinder
+      support_group: compute-storage-api
       playbook: docs/support/playbook/cinder/cinder-low-free-space.html
     annotations:
       description: 'Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 2 datastores with > 30% free space left'
       summary: 'Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 2 datastores with > 30% free space left'
-  - alert: CinderShardMaxVolumeSizeWarning
+  - alert: CinderShardMaxVolumeSizeInfo
     expr: >
       count by (shard, backend) (sum(cinder_available_capacity_gib) by (shard, backend, pool)) - count by (shard, backend) (sum by(shard, backend, pool) (cinder_virtual_free_capacity_gib) - sum by(shard, backend, pool) (cinder_per_volume_gigabytes) <=0) < 3
     for: 15m
     labels:
-      severity: warning
+      severity: info
       tier: vmware
       service: cinder
+      support_group: compute-storage-api
       context: "openstack-exporter"
       meta: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has 2 or less datastores that can accept max volume size"
       playbook: docs/support/playbook/cinder/cinder-low-free-space.html
     annotations:
       description: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has 2 or less datastores that can accept max volume size"
       summary: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has 2 or less datastores that can accept max volume size"
-  - alert: CinderShardMaxVolumeSizeCritical
-    expr: >
-      count by (shard, backend) (sum(cinder_available_capacity_gib) by (shard, backend, pool)) - count by (shard, backend) (sum by(shard, backend, pool) (cinder_virtual_free_capacity_gib) - sum by(shard, backend, pool) (cinder_per_volume_gigabytes) <=0) < 2
-    for: 15m
-    labels:
-      severity: warning
-      tier: vmware
-      service: cinder
-      context: "openstack-exporter"
-      meta: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 2 datastores that can accept max volume size"
-      playbook: docs/support/playbook/cinder/cinder-low-free-space.html
-    annotations:
-      description: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 2 datastores that can accept max volume size"
-      summary: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has less than 2 datastores that can accept max volume size"
   - alert: CinderBackendDown
     expr: >
         cinder_backend_state_info{backend_state='down'}
@@ -73,26 +63,28 @@ groups:
       severity: info
       tier: vmware
       service: cinder
+      support_group: compute-storage-api
       context: "openstack-exporter"
       meta: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} is marked as down"
       playbook: docs/support/playbook/cinder/cinder-backend-down.html
     annotations:
       description: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} is marked as down"
       summary: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} is marked as down"
-  - alert: CinderPoolDown
+  - alert: CinderPoolOvercommited
     expr: >
-        cinder_pool_state_info{pool_state='down'}
+        cinder_virtual_free_capacity_gib < 0
     for: 15m
     labels:
       severity: info
       tier: vmware
       service: cinder
+      support_group: compute-storage-api
       context: "openstack-exporter"
-      meta: "Cinder pool {{ $labels.shard }}/{{ $labels.backend }}/{{ $labels.pool }} is marked as down"
+      meta: "Cinder pool {{ $labels.shard }}/{{ $labels.backend }}/{{ $labels.pool }} is overcommited"
       playbook: docs/support/playbook/cinder/cinder-pool-down.html
     annotations:
-      description: "Cinder pool {{ $labels.shard }}/{{ $labels.backend }}/{{ $labels.pool }} is marked as down"
-      summary: "Cinder pool {{ $labels.shard }}/{{ $labels.backend }}/{{ $labels.pool }} is marked as down"
+      description: "Cinder pool {{ $labels.shard }}/{{ $labels.backend }}/{{ $labels.pool }} is overcommited"
+      summary: "Cinder pool {{ $labels.shard }}/{{ $labels.backend }}/{{ $labels.pool }} is overcommited"
   - alert: CinderPoolNetappFQDNNotSet
     expr: >
         cinder_pool_netapp_fqdn_info{netapp_fqdn='None'}
@@ -101,6 +93,7 @@ groups:
       severity: info
       tier: vmware
       service: cinder
+      support_group: compute-storage-api
       context: "openstack-exporter"
       meta: "Cinder pool {{ $labels.shard }}/{{ $labels.backend }}/{{ $labels.pool }} Netapp FQDN is not set"
       playbook: docs/support/playbook/cinder/cinder-pool-netapp-fqdn.html

--- a/prometheus-exporters/openstack-exporter/values.yaml
+++ b/prometheus-exporters/openstack-exporter/values.yaml
@@ -1,7 +1,9 @@
 owner-info:
+  support-group: compute-storage-api
   maintainers:
   - Tommy Sauer
   - Walter Boring IV
+  - Johannes Kulik
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/prometheus-exporter/openstack-exporter
 exporter:
   prometheus_port: 9102


### PR DESCRIPTION
This patch adds the support_group label.
This patch changes the CinderPoolDown alert to CinderPoolOvercommited as we only care if a pool is overcommited.