### PR TITLE
[mariadb] moves grants for backup user to values

### DIFF
--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.7.0
+version: 0.7.1

--- a/common/mariadb/templates/initdb/_init.sql.tpl
+++ b/common/mariadb/templates/initdb/_init.sql.tpl
@@ -28,5 +28,3 @@ GRANT {{ . }} TO '{{ $username }}';
         {{- end }}
     {{- end }}
 {{- end }}
-
-GRANT ALL PRIVILEGES ON *.* TO '{{ $.Values.users.backup.name }}';

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -41,6 +41,8 @@ users:
     password: null
     limits:
       max_user_connections: 4
+    grants:
+      - ALL PRIVILEGES ON *.*
 #  example:
 #    name: example1 # This looks repetitive, but the point is that they key is the name
 #                   # you refer to in your charts, while the field 'name' is the actual name


### PR DESCRIPTION
Metis does not require backups. Thus, I have no backup user password set and creation of the backup user is skipped. 
Now the deploy fails because it wants to add grants to a non-existing user:
```
k logs metisdb-mariadb-pre-change-nx5wj
ERROR 1133 (28000) at line 9: Can't find any matching row in the user table
command terminated with exit code 1
```

My proposal is to move the grant to the values.yaml instead of having it hard-wired