### PR TITLE
[maia] get ingress to actually be there

### DIFF
--- a/openstack/maia/Chart.yaml
+++ b/openstack/maia/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Expose Prometheus as multi-tenant OpenStack service
 name: maia
-version: 1.2.2
+version: 1.2.3
 maintainers:
   - name: Martin Vossen (artherd42)
 dependencies:

--- a/openstack/maia/values.yaml
+++ b/openstack/maia/values.yaml
@@ -59,7 +59,8 @@ prometheus_server:
 
   ingress:
     enabled: true
-    host: [maia-prometheus-collector]
+    hosts:
+      - maia-prometheus
 
   service:
     annotations:


### PR DESCRIPTION
it was using the wrong directive and that's why alertmanager couldn't be set up fqdn helper should be happy now