### PR TITLE
[neutron] Bump chart versions of shared services to add support_group label support 

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -10,10 +10,10 @@ dependencies:
   version: 0.2.7
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.2
+  version: 0.4.4
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.2
+  version: 0.4.4
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.4.1

--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.55
+  version: 0.7.1
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.0.10

--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.7.1
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.0.10
+  version: 0.0.11
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.7

--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -17,5 +17,5 @@ dependencies:
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.4.1
-digest: sha256:fdc2b998d63da0816a5fd0ef3b8ae988d0e1bd6813b9e5bfc574ac1ad385c5ff
-generated: "2022-09-12T09:56:31.305225759+02:00"
+digest: sha256:553548b7926b175ae9d75427f57c599d7c0194b48d4ecfbebf73de32888fcb25
+generated: "2022-10-21T11:25:53.140271872+02:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.55
+    version: 0.7.1
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.0.10

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -17,12 +17,12 @@ dependencies:
     version: 0.2.7
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.2
+    version: 0.4.4
   - alias: rabbitmq_notifications
     condition: audit.enabled
     name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.2
+    version: 0.4.4
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.4.1

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -10,7 +10,7 @@ dependencies:
     version: 0.7.1
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.0.10
+    version: 0.0.11
   - condition: mariadb.enabled
     name: mysql_metrics
     repository: https://charts.eu-de-2.cloud.sap


### PR DESCRIPTION
Bump chart versions for mariadb, memcached, rabbitmq