### PR TITLE
[neutron] Avoid that network agents are co-scheduled on the same machine

### DIFF
--- a/openstack/neutron/templates/statefulset-network-agent-apod.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent-apod.yaml
@@ -26,7 +26,7 @@ spec:
   serviceName: neutron-network-agent
   podManagementPolicy: "Parallel"
 {{- if $.Values.pod.replicas.network_agent_apod }}
-  replicas: {{ $.Values.pod.replicas.network_agent_apod}} 
+  replicas: {{ $.Values.pod.replicas.network_agent_apod }} 
 {{- else }}
   replicas: 15
 {{- end }}
@@ -43,9 +43,18 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
+          - weight: 50
             podAffinityTerm:
               topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchExpressions:
+                - key: component
+                  operator: In
+                  values:
+                  - agent
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: kubernetes.cloud.sap/host
               labelSelector:
                 matchExpressions:
                 - key: component


### PR DESCRIPTION
Right now there is a not too small chance that any 2 network agents of a
network in a single-site region or an az-local network end up on the
same hypervisor. That is because we only use anti-affinity on hostname
level, but not on the physical host level.

To make this a little less likely, let us add a higher-weighted
anti-affinity on the physical host level. That way we avoid scheduling
on the same machine a long as there are enough machines available. In
case there are not, we will still schedule but just on another VM. These
are all soft affinities, so nothing will stay in pending.

Unfortunately we cannot just reduce the amount of replicas, as the
number of physical machines varies between regions. If a physical
machine were to be taken out, that would reduce the number of replicas
and would entail a rebalancing of the networks to fewer agents, each
time a physical host is added or removed.