### PR TITLE
[placement] Add support_group label to all alerts

### DIFF
--- a/openstack/placement/Chart.lock
+++ b/openstack/placement/Chart.lock
@@ -1,12 +1,15 @@
 dependencies:
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.55
+  version: 0.7.1
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.0.10
+  version: 0.0.11
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.4.4
-digest: sha256:c8145237e722226e5a311ca7e599ac566436e6cabac995deec733dc6505b2a6e
-generated: "2022-09-12T09:39:10.766267246+02:00"
+- name: owner-info
+  repository: https://charts.eu-de-2.cloud.sap
+  version: 0.2.0
+digest: sha256:8cb273452ebe8450ba3547fcd16df76a093219cde857899d97a8f4da3ac87006
+generated: "2022-10-24T09:57:31.889198918+02:00"

--- a/openstack/placement/Chart.yaml
+++ b/openstack/placement/Chart.yaml
@@ -8,10 +8,13 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.55
+    version: 0.7.1
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.0.10
+    version: 0.0.11
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.4.4
+  - name: owner-info
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 0.2.0

--- a/openstack/placement/values.yaml
+++ b/openstack/placement/values.yaml
@@ -54,6 +54,12 @@ api_db: # Only used when mariadb.enabled=False to connect to the nova-api-mariad
 mariadb:
   enabled: true
   name: placement
+  alerts:
+    support_group: "compute-storage-api"
+
+memcached:
+  alerts:
+    support_group: "compute-storage-api"
 
 logging:
   formatters:
@@ -98,3 +104,13 @@ sentry:
 # Each first level item will become a section, and only on the second-level
 # we have key value pairs
 placement_conf: {}
+
+owner-info:
+  support-group: compute-storage-api
+  service: placement
+  maintainers:
+    - Fabian Wiesel
+    - Johannes Kulik
+    - Jakob Karge
+    - Marius Leustean
+  helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/openstack/placement


### PR DESCRIPTION
We need to bump the mariadb and memcached chart to get support for setting the support_group label on the included alerts and we also have to include the owner-info chart for getting support for setting support_group on the k8s objects' alerts.