### PR TITLE
[cinder] Add support_group label to all alerts

### DIFF
--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -4,18 +4,21 @@ dependencies:
   version: 0.4.2
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.55
+  version: 0.7.1
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.7
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.0.10
+  version: 0.0.11
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.4.4
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.2.1
-digest: sha256:f2079128666a19fb6bbf03e7e2ffd30373cabf827551ed45e566fa3311701d5e
-generated: "2022-10-20T15:34:16.786651446+02:00"
+- name: owner-info
+  repository: https://charts.eu-de-2.cloud.sap
+  version: 0.2.0
+digest: sha256:66c372bd10d2f6ab12af71e1d67c3a88798d70b5f735c3701f5efed54fc855a7
+generated: "2022-10-24T10:04:41.776463357+02:00"

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
     version: 0.4.2
   - name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.55
+    version: 0.7.1
     condition: mariadb.enabled
   - name: mysql_metrics
     repository: https://charts.eu-de-2.cloud.sap
@@ -17,7 +17,7 @@ dependencies:
     condition: mariadb.enabled
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.0.10
+    version: 0.0.11
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.4.4
@@ -26,3 +26,6 @@ dependencies:
     repository: https://charts.eu-de-2.cloud.sap
     version: 1.2.1
     condition: api_rate_limit.enabled
+  - name: owner-info
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 0.2.0

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -116,6 +116,8 @@ mariadb:
     cinder.cnf: |+
       [mysqld]
       connect_timeout = 15
+  alerts:
+    support_group: compute-storage-api
 
 max_pool_size: 15
 max_overflow: 5
@@ -367,3 +369,17 @@ alerts:
 
 cors:
   enabled: true
+
+memcached:
+  alerts:
+    support_group: compute-storage-api
+
+owner-info:
+  support-group: compute-storage-api
+  service: cinder
+  maintainers:
+    - Walter Boring IV
+    - Johannes Kulik
+    - Csaba Seres
+    - Marius Leustean
+  helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/openstack/cinder


### PR DESCRIPTION
We need to bump mariadb and memcached chart versions to get support for setting the support_group label on the included alerts and we also have to include the owner-info chart for getting support for setting suport_group on the k8s objects' alerts.

Bumping mariadb to >= 0.6.0 needs an explicit password set for the backup user.