### PR TITLE
[placement] Set logging to INFO

### DIFF
--- a/openstack/placement/values.yaml
+++ b/openstack/placement/values.yaml
@@ -87,7 +87,7 @@ logging:
     migrate:
       handlers: stdout, sentry
       level: INFO
-    nova:
+    placement:
       handlers: stdout, sentry
       level: INFO
 


### PR DESCRIPTION
We didn't have logging for placement on INFO since we switched from Nova-based images on Rocky to Placement's own images on Yoga, because we forgot to switch over the logger definition. With fixing the logger here, we get back INFO-level logging and by that global request ids back in the log lines of all requests.