### PR TITLE
[metis] adds sync-pod, adds config for vcenter guestOS sync to metis

### DIFF
--- a/system/metis/Chart.yaml
+++ b/system/metis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: metis
-version: 0.0.6
+version: 0.0.7
 description: Read-only DB for replicas of OpenStack DBs and Project Masterdata
 dependencies:
   - condition: mariadb.enabled

--- a/system/metis/templates/_replication-etc-configmap.tpl
+++ b/system/metis/templates/_replication-etc-configmap.tpl
@@ -1,5 +1,5 @@
 {{/*
-Create the config map content
+Create the config map content for replication pod
 */}}
 {{- define "replication.configmap" -}}
 namespace: {{ .root.Release.Namespace }}
@@ -41,7 +41,7 @@ storages:
 {{- end -}}
 
 {{/*
-Create the config map content
+Create the config map content for sync pod
 */}}
 {{- define "sync.configmap" -}}
 region: {{ .root.Values.global.region }}
@@ -55,10 +55,15 @@ swiftBackup:
     userDomain: "Default"
     project: "master"
     projectDomain: "ccadmin"
-mariaDB:
-  host: "{{ .mariadb.name }}-mariadb"
-  port: {{ .mariadb.port_public }}
-  user: "root"
+replication:
+  sourceDB:
+    host: "{{ .backup.name }}-mariadb.monsoon3"
+    port: {{ .mariadb.port_public }}
+    user: "root"
+  targetDB:
+    host: "{{ .mariadb.name }}-mariadb.metis"
+    port: {{ .mariadb.port_public }}
+    user: "root"
   schemas:
   {{- range $db := .backup.databases }}
     - "{{$db}}"

--- a/system/metis/templates/_replication-etc-configmap.tpl
+++ b/system/metis/templates/_replication-etc-configmap.tpl
@@ -39,3 +39,30 @@ storages:
         {{- end }}
         dump_filter_buffer_size_mb: {{ .common.dump_filter_buffer_size_mb }}
 {{- end -}}
+
+{{/*
+Create the config map content
+*/}}
+{{- define "sync.configmap" -}}
+region: {{ .root.Values.global.region }}
+loglevel: "debug"
+swiftBackup:
+  service: "{{ .backup.name }}"
+  container: "mariadb-backup-qa-de-1"
+  creds:
+    identityEndpoint:  "https://identity-3.{{ .root.Values.global.region }}.cloud.sap/v3"
+    user: "db_backup"
+    userDomain: "Default"
+    project: "master"
+    projectDomain: "ccadmin"
+mariaDB:
+  host: "{{ .mariadb.name }}-mariadb"
+  port: {{ .mariadb.port_public }}
+  user: "root"
+  schemas:
+  {{- range $db := .backup.databases }}
+    - "{{$db}}"
+  {{- end }}
+  serverID: 998
+  binlogMaxReconnectAttempts: {{ .common.binlog_max_reconnect_attempts }}
+{{- end -}}

--- a/system/metis/templates/metis-etc-configmap.yaml
+++ b/system/metis/templates/metis-etc-configmap.yaml
@@ -16,6 +16,7 @@ data:
       sync_cron_schedule: "0 */6 * * *"
       api_host: {{ required "Missing required global billing API endpoint" .Values.metis.billingApiHost}}
     vcenter:
+      enabled: {{ .Values.metis.vcenter.enabled }}
       sync_cron_schedule: "0 */12 * * *"
     db:
       user: "root"

--- a/system/metis/templates/metis-secrets.yaml
+++ b/system/metis/templates/metis-secrets.yaml
@@ -13,8 +13,6 @@ data:
   metisAdminPW: {{ required "missing MetisDB root pw" .Values.mariadb.root_password | b64enc }}
   metisRonlyPW: {{ required "missing MetisDB ronly pw" .Values.metis.ronlyPassword | b64enc }}
   billingToken: {{ required "missing billing API token" .Values.metis.billingApiToken | b64enc }}
-  vcenterUser:  {{ required "missing vcenter user" .Values.metis.vcenterUser | b64enc }}
-  vcenterMasterPW:  {{ required "missing vcenter master PW" .Values.metis.vcenterMasterPW | b64enc }}
-  openstackPW: {{ required "missing openstack password" .Values.metis.openstackPassword | b64enc }}
-
+  vcenterUser:  {{ required "missing vcenter user" .Values.metis.vcenter.user | b64enc }}
+  vcenterMasterPW:  {{ required "missing vcenter master PW" .Values.metis.vcenter.masterPW | b64enc }}
 {{- end }}

--- a/system/metis/templates/metis-secrets.yaml
+++ b/system/metis/templates/metis-secrets.yaml
@@ -15,4 +15,6 @@ data:
   billingToken: {{ required "missing billing API token" .Values.metis.billingApiToken | b64enc }}
   vcenterUser:  {{ required "missing vcenter user" .Values.metis.vcenterUser | b64enc }}
   vcenterMasterPW:  {{ required "missing vcenter master PW" .Values.metis.vcenterMasterPW | b64enc }}
+  openstackPW: {{ required "missing openstack password" .Values.metis.openstackPassword | b64enc }}
+
 {{- end }}

--- a/system/metis/templates/replication-deployment.yaml
+++ b/system/metis/templates/replication-deployment.yaml
@@ -69,6 +69,7 @@ spec:
                   operator: In
                   values:
                   - mariadb-replication
+                  - mariadb-sync
       containers:
       - name: backup
         image: "{{ required ".Values.global.registry variable missing" $global.registry }}/{{ $common.image }}:{{ $common.image_version }}"

--- a/system/metis/templates/sync-deployment.yaml
+++ b/system/metis/templates/sync-deployment.yaml
@@ -13,7 +13,7 @@ metadata:
   labels:
     app.kubernetes.io/name: mariadb-sync
     helm.sh/chart: {{ include "metis.chart" $ }}
-    app.kubernetes.io/instance: mariadb-sync-{{ $backup.name }}-{{ $.Release.Name }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}-sync-{{ $backup.name }}-mariadb
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
     app.kubernetes.io/version: "{{ $.Values.backup_v2.image_version }}"
     alert-service: "metis"
@@ -75,15 +75,20 @@ spec:
         env:
         - name: CONFIG
           value: "/etc/config/config.yaml"
-        - name: DB_PASSWORD
+        - name: SOURCEDB_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: metis-secrets
+              name: mariadb-sync-{{$backup.name}}-secrets
+              key: sourceDBPW
+        - name: TARGETDB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mariadb-sync-{{$backup.name}}-secrets
               key: metisAdminPW
         - name: "OPENSTACK_PASSWORD"
           valueFrom:
             secretKeyRef:
-              name: metis-secrets
+              name: mariadb-sync-{{$backup.name}}-secrets
               key: openstackPW
         volumeMounts:
         - name: mariadb-sync-etc

--- a/system/metis/templates/sync-deployment.yaml
+++ b/system/metis/templates/sync-deployment.yaml
@@ -2,18 +2,18 @@
 {{- $common := $.Values.backup_v2 }}
 {{- $global := $.Values.global }}
 {{- range $backup := $.Values.backup_v2.backups }}
-{{- if not $backup.sync_enabled }}
+{{- if $backup.sync_enabled }}
 ---
 
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: mariadb-replication-{{ $backup.name }}
+  name: mariadb-sync-{{ $backup.name }}
   namespace: {{ $.Values.namespace }}
   labels:
-    app.kubernetes.io/name: mariadb-replication
+    app.kubernetes.io/name: mariadb-sync
     helm.sh/chart: {{ include "metis.chart" $ }}
-    app.kubernetes.io/instance: mariadb-replication-{{ $backup.name }}-{{ $.Release.Name }}
+    app.kubernetes.io/instance: mariadb-sync-{{ $backup.name }}-{{ $.Release.Name }}
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
     app.kubernetes.io/version: "{{ $.Values.backup_v2.image_version }}"
     alert-service: "metis"
@@ -22,24 +22,19 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: mariadb-replication
-      app.kubernetes.io/instance: mariadb-replication-{{ $backup.name }}-{{ $.Release.Name }}
+      app.kubernetes.io/name: mariadb-sync
+      app.kubernetes.io/instance: mariadb-sync-{{ $backup.name }}-{{ $.Release.Name }}
   template:
     metadata:
       labels:
         alert-service: "metis"
         alert-tier: {{ required "$.Values.alerts.tier missing" $.Values.alerts.tier }}
-        app.kubernetes.io/version: "{{ $.Values.backup_v2.image_version }}"
-        app.kubernetes.io/name: mariadb-replication
-        app.kubernetes.io/instance: mariadb-replication-{{ $backup.name }}-{{ $.Release.Name }}
+        app.kubernetes.io/version: "{{ $.Values.metisSync.imageVersion }}"
+        app.kubernetes.io/name: mariadb-sync
+        app.kubernetes.io/instance: mariadb-sync-{{ $backup.name }}-{{ $.Release.Name }}
       annotations:
         {{- $data := dict "common" $common "backup" $backup "mariadb" $.Values.mariadb "root" $ }}
-        checksum/config: {{ include "replication.configmap" $data | sha256sum }}
-{{- if $common.metrics.enabled }}
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "8082"
-        prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" $.Values.alerts.prometheus | quote }}
-{{- end }}
+        checksum/config: {{ include "sync.configmap" $data | sha256sum }}
     spec:
       affinity:
         nodeAffinity:
@@ -51,13 +46,6 @@ spec:
                   operator: In
                   values:
                   - operational
-            - weight: 1
-              preference:
-                matchExpressions:
-                - key: cloud.sap/deployment-state
-                  operator: NotIn
-                  values:
-                  - reinstalling
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 1
@@ -69,11 +57,12 @@ spec:
                   operator: In
                   values:
                   - mariadb-replication
+                  - mariadb-sync
       containers:
-      - name: backup
-        image: "{{ required ".Values.global.registry variable missing" $global.registry }}/{{ $common.image }}:{{ $common.image_version }}"
+      - name: sync
+        image: "{{ required ".Values.global.registry variable missing" $global.registry }}/{{ $.Values.metisSync.image }}:{{ $.Values.metisSync.imageVersion }}"
         command:
-          - backup
+          - sync
         ports:
           - containerPort: 8081
             name: http
@@ -84,16 +73,26 @@ spec:
         resources:
 {{ toYaml (required "missing .resources" $common.resources) | indent 10 }}
         env:
-        - name: CONFIG_FILE
+        - name: CONFIG
           value: "/etc/config/config.yaml"
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: metis-secrets
+              key: metisAdminPW
+        - name: "OPENSTACK_PASSWORD"
+          valueFrom:
+            secretKeyRef:
+              name: metis-secrets
+              key: openstackPW
         volumeMounts:
-        - name: mariadb-replication-etc
+        - name: mariadb-sync-etc
           mountPath: /etc/config
           readOnly: true
       volumes:
-        - name: mariadb-replication-etc
+        - name: mariadb-sync-etc
           configMap:
-            name: mariadb-replication-{{ $backup.name }}-etc
+            name: mariadb-sync-{{ $backup.name }}-etc
 {{- end }}
 {{- end }}
 {{- end }}

--- a/system/metis/templates/sync-etc-configmap.yaml
+++ b/system/metis/templates/sync-etc-configmap.yaml
@@ -2,22 +2,21 @@
 {{ $common := $.Values.backup_v2 }}
 {{ $mariadb := $.Values.mariadb }}
 {{- range $backup := $.Values.backup_v2.backups }}
-{{- if not $backup.sync_enabled }}
+{{- if $backup.sync_enabled }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: mariadb-replication-{{ $backup.name }}-etc
+  name: mariadb-sync-{{ $backup.name }}-etc
   namespace: {{ $.Values.namespace }}
   labels:
-    app.kubernetes.io/name: mariadb-replication
-    helm.sh/chart: {{ include "metis.chart" $ }}
-    app.kubernetes.io/instance: mariadb-replication-{{ $backup.name }}-{{ $.Release.Name }}
+    app.kubernetes.io/name: mariadb-sync
+    app.kubernetes.io/instance: mariadb-sync-{{ $backup.name }}-{{ $.Release.Name }}
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
 data:
     {{- $data := dict "common" $common "backup" $backup "mariadb" $mariadb "root" $ }}
   config.yaml: |
-{{ include "replication.configmap" $data | indent 4 }}
+{{ include "sync.configmap" $data | indent 4 }}
 
 {{- end }}
 {{- end }}

--- a/system/metis/templates/sync-secrets.yaml
+++ b/system/metis/templates/sync-secrets.yaml
@@ -3,21 +3,23 @@
 {{ $mariadb := $.Values.mariadb }}
 {{- range $backup := $.Values.backup_v2.backups }}
 {{- if $backup.sync_enabled }}
+
 ---
+
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
-  name: mariadb-sync-{{ $backup.name }}-etc
+  name: mariadb-sync-{{$backup.name}}-secrets
   namespace: {{ $.Values.namespace }}
   labels:
-    app.kubernetes.io/name: mariadb-sync
+    app.kubernetes.io/name: metis
     helm.sh/chart: {{ include "metis.chart" $ }}
     app.kubernetes.io/instance: {{ $.Release.Name }}-sync-{{ $backup.name }}-mariadb
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
 data:
-    {{- $data := dict "common" $common "backup" $backup "mariadb" $mariadb "root" $ }}
-  config.yaml: |
-{{ include "sync.configmap" $data | indent 4 }}
+  metisAdminPW: {{ required "missing MetisDB root pw" $.Values.mariadb.root_password | b64enc }}
+  sourceDBPW: {{required (printf "missing MariaDB password for '%s'" $backup.name) $backup.root_password | b64enc }}
+  openstackPW: {{ required "missing openstack password" $.Values.metis.openstackPassword | b64enc }}
 
 {{- end }}
 {{- end }}

--- a/system/metis/values.yaml
+++ b/system/metis/values.yaml
@@ -95,6 +95,10 @@ backup_v2:
     #   databases: // list of schemas to replicate
     #     - "<schemaName>"
 
+metisSync:
+  image: go-maria-sync
+  imageVersion: "202210131745"
+
 metis:
   enabled: false
   metrics:

--- a/system/metis/values.yaml
+++ b/system/metis/values.yaml
@@ -97,7 +97,7 @@ backup_v2:
 
 metisSync:
   image: go-maria-sync
-  imageVersion: "202210261448"
+  imageVersion: "202211021747"
 
 metis:
   enabled: false

--- a/system/metis/values.yaml
+++ b/system/metis/values.yaml
@@ -97,7 +97,7 @@ backup_v2:
 
 metisSync:
   image: go-maria-sync
-  imageVersion: "202210131745"
+  imageVersion: "202210261448"
 
 metis:
   enabled: false
@@ -107,6 +107,8 @@ metis:
     port: "9100"
   image: "metis"
   imageTag: DEFINED-IN-PIPELINE
+  vcenter:
+    enabled: false
   releaseLocks: false
   requiredDatabases:
     - "keystone"


### PR DESCRIPTION
Changes:
- sync-pod replace replication. Pulls full backup + increments from swift instead of pulling dump from DB.
- metis pod: adds config required for guestOS collection from vCenter