### PR TITLE
[common][mariab] make slow queries alert less flappy

### DIFF
--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.7.3
+version: 0.7.4

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.7.2
+version: 0.7.3

--- a/common/mariadb/templates/alerts/_mysql.alerts.tpl
+++ b/common/mariadb/templates/alerts/_mysql.alerts.tpl
@@ -14,7 +14,7 @@
       summary: {{ include "fullName" . }} has too many connections open.
 
   - alert: {{ include "alerts.service" . | title }}MariaDBSlowQueries
-    expr: (rate(mysql_global_status_slow_queries{app=~"{{ include "fullName" . }}"}[5m]) > 0)
+    expr: (rate(mysql_global_status_slow_queries{app=~"{{ include "fullName" . }}"}[30m]) > 0)
     for: 10m
     labels:
       context: database

--- a/common/mariadb/templates/etc-configmap.yaml
+++ b/common/mariadb/templates/etc-configmap.yaml
@@ -30,14 +30,14 @@ data:
     table_definition_cache    = 800
     sql_mode                  = "TRADITIONAL"
     slow_query_log            = 1
-    long_query_time           = 3
+    long_query_time           = {{ .Values.long_query_time }}
     log_warnings              = {{ .Values.log_warnings }}
     general_log_file          = /var/log/mysql/mariadb_general.log
 {{- if .Values.db_performance_schema.enabled}}
     performance_schema        = ON
 {{ else }}
     performance_schema        = OFF
-{{- end }}  
+{{- end }}
 {{- if .Values.db_performance_schema.enabled }}
 {{- if .Values.db_performance_schema_instrument.enabled}}
     performance-schema-instrument        = 'stage/%=ON'
@@ -50,7 +50,7 @@ data:
     performance_schema_consumer_thread_instrumentation        = OFF
     performance_schema_consumer_statements_digest        = OFF
 {{- end }}
-{{- end }} 
+{{- end }}
 {{- if .Values.backup_v2.enabled }}
     binlog_format             = {{ .Values.binlog_format }}
     expire_logs_days          = {{ .Values.expire_logs_days }}

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -14,6 +14,7 @@ log_warnings: "2"
 query_cache_size: "0"
 query_cache_type: "0"
 join_buffer_size: "4M"
+long_query_time: 5
 binlog_format: "MIXED"
 expire_logs_days: 10
 character_set_server: "utf8" # Should be utf8mb4, but we started with this


### PR DESCRIPTION
e.g. having a slow query every 7 minutes (seen in manila) would make this alert flap around a lot, smoothen a bit by increasing the rate to 30 min