### PR TITLE
[Ironic] Limit authentication to initial connection

### DIFF
--- a/openstack/ironic/templates/console-configmap.yaml
+++ b/openstack/ironic/templates/console-configmap.yaml
@@ -17,19 +17,44 @@ data:
         listen       80;
         server_name  {{ include "ironic_console_endpoint_host_public" . }};
 
-        location ~* "/[^/]*/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/([0-9]*)/([^/]*)/?(.*)$" {
+        # Health-Check
+        location /health {
+            access_log off;
+            return 204;
+        }
+
+        # Possibly proxies probing the host
+        location / {
+            access_log off;
+            return 204;
+        }
+
+        # We only need to authenticate the GET of the index, as that
+        # creates a session and returns a secret used in all futher requests
+        # The url is of the form:
+        #   /<conductor-name>/<instance-uuid>/<expiry>/<md5-signature>/<static-resources>
+
+        # We obviously do not have to secure any static resources
+        location ~* "/[^/]*/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/([0-9]*)/([^/]*)/?$" {
             secure_link $3,$2;
             secure_link_md5 "$secure_link_expires$1 {{required "A valid .Values.console.secret required!" .Values.console.secret}}";
 
-            if ($secure_link = "") {
+            set $check $secure_link;
+
+            # Do not authenticate the POST, as it is handled internally
+            if ($request_method = POST) {
+                set $check "1";
+            }
+
+            if ($check = "" ) {
                 return 403;
             }
 
-            if ($secure_link = "0") {
+            if ($check = "0") {
                 return 410;
             }
 
-            proxy_pass http://unix:/shellinabox/$1.sock:/$4;
+            proxy_pass http://unix:/shellinabox/$1.sock:/;
             proxy_set_header    Host      $host;
             proxy_http_version  1.1;
             proxy_redirect      off;
@@ -38,8 +63,16 @@ data:
             proxy_set_header Connection $connection_upgrade;
         }
 
-        location /health {
-            access_log off;
-            return 204;
+        location ~* "/[^/]*/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/([0-9]*)/([^.]+\.[^.]+)$" {
+            if ($request_method != GET) {
+                return 400;
+            }
+            proxy_pass http://unix:/shellinabox/$1.sock:/$4;
+            proxy_set_header    Host      $host;
+            proxy_http_version  1.1;
+            proxy_redirect      off;
+            proxy_buffering     off;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
         }
     }


### PR DESCRIPTION
Prior this change, nginx would expire the url for all requests. The problem here is that the javascript app running in the browser will periodically do a POST request with a session id and possibly commands
to the url, and the validation will break that.

To make matters worse, the app won't close the session normally, keeping the shell on the server running
until it timeouts.

The session-id replaces the authenticated url as a secret, so we do not need to validate the POST requests anymore.

In similar vein, validating the url for static resources is superfluous, and we can pass those requests right through.