### PR TITLE
[PX] Add switch to tolerate arista fabric no-schedule taint

### DIFF
--- a/px/bird/templates/_deployment_header.tpl
+++ b/px/bird/templates/_deployment_header.tpl
@@ -50,7 +50,9 @@ spec:
         prometheus.io/port: "9324"
         prometheus.io/targets: "infra-collector"
     spec:
-{{- if len $apods | ne 0 }}
+{{- if len $apods | eq 0 }}
+{{- fail "You must supply at least one apod for scheduling" -}}
+{{ end }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -88,19 +90,5 @@ spec:
                 operator: In
                 values:
                 - {{ $domain_number | quote }}
-{{- end }}
-{{- else }}
-{{ $domain_scheduling_labels := get $scheduling_labels $domain }}
-{{- if $domain_scheduling_labels | len | eq 0 -}}
-{{- fail "scheduling_labels must be set if not running on apod" -}}
-{{- end }}
-      tolerations:
-        - key: species
-          operator: Equal
-          value: px
-          effect: NoSchedule
-      nodeSelector:
-          # This calculation only works if we have no more than 2 instances and no more than 2 scheduling labels per domain
-          pxdomain: "{{ index $domain_scheduling_labels (mod (sub $instance_number 1) (len $domain_scheduling_labels)) }}"
 {{- end }}
 {{- end }}

--- a/px/bird/templates/_deployment_header.tpl
+++ b/px/bird/templates/_deployment_header.tpl
@@ -11,6 +11,7 @@
 {{- $instance_number := index . 9}}
 {{- $instance := index . 10}}
 {{- $az_redundancy  := index . 11}}
+{{- $tolerate_arista_fabric  := index . 12}}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -90,5 +91,12 @@ spec:
                 operator: In
                 values:
                 - {{ $domain_number | quote }}
+{{- end }}
+{{- if $tolerate_arista_fabric }}
+      tolerations:
+      - key: "fabric"
+        operator: "Equal"
+        value: "arista"
+        effect: "NoSchedule"
 {{- end }}
 {{- end }}

--- a/px/bird/templates/bird.yaml
+++ b/px/bird/templates/bird.yaml
@@ -16,7 +16,7 @@
 
 ---
 {{ tuple $deployment_name $domain_config.multus_vlan $instance_config.bird_ip | include "nad_multus"}}
-{{ tuple $deployment_name $.Values.global.availability_zones $.Values.scheduling_labels $.Values.apods $domain_config.multus_vlan $service_number $service $domain_number $domain $instance_number $instance $.Values.az_redundancy | include "deployment_header" }}
+{{ tuple $deployment_name $.Values.global.availability_zones $.Values.scheduling_labels $.Values.apods $domain_config.multus_vlan $service_number $service $domain_number $domain $instance_number $instance $.Values.az_redundancy $.Values.tolerate_arista_fabric | include "deployment_header" }}
 {{ tuple $.Values $deployment_name $service_number $service_config $domain_number $domain_config | include "deployment_bird" | indent 6 }}
 {{ tuple $deployment_name $.Values.looking_glass | include "service_pxrs" }}
 

--- a/px/bird/values.yaml
+++ b/px/bird/values.yaml
@@ -20,11 +20,6 @@ apods: {}
 
 az_redundancy: True
 
-# only required if apods is empty
-scheduling_labels:
-  domain_1: []
-  domain_2: []
-
 bird_config_path: bird_configs/
 
 bird_exporter_image:

--- a/px/bird/values.yaml
+++ b/px/bird/values.yaml
@@ -20,6 +20,8 @@ apods: {}
 
 az_redundancy: True
 
+tolerate_arista_fabric: False
+
 bird_config_path: bird_configs/
 
 bird_exporter_image:


### PR DESCRIPTION
We have regions where PX was only build on Arista, yet the apods on the
Arista-Farbic still have a no-schedule taint. We need to be able to set
a toleration, hence introducing a switch.