### PR TITLE
maia - adding new cronus client metric - aws_ses_cronus_identity_is_v…

### DIFF
--- a/openstack/maia/templates/etc/_maia_scrape_config.yaml.tpl
+++ b/openstack/maia/templates/etc/_maia_scrape_config.yaml.tpl
@@ -211,6 +211,7 @@
       - '{__name__="aws_ses_cronus_provider_send"}'
       - '{__name__="aws_ses_cronus_security_attributes_remaining_months_until_lease_ends"}'
       - '{__name__="aws_ses_cronus_suppressed_email_since_last_update_minutes"}'
+      - '{__name__="aws_ses_cronus_identity_is_verified"}'
   metric_relabel_configs:
     - action: labeldrop
       regex: "exported_instance|exported_job|instance|job|tags|cluster|cluster_type|multicloud_id|alert_tier|alert_service"


### PR DESCRIPTION
…erified to track info on domains and emails identities status