### PR TITLE
[vrops-exporter] Avoid using Analytics Metrics

### DIFF
--- a/prometheus-exporters/vrops-exporter/templates/collector-configmap.yaml
+++ b/prometheus-exporters/vrops-exporter/templates/collector-configmap.yaml
@@ -139,8 +139,10 @@ data:
 
     SDRSStatsCollector:
     # INFO - Prefix: vrops_storagepod_
-      - metric_suffix: "capacity_remaining_percentage"
-        key: "OnlineCapacityAnalytics|capacityRemainingPercentage"
+      - metric_suffix: "capacity_available_space"
+        key: "capacity|available_space"
+      - metric_suffix: "capacity_total_capacity"
+        key: "capacity|total_capacity"
 
     HostSystemStatsCollector:
     # INFO - Prefix: vrops_hostsystem_


### PR DESCRIPTION
The "OnlineCapacityAnalytics" metrics are not reliable for monitoring current capacity. As suggested by VMware we should solely use the "capacity" metrics.
Metric keys were tested manually in qa-de-1.