### PR TITLE
[maia] scrape jobs with single match query

### DIFF
--- a/openstack/maia/Chart.yaml
+++ b/openstack/maia/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Expose Prometheus as multi-tenant OpenStack service
 name: maia
-version: 1.3.6
+version: 1.3.8
 maintainers:
   - name: Martin Vossen (artherd42)
 dependencies:

--- a/openstack/maia/values.yaml
+++ b/openstack/maia/values.yaml
@@ -127,6 +127,52 @@ prometheus_vmware:
   enabled: true
   scrape_interval: 1m
   scrape_timeout: 55s
+    # every match is queried in a dedicated job to avoid long scrape times. The resulting job name will be prefixed with "prometheus-vmware-vrops-" and everything after the 5th "_" will be appended. This assumes, it starts with __name__ and has vrops_ as a prefix already.
+    # Example job name
+    # - '{__name__=~"^vrops_virtualmachine_config_hardware_memory_kilobytes", project!~"internal", vccluster!~".*management.*"}'
+    # will be
+    # prometheus-vmware-vrops-virtualmachine-config-hardware-memory-kilobytes
+  matches:
+    - '{__name__=~"^vrops_virtualmachine_config_hardware_memory_kilobytes", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_cpu_contention_ratio", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_cpu_demand_ratio", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_cpu_usage_ratio", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_cpu_usage_average_mhz", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_cpu_wait_summation_miliseconds", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_datastore_outstanding_io_requests", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_disk_usage_average_kilobytes_per_second", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_diskspace_gigabytes", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_diskspace_virtual_machine_used_gigabytes", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_guest_os_full_name_info", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_guest_tools_version_info", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_memory_active_ratio", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_memory_activewrite_kilobytes", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_memory_balloning_ratio", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_memory_consumed_kilobytes", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_memory_contention_ratio", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_memory_usage_average", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_network_data_received_kilobytes_per_second", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_network_data_transmitted_kilobytes_per_second", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_network_packets_dropped.+", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_network_packets.+", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_network_usage_average_kilobytes_per_second", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_number_vcpus_total", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_oversized", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_oversized_vcpus", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_oversized_memory", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_runtime_connectionstate", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_runtime_powerstate", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_summary_ethernetcards", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_swapin_memory_kilobytes", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_swapped_memory_kilobytes", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_undersized", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_undersized_vcpus", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_undersized_memory", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_virtual_disk_average.+", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_virtual_disk_outstanding.+", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_virtual_disk_read_kilobytes_per_second", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_virtual_disk_write_kilobytes_per_second", project!~"internal", vccluster!~".*management.*"}'
+    - '{__name__=~"^vrops_virtualmachine_config_hardware_memory_kilobytes", project!~"internal", vccluster!~".*management.*"}'
 
 owner-info:
   support-group: observability


### PR DESCRIPTION
given the amount of data returned by single matches in large regions respective queries should be as minimal as possible. This will reduce scrape times to a minimum. Only implemented for prometheus-vmware targets, as it is only needed there

Additionally: neo federate is in a dedicated job now if applicable