### PR TITLE
[cinder] Update cinder attaching alert to 1 hour

### DIFF
--- a/openstack/cinder/alerts/openstack-cinder.alerts
+++ b/openstack/cinder/alerts/openstack-cinder.alerts
@@ -2,7 +2,7 @@ groups:
 - name: openstack-cinder.alerts
   rules:
   - alert: OpenstackCinderVolumeInDeletingState
-    expr: sum(openstack_stuck_volumes_max_duration_gauge{status="deleting"}) BY (id,display_name) > 15
+    expr: count(sum(openstack_stuck_volumes_max_duration_gauge{status="deleting"}) BY (id,display_name) > 15) by (id, display_name)
     for: 5m
     labels:
       dashboard: cinder
@@ -17,7 +17,7 @@ groups:
       summary: Cinder Volumes taking more than 15s to delete
 
   - alert: OpenstackCinderVolumeInAttachingState
-    expr: sum(openstack_stuck_volumes_max_duration_gauge{status="attaching"}) BY (id,display_name) > 15
+    expr: count(sum(openstack_stuck_volumes_max_duration_gauge{status="attaching"}) BY (id,display_name) > 3600) by (id, display_name)
     for: 5m
     labels:
       dashboard: cinder
@@ -25,14 +25,14 @@ groups:
       playbook: docs/support/playbook/volumes.html
       support_group: compute-storage-api
       service: cinder
-      severity: info
+      severity: warning
       tier: os
     annotations:
       description: Volume {{ $labels.display_name }} with {{ $labels.id }} in Attaching State
-      summary: Cinder Volumes taking more than 15s to attach
+      summary: Cinder Volumes taking more than 1 hour to attach
 
   - alert: OpenstackCinderVolumeInDetachingState
-    expr: sum(openstack_stuck_volumes_max_duration_gauge{status="detaching"}) BY (id,display_name) > 15
+    expr: count(sum(openstack_stuck_volumes_max_duration_gauge{status="detaching"}) BY (id,display_name) > 15) by (id, display_name)
     for: 5m
     labels:
       dashboard: cinder


### PR DESCRIPTION
Since we have potentially long attachment times, we should be warned if a volume is stuck in attaching state for more than 1 hour.