### PR TITLE
[nova] Bump mariadb 0.7.4 for slow query warnings

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.1
+  version: 0.7.4
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.1
+  version: 0.7.4
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.7
@@ -19,12 +19,12 @@ dependencies:
   version: 0.6.0
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.1
+  version: 0.7.4
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.4.4
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:95246b2997c0fc2e372a042bd51e4dca65443b18044e9209fa7c5087f8d7fa98
-generated: "2022-10-26T11:41:50.259087799+02:00"
+digest: sha256:bdf3201b9e314db72a2cf456cd83d947c11eee7e94751adcec6af06586b8b4d0
+generated: "2022-11-04T14:55:09.128180194+01:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -5,17 +5,17 @@ icon: https://www.openstack.org/themes/openstack/images/project-mascots/Nova/Ope
 version: 0.2.0
 appVersion: "rocky"
 dependencies:
-  - condition: mariadb.enabled
-    name: mariadb
+  - name: mariadb
+    condition: mariadb.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.7.1
+    version: 0.7.4
   - name: mariadb
     alias: mariadb_api
     condition: mariadb_api.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.7.1
-  - condition: mariadb.enabled
-    name: mysql_metrics
+    version: 0.7.4
+  - name: mysql_metrics
+    condition: mariadb.enabled
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.7
   - name: rabbitmq
@@ -31,7 +31,7 @@ dependencies:
     alias: mariadb_cell2
     condition: mariadb_cell2.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.7.1
+    version: 0.7.4
   - name: rabbitmq
     alias: rabbitmq_cell2
     condition: cell2.enabled

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -680,6 +680,7 @@ mariadb:
   log_file_size: "1024M"
   name: nova
   initdb_configmap: true
+  long_query_time: 8
   databases:
   - nova
   - nova_cell0
@@ -717,6 +718,7 @@ mariadb_api:
   log_file_size: "1024M"
   name: nova-api
   initdb_configmap: true
+  long_query_time: 8
   databases:
   - nova_api
   users:
@@ -747,6 +749,7 @@ mariadb_cell2:
   buffer_pool_size: "4096M"
   log_file_size: "1024M"
   initdb_configmap: true
+  long_query_time: 8
   persistence_claim:
     name: db-nova-cell2-pvc
     size: "50Gi"


### PR DESCRIPTION
0.7.2 lowers severity of the slow-query alert to INFO.

0.7.3 reduces flappiness by calculating rate over 30m instead of 5m.

0.7.4 makes the slow-query time threshold configurable, and sets a default of 5 seconds (the literal value was 3s previously).
Override that default with 8s based on the following sample data from eu-de-1:

```
$ cat [...]-slow.log | grep Query_time | cut -d ' ' -f 3 \
                     | sort -h | cut -d '.' -f 1 | uniq -c
  35 3
3515 4
1693 5
  47 6
   5 7   <- there seems to be a marked cutoff after here
   1 9
   2 10
   2 11
   2 12
   2 14
   2 15
   1 16
   1 199
   1 200
   1 204
```
The huge times are backup queries.
