### PR TITLE
[Octavia] Add support_group for subchart rabbitmq_notifications

### DIFF
--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -30,6 +30,10 @@ rabbitmq:
   alerts:
     support_group: network-api
 
+rabbitmq_notifications:
+  alerts:
+    support_group: network-api
+
 memcached:
   alerts:
     support_group: network-api


### PR DESCRIPTION
Added for mariadb, memcached and rabbitmq [here](https://github.com/sapcc/helm-charts/pull/4295), but aliased subchart rabbitmq_notifications was missing