### PR TITLE
[nova] Enable/Disable vnc on hypervisor level

### DIFF
--- a/openstack/nova/templates/hypervisors/hypervisors-vmware-configmap-vct.yaml
+++ b/openstack/nova/templates/hypervisors/hypervisors-vmware-configmap-vct.yaml
@@ -79,6 +79,9 @@ template: |
       serial_log_uri = http://{{ .Values.vspc.nodeIP }}:{{ .Values.vspc.web.portExternal }}
       {{- end }}
       hostgroup_reservations_json_file = /etc/nova/hostgroup-reservations.json
+
+      {{"\n"}}
+      {{- include "util.helpers.valuesToIni" .Values.compute.vmware | indent 6 }}
     hostgroup-reservations.json: |
       {"__default__": {"memory_percent": 5} }
   {{ end }}

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -293,6 +293,9 @@ compute:
       default_hw_version: vmx-18
       memory_reservation_cluster_hosts_max_fail: 2
       memory_reservation_max_ratio_fallback: 0.8
+  vmware:
+    vnc:
+      enabled: false
 
 conductor:
   config_file:


### PR DESCRIPTION
Previously, we were enabling vnc for all hypervisors globally, but we rather do not want to do that for vmware, where mks is preferred

We set the vnc value for for the compute node,
which overrides the value in nova.conf