### PR TITLE
Introducing vmware-monitoring

### DIFF
--- a/system/vmware-monitoring/Chart.yaml
+++ b/system/vmware-monitoring/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: vmware-monitoring
+version: 1.0.0
+description: VMware Monitoring and Metrics Collection
+dependencies:
+  - name: prometheus-server
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 7.1.0
+  - name: thanos
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 0.2.0
+  - name: owner-info
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 0.2.0

--- a/system/vmware-monitoring/alerts/vrops-exporter.alerts
+++ b/system/vmware-monitoring/alerts/vrops-exporter.alerts
@@ -1,0 +1,20 @@
+groups:
+- name: vrops-exporter.alerts
+  rules:
+  - alert: VropsExporterInventoryDataMissing
+    expr: |
+      sum by (__name__, target) ({__name__=~"^vrops_inventory_(?:vcenters|nsxt_adapter)"}) == 0
+    for: 20m
+    labels:
+      context: vrops-exporter
+      severity: info
+      service: exporter
+      support_group: observability
+      no_alert_on_absence: "true"
+      meta: "vrops-exporter inventory is not getting any vCenter or NSX-T resources for `{{ $labels.target }}` anymore."
+    annotations:
+      summary: "vrops-exporter inventory is not getting any vCenter or NSX-T resources for `{{ $labels.target }}` anymore."
+      description: |
+        vrops-exporter collectors no longer getting resources from
+        which to retrieve new metrics. The inventory should provide
+        at least one iteration of the current resources available in vrops.

--- a/system/vmware-monitoring/ci/test-values.yaml
+++ b/system/vmware-monitoring/ci/test-values.yaml
@@ -1,0 +1,17 @@
+global:
+  targets:
+    - vrops-vc-z-99.cc.zz-oo-33.test.test
+
+prometheus-server:
+  resources:
+    requests:
+      cpu: 500m
+      memory: 2Gi
+
+  thanos:
+    swiftStorageConfig:
+      authURL: https://test
+      userDomainName: test
+      password: dummy
+      domainName: testdomain
+      tenantName: main

--- a/system/vmware-monitoring/ci/test-values.yaml
+++ b/system/vmware-monitoring/ci/test-values.yaml
@@ -1,17 +1,3 @@
 global:
   targets:
     - vrops-vc-z-99.cc.zz-oo-33.test.test
-
-prometheus-server:
-  resources:
-    requests:
-      cpu: 500m
-      memory: 2Gi
-
-  thanos:
-    swiftStorageConfig:
-      authURL: https://test
-      userDomainName: test
-      password: dummy
-      domainName: testdomain
-      tenantName: main

--- a/system/vmware-monitoring/templates/_helper.tpl
+++ b/system/vmware-monitoring/templates/_helper.tpl
@@ -1,0 +1,27 @@
+{{- define "vropsExporter.name" -}}
+{{- $name := index . 0 -}}
+{{- $root := index . 1 -}}
+{{- $vropshostname := split "." $name -}}
+{{ $vropshostname._0 | trimPrefix "vrops-" }}
+{{- end -}}
+
+{{- define "vropsExporter.fullName" -}}
+{{- $name := index . 0 -}}
+{{- $root := index . 1 -}}
+{{- $vropshostname := split "." $name -}}
+vrops-exporter-{{ $vropshostname._0 | trimPrefix "vrops-" }}
+{{- end -}}
+
+{{- define "vropsInventoryExporter.fullName" -}}
+{{- $name := index . 0 -}}
+{{- $root := index . 1 -}}
+{{- $vropshostname := split "." $name -}}
+vrops-inventory-exporter-{{ $vropshostname._0 | trimPrefix "vrops-" }}
+{{- end -}}
+
+{{- define "prometheusVMware.fullName" -}}
+{{- $name := index . 0 -}}
+{{- $root := index . 1 -}}
+{{- $vropshostname := split "." $name -}}
+prometheus-vmware-{{ $vropshostname._0 | trimPrefix "vrops-" }}
+{{- end -}}

--- a/system/vmware-monitoring/templates/alerts.yaml
+++ b/system/vmware-monitoring/templates/alerts.yaml
@@ -1,0 +1,23 @@
+{{- $root := . }}
+{{- $values := .Values.vrops }}
+{{- if .Values.vrops.enabled }}
+{{- range $target := .Values.global.targets }}
+{{- if $values.alerts.enabled }}
+{{- range $path, $bytes := $.Files.Glob "alerts/*.alerts" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: {{ printf "vmware-monitoring-%s" $path | replace "/" "-" }}
+  labels:
+    app: vrops-exporter
+    prometheus: {{ include "prometheusVMware.fullName" (list $target $root) }}
+
+spec:
+{{ printf "%s" $bytes | indent 2 }}
+
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/system/vmware-monitoring/templates/collector-configmap.yaml
+++ b/system/vmware-monitoring/templates/collector-configmap.yaml
@@ -1,0 +1,588 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vrops-exporter-collector-config
+data:
+  collector_config.yaml: |
+    default_collectors:
+    #    - 'NSXTMgmtClusterStatsCollector'
+    #    - 'NSXTMgmtClusterPropertiesCollector'
+    #    - 'NSXTLogicalSwitchPropertiesCollector'
+    #    - 'NSXTMgmtNodeStatsCollector'
+    #    - 'NSXTMgmtNodePropertiesCollector'
+    #    - 'NSXTTransportNodePropertiesCollector'
+        - 'CustomInfoMetricsGenerator'
+        - 'ClusterStatsCollector'
+        - 'ClusterPropertiesCollector'
+        - 'DistributedvSwitchPropertiesCollector'
+        - 'DatastoreStatsCollector'
+        - 'DatastorePropertiesCollector'
+        - 'SDRSStatsCollector'
+    #    - 'HostSystemStatsCollector'
+    #    - 'HostSystemPropertiesCollector'
+        - 'VCenterStatsCollector'
+        - 'VCenterPropertiesCollector'
+    #    - 'VMPropertiesCollector'
+    #    - 'VMStatsCPUCollector'
+    #    - 'VMStatsNetworkCollector'
+    #    - 'VMStatsVirtualDiskCollector'
+    #    - 'VMStatsMemoryCollector'
+    #    - 'VMStatsDefaultCollector'
+        - 'VcopsSelfMonitoringPropertiesCollector'
+        - 'VcopsSelfMonitoringStatsCollector'
+    ##  INFO - Alerts
+    #    - 'NSXTAdapterAlertCollector'
+    #    - 'NSXTMgmtClusterAlertCollector'
+    #    - 'NSXTMgmtServiceAlertCollector'
+    #    - 'NSXTMgmtNodeAlertCollector'
+    #    - 'NSXTTransportNodeAlertCollector'
+    #    - 'NSXTLogicalSwitchAlertCollector'
+    #    - 'ClusterAlertCollector'
+    #    - 'DatastoreAlertCollector'
+    #    - 'HostSystemAlertCollector'
+    #    - 'VCenterAlertCollector'
+    #    - 'VMAlertCollector'
+    #    - 'VcopsSelfMonitoringAlertCollector'
+    #    - 'SDDCAlertCollector'
+
+    alerts:
+      alertCriticality:
+        - 'CRITICAL'
+        - 'WARNING'
+        - 'IMMEDIATE'
+      activeOnly: True
+
+    CustomInfoMetricsGenerator:
+       - metric: 'vrops_virtualmachine_guest_tools_target_version'
+         values_dict:
+           # A dict with your static input > label: label_value
+           guest_tools_target_version: '11.3.5'
+
+
+    ClusterPropertiesCollector:
+    # INFO - Prefix: vrops_cluster_
+      - metric_suffix: "configuration_dasConfig_enabled"
+        expected: "true"
+        key: "configuration|dasConfig|enabled"
+      - metric_suffix: "configuration_dasConfig_admissionControlEnabled"
+        expected: "true"
+        key: "configuration|dasConfig|admissionControlEnabled"
+      - metric_suffix: "configuration_dasConfig_admissionControlPolicyId"
+        key: "configuration|dasConfig|admissionControlPolicyId"
+      - metric_suffix: "configuration_drsconfig_enabled"
+        expected: "true"
+        key: "configuration|drsConfig|enabled"
+      - metric_suffix: "configuration_drsconfig_defaultVmBehavior"
+        expected: "fullyAutomated"
+        key: "configuration|drsConfig|defaultVmBehavior"
+      - metric_suffix: "configuration_drsConfig_targetBalance"
+        key: "configuration|drsConfig|targetBalance"
+      - metric_suffix: "custom_attributes_info"
+        key: "summary|customTag:INFO|customTagValue"
+      - metric_suffix: "configuration_drsconfiguration_affinity_rules"
+        key: "configuration|drsconfig|affinityRules"
+
+    ClusterStatsCollector:
+    # INFO - Prefix: vrops_cluster_
+      - metric_suffix: "cpu_capacity_usage_percentage"
+        key: "cpu|capacity_usagepct_average"
+      - metric_suffix: "cpu_usage_mhz"
+        key: "cpu|usagemhz_average"
+      - metric_suffix: "cpu_capacity_mhz"
+        key: "cpu|haTotalCapacity_average"
+      - metric_suffix: "memory_usage_percentage"
+        key: "mem|host_usagePct"
+      - metric_suffix: "memory_usage_kilobytes"
+        key: "mem|host_usage"
+      - metric_suffix: "memory_capacity_kilobytes"
+        key: "mem|totalCapacity_average"
+      - metric_suffix: "cluster_running_hosts"
+        key: "summary|number_running_hosts"
+      - metric_suffix: "cluster_running_vms"
+        key: "summary|number_running_vms"
+      - metric_suffix: "services_totalImbalance"
+        key: "clusterServices|total_imbalance"
+      - metric_suffix: "summary_total_number_vms"
+        key: "summary|total_number_vms"
+      - metric_suffix: "cpu_contention_percentage"
+        key: "cpu|capacity_contentionPct"
+      - metric_suffix: "summary_drs_unhappy_vms"
+        key: "summary|drs_unhappy_vms"
+      - metric_suffix: "badge_efficiency_percentage"
+        key: "badge|efficiency"
+      - metric_suffix: "badge_health_percentage"
+        key: "badge|health"
+
+    DistributedvSwitchPropertiesCollector:
+    # INFO - Prefix: vrops_distributed_virtual_switch_
+      - metric_suffix: "summary_version"
+        key: "summary|version"
+
+    DatastoreStatsCollector:
+    # INFO - Prefix: vrops_datastore_
+      - metric_suffix: "diskspace_total_usage_gigabytes"
+        key: "diskspace|disktotal"
+      - metric_suffix: "diskspace_freespace_gigabytes"
+        key: "diskspace|freespace"
+      - metric_suffix: "diskspace_capacity_gigabytes"
+        key: "diskspace|capacity"
+      - metric_suffix: "summary_total_number_vms"
+        key: "summary|total_number_vms"
+
+    DatastorePropertiesCollector:
+    # INFO - Prefix: vrops_datastore_
+      - metric_suffix: "summary_datastore_accessible"
+        expected: "PoweredOn"
+        key: "summary|accessible"
+      - metric_suffix: "hostcount"
+        key: "datastore|hostcount"
+
+    SDRSStatsCollector:
+    # INFO - Prefix: vrops_storagepod_
+      - metric_suffix: "capacity_remaining_percentage"
+        key: "OnlineCapacityAnalytics|capacityRemainingPercentage"
+
+    HostSystemStatsCollector:
+    # INFO - Prefix: vrops_hostsystem_
+      - metric_suffix: "hardware_number_of_cpu_cores_info"
+        key: "hardware|cpuInfo|num_CpuCores"
+      - metric_suffix: "configuration_dasConfig_admissionControlPolicy_failoverHost"
+        key: "configuration|dasConfig|admissionControlPolicy|failoverHost"
+      - metric_suffix: "cpu_sockets_number"
+        key: "cpu|numpackages"
+      - metric_suffix:  "cpu_usage_megahertz"
+        key: "cpu|usagemhz_average"
+      - metric_suffix: "cpu_capacity_provisioned"
+        key: "cpu|capacity_provisioned"
+      - metric_suffix: "cpu_demand_percentage"
+        key: "cpu|demandPct"
+      - metric_suffix: "cpu_demand_megahertz"
+        key: "cpu|demandmhz"
+      - metric_suffix: "cpu_usage_average_percentage"
+        key: "cpu|usage_average"
+      - metric_suffix: "cpu_co_stop_miliseconds"
+        key: "cpu|costop_summation"
+      - metric_suffix: "cpu_contention_percentage"
+        key: "cpu|capacity_contentionPct"
+      - metric_suffix: "cpu_io_wait_miliseconds"
+        key: "cpu|iowait"
+      - metric_suffix: "cpu_ready_miliseconds"
+        key: "cpu|ready_summation"
+      - metric_suffix: "cpu_swap_wait_miliseconds"
+        key: "cpu|swapwait_summation"
+      - metric_suffix: "memory_host_usage_kilobytes"
+        key: "mem|host_usage"
+      - metric_suffix: "memory_useable_kilobytes"
+        key: "mem|host_usable"
+      - metric_suffix: "memory_usage_percentage"
+        key: "mem|usage_average"
+      - metric_suffix: "memory_utilization"
+        key: "mem|total_need"
+      - metric_suffix: "memory_contention_percentage"
+        key: "mem|host_contentionPct"
+      - metric_suffix: "memory_ballooning_kilobytes"
+        key: "mem|vmmemctl_average"
+      - metric_suffix: "memory_compressed_kilobytes"
+        key: "mem|compressed_average"
+      - metric_suffix: "memory_activly_used_by_vms_kilobytes"
+        key: "mem|active_average"
+      - metric_suffix: "memory_consumed_by_vms_kilobytes"
+        key: "mem|consumed_average"
+      - metric_suffix: "memory_capacity_available_to_vms_kilobytes"
+        key: "mem|host_provisioned"
+      - metric_suffix: "memory_swap_in_rate_kbps"
+        key: "mem|swapinRate_average"
+      - metric_suffix: "memory_swap_out_rate_kbps"
+        key: "mem|swapoutRate_average"
+      - metric_suffix: "memory_swap_used_rate_kbps"
+        key: "mem|swapused_average"
+      - metric_suffix: "memory_reserved_capacity_percentage"
+        key: "mem|reservedCapacityPct"
+      - metric_suffix: "network_packets_dropped_rx_number"
+        key: "net|droppedRx_summation"
+      - metric_suffix: "network_packets_dropped_tx_number"
+        key: "net|droppedTx_summation"
+      - metric_suffix: "network_packets_dropped_percentage"
+        key: "net:Aggregate of all instances|droppedPct"
+      - metric_suffix: "summary_number_VMs_total"
+        key: "summary|total_number_vms"
+      - metric_suffix: "summary_running_VMs_number"
+        key: "summary|number_running_vms"
+      - metric_suffix: "summary_number_running_vcpus_total"
+        key: "summary|number_running_vcpus"
+      - metric_suffix: "summary_number_vmotion_total"
+        key: "summary|number_vmotion"
+      - metric_suffix: "system_uptime_seconds"
+        key: "sys|uptime_latest"
+      - metric_suffix: "diskspace_capacity_gigabytes"
+        key: "diskspace|total_capacity"
+      - metric_suffix: "diskspace_usage_gigabytes"
+        key: "diskspace|total_usage"
+
+    HostSystemPropertiesCollector:
+    # INFO - Prefix: vrops_hostsystem_
+      - metric_suffix: "runtime_powerState"
+        key: "runtime|powerState"
+        expected: "Powered On"
+      - metric_suffix: "runtime_connectionState"
+        key: "runtime|connectionState"
+        expected: "connected"
+      - metric_suffix: "runtime_maintenanceState"
+        key: "runtime|maintenanceState"
+        expected: "notInMaintenance"
+      - metric_suffix: "summary_version_info"
+        key: "summary|version"
+      - metric_suffix: "custom_attributes_hw_info"
+        key: "summary|customTag:HW|customTagValue"
+      - metric_suffix: "sys_build_info"
+        key: "sys|build"
+      - metric_suffix: "config_diskSpace_bytes"
+        key: "config|diskSpace"
+      - metric_suffix: "config_hyperthread_available"
+        key: "config|hyperThread|available"
+      - metric_suffix: "cpu_model"
+        key: "cpu|cpuModel"
+      - metric_suffix: "hardware_model"
+        key: "hardware|vendorModel"
+      - metric_suffix: "hardware_bios_version"
+        key: "hardware|biosVersion"
+      - metric_suffix: "storage_number_of_active_path"
+        key: "config|storageDevice|multipathInfo|numberofActivePath"
+      - metric_suffix: "storage_number_of_path"
+        key: "config|storageDevice|plugStoreTopology|numberofPath"
+
+    VCenterStatsCollector:
+    # INFO - Prefix: vrops_virtualmachine_
+      - metric_suffix: "cpu_used_percent"
+        key: "cpu|capacity_usagepct_average"
+      - metric_suffix: "memory_used_percent"
+        key: "mem|host_usagePct"
+      - metric_suffix: "memory_reserved_capacity_average"
+        key: "mem|reservedCapacity_average"
+      - metric_suffix: "diskspace_total_gigabytes"
+        key: "diskspace|total_capacity"
+      - metric_suffix: "diskspace_usage_gigabytes"
+        key: "diskspace|total_usage"
+      - metric_suffix: "vcsa_certificate_remaining_days"
+        key: "summary|CPO vCSA Certificate Remaining Days"
+
+    VCenterPropertiesCollector:
+    # INFO - Prefix: vrops_virtualmachine_
+      - metric_suffix: "summary_version_info"
+        key: "summary|version"
+      - metric_suffix: "vc_fullname_info"
+        key: "summary|vcfullname"
+      - metric_suffix: "summary_certificate_expiry_date"
+        key: "summary|cert_expiry_date"
+      - metric_suffix: "summary_custom_sts_certificate_remaining_days"
+        key: "SummaryCustom|STS Certificate Remaining Days"
+
+    VMPropertiesCollector:
+    # INFO - Prefix: vrops_virtualmachine_
+      - metric_suffix: "runtime_powerState"
+        expected: "Powered On"
+        key: "summary|runtime|powerState"
+      - metric_suffix: "runtime_connectionState"
+        expected: "connected"
+        key: "summary|runtime|connectionState"
+      - metric_suffix: "guest_tools_version"
+        key: "summary|guest|toolsVersion"
+      - metric_suffix: "summary_ethernetCards"
+        key: "summary|config|numEthernetCards"
+      - metric_suffix: "virtualdisk_scsi0_0_datastore"
+        key: "virtualDisk:scsi0:0|datastore"
+      - metric_suffix: "virtualdisk_scsi0_1_datastore"
+        key: "virtualDisk:scsi0:1|datastore"
+      - metric_suffix: "guest_os_full_name"
+        key: "config|guestFullName"
+      - metric_suffix: "config_hardware_memory_kilobytes"
+        key: "config|hardware|memoryKB"
+      - metric_suffix: "disk_space_snapshot_age_days"
+        key: "diskspace|snapshot|snapshotAge"
+      - metric_suffix: "guest_tools_running_status"
+        key: "summary|guest|toolsRunningStatus"
+      - metric_suffix: "guest_tools_version_status"
+        key: "summary|guest|toolsVersionStatus2"
+      - metric_suffix: "summary_datastore"
+        key: "summary|datastore"
+
+    VMStatsMemoryCollector:
+    # INFO - Prefix: vrops_virtualmachine_
+      - metric_suffix: "memory_usage_average"
+        key: "mem|usage_average"
+      - metric_suffix: "memory_kilobytes"
+        key: "mem|guest_provisioned"
+      - metric_suffix: "memory_consumed_kilobytes"
+        key: "mem|consumed_average"
+      - metric_suffix: "memory_consumed_ratio"
+        key: "mem|consumedPct"
+      - metric_suffix: "memory_activewrite_kilobytes"
+        key: "mem|activewrite_average"
+      - metric_suffix: "memory_demand_kilobytes"
+        key: "mem|vmMemoryDemand"
+      - metric_suffix: "memory_active_ratio"
+        key: "mem|guest_activePct"
+      - metric_suffix: "memory_ballooning_ratio"
+        key: "mem|balloonPct"
+      - metric_suffix: "memory_contention_ratio"
+        key: "mem|host_contentionPct"
+      - metric_suffix: "swapped_memory_kilobytes"
+        key: "mem|swapped_average"
+      - metric_suffix: "swapin_memory_kilobytes"
+        key: "mem|swapinRate_average"
+      - metric_suffix: "memory_recommended_size_kilobytes"
+        key: "OnlineCapacityAnalytics|mem|recommendedSize"
+      - metric_suffix: "memory_reservation_used"
+        key: "mem|reservation_used"
+      - metric_suffix: "undersized_memory"
+        key: "summary|undersized|memory"
+      - metric_suffix: "oversized_memory"
+        key: "summary|oversized|memory"
+
+    VMStatsCPUCollector:
+    # INFO - Prefix: vrops_virtualmachine_
+      - metric_suffix: "number_vcpus_total"
+        key: "config|hardware|num_Cpu"
+      - metric_suffix: "cpu_costop_percentage"
+        key: "cpu|costopPct"
+      - metric_suffix: "cpu_demand_mhz"
+        key: "cpu|demandmhz"
+      - metric_suffix: "cpu_demand_ratio"
+        key: "cpu|demandPct"
+      - metric_suffix: "cpu_provisioned_capacity_mhz"
+        key: "cpu|vm_capacity_provisioned"
+      - metric_suffix: "cpu_usage_ratio"
+        key: "cpu|usage_average"
+      - metric_suffix: "cpu_usage_average_mhz"
+        key: "cpu|usagemhz_average"
+      - metric_suffix: "cpu_workload_percentage"
+        key: "cpu|workload"
+      - metric_suffix: "cpu_contention_ratio"
+        key: "cpu|capacity_contentionPct"
+      - metric_suffix: "cpu_contention_miliseconds"
+        key: "cpu|capacity_contention"
+      - metric_suffix: "cpu_ready_ratio"
+        key: "cpu|readyPct"
+      - metric_suffix: "cpu_latency_average"
+        key: "cpu|latency_average"
+      - metric_suffix: "cpu_overlap_summation_miliseconds"
+        key: "cpu|overlap_summation"
+      - metric_suffix: "cpu_wait_summation_miliseconds"
+        key: "cpu|wait_summation"
+      - metric_suffix: "cpu_io_wait_percentage"
+        key: "cpu|iowaitPct"
+      - metric_suffix: "cpu_recommended_size_mhz"
+        key: "OnlineCapacityAnalytics|cpu|recommendedSize"
+      - metric_suffix: "undersized_vcpus"
+        key: "summary|undersized|vcpus"
+      - metric_suffix: "oversized_vcpus"
+        key: "summary|oversized|vcpus"
+
+    VMStatsNetworkCollector:
+    # INFO - Prefix: vrops_virtualmachine_
+      - metric_suffix: "network_packets_dropped_rx_number"
+        key: "net|droppedRx_summation"
+      - metric_suffix: "network_packets_dropped_tx_number"
+        key: "net|droppedTx_summation"
+      - metric_suffix: "network_packets_rx_number"
+        key: "net|packetsRx_summation"
+      - metric_suffix: "network_packets_tx_number"
+        key: "net|packetsTx_summation"
+      - metric_suffix: "network_usage_average_kilobytes_per_second"
+        key: "net|usage_average"
+      - metric_suffix: "network_data_received_kilobytes_per_second"
+        key: "net|bytesRx_average"
+      - metric_suffix: "network_data_transmitted_kilobytes_per_second"
+        key: "net|bytesTx_average"
+
+    VMStatsVirtualDiskCollector:
+    # INFO - Prefix: vrops_virtualmachine_
+      - metric_suffix: "virtual_disk_outstanding_io"
+        key: "virtualDisk|vDiskOIO"
+      - metric_suffix: "virtual_disk_read_kilobytes_per_second"
+        key: "virtualDisk|read_average"
+      - metric_suffix: "virtual_disk_write_kilobytes_per_second"
+        key: "virtualDisk|write_average"
+      - metric_suffix: "virtual_disk_outstanding_read_number"
+        key: "virtualDisk|readOIO_latest"
+      - metric_suffix: "virtual_disk_outstanding_write_number"
+        key: "virtualDisk|writeOIO_latest"
+      - metric_suffix: "virtual_disk_average_read_miliseconds"
+        key: "virtualDisk|totalReadLatency_average"
+      - metric_suffix: "virtual_disk_average_write_miliseconds"
+        key: "virtualDisk|totalWriteLatency_average"
+
+    VMStatsDefaultCollector:
+    # INFO - Prefix: vrops_virtualmachine_
+      - metric_suffix: "health"
+        key: "badge|health"
+      - metric_suffix: "undersized"
+        key: "summary|undersized"
+      - metric_suffix: "oversized"
+        key: "summary|oversized"
+      - metric_suffix: "disk_usage_average_kilobytes_per_second"
+        key: "disk|usage_average"
+      - metric_suffix: "diskspace_virtual_machine_used_gigabytes"
+        key: "diskspace|perDsUsed"
+      - metric_suffix: "diskspace_gigabytes"
+        key: "config|hardware|disk_Space"
+      - metric_suffix: "datastore_total"
+        key: "summary|number_datastore"
+      - metric_suffix: "datastore_outstanding_io_requests"
+        key: "datastore|demand_oio"
+      - metric_suffix: "database_disk_usage_gigabytes"
+        key: "guestfilesystem:/storage/db|usage"
+      - metric_suffix: "database_disk_capacity_gigabytes"
+        key: "guestfilesystem:/storage/db|capacity"
+      - metric_suffix: "database_disk_usage_percent"
+        key: "guestfilesystem:/storage/db|percentage"
+      - metric_suffix: "guestfilesystem_storage_log_usage"
+        key: "guestfilesystem:/storage/log|usage"
+      - metric_suffix: "guestfilesystem_storage_log_capacity"
+        key: "guestfilesystem:/storage/log|capacity"
+      - metric_suffix: "guestfilesystem_storage_log_percentage"
+        key: "guestfilesystem:/storage/log|percentage"
+      - metric_suffix: "guestfilesystem_storage_autodeploy_usage"
+        key: "guestfilesystem:/storage/autodeploy|usage"
+      - metric_suffix: "guestfilesystem_storage_autodeploy_capacity"
+        key: "guestfilesystem:/storage/autodeploy|capacity"
+      - metric_suffix: "guestfilesystem_storage_autodeploy_percentage"
+        key: "guestfilesystem:/storage/autodeploy|percentage"
+      - metric_suffix: "guestfilesystem_storage_core_usage"
+        key: "guestfilesystem:/storage/core|usage"
+      - metric_suffix: "guestfilesystem_storage_core_capacity"
+        key: "guestfilesystem:/storage/core|capacity"
+      - metric_suffix: "guestfilesystem_storage_core_percentage"
+        key: "guestfilesystem:/storage/core|percentage"
+      - metric_suffix: "guestfilesystem_storage_dblog_usage"
+        key: "guestfilesystem:/storage/dblog|usage"
+      - metric_suffix: "guestfilesystem_storage_dblog_capacity"
+        key: "guestfilesystem:/storage/dblog|capacity"
+      - metric_suffix: "guestfilesystem_storage_dblog_percentage"
+        key: "guestfilesystem:/storage/dblog|percentage"
+      - metric_suffix: "guestfilesystem_storage_imagebuilder_usage"
+        key: "guestfilesystem:/storage/imagebuilder|usage"
+      - metric_suffix: "guestfilesystem_storage_imagebuilder_capacity"
+        key: "guestfilesystem:/storage/imagebuilder|capacity"
+      - metric_suffix: "guestfilesystem_storage_imagebuilder_percentage"
+        key: "guestfilesystem:/storage/imagebuilder|percentage"
+      - metric_suffix: "guestfilesystem_storage_netdump_usage"
+        key: "guestfilesystem:/storage/netdump|usage"
+      - metric_suffix: "guestfilesystem_storage_netdump_capacity"
+        key: "guestfilesystem:/storage/netdump|capacity"
+      - metric_suffix: "guestfilesystem_storage_netdump_percentage"
+        key: "guestfilesystem:/storage/netdump|percentage"
+      - metric_suffix: "guestfilesystem_storage_seat_usage"
+        key: "guestfilesystem:/storage/seat|usage"
+      - metric_suffix: "guestfilesystem_storage_seat_capacity"
+        key: "guestfilesystem:/storage/seat|capacity"
+      - metric_suffix: "guestfilesystem_storage_seat_percentage"
+        key: "guestfilesystem:/storage/seat|percentage"
+      - metric_suffix: "guestfilesystem_storage_updatemgr_usage"
+        key: "guestfilesystem:/storage/updatemgr|usage"
+      - metric_suffix: "guestfilesystem_storage_updatemgr_capacity"
+        key: "guestfilesystem:/storage/updatemgr|capacity"
+      - metric_suffix: "guestfilesystem_storage_updatemgr_percentage"
+        key: "guestfilesystem:/storage/updatemgr|percentage"
+      - metric_suffix: "guestfilesystem_boot_usage"
+        key: "guestfilesystem:/boot|usage"
+      - metric_suffix: "guestfilesystem_boot_capacity"
+        key: "guestfilesystem:/boot|capacity"
+      - metric_suffix: "guestfilesystem_boot_percentage"
+        key: "guestfilesystem:/boot|percentage"
+      - metric_suffix: "guestfilesystem_usage"
+        key: "guestfilesystem:/|usage"
+      - metric_suffix: "guestfilesystem_capacity"
+        key: "guestfilesystem:/|capacity"
+      - metric_suffix: "guestfilesystem_percentage"
+        key: "guestfilesystem:/|percentage"
+
+    NSXTMgmtClusterStatsCollector:
+    # INFO - Prefix: vrops_nsxt_mgmt_cluster_
+      - metric_suffix: "sys_capacity_distributed_firewall_rules_usage_count"
+        key: "System Capacity|Distributed Firewall Rules|UsageCount"
+      - metric_suffix: "sys_capacity_distributed_firewall_rules_max_supported_count"
+        key: "System Capacity|Distributed Firewall Rules|MaxSupportedCount"
+      - metric_suffix: "sys_capacity_distributed_firewall_section_max_supported_count"
+        key: "System Capacity|Distributed Firewall Sections|MaxSupportedCount"
+      - metric_suffix: "sys_capacity_distributed_firewall_section_usage_count"
+        key: "System Capacity|Distributed Firewall Sections|UsageCount"
+      - metric_suffix: "sys_capacity_logical_switches_max_supported_count"
+        key: "System Capacity|Logical Switches|MaxSupportedCount"
+      - metric_suffix: "sys_capacity_logical_switches_usage_count"
+        key: "System Capacity|Logical Switches|UsageCount"
+      - metric_suffix: "sys_capacity_logical_switch_ports_max_supported_count"
+        key: "System Capacity|System-wide Logical Switch Ports|MaxSupportedCount"
+      - metric_suffix: "sys_capacity_logical_switch_ports_usage_count"
+        key: "System Capacity|System-wide Logical Switch Ports|UsageCount"
+      - metric_suffix: "sys_capacity_nsgroups_max_supported_count"
+        key: "System Capacity|Groups|MaxSupportedCount"
+      - metric_suffix: "sys_capacity_nsgroups_usage_count"
+        key: "System Capacity|Groups|UsageCount"
+      - metric_suffix: "sys_capacity_ip_sets_max_supported_count"
+        key: "System Capacity|IP Sets|MaxSupportedCount"
+      - metric_suffix: "sys_capacity_ip_sets_usage_count"
+        key: "System Capacity|IP Sets|UsageCount"
+      - metric_suffix: "sys_capacity_groups_based_in_ip_max_supported_count"
+        key: "System Capacity|Groups Based on IP Sets|MaxSupportedCount"
+      - metric_suffix: "sys_capacity_groups_based_in_ip_usage_count"
+        key: "System Capacity|Groups Based on IP Sets|UsageCount"
+
+    NSXTMgmtClusterPropertiesCollector:
+    # INFO - Prefix: vrops_nsxt_mgmt_cluster_
+      - metric_suffix: "product_version"
+        key: "NSXTProductVersion"
+      - metric_suffix: "management_cluster_connectivity_status"
+        expected: "STABLE"
+        key: "ConnectivityStatus|ClusterStatus|ManagementClusterStatusProperty"
+      - metric_suffix: "controller_cluster_connectivity_status"
+        expected: "STABLE"
+        key: "ConnectivityStatus|ClusterStatus|ControllerClusterStatusProperty"
+
+    NSXTMgmtNodeStatsCollector:
+    # INFO - Prefix: vrops_nsxt_mgmt_node_
+      - metric_suffix: "memory_used"
+        key: "Memory|Used"
+      - metric_suffix: "memory_total"
+        key: "Memory|Total"
+      - metric_suffix: "filesystems_var_log_usedpercentage"
+        key: "FileSystems|/var/log|usedPercentage"
+      - metric_suffix: "filesystems_image_usedpercentage"
+        key: "FileSystems|/image|usedPercentage"
+
+    NSXTMgmtNodePropertiesCollector:
+    # INFO - Prefix: vrops_nsxt_mgmt_node_
+      - metric_suffix: "version"
+        key: "NSXTManagerNodeVersion"
+      - metric_suffix: "connectivity_status"
+        expected: "CONNECTED"
+        key: "ConnectivityStatus|ManagerConnectivityProperty"
+
+    NSXTTransportNodePropertiesCollector:
+    # INFO - Prefix: vrops_nsxt_transport_node_
+      - metric_suffix: "connectivity_status"
+        expected: "SUCCESS"
+        key: "ConnectivityStatus|TransportNodeState"
+      - metric_suffix: "summary_version"
+        key: "summary|SoftwareVersion"
+
+    NSXTLogicalSwitchPropertiesCollector:
+    # INFO - Prefix: vrops_nsxt_logical_switch_
+       - metric_suffix: "state"
+         expected: "SUCCESS"
+         key: "summary|LogicalSwitchStateProperty"
+
+    VcopsSelfMonitoringStatsCollector:
+    # INFO - Prefix: vrops_self_
+       - metric_suffix: "primary_objects_count"
+         key: "PrimaryResourcesCount"
+       - metric_suffix: "primary_metrics_count"
+         key: "PrimaryMetricsCount"
+
+    VcopsSelfMonitoringPropertiesCollector:
+    # INFO - Prefix: vrops_self_
+       - metric_suffix: "build_number"
+         key: "build_number"
+       - metric_suffix: "cluster_state"
+         expected: "ONLINE"
+         key: "ClusterState"

--- a/system/vmware-monitoring/templates/inventory-configmap.yaml
+++ b/system/vmware-monitoring/templates/inventory-configmap.yaml
@@ -1,0 +1,93 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vrops-exporter-inventory-config
+data:
+  inventory_config.yaml: |
+    query_specs:
+    # to create specific resource query specs for a resourcekind, stick to one of the following keys:
+    # vCenter Adapter: [Datacenter, ClusterComputeResource, Datastore, HostSystem, VmwareDistributedVirtualSwitch]
+    # NSX-T: [ManagementCluster, ManagementNode, ManagementService, TransportZone, TransportNode, LogicalSwitch]
+      VirtualMachine:
+        resourceHealth:
+          - "GREEN"
+          - "YELLOW"
+          - "ORANGE"
+          - "RED"
+          - "GREY"
+        resourceStatus:
+          # resource data collection stats
+    #      - "ERROR"
+          - "UNKNOWN"
+    #      - "DOWN"
+          - "DATA_RECEIVING"
+    #      - "OLD_DATA_RECEIVING"
+    #      - "NO_DATA_RECEIVING"
+    #      - "NO_PARENT_MONITORING"
+    #      - "COLLECTOR_DOWN"
+        resourceStates:
+          # resource states
+    #      - "STOPPED"
+    #      - "STARTING"
+          - "STARTED"
+    #      - "STOPPING"
+    #      - "UPDATING"
+    #      - "FAILED"
+    #      - "MAINTAINED"
+    #      - "MAINTAINED_MANUAL"
+    #      - "REMOVING"
+    #      - "NOT_EXISTING"
+    #      - "UNKNOWN"
+
+      default:
+        resourceHealth:
+          - "GREEN"
+          - "YELLOW"
+          - "ORANGE"
+          - "RED"
+          - "GREY"
+        resourceStatus:
+          # resource data collection stats
+          - "ERROR"
+          - "UNKNOWN"
+          - "DOWN"
+          - "DATA_RECEIVING"
+          - "OLD_DATA_RECEIVING"
+          - "NO_DATA_RECEIVING"
+          - "NO_PARENT_MONITORING"
+          - "COLLECTOR_DOWN"
+        resourceStates:
+          # resource states
+          - "STOPPED"
+          - "STARTING"
+          - "STARTED"
+          - "STOPPING"
+          - "UPDATING"
+          - "FAILED"
+          - "MAINTAINED"
+          - "MAINTAINED_MANUAL"
+          - "REMOVING"
+          - "NOT_EXISTING"
+          - "UNKNOWN"
+
+    resourcekinds:
+        vcops_resourcekinds:
+          - "vC-Ops-Analytics"
+          - "vC-Ops-CaSA"
+          - "vC-Ops-Cluster"
+          - "vC-Ops-Collector"
+          - "vC-Ops-Node"
+          - "vC-Ops-Suite-API"
+          - "vC-Ops-Watchdog"
+
+        sddc_resourcekinds:
+          - "NSXT Server"
+          - "VCENTER"
+          - "NSXVPostgresService"
+          - "SSHService"
+          - "NSXReplicatorService"
+          - "NSXRabbitmqService"
+          - "NSXManagerService"
+          - "NSXControllerService"
+          - "SDDCHealth Instance"
+          - "vCenterBackupJob"

--- a/system/vmware-monitoring/templates/vrops-exporter-deployment.yaml
+++ b/system/vmware-monitoring/templates/vrops-exporter-deployment.yaml
@@ -1,0 +1,121 @@
+{{- $root := . }}
+{{- if .Values.vrops.enabled }}
+{{- range $target := .Values.global.targets }}
+{{- range $exporter_type := $.Values.vrops.exporter_types }}
+{{- if $exporter_type.enabled }}
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: {{ include "vropsExporter.fullName" (list $target $root) }}-{{ required "$exporter_type.name is missing" $exporter_type.name }}
+  namespace: {{ required ".Values.vrops.namespace variable missing" $.Values.vrops.namespace }}
+  labels:
+    target: {{ include "vropsExporter.fullName" (list $target $root) }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "vropsExporter.fullName" (list $target $root) }}-{{ required "$exporter_type.name is missing" $exporter_type.name }}
+      type: exporter
+  template:
+    metadata:
+      labels:
+        app: {{ include "vropsExporter.fullName" (list $target $root) }}-{{ required "$exporter_type.name is missing" $exporter_type.name }}
+        type: exporter
+        vrops-collector-target: {{ include "vropsExporter.name" (list $target $root) }}
+        target: {{ include "vropsExporter.fullName" (list $target $root) }}
+        alert-tier: vmware
+        alert-service: vrops
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: vrops-collector-target
+                      operator: In
+                      values:
+                        - {{ include "vropsExporter.name" (list $target $root) }}
+                topologyKey: kubernetes.io/hostname
+      volumes:
+        - name: vrops-config
+          configMap:
+            name: vrops-exporter-collector-config
+      containers:
+         - name: vrops-exporter
+           image: {{ required ".Values.global.registry variable missing" $.Values.global.registry }}/{{ required ".Values.vrops.image.name variable missing" $.Values.vrops.image.name }}:{{ required ".Values.vrops.image.tag variable missing" $.Values.vrops.image.tag }}
+           ports:
+             - name: metrics
+               containerPort: {{ required ".Values.vrops.port missing" $.Values.vrops.port_number }}
+           command:
+             - ./exporter.py
+           args:
+             - -m
+             - /config/collector_config.yaml
+             - -t
+             - {{ required "$target missing" $target }}
+             {{- range $collector := $exporter_type.collectors }}
+             - -c
+             - {{ $collector }}
+             {{- end }}
+           env:
+           - name: PORT
+             value: {{ required ".Values.vrops.port_number missing" $.Values.vrops.port_number | quote }}
+           - name: DEBUG
+             value: {{ $.Values.vrops.debug | quote }}
+           - name: INVENTORY
+             value: vrops-inventory
+           resources:
+             limits:
+               memory: {{ required "$exporter_type.resources.limits.memory missing" $exporter_type.resources.limits.memory }}
+               cpu: {{ required "$exporter_type.resources.limits.cpu missing" $exporter_type.resources.limits.cpu }}
+             requests:
+               memory: {{ required "$exporter_type.resources.requests.memory missing" $exporter_type.resources.requests.memory }}
+               cpu: {{ required "$exporter_type.resources.requests.cpu missing" $exporter_type.resources.requests.cpu }}
+           volumeMounts:
+             - name: vrops-config
+               mountPath: "/config"
+               readOnly: true
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+
+metadata:
+  name: {{ include "vropsExporter.fullName" (list $target $root) }}
+  labels:
+    prometheus: {{ include "prometheusVMware.fullName" (list $target $root) }}
+
+spec:
+  jobLabel: {{ include "vropsExporter.fullName" (list $target $root) }}
+
+  selector:
+    matchLabels:
+      target: {{ include "vropsExporter.fullName" (list $target $root) }}
+
+  namespaceSelector:
+    matchNames:
+      - {{ required "$.Values.vrops.namespace variable missing" $.Values.vrops.namespace }}
+
+  podMetricsEndpoints:
+    - port: metrics
+      interval: {{ required "$.Values.vrops.scrapeInterval  missing" $.Values.vrops.scrapeInterval }}
+      scrapeTimeout: {{ required "$.Values.vrops.scrapeTimeout  missing" $.Values.vrops.scrapeTimeout }}
+      scheme: http
+      honorLabels: true
+      relabelings:
+        - sourceLabels:
+            - __meta_kubernetes_pod_label_app
+          targetLabel: collector
+          regex: (vrops-exporter-)(vc-.*)
+          replacement: vrops-${2}
+        - sourceLabels:
+            - container
+          targetLabel: job
+      metricRelabelings:
+        - action: labeldrop
+          regex: "pod|container|instance|endpoint|namespace|service"
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/system/vmware-monitoring/templates/vrops-inventory-deployment.yaml
+++ b/system/vmware-monitoring/templates/vrops-inventory-deployment.yaml
@@ -1,0 +1,84 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: vrops-inventory
+  namespace: {{ required ".Values.vrops.namespace variable missing" $.Values.vrops.namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: vrops-inventory
+      type: inventorycollector
+  template:
+    metadata:
+      labels:
+        app: vrops-inventory
+        type: inventorycollector
+        alert-tier: vmware
+        alert-service: vrops
+    spec:
+      volumes:
+        - name: vrops-exporter-inventory-config
+          configMap:
+            name: vrops-exporter-inventory-config
+      containers:
+         - name: vrops-inventory
+           image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.vrops.image.name variable missing" .Values.vrops.image.name }}:{{ required ".Values.vrops.inventory.tag variable missing" .Values.vrops.inventory.tag }}
+           ports:
+             - name: metrics
+               containerPort: {{ required ".Values.vrops.inventory.port_number missing" .Values.vrops.inventory.port_number }}
+           command:
+             - ./inventory.py
+           args:
+             - -m
+             - /config/inventory_config.yaml
+           env:
+           - name: USER
+             value: {{ required ".Values.vrops.user variable is missing" .Values.vrops.user }}
+           - name: PASSWORD
+             value: {{ required ".Values.vrops.password variable is missing" .Values.vrops.password | quote }}
+           - name: PORT
+             value: {{ required ".Values.vrops.inventory.port_number missing" .Values.vrops.inventory.port_number | quote }}
+           - name: DEBUG
+             value: {{ .Values.vrops.debug | quote }}
+           - name: SLEEP
+             value: {{ .Values.vrops.inventory.sleep | quote }}
+           - name: TIMEOUT
+             value: {{ .Values.vrops.inventory.timeout | quote }}
+           - name: ATLAS
+             value: {{ .Values.vrops.atlas }}
+           resources:
+             limits:
+               memory: 240Mi
+               cpu: 300m
+             requests:
+               memory: 120Mi
+               cpu: 150m
+             limits:
+               memory: {{ required ".Values.vrops.inventory.resources.limits.memory missing" .Values.vrops.inventory.resources.limits.memory }}
+               cpu: {{ required ".Values.vrops.inventory.resources.limits.cpu missing" .Values.vrops.inventory.resources.limits.cpu }}
+             requests:
+               memory: {{ required ".Values.vrops.inventory.resources.requests.memory missing" .Values.vrops.inventory.resources.requests.memory }}
+               cpu: {{ required ".Values.vrops.inventory.resources.requests.cpu missing" .Values.vrops.inventory.resources.requests.cpu }}
+           volumeMounts:
+             - name: vrops-exporter-inventory-config
+               mountPath: "/config"
+               readOnly: true
+           livenessProbe:
+             httpGet:
+               path: /vrops_list
+               port: {{ required ".Values.vrops.inventory.port_number missing" .Values.vrops.inventory.port_number }}
+             initialDelaySeconds: 5
+             timeoutSeconds: 10
+             periodSeconds: 15
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: vrops-inventory
+  namespace: {{ required ".Values.vrops.namespace variable missing" $.Values.vrops.namespace }}
+spec:
+  selector:
+    app: vrops-inventory
+  ports:
+    - name: metrics
+      port: {{ .Values.vrops.inventory.port_number }}

--- a/system/vmware-monitoring/templates/vrops-inventory-exporter-deployment.yaml
+++ b/system/vmware-monitoring/templates/vrops-inventory-exporter-deployment.yaml
@@ -1,0 +1,93 @@
+{{- $root := . }}
+{{- if .Values.vrops.enabled }}
+{{- range $target := .Values.global.targets }}
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: {{ include "vropsInventoryExporter.fullName" (list $target $root) }}
+  namespace: {{ required "$.Values.vrops.namespace variable missing" $.Values.vrops.namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "vropsInventoryExporter.fullName" (list $target $root) }}
+      type: exporter
+  template:
+    metadata:
+      labels:
+        app: {{ include "vropsInventoryExporter.fullName" (list $target $root) }}
+        type: exporter
+        target: {{ include "vropsInventoryExporter.fullName" (list $target $root) }}
+        alert-tier: vmware
+        alert-service: vrops
+    spec:
+      containers:
+         - name: vrops-inventory-exporter
+           image: {{ required "$.Values.global.registry variable missing" $.Values.global.registry }}/{{ required "$.Values.vrops.image.name variable missing" $.Values.vrops.image.name }}:{{ required "$.Values.vrops.image.tag variable missing" $.Values.vrops.image.tag }}
+           ports:
+             - name: metrics
+               containerPort: {{ required "$.Values.vrops.inventory_exporter.port_number missing" $.Values.vrops.inventory_exporter.port_number }}
+           command:
+             - ./exporter.py
+           args:
+             - -m
+             - /config/collector_config.yaml
+             - -c
+             - InventoryCollector
+             - -t
+             - {{ required "$target missing" $target }}
+           env:
+           - name: PORT
+             value: {{ required "$.Values.vrops.inventory_exporter.port_number missing" $.Values.vrops.inventory_exporter.port_number | quote }}
+           - name: DEBUG
+             value: {{ $.Values.vrops.debug | quote }}
+           - name: INVENTORY
+             value: vrops-inventory
+           resources:
+             limits:
+               memory: {{ required "$.Values.vrops.exporter_types.default.resources.limits.memory missing" $.Values.vrops.exporter_types.default.resources.limits.memory }}
+               cpu: {{ required "$.Values.vrops.exporter_types.default.resources.limits.cpu missing" $.Values.vrops.exporter_types.default.resources.limits.cpu }}
+             requests:
+               memory: {{ required "$.Values.vrops.exporter_types.default.resources.requests.memory missing" $.Values.vrops.exporter_types.default.resources.requests.memory }}
+               cpu: {{ required "$.Values.vrops.exporter_types.default.resources.requests.cpu missing" $.Values.vrops.exporter_types.default.resources.requests.cpu }}
+           volumeMounts:
+             - mountPath: /config
+               name: vrops-config
+               readOnly: true
+      volumes:
+        - configMap:
+            name: vrops-exporter-collector-config
+          name: vrops-config
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+
+metadata:
+  name: {{ include "vropsInventoryExporter.fullName" (list $target $root) }}
+  labels:
+    prometheus: {{ include "prometheusVMware.fullName" (list $target $root) }}
+
+spec:
+  jobLabel: {{ include "vropsInventoryExporter.fullName" (list $target $root) }}
+
+  selector:
+    matchLabels:
+      target: {{ include "vropsInventoryExporter.fullName" (list $target $root) }}
+
+  namespaceSelector:
+    matchNames: [{{ required ".Values.vrops.namespace variable missing" $.Values.vrops.namespace }}]
+
+  podMetricsEndpoints:
+    - interval: 60s
+      scrapeTimeout: 50s
+      path: /metrics
+      scheme: http
+      port: metrics
+      relabelings:
+        - targetLabel: job
+          replacement: {{ include "vropsInventoryExporter.fullName" (list $target $root) }}
+      metricRelabelings:
+        - action: labeldrop
+          regex: "container|instance|endpoint|pod|namespace|service"
+{{ end }}
+{{ end }}

--- a/system/vmware-monitoring/values.yaml
+++ b/system/vmware-monitoring/values.yaml
@@ -1,0 +1,260 @@
+global:
+  domain: cloud.sap
+  clusterType: controlplane
+  alerts:
+    enabled: true
+    prometheus: vmware
+
+  aggregations:
+    enabled: true
+    prometheus: vmware
+
+owner-info:
+  support-group: observability
+  maintainers: 
+    - Richard Tief
+    - Tommy Sauer
+  helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/system/vmware-monitoring
+
+thanos:
+  vmware: true
+  deployWholeThanos: true
+
+prometheus-server:
+  vmware: true
+
+  retentionTime: 7d
+
+  additionalScrapeConfigs: {}
+
+  scrapeInterval: "60s"
+
+  alertmanagers:
+    hosts:
+      - alertmanager-internal.scaleout.eu-de-1.cloud.sap
+      - alertmanager-internal.scaleout.eu-nl-1.cloud.sap
+
+  ingress:
+    enabled: true
+    authentication:
+      sso:
+        enabled: true
+        authTLSSecret: kube-system/ingress-cacrt
+        authTLSVerifyDepth: 3
+        authTLSVerifyClient: on
+
+  internalIngress:
+    enabled: false
+
+  persistence:
+    enabled: true
+    accessMode: ReadWriteOnce
+    size: 10Gi
+
+  rbac:
+    create: true
+
+  serviceDiscoveries:
+    scrapeInterval: 60s
+    scrapeTimeout: 45s
+
+  serviceAccount:
+    create: true
+
+  logLevel: info
+
+  resources:
+    requests:
+      cpu: 500m
+      memory: 4Gi
+
+  securityContext:
+    fsGroup: 0
+    runAsUser: 0
+
+  alerts:
+    tier: monitor
+
+  thanos:
+    enabled: true
+
+vrops:
+  enabled: false
+  prometheusName: DEFINED-IN-REGION-SECRETS
+  scrapeInterval: 180s
+  scrapeTimeout: 175s
+  namespace: DEFINED-IN-REGION-SECRETS
+  image:
+    name: vrops_exporter
+    tag: DEFINED-IN-REGION-SECRETS
+  inventory:
+    tag: DEFINED-IN-REGION-SECRETS
+    port_number: 80
+    sleep: 60
+    timeout: 120
+    resources:
+      limits:
+        memory: 400Mi
+        cpu: 400m
+      requests:
+        memory: 200Mi
+        cpu: 200m
+  inventory_exporter:
+    port_number: 9161
+  port_number: 9160
+  alerts:
+    enabled: false
+  user: DEFINED-IN-REGION-SECRETS
+  password: DEFINED-IN-REGION-SECRETS
+  debug: DEFINED-IN-REGION-SECRETS
+  atlas: http://infra-monitoring-atlas-sd.infra-monitoring.svc:8080/service_discovery/netbox
+  targets: DEFINED-IN-REGION-SECRETS
+  exporter_types:
+    default:
+      name: default
+      enabled: false
+      collectors: []
+      resources:
+        limits:
+          memory: 200Mi
+          cpu: 100m
+        requests:
+          memory: 100Mi
+          cpu: 50m
+    host:
+      name: host
+      enabled: false
+      collectors:
+        - HostSystemStatsCollector
+        - HostSystemPropertiesCollector
+        - HostSystemAlertCollector
+      resources:
+        limits:
+          memory: 200Mi
+          cpu: 100m
+        requests:
+          memory: 100Mi
+          cpu: 50m
+    vm-memory:
+      name: vm-memory
+      enabled: false
+      collectors:
+        - VMStatsMemoryCollector
+      resources:
+        limits:
+          memory: 300Mi
+          cpu: 200m
+        requests:
+          memory: 150Mi
+          cpu: 100m
+    vm-cpu:
+      name: vm-cpu
+      enabled: false
+      collectors:
+        - VMStatsCPUCollector
+      resources:
+        limits:
+          memory: 300Mi
+          cpu: 200m
+        requests:
+          memory: 150Mi
+          cpu: 100m
+    vm-network:
+      name: vm-network
+      enabled: false
+      collectors:
+        - VMStatsNetworkCollector
+      resources:
+        limits:
+          memory: 300Mi
+          cpu: 200m
+        requests:
+          memory: 150Mi
+          cpu: 100m
+    vm-virtualdisk:
+      name: vm-virtualdisk
+      enabled: false
+      collectors:
+        - VMStatsVirtualDiskCollector
+      resources:
+        limits:
+          memory: 300Mi
+          cpu: 200m
+        requests:
+          memory: 150Mi
+          cpu: 100m
+    vm-default:
+      name: vm-default
+      enabled: false
+      collectors:
+        - VMStatsDefaultCollector
+      resources:
+        limits:
+          memory: 300Mi
+          cpu: 200m
+        requests:
+          memory: 150Mi
+          cpu: 100m
+    vm-properties-alerts:
+      name: vm-properties-alerts
+      enabled: false
+      collectors:
+        - VMPropertiesCollector
+        - VMAlertCollector
+      resources:
+        limits:
+          memory: 300Mi
+          cpu: 200m
+        requests:
+          memory: 150Mi
+          cpu: 100m
+    nsxt:
+      name: nsxt
+      enabled: false
+      collectors:
+        - NSXTMgmtClusterStatsCollector
+        - NSXTMgmtClusterPropertiesCollector
+        - NSXTMgmtNodeStatsCollector
+        - NSXTMgmtNodePropertiesCollector
+        - NSXTTransportNodePropertiesCollector
+        - NSXTLogicalSwitchPropertiesCollector
+      resources:
+        limits:
+          memory: 200Mi
+          cpu: 100m
+        requests:
+          memory: 100Mi
+          cpu: 50m
+    nsxt-alerts:
+      name: nsxt-alerts
+      enabled: false
+      collectors:
+        - NSXTAdapterAlertCollector
+        - NSXTMgmtClusterAlertCollector
+        - NSXTMgmtServiceAlertCollector
+        - NSXTMgmtNodeAlertCollector
+        - NSXTTransportNodeAlertCollector
+        - NSXTLogicalSwitchAlertCollector
+      resources:
+        limits:
+          memory: 200Mi
+          cpu: 100m
+        requests:
+          memory: 100Mi
+          cpu: 50m
+    alerts:
+      name: alerts
+      enabled: false
+      collectors:
+        - ClusterAlertCollector
+        - DatastoreAlertCollector
+        - VCenterAlertCollector
+        - VcopsSelfMonitoringAlertCollector
+        - SDDCAlertCollector
+      resources:
+        limits:
+          memory: 200Mi
+          cpu: 100m
+        requests:
+          memory: 100Mi
+          cpu: 50m


### PR DESCRIPTION
Merge `vrops-exporter` and `prometheus-vmware` to create resources for multiple monitoring targets. 

The chart requires the newly implemented dependency prometheus-server 7.1.0 and thanos 0.2.0, which are capable of creating multiple resources. 

vrops-exporter alerts are still deployed with this chart. They will be moved to a separate chart in the future. 