### PR TITLE
[common thanos] Enablement to create multiple thanos

### DIFF
--- a/common/thanos/Chart.yaml
+++ b/common/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: Deploy Thanos via operator
 type: application
-version: 0.1.22
+version: 0.2.0
 appVersion: v0.28.1
 maintainers:
   - name: Tommy Sauer (viennaa)

--- a/common/thanos/ci/test-values.yaml
+++ b/common/thanos/ci/test-values.yaml
@@ -5,19 +5,18 @@ global:
   cluster: x-regionOne
   tier: alertTierKubernetes
 
-thanos:
-  name: bestThanos
-  enabled: true
-  swiftStorageConfig:
-    authURL: https://keystone.evil.corp/v3
-    userName: prometheus
-    userDomainName: Default
-    password: topSecret!
-    domainName: Default
-    tenantName: master
-    regionName: regionOne
-    containerName: regionOnePrometheusThanos
-  queryDiscovery: true
+name: bestThanos
+enabled: true
+swiftStorageConfig:
+  authURL: https://keystone.evil.corp/v3
+  userName: prometheus
+  userDomainName: Default
+  password: topSecret!
+  domainName: Default
+  tenantName: master
+  regionName: regionOne
+  containerName: regionOnePrometheusThanos
+queryDiscovery: true
 GRPCClientCA: itrustyou
 GRPCClientCertificate:
   certificate: ihavebeentrusted

--- a/common/thanos/templates/_thanos_helpers.tpl
+++ b/common/thanos/templates/_thanos_helpers.tpl
@@ -1,8 +1,3 @@
-{{/* Generated objectStorageConfigName */}}
-{{- define "thanos.objectStorageConfigName" -}}
-prometheus-{{- required ".Values.name" .Values.name -}}-thanos-storage-config
-{{- end -}}
-
 {{/* Thanos image. */}}
 {{- define "thanosimage" -}}
 {{- required ".Values.spec.baseImage missing" .Values.spec.baseImage -}}:{{- required ".Chart.appVersion missing" .Chart.AppVersion -}}
@@ -10,38 +5,81 @@ prometheus-{{- required ".Values.name" .Values.name -}}-thanos-storage-config
 
 {{/* Thanos name */}}
 {{- define "thanos.name" -}}
-{{- required ".Values.name" .Values.name -}}
+{{- $name := index . 0 -}}
+{{- $root := index . 1 -}}
+{{- if and (not $root.Values.names) (not $root.Values.global.targets) (not $root.Values.name) -}}
+{{- fail "Cannot create any Thanos resource. Please define a name or at least one list element to names or global.targets" -}}
+{{- end -}}
+{{- if $root.Values.vmware -}}
+{{- $vropshostname := split "." $name -}}
+vmware-{{ $vropshostname._0 | trimPrefix "vrops-" }}
+{{- else -}}
+{{- $name -}}
+{{- end -}}
 {{- end -}}
 
 {{/* Thanos combined name */}}
 {{- define "thanos.fullName" -}}
-thanos-{{- required ".Values.name" .Values.name -}}
+{{- $name := index . 0 -}}
+{{- $root := index . 1 -}}
+{{- if $root.Values.vmware -}}
+{{- $vropshostname := split "." $name -}}
+thanos-vmware-{{ $vropshostname._0 | trimPrefix "vrops-" }}
+{{- else -}}
+thanos-{{- $name -}}
+{{- end -}}
 {{- end -}}
 
-{{/* External URL of this Thanos. Copied from prometheus-server */}}
+{{/* External URL of this Thanos. */}}
 {{- define "thanos.externalURL" -}}
-{{- if and .Values.ingress.hosts .Values.ingress.hostsFQDN -}}
+{{- $name := index . 0 -}}
+{{- $root := index . 1 -}}
+{{- if and $root.Values.ingress.hosts $root.Values.ingress.hostsFQDN -}}
 {{- fail ".Values.ingress.hosts and .Values.ingress.hostsFQDN are mutually exclusive." -}}
 {{- end -}}
-{{- if .Values.ingress.hosts -}}
-{{- $firstHost := first .Values.ingress.hosts -}}
-{{- required ".Values.ingress.hosts must have at least one hostname set" $firstHost -}}.{{- required ".Values.global.region missing" .Values.global.region -}}.{{- required ".Values.global.tld missing" .Values.global.tld -}}
-{{- else -}}
-{{- $firstHost := first .Values.ingress.hostsFQDN -}}
+{{- if $root.Values.ingress.hosts -}}
+{{- $firstHost := first $root.Values.ingress.hosts -}}
+{{- required ".Values.ingress.hosts must have at least one hostname set" $firstHost -}}.{{- required ".Values.global.region missing" $root.Values.global.region -}}.{{- required ".Values.global.domain missing" $root.Values.global.domain -}}
+{{- else if $root.Values.ingress.hostsFQDN -}}
+{{- $firstHost := first $root.Values.ingress.hostsFQDN -}}
 {{- required ".Values.ingress.hostsFQDN must have at least one hostname set" $firstHost -}}
+{{- else -}}
+thanos-{{- $name -}}.{{- required "$root.Values.global.region missing" $root.Values.global.region -}}.{{- required "$root.Values.global.tld missing" $root.Values.global.tld -}}
 {{- end -}}
 {{- end -}}
 
-{{/* gRPC URL of this Thanos. */}}
-{{- define "thanos.grpcURL" -}}
-{{- if and .Values.grpcIngress.hosts .Values.grpcIngress.hostsFQDN -}}
-{{- fail ".Values.grpcIngress.hosts and .Values.grpcIngress.hostsFQDN are mutually exclusive." -}}
+{{/* External gRPC URL of this Thanos. */}}
+{{- define "thanos.externalGrpcURL" -}}
+{{- $name := index . 0 -}}
+{{- $root := index . 1 -}}
+{{- if and $root.Values.ingress.hosts $root.Values.ingress.hostsFQDN -}}
+{{- fail ".Values.ingress.hosts and .Values.ingress.hostsFQDN are mutually exclusive." -}}
 {{- end -}}
-{{- if .Values.grpcIngress.hosts -}}
-{{- $firstHost := first .Values.grpcIngress.hosts -}}
-{{- required ".Values.grpcIngress.hosts must have at least one hostname set" $firstHost -}}-grpc.{{- required ".Values.global.region missing" .Values.global.region -}}.{{- required ".Values.global.tld missing" .Values.global.tld -}}
+thanos-{{- $name -}}-grpc.{{- required "$root.Values.global.region missing" $root.Values.global.region -}}.{{- required "$root.Values.global.tld missing" $root.Values.global.tld -}}
+{{- end -}}
+
+{{- define "fqdnHelper" -}}
+{{- $host := index . 0 -}}
+{{- $root := index . 1 -}}
+{{- if not $root.Values.ingress.hosts -}}
+thanos-{{- $host -}}.{{- required ".Values.global.region missing" $root.Values.global.region -}}.{{- required ".Values.global.tld missing" $root.Values.global.tld -}}
 {{- else -}}
-{{- $firstHost := first .Values.ingress.hostsFQDN -}}
-{{- required ".Values.grpcIngress.hostsFQDN must have at least one hostname set" $firstHost -}}
+{{- $host -}}.{{- required ".Values.global.region missing" $root.Values.global.region -}}.{{- required ".Values.global.tld missing" $root.Values.global.tld -}}
 {{- end -}}
+{{- end -}}
+
+{{- define "grpcFqdnHelper" -}}
+{{- $host := index . 0 -}}
+{{- $root := index . 1 -}}
+{{- if not $root.Values.grpcIngress.hosts -}}
+thanos-{{- $host -}}-grpc.{{- required ".Values.global.region missing" $root.Values.global.region -}}.{{- required ".Values.global.tld missing" $root.Values.global.tld -}}
+{{- else -}}
+{{- $host -}}.{{- required ".Values.global.region missing" $root.Values.global.region -}}.{{- required ".Values.global.tld missing" $root.Values.global.tld -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "thanos.objectStorageConfigName" -}}
+{{- $name := index . 0 -}}
+{{- $root := index . 1 -}}
+prometheus-{{- include "thanos.name" . -}}-thanos-storage-config
 {{- end -}}

--- a/common/thanos/templates/alerts/_thanos-compactor.alerts.tpl
+++ b/common/thanos/templates/alerts/_thanos-compactor.alerts.tpl
@@ -1,3 +1,5 @@
+{{- $name := index . 0 -}}
+{{- $root := index . 1 -}}
 groups:
 - name: thanos-compactor.alerts
   rules:
@@ -6,7 +8,7 @@ groups:
       for: 5m
       labels:
         context: thanos
-        service: {{ default "metrics" .Values.alerts.service }}
+        service: {{ default "metrics" $root.Values.alerts.service }}
         support_group: observability
         severity: info
         playbook: 'docs/support/playbook/prometheus/thanos_compaction.html'
@@ -19,7 +21,7 @@ groups:
       expr: rate(prometheus_tsdb_compactions_failed_total{app="thanos-compactor", prometheus="{{ include "thanos.name" . }}"}[5m]) > 0
       labels:
         context: thanos
-        service: {{ default "metrics" .Values.alerts.service }}
+        service: {{ default "metrics" $root.Values.alerts.service }}
         support_group: observability
         severity: info
         playbook: 'docs/support/playbook/prometheus/thanos_compaction.html'
@@ -32,7 +34,7 @@ groups:
       expr: rate(thanos_objstore_bucket_operation_failures_total{app="thanos-compactor", prometheus="{{ include "thanos.name" . }}"}[5m]) > 0
       labels:
         context: thanos
-        service: {{ default "metrics" .Values.alerts.service }}
+        service: {{ default "metrics" $root.Values.alerts.service }}
         support_group: observability
         severity: info
         playbook: 'docs/support/playbook/prometheus/thanos_compaction.html'
@@ -45,7 +47,7 @@ groups:
       expr: (time() - max(thanos_objstore_bucket_last_successful_upload_time{app="thanos-compactor", prometheus="{{ include "thanos.name" . }}"}) ) /60/60 > 24
       labels:
         context: thanos
-        service: {{ default "metrics" .Values.alerts.service }}
+        service: {{ default "metrics" $root.Values.alerts.service }}
         support_group: observability
         severity: info
         playbook: 'docs/support/playbook/prometheus/thanos_compaction.html'
@@ -60,7 +62,7 @@ groups:
       labels:
         no_alert_on_absence: "true" # because the expression already checks for absence
         context: thanos
-        service: {{ default "metrics" .Values.alerts.service }}
+        service: {{ default "metrics" $root.Values.alerts.service }}
         support_group: observability
         severity: info
         playbook: 'docs/support/playbook/prometheus/thanos_compaction.html'
@@ -74,7 +76,7 @@ groups:
       for: 5m
       labels:
         context: thanos
-        service: {{ default "metrics" .Values.alerts.service }}
+        service: {{ default "metrics" $root.Values.alerts.service }}
         support_group: observability
         severity: warning
         meta: 'Multiple Thanos compactors running for Prometheus `{{`{{ $labels.prometheus }}`}}`.'

--- a/common/thanos/templates/alerts/_thanos-query.alerts.tpl
+++ b/common/thanos/templates/alerts/_thanos-query.alerts.tpl
@@ -1,3 +1,5 @@
+{{- $name := index . 0 -}}
+{{- $root := index . 1 -}}
 groups:
 - name: thanos-query.alerts
   rules:
@@ -6,7 +8,7 @@ groups:
       for: 5m
       labels:
         context: thanos
-        service: {{ default "metrics" .Values.alerts.service }}
+        service: {{ default "metrics" $root.Values.alerts.service }}
         support_group: observability
         severity: info
         meta: 'Thanos query is returning errors for Prometheus `{{`{{ $labels.prometheus }}`}}`'

--- a/common/thanos/templates/alerts/_thanos-store.alerts.tpl
+++ b/common/thanos/templates/alerts/_thanos-store.alerts.tpl
@@ -1,3 +1,5 @@
+{{- $name := index . 0 -}}
+{{- $root := index . 1 -}}
 groups:
 - name: thanos-store.alerts
   rules:
@@ -6,7 +8,7 @@ groups:
       for: 5m
       labels:
         context: thanos
-        service: {{ default "metrics" .Values.alerts.service }}
+        service: {{ default "metrics" $root.Values.alerts.service }}
         support_group: observability
         severity: info
         playbook: 'docs/support/playbook/prometheus/thanos_store.html'
@@ -20,7 +22,7 @@ groups:
       for: 5m
       labels:
         context: thanos
-        service: {{ default "metrics" .Values.alerts.service }}
+        service: {{ default "metrics" $root.Values.alerts.service }}
         support_group: observability
         severity: info
         playbook: 'docs/support/playbook/prometheus/thanos_store.html'

--- a/common/thanos/templates/alerts/thanos-alerts.yaml
+++ b/common/thanos/templates/alerts/thanos-alerts.yaml
@@ -1,18 +1,41 @@
 {{- if .Values.enabled }}
 {{- $root := . }}
-{{- range tuple "compactor" "query" "store" }}
-{{- $path := (printf "%s/alerts/_thanos-%s.alerts.tpl" $root.Template.BasePath . ) }}
+{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 
 metadata:
-  name: {{ include "thanos.fullName" $root }}-{{ printf "-%s.alerts" . }}
+  name: {{ include "thanos.fullName" (list $name $root) }}-thanos-compactor.alerts
   labels:
-    prometheus: {{ default (include "thanos.name" $root) $.Values.alerts.prometheus }}
+    prometheus: {{ include "thanos.name" (list $name $root) }}
 
 spec:
-{{ include $path $root | indent 2 }}
+{{ include (print $.Template.BasePath "/alerts/_thanos-compactor.alerts.tpl") (list $name $root) | indent 2 }}
+
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: {{ include "thanos.fullName" (list $name $root) }}-thanos-query.alerts
+  labels:
+    prometheus: {{ include "thanos.name" (list $name $root) }}
+
+spec:
+{{ include (print $.Template.BasePath "/alerts/_thanos-query.alerts.tpl") (list $name $root) | indent 2 }}
+
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: {{ include "thanos.fullName" (list $name $root) }}-thanos-store.alerts
+  labels:
+    prometheus: {{ include "thanos.name" (list $name $root) }}
+
+spec:
+{{ include (print $.Template.BasePath "/alerts/_thanos-store.alerts.tpl") (list $name $root) | indent 2 }}
 
 {{- end }}
 {{- end }}

--- a/common/thanos/templates/ingress-grpc.yaml
+++ b/common/thanos/templates/ingress-grpc.yaml
@@ -1,38 +1,53 @@
 {{- if .Values.enabled }}
 {{- if .Values.grpcIngress.enabled }}
 {{- $root := . }}
+{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress 
 metadata:
-  name: {{ include "thanos.fullName" . }}-grpc
+  name: {{ include "thanos.fullName" (list $name $root) }}-grpc
   annotations:
     disco: "true"
     kubernetes.io/tls-acme: "true"
-    {{- if .Values.grpcIngress.annotations }}
-{{ toYaml .Values.grpcIngress.annotations | indent 4 }}
+    {{- if $.Values.grpcIngress.annotations }}
+{{ toYaml $.Values.grpcIngress.annotations | indent 4 }}
     {{ end }}
 spec:
   rules:
-    {{- range $host := $root.Values.grpcIngress.hosts }}
-    - host: {{ $host }}-grpc.{{ $root.Values.global.region }}.{{ $root.Values.global.tld }}
+    {{- range $host := coalesce $.Values.grpcIngress.hosts (list $name) }}
+    - host: {{ include "grpcFqdnHelper" (list $host $root) }}
       http:
         paths:
         - path: /
           backend:
             service:
-              name:  {{ include "thanos.fullName" $root }}-query
+              name:  {{ include "thanos.fullName" (list $name $root) }}-query
+              port:
+                name: grpc
+          pathType: ImplementationSpecific
+    {{- end }}
+    {{- range $host := $.Values.grpcIngress.hostsFQDN }}
+    - host: {{ $host }}
+      http:
+        paths:
+        - path: /
+          backend:
+            service:
+              name:  {{ include "thanos.fullName" (list $name $root) }}-query
               port:
                 name: grpc
           pathType: ImplementationSpecific
     {{- end }}
   tls:
-    - secretName: tls-{{ include "thanos.grpcURL" $root | replace "." "-" }}
+    - secretName: tls-{{ include "thanos.externalGrpcURL" (list $name $root) | replace "." "-" }}
       hosts:
-        {{- range $host := $root.Values.grpcIngress.hosts }}
-        - {{ $host }}-grpc.{{ $root.Values.global.region }}.{{ $root.Values.global.tld }}
+        {{- range $host := coalesce $.Values.grpcIngress.hosts (list $name) }}
+        - {{ include "grpcFqdnHelper" (list $host $root) }}
         {{- end }}
-        {{- range $host := $root.Values.grpcIngress.hostsFQDN }}
+        {{- range $host := $.Values.grpcIngress.hostsFQDN }}
         - {{ $host }}
         {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/common/thanos/templates/ingress.yaml
+++ b/common/thanos/templates/ingress.yaml
@@ -1,47 +1,62 @@
 {{- if .Values.enabled }}
 {{- if .Values.ingress.enabled }}
 {{- $root := . }}
+{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "thanos.fullName" . }}
+  name: {{ include "thanos.fullName" (list $name $root) }}
   annotations:
     disco: "true"
     kubernetes.io/tls-acme: "true"
-    {{- if .Values.ingress.authentication.oauth.enabled }}
-    ingress.kubernetes.io/auth-url: {{ required ".Values.ingress.authentication.oauth.authURL missing" .Values.ingress.authentication.oauth.authURL }}
-    {{ if .Values.ingress.authentication.oauth.authSignInURL }}ingress.kubernetes.io/auth-signin: {{ .Values.ingress.authentication.oauth.authSignInURL }} {{ end }}
+    {{- if $.Values.ingress.authentication.oauth.enabled }}
+    ingress.kubernetes.io/auth-url: {{ required "$.Values.ingress.authentication.oauth.authURL missing" $.Values.ingress.authentication.oauth.authURL }}
+    {{ if $.Values.ingress.authentication.oauth.authSignInURL }}ingress.kubernetes.io/auth-signin: {{ $.Values.ingress.authentication.oauth.authSignInURL }} {{ end }}
     {{ end }}
-    {{- if .Values.ingress.authentication.sso.enabled}}
-    ingress.kubernetes.io/auth-tls-secret: {{ required ".Values.ingress.authentication.sso.authTLSSecret missing" .Values.ingress.authentication.sso.authTLSSecret | quote }}
-    ingress.kubernetes.io/auth-tls-verify-depth: {{ required ".Values.ingress.authentication.sso.authTLSVerifyDepth missing" .Values.ingress.authentication.sso.authTLSVerifyDepth | quote }}
-    ingress.kubernetes.io/auth-tls-verify-client: {{ required ".Values.ingress.authentication.sso.authTLSVerifyClient missing" .Values.ingress.authentication.sso.authTLSVerifyClient | quote }}
+    {{- if $.Values.ingress.authentication.sso.enabled}}
+    ingress.kubernetes.io/auth-tls-secret: {{ required "$.Values.ingress.authentication.sso.authTLSSecret missing" $.Values.ingress.authentication.sso.authTLSSecret | quote }}
+    ingress.kubernetes.io/auth-tls-verify-depth: {{ required "$.Values.ingress.authentication.sso.authTLSVerifyDepth missing" $.Values.ingress.authentication.sso.authTLSVerifyDepth | quote }}
+    ingress.kubernetes.io/auth-tls-verify-client: {{ required "$.Values.ingress.authentication.sso.authTLSVerifyClient missing" $.Values.ingress.authentication.sso.authTLSVerifyClient | quote }}
     {{ end }}
-    {{- if .Values.ingress.annotations }}
-{{ toYaml .Values.ingress.annotations | indent 4 }}
+    {{- if $.Values.ingress.annotations }}
+{{ toYaml $.Values.ingress.annotations | indent 4 }}
     {{ end }}
 spec:
   rules:
-    {{- range $host := $root.Values.ingress.hosts }}
-    - host: {{ $host }}.{{ $root.Values.global.region }}.{{ $root.Values.global.tld }}
+    {{- range $host := coalesce $.Values.ingress.hosts (list $name) }}
+    - host: {{ include "fqdnHelper" (list $host $root) }}
       http:
         paths:
         - path: /
           backend:
             service:
-              name:  {{ include "thanos.fullName" $root }}-query
+              name:  {{ include "thanos.fullName" (list $name $root) }}-query
+              port:
+                name: http
+          pathType: ImplementationSpecific
+    {{- end }}
+    {{- range $host := $.Values.ingress.hostsFQDN }}
+    - host: {{ $host }}
+      http:
+        paths:
+        - path: /
+          backend:
+            service:
+              name:  {{ include "thanos.fullName" (list $name $root) }}-query
               port:
                 name: http
           pathType: ImplementationSpecific
     {{- end }}
   tls:
-    - secretName: tls-{{ include "thanos.externalURL" $root | replace "." "-" }}
+    - secretName: tls-{{ include "thanos.externalURL" (list $name $root) | replace "." "-" }}
       hosts:
-        {{- range $host := $root.Values.ingress.hosts }}
-        - {{ $host }}.{{ $root.Values.global.region }}.{{ $root.Values.global.tld }}
+        {{- range $host := coalesce $.Values.ingress.hosts (list $name) }}
+        - {{ include "fqdnHelper" (list $host $root) }}
         {{- end }}
-        {{- range $host := $root.Values.ingress.hostsFQDN }}
+        {{- range $host := $.Values.ingress.hostsFQDN }}
         - {{ $host }}
         {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/common/thanos/templates/thanos-objectstore.yaml
+++ b/common/thanos/templates/thanos-objectstore.yaml
@@ -1,36 +1,40 @@
+{{- $root := . }}
 {{- if .Values.enabled }}
 {{- if .Values.deployWholeThanos }}
+{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+---
 apiVersion: monitoring.banzaicloud.io/v1alpha1
 kind: ObjectStore
 metadata:
-  name: {{ include "thanos.fullName" . }}
+  name: {{ include "thanos.fullName" (list $name $root) }}
 spec:
   config:
     mountFrom:
       secretKeyRef:
-        name: {{ include "thanos.objectStorageConfigName" . }}
+        name: {{ include "thanos.objectStorageConfigName" (list $name $root) }}
         key: thanos.yaml
   compactor: 
-    consistencyDelay: {{ required "thanos.compactor.consistencyDelay" .Values.compactor.consistencyDelay }}
-    retentionResolutionRaw: {{ mul 24 (required "thanos.compactor.retentionResolutionRaw" .Values.compactor.retentionResolutionRaw) }}h
-    retentionResolution5m: {{ mul 24 (required "thanos.compactor.retentionResolution5m" .Values.compactor.retentionResolution5m) }}h
-    retentionResolution1h: {{ mul 365 24 (required "thanos.compactor.retentionResolution1h" .Values.compactor.retentionResolution1h) }}h
+    consistencyDelay: {{ required "thanos.compactor.consistencyDelay" $.Values.compactor.consistencyDelay }}
+    retentionResolutionRaw: {{ mul 24 (required "thanos.compactor.retentionResolutionRaw" $.Values.compactor.retentionResolutionRaw) }}h
+    retentionResolution5m: {{ mul 24 (required "thanos.compactor.retentionResolution5m" $.Values.compactor.retentionResolution5m) }}h
+    retentionResolution1h: {{ mul 365 24 (required "thanos.compactor.retentionResolution1h" $.Values.compactor.retentionResolution1h) }}h
     serviceOverrides:
       metadata:
         labels:
-          prometheus: {{ default (include "thanos.name" .) .Values.alerts.prometheus }}
+          prometheus: {{ default (include "thanos.name" (list $name $root)) $.Values.alerts.prometheus }}
     deploymentOverrides:
       spec:
         template:
           spec:
             containers:
-            - image: {{ include "thanosimage" . }}
+            - image: {{ include "thanosimage" $root }}
               name: compactor
-              {{ if len .Values.compactor.customArgs -}}
+              {{ if len $.Values.compactor.customArgs -}}
               args:
-                {{- range $arg := .Values.compactor.customArgs }}
+                {{- range $arg := $.Values.compactor.customArgs }}
                 - {{ $arg }}
                 {{- end }}
               {{- end }}
+{{ end }}
 {{ end }}
 {{ end }}

--- a/common/thanos/templates/thanos-storeendpoint.yaml
+++ b/common/thanos/templates/thanos-storeendpoint.yaml
@@ -1,15 +1,19 @@
+{{- $root := . }}
 {{- if .Values.enabled }}
 {{- if .Values.deployWholeThanos }}
+{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+---
 apiVersion: monitoring.banzaicloud.io/v1alpha1
 kind: StoreEndpoint
 metadata:
-  name: {{ include "thanos.fullName" . }}
+  name: {{ include "thanos.fullName" (list $name $root) }}
 spec:
-  thanos: {{ include "thanos.fullName" . }}
+  thanos: {{ include "thanos.fullName" (list $name $root) }}
   config:
     mountFrom:
       secretKeyRef:
-        name: {{ include "thanos.objectStorageConfigName" . }}
+        name: {{ include "thanos.objectStorageConfigName" (list $name $root) }}
         key: thanos.yaml
+{{ end }}
 {{ end }}
 {{ end }}

--- a/common/thanos/templates/thanos.yaml
+++ b/common/thanos/templates/thanos.yaml
@@ -1,36 +1,38 @@
 {{- $root := . }}
 {{- if .Values.enabled }}
+{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+---
 apiVersion: monitoring.banzaicloud.io/v1alpha1
 kind: Thanos
 metadata:
-  name: {{ include "thanos.fullName" . }}
+  name: {{ include "thanos.fullName" (list $name $root) }}
 spec:
-  queryDiscovery: {{ .Values.queryDiscovery }}
-  clusterDomain: kubernetes.{{ required ".Values.global.region missing" .Values.global.region }}.{{ required ".Values.global.tld missing" .Values.global.tld }}
+  queryDiscovery: {{ $.Values.queryDiscovery }}
+  clusterDomain: kubernetes.{{ required "$.Values.global.region missing" $.Values.global.region }}.{{ required "$.Values.global.tld missing" $.Values.global.tld }}
   query:
-    {{- if (.Values.useQueryRegions) }}
+    {{- if ($.Values.useQueryRegions) }}
     GRPCClientCA: thanos-grpcclient-ca
     GRPCClientCertificate: thanos-grpcclient-crt
     {{- end }}
-    logLevel: {{ .Values.logLevel }}
+    logLevel: {{ $.Values.logLevel }}
     queryAutoDownsampling: true
     queryReplicaLabel:
       - prometheus_replica
-    {{- if .Values.deployWholeThanos }}
-    webRoutePrefix: {{ required ".Values.query.webRouteprefix missing" .Values.query.webRouteprefix }}
-    webExternalPrefix: {{ required ".Values.query.webRouteprefix missing" .Values.query.webRouteprefix }}
+    {{- if $.Values.deployWholeThanos }}
+    webRoutePrefix: {{ required "$.Values.query.webRouteprefix missing" $.Values.query.webRouteprefix }}
+    webExternalPrefix: {{ required "$.Values.query.webRouteprefix missing" $.Values.query.webRouteprefix }}
     {{- end }}
-    {{- if or .Values.deployWholeThanos ((.Values.query).stores) (.Values.useQueryRegions) }}
+    {{- if or $.Values.deployWholeThanos (($.Values.query).stores) ($.Values.useQueryRegions) }}
     stores:
     {{- end }}
-    {{- if ((.Values.query).stores) }}
-      {{- range $store := .Values.query.stores }}
+    {{- if (($.Values.query).stores) }}
+      {{- range $store := $.Values.query.stores }}
       - {{ $store }}
       {{- end }}
-    {{- else if .Values.deployWholeThanos }}
-      - prometheus-{{ required ".Values.name missing" .Values.name }}:10901
-    {{- else if (.Values.useQueryRegions) }}
-      {{- range $region := .Values.queryRegions }}
+    {{- else if $.Values.deployWholeThanos }}
+      - prometheus-{{ include "thanos.name" (list $name $root) }}:10901
+    {{- else if ($.Values.useQueryRegions) }}
+      {{- range $region := $.Values.queryRegions }}
         {{- range $cluster := $root.Values.clusterTypes }}
         - thanos-{{ $cluster }}-grpc.{{ $region }}.{{ $root.Values.global.tld }}:443
         {{- end }}
@@ -39,30 +41,31 @@ spec:
     serviceOverrides:
       metadata:
         labels:
-          prometheus: {{ default (include "thanos.name" .) .Values.alerts.prometheus }}
+          prometheus: {{ default (include "thanos.name" (list $name $root)) $.Values.alerts.prometheus }}
     deploymentOverrides:
       spec:
         template:
           spec:
             containers:
-            - image: {{ include "thanosimage" . }}
+            - image: {{ include "thanosimage" $root }}
               name: query
-  {{- if .Values.deployWholeThanos }}
+  {{- if $.Values.deployWholeThanos }}
   storeGateway:
-    logLevel: {{ .Values.logLevel }}
-    indexCacheSize: {{ required ".Values.store.indexCacheSize missing" .Values.store.indexCacheSize }}
-    chunkPoolSize: {{ required ".Values.store.chunkPoolSize missing" .Values.store.chunkPoolSize }}
-    storeGRPCSeriesMaxConcurrency: {{ required ".Values.store.seriesMaxConcurrency missing" .Values.store.seriesMaxConcurrency }}
+    logLevel: {{ $.Values.logLevel }}
+    indexCacheSize: {{ required ".Values.store.indexCacheSize missing" $.Values.store.indexCacheSize }}
+    chunkPoolSize: {{ required ".Values.store.chunkPoolSize missing" $.Values.store.chunkPoolSize }}
+    storeGRPCSeriesMaxConcurrency: {{ required ".Values.store.seriesMaxConcurrency missing" $.Values.store.seriesMaxConcurrency }}
     serviceOverride:
       metadata:
         labels:
-          prometheus: {{ default (include "thanos.name" .) .Values.alerts.prometheus }}
+          prometheus: {{ default (include "thanos.name" (list $name $root)) $.Values.alerts.prometheus }}
     deploymentOverrides:
       spec:
         template:
           spec:
             containers:
-            - image: {{ include "thanosimage" . }}
+            - image: {{ include "thanosimage" $root }}
               name: store
   {{- end }}
+{{- end }}
 {{- end }}

--- a/common/thanos/values.yaml
+++ b/common/thanos/values.yaml
@@ -131,7 +131,7 @@ query:
 ingress:
   enabled: false
 
-  # List of hostnames for this Thanos server. FQDN will be generated using the pattern  <host>.<region>.<domain> .
+  # List of hostnames for this Thanos Query. If empty, the FQDN will be generated using the pattern  thanos-<name>.<region>.<domain> otherwise <host>.<region>.<domain>.
   # The first host is used to generate the external URL for the Thanos. Remaining hosts will be used as SANs.
   # If the ingress is enabled, it's also used for the ingress host.
   hosts: []
@@ -169,8 +169,8 @@ ingress:
 grpcIngress:
   enabled: false
 
-  # List of hostnames for this Thanos Query. FQDN will be generated using the pattern  <host>.<region>.<domain> .
-  # The first host is used to generate the external URL for the Prometheus. Remaining hosts will be used as SANs.
+  # List of hostnames for this Thanos Query. If empty, the FQDN will be generated using the pattern  thanos-<name>-grpc.<region>.<domain> otherwise <host>.<region>.<domain>.
+  # The first host is used to generate the external URL for the Thanos. Remaining hosts will be used as SANs.
   # If the ingress is enabled, it's also used for the ingress host.
   hosts: []
 
@@ -201,6 +201,9 @@ alerts:
 
   # service name routing the alerts, defaults to `metrics`
   service:
+
+# If true, a custom Prometheus naming will take place. Only needed for vmware-monitoring.
+vmware: false
 
 traefik:
   # defaults to false. Should only be enabled if traefik is used over default ingress-nginx. Please set grpcIngress.enabled to false in this case.


### PR DESCRIPTION
Enabling the common chart to deploy multiple Thanos along Prometheus. This can be done either via the list `names: []` or via a list of targets to create Thanos `global.targets: []`.