### PR TITLE
[elastic-query-exporters] adds owner info

### DIFF
--- a/prometheus-exporters/elastiflow-query-exporter/Chart.lock
+++ b/prometheus-exporters/elastiflow-query-exporter/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: owner-info
+  repository: https://charts.eu-de-2.cloud.sap
+  version: 0.2.0
+digest: sha256:6c7a0e8b21abdaecf3124234d79457638aff93c3f51c9cedd56500d24eb652e0
+generated: "2022-11-08T18:17:59.61578+01:00"

--- a/prometheus-exporters/elastiflow-query-exporter/Chart.yaml
+++ b/prometheus-exporters/elastiflow-query-exporter/Chart.yaml
@@ -4,3 +4,7 @@ version: 1.0.0
 description: Elasticsearch prometheus query exporter for Elastiflow
 maintainers:
   - name: Ivo Gosemann
+dependencies:
+  - name: owner-info
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 0.2.0

--- a/prometheus-exporters/elastiflow-query-exporter/values.yaml
+++ b/prometheus-exporters/elastiflow-query-exporter/values.yaml
@@ -1,6 +1,13 @@
+owner-info:
+  support-group: observability
+  maintainers:
+    - "Ivo Gosemann"
+    - "Nathan Oyler"
+  helm-chart-url: "https://github.com/sapcc/helm-charts/tree/master/prometheus-exporters/elastiflow-query-exporter"
+
 enabled: false
-version: '20220317091500'
+version: "20220317091500"
 listen_port: 9206
-log_level: 'ERROR'
+log_level: "ERROR"
 alerts:
   prometheus: infra-frontend

--- a/prometheus-exporters/elk-query-exporter/Chart.lock
+++ b/prometheus-exporters/elk-query-exporter/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: owner-info
+  repository: https://charts.eu-de-2.cloud.sap
+  version: 0.2.0
+digest: sha256:6c7a0e8b21abdaecf3124234d79457638aff93c3f51c9cedd56500d24eb652e0
+generated: "2022-11-08T18:09:28.887346+01:00"

--- a/prometheus-exporters/elk-query-exporter/Chart.yaml
+++ b/prometheus-exporters/elk-query-exporter/Chart.yaml
@@ -4,3 +4,7 @@ version: 1.0.0
 description: Elasticsearch prometheus query exporter for ELK
 maintainers:
   - name: Olaf Heydorn
+dependencies:
+  - name: owner-info
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 0.2.0

--- a/prometheus-exporters/elk-query-exporter/values.yaml
+++ b/prometheus-exporters/elk-query-exporter/values.yaml
@@ -1,10 +1,16 @@
+owner-info:
+  support-group: observability
+  maintainers:
+    - "Olaf Heydorn"
+  helm-chart-url: "https://github.com/sapcc/helm-charts/tree/master/prometheus-exporters/elk-query-exporter"
+
 enabled: false
-version: '20220317091500'
+version: "20220317091500"
 listen_port: 9206
 hostname: es-client.elk
 protocol: http
 port: 9200
-log_level: 'ERROR'
+log_level: "ERROR"
 alerts:
   enabled: false
   prometheus: infra-frontend

--- a/prometheus-exporters/octobus-query-exporter/Chart.lock
+++ b/prometheus-exporters/octobus-query-exporter/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: owner-info
+  repository: https://charts.eu-de-2.cloud.sap
+  version: 0.2.0
+digest: sha256:6c7a0e8b21abdaecf3124234d79457638aff93c3f51c9cedd56500d24eb652e0
+generated: "2022-11-08T18:11:07.962072+01:00"


### PR DESCRIPTION
- Adding owner info to charts elk-query-exporter, elastiflow-query-exporter
-  creates Chart.lock for octobus-query exporter.

FYI @Kuckkuck @notque 