### PR TITLE
[MariaDB] - Security Patches - upgrade to 10.5.17

### DIFF
--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.7.4
+version: 0.7.5

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -4,7 +4,7 @@
 # name: value
 
 name: null
-image: library/mariadb:10.5.12
+image: library/mariadb:10.5.17
 imagePullPolicy: IfNotPresent
 port_public: 3306
 max_connections: 1024
@@ -28,7 +28,6 @@ db_performance_schema: # Enabling performance schema only (without enabling inst
 db_performance_schema_instrument: # Enabling performance schema instruments.
   # Please enable the db_performance_schema in order to enable the db_performance_schema_instrument.
   enabled: false
-  # default : false
 
 root_password: null
 initdb_configmap: null


### PR DESCRIPTION
The version contains the following 

Fixes for the following [security vulnerabilities](https://mariadb.com/kb/en/cve/):
[CVE-2022-32082](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-32082)
[CVE-2022-32089](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-32089)
[CVE-2022-32081](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-32081)
[CVE-2018-25032](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-25032)
[CVE-2022-32091](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-32091)
[CVE-2022-32084](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-32084)

Full Release Notes can be found: https://mariadb.com/kb/en/mariadb-10517-release-notes/