### PR TITLE
[nova] Switch to loci images in Xena

### DIFF
--- a/openstack/nova/templates/_console_deployment.yaml.tpl
+++ b/openstack/nova/templates/_console_deployment.yaml.tpl
@@ -48,7 +48,7 @@ spec:
       {{- include "utils.proxysql.volumes" . | indent 6 }}
       containers:
       - name: nova-console-{{ $name }}
-        image: {{ required ".Values.global.registry is missing" .Values.global.registry}}/ubuntu-source-nova-{{ $name }}proxy:{{index .Values (print "imageVersionNova" (title $name) "proxy") | default .Values.imageVersionNova | default .Values.imageVersion | required "Please set nova.imageVersion or similar" }}
+        image: {{ tuple . (print (title $name) "proxy") | include "container_image_nova" }}
         imagePullPolicy: IfNotPresent
         command:
         - dumb-init

--- a/openstack/nova/templates/_helpers.tpl
+++ b/openstack/nova/templates/_helpers.tpl
@@ -23,7 +23,7 @@ rabbit://{{ default "" .Values.global.user_suffix | print .Values.rabbitmq_cell2
   {{- $name := index . 1 -}}
   {{- with index . 0 -}}
     {{- $version_name := printf "imageVersionNova%s" ($name | lower | replace "-" " " | title | nospace) -}}
-    {{- $image_name := ( .Values.loci.nova | ternary .Values.imageNameNova (printf "ubuntu-source-nova-%s" ($name | lower)) ) -}}
+    {{- $image_name := ( not (.Values.imageVersion | hasPrefix "rocky") | ternary .Values.imageNameNova (printf "ubuntu-source-nova-%s" ($name | lower)) ) -}}
 
     {{ required ".Values.global.registry is missing" .Values.global.registry}}/{{$image_name}}:{{index .Values $version_name | default .Values.imageVersionNova | default .Values.imageVersion | required "Please set nova.imageVersionNova or similar" }}
 

--- a/openstack/nova/templates/api-deployment.yaml
+++ b/openstack/nova/templates/api-deployment.yaml
@@ -44,7 +44,7 @@ spec:
       hostname: nova-api
       containers:
         - name: nova-api
-          image: {{ required ".Values.global.registry is missing" .Values.global.registry}}/ubuntu-source-nova-api:{{.Values.imageVersionNovaApi | default .Values.imageVersionNova | default .Values.imageVersion | required "Please set nova.imageVersion or similar"}}
+          image: {{ tuple . "api" | include "container_image_nova" }}
           imagePullPolicy: IfNotPresent
           command:
             - dumb-init

--- a/openstack/nova/templates/api-metadata-deployment.yaml
+++ b/openstack/nova/templates/api-metadata-deployment.yaml
@@ -40,7 +40,7 @@ spec:
       hostname: nova-api-metadata
       containers:
         - name: nova-api-metadata
-          image: {{ required ".Values.global.registry is missing" .Values.global.registry}}/ubuntu-source-nova-api:{{.Values.imageVersionNovaApi | default .Values.imageVersionNova | default .Values.imageVersion | required "Please set nova.imageVersion or similar"}}
+          image: {{ tuple . "api" | include "container_image_nova" }}
           imagePullPolicy: IfNotPresent
           command:
             - dumb-init

--- a/openstack/nova/templates/bigvm-deployment.yaml
+++ b/openstack/nova/templates/bigvm-deployment.yaml
@@ -41,7 +41,7 @@ spec:
       hostname: nova-bigvm
       containers:
         - name: nova-bigvm
-          image: {{ required ".Values.global.registry is missing" .Values.global.registry}}/ubuntu-source-nova-scheduler:{{.Values.imageVersionNova | default .Values.imageVersion | required "Please set nova.imageVersion or similar" }}
+          image: {{ tuple . "scheduler" | include "container_image_nova" }}
           imagePullPolicy: IfNotPresent
           command:
             - dumb-init

--- a/openstack/nova/templates/cell2-conductor-deployment.yaml
+++ b/openstack/nova/templates/cell2-conductor-deployment.yaml
@@ -41,7 +41,7 @@ spec:
       hostname: nova-conductor
       initContainers:
         - name: dependencies
-          image: {{ required ".Values.global.registry is missing" .Values.global.registry}}/ubuntu-source-nova-conductor:{{.Values.imageVersionNovaConductor | default .Values.imageVersionNova | default .Values.imageVersion | required "Please set nova.imageVersion or similar"}}
+          image: {{ tuple . "conductor" | include "container_image_nova" }}
           imagePullPolicy: IfNotPresent
           command:
             - kubernetes-entrypoint
@@ -54,7 +54,7 @@ spec:
               value: "{{ .Release.Name }}-{{ .Values.cell2.name }}-rabbitmq,{{ .Release.Name }}-{{ .Values.cell2.name }}-mariadb"      
       containers:
         - name: nova-conductor
-          image: {{ required ".Values.global.registry is missing" .Values.global.registry}}/ubuntu-source-nova-conductor:{{.Values.imageVersionNovaConductor | default .Values.imageVersionNova | default .Values.imageVersion | required "Please set nova.imageVersion or similar"}}
+          image: {{ tuple . "conductor" | include "container_image_nova" }}
           imagePullPolicy: IfNotPresent
           command:
             - dumb-init

--- a/openstack/nova/templates/conductor-deployment.yaml
+++ b/openstack/nova/templates/conductor-deployment.yaml
@@ -40,7 +40,7 @@ spec:
       hostname: nova-conductor
       initContainers:
         - name: dependencies
-          image: {{ required ".Values.global.registry is missing" .Values.global.registry}}/ubuntu-source-nova-conductor:{{.Values.imageVersionNovaConductor | default .Values.imageVersionNova | default .Values.imageVersion | required "Please set nova.imageVersion or similar"}}
+          image: {{ tuple . "conductor" | include "container_image_nova" }}
           imagePullPolicy: IfNotPresent
           command:
             - kubernetes-entrypoint
@@ -53,7 +53,7 @@ spec:
               value: "nova-api,{{ .Release.Name }}-rabbitmq"
       containers:
         - name: nova-conductor
-          image: {{ required ".Values.global.registry is missing" .Values.global.registry}}/ubuntu-source-nova-conductor:{{.Values.imageVersionNovaConductor | default .Values.imageVersionNova | default .Values.imageVersion | required "Please set nova.imageVersion or similar"}}
+          image: {{ tuple . "conductor" | include "container_image_nova" }}
           imagePullPolicy: IfNotPresent
           command:
             - dumb-init

--- a/openstack/nova/templates/db-migrate-job.yaml
+++ b/openstack/nova/templates/db-migrate-job.yaml
@@ -18,7 +18,7 @@ spec:
       {{- include "utils.proxysql.job_pod_settings" . | indent 6 }}
       containers:
       - name: nova-migration
-        image: {{ required ".Values.global.registry is missing" .Values.global.registry}}/ubuntu-source-nova-api:{{.Values.imageVersionNovaApi | default .Values.imageVersionNova | default .Values.imageVersion | required "Please set nova.imageVersion or similar"}}
+        image: {{ tuple . "api" | include "container_image_nova" }}
         imagePullPolicy: IfNotPresent
         command:
         - kubernetes-entrypoint

--- a/openstack/nova/templates/db-online-migrate-job.yaml
+++ b/openstack/nova/templates/db-online-migrate-job.yaml
@@ -18,7 +18,7 @@ spec:
       {{- include "utils.proxysql.job_pod_settings" . | indent 6 }}
       containers:
       - name: nova-migrate
-        image: {{ required ".Values.global.registry is missing" .Values.global.registry}}/ubuntu-source-nova-api:{{.Values.imageVersionNovaApi | default .Values.imageVersionNova | default .Values.imageVersion | required "Please set nova.imageVersion or similar"}}
+        image: {{ tuple . "api" | include "container_image_nova" }}
         imagePullPolicy: IfNotPresent
         command:
         - kubernetes-entrypoint

--- a/openstack/nova/templates/hypervisors/_ironic-deployment.yaml.tpl
+++ b/openstack/nova/templates/hypervisors/_ironic-deployment.yaml.tpl
@@ -39,7 +39,7 @@ spec:
       terminationGracePeriodSeconds: {{ $hypervisor.default.graceful_shutdown_timeout | default .Values.defaults.default.graceful_shutdown_timeout | add 5 }}
       containers:
         - name: nova-compute
-          image: {{ required ".Values.global.registry is missing" .Values.global.registry}}/ubuntu-source-nova-compute:{{.Values.imageVersionNovaCompute | default .Values.imageVersionNova | default .Values.imageVersion | required "Please set nova.imageVersion or similar" }}
+          image: {{ tuple . "compute" | include "container_image_nova" }}
           imagePullPolicy: IfNotPresent
           command:
             - dumb-init

--- a/openstack/nova/templates/hypervisors/_kvm-deployment.yaml.tpl
+++ b/openstack/nova/templates/hypervisors/_kvm-deployment.yaml.tpl
@@ -49,7 +49,7 @@ spec:
               name: instances
       containers:
         - name: nova-compute
-          image: {{ required ".Values.global.registry is missing" .Values.global.registry}}/ubuntu-source-nova-compute:{{ .Values.imageVersionNovaCompute | default .Values.imageVersion | required "Please set .imageVersion or similar" }}
+          image: {{ tuple . "compute" | include "container_image_nova" }}
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -106,7 +106,7 @@ spec:
               subPath: rootwrap.conf
               readOnly: true
         - name: nova-libvirt
-          image: {{ required ".Values.global.registry is missing" .Values.global.registry}}/ubuntu-source-nova-libvirt:{{.Values.imageVersionNovaLibvirt | default .Values.imageVersionNova | default .Values.imageVersion | required "Please set nova.imageVersion or similar" }}
+          image: {{ tuple . "libvirt" | include "container_image_nova" }}
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -157,7 +157,7 @@ spec:
             - mountPath: /container.init
               name: nova-container-init
         - name: nova-virtlog
-          image: {{ required ".Values.global.registry is missing" .Values.global.registry}}/ubuntu-source-nova-libvirt:{{.Values.imageVersionNovaLibvirt | default .Values.imageVersion | required "Please set nova.imageVersion or similar"}}
+          image: {{ tuple . "libvirt" | include "container_image_nova" }}
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true

--- a/openstack/nova/templates/hypervisors/hypervisors-vmware-deployment-vct.yaml
+++ b/openstack/nova/templates/hypervisors/hypervisors-vmware-deployment-vct.yaml
@@ -46,7 +46,7 @@ template: |
 {{- include "kubernetes_maintenance_affinity" . | indent 4 }}
         containers:
         - name: nova-compute
-          image: {{ required ".Values.global.registry is missing" .Values.global.registry}}/ubuntu-source-nova-compute:{{ .Values.imageVersionNovaCompute | default .Values.imageVersionNova | default .Values.imageVersion | required "Please set .imageVersion or similar" }}
+          image: {{ tuple . "compute" | include "container_image_nova" }}
           imagePullPolicy: IfNotPresent
           terminationGracePeriodSeconds: 900
           command:

--- a/openstack/nova/templates/scheduler-deployment.yaml
+++ b/openstack/nova/templates/scheduler-deployment.yaml
@@ -41,7 +41,7 @@ spec:
       hostname: nova-scheduler
       containers:
         - name: nova-scheduler
-          image: {{ required ".Values.global.registry is missing" .Values.global.registry}}/ubuntu-source-nova-scheduler:{{.Values.imageVersionNovaScheduler | default .Values.imageVersionNova | default .Values.imageVersion | required "Please set nova.imageVersion or similar" }}
+          image: {{ tuple . "scheduler" | include "container_image_nova" }}
           imagePullPolicy: IfNotPresent
           command:
             - dumb-init


### PR DESCRIPTION
Once we're not on Rocky anymore, we will use the loci images instead of the ones built by kolla. To facilitate that change, we use the container_image_nova helper introduced a long time ago everywhere, but change it to check the image-version.