### PR TITLE
[ironic]sets regression tests alerts to level info

### DIFF
--- a/openstack/ironic/alerts/openstack-ironic.alerts
+++ b/openstack/ironic/alerts/openstack-ironic.alerts
@@ -22,7 +22,7 @@ groups:
     expr: blackbox_regression_status_gauge{service=~"ironic"} == 1
     for: 5m
     labels:
-      severity: warning
+      severity: info
       support_group: compute-storage-api
       service: ironic
       context: test
@@ -40,7 +40,7 @@ groups:
     expr: blackbox_regression_status_gauge{service=~"ironic"} == 0.5
     for: 5m
     labels:
-      severity: warning
+      severity: info
       support_group: compute-storage-api
       service: ironic
       context: test


### PR DESCRIPTION
the current state of blackbox test are very unstable. set those alerts to info until the new developed blackbox test is up and running to avoid constant flapping of the alerts.