### PR TITLE
Make l3 gateway handling configurable for aci/cc-fabric

### DIFF
--- a/openstack/neutron/templates/configmap-etc-cc-fabric.yaml
+++ b/openstack/neutron/templates/configmap-etc-cc-fabric.yaml
@@ -11,8 +11,7 @@ metadata:
 
 data:
   ml2_conf_cc-fabric.ini: |
-    [ml2_cc_fabric]
-    driver_config_path = /etc/neutron/plugins/ml2/cc-fabric-driver-config.yaml
+{{ include (print .Template.BasePath "/etc/_ml2-conf-cc-fabric.ini.tpl") . | indent 4 }}
   cc-fabric-driver-config.yaml: |
 {{ toYaml (required "cc_fabric.driver_config cannot be empty" .Values.cc_fabric.driver_config) | indent 4 }}
 {{- end }}

--- a/openstack/neutron/templates/etc/_ml2-conf-aci.ini.tpl
+++ b/openstack/neutron/templates/etc/_ml2-conf-aci.ini.tpl
@@ -35,6 +35,9 @@ baremetal_reserved_vlan_ids = {{ .Values.aci.baremetal_reserved_vlan_ids }}
 {{- if .Values.aci.az_checks_enabled }}
 az_checks_enabled = {{ .Values.aci.az_checks_enabled }}
 {{- end }}
+{{- if .Values.aci.handle_all_l3_gateways }}
+handle_all_l3_gateways = {{ .Values.aci.handle_all_l3_gateways }}
+{{- end }}
 
 {{- if .Values.aci.pc_policy_groups }}
 {{ range $i, $pc_policy_group := .Values.aci.pc_policy_groups }}

--- a/openstack/neutron/templates/etc/_ml2-conf-cc-fabric.ini.tpl
+++ b/openstack/neutron/templates/etc/_ml2-conf-cc-fabric.ini.tpl
@@ -1,0 +1,5 @@
+[ml2_cc_fabric]
+driver_config_path = /etc/neutron/plugins/ml2/cc-fabric-driver-config.yaml
+{{- if .Values.cc_fabric.handle_all_l3_gateways }}
+handle_all_l3_gateways = {{ .Values.cc_fabric.handle_all_l3_gateways }}
+{{- end }}


### PR DESCRIPTION
Both drivers will have a configuration option to let them handle l3 gateways by default.