### PR TITLE
[nova] use oslo.cache MemcacheClientPool for keystone_auth tokens

### DIFF
--- a/openstack/nova/templates/etc/_nova.conf.tpl
+++ b/openstack/nova/templates/etc/_nova.conf.tpl
@@ -154,6 +154,7 @@ token_cache_time = 600
 include_service_catalog = true
 service_type = compute
 service_token_roles_required = True
+memcache_use_advanced_pool = True
 
 #[upgrade_levels]
 #compute = auto


### PR DESCRIPTION
Nova has a high amount of open memcached connections in prod. This might be related to keystonemiddleware not using oslo.cache but an old in-house CacheClient implementation.

There is a good explanation of this issue when upstream enabled oslo.cache in Zed by default [1].

Neutron has already enabled this in prod a long time ago [2].

[1] https://github.com/sapcc/keystonemiddleware/commit/788d3c4969e3446778496f3a9055f654602ae2c1
[2] https://github.com/sapcc/helm-charts/commit/0a0f884ebeb6f9e2e9d944bac89d1cbc3561f2de