### PR TITLE
fix aggregate offline alerts

### DIFF
--- a/prometheus-exporters/netapp-exporter/charts/netapp-cap-exporter/alerts/netapp-capacity.alerts
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-cap-exporter/alerts/netapp-capacity.alerts
@@ -85,7 +85,8 @@ groups:
           summary: 'Nearly Full Capacity Usage on {{$labels.filer}}'
 
       - alert: NetAppFilerAggregateIsOffline
-        expr: netapp_aggregate_state_is_online == 0
+        expr: netapp_aggregate_state_is_online == 0 
+          OR (count (netapp_aggregate_state_is_online offset 24h) by (filer, aggregate) unless count(netapp_aggregate_state_is_online) by (filer, aggregate))
         for: 5m
         labels:
           severity: warning


### PR DESCRIPTION
When aggregate not reachable, the alert should also be fired.