### PR TITLE
[nova] Update policy for system-scoped endpoints

### DIFF
--- a/openstack/nova/templates/etc/_nova-policy.yaml.tpl
+++ b/openstack/nova/templates/etc/_nova-policy.yaml.tpl
@@ -2,10 +2,10 @@
 #context_is_admin: role:admin
 context_is_admin: role:cloud_compute_admin
 
-owner: project_id:%(project_id)s
-member: role:member and rule:owner
-viewer: role:compute_viewer and rule:owner
-admin: (role:compute_admin or role:compute_admin_wsg) and rule:owner
+owner_or_no_project: project_id:%(project_id)s or ccloud_no_project_id_in_target:True
+member: role:member and rule:owner_or_no_project
+viewer: role:compute_viewer and rule:owner_or_no_project
+admin: (role:compute_admin or role:compute_admin_wsg) and rule:owner_or_no_project
 context_is_compute_admin: rule:context_is_admin or rule:admin
 context_is_editor: rule:context_is_compute_admin or rule:member
 context_is_viewer: rule:context_is_editor or rule:viewer


### PR DESCRIPTION
System-scoped endpoints got their "target" dict set to an empty dict which made our previous way to write the policy break. Instead of having only "rule:owner", we now also allow "rule:projectless" for view, member and admin rules. This makes sure that these roles are also allowed to use non-project endpoints e.g. listing availability zones where the target is empty.

Previously, those endpoints did not set an explicit target and thus got
the default: the token's project_id.