### PR TITLE
Remove not needed alerts

### DIFF
--- a/prometheus-rules/prometheus-vmware-rules/alerts/host.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/host.alerts
@@ -76,20 +76,6 @@ groups:
       description: "Failover Host {{ $labels.hostsystem }} has Virtual Machines on it. Free up the host. ({{ $labels.vcenter }}, {{ $labels.vccluster }})"
       summary: "Failover Host {{ $labels.hostsystem }} has Virtual Machines on it. ({{ $labels.vcenter }}, {{ $labels.vccluster }})"
 
-  - alert: HostDiskSpaceUsageWarning
-    expr: vrops_hostsystem_diskspace_usage_gigabytes / vrops_hostsystem_diskspace_capacity_gigabytes > 0.7
-    for: 30m
-    labels:
-      severity: info
-      tier: vmware
-      service: compute
-      support_group: compute
-      context: "{{ $labels.hostsystem }} disk space"
-      meta: "Disk space usage of host {{ $labels.hostsystem }} is above 70%. ({{ $labels.vcenter }}, {{ $labels.vccluster }})"
-    annotations:
-      description: "Disk space usage of host {{ $labels.hostsystem }} is above 70%. ({{ $labels.vcenter }}, {{ $labels.vccluster }})"
-      summary: "Disk space usage of host {{ $labels.hostsystem }} is above 70%. ({{ $labels.vcenter }}, {{ $labels.vccluster }})"
-
   - alert: HostDiskSpaceUsageCritical
     expr: vrops_hostsystem_diskspace_usage_gigabytes / vrops_hostsystem_diskspace_capacity_gigabytes > 0.9
     for: 15m
@@ -299,22 +285,6 @@ groups:
     annotations:
       description: "IPMI System Event Log for `{{ $labels.hostsystem }}` is becoming full. ({{ $labels.vcenter }}) {{ $labels.recommendation_1 }}"
       summary: "IPMI System Event Log for `{{ $labels.hostsystem }}` is becoming full. ({{ $labels.vcenter }}) {{ $labels.recommendation_1 }}"
-
-  - alert: HostRootFilesystemUnhealthy
-    expr: |
-      vrops_hostsystem_alert_info{alert_name="Root filesystem not present through CMMDS or is not responsive."}
-      and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!~"inMaintenance"}
-    labels:
-      severity: info
-      tier: vmware
-      service: compute
-      support_group: compute
-      context: "{{ $labels.hostsystem }} root fs"
-      meta: "`{{ $labels.hostsystem }}` root filesystem not present through CMMDS or is not responsive. ({{ $labels.vcenter }})"
-      no_alert_on_absence: "true"
-    annotations:
-      description: "`{{ $labels.hostsystem }}` root filesystem not present through CMMDS or is not responsive. ({{ $labels.vcenter }})"
-      summary: "`{{ $labels.hostsystem }}` root filesystem not present through CMMDS or is not responsive. ({{ $labels.vcenter }})"
 
   - alert: HostStoragePathsDown
     expr: vrops_hostsystem_storage_number_of_path - vrops_hostsystem_storage_number_of_active_path > 4

--- a/prometheus-rules/prometheus-vmware-rules/alerts/vccluster.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/vccluster.alerts
@@ -1,22 +1,6 @@
 groups:
 - name: vccluster.alerts
   rules:
-  - alert: VCenterRedundancyLostFailoverHostMissing
-    expr: |
-      count by (vcenter, vccluster) (vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{vccluster=~"production.*"} == 1) == 0
-    for: 30m
-    labels:
-      severity: critical
-      tier: vmware
-      service: compute
-      support_group: compute
-      context: "vc cluster config"
-      meta: "Missing failover host for in {{ $labels.vcenter }} cluster {{ $labels.vccluster }}."
-      playbook: docs/devops/alert/vcenter/#restore-ha-redundancy-in-vcenter
-    annotations:
-      description: "Missing failover host for in {{ $labels.vcenter }} cluster {{ $labels.vccluster }}."
-      summary: "Missing failover host for in {{ $labels.vcenter }} cluster {{ $labels.vccluster }}."
-
   - alert: VCenterRedundancyLostHAPolicyFaulty
     expr: |
       sum by (vccluster, vcenter) (vrops_cluster_configuration_dasconfig_enabled{vccluster=~"production.*"}) unless

--- a/prometheus-rules/prometheus-vmware-rules/alerts/vcenter.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/vcenter.alerts
@@ -87,20 +87,6 @@ groups:
       description: "Memory usage of vCSA {{ $labels.vcenter}} is above 90%"
       summary: "Memory usage of vCSA {{ $labels.vcenter}} is above 90%"
 
-  - alert: VCenterDiskSpaceUsageWarning
-    expr: vrops_vcenter_diskspace_usage_gigabytes / vrops_vcenter_diskspace_total_gigabytes > 0.7
-    for: 30m
-    labels:
-      severity: info
-      tier: vmware
-      service: compute
-      support_group: compute
-      context: "vcenter disk usage"
-      meta: "Disk space usage of vCSA {{ $labels.vcenter}} is above 70%"
-    annotations:
-      description: "Disk space usage of vCSA {{ $labels.vcenter}} is above 70%"
-      summary: "Disk space usage of vCSA {{ $labels.vcenter}} is above 70%"
-
   - alert: VCenterDiskSpaceUsageCritical
     expr: vrops_vcenter_diskspace_usage_gigabytes / vrops_vcenter_diskspace_total_gigabytes > 0.9
     for: 15m


### PR DESCRIPTION
As requested by Operations.

Not needed alerts:
- HostDiskSpaceUsageWarning
- HostRootFilesystemUnhealthy
- VCenterDiskSpaceUsageWarning

Alert duplicate:
- VCenterRedundancyLostFailoverHostMissing