### PR TITLE
[nova] Add pre-upgrade service version bump Job

### DIFF
--- a/openstack/nova/templates/bump-compute-service-version-xena.yaml
+++ b/openstack/nova/templates/bump-compute-service-version-xena.yaml
@@ -1,0 +1,39 @@
+{{- if contains "xena" .Values.imageVersion }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "nova-bump-service-version"
+  labels:
+    system: openstack
+    type: configuration
+{{ tuple . "nova" "bump-service-version" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  template:
+    metadata:
+      name: "nova-bump-service-version"
+      labels:
+        system: openstack
+        type: configuration
+{{ tuple . "nova" "bump-service-version" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: bump
+        image: {{ required ".Values.global.dockerHubMirror is missing" .Values.global.dockerHubMirror }}/{{ .Values.mariadb.image | default "library/mariadb:10.5.12" }}
+        command:
+        - /usr/bin/env
+        - bash
+        - -c
+        - |
+          mariadb -v -hnova-mariadb -u{{ .Values.dbUser }} --password='{{ default .Values.dbPassword .Values.global.dbPassword }}' '{{ .Values.dbName }}' -e '
+          UPDATE services SET version = 54 WHERE deleted = 0 AND `binary` = 'nova-compute' AND version < 54;
+          ';
+          {{- if .Values.cell2.enabled }}
+          mariadb -v -hnova-{{ .Values.cell2.name }}-mariadb -u{{ .Values.cell2dbUser }} --password='{{ default .Values.cell2dbPassword .Values.global.dbPassword }}' '{{ .Values.cell2dbName }}' -e '
+          UPDATE services SET version = 54 WHERE deleted = 0 AND `binary` = 'nova-compute' AND version < 54;
+          '
+          {{- end }}
+{{- end }}


### PR DESCRIPTION
Some time ago, Nova introduced a check in scheduler and conductor that prohibits starting these services if there are compute services with a too old version around. This version is read from the DB and is supposed to be not older than 2 releases.

Since we want to do a big multi-version jump from Rocky to Xena, the conductors will not come up with the Xena image because of the old compute versions - but the new compute services also cannot come up to set their newer versions, because they need the conductor for DB access.

To get out of this circular dependency, we run a k8s Job when we deploy a "xena"-prefixed imageVersion that sets the versions of all compute hosts to 54. This ensures a still supported version to let conductor come up, but is not the version set by upgrade compute services. Having an older version than Xena enables us to see if compute services did not update their versions correctly and thus maybe didn't come up properly.

Updating the version needs to be done in all cells holding services.