### PR TITLE
Adding VCClusterHasNotEnoughResourcesToDistributeNSXTControllers alert

### DIFF
--- a/prometheus-rules/prometheus-vmware-rules/alerts/vccluster.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/vccluster.alerts
@@ -95,7 +95,7 @@ groups:
       description: "Cluster {{ $labels.vccluster }} DRS configuration is not set to fully automated."
       summary: "Cluster {{ $labels.vccluster }} DRS configuration is not set to fully automated."
 
-  - alert: VCClusterHasNotEnoughResourcesToDistributeNSXTControllers
+  - alert: VCClusterCannotDistributeNSXTControllers
     expr: count(max_over_time(vrops_hostsystem_memory_useable_kilobytes{vccluster=~".*management"}[1h]) / 1024 / 1024 >= 48) by(vccluster, vcenter) < 3
     for: 30m
     labels:

--- a/prometheus-rules/prometheus-vmware-rules/alerts/vccluster.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/vccluster.alerts
@@ -94,3 +94,17 @@ groups:
     annotations:
       description: "Cluster {{ $labels.vccluster }} DRS configuration is not set to fully automated."
       summary: "Cluster {{ $labels.vccluster }} DRS configuration is not set to fully automated."
+
+  - alert: VCClusterHasNotEnoughResourcesToDistributeNSXTControllers
+    expr: count(max_over_time(vrops_hostsystem_memory_useable_kilobytes{vccluster=~".*management"}[1h]) / 1024 / 1024 >= 48) by(vccluster, vcenter) < 3
+    for: 30m
+    labels:
+      severity: info
+      tier: vmware
+      service: compute
+      support_group: compute
+      context: "Cluster NSXT Resources"
+      meta: "Cluster {{ $labels.vccluster }} cannot evenly distribute new NSX-T controllers."
+    annotations:
+      description: "Cluster {{ $labels.vccluster }} cannot evenly distribute new NSX-T controllers. {{ $labels.vcenter}}"
+      summary: "Cluster {{ $labels.vccluster }} cannot evenly distribute new NSX-T controllers. {{ $labels.vcenter }}"


### PR DESCRIPTION
Every NSX-T Management Cluster consists out of 3 nodes. Each node must be placed on a different host. The alert triggers, if we have less than 3 hosts with enough resources.