### PR TITLE
[nova] Run online_data_migrations in cell2

### DIFF
--- a/openstack/nova/templates/bin/_db-online-migrate.tpl
+++ b/openstack/nova/templates/bin/_db-online-migrate.tpl
@@ -7,6 +7,10 @@ available_commands_text=$(nova-manage --help | awk '/Command categories/ {getlin
 {{- if (.Values.imageVersion | hasPrefix "rocky" | not) }}
 
 $nova_manage db online_data_migrations
+
+{{- if .Values.cell2.enabled }}
+$nova_manage --config-file /etc/nova/nova-cell2.conf db online_data_migrations
+{{- end }}
 {{- end }}
 
 if echo "${available_commands_text}" | grep -q -E '[{,]placement[},]'; then

--- a/openstack/nova/templates/db-online-migrate-job.yaml
+++ b/openstack/nova/templates/db-online-migrate-job.yaml
@@ -42,6 +42,12 @@ spec:
           name: nova-etc
           subPath: nova.conf
           readOnly: true
+{{- if .Values.cell2.enabled }}
+        - mountPath: /etc/nova/nova-cell2.conf
+          name: nova-etc
+          subPath: nova-cell2.conf
+          readOnly: true
+{{- end }}
         - mountPath: /etc/nova/logging.ini
           name: nova-etc
           subPath: logging.ini


### PR DESCRIPTION
While most of the online data migrations run in the API DB and break out to the different cells as necessary, there's at least one migration running in the local cell only: migrate_empty_ratio [0]

Therefore, we explicitly run the online_data_migrations command again with the "nova-cell2.conf" added, so we run in cell2.

[0] https://github.com/sapcc/nova/blob/a4469a15d302914a5a34f344fe3aa5efe638ce1a/nova/objects/compute_node.py#L524-L525