### PR TITLE
[prometheus-monitors] subchart for Pod|ServiceMonitors with default relabelings

### DIFF
--- a/common/prometheus-monitors/Chart.yaml
+++ b/common/prometheus-monitors/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
-name: prometheus-monitor-templates
+name: prometheus-monitors
 version: 0.0.1

--- a/common/prometheus-monitors/Chart.yaml
+++ b/common/prometheus-monitors/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: prometheus-monitor-templates
+version: 0.0.1

--- a/common/prometheus-monitors/README.md
+++ b/common/prometheus-monitors/README.md
@@ -39,14 +39,21 @@ The following table lists the configurable parameters of the `prometheus-monitor
 | `podMonitor.enabled` | `false` | If set to `true` it will render the PodMonitor  |
 | `serviceMonitor.enabled` | `false` | If set to `true` it will render the ServiceMonitor  |
 | `prometheus` | "" | Name of the Prometheus to scrape the monitor |
+| `clusterType`| `controlplane` | __Note:__ In most cases this value is set via regional globals.yaml |
 | `namespaces` | `[]` | Selector to select which namespaces the Kubernetes Endpoints objects are discovered from. See [NamespaceSelector](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.NamespaceSelector) |
-| `labelSelector` | `[]` | Selector to select Endpoints objects see [Kubernetes meta/v1.LabelSelectors](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#labelselector-v1-meta) |
+| `matchLabels` | `[]` | Selector to select Endpoints objects see [Kubernetes meta/v1.LabelSelectors](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#labelselector-v1-meta) |
+| `matchExpressions` | `[]` | Selector to select Endpoints objects see [Kubernetes meta/v1.LabelSelectors](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#labelselector-v1-meta) |
 | `scrapeInterval` | `60` | Interval in seconds at which metrics should be scraped. |
 | `scrapeTimeout` | `55` | Timeout in seconds after which the scrape is ended. |
 | `metricsPort` | `metrics` | Name of the pod port this endpoint refers to. |
 | `metricsPath` | `true` | HTTP path to scrape for metrics |
 | `customRelabelings` | `[]` | RelabelConfigs to apply to samples before scraping. Prometheus Operator automatically adds relabelings for a few standard Kubernetes fields. The original scrape job’s name is available via the __tmp_prometheus_job_name label. More info: <https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config> also see [[]RelabelConfig](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.RelabelConfig) |
 | `customMetricRelabelings` | `[]` | MetricRelabelConfigs to apply to samples before ingestion. see [[]RelabelConfig](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.RelabelConfig) |
+
+### Notes
+
+- No monitor is rendered if both "podMonitor.enabled" and "serviceMonitor.enabled" are enabled
+- It may be sufficient to only configure `matchExpressions` or `matchLabels`
 
 ## Additional Documentation
 

--- a/common/prometheus-monitors/README.md
+++ b/common/prometheus-monitors/README.md
@@ -11,7 +11,8 @@ This includes:
 - Cluster
 - Cluster Type [e.g. metal, scaleout, ...]
 
-This chart is meant to be used as a dependency in other charts, whenever a Pod|ServiceMonitor is used to ensure all labels required for alert routing are attached to the scraped metrics.
+This chart is meant to serve a set of common rules for Pod|ServiceMonitors to ensure that all labels required for alert routing are appended to the scraped series.
+
 
 ## Usage
 

--- a/common/prometheus-monitors/README.md
+++ b/common/prometheus-monitors/README.md
@@ -48,7 +48,6 @@ The following table lists the configurable parameters of the `prometheus-monitor
 | `customRelabelings` | `[]` | RelabelConfigs to apply to samples before scraping. Prometheus Operator automatically adds relabelings for a few standard Kubernetes fields. The original scrape job’s name is available via the __tmp_prometheus_job_name label. More info: <https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config> also see [[]RelabelConfig](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.RelabelConfig) |
 | `customMetricRelabelings` | `[]` | MetricRelabelConfigs to apply to samples before ingestion. see [[]RelabelConfig](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.RelabelConfig) |
 
-
 ## Additional Documentation
 
 - API Spec for [PodMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.PodMonitor)

--- a/common/prometheus-monitors/README.md
+++ b/common/prometheus-monitors/README.md
@@ -1,0 +1,56 @@
+# prometheus-monitors
+
+This chart deploys a Pod|ServiceMonitor that contains the same relabelings which are performed when using the Prometheus scrape annotations.
+
+This includes:
+
+- Kubernetes Namespace
+- Kubernetes Pod Name
+- Labels set for the Kubernetes Pod
+- Region
+- Cluster
+- Cluster Type [e.g. metal, scaleout, ...]
+
+This chart is meant to be used as a dependency in other charts, whenever a Pod|ServiceMonitor is used to ensure all labels required for alert routing are attached to the scraped metrics.
+
+## Usage
+
+Add `prometheus-monitors` as a dependency to your chart's `Chart.yaml` file:
+
+```yaml
+dependencies:
+  - name: prometheus-monitors
+    repository: https://charts.eu-de-2.cloud.sap
+    version: # use prometheus-monitors's current version from Chart.yaml
+```
+
+ then run:
+
+```sh
+helm dep update
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the `prometheus-monitors` chart and their default values.
+
+| Parameter | Default | Description |
+| ---       | ---         | ---     |
+| `podMonitor.enabled` | `false` | If set to `true` it will render the PodMonitor  |
+| `serviceMonitor.enabled` | `false` | If set to `true` it will render the ServiceMonitor  |
+| `prometheus` | "" | Name of the Prometheus to scrape the monitor |
+| `namespaces` | `[]` | Selector to select which namespaces the Kubernetes Endpoints objects are discovered from. See [NamespaceSelector](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.NamespaceSelector) |
+| `labelSelector` | `[]` | Selector to select Endpoints objects see [Kubernetes meta/v1.LabelSelectors](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#labelselector-v1-meta) |
+| `scrapeInterval` | `60` | Interval in seconds at which metrics should be scraped. |
+| `scrapeTimeout` | `55` | Timeout in seconds after which the scrape is ended. |
+| `metricsPort` | `metrics` | Name of the pod port this endpoint refers to. |
+| `metricsPath` | `true` | HTTP path to scrape for metrics |
+| `customRelabelings` | `[]` | RelabelConfigs to apply to samples before scraping. Prometheus Operator automatically adds relabelings for a few standard Kubernetes fields. The original scrape job’s name is available via the __tmp_prometheus_job_name label. More info: <https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config> also see [[]RelabelConfig](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.RelabelConfig) |
+| `customMetricRelabelings` | `[]` | MetricRelabelConfigs to apply to samples before ingestion. see [[]RelabelConfig](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.RelabelConfig) |
+
+
+## Additional Documentation
+
+- API Spec for [PodMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.PodMonitor)
+
+- API Spec for [ServiceMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.ServiceMonitor)

--- a/common/prometheus-monitors/ci/test-values.yaml
+++ b/common/prometheus-monitors/ci/test-values.yaml
@@ -1,0 +1,27 @@
+global:
+  region: test-region
+  clusterType: test
+
+podMonitor:
+  enabled: false
+serviceMonitor:
+  enabled: true
+
+prometheus: dummy-prometheus
+
+namespaces:
+  - "my-namespace"
+
+labelSelector:
+  - key: "app.kubernetes.io/name"
+    value: "my-app"
+
+customRelabelings:
+  - action: labelmap
+    sourceLabels:
+      - __test__
+
+customMetricRelabelings:
+  - action: drop
+    regex: ".*"
+    sourceLabels: [__name__]

--- a/common/prometheus-monitors/ci/test-values.yaml
+++ b/common/prometheus-monitors/ci/test-values.yaml
@@ -3,16 +3,16 @@ global:
   clusterType: test
 
 podMonitor:
-  enabled: false
-serviceMonitor:
   enabled: true
+serviceMonitor:
+  enabled: false
 
 prometheus: dummy-prometheus
 
 namespaces:
   - "my-namespace"
 
-labelSelector:
+matchLabels:
   - key: "app.kubernetes.io/name"
     value: "my-app"
 

--- a/common/prometheus-monitors/templates/_helpers.tpl
+++ b/common/prometheus-monitors/templates/_helpers.tpl
@@ -1,0 +1,11 @@
+{{- define "prometheus.defaultRelabelConfig" -}}
+- action: replace
+  targetLabel: region
+  replacement: {{ required ".Values.global.region missing" .Values.global.region }}
+- action: replace
+  targetLabel: cluster_type
+  replacement: {{ required ".Values.global.clusterType missing" .Values.global.clusterType }}
+- action: replace
+  targetLabel: cluster
+  replacement: {{ if .Values.global.cluster }}{{ .Values.global.cluster }}{{ else }}{{ .Values.global.region }}{{ end }}
+{{- end -}}

--- a/common/prometheus-monitors/templates/podmonitor.yaml
+++ b/common/prometheus-monitors/templates/podmonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.podMonitor.enabled }}
+{{- if and .Values.podMonitor.enabled ( not .Values.serviceMonitor.enabled ) }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:

--- a/common/prometheus-monitors/templates/podmonitor.yaml
+++ b/common/prometheus-monitors/templates/podmonitor.yaml
@@ -1,4 +1,7 @@
-{{- if and .Values.podMonitor.enabled ( not .Values.serviceMonitor.enabled ) }}
+{{- if .Values.podMonitor.enabled }}
+{{- if .Values.serviceMonitor.enabled }}
+{{ fail "failed to render PodMonitor. ServiceMonitor is also enabed. Only one is allowed."}}
+{{- end }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -7,13 +10,22 @@ metadata:
     prometheus: {{ required "required '.Values.prometheus' is not specified" .Values.prometheus }}
 
 spec:
+  jobLabel: {{ .Release.Namespace }}
   selector:
+{{- if and ( empty .Values.matchLabels ) ( empty .Values.matchExpressions ) }}
+{{ fail "required either '.Values.matchLabels' or '.Values.matchExpressions' but neither is defined" }}
+{{- end }}
+
+{{- if .Values.matchLabels }}
     matchLabels:
-    
-    {{- range ( required "required '.Values.labelSelector' is not specified" .Values.labelSelector ) }}
-      {{ .key }}: {{ .value | quote }}
-    {{- end }}
-  
+{{ .Values.matchLabels | toYaml | indent 6 }}
+{{- end }}
+
+{{- if .Values.matchExpressions }}
+    matchExpressions:
+{{ .Values.matchExpressions | toYaml | indent 6 }}
+{{- end }}
+
   namespaceSelector:
     matchNames:
 {{  default (list .Release.Namespace ) .Values.namespaces | toYaml | indent 6 }}
@@ -34,7 +46,9 @@ spec:
             - __meta_kubernetes_pod_name
           targetLabel: kubernetes_pod_name
 {{ include "prometheus.defaultRelabelConfig" .  | indent 8 }}
+{{- if .Values.customRelabelings }}
 {{ .Values.customRelabelings | toYaml | indent 8 }}
+{{- end }}
 {{- if .Values.customMetricRelabelings }}
       metricRelabelings:
 {{ .Values.customMetricRelabelings | toYaml | indent 8 }}

--- a/common/prometheus-monitors/templates/podmonitor.yaml
+++ b/common/prometheus-monitors/templates/podmonitor.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.podMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ default .Release.Namespace .Values.nameOverride }}-pod-monitor
+  labels:
+    prometheus: {{ required "required '.Values.prometheus' is not specified" .Values.prometheus }}
+
+spec:
+  selector:
+    matchLabels:
+    
+    {{- range ( required "required '.Values.labelSelector' is not specified" .Values.labelSelector ) }}
+      {{ .key }}: {{ .value | quote }}
+    {{- end }}
+  
+  namespaceSelector:
+    matchNames:
+{{  default (list .Release.Namespace ) .Values.namespaces | toYaml | indent 6 }}
+  
+  podMetricsEndpoints:
+    - interval: {{ default "60s" .Values.scrapeInterval }}
+      scrapeTimeout: {{ default "55s" .Values.scrapeTimeout }}
+      port: {{ default "metrics" .Values.metricsPort }}
+      path: {{ default "/metrics" .Values.metricsPath }}
+      honorLabels: true
+      relabelings: 
+        - action: labelmap
+          regex: '__meta_kubernetes_pod_label_(.+)'
+        - sourceLabels:
+            - __meta_kubernetes_namespace
+          targetLabel: kubernetes_namespace
+        - sourceLabels:
+            - __meta_kubernetes_pod_name
+          targetLabel: kubernetes_pod_name
+{{ include "prometheus.defaultRelabelConfig" .  | indent 8 }}
+{{ .Values.customRelabelings | toYaml | indent 8 }}
+{{- if .Values.customMetricRelabelings }}
+      metricRelabelings:
+{{ .Values.customMetricRelabelings | toYaml | indent 8 }}
+{{- end }}
+{{- end }}

--- a/common/prometheus-monitors/templates/servicemonitor.yaml
+++ b/common/prometheus-monitors/templates/servicemonitor.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Namespace }}-service-monitor
+  labels:
+    prometheus: {{ required "required '.Values.prometheus' is not specified" .Values.prometheus }}
+
+spec:
+  selector:
+    matchLabels:
+    {{- range .Values.labelSelector }}
+      {{ .key }}: {{ .value | quote }}
+    {{- end }}
+  
+  namespaceSelector:
+    matchNames:
+    {{  default (list .Release.Namespace ) .Values.namespaces | toYaml | indent 6 }}
+  
+  endpoints:
+    - interval: {{ default "60s" .Values.scrapeInterval }}
+      scrapeTimeout: {{ default "55s" .Values.scrapeTimeout }}
+      port: {{ default "metrics" .Values.metricsPort }}
+      path: {{ default "/metrics" .Values.metricsPath }}
+      honorLabels: {{ default true .Values.honorLabels }}
+      relabelings: 
+        - action: labelmap
+          regex: '__meta_kubernetes_pod_label_(.+)'
+        - sourceLabels:
+            - __meta_kubernetes_namespace
+          targetLabel: kubernetes_namespace
+        - sourceLabels:
+            - __meta_kubernetes_pod_name
+          targetLabel: kubernetes_pod_name
+{{ include "prometheus.defaultRelabelConfig" .  | indent 8 }}
+{{ .Values.customRelabelings | toYaml | indent 8 }}
+{{- if .Values.customMetricRelabelings }}
+      metricRelabelings:
+{{ .Values.customMetricRelabelings | toYaml | indent 8 }}
+{{- end }}
+{{- end }}

--- a/common/prometheus-monitors/templates/servicemonitor.yaml
+++ b/common/prometheus-monitors/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceMonitor.enabled }}
+{{- if and .Values.serviceMonitor.enabled ( not .Values.podMonitor.enabled ) }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/common/prometheus-monitors/templates/servicemonitor.yaml
+++ b/common/prometheus-monitors/templates/servicemonitor.yaml
@@ -1,4 +1,7 @@
-{{- if and .Values.serviceMonitor.enabled ( not .Values.podMonitor.enabled ) }}
+{{- if .Values.serviceMonitor.enabled }}
+{{- if .Values.podMonitor.enabled }}
+{{ fail "failed to render ServiceMonitor. PodMonitor is also enabed. Only one is allowed."}}
+{{- end }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -8,10 +11,15 @@ metadata:
 
 spec:
   selector:
+{{- if .Values.matchLabels }}
     matchLabels:
-    {{- range .Values.labelSelector }}
-      {{ .key }}: {{ .value | quote }}
-    {{- end }}
+{{ .Values.matchLabels | toYaml | indent 6 }}
+{{- end }}
+
+{{- if .Values.matchExpressions }}
+    matchExpressions:
+{{ .Values.matchExpressions | toYaml | indent 6 }}
+{{- end }}
   
   namespaceSelector:
     matchNames:

--- a/common/prometheus-monitors/values.yaml
+++ b/common/prometheus-monitors/values.yaml
@@ -1,0 +1,16 @@
+podMonitor:
+  enabled: false
+serviceMonitor:
+  enabled: false
+
+prometheus: ""
+
+namespaces: []
+
+labelSelector:
+  []
+  # - key:
+  #   value:
+
+customRelabelings: []
+customMetricRelabelings: []

--- a/common/prometheus-monitors/values.yaml
+++ b/common/prometheus-monitors/values.yaml
@@ -21,4 +21,7 @@ matchExpressions: []
 matchLabels: []
 
 customRelabelings: []
+
+# RelabelConfig allows dynamic rewriting of the label set, being applied to
+# samples before ingestion.
 customMetricRelabelings: []

--- a/common/prometheus-monitors/values.yaml
+++ b/common/prometheus-monitors/values.yaml
@@ -12,6 +12,7 @@ prometheus: ""
 
 namespaces: []
 
+# matchExpressions is a list of label selector requirements. The requirements are ANDed.
 matchExpressions: []
 matchLabels: []
 

--- a/common/prometheus-monitors/values.yaml
+++ b/common/prometheus-monitors/values.yaml
@@ -20,6 +20,7 @@ matchExpressions: []
 # is "In", and the values array contains only "value". The requirements are ANDed.
 matchLabels: []
 
+#  RelabelConfigs to apply to samples before scraping.
 customRelabelings: []
 
 # RelabelConfig allows dynamic rewriting of the label set, being applied to

--- a/common/prometheus-monitors/values.yaml
+++ b/common/prometheus-monitors/values.yaml
@@ -1,3 +1,8 @@
+global:
+  # Type of the cluster to which the Prometheus is deployed.
+  # Choose between: controlplane, kubernikus-controlplane, kubernikus-scaleout.
+  clusterType: controlplane
+
 podMonitor:
   enabled: false
 serviceMonitor:
@@ -7,10 +12,8 @@ prometheus: ""
 
 namespaces: []
 
-labelSelector:
-  []
-  # - key:
-  #   value:
+matchExpressions: []
+matchLabels: []
 
 customRelabelings: []
 customMetricRelabelings: []

--- a/common/prometheus-monitors/values.yaml
+++ b/common/prometheus-monitors/values.yaml
@@ -14,6 +14,10 @@ namespaces: []
 
 # matchExpressions is a list of label selector requirements. The requirements are ANDed.
 matchExpressions: []
+
+# matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map
+# is equivalent to an element of matchExpressions, whose key field is "key", the operator
+# is "In", and the values array contains only "value". The requirements are ANDed.
 matchLabels: []
 
 customRelabelings: []

--- a/common/prometheus-monitors/values.yaml
+++ b/common/prometheus-monitors/values.yaml
@@ -10,6 +10,7 @@ serviceMonitor:
 
 prometheus: ""
 
+# List of namespace names from which the Endpoint objects are selected.
 namespaces: []
 
 # matchExpressions is a list of label selector requirements. The requirements are ANDed.


### PR DESCRIPTION
For proper alert routing we require certain labels to be attached to a metric (e.g. region, cluster_type). Many Pod|ServiceMonitors in this repository do not set these labels. The problem is that every chart maintainer must be aware of these mandatory labels for alert routing.
Previously this was not an issue, since most pods/services were scraped by one scrape job discovering targets via the prometheus scrape annotations.
This Subchart should provide a similarly convenient  option of adding a Pod|ServiceMonitor with a certain set of defaults and the option to further adjust the scrape configuration.

Example metric with default relabelings:
https://prometheus-infra-collector.qa-de-1.cloud.sap/graph?g0.expr=metis_replication_restart_counter%7Bpod%3D~%22mariadb-sync-nova-api.*%22%7D&g0.tab=1&g0.stacked=0&g0.show_exemplars=0&g0.range_input=1h

Example PR for basic usage: #4337 