### PR TITLE
[cc3test] fix playbook link for nova alerts

### DIFF
--- a/openstack/cc3test/Chart.yaml
+++ b/openstack/cc3test/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: cc3test - for blackbox testing the CC+1
 name: cc3test
-version: 0.1.3
+version: 0.1.4
 dependencies:
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap

--- a/openstack/cc3test/alerts/compute.alerts
+++ b/openstack/cc3test/alerts/compute.alerts
@@ -121,7 +121,7 @@ groups:
       context: '{{ $labels.service }}'
       meta: 'Openstack Compute Canary: {{ $labels.name }} is down, see report for more details'
       dashboard: cc3test-overview?var-service={{ $labels.service }}
-      playbook: 'docs/devops/alert/{{ $labels.service }}/#test_create_server'
+      playbook: 'docs/support/playbook/{{ $labels.service }}/alerts/cc3test-alert-create-server-bb/'
       report: 'cc3test/admin/object-storage/containers/cc3test/list/reports/{{ $labels.type }}'
     annotations:
       description: 'Openstack Compute Canary: {{ $labels.name }} is down, see report for more details'


### PR DESCRIPTION
fixing playbook link for alert OpenstackComputeCanaryCreateHanaServerDown to point to the new documentation under https://operations.global.cloud.sap/docs/support/playbook/nova/alerts/cc3test-alert-create-server-bb/