### PR TITLE
[mariadb] adds toggle for prechangejob

### DIFF
--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.7.5
+version: 0.7.6

--- a/common/mariadb/templates/pre-change-job.yaml
+++ b/common/mariadb/templates/pre-change-job.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.databases .Values.users }}
+{{- if and ( or .Values.databases .Values.users ) ( not .disablePreChangeJob ) }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -20,6 +20,9 @@ expire_logs_days: 10
 character_set_server: "utf8" # Should be utf8mb4, but we started with this
 collation_server: "utf8_general_ci"
 
+# set this when DB is initially deployed and the PreChangeJob can't succeeed
+disablePreChangeJob: false
+
 db_performance_schema: # Enabling performance schema only (without enabling instruments for data collections).
   # Instrument can be enabled separately. Only Performance Schema Enablement does not cause any
   # overhead.


### PR DESCRIPTION
The PreChange will never succeed in case the DB was not yet deployed or is not up for some reason.
This toggle is a convenience to be used in this scenarios to avoid the deployment to fail.