### PR TITLE
[nova] Set initial allocation ratios

### DIFF
--- a/openstack/nova/templates/etc/_nova.conf.tpl
+++ b/openstack/nova/templates/etc/_nova.conf.tpl
@@ -203,3 +203,8 @@ default_pool_size = {{ .Values.wsgi_default_pool_size | default .Values.global.w
 
 [workarounds]
 enable_live_migration_to_old_hypervisor = True
+
+[compute]
+initial_cpu_allocation_ratio = 1.0
+initial_ram_allocation_ratio = 1.0
+initial_disk_allocation_ratio = 1.0


### PR DESCRIPTION
These settings have defaults we do not want - e.g. 16 x CPU overcommit and 1.5 x RAM overcommit. They are only used to set defaults when a new ComputeNode object is created and during an online data migration when upgrading to Xena if they are set to None or 0. The allocation ratios can then overwritten by the nova-compute service later on.