### PR TITLE
openstack/clair: split combo deployment into split openstack

### DIFF
--- a/openstack/clair/ci/test-values.yaml
+++ b/openstack/clair/ci/test-values.yaml
@@ -6,6 +6,7 @@ global:
   quayIoMirror: registry.example.com/quayio
 
 clair:
+  image_version: 1.0.0
   auth:
     preshared_key: 'thisisnotreallyasecret'
 

--- a/openstack/clair/templates/configmap.yaml
+++ b/openstack/clair/templates/configmap.yaml
@@ -9,4 +9,4 @@ data:
     #!/bin/sh
     set -euo pipefail
     sed "s/%POSTGRES_PASSWORD%/${POSTGRES_PASSWORD}/; s/%AUTH_PRESHARED_KEY%/${AUTH_PRESHARED_KEY}/;" < /etc/clair/config.yaml.in > /tmp/clair-config.yaml
-    clair -conf /tmp/clair-config.yaml -mode combo
+    clair -conf /tmp/clair-config.yaml -mode "$1"

--- a/openstack/clair/templates/deployment-indexer.yaml
+++ b/openstack/clair/templates/deployment-indexer.yaml
@@ -2,11 +2,11 @@ kind: Deployment
 apiVersion: apps/v1
 
 metadata:
-  name: clair
+  name: clair-indexer
 
 spec:
   revisionHistoryLimit: 5
-  replicas: 3
+  replicas: 2
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -14,11 +14,11 @@ spec:
       maxSurge: 1
   selector:
     matchLabels:
-      name: clair
+      name: clair-indexer
   template:
     metadata:
       labels:
-        name: clair
+        name: clair-indexer
         alert-tier: os
         alert-service: keppel
       annotations:
@@ -30,10 +30,10 @@ spec:
           configMap:
             name: clair-etc
       containers:
-        - name: clair
+        - name: clair-indexer
           image: {{.Values.global.registry}}/clair:{{.Values.clair.image_version | required ".Values.clair.image_version is not set!"}}
           imagePullPolicy: IfNotPresent
-          command: [ /bin/sh, /etc/clair/start.sh ]
+          command: [ /bin/sh, /etc/clair/start.sh, indexer ]
           env:
             - name: AUTH_PRESHARED_KEY
               valueFrom:

--- a/openstack/clair/templates/deployment-matcher.yaml
+++ b/openstack/clair/templates/deployment-matcher.yaml
@@ -1,0 +1,64 @@
+kind: Deployment
+apiVersion: apps/v1
+
+metadata:
+  name: clair-matcher
+
+spec:
+  revisionHistoryLimit: 5
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+  selector:
+    matchLabels:
+      name: clair-matcher
+  template:
+    metadata:
+      labels:
+        name: clair-matcher
+        alert-tier: os
+        alert-service: keppel
+      annotations:
+        checksum/configmap: {{ include "clair/templates/configmap.yaml" . | sha256sum }}
+        checksum/secret: {{ include "clair/templates/secret.yaml" . | sha256sum }}
+    spec:
+      volumes:
+        - name: config
+          configMap:
+            name: clair-etc
+      containers:
+        - name: clair-matcher
+          image: {{.Values.global.registry}}/clair:{{.Values.clair.image_version | required ".Values.clair.image_version is not set!"}}
+          imagePullPolicy: IfNotPresent
+          command: [ /bin/sh, /etc/clair/start.sh, matcher ]
+          env:
+            - name: AUTH_PRESHARED_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: clair
+                  key: auth_preshared_key
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: clair
+                  key: postgres_password
+          volumeMounts:
+            - mountPath: /etc/clair
+              name: config
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            timeoutSeconds: 10
+            periodSeconds: 60
+            initialDelaySeconds: 60
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            timeoutSeconds: 5
+            periodSeconds: 5
+          resources: {} # TODO: configure once we have some data

--- a/openstack/clair/templates/etc/_config.yaml.tpl
+++ b/openstack/clair/templates/etc/_config.yaml.tpl
@@ -19,7 +19,7 @@ indexer:
 matcher:
   connstring: "host=clair-postgresql port=5432 dbname=clair user=postgres password=%POSTGRES_PASSWORD% sslmode=disable application_name=c-matcher"
   max_conn_pool: 32
-  indexer_addr: "" # ignored since we're running in combo mode
+  indexer_addr: "http://clair-indexer:8080"
   migrations: true
   period: {{ quote .Values.clair.update_interval }}
 
@@ -27,7 +27,6 @@ matcher:
   # does not get applied correctly, causing garbage collection to not run
   # <https://github.com/quay/clair/issues/1337#issuecomment-898485216>
   update_retention: 5
-
 
 matchers:
   # do NOT enable the crda matcher; it tries to make API calls that fail with 403 errors left and right
@@ -37,17 +36,17 @@ updaters:
   sets: [ alpine, debian, rhel, suse, ubuntu ]
   config: {} # no special config options for updaters yet
 
-notifier:
-  connstring: "host=clair-postgresql port=5432 dbname=clair user=postgres password=%POSTGRES_PASSWORD% sslmode=disable application_name=c-notifier"
-  migrations: true
-  indexer_addr: "" # ignored since we're running in combo mode
-  matcher_addr: "" # ignored since we're running in combo mode
-  poll_interval: 1000h # basically never, we don't use the notifier
-  delivery_interval: 1000h # basically never, we don't use the notifier
-  disable_summary: false
-  webhook: null
-  amqp: null
-  stomp: null
+# notifier:
+#   connstring: "host=clair-postgresql port=5432 dbname=clair user=postgres password=%POSTGRES_PASSWORD% sslmode=disable application_name=c-notifier"
+#   migrations: true
+#   indexer_addr: "" # ignored since we're running in combo mode
+#   matcher_addr: "" # ignored since we're running in combo mode
+#   poll_interval: 1000h # basically never, we don't use the notifier
+#   delivery_interval: 1000h # basically never, we don't use the notifier
+#   disable_summary: false
+#   webhook: null
+#   amqp: null
+#   stomp: null
 
 auth:
   psk:

--- a/openstack/clair/templates/ingress.yaml
+++ b/openstack/clair/templates/ingress.yaml
@@ -15,10 +15,24 @@ spec:
     - host: keppel-clair.{{.Values.global.region}}.{{.Values.global.tld}}
       http:
         paths:
-        - path: /
+        # - path: /notifier
+        #   pathType: Prefix
+        #   backend:
+        #     service:
+        #       name: clair-notifier
+        #       port:
+        #         number: 8080
+        - path: /indexer
           pathType: Prefix
           backend:
             service:
-              name: clair
+              name: clair-indexer
+              port:
+                number: 8080
+        - path: /matcher
+          pathType: Prefix
+          backend:
+            service:
+              name: clair-matcher
               port:
                 number: 8080

--- a/openstack/clair/templates/service-indexer.yaml
+++ b/openstack/clair/templates/service-indexer.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+
+metadata:
+  name: clair-indexer
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8081"
+    prometheus.io/targets: "openstack"
+
+spec:
+  selector:
+    name: clair-indexer
+  ports:
+    - name: api
+      port: 8080
+    - name: introspection
+      port: 8081

--- a/openstack/clair/templates/service-matcher.yaml
+++ b/openstack/clair/templates/service-matcher.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 
 metadata:
-  name: clair
+  name: clair-matcher
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "8081"
@@ -10,7 +10,7 @@ metadata:
 
 spec:
   selector:
-    name: clair
+    name: clair-matcher
   ports:
     - name: api
       port: 8080


### PR DESCRIPTION
This allows us to scale each component individually and drop the unused notifier.