### PR TITLE
[Keystone] Migrate pdb manifests to use the policy/v1 API version

### DIFF
--- a/openstack/keystone/templates/pdb.yaml
+++ b/openstack/keystone/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.api.pdb.minAvailable }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ .Release.Name }}-api


### PR DESCRIPTION
policy/v1beta1 API version of PodDisruptionBudget will no longer be served in v1.25

Ref : https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125