### PR TITLE
cc3test: set a defined exit code for the pytest tests

### DIFF
--- a/openstack/cc3test/templates/cronjob-api.yaml
+++ b/openstack/cc3test/templates/cronjob-api.yaml
@@ -24,7 +24,8 @@ spec:
           containers:
           - name: cc3test-api
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
-            args: ['pytest', '--disable-pytest-warnings', '--no-header', '--color=yes', '--variables', 'config/config.yaml', '--variables', 'secrets/secrets.yaml', '-r', 'ap', '-m', 'api', 'tests']
+            command: ["/bin/sh"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -r ap -m api tests; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-automation.yaml
+++ b/openstack/cc3test/templates/cronjob-automation.yaml
@@ -25,7 +25,7 @@ spec:
           - name: base
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'lyra and canary' -r ap tests"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'lyra and canary' -r ap tests; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config
@@ -36,7 +36,7 @@ spec:
           - name: purge
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'arc and purge' -r ap tests"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'arc and purge' -r ap tests; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-baremetal.yaml
+++ b/openstack/cc3test/templates/cronjob-baremetal.yaml
@@ -25,7 +25,7 @@ spec:
           - name: regular
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'baremetal and regression' -r ap tests"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'baremetal and regression' -r ap tests; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-blockstorage-volume-hana.yaml
+++ b/openstack/cc3test/templates/cronjob-blockstorage-volume-hana.yaml
@@ -25,7 +25,7 @@ spec:
           - name: hana
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'block_storage and canary and hana' -r ap tests"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'block_storage and canary and hana' -r ap tests; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-blockstorage-volume-regular.yaml
+++ b/openstack/cc3test/templates/cronjob-blockstorage-volume-regular.yaml
@@ -25,7 +25,7 @@ spec:
           - name: regular
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'block_storage and canary and regular' -r ap tests"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'block_storage and canary and regular' -r ap tests; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-blockstorage.yaml
+++ b/openstack/cc3test/templates/cronjob-blockstorage.yaml
@@ -25,7 +25,7 @@ spec:
           - name: base
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'block_storage and canary and base' -r ap tests"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'block_storage and canary and base' -r ap tests; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config
@@ -36,7 +36,7 @@ spec:
           - name: purge
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'block_storage and purge' -r ap tests"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'block_storage and purge' -r ap tests; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-certificate.yaml
+++ b/openstack/cc3test/templates/cronjob-certificate.yaml
@@ -25,7 +25,7 @@ spec:
           - name: certificate
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m certificate -r ap tests"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m certificate -r ap tests; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-compute-server-hana.yaml
+++ b/openstack/cc3test/templates/cronjob-compute-server-hana.yaml
@@ -25,7 +25,7 @@ spec:
           - name: hana
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh" ]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'compute and hana' -r ap tests"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'compute and hana' -r ap tests; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-compute-server-regular.yaml
+++ b/openstack/cc3test/templates/cronjob-compute-server-regular.yaml
@@ -25,7 +25,7 @@ spec:
           - name: regular
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'compute and regular' -r ap tests"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'compute and regular' -r ap tests; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-compute.yaml
+++ b/openstack/cc3test/templates/cronjob-compute.yaml
@@ -25,7 +25,7 @@ spec:
           - name: base
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'compute and base' -r ap tests"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'compute and base' -r ap tests; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config
@@ -36,7 +36,7 @@ spec:
           - name: purge
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'compute and purge' -r ap tests"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'compute and purge' -r ap tests; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-datapath.yaml
+++ b/openstack/cc3test/templates/cronjob-datapath.yaml
@@ -24,7 +24,8 @@ spec:
           containers:
           - name: cc3test-datapath
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
-            args: ['pytest', '--disable-pytest-warnings', '--no-header', '--color=yes', '--variables', 'config/config.yaml', '--variables', 'secrets/secrets.yaml', '-r', 'ap', '-m', 'datapath', 'tests']
+            command: ["/bin/sh"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -r ap -m datapath tests; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-datastore.yaml
+++ b/openstack/cc3test/templates/cronjob-datastore.yaml
@@ -24,7 +24,8 @@ spec:
           containers:
           - name: cc3test-datastore-host-missing
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
-            args: ['pytest', '--disable-pytest-warnings', '--no-header', '--color=yes', '--variables', 'config/config.yaml', '--variables', 'secrets/secrets.yaml', '-r', 'ap', '-k', 'TestDatastore and mounted', 'tests']
+            command: ["/bin/sh"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -r ap -k 'TestDatastore and mounted' tests; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config
@@ -34,7 +35,8 @@ spec:
                 readOnly: true
           - name: cc3test-datastore-host-accessible
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
-            args: ['pytest', '--disable-pytest-warnings', '--no-header', '--color=yes', '--variables', 'config/config.yaml', '--variables', 'secrets/secrets.yaml', '-r', 'ap', '-k', 'TestDatastore and accessible', 'tests']
+            command: ["/bin/sh"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -r ap -k 'TestDatastore and accessible' tests; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-dns.yaml
+++ b/openstack/cc3test/templates/cronjob-dns.yaml
@@ -25,7 +25,7 @@ spec:
           - name: base
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'dns and base' -r ap tests"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'dns and base' -r ap tests; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config
@@ -36,7 +36,7 @@ spec:
           - name: purge
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'dns and purge' -r ap tests"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'dns and purge' -r ap tests; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-fileshare.yaml
+++ b/openstack/cc3test/templates/cronjob-fileshare.yaml
@@ -25,7 +25,7 @@ spec:
           - name: base
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'file_shares and base' -r ap tests"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'file_shares and base' -r ap tests; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config
@@ -36,7 +36,7 @@ spec:
           - name: purge
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'file_shares and purge' -r ap tests"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'file_shares and purge' -r ap tests; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-hermes.yaml
+++ b/openstack/cc3test/templates/cronjob-hermes.yaml
@@ -25,7 +25,7 @@ spec:
           - name: base
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'hermes and base' -r ap tests"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'hermes and base' -r ap tests; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-integrity.yaml
+++ b/openstack/cc3test/templates/cronjob-integrity.yaml
@@ -24,7 +24,8 @@ spec:
           containers:
           - name: cc3test-integrity
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
-            args: ['pytest', '--disable-pytest-warnings', '--no-header', '--color=yes', '--variables', 'config/config.yaml', '--variables', 'secrets/secrets.yaml', '-r', 'ap', '-m', 'integrity', 'tests']
+            command: ["/bin/sh"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -r ap -m integrity tests; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-key-manager.yaml
+++ b/openstack/cc3test/templates/cronjob-key-manager.yaml
@@ -25,7 +25,7 @@ spec:
           - name: base
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'key_manager and base' -r ap tests"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'key_manager and base' -r ap tests; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config
@@ -36,7 +36,7 @@ spec:
           - name: purge
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'key_manager and purge' -r ap tests"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'key_manager and purge' -r ap tests; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-loadbalancer.yaml
+++ b/openstack/cc3test/templates/cronjob-loadbalancer.yaml
@@ -25,7 +25,7 @@ spec:
           - name: base
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'load_balancer and base' -r ap tests"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'load_balancer and base' -r ap tests; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config
@@ -36,7 +36,7 @@ spec:
           - name: purge
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'load_balancer and purge' -r ap tests"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'load_balancer and purge' -r ap tests; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-neutron-fip.yaml
+++ b/openstack/cc3test/templates/cronjob-neutron-fip.yaml
@@ -25,7 +25,7 @@ spec:
           - name: base
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -k 'TestFloatingIp and create' -r ap tests --count=2"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -k 'TestFloatingIp and create' -r ap tests --count=2; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config
@@ -36,7 +36,7 @@ spec:
           - name: purge
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'network and purge' -r ap tests"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'network and purge' -r ap tests; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-neutron.yaml
+++ b/openstack/cc3test/templates/cronjob-neutron.yaml
@@ -25,7 +25,7 @@ spec:
           - name: base
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'network and base' -r ap tests"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'network and base' -r ap tests; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config


### PR DESCRIPTION
if the tests do not return 0 kubernetes might just restart them over and over and trying to set a exit status 0 within the tests seems to confuse pytest, so simply set it after executing the test, so that always exit 0 is returned to kubernetes to make it happy