### PR TITLE
cerebro: Add ccadmin domain technical user and role assignments

### DIFF
--- a/openstack/cerebro/templates/domain-ccadmin-seed.yaml
+++ b/openstack/cerebro/templates/domain-ccadmin-seed.yaml
@@ -56,25 +56,59 @@ spec:
         {{- end }}
       role_assignments:
       - user: {{ .Values.technicalUserPerRegion }}
+        role: admin
+      - user: {{ .Values.technicalUserPerRegion }}
+        role: audit_viewer
+      - user: {{ .Values.technicalUserPerRegion }}
+        role: automation_admin
+      - user: {{ .Values.technicalUserPerRegion }}
+        role: compute_admin
+      - user: {{ .Values.technicalUserPerRegion }}
+        role: compute_admin_wsg
+      - user: {{ .Values.technicalUserPerRegion }}
         role: compute_viewer
+      - user: {{ .Values.technicalUserPerRegion }}
+        role: dns_hostmaster
       - user: {{ .Values.technicalUserPerRegion }}
         role: dns_webmaster
       - user: {{ .Values.technicalUserPerRegion }}
+        role: dns_zonemaster
+      - user: {{ .Values.technicalUserPerRegion }}
+        role: image_admin
+      - user: {{ .Values.technicalUserPerRegion }}
+        role: keymanager_admin
+      - user: {{ .Values.technicalUserPerRegion }}
         role: kubernetes_admin
+      - user: {{ .Values.technicalUserPerRegion }}
+        role: masterdata_admin
       - user: {{ .Values.technicalUserPerRegion }}
         role: member
       - user: {{ .Values.technicalUserPerRegion }}
         role: monitoring_viewer
       - user: {{ .Values.technicalUserPerRegion }}
+        role: network_admin
+      - user: {{ .Values.technicalUserPerRegion }}
         role: network_viewer
       - user: {{ .Values.technicalUserPerRegion }}
         role: registry_admin
       - user: {{ .Values.technicalUserPerRegion }}
+        role: registry_viewer
+      - user: {{ .Values.technicalUserPerRegion }}
+        role: resource_admin
+      - user: {{ .Values.technicalUserPerRegion }}
         role: resource_viewer
+      - user: {{ .Values.technicalUserPerRegion }}
+        role: role_admin
       - user: {{ .Values.technicalUserPerRegion }}
         role: securitygroup_admin
       - user: {{ .Values.technicalUserPerRegion }}
+        role: sharedfilesystem_admin
+      - user: {{ .Values.technicalUserPerRegion }}
         role: sharedfilesystem_viewer
+      - user: {{ .Values.technicalUserPerRegion }}
+        role: objectstore_admin
+      - user: {{ .Values.technicalUserPerRegion }}
+        role: volume_admin
       - user: {{ .Values.technicalUserPerRegion }}
         role: volume_viewer
     groups:

--- a/openstack/cerebro/templates/domain-ccadmin-seed.yaml
+++ b/openstack/cerebro/templates/domain-ccadmin-seed.yaml
@@ -112,7 +112,7 @@ spec:
       - user: {{ .Values.technicalUserPerRegion }}
         role: volume_viewer
     groups:
-    - name: CCADMIN_CEREBRO_ADMIN
+    - name: CCADMIN_CEREBRO_TECHNICAL_TEAM_USERS
       role_assignments:
       - project: cerebro
         role: admin
@@ -152,7 +152,7 @@ spec:
         role: objectstore_admin 
       - project: cerebro
         role: volume_admin
-    - name: CCADMIN_CEREBRO_VIEWER
+    - name: CCADMIN_CEREBRO_TEAM_USERS
       role_assignments:
       - project: cerebro
         role: audit_viewer

--- a/openstack/cerebro/values.yaml
+++ b/openstack/cerebro/values.yaml
@@ -4,5 +4,5 @@ owner-info:
     - Alan Sergeant
     - Oliver Frendo
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/openstack/cerebro
-technicalUserPerRegion: null
+technicalUserPerRegion: TCC_CEREBRO_001
 dnsZoneEmail: null


### PR DESCRIPTION
Adding technical TCC_CEREBRO_001 user to all regions in the CCADMIN domain, with the necessary permissions for Cerebro operations.