### PR TITLE
[nova] Bump mariadb dependency to 0.7.5

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.4
+  version: 0.7.5
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.4
+  version: 0.7.5
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.7
@@ -19,12 +19,12 @@ dependencies:
   version: 0.6.0
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.4
+  version: 0.7.5
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.4.4
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:3ef1e64088874f724ef689419bfbfd73d0c67a6fe3a8b0681d942df1eff8e500
-generated: "2022-12-05T11:47:45.209656704+01:00"
+digest: sha256:1bf31d92749db2ee880660bc89da0bc4f7df65fc006178a2741f79cbb2fd4c55
+generated: "2022-12-14T10:59:00.528497183+01:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -8,12 +8,12 @@ dependencies:
   - name: mariadb
     condition: mariadb.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.7.4
+    version: 0.7.5
   - name: mariadb
     alias: mariadb_api
     condition: mariadb_api.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.7.4
+    version: 0.7.5
   - name: mysql_metrics
     condition: mariadb.enabled
     repository: https://charts.eu-de-2.cloud.sap
@@ -31,7 +31,7 @@ dependencies:
     alias: mariadb_cell2
     condition: mariadb_cell2.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.7.4
+    version: 0.7.5
   - name: rabbitmq
     alias: rabbitmq_cell2
     condition: cell2.enabled


### PR DESCRIPTION
This updates the mariadb image version to include security patches.