### PR TITLE
maia: add federation for Keppel metrics

### DIFF
--- a/openstack/maia/templates/etc/_maia_scrape_config.yaml.tpl
+++ b/openstack/maia/templates/etc/_maia_scrape_config.yaml.tpl
@@ -96,6 +96,7 @@
       - '{__name__=~"^openstack_.+",project_id!=""}'
       - '{__name__=~"^limes_(?:project|domain)_(?:quota|usage)$"}'
       - '{__name__=~"^limes_swift_.+",project_id!=""}'
+      - '{__name__=~"^keppel_.+",project_id!=""}'
 
 - job_name: 'prometheus-infra-collector'
   scrape_interval: 1m


### PR DESCRIPTION
Based on a customer request, I added the metric `keppel_manifests_with_unclean_vuln_status_count` in af5e6d6f2. Our pgmetrics end up in prometheus-openstack, so this needs to be federated into Maia.