### PR TITLE
[cc3test] playbook path updated for cinder alert

### DIFF
--- a/openstack/cc3test/alerts/block-storage.alerts
+++ b/openstack/cc3test/alerts/block-storage.alerts
@@ -74,7 +74,7 @@ groups:
       context: '{{ $labels.type }}'
       meta: 'Cinder create volume test fails'
       dashboard: 'cc3test-overview?var-service={{ $labels.service }}'
-      playbook: 'docs/support/playbook/cinder/alerts'
+      playbook: 'docs/support/playbook/cinder/alerts/cc3test-alert-create-volume-shard/'
       report: 'cc3test/admin/object-storage/containers/cc3test/list/reports/{{ $labels.type }}'
     annotations:
       description: 'Cinder create volume test fails: {{ $labels.name }}'


### PR DESCRIPTION
- OpenstackCinderCreateVolumeShardDown
- direct link to the playbook instead of the parent folder
- https://jira.tools.sap/browse/CCC-34265