### PR TITLE
[nova] Unset X-Frame-Options in shellinabox

### DIFF
--- a/openstack/nova/shellinabox/10_default_server.conf
+++ b/openstack/nova/shellinabox/10_default_server.conf
@@ -27,6 +27,8 @@ server {
   proxy_http_version          1.1;
   recursive_error_pages       on;
 
+  add_header "X-Frame-Options"  "";
+
   location = / {
     if ($http_user_agent ~ "^http-keepalive-monitor/") {
       return 301 /status;


### PR DESCRIPTION
The header is set by default in the docker image,
and stops us from using the console in an iframe
as Elektra does.