### PR TITLE
[nova] Unset X-Frame-Options in shellinabox

### DIFF
--- a/openstack/nova/shellinabox/10_default_server.conf
+++ b/openstack/nova/shellinabox/10_default_server.conf
@@ -27,6 +27,10 @@ server {
   proxy_http_version          1.1;
   recursive_error_pages       on;
 
+  # Those options are in place to allow the iframe in elektra
+  add_header "X-Frame-Options"  "";     # Undo what is set in nginx.conf
+  proxy_hide_header "X-Frame-Options";  # Remove it from the upstream server
+
   location = / {
     if ($http_user_agent ~ "^http-keepalive-monitor/") {
       return 301 /status;


### PR DESCRIPTION
The header is set by default in the docker image,
and stops us from using the console in an iframe
as Elektra does.