### PR TITLE
memcached: Move yielded connections alert to info

### DIFF
--- a/common/memcached/Chart.yaml
+++ b/common/memcached/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: memcached
-version: 0.0.11
+version: 0.0.12
 description: Free & open source, high-performance, distributed memory object caching system.
 home: http://memcached.org/
 sources:

--- a/common/memcached/templates/alerts/_memcached.alerts.tpl
+++ b/common/memcached/templates/alerts/_memcached.alerts.tpl
@@ -2,12 +2,12 @@ groups:
 - name: memcached.alerts
   rules:
   - alert: {{ include "alerts.service" . | title }}MemcachedManyConnectionsThrottled
-    expr: (rate(memcached_connections_yielded_total{app="{{ template "fullname" . }}"}[5m]) * 60) > 5
+    expr: (rate(memcached_connections_yielded_total{app="{{ template "fullname" . }}"}[5m]) * 60) > {{ .Values.alerts.yielded_connections_threshold }}
     for: 5m
     labels:
       context: database
       service: {{ include "alerts.service" . }}
-      severity: warning
+      severity: info
       tier: {{ required ".Values.alerts.tier missing" .Values.alerts.tier }}
       support_group: {{ required ".Values.alerts.support_group missing" .Values.alerts.support_group }}
     annotations:

--- a/common/memcached/values.yaml
+++ b/common/memcached/values.yaml
@@ -79,3 +79,7 @@ alerts:
 
   # Configurable service label of the alerts. Defaults to `.Release.Name`.
   # service:
+
+  # Define the threshold for the MemcachedManyConnectionsThrottled alert in
+  # yielded connections per minute
+  yielded_connections_threshold: 5


### PR DESCRIPTION
This alert is not actionable, as it is at best a hint for possible performance degradations - yielded connections are connections doing multiple requests in batches and memcached interrupting to read from that same connection to give other connections a change to get processed and not starve out.

We also make the threshold for the alert configurable as different services might have different thresholds.