### PR TITLE
[Octavia] Annotate migration job as hook

### DIFF
--- a/openstack/octavia/templates/_helpers.tpl
+++ b/openstack/octavia/templates/_helpers.tpl
@@ -32,8 +32,8 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
-Unique DB migration job name
+DB migration job name
 */}}
 {{- define "octavia.migration_job_name" -}}
-octavia-migration-{{ .Values.imageVersion }}-{{- if .Values.proxysql.mode }}{{ .Values.proxysql.mode | replace "_" "-" }}{{ else }}noproxysql{{ end }}
+octavia-migration-{{ .Values.imageVersion }}
 {{- end }}

--- a/openstack/octavia/templates/octavia-migration-job.yaml
+++ b/openstack/octavia/templates/octavia-migration-job.yaml
@@ -1,9 +1,9 @@
 {{/*
    With Helm3, we don't force the replacements of job specs anymore, which
-   causes deployment issues since kuberentes job specs are immutable by default.
-   We solve this by generating an image specific name for every deployment,
-   therefor no job will be replaced. Instead, a new job will be spawned while
-   the old one will be deleted.
+   causes deployment issues since kuberentes job specs are immutable by
+   default.  We solve this by generating an image specific name for every
+   deployment, therefore no job will be replaced. Instead, a new job will be
+   spawned while the old one will be deleted.
 */}}
 apiVersion: batch/v1
 kind: Job
@@ -13,6 +13,12 @@ metadata:
     system: openstack
     type: configuration
     component: octavia
+  annotations:
+    # post-install is necessary so that we can be sure when deploying to a
+    # region for the first time that the DB pod is already running.
+    "helm.sh/hook": "post-install,pre-upgrade"
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   template:
     spec:


### PR DESCRIPTION
This is better than using discriminators (based on image tags) in the job name, since the image tag may not change when other dependencies change.