### PR TITLE
[octavia] Increate limits for containers in octavia-worker pods.

### DIFF
--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -239,17 +239,17 @@ pod:
         cpu: 500m
     driver_agent:
       limits:
-        memory: 256Mi
-        cpu: 100m
+        memory: 512Mi
+        cpu: 1000m
       requests:
-        memory: 100Mi
-        cpu: 50m
+        memory: 256Mi
+        cpu: 500m
     status_manager:
       limits:
         memory: 512Mi
         cpu: 1000m
       requests:
-        memory: 24Mi
+        memory: 256Mi
         cpu: 500m
     statsd:
       limits:


### PR DESCRIPTION
This PR increases limit and request resources for two containers in octavia-worker pod based on graphics because we have CPU throttling and as result OOMkiller kills the containers.