### PR TITLE
[Cinder] Enable independent snapshots by default

### DIFF
--- a/openstack/cinder/templates/etc/_cinder.conf.tpl
+++ b/openstack/cinder/templates/etc/_cinder.conf.tpl
@@ -56,6 +56,7 @@ allocated_capacity_weight_multiplier = {{ .Values.allocated_capacity_weight_mult
 
 allow_migration_on_attach = {{ .Values.cinder_api_allow_migration_on_attach }}
 sap_disable_incremental_backup = {{ .Values.sap_disable_incremental_backup }}
+sap_allow_independent_snapshots = {{ .Values.sap_allow_independent_snapshots }}
 
 {{- include "ini_sections.database" . }}
 

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -91,6 +91,7 @@ allocated_capacity_weight_multiplier: -1.0
 cinder_api_allow_migration_on_attach: True
 
 sap_disable_incremental_backup: True
+sap_allow_independent_snapshots: True
 
 proxysql:
   mode: null # Disabled by default


### PR DESCRIPTION
This patch adds the cinder.conf setting of
sap_allow_independent_snapshots to default to True. This allows all cinder snapshots to go through the scheduler to pick which pool (datastore) the snapshot will live on.