### PR TITLE
[neutron] Optional Log-shipping for dnsmasq

### DIFF
--- a/openstack/neutron/templates/etc/_dhcp-agent.ini.tpl
+++ b/openstack/neutron/templates/etc/_dhcp-agent.ini.tpl
@@ -15,3 +15,6 @@ num_sync_threads = {{.Values.agent.dhcp.num_sync_threads | default 4 }}
 rpc_response_timeout = {{ .Values.rpc_response_timeout | default .Values.global.rpc_response_timeout | default 50 }}
 rpc_workers = {{ .Values.rpc_workers | default .Values.global.rpc_workers | default 5 }}
 rpc_conn_pool_size = {{ .Values.rpc_conn_pool_size | default .Values.global.rpc_conn_pool_size | default 100 }}
+{{- if .Values.dnsmasq_log_export }}
+dnsmasq_base_log_dir = /var/lib/neutron/dhcp
+{{- end }}

--- a/openstack/neutron/templates/statefulset-network-agent-apod.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent-apod.yaml
@@ -71,6 +71,7 @@ spec:
           volumeMounts:
             - name: host
               mountPath: "/host"
+      shareProcessNamespace: true
       containers:
         - name: neutron-dhcp-agent
           image: {{$.Values.global.registry}}/loci-neutron:{{$.Values.imageVersionNetworkAgentDHCP | default $.Values.imageVersionNetworkAgent | default $.Values.imageVersion | required "Please set neutron.imageVersionNetworkAgentDHCP or similar"}}
@@ -116,6 +117,10 @@ spec:
               readOnly: true
             - name: network-namespace
               mountPath: /var/run/netns
+{{- if $.Values.dnsmasq_log_export }}
+            - name: dhcp
+              mountPath: /var/lib/neutron/dhcp
+{{- end }}
         - name: neutron-linuxbridge-agent
           image: {{$.Values.global.registry}}/loci-neutron:{{$.Values.imageVersionNetworkAgentLinuxBridge | default $.Values.imageVersionNetworkAgent | default $.Values.imageVersion | required "Please set neutron.imageVersionNetworkAgentLinuxBridge or similar"}}
           imagePullPolicy: IfNotPresent
@@ -183,6 +188,15 @@ spec:
             - name: etc-neutron-metadata-agent
               mountPath: /etc/neutron
               readOnly: true
+{{- if $.Values.dnsmasq_log_export }}
+        - name: dnsmasq-log-exporter
+          image: {{$.Values.global.registry}}/dnsmasq-log-exporter:{{ $.Values.imageVersionDnsMasqLogExporter | required "Please set .Values.imageVersionDnsMasqLogExporter" }}
+          imagePullPolicy: Present
+          command: ["/app/dnsmasq-log-exporter"]
+          volumeMounts:
+            - name: dhcp
+              mountPath: /var/lib/neutron/dhcp
+{{- end }}
       volumes:
         - name: metadata-proxy
           emptyDir: {}
@@ -258,6 +272,10 @@ spec:
                   path: logging.conf
                 - key: metadata-agent.ini
                   path: metadata-agent.ini
+{{- if $.Values.dnsmasq_log_export }}
+        - name: dhcp
+          emptyDir: {}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/openstack/neutron/templates/statefulset-network-agent.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent.yaml
@@ -80,6 +80,7 @@ spec:
           volumeMounts:
             - name: host
               mountPath: "/host"
+      shareProcessNamespace: true
       containers:
         - name: neutron-dhcp-agent
           image: {{$.Values.global.registry}}/loci-neutron:{{$.Values.imageVersionNetworkAgentDHCP | default $.Values.imageVersionNetworkAgent | default $.Values.imageVersion | required "Please set neutron.imageVersionNetworkAgentDHCP or similar"}}
@@ -154,6 +155,10 @@ spec:
               readOnly: false
             - name: network-namespace
               mountPath: /var/run/netns
+{{- if $.Values.dnsmasq_log_export }}
+            - name: dhcp
+              mountPath: /var/lib/neutron/dhcp
+{{- end }}
 {{- if $.Values.agent.neutron_l3 | default false }}
         - name: neutron-l3-agent
           image: {{$.Values.global.registry}}/loci-neutron:{{$.Values.imageVersionNetworkAgentL3 | default $.Values.imageVersionNetworkAgent | default $.Values.imageVersion | required "Please set neutron.imageVersionNetworkAgentL3 or similar"}}
@@ -272,6 +277,15 @@ spec:
               readOnly: true
             - name: network-namespace
               mountPath: /var/run/netns
+{{- if $.Values.dnsmasq_log_export }}
+        - name: dnsmasq-log-exporter
+          image: {{$.Values.global.registry}}/dnsmasq-log-exporter:{{ $.Values.imageVersionDnsMasqLogExporter | required "Please set .Values.imageVersionDnsMasqLogExporter" }}
+          imagePullPolicy: Present
+          command: ["/app/dnsmasq-log-exporter"]
+          volumeMounts:
+            - name: dhcp
+              mountPath: /var/lib/neutron/dhcp
+{{- end }}
       volumes:
         - name: metadata-proxy
           hostPath:
@@ -290,5 +304,9 @@ spec:
         - name: host
           hostPath:
               path: "/"
+{{- if $.Values.dnsmasq_log_export }}
+        - name: dhcp
+          emptyDir: {}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -182,6 +182,7 @@ imageNameNetworkAgentDHCPInit: alpine
 imageVersionRedis: 7.0.0-alpine
 imageVersionLogstash: 8.2.0
 imageVersionNetworkAgentDHCPInit: 3.8
+imageVersionDnsMasqLogExporter: 20221201T182527Z
 
 api:
   processes: 8
@@ -289,6 +290,8 @@ drivers:
 #    password:
 #    physical_network:
 #    vnic_paths:
+
+dnsmasq_log_export: false
 
 logging:
   formatters:
@@ -598,3 +601,7 @@ agent:
 dnsmasq:
   conf:
     no-negcache: true
+    quiet-dhcp: true
+    quiet-dhcp6: true
+    quiet-ra: true
+    quiet-tftp: true


### PR DESCRIPTION
It depends on the image build from
https://github.com/sapcc/dnsmasq-log-exporter
which prints and rotates the logs from dnsmasq
and prefixes the logs with the network-id