### PR TITLE
[ironic] Enable idrac-redfish and redfish

### DIFF
--- a/openstack/ironic/values.yaml
+++ b/openstack/ironic/values.yaml
@@ -132,17 +132,18 @@ conductor:
     port: 8088
   defaults:
     default:
-      enabled_hardware_types: ipmi
-      enabled_boot_interfaces: pxe, ipxe
+      enabled_hardware_types: ipmi, idrac, redfish
+      enabled_boot_interfaces: pxe, ipxe, idrac-redfish-virtual-media, redfish-virtual-media
+      enabled_bios_interfaces: no-bios, idrac-redfish, redfish
       enabled_deploy_interfaces: direct
-      enabled_inspect_interfaces: inspector,no-inspect
-      enabled_management_interfaces: ipmitool
-      enabled_power_interfaces: ipmitool
-      enabled_console_interfaces: ipmitool-shellinabox,no-console
-      enabled_raid_interfaces: agent,no-raid
+      enabled_inspect_interfaces: inspector, no-inspect
+      enabled_management_interfaces: ipmitool, idrac-redfish, redfish
+      enabled_power_interfaces: ipmitool, idrac-redfish, redfish
+      enabled_console_interfaces: no-console, ipmitool-shellinabox, idrac-redfish-kvm
+      enabled_raid_interfaces: no-raid, agent, idrac-redfish, redfish
+      enabled_vendor_interfaces: no-vendor, ipmitool, idrac-redfish, redfish
       enabled_network_interfaces: neutron
       enabled_storage_interfaces: cinder,noop
-      enabled_vendor_interfaces: ipmitool
 
       # enables collecting metrics for rpc calls
       statsd_enabled: false


### PR DESCRIPTION
Since it is working in some regions, we might as well open the option to enable it in all regions.

We still need to configure it on a host-by-host
basis, so the impact of this change is close to zero by itself.