### PR TITLE
[nova] memcached alert becomes info-level and less triggery

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 0.4.4
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.0.11
+  version: 0.0.12
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.6.0
@@ -26,5 +26,5 @@ dependencies:
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:bdf3201b9e314db72a2cf456cd83d947c11eee7e94751adcec6af06586b8b4d0
-generated: "2022-11-04T14:55:09.128180194+01:00"
+digest: sha256:3ef1e64088874f724ef689419bfbfd73d0c67a6fe3a8b0681d942df1eff8e500
+generated: "2022-12-05T11:47:45.209656704+01:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
     version: 0.4.4
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.0.11
+    version: 0.0.12
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.6.0

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -888,6 +888,7 @@ cors:
 memcached:
   alerts:
     support_group: compute-storage-api
+    yielded_connections_threshold: 100
 
 owner-info:
   support-group: compute-storage-api


### PR DESCRIPTION
This reduces the alert-level to info by updating the memcached chart and also sets the threshold for triggering the alert in Nova to a higher threshold, because looking at the current levels we didn't see any service degradation.