### PR TITLE
[nova] Set password_all_group_samples to 2

### DIFF
--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -898,3 +898,6 @@ owner-info:
     - Marius Leustean
     - Jakob Karge
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/openstack/nova
+
+default:
+  password_all_group_samples: 2


### PR DESCRIPTION
With ESXi ignoring an upper-case character at the start and a number at the end of a password for counting the used and required character classes, we need to use every class at least twice to make the password fit the policy. Nova recently added code to make this possible, so we're setting the password_all_group_samples setting here to enable it.