### PR TITLE
[Cinder] Enable independent clone by default

### DIFF
--- a/openstack/cinder/templates/etc/_cinder.conf.tpl
+++ b/openstack/cinder/templates/etc/_cinder.conf.tpl
@@ -57,6 +57,7 @@ allocated_capacity_weight_multiplier = {{ .Values.allocated_capacity_weight_mult
 allow_migration_on_attach = {{ .Values.cinder_api_allow_migration_on_attach }}
 sap_disable_incremental_backup = {{ .Values.sap_disable_incremental_backup }}
 sap_allow_independent_snapshots = {{ .Values.sap_allow_independent_snapshots }}
+sap_allow_independent_clone = {{ .Values.sap_allow_independent_clone }}
 
 {{- include "ini_sections.database" . }}
 

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -92,6 +92,7 @@ cinder_api_allow_migration_on_attach: True
 
 sap_disable_incremental_backup: True
 sap_allow_independent_snapshots: True
+sap_allow_independent_clone: True
 
 proxysql:
   mode: null # Disabled by default


### PR DESCRIPTION
This patch updates the cinder helm chart to enable the new cinder ability to allow independent cinder clones. This means that volumes created from another volume can be scheduled on a different pool (datastore) on the same backend as the source volume.

By default cinder doesn't allow this.