### PR TITLE
keystone: avoid dns dependency for 2faproxy

### DIFF
--- a/openstack/keystone/templates/deployment-2faproxy.yaml
+++ b/openstack/keystone/templates/deployment-2faproxy.yaml
@@ -35,6 +35,8 @@ spec:
             - -exclude-domain={{ $domain }}
             {{- end}}
           env:
+            - value: OS_AUTH_URL
+              name: "http://$(KEYSTONE_SERVICE_HOST):$(KEYSTONE_SERVICE_PORT)/v3"
           {{- range $key, $value :=  index .Values "2fa" "openstack" }}
             - name: {{ $key }}
               valueFrom: { secretKeyRef: { name: {{ $.Release.Name }}-2faproxy, key: {{ $key }} } }


### PR DESCRIPTION
We used to inject http://keystone.monsoon3.svc.kubernetes.qa-de-2.cloud.sap:5000/v3 via secrets but this requires a dns lookup and a working coredns in the clusters.

By using the service ip directly we remove a dependency and make the keystone datapath more robust