### PR TITLE
vmware-monitoring: improved maia federation query

### DIFF
--- a/system/vmware-monitoring/Chart.yaml
+++ b/system/vmware-monitoring/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vmware-monitoring
-version: 1.0.11
+version: 1.0.12
 description: VMware Monitoring and Metrics Collection
 dependencies:
   - name: prometheus-server

--- a/system/vmware-monitoring/templates/_helper.tpl
+++ b/system/vmware-monitoring/templates/_helper.tpl
@@ -34,6 +34,14 @@ prometheus-vmware-{{ $vropshostname._0 | trimPrefix "vrops-" }}
 {{- end -}}
 
 {{- define "maiaFederationMatches" -}}
-{{- range $.Values.maiaFederation.matches -}}.*{{- . | trimPrefix "vrops_virtualmach" -}}|
+vrops_virtualmachine_(?:
+{{- range .Values.maiaFederation.matches -}}
+{{- . | trimPrefix "vrops_virtualmachine_" -}}|
+{{- end -}}
+){{- if .Values.maiaFederation.neo.enabled }}|vrops_hostsystem_(?:
+{{- range .Values.maiaFederation.neo.matches -}}
+{{- . | trimPrefix "vrops_hostsystem_" -}}|
+{{- end -}}
+)
 {{- end -}}
 {{- end -}}

--- a/system/vmware-monitoring/templates/servicemonitors/maia-federation.yaml
+++ b/system/vmware-monitoring/templates/servicemonitors/maia-federation.yaml
@@ -20,8 +20,7 @@ spec:
     scrapeTimeout: 55s
     params:
       match[]:
-        - '{__name__=~"{{- include "maiaFederationMatches" $root | trimSuffix "|" }}",
-        project!~"internal", vccluster!~".*management.*"}'
+        - '{__name__=~"{{- include "maiaFederationMatches" $root }}", project!~"internal", vccluster!~".*management.*"}'
   jobLabel: {{ include "prometheusVMware.name" (list $target $root) }}
   selector:
     matchLabels:

--- a/system/vmware-monitoring/values.yaml
+++ b/system/vmware-monitoring/values.yaml
@@ -264,7 +264,7 @@ vrops:
 maiaFederation:
   enabled: true
   # to avoid HTTP 400 Bad Request (request header too long) with GET /federate
-  # the metrics are trimmed with `vrops_virtualmach` and combined into one query
+  # the metrics prefixes are truncated and combined to one query
   matches:
     - vrops_virtualmachine_config_hardware_memory_kilobytes
     - vrops_virtualmachine_cpu_contention_ratio
@@ -300,3 +300,12 @@ maiaFederation:
     - vrops_virtualmachine_virtual_disk_average.+
     - vrops_virtualmachine_virtual_disk_read_kilobytes_per_second
     - vrops_virtualmachine_virtual_disk_write_kilobytes_per_second
+
+  neo:
+    enabled: false
+    matches:
+      - vrops_hostsystem_cpu_model
+      - vrops_hostsystem_cpu_sockets_number
+      - vrops_hostsystem_cpu_usage_average_percentage
+      - vrops_hostsystem_memory_ballooning_kilobytes
+      - vrops_hostsystem_memory_contention_percentage


### PR DESCRIPTION
Improved maia federation query to increase comprehension.

`{__name__=~"vrops_virtualmachine_(?:config_hardware_memory_kilobytes|cpu_contention_ratio|cpu_demand_ratio|cpu_usage_ratio|cpu_usage_average_mhz|cpu_wait_summation_miliseconds|datastore_outstanding_io_requests|disk_usage_average_kilobytes_per_second|diskspace_gigabytes|diskspace_virtual_machine_used_gigabytes|guest_os_full_name_info|guest_tools_version_info|memory_active_ratio|memory_activewrite_kilobytes|memory_balloning_ratio|memory_consumed_kilobytes|memory_contention_ratio|memory_usage_average|network_data_received_kilobytes_per_second|network_data_transmitted_kilobytes_per_second|network_packets_dropped.+|network_packets.+|network_usage_average_kilobytes_per_second|number_vcpus_total|oversized.+|runtime_connectionstate|runtime_powerstate|summary_ethernetcards|swapin_memory_kilobytes|swapped_memory_kilobytes|undersized.+|virtual_disk_average.+|virtual_disk_read_kilobytes_per_second|virtual_disk_write_kilobytes_per_second|)",project!~"internal", vccluster!~".*management.*"}`