### PR TITLE
[unbound] enable infra-keep-probing reduce host ttl from 15 to 10 mins.

### DIFF
--- a/system/unbound/templates/config.yaml
+++ b/system/unbound/templates/config.yaml
@@ -26,7 +26,12 @@ data:
 
         cache-max-negative-ttl: 100
         cache-max-ttl: 28800
-        
+
+        # time to live for entries in the host cache incl roundtrip timing
+        infra-host-ttl: 600
+        # to keep probing hosts that were marked down
+        infra-keep-probing: yes
+
         # more cache memory (default is 4m), rrset=msg*2
         rrset-cache-size: 100m
         msg-cache-size: 50m


### PR DESCRIPTION
by default hosts that are down, eg. they did not respond during the one probe  at  a  time period,  are  marked as down and it may take infra-host-ttl time to get probed again.