### PR TITLE
Ironic: Add Cronjob to manage BMC certs

### DIFF
--- a/openstack/ironic/templates/redfish-certrobot-cronjob.yaml
+++ b/openstack/ironic/templates/redfish-certrobot-cronjob.yaml
@@ -1,0 +1,62 @@
+{{- define "_values_to_env" }}
+{{- $prefix := index . 1 }}
+    {{- with $map := index . 0 }}
+        {{- $keys := keys $map | sortAlpha }}
+        {{- range $_, $k := $keys }}
+            {{- $path := append $prefix $k }}
+            {{- $v := get $map $k }}
+            {{- if kindIs "map" $v }}
+                {{- tuple $v $path | include "_values_to_env" }}
+            {{- else }}
+- name: {{ $path | join "_" | upper }}
+{{- if kindIs "slice" $v }}
+  value: {{ $v | join "," }}
+{{- else }}
+  value: {{ $v }}
+{{- end }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+
+{{- define "values_to_env" }}
+{{- tuple . (list) | include "_values_to_env" }}
+{{- end }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-redfish-certrobot
+spec:
+  schedule: {{ .Values.cert_robot.schedule | quote }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: redfish-certrobot
+            image: {{ .Values.global.registry }}/redfish-certrobot:{{ .Values.cert_robot.image_tag }}
+            imagePullPolicy: IfNotPresent
+            command:
+            - python
+            - -m
+            - redfish_certrobot
+            env:
+            - name: OS_CLIENT_SECURE_FILE # gophercloud doesn't interprete that variable, but openstacksdk does
+              value: "/etc/openstack/sdk.yaml"
+            {{- include "values_to_env" .Values.cert_robot.env | indent 12 }}
+            volumeMounts:
+            - name: config
+              mountPath: "/etc/openstack"
+              readOnly: true
+          volumes:
+          - name: config
+            projected:
+              sources:
+              - secret:
+                  name: {{ .Release.Name }}-redfish-certrobot
+                  items:
+                  - key: common
+                    path: clouds.yaml
+                  - key: sdk
+                    path: sdk.yaml

--- a/openstack/ironic/templates/redfish-certrobot-secret.yaml
+++ b/openstack/ironic/templates/redfish-certrobot-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-redfish-certrobot
+type: Opaque
+stringData:
+  common: |
+{{ toYaml .Values.cert_robot.cloud_common | indent 4 }}
+  sdk: |
+{{ toYaml .Values.cert_robot.cloud_sdk | indent 4 }}

--- a/openstack/ironic/values.yaml
+++ b/openstack/ironic/values.yaml
@@ -31,6 +31,36 @@ debug: "True"
 
 kos_conductor: true
 
+cert_robot:
+  image_tag: "latest"
+  schedule: "@weekly"
+  env:
+    issuer:
+    dns_resolvers:
+    acme_server:
+    csr:
+      country:
+      state:
+      city:
+      organization:
+      organizational_unit:
+    os_cloud: default  # Needs to match the name of the cloud in cloud_common and cloud_secure
+  cloud_common:
+    clouds:
+      default:
+        auth:
+          auth_url: http://keystone:5000/v3
+          username:
+          password:
+          user_domain_name: ccadmin
+          project_name: master
+          project_domain_name: ccadmin
+  cloud_sdk:
+    clouds:
+      default:
+        auth:
+          project_name: cloud_admin
+
 tempest:
   enabled: false
 


### PR DESCRIPTION
The cronjob runs a script, which checks
the certificates and replaces them, if
- the issuer is not matching an expected one
- the common name or the SAN is not matching/containing the hostname
- the expiry date is within a certain grace period