### PR TITLE
[Cinder] Update mariadb chart to 0.7.5

### DIFF
--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.4.2
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.1
+  version: 0.7.5
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.7
@@ -20,5 +20,5 @@ dependencies:
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:66c372bd10d2f6ab12af71e1d67c3a88798d70b5f735c3701f5efed54fc855a7
-generated: "2022-10-24T10:04:41.776463357+02:00"
+digest: sha256:0ccd707309af4734b8c9d43730fabf79c4e9cfed3607eab86bd67c1074a587d9
+generated: "2023-01-05T09:20:53.023039-05:00"

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
     version: 0.4.2
   - name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.7.1
+    version: 0.7.5
     condition: mariadb.enabled
   - name: mysql_metrics
     repository: https://charts.eu-de-2.cloud.sap


### PR DESCRIPTION
This patch updates the mariadb chart to 0.7.5 for cinder.