### PR TITLE
[alertmanager/kubernikus] inhibit dependent kubernikus alerts

### DIFF
--- a/global/prometheus-alertmanager-operated/templates/_alertmanager.yaml.tpl
+++ b/global/prometheus-alertmanager-operated/templates/_alertmanager.yaml.tpl
@@ -46,6 +46,11 @@ inhibit_rules:
       inhibited_by: node-maintenance
     equal: ['node']
 
+  - source_matchers: [alertname="KubernikusKlusterLowOnObjectStoreQuota"]
+    target_matchers: [alertname="KubernikusEtcdBackupFailed"]
+    equal: ['kluster_name']
+
+
 route:
   group_by: ['region', 'service', 'alertname', 'cluster', 'support_group']
   group_wait: 1m

--- a/system/kubernikus-monitoring/alerts/kluster.alerts
+++ b/system/kubernikus-monitoring/alerts/kluster.alerts
@@ -64,6 +64,7 @@ groups:
       severity: warning
       meta: "Kluster {{ $labels.kluster_name }} is low on object-store quota"
       playbook: docs/support/playbook/kubernikus/low_object_store_quota.html
+      kluster_name: {{ $labels.kluster_name | default "KubernikusKlusterLowOnObjectStoreQuota_kluster_name_label_missing"}}
     annotations:
       summary: "Kluster {{ $labels.kluster_name }} is low on object-store quota"
       description: "Kluster {{ $labels.kluster_name }} in `{{ $labels.domain }}/{{ $labels.project }}` has *{{ humanize1024 $value }}B* of object-store quota left. If the quota is exhausted the etcd backup of the cluster will fail. This can also cause an outage. The project admin needs to raise quota or free up space. <https://dashboard.{{ $externalLabels.region }}.cloud.sap/_/{{ $labels.project_id }}/masterdata-cockpit/project|Masterdata>, cluster creator:  <https://people.wdf.sap.corp/profiles/{{$labels.creator}}|{{$labels.creator}}>"

--- a/system/kubernikus-monitoring/alerts/operator.alerts
+++ b/system/kubernikus-monitoring/alerts/operator.alerts
@@ -106,6 +106,7 @@ groups:
       context: kluster
       meta: "Latest etcd backup for kluster {{ $labels.release }} older than 2h"
       playbook: 'docs/support/playbook/kubernikus/etcd_backup_failed.html'
+      kluster_name: {{ $labels.release | default "KubernikusEtcdBackupFailed_release_label_missing"}}
     annotations:
       description: Backup of etcd is failing for kluster {{ $labels.release }}. Latest full backup is older then 2 hours.
       summary: Etcd backup error for kluster {{ $labels.release }}


### PR DESCRIPTION
Adds `kluster_name` label to the following alerts:
`KubernikusKlusterLowOnObjectStoreQuota` and `KubernikusEtcdBackupFailed`
Labels are added with defaults, to prevent matching missing labels

Inhibits `KubernikusEtcdBackupFailed` on matching `KubernikusKlusterLowOnObjectStoreQuota`