### PR TITLE
[prometheus] dedicated seed deployment

### DIFF
--- a/common/prometheus-server/CHANGELOG.md
+++ b/common/prometheus-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.1.17
+
+* Dedicated thanos seed deployment to support various clusters. Seeds are going to be deployed in metal only. 
+
 ## 7.1.15 - 7.1.16
 
 * remoteWrite alerting added

--- a/common/prometheus-server/Chart.yaml
+++ b/common/prometheus-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus via operator.
 name: prometheus-server
-version: 7.1.16
+version: 7.1.17
 appVersion: v2.39.1
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
 maintainers:

--- a/common/prometheus-server/templates/_helpers.tpl
+++ b/common/prometheus-server/templates/_helpers.tpl
@@ -6,7 +6,7 @@
 {{- fail "Cannot create any Prometheus resource. Please define a name or at least one list element to names or global.targets" -}}
 {{- end -}}
 {{/* vmware prometheis need additional renaming */}}
-{{- if $root.Values.vmware -}}
+{{- if or $root.Values.vmware $root.Values.thanosSeeds.vmware -}}
 {{- include "vmwareRenaming" $name -}}
 {{- else -}}
 {{- $name -}}
@@ -127,18 +127,18 @@ prometheus-{{- $name -}}.{{- required "$root.Values.global.region missing" $root
 {{- end -}}
 
 {{- define "thanos.projectName" -}}
-{{- if .Values.thanos.swiftStorageConfig.tenantName }}
-{{- .Values.thanos.swiftStorageConfig.tenantName | quote -}}
+{{- if .Values.thanosSeeds.swiftStorageConfig.tenantName }}
+{{- .Values.thanosSeeds.swiftStorageConfig.tenantName | quote -}}
 {{- else -}}
-{{- required ".Values.thanos.swiftStorageConfig.projectName missing" .Values.thanos.swiftStorageConfig.projectName | quote -}}
+{{- required ".Values.thanosSeeds.swiftStorageConfig.projectName missing" .Values.thanosSeeds.swiftStorageConfig.projectName | quote -}}
 {{- end -}}
 {{- end -}}
 
 {{- define "thanos.projectDomainName" -}}
-{{- if .Values.thanos.swiftStorageConfig.projectDomainName -}}
-{{- .Values.thanos.swiftStorageConfig.projectDomainName | quote -}}
+{{- if .Values.thanosSeeds.swiftStorageConfig.projectDomainName -}}
+{{- .Values.thanosSeeds.swiftStorageConfig.projectDomainName | quote -}}
 {{- else -}}
-{{- required ".Values.thanos.swiftStorageConfig.domainName missing" .Values.thanos.swiftStorageConfig.domainName | quote -}}
+{{- required ".Values.thanosSeeds.swiftStorageConfig.domainName missing" .Values.thanosSeeds.swiftStorageConfig.domainName | quote -}}
 {{- end -}}
 {{- end -}}
 

--- a/common/prometheus-server/templates/thanos/thanos-seed.yaml
+++ b/common/prometheus-server/templates/thanos/thanos-seed.yaml
@@ -1,0 +1,39 @@
+{{- $root := . }}
+{{- if and .Values.thanos.enabled .Values.thanosSeeds.seed.enabled }}
+{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+---
+apiVersion: "openstack.stable.sap.cc/v1"
+kind: OpenstackSeed
+metadata:
+  name: {{ include "prometheus.name" (list $name $root) }}-thanos
+  labels:
+    prometheus: {{ include "prometheus.name" (list $name $root) }}
+
+spec:
+  {{ if $.Values.thanosSeeds.seed.requires }}
+  requires:
+{{ toYaml $.Values.thanosSeeds.seed.requires | indent 4 }}
+  {{ end }}
+
+  domains:
+    - name: {{ required "$.Values.thanosSeeds.swiftStorageConfig.userDomainName missing" $.Values.thanosSeeds.swiftStorageConfig.userDomainName }}
+      users:
+        - name: {{ include "swift.userName" (list $name $root) }}
+          description: Thanos Service User
+          password: {{ required "$.Values.thanosSeeds.swiftStorageConfig.password missing" $.Values.thanosSeeds.swiftStorageConfig.password | quote }}
+          role_assignments:
+            - project: service
+              role:    service
+
+    - name: {{ required "$.Values.thanosSeeds.swiftStorageConfig.domainName missing" $.Values.thanosSeeds.swiftStorageConfig.domainName }}
+      projects:
+        - name: {{ include "thanos.projectName" $root }}
+          role_assignments:
+            # Read/write permission to $domain/$project containers.
+            - user: {{ include "swift.userName" (list $name $root) }}@{{ required "$.Values.thanosSeeds.swiftStorageConfig.userDomainName missing" $.Values.thanosSeeds.swiftStorageConfig.userDomainName }}
+              role: objectstore_admin
+          swift:
+            containers:
+              - name: {{ include "swift.userName" (list $name $root) }}
+{{- end }}
+{{- end }}

--- a/common/prometheus-server/values.yaml
+++ b/common/prometheus-server/values.yaml
@@ -193,10 +193,25 @@ serviceAccount:
 thanos:
   # Enables Prometheus sidecar. This is now the default setting for global monitoring integration.
   # Only disable this, if you don't want to have your Prometheus being queried by global Thanos.
+  # Important: needed thanos swift seed configuration is provided by system/thanos-seeds and specified with thanosSeeds below
   enabled: true
 
-  # Deploy an OpenstackSeed custom resource triggering creation of an Openstack user and Swift container used to persist Prometheus metrics.
-  # See: https://github.com/sapcc/kubernetes-operators/tree/master/openstack-seeder
+  objectStorageConfig:
+    # Note:
+    # The name of the secret specified below will be prefixed with `prometheus-<name>`
+    # to avoid multiple configurations with the same name.
+    name: thanos-storage-config
+    key: thanos.yaml
+    optional: true
+
+  # Specification for Thanos sidecar to Prometheus server.
+  # See https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#thanosspec .
+  spec:
+    baseImage: keppel.eu-de-1.cloud.sap/ccloud-quay-mirror/thanos/thanos
+    version: v0.26.0
+
+# no impact to this chart. system/thanos-seeds is incorporating this and sharing the same values file
+thanosSeeds:
   seed:
     # If disabled the user and container need to exist.
     enabled: true
@@ -209,6 +224,8 @@ thanos:
       - monsoon3/domain-default-seed
 
   # Configuration for OpenStack Swift Thanos storage backend.
+  # Deploy an OpenstackSeed custom resource triggering creation of an Openstack user and Swift container used to persist Prometheus metrics.
+  # See: https://github.com/sapcc/kubernetes-operators/tree/master/openstack-seeder
   swiftStorageConfig:
     authURL:
     userDomainName:
@@ -226,19 +243,8 @@ thanos:
     # domainID:
     # userID:
 
-  objectStorageConfig:
-    # Note:
-    # The name of the secret specified below will be prefixed with `prometheus-<name>`
-    # to avoid multiple configurations with the same name.
-    name: thanos-storage-config
-    key: thanos.yaml
-    optional: true
-
-  # Specification for Thanos sidecar to Prometheus server.
-  # See https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#thanosspec .
-  spec:
-    baseImage: keppel.eu-de-1.cloud.sap/ccloud-quay-mirror/thanos/thanos
-    version: v0.26.0
+  # needs to be enabled for vmware-monitoring only
+  vmware: false
 
 # The labels to add to any time series or alerts when communicating with
 # external systems (federation, remote storage, Alertmanager).

--- a/common/prometheus-server/values.yaml
+++ b/common/prometheus-server/values.yaml
@@ -210,10 +210,9 @@ thanos:
     baseImage: keppel.eu-de-1.cloud.sap/ccloud-quay-mirror/thanos/thanos
     version: v0.26.0
 
-# no impact to this chart. system/thanos-seeds is incorporating this and sharing the same values file
 thanosSeeds:
   seed:
-    # If disabled the user and container need to exist.
+    # If disabled the user and container need to exist, or you are in another cluster but metal. In this case leverage the dedicated system/thanos-seeds chart instead of this default, prometheus-bundled seed.
     enabled: true
 
     # List of required OpenstackSeeds that need to be resolved before.

--- a/system/thanos-seeds/.helmignore
+++ b/system/thanos-seeds/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/system/thanos-seeds/Chart.yaml
+++ b/system/thanos-seeds/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: thanos-seeds
+description: dedicated seed deployment needed for thanos-sidecar in prometheus
+version: 0.0.1
+dependencies:
+  - name: owner-info
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 0.2.0

--- a/system/thanos-seeds/ci/test-values.yaml
+++ b/system/thanos-seeds/ci/test-values.yaml
@@ -1,0 +1,25 @@
+global:
+  region: regionOne
+  tld: evil.corp
+  clusterType: controlplane
+  cluster: x-regionOne
+  tier: alertTierKubernetes
+
+
+name: bestThanos
+thanosSeeds:
+  swiftStorageConfig:
+    authURL: https://keystone.evil.corp/v3
+    userName: prometheus
+    userDomainName: Default
+    password: topSecret!
+    domainName: Default
+    tenantName: master
+    regionName: regionOne
+    containerName: regionOnePrometheusThanos
+  queryDiscovery: true
+  GRPCClientCA: itrustyou
+  GRPCClientCertificate:
+    certificate: ihavebeentrusted
+    privateKey: seriously
+  vmware: true

--- a/system/thanos-seeds/templates/_helpers.tpl
+++ b/system/thanos-seeds/templates/_helpers.tpl
@@ -1,0 +1,1 @@
+../../../common/prometheus-server/templates/_helpers.tpl

--- a/system/thanos-seeds/templates/seed.yaml
+++ b/system/thanos-seeds/templates/seed.yaml
@@ -1,5 +1,4 @@
 {{- $root := . }}
-{{- if and .Values.thanos.enabled .Values.thanos.seed.enabled }}
 {{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
 ---
 apiVersion: "openstack.stable.sap.cc/v1"
@@ -10,30 +9,29 @@ metadata:
     prometheus: {{ include "prometheus.name" (list $name $root) }}
 
 spec:
-  {{ if $.Values.thanos.seed.requires }}
+  {{ if $.Values.thanosSeeds.seed.requires }}
   requires:
-{{ toYaml $.Values.thanos.seed.requires | indent 4 }}
+{{ toYaml $.Values.thanosSeeds.seed.requires | indent 4 }}
   {{ end }}
 
   domains:
-    - name: {{ required "$.Values.thanos.swiftStorageConfig.userDomainName missing" $.Values.thanos.swiftStorageConfig.userDomainName }}
+    - name: {{ required "$.Values.thanosSeeds.swiftStorageConfig.userDomainName missing" $.Values.thanosSeeds.swiftStorageConfig.userDomainName }}
       users:
         - name: {{ include "swift.userName" (list $name $root) }}
           description: Thanos Service User
-          password: {{ required "$.Values.thanos.swiftStorageConfig.password missing" $.Values.thanos.swiftStorageConfig.password | quote }}
+          password: {{ required "$.Values.thanosSeeds.swiftStorageConfig.password missing" $.Values.thanosSeeds.swiftStorageConfig.password | quote }}
           role_assignments:
             - project: service
               role:    service
 
-    - name: {{ required "$.Values.thanos.swiftStorageConfig.domainName missing" $.Values.thanos.swiftStorageConfig.domainName }}
+    - name: {{ required "$.Values.thanosSeeds.swiftStorageConfig.domainName missing" $.Values.thanosSeeds.swiftStorageConfig.domainName }}
       projects:
         - name: {{ include "thanos.projectName" $root }}
           role_assignments:
             # Read/write permission to $domain/$project containers.
-            - user: {{ include "swift.userName" (list $name $root) }}@{{ required "$.Values.thanos.swiftStorageConfig.userDomainName missing" $.Values.thanos.swiftStorageConfig.userDomainName }}
+            - user: {{ include "swift.userName" (list $name $root) }}@{{ required "$.Values.thanosSeeds.swiftStorageConfig.userDomainName missing" $.Values.thanosSeeds.swiftStorageConfig.userDomainName }}
               role: objectstore_admin
           swift:
             containers:
               - name: {{ include "swift.userName" (list $name $root) }}
-{{- end }}
 {{- end }}

--- a/system/thanos-seeds/values.yaml
+++ b/system/thanos-seeds/values.yaml
@@ -1,0 +1,47 @@
+owner-info:
+  support-group: observability
+  maintainers:
+    - Tommy Sauer
+    - Richard Tief
+  helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/system/thanos-seeds
+
+# this shart shared the regional values file with the respective prometheus
+# global:
+  # targets:
+
+name:
+
+thanosSeeds:
+  seed:
+    # If disabled the user and container need to exist.
+    enabled: true
+
+    # List of required OpenstackSeeds that need to be resolved before.
+    # Warning: This list is rather specific to SAP Converged Cloud.
+    requires:
+      - swift/swift-seed
+      - monsoon3/domain-ccadmin-seed
+      - monsoon3/domain-default-seed
+
+  # Configuration for OpenStack Swift Thanos storage backend.
+  # Deploy an OpenstackSeed custom resource triggering creation of an Openstack user and Swift container used to persist Prometheus metrics.
+  # See: https://github.com/sapcc/kubernetes-operators/tree/master/openstack-seeder
+  swiftStorageConfig:
+    authURL:
+    userDomainName:
+    password:
+    domainName:
+    projectName:
+    projectDomainName:
+    # all settings below are not mandatory and auto-generated
+    userName:
+    regionName:
+    containerName:
+
+    # Currently not supported are:
+    # tenantID:
+    # domainID:
+    # userID:
+
+  # needs to be enabled for vmware-monitoring only
+  vmware: false


### PR DESCRIPTION
introduced system/thanos-seeds chart
prometheus-server is not taking care of seed deployment anymore. prometheus-server helpers changed to meet requirements. helper file is used by system/thanos-seeds too. new directive introduced thanosSeeds