### PR TITLE
use smons for prometheus-infra-frontend

### DIFF
--- a/system/prometheus-infra/Chart.yaml
+++ b/system/prometheus-infra/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus-infra
 description: Prometheus Infrastructure Monitoring - A Helm chart for the operated regional Prometheus Frontend for monitoring infrastructure.
-version: 2.0.5
+version: 2.0.6
 dependencies:
   - name: prometheus-server
     alias: prometheus-infra-frontend

--- a/system/prometheus-infra/alerts/prometheus.alerts
+++ b/system/prometheus-infra/alerts/prometheus.alerts
@@ -2,7 +2,7 @@ groups:
 - name: prometheus.alerts
   rules:
   - alert: InfrastructurePrometheusFederationFailed
-    expr: absent(up{job=~"prometheus-infra-collector|prometheus-vmware"}) or up{job=~"prometheus-infra-collector|prometheus-vmware"} == 0
+    expr: absent(up{job=~"prometheus-infra-collector|prometheus-vmware.*"}) or up{job=~"prometheus-infra-collector|prometheus-vmware.*"} == 0
     for: 15m
     labels:
       meta: Infrastructure Prometheus (Scaleout) can't federate data from infra-collector or vmware prometheus in {{ $labels.region }}

--- a/system/prometheus-infra/templates/_prometheus-infra.yaml.tpl
+++ b/system/prometheus-infra/templates/_prometheus-infra.yaml.tpl
@@ -1,3 +1,4 @@
+{{ if not .Values.migration_done }}
 - job_name: 'prometheus-vmware'
   scheme: https
   scrape_interval: {{ .Values.collector.scrapeInterval }}
@@ -28,6 +29,7 @@
   static_configs:
     - targets:
       - "prometheus-vmware.{{ .Values.global.region }}.cloud.sap"
+{{- end }}
 
 - job_name: 'prometheus-infra-snmp'
   scheme: https

--- a/system/prometheus-infra/values.yaml
+++ b/system/prometheus-infra/values.yaml
@@ -90,3 +90,7 @@ bastion:
   enabled: false
   scrapeInterval: 2m
   scrapeTimeout: 115s
+
+# migration to thanos directives
+# it removes the scrapeconfig and the job, therefore the respective alert
+migration_done: false

--- a/system/vmware-monitoring/Chart.yaml
+++ b/system/vmware-monitoring/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vmware-monitoring
-version: 1.0.22
+version: 1.0.23
 description: VMware Monitoring and Metrics Collection
 dependencies:
   - name: prometheus-server

--- a/system/vmware-monitoring/templates/servicemonitors/infra-frontend.yaml
+++ b/system/vmware-monitoring/templates/servicemonitors/infra-frontend.yaml
@@ -5,7 +5,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    ccloud/support-group: observability
     prometheus: infra-frontend 
   name: {{ include "prometheusVMware.name" (list $target $root) }}
   namespace: vmware-monitoring
@@ -18,23 +17,10 @@ spec:
     scheme: http
     scrapeTimeout: 55s
     params:
-  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    interval: 60s
-    path: federate
-    port: http
-    scheme: http
-    scrapeTimeout: 55s
-    params:
       match[]:
         - '{job="vrops-exporter",__name__!~"^vrops_virtualmachine_.*", __name__!~"^(up|ALERTS.*|scrape.+)"}'
         - '{job="vrops-exporter",__name__=~"^vrops_virtualmachine_.*", vccluster=~".*management.*", __name__!~"^(up|ALERTS.*|scrape.+)"}'
         - '{job="vrops-inventory-exporter", __name__!~"^(up|ALERTS.*|scrape.+)"}'
-    metricRelabelings:
-    - action: replace
-      sourceLabels: [__address__]
-      targetLabel: region
-      regex: prometheus-vmware.(.+).cloud.sap
-      replacement: $1
 
   jobLabel: {{ include "prometheusVMware.fullName" (list $target $root) }}
   selector:

--- a/system/vmware-monitoring/templates/servicemonitors/infra-frontend.yaml
+++ b/system/vmware-monitoring/templates/servicemonitors/infra-frontend.yaml
@@ -1,0 +1,43 @@
+{{- $root := . }}
+{{- range $target := .Values.global.targets }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    ccloud/support-group: observability
+    prometheus: infra-frontend 
+  name: {{ include "prometheusVMware.name" (list $target $root) }}
+  namespace: vmware-monitoring
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 60s
+    path: federate
+    port: http
+    scheme: http
+    scrapeTimeout: 55s
+    params:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 60s
+    path: federate
+    port: http
+    scheme: http
+    scrapeTimeout: 55s
+    params:
+      match[]:
+        - '{job="vrops-exporter",__name__!~"^vrops_virtualmachine_.*", __name__!~"^(up|ALERTS.*|scrape.+)"}'
+        - '{job="vrops-exporter",__name__=~"^vrops_virtualmachine_.*", vccluster=~".*management.*", __name__!~"^(up|ALERTS.*|scrape.+)"}'
+        - '{job="vrops-inventory-exporter", __name__!~"^(up|ALERTS.*|scrape.+)"}'
+    metricRelabelings:
+    - action: replace
+      sourceLabels: [__address__]
+      targetLabel: region
+      regex: prometheus-vmware.(.+).cloud.sap
+      replacement: $1
+
+  jobLabel: {{ include "prometheusVMware.fullName" (list $target $root) }}
+  selector:
+    matchLabels:
+      prometheus: {{ include "prometheusVMware.name" (list $target $root) }}
+{{- end }}


### PR DESCRIPTION
* as we are in the same cluster, we deploy service monitors instead of directly instrumenting the federation target instance (prometheus-infra-frontend)
* federation will be in place until it is fully replaced by thanos everywhere