### PR TITLE
elastiflow: drop unnecessary privileges on initContainer

### DIFF
--- a/system/elastiflow/values.yaml
+++ b/system/elastiflow/values.yaml
@@ -5,8 +5,10 @@ owner-info:
     - "Ivo Gosemann"
   helm-chart-url: "https://github.com/sapcc/helm-charts/tree/master/system/elastiflow"
 
+# Deploy Prometheus alerts.
 alerts:
   enabled: false
+  # Name of the Prometheus to which the alerts should be assigned to.
   prometheus: infra-frontend
 
 curator:
@@ -349,9 +351,3 @@ kibana:
   #     memory: 4Gi
   #   limits:
   #     memory: 5Gi
-
-# Deploy Prometheus alerts.
-alerts:
-  enabled: false
-  # Name of the Prometheus to which the alerts should be assigned to.
-  prometheus: infra-frontend

--- a/system/elastiflow/values.yaml
+++ b/system/elastiflow/values.yaml
@@ -139,7 +139,6 @@ elasticsearch:
     - name: configure-ownership
       securityContext:
         runAsUser: 0
-        privileged: true
       image: "{{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ .Values.global.elastic.image}}:{{ .Values.global.elastic.tag}}"
       imagePullPolicy: "{{ .Values.imagePullPolicy }}"
       command: ["sh", "-c", "mkdir -p /usr/share/elasticsearch/data && chown -R 1000:1000 /usr/share/elasticsearch/data"]
@@ -185,7 +184,6 @@ elasticsearch-data:
     - name: configure-ownership
       securityContext:
         runAsUser: 0
-        privileged: true
       image: "{{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ .Values.global.elastic.image}}:{{ .Values.global.elastic.tag}}"
       imagePullPolicy: "{{ .Values.imagePullPolicy }}"
       command: ["sh", "-c", "mkdir -p /usr/share/elasticsearch/data && chown -R 1000:1000 /usr/share/elasticsearch/data"]


### PR DESCRIPTION
This init container only changes file permissions on a mounted volume. It does not need to run in privileged mode as far as I can see.