### PR TITLE
I544510 pxalerting

### DIFF
--- a/system/infra-monitoring/vendor/px-exporter/px.alerts/px.alerts
+++ b/system/infra-monitoring/vendor/px-exporter/px.alerts/px.alerts
@@ -44,7 +44,7 @@ groups:
 
   - alert: PXTransportRouterBgpDown
     expr: bird_protocol_up{name!~"kernel.", peer_type="TP"} == 0
-    for: 0s
+    for: 60m
     labels:
       severity: critical
       tier: net
@@ -56,6 +56,19 @@ groups:
       description:  The BGP session from {{ $labels.name }} to {{ $labels.app }} is lost. Redundancy is lost for route server clients peering that route server.
       summary:  The BGP session from {{ $labels.name }} to {{ $labels.app }} is lost. Redundancy is lost for route server clients peering that route server.
 
+  - alert: PXTransportAllRouterBgpDown
+    expr: count(bird_protocol_up{name!~"kernel.", peer_type="TP"}) by (app) - sum(bird_protocol_up{name!~"kernel.", peer_type="TP"} ==bool 0) by (app) == 0 
+    for: 1m
+    labels:
+      severity: critical
+      tier: net
+      service: px
+      context: px
+      playbook: docs/devops/alert/network/px.html#PXTransportRouterBgpDown
+      dashboard: px-control-plane
+    annotations:
+      description:  All BGP sessions from {{ $labels.name }} to PX service {{$labels.pxservice}} in domain {{$labels.pxdomain}} are lost. All route server client peerings are down.
+      summary:  All BGP sessions from {{ $labels.name }} are lost. All route server client peerings in domain {{$labels.pxdomain}} on service {{$labels.pxservice}} are down.
 
   - alert: PXTransportRouterPrefixImportCountZero
     expr: (sum(bird_protocol_up{peer_type="PL"}) by (app, ip_version, proto, pxdomain, pxinstance, pxservice) > 0 ) + on (app, ip_version, proto, pxdomain, pxinstance, pxservice) group_right() bird_protocol_prefix_import_count{name!~"kernel.", peer_type="TP"} <= 0 

--- a/system/infra-monitoring/vendor/px-exporter/px.alerts/px.alerts
+++ b/system/infra-monitoring/vendor/px-exporter/px.alerts/px.alerts
@@ -64,7 +64,7 @@ groups:
       tier: net
       service: px
       context: px
-      playbook: docs/devops/alert/network/px.html#PXTransportRouterBgpDown
+      playbook: docs/devops/alert/network/px.html#PXTransportAllRouterBgpDown
       dashboard: px-control-plane
     annotations:
       description:  All BGP sessions from {{ $labels.name }} to PX service {{$labels.pxservice}} in domain {{$labels.pxdomain}} are lost. All route server client peerings are down.


### PR DESCRIPTION
 [PX] Adjust transport router down alert

The PXTransportRouterBgpDown fires upon loss of at least one peering to
he transport router. To reduce the number of self healing alerts the
alert fires now after 60 minutes.

Additionally, we add PXTransportAllRouterBgpDown as another cirtical
alert firing after 1 minute. This alert triggers when connectivity to
all transport routers is lost.

