### PR TITLE
common/prometheus-server: order of coalescence corrected

### DIFF
--- a/common/prometheus-server/CHANGELOG.md
+++ b/common/prometheus-server/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 7.1.21
+
+ * Order of coalescence corrected
+
 ## 7.1.20
 
- * option to set support_group for alerts
+ * Option to set support_group for alerts
 
 ## 7.1.19
 

--- a/common/prometheus-server/Chart.yaml
+++ b/common/prometheus-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus via operator.
 name: prometheus-server
-version: 7.1.20
+version: 7.1.21
 appVersion: v2.39.1
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
 maintainers:

--- a/common/prometheus-server/templates/alertmanager-config.yaml
+++ b/common/prometheus-server/templates/alertmanager-config.yaml
@@ -1,6 +1,6 @@
 {{- $root := . }}
 {{- if .Values.alertmanagers.hosts }}
-{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+{{- range $name := coalesce .Values.names (list .Values.name) .Values.global.targets }}
 ---
 apiVersion: v1
 kind: Secret

--- a/common/prometheus-server/templates/alertmanager-sso-secret.yaml
+++ b/common/prometheus-server/templates/alertmanager-sso-secret.yaml
@@ -1,6 +1,6 @@
 {{- $root := . }}
 {{- if .Values.alertmanagers.authentication.enabled }}
-{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+{{- range $name := coalesce .Values.names (list .Values.name) .Values.global.targets }}
 ---
 apiVersion: v1
 kind: Secret

--- a/common/prometheus-server/templates/alerts/prometheus-alerts.yaml
+++ b/common/prometheus-server/templates/alerts/prometheus-alerts.yaml
@@ -1,6 +1,6 @@
 {{- $root := . }}
 {{- if .Values.alertmanagers.hosts }}
-{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+{{- range $name := coalesce .Values.names (list .Values.name) .Values.global.targets }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule

--- a/common/prometheus-server/templates/alerts/prometheus-thanos-alerts.yaml
+++ b/common/prometheus-server/templates/alerts/prometheus-thanos-alerts.yaml
@@ -1,6 +1,6 @@
 {{- $root := . }}
 {{- if and .Values.alertmanagers.hosts .Values.thanos.enabled }}
-{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+{{- range $name := coalesce .Values.names (list .Values.name) .Values.global.targets }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule

--- a/common/prometheus-server/templates/cluster-role-binding.yaml
+++ b/common/prometheus-server/templates/cluster-role-binding.yaml
@@ -1,6 +1,6 @@
 {{- $root := . }}
 {{- if .Values.rbac.create }}
-{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+{{- range $name := coalesce .Values.names (list .Values.name) .Values.global.targets }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/common/prometheus-server/templates/cluster-role.yaml
+++ b/common/prometheus-server/templates/cluster-role.yaml
@@ -1,6 +1,6 @@
 {{- $root := . }}
 {{- if .Values.rbac.create }}
-{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+{{- range $name := coalesce .Values.names (list .Values.name) .Values.global.targets }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/common/prometheus-server/templates/ingress-internal.yaml
+++ b/common/prometheus-server/templates/ingress-internal.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.internalIngress.enabled }}
 {{- $root := . }}
-{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+{{- range $name := coalesce .Values.names (list .Values.name) .Values.global.targets }}
 ---
 {{- if $root.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1

--- a/common/prometheus-server/templates/ingress.yaml
+++ b/common/prometheus-server/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled }}
 {{- $thanos := .Values.thanos }}
 {{- $root := . }}
-{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+{{- range $name := coalesce .Values.names (list .Values.name) .Values.global.targets }}
 ---
 {{- if $root.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1

--- a/common/prometheus-server/templates/podmonitors/kube-dns.yaml
+++ b/common/prometheus-server/templates/podmonitors/kube-dns.yaml
@@ -1,6 +1,6 @@
 {{- $root := . }}
 {{- if .Values.serviceDiscoveries.kubeDNS.enabled }}
-{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+{{- range $name := coalesce .Values.names (list .Values.name) .Values.global.targets }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor

--- a/common/prometheus-server/templates/podmonitors/pod-sd.yaml
+++ b/common/prometheus-server/templates/podmonitors/pod-sd.yaml
@@ -1,6 +1,6 @@
 {{- $root := . }}
 {{- if .Values.serviceDiscoveries.pods.enabled }}
-{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+{{- range $name := coalesce .Values.names (list .Values.name) .Values.global.targets }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor

--- a/common/prometheus-server/templates/prometheus-server.yaml
+++ b/common/prometheus-server/templates/prometheus-server.yaml
@@ -1,5 +1,5 @@
 {{- $root := . }}
-{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+{{- range $name := coalesce .Values.names (list .Values.name) .Values.global.targets  }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: Prometheus

--- a/common/prometheus-server/templates/service-account.yaml
+++ b/common/prometheus-server/templates/service-account.yaml
@@ -1,6 +1,6 @@
 {{- $root := . }}
 {{- if and .Values.rbac.create .Values.serviceAccount.create }}
-{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+{{- range $name := coalesce .Values.names (list .Values.name) .Values.global.targets }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/common/prometheus-server/templates/service.yaml
+++ b/common/prometheus-server/templates/service.yaml
@@ -1,5 +1,5 @@
 {{- $root := . }}
-{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+{{- range $name := coalesce .Values.names (list .Values.name) .Values.global.targets }}
 ---
 apiVersion: v1
 kind: Service

--- a/common/prometheus-server/templates/servicemonitors/apiserver.yaml
+++ b/common/prometheus-server/templates/servicemonitors/apiserver.yaml
@@ -1,6 +1,6 @@
 {{- $root := . }}
 {{- if .Values.serviceDiscoveries.kubeAPIServer.enabled }}
-{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+{{- range $name := coalesce .Values.names (list .Values.name) .Values.global.targets }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/common/prometheus-server/templates/servicemonitors/cadvisor.yaml
+++ b/common/prometheus-server/templates/servicemonitors/cadvisor.yaml
@@ -1,6 +1,6 @@
 {{- $root := . }}
 {{- if .Values.serviceDiscoveries.cAdvisor.enabled }}
-{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+{{- range $name := coalesce .Values.names (list .Values.name) .Values.global.targets }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/common/prometheus-server/templates/servicemonitors/endpoint-sd.yaml
+++ b/common/prometheus-server/templates/servicemonitors/endpoint-sd.yaml
@@ -1,6 +1,6 @@
 {{- $root := . }}
 {{- if .Values.serviceDiscoveries.endpoints.enabled }}
-{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+{{- range $name := coalesce .Values.names (list .Values.name) .Values.global.targets }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/common/prometheus-server/templates/servicemonitors/kubelet.yaml
+++ b/common/prometheus-server/templates/servicemonitors/kubelet.yaml
@@ -1,6 +1,6 @@
 {{- $root := . }}
 {{- if .Values.serviceDiscoveries.kubelet.enabled }}
-{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+{{- range $name := coalesce .Values.names (list .Values.name) .Values.global.targets }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/common/prometheus-server/templates/servicemonitors/node-exporter.yaml
+++ b/common/prometheus-server/templates/servicemonitors/node-exporter.yaml
@@ -1,6 +1,6 @@
 {{- $root := . }}
 {{- if .Values.serviceDiscoveries.nodeExporter.enabled }}
-{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+{{- range $name := coalesce .Values.names (list .Values.name) .Values.global.targets }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/common/prometheus-server/templates/servicemonitors/prometheus.yaml
+++ b/common/prometheus-server/templates/servicemonitors/prometheus.yaml
@@ -1,5 +1,5 @@
 {{- $root := . }}
-{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+{{- range $name := coalesce .Values.names (list .Values.name) .Values.global.targets }}
 ---
 # This ServiceMonitor is used for monitoring the Prometheus itself and - if enabled - its Thanos sidecar deployed alongside.
 apiVersion: monitoring.coreos.com/v1

--- a/common/prometheus-server/templates/thanos/thanos-config-secret.yaml
+++ b/common/prometheus-server/templates/thanos/thanos-config-secret.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.thanos.enabled }}
 {{- $root := . }}
-{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+{{- range $name := coalesce .Values.names (list .Values.name) .Values.global.targets }}
 ---
 apiVersion: v1
 kind: Secret

--- a/common/prometheus-server/templates/thanos/thanos-seed.yaml
+++ b/common/prometheus-server/templates/thanos/thanos-seed.yaml
@@ -1,6 +1,6 @@
 {{- $root := . }}
 {{- if and .Values.thanos.enabled .Values.thanosSeeds.seed.enabled }}
-{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+{{- range $name := coalesce .Values.names (list .Values.name) .Values.global.targets }}
 ---
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: OpenstackSeed

--- a/common/prometheus-server/templates/vpa.yaml
+++ b/common/prometheus-server/templates/vpa.yaml
@@ -1,5 +1,5 @@
 {{- $root := . }}
-{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+{{- range $name := coalesce .Values.names (list .Values.name) .Values.global.targets }}
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler


### PR DESCRIPTION
The order can cause the targets to be preferred to the set name. For example, if a prometheus needs the targets additionally as for scrape jobs, multiple prometheus instances of the targets are created by default. What is not wanted.