### PR TITLE
[infra-prom] removes dedicated apic-exporter scrape job

### DIFF
--- a/system/infra-monitoring/templates/_prometheus-infra-collector.yaml.tpl
+++ b/system/infra-monitoring/templates/_prometheus-infra-collector.yaml.tpl
@@ -525,21 +525,6 @@
       action: keep
 {{- end }}
 
-{{- $values := .Values.apic_exporter -}}
-{{- if $values.enabled }}
-- job_name: 'apic-exporter'
-  scrape_interval: {{$values.scrapeInterval}}
-  scrape_timeout: {{$values.scrapeTimeout}}
-  static_configs:
-    - targets:
-      - 'apic-exporter:9102'
-  metrics_path: /
-  relabel_configs:
-    - source_labels: [job]
-      regex: apic-exporter
-      action: keep
-{{- end }}
-
 {{- range $name, $app := .Values.netapp_cap_exporter.apps }}
 - job_name: '{{ $app.fullname }}'
   scrape_interval: {{ required ".Values.netapp_cap_exporter.apps[].scrapeInterval" $app.scrapeInterval }}


### PR DESCRIPTION
The apic-exporter is scraped by a servicemonitor. I believe this is a leftover from the previous version of the exporter