### PR TITLE
[rabbitmq] add support for rabbitmq-prometheus

### DIFF
--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 0.4.4
+version: 0.5.0
 description: A Helm chart for RabbitMQ
 sources:
 - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/templates/bin/_rabbitmq-start.tpl
+++ b/common/rabbitmq/templates/bin/_rabbitmq-start.tpl
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+{{- if and .Values.metrics.enabled (ne .Values.metrics.sidecar.enabled true) .Values.metrics.port }}
+echo "prometheus.tcp.port = {{ .Values.metrics.port }}" >> /etc/rabbitmq/conf.d/10-defaults.conf
+{{- end}}
 LOCKFILE=/var/lib/rabbitmq/rabbitmq-server.lock
 echo "Starting RabbitMQ with lock ${LOCKFILE}"
 exec 9>${LOCKFILE}

--- a/common/rabbitmq/templates/deployment.yaml
+++ b/common/rabbitmq/templates/deployment.yaml
@@ -87,12 +87,16 @@ spec:
             containerPort: {{ default "5672" .Values.ports.public }}
           - name: management
             containerPort: {{ default "15672" .Values.ports.management }}
+{{- if and (ne .Values.metrics.sidecar.enabled true) .Values.metrics.enabled }}
+          - name: metrics
+            containerPort: {{ default "15692" .Values.metrics.port }}
+{{- end }}
         volumeMounts:
           - mountPath: /var/lib/rabbitmq
             name: rabbitmq-persistent-storage
           - mountPath: /container.init
             name: container-init
-{{- if .Values.metrics.enabled }}
+{{- if and .Values.metrics.sidecar.enabled .Values.metrics.enabled }}
       - name: metrics
         image: {{include "dockerHubMirror" .}}/{{ .Values.metrics.image }}:{{ .Values.metrics.imageTag }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.metrics.imagePullPolicy | quote }}

--- a/common/rabbitmq/templates/statefulset.yaml
+++ b/common/rabbitmq/templates/statefulset.yaml
@@ -79,12 +79,16 @@ spec:
             containerPort: {{ default "5672" .Values.ports.public }}
           - name: management
             containerPort: {{ default "15672" .Values.ports.management }}
+{{- if and (ne .Values.metrics.sidecar.enabled true) .Values.metrics.enabled }}
+          - name: metrics
+            containerPort: {{ default "15692" .Values.metrics.port }}
+{{- end }}
         volumeMounts:
           - mountPath: /var/lib/rabbitmq
             name: rabbitmq-persistent-storage
           - mountPath: /container.init
             name: container-init
-{{- if .Values.metrics.enabled }}
+{{- if and .Values.metrics.sidecar.enabled .Values.metrics.enabled }}
       - name: metrics
         image: {{include "dockerHubMirror" .}}/{{ .Values.metrics.image }}:{{ .Values.metrics.imageTag }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.metrics.imagePullPolicy | quote }}

--- a/common/rabbitmq/values.yaml
+++ b/common/rabbitmq/values.yaml
@@ -69,7 +69,9 @@ resources:
 nodeAffinity: {}
 
 metrics:
-  enabled: true
+  enabled: &metrics true
+  sidecar:
+    enabled: *metrics
   image: kbudde/rabbitmq-exporter
   imageTag: 0.16.0
   user: monitoring


### PR DESCRIPTION
added switcher to activate rabbitmq-prometheus plugin instead of the side car exporter. to activate collect metrics with plugin please set your values to:
```
metrics:
  port: 9150
  enabled: false
  sidecar:
    enabled: false
```

RabbitMQ-prometheus plugin provides different naming schema of the metrics as the side car RabbitMQ exporter.
  metrics can be found: https://github.com/rabbitmq/rabbitmq-prometheus/blob/master/metrics.md

default values still using metrics sidecar exporter