### PR TITLE
volume-claims: remove PVCs from ap-sa-2 that did not exist there before

### DIFF
--- a/openstack/volume-claims/templates/db-nova-pvclaim.yaml
+++ b/openstack/volume-claims/templates/db-nova-pvclaim.yaml
@@ -1,3 +1,4 @@
+{{- if ne .Values.global.region "ap-sa-2" }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -12,3 +13,4 @@ spec:
   resources:
     requests:
       storage: 10Gi
+{{- end }}

--- a/openstack/volume-claims/templates/glance-pvclaim.yaml
+++ b/openstack/volume-claims/templates/glance-pvclaim.yaml
@@ -1,3 +1,4 @@
+{{- if ne .Values.global.region "ap-sa-2" }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -12,3 +13,4 @@ spec:
   resources:
     requests:
       storage: 10Gi
+{{- end }}

--- a/openstack/volume-claims/templates/kvm-shared1-pvclaim.yaml
+++ b/openstack/volume-claims/templates/kvm-shared1-pvclaim.yaml
@@ -1,3 +1,4 @@
+{{- if ne .Values.global.region "ap-sa-2" }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -12,3 +13,4 @@ spec:
   resources:
     requests:
       storage: 500Gi
+{{- end }}

--- a/openstack/volume-claims/templates/rabbitmq-pvclaim.yaml
+++ b/openstack/volume-claims/templates/rabbitmq-pvclaim.yaml
@@ -1,3 +1,4 @@
+{{- if ne .Values.global.region "ap-sa-2" }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -11,3 +12,4 @@ spec:
   resources:
     requests:
       storage: 10Gi
+{{- end }}


### PR DESCRIPTION
While we're at it, some handover instructions for you:
* The first version was created by adopting the left-over remains of the Helm-2-era region charts. The chart was generated to match the existing PVCs, hence why there are some rather bizarre if-statements in the templating.
* There is no pipeline for this. My process so far was to review diffs and then apply with:
  ```
  h diff upgrade volume-claims . --color --set global.region="$(u8s env | awk -F= '/U8S_CONTEXT/{print$2}')"
  h upgrade volume-claims . --set global.region="$(u8s env | awk -F= '/U8S_CONTEXT/{print$2}')"
  ```