### PR TITLE
[sap-seeds] Fix cores-per-socket for HANA flavors

### DIFF
--- a/openstack/sap-seeds/templates/_flavors_hana_exclusive.tpl
+++ b/openstack/sap-seeds/templates/_flavors_hana_exclusive.tpl
@@ -8,6 +8,7 @@
     "hw_video:ram_max_mb": "16"
     "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "required"
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
+    "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
 - name: "hana_c48_m729"
   id: "301"
   vcpus: 48
@@ -18,6 +19,7 @@
     "hw_video:ram_max_mb": "16"
     "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "required"
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
+    "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
 - name: "hana_c96_m1458"
   id: "302"
   vcpus: 96
@@ -28,6 +30,7 @@
     "hw_video:ram_max_mb": "16"
     "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "required"
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
+    "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
 - name: "hana_c144_m2188"
   id: "303"
   vcpus: 144
@@ -38,7 +41,7 @@
     "hw_video:ram_max_mb": "16"
     "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "required"
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
-    "hw:cpu_cores": "2"
+    "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
     "vmware:hw_version": "vmx-18"
 - name: "hana_c192_m2917"
   id: "304"
@@ -50,7 +53,7 @@
     "hw_video:ram_max_mb": "16"
     "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "required"
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
-    "hw:cpu_cores": "2"
+    "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
     "vmware:hw_version": "vmx-18"
 - name: "hana_c384_m5835"
   id: "305"
@@ -62,7 +65,7 @@
     "hw_video:ram_max_mb": "16"
     "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "required"
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
-    "hw:cpu_cores": "3"
+    "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
     "vmware:hw_version": "vmx-18"
 - name: "hana_c288_m4377"
   id: "311"
@@ -74,7 +77,7 @@
     "hw_video:ram_max_mb": "16"
     "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "required"
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
-    "hw:cpu_cores": "3"
+    "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
     "vmware:hw_version": "vmx-18"
 - name: "hana_c448_m11671"
   id: "313"
@@ -86,7 +89,7 @@
     "hw_video:ram_max_mb": "16"
     "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "required"
     "trait:CUSTOM_NUMASIZE_C56_M1459": "required"
-    "hw:cpu_cores": "4"
+    "hw:cpu_cores": "56"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
     "vmware:hw_version": "vmx-18"
 
 {{- if .Values.hana_exclusive_contains_legacy_bigvm_flavors }}

--- a/openstack/sap-seeds/templates/_flavors_hana_no_exclusive.tpl
+++ b/openstack/sap-seeds/templates/_flavors_hana_no_exclusive.tpl
@@ -8,6 +8,7 @@
     "hw_video:ram_max_mb": "16"
     "resources:CUSTOM_MEMORY_RESERVABLE_MB": "373352"
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
+    "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24vCPU => 48pCPU)
 - name: "hana_c48_m729"
   id: "301"
   vcpus: 48
@@ -18,6 +19,7 @@
     "hw_video:ram_max_mb": "16"
     "resources:CUSTOM_MEMORY_RESERVABLE_MB": "746720"
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
+    "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24vCPU => 48pCPU)
 - name: "hana_c96_m1458"
   id: "302"
   vcpus: 96
@@ -29,6 +31,7 @@
     "resources:CUSTOM_MEMORY_RESERVABLE_MB": "1493460"
     "resources:CUSTOM_BIGVM": "2"
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
+    "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24vCPU => 48pCPU)
 - name: "hana_c144_m2188"
   id: "303"
   vcpus: 144
@@ -40,7 +43,7 @@
     "resources:CUSTOM_MEMORY_RESERVABLE_MB": "2240196"
     "resources:CUSTOM_BIGVM": "2"
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
-    "hw:cpu_cores": "2"
+    "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24vCPU => 48pCPU)
     "vmware:hw_version": "vmx-15"
 - name: "hana_c192_m2917"
   id: "304"
@@ -53,7 +56,7 @@
     "resources:CUSTOM_MEMORY_RESERVABLE_MB": "2986936"
     "resources:CUSTOM_BIGVM": "2"
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
-    "hw:cpu_cores": "2"
+    "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24vCPU => 48pCPU)
     "vmware:hw_version": "vmx-15"
 - name: "hana_c384_m5835"
   id: "305"
@@ -66,7 +69,7 @@
     "resources:CUSTOM_MEMORY_RESERVABLE_MB": "5975024"
     "resources:CUSTOM_BIGVM": "2"
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
-    "hw:cpu_cores": "3"
+    "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24vCPU => 48pCPU)
     "vmware:hw_version": "vmx-18"
 - name: "hana_c288_m4377"
   id: "311"
@@ -79,7 +82,7 @@
     "resources:CUSTOM_MEMORY_RESERVABLE_MB": "4481528"
     "resources:CUSTOM_BIGVM": "2"
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
-    "hw:cpu_cores": "3"
+    "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24vCPU => 48pCPU)
     "vmware:hw_version": "vmx-18"
 
 ### Deprecated BigVM flavors


### PR DESCRIPTION
Nova's VMware driver uses the number given in `hw:cpu_cores` to set the CoresPerSocket VMware setting for the VM[1]. While I think that's probably a misunderstanding of what CoresPerSocket means by the original author (description in [2], compare with "numCoresPerSocket" in [3]), and should probably be fixed in the driver, let's do the quick fix first and adjust the values for the flavors.

We thus use the NUMA node CPU number for the HANA flavors, which means 48 for most HANA flavors/BBs and 56 for the 12TiB flavors & BBs. This aligns with the trait names CUSTOM_NUMASIZE_C48_M729 and CUSTOM_NUMASIZE_C56_M1459 respectively.

Also, add the same "hw:cpu_cores" for all smaller HANA flavors, because otherwise they too get smeared all over the sockets and who wants to clean that mess up, really.

[1] https://github.com/sapcc/nova/blob/de8710b/nova/virt/vmwareapi/vmops.py#L468
[2] https://review.opendev.org/c/openstack/nova/+/187942
[3] https://vdc-repo.vmware.com/vmwb-repository/dcr-public/6b586ed2-655c-49d9-9029-bc416323cb22/fa0b429a-a695-4c11-b7d2-2cbc284049dc/doc/vim.vm.VirtualHardware.html
