### PR TITLE
elektra: use new common/pgbackup chart

### DIFF
--- a/openstack/elektra/Chart.lock
+++ b/openstack/elektra/Chart.lock
@@ -2,11 +2,14 @@ dependencies:
 - name: postgresql
   repository: file://../../common/postgresql
   version: 0.3.0
+- name: pgbackup
+  repository: https://charts.eu-de-2.cloud.sap
+  version: 0.1.2
 - name: pgmetrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.3.1
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:a0bd0c8af2e2c462df6b06da7a5a56430b0f8c132cf40d7d9c9f5cf622b08c8d
-generated: "2022-10-21T15:31:33.862763+02:00"
+digest: sha256:635ed4421903fe5057e7ba2ab21da70e95cae71a839d38c73ebcbdf2f7adc149
+generated: "2023-01-23T16:56:48.54563029+01:00"

--- a/openstack/elektra/Chart.yaml
+++ b/openstack/elektra/Chart.yaml
@@ -6,8 +6,11 @@ dependencies:
   - name: postgresql
     repository: "file://../../common/postgresql"
     version: 0.3.0
+  - name: pgbackup
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 0.1.2
   - name: pgmetrics
-    repository: "https://charts.eu-de-2.cloud.sap"
+    repository: https://charts.eu-de-2.cloud.sap
     version: 0.3.1
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap

--- a/openstack/elektra/values.yaml
+++ b/openstack/elektra/values.yaml
@@ -75,20 +75,16 @@ postgresql:
       cpu: "400m"
 
   backup:
-    enabled: true
-    image: keppel.eu-de-1.cloud.sap/ccloud/backup-tools
-    imageTag: v0.6.5
-    custom_repository: true
-    resources:
-      enabled: true
-      limits:
-        memory: "1.5Gi"
-        cpu: "300m"
-      requests:
-        memory: "1.5Gi"
-        cpu: "300m"
+    enabled: false # uses new pgbackup chart instead
+
   probe_timeout_secs: 10 # instead of 3
 
+  alerts:
+    support_group: containers
+
+pgbackup:
+  database:
+    name: monsoon-dashboard_production
   alerts:
     support_group: containers
 


### PR DESCRIPTION
This bumps backup-tools from 0.6.5 to 0.7.0 and moves it into a separate pod, so it can be upgraded in the future without having to restart the postgres container. It also gets adjusted resource limits with a significantly increased CPU limit, meaning that individual backups should take less time to create in the future. The RAM limit is significantly decreased, however, since the backup container never uses more than around 150 MiB in practice.

This new setup is already deployed and tested in my own services (Castellum, Keppel, Limes and Tenso).

Merge this together with the respective companion PR in cc/secrets.