### PR TITLE
[sap-seeds] Fix cores-per-socket > total cores

### DIFF
--- a/openstack/sap-seeds/templates/_flavors_hana_exclusive.tpl
+++ b/openstack/sap-seeds/templates/_flavors_hana_exclusive.tpl
@@ -8,7 +8,7 @@
     "hw_video:ram_max_mb": "16"
     "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "required"
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
-    "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
+    "hw:cpu_cores": "24"  # used in nova-vmware as cores-per-socket (12pCPU = 24vCPU)
 - name: "hana_c48_m729"
   id: "301"
   vcpus: 48

--- a/openstack/sap-seeds/templates/_flavors_hana_no_exclusive.tpl
+++ b/openstack/sap-seeds/templates/_flavors_hana_no_exclusive.tpl
@@ -8,7 +8,7 @@
     "hw_video:ram_max_mb": "16"
     "resources:CUSTOM_MEMORY_RESERVABLE_MB": "373352"
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
-    "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
+    "hw:cpu_cores": "24"  # used in nova-vmware as cores-per-socket (12pCPU = 24vCPU)
 - name: "hana_c48_m729"
   id: "301"
   vcpus: 48


### PR DESCRIPTION
If `hw:cpu_cores` is larger than the amount of actual CPUs in the flavor our topology is not even suggested in `nova/virt/hardware.py`, and the variant with maximum cores (i.e. cores-per-socket = 1) is selected by nova instead.

Fix the half-socket flavor `hana_c24_m365` to only request 24 cores-per-socket through the `hw:cpu_cores` extra spec.
