### PR TITLE
[elastiflow] enables sflow

### DIFF
--- a/system/elastiflow/ci/test-values.yaml
+++ b/system/elastiflow/ci/test-values.yaml
@@ -5,3 +5,5 @@ global:
   metis:
     user: test
     password: test123
+elastic:
+  password: test123

--- a/system/elastiflow/templates/filebeat-deployment.yaml
+++ b/system/elastiflow/templates/filebeat-deployment.yaml
@@ -17,6 +17,7 @@ spec:
     metadata:
       labels:
         app: elastiflow-filebeat
+        component: "event-receiver"
         chart: "{{ .Chart.Name }}"
         heritage: {{ .Release.Service | quote }}
         release: {{ .Release.Name | quote }}
@@ -43,7 +44,8 @@ spec:
         image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.filebeat.image variable missing" .Values.filebeat.image }}:{{ required ".Values.filebeat.imageTag variable missing" .Values.filebeat.imageTag }}
       {{- end }}
         ports:
-          - containerPort: 2055
+          - name: netflow-udp
+            containerPort: 2055
             protocol: UDP
         env:
           - name: LOGSTASH_HOSTS

--- a/system/elastiflow/templates/filebeat-service.yaml
+++ b/system/elastiflow/templates/filebeat-service.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   type: {{ .Values.filebeat.service.type }}
   selector:
-    app: "elastiflow-filebeat"
+    component: "event-receiver"
     chart: "{{ .Chart.Name }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}

--- a/system/elastiflow/values.yaml
+++ b/system/elastiflow/values.yaml
@@ -309,7 +309,11 @@ filebeat:
     ports:
       - name: netflow-udp
         port: 2055
-        targetPort: 2055
+        targetPort: netflow-udp
+        protocol: UDP
+      - name: sflow-udp
+        port: 6343
+        targetPort: sflow-udp
         protocol: UDP
   resources:
     requests:

--- a/system/elastiflow/vendor/logstash/templates/statefulset.yaml
+++ b/system/elastiflow/vendor/logstash/templates/statefulset.yaml
@@ -39,6 +39,7 @@ spec:
       name: "{{ template "logstash.fullname" . }}"
       labels:
         app: "{{ template "logstash.fullname" . }}"
+        component: "event-receiver"
         chart: "{{ .Chart.Name }}"
         heritage: {{ .Release.Service | quote }}
         release: {{ .Release.Name | quote }}

--- a/system/elastiflow/vendor/logstash/values.yaml
+++ b/system/elastiflow/vendor/logstash/values.yaml
@@ -130,6 +130,9 @@ extraPorts:
   - name: beats-tcp
     containerPort: 5044
     protocol: TCP
+  - name: sflow-udp
+    containerPort: 6343
+    protocol: UDP
 
 updateStrategy: RollingUpdate
 


### PR DESCRIPTION
Testing one service for both sflow and netflow events. With the named ports the traffic for sflow should be forwarded to logstash and the netflow events should be send to the logstash