### PR TITLE
[alertmanager] Inhibit dependent kubernikus alerts

### DIFF
--- a/global/prometheus-alertmanager-operated/Chart.yaml
+++ b/global/prometheus-alertmanager-operated/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 description: Prometheus Alertmanager via operator.
 name: prometheus-alertmanager-operated
-version: 2.1.16
+version: 2.1.18
 
 dependencies:
   - alias: prometheus-alertmanager

--- a/global/prometheus-alertmanager-operated/templates/_alertmanager.yaml.tpl
+++ b/global/prometheus-alertmanager-operated/templates/_alertmanager.yaml.tpl
@@ -46,6 +46,11 @@ inhibit_rules:
       inhibited_by: node-maintenance
     equal: ['node']
 
+  # Inhibit specific KubernikusEtcdBackupFailed alert if KubernikusKlusterLowOnObjectStoreQuota is firing
+  - source_matchers: [alertname="KubernikusKlusterLowOnObjectStoreQuota"]
+    target_matchers: [alertname="KubernikusEtcdBackupFailed"]
+    equal: ['kluster_name']
+
 route:
   group_by: ['region', 'service', 'alertname', 'cluster', 'support_group']
   group_wait: 1m


### PR DESCRIPTION
Inhibits `KubernikusEtcdBackupFailed` if `KubernikusKlusterLowOnObjectStoreQuota`

Necessary label `kluster_name` on the alerts is deployed:
E.g.

https://alertmanager.scaleout.eu-de-1.cloud.sap/#/alerts?silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22KubernikusKlusterLowOnObjectStoreQuota%22%7D

https://alertmanager.scaleout.eu-de-1.cloud.sap/#/alerts?silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22KubernikusEtcdBackupFailed%22%7D