### PR TITLE
Corrected broken link for NVMeDataStoreAlmostFullyUtilised

### DIFF
--- a/prometheus-rules/prometheus-vmware-rules/alerts/datastore.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/datastore.alerts
@@ -182,7 +182,7 @@ groups:
       context: "{{ $labels.datastore }}"
       meta: "NVMe datastore {{ $labels.datastore }} is used over 90%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})"
       dashboard: vcenter-datastore-utilization
-      playbook: docs/devops/alert/vcenter.html#nvme-swap-disk-is-reaching-90-1
+      playbook: docs/devops/alert/vcenter.html#nvme-swap-disk-is-reaching-90
     annotations:
       description: "NVMe datastore {{ $labels.datastore }} is used over 90%. Consider to move VMs. ({{ $labels.vcenter }}, {{ $labels.datacenter }})"
       summary: "NVMe datastore {{ $labels.datastore }} is used over 90%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})"


### PR DESCRIPTION
The alert was pointing to a non-existing link. Corrected it that it jumps to the correct playbook.