### PR TITLE
lyra: use new common/pgbackup chart

### DIFF
--- a/openstack/lyra/Chart.lock
+++ b/openstack/lyra/Chart.lock
@@ -5,8 +5,11 @@ dependencies:
 - name: postgresql
   repository: file://../../common/postgresql
   version: 0.3.0
+- name: pgbackup
+  repository: https://charts.eu-de-2.cloud.sap
+  version: 0.1.2
 - name: pgmetrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.3.1
-digest: sha256:e13dc40543a1fab766f6971f27b658dbdaf6c43ae59c4adf93d24cd10e301d8b
-generated: "2022-10-19T17:07:02.749566+02:00"
+digest: sha256:e3390fc94e2c2ade6427225d7fd8eb5b2385b2fb32e57ed3f04eb2aeef7eaf73
+generated: "2023-01-24T16:53:16.498265404+01:00"

--- a/openstack/lyra/Chart.yaml
+++ b/openstack/lyra/Chart.yaml
@@ -9,6 +9,9 @@ dependencies:
   - name: postgresql
     repository: "file://../../common/postgresql"
     version: 0.3.0
+  - name: pgbackup
+    repository: "https://charts.eu-de-2.cloud.sap"
+    version: 0.1.2
   - name: pgmetrics
     repository: "https://charts.eu-de-2.cloud.sap"
     version: 0.3.1

--- a/openstack/lyra/ci/test-values.yaml
+++ b/openstack/lyra/ci/test-values.yaml
@@ -1,7 +1,29 @@
+global:
+  region: qa-de-1
+  tld: example.com
+  registry: keppel.example.com/ccloud
+  dockerHubMirror: keppel.example.com/dockerhub
+  quayIoMirror: keppel.example.com/quayio
+
 auth:
+  password: testauthpassword
+  swift:
+    tempURLKey: testkey
   queweb:
     username: testuser
     password: testpassword
+
+secretKey: testsecretkey
 sentryDSN: "auto"
-global:
-  dockerHubMirror: thisIsAUrl
+
+postgresql:
+  postgresPassword: testdbpassword
+
+pgbackup:
+  database:
+    password: testdbpassword
+  swift:
+    os_password: testbackuppassword
+
+pgmetrics:
+  db_password: testdbpassword

--- a/openstack/lyra/values.yaml
+++ b/openstack/lyra/values.yaml
@@ -54,7 +54,7 @@ omnitruck:
 
 postgresql:
   image: keppel.global.cloud.sap/ccloud/postgres
-  imageTag: "12.11"
+  imageTag: "12.13"
   enabled: true
   alerts:
     prometheus: openstack
@@ -68,16 +68,19 @@ postgresql:
       memory: 256Mi
       cpu: 100m
   backup:
-    enabled: true
-    image: keppel.global.cloud.sap/ccloud/backup-tools
-    imageTag: v0.6.5
-    custom_repository: true
+    enabled: false # uses new pgbackup chart instead
 
 # Deploy Lyra Prometheus alerts.
 alerts:
   enabled: true
   # Name of the Prometheus to which the alerts should be assigned to.
   prometheus: openstack
+
+pgbackup:
+  database:
+    name: monsoon-automation_production
+  alerts:
+    support_group: containers
 
 pgmetrics:
   db_name: monsoon-automation_production


### PR DESCRIPTION
This bumps backup-tools from 0.6.5 to 0.7.0 and moves it into a separate pod, so it can be upgraded in the future without having to restart the postgres container.

This new setup is already deployed and tested in my own services (Castellum, Keppel, Limes and Tenso).

Since this will restart the postgres container anyway, I took the liberty of bumping Postgres from 12.11 to 12.13. This is a bugfix release with no incompatibilities, my own services are already running on 12.13 without any issues.

Merge this together with the respective companion PR in cc/secrets.