### PR TITLE
arc: use common/pgmetrics and common/pgbackup charts

### DIFF
--- a/openstack/arc/Chart.lock
+++ b/openstack/arc/Chart.lock
@@ -2,5 +2,11 @@ dependencies:
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:6c7a0e8b21abdaecf3124234d79457638aff93c3f51c9cedd56500d24eb652e0
-generated: "2022-10-21T09:42:12.189003+02:00"
+- name: pgbackup
+  repository: https://charts.eu-de-2.cloud.sap
+  version: 0.1.2
+- name: pgmetrics
+  repository: https://charts.eu-de-2.cloud.sap
+  version: 0.3.5
+digest: sha256:85ca035213099ca016104f214dfcb92f3dc179e6cc00cc67d3de3dcaea76eccb
+generated: "2023-01-25T15:15:50.347978872+01:00"

--- a/openstack/arc/Chart.yaml
+++ b/openstack/arc/Chart.yaml
@@ -6,3 +6,9 @@ dependencies:
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0
+  - name: pgbackup
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 0.1.2
+  - name: pgmetrics
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 0.3.5

--- a/openstack/arc/charts/postgresql/README.md
+++ b/openstack/arc/charts/postgresql/README.md
@@ -57,11 +57,6 @@ The following tables lists the configurable parameters of the PostgresSQL chart 
 | `persistence.size`         | Size of data volume                        | `10Gi`                                                     |
 | `persistence.existingClaim`| Re-Use existing PVC                        |                                                            |
 | `resources`                | CPU/Memory resource requests/limits        | Memory: `256Mi`, CPU: `100m`                               |
-| `metrics.enabled`          | Start a side-car prometheus exporter       | `false`                                                    |
-| `metrics.image`            | Exporter image                             | `wrouesnel/postgres_exporter`                              |
-| `metrics.imageTag`         | Exporter image                             | `v0.1.1`                                                   |
-| `metrics.imagePullPolicy`  | Exporter image pull policy                 | `IfNotPresent`                                             |
-| `metrics.resources`        | Exporter resource requests/limit           | Memory: `256Mi`, CPU: `100m`                               |
 
 The above parameters map to the env variables defined in [postgres](http://github.com/docker-library/postgres). For more information please refer to the [postgres](http://github.com/docker-library/postgres) image documentation.
 
@@ -88,6 +83,3 @@ $ helm install --name my-release -f values.yaml stable/postgresql
 The [postgres](https://github.com/docker-library/postgres) image stores the PostgreSQL data and configurations at the `/var/lib/postgresql/data/pgdata` path of the container.
 
 The chart mounts a [Persistent Volume](http://kubernetes.io/docs/user-guide/persistent-volumes/) volume at this location. The volume is created using dynamic volume provisioning.
-
-## Metrics
-The chart optionally can start a metrics exporter for [prometheus](https://prometheus.io). The metrics endpoint (port 9187) is not exposed and it is expected that the metrics are collected from inside the k8s cluster using something similar as the described in the [example Prometheus scrape configuration](https://github.com/prometheus/prometheus/blob/master/documentation/examples/prometheus-kubernetes.yml).

--- a/openstack/arc/charts/postgresql/templates/deployment.yaml
+++ b/openstack/arc/charts/postgresql/templates/deployment.yaml
@@ -68,53 +68,6 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /postgresql
-{{- if .Values.backup.enabled }}
-      - image: {{.Values.backup.repository}}:{{.Values.backup.image_version}}
-        name: backup
-        env:
-          - name: MY_POD_NAME
-            value: {{ template "fullname" . }}
-          - name: MY_POD_NAMESPACE
-            value: {{.Release.Namespace}}
-          - name: OS_AUTH_URL
-            value: {{.Values.backup.os_auth_url}}
-          - name: OS_AUTH_VERSION
-            value: "3"
-          - name: OS_USERNAME
-            value: {{.Values.backup.os_username}}
-          - name: OS_USER_DOMAIN_NAME
-            value: {{.Values.backup.os_user_domain}}
-          - name: OS_PROJECT_NAME
-            value: {{.Values.backup.os_project_name}}
-          - name: OS_PROJECT_DOMAIN_NAME
-            value: {{.Values.backup.os_project_domain}}
-          - name: OS_REGION_NAME
-            value: {{.Values.backup.os_region_name}}
-          - name: OS_PASSWORD
-            value: {{.Values.backup.os_password | quote}}
-          - name: BACKUP_PGSQL_FULL
-            value: {{.Values.backup.interval_full | quote}}
-{{- end }}
-{{- if .Values.metrics.enabled }}
-      - name: metrics
-        image: "{{.Values.global.dockerHubMirror}}/{{ .Values.metrics.image }}:{{ .Values.metrics.imageTag }}"
-        imagePullPolicy: {{ default "" .Values.metrics.imagePullPolicy | quote }}
-        env:
-        - name: DATA_SOURCE_NAME
-          value: postgresql://postgres@localhost:5432{{ if .Values.metrics.database }}/{{.Values.metrics.database}}{{ end }}?sslmode=disable
-        ports:
-        - name: metrics
-          containerPort: 9187
-        {{- if .Values.metrics.customMetrics }}
-        args: ["--extend.query-path", "/conf/custom-metrics.yaml"]
-        volumeMounts:
-          - name: custom-metrics
-            mountPath: /conf
-            readOnly: true
-        {{- end }}
-        resources:
-{{ toYaml .Values.metrics.resources | indent 10 }}
-{{- end }}
       volumes:
       - name: data
       {{- if .Values.persistence.enabled }}
@@ -122,12 +75,4 @@ spec:
           claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ template "fullname" . }}{{- end }}
       {{- else }}
         emptyDir: {}
-      {{- end }}
-      {{- if and .Values.metrics.enabled .Values.metrics.customMetrics }}
-      - name: custom-metrics
-        secret:
-          secretName: {{ template "fullname" . }}
-          items:
-            - key: custom-metrics.yaml
-              path: custom-metrics.yaml
       {{- end }}

--- a/openstack/arc/charts/postgresql/templates/secrets.yaml
+++ b/openstack/arc/charts/postgresql/templates/secrets.yaml
@@ -14,6 +14,3 @@ data:
   {{ else }}
   postgres-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{ end }} 
-  {{- if .Values.metrics.customMetrics }}
-  custom-metrics.yaml: {{ toYaml .Values.metrics.customMetrics | b64enc | quote }}
-  {{- end}}

--- a/openstack/arc/charts/postgresql/templates/svc.yaml
+++ b/openstack/arc/charts/postgresql/templates/svc.yaml
@@ -7,12 +7,6 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-{{- if .Values.metrics.enabled }}
-  annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9187"
-    prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
-{{- end }}
 spec:
   ports:
   - name: postgresql
@@ -20,29 +14,3 @@ spec:
     targetPort: postgresql
   selector:
     app: {{ template "fullname" . }}
-    
- {{- if .Values.metrics.enabled }}
----
-
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ template "fullname" . }}-backup-metrics
-  labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
-  annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9188"
-    prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
-spec:
-  clusterIP: None
-  ports:
-    - name: backup-metrics
-      port: 9188
-      protocol: TCP
-  selector:
-    app: {{ template "fullname" . }}
-{{- end }}

--- a/openstack/arc/charts/postgresql/values.yaml
+++ b/openstack/arc/charts/postgresql/values.yaml
@@ -29,26 +29,6 @@ persistence:
   # Re-use existing (unmanged) PVC
   # existingClaim: claimName
 
-metrics:
-  enabled: false
-  image: "wrouesnel/postgres_exporter"
-  imageTag: v0.8.0
-  imagePullPolicy: IfNotPresent
-  customMetrics:
-    pg_database:
-      query: "SELECT d.datname AS datname, CASE WHEN pg_catalog.has_database_privilege(d.datname, 'CONNECT') THEN pg_catalog.pg_database_size(d.datname) ELSE 0 END AS size_bytes FROM pg_catalog.pg_database d where datname not in ('template0', 'template1', 'postgres')"
-      metrics:
-        - datname:
-            usage: "LABEL"
-            description: "Name of the database"
-        - size_bytes:
-            usage: "GAUGE"
-            description: "Size of the database in bytes"
-  resources:
-    requests:
-      memory: 256Mi
-      cpu: 100m
-
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##
@@ -56,16 +36,3 @@ resources:
   requests:
     memory: 256Mi
     cpu: 100m
-
-backup:
-  enabled: false
-  repository: sapcc/backup-tools
-  image_version: v0.6.5
-  interval_full: 1 hours
-  os_auth_url: DEFINED-IN-REGION-SECRETS
-  os_region_name: DEFINED-IN-REGION-SECRETS
-  os_password: DEFINED-IN-REGION-SECRETS
-  os_username: db_backup
-  os_user_domain: Default
-  os_project_name: master
-  os_project_domain: ccadmin

--- a/openstack/arc/ci/test-values.yaml
+++ b/openstack/arc/ci/test-values.yaml
@@ -1,3 +1,11 @@
+global:
+  region: qa-de-1
+  registry: keppel.example.com/ccloud
+  dockerHubMirror: keppel.example.com/dockerhub
+  quayIoMirror: keppel.example.com/quayio
+  domain_seeds:
+    skip_hcm_domain: false
+
 api:
   tls:
     enabled: true
@@ -6,7 +14,15 @@ ca:
   privateKey: xY2EgcHJpdmF0ZUtleQ==yz
 tls:
   crl: Y2EgY2VydFJldm9jYXRpb25MaXN0
-global:
-  registry: "myImage"
-  domain_seeds:
-    skip_hcm_domain: false
+
+postgresql:
+  postgresPassword: testdbpassword
+
+pgbackup:
+  database:
+    password: testdbpassword
+  swift:
+    os_password: testbackuppassword
+
+pgmetrics:
+  db_password: testdbpassword

--- a/openstack/arc/values.yaml
+++ b/openstack/arc/values.yaml
@@ -60,20 +60,29 @@ postgresql:
   enabled: true
   metrics:
     database: arc_production
-    customMetrics:
-      arc:
-        query: "select split_part(facts->>'arc_version', ' ', 1) as arc_version, facts->>'platform_family' as os, count(*) AS active_agents FROM agents where facts->>'online'='true' AND updated_at > now() - INTERVAL '1 hour' group by 1, facts->>'platform_family' order by arc_version;"
-        metrics:
-          - active_agents:
-              usage: GAUGE
-              description: "Online agents"
-          - arc_version:
-              usage: LABEL
-          - os:
-              usage: LABEL
 
+pgbackup:
+  database:
+    name: arc_production
   alerts:
-    prometheus: openstack
+    support_group: containers
+
+pgmetrics:
+  db_name: arc_production
+  alerts:
+    support_group: containers
+
+  customMetrics:
+    arc:
+      query: "select split_part(facts->>'arc_version', ' ', 1) as arc_version, facts->>'platform_family' as os, count(*) AS active_agents FROM agents where facts->>'online'='true' AND updated_at > now() - INTERVAL '1 hour' group by 1, facts->>'platform_family' order by arc_version;"
+      metrics:
+        - active_agents:
+            usage: GAUGE
+            description: "Online agents"
+        - arc_version:
+            usage: LABEL
+        - os:
+            usage: LABEL
 
 mosquitto:
   alerts:


### PR DESCRIPTION
This bumps postgres-exporter from 0.8.0 to 0.10.1 and backup-tools from 0.6.5 to 0.7.0, and moves them into separate pods, so they can be upgraded in the future without having to restart the postgres container.

Merge this together with the respective companion PR in cc/secrets.