### PR TITLE
Adjusted service labels for compute alerts

### DIFF
--- a/prometheus-rules/prometheus-vmware-rules/alerts/datastore.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/datastore.alerts
@@ -8,7 +8,7 @@ groups:
     labels:
       severity: critical
       tier: vmware
-      service: compute
+      service: storage
       support_group: compute
       context: "{{ $labels.datastore }}"
       meta: 'Datastore {{ $labels.datastore }} is not accessible. ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
@@ -24,7 +24,7 @@ groups:
     labels:
       severity: critical
       tier: vmware
-      service: compute
+      service: storage
       support_group: compute
       context: "{{ $labels.datastore }}"
       meta: 'Datastore {{ $labels.datastore }} has no free space. ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
@@ -41,7 +41,7 @@ groups:
     labels:
       severity: critical
       tier: vmware
-      service: compute
+      service: storage
       support_group: compute
       context: "{{ $labels.datastore }}"
       meta: 'Datastore {{ $labels.datastore }} has zero capacity. ({{ $labels.vcenter }}, {{ $labels.datacenter }})'

--- a/prometheus-rules/prometheus-vmware-rules/alerts/nsxt.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/nsxt.alerts
@@ -9,7 +9,7 @@ groups:
     labels:
       severity: warning
       tier: vmware
-      service: compute
+      service: network
       support_group: compute
       meta: "NSX-T cluster {{ $labels.nsxt_adapter }} firewall sections usage exceeded the supported limit. https://{{ $labels.target }}"
       dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
@@ -27,7 +27,7 @@ groups:
     labels:
       severity: warning
       tier: vmware
-      service: compute
+      service: network
       support_group: compute
       meta: "NSX-T cluster {{ $labels.nsxt_adapter }} firewall rules usage exceeded the supported limit. https://{{ $labels.target }}"
       dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
@@ -45,7 +45,7 @@ groups:
     labels:
       severity: warning
       tier: vmware
-      service: compute
+      service: network
       support_group: compute
       meta: "NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switches exceeded the supported limit. https://{{ $labels.target }}"
       dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
@@ -63,7 +63,7 @@ groups:
     labels:
       severity: warning
       tier: vmware
-      service: compute
+      service: network
       support_group: compute
       meta: "NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switch ports exceeded the supported limit. https://{{ $labels.target }}"
       dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
@@ -81,7 +81,7 @@ groups:
     labels:
       severity: warning
       tier: vmware
-      service: compute
+      service: network
       support_group: compute
       meta: "NSX-T cluster {{ $labels.nsxt_adapter }} count of NSGroups exceeded the supported limit. https://{{ $labels.target }}"
       dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
@@ -99,7 +99,7 @@ groups:
     labels:
       severity: warning
       tier: vmware
-      service: compute
+      service: network
       support_group: compute
       meta: "NSX-T cluster {{ $labels.nsxt_adapter }} count of IP sets exceeded the supported limit. https://{{ $labels.target }}"
       dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
@@ -117,7 +117,7 @@ groups:
     labels:
       severity: warning
       tier: vmware
-      service: compute
+      service: network
       support_group: compute
       meta: "NSX-T cluster {{ $labels.nsxt_adapter }} count of groups based in IP exceeded the supported limit. https://{{ $labels.target }}"
       dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
@@ -133,7 +133,7 @@ groups:
     labels:
       severity: critical
       tier: vmware
-      service: compute
+      service: network
       support_group: compute
       meta: "NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage `/image` > 80%. {{ $labels.nsxt_adapter}} https://{{ $labels.target }}"
       playbook: docs/devops/alert/nsxt/#NSXTMgmtNodeImageFilesystemCapacityCritical
@@ -147,7 +147,7 @@ groups:
     labels:
       severity: warning
       tier: vmware
-      service: compute
+      service: network
       support_group: compute
       meta: "NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage `/var/log` > 80%. {{ $labels.nsxt_adapter}} https://{{ $labels.target }}"
       playbook: docs/devops/alert/nsxt/#NSXTMgmtNodeLogFilesystemCapacityCritical
@@ -161,7 +161,7 @@ groups:
     labels:
       severity: warning
       tier: vmware
-      service: compute
+      service: network
       support_group: compute
       meta: "NSX-T management cluster {{ $labels.nsxt_adapter }} has connectivity status `{{ $labels.state }}`. https://{{ $labels.target }}"
       playbook: docs/devops/alert/nsxt/#cluster_control_status_no_controllers
@@ -175,7 +175,7 @@ groups:
     labels:
       severity: warning
       tier: vmware
-      service: compute
+      service: network
       support_group: compute
       meta: "NSX-T management cluster {{ $labels.nsxt_adapter }} has connectivity status `{{ $labels.state }}`. https://{{ $labels.target }}"
       playbook: docs/devops/alert/nsxt/#cluster_control_status_unstable
@@ -189,7 +189,7 @@ groups:
     labels:
       severity: critical
       tier: vmware
-      service: compute
+      service: network
       support_group: compute
       meta: "NSX-T management cluster {{ $labels.nsxt_adapter }} has connectivity status `{{ $labels.state }}`. https://{{ $labels.target }}"
       playbook: docs/devops/alert/nsxt/#cluster_control_status_degraded
@@ -203,7 +203,7 @@ groups:
     labels:
       severity: warning
       tier: vmware
-      service: compute
+      service: network
       support_group: compute
       meta: "NSX-T management cluster {{ $labels.nsxt_adapter }} has connectivity status `{{ $labels.state }}`. https://{{ $labels.target }}"
       playbook: docs/devops/alert/nsxt/#cluster_control_status_unkown
@@ -217,7 +217,7 @@ groups:
     labels:
       severity: critical
       tier: vmware
-      service: compute
+      service: network
       support_group: compute
       meta: "NSX-T Node {{ $labels.nsxt_mgmt_node }} of cluster {{ $labels.nsxt_adapter }} has memory usage of over 95%. https://{{ $labels.target }}"
       playbook: docs/devops/alert/nsxt/#NSXT_Memory_Usage_Over95
@@ -231,7 +231,7 @@ groups:
     labels:
       severity: info
       tier: vmware
-      service: compute
+      service: network
       support_group: compute
       meta: "NSX-T Node `{{ $labels.nsxt_mgmt_node }}` connectivity is broken. ({{ $labels.nsxt_adapter }}) https://{{ $labels.target }}"
       playbook: docs/devops/alert/nsxt
@@ -246,7 +246,7 @@ groups:
     labels:
       severity: info
       tier: vmware
-      service: compute
+      service: network
       meta: "Critical NSX-T management service `{{ $labels.nsxt_mgmt_service }}` has failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }}) https://{{ $labels.target }}"
       no_alert_on_absence: "true"
     annotations:
@@ -260,7 +260,7 @@ groups:
     labels:
       severity: info
       tier: vmware
-      service: compute
+      service: network
       support_group: compute
       meta: "NSX-T management service `{{ $labels.nsxt_mgmt_service }}` has failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }}). https://{{ $labels.target }}"
       no_alert_on_absence: "true"
@@ -277,7 +277,7 @@ groups:
     labels:
       severity: critical
       tier: vmware
-      service: compute
+      service: network
       support_group: compute
       meta: "Transport node {{ $labels.nsxt_transport_node }} Controller/Manager Connectivity status is not UP. https://{{ $labels.target }}."
       playbook: docs/devops/alert/nsxt/#Transport_node_status_not_UP_in_NSXT
@@ -292,7 +292,7 @@ groups:
     labels:
       severity: info
       tier: vmware
-      service: compute
+      service: network
       support_group: compute
       meta: "NSX-T logical switch `{{ $labels.nsxt_logical_switch }}` state is {{ $labels.state }}. ({{ $labels.nsxt_adapter }}). https://{{ $labels.target }}"
       no_alert_on_absence: "true"

--- a/prometheus-rules/prometheus-vmware-rules/alerts/virtualmachine.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/virtualmachine.alerts
@@ -157,7 +157,7 @@ groups:
     labels:
       severity: info
       tier: vmware
-      service: compute
+      service: network
       support_group: compute
       context: "NSXTMgmtVMDistribution"
       dashboard: management-cluster-resources/management-cluster-resources?orgId=1&var-pod=All&var-clusters={{ $labels.vccluster }}&var-hosts={{ $labels.hostsystem }}


### PR DESCRIPTION
For better analyses and accountability I would like to adjust the service labels of some alerts from the compute support group according to their service group (compute, storage, network).

@geisslet I hope the service label is free to choose and won't affect routing/paging.