### PR TITLE
[neutron] Flip network_owner_or_owner policy for performance

### DIFF
--- a/openstack/neutron/templates/etc/_neutron-policy.json.tpl
+++ b/openstack/neutron/templates/etc/_neutron-policy.json.tpl
@@ -12,7 +12,7 @@
     "network_view_all": "role:network_viewer or role:member or role:network_admin or rule:context_is_admin",
 
     "network_owner": "tenant_id:%(network:tenant_id)s",
-    "network_owner_or_owner": "rule:network_owner or rule:owner",
+    "network_owner_or_owner": "rule:owner or rule:network_owner",
     "network_member": "role:member and rule:network_owner_or_owner",
     "network_viewer": "role:network_viewer and rule:network_owner_or_owner",
     "network_admin": "role:network_admin and rule:network_owner_or_owner",


### PR DESCRIPTION
The check rule:owner is much faster than the check rule:network_owner, as rule:network_owner needs to look up a network in neutron, which means another DB query + dict buildup in python. rule:owner only looks up fields that are already available on the port that the policy is checked for.

The rule network_owner_or_owner is mainly used by get_ports, so hopefully this increases the performance for port lists in Neutron for ports in non-shared networks by users that are scoped to a project.

Co-Authored-By: Johannes Kulik <johannes.kulik@sap.com>