### PR TITLE
[glance] Bump proxysql and scale by workers

### DIFF
--- a/openstack/glance/Chart.lock
+++ b/openstack/glance/Chart.lock
@@ -10,12 +10,12 @@ dependencies:
   version: 0.2.7
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.5.0
+  version: 0.7.0
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.2.4
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:eab7381b2ed3bad14772124924adc7f89555cb25c2eb0752bc3109e0bacba479
-generated: "2022-11-21T12:24:00.257656+05:30"
+digest: sha256:984af353157cbdc9644f40e69fec010c966dd487cc135ccc69238834bade7665
+generated: "2023-01-31T10:09:34.448745081+01:00"

--- a/openstack/glance/Chart.yaml
+++ b/openstack/glance/Chart.yaml
@@ -18,7 +18,7 @@ dependencies:
     version: 0.2.7
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.5.0
+    version: 0.7.0
   - name: redis
     alias: sapcc_rate_limit
     repository: https://charts.eu-de-2.cloud.sap

--- a/openstack/glance/templates/deployment.yaml
+++ b/openstack/glance/templates/deployment.yaml
@@ -173,7 +173,7 @@ spec:
           readOnly: true
         {{- end }}
         {{- include "utils.proxysql.volume_mount" . | indent 8 }}
-      {{- include "utils.proxysql.container" . | indent 6 }}
+      {{- tuple . (add .Values.rpc_workers .Values.workers) | include "utils.proxysql.container" | indent 6 }}
       {{- if .Values.imageVersionGlanceRegistry }}
       - name: registry
         image: {{ required ".Values.global.registry is missing" .Values.global.registry }}/ubuntu-source-glance-registry:{{ required "Please set glance.imageVersion or similar" .Values.imageVersion }}

--- a/openstack/glance/templates/etc/_glance-api.conf.tpl
+++ b/openstack/glance/templates/etc/_glance-api.conf.tpl
@@ -16,8 +16,8 @@ show_image_direct_url = True
 admin_role = ''
 
 rpc_response_timeout = {{ .Values.rpc_response_timeout | default 300 }}
-rpc_workers = {{ .Values.rpc_workers | default 1 }}
-workers = {{ .Values.workers | default 4 }}
+rpc_workers = {{ .Values.rpc_workers }}
+workers = {{ .Values.workers }}
 
 wsgi_default_pool_size = {{ .Values.wsgi_default_pool_size | default 100 }}
 

--- a/openstack/glance/values.yaml
+++ b/openstack/glance/values.yaml
@@ -16,6 +16,9 @@ global:
 stores: "swift"
 default_store: swift
 
+rpc_workers: 1
+workers: 4
+
 owner-info:
   support-group: compute-storage-api
   service: glance


### PR DESCRIPTION
Sqlalchemy has a pool per process, and for each worker a process is started. To maintain the same number of maximum connections in proxysql, we need to multiply the number by the number of workers

Also, update proxysql by a minor version