### PR TITLE
sentry: use new common/pgbackup chart

### DIFF
--- a/system/sentry/Chart.lock
+++ b/system/sentry/Chart.lock
@@ -1,9 +1,12 @@
 dependencies:
+- name: pgbackup
+  repository: https://charts.eu-de-2.cloud.sap
+  version: 0.1.2
 - name: pgmetrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.3.5
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:c68de54720513ae69f0a81526e28b52591d9ed3d7b825885898dfa5f8d87c18d
-generated: "2022-12-02T13:49:01.10213+05:30"
+digest: sha256:bb620000d7122e1f971de2cbde278f0fab05957387bfb525e8142c7448e07621
+generated: "2023-01-31T13:22:33.951388826+01:00"

--- a/system/sentry/Chart.yaml
+++ b/system/sentry/Chart.yaml
@@ -3,6 +3,9 @@ description: A Helm chart for Kubernetes
 name: sentry
 version: 0.2.0
 dependencies:
+  - name: pgbackup
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 0.1.2
   - name: pgmetrics
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.3.5

--- a/system/sentry/charts/postgresql/templates/deployment.yaml
+++ b/system/sentry/charts/postgresql/templates/deployment.yaml
@@ -73,33 +73,6 @@ spec:
           mountPath: /postgresql
         - name: postgres-etc
           mountPath: /postgresql-conf
-{{- if .Values.backup.enabled }}
-      - image: "{{required ".Values.global.registry is missing" .Values.global.registry }}/backup-tools:v0.6.5"
-        name: backup
-        env:
-          - name: MY_POD_NAME
-            value: {{ template "fullname" . }}
-          - name: MY_POD_NAMESPACE
-            value: {{.Release.Namespace}}
-          - name: OS_AUTH_URL
-            value: {{.Values.backup.os_auth_url}}
-          - name: OS_AUTH_VERSION
-            value: "3"
-          - name: OS_USERNAME
-            value: {{.Values.backup.os_username}}
-          - name: OS_USER_DOMAIN_NAME
-            value: {{.Values.backup.os_user_domain}}
-          - name: OS_PROJECT_NAME
-            value: {{.Values.backup.os_project_name}}
-          - name: OS_PROJECT_DOMAIN_NAME
-            value: {{.Values.backup.os_project_domain}}
-          - name: OS_REGION_NAME
-            value: {{.Values.backup.os_region_name}}
-          - name: OS_PASSWORD
-            value: {{.Values.backup.os_password | quote}}
-          - name: BACKUP_PGSQL_FULL
-            value: {{.Values.backup.interval_full | quote}}
-{{- end }}
       volumes:
       - name: postgres-etc
         configMap:

--- a/system/sentry/charts/postgresql/values.yaml
+++ b/system/sentry/charts/postgresql/values.yaml
@@ -37,18 +37,6 @@ resources:
     memory: 256Mi
     cpu: 100m
 
-backup:
-  enabled: true
-  interval_full: 1 hours
-  os_auth_url: DEFINED-IN-REGION-SECRETS
-  os_region_name: DEFINED-IN-REGION-SECRETS
-  os_password: DEFINED-IN-REGION-SECRETS
-  os_username: db_backup
-  os_user_domain: Default
-  os_project_name: master
-  os_project_domain: ccadmin
-
-
 # Deploy Sentry Prometheus alerts.
 alerts:
   enabled: true

--- a/system/sentry/ci/test-values.yaml
+++ b/system/sentry/ci/test-values.yaml
@@ -1,1 +1,10 @@
-global: {}
+global:
+  registry: keppel.example.com/ccloud
+  dockerHubMirror: keppel.example.com/dockerhub
+  quayIoMirror: keppel.example.com/quayio
+
+pgbackup:
+  database:
+    password: supersecret
+  swift:
+    os_password: alsoverysecret

--- a/system/sentry/values.yaml
+++ b/system/sentry/values.yaml
@@ -96,6 +96,12 @@ alerts:
   # Name of the Prometheus to which the alerts should be assigned to.
   prometheus: openstack
 
+pgbackup:
+  database:
+    name: sentry
+  alerts:
+    support_group: compute-storage-api
+
 pgmetrics:
   db_name: sentry
   alerts:


### PR DESCRIPTION
This bumps backup-tools from 0.6.5 to 0.7.0 and moves it into a separate pod, so it can be upgraded in the future without having to restart the postgres container.

The new pgbackup chart is already deployed and tested across all regions in my own services (Castellum, Limes, Keppel, Tenso).

This also fixes the lack of backup monitoring and alerts for Sentry.

Please merge this together with the respective companion PR in cc/secrets.