### PR TITLE
[neutron] Use "host" variable for "vcenter" label

### DIFF
--- a/openstack/neutron/templates/vct-nsxv3-agent-configmap.yaml
+++ b/openstack/neutron/templates/vct-nsxv3-agent-configmap.yaml
@@ -18,7 +18,7 @@ template: |
       system: openstack
       type: configuration
       component: neutron
-      vcenter: {= vcenter_name =}
+      vcenter: {= host =}
       datacenter: {= availability_zone =}
       vccluster: {= cluster_name =}
   data:


### PR DESCRIPTION
In 96cea43ef5 we changed all VCenterTemplate objects to include a vcenter label. All other templates use the "host" variable to set the "vcenter" label, except the nxv3-agent-configmap, which uses the "vcenter_name" variable.

We change the configmap to use the "host" variable to make the label consistent over all VCenterTemplates.