### PR TITLE
Ironic: Add setting to controll disk erase

### DIFF
--- a/openstack/ironic/templates/etc/_ironic_conductor.conf.tpl
+++ b/openstack/ironic/templates/etc/_ironic_conductor.conf.tpl
@@ -40,6 +40,7 @@ url_auth_digest_secret = {{required "A valid .Values.console.secret required!" .
 # We expose this directory over http and tftp
 http_root = /tftpboot
 http_url = {{ .Values.conductor.deploy.protocol }}://{{ $tftp_ip }}:{{ .Values.conductor.deploy.port }}/tftpboot
+erase_devices_priority = {{ .Values.conductor.deploy.erase_devices_priority}}
 {{- range $k, $v :=  $conductor.deploy }}
 {{ $k }} = {{ $v }}
 {{- end }}

--- a/openstack/ironic/values.yaml
+++ b/openstack/ironic/values.yaml
@@ -139,6 +139,7 @@ conductor:
   deploy:
     protocol: 'http'
     port: 8088
+    erase_devices_priority: 0
   defaults:
     default:
       enabled_hardware_types: ipmi, idrac, redfish


### PR DESCRIPTION
This setting allows us to enable or disable the erasure of the disk
during the cleaning of a node. For now, we want to disable this. Later we
can then enable it again. The other cleaning steps shouldn't cause major
issues but by enabling automated cleaning for some regions blocks we can
test if we find any other issues.

@stefanhipfel please make sure that makes sense. I'm still not very familiar with helm.