### PR TITLE
px: added podmonitor for custom relabeling

### DIFF
--- a/px/bird/Chart.lock
+++ b/px/bird/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: owner-info
+  repository: https://charts.eu-de-2.cloud.sap
+  version: 0.2.0
+digest: sha256:6c7a0e8b21abdaecf3124234d79457638aff93c3f51c9cedd56500d24eb652e0
+generated: "2023-02-06T14:49:50.085837+01:00"

--- a/px/bird/Chart.yaml
+++ b/px/bird/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for a PX Bird deployment
 name: px-bird
-version: "0.1"
+version: "0.2"
 
 dependencies:
   - name: owner-info

--- a/px/bird/templates/_deployment_header.tpl
+++ b/px/bird/templates/_deployment_header.tpl
@@ -45,11 +45,9 @@ spec:
         pxservice: '{{ $service_number }}'
         pxdomain: '{{ $domain_number }}'
         pxinstance: '{{ $instance_number }}'
+        app.kubernetes.io/name: px
       annotations:
         k8s.v1.cni.cncf.io/networks: '[{ "name": "{{ $deployment_name }}", "interface": "vlan{{ $multus_vlan}}"}]'
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9324"
-        prometheus.io/targets: "infra-collector"
     spec:
 {{- if len $apods | eq 0 }}
 {{- fail "You must supply at least one apod for scheduling" -}}

--- a/px/bird/templates/podmonitor.yaml
+++ b/px/bird/templates/podmonitor.yaml
@@ -1,0 +1,90 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata: 
+  labels:
+    prometheus: infra-collector
+  name: px
+  namespace: infra-monitoring
+spec: 
+  namespaceSelector: 
+    matchNames: 
+    - px
+  podMetricsEndpoints: 
+  - honorLabels: true
+    interval: 60s
+    metricRelabelings: 
+    - action: replace
+      regex: ^bird_.+;{{ .Values.global.region }}-pxrs-([0-9])-s([0-9])-([0-9])
+      replacement: $1
+      sourceLabels: 
+      - __name__
+      - app
+      targetLabel: pxdomain
+    - action: replace
+      regex: ^bird_.+;{{ .Values.global.region }}-pxrs-([0-9])-s([0-9])-([0-9])
+      replacement: $2
+      sourceLabels: 
+      - __name__
+      - app
+      targetLabel: pxservice
+    - action: replace
+      regex: ^bird_.+;{{ .Values.global.region }}-pxrs-([0-9])-s([0-9])-([0-9])
+      replacement: $3
+      sourceLabels: 
+      - __name__
+      - app
+      targetLabel: pxinstance
+    - action: replace
+      regex: ^bird_.+;BGP;(PL|TP|MN)-([A-Z0-9]*)-(.*)
+      replacement: $1
+      sourceLabels: 
+      - __name__
+      - proto
+      - name
+      targetLabel: peer_type
+    - action: replace
+      regex: ^bird_.+;BGP;(PL|TP|MN)-([A-Z0-9]*)-(.*)
+      replacement: $2
+      sourceLabels: 
+      - __name__
+      - proto
+      - name
+      targetLabel: peer_id
+    - action: replace
+      regex: ^bird_.+;BGP;(PL|TP|MN)-([A-Z0-9]*)-(.*)
+      replacement: $3
+      sourceLabels: 
+      - __name__
+      - proto
+      - name
+      targetLabel: peer_hostname
+    path: /metrics
+    port: metrics
+    relabelings: 
+    - action: labelmap
+      regex: __meta_kubernetes_pod_label_(.+)
+    - action: replace
+      sourceLabels: 
+      - __meta_kubernetes_namespace
+      targetLabel: kubernetes_namespace
+    - action: replace
+      sourceLabels: 
+      - __meta_kubernetes_pod_name
+      targetLabel: kubernetes_pod_name
+    - action: replace
+      replacement: {{ .Values.global.region }}
+      targetLabel: region
+    - action: replace
+      replacement: controlplane
+      targetLabel: cluster_type
+    - action: replace
+      replacement: {{ .Values.global.region }}
+      targetLabel: cluster
+    scheme: http
+    scrapeTimeout: 55s
+  selector: 
+    matchExpressions: 
+    - key: app.kubernetes.io/name
+      operator: In
+      values: 
+      - px


### PR DESCRIPTION
px pods are scraped from the prometheus infra-collector by annotations via the job `pods`. Custom relabeling should not be done on a default scrape job. Since we enable `pod-sd` in #4566 and the scrape job `pods` is [omitted](https://github.com/sapcc/helm-charts/pull/4566/commits/a7eb11f5a4d84c9c9955696eee1c5fb14fb5ff17), the custom relabeling is now meaningfully assigned to the px chart.