### PR TITLE
prometheus-kubernetes|kubernikus: support_group for prometheus alerts

### DIFF
--- a/global/prometheus-kubernetes-global/Chart.lock
+++ b/global/prometheus-kubernetes-global/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: prometheus-server-pre7
   repository: https://charts.eu-de-2.cloud.sap
-  version: 6.3.4
-digest: sha256:748bd5ab2ad78d275e9aaa12a823a79403bb321dcf756de3f62645c7a651ffc0
-generated: "2022-10-17T14:34:18.85622+02:00"
+  version: 6.4.20
+digest: sha256:574fb2a10b8bca19c0de21cbd3774b4b43e77293be8b6e44e4cf2e241133c33a
+generated: "2023-02-06T11:14:22.885188+01:00"

--- a/global/prometheus-kubernetes-global/Chart.yaml
+++ b/global/prometheus-kubernetes-global/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
 description: A Helm chart for the operated global Prometheus for monitoring Kubernetes.
 name: prometheus-kubernetes-global
-version: 4.0.2
+version: 4.0.3
 
 dependencies:
   - name: prometheus-server-pre7
     alias: prometheus-kubernetes-global
     repository: https://charts.eu-de-2.cloud.sap
-    version: 6.3.4
+    version: 6.4.20

--- a/global/prometheus-kubernetes-global/values.yaml
+++ b/global/prometheus-kubernetes-global/values.yaml
@@ -55,6 +55,10 @@ prometheus-kubernetes-global:
       - alertmanager-internal.scaleout.eu-de-1.cloud.sap
       - alertmanager-internal.scaleout.eu-nl-1.cloud.sap
 
+  alerts:
+    service: k8s
+    support_group: containers
+
 # List of metrics that get federated from the regional Prometheis.
 # Per convention all metrics with the `global:` prefix are federated.
 allowedMetrics:

--- a/global/prometheus-kubernikus-global/Chart.lock
+++ b/global/prometheus-kubernikus-global/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: prometheus-server-pre7
   repository: https://charts.eu-de-2.cloud.sap
-  version: 6.3.4
-digest: sha256:1214b727a07d273f052c764384b241b33826d7114041da5f73c34d90b963c6eb
-generated: "2022-10-17T14:34:25.630772+02:00"
+  version: 6.4.20
+digest: sha256:413bb7df60b25987de4b3c82e36d8fd3b14dcc96683c29d6bf21387edeb21fe0
+generated: "2023-02-06T11:15:51.44151+01:00"

--- a/global/prometheus-kubernikus-global/Chart.yaml
+++ b/global/prometheus-kubernikus-global/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for the operated global Prometheus for monitoring Kubernikus.
 name: prometheus-kubernikus-global
-version: 4.0.2
+version: 4.0.3
 
 dependencies:
   - name: prometheus-server-pre7
     alias: prometheus-kubernikus-global
     repository: https://charts.eu-de-2.cloud.sap
-    version: 6.3.4
+    version: 6.4.20

--- a/global/prometheus-kubernikus-global/values.yaml
+++ b/global/prometheus-kubernikus-global/values.yaml
@@ -41,6 +41,10 @@ prometheus-kubernikus-global:
       - alertmanager-internal.scaleout.eu-de-1.cloud.sap
       - alertmanager-internal.scaleout.eu-nl-1.cloud.sap
 
+  alerts:
+    service: kubernikus
+    support_group: containers
+
 # Basic alerts for global Prometheus.
 alerts:
   prometheus: kubernikus-global

--- a/system/kube-monitoring-admin-k3s/Chart.yaml
+++ b/system/kube-monitoring-admin-k3s/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes admin k3s cluster monitoring.
 name: kube-monitoring-admin-k3s
-version: 4.3.6
+version: 4.3.7
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-admin-k3s
 dependencies:
   - condition: absent-metrics-operator.enabled

--- a/system/kube-monitoring-admin-k3s/values.yaml
+++ b/system/kube-monitoring-admin-k3s/values.yaml
@@ -242,6 +242,17 @@ prometheus-server:
   thanos:
     enabled: false
 
+  alert:
+    service: k8s
+    support_group: containers
+
+    multipleTargetScrapes:
+      exceptions:
+        # we exclude cadvisor metrics because it has the same instance as the kubelet but a different path
+        # e.g. 10.246.204.80:10250/metrics vs. 10.246.204.80:10250/metrics/cadvisor
+        - kubernetes-cadvisors
+        - kubernetes-kubelets
+
 prometheus-kubernetes-rules:
   prometheusName: kubernetes
   kubelet:

--- a/system/kube-monitoring-kubernikus/Chart.yaml
+++ b/system/kube-monitoring-kubernikus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for monitoring Kubernikus.
 name: kube-monitoring-kubernikus
-version: 7.4.10
+version: 7.4.11
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-kubernikus
 dependencies:
   - condition: absent-metrics-operator.enabled

--- a/system/kube-monitoring-kubernikus/values.yaml
+++ b/system/kube-monitoring-kubernikus/values.yaml
@@ -91,9 +91,16 @@ prometheus-server:
     kubeDNS:
       enabled: false
 
-  # The tier to use for prometheus-server alerts.
   alerts:
-    tier: kks
+    service: kubernikus
+    support_group: containers
+
+    multipleTargetScrapes:
+      exceptions:
+        # we exclude cadvisor metrics because it has the same instance as the kubelet but a different path
+        # e.g. 10.246.204.80:10250/metrics vs. 10.246.204.80:10250/metrics/cadvisor
+        - kubernetes-cadvisors
+        - kubernetes-kubelet
 
   # Send alerts to these alertmanagers.
   alertmanagers:

--- a/system/kube-monitoring-metal/Chart.yaml
+++ b/system/kube-monitoring-metal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes metal controlplane monitoring.
 name: kube-monitoring-metal
-version: 4.4.5
+version: 4.4.6
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-metal
 dependencies:
   - condition: absent-metrics-operator.enabled

--- a/system/kube-monitoring-metal/values.yaml
+++ b/system/kube-monitoring-metal/values.yaml
@@ -248,6 +248,17 @@ prometheus-frontend:
   thanos:
     enabled: false
 
+  alerts:
+    service: k8s
+    support_group: containers
+
+    multipleTargetScrapes:
+      exceptions:
+        # we exclude cadvisor metrics because it has the same instance as the kubelet but a different path
+        # e.g. 10.246.204.80:10250/metrics vs. 10.246.204.80:10250/metrics/cadvisor
+        - kubernetes-cadvisors
+        - kubernetes-kubelet
+
 # Deploy basic set of Prometheus alert and aggregation rules for monitoring Kubernetes.
 prometheus-kubernetes-rules:
   prometheusName: kubernetes

--- a/system/kube-monitoring-scaleout/Chart.yaml
+++ b/system/kube-monitoring-scaleout/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kubernetes scaleout cluster monitoring.
 name: kube-monitoring-scaleout
-version: 4.4.3
+version: 4.4.4
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-scaleout
 dependencies:
   - condition: absent-metrics-operator.enabled

--- a/system/kube-monitoring-scaleout/values.yaml
+++ b/system/kube-monitoring-scaleout/values.yaml
@@ -228,6 +228,17 @@ prometheus-server:
   thanos:
     enabled: false
 
+  alerts:
+    service: k8s
+    support_group: containers
+
+    multipleTargetScrapes:
+      exceptions:
+        # we exclude cadvisor metrics because it has the same instance as the kubelet but a different path
+        # e.g. 10.246.204.80:10250/metrics vs. 10.246.204.80:10250/metrics/cadvisor
+        - kubernetes-cadvisors
+        - kubernetes-kubelet
+
 prometheus-kubernetes-rules:
   prometheusName: kubernetes
 

--- a/system/kube-monitoring-virtual/Chart.yaml
+++ b/system/kube-monitoring-virtual/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes virtual cluster monitoring.
 name: kube-monitoring-virtual
-version: 6.5.5
+version: 6.5.6
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-virtual
 dependencies:
   - condition: absent-metrics-operator.enabled

--- a/system/kube-monitoring-virtual/values.yaml
+++ b/system/kube-monitoring-virtual/values.yaml
@@ -240,6 +240,17 @@ prometheus-server:
   thanos:
     enabled: false
 
+  alerts:
+    service: k8s
+    support_group: containers
+
+    multipleTargetScrapes:
+      exceptions:
+        # we exclude cadvisor metrics because it has the same instance as the kubelet but a different path
+        # e.g. 10.246.204.80:10250/metrics vs. 10.246.204.80:10250/metrics/cadvisor
+        - kubernetes-cadvisors
+        - kubernetes-kubelet
+
 prometheus-kubernetes-rules:
   prometheusName: kubernetes
 


### PR DESCRIPTION
- Forwarding of prometheus alerts to the right support group and service. 

### kube-monitoring-*:
- Pre-requisite: Adding the exceptions for the MultipleTargetScrapeAlerts, as they were removed from the common chart in prometheus-server `v7.1.25`

### kubernetes and kubernikus global:
- bump prometheus-server-pre7 to `v6.4.20` (latest improvements, revised prometheus and thanos alerts)