### PR TITLE
Add NetworkNamespaceProbeHighErrorRate

### DIFF
--- a/prometheus-exporters/ns-exporter/Chart.yaml
+++ b/prometheus-exporters/ns-exporter/Chart.yaml
@@ -5,4 +5,4 @@ version: 1.1.0
 dependencies:
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.2.0
+  version: 0.2.1

--- a/prometheus-exporters/ns-exporter/alerts/probe.alerts
+++ b/prometheus-exporters/ns-exporter/alerts/probe.alerts
@@ -45,3 +45,16 @@ Please run ```hammer -r {{ $externalLabels.region }} net check {{ $labels.networ
     annotations:
       description: 'The metrics from the namespace prober are missing. This suggests there is a problem with the exporter deployment. Check the ns-exporter namespace for running pods.'
       summary: Metrics for namespace prober are missing
+  - alert: NetworkNamespaceProbeHighErrorRate
+    expr: (sum by (host) (rate(ns_exporter_probe_failure_total[5m])))/(sum by (host) (rate(ns_exporter_probe_failure_total[5m])) + sum by (host) (rate(ns_exporter_probe_success_total[5m]))) > 0.15
+    for: 10m
+    labels:
+      context: availability
+      service: dns
+      severity: warning
+      support_group: network-api
+      tier: os
+      meta: 'High error rate for network namespace probes'
+    annotations:
+      description: 'The namespace-exporter is experiencing an unusual high error rate for host `{{ $labels.host }}`. There is a high chance that dns resolution is impacted in the region.'
+      summary: ns-exporter high error rate


### PR DESCRIPTION
As a follow up on the todays dns outage I’m proposing a new alert based on ns-exporter metrics.

This alert fires when the error rates for a probed host exceed 15%.

@sebageek @galkindmitrii I'm not sure which support-group this should go to. I left it at network-api but I'm open to suggestions?