### PR TITLE
grafanasix: use new common/pgbackup chart

### DIFF
--- a/openstack/grafanasix/Chart.lock
+++ b/openstack/grafanasix/Chart.lock
@@ -2,8 +2,11 @@ dependencies:
 - name: postgresql
   repository: file://../../common/postgresql
   version: 0.3.0
+- name: pgbackup
+  repository: https://charts.eu-de-2.cloud.sap
+  version: 0.1.4
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:c2193d3fe181cce85a9c16fa311e0b429c27308e868b369817ed53281e53d381
-generated: "2023-01-23T13:10:39.543447+01:00"
+digest: sha256:e392692cb508b08f3196feedfd20b69c5f20eaa81703a4dacc8e1bc1a8de13d9
+generated: "2023-02-06T17:07:52.030404176+01:00"

--- a/openstack/grafanasix/Chart.yaml
+++ b/openstack/grafanasix/Chart.yaml
@@ -6,6 +6,10 @@ dependencies:
   - name: postgresql
     repository: file://../../common/postgresql
     version: 0.3.0
+  - name: pgbackup
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 0.1.4
+    condition: pgbackup.enabled
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0

--- a/openstack/grafanasix/values.yaml
+++ b/openstack/grafanasix/values.yaml
@@ -89,19 +89,22 @@ nginx:
 postgresql:
   image: '@/cc/secrets'
   imageTag: '9.4'
-  metrics:
-    enabled: false
   postgresDatabase: grafana
   postgresUser: postgres
   postgresPassword: '@/cc/secrets'
   persistence:
     enabled: false
     existingClaim: storage-grafana-postgres-0
-  backup:
-    enabled: true
-    metrics: true
-    os_password: '@/cc/secrets'
   nameOverride: pgsql
+  alerts:
+    support_group: observability
+  backup:
+    enabled: false # uses new pgbackup chart instead
+
+pgbackup:
+  enabled: false # can be enabled in values.yaml
+  database:
+    name: grafana
   alerts:
     support_group: observability
 


### PR DESCRIPTION
This bumps backup-tools from 0.6.5 to 0.7.0 and moves it into a separate pod, so it can be upgraded in the future without having to restart the postgres container.

This change is already rolled out to prod for Arc, Castellum, Elektra, Keppel, Limes, Lyra, Sentry and Tenso.

Note that this only generates a diff in grafanasix-author; the other Grafanas do not have a database backup.

Merge this together with the respective companion PR in cc/secrets.