### PR TITLE
[glance] Update utils with proxysql startup fixes

### DIFF
--- a/openstack/glance/Chart.lock
+++ b/openstack/glance/Chart.lock
@@ -10,12 +10,12 @@ dependencies:
   version: 0.2.7
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.0
+  version: 0.7.2
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.2.4
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:984af353157cbdc9644f40e69fec010c966dd487cc135ccc69238834bade7665
-generated: "2023-01-31T10:09:34.448745081+01:00"
+digest: sha256:88a818e2aea8994d4cfd48d808ac40c82f8c640c1cfd11f0c8db8f7d356553eb
+generated: "2023-02-07T16:46:34.224869948+01:00"

--- a/openstack/glance/Chart.yaml
+++ b/openstack/glance/Chart.yaml
@@ -18,7 +18,7 @@ dependencies:
     version: 0.2.7
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.7.0
+    version: ~0.7.2
   - name: redis
     alias: sapcc_rate_limit
     repository: https://charts.eu-de-2.cloud.sap


### PR DESCRIPTION
There is a race between the startup of proxysql
and the poststarthook trying to access it.
The updated dependency will fix that.

Also update proxysql to the latest minor version
for various bugfixes