### PR TITLE
[nova] Update utils with proxysql startup fixes

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 0.0.12
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.6.0
+  version: 0.7.2
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.7.5
@@ -26,5 +26,5 @@ dependencies:
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:1bf31d92749db2ee880660bc89da0bc4f7df65fc006178a2741f79cbb2fd4c55
-generated: "2022-12-14T10:59:00.528497183+01:00"
+digest: sha256:da30d2c70b19dbf13d86031fe9d0258595081a861ebde2e045f06b9d66f1d955
+generated: "2023-02-07T16:46:59.251624703+01:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     version: 0.0.12
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.6.0
+    version: ~0.7.2
   - name: mariadb
     alias: mariadb_cell2
     condition: mariadb_cell2.enabled


### PR DESCRIPTION
There is a race between the startup of proxysql
and the poststarthook trying to access it.
The updated dependency will fix that.

Also update proxysql to the latest minor version
for various bugfixes