### PR TITLE
[ironic] Update utils with proxysql startup fixes

### DIFF
--- a/openstack/ironic/Chart.lock
+++ b/openstack/ironic/Chart.lock
@@ -16,6 +16,6 @@ dependencies:
   version: 0.4.4
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.0
-digest: sha256:0cfd899e49704ab3c4bbf69b7d379cdb14cc7cdaf79c0b92ee757c3554c3534a
-generated: "2023-01-31T11:06:30.346296828+01:00"
+  version: 0.7.2
+digest: sha256:186a8b7a6f5f5da72adcdf188594b028cd90cd1c17d81d8e1d80ea7c864a88b8
+generated: "2023-02-07T16:46:39.714826425+01:00"

--- a/openstack/ironic/Chart.yaml
+++ b/openstack/ironic/Chart.yaml
@@ -23,4 +23,4 @@ dependencies:
     version: ~0.4.4
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.7.0
+    version: ~0.7.2


### PR DESCRIPTION
There is a race between the startup of proxysql
and the poststarthook trying to access it.
The updated dependency will fix that.

Also update proxysql to the latest minor version
for various bugfixes