### PR TITLE
[cc3test] combine hana and regular server tests into one

### DIFF
--- a/openstack/cc3test/alerts/block-storage.alerts
+++ b/openstack/cc3test/alerts/block-storage.alerts
@@ -63,7 +63,7 @@ groups:
   - alert: OpenstackCinderCreateVolumeShardDown
     expr: |
         cc3test_status{service="cinder",
-            name=~"TestVolume_attach_to_regular_server.+"
+            name=~"TestVolume_attach_to_server.+"
         } == 0
     for: 120m
     labels:

--- a/openstack/cc3test/alerts/compute.alerts
+++ b/openstack/cc3test/alerts/compute.alerts
@@ -137,7 +137,7 @@ groups:
       context: '{{ $labels.service }}'
       meta: 'Openstack Compute Canary is flapping for 2 hours, see last three reports for more details'
       dashboard: cc3test-overview?var-service={{ $labels.service }}
-      playbook: 'docs/devops/alert/{{ $labels.service }}/#test_create_server'
+      playbook: 'docs/support/playbook/{{ $labels.service }}/alerts/cc3test-alert-create-server-bb/'
       report: 'cc3test/admin/object-storage/containers/cc3test/list/reports/{{ $labels.type }}'
     annotations:
       description: 'Openstack Compute Canary is flapping for 2 hours, see last three reports for more details'
@@ -154,7 +154,7 @@ groups:
       context: '{{ $labels.service }}'
       meta: 'Openstack Compute Canary: {{ $labels.name }} is down, see report for more details'
       dashboard: cc3test-overview?var-service={{ $labels.service }}
-      playbook: 'docs/devops/alert/{{ $labels.service }}/#test_create_server'
+      playbook: 'docs/support/playbook/{{ $labels.service }}/alerts/cc3test-alert-create-server-bb/'
       report: 'cc3test/admin/object-storage/containers/cc3test/list/reports/{{ $labels.type }}'
     annotations:
       description: 'Openstack Compute Canary: {{ $labels.name }} is down, see report for more details'
@@ -170,7 +170,40 @@ groups:
       context: '{{ $labels.service }}'
       meta: 'Openstack Compute Canary is flapping for 2 hours, see last three reports for more details'
       dashboard: cc3test-overview?var-service={{ $labels.service }}
-      playbook: 'docs/devops/alert/{{ $labels.service }}/#test_create_server'
+      playbook: 'docs/support/playbook/{{ $labels.service }}/alerts/cc3test-alert-create-server-bb/'
+      report: 'cc3test/admin/object-storage/containers/cc3test/list/reports/{{ $labels.type }}'
+    annotations:
+      description: 'Openstack Compute Canary is flapping for 2 hours, see last three reports for more details'
+      summary: 'Openstack Compute Canary is flapping for 2 hours, see last three reports for more details'
+
+  - alert: OpenstackComputeCanaryCreateServerDown
+    expr: cc3test_status{service="nova",name=~"TestComputeServer_create_server-.+"} == 0
+    for: 3h
+    labels:
+      severity: warning
+      support_group: compute-storage-api
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      meta: 'Openstack Compute Canary: {{ $labels.name }} is down, see report for more details'
+      dashboard: cc3test-overview?var-service={{ $labels.service }}
+      playbook: 'docs/support/playbook/{{ $labels.service }}/alerts/cc3test-alert-create-server-bb/'
+      report: 'cc3test/admin/object-storage/containers/cc3test/list/reports/{{ $labels.type }}'
+    annotations:
+      description: 'Openstack Compute Canary: {{ $labels.name }} is down, see report for more details'
+      summary: 'Openstack Compute Canary: {{ $labels.name }} is down, see report for more details'
+
+  - alert: OpenstackComputeCanaryCreateServerFlapping
+    expr: changes(cc3test_status{service="nova",name=~"TestComputeServer_create_server-.+"}[2h]) > 8
+    labels:
+      severity: info
+      support_group: compute-storage-api
+      tier: os
+      service: '{{ $labels.service }}'
+      context: '{{ $labels.service }}'
+      meta: 'Openstack Compute Canary is flapping for 2 hours, see last three reports for more details'
+      dashboard: cc3test-overview?var-service={{ $labels.service }}
+      playbook: 'docs/support/playbook/{{ $labels.service }}/alerts/cc3test-alert-create-server-bb/'
       report: 'cc3test/admin/object-storage/containers/cc3test/list/reports/{{ $labels.type }}'
     annotations:
       description: 'Openstack Compute Canary is flapping for 2 hours, see last three reports for more details'


### PR DESCRIPTION
as the hana_cc3test flavor used for the tests can run on both regular and hana hosts we do not need separate tests for them - this commit adjusts the alerts accordingly and makes sure they will still match to the old behaviour as well - this compatibility will be dropped once the unified tests are rolled out everywhere