### PR TITLE
[sap-seeds] Add s_c64_m64 special private flavor

### DIFF
--- a/openstack/sap-seeds/templates/flavor-seed.yaml
+++ b/openstack/sap-seeds/templates/flavor-seed.yaml
@@ -501,3 +501,15 @@ spec:
     extra_specs:
       "vmware:hv_enabled": "True"
       "hw_video:ram_max_mb": "16"
+
+  ### Special, i.e. private customer flavors
+  - name: "s_c64_m64"
+    id: "400"
+    vcpus: 64
+    ram: 65520
+    disk: 64
+    is_public: false
+    extra_specs:
+      "vmware:hv_enabled": "True"
+      "hw_video:ram_max_mb": "16"
+      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"


### PR DESCRIPTION
This flavor is needed for customers wanting to run MongoDB which is charged by RAM and needs a lot of CPU.

Start the 400+ flavorid range for special flavors.

Start using the s_ prefix for special customer flavors.
