### PR TITLE
[MemcacheD] - Security Patch and Version upgrade to 1.6.18

### DIFF
--- a/common/memcached/Chart.yaml
+++ b/common/memcached/Chart.yaml
@@ -1,7 +1,14 @@
 apiVersion: v1
 name: memcached
-version: 0.0.12
+version: 0.1.0
 description: Free & open source, high-performance, distributed memory object caching system.
+keywords:
+  - memcached
+  - caching
 home: http://memcached.org/
 sources:
-- https://github.com/sapcc/helm-charts/common/memcached
+  - https://github.com/sapcc/helm-charts/common/memcached
+dependencies:
+  - name: owner-info
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 0.2.0

--- a/common/memcached/values.yaml
+++ b/common/memcached/values.yaml
@@ -1,8 +1,17 @@
 ## Memcached image and tag
 ## ref: https://hub.docker.com/r/library/memcached/tags/
 ##
+
+owner-info:
+  support-group: shared-services
+  maintainers:
+    - Bashar Alkhateeb
+    - Birk Bohne
+    - Viktor Kovacs
+  helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/common/memcached
+
 image: library/memcached
-imageTag: 1.5.12-alpine
+imageTag: 1.6.18-alpine
 # set to true to use .Values.global.dockerHubMirrorAlternateRegion instead of .Values.global.dockerHubMirror
 use_alternate_registry: false
 
@@ -10,8 +19,8 @@ use_alternate_registry: false
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
 ##
-# imagePullPolicy:
-#
+imagePullPolicy: IfNotPresent
+##
 
 ## Affinity for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity


### PR DESCRIPTION
MemcacheD Security Patch and Version upgrade from 1.5.12 to 1.6.18

 - Exporter is the latest
 - No interim upgrade requires
 - The upgrade involves cold boot (clearing the data)