### PR TITLE
[MemcacheD] - Security Patch and Version upgrade to 1.6.18

### DIFF
--- a/common/memcached/Chart.yaml
+++ b/common/memcached/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: memcached
-version: 0.0.12
+version: 0.1.0
 description: Free & open source, high-performance, distributed memory object caching system.
 home: http://memcached.org/
 sources:

--- a/common/memcached/values.yaml
+++ b/common/memcached/values.yaml
@@ -2,7 +2,7 @@
 ## ref: https://hub.docker.com/r/library/memcached/tags/
 ##
 image: library/memcached
-imageTag: 1.5.12-alpine
+imageTag: 1.6.18-alpine
 # set to true to use .Values.global.dockerHubMirrorAlternateRegion instead of .Values.global.dockerHubMirror
 use_alternate_registry: false
 
@@ -10,7 +10,7 @@ use_alternate_registry: false
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
 ##
-# imagePullPolicy:
+imagePullPolicy: IfNotPresent
 #
 
 ## Affinity for pod assignment


### PR DESCRIPTION
MemcacheD Security patch and Version upgrade from 1.5.12 to 1.6.18

- Exporter is the latest
- No interim upgrade requires
- The upgrade involves cold boot (clearing the data)