### PR TITLE
[barbican] update dependency of rabbitmq to 0.5.0:

### DIFF
--- a/openstack/barbican/Chart.lock
+++ b/openstack/barbican/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 0.2.7
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.4.4
+  version: 0.5.0
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.5.0
@@ -20,5 +20,5 @@ dependencies:
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:3c5a106ace49f5d9ca6784d6e62296f61caef9e16d65c5edaca605bcad9b8794
-generated: "2022-11-21T12:22:52.637015+05:30"
+digest: sha256:c7adbeefc77d5fc33832262f0b033a8be21d80e4b057e4025adbe59a6ec22f73
+generated: "2023-02-09T15:37:22.630295+01:00"

--- a/openstack/barbican/Chart.yaml
+++ b/openstack/barbican/Chart.yaml
@@ -18,7 +18,7 @@ dependencies:
     version: 0.2.7
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.4.4
+    version: 0.5.0
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.5.0

--- a/openstack/barbican/values.yaml
+++ b/openstack/barbican/values.yaml
@@ -161,7 +161,10 @@ rabbitmq:
     enabled: false
   alerts:
     support_group: identity
-
+  metrics:
+    enabled: &metrics true
+    sidecar:
+      enabled: *metrics
 memcached:
   alerts:
     support_group: identity


### PR DESCRIPTION
 add support for prometheus-rabbitmq plugin instead of the side car metrics container