### PR TITLE
[cinder]update dependency of rabbitmq to 0.5.0

### DIFF
--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -13,12 +13,12 @@ dependencies:
   version: 0.0.11
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.4.4
+  version: 0.5.0
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.2.1
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:0ccd707309af4734b8c9d43730fabf79c4e9cfed3607eab86bd67c1074a587d9
-generated: "2023-01-05T09:20:53.023039-05:00"
+digest: sha256:0dc71c5740feacb0cdfc760d337c599a98cb8dd7be3fc6299a0b6d0e478af54a
+generated: "2023-02-09T15:37:39.602688+01:00"

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -20,7 +20,7 @@ dependencies:
     version: 0.0.11
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.4.4
+    version: 0.5.0
   - name: redis
     alias: api-ratelimit-redis
     repository: https://charts.eu-de-2.cloud.sap

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -307,10 +307,12 @@ rabbitmq:
     unacknowledged_total_wait_for: 60m
     ready_total_wait_for: 60m
     support_group: compute-storage-api
-
+  metrics:
+    enabled: &metrics true
+    sidecar:
+      enabled: *metrics
 rabbitmq_notifications:
   name: cinder
-
 logging:
   formatters:
     context:


### PR DESCRIPTION
update dependencies to rabbitmq 0.50 which adds support for prometheus-rabbitmq plugin