### PR TITLE
[cronus] update dependency of rabbitmq to 0.5.0

### DIFF
--- a/openstack/cronus/Chart.lock
+++ b/openstack/cronus/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.4.3
+  version: 0.5.0
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.4.3
+  version: 0.5.0
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:a88443101382510dcbd25f068fd6ec3f861e9f61636070f26db9d2b13d3d25df
-generated: "2023-01-05T17:50:56.850138+01:00"
+digest: sha256:c1d83aa89b1b4fced1837b3ef8acf0ba2792da30f29d571dbf192cded728a8c0
+generated: "2023-02-09T15:37:54.052179+01:00"

--- a/openstack/cronus/Chart.yaml
+++ b/openstack/cronus/Chart.yaml
@@ -5,10 +5,10 @@ version: 0.1.13
 dependencies:
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.4.3
+    version: 0.5.0
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.4.3
+    version: 0.5.0
     alias: rhea_rabbitmq
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap

--- a/openstack/cronus/values.yaml
+++ b/openstack/cronus/values.yaml
@@ -440,8 +440,9 @@ rabbitmq:
     accessMode: ReadWriteOnce
     size: 10Gi
   metrics:
-    enabled: false
-
+    enabled: &metrics true
+    sidecar:
+      enabled: *metrics
 rhea:
   enabled: false
   server:
@@ -530,8 +531,9 @@ rhea_rabbitmq:
     accessMode: ReadWriteOnce
     size: 10Gi
   metrics:
-    enabled: false
-
+    enabled: &metrics true
+    sidecar:
+      enabled: *metrics
 poller: # service that handles received emails
   enabled: false
   # all below can be used only with a deployment style


### PR DESCRIPTION
update dependencies to rabbitmq 0.5.0 which adds support for prometheus-rabbitmq plugin