### PR TITLE
[designate] update dependency of rabbitmq to 0.5.0

### DIFF
--- a/openstack/designate/Chart.lock
+++ b/openstack/designate/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 0.2.7
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.4.4
+  version: 0.5.0
 - name: rabbitmq_cluster
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.6
@@ -23,5 +23,5 @@ dependencies:
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:6c8819bc4020b48a700a29fb4b37951f85d9c80adfbfad48667b6606421deccc
-generated: "2023-01-16T11:42:37.573072+01:00"
+digest: sha256:9c1f33e0b3f61441263a952c2d0dd3da4631112484d346a8a6711efaaf71b583
+generated: "2023-02-09T15:38:02.828861+01:00"

--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -22,7 +22,7 @@ dependencies:
   - name: rabbitmq
     condition: rabbitmq.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.4.4
+    version: 0.5.0
   - name: rabbitmq_cluster
     condition: rabbitmq_cluster.enabled
     repository: https://charts.eu-de-2.cloud.sap

--- a/openstack/designate/values.yaml
+++ b/openstack/designate/values.yaml
@@ -295,7 +295,10 @@ rabbitmq:
       password: secret
   alerts:
     support_group: network-api
-
+  metrics:
+    enabled: &metrics true
+    sidecar:
+      enabled: *metrics
 rabbitmq_cluster:
   enabled: false
   use_alternate_registry: true


### PR DESCRIPTION
update dependencies to rabbitmq 0.5.0 which adds support for prometheus-rabbitmq plugin