### PR TITLE
[hermes] update dependency of rabbitmq to 0.5.0

### DIFF
--- a/openstack/hermes/Chart.yaml
+++ b/openstack/hermes/Chart.yaml
@@ -10,7 +10,7 @@ dependencies:
     condition: audit.enabled
     name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.4.4
+    version: 0.5.0
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0

--- a/openstack/hermes/values.yaml
+++ b/openstack/hermes/values.yaml
@@ -66,12 +66,14 @@ rabbitmq_notifications:
       # password: DEFINED-IN-SECRETS
   alerts:
     support_group: observability
-
+  metrics:
+    enabled: &metrics true
+    sidecar:
+      enabled: *metrics
 # Pod Monitor
 exporter:
   enabled: false
   prometheus: openstack
-
 # Deploy hermes Prometheus alerts.
 alerts:
   enabled: true


### PR DESCRIPTION
update dependencies to rabbitmq 0.5.0 which adds support for prometheus-rabbitmq plugin