### PR TITLE
[ironic] update dependency of rabbitmq to 0.5.0

### DIFF
--- a/openstack/ironic/Chart.lock
+++ b/openstack/ironic/Chart.lock
@@ -13,9 +13,9 @@ dependencies:
   version: 0.2.0
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.4.4
+  version: 0.5.0
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.0
-digest: sha256:0cfd899e49704ab3c4bbf69b7d379cdb14cc7cdaf79c0b92ee757c3554c3534a
-generated: "2023-01-31T11:06:30.346296828+01:00"
+  version: 0.7.3
+digest: sha256:98a7c2918dcbb9f4bc431f78244ed0fd7497e8b79da3f2400b84485e6a9ef836
+generated: "2023-02-09T15:38:25.441054+01:00"

--- a/openstack/ironic/Chart.yaml
+++ b/openstack/ironic/Chart.yaml
@@ -20,7 +20,7 @@ dependencies:
     version: ~0.2.0
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.4.4
+    version: ~0.5.0
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
     version: ~0.7.0

--- a/openstack/ironic/values.yaml
+++ b/openstack/ironic/values.yaml
@@ -353,7 +353,10 @@ rabbitmq:
       cpu: 1000m
   alerts:
     support_group: compute-storage-api
-
+  metrics:
+    enabled: &metrics true
+    sidecar:
+      enabled: *metrics
 logging:
   formatters:
     context:


### PR DESCRIPTION
update dependencies to rabbitmq 0.5.0 which adds support for prometheus-rabbitmq plugin