### PR TITLE
[manila] update dependency of rabbitmq to 0.5.0

### DIFF
--- a/openstack/manila/Chart.lock
+++ b/openstack/manila/Chart.lock
@@ -13,9 +13,9 @@ dependencies:
   version: 0.2.0
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.4.4
+  version: 0.5.0
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.7.3
-digest: sha256:d13c52d00b196ef9239d2c09742e667b7220ba120ecdbcbae19fbcd65844e210
-generated: "2023-02-09T13:22:20.630473+01:00"
+digest: sha256:fff98d2f5710f64d3c76462602103d3d837495f925f3d132b0ce37c36fa3d9a2
+generated: "2023-02-09T15:38:38.585437+01:00"

--- a/openstack/manila/Chart.yaml
+++ b/openstack/manila/Chart.yaml
@@ -28,7 +28,7 @@ dependencies:
     version: 0.2.0
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.4.4
+    version: 0.5.0
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
     version: ~0.7.2

--- a/openstack/manila/values.yaml
+++ b/openstack/manila/values.yaml
@@ -569,7 +569,10 @@ rabbitmq:
     support_group: compute-storage-api
   persistence:
     enabled: false
-
+  metrics:
+    enabled: &metrics true
+    sidecar:
+      enabled: *metrics
 sentry:
   enabled: true
 


### PR DESCRIPTION
update dependencies to rabbitmq 0.5.0 which adds support for prometheus-rabbitmq plugin