### PR TITLE
[neutron] update dependency of rabbitmq to 0.5.1

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -10,15 +10,15 @@ dependencies:
   version: 0.2.7
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.2
+  version: 0.5.1
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.2
+  version: 0.5.1
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.4.1
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:8f410674f6456b6e787b1b6bd82cb26c079fca57889eebe707b3b7f47103f792
-generated: "2022-11-28T10:28:15.886759-05:00"
+digest: sha256:13be0c3c64a043d38099c22d0b9e2cf42e98f2d7cb4fef0b7933a7475832c636
+generated: "2023-02-10T14:31:08.833377+01:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -17,12 +17,12 @@ dependencies:
     version: 0.2.7
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.2
+    version: 0.5.1
   - alias: rabbitmq_notifications
     condition: audit.enabled
     name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.2
+    version: 0.5.1
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.4.1

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -568,10 +568,16 @@ rabbitmq:
       cpu: 2000m
     limits:
       cpu: 4000m
-
+  metrics:
+    enabled: true
+    sidecar:
+      enabled: false
 rabbitmq_notifications:
   name: neutron
-
+  metrics:
+    enabled: true
+    sidecar:
+      enabled: false
 # openstack-watcher-middleware
 watcher:
   enabled: true


### PR DESCRIPTION
update dependencies to rabbitmq 0.5.0 which adds support for prometheus-rabbitmq plugin