### PR TITLE
[nova] update dependency of rabbitmq to 0.5.1

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 0.2.7
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.4.4
+  version: 0.5.1
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.0.12
@@ -22,9 +22,9 @@ dependencies:
   version: 0.7.5
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.4.4
+  version: 0.5.1
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:1bf31d92749db2ee880660bc89da0bc4f7df65fc006178a2741f79cbb2fd4c55
-generated: "2022-12-14T10:59:00.528497183+01:00"
+digest: sha256:6ba57352cfc1c29042223858b5fe8760d7c34b792243243e0e39d460030beb65
+generated: "2023-02-10T14:26:06.207088+01:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -20,7 +20,7 @@ dependencies:
     version: 0.2.7
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.4.4
+    version: 0.5.1
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.0.12
@@ -36,7 +36,7 @@ dependencies:
     alias: rabbitmq_cell2
     condition: cell2.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.4.4
+    version: 0.5.1
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -766,19 +766,20 @@ mariadb_cell2:
       client_id: "nova-cell2"
   alerts:
     support_group: compute-storage-api
-
 rabbitmq_cell2:
   name: nova-cell2
   persistence:
     enabled: false
-
   alerts:
     # unacked/ready messages in rabbitmq
     rabbit_queue_length: 50
     unacknowledged_total_wait_for: 10m
     ready_total_wait_for: 10m
     support_group: compute-storage-api
-
+  metrics:
+    enabled: true
+    sidecar:
+      enabled: false
 audit:
   central_service:
     user: rabbitmq
@@ -800,7 +801,9 @@ rabbitmq:
     enabled: false
   metrics:
     password: null
-
+    enabled: true
+    sidecar:
+      enabled: false
   resources:
     requests:
       memory: 2Gi


### PR DESCRIPTION
update dependencies to rabbitmq 0.5.0 which adds support for prometheus-rabbitmq plugin