### PR TITLE
[octavia] update dependency of rabbitmq to 0.5.0

### DIFF
--- a/openstack/octavia/Chart.lock
+++ b/openstack/octavia/Chart.lock
@@ -10,15 +10,15 @@ dependencies:
   version: 0.2.7
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.4.4
+  version: 0.5.0
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.4.4
+  version: 0.5.0
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.7.0
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:22d9aba52eee622c459cf9a858a264d5865cbab31840b8c74aed2bfcc83b177f
-generated: "2022-11-28T16:21:51.209647852+01:00"
+digest: sha256:32a28a16de6037c3042a7a00bfa8e831e26f77ba77d8b4a010ba3ee354a3f925
+generated: "2023-02-09T15:39:23.59587+01:00"

--- a/openstack/octavia/Chart.yaml
+++ b/openstack/octavia/Chart.yaml
@@ -22,12 +22,12 @@ dependencies:
     version: 0.2.7
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.4.4
+    version: 0.5.0
   - alias: rabbitmq_notifications
     condition: audit.enabled
     name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.4.4
+    version: 0.5.0
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.7.0

--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -29,11 +29,17 @@ proxysql:
 rabbitmq:
   alerts:
     support_group: network-api
-
+  metrics:
+    enabled: &metrics true
+    sidecar:
+      enabled: *metrics
 rabbitmq_notifications:
   alerts:
     support_group: network-api
-
+  metrics:
+    enabled: &metrics true
+    sidecar:
+      enabled: *metrics
 memcached:
   alerts:
     support_group: network-api


### PR DESCRIPTION
update dependencies to rabbitmq 0.5.0 which adds support for prometheus-rabbitmq plugin