### PR TITLE
Change some alerts to warnings

### DIFF
--- a/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
+++ b/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
@@ -45,7 +45,7 @@ groups:
       count by (shard, backend) (sum(cinder_available_capacity_gib) by (shard, backend, pool)) - count by (shard, backend) (sum by(shard, backend, pool) (cinder_virtual_free_capacity_gib) - sum by(shard, backend, pool) (cinder_per_volume_gigabytes) <=0) < 3
     for: 15m
     labels:
-      severity: info
+      severity: warning
       tier: vmware
       service: cinder
       support_group: compute
@@ -60,7 +60,7 @@ groups:
         cinder_backend_state_info{backend_state='down'}
     for: 15m
     labels:
-      severity: info
+      severity: warning
       tier: vmware
       service: cinder
       support_group: compute
@@ -75,7 +75,7 @@ groups:
         cinder_virtual_free_capacity_gib < 0
     for: 15m
     labels:
-      severity: info
+      severity: warning
       tier: vmware
       service: cinder
       support_group: compute
@@ -90,7 +90,7 @@ groups:
         cinder_pool_netapp_fqdn_info{netapp_fqdn='None'}
     for: 15m
     labels:
-      severity: info
+      severity: warning
       tier: vmware
       service: cinder
       support_group: compute


### PR DESCRIPTION
The info alerts are basically being ignored and some of these alerts are pretty critical for visibility.  Changing these alerts to warning so they get into the right slack channel with visibility.