### PR TITLE
[common/rabbitmq] Shorter hostnames

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -3,6 +3,11 @@ Rabbitmq CHANGELOG
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+0.5.1
+_____
+fabian.wiesel@sap.common
+- Use just the hostname without domain for the transport-url
+
 0.5.0
 -----
 b.alkhateeb@sap.com

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 0.5.0
+version: 0.5.1
 description: A Helm chart for RabbitMQ
 sources:
 - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/templates/_helpers.tpl
+++ b/common/rabbitmq/templates/_helpers.tpl
@@ -15,7 +15,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | replace "_" "-" | trimSuffix "-" -}}
 {{- end -}}
 
-{{define "rabbitmq.release_host"}}{{.Release.Name}}-rabbitmq.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.region}}.{{.Values.global.tld}}{{end}}
+{{define "rabbitmq.release_host"}}{{.Release.Name}}-rabbitmq{{end}}
 
 {{- define "rabbitmq.transport_url" -}}{{ tuple . .Values.rabbitmq | include "rabbitmq._transport_url" }}{{- end}}
 


### PR DESCRIPTION
Use short hostnames instead of the fqdn,
and rely on the DNS for Services discovery
from kubernetes to resolve it

For normal pods, that should be just a cosmetic change but for the KVM use-case, which runs on baremetal, it allows us to resolve and use external ips
with the same configuration