### PR TITLE
[neutron] update dependency of rabbitmq to 0.5.1

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -10,15 +10,15 @@ dependencies:
   version: 0.2.7
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.2
+  version: 0.5.1
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.2
+  version: 0.5.1
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.4.1
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:2f967261893b9fde44884722ccfc36b2238a7ad8fa813f1d8ecf298cc1b16851
-generated: "2023-04-25T13:39:37.148277641+02:00"
+digest: sha256:f447ca090500400ba3e514c8a35417f0e62200210b2815fd19f30acf21f21da7
+generated: "2023-04-25T14:06:54.424443+02:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -17,12 +17,12 @@ dependencies:
     version: 0.2.7
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.2
+    version: 0.5.1
   - alias: rabbitmq_notifications
     condition: audit.enabled
     name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.2
+    version: 0.5.1
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.4.1

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -568,10 +568,20 @@ rabbitmq:
       cpu: 2000m
     limits:
       cpu: 4000m
-
+  metrics:
+    enabled: true
+    sidecar:
+      enabled: false
+  alerts:
+    support_group: network-api
 rabbitmq_notifications:
   name: neutron
-
+  metrics:
+    enabled: true
+    sidecar:
+      enabled: false
+  alerts:
+    support_group: network-api
 # openstack-watcher-middleware
 watcher:
   enabled: true


### PR DESCRIPTION
included releases:
rabbitmq 0.5.0 which adds support for prometheus-rabbitmq plugin 
rabbitmq 0.5.1 which use short hostname instead of FQDN for rabbitmq