### PR TITLE
[nova] update dependency of rabbitmq to 0.5.1

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 0.2.7
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.4.4
+  version: 0.5.1
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.1
@@ -22,9 +22,9 @@ dependencies:
   version: 0.7.5
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.4.4
+  version: 0.5.1
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:c7db7afe2e365657730bca814d4fcef0e145f7d94a230a21ba3d992ab23206da
-generated: "2023-06-22T13:14:30.13592467+02:00"
+digest: sha256:80587f46d10899feb27d95877c9346f4a3e24b90c54fd69a46839e055f0bc3cd
+generated: "2023-07-21T12:36:17.859998497+02:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -20,7 +20,7 @@ dependencies:
     version: 0.2.7
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.4.4
+    version: 0.5.1
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.1.1
@@ -36,7 +36,7 @@ dependencies:
     alias: rabbitmq_cell2
     condition: cell2.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.4.4
+    version: 0.5.1
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -776,19 +776,20 @@ mariadb_cell2:
       client_id: "nova-cell2"
   alerts:
     support_group: compute-storage-api
-
 rabbitmq_cell2:
   nameOverride: cell2-rabbitmq
   persistence:
     enabled: false
-
   alerts:
     # unacked/ready messages in rabbitmq
     rabbit_queue_length: 50
     unacknowledged_total_wait_for: 10m
     ready_total_wait_for: 10m
     support_group: compute-storage-api
-
+  metrics:
+    enabled: true
+    sidecar:
+      enabled: false
 audit:
   central_service:
     user: rabbitmq
@@ -809,7 +810,9 @@ rabbitmq:
     enabled: false
   metrics:
     password: null
-
+    enabled: true
+    sidecar:
+      enabled: false
   resources:
     requests:
       memory: 2Gi


### PR DESCRIPTION
included releases:
rabbitmq 0.5.0 which adds support for prometheus-rabbitmq plugin
rabbitmq 0.5.1 which use short hostname instead of FQDN for rabbitmq