### PR TITLE
[barbican] update dependency of rabbitmq to 0.5.1

### DIFF
--- a/openstack/barbican/Chart.lock
+++ b/openstack/barbican/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 0.2.7
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.4.4
+  version: 0.5.1
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.5.0
@@ -20,5 +20,5 @@ dependencies:
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:3c5a106ace49f5d9ca6784d6e62296f61caef9e16d65c5edaca605bcad9b8794
-generated: "2022-11-21T12:22:52.637015+05:30"
+digest: sha256:7834d393ef7b059bc67bca0cf2f4ddbfcd7d8f2c329c29f68fddf6b61a7176c3
+generated: "2023-02-13T09:46:11.510912+01:00"

--- a/openstack/barbican/Chart.yaml
+++ b/openstack/barbican/Chart.yaml
@@ -18,7 +18,7 @@ dependencies:
     version: 0.2.7
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.4.4
+    version: 0.5.1
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.5.0

--- a/openstack/barbican/values.yaml
+++ b/openstack/barbican/values.yaml
@@ -161,7 +161,10 @@ rabbitmq:
     enabled: false
   alerts:
     support_group: identity
-
+  metrics:
+    enabled: &metrics true
+    sidecar:
+      enabled: *metrics
 memcached:
   alerts:
     support_group: identity


### PR DESCRIPTION
included releases:
rabbitmq 0.5.0 which adds support for prometheus-rabbitmq plugin
rabbitmq 0.5.1 which uses short hostname instead of FQDN for rabbitmq