### PR TITLE
grafanasix: do not select an existingClaim by default

### DIFF
--- a/openstack/grafanasix/values.yaml
+++ b/openstack/grafanasix/values.yaml
@@ -94,7 +94,6 @@ postgresql:
   postgresPassword: '@/cc/secrets'
   persistence:
     enabled: false
-    existingClaim: storage-grafana-postgres-0
   nameOverride: pgsql
   alerts:
     support_group: observability


### PR DESCRIPTION
This is redundant with cc/secrets.