### PR TITLE
[octavia] update dependency of rabbitmq to 0.5.1

### DIFF
--- a/openstack/octavia/Chart.lock
+++ b/openstack/octavia/Chart.lock
@@ -10,15 +10,15 @@ dependencies:
   version: 0.2.7
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.4.4
+  version: 0.5.1
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.4.4
+  version: 0.5.1
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.7.0
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:22d9aba52eee622c459cf9a858a264d5865cbab31840b8c74aed2bfcc83b177f
-generated: "2022-11-28T16:21:51.209647852+01:00"
+digest: sha256:d82434a9c0e6acbdc9401c5e237cd2ded3a6b5114c3f1b06e5219c69b7dd3fc0
+generated: "2023-02-13T15:12:01.395739+01:00"

--- a/openstack/octavia/Chart.yaml
+++ b/openstack/octavia/Chart.yaml
@@ -22,12 +22,12 @@ dependencies:
     version: 0.2.7
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.4.4
+    version: 0.5.1
   - alias: rabbitmq_notifications
     condition: audit.enabled
     name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.4.4
+    version: 0.5.1
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.7.0

--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -29,11 +29,17 @@ proxysql:
 rabbitmq:
   alerts:
     support_group: network-api
-
+  metrics:
+    enabled: true
+    sidecar:
+      enabled: false
 rabbitmq_notifications:
   alerts:
     support_group: network-api
-
+  metrics:
+    enabled: true
+    sidecar:
+      enabled: false
 memcached:
   alerts:
     support_group: network-api


### PR DESCRIPTION
include releases:
rabbitmq 0.5.0 which adds support for prometheus-rabbitmq plugin 
rabbitmq 0.5.1 which uses short hostname instead of FQDN for rabbitmq