### PR TITLE
[ironic] update dependency of rabbitmq to 0.5.1

### DIFF
--- a/openstack/ironic/Chart.lock
+++ b/openstack/ironic/Chart.lock
@@ -13,9 +13,9 @@ dependencies:
   version: 0.2.0
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.4.4
+  version: 0.5.1
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.0
-digest: sha256:0cfd899e49704ab3c4bbf69b7d379cdb14cc7cdaf79c0b92ee757c3554c3534a
-generated: "2023-01-31T11:06:30.346296828+01:00"
+  version: 0.7.4
+digest: sha256:b4cd9ba1acbf09f0662d5770dac427d3cc051c9568046152ec5d1029ece869b1
+generated: "2023-02-13T14:53:30.581373+01:00"

--- a/openstack/ironic/Chart.yaml
+++ b/openstack/ironic/Chart.yaml
@@ -20,7 +20,7 @@ dependencies:
     version: ~0.2.0
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.4.4
+    version: ~0.5.1
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
     version: ~0.7.0

--- a/openstack/ironic/values.yaml
+++ b/openstack/ironic/values.yaml
@@ -353,6 +353,10 @@ rabbitmq:
       cpu: 1000m
   alerts:
     support_group: compute-storage-api
+  metrics:
+    enabled: true
+    sidecar:
+      enabled: false
 
 logging:
   formatters:


### PR DESCRIPTION
include releases:
rabbitmq 0.5.0 which adds support for prometheus-rabbitmq plugin 
rabbitmq 0.5.1 which uses short hostname instead of FQDN for rabbitmq