### PR TITLE
[PX] Only deploy PodMonitor once and in px namespace 

### DIFF
--- a/px/bird/templates/_deployment_header.tpl
+++ b/px/bird/templates/_deployment_header.tpl
@@ -61,7 +61,7 @@ spec:
                 operator: In
                 values: 
 {{- range $az_apods := values $apods }}
-{{- range $az_apods }}
+{{- range $az_apods | sortAlpha }}
                 - {{ . }}
 {{- end }}
 {{- end }}

--- a/px/bird/templates/_podmonitor.tpl
+++ b/px/bird/templates/_podmonitor.tpl
@@ -1,10 +1,11 @@
+{{- define "podmonitor" -}}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata: 
   labels:
     prometheus: infra-collector
   name: px
-  namespace: infra-monitoring
+  namespace: px
 spec: 
   namespaceSelector: 
     matchNames: 
@@ -88,3 +89,4 @@ spec:
       operator: In
       values: 
       - px
+{{ end }}

--- a/px/bird/templates/bird.yaml
+++ b/px/bird/templates/bird.yaml
@@ -22,6 +22,7 @@
 
 {{- if hasKey $instance_config "pxmon_ip" -}}
 {{- tuple (printf "%s-pxmon" $deployment_name) $domain_config.multus_vlan $instance_config.bird_ip | include "nad_multus"}}
+{{- include "podmonitor" }}
 {{- end -}}
 
 {{- end -}}


### PR DESCRIPTION
Since we deploy the same release with 2 domains, so 2 times we
would deploy the pmon twice as well. Let's just make sure we deploy the
pmon on domain 1 and everything works fine.