### PR TITLE
[PX] Deploy podmonitor with each domain, per domain

### DIFF
--- a/px/bird/templates/bird.yaml
+++ b/px/bird/templates/bird.yaml
@@ -22,7 +22,6 @@
 
 {{- if hasKey $instance_config "pxmon_ip" -}}
 {{- tuple (printf "%s-pxmon" $deployment_name) $domain_config.multus_vlan $instance_config.bird_ip | include "nad_multus"}}
-{{- include "podmonitor" }}
 {{- end -}}
 
 {{- end -}}

--- a/px/bird/templates/podmonitor.yaml
+++ b/px/bird/templates/podmonitor.yaml
@@ -1,35 +1,46 @@
-{{- define "podmonitor" -}}
+{{- $domains := list -}} 
+{{- range $service, $service_config := .Values.config -}}
+{{- range $domain, $domain_config := $service_config -}}
+{{- if and (hasPrefix "domain_" $domain) (has $domain $.Values.deploy) -}}
+{{- $domains = append $domains $domain -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- $domains = uniq $domains -}}
+{{- range $domain := $domains -}}
+{{- $domain_number := trimPrefix "domain_" $domain | int -}}
+---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata: 
   labels:
     prometheus: infra-collector
-  name: px
+  name: px-domain-{{ $domain_number }}
   namespace: px
 spec: 
-  namespaceSelector: 
-    matchNames: 
-    - px
+  selector:
+    matchLabels:
+      pxdomain: '{{ $domain_number }}'
   podMetricsEndpoints: 
   - honorLabels: true
     interval: 60s
     metricRelabelings: 
     - action: replace
-      regex: ^bird_.+;{{ .Values.global.region }}-pxrs-([0-9])-s([0-9])-([0-9])
+      regex: ^bird_.+;{{ $.Values.global.region }}-pxrs-([0-9])-s([0-9])-([0-9])
       replacement: $1
       sourceLabels: 
       - __name__
       - app
       targetLabel: pxdomain
     - action: replace
-      regex: ^bird_.+;{{ .Values.global.region }}-pxrs-([0-9])-s([0-9])-([0-9])
+      regex: ^bird_.+;{{ $.Values.global.region }}-pxrs-([0-9])-s([0-9])-([0-9])
       replacement: $2
       sourceLabels: 
       - __name__
       - app
       targetLabel: pxservice
     - action: replace
-      regex: ^bird_.+;{{ .Values.global.region }}-pxrs-([0-9])-s([0-9])-([0-9])
+      regex: ^bird_.+;{{ $.Values.global.region }}-pxrs-([0-9])-s([0-9])-([0-9])
       replacement: $3
       sourceLabels: 
       - __name__
@@ -73,20 +84,14 @@ spec:
       - __meta_kubernetes_pod_name
       targetLabel: kubernetes_pod_name
     - action: replace
-      replacement: {{ .Values.global.region }}
+      replacement: {{ $.Values.global.region }}
       targetLabel: region
     - action: replace
       replacement: controlplane
       targetLabel: cluster_type
     - action: replace
-      replacement: {{ .Values.global.region }}
+      replacement: {{ $.Values.global.region }}
       targetLabel: cluster
     scheme: http
     scrapeTimeout: 55s
-  selector: 
-    matchExpressions: 
-    - key: app.kubernetes.io/name
-      operator: In
-      values: 
-      - px
-{{ end }}
+{{- end -}}


### PR DESCRIPTION
Carve the podmonitor again out of the bird.yaml file and deploy it for every domain found usning loops to find out which domains exists. Previous chart did not deploy the podmonitor at all, since it was in a conditional that requires pxmon to be present.