### PR TITLE
[dns][bind] health check

### DIFF
--- a/system/bind/templates/config.yaml
+++ b/system/bind/templates/config.yaml
@@ -63,7 +63,7 @@ data:
     };
   {{- end }}
   healthz: |
-    #!/bin/bash
-    rndc -s $(hostname -i) status
+    #!/bin/sh
+    rndc status
     return $?
     };


### PR DESCRIPTION
There is not neccessarily a bash in the image, and the script gets called via sh externally anyhow.
Additionally hostname -i is deprecated and to work it requires working name resolution but could return a different IP than the local one. 
Anyhow, because rndc uses localhost by default, the parameter can be omitted completely.