### PR TITLE
[dns][bind] adding serverid with region

### DIFF
--- a/system/bind/templates/config.yaml
+++ b/system/bind/templates/config.yaml
@@ -6,6 +6,7 @@ metadata:
 data:
   named.conf: |
      options {
+      server-id "{{ .Values.name }}.{{ .Values.global.region }}";
       directory "/var/lib/bind";
       dnssec-validation auto;
       auth-nxdomain no; # conform to RFC1035


### PR DESCRIPTION
Will enable querying the server name and region using
`dig CH TXT id.server`
