### PR TITLE
[dns][unbound] adding serverid with region

### DIFF
--- a/system/unbound/templates/config.yaml
+++ b/system/unbound/templates/config.yaml
@@ -6,6 +6,7 @@ metadata:
 data:
   unbound.conf: |
        server:
+        identity: "{{ .Values.unbound.name }}.{{ .Values.global.region }}"
         interface: {{.Values.unbound.interface}}
         port: 53
         do-ip4: yes


### PR DESCRIPTION
add server name and region to config, so we can query them using
`dig CH TXT id.server`