### PR TITLE
[nova] Re-enable heartbeat in pthread for uwsgi

### DIFF
--- a/openstack/nova/templates/api-deployment.yaml
+++ b/openstack/nova/templates/api-deployment.yaml
@@ -62,6 +62,10 @@ spec:
               value: "localhost"
             - name: STATSD_PORT
               value: "9125"
+            {{- if .Values.api.use_uwsgi }}
+            - name: OS_OSLO_MESSAGING_RABBIT__HEARTBEAT_IN_PTHREAD
+              value: "true"
+            {{- end }}
             {{- if .Values.sentry.enabled }}
             - name: SENTRY_DSN
               valueFrom:


### PR DESCRIPTION
Heartbeat in pthread has been disabled due to
https://bugs.launchpad.net/oslo.messaging/+bug/1961402

But uwsgi needs that setting, so we override in that case via environment according to
https://docs.openstack.org/oslo.config/xena/reference/drivers.html#module-oslo_config.sources._environment

Similarly like already done in neutron 58520f0