### PR TITLE
[cinder] disable heartbeat_in_pthread for non wsgi

### DIFF
--- a/openstack/cinder/templates/api-deployment.yaml
+++ b/openstack/cinder/templates/api-deployment.yaml
@@ -68,6 +68,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            {{- if .Values.api.use_uwsgi }}
+            - name: OS_OSLO_MESSAGING_RABBIT__HEARTBEAT_IN_PTHREAD
+              value: "true"
+            {{- end }}
           lifecycle:
             preStop:
               {{- include "utils.snippets.pre_stop_graceful_shutdown" . | indent 14 }}

--- a/openstack/cinder/templates/etc/_cinder.conf.tpl
+++ b/openstack/cinder/templates/etc/_cinder.conf.tpl
@@ -61,6 +61,8 @@ sap_allow_independent_clone = {{ .Values.sap_allow_independent_clone }}
 
 {{- include "ini_sections.database" . }}
 
+{{ include "ini_sections.oslo_messaging_rabbit" . }}
+
 {{- include "osprofiler" . }}
 
 [keystone_authtoken]


### PR DESCRIPTION
We observed hanging agents like reported in https://bugs.launchpad.net/oslo.messaging/+bug/1961402 in manila and neutron.
The bug was introduced in wallaby, so we disable it by default.

But wsgi needs that setting, so we override in that case via environment according to https://docs.openstack.org/oslo.config/xena/reference/drivers.html#module-oslo_config.sources._environment

Similarly like already done in neutron 58520f04d86e6479e8fa02e265bb7619e91ed10f