### PR TITLE
[prometheus-infra-global] alert not longer needed

### DIFF
--- a/global/prometheus-infra/Chart.yaml
+++ b/global/prometheus-infra/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for the operated global Prometheus for monitoring infrastructure.
 name: prometheus-infra
-version: 1.0.9
+version: 1.0.10
 dependencies:
   - name: prometheus-server-pre7
     alias: prometheus-infra-global

--- a/global/prometheus-infra/alerts/prometheus.alerts
+++ b/global/prometheus-infra/alerts/prometheus.alerts
@@ -14,16 +14,3 @@ groups:
       description: Global Infrastructure Prometheus can't federate data{{ if $labels.instance }} from `{{ $labels.instance }}`.{{ else if $labels.region }} from `{{ $labels.region }}`.{{ else }}.{{ end }}
         Alerting will be unavailable! This could mean the region is partly down!
       summary: Global Infrastructure Prometheus federation is having trouble.
-
-  - alert: InfraGlobalPrometheusThanosLogsNotShipping
-    expr: prometheus_tsdb_storage_blocks_bytes > 4000000000
-    for: 15m
-    labels:
-      meta: Global Infrastructure Prometheus Thanos logs are piling up in memory in {{ $labels.region }}.
-      support_group: observability
-      service: metrics
-      severity: info
-      tier: monitor
-    annotations:
-      description: Thanos logs in  /prometheus are not properly shipped to swift. It should only host up to 1GB of data. Pod restart might be required.
-      summary: Global Infrastructure Proemtheus is not properly shipping logs


### PR DESCRIPTION
old thanos version which produced this error is not around anymore.