### PR TITLE
[Swift] kernel.panic_on_oops=0 and more resources for HAProxy

### DIFF
--- a/openstack/swift-drive-autopilot/templates/daemonset.yaml
+++ b/openstack/swift-drive-autopilot/templates/daemonset.yaml
@@ -62,7 +62,6 @@ spec:
         - name: coreos
           hostPath:
             path: /
-      {{- if hasPrefix "qa" $.Values.global.region }}
       initContainers:
       - name: sysctl
         image: {{$.Values.global.registryAlternateRegion}}/swift-drive-autopilot:{{include "image_version" $}}
@@ -72,7 +71,6 @@ spec:
         securityContext:
           runAsUser: 0
           privileged: true
-      {{- end }}
       containers:
         - name: boot
           image: {{$.Values.global.registryAlternateRegion}}/swift-drive-autopilot:{{include "image_version" $}}

--- a/openstack/swift/templates/etc/_haproxy.cfg.tpl
+++ b/openstack/swift/templates/etc/_haproxy.cfg.tpl
@@ -7,7 +7,7 @@ global
   log stdout format raw local0 info
   zero-warning
 
-  maxconn 4000
+  maxconn 2000
 
   # TODO: Should be replaced by https://ssl-config.mozilla.org/#server=haproxy&version=2.3&config=intermediate&openssl=1.1.1d&guideline=5.6
   # AES256-SHA256 seems to be needed for iPXE with tlsv1.2

--- a/openstack/swift/templates/haproxy-deployment.yaml
+++ b/openstack/swift/templates/haproxy-deployment.yaml
@@ -27,7 +27,7 @@ metadata:
     os-cluster: {{ $.Values.cluster_name }}
 spec:
   revisionHistoryLimit: 5
-  {{- $replicas_az := default 2.0 (index $.Values (printf "haproxy_deployment_replicas_%s" $az)) }}
+  {{- $replicas_az := default 4.0 (index $.Values (printf "haproxy_deployment_replicas_%s" $az)) }}
   {{- if lt $replicas_az 0.0 }}
   {{- /* To explicit disable in an AZ, replicas must be set negative, otherwise 0 will trigger the default */ -}}
   {{- $replicas_az = 0.0 }}

--- a/openstack/swift/values.yaml
+++ b/openstack/swift/values.yaml
@@ -143,8 +143,8 @@ alerts:
 #    name: node1
 
 # haproxy nodes act as LBs in front of the Swift proxies
-haproxy_deployment_resources_cpu: "1500m"
-haproxy_deployment_resources_memory: "600Mi"
+haproxy_deployment_resources_cpu: "2000m"
+haproxy_deployment_resources_memory: "1024Mi"
 
 # # Swift proxies can be deployed as Deployment, Daemonset or both
 # proxy_deployment_enabled: true


### PR DESCRIPTION
- swift-drive-auto-pilot: disable `kernel.panic_on_oops` in all regions
- swift HAProxy:
  - lower maxconn from 4000 to 2000
  - increase default replicas per AZ from 2 to 4
  - increase cpu and memory requests