### PR TITLE
Adding parent object properties

### DIFF
--- a/system/vmware-monitoring/templates/collector-configmap.yaml
+++ b/system/vmware-monitoring/templates/collector-configmap.yaml
@@ -313,6 +313,12 @@ data:
         key: "summary|guest|toolsVersionStatus2"
       - metric_suffix: "summary_datastore"
         key: "summary|datastore"
+      - metric_suffix: "summary_parent_host"
+        key: "summary|parentHost"
+      - metric_suffix: "summary_parent_cluster"
+        key: "summary|parentCluster"
+      - metric_suffix: "summary_parent_vcenter"
+        key: "summary|parentVcenter"
 
     VMStatsMemoryCollector:
     # INFO - Prefix: vrops_virtualmachine_


### PR DESCRIPTION
Sometimes we get false positive alerts, because the information from the vrops-inventory is outdated.

Would it make sense to compare i.e. the hostsystem label with the parent host from the parentHost property?