### PR TITLE
arc, lyra: bump pgbackup to 0.1.7

### DIFF
--- a/openstack/arc/Chart.lock
+++ b/openstack/arc/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 0.2.0
 - name: pgbackup
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.2
+  version: 0.1.7
 - name: pgmetrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.3.5
-digest: sha256:85ca035213099ca016104f214dfcb92f3dc179e6cc00cc67d3de3dcaea76eccb
-generated: "2023-01-25T15:15:50.347978872+01:00"
+digest: sha256:e27dbd28d381e29b068373431487649c352160639977f00963473c40a102852c
+generated: "2023-02-21T14:58:21.208848743+01:00"

--- a/openstack/arc/Chart.yaml
+++ b/openstack/arc/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
     version: 0.2.0
   - name: pgbackup
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.2
+    version: 0.1.7
   - name: pgmetrics
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.3.5

--- a/openstack/lyra/Chart.lock
+++ b/openstack/lyra/Chart.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 0.3.0
 - name: pgbackup
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.2
+  version: 0.1.7
 - name: pgmetrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.3.1
-digest: sha256:e3390fc94e2c2ade6427225d7fd8eb5b2385b2fb32e57ed3f04eb2aeef7eaf73
-generated: "2023-01-24T16:53:16.498265404+01:00"
+digest: sha256:fc9c861b8d857e44b2c93cdc2f82f7241eb9da81c7452c8698fabcb20c46bcdc
+generated: "2023-02-21T14:58:24.960832949+01:00"

--- a/openstack/lyra/Chart.yaml
+++ b/openstack/lyra/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
     version: 0.3.0
   - name: pgbackup
     repository: "https://charts.eu-de-2.cloud.sap"
-    version: 0.1.2
+    version: 0.1.7
   - name: pgmetrics
     repository: "https://charts.eu-de-2.cloud.sap"
     version: 0.3.1


### PR DESCRIPTION
This updates backup-tools from 0.7.0 to 0.8.1, with the following changes:

- All usage of python-swiftclient is replaced with native Go code, thereby reducing CPU consumption and memory usage spikes.
- Backups are streamed directly into Swift instead of going through the local filesystem first.

Furthermore, the Helm chart has been extended with a configurable memory limit that is raised in the big regions (see companion PR in cc/secrets). This should permanently fix the current backup pod instability in eu-de-1/2.