### PR TITLE
[nova] Fix nova-api-wsgi path for loci images

### DIFF
--- a/openstack/nova/templates/etc/_api_uwsgi.ini.tpl
+++ b/openstack/nova/templates/etc/_api_uwsgi.ini.tpl
@@ -15,4 +15,4 @@ die-on-term = true
 master = true
 memory-report = true
 processes = {{ .Values.api.wsgi_processes }}
-wsgi-file = /var/lib/kolla/venv/bin/nova-api-wsgi
+wsgi-file = /var/lib/openstack/bin/nova-api-wsgi


### PR DESCRIPTION
To re-allow uWSGI testing in qa-de-2.
