### PR TITLE
Federate kube_pod_container_resource_requests

### DIFF
--- a/global/prometheus-kubernetes-global/Chart.yaml
+++ b/global/prometheus-kubernetes-global/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for the operated global Prometheus for monitoring Kubernetes.
 name: prometheus-kubernetes-global
-version: 4.0.2
+version: 4.0.3
 
 dependencies:
   - name: prometheus-server-pre7

--- a/global/prometheus-kubernetes-global/values.yaml
+++ b/global/prometheus-kubernetes-global/values.yaml
@@ -65,6 +65,7 @@ allowedMetrics:
   - kube_node_status_capacity
   - kube_pod_container_resource_requests_cpu_cores
   - kube_pod_container_resource_requests_memory_bytes
+  - kube_pod_container_resource_requests
   - node_cpu_seconds_total
   - node_memory_MemTotal_bytes
   - node_memory_MemFree_bytes


### PR DESCRIPTION
It replaces kube_pod_container_resource_requests_cpu_cores and kube_pod_container_resource_requests_memory_bytes in version 2 of kube-state-metrics.