### PR TITLE
Update DatastoreNotAccessibleFromHost Alert

### DIFF
--- a/openstack/cc3test/alerts/datastore.alerts
+++ b/openstack/cc3test/alerts/datastore.alerts
@@ -3,7 +3,8 @@ groups:
   rules:
   - alert: DatastoreNotAccessibleFromHost
     expr: |
-        cc3test_vcenter_datastore_accessible_from_host == 0
+        label_replace(cc3test_vcenter_datastore_accessible_from_host, "datastore", "$1", "vc_ds", "(.+)") == 0 
+        unless on(datastore) vrops_datastore_summary_datastore_accessible == 0
     for: 30m
     labels:
       severity: warning


### PR DESCRIPTION
Update DatastoreNotAccessibleFromHost alert. Alert does not fire anymore, if the whole datastore is inaccessible. There are dedicated alerts for this case.