### PR TITLE
[MariaDB] - Backup Slow log fix

### DIFF
--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.7.5
+version: 0.7.6

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -115,7 +115,7 @@ backup_v2:
   enabled: false
   backup_dir: "./backup"
   image: maria-back-me-up
-  image_version: "20220802151433"
+  image_version: "20230209133906"
   full_backup_cron_schedule: "0 0 * * *"
   incremental_backup_in_minutes: 5
   purge_binlog_after_minutes: 60


### PR DESCRIPTION
Avoid to spamming alerts channels by slow logs by backup execution 

Image version has been changed from "20220802151433" to new image "20230209133906"