### PR TITLE
[octavia] Add loadbalancer id to "stuck in" alert

### DIFF
--- a/openstack/octavia/alerts/octavia.alerts
+++ b/openstack/octavia/alerts/octavia.alerts
@@ -88,5 +88,5 @@ groups:
       playbook: docs/support/playbook/octavia/stuck_pending
       cloudops: "?searchTerm={{ $labels.loadbalancer_id }}&type=loadbalancer"
     annotations:
-      description: 'The Load Balancer `{{ $labels.loadbalancer_name }}` of agent `{{ $labels.loadbalancer_host }}` stuck in {{ $labels.loadbalancer_status }} state (<https://dashboard.{{ $externalLabels.region }}.cloud.sap/ccadmin/cloud_admin/cloudops#/universal-search/?searchTerm={{ $labels.loadbalancer_id }}&type=loadbalancer|{{ $labels.loadbalancer_id }}>)'
+      description: 'The Load Balancer `{{ $labels.loadbalancer_name }} ({{ $labels.loadbalancer_id }})` of agent `{{ $labels.loadbalancer_host }}` stuck in {{ $labels.loadbalancer_status }} state (<https://dashboard.{{ $externalLabels.region }}.cloud.sap/ccadmin/cloud_admin/cloudops#/universal-search/?searchTerm={{ $labels.loadbalancer_id }}&type=loadbalancer|{{ $labels.loadbalancer_id }}>)'
       summary: Octavia Load-Balancer stuck in PENDING_* state


### PR DESCRIPTION
I like to have the id of everything handy, as most of our tooling works well with uuids but takes a longer time with names. Therefore we now have the loadbalancer id together with the loadbalancer name in the alert text, same as we already do for our network alerts.