### PR TITLE
adding in a key/path mapping to the tls crt and key

### DIFF
--- a/openstack/cronus/templates/cronus/deployment.yaml
+++ b/openstack/cronus/templates/cronus/deployment.yaml
@@ -108,6 +108,11 @@ spec:
               - secret:
                   name: {{$be.name}}-certs
                   optional: false
+                  items:
+                    - key: tls.crt
+                      path: {{$be.name}}.crt
+                    - key: tls.key
+                      path: {{$be.name}}.key
 {{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Now that we are using cert manager to generate client certs, the "tls.crt" and "tls.key" are hardcoded. This change maps the cert and key to the backend name.

This also makes sense as it will avoid any collisions between the backend certs.