### PR TITLE
[nova] Enable oslo.messaging's ping endpoint

### DIFF
--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -905,3 +905,4 @@ owner-info:
 
 default:
   password_all_group_samples: 2
+  rpc_ping_enabled: true


### PR DESCRIPTION
Since the Victoria release of OpenStack, oslo.messaging supports an RPC endpoint called "oslo_rpc_server_ping" [0]. This endpoint can be used to implement a generic RPC check to see if a server is still receiving messages/rpc calls via rabbitmq.

We enable this endpoint for Nova, so we can do availability checks on its services - manually for now, but we might extend this to be called automatically and alert on it.

[0] https://github.com/sapcc/oslo.messaging/commit/82492442f3387a0e4f19623ccfda64f8b84d59c3