### PR TITLE
[cinder] Enable oslo.messaging's ping endpoint

### DIFF
--- a/openstack/cinder/templates/etc/_cinder.conf.tpl
+++ b/openstack/cinder/templates/etc/_cinder.conf.tpl
@@ -30,6 +30,7 @@ auth_strategy = keystone
 
 rpc_response_timeout = {{ .Values.rpc_response_timeout | default .Values.global.rpc_response_timeout | default 600 }}
 rpc_workers = {{ .Values.rpc_workers | default .Values.global.rpc_workers | default 1 }}
+rpc_ping_enabled = {{ .Values.rpc_ping_enabled }}
 
 {{- if not .Values.api.use_uwsgi }}
 osapi_volume_workers = {{ .Values.osapi_volume_workers | default .Values.api.workers }}

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -94,6 +94,8 @@ sap_disable_incremental_backup: True
 sap_allow_independent_snapshots: True
 sap_allow_independent_clone: True
 
+rpc_ping_enabled: true
+
 proxysql:
   mode: null # Disabled by default
 


### PR DESCRIPTION
Since the Victoria release of OpenStack, oslo.messaging supports an RPC endpoint called "oslo_rpc_server_ping" [0]. This endpoint can be used to implement a generic RPC check to see if a server is still receiving messages/rpc calls via rabbitmq.

[0] https://github.com/sapcc/oslo.messaging/commit/82492442f3387a0e4f19623ccfda64f8b84d59c3