### PR TITLE
[manila] Enable oslo.messaging's ping endpoint

### DIFF
--- a/openstack/manila/templates/etc/_manila.conf.tpl
+++ b/openstack/manila/templates/etc/_manila.conf.tpl
@@ -29,6 +29,7 @@ periodic_interval = {{ .Values.periodic_interval | default 300 }}
 
 rpc_response_timeout = {{ .Values.rpc_response_timeout | default .Values.global.rpc_response_timeout | default 300 }}
 rpc_workers = {{ .Values.rpc_workers | default .Values.global.rpc_workers | default 1 }}
+rpc_ping_enabled = {{ .Values.rpc_ping_enabled }}
 
 # time to live in sec of idle connections in the pool:
 conn_pool_ttl = {{ .Values.rpc_conn_pool_ttl | default 600 }}

--- a/openstack/manila/values.yaml
+++ b/openstack/manila/values.yaml
@@ -21,6 +21,7 @@ loci:
 api_port_internal: '8786'
 api_backdoor: false
 debug: "True"
+rpc_ping_enabled: true
 
 coordinationBackend: 'file'
 wsgi_processes: 8


### PR DESCRIPTION
Since the Victoria release of OpenStack, oslo.messaging supports an RPC endpoint called "oslo_rpc_server_ping" [0]. This endpoint can be used to implement a generic RPC check to see if a server is still receiving messages/rpc calls via rabbitmq.

[0] https://github.com/sapcc/oslo.messaging/commit/82492442f3387a0e4f19623ccfda64f8b84d59c3