### PR TITLE
[audit-logs] renames kube-api requestObject label app to app_

### DIFF
--- a/system/audit-logs/Chart.lock
+++ b/system/audit-logs/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: fluent-audit-container
   repository: file://vendor/fluent-audit-container
-  version: 2.0.44
+  version: 2.0.45
 - name: fluent-audit-systemd
   repository: file://vendor/fluent-audit-systemd
   version: 2.0.6
@@ -20,5 +20,5 @@ dependencies:
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:87e4eab93116cd10bedc8cc48955598b71c4c4372deaac87df34fbbb675d3614
-generated: "2023-02-22T17:48:20.266511+01:00"
+digest: sha256:e2de910ffc9879abf36928fcfdd41c1fb6cbb540ddc1c4eef888971214f416a3
+generated: "2023-02-28T11:59:55.812826+01:00"

--- a/system/audit-logs/Chart.yaml
+++ b/system/audit-logs/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
 description: Audit logging components
 name: audit-logs
-version: 0.1.58
+version: 0.1.59
 dependencies:
   - name: fluent-audit-container
     alias: fluent_audit_container
     repository: file://vendor/fluent-audit-container
-    version: 2.0.44
+    version: 2.0.45
     condition: fluent_audit_container.enabled
 
   - name: fluent-audit-systemd

--- a/system/audit-logs/vendor/fluent-audit-container/Chart.yaml
+++ b/system/audit-logs/vendor/fluent-audit-container/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluent-audit-container
-version: 2.0.44
+version: 2.0.45
 description: fluent audit log collector
 maintainers:
   - name: Olaf Heydorn

--- a/system/audit-logs/vendor/fluent-audit-container/templates/_fluent.conf.tpl
+++ b/system/audit-logs/vendor/fluent-audit-container/templates/_fluent.conf.tpl
@@ -124,8 +124,12 @@
 </filter>
 # remove fields which cause parsing errors in elastic and are not audit relevant
 <filter kubeapi.**>
-  @type record_transformer
-  remove_keys $["requestObject"]["metadata"]["labels"]["app.kubernetes.io/managed-by"],$.requestObject.metadata.managedFields
+  @type record_modifier
+  enable_ruby
+  <record>
+  temp ${ t = record.dig("requestObject","metadata","labels","app"); record["requestObject"]["metadata"]["labels"]["app.kubernetes.io/name"] = t; nil;}
+  </record>
+  remove_keys temp,$.requestObject.metadata.labels.app,$.requestObject.metadata.managedFields
 </filter>
 {{- end }}
 


### PR DESCRIPTION
Log ingestions breaks if some contain a label app and others app.kubernetes.io/name 
Renaming app to app_ avoids this issue during log ingestion