### PR TITLE
storeendpoint namespace like thanos

### DIFF
--- a/common/prometheus-server/CHANGELOG.md
+++ b/common/prometheus-server/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 7.1.34 - 7.1.35
+## 7.1.34 - 7.1.36
 
 * SidecarDiscovey added
 

--- a/common/prometheus-server/Chart.yaml
+++ b/common/prometheus-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus via operator.
 name: prometheus-server
-version: 7.1.35
+version: 7.1.36
 appVersion: v2.39.1
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
 maintainers:

--- a/common/prometheus-server/templates/thanos/storeendpoint.yaml
+++ b/common/prometheus-server/templates/thanos/storeendpoint.yaml
@@ -7,6 +7,9 @@ apiVersion: monitoring.banzaicloud.io/v1alpha1
 kind: StoreEndpoint
 metadata:
   name: {{ include "prometheus.name" (list $name $root) }}-to-{{ $thanos.thanosName }}
+  {{- if $thanos.thanosNamespace }}
+  namespace: {{ $thanos.thanosNamespace }} 
+  {{- end}}
 spec:
   {{- if $thanos.domain }}
   url: {{ include "prometheus.name" (list $name $root) }}.{{ $thanos.namespace }}.svc.{{ $thanos.domain }}.{{- required ".Values.global.region missing" $root.Values.global.region -}}.{{- required ".Values.global.domain missing" $root.Values.global.domain }}:10901

--- a/common/prometheus-server/values.yaml
+++ b/common/prometheus-server/values.yaml
@@ -209,8 +209,10 @@ thanos:
   # When there is no store activated (objectStorageConfig.enabled = false) you can have this sidecar detected by the operator
   # using a StoreEndpoint. You need to specify which thanos should pick up the sidecar. This Thanos needs to run QueryDiscovery.
   # domain defaults to cluster.local and only needs to be set if it differs
+  # thanosNamespace needs to be set, if the thanos specified with thanosName resides in a Sidecar disjunct namespace. 
   sidecarDiscovery:
     - thanosName:
+      # thanosNamespace:
       namespace:
       # domain:
 


### PR DESCRIPTION
the storeendpoint must be created in the respective thanos namespace, otherwise the operator would complain about thanos not being available