### PR TITLE
[nova] Update utils chart dependency to 0.7.4

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 0.0.12
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.2
+  version: 0.7.4
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.7.5
@@ -26,5 +26,5 @@ dependencies:
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:da30d2c70b19dbf13d86031fe9d0258595081a861ebde2e045f06b9d66f1d955
-generated: "2023-02-07T16:46:59.251624703+01:00"
+digest: sha256:ddc985639b709fcd49dd39fe1d5178d5fcc1332b52511660dd60b1bc99f5a418
+generated: "2023-03-02T12:27:51.724145481+01:00"


### PR DESCRIPTION
This includes the revert of the premature switch to `topology.kubernetes.io/zone` in 3a66513 (which reverts 3987bc7), and a fix for template values validation for proxysql (https://github.com/sapcc/helm-charts/commit/fcab93396dc77fc42c8cce6dc3fd9febe6d7ca36).
