### PR TITLE
Remove custom metric summary|CPO vCSA Certificate Remaining Days

### DIFF
--- a/system/vmware-monitoring/templates/collector-configmap.yaml
+++ b/system/vmware-monitoring/templates/collector-configmap.yaml
@@ -271,8 +271,6 @@ data:
         key: "diskspace|total_capacity"
       - metric_suffix: "diskspace_usage_gigabytes"
         key: "diskspace|total_usage"
-      - metric_suffix: "vcsa_certificate_remaining_days"
-        key: "summary|CPO vCSA Certificate Remaining Days"
 
     VCenterPropertiesCollector:
     # INFO - Prefix: vrops_vcenter_


### PR DESCRIPTION
Covered by native metric summary|cert_expiry_date