### PR TITLE
hubcopter: simplify values structure

### DIFF
--- a/system/hubcopter/templates/configmap-html.yaml
+++ b/system/hubcopter/templates/configmap-html.yaml
@@ -12,8 +12,8 @@ data:
     <main>
       <h1>Hubcopter 🚁💨</h1>
       <ul>
-{{- range $instance, $description := required ".Values.hubcopter.instances is missing" .Values.hubcopter.instances }}
-        <li><a href="/{{ $instance }}/">{{ $description }}</a></li>
+{{- range .Values.hubcopter.instances }}
+        <li><a href="/{{ .id }}/">{{ .name | default .id }}</a></li>
 {{- end }}
       </ul>
     </main>

--- a/system/hubcopter/templates/configmap.yaml
+++ b/system/hubcopter/templates/configmap.yaml
@@ -1,14 +1,14 @@
-{{- range $key, $value := (required ".Values.hubcopter.instances is missing" .Values.hubcopter.instances) }}
+{{- range .Values.hubcopter.instances }}
 ---
 apiVersion: v1
 kind: ConfigMap
 
 metadata:
-  name: hubcopter-config-{{ $key }}
+  name: hubcopter-config-{{ .id }}
 
 data:
   hubcopter.yaml: |
-    {{ required (printf ".Values.hubcopter.config-%s is missing" $key) (get $.Values.hubcopter (printf "config-%s" $key)) | nindent 4 }}
+    {{ .api_config | required (printf "api_config is missing for instance %q" .id) | toYaml | nindent 4 }}
     regionQuality:
       {{ toYaml $.Values.hubcopter.regionQuality | nindent 6 }}
 {{- end }}

--- a/system/hubcopter/templates/deployment-api.yaml
+++ b/system/hubcopter/templates/deployment-api.yaml
@@ -1,10 +1,10 @@
-{{- range $key, $value := (required ".Values.hubcopter.instances is missing" .Values.hubcopter.instances) }}
+{{- range $instance := .Values.hubcopter.instances }}
 ---
 kind: Deployment
 apiVersion: apps/v1
 
 metadata:
-  name: hubcopter-api-{{ $key }}
+  name: hubcopter-api-{{ .id }}
 
 spec:
   revisionHistoryLimit: 5
@@ -16,11 +16,11 @@ spec:
       maxSurge: 1
   selector:
     matchLabels:
-      name: hubcopter-api-{{ $key }}
+      name: hubcopter-api-{{ .id }}
   template:
     metadata:
       labels:
-        name: hubcopter-api-{{ $key }}
+        name: hubcopter-api-{{ .id }}
         alert-tier: os
         alert-service: hubcopter
       annotations:
@@ -42,7 +42,7 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: hubcopter-config-{{ $key }}
+            name: hubcopter-config-{{ .id }}
       initContainers:
         - name: wait-for-glas
           env:

--- a/system/hubcopter/templates/ingress.yaml
+++ b/system/hubcopter/templates/ingress.yaml
@@ -27,12 +27,12 @@ spec:
                 name: hubcopter-html
                 port:
                   number: 80
-{{- range $key, $value := required ".Values.hubcopter.instances is missing" .Values.hubcopter.instances }}
-          - path: /{{ $key }}/(.*)
+{{- range .Values.hubcopter.instances }}
+          - path: /{{ .id }}/(.*)
             pathType: Prefix
             backend:
               service:
-                name: hubcopter-api-{{ $key }}
+                name: hubcopter-api-{{ .id }}
                 port:
                   number: 8080
 {{- end }}

--- a/system/hubcopter/templates/service.yaml
+++ b/system/hubcopter/templates/service.yaml
@@ -24,17 +24,17 @@ spec:
   ports:
     - port: 80
 
-{{- range $key, $value := (required ".Values.hubcopter.instances is missing" .Values.hubcopter.instances) }}
+{{- range .Values.hubcopter.instances }}
 ---
 kind: Service
 apiVersion: v1
 
 metadata:
-  name: hubcopter-api-{{ $key }}
+  name: hubcopter-api-{{ .id }}
 
 spec:
   selector:
-    name: hubcopter-api-{{ $key }}
+    name: hubcopter-api-{{ .id }}
   ports:
     - port: 8080
 {{- end }}

--- a/system/hubcopter/values.yaml
+++ b/system/hubcopter/values.yaml
@@ -6,7 +6,7 @@ owner-info:
     - Stefan Majewsky
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/system/hubcopter
 
-# NOTE: This chart shares the regional values.yaml file with the `system/hubcopter` chart.
+# NOTE: This chart shares the regional values.yaml file with the `system/hubcopter-seeds` chart.
 
 hubcopter:
   service_password: null   # provided by regional values.yaml
@@ -15,8 +15,12 @@ hubcopter:
     username: null
     password: null
 
-  instances:
-    - default: Default
+  # Entries must have the following form:
+  #
+  #   - id:         <machine-readable short ID>
+  #     name:       <human-readable team name>
+  #     api_config: <config for hubcopter-api>
+  instances: []
 
   image_tag: DEFINED_BY_PIPELINE
 


### PR DESCRIPTION
Instead of constructing IDs in one structure from values of another structure, both structures are nested together.

I also removed several `required` calls that were ineffective because a default value was given in the Chart's `values.yaml`.

I also updated said default value to match what the code expects. The new behavior now is to not deploy any instances at all if none are configured explicitly, which is safe (albeit useless).