### PR TITLE
hubcopter: fix Keystone selection

### DIFF
--- a/system/hubcopter/templates/deployment-api.yaml
+++ b/system/hubcopter/templates/deployment-api.yaml
@@ -74,7 +74,7 @@ spec:
               value: 'true' # turn off
             - *HUBCOPTER_GLAS_URL
             - name:  OS_AUTH_URL
-              value: "https://identity-3.{{ $.Values.global.region }}.{{ $.Values.global.tld }}/v3"
+              value: "https://identity-3.{{ $.Values.hubcopter.tenso_region }}.{{ $.Values.global.tld }}/v3"
             - name:  OS_AUTH_VERSION
               value: '3'
             - name:  OS_IDENTITY_API_VERSION
@@ -91,7 +91,7 @@ spec:
             - name:  OS_PROJECT_NAME
               value: 'master'
             - name:  OS_REGION_NAME
-              value: {{ quote $.Values.global.region }}
+              value: {{ quote $.Values.hubcopter.tenso_region }}
             - name:  OS_USER_DOMAIN_NAME
               value: 'Default'
             - name:  OS_USERNAME


### PR DESCRIPTION
We need to access Swift in the region that has the tenso-deployment-events container, which is not always the local region.