### PR TITLE
[unbound] config update:

### DIFF
--- a/system/unbound/Chart.yaml
+++ b/system/unbound/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 description: Unbound DNS Recursor 
 name: unbound
 version: 1.0.1

--- a/system/unbound/ci/test-values.yaml
+++ b/system/unbound/ci/test-values.yaml
@@ -3,6 +3,7 @@ global:
   tld: test.corp
   imageRegistry: testRepo
   image_namespace: testNamespace
+  registryAlternateRegion: test-1
 
 unbound:
   name: "testunbound"

--- a/system/unbound/templates/config.yaml
+++ b/system/unbound/templates/config.yaml
@@ -37,6 +37,14 @@ data:
         rrset-cache-size: 100m
         msg-cache-size: 50m
 
+        # prefetch cache before expiration
+        prefetch: yes
+
+        # to serve stale records
+        serve-expired: yes
+        serve-expired-ttl: 3600
+        serve-expired-client-timeout: 1800
+
         # Faster UDP with multithreading (only on Linux)
         so-reuseport: yes
         


### PR DESCRIPTION
- enable prefetch to keep cache up-to-date
- enable serving expired for stale, expired data

- also make linter happy; switch to api v2 chart