### PR TITLE
[nova] Set image default architecture for scheduler

### DIFF
--- a/openstack/nova/templates/etc/_nova-scheduler.conf.tpl
+++ b/openstack/nova/templates/etc/_nova-scheduler.conf.tpl
@@ -27,3 +27,4 @@ io_ops_weight_multiplier = {{ .Values.scheduler.io_ops_weight_multiplier }}
 soft_affinity_weight_multiplier = {{ .Values.scheduler.soft_affinity_weight_multiplier }}
 prefer_same_host_resize_weight_multiplier = {{ .Values.scheduler.prefer_same_host_resize_weight_multiplier }}
 hv_ram_class_weight_multiplier = {{ .Values.scheduler.hv_ram_class_weight_multiplier }}
+image_properties_default_architecture = {{ .Values.scheduler.image_properties_default_architecture }}

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -268,6 +268,7 @@ scheduler:
   # if it doesn't have to - even if it's in the wrong RAM class currently.
   prefer_same_host_resize_weight_multiplier: 1000.0
   hv_ram_class_weight_multiplier: 100.0
+  image_properties_default_architecture: "x86_64"
 
 compute:
   defaults:


### PR DESCRIPTION
The scheduler decides according to the image properties on which hypervisor to put the vm.
That requires hw_architecture to be set, but for convenience we can set a default architecture in the schedulers config