### PR TITLE
[Cinder] Bump mariadb and memcached chart versions

### DIFF
--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -4,13 +4,13 @@ dependencies:
   version: 0.4.2
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.5
+  version: 0.7.6
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.7
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.0.11
+  version: 0.1.0
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.5.1
@@ -20,5 +20,5 @@ dependencies:
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:2d1dd8b3f58ab289b40bb998f7250212e58f80f1c221ea755478d6d27e9579d2
-generated: "2023-02-13T10:40:09.909671+01:00"
+digest: sha256:bf63449b11fdefe9c712c20c780f8a09f7307094ec11fc86c7614470c99361cc
+generated: "2023-03-09T09:10:33.752945-05:00"

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
     version: 0.4.2
   - name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.7.5
+    version: 0.7.6
     condition: mariadb.enabled
   - name: mysql_metrics
     repository: https://charts.eu-de-2.cloud.sap
@@ -17,7 +17,7 @@ dependencies:
     condition: mariadb.enabled
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.0.11
+    version: 0.1.0
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.5.1


### PR DESCRIPTION
This patch updates the mariadb chart to 0.7.6 and
memcached to 0.1.0