### PR TITLE
Add env-vars snippet for pyroscope

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.7.4
+version: 0.8.0

--- a/openstack/utils/templates/_env.tpl
+++ b/openstack/utils/templates/_env.tpl
@@ -1,0 +1,15 @@
+{{- define "utils.env.pyroscope" }}
+    {{- $envAll := index . 0 -}}
+    {{- $application := index . 1 -}}
+    {{- with $envAll }}
+        {{- $settings := merge (get .Values.pyroscope $application) (dict "app_name" $application) .Values.pyroscope.defaults .Values.utils.pyroscope_defaults }}
+        {{- if $settings.enabled }}
+            {{- range $k, $v := $settings }}
+                {{- if not (eq $k "enabled") }}
+- name: PYRO_{{ $k | upper}}
+  value: "{{ $v }}"
+                {{- end }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end }}

--- a/openstack/utils/values.yaml
+++ b/openstack/utils/values.yaml
@@ -11,3 +11,19 @@ cors:
   # default headers. additional headers can be specified via {cors:
   # {additional_allow_headers: "comma,separated,values"}} in the parent chart
   allow_headers: 'Accept,Content-Type,OpenStack-API-Version,User-Agent,X-Auth-Token,X-Openstack-Request-Id'
+
+pyroscope_defaults:
+  enabled: false
+  # app_subset: regular expression, i.e. "[0,2,4,6,8,a-m]$"
+  # tags: null # a=1;b=c
+  # url: 'http://pyroscope:4040'
+  # auth_token: null
+  # enable_logging: false
+  # sample_rate: 100
+  # detect_subprocesses: true
+  # oncpu: true
+  # native: false
+  # gil_only: true
+  # report_pid: false
+  # report_thread_id: false
+  # report_thread_name: false


### PR DESCRIPTION
The snippet should take care of setting all the environment variables,
taking the defaults from utils, allowing an chart level override, but
also one on an application-level.

It requires a python user-customization file merge in sapcc/loci#15,
and additionally, the process cannot be run as root,
as a root process in a container is more restricted than a non-root user
one.

All settings from pyroscope can be set via the `PYRO_*` environment
variables.

Additionally, there is the `PYRO_APP_SUBSET` variable,
which is a regular expression, which needs to match the hostname,
for the agent to be come active.
The idea is, that you can thereby select a subset of the application
instances to be sampled for a potential A/B split.