### PR TITLE
keppel: expose health-monitor result on GET /healthcheck

### DIFF
--- a/openstack/keppel/templates/deployment-health-monitor.yaml
+++ b/openstack/keppel/templates/deployment-health-monitor.yaml
@@ -23,8 +23,6 @@ spec:
         alert-service: keppel
       annotations:
         checksum/secret: {{ include "keppel/templates/secret.yaml" . | sha256sum }}
-        prometheus.io/scrape: "true"
-        prometheus.io/targets: "openstack"
     spec:
       containers:
         - name: monitor
@@ -58,7 +56,7 @@ spec:
             - name:  OS_USERNAME
               value: 'keppel'
           ports:
-            - name: metrics
+            - name: http
               containerPort: 8080
           # NOTE: This is only a readiness probe for a reason.
           # - We want the readiness probe to have `k rollout status` fail (and

--- a/openstack/keppel/templates/ingress-api.yaml
+++ b/openstack/keppel/templates/ingress-api.yaml
@@ -25,6 +25,13 @@ spec:
                 name: keppel-api
                 port:
                   number: 80
+          - path: /healthcheck # this is used by the loadbalancer for keppel.global to monitor the health of this region
+            pathType: Exact
+            backend:
+              service:
+                name: keppel-health-monitor
+                port:
+                  number: 80
     - host: '*.keppel.{{ .Values.global.region }}.{{ .Values.global.tld }}'
       http:
         paths:

--- a/openstack/keppel/templates/service-health-monitor.yaml
+++ b/openstack/keppel/templates/service-health-monitor.yaml
@@ -1,0 +1,17 @@
+kind: Service
+apiVersion: v1
+
+metadata:
+  # This is used by the loadbalancer for keppel.global to monitor the health of this region (cf. ingress-api).
+  name: keppel-health-monitor
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/targets: "openstack"
+
+spec:
+  selector:
+    name: keppel-health-monitor
+  ports:
+    - name: metrics # this specific name is required for Prometheus scraping
+      port: 8080
+      protocol: TCP


### PR DESCRIPTION
This can be used by the F5 for keppel.global to monitor the health of the Keppel API in an E2E fashion (including basic health of Keystone and Swift).