### PR TITLE
common/thanos: thanos ruler functionality added

### DIFF
--- a/common/thanos/Chart.yaml
+++ b/common/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: Deploy Thanos via operator
 type: application
-version: 0.2.2
+version: 0.3.0
 appVersion: v0.28.1
 maintainers:
   - name: Tommy Sauer (viennaa)

--- a/common/thanos/Chart.yaml
+++ b/common/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: Deploy Thanos via operator
 type: application
-version: 0.2.16
+version: 0.2.2
 appVersion: v0.28.1
 maintainers:
   - name: Tommy Sauer (viennaa)

--- a/common/thanos/templates/_thanos_helpers.tpl
+++ b/common/thanos/templates/_thanos_helpers.tpl
@@ -107,3 +107,19 @@ vmware-{{ $vropshostname._0 | trimPrefix "vrops-" }}
 cluster.local
 {{- end -}}
 {{- end -}}
+
+{{/* The name of the serviceAccount. */}}
+{{- define "serviceAccount.name" -}}
+{{- $name := index . 0 -}}
+{{- $root := index . 1 -}}
+{{- $svcName := $root.Values.serviceAccount.name -}}
+{{- if $root.Values.serviceAccount.create -}}
+{{- if and $svcName (ne $svcName "default") -}}
+{{- $svcName -}}
+{{- else -}}
+{{- (include "thanos.fullName" . ) -}}
+{{- end -}}
+{{- else -}}
+{{- default "default" $svcName -}}
+{{- end -}}
+{{- end -}}

--- a/common/thanos/templates/alerts/_thanos-ruler.alerts.tpl
+++ b/common/thanos/templates/alerts/_thanos-ruler.alerts.tpl
@@ -1,0 +1,192 @@
+{{- $name := index . 0 -}}
+{{- $root := index . 1 -}}
+groups:
+- name: thanos-ruler.alerts
+  rules:
+    - alert: ThanosRuleQueueIsDroppingAlerts
+      expr: |
+        sum by (job, instance) (rate(thanos_alert_queue_alerts_dropped_total{job=~".*thanos.*rule.*", thanos="{{ include "thanos.name" . }}"}[5m])) > 0
+      for: 5m
+      labels:
+        service: {{ default "metrics" $root.Values.alerts.service }}
+        support_group: {{ default "observability" $root.Values.alerts.support_group }}
+        severity: warning
+        meta: Thanos Rule `{{`{{ $labels.thanos }}`}}` is failing to queue alerts.
+      annotations:
+        description: |
+          Thanos Rule `{{`{{ $labels.thanos }}`}}` is failing to queue alerts.
+        summary: Thanos Rule is failing to queue alerts.
+
+    - alert: ThanosRuleSenderIsFailingAlerts
+      expr: |
+        sum by (job, instance) (rate(thanos_alert_sender_alerts_dropped_total{job=~".*thanos.*rule.*", thanos="{{ include "thanos.name" . }}"}[5m])) > 0
+      for: 5m
+      labels:
+        service: {{ default "metrics" $root.Values.alerts.service }}
+        support_group: {{ default "observability" $root.Values.alerts.support_group }}
+        severity: warning
+        meta: Thanos Rule `{{`{{ $labels.thanos }}`}}` is failing to send alerts to alertmanager.
+      annotations:
+        description: |
+          Thanos Rule `{{`{{ $labels.thanos }}`}}` is failing to send alerts to alertmanager.
+        summary: Thanos Rule is failing to send alerts to alertmanager.
+
+    - alert: ThanosRuleHighRuleEvaluationFailures
+      expr: |
+        (
+          sum by (job, instance) (rate(prometheus_rule_evaluation_failures_total{job=~".*thanos.*rule.*", thanos="{{ include "thanos.name" . }}"}[5m]))
+        /
+          sum by (job, instance) (rate(prometheus_rule_evaluations_total{job=~".*thanos.*rule.*", thanos="{{ include "thanos.name" . }}"}[5m]))
+        * 100 > 5
+        )
+      for: 5m
+      labels:
+        service: {{ default "metrics" $root.Values.alerts.service }}
+        support_group: {{ default "observability" $root.Values.alerts.support_group }}
+        severity: warning
+        meta: Thanos Rule `{{`{{ $labels.thanos }}`}}` is failing to evaluate rules.
+      annotations:
+        description: |
+          Thanos Rule `{{`{{ $labels.thanos }}`}}` is failing to evaluate rules.
+        summary: Thanos Rule is failing to evaluate rules.
+
+    - alert: ThanosRuleHighRuleEvaluationWarnings
+      expr: |
+        sum by (job, instance) (rate(thanos_rule_evaluation_with_warnings_total{job=~".*thanos.*rule.*", thanos="{{ include "thanos.name" . }}"}[5m])) > 0
+      for: 15m
+      labels:
+        service: {{ default "metrics" $root.Values.alerts.service }}
+        support_group: {{ default "observability" $root.Values.alerts.support_group }}
+        severity: info
+        meta: Thanos Rule `{{`{{ $labels.thanos }}`}}` has high number of evaluation warnings.
+      annotations:
+        description: |
+          Thanos Rule `{{`{{ $labels.thanos }}`}}` has high number of evaluation warnings.
+        summary: Thanos Rule has high number of evaluation warnings.
+
+    - alert: ThanosRuleEvaluationLatencyHigh
+      expr: |
+        (
+          sum by (job, instance, rule_group) (prometheus_rule_group_last_duration_seconds{job=~".*thanos.*rule.*", thanos="{{ include "thanos.name" . }}"})
+        >
+          sum by (job, instance, rule_group) (prometheus_rule_group_interval_seconds{job=~".*thanos.*rule.*", thanos="{{ include "thanos.name" . }}"})
+        )
+      for: 5m
+      labels:
+        service: {{ default "metrics" $root.Values.alerts.service }}
+        support_group: {{ default "observability" $root.Values.alerts.support_group }}
+        severity: info
+        meta: Thanos Rule `{{`{{ $labels.thanos }}`}}` has high rule evaluation latency.
+      annotations:
+        description: |
+          Thanos Rule `{{`{{ $labels.thanos }}`}}` has higher evaluation latency than
+          interval for `{{`{{ $labels.rule_group }}`}}`.
+        summary: Thanos Rule has high rule evaluation latency.
+    
+    - alert: ThanosRuleGrpcErrorRate
+      expr: |
+        (
+          sum by (job, instance) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~".*thanos.*rule.*", thanos="{{ include "thanos.name" . }}"}[5m]))
+        /
+          sum by (job, instance) (rate(grpc_server_started_total{job=~".*thanos.*rule.*", thanos="{{ include "thanos.name" . }}"}[5m]))
+        * 100 > 5
+        )
+      for: 5m
+      labels:
+        service: {{ default "metrics" $root.Values.alerts.service }}
+        support_group: {{ default "observability" $root.Values.alerts.support_group }}
+        severity: info
+        meta: Thanos Rule `{{`{{ $labels.thanos }}`}}` is failing to handle grpc requests.
+      annotations:
+        description: |
+          Thanos Rule `{{`{{ $labels.thanos }}`}}` is failing to handle `{{`{{ $value | humanize }}%`}}`
+          of requests.
+        summary: Thanos Rule is failing to handle grpc requests.
+    
+    - alert: ThanosRuleConfigReloadFailure
+      expr: |
+        avg by (job, instance) (thanos_rule_config_last_reload_successful{job=~".*thanos.*rule.*", thanos="{{ include "thanos.name" . }}"}) != 1
+      for: 5m
+      labels:
+        service: {{ default "metrics" $root.Values.alerts.service }}
+        support_group: {{ default "observability" $root.Values.alerts.support_group }}
+        severity: info
+        meta: Thanos Rule `{{`{{ $labels.thanos }}`}}` has not been able to reload configuration.
+      annotations:
+        description: |
+          Thanos Rule `{{`{{ $labels.thanos }}`}}` has not been able to reload its configuration.
+        summary: Thanos Rule has not been able to reload configuration.
+    
+    - alert: ThanosRuleQueryHighDNSFailures
+      expr: |
+        (
+          sum by (job, instance) (rate(thanos_rule_query_apis_dns_failures_total{job=~".*thanos.*rule.*", thanos="{{ include "thanos.name" . }}"}[5m]))
+        /
+          sum by (job, instance) (rate(thanos_rule_query_apis_dns_lookups_total{job=~".*thanos.*rule.*", thanos="{{ include "thanos.name" . }}"}[5m]))
+        * 100 > 1
+        )
+      for: 15m
+      labels:
+        service: {{ default "metrics" $root.Values.alerts.service }}
+        support_group: {{ default "observability" $root.Values.alerts.support_group }}
+        severity: info
+        meta: Thanos Rule `{{`{{ $labels.thanos }}`}}` is having high number of DNS failures.
+      annotations:
+        description: |
+          Thanos Rule `{{`{{ $labels.thanos }}`}}` has `{{`{{ $value | humanize }}%`}}` of failing DNS
+          queries for query endpoints.
+        summary: Thanos Rule is having high number of DNS failures.
+
+    - alert: ThanosRuleAlertmanagerHighDNSFailures
+      expr: |
+        (
+          sum by (job, instance) (rate(thanos_rule_alertmanagers_dns_failures_total{job=~".*thanos.*rule.*", thanos="{{ include "thanos.name" . }}"}[5m]))
+        /
+          sum by (job, instance) (rate(thanos_rule_alertmanagers_dns_lookups_total{job=~".*thanos.*rule.*", thanos="{{ include "thanos.name" . }}"}[5m]))
+        * 100 > 1
+        )
+      for: 15m
+      labels:
+        service: {{ default "metrics" $root.Values.alerts.service }}
+        support_group: {{ default "observability" $root.Values.alerts.support_group }}
+        severity: info
+        meta: Thanos Rule `{{`{{ $labels.thanos }}`}}` is having high number of DNS failures.
+      annotations:
+        description: |
+          Thanos Rule `{{`{{ $labels.thanos }}`}}` has `{{`{{ $value | humanize }}%`}}` of failing
+          DNS queries for Alertmanager endpoints.
+        summary: Thanos Rule is having high number of DNS failures.
+    
+    - alert: ThanosRuleNoEvaluationFor10Intervals
+      expr: |
+        time() -  max by (job, instance, group) (prometheus_rule_group_last_evaluation_timestamp_seconds{job=~".*thanos.*rule.*", thanos="{{ include "thanos.name" . }}"})
+        >
+        10 * max by (job, instance, group) (prometheus_rule_group_interval_seconds{job=~".*thanos.*rule.*", thanos="{{ include "thanos.name" . }}"})
+      for: 5m
+      labels:
+        service: {{ default "metrics" $root.Values.alerts.service }}
+        support_group: {{ default "observability" $root.Values.alerts.support_group }}
+        severity: warning
+        meta: Thanos Rule `{{`{{ $labels.thanos }}`}}` has rule groups that did not evaluate for 10 intervals.
+      annotations:
+        description: |
+          Thanos Rule `{{`{{ $labels.thanos }}`}}` has rule groups that did not evaluate for
+          at least 10x of their expected interval.
+        summary: Thanos Rule has rule groups that did not evaluate for 10 intervals.
+    
+    - alert: ThanosNoRuleEvaluations
+      expr: |
+        sum by (job, instance) (rate(prometheus_rule_evaluations_total{job=~".*thanos.*rule.*", thanos="{{ include "thanos.name" . }}"}[5m])) <= 0
+          and
+        sum by (job, instance) (thanos_rule_loaded_rules{job=~".*thanos.*rule.*", thanos="{{ include "thanos.name" . }}"}) > 0
+      for: 5m
+      labels:
+        service: {{ default "metrics" $root.Values.alerts.service }}
+        support_group: {{ default "observability" $root.Values.alerts.support_group }}
+        severity: warning
+        meta: Thanos Rule `{{`{{ $labels.thanos }}`}}` did not perform any rule evaluations.
+      annotations:
+        description: |
+          Thanos Rule `{{`{{ $labels.thanos }}`}}` did not perform any rule evaluations
+          in the past 10 minutes.
+        summary: Thanos Rule did not perform any rule evaluations.

--- a/common/thanos/templates/alerts/thanos-alerts.yaml
+++ b/common/thanos/templates/alerts/thanos-alerts.yaml
@@ -1,3 +1,6 @@
+{{- /*
+Alerts are deployed dependent upon the components chosen. It could either be Compactor|Query|Store, Query|Ruler or Query.
+*/}}
 {{- if .Values.enabled }}
 {{- $root := . }}
 {{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
@@ -5,6 +8,7 @@
 {{- range $component := tuple "compactor" "query" "store" }}
 {{- $path := (printf "%s/alerts/_thanos-%s.alerts.tpl" $root.Template.BasePath $component ) }}
 ---
+# This PrometheusRules cover Compactor|Query|Store alerts
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 
@@ -21,6 +25,7 @@ spec:
 {{- range $component := tuple "query" "ruler" }}
 {{- $path := (printf "%s/alerts/_thanos-%s.alerts.tpl" $root.Template.BasePath $component ) }}
 ---
+# This PrometheusRules cover Query|Ruler alerts
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 
@@ -37,6 +42,7 @@ spec:
 {{- range $component := tuple "query" }}
 {{- $path := (printf "%s/alerts/_thanos-%s.alerts.tpl" $root.Template.BasePath $component ) }}
 ---
+# This PrometheusRules cover Query alerts
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 

--- a/common/thanos/templates/alerts/thanos-alerts.yaml
+++ b/common/thanos/templates/alerts/thanos-alerts.yaml
@@ -17,18 +17,38 @@ spec:
 {{ include $path (list $name $root) | indent 2 }}
 
 {{- end }}
-{{- else }}
+{{- else if and $.Values.ruler.enabled (eq $.Values.deployWholeThanos false) }}
+{{- range $component := tuple "query" "ruler" }}
+{{- $path := (printf "%s/alerts/_thanos-%s.alerts.tpl" $root.Template.BasePath $component ) }}
+---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 
 metadata:
-  name: {{ include "thanos.fullName" (list $name $root) }}-query.alerts
+  name: {{ include "thanos.fullName" (list $name $root) }}-{{ printf "%s" $component }}.alerts
   labels:
-    prometheus: {{ required "$.Values.alerts.prometheus" $.Values.alerts.prometheus }}
+    prometheus: {{ default (include "thanos.name" (list $name $root)) $.Values.alerts.prometheus }}
 
 spec:
-{{ include (print $.Template.BasePath "/alerts/_thanos-query.alerts.tpl") (list $name $root) | indent 2 }}
+{{ include $path (list $name $root) | indent 2 }}
 
+{{- end }}
+{{- else }}
+{{- range $component := tuple "query" }}
+{{- $path := (printf "%s/alerts/_thanos-%s.alerts.tpl" $root.Template.BasePath $component ) }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: {{ include "thanos.fullName" (list $name $root) }}-{{ printf "%s" $component }}.alerts
+  labels:
+    prometheus: {{ default (include "thanos.name" (list $name $root)) $.Values.alerts.prometheus }}
+
+spec:
+{{ include $path (list $name $root) | indent 2 }}
+
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/common/thanos/templates/ingress.yaml
+++ b/common/thanos/templates/ingress.yaml
@@ -35,6 +35,15 @@ spec:
               port:
                 name: http
           pathType: ImplementationSpecific
+        {{- if and $.Values.ruler.enabled (not $.Values.deployWholeThanos) }}
+        - path: {{ $.Values.ruler.externalPrefix }}
+          backend:
+            service:
+              name:  thanos-ruler-{{ include "thanos.name" (list $name $root) }}
+              port:
+                name: web
+          pathType: ImplementationSpecific
+        {{- end }}
     {{- end }}
     {{- range $host := $.Values.ingress.hostsFQDN }}
     - host: {{ $host }}

--- a/common/thanos/templates/ruler/_alertmanager.yaml.tpl
+++ b/common/thanos/templates/ruler/_alertmanager.yaml.tpl
@@ -1,0 +1,16 @@
+{{- $name := index . 0 -}}
+{{- $root := index . 1 -}}
+{{- if $root.Values.ruler.alertmanagers.hosts }}
+alertmanagers:
+  - scheme: https
+    timeout: 10s
+    api_version: v2
+    {{- if $root.Values.ruler.alertmanagers.authentication.enabled }}
+    http_config:
+      tls_config:
+        cert_file: /etc/thanos/secrets/{{ include "thanos.fullName" . }}-ruler-alertmanager-sso-cert/sso.crt
+        key_file: /etc/thanos/secrets/{{ include "thanos.fullName" . }}-ruler-alertmanager-sso-cert/sso.key
+    {{- end }}
+    static_configs:
+{{ toYaml $root.Values.ruler.alertmanagers.hosts | indent 8 }}
+{{- end }}

--- a/common/thanos/templates/ruler/alertmanager-config.yaml
+++ b/common/thanos/templates/ruler/alertmanager-config.yaml
@@ -1,0 +1,17 @@
+{{- $root := . }}
+{{- if .Values.ruler.alertmanagers.hosts }}
+{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+---
+apiVersion: v1
+kind: Secret
+
+metadata:
+  name: {{ include "thanos.fullName" (list $name $root) }}-alertmanager-config
+  labels:
+    thanos: {{ include "thanos.name" (list $name $root) }}
+
+data:
+  alertManagerConfig.yaml: |
+{{ include (print $.Template.BasePath "/ruler/_alertmanager.yaml.tpl") (list $name $root) | b64enc | indent 4 }}
+{{- end }}
+{{- end }}

--- a/common/thanos/templates/ruler/alertmanager-sso-secret.yaml
+++ b/common/thanos/templates/ruler/alertmanager-sso-secret.yaml
@@ -1,0 +1,16 @@
+{{- $root := . }}
+{{- if .Values.ruler.alertmanagers.authentication.enabled }}
+{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+
+metadata:
+  name: {{ include "thanos.fullName" (list $name $root) }}-ruler-alertmanager-sso-cert
+
+data:
+  sso.crt: {{ required ".Values.ruler.alertmanagers.authentication.ssoCert missing" $.Values.ruler.alertmanagers.authentication.ssoCert | b64enc | quote }}
+  sso.key: {{ required ".Values.ruler.alertmanagers.authentication.ssoKey missing" $.Values.ruler.alertmanagers.authentication.ssoKey | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/common/thanos/templates/ruler/ruler.yaml
+++ b/common/thanos/templates/ruler/ruler.yaml
@@ -23,7 +23,7 @@ spec:
 {{- end }}
   ruleSelector: 
       matchLabels: 
-        thanos: {{ include "thanos.name" (list $name $root) }}
+        thanos-ruler: {{ include "thanos.name" (list $name $root) }}
   alertQueryUrl: https://{{ include "thanos.externalURL" (list $name $root) }}
 {{ if required "$.Values.ruler.alertmanagers.hosts missing" $.Values.ruler.alertmanagers.hosts }}
   # Alertmanager configuration.

--- a/common/thanos/templates/ruler/ruler.yaml
+++ b/common/thanos/templates/ruler/ruler.yaml
@@ -1,0 +1,58 @@
+{{- $root := . }}
+{{- if and .Values.ruler.enabled (eq .Values.deployWholeThanos false) }}
+{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ThanosRuler
+metadata:
+  name: {{ include "thanos.name" (list $name $root) }}
+spec:
+  image: {{ include "thanosimage" $root }}
+  paused: {{ $.Values.ruler.paused }}
+  logLevel: {{ default "info" $.Values.ruler.logLevel }}
+{{- if $.Values.ruler.retention }}
+  retention: {{ $.Values.ruler.retention | quote }}
+{{- end }}
+{{- if $.Values.rbac.create }}
+  serviceAccountName: {{ include "serviceAccount.name" (list $name $root) }}
+{{- end }}
+{{- if $.Values.ruler.externalPrefix }}
+  externalPrefix: {{ $.Values.ruler.externalPrefix }}
+{{- end }}
+{{- if $.Values.ruler.evaluationInterval }}
+  evaluationInterval: {{ $.Values.ruler.evaluationInterval }}
+{{- end }}
+  ruleSelector: 
+      matchLabels: 
+        thanos: {{ include "thanos.name" (list $name $root) }}
+  alertQueryUrl: https://{{ include "thanos.externalURL" (list $name $root) }}
+{{ if required "$.Values.ruler.alertmanagers.hosts missing" $.Values.ruler.alertmanagers.hosts }}
+  # Alertmanager configuration.
+  alertmanagersConfig:
+    name: {{ include "thanos.fullName" (list $name $root) }}-alertmanager-config
+    key: alertManagerConfig.yaml
+{{- end }}
+{{ if not $.Values.ruler.queryEndpoints }}
+  queryEndpoints: 
+    - {{ include "thanos.fullName" (list $name $root) }}-query:10902
+{{- else }}
+{{ toYaml $.Values.ruler.queryEndpoints | indent 4 }}
+{{- end }}
+{{- if $.Values.ruler.resources }}
+  resources:
+{{ toYaml $.Values.ruler.resources | indent 4 }}
+{{- end }}
+{{- if $.Values.ruler.alertmanagers.authentication.enabled }}
+  containers:
+    - name: thanos-ruler
+      volumeMounts:
+        - mountPath: /etc/thanos/secrets/{{ include "thanos.fullName" (list $name $root) }}-ruler-alertmanager-sso-cert
+          name: {{ include "thanos.fullName" (list $name $root) }}-ruler-alertmanager-sso-cert
+          readOnly: true
+  volumes:
+    - name: {{ include "thanos.fullName" (list $name $root) }}-ruler-alertmanager-sso-cert
+      secret:
+        secretName: {{ include "thanos.fullName" (list $name $root) }}-ruler-alertmanager-sso-cert
+{{- end }}
+
+{{- end }}
+{{- end }}

--- a/common/thanos/templates/ruler/service-account.yaml
+++ b/common/thanos/templates/ruler/service-account.yaml
@@ -1,0 +1,12 @@
+{{- $root := . }}
+{{- if and .Values.rbac.create .Values.serviceAccount.create }}
+{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "serviceAccount.name" (list $name $root) }}
+  labels:
+    thanos: {{ include "thanos.name" (list $name $root) }}
+{{- end }}
+{{- end }}

--- a/common/thanos/templates/ruler/service.yaml
+++ b/common/thanos/templates/ruler/service.yaml
@@ -7,6 +7,8 @@ kind: Service
 
 metadata:
   name: thanos-ruler-{{ include "thanos.name" (list $name $root) }}
+  labels:
+    thanos: {{ include "thanos.name" (list $name $root) }}
 {{ if $.Values.ruler.service.annotations }}
   annotations:
 {{ toYaml $.Values.ruler.service.annotations | indent 4 }}

--- a/common/thanos/templates/ruler/service.yaml
+++ b/common/thanos/templates/ruler/service.yaml
@@ -1,0 +1,23 @@
+{{- $root := . }}
+{{- if and .Values.ruler.enabled (eq .Values.deployWholeThanos false) }}
+{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+---
+apiVersion: v1
+kind: Service
+
+metadata:
+  name: thanos-ruler-{{ include "thanos.name" (list $name $root) }}
+{{ if $.Values.ruler.service.annotations }}
+  annotations:
+{{ toYaml $.Values.ruler.service.annotations | indent 4 }}
+{{ end }}
+spec:
+  selector:
+    thanos-ruler: {{ include "thanos.name" (list $name $root) }}
+  ports:
+    - name: web
+      port: 10902
+    - name: grpc
+      port: 10901
+{{- end }}
+{{- end }}

--- a/common/thanos/templates/servicemonitor.yaml
+++ b/common/thanos/templates/servicemonitor.yaml
@@ -36,4 +36,24 @@ spec:
             - __meta_kubernetes_service_name
           targetLabel: kubernetes_name
 {{ include "thanos.defaultRelabelConfig" $root | indent 8 }}
+{{- if and $.Values.ruler.enabled (eq $.Values.deployWholeThanos false) }}
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      interval: 30s
+      scrapeTimeout: 25s
+      port: web
+      scheme: http
+      relabelings:
+        - action: replace
+          targetLabel: thanos
+          replacement: {{ include "thanos.name" (list $name $root) }}
+        - action: labelmap
+          regex: '__meta_kubernetes_service_label_(.+)'
+        - sourceLabels:
+            - __meta_kubernetes_namespace
+          targetLabel: kubernetes_namespace
+        - sourceLabels:
+            - __meta_kubernetes_service_name
+          targetLabel: kubernetes_name
+{{ include "thanos.defaultRelabelConfig" $root | indent 8 }}
+{{- end }}
 {{- end }}

--- a/common/thanos/values.yaml
+++ b/common/thanos/values.yaml
@@ -170,8 +170,7 @@ ruler:
   # evaluationInterval: <string>
 
   # The external URL the Thanos Ruler instances will be available under. This
-  # is necessary to generate correct URLs. This is necessary because Thanos Ruler is
-  # served from a subpath of the Thanos Query.
+  # is necessary to generate correct URLs to serve Thanos Ruler from a subpath of Thanos Query.
   externalPrefix: /ruler
 
   # Define URLs to send alerts to Alertmanager.

--- a/common/thanos/values.yaml
+++ b/common/thanos/values.yaml
@@ -42,6 +42,9 @@ queryDiscovery:
 # defaults to cluster.local
 clusterDomain:
 
+# optional
+# namespace:
+
 # used for cross cluster TLS 
 # only used, when useQueryRegions is set
 GRPCClientCA:
@@ -67,6 +70,20 @@ swiftStorageConfig:
 # Specification for Thanos image
 spec:
   baseImage: keppel.eu-de-1.cloud.sap/ccloud-quay-mirror/thanos/thanos
+
+# Create RBAC resources.
+rbac:
+  create: true
+
+# ServiceAccount to use for the Thanos.
+# Note that a ServiceAccount with name `default` cannot be created.
+# Instead the generated name will be used.
+serviceAccount:
+  create: true
+
+  # Optional name of the service account.
+  # If not provided one will be generated in the format: thanos-<name>.
+  name: ""
 
 # Specification for Thanos components.
 compactor:
@@ -135,6 +152,51 @@ query:
     # - name: storeN
     #   namespace: default
     #   port: 10901
+
+ruler:
+  enabled: false
+  # When a ThanosRuler deployment is paused, no actions except for deletion
+  # will be performed on the underlying objects.
+  paused: false
+
+  loglevel: info
+
+  # Time duration ThanosRuler shall retain data for. Default is '24h', and must
+  # match the regular expression `[0-9]+(ms|s|m|h|d|w|y)` (milliseconds seconds
+  # minutes hours days weeks years).
+  # retention: <string>
+
+  # Interval between consecutive evaluations. Defaults to 15s
+  # evaluationInterval: <string>
+
+  # The external URL the Thanos Ruler instances will be available under. This
+  # is necessary to generate correct URLs. This is necessary because Thanos Ruler is
+  # served from a subpath of the Thanos Query.
+  externalPrefix: /ruler
+
+  # Define URLs to send alerts to Alertmanager.
+  alertmanagers:
+    # Configuration if the Alertmanager has client certificate authentication enabled.
+    authentication:
+      enabled: false
+      # The certificate used for authentication with the Alertmanager..
+      ssoCert:
+      # The key used for authentication with the Alertmanager.
+      ssoKey:
+
+    hosts: []
+
+  # QueryEndpoints defines Thanos querier endpoints from which to query
+  # metrics. Maps to the --query flag of thanos ruler.
+  # Defaults to <name>-query.<namespace>.svc.<clusterDomain>
+  queryEndpoints: []
+
+  # Resources defines the resource requirements for single Pods. If not
+  # provided, no requests/limits will be set
+  # resources:
+
+  service:
+    annotations: {}
 
 # Optional ingress for this Thanos. Only needed when net deployed alongside Prometheus. So to say, if deployWholeThanos is set, this shouldn't be needed
 ingress:


### PR DESCRIPTION
This PR enables the common/thanos chart to specify a Thanos Ruler. This is intended to sit alongside a Thanos Query deployment and evaluate alerting and aggregations rules across prometheus. 