### PR TITLE
[elektra] use separate webcli endpoint for qa regions

### DIFF
--- a/openstack/elektra/templates/seed.yaml
+++ b/openstack/elektra/templates/seed.yaml
@@ -35,7 +35,7 @@ spec:
     endpoints:
     - interface: public
       region: '{{.Values.monsoon_dashboard_region}}'
-      {{- if contains "qa" .Values.monsoon_dashboard_region }}
+      {{- if hasPrefix "qa" (print .Values.monsoon_dashboard_region) }}
       url: https://ccloudshell.qa-de-1.cloud.sap
       {{- else }}
       url: https://ccloudshell.eu-de-2.cloud.sap

--- a/openstack/elektra/templates/seed.yaml
+++ b/openstack/elektra/templates/seed.yaml
@@ -35,7 +35,11 @@ spec:
     endpoints:
     - interface: public
       region: '{{.Values.monsoon_dashboard_region}}'
+      {{- if contains "qa" .Values.monsoon_dashboard_region }}
+      url: https://ccloudshell.qa-de-1.cloud.sap
+      {{- else }}
       url: https://ccloudshell.eu-de-2.cloud.sap
+      {{- end }}
 
   roles:
   - name: cloud_compute_admin


### PR DESCRIPTION
There is a new cloudshell cluster in QA region. For the dashboard of QA regions, I would like to use this cluster.
