### PR TITLE
[cc3test] avoid false alerts due to the statsd pod restarting

### DIFF
--- a/openstack/cc3test/alerts/cc3test-absent.alerts
+++ b/openstack/cc3test/alerts/cc3test-absent.alerts
@@ -3,7 +3,7 @@ groups:
   rules:
   - alert: CCloudApiTestNotRunningWell
     expr: increase(cc3test_finished_seconds{type="api"}[20m]) == 0
-    for: 30m
+    for: 40m
     labels:
       severity: warning
       service: cc3test
@@ -16,7 +16,7 @@ groups:
 
   - alert: CCloudDatapathTestNotRunningWell
     expr: increase(cc3test_finished_seconds{type="datapath"}[40m]) == 0
-    for: 60m
+    for: 40m
     labels:
       severity: warning
       service: cc3test
@@ -29,7 +29,7 @@ groups:
 
   - alert: CCloudCanaryTestNotRunningWell
     expr: increase(cc3test_finished_seconds{type="canary"}[1h]) == 0
-    for: 90m
+    for: 40m
     labels:
       severity: warning
       service: cc3test

--- a/openstack/cc3test/alerts/cc3test-absent.alerts
+++ b/openstack/cc3test/alerts/cc3test-absent.alerts
@@ -3,6 +3,7 @@ groups:
   rules:
   - alert: CCloudApiTestNotRunningWell
     expr: increase(cc3test_finished_seconds{type="api"}[20m]) == 0
+    for: 30m
     labels:
       severity: warning
       service: cc3test
@@ -15,6 +16,7 @@ groups:
 
   - alert: CCloudDatapathTestNotRunningWell
     expr: increase(cc3test_finished_seconds{type="datapath"}[40m]) == 0
+    for: 60m
     labels:
       severity: warning
       service: cc3test
@@ -27,6 +29,7 @@ groups:
 
   - alert: CCloudCanaryTestNotRunningWell
     expr: increase(cc3test_finished_seconds{type="canary"}[1h]) == 0
+    for: 90m
     labels:
       severity: warning
       service: cc3test


### PR DESCRIPTION
wait a bit longer for now to really avoid false positives