### PR TITLE
[nova] Fixup PR #4766: DB access for Jobs with projected volumes

### DIFF
--- a/openstack/nova/templates/db-migrate-job.yaml
+++ b/openstack/nova/templates/db-migrate-job.yaml
@@ -37,50 +37,41 @@ spec:
           value: {{ .Values.python_warnings | quote }}
         volumeMounts:
         - mountPath: /etc/nova
-          name: etcnova
-        - mountPath: /etc/nova/nova.conf
           name: nova-etc
-          subPath: nova.conf
-          readOnly: true
-        - mountPath: /etc/nova/nova-api.conf
-          name: nova-etc
-          subPath: nova-api.conf
-          readOnly: true
-        - mountPath: /etc/nova/api-paste.ini
-          name: nova-etc
-          subPath: api-paste.ini
-          readOnly: true
-{{- if .Values.cell2.enabled }}
-        - mountPath: /etc/nova/nova-cell2.conf
-          name: nova-etc
-          subPath: nova-cell2.conf
-          readOnly: true
-{{- end }}
-{{- if .Values.audit.enabled }}
-        - mountPath: /etc/nova/nova_audit_map.yaml
-          name: nova-etc
-          subPath: nova_audit_map.yaml
-          readOnly: true
-{{- end }}
-        {{- /* Note I533984: Replace with plain policy.yaml after Xena upgrade */}}
-        - mountPath: /etc/nova/{{if (.Values.imageVersion | hasPrefix "rocky") }}policy.json{{else}}policy.yaml{{end}}
-          name: nova-etc
-          subPath: {{if (.Values.imageVersion | hasPrefix "rocky") }}policy.json{{else}}policy.yaml{{end}}
-          readOnly: true
-        - mountPath: /etc/nova/logging.ini
-          name: nova-etc
-          subPath: logging.ini
-          readOnly: true
         - mountPath: /container.init
           name: container-init
         {{- include "utils.proxysql.volume_mount" . | indent 8 }}
       {{- include "utils.proxysql.container" . | indent 6 }}
       volumes:
-      - name: etcnova
-        emptyDir: {}
       - name: nova-etc
-        configMap:
-          name: nova-etc
+        projected:
+          sources:
+          - configMap:
+              name: nova-etc
+              items:
+              - key:  nova.conf
+                path: nova.conf
+              - key:  nova-api.conf
+                path: nova-api.conf
+              - key:  api-paste.ini
+                path: api-paste.ini
+              - key:  policy.yaml
+                path: policy.yaml
+              - key:  logging.ini
+                path: logging.ini
+{{- if .Values.cell2.enabled }}
+              - key:  nova-cell2.conf
+                path: nova-cell2.conf
+{{- end }}
+{{- if .Values.audit.enabled }}
+              - key:  nova_audit_map.yaml
+                path: nova_audit_map.yaml
+{{- end }}
+          - secret:
+              name: nova-etc
+              items:
+              - key: db.conf
+                path: nova.conf.d/db.conf
       - name: container-init
         configMap:
           name: nova-bin

--- a/openstack/nova/templates/db-online-migrate-job.yaml
+++ b/openstack/nova/templates/db-online-migrate-job.yaml
@@ -37,31 +37,31 @@ spec:
               fieldPath: metadata.name
         volumeMounts:
         - mountPath: /etc/nova
-          name: etcnova
-        - mountPath: /etc/nova/nova.conf
           name: nova-etc
-          subPath: nova.conf
-          readOnly: true
-{{- if .Values.cell2.enabled }}
-        - mountPath: /etc/nova/nova-cell2.conf
-          name: nova-etc
-          subPath: nova-cell2.conf
-          readOnly: true
-{{- end }}
-        - mountPath: /etc/nova/logging.ini
-          name: nova-etc
-          subPath: logging.ini
-          readOnly: true
         - mountPath: /container.init
           name: container-init
         {{- include "utils.proxysql.volume_mount" . | indent 8 }}
       {{- include "utils.proxysql.container" . | indent 6 }}
       volumes:
-      - name: etcnova
-        emptyDir: {}
       - name: nova-etc
-        configMap:
-          name: nova-etc
+        projected:
+          sources:
+          - configMap:
+              name: nova-etc
+              items:
+              - key:  nova.conf
+                path: nova.conf
+              - key:  logging.ini
+                path: logging.ini
+{{- if .Values.cell2.enabled }}
+              - key:  nova-cell2.conf
+                path: nova-cell2.conf
+{{- end }}
+          - secret:
+              name: nova-etc
+              items:
+              - key: db.conf
+                path: nova.conf.d/db.conf
       - name: container-init
         configMap:
           name: nova-bin

--- a/openstack/nova/templates/etc-secret.yaml
+++ b/openstack/nova/templates/etc-secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nova-etc
+  labels:
+    system: openstack
+    type: configuration
+    component: nova
+stringData:
+  db.conf: |
+    {{- include "nova.helpers.ini_sections.api_database" . | indent 4 }}
+
+    {{- include "ini_sections.database" . | indent 4 }}


### PR DESCRIPTION
This should just fix the jobs, the other specs will get updated accordingly.

- Instead of pasting the credentials into serveral files, rely on the default include path pattern.

- Instead of having the credentials for the dbs in a configmap, put them in a secret.

- Instead of mounting all files individually, create a projected volume in the spec which contains them.