### PR TITLE
[nova] Split out db with projected volumes plus minor cleanups

### DIFF
--- a/openstack/nova/bin/iptables-restore.mock
+++ b/openstack/nova/bin/iptables-restore.mock
@@ -1,2 +1,0 @@
-#!/bin/bash
-exit 0

--- a/openstack/nova/templates/api-deployment.yaml
+++ b/openstack/nova/templates/api-deployment.yaml
@@ -106,88 +106,75 @@ spec:
             - name: nova-api
               containerPort: {{.Values.global.novaApiPortInternal}}
           volumeMounts:
-            - mountPath: /etc/nova
-              name: etcnova
-            - mountPath: /etc/nova/nova.conf
-              name: nova-etc
-              subPath: nova.conf
-              readOnly: true
-            - mountPath: /etc/nova/nova-api.conf
-              name: nova-etc
-              subPath: nova-api.conf
-              readOnly: true
-            - mountPath: /etc/nova/api-paste.ini
-              name: nova-etc
-              subPath: api-paste.ini
-              readOnly: true
-           {{- if .Values.api.use_uwsgi }}
-            - mountPath: /etc/nova/api_uwsgi.ini
-              name: nova-etc
-              subPath: api_uwsgi.ini
-              readOnly: true
-           {{- end }}
-{{- if .Values.audit.enabled }}
-            - mountPath: /etc/nova/nova_audit_map.yaml
-              name: nova-etc
-              subPath: nova_audit_map.yaml
-              readOnly: true
-{{- end }}
-            {{- /* Note I533984: Replace with plain policy.yaml after Xena upgrade */}}
-            - mountPath: /etc/nova/{{if (.Values.imageVersion | hasPrefix "rocky") }}policy.json{{else}}policy.yaml{{end}}
-              name: nova-etc
-              subPath: {{if (.Values.imageVersion | hasPrefix "rocky") }}policy.json{{else}}policy.yaml{{end}}
-              readOnly: true
-            - mountPath: /etc/nova/logging.ini
-              name: nova-etc
-              subPath: logging.ini
-              readOnly: true
-            - mountPath: /etc/nova/rootwrap.conf
-              name: nova-etc
-              subPath: rootwrap.conf
-              readOnly: true
-            - mountPath: /etc/nova/rootwrap.d/api-metadata.filters
-              name: nova-etc
-              subPath: api-metadata.filters
-              readOnly: true
-            - mountPath: /etc/nova/release
-              name: nova-etc
-              subPath: release
-              readOnly: true
-            - mountPath: /var/lib/kolla/venv/bin/iptables-restore
-              name: nova-bin
-              subPath: iptables-restore.mock
-              readOnly: true
-            {{- if .Values.watcher.enabled }}
-            - name: nova-etc
-              mountPath: /etc/nova/watcher.yaml
-              subPath: watcher.yaml
-              readOnly: true
-            {{- end }}
-            {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+          - mountPath: /etc/nova
+            name: nova-etc
+            {{- include "utils.proxysql.volume_mount" . | indent 10 }}
         {{- tuple . .Values.api.config_file.DEFAULT.osapi_compute_workers | include "utils.proxysql.container" | indent 8 }}
         - name: statsd
           image: {{ required ".Values.global.dockerHubMirror is missing" .Values.global.dockerHubMirror}}/prom/statsd-exporter:v0.8.1
           imagePullPolicy: IfNotPresent
           args: [ --statsd.mapping-config=/etc/statsd/statsd-exporter.yaml ]
           ports:
-            - name: statsd
-              containerPort: 9125
-              protocol: UDP
-            - name: metrics
-              containerPort: 9102
+          - name: statsd
+            containerPort: 9125
+            protocol: UDP
+          - name: metrics
+            containerPort: 9102
           volumeMounts:
-            - name: nova-etc
-              mountPath: /etc/statsd/statsd-exporter.yaml
-              subPath: statsd-exporter.yaml
-              readOnly: true
+          - name: statsd-etc
+            mountPath: /etc/statsd/statsd-exporter.yaml
+            subPath: statsd-exporter.yaml
+            readOnly: true
       volumes:
-        - name: etcnova
-          emptyDir: {}
-        - name: nova-etc
-          configMap:
-            name: nova-etc
-        - name: nova-bin
-          configMap:
-            name: nova-bin
-            defaultMode: 0755
-        {{- include "utils.proxysql.volumes" . | indent 8 }}
+      - name: nova-etc
+        projected:
+          sources:
+          - configMap:
+              name: nova-etc
+              items:
+              - key:  nova.conf
+                path: nova.conf
+              - key:  nova-api.conf
+                path: nova-api.conf
+              - key:  api-paste.ini
+                path: api-paste.ini
+              - key:  policy.yaml
+                path: policy.yaml
+              - key:  logging.ini
+                path: logging.ini
+              - key:  rootwrap.conf
+                path: rootwrap.conf
+              - key:  api-metadata.filters
+                path: rootwrap.d/api-metadata.filters
+              - key:  release
+                path: release
+{{- if .Values.api.use_uwsgi }}
+              - key:  api_uwsgi.ini
+                path: api_uwsgi.ini
+{{- end }}
+{{- if .Values.audit.enabled }}
+              - key:  nova_audit_map.yaml
+                path: nova_audit_map.yaml
+{{- end }}
+{{- if .Values.watcher.enabled }}
+              - key:  watcher.yaml
+                path: watcher.yaml
+{{- end }}
+          - secret:
+              name: nova-etc
+              items:
+              - key: db.conf
+                path: nova.conf.d/db.conf
+      - name: statsd-etc
+        projected:
+          sources:
+          - configMap:
+              name: nova-etc
+              items:
+              - key:  statsd-exporter.yaml
+                path: statsd-exporter.yaml
+      - name: nova-bin
+        configMap:
+          name: nova-bin
+          defaultMode: 0755
+      {{- include "utils.proxysql.volumes" . | indent 6 }}

--- a/openstack/nova/templates/api-metadata-deployment.yaml
+++ b/openstack/nova/templates/api-metadata-deployment.yaml
@@ -93,81 +93,78 @@ spec:
 {{ toYaml .Values.pod.resources.metadata | indent 12 }}
           {{- end }}
           ports:
-            - name: nova-metdata
-              containerPort: {{.Values.global.novaApiMetadataPortInternal}}
+          - name: nova-metdata
+            containerPort: {{.Values.global.novaApiMetadataPortInternal}}
           volumeMounts:
-            - mountPath: /etc/nova
-              name: etcnova
-            - mountPath: /etc/nova/nova.conf
-              name: nova-etc
-              subPath: nova.conf
-              readOnly: true
-            - mountPath: /etc/nova/nova-api.conf
-              name: nova-etc
-              subPath: nova-api-metadata.conf
-              readOnly: true
-            - mountPath: /etc/nova/api-paste.ini
-              name: nova-etc
-              subPath: api-paste.ini
-              readOnly: true
-{{- if .Values.audit.enabled }}
-            - mountPath: /etc/nova/nova_audit_map.yaml
-              name: nova-etc
-              subPath: nova_audit_map.yaml
-              readOnly: true
-{{- end }}
-            {{- /* Note I533984: Replace with plain policy.yaml after Xena upgrade */}}
-            - mountPath: /etc/nova/{{if (.Values.imageVersion | hasPrefix "rocky") }}policy.json{{else}}policy.yaml{{end}}
-              name: nova-etc
-              subPath: {{if (.Values.imageVersion | hasPrefix "rocky") }}policy.json{{else}}policy.yaml{{end}}
-              readOnly: true
-            - mountPath: /etc/nova/logging.ini
-              name: nova-etc
-              subPath: logging.ini
-              readOnly: true
-            - mountPath: /etc/nova/rootwrap.conf
-              name: nova-etc
-              subPath: rootwrap.conf
-              readOnly: true
-            - mountPath: /etc/nova/rootwrap.d/api-metadata.filters
-              name: nova-etc
-              subPath: api-metadata.filters
-              readOnly: true
-            - mountPath: /var/lib/kolla/venv/bin/iptables-restore
-              name: nova-bin
-              subPath: iptables-restore.mock
-              readOnly: true
-            {{- if .Values.watcher.enabled }}
-            - name: nova-etc
-              mountPath: /etc/nova/watcher.yaml
-              subPath: watcher.yaml
-              readOnly: true
-            {{- end }}
-            {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+          - mountPath: /etc/nova
+            name: nova-etc
+          {{- include "utils.proxysql.volume_mount" . | indent 10 }}
         {{- tuple . .Values.api_metadata.config_file.DEFAULT.metadata_workers | include "utils.proxysql.container" | indent 8 }}
         - name: statsd
           image: {{ required ".Values.global.dockerHubMirror is missing" .Values.global.dockerHubMirror}}/prom/statsd-exporter:v0.8.1
           imagePullPolicy: IfNotPresent
           args: [ --statsd.mapping-config=/etc/statsd/statsd-exporter.yaml ]
           ports:
-            - name: statsd
-              containerPort: 9125
-              protocol: UDP
-            - name: metrics
-              containerPort: 9102
+          - name: statsd
+            containerPort: 9125
+            protocol: UDP
+          - name: metrics
+            containerPort: 9102
           volumeMounts:
-            - name: nova-etc
-              mountPath: /etc/statsd/statsd-exporter.yaml
-              subPath: statsd-exporter.yaml
-              readOnly: true
+          - name: statsd-etc
+            mountPath: /etc/statsd/statsd-exporter.yaml
+            subPath: statsd-exporter.yaml
+            readOnly: true
       volumes:
-        - name: etcnova
-          emptyDir: {}
-        - name: nova-etc
-          configMap:
-            name: nova-etc
-        - name: nova-bin
-          configMap:
-            name: nova-bin
-            defaultMode: 0755
-        {{- include "utils.proxysql.volumes" . | indent 8 }}
+      - name: nova-etc
+        projected:
+          sources:
+          - configMap:
+              name: nova-etc
+              items:
+              - key:  nova.conf
+                path: nova.conf
+              - key:  nova-api.conf
+                path: nova-api-metadata.conf
+              - key:  api-paste.ini
+                path: api-paste.ini
+              - key:  policy.yaml
+                path: policy.yaml
+              - key:  logging.ini
+                path: logging.ini
+              - key:  rootwrap.conf
+                path: rootwrap.conf
+              - key:  api-metadata.filters
+                path: rootwrap.d/api-metadata.filters
+              - key:  release
+                path: release
+{{- if .Values.api.use_uwsgi }}
+              - key:  api_uwsgi.ini
+                path: api_uwsgi.ini
+{{- end }}
+{{- if .Values.audit.enabled }}
+              - key:  nova_audit_map.yaml
+                path: nova_audit_map.yaml
+{{- end }}
+{{- if .Values.watcher.enabled }}
+              - key:  watcher.yaml
+                path: watcher.yaml
+{{- end }}
+          - secret:
+              name: nova-etc
+              items:
+              - key: db.conf
+                path: nova.conf.d/db.conf
+      - name: statsd-etc
+        projected:
+          sources:
+          - configMap:
+              name: nova-etc
+              items:
+              - key:  statsd-exporter.yaml
+                path: statsd-exporter.yaml
+      - name: nova-bin
+        configMap:
+          name: nova-bin
+          defaultMode: 0755
+      {{- include "utils.proxysql.volumes" . | indent 6 }}

--- a/openstack/nova/templates/bigvm-deployment.yaml
+++ b/openstack/nova/templates/bigvm-deployment.yaml
@@ -79,27 +79,27 @@ spec:
 {{ toYaml .Values.pod.resources.bigvm | indent 12 }}
           {{- end }}
           volumeMounts:
-            - name: etcnova
-              mountPath: /etc/nova
-            - name: nova-etc
-              mountPath: /etc/nova/nova.conf
-              subPath: nova.conf
-              readOnly: true
-            - name: nova-etc
-              mountPath: /etc/nova/nova-bigvm.conf
-              subPath: nova-bigvm.conf
-              readOnly: true
-            - name: nova-etc
-              mountPath: /etc/nova/logging.ini
-              subPath: logging.ini
-              readOnly: true
-            {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+          - name: nova-etc
+            mountPath: /etc/nova
+          {{- include "utils.proxysql.volume_mount" . | indent 10 }}
         {{- include "utils.proxysql.container" . | indent 8 }}
       volumes:
-        - name: etcnova
-          emptyDir: {}
-        - name: nova-etc
-          configMap:
-            name: nova-etc
-        {{- include "utils.proxysql.volumes" . | indent 8 }}
+      - name: nova-etc
+        projected:
+          sources:
+          - configMap:
+              name: nova-etc
+              items:
+              - key:  nova.conf
+                path: nova.conf
+              - key:  nova-bigvm.conf
+                path: nova-bigvm.conf
+              - key:  logging.ini
+                path: logging.ini
+          - secret:
+              name: nova-etc
+              items:
+              - key: db.conf
+                path: nova.conf.d/db.conf
+      {{- include "utils.proxysql.volumes" . | indent 6 }}
 {{- end }}

--- a/openstack/nova/templates/conductor-deployment.yaml
+++ b/openstack/nova/templates/conductor-deployment.yaml
@@ -85,21 +85,9 @@ spec:
 {{ toYaml .Values.pod.resources.conductor | indent 12 }}
           {{- end }}
           volumeMounts:
-            - mountPath: /etc/nova
-              name: etcnova
-            - mountPath: /etc/nova/nova.conf
-              name: nova-etc
-              subPath: nova.conf
-              readOnly: true
-            - mountPath: /etc/nova/nova-conductor.conf
-              name: nova-etc
-              subPath: nova-conductor.conf
-              readOnly: true
-            - mountPath: /etc/nova/logging.ini
-              name: nova-etc
-              subPath: logging.ini
-              readOnly: true
-            {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+          - mountPath: /etc/nova
+            name: nova-etc
+          {{- include "utils.proxysql.volume_mount" . | indent 10 }}
         {{- tuple . .Values.conductor.config_file.conductor.workers | include "utils.proxysql.container" | indent 8 }}
         {{- if .Values.conductor.config_file.DEFAULT.statsd_enabled }}
         - name: statsd
@@ -113,15 +101,37 @@ spec:
           - name: metrics
             containerPort: 9102
           volumeMounts:
-            - name: nova-etc
-              mountPath: /etc/statsd/statsd-exporter.yaml
-              subPath: statsd-exporter.yaml
-              readOnly: true
+          - name: statsd-etc
+            mountPath: /etc/statsd/statsd-exporter.yaml
+            subPath: statsd-exporter.yaml
+            readOnly: true
         {{- end }}
       volumes:
-        - name: etcnova
-          emptyDir: {}
-        - name: nova-etc
-          configMap:
-            name: nova-etc
-        {{- include "utils.proxysql.volumes" . | indent 8 }}
+      - name: nova-etc
+        projected:
+          sources:
+          - configMap:
+              name: nova-etc
+              items:
+              - key:  nova.conf
+                path: nova.conf
+              - key:  nova-conductor.conf
+                path: nova-conductor.conf
+              - key:  logging.ini
+                path: logging.ini
+          - secret:
+              name: nova-etc
+              items:
+              - key: db.conf
+                path: nova.conf.d/db.conf
+{{- if .Values.conductor.config_file.DEFAULT.statsd_enabled }}
+      - name: statsd-etc
+        projected:
+          sources:
+          - configMap:
+              name: nova-etc
+              items:
+              - key:  statsd-exporter.yaml
+                path: statsd-exporter.yaml
+{{- end }}
+      {{- include "utils.proxysql.volumes" . | indent 6 }}

--- a/openstack/nova/templates/etc-configmap.yaml
+++ b/openstack/nova/templates/etc-configmap.yaml
@@ -19,11 +19,9 @@ data:
   nova-api-metadata.conf: |
 {{ include (print .Template.BasePath "/etc/_nova-api-metadata.conf.tpl") . | indent 4 }}
   nova-bigvm.conf: |
-{{ include (print .Template.BasePath "/etc/_nova-bigvm.conf.tpl") . | indent 4 }}
+{{ include "util.helpers.valuesToIni" .Values.bigvm.config_file | indent 4 }}
   nova-conductor.conf: |
 {{ include (print .Template.BasePath "/etc/_nova-conductor.conf.tpl") . | indent 4 }}
-  nova-console.conf: |
-{{ include (print .Template.BasePath "/etc/_nova-console.conf.tpl") . | indent 4 }}
 {{- /* Note I533984: Replace with plain policy.yaml after Xena upgrade */}}
 {{if (.Values.imageVersion | hasPrefix "rocky") }}
   policy.json: |

--- a/openstack/nova/templates/etc/_nova-api-metadata.conf.tpl
+++ b/openstack/nova/templates/etc/_nova-api-metadata.conf.tpl
@@ -1,5 +1,1 @@
-{{- include "nova.helpers.ini_sections.api_database" . }}
-
-{{- include "ini_sections.database" . }}
-
 {{ include "util.helpers.valuesToIni" .Values.api_metadata.config_file }}

--- a/openstack/nova/templates/etc/_nova-api.conf.tpl
+++ b/openstack/nova/templates/etc/_nova-api.conf.tpl
@@ -1,5 +1,1 @@
-{{- include "nova.helpers.ini_sections.api_database" . }}
-
-{{- include "ini_sections.database" . }}
-
 {{ include "util.helpers.valuesToIni" .Values.api.config_file }}

--- a/openstack/nova/templates/etc/_nova-bigvm.conf.tpl
+++ b/openstack/nova/templates/etc/_nova-bigvm.conf.tpl
@@ -1,5 +1,0 @@
-{{- include "nova.helpers.ini_sections.api_database" . }}
-
-{{- include "ini_sections.database" . }}
-
-{{ include "util.helpers.valuesToIni" .Values.bigvm.config_file | indent 4 }}

--- a/openstack/nova/templates/etc/_nova-conductor.conf.tpl
+++ b/openstack/nova/templates/etc/_nova-conductor.conf.tpl
@@ -1,5 +1,1 @@
-{{- include "nova.helpers.ini_sections.api_database" . }}
-
-{{- include "ini_sections.database" . }}
-
 {{ include "util.helpers.valuesToIni" .Values.conductor.config_file }}

--- a/openstack/nova/templates/etc/_nova-console.conf.tpl
+++ b/openstack/nova/templates/etc/_nova-console.conf.tpl
@@ -1,3 +1,0 @@
-{{- include "nova.helpers.ini_sections.api_database" . }}
-
-{{- include "ini_sections.database" . }}

--- a/openstack/nova/templates/etc/_nova-scheduler.conf.tpl
+++ b/openstack/nova/templates/etc/_nova-scheduler.conf.tpl
@@ -5,10 +5,6 @@ scheduler_driver = {{ .Values.scheduler.driver }}
 statsd_port = {{ .Values.scheduler.rpc_statsd_port }}
 statsd_enabled = {{ .Values.scheduler.rpc_statsd_enabled }}
 
-{{- include "nova.helpers.ini_sections.api_database" . }}
-
-{{- include "ini_sections.database" . }}
-
 [scheduler]
 discover_hosts_in_cells_interval = 60
 workers = {{ .Values.scheduler.workers }}

--- a/openstack/nova/templates/scheduler-deployment.yaml
+++ b/openstack/nova/templates/scheduler-deployment.yaml
@@ -79,26 +79,9 @@ spec:
 {{ toYaml .Values.pod.resources.scheduler | indent 12 }}
           {{- end }}
           volumeMounts:
-            - name: etcnova
-              mountPath: /etc/nova
-            - name: nova-etc
-              mountPath: /etc/nova/nova.conf
-              subPath: nova.conf
-              readOnly: true
-            - name: nova-scheduler-etc
-              mountPath: /etc/nova/nova-scheduler.conf
-              subPath: nova-scheduler.conf
-              readOnly: true
-            {{- /* Note I533984: Replace with plain policy.yaml after Xena upgrade */}}
-            - name: nova-etc
-              mountPath: /etc/nova/{{if (.Values.imageVersion | hasPrefix "rocky") }}policy.json{{else}}policy.yaml{{end}}
-              subPath: {{if (.Values.imageVersion | hasPrefix "rocky") }}policy.json{{else}}policy.yaml{{end}}
-              readOnly: true
-            - name: nova-etc
-              mountPath: /etc/nova/logging.ini
-              subPath: logging.ini
-              readOnly: true
-            {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+          - name: nova-etc
+            mountPath: /etc/nova
+          {{- include "utils.proxysql.volume_mount" . | indent 10 }}
         {{- tuple . .Values.scheduler.workers | include "utils.proxysql.container" | indent 8 }}
         {{- if .Values.scheduler.rpc_statsd_enabled }}
         - name: statsd
@@ -112,18 +95,40 @@ spec:
           - name: metrics
             containerPort: 9102
           volumeMounts:
-            - name: nova-etc
-              mountPath: /etc/statsd/statsd-exporter.yaml
-              subPath: statsd-exporter.yaml
-              readOnly: true
+          - name: statsd-etc
+            mountPath: /etc/statsd/statsd-exporter.yaml
+            subPath: statsd-exporter.yaml
+            readOnly: true
         {{- end }}
       volumes:
-        - name: etcnova
-          emptyDir: {}
-        - name: nova-etc
-          configMap:
-            name: nova-etc
-        - name: nova-scheduler-etc
-          configMap:
-            name: nova-scheduler-etc
-        {{- include "utils.proxysql.volumes" . | indent 8 }}
+      - name: nova-etc
+        projected:
+          sources:
+          - configMap:
+              name: nova-etc
+              items:
+              - key:  nova.conf
+                path: nova.conf
+              - key:  logging.ini
+                path: logging.ini
+          - secret:
+              name: nova-etc
+              items:
+              - key:  db.conf
+                path: nova.conf.d/db.conf
+          - configMap:
+              name: nova-scheduler-etc
+              items:
+              - key:  nova-scheduler.conf
+                path: nova-scheduler.conf
+{{- if .Values.scheduler.rpc_statsd_enabled }}
+      - name: statsd-etc
+        projected:
+          sources:
+          - configMap:
+              name: nova-etc
+              items:
+              - key:  statsd-exporter.yaml
+                path: statsd-exporter.yaml
+{{- end }}
+      {{- include "utils.proxysql.volumes" . | indent 6 }}


### PR DESCRIPTION
Instead of injecting the config for the databases in each config
use the default config dir logic and put place the config
under /etc/nova/nova.conf.d/db.conf, where all *.conf files
will be loaded.

Since the database config contains the db credentials, place
the file in a secret.

Use a projected volume to bind it all together.

Remove
- `policy.yaml` from nova-scheduler
-  iptables-restore completely
as they are not used
