### PR TITLE
[nova] Remove common.sh

### DIFF
--- a/openstack/nova/templates/bin-configmap.yaml
+++ b/openstack/nova/templates/bin-configmap.yaml
@@ -8,8 +8,6 @@ metadata:
     component: nova
 data:
 {{ (.Files.Glob "bin/*").AsConfig | indent 2 }}
-  common.sh: |
-{{ include "common.sh" .| indent 4 }}
   db-migrate: |
 {{ include (print .Template.BasePath "/bin/_db-migrate.tpl") . | indent 4 }}
   db-online-migrate: |


### PR DESCRIPTION
The file isn't use anymore, so we might as well remove it from the configmap