### PR TITLE
[nova] Use rootwrap.conf from loci image

### DIFF
--- a/openstack/nova/templates/etc/_rootwrap.conf.tpl
+++ b/openstack/nova/templates/etc/_rootwrap.conf.tpl
@@ -1,5 +1,27 @@
+# Configuration for nova-rootwrap
+# This file should be owned by (and only-writeable by) the root user
+
 [DEFAULT]
-filters_path=/etc/nova/rootwrap.d,/usr/share/nova/rootwrap
-exec_dirs=/var/lib/kolla/venv/bin,/sbin,/usr/sbin,/bin,/usr/bin,/usr/local/bin,/usr/local/sbin
+# List of directories to load filter definitions from (separated by ',').
+# These directories MUST all be only writeable by root !
+filters_path=/etc/nova/rootwrap.d,/usr/share/nova/rootwrap,/var/lib/openstack/etc/nova/rootwrap.d
+
+# List of directories to search executables in, in case filters do not
+# explicitly specify a full path (separated by ',')
+# If not specified, defaults to system PATH environment variable.
+# These directories MUST all be only writeable by root !
+exec_dirs=/sbin,/usr/sbin,/bin,/usr/bin,/usr/local/bin,/usr/local/sbin,/var/lib/openstack/bin
+
+# Enable logging to syslog
+# Default value is False
 use_syslog=False
+
+# Which syslog facility to use.
+# Valid values include auth, authpriv, syslog, local0, local1...
+# Default value is 'syslog'
+syslog_log_facility=syslog
+
+# Which messages to log.
+# INFO means log all usage
+# ERROR means only log unsuccessful attempts
 syslog_log_level=ERROR


### PR DESCRIPTION
The checked in rootwrap.conf is based on the one from kolla, but since we switched to loci images the paths are not correct.