### PR TITLE
[nova] Add iscsiadm to bin configmap

### DIFF
--- a/openstack/nova/bin/iscsiadm
+++ b/openstack/nova/bin/iscsiadm
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec chroot /host /usr/bin/env -i PATH="/sbin:/bin:/usr/sbin:/usr/bin" "${0##*/}" "$@"


### PR DESCRIPTION
For KVM we need to access the iscsiadm of the host-system.