### PR TITLE
arc/lyra: bump pgbackup chart from 0.1.7 to 0.1.10

### DIFF
--- a/openstack/arc/Chart.lock
+++ b/openstack/arc/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 0.1.10
 - name: pgmetrics
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.5
-digest: sha256:6481629234759550a1e6f5996acf61482acd27405851dcf857dd7038f26c3dc7
-generated: "2023-03-20T14:33:09.249629737+01:00"
+  version: 0.4.1
+digest: sha256:016f7fa2f646922b015d2314d1e001e6258a15eccfc079df66eecd45b9f34d6d
+generated: "2023-03-20T14:50:15.252979237+01:00"

--- a/openstack/arc/Chart.lock
+++ b/openstack/arc/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 0.2.0
 - name: pgbackup
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.7
+  version: 0.1.10
 - name: pgmetrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.3.5
-digest: sha256:e27dbd28d381e29b068373431487649c352160639977f00963473c40a102852c
-generated: "2023-02-21T14:58:21.208848743+01:00"
+digest: sha256:6481629234759550a1e6f5996acf61482acd27405851dcf857dd7038f26c3dc7
+generated: "2023-03-20T14:33:09.249629737+01:00"

--- a/openstack/arc/Chart.yaml
+++ b/openstack/arc/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
     version: 0.2.0
   - name: pgbackup
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.7
+    version: 0.1.10
   - name: pgmetrics
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.3.5

--- a/openstack/arc/Chart.yaml
+++ b/openstack/arc/Chart.yaml
@@ -11,4 +11,4 @@ dependencies:
     version: 0.1.10
   - name: pgmetrics
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.3.5
+    version: 0.4.1

--- a/openstack/lyra/Chart.lock
+++ b/openstack/lyra/Chart.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 0.3.0
 - name: pgbackup
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.7
+  version: 0.1.10
 - name: pgmetrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.3.1
-digest: sha256:fc9c861b8d857e44b2c93cdc2f82f7241eb9da81c7452c8698fabcb20c46bcdc
-generated: "2023-02-21T14:58:24.960832949+01:00"
+digest: sha256:106336796f02c176c0d7aa220f103ca4d1f4ff7c14ea7dc004390b1605971379
+generated: "2023-03-20T14:33:14.439553012+01:00"

--- a/openstack/lyra/Chart.lock
+++ b/openstack/lyra/Chart.lock
@@ -10,6 +10,6 @@ dependencies:
   version: 0.1.10
 - name: pgmetrics
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.3.1
-digest: sha256:106336796f02c176c0d7aa220f103ca4d1f4ff7c14ea7dc004390b1605971379
-generated: "2023-03-20T14:33:14.439553012+01:00"
+  version: 0.4.1
+digest: sha256:62372c6b2e8f7f9cee9ba3f329466e07ec63b76ef72041bd3fc7170c9413e3be
+generated: "2023-03-20T14:49:52.471072862+01:00"

--- a/openstack/lyra/Chart.yaml
+++ b/openstack/lyra/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
     version: 0.3.0
   - name: pgbackup
     repository: "https://charts.eu-de-2.cloud.sap"
-    version: 0.1.7
+    version: 0.1.10
   - name: pgmetrics
     repository: "https://charts.eu-de-2.cloud.sap"
     version: 0.3.1

--- a/openstack/lyra/Chart.yaml
+++ b/openstack/lyra/Chart.yaml
@@ -14,4 +14,4 @@ dependencies:
     version: 0.1.10
   - name: pgmetrics
     repository: "https://charts.eu-de-2.cloud.sap"
-    version: 0.3.1
+    version: 0.4.1

--- a/openstack/lyra/values.yaml
+++ b/openstack/lyra/values.yaml
@@ -84,13 +84,3 @@ pgmetrics:
   db_name: monsoon-automation_production
   alerts:
     support_group: containers
-  customMetrics:
-    pg_database:
-      query: "SELECT d.datname AS datname, CASE WHEN pg_catalog.has_database_privilege(d.datname, 'CONNECT') THEN pg_catalog.pg_database_size(d.datname) ELSE 0 END AS size_bytes FROM pg_catalog.pg_database d where datname not in ('template0', 'template1', 'postgres')"
-      metrics:
-        - datname:
-            usage: "LABEL"
-            description: "Name of the database"
-        - size_bytes:
-            usage: "GAUGE"
-            description: "Size of the database in bytes"


### PR DESCRIPTION
This upgrades https://github.com/sapcc/backup-tools from 0.8.0 to 0.9.1, including a cleanup of all code towards current best practices. Starting with 0.9.x, backup-tools releases are validated by E2E tests in Concourse.

*Update:* This now also bumps the pgmetrics chart to update prometheus-exporter to 0.11.1 and set `support_group` on all alerts.