### PR TITLE
sentry: bump pgbackup chart from 0.1.4 to 0.1.10

### DIFF
--- a/system/sentry/Chart.lock
+++ b/system/sentry/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: pgbackup
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.4
+  version: 0.1.10
 - name: pgmetrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.3.5
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:058ed1da68f080c4d5ab468e039993f53690ad95f98c16afd5156d3f19ca627b
-generated: "2023-03-20T16:25:45.552987174+01:00"
+digest: sha256:fe4ab41322b3146bebe5233884a9a8376ed8c345d61292335398b0abc3e1676f
+generated: "2023-03-20T16:26:22.215390814+01:00"

--- a/system/sentry/Chart.yaml
+++ b/system/sentry/Chart.yaml
@@ -5,7 +5,7 @@ version: 0.2.0
 dependencies:
   - name: pgbackup
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.4
+    version: 0.1.10
   - name: pgmetrics
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.3.5


### PR DESCRIPTION
This upgrades https://github.com/sapcc/backup-tools from 0.7.0 to 0.9.1, including a cleanup of all code towards current best practices and a replacement of python-swiftclient usage with native Go code. Overall, everything should be a bit cleaner and more modern. Starting with 0.9.x, backup-tools releases are validated by E2E tests in Concourse.