### PR TITLE
[sap-seeds] Extract common flags to snippets, set hypervisor to vmware

### DIFF
--- a/openstack/sap-seeds/Chart.lock
+++ b/openstack/sap-seeds/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: owner-info
+  repository: https://charts.eu-de-2.cloud.sap
+  version: 0.2.0
+digest: sha256:6c7a0e8b21abdaecf3124234d79457638aff93c3f51c9cedd56500d24eb652e0
+generated: "2023-03-21T16:03:08.191727412+01:00"

--- a/openstack/sap-seeds/templates/_flavors_hana_exclusive.tpl
+++ b/openstack/sap-seeds/templates/_flavors_hana_exclusive.tpl
@@ -4,9 +4,7 @@
   ram: 373352
   disk: 64
   extra_specs:
-    "vmware:hv_enabled": "True"
-    "hw_video:ram_max_mb": "16"
-    "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "required"
+    {{- tuple . "vmware_hana_exclusive" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "24"  # used in nova-vmware as cores-per-socket (12pCPU = 24vCPU)
 - name: "hana_c48_m729"
@@ -15,9 +13,7 @@
   ram: 746720
   disk: 64
   extra_specs:
-    "vmware:hv_enabled": "True"
-    "hw_video:ram_max_mb": "16"
-    "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "required"
+    {{- tuple . "vmware_hana_exclusive" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
 - name: "hana_c96_m1458"
@@ -26,9 +22,7 @@
   ram: 1493460
   disk: 64
   extra_specs:
-    "vmware:hv_enabled": "True"
-    "hw_video:ram_max_mb": "16"
-    "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "required"
+    {{- tuple . "vmware_hana_exclusive" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
 - name: "hana_c144_m2188"
@@ -37,9 +31,7 @@
   ram: 2240196
   disk: 64
   extra_specs:
-    "vmware:hv_enabled": "True"
-    "hw_video:ram_max_mb": "16"
-    "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "required"
+    {{- tuple . "vmware_hana_exclusive" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
     "vmware:hw_version": "vmx-18"
@@ -49,9 +41,7 @@
   ram: 2986936
   disk: 64
   extra_specs:
-    "vmware:hv_enabled": "True"
-    "hw_video:ram_max_mb": "16"
-    "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "required"
+    {{- tuple . "vmware_hana_exclusive" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
     "vmware:hw_version": "vmx-18"
@@ -61,9 +51,7 @@
   ram: 5975024
   disk: 64
   extra_specs:
-    "vmware:hv_enabled": "True"
-    "hw_video:ram_max_mb": "16"
-    "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "required"
+    {{- tuple . "vmware_hana_exclusive" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
     "vmware:hw_version": "vmx-18"
@@ -73,9 +61,7 @@
   ram: 4481528
   disk: 64
   extra_specs:
-    "vmware:hv_enabled": "True"
-    "hw_video:ram_max_mb": "16"
-    "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "required"
+    {{- tuple . "vmware_hana_exclusive" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
     "vmware:hw_version": "vmx-18"
@@ -85,9 +71,7 @@
   ram: 11950772
   disk: 64
   extra_specs:
-    "vmware:hv_enabled": "True"
-    "hw_video:ram_max_mb": "16"
-    "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "required"
+    {{- tuple . "vmware_hana_exclusive" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "trait:CUSTOM_NUMASIZE_C56_M1459": "required"
     "hw:cpu_cores": "56"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
     "vmware:hw_version": "vmx-18"
@@ -101,10 +85,8 @@
   disk: 64
   is_public: true
   extra_specs:
-    "vmware:hv_enabled": "True"
-    "hw_video:ram_max_mb": "16"
+    {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "host_fraction": "1/4,3/4,1/2,1"
-    "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
 - name: "x1.32xlarge"
   id: "250"
   vcpus: 128
@@ -112,8 +94,6 @@
   disk: 64
   is_public: true
   extra_specs:
-    "vmware:hv_enabled": "True"
-    "hw_video:ram_max_mb": "16"
+    {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "host_fraction": "1,0.67,0.34"
-    "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
 {{- end }}

--- a/openstack/sap-seeds/templates/_flavors_hana_no_exclusive.tpl
+++ b/openstack/sap-seeds/templates/_flavors_hana_no_exclusive.tpl
@@ -4,8 +4,7 @@
   ram: 373352
   disk: 64
   extra_specs:
-    "vmware:hv_enabled": "True"
-    "hw_video:ram_max_mb": "16"
+    {{- tuple . "vmware_common" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "resources:CUSTOM_MEMORY_RESERVABLE_MB": "373352"
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "24"  # used in nova-vmware as cores-per-socket (12pCPU = 24vCPU)
@@ -15,8 +14,7 @@
   ram: 746720
   disk: 64
   extra_specs:
-    "vmware:hv_enabled": "True"
-    "hw_video:ram_max_mb": "16"
+    {{- tuple . "vmware_common" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "resources:CUSTOM_MEMORY_RESERVABLE_MB": "746720"
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
@@ -26,8 +24,7 @@
   ram: 1493460
   disk: 64
   extra_specs:
-    "vmware:hv_enabled": "True"
-    "hw_video:ram_max_mb": "16"
+    {{- tuple . "vmware_common" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "resources:CUSTOM_MEMORY_RESERVABLE_MB": "1493460"
     "resources:CUSTOM_BIGVM": "2"
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
@@ -38,8 +35,7 @@
   ram: 2240196
   disk: 64
   extra_specs:
-    "vmware:hv_enabled": "True"
-    "hw_video:ram_max_mb": "16"
+    {{- tuple . "vmware_common" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "resources:CUSTOM_MEMORY_RESERVABLE_MB": "2240196"
     "resources:CUSTOM_BIGVM": "2"
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
@@ -51,8 +47,7 @@
   ram: 2986936
   disk: 64
   extra_specs:
-    "vmware:hv_enabled": "True"
-    "hw_video:ram_max_mb": "16"
+    {{- tuple . "vmware_common" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "resources:CUSTOM_MEMORY_RESERVABLE_MB": "2986936"
     "resources:CUSTOM_BIGVM": "2"
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
@@ -64,8 +59,7 @@
   ram: 5975024
   disk: 64
   extra_specs:
-    "vmware:hv_enabled": "True"
-    "hw_video:ram_max_mb": "16"
+    {{- tuple . "vmware_common" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "resources:CUSTOM_MEMORY_RESERVABLE_MB": "5975024"
     "resources:CUSTOM_BIGVM": "2"
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
@@ -77,8 +71,7 @@
   ram: 4481528
   disk: 64
   extra_specs:
-    "vmware:hv_enabled": "True"
-    "hw_video:ram_max_mb": "16"
+    {{- tuple . "vmware_common" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "resources:CUSTOM_MEMORY_RESERVABLE_MB": "4481528"
     "resources:CUSTOM_BIGVM": "2"
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
@@ -93,11 +86,9 @@
   disk: 64
   is_public: true
   extra_specs:
-    "vmware:hv_enabled": "True"
-    "hw_video:ram_max_mb": "16"
+    {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "host_fraction": "1/4,3/4,1/2,1"
     "resources:CUSTOM_BIGVM": "2"
-    "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
 - name: "x1.32xlarge"
   id: "250"
   vcpus: 128
@@ -105,8 +96,6 @@
   disk: 64
   is_public: true
   extra_specs:
-    "vmware:hv_enabled": "True"
-    "hw_video:ram_max_mb": "16"
+    {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "host_fraction": "1,0.67,0.34"
     "resources:CUSTOM_BIGVM": "2"
-    "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"

--- a/openstack/sap-seeds/templates/_helpers.tpl
+++ b/openstack/sap-seeds/templates/_helpers.tpl
@@ -1,0 +1,12 @@
+{{- define "sap_seeds.helpers.extra_specs" }}
+{{- $envAll := index . 0 }}
+{{- $key :=  index . 1 }}
+{{- $extraSpecs := get $envAll.Values.extra_specs $key | required (print "Please set sap-seeds.extra_specs." $key) }}
+{{- if ge (len .) 3 }}
+    {{- $override := index . 2 }}
+    {{- $extraSpecs = merge $override $extraSpecs }}
+{{- end }}
+{{- range $k, $v := $extraSpecs }}
+{{ $k | quote }}: {{ $v | quote }}
+{{- end }}
+{{- end }}

--- a/openstack/sap-seeds/templates/flavor-seed.yaml
+++ b/openstack/sap-seeds/templates/flavor-seed.yaml
@@ -6,6 +6,14 @@ spec:
   requires:
   - monsoon3/nova-flavor-seed
   flavors:
+  - name: "forced"
+    id: "1"
+    vcpus: 1
+    ram: 1024
+    disk: 0
+    is_public: false
+    extra_specs:
+      {{- tuple . "forced" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m1.tiny"
     id: "10"
     vcpus: 1

--- a/openstack/sap-seeds/templates/flavor-seed.yaml
+++ b/openstack/sap-seeds/templates/flavor-seed.yaml
@@ -13,9 +13,7 @@ spec:
     disk: 1
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "4"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" (dict "hw_video:ram_max_mb" 4) | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c1_m2"
     id: "19"
     vcpus: 1
@@ -23,10 +21,8 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
       "catalog:alias": "m1.xsmallcpuhdd"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "c_c2_m2"
     id: "20"
     vcpus: 2
@@ -34,10 +30,8 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
       "catalog:alias": "m1.small,m1.smallhdd"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c2_m4"
     id: "22"
     vcpus: 2
@@ -45,10 +39,8 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
       "catalog:alias": "m1.xsmall,m1.xsmallhdd"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c1_m3"
     id: "24"
     vcpus: 1
@@ -56,9 +48,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c1_m4"
     id: "25"
     vcpus: 1
@@ -66,9 +56,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c2_m8"
     id: "32"
     vcpus: 2
@@ -76,10 +64,8 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
       "catalog:alias": "m1.xmedium"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "c_c4_m4"
     id: "30"
     vcpus: 4
@@ -87,10 +73,8 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
       "catalog:alias": "m1.medium"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c4_m8"
     id: "40"
     vcpus: 4
@@ -98,10 +82,8 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
       "catalog:alias": "m1.large"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c4_m16"
     id: "50"
     vcpus: 4
@@ -109,10 +91,8 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
       "catalog:alias": "m1.xlarge"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "c_c16_m16"
     id: "52"
     vcpus: 16
@@ -120,10 +100,8 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
       "catalog:alias": "m1.xlarge_cpu"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c6_m24"
     id: "53"
     vcpus: 6
@@ -131,9 +109,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c8_m32"
     id: "60"
     vcpus: 8
@@ -141,10 +117,8 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
       "catalog:alias": "m1.2xlarge"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c16_m32"
     id: "61"
     vcpus: 16
@@ -152,10 +126,8 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
       "catalog:alias": "m1.2xlargecpu"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c12_m48"
     id: "62"
     vcpus: 12
@@ -163,9 +135,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c16_m64"
     id: "70"
     vcpus: 16
@@ -173,10 +143,8 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
       "catalog:alias": "m1.4xlarge"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m1.10xlarge"
     id: "80"
     vcpus: 40
@@ -184,9 +152,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m1.10xlargesmallcpu"
     id: "81"
     vcpus: 16
@@ -194,9 +160,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "x1.memory"
     id: "90"
     vcpus: 8
@@ -204,9 +168,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "x1.2xmemory"
     id: "99"
     vcpus: 16
@@ -214,9 +176,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "x1.4xmemory"
     id: "150"
     vcpus: 32
@@ -224,9 +184,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "x1.8xmemory"
     id: "151"
     vcpus: 64
@@ -234,9 +192,7 @@ spec:
     disk: 64
     is_public: false
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c4_m64"
     id: "100"
     vcpus: 4
@@ -244,10 +200,8 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
       "catalog:alias": "m2.large"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c8_m16"
     id: "110"
     vcpus: 8
@@ -255,10 +209,8 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
       "catalog:alias": "m2.xlarge"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m2.2xlarge"
     id: "120"
     vcpus: 8
@@ -266,9 +218,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m2.2xlarge_cpu"
     id: "122"
     vcpus: 24
@@ -276,9 +226,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m2.10xlarge_cpu"
     id: "123"
     vcpus: 24
@@ -286,9 +234,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m2.14xlarge_cpu"
     id: "124"
     vcpus: 24
@@ -296,9 +242,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m2.14xlarge_cpuhdd"
     id: "125"
     vcpus: 24
@@ -306,9 +250,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m2.3xlarge"
     id: "130"
     vcpus: 8
@@ -316,9 +258,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c8_m64"
     id: "140"
     vcpus: 8
@@ -326,10 +266,8 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
       "catalog:alias": "m2.4xlarge"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c8_m256"
     id: "141"
     vcpus: 8
@@ -337,9 +275,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c24_m192"
     id: "142"
     vcpus: 24
@@ -347,9 +283,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c16_m128"
     id: "160"
     vcpus: 16
@@ -357,10 +291,8 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
       "catalog:alias": "m2.8xlarge"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m2.16xlarge"
     id: "161"
     vcpus: 16
@@ -368,9 +300,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c16_m512"
     id: "164"
     vcpus: 16
@@ -378,9 +308,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c32_m128"
     id: "162"
     vcpus: 32
@@ -388,9 +316,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m5.xlarge2hdd"
     id: "210"
     vcpus: 4
@@ -398,9 +324,7 @@ spec:
     disk: 150
     is_public: false
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m5.12xlarge"
     id: "211"
     vcpus: 48
@@ -408,9 +332,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m5.14xlarge"
     id: "212"
     vcpus: 60
@@ -418,9 +340,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c32_m256"
     id: "163"
     vcpus: 32
@@ -428,9 +348,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c64_m256"
     id: "220"
     vcpus: 64
@@ -438,10 +356,8 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
       "catalog:alias": "m5.16xlarge"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c48_m512"
     id: "221"
     vcpus: 48
@@ -449,9 +365,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c128_m512"
     id: "230"
     vcpus: 128
@@ -459,10 +373,8 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
       "catalog:alias": "m5.32xlarge"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m5.48xlarge"
     id: "231"
     vcpus: 96
@@ -470,9 +382,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c128_m1000"
     id: "240"
     vcpus: 128
@@ -480,10 +390,8 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
       "catalog:alias": "m5.64xlarge"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
 
   ### HANA flavors
 {{- if .Values.use_hana_exclusive }}
@@ -499,8 +407,7 @@ spec:
     disk: 64
     is_public: false
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
+      {{- tuple . "vmware_common" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
 
   ### Special, i.e. private customer flavors
   - name: "s_c64_m64"
@@ -510,6 +417,4 @@ spec:
     disk: 64
     is_public: false
     extra_specs:
-      "vmware:hv_enabled": "True"
-      "hw_video:ram_max_mb": "16"
-      "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}

--- a/openstack/sap-seeds/values.yaml
+++ b/openstack/sap-seeds/values.yaml
@@ -19,3 +19,15 @@ owner-info:
 global:
   domain_seeds:
     skip_hcm_domain: false
+
+extra_specs:
+  vmware_common: &vmware_common
+    "capabilities:hypervisor_type": "VMware vCenter Server"
+    "hw_video:ram_max_mb": "16"
+    "vmware:hv_enabled": "True"
+  vmware:
+    <<: *vmware_common
+    "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+  vmware_hana_exclusive:
+    <<: *vmware_common
+    "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "required"

--- a/openstack/sap-seeds/values.yaml
+++ b/openstack/sap-seeds/values.yaml
@@ -21,6 +21,7 @@ global:
     skip_hcm_domain: false
 
 extra_specs:
+  forced: {}
   vmware_common: &vmware_common
     "capabilities:hypervisor_type": "VMware vCenter Server"
     "hw_video:ram_max_mb": "16"


### PR DESCRIPTION
We want to be able to allow users to target another hypervisor (libvirt) in the future, so for compatability reasons, the existing flavors need to target vsphere.

We chose flavors over image attributes as it is more explicit, and we only want allow boot-from-volume on KVM, while the existing flavors have root-disks.

As a side-effect, it "breaks" forcing those non-baremetal flavor to a baremetal host.