### PR TITLE
do not assign kubernetes_member role to MEMBER group

### DIFF
--- a/openstack/octobus/templates/seeds.yaml
+++ b/openstack/octobus/templates/seeds.yaml
@@ -115,8 +115,6 @@ spec:
       - project: octobus
         role: keymanager_viewer
       - project: octobus
-        role: kubernetes_member
-      - project: octobus
         role: masterdata_viewer
       - project: octobus
         role: member


### PR DESCRIPTION
cc @viennaa 

Do not assign the `kubernetes_member` openstack role to the **MEMBER** group.