### PR TITLE
[Swift] swift_avoid_node_reboot metric

### DIFF
--- a/openstack/swift/aggregations/openstack/consolidation.rules
+++ b/openstack/swift/aggregations/openstack/consolidation.rules
@@ -19,10 +19,13 @@ groups:
     expr: topk(10, sum(rate(openstack_watcher_api_requests_total{service="object-store"}[5m]) * 60) by (target_project_id, action) > 15)
 
   - record: swift_avoid_node_reboot
-    # Replication ages in the last 10m not older than 5m
-    # No stroage node down
-    # Not more than 2 disks unmounted
-    # Swift healthy
+    # Automatic reboots of storage nodes are safe if:
+    # - Replication ages in the last 10m not older than 5m
+    # - No storage node down
+    # - Not more than 2 disks unmounted
+    # - Swift healthy
+    #
+    # The `vector(1) and (...) or vector(0)` forces the timeseries to be either 1 (if the inner query is present) or 0 (if it is absent).
     expr: vector(1) and (
         max(max_over_time(swift_cluster_objects_replication_age[10m]) / 60) > 5 or
         max(max_over_time(swift_cluster_containers_replication_age[10m]) / 60) > 5 or

--- a/openstack/swift/aggregations/openstack/consolidation.rules
+++ b/openstack/swift/aggregations/openstack/consolidation.rules
@@ -17,3 +17,17 @@ groups:
 
   - record: swift_opm_top10_by_action
     expr: topk(10, sum(rate(openstack_watcher_api_requests_total{service="object-store"}[5m]) * 60) by (target_project_id, action) > 15)
+
+  - record: swift_avoid_node_reboot
+    # Replication ages in the last 10m not older than 5m
+    # No stroage node down
+    # Not more than 2 disks unmounted
+    # Swift healthy
+    expr: vector(1) and (
+        max(max_over_time(swift_cluster_objects_replication_age[10m]) / 60) > 5 or
+        max(max_over_time(swift_cluster_containers_replication_age[10m]) / 60) > 5 or
+        max(max_over_time(swift_cluster_accounts_replication_age[10m]) / 60) > 5 or
+        max(max_over_time(swift_cluster_md5_errors{kind="ring"}[10m])) > 0 or
+        max(swift_cluster_drives_unmounted) > 1 or
+        avg_over_time(swift_recon_task_exit_code[10m]) > 0.2 or avg_over_time(swift_dispersion_task_exit_code[10m]) > 0.2 or absent_over_time(swift_dispersion_task_exit_code[10m])
+      ) or vector(0)


### PR DESCRIPTION
To allow automatic node reinstallations or reboots through the maintenance controller it is helpfull that everyone can rely on a single metric which indicates, whether it is safe to proceed with the next node in the queue.