### PR TITLE
[cinder] Bump memcached to 0.1.0

### DIFF
--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 0.2.7
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.0.11
+  version: 0.1.0
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.5.1
@@ -20,5 +20,5 @@ dependencies:
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:359746e5f1442ef82b85f4f9136878d0f52f063fbcfe52dbcd879906ac3c0f8a
-generated: "2023-03-13T14:32:52.534943004+01:00"
+digest: sha256:25763d32d1a1bb3557906e65621f31311826583d544bf456ea4e15bae5303393
+generated: "2023-03-28T15:29:15.959509435+02:00"

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
     condition: mariadb.enabled
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.0.11
+    version: 0.1.0
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.5.1


### PR DESCRIPTION
With that we get the newest version (1.6.18) and reduce the MemcachedManyConnectionsThrottled to info level.