### PR TITLE
[placement] Bump memcached to 0.1.0

### DIFF
--- a/openstack/placement/Chart.lock
+++ b/openstack/placement/Chart.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 0.7.1
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.0.11
+  version: 0.1.0
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.4.4
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:8cb273452ebe8450ba3547fcd16df76a093219cde857899d97a8f4da3ac87006
-generated: "2022-10-24T09:57:31.889198918+02:00"
+digest: sha256:69d640e0947036be45c4b3228b8ea6b16dfdc0f7cb699cc2b546d6e4256ec72a
+generated: "2023-03-28T15:35:59.236642194+02:00"

--- a/openstack/placement/Chart.yaml
+++ b/openstack/placement/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
     version: 0.7.1
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.0.11
+    version: 0.1.0
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.4.4


### PR DESCRIPTION
With this we get security-patches and a version upgrade to 1.6.18 and reduce the MemcachedManyConnectionsThrottled alert to info level.