### PR TITLE
[Octavia] Bump subcharts, update chart version

### DIFF
--- a/openstack/octavia/Chart.lock
+++ b/openstack/octavia/Chart.lock
@@ -1,21 +1,21 @@
 dependencies:
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.5
+  version: 0.7.7
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.0.11
+  version: 0.1.0
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.7
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.4.4
+  version: 0.5.1
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.10.1
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:c902cda067d92ec292fc36c2f04539927c918cee54d2d8d4891db554c30dd972
-generated: "2023-07-14T11:55:51.540693332+02:00"
+digest: sha256:080034d39fb7a50e0aceb6660cc6a65e12331c37a10796ac81f2a54bcd527ec2
+generated: "2023-07-17T15:48:36.88675555+02:00"

--- a/openstack/octavia/Chart.yaml
+++ b/openstack/octavia/Chart.yaml
@@ -7,7 +7,8 @@ name: octavia
 sources:
   - https://git.openstack.org/cgit/openstack/octavia
   - https://git.openstack.org/cgit/openstack/openstack-helm
-version: 0.1.11
+# The versions are defined in the changelog: https://docs.openstack.org/releasenotes/octavia/yoga.html
+version: 10.0.0
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/octavia/Chart.yaml
+++ b/openstack/octavia/Chart.yaml
@@ -12,17 +12,17 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.7.5
+    version: 0.7.7
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.0.11
+    version: 0.1.0
   - condition: mariadb.enabled
     name: mysql_metrics
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.7
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.4.4
+    version: 0.5.1
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
     version: ~0.10.0


### PR DESCRIPTION
mariadb 0.7.5 -> 0.7.7
- a8725d6f5cbcf047c8101f7c87ac2e51a8e21435 backup slow log fix
- 956519b7aa371cafb8584ab6a38aa6e6fef36c75 fixes slow_query log setting in backup tool (#4787)

memcached 0.0.11 -> 0.1.0
- ff9ae0838ea666688a5ee0c2bdc818dfdd33b9f1 Move yielded connections alert to info
- f9ec2655a2e2fa6fa8b745112d21416d93cd305d Security Patch and Version upgrade to 1.6.18

rabbitmq 0.4.4 -> 0.5.1
- 9df22ade734c5917caf5eec18c1fbc7ee94a6320 add support for rabbitmq-prometheus
- b37ff0be1c1c81933b3f44ca3478b641c25b0e51 Shorter hostnames

utils 0.7.0 -> 0.8.0 (Edit: After rebasing utils is now on 0.10.1)
- 3987bc736873001d1f8a36558d55a195a9873c4f fix deprecated match key in node affinity
- 7a948411d5327e842a347ada112024e6e2dab0c3 Retry failing proxysql post-start config
- b148fbdf168b3a12fd8ea2b4617ec47681226358 Update proxysql to 2.4.7
- 3a66513088f4f773d8f6fae54a4e9c7d2b4c2788 Revert "[openstack] fix deprecated match key in node affinity" (3987bc736873001d1f8a36558d55a195a9873c4f)
- fcab93396dc77fc42c8cce6dc3fd9febe6d7ca36 attempted fix of proxysql_configmap snippet
- 27b06517d7e409b075c8565c379ad4656da58e01 Add env-vars snippet for pyroscope

---

Includes and thus Closes #4637 