### PR TITLE
srs: add `runAsNonRoot: true` or `runAsUser: 0` to most containers

### DIFF
--- a/openstack/backup-replication/templates/replication-deployment.yaml
+++ b/openstack/backup-replication/templates/replication-deployment.yaml
@@ -59,6 +59,8 @@ spec:
           value: 'true'
         - name: 'DEBUG'
           value: {{ $.Values.swift_http_import.debug | quote }}
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - name: bin
           mountPath: /bin-backup-replication

--- a/openstack/backup-replication/templates/statsd-deployment.yaml
+++ b/openstack/backup-replication/templates/statsd-deployment.yaml
@@ -30,6 +30,8 @@ spec:
       - name: statsd
         image: {{ .Values.global.dockerHubMirror | required ".Values.global.dockerHubMirror is missing" }}/prom/statsd-exporter:{{ .Values.statsd.exporter_image_version }}
         args: [ --statsd.mapping-config=/etc/statsd/statsd-exporter.yaml ]
+        securityContext:
+          runAsNonRoot: true
         ports:
           - name: statsd
             containerPort: 9125

--- a/openstack/castellum/templates/api-deployment.yaml
+++ b/openstack/castellum/templates/api-deployment.yaml
@@ -52,6 +52,8 @@ spec:
           args:
             - api
           env: {{ include "castellum_common_envvars" . | indent 12 }}
+          securityContext:
+            runAsNonRoot: true
           volumeMounts:
             - mountPath: /etc/castellum
               name: config

--- a/openstack/castellum/templates/netapp-scout-deployment.yaml
+++ b/openstack/castellum/templates/netapp-scout-deployment.yaml
@@ -41,6 +41,8 @@ spec:
           imagePullPolicy: {{ .Values.castellum.image_pull_policy }}
           command: [ /usr/bin/castellum-netapp-scout ]
           args: [ /etc/castellum/netapp-scout.yaml ]
+          securityContext:
+            runAsNonRoot: true
           volumeMounts:
             - mountPath: /etc/castellum
               name: config

--- a/openstack/castellum/templates/observer-deployment.yaml
+++ b/openstack/castellum/templates/observer-deployment.yaml
@@ -42,6 +42,8 @@ spec:
           args:
             - observer
           env: {{ include "castellum_common_envvars" . | indent 12 }}
+          securityContext:
+            runAsNonRoot: true
           volumeMounts:
             - mountPath: /etc/castellum
               name: config

--- a/openstack/castellum/templates/worker-deployment.yaml
+++ b/openstack/castellum/templates/worker-deployment.yaml
@@ -42,6 +42,8 @@ spec:
           args:
             - worker
           env: {{ include "castellum_common_envvars" . | indent 12 }}
+          securityContext:
+            runAsNonRoot: true
           volumeMounts:
             - mountPath: /etc/castellum
               name: config

--- a/openstack/clair/templates/deployment.yaml
+++ b/openstack/clair/templates/deployment.yaml
@@ -47,6 +47,7 @@ spec:
                 secretKeyRef:
                   name: clair
                   key: postgres_password
+          # TODO: securityContext: { runAsNonRoot: true }
           volumeMounts:
             - mountPath: /etc/clair
               name: config

--- a/openstack/content-repo/templates/check-deployment.yaml
+++ b/openstack/content-repo/templates/check-deployment.yaml
@@ -51,6 +51,7 @@ spec:
             value: {{ $.Values.statsd_hostname | quote }}
           - name: CHECK_INTERVAL
             value: "900" # 15 min
+        # TODO: securityContext: { runAsNonRoot: true }
         volumeMounts:
           - mountPath: /secret-check
             name: secret

--- a/openstack/content-repo/templates/mirror-cronjob.yaml
+++ b/openstack/content-repo/templates/mirror-cronjob.yaml
@@ -37,6 +37,8 @@ spec:
           - name: 'DEBUG'
             value: '1'
         {{- end}}
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
           - mountPath: /etc/http-import/config
             name: config

--- a/openstack/content-repo/templates/mirror-deployment.yaml
+++ b/openstack/content-repo/templates/mirror-deployment.yaml
@@ -71,6 +71,8 @@ spec:
           - name: 'DEBUG'
             value: 'true'
         {{- end}}
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
           - mountPath: /bin-content-repo
             name: bin

--- a/openstack/content-repo/templates/statsd-deployment.yaml
+++ b/openstack/content-repo/templates/statsd-deployment.yaml
@@ -33,6 +33,8 @@ spec:
       - name: statsd
         image: {{$.Values.global.dockerHubMirror}}/prom/statsd-exporter:{{.Values.image_version_auxiliary_statsd_exporter}}
         args: [ --statsd.mapping-config=/config/statsd-exporter.yaml ]
+        securityContext:
+          runAsNonRoot: true
         ports:
           - name: statsd
             containerPort: 9125

--- a/openstack/keppel/templates/daemonset-keep-image-pulled.yaml
+++ b/openstack/keppel/templates/daemonset-keep-image-pulled.yaml
@@ -39,6 +39,8 @@ spec:
           image: {{ include "keppel_image" . }}
           imagePullPolicy: IfNotPresent
           command: [ '/bin/sleep', 'inf' ]
+          securityContext:
+            runAsNonRoot: true
           resources:
             requests:
               cpu: "1m"
@@ -50,6 +52,10 @@ spec:
           image: "{{ .Values.global.registryAlternateRegion }}/postgres:{{.Values.postgresql.imageTag}}"
           imagePullPolicy: IfNotPresent
           command: [ '/bin/sleep', 'inf' ]
+          securityContext:
+            runAsNonRoot: true
+            runAsUser:    65534 # nobody
+            runAsGroup:   65534 # nobody
           resources:
             requests:
               cpu: "1m"
@@ -61,6 +67,10 @@ spec:
           image: "{{.Values.redis.image.repository}}:{{.Values.redis.image.tag}}"
           imagePullPolicy: IfNotPresent
           command: [ '/bin/sleep', 'inf' ]
+          securityContext:
+            runAsNonRoot: true
+            runAsUser:    65534 # nobody
+            runAsGroup:   65534 # nobody
           resources:
             requests:
               cpu: "1m"

--- a/openstack/keppel/templates/deployment-anycast-monitor.yaml
+++ b/openstack/keppel/templates/deployment-anycast-monitor.yaml
@@ -39,6 +39,8 @@ spec:
           env:
             - name:  KEPPEL_DEBUG
               value: 'false'
+          securityContext:
+            runAsNonRoot: true
           ports:
             - name: metrics
               containerPort: 8080

--- a/openstack/keppel/templates/deployment-api.yaml
+++ b/openstack/keppel/templates/deployment-api.yaml
@@ -51,6 +51,8 @@ spec:
           imagePullPolicy: IfNotPresent
           args: [ server, api ]
           env: {{ include "keppel_environment" $ | indent 12 }}
+          securityContext:
+            runAsNonRoot: true
           volumeMounts:
             - mountPath: /etc/keppel
               name: config

--- a/openstack/keppel/templates/deployment-health-monitor.yaml
+++ b/openstack/keppel/templates/deployment-health-monitor.yaml
@@ -55,6 +55,8 @@ spec:
               value: 'Default'
             - name:  OS_USERNAME
               value: 'keppel'
+          securityContext:
+            runAsNonRoot: true
           ports:
             - name: http
               containerPort: 8080

--- a/openstack/keppel/templates/deployment-janitor.yaml
+++ b/openstack/keppel/templates/deployment-janitor.yaml
@@ -41,6 +41,8 @@ spec:
           imagePullPolicy: IfNotPresent
           args: [ server, janitor ]
           env: {{ include "keppel_environment" $ | indent 12 }}
+          securityContext:
+            runAsNonRoot: true
           volumeMounts:
             - mountPath: /etc/keppel
               name: config

--- a/openstack/limes/templates/api-deployment.yaml
+++ b/openstack/limes/templates/api-deployment.yaml
@@ -54,6 +54,8 @@ spec:
             - /etc/limes/limes.yaml
           env:
             {{ include "limes_common_envvars" . | indent 12 }}
+          securityContext:
+            runAsNonRoot: true
           volumeMounts:
             - mountPath: /etc/limes
               name: config

--- a/openstack/limes/templates/collect-deployment.yaml
+++ b/openstack/limes/templates/collect-deployment.yaml
@@ -42,6 +42,8 @@ spec:
             - /etc/limes/limes.yaml
           env:
             {{ include "limes_common_envvars" . | indent 12 }}
+          securityContext:
+            runAsNonRoot: true
           volumeMounts:
             - mountPath: /etc/limes
               name: config

--- a/openstack/swift-drive-autopilot/templates/daemonset.yaml
+++ b/openstack/swift-drive-autopilot/templates/daemonset.yaml
@@ -75,6 +75,7 @@ spec:
         - name: boot
           image: {{$.Values.global.registryAlternateRegion}}/swift-drive-autopilot:{{include "image_version" $}}
           securityContext:
+            runAsUser: 0
             privileged: true
           args:
             - /etc/drive-autopilot/config{{$suffix}}.yaml

--- a/openstack/swift-utils/templates/account-caretaker-collect-daemonset.yaml
+++ b/openstack/swift-utils/templates/account-caretaker-collect-daemonset.yaml
@@ -62,6 +62,7 @@ spec:
             - account-caretaker-collect
           # privileged access required for /swift-bin/unmount-helper (TODO: use shared/slave mount namespace instead)
           securityContext:
+            runAsUser: 0
             privileged: true
           env:
             - name: DEBUG_CONTAINER

--- a/openstack/swift-utils/templates/account-caretaker-mergify-deployment.yaml
+++ b/openstack/swift-utils/templates/account-caretaker-mergify-deployment.yaml
@@ -51,6 +51,7 @@ spec:
                 secretKeyRef:
                   name: swift-utils-secret
                   key: caretaker_password
+          # TODO: securityContext: { runAsNonRoot: true }
           volumeMounts:
             - mountPath: /caretaker-etc
               name: caretaker-etc

--- a/openstack/swift/templates/_utils.tpl
+++ b/openstack/swift/templates/_utils.tpl
@@ -130,6 +130,7 @@ checksum/object.ring: {{ include "swift/templates/object-ring.yaml" . | sha256su
     limits:
       cpu: {{ required (printf "proxy_%s_resources_cpu is required" $kind) $resources_cpu | quote }}
       memory: {{ required (printf "proxy_%s_resources_memory is required" $kind) $resources_memory | quote }}
+  # TODO: securityContext: { runAsNonRoot: true }
   volumeMounts:
     - mountPath: /swift-etc
       name: swift-etc
@@ -188,6 +189,7 @@ checksum/object.ring: {{ include "swift/templates/object-ring.yaml" . | sha256su
     limits:
       cpu: "100m"
       memory: "150Mi"
+  # TODO: securityContext: { runAsNonRoot: true }
   volumeMounts:
     - mountPath: /swift-etc
       name: swift-etc
@@ -203,6 +205,8 @@ checksum/object.ring: {{ include "swift/templates/object-ring.yaml" . | sha256su
   args: [ --statsd.mapping-config=/swift-etc/statsd-exporter.yaml ]
   {{- $resources_cpu := index $context.Values "proxy_statsd_exporter_resources_cpu" }}
   {{- $resources_memory := index $context.Values "proxy_statsd_exporter_resources_memory" }}
+  securityContext:
+    runAsNonRoot: true
   resources:
     requests:
       cpu: {{ required "proxy_statsd_exporter_resources_cpu is required" $resources_cpu | quote }}
@@ -236,6 +240,7 @@ checksum/object.ring: {{ include "swift/templates/object-ring.yaml" . | sha256su
     - {{ $service }}
   # privileged access required for /usr/bin/unmount-helper (TODO: use shared/slave mount namespace instead)
   securityContext:
+    runAsUser: 0
     privileged: true
   env:
     - name: DEBUG_CONTAINER

--- a/openstack/swift/templates/envoy-deployment.yaml
+++ b/openstack/swift/templates/envoy-deployment.yaml
@@ -98,6 +98,7 @@ spec:
           env:
             - name: DEBUG_CONTAINER
               value: "false"
+          # TODO: securityContext: { runAsNonRoot: true }
           resources:
             requests:
               cpu: "1000m"

--- a/openstack/swift/templates/haproxy-deployment.yaml
+++ b/openstack/swift/templates/haproxy-deployment.yaml
@@ -151,6 +151,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
+          # TODO: securityContext: { runAsNonRoot: true }
           resources:
             requests:
               cpu: {{ $.Values.haproxy_deployment_resources_cpu | required "haproxy_deployment_resources_cpu is required" | quote }}

--- a/openstack/swift/templates/health-exporter-deployment.yaml
+++ b/openstack/swift/templates/health-exporter-deployment.yaml
@@ -81,7 +81,7 @@ spec:
                   key: dispersion_password
             - name: SWIFT_CLUSTER_RAW_CAPACITY_BYTES
               value: {{ quote .Values.raw_capacity }}
-
+          # TODO: securityContext: { runAsNonRoot: true }
           ports:
             - name: metrics
               containerPort: 9520

--- a/openstack/swift/templates/keep-image-pulled-daemonset.yaml
+++ b/openstack/swift/templates/keep-image-pulled-daemonset.yaml
@@ -39,6 +39,10 @@ spec:
           image: {{ include "swift_image" . }}
           imagePullPolicy: IfNotPresent
           command: [ '/bin/sleep', 'inf' ]
+          securityContext:
+            runAsNonRoot: true
+            runAsUser:    65534 # nobody
+            runAsGroup:   65534 # nobody
           resources:
             requests:
               cpu: "1m"
@@ -50,6 +54,10 @@ spec:
           image: {{ .Values.global.registryAlternateRegion}}/swift-haproxy:{{ .Values.image_version_haproxy }}
           imagePullPolicy: IfNotPresent
           command: [ '/bin/sleep', 'inf' ]
+          securityContext:
+            runAsNonRoot: true
+            runAsUser:    65534 # nobody
+            runAsGroup:   65534 # nobody
           resources:
             requests:
               cpu: "1m"
@@ -61,6 +69,8 @@ spec:
           image: {{ .Values.global.dockerHubMirrorAlternateRegion }}/prom/statsd-exporter:{{ .Values.image_version_auxiliary_statsd_exporter }}
           imagePullPolicy: IfNotPresent
           command: [ '/bin/tail', '-f', '/dev/null' ] # does not support "sleep inf" in the image version currently in use
+          securityContext:
+            runAsNonRoot: true
           resources:
             requests:
               cpu: "1m"

--- a/openstack/swift/templates/memcached-deployment.yaml
+++ b/openstack/swift/templates/memcached-deployment.yaml
@@ -27,6 +27,7 @@ spec:
       containers:
         - name: memcached
           image: {{ $.Values.global.dockerHubMirrorAlternateRegion }}/library/memcached:{{ $.Values.image_version_auxiliary_memcached }}
+          # TODO: securityContext: { runAsNonRoot: true }
           ports:
             - name: memcached
               containerPort: 11211
@@ -41,6 +42,7 @@ spec:
               memory: '2048Mi'
         - name: metrics
           image: {{ $.Values.global.dockerHubMirrorAlternateRegion }}/prom/memcached-exporter:{{ $.Values.image_version_auxiliary_memcached_exporter }}
+          # TODO: securityContext: { runAsNonRoot: true }
           ports:
             - name: metrics
               containerPort: 9150

--- a/openstack/swift/templates/object-expirer-deployment.yaml
+++ b/openstack/swift/templates/object-expirer-deployment.yaml
@@ -65,6 +65,7 @@ spec:
                 secretKeyRef:
                   name: swift-secret
                   key: hash_path_suffix
+          # TODO: securityContext: { runAsNonRoot: true }
           resources:
             # observed usage: CPU = 1m-300m, RAM = 50-180 MiB
             requests:
@@ -86,6 +87,8 @@ spec:
         - name: statsd
           image: {{ .Values.global.dockerHubMirrorAlternateRegion }}/prom/statsd-exporter:{{ .Values.image_version_auxiliary_statsd_exporter }}
           args: [ --statsd.mapping-config=/swift-etc/statsd-exporter.yaml ]
+          securityContext:
+            runAsNonRoot: true
           resources:
             # observed usage: CPU = 10m-100m, RAM = 550-950 MiB
             requests:

--- a/openstack/swift/templates/rsyncd-daemonset.yaml
+++ b/openstack/swift/templates/rsyncd-daemonset.yaml
@@ -53,6 +53,7 @@ spec:
             - /usr/bin/rsyncd-start
           # privileged access required for /usr/bin/unmount-helper (TODO: use shared/slave mount namespace instead)
           securityContext:
+            runAsUser: 0
             privileged: true
           env:
             - name: DEBUG_CONTAINER

--- a/openstack/swift/templates/s3-cache-prewarmer-deployment.yaml
+++ b/openstack/swift/templates/s3-cache-prewarmer-deployment.yaml
@@ -40,6 +40,8 @@ spec:
             - '--servers'
             - "memcached.{{ .Release.Namespace }}.svc:11211"
           args: {{ toJson .Values.s3_cred_cache_prewarm_credentials }}
+          securityContext:
+            runAsNonRoot: true
           ports:
             - name: metrics
               containerPort: 8080

--- a/openstack/swift/templates/statsd-exporter-daemonset.yaml
+++ b/openstack/swift/templates/statsd-exporter-daemonset.yaml
@@ -42,6 +42,8 @@ spec:
         - name: statsd
           image: {{ .Values.global.dockerHubMirrorAlternateRegion }}/prom/statsd-exporter:{{.Values.image_version_auxiliary_statsd_exporter}}
           args: [ --statsd.mapping-config=/swift-etc/statsd-exporter.yaml ]
+          securityContext:
+            runAsNonRoot: true
           ports:
             - name: statsd
               containerPort: 9125

--- a/system/doop-central/templates/deployment.yaml
+++ b/system/doop-central/templates/deployment.yaml
@@ -93,6 +93,7 @@ spec:
               cpu: '50m'
               memory: '128Mi'
           securityContext:
+            runAsNonRoot: true
             allowPrivilegeEscalation: false
           volumeMounts:
             - mountPath: /etc/doop-central

--- a/system/gatekeeper/templates/deployment-doop-agent.yaml
+++ b/system/gatekeeper/templates/deployment-doop-agent.yaml
@@ -61,6 +61,8 @@ spec:
                 secretKeyRef:
                   name: doop-agent
                   key: swift_password
+          securityContext:
+            runAsNonRoot: true
           ports:
             - name: metrics
               containerPort: 8080

--- a/system/gatekeeper/templates/deployment-doop-image-checker.yaml
+++ b/system/gatekeeper/templates/deployment-doop-image-checker.yaml
@@ -57,4 +57,5 @@ spec:
               cpu: "25m"
               memory: "64Mi"
           securityContext:
+            runAsNonRoot: true
             allowPrivilegeEscalation: false

--- a/system/gatekeeper/templates/deployment-helm-manifest-parser.yaml
+++ b/system/gatekeeper/templates/deployment-helm-manifest-parser.yaml
@@ -57,4 +57,5 @@ spec:
               cpu: "1000m"
               memory: "128Mi"
           securityContext:
+            runAsNonRoot: true
             allowPrivilegeEscalation: false

--- a/system/hubcopter/templates/deployment-api.yaml
+++ b/system/hubcopter/templates/deployment-api.yaml
@@ -52,6 +52,10 @@ spec:
           image: "{{ required ".Values.global.dockerHubMirror variable missing" $.Values.global.dockerHubMirror }}/library/alpine:latest"
           imagePullPolicy: IfNotPresent
           command: ["sh", "-c", "until wget -O- $HUBCOPTER_GLAS_URL/healthcheck; do echo waiting for glas; sleep 1; done"]
+          securityContext:
+            runAsNonRoot: true
+            runAsUser:    65534 # nobody
+            runAsGroup:   65534 # nobody
       containers:
         - name: api
           image: {{ $.Values.global.registry }}/hubcopter:{{ $.Values.hubcopter.image_tag | required ".Values.hubcopter.image_tag is missing" }}
@@ -96,6 +100,8 @@ spec:
               value: 'Default'
             - name:  OS_USERNAME
               value: 'hubcopter'
+          securityContext:
+            runAsNonRoot: true
           volumeMounts:
             - mountPath: /etc/hubcopter
               name: config

--- a/system/hubcopter/templates/deployment-glas.yaml
+++ b/system/hubcopter/templates/deployment-glas.yaml
@@ -53,7 +53,6 @@ spec:
       containers:
         - name: api
           image: {{ $.Values.global.registry }}/hubcopter:{{ $.Values.hubcopter.image_tag | required ".Values.hubcopter.image_tag is missing" }}
-
           imagePullPolicy: IfNotPresent
           command: [ "/usr/bin/glas" ]
           args: [ ]
@@ -66,6 +65,8 @@ spec:
               value: '/etc/glas'
             - name:  GLAS_STATE_DIR
               value: '/tmp/glas'
+          securityContext:
+            runAsNonRoot: true
           volumeMounts:
 {{- range $k,$v := required ".Values.hubcopter.deploy_keys is missing" .Values.hubcopter.deploy_keys }}
             - mountPath: /etc/glas/{{ $k }}

--- a/system/hubcopter/templates/deployment-html.yaml
+++ b/system/hubcopter/templates/deployment-html.yaml
@@ -45,6 +45,7 @@ spec:
           image: {{ $.Values.global.dockerHubMirror }}/library/nginx:latest
           imagePullPolicy: IfNotPresent
           args: [ ]
+          # TODO: securityContext: { runAsNonRoot: true }
           volumeMounts:
             - mountPath: /usr/share/nginx/html
               name: html

--- a/system/tenso/templates/deployment-api.yaml
+++ b/system/tenso/templates/deployment-api.yaml
@@ -47,6 +47,8 @@ spec:
           imagePullPolicy: IfNotPresent
           args: [ api ]
           env: {{ include "tenso_environment" $ | indent 12 }}
+          securityContext:
+            runAsNonRoot: true
           volumeMounts:
             - mountPath: /etc/tenso
               name: config

--- a/system/tenso/templates/deployment-worker.yaml
+++ b/system/tenso/templates/deployment-worker.yaml
@@ -40,6 +40,8 @@ spec:
           imagePullPolicy: IfNotPresent
           args: [ worker ]
           env: {{ include "tenso_environment" $ | indent 12 }}
+          securityContext:
+            runAsNonRoot: true
           volumeMounts:
             - mountPath: /etc/tenso
               name: config


### PR DESCRIPTION
This is a first pass that mostly just documents the state of things and marks where work can be done to move more stuff from root to non-root.

Most of our own container images (using the Dockerfile template from go-makefile-maker) are already running as `USER 4200:4200`, so we can immediately add `runAsNonRoot: true` here and be done.

Same for statsd-exporter: It has `USER 65534` (that UID is `nobody` by convention), so we can also just set `runAsNonRoot: true`.

In `keep-image-pulled`, several external images default to user `root`, but we can force the `sleep` to execute as user `nobody` with explicit `runAsUser/runAsGroup: 65534` directives.

In Swift, several images are legitimately running as root, so I documented this by putting in an explicit `runAsUser: 0` directive. We should work on reducing the number of images that need this (esp. by checking if shared mount propagation can be used to obsolete the unmount-helper), but this is outside the scope of this PR.

In those images which currently run with root permissions, but which don't look like they need it, I put a TODO in to move the image and/or container towards a `runAsNonRoot` setup. Final note: I did not consider the containers in the `common` charts yet.

This change should be fairly safe to apply. Even if I made a mistake, it will only cause the containers to immediately fail and go into state `RunContainerError`, so the CI in QA will likely catch all mistakes.