### PR TITLE
[MariaDB] - Fixing Slow Log Alerts

### DIFF
--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.7.6
+version: 0.7.7

--- a/common/mariadb/templates/alerts/_mysql.alerts.tpl
+++ b/common/mariadb/templates/alerts/_mysql.alerts.tpl
@@ -14,7 +14,7 @@
       summary: {{ include "fullName" . }} has too many connections open.
 
   - alert: {{ include "alerts.service" . | title }}MariaDBSlowQueries
-    expr: (rate(mysql_global_status_slow_queries{app=~"{{ include "fullName" . }}"}[30m]) > 0)
+    expr: (delta(mysql_global_status_slow_queries{app=~"{{ include "fullName" . }}"}[8m]) > 3)
     for: 10m
     labels:
       context: database


### PR DESCRIPTION
Fixing Slow Log Alert:
Rate is not able to handle count and proper condition:
Alert Rule has been changed
from:
`(rate(mysql_global_status_slow_queries{app=~"{{ include "fullName" . }}"}[30m]) > 0)`
to:
`(delta(mysql_global_status_slow_queries{app=~"{{ include "fullName" . }}"}[8m]) > 3)`