### PR TITLE
kubernikus-monitoring: filter stale metrics

### DIFF
--- a/system/kubernikus-monitoring/Chart.yaml
+++ b/system/kubernikus-monitoring/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart containing Prometheus alert and aggregatino rules and Grafana dashboards for Kubernikus.
 name: kubernikus-monitoring
-version: 1.1.22
+version: 1.1.23

--- a/system/kubernikus-monitoring/alerts/operator.alerts
+++ b/system/kubernikus-monitoring/alerts/operator.alerts
@@ -54,7 +54,10 @@ groups:
       summary: Deorbiter operations dropped to 0
 
   - alert: KubernikusHammertime
-    expr: kubernikus_hammertime_status == 1
+    # the kubernikus_hammertime_status can leave stale entries for already deleted clusters
+    # in joining with the kubernikus_kluster_info metric we filter out stale metrics as
+    # kluster info is not leaving behind stale metrics
+    expr: kubernikus_hammertime_status == 1 and on(kluster) label_replace(kubernikus_kluster_info,"kluster","$1","kluster_name","(.*)")
     for: 10m
     labels:
       tier: kks


### PR DESCRIPTION
We are seeing a lot of hammertime alerts for deleted e2e clusters due to stale `kubernikus_hammertime_status`. The `kubernikus_kluster_info` metrics does not suffer from stale metrics so by joinging with the metric we avoid this false positives