### PR TITLE
[Cinder] Enable stacking of cinder volumes on pools

### DIFF
--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -98,7 +98,7 @@ db_name: cinder
 scheduler_default_filters: "AvailabilityZoneFilter,ShardFilter,SAPPoolDownFilter,CapabilitiesFilter,SAPLargeVolumeFilter,SAPDifferentBackendFilter,SAPSameBackendFilter,CapacityFilter"
 scheduler_default_weighers: "CapacityWeigher"
 
-capacity_weight_multiplier: 1.0
+capacity_weight_multiplier: -1.0
 allocated_capacity_weight_multiplier: -1.0
 
 cinder_api_allow_migration_on_attach: True


### PR DESCRIPTION
This patch changes the default scheduler behavior to stack volumes on pools (datastores) again.  We had disabled this because we couldn't create independent clones or snapshots, so when a datastore got full a customer couldn't snap or clone their volume.  Cinder now supports creating independent snaps and clones, so it makes sense to start stacking volumes again.

We want to stack volumes to ensure that we always have storage available to house the max volume size creation on the new datastores.