### PR TITLE
[MemcacheD] - Fixing Memcached Metrics Issue

### DIFF
--- a/common/memcached/Chart.yaml
+++ b/common/memcached/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: memcached
-version: 0.1.0
+version: 0.1.1
 description: Free & open source, high-performance, distributed memory object caching system.
 home: http://memcached.org/
 sources:

--- a/common/memcached/values.yaml
+++ b/common/memcached/values.yaml
@@ -45,7 +45,7 @@ resources:
 metrics:
   enabled: true
   image: 'prom/memcached-exporter'
-  imageTag: 'v0.5.0'
+  imageTag: 'v0.11.2'
 
   port: '9150'
   resources:


### PR DESCRIPTION
Memcached metrics does not get values for what causes errors 
Error:
time="2023-03-30T13:32:18Z" level=error msg="Failed to parse mem_requested \"\": strconv.ParseFloat: parsing \"\": invalid syntax" source="main.go:479"
Values:
memcached_slab_mem_requested_bytes{slab="24"} NaN
memcached_slab_mem_requested_bytes{slab="25"} NaN

The new image solves the issue
