### PR TITLE
Pull keystone-statsd from dockerHubMirrorAlternateRegion

### DIFF
--- a/openstack/keystone/templates/deployment-api.yaml
+++ b/openstack/keystone/templates/deployment-api.yaml
@@ -231,7 +231,7 @@ spec:
           {{- end }}
         {{- if .Values.api.metrics.enabled }}
         - name: keystone-statsd
-          image: "{{.Values.global.dockerHubMirror}}/{{ .Values.api.metrics.image }}:{{ .Values.api.metrics.imageTag }}"
+          image: "{{.Values.global.dockerHubMirrorAlternateRegion}}/{{ .Values.api.metrics.image }}:{{ .Values.api.metrics.imageTag }}"
           imagePullPolicy: {{ .Values.api.metrics.imagePullPolicy | default "IfNotPresent" | quote }}
           command:
             - /bin/statsd_exporter


### PR DESCRIPTION
Pulling keystone-statsd from the region where keystone runs might lead to circular dependency: keystone image cannot be obtained, because image service cannot run, because keystone is not available.

Pull keystone-statsd components from another region to avoid the dependency.