### PR TITLE
[nova] Bump memcached chart dependency

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 0.4.4
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.0.12
+  version: 0.1.1
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.7.4
@@ -26,5 +26,5 @@ dependencies:
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:ddc985639b709fcd49dd39fe1d5178d5fcc1332b52511660dd60b1bc99f5a418
-generated: "2023-03-02T12:27:51.724145481+01:00"
+digest: sha256:e30a9cce632fcde5a6530ea6eed5998cc2a8f439745b2853e65453a149883268
+generated: "2023-04-17T12:23:45.79390831+02:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
     version: 0.4.4
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.0.12
+    version: 0.1.1
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
     version: ~0.7.2


### PR DESCRIPTION
We need to upgrade our memcached and memcached-exporter images for security updates.