### PR TITLE
Updating HostNotResponding alerts

### DIFF
--- a/prometheus-rules/prometheus-vmware-rules/alerts/host.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/host.alerts
@@ -4,7 +4,7 @@ groups:
   - alert: HostWithRunningVMsNotResponding
     expr: |
       avg_over_time(vrops_hostsystem_runtime_connectionstate{state="notResponding"}[5m])
-      and on (hostsystem) avg_over_time(vrops_hostsystem_runtime_powerstate{state="Unknown"}[5m])
+      and on (hostsystem) avg_over_time(vrops_hostsystem_runtime_powerstate{state!="Powered Off"}[5m])
       and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"}
       and on (hostsystem) count(vrops_virtualmachine_runtime_powerstate{virtualmachine!~"vCLS.*", state="Powered On"}) by (hostsystem) > 0
     for: 5m
@@ -26,7 +26,7 @@ groups:
       vrops_hostsystem_summary_running_vms_number == 0 and
       on (hostsystem) vrops_hostsystem_runtime_connectionstate{state="notResponding"} and
       on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"} and
-      on (hostsystem) vrops_hostsystem_runtime_powerstate{state="Powered On"}
+      on (hostsystem) vrops_hostsystem_runtime_powerstate{state!="Powered Off"}
     labels:
       severity: warning
       tier: vmware
@@ -197,6 +197,7 @@ groups:
     expr: |
       vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) has detected a possible host failure"} 
       and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!~"inMaintenance", vccluster!~".*controlplane-swift"}
+      and on (hostsystem) vrops_hostsystem_runtime_connectionstate{state!="notResponding"} 
     labels:
       severity: critical
       tier: vmware


### PR DESCRIPTION
1. changing power state for HostNotResponding alerts to not "Powered Off". Not reponding hosts usually respond an unknown powerstate. However just filtering for "Unknown" will not cover "Powered On" hosts, in case the powerstate gets reported correctly.
2. Removing not responding hosts from HADetectedAPossibleHostFailure to prevent alert duplcation.