### PR TITLE
Fix ACI endpoint learning metrics

### DIFF
--- a/system/atlas/templates/configmap.yaml
+++ b/system/atlas/templates/configmap.yaml
@@ -45,18 +45,18 @@ data:
         {{- end }}
         dcim:
           devices:
-        #    - custom_labels:
-        #        batch: "acileaf"
-        #        job: "network/ssh"
-        #        credential: "apic"
-        #        device: "cisco-aci"
-        #      target: 1
-        #      metrics_label: "acileaf"
-        #      role: "aci-leaf"
-        #      manufacturer: "cisco"
-        #      tenant: "converged-cloud"
-        #      region: "{{ .Values.global.region }}"
-        #      status: "active"
+            - custom_labels:
+                batch: "aci-leaf"
+                job: "network/ssh"
+                credential: "apic"
+                device: "cisco-aci"
+              target: 1
+              metrics_label: "acileaf"
+              role: "aci-leaf"
+              manufacturer: "cisco"
+              tenant: "converged-cloud"
+              region: "{{ .Values.global.region }}"
+              status: "active"
 
             - custom_labels:
                 batch: "neutron-router"


### PR DESCRIPTION
Prometheus labels should be used to _differentiate the characteristics of the thing that is being measured_.
(https://prometheus.io/docs/practices/naming/#labels) In this case the label contained the actual value that was being measured. This should hence be 3 individual metrics, where their value carries the measured state. Also simplified the regex a bit.

ACI leafs currently carry the platform NXOS in our inventory which is technically incorrect. However this is what the SD will feed into prometheus, so I deleted the aci-leaf device type. `terminal length 0` will be executed as init command and will return an error, yet that will be ignored.