### PR TITLE
Change VMFS DS Capacity Alert tier and Severity

### DIFF
--- a/prometheus-rules/prometheus-vmware-rules/alerts/datastore.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/datastore.alerts
@@ -124,8 +124,8 @@ groups:
       avg by (type, vcenter) (vrops_datastore_diskspace_total_usage_gigabytes{type=~"vmfs_p_ssd|vmfs_s_hdd"} / vrops_datastore_diskspace_capacity_gigabytes) > 0.7
     for: 20m
     labels:
-      severity: warning
-      tier: os
+      severity: info
+      tier: vmware
       service: storage
       support_group: compute
       context: "{{ $labels.type }} storage"


### PR DESCRIPTION
Change VMFS Datastore Capacity Alert tier from OS to VMware and reduce severity from Warning to Info