### PR TITLE
remove remaining references to k8s.gcr.io

### DIFF
--- a/system/descheduler/Chart.yaml
+++ b/system/descheduler/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 name: descheduler
 sources:
 - https://github.com/kubernetes-sigs/descheduler
-version: 0.23.7
+version: 0.23.8

--- a/system/descheduler/values.yaml
+++ b/system/descheduler/values.yaml
@@ -6,7 +6,7 @@
 kind: CronJob
 
 image:
-  repository: keppel.eu-de-1.cloud.sap/ccloud-k8sgcr-mirror/descheduler/descheduler
+  repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/descheduler/descheduler
   # Overrides the image tag whose default is the chart version
   tag: ""
   pullPolicy: IfNotPresent

--- a/system/kube-monitoring-metal/Chart.yaml
+++ b/system/kube-monitoring-metal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes metal controlplane monitoring.
 name: kube-monitoring-metal
-version: 4.4.11
+version: 4.4.12
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-metal
 dependencies:
   - condition: absent-metrics-operator.enabled

--- a/system/kube-monitoring-metal/values.yaml
+++ b/system/kube-monitoring-metal/values.yaml
@@ -35,7 +35,7 @@ kube-prometheus-stack:
       failurePolicy: Ignore
       patch:
         image:
-          repository: keppel.eu-de-1.cloud.sap/ccloud-k8sgcr-mirror/ingress-nginx/kube-webhook-certgen
+          repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/ingress-nginx/kube-webhook-certgen
 
     createCustomResource: false
     service:

--- a/system/kube-system-global/Chart.yaml
+++ b/system/kube-system-global/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for global clusters.
 name: kube-system-global
-version: 1.0.10
+version: 1.0.11
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-global
 dependencies:
   - name: cc-rbac

--- a/system/kube-system-global/values.yaml
+++ b/system/kube-system-global/values.yaml
@@ -216,7 +216,7 @@ maintenance-controller:
 
 metrics-server:
   image:
-    repository: keppel.global.cloud.sap/ccloud-k8sgcr-mirror/metrics-server/metrics-server
+    repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/metrics-server/metrics-server
 
   # Workaround for qa landscapes.
   args:

--- a/system/kube-system-metal/Chart.yaml
+++ b/system/kube-system-metal/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for metal clusters.
 name: kube-system-metal
-version: 5.3.5
+version: 5.3.6
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-metal
 dependencies:
   - name: cc-rbac

--- a/system/kube-system-metal/values.yaml
+++ b/system/kube-system-metal/values.yaml
@@ -116,7 +116,7 @@ ingress-nginx-external:
 
   controller:
     image:
-      registry: keppel.eu-de-1.cloud.sap/ccloud-k8sgcr-mirror
+      registry: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror
 
     minReadySeconds: 60
     ingressClass: nginx-external
@@ -212,7 +212,7 @@ ingress-nginx-external:
     nodeSelector: {}
 
     image:
-      registry: keppel.eu-de-1.cloud.sap/ccloud-k8sgcr-mirror
+      registry: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror
 
     service:
       omitClusterIP: true

--- a/system/metrics-server/Chart.yaml
+++ b/system/metrics-server/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: metrics-server
 description: A Helm chart for the kubernetes-sigs/metrics-server.
 type: application
-version: 2.0.0
+version: 2.0.1
 appVersion: v0.6.2

--- a/system/metrics-server/values.yaml
+++ b/system/metrics-server/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 3
 
 image:
   # Default upstream repository: k8s.gcr.io/metrics-server/metrics-server
-  repository: keppel.global.cloud.sap/ccloud-k8sgcr-mirror/metrics-server/metrics-server
+  repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/metrics-server/metrics-server
   pullPolicy: IfNotPresent
 
 # Workaround for qa landscapes for now:

--- a/system/prometheus-operator/Chart.yaml
+++ b/system/prometheus-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus operator via kube-prom-stack
 name: prometheus-operator
-version: 1.0.5
+version: 1.0.6
 home: https://github.com/sapcc/helm-charts/tree/master/system/prometheus-operator
 dependencies:
   - name: prometheus-crds

--- a/system/prometheus-operator/values.yaml
+++ b/system/prometheus-operator/values.yaml
@@ -26,8 +26,8 @@ kube-prometheus-stack:
       failurePolicy: Ignore
       patch:
         image:
-          registry: keppel.eu-de-1.cloud.sap
-          repository: ccloud-k8sgcr-mirror/ingress-nginx/kube-webhook-certgen
+          registry: keppel.global.cloud.sap
+          repository: ccloud-registry-k8s-io-mirror/ingress-nginx/kube-webhook-certgen
           tag: v1.2.0
 
     createCustomResource: false


### PR DESCRIPTION
I want to start tearing down the `ccloud-k8sgcr-mirror`. I plan to merge this at the end of next week latest, until someone objects.