### PR TITLE
[neutron] Options to indicate and configure decomssioning or no schedule

### DIFF
--- a/openstack/neutron/templates/asr_config_agents/_deployment-asr1k.yaml.tpl
+++ b/openstack/neutron/templates/asr_config_agents/_deployment-asr1k.yaml.tpl
@@ -33,6 +33,8 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" $context.Values.alerts.prometheus | quote }}
         configmap-asr1k-{{ $config_agent.name }}: {{ tuple $context $config_agent |include "asr1k_configmap" | sha256sum  }}
+        cloud.sap/scheduling-disabled: {{ or ($config_agent.scheduling_disabled | default false) ($config_agent.decommissioning | default false) | quote }}
+        cloud.sap/decommissioning: {{ $config_agent.decommissioning | default false | quote }}
     spec:
       hostname:  asr1k-{{ $config_agent.name }}
       containers:

--- a/openstack/neutron/templates/etc/_asr1k.conf.tpl
+++ b/openstack/neutron/templates/etc/_asr1k.conf.tpl
@@ -50,8 +50,9 @@ nc_timeout = {{$hosting_device.nc_timeout | default 20}}
 use_bdvif = {{$hosting_device.use_bdvif | default "True"}}
 {{end}}
 
-{{- if $config_agent.availability_zone }}
 [AGENT]
+scheduling_disabled = {{ or ($config_agent.scheduling_disabled | default false) ($config_agent.decommissioning | default false) }}
+{{- if $config_agent.availability_zone  }}
 availability_zone = {{$config_agent.availability_zone}}
 {{ end }}
 


### PR DESCRIPTION
We introduced to disable scheduling on a particular agent in the asr1k code. This feature can be used either if an agent is supposed to be decomissioned or if we do not want to increase the load on an agent.

However that is an important difference for the capacity calculation, hence we employ different annotations on the pod, depending of the purpose. If an agent is to be torn down and never used again, `decomissioning` must be used. It indicates that the agent should not ne included in the capacity calculation.

If we just intend to prevent any additional load on the agent, `scheduling_disabled` must be used. The agent shall than still be considered as capacity available.