### PR TITLE
[nannies] manila: switch prom host

### DIFF
--- a/openstack/nannies/templates/manila-nanny-deployment.yaml
+++ b/openstack/nannies/templates/manila-nanny-deployment.yaml
@@ -195,7 +195,7 @@ spec:
             - name: MANILA_SHARE_SIZE_SYNC_DRY_RUN
               value: {{ .Values.manila_nanny.share_sync.dry_run | quote }}
             - name: PROMETHEUS_HOST
-              value: http://prometheus-infra-collector.infra-monitoring.svc:9090
+              value: http://prometheus-storage.infra-monitoring.svc:9090
             - name: MANILA_NANNY_INTERVAL
               value: {{ .Values.manila_nanny.share_sync.interval | quote }}
             - name: PYTHONUNBUFFERED


### PR DESCRIPTION
follow move of netapp metrics from infra-collector to prometheus-storage