### PR TITLE
[neutron] Bump memcached chart dependency to 0.1.1

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.7.5
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.0.10
+  version: 0.1.1
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.7
@@ -20,5 +20,5 @@ dependencies:
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:8f410674f6456b6e787b1b6bd82cb26c079fca57889eebe707b3b7f47103f792
-generated: "2022-11-28T10:28:15.886759-05:00"
+digest: sha256:2f967261893b9fde44884722ccfc36b2238a7ad8fa813f1d8ecf298cc1b16851
+generated: "2023-04-25T13:39:37.148277641+02:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -10,7 +10,7 @@ dependencies:
     version: 0.7.5
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.0.10
+    version: 0.1.1
   - condition: mariadb.enabled
     name: mysql_metrics
     repository: https://charts.eu-de-2.cloud.sap

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -599,3 +599,7 @@ agent:
 dnsmasq:
   conf:
     no-negcache: true
+
+memcached:
+  alerts:
+    support_group: network-api


### PR DESCRIPTION
Now with memcached 1.6.18 and memcached-exporter 0.11.2