### PR TITLE
[tempest] Use oslo.config env source for "dynamic" variables

### DIFF
--- a/openstack/tempest/cinder-tempest/templates/etc/_tempest_extra_options.tpl
+++ b/openstack/tempest/cinder-tempest/templates/etc/_tempest_extra_options.tpl
@@ -62,8 +62,7 @@ driver = fake-hardware
 
 [compute]
 # image_ref and image_ref_alt will be changed to the image-id during init-script as the image-id can change over time.
-image_ref = CHANGE_ME_IMAGE_REF
-image_ref_alt = CHANGEMEIMAGEREFALT
+# Set them via environment variable OS_COMPUTE__IMAGE_REF and OS_COMPUTE__IMAGE_REF_ALT
 endpoint_type = internal
 v3_endpoint_type = internal
 region = {{ .Values.global.region }}

--- a/openstack/tempest/octavia-tempest/templates/etc/_tempest_extra_options.tpl
+++ b/openstack/tempest/octavia-tempest/templates/etc/_tempest_extra_options.tpl
@@ -62,8 +62,7 @@ driver = fake-hardware
 
 [compute]
 # image_ref and image_ref_alt will be changed to the image-id during init-script as the image-id can change over time.
-image_ref = CHANGE_ME_IMAGE_REF
-image_ref_alt = CHANGEMEIMAGEREFALT
+# Set them via environment variable OS_COMPUTE__IMAGE_REF and OS_COMPUTE__IMAGE_REF_ALT
 endpoint_type = internal
 v3_endpoint_type = internal
 region = {{ .Values.global.region }}

--- a/openstack/tempest/tempest-base/templates/bin/_function_start_tempest_tests.tpl
+++ b/openstack/tempest/tempest-base/templates/bin/_function_start_tempest_tests.tpl
@@ -15,11 +15,9 @@ function start_tempest_tests {
   export OS_USERNAME={{ default "neutron-tempestadmin1" (index .Values (print .Chart.Name | replace "-" "_")).tempest.admin_name | quote }}
   export OS_TENANT_NAME={{ default "neutron-tempest-admin1" (index .Values (print .Chart.Name | replace "-" "_")).tempest.admin_project_name | quote }}
   export OS_PROJECT_NAME={{ default "neutron-tempest-admin1" (index .Values (print .Chart.Name | replace "-" "_")).tempest.admin_project_name | quote }}
-  export IMAGE_REF={{ default "ubuntu-18.04-amd64-vmware" (index .Values (print .Chart.Name | replace "-" "_")).tempest.image_ref | include "tempest-base._image_ref" }}
-  export IMAGE_REF_ALT={{ default "ubuntu-20.04-amd64-vmware" (index .Values (print .Chart.Name | replace "-" "_")).tempest.image_ref_alt | include "tempest-base._image_ref" }}
+  export OS_COMPUTE__IMAGE_REF={{ default "ubuntu-18.04-amd64-vmware" (index .Values (print .Chart.Name | replace "-" "_")).tempest.image_ref | include "tempest-base._image_ref" }}
+  export OS_COMPUTE__IMAGE_REF_ALT={{ default "ubuntu-20.04-amd64-vmware" (index .Values (print .Chart.Name | replace "-" "_")).tempest.image_ref_alt | include "tempest-base._image_ref" }}
   cp /{{ .Chart.Name }}-etc/tempest_extra_options /tmp
-  sed -i "s/CHANGE_ME_IMAGE_REF/$(echo $IMAGE_REF)/g" /tmp/tempest_extra_options
-  sed -i "s/CHANGEMEIMAGEREFALT/$(echo $IMAGE_REF_ALT)/g" /tmp/tempest_extra_options
 
   echo -e "\n === CONFIGURING RALLY & TEMPEST === \n"
 

--- a/openstack/tempest/tempest-base/templates/etc/_tempest_extra_options.tpl
+++ b/openstack/tempest/tempest-base/templates/etc/_tempest_extra_options.tpl
@@ -69,8 +69,7 @@ driver = fake-hardware
 
 [compute]
 # image_ref and image_ref_alt will be changed to the image-id during init-script as the image-id can change over time.
-image_ref = CHANGE_ME_IMAGE_REF
-image_ref_alt = CHANGEMEIMAGEREFALT
+# Set them via environment variable OS_COMPUTE__IMAGE_REF and OS_COMPUTE__IMAGE_REF_ALT
 endpoint_type = internal
 v3_endpoint_type = internal
 region = {{ .Values.global.region }}


### PR DESCRIPTION
Instead of editing the config-file, we can simply set the environment variable according to the following schema:

https://github.com/openstack/oslo.config/blob/master/oslo_config/sources/_environment.py