### PR TITLE
[openstack/utils] Snippet for kubernetes-entrypoint in initcontainer

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.8.0
+version: 0.9.0

--- a/openstack/utils/templates/snippets/_kubernetes_entrypoint.tpl
+++ b/openstack/utils/templates/snippets/_kubernetes_entrypoint.tpl
@@ -1,0 +1,19 @@
+{{- define "utils.snippets.kubernetes_entrypoint_init_container" }}
+  {{- $envAll := index . 0 }}
+  {{- $params := index . 1 }}
+- name: kubernetes-entrypoint
+  image: {{ $envAll.Values.global.registry }}/kubernetes-entrypoint:v0.3.1
+  command:
+  - /kubernetes-entrypoint
+  env:
+  - name: COMMAND
+    value: "true"
+  - name: POD_NAME
+    valueFrom: {fieldRef: {fieldPath: metadata.name}}
+  - name: NAMESPACE
+    valueFrom: {fieldRef: {fieldPath: metadata.namespace}}
+  {{- range $k, $v := $params }}
+  - name: DEPENDENCY_{{ $k | upper }}
+    value: {{ $v }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
Moving the logic to an initcontainer means we do not have to build in the executable in the main image and can share that image among services.

Also, a missing dependency won't get mixed up with "normal" program failures.