### PR TITLE
[ironic] Move kubernetes-entrypoint to init containers

### DIFF
--- a/openstack/ironic/Chart.lock
+++ b/openstack/ironic/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.7
+  version: 0.7.8
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.0.12
@@ -16,6 +16,6 @@ dependencies:
   version: 0.4.4
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.4
-digest: sha256:b0632b3bca7700aa52861063f145c45c3d360419f83399d4be73d96c0f93bded
-generated: "2023-04-13T16:34:38.374582+02:00"
+  version: 0.9.0
+digest: sha256:ed7f8426d3986e381b8a70eadf9958c919346072d58b56187c99f56811f68622
+generated: "2023-05-02T13:21:59.729098499+02:00"

--- a/openstack/ironic/Chart.yaml
+++ b/openstack/ironic/Chart.yaml
@@ -23,4 +23,4 @@ dependencies:
     version: ~0.4.4
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.7.0
+    version: ~0.9.0

--- a/openstack/ironic/templates/api-deployment.yaml
+++ b/openstack/ironic/templates/api-deployment.yaml
@@ -34,6 +34,8 @@ spec:
     spec:
 {{ tuple . "ironic" "api" | include "kubernetes_pod_anti_affinity" | indent 6 }}
       {{- include "utils.proxysql.pod_settings" . | indent 6 }}
+      initContainers:
+      {{- tuple . (dict "service" "ironic-mariadb,ironic-rabbitmq" "jobs" "ironic-db-migration") | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
       - name: ironic-api
         image: {{ .Values.global.registry }}/loci-ironic:{{ .Values.imageVersion }}
@@ -41,17 +43,9 @@ spec:
         resources:
 {{ toYaml .Values.pod.resources.api | indent 10 }}
         command:
-          - dumb-init
-          - kubernetes-entrypoint
+        - dumb-init
+        - ironic-api
         env:
-        - name: COMMAND
-          value: "ironic-api"
-        - name: NAMESPACE
-          value: {{ .Release.Namespace }}
-        - name: DEPENDENCY_JOBS
-          value: "ironic-db-migration"
-        - name: DEPENDENCY_SERVICE
-          value: "ironic-mariadb,ironic-rabbitmq"
         - name: PYTHONWARNINGS
           value: 'ignore:Unverified HTTPS request'
         {{- if .Values.logging.handlers.sentry }}
@@ -61,10 +55,6 @@ spec:
               name: sentry
               key: {{ .Chart.Name }}.DSN.python
         {{- end }}
-        - name: PGAPPNAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
         lifecycle:
           preStop:
             {{- include "utils.snippets.pre_stop_graceful_shutdown" . | indent 12 }}

--- a/openstack/ironic/templates/db-migration-job.yaml
+++ b/openstack/ironic/templates/db-migration-job.yaml
@@ -18,17 +18,7 @@ spec:
   template:
     spec:
       initContainers:
-      - name: "kubernetes-entrypoint"
-        image: {{ .Values.global.registry }}/loci-ironic:{{ .Values.imageVersion }}
-        imagePullPolicy: "IfNotPresent"
-        command: ["kubernetes-entrypoint"]
-        env:
-        - name: "NAMESPACE"
-          value: {{ .Release.Namespace | quote }}
-        - name: "DEPENDENCY_SERVICE"
-          value: "ironic-mariadb"
-        - name: "COMMAND"
-          value: "true"
+      {{- tuple . (dict "service" "ironic-mariadb") | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       restartPolicy: OnFailure
       containers:
       - name: ironic-dbsync

--- a/openstack/ironic/templates/inspector-conductor-deployment.yaml
+++ b/openstack/ironic/templates/inspector-conductor-deployment.yaml
@@ -36,20 +36,16 @@ spec:
     spec:
 {{ tuple . "ironic" "inspector" | include "kubernetes_pod_anti_affinity" | indent 6 }}
 {{ include "utils.proxysql.pod_settings" . | indent 6 }}
+      initContainers:
+      {{- tuple . (dict "service" "ironic-api,ironic-rabbitmq") | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
       - name: ironic-inspector-conductor
         image: {{ .Values.global.registry }}/loci-ironic:{{ .Values.imageVersion }}
         imagePullPolicy: IfNotPresent
         command:
         - dumb-init
-        - kubernetes-entrypoint
+        - ironic-inspector-conductor
         env:
-        - name: COMMAND
-          value: "ironic-inspector-conductor --config-file /etc/ironic-inspector/ironic-inspector.conf"
-        - name: NAMESPACE
-          value: {{ .Release.Namespace }}
-        - name: DEPENDENCY_SERVICE
-          value: "ironic-api,ironic-rabbitmq"
         {{- if .Values.logging.handlers.sentry }}
         - name: SENTRY_DSN
           valueFrom:
@@ -57,10 +53,6 @@ spec:
               name: sentry
               key: {{ .Chart.Name }}.DSN.python
         {{- end }}
-        - name: PGAPPNAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
         resources:
 {{ toYaml .Values.pod.resources.inspector | indent 10 }}
         volumeMounts:

--- a/openstack/ironic/templates/inspector-db-migration-job.yaml
+++ b/openstack/ironic/templates/inspector-db-migration-job.yaml
@@ -17,19 +17,9 @@ metadata:
 spec:
   template:
     spec:
-      initContainers:
-      - name: "kubernetes-entrypoint"
-        image: {{ .Values.global.registry }}/loci-ironic:{{ .Values.imageVersion }}
-        imagePullPolicy: "IfNotPresent"
-        command: ["kubernetes-entrypoint"]
-        env:
-        - name: "NAMESPACE"
-          value: {{ .Release.Namespace | quote }}
-        - name: "DEPENDENCY_SERVICE"
-          value: "ironic-mariadb"
-        - name: "COMMAND"
-          value: "true"
       restartPolicy: OnFailure
+      initContainers:
+      {{- tuple . (dict "service" "ironic-mariadb") | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
       - name: dbsync
         image: {{ .Values.global.registry }}/loci-ironic:{{ .Values.imageVersion }}

--- a/openstack/ironic/templates/inspector-deployment.yaml
+++ b/openstack/ironic/templates/inspector-deployment.yaml
@@ -35,6 +35,8 @@ spec:
     spec:
 {{ tuple . "ironic" "inspector" | include "kubernetes_pod_anti_affinity" | indent 6 }}
       {{- include "utils.proxysql.pod_settings" . | indent 6 }}
+      initContainers:
+      {{- tuple . (dict "service" "ironic-api,ironic-rabbitmq") | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
       - name: ironic-inspector
         {{- if .Values.oslo_metrics.enabled }}
@@ -45,18 +47,12 @@ spec:
         imagePullPolicy: IfNotPresent
         command:
         - dumb-init
-        - kubernetes-entrypoint
+        - ironic-inspector
         securityContext:
           capabilities:
             add:
               - NET_ADMIN
         env:
-        - name: COMMAND
-          value: "ironic-inspector --config-file /etc/ironic-inspector/ironic-inspector.conf"
-        - name: NAMESPACE
-          value: {{ .Release.Namespace }}
-        - name: DEPENDENCY_SERVICE
-          value: "ironic-api,ironic-rabbitmq"
         {{- if .Values.logging.handlers.sentry }}
         - name: SENTRY_DSN
           valueFrom:
@@ -64,10 +60,6 @@ spec:
               name: sentry
               key: {{ .Chart.Name }}.DSN.python
         {{- end }}
-        - name: PGAPPNAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
         lifecycle:
           preStop:
             {{- include "utils.snippets.pre_stop_graceful_shutdown" . | indent 12 }}


### PR DESCRIPTION
Moving the logic to an initcontainer means we do not have to build
in the executable in the main image and can share that image among
services.

Also, a missing dependency won't get mixed up with normal program
failures.