### PR TITLE
[ironic] remove NULL from openstack_ironic_nodes_list_gauge

### DIFF
--- a/openstack/ironic/values.yaml
+++ b/openstack/ironic/values.yaml
@@ -213,9 +213,9 @@ mysql_metrics:
           uuid,
           name,
           COALESCE(instance_uuid, "") AS instance_uuid,
-          power_state,
+          COALESCE(power_state, 'unknown') AS power_state,
           provision_state,
-          retired,
+          COALESCE(retired, 'unknown') AS retired,
           last_error IS NOT NULL AS last_error,
           COUNT(*) AS gauge
         FROM nodes


### PR DESCRIPTION
hopefully fixes mysql-metrics errors like
```
Column 'retired' must be type text (string)
```