### PR TITLE
[manila] Move kubernetes-entrypoint to init containers

### DIFF
--- a/openstack/manila/Chart.lock
+++ b/openstack/manila/Chart.lock
@@ -16,6 +16,6 @@ dependencies:
   version: 0.5.1
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.4
-digest: sha256:3c7e9b0528d4e968ef7d5e6933c4a6ada08dd839a3ad85edfd181be98a9b2b67
-generated: "2023-04-25T10:54:34.119388+02:00"
+  version: 0.9.0
+digest: sha256:35506925cd33e08e0ea8dec0f89939be45ecde16c499f9a4f7085cad2403547e
+generated: "2023-05-02T13:56:42.669062312+02:00"

--- a/openstack/manila/Chart.yaml
+++ b/openstack/manila/Chart.yaml
@@ -31,4 +31,4 @@ dependencies:
     version: 0.5.1
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.7.2
+    version: ~0.9.0

--- a/openstack/manila/templates/api-deployment.yaml
+++ b/openstack/manila/templates/api-deployment.yaml
@@ -39,20 +39,7 @@ spec:
 {{ tuple . "manila" "api" | include "kubernetes_pod_anti_affinity" | indent 6 }}
       {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       initContainers:
-      - name: kubernetes-entrypoint
-        image: {{.Values.global.registry}}/loci-manila:{{.Values.loci.imageVersion}}
-        imagePullPolicy: IfNotPresent
-        command:
-          - kubernetes-entrypoint
-        env:
-            - name: NAMESPACE
-              value: {{ .Release.Namespace }}
-            - name: DEPENDENCY_JOBS
-              value: {{ .Release.Name }}-migration
-            - name: DEPENDENCY_SERVICE
-              value: "{{ .Release.Name }}-mariadb,{{ .Release.Name }}-rabbitmq,{{ .Release.Name }}-memcached"
-            - name: COMMAND
-              value: "true"
+      {{- tuple . (dict "jobs" (print .Release.Name "-migration") "service" (print .Release.Name "-mariadb," .Release.Name "-rabbitmq," .Release.Name "-memcached")) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       - name: fetch-rabbitmqadmin
         image: {{.Values.global.dockerHubMirror}}/library/busybox
         command: ["/scripts/fetch-rabbitmqadmin.sh"]

--- a/openstack/manila/templates/migration-job.yaml
+++ b/openstack/manila/templates/migration-job.yaml
@@ -29,19 +29,15 @@ spec:
 {{- if $proxysql }}
       {{- include "utils.proxysql.job_pod_settings" . | indent 6 }}
 {{- end }}
+      initContainers:
+      {{- tuple . (dict "service" (print .Release.Name "-mariadb")) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
         - name: manila-migration
           image: {{.Values.global.registry}}/loci-manila:{{.Values.loci.imageVersion}}
           imagePullPolicy: IfNotPresent
           command:
-            - kubernetes-entrypoint
+            - /container.init/db-migrate
           env:
-            - name: COMMAND
-              value: "/container.init/db-migrate"
-            - name: NAMESPACE
-              value: {{ .Release.Namespace }}
-            - name: DEPENDENCY_SERVICE
-              value: "{{ .Release.Name }}-mariadb"
             {{- if .Values.sentry.enabled }}
             - name: SENTRY_DSN_SSL
               valueFrom:

--- a/openstack/manila/templates/scheduler-deployment.yaml
+++ b/openstack/manila/templates/scheduler-deployment.yaml
@@ -46,6 +46,7 @@ spec:
                   - manila-scheduler
               topologyKey: "failure-domain.beta.kubernetes.io/zone"
       initContainers:
+        {{- tuple . (dict "jobs" (print .Release.Name "-migration") "service" (print .Release.Name "-mariadb," .Release.Name "-rabbitmq")) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
         - name: fetch-rabbitmqadmin
           image: {{.Values.global.dockerHubMirror}}/library/busybox
           command: ["/scripts/fetch-rabbitmqadmin.sh"]
@@ -61,14 +62,8 @@ spec:
           imagePullPolicy: IfNotPresent
           command:
             - dumb-init
-            - kubernetes-entrypoint
+            - manila-scheduler
           env:
-            - name: COMMAND
-              value: "manila-scheduler --config-file /etc/manila/manila.conf"
-            - name: NAMESPACE
-              value: {{ .Release.Namespace }}
-            - name: DEPENDENCY_SERVICE
-              value: "{{ .Release.Name }}-mariadb,{{ .Release.Name }}-rabbitmq"
             {{- if .Values.sentry.enabled }}
             - name: SENTRY_DSN_SSL
               valueFrom:


### PR DESCRIPTION
Moving the logic to an initcontainer means we do not have to build
in the executable in the main image and can share that image among
services.

Also, a missing dependency won't get mixed up with normal program
failures.