### PR TITLE
[glance] Move kubernetes-entrypoint to init containers

### DIFF
--- a/openstack/glance/Chart.lock
+++ b/openstack/glance/Chart.lock
@@ -10,12 +10,12 @@ dependencies:
   version: 0.2.7
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.4
+  version: 0.9.0
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.2.4
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:0969df3a8e2d7706a8933dbc0d3ddeef16a5906acd7395d3d4337eb7ad8a5021
-generated: "2023-04-25T16:31:20.165986+05:30"
+digest: sha256:866458b7b9113690116f51dcf066a0fde4d20fa122e6ff66d606a4f4e817e209
+generated: "2023-05-02T13:27:30.798603614+02:00"

--- a/openstack/glance/Chart.yaml
+++ b/openstack/glance/Chart.yaml
@@ -18,7 +18,7 @@ dependencies:
     version: 0.2.7
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.7.2
+    version: ~0.9.0
   - name: redis
     alias: sapcc_rate_limit
     repository: https://charts.eu-de-2.cloud.sap

--- a/openstack/glance/templates/deployment.yaml
+++ b/openstack/glance/templates/deployment.yaml
@@ -39,8 +39,9 @@ spec:
         {{- end }}
     spec:
       {{ include "utils.proxysql.pod_settings" . | indent 6 }}
-      {{- if .Values.file.persistence.enabled }}
       initContainers:
+      {{- tuple . (dict "jobs" (tuple . "migration-job" | include "job_name") "service" (print .Release.Name "-mariadb," .Release.Name "-memcached")) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
+      {{- if .Values.file.persistence.enabled }}
       - name: permissions
         securityContext:
           runAsUser: 0
@@ -82,22 +83,10 @@ spec:
           failureThreshold: 2
         command:
         - dumb-init
-        - kubernetes-entrypoint
+        - /var/lib/openstack/bin/glance-api
         env:
-        - name: COMMAND
-          value: "/var/lib/openstack/bin/glance-api"
-        - name: NAMESPACE
-          value: {{ .Release.Namespace }}
-        - name: DEPENDENCY_JOBS
-          value: "{{ tuple . "migration-job" | include "job_name" }}"
-        - name: DEPENDENCY_SERVICE
-          value: {{ .Release.Name }}-mariadb,{{ .Release.Name }}-memcached
         - name: DEBUG_CONTAINER
           value: "false"
-        - name: PGAPPNAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
         {{- if .Values.sentry.enabled }}
         - name: SENTRY_DSN
           valueFrom:

--- a/openstack/glance/templates/migration-job.yaml
+++ b/openstack/glance/templates/migration-job.yaml
@@ -25,18 +25,7 @@ spec:
       restartPolicy: OnFailure
       {{- include "utils.proxysql.job_pod_settings" . | indent 6 }}
       initContainers:
-      - name: glance-init
-        image: {{ required ".Values.global.registry is missing" .Values.global.registry }}/loci-glance:{{ required "Please set glance.imageVersion or similar" .Values.imageVersion }}
-        imagePullPolicy: IfNotPresent
-        command:
-        - kubernetes-entrypoint
-        env:
-        - name: COMMAND
-          value: "true"
-        - name: NAMESPACE
-          value: {{ .Release.Namespace }}
-        - name: DEPENDENCY_SERVICE
-          value: {{ .Release.Name }}-mariadb
+      {{- tuple . (dict "service" (print .Release.Name "-mariadb" )) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
       - name: glance-migration
         image: {{ required ".Values.global.registry is missing" .Values.global.registry }}/loci-glance:{{ required "Please set glance.imageVersion or similar" .Values.imageVersion }}


### PR DESCRIPTION
Moving the logic to an initcontainer means we do not have to build
in the executable in the main image and can share that image among
services.

Also, a missing dependency won't get mixed up with normal program
failures.