### PR TITLE
[cinder] Move kubernetes-entrypoint to init containers 

### DIFF
--- a/openstack/cinder/templates/_helpers.tpl
+++ b/openstack/cinder/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "cinder.migration_job_name" -}}
+cinder-migration-{{.Values.imageVersion | required "Please set cinder.imageVersion or similar"}}{{- if .Values.proxysql.mode}}-{{ .Values.proxysql.mode | replace "_" "-" }}{{ end }}
+{{- end }}

--- a/openstack/cinder/templates/_helpers.tpl
+++ b/openstack/cinder/templates/_helpers.tpl
@@ -1,3 +1,3 @@
 {{- define "cinder.migration_job_name" -}}
-cinder-migration-{{.Values.imageVersion | required "Please set cinder.imageVersion or similar"}}{{- if .Values.proxysql.mode}}-{{ .Values.proxysql.mode | replace "_" "-" }}{{ end }}
+cinder-migration-job-{{.Values.imageVersion | required "Please set cinder.imageVersion or similar"}}{{- if .Values.proxysql.mode}}-{{ .Values.proxysql.mode | replace "_" "-" }}{{ end }}
 {{- end }}

--- a/openstack/cinder/templates/api-deployment.yaml
+++ b/openstack/cinder/templates/api-deployment.yaml
@@ -37,36 +37,36 @@ spec:
       {{- tuple . "cinder" "api" | include "kubernetes_pod_anti_affinity" | nindent 6 }}
       {{- include "utils.proxysql.pod_settings" . | nindent 6 }}
       {{- tuple . (dict "name" "cinder-api") | include "utils.topology.constraints" | indent 6 }}
+      initContainers:
+      {{- tuple . (dict "service" (print .Release.Name "-mariadb," .Release.Name "-rabbitmq") "jobs" (include "cinder.migration_job_name" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
         - name: cinder-api
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{.Values.imageVersionCinderApi | default .Values.imageVersion | required "Please set cinder.imageVersion or similar" }}
           imagePullPolicy: {{ required ".Values.global.imagePullPolicy is missing" .Values.global.imagePullPolicy }}
           command:
-            - kubernetes-entrypoint
+          {{- if .Values.api.use_uwsgi }}
+            - uwsgi
+            - --ini
+            - /etc/cinder/api_uwsgi.ini
+          {{- else }}
+            - cinder-api
+          {{ end }}
           env:
-            - name: COMMAND
-              value: "{{ if .Values.api.use_uwsgi }}uwsgi --ini /etc/cinder/api_uwsgi.ini{{ else }}cinder-api{{ end }}"
-            - name: NAMESPACE
-              value: {{ .Release.Namespace }}
-            - name: DEPENDENCY_JOBS
-              value: {{ include "cinder.migration_job_name" . }}
-            - name: DEPENDENCY_SERVICE
-              value: "{{ .Release.Name }}-mariadb,{{ .Release.Name }}-rabbitmq"
-            - name: STATSD_HOST
-              value: "localhost"
-            - name: STATSD_PORT
-              value: "9125"
-            {{- if .Values.sentry.enabled }}
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: sentry
-                  key: {{ .Chart.Name }}.DSN.python
-            {{- end }}
-            {{- if .Values.api.use_uwsgi }}
-            - name: OS_OSLO_MESSAGING_RABBIT__HEARTBEAT_IN_PTHREAD
-              value: "true"
-            {{- end }}
+          - name: STATSD_HOST
+            value: "localhost"
+          - name: STATSD_PORT
+            value: "9125"
+          {{- if .Values.sentry.enabled }}
+          - name: SENTRY_DSN
+            valueFrom:
+              secretKeyRef:
+                name: sentry
+                key: {{ .Chart.Name }}.DSN.python
+          {{- end }}
+          {{- if .Values.api.use_uwsgi }}
+          - name: OS_OSLO_MESSAGING_RABBIT__HEARTBEAT_IN_PTHREAD
+            value: "true"
+          {{- end }}
           lifecycle:
             preStop:
               {{- include "utils.snippets.pre_stop_graceful_shutdown" . | indent 14 }}

--- a/openstack/cinder/templates/api-deployment.yaml
+++ b/openstack/cinder/templates/api-deployment.yaml
@@ -51,11 +51,7 @@ spec:
             - name: DEPENDENCY_JOBS
               value: {{ include "cinder.migration_job_name" . }}
             - name: DEPENDENCY_SERVICE
-{{- if eq .Values.mariadb.enabled true }}
               value: "{{ .Release.Name }}-mariadb,{{ .Release.Name }}-rabbitmq"
-{{- else }}
-              value: "{{ .Release.Name }}-postgresql,{{ .Release.Name }}-rabbitmq"
-{{- end }}
             - name: STATSD_HOST
               value: "localhost"
             - name: STATSD_PORT
@@ -67,10 +63,6 @@ spec:
                   name: sentry
                   key: {{ .Chart.Name }}.DSN.python
             {{- end }}
-            - name: PGAPPNAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
             {{- if .Values.api.use_uwsgi }}
             - name: OS_OSLO_MESSAGING_RABBIT__HEARTBEAT_IN_PTHREAD
               value: "true"

--- a/openstack/cinder/templates/api-deployment.yaml
+++ b/openstack/cinder/templates/api-deployment.yaml
@@ -49,7 +49,7 @@ spec:
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
             - name: DEPENDENCY_JOBS
-              value: cinder-migration-{{.Values.imageVersion | required "Please set cinder.imageVersion or similar"}}{{- if .Values.proxysql.mode}}-{{ .Values.proxysql.mode | replace "_" "-" }}{{ end }}
+              value: {{ include "cinder.migration_job_name" . }}
             - name: DEPENDENCY_SERVICE
 {{- if eq .Values.mariadb.enabled true }}
               value: "{{ .Release.Name }}-mariadb,{{ .Release.Name }}-rabbitmq"

--- a/openstack/cinder/templates/backup_deployment.yaml
+++ b/openstack/cinder/templates/backup_deployment.yaml
@@ -66,8 +66,6 @@ template: |
             value: {{ .Values.sentry_dsn | quote }}
           - name: PYTHONWARNINGS
             value: 'ignore:Unverified HTTPS request'
-          - name: PGAPPNAME
-            value: cinder-volume-backup-vmware-{= name =}
           livenessProbe:
             exec:
               command: ["openstack-agent-liveness", "--component", "cinder", "--config-file", "/etc/cinder/cinder.conf", "--config-file", "/etc/cinder/cinder-backup.conf"]

--- a/openstack/cinder/templates/backup_deployment.yaml
+++ b/openstack/cinder/templates/backup_deployment.yaml
@@ -47,6 +47,8 @@ template: |
         hostname: cinder-volume-backup-vmware-{= name =}
         {{- include "utils.proxysql.pod_settings" . | nindent 8 }}
         {{- tuple . "{= availability_zone =}" | include "utils.kubernetes_pod_az_affinity" | nindent 8 }}
+        initContainers:
+        {{- tuple . (dict "service" (print .Release.Name "-mariadb," .Release.Name "-rabbitmq") "jobs" (include "cinder.migration_job_name" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
         containers:
         - name: cinder-volume-backup-vmware-{= name =}
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{.Values.imageVersionCinderVolumeBackup | default .Values.imageVersion | required "Please set cinder.imageVersion or similar" }}
@@ -56,12 +58,8 @@ template: |
               add: ["SYS_ADMIN"]
           command:
           - dumb-init
-          - kubernetes-entrypoint
+          - cinder-backup
           env:
-          - name: COMMAND
-            value: 'cinder-backup'
-          - name: NAMESPACE
-            value: {= namespace =}
           - name: SENTRY_DSN
             value: {{ .Values.sentry_dsn | quote }}
           - name: PYTHONWARNINGS

--- a/openstack/cinder/templates/migration-job.yaml
+++ b/openstack/cinder/templates/migration-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: cinder-migration-{{.Values.imageVersion | required "Please set cinder.imageVersion or similar"}}{{- if .Values.proxysql.mode}}-{{ .Values.proxysql.mode | replace "_" "-" }}{{ end }}
+  name: {{ include "cinder.migration_job_name" . }}
   labels:
     system: openstack
     type: configuration

--- a/openstack/cinder/templates/migration-job.yaml
+++ b/openstack/cinder/templates/migration-job.yaml
@@ -12,18 +12,7 @@ spec:
       restartPolicy: OnFailure
 {{ include "utils.proxysql.job_pod_settings" . | indent 6 }}
       initContainers:
-        - name: dependencies
-          image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{.Values.imageVersionCinderApi | default .Values.imageVersion | required "Please set cinder.imageVersion or similar" }}
-          imagePullPolicy: IfNotPresent
-          command:
-            - kubernetes-entrypoint
-          env:
-            - name: COMMAND
-              value: "true"
-            - name: NAMESPACE
-              value: {{ .Release.Namespace }}
-            - name: DEPENDENCY_SERVICE
-              value: "{{ .Release.Name }}-mariadb"
+      {{- tuple . (dict "service" (print .Release.Name "-mariadb")) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
         - name: cinder-migration
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{.Values.imageVersionCinderApi | default .Values.imageVersion | required "Please set cinder.imageVersion or similar" }}

--- a/openstack/cinder/templates/migration-job.yaml
+++ b/openstack/cinder/templates/migration-job.yaml
@@ -23,11 +23,7 @@ spec:
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
             - name: DEPENDENCY_SERVICE
-{{- if eq .Values.mariadb.enabled true }}
               value: "{{ .Release.Name }}-mariadb"
-{{- else }}
-              value: "{{ .Release.Name }}-postgresql"
-{{- end }}
       containers:
         - name: cinder-migration
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{.Values.imageVersionCinderApi | default .Values.imageVersion | required "Please set cinder.imageVersion or similar" }}

--- a/openstack/cinder/templates/scheduler-deployment.yaml
+++ b/openstack/cinder/templates/scheduler-deployment.yaml
@@ -34,28 +34,24 @@ spec:
         {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
 {{ tuple . "cinder" "scheduler" | include "kubernetes_pod_anti_affinity" | indent 6 }}
-{{ include "utils.proxysql.pod_settings" . | indent 6 }}
+      {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       hostname: cinder-scheduler
+      initContainers:
+      {{- tuple . (dict "service" (print "cinder-api," .Release.Name "-rabbitmq")) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
         - name: cinder-scheduler
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{.Values.imageVersionCinderScheduler | default .Values.imageVersion | required "Please set cinder.imageVersion or similar" }}
           imagePullPolicy: {{ required ".Values.global.imagePullPolicy is missing" .Values.global.imagePullPolicy }}
           command:
-            - kubernetes-entrypoint
+          - cinder-scheduler
           env:
-            - name: COMMAND
-              value: "cinder-scheduler"
-            - name: NAMESPACE
-              value: {{ .Release.Namespace }}
-            - name: DEPENDENCY_SERVICE
-              value: "cinder-api,{{ .Release.Name }}-rabbitmq"
-            {{- if .Values.sentry.enabled }}
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: sentry
-                  key: {{ .Chart.Name }}.DSN.python
-            {{- end }}
+          {{- if .Values.sentry.enabled }}
+          - name: SENTRY_DSN
+            valueFrom:
+              secretKeyRef:
+                name: sentry
+                key: {{ .Chart.Name }}.DSN.python
+          {{- end }}
           livenessProbe:
             exec:
               command: ["openstack-agent-liveness", "--component", "cinder", "--config-file", "/etc/cinder/cinder.conf"]

--- a/openstack/cinder/templates/scheduler-deployment.yaml
+++ b/openstack/cinder/templates/scheduler-deployment.yaml
@@ -56,10 +56,6 @@ spec:
                   name: sentry
                   key: {{ .Chart.Name }}.DSN.python
             {{- end }}
-            - name: PGAPPNAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
           livenessProbe:
             exec:
               command: ["openstack-agent-liveness", "--component", "cinder", "--config-file", "/etc/cinder/cinder.conf"]

--- a/openstack/cinder/templates/vcenter_datacenter_cinder_deployment.yaml
+++ b/openstack/cinder/templates/vcenter_datacenter_cinder_deployment.yaml
@@ -49,6 +49,8 @@ template: |
         hostname: cinder-volume-vmware-{= name =}
         {{- tuple . "{= availability_zone =}" | include "utils.kubernetes_pod_az_affinity" | nindent 8 }}
         {{- include "utils.proxysql.pod_settings" . | nindent 8 }}
+        initContainers:
+        {{- tuple . (dict "service" (print "cinder-api," .Release.Name "-rabbitmq")) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
         containers:
         - name: cinder-volume-vmware-{= name =}
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{.Values.imageVersionCinderScheduler | default .Values.imageVersion | required "Please set cinder.imageVersion or similar" }}
@@ -58,12 +60,8 @@ template: |
               add: ["SYS_ADMIN"]
           command:
           - dumb-init
-          - kubernetes-entrypoint
+          - cinder-volume
           env:
-          - name: COMMAND
-            value: 'cinder-volume'
-          - name: NAMESPACE
-            value: {= namespace =}
           {{- if .Values.sentry.enabled }}
           - name: SENTRY_DSN
             valueFrom:

--- a/openstack/cinder/templates/vcenter_datacenter_cinder_deployment.yaml
+++ b/openstack/cinder/templates/vcenter_datacenter_cinder_deployment.yaml
@@ -73,8 +73,6 @@ template: |
           {{- end }}
           - name: PYTHONWARNINGS
             value: 'ignore:Unverified HTTPS request'
-          - name: PGAPPNAME
-            value: cinder-volume-vmware-{= name =}
           livenessProbe:
             exec:
               command: ["openstack-agent-liveness", "--component", "cinder", "--config-file", "/etc/cinder/cinder.conf"]


### PR DESCRIPTION
Split into smaller commits
Some minor cleanup plus the actual change:

Moving the logic to an initcontainer means we do not have to build
in the executable in the main image and can share that image among
services.

Also, a missing dependency won't get mixed up with normal program
failures.