### PR TITLE
[nova] Move kubernetes-entrypoint to init containers + cleanup

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 0.1.1
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.4
+  version: 0.9.0
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.7.5
@@ -26,5 +26,5 @@ dependencies:
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:e30a9cce632fcde5a6530ea6eed5998cc2a8f439745b2853e65453a149883268
-generated: "2023-04-17T12:23:45.79390831+02:00"
+digest: sha256:84598e302b07470109f48aea713085c8daa52406bf7313ebeee02c0b34e282bb
+generated: "2023-05-02T14:32:04.267291935+02:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     version: 0.1.1
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.7.2
+    version: ~0.9.0
   - name: mariadb
     alias: mariadb_cell2
     condition: mariadb_cell2.enabled

--- a/openstack/nova/templates/_console_deployment.yaml.tpl
+++ b/openstack/nova/templates/_console_deployment.yaml.tpl
@@ -40,7 +40,7 @@ spec:
         {{- end }}
     spec:
 {{ tuple . "nova" (print "console-" $name) | include "kubernetes_pod_anti_affinity" | indent 6 }}
-{{ include "utils.proxysql.pod_settings" . | indent 6 }}
+      {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       hostname: nova-console-{{ $name }}
       volumes:
       - name: nova-etc
@@ -75,12 +75,13 @@ spec:
         imagePullPolicy: IfNotPresent
         command:
         - dumb-init
-        - kubernetes-entrypoint
+        - nova-{{ $name }}proxy
+        {{- if $config.args }}
+          {{- range (regexSplit "\\s+" $config.args -1) }}
+        - {{ . }}
+          {{- end }}
+        {{- end }}
         env:
-        - name: COMMAND
-          value: nova-{{ $type }}proxy {{ $config.args }}
-        - name: NAMESPACE
-          value: {{ .Release.Namespace }}
         - name: LANG
           value: en_US.UTF-8
 {{- if .Values.python_warnings }}

--- a/openstack/nova/templates/api-deployment.yaml
+++ b/openstack/nova/templates/api-deployment.yaml
@@ -77,10 +77,6 @@ spec:
             - name: PYTHONWARNINGS
               value: {{ .Values.python_warnings | quote }}
 {{- end }}
-            - name: PGAPPNAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
           lifecycle:
             preStop:
               {{- include "utils.snippets.pre_stop_graceful_shutdown" . | indent 14 }}

--- a/openstack/nova/templates/api-deployment.yaml
+++ b/openstack/nova/templates/api-deployment.yaml
@@ -35,52 +35,52 @@ spec:
         {{- end }}
     spec:
       terminationGracePeriodSeconds: {{ .Values.defaults.default.graceful_shutdown_timeout | add 5 }}
-{{- if .Values.pod.debug.api }}
+      {{- if .Values.pod.debug.api }}
       securityContext:
         runAsUser: 0
-{{- end }}
+      {{- end }}
 {{ tuple . "nova" "api" | include "kubernetes_pod_anti_affinity" | indent 6 }}
-{{ include "utils.proxysql.pod_settings" . | indent 6 }}
+      {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       hostname: nova-api
+      initContainers:
+      {{- tuple . (dict "service" (include "nova.helpers.cell01_services" .) "jobs" (tuple . "db-migrate" | include "job_name")) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
         - name: nova-api
           image: {{ tuple . "api" | include "container_image_nova" }}
           imagePullPolicy: IfNotPresent
           command:
-            - dumb-init
-            - kubernetes-entrypoint
+          - dumb-init
+          {{- if .Values.api.use_uwsgi }}
+          - uwsgi
+          - --ini
+          - /etc/nova/api_uwsgi.ini
+          {{- else }}
+          - nova-api
+          {{- end }}
           env:
-            - name: COMMAND
-              value: "{{ if .Values.api.use_uwsgi }}uwsgi --ini /etc/nova/api_uwsgi.ini{{ else }}nova-api{{ end }}"
-            - name: NAMESPACE
-              value: {{ .Release.Namespace }}
-            - name: DEPENDENCY_JOBS
-              value: {{ tuple . "db-migrate" | include "job_name" }}
-            - name: DEPENDENCY_SERVICE
-              value: "{{ .Release.Name }}-mariadb,{{ .Release.Name }}-api-mariadb,{{ .Release.Name }}-rabbitmq"
-            - name: STATSD_HOST
-              value: "localhost"
-            - name: STATSD_PORT
-              value: "9125"
-            {{- if .Values.api.use_uwsgi }}
-            - name: OS_OSLO_MESSAGING_RABBIT__HEARTBEAT_IN_PTHREAD
-              value: "true"
-            {{- end }}
-            {{- if .Values.sentry.enabled }}
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: sentry
-                  key: {{ .Chart.Name }}.DSN.python
-            {{- end }}
-{{- if .Values.python_warnings }}
-            - name: PYTHONWARNINGS
-              value: {{ .Values.python_warnings | quote }}
-{{- end }}
+          - name: STATSD_HOST
+            value: "localhost"
+          - name: STATSD_PORT
+            value: "9125"
+          {{- if .Values.api.use_uwsgi }}
+          - name: OS_OSLO_MESSAGING_RABBIT__HEARTBEAT_IN_PTHREAD
+            value: "true"
+          {{- end }}
+          {{- if .Values.sentry.enabled }}
+          - name: SENTRY_DSN
+            valueFrom:
+              secretKeyRef:
+                name: sentry
+                key: {{ .Chart.Name }}.DSN.python
+          {{- end }}
+          {{- if .Values.python_warnings }}
+          - name: PYTHONWARNINGS
+            value: {{ .Values.python_warnings | quote }}
+          {{- end }}
           lifecycle:
             preStop:
               {{- include "utils.snippets.pre_stop_graceful_shutdown" . | indent 14 }}
-{{- if not .Values.pod.debug.api }}
+          {{- if not .Values.pod.debug.api }}
           livenessProbe:
             httpGet:
               path: /
@@ -93,7 +93,7 @@ spec:
               port: {{.Values.global.novaApiPortInternal}}
             initialDelaySeconds: 15
             timeoutSeconds: 5
-{{- end }}
+          {{- end }}
           {{- if .Values.pod.resources.api }}
           resources:
 {{ toYaml .Values.pod.resources.api | indent 12 }}

--- a/openstack/nova/templates/api-metadata-deployment.yaml
+++ b/openstack/nova/templates/api-metadata-deployment.yaml
@@ -69,10 +69,6 @@ spec:
             - name: PYTHONWARNINGS
               value: {{ .Values.python_warnings | quote }}
 {{- end }}
-            - name: PGAPPNAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
           lifecycle:
             preStop:
               {{- include "utils.snippets.pre_stop_graceful_shutdown" . | indent 14 }}

--- a/openstack/nova/templates/api-metadata-deployment.yaml
+++ b/openstack/nova/templates/api-metadata-deployment.yaml
@@ -35,40 +35,34 @@ spec:
         {{- end }}
     spec:
 {{ tuple . "nova" "api-metadata" | include "kubernetes_pod_anti_affinity" | indent 6 }}
-{{ include "utils.proxysql.pod_settings" . | indent 6 }}
+      {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       terminationGracePeriodSeconds: {{ .Values.defaults.default.graceful_shutdown_timeout | add 5 }}
       hostname: nova-api-metadata
+      initContainers:
+      {{- tuple . (dict "service" (print .Values.mariadb_api.name "-mariadb") "jobs" (tuple . "db-migrate" | include "job_name")) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
         - name: nova-api-metadata
           image: {{ tuple . "api" | include "container_image_nova" }}
           imagePullPolicy: IfNotPresent
           command:
-            - dumb-init
-            - kubernetes-entrypoint
+          - dumb-init
+          - nova-api
           env:
-            - name: COMMAND
-              value: "nova-api"
-            - name: NAMESPACE
-              value: {{ .Release.Namespace }}
-            - name: DEPENDENCY_JOBS
-              value: {{ tuple . "db-migrate" | include "job_name" }}
-            - name: DEPENDENCY_SERVICE
-              value: "{{ .Release.Name }}-mariadb,{{ .Release.Name }}-api-mariadb,{{ .Release.Name }}-rabbitmq"
-            - name: STATSD_HOST
-              value: "localhost"
-            - name: STATSD_PORT
-              value: "9125"
-            {{- if .Values.sentry.enabled }}
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: sentry
-                  key: {{ .Chart.Name }}.DSN.python
-            {{- end }}
-{{- if .Values.python_warnings }}
-            - name: PYTHONWARNINGS
-              value: {{ .Values.python_warnings | quote }}
-{{- end }}
+          - name: STATSD_HOST
+            value: "localhost"
+          - name: STATSD_PORT
+            value: "9125"
+          {{- if .Values.sentry.enabled }}
+          - name: SENTRY_DSN
+            valueFrom:
+              secretKeyRef:
+                name: sentry
+                key: {{ .Chart.Name }}.DSN.python
+          {{- end }}
+          {{- if .Values.python_warnings }}
+          - name: PYTHONWARNINGS
+            value: {{ .Values.python_warnings | quote }}
+          {{- end }}
           lifecycle:
             preStop:
               {{- include "utils.snippets.pre_stop_graceful_shutdown" . | indent 14 }}

--- a/openstack/nova/templates/bigvm-deployment.yaml
+++ b/openstack/nova/templates/bigvm-deployment.yaml
@@ -64,10 +64,6 @@ spec:
             - name: PYTHONWARNINGS
               value: {{ .Values.python_warnings | quote }}
 {{- end }}
-            - name: PGAPPNAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
           livenessProbe:
             exec:
               command: ["openstack-agent-liveness", "--component", "nova", "--config-file", "/etc/nova/nova.conf"]

--- a/openstack/nova/templates/bigvm-deployment.yaml
+++ b/openstack/nova/templates/bigvm-deployment.yaml
@@ -36,34 +36,30 @@ spec:
         {{- end }}
     spec:
 {{ tuple . "nova" "bigvm" | include "kubernetes_pod_anti_affinity" | indent 6 }}
-{{ include "utils.proxysql.pod_settings" . | indent 6 }}
+      {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       terminationGracePeriodSeconds: {{ .Values.defaults.default.graceful_shutdown_timeout | add 5 }}
       hostname: nova-bigvm
+      initContainers:
+      {{- tuple . (dict "service" (include "nova.helpers.all_cell_services" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
         - name: nova-bigvm
           image: {{ tuple . "scheduler" | include "container_image_nova" }}
           imagePullPolicy: IfNotPresent
           command:
-            - dumb-init
-            - kubernetes-entrypoint
+          - dumb-init
+          - nova-bigvm
           env:
-            - name: COMMAND
-              value: "nova-bigvm"
-            - name: NAMESPACE
-              value: {{ .Release.Namespace }}
-            - name: DEPENDENCY_SERVICE
-              value: "{{ .Release.Name }}-mariadb,{{ .Release.Name }}-api-mariadb,{{ .Release.Name }}-rabbitmq{{ if .Values.cell2.enabled }},{{ .Release.Name }}-{{ .Values.cell2.name }}-mariadb,{{ .Release.Name }}-{{ .Values.cell2.name }}-rabbitmq{{ end }}"
-            {{- if .Values.sentry.enabled }}
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: sentry
-                  key: {{ .Chart.Name }}.DSN.python
-            {{- end }}
-{{- if .Values.python_warnings}}
-            - name: PYTHONWARNINGS
-              value: {{ .Values.python_warnings | quote }}
-{{- end }}
+          {{- if .Values.sentry.enabled }}
+          - name: SENTRY_DSN
+            valueFrom:
+              secretKeyRef:
+                name: sentry
+                key: {{ .Chart.Name }}.DSN.python
+          {{- end }}
+          {{- if .Values.python_warnings}}
+          - name: PYTHONWARNINGS
+            value: {{ .Values.python_warnings | quote }}
+          {{- end }}
           livenessProbe:
             exec:
               command: ["openstack-agent-liveness", "--component", "nova", "--config-file", "/etc/nova/nova.conf"]

--- a/openstack/nova/templates/cell2-conductor-deployment.yaml
+++ b/openstack/nova/templates/cell2-conductor-deployment.yaml
@@ -77,10 +77,6 @@ spec:
             - name: PYTHONWARNINGS
               value: {{ .Values.python_warnings | quote }}
 {{- end }}
-            - name: PGAPPNAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
           livenessProbe:
             exec:
               command: ["openstack-agent-liveness", "--component", "nova", "--config-file", "/etc/nova/nova.conf"]

--- a/openstack/nova/templates/cell2-conductor-deployment.yaml
+++ b/openstack/nova/templates/cell2-conductor-deployment.yaml
@@ -40,18 +40,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.defaults.default.graceful_shutdown_timeout | add 5 }}
       hostname: nova-conductor
       initContainers:
-        - name: dependencies
-          image: {{ tuple . "conductor" | include "container_image_nova" }}
-          imagePullPolicy: IfNotPresent
-          command:
-            - kubernetes-entrypoint
-          env:
-            - name: COMMAND
-              value: "true"
-            - name: NAMESPACE
-              value: {{ .Release.Namespace }}
-            - name: DEPENDENCY_SERVICE
-              value: "{{ .Release.Name }}-{{ .Values.cell2.name }}-rabbitmq,{{ .Release.Name }}-{{ .Values.cell2.name }}-mariadb"      
+      {{- tuple . (dict "service" (include "nova.helpers.cell2_services" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
         - name: nova-conductor
           image: {{ tuple . "conductor" | include "container_image_nova" }}
@@ -73,10 +62,10 @@ spec:
                   name: sentry
                   key: {{ .Chart.Name }}.DSN.python
             {{- end }}
-{{- if .Values.python_warnings}}
+            {{- if .Values.python_warnings}}
             - name: PYTHONWARNINGS
               value: {{ .Values.python_warnings | quote }}
-{{- end }}
+            {{- end }}
           livenessProbe:
             exec:
               command: ["openstack-agent-liveness", "--component", "nova", "--config-file", "/etc/nova/nova.conf"]

--- a/openstack/nova/templates/conductor-deployment.yaml
+++ b/openstack/nova/templates/conductor-deployment.yaml
@@ -70,10 +70,6 @@ spec:
             - name: PYTHONWARNINGS
               value: {{ .Values.python_warnings | quote }}
 {{- end }}
-            - name: PGAPPNAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
           livenessProbe:
             exec:
               command: ["openstack-agent-liveness", "--component", "nova", "--config-file", "/etc/nova/nova.conf"]

--- a/openstack/nova/templates/conductor-deployment.yaml
+++ b/openstack/nova/templates/conductor-deployment.yaml
@@ -35,22 +35,11 @@ spec:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
     spec:
 {{ tuple . "nova" "conductor" | include "kubernetes_pod_anti_affinity" | indent 6 }}
-{{ include "utils.proxysql.pod_settings" . | indent 6 }}
+      {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       terminationGracePeriodSeconds: {{ .Values.defaults.default.graceful_shutdown_timeout | add 5 }}
       hostname: nova-conductor
       initContainers:
-        - name: dependencies
-          image: {{ tuple . "conductor" | include "container_image_nova" }}
-          imagePullPolicy: IfNotPresent
-          command:
-            - kubernetes-entrypoint
-          env:
-            - name: COMMAND
-              value: "true"
-            - name: NAMESPACE
-              value: {{ .Release.Namespace }}
-            - name: DEPENDENCY_SERVICE
-              value: "nova-api,{{ .Release.Name }}-rabbitmq"
+      {{- tuple . (dict "service" (include "nova.helpers.cell01_services" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
         - name: nova-conductor
           image: {{ tuple . "conductor" | include "container_image_nova" }}

--- a/openstack/nova/templates/db-migrate-job.yaml
+++ b/openstack/nova/templates/db-migrate-job.yaml
@@ -29,10 +29,6 @@ spec:
           value: {{ .Release.Namespace }}
         - name: DEPENDENCY_SERVICE
           value: "{{ .Release.Name }}-mariadb,{{ .Release.Name }}-api-mariadb{{ if eq .Values.cell2.enabled true }},{{ .Values.mariadb_cell2.name }}-mariadb{{ end }}"
-        - name: PGAPPNAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
         - name: PYTHONWARNINGS
           value: {{ .Values.python_warnings | quote }}
         volumeMounts:

--- a/openstack/nova/templates/db-migrate-job.yaml
+++ b/openstack/nova/templates/db-migrate-job.yaml
@@ -16,19 +16,15 @@ spec:
     spec:
       restartPolicy: OnFailure
       {{- include "utils.proxysql.job_pod_settings" . | indent 6 }}
+      initContainers:
+      {{- tuple . (dict "service" (include "nova.helpers.database_services" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
       - name: nova-migration
         image: {{ tuple . "api" | include "container_image_nova" }}
         imagePullPolicy: IfNotPresent
         command:
-        - kubernetes-entrypoint
+        - /container.init/db-migrate
         env:
-        - name: COMMAND
-          value: "/container.init/db-migrate"
-        - name: NAMESPACE
-          value: {{ .Release.Namespace }}
-        - name: DEPENDENCY_SERVICE
-          value: "{{ .Release.Name }}-mariadb,{{ .Release.Name }}-api-mariadb{{ if eq .Values.cell2.enabled true }},{{ .Values.mariadb_cell2.name }}-mariadb{{ end }}"
         - name: PYTHONWARNINGS
           value: {{ .Values.python_warnings | quote }}
         volumeMounts:

--- a/openstack/nova/templates/db-online-migrate-job.yaml
+++ b/openstack/nova/templates/db-online-migrate-job.yaml
@@ -31,10 +31,6 @@ spec:
           value: {{ tuple . "db-migrate" | include "job_name" }}
         - name: DEPENDENCY_SERVICE
           value: "{{ .Release.Name }}-mariadb,{{ .Release.Name }}-api-mariadb{{ if eq .Values.cell2.enabled true }},{{ .Values.mariadb_cell2.name }}-mariadb{{ end }}"
-        - name: PGAPPNAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
         volumeMounts:
         - mountPath: /etc/nova
           name: nova-etc

--- a/openstack/nova/templates/db-online-migrate-job.yaml
+++ b/openstack/nova/templates/db-online-migrate-job.yaml
@@ -16,21 +16,18 @@ spec:
     spec:
       restartPolicy: OnFailure
       {{- include "utils.proxysql.job_pod_settings" . | indent 6 }}
+      initContainers:
+      {{- $dependencies := dict "jobs" (tuple . "db-migrate" | include "job_name") "service" (include "nova.helpers.database_services" .) }}
+      {{- tuple . $dependencies | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
       - name: nova-migrate
         image: {{ tuple . "api" | include "container_image_nova" }}
         imagePullPolicy: IfNotPresent
         command:
-        - kubernetes-entrypoint
+        - /container.init/db-online-migrate
         env:
-        - name: COMMAND
-          value: "/container.init/db-online-migrate"
-        - name: NAMESPACE
-          value: {{ .Release.Namespace }}
-        - name: DEPENDENCY_JOBS
-          value: {{ tuple . "db-migrate" | include "job_name" }}
-        - name: DEPENDENCY_SERVICE
-          value: "{{ .Release.Name }}-mariadb,{{ .Release.Name }}-api-mariadb{{ if eq .Values.cell2.enabled true }},{{ .Values.mariadb_cell2.name }}-mariadb{{ end }}"
+        - name: PYTHONWARNINGS
+          value: {{ .Values.python_warnings | quote }}
         volumeMounts:
         - mountPath: /etc/nova
           name: nova-etc
@@ -49,10 +46,10 @@ spec:
                 path: nova.conf
               - key:  logging.ini
                 path: logging.ini
-{{- if .Values.cell2.enabled }}
+              {{- if .Values.cell2.enabled }}
               - key:  nova-cell2.conf
                 path: nova-cell2.conf
-{{- end }}
+              {{- end }}
           - secret:
               name: nova-etc
               items:

--- a/openstack/nova/templates/hypervisors/_ironic-deployment.yaml.tpl
+++ b/openstack/nova/templates/hypervisors/_ironic-deployment.yaml.tpl
@@ -60,10 +60,6 @@ spec:
             - name: PYTHONWARNINGS
               value: {{ or $hypervisor.python_warnings .Values.python_warnings | quote }}
 {{- end }}
-            - name: PGAPPNAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
           {{- if .Values.pod.resources.hv_ironic }}
           resources:
 {{ toYaml .Values.pod.resources.hv_ironic | indent 12 }}

--- a/openstack/nova/templates/hypervisors/_ironic-deployment.yaml.tpl
+++ b/openstack/nova/templates/hypervisors/_ironic-deployment.yaml.tpl
@@ -37,28 +37,24 @@ spec:
         configmap-ironic-etc-hash: {{ tuple . $hypervisor | include "ironic_configmap" | sha256sum }}
     spec:
       terminationGracePeriodSeconds: {{ $hypervisor.default.graceful_shutdown_timeout | default .Values.defaults.default.graceful_shutdown_timeout | add 5 }}
+      initContainers:
+      {{- tuple . (dict "service" (print .Release.Name "-rabbitmq")) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
         - name: nova-compute
           image: {{ tuple . "compute" | include "container_image_nova" }}
           imagePullPolicy: IfNotPresent
-          command:
-            - dumb-init
-            - kubernetes-entrypoint
+          command: ["dumb-init", "nova-compute"]
           env:
-            - name: COMMAND
-              value: "nova-compute"
-            - name: NAMESPACE
-              value: {{ .Release.Namespace }}
-            {{- if .Values.sentry.enabled }}
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: sentry
-                  key: {{ .Chart.Name }}.DSN.python
-            {{- end }}
+          {{- if .Values.sentry.enabled }}
+          - name: SENTRY_DSN
+            valueFrom:
+              secretKeyRef:
+                name: sentry
+                key: {{ .Chart.Name }}.DSN.python
+          {{- end }}
 {{- if or $hypervisor.python_warnings .Values.python_warnings }}
-            - name: PYTHONWARNINGS
-              value: {{ or $hypervisor.python_warnings .Values.python_warnings | quote }}
+          - name: PYTHONWARNINGS
+            value: {{ or $hypervisor.python_warnings .Values.python_warnings | quote }}
 {{- end }}
           {{- if .Values.pod.resources.hv_ironic }}
           resources:

--- a/openstack/nova/templates/hypervisors/hypervisors-vmware-deployment-vct.yaml
+++ b/openstack/nova/templates/hypervisors/hypervisors-vmware-deployment-vct.yaml
@@ -76,8 +76,6 @@ template: |
             value: "9125"
           - name: PYTHONWARNINGS
             value: "ignore:Unverified HTTPS request"
-          - name: PGAPPNAME
-            value: nova-compute-{= name =}
           {{- if .Values.pod.resources.hv_vmware }}
           resources:
 {{ toYaml .Values.pod.resources.hv_vmware | indent 12 }}

--- a/openstack/nova/templates/hypervisors/hypervisors-vmware-deployment-vct.yaml
+++ b/openstack/nova/templates/hypervisors/hypervisors-vmware-deployment-vct.yaml
@@ -55,14 +55,8 @@ template: |
         - name: nova-compute
           image: {{ tuple . "compute" | include "container_image_nova" }}
           imagePullPolicy: IfNotPresent
-          command:
-          - dumb-init
-          - kubernetes-entrypoint
+          command: ["dumb-init", "nova-compute"]
           env:
-          - name: COMMAND
-            value: "nova-compute"
-          - name: NAMESPACE
-            value: {{ .Release.Namespace }}
           {{- if .Values.sentry.enabled }}
           - name: SENTRY_DSN
             valueFrom:

--- a/openstack/nova/templates/scheduler-deployment.yaml
+++ b/openstack/nova/templates/scheduler-deployment.yaml
@@ -64,10 +64,6 @@ spec:
             - name: PYTHONWARNINGS
               value: {{ .Values.python_warnings | quote }}
 {{- end }}
-            - name: PGAPPNAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
           livenessProbe:
             exec:
               command: ["openstack-agent-liveness", "--component", "nova", "--config-file", "/etc/nova/nova.conf"]

--- a/openstack/nova/templates/scheduler-deployment.yaml
+++ b/openstack/nova/templates/scheduler-deployment.yaml
@@ -39,31 +39,27 @@ spec:
 {{ include "utils.proxysql.pod_settings" . | indent 6 }}
       terminationGracePeriodSeconds: {{ .Values.defaults.default.graceful_shutdown_timeout | add 5 }}
       hostname: nova-scheduler
+      initContainers:
+      {{- tuple . (dict "service" (include "nova.helpers.cell01_services" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
         - name: nova-scheduler
           image: {{ tuple . "scheduler" | include "container_image_nova" }}
           imagePullPolicy: IfNotPresent
           command:
-            - dumb-init
-            - kubernetes-entrypoint
+          - dumb-init
+          - nova-scheduler
           env:
-            - name: COMMAND
-              value: "nova-scheduler"
-            - name: NAMESPACE
-              value: {{ .Release.Namespace }}
-            - name: DEPENDENCY_SERVICE
-              value: "nova-api,{{ .Release.Name }}-rabbitmq"
-            {{- if .Values.sentry.enabled }}
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: sentry
-                  key: {{ .Chart.Name }}.DSN.python
-            {{- end }}
-{{- if .Values.python_warnings}}
-            - name: PYTHONWARNINGS
-              value: {{ .Values.python_warnings | quote }}
-{{- end }}
+          {{- if .Values.sentry.enabled }}
+          - name: SENTRY_DSN
+            valueFrom:
+              secretKeyRef:
+                name: sentry
+                key: {{ .Chart.Name }}.DSN.python
+          {{- end }}
+          {{- if .Values.python_warnings}}
+          - name: PYTHONWARNINGS
+            value: {{ .Values.python_warnings | quote }}
+          {{- end }}
           livenessProbe:
             exec:
               command: ["openstack-agent-liveness", "--component", "nova", "--config-file", "/etc/nova/nova.conf"]


### PR DESCRIPTION
Moving the logic to an initcontainer means we do not have to build
in the executable in the main image and can share that image among
services.

Also, a missing dependency won't get mixed up with normal program
failures.
