### PR TITLE
[barbican] Move kubernetes-entrypoint to init containers

### DIFF
--- a/openstack/barbican/Chart.lock
+++ b/openstack/barbican/Chart.lock
@@ -13,12 +13,12 @@ dependencies:
   version: 0.5.1
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.5.0
+  version: 0.9.0
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.2.4
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:71e95cd542cf88dd2716068faf724e7ce985dc9a17d86f0d556fa662a537e8b9
-generated: "2023-04-25T16:51:09.974557+05:30"
+digest: sha256:f5afd32ece7a3334ea3109a44802dc88e1f171e5dce0a1175f14917b34c254d2
+generated: "2023-05-02T15:44:55.333181873+02:00"

--- a/openstack/barbican/Chart.yaml
+++ b/openstack/barbican/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
     version: 0.5.1
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.5.0
+    version: ~0.9.0
   - name: redis
     alias: sapcc_rate_limit
     repository: https://charts.eu-de-2.cloud.sap

--- a/openstack/barbican/templates/api-deployment.yaml
+++ b/openstack/barbican/templates/api-deployment.yaml
@@ -40,34 +40,28 @@ spec:
         {{- end }}
     spec:
 {{ tuple . "barbican" "api" | include "kubernetes_pod_anti_affinity" | indent 6 }}
-{{ include "utils.proxysql.pod_settings" . | indent 6 }}
+      {{- include "utils.proxysql.pod_settings" . | indent 6 }}
+      initContainers:
+      {{- tuple . (dict "service" "barbican-mariadb,barbican-rabbitmq") | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
         - name: barbican-api
           image: {{required ".Values.global.registry is missing" .Values.global.registry }}/loci-barbican:{{required "Values.imageVersionBarbicanApi is missing" .Values.imageVersionBarbicanApi}}
           imagePullPolicy: IfNotPresent
           command:
-            - dumb-init
-            - kubernetes-entrypoint
+          - dumb-init
+          - barbican-api
           env:
-            - name: COMMAND
-              value: "/var/lib/openstack/bin/barbican-api"
-            - name: NAMESPACE
-              value: {{ .Release.Namespace }}
-            - name: DEPENDENCY_JOBS
-              value: "barbican-migration-job-{{ required "Please set barbican.imageVersionBarbicanApi or similar" .Values.imageVersionBarbicanApi }}"
-            - name: DEPENDENCY_SERVICE
-              value: "barbican-mariadb,barbican-rabbitmq"
-            {{- if .Values.sentry.enabled }}
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: sentry
-                  key: barbican.DSN.python
-            {{- end }}
-            {{- if .Values.hsm.enabled }}
-            - name: ChrystokiConfigurationPath
-              value: "/thales/safenet/lunaclient/config"
-            {{- end }}
+          {{- if .Values.sentry.enabled }}
+          - name: SENTRY_DSN
+            valueFrom:
+              secretKeyRef:
+                name: sentry
+                key: barbican.DSN.python
+          {{- end }}
+          {{- if .Values.hsm.enabled }}
+          - name: ChrystokiConfigurationPath
+            value: "/thales/safenet/lunaclient/config"
+          {{- end }}
           {{- if .Values.api.resources.enabled }}
           resources:
             limits:

--- a/openstack/barbican/templates/migration-job.yaml
+++ b/openstack/barbican/templates/migration-job.yaml
@@ -22,26 +22,24 @@ spec:
 {{ tuple . "barbican" "migration" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
     spec:
       restartPolicy: OnFailure
+      initContainers:
+      {{- tuple . (dict "service" "barbican-mariadb") | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
         - name: barbican-migration
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-barbican:{{required ".Values.imageVersionBarbicanApi is missing" .Values.imageVersionBarbicanApi}}
           imagePullPolicy: IfNotPresent
           command:
-            - kubernetes-entrypoint
+          - barbican-manage
+          - db
+          - upgrade
           env:
-            - name: COMMAND
-              value: "/var/lib/openstack/bin/barbican-manage db upgrade"
-            - name: NAMESPACE
-              value: {{ .Release.Namespace }}
-            - name: DEPENDENCY_SERVICE
-              value: "barbican-mariadb"
-            {{- if .Values.sentry.enabled }}
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: sentry
-                  key: barbican.DSN.python
-            {{- end }}
+          {{- if .Values.sentry.enabled }}
+          - name: SENTRY_DSN
+            valueFrom:
+              secretKeyRef:
+                name: sentry
+                key: barbican.DSN.python
+          {{- end }}
           volumeMounts:
             - name: etcbarbican
               mountPath: /etc/barbican


### PR DESCRIPTION
Moving the logic to an initcontainer means we do not have to build in the executable in the main image and can share that image among services.

Also, a missing dependency won't get mixed up with normal program failures.