### PR TITLE
[manila] Fixup c83a39, no tailing ','

### DIFF
--- a/openstack/manila/templates/shares/_netapp-deployment.yaml.tpl
+++ b/openstack/manila/templates/shares/_netapp-deployment.yaml.tpl
@@ -39,7 +39,7 @@ spec:
 {{ tuple $availability_zone | include "kubernetes_pod_az_affinity" | indent 6 }}
 {{ include "utils.proxysql.pod_settings" . | indent 6 }}
       initContainers:
-      {{- tuple . (dict "service" (print .Release.Name "-mariadb," .Release.Name "-rabbitmq,")) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
+      {{- tuple . (dict "service" (print .Release.Name "-mariadb," .Release.Name "-rabbitmq")) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
         - name: fetch-rabbitmqadmin
           image: {{.Values.global.dockerHubMirror}}/library/busybox
           command: ["/scripts/fetch-rabbitmqadmin.sh"]

--- a/openstack/manila/templates/shares/_netapp-ensure-deployment.yaml.tpl
+++ b/openstack/manila/templates/shares/_netapp-ensure-deployment.yaml.tpl
@@ -43,7 +43,7 @@ spec:
                   - manila-share-netapp-{{$share.name}}
               topologyKey: kubernetes.io/hostname
       initContainers:
-      {{- tuple . (dict "service" (print .Release.Name "-mariadb,")) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
+      {{- tuple . (dict "service" (print .Release.Name "-mariadb")) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
         - name: reexport
           image: "{{.Values.global.registry}}/manila-ensure:{{.Values.loci.imageVersionEnsure}}"


### PR DESCRIPTION
The kubernetes-entrypoint doesn't seem to like a tailing ',' as it then looks for a resource with an empty name