### PR TITLE
[glance] Change the job-name when the init-container changes

### DIFF
--- a/openstack/glance/templates/_helpers.tpl
+++ b/openstack/glance/templates/_helpers.tpl
@@ -22,7 +22,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
   {{- $name := index . 1 }}
   {{- with index . 0 }}
     {{- $bin := include "utils.proxysql.proxysql_signal_stop_script" . | trim }}
-    {{- $all := list $bin (include "utils.proxysql.job_pod_settings" . ) (include "utils.proxysql.volume_mount" . ) (include "utils.proxysql.container" . ) (include "utils.proxysql.volumes" .) | join "\n" }}
+    {{- $all := list $bin (include "utils.proxysql.job_pod_settings" . ) (include "utils.proxysql.volume_mount" . ) (include "utils.proxysql.container" . ) (include "utils.proxysql.volumes" .) (tuple . (dict) | include "utils.snippets.kubernetes_entrypoint_init_container")  | join "\n" }}
     {{- $hash := empty .Values.proxysql.mode | ternary $bin $all | sha256sum }}
 {{- .Release.Name }}-{{ $name }}-{{ substr 0 4 $hash }}-{{ .Values.imageVersion | required "Please set glance.imageVersion or similar"}}
   {{- end }}


### PR DESCRIPTION
The job needs to be immutable, so any change to it should be a different job(-name).