### PR TITLE
[manila] adding init to manila-api for nfs permissions

### DIFF
--- a/openstack/manila/templates/api-deployment.yaml
+++ b/openstack/manila/templates/api-deployment.yaml
@@ -49,6 +49,13 @@ spec:
             readOnly: true
           - name: etcmanila
             mountPath: /shared
+      {{- if eq .Values.coordinationBackend "file" }}
+      - name: chown
+        image: {{.Values.global.dockerHubMirror}}/library/busybox
+        command: ["sh", "-c", "chown -R 42424:42424 /var/lib/manila/coordination"]
+        volumeMounts:
+        {{- include "utils.coordination.volume_mount" . | indent 10 }}
+      {{- end }}
       containers:
         - name: manila-api
           image: {{.Values.global.registry}}/loci-manila:{{.Values.loci.imageVersion}}


### PR DESCRIPTION
42424 is the default uid and gid coming from loci

directly going for the workaround provided by
https://github.com/kubernetes/examples/issues/260