### PR TITLE
[Cinder] Downgrade CinderShardMaxVolumeSize alerts

### DIFF
--- a/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
+++ b/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
@@ -45,7 +45,7 @@ groups:
       count by (shard, backend) (sum(cinder_available_capacity_gib) by (shard, backend, pool)) - count by (shard, backend) (sum by(shard, backend, pool) (cinder_virtual_free_capacity_gib) - sum by(shard, backend, pool) (cinder_per_volume_gigabytes) <=0) < 1
     for: 15m
     labels:
-      severity: critical
+      severity: info
       tier: vmware
       service: cinder
       support_group: compute
@@ -60,7 +60,7 @@ groups:
       count by (shard, backend) (sum(cinder_available_capacity_gib) by (shard, backend, pool)) - count by (shard, backend) (sum by(shard, backend, pool) (cinder_virtual_free_capacity_gib) - sum by(shard, backend, pool) (cinder_per_volume_gigabytes) <=0) < 2
     for: 15m
     labels:
-      severity: warning
+      severity: info
       tier: vmware
       service: cinder
       support_group: compute


### PR DESCRIPTION
This patch temporarily downgrades the  CinderShardMaxVolumeSize alerts to info.  We are going to test out stacking for 2 weeks in ap-cn-1 and see how it goes.  So for the duration we decided in the storage meeting to downgrade the max volume size alerts to info.