### PR TITLE
[ironic] Randomize job name

### DIFF
--- a/openstack/ironic/templates/api-deployment.yaml
+++ b/openstack/ironic/templates/api-deployment.yaml
@@ -35,7 +35,7 @@ spec:
 {{ tuple . "ironic" "api" | include "kubernetes_pod_anti_affinity" | indent 6 }}
       {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       initContainers:
-      {{- tuple . (dict "service" "ironic-mariadb,ironic-rabbitmq" "jobs" "ironic-db-migration") | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
+      {{- tuple . (dict "service" "ironic-mariadb,ironic-rabbitmq") | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
       - name: ironic-api
         image: {{ .Values.global.registry }}/loci-ironic:{{ .Values.imageVersion }}

--- a/openstack/ironic/templates/db-migration-job.yaml
+++ b/openstack/ironic/templates/db-migration-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: ironic-db-migration
+  name: ironic-db-migration-{{ randAlphaNum 4 }}
   labels:
     system: openstack
     type: job


### PR DESCRIPTION
If the job changes, it causes an error on validation with three-way merge, despite the job being marked as hook-delete-policy: before-hook-creation.
So, randomize the name to ensure there is no conflict.

Remove it as dependency from the api-deployment,
since that dependency is already solved
by helm itself (it won't apply the job, unless
the job has been executed successfully)