### PR TITLE
[nova] Switch nova-vspc version variable

### DIFF
--- a/openstack/nova/ci/test-values.yaml
+++ b/openstack/nova/ci/test-values.yaml
@@ -12,6 +12,7 @@ global:
   nova_service_password: topSecret
 
 imageVersion: myTag
+imageVersionVspc: vspc-latest-tag
 
 mariadb:
   root_password: rootroot

--- a/openstack/nova/templates/vspc-deployment.yaml
+++ b/openstack/nova/templates/vspc-deployment.yaml
@@ -31,7 +31,7 @@ spec:
       hostname: nova-vspc
       containers:
         - name: vmware-vspc
-          image: {{ required ".Values.global.registry is missing" .Values.global.registry}}/vmware-vspc:{{ .Values.vspc.version }}
+          image: {{ required ".Values.global.registry is missing" .Values.global.registry}}/vmware-vspc:{{ required ".Values.imageVersionVspc is missing" .Values.imageVersionVspc }}
           imagePullPolicy: IfNotPresent
           command: ['dumb-init', '--', 'vmware-vspc', '--config-file', '/etc/vspc.conf']
           env:

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -167,6 +167,8 @@ imageVersionNovaSpicehtml5proxy: null
 imageVersionNovaScheduler: null
 imageVersionBitnamiOpenResty: 1.21.4-1-debian-11-r57
 
+imageVersionVspc: null
+
 vspc:
   enabled: false
   telnet:
@@ -177,7 +179,6 @@ vspc:
     portExternal: 1334
   nodeIP: null
   url: vmware-vspc
-  version: "20210111143046"
   pvc:
     existingClaim: null
     accessMode: ReadWriteMany


### PR DESCRIPTION
Instead of using `vspc.version` we switch to using `imageVersionVspc`. We need to do this, because we want to use the automatic version transport of the shared pipeline to regularly get security updates in the image. The automatic version transport needs the version to be tracked in a variable adhering to a regex and being on the top level, which `vspc.version` both does not satisfy.