### PR TITLE
Adding capacity metrics

### DIFF
--- a/system/vmware-monitoring/templates/collector-configmap.yaml
+++ b/system/vmware-monitoring/templates/collector-configmap.yaml
@@ -114,6 +114,14 @@ data:
         key: "badge|efficiency"
       - metric_suffix: "badge_health_percentage"
         key: "badge|health"
+      - metric_suffix: "cpu_capacity_total"
+        key: "cpu|capacity_provisioned"
+      - metric_suffix: "memory_capacity_total"
+        key: "mem|host_provisioned"
+      - metric_suffix: "configuration_dasConfig_admissionControlPolicy_cpu_failover_resource_percent"
+        key: "configuration|dasconfig|adminissionControlPolicy|cpuFailoverResourcesPercent"
+      - metric_suffix: "configuration_dasConfig_admissionControlPolicy_memory_failover_resource_percent"
+        key: "configuration|dasconfig|adminissionControlPolicy|memoryFailoverResourcesPercent"
 
     DistributedvSwitchPropertiesCollector:
     # INFO - Prefix: vrops_distributed_virtual_switch_


### PR DESCRIPTION
Capacity metrics needed for "Percent Cluster Resource" admission control policy.