### PR TITLE
[neutron] Quicker deployments through adjusting maxSurge/Unavailable

### DIFF
--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -37,8 +37,8 @@ pod:
         revision_history: 5
         pod_replacement_strategy: RollingUpdate
         rolling_update:
-          max_unavailable: 0
-          max_surge: 1
+          max_unavailable: 10%
+          max_surge: 25%
   debug:
     server: false
     dhcp_agent: false


### PR DESCRIPTION
Our neutron deployments often time out. Let's assume all neutron-server pods are not completely busy at the time of deployment we can try to replace multiple pods at the same time.

Refresher:
`maxUnavailable` is an optional field that specifies the maximum number of Pods that can be unavailable during the update process. `maxSurge` is an optional field that specifies the maximum number of Pods that can be created over the desired number of Pods.

With maxUnavailble = 10% we cut out 10% of our capacity and hence roll over quicker. On top of that we can borrow some control plane resources during the deployment with maxSurge set to 25%. In conjunction, that allows us to roll 35% of our servers at the same time.