### PR TITLE
[openstack/nova] Change misleading rabbitmq-defaults

### DIFF
--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -773,7 +773,7 @@ mariadb_cell2:
     support_group: compute-storage-api
 
 rabbitmq_cell2:
-  name: nova-cell2
+  nameOverride: cell2-rabbitmq
   persistence:
     enabled: false
 
@@ -795,7 +795,6 @@ audit:
   metrics_enabled: true
 
 rabbitmq:
-  name: nova
   users:
     default:
       password: null


### PR DESCRIPTION
The .name value is not evaluated by the rabbitmq chart, so remove it, or replace it with nameOverride in cell2, where we need a sensible value