### PR TITLE
Mitigate hanging datapath jobs

### DIFF
--- a/openstack/cc3test/templates/cronjob-datapath.yaml
+++ b/openstack/cc3test/templates/cronjob-datapath.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Values.cc3test.namespace }}
 spec:
   schedule: "*/5 * * * *"
-  concurrencyPolicy: Forbid
+  concurrencyPolicy: Replace
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 1
   jobTemplate:


### PR DESCRIPTION
Tests were not executed due to a hanging job/pod: https://grafana.ap-cn-1.cloud.sap/d/cc3test-overview/cc3test-overview?orgId=1&var-service=neutron&from=1683669600000&to=1683842399000