### PR TITLE
[sap-seeds] Set disk for "forced" flavor to 1 GiB

### DIFF
--- a/openstack/sap-seeds/templates/flavor-seed.yaml
+++ b/openstack/sap-seeds/templates/flavor-seed.yaml
@@ -10,7 +10,7 @@ spec:
     id: "1"
     vcpus: 1
     ram: 1024
-    disk: 0
+    disk: 1
     is_public: false
     extra_specs:
       {{- tuple . "forced" | include "sap_seeds.helpers.extra_specs" | indent 6 }}


### PR DESCRIPTION
The current Openstack-Seeder cannot deal with zero-sized disks because it treats 0 as "empty" and prunes the key from the input flavor spec.

As a band-aid we set disk-size to 1 GiB for the KVM testing flavor, but this needs to be reverted before the rollout of KVM since KVM flavors shouldn't have ephemeral root disks at all.
