### PR TITLE
parser for monitoring zmq errors on aci leaf switches

### DIFF
--- a/prometheus-exporters/network-generic-ssh-exporter/templates/_config.yaml.tpl
+++ b/prometheus-exporters/network-generic-ssh-exporter/templates/_config.yaml.tpl
@@ -17,6 +17,29 @@ lookup_sources:
       router_project: SELECT DISTINCT id, project_id FROM neutron.routers
 
 metrics:
+  zmq_rx_error:
+    regex: >-
+      ^ZmQ\:\s*RX\sCNT\:\s\d+\,\sBYTES\:\s\d+\,\sERRORS\:\s(\d*)
+    multi_value: true
+    value: $1
+    labels:
+      errors: $1  
+    description: check for zmq rx errors
+    metric_type_name: gauge
+    command: show system internal epm counters zmq
+    timeout_secs: 5
+  zmq_tx_error:
+    regex: >-
+      ^ZmQ\:\s*TX\sCNT\:\s\d+\,\sBYTES\:\s\d+\,\sERRORS\:\s(\d*)
+    multi_value: true
+    value: $1
+    labels:
+      errors: $1  
+    description: check for zmq tx errors
+    metric_type_name: gauge
+    command: show system internal epm counters zmq
+    timeout_secs: 5
+
   xr_tcam_learn_disabled: &xr_tcam_learn_disabled
     regex: |
       ^Xr tcam limit learn disabled\s*:\s+(\w+)$
@@ -653,6 +676,8 @@ batches:
     - xr_tcam_learn_disabled
     - hal_learn_disabled
     - epm_pending_epreg
+    - zmq_rx_error
+    - zmq_tx_error
   neutron-router:
     - nat_dynamic
     - nat_static

--- a/prometheus-exporters/network-generic-ssh-exporter/templates/_config.yaml.tpl
+++ b/prometheus-exporters/network-generic-ssh-exporter/templates/_config.yaml.tpl
@@ -17,26 +17,15 @@ lookup_sources:
       router_project: SELECT DISTINCT id, project_id FROM neutron.routers
 
 metrics:
-  zmq_rx_error:
+  zmq_errors:
     regex: >-
-      ^ZmQ\:\s*RX\sCNT\:\s\d+\,\sBYTES\:\s\d+\,\sERRORS\:\s(\d*)
+      ^ZmQ\:\s*(RX|TX)\sCNT\:\s\d+\,\sBYTES\:\s\d+\,\sERRORS\:\s(\d*)
     multi_value: true
-    value: $1
+    value: $2
     labels:
-      errors: $1  
-    description: check for zmq rx errors
-    metric_type_name: gauge
-    command: show system internal epm counters zmq
-    timeout_secs: 5
-  zmq_tx_error:
-    regex: >-
-      ^ZmQ\:\s*TX\sCNT\:\s\d+\,\sBYTES\:\s\d+\,\sERRORS\:\s(\d*)
-    multi_value: true
-    value: $1
-    labels:
-      errors: $1  
-    description: check for zmq tx errors
-    metric_type_name: gauge
+      direction: $1
+    description: check for zmq  errors
+    metric_type_name: counter
     command: show system internal epm counters zmq
     timeout_secs: 5
 
@@ -676,8 +665,7 @@ batches:
     - xr_tcam_learn_disabled
     - hal_learn_disabled
     - epm_pending_epreg
-    - zmq_rx_error
-    - zmq_tx_error
+    - zmq_errors
   neutron-router:
     - nat_dynamic
     - nat_static


### PR DESCRIPTION
adding parser for ssh exporter to monitor tx/rx errors captured via command 'show system internal epm counters zmq' on aci leaf switches