### PR TITLE
[F5 alerts] - raise f5 sync-failed alert severity and delay

### DIFF
--- a/prometheus-exporters/snmp-exporter/alerts/f5.alerts
+++ b/prometheus-exporters/snmp-exporter/alerts/f5.alerts
@@ -73,16 +73,16 @@ groups:
           summary: "F5 - high utilization of the \"/var/log\" directory."
       - alert: NetworkF5SyncFailed
         expr: snmp_f5_sysCmSyncStatusStatus{module="f5customer", snmp_f5_sysCmSyncStatusStatus="Sync Failed"}
-        for: 10m
+        for: 15m
         labels:
           context: f5
           meta: "Big-IP device {{ $labels.devicename }} reports config-sync failure."
           service: f5
-          severity: info
+          severity: warning
           tier: net
         annotations:
           description: Big-IP device {{ $labels.devicename }} reports config sync failure. See the exact reason on the device itself and resolve.
-          summary: Configuration failed to synchronize
+          summary: Active Big-IP configuration failed to synchronize to standby device.
       - alert: NetworkF5PoolsFlapping
         expr: (ceil((count by (devicename) (changes(snmp_f5_ltmPoolStatusAvailState[10m]) > 5) / sum by (devicename) (snmp_f5_ltmPoolNumber)) * 100)) > 50
         for: 5m


### PR DESCRIPTION
The existing `NetworkF5SyncFailed` alert was left at the initial severity `info` and forgotten to be raised to `warning`.
The sync-failed condition is severe and needs to be treated accordingly, hence severity `warning` should be the minimal one.
At the same time, I am raising the trigger delay to 15 minutes, to allow more that enough time for Octavia sync mechanism to finish synchronizing the database to the Big-IP devices.

FYI:
@artherd42, @BenjaminLudwigSAP 

Part of existing issue sapcc/octavia-f5-provider-driver#226
