### PR TITLE
prombump, bringing back hw metrics

### DIFF
--- a/system/infra-monitoring/Chart.lock
+++ b/system/infra-monitoring/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: prometheus-server
   repository: https://charts.eu-de-2.cloud.sap
-  version: 7.1.39
+  version: 7.2.5
 - name: kube-state-metrics-exporter
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.9
@@ -41,5 +41,5 @@ dependencies:
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:e1c66085f49cfc6a5324503b33ed252ac1d497e194618f6ed855731e3c58fcf1
-generated: "2023-03-15T15:39:40.951223+01:00"
+digest: sha256:95406fdab1968ef5e2a54cd703f0e6c5600c13e543cb7ddff155a2e81b123bf2
+generated: "2023-05-22T11:32:08.724349+02:00"

--- a/system/infra-monitoring/Chart.yaml
+++ b/system/infra-monitoring/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
 name: infra-monitoring
-version: 1.4.0
+version: 1.4.1
 description: Prometheus Infrastructure Monitoring and Metrics Collection
 dependencies:
   - name: prometheus-server
     alias: prometheus_infra_collector
     repository: https://charts.eu-de-2.cloud.sap
-    version: 7.1.39
+    version: 7.2.5
     condition: prometheus_infra_collector.enabled
 
   - name: kube-state-metrics-exporter

--- a/system/infra-monitoring/ci/test-values.yaml
+++ b/system/infra-monitoring/ci/test-values.yaml
@@ -1,2 +1,4 @@
+global:
+  region: bogus
 prometheus-server:
   name: ci-test-name

--- a/system/infra-monitoring/templates/_prometheus-infra-collector.yaml.tpl
+++ b/system/infra-monitoring/templates/_prometheus-infra-collector.yaml.tpl
@@ -28,9 +28,6 @@
     - source_labels: [job]
       regex: asw-eapi
       action: keep
-    - source_labels: [__name__]
-      regex: '!arista_port_stats'
-      action: keep
     - source_labels: [__address__]
       target_label: __param_target
     - source_labels: [__param_target]
@@ -216,9 +213,6 @@
     - url: {{ .Values.atlas_url }}
   metrics_path: /ipmi
   relabel_configs:
-    - source_labels: [__name__]
-      regex: '!ipmi_temperature_state'
-      action: keep
     - source_labels: [job]
       regex: vmware-esxi
       action: keep


### PR DESCRIPTION
* metrics were previously dropped to ensure a stable environment (high cardinality, low resources available)
* technically reverts #a88e363 #062a6e5, additionally to #3cd790f