### PR TITLE
gatekeeper: improve owner-info check

### DIFF
--- a/common/owner-info/README.md
+++ b/common/owner-info/README.md
@@ -38,7 +38,7 @@ The following fields can appear within the `owner-info` section of your chart's 
 | --------- | --------- | ----------- |
 | `helm-chart-url` | **yes** | An HTTP(S) URL describing where to find the Helm chart in GitHub etc., e.g. `https://github.com/sapcc/helm-charts/tree/master/common/owner-info`. |
 | `maintainers` | no | List of people that maintain the Helm chart. If multiple people can help with issues regarding the chart, feel free to include as many names as you like. The list should be ordered by priority, i.e. the primary maintainer should be at the top. |
-| `support-group` | **yes** | For routing alerts/tickets regarding this deployment to the right support group. |
-| `service` | no | Allows sorting alerts/tickets within the realm of a single support group. |
+| `support-group` | **yes** | Associates this deployment with the respective support group. This is used for routing generic Kubernetes alerts (pod not ready, PVC nearly full, etc.), for measuring resource consumption by support group and service, for delivering DOOP violations, and many other things. |
+| `service` | no | A subclassification for alerts, tickets, policy violations, resource consumption, etc. within the realm of a single support group. |
 
 The values for `support-group` and `service` will be carried over into all Kubernetes objects belonging to the Helm release (both directly and indirectly), and appear in `.metadata.labels["ccloud/support-group"]` and `.metadata.labels["ccloud/service"]`, respectively. This mapping is automatically performed by the owner-label-injector component.

--- a/system/gatekeeper-config/templates/constraint-owner-info-on-helm-releases.yaml
+++ b/system/gatekeeper-config/templates/constraint-owner-info-on-helm-releases.yaml
@@ -7,7 +7,19 @@ metadata:
   labels:
     on-prod-ui: 'true'
 spec:
-  enforcementAction: dryrun # set to 'deny' to enforce
+  enforcementAction: {{ if eq .Values.cluster_layer "qa" }}deny{{ else }}dryrun{{ end }}
   match: {{ include "match_active_helm_releases" . | indent 4 }}
   parameters:
     helmManifestParserURL: {{ quote .Values.helm_manifest_parser_url }}
+    knownBrokenReleases:
+      # This is a list of Helm releases (in the format "namespace/name") that
+      # are TEMPORARILY exempted from the owner-info requirement because
+      # their owners do not belong to a support group yet.
+      #
+      # When adding entries, add a comment with the date of inclusion in the
+      # list and the responsible owners for that deployment. We will use this
+      # to regularly follow up with the service owners to check on the state of
+      # their support group assignment.
+      {{- if eq .Values.cluster_type "test" }}
+      - testing/known-broken # used for testing the exception mechanism
+      {{- end }}

--- a/system/gatekeeper/templates/constrainttemplate-owner-info-on-helm-releases.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-owner-info-on-helm-releases.yaml
@@ -14,6 +14,10 @@ spec:
           properties:
             helmManifestParserURL:
               type: string
+            knownBrokenReleases:
+              type: array
+              items:
+                type: string
 
   targets:
     - target: admission.k8s.gatekeeper.sh
@@ -46,10 +50,14 @@ spec:
         violation[{"msg": add_support_labels.from_helm_release(release, msg)}] {
           release.error == ""
 
-          # Check if an 'owner-of-<release-name>' ConfigMap exists for this release.
+          # Complain if no 'owner-of-<release-name>' ConfigMap exists for this release.
           count(configmaps) == 0
-          release_name := iro.metadata.labels.name
-          msg := sprintf("could not find ConfigMap: %s", [configmap_name])
+
+          # Do not complain if this release is part of the knownBrokenReleases.
+          key := sprintf("%s/%s", [iro.metadata.namespace, iro.metadata.labels.name])
+          count({ k | k := input.parameters.knownBrokenReleases[_]; k == key }) == 0
+
+          msg := "Chart does not contain owner info. Please add the common/owner-info chart as a direct dependency."
         }
 
         violation[{"msg": add_support_labels.from_helm_release(release, msg)}] {

--- a/system/gatekeeper/tests/fixtures/owner-info-on-helm-releases/configmap-no-owner-but-allowlisted.in.yaml
+++ b/system/gatekeeper/tests/fixtures/owner-info-on-helm-releases/configmap-no-owner-but-allowlisted.in.yaml
@@ -1,0 +1,16 @@
+metadata:
+  name: known-broken
+  namespace: testing
+  status: deployed
+owner-info: null # we test with an explicit owner-info ConfigMap here
+
+items:
+  - apiVersion: v1
+    data:
+      maintainers: Jon Doe, Max Mustermann
+    kind: ConfigMap
+    metadata:
+      labels:
+        owner-info-version: 0.2.0
+      namespace: testing
+      name: something-else # !!!

--- a/system/gatekeeper/tests/suite.yaml
+++ b/system/gatekeeper/tests/suite.yaml
@@ -308,12 +308,12 @@ tests:
     object: fixtures/owner-info-on-helm-releases/configmap-no-owner.out.yaml
     assertions:
     - violations: 1
-      message: '^support-group=none,service=none: could not find ConfigMap: owner-of-almost-empty-chart$'
+      message: '^support-group=none,service=none: Chart does not contain owner info. Please add the common/owner-info chart as a direct dependency.$'
   - name: configmap-no-owner-pending-upgrade
     object: fixtures/owner-info-on-helm-releases/configmap-no-owner-pending-upgrade.out.yaml
     assertions:
     - violations: 1
-      message: '^support-group=none,service=none: could not find ConfigMap: owner-of-almost-empty-chart$'
+      message: '^support-group=none,service=none: Chart does not contain owner info. Please add the common/owner-info chart as a direct dependency.$'
   - name: configmap-no-owner-superseded
     object: fixtures/owner-info-on-helm-releases/configmap-no-owner-superseded.out.yaml
     assertions:
@@ -323,6 +323,10 @@ tests:
     assertions:
     - violations: 1
       message: '^support-group=none,service=none: Chart uses outdated owner-info version "0.1.2". Please update to at least "0.2.0".$'
+  - name: pod-owner-info
+    object: fixtures/owner-info-on-helm-releases/configmap-no-owner-but-allowlisted.out.yaml
+    assertions:
+    - violations: no
   - name: pod-owner-info
     object: fixtures/owner-info-on-helm-releases/configmap-pass.out.yaml
     assertions:


### PR DESCRIPTION
- clarify error message for missing owner-info
- update documentation on owner-info chart
- enforce in QA clusters to force people to add owner-info everywhere
- add an exemption mechanism, because I know how these exercises tend to go 😑