### PR TITLE
ipmi-exporter: move metal-esxi alerts to thanos-ruler regional

### DIFF
--- a/prometheus-exporters/ipmi-exporter/Chart.yaml
+++ b/prometheus-exporters/ipmi-exporter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: ipmi-exporter
-version: 0.1.0
+version: 0.1.1
 maintainers:
   - name: Stefan Hipfel (D058695)

--- a/prometheus-exporters/ipmi-exporter/alerts/metal-esxi.alerts
+++ b/prometheus-exporters/ipmi-exporter/alerts/metal-esxi.alerts
@@ -1,3 +1,5 @@
+# metal-esxi alerts, which combine metrics from infra-collector and vmware, are available from the thanos regional query.
+#
 # The metric vrops_hostsystem_runtime_maintenancestate indicates in the propkey label if a hypervisor is in maintenance.
 # It can be used in two ways:
 # 1.) use the value and a regex

--- a/prometheus-exporters/ipmi-exporter/templates/alerts.yaml
+++ b/prometheus-exporters/ipmi-exporter/templates/alerts.yaml
@@ -10,8 +10,12 @@ metadata:
   name: {{ printf "%s" $path | replace "/" "-" }}
   labels:
     type: alerting-rules
+  {{- if contains "metal-esxi" $path }}
+    # metal-esxi alerts, which combine metrics from infra-collector and vmware, are available from the thanos regional query.
+    thanos-ruler: regional
+  {{- else }}
     prometheus: {{ required "$values.prometheus missing" $values.prometheus }}
-
+  {{- end }}
 spec:
 {{ printf "%s" $bytes | indent 2 }}
 


### PR DESCRIPTION
The newly introduced Thanos Rule component is intended to allow the evaluation of Prometheus Rules across multiple Prometheis. In this case, metrics from the infra-collector and the numerous vmware Prometheis are needed to evaluate the rules. Therefore, they are labeled on the regional Thanos Rule.