### PR TITLE
system/elastic: add sts metric to cluster yellow alert

### DIFF
--- a/system/elastiflow/alerts/elastiflow.alerts
+++ b/system/elastiflow/alerts/elastiflow.alerts
@@ -46,7 +46,7 @@ groups:
       summary: '*elastiflow* cluster in `{{ $labels.region }}` is RED'
 
   - alert: ElastiflowClusterYellow
-    expr: es_cluster_status{elastic_cluster="elastiflow",pod=~".*-master-0"} == 1
+    expr: es_cluster_status{elastic_cluster="elastiflow",pod=~".*-master-0"} == 1 and sum(kube_statefulset_replicas{statefulset=~"elastiflow.*"}) - sum(kube_statefulset_status_replicas_ready{statefulset=~"elastiflow.*"}) > 0
     for: 30m
     labels:
       context: nodes

--- a/system/elk/alerts/elk.alerts
+++ b/system/elk/alerts/elk.alerts
@@ -49,7 +49,7 @@ groups:
       summary: '*elkelasticsearch* cluster in `{{ $labels.region }}` is RED'
 
   - alert: ELKClusterYellow
-    expr: es_cluster_status{elastic_cluster="elkelasticsearch",pod=~".*-master-0"} == 1
+    expr: es_cluster_status{elastic_cluster="elkelasticsearch",pod=~".*-master-0"} == 1 and sum(kube_statefulset_replicas{statefulset=~"es.*"}) - sum(kube_statefulset_status_replicas_ready{statefulset=~"es.*"}) > 0
     for: 30m
     labels:
       context: nodes

--- a/system/opensearch-logs/alerts/opensearch.alerts
+++ b/system/opensearch-logs/alerts/opensearch.alerts
@@ -49,7 +49,7 @@ groups:
       summary: '*opensearch-logs* cluster in `{{ $labels.region }}` is RED'
 
   - alert: OpensearchLogsClusterYellow
-    expr: opensearch_cluster_status{elastic_cluster="opensearch-logs",pod=~".*-master-0"} == 1
+    expr: opensearch_cluster_status{elastic_cluster="opensearch-logs",pod=~".*-master-0"} == 1 and sum(kube_statefulset_replicas{statefulset=~"opensearch-logs.*"}) - sum(kube_statefulset_status_replicas_ready{statefulset=~"opensearch-logs.*"}) > 0
     for: 30m
     labels:
       context: nodes


### PR DESCRIPTION
the alert is firing often in the last weeks due to node
maintenance in the region. Yellow status of the cluster
itself is not so problematic, as the cluster is able to
resync. If one or more nodes is also facing volume attach
issues then this can become a problem.
This additional condition should improve this alert, as
the OnDuty only needs to check once the cluster is actually
missing elastic cluster nodes.
