### PR TITLE
[openstack/utils] Templates to spread pods across AZs

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.9.2
+version: 0.9.3

--- a/openstack/utils/templates/_affinity.tpl
+++ b/openstack/utils/templates/_affinity.tpl
@@ -32,10 +32,10 @@ affinity:
       - weight: 1
         preference:
           matchExpressions:
-            - key: "failure-domain.beta.kubernetes.io/zone"
+            - key: "{{ .Values.global.topology_key }}"
               operator: In
               values:
-                - {{$availability_zone}}
+                - {{ $availability_zone }}
 {{- end }}
 
 {{- define "kubernetes_maintenance_affinity" }}

--- a/openstack/utils/templates/_topology.tpl
+++ b/openstack/utils/templates/_topology.tpl
@@ -1,0 +1,57 @@
+{{/*
+  Topology constraints to spread nodes across azs to ensure the
+  service being up even in the face of an az being down
+*/}}
+
+{{/* "utils.topology.constraints"
+  Deployment: .spec.template.spec
+  I.e.
+  spec:
+    {{-  include "utils.topology.constraints" . | indent 2 }}
+    */}}
+{{- define "utils.topology.constraints" }}
+topologySpreadConstraints:
+{{- include "utils.topology.az_spread" . }}
+{{- end }}
+
+{{/* "utils.topology.pod_label"
+  Deployment: .spec.template.metadata.labels
+  I.e.
+  metadata:
+    labels:
+      mylabel: myvalue
+      {{- include "utils.topology.pod_label" . | indent 4 }}
+
+ The scheduler needs to differentiate between the pods of the
+ old replicaset, which is being teared down, and the new one.
+ Prior kubernetes 1.27, that needs to be done explicitly, here
+ with the .Release.Revision.
+*/}}
+{{- define "utils.topology.pod_label" }}
+  {{- if semverCompare "< 1.27" .Capabilities.KubeVersion.Version }}
+release_revision: "{{ .Release.Revision }}"
+  {{- end }}
+{{- end }}
+
+{{/* "utils.topology.az_spread"
+  Just the portion for the az-spread, in case it needs
+  to be combined with some custom topologySpreadConstraints
+  */}}
+{{- define "utils.topology.az_spread" }}
+{{- $envAll := index . 0 }}
+{{- $labels := index . 1 }}
+- maxSkew: 1
+  topologyKey: "{{ $envAll.Values.global.topology_key }}"
+  whenUnsatisfiable: ScheduleAnyway
+  labelSelector:
+    matchLabels:
+  {{- range $k, $v := $labels }}
+      {{ $k }}: "{{ $v }}"
+  {{- end }}
+  {{- if semverCompare "< 1.27" $envAll.Capabilities.KubeVersion.Version }}
+      release_revision: "{{ $envAll.Release.Revision }}"
+  {{- else }}
+  matchLabelKeys:
+    - pod-template-hash
+  {{- end }}
+{{- end }}

--- a/openstack/utils/values.yaml
+++ b/openstack/utils/values.yaml
@@ -6,6 +6,7 @@
 global:
   user_suffix: ""
   master_password: ""
+  topology_key: "failure-domain.beta.kubernetes.io/zone"
 
 cors:
   # default headers. additional headers can be specified via {cors:


### PR DESCRIPTION
topologySpreadConstraints lets us define, how the pods should
be spread across different topologies, like nodes, racks, or in our case
(availability-)zones.

The topology key is by default the deprecated
"failure-domain.beta.kubernetes.io/zone", but can be switched via the
global value `.global.topology_key`.

By spreading the pods out, we reduce the risk of a downtime
due to all pods being affected by a problem in one zone.

The scheduler should handle it with best effort.

This also a preparation for [Topology Aware Routing](https://kubernetes.io/docs/concepts/services-networking/topology-aware-routing/),
when configured, would allow us prioritize communication within a zone.

But for that to make even sense, the (usually api) nodes
need to be spread out a bit.
