### PR TITLE
common/thanos: external rule labels added

### DIFF
--- a/common/thanos/Chart.yaml
+++ b/common/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: Deploy Thanos via operator
 type: application
-version: 0.3.4
+version: 0.3.5
 appVersion: v0.28.1
 maintainers:
   - name: Tommy Sauer (viennaa)

--- a/common/thanos/templates/ruler/ruler.yaml
+++ b/common/thanos/templates/ruler/ruler.yaml
@@ -30,6 +30,12 @@ spec:
   # Select rules from all namespaces.
   ruleNamespaceSelector: {}
 
+  # The labels to add to any alert when communicating with Alertmanager
+  labels:
+    region: {{ required ".Values.global.region missing" $.Values.global.region }}
+    cluster: {{ if $.Values.global.cluster }}{{ $.Values.global.cluster }}{{ else }}{{ $.Values.global.region }}{{ end }}
+    cluster_type: {{ required ".Values.global.clusterType missing" $.Values.global.clusterType }}
+
   alertQueryUrl: https://{{ include "thanos.externalURL" (list $name $root) }}
 {{ if required "$.Values.ruler.alertmanagers.hosts missing" $.Values.ruler.alertmanagers.hosts }}
   # Alertmanager configuration.


### PR DESCRIPTION
External labels are needed for the Thanos Rule to get alerts routed properly.