### PR TITLE
[maia] Drop space saving metrics for Manila shares

### DIFF
--- a/openstack/maia/templates/etc/_maia_scrape_config.yaml.tpl
+++ b/openstack/maia/templates/etc/_maia_scrape_config.yaml.tpl
@@ -159,7 +159,7 @@
       action: labeldrop
     - action: drop
       source_labels: [__name__]
-      regex: netapp_volume_saved_.*
+      regex: netapp_volume_.*saved_.*
     - source_labels: [__name__]
       target_label: __name__
       regex: netapp_volume_(.*)


### PR DESCRIPTION
Following metrics are for monitoring purposes and should not be exposed to customers. Old drop rules are not working correctly.

netapp_volume_compression_saved_bytes{}
netapp_volume_compression_saved_percentage{}
netapp_volume_deduplication_saved_bytes{}
netapp_volume_deduplication_saved_percentage{}
netapp_volume_total_saved_bytes{}
netapp_volume_total_saved_percentage{}