### PR TITLE
[maia] aggregate Manila share used bytes with logical used bytes

### DIFF
--- a/openstack/maia/templates/etc/_maia_scrape_config.yaml.tpl
+++ b/openstack/maia/templates/etc/_maia_scrape_config.yaml.tpl
@@ -131,10 +131,6 @@
     - source_labels: [ltmVirtualServStatName]
       target_label: listener_id
       regex: /net_.*/lb_.*/listener_(.*)
-    - source_labels: [__name__]
-      target_label: __name__
-      regex: netapp_volume_(.*)
-      replacement: openstack_manila_share_${1}
 
   metrics_path: '/federate'
   params:
@@ -145,9 +141,6 @@
       - '{__name__=~"^ssh_nat_limits_miss", project_id!=""}'
       - '{__name__=~"^ssh_nat_limits_use", project_id!=""}'
       - '{__name__=~"^snmp_asr_ifHC.+", project_id!=""}'
-      - '{__name__=~"^netapp_capacity_.+", project_id!=""}'
-      - '{__name__=~"^netapp_volume_.+", app="netapp-capacity-exporter-manila", project_id!=""}'
-      - '{__name__=~"^openstack_manila_share_.+", project_id!=""}'
 
 - job_name: 'prometheus-storage'
   scrape_interval: 1m

--- a/openstack/maia/templates/etc/_maia_scrape_config.yaml.tpl
+++ b/openstack/maia/templates/etc/_maia_scrape_config.yaml.tpl
@@ -160,6 +160,13 @@
     - action: drop
       source_labels: [__name__]
       regex: netapp_volume_saved_.*
+    - action: drop
+      source_labels: [__name__]
+      regex: netapp_volume_used_bytes
+    - source_labels: [__name__]
+      target_label: __name__
+      regex: netapp_volume_used_bytes:customer
+      replacement: openstack_manila_share_used_bytes
     - source_labels: [__name__]
       target_label: __name__
       regex: netapp_volume_(.*)

--- a/openstack/maia/templates/etc/_maia_scrape_config.yaml.tpl
+++ b/openstack/maia/templates/etc/_maia_scrape_config.yaml.tpl
@@ -176,10 +176,7 @@
   params:
     'match[]':
       # import any tenant-specific metric, except for those which already have been imported
-      # filter for ltmVirtualServStatName to be present as it relabels into project_id. It gets enriched by "openstack/maia/aggregations/snmp-f5.rules with the openstack metric openstack_neutron_networks_projects"
-      - '{__name__=~"^netapp_capacity_.+", project_id!=""}'
       - '{__name__=~"^netapp_volume_.+", app="netapp-capacity-exporter-manila", project_id!=""}'
-      - '{__name__=~"^openstack_manila_share_.+", project_id!=""}'
 
 
 # iteration over vmware-monitoring values

--- a/prometheus-exporters/netapp-exporter/charts/netapp-cap-exporter/aggregations/netapp-cap.rules
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-cap-exporter/aggregations/netapp-cap.rules
@@ -34,3 +34,5 @@ groups:
   - record: netapp_aggregate_used_percentage:vpod:big
     expr: netapp_aggregate_used_percentage * netapp_aggregate_total_bytes / on (aggregate, availability_zone, filer, node) netapp_aggregate_total_bytes:vpod:big
 
+  - record: netapp_volume_used_bytes:customer
+    expr: (netapp_volume_logical_used_bytes{app="netapp-capacity-exporter-manila"} and (netapp_volume_is_space_reporting_logical == 1)) or netapp_volume_used_bytes{app="netapp-capacity-exporter-manila"}


### PR DESCRIPTION
The metrics should report sizes that are consistent with `df` on the client side. For volumes/shares that have logical space reporting/enforcement enabled, the metrics openstack_manila_share_used_bytes should report the logical used bytes.