### PR TITLE
[neutron] Assume NSX-T Always Enabled

### DIFF
--- a/openstack/neutron/templates/vct-nsxv3-agent-configmap.yaml
+++ b/openstack/neutron/templates/vct-nsxv3-agent-configmap.yaml
@@ -9,7 +9,6 @@ options:
     variable_start_string: '{='
     variable_end_string: '=}'
 template: |
-  {% if nsx_t_enabled is defined and nsx_t_enabled -%}
   apiVersion: v1
   kind: ConfigMap
   metadata:
@@ -52,5 +51,4 @@ template: |
       {{- range $k, $v := .Values.drivers.nsxv3.defaults.NSXV3 }}
       {{ $k }} = {{ $v }}
       {{- end }}
-  {% endif %}
 {{ end }}

--- a/openstack/neutron/templates/vct-nsxv3-agent-deployment.yaml
+++ b/openstack/neutron/templates/vct-nsxv3-agent-deployment.yaml
@@ -9,7 +9,6 @@ options:
     variable_start_string: '{='
     variable_end_string: '=}'
 template: |
-  {% if nsx_t_enabled is defined and nsx_t_enabled -%}
   apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -127,5 +126,4 @@ template: |
                 items:
                 - key: ml2-nsxv3.ini
                   path: plugins/ml2/ml2-nsxv3.ini
-  {% endif %}
 {{- end }}


### PR DESCRIPTION
The NSX-t/v driver is the only option we currently have, so drop the check. This means less dependencies between the vcenter-operator and the chart.