### PR TITLE
[cinder] Update mariadb chart to 0.7.8

### DIFF
--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.7.4
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.5
+  version: 0.7.8
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.7
@@ -20,5 +20,5 @@ dependencies:
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:25763d32d1a1bb3557906e65621f31311826583d544bf456ea4e15bae5303393
-generated: "2023-03-28T15:29:15.959509435+02:00"
+digest: sha256:8467ab198ec11f7c1192feca617d93cd8badf9c22b95ca200efe3b3d319a9b73
+generated: "2023-05-31T09:26:21.715607-04:00"

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
     version: 0.7.4
   - name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.7.5
+    version: 0.7.8
     condition: mariadb.enabled
   - name: mysql_metrics
     repository: https://charts.eu-de-2.cloud.sap


### PR DESCRIPTION
This patch updates cinder's mariadb chart to help fix some false positive alerts for slow db queries.