### PR TITLE
[nova] Add api_database config to nova-cell2.conf

### DIFF
--- a/openstack/nova/templates/etc/_nova-cell2.conf.tpl
+++ b/openstack/nova/templates/etc/_nova-cell2.conf.tpl
@@ -3,5 +3,7 @@
 [DEFAULT]
 transport_url = {{ include "cell2_transport_url" . }}
 
+{{- include "nova.helpers.ini_sections.api_database" . }}
+
 [database]
 connection = {{ include "cell2_db_path" . }}


### PR DESCRIPTION
With moving the database configuration for the non-cell2 use-case into the `nova-etc` secret, we left the cell2-using services without an `[api_database]` config section. This prohibited `nova-conductor` from properly fulfilling request for the `nova-compute` depending on it.