### PR TITLE
[placement] Topology aware scheduling and spreading

### DIFF
--- a/openstack/placement/Chart.lock
+++ b/openstack/placement/Chart.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 0.1.0
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.9.0
+  version: 0.10.0
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:8b42fbf2c337b7d14ce5e2e7b7e4d98a43c979962d945683bb850a7ad5fe70ca
-generated: "2023-05-02T15:30:06.300376867+02:00"
+digest: sha256:47c21926c21bc8df748ec2322dd66084f34b541f1d7957207cad7c05038da5f9
+generated: "2023-06-01T10:29:10.272544602+02:00"

--- a/openstack/placement/Chart.yaml
+++ b/openstack/placement/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
     version: 0.1.0
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.9.0
+    version: ~0.10.0
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0

--- a/openstack/placement/ci/test-values.yaml
+++ b/openstack/placement/ci/test-values.yaml
@@ -7,7 +7,7 @@ global:
 
   placement_service_password: verySecret
   dbBackupServicePassword: topSecret
-
+  availability_zones: []
 
 imageVersion: myTag
 

--- a/openstack/placement/templates/placement-api-deployment.yaml
+++ b/openstack/placement/templates/placement-api-deployment.yaml
@@ -24,7 +24,8 @@ spec:
     metadata:
       labels:
         name: placement-api
-{{ tuple . "placement" "api" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
+        {{ tuple . "placement" "api" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | nindent 8 }}
+        {{- include "utils.topology.pod_label" . | indent 8 }}
         alert-tier: os
         alert-service: nova
       annotations:
@@ -34,7 +35,8 @@ spec:
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
         {{- end }}
     spec:
-{{ tuple . "placement" "api" | include "kubernetes_pod_anti_affinity" | indent 6 }}
+      {{ tuple . "placement" "api" | include "kubernetes_pod_anti_affinity" | nindent 6 }}
+      {{- tuple . (dict "name" "placement-api") | include "utils.topology.constraints" | indent 6 }}
       {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       initContainers:
       {{- tuple . (dict "service" (include "db_name" .) "jobs" (tuple . "db-migrate" | include "job_name") ) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}

--- a/openstack/placement/templates/placement-api-service.yaml
+++ b/openstack/placement/templates/placement-api-service.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 
 metadata:
   name: placement-api
+  annotations:
+  {{- include "utils.topology.service_topology_mode" . | indent 2 }}
   labels:
     system: openstack
     type: api


### PR DESCRIPTION
Use topologySpreadConstraints to spread the api pods over the zones in a best effort manner to improve the situation in the situation of a zone is down (kubernetes may not rebalance, or cannot due to inbalance)

Use topology aware routing service-annotation to make use of the distributed placement and prefer communicating to nodes in the same AZ

In regions with a single AZ, the annoations are not set.