### PR TITLE
[cinder] Topology aware scheduling and spreading + AZ update

### DIFF
--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.4
+  version: 0.10.0
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.7.8
@@ -20,5 +20,5 @@ dependencies:
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:8467ab198ec11f7c1192feca617d93cd8badf9c22b95ca200efe3b3d319a9b73
-generated: "2023-05-31T09:26:21.715607-04:00"
+digest: sha256:dd0613c0e7138681826ac6115fa12924a4c72bd4cdcd888f45546cc8e6942cb2
+generated: "2023-06-01T11:17:28.591704219+02:00"

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.1.1
 dependencies:
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.7.4
+    version: ~0.10.0
   - name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.7.8

--- a/openstack/cinder/templates/api-deployment.yaml
+++ b/openstack/cinder/templates/api-deployment.yaml
@@ -24,7 +24,8 @@ spec:
     metadata:
       labels:
         name: cinder-api
-{{ tuple . "cinder" "api" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
+        {{- tuple . "cinder" "api" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | nindent 8 }}
+        {{- include "utils.topology.pod_label" . | indent 8 }}
       annotations:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
         {{- if .Values.proxysql.mode }}
@@ -32,8 +33,9 @@ spec:
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
         {{- end }}
     spec:
-{{ tuple . "cinder" "api" | include "kubernetes_pod_anti_affinity" | indent 6 }}
-{{ include "utils.proxysql.pod_settings" . | indent 6 }}
+      {{- tuple . "cinder" "api" | include "kubernetes_pod_anti_affinity" | nindent 6 }}
+      {{- include "utils.proxysql.pod_settings" . | nindent 6 }}
+      {{- tuple . (dict "name" "cinder-api") | include "utils.topology.constraints" | indent 6 }}
       containers:
         - name: cinder-api
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{.Values.imageVersionCinderApi | default .Values.imageVersion | required "Please set cinder.imageVersion or similar" }}

--- a/openstack/cinder/templates/api-service.yaml
+++ b/openstack/cinder/templates/api-service.yaml
@@ -11,6 +11,7 @@ metadata:
     prometheus.io/scrape: "true"
     maia.io/scrape: "true"
     prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
+    {{- include "utils.topology.service_topology_mode" . | indent 2 }}
 spec:
   selector:
     name: cinder-api

--- a/openstack/cinder/templates/backup_deployment.yaml
+++ b/openstack/cinder/templates/backup_deployment.yaml
@@ -34,7 +34,7 @@ template: |
       metadata:
         labels:
           name: cinder-volume-backup-vmware-{= name =}
-{{ tuple . "cinder" "volume-backup-vmware" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 10 }}
+          {{- tuple . "cinder" "volume-backup-vmware" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | nindent 10 }}
         annotations:
           vcenter: {= host =}
           datacenter: {= availability_zone =}
@@ -44,7 +44,8 @@ template: |
           {{- end }}
       spec:
         hostname: cinder-volume-backup-vmware-{= name =}
-{{ include "utils.proxysql.pod_settings" . | indent 8 }}
+        {{- include "utils.proxysql.pod_settings" . | nindent 8 }}
+        {{- tuple . "{= availability_zone =}" | include "utils.kubernetes_pod_az_affinity" | nindent 8 }}
         containers:
         - name: cinder-volume-backup-vmware-{= name =}
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{.Values.imageVersionCinderVolumeBackup | default .Values.imageVersion | required "Please set cinder.imageVersion or similar" }}

--- a/openstack/cinder/templates/vcenter_datacenter_cinder_deployment.yaml
+++ b/openstack/cinder/templates/vcenter_datacenter_cinder_deployment.yaml
@@ -34,7 +34,7 @@ template: |
       metadata:
         labels:
           name: cinder-volume-vmware-{= name =}
-{{ tuple . "cinder" "volume-vmware" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 10 }}
+          {{- tuple . "cinder" "volume-vmware" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | nindent 10 }}
           vcenter: {= host =}
           datacenter: {= availability_zone =}
         annotations:
@@ -46,8 +46,8 @@ template: |
           {{- end }}
       spec:
         hostname: cinder-volume-vmware-{= name =}
-{{ tuple "{= availability_zone =}" | include "kubernetes_pod_az_affinity" | indent 8 }}
-{{ include "utils.proxysql.pod_settings" . | indent 8 }}
+        {{- tuple . "{= availability_zone =}" | include "utils.kubernetes_pod_az_affinity" | nindent 8 }}
+        {{- include "utils.proxysql.pod_settings" . | nindent 8 }}
         containers:
         - name: cinder-volume-vmware-{= name =}
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{.Values.imageVersionCinderScheduler | default .Values.imageVersion | required "Please set cinder.imageVersion or similar" }}


### PR DESCRIPTION
Use topologySpreadConstraints to spread the api pods over the zones in a best effort manner to improve the situation in the situation of a zone is down (kubernetes may not rebalance, or cannot due to inbalance)

Use topology aware routing service-annotation to make use of the distributed placement and prefer communicating to nodes in the same AZ

In regions with a single AZ, the annotations are not set.

Option to change the AZ affinity with global.topology_key to something non-deprecated (i.e. topology.kubernetes.io/zone)

Add AZ affinity for cinder-backup deployment