### PR TITLE
[nova] Topology aware scheduling and spreading + AZ update

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 0.1.1
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.9.0
+  version: 0.10.1
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.7.5
@@ -26,5 +26,5 @@ dependencies:
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:84598e302b07470109f48aea713085c8daa52406bf7313ebeee02c0b34e282bb
-generated: "2023-05-02T14:32:04.267291935+02:00"
+digest: sha256:c7db7afe2e365657730bca814d4fcef0e145f7d94a230a21ba3d992ab23206da
+generated: "2023-06-22T13:14:30.13592467+02:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     version: 0.1.1
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.9.0
+    version: ~0.10.0
   - name: mariadb
     alias: mariadb_cell2
     condition: mariadb_cell2.enabled

--- a/openstack/nova/ci/test-values.yaml
+++ b/openstack/nova/ci/test-values.yaml
@@ -10,6 +10,9 @@ global:
     
   master_password: topSecret
   nova_service_password: topSecret
+  availability_zones:
+    - foo
+    - bar
 
 imageVersion: myTag
 imageVersionVspc: vspc-latest-tag

--- a/openstack/nova/templates/_console-service.yaml.tpl
+++ b/openstack/nova/templates/_console-service.yaml.tpl
@@ -7,6 +7,8 @@ kind: Service
 apiVersion: v1
 metadata:
   name: nova-console-{{ $name }}
+  annotations:
+  {{- include "utils.topology.service_topology_mode" . | indent 2 }}
   labels:
     system: openstack
     type: backend

--- a/openstack/nova/templates/_console_deployment.yaml.tpl
+++ b/openstack/nova/templates/_console_deployment.yaml.tpl
@@ -31,7 +31,8 @@ spec:
     metadata:
       labels:
         name: nova-console-{{ $name }}
-{{ tuple . "nova" (print "console-" $name) | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
+        {{- tuple . "nova" (print "console-" $name) | include "helm-toolkit.snippets.kubernetes_metadata_labels" | nindent 8 }}
+        {{- include "utils.topology.pod_label" . | indent 8 }}
       annotations:
         configmap-etc-hash: {{ include (print .Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
         {{- if .Values.proxysql.mode }}
@@ -39,8 +40,9 @@ spec:
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
         {{- end }}
     spec:
-{{ tuple . "nova" (print "console-" $name) | include "kubernetes_pod_anti_affinity" | indent 6 }}
-      {{- include "utils.proxysql.pod_settings" . | indent 6 }}
+      {{- tuple . "nova" (print "console-" $name) | include "kubernetes_pod_anti_affinity" | nindent 6 }}
+      {{- include "utils.proxysql.pod_settings" . | nindent 6 }}
+      {{- tuple . (dict "name" (print "nova-console-" $name )) | include "utils.topology.constraints" | indent 6 }}
       hostname: nova-console-{{ $name }}
       volumes:
       - name: nova-etc

--- a/openstack/nova/templates/api-deployment.yaml
+++ b/openstack/nova/templates/api-deployment.yaml
@@ -26,7 +26,8 @@ spec:
         name: nova-api
         alert-tier: os
         alert-service: nova
-{{ tuple . "nova" "api" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
+        {{- tuple . "nova" "api" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | nindent 8 }}
+        {{- include "utils.topology.pod_label" . | indent 8 }}
       annotations:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
         {{- if or .Values.conductor.config_file.DEFAULT.statsd_enabled .Values.proxysql.mode }}
@@ -35,12 +36,13 @@ spec:
         {{- end }}
     spec:
       terminationGracePeriodSeconds: {{ .Values.defaults.default.graceful_shutdown_timeout | add 5 }}
+      {{- tuple . (dict "name" "nova-api") | include "utils.topology.constraints" | indent 6 }}
       {{- if .Values.pod.debug.api }}
       securityContext:
         runAsUser: 0
       {{- end }}
-{{ tuple . "nova" "api" | include "kubernetes_pod_anti_affinity" | indent 6 }}
-      {{- include "utils.proxysql.pod_settings" . | indent 6 }}
+      {{- tuple . "nova" "api" | include "kubernetes_pod_anti_affinity" | nindent 6 }}
+      {{- include "utils.proxysql.pod_settings" . | nindent 6 }}
       hostname: nova-api
       initContainers:
       {{- tuple . (dict "service" (include "nova.helpers.cell01_services" .) "jobs" (tuple . "db-migrate" | include "job_name")) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}

--- a/openstack/nova/templates/api-metadata-deployment.yaml
+++ b/openstack/nova/templates/api-metadata-deployment.yaml
@@ -26,7 +26,8 @@ spec:
         name: nova-api-metadata
         alert-tier: os
         alert-service: nova
-{{ tuple . "nova" "api-metadata" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
+        {{- tuple . "nova" "api-metadata" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | nindent 8 }}
+        {{- include "utils.topology.pod_label" . | indent 8 }}
       annotations:
         configmap-etc-hash: {{ include (print .Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
         {{- if or .Values.conductor.config_file.DEFAULT.statsd_enabled .Values.proxysql.mode }}
@@ -34,8 +35,9 @@ spec:
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
         {{- end }}
     spec:
-{{ tuple . "nova" "api-metadata" | include "kubernetes_pod_anti_affinity" | indent 6 }}
-      {{- include "utils.proxysql.pod_settings" . | indent 6 }}
+      {{- tuple . "nova" "api-metadata" | include "kubernetes_pod_anti_affinity" | nindent 6 }}
+      {{- include "utils.proxysql.pod_settings" . | nindent 6 }}
+      {{- tuple . (dict "name" "nova-api-metadata") | include "utils.topology.constraints" | indent 6 }}
       terminationGracePeriodSeconds: {{ .Values.defaults.default.graceful_shutdown_timeout | add 5 }}
       hostname: nova-api-metadata
       initContainers:

--- a/openstack/nova/templates/api-metadata-service.yaml
+++ b/openstack/nova/templates/api-metadata-service.yaml
@@ -12,6 +12,7 @@ metadata:
     maia.io/scrape: "true"
     prometheus.io/port: "9102"
     prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
+    {{- include "utils.topology.service_topology_mode" . | indent 2 }}
 
 spec:
   selector:

--- a/openstack/nova/templates/api-service.yaml
+++ b/openstack/nova/templates/api-service.yaml
@@ -12,6 +12,7 @@ metadata:
     maia.io/scrape: "true"
     prometheus.io/port: "9102"
     prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
+    {{- include "utils.topology.service_topology_mode" . | indent 2 }}
 
 spec:
   selector:

--- a/openstack/nova/templates/cell2-conductor-deployment.yaml
+++ b/openstack/nova/templates/cell2-conductor-deployment.yaml
@@ -27,7 +27,8 @@ spec:
         name: nova-conductor
         alert-tier: os
         alert-service: nova
-{{ tuple . "nova" "conductor" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
+        {{- tuple . "nova" "conductor" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | nindent 8 }}
+        {{- include "utils.topology.pod_label" . | indent 8 }}
       annotations:
         {{- if or .Values.cell2.conductor.config_file.DEFAULT.statsd_enabled .Values.proxysql.mode }}
         prometheus.io/scrape: "true"
@@ -35,8 +36,9 @@ spec:
         {{- end }}
         configmap-etc-hash: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
     spec:
-{{ tuple . "nova" "conductor" | include "kubernetes_pod_anti_affinity" | indent 6 }}
-{{ include "utils.proxysql.pod_settings" . | indent 6 }}
+      {{- tuple . "nova" "conductor" | include "kubernetes_pod_anti_affinity" | nindent 6 }}
+      {{- include "utils.proxysql.pod_settings" . | nindent 6 }}
+      {{- tuple . (dict "name" "nova-conductor") | include "utils.topology.constraints" | indent 6 }}
       terminationGracePeriodSeconds: {{ .Values.defaults.default.graceful_shutdown_timeout | add 5 }}
       hostname: nova-conductor
       initContainers:

--- a/openstack/nova/templates/conductor-deployment.yaml
+++ b/openstack/nova/templates/conductor-deployment.yaml
@@ -26,7 +26,8 @@ spec:
         name: nova-conductor
         alert-tier: os
         alert-service: nova
-{{ tuple . "nova" "conductor" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
+        {{- tuple . "nova" "conductor" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | nindent 8 }}
+        {{- include "utils.topology.pod_label" . | indent 8 }}
       annotations:
         {{- if or .Values.conductor.config_file.DEFAULT.statsd_enabled .Values.proxysql.mode }}
         prometheus.io/scrape: "true"
@@ -34,8 +35,9 @@ spec:
         {{- end }}
         configmap-etc-hash: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
     spec:
-{{ tuple . "nova" "conductor" | include "kubernetes_pod_anti_affinity" | indent 6 }}
-      {{- include "utils.proxysql.pod_settings" . | indent 6 }}
+      {{- tuple . "nova" "conductor" | include "kubernetes_pod_anti_affinity" | nindent 6 }}
+      {{- include "utils.proxysql.pod_settings" . | nindent 6 }}
+      {{- tuple . (dict "name" "nova-conductor") | include "utils.topology.constraints" | indent 6 }}
       terminationGracePeriodSeconds: {{ .Values.defaults.default.graceful_shutdown_timeout | add 5 }}
       hostname: nova-conductor
       initContainers:

--- a/openstack/nova/templates/console-shellinabox-deployment.yaml
+++ b/openstack/nova/templates/console-shellinabox-deployment.yaml
@@ -24,7 +24,8 @@ spec:
     metadata:
       labels:
         name: nova-console-cell1-shellinabox
-{{ tuple . "nova" "console-cell1-shellinabox" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
+        {{- tuple . "nova" "console-cell1-shellinabox" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | nindent 8 }}
+        {{- include "utils.topology.pod_label" . | indent 8 }}
       annotations:
         {{- if .Values.proxysql.mode }}
         prometheus.io/scrape: "true"
@@ -36,8 +37,9 @@ spec:
         runAsUser: 33
         runAsGroup: 33
         fsGroup: 33
-{{ tuple . "nova" "console-cell1-shellinabox" | include "kubernetes_pod_anti_affinity" | indent 6 }}
-{{ include "utils.proxysql.pod_settings" . | indent 6 }}
+      {{- tuple . "nova" "console-cell1-shellinabox" | include "kubernetes_pod_anti_affinity" | nindent 6 }}
+      {{- include "utils.proxysql.pod_settings" . | nindent 6 }}
+      {{- tuple . (dict "name" "nova-console-cell1-shellinabox") | include "utils.topology.constraints" | indent 6 }}
       containers:
       - name: nova-console-cell1-shellinabox
         image: {{ required ".Values.global.dockerHubMirror is missing" .Values.global.dockerHubMirror }}/bitnami/openresty:{{ .Values.imageVersionBitnamiOpenResty }}

--- a/openstack/nova/templates/hypervisors/hypervisors-vmware-deployment-vct.yaml
+++ b/openstack/nova/templates/hypervisors/hypervisors-vmware-deployment-vct.yaml
@@ -34,7 +34,7 @@ template: |
     template:
       metadata:
         labels:
-{{ tuple . "nova" "compute" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 10 }}
+          {{- tuple . "nova" "compute" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | nindent 10 }}
           name: nova-compute-{= name =}
           alert-tier: os
           alert-service: nova
@@ -48,8 +48,8 @@ template: |
           configmap-etc-hash: {{ include (print .Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
           configmap-nova-compute-hash: {= "vcenter_cluster/{{ .Release.Namespace }}/vcenter-cluster-nova-compute-configmap.yaml.j2" | render | sha256sum =}
       spec:
-{{ tuple "{= availability_zone =}" | include "kubernetes_pod_az_affinity" | indent 8 }}
-{{- include "kubernetes_maintenance_affinity" . | indent 4 }}
+        {{- tuple . "{= availability_zone =}" | include "utils.kubernetes_pod_az_affinity" | nindent 8 }}
+        {{- include "kubernetes_maintenance_affinity" . | nindent 4 }}
         terminationGracePeriodSeconds: 900
         containers:
         - name: nova-compute

--- a/openstack/nova/templates/scheduler-deployment.yaml
+++ b/openstack/nova/templates/scheduler-deployment.yaml
@@ -26,7 +26,7 @@ spec:
         name: nova-scheduler
         alert-tier: os
         alert-service: nova
-{{ tuple . "nova" "scheduler" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
+        {{- tuple . "nova" "scheduler" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | nindent 8 }}
       annotations:
         {{- if or .Values.scheduler.rpc_statsd_enabled .Values.proxysql.mode }}
         prometheus.io/scrape: "true"
@@ -35,8 +35,8 @@ spec:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
         configmap-scheduler-etc-hash: {{ include (print $.Template.BasePath "/scheduler-etc-configmap.yaml") . | sha256sum }}
     spec:
-{{ tuple . "nova" "scheduler" | include "kubernetes_pod_anti_affinity" | indent 6 }}
-{{ include "utils.proxysql.pod_settings" . | indent 6 }}
+      {{- tuple . "nova" "scheduler" | include "kubernetes_pod_anti_affinity" | nindent 6 }}
+      {{- include "utils.proxysql.pod_settings" . | nindent 6 }}
       terminationGracePeriodSeconds: {{ .Values.defaults.default.graceful_shutdown_timeout | add 5 }}
       hostname: nova-scheduler
       initContainers:

--- a/openstack/nova/templates/vspc-deployment.yaml
+++ b/openstack/nova/templates/vspc-deployment.yaml
@@ -24,11 +24,13 @@ spec:
         name: nova-vspc
         alert-tier: os
         alert-service: nova
-{{ tuple . "nova" "vspc" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
+        {{- tuple . "nova" "vspc" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | nindent 8 }}
+        {{- include "utils.topology.pod_label" . | indent 8 }}
       annotations:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
     spec:
       hostname: nova-vspc
+      {{- tuple . (dict "name" "nova-vspc") | include "utils.topology.constraints" | indent 6 }}
       containers:
         - name: vmware-vspc
           image: {{ required ".Values.global.registry is missing" .Values.global.registry}}/vmware-vspc:{{ required ".Values.imageVersionVspc is missing" .Values.imageVersionVspc }}

--- a/openstack/nova/templates/vspc-service.yaml
+++ b/openstack/nova/templates/vspc-service.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 
 metadata:
   name: nova-vspc
+  annotations:
+  {{- include "utils.topology.service_topology_mode" . | indent 2 }}
   labels:
     system: openstack
     type: backend


### PR DESCRIPTION
Use topologySpreadConstraints to spread the api pods over the zones in a best effort manner to improve the situation in the situation of a zone is down (kubernetes may not rebalance, or cannot due to inbalance)

Use topology aware routing service-annotation to make use of the distributed placement and prefer communicating to nodes in the same AZ

In regions with a single AZ, the annotations are not set.
