### PR TITLE
[glance] Topology aware scheduling and spreading

### DIFF
--- a/openstack/glance/Chart.lock
+++ b/openstack/glance/Chart.lock
@@ -10,12 +10,12 @@ dependencies:
   version: 0.2.7
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.9.0
+  version: 0.10.0
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.2.4
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:866458b7b9113690116f51dcf066a0fde4d20fa122e6ff66d606a4f4e817e209
-generated: "2023-05-02T13:27:30.798603614+02:00"
+digest: sha256:1a75cd1eb9c83b26ee6d4fea325e4b3b6c221b45f2d325aca90e6f34144b90f6
+generated: "2023-06-01T11:35:28.136090299+02:00"

--- a/openstack/glance/Chart.yaml
+++ b/openstack/glance/Chart.yaml
@@ -18,7 +18,7 @@ dependencies:
     version: 0.2.7
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.9.0
+    version: ~0.10.0
   - name: redis
     alias: sapcc_rate_limit
     repository: https://charts.eu-de-2.cloud.sap

--- a/openstack/glance/ci/test-values.yaml
+++ b/openstack/glance/ci/test-values.yaml
@@ -3,6 +3,9 @@ global:
   dockerHubMirror: myRegistry/dockerhub
   dockerHubMirrorAlternateRegion: myRegistry/dockerhubalternate
   glance_service_password: secret
+  availability_zones:
+    - foo
+    - bar
   domain_seeds:
     skip_hcm_domain: false
     

--- a/openstack/glance/templates/deployment.yaml
+++ b/openstack/glance/templates/deployment.yaml
@@ -30,6 +30,7 @@ spec:
         name: glance
         alert-tier: os
         alert-service: glance
+        {{- include "utils.topology.pod_label" . | indent 8 }}
       annotations:
         chart-version: {{.Chart.Version}}
         checksum/etc-configmap.conf: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
@@ -39,6 +40,7 @@ spec:
         {{- end }}
     spec:
       {{ include "utils.proxysql.pod_settings" . | indent 6 }}
+      {{- tuple . (dict "name" "glance") | include "utils.topology.constraints" | indent 6 }}
       initContainers:
       {{- tuple . (dict "jobs" (tuple . "migration-job" | include "job_name") "service" (print .Release.Name "-mariadb," .Release.Name "-memcached")) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       {{- if .Values.file.persistence.enabled }}

--- a/openstack/glance/templates/service.yaml
+++ b/openstack/glance/templates/service.yaml
@@ -10,8 +10,9 @@ metadata:
     heritage: "{{ .Release.Service }}"
     component: glance
     type: api
-{{- if .Values.metrics.enabled }}
   annotations:
+    {{- include "utils.topology.service_topology_mode" . | indent 2 }}
+{{- if .Values.metrics.enabled }}
     prometheus.io/scrape: "true"
     prometheus.io/port: "{{.Values.metrics.port}}"
     prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}


### PR DESCRIPTION
Use topologySpreadConstraints to spread the api pods over the zones in a best effort manner to improve the situation in the situation of a zone is down (kubernetes may not rebalance, or cannot due to inbalance)

Use topology aware routing service-annotation to make use of the distributed placement and prefer communicating to nodes in the same AZ

In regions with a single AZ, the annotations are not set.