### PR TITLE
[keystone] Topology aware scheduling and spreading

### DIFF
--- a/openstack/keystone/Chart.lock
+++ b/openstack/keystone/Chart.lock
@@ -19,6 +19,6 @@ dependencies:
   version: 1.2.0
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.5.0
-digest: sha256:22657abb774c8e6e75b9e05d1ddb7c8893ace62f724db6dfa7f966d61f355e2b
-generated: "2023-01-16T11:43:41.114222+01:00"
+  version: 0.10.0
+digest: sha256:2d0c8e2a780c8ea7785aedb87ce229a4a7ba1fb4dcaa632dd6f64205261ab7af
+generated: "2023-06-01T11:46:30.908824435+02:00"

--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -36,4 +36,4 @@ dependencies:
     version: 1.2.0
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.5.0
+    version: 0.10.0

--- a/openstack/keystone/ci/test-values.yaml
+++ b/openstack/keystone/ci/test-values.yaml
@@ -10,6 +10,7 @@ global:
     jager:
       enabled: true
   registry: test
+  availability_zones: []
 
 api:
   cloudAdminProjectId: default

--- a/openstack/keystone/templates/deployment-2faproxy.yaml
+++ b/openstack/keystone/templates/deployment-2faproxy.yaml
@@ -19,8 +19,10 @@ spec:
         {{- end}}
       labels:
         {{- include "2faproxy.selectorLabels" . | nindent 8 }}
+        {{- include "utils.topology.pod_label" . | nindent 8 }}
     spec:
       serviceAccountName: {{ .Release.Name }}-2faproxy
+      {{- tuple . (dict "app.kubernetes.io/name" "2faproxy" "app.kubernetes.io/instance" .Release.Name) | include "utils.topology.constraints" | indent 6 }}
       containers:
         - name: 2fa
           image: {{ required ".Values.global.registryAlternateRegion is missing" .Values.global.registryAlternateRegion }}/{{ index .Values "2fa" "image" }}:{{ required ".Values.2fa.imageTag is missing" (index .Values "2fa" "imageTag") }}

--- a/openstack/keystone/templates/deployment-api.yaml
+++ b/openstack/keystone/templates/deployment-api.yaml
@@ -34,6 +34,7 @@ spec:
         type: api
         alert-tier: os
         alert-service: keystone
+        {{- include "utils.topology.pod_label" . | nindent 8 }}
       annotations:
         chart-version: {{.Chart.Version}}
         configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") . | sha256sum }}
@@ -46,6 +47,7 @@ spec:
 {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ .Release.Name }}
 {{- end }}
+      {{- tuple . (dict "name" (print .Release.Name "-api")) | include "utils.topology.constraints" | indent 6 }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/openstack/keystone/templates/service-2faproxy.yaml
+++ b/openstack/keystone/templates/service-2faproxy.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ .Release.Name }}-2faproxy
   labels:
     {{- include "2faproxy.labels" . | nindent 4 }}
+  annotations:
+  {{- include "utils.topology.service_topology_mode" . | indent 2 }}
 spec:
   type: ClusterIP
   ports:

--- a/openstack/keystone/templates/service-api.yaml
+++ b/openstack/keystone/templates/service-api.yaml
@@ -10,12 +10,13 @@ metadata:
     system: openstack
     component: keystone
     type: api
-{{- if .Values.api.metrics.enabled }}
   annotations:
+{{- if .Values.api.metrics.enabled }}
     prometheus.io/scrape: "true"
     prometheus.io/port: "{{.Values.api.metrics.port}}"
     prometheus.io/targets: "{{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus }}"
 {{- end }}
+  {{- include "utils.topology.service_topology_mode" . | indent 2 }}
 spec:
   selector:
     name: {{ .Release.Name }}-api


### PR DESCRIPTION
Use topologySpreadConstraints to spread the api pods over the zones in a best effort manner to improve the situation in the situation of a zone is down (kubernetes may not rebalance, or cannot due to inbalance)

Use topology aware routing service-annotation to make use of the distributed placement and prefer communicating to nodes in the same AZ

In regions with a single AZ, the annotations are not set.