### PR TITLE
[manila] Topology aware scheduling and spreading

### DIFF
--- a/openstack/manila/ci/test-values.yaml
+++ b/openstack/manila/ci/test-values.yaml
@@ -19,6 +19,7 @@ global:
   registry: myRegistry
   domain_seeds:
     skip_hcm_domain: false
+  availability_zones: []
 
 loci:
   imageVersion: xena

--- a/openstack/manila/templates/api-deployment.yaml
+++ b/openstack/manila/templates/api-deployment.yaml
@@ -30,13 +30,15 @@ spec:
         name: manila-api
         alert-tier: os
         alert-service: manila
-{{ tuple . "manila" "api" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
+        {{- tuple . "manila" "api" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | nindent 8 }}
+        {{- include "utils.topology.pod_label" . | indent 8 }}
       annotations:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
         configmap-bin-hash: {{ include (print $.Template.BasePath "/bin-configmap.yaml") . | sha256sum }}
         kubectl.kubernetes.io/default-container: manila-api
     spec:
-{{ tuple . "manila" "api" | include "kubernetes_pod_anti_affinity" | indent 6 }}
+      {{- tuple . "manila" "api" | include "kubernetes_pod_anti_affinity" | nindent 6 }}
+      {{- tuple . (dict "name" "manila-api") | include "utils.topology.constraints" | indent 6 }}
       {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       initContainers:
       {{- tuple . (dict "jobs" (print .Release.Name "-migration") "service" (print .Release.Name "-mariadb," .Release.Name "-rabbitmq," .Release.Name "-memcached")) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}

--- a/openstack/manila/templates/api-service.yaml
+++ b/openstack/manila/templates/api-service.yaml
@@ -10,6 +10,7 @@ metadata:
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/targets: {{ required ".Values.alerts.prometheus.openstack" .Values.alerts.prometheus.openstack |  quote }}
+  {{- include "utils.topology.service_topology_mode" . | indent 2 }}
 spec:
   selector:
     name: manila-api


### PR DESCRIPTION
Use topologySpreadConstraints to spread the api pods over the zones in a best effort manner to improve the situation in the situation of a zone is down (kubernetes may not rebalance, or cannot due to inbalance)

Use topology aware routing service-annotation to make use of the distributed placement and prefer communicating to nodes in the same AZ

In regions with a single AZ, the annotations are not set.