### PR TITLE
[octavia] Topology aware scheduling and spreading

### DIFF
--- a/openstack/octavia/Chart.lock
+++ b/openstack/octavia/Chart.lock
@@ -16,9 +16,9 @@ dependencies:
   version: 0.4.4
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.0
+  version: 0.10.0
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:22d9aba52eee622c459cf9a858a264d5865cbab31840b8c74aed2bfcc83b177f
-generated: "2022-11-28T16:21:51.209647852+01:00"
+digest: sha256:365234bfde292dc74cdd4b38f823a1e785a1915dd4752a9d63b32e728fc83a54
+generated: "2023-06-01T12:42:48.944327634+02:00"

--- a/openstack/octavia/Chart.yaml
+++ b/openstack/octavia/Chart.yaml
@@ -30,7 +30,7 @@ dependencies:
     version: 0.4.4
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.7.0
+    version: ~0.10.0
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0

--- a/openstack/octavia/ci/test-values.yaml
+++ b/openstack/octavia/ci/test-values.yaml
@@ -4,6 +4,9 @@ global:
   master_password: topSecret!
   octavia_service_password: topSecret!!
   dockerHubMirrorAlternateRegion: some_region
+  availability_zones:
+    - foo
+    - bar
 
 imageVersion: train
 

--- a/openstack/octavia/templates/octavia-api-deployment.yaml
+++ b/openstack/octavia/templates/octavia-api-deployment.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app.kubernetes.io/name: octavia-api
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- include "utils.topology.pod_label" . | indent 8 }}
       annotations:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/octavia-etc-configmap.yaml") . | sha256sum }}
         {{- if or .Values.watcher.enabled .Values.proxysql.mode }}
@@ -33,7 +34,8 @@ spec:
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
         {{- end }}
     spec:
-{{ include "utils.proxysql.pod_settings" . | indent 6 }}
+      {{- include "utils.proxysql.pod_settings" . | nindent 6 }}
+      {{- tuple . (dict "app.kubernetes.io/name" "octavia-api") | include "utils.topology.constraints" | indent 6 }}
       containers:
         - name: {{ .Chart.Name }}-api
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-octavia:{{required "Values.imageVersion is missing" .Values.imageVersion}}

--- a/openstack/octavia/templates/octavia-api-service.yaml
+++ b/openstack/octavia/templates/octavia-api-service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: octavia-api
+  annoations:
+  {{- include "utils.topology.service_topology_mode" . | indent 2 }}
   labels:
     app.kubernetes.io/name: octavia-api
     helm.sh/chart: {{ include "octavia.chart" . }}


### PR DESCRIPTION
Use topologySpreadConstraints to spread the api pods over the zones in a best effort manner to improve the situation in the situation of a zone is down (kubernetes may not rebalance, or cannot due to inbalance)

Use topology aware routing service-annotation to make use of the distributed placement and prefer communicating to nodes in the same AZ

In regions with a single AZ, the annotations are not set.