### PR TITLE
reducing alert severity to warning because dhcp and metadata service …

### DIFF
--- a/openstack/cc3test/alerts/network.alerts
+++ b/openstack/cc3test/alerts/network.alerts
@@ -164,7 +164,7 @@ groups:
         } == 0
     for: 20m
     labels:
-      severity: critical
+      severity: warning
       support_group: network-api
       tier: os
       service: '{{ $labels.service }}'
@@ -186,7 +186,7 @@ groups:
         } == 0
     for: 20m
     labels:
-      severity: critical
+      severity: warning
       support_group: network-api
       tier: os
       service: '{{ $labels.service }}'


### PR DESCRIPTION
…is not global but per project