### PR TITLE
[neutron] Remove unused sections

### DIFF
--- a/openstack/neutron/templates/etc/_ml2-conf.ini.tpl
+++ b/openstack/neutron/templates/etc/_ml2-conf.ini.tpl
@@ -52,16 +52,5 @@ enable_ipset=True
 polling_interval=5
 prevent_arp_spoofing = False
 
-[linux_bridge]
-physical_interface_mappings = {{required "A valid .Values.cp_physical_network required!" .Values.cp_physical_network}}:{{required "A valid .Values.cp_network_interface required!" .Values.cp_network_interface}}
-
 [vxlan]
 enable_vxlan = false
-
-[ovs]
-bridge_mappings = {{required "A valid .Values.cp_physical_network required!" .Values.cp_physical_network}}:br-{{required "A valid .Values.cp_network_interface required!" .Values.cp_network_interface}}
-enable_tunneling=False
-
-
-
-


### PR DESCRIPTION
We use linuxbridge only on the network-agents to bind the dchp/metadata/dns ports. Those come with their own linuxbridge config in openstack/neutron/templates/configmap-etc-apod.yaml decoupled from the neutron-server or ml2-agent config config. We do not use ovs for ml2 bindings at all.