### PR TITLE
[nova] Disable uptime RPC call in hypervisor details

### DIFF
--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -195,6 +195,7 @@ api:
     api:
       list_records_by_skipping_down_cells: false
       use_forwarded_for: true
+      disable_hypervisor_uptime_detail: true
 
     wsgi:
       api_paste_config: /etc/nova/api-paste.ini


### PR DESCRIPTION
When fetching hypervisors from Nova's API, newer API versions (2.88+) return an "uptime" field in the response. To fill this field, nova-api makes an RPC call to each hypervisor. Since some of the drivers (namely Ironic and VMware) do not implement the `get_host_uptime()` call and thus end up raising a `NotImplementedError`. Making the RPC call for every hypervisor is slow and since our hypervisors don't implement it also clog the logs. Therefore, we disable the RPC call and always return `None` for the field.