### PR TITLE
neutron: fix labels on asr1k pods

### DIFF
--- a/openstack/neutron/templates/asr_config_agents/_deployment-asr1k.yaml.tpl
+++ b/openstack/neutron/templates/asr_config_agents/_deployment-asr1k.yaml.tpl
@@ -27,14 +27,14 @@ spec:
     metadata:
       labels:
         name: neutron-asr1k-{{ $config_agent.name }}
+        cloud.sap/scheduling-disabled: {{ or ($config_agent.scheduling_disabled | default false) ($config_agent.decommissioning | default false) | quote }}
+        cloud.sap/decommissioning: {{ $config_agent.decommissioning | default false | quote }}
 {{ tuple $context "neutron" "asr1k-agent" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
       annotations:
         pod.beta.kubernetes.io/hostname:  asr1k-{{ $config_agent.name }}
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" $context.Values.alerts.prometheus | quote }}
         configmap-asr1k-{{ $config_agent.name }}: {{ tuple $context $config_agent |include "asr1k_configmap" | sha256sum  }}
-        cloud.sap/scheduling-disabled: {{ or ($config_agent.scheduling_disabled | default false) ($config_agent.decommissioning | default false) | quote }}
-        cloud.sap/decommissioning: {{ $config_agent.decommissioning | default false | quote }}
     spec:
       hostname:  asr1k-{{ $config_agent.name }}
       containers:


### PR DESCRIPTION
These need to be labels instead of annotations because only those get exported to Prometheus (`kube_pod_labels`).