### PR TITLE
maia: disable multiple scrape alerts

### DIFF
--- a/openstack/maia/Chart.yaml
+++ b/openstack/maia/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Expose Prometheus as multi-tenant OpenStack service
 name: maia
-version: 1.4.12
+version: 1.4.13
 maintainers:
   - name: Martin Vossen (artherd42)
 dependencies:

--- a/openstack/maia/values.yaml
+++ b/openstack/maia/values.yaml
@@ -102,14 +102,10 @@ prometheus_server:
     service: maia
 
     multipleTargetScrapes:
-      # List of exceptions for scrape jobs. This is joined together with a `|`.
-      exceptions:
-        # jobs `prometheus-vmware.*` scrape prometheus-vmware multiple times for different metrics
-        - prometheus-vmware.*
-        # job `netbox-webhook-dist-client` is from prometheus-openstack
-        - netbox-webhook-dist-client
-        # jobs `maia/prometheus-maia-oprom` and `prometheus-maia-oprom` scrape prometheus-maia multiple times for different metrics
-        - .*prometheus-maia-oprom
+      enabled: false
+
+    multiplePodScrapes:
+      enabled: false
 
 # Deploy Maia Prometheus alerts.
 alerts:


### PR DESCRIPTION
The multiple scrape alerts from maia prometheus are evaluated by prometheus-openstack. This led to duplicate alert notifications several times in the past. Since we know what we are doing, these alerts can be disabled for maia.