### PR TITLE
Expose custom Cinder tag/state information

### DIFF
--- a/system/vmware-monitoring/templates/collector-configmap.yaml
+++ b/system/vmware-monitoring/templates/collector-configmap.yaml
@@ -146,6 +146,10 @@ data:
         key: "summary|accessible"
       - metric_suffix: "hostcount"
         key: "datastore|hostcount"
+      - metric_suffix: "cinder_tag"
+        key: "summary|tagJson"
+      - metric_suffix: "cinder_state"
+        key: "summary|customTag:cinder_state|customTagValue"
 
     SDRSStatsCollector:
     # INFO - Prefix: vrops_storagepod_


### PR DESCRIPTION
- Adds keys to the vrops-exporter-collector-config to generate the Prometheus metrics

Custom tags for the VMware objects that allow mapping to e.g.: OpenStack --> ~~added as a label on the resource metrics to be able to filter by~~ or exposed as an own, separate metric

- [x] Check if the data is available in the vROps REST API
- [ ] Implement
- [ ] Test and verify