### PR TITLE
update links for compute vmware ops playbooks

### DIFF
--- a/openstack/cc3test/alerts/compute.alerts
+++ b/openstack/cc3test/alerts/compute.alerts
@@ -52,7 +52,7 @@ groups:
       context: '{{ $labels.service }}'
       meta: 'VMWare vcenter API is down: {{ $labels.name }}'
       dashboard: 'cc3test-overview?var-service={{ $labels.service }}'
-      playbook: 'docs/devops/alert/vcenter/#test_api'
+      playbook: 'docs/devops/alert/vcenter/#vcenterapidown'
       report: 'cc3test/admin/object-storage/containers/cc3test/list/reports/{{ $labels.type }}'
     annotations:
       description: 'VMWare vcenter API is down: {{ $labels.name }}'
@@ -71,7 +71,7 @@ groups:
       context: '{{ $labels.service }}'
       meta: 'VMWare vcenter API is flapping'
       dashboard: 'cc3test-overview?var-service={{ $labels.service }}'
-      playbook: 'docs/devops/alert/vcenter/#test_api'
+      playbook: 'docs/devops/alert/vcenter/#vcenterapidown'
       report: 'cc3test/admin/object-storage/containers/cc3test/list/reports/{{ $labels.type }}'
     annotations:
       description: 'VMWare vcenter API is flapping: {{ $labels.name }}'

--- a/prometheus-rules/prometheus-vmware-rules/alerts/host.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/host.alerts
@@ -16,7 +16,7 @@ groups:
       context: "ESXi not responding"
       meta: "Host {{ $labels.hostsystem }} with running VMs not responding. ({{ $labels.vcenter }}, {{ $labels.vccluster }})"
       dashboard: esxi-host-disconnected/esxi-host-disconnected?&var-host={{ $labels.hostsystem }}
-      playbook: docs/devops/alert/vcenter/#test_esxi_hs_1
+      playbook: docs/devops/alert/vcenter/#hostwithrunningvmsnotresponding
     annotations:
       description: "Host {{ $labels.hostsystem }} with running VMs not responding. ({{ $labels.vcenter }}, {{ $labels.vccluster }})"
       summary: "Host {{ $labels.hostsystem }} with running VMs not responding. ({{ $labels.vcenter }}, {{ $labels.vccluster }})"
@@ -35,7 +35,7 @@ groups:
       context: "ESXi not responding"
       meta: "Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter }}, {{ $labels.vccluster }})"
       dashboard: esxi-host-disconnected/esxi-host-disconnected?&var-host={{ $labels.hostsystem }}
-      playbook: docs/devops/alert/vcenter/#test_esxi_hs_2
+      playbook: docs/devops/alert/vcenter/#hostnotresponding
     annotations:
       description: "Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter }}, {{ $labels.vccluster }})"
       summary: "Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter }}, {{ $labels.vccluster }})"

--- a/prometheus-rules/prometheus-vmware-rules/alerts/vcenter.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/vcenter.alerts
@@ -110,7 +110,7 @@ groups:
       support_group: compute
       context: "vasa provider"
       meta: "VASA Provider disconnected from {{ $labels.vcenter}}."
-      playbook: docs/devops/alert/vcenter/#vasa_provider_down
+      playbook: docs/devops/alert/vcenter/#vasaproviderdown
       no_alert_on_absence: "true"
     annotations:
       description: "VASA Provider disconnected from {{ $labels.vcenter}}."


### PR DESCRIPTION
update playbook reference for vcenterapidown, hostwithrunningvmsnotresponding, hostnotresponding, vasaproviderdown