### PR TITLE
[neutron] Drop per-service rabbitmq-notifications

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -11,9 +11,6 @@ dependencies:
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.5.1
-- name: rabbitmq
-  repository: https://charts.eu-de-2.cloud.sap
-  version: 0.5.1
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.7.4
@@ -23,5 +20,5 @@ dependencies:
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.2.29
-digest: sha256:9ac9142cbe9ea2b11cc8a7baa0520ffd780ee64e65ef03500540bd45e3deef7e
-generated: "2023-08-16T16:37:37.456493+02:00"
+digest: sha256:d67ea10c8eb6dfbc6c599be1918463d0ec774e5fe7d05992ccaa9b749c78aa0e
+generated: "2023-11-13T16:52:09.490020548+01:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -18,11 +18,6 @@ dependencies:
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.5.1
-  - alias: rabbitmq_notifications
-    condition: audit.enabled
-    name: rabbitmq
-    repository: https://charts.eu-de-2.cloud.sap
-    version: 0.5.1
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
     version: ~0.7.2

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -602,14 +602,7 @@ rabbitmq:
       enabled: false
   alerts:
     support_group: network-api
-rabbitmq_notifications:
-  name: neutron
-  metrics:
-    enabled: true
-    sidecar:
-      enabled: false
-  alerts:
-    support_group: network-api
+
 # openstack-watcher-middleware
 watcher:
   enabled: true


### PR DESCRIPTION
We have now a central one for all services, and neutron is already sending to the new one, so we can drop the old one: It is only wasting resources.