### PR TITLE
[Octavia][mariadb] Increase DB connection capacity

### DIFF
--- a/openstack/octavia/templates/etc/_octavia.conf.tpl
+++ b/openstack/octavia/templates/etc/_octavia.conf.tpl
@@ -82,6 +82,8 @@ max_workers = {{ .Values.max_workers | default "10" }}
 
 [database]
 connection = {{ include "db_url_mysql" . }}
+max_pool_size = 30
+max_overflow = 50
 
 [oslo_messaging]
 # Topic (i.e. Queue) Name


### PR DESCRIPTION
This PR persists values that we set in one of the Germany gold regions when DB connections were piling up (possibly due to many concurrent status updates).