### PR TITLE
[logstash-audit] Remove host specific fields from event_data

### DIFF
--- a/system/audit-logs/Chart.lock
+++ b/system/audit-logs/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 2.0.7
 - name: logstash-audit-external
   repository: file://vendor/logstash-audit-external
-  version: 2.0.23
+  version: 2.1.0
 - name: auditbeat
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.20
@@ -20,5 +20,5 @@ dependencies:
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:577a0a5d7b4133c2ddb76e813131bd02762c957cbf2980e204cc855d9eee56bc
-generated: "2023-06-12T15:47:17.422875+02:00"
+digest: sha256:2d59c4e4443e48db02eb6428a0f889ced8a1660eaa20934081689781e667bb6c
+generated: "2023-06-13T14:42:09.537720078+02:00"

--- a/system/audit-logs/Chart.yaml
+++ b/system/audit-logs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Audit logging components
 name: audit-logs
-version: 0.1.78
+version: 0.1.79
 dependencies:
   - name: fluent-audit-container
     alias: fluent_audit_container
@@ -18,7 +18,7 @@ dependencies:
   - name: logstash-audit-external
     alias: logstash_audit_external
     repository: file://vendor/logstash-audit-external
-    version: 2.0.23
+    version: 2.1.0
     condition: logstash_audit_external.enabled
 
   - name: auditbeat

--- a/system/audit-logs/vendor/logstash-audit-external/Chart.yaml
+++ b/system/audit-logs/vendor/logstash-audit-external/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: logstash-audit-external
-version: 2.0.23
+version: 2.1.0
 description: logstash log collector
 maintainers:
   - name: Olaf Heydorn

--- a/system/audit-logs/vendor/logstash-audit-external/templates/_logstash.conf.tpl
+++ b/system/audit-logs/vendor/logstash-audit-external/templates/_logstash.conf.tpl
@@ -181,10 +181,13 @@ filter {
         {{ end -}}
       }
 
-      if "awx" in [cluster_host_id] {
+      if "awx" in [logger_name] {
         mutate {
           add_field => { "[sap][cc][audit][source]"  => "awx" }
-          remove_field => [ "event_data" ]
+          remove_field => [ "[event_data][artifact_data]", "[event_data][changed]", "[event_data][dark]",
+                            "[event_data][failures]", "[event_data][ignored]", "[event_data][ok]",
+                            "[event_data][processed]", "[event_data][res]", "[event_data][rescued]",
+                            "[event_data][skipped]" ]
         }
       }
 


### PR DESCRIPTION
To enable "job_events" log aggregator on AWX we need to control the number of fields generated to avoid overloading the receiving ELK stack. Fields observed to contain host or user specific data therefore need to be excluded.