### PR TITLE
[cc_email_receiver] no alert grouping + email template

### DIFF
--- a/common/prometheus-alertmanager-base/notification-templates/email.tmpl
+++ b/common/prometheus-alertmanager-base/notification-templates/email.tmpl
@@ -1,0 +1,16 @@
+{{ define "cc_email_receiver.KubernikusKlusterLowOnObjectStoreQuota" }}
+<html>
+<head>
+<title>{{ .CommonAnnotations.summary}}</title>
+</head>
+<body itemscope itemtype="http://schema.org/EmailMessage">
+
+    <p>Dear Converged Cloud customer,</p>
+    <p>the project {{ .CommonLabels.domain }}/{{ .CommonLabels.project }} has {{ .CommonAnnotations.storage_left}} of object-store capacity left.</p> 
+    <a href="{{ .CommonAnnotations.dashboard_url}}">{{ .CommonAnnotations.dashboard_url}}</a>
+    <p>The kubernetes cluster {{ .CommonLabels.shortname }} relies on the object store to continously backup its etcd data. If the quota is exhausted the backup will fail and recovering the cluster from data loss or corruption will be impossible. For the correct functionining of the provisioned cluster please make sure you always have >200MB of object-store capacity available.</p>
+    <p>Kind regards,</p>
+    <p>Converged Cloud support team</p>
+
+</body></html>
+{{ end }}

--- a/global/prometheus-alertmanager-operated/templates/_alertmanager.yaml.tpl
+++ b/global/prometheus-alertmanager-operated/templates/_alertmanager.yaml.tpl
@@ -64,6 +64,7 @@ route:
 
   {{- if .Values.cc_email_receiver.enabled }}
   - receiver: cc_email_receiver
+    group_by: ['...']
     continue: false
     matchers: [alertname="KubernikusKlusterLowOnObjectStoreQuota",primary_email_recipients!=""]
   {{- end }}
@@ -1522,7 +1523,7 @@ receivers:
           To: {{"'{{.CommonLabels.primary_email_recipients}}'"}}
           CC: {{"'{{.CommonLabels.cc_email_recipients}}'"}}
         text: {{"'{{ .CommonAnnotations.mail_body }}'"}}
-        html: {{"'{{ .CommonAnnotations.mail_body }}'"}}
+        html: {{"'{{ template \"cc_email_receiver.KubernikusKlusterLowOnObjectStoreQuota\" . }}'"}}
         smarthost: {{ required ".Values.cc_email_receiver.smtp_host undefined" .Values.cc_email_receiver.smtp_host | quote }}
         auth_username: {{ required ".Values.cc_email_receiver.auth_username undefined" .Values.cc_email_receiver.auth_username | quote }}
         auth_password: {{ required ".Values.cc_email_receiver.auth_password undefined" .Values.cc_email_receiver.auth_password | quote }}


### PR DESCRIPTION
This commit:

- disables grouping of alerts for cc_email_receiver route
- adds a basic html email template for KubernikusKlusterLowOnObjectStoreQuota alerts