### PR TITLE
prometheus-kubernetes|kubernikus-global: alert routing updated

### DIFF
--- a/global/prometheus-kubernetes-global/Chart.yaml
+++ b/global/prometheus-kubernetes-global/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for the operated global Prometheus for monitoring Kubernetes.
 name: prometheus-kubernetes-global
-version: 4.0.6
+version: 4.0.7
 
 dependencies:
   - name: prometheus-server-pre7

--- a/global/prometheus-kubernetes-global/alerts/federation.alerts
+++ b/global/prometheus-kubernetes-global/alerts/federation.alerts
@@ -8,9 +8,9 @@ groups:
       context: availability
       dashboard: kubernetes-prometheus?var-instance=frontend
       meta: Prometheus frontend is down
-      service: prometheus
-      severity: critical
-      tier: k8s
+      service: metrics
+      severity: warning
+      support_group: observability
       playbook: docs/support/playbook/prometheus/federation
     annotations:
       description: Global Prometheus cannot federate from Prometheus in admin cluster {{ $labels.cluster }}. Alerting and dashboards are unavailable. This could mean the region {{ $labels.region }} or cluster {{ $labels.cluster }} is partly down!
@@ -23,9 +23,9 @@ groups:
       context: availability
       dashboard: kubernetes-prometheus?var-instance=frontend
       meta: Prometheus frontend is down
-      service: prometheus
-      severity: critical
-      tier: k8s
+      service: metrics
+      severity: warning
+      support_group: observability
       playbook: docs/support/playbook/prometheus/federation
     annotations:
       description: Global Prometheus cannot federate from Prometheus in virtual cluster {{ $labels.cluster }}. Alerting and dashboards are unavailable. This could mean the region {{ $labels.region }} or cluster {{ $labels.cluster }} is partly down!
@@ -38,9 +38,9 @@ groups:
       context: availability
       dashboard: kubernetes-prometheus?var-instance=frontend
       meta: Prometheus frontend is down
-      service: prometheus
-      severity: critical
-      tier: k8s
+      service: metrics
+      severity: warning
+      support_group: observability
       playbook: docs/support/playbook/prometheus/federation
     annotations:
       description: Global Prometheus cannot federate from Prometheus Frontend in region {{ $labels.region }}. Alerting and dashboards are unavailable. This could mean the region {{ $labels.region }} is partly down!
@@ -53,9 +53,9 @@ groups:
       context: availability
       dashboard: kubernetes-prometheus?var-instance=frontend
       meta: Prometheus frontend can't federate data from the collector
-      service: prometheus
+      service: metrics
       severity: warning
-      tier: k8s
+      support_group: observability
       playbook: docs/support/playbook/prometheus/federation
     annotations:
       description: Prometheus Frontend can't federate data from the collector. Data will be stale
@@ -68,9 +68,9 @@ groups:
       context: availability
       dashboard: kubernetes-prometheus
       meta: Prometheus frontend is down
-      service: prometheus
-      severity: critical
-      tier: k8s
+      service: metrics
+      severity: warning
+      support_group: observability
       playbook: docs/support/playbook/prometheus/federation
     annotations:
       description: "Global Prometheus cannot federate from Prometheus in scaleout cluster {{ $labels.cluster }}. Alerting and dashboards are unavailable."
@@ -83,9 +83,9 @@ groups:
       context: availability
       dashboard: kubernetes-prometheus
       meta: Prometheus frontend is down
-      service: prometheus
-      severity: critical
-      tier: k8s
+      service: metrics
+      severity: warning
+      support_group: observability
       playbook: docs/support/playbook/prometheus/federation
     annotations:
       description: "Global Prometheus cannot federate from Prometheus in internet cluster {{ $labels.cluster }}. Alerting and dashboards are unavailable."
@@ -98,9 +98,9 @@ groups:
       context: availability
       dashboard: kubernetes-prometheus
       meta: Prometheus frontend is down
-      service: prometheus
-      severity: critical
-      tier: k8s
+      service: metrics
+      severity: warning
+      support_group: observability
       playbook: docs/support/playbook/prometheus/federation
     annotations:
       description: "Global Prometheus cannot federate from Prometheus in customer cluster {{ $labels.cluster }}. Alerting and dashboards are unavailable."
@@ -112,9 +112,9 @@ groups:
     labels:
       context: availability-global
       meta: Prometheus global can't federate data from Prometheus frontend in {{ $labels.region }}
-      service: prometheus
-      severity: critical
-      tier: k8s
+      service: metrics
+      severity: warning
+      support_group: observability
       playbook: docs/support/playbook/prometheus/federation
     annotations:
       description: Prometheus Global can't federate data from {{ $labels.region }}. Alerting will be unavailable! This could mean the region is partly down!

--- a/global/prometheus-kubernikus-global/Chart.yaml
+++ b/global/prometheus-kubernikus-global/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for the operated global Prometheus for monitoring Kubernikus.
 name: prometheus-kubernikus-global
-version: 4.0.3
+version: 4.0.4
 
 dependencies:
   - name: prometheus-server-pre7

--- a/global/prometheus-kubernikus-global/alerts/prometheus.alerts
+++ b/global/prometheus-kubernikus-global/alerts/prometheus.alerts
@@ -8,9 +8,9 @@ groups:
         context: availability-global
         meta: Prometheus global can't federate data from Prometheus frontend in kubernikus-{{ $labels.region }}
         playbook: docs/support/playbook/kubernikus/index
-        service: prometheus
-        severity: critical
-        tier: kks
+        service: metrics
+        severity: warning
+        support_group: observability
       annotations:
         description: Prometheus Global can't federate data from kubernikus-{{ $labels.region }}. Alerting will be unavailable. This could mean the region is partly down!
         summary: Global Prometheus Federation is having trouble


### PR DESCRIPTION
Updated the support group and service to forward alerts. None of the alerts are critical, so I reduced them to warning.