### PR TITLE
[hermes] increase es replicas to 1 

### DIFF
--- a/openstack/hermes/templates/etc/_audit.json.tpl
+++ b/openstack/hermes/templates/etc/_audit.json.tpl
@@ -5,7 +5,7 @@
   "settings" : {
     "index" : {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "codec": "best_compression",
       "max_result_window": 20000
     }


### PR DESCRIPTION
Increasing ES replicas to 1 in the index template. We cannot merge this until the Single Node is removed, when we are ready to remove it.