### PR TITLE
common/prometheus-server: adds option to name swift containers uniquely

### DIFF
--- a/common/prometheus-server/CHANGELOG.md
+++ b/common/prometheus-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.2.8
+
+* Option to create unique swift containers
+
 ## 7.2.7
 
 * Switch domain source to `.Values.global.tld`

--- a/common/prometheus-server/Chart.yaml
+++ b/common/prometheus-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus via operator.
 name: prometheus-server
-version: 7.2.7
+version: 7.2.8
 appVersion: v2.43.0
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
 maintainers:

--- a/common/prometheus-server/templates/_helpers.tpl
+++ b/common/prometheus-server/templates/_helpers.tpl
@@ -194,7 +194,11 @@ prometheus-{{- $name -}}.{{- required "$root.Values.global.region missing" $root
 {{- define "swift.userName" -}}
 {{- $name := index . 0 -}}
 {{- $root := index . 1 -}}
+{{- if $root.Values.thanosSeeds.seed.clusterType -}}
+{{- (include "prometheus.fullName" .) -}}-{{- $root.Values.thanosSeeds.seed.clusterType -}}-thanos
+{{- else -}}
 {{- (include "prometheus.fullName" .) -}}-thanos
+{{- end -}}
 {{- end -}}
 
 {{/* Special renaming for vmware-monitoring */}}

--- a/common/prometheus-server/values.yaml
+++ b/common/prometheus-server/values.yaml
@@ -237,6 +237,9 @@ thanosSeeds:
       - monsoon3/domain-ccadmin-seed
       - monsoon3/domain-default-seed
 
+    # optional cluster type appended to container name to prevent same names for different prometheus
+    clusterType:
+
   # Configuration for OpenStack Swift Thanos storage backend.
   # Deploy an OpenstackSeed custom resource triggering creation of an Openstack user and Swift container used to persist Prometheus metrics.
   # See: https://github.com/sapcc/kubernetes-operators/tree/master/openstack-seeder


### PR DESCRIPTION
When we extend prometheus kubernetes with thanos, thanos swift containers are rendered with the same name. To avoid this, we append the appropriate cluster type to the name.