### PR TITLE
kube-monitoring-scaleout: removes prometheus-server

### DIFF
--- a/system/kube-monitoring-scaleout/Chart.lock
+++ b/system/kube-monitoring-scaleout/Chart.lock
@@ -41,9 +41,6 @@ dependencies:
 - name: prometheus-scaleout-rules
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.0
-- name: prometheus-server
-  repository: https://charts.eu-de-2.cloud.sap
-  version: 7.1.22
 - name: watchcache-exporter
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.6
@@ -59,5 +56,5 @@ dependencies:
 - name: falco
   repository: https://falcosecurity.github.io/charts
   version: 3.1.4
-digest: sha256:7d138ec2940ed2cd8cd40cf6580a4ed3163ebf61acbb4d616c12b73e888c3ae3
-generated: "2023-06-16T15:54:22.663082827+02:00"
+digest: sha256:01ad94819f2fc25029bd51f8af75b91f58fbb6d09fe43112e566bc12c4644060
+generated: "2023-06-19T08:35:17.154408+02:00"

--- a/system/kube-monitoring-scaleout/Chart.yaml
+++ b/system/kube-monitoring-scaleout/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kubernetes scaleout cluster monitoring.
 name: kube-monitoring-scaleout
-version: 4.5.11
+version: 4.5.12
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-scaleout
 dependencies:
   - condition: absent-metrics-operator.enabled
@@ -48,9 +48,6 @@ dependencies:
   - name: prometheus-scaleout-rules
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.1.0
-  - name: prometheus-server
-    repository: https://charts.eu-de-2.cloud.sap
-    version: 7.1.22
   - name: watchcache-exporter
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.1.6


### PR DESCRIPTION
In order to include it in the unified Thanos setup, prometheus-server will be managed and operated by observability team in the future. For this purpose, it will be removed from kube-monitoring and transferred to its own Helm Chart.