### PR TITLE
[nova] Automatically confirm resize after three days

### DIFF
--- a/openstack/nova/templates/hypervisors/hypervisors-vmware-configmap-vct.yaml
+++ b/openstack/nova/templates/hypervisors/hypervisors-vmware-configmap-vct.yaml
@@ -27,6 +27,7 @@ template: |
       graceful_shutdown_timeout = 900
       compute_driver = vmwareapi.VMwareVCDriver
       reserved_host_memory_mb = 0
+      resize_confirm_window = {{ .Values.compute.defaults.default.resize_confirm_window }}
       {{- if .Values.compute.defaults.default.max_concurrent_builds_per_project }}
       max_concurrent_builds_per_project = {{ .Values.compute.defaults.default.max_concurrent_builds_per_project }}
       {{- end }}

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -277,6 +277,8 @@ compute:
       rpc_statsd_port: 9125
       # enables collecting metrics for RPC calls
       rpc_statsd_enabled: true
+      # confirm automatically a resize after 3 days
+      resize_confirm_window: 259200
     vmware:
       insecure: true
       use_linked_clone: false


### PR DESCRIPTION
Users often forget to confirm a resize after the vm has been successfully resized.

Automatically confirming brings the VMs back to a standard state and clean up the copy of the root disk.

The time-frame was chosen to be a weekend plus one day to be hopefully as short as possible without messing up anyany manual process going on, which might get delayed over a weekend.