### PR TITLE
[sap-seeds] "forced" flavor requires no resources

### DIFF
--- a/openstack/sap-seeds/values.yaml
+++ b/openstack/sap-seeds/values.yaml
@@ -21,7 +21,10 @@ global:
     skip_hcm_domain: false
 
 extra_specs:
-  forced: {}
+  forced:
+    "resources:VCPU": "0"
+    "resources:MEMORY_MB": "0"
+    "resources:DISK_GB": "0"
   vmware_common: &vmware_common
     "capabilities:hypervisor_type": "VMware vCenter Server"
     "hw_video:ram_max_mb": "16"


### PR DESCRIPTION
Since the purpose of the "forced" flavor is to be able to force a deployment to any Ironic node, it must not have any resource requests. Since Nova's Xena update, Ironic hypervisors report only their CUSTOM_* resource and no disk, memory or vcpus. Therefore, the "forced" flavor would not work anymore.