### PR TITLE
[nova] Support and configure weights for PreferSameShardOnResizeWeigher

### DIFF
--- a/openstack/nova/templates/etc/_nova-scheduler.conf.tpl
+++ b/openstack/nova/templates/etc/_nova-scheduler.conf.tpl
@@ -26,5 +26,6 @@ disk_weight_multiplier =  {{ .Values.scheduler.disk_weight_multiplier }}
 io_ops_weight_multiplier = {{ .Values.scheduler.io_ops_weight_multiplier }}
 soft_affinity_weight_multiplier = {{ .Values.scheduler.soft_affinity_weight_multiplier }}
 prefer_same_host_resize_weight_multiplier = {{ .Values.scheduler.prefer_same_host_resize_weight_multiplier }}
+prefer_same_shard_resize_weight_multiplier = {{ .Values.scheduler.prefer_same_shard_resize_weight_multiplier }}
 hv_ram_class_weight_multiplier = {{ .Values.scheduler.hv_ram_class_weight_multiplier }}
 image_properties_default_architecture = {{ .Values.scheduler.image_properties_default_architecture }}

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -258,9 +258,13 @@ scheduler:
   # The following weighers are crutches, but we can't express it otherwise
   # currently. They should overpower the other weighers even in worst-case
   # (e.g. least ram available + worst disk weight), so we have to make it >=
-  # len(other_weighers). At the same time, we, want a VM to not move on resize,
-  # if it doesn't have to - even if it's in the wrong RAM class currently.
+  # len(other_weighers). At the same time, we want a VM to not move on resize,
+  # if it doesn't have to - even if it's in the wrong RAM class currently,
+  # preferring the same host to keep the ephemeral disk on the same
+  # datastore-cluster, but using the same shard if possible for less
+  # volume-migrations.
   prefer_same_host_resize_weight_multiplier: 1000.0
+  prefer_same_shard_resize_weight_multiplier: 200.0
   hv_ram_class_weight_multiplier: 100.0
   image_properties_default_architecture: "x86_64"
 


### PR DESCRIPTION
We want VMs to not move between shards on resize if possible, because this takes a long time for VMs having volumes attached because of the amount of data needing migration. We already prefer the same host on resize, but if that's not possible e.g. because of resizing to HANA or away from a small VM, the same shard should be used.

To accommodate that, we set the weight for the
`PreferSameShardOnResizeWeigher` to 200. This still prefers the same host if possible, which is advantageous because of less ephemeral disk copying/duplication, but prefer the same shard over the right RAM class. E.g., the right RAM class with more space in another shard would now, with weight 100 on the `HvRamClassWeigher` have a weight of 1xx, while the weight of the wrong RAM class in the same shard would now be 2xx and by that overpower the RAM class in another shard.