### PR TITLE
[nova] Switch to single HV RAM class

### DIFF
--- a/openstack/nova/templates/etc/_nova-scheduler.conf.tpl
+++ b/openstack/nova/templates/etc/_nova-scheduler.conf.tpl
@@ -28,4 +28,5 @@ soft_affinity_weight_multiplier = {{ .Values.scheduler.soft_affinity_weight_mult
 prefer_same_host_resize_weight_multiplier = {{ .Values.scheduler.prefer_same_host_resize_weight_multiplier }}
 prefer_same_shard_resize_weight_multiplier = {{ .Values.scheduler.prefer_same_shard_resize_weight_multiplier }}
 hv_ram_class_weight_multiplier = {{ .Values.scheduler.hv_ram_class_weight_multiplier }}
+hv_ram_class_weights_gib = {{ .Values.scheduler.hv_ram_class_weights_gib }}
 image_properties_default_architecture = {{ .Values.scheduler.image_properties_default_architecture }}

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -266,6 +266,8 @@ scheduler:
   prefer_same_host_resize_weight_multiplier: 1000.0
   prefer_same_shard_resize_weight_multiplier: 200.0
   hv_ram_class_weight_multiplier: 100.0
+  # this is a DictOpt and takes the form key1:value1,key2:value2
+  hv_ram_class_weights_gib: "1024:1"
   image_properties_default_architecture: "x86_64"
 
 compute:


### PR DESCRIPTION
We used to define 3 RAM classes (by default in Nova): < 1024, < 3072 and the rest. These latter two were meant to keep big VMs spawnable before we had HANA-only blocks.

By now we have blocks >= 3072 that are not HANA-only - but only in regions were we define HANA-only blocks. These big, general purpose blocks are kept free by this weigher, even though there's no need for it anymore.

To make more use of those big, general purpose blocks, we remove the last RAM class and thus divide now into < 1024 and the rest. This means, that big VMs might spawn more likely on HANA-only blocks >= 3072, but we have means of automatically balancing those after the fact if the need arises and we value the normal VMs using the big, general purpose blocks more than not having to balance big VMs.