### PR TITLE
[bind] allow more SOA queries, but limit notifies

### DIFF
--- a/system/bind/templates/config.yaml
+++ b/system/bind/templates/config.yaml
@@ -31,6 +31,9 @@ data:
       transfers-in {{ .Values.transfers_in | default 100 }};
       tcp-clients {{ .Values.tcp_clients | default 250 }};
       tcp-listen-queue {{ .Values.tcp_listen_queue | default 25 }};
+      serial-query-rate {{.Values.serial_query_rate | default 20}};
+      notify-rate {{.Values.notify_rate | default 20}};
+      startup-notify-rate {{.Values.startup_notify_rate | default 20}};
      };
      server {{ .Values.master_server }} {
       keys tsig-key;

--- a/system/bind/values.yaml
+++ b/system/bind/values.yaml
@@ -20,6 +20,18 @@ rndc_allow: DEFINED-REGION-CHART
 rndc_key: DEFINED-REGION-CHART
 tsig_key: DEFINED-REGION-CHART
 
+# lets allow more outgoing SOA queries:
+serial_query_rate: 50
+
+# but don't overwhelm secondaries:
+notify_rate: 20
+
+# slow the rate of notifications to downstream servers on restart,
+# They will be removed from the start-up notify queue if their zone
+# is updated as part of regular zone maintenance, and we don't need
+# to flood them on each pod/container restart
+startup_notify_rate: 10
+
 # should be set to different AZs; this is where PV will be claimed
 failure_domain_zone: a
 


### PR DESCRIPTION
We hit the limit of parallel SOA queries to mdns -- the default in bind is 20.
These settings allow more queries in parallel, allowing for faster zone syncs.
Details on the values can be found in https://kb.isc.org/docs/aa-01313
