### PR TITLE
[bind] reverting topology labels

### DIFF
--- a/system/bind/Chart.yaml
+++ b/system/bind/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Bind DNS software. 
 name: bind
-version: 1.0.2
+version: 1.0.1
 appVersion: "9.16.39"
 dependencies:
   - name: owner-info

--- a/system/bind/templates/deployment.yaml
+++ b/system/bind/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
                     {{ if eq .Values.name (printf "bind2-%s" (.Values.global.region)) }}- bind1-{{.Values.global.region}}{{ end }}
                     {{ if eq .Values.name (printf "bind1-global-%s" (.Values.global.region)) }}- bind2-global-{{.Values.global.region}}{{ end }}
                     {{ if eq .Values.name (printf "bind2-global-%s" (.Values.global.region)) }}- bind1-global-{{.Values.global.region}}{{ end }}
-              topologyKey: "topology.kubernetes.io/zone"
+              topologyKey: "failure-domain.beta.kubernetes.io/zone"
         {{ end }} 
       containers:
       - name: {{ .Release.Name }}

--- a/system/bind/templates/pvclaim.yaml
+++ b/system/bind/templates/pvclaim.yaml
@@ -12,5 +12,5 @@ spec:
 {{ if .Values.pvc_zone_selector }}
   selector:
     matchLabels:
-      topology.kubernetes.io/zone: {{ .Values.global.region }}{{ .Values.failure_domain_zone }}
+      failure-domain.beta.kubernetes.io/zone: {{ .Values.global.region }}{{ .Values.failure_domain_zone }}
 {{ end }}


### PR DESCRIPTION
reverting changes from commit e804f5678a67e39f7bcf64d83ef7b224d06da730 "use non-deprecated topology labels" as it currently prevents deployment.