### PR TITLE
[mariadb] updates backupv2 base image

### DIFF
--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.7.10
+version: 0.7.11

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -107,7 +107,7 @@ use_alternate_registry: false
 
 readiness:
   image: pod-readiness
-  image_version: 70f3884b
+  image_version: "20230623091358"
   # set to true if backup_v2 is not enabled, but readiness sidecar is required
   useSidecar: false
 
@@ -115,7 +115,7 @@ backup_v2:
   enabled: false
   backup_dir: "./backup"
   image: maria-back-me-up
-  image_version: "20230320175717"
+  image_version: "20230623092741"
   full_backup_cron_schedule: "0 0 * * *"
   incremental_backup_in_minutes: 5
   purge_binlog_after_minutes: 60


### PR DESCRIPTION
new base image created for backup and readiness pod due to security issue. Both images are now clean.

