### PR TITLE
[memcached] bump imageTag versions of library/memcached and prom/memcached-exporter

### DIFF
--- a/common/memcached/Chart.yaml
+++ b/common/memcached/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: memcached
-version: 0.1.1
+version: 0.1.2
 description: Free & open source, high-performance, distributed memory object caching system.
 home: http://memcached.org/
 sources:

--- a/common/memcached/values.yaml
+++ b/common/memcached/values.yaml
@@ -2,7 +2,7 @@
 ## ref: https://hub.docker.com/r/library/memcached/tags/
 ##
 image: library/memcached
-imageTag: 1.6.18-alpine
+imageTag: 1.6.20-alpine
 # set to true to use .Values.global.dockerHubMirrorAlternateRegion instead of .Values.global.dockerHubMirror
 use_alternate_registry: false
 

--- a/common/memcached/values.yaml
+++ b/common/memcached/values.yaml
@@ -45,7 +45,7 @@ resources:
 metrics:
   enabled: true
   image: 'prom/memcached-exporter'
-  imageTag: 'v0.11.2'
+  imageTag: 'v0.13.0'
 
   port: '9150'
   resources:


### PR DESCRIPTION
The updated versions are clean as per Trivy