### PR TITLE
[kube-system] add support group to IngressExternalPublicServiceDown alerts

### DIFF
--- a/system/kube-system-global/templates/ingress-external-public-service-monitor.yaml
+++ b/system/kube-system-global/templates/ingress-external-public-service-monitor.yaml
@@ -40,6 +40,7 @@ spec:
             context: availability
             service: ingress
             severity: critical
+            support_group: containers
             playbook: "/docs/support/playbook/kubernetes/ingress_public_ip_not_reachable"
             tier: k8s
 {{- end }}

--- a/system/kube-system-metal/templates/ingress-external-public-service-monitor.yaml
+++ b/system/kube-system-metal/templates/ingress-external-public-service-monitor.yaml
@@ -40,6 +40,7 @@ spec:
             context: availability
             service: ingress
             severity: critical
+            support_group: containers
             playbook: "/docs/support/playbook/kubernetes/ingress_public_ip_not_reachable"
             tier: k8s
 {{- end }}


### PR DESCRIPTION
…lerts

critical alert needs alert routing