### PR TITLE
[neutron] Add metric that exposes the last heartbeat's timestamp

### DIFF
--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -490,6 +490,20 @@ mysql_metrics:
         WHERE admin_state_up AND heartbeat_timestamp > (DATE_SUB(now(), INTERVAL 90 SECOND));
       values:
       - "heartbeat_seconds"
+    - help: Neutron agent unix timestamp of the last heartbeat
+      labels:
+      - "neutron_host"
+      - "agent_type"
+      name: openstack_neutron_monitor_agents_heartbeat_timestamp
+      query: |
+        SELECT
+          host AS neutron_host,
+          agent_type,
+          UNIX_TIMESTAMP(heartbeat_timestamp) AS heartbeat_timestamp
+        FROM agents
+        WHERE admin_state_up
+      values:
+      - "heartbeat_timestamp"
     - help: Neutron agents load
       labels:
       - "neutron_host"


### PR DESCRIPTION
Exposing the seconds since the last timestamp as seen from the database
adds some complexity as prometheus will carry that value as it was on
time the exporter run. This makes it necessary to add the time passed
when the exporter was last run to get the actual value.

Just exposing a unix timestamp makes it much easier.
