### PR TITLE
common/postgres: add sharedMemoryLimit parameter, use in Keppel

### DIFF
--- a/common/postgresql/templates/deployment.yaml
+++ b/common/postgresql/templates/deployment.yaml
@@ -109,6 +109,10 @@ spec:
         - name: db-maintain
           mountPath: /docker-entrypoint-maintaindb.d
 {{- end }}
+{{- if .Values.sharedMemoryLimit }}
+        - name: dev-shm
+          mountPath: /dev/shm
+{{- end }}
       volumes:
       - name: postgres-etc
         configMap:
@@ -129,4 +133,10 @@ spec:
       - name: db-maintain
         configMap:
           name: {{ .Values.dbMaintain }}
+{{- end }}
+{{- if .Values.sharedMemoryLimit }}
+      - name: dev-shm
+        emptyDir:
+          medium: Memory
+          sizeLimit: {{ .Values.sharedMemoryLimit }}
 {{- end }}

--- a/common/postgresql/values.yaml
+++ b/common/postgresql/values.yaml
@@ -38,6 +38,10 @@ persistence:
   # Re-use existing (unmanged) PVC
   # existingClaim: claimName
 
+# Size of /dev/shm. If null, we use whatever default amount the container
+# runtime gives us (see `df -h /dev/shm` inside the Postgres container).
+sharedMemoryLimit: null
+
 probe_timeout_secs: 3
 probe_failure_threshold: 6 # number of liveness probes that need to fail to trigger a pod restart
 

--- a/openstack/keppel/values.yaml
+++ b/openstack/keppel/values.yaml
@@ -113,6 +113,8 @@ postgresql:
     accessMode: ReadWriteOnce
     size: 100Gi
 
+  sharedMemoryLimit: 256Mi
+
   log_min_duration_statement: 250
   # less than the postgresql chart's default; I want to know early when connections start getting out of hand
   max_connections: 128


### PR DESCRIPTION
We observed problems with this limit on prod:

```
ERROR: during "GET /keppel/v1/accounts/<redacted>/repositories": pq: could not resize shared memory segment "/PostgreSQL.710526079" to 4194304 bytes: No space left on device
```

I tested the change in qa-de-1/keppel:

```shellSession
$ k exec keppel-postgresql-745557b9d7-w6wrj -- df -h /dev/shm
Filesystem      Size  Used Avail Use% Mounted on
tmpfs           256M   20K  256M   1% /dev/shm
```