### PR TITLE
Introduce possibility to rollout neutron api rate limiting

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -20,5 +20,8 @@ dependencies:
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:e518844dc6db8db7156ce00d00309951fe0df5cf272ad5b427b5481e95dc109e
-generated: "2023-07-04T10:22:50.467459912+02:00"
+- name: redis
+  repository: https://charts.eu-de-2.cloud.sap
+  version: 1.2.4
+digest: sha256:b7654a713b51d19debd2bb453af71ee000e17b310ac1443782bc87dcd4ae35b7
+generated: "2023-08-02T16:00:19.287862+02:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -29,3 +29,8 @@ dependencies:
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0
+  - name: redis
+    alias: api-ratelimit-redis
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 1.2.4
+    condition: rate_limit.enabled

--- a/openstack/neutron/templates/configmap-etc.yaml
+++ b/openstack/neutron/templates/configmap-etc.yaml
@@ -58,6 +58,10 @@ data:
   watcher.yaml: |
 {{ include (print .Template.BasePath "/etc/_watcher.yaml.tpl") . | indent 4 }}
 {{- end }}
+{{- if ((.Values.rate_limit).enabled) }}
+  ratelimit.yaml: |
+{{ include (print .Template.BasePath "/etc/_ratelimit.yaml.tpl") . | indent 4 }}
+{{- end }}
   statsd-exporter.yaml: |
     defaults:
       timer_type: histogram

--- a/openstack/neutron/templates/deployment-server.yaml
+++ b/openstack/neutron/templates/deployment-server.yaml
@@ -204,6 +204,12 @@ spec:
               subPath: watcher.yaml
               readOnly: true
             {{- end }}
+            {{- if ((.Values.rate_limit).enabled) }}
+            - mountPath: /etc/neutron/ratelimit.yaml
+              name: neutron-etc
+              subPath: ratelimit.yaml
+              readOnly: true
+            {{- end }}
             {{- if .Values.pod.debug.server }}
             - mountPath: /development
               name: development

--- a/openstack/neutron/templates/etc/_ratelimit.yaml.tpl
+++ b/openstack/neutron/templates/etc/_ratelimit.yaml.tpl
@@ -1,0 +1,48 @@
+#Allowed Projects List
+{{- if .Values.rate_limit.whitelist }}
+whitelist:
+{{ .Values.rate_limit.whitelist | toYaml | indent 3 }}
+{{- end }}
+
+{{- if .Values.rate_limit.whitelist_users }}
+#Allowed Users List
+whitelist_users:
+{{ .Values.rate_limit.whitelist_users | toYaml | indent 3 }}
+{{- end }}
+
+{{- if .Values.rate_limit.blacklist }}
+#Blocked Projects List
+blacklist:
+{{ .Values.rate_limit.blacklist | toYaml | indent 3 }}
+{{- end }}
+
+{{- if .Values.rate_limit.blacklist_users }}
+#Blocked Users List
+blacklist_users:
+{{ .Values.rate_limit.blacklist_users | toYaml | indent 3 }}
+{{- end }}
+
+{{- if .Values.rate_limit.groups }}
+#Custom groups for CADF actions
+groups:
+{{- range $group_name, $group_actions := .Values.rate_limit.groups }}
+   {{ $group_name }}:
+       {{- range $actions := $group_actions }}
+      - {{ $actions }}
+         {{- end }}
+{{- end }}
+{{- end }}
+
+{{- if .Values.rate_limit.limit_by }}
+{{- end }}
+
+{{- if .Values.rate_limit.rates }}
+rates:
+{{- range $level_k, $level := .Values.rate_limit.rates }}
+  {{ $level_k }}:
+        {{- range $target_uri_type, $target_uri_type_limits := $level }}
+    {{ $target_uri_type }}:
+{{ $target_uri_type_limits | toYaml | indent 6 }}
+        {{- end }}
+{{- end }}
+{{- end }}

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -86,7 +86,7 @@ pod:
         memory: '1Gi'
       requests:
         cpu: '250m'
-        memory: '512Mi' 
+        memory: '512Mi'
     server:
       requests:
         cpu: "4000m"
@@ -343,6 +343,9 @@ logging:
     auditmiddleware:
       handlers: stdout, sentry
       level: INFO
+    rate_limit.rate_limit:
+      handlers: stdout, sentry
+      level: INFO
 
 pgmetrics:
   enabled: false
@@ -590,6 +593,20 @@ rabbitmq_notifications:
 # openstack-watcher-middleware
 watcher:
   enabled: true
+
+# openstack-rate-limit
+rate_limit:
+  enabled: false
+  rate_limit_by: target_project_id
+  max_sleep_time_seconds: 0
+  log_sleep_time_seconds: 10
+  backend_timeout_seconds: 1
+  whitelist:
+    - Default/service
+    - Default/admin
+  whitelist_users: null
+  blacklist: null
+  blacklist_users: null
 
 unittest:
   enabled: false


### PR DESCRIPTION
Based on openstack-watcher and openstack-rate-limit middleware, neutron api should be rate limited. In a first step the technial possiblities should be enabled. This requires the installation of the middleware dependencies via loci pipeline (https://github.com/sapcc/neutron/pull/48)

Per default neutron api rate limiting is disabled. Furthermore the service project is whitelisted (no rate limits apply) and for all other projects only a dummy target uri (named placeholer) is defined. As results no rate limits are applied after all.