### PR TITLE
openstack/cerebro: update owner-info to v0.2.0

### DIFF
--- a/openstack/cerebro/Chart.lock
+++ b/openstack/cerebro/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.2
-digest: sha256:2f618521b7e61bac110b377c476886418fdd89aa96bb9ad1c48d4c6197a602c5
-generated: "2022-05-19T11:50:26.195199+02:00"
+  version: 0.2.0
+digest: sha256:6c7a0e8b21abdaecf3124234d79457638aff93c3f51c9cedd56500d24eb652e0
+generated: "2023-07-10T13:32:51.105366723+02:00"

--- a/openstack/cerebro/Chart.yaml
+++ b/openstack/cerebro/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 dependencies:
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.2
+    version: 0.2.0

--- a/openstack/cerebro/values.yaml
+++ b/openstack/cerebro/values.yaml
@@ -1,4 +1,6 @@
 owner-info:
+  support_group: observability
+  service: cerebro
   maintainers:
     - Tommy Sauer
     - Alan Sergeant


### PR DESCRIPTION
Using older owner-info versions generates a Gatekeeper violation because of the missing support group reference. Since this release contains only seeds, we should be fine falling back to @viennaa's support group association.