### PR TITLE
keystone: controls for delayed assignment cleanup

### DIFF
--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -34,6 +34,10 @@ dependencies:
     name: redis
     repository: https://charts.eu-de-2.cloud.sap
     version: 1.2.23
+  - alias: keystone-cron-redis
+    name: redis
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 1.2.23
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
     version: ~0.10.0

--- a/openstack/keystone/templates/etc/_keystone.conf.tpl
+++ b/openstack/keystone/templates/etc/_keystone.conf.tpl
@@ -238,3 +238,7 @@ allow_headers = Content-Type,Cache-Control,Content-Language,Expires,Last-Modifie
 {{- if .Values.osprofiler.enabled }}
 {{- include "osprofiler" . }}
 {{- end }}
+
+[cron]
+redis_connection = {{ .Values.cron.redis_connection | default keystone-cron-redis }}
+repair_tolerance_days = {{ .Values.cron.repair_tolerance_days | default 14 }}


### PR DESCRIPTION
Immediately deleting role assignments is sometimes not desirable. People might forget to renew their ldap group membership, be on vacation or have other temporary short-term leave. Another case is a temporary unavalability of CAM resulting in users not being visible in keystone.

If the role assignment is gone, projects are left unattended, and it is not desirable.