### PR TITLE
[rabbitmq] improve RabbitMQNotReady alert

### DIFF
--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 0.6.0
+version: 0.6.1
 description: A Helm chart for RabbitMQ
 sources:
 - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/templates/alerts/_health.alerts.tpl
+++ b/common/rabbitmq/templates/alerts/_health.alerts.tpl
@@ -1,7 +1,11 @@
 - name: health.alerts
   rules:
   - alert: {{ include "alerts.service" . | title }}RabbitMQNotReady
+    {{- if eq .Values.kind "statefulset" }}
     expr: (kube_pod_status_ready_normalized{condition="true", pod=~"{{ include "fullname" . }}.*", pod!~"{{ include "fullname" . }}-notifications.*"} < 1)
+    {{- else }}  # kind equals "deployment"
+    expr: (sum(kube_pod_status_ready_normalized{condition="true", pod=~"{{ include "fullname" . }}.*", pod!~"{{ include "fullname" . }}-notifications.*"}) < 1)
+    {{- end }}
     for: 10m
     labels:
       severity: critical


### PR DESCRIPTION
The critical alert should not fire if any rabbitmq is not ready, it should fire if no rabbitmq pods are ready.
Which is is difference, because there may be a NotReady pod still lingering around next to a working Ready pod.
We observed this with a pod stuck in Terminating due a node not being safely drained.