### PR TITLE
[mariadb] improve MariaDBNotReady alert

### DIFF
--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.7.11
+version: 0.7.12

--- a/common/mariadb/templates/alerts/_health.alerts.tpl
+++ b/common/mariadb/templates/alerts/_health.alerts.tpl
@@ -1,7 +1,7 @@
 - name: health.alerts
   rules:
   - alert: {{ include "alerts.service" . | title }}MariaDBNotReady
-    expr: (kube_pod_status_ready_normalized{condition="true", pod=~"{{ include "fullName" . }}.*", pod!~"{{ include "fullName" . }}-backup.*", pod!~"{{ include "fullName" . }}-verification.*"} < 1)
+    expr: (sum(kube_pod_status_ready_normalized{condition="true", pod=~"{{ include "fullName" . }}.*", pod!~"{{ include "fullName" . }}-backup.*", pod!~"{{ include "fullName" . }}-verification.*"}) < 1)
     for: 10m
     labels:
       context: availability
@@ -11,5 +11,5 @@
       support_group: {{ required ".Values.alerts.support_group missing" .Values.alerts.support_group }}
       playbook: 'docs/support/playbook/db_crashloop'
     annotations:
-      description: {{ include "fullName" . }} database is not ready for 10 minutes.
-      summary: {{ include "fullName" . }} is not ready for 10 minutes. Please check the pod.
+      description: No {{ include "fullName" . }} database is ready for 10 minutes.
+      summary: No {{ include "fullName" . }} is ready for 10 minutes. Please check the pod.


### PR DESCRIPTION
The critical alert should not fire if any mariadb is not ready, it should fire if no mariadb pods are ready.
Which is is difference, because there may be a NotReady pod still lingering around next to a working Ready pod.

We observed this on rabbitq with a pod stuck in Terminating due a node not being safely drained.
see similar commit
fc6402dfca1d98fdab0872d4269ee51f36f29f10