### PR TITLE
[barbican] update dependency on rabbitmq to version 0.5.2

### DIFF
--- a/openstack/barbican/Chart.lock
+++ b/openstack/barbican/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 0.2.7
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.5.1
+  version: 0.5.2
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.10.1
@@ -20,5 +20,5 @@ dependencies:
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:722d84fc79244baafccce042894135838842a7da687178f222e2c51e99ba4a19
-generated: "2023-06-29T16:30:52.59205+05:30"
+digest: sha256:65777d9f3eb255a444c5a34c21cdfa1281cd8afd35ecdb1b0824dc0364e74b9a
+generated: "2023-07-14T09:27:03.092619+02:00"

--- a/openstack/barbican/Chart.yaml
+++ b/openstack/barbican/Chart.yaml
@@ -18,7 +18,7 @@ dependencies:
     version: 0.2.7
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.5.1
+    version: 0.5.2
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
     version: ~0.10.1


### PR DESCRIPTION
adding vendor's feature enhancements and bug fixes: rabbitmq-3.11.15-management
[ChangeLog](https://www.rabbitmq.com/changelog.html)