### PR TITLE
[octavia] Drop unused notification rabbitmq

### DIFF
--- a/openstack/octavia/Chart.lock
+++ b/openstack/octavia/Chart.lock
@@ -11,14 +11,11 @@ dependencies:
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.4.4
-- name: rabbitmq
-  repository: https://charts.eu-de-2.cloud.sap
-  version: 0.4.4
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.10.0
+  version: 0.10.1
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:365234bfde292dc74cdd4b38f823a1e785a1915dd4752a9d63b32e728fc83a54
-generated: "2023-06-01T12:42:48.944327634+02:00"
+digest: sha256:c902cda067d92ec292fc36c2f04539927c918cee54d2d8d4891db554c30dd972
+generated: "2023-07-14T11:55:51.540693332+02:00"

--- a/openstack/octavia/Chart.yaml
+++ b/openstack/octavia/Chart.yaml
@@ -23,11 +23,6 @@ dependencies:
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.4.4
-  - alias: rabbitmq_notifications
-    condition: audit.enabled
-    name: rabbitmq
-    repository: https://charts.eu-de-2.cloud.sap
-    version: 0.4.4
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
     version: ~0.10.0


### PR DESCRIPTION
All notification messages are send to the hermes rabbitmq, and the consumer has been removed from the notification rabbitmq from octavia.