### PR TITLE
Cinder: Allow inexact volume/backup search by desc

### DIFF
--- a/openstack/cinder/templates/etc/_resource_filters.json.tpl
+++ b/openstack/cinder/templates/etc/_resource_filters.json.tpl
@@ -1,8 +1,8 @@
 {
     "volume": ["name", "name~", "status", "metadata",
                "bootable", "migration_status", "availability_zone",
-               "group_id", "user_id"],
-    "backup": ["name", "status", "volume_id"],
+               "group_id", "user_id", "description~"],
+    "backup": ["name", "status", "volume_id", "description~"],
     "snapshot": ["name", "name~", "status", "volume_id", "metadata",
                  "availability_zone"],
     "group": [],


### PR DESCRIPTION
This patch updates the Cinder resource filters to allow users to do an inexact search on volume and backup for the description.