### PR TITLE
[content-repo] move ownership from swift to repo

### DIFF
--- a/openstack/content-repo/alerts/content-repo.alerts
+++ b/openstack/content-repo/alerts/content-repo.alerts
@@ -9,7 +9,7 @@ groups:
     labels:
       support_group: containers
       tier: os
-      service: swift
+      service: repo
       severity: info
       context: repo
     annotations:
@@ -23,7 +23,7 @@ groups:
       no_alert_on_absence: "true" # See OpenstackContentRepoMetricsMissing alert.
       support_group: containers
       tier: os
-      service: swift
+      service: repo
       severity: info
       context: repo
       meta: "repo {{ $labels.repo }} is outdated"
@@ -38,7 +38,7 @@ groups:
       no_alert_on_absence: "true" # See OpenstackContentRepoMetricsMissing alert.
       support_group: containers
       tier: os
-      service: swift
+      service: repo
       severity: info
       context: repo
       meta: "repo {{ $labels.repo }} has skipped some sync jobs"
@@ -53,7 +53,7 @@ groups:
       no_alert_on_absence: "true" # See OpenstackContentRepoMetricsMissing alert.
       support_group: containers
       tier: os
-      service: swift
+      service: repo
       severity: info
       context: repo-{{ $labels.repo }}-entitlement
       meta: "invalid entitlement for {{ $labels.repo }}"
@@ -69,7 +69,7 @@ groups:
       no_alert_on_absence: "true" # See OpenstackContentRepoMetricsMissing alert.
       support_group: containers
       tier: os
-      service: swift
+      service: repo
       severity: info
       context: repo-{{ $labels.repo }}-entitlement
       meta: "entitlement check failed for {{ $labels.repo }}"

--- a/openstack/content-repo/templates/check-deployment.yaml
+++ b/openstack/content-repo/templates/check-deployment.yaml
@@ -21,8 +21,6 @@ spec:
     metadata:
       labels:
         component: content-repo-check
-        alert-tier: os
-        alert-service: swift
       annotations:
         checksum/check.bin: {{ include "content-repo/templates/bin-configmap.yaml" . | sha256sum }}
         checksum/check.etc: {{ include "content-repo/templates/configmap.yaml" . | sha256sum }}

--- a/openstack/content-repo/templates/mirror-deployment.yaml
+++ b/openstack/content-repo/templates/mirror-deployment.yaml
@@ -23,8 +23,6 @@ spec:
     metadata:
       labels:
         component: content-repo-{{ $repo }}
-        alert-tier: os
-        alert-service: swift
       annotations:
         checksum/check.bin: {{ include "content-repo/templates/bin-configmap.yaml" $ | sha256sum }}
         checksum/check.etc: {{ include "content-repo/templates/configmap.yaml" $ | sha256sum }}

--- a/openstack/content-repo/templates/statsd-deployment.yaml
+++ b/openstack/content-repo/templates/statsd-deployment.yaml
@@ -20,8 +20,6 @@ spec:
     metadata:
       labels:
         component: content-repo-statsd
-        alert-tier: os
-        alert-service: swift
       annotations:
         checksum/etc: {{ include "content-repo/templates/statsd-configmap.yaml" . | sha256sum }}
     spec:

--- a/openstack/content-repo/values.yaml
+++ b/openstack/content-repo/values.yaml
@@ -5,7 +5,7 @@ global:
 
 owner-info:
   support-group: containers
-  service: swift
+  service: repo
   maintainers:
     - Falk Reimann
     - Stefan Majewsky


### PR DESCRIPTION
Set ownership and alert channel from `swift` to `repo` to reflect future working model.

//cc @majewsky im unsure whether the Slack channel need to be created first?