### PR TITLE
Enable cors for keystone by default

### DIFF
--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: keystone
 sources:
   - https://github.com/sapcc/keystone
-version: 0.3.0
+version: 0.3.1
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -453,7 +453,7 @@ lifesaver:
   enabled: true
 
 cors:
-  enabled: false
+  enabled: true
 
 # Deploy Keystone Prometheus alerts.
 alerts:


### PR DESCRIPTION
Keystone will be used to authenticate using js fetch()-like methods.

The default settings are fine and nothing needs to be configured per-region