### PR TITLE
Point in time recovery option added

### DIFF
--- a/common/mariadb-galera/CHANGELOG.md
+++ b/common/mariadb-galera/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.16.0 - 2023/07/20
+* Point in time recovery option added
+  * documentation added
+  * optional binary log file purging after full backup
+    * to free up disk space on the `log` persistent volume
+    * keep the binlog backups small and fast
+  * binlog filename and position added to snapshot tags
+  * binlog file size limited to 100MB
+    * to limit the required disk space on the backup job container
+* chart version bumped
+
 ## v0.15.4 - 2023/07/05
 * proxysql Kubernetes secret names fixed
 * chart version bumped

--- a/common/mariadb-galera/docker/kopia/Dockerfile
+++ b/common/mariadb-galera/docker/kopia/Dockerfile
@@ -33,7 +33,7 @@ ADD https://github.com/${SOFTWARE_NAME}/${SOFTWARE_NAME}/releases/download/v${SO
 USER root
 WORKDIR /opt
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
-RUN mkdir -p /opt/${SOFTWARE_NAME}/{bin,etc,var/run,var/tmp} \
+RUN mkdir -p /opt/${SOFTWARE_NAME}/{bin,etc,var/run,var/tmp/binlog} \
   && groupadd ${SOFTWARE_NAME} --gid ${USERID} \
   && adduser ${SOFTWARE_NAME} --home /opt/${SOFTWARE_NAME} --uid ${USERID} --gid ${USERID} --gecos "" --shell /sbin/nologin --no-create-home --disabled-login \
   && echo 'export PATH=${PATH}:/opt/${SOFTWARE_NAME}/bin' > /opt/${SOFTWARE_NAME}/.bashrc \

--- a/common/mariadb-galera/helm/Chart.yaml
+++ b/common/mariadb-galera/helm/Chart.yaml
@@ -3,7 +3,7 @@ name: mariadb-galera
 description: Docker images and Helm chart to deploy a [MariaDB](https://mariadb.com/kb/en/getting-installing-and-upgrading-mariadb/) HA cluster based on [Galera](https://mariadb.com/kb/en/what-is-mariadb-galera-cluster/)
 home: "https://github.com/businessbean/helm-charts/tree/master/common/mariadb-galera"
 appVersion: 10.5.20
-version: 0.15.4
+version: 0.16.0
 type: application
 kubeVersion: ">=1.18"
 maintainers:

--- a/common/mariadb-galera/helm/README.md.gotmpl
+++ b/common/mariadb-galera/helm/README.md.gotmpl
@@ -20,7 +20,8 @@
   * [values description](#values-description)
   * [network config](#network-config)
   * [database backup](#database-backup)
-  * [full database restore](#full-database-restore)
+  * [full database recovery](#full-database-recovery)
+  * [point in time database recovery](#point-in-time-database-recovery)
   * [asynchronous replication config](#asynchronous-replication-config)
   * [MariaDB Galera flow charts](#mariadb-galera-flow-charts)
     * [node startup](#node-startup)
@@ -177,10 +178,8 @@ The [Openstack cloud provider documentation](https://github.com/kubernetes/cloud
 * mariadb-binlog will be used to include the existing binary logs in the backup. That allows to do a point in time recovery in addition to the full restore of the database
 * restic will be used to encrypt, compress and deduplicate the backup data. Currently the Openstack Swift backend is supported
 
-### full database restore
+### full database recovery
 ```shell
-helm upgrade --install --namespace database mariadb-galera helm --set mariadb.wipeDataAndLog=true
-or
 helm upgrade --install --namespace database mariadb-galera helm --set mariadb.wipeDataAndLog=true --values helm/custom/eu-de-2.yaml
 ```
 * prepare the database nodes with the `mariadb.wipeDataAndLog` option
@@ -211,8 +210,6 @@ helm upgrade --install --namespace database mariadb-galera helm --set mariadb.wi
     ```
 * start the restore and recovery process using the `mariadb.galera.restore.beforeTimestamp` option
 ```sh
-helm upgrade --install --namespace database mariadb-galera helm --set mariadb.galera.restore.restic.enabled=true --set mariadb.galera.restore.beforeTimestamp="2022-12-13 12:00:00"
-or
 helm upgrade --install --namespace database mariadb-galera helm --set mariadb.galera.restore.kopia.enabled=true --set mariadb.galera.restore.beforeTimestamp="2023-02-19 15:45:00" --values helm/custom/eu-de-2.yaml
 ```
   * a new job pod will be started
@@ -227,10 +224,84 @@ helm upgrade --install --namespace database mariadb-galera helm --set mariadb.ga
     ```
 * run `helm upgrade` again to remove the `mariadb.wipeDataAndLog` and `mariadb.galera.restore.restic.enabled` options
 ```sh
-helm upgrade --install --namespace database mariadb-galera helm
-or
 helm upgrade --install --namespace database mariadb-galera helm --values helm/custom/eu-de-2.yaml
 ```
+  * ProxySQL, the config job and the Backup cronjob will be enabled again (if they have been enabled before)
+  * the MariaDB pods will be restarted and Galera will replicate the restored data
+
+### point in time database recovery
+```shell
+helm upgrade --install --namespace database mariadb-galera helm --set mariadb.wipeDataAndLog=true --values helm/custom/eu-de-2.yaml
+```
+* prepare the database nodes with the `mariadb.wipeDataAndLog` option
+  * the mariadb pods will be restarted
+  * the content of the `data` and the `log` folders will be wiped
+  * the first pod will start MariaDB with Galera
+  * the other pods will only start a sleep process
+  * the backup cronjob and the ProxySQL pods will disabled
+  * check the logs of the first MariaDB pod for the wipe and Galera startup messages
+    ```json
+    {"log.origin.function":"wipedata","log.level":"info","message":"starting wipe of data and log folder content"}
+    {"log.origin.function":"wipedata","log.level":"info","message":"wipe of data and log folder content done"}
+    {"..."}
+    {"log.origin.function":"bootstrapgalera","log.level":"info","message":"init Galera cluster"}
+    {"..."}
+    ```
+    ```text
+    [Note] mariadbd: ready for connections.
+    Version: '10.5.18-MariaDB-1:10.5.18+maria~ubu2004-log'  socket: '/opt/mariadb/run/mariadbd.sock'  port: 3306  mariadb.org binary distribution
+    [Note] WSREP: Starting applier thread 21
+    ```
+  * check the logs of the other MariaDB pod for the wipe and sleep startup messages
+    ```json
+    {"log.origin.function":"wipedata","log.level":"info","message":"starting wipe of data and log folder content"}
+    {"log.origin.function":"wipedata","log.level":"info","message":"wipe of data and log folder content done"}
+    {"..."}
+    {"log.origin.function":"initgalera","log.level":"info","message":"start sleep mode because wipedata flag has been set"}
+    ```
+* start the restore and recovery process using the `mariadb.galera.restore.beforeTimestamp` and the `mariadb.galera.restore.pointInTimeRecovery` option
+  ```sh
+  helm upgrade --install --namespace database mariadb-galera helm --set mariadb.galera.restore.kopia.enabled=true --set mariadb.galera.restore.beforeTimestamp="2023-07-17 13:50:00+CEST" --set mariadb.galera.restore.pointInTimeRecovery=true --values helm/custom/eu-de-2.yaml
+  ```
+  * a new job pod will be started
+  * restic will query the nearest snapshot id related to the provided timestamp
+  * the MariaDB dump included in the snapshot will be restored
+  * the mysql client will import the dump into the first MariaDB node
+  * check the recovery logs of the `restore-kopia-*` pod
+    ```json
+    {"log.origin.function":"initkopiarepo","log.level":"info","message":"init kopia repository if required"}
+    Connected to repository.
+    {"log.origin.function":"initkopiarepo","log.level":"info","message":"kopia repository already exist"}
+    {"log.origin.function":"recoverkopiapointintime","log.level":"info","message":"fetch kopia snapshotid for the '2023-07-20 13:59:00+CEST' timestamp"}
+    {"log.origin.function":"recoverkopiapointintime","log.level":"info","message":"fetch kopia backup starttime for the snapshotid 'k0f18417e1f8c6052241f5f4dcea29b0e'"}
+    {"log.origin.function":"recoverkopiapointintime","log.level":"info","message":"fetch kopia backup startposition for the snapshotid 'k0f18417e1f8c6052241f5f4dcea29b0e'"}
+    {"log.origin.function":"recoverkopiapointintime","log.level":"info","message":"fetch kopia binlog snapshot for the requested timeframe"}
+    {"log.origin.function":"recoverkopiapointintime","log.level":"info","message":"kopia database recovery from '2023-07-20T11:01:05' to nova-mariadb-g-0.database.svc.cluster.local started"}
+    {"log.origin.function":"recoverkopiapointintime","log.level":"info","message":"kopia database recovery done"}
+    {"log.origin.function":"recoverkopiapointintime","log.level":"info","message":"starting kopia binlog recovery from '2023-07-20T11:55:12+UTC' to nova-mariadb-g-0.database.svc.cluster.local"}
+    {"log.origin.function":"recoverkopiapointintime","log.level":"info","message":"kopia binlog recovery using 'nova_binlog.000143'[1/6] started"}
+    {"log.origin.function":"recoverkopiapointintime","log.level":"info","message":"kopia binlog recovery done"}
+    {"log.origin.function":"recoverkopiapointintime","log.level":"info","message":"kopia binlog recovery using 'nova_binlog.000144'[2/6] started"}
+    {"log.origin.function":"recoverkopiapointintime","log.level":"info","message":"kopia binlog recovery done"}
+    {"log.origin.function":"recoverkopiapointintime","log.level":"info","message":"kopia binlog recovery using 'nova_binlog.000145'[3/6] started"}
+    {"log.origin.function":"recoverkopiapointintime","log.level":"info","message":"kopia binlog recovery done"}
+    {"log.origin.function":"recoverkopiapointintime","log.level":"info","message":"kopia binlog recovery using 'nova_binlog.000146'[4/6] started"}
+    {"log.origin.function":"recoverkopiapointintime","log.level":"info","message":"kopia binlog recovery done"}
+    {"log.origin.function":"recoverkopiapointintime","log.level":"info","message":"kopia binlog recovery using 'nova_binlog.000147'[5/6] started"}
+    {"log.origin.function":"recoverkopiapointintime","log.level":"info","message":"kopia binlog recovery done"}
+    {"log.origin.function":"recoverkopiapointintime","log.level":"info","message":"kopia binlog recovery using 'nova_binlog.000148'[6/6] started"}
+    {"log.origin.function":"recoverkopiapointintime","log.level":"info","message":"kopia binlog recovery done"}
+    ```
+* run `helm upgrade` again to remove the `mariadb.wipeDataAndLog` and `mariadb.galera.restore.restic.enabled` options
+  ```sh
+  helm upgrade --install --namespace database mariadb-galera helm --set replicas.application=1 --values helm/custom/eu-de-2.yaml
+  ```
+* restart the other pods after `mariadb-g-0` is ready again
+  ```sh
+  helm upgrade --install --namespace database mariadb-galera helm
+  or
+  helm upgrade --install --namespace database mariadb-galera helm --values helm/custom/eu-de-2.yaml
+  ```
   * ProxySQL, the config job and the Backup cronjob will be enabled again (if they have been enabled before)
   * the MariaDB pods will be restarted and Galera will replicate the restored data
 

--- a/common/mariadb-galera/helm/scripts/backup/kopia/entrypoint-restore.sh
+++ b/common/mariadb-galera/helm/scripts/backup/kopia/entrypoint-restore.sh
@@ -5,16 +5,23 @@ set -o pipefail
 
 source /opt/${SOFTWARE_NAME}/bin/common-functions.sh
 
-function fetchkopiasnapshotid {
+export JQ_RESTORE_TIMESTAMP=$(date --utc --date="${RESTORE_TIMESTAMP}" +'%Y-%m-%dT%H:%M:%S')
+export JQ_DATE_FORMAT='%Y-%m-%dT%H:%M:%S'
+
+function fetchkopiafullbackupsnapshotid {
   local int
-  if [ "${RESTORE_SNAPSHOT_ID}" == "false" ]; then
+
+  if [ "${RESTORE_SNAPSHOT_ID}" == "false" ] || [ "${RESTORE_POINT_IN_TIME}" == "true" ]; then
     if [ "${RESTORE_TIMESTAMP}" == "false" ]; then
       logerror "${FUNCNAME[0]}" "no RESTORE_TIMESTAMP or RESTORE_SNAPSHOT_ID defined. Check the mariadb.galera.restore.beforeTimestamp and mariadb.galera.restore.kopia.snapshotId config options"
       exit 1
     else
       for (( int=${MAX_RETRIES}; int >=1; int-=1));
         do
-        KOPIA_SNAPSHOT_ID=$(kopia snapshot list --all --no-incomplete --json --tags=backup.type:dump | jq --exit-status --raw-output '[.[] | select (.startTime | split(".")[0] | strptime("%Y-%m-%dT%H:%M:%S") <= (env.RESTORE_TIMESTAMP | strptime("%Y-%m-%d %H:%M:%S")))] | last | .rootEntry.obj')
+        KOPIA_SNAPSHOT_ID=$(kopia snapshot list --all --no-incomplete --json --tags=backup.type:dump | jq --exit-status --raw-output \
+          --arg r "${JQ_RESTORE_TIMESTAMP}" \
+          --arg f "${JQ_DATE_FORMAT}" \
+          '[.[] | . as $parent | (.startTime | split(".")[0] | strptime($f)) | select( . <= ($r | strptime($f))) | $parent] | last | .rootEntry.obj')
         if [ $? -ne 0 ]; then
           sleep ${WAIT_SECONDS}
         else
@@ -38,14 +45,76 @@ function fetchkopiasnapshotid {
   echo ${KOPIA_SNAPSHOT_ID}
 }
 
-function recoverkopiadbbackup {
+function fetchkopiabackupstarttime {
+  local int
+  local KOPIA_SNAPSHOT_ID=${1}
+  local KOPIA_START_TIMESTAMP
+
+  for (( int=${MAX_RETRIES}; int >=1; int-=1));
+    do
+    KOPIA_START_TIMESTAMP=$(kopia snapshot list --all --no-incomplete --json | jq --exit-status --raw-output \
+      --arg s "${KOPIA_SNAPSHOT_ID}" \
+      '.[] | select(.rootEntry.obj == $s) | .startTime | split(".")[0]')
+    if [ $? -ne 0 ]; then
+      sleep ${WAIT_SECONDS}
+    else
+      break
+    fi
+  done
+
+  echo ${KOPIA_START_TIMESTAMP}
+}
+
+function fetchkopiabackupstartposition {
+  local int
+  local KOPIA_SNAPSHOT_ID=${1}
+  local KOPIA_START_POSITION
+
+  for (( int=${MAX_RETRIES}; int >=1; int-=1));
+    do
+    KOPIA_START_POSITION=$(kopia snapshot list --all --no-incomplete --json | jq --exit-status --raw-output \
+      --arg s "${KOPIA_SNAPSHOT_ID}" \
+      '.[] | select(.rootEntry.obj == $s) | .tags."tag:mariadb.binlogposition"')
+    if [ $? -ne 0 ]; then
+      sleep ${WAIT_SECONDS}
+    else
+      break
+    fi
+  done
+
+  echo ${KOPIA_START_POSITION}
+}
+
+function fetchkopiabinlogbackupsnapshotid {
+  local int
+  local KOPIA_START_TIMESTAMP=${1}
+  local KOPIA_BINLOG_SNAPSHOT
+
+  for (( int=${MAX_RETRIES}; int >=1; int-=1));
+    do
+    KOPIA_BINLOG_SNAPSHOT=$(kopia snapshot list --all --no-incomplete --json --tags=backup.type:binlog | jq --exit-status --raw-output \
+      --arg r "${JQ_RESTORE_TIMESTAMP}" \
+      --arg s "${KOPIA_START_TIMESTAMP}" \
+      --arg f "${JQ_DATE_FORMAT}" \
+      '[.[] | . as $parent | .startTime | split(".")[0] | strptime($f) | select ( . >= ($s | strptime($f)) and . <= ($r | strptime($f))) | $parent] | last')
+    if [ $? -ne 0 ]; then
+      sleep ${WAIT_SECONDS}
+    else
+      break
+    fi
+  done
+
+  echo ${KOPIA_BINLOG_SNAPSHOT}
+}
+
+function recoverkopiafullbackup {
   if [ "${RESTORE_TIMESTAMP}" != "false" ]; then
     loginfo "${FUNCNAME[0]}" "fetch kopia snapshotid for the '${RESTORE_TIMESTAMP}' timestamp"
   else
     loginfo "${FUNCNAME[0]}" "fetch kopia snapshotid"
   fi
 
-  local snapshotid=$(fetchkopiasnapshotid)
+  local snapshotid=$(fetchkopiafullbackupsnapshotid)
 
   if [ "${snapshotid}" == "null" ]; then
     logerror "${FUNCNAME[0]}" "no (valid) snapshotId found"
@@ -62,5 +131,124 @@ function recoverkopiadbbackup {
   loginfo "${FUNCNAME[0]}" "kopia database recovery done"
 }
 
+function recoverkopiapointintime {
+  loginfo "${FUNCNAME[0]}" "fetch kopia snapshotid for the '${RESTORE_TIMESTAMP}' timestamp"
+  local snapshotid=$(fetchkopiafullbackupsnapshotid)
+  if [ "${snapshotid}" == "null" ]; then
+    logerror "${FUNCNAME[0]}" "no (valid) snapshotId found"
+    loginfo "${FUNCNAME[0]}" "The following timestamps are available: $(kopia snapshot list --all --no-incomplete --json --tags=backup.type:dump | jq --exit-status --raw-output '.[].startTime | split(".")[0] | strptime("%Y-%m-%dT%H:%M:%S") | strftime("%Y-%m-%d %H:%M:%S")')"
+    exit 1
+  fi
+
+  loginfo "${FUNCNAME[0]}" "fetch kopia backup starttime for the snapshotid '${snapshotid}'"
+  local starttime=$(fetchkopiabackupstarttime ${snapshotid})
+  if [ "${starttime}" == "null" ]; then
+    logerror "${FUNCNAME[0]}" "no backup start time for the snapshot '${snapshotid}' found"
+    loginfo "${FUNCNAME[0]}" "The following metadata is available: $(kopia snapshot list --all --no-incomplete --json --tags=backup.type:dump | jq --exit-status --raw-output --arg s "${snapshotid}" '.[] | select(.rootEntry.obj == "$s")')"
+    exit 1
+  fi
+
+  loginfo "${FUNCNAME[0]}" "fetch kopia backup startposition for the snapshotid '${snapshotid}'"
+  local startposition=$(fetchkopiabackupstartposition ${snapshotid})
+  if [ "${startposition}" == "null" ]; then
+    logerror "${FUNCNAME[0]}" "no backup start position for the snapshot '${snapshotid}' found"
+    loginfo "${FUNCNAME[0]}" "The following metadata is available: $(kopia snapshot list --all --no-incomplete --json --tags=backup.type:dump | jq --exit-status --raw-output --arg s "${snapshotid}" '.[] | select(.rootEntry.obj == "$s")')"
+    exit 1
+  fi
+
+  loginfo "${FUNCNAME[0]}" "fetch kopia binlog snapshot for the requested timeframe"
+  local binlogsnapshot=$(fetchkopiabinlogbackupsnapshotid ${starttime})
+  if [ "${binlogsnapshot}" == "null" ]; then
+    logerror "${FUNCNAME[0]}" "no binlog snapshot infos found between '${starttime}' and '${JQ_RESTORE_TIMESTAMP}'"
+    exit 1
+  fi
+
+  loginfo "${FUNCNAME[0]}" "kopia database recovery from '${starttime}' to ${DB_HOST} started"
+  kopia show ${snapshotid}/dump.sql | mysql --protocol=tcp --host=${DB_HOST} --user=${MARIADB_ROOT_USERNAME} --password=${MARIADB_ROOT_PASSWORD} --port=${MYSQL_PORT} --wait --connect-timeout=${WAIT_SECONDS} --reconnect --batch
+  if [ $? -ne 0 ]; then
+    logerror "${FUNCNAME[0]}" "kopia database recovery failed"
+    exit 1
+  fi
+  loginfo "${FUNCNAME[0]}" "kopia database recovery done"
+
+  cd /opt/${SOFTWARE_NAME}/var/tmp/binlog
+
+  local binlogsnapshotid=$(jq --exit-status --raw-output --argjson j "${binlogsnapshot}" -n '$j.rootEntry.obj')
+  if [ $? -ne 0 ]; then
+    logerror "${FUNCNAME[0]}" "binlog snapshot id cannot be parsed"
+    exit 1
+  fi
+
+  local binlogstarttime=$(jq --exit-status --raw-output --argjson j "${binlogsnapshot}" -n '$j.startTime | split(".")[0]')
+  if [ $? -ne 0 ]; then
+    logerror "${FUNCNAME[0]}" "binlog snapshot start time cannot be parsed"
+    exit 1
+  fi
+
+  local binlogfilelist=$(kopia show ${binlogsnapshotid} | jq --exit-status -c '.entries')
+  if [ $? -ne 0 ]; then
+    logerror "${FUNCNAME[0]}" "binlog file list for snapshot '${binlogsnapshotid}' cannot be parsed"
+    exit 1
+  fi
+
+  local binlogfilecount=$(kopia show ${binlogsnapshotid} | jq --exit-status -c '.entries | length')
+  if [ $? -ne 0 ]; then
+    logerror "${FUNCNAME[0]}" "binlog file count for snapshot '${binlogsnapshotid}' cannot be parsed"
+    exit 1
+  fi
+
+  local binlogfilenr=1
+  loginfo "${FUNCNAME[0]}" "starting kopia binlog recovery from '${binlogstarttime}+UTC' to ${DB_HOST}"
+  for binlogfile in $(jq --exit-status --argjson j "${binlogfilelist}" -c -n '$j[]');
+    do
+    if [ $? -ne 0 ]; then
+      logerror "${FUNCNAME[0]}" "binlog file list cannot be parsed"
+      exit 1
+    fi
+
+    local binlogfilename=$(jq --exit-status --raw-output --argjson j "${binlogfile}" -n '$j.name')
+    if [ $? -ne 0 ]; then
+      logerror "${FUNCNAME[0]}" "binlog file name cannot be parsed"
+      exit 1
+    fi
+
+    local binlogfilesnapshotid=$(jq --exit-status --raw-output --argjson j "${binlogfile}" -n '$j.obj')
+    if [ $? -ne 0 ]; then
+      logerror "${FUNCNAME[0]}" "binlog file snapshot id cannot be parsed"
+      exit 1
+    fi
+
+    kopia show ${binlogfilesnapshotid} > ${binlogfilename}
+    if [ $? -ne 0 ]; then
+      logerror "${FUNCNAME[0]}" "kopia binlog restore for '${binlogfilename}' inside the snapshot '${binlogfilesnapshotid}' failed"
+      exit 1
+    fi
+
+    loginfo "${FUNCNAME[0]}" "kopia binlog recovery using '${binlogfilename}'[${binlogfilenr}/${binlogfilecount}] started"
+    {{- /* only the first binlog contains the requested position */}}
+    if [ ${binlogfilenr} -eq 1 ]; then
+      mariadb-binlog --disable-log-bin --start-position=${startposition} --stop-datetime="${JQ_RESTORE_TIMESTAMP}" ${binlogfilename} | mysql --protocol=tcp --host=${DB_HOST} --user=${MARIADB_ROOT_USERNAME} --password=${MARIADB_ROOT_PASSWORD} --port=${MYSQL_PORT} --wait --connect-timeout=${WAIT_SECONDS} --reconnect --batch
+    else
+      mariadb-binlog --disable-log-bin --stop-datetime="${JQ_RESTORE_TIMESTAMP}" ${binlogfilename} | mysql --protocol=tcp --host=${DB_HOST} --user=${MARIADB_ROOT_USERNAME} --password=${MARIADB_ROOT_PASSWORD} --port=${MYSQL_PORT} --wait --connect-timeout=${WAIT_SECONDS} --reconnect --batch
+    fi
+    if [ $? -ne 0 ]; then
+      logerror "${FUNCNAME[0]}" "kopia binlog recovery for '${binlogfilename}' inside the snapshot '${binlogfilesnapshotid}' failed"
+      exit 1
+    fi
+    loginfo "${FUNCNAME[0]}" "kopia binlog recovery done"
+
+    rm /opt/${SOFTWARE_NAME}/var/tmp/binlog/${binlogfilename}
+    if [ $? -ne 0 ]; then
+      logerror "${FUNCNAME[0]}" "kopia binlog file '${binlogfilename}' cannot be deleted"
+      exit 1
+    fi
+    let "binlogfilenr+=1"
+  done
+}
+
 initkopiarepo
-recoverkopiadbbackup
+{{- if $.Values.mariadb.galera.restore.pointInTimeRecovery }}
+recoverkopiapointintime
+{{- else  }}
+recoverkopiafullbackup
+{{- end }}

--- a/common/mariadb-galera/helm/scripts/backup/restic/entrypoint-restore.sh
+++ b/common/mariadb-galera/helm/scripts/backup/restic/entrypoint-restore.sh
@@ -55,7 +55,7 @@ function recoverresticdbbackup {
   fi
 
   loginfo "${FUNCNAME[0]}" "restic database recovery using snapshot ${snapshotid} to ${DB_HOST} started"
-  restic dump --tag dump ${snapshotid} mariadb.dump | mysql --protocol=tcp --host=${DB_HOST} --user=${MARIADB_ROOT_USERNAME} --password=${MARIADB_ROOT_PASSWORD} --port=${MYSQL_PORT} --wait --connect-timeout=${WAIT_SECONDS} --reconnect --batch
+  restic dump --tag dump ${snapshotid} dump.sql | mysql --protocol=tcp --host=${DB_HOST} --user=${MARIADB_ROOT_USERNAME} --password=${MARIADB_ROOT_PASSWORD} --port=${MYSQL_PORT} --wait --connect-timeout=${WAIT_SECONDS} --reconnect --batch
   if [ $? -ne 0 ]; then
     logerror "${FUNCNAME[0]}" "restic database recovery failed"
     exit 1

--- a/common/mariadb-galera/helm/scripts/mariadb-galera/entrypoint-galera.sh
+++ b/common/mariadb-galera/helm/scripts/mariadb-galera/entrypoint-galera.sh
@@ -7,7 +7,13 @@ source /opt/${SOFTWARE_NAME}/bin/common-functions.sh
 
 function bootstrapgalera {
   loginfo "${FUNCNAME[0]}" "init Galera cluster"
-  exec mariadbd --defaults-file=${BASE}/etc/my.cnf --basedir=/usr --wsrep-new-cluster
+  {{- /* disable Galera replication to be able to do PITR with mariadb-binlog https://jira.mariadb.org/browse/MDEV-29665 */}}
+  if [ -f "${BASE}/etc/wipedata.flag" ]; then
+    exec mariadbd --defaults-file=${BASE}/etc/my.cnf --basedir=/usr --wsrep-new-cluster --wsrep_on=OFF --expire-logs-days=0
+  else
+    exec mariadbd --defaults-file=${BASE}/etc/my.cnf --basedir=/usr --wsrep-new-cluster
+  fi
+
 }
 
 function fetchseqnofromgrastate {

--- a/common/mariadb-galera/helm/templates/configmap-mariadb-my.cnf.yaml
+++ b/common/mariadb-galera/helm/templates/configmap-mariadb-my.cnf.yaml
@@ -32,7 +32,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "commonPrefix" $ }}my-cnf
+  name: {{ include "commonPrefix" $ }}mariadb-my-cnf
   namespace: {{ $.Release.Namespace }}
 data:
 {{- range $int, $err := until ($.Values.replicas.application|int) }}
@@ -56,20 +56,22 @@ data:
     wsrep-provider=/usr/lib/libgalera_smm.so
     plugin_load_add = wsrep_info #https://mariadb.com/kb/en/wsrep_info-plugin/
     binlog_format=ROW
-    log-bin=/opt/${SOFTWARE_NAME}/{{ $.Values.mariadb.binLogDir | default "data" }}/mysql-bin.log
+    max_binlog_size=104857600
+    log-bin=/opt/${SOFTWARE_NAME}/{{ $.Values.mariadb.binLogDir | default "data" }}/{{ (required "mariadb.galera.clustername is required to configure the log-bin option for MariaDB" $.Values.mariadb.galera.clustername) }}_binlog
     expire_logs_days=1
     sync_binlog={{ $.Values.mariadb.binLogSync | default 0 | int }}
     default_storage_engine=InnoDB
     innodb_autoinc_lock_mode=2
     innodb_flush_log_at_trx_commit={{ $.Values.mariadb.innodbFlushLogAtTrxCommit | default 0 | int }}
-    wsrep_gtid_mode=on
     {{- if $.Values.mariadb.galera.gtidStrictMode }}
     gtid-strict-mode=1
     {{- else }}
     gtid-strict-mode=0
     {{- end }}
+    {{- /* https://mariadb.com/kb/en/using-mariadb-gtids-with-mariadb-galera-cluster/#enabling-wsrep-gtid-mode */}}
+    wsrep_gtid_mode=on
     wsrep_gtid_domain_id={{ (printf "%d%d%d%d%d" ($.Values.mariadb.galera.gtidDomainId | default 1 | int) 0 8 1 5) | int }}
-    gtid_domain_id={{ $int | int }}
+    gtid_domain_id={{ (printf "%d%d%d%d%d" ($.Values.mariadb.galera.gtidDomainId | default 1 | int) $int 8 1 6) | int }}
     expire_logs_days=1
     wsrep-cluster-name={{ (required "mariadb.galera.clustername is required to configure the wsrep-cluster-name option for MariaDB" $.Values.mariadb.galera.clustername) | quote }}
     wsrep_cluster_address={{ include "wsrepClusterAddress" (dict "global" $) }}
@@ -119,8 +121,9 @@ data:
     auto_increment_offset={{ (add (mul (sub ($.Values.mariadb.galera.gtidDomainIdCount| default 1 | int) ($.Values.mariadb.galera.gtidDomainId | default 1 | int)) ($.Values.replicas.application|int)) (add1 ($int | int))) | int }}
 
     # async replication with MariaDB instances outside of the Galera cluster
-    relay_log=/opt/${SOFTWARE_NAME}/{{ $.Values.mariadb.binLogDir | default "data" }}/mysql-relay-bin.log
-    server_id={{ (printf "%d%d" ($.Values.mariadb.galera.gtidDomainId | default 1 | int) $int) | int }}
+    relay_log=/opt/${SOFTWARE_NAME}/{{ $.Values.mariadb.binLogDir | default "data" }}/{{ (required "mariadb.galera.clustername is required to configure the relay_log option for MariaDB" $.Values.mariadb.galera.clustername) }}_relaylog
+    {{- /* https://mariadb.com/kb/en/using-mariadb-replication-with-mariadb-galera-cluster-using-mariadb-replica/#setting-the-same-server_id-on-each-cluster-node */}}
+    server_id={{ $.Values.mariadb.galera.gtidDomainId | default 1 | int }}
     log_slave_updates=on
     {{- if and ($.Values.mariadb.asyncReplication.autostart) ($.Values.mariadb.asyncReplication.enabled) }}
     wsrep_restart_slave=on

--- a/common/mariadb-galera/helm/templates/job-kopia-restore.yaml
+++ b/common/mariadb-galera/helm/templates/job-kopia-restore.yaml
@@ -65,6 +65,8 @@ spec:
           value: {{ $.Values.mariadb.galera.restore.beforeTimestamp | default "false" | quote }}
         - name: RESTORE_SNAPSHOT_ID
           value: {{ $.Values.mariadb.galera.restore.kopia.snapshotId | default "false" | quote }}
+        - name: RESTORE_POINT_IN_TIME
+          value: {{ $.Values.mariadb.galera.restore.pointInTimeRecovery | default "false" | quote }}
         {{- range $envKey, $envValue := $.Values.env }}
           {{- if (has "jobrestore-kopia" $envValue.containerType) }}
             {{- if $envValue.value }}

--- a/common/mariadb-galera/helm/templates/job-restic-restore.yaml
+++ b/common/mariadb-galera/helm/templates/job-restic-restore.yaml
@@ -75,6 +75,8 @@ spec:
           value: {{ $.Values.mariadb.galera.restore.beforeTimestamp | default "false" | quote }}
         - name: RESTORE_SNAPSHOT_ID
           value: {{ $.Values.mariadb.galera.restore.restic.snapshotId | default "false" | quote }}
+        - name: RESTORE_POINT_IN_TIME
+          value: {{ $.Values.mariadb.galera.restore.pointInTimeRecovery | default "false" | quote }}
         {{- range $envKey, $envValue := $.Values.env }}
           {{- if (has "jobrestore-restic" $envValue.containerType) }}
             {{- if $envValue.value }}

--- a/common/mariadb-galera/helm/templates/statefulset-mariadb.yaml
+++ b/common/mariadb-galera/helm/templates/statefulset-mariadb.yaml
@@ -299,7 +299,7 @@ spec:
               {{- end }}
             {{- end }}
           {{- end }}
-          - name: {{ include "commonPrefix" $ }}my-cnf
+          - name: {{ include "commonPrefix" $ }}mariadb-my-cnf
             mountPath: /opt/mariadb/etc/conf.d/tpl
             readOnly: true
           - name: {{ include "commonPrefix" $ }}galerastatus
@@ -505,9 +505,9 @@ spec:
             {{- end }}
           {{- end }}
         {{- end }}
-        - name: {{ include "commonPrefix" $ }}my-cnf
+        - name: {{ include "commonPrefix" $ }}mariadb-my-cnf
           configMap:
-            name: {{ include "commonPrefix" $ }}my-cnf
+            name: {{ include "commonPrefix" $ }}mariadb-my-cnf
             defaultMode: 0444
         - name: {{ include "commonPrefix" $ }}galerastatus
           configMap:

--- a/common/mariadb-galera/helm/values.yaml
+++ b/common/mariadb-galera/helm/values.yaml
@@ -276,6 +276,8 @@ mariadb:
         # -- [list backup snapshots](https://kopia.io/docs/reference/command-line/common/snapshot-list/)
         # @default -- false
         listBackups: false
+        # -- (bool) [purge binlogs](https://mariadb.com/kb/en/purge-binary-logs/) after a full backup.
+        purgeBinlogsAfterFullBackup: false
         users:
           repository:
             # -- (bool) enable this user
@@ -342,8 +344,11 @@ mariadb:
           # -- (string) S3 bucket name
           bucket:
     restore:
-      # -- define the backup timestamp that should be used for the restore. Only the `%Y-%m-%d %H:%M:%S` format is currently supported and the restic snapshot nearest before will be used
+      # -- define the backup timestamp that should be used for the restore. Only the `%Y-%m-%d %H:%M:%S+%Z` format (e.g 2023-07-18 20:59:00+CEST) is currently supported and the backup created nearest before will be used
+      # -- without `mariab.galera.restore.pointInTimeRecovery` only the full snapshot will be recovered
       beforeTimestamp:
+      # -- (bool) use binlog backups to recover the database to the defined `mariab.galera.restore.beforeTimestamp` and not only the nearest full backup. The `snapshotId` value will be ignored
+      pointInTimeRecovery:
       restic:
         # -- enable the [full database restore](#full-database-restore). Should be done as described in the documentation with `--set` parameters
         enabled: false
@@ -1597,7 +1602,7 @@ env:
     containerType:
       - monitoring
 
-#command:
+# command:
 #   application:
 #     - "sh"
 #     - "-c"


### PR DESCRIPTION
- documentation added
- optional binary log file purging after full backup
- to free up disk space on the log persistent volume
- keep the binlog backups small and fast
- binlog filename and position added to snapshot tags
- binlog file size limited to 100MB
- to limit the required disk space on the backup job container
- my.cnf configmap name fixed
- var/tmp/binlog folder added to Kopia image
- chart version bumped