### PR TITLE
Revert "[Octavia] Add default HTTP2 profile (#3861)"

### DIFF
--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -269,7 +269,6 @@ providers: "noop_driver: 'The No-Op driver.', f5: 'F5 BigIP driver.', F5Networks
 default_provider: "f5"
 default_profiles:
   profile_http: cc_http_profile
-  profile_http2: cc_http2_profile
   profile_http_compression: cc_httpcompression_profile
   profile_l4: cc_fastL4_profile
   profile_tcp: cc_tcp_profile


### PR DESCRIPTION
This reverts commit cd70a01627f20d20e6a2c127cb1bba3aa826ada4.

This PR disables HTTP 2 profile by default. Because of this check https://github.com/sapcc/octavia-f5-provider-driver/blob/stable/yoga-m3/octavia_f5/restclient/as3objects/service.py#L353 it disables HTTP 2 at all and we can enable it only in one region.