### PR TITLE
[PX] Add option to prevent pods from being scheduled on certain nodes

### DIFF
--- a/px/bird/templates/_deployment_header.tpl
+++ b/px/bird/templates/_deployment_header.tpl
@@ -12,6 +12,7 @@
 {{- $instance := index . 10}}
 {{- $az_redundancy  := index . 11}}
 {{- $tolerate_arista_fabric  := index . 12}}
+{{- $prevent_hosts := index . 13 }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -61,6 +62,12 @@ spec:
 {{- range get $apods $site | sortAlpha }}
                 - {{ . }}
 {{- end }}
+{{- end }}
+{{- if $prevent_hosts }}
+              - key: kubernetes.cloud.sap/host
+                operator: NotIn
+                values:
+{{ $prevent_hosts | toYaml | indent  16 }}
 {{- end }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/px/bird/templates/bird.yaml
+++ b/px/bird/templates/bird.yaml
@@ -16,7 +16,7 @@
 
 ---
 {{ tuple $deployment_name $domain_config.multus_vlan $instance_config.bird_ip | include "nad_multus"}}
-{{ tuple $deployment_name $.Values.global.availability_zones $.Values.scheduling_labels $.Values.apods $domain_config.multus_vlan $service_number $service $domain_number $domain $instance_number $instance $.Values.az_redundancy $.Values.tolerate_arista_fabric | include "deployment_header" }}
+{{ tuple $deployment_name $.Values.global.availability_zones $.Values.scheduling_labels $.Values.apods $domain_config.multus_vlan $service_number $service $domain_number $domain $instance_number $instance $.Values.az_redundancy $.Values.tolerate_arista_fabric $.Values.prevent_hosts | include "deployment_header" }}
 {{ tuple $.Values $deployment_name $service_number $service_config $domain_number $domain_config | include "deployment_bird" | indent 6 }}
 {{ tuple $deployment_name $.Values.looking_glass | include "service_pxrs" }}
 

--- a/px/bird/values.yaml
+++ b/px/bird/values.yaml
@@ -17,6 +17,7 @@ deploy: []
 registry:
 
 apods: {}
+prevent_hosts: []
 
 az_redundancy: True
 


### PR DESCRIPTION
Some physical hosts are miscabled and we must not schedule PX pods on
these hosts, as PX VLANs are unavailable there.
We must prevent the scheduler from selecting these nodes.
