### PR TITLE
openstack/keppel: match janitor cpu limits/requests, increase memory

### DIFF
--- a/openstack/keppel/templates/deployment-janitor.yaml
+++ b/openstack/keppel/templates/deployment-janitor.yaml
@@ -66,8 +66,8 @@ spec:
           # - RAM: starts off around 150Mi, leaks about 200Mi per day (but one OOM kill per day is acceptable IMO)
           resources:
             requests:
-              cpu: "200m"
-              memory: "300Mi"
+              cpu: "1"
+              memory: "350Mi"
             limits:
               cpu: "1"
-              memory: "300Mi"
+              memory: "350Mi"


### PR DESCRIPTION
Having a lot of new manifests might send the janitor into CrashLoopBackoff otherwise