### PR TITLE
archer: add "internal" endpoint to service catalog

### DIFF
--- a/openstack/archer/templates/seed.yaml
+++ b/openstack/archer/templates/seed.yaml
@@ -17,6 +17,9 @@ spec:
         - interface: public
           region: '{{.Values.global.region}}'
           url: 'https://{{include "archer_api_endpoint_public" .}}'
+        - interface: internal # Limes accesses backend service APIs using OS_INTERFACE=internal
+          region: '{{.Values.global.region}}'
+          url: 'https://{{include "archer_api_endpoint_public" .}}'
 
   domains:
     - name: Default


### PR DESCRIPTION
Limes uses OS_INTERFACE=internal, and changing this here is way easier than adding an extrawurst in Limes.