### PR TITLE
[PX] Add chart to temporary check on all nodes if PX vlans are present

### DIFF
--- a/px/arp-discovery/Chart.yaml
+++ b/px/arp-discovery/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+description: A Helm chart to deploy px-arp-discovery exporter
+name: px-bird
+version: "0.2"
+
+dependencies:
+  - name: owner-info
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 0.2.0

--- a/px/arp-discovery/templates/deamonset.yaml
+++ b/px/arp-discovery/templates/deamonset.yaml
@@ -1,0 +1,67 @@
+---
+{{ $multus_conf := list }}
+{{- range $service, $service_config := .Values.config -}}
+{{- range $domain, $domain_config := $service_config -}}
+{{ $vlan_name := printf "vlan%d"  ($domain_config.multus_vlan | int) }}
+{{ $multus_conf = append $multus_conf (dict "name" (printf "layer-2-only-%s" $vlan_name)  "interface"  $vlan_name) }}
+{{- end }}
+{{- end }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: arp-discovery-exporter
+  namespace: px
+  labels:
+    app: arp-discovery-exporter
+spec:
+  selector:
+    matchLabels:
+      app: arp-discovery-exporter
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 100%
+  template:
+    metadata:
+      labels:
+        alert-tier: px
+        alert-service: px
+        app: arp-discovery-exporter
+        app.kubernetes.io/name: px
+      annotations:
+        k8s.v1.cni.cncf.io/networks: |
+          {{ $multus_conf | toJson }}
+    spec:
+{{- if len .Values.apods | eq 0 }}
+{{- fail "You must supply at least one apod for scheduling" -}}
+{{ end }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.cloud.sap/apod
+                operator: In
+                values: 
+{{- range $site := keys .Values.apods | sortAlpha }}
+{{- range get $.Values.apods $site | sortAlpha }}
+                - {{ . }}
+{{- end }}
+{{- end }}
+{{- if .Values.tolerate_arista_fabric }}
+      tolerations:
+      - key: "fabric"
+        operator: "Equal"
+        value: "arista"
+        effect: "NoSchedule"
+{{- end }}
+      containers:
+      - name: arp-discovery-exporter
+        image: keppel.{{ required "A registry mus be set" .Values.registry }}.cloud.sap/{{ required "A arp_discovery_exporter_image must be set" .Values.arp_discovery_exporter_image }}
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 9116
+          name: arp-discovery
+        resources:
+{{ toYaml .Values.resources.arp_discovery_exporter | indent 10 }}

--- a/px/arp-discovery/templates/nad.yaml
+++ b/px/arp-discovery/templates/nad.yaml
@@ -1,0 +1,19 @@
+{{- range $service, $service_config := .Values.config -}}
+{{- range $domain, $domain_config := $service_config -}}
+---
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: layer-2-only-vlan{{ $domain_config.multus_vlan }}
+  namespace: px
+spec:
+  config: |
+    {
+        "cniVersion": "0.3.0",
+        "type": "macvlan",
+        "master": "vlan_{{ required "multus_vlan is required for every domaim" $domain_config.multus_vlan }}",
+        "mode": "bridge",
+        "ipam": {}
+    }
+{{ end }}
+{{- end }}

--- a/px/arp-discovery/templates/podmonitor.yaml
+++ b/px/arp-discovery/templates/podmonitor.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata: 
+  labels:
+    prometheus: infra-collector
+  name: px-arp-discovery
+  namespace: px
+spec: 
+  selector:
+    matchLabels:
+      app: arp-discovery-exporter
+  podMetricsEndpoints:
+{{- range $service, $service_config := .Values.config }}
+{{- range $domain, $domain_config := $service_config }}
+  - honorLabels: true
+    interval: 5m
+    path: /arp_discovery
+    port: arp-discovery
+    scheme: http
+    scrapeTimeout: 55s
+    relabelings: 
+    - targetLabel: "__param_interface"
+      replacement: {{ printf "vlan%d"  ($domain_config.multus_vlan | int) }}
+    - targetLabel: "__param_scope"
+      replacement: {{ $domain_config.instance_1.bird_ip }}
+    - action: labelmap
+      regex: __meta_kubernetes_pod_label_(.+)
+    - action: replace
+      sourceLabels: 
+      - __meta_kubernetes_namespace
+      targetLabel: kubernetes_namespace
+    - action: replace
+      sourceLabels: 
+      - __meta_kubernetes_pod_name
+      targetLabel: kubernetes_pod_name
+    - action: replace
+      replacement: {{ $.Values.global.region }}
+      targetLabel: region
+    - action: replace
+      replacement: controlplane
+      targetLabel: cluster_type
+    - action: replace
+      replacement: {{ $.Values.global.region }}
+      targetLabel: cluster
+
+{{- end }}
+{{- end }}

--- a/px/arp-discovery/values.yaml
+++ b/px/arp-discovery/values.yaml
@@ -1,0 +1,74 @@
+global:
+  region:
+  availability_zones:
+
+owner-info:
+  maintainers:
+    - Sebastian Wagner
+    - Franziska Lichtblau
+  support-group: network-api
+  service: px
+  helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/px/bird/
+
+
+registry:
+
+apods: {}
+
+tolerate_arista_fabric: False
+
+arp_discovery_exporter_image:
+
+resources:
+  arp_discovery_exporter:
+    requests:
+      cpu: "10m"
+      memory: "50Mi"
+    limits:
+      cpu: "30m"
+      memory: "80Mi"
+  
+config:
+  service_1:
+    domain_1:
+      multus_vlan:
+      instance_1:
+        bird_ip:
+      instance_2:
+        bird_ip:
+    domain_2:
+      multus_vlan:
+      instance_1:
+        bird_ip:
+      instance_2:
+        bird_ip:
+
+
+  service_2:
+    domain_1:
+      multus_vlan:
+      instance_1:
+        bird_ip:
+      instance_2:
+        bird_ip:
+    domain_2:
+      multus_vlan:
+      instance_1:
+        bird_ip:
+      instance_2:
+        bird_ip:
+
+
+  service_3:
+    domain_1:
+      multus_vlan:
+      instance_1:
+        bird_ip:
+      instance_2:
+        bird_ip:
+    domain_2:
+      multus_vlan:
+      instance_1:
+        bird_ip:
+      instance_2:
+        bird_ip:


### PR DESCRIPTION
We now have had multiple occasions when a pod was rescheduled to a host
that had either a host misconfiguration or the connected switch was
misconfigured. This resulted in the VLAN not being available and hence
the route servers being unreachable. We want to use this deployment as a
site survey to find out were this vlan is misconfigured. As IPs are a
limited resource in the peering nets, we rely on ARP/l2 only.
