### PR TITLE
[neutron] Configure Base Logger for the Rate Limit Middleware

### DIFF
--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -339,7 +339,7 @@ logging:
     auditmiddleware:
       handlers: stdout, sentry
       level: INFO
-    rate_limit.rate_limit:
+    rate_limit:
       handlers: stdout, sentry
       level: INFO
 


### PR DESCRIPTION
Set log level of all loggers (provider, backend, rate_limit) to INFO.