### PR TITLE
keystone: remove more references to train

### DIFF
--- a/openstack/keystone/templates/bin/_keystone_tempest.sh.tpl
+++ b/openstack/keystone/templates/bin/_keystone_tempest.sh.tpl
@@ -15,8 +15,7 @@ start_rally_tests() {
     rally deployment check
 
     # create tempest verifier fetched from our repo
-    # this stays bound to train for now, while we figure out whether we need it at all
-    rally verify create-verifier --type tempest --name keystone-tempest-verifier --source https://github.com/sapcc/tempest --version ccloud-train
+    rally verify create-verifier --type tempest --name keystone-tempest-verifier --source https://github.com/sapcc/tempest --version ccloud
 
     # configure tempest verifier
     rally verify configure-verifier --extend /etc/tempest/tempest.conf --show

--- a/openstack/keystone/templates/configmap-etc.yaml
+++ b/openstack/keystone/templates/configmap-etc.yaml
@@ -31,19 +31,6 @@ data:
 {{ include (print .Template.BasePath "/etc/_tempest.conf.tpl") . | indent 4 }}
   tempest-skip-list.yaml: |
     tempest.api.identity.v3.test_domains.DefaultDomainTestJSON.test_default_domain_exists[id-17a5de24-e6a0-4e4a-a9ee-d85b6e5612b5,smoke]: 'non-cloud-admins are not allowed to get domains'
-    tempest.api.identity.admin.v3.test_trusts.TrustsV3TestJSON.test_get_trusts_all: 'requires cloud-admin permissions'
-    tempest.api.identity.admin.v3.test_groups.GroupsV3TestJSON.test_list_groups: 'tempest admin-domain-scope disables/overrides domain filter'
-    tempest.api.identity.admin.v3.test_groups.GroupsV3TestJSON.test_list_user_groups: 'tempest admin-domain-scope disables/overrides domain filter'
-    tempest.api.identity.admin.v3.test_list_users.UsersV3TestJSON.test_list_users_with_name[id-c285bb37-7325-4c02-bff3-3da5d946d683]: 'domain filter http://localhost:5000/v3/users?name=tempest-test_user-1911711021&domain_id=35e499cc4db94103b77ead7a23b50888'
-    tempest.api.identity.admin.v3.test_list_users.UsersV3TestJSON.test_list_users[id-b30d4651-a2ea-4666-8551-0c0e49692635]: 'domain filter http://localhost:5000/v3/users?domain_id=35e499cc4db94103b77ead7a23b50888'
-    tempest.api.identity.admin.v3.test_list_users.UsersV3TestJSON.test_list_user_domains[id-08f9aabb-dcfe-41d0-8172-82b5fa0bd73d]: 'domain filter http://localhost:5000/v3/users?domain_id=35e499cc4db94103b77ead7a23b50888'
-    tempest.api.identity.admin.v3.test_projects.ProjectsTestJSON.test_create_is_domain_project: 'tempest admin-domain-scope disables/overrides domain filter'
-    tempest.api.identity.admin.v3.test_projects.ProjectsTestJSON.test_project_get_equals_list: 'default_tags not known to tempest'
-    tempest.api.identity.admin.v3.test_roles.RolesV3TestJSON.test_assignments_for_implied_roles_create_delete: 'tempest admin-domain-scope disables/overrides domain filter'
-    tempest.api.identity.admin.v3.test_inherits.InheritsV3TestJSON.test_inherit_assign_list_revoke_user_roles_on_project_tree: 'tempest admin-domain-scope disables/overrides domain filter'
-    tempest.api.identity.admin.v3.test_inherits.InheritsV3TestJSON.test_inherit_assign_list_revoke_user_roles_on_domain: 'tempest admin-domain-scope disables/overrides domain filter'
-    tempest.api.identity.admin.v3.test_projects_negative.ProjectsNegativeStaticTestJSON.test_list_projects_by_unauthorized_user: 'tempest admin-domain-scope disables/overrides domain filter'
-    tempest.api.identity.admin.v3.test_projects_negative.ProjectsNegativeStaticTestJSON.test_create_project_by_unauthorized_user: 'tempest admin-domain-scope disables/overrides domain filter'
   accounts.yaml: |
 {{ include (print .Template.BasePath "/etc/_tempest_accounts.yaml.tpl") . | indent 4 }}
   rally_deployment_config.json: |

--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -193,7 +193,7 @@ tempest:
   enabled: false
   image: "rally-openstack"
   #imageTag: "ccloud-1.5.0"
-  imageTag: "ccloud-train"
+  imageTag: "ccloud-xena"
   adminPassword: ""
   userPassword: ""
   # tempest domain-id  -- do not set in production environments!


### PR DESCRIPTION
This reverts commit https://github.com/sapcc/helm-charts/commit/d5cd90e52eff03a12a0975a1e3009819a34ec28a. It also removes mentions of train and train-specific bits, because, turns out, they are really train-specific and not required today.