### PR TITLE
system/gatekeeper: update gatekeeper to 3.13.0

### DIFF
--- a/system/gatekeeper/Chart.lock
+++ b/system/gatekeeper/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: gatekeeper
   repository: https://open-policy-agent.github.io/gatekeeper/charts
-  version: 3.12.0
+  version: 3.13.0
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:1a298d0709886639e2d8628d4b4012ac15ae819a5b425e227d6ddb667fae4850
-generated: "2023-04-17T15:23:28.69507209+02:00"
+digest: sha256:ebfe83051022d33d06a6e98dcb98aa30664e84d2950cb67b798655ff7441a1a2
+generated: "2023-08-10T14:59:11.392412273+02:00"

--- a/system/gatekeeper/Chart.yaml
+++ b/system/gatekeeper/Chart.yaml
@@ -7,7 +7,7 @@ version: 1.0.0 # please leave like this; this does not use Chartmuseum
 dependencies:
   - name: gatekeeper
     alias: gatekeeper-upstream
-    version: 3.12.0
+    version: 3.13.0
     repository: https://open-policy-agent.github.io/gatekeeper/charts
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap


### PR DESCRIPTION
I will deploy this after the first owner-info enforcement wave.