### PR TITLE
prometheus-kubernetes: thanos enabled

### DIFF
--- a/system/prometheus-kubernetes/Chart.lock
+++ b/system/prometheus-kubernetes/Chart.lock
@@ -5,8 +5,11 @@ dependencies:
 - name: prometheus-server
   repository: https://charts.eu-de-2.cloud.sap
   version: 7.2.8
+- name: thanos
+  repository: https://charts.eu-de-2.cloud.sap
+  version: 0.4.4
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:f9ce4b53c54c0254e5699b62aa8db67bfb96434409e03a9b3d26eeb3d4e82e1e
-generated: "2023-07-27T14:40:25.203423+02:00"
+digest: sha256:6b17488e6a512091f674ce029e2cadc0bcb5f87a4c31c5a8478845227a924834
+generated: "2023-08-04T10:01:29.139425+02:00"

--- a/system/prometheus-kubernetes/Chart.yaml
+++ b/system/prometheus-kubernetes/Chart.yaml
@@ -13,6 +13,9 @@ dependencies:
     repository: https://charts.eu-de-2.cloud.sap
     version: 7.2.8
     condition: prometheus_collector.enabled
+  - name: thanos
+    repository: https://charts.eu-de-2.cloud.sap
+    version: 0.4.4
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0

--- a/system/prometheus-kubernetes/values.yaml
+++ b/system/prometheus-kubernetes/values.yaml
@@ -17,7 +17,6 @@ prometheus-server:
 
 thanos:
   name: kubernetes
-  deployWholeThanos: true
 
 prometheus_collector:
   enabled: false

--- a/system/prometheus-kubernetes/values.yaml
+++ b/system/prometheus-kubernetes/values.yaml
@@ -15,8 +15,9 @@ prometheus-server:
     enabled: true
     size: 100Gi
 
-  thanos:
-    enabled: false
+thanos:
+  name: kubernetes
+  deployWholeThanos: true
 
 prometheus_collector:
   enabled: false

--- a/system/thanos-seeds/Chart.yaml
+++ b/system/thanos-seeds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: thanos-seeds
 description: dedicated seed deployment needed for thanos-sidecar in prometheus
-version: 0.0.2
+version: 0.0.3
 dependencies:
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap

--- a/system/thanos-seeds/templates/seed.yaml
+++ b/system/thanos-seeds/templates/seed.yaml
@@ -4,7 +4,7 @@
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: OpenstackSeed
 metadata:
-  name: {{ include "prometheus.name" (list $name $root) }}-thanos
+  name: {{ include "swift.userName" (list $name $root) | trimPrefix "prometheus-" }}
   labels:
     prometheus: {{ include "prometheus.name" (list $name $root) }}
 

--- a/system/thanos-seeds/values.yaml
+++ b/system/thanos-seeds/values.yaml
@@ -14,6 +14,9 @@ name:
 
 thanosSeeds:
   seed:
+    # optional to distinguish between Thanos seeds with the same name in different clusters
+    # # clusterType:
+
     # If disabled the user and container need to exist.
     enabled: true
 


### PR DESCRIPTION
This PR enables Thanos for Kubernetes Prometheis. 
- added thanos dependency
- adjusted thanos-seed naming to distinguish seed names from different clusters