### PR TITLE
[Octavia] Add stateless UDP ESD with correct naming convention

### DIFF
--- a/openstack/octavia/templates/etc/_esd.json.tpl
+++ b/openstack/octavia/templates/etc/_esd.json.tpl
@@ -53,5 +53,8 @@
   },
   "cc_esd_udp_stateless": {
     "lbaas_cudp": "cc_udp_datagram_profile"
+  },
+  "ccloud_special_udp_stateless": {
+    "lbaas_cudp": "cc_udp_datagram_profile"
   }
 }

--- a/openstack/octavia/templates/etc/_esd.json.tpl
+++ b/openstack/octavia/templates/etc/_esd.json.tpl
@@ -51,9 +51,6 @@
     "lbaas_ctcp": "cc_tcp_profile",
     "lbaas_irule": ["cc_hcm_rmk_restrict_internal"]
   },
-  "cc_esd_udp_stateless": {
-    "lbaas_cudp": "cc_udp_datagram_profile"
-  },
   "ccloud_special_udp_stateless": {
     "lbaas_cudp": "cc_udp_datagram_profile"
   }


### PR DESCRIPTION
3505ef545 added the `cc_esd_udp_stateless` ESD that can be set on listeners for activating stateless UDP load balancing. However, that ESD name didn't adhere to the new naming convention for special tags that was established not too long ago with the addition of the `ccloud_special_l4_deactivate_snat` tag. That tag is not implemented via an ESD, but instead directly in code (see [1] and [2]), which is why I failed to take it into account when adding the `cc_esd_udp_stateless` ESD. Since LoBs are already using the `cc_esd_udp_stateless` ESD, I don't want to just rename it, but instead introduce a new alternative one and remove the other one from the docs.

[1] https://github.com/sapcc/octavia-f5-provider-driver/blob/stable/yoga-m3/octavia_f5/common/constants.py#L61
[2] https://github.com/sapcc/octavia-f5-provider-driver/blob/stable/yoga-m3/octavia_f5/restclient/as3objects/service.py#L376