### PR TITLE
[octavia] enable prometheus-module metrics

### DIFF
--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -29,10 +29,18 @@ proxysql:
 rabbitmq:
   alerts:
     support_group: network-api
+  metrics:
+    enabled: true
+    sidecar:
+      enabled: false
 
 rabbitmq_notifications:
   alerts:
     support_group: network-api
+  metrics:
+    enabled: true
+    sidecar:
+      enabled: false
 
 memcached:
   alerts:


### PR DESCRIPTION
enable prometheus metrics collection using the built-in premetheus plugin of rabbitMQ, 
```
metrics:
    enabled: true
``` 
and deactivate the legacy side car exporter container. 
```
    sidecar:
      enabled: false
```

more information about the values can be found:
https://github.com/sapcc/helm-charts/blob/master/common/rabbitmq/CHANGELOG.md#050

Change-Id: I463f8c116c86343192297075750952c3aa0f445d