### PR TITLE
[rabbitmq] fix values documentation of V0.5.0

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -21,7 +21,7 @@ b.alkhateeb@sap.com
 ```
     metrics:
       port: 9150
-      enabled: false
+      enabled: true
       sidecar:
         enabled: false
 ```


### PR DESCRIPTION
set value of rabbitMQ in documentation of V0.5.0 

enabled: true 

to match the description (**activate metrics** without side car exporter)

Change-Id: I41573e1d6eec87caab9509c4cfd7fdc95893286c