### PR TITLE
thanos-virtual|admin-k3s|kubernikus: remove release

### DIFF
--- a/system/thanos-admin-k3s/Chart.lock
+++ b/system/thanos-admin-k3s/Chart.lock
@@ -1,9 +1,6 @@
 dependencies:
-- name: thanos
-  repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.17
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:ae9287009c5ad3ae6880be84d6d7274d3706b4db120d25491d3bdec01301d661
-generated: "2023-01-02T13:49:47.461841+01:00"
+digest: sha256:6c7a0e8b21abdaecf3124234d79457638aff93c3f51c9cedd56500d24eb652e0
+generated: "2023-08-16T09:55:06.696119+02:00"

--- a/system/thanos-admin-k3s/Chart.yaml
+++ b/system/thanos-admin-k3s/Chart.yaml
@@ -2,11 +2,8 @@ apiVersion: v2
 name: thanos-admin
 description: Deploy Thanos via operator 
 type: application
-version: 0.0.14
+version: 0.0.15
 dependencies:
-  - name: thanos
-    repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.17
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0

--- a/system/thanos-kubernikus/Chart.lock
+++ b/system/thanos-kubernikus/Chart.lock
@@ -1,9 +1,6 @@
 dependencies:
-- name: thanos
-  repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.5
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:8933ed50231e1c429157d153d42541cdf04d7813d8ab620358a1e99a81cea3fa
-generated: "2023-01-02T13:49:34.740803+01:00"
+digest: sha256:6c7a0e8b21abdaecf3124234d79457638aff93c3f51c9cedd56500d24eb652e0
+generated: "2023-08-16T09:55:19.687322+02:00"

--- a/system/thanos-kubernikus/Chart.yaml
+++ b/system/thanos-kubernikus/Chart.yaml
@@ -2,11 +2,8 @@ apiVersion: v2
 name: thanos-kubernikus
 description: Deploy Thanos via operator 
 type: application
-version: 0.0.3
+version: 0.0.4
 dependencies:
-  - name: thanos
-    repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.5
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0

--- a/system/thanos-virtual/Chart.lock
+++ b/system/thanos-virtual/Chart.lock
@@ -1,9 +1,6 @@
 dependencies:
-- name: thanos
-  repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.5
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:8933ed50231e1c429157d153d42541cdf04d7813d8ab620358a1e99a81cea3fa
-generated: "2023-01-02T13:49:19.824913+01:00"
+digest: sha256:6c7a0e8b21abdaecf3124234d79457638aff93c3f51c9cedd56500d24eb652e0
+generated: "2023-08-16T09:56:22.324757+02:00"

--- a/system/thanos-virtual/Chart.yaml
+++ b/system/thanos-virtual/Chart.yaml
@@ -2,11 +2,8 @@ apiVersion: v2
 name: thanos-virtual
 description: Deploy Thanos via operator 
 type: application
-version: 0.0.3
+version: 0.0.4
 dependencies:
-  - name: thanos
-    repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.5
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0


### PR DESCRIPTION
The cluster-wide querier is not needed for these cluster types since there will probably always be a one-to-one relationship between the querier and the kubernetes prometheus. Queriers on the prometheus will then be queried directly.