### PR TITLE
add new thanos endpoints for regional query

### DIFF
--- a/system/thanos-metal/Chart.yaml
+++ b/system/thanos-metal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos-metal-and-regional
 description: Deploy Thanos metal and regional via operator
 type: application
-version: 0.1.7
+version: 0.1.8
 dependencies:
   - name: thanos
     repository: https://charts.eu-de-2.cloud.sap

--- a/system/thanos-metal/values.yaml
+++ b/system/thanos-metal/values.yaml
@@ -57,14 +57,14 @@ regional_thanos:
     - metal
     - scaleout
     - kubernetes-virtual
-    - kubernetes-admin-k3s
+    - kubernetes-admin
     - kubernetes-kubernikus
     - kubernetes-k-master
     - kubernetes-customer
     - kubernetes-internet
-    - kubernetes-concourse
-    - kubernetes-concourse2
-    - kubernetes-concourse3
+    - kubernetes-ci
+    - kubernetes-ci2
+    - kubernetes-ci3
 
   ruler:
     enabled: true

--- a/system/thanos-metal/values.yaml
+++ b/system/thanos-metal/values.yaml
@@ -55,10 +55,16 @@ regional_thanos:
 
   clusterTypes:
     - metal
-    - virtual
-    - admin
-    - kubernikus
     - scaleout
+    - kubernetes-virtual
+    - kubernetes-admin-k3s
+    - kubernetes-kubernikus
+    - kubernetes-k-master
+    - kubernetes-customer
+    - kubernetes-internet
+    - kubernetes-concourse
+    - kubernetes-concourse2
+    - kubernetes-concourse3
 
   ruler:
     enabled: true


### PR DESCRIPTION
all but metal and scaleout are queried directly since it would be a 1:1 relationship with a query in between.