### PR TITLE
Redis increase CPU limit and request

### DIFF
--- a/common/redis/values.yaml
+++ b/common/redis/values.yaml
@@ -28,10 +28,10 @@ persistence:
 resources:
   limits:
     memory: 128Mi
-    cpu: 100m
+    cpu: 350m
   requests:
     memory: 128Mi
-    cpu: 10m
+    cpu: 100m
 
 # Prometheus metrics via oliver006/redis_exporter sidecar.
 metrics:


### PR DESCRIPTION
The RedisDB for services using openstack-rate-limiting is heavily throttled in all regions: Average ratio of throttled CPU seconds/used CPU seconds is above > 80%. Total used cpu (if there is no limit) is above 200% regions in the stages qa, bronze and silver. For eu-de-1 this value is higher than 400%.