### PR TITLE
traefik logic adapted to multiple scheme

### DIFF
--- a/common/thanos/Chart.yaml
+++ b/common/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: Deploy Thanos via operator
 type: application
-version: 0.4.4
+version: 0.4.5
 appVersion: v0.28.1
 maintainers:
   - name: Tommy Sauer (viennaa)

--- a/common/thanos/templates/dummy-grpc-ingress.yaml
+++ b/common/thanos/templates/dummy-grpc-ingress.yaml
@@ -1,10 +1,12 @@
 {{- if .Values.enabled }}
 {{- if .Values.traefik.enabled }}
 {{- $root := . }}
+{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress 
 metadata:
-  name: {{ include "thanos.fullName" . }}-grpc
+  name: {{ include "thanos.fullName" (list $name $root) }}-grpc
   annotations:
     disco: "true"
     kubernetes.io/tls-acme: "true"
@@ -22,12 +24,12 @@ spec:
           pathType: Prefix
           backend:
             service:
-              name:  {{ include "thanos.fullName" $root }}-query
+              name:  {{ include "thanos.fullName" (list $name $root) }}-query
               port:
                 number: 10901
     {{- end }}
   tls:
-    - secretName: tls-{{ include "thanos.grpcURL" $root | replace "." "-" }}
+    - secretName: tls-{{ include "thanos.externalGrpcURL" (list $name $root) | replace "." "-" }}
       hosts:
         {{- range $host := $root.Values.grpcIngress.hosts }}
         - {{ $host }}-grpc.{{ $root.Values.global.region }}.{{ $root.Values.global.tld }}
@@ -35,5 +37,6 @@ spec:
         {{- range $host := $root.Values.grpcIngress.hostsFQDN }}
         - {{ $host }}
         {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/common/thanos/templates/ingressroute-grpc.yaml
+++ b/common/thanos/templates/ingressroute-grpc.yaml
@@ -1,10 +1,12 @@
 {{- if .Values.enabled }}
 {{- if .Values.traefik.route.enabled }}
 {{- $root := . }}
+{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+---
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
-  name: {{ include "thanos.fullName" . }}-grpc
+  name: {{ include "thanos.fullName" (list $name $root) }}-grpc
 spec:
   entryPoints:
   - websecure
@@ -15,11 +17,12 @@ spec:
     priority: 11
     services:
     - kind: Service
-      name: thanos-admin-query
+      name: {{ $root.Values.traefik.route.serviceName }}
       port: 10901
       scheme: h2c
   {{- end }}
   tls:
-    secretName: tls-{{ include "thanos.grpcURL" $root | replace "." "-" }}
+    secretName: tls-{{ include "thanos.externalGrpcURL" (list $name $root) | replace "." "-" }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/common/thanos/values.yaml
+++ b/common/thanos/values.yaml
@@ -294,3 +294,5 @@ traefik:
 
   route:
     enabled: false
+    # service the route should point to. Needs to match Thanos Query.
+    serviceName: thanos-kubernetes-query


### PR DESCRIPTION
traefik part of the chart was not able to handle the newer helpers made for the multiple deployment. adopted it and made serviceName configurable. Since we are only using it in one cluster, it should default to our used name.