### PR TITLE
[hermes] increase es request to 20g

### DIFF
--- a/openstack/hermes/values.yaml
+++ b/openstack/hermes/values.yaml
@@ -101,7 +101,7 @@ elasticsearch_hermes:
   resources:
     requests:
       cpu: "2000m"
-      memory: "6Gi"
+      memory: "20Gi"
     limits:
       cpu: "4000m"
   exporter:


### PR DESCRIPTION
Increase global request to 20g to match a realistic view of the memory limits based on java opts