### PR TITLE
refac(clusterType): switch logs alerts to clusterType=metal

### DIFF
--- a/system/logs/templates/alerts/_fluent-bit-systemd-alerts.tpl
+++ b/system/logs/templates/alerts/_fluent-bit-systemd-alerts.tpl
@@ -3,7 +3,7 @@ groups:
   rules:
   - alert: LogsFluentBitSystemdLogsMissing
 {{ if eq .Values.global.clusterType  "scaleout" }}
-    expr: sum(rate(fluentbit_output_proc_records_total{job="logs-fluent-bit-systemd-exporter",cluster_type!="controlplane"}[60m])) by (nodename,name) == 0
+    expr: sum(rate(fluentbit_output_proc_records_total{job="logs-fluent-bit-systemd-exporter",cluster_type!="controlplane|metal"}[60m])) by (nodename,name) == 0
     for: 180m
 {{ else }}
     expr: sum(rate(fluentbit_output_proc_records_total{job="logs-fluent-bit-systemd-exporter"}[60m])) by (nodename,name) == 0
@@ -25,7 +25,7 @@ groups:
       summary: logs-fluent-bit-systemd is not shipping logs
   - alert: LogsFluentBitSystemdLogsIncreasing
 {{ if eq .Values.global.clusterType  "scaleout" }}
-    expr: (sum(increase(fluentbit_output_proc_records_total{cluster_type!="controlplane",job="logs-fluent-bit-systemd-exporter"}[1h])) by (name) / sum(increase(fluentbit_output_proc_records_total{cluster_type!="controlplane",job="logs-fluent-bit-systemd-exporter"}[1h]offset 2h)) by (name)) > 4
+    expr: (sum(increase(fluentbit_output_proc_records_total{cluster_type!="controlplane|metal",job="logs-fluent-bit-systemd-exporter"}[1h])) by (name) / sum(increase(fluentbit_output_proc_records_total{cluster_type!="controlplane|metal",job="logs-fluent-bit-systemd-exporter"}[1h]offset 2h)) by (name)) > 4
 {{ else }}
     expr: (sum(increase(fluentbit_output_proc_records_total{job="logs-fluent-bit-systemd-exporter"}[1h])) by (name) / sum(increase(fluentbit_output_proc_records_total{job="logs-fluent-bit-systemd-exporter"}[1h]offset 2h)) by (name)) > 4
 {{ end }}

--- a/system/logs/vendor/fluent/templates/alerts/_fluent-alerts.tpl
+++ b/system/logs/vendor/fluent/templates/alerts/_fluent-alerts.tpl
@@ -3,7 +3,7 @@ groups:
   rules:
   - alert: OpenSearchLogsFluentLogsMissing
 {{ if eq .Values.global.clusterType  "scaleout" }}
-    expr: sum by (nodename) (rate(fluentd_output_status_emit_records{cluster_type!="controlplane",component="fluent",type="opensearch"}[60m])) == 0
+    expr: sum by (nodename) (rate(fluentd_output_status_emit_records{cluster_type!="controlplane|metal",component="fluent",type="opensearch"}[60m])) == 0
     for: 360m
 {{ else }}
     expr: sum by (nodename) (rate(fluentd_output_status_emit_records{component="fluent",type="opensearch"}[60m])) == 0
@@ -25,7 +25,7 @@ groups:
       summary: fluent container is not shipping logs
   - alert: OpenSearchLogsFluentContainerIncreasing
 {{ if eq .Values.global.clusterType  "scaleout" }}
-    expr: (sum(increase(fluentd_output_status_emit_records{cluster_type!="controlplane",component="fluent",type="opensearch"}[1h])) / sum(increase(fluentd_output_status_emit_records{cluster_type!="controlplane",component="fluent",type="opensearch"}[1h]offset 2h))) > 2
+    expr: (sum(increase(fluentd_output_status_emit_records{cluster_type!="controlplane|metal",component="fluent",type="opensearch"}[1h])) / sum(increase(fluentd_output_status_emit_records{cluster_type!="controlplane|metal",component="fluent",type="opensearch"}[1h]offset 2h))) > 2
 {{ else }}
     expr: (sum(increase(fluentd_output_status_emit_records{component="fluent",type="opensearch"}[1h])) / sum(increase(fluentd_output_status_emit_records{component="fluent",type="opensearch"}[1h]offset 2h))) > 4
 {{ end }}

--- a/system/logs/vendor/logstash-external/templates/alerts/_logstash-alerts.tpl
+++ b/system/logs/vendor/logstash-external/templates/alerts/_logstash-alerts.tpl
@@ -3,7 +3,7 @@ groups:
   rules:
   - alert: ElkLogstashLogsIncreasing
 {{ if eq .Values.global.clusterType  "scaleout" }}
-    expr: increase(logstash_node_plugin_events_in_total{cluster_type!="controlplane",namespace="logs",plugin_id="elk-syslog"}[1h]) / increase(logstash_node_plugin_events_in_total{namespace="logs",cluster_type!="controlplane",plugin_id="elk-syslog"}[1h]offset 2h) > 2
+    expr: increase(logstash_node_plugin_events_in_total{cluster_type!="controlplane|metal",namespace="logs",plugin_id="elk-syslog"}[1h]) / increase(logstash_node_plugin_events_in_total{namespace="logs",cluster_type!="controlplane|metal",plugin_id="elk-syslog"}[1h]offset 2h) > 2
 {{ else }}
     expr: increase(logstash_node_plugin_events_in_total{namespace="logs",plugin_id="elk-syslog"}[1h]) / increase(logstash_node_plugin_events_in_total{namespace="logs",plugin_id="elk-syslog"}[1h]offset 2h) > 2
 {{ end }}


### PR DESCRIPTION
In order to standardize labels between Prometheis the `cluster_type` label value for metal clusters will be renamed for the infra-prometheis from `controlplane` to `metal`.
This PR prepares the _system/logs_ alerts for this change.