### PR TITLE
setting ingressClassName and adding traefik documentation

### DIFF
--- a/common/thanos/Chart.yaml
+++ b/common/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: Deploy Thanos via operator
 type: application
-version: 0.4.6
+version: 0.4.7
 appVersion: v0.28.1
 maintainers:
   - name: Tommy Sauer (viennaa)

--- a/common/thanos/templates/ingress.yaml
+++ b/common/thanos/templates/ingress.yaml
@@ -23,6 +23,7 @@ metadata:
 {{ toYaml $.Values.ingress.annotations | indent 4 }}
     {{ end }}
 spec:
+  ingressClassName: nginx
   rules:
     {{- range $host := coalesce $.Values.ingress.hosts (list $name) }}
     - host: {{ include "fqdnHelper" (list $host $root) }}

--- a/common/thanos/values.yaml
+++ b/common/thanos/values.yaml
@@ -285,8 +285,11 @@ alerts:
 vmware: false
 
 traefik:
-  # defaults to false. Should only be enabled if traefik is used over default ingress-nginx. Please set grpcIngress.enabled to false in this case.
-  # it will spawn a dummy ingress resource to annotate the hostname for dns record creation. However, this dummy will not do anything because the grpc service is not exposing on 80.
+  # there are two scenarios when this is needed
+  # 1 Should be enabled only if no ingressClass is present in the cluster. Please set grpcIngress.enabled to false and set route.enabled to true.
+  # 
+  # 2 if k8s.io/ingress-nginx and traefik.io/ingress-controller are present, set traefik.enabled: false and route.enabled: true
+  # General information: it will spawn a dummy ingress resource to annotate the hostname for dns record creation. However, this dummy will not do anything because the grpc service is not exposing on 80.
   enabled: false
 
   # List of hostnames to match, typically the same which are configured in grpcIngress.hosts


### PR DESCRIPTION
the admin and customer cluster both need different special handling, which needs some inline explanation
