### PR TITLE
[util] Created function kubernetes_pod_AZ_spread in utils/templates/_…

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.10.1
+version: 0.10.2

--- a/openstack/utils/templates/_affinity.tpl
+++ b/openstack/utils/templates/_affinity.tpl
@@ -48,3 +48,40 @@ affinity:
                   values:
                   - operational
 {{- end }}
+
+{{ define "kubernetes_pod_AZ_spread" -}}
+{{- $envAll := index . 0 -}}
+{{- $application := index . 1 -}}
+{{- $component := index . 2 -}}
+affinity:
+  podAntiAffinity:
+  preferredDuringSchedulingIgnoredDuringExecution:
+  - weight: 1
+    podAffinityTerm:
+      labelSelector:
+        matchExpressions:
+          - key: "app"
+            operator: In
+            values:
+              - {{$envAll.Release.Name}}
+          - key: "component"
+            operator: In
+            values:
+              - {{$component}}
+      topologyKey: "topology.kubernetes.io/zone"
+  - weight: 2
+    podAffinityTerm:
+      labelSelector:
+        matchExpressions:
+          - key: "app"
+            operator: In
+            values:
+              - {{$envAll.Release.Name}}
+          - key: "component"
+            operator: In
+            values:
+              - {{$component}}
+      topologyKey: "kubernetes.io/hostname"
+
+{{- end }}
+


### PR DESCRIPTION
Created function kubernetes_pod_AZ_spread in utils/templates/_affinity.tpl that makes sure pods are spread between all availability zones. Function should replace kubernetes_pod_anti_affinity for scheduling pods in all AZs. 