### PR TITLE
[Nova] nova-bigvm uses 100% of memory

### DIFF
--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -218,7 +218,9 @@ api_metadata:
       api_paste_config: /etc/nova/api-paste.ini
 
 bigvm:
-  config_file: {}
+  config_file:
+    DEFAULT:
+      bigvm_cluster_max_usage_percent: 100
 
 consoles:
   novnc:


### PR DESCRIPTION
The default in Nova is to use 80% of the cluster's memory for bigvms. Since we switched to having 2 failover hosts, we no longer need to reserve 20% memory being able to overcommit and thus can fill the whole available cluster with big vms.