### PR TITLE
keystone: upgrade to zed

### DIFF
--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: xena
+appVersion: zed
 description: A Helm chart for OpenStack Keystone
 home: https://docs.openstack.org/keystone/latest/
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Keystone/OpenStack_Project_Keystone_vertical.png
@@ -9,7 +9,7 @@ maintainers:
 name: keystone
 sources:
   - https://github.com/sapcc/keystone
-version: 0.4.1
+version: 0.5.0
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -29,7 +29,7 @@ run_db_migration: true
 skipRepairRoleAssignments: false
 
 # current keystone release
-release: xena
+release: zed
 
 ## Affinity for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
@@ -193,7 +193,7 @@ tempest:
   enabled: false
   image: "rally-openstack"
   #imageTag: "ccloud-1.5.0"
-  imageTag: "ccloud-xena"
+  imageTag: "ccloud-zed"
   adminPassword: ""
   userPassword: ""
   # tempest domain-id  -- do not set in production environments!


### PR DESCRIPTION
This is a part of the effort to get rid of vulnerabilities in dependencies. Keystone is getting upgraded to zed