### PR TITLE
[cc3test] disable CC3TestCanaryTestsNotRunning for now

### DIFF
--- a/openstack/cc3test/alerts/cc3test-runtime.alerts
+++ b/openstack/cc3test/alerts/cc3test-runtime.alerts
@@ -27,18 +27,18 @@ groups:
       description: 'cc3test {{ $labels.type }}/{{ $labels.name }}/{{ $labels.when }} is not running for more than 30 minutes'
       summary: 'cc3test {{ $labels.type }}/{{ $labels.name }}/{{ $labels.when }} is down'
 
-  - alert: CC3TestCanaryTestsNotRunning
-    expr: sum without (pod, instance) (increase(cc3test_total{type!~'api|datapath|(.+)purge$|purge|certificate|baremetal_and_regression|(.+)allhosts$', when='call'}[60m])) == 0
-    for: 120m
-    labels:
-      severity: info
-      service: cc3test
-      context: '{{ $labels.service }}'
-      dashboard: cc3test-overview
-      meta: 'cc3test {{ $labels.type }}/{{ $labels.name }}/{{ $labels.when }} is not running for more than 60 minutes'
-    annotations:
-      description: 'cc3test {{ $labels.type }}/{{ $labels.name }}/{{ $labels.when }} is not running for more than 60 minutes'
-      summary: 'cc3test {{ $labels.type }}/{{ $labels.name }}/{{ $labels.when }} is down'
+#  - alert: CC3TestCanaryTestsNotRunning
+#    expr: sum without (pod, instance) (increase(cc3test_total{type!~'api|datapath|(.+)purge$|purge|certificate|baremetal_and_regression|(.+)allhosts$', when='call'}[60m])) == 0
+#    for: 120m
+#    labels:
+#      severity: info
+#      service: cc3test
+#      context: '{{ $labels.service }}'
+#      dashboard: cc3test-overview
+#      meta: 'cc3test {{ $labels.type }}/{{ $labels.name }}/{{ $labels.when }} is not running for more than 60 minutes'
+#    annotations:
+#      description: 'cc3test {{ $labels.type }}/{{ $labels.name }}/{{ $labels.when }} is not running for more than 60 minutes'
+#      summary: 'cc3test {{ $labels.type }}/{{ $labels.name }}/{{ $labels.when }} is down'
 
   - alert: CC3TestCertificateTestsNotRunning
     expr: sum without (pod, instance) (increase(cc3test_total{type='certificate', when='call'}[24h])) == 0


### PR DESCRIPTION
it creates a lot of false alerts due to decomissioned bb's and their stale metrics etc - so lets disable it for now until we have found a better way of handling this