### PR TITLE
[neutron] Adjusting nsxt-v3 CPU ressource limits

### DIFF
--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -135,7 +135,7 @@ pod:
         memory: "1Gi"
     nsxv3_agent:
       requests:
-        cpu: "64m"
+        cpu: "256m"
         memory: "256Mi"
       limits:
         cpu: "128m"

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -135,10 +135,10 @@ pod:
         memory: "1Gi"
     nsxv3_agent:
       requests:
-        cpu: "256m"
+        cpu: "128m"
         memory: "256Mi"
       limits:
-        cpu: "128m"
+        cpu: "256m"
         memory: "512Mi"
     nsxv3_exporter:
       requests:


### PR DESCRIPTION
The ressource limits for the nsxt-v3 pods are too low across almost all regions. We went through all regions and compared the calculated ueage rate and the CPU limits. Adjusting the limit to 256m fixes the problem for the following regions:

* ap-sa-1
* na-ca-1
* na-us-3
* ap-ae-1
* ap-cn-1
* ap-jp-1
* ap-sa-1
* la-br-1
* na-us-1
* na-us-2

Note: 256m is a little generous for some regions, locally defining values for smaller regions to 128m is an option in case of ressource problems.

The gold regions need higher custom values across the board.