### PR TITLE
[MariaDB] - Security Patches upgrade to 10.5.21

### DIFF
--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.7.12
+version: 0.7.13

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -4,7 +4,7 @@
 # name: value
 
 name: null
-image: library/mariadb:10.5.17
+image: library/mariadb:10.5.21
 imagePullPolicy: IfNotPresent
 port_public: 3306
 max_connections: 1024
@@ -138,7 +138,7 @@ backup_v2:
 metrics:
   enabled: true
   image: prom/mysqld-exporter
-  image_version: v0.12.1
+  image_version: v0.14.0
   port: "9104"
   flags:
     - collect.binlog_size


### PR DESCRIPTION
  Patch includes:
     - Mariadb upgrade from 10.5.17 to 10.5.21
     - mysqld-exporter upgrade from v0.12.1 to v0.14.0