### PR TITLE
[neutron] Adjusting nsxt-v3 CPU ressource limits

### DIFF
--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -135,10 +135,10 @@ pod:
         memory: "1Gi"
     nsxv3_agent:
       requests:
-        cpu: "64m"
+        cpu: "128m"
         memory: "256Mi"
       limits:
-        cpu: "128m"
+        cpu: "256m"
         memory: "512Mi"
     nsxv3_exporter:
       requests:


### PR DESCRIPTION
The ressource limits for the nsxt-v3 pods are too low across almost all regions. We went through all regions and compared the calculated ueage rate and the CPU limits. Adjusting the limit to 256m fixes the problem for the following regions:

    ap-sa-1
    na-ca-1
    na-us-3
    ap-ae-1
    ap-cn-1
    ap-jp-1
    ap-sa-1
    la-br-1
    na-us-1
    na-us-2

Note: This is a conservative estimate. For most regions 128m will be sufficient and a limit of 256m will take care of the spikes.