### PR TITLE
ingress should always be nginx

### DIFF
--- a/common/prometheus-server/CHANGELOG.md
+++ b/common/prometheus-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.2.11
+
+* Defaulting ingressClassName to nginx to avoid picking up traefik 
+
 ## 7.2.10
 
 * Improved RemoteWriteBehind alert

--- a/common/prometheus-server/Chart.yaml
+++ b/common/prometheus-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus via operator.
 name: prometheus-server
-version: 7.2.10
+version: 7.2.11
 appVersion: v2.43.0
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
 maintainers:

--- a/common/prometheus-server/templates/ingress-internal.yaml
+++ b/common/prometheus-server/templates/ingress-internal.yaml
@@ -26,6 +26,11 @@ metadata:
     {{ end }}
 
 spec:
+  {{- if $.Values.traefik.enabled }}
+  ingressClassName: traefik
+  {{- else }}
+  ingressClassName: nginx
+  {{- fi }}
   rules:
     {{- range $host := coalesce $.Values.internalIngress.hosts (list $name) }}
     - host: {{ include "internalFQDNHelper" (list $host $root) }}

--- a/common/prometheus-server/templates/ingress-internal.yaml
+++ b/common/prometheus-server/templates/ingress-internal.yaml
@@ -26,11 +26,9 @@ metadata:
     {{ end }}
 
 spec:
-  {{- if $.Values.traefik.enabled }}
-  ingressClassName: traefik
-  {{- else }}
+  {{- if not $.Values.traefik.enabled }}
   ingressClassName: nginx
-  {{- fi }}
+  {{- end }}
   rules:
     {{- range $host := coalesce $.Values.internalIngress.hosts (list $name) }}
     - host: {{ include "internalFQDNHelper" (list $host $root) }}

--- a/common/prometheus-server/templates/ingress.yaml
+++ b/common/prometheus-server/templates/ingress.yaml
@@ -27,6 +27,11 @@ metadata:
     {{ end }}
 
 spec:
+  {{- if $.Values.traefik.enabled }}
+  ingressClassName: traefik
+  {{- else }}
+  ingressClassName: nginx
+  {{- fi }}
   rules:
     {{- range $host := coalesce $.Values.ingress.hosts (list $name) }}
     - host: {{ include "fqdnHelper" (list $host $root) }}

--- a/common/prometheus-server/templates/ingress.yaml
+++ b/common/prometheus-server/templates/ingress.yaml
@@ -27,11 +27,9 @@ metadata:
     {{ end }}
 
 spec:
-  {{- if $.Values.traefik.enabled }}
-  ingressClassName: traefik
-  {{- else }}
+  {{- if not $.Values.traefik.enabled }}
   ingressClassName: nginx
-  {{- fi }}
+  {{- end }}
   rules:
     {{- range $host := coalesce $.Values.ingress.hosts (list $name) }}
     - host: {{ include "fqdnHelper" (list $host $root) }}

--- a/common/prometheus-server/values.yaml
+++ b/common/prometheus-server/values.yaml
@@ -80,6 +80,10 @@ alertmanagers:
 service:
   annotations: {}
 
+# Will explicitly set ingressClassName to nginx. If the cluster has traefik deployed only, this needs to be set to true
+traefik:
+  enabled: false
+
 # Optional ingress for this Prometheus.
 ingress:
   enabled: false


### PR DESCRIPTION
if this isn't set, it will pick up traefik in certain clusters which won't work