### PR TITLE
feat(oauth-proxy): made email claim configurable

### DIFF
--- a/global/oauth-proxy/templates/deployment.yaml
+++ b/global/oauth-proxy/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
             - --cookie-name={{ .Values.oauth_proxy.cookie_name }}
             - --cookie-domain={{ .Values.oauth_proxy.cookie_domain }}
             - --cookie-expire={{ .Values.oauth_proxy.cookie_expire }}
-            - --oidc-email-claim=mail
+            - --oidc-email-claim={{ .Values.oauth_proxy.email_claim }}
 
           # Register a new application
           # https://github.com/settings/applications/new

--- a/global/oauth-proxy/values.yaml
+++ b/global/oauth-proxy/values.yaml
@@ -28,3 +28,4 @@ oauth_proxy:
   cookie_name: "_oauth2_proxy"
   cookie_domain: DEFINED_IN_VALUES_FILE
   cookie_expire: DEFINED_IN_VALUES_FILE
+  email_claim: DEFINED_IN_VALUES_FILE


### PR DESCRIPTION
This PR is depending on: 

https://github.wdf.sap.corp/cc/secrets/pull/12373

It makes the "email claim" option of the oauth-proxy configurable and uses for qa-de-2 "login" instead of "email" to test migration to AuzureAD as authentication provider. 