### PR TITLE
nova/flavor: Increase "forced" disk size to 64GiB

### DIFF
--- a/openstack/sap-seeds/templates/flavor-seed.yaml
+++ b/openstack/sap-seeds/templates/flavor-seed.yaml
@@ -10,7 +10,7 @@ spec:
     id: "1"
     vcpus: 1
     ram: 1024
-    disk: 1
+    disk: 64
     is_public: false
     extra_specs:
       {{- tuple . "forced" | include "sap_seeds.helpers.extra_specs" | indent 6 }}


### PR DESCRIPTION
The forced flavor, used for spawning tests on baremetal and elsewhere, still needs a proper disk size because images request a "min_disk" size in their attributes for the VM.

64GiB is the most common size for regular OS images, with most other sizes being smaller.
