### PR TITLE
common/prometheus-server: adds chart and release labels

### DIFF
--- a/common/prometheus-server/CHANGELOG.md
+++ b/common/prometheus-server/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 7.2.13
 
-* Chart version and Release name labeled
+* Chart version labeled
 
 ## 7.2.12
 

--- a/common/prometheus-server/CHANGELOG.md
+++ b/common/prometheus-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.2.13
+
+* Chart version and Release name labeled
+
 ## 7.2.12
 
 * scrapeConfigSelector added to the Prometheus CR

--- a/common/prometheus-server/Chart.yaml
+++ b/common/prometheus-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus via operator.
 name: prometheus-server
-version: 7.2.12
+version: 7.2.14
 appVersion: v2.43.0
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
 maintainers:

--- a/common/prometheus-server/Chart.yaml
+++ b/common/prometheus-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus via operator.
 name: prometheus-server
-version: 7.2.14
+version: 7.2.13
 appVersion: v2.43.0
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
 maintainers:

--- a/common/prometheus-server/templates/prometheus-server.yaml
+++ b/common/prometheus-server/templates/prometheus-server.yaml
@@ -8,6 +8,8 @@ metadata:
   name: {{ include "prometheus.name" (list $name $root) }}
   labels:
     prometheus: {{ include "prometheus.name" (list $name $root) }}
+    common-chart: prometheus-server-{{ $.Chart.Version }}
+    release: {{ $.Release.Name }}
 
 spec:
   replicas: 1

--- a/common/prometheus-server/templates/prometheus-server.yaml
+++ b/common/prometheus-server/templates/prometheus-server.yaml
@@ -9,7 +9,6 @@ metadata:
   labels:
     prometheus: {{ include "prometheus.name" (list $name $root) }}
     common-chart: prometheus-server-{{ $.Chart.Version }}
-    release: {{ $.Release.Name }}
 
 spec:
   replicas: 1


### PR DESCRIPTION
example for infra-monitoring:
```
apiVersion: monitoring.coreos.com/v1
  kind: Prometheus
  metadata:
    labels:
+     common-chart: prometheus-server-7.2.14
      prometheus: infra-collector
    name: infra-collector
```