### PR TITLE
[vmware-monitoring] Expose custom HANA exclusive information

### DIFF
--- a/system/vmware-monitoring/templates/collector-configmap.yaml
+++ b/system/vmware-monitoring/templates/collector-configmap.yaml
@@ -83,6 +83,8 @@ data:
         key: "configuration|drsconfig|affinityRules"
       - metric_suffix: "custom_attributes_hana_exclusive_info"
         key: "summary|customTag:hana_exclusive|customTagValue"
+      - metric_suffix: "summary_custom_tag_openstack_nova_traits_hana_exclusive_host"
+        key: "summary|customTag:openstack.nova.traits.CUSTOM_HANA_EXCLUSIVE_HOST|customTagValue"
 
     ClusterStatsCollector:
     # INFO - Prefix: vrops_cluster_


### PR DESCRIPTION
- Include the HANA exclusive key from the OpenStack Nova traits in the vrops-exporter-collector-config (ClusterPropertiesCollector) for generating the Prometheus metrics
- [ ] Check if the data is available in the vROps REST API