### PR TITLE
swift: move owner-info and alert routing to new support group "storage"

### DIFF
--- a/openstack/swift-drive-autopilot/values.yaml
+++ b/openstack/swift-drive-autopilot/values.yaml
@@ -2,13 +2,17 @@ global:
   imageRegistry: DEFINED_IN_VALUES_FILE
 
 owner-info:
-  support-group: containers
+  support-group: storage
   service: swift
   maintainers:
-    - Falk Reimann
+    # current maintainers in Storage Team
+    - Sumit Arora
+    - Barun Kumar
+    - Adrian Corici
+    - Chandrakanth Renduchintala
+    # previous maintainers in Team Services
     - Stefan Majewsky
     - Sandro Jäckel
-    - Muhammad Talal Anwar
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/openstack/swift-drive-autopilot
 
 encryption_key: DEFINED_IN_VALUES_FILE

--- a/openstack/swift-utils/alerts/caretaker.alerts
+++ b/openstack/swift-utils/alerts/caretaker.alerts
@@ -12,7 +12,7 @@ groups:
       dashboard: swift-overview
       service: swift
       severity: info
-      support_group: containers
+      support_group: storage
       tier: os
       meta: '{{ $value }} orphaned Swift accounts'
     annotations:

--- a/openstack/swift-utils/values.yaml
+++ b/openstack/swift-utils/values.yaml
@@ -4,13 +4,17 @@ global:
   imageRegistry: DEFINED_IN_VALUES_FILE
 
 owner-info:
-  support-group: containers
+  support-group: storage
   service: swift
   maintainers:
-    - Falk Reimann
+    # current maintainers in Storage Team
+    - Sumit Arora
+    - Barun Kumar
+    - Adrian Corici
+    - Chandrakanth Renduchintala
+    # previous maintainers in Team Services
     - Stefan Majewsky
     - Sandro Jäckel
-    - Muhammad Talal Anwar
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/openstack/swift-utils
 
 species: swift-storage

--- a/openstack/swift/alerts/kubernetes/pod.alerts
+++ b/openstack/swift/alerts/kubernetes/pod.alerts
@@ -8,7 +8,7 @@ groups:
       for: 15m
       labels:
         severity: warning
-        support_group: containers
+        support_group: storage
         tier: os
         service: swift
         context: cpu
@@ -23,7 +23,7 @@ groups:
       for: 15m
       labels:
         no_alert_on_absence: "true" # small regions may have no throttled containers at all, so this may legitimately occur
-        support_group: containers
+        support_group: storage
         tier: os
         service: swift
         severity: info
@@ -40,7 +40,7 @@ groups:
       for: 15m
       labels:
         severity: warning
-        support_group: containers
+        support_group: storage
         tier: os
         service: swift
         context: memory
@@ -55,7 +55,7 @@ groups:
       expr: container_memory_saturation_ratio{namespace="swift",pod_name!~"keep-image-pulled-.*"} > 0.7 AND predict_linear(container_memory_saturation_ratio{namespace="swift",pod_name!~"keep-image-pulled-.*"}[1h], 7*3600) > 1.0
       for: 30m
       labels:
-        support_group: containers
+        support_group: storage
         tier: os
         service: swift
         severity: info

--- a/openstack/swift/alerts/openstack/api.alerts
+++ b/openstack/swift/alerts/openstack/api.alerts
@@ -11,7 +11,7 @@ groups:
       dashboard: swift-proxy?var-cluster={{ $labels.os_cluster }}&var-proxy={{ $labels.instance }}
       service: swift
       severity: info
-      support_group: containers
+      support_group: storage
       tier: os
       meta: first byte timing for {{ $labels.type }} in {{ $labels.os_cluster }} increased
     annotations:
@@ -27,7 +27,7 @@ groups:
       dashboard: swift-proxy?var-cluster={{ $labels.os_cluster }}
       service: swift
       severity: warning
-      support_group: containers
+      support_group: storage
       tier: os
       meta: 503 responses from Swift in {{ $labels.os_cluster }}
     annotations:
@@ -42,7 +42,7 @@ groups:
       context: haproxyredispatch
       service: swift
       severity: info
-      support_group: containers
+      support_group: storage
       tier: os
       meta: HAProxy redispatches for server {{ $labels.server }} in {{ $labels.os_cluster }}
     annotations:
@@ -57,7 +57,7 @@ groups:
       context: haproxyredispatch
       service: swift
       severity: info
-      support_group: containers
+      support_group: storage
       tier: os
       meta: HAProxy redispatches for server {{ $labels.server }} in {{ $labels.os_cluster }}
     annotations:
@@ -72,7 +72,7 @@ groups:
       context: haproxyredispatch
       service: swift
       severity: warning
-      support_group: containers
+      support_group: storage
       tier: os
       meta: HAProxy pod {{ $labels.kubernetes_pod_name }} redispatches in {{ $labels.os_cluster }}
     annotations:
@@ -87,7 +87,7 @@ groups:
       context: haproxyredispatch
       service: swift
       severity: warning
-      support_group: containers
+      support_group: storage
       tier: os
       meta: HAProxy pod {{ $labels.kubernetes_pod_name }} redispatches S3 API requests
     annotations:
@@ -103,7 +103,7 @@ groups:
       dashboard: swift-overview
       service: swift
       severity: warning
-      support_group: containers
+      support_group: storage
       tier: os
       playbook: 'docs/support/playbook/swift/healthcheck'
       meta: some health checks for Swift are failing
@@ -119,7 +119,7 @@ groups:
       dashboard: swift-overview
       service: swift
       severity: info
-      support_group: containers
+      support_group: storage
       tier: os
       meta: 'Swift dispersion is reporting {{ $value }} errors'
     annotations:
@@ -134,7 +134,7 @@ groups:
       dashboard: swift-overview
       service: swift
       severity: warning
-      support_group: containers
+      support_group: storage
       tier: os
       playbook: 'docs/support/playbook/swift/rings'
       meta: Rings are not equal on all Swift nodes
@@ -150,7 +150,7 @@ groups:
       dashboard: swift-overview
       service: swift
       severity: warning
-      support_group: containers
+      support_group: storage
       tier: os
       meta: Configuration is not equal on all Swift nodes
     annotations:
@@ -165,7 +165,7 @@ groups:
       dashboard: swift-overview
       service: swift
       severity: warning
-      support_group: containers
+      support_group: storage
       tier: os
       playbook: 'docs/support/playbook/swift/node_error'
       meta: Swift node {{ $labels.storage_ip }} not reachable
@@ -181,7 +181,7 @@ groups:
       dashboard: swift-overview
       service: swift
       severity: info
-      support_group: containers
+      support_group: storage
       tier: os
       meta: '{{ $value }} Swift drives not mounted'
     annotations:
@@ -215,7 +215,7 @@ groups:
       dashboard: swift-overview
       service: swift
       severity: info
-      support_group: containers
+      support_group: storage
       tier: os
       meta: Async Pendings indicate an overload scenario or faulty device(s)
     annotations:
@@ -230,7 +230,7 @@ groups:
       dashboard: swift-overview
       service: swift
       severity: info
-      support_group: containers
+      support_group: storage
       tier: os
       meta: Some accounts/containers are being rate-limited in {{ $labels.os_cluster }}
     annotations:
@@ -245,7 +245,7 @@ groups:
       dashboard: swift-overview
       service: swift
       severity: warning
-      support_group: containers
+      support_group: storage
       tier: os
       meta: Some accounts/containers are being rate-limited in {{ $labels.os_cluster }}
     annotations:
@@ -259,7 +259,7 @@ groups:
       context: usedcapacity
       service: swift
       severity: info
-      support_group: containers
+      support_group: storage
       tier: os
       meta: Swift storage usage will reach 80% in 30 days. Order hardware now!
     annotations:
@@ -273,7 +273,7 @@ groups:
       context: usedcapacity
       service: swift
       severity: info
-      support_group: containers
+      support_group: storage
       tier: os
       meta: 'Swift storage usage above {{ $value }}%'
     annotations:
@@ -287,7 +287,7 @@ groups:
       context: grantedquota
       service: swift
       severity: info
-      support_group: containers
+      support_group: storage
       tier: os
       meta: 'Swift storage is overbooked: {{ $value }}%'
     annotations:
@@ -301,7 +301,7 @@ groups:
       context: grantedquota
       service: swift
       severity: warning
-      support_group: containers
+      support_group: storage
       tier: os
       meta: 'Swift storage is overbooked: {{ $value }}%'
     annotations:
@@ -316,7 +316,7 @@ groups:
       dashboard: swift-overview
       service: swift
       severity: warning
-      support_group: containers
+      support_group: storage
       tier: os
       meta: '{{ $labels.kubernetes_pod_name }} not performing consistency checks on schedule'
     annotations:
@@ -331,7 +331,7 @@ groups:
       dashboard: swift-overview
       service: swift
       severity: warning
-      support_group: containers
+      support_group: storage
       tier: os
       meta: Account replication getting stuck on {{ $labels.storage_ip }}
     annotations:
@@ -347,7 +347,7 @@ groups:
       dashboard: swift-overview
       service: swift
       severity: warning
-      support_group: containers
+      support_group: storage
       tier: os
       meta: Container replication getting stuck on {{ $labels.storage_ip }}
     annotations:
@@ -364,7 +364,7 @@ groups:
       dashboard: swift-overview
       service: swift
       severity: info
-      support_group: containers
+      support_group: storage
       tier: os
       meta: Object auditor quarantined {{ $value }} objects on node {{ $labels.storage_ip }}
     annotations:
@@ -381,7 +381,7 @@ groups:
       dashboard: swift-overview
       service: swift
       severity: info
-      support_group: containers
+      support_group: storage
       tier: os
       meta: Container auditor quarantined {{ $value }} containers on node {{ $labels.storage_ip }}
     annotations:
@@ -398,7 +398,7 @@ groups:
       dashboard: swift-overview
       service: swift
       severity: info
-      support_group: containers
+      support_group: storage
       tier: os
       meta: Account auditor quarantined {{ $value }} accounts on node {{ $labels.storage_ip }}
     annotations:

--- a/openstack/swift/templates/prometheus-alerts.yaml
+++ b/openstack/swift/templates/prometheus-alerts.yaml
@@ -51,7 +51,7 @@ spec:
         expr: absent(openstack_assignments_per_role{role_name="cloud_objectstore_admin"}) or max(openstack_assignments_per_role{role_name="cloud_objectstore_admin"}) > {{if eq $r "eu-nl-1"}} 7 {{ else }} 6 {{ end }}
         for: 10m
         labels:
-          support_group: containers
+          support_group: storage
           tier: os
           service: swift
           severity: info
@@ -69,7 +69,7 @@ spec:
         for: 10m
         labels:
           no_alert_on_absence: "true" # Keystone does not generate a zero-valued metric, so this metric is actually absent until an alert happens (TODO: remove this once we add allowed role assignments)
-          support_group: containers
+          support_group: storage
           tier: os
           service: swift
           severity: info
@@ -107,7 +107,7 @@ spec:
         expr: max(time() - swift_s3_cache_prewarm_last_run_secs) > 600
         for: 5m
         labels:
-          support_group: containers
+          support_group: storage
           tier: os
           service: swift
           severity: info

--- a/openstack/swift/values.yaml
+++ b/openstack/swift/values.yaml
@@ -9,13 +9,17 @@ global:
     skip_hcm_domain: false
 
 owner-info:
-  support-group: containers
+  support-group: storage
   service: swift
   maintainers:
-    - Falk Reimann
+    # current maintainers in Storage Team
+    - Sumit Arora
+    - Barun Kumar
+    - Adrian Corici
+    - Chandrakanth Renduchintala
+    # previous maintainers in Team Services
     - Stefan Majewsky
     - Sandro Jäckel
-    - Muhammad Talal Anwar
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/openstack/swift
 
 debug: false

--- a/system/gatekeeper/tests/gatekeeper-policies/fixtures/pod-security/swift-drive-autopilot.yaml
+++ b/system/gatekeeper/tests/gatekeeper-policies/fixtures/pod-security/swift-drive-autopilot.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: Helm
     ccloud/service: swift
-    ccloud/support-group: containers
+    ccloud/support-group: storage
   name: swift-drive-autopilot
   namespace: swift
 spec:

--- a/system/gatekeeper/tests/gatekeeper-policies/fixtures/pod-security/swift-servers.yaml
+++ b/system/gatekeeper/tests/gatekeeper-policies/fixtures/pod-security/swift-servers.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: Helm
     ccloud/service: swift
-    ccloud/support-group: containers
+    ccloud/support-group: storage
   name: swift-servers
   namespace: swift
 spec:


### PR DESCRIPTION
This should only be merged once the new support group has been set up.

@databus23 @geisslet FYI