### PR TITLE
[proxysql] adds resources

### DIFF
--- a/openstack/placement/values.yaml
+++ b/openstack/placement/values.yaml
@@ -17,6 +17,13 @@ use_tls_acme: true
 
 proxysql:
   mode: ""
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "256Mi"
+    limits:
+      cpu: "150m"
+      memory: "512Mi"
 
 defaults:
   default:

--- a/openstack/utils/templates/_proxysql.tpl
+++ b/openstack/utils/templates/_proxysql.tpl
@@ -24,6 +24,8 @@
 - name: proxysql
   image: {{ required ".Values.global.dockerHubMirror is missing" .Values.global.dockerHubMirror }}/{{ default "proxysql/proxysql" .Values.proxysql.image }}:{{ .Values.proxysql.imageTag | default "2.4.7-debian" }}
   imagePullPolicy: IfNotPresent
+  resources:
+{{ toYaml .Values.proxysql.resources | indent 4 }}
   command: ["proxysql"]
   args: ["--config", "/etc/proxysql/proxysql.cnf", "--exit-on-error", "--foreground", "--idle-threads", "--admin-socket", "/run/proxysql/admin.sock", "--no-version-check", "-D", "/run/proxysql"]
         {{- if gt $scale 1 }}


### PR DESCRIPTION
nova-api proxysql uses ~250mb of ram and ~40-50ms cpu.

Not sure which defaults makes more sense