### PR TITLE
nova/flavor: Allow old bigVM flavors on HANA BBs

### DIFF
--- a/openstack/sap-seeds/templates/_flavors_hana_exclusive.tpl
+++ b/openstack/sap-seeds/templates/_flavors_hana_exclusive.tpl
@@ -86,6 +86,9 @@
   is_public: true
   extra_specs:
     {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
+    "trait:CUSTOM_NUMASIZE_C48_M729": "required"
+    "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
+    "vmware:hw_version": "vmx-18"
     "host_fraction": "1/4,3/4,1/2,1"
 - name: "x1.32xlarge"
   id: "250"
@@ -95,5 +98,8 @@
   is_public: true
   extra_specs:
     {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
+    "trait:CUSTOM_NUMASIZE_C48_M729": "required"
+    "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
+    "vmware:hw_version": "vmx-18"
     "host_fraction": "1,0.67,0.34"
 {{- end }}

--- a/openstack/sap-seeds/templates/_flavors_hana_exclusive.tpl
+++ b/openstack/sap-seeds/templates/_flavors_hana_exclusive.tpl
@@ -83,7 +83,7 @@
   vcpus: 90
   ram: 1468416
   disk: 64
-  is_public: true
+  is_public: false
   extra_specs:
     {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
@@ -95,7 +95,7 @@
   vcpus: 128
   ram: 1991680
   disk: 64
-  is_public: true
+  is_public: false
   extra_specs:
     {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"


### PR DESCRIPTION
For decommissioning old BBs we need to move these VMs away. This patch allows to migrate VMs with these flavors onto HANA BBs. (After the old VMs are updated with the new flavor info.)
