### PR TITLE
exclude kubelet and cadvisor by default

### DIFF
--- a/system/prometheus-kubernetes/Chart.yaml
+++ b/system/prometheus-kubernetes/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Common Kubernetes Prometheus
 name: prometheus-kubernetes
-version: 0.1.4
+version: 0.1.5
 home: https://github.com/sapcc/helm-charts/tree/master/system/prometheus-kubernetes
 dependencies:
   - name: prometheus-server

--- a/system/prometheus-kubernetes/values.yaml
+++ b/system/prometheus-kubernetes/values.yaml
@@ -15,6 +15,12 @@ prometheus-server:
     enabled: true
     size: 100Gi
 
+  alerts:
+    multipleTargetScrapes:
+      exceptions:
+        - kubernetes-cadvisors
+        - kubernetes-kublet
+
 thanos:
   name: kubernetes
 


### PR DESCRIPTION
this is needed in every prometheus-kubernetes based cluser, otherwise alerts will fire
