### PR TITLE
[Nova] Move OpenstackNovaComputeIdle into Thanos

### DIFF
--- a/openstack/nova/alerts/metrics-metal/nova.alerts
+++ b/openstack/nova/alerts/metrics-metal/nova.alerts
@@ -2,7 +2,7 @@ groups:
 - name: openstack-nova.alerts
   rules:
   - alert: OpenstackNovaComputeIdle
-    expr: max(rate(container_cpu_usage_seconds_total{pod_name=~"nova-compute-bb.*"}[5m])) by (pod_name) * 1000 < 15
+    expr: (max(label_replace(rate(container_cpu_usage_seconds_total{pod_name=~"nova-compute-bb.*"}[5m]), 'host', '$1', 'pod_name', '(nova-compute-bb[0-9]+).*')) by (host) * 1000 < 15) AND (max(nova_compute_service_status) by (host) == 1)
     for: 60m
     labels:
       severity: warning

--- a/openstack/nova/templates/prometheus-alerts.yaml
+++ b/openstack/nova/templates/prometheus-alerts.yaml
@@ -1,6 +1,6 @@
 {{- $values := .Values }}
 {{- if $values.alerts.enabled }}
-{{- range $target := list "kubernetes" "openstack" }}
+{{- range $target := list "kubernetes" "openstack" "metrics-metal" }}
 {{- range $path, $bytes := $.Files.Glob (printf "alerts/%s/*.alerts" $target) }}
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -12,7 +12,11 @@ metadata:
     app: nova
     tier: os
     type: alerting-rules
+    {{- if eq (first (splitList "-" $target)) "metrics" }}
+    thanos-ruler: {{ trimPrefix "metrics-" $target }}
+    {{- else }}
     prometheus: {{ $target }}
+    {{- end }}
 
 spec:
 {{ printf "%s" $bytes | indent 2 }}


### PR DESCRIPTION
We want the alert to only fire if the service is not disabled. Our main metric comes from prometheus-kubernetes, while the `nova_compute_service_status` metric containing the service status (0 for disabled, 1 for enabled) comes from prometheus-openstack. Both metrics are available in `metrics.metal.$region.cloud.sap`, so we move the rule into that Thanos instance.

To support Thanos, we need to extend our alert template. We detect thanos by the prefix "metrics-" for the directory. The docs [0] state, that we need to set a different label and then everything should work.

[0] https://operations.global.cloud.sap/docs/architecture/monitoring/alerts/#thanos-rulesthanosrules