### PR TITLE
Aggregated rules consumed by Castellum

### DIFF
--- a/prometheus-exporters/netapp-exporter/Chart.lock
+++ b/prometheus-exporters/netapp-exporter/Chart.lock
@@ -8,5 +8,8 @@ dependencies:
 - name: netapp-perf-exporter
   repository: ""
   version: '>=0.0.2'
-digest: sha256:b53e054edf8988717a8ceabf79b280a740758bc10f4604d76ada4ab109cf5d99
-generated: "2023-03-31T10:39:16.210189+02:00"
+- name: netapp-cap-exporter
+  repository: ""
+  version: '>=0.1.0'
+digest: sha256:d07b46d9003e9e4283aa515eb913e99b6d3c20011690358b04f18c04f098c218
+generated: "2023-09-22T14:40:29.096139+02:00"

--- a/prometheus-exporters/netapp-exporter/Chart.yaml
+++ b/prometheus-exporters/netapp-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: netapp-exporter
 description: A Helm chart for Kubernetes
 type: application
-version: 0.2.2
+version: 0.2.3
 dependencies:
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
@@ -15,8 +15,13 @@ dependencies:
     repository: ""
     version: ">=0.0.2"
     condition: netapp-perf-exporter.enabled
+  - name: netapp-cap-exporter
+    repository: ""
+    version: ">=0.1.0"
+    condition: netapp-cap-exporter.enabled
 
 # Change Log
 # v0.2.0 - add netapp-harvest-exporter
 #        - ... Manila exporters are disabled by default
 # v0.2.2 - switching global Prometheus directive
+# v0.2.3 - add missing chart dependency

--- a/prometheus-exporters/netapp-exporter/charts/netapp-cap-exporter/Chart.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-cap-exporter/Chart.yaml
@@ -2,9 +2,10 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: netapp-cap-exporter
-version: 0.1.2
+version: 0.1.3
 maintainers:
   - name: Chuan Miao (D067954)
 
 # Change Log
 # v0.1.2 - add host label to all metrics
+# v0.1.3 - add metrics for castellum

--- a/prometheus-exporters/netapp-exporter/charts/netapp-cap-exporter/aggregations/netapp-castellum.rules
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-cap-exporter/aggregations/netapp-castellum.rules
@@ -4,7 +4,7 @@ groups:
 - name: castellum_manila
   rules:
 
-  # Case one: old provision style, where snapshot reserve is allocated AS PART OF the target share size and snapshot reserver percentage is 5.
+  # Case one: old provision style, where snapshot reserve is allocated AS PART OF the target share size and snapshot reserve percentage is 5.
   # The logical space reporting/enforcement is always disabled for them.
   # Share size = netapp_volume_total_bytes + netapp_volume_snapshot_reserved_bytes
   # Share usage = netapp_volume_used_bytes

--- a/prometheus-exporters/netapp-exporter/charts/netapp-cap-exporter/aggregations/netapp-castellum.rules
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-cap-exporter/aggregations/netapp-castellum.rules
@@ -1,0 +1,58 @@
+# vim: set ft=yaml:
+
+groups:
+- name: castellum_manila
+  rules:
+
+  # Case one: old provision style, where snapshot reserve is allocated AS PART OF the target share size and snapshot reserver percentage is 5.
+  # The logical space reporting/enforcement is always disabled for them.
+  # Share size = netapp_volume_total_bytes + netapp_volume_snapshot_reserved_bytes
+  # Share usage = netapp_volume_used_bytes
+  - record: netapp_volume_provision_case_one
+    expr: netapp_volume_percentage_snapshot_reserve{share_id!="", volume=~"share.*"} / 5 == 1
+
+  - record: manila_share_size_bytes_for_castellum
+    expr: netapp_volume_provision_case_one * (netapp_volume_total_bytes + netapp_volume_snapshot_reserved_bytes)
+
+  - record: manila_share_used_bytes_for_castellum
+    expr: netapp_volume_provision_case_one * netapp_volume_used_bytes
+
+  # We don't monitor the minimal size in particular for shares in case one, they trun to other cases once resized.
+  - record: manila_share_minimal_size_bytes_for_castellum
+    expr: netapp_volume_provision_case_one * (netapp_volume_total_bytes + netapp_volume_snapshot_reserved_bytes)
+
+  # Case two: new provision style and logical space is NOT enabled
+  # New provision style means snapshot reserve is allocated IN ADDTION TO share size, and sanpshot reserve percentage is 50
+  # To avoid snapshot spill, share's minimal size must be larger than the snapshot used size.
+  # Share size = netapp_volume_total_bytes
+  # Share usage = netapp_volume_used_bytes
+  # Share minimal size = max(netapp_volume_total_bytes, netapp_volume_snapshot_used_bytes)
+  - record: netapp_volume_provision_case_two
+    expr: (netapp_volume_percentage_snapshot_reserve{share_id!="", volume=~"share.*"} / 50 == 1) * (1 + netapp_volume_is_space_enforcement_logical == 1)
+
+  - record: manila_share_size_bytes_for_castellum
+    expr: netapp_volume_provision_case_two * netapp_volume_total_bytes
+
+  - record: manila_share_used_bytes_for_castellum
+    expr: netapp_volume_provision_case_two * netapp_volume_used_bytes
+
+  - record: manila_share_minimal_size_bytes_for_castellum
+    expr: netapp_volume_provision_case_two * on (share_id) group_left max({__name__=~"netapp_volume_total_bytes|netapp_volume_snapshot_used_bytes"}) by (share_id)
+
+  # Case three: new provision style and logical space enabled
+  # To avoid snapshot spill, share's minimal size must be larger than the snapshot used size.
+  # Share size = netapp_volume_total_bytes
+  # Share usage = netapp_volume_logical_used_bytes
+  # Share minimal size = max(netapp_volume_total_bytes, netapp_volume_snapshot_used_bytes)
+  - record: netapp_volume_provision_case_three
+    expr: (netapp_volume_percentage_snapshot_reserve{share_id!="", volume=~"share.*"} / 50 == 1) * (netapp_volume_is_space_enforcement_logical == 1)
+
+  - record: manila_share_size_bytes_for_castellum
+    expr: netapp_volume_provision_case_three * netapp_volume_total_bytes
+
+  - record: manila_share_used_bytes_for_castellum
+    expr: netapp_volume_provision_case_three * netapp_volume_logical_used_bytes
+
+  - record: manila_share_minimal_size_bytes_for_castellum
+    expr: netapp_volume_provision_case_three * on (share_id) group_left max({__name__=~"netapp_volume_total_bytes|netapp_volume_snapshot_used_bytes"}) by (share_id)
+

--- a/prometheus-exporters/netapp-exporter/charts/netapp-cap-exporter/aggregations/netapp-castellum.rules
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-cap-exporter/aggregations/netapp-castellum.rules
@@ -28,7 +28,7 @@ groups:
   # Share usage = netapp_volume_used_bytes
   # Share minimal size = max(netapp_volume_total_bytes, netapp_volume_snapshot_used_bytes)
   - record: netapp_volume_provision_case_two
-    expr: (netapp_volume_percentage_snapshot_reserve{share_id!="", volume=~"share.*"} / 50 == 1) * (1 + netapp_volume_is_space_enforcement_logical == 1)
+    expr: (netapp_volume_percentage_snapshot_reserve{share_id!="", volume=~"share.*"} / 50 == 1) * ((1 + netapp_volume_is_space_enforcement_logical) == 1)
 
   - record: manila_share_size_bytes_for_castellum
     expr: netapp_volume_provision_case_two * netapp_volume_total_bytes

--- a/prometheus-exporters/netapp-exporter/values.yaml
+++ b/prometheus-exporters/netapp-exporter/values.yaml
@@ -14,7 +14,7 @@ netapp-cap-exporter:
 
 netapp-perf-exporter:
   enabled: false
-    
+
 netapp-harvest-exporter:
   enabled: false
   fullnameOverride: netapp-harvest-exporter


### PR DESCRIPTION
We move the queries from Castellum to here. Also monitor the snapshot usage to avoid snapshot spill to active share.