### PR TITLE
[prometheus-vmware-rules] Update VCClusterDRSNotFullyAutomated alert

### DIFF
--- a/prometheus-rules/prometheus-vmware-rules/alerts/vccluster.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/vccluster.alerts
@@ -67,7 +67,7 @@ groups:
   - alert: VCClusterDRSNotFullyAutomated
     expr: |
       vrops_cluster_configuration_drsconfig_defaultvmbehavior{vccluster!~".*controlplane.*", state != "fullyAutomated"} == 0
-      unless on (vccluster) vrops_cluster_custom_attributes_hana_exclusive_info
+      unless on (vccluster) vrops_cluster_summary_custom_tag_openstack_nova_traits_hana_exclusive_host
     for: 10m
     labels:
       severity: warning


### PR DESCRIPTION
- Modify the VCClusterDRSNotFullyAutomated expression to accommodate the HANA-exclusive custom attribute, which is now populated from the OpenStack Nova side instead of manual efforts as before
- The old manually added custom attribute will be removed from all VCs