### PR TITLE
[cc3test] reduce the scope of the test jobs to subdirs

### DIFF
--- a/openstack/cc3test/templates/cronjob-automation-purger.yaml
+++ b/openstack/cc3test/templates/cronjob-automation-purger.yaml
@@ -25,7 +25,7 @@ spec:
           - name: purge
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'arc and purge' -r ap tests; exit 0"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'arc and purge' -r ap tests/ccloud; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-automation.yaml
+++ b/openstack/cc3test/templates/cronjob-automation.yaml
@@ -24,7 +24,7 @@ spec:
           - name: base
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'lyra and canary' -r ap tests; exit 0"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'lyra and canary' -r ap tests/ccloud; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-baremetal-purger.yaml
+++ b/openstack/cc3test/templates/cronjob-baremetal-purger.yaml
@@ -25,7 +25,7 @@ spec:
           - name: purge
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'baremetal and purge' -r ap tests; exit 0"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'baremetal and purge' -r ap tests/baremetal; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-baremetal.yaml
+++ b/openstack/cc3test/templates/cronjob-baremetal.yaml
@@ -24,7 +24,7 @@ spec:
           - name: regular
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'baremetal and regression' -r ap tests; exit 0"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'baremetal and regression' -r ap tests/baremetal; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-blockstorage-purger.yaml
+++ b/openstack/cc3test/templates/cronjob-blockstorage-purger.yaml
@@ -25,7 +25,7 @@ spec:
           - name: purge
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'block_storage and purge' -r ap tests; exit 0"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'block_storage and purge' -r ap tests/block_storage; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-blockstorage-volume.yaml
+++ b/openstack/cc3test/templates/cronjob-blockstorage-volume.yaml
@@ -24,7 +24,7 @@ spec:
           - name: regular
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'block_storage and canary and allhosts' -r ap tests; exit 0"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'block_storage and canary and allhosts' -r ap tests/block_storage; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-blockstorage.yaml
+++ b/openstack/cc3test/templates/cronjob-blockstorage.yaml
@@ -24,7 +24,7 @@ spec:
           - name: base
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'block_storage and canary and base' -r ap tests; exit 0"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'block_storage and canary and base' -r ap tests/block_storage; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-certificate.yaml
+++ b/openstack/cc3test/templates/cronjob-certificate.yaml
@@ -24,7 +24,7 @@ spec:
           - name: certificate
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m certificate -r ap tests; exit 0"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m certificate -r ap tests/ccloud tests/file_sharesi; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-compute-purger.yaml
+++ b/openstack/cc3test/templates/cronjob-compute-purger.yaml
@@ -25,7 +25,7 @@ spec:
           - name: purge
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'compute and purge' -r ap tests; exit 0"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'compute and purge' -r ap tests/compute; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-compute-server.yaml
+++ b/openstack/cc3test/templates/cronjob-compute-server.yaml
@@ -24,7 +24,7 @@ spec:
           - name: regular
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'compute and allhosts' -r ap tests; exit 0"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'compute and allhosts' -r ap tests/compute; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-compute.yaml
+++ b/openstack/cc3test/templates/cronjob-compute.yaml
@@ -24,7 +24,7 @@ spec:
           - name: base
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'compute and base' -r ap tests; exit 0"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'compute and base' -r ap tests/compute; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-datastore.yaml
+++ b/openstack/cc3test/templates/cronjob-datastore.yaml
@@ -21,10 +21,10 @@ spec:
               secret:
                 secretName: cc3test-secrets
           containers:
-          - name: cc3test-datastore-host-missing
+          - name: cc3test-datastore-host-mounted
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -r ap -k 'TestDatastore and mounted' tests; exit 0"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -r ap -m mounted tests/block_storage; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config
@@ -32,15 +32,3 @@ spec:
               - name: cc3test-secrets
                 mountPath: /cc3test/secrets
                 readOnly: true
-          - name: cc3test-datastore-host-accessible
-            image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
-            command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -r ap -k 'TestDatastore and accessible' tests; exit 0"]
-            volumeMounts:
-              - name: cc3test-config
-                mountPath: /cc3test/config
-                readOnly: true
-              - name: cc3test-secrets
-                mountPath: /cc3test/secrets
-                readOnly: true
-          restartPolicy: Never

--- a/openstack/cc3test/templates/cronjob-dns-purger.yaml
+++ b/openstack/cc3test/templates/cronjob-dns-purger.yaml
@@ -25,7 +25,7 @@ spec:
           - name: purge
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'dns and purge' -r ap tests; exit 0"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'dns and purge' -r ap tests/dns; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-dns.yaml
+++ b/openstack/cc3test/templates/cronjob-dns.yaml
@@ -24,7 +24,7 @@ spec:
           - name: base
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'dns and base' -r ap tests; exit 0"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'dns and base' -r ap tests/dns; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-fileshare-purger.yaml
+++ b/openstack/cc3test/templates/cronjob-fileshare-purger.yaml
@@ -25,7 +25,7 @@ spec:
           - name: purge
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'file_shares and purge' -r ap tests; exit 0"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'file_shares and purge' -r ap tests/file_shares; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-fileshare.yaml
+++ b/openstack/cc3test/templates/cronjob-fileshare.yaml
@@ -24,7 +24,7 @@ spec:
           - name: base
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'file_shares and base' -r ap tests; exit 0"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'file_shares and base' -r ap tests/file_shares; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-hermes.yaml
+++ b/openstack/cc3test/templates/cronjob-hermes.yaml
@@ -24,7 +24,7 @@ spec:
           - name: base
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'hermes and base' -r ap tests; exit 0"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'hermes and base' -r ap tests/ccloud; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-integrity.yaml
+++ b/openstack/cc3test/templates/cronjob-integrity.yaml
@@ -24,7 +24,7 @@ spec:
           - name: cc3test-integrity
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -r ap -m integrity tests; exit 0"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -r ap -m integrity tests/compute tests/network; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-key-manager-purger.yaml
+++ b/openstack/cc3test/templates/cronjob-key-manager-purger.yaml
@@ -25,7 +25,7 @@ spec:
           - name: purge
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'key_manager and purge' -r ap tests; exit 0"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'key_manager and purge' -r ap tests/key_manager; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-key-manager.yaml
+++ b/openstack/cc3test/templates/cronjob-key-manager.yaml
@@ -24,7 +24,7 @@ spec:
           - name: base
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'key_manager and base' -r ap tests; exit 0"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'key_manager and base' -r ap tests/key_manager; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-loadbalancer-purger.yaml
+++ b/openstack/cc3test/templates/cronjob-loadbalancer-purger.yaml
@@ -25,7 +25,7 @@ spec:
           - name: purge
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'load_balancer and purge' -r ap tests; exit 0"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'load_balancer and purge' -r ap tests/load_balancer; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-loadbalancer.yaml
+++ b/openstack/cc3test/templates/cronjob-loadbalancer.yaml
@@ -24,7 +24,7 @@ spec:
           - name: base
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'load_balancer and base' -r ap tests; exit 0"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'load_balancer and base' -r ap tests/load_balancer; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-neutron-purger.yaml
+++ b/openstack/cc3test/templates/cronjob-neutron-purger.yaml
@@ -25,7 +25,7 @@ spec:
           - name: purge
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'network and purge' -r ap tests; exit 0"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'network and purge' -r ap tests/network; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config

--- a/openstack/cc3test/templates/cronjob-neutron.yaml
+++ b/openstack/cc3test/templates/cronjob-neutron.yaml
@@ -24,7 +24,7 @@ spec:
           - name: base
             image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ required ".Values.cc3test.image.name variable missing" .Values.cc3test.image.name }}:{{ required ".Values.cc3test.image.tag variable missing" .Values.cc3test.image.tag }}
             command: ["/bin/sh"]
-            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'network and base' -r ap tests; exit 0"]
+            args: ["-c", "pytest --disable-pytest-warnings --no-header --color=yes --variables config/config.yaml --variables secrets/secrets.yaml -m 'network and base' -r ap tests/network; exit 0"]
             volumeMounts:
               - name: cc3test-config
                 mountPath: /cc3test/config


### PR DESCRIPTION
before we were always running all the different tests with the scope set to the complete tests directory which resulted in a lot of unneeded code execution (fixtures and parametrizations for all tests, even the ones not run by a certain job) and with this change we reduce the scope for each job to only the subdirectory (or subdirectories) the corresponding tests are defined in ... this is possible now as we have properly separated all the code