### PR TITLE
[prometheus-vmware-rules] Revise VCClusterDRSNotFullyAutomated alert

### DIFF
--- a/prometheus-rules/prometheus-vmware-rules/alerts/vccluster.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/vccluster.alerts
@@ -67,7 +67,7 @@ groups:
   - alert: VCClusterDRSNotFullyAutomated
     expr: |
       vrops_cluster_configuration_drsconfig_defaultvmbehavior{vccluster!~".*controlplane.*", state != "fullyAutomated"} == 0
-      unless on (vccluster) vrops_cluster_summary_custom_tag_openstack_nova_traits_hana_exclusive_host
+      unless on (vccluster) vrops_cluster_summary_custom_tag_openstack_nova_traits_hana_exclusive_host{summary_custom_tag_openstack_nova_traits_hana_exclusive_host="true"}
     for: 10m
     labels:
       severity: warning


### PR DESCRIPTION
- Adjust the VCClusterDRSNotFullyAutomated expression to explicitly check if the HANA-exclusive time series vector is set to _**true**_

