### PR TITLE
[ironic] Tune certrobot values

### DIFF
--- a/openstack/ironic/values.yaml
+++ b/openstack/ironic/values.yaml
@@ -36,6 +36,9 @@ cert_robot:
   schedule: "@weekly"
   env:
     issuer:
+    designate:
+      polling_interval: 5
+      propagation_timeout: 1200
     dns_resolvers:
     acme_server:
     csr:


### PR DESCRIPTION
Increase the designate-propagation-timeout (from default 10m to 20m) for larger regions
Decrease the polling interval from 10s to 5s for more responsiveness