### PR TITLE
[neutron] Make owner_check_cache_expiration_time configurable

### DIFF
--- a/openstack/neutron/templates/etc/_neutron.conf.tpl
+++ b/openstack/neutron/templates/etc/_neutron.conf.tpl
@@ -48,6 +48,10 @@ wsgi_default_pool_size = {{ .Values.wsgi_default_pool_size | default .Values.glo
 api_workers = {{ .Values.api_workers }}
 periodic_fuzzy_delay = 10
 
+{{- if not (empty .Values.api.owner_check_cache_expiration_time) }}
+owner_check_cache_expiration_time = {{ .Values.api.owner_check_cache_expiration_time }}
+{{- end }}
+
 {{- template "utils.snippets.debug.eventlet_backdoor_ini" "neutron" }}
 
 [nova]

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -192,6 +192,10 @@ api:
   # minimum number of workers to keep at all times
   cheaper: 0
   uwsgi: false
+  # time to cache the OwnerCheck's result in seconds
+  # 0/nil/null results in not setting the config option at all and thus using
+  # the default from Neutron
+  owner_check_cache_expiration_time: null
 
 service_plugins: asr1k_l3_routing
 default_router_type: ASR1k_router


### PR DESCRIPTION
We recently introduced a configuration option for `OwnerCheck`'s cache expiration time in Neutron. This commit exposes the possibility to set said option, defaulting to not setting it in the
`/etc/neutron/neutron.conf` at all and thus using the default from Neutron.