### PR TITLE
[neutron] Expose used router count by AZ using database exporter

### DIFF
--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -549,6 +549,22 @@ mysql_metrics:
         GROUP BY host;
       values:
       - "value"
+    - help: Neutron used routers per project by AZ
+      name: openstack_neutron_routers_used_per_project
+      query: |
+        SELECT
+            r.project_id AS project_id,
+            CASE WHEN a.availability_zone = 'nova' THEN null ELSE a.availability_zone END AS availability_zone,
+            count(r.id) AS count
+        FROM routers r
+        INNER JOIN routerl3agentbindings rabs ON r.id = rabs.router_id
+        INNER JOIN agents a ON a.id = rabs.l3_agent_id
+        GROUP BY r.project_id, a.availability_zone;
+      labels:
+      - project_id
+      - availability_zone
+      values:
+      - count
 
 max_pool_size: 20
 max_overflow: 5


### PR DESCRIPTION
Due to billing by usage, not by quota, we must expose used routers
drilled down by AZ.

The agent table carries the AZ by agent, if the AZ is 'nova' that
indicates a stretched agent, [see here](https://github.com/sapcc/asr1k-neutron-l3/blob/5dbad6b9d10bd99cf39e7da1e16700ed648bf7b1/asr1k_neutron_l3/common/asr1k_constants.py#L36).
If a router is not assigned to an l3 agent, it can also not be in used,
so I assume the `INNER JOIN` here should be fine.
