### PR TITLE
chore(prom-infra): remove image-usage-exporter job from config

### DIFF
--- a/system/prometheus-infra/Chart.yaml
+++ b/system/prometheus-infra/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus-infra
 description: Prometheus Infrastructure Monitoring - A Helm chart for the operated regional Prometheus Frontend for monitoring infrastructure.
-version: 2.1.1
+version: 2.1.2
 dependencies:
   - name: prometheus-server
     alias: prometheus-infra-frontend

--- a/system/prometheus-infra/templates/_prometheus-infra.yaml.tpl
+++ b/system/prometheus-infra/templates/_prometheus-infra.yaml.tpl
@@ -52,7 +52,6 @@
       - '{job="bios/ironic", __name__!~"^(up|ALERTS.*|scrape.+)"}'
       - '{job="bios/cisco_cp", __name__!~"^(up|ALERTS.*|scrape.+)"}'
       - '{job="bios/vpod", __name__!~"^(up|ALERTS.*|scrape.+)"}'
-      - '{job="infra-monitoring/image-usage-exporter", __name__!~"^(up|ALERTS.*|scrape.+)"}'
       - '{job="ipmi/ironic", __name__!~"^(up|ALERTS.*|scrape.+)"}'
       - '{job="vmware-esxi", __name__!~"^(up|ALERTS.*|scrape.+)"}'
       - '{job="atlas", __name__!~"^(up|ALERTS.*|scrape.+)"}'


### PR DESCRIPTION
the exporter has been deleted and this clears it from the federate config