### PR TITLE
[vcf] increase mem requests/limits

### DIFF
--- a/openstack/vcf/templates/deployment.yaml
+++ b/openstack/vcf/templates/deployment.yaml
@@ -42,9 +42,4 @@ spec:
             - mountPath: /pulumi/etc/configs
               name: vcf-configs
           resources:
-            requests:
-              cpu: "500m"
-              memory: "500Mi"
-            limits:
-              cpu: "1500m"
-              memory: "500Mi"
+            {{- toYaml .Values.sidecar.resources | nindent 12 }}

--- a/openstack/vcf/values.yaml
+++ b/openstack/vcf/values.yaml
@@ -8,3 +8,11 @@ owner-info:
 
 vcf:
   servicePort: 8000
+
+resources:
+  requests:
+    cpu: "500m"
+    memory: "1Gi"
+  limits:
+    cpu: "1500m"
+    memory: "2Gi"


### PR DESCRIPTION
Internal subprocesses are oom killed because of mem limit.