### PR TITLE
use kubernetes_pod_AZ_spread utils function to schedule API pods

### DIFF
--- a/openstack/keystone/templates/deployment-api.yaml
+++ b/openstack/keystone/templates/deployment-api.yaml
@@ -34,6 +34,7 @@ spec:
         type: api
         alert-tier: os
         alert-service: keystone
+        app: keystone
       annotations:
         chart-version: {{.Chart.Version}}
         configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") . | sha256sum }}
@@ -46,34 +47,7 @@ spec:
 {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ .Release.Name }}
 {{- end }}
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 10
-            podAffinityTerm:
-              topologyKey: kubernetes.io/hostname
-              labelSelector:
-                matchExpressions:
-                - key: name
-                  operator: In
-                  values:
-                  - keystone-api
-                - key: system
-                  operator: In
-                  values:
-                  - openstack
-                - key: component
-                  operator: In
-                  values:
-                  - keystone
-                - key: type
-                  operator: In
-                  values:
-                  - api
-      {{- with .Values.nodeAffinity }}
-        nodeAffinity:
-{{ toYaml . | indent 10 }}
-      {{- end }}
+{{ tuple . "keystone" "keystone" | include "kubernetes_pod_AZ_spread" | indent 6 }}
       terminationGracePeriodSeconds: {{ .Values.api.terminationGracePeriodSeconds | default "30" }}
 {{ include "utils.proxysql.pod_settings" . | indent 6 }}
       initContainers:


### PR DESCRIPTION
use kubernetes_pod_AZ_spread utils function to schedule API pods, that should make sure pods are spread across all available AZs