### PR TITLE
[ironic] Quote env values to ensure strings

### DIFF
--- a/openstack/ironic/templates/redfish-certrobot-cronjob.yaml
+++ b/openstack/ironic/templates/redfish-certrobot-cronjob.yaml
@@ -8,11 +8,11 @@
             {{- if kindIs "map" $v }}
                 {{- tuple $v $path | include "_values_to_env" }}
             {{- else }}
-- name: {{ $path | join "_" | upper }}
+- name: {{ $path | join "_" | upper | quote }}
 {{- if kindIs "slice" $v }}
-  value: {{ $v | join "," }}
+  value: {{ $v | join "," | quote }}
 {{- else }}
-  value: {{ $v }}
+  value: {{ $v | quote }}
 {{- end }}
             {{- end }}
         {{- end }}


### PR DESCRIPTION
Kubernetes is strict in what values it accepts,
and for env keys and values it only accepts strings. Numbers need to be quoted so they have the right type