### PR TITLE
change support group for OpenstackSwiftDiskFailures

### DIFF
--- a/openstack/swift/alerts/openstack/api.alerts
+++ b/openstack/swift/alerts/openstack/api.alerts
@@ -198,7 +198,7 @@ groups:
       dashboard: swift-overview
       service: swift
       severity: warning
-      support_group: compute # according to Tilo Geissler, this also covers controlplane hardware
+      support_group: storage
       tier: metal
       meta: '{{ $value }} Swift drive failures'
       playbook: 'docs/support/playbook/swift/disk_failures'


### PR DESCRIPTION
put this warning to the group fixing stuff.
if compute needs the alert greenhouse/ alert overview or a separate routing can be enabled.
pls contact me