### PR TITLE
nova/flavors: Fix Unlist m5.96xlarge & x1.32xlarge

### DIFF
--- a/openstack/sap-seeds/templates/_flavors_deleted.tpl
+++ b/openstack/sap-seeds/templates/_flavors_deleted.tpl
@@ -24,6 +24,25 @@
 #   ON j1.instance_uuid = i2.uuid
 #   WHERE flavor in ('$FLAVOR');
 
+- name: "m5.96xlarge"
+  id: "270"
+  vcpus: 90
+  ram: 1468416
+  disk: 64
+  is_public: false
+  extra_specs:
+{{- if .Values.use_hana_exclusive }}
+    {{- tuple . "vmware_hana_exclusive" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
+{{- else }}
+    {{- tuple . "vmware_common" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
+    "host_fraction": "1/4,3/4,1/2,1"
+    "resources:CUSTOM_BIGVM": "2"
+    "resources:CUSTOM_MEMORY_RESERVABLE_MB": "1468416"
+{{- end }}
+    "trait:CUSTOM_NUMASIZE_C48_M729": "required"
+    "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
+    "vmware:hw_version": "vmx-18"
+
 - name: "m5.192xlarge"
   id: "271"
   vcpus: 106
@@ -33,9 +52,30 @@
   extra_specs:
 {{- if .Values.use_hana_exclusive }}
     {{- tuple . "vmware_hana_exclusive" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
-    "trait:CUSTOM_NUMASIZE_C48_M729": "required"
 {{- else }}
     {{- tuple . "vmware_common" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "resources:CUSTOM_BIGVM": "2"
     "host_fraction": "1,1/2"
 {{- end }}
+    "trait:CUSTOM_NUMASIZE_C48_M729": "required"
+    "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
+    "vmware:hw_version": "vmx-18"
+
+- name: "x1.32xlarge"
+  id: "250"
+  vcpus: 128
+  ram: 1991680
+  disk: 64
+  is_public: false
+  extra_specs:
+{{- if .Values.use_hana_exclusive }}
+    {{- tuple . "vmware_hana_exclusive" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
+{{- else }}
+    {{- tuple . "vmware_common" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
+    "host_fraction": "1,0.67,0.34"
+    "resources:CUSTOM_BIGVM": "2"
+    "resources:CUSTOM_MEMORY_RESERVABLE_MB": "1991680"
+{{- end }}
+    "trait:CUSTOM_NUMASIZE_C48_M729": "required"
+    "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
+    "vmware:hw_version": "vmx-18"

--- a/openstack/sap-seeds/templates/_flavors_hana_exclusive.tpl
+++ b/openstack/sap-seeds/templates/_flavors_hana_exclusive.tpl
@@ -75,31 +75,3 @@
     "trait:CUSTOM_NUMASIZE_C56_M1459": "required"
     "hw:cpu_cores": "56"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
     "vmware:hw_version": "vmx-18"
-
-{{- if .Values.hana_exclusive_contains_legacy_bigvm_flavors }}
-### Deprecated BigVM flavors
-- name: "m5.96xlarge"
-  id: "270"
-  vcpus: 90
-  ram: 1468416
-  disk: 64
-  is_public: false
-  extra_specs:
-    {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
-    "trait:CUSTOM_NUMASIZE_C48_M729": "required"
-    "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
-    "vmware:hw_version": "vmx-18"
-    "host_fraction": "1/4,3/4,1/2,1"
-- name: "x1.32xlarge"
-  id: "250"
-  vcpus: 128
-  ram: 1991680
-  disk: 64
-  is_public: false
-  extra_specs:
-    {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
-    "trait:CUSTOM_NUMASIZE_C48_M729": "required"
-    "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
-    "vmware:hw_version": "vmx-18"
-    "host_fraction": "1,0.67,0.34"
-{{- end }}

--- a/openstack/sap-seeds/templates/_flavors_hana_no_exclusive.tpl
+++ b/openstack/sap-seeds/templates/_flavors_hana_no_exclusive.tpl
@@ -77,25 +77,3 @@
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
     "vmware:hw_version": "vmx-18"
-
-### Deprecated BigVM flavors
-- name: "m5.96xlarge"
-  id: "270"
-  vcpus: 90
-  ram: 1468416
-  disk: 64
-  is_public: true
-  extra_specs:
-    {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
-    "host_fraction": "1/4,3/4,1/2,1"
-    "resources:CUSTOM_BIGVM": "2"
-- name: "x1.32xlarge"
-  id: "250"
-  vcpus: 128
-  ram: 1991680
-  disk: 64
-  is_public: true
-  extra_specs:
-    {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
-    "host_fraction": "1,0.67,0.34"
-    "resources:CUSTOM_BIGVM": "2"

--- a/openstack/sap-seeds/values.yaml
+++ b/openstack/sap-seeds/values.yaml
@@ -2,11 +2,6 @@
 # hana_no_exclusive list
 use_hana_exclusive: false
 
-# whether to include the legacy bigvm flavors when deploying the hana_exclusive
-# list - they are always included in the hana_no_exclusive list but are needed
-# in some regions where we don't have a hana-only BB for an AZ
-hana_exclusive_contains_legacy_bigvm_flavors: false
-
 owner-info:
   support-group: compute-storage-api
   maintainers:


### PR DESCRIPTION
- Use correct vmware extra-specs template
- Move the flavors to _flavors_deleted.tpl

Also, remove the usage of hana_exclusive_contains_legacy_bigvm_flavors config value for hana-exclusive regions, because we don't want to delete flavors anymore if old VMs still refer to them.
