### PR TITLE
[neutron] Parametrized mounting of /development volume that is used for debugging

### DIFF
--- a/openstack/neutron/templates/asr_config_agents/_deployment-asr1k.yaml.tpl
+++ b/openstack/neutron/templates/asr_config_agents/_deployment-asr1k.yaml.tpl
@@ -64,8 +64,10 @@ spec:
             - name: METRICS_PORT
               value: "{{$context.Values.port_l3_metrics |  default 9103 }}"
           volumeMounts:
+            {{- if $context.Values.pod.debug.asr_agent }}
             - mountPath: /development
               name: development
+            {{- end }}
             - mountPath: /neutron-etc
               name: neutron-etc
             - mountPath: /neutron-etc-vendor
@@ -107,8 +109,10 @@ spec:
             - name: METRICS_PORT
               value: "{{$context.Values.port_l2_metrics |  default 9102}}"
           volumeMounts:
+            {{ if $context.Values.pod.debug.asr_agent }}
             - mountPath: /development
               name: development
+            {{- end -}}
             - mountPath: /neutron-etc
               name: neutron-etc
             - mountPath: /neutron-etc-vendor
@@ -137,7 +141,9 @@ spec:
         - name:  neutron-etc-asr1k
           configMap:
             name: neutron-etc-asr1k-{{ $config_agent.name }}
+        {{- if $context.Values.pod.debug.asr_agent }}
         - name: development
           persistentVolumeClaim:
             claimName: development-pvclaim
+        {{- end -}}        
 {{- end -}}

--- a/openstack/neutron/templates/deployment-aci-agent.yaml
+++ b/openstack/neutron/templates/deployment-aci-agent.yaml
@@ -53,8 +53,10 @@ spec:
                   name: sentry
                   key: neutron.DSN.python
           volumeMounts:
+            {{- if .Values.pod.debug.aci_agent }}
             - mountPath: /development
               name: development
+            {{- end }}
             - mountPath: /neutron-etc
               name: neutron-etc
             - mountPath: /neutron-etc-vendor
@@ -64,9 +66,11 @@ spec:
             - mountPath: /container.init
               name: container-init
       volumes:
+        {{- if .Values.pod.debug.aci_agent }}
         - name: development
           persistentVolumeClaim:
             claimName: development-pvclaim
+        {{- end }}
         - name: neutron-etc
           configMap:
             name: neutron-etc


### PR DESCRIPTION
At the moment /development volume is mounted in any case. That one is used for development, but is not needed for production. We already do have debug option in values yaml file, so this changes add if statement related to that option (for example if debug.asr_agent = true then mount volume). This change should remove mounting of /development when debug is set to false