### PR TITLE
nova/metrics: Fix empty instances gauge

### DIFF
--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -348,10 +348,10 @@ mysql_metrics:
           instances.project_id,
           COUNT(*) AS gauge,
           instances.vm_state,
-          coalesce(instance_types.name,'N/A') AS flavor_name
+          coalesce(JSON_VALUE(instance_extra.flavor, '$.cur."nova_object.data".name'),'N/A') AS flavor_name
         FROM instances
-        JOIN instance_types ON instances.instance_type_id=instance_types.id
-        GROUP BY instances.vm_state, instances.host, instances.project_id, instance_types.name;
+        LEFT JOIN instance_extra ON instances.uuid=instance_extra.instance_uuid
+        GROUP BY instances.vm_state, instances.host, instances.project_id, flavor_name;
       values:
       - "gauge"
     - help: Total Nova VM Stuck count
@@ -530,11 +530,11 @@ mysql_metrics:
           instances.project_id,
           instances.hostname,
           instances.vm_state,
-          coalesce(instance_types.name,'N/A') AS flavor_name,
+          coalesce(JSON_VALUE(instance_extra.flavor, '$.cur."nova_object.data".name'),'N/A') AS flavor_name,
           COUNT(*) AS gauge
         FROM instances
-        JOIN instance_types ON instances.instance_type_id=instance_types.id where host LIKE 'nova-compute-ironic%'
-        GROUP BY instances.vm_state, instances.project_id, instance_types.name, instances.uuid, instances.hostname, instances.node;
+        LEFT JOIN instance_extra ON instances.uuid=instance_extra.instance_uuid WHERE host LIKE 'nova-compute-ironic%'
+        GROUP BY instances.vm_state, instances.project_id, flavor_name, instances.uuid, instances.hostname, instances.node;
       values:
       - "gauge"
     - help: Stats on compute nodes

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -351,6 +351,7 @@ mysql_metrics:
           coalesce(JSON_VALUE(instance_extra.flavor, '$.cur."nova_object.data".name'),'N/A') AS flavor_name
         FROM instances
         LEFT JOIN instance_extra ON instances.uuid=instance_extra.instance_uuid
+        WHERE instances.deleted = 0
         GROUP BY instances.vm_state, instances.host, instances.project_id, flavor_name;
       values:
       - "gauge"
@@ -533,7 +534,8 @@ mysql_metrics:
           coalesce(JSON_VALUE(instance_extra.flavor, '$.cur."nova_object.data".name'),'N/A') AS flavor_name,
           COUNT(*) AS gauge
         FROM instances
-        LEFT JOIN instance_extra ON instances.uuid=instance_extra.instance_uuid WHERE host LIKE 'nova-compute-ironic%'
+        LEFT JOIN instance_extra ON instances.uuid=instance_extra.instance_uuid
+        WHERE host LIKE 'nova-compute-ironic%' AND instances.deleted = 0
         GROUP BY instances.vm_state, instances.project_id, flavor_name, instances.uuid, instances.hostname, instances.node;
       values:
       - "gauge"


### PR DESCRIPTION
The query used the disused and now mostly-empty `instance_types`
table, which made the metric report no values (or only a very few
ancient instances in some regions).

Use instance_extra instead and parse the flavor name out of the JSON.
The query is a bit more expensive this way (it doubled in time from
the query without any join).
