### PR TITLE
[neutron] Remove all references to /development volume

### DIFF
--- a/openstack/neutron/templates/asr_config_agents/_deployment-asr1k.yaml.tpl
+++ b/openstack/neutron/templates/asr_config_agents/_deployment-asr1k.yaml.tpl
@@ -64,8 +64,6 @@ spec:
             - name: METRICS_PORT
               value: "{{$context.Values.port_l3_metrics |  default 9103 }}"
           volumeMounts:
-            - mountPath: /development
-              name: development
             - mountPath: /neutron-etc
               name: neutron-etc
             - mountPath: /neutron-etc-vendor
@@ -107,8 +105,6 @@ spec:
             - name: METRICS_PORT
               value: "{{$context.Values.port_l2_metrics |  default 9102}}"
           volumeMounts:
-            - mountPath: /development
-              name: development
             - mountPath: /neutron-etc
               name: neutron-etc
             - mountPath: /neutron-etc-vendor
@@ -137,7 +133,4 @@ spec:
         - name:  neutron-etc-asr1k
           configMap:
             name: neutron-etc-asr1k-{{ $config_agent.name }}
-        - name: development
-          persistentVolumeClaim:
-            claimName: development-pvclaim
 {{- end -}}

--- a/openstack/neutron/templates/deployment-aci-agent.yaml
+++ b/openstack/neutron/templates/deployment-aci-agent.yaml
@@ -53,8 +53,6 @@ spec:
                   name: sentry
                   key: neutron.DSN.python
           volumeMounts:
-            - mountPath: /development
-              name: development
             - mountPath: /neutron-etc
               name: neutron-etc
             - mountPath: /neutron-etc-vendor
@@ -64,9 +62,6 @@ spec:
             - mountPath: /container.init
               name: container-init
       volumes:
-        - name: development
-          persistentVolumeClaim:
-            claimName: development-pvclaim
         - name: neutron-etc
           configMap:
             name: neutron-etc

--- a/openstack/neutron/templates/deployment-server.yaml
+++ b/openstack/neutron/templates/deployment-server.yaml
@@ -210,10 +210,6 @@ spec:
               subPath: ratelimit.yaml
               readOnly: true
             {{- end }}
-            {{- if .Values.pod.debug.server }}
-            - mountPath: /development
-              name: development
-            {{- end }}
             {{- if .Values.api.uwsgi }}
             - mountPath: /etc/neutron/uwsgi.ini
               name: neutron-etc-api
@@ -229,10 +225,6 @@ spec:
               name: neutron-etc-region
             - mountPath: /container.init
               name: container-init
-            {{- if .Values.pod.debug.server }}
-            - mountPath: /development
-              name: development
-            {{- end }}
 {{- end }}
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
             {{- include "utils.coordination.volume_mount"  . | indent 12 }}
@@ -276,11 +268,6 @@ spec:
         - name: neutron-etc-region
           configMap:
             name: neutron-etc-region
-{{- if .Values.pod.debug.server }}
-        - name: development
-          persistentVolumeClaim:
-            claimName: development-pvclaim
-{{- end }}
 {{- if .Values.api.uwsgi }}
         - name: neutron-etc-api
           configMap:


### PR DESCRIPTION
Since /development volume is not used at all, and can be impediment for service failover, reference to it is removed.