### PR TITLE
Enable py-tracebacker for Neutron UWSGI

### DIFF
--- a/openstack/neutron/templates/etc/_uwsgi.ini.tpl
+++ b/openstack/neutron/templates/etc/_uwsgi.ini.tpl
@@ -45,6 +45,7 @@ harakiri = 120
 harakiri-verbose = true
 post-buffering = 4096
 backlog-status = true
+py-tracebacker = /var/lib/neutron/uwsgi_pytracebacker.
 
 {{ if gt (.Values.api.cheaper | int64) 0 -}}
 # Automatic scaling of workers


### PR DESCRIPTION
This option will create a unix domain socket for each worker that will print out tracebacks if a worker runs into harakiri. With harakiri-verbose we'll also see the tracebacks in our standard logs, which hopefully will allow us to better debug them.