### PR TITLE
prometheus-server: get PrometheusMultiplePodScrape alerts evaluated

### DIFF
--- a/common/prometheus-server/CHANGELOG.md
+++ b/common/prometheus-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.2.16
+
+* If no `kube_` metrics available within the Prometheus, send `PrometheusMultiplePodScrape` alerts to specified Thanos Rule
+
 ## 7.2.15
 
 * Removal of Prometheus limit warnings, as no limits are defined at all

--- a/common/prometheus-server/Chart.yaml
+++ b/common/prometheus-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus via operator.
 name: prometheus-server
-version: 7.2.15
+version: 7.2.16
 appVersion: v2.43.0
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
 maintainers:

--- a/common/prometheus-server/templates/alerts/_prometheus-thanos-rule.alerts.tpl
+++ b/common/prometheus-server/templates/alerts/_prometheus-thanos-rule.alerts.tpl
@@ -1,0 +1,36 @@
+{{- /*
+Taken from prometheus-rules/prometheus-kubernetes-rules, since it is used in the common chart and every prometheus needs to have it or the chart will fail
+*/}}
+{{- define "alertTierLabelOrDefault" -}}
+"{{`{{ if $labels.label_alert_tier }}`}}{{`{{ $labels.label_alert_tier}}`}}{{`{{ else }}`}}{{ required "default value is missing" . }}{{`{{ end }}`}}"
+{{- end -}}
+{{- /*
+Use the 'label_alert_service', if it exists on the time series, otherwise use the given default.
+Note: The pods define the 'alert-service' label but Prometheus replaces the hyphen with an underscore.
+*/}}
+{{- define "alertServiceLabelOrDefault" -}}
+"{{`{{ if $labels.label_alert_service }}`}}{{`{{ $labels.label_alert_service}}`}}{{`{{ else }}`}}{{ required "default value is missing" . }}{{`{{ end }}`}}"
+{{- end -}}
+{{- define "alertSupportGroupOrDefault" -}}
+"{{`{{ if $labels.ccloud_support_group }}`}}{{`{{ $labels.ccloud_support_group }}`}}{{`{{ else }}`}}{{ required "default value is missing" . }}{{`{{ end }}`}}"
+{{- end -}}
+
+{{- $name := index . 0 -}}
+{{- $root := index . 1 -}}
+groups:
+- name: prometheus.alerts
+  rules:
+  {{- if and $root.Values.alerts.multiplePodScrapes.enabled $root.Values.alerts.thanos.enabled }}
+  - alert: PrometheusMultiplePodScrapes
+    expr: sum by(pod, namespace, label_alert_service, label_alert_tier, ccloud_support_group) (label_replace((up * on(instance) group_left() (sum by(instance) (up{job=~".*{{ include "prometheus.name" . }}.*pod-sd"}) > 1)* on(pod) group_left(label_alert_tier, label_alert_service) (max without(uid) (kube_pod_labels))) , "pod", "$1", "kubernetes_pod_name", "(.*)-[0-9a-f]{8,10}-[a-z0-9]{5}"))
+    for: 30m
+    labels:
+      service: {{ include "alertServiceLabelOrDefault" "metrics" }}
+      support_group: {{ include "alertSupportGroupOrDefault" "observability" }}
+      severity: warning
+      playbook: docs/support/playbook/kubernetes/target_scraped_multiple_times
+      meta: Prometheus is scraping `{{`{{ $labels.pod }}`}}` pods more than once.
+    annotations:
+      description: Prometheus is scraping `{{`{{ $labels.pod }}`}}` pods in namespace `{{`{{ $labels.namespace }}`}}` multiple times. This is likely caused due to incorrectly placed scrape annotations. <https://{{ include "prometheus.externalURL" . }}/graph?g0.expr={{ urlquery `up * on(instance) group_left() (sum by(instance) (up{kubernetes_pod_name=~"PLACEHOLDER.*"}) > 1)` | replace "PLACEHOLDER" "{{ $labels.pod }}"}}|Affected targets>
+      summary: Prometheus scrapes pods multiple times
+  {{- end }}

--- a/common/prometheus-server/templates/alerts/_prometheus.alerts.tpl
+++ b/common/prometheus-server/templates/alerts/_prometheus.alerts.tpl
@@ -234,7 +234,7 @@ groups:
       summary: Prometheus target scraped multiple times.
   {{- end }}
 
-  {{- if $root.Values.alerts.multiplePodScrapes.enabled }}
+  {{- if and $root.Values.alerts.multiplePodScrapes.enabled (not $root.Values.alerts.thanos.enabled) }}
   - alert: PrometheusMultiplePodScrapes
     expr: sum by(pod, namespace, label_alert_service, label_alert_tier, ccloud_support_group) (label_replace((up * on(instance) group_left() (sum by(instance) (up{job=~".*{{ include "prometheus.name" . }}.*pod-sd"}) > 1)* on(pod) group_left(label_alert_tier, label_alert_service) (max without(uid) (kube_pod_labels))) , "pod", "$1", "kubernetes_pod_name", "(.*)-[0-9a-f]{8,10}-[a-z0-9]{5}"))
     for: 30m

--- a/common/prometheus-server/templates/alerts/prometheus-alerts.yaml
+++ b/common/prometheus-server/templates/alerts/prometheus-alerts.yaml
@@ -13,5 +13,19 @@ metadata:
 spec:
 {{ include (print $.Template.BasePath "/alerts/_prometheus.alerts.tpl") (list $name $root) | indent 2 }}
 
+{{- if $root.Values.alerts.thanos.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: {{ include "prometheus.fullName" (list $name $root) }}-prometheus-thanos-rule.alerts
+  labels:
+    thanos-ruler: {{ required "$.Values.alerts.thanos.name " $.Values.alerts.thanos.name }}
+
+spec:
+{{ include (print $.Template.BasePath "/alerts/_prometheus-thanos-rule.alerts.tpl") (list $name $root) | indent 2 }}
+
+{{- end }}
 {{- end }}
 {{- end }}

--- a/common/prometheus-server/values.yaml
+++ b/common/prometheus-server/values.yaml
@@ -415,6 +415,10 @@ nodeSelector: {}
 alerts:
   # prometheus name picking up the prometheus self metrics, defaults to prometheus.name
   prometheus:
+  # thanos name that picks up the alerts from Prometheus - mainly used when kube_ metrics needs to be present
+  thanos:
+    enabled: false
+    # name:
   # service name routing the alerts, defaults to `metrics`
   service:
   # support_group routing the alerts, defaults to `observability`
@@ -428,6 +432,7 @@ alerts:
   # This alert requires kube state metrics. Disable if not present
   multiplePodScrapes:
     enabled: true
+
 
 # If true, a custom Prometheus naming will take place. Only needed for vmware-monitoring.
 vmware: false

--- a/common/prometheus-server/values.yaml
+++ b/common/prometheus-server/values.yaml
@@ -433,7 +433,6 @@ alerts:
   multiplePodScrapes:
     enabled: true
 
-
 # If true, a custom Prometheus naming will take place. Only needed for vmware-monitoring.
 vmware: false
 


### PR DESCRIPTION
This is due to the removal of `kube-state-metrics` from the non-Kubernetes prometheus.