### PR TITLE
infra-monitoring: kube-state-metrics removed

### DIFF
--- a/system/infra-monitoring/Chart.lock
+++ b/system/infra-monitoring/Chart.lock
@@ -5,9 +5,6 @@ dependencies:
 - name: thanos
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.4.10
-- name: kube-state-metrics-exporter
-  repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.9
 - name: thousandeyes-exporter
   repository: file://vendor/thousandeyes-exporter
   version: 0.1.2
@@ -41,5 +38,5 @@ dependencies:
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:abb158295accdcb1fc1e6821931f351e0ecee64a54803ce9971e0e39f132386a
-generated: "2023-09-27T12:35:32.141493+02:00"
+digest: sha256:dbcf54e427a42797a6434ae101f3dbc1415323eccf00d999f34c4fb91d3a46c5
+generated: "2023-10-11T15:31:00.469093+02:00"

--- a/system/infra-monitoring/Chart.yaml
+++ b/system/infra-monitoring/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: infra-monitoring
-version: 1.7.10
+version: 1.8.0
 description: Prometheus Infrastructure Monitoring and Metrics Collection
 dependencies:
   - name: prometheus-server
@@ -12,12 +12,6 @@ dependencies:
   - name: thanos
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.4.10
-
-  - name: kube-state-metrics-exporter
-    alias: kube_state_metrics_exporter
-    repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.9
-    condition: kube_state_metrics_exporter.enabled
 
   - name: thousandeyes-exporter
     alias: thousandeyes_exporter

--- a/system/infra-monitoring/values.yaml
+++ b/system/infra-monitoring/values.yaml
@@ -119,10 +119,6 @@ thanos:
   deployWholeThanos: true
   clusterDomain: kubernetes
 
-kube_state_metrics_exporter:
-  enabled: true
-  prometheusName: infra-collector
-
 alertmanager_exporter:
   enabled: false
   scrapeInterval: 1m


### PR DESCRIPTION
With Thanos, it is no longer necessary to have `kube-state metrics` available in multiple Prometheus. Kubernetes Prometheus keeps these metrics available so that they only need to be maintained in one place. Dependent services have been adjusted accordingly so that no absent metric alerts are generated.