### PR TITLE
[Thanos] request ephemeral storage by default

### DIFF
--- a/common/thanos/Chart.yaml
+++ b/common/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: Deploy Thanos via operator
 type: application
-version: 0.5.0
+version: 0.5.1
 appVersion: v0.28.1
 maintainers:
   - name: Tommy Sauer (viennaa)

--- a/common/thanos/ci/test-values.yaml
+++ b/common/thanos/ci/test-values.yaml
@@ -21,3 +21,7 @@ GRPCClientCA: itrustyou
 GRPCClientCertificate:
   certificate: ihavebeentrusted
   privateKey: seriously
+compactor:
+  resources:
+    requests:
+      ephemeral-storage: "100Gi"

--- a/common/thanos/templates/thanos-objectstore.yaml
+++ b/common/thanos/templates/thanos-objectstore.yaml
@@ -44,6 +44,11 @@ spec:
                 - {{ $arg }}
                 {{- end }}
               {{- end }}
+              {{- if not $.Values.compactor.dataVolume.enabled }}
+              resources:
+                requests:
+                  ephemeral-storage: {{ default "25Gi" $.Values.compactor.resources.requests }}
+              {{- end }}
 {{ end }}
 {{ end }}
 {{ end }}

--- a/common/thanos/values.yaml
+++ b/common/thanos/values.yaml
@@ -124,10 +124,17 @@ compactor:
 
   # In case the root fs of the node is not providing sufficient space this will add a data volume (pvc) and mounting it to /data in the compactor.
   # Pay attention to use the correct storageClass.
+  # If this isn't set, it will request a 25Gi ephemeral storage by default, unless specified different
   dataVolume:
     enabled: false
     size: 100Gi
     storageClassName: cinder-default
+
+  # If dataVolume is not set and node can provide more than 25Gi ephemeral storage you can overwrite it to use more
+  # resources:
+    # requests:
+      # ephemeral-storage: "25Gi"
+
 
 store:
   # Maximum size of items held in the index cache.


### PR DESCRIPTION
Compaction is done on ephemeral storage and it tends to use gigabytes. If it is more than 25Gi a pvc needs to be added. In case of bigger node an overwrite exists.