### PR TITLE
replaced metric to match

### DIFF
--- a/common/thanos/Chart.yaml
+++ b/common/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: Deploy Thanos via operator
 type: application
-version: 0.5.1
+version: 0.5.2
 appVersion: v0.28.1
 maintainers:
   - name: Tommy Sauer (viennaa)

--- a/common/thanos/templates/alerts/_thanos-store.alerts.tpl
+++ b/common/thanos/templates/alerts/_thanos-store.alerts.tpl
@@ -26,9 +26,9 @@ groups:
     - alert: ThanosStoreSeriesGateLatencyHigh
       expr: |
         (
-          histogram_quantile(0.99, sum by (thanos, le) (rate(thanos_bucket_store_series_gate_queries_duration_seconds_bucket{job=~".*thanos.*store.*", thanos="{{ include "thanos.name" . }}"}[5m]))) > 2
+          histogram_quantile(0.99, sum by (thanos, le) (rate(thanos_bucket_store_series_gate_duration_seconds_bucket{job=~".*thanos.*store.*", thanos="{{ include "thanos.name" . }}"}[5m]))) > 2
         and
-          sum by (thanos) (rate(thanos_bucket_store_series_gate_duration_seconds_count{job=~".*thanos.*store.*", thanos="{{ include "thanos.name" . }}"}[5m])) > 0
+          sum by (thanos) (rate(thanos_bucket_store_series_gate_duration_seconds_bucket{job=~".*thanos.*store.*", thanos="{{ include "thanos.name" . }}"}[5m])) > 0
         )
       for: 10m
       labels:


### PR DESCRIPTION
  lots of missing alerts due to a non existent metric name
  replaced with latest mixin:
  https://monitoring.mixins.dev/thanos/#thanosstoreseriesgatelatencyhigh
