### PR TITLE
prometheus-infra.scaleout: kube-state-metrics removed

### DIFF
--- a/system/prometheus-infra/Chart.lock
+++ b/system/prometheus-infra/Chart.lock
@@ -2,14 +2,11 @@ dependencies:
 - name: prometheus-server
   repository: https://charts.eu-de-2.cloud.sap
   version: 7.2.16
-- name: kube-state-metrics-exporter
-  repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.7
 - name: interconnect-sre
   repository: file://vendor/interconnect-sre
   version: 0.1.0
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:b396d551dc68aa3a9998a3f241e2229fe7d2246ba96acdd32e9daf7a9e438b02
-generated: "2023-10-18T14:13:39.355937+02:00"
+digest: sha256:88ab33f5c3b9bf68689d44034da5473c47c1e40148f640431a15e64c07b69a51
+generated: "2023-10-20T14:15:25.68195+02:00"

--- a/system/prometheus-infra/Chart.yaml
+++ b/system/prometheus-infra/Chart.yaml
@@ -1,19 +1,13 @@
 apiVersion: v2
 name: prometheus-infra
 description: Prometheus Infrastructure Monitoring - A Helm chart for the operated regional Prometheus Frontend for monitoring infrastructure.
-version: 3.0.0
+version: 3.0.1
 dependencies:
   - name: prometheus-server
     alias: prometheus-infra-frontend
     repository: https://charts.eu-de-2.cloud.sap
     version: 7.2.16
     condition: prometheus-infra-frontend.enabled
-
-  - name: kube-state-metrics-exporter
-    alias: kube_state_metrics_exporter
-    repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.7
-    condition: kube_state_metrics_exporter.enabled
 
   - name: interconnect-sre
     alias: interconnect_sre

--- a/system/prometheus-infra/values.yaml
+++ b/system/prometheus-infra/values.yaml
@@ -66,11 +66,6 @@ prometheus-infra-frontend:
   thanos:
     enabled: false
 
-# Import metrics from kubernetes Prometheus
-kube_state_metrics_exporter:
-  enabled: true
-  prometheusName: infra-frontend
-
 # Collector Prometheus are only accessible after presenting a valid SSO certificate.
 authentication:
   enabled: true


### PR DESCRIPTION
With Thanos, it is no longer necessary to have `kube-state-metrics` available in multiple Prometheus. Kubernetes Prometheus keeps kube_ metrics available so that they only need to be maintained in one place. Dependent services have been adjusted accordingly so that no absent metric alerts are generated.