### PR TITLE
[common/postgresql] Sort shared_preload_libraries list before rendering

### DIFF
--- a/common/postgresql/templates/etc/_postgresql.conf.tpl
+++ b/common/postgresql/templates/etc/_postgresql.conf.tpl
@@ -145,7 +145,7 @@ dynamic_shared_memory_type = posix	# the default is the first option
 #max_files_per_process = 1000		# min 25
                     # (change requires restart)
 
-shared_preload_libraries = '{{ keys .Values.extensions | join ","}}'		# (change requires restart)
+shared_preload_libraries = '{{ keys .Values.extensions | sortAlpha | join ","}}'		# (change requires restart)
 
 {{- range $k, $v := .Values.extensions }}
 {{- range $k2, $v2 := $v }}


### PR DESCRIPTION
This will sort the stringList shared_preload_libraries before renderning.
If a parent chart is using more than one extension, the rendering
of the extensions will be completely random and generates useless diffs.

e.g.
```
-     = 'pg_stat_statements,pgcrypto'\t\t# (change requires restart)\npg_stat_statements.max
+     = 'pgcrypto,pg_stat_statements'\t\t# (change requires restart)\npg_stat_statements.max
```
