### PR TITLE
prepare to switch the ingress-nginx annotation prefix

### DIFF
--- a/common/linkerd-support/README.md
+++ b/common/linkerd-support/README.md
@@ -86,6 +86,7 @@ metadata:
   annotations:
     {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
     ingress.kubernetes.io/service-upstream: "true"
+    nginx.ingress.kubernetes.io/service-upstream: "true"
     {{- end }}
 ```
 

--- a/common/mariadb/templates/backup-ingress.yaml
+++ b/common/mariadb/templates/backup-ingress.yaml
@@ -7,8 +7,11 @@ metadata:
   annotations:
 {{- if .Values.backup_v2.oauth.sap_id }}
     ingress.kubernetes.io/auth-url: https://auth-internal.{{ .Values.global.region }}.cloud.sap/oauth2/auth
+    nginx.ingress.kubernetes.io/auth-url: https://auth-internal.{{ .Values.global.region }}.cloud.sap/oauth2/auth
     ingress.kubernetes.io/auth-signin: https://auth-internal.{{ .Values.global.region }}.cloud.sap/oauth2/start
+    nginx.ingress.kubernetes.io/auth-signin: https://auth-internal.{{ .Values.global.region }}.cloud.sap/oauth2/start
     ingress.kubernetes.io/auth-response-headers: "Authorization, X-Auth-Request-Email, X-Auth-Request-User, X-Forwarded-Access-Token"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization, X-Auth-Request-Email, X-Auth-Request-User, X-Forwarded-Access-Token"
 {{- end }}
     kubernetes.io/tls-acme: "true"
   name:  {{ include "fullName" . }}-backup

--- a/common/prometheus-alertmanager-base/templates/ingress-internal.yaml
+++ b/common/prometheus-alertmanager-base/templates/ingress-internal.yaml
@@ -18,12 +18,16 @@ metadata:
     disco: "true"
     {{- if .Values.internalIngress.authentication.oauth.enabled }}
     ingress.kubernetes.io/auth-url: {{ required ".Values.internalIngress.authentication.oauth.authURL missing" .Values.internalIngress.authentication.oauth.authURL }}
+    nginx.ingress.kubernetes.io/auth-url: {{ required ".Values.internalIngress.authentication.oauth.authURL missing" .Values.internalIngress.authentication.oauth.authURL }}
     {{ if .Values.internalIngress.authentication.oauth.authSignInURL }}ingress.kubernetes.io/auth-signin: {{ .Values.internalIngress.authentication.oauth.authSignInURL }} {{ end }}
     {{ end }}
     {{- if .Values.internalIngress.authentication.sso.enabled}}
     ingress.kubernetes.io/auth-tls-secret: {{ required ".Values.internalIngress.authentication.sso.authTLSSecret missing" .Values.internalIngress.authentication.sso.authTLSSecret | quote }}
+    nginx.ingress.kubernetes.io/auth-tls-secret: {{ required ".Values.internalIngress.authentication.sso.authTLSSecret missing" .Values.internalIngress.authentication.sso.authTLSSecret | quote }}
     ingress.kubernetes.io/auth-tls-verify-depth: {{ required ".Values.internalIngress.authentication.sso.authTLSVerifyDepth missing" .Values.internalIngress.authentication.sso.authTLSVerifyDepth | quote }}
+    nginx.ingress.kubernetes.io/auth-tls-verify-depth: {{ required ".Values.internalIngress.authentication.sso.authTLSVerifyDepth missing" .Values.internalIngress.authentication.sso.authTLSVerifyDepth | quote }}
     ingress.kubernetes.io/auth-tls-verify-client: {{ required ".Values.internalIngress.authentication.sso.authTLSVerifyClient missing" .Values.internalIngress.authentication.sso.authTLSVerifyClient | quote }}
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: {{ required ".Values.internalIngress.authentication.sso.authTLSVerifyClient missing" .Values.internalIngress.authentication.sso.authTLSVerifyClient | quote }}
     {{ end }}
     {{- if .Values.internalIngress.annotations }}
 {{ toYaml .Values.internalIngress.annotations | indent 4 }}

--- a/common/prometheus-alertmanager-base/templates/ingress.yaml
+++ b/common/prometheus-alertmanager-base/templates/ingress.yaml
@@ -18,12 +18,16 @@ metadata:
     disco: "true"
     {{- if .Values.ingress.authentication.oauth.enabled }}
     ingress.kubernetes.io/auth-url: {{ required ".Values.ingress.authentication.oauth.authURL missing" .Values.ingress.authentication.oauth.authURL }}
+    nginx.ingress.kubernetes.io/auth-url: {{ required ".Values.ingress.authentication.oauth.authURL missing" .Values.ingress.authentication.oauth.authURL }}
     {{ if .Values.ingress.authentication.oauth.authSignInURL }}ingress.kubernetes.io/auth-signin: {{ .Values.ingress.authentication.oauth.authSignInURL }} {{ end }}
     {{ end }}
     {{- if .Values.ingress.authentication.sso.enabled}}
     ingress.kubernetes.io/auth-tls-secret: {{ required ".Values.ingress.authentication.sso.authTLSSecret missing" .Values.ingress.authentication.sso.authTLSSecret | quote }}
+    nginx.ingress.kubernetes.io/auth-tls-secret: {{ required ".Values.ingress.authentication.sso.authTLSSecret missing" .Values.ingress.authentication.sso.authTLSSecret | quote }}
     ingress.kubernetes.io/auth-tls-verify-depth: {{ required ".Values.ingress.authentication.sso.authTLSVerifyDepth missing" .Values.ingress.authentication.sso.authTLSVerifyDepth | quote }}
+    nginx.ingress.kubernetes.io/auth-tls-verify-depth: {{ required ".Values.ingress.authentication.sso.authTLSVerifyDepth missing" .Values.ingress.authentication.sso.authTLSVerifyDepth | quote }}
     ingress.kubernetes.io/auth-tls-verify-client: {{ required ".Values.ingress.authentication.sso.authTLSVerifyClient missing" .Values.ingress.authentication.sso.authTLSVerifyClient | quote }}
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: {{ required ".Values.ingress.authentication.sso.authTLSVerifyClient missing" .Values.ingress.authentication.sso.authTLSVerifyClient | quote }}
     {{ end }}
     {{- if .Values.ingress.annotations }}
 {{ toYaml .Values.ingress.annotations | indent 4 }}

--- a/common/prometheus-pushgateway/templates/ingress.yaml
+++ b/common/prometheus-pushgateway/templates/ingress.yaml
@@ -12,8 +12,11 @@ metadata:
     disco: {{ required ".Values.ingress.disco missing" .Values.ingress.disco | quote }}
     {{- if .Values.ingress.authentication.enabled}}
     ingress.kubernetes.io/auth-tls-secret: {{ required ".Values.ingress.authentication.authTLSSecret missing" .Values.ingress.authentication.authTLSSecret | quote }}
+    nginx.ingress.kubernetes.io/auth-tls-secret: {{ required ".Values.ingress.authentication.authTLSSecret missing" .Values.ingress.authentication.authTLSSecret | quote }}
     ingress.kubernetes.io/auth-tls-verify-depth: {{ required ".Values.ingress.authentication.authTLSVerifyDepth missing" .Values.ingress.authentication.authTLSVerifyDepth | quote }}
+    nginx.ingress.kubernetes.io/auth-tls-verify-depth: {{ required ".Values.ingress.authentication.authTLSVerifyDepth missing" .Values.ingress.authentication.authTLSVerifyDepth | quote }}
     ingress.kubernetes.io/auth-tls-verify-client: {{ required ".Values.ingress.authentication.authTLSVerifyClient missing" .Values.ingress.authentication.authTLSVerifyClient | quote }}
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: {{ required ".Values.ingress.authentication.authTLSVerifyClient missing" .Values.ingress.authentication.authTLSVerifyClient | quote }}
     {{ end }}
 {{- if .Values.ingress.annotations }}
 {{ toYaml .Values.ingress.annotations | indent 4}}

--- a/common/prometheus-server-pre7/templates/ingress-internal.yaml
+++ b/common/prometheus-server-pre7/templates/ingress-internal.yaml
@@ -16,12 +16,16 @@ metadata:
     disco: "true"
     {{- if .Values.internalIngress.authentication.oauth.enabled }}
     ingress.kubernetes.io/auth-url: {{ required ".Values.internalIngress.authentication.oauth.authURL missing" .Values.internalIngress.authentication.oauth.authURL }}
+    nginx.ingress.kubernetes.io/auth-url: {{ required ".Values.internalIngress.authentication.oauth.authURL missing" .Values.internalIngress.authentication.oauth.authURL }}
     {{ if .Values.internalIngress.authentication.oauth.authSignInURL }}ingress.kubernetes.io/auth-signin: {{ .Values.internalIngress.authentication.oauth.authSignInURL }} {{ end }}
     {{ end }}
     {{- if .Values.internalIngress.authentication.sso.enabled}}
     ingress.kubernetes.io/auth-tls-secret: {{ required ".Values.internalIngress.authentication.sso.authTLSSecret missing" .Values.internalIngress.authentication.sso.authTLSSecret | quote }}
+    nginx.ingress.kubernetes.io/auth-tls-secret: {{ required ".Values.internalIngress.authentication.sso.authTLSSecret missing" .Values.internalIngress.authentication.sso.authTLSSecret | quote }}
     ingress.kubernetes.io/auth-tls-verify-depth: {{ required ".Values.internalIngress.authentication.sso.authTLSVerifyDepth missing" .Values.internalIngress.authentication.sso.authTLSVerifyDepth | quote }}
+    nginx.ingress.kubernetes.io/auth-tls-verify-depth: {{ required ".Values.internalIngress.authentication.sso.authTLSVerifyDepth missing" .Values.internalIngress.authentication.sso.authTLSVerifyDepth | quote }}
     ingress.kubernetes.io/auth-tls-verify-client: {{ required ".Values.internalIngress.authentication.sso.authTLSVerifyClient missing" .Values.internalIngress.authentication.sso.authTLSVerifyClient | quote }}
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: {{ required ".Values.internalIngress.authentication.sso.authTLSVerifyClient missing" .Values.internalIngress.authentication.sso.authTLSVerifyClient | quote }}
     {{ end }}
     {{- if .Values.internalIngress.annotations }}
 {{ toYaml .Values.internalIngress.annotations | indent 4 }}

--- a/common/prometheus-server-pre7/templates/ingress.yaml
+++ b/common/prometheus-server-pre7/templates/ingress.yaml
@@ -16,12 +16,16 @@ metadata:
     disco: "true"
     {{- if .Values.ingress.authentication.oauth.enabled }}
     ingress.kubernetes.io/auth-url: {{ required ".Values.ingress.authentication.oauth.authURL missing" .Values.ingress.authentication.oauth.authURL }}
+    nginx.ingress.kubernetes.io/auth-url: {{ required ".Values.ingress.authentication.oauth.authURL missing" .Values.ingress.authentication.oauth.authURL }}
     {{ if .Values.ingress.authentication.oauth.authSignInURL }}ingress.kubernetes.io/auth-signin: {{ .Values.ingress.authentication.oauth.authSignInURL }} {{ end }}
     {{ end }}
     {{- if .Values.ingress.authentication.sso.enabled}}
     ingress.kubernetes.io/auth-tls-secret: {{ required ".Values.ingress.authentication.sso.authTLSSecret missing" .Values.ingress.authentication.sso.authTLSSecret | quote }}
+    nginx.ingress.kubernetes.io/auth-tls-secret: {{ required ".Values.ingress.authentication.sso.authTLSSecret missing" .Values.ingress.authentication.sso.authTLSSecret | quote }}
     ingress.kubernetes.io/auth-tls-verify-depth: {{ required ".Values.ingress.authentication.sso.authTLSVerifyDepth missing" .Values.ingress.authentication.sso.authTLSVerifyDepth | quote }}
+    nginx.ingress.kubernetes.io/auth-tls-verify-depth: {{ required ".Values.ingress.authentication.sso.authTLSVerifyDepth missing" .Values.ingress.authentication.sso.authTLSVerifyDepth | quote }}
     ingress.kubernetes.io/auth-tls-verify-client: {{ required ".Values.ingress.authentication.sso.authTLSVerifyClient missing" .Values.ingress.authentication.sso.authTLSVerifyClient | quote }}
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: {{ required ".Values.ingress.authentication.sso.authTLSVerifyClient missing" .Values.ingress.authentication.sso.authTLSVerifyClient | quote }}
     {{ end }}
     {{- if .Values.ingress.annotations }}
 {{ toYaml .Values.ingress.annotations | indent 4 }}

--- a/common/prometheus-server/templates/ingress-internal.yaml
+++ b/common/prometheus-server/templates/ingress-internal.yaml
@@ -14,12 +14,16 @@ metadata:
     disco: "true"
     {{- if $.Values.internalIngress.authentication.oauth.enabled }}
     ingress.kubernetes.io/auth-url: {{ required "$.Values.internalIngress.authentication.oauth.authURL missing" $.Values.internalIngress.authentication.oauth.authURL }}
+    nginx.ingress.kubernetes.io/auth-url: {{ required "$.Values.internalIngress.authentication.oauth.authURL missing" $.Values.internalIngress.authentication.oauth.authURL }}
     {{ if $.Values.internalIngress.authentication.oauth.authSignInURL }}ingress.kubernetes.io/auth-signin: {{ $.Values.internalIngress.authentication.oauth.authSignInURL }} {{ end }}
     {{ end }}
     {{- if $.Values.internalIngress.authentication.sso.enabled}}
     ingress.kubernetes.io/auth-tls-secret: {{ required "$.Values.internalIngress.authentication.sso.authTLSSecret missing" $.Values.internalIngress.authentication.sso.authTLSSecret | quote }}
+    nginx.ingress.kubernetes.io/auth-tls-secret: {{ required "$.Values.internalIngress.authentication.sso.authTLSSecret missing" $.Values.internalIngress.authentication.sso.authTLSSecret | quote }}
     ingress.kubernetes.io/auth-tls-verify-depth: {{ required "$.Values.internalIngress.authentication.sso.authTLSVerifyDepth missing" $.Values.internalIngress.authentication.sso.authTLSVerifyDepth | quote }}
+    nginx.ingress.kubernetes.io/auth-tls-verify-depth: {{ required "$.Values.internalIngress.authentication.sso.authTLSVerifyDepth missing" $.Values.internalIngress.authentication.sso.authTLSVerifyDepth | quote }}
     ingress.kubernetes.io/auth-tls-verify-client: {{ required "$.Values.internalIngress.authentication.sso.authTLSVerifyClient missing" $.Values.internalIngress.authentication.sso.authTLSVerifyClient | quote }}
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: {{ required "$.Values.internalIngress.authentication.sso.authTLSVerifyClient missing" $.Values.internalIngress.authentication.sso.authTLSVerifyClient | quote }}
     {{ end }}
     {{- if $.Values.internalIngress.annotations }}
 {{ toYaml $.Values.internalIngress.annotations | indent 4 }}

--- a/common/prometheus-server/templates/ingress.yaml
+++ b/common/prometheus-server/templates/ingress.yaml
@@ -15,12 +15,16 @@ metadata:
     disco: "true"
     {{- if $.Values.ingress.authentication.oauth.enabled }}
     ingress.kubernetes.io/auth-url: {{ required "$.Values.ingress.authentication.oauth.authURL missing" $.Values.ingress.authentication.oauth.authURL }}
+    nginx.ingress.kubernetes.io/auth-url: {{ required "$.Values.ingress.authentication.oauth.authURL missing" $.Values.ingress.authentication.oauth.authURL }}
     {{ if $.Values.ingress.authentication.oauth.authSignInURL }}ingress.kubernetes.io/auth-signin: {{ $.Values.ingress.authentication.oauth.authSignInURL }} {{ end }}
     {{ end }}
     {{- if $.Values.ingress.authentication.sso.enabled}}
     ingress.kubernetes.io/auth-tls-secret: {{ required "$.Values.ingress.authentication.sso.authTLSSecret missing" $.Values.ingress.authentication.sso.authTLSSecret | quote }}
+    nginx.ingress.kubernetes.io/auth-tls-secret: {{ required "$.Values.ingress.authentication.sso.authTLSSecret missing" $.Values.ingress.authentication.sso.authTLSSecret | quote }}
     ingress.kubernetes.io/auth-tls-verify-depth: {{ required "$.Values.ingress.authentication.sso.authTLSVerifyDepth missing" $.Values.ingress.authentication.sso.authTLSVerifyDepth | quote }}
+    nginx.ingress.kubernetes.io/auth-tls-verify-depth: {{ required "$.Values.ingress.authentication.sso.authTLSVerifyDepth missing" $.Values.ingress.authentication.sso.authTLSVerifyDepth | quote }}
     ingress.kubernetes.io/auth-tls-verify-client: {{ required "$.Values.ingress.authentication.sso.authTLSVerifyClient missing" $.Values.ingress.authentication.sso.authTLSVerifyClient | quote }}
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: {{ required "$.Values.ingress.authentication.sso.authTLSVerifyClient missing" $.Values.ingress.authentication.sso.authTLSVerifyClient | quote }}
     {{ end }}
     {{- if $.Values.ingress.annotations }}
 {{ toYaml $.Values.ingress.annotations | indent 4 }}

--- a/common/thanos/templates/ingress-grpc.yaml
+++ b/common/thanos/templates/ingress-grpc.yaml
@@ -12,11 +12,16 @@ metadata:
     kubernetes.io/tls-acme: "true"
     {{- if $.Values.ingress.authentication.sso.enabled}}
     ingress.kubernetes.io/auth-tls-secret: {{ required "$.Values.grpcIngress.authentication.sso.authTLSSecret missing" $.Values.grpcIngress.authentication.sso.authTLSSecret | quote }}
+    nginx.ingress.kubernetes.io/auth-tls-secret: {{ required "$.Values.grpcIngress.authentication.sso.authTLSSecret missing" $.Values.grpcIngress.authentication.sso.authTLSSecret | quote }}
     ingress.kubernetes.io/auth-tls-verify-depth: {{ required "$.Values.grpcIngress.authentication.sso.authTLSVerifyDepth missing" $.Values.grpcIngress.authentication.sso.authTLSVerifyDepth | quote }}
+    nginx.ingress.kubernetes.io/auth-tls-verify-depth: {{ required "$.Values.grpcIngress.authentication.sso.authTLSVerifyDepth missing" $.Values.grpcIngress.authentication.sso.authTLSVerifyDepth | quote }}
     ingress.kubernetes.io/auth-tls-verify-client: {{ required "$.Values.grpcIngress.authentication.sso.authTLSVerifyClient missing" $.Values.grpcIngress.authentication.sso.authTLSVerifyClient | quote }}
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: {{ required "$.Values.grpcIngress.authentication.sso.authTLSVerifyClient missing" $.Values.grpcIngress.authentication.sso.authTLSVerifyClient | quote }}
     {{ end }}
     ingress.kubernetes.io/backend-protocol: {{ required "$.Values.grpcIngress.authentication.grpc.backendProtocol missing" $.Values.grpcIngress.authentication.grpc.backendProtocol | quote }}
+    nginx.ingress.kubernetes.io/backend-protocol: {{ required "$.Values.grpcIngress.authentication.grpc.backendProtocol missing" $.Values.grpcIngress.authentication.grpc.backendProtocol | quote }}
     ingress.kubernetes.io/ssl-redirect: {{ required "$.Values.grpcIngress.authentication.grpc.sslRedirect missing" $.Values.grpcIngress.authentication.grpc.sslRedirect | quote }}
+    nginx.ingress.kubernetes.io/ssl-redirect: {{ required "$.Values.grpcIngress.authentication.grpc.sslRedirect missing" $.Values.grpcIngress.authentication.grpc.sslRedirect | quote }}
     {{- if $.Values.grpcIngress.annotations }}
 {{ toYaml $.Values.grpcIngress.annotations | indent 4 }}
     {{ end }}

--- a/common/thanos/templates/ingress.yaml
+++ b/common/thanos/templates/ingress.yaml
@@ -12,12 +12,16 @@ metadata:
     kubernetes.io/tls-acme: "true"
     {{- if $.Values.ingress.authentication.oauth.enabled }}
     ingress.kubernetes.io/auth-url: {{ required "$.Values.ingress.authentication.oauth.authURL missing" $.Values.ingress.authentication.oauth.authURL }}
+    nginx.ingress.kubernetes.io/auth-url: {{ required "$.Values.ingress.authentication.oauth.authURL missing" $.Values.ingress.authentication.oauth.authURL }}
     {{ if $.Values.ingress.authentication.oauth.authSignInURL }}ingress.kubernetes.io/auth-signin: {{ $.Values.ingress.authentication.oauth.authSignInURL }} {{ end }}
     {{ end }}
     {{- if $.Values.ingress.authentication.sso.enabled}}
     ingress.kubernetes.io/auth-tls-secret: {{ required "$.Values.ingress.authentication.sso.authTLSSecret missing" $.Values.ingress.authentication.sso.authTLSSecret | quote }}
+    nginx.ingress.kubernetes.io/auth-tls-secret: {{ required "$.Values.ingress.authentication.sso.authTLSSecret missing" $.Values.ingress.authentication.sso.authTLSSecret | quote }}
     ingress.kubernetes.io/auth-tls-verify-depth: {{ required "$.Values.ingress.authentication.sso.authTLSVerifyDepth missing" $.Values.ingress.authentication.sso.authTLSVerifyDepth | quote }}
+    nginx.ingress.kubernetes.io/auth-tls-verify-depth: {{ required "$.Values.ingress.authentication.sso.authTLSVerifyDepth missing" $.Values.ingress.authentication.sso.authTLSVerifyDepth | quote }}
     ingress.kubernetes.io/auth-tls-verify-client: {{ required "$.Values.ingress.authentication.sso.authTLSVerifyClient missing" $.Values.ingress.authentication.sso.authTLSVerifyClient | quote }}
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: {{ required "$.Values.ingress.authentication.sso.authTLSVerifyClient missing" $.Values.ingress.authentication.sso.authTLSVerifyClient | quote }}
     {{ end }}
     {{- if $.Values.ingress.annotations }}
 {{ toYaml $.Values.ingress.annotations | indent 4 }}

--- a/global/concourse-main/templates/git-resource-proxy.yaml
+++ b/global/concourse-main/templates/git-resource-proxy.yaml
@@ -53,6 +53,7 @@ metadata:
   name: git-resource-proxy
   annotations:
     ingress.kubernetes.io/load-balance: "leastconn"
+    nginx.ingress.kubernetes.io/load-balance: "leastconn"
 spec:
   ingressClassName: git-proxy
   rules:

--- a/global/concourse-main/templates/web-ingress-alias.yaml
+++ b/global/concourse-main/templates/web-ingress-alias.yaml
@@ -7,6 +7,8 @@ metadata:
     kubernetes.io/tls-acme: "true"
     ingress.kubernetes.io/configuration-snippet: |
       return 301 {{ .Values.concourse.concourse.web.externalUrl }}$request_uri;
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      return 301 {{ .Values.concourse.concourse.web.externalUrl }}$request_uri;
   labels:
     app: {{ .Release.Name }}-web
     release: {{ .Release.Name }}

--- a/global/oauth-proxy/templates/ingress.yaml
+++ b/global/oauth-proxy/templates/ingress.yaml
@@ -7,6 +7,7 @@ metadata:
   name: global-auth
   annotations:
     ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
     dns-manager: "true"
     dns-manager/zone-name: auth.{{.Values.global.region}}.{{ .Values.global.tld }}

--- a/global/pulsar/values.yaml
+++ b/global/pulsar/values.yaml
@@ -23,6 +23,7 @@ ingress:
   annotations:
     kubernetes.io/tls-acme: "true"
     ingress.kubernetes.io/ingress.class: nginx-internet
+    nginx.ingress.kubernetes.io/ingress.class: nginx-internet
     kubernetes.io/ingress.class: nginx-internet
 
   hosts: []

--- a/global/supernova/templates/ingress.yaml
+++ b/global/supernova/templates/ingress.yaml
@@ -7,7 +7,9 @@ metadata:
   name: supernova
   annotations:
     ingress.kubernetes.io/affinity: "cookie"
+    nginx.ingress.kubernetes.io/affinity: "cookie"
     ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
     
     {{- if .Values.ingress.internet_facing }}

--- a/openstack/arc/templates/api-ingress.yaml
+++ b/openstack/arc/templates/api-ingress.yaml
@@ -7,6 +7,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
   annotations:
     ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
   {{- if .Values.api.ingress.cert_manager}}
     kubernetes.io/tls-acme: "true"
   {{- end }}

--- a/openstack/castellum/templates/ingress-api.yaml
+++ b/openstack/castellum/templates/ingress-api.yaml
@@ -8,6 +8,7 @@ metadata:
     disco: "true"
     {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
     ingress.kubernetes.io/service-upstream: "true"
+    nginx.ingress.kubernetes.io/service-upstream: "true"
     {{- end }}
 
 spec:

--- a/openstack/cbshelf/templates/ingress.yaml
+++ b/openstack/cbshelf/templates/ingress.yaml
@@ -4,9 +4,13 @@ metadata:
   name: {{ .Chart.Name }}
   annotations:
     ingress.kubernetes.io/auth-tls-secret: kube-system/ingress-cacrt
+    nginx.ingress.kubernetes.io/auth-tls-secret: kube-system/ingress-cacrt
     ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "true"
+    nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "true"
     ingress.kubernetes.io/auth-tls-verify-client: "optional"
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: "optional"
     ingress.kubernetes.io/auth-tls-verify-depth: "3"
+    nginx.ingress.kubernetes.io/auth-tls-verify-depth: "3"
     kubernetes.io/ingress.class: "nginx"
     disco: "true"
     kubernetes.io/tls-acme: "true"

--- a/openstack/cinder/templates/api-ingress.yaml
+++ b/openstack/cinder/templates/api-ingress.yaml
@@ -11,6 +11,9 @@ metadata:
     ingress.kubernetes.io/configuration-snippet: |
       {{- include "utils.snippets.set_openstack_request_id" . | indent 6 }}
     {{- include "utils.snippets.set_ingress_cors_annotations" . | indent 4 }}
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      {{- include "utils.snippets.set_openstack_request_id" . | indent 6 }}
+    {{- include "utils.snippets.set_ingress_cors_annotations" . | indent 4 }}
   {{- if .Values.use_tls_acme }}
     kubernetes.io/tls-acme: "true"
   {{- end }}

--- a/openstack/cronus/sub-charts/maillog/templates/ingress.yaml
+++ b/openstack/cronus/sub-charts/maillog/templates/ingress.yaml
@@ -4,9 +4,13 @@ metadata:
   name: maillog
   annotations:
     ingress.kubernetes.io/auth-tls-secret: kube-system/ingress-cacrt
+    nginx.ingress.kubernetes.io/auth-tls-secret: kube-system/ingress-cacrt
     ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "true"
+    nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "true"
     ingress.kubernetes.io/auth-tls-verify-client: "optional"
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: "optional"
     ingress.kubernetes.io/auth-tls-verify-depth: "3"
+    nginx.ingress.kubernetes.io/auth-tls-verify-depth: "3"
     kubernetes.io/ingress.class: "nginx"
     disco: "true"
     kubernetes.io/tls-acme: "true"

--- a/openstack/elektra/templates/ingress.yaml
+++ b/openstack/elektra/templates/ingress.yaml
@@ -21,21 +21,30 @@ metadata:
 
     {{- if .Values.ingress.ca }}
     ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: {{ default true .Values.ingress.pass_certificate_to_upstream | quote }}
+    nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: {{ default true .Values.ingress.pass_certificate_to_upstream | quote }}
     ingress.kubernetes.io/auth-tls-secret: kube-system/ingress-cacrt
+    nginx.ingress.kubernetes.io/auth-tls-secret: kube-system/ingress-cacrt
     ingress.kubernetes.io/auth-tls-verify-client: "optional"
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: "optional"
     ingress.kubernetes.io/auth-tls-verify-depth: "3"
+    nginx.ingress.kubernetes.io/auth-tls-verify-depth: "3"
     {{- end }}
     {{- if .Values.enable_linkerd }}
     ingress.kubernetes.io/service-upstream: "true"
+    nginx.ingress.kubernetes.io/service-upstream: "true"
     {{- end }}
     disco: "true"
     kubernetes.io/tls-acme: {{ default false .Values.ingress.vice_president | quote }}
     prometheus.io/probe: {{ default false .Values.ingress.probe | quote }}
     {{- if .Values.ingress.oauth_proxy }}
     ingress.kubernetes.io/auth-url: "https://auth.{{ .Values.global.region}}.{{ .Values.global.tld}}/oauth2/auth"
+    nginx.ingress.kubernetes.io/auth-url: "https://auth.{{ .Values.global.region}}.{{ .Values.global.tld}}/oauth2/auth"
     ingress.kubernetes.io/auth-signin: "https://auth.{{ .Values.global.region}}.{{ .Values.global.tld}}/oauth2/start"
+    nginx.ingress.kubernetes.io/auth-signin: "https://auth.{{ .Values.global.region}}.{{ .Values.global.tld}}/oauth2/start"
     ingress.kubernetes.io/auth-request-redirect: $escaped_request_uri
+    nginx.ingress.kubernetes.io/auth-request-redirect: $escaped_request_uri
     ingress.kubernetes.io/auth-response-headers: "Authorization, X-Auth-Request-Email, X-Auth-Request-User, X-Forwarded-Access-Token"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization, X-Auth-Request-Email, X-Auth-Request-User, X-Forwarded-Access-Token"
     {{- end }}
 spec:
   tls:
@@ -63,12 +72,17 @@ metadata:
   annotations:
     {{- if .Values.ingress.ca }}
     ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: {{ default true .Values.ingress.pass_certificate_to_upstream | quote }}
+    nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: {{ default true .Values.ingress.pass_certificate_to_upstream | quote }}
     ingress.kubernetes.io/auth-tls-secret: kube-system/ingress-cacrt
+    nginx.ingress.kubernetes.io/auth-tls-secret: kube-system/ingress-cacrt
     ingress.kubernetes.io/auth-tls-verify-client: "optional"
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: "optional"
     ingress.kubernetes.io/auth-tls-verify-depth: "3"
+    nginx.ingress.kubernetes.io/auth-tls-verify-depth: "3"
     {{- end }}
     {{- if .Values.enable_linkerd }}
     ingress.kubernetes.io/service-upstream: "true"
+    nginx.ingress.kubernetes.io/service-upstream: "true"
     {{- end }}
     disco: "true"
     kubernetes.io/tls-acme: {{ default false .Values.ingress.vice_president | quote }}

--- a/openstack/elektra/templates/ingress_rsa.yaml
+++ b/openstack/elektra/templates/ingress_rsa.yaml
@@ -12,12 +12,17 @@ metadata:
 
     {{- if .Values.ingress.ca }}
     ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: {{ default true .Values.ingress.pass_certificate_to_upstream | quote }}
+    nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: {{ default true .Values.ingress.pass_certificate_to_upstream | quote }}
     ingress.kubernetes.io/auth-tls-secret: kube-system/ingress-cacrt
+    nginx.ingress.kubernetes.io/auth-tls-secret: kube-system/ingress-cacrt
     ingress.kubernetes.io/auth-tls-verify-client: "optional"
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: "optional"
     ingress.kubernetes.io/auth-tls-verify-depth: "3"
+    nginx.ingress.kubernetes.io/auth-tls-verify-depth: "3"
     {{- end }}
     {{- if .Values.enable_linkerd }}
     ingress.kubernetes.io/service-upstream: "true"
+    nginx.ingress.kubernetes.io/service-upstream: "true"
     {{- end }}
     disco: "true"
     kubernetes.io/tls-acme: {{ default false .Values.ingress.vice_president | quote }}

--- a/openstack/glance/templates/ingress.yaml
+++ b/openstack/glance/templates/ingress.yaml
@@ -9,6 +9,7 @@ metadata:
     component: glance
   annotations:
     ingress.kubernetes.io/proxy-request-buffering: "off"
+    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
     {{- if .Values.tlsacme }}
     kubernetes.io/tls-acme: "true"
     disco: "true"

--- a/openstack/grafanasix/templates/grafana-ingress.yaml
+++ b/openstack/grafanasix/templates/grafana-ingress.yaml
@@ -9,8 +9,11 @@ metadata:
     disco: {{ default false .Values.grafana.disco | quote }}
   {{- if .Values.grafana.auth.tls_client_auth.enabled}}
     ingress.kubernetes.io/auth-tls-secret: {{ default "" .Values.grafana.auth.tls_client_auth.secret }}
+    nginx.ingress.kubernetes.io/auth-tls-secret: {{ default "" .Values.grafana.auth.tls_client_auth.secret }}
     ingress.kubernetes.io/auth-tls-verify-depth: "3"
+    nginx.ingress.kubernetes.io/auth-tls-verify-depth: "3"
     ingress.kubernetes.io/auth-tls-verify-client: "optional"
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: "optional"
   {{- end }}
 
 spec:
@@ -41,8 +44,11 @@ metadata:
     disco/zone-name: "global.cloud.sap"
   {{- if .Values.grafana.auth.tls_client_auth.enabled}}
     ingress.kubernetes.io/auth-tls-secret: {{ default "" .Values.grafana.auth.tls_client_auth.secret }}
+    nginx.ingress.kubernetes.io/auth-tls-secret: {{ default "" .Values.grafana.auth.tls_client_auth.secret }}
     ingress.kubernetes.io/auth-tls-verify-depth: "3"
+    nginx.ingress.kubernetes.io/auth-tls-verify-depth: "3"
     ingress.kubernetes.io/auth-tls-verify-client: "optional"
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: "optional"
   {{- end }}
 
 spec:

--- a/openstack/hermes/templates/es-manager-ingress.yaml
+++ b/openstack/hermes/templates/es-manager-ingress.yaml
@@ -8,8 +8,11 @@ metadata:
     kubernetes.io/tls-acme: {{ default true .Values.ingress.tls | quote }}
     disco: {{ default true .Values.ingress.disco | quote }}
     ingress.kubernetes.io/auth-url: "https://auth-internal.{{.Values.global.region}}.{{ .Values.global.tld }}/oauth2/auth"
+    nginx.ingress.kubernetes.io/auth-url: "https://auth-internal.{{.Values.global.region}}.{{ .Values.global.tld }}/oauth2/auth"
     ingress.kubernetes.io/auth-signin: "https://auth-internal.{{.Values.global.region}}.{{ .Values.global.tld }}/oauth2/start"
+    nginx.ingress.kubernetes.io/auth-signin: "https://auth-internal.{{.Values.global.region}}.{{ .Values.global.tld }}/oauth2/start"
     ingress.kubernetes.io/auth-request-redirect: $escaped_request_uri
+    nginx.ingress.kubernetes.io/auth-request-redirect: $escaped_request_uri
 
 spec:
   tls:

--- a/openstack/ironic/templates/_console-ingress.yaml.tpl
+++ b/openstack/ironic/templates/_console-ingress.yaml.tpl
@@ -17,7 +17,9 @@ metadata:
   annotations:
     kubernetes.io/tls-acme: "true"
     ingress.kubernetes.io/backend-protocol: HTTPS
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     ingress.kubernetes.io/ssl-passthrough: "true"
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
 spec:
   tls:
      - secretName: tls-{{ include "ironic_console_endpoint_host_public" . | replace "." "-" }}

--- a/openstack/ironic/templates/api-ingress.yaml
+++ b/openstack/ironic/templates/api-ingress.yaml
@@ -10,6 +10,8 @@ metadata:
   annotations:
     ingress.kubernetes.io/configuration-snippet: |
       {{- include "utils.snippets.set_openstack_request_id" . | indent 6 }}
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      {{- include "utils.snippets.set_openstack_request_id" . | indent 6 }}
     kubernetes.io/tls-acme: "true"
 spec:
   tls:

--- a/openstack/keppel-trivy/templates/ingress.yaml
+++ b/openstack/keppel-trivy/templates/ingress.yaml
@@ -8,6 +8,7 @@ metadata:
     kubernetes.io/tls-acme: "true"
     {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
     ingress.kubernetes.io/service-upstream: "true"
+    nginx.ingress.kubernetes.io/service-upstream: "true"
     {{- end }}
 
 spec:

--- a/openstack/keppel/templates/ingress-api.yaml
+++ b/openstack/keppel/templates/ingress-api.yaml
@@ -7,8 +7,10 @@ metadata:
     kubernetes.io/tls-acme: "true"
     disco: "true"
     ingress.kubernetes.io/proxy-request-buffering: "off" # to improve push performance
+    nginx.ingress.kubernetes.io/proxy-request-buffering: "off" # to improve push performance
     {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
     ingress.kubernetes.io/service-upstream: "true"
+    nginx.ingress.kubernetes.io/service-upstream: "true"
     {{- end }}
 
 spec:

--- a/openstack/keystone/templates/ingress-api.yaml
+++ b/openstack/keystone/templates/ingress-api.yaml
@@ -49,17 +49,25 @@ metadata:
     # clear the trusted key header from external requests
     ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header X-Trusted-Key        "";
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_set_header X-Trusted-Key        "";
     {{- if .Values.services.ingress.limitRps }}
     ingress.kubernetes.io/limit-rps: {{ .Values.services.ingress.limitRps | quote }}
+    nginx.ingress.kubernetes.io/limit-rps: {{ .Values.services.ingress.limitRps | quote }}
     {{- end }}
     {{- if .Values.services.ingress.limitConnections }}
     ingress.kubernetes.io/limit-connections: {{ .Values.services.ingress.limitConnections | quote }}
+    nginx.ingress.kubernetes.io/limit-connections: {{ .Values.services.ingress.limitConnections | quote }}
     {{- end }}
     {{- if .Values.services.ingress.x509.ca }}
     ingress.kubernetes.io/auth-tls-secret: {{ .Release.Namespace }}/{{ .Release.Name }}-x509-ca
+    nginx.ingress.kubernetes.io/auth-tls-secret: {{ .Release.Namespace }}/{{ .Release.Name }}-x509-ca
     ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "true"
+    nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "true"
     ingress.kubernetes.io/auth-tls-verify-client: "optional"
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: "optional"
     ingress.kubernetes.io/auth-tls-verify-depth: "3"
+    nginx.ingress.kubernetes.io/auth-tls-verify-depth: "3"
     {{- end }}
     {{- if .Values.services.ingress.tlsacme }}
     kubernetes.io/tls-acme: "true"

--- a/openstack/limes/templates/ingress-api.yaml
+++ b/openstack/limes/templates/ingress-api.yaml
@@ -12,6 +12,7 @@ metadata:
     disco: "true"
     {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
     ingress.kubernetes.io/service-upstream: "true"
+    nginx.ingress.kubernetes.io/service-upstream: "true"
     {{- end }}
 
 spec:

--- a/openstack/manila/templates/api-ingress.yaml
+++ b/openstack/manila/templates/api-ingress.yaml
@@ -10,7 +10,9 @@ metadata:
   {{- if .Values.use_tls_acme }}
   annotations:
     ingress.kubernetes.io/proxy-read-timeout: "720"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "720"
     ingress.kubernetes.io/proxy-send-timeout: "720"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "720"
     kubernetes.io/tls-acme: "true"
   {{- end }}
 spec:

--- a/openstack/neutron/templates/ingress-server.yaml
+++ b/openstack/neutron/templates/ingress-server.yaml
@@ -12,6 +12,8 @@ metadata:
     disco: "true"
     ingress.kubernetes.io/configuration-snippet: |
       {{- include "utils.snippets.set_openstack_request_id" . | indent 6 }}
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      {{- include "utils.snippets.set_openstack_request_id" . | indent 6 }}
 spec:
   tls:
      - secretName: tls-{{include "neutron_api_endpoint_host_public" . | replace "." "-" }}

--- a/openstack/nova/templates/api-ingress.yaml
+++ b/openstack/nova/templates/api-ingress.yaml
@@ -10,6 +10,8 @@ metadata:
   annotations:
     ingress.kubernetes.io/configuration-snippet: |
       {{- include "utils.snippets.set_openstack_request_id" . | indent 6 }}
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      {{- include "utils.snippets.set_openstack_request_id" . | indent 6 }}
     {{- include "utils.snippets.set_ingress_cors_annotations" . | indent 4 }}
   {{- if .Values.use_tls_acme }}
     kubernetes.io/tls-acme: "true"

--- a/openstack/nova/templates/console-ingress.yaml
+++ b/openstack/nova/templates/console-ingress.yaml
@@ -14,7 +14,9 @@ metadata:
     component: nova
   annotations:
     ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/use-regex: "true"
     ingress.kubernetes.io/rewrite-target: "/$1"
+    nginx.ingress.kubernetes.io/rewrite-target: "/$1"
   {{- if .Values.use_tls_acme }}
     kubernetes.io/tls-acme: "true"
   {{- end }}

--- a/openstack/placement/templates/placement-ingress.yaml
+++ b/openstack/placement/templates/placement-ingress.yaml
@@ -11,6 +11,8 @@ metadata:
     disco: "true"
     ingress.kubernetes.io/configuration-snippet: |
       {{- include "utils.snippets.set_openstack_request_id" . | indent 6 }}
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      {{- include "utils.snippets.set_openstack_request_id" . | indent 6 }}
   {{- if .Values.use_tls_acme }}
     kubernetes.io/tls-acme: "true"
   {{- end }}

--- a/openstack/utils/templates/snippets/_set_ingress_cors_annotations.tpl
+++ b/openstack/utils/templates/snippets/_set_ingress_cors_annotations.tpl
@@ -1,10 +1,16 @@
 {{ define "utils.snippets.set_ingress_cors_annotations" }}
 {{- if .Values.cors.enabled }}
 ingress.kubernetes.io/enable-cors: "true"
+nginx.ingress.kubernetes.io/enable-cors: "true"
 ingress.kubernetes.io/cors-allow-headers: "{{ .Values.utils.cors.allow_headers }}{{ if .Values.cors.additional_allow_headers }},{{ .Values.cors.additional_allow_headers }}{{ end }}"
+nginx.ingress.kubernetes.io/cors-allow-headers: "{{ .Values.utils.cors.allow_headers }}{{ if .Values.cors.additional_allow_headers }},{{ .Values.cors.additional_allow_headers }}{{ end }}"
 ingress.kubernetes.io/cors-expose-headers: "{{ .Values.cors.expose_headers | default "*" }}"
+nginx.ingress.kubernetes.io/cors-expose-headers: "{{ .Values.cors.expose_headers | default "*" }}"
 ingress.kubernetes.io/cors-allow-origin: "{{ required ".Values.global.accessControlAllowOrigin is missing" .Values.global.accessControlAllowOrigin }}{{if .Values.cors.additional_allow_origin }},{{ .Values.cors.additional_allow_origin }}{{ end }}"
+nginx.ingress.kubernetes.io/cors-allow-origin: "{{ required ".Values.global.accessControlAllowOrigin is missing" .Values.global.accessControlAllowOrigin }}{{if .Values.cors.additional_allow_origin }},{{ .Values.cors.additional_allow_origin }}{{ end }}"
 ingress.kubernetes.io/cors-allow-credentials: "{{ .Values.cors.allow_credentials | default "false" }}"
+nginx.ingress.kubernetes.io/cors-allow-credentials: "{{ .Values.cors.allow_credentials | default "false" }}"
 ingress.kubernetes.io/cors-max-age: "{{ .Values.cors.max_age | default "1728000" }}"
+nginx.ingress.kubernetes.io/cors-max-age: "{{ .Values.cors.max_age | default "1728000" }}"
 {{- end }}
 {{- end }}

--- a/px/lg/templates/ingress.yaml
+++ b/px/lg/templates/ingress.yaml
@@ -10,11 +10,17 @@ metadata:
     kubernetes.io/tls-acme: "true"
     {{- if $lg_config.authenticate }}
     ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
     ingress.kubernetes.io/auth-tls-secret: kube-system/ingress-cacrt
+    nginx.ingress.kubernetes.io/auth-tls-secret: kube-system/ingress-cacrt
     ingress.kubernetes.io/auth-tls-verify-client: "true"
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: "true"
     ingress.kubernetes.io/auth-tls-verify-depth: "3"
+    nginx.ingress.kubernetes.io/auth-tls-verify-depth: "3"
     ingress.kubernetes.io/auth-url: https://ccauth.{{ $.Values.global.region }}.cloud.sap/v1/query?authentication-method=ingress-certificate&authorization-method=ldap&authorization-groups=CP_NETWORK_SUPPORT,CP_API_SUPPORT
+    nginx.ingress.kubernetes.io/auth-url: https://ccauth.{{ $.Values.global.region }}.cloud.sap/v1/query?authentication-method=ingress-certificate&authorization-method=ldap&authorization-groups=CP_NETWORK_SUPPORT,CP_API_SUPPORT
     ingress.kubernetes.io/auth-response-headers: "CC-Authorization-Status,CC-Authorization-Response-Groups,CC-Authentication-Status"
+    nginx.ingress.kubernetes.io/auth-response-headers: "CC-Authorization-Status,CC-Authorization-Response-Groups,CC-Authentication-Status"
     {{- end }}
 spec:
   rules:

--- a/system/doop-central/templates/ingress.yaml
+++ b/system/doop-central/templates/ingress.yaml
@@ -14,10 +14,14 @@ metadata:
     kubernetes.io/tls-acme: "true"
     disco: "true"
     ingress.kubernetes.io/auth-url: "https://auth-internal.eu-de-2.{{ $tld }}/oauth2/auth"
+    nginx.ingress.kubernetes.io/auth-url: "https://auth-internal.eu-de-2.{{ $tld }}/oauth2/auth"
     ingress.kubernetes.io/auth-signin: "https://auth-internal.eu-de-2.{{ $tld }}/oauth2/start"
+    nginx.ingress.kubernetes.io/auth-signin: "https://auth-internal.eu-de-2.{{ $tld }}/oauth2/start"
     ingress.kubernetes.io/auth-request-redirect: $escaped_request_uri
+    nginx.ingress.kubernetes.io/auth-request-redirect: $escaped_request_uri
     {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
     ingress.kubernetes.io/service-upstream: "true"
+    nginx.ingress.kubernetes.io/service-upstream: "true"
     {{- end }}
 
 spec:
@@ -70,7 +74,9 @@ metadata:
     kubernetes.io/tls-acme: "true"
     disco: "true"
     ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/enable-cors: "true"
     ingress.kubernetes.io/cors-allow-origin: '*'
+    nginx.ingress.kubernetes.io/cors-allow-origin: '*'
 
 spec:
   tls:

--- a/system/elk/vendor/es-manager/templates/ingress.yaml
+++ b/system/elk/vendor/es-manager/templates/ingress.yaml
@@ -8,8 +8,11 @@ metadata:
     kubernetes.io/tls-acme: "true"
     disco: {{ default true .Values.ingress.disco | quote }}
     ingress.kubernetes.io/auth-url: "https://auth-internal.{{.Values.global.region}}.{{ .Values.global.tld }}/oauth2/auth"
+    nginx.ingress.kubernetes.io/auth-url: "https://auth-internal.{{.Values.global.region}}.{{ .Values.global.tld }}/oauth2/auth"
     ingress.kubernetes.io/auth-signin: "https://auth-internal.{{.Values.global.region}}.{{ .Values.global.tld }}/oauth2/start"
+    nginx.ingress.kubernetes.io/auth-signin: "https://auth-internal.{{.Values.global.region}}.{{ .Values.global.tld }}/oauth2/start"
     ingress.kubernetes.io/auth-request-redirect: $escaped_request_uri
+    nginx.ingress.kubernetes.io/auth-request-redirect: $escaped_request_uri
 
 spec:
   tls:

--- a/system/elk/vendor/kibana/templates/ingress.yaml
+++ b/system/elk/vendor/kibana/templates/ingress.yaml
@@ -10,12 +10,18 @@ metadata:
     # this is for kibana sso cert evaluation
   {{- if .Values.auth.tls_client_auth.enabled}}
     ingress.kubernetes.io/auth-tls-secret: {{ default "" .Values.auth.tls_client_auth.secret }}
+    nginx.ingress.kubernetes.io/auth-tls-secret: {{ default "" .Values.auth.tls_client_auth.secret }}
     ingress.kubernetes.io/auth-tls-verify-depth: "3"
+    nginx.ingress.kubernetes.io/auth-tls-verify-depth: "3"
     ingress.kubernetes.io/auth-tls-verify-client: "optional"
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: "optional"
   {{ end }}
     ingress.kubernetes.io/auth-url: "https://auth-internal.{{.Values.global.region}}.{{ .Values.global.tld }}/oauth2/auth"
+    nginx.ingress.kubernetes.io/auth-url: "https://auth-internal.{{.Values.global.region}}.{{ .Values.global.tld }}/oauth2/auth"
     ingress.kubernetes.io/auth-signin: "https://auth-internal.{{.Values.global.region}}.{{ .Values.global.tld }}/oauth2/start"
+    nginx.ingress.kubernetes.io/auth-signin: "https://auth-internal.{{.Values.global.region}}.{{ .Values.global.tld }}/oauth2/start"
     ingress.kubernetes.io/auth-request-redirect: $escaped_request_uri
+    nginx.ingress.kubernetes.io/auth-request-redirect: $escaped_request_uri
 
 spec:
   tls:

--- a/system/hubcopter/templates/ingress.yaml
+++ b/system/hubcopter/templates/ingress.yaml
@@ -5,12 +5,18 @@ metadata:
   name: hubcopter-api
   annotations:
     ingress.kubernetes.io/auth-url: "https://auth-internal.eu-de-2.{{ $.Values.global.tld }}/oauth2/auth"
+    nginx.ingress.kubernetes.io/auth-url: "https://auth-internal.eu-de-2.{{ $.Values.global.tld }}/oauth2/auth"
     ingress.kubernetes.io/auth-signin: "https://auth-internal.eu-de-2.{{ $.Values.global.tld }}/oauth2/start"
+    nginx.ingress.kubernetes.io/auth-signin: "https://auth-internal.eu-de-2.{{ $.Values.global.tld }}/oauth2/start"
     ingress.kubernetes.io/auth-request-redirect: $escaped_request_uri
+    nginx.ingress.kubernetes.io/auth-request-redirect: $escaped_request_uri
     ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
     ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/use-regex: "true"
     {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
     ingress.kubernetes.io/service-upstream: "true"
+    nginx.ingress.kubernetes.io/service-upstream: "true"
     {{- end }}
     kubernetes.io/tls-acme: "true"
 

--- a/system/jupyterhub/templates/ingress.yaml
+++ b/system/jupyterhub/templates/ingress.yaml
@@ -9,8 +9,11 @@ metadata:
     disco: "true"
     disco/zone-name: global.cloud.sap.
     ingress.kubernetes.io/affinity: cookie
+    nginx.ingress.kubernetes.io/affinity: cookie
     ingress.kubernetes.io/proxy-buffer-size: 32k
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
     ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
 
 spec:
   tls:

--- a/system/maintenance-controller/templates/ingress.yaml
+++ b/system/maintenance-controller/templates/ingress.yaml
@@ -8,18 +8,26 @@ metadata:
   annotations:
     {{- if .Values.ingress.ca }}
     ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "true"
+    nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "true"
     ingress.kubernetes.io/auth-tls-secret: kube-system/ingress-cacrt
+    nginx.ingress.kubernetes.io/auth-tls-secret: kube-system/ingress-cacrt
     ingress.kubernetes.io/auth-tls-verify-client: "optional"
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: "optional"
     ingress.kubernetes.io/auth-tls-verify-depth: "3"
+    nginx.ingress.kubernetes.io/auth-tls-verify-depth: "3"
     {{- end }}
     disco: "true"
     kubernetes.io/tls-acme: "true"
     prometheus.io/probe: "true"
     {{- if .Values.ingress.oauthProxy }}
     ingress.kubernetes.io/auth-url: "https://auth.{{ .Values.global.region}}.{{ .Values.global.tld}}/oauth2/auth"
+    nginx.ingress.kubernetes.io/auth-url: "https://auth.{{ .Values.global.region}}.{{ .Values.global.tld}}/oauth2/auth"
     ingress.kubernetes.io/auth-signin: "https://auth.{{ .Values.global.region}}.{{ .Values.global.tld}}/oauth2/start"
+    nginx.ingress.kubernetes.io/auth-signin: "https://auth.{{ .Values.global.region}}.{{ .Values.global.tld}}/oauth2/start"
     ingress.kubernetes.io/auth-request-redirect: $escaped_request_uri
+    nginx.ingress.kubernetes.io/auth-request-redirect: $escaped_request_uri
     ingress.kubernetes.io/auth-response-headers: "Authorization, X-Auth-Request-Email, X-Auth-Request-User, X-Forwarded-Access-Token"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization, X-Auth-Request-Email, X-Auth-Request-User, X-Forwarded-Access-Token"
     {{- end }}
 spec:
   tls:

--- a/system/metis-api/templates/ingress.yaml
+++ b/system/metis-api/templates/ingress.yaml
@@ -12,8 +12,11 @@ metadata:
     kubernetes.io/tls-acme: "true"
     disco: "true"
     ingress.kubernetes.io/auth-tls-secret: kube-system/ingress-cacrt
+    nginx.ingress.kubernetes.io/auth-tls-secret: kube-system/ingress-cacrt
     ingress.kubernetes.io/auth-tls-verify-client: optional
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: optional
     ingress.kubernetes.io/auth-tls-verify-depth: "3"
+    nginx.ingress.kubernetes.io/auth-tls-verify-depth: "3"
 
 spec:
   tls:

--- a/system/opensearch-hermes/templates/dashboard-ingress.yaml
+++ b/system/opensearch-hermes/templates/dashboard-ingress.yaml
@@ -8,8 +8,11 @@ metadata:
     kubernetes.io/tls-acme: "true"
     disco: "true"
     ingress.kubernetes.io/affinity: cookie
+    nginx.ingress.kubernetes.io/affinity: cookie
     ingress.kubernetes.io/proxy-buffer-size: 32k
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
     ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
 
 spec:
   tls:

--- a/system/opensearch-logs/templates/ingress-dashboard.yaml
+++ b/system/opensearch-logs/templates/ingress-dashboard.yaml
@@ -9,8 +9,11 @@ metadata:
     kubernetes.io/tls-acme: "true"
     disco: "true"
     ingress.kubernetes.io/affinity: cookie
+    nginx.ingress.kubernetes.io/affinity: cookie
     ingress.kubernetes.io/proxy-buffer-size: 32k
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
     ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
 
 spec:
   tls:

--- a/system/opensearch-logs/vendor/elastic-manager/templates/ingress.yaml
+++ b/system/opensearch-logs/vendor/elastic-manager/templates/ingress.yaml
@@ -8,8 +8,11 @@ metadata:
     kubernetes.io/tls-acme: "true"
     disco: {{ default true .Values.ingress.disco | quote }}
     ingress.kubernetes.io/auth-url: "https://auth-internal.{{.Values.global.region}}.{{ .Values.global.tld }}/oauth2/auth"
+    nginx.ingress.kubernetes.io/auth-url: "https://auth-internal.{{.Values.global.region}}.{{ .Values.global.tld }}/oauth2/auth"
     ingress.kubernetes.io/auth-signin: "https://auth-internal.{{.Values.global.region}}.{{ .Values.global.tld }}/oauth2/start"
+    nginx.ingress.kubernetes.io/auth-signin: "https://auth-internal.{{.Values.global.region}}.{{ .Values.global.tld }}/oauth2/start"
     ingress.kubernetes.io/auth-request-redirect: $escaped_request_uri
+    nginx.ingress.kubernetes.io/auth-request-redirect: $escaped_request_uri
 
 spec:
   tls:

--- a/system/plutono/templates/plutono-ingress.yaml
+++ b/system/plutono/templates/plutono-ingress.yaml
@@ -9,8 +9,11 @@ metadata:
     disco: {{ default false .Values.plutono.disco | quote }}
   {{- if .Values.plutono.auth.tls_client_auth.enabled}}
     ingress.kubernetes.io/auth-tls-secret: {{ default "" .Values.plutono.auth.tls_client_auth.secret }}
+    nginx.ingress.kubernetes.io/auth-tls-secret: {{ default "" .Values.plutono.auth.tls_client_auth.secret }}
     ingress.kubernetes.io/auth-tls-verify-depth: "3"
+    nginx.ingress.kubernetes.io/auth-tls-verify-depth: "3"
     ingress.kubernetes.io/auth-tls-verify-client: "optional"
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: "optional"
   {{- end }}
 
 spec:
@@ -41,8 +44,11 @@ metadata:
     disco/zone-name: "global.cloud.sap"
   {{- if .Values.plutono.auth.tls_client_auth.enabled}}
     ingress.kubernetes.io/auth-tls-secret: {{ default "" .Values.plutono.auth.tls_client_auth.secret }}
+    nginx.ingress.kubernetes.io/auth-tls-secret: {{ default "" .Values.plutono.auth.tls_client_auth.secret }}
     ingress.kubernetes.io/auth-tls-verify-depth: "3"
+    nginx.ingress.kubernetes.io/auth-tls-verify-depth: "3"
     ingress.kubernetes.io/auth-tls-verify-client: "optional"
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: "optional"
   {{- end }}
 
 spec:

--- a/system/servicemesh/templates/ingress-viz.yaml
+++ b/system/servicemesh/templates/ingress-viz.yaml
@@ -6,10 +6,15 @@ metadata:
   annotations:
     disco: "true"
     ingress.kubernetes.io/auth-url: "https://auth-internal.{{ .Values.global.region }}.{{ .Values.global.tld }}/oauth2/auth"
+    nginx.ingress.kubernetes.io/auth-url: "https://auth-internal.{{ .Values.global.region }}.{{ .Values.global.tld }}/oauth2/auth"
     ingress.kubernetes.io/auth-signin: "https://auth-internal.{{ .Values.global.region }}.{{ .Values.global.tld }}/oauth2/start"
+    nginx.ingress.kubernetes.io/auth-signin: "https://auth-internal.{{ .Values.global.region }}.{{ .Values.global.tld }}/oauth2/start"
     ingress.kubernetes.io/auth-request-redirect: $escaped_request_uri
+    nginx.ingress.kubernetes.io/auth-request-redirect: $escaped_request_uri
     ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
     ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/use-regex: "true"
     kubernetes.io/tls-acme: "true"
 spec:
   tls:

--- a/system/smee-dynakratos/templates/ingress.yaml
+++ b/system/smee-dynakratos/templates/ingress.yaml
@@ -11,6 +11,7 @@ metadata:
     disco: "true"
     {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
     ingress.kubernetes.io/service-upstream: "true"
+    nginx.ingress.kubernetes.io/service-upstream: "true"
     {{- end }}
 
 spec:

--- a/system/tarslite/templates/ingress.yaml
+++ b/system/tarslite/templates/ingress.yaml
@@ -32,7 +32,9 @@ metadata:
     disco: "true"
     kubernetes.io/tls-acme: "true"
     ingress.kubernetes.io/auth-type: basic
+    nginx.ingress.kubernetes.io/auth-type: basic
     ingress.kubernetes.io/auth-secret: {{ required ".Values.tarslite.secrets.name missing" .Values.tarslite.secrets.name }}
+    nginx.ingress.kubernetes.io/auth-secret: {{ required ".Values.tarslite.secrets.name missing" .Values.tarslite.secrets.name }}
 {{- $hostname :=  print .Release.Name "-backoffice." .Values.tarslite.domain }}
 spec:
   rules:

--- a/system/tenso/templates/ingress-api.yaml
+++ b/system/tenso/templates/ingress-api.yaml
@@ -8,6 +8,7 @@ metadata:
     disco: "true"
     {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
     ingress.kubernetes.io/service-upstream: "true"
+    nginx.ingress.kubernetes.io/service-upstream: "true"
     {{- end }}
 
 spec:


### PR DESCRIPTION
We want to migrate from the old `ingress.kubernetes.io/`-prefixed annotations to the standard format `nginx.ingress.kubernetes.io/`. During the migration, we need to have all Ingress objects annotated in both ways to ensure forward-compatibility. After the move, the old annotations can be removed.

This change is mostly autogenerated through
```
sed -i 's+^\(\s*\)\(ingress.kubernetes.io/.*\)+\1\2\n\1nginx.\2+g' $(rg ingress.kubernetes.io -l)
```

I am currently removing the Gatekeeper check that complains about `nginx.ingress.kubernetes.io/`. Once we start rolling this out, I can add a new check that complains about `ingress.kubernetes.io/foo` without `nginx.ingress.kubernetes.io/foo`.