### PR TITLE
[MariaDB] - Rolling back Security Patches 10.5.21 to 10.5.17

### DIFF
--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.7.15
+version: 0.7.16

--- a/common/mariadb/templates/alerts/_mysql.alerts.tpl
+++ b/common/mariadb/templates/alerts/_mysql.alerts.tpl
@@ -28,7 +28,7 @@
       summary: {{ include "fullName" . }} reports slow queries.
 
   - alert: {{ include "alerts.service" . | title }}MariaDBWaitingForLock
-    expr: (mysql_info_schema_processlist_seconds{app=~"{{ include "fullName" . }}", state=~"waiting for lock"} / 1000  > 15)
+    expr: (mysql_info_schema_threads_seconds{app=~"{{ include "fullName" . }}", state=~"waiting for lock"} / 1000  > 15)
     for: 10m
     labels:
       context: database

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -4,7 +4,7 @@
 # name: value
 
 name: null
-image: library/mariadb:10.5.21
+image: library/mariadb:10.5.17
 imagePullPolicy: IfNotPresent
 port_public: 3306
 max_connections: 1024
@@ -138,7 +138,7 @@ backup_v2:
 metrics:
   enabled: true
   image: prom/mysqld-exporter
-  image_version: v0.14.0
+  image_version: v0.12.1
   port: "9104"
   flags:
     - collect.binlog_size


### PR DESCRIPTION
Reason: The 10.5.21 release blocking connection on various system

Reverting back the following PRs:
[MariaDB] - Security Patches upgrade to 10.5.21: https://github.com/sapcc/helm-charts/pull/5313 
rename metric in alert: https://github.com/sapcc/helm-charts/pull/5339