### PR TITLE
[memcached] priorityClassName made optional

### DIFF
--- a/common/memcached/Chart.yaml
+++ b/common/memcached/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: memcached
-version: 0.1.4
+version: 0.1.5
 description: Free & open source, high-performance, distributed memory object caching system.
 home: http://memcached.org/
 sources:

--- a/common/memcached/templates/deployment.yaml
+++ b/common/memcached/templates/deployment.yaml
@@ -93,6 +93,10 @@ spec:
             memory: {{ .Values.metrics.resources.requests.memory | quote }}
         {{- end }}
       {{- end }}
-      {{- if not (and (hasKey $.Values "priorityClass") (hasKey $.Values.priorityClass "disabled") ($.Values.priorityClass.disabled)) }}
-      priorityClassName: {{ default "openstack-service-critical" .Values.priority_class | quote }}
+      {{- if .Values.priority_class }}
+        {{- if and (kindIs "bool" .Values.priority_class) (eq .Values.priority_class true) }}
+      priorityClassName: "openstack-service-critical"
+        {{- else }}
+      priorityClassName: {{ .Values.priority_class | quote }}
+        {{- end }}
       {{- end }}

--- a/common/memcached/templates/deployment.yaml
+++ b/common/memcached/templates/deployment.yaml
@@ -93,4 +93,6 @@ spec:
             memory: {{ .Values.metrics.resources.requests.memory | quote }}
         {{- end }}
       {{- end }}
+      {{- if not (and (hasKey $.Values "priorityClass") (hasKey $.Values.priorityClass "disabled") ($.Values.priorityClass.disabled)) }}
       priorityClassName: {{ default "openstack-service-critical" .Values.priority_class | quote }}
+      {{- end }}

--- a/common/memcached/values.yaml
+++ b/common/memcached/values.yaml
@@ -19,7 +19,10 @@ imagePullPolicy: IfNotPresent
 nodeAffinity: {}
 
 # name of priorityClass to influence scheduling priority
-#priority_class:
+# false = disabled
+# true = enabled and set to 'openstack-service-critical'
+# <string> = set the priorityClassName to that value
+priority_class: true
 
 memcached:
   ## Various values that get set as command-line flags.


### PR DESCRIPTION
- to support K8s setups without preconfigured PriorityClass objects
- will be used for integration tests
- chart version bumped