### PR TITLE
feat(audit-logs): add probes and alerts for all endpoints

### DIFF
--- a/system/audit-logs/Chart.lock
+++ b/system/audit-logs/Chart.lock
@@ -16,9 +16,9 @@ dependencies:
   version: 0.0.26
 - name: ocb-datain-static-probes
   repository: file://vendor/ocb-datain-static-probes
-  version: 0.1.6
+  version: 0.2.0
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:a1a18a9471e4a80089a09d9bf6c0da57dcb53c10bfc0b7822284ed7bf73a6fa5
-generated: "2023-10-19T10:19:34.604729+02:00"
+digest: sha256:43a33d3d13b29643ef7a6b50b072f12d9aedfe16efbb9c631cbf63b107fc1e9c
+generated: "2023-10-20T12:23:01.614635+02:00"

--- a/system/audit-logs/Chart.yaml
+++ b/system/audit-logs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Audit logging components
 name: audit-logs
-version: 0.2.1
+version: 0.2.2
 dependencies:
   - name: fluent-audit-container
     alias: fluent_audit_container
@@ -34,7 +34,7 @@ dependencies:
 
   - name: ocb-datain-static-probes
     repository: file://vendor/ocb-datain-static-probes
-    version: 0.1.6
+    version: 0.2.0
     condition: ocb-datain-static-probes.enabled
 
   - name: owner-info

--- a/system/audit-logs/vendor/ocb-datain-static-probes/Chart.yaml
+++ b/system/audit-logs/vendor/ocb-datain-static-probes/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: ocb-datain-static-probes
-version: 0.1.6
+version: 0.2.0
 description: static probes for octobus data-in
 maintainers:
   - name: Martin Vossen

--- a/system/audit-logs/vendor/ocb-datain-static-probes/alerts/_ocb-datain.alerts
+++ b/system/audit-logs/vendor/ocb-datain-static-probes/alerts/_ocb-datain.alerts
@@ -2,13 +2,14 @@ groups:
 - name: ocb-data.alerts
   rules:
   - alert: OctobusDataInNotReachable
-    expr: probe_success{instance=~".+/c0001/log/audit$"} == 0
+    expr: probe_success{namespace="audit-logs", job="ocb-data-in"} == 0
     for: 15m
     labels:
       context: octobus
       service: logs
       severity: warning
       support_group: observability
+      playbook: 'docs/operation/elastic_kibana_issues/octobus/data_in_not_reachable'
     annotations:
-      description: '*{{ $labels.region }}/{{ $labels.clusterType }} * cannot reach Octobus https data in'
-      summary:  Cannot reach Octobus https data input
+      description: '*{{ $labels.region }}/{{ $labels.clusterType }} * cannot reach Octobus endpoint: {{$labels.instance}}'
+      summary:  Cannot reach Octobus data input

--- a/system/audit-logs/vendor/ocb-datain-static-probes/templates/probes.yaml
+++ b/system/audit-logs/vendor/ocb-datain-static-probes/templates/probes.yaml
@@ -1,13 +1,11 @@
 apiVersion: monitoring.coreos.com/v1
 kind: Probe
-
 metadata:
-  name: ocb-in-https
+  name: ocb-data-in
   labels:
     prometheus: {{ required "$.Values.global.prometheus missing" $.Values.global.prometheus }}
-
 spec:
-  jobName: ocb-in-https
+  jobName: ocb-data-in
   prober:
     url: {{ .Values.prober }}
     scheme: {{ .Values.scheme }}
@@ -17,7 +15,9 @@ spec:
   targets:
     staticConfig:
       static:
-        - https://{{ required "$.Values.global.forwarding.audit.host" $.Values.global.forwarding.audit.host }}
+      {{- range .Values.global.probe_targets }}
+        - https://{{ . }}
+      {{- end }}
       labels:
         {{ if $.Values.global.region -}}
         region: {{ $.Values.global.region }}


### PR DESCRIPTION
This will allow adding more probe targets and respective alerts via entries in the secrets.
Once this is deployed, we can remove the redundant probes from the `probe-exporter`