### PR TITLE
[utils] allow to override coordination mount path

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.10.3
+version: 0.10.4

--- a/openstack/utils/templates/_coordination.tpl
+++ b/openstack/utils/templates/_coordination.tpl
@@ -6,7 +6,7 @@
 {{- if eq .Values.coordinationBackend "file" }}
 - name: coordination
   # The parent dir of mountPath only matches by convention to $state_path in config and Dockerfile
-  mountPath: /var/lib/{{ .Chart.Name }}/coordination
+  mountPath: /var/lib/{{ .Values.coordinationBackendMountPath | default .Chart.Name }}/coordination
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
a non standard openstack chart may be named different from the
conventional state path
