### PR TITLE
[prometheus] userName and containerName configurable

### DIFF
--- a/common/prometheus-server/CHANGELOG.md
+++ b/common/prometheus-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.3.0
+
+* Swift container userName and containerName now can be set explicitly
+
 ## 7.2.16
 
 * If no `kube_` metrics available within the Prometheus, send `PrometheusMultiplePodScrape` alerts to specified Thanos Rule

--- a/common/prometheus-server/Chart.yaml
+++ b/common/prometheus-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus via operator.
 name: prometheus-server
-version: 7.2.16
+version: 7.3.0
 appVersion: v2.43.0
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
 maintainers:

--- a/common/prometheus-server/templates/_helpers.tpl
+++ b/common/prometheus-server/templates/_helpers.tpl
@@ -190,11 +190,26 @@ prometheus-{{- $name -}}.{{- required "$root.Values.global.region missing" $root
   action: drop
 {{- end -}}
 
-{{/* Generated Swift User Name. */}}
+{{/* Generated Swift userName*/}}
 {{- define "swift.userName" -}}
 {{- $name := index . 0 -}}
 {{- $root := index . 1 -}}
-{{- if $root.Values.thanosSeeds.seed.clusterType -}}
+{{- if $root.Values.thanosSeeds.swiftStorageConfig.userName -}}
+{{- $root.Values.thanosSeeds.swiftStorageConfig.userName -}}
+{{- else if $root.Values.thanosSeeds.seed.clusterType -}}
+{{- (include "prometheus.fullName" .) -}}-{{- $root.Values.thanosSeeds.seed.clusterType -}}-thanos
+{{- else -}}
+{{- (include "prometheus.fullName" .) -}}-thanos
+{{- end -}}
+{{- end -}}
+
+{{/* Generated Swift containerName*/}}
+{{- define "swift.containerName" -}}
+{{- $name := index . 0 -}}
+{{- $root := index . 1 -}}
+{{- if $root.Values.thanosSeeds.swiftStorageConfig.containerName -}}
+{{- $root.Values.thanosSeeds.swiftStorageConfig.containerName -}}
+{{- else if $root.Values.thanosSeeds.seed.clusterType -}}
 {{- (include "prometheus.fullName" .) -}}-{{- $root.Values.thanosSeeds.seed.clusterType -}}-thanos
 {{- else -}}
 {{- (include "prometheus.fullName" .) -}}-thanos

--- a/common/prometheus-server/templates/thanos/README.md
+++ b/common/prometheus-server/templates/thanos/README.md
@@ -28,7 +28,6 @@ thanos:
     projectDomainName:  <projectDomainName>
     # all settings below are not mandatory and auto-generated
     # userName:           <userName>
-    # regionName:         <regionName>
     # containerName:      <swiftContainerName>
 ```
 

--- a/common/prometheus-server/templates/thanos/_thanos.yaml.tpl
+++ b/common/prometheus-server/templates/thanos/_thanos.yaml.tpl
@@ -9,7 +9,7 @@ config:
   project_name: {{ include "thanos.projectName" $root }}
   project_domain_name: {{ include "thanos.projectDomainName" $root }}
   region_name: {{ required "$root.Values.global.region missing" $root.Values.global.region }}
-  container_name: {{ include "swift.userName" (list $name $root) }}
+  container_name: {{ include "swift.containerName" (list $name $root) }}
   {{ if $root.Values.thanosSeeds.swiftStorageConfig.projectDomainName }}
   project_domain_name: {{ $root.Values.thanosSeeds.swiftStorageConfig.projectDomainName | quote }}
   {{ end }}

--- a/common/prometheus-server/values.yaml
+++ b/common/prometheus-server/values.yaml
@@ -256,7 +256,6 @@ thanosSeeds:
     projectDomainName:
     # all settings below are not mandatory and auto-generated
     userName:
-    regionName:
     containerName:
 
     # Currently not supported are:

--- a/system/thanos-seeds/Chart.yaml
+++ b/system/thanos-seeds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: thanos-seeds
 description: dedicated seed deployment needed for thanos-sidecar in prometheus
-version: 0.0.3
+version: 0.0.4
 dependencies:
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap

--- a/system/thanos-seeds/templates/seed.yaml
+++ b/system/thanos-seeds/templates/seed.yaml
@@ -33,5 +33,5 @@ spec:
               role: objectstore_admin
           swift:
             containers:
-              - name: {{ include "swift.userName" (list $name $root) }}
+              - name: {{ include "swift.containerName" (list $name $root) }}
 {{- end }}

--- a/system/thanos-seeds/values.yaml
+++ b/system/thanos-seeds/values.yaml
@@ -39,7 +39,6 @@ thanosSeeds:
     projectDomainName:
     # all settings below are not mandatory and auto-generated
     userName:
-    regionName:
     containerName:
 
     # Currently not supported are:


### PR DESCRIPTION
the directive previously had no impact. setting these values will now result in actually configuring swift the way it is specified in the config.
as thanos-seeds are leveraging the same helper class, they need to follow the pattern. went for a simple copy approach to not overfill the template with too many if-else patterns to differentiate and still provide the old behaviour