### PR TITLE
opensearch-logs: move alerts partially to Thanos Rule

### DIFF
--- a/system/opensearch-logs/Chart.yaml
+++ b/system/opensearch-logs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for the Opensearch stack
 name: opensearch-logs
-version: 0.0.9
+version: 0.0.10
 home: https://github.com/sapcc/helm-charts/tree/master/system/opensearch-logs
 dependencies:
   - name: opensearch

--- a/system/opensearch-logs/alerts/infra-frontend/opensearch.alerts
+++ b/system/opensearch-logs/alerts/infra-frontend/opensearch.alerts
@@ -47,19 +47,3 @@ groups:
     annotations:
       description: 'Opensearch cluster *opensearch-logs* in `{{ $labels.region }}` is RED. Please check all nodes.'
       summary: '*opensearch-logs* cluster in `{{ $labels.region }}` is RED'
-
-  - alert: OpensearchLogsClusterYellow
-    expr: opensearch_cluster_status{elastic_cluster="opensearch-logs",pod=~".*-master-0"} == 1 and sum(kube_statefulset_replicas{statefulset=~"opensearch-logs.*"}) - sum(kube_statefulset_status_replicas_ready{statefulset=~"opensearch-logs.*"}) > 0
-    for: 30m
-    labels:
-      context: nodes
-      service: logs
-      severity: warning
-      support_group: observability
-      tier: os
-      playbook: docs/operation/elastic_kibana_issues/generic/cluster-yellow-no-resync
-      dashboard: health-elasticsearch?var-cluster=opensearch-logs
-    annotations:
-      description: 'Opensearch cluster *opensearch-logs* in `{{ $labels.region }}` is YELLOW. Please check all nodes.
-        nodes one or more are missing.'
-      summary: 'Opensearch cluster *opensearch-logs* in `{{ $labels.region }}` is YELLOW'

--- a/system/opensearch-logs/alerts/scaleout/opensearch.alerts
+++ b/system/opensearch-logs/alerts/scaleout/opensearch.alerts
@@ -1,0 +1,18 @@
+groups:
+- name: opensearch-logs.alerts
+  rules:
+  - alert: OpensearchLogsClusterYellow
+    expr: opensearch_cluster_status{elastic_cluster="opensearch-logs",pod=~".*-master-0"} == 1 and sum(kube_statefulset_replicas{statefulset=~"opensearch-logs.*"}) - sum(kube_statefulset_status_replicas_ready{statefulset=~"opensearch-logs.*"}) > 0
+    for: 30m
+    labels:
+      context: nodes
+      service: logs
+      severity: warning
+      support_group: observability
+      tier: os
+      playbook: docs/operation/elastic_kibana_issues/generic/cluster-yellow-no-resync
+      dashboard: health-elasticsearch?var-cluster=opensearch-logs
+    annotations:
+      description: 'Opensearch cluster *opensearch-logs* in `{{ $labels.region }}` is YELLOW. Please check all nodes.
+        nodes one or more are missing.'
+      summary: 'Opensearch cluster *opensearch-logs* in `{{ $labels.region }}` is YELLOW'

--- a/system/opensearch-logs/templates/prometheus-alerts.yaml
+++ b/system/opensearch-logs/templates/prometheus-alerts.yaml
@@ -1,7 +1,8 @@
 {{- if eq .Values.global.clusterType "scaleout" }}
 {{- $values := .Values }}
 {{- if $values.alerts.enabled }}
-{{- range $path, $bytes := .Files.Glob "alerts/*.alerts" }}
+{{- range $i, $target := $values.alerts.prometheus }}
+{{- range $path, $bytes := $.Files.Glob (printf "alerts/%s/*.alerts" $target.name) }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
@@ -12,11 +13,12 @@ metadata:
     app: opensearch
     tier: os
     type: alerting-rules
-    prometheus: {{ required ".Values.alerts.prometheus missing" $values.alerts.prometheus | quote }}
+    {{ $target.type | required (printf "$values.alerts.prometheus.[%v].type missing" $i) }}: {{ $target.name | required (printf "$values.alerts.prometheus.[%v].name missing" $i) }}
 
 spec:
 {{ printf "%s" $bytes | indent 2 }}
 
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/system/opensearch-logs/values.yaml
+++ b/system/opensearch-logs/values.yaml
@@ -20,7 +20,11 @@ seq_num: 0
 
 alerts:
   enabled: false
-  prometheus: infra-frontend
+  prometheus: 
+    - name: infra-frontend
+      type: prometheus
+    - name: scaleout
+      type: thanos-ruler
 
 opensearch_master:
   enabled: false


### PR DESCRIPTION
With Thanos, it is no longer necessary to have kube-state-metrics available in multiple Prometheus. Kubernetes Prometheus keeps kube_ metrics available so that they only need to be maintained in one place. Dependent services have been adjusted accordingly so that no absent metric alerts are generated.