### PR TITLE
[Cinder] Update mariadb chart to 0.7.12

### DIFF
--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.10.1
+  version: 0.10.4
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.8
+  version: 0.7.12
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.7
@@ -20,5 +20,5 @@ dependencies:
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:2cd932f1fd6a1f9aa6c9e0bdb2ffead607f675cc32559717c693e01a2c5b826e
-generated: "2023-07-14T09:27:35.610854+02:00"
+digest: sha256:ee18aa28bbcfe8acadd3dac09f64fba4bfe0c4fe50664f50b5e2bc13991dd952
+generated: "2023-10-23T08:23:50.238599-04:00"

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
     version: ~0.10.0
   - name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.7.8
+    version: 0.7.12
     condition: mariadb.enabled
   - name: mysql_metrics
     repository: https://charts.eu-de-2.cloud.sap


### PR DESCRIPTION
This patch updates the mariadb chart to 0.7.12 to help prevent false positives with CinderMariaDBNotReady alerts.