### PR TITLE
elastiflow: move alerts partially to Thanos Rule

### DIFF
--- a/system/elastiflow/Chart.yaml
+++ b/system/elastiflow/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: ElastiFlow for NetFlow/SFlow data
 name: elastiflow
-version: 0.0.5
+version: 0.0.6
 dependencies:
   - name: elasticsearch
     alias: elasticsearch

--- a/system/elastiflow/alerts/infra-frontend/elastiflow.alerts
+++ b/system/elastiflow/alerts/infra-frontend/elastiflow.alerts
@@ -44,18 +44,3 @@ groups:
     annotations:
       description: 'Elastic cluster *elastiflow* in `{{ $labels.region }}` is RED. Please check all nodes.'
       summary: '*elastiflow* cluster in `{{ $labels.region }}` is RED'
-
-  - alert: ElastiflowClusterYellow
-    expr: es_cluster_status{elastic_cluster="elastiflow",pod=~".*-master-0"} == 1 and sum(kube_statefulset_replicas{statefulset=~"elastiflow.*"}) - sum(kube_statefulset_status_replicas_ready{statefulset=~"elastiflow.*"}) > 0
-    for: 30m
-    labels:
-      context: nodes
-      service: logs
-      severity: warning
-      support_group: observability
-      playbook: docs/operation/elastic_kibana_issues/generic/cluster-yellow-no-resync
-      dashboard: health-elasticsearch?var-cluster=elastiflow
-    annotations:
-      description: 'Elastic cluster *elastiflow* in `{{ $labels.region }}` is YELLOW. Please check all nodes.
-        nodes one or more are missing.'
-      summary: 'Elastic cluster *elastiflow* in `{{ $labels.region }}` is YELLOW'

--- a/system/elastiflow/alerts/scaleout/elastiflow.alerts
+++ b/system/elastiflow/alerts/scaleout/elastiflow.alerts
@@ -1,0 +1,17 @@
+groups:
+- name: elastiflow.alerts
+  rules:
+  - alert: ElastiflowClusterYellow
+    expr: es_cluster_status{elastic_cluster="elastiflow",pod=~".*-master-0"} == 1 and sum(kube_statefulset_replicas{statefulset=~"elastiflow.*"}) - sum(kube_statefulset_status_replicas_ready{statefulset=~"elastiflow.*"}) > 0
+    for: 30m
+    labels:
+      context: nodes
+      service: logs
+      severity: warning
+      support_group: observability
+      playbook: docs/operation/elastic_kibana_issues/generic/cluster-yellow-no-resync
+      dashboard: health-elasticsearch?var-cluster=elastiflow
+    annotations:
+      description: 'Elastic cluster *elastiflow* in `{{ $labels.region }}` is YELLOW. Please check all nodes.
+        nodes one or more are missing.'
+      summary: 'Elastic cluster *elastiflow* in `{{ $labels.region }}` is YELLOW'

--- a/system/elastiflow/templates/prometheus-alerts.yaml
+++ b/system/elastiflow/templates/prometheus-alerts.yaml
@@ -1,7 +1,8 @@
 {{- if eq .Values.global.clusterType "scaleout" }}
 {{- $values := .Values }}
 {{- if $values.alerts.enabled }}
-{{- range $path, $bytes := .Files.Glob "alerts/*.alerts" }}
+{{- range $i, $target := $values.alerts.prometheus }}
+{{- range $path, $bytes := $.Files.Glob (printf "alerts/%s/*.alerts" $target.name) }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
@@ -12,11 +13,12 @@ metadata:
     app: elastiflow
     tier: os
     type: alerting-rules
-    prometheus: {{ required ".Values.alerts.prometheus missing" $values.alerts.prometheus | quote }}
+    {{ $target.type | required (printf "$values.alerts.prometheus.[%v].type missing" $i) }}: {{ $target.name | required (printf "$values.alerts.prometheus.[%v].name missing" $i) }}
 
 spec:
 {{ printf "%s" $bytes | indent 2 }}
 
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/system/elastiflow/values.yaml
+++ b/system/elastiflow/values.yaml
@@ -10,7 +10,11 @@ owner-info:
 alerts:
   enabled: false
   # Name of the Prometheus to which the alerts should be assigned to.
-  prometheus: infra-frontend
+  prometheus:
+    - name: infra-frontend
+      type: prometheus
+    - name: scaleout
+      type: thanos-ruler
 
 curator:
   enabled: false


### PR DESCRIPTION
With Thanos, it is no longer necessary to have kube-state metrics available in multiple Prometheus. Kubernetes Prometheus keeps these metrics available so that they only need to be maintained in one place. Dependent services have been adjusted accordingly so that no absent metric alerts are generated.