### PR TITLE
poller chart: fixing volume mount

### DIFF
--- a/openstack/poller/templates/deployment.yaml
+++ b/openstack/poller/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
               mountPath: "/poller/mx-records.json"
             {{- end }}
             {{- if $val.mxrecords }}
-            - name: configmx
+            - name: poller-mx-records
               mountPath: "/poller/mx-records.json"
             {{- end }}
       terminationGracePeriodSeconds: {{ $val.terminationGracePeriod | default 60 }}


### PR DESCRIPTION
It looks like the volume name was changed but not the volume mount for `poller-mx-records`