### PR TITLE
adjustable storage config name

### DIFF
--- a/common/thanos/Chart.yaml
+++ b/common/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: Deploy Thanos via operator
 type: application
-version: 0.5.4
+version: 0.5.5
 appVersion: v0.28.1
 maintainers:
   - name: Tommy Sauer (viennaa)

--- a/common/thanos/templates/_thanos_helpers.tpl
+++ b/common/thanos/templates/_thanos_helpers.tpl
@@ -79,7 +79,11 @@ thanos-{{- $host -}}-grpc.{{- required ".Values.global.region missing" $root.Val
 {{- define "thanos.objectStorageConfigName" -}}
 {{- $name := index . 0 -}}
 {{- $root := index . 1 -}}
+{{- if $root.Values.objectStorageConfigName -}} 
+{{- $root.Values.objectStorageConfigName -}}
+{{- else -}}
 prometheus-{{- include "thanos.name" . -}}-thanos-storage-config
+{{- end -}}
 {{- end -}}
 
 {{- define "thanos.defaultRelabelConfig" -}}

--- a/common/thanos/values.yaml
+++ b/common/thanos/values.yaml
@@ -68,6 +68,9 @@ swiftStorageConfig:
   regionName:
   containerName:
 
+# needed when custom names for Thanos are used. Usually goes with a remapping of containerName and userName
+objectStorageConfigName:
+
 # Specification for Thanos image
 spec:
   baseImage: keppel.eu-de-1.cloud.sap/ccloud-quay-mirror/thanos/thanos


### PR DESCRIPTION
when having a name crunch with thanos and prometheus and different containeres are used, the auto generated storage-config-secret is not matching.