### PR TITLE
[nova] Update mariadb to 0.7.16 & Configure VPA

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.5
+  version: 0.7.16
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.5
+  version: 0.7.16
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.7
@@ -16,15 +16,15 @@ dependencies:
   version: 0.1.1
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.10.1
+  version: 0.10.4
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.5
+  version: 0.7.16
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.5.2
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:fa411e9e8f6a121ae32bbe8a2665da4e91cfdbf3d0ba24b1e0b3594fd5dae70d
-generated: "2023-07-21T12:45:13.080980573+02:00"
+digest: sha256:d52304043fbcc353cf801d81ad7a18a73942ec3181b12a50736d5a66446f0988
+generated: "2023-10-24T13:49:21.354124859+02:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -8,12 +8,12 @@ dependencies:
   - name: mariadb
     condition: mariadb.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.7.5
+    version: 0.7.16
   - name: mariadb
     alias: mariadb_api
     condition: mariadb_api.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.7.5
+    version: 0.7.16
   - name: mysql_metrics
     condition: mariadb.enabled
     repository: https://charts.eu-de-2.cloud.sap
@@ -31,7 +31,7 @@ dependencies:
     alias: mariadb_cell2
     condition: mariadb_cell2.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.7.5
+    version: 0.7.16
   - name: rabbitmq
     alias: rabbitmq_cell2
     condition: cell2.enabled

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -700,6 +700,8 @@ mariadb:
   name: nova
   initdb_configmap: true
   long_query_time: 8
+  vpa:
+    set_main_container: true
   databases:
   - nova
   - nova_cell0
@@ -738,6 +740,8 @@ mariadb_api:
   name: nova-api
   initdb_configmap: true
   long_query_time: 8
+  vpa:
+    set_main_container: true
   databases:
   - nova_api
   users:
@@ -769,6 +773,8 @@ mariadb_cell2:
   log_file_size: "1024M"
   initdb_configmap: true
   long_query_time: 8
+  vpa:
+    set_main_container: true
   persistence_claim:
     name: db-nova-cell2-pvc
     size: "50Gi"


### PR DESCRIPTION
Enable `set_main_container` config for mariadb chart, giving the
mariadb container 75% of its pod's resources.

mariadb chart changes (newest-to-oldest):
- Rolling back Security Patches 10.5.21 to 10.5.17
- Enable VPA for mariadb container (#5443)
- metric was renamed (#5339)
- Security Patches upgrade to 10.5.21
    - Mariadb upgrade from 10.5.17 to 10.5.21
    - mysqld-exporter upgrade from v0.12.1 to v0.14.0
- improve MariaDBNotReady alert
- updates backupv2 base image (#5128)
- use non-deprecated topology labels (#5087)
- explicitly add some namespace metadata
- version bump for slow log alert fix
- fixes slow_query log setting in backup tool (#4787)
- Backup Slow log fix
- Security Patches upgrade to 10.5.17
