### PR TITLE
[Nova] Bump mariadb chart to 0.7.17

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.16
+  version: 0.7.17
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.16
+  version: 0.7.17
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.7
@@ -19,12 +19,12 @@ dependencies:
   version: 0.10.4
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.16
+  version: 0.7.17
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.5.2
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:d52304043fbcc353cf801d81ad7a18a73942ec3181b12a50736d5a66446f0988
-generated: "2023-10-24T13:49:21.354124859+02:00"
+digest: sha256:4e88d2c0dce9cf2625095740079ac471c3948c713f9ba24200956e1ace9909a4
+generated: "2023-10-25T10:08:21.035154843+02:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -8,12 +8,12 @@ dependencies:
   - name: mariadb
     condition: mariadb.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.7.16
+    version: 0.7.17
   - name: mariadb
     alias: mariadb_api
     condition: mariadb_api.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.7.16
+    version: 0.7.17
   - name: mysql_metrics
     condition: mariadb.enabled
     repository: https://charts.eu-de-2.cloud.sap
@@ -31,7 +31,7 @@ dependencies:
     alias: mariadb_cell2
     condition: mariadb_cell2.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.7.16
+    version: 0.7.17
   - name: rabbitmq
     alias: rabbitmq_cell2
     condition: cell2.enabled


### PR DESCRIPTION
This moves the main-container annotation to the right place.