### PR TITLE
[designate-nanny] increasing resource limits to prevent crashes and OOM

### DIFF
--- a/openstack/designate-nanny/values.yaml
+++ b/openstack/designate-nanny/values.yaml
@@ -14,10 +14,10 @@ image:
 resources:
   requests:
     memory: "128Mi"
-    cpu: "50m"
+    cpu: "100m"
   limits:
-    memory: "256Mi"
-    cpu: "80m"
+    memory: "512Mi"
+    cpu: "800m"
 
 credentials:
   designate_api:


### PR DESCRIPTION
The nanny was oom killed and cpu limits lead to timeouts fetching the AXFR from designate.