### PR TITLE
Poller: comment out values that are optional

### DIFF
--- a/openstack/poller/values.yaml
+++ b/openstack/poller/values.yaml
@@ -76,11 +76,14 @@ poller:
   keystone:
     authUrl:
     endpointType: public
-    projectDomainName: default
-    projectName:
-    region:
-    username:
-    password:
+    # the following values are optional depending on how you are authenticating
+    # projectDomainName: default
+    # projectName:
+    # region:
+    # username:
+    # password:
+    # applicationCredentialID:
+    # applicationCredentialSecret:
   # use mxrecords only if ldap is not configured
   # mxrecords: |
   #    {


### PR DESCRIPTION
Due to the way the chart is, we need to comment out these values that are not used/required. Instead, we should not just loop over all keystone kv pairs, and instead have them more hardcoded. IMO this would provide a more user-friendly use of the chart