### PR TITLE
[rabbitmq][mariadb][memcached] linkerd annotation support added

### DIFF
--- a/common/mariadb-galera/.gitignore
+++ b/common/mariadb-galera/.gitignore
@@ -1,0 +1,4 @@
+.vscode/launch.json
+**/.DS_Store
+helm/custom/
+**/templates/secrets.json

--- a/common/mariadb-galera/.gitignore
+++ b/common/mariadb-galera/.gitignore
@@ -1,4 +1,2 @@
-.vscode/launch.json
-**/.DS_Store
 helm/custom/
 **/templates/secrets.json

--- a/common/mariadb-galera/helm/.helmignore
+++ b/common/mariadb-galera/helm/.helmignore
@@ -1,0 +1,24 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+*.gotmpl
+custom/
+templates/secrets.json

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.7.17
+version: 0.8.0

--- a/common/mariadb/templates/backup-v2-deployment.yaml
+++ b/common/mariadb/templates/backup-v2-deployment.yaml
@@ -26,6 +26,9 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
 {{- end }}
+{{- if or (and (hasKey $.Values "global") (and (hasKey $.Values.global "linkerd_enabled") $.Values.global.linkerd_enabled) (and (hasKey $.Values.global "linkerd_requested") $.Values.global.linkerd_requested)) $.Values.linkerd.backup.enabled }}
+        linkerd.io/inject: enabled
+{{- end }}
     spec:
       affinity:
 {{- if .Values.nodeAffinity }}

--- a/common/mariadb/templates/backup-verify-deploy.yaml
+++ b/common/mariadb/templates/backup-verify-deploy.yaml
@@ -26,6 +26,9 @@ spec:
         prometheus.io/port: "8082"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
 {{- end }}
+{{- if or (and (hasKey $.Values "global") (and (hasKey $.Values.global "linkerd_enabled") $.Values.global.linkerd_enabled) (and (hasKey $.Values.global "linkerd_requested") $.Values.global.linkerd_requested)) $.Values.linkerd.backup.enabled }}
+        linkerd.io/inject: enabled
+{{- end }}
     spec:
       serviceAccountName: {{ .Values.name }}-db-backup-v2
       containers:

--- a/common/mariadb/templates/deployment.yaml
+++ b/common/mariadb/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
 {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
         linkerd.io/inject: enabled
 {{- end }}
+{{- if or (and (hasKey $.Values "global") (and (hasKey $.Values.global "linkerd_enabled") $.Values.global.linkerd_enabled) (and (hasKey $.Values.global "linkerd_requested") $.Values.global.linkerd_requested)) $.Values.linkerd.mariadb.enabled }}
+        linkerd.io/inject: enabled
+{{- end }}
     spec:
       affinity:
         nodeAffinity:

--- a/common/mariadb/templates/deployment.yaml
+++ b/common/mariadb/templates/deployment.yaml
@@ -30,6 +30,9 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
 {{- end }}
+{{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
+        linkerd.io/inject: enabled
+{{- end }}
     spec:
       affinity:
         nodeAffinity:

--- a/common/mariadb/templates/service.yaml
+++ b/common/mariadb/templates/service.yaml
@@ -9,9 +9,6 @@ metadata:
     type: database
     component: {{.Values.name}}
   annotations:
-{{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
-    linkerd.io/inject: enabled
-{{- end }}
 spec:
   type: ClusterIP
   selector:

--- a/common/mariadb/templates/service.yaml
+++ b/common/mariadb/templates/service.yaml
@@ -8,7 +8,10 @@ metadata:
     system: openstack
     type: database
     component: {{.Values.name}}
-
+  annotations:
+{{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
+    linkerd.io/inject: enabled
+{{- end }}
 spec:
   type: ClusterIP
   selector:
@@ -32,6 +35,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  annotations:
+{{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
+    linkerd.io/inject: enabled
+{{- end }}
 spec:
   selector:
     app: {{ include "fullName" . }}-backup

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -176,3 +176,11 @@ vpa:
   # The maximum available capacity is split evenly across containers specified in the Deployment, StatefulSet or DaemonSet to derive the upper recommendation bound. This does not work out for pods with a single resource-hungry container with several sidecar containers
   # Annotate the Deployment, StatefulSet or DaemonSet with vpa-butler.cloud.sap/main-container=$MAIN_CONTAINER. That will distribute 75% of the maximum available capacity to the main container and the rest evenly across all others
   set_main_container: false
+
+linkerd:
+  mariadb:
+    #linkerd annotation for the MariaDB pod (true/false)
+    enabled:
+  backup:
+    #linkerd annotation for the backup pod (true/false)
+    enabled:

--- a/common/memcached/templates/deployment.yaml
+++ b/common/memcached/templates/deployment.yaml
@@ -26,9 +26,9 @@ spec:
         app: {{ template "fullname" . }}
         component: memcached
       annotations:
-        {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
+{{- if or (and (hasKey $.Values "global") (and (hasKey $.Values.global "linkerd_enabled") $.Values.global.linkerd_enabled) (and (hasKey $.Values.global "linkerd_requested") $.Values.global.linkerd_requested)) $.Values.linkerd.enabled }}
         linkerd.io/inject: enabled
-        {{- end }}
+{{- end }}
     spec:
       affinity:
         nodeAffinity:

--- a/common/memcached/templates/service.yaml
+++ b/common/memcached/templates/service.yaml
@@ -9,9 +9,6 @@ metadata:
     heritage: "{{ .Release.Service }}"
     component: memcached
   annotations:
-    {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
-    linkerd.io/inject: enabled
-    {{- end }}
     {{- if .Values.metrics.enabled }}
     prometheus.io/scrape: "true"
     prometheus.io/port: {{ required ".Values.metrics.port missing" .Values.metrics.port | quote }}

--- a/common/memcached/values.yaml
+++ b/common/memcached/values.yaml
@@ -86,3 +86,7 @@ alerts:
   # Define the threshold for the MemcachedManyConnectionsThrottled alert in
   # yielded connections per minute
   yielded_connections_threshold: 5
+
+linkerd:
+  #linkerd annotation for the Memcached pod (true/false)
+  enabled:

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 0.5.2
+version: 0.6.0
 description: A Helm chart for RabbitMQ
 sources:
 - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/templates/deployment.yaml
+++ b/common/rabbitmq/templates/deployment.yaml
@@ -30,6 +30,9 @@ spec:
         app: {{ template "fullname" . }}
       annotations:
         checksum/container.init: {{ include (print $.Template.BasePath "/bin-configmap.yaml") . | sha256sum }}
+{{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
+        linkerd.io/inject: enabled
+{{- end }}
     spec:
       affinity:
         nodeAffinity:

--- a/common/rabbitmq/templates/deployment.yaml
+++ b/common/rabbitmq/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         app: {{ template "fullname" . }}
       annotations:
         checksum/container.init: {{ include (print $.Template.BasePath "/bin-configmap.yaml") . | sha256sum }}
-{{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
+{{- if or (and (hasKey $.Values "global") (and (hasKey $.Values.global "linkerd_enabled") $.Values.global.linkerd_enabled) (and (hasKey $.Values.global "linkerd_requested") $.Values.global.linkerd_requested)) $.Values.linkerd.enabled }}
         linkerd.io/inject: enabled
 {{- end }}
     spec:

--- a/common/rabbitmq/templates/headless-service.yaml
+++ b/common/rabbitmq/templates/headless-service.yaml
@@ -11,6 +11,10 @@ metadata:
     type: rabbitmq
     component: {{ .Release.Name }}
     system: openstack
+  annotations:
+{{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
+    linkerd.io/inject: enabled
+{{- end }}
 spec:
   selector:
     app: {{ template "fullname" . }}

--- a/common/rabbitmq/templates/service.yaml
+++ b/common/rabbitmq/templates/service.yaml
@@ -16,9 +16,6 @@ metadata:
     prometheus.io/port: {{ required ".Values.metrics.port missing" .Values.metrics.port | quote }}
     prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
 {{- end }}
-{{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
-    linkerd.io/inject: enabled
-{{- end }}
 spec:
   ports:
     - name: public

--- a/common/rabbitmq/templates/service.yaml
+++ b/common/rabbitmq/templates/service.yaml
@@ -16,6 +16,9 @@ metadata:
     prometheus.io/port: {{ required ".Values.metrics.port missing" .Values.metrics.port | quote }}
     prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
 {{- end }}
+{{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
+    linkerd.io/inject: enabled
+{{- end }}
 spec:
   ports:
     - name: public

--- a/common/rabbitmq/templates/statefulset.yaml
+++ b/common/rabbitmq/templates/statefulset.yaml
@@ -23,6 +23,9 @@ spec:
       labels:
         app: {{ template "fullname" . }}
       annotations:
+{{- if or (and (hasKey $.Values "global") (and (hasKey $.Values.global "linkerd_enabled") $.Values.global.linkerd_enabled) (and (hasKey $.Values.global "linkerd_requested") $.Values.global.linkerd_requested)) $.Values.linkerd.enabled }}
+        linkerd.io/inject: enabled
+{{- end }}
         checksum/container.init: {{ include (print $.Template.BasePath "/bin-configmap.yaml") . | sha256sum }}
     spec:
       affinity:
@@ -65,7 +68,7 @@ spec:
         {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
           tcpSocket:
-            port: public 
+            port: public
           failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}

--- a/common/rabbitmq/values.yaml
+++ b/common/rabbitmq/values.yaml
@@ -112,3 +112,7 @@ upgrades:
 #  rollingUpdate:
 #    maxUnavailable: 1
 #    maxSurge: 3
+
+linkerd:
+  #linkerd annotation for the RabbitMQ pod (true/false)
+  enabled:


### PR DESCRIPTION
- parameter added to enable the annotation per pod type independent from the `global.linkerd_enabled` & `global.linkerd_requested` parameters
- chart version bumped
