### PR TITLE
[trust-manager] Central way to manage certificate trust bases

### DIFF
--- a/openstack/trust-manager/Chart.lock
+++ b/openstack/trust-manager/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: trust-manager
+  repository: https://charts.jetstack.io
+  version: v0.7.0
+- name: owner-info
+  repository: https://charts.eu-de-2.cloud.sap
+  version: 0.2.0
+digest: sha256:2431e22402f4c0f02e0e9dfbc9a43cd6b78774f3b0bfda0725d2fa2ee99b3f4d
+generated: "2023-10-31T11:24:32.482765875+01:00"

--- a/openstack/trust-manager/Chart.yaml
+++ b/openstack/trust-manager/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: trust-manager
+description: Importing Trust-Manager Chart into SAPCC environment
+type: application
+version: v0.7.0
+appVersion: v0.7.0
+dependencies:
+- name: trust-manager
+  version: ~0.7.0
+  repository: "https://charts.jetstack.io"
+- name: owner-info
+  repository: https://charts.eu-de-2.cloud.sap
+  version: ~0.2.0

--- a/openstack/trust-manager/templates/sapcc-bundle.yaml
+++ b/openstack/trust-manager/templates/sapcc-bundle.yaml
@@ -1,0 +1,20 @@
+{{ if .Capabilities.APIVersions.Has "trust.cert-manager.io/v1alpha1" -}}
+apiVersion: trust.cert-manager.io/v1alpha1
+kind: Bundle
+metadata:
+  name: cloud-sap # The bundle name will also be used for the target
+spec:
+  sources:
+  - useDefaultCAs: true
+  - configMap:
+      key: ca.crt
+      name: kube-root-ca.crt
+{{- if .Values.additional_sources }}
+  {{- .Values.additional_sources | toYaml | nindent 2 }}
+{{- end }}
+  target:
+    configMap:
+      key: "trust-bundle.pem"
+    namespaceSelector:
+      {{- .Values.namespaces | toYaml | nindent 6 }}
+{{- end }}

--- a/openstack/trust-manager/values.yaml
+++ b/openstack/trust-manager/values.yaml
@@ -1,0 +1,22 @@
+owner-info:
+  support-group: compute-storage-api
+  service: trust-manager
+  maintainers:
+  - Fabian Wiesel
+  helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/openstack/trust-manager
+
+trust-manager:
+  app:
+    trust:
+      namespace: kube-system
+  resources:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+namespaces:
+  matchLabels:
+    name: "monsoon3"


### PR DESCRIPTION
Instead of having to build our own images with the certificates baked in, we can centrally declare them all and just mount them in the way described here:
https://cert-manager.io/docs/tutorials/getting-started-with-trust-manager/