### PR TITLE
alertmanager: move Swift alerts from #cc-os-swift to #cc-swift

### DIFF
--- a/global/prometheus-alertmanager-operated/Chart.yaml
+++ b/global/prometheus-alertmanager-operated/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 description: Prometheus Alertmanager via operator.
 name: prometheus-alertmanager-operated
-version: 2.2.3
+version: 2.2.4
 
 dependencies:
   - alias: prometheus-alertmanager

--- a/global/prometheus-alertmanager-operated/templates/_alertmanager.yaml.tpl
+++ b/global/prometheus-alertmanager-operated/templates/_alertmanager.yaml.tpl
@@ -167,14 +167,14 @@ route:
     match_re:
       tier: os
       severity: info|warning|critical
-      service: arc|barbican|cinder|cronus|designate|documentation|elektra|elk|glance|ironic|lyra|manila|neutron|nova|octavia|placement|sentry|swift|snmp
+      service: arc|barbican|cinder|cronus|designate|documentation|elektra|elk|glance|ironic|lyra|manila|neutron|nova|octavia|placement|sentry|snmp
       region: qa-de-1|ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|ap-sa-2|eu-de-1|eu-de-2|eu-nl-1|la-br-1|na-ca-1|na-us-1|na-us-2|na-us-3
 
   - receiver: slack_by_cc_service
     continue: true
     match_re:
       severity: info|warning|critical
-      service: alerting|backup|castellum|cc3test|exporter|gatekeeper|grafana|hermes|jumpserver|keppel|limes|logs|maia|metis|metrics|repo|slack-alert-reactions|tenso
+      service: alerting|backup|castellum|cc3test|exporter|gatekeeper|grafana|hermes|jumpserver|keppel|limes|logs|maia|metis|metrics|repo|slack-alert-reactions|swift|tenso
       region: qa-de-1|ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|ap-sa-2|eu-de-1|eu-de-2|eu-nl-1|la-br-1|na-ca-1|na-us-1|na-us-2|na-us-3
 
   # to be reviewed


### PR DESCRIPTION
Same as for my own services that were already moved. This was discussed with the Swift service owners (cc @sumitarora2786).