### PR TITLE
Require an explicit policy group if >1 bindings per subgroup

### DIFF
--- a/openstack/neutron/templates/etc/_ml2-conf-aci.ini.tpl
+++ b/openstack/neutron/templates/etc/_ml2-conf-aci.ini.tpl
@@ -100,7 +100,7 @@ port_selectors = {{ $subgroup.port_selectors | join "," }}
 {{- if and (empty $subgroup.infra_pc_policy_group) (eq (len $subgroup.bindings) 1) }}
 infra_pc_policy_group = {{ (split "/" (index $subgroup.bindings 0))._3 }}
 {{ else }}
-infra_pc_policy_group = {{ $subgroup.infra_pc_policy_group }}
+infra_pc_policy_group = {{ required "If more than one direct binding is supplied, the field infra_pc_policy_group is mandatory" $subgroup.infra_pc_policy_group }}
 {{ end -}}
 {{- if or $aci_hostgroup.baremetal_pc_policy_group $subgroup.baremetal_pc_policy_group -}}
 baremetal_pc_policy_group = {{ default $aci_hostgroup.baremetal_pc_policy_group $subgroup.baremetal_pc_policy_group }}


### PR DESCRIPTION
The policy group was inferred to be the same name as the VPC profile's
first binding's name. This failed when our subgroups got multiple
bindings which lead to an empty string being rendered into the config.
This shouldn't go unnoticed so we prompt the user to supply an explicit
pc-group.
