### PR TITLE
[Nova] Remove configuration-snippet ingress annotation

### DIFF
--- a/openstack/nova/templates/api-ingress.yaml
+++ b/openstack/nova/templates/api-ingress.yaml
@@ -8,10 +8,6 @@ metadata:
     type: api
     component: nova
   annotations:
-    ingress.kubernetes.io/configuration-snippet: |
-      {{- include "utils.snippets.set_openstack_request_id" . | indent 6 }}
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      {{- include "utils.snippets.set_openstack_request_id" . | indent 6 }}
     {{- include "utils.snippets.set_ingress_cors_annotations" . | indent 4 }}
   {{- if .Values.use_tls_acme }}
     kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
Using `configuration-snippet` is disabled for security reasons. Setting the OpenStack request-id is by now integrated into the ingress itself.