### PR TITLE
[Placement] Remove configuration-snippet ingress annotation

### DIFF
--- a/openstack/placement/templates/placement-ingress.yaml
+++ b/openstack/placement/templates/placement-ingress.yaml
@@ -9,10 +9,6 @@ metadata:
     component: placement
   annotations:
     disco: "true"
-    ingress.kubernetes.io/configuration-snippet: |
-      {{- include "utils.snippets.set_openstack_request_id" . | indent 6 }}
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      {{- include "utils.snippets.set_openstack_request_id" . | indent 6 }}
   {{- if .Values.use_tls_acme }}
     kubernetes.io/tls-acme: "true"
   {{- end }}


### PR DESCRIPTION
Using `configuration-snippet` is disabled for security reasons. Setting the OpenStack request-id is by now integrated into the ingress itself.