### PR TITLE
[Cinder] Remove configuration-snippet ingress annotation

### DIFF
--- a/openstack/cinder/templates/api-ingress.yaml
+++ b/openstack/cinder/templates/api-ingress.yaml
@@ -8,11 +8,6 @@ metadata:
     type: api
     component: cinder
   annotations:
-    ingress.kubernetes.io/configuration-snippet: |
-      {{- include "utils.snippets.set_openstack_request_id" . | indent 6 }}
-    {{- include "utils.snippets.set_ingress_cors_annotations" . | indent 4 }}
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      {{- include "utils.snippets.set_openstack_request_id" . | indent 6 }}
     {{- include "utils.snippets.set_ingress_cors_annotations" . | indent 4 }}
   {{- if .Values.use_tls_acme }}
     kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
Using `configuration-snippet` is disabled for security reasons. Setting the OpenStack request-id is by now integrated into the ingress itself.