### PR TITLE
[Neutron] Remove configuration-snippet ingress annotation

### DIFF
--- a/openstack/neutron/templates/ingress-server.yaml
+++ b/openstack/neutron/templates/ingress-server.yaml
@@ -10,10 +10,6 @@ metadata:
   annotations:
     kubernetes.io/tls-acme: "true"
     disco: "true"
-    ingress.kubernetes.io/configuration-snippet: |
-      {{- include "utils.snippets.set_openstack_request_id" . | indent 6 }}
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      {{- include "utils.snippets.set_openstack_request_id" . | indent 6 }}
 spec:
   tls:
      - secretName: tls-{{include "neutron_api_endpoint_host_public" . | replace "." "-" }}


### PR DESCRIPTION
Using `configuration-snippet` is disabled for security reasons. Setting the OpenStack request-id is by now integrated into the ingress itself.