### PR TITLE
[Ironic] Remove configuration-snippet ingress annotation

### DIFF
--- a/openstack/ironic/templates/api-ingress.yaml
+++ b/openstack/ironic/templates/api-ingress.yaml
@@ -8,10 +8,6 @@ metadata:
     type: api
     component: ironic
   annotations:
-    ingress.kubernetes.io/configuration-snippet: |
-      {{- include "utils.snippets.set_openstack_request_id" . | indent 6 }}
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      {{- include "utils.snippets.set_openstack_request_id" . | indent 6 }}
     kubernetes.io/tls-acme: "true"
 spec:
   tls:


### PR DESCRIPTION
Using `configuration-snippet` is disabled for security reasons. Setting the OpenStack request-id is by now integrated into the ingress itself.