### PR TITLE
[trust-manager] Fix label selector for monsoon3 namespace

### DIFF
--- a/openstack/trust-manager/values.yaml
+++ b/openstack/trust-manager/values.yaml
@@ -19,4 +19,4 @@ trust-manager:
 
 namespaces:
   matchLabels:
-    name: "monsoon3"
+    kubernetes.io/metadata.name: monsoon3


### PR DESCRIPTION
the label `name` is apparently the old version of
`kubernetes.io/metadata.name`.