### PR TITLE
[linkerd-support] Add helper snippets

### DIFF
--- a/common/linkerd-support/Chart.yaml
+++ b/common/linkerd-support/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: linkerd-support
-version: 0.1.3
+version: 0.1.4
 description: Integration with Linkerd for your application

--- a/common/linkerd-support/README.md
+++ b/common/linkerd-support/README.md
@@ -56,6 +56,14 @@ metadata:
     {{- end }}
 ```
 
+or use the snippet
+
+```yaml
+metadata:
+  annotations:
+    {{- include "linkerd-support.snippets.pod_and_service_annotation" . | indent 4 }}
+```
+
 Use exactly this conditional statement around each such annotation.
 
 ### Simplified option: This Helm release is the only one in its namespace
@@ -88,6 +96,17 @@ metadata:
     ingress.kubernetes.io/service-upstream: "true"
     nginx.ingress.kubernetes.io/service-upstream: "true"
     {{- end }}
+```
+
+or use the snippet
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+
+metadata:
+  annotations:
+    {{- include "linkerd-support.snippets.ingress_annotation" . | indent 4 }}
 ```
 
 Use exactly this conditional statement around each such annotation.

--- a/common/linkerd-support/templates/_snippets.yaml
+++ b/common/linkerd-support/templates/_snippets.yaml
@@ -1,0 +1,12 @@
+{{- define "linkerd-support.snippets.pod_and_service_annotation" }}
+{{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
+linkerd.io/inject: enabled
+{{- end }}
+{{- end }}
+
+{{- define "linkerd-support.snippets.ingress_annotation" }}
+{{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
+ingress.kubernetes.io/service-upstream: "true"
+nginx.ingress.kubernetes.io/service-upstream: "true"
+{{- end }}
+{{- end }}


### PR DESCRIPTION
Instead of having to add 3 lines into every template, one can use these snippets and only add a single line. This also makes it easier to upgrade (most of) the annotations if necessary.