### PR TITLE
[utils] Add linkerd helpers

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.11.0
+version: 0.11.1

--- a/openstack/utils/templates/_linkerd.tpl
+++ b/openstack/utils/templates/_linkerd.tpl
@@ -1,0 +1,12 @@
+{{- define "utils.linkerd.pod_and_service_annotation" }}
+{{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
+linkerd.io/inject: enabled
+{{- end }}
+{{- end }}
+
+{{- define "utils.linkerd.ingress_annotation" }}
+{{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
+ingress.kubernetes.io/service-upstream: "true"
+nginx.ingress.kubernetes.io/service-upstream: "true"
+{{- end }}
+{{- end }}


### PR DESCRIPTION
While they might also seem to fit directly into the common/linkerd-support chart, they don't, because the snippets would not be helpful for all the charts consuming the linkerd-support chart. Specifically those in common/ would not be able to access them if their parent chart includes linkerd-support. Having the chart as extra dependency is also not wanted. Therefore, we add these helper snippets here to use them in the openstack charts.

There are 2 annotation helpers defined for which more documentation can be found in the README of the linkerd-support chart.

Instead of having to put the 3-4 lines in every template, these snippets allow us to add only one and also update it centrally.

---

For reference, I tried to add it into `linkerd-support` in #5556 