### PR TITLE
[Nova] Add basic linkerd support

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 0.1.1
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.10.4
+  version: 0.11.1
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.7.17
@@ -26,5 +26,8 @@ dependencies:
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:4e88d2c0dce9cf2625095740079ac471c3948c713f9ba24200956e1ace9909a4
-generated: "2023-10-25T10:08:21.035154843+02:00"
+- name: linkerd-support
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 0.1.3
+digest: sha256:1ef6db35dc4a4d8968792584f4622e6216bc8dad6553204aaff36f19f7b4539f
+generated: "2023-11-07T12:06:29.611070935+01:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     version: 0.1.1
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.10.0
+    version: ~0.11.1
   - name: mariadb
     alias: mariadb_cell2
     condition: mariadb_cell2.enabled
@@ -40,3 +40,6 @@ dependencies:
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0
+  - name: linkerd-support
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: 0.1.3

--- a/openstack/nova/templates/_console-service.yaml.tpl
+++ b/openstack/nova/templates/_console-service.yaml.tpl
@@ -9,6 +9,7 @@ metadata:
   name: nova-console-{{ $name }}
   annotations:
   {{- include "utils.topology.service_topology_mode" . | indent 2 }}
+  {{- include "utils.linkerd.pod_and_service_annotation" . | indent 4 }}
   labels:
     system: openstack
     type: backend

--- a/openstack/nova/templates/_console_deployment.yaml.tpl
+++ b/openstack/nova/templates/_console_deployment.yaml.tpl
@@ -39,6 +39,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
         {{- end }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
       {{- tuple . "nova" (print "console-" $name) | include "kubernetes_pod_anti_affinity" | nindent 6 }}
       {{- include "utils.proxysql.pod_settings" . | nindent 6 }}

--- a/openstack/nova/templates/api-deployment.yaml
+++ b/openstack/nova/templates/api-deployment.yaml
@@ -34,6 +34,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
         {{- end }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
       terminationGracePeriodSeconds: {{ .Values.defaults.default.graceful_shutdown_timeout | add 5 }}
       {{- tuple . (dict "name" "nova-api") | include "utils.topology.constraints" | indent 6 }}

--- a/openstack/nova/templates/api-ingress.yaml
+++ b/openstack/nova/templates/api-ingress.yaml
@@ -9,6 +9,7 @@ metadata:
     component: nova
   annotations:
     {{- include "utils.snippets.set_ingress_cors_annotations" . | indent 4 }}
+    {{- include "utils.linkerd.ingress_annotation" . | indent 4 }}
   {{- if .Values.use_tls_acme }}
     kubernetes.io/tls-acme: "true"
   {{- end }}

--- a/openstack/nova/templates/api-metadata-deployment.yaml
+++ b/openstack/nova/templates/api-metadata-deployment.yaml
@@ -34,6 +34,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
         {{- end }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
       {{- tuple . "nova" "api-metadata" | include "kubernetes_pod_anti_affinity" | nindent 6 }}
       {{- include "utils.proxysql.pod_settings" . | nindent 6 }}

--- a/openstack/nova/templates/api-metadata-service.yaml
+++ b/openstack/nova/templates/api-metadata-service.yaml
@@ -13,6 +13,7 @@ metadata:
     prometheus.io/port: "9102"
     prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
     {{- include "utils.topology.service_topology_mode" . | indent 2 }}
+    {{- include "utils.linkerd.pod_and_service_annotation" . | indent 4 }}
 
 spec:
   selector:

--- a/openstack/nova/templates/api-service.yaml
+++ b/openstack/nova/templates/api-service.yaml
@@ -13,6 +13,7 @@ metadata:
     prometheus.io/port: "9102"
     prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
     {{- include "utils.topology.service_topology_mode" . | indent 2 }}
+    {{- include "utils.linkerd.pod_and_service_annotation" . | indent 4 }}
 
 spec:
   selector:

--- a/openstack/nova/templates/bigvm-deployment.yaml
+++ b/openstack/nova/templates/bigvm-deployment.yaml
@@ -34,6 +34,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
         {{- end }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
 {{ tuple . "nova" "bigvm" | include "kubernetes_pod_anti_affinity" | indent 6 }}
       {{- include "utils.proxysql.pod_settings" . | indent 6 }}

--- a/openstack/nova/templates/cell2-conductor-deployment.yaml
+++ b/openstack/nova/templates/cell2-conductor-deployment.yaml
@@ -34,6 +34,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
         {{- end }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
         configmap-etc-hash: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
     spec:
       {{- tuple . "nova" "conductor" | include "kubernetes_pod_anti_affinity" | nindent 6 }}

--- a/openstack/nova/templates/conductor-deployment.yaml
+++ b/openstack/nova/templates/conductor-deployment.yaml
@@ -33,6 +33,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
         {{- end }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
         configmap-etc-hash: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
     spec:
       {{- tuple . "nova" "conductor" | include "kubernetes_pod_anti_affinity" | nindent 6 }}

--- a/openstack/nova/templates/console-ingress.yaml
+++ b/openstack/nova/templates/console-ingress.yaml
@@ -20,6 +20,7 @@ metadata:
   {{- if .Values.use_tls_acme }}
     kubernetes.io/tls-acme: "true"
   {{- end }}
+    {{- include "utils.linkerd.ingress_annotation" . | indent 4 }}
 spec:
   tls:
   - secretName: tls-{{include "nova_console_endpoint_host_public" . | replace "." "-" }}

--- a/openstack/nova/templates/console-shellinabox-deployment.yaml
+++ b/openstack/nova/templates/console-shellinabox-deployment.yaml
@@ -31,6 +31,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
         {{- end }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
         config-hash: {{ print (.Files.Glob "shellinabox/*").AsConfig (include "nova.etc_config_lua" .) | sha256sum }}
     spec:
       securityContext:

--- a/openstack/nova/templates/hypervisors/_ironic-deployment.yaml.tpl
+++ b/openstack/nova/templates/hypervisors/_ironic-deployment.yaml.tpl
@@ -33,6 +33,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
         {{- end }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
         configmap-etc-hash: {{ include (print .Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
         configmap-ironic-etc-hash: {{ tuple . $hypervisor | include "ironic_configmap" | sha256sum }}
     spec:

--- a/openstack/nova/templates/hypervisors/_kvm-deployment.yaml.tpl
+++ b/openstack/nova/templates/hypervisors/_kvm-deployment.yaml.tpl
@@ -26,6 +26,7 @@ spec:
         alert-service: nova
         hypervisor: "kvm"
       annotations:
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
         configmap-etc-hash: {{ include (print .Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
         configmap-ironic-etc-hash: {{ tuple . $hypervisor | include "kvm_configmap" | sha256sum }}
     spec:

--- a/openstack/nova/templates/hypervisors/hypervisors-vmware-deployment-vct.yaml
+++ b/openstack/nova/templates/hypervisors/hypervisors-vmware-deployment-vct.yaml
@@ -45,6 +45,7 @@ template: |
         annotations:
           prometheus.io/scrape: "true"
           prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
+          {{- include "utils.linkerd.pod_and_service_annotation" . | indent 10 }}
           configmap-etc-hash: {{ include (print .Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
           configmap-nova-compute-hash: {= "vcenter_cluster/{{ .Release.Namespace }}/vcenter-cluster-nova-compute-configmap.yaml.j2" | render | sha256sum =}
       spec:

--- a/openstack/nova/templates/scheduler-deployment.yaml
+++ b/openstack/nova/templates/scheduler-deployment.yaml
@@ -32,6 +32,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
         {{- end }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
         configmap-etc-hash: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
         configmap-scheduler-etc-hash: {{ include (print $.Template.BasePath "/scheduler-etc-configmap.yaml") . | sha256sum }}
     spec:

--- a/openstack/nova/templates/vspc-deployment.yaml
+++ b/openstack/nova/templates/vspc-deployment.yaml
@@ -27,6 +27,7 @@ spec:
         {{- tuple . "nova" "vspc" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | nindent 8 }}
         {{- include "utils.topology.pod_label" . | indent 8 }}
       annotations:
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
         configmap-etc-hash: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
     spec:
       hostname: nova-vspc

--- a/openstack/nova/templates/vspc-service.yaml
+++ b/openstack/nova/templates/vspc-service.yaml
@@ -5,6 +5,7 @@ metadata:
   name: nova-vspc
   annotations:
   {{- include "utils.topology.service_topology_mode" . | indent 2 }}
+  {{- include "utils.linkerd.pod_and_service_annotation" . | indent 4 }}
   labels:
     system: openstack
     type: backend

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -21,6 +21,8 @@ global:
   hypervisors_ironic: []
   osprofiler: {}
 
+  linkerd_requested: false
+
 osprofiler: {}
 
 auto_assign_aggregates: 'dry_run'


### PR DESCRIPTION
This adds the `linkerd-support` chart as dependency and also adds the annotations to all `Deployment`, `Service` and `Ingress` objects. `Job` objects are out of the picture for now, because they need more than just annotations as we need to shut down linkerd for the pod to shut down. There will be a follow-up to support these.

linkerd is disabled by default and needs to be enabled per region.

We depend on the `utils` chart for the annotation snippets and the conditions so our templates stay more compact and thus better readable.