### PR TITLE
[rabbitmq] add linkerd annotation

### DIFF
--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 0.5.2
+version: 0.6.0
 description: A Helm chart for RabbitMQ
 sources:
 - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/templates/deployment.yaml
+++ b/common/rabbitmq/templates/deployment.yaml
@@ -30,6 +30,9 @@ spec:
         app: {{ template "fullname" . }}
       annotations:
         checksum/container.init: {{ include (print $.Template.BasePath "/bin-configmap.yaml") . | sha256sum }}
+{{- if and (and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested) $.Values.linkerd.enabled }}
+        linkerd.io/inject: enabled
+{{- end }}
     spec:
       affinity:
         nodeAffinity:

--- a/common/rabbitmq/templates/headless-service.yaml
+++ b/common/rabbitmq/templates/headless-service.yaml
@@ -11,6 +11,10 @@ metadata:
     type: rabbitmq
     component: {{ .Release.Name }}
     system: openstack
+  annotations:
+{{- if and (and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested) $.Values.linkerd.enabled }}
+    linkerd.io/inject: enabled
+{{- end }}
 spec:
   selector:
     app: {{ template "fullname" . }}

--- a/common/rabbitmq/templates/service.yaml
+++ b/common/rabbitmq/templates/service.yaml
@@ -10,11 +10,14 @@ metadata:
     type: rabbitmq
     component: {{ .Release.Name }}
     system: openstack
-{{- if .Values.metrics.enabled }}
   annotations:
+{{- if .Values.metrics.enabled }}
     prometheus.io/scrape: "true"
     prometheus.io/port: {{ required ".Values.metrics.port missing" .Values.metrics.port | quote }}
     prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
+{{- end }}
+{{- if and (and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested) $.Values.linkerd.enabled }}
+    linkerd.io/inject: enabled
 {{- end }}
 spec:
   ports:

--- a/common/rabbitmq/templates/statefulset.yaml
+++ b/common/rabbitmq/templates/statefulset.yaml
@@ -23,6 +23,9 @@ spec:
       labels:
         app: {{ template "fullname" . }}
       annotations:
+{{- if and (and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested) $.Values.linkerd.enabled }}
+        linkerd.io/inject: enabled
+{{- end }}
         checksum/container.init: {{ include (print $.Template.BasePath "/bin-configmap.yaml") . | sha256sum }}
     spec:
       affinity:
@@ -65,7 +68,7 @@ spec:
         {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
           tcpSocket:
-            port: public 
+            port: public
           failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}

--- a/common/rabbitmq/values.yaml
+++ b/common/rabbitmq/values.yaml
@@ -112,3 +112,7 @@ upgrades:
 #  rollingUpdate:
 #    maxUnavailable: 1
 #    maxSurge: 3
+
+linkerd:
+  # linkerd annotation for the RabbitMQ pod (true/false)
+  enabled: true


### PR DESCRIPTION
adding support for linkerd annotation to rabbitmq helm chart the annotation can be activated by setting up the following global values to true :
```
.Values.global.linkerd_enabled = true
.Values.global.linkerd_requested = true
```

if the previous values are set globally in the top level Chart, you can deactivate the annotation for this particular chart by overriding:` .Values.linkerd.enabled` to `false` (default true)

for more information about linkerd lease find:
https://github.com/sapcc/helm-charts/tree/master/common/linkerd-support

splitting PR: https://github.com/sapcc/helm-charts/pull/5532 into multiple PRs per helm chart