### PR TITLE
[memcached] add linkerd annotation

### DIFF
--- a/common/memcached/templates/deployment.yaml
+++ b/common/memcached/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         app: {{ template "fullname" . }}
         component: memcached
       annotations:
-        {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
+        {{- if and (and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested) $.Values.linkerd.enabled }}
         linkerd.io/inject: enabled
         {{- end }}
     spec:

--- a/common/memcached/values.yaml
+++ b/common/memcached/values.yaml
@@ -86,3 +86,8 @@ alerts:
   # Define the threshold for the MemcachedManyConnectionsThrottled alert in
   # yielded connections per minute
   yielded_connections_threshold: 5
+
+global: {}
+linkerd:
+  #linkerd annotation for the Memcached pod (true/false)
+  enabled: true


### PR DESCRIPTION
adding support for linkerd annotation to memcached helm chart the annotation can be activated by setting up the following values to true :

```
.Values.global.linkerd_enabled = true
.Values.global.linkerd_requested = true
```
if the previous values are set globally in the top level Chart, you can deactivate the annotation for this particular chart by overriding: `.Values.linkerd.enabled` to `false` (default true)

for more information about linkerd please find:
https://github.com/sapcc/helm-charts/tree/master/common/linkerd-support

splitting PR: https://github.com/sapcc/helm-charts/pull/5532 into multiple PRs per helm chart
