### PR TITLE
[mariadb] add linkerd annotation

### DIFF
--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.7.18
+version: 0.8.0

--- a/common/mariadb/templates/backup-ingress.yaml
+++ b/common/mariadb/templates/backup-ingress.yaml
@@ -14,6 +14,10 @@ metadata:
     nginx.ingress.kubernetes.io/auth-response-headers: "Authorization, X-Auth-Request-Email, X-Auth-Request-User, X-Forwarded-Access-Token"
 {{- end }}
     kubernetes.io/tls-acme: "true"
+{{- if and (and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested) $.Values.linkerd.backup.enabled }}
+    ingress.kubernetes.io/service-upstream: "true"
+    nginx.ingress.kubernetes.io/service-upstream: "true"
+{{- end }}
   name:  {{ include "fullName" . }}-backup
 
 spec:

--- a/common/mariadb/templates/backup-v2-deployment.yaml
+++ b/common/mariadb/templates/backup-v2-deployment.yaml
@@ -26,6 +26,9 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
 {{- end }}
+{{- if and (and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested) $.Values.linkerd.backup.enabled }}
+        linkerd.io/inject: enabled
+{{- end }}
     spec:
       affinity:
 {{- if .Values.nodeAffinity }}

--- a/common/mariadb/templates/backup-verify-deploy.yaml
+++ b/common/mariadb/templates/backup-verify-deploy.yaml
@@ -26,6 +26,9 @@ spec:
         prometheus.io/port: "8082"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
 {{- end }}
+{{- if and (and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested) $.Values.linkerd.backup.enabled }}
+        linkerd.io/inject: enabled
+{{- end }}
     spec:
       serviceAccountName: {{ .Values.name }}-db-backup-v2
       containers:

--- a/common/mariadb/templates/deployment.yaml
+++ b/common/mariadb/templates/deployment.yaml
@@ -30,6 +30,9 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
 {{- end }}
+{{- if and (and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested) $.Values.linkerd.mariadb.enabled }}
+        linkerd.io/inject: enabled
+{{- end }}
     spec:
       affinity:
         nodeAffinity:

--- a/common/mariadb/templates/service.yaml
+++ b/common/mariadb/templates/service.yaml
@@ -8,7 +8,10 @@ metadata:
     system: openstack
     type: database
     component: {{.Values.name}}
-
+  annotations:
+{{- if and (and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested) $.Values.linkerd.mariadb.enabled }}
+    linkerd.io/inject: enabled
+{{- end }}
 spec:
   type: ClusterIP
   selector:
@@ -32,6 +35,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  annotations:
+{{- if and (and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested) $.Values.linkerd.backup.enabled }}
+    linkerd.io/inject: enabled
+{{- end }}
 spec:
   selector:
     app: {{ include "fullName" . }}-backup

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -176,3 +176,11 @@ vpa:
   # The maximum available capacity is split evenly across containers specified in the Deployment, StatefulSet or DaemonSet to derive the upper recommendation bound. This does not work out for pods with a single resource-hungry container with several sidecar containers
   # Annotate the Deployment, StatefulSet or DaemonSet with vpa-butler.cloud.sap/main-container=$MAIN_CONTAINER. That will distribute 75% of the maximum available capacity to the main container and the rest evenly across all others
   set_main_container: false
+linkerd:
+  mariadb:
+    #linkerd annotation for the MariaDB pod (true/false)
+    enabled: true
+  backup:
+    #linkerd annotation for the backup pod (true/false)
+    enabled: true
+global: {}


### PR DESCRIPTION
adding support for linkerd annotation to mariadb helm chart the annotation can be activated by setting up the following values to true:
```
.Values.global.linkerd_enabled = true
.Values.global.linkerd_requested = true

```
if the previous values are set globally in the top level Chart, you can deactivate the annotation for parts of the chart as the following:
- deactivate linkerd annotations for mariadb pod` Values.linkerd.mariadb.enabled = false `(default true)
- deactivate linkerd annotations for the backup pod `Values.linkerd.backup.enabled = false` (default true)

for more information about linkerd please find:
https://github.com/sapcc/helm-charts/tree/master/common/linkerd-support

splitting PR: https://github.com/sapcc/helm-charts/pull/5532 into multiple PRs per helm chart