### PR TITLE
[Nova] Bump rabbitmq, memcached, mariadb for linkerd

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -1,33 +1,33 @@
 dependencies:
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.17
+  version: 0.8.0
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.17
+  version: 0.8.0
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.7
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.5.2
+  version: 0.6.0
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.1
+  version: 0.1.5
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.11.1
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.17
+  version: 0.8.0
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.5.2
+  version: 0.6.0
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:1ef6db35dc4a4d8968792584f4622e6216bc8dad6553204aaff36f19f7b4539f
-generated: "2023-11-07T12:06:29.611070935+01:00"
+digest: sha256:5fe352edbfc5a0bfb4cc7a9bee5ae89c8f30ab233b91ce3f8f11389e183ed481
+generated: "2023-11-09T09:52:32.838776358+01:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -8,22 +8,22 @@ dependencies:
   - name: mariadb
     condition: mariadb.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.7.17
+    version: 0.8.0
   - name: mariadb
     alias: mariadb_api
     condition: mariadb_api.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.7.17
+    version: 0.8.0
   - name: mysql_metrics
     condition: mariadb.enabled
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.7
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.5.2
+    version: 0.6.0
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.1
+    version: 0.1.5
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
     version: ~0.11.1
@@ -31,12 +31,12 @@ dependencies:
     alias: mariadb_cell2
     condition: mariadb_cell2.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.7.17
+    version: 0.8.0
   - name: rabbitmq
     alias: rabbitmq_cell2
     condition: cell2.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.5.2
+    version: 0.6.0
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0


### PR DESCRIPTION
The new versions of the above-mentioned charts support linkerd annotations.