### PR TITLE
[memcached] bumping the version for activating linkerd

### DIFF
--- a/common/memcached/Chart.yaml
+++ b/common/memcached/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: memcached
-version: 0.1.5
+version: 0.2.0
 description: Free & open source, high-performance, distributed memory object caching system.
 home: http://memcached.org/
 sources:


### PR DESCRIPTION
version bumping was forgotten in commit
"[memcached] add linkerd annotation" / 1b829661b4a172b4e7615ad784dd109a9e9262f5

 bumping up the version to 0.2.0
