### PR TITLE
[Cinder] Update chart to include linkerd

### DIFF
--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -1,24 +1,27 @@
 dependencies:
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.10.4
+  version: 0.11.1
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.12
+  version: 0.8.0
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.7
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.0
+  version: 0.2.0
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.5.2
+  version: 0.6.0
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
-  version: 1.2.1
+  version: 1.3.5
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:ee18aa28bbcfe8acadd3dac09f64fba4bfe0c4fe50664f50b5e2bc13991dd952
-generated: "2023-10-23T08:23:50.238599-04:00"
+- name: linkerd-support
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 0.1.3
+digest: sha256:92d53100080c267c31ad051375615c8a1d08e82b72a2c27fc16ffb6d4725bbf3
+generated: "2023-11-28T08:45:58.911628-05:00"

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -2,14 +2,14 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Cinder/OpenStack_Project_Cinder_mascot.png
 name: cinder
-version: 0.1.1
+version: 0.1.2
 dependencies:
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.10.0
+    version: ~0.11.1
   - name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.7.12
+    version: 0.8.0
     condition: mariadb.enabled
   - name: mysql_metrics
     repository: https://charts.eu-de-2.cloud.sap
@@ -17,15 +17,18 @@ dependencies:
     condition: mariadb.enabled
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.0
+    version: 0.2.0
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.5.2
+    version: 0.6.0
   - name: redis
     alias: api-ratelimit-redis
     repository: https://charts.eu-de-2.cloud.sap
-    version: 1.2.1
+    version: 1.3.5
     condition: api_rate_limit.enabled
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0
+  - name: linkerd-support
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: 0.1.3

--- a/openstack/cinder/templates/api-deployment.yaml
+++ b/openstack/cinder/templates/api-deployment.yaml
@@ -32,6 +32,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
         {{- end }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
       {{- tuple . "cinder" "api" | include "kubernetes_pod_anti_affinity" | nindent 6 }}
       {{- include "utils.proxysql.pod_settings" . | nindent 6 }}

--- a/openstack/cinder/templates/api-ingress.yaml
+++ b/openstack/cinder/templates/api-ingress.yaml
@@ -9,6 +9,7 @@ metadata:
     component: cinder
   annotations:
     {{- include "utils.snippets.set_ingress_cors_annotations" . | indent 4 }}
+    {{- include "utils.linkerd.ingress_annotation" . | indent 4 }}
   {{- if .Values.use_tls_acme }}
     kubernetes.io/tls-acme: "true"
   {{- end }}

--- a/openstack/cinder/templates/api-service.yaml
+++ b/openstack/cinder/templates/api-service.yaml
@@ -12,6 +12,7 @@ metadata:
     maia.io/scrape: "true"
     prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
     {{- include "utils.topology.service_topology_mode" . | indent 2 }}
+    {{- include "utils.linkerd.pod_and_service_annotation" . | indent 4 }}
 spec:
   selector:
     name: cinder-api

--- a/openstack/cinder/templates/backup_deployment.yaml
+++ b/openstack/cinder/templates/backup_deployment.yaml
@@ -42,6 +42,7 @@ template: |
           prometheus.io/scrape: "true"
           prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
           {{- end }}
+          {{- include "utils.linkerd.pod_and_service_annotation" . | indent 10 }}
       spec:
         hostname: cinder-volume-backup-vmware-{= name =}
         {{- include "utils.proxysql.pod_settings" . | nindent 8 }}

--- a/openstack/cinder/templates/scheduler-deployment.yaml
+++ b/openstack/cinder/templates/scheduler-deployment.yaml
@@ -31,6 +31,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
         {{- end }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
 {{ tuple . "cinder" "scheduler" | include "kubernetes_pod_anti_affinity" | indent 6 }}
 {{ include "utils.proxysql.pod_settings" . | indent 6 }}

--- a/openstack/cinder/templates/vcenter_datacenter_cinder_deployment.yaml
+++ b/openstack/cinder/templates/vcenter_datacenter_cinder_deployment.yaml
@@ -44,6 +44,7 @@ template: |
           prometheus.io/scrape: "true"
           prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
           {{- end }}
+          {{- include "utils.linkerd.pod_and_service_annotation" . | indent 10 }}
       spec:
         hostname: cinder-volume-vmware-{= name =}
         {{- tuple . "{= availability_zone =}" | include "utils.kubernetes_pod_az_affinity" | nindent 8 }}

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -6,7 +6,8 @@ global:
   dbUser: cinder
   domain_seeds:
     skip_hcm_domain: false
-    
+ 
+  linkerd_requested: false
   osprofiler: {}
   imagePullPolicy: IfNotPresent
 


### PR DESCRIPTION
This adds the `linkerd-support` chart as dependency and also adds the annotations to all `Deployment`, `Service` and `Ingress` objects.

linkerd is disabled by default and needs to be enabled per region.

We depend on the `utils` chart for the annotation snippets and the conditions so our templates stay more compact and thus better readable.