### PR TITLE
Improve empty port-selector and multiple subgroup bindings hadling

### DIFF
--- a/openstack/neutron/templates/etc/_ml2-conf-aci.ini.tpl
+++ b/openstack/neutron/templates/etc/_ml2-conf-aci.ini.tpl
@@ -88,26 +88,27 @@ host_azs = {{ range $az, $hosts := $aci_hostgroup.host_azs -}}
             {{- if lt $n (sub (len $hosts) 1) -}},{{- end -}}
         {{- end -}}
     {{- end -}}
-{{ end -}}
-{{- range $i, $subgroup := $aci_hostgroup.subgroups }}
-
+{{- end }}
+{{ range $i, $subgroup := $aci_hostgroup.subgroups }}
 [aci-hostgroup:{{ $subgroup.name }}]
 hosts = {{ default $subgroup.name $subgroup.hosts | join "," }}
 bindings = {{ $subgroup.bindings | join "," }}
 segment_type  = {{ $.Values.aci.aci_hostgroups.segment_type }}
 direct_mode = True
+{{ if and (hasKey $subgroup "port_selectors") ( gt ($subgroup.port_selectors | len ) 0) -}}
 port_selectors = {{ $subgroup.port_selectors | join "," }}
-{{- if and (empty $subgroup.infra_pc_policy_group) (eq (len $subgroup.bindings) 1) }}
+{{ if and (empty $subgroup.infra_pc_policy_group) (eq (len $subgroup.bindings) 1) -}}
 infra_pc_policy_group = {{ (split "/" (index $subgroup.bindings 0))._3 }}
-{{ else }}
-infra_pc_policy_group = {{ $subgroup.infra_pc_policy_group }}
+{{ else if and (hasKey $subgroup "port_selectors") (gt ($subgroup.port_selectors | len ) 0) -}}
+infra_pc_policy_group = {{ required "If more than one direct binding is supplied and a port-selector is given the field infra_pc_policy_group is mandatory" $subgroup.infra_pc_policy_group }}
 {{ end -}}
 {{- if or $aci_hostgroup.baremetal_pc_policy_group $subgroup.baremetal_pc_policy_group -}}
 baremetal_pc_policy_group = {{ default $aci_hostgroup.baremetal_pc_policy_group $subgroup.baremetal_pc_policy_group }}
 {{ end -}}
+{{ end -}}
 parent_hostgroup = {{ $aci_hostgroup.name }}
-{{- end }}
-{{ end }}
+{{ end -}}
+{{ end -}}
 
 {{- range $i, $fixed_binding := .Values.aci.fixed_bindings }}
 [fixed-binding:{{ $fixed_binding.name }}]


### PR DESCRIPTION
In the driver we do now support no port-selectors, if a host never has
to go into baremetal mode. This commit will omit the port_selectors key
if they are unset.

The policy group was inferred to be the same name as the VPC profile's
first binding's name. This failed when our subgroups got multiple
bindings which lead to an empty string being rendered into the config.
This shouldn't go unnoticed so we prompt the user to supply an explicit
pc-group only if port selectors are set. Policy groups are not needed if
port-selectors are unset, as no disassembling of the VPC profile will
happen.
