### PR TITLE
Fix velero pod annotation to avoid double scraping

### DIFF
--- a/system/kube-system-virtual/values.yaml
+++ b/system/kube-system-virtual/values.yaml
@@ -107,6 +107,10 @@ owner-info:
 velero:
   enabled: false
 
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: "/metrics"
+
   image:
     repository: keppel.global.cloud.sap/ccloud-dockerhub-mirror/velero/velero
     tag: v1.11.1


### PR DESCRIPTION
fixes the `Prometheus is scraping kube-system-virtual-velero pods in namespace kube-system multiple times. This is likely caused due to incorrectly placed scrape annotations.` alert