### PR TITLE
[openstack/placement] Make use of trust-bundle snippets

### DIFF
--- a/openstack/placement/Chart.lock
+++ b/openstack/placement/Chart.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 0.1.0
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.9.0
+  version: 0.12.0
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:8b42fbf2c337b7d14ce5e2e7b7e4d98a43c979962d945683bb850a7ad5fe70ca
-generated: "2023-05-02T15:30:06.300376867+02:00"
+digest: sha256:402854da2f3d1b8031bb6191bc72e48ab93dad3a624679f7317f4394f3196ba6
+generated: "2023-11-14T10:39:58.20350022+01:00"

--- a/openstack/placement/Chart.yaml
+++ b/openstack/placement/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
     version: 0.1.0
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.9.0
+    version: ~0.12.0
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0

--- a/openstack/placement/templates/_helpers.tpl
+++ b/openstack/placement/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{- define "job_name" }}
   {{- $name := index . 1 }}
   {{- with index . 0 }}
-    {{- $all := list (include "utils.proxysql.job_pod_settings" . ) (include "utils.proxysql.volume_mount" . ) (include "utils.proxysql.container" . ) (include "utils.proxysql.volumes" .) (tuple . (dict) | include "utils.snippets.kubernetes_entrypoint_init_container") | join "\n" }}
+    {{- $all := list (include "utils.proxysql.job_pod_settings" . ) (include "utils.proxysql.volume_mount" . ) (include "utils.proxysql.container" . ) (include "utils.proxysql.volumes" .) (tuple . (dict) | include "utils.snippets.kubernetes_entrypoint_init_container") (include "utils.trust_bundle.volume_mount" . ) (include "utils.trust_bundle.volumes" .) | join "\n" }}
     {{- $hash := empty .Values.proxysql.mode | ternary "" $all | sha256sum }}
 {{- .Release.Name }}-{{ $name }}-{{ substr 0 4 $hash }}-{{ .Values.imageVersion | required "Please set .imageVersion or similar"}}
   {{- end }}

--- a/openstack/placement/templates/db-migrate-job.yaml
+++ b/openstack/placement/templates/db-migrate-job.yaml
@@ -52,9 +52,11 @@ spec:
         - mountPath: /etc/placement
           name: placement-etc
         {{- include "utils.proxysql.volume_mount" . | indent 8 }}
+        {{- include "utils.trust_bundle.volume_mount" . | indent 8 }}
       {{- include "utils.proxysql.container" . | indent 6 }}
       volumes:
       - name: placement-etc
         configMap:
           name: placement-etc
       {{- include "utils.proxysql.volumes" . | indent 6 }}
+      {{- include "utils.trust_bundle.volumes" . | indent 6 }}

--- a/openstack/placement/templates/db-online-migrate-job.yaml
+++ b/openstack/placement/templates/db-online-migrate-job.yaml
@@ -52,9 +52,11 @@ spec:
         - mountPath: /etc/placement
           name: placement-etc
         {{- include "utils.proxysql.volume_mount" . | indent 8 }}
+        {{- include "utils.trust_bundle.volume_mount" . | indent 8 }}
       {{- include "utils.proxysql.container" . | indent 6 }}
       volumes:
       - name: placement-etc
         configMap:
           name: placement-etc
       {{- include "utils.proxysql.volumes" . | indent 6 }}
+      {{- include "utils.trust_bundle.volumes" . | indent 6 }}

--- a/openstack/placement/templates/placement-api-deployment.yaml
+++ b/openstack/placement/templates/placement-api-deployment.yaml
@@ -84,9 +84,11 @@ spec:
         - mountPath: /etc/placement
           name: placement-etc
         {{- include "utils.proxysql.volume_mount" . | indent 8 }}
+        {{- include "utils.trust_bundle.volume_mount" . | indent 8 }}
       {{- include "utils.proxysql.container" . | indent 6 }}
       volumes:
       - name: placement-etc
         configMap:
           name: placement-etc
       {{- include "utils.proxysql.volumes" . | indent 6 }}
+      {{- include "utils.trust_bundle.volumes" . | indent 6 }}

--- a/openstack/placement/values.yaml
+++ b/openstack/placement/values.yaml
@@ -100,6 +100,10 @@ alerts:
 sentry:
   enabled: true
 
+utils:
+  trust_bundle:
+    enabled: true
+
 # Additional sections and values for the placement.conf file
 # Each first level item will become a section, and only on the second-level
 # we have key value pairs


### PR DESCRIPTION
The snippets replace the system ca trust-bundle with a centrally managed one by trust-manager in k8s. 
This eliminates the need for patching the images to contain the company internal CA.