### PR TITLE
disable pod scrape alerts by default

### DIFF
--- a/common/prometheus-server/CHANGELOG.md
+++ b/common/prometheus-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.4.4
+
+* default MultiplePodScrape-alert to false 
+
 ## 7.4.3
 
 * Thanos sidecar to v0.31.0 to match Thanos environment 

--- a/common/prometheus-server/values.yaml
+++ b/common/prometheus-server/values.yaml
@@ -430,7 +430,7 @@ alerts:
 
   # This alert requires kube state metrics. Disable if not present
   multiplePodScrapes:
-    enabled: true
+    enabled: false
 
 # If true, a custom Prometheus naming will take place. Only needed for vmware-monitoring.
 vmware: false


### PR DESCRIPTION
since kube_state_metrics are available in the respective kubernetes proms only, they are usually not needed