### PR TITLE
[openstack/nova] Make use of trust-bundle snippets

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 0.1.5
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.11.1
+  version: 0.12.1
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.8.0
@@ -29,5 +29,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:5fe352edbfc5a0bfb4cc7a9bee5ae89c8f30ab233b91ce3f8f11389e183ed481
-generated: "2023-11-09T09:52:32.838776358+01:00"
+digest: sha256:1974a02465e1fd3e9572ea7cf153c5ecba0dda368b202e4b7b58dbbe2548571b
+generated: "2023-11-14T14:15:29.460325376+01:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     version: 0.1.5
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.11.1
+    version: ~0.12.1
   - name: mariadb
     alias: mariadb_cell2
     condition: mariadb_cell2.enabled

--- a/openstack/nova/ci/test-values.yaml
+++ b/openstack/nova/ci/test-values.yaml
@@ -1,4 +1,5 @@
 global:
+  accessControlAllowOrigin: '*'
   region: regionOne
   domain: evil.corp
   registry: keppel.regionOne.cloud
@@ -24,6 +25,10 @@ mariadb:
     enabled: false
   backup_v2:
     enabled: false
+  users:
+    nova:
+      name: nova
+      password: password
 
 mariadb_api:
   enabled: false
@@ -31,6 +36,10 @@ mariadb_api:
     enabled: false
   backup_v2:
     enabled: false
+  users:
+    nova_api:
+      name: nova_api
+      password: password
 
 rabbitmq:
   users:

--- a/openstack/nova/templates/_console_deployment.yaml.tpl
+++ b/openstack/nova/templates/_console_deployment.yaml.tpl
@@ -72,6 +72,7 @@ spec:
               - key: console-{{ $cell_name }}-{{ $type }}.conf
                 path: nova.conf.d/console-{{ $cell_name }}-{{ $type }}.conf
       {{- include "utils.proxysql.volumes" . | indent 6 }}
+      {{- include "utils.trust_bundle.volumes" . | indent 6 }}
       containers:
       - name: nova-console-{{ $type }}
         image: {{ tuple . (print (title $type) "proxy") | include "container_image_nova" }}
@@ -108,6 +109,7 @@ spec:
         - name: nova-etc
           mountPath: /etc/nova
         {{- include "utils.proxysql.volume_mount" . | indent 8 }}
+        {{- include "utils.trust_bundle.volume_mount" . | indent 8 }}
       {{- include "utils.proxysql.container" . | indent 6 }}
 {{- end }}
 {{- end }}

--- a/openstack/nova/templates/api-deployment.yaml
+++ b/openstack/nova/templates/api-deployment.yaml
@@ -108,6 +108,7 @@ spec:
           - mountPath: /etc/nova
             name: nova-etc
             {{- include "utils.proxysql.volume_mount" . | indent 10 }}
+            {{- include "utils.trust_bundle.volume_mount" . | indent 10 }}
         {{- tuple . .Values.api.config_file.DEFAULT.osapi_compute_workers | include "utils.proxysql.container" | indent 8 }}
         - name: statsd
           image: {{ required ".Values.global.dockerHubMirror is missing" .Values.global.dockerHubMirror}}/prom/statsd-exporter:v0.8.1
@@ -177,3 +178,4 @@ spec:
           name: nova-bin
           defaultMode: 0755
       {{- include "utils.proxysql.volumes" . | indent 6 }}
+      {{- include "utils.trust_bundle.volumes" . | indent 6 }}

--- a/openstack/nova/templates/api-metadata-deployment.yaml
+++ b/openstack/nova/templates/api-metadata-deployment.yaml
@@ -92,6 +92,7 @@ spec:
           - mountPath: /etc/nova
             name: nova-etc
           {{- include "utils.proxysql.volume_mount" . | indent 10 }}
+          {{- include "utils.trust_bundle.volume_mount" . | indent 10 }}
         {{- tuple . .Values.api_metadata.config_file.DEFAULT.metadata_workers | include "utils.proxysql.container" | indent 8 }}
         - name: statsd
           image: {{ required ".Values.global.dockerHubMirror is missing" .Values.global.dockerHubMirror}}/prom/statsd-exporter:v0.8.1
@@ -161,3 +162,4 @@ spec:
           name: nova-bin
           defaultMode: 0755
       {{- include "utils.proxysql.volumes" . | indent 6 }}
+      {{- include "utils.trust_bundle.volumes" . | indent 6 }}

--- a/openstack/nova/templates/bigvm-deployment.yaml
+++ b/openstack/nova/templates/bigvm-deployment.yaml
@@ -75,6 +75,7 @@ spec:
           - name: nova-etc
             mountPath: /etc/nova
           {{- include "utils.proxysql.volume_mount" . | indent 10 }}
+          {{- include "utils.trust_bundle.volume_mount" . | indent 10 }}
         {{- include "utils.proxysql.container" . | indent 8 }}
       volumes:
       - name: nova-etc
@@ -95,4 +96,5 @@ spec:
               - key: db.conf
                 path: nova.conf.d/db.conf
       {{- include "utils.proxysql.volumes" . | indent 6 }}
+      {{- include "utils.trust_bundle.volumes" . | indent 6 }}
 {{- end }}

--- a/openstack/nova/templates/cell2-conductor-deployment.yaml
+++ b/openstack/nova/templates/cell2-conductor-deployment.yaml
@@ -99,6 +99,7 @@ spec:
               subPath: logging.ini
               readOnly: true
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+            {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
         {{- tuple . .Values.conductor.config_file.conductor.workers | include "utils.proxysql.container" | indent 8 }}
         {{- if .Values.cell2.conductor.config_file.DEFAULT.statsd_enabled }}
         - name: statsd
@@ -124,4 +125,5 @@ spec:
           configMap:
             name: nova-etc
         {{- include "utils.proxysql.volumes" . | indent 8 }}
+        {{- include "utils.trust_bundle.volumes" . | indent 8 }}
 {{- end }}

--- a/openstack/nova/templates/conductor-deployment.yaml
+++ b/openstack/nova/templates/conductor-deployment.yaml
@@ -76,6 +76,7 @@ spec:
           - mountPath: /etc/nova
             name: nova-etc
           {{- include "utils.proxysql.volume_mount" . | indent 10 }}
+          {{- include "utils.trust_bundle.volume_mount" . | indent 10 }}
         {{- tuple . .Values.conductor.config_file.conductor.workers | include "utils.proxysql.container" | indent 8 }}
         {{- if .Values.conductor.config_file.DEFAULT.statsd_enabled }}
         - name: statsd
@@ -123,3 +124,4 @@ spec:
                 path: statsd-exporter.yaml
 {{- end }}
       {{- include "utils.proxysql.volumes" . | indent 6 }}
+      {{- include "utils.trust_bundle.volumes" . | indent 6 }}

--- a/openstack/nova/templates/console-shellinabox-deployment.yaml
+++ b/openstack/nova/templates/console-shellinabox-deployment.yaml
@@ -93,3 +93,4 @@ spec:
               - key: config.lua
                 path: config.lua
       {{- include "utils.proxysql.volumes" . | indent 6 }}
+      {{- include "utils.trust_bundle.volumes" . | indent 6 }}

--- a/openstack/nova/templates/db-migrate-job.yaml
+++ b/openstack/nova/templates/db-migrate-job.yaml
@@ -33,6 +33,7 @@ spec:
         - mountPath: /container.init
           name: container-init
         {{- include "utils.proxysql.volume_mount" . | indent 8 }}
+        {{- include "utils.trust_bundle.volume_mount" . | indent 8 }}
       {{- include "utils.proxysql.container" . | indent 6 }}
       volumes:
       - name: nova-etc
@@ -69,3 +70,4 @@ spec:
           name: nova-bin
           defaultMode: 0755
       {{- include "utils.proxysql.volumes" . | indent 6 }}
+      {{- include "utils.trust_bundle.volumes" . | indent 6 }}

--- a/openstack/nova/templates/db-online-migrate-job.yaml
+++ b/openstack/nova/templates/db-online-migrate-job.yaml
@@ -34,6 +34,7 @@ spec:
         - mountPath: /container.init
           name: container-init
         {{- include "utils.proxysql.volume_mount" . | indent 8 }}
+        {{- include "utils.trust_bundle.volume_mount" . | indent 8 }}
       {{- include "utils.proxysql.container" . | indent 6 }}
       volumes:
       - name: nova-etc
@@ -60,3 +61,4 @@ spec:
           name: nova-bin
           defaultMode: 0755
       {{- include "utils.proxysql.volumes" . | indent 6 }}
+      {{- include "utils.trust_bundle.volumes" . | indent 6 }}

--- a/openstack/nova/templates/hypervisors/_ironic-deployment.yaml.tpl
+++ b/openstack/nova/templates/hypervisors/_ironic-deployment.yaml.tpl
@@ -66,6 +66,7 @@ spec:
               name: nova-etc
             - mountPath: /nova-patches
               name: nova-patches
+            {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
         {{- if $hypervisor.default.statsd_enabled }}
         - name: statsd
           image: {{ required ".Values.global.dockerHubMirror is missing" .Values.global.dockerHubMirror}}/prom/statsd-exporter:v0.8.1
@@ -123,5 +124,6 @@ spec:
               - key:  statsd-exporter.yaml
                 path: statsd-exporter.yaml
       {{- end }}
+      {{- include "utils.trust_bundle.volumes" . | indent 6 }}
 {{- end -}}
 {{- end -}}

--- a/openstack/nova/templates/hypervisors/_kvm-deployment.yaml.tpl
+++ b/openstack/nova/templates/hypervisors/_kvm-deployment.yaml.tpl
@@ -102,6 +102,7 @@ spec:
               name: nova-etc
               subPath: rootwrap.conf
               readOnly: true
+            {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
         - name: nova-libvirt
           image: {{ tuple . "libvirt" | include "container_image_nova" }}
           imagePullPolicy: IfNotPresent
@@ -150,6 +151,7 @@ spec:
               readOnly: true
             - mountPath: /container.init
               name: nova-container-init
+            {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
         - name: nova-virtlog
           image: {{ tuple . "libvirt" | include "container_image_nova" }}
           imagePullPolicy: IfNotPresent
@@ -198,6 +200,7 @@ spec:
               readOnly: true
             - mountPath: /container.init
               name: nova-container-init
+            {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
         - name: neutron-openvswitch-agent
           image: {{ required ".Values.global.registry is missing" .Values.global.registry}}/loci-neutron:{{.Values.imageVersionNeutron | required "Please set nova.imageVersionNeutron or similar" }}
           imagePullPolicy: IfNotPresent
@@ -215,6 +218,7 @@ spec:
               name: neutron-etc
             - mountPath: /container.init
               name: neutron-container-init
+            {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
         - name: ovs
           image: {{ required ".Values.global.registry is missing" .Values.global.registry}}/ubuntu-source-openvswitch-vswitchd:{{ .Values.imageVersionOpenvswitchVswitchd | default .Values.imageVersionNova | default .Values.imageVersion | required "Please set .imageVersion" }}
           imagePullPolicy: IfNotPresent
@@ -230,6 +234,7 @@ spec:
               readOnly: true
             - mountPath: /container.init
               name: neutron-container-init
+            {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
         - name: ovs-db
           image: {{ required ".Values.global.registry is missing" .Values.global.registry}}/ubuntu-source-openvswitch-db-server:{{ .Values.imageVersionOpenvswitchDbServer | default .Values.imageVersionNova | default .Values.imageVersion | required "Please set .imageVersion" }}
           imagePullPolicy: IfNotPresent
@@ -244,6 +249,7 @@ spec:
               name: modules
             - mountPath: /container.init
               name: neutron-container-init
+            {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
       volumes:
         - name: instances
           persistentVolumeClaim:
@@ -284,5 +290,6 @@ spec:
           configMap:
             name: neutron-bin
             defaultMode: 0755
+        {{- include "utils.trust_bundle.volumes" . | indent 8 }}
 {{- end }}
 {{- end }}

--- a/openstack/nova/templates/hypervisors/hypervisors-vmware-deployment-vct.yaml
+++ b/openstack/nova/templates/hypervisors/hypervisors-vmware-deployment-vct.yaml
@@ -81,6 +81,7 @@ template: |
           - mountPath: /etc/sudoers
             name: sudoers
             subPath: sudoers
+          {{- include "utils.trust_bundle.volume_mount" . | indent 10 }}
         - name: statsd
           image: {{ required ".Values.global.dockerHubMirror is missing" .Values.global.dockerHubMirror}}/prom/statsd-exporter:v0.8.1
           imagePullPolicy: IfNotPresent
@@ -152,4 +153,5 @@ template: |
                 items:
                 - key:  statsd-exporter.yaml
                   path: statsd-exporter.yaml
+        {{- include "utils.trust_bundle.volumes" . | indent 8 }}
 {{- end }}

--- a/openstack/nova/templates/scheduler-deployment.yaml
+++ b/openstack/nova/templates/scheduler-deployment.yaml
@@ -75,6 +75,7 @@ spec:
           - name: nova-etc
             mountPath: /etc/nova
           {{- include "utils.proxysql.volume_mount" . | indent 10 }}
+          {{- include "utils.trust_bundle.volume_mount" . | indent 10 }}
         {{- tuple . .Values.scheduler.workers | include "utils.proxysql.container" | indent 8 }}
         {{- if .Values.scheduler.rpc_statsd_enabled }}
         - name: statsd
@@ -125,3 +126,4 @@ spec:
                 path: statsd-exporter.yaml
 {{- end }}
       {{- include "utils.proxysql.volumes" . | indent 6 }}
+      {{- include "utils.trust_bundle.volumes" . | indent 6 }}

--- a/openstack/nova/templates/vspc-deployment.yaml
+++ b/openstack/nova/templates/vspc-deployment.yaml
@@ -74,6 +74,7 @@ spec:
               name: nova-etc
               subPath: vspc.conf
               readOnly: true
+            {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
         - name: log-nanny
           image: {{ required ".Values.global.dockerHubMirror: is missing" .Values.global.dockerHubMirror }}/library/busybox
           args: ['sh', '-c', 'while true; do find /var/run/serial_log_dir -mtime +30 -exec rm {} \;; sleep 1d; done']
@@ -89,3 +90,4 @@ spec:
         - name: serial-log-dir
           persistentVolumeClaim:
             claimName: {{ .Values.vspc.pvc.existingClaim | default "nova-vspc-pvclaim" }}
+        {{- include "utils.trust_bundle.volumes" . | indent 8 }}

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -930,3 +930,7 @@ owner-info:
 default:
   password_all_group_samples: 2
   rpc_ping_enabled: true
+
+utils:
+  trust_bundle:
+    enabled: true


### PR DESCRIPTION
The snippets replace the system ca trust-bundle with a centrally managed one by trust-manager in k8s. This eliminates the need for patching the images to contain the company internal CA.