### PR TITLE
[openstack/placement] Fix trust-bundle without proxysql

### DIFF
--- a/openstack/placement/Chart.lock
+++ b/openstack/placement/Chart.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 0.1.0
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.12.0
+  version: 0.12.1
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:402854da2f3d1b8031bb6191bc72e48ab93dad3a624679f7317f4394f3196ba6
-generated: "2023-11-14T10:39:58.20350022+01:00"
+digest: sha256:8df30477ac2d5795fde779b657a169e2a1d99ca4d12ca6c56a94d101f9f50558
+generated: "2023-11-14T14:29:40.905738575+01:00"

--- a/openstack/placement/Chart.yaml
+++ b/openstack/placement/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
     version: 0.1.0
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.12.0
+    version: ~0.12.1
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0


### PR DESCRIPTION
The dependency was incorrectly adding a volume mount of the proxysql when proxysql has been disabled