### PR TITLE
[openstack/ironic] Make use of trust-bundle snippets

### DIFF
--- a/openstack/ironic/Chart.lock
+++ b/openstack/ironic/Chart.lock
@@ -16,9 +16,9 @@ dependencies:
   version: 0.5.2
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.10.4
+  version: 0.12.1
 - name: ironic-exporter
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.0.0
-digest: sha256:ee1064364eda0535ff292a5bb9d4bb69f6b7a4cebdf2fdd49a8fb4166f414182
-generated: "2023-11-06T10:58:07.369792908+01:00"
+digest: sha256:046b037549e9036cf18ab66e9f9edde83e7bae41c559bc0002c28d7fe27f77bb
+generated: "2023-11-14T15:58:48.866852211+01:00"

--- a/openstack/ironic/Chart.yaml
+++ b/openstack/ironic/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
     version: ~0.5.2
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.10.4
+    version: ~0.12.1
   - name: ironic-exporter
     repository: https://charts.eu-de-2.cloud.sap
     version: ~1.0.0

--- a/openstack/ironic/templates/_conductor-deployment.yaml.tpl
+++ b/openstack/ironic/templates/_conductor-deployment.yaml.tpl
@@ -145,6 +145,7 @@ spec:
           name: development
         {{- end }}
         {{- include "utils.proxysql.volume_mount" . | indent 8 }}
+        {{- include "utils.trust_bundle.volume_mount" . | indent 8 }}
       {{- include "utils.proxysql.container" . | indent 6 }}
       - name: console
         image: {{ .Values.global.dockerHubMirror }}/library/{{ .Values.imageVersionNginx | default "nginx:stable-alpine" }}
@@ -225,5 +226,6 @@ spec:
         secret:
           secretName: tls-{{ include "ironic_console_endpoint_host_public" . | replace "." "-" }}
       {{- include "utils.proxysql.volumes" . | indent 6 }}
+      {{- include "utils.trust_bundle.volumes" . | indent 6 }}
     {{- end }}
 {{- end }}

--- a/openstack/ironic/templates/api-deployment.yaml
+++ b/openstack/ironic/templates/api-deployment.yaml
@@ -99,6 +99,7 @@ spec:
           readOnly: true
         {{- end }}
         {{- include "utils.proxysql.volume_mount" . | indent 8 }}
+        {{- include "utils.trust_bundle.volume_mount" . | indent 8 }}
       {{- tuple . .Values.api.api_workers | include "utils.proxysql.container" | indent 6 }}
       - name: statsd
         image:  "{{.Values.global.dockerHubMirror}}/{{.Values.statsd.image.repository}}:{{.Values.statsd.image.tag}}"
@@ -127,4 +128,5 @@ spec:
           name: ironic-etc
           defaultMode: 0444
       {{- include "utils.proxysql.volumes" . | indent 6 }}
+      {{- include "utils.trust_bundle.volumes" . | indent 6 }}
       {{- tuple . .Values.api.override "ironic-api" .Values.global.ironicApiPortInternal | include "utils.snippets.debug.debug_port_volumes_and_configmap" }}

--- a/openstack/ironic/templates/db-migration-job.yaml
+++ b/openstack/ironic/templates/db-migration-job.yaml
@@ -57,6 +57,7 @@ spec:
           name: ironic-etc
           subPath: logging.ini
           readOnly: true
+        {{- include "utils.trust_bundle.volume_mount" . | indent 8 }}
       volumes:
       - name: etcironic
         emptyDir: {}
@@ -64,3 +65,4 @@ spec:
         configMap:
           name: ironic-etc
           defaultMode: 0444
+      {{- include "utils.trust_bundle.volumes" . | indent 6 }}

--- a/openstack/ironic/templates/inspector-conductor-deployment.yaml
+++ b/openstack/ironic/templates/inspector-conductor-deployment.yaml
@@ -79,6 +79,7 @@ spec:
           subPath: policy.json
           readOnly: true
         {{- include "utils.proxysql.volume_mount" . | indent 10 }}
+        {{- include "utils.trust_bundle.volume_mount" . | indent 10 }}
       {{- include "utils.proxysql.container" . | indent 8 }}
       volumes:
       - name: etcironic
@@ -96,4 +97,5 @@ spec:
           name: ironic-inspector-rootwrap
           defaultMode: 0444
       {{- include "utils.proxysql.volumes" . | indent 8 }}
+      {{- include "utils.trust_bundle.volumes" . | indent 8 }}
 {{- end }}

--- a/openstack/ironic/templates/inspector-db-migration-job.yaml
+++ b/openstack/ironic/templates/inspector-db-migration-job.yaml
@@ -56,6 +56,7 @@ spec:
           name: ironic-etc
           subPath: logging.ini
           readOnly: true
+        {{- include "utils.trust_bundle.volume_mount" . | indent 8 }}
       volumes:
       - name: etcironicinspector
         emptyDir: {}
@@ -67,3 +68,4 @@ spec:
         configMap:
           name: ironic-inspector-etc
           defaultMode: 0444
+      {{- include "utils.trust_bundle.volumes" . | indent 6 }}

--- a/openstack/ironic/templates/inspector-deployment.yaml
+++ b/openstack/ironic/templates/inspector-deployment.yaml
@@ -93,6 +93,7 @@ spec:
           subPath: ironic-inspector.filters
           readOnly: true
         {{- include "utils.proxysql.volume_mount" . | indent 8 }}
+        {{- include "utils.trust_bundle.volume_mount" . | indent 8 }}
       {{- tuple . .Values.api.api_workers | include "utils.proxysql.container" | indent 6 }}
       {{- if and .Values.global.ironic_tftp_ip .Values.inspector.dhcp.range .Values.inspector.dhcp.options.router }}
       - name: dhcp
@@ -159,3 +160,4 @@ spec:
           defaultMode: 0444
       {{- end }}
       {{- include "utils.proxysql.volumes" . | indent 6 }}
+      {{- include "utils.trust_bundle.volumes" . | indent 6 }}

--- a/openstack/ironic/templates/pxe-deployment.yaml
+++ b/openstack/ironic/templates/pxe-deployment.yaml
@@ -40,6 +40,7 @@ spec:
         volumeMounts:
         - mountPath: /tftpboot
           name: ironic-tftp
+        {{- include "utils.proxysql.volume_mount" . | indent 8 }}
         resources:
 {{ toYaml .Values.pod.resources.pxe | indent 10 }}
       - name: ironic-ipxe
@@ -73,3 +74,4 @@ spec:
         configMap:
           name: ironic-pxe
           defaultMode: 0444
+      {{- include "utils.trust_bundle.volumes" . | indent 6 }}

--- a/openstack/ironic/templates/pxe-setup-job.yaml
+++ b/openstack/ironic/templates/pxe-setup-job.yaml
@@ -51,7 +51,9 @@ spec:
         volumeMounts:
         - mountPath: /tftpboot
           name: ironic-tftp
+        {{- include "utils.trust_bundle.volume_mount" . | indent 8 }}
       volumes:
       - name: ironic-tftp
         persistentVolumeClaim:
           claimName: ironic-tftp-pvclaim
+      {{- include "utils.trust_bundle.volumes" . | indent 6 }}

--- a/openstack/ironic/templates/redfish-certrobot-cronjob.yaml
+++ b/openstack/ironic/templates/redfish-certrobot-cronjob.yaml
@@ -25,7 +25,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ .Release.Name }}-redfish-certrobot
+  name: {{ .Release.Name }}-redfish-certrobot-0
 spec:
   schedule: {{ .Values.cert_robot.schedule | quote }}
   jobTemplate:
@@ -49,6 +49,7 @@ spec:
             - name: config
               mountPath: "/etc/openstack"
               readOnly: true
+            {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
           volumes:
           - name: config
             projected:
@@ -60,3 +61,4 @@ spec:
                     path: clouds.yaml
                   - key: sdk
                     path: sdk.yaml
+          {{- include "utils.trust_bundle.volumes" . | indent 10 }}

--- a/openstack/ironic/templates/security-group-setup.yaml
+++ b/openstack/ironic/templates/security-group-setup.yaml
@@ -55,6 +55,7 @@ spec:
           name: ironic-etc
           subPath: ironic.conf
           readOnly: true
+        {{- include "utils.trust_bundle.volume_mount" . | indent 8 }}
       volumes:
       - name: etcironic
         emptyDir: {}
@@ -62,4 +63,4 @@ spec:
         configMap:
           name: ironic-etc
           defaultMode: 0444
-
+      {{- include "utils.trust_bundle.volumes" . | indent 6 }}

--- a/openstack/ironic/values.yaml
+++ b/openstack/ironic/values.yaml
@@ -434,3 +434,7 @@ alerts:
   # Name of the Prometheus to which the alerts should be assigned to.
   prometheus: openstack
   support_group: foundation
+
+utils:
+  trust_bundle:
+    enabled: true


### PR DESCRIPTION
The snippets replace the system ca trust-bundle with a centrally managed one by trust-manager in k8s. This eliminates the need for patching the images to contain the company internal CA.