### PR TITLE
[openstack/glance] Make use of trust-bundle snippets

### DIFF
--- a/openstack/glance/Chart.lock
+++ b/openstack/glance/Chart.lock
@@ -10,12 +10,12 @@ dependencies:
   version: 0.2.7
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.10.3
+  version: 0.12.1
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.3.8
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:ab9497dc9b6ab42ba33b23c036ccbe56c4c914e0ed10f74f5589603fd15c7c69
-generated: "2023-10-23T08:12:26.656476+05:30"
+digest: sha256:0117d67c314e9d8eeb927fc64964486f03e9706e514f1675ed31c6060597311e
+generated: "2023-11-14T15:41:25.267789979+01:00"

--- a/openstack/glance/Chart.yaml
+++ b/openstack/glance/Chart.yaml
@@ -18,7 +18,7 @@ dependencies:
     version: 0.2.7
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.10.1
+    version: ~0.12.1
   - name: redis
     alias: sapcc_rate_limit
     repository: https://charts.eu-de-2.cloud.sap

--- a/openstack/glance/templates/_helpers.tpl
+++ b/openstack/glance/templates/_helpers.tpl
@@ -22,7 +22,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
   {{- $name := index . 1 }}
   {{- with index . 0 }}
     {{- $bin := include "utils.proxysql.proxysql_signal_stop_script" . | trim }}
-    {{- $all := list $bin (include "utils.proxysql.job_pod_settings" . ) (include "utils.proxysql.volume_mount" . ) (include "utils.proxysql.container" . ) (include "utils.proxysql.volumes" .) (tuple . (dict) | include "utils.snippets.kubernetes_entrypoint_init_container")  | join "\n" }}
+    {{- $all := list $bin (include "utils.proxysql.job_pod_settings" . ) (include "utils.proxysql.volume_mount" . ) (include "utils.proxysql.container" . ) (include "utils.proxysql.volumes" .) (tuple . (dict) | include "utils.snippets.kubernetes_entrypoint_init_container") (include "utils.trust_bundle.volume_mount" . ) (include "utils.trust_bundle.volumes" . )  | join "\n" }}
     {{- $hash := empty .Values.proxysql.mode | ternary $bin $all | sha256sum }}
 {{- .Release.Name }}-{{ $name }}-{{ substr 0 4 $hash }}-{{ .Values.imageVersion | required "Please set glance.imageVersion or similar"}}
   {{- end }}

--- a/openstack/glance/templates/deployment.yaml
+++ b/openstack/glance/templates/deployment.yaml
@@ -164,6 +164,7 @@ spec:
           readOnly: true
         {{- end }}
         {{- include "utils.proxysql.volume_mount" . | indent 8 }}
+        {{- include "utils.trust_bundle.volume_mount" . | indent 8 }}
       {{- tuple . (add .Values.rpc_workers .Values.workers) | include "utils.proxysql.container" | indent 6 }}
       {{- if .Values.imageVersionGlanceRegistry }}
       - name: registry
@@ -294,3 +295,4 @@ spec:
         configMap:
           name: glance-etc
       {{- include "utils.proxysql.volumes" . | indent 6 }}
+      {{- include "utils.trust_bundle.volumes" . | indent 6 }}

--- a/openstack/glance/templates/migration-job.yaml
+++ b/openstack/glance/templates/migration-job.yaml
@@ -72,3 +72,4 @@ spec:
         configMap:
           name: glance-etc
       {{- include "utils.proxysql.volumes" . | indent 6 }}
+      {{- include "utils.trust_bundle.volumes" . | indent 6 }}


### PR DESCRIPTION
The snippets replace the system ca trust-bundle with a centrally managed one by trust-manager in k8s. This eliminates the need for patching the images to contain the company internal CA.