### PR TITLE
[openstack/manila] Make use of trust-bundle snippets

### DIFF
--- a/openstack/manila/Chart.lock
+++ b/openstack/manila/Chart.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.16
+  version: 0.7.18
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.4
+  version: 0.1.5
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.7
@@ -16,9 +16,9 @@ dependencies:
   version: 0.5.2
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.10.4
+  version: 0.12.1
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.2.1
-digest: sha256:0b9f025d6c1e574828335e08628c0305ce1921583c7578f6c87a42e059d3ea17
-generated: "2023-10-23T10:58:00.307139+02:00"
+digest: sha256:aee6015610eafe67390ec890c847d67e8da60c01a362555f599a8ed64383c0fa
+generated: "2023-11-14T16:13:51.45505217+01:00"

--- a/openstack/manila/Chart.yaml
+++ b/openstack/manila/Chart.yaml
@@ -31,7 +31,7 @@ dependencies:
     version: ~0.5.2
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.10.4
+    version: ~0.12.1
   - name: redis
     alias: api-ratelimit-redis
     repository: https://charts.eu-de-2.cloud.sap

--- a/openstack/manila/templates/api-deployment.yaml
+++ b/openstack/manila/templates/api-deployment.yaml
@@ -172,6 +172,7 @@ spec:
               readOnly: true
             {{- include "utils.coordination.volume_mount" . | indent 12 }}
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+            {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
           {{- if .Values.pod.resources.api }}
           resources:
             {{ toYaml .Values.pod.resources.api | nindent 13 }}
@@ -215,3 +216,4 @@ spec:
             defaultMode: 0555
         {{- include "utils.coordination.volumes" . | indent 8 }}
         {{- include "utils.proxysql.volumes" . | indent 8 }}
+        {{- include "utils.trust_bundle.volumes" . | indent 8 }}

--- a/openstack/manila/templates/migration-job.yaml
+++ b/openstack/manila/templates/migration-job.yaml
@@ -64,6 +64,7 @@ spec:
               readOnly: true
             - mountPath: /container.init
               name: container-init
+            {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
 {{- if $proxysql }}
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
         {{- include "utils.proxysql.container" . | indent 8 }}
@@ -78,6 +79,7 @@ spec:
           configMap:
             name: manila-bin
             defaultMode: 0755
+        {{- include "utils.trust_bundle.volumes" . | indent 8 }}
 {{- if $proxysql }}
         {{- include "utils.proxysql.volumes" . | indent 8 }}
 {{- end }}

--- a/openstack/manila/templates/scheduler-deployment.yaml
+++ b/openstack/manila/templates/scheduler-deployment.yaml
@@ -113,6 +113,7 @@ spec:
               readOnly: true
             {{- include "utils.coordination.volume_mount" . | indent 12 }}
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+            {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
           {{- if .Values.pod.resources.scheduler }}
           resources:
 {{ toYaml .Values.pod.resources.scheduler | indent 13 }}
@@ -148,3 +149,4 @@ spec:
             name: {{ .Release.Name }}-etc
         {{- include "utils.coordination.volumes" . | indent 8 }}
         {{- include "utils.proxysql.volumes" . | indent 8 }}
+        {{- include "utils.trust_bundle.volumes" . | indent 8 }}

--- a/openstack/manila/templates/shares/_netapp-deployment.yaml.tpl
+++ b/openstack/manila/templates/shares/_netapp-deployment.yaml.tpl
@@ -97,6 +97,7 @@ spec:
               subPath: backend.conf
               readOnly: true
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+            {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
           {{- if .Values.pod.resources.share }}
           resources:
 {{ toYaml .Values.pod.resources.share | indent 13 }}
@@ -152,5 +153,6 @@ spec:
           configMap:
             name: {{ .Release.Name }}-share-netapp-{{$share.name}}
         {{- include "utils.proxysql.volumes" . | indent 8 }}
+        {{- include "utils.trust_bundle.volumes" . | indent 8 }}
 {{ end }}
 {{- end -}}

--- a/openstack/manila/templates/shares/_netapp-ensure-deployment.yaml.tpl
+++ b/openstack/manila/templates/shares/_netapp-ensure-deployment.yaml.tpl
@@ -87,6 +87,7 @@ spec:
               subPath: backend.conf
               readOnly: true
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+            {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
           {{- if .Values.pod.resources.share_ensure }}
           resources:
             {{ toYaml .Values.pod.resources.share_ensure | nindent 13 }}
@@ -119,5 +120,6 @@ spec:
           configMap:
             name: {{ .Release.Name }}-share-netapp-{{$share.name}}
         {{- include "utils.proxysql.volumes" . | indent 8 }}
+        {{- include "utils.trust_bundle.volumes" . | indent 8 }}
 {{ end }}
 {{- end -}}


### PR DESCRIPTION
The snippets replace the system ca trust-bundle with a centrally managed one by trust-manager in k8s. This eliminates the need for patching the images to contain the company internal CA.