### PR TITLE
[openstack/neutron] Make use of trust-bundle snippets

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 0.6.0
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.14.1
+  version: 0.14.3
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:fd3fa1c7d698d30477b8251eb46fa0243c945ab5c005294b8eee0275c5beb8b9
-generated: "2023-12-14T10:39:57.105854459+01:00"
+digest: sha256:056ef37daf044ee3d39c5b7f7100aa4a861fde10d55a0d9692286ef2accb6fcd
+generated: "2023-12-22T09:59:05.860714653+01:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -20,7 +20,7 @@ dependencies:
     version: 0.6.0
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.14.1
+    version: 0.14.3
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0

--- a/openstack/neutron/templates/_helper.tpl
+++ b/openstack/neutron/templates/_helper.tpl
@@ -1,3 +1,8 @@
 {{- define "neutron.migration_job_name" -}}
-neutron-migration-{{ .Values.imageVersion | required "Please set neutron.imageVersion or similar"}}{{ if .Values.proxysql }}{{ if .Values.proxysql.mode }}-{{ .Values.proxysql.mode | replace "_" "-" }}{{ end }}{{ end }}
+  {{- $bin := include "utils.proxysql.proxysql_signal_stop_script" . | trim }}
+  {{- $all := list $bin (include "utils.proxysql.job_pod_settings" . ) (include "utils.proxysql.volume_mount" . ) (include "utils.proxysql.container" . ) (include "utils.proxysql.volumes" .) (tuple . (dict) | include "utils.snippets.kubernetes_entrypoint_init_container")  | join "\n" }}
+  {{- $all := list $bin (include "utils.proxysql.job_pod_settings" . ) (include "utils.proxysql.volume_mount" . ) (include "utils.proxysql.container" . ) (include "utils.proxysql.volumes" .) (tuple . (dict) | include "utils.snippets.kubernetes_entrypoint_init_container") (include "utils.trust_bundle.volume_mount" . ) (include "utils.trust_bundle.volumes" . ) (include "utils.trust_bundle.env" . )  | join "\n" }}
+  {{- $hash := empty .Values.proxysql.mode | ternary $bin $all | sha256sum }}
+
+  {{- .Release.Name }}-migration-{{ substr 0 4 $hash }}-{{ .Values.imageVersion | required "Please set neutron.imageVersion or similar"}}
 {{- end }}

--- a/openstack/neutron/templates/daemonset-metadata-agent.yaml
+++ b/openstack/neutron/templates/daemonset-metadata-agent.yaml
@@ -53,6 +53,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
+            {{- include "utils.trust_bundle.env" . | indent 12 }}
           livenessProbe:
             exec:
               command: ["neutron-agent-liveness", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/run/hostname.conf", "--agent-type", "Metadata agent"]
@@ -67,6 +68,7 @@ spec:
             - name: etc-neutron
               mountPath: /etc/neutron
               readOnly: true
+            {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
       volumes:
         - name: metadata-proxy
           hostPath:
@@ -84,4 +86,5 @@ spec:
                   path: logging.conf
                 - key: metadata-agent.ini
                   path: metadata-agent.ini
+        {{- include "utils.trust_bundle.volumes" . | indent 8 }}
   {{- end }}

--- a/openstack/neutron/templates/deployment-aci-agent.yaml
+++ b/openstack/neutron/templates/deployment-aci-agent.yaml
@@ -57,6 +57,7 @@ spec:
                 secretKeyRef:
                   name: sentry
                   key: neutron.DSN.python
+            {{- include "utils.trust_bundle.env" . | indent 12 }}
           volumeMounts:
             - mountPath: /neutron-etc
               name: neutron-etc
@@ -66,6 +67,7 @@ spec:
               name: neutron-etc-region
             - mountPath: /container.init
               name: container-init
+            {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
       volumes:
         - name: neutron-etc
           configMap:
@@ -80,4 +82,4 @@ spec:
           configMap:
             name: neutron-bin-vendor
             defaultMode: 0755
-
+        {{- include "utils.trust_bundle.volumes" . | indent 8 }}

--- a/openstack/neutron/templates/deployment-cc-fabric-agent.yaml
+++ b/openstack/neutron/templates/deployment-cc-fabric-agent.yaml
@@ -66,6 +66,7 @@ spec:
                 secretKeyRef:
                   name: sentry
                   key: neutron.DSN.python
+            {{- include "utils.trust_bundle.env" $ | indent 12 }}
           ports:
             - containerPort: 9090
               name: metrics
@@ -96,6 +97,7 @@ spec:
               name: neutron-etc
               subPath: logging.conf
               readOnly: true
+            {{- include "utils.trust_bundle.volume_mount" $ | indent 12 }}
       volumes:
         - name: empty-neutron-ml2
           emptyDir: {}
@@ -105,5 +107,6 @@ spec:
         - name: neutron-etc-cc-fabric
           configMap:
             name: neutron-etc-cc-fabric
+        {{- include "utils.trust_bundle.volumes" $ | indent 8 }}
 {{- end }}
 {{- end }}

--- a/openstack/neutron/templates/deployment-ironic-agent.yaml
+++ b/openstack/neutron/templates/deployment-ironic-agent.yaml
@@ -47,10 +47,12 @@ spec:
                 secretKeyRef:
                   name: sentry
                   key: neutron.DSN.python
+            {{- include "utils.trust_bundle.env" . | indent 12 }}
           volumeMounts:
             - name: etc-neutron
               mountPath: /etc/neutron
               readOnly: true
+            {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
       volumes:
         - name: etc-neutron
           projected:
@@ -68,4 +70,5 @@ spec:
                 items:
                 - key: ironic_neutron_agent.ini
                   path: plugins/ml2/ironic_neutron_agent.ini
+        {{- include "utils.trust_bundle.volumes" . | indent 8 }}
 {{- end }}

--- a/openstack/neutron/templates/deployment-nsxv3-logstash.yaml
+++ b/openstack/neutron/templates/deployment-nsxv3-logstash.yaml
@@ -57,12 +57,14 @@ spec:
           env:
           - name: XPACK_MONITORING_ENABLED
             value: "false"
+          {{- include "utils.trust_bundle.env" . | indent 10 }}
           ports:
           - containerPort: 5514
           volumeMounts:
           - mountPath: /usr/share/logstash/pipeline/logstash.conf
             subPath: pipeline.conf
             name: logger-config
+          {{- include "utils.trust_bundle.volume_mount" . | indent 10 }}
         {{- if .Values.logger.persistence.enabled }}
           - name: logstash-data
             mountPath: /data
@@ -93,4 +95,5 @@ spec:
           persistentVolumeClaim:
             claimName: neutron-nsxv3-logstash
         {{- end }}
+        {{- include "utils.trust_bundle.volumes" . | indent 8 }}
 {{- end -}}

--- a/openstack/neutron/templates/deployment-rpc-server.yaml
+++ b/openstack/neutron/templates/deployment-rpc-server.yaml
@@ -77,6 +77,7 @@ spec:
                   fieldPath: metadata.name
             - name: PYTHONWARNINGS
               value: "ignore:Unverified HTTPS request"
+            {{- include "utils.trust_bundle.env" . | indent 12 }}
           resources:
 {{ toYaml .Values.pod.resources.rpc_server | indent 12 }}
           volumeMounts:
@@ -139,6 +140,7 @@ spec:
               readOnly: true
             {{- end}}
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+            {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
             {{- include "utils.coordination.volume_mount"  . | indent 12 }}
         {{- tuple . (add .Values.rpc_workers .Values.rpc_state_workers)| include "utils.proxysql.container" | indent 8 }}
 {{- include "jaeger_agent_sidecar" . | indent 8 }}
@@ -164,5 +166,6 @@ spec:
             name: neutron-bin
             defaultMode: 0755
         {{- include "utils.proxysql.volumes" . | indent 8 }}
+        {{- include "utils.trust_bundle.volumes" . | indent 8 }}
         {{- include "utils.coordination.volumes" . | indent 8 }}
 {{- end }}

--- a/openstack/neutron/templates/deployment-server.yaml
+++ b/openstack/neutron/templates/deployment-server.yaml
@@ -112,6 +112,7 @@ spec:
                   fieldPath: metadata.name
             - name: PYTHONWARNINGS
               value: "ignore:Unverified HTTPS request"
+            {{- include "utils.trust_bundle.env" . | indent 12 }}
           resources:
 {{- if .Values.api.uwsgi }}
 {{ toYaml .Values.pod.resources.uwsgi_server | indent 12 }}
@@ -232,6 +233,7 @@ spec:
               name: container-init
 {{- end }}
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+            {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
             {{- include "utils.coordination.volume_mount"  . | indent 12 }}
 {{- if not .Values.api.uwsgi }}
         {{- tuple . (add .Values.api_workers .Values.rpc_workers .Values.rpc_state_workers) | include "utils.proxysql.container" | indent 8 }}
@@ -283,4 +285,5 @@ spec:
             name: neutron-bin
             defaultMode: 0755
         {{- include "utils.proxysql.volumes" . | indent 8 }}
+        {{- include "utils.trust_bundle.volumes" . | indent 8 }}
         {{- include "utils.coordination.volumes" . | indent 8 }}

--- a/openstack/neutron/templates/deployment-ucs-bm-ml2-agent.yaml
+++ b/openstack/neutron/templates/deployment-ucs-bm-ml2-agent.yaml
@@ -60,12 +60,14 @@ spec:
                   key: neutron.DSN.python
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
+            {{- include "utils.trust_bundle.env" . | indent 12 }}
           resources:
 {{ toYaml .Values.pod.resources.cisco_ml2_ucsm_bm | indent 12 }}
           volumeMounts:
             - name: etc-neutron
               mountPath: /etc/neutron
               readOnly: true
+            {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
       volumes:
         - name: etc-neutron
           projected:
@@ -85,4 +87,5 @@ spec:
                 items:
                 - key: cisco-ucs-bm-ml2-agent.ini
                   path: plugins/ml2/cisco-ucs-bm-ml2-agent.ini
+        {{- include "utils.trust_bundle.volumes" . | indent 8 }}
 {{- end -}}

--- a/openstack/neutron/templates/job-migration.yaml
+++ b/openstack/neutron/templates/job-migration.yaml
@@ -48,11 +48,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            {{- include "utils.trust_bundle.env" . | indent 12 }}
           volumeMounts:
             - mountPath: /etc/neutron
               name: etc-neutron
               readOnly: true
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+            {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
         {{- include "utils.proxysql.container" . | indent 8 }}
       volumes:
         - name: etc-neutron
@@ -67,3 +69,4 @@ spec:
                   path: plugins/ml2/ml2-conf.ini
                 name: neutron-etc
         {{- include "utils.proxysql.volumes" . | indent 8 }}
+        {{- include "utils.trust_bundle.volumes" . | indent 8 }}

--- a/openstack/neutron/templates/sftp-deployment.yaml
+++ b/openstack/neutron/templates/sftp-deployment.yaml
@@ -35,6 +35,7 @@ spec:
                 secretKeyRef:
                   name: neutron-sftp-backup
                   key: password
+            {{- include "utils.trust_bundle.env" . | indent 12 }}
           resources:
 {{ toYaml .Values.pod.resources.sftp_backup | indent 12 }}
           volumeMounts:
@@ -52,6 +53,7 @@ spec:
               readOnly: true
             - mountPath: /tmp
               name: cache-volume
+            {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
       volumes:
         - name: neutron-sftp-backup
           configMap:

--- a/openstack/neutron/templates/statefulset-network-agent-apod.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent-apod.yaml
@@ -1,3 +1,4 @@
+{{- $envAll := . }}
 {{- if .Values.agent.apod | default false }}
 {{- if .Values.global.apods | default false }}
 {{- $release_requires_sec_cap:= or (hasPrefix "ussuri" (default .Values.imageVersion .Values.imageVersionServerAPI)) (hasPrefix "yoga" (default .Values.imageVersion .Values.imageVersionServerAPI)) -}}
@@ -101,6 +102,7 @@ spec:
               value: "yes,please"
             - name: PYTHONWARNINGS
               value: "ignore:Unverified HTTPS request"
+            {{- include "utils.trust_bundle.env" $ | indent 12 }}
           readinessProbe:
             exec:
               command: ["neutron-dhcp-readiness", "-config-file", "/etc/neutron/neutron.conf"]
@@ -129,6 +131,7 @@ spec:
               readOnly: true
             - name: network-namespace
               mountPath: /var/run/netns
+            {{- include "utils.trust_bundle.volume_mount" $ | indent 12 }}
         - name: neutron-linuxbridge-agent
           image: {{$.Values.global.registry}}/loci-neutron:{{$.Values.imageVersionNetworkAgentLinuxBridge | default $.Values.imageVersionNetworkAgent | default $.Values.imageVersion | required "Please set neutron.imageVersionNetworkAgentLinuxBridge or similar"}}
           imagePullPolicy: IfNotPresent
@@ -143,6 +146,7 @@ spec:
               value: "false"
             - name: PYTHONWARNINGS
               value: "ignore:Unverified HTTPS request"
+            {{- include "utils.trust_bundle.env" $ | indent 12 }}
           readinessProbe:
             exec:
               command: ["neutron-linuxbridge-readiness", "-config-file", "/etc/neutron/neutron.conf"]
@@ -174,6 +178,7 @@ spec:
               readOnly: true
             - name: network-namespace
               mountPath: /var/run/netns
+            {{- include "utils.trust_bundle.volume_mount" $ | indent 12 }}
         - name: neutron-metadata-agent
           image: {{$.Values.global.registry}}/loci-neutron:{{$.Values.imageVersionNetworkAgentMetadata | default $.Values.imageVersionNetworkAgent | default $.Values.imageVersion | required "Please set neutron.imageVersionNetworkAgentMetadata or similar"}}
           imagePullPolicy: IfNotPresent
@@ -188,6 +193,7 @@ spec:
               value: "ignore:Unverified HTTPS request"
             - name: DEBUG_CONTAINER
               value: "false"
+            {{- include "utils.trust_bundle.env" $ | indent 12 }}
           resources:
 {{  toYaml $.Values.pod.resources.metadata_agent | indent 12 }}
           volumeMounts:
@@ -196,6 +202,7 @@ spec:
             - name: etc-neutron-metadata-agent
               mountPath: /etc/neutron
               readOnly: true
+            {{- include "utils.trust_bundle.volume_mount" $ | indent 12 }}
       volumes:
         - name: metadata-proxy
           emptyDir: {}
@@ -271,6 +278,7 @@ spec:
                   path: logging.conf
                 - key: metadata-agent.ini
                   path: metadata-agent.ini
+        {{- include "utils.trust_bundle.volumes" $ | indent 8 }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/openstack/neutron/templates/statefulset-network-agent.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent.yaml
@@ -1,3 +1,4 @@
+{{- $envAll := . }}
 {{- $release_requires_sec_cap:= or (hasPrefix "ussuri" (default .Values.imageVersion .Values.imageVersionServerAPI)) (hasPrefix "yoga" (default .Values.imageVersion .Values.imageVersionServerAPI)) -}}
 {{- if and (.Values.agent.multus | default false) .Values.agent.controlplane }}
 {{- $az_count := len .Values.global.availability_zones -}}
@@ -97,6 +98,7 @@ spec:
               value: "yes,please"
             - name: PYTHONWARNINGS
               value: "ignore:Unverified HTTPS request"
+            {{- include "utils.trust_bundle.env" $ | indent 12 }}
           readinessProbe:
             exec:
               command: ["neutron-dhcp-readiness", "-config-file", "/etc/neutron/neutron.conf"]
@@ -154,6 +156,7 @@ spec:
               readOnly: false
             - name: network-namespace
               mountPath: /var/run/netns
+            {{- include "utils.trust_bundle.volume_mount" $ | indent 12 }}
 {{- if $.Values.agent.neutron_l3 | default false }}
         - name: neutron-l3-agent
           image: {{$.Values.global.registry}}/loci-neutron:{{$.Values.imageVersionNetworkAgentL3 | default $.Values.imageVersionNetworkAgent | default $.Values.imageVersion | required "Please set neutron.imageVersionNetworkAgentL3 or similar"}}
@@ -167,6 +170,7 @@ spec:
                   key: neutron.DSN.python
             - name: DEBUG_CONTAINER
               value: "false"
+            {{- include "utils.trust_bundle.env" $ | indent 12 }}
           securityContext:
             privileged: true
           volumeMounts:
@@ -209,6 +213,7 @@ spec:
               mountPath: /etc/sudoers
               subPath: sudoers
               readOnly: true
+            {{- include "utils.trust_bundle.volume_mount" $ | indent 12 }}
 {{- end }}
         - name: neutron-linuxbridge-agent
           image: {{$.Values.global.registry}}/loci-neutron:{{$.Values.imageVersionNetworkAgentLinuxBridge | default $.Values.imageVersionNetworkAgent | default $.Values.imageVersion | required "Please set neutron.imageVersionNetworkAgentLinuxBridge or similar"}}
@@ -226,6 +231,7 @@ spec:
               value: "ignore:Unverified HTTPS request"
             - name: OS_LINUX_BRIDGE__PHYSICAL_INTERFACE_MAPPINGS
               value: {{required "A valid .Values.global.cp required!" $.Values.global.cp}}:{{required "A valid .Values.cp_network_interface required!" $.Values.cp_network_interface}}
+            {{- include "utils.trust_bundle.env" $ | indent 12 }}
           readinessProbe:
             exec:
               command: ["neutron-linuxbridge-readiness", "-config-file", "/etc/neutron/neutron.conf"]
@@ -274,6 +280,7 @@ spec:
               readOnly: true
             - name: network-namespace
               mountPath: /var/run/netns
+            {{- include "utils.trust_bundle.volume_mount" $ | indent 12 }}
       volumes:
         - name: metadata-proxy
           hostPath:
@@ -292,5 +299,6 @@ spec:
         - name: host
           hostPath:
               path: "/"
+        {{- include "utils.trust_bundle.volumes" $ | indent 8 }}
 {{- end }}
 {{- end }}

--- a/openstack/neutron/templates/statefulset-swift-injector.yaml
+++ b/openstack/neutron/templates/statefulset-swift-injector.yaml
@@ -84,6 +84,7 @@ spec:
               value: {{ $.Values.global.keystone_service_project |  default "service" }}
             - name: OS_USER_DOMAIN_NAME
               value: {{ $.Values.global.keystone_service_domain | default "Default" }}
+            {{- include "utils.trust_bundle.env" $ | indent 12 }}
           securityContext:
             privileged: true
           volumeMounts:
@@ -91,6 +92,7 @@ spec:
               mountPath: /var/run/netns
             - name: socat-proxy
               mountPath: /var/run/socat-proxy
+            {{- include "utils.trust_bundle.volume_mount" $ | indent 12 }}
           ports:
             - name: metrics-inject
               containerPort: 8080
@@ -112,6 +114,7 @@ spec:
               value: "false"
             - name: PYTHONWARNINGS
               value: "ignore:Unverified HTTPS request"
+            {{- include "utils.trust_bundle.env" $ | indent 12 }}
           readinessProbe:
             exec:
               command: ["neutron-agent-liveness", "-config-file", "/etc/neutron/neutron.conf", "-agent-type", "Linux bridge agent"]
@@ -141,6 +144,7 @@ spec:
               readOnly: true
             - name: network-namespace
               mountPath: /var/run/netns
+            {{- include "utils.trust_bundle.volume_mount" $ | indent 12 }}
         - name: socat
           image: {{ $.Values.global.registry }}/network-injector:{{ $.Values.imageVersionNetworkInjector | default "latest" }}
           imagePullPolicy: IfNotPresent
@@ -185,6 +189,7 @@ spec:
                 items:
                 - key: apod-{{ $apod }}.conf
                   path: apod-{{ $apod }}.conf
+        {{- include "utils.trust_bundle.volumes" $ | indent 8 }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/openstack/neutron/templates/vct-nsxv3-agent-deployment.yaml
+++ b/openstack/neutron/templates/vct-nsxv3-agent-deployment.yaml
@@ -63,6 +63,7 @@ template: |
             value: neutron-nsxv3-agent-{= name =}
           - name: REQUESTS_CA_BUNDLE
             value: ""
+          {{- include "utils.trust_bundle.env" . | indent 10 }}
           ports:
             - name: metrics-agent
               containerPort: 8000
@@ -78,6 +79,7 @@ template: |
           - name: etc-neutron
             mountPath: /etc/neutron
             readOnly: true
+          {{- include "utils.trust_bundle.volume_mount" . | indent 10 }}
         - name: exporter
           image: {{.Values.global.registry}}/nsx-t-exporter:{{.Values.imageVersionNSXTExporter | required "Please set neutron.imageVersionNSXTExporter"}}
           ports:
@@ -127,4 +129,5 @@ template: |
                 items:
                 - key: ml2-nsxv3.ini
                   path: plugins/ml2/ml2-nsxv3.ini
+        {{- include "utils.trust_bundle.volumes" . | indent 8 }}
 {{- end }}

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -782,6 +782,10 @@ memcached:
   alerts:
     support_group: network-api
 
+utils:
+  trust_bundle:
+    enable: false
+
 vpa:
   # https://github.com/sapcc/vpa_butler
   # The maximum available capacity is split evenly across containers specified in the Deployment, StatefulSet or DaemonSet to derive the upper recommendation bound. This does not work out for pods with a single resource-hungry container with several sidecar containers


### PR DESCRIPTION
The snippets replace the system ca trust-bundle with a centrally managed one by trust-manager in k8s. This eliminates the need for patching the images to contain the company internal CA.

Also update the job-name to include more fields to monitor for a change.