### PR TITLE
[openstack/octavia] Make use of trust-bundle snippets

### DIFF
--- a/openstack/octavia/Chart.lock
+++ b/openstack/octavia/Chart.lock
@@ -21,4 +21,4 @@ dependencies:
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
 digest: sha256:1a6a12ea2e327794e161a0ba0fb66ab079cbb075aa8670b62bff7fe1bf6659ab
-generated: "2023-12-04T15:45:14.478899686+01:00"
+generated: "2023-12-08T13:23:08.440319798+01:00"

--- a/openstack/octavia/templates/octavia-api-deployment.yaml
+++ b/openstack/octavia/templates/octavia-api-deployment.yaml
@@ -114,6 +114,7 @@ spec:
               readOnly: true
             {{- end }}
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+            {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
         {{- include "utils.proxysql.container" . | indent 8 }}
         {{- include "jaeger_agent_sidecar" . | indent 8 }}
 {{- if .Values.watcher.enabled }}
@@ -134,3 +135,4 @@ spec:
           configMap:
             name: octavia-etc
         {{- include "utils.proxysql.volumes" . | indent 8 }}
+        {{- include "utils.trust_bundle.volumes" . | indent 8 }}

--- a/openstack/octavia/templates/octavia-housekeeping.yaml
+++ b/openstack/octavia/templates/octavia-housekeeping.yaml
@@ -46,6 +46,7 @@ spec:
               subPath: logging.ini
               readOnly: true
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+            {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
           env:
             - name: COMMAND
               value: "octavia-f5-housekeeping --config-file /etc/octavia/octavia.conf"
@@ -70,3 +71,4 @@ spec:
           configMap:
             name: octavia-etc
         {{- include "utils.proxysql.volumes" . | indent 8 }}
+        {{- include "utils.trust_bundle.volumes" . | indent 8 }}

--- a/openstack/octavia/templates/octavia-migration-job.yaml
+++ b/openstack/octavia/templates/octavia-migration-job.yaml
@@ -64,6 +64,7 @@ spec:
               mountPath: /etc/octavia/logging.ini
               subPath: logging.ini
               readOnly: true
+            {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
     {{- if $proxysql}}
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
         {{- include "utils.proxysql.container" . | indent 8 }}
@@ -75,3 +76,4 @@ spec:
     {{- if $proxysql}}
         {{- include "utils.proxysql.volumes" . | indent 8 }}
     {{- end }}
+        {{- include "utils.trust_bundle.volumes" . | indent 8 }}

--- a/openstack/octavia/templates/octavia-worker-deployment.yaml
+++ b/openstack/octavia/templates/octavia-worker-deployment.yaml
@@ -60,6 +60,7 @@ spec:
             - mountPath: /var/run/octavia
               name: octavia-var
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+            {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
           env:
             - name: COMMAND
               value: "octavia-worker --config-file /etc/octavia/octavia.conf --config-file /etc/octavia/octavia-worker.conf"
@@ -96,6 +97,7 @@ spec:
             - mountPath: /var/run/octavia
               name: octavia-var
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+            {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
           env:
             - name: COMMAND
               value: "octavia-driver-agent --config-file /etc/octavia/octavia.conf"
@@ -133,6 +135,7 @@ spec:
               subPath: logging.ini
               readOnly: true
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+            {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
           env:
             - name: COMMAND
               value: "octavia-f5-status-manager --config-file /etc/octavia/octavia.conf --config-file /etc/octavia/octavia-worker.conf"
@@ -164,5 +167,6 @@ spec:
         - name: octavia-var
           emptyDir: {}
         {{- include "utils.proxysql.volumes" . | indent 8 }}
+        {{- include "utils.trust_bundle.volumes" . | indent 8 }}
 {{- end }}
 {{- end }}

--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -359,3 +359,7 @@ logging:
     sqlalchemy:
       handlers: stdout, sentry
       level: WARNING
+
+utils:
+  trust_bundle:
+    enable: true


### PR DESCRIPTION
The snippets replace the system ca trust-bundle with a centrally managed one by trust-manager in k8s. This eliminates the need for patching the images to contain the company internal CA.

Also update the job-name to include more fields to monitor for a change.