### PR TITLE
[Neutron] Add basic linkerd support, bump chart and supporting charts…

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -19,9 +19,9 @@ dependencies:
   version: 0.2.0
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
-  version: 1.2.29
+  version: 1.3.5
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:6f04f17b64beab052057ddca0c156af6c538b3e580cd05a995009631b18ab821
-generated: "2023-11-15T08:54:54.347995Z"
+digest: sha256:efd832e4ef2e9e4c733b30d45987fd48bad71c880c14b65e32df41051275f3c9
+generated: "2023-11-15T09:38:18.34335Z"

--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -1,24 +1,27 @@
 dependencies:
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.5
+  version: 0.8.0
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.1
+  version: 0.1.5
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.7
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.5.1
+  version: 0.6.0
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.4
+  version: 0.11.1
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.2.29
-digest: sha256:d67ea10c8eb6dfbc6c599be1918463d0ec774e5fe7d05992ccaa9b749c78aa0e
-generated: "2023-11-13T16:52:09.490020548+01:00"
+- name: linkerd-support
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 0.1.3
+digest: sha256:6f04f17b64beab052057ddca0c156af6c538b3e580cd05a995009631b18ab821
+generated: "2023-11-15T08:54:54.347995Z"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -1,26 +1,26 @@
 apiVersion: v2
 description: A Helm chart for Openstack Neutron
 name: neutron
-version: 0.2.0
+version: 0.2.2
 appVersion: "yoga"
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.7.5
+    version: 0.8.0
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.1
+    version: 0.1.5
   - condition: mariadb.enabled
     name: mysql_metrics
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.7
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.5.1
+    version: 0.6.0
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.7.2
+    version: 0.11.1
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0
@@ -29,3 +29,6 @@ dependencies:
     repository: https://charts.eu-de-2.cloud.sap
     version: 1.2.29
     condition: rate_limit.enabled
+  - name: linkerd-support
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: 0.1.3

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -27,7 +27,7 @@ dependencies:
   - name: redis
     alias: api-ratelimit-redis
     repository: https://charts.eu-de-2.cloud.sap
-    version: 1.2.29
+    version: 1.3.5
     condition: rate_limit.enabled
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/neutron/templates/daemonset-metadata-agent.yaml
+++ b/openstack/neutron/templates/daemonset-metadata-agent.yaml
@@ -21,6 +21,7 @@ spec:
     metadata:
       annotations:
         configmap-etc-hash: {{ include (print .Template.BasePath "/configmap-etc.yaml") $ | sha256sum }}
+        {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 8 }}
       labels:
         name: neutron-metadata-agent
 {{ tuple . "neutron" "metadata-agent" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}

--- a/openstack/neutron/templates/daemonset-metadata-agent.yaml
+++ b/openstack/neutron/templates/daemonset-metadata-agent.yaml
@@ -21,7 +21,7 @@ spec:
     metadata:
       annotations:
         configmap-etc-hash: {{ include (print .Template.BasePath "/configmap-etc.yaml") $ | sha256sum }}
-        {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 8 }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
       labels:
         name: neutron-metadata-agent
 {{ tuple . "neutron" "metadata-agent" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}

--- a/openstack/neutron/templates/deployment-aci-agent.yaml
+++ b/openstack/neutron/templates/deployment-aci-agent.yaml
@@ -28,6 +28,7 @@ spec:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") . | sha256sum }}
         configmap-etc-region-hash: {{ include (print $.Template.BasePath "/configmap-etc-region.yaml") . | sha256sum }}
         configmap-etc-vendor-hash: {{ include (print $.Template.BasePath "/configmap-etc-vendor.yaml") . | sha256sum }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
       hostname:  aci-agent-pet
       containers:

--- a/openstack/neutron/templates/deployment-cc-fabric-agent.yaml
+++ b/openstack/neutron/templates/deployment-cc-fabric-agent.yaml
@@ -32,6 +32,7 @@ spec:
         configmap-etc-cc-fabric: {{ include (print $.Template.BasePath "/configmap-etc-cc-fabric.yaml") $ | sha256sum }}
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required "$.Values.metrics.prometheus missing" $.Values.metrics.prometheus }}
+        {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 8 }}
     spec:
       hostname: cc-fabric-{{ $platform }}-agent
       containers:

--- a/openstack/neutron/templates/deployment-ironic-agent.yaml
+++ b/openstack/neutron/templates/deployment-ironic-agent.yaml
@@ -8,6 +8,8 @@ metadata:
     system: openstack
     type: backend
     component: neutron
+  annotations:
+    {{- include "utils.linkerd.ingress_annotation" $ | indent 4 }}
 spec:
   replicas: 1
   revisionHistoryLimit: 5

--- a/openstack/neutron/templates/deployment-ironic-agent.yaml
+++ b/openstack/neutron/templates/deployment-ironic-agent.yaml
@@ -9,7 +9,7 @@ metadata:
     type: backend
     component: neutron
   annotations:
-    {{- include "utils.linkerd.ingress_annotation" $ | indent 4 }}
+    {{- include "utils.linkerd.ingress_annotation" . | indent 4 }}
 spec:
   replicas: 1
   revisionHistoryLimit: 5

--- a/openstack/neutron/templates/deployment-nsxv3-logstash.yaml
+++ b/openstack/neutron/templates/deployment-nsxv3-logstash.yaml
@@ -22,7 +22,7 @@ spec:
         name: neutron-nsxv3-logstash
       annotations:
         configmap-logger-hash: {{ include (print .Template.BasePath "/configmap-nsxv3-logstash.yaml") . | sha256sum }}
-        {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 8 }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
       {{- if .Values.logger.persistence.enabled }}
       initContainers:

--- a/openstack/neutron/templates/deployment-nsxv3-logstash.yaml
+++ b/openstack/neutron/templates/deployment-nsxv3-logstash.yaml
@@ -22,6 +22,7 @@ spec:
         name: neutron-nsxv3-logstash
       annotations:
         configmap-logger-hash: {{ include (print .Template.BasePath "/configmap-nsxv3-logstash.yaml") . | sha256sum }}
+        {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 8 }}
     spec:
       {{- if .Values.logger.persistence.enabled }}
       initContainers:

--- a/openstack/neutron/templates/deployment-rpc-server.yaml
+++ b/openstack/neutron/templates/deployment-rpc-server.yaml
@@ -37,8 +37,8 @@ spec:
         {{- if .Values.proxysql.mode }}
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required "$.Values.metrics.prometheus missing" $.Values.metrics.prometheus }}
-        {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 8 }}
         {{- end }}
+        {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 8 }}
     spec:
 {{ tuple . "neutron" "rpc" | include "kubernetes_pod_anti_affinity" | indent 6 }}
       {{- include "utils.proxysql.pod_settings" . | indent 6 }}

--- a/openstack/neutron/templates/deployment-rpc-server.yaml
+++ b/openstack/neutron/templates/deployment-rpc-server.yaml
@@ -38,7 +38,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required "$.Values.metrics.prometheus missing" $.Values.metrics.prometheus }}
         {{- end }}
-        {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 8 }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
 {{ tuple . "neutron" "rpc" | include "kubernetes_pod_anti_affinity" | indent 6 }}
       {{- include "utils.proxysql.pod_settings" . | indent 6 }}

--- a/openstack/neutron/templates/deployment-rpc-server.yaml
+++ b/openstack/neutron/templates/deployment-rpc-server.yaml
@@ -37,6 +37,7 @@ spec:
         {{- if .Values.proxysql.mode }}
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required "$.Values.metrics.prometheus missing" $.Values.metrics.prometheus }}
+        {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 8 }}
         {{- end }}
     spec:
 {{ tuple . "neutron" "rpc" | include "kubernetes_pod_anti_affinity" | indent 6 }}

--- a/openstack/neutron/templates/deployment-server.yaml
+++ b/openstack/neutron/templates/deployment-server.yaml
@@ -29,6 +29,7 @@ spec:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") . | sha256sum }}
         configmap-etc-region-hash: {{ include (print $.Template.BasePath "/configmap-etc-region.yaml") . | sha256sum }}
         configmap-etc-vendor-hash: {{ include (print $.Template.BasePath "/configmap-etc-vendor.yaml") . | sha256sum }}
+        {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 8 }}
 {{- if .Values.api.uwsgi }}
         configmap-etc-api-hash: {{ include (print $.Template.BasePath "/configmap-etc-api.yaml") . | sha256sum }}
 {{- if .Values.cc_fabric.enabled }}

--- a/openstack/neutron/templates/deployment-server.yaml
+++ b/openstack/neutron/templates/deployment-server.yaml
@@ -29,7 +29,7 @@ spec:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") . | sha256sum }}
         configmap-etc-region-hash: {{ include (print $.Template.BasePath "/configmap-etc-region.yaml") . | sha256sum }}
         configmap-etc-vendor-hash: {{ include (print $.Template.BasePath "/configmap-etc-vendor.yaml") . | sha256sum }}
-        {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 8 }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
 {{- if .Values.api.uwsgi }}
         configmap-etc-api-hash: {{ include (print $.Template.BasePath "/configmap-etc-api.yaml") . | sha256sum }}
 {{- if .Values.cc_fabric.enabled }}

--- a/openstack/neutron/templates/deployment-ucs-bm-ml2-agent.yaml
+++ b/openstack/neutron/templates/deployment-ucs-bm-ml2-agent.yaml
@@ -25,7 +25,7 @@ spec:
         name: neutron-cisco-ml2-ucsm-bm
       annotations:
         pod.beta.kubernetes.io/hostname: cisco-ml2-ucsm-bm
-        {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 8 }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
       hostname:  cisco-ml2-ucsm-bm
       containers:

--- a/openstack/neutron/templates/deployment-ucs-bm-ml2-agent.yaml
+++ b/openstack/neutron/templates/deployment-ucs-bm-ml2-agent.yaml
@@ -25,6 +25,7 @@ spec:
         name: neutron-cisco-ml2-ucsm-bm
       annotations:
         pod.beta.kubernetes.io/hostname: cisco-ml2-ucsm-bm
+        {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 8 }}
     spec:
       hostname:  cisco-ml2-ucsm-bm
       containers:

--- a/openstack/neutron/templates/ingress-server.yaml
+++ b/openstack/neutron/templates/ingress-server.yaml
@@ -10,6 +10,7 @@ metadata:
   annotations:
     kubernetes.io/tls-acme: "true"
     disco: "true"
+    {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 4 }}
 spec:
   tls:
      - secretName: tls-{{include "neutron_api_endpoint_host_public" . | replace "." "-" }}

--- a/openstack/neutron/templates/ingress-server.yaml
+++ b/openstack/neutron/templates/ingress-server.yaml
@@ -10,7 +10,7 @@ metadata:
   annotations:
     kubernetes.io/tls-acme: "true"
     disco: "true"
-    {{- include "utils.linkerd.ingress_annotation" $ | indent 4 }}
+    {{- include "utils.linkerd.ingress_annotation" . | indent 4 }}
 spec:
   tls:
      - secretName: tls-{{include "neutron_api_endpoint_host_public" . | replace "." "-" }}

--- a/openstack/neutron/templates/ingress-server.yaml
+++ b/openstack/neutron/templates/ingress-server.yaml
@@ -10,7 +10,7 @@ metadata:
   annotations:
     kubernetes.io/tls-acme: "true"
     disco: "true"
-    {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 4 }}
+    {{- include "utils.linkerd.ingress_annotation" $ | indent 4 }}
 spec:
   tls:
      - secretName: tls-{{include "neutron_api_endpoint_host_public" . | replace "." "-" }}

--- a/openstack/neutron/templates/service-nsxv3-logstash.yaml
+++ b/openstack/neutron/templates/service-nsxv3-logstash.yaml
@@ -12,6 +12,7 @@ metadata:
     disco: "true"
     disco/record: "esxi-log.cc.{{.Values.global.region}}.{{.Values.global.tld}}."
     disco/zone-name: "cc.{{.Values.global.region}}.{{.Values.global.tld}}."
+    {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 4 }}
 spec:
   externalIPs: {{ .Values.logger.externalIPs }}
   ports:

--- a/openstack/neutron/templates/service-nsxv3-logstash.yaml
+++ b/openstack/neutron/templates/service-nsxv3-logstash.yaml
@@ -12,7 +12,7 @@ metadata:
     disco: "true"
     disco/record: "esxi-log.cc.{{.Values.global.region}}.{{.Values.global.tld}}."
     disco/zone-name: "cc.{{.Values.global.region}}.{{.Values.global.tld}}."
-    {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 4 }}
+    {{- include "utils.linkerd.pod_and_service_annotation" . | indent 4 }}
 spec:
   externalIPs: {{ .Values.logger.externalIPs }}
   ports:

--- a/openstack/neutron/templates/service-server.yaml
+++ b/openstack/neutron/templates/service-server.yaml
@@ -13,7 +13,7 @@ metadata:
     type: api
   annotations:
     maia.io/scrape: "true"
-    {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 4 }}
+    {{- include "utils.linkerd.pod_and_service_annotation" . | indent 4 }}
 spec:
   selector:
     name: neutron-server

--- a/openstack/neutron/templates/service-server.yaml
+++ b/openstack/neutron/templates/service-server.yaml
@@ -13,6 +13,7 @@ metadata:
     type: api
   annotations:
     maia.io/scrape: "true"
+    {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 4 }}
 spec:
   selector:
     name: neutron-server

--- a/openstack/neutron/templates/sftp-deployment.yaml
+++ b/openstack/neutron/templates/sftp-deployment.yaml
@@ -19,6 +19,7 @@ spec:
         component: neutron-sftp-backup
       annotations:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/sftp-configmap.yaml") . | sha256sum }}
+        {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 8 }}
     spec:
       containers:
         - name: sftp

--- a/openstack/neutron/templates/sftp-deployment.yaml
+++ b/openstack/neutron/templates/sftp-deployment.yaml
@@ -19,7 +19,7 @@ spec:
         component: neutron-sftp-backup
       annotations:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/sftp-configmap.yaml") . | sha256sum }}
-        {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 8 }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
       containers:
         - name: sftp

--- a/openstack/neutron/templates/sftp-service.yaml
+++ b/openstack/neutron/templates/sftp-service.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     disco: "true"
     disco/record: {{ include "sftp_api_endpoint_host" . }}.
+    {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 4 }}
 spec:
   selector:
     component: neutron-sftp-backup

--- a/openstack/neutron/templates/sftp-service.yaml
+++ b/openstack/neutron/templates/sftp-service.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     disco: "true"
     disco/record: {{ include "sftp_api_endpoint_host" . }}.
-    {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 4 }}
+    {{- include "utils.linkerd.pod_and_service_annotation" . | indent 4 }}
 spec:
   selector:
     component: neutron-sftp-backup

--- a/openstack/neutron/templates/vct-nsxv3-agent-deployment.yaml
+++ b/openstack/neutron/templates/vct-nsxv3-agent-deployment.yaml
@@ -43,7 +43,7 @@ template: |
           configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") . | sha256sum }}
           prometheus.io/scrape: "true"
           prometheus.io/targets: {{ required ".Values.metrics.prometheus missing" .Values.metrics.prometheus | quote }}
-          {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 10 }}
+          {{- include "utils.linkerd.pod_and_service_annotation" . | indent 10 }}
       spec:
         containers:
         - name: neutron-nsxv3-agent

--- a/openstack/neutron/templates/vct-nsxv3-agent-deployment.yaml
+++ b/openstack/neutron/templates/vct-nsxv3-agent-deployment.yaml
@@ -43,6 +43,7 @@ template: |
           configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") . | sha256sum }}
           prometheus.io/scrape: "true"
           prometheus.io/targets: {{ required ".Values.metrics.prometheus missing" .Values.metrics.prometheus | quote }}
+          {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 10 }}
       spec:
         containers:
         - name: neutron-nsxv3-agent

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -16,6 +16,7 @@ global:
   rpc_response_timeout: 60
   domain_seeds:
     skip_hcm_domain: false
+  linkerd_requested: false
 
 api_workers: 12
 rpc_workers: 5


### PR DESCRIPTION
… versions. This adds the `linkerd-support` chart as dependency and also adds the
annotations to all `Deployment`, `Service`, `Daemonset`  and `Ingress` objects. 

linkerd is disabled by default and needs to be enabled per region.

We depend on the `utils` chart for the annotation snippets and the
conditions so our templates stay more compact and thus better readable.

Supporting charts versions are bumped to support this change.

Chart version bumped to 0.2.2.