### PR TITLE
Fix velero pod annotation to avoid double scraping (try 2)

### DIFF
--- a/system/kube-system-virtual/values.yaml
+++ b/system/kube-system-virtual/values.yaml
@@ -107,9 +107,10 @@ owner-info:
 velero:
   enabled: false
 
-  podAnnotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/path: "/metrics"
+  metrics:
+    podAnnotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/path: "/metrics"
 
   image:
     repository: keppel.global.cloud.sap/ccloud-dockerhub-mirror/velero/velero


### PR DESCRIPTION
Follow up for the #5577 