### PR TITLE
common/thanos: query deployment overrides

### DIFF
--- a/common/thanos/Chart.yaml
+++ b/common/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: Deploy Thanos via operator
 type: application
-version: 0.6.3
+version: 0.6.4
 appVersion: v0.31.0
 maintainers:
   - name: Tommy Sauer (viennaa)

--- a/common/thanos/templates/_thanos_helpers.tpl
+++ b/common/thanos/templates/_thanos_helpers.tpl
@@ -123,3 +123,35 @@ cluster.local
 {{- default "default" $svcName -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "thanos.storeAPIs" -}}
+{{- $host := index . 0 -}}
+{{- $root := index . 1 -}}
+{{/* Thanos Query discovery within the cluster */}}
+{{- if $root.Values.queryDiscovery -}}
+- targets:
+{{- range $index, $service := (lookup "v1" "Service" "" "").items }}
+{{- if and (hasPrefix "thanos" $service.metadata.name) (contains "query" $service.metadata.name) (not (contains "maia" $service.metadata.name)) (not (contains "metal" $service.metadata.name)) (not (contains "scaleout" $service.metadata.name)) (not (contains "regional" $service.metadata.name)) }}
+{{- $store := $service.metadata.name }}
+{{ printf "- dnssrvnoa+_grpc._tcp.%s.%s.svc.%s" $store $service.metadata.namespace (include "clusterDomainOrDefault" $root) | indent 2 }}
+{{- end }}
+{{- end }}
+{{/* Global Thanos Query Store API endpoints */}}
+{{- else if and $root.Values.useQueryRegions $root.Values.clusterTypes -}}
+- targets:
+{{- range $region := $.Values.queryRegions }}
+{{- range $cluster := $root.Values.clusterTypes }}
+  - thanos-{{ $cluster }}-grpc.{{ $region }}.{{ $root.Values.global.tld }}:443
+{{- end }}
+{{- end }}
+{{- range $store := $.Values.query.stores }}
+  - {{ $store }}.{{ $root.Values.global.tld }}:443
+{{- end }}
+{{/* Regional Thanos Query Store API endpoints */}}
+{{- else if $root.Values.clusterTypes -}}
+- targets:
+{{- range $cluster := $root.Values.clusterTypes }}
+  - thanos-{{ $cluster }}-grpc.{{ $root.Values.global.region }}.{{ $root.Values.global.tld }}:443
+{{- end }}
+{{- end }}
+{{- end }}

--- a/common/thanos/templates/_thanos_helpers.tpl
+++ b/common/thanos/templates/_thanos_helpers.tpl
@@ -139,12 +139,12 @@ cluster.local
 {{/* Global Thanos Query Store API endpoints */}}
 {{- else if and $root.Values.useQueryRegions $root.Values.clusterTypes -}}
 - targets:
-{{- range $region := $.Values.queryRegions }}
+{{- range $region := $root.Values.queryRegions }}
 {{- range $cluster := $root.Values.clusterTypes }}
   - thanos-{{ $cluster }}-grpc.{{ $region }}.{{ $root.Values.global.tld }}:443
 {{- end }}
 {{- end }}
-{{- range $store := $.Values.query.stores }}
+{{- range $store := $root.Values.query.stores }}
   - {{ $store }}.{{ $root.Values.global.tld }}:443
 {{- end }}
 {{/* Regional Thanos Query Store API endpoints */}}

--- a/common/thanos/templates/sd-configmap.yaml
+++ b/common/thanos/templates/sd-configmap.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.enabled }}
+{{- if not $.Values.deployWholeThanos }}
+{{- $root := . }}
+{{- range $name := coalesce .Values.names .Values.global.targets (list .Values.name) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "thanos.fullName" (list $name $root) }}-query-sd-configmap
+  labels:
+    app.kubernetes.io/component: query
+data:
+  servicediscovery.yaml: |-
+{{ include "thanos.storeAPIs" (list $name $root) | indent 8 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/common/thanos/templates/thanos.yaml
+++ b/common/thanos/templates/thanos.yaml
@@ -61,7 +61,7 @@ spec:
               - mountPath: /etc/tls/client-ca
                 name: client-ca
                 readOnly: true
-            {{- end }}
+              {{- end }}
               - name: sd-config
                 mountPath: /conf/sd
             volumes:

--- a/common/thanos/templates/thanos.yaml
+++ b/common/thanos/templates/thanos.yaml
@@ -7,13 +7,9 @@ kind: Thanos
 metadata:
   name: {{ include "thanos.fullName" (list $name $root) }}
 spec:
-  queryDiscovery: {{ $.Values.queryDiscovery }}
+  queryDiscovery: false
   clusterDomain: {{ include "clusterDomainOrDefault" $root }}
   query:
-    {{- if ($.Values.authentication.enabled) }}
-    GRPCClientCA: {{ include "thanos.fullName" (list $name $root) }}-grpcclient-ca
-    GRPCClientCertificate: {{ include "thanos.fullName" (list $name $root) }}-grpcclient-crt
-    {{- end }}
     logLevel: {{ $.Values.logLevel }}
     queryAutoDownsampling: true
     queryReplicaLabel:
@@ -21,33 +17,9 @@ spec:
     {{- if $.Values.deployWholeThanos }}
     webRoutePrefix: {{ required "$.Values.query.webRouteprefix missing" $.Values.query.webRouteprefix }}
     webExternalPrefix: {{ required "$.Values.query.webRouteprefix missing" $.Values.query.webRouteprefix }}
-    {{- end }}
-    {{- if or $.Values.deployWholeThanos (($.Values.query).stores) ($.Values.useQueryRegions) ($.Values.clusterTypes) }}
     stores:
-    {{- end }}
-    {{- if and (($.Values.query).stores) (not $.Values.useQueryRegions) }}
-    # add stores manually
-      {{- range $store := $.Values.query.stores }}
-      - {{ $store.name }}.{{ $store.namespace }}.svc.{{ default "cluster.local" $.Values.clusterDomain }}:{{ $store.port }}
-      {{- end }}
-    {{- else if $.Values.deployWholeThanos }}
     # add stores for prometheus and thanos setup
       - prometheus-{{ include "thanos.name" (list $name $root) }}:10901
-    {{- else if and $.Values.useQueryRegions $.Values.clusterTypes }}
-    # add stores for global thanos
-      {{- range $region := $.Values.queryRegions }}
-        {{- range $cluster := $root.Values.clusterTypes }}
-        - thanos-{{ $cluster }}-grpc.{{ $region }}.{{ $root.Values.global.tld }}:443
-        {{- end }}
-      {{- end }}
-      {{- range $store := $.Values.query.stores }}
-        - {{ $store }}.{{ $root.Values.global.tld }}:443
-      {{- end }}
-    {{- else if ($.Values.clusterTypes) }}
-    # add stores for regional thanos
-      {{- range $cluster := $.Values.clusterTypes }}
-      - thanos-{{ $cluster }}-grpc.{{ $root.Values.global.region }}.{{ $root.Values.global.tld }}:443
-      {{- end }}
     {{- end }}
     serviceOverrides:
       metadata:
@@ -61,6 +33,53 @@ spec:
             containers:
             - image: {{ include "thanosimage" $root }}
               name: query
+            {{- if not $.Values.deployWholeThanos }}
+              args:
+              - query
+              - --grpc-address=0.0.0.0:10901
+              - --http-address=0.0.0.0:10902
+              - --log.level={{ default "info" $.Values.query.logLevel }}
+              - --query.auto-downsampling
+              - --query.replica-label=prometheus_replica
+              - --alert.query-url=http://{{- include "thanos.externalURL" (list $name $root) -}}
+              {{- if $.Values.authentication.enabled }}
+              - --grpc-client-tls-ca=/etc/tls/client-ca/ca.crt
+              - --grpc-client-tls-cert=/etc/tls/client/tls.crt
+              - --grpc-client-tls-key=/etc/tls/client/tls.key
+              - --grpc-client-tls-secure
+              {{- end }}
+              - --store.sd-files=/conf/sd/servicediscovery.yaml
+              - --store.sd-interval=5m
+              {{- range $.Values.query.extraArgs}}
+              - {{ . }}
+              {{- end }}
+              volumeMounts:
+            {{- if $.Values.authentication.enabled }}
+              - mountPath: /etc/tls/client
+                name: client-certificate
+                readOnly: true
+              - mountPath: /etc/tls/client-ca
+                name: client-ca
+                readOnly: true
+            {{- end }}
+              - name: sd-config
+                mountPath: /conf/sd
+            volumes:
+            {{- if $.Values.authentication.enabled }}
+            - name: client-certificate
+              secret:
+                defaultMode: 420
+                secretName: {{ include "thanos.fullName" (list $name $root) }}-grpcclient-crt
+            - name: client-ca
+              secret:
+                defaultMode: 420
+                secretName: {{ include "thanos.fullName" (list $name $root) }}-grpcclient-ca
+            {{- end }}
+            - configMap:
+                defaultMode: 420
+                name: {{ include "thanos.fullName" (list $name $root) }}-query-sd-configmap
+              name: sd-config
+            {{- end }}
   {{- if $.Values.deployWholeThanos }}
   storeGateway:
     logLevel: {{ $.Values.logLevel }}

--- a/common/thanos/templates/thanos.yaml
+++ b/common/thanos/templates/thanos.yaml
@@ -54,7 +54,7 @@ spec:
               - {{ . }}
               {{- end }}
               volumeMounts:
-            {{- if $.Values.authentication.enabled }}
+              {{- if $.Values.authentication.enabled }}
               - mountPath: /etc/tls/client
                 name: client-certificate
                 readOnly: true

--- a/common/thanos/templates/thanos.yaml
+++ b/common/thanos/templates/thanos.yaml
@@ -49,7 +49,7 @@ spec:
               - --grpc-client-tls-secure
               {{- end }}
               - --store.sd-files=/conf/sd/servicediscovery.yaml
-              - --store.sd-interval=5m
+              - --store.sd-interval={{ default "5m" $.Values.querySDInterval }}
               {{- range $.Values.query.extraArgs}}
               - {{ . }}
               {{- end }}

--- a/common/thanos/values.yaml
+++ b/common/thanos/values.yaml
@@ -39,6 +39,7 @@ clusterTypes: []
 # Replaces the default thanos-operator discovery
 # If true it will discover all Thaneis Query Services starting with 'thanos', containing 'query'.
 # Excluded are 'maia', 'metal', 'scaleout', 'regional'
+# Needs to be disabled if the added stores are cluster external like in regional, global.
 queryDiscovery: true
 
 # Refresh interval to re-read file SD files

--- a/common/thanos/values.yaml
+++ b/common/thanos/values.yaml
@@ -38,7 +38,7 @@ clusterTypes: []
 
 # Replaces the default thanos-operator discovery
 # If true it will discovery all Thaneis Query Services starting with 'thanos', containing 'query'.
-# Excluded are 'maia', 'metal', 'regional'
+# Excluded are 'maia', 'metal', 'scaleout', 'regional'
 queryDiscovery: true
 
 # set name only, region and domain will be generated like clusterDomain.region.cloud.sap

--- a/common/thanos/values.yaml
+++ b/common/thanos/values.yaml
@@ -41,6 +41,9 @@ clusterTypes: []
 # Excluded are 'maia', 'metal', 'scaleout', 'regional'
 queryDiscovery: true
 
+# Refresh interval to re-read file SD files
+# querySDInterval:
+
 # set name only, region and domain will be generated like clusterDomain.region.cloud.sap
 # defaults to cluster.local
 clusterDomain:

--- a/common/thanos/values.yaml
+++ b/common/thanos/values.yaml
@@ -37,7 +37,7 @@ queryRegions: []
 clusterTypes: []
 
 # Replaces the default thanos-operator discovery
-# If true it will discovery all Thaneis Query Services starting with 'thanos', containing 'query'.
+# If true it will discover all Thaneis Query Services starting with 'thanos', containing 'query'.
 # Excluded are 'maia', 'metal', 'scaleout', 'regional'
 queryDiscovery: true
 

--- a/common/thanos/values.yaml
+++ b/common/thanos/values.yaml
@@ -36,8 +36,10 @@ queryRegions: []
 # thanos-$clusterType-grpc is the corresponding ingress to be queried
 clusterTypes: []
 
-# If true it will discovery all Thaneis Services deployed by Thanos operator
-queryDiscovery:
+# Replaces the default thanos-operator discovery
+# If true it will discovery all Thaneis Query Services starting with 'thanos', containing 'query'.
+# Excluded are 'maia', 'metal', 'regional'
+queryDiscovery: true
 
 # set name only, region and domain will be generated like clusterDomain.region.cloud.sap
 # defaults to cluster.local
@@ -158,6 +160,9 @@ store:
 # not relevant when deployWholeTHanos set to false
 query:
   replicas: 1
+
+  # logLevel:
+
   webRouteprefix: /thanos
   # statically specify stores, if deployWholeThanos is set and this is not present, it will default to query the single Prometheus sidecar container prometheus-<thanos-name>:10901
   # stores from the following list will be build as an cluster internal dns fqdn. Like store1.default.svc.cluster.local:10901
@@ -168,6 +173,8 @@ query:
     # - name: storeN
     #   namespace: default
     #   port: 10901
+
+  extraArgs: []
 
 ruler:
   enabled: false


### PR DESCRIPTION
This change will move away from thanos-operator functionality to get more control over container args. Query discovery is ensured via helm lookup function on Kubernetes Services.