### PR TITLE
[Octavia] Add basic linkerd support, bump chart and supporting charts…

### DIFF
--- a/openstack/octavia/Chart.lock
+++ b/openstack/octavia/Chart.lock
@@ -1,21 +1,24 @@
 dependencies:
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.7
+  version: 0.8.0
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.0
+  version: 0.1.5
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.7
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.5.2
+  version: 0.6.0
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.10.3
+  version: 0.11.1
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:fc7be2427498b62e42ac7973b82fd10ddf308a68168e87dc602bed76eb3bf440
-generated: "2023-09-26T15:54:51.644433883+02:00"
+- name: linkerd-support
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 0.1.3
+digest: sha256:095529ce86c1a4aa3a120c6177ddd4c9d909fd1d20d7ca30cafc3946d642858e
+generated: "2023-11-16T11:49:07.851538Z"

--- a/openstack/octavia/Chart.yaml
+++ b/openstack/octavia/Chart.yaml
@@ -8,25 +8,28 @@ sources:
   - https://git.openstack.org/cgit/openstack/octavia
   - https://git.openstack.org/cgit/openstack/openstack-helm
 # The versions are defined in the changelog: https://docs.openstack.org/releasenotes/octavia/yoga.html
-version: 10.0.0
+version: 10.0.1
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.7.7
+    version: 0.8.0
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.0
+    version: 0.1.5
   - condition: mariadb.enabled
     name: mysql_metrics
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.7
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.5.2
+    version: 0.6.0
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.10.0
+    version: 0.11.1
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0
+  - name: linkerd-support
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: 0.1.3

--- a/openstack/octavia/templates/octavia-api-deployment.yaml
+++ b/openstack/octavia/templates/octavia-api-deployment.yaml
@@ -33,6 +33,8 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
         {{- end }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
+        
     spec:
       {{- include "utils.proxysql.pod_settings" . | nindent 6 }}
       {{- tuple . (dict "app.kubernetes.io/name" "octavia-api") | include "utils.topology.constraints" | indent 6 }}

--- a/openstack/octavia/templates/octavia-api-ingress.yaml
+++ b/openstack/octavia/templates/octavia-api-ingress.yaml
@@ -12,8 +12,7 @@ metadata:
     type: api
     component: octavia
   annotations:
-  {{- include "utils.linkerd.ingress_annotation" $ | indent 4 }}
-
+  {{- include "utils.linkerd.ingress_annotation" . | indent 4 }}
 {{- with .Values.ingress.annotations }}  
 {{ toYaml . | indent 4 }}
 {{- end }}

--- a/openstack/octavia/templates/octavia-api-ingress.yaml
+++ b/openstack/octavia/templates/octavia-api-ingress.yaml
@@ -13,6 +13,7 @@ metadata:
     component: octavia
 {{- with .Values.ingress.annotations }}
   annotations:
+  {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 4 }}
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:

--- a/openstack/octavia/templates/octavia-api-ingress.yaml
+++ b/openstack/octavia/templates/octavia-api-ingress.yaml
@@ -12,10 +12,10 @@ metadata:
     type: api
     component: octavia
   annotations:
+    # linkerd annotations
     {{- include "utils.linkerd.ingress_annotation" . | indent 4 }}
-    {{- with .Values.ingress.annotations }}  
-{{ toYaml . | indent 4 }}
-    {{- end }}
+    # other annotations
+    {{- .Values.ingress.annotations | toYaml | nindent 4 }}
 spec:
   tls:
      - secretName: tls-{{ include "octavia_api_endpoint_host_public" . | replace "." "-" }}

--- a/openstack/octavia/templates/octavia-api-ingress.yaml
+++ b/openstack/octavia/templates/octavia-api-ingress.yaml
@@ -11,9 +11,10 @@ metadata:
     system: openstack
     type: api
     component: octavia
-{{- with .Values.ingress.annotations }}
   annotations:
   {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 4 }}
+
+{{- with .Values.ingress.annotations }}  
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:

--- a/openstack/octavia/templates/octavia-api-ingress.yaml
+++ b/openstack/octavia/templates/octavia-api-ingress.yaml
@@ -12,7 +12,7 @@ metadata:
     type: api
     component: octavia
   annotations:
-  {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 4 }}
+  {{- include "utils.linkerd.ingress_annotation" $ | indent 4 }}
 
 {{- with .Values.ingress.annotations }}  
 {{ toYaml . | indent 4 }}

--- a/openstack/octavia/templates/octavia-api-ingress.yaml
+++ b/openstack/octavia/templates/octavia-api-ingress.yaml
@@ -12,10 +12,10 @@ metadata:
     type: api
     component: octavia
   annotations:
-  {{- include "utils.linkerd.ingress_annotation" . | indent 4 }}
-{{- with .Values.ingress.annotations }}  
+    {{- include "utils.linkerd.ingress_annotation" . | indent 4 }}
+    {{- with .Values.ingress.annotations }}  
 {{ toYaml . | indent 4 }}
-{{- end }}
+    {{- end }}
 spec:
   tls:
      - secretName: tls-{{ include "octavia_api_endpoint_host_public" . | replace "." "-" }}

--- a/openstack/octavia/templates/octavia-api-service.yaml
+++ b/openstack/octavia/templates/octavia-api-service.yaml
@@ -4,6 +4,7 @@ metadata:
   name: octavia-api
   annotations:
     {{- include "utils.topology.service_topology_mode" . | indent 2 }}
+    {{- include "utils.linkerd.pod_and_service_annotation" . | indent 4 }}
   labels:
     app.kubernetes.io/name: octavia-api
     helm.sh/chart: {{ include "octavia.chart" . }}

--- a/openstack/octavia/templates/octavia-api-service.yaml
+++ b/openstack/octavia/templates/octavia-api-service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: octavia-api
   annotations:
-  {{- include "utils.topology.service_topology_mode" . | indent 2 }}
+    {{- include "utils.topology.service_topology_mode" . | indent 2 }}
   labels:
     app.kubernetes.io/name: octavia-api
     helm.sh/chart: {{ include "octavia.chart" . }}

--- a/openstack/octavia/templates/octavia-f5-as3-deployment.yaml
+++ b/openstack/octavia/templates/octavia-f5-as3-deployment.yaml
@@ -19,6 +19,9 @@ spec:
       labels:
         app.kubernetes.io/name: octavia-f5-as3
         app.kubernetes.io/instance: {{ .Release.Name }}
+      annotations:
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
+
     spec:
       containers:
         - name: f5-as3-container

--- a/openstack/octavia/templates/octavia-f5-as3-service.yaml
+++ b/openstack/octavia/templates/octavia-f5-as3-service.yaml
@@ -11,6 +11,8 @@ metadata:
     system: openstack
     type: api
     component: octavia
+  annotations:
+    {{- include "utils.linkerd.pod_and_service_annotation" . | indent 4 }}
 spec:
   ports:
     - port: 443

--- a/openstack/octavia/templates/octavia-housekeeping.yaml
+++ b/openstack/octavia/templates/octavia-housekeeping.yaml
@@ -23,6 +23,7 @@ spec:
         configmap-worker-hash: {{ include (print $.Template.BasePath "/octavia-worker-configmap.yaml") . | sha256sum }}
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
 {{ include "utils.proxysql.pod_settings" . | indent 6 }}
       containers:

--- a/openstack/octavia/templates/octavia-worker-deployment.yaml
+++ b/openstack/octavia/templates/octavia-worker-deployment.yaml
@@ -27,6 +27,7 @@ spec:
         configmap-worker-hash: {{ include (print $.Template.BasePath "/octavia-worker-configmap.yaml") . | sha256sum }}
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
 {{ include "utils.proxysql.pod_settings" . | indent 6 }}
       containers:

--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -17,7 +17,8 @@ global:
   dbUser: octavia
   rpc_response_timeout: 60
   osprofiler: {}
-
+  linkerd_requested: false
+  
 osprofiler:
   enabled: false
 


### PR DESCRIPTION
… versions. This adds the linkerd-support chart as dependency and also adds the
annotations to all Deployment, Service, Daemonset and Ingress objects.

linkerd is disabled by default and needs to be enabled per region.

We depend on the utils chart for the annotation snippets and the
conditions so our templates stay more compact and thus better readable.

Supporting charts versions are bumped to support this change.

Chart version bumped to 10.0.1