### PR TITLE
octavia: fix jobs being left over after redeployment

### DIFF
--- a/openstack/octavia/templates/_helpers.tpl
+++ b/openstack/octavia/templates/_helpers.tpl
@@ -30,10 +30,3 @@ Create chart name and version as used by the chart label.
 {{- define "octavia.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-
-{{/*
-DB migration job name
-*/}}
-{{- define "octavia.migration_job_name" -}}
-octavia-migration-{{ .Values.imageVersion }}
-{{- end }}

--- a/openstack/octavia/templates/octavia-api-deployment.yaml
+++ b/openstack/octavia/templates/octavia-api-deployment.yaml
@@ -49,7 +49,7 @@ spec:
             - name: COMMAND
               value: "/usr/sbin/apachectl -D FOREGROUND"
             - name: DEPENDENCY_JOBS
-              value: "{{ include "octavia.migration_job_name" . }}"
+              value: octavia-migration
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
             - name: PYTHONWARNINGS

--- a/openstack/octavia/templates/octavia-housekeeping.yaml
+++ b/openstack/octavia/templates/octavia-housekeeping.yaml
@@ -49,7 +49,7 @@ spec:
             - name: COMMAND
               value: "octavia-f5-housekeeping --config-file /etc/octavia/octavia.conf"
             - name: DEPENDENCY_JOBS
-              value: "{{ include "octavia.migration_job_name" . }}"
+              value: octavia-migration
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
             - name: PYTHONWARNINGS

--- a/openstack/octavia/templates/octavia-migration-job.yaml
+++ b/openstack/octavia/templates/octavia-migration-job.yaml
@@ -1,15 +1,8 @@
-{{/*
-   With Helm3, we don't force the replacements of job specs anymore, which
-   causes deployment issues since kuberentes job specs are immutable by
-   default.  We solve this by generating an image specific name for every
-   deployment, therefore no job will be replaced. Instead, a new job will be
-   spawned while the old one will be deleted.
-*/}}
 {{- $proxysql := lookup "v1" "ConfigMap" .Release.Namespace (print .Release.Name "-proxysql-etc") -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "octavia.migration_job_name" . }}
+  name: octavia-migration
   labels:
     system: openstack
     type: configuration

--- a/openstack/octavia/templates/octavia-worker-deployment.yaml
+++ b/openstack/octavia/templates/octavia-worker-deployment.yaml
@@ -63,7 +63,7 @@ spec:
             - name: COMMAND
               value: "octavia-worker --config-file /etc/octavia/octavia.conf --config-file /etc/octavia/octavia-worker.conf"
             - name: DEPENDENCY_JOBS
-              value: "{{ include "octavia.migration_job_name" . }}"
+              value: octavia-migration
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
             - name: PYTHONWARNINGS
@@ -99,7 +99,7 @@ spec:
             - name: COMMAND
               value: "octavia-driver-agent --config-file /etc/octavia/octavia.conf"
             - name: DEPENDENCY_JOBS
-              value: "{{ include "octavia.migration_job_name" . }}"
+              value: octavia-migration
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
             {{- if .Values.sentry.enabled }}
@@ -136,7 +136,7 @@ spec:
             - name: COMMAND
               value: "octavia-f5-status-manager --config-file /etc/octavia/octavia.conf --config-file /etc/octavia/octavia-worker.conf"
             - name: DEPENDENCY_JOBS
-              value: "{{ include "octavia.migration_job_name" . }}"
+              value: octavia-migration
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
             - name: PYTHONWARNINGS


### PR DESCRIPTION
The explanation in the deleted code comment that jobs cannot be recreated was correct at the time, in commit 24c84622a6, because the job was created as a regular manifest object instead of a hook object.

As of now, the job has a `hook-delete-policy: before-hook-creation`, so job spec immutability is not a concern.

We found this issue while I was explaining the GkVulnerableImages check to Benjamin Ludwig, and we saw that dozens of old images are kept from being GC'd because these jobs are still referencing them.

#### Todos after this deployment:
- [ ] clean up existing job objects, e.g. with `k delete $(k get job -o name | grep octavia-migration-yoga-202)`.