### PR TITLE
manila: add share_type_id to snapshot size/count metrics

### DIFF
--- a/openstack/manila/values.yaml
+++ b/openstack/manila/values.yaml
@@ -194,6 +194,7 @@ mysql_metrics:
         - "share_id"
         - "id"
         - "status"
+        - "share_type_id"
         - "availability_zone_name"
       name: openstack_manila_snapshot_count_gauge
       query: |
@@ -202,6 +203,7 @@ mysql_metrics:
           snap.share_id as share_id,
           snap.id as id,
           si.status as status,
+          coalesce(share_instances.share_type_id, 'N/A') AS share_type_id,
           availability_zones.name AS availability_zone_name,
           COUNT(*) AS count_gauge
         FROM share_snapshots AS snap
@@ -231,6 +233,7 @@ mysql_metrics:
         - "share_id"
         - "id"
         - "status"
+        - "share_type_id"
         - "availability_zone_name"
       name: openstack_manila_snapshot_size_gauge
       query: |
@@ -239,6 +242,7 @@ mysql_metrics:
           share_snapshots.share_id,
           share_snapshots.id,
           share_snapshot_instances.status,
+          coalesce(share_instances.share_type_id, 'N/A') AS share_type_id,
           availability_zones.name AS availability_zone_name,
           SUM(share_snapshots.size) size_gauge
         FROM share_snapshots

--- a/openstack/manila/values.yaml
+++ b/openstack/manila/values.yaml
@@ -223,6 +223,7 @@ mysql_metrics:
           'none' AS project_id,
           'none' AS share_id,
           'none' AS status,
+          'none' AS share_type_id,
           'none' AS availability_zone_name,
           0 AS count_gauge;
       values:


### PR DESCRIPTION
I need these to collect the respective usage data in Limes.

Otherwise this would require extensive shenanigans to join in the respective labels from the share metrics, which would put unreasonable strain on the Prometheus server.

Note that I have not tested this; I'm just going by what is already working in the corresponding share metrics queries, since the `share_instances` table is already joined into this query anyway.