### PR TITLE
[Barbican]Add basic linkerd support

### DIFF
--- a/openstack/barbican/Chart.lock
+++ b/openstack/barbican/Chart.lock
@@ -1,24 +1,27 @@
 dependencies:
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.16
+  version: 0.8.0
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.4
+  version: 0.1.5
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.7
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.5.2
+  version: 0.6.1
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.12.1
+  version: 0.12.2
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.3.8
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:054a07954a2815ea281f761ea05dc815fc54ac0b8069aa4a06617869554d1ffd
-generated: "2023-11-14T14:12:21.96854155+01:00"
+- name: linkerd-support
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 0.1.3
+digest: sha256:2c49ac292f8d8b8fd7dd4367480bdfefa1c144cc088ba7685a8a5b5be1a751c3
+generated: "2023-11-20T08:54:41.886419+05:30"

--- a/openstack/barbican/Chart.yaml
+++ b/openstack/barbican/Chart.yaml
@@ -3,22 +3,22 @@ appVersion: bobcat
 description: A Helm chart for Openstack Barbican
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Barbican/OpenStack_Project_Barbican_vertical.png
 name: barbican
-version: 0.5.0
+version: 0.5.1
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.7.16
+    version: 0.8.0
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.4
+    version: 0.1.5
   - condition: mariadb.enabled
     name: mysql_metrics
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.7
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.5.2
+    version: 0.6.1
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
     version: ~0.12.1
@@ -30,3 +30,6 @@ dependencies:
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0
+  - name: linkerd-support
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: 0.1.3

--- a/openstack/barbican/templates/api-deployment.yaml
+++ b/openstack/barbican/templates/api-deployment.yaml
@@ -38,6 +38,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
         {{- end }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
 {{ tuple . "barbican" "api" | include "kubernetes_pod_anti_affinity" | indent 6 }}
       {{- include "utils.proxysql.pod_settings" . | indent 6 }}

--- a/openstack/barbican/templates/ingress.yaml
+++ b/openstack/barbican/templates/ingress.yaml
@@ -17,6 +17,7 @@ metadata:
     kubernetes.io/tls-acme: "true"
     disco: "true"
   {{- end }}
+  {{- include "utils.linkerd.ingress_annotation" . | indent 4 }}
 spec:
   tls:
      - secretName: tls-{{ include "barbican_api_endpoint_host_public" . | replace "." "-" }}

--- a/openstack/barbican/templates/ingress.yaml
+++ b/openstack/barbican/templates/ingress.yaml
@@ -12,8 +12,8 @@ metadata:
     system: openstack
     type: api
     component: barbican
-  {{- if .Values.tlsacme }}
   annotations:
+  {{- if .Values.tlsacme }}
     kubernetes.io/tls-acme: "true"
     disco: "true"
   {{- end }}

--- a/openstack/barbican/templates/service.yaml
+++ b/openstack/barbican/templates/service.yaml
@@ -16,6 +16,7 @@ metadata:
     prometheus.io/scrape: "true"
     prometheus.io/port: {{.Values.statsd.port | quote }}
     prometheus.io/targets: {{ .Values.alerts.prometheus | quote }}
+    {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
 spec:
   selector:
     name: barbican-api

--- a/openstack/barbican/templates/service.yaml
+++ b/openstack/barbican/templates/service.yaml
@@ -16,7 +16,7 @@ metadata:
     prometheus.io/scrape: "true"
     prometheus.io/port: {{.Values.statsd.port | quote }}
     prometheus.io/targets: {{ .Values.alerts.prometheus | quote }}
-    {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
+    {{- include "utils.linkerd.pod_and_service_annotation" . | indent 4 }}
 spec:
   selector:
     name: barbican-api

--- a/openstack/barbican/values.yaml
+++ b/openstack/barbican/values.yaml
@@ -10,6 +10,7 @@ global:
   dbUser: barbican
   domain_seeds:
     skip_hcm_domain: false
+  linkerd_requested: false
 
 owner-info:
   support-group: identity


### PR DESCRIPTION
This adds the `linkerd-support` chart as dependency and also adds the annotations to all `Deployment`, `Service` and `Ingress` objects. `Job` objects are out of the picture for now