### PR TITLE
[designate] Add basic linkerd support

### DIFF
--- a/openstack/designate/Chart.lock
+++ b/openstack/designate/Chart.lock
@@ -4,16 +4,16 @@ dependencies:
   version: 1.1.6
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.11
+  version: 0.8.0
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.2
+  version: 0.1.5
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.7
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.5.2
+  version: 0.6.0
 - name: rabbitmq_cluster
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.9
@@ -23,5 +23,8 @@ dependencies:
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:8a51a195bf115d193ced690dfe3bd8536290783afc84518e8085902f5f3c1c39
-generated: "2023-11-10T12:12:20.156241997+01:00"
+- name: linkerd-support
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 0.1.3
+digest: sha256:0012947eb6f91dd23fd4608a78ca50d6dc0a840ce76c0720ffc16f00ed8e259e
+generated: "2023-11-20T10:43:26.567658Z"

--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes to deploy Openstack Designate  (DNSaaS)
 name: designate
-version: 0.2.0
+version: 0.2.1
 appVersion: "xena"
 dependencies:
   - condition: percona_cluster.enabled
@@ -11,10 +11,10 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.7.11
+    version: 0.8.0
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.2
+    version: 0.1.5
   - condition: mysql_metrics.enabled
     name: mysql_metrics
     repository: https://charts.eu-de-2.cloud.sap
@@ -22,7 +22,7 @@ dependencies:
   - name: rabbitmq
     condition: rabbitmq.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.5.2
+    version: 0.6.0
   - name: rabbitmq_cluster
     condition: rabbitmq_cluster.enabled
     repository: https://charts.eu-de-2.cloud.sap
@@ -33,3 +33,6 @@ dependencies:
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0
+  - name: linkerd-support
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: 0.1.3

--- a/openstack/designate/templates/api-deployment.yaml
+++ b/openstack/designate/templates/api-deployment.yaml
@@ -32,6 +32,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.metrics.prometheus missing" .Values.metrics.prometheus | quote }}
         {{- end }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
 {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ .Release.Name }}

--- a/openstack/designate/templates/api-ingress.yaml
+++ b/openstack/designate/templates/api-ingress.yaml
@@ -12,6 +12,7 @@ metadata:
     {{- if .Values.global_setup }}
     kubernetes.io/ingress.class: "nginx-external"
     {{- end }}
+    {{- include "utils.linkerd.ingress_annotation" . | indent 4 }}
 spec:
 {{- if .Values.global_setup }}
   ingressClassName: "nginx-external"

--- a/openstack/designate/templates/api-service.yaml
+++ b/openstack/designate/templates/api-service.yaml
@@ -11,6 +11,7 @@ metadata:
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/targets: {{ required ".Values.metrics.prometheus missing" .Values.metrics.prometheus | quote }}
+    {{- include "utils.linkerd.pod_and_service_annotation" . | indent 4 }}
 spec:
   selector:
     app: {{ .Release.Name }}-api

--- a/openstack/designate/templates/central-deployment.yaml
+++ b/openstack/designate/templates/central-deployment.yaml
@@ -32,6 +32,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.metrics.prometheus missing" .Values.metrics.prometheus | quote }}
         {{- end }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
 {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ .Release.Name }}

--- a/openstack/designate/templates/mdns-deployment.yaml
+++ b/openstack/designate/templates/mdns-deployment.yaml
@@ -32,6 +32,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.metrics.prometheus missing" .Values.metrics.prometheus | quote }}
         {{- end }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
 {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ .Release.Name }}

--- a/openstack/designate/templates/mdns-service.yaml
+++ b/openstack/designate/templates/mdns-service.yaml
@@ -9,6 +9,8 @@ metadata:
     application: designate
     type: backend
     component: mdns
+  annotations:
+    {{- include "utils.linkerd.pod_and_service_annotation" . | indent 4 }}
 spec:
   selector:
     app: designate-mdns

--- a/openstack/designate/templates/producer-deployment.yaml
+++ b/openstack/designate/templates/producer-deployment.yaml
@@ -32,6 +32,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.metrics.prometheus missing" .Values.metrics.prometheus | quote }}
         {{- end }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
 {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ .Release.Name }}

--- a/openstack/designate/templates/sink-deployment.yaml
+++ b/openstack/designate/templates/sink-deployment.yaml
@@ -32,6 +32,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.metrics.prometheus missing" .Values.metrics.prometheus | quote }}
         {{- end }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
 {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ .Release.Name }}

--- a/openstack/designate/templates/worker-deployment.yaml
+++ b/openstack/designate/templates/worker-deployment.yaml
@@ -33,6 +33,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.metrics.prometheus missing" .Values.metrics.prometheus | quote }}
         {{- end }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
 {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ .Release.Name }}

--- a/openstack/designate/values.yaml
+++ b/openstack/designate/values.yaml
@@ -28,7 +28,8 @@ global:
   designate_service_user: designate
   domain_seeds:
     skip_hcm_domain: false
-
+  linkerd_requested: false
+  
 pod:
   replicas:
     api: 3


### PR DESCRIPTION
This adds the linkerd-support chart as dependency and also adds the
annotations to all Deployment, Service, Daemonset and Ingress objects.

linkerd is disabled by default and needs to be enabled per region.

We depend on the utils chart for the annotation snippets and the
conditions so our templates stay more compact and thus better readable.

Supporting charts versions are bumped to support this change.

Chart version bumped to 0.2.1