### PR TITLE
[designate] Fix chicken-and-egg with proxysql in pre-upgrade job

### DIFF
--- a/openstack/designate/templates/migration-job.yaml
+++ b/openstack/designate/templates/migration-job.yaml
@@ -1,3 +1,4 @@
+{{- $proxysql := lookup "v1" "ConfigMap" .Release.Namespace (print .Release.Name "-proxysql-etc") -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -13,7 +14,9 @@ spec:
       serviceAccountName: {{ .Release.Name }}
 {{- end }}
       restartPolicy: OnFailure
+      {{- if $proxysql}}
       {{- include "utils.proxysql.job_pod_settings" . | indent 6 }}
+      {{- end }}
       containers:
         - name: designate-migration
           image: {{ required ".Values.global.registry is missing" .Values.global.registry }}/loci-designate:{{ required ".Values.image_version_designate is missing" .Values.image_version_designate }}
@@ -36,8 +39,10 @@ spec:
               name: designate-etc
             - mountPath: /container.init
               name: container-init
+      {{- if $proxysql}}
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
         {{- include "utils.proxysql.container" . | indent 8 }}
+      {{- end }}
       volumes:
         - name: designate-etc
           configMap:
@@ -46,4 +51,6 @@ spec:
           configMap:
             name: designate-bin
             defaultMode: 0755
-{{- include "utils.proxysql.volumes" . | indent 8 }}
+      {{- if $proxysql }}
+        {{- include "utils.proxysql.volumes" . | indent 8 }}
+      {{- end }}


### PR DESCRIPTION
Only if proxysql is actually deployed can we make use of it in the pre-upgrade job, as the configmap gets created in the actual deployment.