### PR TITLE
fix(hermes): swap logstash mutate of initiator project/domain

### DIFF
--- a/openstack/hermes/templates/etc/_logstash.conf.tpl
+++ b/openstack/hermes/templates/etc/_logstash.conf.tpl
@@ -69,12 +69,12 @@ filter {
   if ![initiator][project_id] and ![initiator][domain_id] {
     if [project] {
       mutate {
-        add_field => { "%{[initiator][project_id]}" => "%{[project]}" }
+        add_field => { "%{[project]}" => "%{[initiator][project_id]}"  }
         id => "f06a_mutate_initiator_project_id"
         }
     } else if [domain] {
       mutate {
-        add_field => { "%{[initiator][domain_id]}" => "%{[domain]}" }
+        add_field => { "%{[domain]}" ==> "%{[initiator][domain_id]}"}
         id => "f06b_mutate_initiator_domain_id"
       }
     }


### PR DESCRIPTION
There have been exception such as:
```bash
[WARN ] 2023-11-23 02:02:22.080 [[main]>worker0] mutate - Exception caught while applying mutate filter {:exception=>"Invalid FieldReference: `%{[initiator][project_id]}`",
:backtrace=>[
"org/logstash/ext/JrubyEventExtLibrary.java:154:in `include?'",
"/usr/share/logstash/logstash-core/lib/logstash/util/decorators.rb:35:in `block in add_fields'",
"org/jruby/RubyArray.java:1821:in `each'",
"/usr/share/logstash/logstash-core/lib/logstash/util/decorators.rb:33:in `block in add_fields'",
"org/jruby/RubyHash.java:1415:in `each'", 
"/usr/share/logstash/logstash-core/lib/logstash/util/decorators.rb:30:in `add_fields'", 
"/usr/share/logstash/logstash-core/lib/logstash/filters/base.rb:198:in `filter_matched'", 
"/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-filter-mutate-3.5.6/lib/logstash/filters/mutate.rb:266:in `filter'", 
"/usr/share/logstash/logstash-core/lib/logstash/filters/base.rb:159:in `do_filter'",
"/usr/share/logstash/logstash-core/lib/logstash/filters/base.rb:178:in `block in multi_filter'", 
"org/jruby/RubyArray.java:1821:in `each'", "/usr/share/logstash/logstash-core/lib/logstash/filters/base.rb:175:in `multi_filter'",
"org/logstash/config/ir/compiler/AbstractFilterDelegatorExt.java:134:in `multi_filter'", 
/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:299:in `block in start_workers'"]}

```
These errors have been stalling the logstash pipeline. The issue is that `source` and `target` field for the mutate filter's add operation are swapped. This leads to the error: `Invalid FieldReference: '%{[initiator][project_id]}'`