### PR TITLE
adding global stores alert

### DIFF
--- a/global/thanos-global/Chart.yaml
+++ b/global/thanos-global/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos-global
 description: Deploy Thanos via operator
 type: application
-version: 0.2.5
+version: 0.2.6
 dependencies:
   - name: thanos
     repository: https://charts.eu-de-2.cloud.sap

--- a/global/thanos-global/alerts/thanos-global.alerts
+++ b/global/thanos-global/alerts/thanos-global.alerts
@@ -1,0 +1,14 @@
+groups:
+- name: thanos-global.alerts
+  rules:
+  - alert: ThanosGlobalNotFetchingAllStores
+    expr: count by (region)(sum by (pod, cluster_type, region) (thanos_build_info{container="store", pod!~"thanos-vmware.*", cluster_type!~"customer|ci|internet", cluster!="k-master", region!~"qa-de-2|qa-de-3"})) < 9 
+    for: 10m
+    labels:
+      severity: info
+      service: metrics 
+      support_group: observability
+      meta: Thanos global can't reach all expected stores. {{ $labels.region }} is not providing all 9 stores.
+    annotations:
+      description: There is a connection problem or a store in {{ $labels.region }} is down. Usually GRPC error rate grows as well.
+      summary: Thanos global can't reach all stores.

--- a/global/thanos-global/templates/alerts.yaml
+++ b/global/thanos-global/templates/alerts.yaml
@@ -1,0 +1,18 @@
+{{/* Generate Thanos Alert Rules */}}
+{{- $values := .Values.thanos.ruler }}
+{{- if $values.enabled }}
+{{- range $path, $bytes := .Files.Glob "alerts/*.alerts" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: {{ printf "%s" $path | replace "/" "-" }}
+  labels:
+    type: alerting-rules
+    thanos-ruler: global
+spec:
+{{ printf "%s" $bytes | indent 2 }}
+
+{{- end }}
+{{- end }}


### PR DESCRIPTION
Global should be able to reach 9 stores, not checking all vmware stores and ignoring special clusters. This is a sanity check and does not show, which store is missing exactly