### PR TITLE
[Ironic] Add basic linkerd support

### DIFF
--- a/openstack/ironic/Chart.lock
+++ b/openstack/ironic/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.18
+  version: 0.8.0
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.5
@@ -16,9 +16,12 @@ dependencies:
   version: 0.5.2
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.12.1
+  version: 0.12.2
 - name: ironic-exporter
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.0.0
-digest: sha256:046b037549e9036cf18ab66e9f9edde83e7bae41c559bc0002c28d7fe27f77bb
-generated: "2023-11-14T15:58:48.866852211+01:00"
+- name: linkerd-support
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 0.1.3
+digest: sha256:abb037a1a8f635428a68d533c885492962524db057e0bb76a1ba665b2bb07fbf
+generated: "2023-11-24T12:08:58.339957+05:30"

--- a/openstack/ironic/Chart.lock
+++ b/openstack/ironic/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.8.0
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.5
+  version: 0.2.0
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.7
@@ -13,7 +13,7 @@ dependencies:
   version: 0.2.0
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.5.2
+  version: 0.6.1
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.12.2
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:abb037a1a8f635428a68d533c885492962524db057e0bb76a1ba665b2bb07fbf
-generated: "2023-11-24T12:08:58.339957+05:30"
+digest: sha256:5bcb1ff8d155764c3156c59e1be2909b500064c5cc790566572fccbee58533e0
+generated: "2023-11-27T11:21:54.735838+05:30"

--- a/openstack/ironic/Chart.yaml
+++ b/openstack/ironic/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Ironic/OpenStack_Project_Ironic_vertical.png
 name: ironic
-version: 0.1.5
+version: 0.1.6
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.7.18
+    version: ~0.8.0
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
     version: ~0.1.5
@@ -27,3 +27,6 @@ dependencies:
   - name: ironic-exporter
     repository: https://charts.eu-de-2.cloud.sap
     version: ~1.0.0
+  - name: linkerd-support
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: 0.1.3

--- a/openstack/ironic/Chart.yaml
+++ b/openstack/ironic/Chart.yaml
@@ -10,7 +10,7 @@ dependencies:
     version: ~0.8.0
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.1.5
+    version: ~0.2.0
   - condition: mysql_metrics.enabled
     name: mysql_metrics
     repository: https://charts.eu-de-2.cloud.sap
@@ -20,10 +20,10 @@ dependencies:
     version: ~0.2.0
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.5.2
+    version: ~0.6.1
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.12.1
+    version: ~0.12.2
   - name: ironic-exporter
     repository: https://charts.eu-de-2.cloud.sap
     version: ~1.0.0

--- a/openstack/ironic/templates/_conductor-deployment.yaml.tpl
+++ b/openstack/ironic/templates/_conductor-deployment.yaml.tpl
@@ -43,6 +43,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
         {{- end }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
       {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       initContainers:

--- a/openstack/ironic/templates/_console-ingress.yaml.tpl
+++ b/openstack/ironic/templates/_console-ingress.yaml.tpl
@@ -20,6 +20,7 @@ metadata:
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     ingress.kubernetes.io/ssl-passthrough: "true"
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    {{- include "utils.linkerd.ingress_annotation" . | indent 4 }}
 spec:
   tls:
      - secretName: tls-{{ include "ironic_console_endpoint_host_public" . | replace "." "-" }}

--- a/openstack/ironic/templates/_console-service.yaml.tpl
+++ b/openstack/ironic/templates/_console-service.yaml.tpl
@@ -14,6 +14,8 @@ metadata:
     system: openstack
     type: api
     component: ironic-conductor
+  annotations:
+    {{- include "utils.linkerd.pod_and_service_annotation" . | indent 4 }}
 spec:
   selector:
   {{- if $conductor.name }}

--- a/openstack/ironic/templates/api-deployment.yaml
+++ b/openstack/ironic/templates/api-deployment.yaml
@@ -31,6 +31,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
         {{- end }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
 {{ tuple . "ironic" "api" | include "kubernetes_pod_anti_affinity" | indent 6 }}
       {{- include "utils.proxysql.pod_settings" . | indent 6 }}

--- a/openstack/ironic/templates/api-ingress.yaml
+++ b/openstack/ironic/templates/api-ingress.yaml
@@ -9,6 +9,7 @@ metadata:
     component: ironic
   annotations:
     kubernetes.io/tls-acme: "true"
+    {{- include "utils.linkerd.ingress_annotation" . | indent 4 }}
 spec:
   tls:
      - secretName: tls-{{ include "ironic_api_endpoint_host_public" . | replace "." "-" }}

--- a/openstack/ironic/templates/api-service.yaml
+++ b/openstack/ironic/templates/api-service.yaml
@@ -10,7 +10,7 @@ metadata:
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
-
+    {{- include "utils.linkerd.pod_and_service_annotation" . | indent 4 }}
 spec:
   selector:
     name: ironic-api

--- a/openstack/ironic/templates/hpa-conductor.yaml
+++ b/openstack/ironic/templates/hpa-conductor.yaml
@@ -3,6 +3,8 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: ironic-conductor
+annotations:
+{{- include "utils.linkerd.pod_and_service_annotation" . | indent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/openstack/ironic/templates/inspector-conductor-deployment.yaml
+++ b/openstack/ironic/templates/inspector-conductor-deployment.yaml
@@ -33,6 +33,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
         {{- end }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
 {{ tuple . "ironic" "inspector" | include "kubernetes_pod_anti_affinity" | indent 6 }}
 {{ include "utils.proxysql.pod_settings" . | indent 6 }}

--- a/openstack/ironic/templates/inspector-deployment.yaml
+++ b/openstack/ironic/templates/inspector-deployment.yaml
@@ -32,6 +32,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
         {{- end }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
 {{ tuple . "ironic" "inspector" | include "kubernetes_pod_anti_affinity" | indent 6 }}
       {{- include "utils.proxysql.pod_settings" . | indent 6 }}

--- a/openstack/ironic/templates/inspector-ingress.yaml
+++ b/openstack/ironic/templates/inspector-ingress.yaml
@@ -10,6 +10,7 @@ metadata:
   annotations:
     kubernetes.io/tls-acme: "true"
     disco: "true"
+    {{- include "utils.linkerd.ingress_annotation" . | indent 4 }}
 spec:
   tls:
   - secretName: tls-{{ include "ironic_inspector_endpoint_host_public" . | replace "." "-" }}

--- a/openstack/ironic/templates/inspector-service.yaml
+++ b/openstack/ironic/templates/inspector-service.yaml
@@ -7,6 +7,8 @@ metadata:
     system: openstack
     type: inspector
     component: ironic
+  annotations:
+    {{- include "utils.linkerd.pod_and_service_annotation" . | indent 4 }}
 spec:
   selector:
     name: ironic-inspector

--- a/openstack/ironic/templates/pxe-deployment.yaml
+++ b/openstack/ironic/templates/pxe-deployment.yaml
@@ -27,6 +27,7 @@ spec:
 {{ tuple . "ironic" "pxe" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
       annotations:
         configmap-pxe-hash: {{ include (print $.Template.BasePath "/pxe-configmap.yaml") . | sha256sum }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
       containers:
       - name: ironic-tftp

--- a/openstack/ironic/templates/pxe-service.yaml
+++ b/openstack/ironic/templates/pxe-service.yaml
@@ -7,6 +7,8 @@ metadata:
     system: openstack
     type: backend
     component: ironic
+  annotations:
+    {{- include "utils.linkerd.pod_and_service_annotation" . | indent 4 }}
 spec:
   type: NodePort
   selector:

--- a/openstack/ironic/values.yaml
+++ b/openstack/ironic/values.yaml
@@ -23,6 +23,7 @@ global:
     image: "monsoon/fernet-router:latest"
   domain_seeds:
     skip_hcm_domain: false
+  linkerd_requested: false
 
 imageVersion: rocky-20200214123740
 imageVersionStaticdhcpd: rocky-20201012110713


### PR DESCRIPTION
This adds the `linkerd-support` chart as dependency and also adds the annotations to all `Deployment`, `Service` and `Ingress` objects. `Job` objects are out of the picture for now