### PR TITLE
[Placement] Add basic linkerd support

### DIFF
--- a/openstack/placement/Chart.lock
+++ b/openstack/placement/Chart.lock
@@ -1,15 +1,18 @@
 dependencies:
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.1
+  version: 0.8.0
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.0
+  version: 0.2.0
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.12.1
+  version: 0.12.2
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:8df30477ac2d5795fde779b657a169e2a1d99ca4d12ca6c56a94d101f9f50558
-generated: "2023-11-14T14:29:40.905738575+01:00"
+- name: linkerd-support
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 0.1.3
+digest: sha256:4df1763f169990b7aa598ac359e00726c69ea2efad66d0bc623afb36eb2bbae0
+generated: "2023-11-24T11:06:22.228237283+01:00"

--- a/openstack/placement/Chart.yaml
+++ b/openstack/placement/Chart.yaml
@@ -8,13 +8,16 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.7.1
+    version: 0.8.0
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.0
+    version: 0.2.0
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
     version: ~0.12.1
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0
+  - name: linkerd-support
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: 0.1.3

--- a/openstack/placement/templates/placement-api-deployment.yaml
+++ b/openstack/placement/templates/placement-api-deployment.yaml
@@ -33,6 +33,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
         {{- end }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
 {{ tuple . "placement" "api" | include "kubernetes_pod_anti_affinity" | indent 6 }}
       {{- include "utils.proxysql.pod_settings" . | indent 6 }}

--- a/openstack/placement/templates/placement-api-service.yaml
+++ b/openstack/placement/templates/placement-api-service.yaml
@@ -7,6 +7,8 @@ metadata:
     system: openstack
     type: api
     component: placement
+  annotations:
+    {{- include "utils.linkerd.pod_and_service_annotation" . | indent 4 }}
 spec:
   selector:
     name: placement-api

--- a/openstack/placement/templates/placement-ingress.yaml
+++ b/openstack/placement/templates/placement-ingress.yaml
@@ -12,6 +12,7 @@ metadata:
   {{- if .Values.use_tls_acme }}
     kubernetes.io/tls-acme: "true"
   {{- end }}
+    {{- include "utils.linkerd.ingress_annotation" . | indent 4 }}
 spec:
   tls:
   - secretName: tls-{{include "placement_api_endpoint_host_public" . | replace "." "-" }}

--- a/openstack/placement/values.yaml
+++ b/openstack/placement/values.yaml
@@ -8,6 +8,7 @@ global:
   placementApiPortPublic: '443'
   dbUser: placement
   placement_service_user: placement
+  linkerd_requested: false
 
   osprofiler: {}
 


### PR DESCRIPTION
We need to bump the mariadb chart and the memcached chart, which brings in a new memcached version 1.6.21 in addition to linkerd support.

We do not support Job objects here, yet, as it's still open how we will do the shutdown of linkerd.