### PR TITLE
[octavia] - remove obsolete esd

### DIFF
--- a/openstack/octavia/templates/etc/_esd.json.tpl
+++ b/openstack/octavia/templates/etc/_esd.json.tpl
@@ -47,10 +47,6 @@
     "lbaas_ctcp": "cc_tcp_profile",
     "lbaas_irule": ["cc_http_redirect_a26c_v1_0"]
   },
-  "hcm_rmk_restrict_internal": {
-    "lbaas_ctcp": "cc_tcp_profile",
-    "lbaas_irule": ["cc_hcm_rmk_restrict_internal"]
-  },
   "ccloud_special_udp_stateless": {
     "lbaas_cudp": "cc_udp_datagram_profile"
   },

--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -103,8 +103,7 @@ mysql_metrics:
           OR tag='cookie_encryption_b82a_v1_0'
           OR tag='sso_22b0_v1_0'
           OR tag='sso_required_f544_v1_0'
-          OR tag='http_redirect_a26c_v1_0'
-          OR tag='hcm_rmk_restrict_internal';
+          OR tag='http_redirect_a26c_v1_0';
       values:
         - "count_gauge"
     - name: octavia_esd_l7policies_count_gauge
@@ -126,8 +125,7 @@ mysql_metrics:
           OR name='cookie_encryption_b82a_v1_0'
           OR name='sso_22b0_v1_0'
           OR name='sso_required_f544_v1_0'
-          OR name='http_redirect_a26c_v1_0'
-          OR name='hcm_rmk_restrict_internal';
+          OR name='http_redirect_a26c_v1_0';
       values:
         - "count_gauge"
     - name: octavia_normal_l7policies_count_gauge
@@ -149,8 +147,7 @@ mysql_metrics:
           AND name!='cookie_encryption_b82a_v1_0'
           AND name!='sso_22b0_v1_0'
           AND name!='sso_required_f544_v1_0'
-          AND name!='http_redirect_a26c_v1_0'
-          AND name!='hcm_rmk_restrict_internal';
+          AND name!='http_redirect_a26c_v1_0';
       values:
         - "count_gauge"
     - name: octavia_loadbalancers_count_gauge


### PR DESCRIPTION
In this PR I am removing an obsolete esd `hcm_rmk_restrict_internal` from octavia esd templates and from DB metrics queries.
This esd was introduced back in 2020 for HCM specific security use case (redirecting users to specific web pages based on their IPs). This was only ever used in ap-ae-1 and ap-sa-1.

I verified that the policy is not used any more on any listeners and I also confirmed with HCM (Dave McElhinney) that it is not needed any more as the use case is no longer valid.
