### PR TITLE
Add linkerd support, bump chart and supporting charts versions

### DIFF
--- a/openstack/manila/Chart.lock
+++ b/openstack/manila/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.7.18
+  version: 0.8.0
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.5
@@ -13,12 +13,15 @@ dependencies:
   version: 0.2.0
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.5.2
+  version: 0.6.0
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.12.2
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.2.1
-digest: sha256:f75eb4cfe7f08b41a914917729c7628da96900307e5a520a6bd2e7d4f53e3e14
-generated: "2023-11-21T15:46:54.295782+01:00"
+- name: linkerd-support
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 0.1.3
+digest: sha256:c0de993f4f03fcdaa3e30c841b9c61e20a2a537b29a0cc8a8d55a112405aa049
+generated: "2023-11-28T12:50:41.839874Z"

--- a/openstack/manila/Chart.lock
+++ b/openstack/manila/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.8.0
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.5
+  version: 0.2.0
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.7
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:ce6834d8fffdd8700978b6b9fc35ed2b44caa121ebe17d2e39ea2967b63dcdd2
-generated: "2023-11-28T13:16:10.033625Z"
+digest: sha256:a8e8ab890a7efc8d018ba1f35fa5c4712dc3a0c15be7dda68e22d0902f40ca11
+generated: "2023-11-28T13:31:09.994366Z"

--- a/openstack/manila/Chart.lock
+++ b/openstack/manila/Chart.lock
@@ -19,9 +19,9 @@ dependencies:
   version: 0.12.2
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
-  version: 1.2.1
+  version: 1.3.5
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:c0de993f4f03fcdaa3e30c841b9c61e20a2a537b29a0cc8a8d55a112405aa049
-generated: "2023-11-28T12:50:41.839874Z"
+digest: sha256:ce6834d8fffdd8700978b6b9fc35ed2b44caa121ebe17d2e39ea2967b63dcdd2
+generated: "2023-11-28T13:16:10.033625Z"

--- a/openstack/manila/Chart.yaml
+++ b/openstack/manila/Chart.yaml
@@ -35,7 +35,7 @@ dependencies:
   - name: redis
     alias: api-ratelimit-redis
     repository: https://charts.eu-de-2.cloud.sap
-    version: 1.2.1
+    version: 1.3.5
     condition: api_rate_limit.enabled
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/manila/Chart.yaml
+++ b/openstack/manila/Chart.yaml
@@ -18,7 +18,7 @@ dependencies:
   - condition: memcached.enabled
     name: memcached
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.5
+    version: 0.2.0
   - condition: mariadb.enabled
     name: mysql_metrics
     repository: https://charts.eu-de-2.cloud.sap

--- a/openstack/manila/Chart.yaml
+++ b/openstack/manila/Chart.yaml
@@ -9,16 +9,16 @@ maintainers:
 name: manila
 sources:
   - https://github.com/sapcc/manila
-version: 0.3.10
+version: 0.3.11
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.7.6
+    version: 0.8.0
   - condition: memcached.enabled
     name: memcached
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.1.0
+    version: 0.1.5
   - condition: mariadb.enabled
     name: mysql_metrics
     repository: https://charts.eu-de-2.cloud.sap
@@ -28,7 +28,7 @@ dependencies:
     version: 0.2.0
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.5.2
+    version: 0.6.0
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
     version: ~0.12.1
@@ -37,3 +37,6 @@ dependencies:
     repository: https://charts.eu-de-2.cloud.sap
     version: 1.2.1
     condition: api_rate_limit.enabled
+  - name: linkerd-support
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: 0.1.3

--- a/openstack/manila/templates/api-deployment.yaml
+++ b/openstack/manila/templates/api-deployment.yaml
@@ -36,6 +36,7 @@ spec:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
         configmap-bin-hash: {{ include (print $.Template.BasePath "/bin-configmap.yaml") . | sha256sum }}
         kubectl.kubernetes.io/default-container: manila-api
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
       {{- tuple . "manila" "api" | include "kubernetes_pod_anti_affinity" | nindent 6 }}
       {{- tuple . (dict "name" (print .Release.Name "-api")) | include "utils.topology.constraints" | indent 6 }}

--- a/openstack/manila/templates/api-ingress.yaml
+++ b/openstack/manila/templates/api-ingress.yaml
@@ -7,14 +7,15 @@ metadata:
     system: openstack
     type: api
     component: manila
-  {{- if .Values.use_tls_acme }}
   annotations:
+  {{- if .Values.use_tls_acme }}
     ingress.kubernetes.io/proxy-read-timeout: "720"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "720"
     ingress.kubernetes.io/proxy-send-timeout: "720"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "720"
     kubernetes.io/tls-acme: "true"
   {{- end }}
+    {{- include "utils.linkerd.ingress_annotation" . | indent 4 }}
 spec:
   tls:
      - secretName: tls-{{.Values.seeds.endpoint_prefix}}{{include "manila_api_endpoint_host_public" . | replace "." "-" }}

--- a/openstack/manila/templates/api-service.yaml
+++ b/openstack/manila/templates/api-service.yaml
@@ -10,7 +10,9 @@ metadata:
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/targets: {{ required ".Values.alerts.prometheus.openstack" .Values.alerts.prometheus.openstack |  quote }}
+    {{- include "utils.linkerd.pod_and_service_annotation" . | indent 4 }}
   {{- include "utils.topology.service_topology_mode" . | indent 2 }}
+
 spec:
   selector:
     name: {{ .Release.Name }}-api

--- a/openstack/manila/templates/api-service.yaml
+++ b/openstack/manila/templates/api-service.yaml
@@ -12,7 +12,6 @@ metadata:
     prometheus.io/targets: {{ required ".Values.alerts.prometheus.openstack" .Values.alerts.prometheus.openstack |  quote }}
     {{- include "utils.linkerd.pod_and_service_annotation" . | indent 4 }}
   {{- include "utils.topology.service_topology_mode" . | indent 2 }}
-
 spec:
   selector:
     name: {{ .Release.Name }}-api

--- a/openstack/manila/templates/scheduler-deployment.yaml
+++ b/openstack/manila/templates/scheduler-deployment.yaml
@@ -31,6 +31,8 @@ spec:
         {{- end }}
         kubectl.kubernetes.io/default-container: manila-scheduler
         configmap-etc-hash: {{ include (print .Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
+
     spec:
       {{ include "utils.proxysql.pod_settings" . | indent 6 }}
       affinity:

--- a/openstack/manila/templates/shares/_netapp-deployment.yaml.tpl
+++ b/openstack/manila/templates/shares/_netapp-deployment.yaml.tpl
@@ -35,6 +35,7 @@ spec:
         kubectl.kubernetes.io/default-container: manila-share-netapp-{{$share.name}}
         configmap-etc-hash: {{ include (print .Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
         configmap-netapp-hash: {{ list . $share | include "share_netapp_configmap" | sha256sum }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
 {{ tuple . $availability_zone | include "utils.kubernetes_pod_az_affinity" | indent 6 }}
 {{ include "utils.proxysql.pod_settings" . | indent 6 }}

--- a/openstack/manila/templates/shares/_netapp-ensure-deployment.yaml.tpl
+++ b/openstack/manila/templates/shares/_netapp-ensure-deployment.yaml.tpl
@@ -29,6 +29,7 @@ spec:
         configmap-etc-hash: {{ include (print .Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
         configmap-netapp-hash: {{ list . $share | include "share_netapp_configmap" | sha256sum }}
         netapp_deployment-hash: {{ list . $share | include "share_netapp" | sha256sum }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
       affinity:
         podAffinity:

--- a/openstack/manila/values.yaml
+++ b/openstack/manila/values.yaml
@@ -14,6 +14,8 @@ global:
   metrics_port: 9102
   domain_seeds:
     skip_hcm_domain: false
+  
+  linkerd_requested: false
 
 loci:
   imageNamespace: monsoon


### PR DESCRIPTION
This adds the linkerd-support chart as dependency and also adds the
annotations to all Deployment, Service, Daemonset and Ingress objects.

linkerd is disabled by default and needs to be enabled per region.

We depend on the utils chart for the annotation snippets and the
conditions so our templates stay more compact and thus better readable.

Supporting charts versions are bumped to support this change.

Chart version bumped to 0.3.11