### PR TITLE
[octavia] Add project/AZ metric labels for AZ-aware LB usage reporting

### DIFF
--- a/openstack/octavia/alerts/octavia.alerts
+++ b/openstack/octavia/alerts/octavia.alerts
@@ -60,7 +60,7 @@ groups:
       description: 'Failover detected for agent {{ $labels.app_kubernetes_io_name }}, AS3 target will be changed to active device.'
       summary: Openstack Octavia Metric to monitor F5 Worker Agent failover events
   - alert: OpenstackOctaviaLoadbalancerErrored
-    expr: rate(octavia_loadbalancers_count_gauge{loadbalancer_status="ERROR"}[5m]) > 0
+    expr: sum(rate(octavia_loadbalancers_count_gauge{loadbalancer_status="ERROR"}[5m])) > 0
     for: 10m
     labels:
       context: Loadbalancer go to ERROR

--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -18,7 +18,7 @@ global:
   rpc_response_timeout: 60
   osprofiler: {}
   linkerd_requested: true
-  
+
 osprofiler:
   enabled: false
 
@@ -158,14 +158,18 @@ mysql_metrics:
       labels:
         - "loadbalancer_status"
         - "loadbalancer_host"
+        - "loadbalancer_project"
+        - "loadbalancer_availabilityzone"
       help: Total Load Balancer count
       query: |
         SELECT
           COUNT(*) AS count_gauge,
           provisioning_status AS loadbalancer_status,
-          server_group_id as loadbalancer_host
+          server_group_id as loadbalancer_host,
+          project_id as loadbalancer_project,
+          availability_zone as loadbalancer_availabilityzone
         FROM load_balancer
-        GROUP BY loadbalancer_host, loadbalancer_status;
+        GROUP BY loadbalancer_host, loadbalancer_status, loadbalancer_project, loadbalancer_availabilityzone;
       values:
         - "count_gauge"
     - name: octavia_seconds_since_last_nonpending_status


### PR DESCRIPTION
This PR is for AZ-aware LB usage reporting with Limes. Limes will probably want to `sum by (loadbalancer_availabilityzone)` or something and set label `loadbalancer_status!="DELETED"`.

Neutron added a dedicated metric for this in #5374, but the already existing `octavia_loadbalancers_count_gauge` should work fine, since our Grafana/Plutono dashboards all use this metric with `sum()`. The only place that has to be changed is the `OpenstackOctaviaLoadbalancerErrored` alert, see below.

---

Also:

- Fix `OpenstackOctaviaLoadbalancerErrored` alert: Since `octavia_loadbalancers_count_gauge` is labelled by status and host (and now also project and AZ), `rate()` will calculate the rate of `ERROR` LB count per status and host (and project and AZ), but we are interested in the *overall* `ERROR` LB count.

- `values.yaml`: Remove trailing whitespace

---

Belongs to CCC-34464