### PR TITLE
nova: Rename config vars for CPU reservation

### DIFF
--- a/openstack/sap-seeds/templates/_flavors_hana_exclusive.tpl
+++ b/openstack/sap-seeds/templates/_flavors_hana_exclusive.tpl
@@ -7,6 +7,7 @@
     {{- tuple . "vmware_hana_exclusive" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "24"  # used in nova-vmware as cores-per-socket (12pCPU = 24vCPU)
+    "reservation:cpu": "24"
 - name: "hana_c48_m729"
   id: "301"
   vcpus: 48
@@ -16,6 +17,7 @@
     {{- tuple . "vmware_hana_exclusive" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
+    "reservation:cpu": "48"
 - name: "hana_c96_m1458"
   id: "302"
   vcpus: 96
@@ -25,6 +27,7 @@
     {{- tuple . "vmware_hana_exclusive" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
+    "reservation:cpu": "96"
 - name: "hana_c144_m2188"
   id: "303"
   vcpus: 144
@@ -34,6 +37,7 @@
     {{- tuple . "vmware_hana_exclusive" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
+    "reservation:cpu": "144"
     "vmware:hw_version": "vmx-18"
 - name: "hana_c192_m2917"
   id: "304"
@@ -44,6 +48,7 @@
     {{- tuple . "vmware_hana_exclusive" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
+    "reservation:cpu": "192"
     "vmware:hw_version": "vmx-18"
 - name: "hana_c384_m5835"
   id: "305"
@@ -54,6 +59,7 @@
     {{- tuple . "vmware_hana_exclusive" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
+    "reservation:cpu": "384"
     "vmware:hw_version": "vmx-18"
 - name: "hana_c288_m4377"
   id: "311"
@@ -64,6 +70,7 @@
     {{- tuple . "vmware_hana_exclusive" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
+    "reservation:cpu": "288"
     "vmware:hw_version": "vmx-18"
 - name: "hana_c448_m11671"
   id: "313"
@@ -74,4 +81,5 @@
     {{- tuple . "vmware_hana_exclusive" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "trait:CUSTOM_NUMASIZE_C56_M1459": "required"
     "hw:cpu_cores": "56"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
+    "reservation:cpu": "448"
     "vmware:hw_version": "vmx-18"


### PR DESCRIPTION
The upcoming CPU reservation change in nova renames these two config vars. The old name should be removed after the rollout.
