### PR TITLE
fix(auditbeat): disable hostnetwork, set name

### DIFF
--- a/system/auditbeat/Chart.yaml
+++ b/system/auditbeat/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: auditbeat
 description: Elastic Auditbeat Chart
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "7.17.12"

--- a/system/auditbeat/templates/auditbeat-configmap.yaml
+++ b/system/auditbeat/templates/auditbeat-configmap.yaml
@@ -7,6 +7,7 @@ metadata:
     k8s-app: auditbeat
 data:
   auditbeat.yml: |-
+    name: ${NODE_NAME}
     auditbeat.config.modules:
       # Mounted `auditbeat-daemonset-modules` configmap:
       path: ${path.config}/modules.d/*.yml

--- a/system/auditbeat/templates/auditbeat-daemonset.yaml
+++ b/system/auditbeat/templates/auditbeat-daemonset.yaml
@@ -22,7 +22,7 @@ spec:
       - operator: Exists
       serviceAccountName: {{ include "auditbeat.serviceAccountName" . }}
       terminationGracePeriodSeconds: 30
-      hostNetwork: true
+      hostNetwork: false
       hostPID: true  # Required by auditd module
       dnsPolicy: ClusterFirstWithHostNet
 {{- if .Values.enable_pamd_tty }}


### PR DESCRIPTION
We do not want to run the auditbeat DaemonSet with `hostNetwork: true` anymore. This causes that `agent.hostname` and `agent.name` no longer point to the actual minion the auditbeat container is running on.

Tried to mitigate this with using `add_host_metadata` and `add_kubernetes_metadata`. Both did not yield any results in respect of getting the minion hostname included in the emitted audit events.

Setting `name: ${NODE_NAME}` overwrites the content of field `agent.name`, while the `agent.hostname` still points to the name of the auditbeat pod. This way we can still identify the minion node the audit events were generated on.