### PR TITLE
chore(auditbeat): update exporter image

### DIFF
--- a/system/auditbeat/Chart.yaml
+++ b/system/auditbeat/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: auditbeat
 description: Elastic Auditbeat Chart
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: "7.17.12"

--- a/system/auditbeat/Dockerfile.exporter
+++ b/system/auditbeat/Dockerfile.exporter
@@ -1,0 +1,17 @@
+from keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/alpine/git:latest as git
+RUN git clone https://github.com/sepich/beats-exporter.git
+
+from keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/library/python:3.10-slim
+LABEL source_repository="https://github.com/sapcc/helm-charts/system/auditbeat"
+ENV PYTHONDONTWRITEBYTECODE=true
+ENV PYTHONUNBUFFERED=true
+
+WORKDIR /usr/src/app
+# Install latest version of requirements required
+RUN pip install --no-cache-dir aiodns>=2.0.0
+RUN pip install --no-cache-dir aiohttp>=3.7.4
+RUN pip install --no-cache-dir requests>=2.22.0
+
+USER 1000
+COPY --from=git /git/beats-exporter/beats-exporter.py .
+ENTRYPOINT [ "./beats-exporter.py" ]

--- a/system/auditbeat/Makefile
+++ b/system/auditbeat/Makefile
@@ -1,9 +1,19 @@
 VERSION=7.17.12-amd64
-
+VERSION_EXPORTER=202311291700
 all: build push
 
-build:
+build: build-auditbeat build-exporter
+
+push: push-auditbeat push-exporter
+
+build-auditbeat:
 	docker build --network=host -t keppel.eu-de-1.cloud.sap/ccloud/auditbeat-oss:${VERSION} --build-arg IMAGE=docker.elastic.co/beats/auditbeat-oss:${VERSION} .
 
-push:
+push-auditbeat:
 	docker push keppel.eu-de-1.cloud.sap/ccloud/auditbeat-oss:${VERSION}
+
+build-exporter:
+	docker build -t keppel.eu-de-1.cloud.sap/ccloud/auditbeat-exporter:${VERSION_EXPORTER} -f ./Dockerfile.exporter --platform linux/amd64 .
+
+push-exporter:
+  docker push keppel.eu-de-1.cloud.sap/ccloud/auditbeat-exporter:${VERSION_EXPORTER}

--- a/system/auditbeat/templates/auditbeat-daemonset.yaml
+++ b/system/auditbeat/templates/auditbeat-daemonset.yaml
@@ -50,7 +50,7 @@ spec:
 {{- end }}
       containers:
       - name: exporter
-        image: "{{ required ".Values.global.dockerHubMirror variable missing" .Values.global.dockerHubMirror }}/{{ .Values.exporter.image.repository }}:{{ .Values.exporter.image.tag }}"
+        image: "{{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ .Values.exporter.image.repository }}:{{ .Values.exporter.image.tag }}"
         imagePullPolicy: {{ .Values.exporter.image.pullPolicy }}
         args:
           - -p=5066

--- a/system/auditbeat/values.yaml
+++ b/system/auditbeat/values.yaml
@@ -36,8 +36,8 @@ resources:
 
 exporter:
   image:
-    repository: sepa/beats-exporter
-    tag: "220124"
+    repository: auditbeat-exporter
+    tag: "202311291700"
     pullPolicy: IfNotPresent
   metrics:
     port: "5971"


### PR DESCRIPTION
The upstream Dockerfile is using an outdated version of Python and has old versions of requirements.
This PR provides a new `Dockerfile.exporter` which uses Python 3.10 and installs latest versions of the requirements.