### PR TITLE
[manila-nanny] adding basic linkerd support

### DIFF
--- a/openstack/manila-nanny/Chart.lock
+++ b/openstack/manila-nanny/Chart.lock
@@ -1,9 +1,12 @@
 dependencies:
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.4.2
+  version: 0.12.2
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:97b91fdb0baad7c28fdd17ab0cbc55e2b648d0781380012e25eb5c16a9096cb9
-generated: "2023-08-05T23:50:03.158997+08:00"
+- name: linkerd-support
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 0.1.3
+digest: sha256:874fd0d404fdd75a389ca7cd1a75847a231ce19231d700d7c6248e1f177c8764
+generated: "2023-11-30T10:06:12.119501Z"

--- a/openstack/manila-nanny/Chart.yaml
+++ b/openstack/manila-nanny/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Manila Nanny - sync descrepancies from NetApp filers to Manila DB 
 name: manila-nanny
 type: application
-version: 0.1.0
+version: 0.1.1
 
 appVersion: "0.0.0"
 sources:
@@ -11,7 +11,10 @@ sources:
 dependencies:
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.4.2
+    version: ~0.12.1
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0
+  - name: linkerd-support
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: 0.1.3

--- a/openstack/manila-nanny/templates/deployment.yaml
+++ b/openstack/manila-nanny/templates/deployment.yaml
@@ -30,6 +30,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ quote .Values.alerts.prometheus }}
         {{ include "configmapHash" . | nindent 8 | trim }}
+        {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 8 }}
     spec:
       nodeSelector:
         zone: farm

--- a/openstack/manila-nanny/templates/deployment.yaml
+++ b/openstack/manila-nanny/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ quote .Values.alerts.prometheus }}
         {{ include "configmapHash" . | nindent 8 | trim }}
-        {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 8 }}
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
       nodeSelector:
         zone: farm

--- a/openstack/manila-nanny/values.yaml
+++ b/openstack/manila-nanny/values.yaml
@@ -96,3 +96,6 @@ nannies:
   db_cleanup:
     enabled: false
     dry_run: false
+
+global:
+  linkerd_requested: false


### PR DESCRIPTION
This adds the linkerd-support chart as dependency and also adds the
annotations to Deployment.

linkerd is disabled by default and needs to be enabled per region.

We depend on the utils chart for the annotation snippets and the
conditions so our templates stay more compact and thus better readable.

Supporting charts versions are bumped to support this change.

Chart version bumped to 0.1.1