### PR TITLE
fetching vmware stores using kubes-state-metrics

### DIFF
--- a/global/thanos-global/Chart.yaml
+++ b/global/thanos-global/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos-global
 description: Deploy Thanos via operator
 type: application
-version: 0.2.11
+version: 0.2.12
 dependencies:
   - name: thanos
     repository: https://charts.eu-de-2.cloud.sap

--- a/global/thanos-global/alerts/thanos-global.alerts
+++ b/global/thanos-global/alerts/thanos-global.alerts
@@ -15,9 +15,9 @@ groups:
       summary: Thanos global can't reach all stores.
   - alert: ThanosGlobalMissingVMwareThanos
     expr: |
-      (count by (region, thanos)(label_replace(openstack_volumes_size_gauge{cinder_host=~"(cinder-volume-vmware-vc-[a-z]-[0-9])(@.*)",region!~"qa-de-[1-9]",thanos!~"vmware-vc-a-1|vmware-vc-b-1|vmware-vc-b-2|vmware-vc-d-0|vmware-vc-d-1"}, "thanos", "$2", "cinder_host", "(cinder-volume-)(vmware-vc-[a-z]-[0-9])(@.*)")) * 0 + 1) 
-      unless 
-      (count by (thanos, region)(thanos_build_info{container="store",pod=~"thanos-vmware.*",region!~"qa-de-[1-9]"}) * 0 + 1)
+      (count by (region, thanos) (label_replace(kube_pod_container_info{pod=~"thanos-vmware-vc-.+-store-.+", region!="qa-de-1"}, "thanos", "$2", "pod", "(thanos-)(vmware-vc-.+)(-thanos-vmware-vc-.+)")) * 0 + 1)
+      unless
+      (count by (thanos, region) (thanos_build_info{container="store",pod=~"thanos-vmware.*",region!~"qa-de-[1-9]"}) * 0 + 1)
     for: 10m
     labels:
       severity: info
@@ -30,9 +30,9 @@ groups:
       summary: Thanos global can't reach VMware store.
   - alert: ThanosGlobalMissingVMwareThanosQA
     expr: |
-      (count by (region, thanos)(label_replace(openstack_volumes_size_gauge{cinder_host=~"(cinder-volume-vmware-vc-[a-z]-[0-9])(@.*)",region="qa-de-1", cinder_host!~".+vmware-vc-a-1.+|.+vmware-vc-b-1.+|.+vmware-vc-b-2.+|.+vmware-vc-d-0.+|.+vmware-vc-d-1.+"}, "thanos", "$2", "cinder_host", "(cinder-volume-)(vmware-vc-[a-z]-[0-9])(@.*)")) * 0 + 1)
-      unless 
-      (count by (thanos, region)(thanos_build_info{container="store",pod=~"thanos-vmware.*",region="qa-de-1"}) * 0 + 1)
+      (count by (region, thanos) (label_replace(kube_pod_container_info{pod=~"thanos-vmware-vc-.+-store-.+", region!="qa-de-1"}, "thanos", "$2", "pod", "(thanos-)(vmware-vc-.+)(-thanos-vmware-vc-.+)")) * 0 + 1)
+      unless
+      (count by (thanos, region) (thanos_build_info{container="store",pod=~"thanos-vmware.*",region="qa-de-1"}) * 0 + 1)
     for: 10m
     labels:
       severity: info


### PR DESCRIPTION
it will avoid having alerts for decommissioned VCs, which are still in cinder but not in Thanos anymore.