### PR TITLE
[system/sentry] add `create` verb to clusterrole, enables creation of new secrets

### DIFF
--- a/system/sentry/templates/clusterrole.yaml
+++ b/system/sentry/templates/clusterrole.yaml
@@ -17,6 +17,7 @@ rules:
       - watch
       - patch
       - update
+      - create
   - apiGroups:
     - apiextensions.k8s.io
     resources:


### PR DESCRIPTION
sentry operator runs into following error if a SentryProject is defined in a
foreign namespace with no prior secrets:
```
Error running handler: secrets is forbidden: User "system:serviceaccount:sentry:sentry" cannot create resource "secrets" in API group "" in the namespace "andromeda"
```

This patch adds the create verb to the clusterrole, enabled the sentry
service account to create secrets clusterwide.
