### PR TITLE
remove broken link in nova alerts

### DIFF
--- a/openstack/nova/alerts/openstack/nova.alerts
+++ b/openstack/nova/alerts/openstack/nova.alerts
@@ -63,7 +63,6 @@ groups:
     expr: sum(openstack_compute_stuck_instances_count_gauge{task_state="deleting"}) BY (nova_host) > 0
     for: 5m
     labels:
-      dashboard: nova-hypervisor
       playbook: docs/support/playbook/nova/delete_stuck_instance#Delete
       service: nova
       severity: info


### PR DESCRIPTION
The dashboard was apparently not used very much and is gone by now.