### PR TITLE
[openstack/utils] Add config option for proxysql imageRepository

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.12.3
+version: 0.13.0

--- a/openstack/utils/templates/_proxysql.tpl
+++ b/openstack/utils/templates/_proxysql.tpl
@@ -22,7 +22,11 @@
     {{- if .Values.proxysql }}
       {{- if .Values.proxysql.mode }}
 - name: proxysql
-  image: {{ required ".Values.global.dockerHubMirror is missing" .Values.global.dockerHubMirror }}/{{ default "proxysql/proxysql" .Values.proxysql.image }}:{{ .Values.proxysql.imageTag | default "2.4.7-debian" }}
+  image: {{ if .Values.proxysql.imageRepository -}}
+            {{ .Values.proxysql.imageRepository }}
+        {{- else -}}
+          {{ required ".Values.global.dockerHubMirror is missing" .Values.global.dockerHubMirror }}/{{ default "proxysql/proxysql" .Values.proxysql.image }}
+        {{- end }}:{{ .Values.proxysql.imageTag | default "2.4.7-debian" }}
   imagePullPolicy: IfNotPresent
   command: ["proxysql"]
   args: ["--config", "/etc/proxysql/proxysql.cnf", "--exit-on-error", "--foreground", "--idle-threads", "--admin-socket", "/run/proxysql/admin.sock", "--no-version-check", "-D", "/run/proxysql"]


### PR DESCRIPTION
The default was hardcoded to dockerhub (via the keppel proxy). For updating the image with os updates, we need to point it to our own image, which is in our keppel repo.