### PR TITLE
[nova] Bump utils dependency for proxysql update

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 0.1.5
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.12.1
+  version: 0.13.0
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.8.0
@@ -29,5 +29,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:1974a02465e1fd3e9572ea7cf153c5ecba0dda368b202e4b7b58dbbe2548571b
-generated: "2023-11-14T14:15:29.460325376+01:00"
+digest: sha256:3236186eb4f6616e6657e6221f6252d7ba1d1fb014339c911ba0e37556898dce
+generated: "2023-12-04T15:44:58.573896905+01:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     version: 0.1.5
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.12.1
+    version: ~0.13.0
   - name: mariadb
     alias: mariadb_cell2
     condition: mariadb_cell2.enabled


### PR DESCRIPTION
The change does not pull in a new proxysql-sidecar, it just creates the option to pull the proxysql image from a different registry than docker.io