### PR TITLE
[manila] Bump utils dependency for proxysql update

### DIFF
--- a/openstack/manila/Chart.lock
+++ b/openstack/manila/Chart.lock
@@ -16,12 +16,12 @@ dependencies:
   version: 0.6.0
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.12.2
+  version: 0.13.0
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.3.5
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:a8e8ab890a7efc8d018ba1f35fa5c4712dc3a0c15be7dda68e22d0902f40ca11
-generated: "2023-11-28T13:31:09.994366Z"
+digest: sha256:671e6c27d1d98cb6ff9376034cf80343e704c67c41024d0272b99e15e40737d1
+generated: "2023-12-04T15:44:24.605846162+01:00"

--- a/openstack/manila/Chart.yaml
+++ b/openstack/manila/Chart.yaml
@@ -31,7 +31,7 @@ dependencies:
     version: 0.6.0
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.12.1
+    version: ~0.13.0
   - name: redis
     alias: api-ratelimit-redis
     repository: https://charts.eu-de-2.cloud.sap


### PR DESCRIPTION
The change does not pull in a new proxysql-sidecar, it just creates the option to pull the proxysql image from a different registry than docker.io