### PR TITLE
[neutron] Bump utils dependency for proxysql update

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 0.6.0
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.11.1
+  version: 0.13.0
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:494d6433e1086113a0565601367df148f879e4795074f78c21380b75b2d01fb9
-generated: "2023-11-28T14:30:17.091601Z"
+digest: sha256:2c7286b47ef49744b6b6bfa9cedf0c99777f8e4eefcd871bc45bab517ace7979
+generated: "2023-12-04T15:44:40.069750993+01:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -20,7 +20,7 @@ dependencies:
     version: 0.6.0
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.11.1
+    version: 0.13.0
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0


### PR DESCRIPTION
The change does not pull in a new proxysql-sidecar, it just creates the option to pull the proxysql image from a different registry than docker.io