### PR TITLE
[ironic] Bump utils dependency for proxysql update

### DIFF
--- a/openstack/ironic/Chart.lock
+++ b/openstack/ironic/Chart.lock
@@ -16,12 +16,12 @@ dependencies:
   version: 0.6.1
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.12.2
+  version: 0.13.0
 - name: ironic-exporter
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.0.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:5bcb1ff8d155764c3156c59e1be2909b500064c5cc790566572fccbee58533e0
-generated: "2023-11-27T11:21:54.735838+05:30"
+digest: sha256:4d6ac250cbe076e57604e0523e6867cdd32a5fcaea36354b3cf0fb76aa7b6ff2
+generated: "2023-12-04T15:43:47.452274036+01:00"

--- a/openstack/ironic/Chart.yaml
+++ b/openstack/ironic/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
     version: ~0.6.1
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.12.2
+    version: ~0.13.0
   - name: ironic-exporter
     repository: https://charts.eu-de-2.cloud.sap
     version: ~1.0.0


### PR DESCRIPTION
The change does not pull in a new proxysql-sidecar, it just creates the option to pull the proxysql image from a different registry than docker.io