### PR TITLE
[keystone] Bump utils dependency for proxysql update

### DIFF
--- a/openstack/keystone/Chart.lock
+++ b/openstack/keystone/Chart.lock
@@ -19,9 +19,9 @@ dependencies:
   version: 1.3.5
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.12.2
+  version: 0.13.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:cf4ed24dd0976dffae192ec8f2b337c02c1575dfdee487ea014b913ceb84d9db
-generated: "2023-11-23T16:52:52.030809+05:30"
+digest: sha256:546fad5b250bcf2fb3873000a81c037f8b249b4d53f989ae77d4ffa02806529c
+generated: "2023-12-04T15:44:08.941690577+01:00"

--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -36,7 +36,7 @@ dependencies:
     version: 1.3.5
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.12.0
+    version: ~0.13.0
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.1.3    


### PR DESCRIPTION
The change does not pull in a new proxysql-sidecar, it just creates the option to pull the proxysql image from a different registry than docker.io