### PR TITLE
[designate] Bump utils dependency for proxysql update

### DIFF
--- a/openstack/designate/Chart.lock
+++ b/openstack/designate/Chart.lock
@@ -19,12 +19,12 @@ dependencies:
   version: 0.1.9
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.11.1
+  version: 0.13.0
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:e0c7ca0aa1325b36c408dc06ad08bb01d8b77c520b824cdff2ba21c5fdbfe179
-generated: "2023-11-28T14:35:45.566522Z"
+digest: sha256:e8c8254520957219171c504ed018a800d251be2cdd85d73d26b3a8f973d87255
+generated: "2023-12-04T15:43:04.217070428+01:00"

--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -29,7 +29,7 @@ dependencies:
     version: 0.1.9
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.11.1
+    version: 0.13.0
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0


### PR DESCRIPTION
The change does not pull in a new proxysql-sidecar, it just creates the option to pull the proxysql image from a different registry than docker.io