### PR TITLE
[glance] Bump utils dependency for proxysql update

### DIFF
--- a/openstack/glance/Chart.lock
+++ b/openstack/glance/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 0.2.7
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.12.2
+  version: 0.13.0
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.3.8
@@ -20,5 +20,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:4d4952a6dc072f41f218be2227379a9664dc3b3678981c926883900916e8a5b2
-generated: "2023-11-27T08:17:09.77786+05:30"
+digest: sha256:c49822aef0aeead8eba3ea115f73a4fc19fc0ce673c41ced4f059d3404923b1b
+generated: "2023-12-04T15:43:32.749652628+01:00"

--- a/openstack/glance/Chart.yaml
+++ b/openstack/glance/Chart.yaml
@@ -18,7 +18,7 @@ dependencies:
     version: 0.2.7
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.12.1
+    version: ~0.13.0
   - name: redis
     alias: sapcc_rate_limit
     repository: https://charts.eu-de-2.cloud.sap


### PR DESCRIPTION
The change does not pull in a new proxysql-sidecar, it just creates the option to pull the proxysql image from a different registry than docker.io