### PR TITLE
[barbican] Bump utils dependency for proxysql update

### DIFF
--- a/openstack/barbican/Chart.lock
+++ b/openstack/barbican/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 0.6.1
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.12.2
+  version: 0.13.0
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.3.8
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:8d781b97d3dbbc5823663e7b90164506b7d2bd53e1d02e7b9348a132d2ff4af9
-generated: "2023-11-27T08:19:59.599163+05:30"
+digest: sha256:a8da8bee4e33e9d53cf49587d00f8a5e6466a3137724f8a2467ceec3b64524b6
+generated: "2023-12-04T15:42:46.474408485+01:00"

--- a/openstack/barbican/Chart.yaml
+++ b/openstack/barbican/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
     version: 0.6.1
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.12.1
+    version: ~0.13.0
   - name: redis
     alias: sapcc_rate_limit
     repository: https://charts.eu-de-2.cloud.sap

--- a/openstack/placement/Chart.lock
+++ b/openstack/placement/Chart.lock
@@ -7,12 +7,12 @@ dependencies:
   version: 0.2.0
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.12.2
+  version: 0.13.0
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:4df1763f169990b7aa598ac359e00726c69ea2efad66d0bc623afb36eb2bbae0
-generated: "2023-11-24T11:06:22.228237283+01:00"
+digest: sha256:4f7036b51c6b18c4d5d26297d516e63e8d5fddd287cee08b92e95b78d1b1515d
+generated: "2023-12-04T15:37:33.379994947+01:00"

--- a/openstack/placement/Chart.yaml
+++ b/openstack/placement/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
     version: 0.2.0
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.12.1
+    version: ~0.13.0
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0


### PR DESCRIPTION
The change does not pull in a new proxysql-sidecar, it just creates the option to pull the proxysql image from a different registry than docker.io