### PR TITLE
[octavia] Bump utils dependency for proxysql update

### DIFF
--- a/openstack/octavia/Chart.lock
+++ b/openstack/octavia/Chart.lock
@@ -13,12 +13,12 @@ dependencies:
   version: 0.6.0
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.11.1
+  version: 0.13.0
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:a2d717b8cfb96ed0d50852c35b0f0e0d2cb368b2c19d140f127fcd80545d7ac8
-generated: "2023-11-28T14:33:40.246007Z"
+digest: sha256:1a6a12ea2e327794e161a0ba0fb66ab079cbb075aa8670b62bff7fe1bf6659ab
+generated: "2023-12-04T15:45:14.478899686+01:00"

--- a/openstack/octavia/Chart.yaml
+++ b/openstack/octavia/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     version: 0.6.0
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.11.1
+    version: 0.13.0
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0


### PR DESCRIPTION
The change does not pull in a new proxysql-sidecar, it just creates the option to pull the proxysql image from a different registry than docker.io