### PR TITLE
[nova] Bump utils dependency for proxysql update

### DIFF
--- a/openstack/placement/Chart.lock
+++ b/openstack/placement/Chart.lock
@@ -7,12 +7,12 @@ dependencies:
   version: 0.2.0
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.12.2
+  version: 0.13.0
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:4df1763f169990b7aa598ac359e00726c69ea2efad66d0bc623afb36eb2bbae0
-generated: "2023-11-24T11:06:22.228237283+01:00"
+digest: sha256:4f7036b51c6b18c4d5d26297d516e63e8d5fddd287cee08b92e95b78d1b1515d
+generated: "2023-12-04T16:44:32.408849211+01:00"

--- a/openstack/placement/Chart.yaml
+++ b/openstack/placement/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
     version: 0.2.0
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.12.1
+    version: ~0.13.0
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0


### PR DESCRIPTION
The change does not pull in a new proxysql-sidecar, it just creates the option to pull the proxysql image from a different registry than docker.io