### PR TITLE
adding cronus toleration for logging

### DIFF
--- a/system/logs/values.yaml
+++ b/system/logs/values.yaml
@@ -65,6 +65,8 @@ fluent-bit:
   tolerations:
   - key: "species"
     operator: "Exists"
+  - key: "dedicated"
+    operator: "cronus"
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
It looks like the cronus nodes in the scaleout clusters have a taint `dedicated=cronus`, causing no fluent bit on the nodes and not logging being shipped