### PR TITLE
[neutron] Add service info to owner-info

### DIFF
--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -24,6 +24,7 @@ rpc_state_workers: 5
 
 owner-info:
   support-group: network-api
+  service: neutron
   maintainers:
     - Sebastian Lohff
     - Sebastian Wagner


### PR DESCRIPTION
This should make it easier to get cross-service metric dashboards, such as the proxysql one.