### PR TITLE
[octavia] Add service info to owner-info

### DIFF
--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -4,6 +4,7 @@
 
 owner-info:
   support-group: network-api
+  service: octavia
   maintainers:
     - Benjamin Ludwig
     - Andrew Karpow


### PR DESCRIPTION
This should make it easier to get cross-service metric dashboards, such as the proxysql one.