### PR TITLE
[keystone] Add service info to owner-info

### DIFF
--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -14,6 +14,7 @@ global:
 
 owner-info:
   support-group: identity
+  service: keystone
   maintainers:
     - Boris Bobrov
     - Rajiv Mucheli


### PR DESCRIPTION
This should make it easier to get cross-service metric dashboards, such as the proxysql one.