### PR TITLE
[keystone] Set keep-image-pulled maxUnavailable to 10%

### DIFF
--- a/openstack/keystone/templates/daemonset-keep-image-pulled.yaml
+++ b/openstack/keystone/templates/daemonset-keep-image-pulled.yaml
@@ -13,7 +13,7 @@ spec:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 5
+      maxUnavailable: 10%
   selector:
     matchLabels:
       app: {{ .Release.Name }}-keep-image-pulled


### PR DESCRIPTION
The old value was 5 and has practically never been revisited. Change it to 10% so it scales with the cluster size.