### PR TITLE
[NSXT] Switch user to none admin

### DIFF
--- a/openstack/neutron/templates/vct-nsxv3-agent-configmap.yaml
+++ b/openstack/neutron/templates/vct-nsxv3-agent-configmap.yaml
@@ -39,8 +39,7 @@ template: |
       {{- end }}
 
       [NSXV3]
-      # nsx-t has only admin / audit user
-      nsxv3_login_user = admin
+      nsxv3_login_user = osapinsxt
       {%- set bb = name | replace( "bb", "") | int %}
       {%- set hostname = "nsx-ctl-" + "bb" + ( '%03d' % bb ) + "." + domain %}
       nsxv3_login_hostname = {= hostname =}


### PR DESCRIPTION
Due to PCI4. running the agent with an admin user is no longer allowed. 