### PR TITLE
explicitly set am version

### DIFF
--- a/common/prometheus-alertmanager-base/Chart.yaml
+++ b/common/prometheus-alertmanager-base/Chart.yaml
@@ -1,6 +1,6 @@
 description: Template for a Prometheus Alertmanager via Prometheus operator.
 name: prometheus-alertmanager-base
 apiVersion: v2
-version: 3.0.0
-appVersion: v0.26.0
+version: 2.2.7
+appVersion: v0.23.0
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/common/prometheus-alertmanager-base/templates/alertmanager.yaml
+++ b/common/prometheus-alertmanager-base/templates/alertmanager.yaml
@@ -12,6 +12,8 @@ spec:
 
   image: {{ include "alertmanager.image" . }}
 
+  version: {{ required ".Chart.AppVersion missing" .Chart.AppVersion }} 
+
   logLevel: {{ required ".Values.logLevel missing" .Values.logLevel }}
 
   # The retention time of the Alertmanager.


### PR DESCRIPTION
the operator will obey the version set and set flags accordingly

https://github.com/prometheus-operator/prometheus-operator/blob/9fe4c212cb085356ae24591fd3075e728196b213/pkg/alertmanager/statefulset.go#L311-L320

If this is not set, it will use the default: https://github.com/prometheus-operator/prometheus-operator/blob/30148709865dcd8a56c59363dcb953f117d0d0ce/pkg/operator/defaults.go#L21

This PR will make sure, that an operator upgrade is not breaking the AM again based on versioning flags, if it is covered in code.

Version the previous to current version increased by one to ensure cluster functionality as is.