### PR TITLE
[Octavia] Add availability zone to worker pod labels

### DIFF
--- a/openstack/octavia/templates/octavia-worker-deployment.yaml
+++ b/openstack/octavia/templates/octavia-worker-deployment.yaml
@@ -21,7 +21,9 @@ spec:
       labels:
         app.kubernetes.io/name: octavia-worker-{{ $name }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-        f5-device-model: {{ $v.model }} # used by Limes for capacity discovery (via Prometheus metric "kube_pod_labels")
+        # Labels used by Limes for capacity discovery (via Prometheus metric "kube_pod_labels")
+        f5-device-model: {{ $v.model }}
+        availability-zone: {{ $v.availability_zone }}
       annotations:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/octavia-etc-configmap.yaml") . | sha256sum }}
         configmap-worker-hash: {{ include (print $.Template.BasePath "/octavia-worker-configmap.yaml") . | sha256sum }}

--- a/openstack/octavia/templates/octavia-worker-deployment.yaml
+++ b/openstack/octavia/templates/octavia-worker-deployment.yaml
@@ -23,7 +23,8 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         # Labels used by Limes for capacity discovery (via Prometheus metric "kube_pod_labels")
         f5-device-model: {{ $v.model }}
-        availability-zone: {{ $v.availability_zone }}
+        # AZ value "any" corresponds to the enum symbol used by Limes: https://pkg.go.dev/github.com/sapcc/go-api-declarations/limes#AvailabilityZone
+        availability-zone: {{ $v.availability_zone | default "any" }}
       annotations:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/octavia-etc-configmap.yaml") . | sha256sum }}
         configmap-worker-hash: {{ include (print $.Template.BasePath "/octavia-worker-configmap.yaml") . | sha256sum }}


### PR DESCRIPTION
When the worker does not have an availability zone set, the label will be empty.
@majewsky please keep this in mind and check whether this behavior is okay.