### PR TITLE
[unbound][dnstap] -- args names/values need to be separate list items

### DIFF
--- a/system/unbound/templates/deployment.yaml
+++ b/system/unbound/templates/deployment.yaml
@@ -102,13 +102,17 @@ spec:
         resources:
 {{ toYaml .Values.resources.dnstap | indent 10 }}
         args:
-          - -u {{ .Values.unbound.dnstap.socket_path | default "/run/dnstap/dnstap.sock" }}
+          - -u
+          - {{ .Values.unbound.dnstap.socket_path | default "/run/dnstap/dnstap.sock" }}
 {{ if .Values.unbound.dnstap.hec_splunk_url }}
 {{ if .Values.unbound.dnstap.hec_splunk_token }}
 {{ if .Values.unbound.dnstap.hec_splunk_server_uuid }}
-          - -H {{ .Values.unbound.dnstap.hec_splunk_url }}
-          - -token {{ .Values.unbound.dnstap.hec_splunk_token }}
-          - -server_uuid {{ .Values.unbound.dnstap.hec_splunk_server_uuid }}
+          - -H
+          - {{ .Values.unbound.dnstap.hec_splunk_url }}
+          - -token
+          - {{ .Values.unbound.dnstap.hec_splunk_token }}
+          - -server_uuid
+          - {{ .Values.unbound.dnstap.hec_splunk_server_uuid }}
 {{ end }}
 {{ end }}
 {{ end }}


### PR DESCRIPTION
bad:
```yaml
- -arg1 value1
- -arg2 value2
```

good:
```yaml
- -arg1
- value1
- -arg2
- value2
```