### PR TITLE
allow am crd to have a different version

### DIFF
--- a/common/prometheus-alertmanager-base/CHANGELOG.md
+++ b/common/prometheus-alertmanager-base/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.2
+
+* make version for operator customizable 
+
 ## 3.0.0
 
 * upgrading to v0.26.0

--- a/common/prometheus-alertmanager-base/Chart.yaml
+++ b/common/prometheus-alertmanager-base/Chart.yaml
@@ -1,6 +1,6 @@
 description: Template for a Prometheus Alertmanager via Prometheus operator.
 name: prometheus-alertmanager-base
 apiVersion: v2
-version: 3.0.1
+version: 3.0.2
 appVersion: "v0.26.0"
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/common/prometheus-alertmanager-base/ci/test-values.yaml
+++ b/common/prometheus-alertmanager-base/ci/test-values.yaml
@@ -7,6 +7,8 @@ global:
 
 name: regionOneAlertmanager
 
+version: "v10.10.10"
+
 # Number of replicas of the Alertmanager.
 replicas: 1
 

--- a/common/prometheus-alertmanager-base/templates/alertmanager.yaml
+++ b/common/prometheus-alertmanager-base/templates/alertmanager.yaml
@@ -12,7 +12,7 @@ spec:
 
   image: {{ include "alertmanager.image" . }}
 
-  version: {{ required ".Chart.AppVersion missing" .Chart.AppVersion }} 
+  version: {{ default (required ".Chart.AppVersion missing" .Chart.AppVersion) .Values.version }} 
 
   logLevel: {{ required ".Values.logLevel missing" .Values.logLevel }}
 

--- a/common/prometheus-alertmanager-base/values.yaml
+++ b/common/prometheus-alertmanager-base/values.yaml
@@ -9,6 +9,11 @@ global:
 image:
   repository: keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/prom/alertmanager
 
+# custom specified version only to be set as version string in the alertmanager spec. The image can be different.
+# used to explicitly avoid newly introduced operator settings which might not fit.
+# defaults to .Chart.AppVersion
+version:
+
 # Mandatory name for this Alertmanager.
 name:
 


### PR DESCRIPTION
version in the AM CRD can now be set differently from .Chart.AppVersion Used to avoid newer features which are hard coded