### PR TITLE
[utils] trust bundle: mount subpath

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.13.0
+version: 0.14.0

--- a/openstack/utils/templates/_trust_bundle.tpl
+++ b/openstack/utils/templates/_trust_bundle.tpl
@@ -1,6 +1,7 @@
 {{- define "utils.trust_bundle.volume_mount" }}
   {{- if .Values.utils.trust_bundle.enabled }}
-- mountPath: /etc/ssl/certs
+- mountPath: /etc/ssl/certs/ca-certificates.crt
+  subPath: ca-certificates.crt
   name: trust-bundle
   readOnly: true
   {{- end }}


### PR DESCRIPTION
limit the scope by not mounting over the
whole /etc/ssl/certs directory
