### PR TITLE
Set trust-bundle to off by default

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.14.0
+version: 0.14.1

--- a/openstack/utils/values.yaml
+++ b/openstack/utils/values.yaml
@@ -29,6 +29,6 @@ pyroscope_defaults:
   # report_thread_name: false
 
 trust_bundle:
-  enabled: true         # Should the trust-bundle be mounted?
+  enabled: false        # Should the trust-bundle be mounted?
   name: cloud-sap       # What is the name of the ConfigMap with the trust-bundle
   key: trust-bundle.pem # What is the key of the trust-bundle in the ConfigMap


### PR DESCRIPTION
Set trust-bundle feature to off by default, as described in the original commit message, to provide backwards compatibility.