### PR TITLE
[unbound][dnstap] -- make the -server_uid HEC splunk cmdline arg optional

### DIFF
--- a/system/unbound/templates/deployment.yaml
+++ b/system/unbound/templates/deployment.yaml
@@ -106,11 +106,11 @@ spec:
           - {{ .Values.unbound.dnstap.socket_path | default "/run/dnstap/dnstap.sock" }}
 {{ if .Values.unbound.dnstap.hec_splunk_url }}
 {{ if .Values.unbound.dnstap.hec_splunk_token }}
-{{ if .Values.unbound.dnstap.hec_splunk_server_uuid }}
           - -H
           - {{ .Values.unbound.dnstap.hec_splunk_url }}
           - -token
           - {{ .Values.unbound.dnstap.hec_splunk_token }}
+{{ if .Values.unbound.dnstap.hec_splunk_server_uuid }}
           - -server_uuid
           - {{ .Values.unbound.dnstap.hec_splunk_server_uuid }}
 {{ end }}


### PR DESCRIPTION
Set it only if .Values.unbound.dnstap.hec_splunk_server_uuid is defined.