### PR TITLE
[neutron] Use newer utils version with disabled by default trust-bundle

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 0.6.0
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.13.0
+  version: 0.14.1
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:2c7286b47ef49744b6b6bfa9cedf0c99777f8e4eefcd871bc45bab517ace7979
-generated: "2023-12-04T15:44:40.069750993+01:00"
+digest: sha256:fd3fa1c7d698d30477b8251eb46fa0243c945ab5c005294b8eee0275c5beb8b9
+generated: "2023-12-14T10:39:57.105854459+01:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -20,7 +20,7 @@ dependencies:
     version: 0.6.0
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.13.0
+    version: 0.14.1
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0


### PR DESCRIPTION
The prior version had the trust-bundle enabled by default, this reverts that behaviour.