### PR TITLE
[cinder] Bump utils dependency for proxysql update

### DIFF
--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.11.1
+  version: 0.14.1
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.8.0
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:92d53100080c267c31ad051375615c8a1d08e82b72a2c27fc16ffb6d4725bbf3
-generated: "2023-11-28T08:45:58.911628-05:00"
+digest: sha256:bc6776ef85dcd8c49af8b9c07ed6bb3ad292b2c4d2a74d3d835e0105c3cf7c25
+generated: "2023-12-14T10:56:47.295467105+01:00"

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.1.2
 dependencies:
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.11.1
+    version: ~0.14.1
   - name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.8.0


### PR DESCRIPTION
The change does not pull in a new proxysql-sidecar, it just creates the option to pull the proxysql image from a different registry than docker.io