### PR TITLE
Enable harakiri-gracefule-signal

### DIFF
--- a/openstack/neutron/templates/etc/_uwsgi.ini.tpl
+++ b/openstack/neutron/templates/etc/_uwsgi.ini.tpl
@@ -43,6 +43,10 @@ memory-report = true
 # Limits, Kill requests after 120 seconds
 harakiri = 120
 harakiri-verbose = true
+{{ if .Values.api.uwsgi_enable_harakiri_graceful_signal -}}
+harakiri-graceful-signal = SIGWINCH
+harakiri-graceful-timeout = 5
+{{ end -}}
 post-buffering = 4096
 backlog-status = true
 py-tracebacker = /var/lib/neutron/uwsgi_pytracebacker.

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -195,6 +195,7 @@ api:
   # minimum number of workers to keep at all times
   cheaper: 0
   uwsgi: false
+  uwsgi_enable_harakiri_graceful_signal: false
   # time to cache the OwnerCheck's result in seconds
   # 0/nil/null results in not setting the config option at all and thus using
   # the default from Neutron


### PR DESCRIPTION
Send the SIGWINCH signal if a process gets shutdown in order to trigger a guru meditation report creation.