### PR TITLE
nova/flavors: Add BigVM extra-specs to =1TiB flavors

### DIFF
--- a/openstack/sap-seeds/templates/_flavors_deleted.tpl
+++ b/openstack/sap-seeds/templates/_flavors_deleted.tpl
@@ -88,6 +88,9 @@
   is_public: false
   extra_specs:
     {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
+    trait:CUSTOM_NUMASIZE_C48_M729: required
+    hw:cpu_cores: '48'  # cores-per-socket
+    vmware:hw_version: vmx-18
 
 - name: gmp_m1024_c96
   id: 97709ba4-e52e-4a92-ae28-caf53f28243e
@@ -97,6 +100,9 @@
   is_public: false
   extra_specs:
     {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
+    trait:CUSTOM_NUMASIZE_C48_M729: required
+    hw:cpu_cores: '48'  # cores-per-socket
+    vmware:hw_version: vmx-18
 
 - name: gmp_m1024_c96_hana
   id: a219a815-e08e-47c6-9b71-bc77bc1cbbfd
@@ -106,6 +112,9 @@
   is_public: false
   extra_specs:
     {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
+    trait:CUSTOM_NUMASIZE_C48_M729: required
+    hw:cpu_cores: '48'  # cores-per-socket
+    vmware:hw_version: vmx-18
 
 - name: gmp_m128_c20
   id: 85a96f15-70f8-43fd-86f3-cdde3c26874a


### PR DESCRIPTION
The size threshold for BigVMs is >=1024 and not >1024, so these 3
flavors will also need the BigVM treatment, or VMs' migrations will
be rejected.

The flavors don't have the NUMASIZE ratio that their resource
extra-spec requires (C48_M729), but:
 - there are so few VMs of these flavors,
 - the CPU is _less_ than the ratio, so we won't run into contention,
 - there are much more C48_M729 clusters available than the
   alternative, C49_M1459

