### PR TITLE
[Neutron] Fix trailing whitespaces in rate_limit template

### DIFF
--- a/openstack/neutron/templates/etc/_ratelimit.yaml.tpl
+++ b/openstack/neutron/templates/etc/_ratelimit.yaml.tpl
@@ -28,6 +28,6 @@ groups:
 {{ .Values.rate_limit.groups | toYaml | indent 2 }}
 {{- end }}
 {{- if .Values.rate_limit.rates }}
-rates: 
+rates:
 {{ .Values.rate_limit.rates | toYaml | indent 2 }}
 {{- end }}


### PR DESCRIPTION
Fix trailing whitespaces in rate_limit template