### PR TITLE
[designate-nanny] using the auth_url from values to support global setup

### DIFF
--- a/openstack/designate-nanny/templates/deployment.yaml
+++ b/openstack/designate-nanny/templates/deployment.yaml
@@ -35,24 +35,24 @@ spec:
          - name: NANNY_CONFIG
            value: "/srv/nanny.yaml"
          - name: OS_AUTH_URL
-           value: "https://{{ include "keystone_api_endpoint_host_public" . }}/v3"
+           value: {{ required "missing .Values.credentials.designate_api.auth_url" .Values.credentials.designate_api.auth_url}}
          - name: PYCCLOUD_USE_DUMMY_SECRETS
            value: "yes"          
          - name: OS_REGION_NAME
-           value: "{{.Values.global.region}}"
+           value: "{{ required "missing .Values.global.region" .Values.global.region}}"
          - name: OS_PROJECT_NAME
-           value:  "{{ .Values.credentials.designate_api.project_name}}"
+           value:  "{{ required "missing .Values.credentials.designate_api.project_name" .Values.credentials.designate_api.project_name}}"
          - name: OS_PROJECT_DOMAIN_NAME
-           value:  "{{ .Values.credentials.designate_api.project_domain_name}}"
+           value:  "{{ required "missing .Values.credentials.designate_api.project_domain_name" .Values.credentials.designate_api.project_domain_name}}"
          - name: OS_USERNAME
-           value: "{{ .Values.credentials.designate_api.user}}"
+           value: "{{ required "missing .Values.credentials.designate_api.user" .Values.credentials.designate_api.user}}"
          - name: OS_PASSWORD
            valueFrom:
              secretKeyRef:
                name: designate-nanny-secret
                key:  designate_nanny_os_password
          - name: OS_USER_DOMAIN_NAME
-           value:  "{{ .Values.credentials.designate_api.project_user_domain_name}}"
+           value:  "{{ required "missing .Values.credentials.designate_api.project_user_domain_name" .Values.credentials.designate_api.project_user_domain_name}}"
        ports:
        - containerPort: 9102
          name: metrics

--- a/openstack/designate-nanny/values.yaml
+++ b/openstack/designate-nanny/values.yaml
@@ -25,6 +25,7 @@ credentials:
     project_name: "cloud_admin"
     project_domain_name: "ccadmin"
     project_user_domain_name: "Default"
+#   auth_url: DEFINED_IN_SECRETS_REPO
 #   password: DEFINED_IN_SECRETS_REPO
 
 nanny:


### PR DESCRIPTION
Our dnsglobal setup uses a different auth_url scheme, so adding it to the values of each region and taking it from there. Also adding errors when parameters are missing sounds like a good idea.