### PR TITLE
[designate-nanny] adding seed for global user

### DIFF
--- a/openstack/designate-nanny/templates/seed.yaml
+++ b/openstack/designate-nanny/templates/seed.yaml
@@ -5,9 +5,14 @@ metadata:
   name: designate-nanny-seed
 spec:
   requires:
-  - monsoon3/domain-default-seed
-  - monsoon3/domain-ccadmin-seed
-  - monsoon3/designate-seed
+  - {{ .Release.Namespace }}/domain-default-seed
+  - {{ .Release.Namespace }}/domain-ccadmin-seed
+{{- if .Values.global_setup }}
+  - {{ .Release.Namespace }}/designate-global-seed
+  - {{ .Release.Namespace }}/domain-global-seed
+{{- else}}
+  - {{ .Release.Namespace }}/designate-seed
+{{- end }}
   - swift/swift-seed
 
   domains:

--- a/openstack/designate-nanny/values.yaml
+++ b/openstack/designate-nanny/values.yaml
@@ -28,6 +28,8 @@ credentials:
 #   auth_url: DEFINED_IN_SECRETS_REPO
 #   password: DEFINED_IN_SECRETS_REPO
 
+global_setup: false
+
 nanny:
   enabled: true
 


### PR DESCRIPTION
The designate_nanny user is not created in the global region yet, this change should fix that.