### PR TITLE
[designate-nanny] using makro for keystone url at proper location

### DIFF
--- a/openstack/designate-nanny/ci/test-values.yaml
+++ b/openstack/designate-nanny/ci/test-values.yaml
@@ -12,7 +12,6 @@ designate_nanny:
       project_name: "test_project_name"
       project_domain_name: "test_project_domain_name"
       project_user_domain_name: "test_user_domain_name"
-      auth_url: https://example.org/some/auth-url
   config:
     nanny-config: yes
     opaque_yaml_values: here

--- a/openstack/designate-nanny/templates/deployment.yaml
+++ b/openstack/designate-nanny/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
          - name: NANNY_CONFIG
            value: "/srv/nanny.yaml"
          - name: OS_AUTH_URL
-           value: {{ required "missing .Values.designate_nanny.credentials.designate_api.auth_url" .Values.designate_nanny.credentials.designate_api.auth_url}}
+           value: "{{ .Values.global.keystone_api_endpoint_protocol_public | default "https"}}://{{include "keystone_api_endpoint_host_public" .}}/v3"
          - name: PYCCLOUD_USE_DUMMY_SECRETS
            value: "yes"          
          - name: OS_REGION_NAME

--- a/openstack/designate-nanny/values.yaml
+++ b/openstack/designate-nanny/values.yaml
@@ -24,16 +24,14 @@ global_setup: false
 nanny_enabled: false
 
 designate_nanny:
-  credentials:
-    designate_api:
-      auth_url: "{{ .Values.global.keystone_api_endpoint_protocol_public | default "https"}}://{{include "keystone_api_endpoint_host_public" .}}/v3"
-
 # defined in secrets:
+#  credentials:
+#    designate_api:
 #     user:
+#     password:
 #     project_name:
 #     project_domain_name:
 #     project_user_domain_name:
-#     password:
 
   config:
     global:


### PR DESCRIPTION
cannot use the makro in values.yaml, reverting for now and setting explicitly in secrets.