### PR TITLE
[openstack/utils] Set SSL_CERT_FILE specifically

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.14.1
+version: 0.14.2

--- a/openstack/utils/templates/_trust_bundle.tpl
+++ b/openstack/utils/templates/_trust_bundle.tpl
@@ -1,3 +1,8 @@
+{{- define "utils.trust_bundle.env" }}
+- name: SSL_CERT_FILE
+  value: /etc/ssl/certs/ca-certificates.crt
+{{- end }}
+
 {{- define "utils.trust_bundle.volume_mount" }}
   {{- if .Values.utils.trust_bundle.enabled }}
 - mountPath: /etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
The defaults seem to differ between implementations, so we rather want to set it explicitly to make sure it is picked up as expected.