### PR TITLE
[keystone] invalid yaml for DEPENDENCY_JOBS env var fixed

### DIFF
--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: keystone
 sources:
   - https://github.com/sapcc/keystone
-version: 0.5.3
+version: 0.5.4
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/keystone/templates/deployment-api.yaml
+++ b/openstack/keystone/templates/deployment-api.yaml
@@ -63,7 +63,7 @@ spec:
           value: {{ .Release.Namespace }}
 {{- if .Release.IsInstall }}
         - name: DEPENDENCY_JOBS
-          value: "{{ tuple . "job-migration" | include "job_name" }}","{{ tuple . "job-bootstrap" | include "job_name" }}"
+          value: "{{ tuple . "job-migration" | include "job_name" }},{{ tuple . "job-bootstrap" | include "job_name" }}"
 {{- else }}
   {{- if or .Values.run_db_migration }}
         - name: DEPENDENCY_JOBS

--- a/openstack/keystone/templates/deployment-cron.yaml
+++ b/openstack/keystone/templates/deployment-cron.yaml
@@ -50,7 +50,7 @@ spec:
           value: {{ .Release.Namespace }}
 {{- if .Release.IsInstall }}
         - name: DEPENDENCY_JOBS
-          value: "{{ tuple . "job-migration" | include "job_name" }}","{{ tuple . "job-bootstrap" | include "job_name" }}"
+          value: "{{ tuple . "job-migration" | include "job_name" }},{{ tuple . "job-bootstrap" | include "job_name" }}"
 {{- else }}
   {{- if or .Values.run_db_migration }}
         - name: DEPENDENCY_JOBS

--- a/openstack/keystone/templates/job-bootstrap.yaml
+++ b/openstack/keystone/templates/job-bootstrap.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-job-bootstrap
+  name: "{{ tuple . "job-bootstrap" | include "job_name" }}"
   labels:
     app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       labels:
-        name: {{ .Release.Name }}-job-bootstrap
+        name: "{{ tuple . "job-bootstrap" | include "job_name" }}"
         system: openstack
         component: keystone
         type: job
@@ -52,7 +52,7 @@ spec:
               value: "{{ .Release.Name }}-mariadb"
 {{- end }}
             - name: DEPENDENCY_JOBS
-              value: {{ .Release.Name }}-job-migration
+              value: "{{ tuple . "job-migration" | include "job_name" }}"
             {{- if .Values.sentry.enabled }}
             - name: SENTRY_DSN
             {{- if .Values.sentry.dsn }}


### PR DESCRIPTION
- chart version bumped
## old:
```yaml

- name: DEPENDENCY_JOBS
   value: "keystone-job-migration-e3b0-zed-20231213110943","keystone-job-bootstrap-e3b0-zed-20231213110943"
```
## new:
```yaml

- name: DEPENDENCY_JOBS
   value: "keystone-job-migration-e3b0-zed-20231213110943,keystone-job-bootstrap-e3b0-zed-20231213110943"
```