### PR TITLE
nova/flavors: Add g_c48_m192

### DIFF
--- a/openstack/sap-seeds/templates/flavor-seed.yaml
+++ b/openstack/sap-seeds/templates/flavor-seed.yaml
@@ -344,6 +344,14 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  - name: "g_c48_m192"
+    id: "166"
+    vcpus: 48
+    ram: 196592
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m5.xlarge2hdd"
     id: "210"
     vcpus: 4


### PR DESCRIPTION
As new-style replacement for ~m1.10xlarge.
