### PR TITLE
[Neutron] Adapt rate limit

### DIFF
--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -677,7 +677,7 @@ rate_limit:
           limit: 52r/m
       ports.json:
         - action: read
-          limit: 174r/m
+          limit: 215r/m
       ports/port:
         - action: read
           limit: 108r/m
@@ -713,7 +713,7 @@ rate_limit:
           limit: 52r/m
       security-group-rules/security-group-rule:
         - action: read
-          limit: 552r/m
+          limit: 650r/m
         - action: write
           limit: 83r/m
       security-groups:


### PR DESCRIPTION
Increase the limit for security-group-rules list and port.json list by the value of the metric openstack_requests_ratelimit_total. 