### PR TITLE
common/thanos: sort query store apis

### DIFF
--- a/common/thanos/Chart.yaml
+++ b/common/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: Deploy Thanos via operator
 type: application
-version: 0.6.9
+version: 0.6.10
 appVersion: v0.31.0
 maintainers:
   - name: Tommy Sauer (viennaa)

--- a/common/thanos/templates/_thanos_helpers.tpl
+++ b/common/thanos/templates/_thanos_helpers.tpl
@@ -138,9 +138,8 @@ cluster.local
 {{- $clusterList = append $clusterList $storeItem -}}
 {{- end }}
 {{- end }}
-{{- $sortedClusterList := $clusterList | sortAlpha -}}
-{{- range $queryStoreAPI := $sortedClusterList }}
-  - {{ $queryStoreAPI }}
+{{- range $clusterList | sortAlpha -}}
+  - {{ . }}
 {{- end }}
 {{/* Global Thanos Query Store API endpoints */}}
 {{- else if and $root.Values.useQueryRegions $root.Values.queryStoreAPIs -}}

--- a/common/thanos/templates/_thanos_helpers.tpl
+++ b/common/thanos/templates/_thanos_helpers.tpl
@@ -156,7 +156,7 @@ cluster.local
 {{- $globalList = append $globalList $storeItem -}}
 {{- end -}}
 {{- range $globalList | sortAlpha -}}
-  - {{ . }}
+  - {{ . }}:443
 {{- end }}
 {{- end }}
 {{/* Regional Thanos Query Store API endpoints */}}

--- a/common/thanos/templates/_thanos_helpers.tpl
+++ b/common/thanos/templates/_thanos_helpers.tpl
@@ -155,9 +155,9 @@ cluster.local
 {{- $storeItem := printf "%s.%s" $store $root.Values.global.tld -}}
 {{- $globalList = append $globalList $storeItem -}}
 {{- end -}}
-{{- $sortedGlobalList := $globalList | sortAlpha -}}
-{{- range $queryStoreAPI := $sortedGlobalList }}
-  - {{ $queryStoreAPI }}:443
+{{- range $globalList | sortAlpha -}}
+  - {{ . }}
+{{- end }}
 {{- end }}
 {{/* Regional Thanos Query Store API endpoints */}}
 {{- else if and (not $root.Values.useQueryRegions) $root.Values.queryStoreAPIs -}}

--- a/common/thanos/templates/_thanos_helpers.tpl
+++ b/common/thanos/templates/_thanos_helpers.tpl
@@ -138,7 +138,7 @@ cluster.local
 {{- $clusterList = append $clusterList $storeItem -}}
 {{- end }}
 {{- end }}
-{{- range $clusterList | sortAlpha -}}
+{{- range $clusterList | sortAlpha }}
   - {{ . }}
 {{- end }}
 {{/* Global Thanos Query Store API endpoints */}}
@@ -155,9 +155,8 @@ cluster.local
 {{- $storeItem := printf "%s.%s" $store $root.Values.global.tld -}}
 {{- $globalList = append $globalList $storeItem -}}
 {{- end -}}
-{{- range $globalList | sortAlpha -}}
+{{- range $globalList | sortAlpha }}
   - {{ . }}:443
-{{- end }}
 {{- end }}
 {{/* Regional Thanos Query Store API endpoints */}}
 {{- else if and (not $root.Values.useQueryRegions) $root.Values.queryStoreAPIs -}}
@@ -167,7 +166,7 @@ cluster.local
 {{- $storeItem := printf "thanos-%s-grpc.%s.%s" $cluster $root.Values.global.region $root.Values.global.tld -}}
 {{- $regionalList = append $regionalList $storeItem -}}
 {{- end }}
-{{- range $regionalList | sortAlpha -}}
+{{- range $regionalList | sortAlpha }}
   - {{ . }}:443
 {{- end }}
 {{- end }}

--- a/common/thanos/templates/_thanos_helpers.tpl
+++ b/common/thanos/templates/_thanos_helpers.tpl
@@ -167,9 +167,8 @@ cluster.local
 {{- $storeItem := printf "thanos-%s-grpc.%s.%s" $cluster $root.Values.global.region $root.Values.global.tld -}}
 {{- $regionalList = append $regionalList $storeItem -}}
 {{- end }}
-{{- $sortedRegionalList := $regionalList | sortAlpha -}}
-{{- range $queryStoreAPI := $sortedRegionalList }}
-  - {{ $queryStoreAPI }}:443
+{{- range $regionalList | sortAlpha -}}
+  - {{ . }}:443
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Query store api's are added to the service discovery file in different orders. This quickly becomes disorganized if many targets are involved (global). This PR sorts the targets alphabetically.