### PR TITLE
common/prometheus: reduce memory request

### DIFF
--- a/common/prometheus-server/Chart.yaml
+++ b/common/prometheus-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus via operator.
 name: prometheus-server
-version: 7.4.4
+version: 7.4.5
 appVersion: v2.46.0
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
 maintainers:

--- a/common/prometheus-server/values.yaml
+++ b/common/prometheus-server/values.yaml
@@ -279,7 +279,7 @@ externalLabels: {}
 resources:
   requests:
     cpu: "1"
-    memory: 8Gi
+    memory: 4Gi
 
 # VerticalPodAutoscaler UpdateMode defaults to Off.
 # vpaUpdateMode: "Initial"


### PR DESCRIPTION
Since the new version with Go tag `stringlabels` is deployed everywhere, we can reduce the default memory request to 4Gi.