### PR TITLE
[Neutron] Increase Rate Limits

### DIFF
--- a/openstack/neutron/diff.txt
+++ b/openstack/neutron/diff.txt
@@ -1,0 +1,3814 @@
+[0;33mmonsoon3, neutron-aci-agent, Deployment (apps) has changed:[0m
+  # Source: neutron/templates/deployment-aci-agent.yaml
+  kind: Deployment
+  apiVersion: apps/v1
+
+  metadata:
+    name: neutron-aci-agent
+    labels:
+      system: openstack
+      type: backend
+      component: neutron
+    annotations:
+      vpa-butler.cloud.sap/main-container: neutron-aci-agent
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 5
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 0
+        maxSurge: 3
+    selector:
+      matchLabels:
+        name: neutron-aci-agent
+    template:
+      metadata:
+        labels:
+          name: neutron-aci-agent
+          release_name: neutron
+          application: neutron
+          component: aci-agent
+        annotations:
+          pod.beta.kubernetes.io/hostname:  aci-agent-pet
+[0;31m-         configmap-etc-hash: d804d23560cc00cfee20fce94ce5b491b6c57bd26ee4fd7f3cd5adbfbc96e871[0m
+[0;32m+         configmap-etc-hash: 411229865bca0b45fb623df0a5ef0a0dd4c4a14064c3afa6bae3d1009b83818f[0m
+          configmap-etc-region-hash: 10d539fe03ecd1358c101afca3a918a31da73335116cff34a8c6e3c297506403
+          configmap-etc-vendor-hash: 589f42ada9adf51757198ffe22bb3f86e8fb6224a8d5112fd83129e53a73b18a        
+          linkerd.io/inject: enabled
+      spec:
+        hostname:  aci-agent-pet
+        containers:
+          - name: neutron-aci-agent
+            image: keppel.eu-de-1.cloud.sap/ccloud/loci-neutron:yoga-20231220120402
+            imagePullPolicy: IfNotPresent
+            command:
+              - /container.init/neutron-aci-agent-start
+            livenessProbe:
+              exec:
+                command: ["neutron-agent-liveness", "--agent-type", "ACI Agent", "--config-file", "/etc/neutron/neutron.conf"]
+              initialDelaySeconds: 30
+              periodSeconds: 30
+              timeoutSeconds: 10
+            resources:
+              limits:
+                cpu: 500m
+                memory: 1Gi
+              requests:
+                cpu: 250m
+                memory: 512Mi
+            env:
+              - name: DEBUG_CONTAINER
+                value: "false"
+              - name: SENTRY_DSN
+                valueFrom:
+                  secretKeyRef:
+                    name: sentry
+                    key: neutron.DSN.python
+            volumeMounts:
+              - mountPath: /neutron-etc
+                name: neutron-etc
+              - mountPath: /neutron-etc-vendor
+                name: neutron-etc-vendor
+              - mountPath: /neutron-etc-region
+                name: neutron-etc-region
+              - mountPath: /container.init
+                name: container-init
+        volumes:
+          - name: neutron-etc
+            configMap:
+              name: neutron-etc
+          - name: neutron-etc-region
+            configMap:
+              name: neutron-etc-region
+          - name: neutron-etc-vendor
+            configMap:
+              name: neutron-etc-vendor
+          - name: container-init
+            configMap:
+              name: neutron-bin-vendor
+              defaultMode: 0755
+[0;33mmonsoon3, neutron-cc-fabric-eos-agent, Deployment (apps) has changed:[0m
+  # Source: neutron/templates/deployment-cc-fabric-agent.yaml
+  kind: Deployment
+  apiVersion: apps/v1
+
+  metadata:
+    name: neutron-cc-fabric-eos-agent
+    labels:
+      system: openstack
+      type: backend
+      component: neutron
+    annotations:
+      vpa-butler.cloud.sap/main-container: neutron-cc-fabric-eos-agent
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 5
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 0
+        maxSurge: 3
+    selector:
+      matchLabels:
+        name: neutron-cc-fabric-eos-agent
+    template:
+      metadata:
+        labels:
+          name: neutron-cc-fabric-eos-agent
+          release_name: neutron
+          application: neutron
+          component: cc-fabric-eos-agent
+        annotations:
+          pod.beta.kubernetes.io/hostname:  cc-fabric-eos-agent
+[0;31m-         configmap-etc-hash: d804d23560cc00cfee20fce94ce5b491b6c57bd26ee4fd7f3cd5adbfbc96e871[0m
+[0;32m+         configmap-etc-hash: 411229865bca0b45fb623df0a5ef0a0dd4c4a14064c3afa6bae3d1009b83818f[0m
+          configmap-etc-cc-fabric: fc8f785bce813634a987f4df3c47e510d42170329e0b81f14779ab8b59dfcd9b
+          prometheus.io/scrape: "true"
+          prometheus.io/targets: openstack        
+          linkerd.io/inject: enabled
+      spec:
+        hostname: cc-fabric-eos-agent
+        containers:
+          - name: neutron-cc-fabric-eos-agent
+            image: keppel.eu-de-1.cloud.sap/ccloud/loci-neutron:yoga-20231220120402
+            imagePullPolicy: IfNotPresent
+            command:
+              - cc-eos-switch-agent
+            args:
+              - --config-file
+              - /etc/neutron/neutron.conf
+              - --config-file
+              - /etc/neutron/plugins/ml2/ml2-conf.ini
+              - --config-file
+              - /etc/neutron/plugins/ml2/ml2_conf_cc-fabric.ini
+            livenessProbe:
+              exec:
+                command: ["neutron-agent-liveness", "--agent-type", "CC fabric agent", "--config-file", "/etc/neutron/neutron.conf"]
+              initialDelaySeconds: 30
+              periodSeconds: 30
+              timeoutSeconds: 10
+            resources:
+              limits:
+                cpu: 1000m
+                memory: 1Gi
+              requests:
+                cpu: 250m
+                memory: 512Mi
+            env:
+              - name: SENTRY_DSN
+                valueFrom:
+                  secretKeyRef:
+                    name: sentry
+                    key: neutron.DSN.python
+            ports:
+              - containerPort: 9090
+                name: metrics
+            volumeMounts:
+              - mountPath: /etc/neutron/neutron.conf
+                name: neutron-etc
+                subPath: neutron.conf
+                readOnly: true
+              - mountPath: /etc/neutron/plugins/ml2/
+                name: empty-neutron-ml2
+              - mountPath: /etc/neutron/plugins/ml2/ml2_conf_cc-fabric.ini
+                name: neutron-etc-cc-fabric
+                subPath: ml2_conf_cc-fabric.ini
+                readOnly: true
+              - mountPath: /etc/neutron/plugins/ml2/cc-fabric-driver-config.yaml
+                name: neutron-etc-cc-fabric
+                subPath: cc-fabric-driver-config.yaml
+                readOnly: true
+              - mountPath: /etc/neutron/plugins/ml2/ml2-conf.ini
+                name: neutron-etc
+                subPath: ml2-conf.ini
+                readOnly: true
+              - mountPath: /etc/neutron/rootwrap.conf
+                name: neutron-etc
+                subPath: rootwrap.conf
+                readOnly: true
+              - mountPath: /etc/neutron/logging.conf
+                name: neutron-etc
+                subPath: logging.conf
+                readOnly: true
+        volumes:
+          - name: empty-neutron-ml2
+            emptyDir: {}
+          - name: neutron-etc
+            configMap:
+              name: neutron-etc
+          - name: neutron-etc-cc-fabric
+            configMap:
+              name: neutron-etc-cc-fabric
+[0;33mmonsoon3, neutron-cc-fabric-nxos-agent, Deployment (apps) has changed:[0m
+  # Source: neutron/templates/deployment-cc-fabric-agent.yaml
+  kind: Deployment
+  apiVersion: apps/v1
+
+  metadata:
+    name: neutron-cc-fabric-nxos-agent
+    labels:
+      system: openstack
+      type: backend
+      component: neutron
+    annotations:
+      vpa-butler.cloud.sap/main-container: neutron-cc-fabric-nxos-agent
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 5
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 0
+        maxSurge: 3
+    selector:
+      matchLabels:
+        name: neutron-cc-fabric-nxos-agent
+    template:
+      metadata:
+        labels:
+          name: neutron-cc-fabric-nxos-agent
+          release_name: neutron
+          application: neutron
+          component: cc-fabric-nxos-agent
+        annotations:
+          pod.beta.kubernetes.io/hostname:  cc-fabric-nxos-agent
+[0;31m-         configmap-etc-hash: d804d23560cc00cfee20fce94ce5b491b6c57bd26ee4fd7f3cd5adbfbc96e871[0m
+[0;32m+         configmap-etc-hash: 411229865bca0b45fb623df0a5ef0a0dd4c4a14064c3afa6bae3d1009b83818f[0m
+          configmap-etc-cc-fabric: fc8f785bce813634a987f4df3c47e510d42170329e0b81f14779ab8b59dfcd9b
+          prometheus.io/scrape: "true"
+          prometheus.io/targets: openstack        
+          linkerd.io/inject: enabled
+      spec:
+        hostname: cc-fabric-nxos-agent
+        containers:
+          - name: neutron-cc-fabric-nxos-agent
+            image: keppel.eu-de-1.cloud.sap/ccloud/loci-neutron:yoga-20231220120402
+            imagePullPolicy: IfNotPresent
+            command:
+              - cc-nxos-switch-agent
+            args:
+              - --config-file
+              - /etc/neutron/neutron.conf
+              - --config-file
+              - /etc/neutron/plugins/ml2/ml2-conf.ini
+              - --config-file
+              - /etc/neutron/plugins/ml2/ml2_conf_cc-fabric.ini
+            livenessProbe:
+              exec:
+                command: ["neutron-agent-liveness", "--agent-type", "CC fabric agent", "--config-file", "/etc/neutron/neutron.conf"]
+              initialDelaySeconds: 30
+              periodSeconds: 30
+              timeoutSeconds: 10
+            resources:
+              limits:
+                cpu: 1000m
+                memory: 1Gi
+              requests:
+                cpu: 250m
+                memory: 512Mi
+            env:
+              - name: SENTRY_DSN
+                valueFrom:
+                  secretKeyRef:
+                    name: sentry
+                    key: neutron.DSN.python
+            ports:
+              - containerPort: 9090
+                name: metrics
+            volumeMounts:
+              - mountPath: /etc/neutron/neutron.conf
+                name: neutron-etc
+                subPath: neutron.conf
+                readOnly: true
+              - mountPath: /etc/neutron/plugins/ml2/
+                name: empty-neutron-ml2
+              - mountPath: /etc/neutron/plugins/ml2/ml2_conf_cc-fabric.ini
+                name: neutron-etc-cc-fabric
+                subPath: ml2_conf_cc-fabric.ini
+                readOnly: true
+              - mountPath: /etc/neutron/plugins/ml2/cc-fabric-driver-config.yaml
+                name: neutron-etc-cc-fabric
+                subPath: cc-fabric-driver-config.yaml
+                readOnly: true
+              - mountPath: /etc/neutron/plugins/ml2/ml2-conf.ini
+                name: neutron-etc
+                subPath: ml2-conf.ini
+                readOnly: true
+              - mountPath: /etc/neutron/rootwrap.conf
+                name: neutron-etc
+                subPath: rootwrap.conf
+                readOnly: true
+              - mountPath: /etc/neutron/logging.conf
+                name: neutron-etc
+                subPath: logging.conf
+                readOnly: true
+        volumes:
+          - name: empty-neutron-ml2
+            emptyDir: {}
+          - name: neutron-etc
+            configMap:
+              name: neutron-etc
+          - name: neutron-etc-cc-fabric
+            configMap:
+              name: neutron-etc-cc-fabric
+[0;33mmonsoon3, neutron-etc, ConfigMap (v1) has changed:[0m
+  # Source: neutron/templates/configmap-etc.yaml
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: neutron-etc
+    labels:
+      system: openstack
+      type: configuration
+      component: neutron
+
+  data:
+    api-paste.ini: |
+      [composite:neutron]
+      use = egg:Paste#urlmap
+      /: neutronversions
+      /v2.0: neutronapi_v2_0
+      
+      [composite:neutronapi_v2_0]
+      use = call:neutron.auth:pipeline_factory
+      noauth = cors healthcheck http_proxy_to_wsgi request_id watcher catch_errors raven uwsgi manhole extensions neutronapiapp_v2_0
+      keystone = cors healthcheck http_proxy_to_wsgi request_id catch_errors raven authtoken keystonecontext watcher rate_limit audit uwsgi manhole extensions neutronapiapp_v2_0
+      
+      [filter:healthcheck]
+      paste.filter_factory = oslo_middleware:Healthcheck.factory
+      backends = disable_by_file
+      disable_by_file_path = /etc/neutron/healthcheck_disable
+      
+      [filter:request_id]
+      paste.filter_factory = oslo_middleware:RequestId.factory
+      
+      [filter:catch_errors]
+      paste.filter_factory = oslo_middleware:CatchErrors.factory
+      
+      [filter:cors]
+      paste.filter_factory = oslo_middleware.cors:filter_factory
+      oslo_config_project = neutron
+      
+      [filter:http_proxy_to_wsgi]
+      paste.filter_factory = oslo_middleware:HTTPProxyToWSGI.factory
+      
+      [filter:keystonecontext]
+      paste.filter_factory = neutron.auth:NeutronKeystoneContext.factory
+      
+      [filter:authtoken]
+      paste.filter_factory = keystonemiddleware.auth_token:filter_factory
+      
+      [filter:extensions]
+      paste.filter_factory = neutron.api.extensions:plugin_aware_extension_middleware_factory
+      
+      [app:neutronversionsapp]
+      paste.app_factory = neutron.pecan_wsgi.app:versions_factory
+      
+      [app:neutronapiapp_v2_0]
+      paste.app_factory = neutron.api.v2.router:APIRouter.factory
+      
+      [pipeline:neutronversions]
+      pipeline = http_proxy_to_wsgi healthcheck neutronversionsapp
+      
+      [filter:osprofiler]
+      paste.filter_factory = osprofiler.web:WsgiMiddleware.factory
+      
+      [filter:debug]
+      paste.filter_factory = oslo_middleware:Debug.factory
+      
+      [filter:raven]
+      use = egg:raven#raven
+      level = ERROR
+      
+      [filter:audit]
+      paste.filter_factory = auditmiddleware:filter_factory
+      audit_map_file = /etc/neutron/neutron_audit_map.yaml
+      ignore_req_list = GET
+      record_payloads = True
+      metrics_enabled = True
+      
+      [filter:watcher]
+      use = egg:watcher-middleware#watcher
+      service_type = network
+      config_file = /etc/neutron/watcher.yaml
+      
+      [filter:rate_limit]
+      use = egg:rate-limit-middleware#rate-limit
+      config_file = /etc/neutron/ratelimit.yaml
+      service_type = network
+      rate_limit_by = target_project_id
+      max_sleep_time_seconds: 0
+      clock_accuracy = 1ns
+      log_sleep_time_seconds: 10
+      backend_host = neutron-api-ratelimit-redis
+      backend_port = 6379
+      backend_timeout_seconds = 1
+      
+      
+      [filter:manhole]
+      paste.filter_factory = manhole_middleware:Manhole.factory
+      
+      [filter:uwsgi]
+      paste.filter_factory = uwsgi_middleware:Uwsgi.factory
+      
+    dhcp-agent.ini: |
+      # dhcp_agent.ini
+      [DEFAULT]
+      
+      debug = false
+      
+      dnsmasq_config_file = /etc/neutron/dnsmasq.conf
+      force_metadata=True
+      enable_isolated_metadata=True
+      metadata_proxy_socket = /run/metadata_proxy/metadata_proxy
+      dnsmasq_dns_servers = 147.204.9.200, 147.204.9.201
+      dhcp_domain = openstack.qa-de-1.cloud.sap
+      dns_domain = openstack.qa-de-1.cloud.sap
+      num_sync_threads = 10
+      
+      rpc_response_timeout = 60
+      rpc_workers = 10
+      rpc_conn_pool_size = 100
+      
+    linux-bridge.ini: |
+      [DEFAULT]
+      interface_driver = linuxbridge
+      
+      # Disable Security Group for linux-bridge to increase buildup performance
+      [SECURITYGROUP]
+      firewall_driver = noop
+      
+    dnsmasq.conf: |
+      
+      log-facility=/var/log/dnsmasq.log
+      log-queries
+      no-negcache
+      dhcp-option=option:ntp-server,147.204.9.202,147.204.9.203,147.204.9.204
+      local=/openstack.qa-de-1.cloud.sap/
+      
+    l3-agent.ini: |
+      # l3_agent.ini
+      [DEFAULT]
+      debug = false
+      
+      l3_agent_manager = neutron.agent.l3_agent.L3NATAgentWithStateReport
+      agent_mode = legacy
+      
+    asr1k-global.ini: |
+      [asr1k]
+      ignore_invalid_az_hint_for_router = False
+      
+      [asr1k-address-scopes]
+      monsoon3-external = 65126:101
+      monsoon3-public = 65126:101
+      bs-public = 65126:102
+      hcp03-public = 65126:102
+      wbs-public = 65126:102
+      cp-public = 65126:102
+      s4-public = 65126:103
+      s4hana-public = 65126:103
+      hcm-public = 65126:104
+      neo-public = 65126:105
+      neo-public-ha = 65126:105
+      ccadmin-public = 65126:106
+      fsn-public = 65126:107
+      hda-public = 65126:108
+      cf-public = 65126:109
+      cis-public = 65126:110
+      kyma-public = 65126:111
+      hec-public = 65126:112
+      
+      
+    networking-bgpvpn.conf: |
+      [service_providers]
+      service_provider=BGPVPN:ASR1K:asr1k_neutron_l3.neutron.services.service_drivers.asr1k.ASR1KBGPVPNDriver:default
+      
+      [bgpvpn]
+      region_asn = 65130.4
+      target_id_range = 2000-4000
+      import_target_auto_allocation = true
+      export_target_auto_allocation = true
+      route_target_auto_allocation = false
+      
+    networking-interconnection.conf: |
+      [interconnection]
+      region_name = qa-de-1
+      username = interconnection
+      password = Ln9&H1YU%NTQsa11uOn3
+      
+    metadata-agent.ini: |
+      # metadata_agent.ini
+      [DEFAULT]
+      debug = false
+      
+      #endpoint_type = internalURL
+      
+      nova_metadata_ip = nova-api-metadata.monsoon3.svc.kubernetes.qa-de-1.cloud.sap
+      nova_metadata_host = nova-api-metadata.monsoon3.svc.kubernetes.qa-de-1.cloud.sap
+      nova_metadata_protocol = http
+      nova_metadata_port = 8775
+      
+      metadata_proxy_shared_secret = 4IsnfNsBowuP3eLYIeph
+      metadata_proxy_socket = /run/metadata_proxy/metadata_proxy
+      
+      rpc_response_timeout = 60
+      rpc_workers = 10
+      rpc_conn_pool_size = 100
+      metadata_workers = 1
+      
+      [cache]
+      backend = dogpile.cache.memory
+      expiration_time = 5
+      
+    ml2-conf.ini: |
+      [ml2]
+      
+      # Changing type_drivers after bootstrap can lead to database inconsistencies
+      type_drivers = vlan,vxlan
+      tenant_network_types = vxlan,vlan
+      
+      
+      #mechanism_drivers = aci,openvswitch,arista,asr,manila,f5ml2
+      
+      mechanism_drivers = cc-fabric,aci,nsxv3,linuxbridge,asr1k_ml2,manila,simple_f5,arista,openvswitch
+      # Designate configuration
+      extension_drivers = dns
+      
+      path_mtu = 9000
+      
+      [ml2_type_vlan]
+      network_vlan_ranges = cp090:2000:3750,ap001:2000:3750,ap002:2000:3750,bb91:2000:3750,bb92:2000:3750,bb93:2000:3750,bb94:2000:3750,bb95:2000:3750,bb96:2000:3750,bb97:2000:3750,bb90:2000:3750,service1:2000:3750,pod2_leaf_2203_2204:2000:3750,md004:2000:3750,md005:2000:3750,st051:2000:3750,np090-np091:3001:3750,np090:2000:3000,np091:2000:3000,transit1101:2000:3750,transit2102:2000:3750,ap028:2000:3750,bb271:2000:3750,bb272:2000:3750,bb273:2000:3750,bb274:2000:3750,bb275:2000:3750,bgw1103:2000:3750,bgw2103:2000:3750,bgw2203:2000:3750,bgw4103:2000:3750,np024:3001:3750,np024:3001:3750,st035:2000:3750,st035:2000:3750,st036:2000:3750,transit1101:2000:3750,transit2102:2000:3750
+      
+      [ml2_type_vxlan]
+      vni_ranges = 10000:20000
+      
+      [ml2_f5]
+      supported_device_owners = network:f5listener,network:f5selfip,network:f5lbaasv2,network:f5snat,network:archer
+      
+      [securitygroup]
+      firewall_driver = iptables_hybrid
+      enable_security_group=True
+      enable_ipset=True
+      
+      [agent]
+      polling_interval=5
+      prevent_arp_spoofing = False
+      
+      [vxlan]
+      enable_vxlan = false
+      
+      [profiler]
+[0;31m-     enabled = True[0m
+[0;31m-     trace_sqlalchemy = True[0m
+[0;32m+     enabled = False[0m
+[0;32m+     trace_sqlalchemy = False[0m
+      trace_requests = False
+      
+    neutron.conf: |
+      # neutron.conf
+      [DEFAULT]
+      debug = false
+      verbose = True
+      
+      log_config_append = /etc/neutron/logging.conf
+      logging_context_format_string = %(asctime)s %(process)d %(levelname)s %(name)s [%(request_id)s g%(global_request_id)s %(user_identity)s] %(resource)s%(instance)s%(message)s
+      logging_default_format_string = %(asctime)s %(process)d %(levelname)s %(name)s [-] %(resource)s%(instance)s%(message)s
+      logging_user_identity_format = %(user)s %(tenant)s %(domain)s %(user_domain)s %(project_domain)s
+      logging_exception_prefix = %(asctime)s %(process)d ERROR %(name)s %(resource)s%(instance)s
+      
+      api_paste_config = /etc/neutron/api-paste.ini
+      
+      transport_url = rabbit://openstack:hoor3aefocoomab0Taig@neutron-rabbitmq:5672/
+      
+      pagination_max_limit = 500
+      max_allowed_address_pair = 100
+      max_routes = 256
+      
+      allow_overlapping_ips = true
+      core_plugin = ml2
+      
+      service_plugins = asr1k_l3_routing,bgpvpn,trunk,log,networking-interconnection
+      
+      default_router_type = ASR1k_m3_router
+      router_scheduler_driver = asr1k_neutron_l3.plugins.l3.schedulers.simple_asr1k_scheduler.SimpleASR1KScheduler
+      router_auto_schedule = false
+      allow_automatic_l3agent_failover = false
+      
+      network_scheduler_driver = neutron.scheduler.dhcp_agent_scheduler.AZAwareWeightScheduler
+      allow_automatic_dhcp_failover = false
+      dhcp_agents_per_network = 2
+      dhcp_lease_duration = 86400
+      
+      filter_validation = false
+      
+      # Designate configuration
+      dns_domain = openstack.qa-de-1.cloud.sap
+      external_dns_driver = designate
+      
+      global_physnet_mtu = 9000
+      advertise_mtu = True
+      
+      rpc_response_timeout = 60
+      rpc_workers = 10
+      rpc_state_report_workers = 5
+      
+      wsgi_default_pool_size = 100
+      
+      api_workers = 12
+      periodic_fuzzy_delay = 10
+      owner_check_cache_expiration_time = 86400
+      backdoor_socket=/var/lib/neutron/eventlet_backdoor-{pid}.socket
+      
+      
+      [nova]
+      auth_url = http://keystone.monsoon3.svc.kubernetes.qa-de-1.cloud.sap:5000/v3
+      # DEPRECATED: auth_plugin
+      auth_plugin = v3password
+      auth_type = v3password
+      region_name = qa-de-1
+      username = neutron
+      password = kiedaiYaik4quohf3Bae
+      user_domain_name = Default
+      project_name = service
+      project_domain_name = Default
+      insecure = True
+      endpoint_type = internal
+      
+      [designate]
+      url =  http://designate-api.monsoon3.svc.kubernetes.qa-de-1.cloud.sap:9001/v2
+      auth_url = http://keystone.monsoon3.svc.kubernetes.qa-de-1.cloud.sap:5000/v3
+      auth_plugin = v3password
+      auth_type = v3password
+      region_name = qa-de-1
+      user_domain_name = Default
+      project_name = master
+      project_domain_name = ccadmin
+      username = neutron
+      password = kiedaiYaik4quohf3Bae
+      insecure = True
+      allow_reverse_dns_lookup = true
+      ipv4_ptr_zone_prefix_size = 24
+      
+      [oslo_concurrency]
+      lock_path = /var/lib/neutron/tmp
+      
+      
+      [oslo_messaging_rabbit]
+      rabbit_ha_queues = true
+      rabbit_transient_queues_ttl = 60
+      heartbeat_in_pthread = False
+      rpc_conn_pool_size = 100
+      
+      [oslo_middleware]
+      enable_proxy_headers_parsing = true
+      
+      [agent]
+      
+      root_helper = sudo
+      root_helper_daemon = neutron-rootwrap-daemon /etc/neutron/rootwrap.conf
+      
+      
+      [database]
+      connection = mysql+pymysql://neutron:Ko85Mgoj2Vtj3luiHdb2@/neutron?unix_socket=/run/proxysql/mysql.sock&charset=utf8
+      max_pool_size = 50
+      max_overflow = -1
+      
+      [keystone_authtoken]
+      auth_plugin = v3password
+      auth_version = v3
+      auth_interface = internal
+      www_authenticate_uri = https://identity-3.qa-de-1.cloud.sap/v3
+      auth_url = http://keystone.monsoon3.svc.kubernetes.qa-de-1.cloud.sap:5000/v3
+      username = neutron
+      password = kiedaiYaik4quohf3Bae
+      user_domain_name = Default
+      project_name = service
+      project_domain_name = Default
+      region_name = qa-de-1
+      memcached_servers = neutron-memcached.monsoon3.svc.kubernetes.qa-de-1.cloud.sap:11211
+      service_token_roles_required = True
+      insecure = True
+      token_cache_time = 600
+      memcache_use_advanced_pool = True
+      include_service_catalog = true
+      service_type = network
+      
+      [oslo_messaging_notifications]
+      driver = noop
+      
+      # all default quotas are 0 to enforce usage of the Resource Management tool in Elektra
+      [quotas]
+      default_quota = 0
+      quota_floatingip = 0
+      quota_network = 0
+      quota_subnet = 0
+      quota_port = 0
+      quota_router = 0
+      quota_rbac_policy = 0
+      # need 1 secgroup quota for "default" secgroup
+      quota_security_group = 1
+      # need 4 secgrouprule quota for "default" secgroup
+      quota_security_group_rule = 4
+      
+      [privsep]
+      # The number of threads available for privsep to concurrently run processes.
+      # Defaults to the number of CPU cores in the system (integer value)
+      # Minimum value: 1
+      thread_pool_size = 3
+      
+      # this is for the cadf audit messaging
+      [audit_middleware_notifications]
+      # topics = notifications
+      driver = messagingv2
+      transport_url = rabbit://rabbitmq:8ihkWDW9wzM6o9o6fVs0bReE@hermes-rabbitmq-notifications.hermes:5672/
+      mem_queue_size = 1000
+      
+      [cache]
+      backend = oslo_cache.memcache_pool
+      memcache_servers = neutron-memcached.monsoon3.svc.kubernetes.qa-de-1.cloud.sap:11211
+      config_prefix = cache.neutron
+      enabled = true
+      
+    neutron-policy.json: |
+      {
+          "context_is_cloud_admin": "role:cloud_network_admin",
+          "context_is_admin": "rule:context_is_cloud_admin",
+          "owner": "tenant_id:%(tenant_id)s or project_id:%(project_id)s",
+          "member": "role:member and rule:owner",
+          "viewer": "role:network_viewer and rule:owner",
+          "admin": "role:network_admin and rule:owner",
+          "compute_admin_wsg": "role:compute_admin_wsg and rule:owner",
+          "context_is_network_admin": "rule:context_is_admin or rule:admin",
+          "context_is_editor": "rule:context_is_network_admin or rule:member or rule:compute_admin_wsg",
+          "context_is_viewer": "rule:context_is_editor or rule:viewer",
+          "network_view_all": "role:network_viewer or role:member or role:network_admin or rule:context_is_admin",
+      
+          "network_owner": "tenant_id:%(network:tenant_id)s",
+          "network_owner_or_owner": "rule:owner or rule:network_owner",
+          "network_member": "role:member and rule:network_owner_or_owner",
+          "network_viewer": "role:network_viewer and rule:network_owner_or_owner",
+          "network_admin": "role:network_admin and rule:network_owner_or_owner",
+          "context_is_network_network_admin": "rule:context_is_admin or rule:network_admin",
+          "context_is_network_editor": "rule:context_is_network_network_admin or rule:network_member",
+          "context_is_network_viewer":  "rule:context_is_network_editor or rule:network_viewer",
+      
+          "compute_admin": "role:compute_admin and rule:owner",
+          "context_is_compute_admin": "role:cloud_compute_admin or rule:compute_admin",
+          "context_is_securitygroup_admin": "(role:securitygroup_admin and rule:owner) or rule:context_is_compute_admin or rule:context_is_network_admin",
+          "context_is_securitygroup_viewer": "(role:securitygroup_viewer and rule:owner) or rule:context_is_viewer or rule:context_is_securitygroup_admin",
+      
+          "shared": "field:networks:shared=True",
+          "shared_firewalls": "field:firewalls:shared=True",
+          "shared_firewall_policies": "field:firewall_policies:shared=True",
+          "shared_subnetpools": "field:subnetpools:shared=True",
+          "shared_address_scopes": "field:address_scopes:shared=True",
+          "shared_security_groups": "field:security_groups:shared=True",
+          "shared_bgpvpns": "field:bgpvpns:shared=True",
+          "dhcp_enabled": "field:subnets:enable_dhcp=True",
+          "default": "rule:context_is_editor or rule:shared",
+          "default_viewer": "rule:context_is_viewer or rule:shared",
+          "default_network_viewer": "rule:context_is_network_viewer or rule:shared",
+      
+          "create_subnet": "rule:context_is_admin or (rule:network_admin and rule:network_owner and rule:dhcp_enabled)",
+          "create_subnet:segment_id": "rule:context_is_admin",
+          "get_subnet": "rule:default_viewer",
+          "get_subnet:segment_id": "rule:default_viewer",
+          "update_subnet": "rule:context_is_network_admin",
+          "delete_subnet": "rule:context_is_network_admin",
+      
+          "create_subnetpool": "rule:context_is_network_admin",
+          "create_subnetpool:shared": "rule:context_is_admin",
+          "create_subnetpool:is_default": "rule:context_is_admin",
+          "get_subnetpool": "rule:context_is_viewer or rule:shared_subnetpools",
+          "update_subnetpool": "rule:context_is_network_admin",
+          "update_subnetpool:is_default": "rule:context_is_admin",
+          "delete_subnetpool": "rule:context_is_network_admin",
+      
+          "create_address_scope": "rule:context_is_network_admin",
+          "create_address_scope:shared": "rule:context_is_admin",
+          "get_address_scope": "rule:context_is_editor or rule:shared_address_scopes",
+          "update_address_scope": "rule:context_is_network_admin",
+          "update_address_scope:shared": "rule:context_is_admin",
+          "delete_address_scope": "rule:context_is_network_admin",
+      
+          "create_network": "rule:context_is_network_admin",
+          "get_network": "rule:default_viewer",
+          "get_network:router:external": "rule:default_viewer",
+          "get_network:segments": "rule:default_viewer",
+          "get_network:provider:network_type": "rule:default_viewer",
+          "get_network:provider:physical_network": "rule:default_viewer",
+          "get_network:provider:segmentation_id": "rule:default_viewer",
+          "get_network:queue_id": "rule:context_is_admin",
+          "get_network_ip_availabilities": "rule:default_network_viewer",
+          "get_network_ip_availability": "rule:default_network_viewer",
+          "create_network:shared": "rule:context_is_admin",
+          "create_network:router:external": "rule:context_is_admin",
+          "create_network:is_default": "rule:context_is_admin",
+          "create_network:segments": "rule:context_is_admin",
+          "create_network:provider:network_type": "rule:context_is_admin",
+          "create_network:provider:physical_network": "rule:context_is_admin",
+          "create_network:provider:segmentation_id": "rule:context_is_admin",
+          "update_network": "rule:context_is_network_admin",
+          "update_network:segments": "rule:context_is_admin",
+          "update_network:shared": "rule:context_is_admin",
+          "update_network:provider:network_type": "rule:context_is_admin",
+          "update_network:provider:physical_network": "rule:context_is_admin",
+          "update_network:provider:segmentation_id": "rule:context_is_admin",
+          "update_network:router:external": "rule:context_is_admin",
+          "delete_network": "rule:context_is_network_admin",
+      
+          "create_segment": "rule:context_is_admin",
+          "get_segment": "rule:context_is_admin",
+          "update_segment": "rule:context_is_admin",
+          "delete_segment": "rule:context_is_admin",
+      
+          "network_device": "field:port:device_owner=~^network:",
+          "share_device": "field:port:device_owner=~^manila:",
+          "create_port": "rule:default",
+          "create_port:device_owner": "(not rule:network_device and not rule:share_device) or rule:context_is_admin",
+          "create_port:mac_address": "rule:context_is_network_editor",
+          "create_port:fixed_ips": "rule:default",
+          "create_port:fixed_ips:ip_address": "rule:default",
+          "create_port:fixed_ips:subnet_id": "rule:default",
+          "create_port:port_security_enabled": "rule:context_is_network_editor",
+          "create_port:binding:host_id": "rule:context_is_network_admin",
+          "create_port:binding:profile": "rule:context_is_network_admin",
+          "create_port:binding:vnic_type": "rule:context_is_network_admin",
+          "create_port:mac_learning_enabled": "rule:context_is_network_editor",
+          "create_port:allowed_address_pairs": "rule:context_is_network_editor",
+          "create_port:allowed_address_pairs:ip_address": "rule:context_is_network_editor",
+          "get_port": "rule:context_is_network_viewer",
+          "get_port:queue_id": "rule:context_is_admin",
+          "get_port:binding:vif_type": "rule:context_is_network_viewer",
+          "get_port:binding:vif_details": "rule:context_is_network_viewer",
+          "get_port:binding:host_id": "rule:context_is_network_viewer",
+          "get_port:binding:profile": "rule:context_is_network_viewer",
+          "get_port:binding:vnic_type": "rule:context_is_network_viewer",
+          "update_port": "rule:context_is_editor or rule:context_is_securitygroup_admin",
+          "update_port:security_groups": "rule:context_is_editor or rule:context_is_securitygroup_admin",
+          "update_port:device_owner": "(not rule:network_device and not rule:share_device) or rule:context_is_admin",
+          "update_port:mac_address": "rule:context_is_admin",
+          "update_port:fixed_ips": "(rule:context_is_editor and not rule:network_device and not rule:share_device) or rule:context_is_admin",
+          "update_port:fixed_ips:ip_address": "(rule:context_is_editor and not rule:network_device and not rule:share_device) or rule:context_is_admin",
+          "update_port:fixed_ips:subnet_id": "(rule:context_is_editor and not rule:network_device and not rule:share_device) or rule:context_is_admin",
+          "update_port:port_security_enabled": "rule:context_is_network_editor",
+          "update_port:binding:host_id": "rule:context_is_network_admin",
+          "update_port:binding:profile": "rule:context_is_network_admin",
+          "update_port:binding:vnic_type": "rule:context_is_network_admin",
+          "update_port:mac_learning_enabled": "rule:context_is_network_editor",
+          "update_port:allowed_address_pairs": "rule:context_is_network_editor",
+          "update_port:allowed_address_pairs:ip_address": "rule:context_is_network_editor",
+          "delete_port": "(not rule:network_device and not rule:share_device and rule:context_is_network_editor) or rule:context_is_admin",
+      
+          "get_router:ha": "rule:context_is_admin",
+          "create_router": "rule:context_is_network_admin",
+          "create_router:external_gateway_info:enable_snat": "rule:context_is_admin",
+          "create_router:distributed": "rule:context_is_admin",
+          "create_router:ha": "rule:context_is_admin",
+          "get_router": "rule:context_is_viewer",
+          "get_router:distributed": "rule:context_is_admin",
+          "update_router": "rule:context_is_network_admin",
+          "update_router:external_gateway_info:enable_snat": "rule:context_is_admin",
+          "update_router:distributed": "rule:context_is_admin",
+          "update_router:ha": "rule:context_is_admin",
+      
+          "update_router:cisco_ha:enabled": "rule:context_is_admin",
+          "update_router:cisco_ha:details": "rule:context_is_admin",
+      
+          "delete_router": "rule:context_is_network_admin",
+      
+          "add_router_interface": "rule:context_is_editor",
+          "remove_router_interface": "rule:context_is_editor",
+      
+          "create_router:external_gateway_info:external_fixed_ips": "rule:context_is_network_admin",
+          "update_router:external_gateway_info:external_fixed_ips": "rule:context_is_network_admin",
+      
+          "create_security_group": "rule:context_is_securitygroup_admin",
+          "get_security_group": "rule:context_is_securitygroup_viewer or rule:shared_security_groups",
+          "get_security_groups": "rule:context_is_securitygroup_viewer or rule:shared_security_groups",
+          "update_security_group": "rule:context_is_securitygroup_admin",
+          "update_security_group:stateful": "rule:context_is_admin",
+          "delete_security_group": "rule:context_is_securitygroup_admin",
+      
+          "create_security_group_rule": "rule:context_is_securitygroup_admin",
+          "get_security_group_rule": "rule:context_is_securitygroup_viewer",
+          "get_security_group_rules": "rule:context_is_securitygroup_viewer",
+          "update_security_group_rule": "rule:context_is_securitygroup_admin",
+          "delete_security_group_rule": "rule:context_is_securitygroup_admin",
+      
+          "create_firewall": "rule:context_is_admin",
+          "get_firewall": "rule:context_is_admin",
+          "create_firewall:shared": "rule:context_is_admin",
+          "get_firewall:shared": "rule:context_is_admin",
+          "update_firewall": "rule:context_is_admin",
+          "update_firewall:shared": "rule:context_is_admin",
+          "delete_firewall": "rule:context_is_admin",
+      
+          "create_firewall_policy": "rule:context_is_admin",
+          "get_firewall_policy": "rule:context_is_admin or rule:shared_firewall_policies",
+          "create_firewall_policy:shared": "rule:context_is_admin",
+          "update_firewall_policy": "rule:context_is_admin",
+          "delete_firewall_policy": "rule:context_is_admin",
+      
+          "insert_rule": "rule:context_is_admin",
+          "remove_rule": "rule:context_is_admin",
+      
+          "create_firewall_rule": "rule:context_is_admin",
+          "get_firewall_rule": "rule:context_is_admin or rule:shared_firewalls",
+          "update_firewall_rule": "rule:context_is_admin",
+          "delete_firewall_rule": "rule:context_is_admin",
+      
+          "create_qos_queue": "rule:context_is_admin",
+          "get_qos_queue": "rule:context_is_admin",
+      
+          "update_agent": "rule:context_is_admin",
+          "delete_agent": "rule:context_is_admin",
+          "get_agent": "rule:context_is_admin",
+      
+          "create_dhcp-network": "rule:context_is_admin",
+          "delete_dhcp-network": "rule:context_is_admin",
+          "get_dhcp-networks": "rule:context_is_admin",
+          "create_l3-router": "rule:context_is_admin",
+          "delete_l3-router": "rule:context_is_admin",
+          "get_l3-routers": "rule:context_is_admin",
+          "get_dhcp-agents": "rule:context_is_admin",
+          "get_l3-agents": "rule:context_is_admin",
+          "get_loadbalancer-agent": "rule:context_is_admin",
+          "get_loadbalancer-pools": "rule:context_is_admin",
+          "get_agent-loadbalancers": "rule:context_is_admin",
+          "get_loadbalancer-hosting-agent": "rule:context_is_admin",
+      
+          "create_floatingip": "rule:context_is_editor",
+          "create_floatingip:floating_ip_address": "rule:context_is_network_admin",
+          "update_floatingip": "rule:context_is_editor",
+          "delete_floatingip": "rule:context_is_editor",
+          "get_floatingip": "rule:context_is_viewer",
+      
+          "create_network_profile": "rule:context_is_admin",
+          "update_network_profile": "rule:context_is_admin",
+          "delete_network_profile": "rule:context_is_admin",
+          "get_network_profiles": "rule:context_is_admin",
+          "get_network_profile": "rule:context_is_admin",
+          "update_policy_profiles": "rule:context_is_admin",
+          "get_policy_profiles": "rule:context_is_admin",
+          "get_policy_profile": "rule:context_is_admin",
+      
+          "create_metering_label": "rule:context_is_admin",
+          "delete_metering_label": "rule:context_is_admin",
+          "get_metering_label": "rule:context_is_admin",
+      
+          "create_metering_label_rule": "rule:context_is_admin",
+          "delete_metering_label_rule": "rule:context_is_admin",
+          "get_metering_label_rule": "rule:context_is_admin",
+      
+          "get_service_provider": "rule:context_is_admin",
+          "get_lsn": "rule:context_is_admin",
+          "create_lsn": "rule:context_is_admin",
+      
+          "create_flavor": "rule:context_is_admin",
+          "update_flavor": "rule:context_is_admin",
+          "delete_flavor": "rule:context_is_admin",
+          "get_flavors": "rule:context_is_admin",
+          "get_flavor": "rule:context_is_admin",
+          "create_service_profile": "rule:context_is_admin",
+          "update_service_profile": "rule:context_is_admin",
+          "delete_service_profile": "rule:context_is_admin",
+          "get_service_profiles": "rule:context_is_admin",
+          "get_service_profile": "rule:context_is_admin",
+      
+          "get_policy": "rule:context_is_admin",
+          "create_policy": "rule:context_is_admin",
+          "update_policy": "rule:context_is_admin",
+          "delete_policy": "rule:context_is_admin",
+          "get_policy_bandwidth_limit_rule": "rule:context_is_admin",
+          "create_policy_bandwidth_limit_rule": "rule:context_is_admin",
+          "delete_policy_bandwidth_limit_rule": "rule:context_is_admin",
+          "update_policy_bandwidth_limit_rule": "rule:context_is_admin",
+          "get_policy_dscp_marking_rule": "rule:context_is_admin",
+          "create_policy_dscp_marking_rule": "rule:context_is_admin",
+          "delete_policy_dscp_marking_rule": "rule:context_is_admin",
+          "update_policy_dscp_marking_rule": "rule:context_is_admin",
+          "get_rule_type": "rule:context_is_admin",
+      
+          "restrict_wildcard": "(not field:rbac_policy:target_tenant=*) or rule:context_is_admin",
+          "create_rbac_policy": "rule:context_is_network_admin",
+          "create_rbac_policy:target_tenant": "rule:restrict_wildcard",
+          "update_rbac_policy": "rule:context_is_network_admin",
+          "update_rbac_policy:target_tenant": "rule:restrict_wildcard and rule:context_is_network_admin",
+          "get_rbac_policy": "rule:context_is_viewer",
+          "delete_rbac_policy": "rule:context_is_network_admin",
+      
+          "create_flavor_service_profile": "rule:context_is_admin",
+          "delete_flavor_service_profile": "rule:context_is_admin",
+          "get_flavor_service_profile": "rule:context_is_admin",
+          "get_auto_allocated_topology": "rule:context_is_network_admin",
+      
+          "create_trunk": "rule:context_is_network_admin",
+          "get_trunk": "rule:context_is_network_viewer",
+          "delete_trunk": "rule:context_is_network_admin",
+          "get_subports": "rule:context_is_network_viewer",
+          "add_subports": "rule:context_is_network_admin",
+          "remove_subports": "rule:context_is_network_admin",
+      
+          "get_loggable_resources": "rule:network_view_all",
+          "create_log": "rule:context_is_network_admin",
+          "update_log": "rule:context_is_network_admin",
+          "delete_log": "rule:context_is_network_admin",
+          "get_logs": "rule:context_is_network_viewer",
+          "get_log": "rule:context_is_network_viewer",
+      
+          "create_interconnection": "rule:context_is_editor",
+          "update_interconnection": "rule:context_is_editor",
+          "update_interconnection:name": "rule:context_is_editor",
+          "update_interconnection:state": "rule:context_is_admin",
+          "update_interconnection:remote_interconnection_id": "rule:context_is_admin",
+          "delete_interconnection": "rule:context_is_editor",
+          "get_interconnection": "rule:context_is_editor",
+      
+          "create_bgpvpn": "rule:context_is_editor or rule:context_is_admin",
+          "update_bgpvpn": "rule:context_is_admin",
+          "delete_bgpvpn": "rule:context_is_editor or rule:context_is_admin",
+          "get_bgpvpn": "rule:context_is_viewer or rule:shared_bgpvpns",
+          "get_bgpvpn:tenant_id": "rule:context_is_viewer or rule:shared_bgpvpns",
+          "get_bgpvpn:route_targets": "rule:context_is_viewer or rule:shared_bgpvpns",
+          "get_bgpvpn:import_targets": "rule:context_is_viewer or rule:shared_bgpvpns",
+          "get_bgpvpn:export_targets": "rule:context_is_viewer or rule:shared_bgpvpns",
+          "get_bgpvpn:route_distinguishers": "rule:context_is_viewer or rule:shared_bgpvpns",
+          "get_bgpvpn:vni": "rule:context_is_viewer or rule:shared_bgpvpns",
+          "create_bgpvpn:route_targets": "rule:context_is_admin",
+          "create_bgpvpn:import_targets": "rule:context_is_admin",
+          "create_bgpvpn:export_targets": "rule:context_is_admin",
+          "create_bgpvpn:route_distinguishers": "rule:context_is_admin",
+          "create_bgpvpn:type": "rule:context_is_admin",
+          "create_bgpvpn:local_pref": "rule:context_is_admin",
+          "create_bgpvpn:vni": "rule:context_is_admin",
+          "update_bgpvpn:tenant_id": "rule:context_is_admin",
+          "update_bgpvpn:route_targets": "rule:context_is_admin",
+          "update_bgpvpn:import_targets": "rule:context_is_admin",
+          "update_bgpvpn:export_targets": "rule:context_is_admin",
+          "update_bgpvpn:route_distinguishers": "rule:context_is_admin",
+          "update_bgpvpn:vni": "rule:context_is_admin",
+      
+          "create_bgpvpn_network_association": "rule:context_is_admin",
+          "update_bgpvpn_network_association": "rule:context_is_admin",
+          "delete_bgpvpn_network_association": "rule:context_is_admin",
+          "get_bgpvpn_network_association": "rule:context_is_admin",
+          "get_bgpvpn_network_association:tenant_id": "rule:context_is_admin",
+      
+          "create_bgpvpn_port_association": "rule:context_is_admin",
+          "update_bgpvpn_port_association": "rule:context_is_admin",
+          "delete_bgpvpn_port_association": "rule:context_is_admin",
+          "get_bgpvpn_port_association": "rule:context_is_admin",
+          "get_bgpvpn_port_association:tenant_id": "rule:context_is_admin",
+      
+          "create_bgpvpn_router_association": "rule:context_is_editor or rule:shared_bgpvpns",
+          "update_bgpvpn_router_association": "rule:context_is_editor or rule:shared_bgpvpns",
+          "delete_bgpvpn_router_association": "rule:context_is_editor or rule:shared_bgpvpns",
+          "get_bgpvpn_router_association": "rule:context_is_viewer or rule:shared_bgpvpns",
+          "get_bgpvpn_router_association:tenant_id": "rule:context_is_viewer or rule:shared_bgpvpns"
+      }
+      
+    rootwrap.conf: |
+      # Configuration for neutron-rootwrap
+      # This file should be owned by (and only-writeable by) the root user
+      
+      [DEFAULT]
+      # List of directories to load filter definitions from (separated by ',').
+      # These directories MUST all be only writeable by root !
+      filters_path=/etc/neutron/rootwrap.d,/usr/share/neutron/rootwrap,/var/lib/openstack/etc/neutron/rootwrap.d
+      
+      # List of directories to search executables in, in case filters do not
+      # explicitely specify a full path (separated by ',')
+      # If not specified, defaults to system PATH environment variable.
+      # These directories MUST all be only writeable by root !
+      exec_dirs=/sbin,/usr/sbin,/bin,/usr/bin,/usr/local/bin,/usr/local/sbin,/var/lib/openstack/bin
+      
+      # Enable logging to syslog
+      # Default value is False
+      use_syslog=False
+      
+      # Which syslog facility to use.
+      # Valid values include auth, authpriv, syslog, local0, local1...
+      # Default value is 'syslog'
+      syslog_log_facility=syslog
+      
+      # Which messages to log.
+      # INFO means log all usage
+      # ERROR means only log unsuccessful attempts
+      syslog_log_level=ERROR
+      
+      [xenapi]
+      # XenAPI configuration is only required by the L2 agent if it is to
+      # target a XenServer/XCP compute host's dom0.
+      xenapi_connection_url=<None>
+      xenapi_connection_username=root
+      xenapi_connection_password=<None>
+      
+    dhcp.filters: |
+      # neutron-rootwrap command filters for nodes on which neutron is
+      # expected to control network
+      #
+      # This file should be owned by (and only-writeable by) the root user
+      
+      # format seems to be
+      # cmd-name: filter-name, raw-command, user, args
+      
+      [Filters]
+      
+      # dhcp-agent
+      dnsmasq: CommandFilter, dnsmasq, root
+      # dhcp-agent uses kill as well, that's handled by the generic KillFilter
+      # it looks like these are the only signals needed, per
+      # neutron/agent/linux/dhcp.py
+      kill_dnsmasq: KillFilter, root, /sbin/dnsmasq, -9, -HUP
+      kill_dnsmasq_usr: KillFilter, root, /usr/sbin/dnsmasq, -9, -HUP
+      
+      ovs-vsctl: CommandFilter, ovs-vsctl, root
+      ivs-ctl: CommandFilter, ivs-ctl, root
+      mm-ctl: CommandFilter, mm-ctl, root
+      dhcp_release: CommandFilter, dhcp_release, root
+      
+      # haproxy
+      haproxy: RegExpFilter, haproxy, root, haproxy, -f, .*
+      kill_haproxy: KillFilter, root, haproxy, -15, -9, -HUP
+      # DEPRECATED: metadata proxy
+      metadata_proxy: CommandFilter, neutron-ns-metadata-proxy, root
+      
+      # TODO(dalvarez): Remove kill_metadata* filters in Q release since
+      # neutron-ns-metadata-proxy is now replaced by haproxy. We keep them for now
+      # for the migration process
+      # RHEL invocation of the metadata proxy will report /usr/bin/python
+      kill_metadata: KillFilter, root, python, -9
+      kill_metadata7: KillFilter, root, python2.7, -9
+      # SAPCC: for killing neutron-ns-metadata-proxy on CC
+      kill_metadata2: KillFilter, root, python2, -9
+      
+      # ip_lib
+      ip: IpFilter, ip, root
+      find: RegExpFilter, find, root, find, /sys/class/net, -maxdepth, 1, -type, l, -printf, %.*
+      ip_exec: IpNetnsExecFilter, ip, root
+      
+    l3.filters: |
+      # neutron-rootwrap command filters for nodes on which neutron is
+      # expected to control network
+      #
+      # This file should be owned by (and only-writeable by) the root user
+      
+      # format seems to be
+      # cmd-name: filter-name, raw-command, user, args
+      
+      [Filters]
+      
+      # arping
+      arping: CommandFilter, arping, root
+      
+      # l3_agent
+      sysctl: CommandFilter, sysctl, root
+      route: CommandFilter, route, root
+      radvd: CommandFilter, radvd, root
+      
+      # haproxy
+      haproxy: RegExpFilter, haproxy, root, haproxy, -f, .*
+      kill_haproxy: KillFilter, root, haproxy, -15, -9, -HUP
+      # DEPRECATED: metadata proxy
+      metadata_proxy: CommandFilter, neutron-ns-metadata-proxy, root
+      # RHEL invocation of the metadata proxy will report /usr/bin/python
+      kill_metadata: KillFilter, root, python, -9
+      kill_metadata7: KillFilter, root, python2.7, -9
+      kill_metadata2: KillFilter, root, python2, -9
+      kill_radvd_usr: KillFilter, root, /usr/sbin/radvd, -9, -HUP
+      kill_radvd: KillFilter, root, /sbin/radvd, -9, -HUP
+      
+      # ip_lib
+      ip: IpFilter, ip, root
+      find: RegExpFilter, find, root, find, /sys/class/net, -maxdepth, 1, -type, l, -printf, %.*
+      ip_exec: IpNetnsExecFilter, ip, root
+      
+      # For ip monitor
+      kill_ip_monitor: KillFilter, root, ip, -9
+      
+      # ovs_lib (if OVSInterfaceDriver is used)
+      ovs-vsctl: CommandFilter, ovs-vsctl, root
+      
+      # iptables_manager
+      iptables-save: CommandFilter, iptables-save, root
+      iptables-restore: CommandFilter, iptables-restore, root
+      ip6tables-save: CommandFilter, ip6tables-save, root
+      ip6tables-restore: CommandFilter, ip6tables-restore, root
+      
+      # Keepalived
+      keepalived: CommandFilter, keepalived, root
+      kill_keepalived: KillFilter, root, /usr/sbin/keepalived, -HUP, -15, -9
+      
+      # l3 agent to delete floatingip's conntrack state
+      conntrack: CommandFilter, conntrack, root
+      
+      # keepalived state change monitor
+      keepalived_state_change: CommandFilter, neutron-keepalived-state-change, root
+      kill_keepalived_state_change: KillFilter, root, python, -15, -9
+      kill_keepalived_state_change7: KillFilter, root, python2.7, -15, -9
+      
+    sudoers: |
+      #
+      # This file MUST be edited with the 'visudo' command as root.
+      #
+      # Please consider adding local content in /etc/sudoers.d/ instead of
+      # directly modifying this file.
+      #
+      # See the man page for details on how to write a sudoers file.
+      #
+      Defaults	env_reset
+      Defaults	mail_badpass
+      Defaults	secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:/var/lib/openstack/bin"
+      
+      # Host alias specification
+      
+      # User alias specification
+      
+      # Cmnd alias specification
+      
+      # User privilege specification
+      root	ALL=(ALL:ALL) ALL
+      
+      # Members of the admin group may gain root privileges
+      %admin ALL=(ALL) ALL
+      
+      # Allow members of group sudo to execute any command
+      %sudo	ALL=(ALL:ALL) ALL
+      
+      # See sudoers(5) for more information on "#include" directives:
+      
+      #includedir /etc/sudoers.d
+      
+    logging.conf: |
+      
+      [formatters]
+      keys=context,default
+      
+      
+      [formatter_context]
+      class=oslo_log.formatters.ContextFormatter
+      
+      [formatter_default]
+      format=%(message)s
+      
+      [handlers]
+      keys=null,sentry,stdout
+      
+      
+      [handler_null]
+      args=()
+      class=logging.NullHandler
+      formatter=default
+      
+      [handler_sentry]
+      args=()
+      class=raven.handlers.logging.SentryHandler
+      level=ERROR
+      
+      [handler_stdout]
+      args=(sys.stdout,)
+      class=StreamHandler
+      formatter=context
+      
+      [loggers]
+      keys=asr1k_neutron_l3,auditmiddleware,eventlet_wsgi_server,networking_aci,networking_aci_plugins_ml2_drivers_mech_aci_allocations_manager,networking_arista,networking_ccloud,networking_f5,networking_nsxv3,neutron,neutron_api_rpc,neutron_pecan_wsgi_hooks_policy_enforcement,neutron_plugins_ml2_drivers_mech_agent,neutron_wsgi,paste,rate_limit_rate_limit,root,suds
+      
+      
+      [logger_asr1k_neutron_l3]
+      qualname=asr1k_neutron_l3
+      propagate=0
+      handlers=stdout, sentry
+      level=DEBUG
+      
+      [logger_auditmiddleware]
+      qualname=auditmiddleware
+      propagate=0
+      handlers=stdout, sentry
+      level=DEBUG
+      
+      [logger_eventlet_wsgi_server]
+      qualname=eventlet.wsgi.server
+      propagate=0
+      handlers=stdout, sentry
+      level=INFO
+      
+      [logger_networking_aci]
+      qualname=networking_aci
+      propagate=0
+      handlers=stdout, sentry
+      level=DEBUG
+      
+      [logger_networking_aci_plugins_ml2_drivers_mech_aci_allocations_manager]
+      qualname=networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager
+      propagate=0
+      handlers=stdout, sentry
+      level=WARNING
+      
+      [logger_networking_arista]
+      qualname=networking_arista
+      propagate=0
+      handlers=stdout, sentry
+      level=DEBUG
+      
+      [logger_networking_ccloud]
+      qualname=networking_ccloud
+      propagate=0
+      handlers=stdout, sentry
+      level=DEBUG
+      
+      [logger_networking_f5]
+      qualname=networking_f5
+      propagate=0
+      handlers=stdout, sentry
+      level=DEBUG
+      
+      [logger_networking_nsxv3]
+      qualname=networking_nsxv3
+      propagate=0
+      handlers=stdout, sentry
+      level=INFO
+      
+      [logger_neutron]
+      qualname=neutron
+      propagate=0
+      handlers=stdout, sentry
+      level=DEBUG
+      
+      [logger_neutron_api_rpc]
+      qualname=neutron.api.rpc
+      propagate=0
+      handlers=stdout, sentry
+      level=INFO
+      
+      [logger_neutron_pecan_wsgi_hooks_policy_enforcement]
+      qualname=neutron.pecan_wsgi.hooks.policy_enforcement
+      propagate=0
+      handlers=stdout, sentry
+      level=INFO
+      
+      [logger_neutron_plugins_ml2_drivers_mech_agent]
+      qualname=neutron.plugins.ml2.drivers.mech_agent
+      propagate=0
+      handlers=stdout, sentry
+      level=DEBUG
+      
+      [logger_neutron_wsgi]
+      qualname=neutron.wsgi
+      propagate=0
+      handlers=stdout, sentry
+      level=INFO
+      
+      [logger_paste]
+      qualname=paste
+      propagate=0
+      handlers=stdout, sentry
+      level=ERROR
+      
+      [logger_rate_limit_rate_limit]
+      qualname=rate_limit.rate_limit
+      propagate=0
+      handlers=stdout, sentry
+      level=INFO
+      
+      [logger_root]
+      formatter=context
+      handlers=stdout, sentry
+      level=ERROR
+      
+      [logger_suds]
+      qualname=suds
+      propagate=0
+      handlers=null
+      level=ERROR
+      
+    neutron_audit_map.yaml: |
+      service_type: 'network'
+      service_name: 'neutron'
+      
+      # prefix: '/v2[0-9\.]*(?:/[0-9a-f\-]+)?'
+      prefix: '/v2.0'
+      
+      resources:
+        #custom endpoint
+        asrk1:
+          singleton: true
+        bgpvpn:
+          # BPG VPNs namespace
+          singleton: true
+          children:
+            bgpvpns:
+              type_uri: network/bgpvpns
+              children:
+                network_associations:
+                  type_uri: network/bgpvpn/network-associations
+                router_associations:
+                  type_uri: network/bgpvpn/router-associations
+                port_associations:
+                  type_uri: network/bgpvpn/port-associations
+        #custom endpoint
+        cc-fabric:
+          children:
+            switches:
+              type_uri: network/cc-fabric/switches
+        interconnection:
+          singleton: true
+          children:
+            interconnections:
+              type_uri: network/interconnections
+        flavors:
+        floatingips:
+          children:
+            tags:
+        fw:
+          # FWaaS 1.0 namespace
+          singleton: true
+          type_uri: network/firewalls
+          children:
+            firewalls:
+              type_uri: network/firewalls
+            firewall_policies:
+              type_uri: network/firewall/policies
+              el_type_uri: network/firewall/policy
+            firewall_rules:
+              type_uri: network/firewall/rules
+        fwaas:
+          # FWaas 2.0 namespace (uses same logical resource uris as 1.0)
+          singleton: true
+          type_uri: network/firewalls
+          children:
+            firewall_groups:
+              type_uri: network/firewalls
+            firewall_policies:
+              type_uri: network/firewall/policies
+              el_type_uri: network/firewall/policy
+            firewall_rules:
+              type_uri: network/firewall/rules
+      
+        lbaas:
+          # LBaaS 2.0 namespace
+          singleton: true
+          children:
+            healthmonitors:
+              type_uri: network/loadbalancer/healthmonitors
+            loadbalancers:
+              type_uri: network/loadbalancers
+              children:
+                statuses:
+                  singleton: true
+            listeners:
+              type_uri: network/loadbalancer/listeners
+            pools:
+              type_uri: network/loadbalancer/pools
+              children:
+                members:
+            l7policies:
+              type_uri: network/loadbalancer/l7policies
+              el_type_uri: network/loadbalancer/l7policy
+              children:
+                rules:
+        log:
+          # logging extension namespace
+          singleton: true
+          children:
+            logs:
+            loggable-resources:
+              singleton: true
+        metering:
+          # metering namespace
+          singleton: true
+          children:
+            metering-labels:
+              type_uri: network/metering/labels
+            metering-label-rules:
+              type_uri: network/metering/label-rules
+        networks:
+          children:
+            tags:
+        network-ip-availabilities:
+        ports:
+          custom_attributes:
+            security_groups: network/security-groups
+          children:
+            tags:
+        quotas:
+          custom_actions:
+            details: read/list/details
+        qos:
+          # qos namespace
+          singleton: true
+          children:
+            policies:
+              children:
+                bandwidth_limit_rules:
+                  type_uri: network/qos/bandwidth-limit-rules
+                dscp_marking_rules:
+                  type_uri: network/qos/dscp-marking-rules
+                minimum_bandwidth_rules:
+                  type_uri: network/qos/minimum-bandwidth-rules
+            rule-types:
+            tags:
+        rbac-policies:
+        routers:
+          custom_actions:
+            add_router_interface: update/add/router-interface
+            remove_router_interface: update/remove/router-interface
+          children:
+            tags:
+        security-groups:
+          children:
+            tags:
+        security-group-rules:
+          # does not have a name field, so let's use the description
+          custom_name: description
+          custom_attributes:
+            security_rule_id: network/security-group-rule
+          children:
+            tags:
+        segments:
+        service-profiles:
+        subnetpools:
+          children:
+            tags:
+        subnets:
+          children:
+            tags:
+        trunks:
+          children:
+            tags:
+        vpn:
+          # VPNaaS 2.0 namespace
+          singleton: true
+          children:
+            endpoint-groups:
+            ikepolicies:
+              type_uri: network/vpn/ike-policies
+              el_type_uri: network/vpn/ike-policy
+            ipsecpolicies:
+              type_uri: network/vpn/ipsec-policies
+              el_type_uri: network/vpn/ipsec-policy
+            ipsec-site-connections:
+            vpnservices:
+              type_uri: network/vpn/vpn-services
+      
+    watcher.yaml: |
+      path_keywords:
+        - address-scopes
+        - agents
+        - availability_zones
+        - bandwidth_limit_rules
+        - bgpvpns
+        - interconnections
+        - dscp_marking_rules
+        - endpoint-groups
+        - extensions
+        - firewall_groups
+        - firewall_logs
+        - firewall_policies
+        - firewall_rules
+        - firewalls
+        - flavors
+        - floatingips
+        - healthmonitors
+        - ikepolicies
+        - ipsec-site-connections
+        - ipsecpolicies
+        - listeners
+        - loadbalancers
+        - loggable-resources
+        - logging_resources
+        - logs
+        - members
+        - metering-label-rules
+        - metering-labels
+        - minimum_bandwidth_rules
+        - network-ip-availabilities
+        - network_associations
+        - networks
+        - policies
+        - pools
+        - port_associations
+        - ports
+        - quotas
+        - rbac-policies
+        - router_associations
+        - routers
+        - rule-types
+        - security-group-rules
+        - security-groups
+        - segments
+        - service-providers
+        - service_profiles
+        - subnetpools
+        - subnets
+        - tags
+        - trunks
+        - vpnservices
+      
+      regex_path_mapping:
+        - 'v2.0/\S+/\S+/tags$': 'resource_type/resource/tags'
+        - 'v2.0/\S+/\S+/tags/\S+$': 'resource_type/resource/tags/tag'
+      
+    ratelimit.yaml: |
+      #Allowed Projects List
+      whitelist:
+         - Default/service
+         - Default/admin
+         - tempest/performance-testing
+      #Custom groups for CADF actions
+      groups:
+        write:
+        - delete
+        - update
+      rates:
+        default:
+          address-scopes:
+          - action: read/list
+            limit: 43r/m
+          agents:
+          - action: read/list
+            limit: 279r/m
+          agents/agent/*:
+          - action: read
+            limit: 159r/m
+          extensions:
+          - action: read/list
+            limit: 83r/m
+          extensions/extension:
+          - action: read
+            limit: 83r/m
+          floatingips:
+          - action: read/list
+            limit: 454r/m
+          - action: create
+            limit: 83r/m
+          floatingips.json:
+          - action: read
+            limit: 202r/m
+          floatingips/floatingip:
+          - action: read
+            limit: 83r/m
+          - action: write
+            limit: 83r/m
+          network-ip-availabilities/network-ip-availability:
+          - action: read
+            limit: 83r/m
+          networks:
+          - action: read/list
+            limit: 154r/m
+          networks/default:
+          - action: read
+            limit: 83r/m
+          networks/network:
+          - action: read
+            limit: 289r/m
+          ports:
+          - action: read/list
+            limit: 3042r/m
+          - action: create
+            limit: 83r/m
+          - action: write
+            limit: 52r/m
+          ports.json:
+          - action: read
+            limit: 174r/m
+          ports/port:
+          - action: read
+            limit: 108r/m
+          - action: write
+            limit: 83r/m
+          ports/port/*:
+          - action: read
+            limit: 20r/m
+          quotas/quota:
+          - action: read
+            limit: 83r/m
+          - action: write
+            limit: 83r/m
+          quotas/quota/*:
+          - action: read
+            limit: 83r/m
+          resource_type/resource/*:
+          - action: write
+            limit: 83r/m
+          routers:
+          - action: read/list
+            limit: 105r/m
+          routers/router:
+          - action: read
+            limit: 663r/m
+          routers/router/*:
+          - action: write
+            limit: 43r/m
+          security-group-rules:
+          - action: create
+            limit: 83r/m
+          - action: read/list
+            limit: 52r/m
+          security-group-rules/security-group-rule:
+          - action: read
+            limit: 552r/m
+          - action: write
+            limit: 83r/m
+          security-groups:
+          - action: read/list
+            limit: 2080r/m
+          - action: create
+            limit: 83r/m
+          security-groups/default:
+          - action: read
+            limit: 83r/m
+          security-groups/security-group:
+          - action: read
+            limit: 83r/m
+          subnetpools:
+          - action: read/list
+            limit: 83r/m
+          subnetpools/subnetpool:
+          - action: write
+            limit: 41r/m
+          subnets:
+          - action: read/list
+            limit: 228r/m
+          subnets/subnet:
+          - action: read
+            limit: 261r/m
+          - action: write
+            limit: 83r/m
+      
+    statsd-exporter.yaml: |
+      defaults:
+        timer_type: histogram
+        buckets: [.025, .1, .25, 1, 2.5]
+        match_type: glob
+        glob_disable_ordering: false
+        ttl: 0 # metrics do not expire
+    az-a.conf: |
+      [agent]
+      availability_zone = qa-de-1a
+    az-b.conf: |
+      [agent]
+      availability_zone = qa-de-1b
+    az-c.conf: |
+      [agent]
+      availability_zone = qa-de-1c
+    az-d.conf: |
+      [agent]
+      availability_zone = qa-de-1d
+[0;33mmonsoon3, neutron-network-agent-ap001, StatefulSet (apps) has changed:[0m
+  # Source: neutron/templates/statefulset-network-agent-apod.yaml
+  apiVersion: apps/v1
+  kind: StatefulSet
+  metadata:
+    name: neutron-network-agent-ap001
+    labels:
+      system: openstack
+      application: neutron
+      component: agent
+    annotations:
+      vpa-butler.cloud.sap/main-container: neutron-dhcp-agent
+  spec:
+    updateStrategy:
+      type: RollingUpdate
+    selector:
+      matchLabels:
+        name: neutron-network-agent-ap001
+    serviceName: neutron-network-agent
+    podManagementPolicy: "Parallel"
+    replicas: 15
+    template:
+      metadata:
+        annotations:
+          k8s.v1.cni.cncf.io/networks: '[{ "name": "cbr1-bridge", "interface":"bond1" }]'
+[0;31m-         configmap-etc-hash: d804d23560cc00cfee20fce94ce5b491b6c57bd26ee4fd7f3cd5adbfbc96e871[0m
+[0;32m+         configmap-etc-hash: 411229865bca0b45fb623df0a5ef0a0dd4c4a14064c3afa6bae3d1009b83818f[0m
+          configmap-etc-apod-hash: bebf8c0481441a33bb1a13bc60dbfb73daa87b95a574bec00b7de7611c9e178d
+        labels:
+          name: neutron-network-agent-ap001
+          release_name: neutron
+          application: neutron
+          component: agent
+      spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 50
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchExpressions:
+                  - key: component
+                    operator: In
+                    values:
+                    - agent
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.cloud.sap/host
+                labelSelector:
+                  matchExpressions:
+                  - key: component
+                    operator: In
+                    values:
+                    - agent
+        nodeSelector:
+          multus: bond1
+          topology.kubernetes.io/zone: qa-de-1a
+          kubernetes.cloud.sap/apod: ap001
+        initContainers:
+          - name: init
+            image: keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/library/alpine:3.8
+            securityContext:
+              privileged: true
+            command:
+              - sh
+              - -c
+            args:
+              - |-
+                set -xe
+                chroot /host modprobe ebtable_nat
+            volumeMounts:
+              - name: host
+                mountPath: "/host"
+        containers:
+          - name: neutron-dhcp-agent
+            image: keppel.eu-de-1.cloud.sap/ccloud/loci-neutron:yoga-20231220120402
+            imagePullPolicy: IfNotPresent
+            command: ["dumb-init", "neutron-dhcp-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/dhcp-agent.ini", "--config-file", "/etc/neutron/linux-bridge.ini", "--config-file", "/etc/neutron/az-a.conf"]
+            env:
+              - name: SENTRY_DSN
+                valueFrom:
+                  secretKeyRef:
+                    name: sentry
+                    key: neutron.DSN.python
+              - name: DEBUG_CONTAINER
+                value: "false"
+              - name: SPT_NOENV
+                value: "yes,please"
+              - name: PYTHONWARNINGS
+                value: "ignore:Unverified HTTPS request"
+            readinessProbe:
+              exec:
+                command: ["neutron-dhcp-readiness", "-config-file", "/etc/neutron/neutron.conf"]
+              initialDelaySeconds: 30
+              periodSeconds: 60
+              timeoutSeconds: 10
+            securityContext:
+              privileged: true
+            resources:
+              limits:
+                cpu: 4000m
+                memory: 2.5Gi
+              requests:
+                cpu: 1000m
+                memory: 1Gi
+            volumeMounts:
+              - name: metadata-proxy
+                mountPath: /run/metadata_proxy
+              - name: modules
+                mountPath: /lib/modules
+                readOnly: true
+              - name: logvol
+                mountPath: /dev/log
+                readOnly: false
+              - name: etc-neutron-dhcp-agent
+                mountPath: /etc/neutron
+                readOnly: true
+              - name: neutron-etc
+                mountPath: /etc/sudoers
+                subPath: sudoers
+                readOnly: true
+              - name: network-namespace
+                mountPath: /var/run/netns
+          - name: neutron-linuxbridge-agent
+            image: keppel.eu-de-1.cloud.sap/ccloud/loci-neutron:yoga-20231220120402
+            imagePullPolicy: IfNotPresent
+            command: ["dumb-init", "neutron-linuxbridge-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/plugins/ml2/ml2_conf.ini", "--config-file", "/etc/neutron/linux-bridge.ini", "--config-file", "/etc/neutron/apod-ap001.conf"]
+            env:
+              - name: SENTRY_DSN
+                valueFrom:
+                  secretKeyRef:
+                    name: sentry
+                    key: neutron.DSN.python
+              - name: DEBUG_CONTAINER
+                value: "false"
+              - name: PYTHONWARNINGS
+                value: "ignore:Unverified HTTPS request"
+            readinessProbe:
+              exec:
+                command: ["neutron-linuxbridge-readiness", "-config-file", "/etc/neutron/neutron.conf"]
+              initialDelaySeconds: 30
+              periodSeconds: 60
+              timeoutSeconds: 10
+            securityContext:
+              capabilities:
+                add:
+                  - NET_ADMIN
+                  - SYS_ADMIN
+                  - DAC_OVERRIDE
+                  - DAC_READ_SEARCH
+                  - SYS_PTRACE
+
+            resources:
+              limits:
+                cpu: 2000m
+                memory: 1Gi
+              requests:
+                cpu: 256m
+                memory: 512Mi
+            volumeMounts:
+              - mountPath: /lib/modules
+                name: modules
+                readOnly: true
+              - name: etc-neutron-linuxbridge-agent
+                mountPath: /etc/neutron
+                readOnly: true
+              - name: neutron-etc
+                mountPath: /etc/sudoers
+                subPath: sudoers
+                readOnly: true
+              - name: network-namespace
+                mountPath: /var/run/netns
+          - name: neutron-metadata-agent
+            image: keppel.eu-de-1.cloud.sap/ccloud/loci-neutron:yoga-20231220120402
+            imagePullPolicy: IfNotPresent
+            command: ["dumb-init", "neutron-metadata-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/metadata-agent.ini"]
+            env:
+              - name: SENTRY_DSN
+                valueFrom:
+                  secretKeyRef:
+                    name: sentry
+                    key: neutron.DSN.python
+              - name: PYTHONWARNINGS
+                value: "ignore:Unverified HTTPS request"
+              - name: DEBUG_CONTAINER
+                value: "false"
+            resources:
+              limits:
+                cpu: 500m
+                memory: 512Mi
+              requests:
+                cpu: 250m
+                memory: 256Mi
+            volumeMounts:
+              - name: metadata-proxy
+                mountPath: /run/metadata_proxy
+              - name: etc-neutron-metadata-agent
+                mountPath: /etc/neutron
+                readOnly: true
+        volumes:
+          - name: metadata-proxy
+            emptyDir: {}
+          - name: network-namespace
+            emptyDir: {}
+          - name: modules
+            hostPath:
+              path: /lib/modules
+          - name: logvol
+            hostPath:
+              path: /dev/log
+          - name: neutron-etc
+            configMap:
+              name: neutron-etc
+          - name: host
+            hostPath:
+                path: "/"
+          - name: etc-neutron-dhcp-agent
+            projected:
+              defaultMode: 420
+              sources:
+              - configMap:
+                  name: neutron-etc
+                  items:
+                  - key: neutron.conf
+                    path: neutron.conf
+                  - key: logging.conf
+                    path: logging.conf
+                  - key: rootwrap.conf
+                    path: rootwrap.conf
+                  - key: dnsmasq.conf
+                    path: dnsmasq.conf
+                  - key: dhcp.filters
+                    path: rootwrap.d/dhcp.filters
+                  - key: linux-bridge.ini
+                    path: linux-bridge.ini
+                  - key: dhcp-agent.ini
+                    path: dhcp-agent.ini
+                  - key: az-a.conf
+                    path: az-a.conf
+          - name: etc-neutron-linuxbridge-agent
+            projected:
+              defaultMode: 420
+              sources:
+              - configMap:
+                  name: neutron-etc
+                  items:
+                  - key: neutron.conf
+                    path: neutron.conf
+                  - key: logging.conf
+                    path: logging.conf
+                  - key: rootwrap.conf
+                    path: rootwrap.conf
+                  - key: linux-bridge.ini
+                    path: linux-bridge.ini
+                  - key: ml2-conf.ini
+                    path: plugins/ml2/ml2_conf.ini
+              - configMap:
+                  name: neutron-etc-apod
+                  items:
+                  - key: apod-ap001.conf
+                    path: apod-ap001.conf
+          - name: etc-neutron-metadata-agent
+            projected:
+              defaultMode: 420
+              sources:
+              - configMap:
+                  name: neutron-etc
+                  items:
+                  - key: neutron.conf
+                    path: neutron.conf
+                  - key: logging.conf
+                    path: logging.conf
+                  - key: metadata-agent.ini
+                    path: metadata-agent.ini
+[0;33mmonsoon3, neutron-network-agent-ap002, StatefulSet (apps) has changed:[0m
+  # Source: neutron/templates/statefulset-network-agent-apod.yaml
+  apiVersion: apps/v1
+  kind: StatefulSet
+  metadata:
+    name: neutron-network-agent-ap002
+    labels:
+      system: openstack
+      application: neutron
+      component: agent
+    annotations:
+      vpa-butler.cloud.sap/main-container: neutron-dhcp-agent
+  spec:
+    updateStrategy:
+      type: RollingUpdate
+    selector:
+      matchLabels:
+        name: neutron-network-agent-ap002
+    serviceName: neutron-network-agent
+    podManagementPolicy: "Parallel"
+    replicas: 15
+    template:
+      metadata:
+        annotations:
+          k8s.v1.cni.cncf.io/networks: '[{ "name": "cbr1-bridge", "interface":"bond1" }]'
+[0;31m-         configmap-etc-hash: d804d23560cc00cfee20fce94ce5b491b6c57bd26ee4fd7f3cd5adbfbc96e871[0m
+[0;32m+         configmap-etc-hash: 411229865bca0b45fb623df0a5ef0a0dd4c4a14064c3afa6bae3d1009b83818f[0m
+          configmap-etc-apod-hash: bebf8c0481441a33bb1a13bc60dbfb73daa87b95a574bec00b7de7611c9e178d
+        labels:
+          name: neutron-network-agent-ap002
+          release_name: neutron
+          application: neutron
+          component: agent
+      spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 50
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchExpressions:
+                  - key: component
+                    operator: In
+                    values:
+                    - agent
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.cloud.sap/host
+                labelSelector:
+                  matchExpressions:
+                  - key: component
+                    operator: In
+                    values:
+                    - agent
+        nodeSelector:
+          multus: bond1
+          topology.kubernetes.io/zone: qa-de-1b
+          kubernetes.cloud.sap/apod: ap002
+        initContainers:
+          - name: init
+            image: keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/library/alpine:3.8
+            securityContext:
+              privileged: true
+            command:
+              - sh
+              - -c
+            args:
+              - |-
+                set -xe
+                chroot /host modprobe ebtable_nat
+            volumeMounts:
+              - name: host
+                mountPath: "/host"
+        containers:
+          - name: neutron-dhcp-agent
+            image: keppel.eu-de-1.cloud.sap/ccloud/loci-neutron:yoga-20231220120402
+            imagePullPolicy: IfNotPresent
+            command: ["dumb-init", "neutron-dhcp-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/dhcp-agent.ini", "--config-file", "/etc/neutron/linux-bridge.ini", "--config-file", "/etc/neutron/az-b.conf"]
+            env:
+              - name: SENTRY_DSN
+                valueFrom:
+                  secretKeyRef:
+                    name: sentry
+                    key: neutron.DSN.python
+              - name: DEBUG_CONTAINER
+                value: "false"
+              - name: SPT_NOENV
+                value: "yes,please"
+              - name: PYTHONWARNINGS
+                value: "ignore:Unverified HTTPS request"
+            readinessProbe:
+              exec:
+                command: ["neutron-dhcp-readiness", "-config-file", "/etc/neutron/neutron.conf"]
+              initialDelaySeconds: 30
+              periodSeconds: 60
+              timeoutSeconds: 10
+            securityContext:
+              privileged: true
+            resources:
+              limits:
+                cpu: 4000m
+                memory: 2.5Gi
+              requests:
+                cpu: 1000m
+                memory: 1Gi
+            volumeMounts:
+              - name: metadata-proxy
+                mountPath: /run/metadata_proxy
+              - name: modules
+                mountPath: /lib/modules
+                readOnly: true
+              - name: logvol
+                mountPath: /dev/log
+                readOnly: false
+              - name: etc-neutron-dhcp-agent
+                mountPath: /etc/neutron
+                readOnly: true
+              - name: neutron-etc
+                mountPath: /etc/sudoers
+                subPath: sudoers
+                readOnly: true
+              - name: network-namespace
+                mountPath: /var/run/netns
+          - name: neutron-linuxbridge-agent
+            image: keppel.eu-de-1.cloud.sap/ccloud/loci-neutron:yoga-20231220120402
+            imagePullPolicy: IfNotPresent
+            command: ["dumb-init", "neutron-linuxbridge-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/plugins/ml2/ml2_conf.ini", "--config-file", "/etc/neutron/linux-bridge.ini", "--config-file", "/etc/neutron/apod-ap002.conf"]
+            env:
+              - name: SENTRY_DSN
+                valueFrom:
+                  secretKeyRef:
+                    name: sentry
+                    key: neutron.DSN.python
+              - name: DEBUG_CONTAINER
+                value: "false"
+              - name: PYTHONWARNINGS
+                value: "ignore:Unverified HTTPS request"
+            readinessProbe:
+              exec:
+                command: ["neutron-linuxbridge-readiness", "-config-file", "/etc/neutron/neutron.conf"]
+              initialDelaySeconds: 30
+              periodSeconds: 60
+              timeoutSeconds: 10
+            securityContext:
+              capabilities:
+                add:
+                  - NET_ADMIN
+                  - SYS_ADMIN
+                  - DAC_OVERRIDE
+                  - DAC_READ_SEARCH
+                  - SYS_PTRACE
+
+            resources:
+              limits:
+                cpu: 2000m
+                memory: 1Gi
+              requests:
+                cpu: 256m
+                memory: 512Mi
+            volumeMounts:
+              - mountPath: /lib/modules
+                name: modules
+                readOnly: true
+              - name: etc-neutron-linuxbridge-agent
+                mountPath: /etc/neutron
+                readOnly: true
+              - name: neutron-etc
+                mountPath: /etc/sudoers
+                subPath: sudoers
+                readOnly: true
+              - name: network-namespace
+                mountPath: /var/run/netns
+          - name: neutron-metadata-agent
+            image: keppel.eu-de-1.cloud.sap/ccloud/loci-neutron:yoga-20231220120402
+            imagePullPolicy: IfNotPresent
+            command: ["dumb-init", "neutron-metadata-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/metadata-agent.ini"]
+            env:
+              - name: SENTRY_DSN
+                valueFrom:
+                  secretKeyRef:
+                    name: sentry
+                    key: neutron.DSN.python
+              - name: PYTHONWARNINGS
+                value: "ignore:Unverified HTTPS request"
+              - name: DEBUG_CONTAINER
+                value: "false"
+            resources:
+              limits:
+                cpu: 500m
+                memory: 512Mi
+              requests:
+                cpu: 250m
+                memory: 256Mi
+            volumeMounts:
+              - name: metadata-proxy
+                mountPath: /run/metadata_proxy
+              - name: etc-neutron-metadata-agent
+                mountPath: /etc/neutron
+                readOnly: true
+        volumes:
+          - name: metadata-proxy
+            emptyDir: {}
+          - name: network-namespace
+            emptyDir: {}
+          - name: modules
+            hostPath:
+              path: /lib/modules
+          - name: logvol
+            hostPath:
+              path: /dev/log
+          - name: neutron-etc
+            configMap:
+              name: neutron-etc
+          - name: host
+            hostPath:
+                path: "/"
+          - name: etc-neutron-dhcp-agent
+            projected:
+              defaultMode: 420
+              sources:
+              - configMap:
+                  name: neutron-etc
+                  items:
+                  - key: neutron.conf
+                    path: neutron.conf
+                  - key: logging.conf
+                    path: logging.conf
+                  - key: rootwrap.conf
+                    path: rootwrap.conf
+                  - key: dnsmasq.conf
+                    path: dnsmasq.conf
+                  - key: dhcp.filters
+                    path: rootwrap.d/dhcp.filters
+                  - key: linux-bridge.ini
+                    path: linux-bridge.ini
+                  - key: dhcp-agent.ini
+                    path: dhcp-agent.ini
+                  - key: az-b.conf
+                    path: az-b.conf
+          - name: etc-neutron-linuxbridge-agent
+            projected:
+              defaultMode: 420
+              sources:
+              - configMap:
+                  name: neutron-etc
+                  items:
+                  - key: neutron.conf
+                    path: neutron.conf
+                  - key: logging.conf
+                    path: logging.conf
+                  - key: rootwrap.conf
+                    path: rootwrap.conf
+                  - key: linux-bridge.ini
+                    path: linux-bridge.ini
+                  - key: ml2-conf.ini
+                    path: plugins/ml2/ml2_conf.ini
+              - configMap:
+                  name: neutron-etc-apod
+                  items:
+                  - key: apod-ap002.conf
+                    path: apod-ap002.conf
+          - name: etc-neutron-metadata-agent
+            projected:
+              defaultMode: 420
+              sources:
+              - configMap:
+                  name: neutron-etc
+                  items:
+                  - key: neutron.conf
+                    path: neutron.conf
+                  - key: logging.conf
+                    path: logging.conf
+                  - key: metadata-agent.ini
+                    path: metadata-agent.ini
+[0;33mmonsoon3, neutron-network-agent-ap028, StatefulSet (apps) has changed:[0m
+  # Source: neutron/templates/statefulset-network-agent-apod.yaml
+  apiVersion: apps/v1
+  kind: StatefulSet
+  metadata:
+    name: neutron-network-agent-ap028
+    labels:
+      system: openstack
+      application: neutron
+      component: agent
+    annotations:
+      vpa-butler.cloud.sap/main-container: neutron-dhcp-agent
+  spec:
+    updateStrategy:
+      type: RollingUpdate
+    selector:
+      matchLabels:
+        name: neutron-network-agent-ap028
+    serviceName: neutron-network-agent
+    podManagementPolicy: "Parallel"
+    replicas: 15
+    template:
+      metadata:
+        annotations:
+          k8s.v1.cni.cncf.io/networks: '[{ "name": "cbr1-bridge", "interface":"bond1" }]'
+[0;31m-         configmap-etc-hash: d804d23560cc00cfee20fce94ce5b491b6c57bd26ee4fd7f3cd5adbfbc96e871[0m
+[0;32m+         configmap-etc-hash: 411229865bca0b45fb623df0a5ef0a0dd4c4a14064c3afa6bae3d1009b83818f[0m
+          configmap-etc-apod-hash: bebf8c0481441a33bb1a13bc60dbfb73daa87b95a574bec00b7de7611c9e178d
+        labels:
+          name: neutron-network-agent-ap028
+          release_name: neutron
+          application: neutron
+          component: agent
+      spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 50
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchExpressions:
+                  - key: component
+                    operator: In
+                    values:
+                    - agent
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.cloud.sap/host
+                labelSelector:
+                  matchExpressions:
+                  - key: component
+                    operator: In
+                    values:
+                    - agent
+        nodeSelector:
+          multus: bond1
+          topology.kubernetes.io/zone: qa-de-1d
+          kubernetes.cloud.sap/apod: ap028
+        initContainers:
+          - name: init
+            image: keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/library/alpine:3.8
+            securityContext:
+              privileged: true
+            command:
+              - sh
+              - -c
+            args:
+              - |-
+                set -xe
+                chroot /host modprobe ebtable_nat
+            volumeMounts:
+              - name: host
+                mountPath: "/host"
+        containers:
+          - name: neutron-dhcp-agent
+            image: keppel.eu-de-1.cloud.sap/ccloud/loci-neutron:yoga-20231220120402
+            imagePullPolicy: IfNotPresent
+            command: ["dumb-init", "neutron-dhcp-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/dhcp-agent.ini", "--config-file", "/etc/neutron/linux-bridge.ini", "--config-file", "/etc/neutron/az-d.conf"]
+            env:
+              - name: SENTRY_DSN
+                valueFrom:
+                  secretKeyRef:
+                    name: sentry
+                    key: neutron.DSN.python
+              - name: DEBUG_CONTAINER
+                value: "false"
+              - name: SPT_NOENV
+                value: "yes,please"
+              - name: PYTHONWARNINGS
+                value: "ignore:Unverified HTTPS request"
+            readinessProbe:
+              exec:
+                command: ["neutron-dhcp-readiness", "-config-file", "/etc/neutron/neutron.conf"]
+              initialDelaySeconds: 30
+              periodSeconds: 60
+              timeoutSeconds: 10
+            securityContext:
+              privileged: true
+            resources:
+              limits:
+                cpu: 4000m
+                memory: 2.5Gi
+              requests:
+                cpu: 1000m
+                memory: 1Gi
+            volumeMounts:
+              - name: metadata-proxy
+                mountPath: /run/metadata_proxy
+              - name: modules
+                mountPath: /lib/modules
+                readOnly: true
+              - name: logvol
+                mountPath: /dev/log
+                readOnly: false
+              - name: etc-neutron-dhcp-agent
+                mountPath: /etc/neutron
+                readOnly: true
+              - name: neutron-etc
+                mountPath: /etc/sudoers
+                subPath: sudoers
+                readOnly: true
+              - name: network-namespace
+                mountPath: /var/run/netns
+          - name: neutron-linuxbridge-agent
+            image: keppel.eu-de-1.cloud.sap/ccloud/loci-neutron:yoga-20231220120402
+            imagePullPolicy: IfNotPresent
+            command: ["dumb-init", "neutron-linuxbridge-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/plugins/ml2/ml2_conf.ini", "--config-file", "/etc/neutron/linux-bridge.ini", "--config-file", "/etc/neutron/apod-ap028.conf"]
+            env:
+              - name: SENTRY_DSN
+                valueFrom:
+                  secretKeyRef:
+                    name: sentry
+                    key: neutron.DSN.python
+              - name: DEBUG_CONTAINER
+                value: "false"
+              - name: PYTHONWARNINGS
+                value: "ignore:Unverified HTTPS request"
+            readinessProbe:
+              exec:
+                command: ["neutron-linuxbridge-readiness", "-config-file", "/etc/neutron/neutron.conf"]
+              initialDelaySeconds: 30
+              periodSeconds: 60
+              timeoutSeconds: 10
+            securityContext:
+              capabilities:
+                add:
+                  - NET_ADMIN
+                  - SYS_ADMIN
+                  - DAC_OVERRIDE
+                  - DAC_READ_SEARCH
+                  - SYS_PTRACE
+
+            resources:
+              limits:
+                cpu: 2000m
+                memory: 1Gi
+              requests:
+                cpu: 256m
+                memory: 512Mi
+            volumeMounts:
+              - mountPath: /lib/modules
+                name: modules
+                readOnly: true
+              - name: etc-neutron-linuxbridge-agent
+                mountPath: /etc/neutron
+                readOnly: true
+              - name: neutron-etc
+                mountPath: /etc/sudoers
+                subPath: sudoers
+                readOnly: true
+              - name: network-namespace
+                mountPath: /var/run/netns
+          - name: neutron-metadata-agent
+            image: keppel.eu-de-1.cloud.sap/ccloud/loci-neutron:yoga-20231220120402
+            imagePullPolicy: IfNotPresent
+            command: ["dumb-init", "neutron-metadata-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/metadata-agent.ini"]
+            env:
+              - name: SENTRY_DSN
+                valueFrom:
+                  secretKeyRef:
+                    name: sentry
+                    key: neutron.DSN.python
+              - name: PYTHONWARNINGS
+                value: "ignore:Unverified HTTPS request"
+              - name: DEBUG_CONTAINER
+                value: "false"
+            resources:
+              limits:
+                cpu: 500m
+                memory: 512Mi
+              requests:
+                cpu: 250m
+                memory: 256Mi
+            volumeMounts:
+              - name: metadata-proxy
+                mountPath: /run/metadata_proxy
+              - name: etc-neutron-metadata-agent
+                mountPath: /etc/neutron
+                readOnly: true
+        volumes:
+          - name: metadata-proxy
+            emptyDir: {}
+          - name: network-namespace
+            emptyDir: {}
+          - name: modules
+            hostPath:
+              path: /lib/modules
+          - name: logvol
+            hostPath:
+              path: /dev/log
+          - name: neutron-etc
+            configMap:
+              name: neutron-etc
+          - name: host
+            hostPath:
+                path: "/"
+          - name: etc-neutron-dhcp-agent
+            projected:
+              defaultMode: 420
+              sources:
+              - configMap:
+                  name: neutron-etc
+                  items:
+                  - key: neutron.conf
+                    path: neutron.conf
+                  - key: logging.conf
+                    path: logging.conf
+                  - key: rootwrap.conf
+                    path: rootwrap.conf
+                  - key: dnsmasq.conf
+                    path: dnsmasq.conf
+                  - key: dhcp.filters
+                    path: rootwrap.d/dhcp.filters
+                  - key: linux-bridge.ini
+                    path: linux-bridge.ini
+                  - key: dhcp-agent.ini
+                    path: dhcp-agent.ini
+                  - key: az-d.conf
+                    path: az-d.conf
+          - name: etc-neutron-linuxbridge-agent
+            projected:
+              defaultMode: 420
+              sources:
+              - configMap:
+                  name: neutron-etc
+                  items:
+                  - key: neutron.conf
+                    path: neutron.conf
+                  - key: logging.conf
+                    path: logging.conf
+                  - key: rootwrap.conf
+                    path: rootwrap.conf
+                  - key: linux-bridge.ini
+                    path: linux-bridge.ini
+                  - key: ml2-conf.ini
+                    path: plugins/ml2/ml2_conf.ini
+              - configMap:
+                  name: neutron-etc-apod
+                  items:
+                  - key: apod-ap028.conf
+                    path: apod-ap028.conf
+          - name: etc-neutron-metadata-agent
+            projected:
+              defaultMode: 420
+              sources:
+              - configMap:
+                  name: neutron-etc
+                  items:
+                  - key: neutron.conf
+                    path: neutron.conf
+                  - key: logging.conf
+                    path: logging.conf
+                  - key: metadata-agent.ini
+                    path: metadata-agent.ini
+[0;33mmonsoon3, neutron-nsxv3-agent-deployment, VCenterTemplate (vcenter-operator.stable.sap.cc) has changed:[0m
+  # Source: neutron/templates/vct-nsxv3-agent-deployment.yaml
+  apiVersion: vcenter-operator.stable.sap.cc/v1
+  kind: VCenterTemplate
+  metadata:
+    name: 'neutron-nsxv3-agent-deployment'
+  options:
+    scope: 'cluster'
+    jinja2_options:
+      variable_start_string: '{='
+      variable_end_string: '=}'
+  template: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: neutron-nsxv3-agent-{= name =}
+      labels:
+        system: openstack
+        type: backend
+        component: neutron
+        vcenter: {= host =}
+        datacenter: {= availability_zone =}
+        vccluster: {= cluster_name =}
+    spec:
+      replicas: 1
+      revisionHistoryLimit: 5
+      strategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxUnavailable: 0
+          maxSurge: 1
+      selector:
+        matchLabels:
+            name: neutron-nsxv3-agent-{= name =}
+      template:
+        metadata:
+          labels:
+            release_name: neutron
+            application: neutron
+            component: nsxv3
+            name: neutron-nsxv3-agent-{= name =}
+            vcenter: {= host =}
+            datacenter: {= availability_zone =}
+            vccluster: {= cluster_name =}
+          annotations:
+[0;31m-           configmap-etc-hash: d804d23560cc00cfee20fce94ce5b491b6c57bd26ee4fd7f3cd5adbfbc96e871[0m
+[0;32m+           configmap-etc-hash: 411229865bca0b45fb623df0a5ef0a0dd4c4a14064c3afa6bae3d1009b83818f[0m
+            prometheus.io/scrape: "true"
+            prometheus.io/targets: "openstack"          
+            linkerd.io/inject: enabled
+        spec:
+          containers:
+          - name: neutron-nsxv3-agent
+            image: keppel.eu-de-1.cloud.sap/ccloud/loci-neutron:yoga-20231220120402
+            imagePullPolicy: IfNotPresent
+            command: ["dumb-init"]
+            args: ["neutron-nsxv3-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/plugins/ml2/ml2-conf.ini", "--config-file", "/etc/neutron/plugins/ml2/ml2-nsxv3.ini"]
+            env:
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: sentry
+                  key: neutron.DSN.python
+            - name: PYTHONWARNINGS
+              value: "ignore:Unverified HTTPS request"
+            - name: PGAPPNAME
+              value: neutron-nsxv3-agent-{= name =}
+            - name: REQUESTS_CA_BUNDLE
+              value: ""
+            ports:
+              - name: metrics-agent
+                containerPort: 8000
+            livenessProbe:
+              exec:
+                command: ["neutron-agent-liveness", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/plugins/ml2/ml2-nsxv3.ini", "--agent-type", "NSXv3 Agent"]
+              initialDelaySeconds: 90
+              periodSeconds: 30
+              timeoutSeconds: 10
+            resources:
+              limits:
+                cpu: 256m
+                memory: 512Mi
+              requests:
+                cpu: 128m
+                memory: 256Mi
+            volumeMounts:
+            - name: etc-neutron
+              mountPath: /etc/neutron
+              readOnly: true
+          - name: exporter
+            image: keppel.eu-de-1.cloud.sap/ccloud/nsx-t-exporter:20220616123322
+            ports:
+              - name: metrics-export
+                containerPort: 9191
+            env:
+              {%- set bb = name | replace( "bb", "") | int %}
+              {%- set hostname = "nsx-ctl-" + "bb" + ( '%03d' % bb ) + "." + domain %}
+              - name: NSXV3_LOGIN_HOST
+                value: {= hostname =}
+              - name: NSXV3_LOGIN_PORT
+                value: "443"
+              - name: NSXV3_LOGIN_USER
+                value: "admin"
+              - name: NSXV3_LOGIN_PASSWORD
+                value: {= username | derive_password(hostname) | quote =}
+              - name: NSXV3_REQUESTS_PER_SECOND
+                value: "10"
+              - name: NSXV3_REQUEST_TIMEOUT_SECONDS
+                value: "120"
+              - name: NSXV3_CONNECTION_POOL_SIZE
+                value: "100"
+              - name: NSXV3_SUPPRESS_SSL_WARNINGS
+                value: "true"
+              - name: SCRAP_PORT
+                value: "9191"
+              - name: SCRAP_SCHEDULE_SECONDS
+                value: "300"
+            resources:
+              limits:
+                cpu: 128m
+                memory: 128Mi
+              requests:
+                cpu: 32m
+                memory: 64Mi
+          volumes:
+          - name: etc-neutron
+            projected:
+              defaultMode: 420
+              sources:
+              - configMap:
+                  name: neutron-etc
+                  items:
+                  - key: neutron.conf
+                    path: neutron.conf
+                  - key: logging.conf
+                    path: logging.conf
+                  - key: ml2-conf.ini
+                    path: plugins/ml2/ml2-conf.ini
+              - configMap:
+                  name: neutron-ml2-nsxv3-{= name =}
+                  items:
+                  - key: ml2-nsxv3.ini
+                    path: plugins/ml2/ml2-nsxv3.ini
+[0;33mmonsoon3, neutron-rpc-server, Deployment (apps) has changed:[0m
+  # Source: neutron/templates/deployment-rpc-server.yaml
+  kind: Deployment
+  apiVersion: apps/v1
+
+  metadata:
+    name: neutron-rpc-server
+    labels:
+      system: openstack
+      type: rpc
+      component: neutron
+    annotations:
+      vpa-butler.cloud.sap/main-container: neutron-rpc-server
+  spec:
+    replicas: 2
+    revisionHistoryLimit: 5
+    strategy:
+      type: RollingUpdate
+      
+      rollingUpdate:
+        maxUnavailable: 10%
+        maxSurge: 25%
+      
+    selector:
+      matchLabels:
+        name: neutron-rpc-server
+    template:
+      metadata:
+        labels:
+          name: neutron-rpc-server
+          release_name: neutron
+          application: neutron
+          component: rpc
+        annotations:
+[0;31m-         configmap-etc-hash: d804d23560cc00cfee20fce94ce5b491b6c57bd26ee4fd7f3cd5adbfbc96e871[0m
+[0;32m+         configmap-etc-hash: 411229865bca0b45fb623df0a5ef0a0dd4c4a14064c3afa6bae3d1009b83818f[0m
+          configmap-etc-region-hash: 10d539fe03ecd1358c101afca3a918a31da73335116cff34a8c6e3c297506403
+          configmap-etc-vendor-hash: 589f42ada9adf51757198ffe22bb3f86e8fb6224a8d5112fd83129e53a73b18a
+          configmap-bin-hash: b9fb770fa1d8492cd21f84aa755a40acc342e3bfdde7b3b84e24527c7b12e4be
+          configmap-etc-cc-fabric: fc8f785bce813634a987f4df3c47e510d42170329e0b81f14779ab8b59dfcd9b
+          prometheus.io/scrape: "true"
+          prometheus.io/targets: openstack        
+          linkerd.io/inject: enabled
+      spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 10
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchExpressions:
+                  - key: release_name
+                    operator: In
+                    values:
+                    - neutron
+                  - key: application
+                    operator: In
+                    values:
+                    - neutron
+                  - key: component
+                    operator: In
+                    values:
+                    - rpc      
+        hostAliases:
+        - ip: "127.0.0.1"
+          hostnames:
+          - "neutron-mariadb"
+        containers:
+          - name: neutron-rpc-server
+            image: keppel.eu-de-1.cloud.sap/ccloud/loci-neutron:yoga-20231220120402
+            imagePullPolicy: IfNotPresent
+            command: ['dumb-init', 'kubernetes-entrypoint']
+            env:
+              - name: COMMAND
+                value: "neutron-rpc-server --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/ml2-conf.ini --config-file /etc/neutron/plugins/ml2/ml2-conf-aci.ini --config-file /etc/neutron/plugins/ml2/ml2-conf-manila.ini --config-file /etc/neutron/plugins/ml2/ml2-conf-arista.ini --config-file /etc/neutron/plugins/ml2/ml2-conf-asr1k.ini --config-file /etc/neutron/networking-bgpvpn.conf --config-file /etc/neutron/networking-interconnection.conf --config-file /etc/neutron/plugins/ml2/ml2_conf_cc-fabric.ini"
+              - name: NAMESPACE
+                value: monsoon3
+              - name: DEPENDENCY_JOBS
+                value: "neutron-migration-yoga-20231220120402-unix-socket"
+              - name: DEPENDENCY_SERVICE
+                value: "neutron-mariadb,neutron-rabbitmq"
+              - name: STATSD_HOST
+                value: "localhost"
+              - name: STATSD_PORT
+                value: "9125"
+              - name: STATSD_PREFIX
+                value: "openstack"
+              - name: SENTRY_DSN
+                valueFrom:
+                  secretKeyRef:
+                    name: sentry
+                    key: neutron.DSN.python
+              - name: PGAPPNAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.name
+              - name: PYTHONWARNINGS
+                value: "ignore:Unverified HTTPS request"
+            resources:
+              limits:
+                cpu: 4000m
+                memory: 4Gi
+              requests:
+                cpu: 1000m
+                memory: 3Gi
+            volumeMounts:
+              - mountPath: /etc/neutron
+                name: empty-dir
+              - mountPath: /etc/neutron/neutron.conf
+                name: neutron-etc
+                subPath: neutron.conf
+                readOnly: true
+              - mountPath: /etc/neutron/logging.conf
+                name: neutron-etc
+                subPath: logging.conf
+                readOnly: true
+              - mountPath: /etc/neutron/plugins/ml2/ml2_conf_cc-fabric.ini
+                name: neutron-etc-cc-fabric
+                subPath: ml2_conf_cc-fabric.ini
+                readOnly: true
+              - mountPath: /etc/neutron/plugins/ml2/cc-fabric-driver-config.yaml
+                name: neutron-etc-cc-fabric
+                subPath: cc-fabric-driver-config.yaml
+                readOnly: true
+              - mountPath: /etc/neutron/plugins/ml2/ml2-conf.ini
+                name: neutron-etc
+                subPath: ml2-conf.ini
+                readOnly: true
+              - mountPath: /etc/neutron/plugins/ml2/ml2-conf-aci.ini
+                name: neutron-etc-region
+                subPath: ml2-conf-aci.ini
+                readOnly: true
+              - mountPath: /etc/neutron/plugins/ml2/ml2-conf-arista.ini
+                name: neutron-etc-vendor
+                subPath: ml2-conf-arista.ini
+                readOnly: true
+              - mountPath: /etc/neutron/plugins/ml2/ml2-conf-manila.ini
+                name: neutron-etc-vendor
+                subPath: ml2-conf-manila.ini
+                readOnly: true
+              - mountPath: /etc/neutron/plugins/ml2/ml2-conf-asr1k.ini
+                name: neutron-etc-vendor
+                subPath: ml2-conf-asr1k.ini
+                readOnly: true
+              - mountPath: /etc/neutron/networking-bgpvpn.conf
+                name: neutron-etc
+                subPath: networking-bgpvpn.conf
+                readOnly: true
+              - mountPath: /etc/neutron/networking-interconnection.conf
+                name: neutron-etc
+                subPath: networking-interconnection.conf
+                readOnly: true            
+              - mountPath: /run/proxysql
+                name: runproxysql                    
+          - name: proxysql
+            image: keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/proxysql/proxysql:2.4.7-debian
+            imagePullPolicy: IfNotPresent
+            command: ["proxysql"]
+            args: ["--config", "/etc/proxysql/proxysql.cnf", "--exit-on-error", "--foreground", "--idle-threads", "--admin-socket", "/run/proxysql/admin.sock", "--no-version-check", "-D", "/run/proxysql"]
+            lifecycle:
+              postStart:
+                exec:
+                  command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    for ((i=0;i<10;++i)); do
+                      test -S /run/proxysql/admin.sock && break || sleep 1
+                    done
+                    for ((i=0;i<10;++i)); do
+                      mysql --wait -S /run/proxysql/admin.sock -uadmin -padmin -e '
+                        UPDATE mysql_servers SET max_connections=225;
+                        LOAD MYSQL SERVERS TO RUNTIME;
+                      ' && exit 0 || sleep 1
+                    done
+                    exit 1
+            ports:
+            - name: metrics-psql
+              containerPort: 6070
+            livenessProbe:
+              exec:
+                command:
+                - test
+                - -S
+                - /run/proxysql/mysql.sock
+            volumeMounts:
+            - mountPath: /etc/proxysql
+              name: etcproxysql  
+            - mountPath: /run/proxysql
+              name: runproxysql          
+        volumes:
+          - name: empty-dir
+            emptyDir: {}
+          - name: neutron-etc
+            configMap:
+              name: neutron-etc
+          - name: neutron-etc-cc-fabric
+            configMap:
+              name: neutron-etc-cc-fabric
+          - name: neutron-etc-vendor
+            configMap:
+              name: neutron-etc-vendor
+          - name: neutron-etc-region
+            configMap:
+              name: neutron-etc-region
+          - name: neutron-bin
+            configMap:
+              name: neutron-bin
+              defaultMode: 0755        
+          - name: runproxysql
+            emptyDir: {}
+          - name: etcproxysql
+            configMap:
+              name: neutron-proxysql-etc
+[0;33mmonsoon3, neutron-server, Deployment (apps) has changed:[0m
+  # Source: neutron/templates/deployment-server.yaml
+  kind: Deployment
+  apiVersion: apps/v1
+
+  metadata:
+    name: neutron-server
+    labels:
+      system: openstack
+      type: api
+      component: neutron
+    annotations:
+      vpa-butler.cloud.sap/main-container: neutron-server
+  spec:
+    replicas: 3
+    revisionHistoryLimit: 5
+    strategy:
+      type: RollingUpdate
+      
+      rollingUpdate:
+        maxUnavailable: 10%
+        maxSurge: 25%
+      
+    selector:
+      matchLabels:
+        name: neutron-server
+    template:
+      metadata:
+        labels:
+          name: neutron-server
+          release_name: neutron
+          application: neutron
+          component: api
+        annotations:
+[0;31m-         configmap-etc-hash: d804d23560cc00cfee20fce94ce5b491b6c57bd26ee4fd7f3cd5adbfbc96e871[0m
+[0;32m+         configmap-etc-hash: 411229865bca0b45fb623df0a5ef0a0dd4c4a14064c3afa6bae3d1009b83818f[0m
+          configmap-etc-region-hash: 10d539fe03ecd1358c101afca3a918a31da73335116cff34a8c6e3c297506403
+          configmap-etc-vendor-hash: 589f42ada9adf51757198ffe22bb3f86e8fb6224a8d5112fd83129e53a73b18a        
+          linkerd.io/inject: enabled
+          configmap-etc-api-hash: 9732626a5eb1a44b37bb12318aa6e19b9c0132ccb7164fe69014588bacc4308f
+          configmap-etc-cc-fabric: fc8f785bce813634a987f4df3c47e510d42170329e0b81f14779ab8b59dfcd9b
+          prometheus.io/scrape: "true"
+          prometheus.io/targets: openstack
+      spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 10
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchExpressions:
+                  - key: release_name
+                    operator: In
+                    values:
+                    - neutron
+                  - key: application
+                    operator: In
+                    values:
+                    - neutron
+                  - key: component
+                    operator: In
+                    values:
+                    - api      
+        hostAliases:
+        - ip: "127.0.0.1"
+          hostnames:
+          - "neutron-mariadb"
+        containers:
+          - name: neutron-server
+            image: keppel.eu-de-1.cloud.sap/ccloud/loci-neutron:yoga-20231220120402
+            imagePullPolicy: IfNotPresent
+            lifecycle:
+              preStop:              
+                exec:
+                  command: [
+                    # Introduce a delay to the shutdown sequence to wait for the
+                    # pod eviction event to propagate.
+                    "/bin/sleep",
+                    "10"
+                  ]
+            readinessProbe:
+              httpGet:
+                path: /healthcheck
+                port: 9696
+              initialDelaySeconds: 15
+              timeoutSeconds: 5
+            command: ['dumb-init', 'kubernetes-entrypoint']
+            env:
+              - name: COMMAND
+                value: "uwsgi --ini /etc/neutron/uwsgi.ini"
+              - name: DEBUG_CONTAINER
+                value: "false"
+              - name: OS_OSLO_MESSAGING_RABBIT__HEARTBEAT_IN_PTHREAD
+                value: "true"
+              - name: NAMESPACE
+                value: monsoon3
+              - name: DEPENDENCY_JOBS
+                value: "neutron-migration-yoga-20231220120402-unix-socket"
+              - name: DEPENDENCY_SERVICE
+                value: "neutron-mariadb,neutron-rabbitmq"
+              - name: STATSD_HOST
+                value: "localhost"
+              - name: STATSD_PORT
+                value: "9125"
+              - name: STATSD_PREFIX
+                value: "openstack"
+              - name: SENTRY_DSN
+                valueFrom:
+                  secretKeyRef:
+                    name: sentry
+                    key: neutron.DSN.python
+              - name: PGAPPNAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.name
+              - name: PYTHONWARNINGS
+                value: "ignore:Unverified HTTPS request"
+            resources:
+              limits:
+                cpu: 4000m
+                memory: 3Gi
+              requests:
+                cpu: 2000m
+                memory: 2Gi
+            ports:
+              - name: neutron-api
+                containerPort: 9696
+            volumeMounts:
+              - mountPath: /etc/neutron
+                name: empty-dir
+              - mountPath: /etc/neutron/neutron.conf
+                name: neutron-etc
+                subPath: neutron.conf
+                readOnly: true
+              - mountPath: /etc/neutron/plugins/asr1k-global.ini
+                name: neutron-etc
+                subPath: asr1k-global.ini
+                readOnly: true
+              - mountPath: /etc/neutron/policy.json
+                name: neutron-etc
+                subPath: neutron-policy.json
+                readOnly: true
+              - mountPath: /etc/neutron/rootwrap.conf
+                name: neutron-etc
+                subPath: rootwrap.conf
+                readOnly: true
+              - mountPath: /etc/neutron/api-paste.ini
+                name: neutron-etc
+                subPath: api-paste.ini
+                readOnly: true
+              - mountPath: /etc/neutron/logging.conf
+                name: neutron-etc
+                subPath: logging.conf
+                readOnly: true
+              - mountPath: /etc/neutron/plugins/ml2/ml2_conf_cc-fabric.ini
+                name: neutron-etc-cc-fabric
+                subPath: ml2_conf_cc-fabric.ini
+                readOnly: true
+              - mountPath: /etc/neutron/plugins/ml2/cc-fabric-driver-config.yaml
+                name: neutron-etc-cc-fabric
+                subPath: cc-fabric-driver-config.yaml
+                readOnly: true
+              - mountPath: /etc/neutron/plugins/ml2/ml2-conf.ini
+                name: neutron-etc
+                subPath: ml2-conf.ini
+                readOnly: true
+              - mountPath: /etc/neutron/plugins/ml2/ml2-conf-aci.ini
+                name: neutron-etc-region
+                subPath: ml2-conf-aci.ini
+                readOnly: true
+              - mountPath: /etc/neutron/plugins/ml2/ml2-conf-arista.ini
+                name: neutron-etc-vendor
+                subPath: ml2-conf-arista.ini
+                readOnly: true
+              - mountPath: /etc/neutron/plugins/ml2/ml2-conf-manila.ini
+                name: neutron-etc-vendor
+                subPath: ml2-conf-manila.ini
+                readOnly: true
+              - mountPath: /etc/neutron/plugins/ml2/ml2-conf-asr1k.ini
+                name: neutron-etc-vendor
+                subPath: ml2-conf-asr1k.ini
+                readOnly: true
+              - mountPath: /etc/neutron/networking-bgpvpn.conf
+                name: neutron-etc
+                subPath: networking-bgpvpn.conf
+                readOnly: true
+              - mountPath: /etc/neutron/networking-interconnection.conf
+                name: neutron-etc
+                subPath: networking-interconnection.conf
+                readOnly: true
+              - mountPath: /etc/neutron/neutron_audit_map.yaml
+                name: neutron-etc
+                subPath: neutron_audit_map.yaml
+                readOnly: true
+              - mountPath: /etc/neutron/watcher.yaml
+                name: neutron-etc
+                subPath: watcher.yaml
+                readOnly: true
+              - mountPath: /etc/neutron/ratelimit.yaml
+                name: neutron-etc
+                subPath: ratelimit.yaml
+                readOnly: true
+              - mountPath: /etc/neutron/uwsgi.ini
+                name: neutron-etc-api
+                subPath: uwsgi.ini
+                readOnly: true            
+              - mountPath: /run/proxysql
+                name: runproxysql                    
+          - name: proxysql
+            image: keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/proxysql/proxysql:2.4.7-debian
+            imagePullPolicy: IfNotPresent
+            command: ["proxysql"]
+            args: ["--config", "/etc/proxysql/proxysql.cnf", "--exit-on-error", "--foreground", "--idle-threads", "--admin-socket", "/run/proxysql/admin.sock", "--no-version-check", "-D", "/run/proxysql"]
+            lifecycle:
+              postStart:
+                exec:
+                  command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    for ((i=0;i<10;++i)); do
+                      test -S /run/proxysql/admin.sock && break || sleep 1
+                    done
+                    for ((i=0;i<10;++i)); do
+                      mysql --wait -S /run/proxysql/admin.sock -uadmin -padmin -e '
+                        UPDATE mysql_servers SET max_connections=120;
+                        LOAD MYSQL SERVERS TO RUNTIME;
+                      ' && exit 0 || sleep 1
+                    done
+                    exit 1
+            ports:
+            - name: metrics-psql
+              containerPort: 6070
+            livenessProbe:
+              exec:
+                command:
+                - test
+                - -S
+                - /run/proxysql/mysql.sock
+            volumeMounts:
+            - mountPath: /etc/proxysql
+              name: etcproxysql  
+            - mountPath: /run/proxysql
+              name: runproxysql  
+          - name: statsd
+            image: keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/prom/statsd-exporter:v0.8.1
+            imagePullPolicy: IfNotPresent
+            args: [ --statsd.mapping-config=/etc/statsd/statsd-exporter.yaml ]
+            ports:
+              - name: statsd
+                containerPort: 9125
+                protocol: UDP
+              - name: metrics
+                containerPort: 9102
+            resources:
+              limits:
+                cpu: 128m
+                memory: 128Mi
+              requests:
+                cpu: 64m
+                memory: 64Mi
+            volumeMounts:
+              - name: neutron-etc
+                mountPath: /etc/statsd/statsd-exporter.yaml
+                subPath: statsd-exporter.yaml
+                readOnly: true        
+        volumes:
+          - name: empty-dir
+            emptyDir: {}
+          - name: neutron-etc
+            configMap:
+              name: neutron-etc
+          - name: neutron-etc-cc-fabric
+            configMap:
+              name: neutron-etc-cc-fabric
+          - name: neutron-etc-vendor
+            configMap:
+              name: neutron-etc-vendor
+          - name: neutron-etc-region
+            configMap:
+              name: neutron-etc-region
+          - name: neutron-etc-api
+            configMap:
+              name: neutron-etc-api
+          - name: container-init
+            configMap:
+              name: neutron-bin
+              defaultMode: 0755        
+          - name: runproxysql
+            emptyDir: {}
+          - name: etcproxysql
+            configMap:
+              name: neutron-proxysql-etc
+[0;33mmonsoon3, neutron-swift-injector-ap001, StatefulSet (apps) has changed:[0m
+  # Source: neutron/templates/statefulset-swift-injector.yaml
+  apiVersion: apps/v1
+  kind: StatefulSet
+  metadata:
+    name: neutron-swift-injector-ap001
+    labels:
+      system: openstack
+      application: neutron
+      component: swift-injector
+  spec:
+    updateStrategy:
+      type: RollingUpdate
+    selector:
+      matchLabels:
+        name: neutron-swift-injector-ap001
+    serviceName: neutron-swift-injector
+    podManagementPolicy: "Parallel"
+    replicas: 1
+    template:
+      metadata:
+        annotations:
+          k8s.v1.cni.cncf.io/networks: '[{ "name": "cbr1-bridge", "interface":"bond1" }]'
+[0;31m-         configmap-etc-hash: d804d23560cc00cfee20fce94ce5b491b6c57bd26ee4fd7f3cd5adbfbc96e871[0m
+[0;32m+         configmap-etc-hash: 411229865bca0b45fb623df0a5ef0a0dd4c4a14064c3afa6bae3d1009b83818f[0m
+          configmap-etc-apod-hash: bebf8c0481441a33bb1a13bc60dbfb73daa87b95a574bec00b7de7611c9e178d
+          prometheus.io/scrape: "true"
+          prometheus.io/targets: openstack
+        labels:
+          name: neutron-swift-injector-ap001
+          release_name: neutron
+          application: neutron
+          component: swift-injector
+      spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 50
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchExpressions:
+                  - key: component
+                    operator: In
+                    values:
+                    - agent
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.cloud.sap/host
+                labelSelector:
+                  matchExpressions:
+                  - key: component
+                    operator: In
+                    values:
+                    - agent
+        nodeSelector:
+          multus: bond1
+          topology.kubernetes.io/zone: qa-de-1a
+          kubernetes.cloud.sap/apod: ap001
+        containers:
+          - name: swift-agent
+            image: keppel.eu-de-1.cloud.sap/ccloud/network-injector:latest
+            imagePullPolicy: IfNotPresent
+            command:
+              - "dumb-init"
+              - "/manager"
+              - "-upstream-host"
+              - "objectstore-3.qa-de-1.cloud.sap"
+              - "-network-tag"
+              - "cc-swift-injector-ap001"
+              - "-injector-dns"
+              - "swift"
+            env:
+              - name: OS_AUTH_URL
+                value: http://keystone.monsoon3.svc.kubernetes.qa-de-1.cloud.sap:5000/v3
+              - name: OS_DOMAIN_NAME
+                value: Default
+              - name: OS_USERNAME
+                value: neutron
+              - name: OS_PASSWORD
+                value: kiedaiYaik4quohf3Bae
+              - name: OS_REGION_NAME
+                value: qa-de-1
+              - name: OS_TENANT_NAME
+                value: service
+              - name: OS_USER_DOMAIN_NAME
+                value: Default
+            securityContext:
+              privileged: true
+            volumeMounts:
+              - name: network-namespace
+                mountPath: /var/run/netns
+              - name: socat-proxy
+                mountPath: /var/run/socat-proxy
+            ports:
+              - name: metrics-inject
+                containerPort: 8080
+            livenessProbe:
+              httpGet:
+                path: /healthz
+                port: metrics-inject
+          - name: neutron-linuxbridge-agent
+            image: keppel.eu-de-1.cloud.sap/ccloud/loci-neutron:yoga-20231220120402
+            imagePullPolicy: IfNotPresent
+            command: ["dumb-init", "neutron-linuxbridge-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/plugins/ml2/ml2_conf.ini", "--config-file", "/etc/neutron/linux-bridge.ini", "--config-file", "/etc/neutron/apod-ap001.conf"]
+            env:
+              - name: SENTRY_DSN
+                valueFrom:
+                  secretKeyRef:
+                    name: sentry
+                    key: neutron.DSN.python
+              - name: DEBUG_CONTAINER
+                value: "false"
+              - name: PYTHONWARNINGS
+                value: "ignore:Unverified HTTPS request"
+            readinessProbe:
+              exec:
+                command: ["neutron-agent-liveness", "-config-file", "/etc/neutron/neutron.conf", "-agent-type", "Linux bridge agent"]
+              initialDelaySeconds: 30
+              periodSeconds: 60
+              timeoutSeconds: 10
+            securityContext:
+              capabilities:
+                add:
+                  - NET_ADMIN
+                  - SYS_ADMIN
+                  - DAC_OVERRIDE
+                  - DAC_READ_SEARCH
+                  - SYS_PTRACE
+            resources:
+              limits:
+                cpu: 2000m
+                memory: 1Gi
+              requests:
+                cpu: 256m
+                memory: 512Mi
+            volumeMounts:
+              - mountPath: /lib/modules
+                name: modules
+                readOnly: true
+              - name: etc-neutron-linuxbridge-agent
+                mountPath: /etc/neutron
+                readOnly: true
+              - name: neutron-etc
+                mountPath: /etc/sudoers
+                subPath: sudoers
+                readOnly: true
+              - name: network-namespace
+                mountPath: /var/run/netns
+          - name: socat
+            image: keppel.eu-de-1.cloud.sap/ccloud/network-injector:latest
+            imagePullPolicy: IfNotPresent
+            command:
+              - "dumb-init"
+              - "socat"
+              - "UNIX-LISTEN:/var/run/socat-proxy/proxy.sock,fork,reuseaddr,unlink-early,user=nobody,group=nobody,mode=777"
+              - "TCP:swift-proxy-internal-cluster-3.swift.svc.kubernetes.qa-de-1.cloud.sap:8080"
+            volumeMounts:
+              - name: socat-proxy
+                mountPath: /var/run/socat-proxy
+        volumes:
+          - name: network-namespace
+            emptyDir: {}
+          - name: socat-proxy
+            emptyDir: {}
+          - name: modules
+            hostPath:
+              path: /lib/modules
+          - name: neutron-etc
+            configMap:
+              name: neutron-etc
+          - name: etc-neutron-linuxbridge-agent
+            projected:
+              defaultMode: 420
+              sources:
+              - configMap:
+                  name: neutron-etc
+                  items:
+                  - key: neutron.conf
+                    path: neutron.conf
+                  - key: logging.conf
+                    path: logging.conf
+                  - key: rootwrap.conf
+                    path: rootwrap.conf
+                  - key: linux-bridge.ini
+                    path: linux-bridge.ini
+                  - key: ml2-conf.ini
+                    path: plugins/ml2/ml2_conf.ini
+              - configMap:
+                  name: neutron-etc-apod
+                  items:
+                  - key: apod-ap001.conf
+                    path: apod-ap001.conf
+[0;33mmonsoon3, neutron-swift-injector-ap002, StatefulSet (apps) has changed:[0m
+  # Source: neutron/templates/statefulset-swift-injector.yaml
+  apiVersion: apps/v1
+  kind: StatefulSet
+  metadata:
+    name: neutron-swift-injector-ap002
+    labels:
+      system: openstack
+      application: neutron
+      component: swift-injector
+  spec:
+    updateStrategy:
+      type: RollingUpdate
+    selector:
+      matchLabels:
+        name: neutron-swift-injector-ap002
+    serviceName: neutron-swift-injector
+    podManagementPolicy: "Parallel"
+    replicas: 1
+    template:
+      metadata:
+        annotations:
+          k8s.v1.cni.cncf.io/networks: '[{ "name": "cbr1-bridge", "interface":"bond1" }]'
+[0;31m-         configmap-etc-hash: d804d23560cc00cfee20fce94ce5b491b6c57bd26ee4fd7f3cd5adbfbc96e871[0m
+[0;32m+         configmap-etc-hash: 411229865bca0b45fb623df0a5ef0a0dd4c4a14064c3afa6bae3d1009b83818f[0m
+          configmap-etc-apod-hash: bebf8c0481441a33bb1a13bc60dbfb73daa87b95a574bec00b7de7611c9e178d
+          prometheus.io/scrape: "true"
+          prometheus.io/targets: openstack
+        labels:
+          name: neutron-swift-injector-ap002
+          release_name: neutron
+          application: neutron
+          component: swift-injector
+      spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 50
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchExpressions:
+                  - key: component
+                    operator: In
+                    values:
+                    - agent
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.cloud.sap/host
+                labelSelector:
+                  matchExpressions:
+                  - key: component
+                    operator: In
+                    values:
+                    - agent
+        nodeSelector:
+          multus: bond1
+          topology.kubernetes.io/zone: qa-de-1b
+          kubernetes.cloud.sap/apod: ap002
+        containers:
+          - name: swift-agent
+            image: keppel.eu-de-1.cloud.sap/ccloud/network-injector:latest
+            imagePullPolicy: IfNotPresent
+            command:
+              - "dumb-init"
+              - "/manager"
+              - "-upstream-host"
+              - "objectstore-3.qa-de-1.cloud.sap"
+              - "-network-tag"
+              - "cc-swift-injector-ap002"
+              - "-injector-dns"
+              - "swift"
+            env:
+              - name: OS_AUTH_URL
+                value: http://keystone.monsoon3.svc.kubernetes.qa-de-1.cloud.sap:5000/v3
+              - name: OS_DOMAIN_NAME
+                value: Default
+              - name: OS_USERNAME
+                value: neutron
+              - name: OS_PASSWORD
+                value: kiedaiYaik4quohf3Bae
+              - name: OS_REGION_NAME
+                value: qa-de-1
+              - name: OS_TENANT_NAME
+                value: service
+              - name: OS_USER_DOMAIN_NAME
+                value: Default
+            securityContext:
+              privileged: true
+            volumeMounts:
+              - name: network-namespace
+                mountPath: /var/run/netns
+              - name: socat-proxy
+                mountPath: /var/run/socat-proxy
+            ports:
+              - name: metrics-inject
+                containerPort: 8080
+            livenessProbe:
+              httpGet:
+                path: /healthz
+                port: metrics-inject
+          - name: neutron-linuxbridge-agent
+            image: keppel.eu-de-1.cloud.sap/ccloud/loci-neutron:yoga-20231220120402
+            imagePullPolicy: IfNotPresent
+            command: ["dumb-init", "neutron-linuxbridge-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/plugins/ml2/ml2_conf.ini", "--config-file", "/etc/neutron/linux-bridge.ini", "--config-file", "/etc/neutron/apod-ap002.conf"]
+            env:
+              - name: SENTRY_DSN
+                valueFrom:
+                  secretKeyRef:
+                    name: sentry
+                    key: neutron.DSN.python
+              - name: DEBUG_CONTAINER
+                value: "false"
+              - name: PYTHONWARNINGS
+                value: "ignore:Unverified HTTPS request"
+            readinessProbe:
+              exec:
+                command: ["neutron-agent-liveness", "-config-file", "/etc/neutron/neutron.conf", "-agent-type", "Linux bridge agent"]
+              initialDelaySeconds: 30
+              periodSeconds: 60
+              timeoutSeconds: 10
+            securityContext:
+              capabilities:
+                add:
+                  - NET_ADMIN
+                  - SYS_ADMIN
+                  - DAC_OVERRIDE
+                  - DAC_READ_SEARCH
+                  - SYS_PTRACE
+            resources:
+              limits:
+                cpu: 2000m
+                memory: 1Gi
+              requests:
+                cpu: 256m
+                memory: 512Mi
+            volumeMounts:
+              - mountPath: /lib/modules
+                name: modules
+                readOnly: true
+              - name: etc-neutron-linuxbridge-agent
+                mountPath: /etc/neutron
+                readOnly: true
+              - name: neutron-etc
+                mountPath: /etc/sudoers
+                subPath: sudoers
+                readOnly: true
+              - name: network-namespace
+                mountPath: /var/run/netns
+          - name: socat
+            image: keppel.eu-de-1.cloud.sap/ccloud/network-injector:latest
+            imagePullPolicy: IfNotPresent
+            command:
+              - "dumb-init"
+              - "socat"
+              - "UNIX-LISTEN:/var/run/socat-proxy/proxy.sock,fork,reuseaddr,unlink-early,user=nobody,group=nobody,mode=777"
+              - "TCP:swift-proxy-internal-cluster-3.swift.svc.kubernetes.qa-de-1.cloud.sap:8080"
+            volumeMounts:
+              - name: socat-proxy
+                mountPath: /var/run/socat-proxy
+        volumes:
+          - name: network-namespace
+            emptyDir: {}
+          - name: socat-proxy
+            emptyDir: {}
+          - name: modules
+            hostPath:
+              path: /lib/modules
+          - name: neutron-etc
+            configMap:
+              name: neutron-etc
+          - name: etc-neutron-linuxbridge-agent
+            projected:
+              defaultMode: 420
+              sources:
+              - configMap:
+                  name: neutron-etc
+                  items:
+                  - key: neutron.conf
+                    path: neutron.conf
+                  - key: logging.conf
+                    path: logging.conf
+                  - key: rootwrap.conf
+                    path: rootwrap.conf
+                  - key: linux-bridge.ini
+                    path: linux-bridge.ini
+                  - key: ml2-conf.ini
+                    path: plugins/ml2/ml2_conf.ini
+              - configMap:
+                  name: neutron-etc-apod
+                  items:
+                  - key: apod-ap002.conf
+                    path: apod-ap002.conf
+[0;33mmonsoon3, neutron-swift-injector-ap028, StatefulSet (apps) has changed:[0m
+  # Source: neutron/templates/statefulset-swift-injector.yaml
+  apiVersion: apps/v1
+  kind: StatefulSet
+  metadata:
+    name: neutron-swift-injector-ap028
+    labels:
+      system: openstack
+      application: neutron
+      component: swift-injector
+  spec:
+    updateStrategy:
+      type: RollingUpdate
+    selector:
+      matchLabels:
+        name: neutron-swift-injector-ap028
+    serviceName: neutron-swift-injector
+    podManagementPolicy: "Parallel"
+    replicas: 1
+    template:
+      metadata:
+        annotations:
+          k8s.v1.cni.cncf.io/networks: '[{ "name": "cbr1-bridge", "interface":"bond1" }]'
+[0;31m-         configmap-etc-hash: d804d23560cc00cfee20fce94ce5b491b6c57bd26ee4fd7f3cd5adbfbc96e871[0m
+[0;32m+         configmap-etc-hash: 411229865bca0b45fb623df0a5ef0a0dd4c4a14064c3afa6bae3d1009b83818f[0m
+          configmap-etc-apod-hash: bebf8c0481441a33bb1a13bc60dbfb73daa87b95a574bec00b7de7611c9e178d
+          prometheus.io/scrape: "true"
+          prometheus.io/targets: openstack
+        labels:
+          name: neutron-swift-injector-ap028
+          release_name: neutron
+          application: neutron
+          component: swift-injector
+      spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 50
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchExpressions:
+                  - key: component
+                    operator: In
+                    values:
+                    - agent
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.cloud.sap/host
+                labelSelector:
+                  matchExpressions:
+                  - key: component
+                    operator: In
+                    values:
+                    - agent
+        nodeSelector:
+          multus: bond1
+          topology.kubernetes.io/zone: qa-de-1d
+          kubernetes.cloud.sap/apod: ap028
+        containers:
+          - name: swift-agent
+            image: keppel.eu-de-1.cloud.sap/ccloud/network-injector:latest
+            imagePullPolicy: IfNotPresent
+            command:
+              - "dumb-init"
+              - "/manager"
+              - "-upstream-host"
+              - "objectstore-3.qa-de-1.cloud.sap"
+              - "-network-tag"
+              - "cc-swift-injector-ap028"
+              - "-injector-dns"
+              - "swift"
+            env:
+              - name: OS_AUTH_URL
+                value: http://keystone.monsoon3.svc.kubernetes.qa-de-1.cloud.sap:5000/v3
+              - name: OS_DOMAIN_NAME
+                value: Default
+              - name: OS_USERNAME
+                value: neutron
+              - name: OS_PASSWORD
+                value: kiedaiYaik4quohf3Bae
+              - name: OS_REGION_NAME
+                value: qa-de-1
+              - name: OS_TENANT_NAME
+                value: service
+              - name: OS_USER_DOMAIN_NAME
+                value: Default
+            securityContext:
+              privileged: true
+            volumeMounts:
+              - name: network-namespace
+                mountPath: /var/run/netns
+              - name: socat-proxy
+                mountPath: /var/run/socat-proxy
+            ports:
+              - name: metrics-inject
+                containerPort: 8080
+            livenessProbe:
+              httpGet:
+                path: /healthz
+                port: metrics-inject
+          - name: neutron-linuxbridge-agent
+            image: keppel.eu-de-1.cloud.sap/ccloud/loci-neutron:yoga-20231220120402
+            imagePullPolicy: IfNotPresent
+            command: ["dumb-init", "neutron-linuxbridge-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/plugins/ml2/ml2_conf.ini", "--config-file", "/etc/neutron/linux-bridge.ini", "--config-file", "/etc/neutron/apod-ap028.conf"]
+            env:
+              - name: SENTRY_DSN
+                valueFrom:
+                  secretKeyRef:
+                    name: sentry
+                    key: neutron.DSN.python
+              - name: DEBUG_CONTAINER
+                value: "false"
+              - name: PYTHONWARNINGS
+                value: "ignore:Unverified HTTPS request"
+            readinessProbe:
+              exec:
+                command: ["neutron-agent-liveness", "-config-file", "/etc/neutron/neutron.conf", "-agent-type", "Linux bridge agent"]
+              initialDelaySeconds: 30
+              periodSeconds: 60
+              timeoutSeconds: 10
+            securityContext:
+              capabilities:
+                add:
+                  - NET_ADMIN
+                  - SYS_ADMIN
+                  - DAC_OVERRIDE
+                  - DAC_READ_SEARCH
+                  - SYS_PTRACE
+            resources:
+              limits:
+                cpu: 2000m
+                memory: 1Gi
+              requests:
+                cpu: 256m
+                memory: 512Mi
+            volumeMounts:
+              - mountPath: /lib/modules
+                name: modules
+                readOnly: true
+              - name: etc-neutron-linuxbridge-agent
+                mountPath: /etc/neutron
+                readOnly: true
+              - name: neutron-etc
+                mountPath: /etc/sudoers
+                subPath: sudoers
+                readOnly: true
+              - name: network-namespace
+                mountPath: /var/run/netns
+          - name: socat
+            image: keppel.eu-de-1.cloud.sap/ccloud/network-injector:latest
+            imagePullPolicy: IfNotPresent
+            command:
+              - "dumb-init"
+              - "socat"
+              - "UNIX-LISTEN:/var/run/socat-proxy/proxy.sock,fork,reuseaddr,unlink-early,user=nobody,group=nobody,mode=777"
+              - "TCP:swift-proxy-internal-cluster-3.swift.svc.kubernetes.qa-de-1.cloud.sap:8080"
+            volumeMounts:
+              - name: socat-proxy
+                mountPath: /var/run/socat-proxy
+        volumes:
+          - name: network-namespace
+            emptyDir: {}
+          - name: socat-proxy
+            emptyDir: {}
+          - name: modules
+            hostPath:
+              path: /lib/modules
+          - name: neutron-etc
+            configMap:
+              name: neutron-etc
+          - name: etc-neutron-linuxbridge-agent
+            projected:
+              defaultMode: 420
+              sources:
+              - configMap:
+                  name: neutron-etc
+                  items:
+                  - key: neutron.conf
+                    path: neutron.conf
+                  - key: logging.conf
+                    path: logging.conf
+                  - key: rootwrap.conf
+                    path: rootwrap.conf
+                  - key: linux-bridge.ini
+                    path: linux-bridge.ini
+                  - key: ml2-conf.ini
+                    path: plugins/ml2/ml2_conf.ini
+              - configMap:
+                  name: neutron-etc-apod
+                  items:
+                  - key: apod-ap028.conf
+                    path: apod-ap028.conf

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -713,7 +713,7 @@ rate_limit:
           limit: 52r/m
       security-group-rules/security-group-rule:
         - action: read
-          limit: 650r/m
+          limit: 2000r/m
         - action: write
           limit: 83r/m
       security-groups:


### PR DESCRIPTION
A customer periodically fetches all information stored in the database
 about networks, routers, security groups and security rules.
For security rules the calculated limits are not high enough. They have a maximum number of 1165 SGR.
Adapt the value of the operation <security-group-rules/security-group-rule, list> to 2000 as set for the tuple <security-groups, list>.