### PR TITLE
alert move and version bump

### DIFF
--- a/common/thanos/Chart.yaml
+++ b/common/thanos/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: thanos
 description: Deploy Thanos via operator
 type: application
-version: 0.6.10
-appVersion: v0.31.0
+version: 0.6.11
+appVersion: v0.32.5
 maintainers:
   - name: Tommy Sauer (viennaa)
   - name: Richard Tief (richardtief)

--- a/common/thanos/templates/alerts/_thanos-compactor.alerts.tpl
+++ b/common/thanos/templates/alerts/_thanos-compactor.alerts.tpl
@@ -109,17 +109,3 @@ groups:
           Thanos Compact `{{`{{ $labels.thanos }}`}}` has disappeared.
           Prometheus target for the component cannot be discovered.
         summary: Thanos component has disappeared.
-
-    - alert: ThanosCompactSpawningMultiplePods
-      expr: count by (region, namespace, thanos, cluster) (label_replace(kube_pod_info{pod=~"thanos-{{ include "thanos.name" . }}-compactor-*.+"}, "thanos", "$2", "pod", "(thanos-)(.+)(-compactor.+)")) > 1
-      for: 30m
-      labels:
-        service: {{ default "metrics" $root.Values.alerts.service }}
-        support_group: {{ default "observability" $root.Values.alerts.support_group }}
-        severity: info
-        playbook: docs/support/playbook/prometheus/thanos_compaction/#thanos-compact-halted
-        meta: Thanos compact `{{`{{ $labels.thanos }}`}}` in `{{`{{ $labels.namespace }}`}}` is spawning more than one pod.
-      annotations:
-        description: |
-          Compactor `thanos-{{`{{ $labels.thanos }}`}}-compactor` is having a problem in `{{`{{ $labels.cluster }}`}}`/`{{`{{ $labels.namespace }}`}}`. If it is more than one erroring pod, check if there is a block storage issue and tidy up the broken pods. Otherwise just remove the single pod.
-        summary: Thanos compact is spawning more than one pod.


### PR DESCRIPTION
alert needs to move to respective regional thanos. since it is pushed to every thanos it is missing the kube_pod_info. We want it centrally only