### PR TITLE
moving alert to regional and version bump

### DIFF
--- a/common/thanos/Chart.yaml
+++ b/common/thanos/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: thanos
 description: Deploy Thanos via operator
 type: application
-version: 0.6.10
-appVersion: v0.31.0
+version: 0.6.11
+appVersion: v0.32.5
 maintainers:
   - name: Tommy Sauer (viennaa)
   - name: Richard Tief (richardtief)

--- a/common/thanos/templates/alerts/_thanos-compactor.alerts.tpl
+++ b/common/thanos/templates/alerts/_thanos-compactor.alerts.tpl
@@ -109,17 +109,3 @@ groups:
           Thanos Compact `{{`{{ $labels.thanos }}`}}` has disappeared.
           Prometheus target for the component cannot be discovered.
         summary: Thanos component has disappeared.
-
-    - alert: ThanosCompactSpawningMultiplePods
-      expr: count by (region, namespace, thanos, cluster) (label_replace(kube_pod_info{pod=~"thanos-{{ include "thanos.name" . }}-compactor-*.+"}, "thanos", "$2", "pod", "(thanos-)(.+)(-compactor.+)")) > 1
-      for: 30m
-      labels:
-        service: {{ default "metrics" $root.Values.alerts.service }}
-        support_group: {{ default "observability" $root.Values.alerts.support_group }}
-        severity: info
-        playbook: docs/support/playbook/prometheus/thanos_compaction/#thanos-compact-halted
-        meta: Thanos compact `{{`{{ $labels.thanos }}`}}` in `{{`{{ $labels.namespace }}`}}` is spawning more than one pod.
-      annotations:
-        description: |
-          Compactor `thanos-{{`{{ $labels.thanos }}`}}-compactor` is having a problem in `{{`{{ $labels.cluster }}`}}`/`{{`{{ $labels.namespace }}`}}`. If it is more than one erroring pod, check if there is a block storage issue and tidy up the broken pods. Otherwise just remove the single pod.
-        summary: Thanos compact is spawning more than one pod.

--- a/system/thanos-metal/Chart.lock
+++ b/system/thanos-metal/Chart.lock
@@ -9,4 +9,4 @@ dependencies:
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
 digest: sha256:08e227a96955f182d4e5816da5fb9a7a7cce5f4f727358f26f540d2e7e5b5a88
-generated: "2023-12-19T14:20:06.339763+01:00"
+generated: "2024-01-04T10:15:40.892855+01:00"

--- a/system/thanos-metal/Chart.yaml
+++ b/system/thanos-metal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos-metal-and-regional
 description: Deploy Thanos metal and regional via operator
 type: application
-version: 0.3.8
+version: 0.3.9
 dependencies:
   - name: thanos
     repository: https://charts.eu-de-2.cloud.sap

--- a/system/thanos-metal/alerts/thanos-regional.alerts
+++ b/system/thanos-metal/alerts/thanos-regional.alerts
@@ -1,0 +1,16 @@
+groups:
+- name: thanos-regional.alerts
+  rules:
+  - alert: ThanosCompactSpawningMultiplePods
+    expr: count by (region, namespace, thanos, cluster) (label_replace(kube_pod_info{pod=~"thanos-.+-compactor-*.+"}, "thanos", "$2", "pod", "(thanos-)(.+)(-compactor.+)")) > 1
+    for: 30m
+    labels:
+      service: metrics 
+      support_group: observability 
+      severity: info
+      playbook: docs/support/playbook/prometheus/thanos_compaction/#thanos-compact-halted
+      meta: Thanos compact `{{`{{ $labels.thanos }}`}}` in `{{`{{ $labels.namespace }}`}}` is spawning more than one pod.
+    annotations:
+      description: |
+        Compactor `thanos-{{`{{ $labels.thanos }}`}}-compactor` is having a problem in `{{`{{ $labels.cluster }}`}}`/`{{`{{ $labels.namespace }}`}}`. If it is more than one erroring pod, check if there is a block storage issue and tidy up the broken pods. Otherwise just remove the single pod.
+      summary: Thanos compact is spawning more than one pod.

--- a/system/thanos-metal/templates/alerts_regional.yaml
+++ b/system/thanos-metal/templates/alerts_regional.yaml
@@ -1,0 +1,18 @@
+{{/* Generate Thanos Alert Rules for regional Thanos*/}}
+{{- $values := .Values.regional_thanos.ruler }}
+{{- if $values.enabled }}
+{{- range $path, $bytes := .Files.Glob "alerts/*.alerts" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: {{ printf "%s" $path | replace "/" "-" }}
+  labels:
+    type: alerting-rules
+    thanos-ruler: regional
+spec:
+{{ printf "%s" $bytes | indent 2 }}
+
+{{- end }}
+{{- end }}


### PR DESCRIPTION
alert needs to move to respective regional thanos. since it is pushed to every thanos it is missing the kube_pod_info. We want it centrally only

Using the opportunity to upgrade.