### PR TITLE
common/thanos: set default user to 0 (root)

### DIFF
--- a/common/thanos/Chart.yaml
+++ b/common/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: Deploy Thanos via operator
 type: application
-version: 0.6.11
+version: 0.6.12
 appVersion: v0.32.5
 maintainers:
   - name: Tommy Sauer (viennaa)

--- a/common/thanos/templates/thanos-objectstore.yaml
+++ b/common/thanos/templates/thanos-objectstore.yaml
@@ -49,6 +49,10 @@ spec:
                 requests:
                   ephemeral-storage: {{ $.Values.compactor.resources.requests.ephemeralStorage }}
               {{- end }}
+            securityContext:
+              fsGroup: 0
+              runAsGroup: 0
+              runAsUser: 0
 {{ end }}
 {{ end }}
 {{ end }}

--- a/common/thanos/templates/thanos.yaml
+++ b/common/thanos/templates/thanos.yaml
@@ -64,6 +64,10 @@ spec:
               {{- end }}
               - name: sd-config
                 mountPath: /conf/sd
+            securityContext:
+              fsGroup: 0
+              runAsGroup: 0
+              runAsUser: 0
             volumes:
             {{- if $.Values.authentication.enabled }}
             - name: client-certificate
@@ -97,6 +101,10 @@ spec:
             containers:
             - image: {{ include "thanosimage" $root }}
               name: store
+            securityContext:
+              fsGroup: 0
+              runAsGroup: 0
+              runAsUser: 0
   {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
The upstream Thanos image has changed the default user in the container image to 1001 instead of 0 (root).

https://github.com/thanos-io/thanos/pull/6107

As we are dependent on user 0 in our environment, we explicitly set it to 0.