### PR TITLE
[neutron] Parameterize neutron service user

### DIFF
--- a/openstack/neutron/templates/seed.yaml
+++ b/openstack/neutron/templates/seed.yaml
@@ -57,7 +57,7 @@ spec:
     - name: l3admin
       description: Cisco L3 Admin Project
     users:
-    - name: neutron
+    - name: {{ .Values.global.neutron_service_user }}
       description: Neutron Service
       password: {{ .Values.global.neutron_service_password }}
       role_assignments:

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -9,6 +9,7 @@ osprofiler:
   enabled: false
 
 global:
+  neutron_service_user: neutron
   dbUser: neutron
   # dbPassword:
   # imageRegistry:


### PR DESCRIPTION
One of many commits towards being able to do easier password rotations. The Neutron user can now be changed via helm-chart.