### PR TITLE
[limes] Make rabbitmq user configurable

### DIFF
--- a/openstack/limes/templates/_utils.tpl
+++ b/openstack/limes/templates/_utils.tpl
@@ -20,7 +20,7 @@
       name: limes-secret
       key: rabbitmq_password
 - name: LIMES_AUDIT_RABBITMQ_USERNAME
-  value: "rabbitmq"
+  value: "{{ default "rabbitmq" .Values.limes.passwords.ccloud.rabbitmq_user }}"
 {{- end }}
 - name: LIMES_AUTHORITATIVE
   value: "true"


### PR DESCRIPTION
We need to change user with credentials to enable a interruption free deployment.
First, roll-out new user with new password, then remove old user.