### PR TITLE
allow individual mapping

### DIFF
--- a/common/prometheus-server/CHANGELOG.md
+++ b/common/prometheus-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.4.9
+
+* VPA mapping adjustment to set individual values 
+
 ## 7.4.8
 
 * VPA memory and cpu alerts added

--- a/common/prometheus-server/Chart.yaml
+++ b/common/prometheus-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus via operator.
 name: prometheus-server
-version: 7.4.8
+version: 7.4.9
 appVersion: v2.47.2
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
 maintainers:

--- a/common/prometheus-server/templates/vpa.yaml
+++ b/common/prometheus-server/templates/vpa.yaml
@@ -15,13 +15,13 @@ spec:
     updateMode: {{ default "Off" $.Values.vpaUpdateMode | quote }}
   resourcePolicy:
     containerPolicies:
-{{- range $vpaResources := $.Values.vpaResources }}
-      - containerName: {{ $vpaResources.name  }}
+{{- range $_, $vpa := $.Values.vpaResources }}
+      - containerName: {{ $vpa.containerName }}
         controlledValues: RequestsOnly
         controlledResources:
           - cpu
           - memory
         maxAllowed:
-{{ toYaml $vpaResources.maxAllowed | indent 10 }}
+{{ toYaml $vpa.maxAllowed | indent 10 }}
 {{- end }}
 {{- end }}

--- a/common/prometheus-server/values.yaml
+++ b/common/prometheus-server/values.yaml
@@ -284,15 +284,18 @@ resources:
 # specifying container specific maximal values.
 vpaResources:
   # if prometheus needs more than 10Gi memory, this needs to be increased otherwise the VPA will not set it accordingly
-  - name: prometheus
+  prometheus:
+    containerName: "prometheus"
     maxAllowed:
       cpu: "3"
       memory: "10Gi"
-  - name: config-reloader
+  configReloader:
+    containerName: "config-reloader"
     maxAllowed:
       cpu: "100"
       memory: "200Mi"
-  - name: thanos-sidecar
+  thanosSidecar:
+    containerName: "thanos-sidecar"
     maxAllowed:
       cpu: "1"
       memory: "3Gi"


### PR DESCRIPTION
specifying some dedicated values in our config repository lead to overwriting of the whole maxAllowed list. This uses a map instead of a list now and will prohibit this behaviour.