### PR TITLE
[Neutron] Round up rate limit values

### DIFF
--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -631,117 +631,123 @@ rate_limit:
     default:
       address-scopes:
         - action: read/list
-          limit: 43r/m
+          limit: 100r/m
       agents:
         - action: read/list
-          limit: 279r/m
+          limit: 300r/m
       agents/agent/*:
         - action: read
-          limit: 159r/m
+          limit: 200r/m
       extensions:
         - action: read/list
-          limit: 83r/m
+          limit: 100r/m
       extensions/extension:
         - action: read
-          limit: 83r/m
+          limit: 100r/m
       floatingips:
         - action: read/list
-          limit: 454r/m
+          limit: 500r/m
         - action: create
-          limit: 83r/m
+          limit: 100r/m
       floatingips.json:
         - action: read
-          limit: 202r/m
+          limit: 300r/m
       floatingips/floatingip:
         - action: read
-          limit: 83r/m
+          limit: 100r/m
         - action: write
-          limit: 83r/m
+          limit: 100r/m
       network-ip-availabilities/network-ip-availability:
         - action: read
-          limit: 83r/m
+          limit: 100r/m
       networks:
         - action: read/list
-          limit: 154r/m
+          limit: 200r/m
+        - action: create
+          limit: 200r/m
       networks/default:
         - action: read
-          limit: 83r/m
+          limit: 200r/m
       networks/network:
         - action: read
-          limit: 289r/m
+          limit: 300r/m
       ports:
         - action: read/list
-          limit: 3042r/m
+          limit: 3100r/m
         - action: create
-          limit: 83r/m
-        - action: write
-          limit: 52r/m
+          limit: 100r/m
       ports.json:
         - action: read
-          limit: 215r/m
+          limit: 300r/m
       ports/port:
         - action: read
-          limit: 108r/m
+          limit: 3100r/m
         - action: write
-          limit: 83r/m
+          limit: 100r/m
       ports/port/*:
         - action: read
-          limit: 20r/m
+          limit: 100r/m
       quotas/quota:
         - action: read
-          limit: 83r/m
+          limit: 100r/m
         - action: write
-          limit: 83r/m
+          limit: 100r/m
       quotas/quota/*:
         - action: read
-          limit: 83r/m
+          limit: 100r/m
       resource_type/resource/*:
         - action: write
-          limit: 83r/m
+          limit: 100r/m
       routers:
         - action: read/list
-          limit: 105r/m
+          limit: 200r/m
+        - action: create
+          limit: 200r/m
       routers/router:
         - action: read
-          limit: 663r/m
+          limit: 700r/m
+        - action: write
+          limit: 200r/m
       routers/router/*:
         - action: write
-          limit: 43r/m
+          limit: 200r/m
       security-group-rules:
         - action: create
-          limit: 83r/m
+          limit: 100r/m
         - action: read/list
-          limit: 52r/m
+          limit: 7700r/m
       security-group-rules/security-group-rule:
         - action: read
-          limit: 2000r/m
+          limit: 7700r/m
         - action: write
-          limit: 83r/m
+          limit: 100r/m
       security-groups:
         - action: read/list
-          limit: 2080r/m
+          limit: 2100r/m
         - action: create
-          limit: 83r/m
+          limit: 100r/m
       security-groups/default:
         - action: read
-          limit: 83r/m
+          limit: 100r/m
       security-groups/security-group:
         - action: read
-          limit: 83r/m
+          limit: 2100r/m
       subnetpools:
         - action: read/list
-          limit: 83r/m
+          limit: 100r/m
       subnetpools/subnetpool:
         - action: write
-          limit: 41r/m
+          limit: 100r/m
       subnets:
+        - action: create
+          limit: 300r/m
         - action: read/list
-          limit: 228r/m
+          limit: 300r/m
       subnets/subnet:
         - action: read
-          limit: 261r/m
+          limit: 300r/m
         - action: write
-          limit: 83r/m
+          limit: 100r/m
 
 unittest:
   enabled: false


### PR DESCRIPTION
Round up rate limit values.

Introduce missing limits for update, delete and create operations on networks, routers and subnets

Change values for root objects: ports, routers, securytigroups, securitygrouprules, routerroutes, subnets, networks. E.g. Compare ports/port read with the value set for ports list and the maximum number of ports a single project in that all bronze and silver regions has. Take the max out of those numbers as new rate limit boundary.

The argument of doing this is due to the eager loading implemented in neutron-lib. For a port list, all data from all related ports table are fetched from the DB (filtered by some conditions). So the query for e.g. port show does the same reducing the number of join partners by filtering for a specific port.