### PR TITLE
[nova] audit_map adjust os-services mapping

### DIFF
--- a/openstack/nova/templates/etc/_nova_audit_map.yaml.tpl
+++ b/openstack/nova/templates/etc/_nova_audit_map.yaml.tpl
@@ -160,12 +160,11 @@ resources:
             disable-log-reason: disable
             enable: enable
         custom_attributes:
-            host: compute/server/host
-            state: compute/server/state
-            status: compute/server/status
-            disabled_reason: compute/server/disabled_reason
-            zone: compute/server/zone
-            forced_down: compute/server/forced_down
+            host: compute/service/host
+            state: compute/service/state
+            status: compute/service/status
+            disabled_reason: compute/service/disabled_reason
+            zone: compute/service/zone
+            forced_down: compute/service/forced_down
     usage:
         api_name: os-simple-tenant-usage
-


### PR DESCRIPTION
Adjust to Service vs. Server as it's a service. Then it will need tested, and validated as a solution to handle these events from the endpoint change from /enable to relying on put and delete on the /uuid

Put contains the details listed here for an update: https://docs.openstack.org/api-ref/compute/#update-compute-service

However delete does not contain the host, or other information in the response, just the UUID of the service.

https://docs.openstack.org/api-ref/compute/#delete-compute-service

This is a test to validate the data returned, and to try to sort out the best solution for auditors to follow the path of activity from these compute-services