### PR TITLE
[neutron] Parameterize neutron user in seeds

### DIFF
--- a/openstack/neutron/templates/seed.yaml
+++ b/openstack/neutron/templates/seed.yaml
@@ -111,7 +111,7 @@ spec:
         role: cloud_network_admin
     - name: master
       role_assignments:
-      - user: neutron@Default
+      - user: {{ .Values.global.neutron_service_user }}@Default
         role: cloud_dns_admin
     groups:
     - name: CCADMIN_CLOUD_ADMINS


### PR DESCRIPTION
The username was still hardcoded to neutron for the cloud_dns_admin role, now it's parameter!