### PR TITLE
[Nova] Reduce cpu_allocation_ratio to 3

### DIFF
--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -281,7 +281,7 @@ compute:
       max_concurrent_builds_per_project: 20
       max_concurrent_builds: 50
       ram_allocation_ratio: 1.0
-      cpu_allocation_ratio: 4.0
+      cpu_allocation_ratio: 3.0
       # this will set a 15 mins timeout for blockdevice mapping
       block_device_allocate_retries: 300
       rpc_statsd_port: 9125


### PR DESCRIPTION
We've seen 4 times CPU overcommit being too high and leading to problems for VMs since the VMware driver also counts hyperthreading cores as full VCPUS.