### PR TITLE
[cc3test] intially drop new phase label

### DIFF
--- a/prometheus-exporters/statsd-exporter/templates/service.yaml
+++ b/prometheus-exporters/statsd-exporter/templates/service.yaml
@@ -45,6 +45,8 @@ spec:
       port: metrics
       scheme: http
       relabelings:
+        - action: labeldrop
+          regex: 'phase'
         - action: labelmap
           regex: '__meta_kubernetes_service_label_(.+)'
         - targetLabel: job

--- a/prometheus-exporters/statsd-exporter/templates/service.yaml
+++ b/prometheus-exporters/statsd-exporter/templates/service.yaml
@@ -44,9 +44,15 @@ spec:
       scrapeTimeout: {{ required ".Values.exporters.scrapeTimeout variable missing" $exporter.scrapeTimeout }}
       port: metrics
       scheme: http
-      relabelings:
+      metricRelabelings:
+        - action: drop
+          regex: '.+;(setup|teardown)'
+          sourceLabels:
+            - __name__
+            - phase
         - action: labeldrop
           regex: 'phase'
+      relabelings:
         - action: labelmap
           regex: '__meta_kubernetes_service_label_(.+)'
         - targetLabel: job


### PR DESCRIPTION
as the introduction of the new phase label might result in partial false alerts until we have rolled out the change to all regions and updated the alerts accordingly, we will simply drop it initially and reenable it later when everything is prepared everywhere