### PR TITLE
nova/flavors: Separate instance quota for hana-flavors

### DIFF
--- a/openstack/sap-seeds/ci/test-values.yaml
+++ b/openstack/sap-seeds/ci/test-values.yaml
@@ -1,0 +1,1 @@
+hana_flavors_quota_separate: true

--- a/openstack/sap-seeds/templates/_flavors_hana_no_exclusive.tpl
+++ b/openstack/sap-seeds/templates/_flavors_hana_no_exclusive.tpl
@@ -8,6 +8,10 @@
     "resources:CUSTOM_MEMORY_RESERVABLE_MB": "373352"
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "24"  # used in nova-vmware as cores-per-socket (12pCPU = 24vCPU)
+    {{- if ( .Values.hana_flavors_quota_separate ) }}
+    "quota:instance_only": "true"
+    "quota:separate": "true"
+    {{- end }}
 - name: "hana_c48_m729"
   id: "301"
   vcpus: 48
@@ -18,6 +22,10 @@
     "resources:CUSTOM_MEMORY_RESERVABLE_MB": "746720"
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
+    {{- if ( .Values.hana_flavors_quota_separate ) }}
+    "quota:instance_only": "true"
+    "quota:separate": "true"
+    {{- end }}
 - name: "hana_c96_m1458"
   id: "302"
   vcpus: 96
@@ -29,6 +37,10 @@
     "resources:CUSTOM_BIGVM": "2"
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
+    {{- if ( .Values.hana_flavors_quota_separate ) }}
+    "quota:instance_only": "true"
+    "quota:separate": "true"
+    {{- end }}
 - name: "hana_c144_m2188"
   id: "303"
   vcpus: 144
@@ -41,6 +53,10 @@
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
     "vmware:hw_version": "vmx-15"
+    {{- if ( .Values.hana_flavors_quota_separate ) }}
+    "quota:instance_only": "true"
+    "quota:separate": "true"
+    {{- end }}
 - name: "hana_c192_m2917"
   id: "304"
   vcpus: 192
@@ -53,6 +69,10 @@
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
     "vmware:hw_version": "vmx-15"
+    {{- if ( .Values.hana_flavors_quota_separate ) }}
+    "quota:instance_only": "true"
+    "quota:separate": "true"
+    {{- end }}
 - name: "hana_c384_m5835"
   id: "305"
   vcpus: 384
@@ -65,6 +85,10 @@
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
     "vmware:hw_version": "vmx-18"
+    {{- if ( .Values.hana_flavors_quota_separate ) }}
+    "quota:instance_only": "true"
+    "quota:separate": "true"
+    {{- end }}
 - name: "hana_c288_m4377"
   id: "311"
   vcpus: 288
@@ -77,3 +101,7 @@
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
     "vmware:hw_version": "vmx-18"
+    {{- if ( .Values.hana_flavors_quota_separate ) }}
+    "quota:instance_only": "true"
+    "quota:separate": "true"
+    {{- end }}

--- a/openstack/sap-seeds/values.yaml
+++ b/openstack/sap-seeds/values.yaml
@@ -1,6 +1,8 @@
 # whether to use the hana_exclusive list of flavors or the older
 # hana_no_exclusive list
 use_hana_exclusive: false
+# whether to use separate quota for each hana-flavor for pay-per-use billing
+hana_flavors_quota_separate: false
 
 owner-info:
   support-group: compute-storage-api


### PR DESCRIPTION
Needed for Limes' upcoming 2024 quota revamp.

Only for nova-bigvm-enabled regions, since we only need it in qa-de-1 first.
