### PR TITLE
[hermes] modify hooks to refresh configmap

### DIFF
--- a/openstack/hermes/templates/logstash-etc-configmap.yaml
+++ b/openstack/hermes/templates/logstash-etc-configmap.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-upgrade,pre-install
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
 
 data:
   logstash.conf: |


### PR DESCRIPTION
I think doing it on succeed was too aggressive and causes the config map to not be available.