### PR TITLE
[maia] adjusting values order annotation isn't triggering

### DIFF
--- a/openstack/maia/values.yaml
+++ b/openstack/maia/values.yaml
@@ -2,10 +2,10 @@ global:
   # region: DEFINED-IN-REGION-SECRETS
   # domain: DEFINED-IN-REGION-SECRETS
   # imageRegistry: DEFINED-IN-REGION-SECRETS
+  linkerd_requested: true
   clusterType: controlplane
   domain_seeds:
     skip_hcm_domain: false
-  linkerd_requested: true
 
 linkerd-support:
   annotate_namespace: true


### PR DESCRIPTION
I don't see the annotation when checking values on the release. I'm quite confused what is missing, just reordering which shouldn't matter.