### PR TITLE
[unbound][dnstap] -- let's run dnstap in a sidecar container

### DIFF
--- a/system/unbound/templates/deployment.yaml
+++ b/system/unbound/templates/deployment.yaml
@@ -36,6 +36,34 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       nodeSelector:
         topology.kubernetes.io/zone: {{ .Values.global.region}}{{ .Values.unbound.failure_domain_zone}}
+      initContainers:
+{{ if .Values.unbound.dnstap.enabled }}
+      - name: dnstap
+        image: {{ required ".Values.global.registryAlternateRegion is missing" .Values.global.registryAlternateRegion }}/{{.Values.unbound.dnstap.image}}:{{ .Values.unbound.dnstap.image_tag}}
+        imagePullPolicy: {{ .Values.unbound.image_pullPolicy }}
+        restartPolicy: Always
+        resources:
+{{ toYaml .Values.resources.dnstap | indent 10 }}
+        args:
+          - -u
+          - {{ .Values.unbound.dnstap.socket_path | default "/run/dnstap/dnstap.sock" }}
+{{ if .Values.unbound.dnstap.hec_splunk_url }}
+{{ if .Values.unbound.dnstap.hec_splunk_token }}
+          - -H
+          - {{ .Values.unbound.dnstap.hec_splunk_url }}
+          - -token
+          - {{ .Values.unbound.dnstap.hec_splunk_token }}
+{{ if .Values.unbound.dnstap.hec_splunk_server_uuid }}
+          - -server_uuid
+          - {{ .Values.unbound.dnstap.hec_splunk_server_uuid }}
+{{ end }}
+{{ end }}
+{{ end }}
+{{ toYaml .Values.unbound.dnstap.additional_cmdline_args | indent 10 }}
+        volumeMounts:
+          - name: dnstap-socket
+            mountPath: {{ .Values.unbound.dnstap.socket_path | default "/run/dnstap/dnstap.sock" | dir }}
+{{ end }}
       containers:
       - name: unbound
         image: {{ required ".Values.global.registryAlternateRegion is missing" .Values.global.registryAlternateRegion }}/{{.Values.unbound.unbound.image}}:{{ .Values.unbound.unbound.image_tag}}
@@ -95,32 +123,6 @@ spec:
         volumeMounts:
           - name: unbound-conf
             mountPath: /etc/unbound
-{{ if .Values.unbound.dnstap.enabled }}
-      - name: dnstap
-        image: {{ required ".Values.global.registryAlternateRegion is missing" .Values.global.registryAlternateRegion }}/{{.Values.unbound.dnstap.image}}:{{ .Values.unbound.dnstap.image_tag}}
-        imagePullPolicy: {{ .Values.unbound.image_pullPolicy }}
-        resources:
-{{ toYaml .Values.resources.dnstap | indent 10 }}
-        args:
-          - -u
-          - {{ .Values.unbound.dnstap.socket_path | default "/run/dnstap/dnstap.sock" }}
-{{ if .Values.unbound.dnstap.hec_splunk_url }}
-{{ if .Values.unbound.dnstap.hec_splunk_token }}
-          - -H
-          - {{ .Values.unbound.dnstap.hec_splunk_url }}
-          - -token
-          - {{ .Values.unbound.dnstap.hec_splunk_token }}
-{{ if .Values.unbound.dnstap.hec_splunk_server_uuid }}
-          - -server_uuid
-          - {{ .Values.unbound.dnstap.hec_splunk_server_uuid }}
-{{ end }}
-{{ end }}
-{{ end }}
-{{ toYaml .Values.unbound.dnstap.additional_cmdline_args | indent 10 }}
-        volumeMounts:
-          - name: dnstap-socket
-            mountPath: {{ .Values.unbound.dnstap.socket_path | default "/run/dnstap/dnstap.sock" | dir }}
-{{ end }}
       volumes:
       - name: unbound-conf
         configMap:


### PR DESCRIPTION
As per https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/#sidecar-containers-and-pod-lifecycle

The dnstap container serves a clear supporting role.

Also, if enabled, it should be available before the main unbound container starts.

All in all, it ticks all the boxes as far as sidecar containers described in the above URL go.

The patch basically moves the dnstap container out of the "containers:" section
and into the "initContainers:" one and sets its restartPolicy to Always.