### PR TITLE
nova/flavors: Allow gmp_m1946_c128 on hana-exclusive hosts

### DIFF
--- a/openstack/sap-seeds/templates/_flavors_deleted.tpl
+++ b/openstack/sap-seeds/templates/_flavors_deleted.tpl
@@ -151,7 +151,7 @@
   is_public: false
   extra_specs:
 {{- if .Values.use_hana_exclusive }}
-    {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
+    {{- tuple . "vmware_hana_exclusive" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
 {{ else }}
     {{- tuple . "vmware_common" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "resources:CUSTOM_BIGVM": "2"


### PR DESCRIPTION
Fix for

    6ea87996 nova/flavors: Add back GMP- & other deleted flavors

Typo for the one flavor to be allowed instead of forbidden on hana-exclusive hosts.
