### PR TITLE
Foundation exporters: maintain `owner-info.service`

### DIFF
--- a/common/inventory-updater/templates/service.yaml
+++ b/common/inventory-updater/templates/service.yaml
@@ -2,17 +2,16 @@ kind: Service
 apiVersion: v1
 
 metadata:
-    name: {{ include "fullname" . }}-api
-    namespace: {{ .Values.updater.namespace }}
-    labels:
-        app: {{ include "fullname" . }}
-        type: api
+  name: {{ include "fullname" . }}-api
+  namespace: {{ .Values.updater.namespace }}
+  labels:
+    app: {{ include "fullname" . }}
+    type: api
 
 spec:
   selector:
     name: {{ include "fullname" . }}-api
   ports:
-    - name: {{ include "fullname" . }}-api
-      port: {{.Values.updater.api.port}}
-      targetPort: {{ include "fullname" . }}-api
-        protocol: TCP
+  - name: {{ include "fullname" . }}-api
+    port: {{.Values.updater.api.port}}
+    targetPort: api

--- a/common/inventory-updater/values.yaml
+++ b/common/inventory-updater/values.yaml
@@ -1,6 +1,6 @@
 owner-info:
   support-group: foundation
-  # service: foobar        # optional
+  service: inventory-updater
   maintainers:
     - Bernd Kuespert
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/common/inventory-updater

--- a/prometheus-exporters/arista-exporter/values.yaml
+++ b/prometheus-exporters/arista-exporter/values.yaml
@@ -1,6 +1,6 @@
 owner-info:
   support-group: foundation
-  # service: foobar        # optional
+  service: arista-exporter
   maintainers:
     - Bernd Kuespert
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/prometheus-exporters/arista-exporter

--- a/prometheus-exporters/ipmi-exporter/ci/test-values.yaml
+++ b/prometheus-exporters/ipmi-exporter/ci/test-values.yaml
@@ -7,5 +7,8 @@ global:
     ironic:
       enabled: true
 
+  http_sd_configs:
+    netbox_url: http://netbox
+
 ipmi_username: ipmi
 ipmi_password: topSecret

--- a/prometheus-exporters/ipmi-exporter/values.yaml
+++ b/prometheus-exporters/ipmi-exporter/values.yaml
@@ -1,6 +1,6 @@
 owner-info:
   support-group: foundation
-  # service: foobar        # optional
+  service: ipmi-exporter
   maintainers:
     - Stefan Hipfel
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/prometheus-exporters/ipmi-exporter


### PR DESCRIPTION
To subclassify alerts, tickets, policy violations, resource consumption,
etc. within the realm of a single support group.

https://github.com/sapcc/helm-charts/blob/65c0a486f5edd9f29c7d0d033222918651aa12a1/common/owner-info/README.md#L42

Without it, some alerts produce non-informative messages, e.g.

> GkVulnerableImagesForFoundation - Vulnerable images in prod deployments of None
