### PR TITLE
[hermes] activate linkerd only for logstash

### DIFF
--- a/openstack/hermes/ci/test-values.yaml
+++ b/openstack/hermes/ci/test-values.yaml
@@ -20,6 +20,10 @@ hermes_elasticsearch_host: my-es-host
 hermes_elasticsearch_port: my-es-port
 
 docker_repo: my-docker-repository
+users:
+  audit:
+    username: test
+    password: test
 
 hermes:
   image: my-image
@@ -43,10 +47,6 @@ hermes:
 logstash:
   access_key_id: some-key
   secret_access_key: secret!
-  users:
-    audit:
-      username: test
-      password: test
 
 ingress:
   tls: true

--- a/openstack/hermes/ci/test-values.yaml
+++ b/openstack/hermes/ci/test-values.yaml
@@ -43,6 +43,10 @@ hermes:
 logstash:
   access_key_id: some-key
   secret_access_key: secret!
+  users:
+    audit:
+      username: test
+      password: test
 
 ingress:
   tls: true

--- a/openstack/hermes/templates/logstash-deployment.yaml
+++ b/openstack/hermes/templates/logstash-deployment.yaml
@@ -23,6 +23,9 @@ spec:
         component: logstash
       annotations:
         checksum/logstash-etc-configmap.yaml: {{ include "hermes/templates/logstash-etc-configmap.yaml" . | sha256sum }}
+        {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
+        linkerd.io/inject: enabled
+        {{- end }}
     spec:
       nodeSelector:
         zone: farm

--- a/openstack/hermes/templates/logstash-service.yaml
+++ b/openstack/hermes/templates/logstash-service.yaml
@@ -10,6 +10,9 @@ metadata:
     prometheus.io/targets: {{ required ".Values.metrics.prometheus missing" .Values.metrics.prometheus }}
     prometheus.io/scrape: "true"
     prometheus.io/port: "9198"
+    {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
+    linkerd.io/inject: enabled
+    {{- end }}
 spec:
   selector:
     component: logstash

--- a/openstack/hermes/values.yaml
+++ b/openstack/hermes/values.yaml
@@ -5,9 +5,6 @@ global:
     admin:
       name: admin
       
-linkerd-support:
-  annotate_namespace: true
-
 owner-info:
   support-group: observability
   service: hermes


### PR DESCRIPTION
My proposal:

Disabling linkerd for the namespace and activating it only for logstash, because the namespace activation blocks the helm post-deploy and job pods. At the moment the post-deploy and job pods are using the toolbox image, which has no linkerd support. Switching to an own image is increasing the complexity.