### PR TITLE
[Cinder] merge standard_hdd to vmware

### DIFF
--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -60,11 +60,9 @@ backend_defaults:
   vmware_datastores_as_pools: True
 
 backends:
-  enabled: vmware,standard_hdd
+  enabled: vmware
   vmware:
-    vmware_storage_profile: cinder-vvol
-  standard_hdd:
-    vmware_storage_profile: cinder-standard-hdd
+    vmware_storage_profile: cinder-vvol,cinder-standard-hdd
 
 cinderApiPortPublic: 443
 cinderApiPortInternal: 8776


### PR DESCRIPTION
This patch changes how the vmware driver is deployed. This eliminates the standard_hdd driver instance and configures the vmware driver instance to be aware of both cinder-standard-hdd and vmware storage profiles.

This means that 1 driver instance will run that supports both of the volume types (vmware, standard_hdd).

In order for this to work correctly:
a) The 2 volume types will need a new extra spec manually added in the DB.  The new extra spec will be 'storage_profle:cinder-standard-hdd' and
'storage_profile:vmware' for the 2 volume types.   This is required to
have the cinder scheduler filter out pools (datastores) correctly
depending on which volume type is selected at create time.
b) all existing standard_hdd volumes have to have their host entries
changed from
cinder-volume-vmware-vc-a-0@standard_hdd#<Pool name here>
to
cinder-volume-vmware-vc-a-0@vmware#<Pool name here>

Refers to cinder-issue:
https://github.wdf.sap.corp/cc/cinder-issues/issues/14

The purpose is to allow for driver assisted retype to work without creating a generic cinder migration event.