### PR TITLE
[neutron] Don't share netns between dhcp/bridge agent

### DIFF
--- a/openstack/neutron/templates/statefulset-network-agent-apod.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent-apod.yaml
@@ -129,8 +129,6 @@ spec:
               mountPath: /etc/sudoers
               subPath: sudoers
               readOnly: true
-            - name: network-namespace
-              mountPath: /var/run/netns
             {{- include "utils.trust_bundle.volume_mount" $ | indent 12 }}
         - name: neutron-linuxbridge-agent
           image: {{$.Values.global.registry}}/loci-neutron:{{$.Values.imageVersionNetworkAgentLinuxBridge | default $.Values.imageVersionNetworkAgent | default $.Values.imageVersion | required "Please set neutron.imageVersionNetworkAgentLinuxBridge or similar"}}
@@ -176,8 +174,6 @@ spec:
               mountPath: /etc/sudoers
               subPath: sudoers
               readOnly: true
-            - name: network-namespace
-              mountPath: /var/run/netns
             {{- include "utils.trust_bundle.volume_mount" $ | indent 12 }}
         - name: neutron-metadata-agent
           image: {{$.Values.global.registry}}/loci-neutron:{{$.Values.imageVersionNetworkAgentMetadata | default $.Values.imageVersionNetworkAgent | default $.Values.imageVersion | required "Please set neutron.imageVersionNetworkAgentMetadata or similar"}}
@@ -205,8 +201,6 @@ spec:
             {{- include "utils.trust_bundle.volume_mount" $ | indent 12 }}
       volumes:
         - name: metadata-proxy
-          emptyDir: {}
-        - name: network-namespace
           emptyDir: {}
         - name: modules
           hostPath:

--- a/openstack/neutron/templates/statefulset-network-agent.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent.yaml
@@ -154,8 +154,6 @@ spec:
             - name: logvol
               mountPath: /dev/log
               readOnly: false
-            - name: network-namespace
-              mountPath: /var/run/netns
             {{- include "utils.trust_bundle.volume_mount" $ | indent 12 }}
 {{- if $.Values.agent.neutron_l3 | default false }}
         - name: neutron-l3-agent
@@ -278,15 +276,11 @@ spec:
               mountPath: /etc/sudoers
               subPath: sudoers
               readOnly: true
-            - name: network-namespace
-              mountPath: /var/run/netns
             {{- include "utils.trust_bundle.volume_mount" $ | indent 12 }}
       volumes:
         - name: metadata-proxy
           hostPath:
             path: /run/metadata-proxy
-        - name: network-namespace
-          emptyDir: {}
         - name : modules
           hostPath:
             path: /lib/modules


### PR DESCRIPTION
The linux-bridge-agent and dhcp-agent used to share their /var/run/netns directory with each other. This results in two things:

1. The network namespaces are generally not usable in the linux-bridge-agent
2. When the dhcp-agent container restarts, the netns files are still present, even when the namespaces themselves are gone

Generally, only the dhcp-agent interacts with the network namespaces. The netns are managed by it and it also puts interfaces inside the netns. The bridge-agent only puts interfaces provided to it into a bridge. This is possible with and without the knowledge of the netns from the dhcp-agent.

When the dhcp-agent restarts it can no longer recreate the network namespaces, as the namespaces themselves are gone, but the files are still there. It'll try to use these invalid files, but it won't work anymore.

Therefore, to allow the dhcp-agent container to properly restart without restarting the whole pod, we now remove this crossmount of the netns directory.