### PR TITLE
[maria db] Enable VPA butler

### DIFF
--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -175,7 +175,7 @@ vpa:
   # https://github.com/sapcc/vpa_butler
   # The maximum available capacity is split evenly across containers specified in the Deployment, StatefulSet or DaemonSet to derive the upper recommendation bound. This does not work out for pods with a single resource-hungry container with several sidecar containers
   # Annotate the Deployment, StatefulSet or DaemonSet with vpa-butler.cloud.sap/main-container=$MAIN_CONTAINER. That will distribute 75% of the maximum available capacity to the main container and the rest evenly across all others
-  set_main_container: false
+  set_main_container: true
 linkerd:
   mariadb:
     #linkerd annotation for the MariaDB pod (true/false)


### PR DESCRIPTION
Add VPA butler annotation to unblock Erik Schuberts vpa-butler deployment. It is already enabled for the neutron chart, but mariadb still misses it.