### PR TITLE
[ neutron ] Enable vpa for mariadb

### DIFF
--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -370,6 +370,8 @@ mariadb:
   log_file_size: "1024M"
   name: neutron
   initdb_configmap: neutron-initdb
+  vpa:
+    set_main_container: true
   persistence_claim:
     name: db-neutron-pvclaim
   backup:


### PR DESCRIPTION
vpa is already eneabled in the neutron chart, now we add it for the mariadb dependancy