### PR TITLE
Added recon_candidates_limit to overwrite default value of 5

### DIFF
--- a/openstack/swift/templates/etc/_container-server.conf.tpl
+++ b/openstack/swift/templates/etc/_container-server.conf.tpl
@@ -46,6 +46,7 @@ internal_client_conf_path = /etc/swift/internal-client-no-cache.conf
 # production; do not set this option to true in a production cluster.
 auto_shard = false
 internal_client_conf_path = /etc/swift/internal-client-no-cache.conf
+recon_candidates_limit = -1
 
 [filter:healthcheck]
 use = egg:swift#healthcheck


### PR DESCRIPTION
Creating this PR to make changes in container-sharder to overwrite the default recon candidate value, which is 5 as of now. Setting value to -1 will help.