### PR TITLE
[hermes] fix logstash conf metis cleanup

### DIFF
--- a/openstack/hermes/templates/etc/_logstash.conf.tpl
+++ b/openstack/hermes/templates/etc/_logstash.conf.tpl
@@ -355,32 +355,32 @@ filter {
         }
       }
     }
-    # Cleanup
+  }
+  # Cleanup
+  mutate {
+    id => "f20d_removing_domain_mapping"
+    remove_field => ["[domain_mapping]"]
+  }
+
+  # Cleanup unavailable entries
+  if [initiator][project_id] == "unavailable" {
     mutate {
-      id => "f20d_removing_domain_mapping"
-      remove_field => ["[domain_mapping]"]
+      id => "f20e_removing_initiator_project_id"
+      remove_field => ["[initiator][project_id]"]
     }
+  }
 
-    # Cleanup unavailable entries
-    if [initiator][project_id] == "unavailable" {
-      mutate {
-        id => "f20e_removing_initiator_project_id"
-        remove_field => ["[initiator][project_id]"]
-      }
+  if [target][project_id] == "unavailable" {
+    mutate {
+      id => "f20f_removing_target_project_id"
+      remove_field => ["[target][project_id]"]
     }
+  }
 
-    if [target][project_id] == "unavailable" {
-      mutate {
-        id => "f20f_removing_target_project_id"
-        remove_field => ["[target][project_id]"]
-      }
-    }
-
-    if [initiator][id] == "unavailable" {
-      mutate {
-        id => "f20g_removing_initiator_id"
-        remove_field => ["[initiator][id]"]
-      }
+  if [initiator][id] == "unavailable" {
+    mutate {
+      id => "f20g_removing_initiator_id"
+      remove_field => ["[initiator][id]"]
     }
   }
   {{- end}}

--- a/openstack/hermes/templates/etc/_logstash.conf.tpl
+++ b/openstack/hermes/templates/etc/_logstash.conf.tpl
@@ -355,11 +355,12 @@ filter {
         }
       }
     }
-  }
-  # Cleanup
-  mutate {
-    id => "f20d_removing_domain_mapping"
-    remove_field => ["[domain_mapping]"]
+
+    # Cleanup
+    mutate {
+      id => "f20d_removing_domain_mapping"
+      remove_field => ["[domain_mapping]"]
+    }
   }
 
   # Cleanup unavailable entries


### PR DESCRIPTION
The cleanup wasn't happening for the unavailable fields, leading to events going into an "unavailable" index which gives us two different dump indexes. This change removes what looks like an incorrect grouping of the domain_mapping if. Please take a look and validate. 