### PR TITLE
compactor multi attach fixed

### DIFF
--- a/common/thanos/Chart.yaml
+++ b/common/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: Deploy Thanos via operator
 type: application
-version: 0.7.8
+version: 0.7.9
 appVersion: v0.33.0
 maintainers:
   - name: Tommy Sauer (viennaa)

--- a/common/thanos/templates/thanos-objectstore.yaml
+++ b/common/thanos/templates/thanos-objectstore.yaml
@@ -33,6 +33,8 @@ spec:
           thanos: {{ default (include "thanos.name" (list $name $root)) $.Values.alerts.prometheus }}
     deploymentOverrides:
       spec:
+        strategy:
+          type: Recreate
         template:
           spec:
             containers:


### PR DESCRIPTION
when rolling out new compactors they often will be stuck in ContainerCreating with multi-attach volume errors. Since they are not mission critical, we can easily take the short downtime and bring them down first, ensuring a working rollout.
