### PR TITLE
common/prometheus-server: align on prometheus label

### DIFF
--- a/common/prometheus-server/Chart.yaml
+++ b/common/prometheus-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus via operator.
 name: prometheus-server
-version: 7.4.11
+version: 7.4.12
 appVersion: v2.47.2
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
 maintainers:

--- a/common/prometheus-server/templates/servicemonitors/prometheus.yaml
+++ b/common/prometheus-server/templates/servicemonitors/prometheus.yaml
@@ -26,7 +26,7 @@ spec:
       relabelings:
         - action: replace
           targetLabel: prometheus
-          replacement: {{ include "prometheus.name" (list $name $root) }}
+          replacement: {{ printf "%s/%s" $.Release.Namespace (include "prometheus.name" (list $name $root)) }}
         - action: labelmap
           regex: '__meta_kubernetes_service_label_(.+)'
         - sourceLabels:


### PR DESCRIPTION
If a prometheus label exists on a metric, then it should have the form `prometheus="<namespace/prometheus-name>"`, as each prometheus attaches an external label of the same name to each metric. Otherwise duplicate metrics will be created.