### PR TITLE
[mariadb-galera] db migration options added

### DIFF
--- a/common/mariadb-galera/CHANGELOG.md
+++ b/common/mariadb-galera/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.23.0 - 2024/01/30
+* helm unit tests added
+* mariadb.migration.enabled chart option added
+  * to support the migration from another MariaDB instance
+* chart version bumped
+
 ## v0.22.3 - 2024/01/29
 * packages timestamp updated to `20240129111302`
 * chart version bumped

--- a/common/mariadb-galera/CHANGELOG.md
+++ b/common/mariadb-galera/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.23.1 - 2024/02/12
+* helm unit tests for migration option added
+* packages timestamp updated to `20240212072432`
+* chart version bumped
+
 ## v0.23.0 - 2024/01/30
 * helm unit tests added
 * mariadb.migration.enabled chart option added

--- a/common/mariadb-galera/README.md
+++ b/common/mariadb-galera/README.md
@@ -42,7 +42,7 @@ Docker images and Helm chart to deploy a [MariaDB](https://mariadb.com/kb/en/get
 ## Metadata
 | chart version | app version | type | url |
 |:--------------|:-------------|:-------------|:-------------|
-| 0.23.0 | 10.5.22 | application | [Git repo](https://github.com/sapcc/helm-charts/tree/mariadb-galera/common/mariadb-galera) |
+| 0.23.1 | 10.5.23 | application | [Git repo](https://github.com/sapcc/helm-charts/tree/mariadb-galera/common/mariadb-galera) |
 
 | Name | Email | Url |
 | ---- | ------ | --- |
@@ -152,7 +152,7 @@ docker build --build-arg BASE_SOFT_NAME=ubuntu --build-arg BASE_SOFT_VERSION=22.
   ```
 * [push](https://helm.sh/docs/topics/registries/#the-push-subcommand) the chart to the registry
   ```shell
-  helm push mariadb-galera-0.23.0.tgz oci://keppel.eu-de-1.cloud.sap/ccloud-helm/
+  helm push mariadb-galera-0.23.1.tgz oci://keppel.eu-de-1.cloud.sap/ccloud-helm/
   ```
 
 ### values description
@@ -254,7 +254,7 @@ docker build --build-arg BASE_SOFT_NAME=ubuntu --build-arg BASE_SOFT_VERSION=22.
 | hpa.proxy.minReplicas | int | 3 | minimum number of replicas allowed for the ProxySQL cluster pods |
 | image.database.databasename | string | `"mariadb-galera"` | folder/container used in the image registry and also part of the image name |
 | image.database.databaseversion | string | `"10.5.23"` | database part of the image version that should be pulled |
-| image.database.imageversion | int | `20240130112825` | image part of the image version that should be pulled |
+| image.database.imageversion | int | `20240212072432` | image part of the image version that should be pulled |
 | image.database.project | string | `"ccloud"` | project/tenant used in the image registry |
 | image.database.pullPolicy | string | IfNotPresent | `Always` to enforce that the image will be pulled even if it is already available on the worker node |
 | image.database.pullSecret | string | `nil` | name of the defined Kubernetes secret defined in `image.pullSecrets` that should be used for container registry authentication |
@@ -267,28 +267,28 @@ docker build --build-arg BASE_SOFT_NAME=ubuntu --build-arg BASE_SOFT_VERSION=22.
 | image.haproxy.registry | string | `"keppel.eu-de-1.cloud.sap"` | hostname of the image registry used to pull the proxy image that contains the Restic backup software |
 | image.kopiabackup.databasename | string | `"mariadb-galera-kopia"` | folder/container used in the image registry and also part of the image name |
 | image.kopiabackup.databaseversion | string | `"0.12.1"` | database part of the image version that should be pulled |
-| image.kopiabackup.imageversion | int | `20240130112825` | image part of the image version that should be pulled |
+| image.kopiabackup.imageversion | int | `20240212072432` | image part of the image version that should be pulled |
 | image.kopiabackup.project | string | `"ccloud"` | project/tenant used in the image registry |
 | image.kopiabackup.pullPolicy | string | IfNotPresent | `Always` to enforce that the image will be pulled even if it is already available on the worker node |
 | image.kopiabackup.pullSecret | string | `nil` | name of the defined Kubernetes secret defined in `image.pullSecrets` that should be used for container registry authentication |
 | image.kopiabackup.registry | string | `"keppel.eu-de-1.cloud.sap"` | hostname of the image registry used to pull the proxy image that contains the Kopia backup software |
 | image.monitoring.databasename | string | `"mariadb-galera-mysqld_exporter"` | folder/container used in the image registry and also part of the image name |
 | image.monitoring.databaseversion | string | `"0.14.0"` | database part of the image version that should be pulled |
-| image.monitoring.imageversion | int | `20240130112825` | image part of the image version that should be pulled |
+| image.monitoring.imageversion | int | `20240212072432` | image part of the image version that should be pulled |
 | image.monitoring.project | string | `"ccloud"` | project/tenant used in the image registry |
 | image.monitoring.pullPolicy | string | IfNotPresent | `Always` to enforce that the image will be pulled even if it is already available on the worker node |
 | image.monitoring.pullSecret | string | `nil` | name of the defined Kubernetes secret defined in `image.pullSecrets` that should be used for container registry authentication |
 | image.monitoring.registry | string | `"keppel.eu-de-1.cloud.sap"` | hostname of the image registry used to pull the monitoring image that currently contains the MySQL exporter for Prometheus |
 | image.os.databasename | string | `"mariadb-galera-ubuntu"` | folder/container used in the image registry and also part of the image name |
 | image.os.databaseversion | float | `22.04` | database part of the image version that should be pulled |
-| image.os.imageversion | int | `20240130112825` | image part of the image version that should be pulled |
+| image.os.imageversion | int | `20240212072432` | image part of the image version that should be pulled |
 | image.os.project | string | `"ccloud"` | project/tenant used in the image registry |
 | image.os.pullPolicy | string | IfNotPresent | `Always` to enforce that the image will be pulled even if it is already available on the worker node |
 | image.os.pullSecret | string | `nil` | name of the defined Kubernetes secret defined in `image.pullSecrets` that should be used for container registry authentication |
 | image.os.registry | string | `"keppel.eu-de-1.cloud.sap"` | hostname of the image registry used to pull the basic OS image that will be used for certain init steps |
 | image.proxy.databasename | string | `"mariadb-galera-proxysql"` | folder/container used in the image registry and also part of the image name |
 | image.proxy.databaseversion | string | `"2.5.5"` | database part of the image version that should be pulled |
-| image.proxy.imageversion | int | `20240130112825` | image part of the image version that should be pulled |
+| image.proxy.imageversion | int | `20240212072432` | image part of the image version that should be pulled |
 | image.proxy.project | string | `"ccloud"` | project/tenant used in the image registry |
 | image.proxy.pullPolicy | string | IfNotPresent | `Always` to enforce that the image will be pulled even if it is already available on the worker node |
 | image.proxy.pullSecret | string | `nil` | name of the defined Kubernetes secret defined in `image.pullSecrets` that should be used for container registry authentication |

--- a/common/mariadb-galera/README.md
+++ b/common/mariadb-galera/README.md
@@ -42,7 +42,7 @@ Docker images and Helm chart to deploy a [MariaDB](https://mariadb.com/kb/en/get
 ## Metadata
 | chart version | app version | type | url |
 |:--------------|:-------------|:-------------|:-------------|
-| 0.22.3 | 10.5.22 | application | [Git repo](https://github.com/sapcc/helm-charts/tree/mariadb-galera/common/mariadb-galera) |
+| 0.23.0 | 10.5.22 | application | [Git repo](https://github.com/sapcc/helm-charts/tree/mariadb-galera/common/mariadb-galera) |
 
 | Name | Email | Url |
 | ---- | ------ | --- |
@@ -152,7 +152,7 @@ docker build --build-arg BASE_SOFT_NAME=ubuntu --build-arg BASE_SOFT_VERSION=22.
   ```
 * [push](https://helm.sh/docs/topics/registries/#the-push-subcommand) the chart to the registry
   ```shell
-  helm push mariadb-galera-0.22.3.tgz oci://keppel.eu-de-1.cloud.sap/ccloud-helm/
+  helm push mariadb-galera-0.23.0.tgz oci://keppel.eu-de-1.cloud.sap/ccloud-helm/
   ```
 
 ### values description
@@ -253,8 +253,8 @@ docker build --build-arg BASE_SOFT_NAME=ubuntu --build-arg BASE_SOFT_VERSION=22.
 | hpa.proxy.maxReplicas | int | 5 | maximum number of replicas allowed for the ProxySQL cluster pods |
 | hpa.proxy.minReplicas | int | 3 | minimum number of replicas allowed for the ProxySQL cluster pods |
 | image.database.databasename | string | `"mariadb-galera"` | folder/container used in the image registry and also part of the image name |
-| image.database.databaseversion | string | `"10.5.22"` | database part of the image version that should be pulled |
-| image.database.imageversion | int | `20240129111302` | image part of the image version that should be pulled |
+| image.database.databaseversion | string | `"10.5.23"` | database part of the image version that should be pulled |
+| image.database.imageversion | int | `20240130112825` | image part of the image version that should be pulled |
 | image.database.project | string | `"ccloud"` | project/tenant used in the image registry |
 | image.database.pullPolicy | string | IfNotPresent | `Always` to enforce that the image will be pulled even if it is already available on the worker node |
 | image.database.pullSecret | string | `nil` | name of the defined Kubernetes secret defined in `image.pullSecrets` that should be used for container registry authentication |
@@ -267,28 +267,28 @@ docker build --build-arg BASE_SOFT_NAME=ubuntu --build-arg BASE_SOFT_VERSION=22.
 | image.haproxy.registry | string | `"keppel.eu-de-1.cloud.sap"` | hostname of the image registry used to pull the proxy image that contains the Restic backup software |
 | image.kopiabackup.databasename | string | `"mariadb-galera-kopia"` | folder/container used in the image registry and also part of the image name |
 | image.kopiabackup.databaseversion | string | `"0.12.1"` | database part of the image version that should be pulled |
-| image.kopiabackup.imageversion | int | `20240129111302` | image part of the image version that should be pulled |
+| image.kopiabackup.imageversion | int | `20240130112825` | image part of the image version that should be pulled |
 | image.kopiabackup.project | string | `"ccloud"` | project/tenant used in the image registry |
 | image.kopiabackup.pullPolicy | string | IfNotPresent | `Always` to enforce that the image will be pulled even if it is already available on the worker node |
 | image.kopiabackup.pullSecret | string | `nil` | name of the defined Kubernetes secret defined in `image.pullSecrets` that should be used for container registry authentication |
 | image.kopiabackup.registry | string | `"keppel.eu-de-1.cloud.sap"` | hostname of the image registry used to pull the proxy image that contains the Kopia backup software |
 | image.monitoring.databasename | string | `"mariadb-galera-mysqld_exporter"` | folder/container used in the image registry and also part of the image name |
 | image.monitoring.databaseversion | string | `"0.14.0"` | database part of the image version that should be pulled |
-| image.monitoring.imageversion | int | `20240129111302` | image part of the image version that should be pulled |
+| image.monitoring.imageversion | int | `20240130112825` | image part of the image version that should be pulled |
 | image.monitoring.project | string | `"ccloud"` | project/tenant used in the image registry |
 | image.monitoring.pullPolicy | string | IfNotPresent | `Always` to enforce that the image will be pulled even if it is already available on the worker node |
 | image.monitoring.pullSecret | string | `nil` | name of the defined Kubernetes secret defined in `image.pullSecrets` that should be used for container registry authentication |
 | image.monitoring.registry | string | `"keppel.eu-de-1.cloud.sap"` | hostname of the image registry used to pull the monitoring image that currently contains the MySQL exporter for Prometheus |
 | image.os.databasename | string | `"mariadb-galera-ubuntu"` | folder/container used in the image registry and also part of the image name |
 | image.os.databaseversion | float | `22.04` | database part of the image version that should be pulled |
-| image.os.imageversion | int | `20240129111302` | image part of the image version that should be pulled |
+| image.os.imageversion | int | `20240130112825` | image part of the image version that should be pulled |
 | image.os.project | string | `"ccloud"` | project/tenant used in the image registry |
 | image.os.pullPolicy | string | IfNotPresent | `Always` to enforce that the image will be pulled even if it is already available on the worker node |
 | image.os.pullSecret | string | `nil` | name of the defined Kubernetes secret defined in `image.pullSecrets` that should be used for container registry authentication |
 | image.os.registry | string | `"keppel.eu-de-1.cloud.sap"` | hostname of the image registry used to pull the basic OS image that will be used for certain init steps |
 | image.proxy.databasename | string | `"mariadb-galera-proxysql"` | folder/container used in the image registry and also part of the image name |
 | image.proxy.databaseversion | string | `"2.5.5"` | database part of the image version that should be pulled |
-| image.proxy.imageversion | int | `20240129111302` | image part of the image version that should be pulled |
+| image.proxy.imageversion | int | `20240130112825` | image part of the image version that should be pulled |
 | image.proxy.project | string | `"ccloud"` | project/tenant used in the image registry |
 | image.proxy.pullPolicy | string | IfNotPresent | `Always` to enforce that the image will be pulled even if it is already available on the worker node |
 | image.proxy.pullSecret | string | `nil` | name of the defined Kubernetes secret defined in `image.pullSecrets` that should be used for container registry authentication |
@@ -376,7 +376,7 @@ docker build --build-arg BASE_SOFT_NAME=ubuntu --build-arg BASE_SOFT_VERSION=22.
 | mariadb.galera.clustername | string | `nil` | Name of the MariaDB Galera cluster defined with the [wsrep_cluster_name](https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_cluster_name) option. It can also be used as the prefix for all generated objects to avoid name collisions by enabling the `namePrefix.includeClusterName` option |
 | mariadb.galera.debug | bool | false | [Galera debug](https://galeracluster.com/library/documentation/galera-parameters.html#debug) |
 | mariadb.galera.gcache.recover | bool | false | `false` until [PR#624](https://github.com/codership/galera/issues/624) is fixed |
-| mariadb.galera.gtidDomainId | int | 1 | must be a positive integer [wsrep_gtid_domain_id](https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_gtid_domain_id) |
+| mariadb.galera.gtidDomainId | int | 10817 | must be a positive integer [wsrep_gtid_domain_id](https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_gtid_domain_id) do not set it to `1` if you want to avoid server id collisions during [asynchronous replication](#asynchronous-replication-config) |
 | mariadb.galera.gtidDomainIdCount | int | 1 | how many Galera cluster instances will be connected. Used for [asynchronous replication](#asynchronous-replication-config) setups. Maximum of `2` is supported |
 | mariadb.galera.gtidStrictMode | bool | false | enable [gtid_strict_mode](https://mariadb.com/kb/en/gtid/#gtid_strict_mode) |
 | mariadb.galera.logLevel | string | info | [wsrep_debug](https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_debug) |
@@ -401,6 +401,8 @@ docker build --build-arg BASE_SOFT_NAME=ubuntu --build-arg BASE_SOFT_VERSION=22.
 | mariadb.job.config.ttlSecondsAfterFinished | int | 120 | After how many seconds will a stopped MariaDB config job be [deleted from the Kubernetes cluster](https://kubernetes.io/docs/concepts/workloads/controllers/job/#clean-up-finished-jobs-automatically) |
 | mariadb.job.linkerd.enabled | bool | false | enable the [annotation](https://linkerd.io/2.14/tasks/adding-your-service/#meshing-a-service-with-annotations) for linkerd to inject the sidecar container for transport encryption |
 | mariadb.linkerd.enabled | bool | false | enable the [annotation](https://linkerd.io/2.14/tasks/adding-your-service/#meshing-a-service-with-annotations) for linkerd to inject the sidecar container for transport encryption |
+| mariadb.migration.enabled | bool | `false` | if enabled the `mariadb` service will be renamed to `mariadb-replica` and the async replication from the `mariadb` service will be configured Another `mariadb` service (from another subchart) must be available in the same namespace as a source for the async replication |
+| mariadb.migration.stage | string | `"replica"` |  |
 | mariadb.performance_schema | bool | false | to enable the [Performance Schema](https://mariadb.com/kb/en/performance-schema-overview/) |
 | mariadb.roles.contentfullaccess.enabled | bool | `false` | enable this role |
 | mariadb.roles.contentfullaccess.grant | bool | `false` | allow to grant the [privileges](https://mariadb.com/kb/en/grant/#the-grant-option-privilege) to other users |

--- a/common/mariadb-galera/helm/Chart.yaml
+++ b/common/mariadb-galera/helm/Chart.yaml
@@ -3,7 +3,7 @@ name: mariadb-galera
 description: Docker images and Helm chart to deploy a [MariaDB](https://mariadb.com/kb/en/getting-installing-and-upgrading-mariadb/) HA cluster based on [Galera](https://mariadb.com/kb/en/what-is-mariadb-galera-cluster/)
 home: "https://github.com/sapcc/helm-charts/tree/mariadb-galera/common/mariadb-galera"
 appVersion: 10.5.22
-version: 0.22.3
+version: 0.23.0
 type: application
 kubeVersion: ">=1.18"
 maintainers:

--- a/common/mariadb-galera/helm/Chart.yaml
+++ b/common/mariadb-galera/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mariadb-galera
 description: Docker images and Helm chart to deploy a [MariaDB](https://mariadb.com/kb/en/getting-installing-and-upgrading-mariadb/) HA cluster based on [Galera](https://mariadb.com/kb/en/what-is-mariadb-galera-cluster/)
 home: "https://github.com/sapcc/helm-charts/tree/mariadb-galera/common/mariadb-galera"
-appVersion: 10.5.22
-version: 0.23.0
+appVersion: 10.5.23
+version: 0.23.1
 type: application
 kubeVersion: ">=1.18"
 maintainers:

--- a/common/mariadb-galera/helm/scripts/mariadb-galera/common-functions-extended.sh
+++ b/common/mariadb-galera/helm/scripts/mariadb-galera/common-functions-extended.sh
@@ -68,16 +68,6 @@ function fetchcurrentseqno {
   echo ${SEQNOARRAY[1]}
 }
 
-function checkdblogon {
-  mysql --protocol=socket --user=root --database=mysql --wait --connect-timeout=${WAIT_SECONDS} --reconnect --execute="STATUS;" | grep 'Server version:' | grep --silent "${SOFTWARE_VERSION}"
-  if [ $? -eq 0 ]; then
-    echo 'MariaDB MySQL API usable'
-  else
-    echo 'MariaDB MySQL API not usable'
-    exit 1
-  fi
-}
-
 function checkdbk8sservicelogon {
   local ONLY_RETURN_STATUS=${1-false}
 

--- a/common/mariadb-galera/helm/scripts/mariadb-galera/liveness.sh
+++ b/common/mariadb-galera/helm/scripts/mariadb-galera/liveness.sh
@@ -5,8 +5,8 @@ set -o pipefail
 
 source /opt/${SOFTWARE_NAME}/bin/common-functions.sh
 
-function checkdblogon {
-  mysql --protocol=socket --user=root --batch --connect-timeout={{ $.Values.livenessProbe.timeoutSeconds.database }} --execute="SHOW DATABASES;" | grep --silent 'mysql'
+function checkdbconnection {
+  echo ''| socat TCP4-connect:${CONTAINER_IP}:${MYSQL_PORT} stdio | grep --binary-files=text MariaDB | grep --binary-files=text --silent "${SOFTWARE_VERSION}"
   if [ $? -eq 0 ]; then
     echo 'MariaDB MySQL API reachable'
   else
@@ -25,6 +25,6 @@ function checkgaleraport {
   fi
 }
 
-checkdblogon
 checkgaleraport
+checkdbconnection
 setconfigmap "running" "true" "Update"

--- a/common/mariadb-galera/helm/scripts/mariadb-galera/readiness.sh
+++ b/common/mariadb-galera/helm/scripts/mariadb-galera/readiness.sh
@@ -5,6 +5,22 @@ set -o pipefail
 
 source /opt/${SOFTWARE_NAME}/bin/common-functions.sh
 
+function checkdblogon {
+  mysql --protocol=socket --user=root --database=mysql --wait --connect-timeout={{ $.Values.readinessProbe.timeoutSeconds.database }} --reconnect --execute="STATUS;" | grep 'Server version:' | grep --silent "${SOFTWARE_VERSION}"
+  if [ $? -eq 0 ]; then
+    mysql --protocol=socket --user=root --batch --connect-timeout={{ $.Values.readinessProbe.timeoutSeconds.database }} --execute="SHOW DATABASES;" | grep --silent 'mysql'
+    if [ $? -eq 0 ]; then
+      echo 'MariaDB MySQL API usable'
+    else
+      echo 'MariaDB MySQL API not usable'
+      exit 1
+    fi
+  else
+    echo 'MariaDB MySQL API not usable'
+    exit 1
+  fi
+}
+
 function checkgaleraclusterstatus {
   mysql --protocol=socket --user=root --database=mysql --connect-timeout={{ $.Values.readinessProbe.timeoutSeconds.database }} --execute="SHOW GLOBAL STATUS LIKE 'wsrep_cluster_status';" --batch --skip-column-names | grep --silent 'Primary'
   if [ $? -eq 0 ]; then

--- a/common/mariadb-galera/helm/templates/_helpers.tpl
+++ b/common/mariadb-galera/helm/templates/_helpers.tpl
@@ -17,7 +17,11 @@ metadata:
   namespace: {{ .global.Release.Namespace }}
   {{- if eq .replica "notused" }}
     {{- if and (eq .type "frontend") (or (eq .component "database") (eq .component "proxysql") (eq .component "haproxy"))}}
+      {{- if .global.Values.mariadb.migration.enabled }}
+  name: {{ (printf "%s-%s" (include "commonPrefix" .global) "mariadb-replica") }}
+      {{- else }}
   name: {{ (printf "%s-%s" (include "commonPrefix" .global) "mariadb") }}
+      {{- end }}
     {{- else if and (eq .type "frontend") (eq .component "database-direct")}}
   name: {{ (printf "%s-%s-direct" (include "commonPrefix" .global) "mariadb") }}
     {{- else }}

--- a/common/mariadb-galera/helm/templates/configmap-mariadb-my.cnf.yaml
+++ b/common/mariadb-galera/helm/templates/configmap-mariadb-my.cnf.yaml
@@ -20,12 +20,7 @@
 {{- $_ := set $wsrepProviderOptions "pc.wait_prim_timeout" (printf "pc.wait_prim_timeout=PT%dS" ($.Values.mariadb.galera.waitForPrimaryTimeoutInSeconds | default 30 | int)) }}
 {{- if hasKey $.Values.mariadb.galera "gtidDomainIdCount" }}
   {{- if or (lt ($.Values.mariadb.galera.gtidDomainIdCount | int) 1) (gt ($.Values.mariadb.galera.gtidDomainIdCount | int) 2) }}
-  fail "mariadb.galera.gtidDomainIdCount has to be 1 or 2"
-  {{- end }}
-{{- end }}
-{{- if hasKey $.Values.mariadb.galera "gtidDomainId" }}
-  {{- if or (lt ($.Values.mariadb.galera.gtidDomainId | int) 1) (gt ($.Values.mariadb.galera.gtidDomainId | int) 2) }}
-  fail "mariadb.galera.gtidDomainId has to be 1 or 2"
+    {{- fail "mariadb.galera.gtidDomainIdCount has to be 1 or 2" }}
   {{- end }}
 {{- end }}
 ---
@@ -123,7 +118,7 @@ data:
     # async replication with MariaDB instances outside of the Galera cluster
     relay_log=/opt/${SOFTWARE_NAME}/{{ $.Values.mariadb.binLogDir | default "data" }}/{{ (required "mariadb.galera.clustername is required to configure the relay_log option for MariaDB" $.Values.mariadb.galera.clustername) }}_relaylog
     {{- /* https://mariadb.com/kb/en/using-mariadb-replication-with-mariadb-galera-cluster-using-mariadb-replica/#setting-the-same-server_id-on-each-cluster-node */}}
-    server_id={{ $.Values.mariadb.galera.gtidDomainId | default 1 | int }}
+    server_id={{ (printf "%d%d%d%d%d" ($.Values.mariadb.galera.gtidDomainId | default 1 | int) 0 8 1 7) | int }}
     log_slave_updates=on
     {{- if and ($.Values.mariadb.asyncReplication.autostart) ($.Values.mariadb.asyncReplication.enabled) }}
     wsrep_restart_slave=on

--- a/common/mariadb-galera/helm/templates/storageclass.yaml
+++ b/common/mariadb-galera/helm/templates/storageclass.yaml
@@ -16,7 +16,7 @@ metadata:
   name: {{ include "commonPrefix" $ }}-nfs
 parameters:
   pathPattern: "${.PVC.namespace}-${.PVC.name}"
-  onDelete: delete
+  onDelete: "delete"
   archiveOnDelete: "true"
 provisioner: cluster.local/nfs-subdir-external-provisioner
 reclaimPolicy: Delete

--- a/common/mariadb-galera/helm/tests/01-default-statefulset_test.yaml
+++ b/common/mariadb-galera/helm/tests/01-default-statefulset_test.yaml
@@ -1,8 +1,8 @@
 
 ---
 checksums:
-  my.cnf: &mycnf "25a9bd0d9df58ed9bb1b2b8d3a31d6bdd2a0f6b4d4e277da2c0feec2d64ccc42"
-  configmap: &configmap "f8c17888b9c86327163a41eaf4b9b07672cbfacbfe4e7c0b6bc9b2430b142205"
+  my.cnf: &mycnf "5154f9752a947d04e0b5884536fb7d7b488072890bba3c875b6c2afe5316bb0a"
+  configmap: &configmap "3ce595230ab36cda233e0d33a9f1ca9825d78080ada86a99198b093e6d2a7c5a"
 
 suite: statefulset-mariadb
 values:
@@ -310,7 +310,7 @@ tests:
           value: "sysctl-tcp-keepalive"
       - equal:
           path: spec.template.spec.initContainers[0].image
-          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera-ubuntu:22.04-20240129111302"
+          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera-ubuntu:22.04-20240130112825"
       - equal:
           path: spec.template.spec.initContainers[0].imagePullPolicy
           value: "IfNotPresent"
@@ -379,7 +379,7 @@ tests:
           value: "increase-map-count"
       - equal:
           path: spec.template.spec.initContainers[1].image
-          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera-ubuntu:22.04-20240129111302"
+          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera-ubuntu:22.04-20240130112825"
       - equal:
           path: spec.template.spec.initContainers[1].imagePullPolicy
           value: "IfNotPresent"
@@ -471,7 +471,7 @@ tests:
           value: "clean-os-cache"
       - equal:
           path: spec.template.spec.initContainers[2].image
-          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera-ubuntu:22.04-20240129111302"
+          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera-ubuntu:22.04-20240130112825"
       - equal:
           path: spec.template.spec.initContainers[2].imagePullPolicy
           value: "IfNotPresent"
@@ -541,7 +541,7 @@ tests:
           value: "db"
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera:10.5.22-20240129111302"
+          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera:10.5.23-20240130112825"
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: "IfNotPresent"
@@ -1640,7 +1640,7 @@ tests:
           value: "metrics"
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera-mysqld_exporter:0.14.0-20240129111302"
+          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera-mysqld_exporter:0.14.0-20240130112825"
       - equal:
           path: spec.template.spec.containers[1].imagePullPolicy
           value: "IfNotPresent"

--- a/common/mariadb-galera/helm/tests/01-default-statefulset_test.yaml
+++ b/common/mariadb-galera/helm/tests/01-default-statefulset_test.yaml
@@ -310,7 +310,7 @@ tests:
           value: "sysctl-tcp-keepalive"
       - equal:
           path: spec.template.spec.initContainers[0].image
-          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera-ubuntu:22.04-20240130112825"
+          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera-ubuntu:22.04-20240212072432"
       - equal:
           path: spec.template.spec.initContainers[0].imagePullPolicy
           value: "IfNotPresent"
@@ -379,7 +379,7 @@ tests:
           value: "increase-map-count"
       - equal:
           path: spec.template.spec.initContainers[1].image
-          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera-ubuntu:22.04-20240130112825"
+          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera-ubuntu:22.04-20240212072432"
       - equal:
           path: spec.template.spec.initContainers[1].imagePullPolicy
           value: "IfNotPresent"
@@ -471,7 +471,7 @@ tests:
           value: "clean-os-cache"
       - equal:
           path: spec.template.spec.initContainers[2].image
-          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera-ubuntu:22.04-20240130112825"
+          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera-ubuntu:22.04-20240212072432"
       - equal:
           path: spec.template.spec.initContainers[2].imagePullPolicy
           value: "IfNotPresent"
@@ -541,7 +541,7 @@ tests:
           value: "db"
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera:10.5.23-20240130112825"
+          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera:10.5.23-20240212072432"
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: "IfNotPresent"
@@ -1640,7 +1640,7 @@ tests:
           value: "metrics"
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera-mysqld_exporter:0.14.0-20240130112825"
+          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera-mysqld_exporter:0.14.0-20240212072432"
       - equal:
           path: spec.template.spec.containers[1].imagePullPolicy
           value: "IfNotPresent"

--- a/common/mariadb-galera/helm/tests/02-services-mariadb-galera_test.yaml
+++ b/common/mariadb-galera/helm/tests/02-services-mariadb-galera_test.yaml
@@ -974,3 +974,37 @@ tests:
       - equal:
           path: spec.sessionAffinityConfig.clientIP.timeoutSeconds
           value: 28800
+  - it: database service name changed if migration option is enabled
+    template: service.yaml
+    documentSelector:
+      path: metadata.name
+      value: testrelease-mariadb-replica
+    set:
+      mariadb.galera.clustername: "testclustername"
+      mariadb.migration.enabled: true
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: testrelease-mariadb-replica
+      - equal:
+          path: metadata.labels.app
+          value: testrelease
+  - it: database service name changed if migration option is disabled
+    template: service.yaml
+    documentSelector:
+      path: metadata.name
+      value: testrelease-mariadb
+    set:
+      mariadb.galera.clustername: "testclustername"
+      mariadb.migration.enabled: false
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: testrelease-mariadb
+      - equal:
+          path: metadata.labels.app
+          value: testrelease

--- a/common/mariadb-galera/helm/tests/02-services-mariadb-galera_test.yaml
+++ b/common/mariadb-galera/helm/tests/02-services-mariadb-galera_test.yaml
@@ -974,6 +974,7 @@ tests:
       - equal:
           path: spec.sessionAffinityConfig.clientIP.timeoutSeconds
           value: 28800
+
   - it: database service name changed if migration option is enabled
     template: service.yaml
     documentSelector:
@@ -988,9 +989,13 @@ tests:
       - equal:
           path: metadata.name
           value: testrelease-mariadb-replica
+      - notEqual:
+          path: metadata.name
+          value: testrelease-mariadb
       - equal:
           path: metadata.labels.app
           value: testrelease
+
   - it: database service name changed if migration option is disabled
     template: service.yaml
     documentSelector:
@@ -1005,6 +1010,9 @@ tests:
       - equal:
           path: metadata.name
           value: testrelease-mariadb
+      - notEqual:
+          path: metadata.name
+          value: testrelease-mariadb-replica
       - equal:
           path: metadata.labels.app
           value: testrelease

--- a/common/mariadb-galera/helm/tests/03-configmap-mariadb_test.yaml
+++ b/common/mariadb-galera/helm/tests/03-configmap-mariadb_test.yaml
@@ -1,5 +1,5 @@
 ---
-suite: mariadb-galera-services
+suite: mariadb-galera-configmaps
 values:
   - default_values.yaml
 set:
@@ -10,7 +10,7 @@ release:
 templates:
   - configmap-mariadb.yaml
 tests:
-  - it: default mariadb entrypoint script 
+  - it: default mariadb entrypoint script
     template: configmap-mariadb.yaml
     documentIndex: 0
     set:

--- a/common/mariadb-galera/helm/tests/04-configmap-mariadb-my-cnf_test.yaml
+++ b/common/mariadb-galera/helm/tests/04-configmap-mariadb-my-cnf_test.yaml
@@ -1,5 +1,5 @@
 ---
-suite: mariadb-my-cnf-configmap
+suite: mariadb-galera-configmaps
 values:
   - default_values.yaml
 set:

--- a/common/mariadb-galera/helm/tests/04-configmap-mariadb-my-cnf_test.yaml
+++ b/common/mariadb-galera/helm/tests/04-configmap-mariadb-my-cnf_test.yaml
@@ -95,7 +95,7 @@ tests:
       - matchRegex:
           path: data["my.cnf.testrelease-mariadb-g-0.tpl"]
           pattern: |
-            server_id=1
+            server_id=10817
             log_slave_updates=on
             wsrep_restart_slave=off
             report-host=testrelease-mariadb-g-0

--- a/common/mariadb-galera/helm/values.yaml
+++ b/common/mariadb-galera/helm/values.yaml
@@ -724,7 +724,7 @@ image:
     # -- database part of the image version that should be pulled
     databaseversion: 22.04
     # -- image part of the image version that should be pulled
-    imageversion: 20240130112825
+    imageversion: 20240212072432
     # -- (string) `Always` to enforce that the image will be pulled even if it is already available on the worker node
     # @default -- IfNotPresent
     pullPolicy:
@@ -740,7 +740,7 @@ image:
     # -- database part of the image version that should be pulled
     databaseversion: 10.5.23
     # -- image part of the image version that should be pulled
-    imageversion: 20240130112825
+    imageversion: 20240212072432
     # -- (string) `Always` to enforce that the image will be pulled even if it is already available on the worker node
     # @default -- IfNotPresent
     pullPolicy:
@@ -756,7 +756,7 @@ image:
     # -- database part of the image version that should be pulled
     databaseversion: 0.14.0
     # -- image part of the image version that should be pulled
-    imageversion: 20240130112825
+    imageversion: 20240212072432
     # -- (string) `Always` to enforce that the image will be pulled even if it is already available on the worker node
     # @default -- IfNotPresent
     pullPolicy:
@@ -772,7 +772,7 @@ image:
     # -- database part of the image version that should be pulled
     databaseversion: 2.5.5
     # -- image part of the image version that should be pulled
-    imageversion: 20240130112825
+    imageversion: 20240212072432
     # -- (string) `Always` to enforce that the image will be pulled even if it is already available on the worker node
     # @default -- IfNotPresent
     pullPolicy:
@@ -788,7 +788,7 @@ image:
     # -- database part of the image version that should be pulled
     databaseversion: 0.12.1
     # -- image part of the image version that should be pulled
-    imageversion: 20240130112825
+    imageversion: 20240212072432
     # -- (string) `Always` to enforce that the image will be pulled even if it is already available on the worker node
     # @default -- IfNotPresent
     pullPolicy:

--- a/common/mariadb-galera/helm/values.yaml
+++ b/common/mariadb-galera/helm/values.yaml
@@ -87,6 +87,11 @@ mariadb:
     # -- (bool) enable the [annotation](https://linkerd.io/2.14/tasks/adding-your-service/#meshing-a-service-with-annotations) for linkerd to inject the sidecar container for transport encryption
     # @default -- false
     enabled:
+  migration:
+    # -- (bool) if enabled the `mariadb` service will be renamed to `mariadb-replica` and the async replication from the `mariadb` service will be configured
+    # Another `mariadb` service (from another subchart) must be available in the same namespace as a source for the async replication
+    enabled: false
+    stage: replica
   job:
     config:
       # -- How many [retries](https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy) before the MariaDB config job will be marked as failed
@@ -146,8 +151,9 @@ mariadb:
     # @default -- 4
     slaveThreads: 16
     # -- (int) must be a positive integer [wsrep_gtid_domain_id](https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_gtid_domain_id)
-    # @default -- 1
-    gtidDomainId: 1
+    # do not set it to `1` if you want to avoid server id collisions during [asynchronous replication](#asynchronous-replication-config)
+    # @default -- 10817
+    gtidDomainId:
     # -- (int) how many Galera cluster instances will be connected. Used for [asynchronous replication](#asynchronous-replication-config) setups. Maximum of `2` is supported
     # @default -- 1
     gtidDomainIdCount: 1
@@ -718,7 +724,7 @@ image:
     # -- database part of the image version that should be pulled
     databaseversion: 22.04
     # -- image part of the image version that should be pulled
-    imageversion: 20240129111302
+    imageversion: 20240130112825
     # -- (string) `Always` to enforce that the image will be pulled even if it is already available on the worker node
     # @default -- IfNotPresent
     pullPolicy:
@@ -732,9 +738,9 @@ image:
     # -- folder/container used in the image registry and also part of the image name
     databasename: mariadb-galera
     # -- database part of the image version that should be pulled
-    databaseversion: 10.5.22
+    databaseversion: 10.5.23
     # -- image part of the image version that should be pulled
-    imageversion: 20240129111302
+    imageversion: 20240130112825
     # -- (string) `Always` to enforce that the image will be pulled even if it is already available on the worker node
     # @default -- IfNotPresent
     pullPolicy:
@@ -750,7 +756,7 @@ image:
     # -- database part of the image version that should be pulled
     databaseversion: 0.14.0
     # -- image part of the image version that should be pulled
-    imageversion: 20240129111302
+    imageversion: 20240130112825
     # -- (string) `Always` to enforce that the image will be pulled even if it is already available on the worker node
     # @default -- IfNotPresent
     pullPolicy:
@@ -766,7 +772,7 @@ image:
     # -- database part of the image version that should be pulled
     databaseversion: 2.5.5
     # -- image part of the image version that should be pulled
-    imageversion: 20240129111302
+    imageversion: 20240130112825
     # -- (string) `Always` to enforce that the image will be pulled even if it is already available on the worker node
     # @default -- IfNotPresent
     pullPolicy:
@@ -782,7 +788,7 @@ image:
     # -- database part of the image version that should be pulled
     databaseversion: 0.12.1
     # -- image part of the image version that should be pulled
-    imageversion: 20240129111302
+    imageversion: 20240130112825
     # -- (string) `Always` to enforce that the image will be pulled even if it is already available on the worker node
     # @default -- IfNotPresent
     pullPolicy:


### PR DESCRIPTION
- to allow migrations from another MariaDB service in the same K8s cluster
- chart version bumped
- gtidDomainId default set to 10817 to avoid server_id collisions for async replication setups
- gtidDomainId check removed, we want to support ids other than 1 or 2 to avoid async replication problems
- unit test rules updated
- DB logon removed from the liveness check to avoid pod restarts only because the credentials are wrong
- checkdbconnection added to still check if MariaDB provides a usable endpoint