### PR TITLE
kube-state-metrics exporter: align on external prometheus label

### DIFF
--- a/prometheus-exporters/kube-state-metrics-exporter/Chart.yaml
+++ b/prometheus-exporters/kube-state-metrics-exporter/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Helm chart for collecting metrics from kube-state-metrics.
 name: kube-state-metrics-exporter
-version: 0.1.9
+version: 0.2.0

--- a/prometheus-exporters/kube-state-metrics-exporter/templates/servicemonitor.yaml
+++ b/prometheus-exporters/kube-state-metrics-exporter/templates/servicemonitor.yaml
@@ -25,10 +25,11 @@ spec:
   endpoints:
     - port: http
       honorLabels: {{ default true .Values.honorLabels }}
-      relabelings:
+      metricRelabelings:
         - action: replace
           targetLabel: prometheus
           replacement: {{ printf "%s/%s" $.Release.Namespace (required ".Values.prometheusName missing" .Values.prometheusName) }}
+      relabelings:
         - action: labelmap
           regex: '__meta_kubernetes_service_label_(.+)'
         - sourceLabels:

--- a/prometheus-exporters/kube-state-metrics-exporter/templates/servicemonitor.yaml
+++ b/prometheus-exporters/kube-state-metrics-exporter/templates/servicemonitor.yaml
@@ -28,7 +28,7 @@ spec:
       relabelings:
         - action: replace
           targetLabel: prometheus
-          replacement: {{ required ".Values.prometheusName missing" .Values.prometheusName }}
+          replacement: {{ printf "%s/%s" $.Release.Namespace (required ".Values.prometheusName missing" .Values.prometheusName) }}
         - action: labelmap
           regex: '__meta_kubernetes_service_label_(.+)'
         - sourceLabels:


### PR DESCRIPTION
If a prometheus label exists on a metric, then it should have the form `prometheus="<namespace/prometheus-name>"`, as each prometheus attaches an external label of the same name to each metric. Otherwise duplicate metrics will be created.