### PR TITLE
rollback to last working version

### DIFF
--- a/system/prometheus-crds/Chart.yaml
+++ b/system/prometheus-crds/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: prometheus-crds
 description: A Helm chart containing Prometheus CRDs.
 type: application
-version: 6.2.0
+version: 6.3.0

--- a/system/prometheus-crds/crds/alertmanagerconfigs.monitoring.coreos.com.yaml
+++ b/system/prometheus-crds/crds/alertmanagerconfigs.monitoring.coreos.com.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
-    operator.prometheus.io/version: 0.71.2
+    operator.prometheus.io/version: 0.70.0
   name: alertmanagerconfigs.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -63,7 +63,7 @@ spec:
                               minLength: 1
                               type: string
                             regex:
-                              description: 'Whether to match on equality (false) or regular-expression (true). Deprecated: for AlertManager >= v0.22.0, `matchType` should be used instead.'
+                              description: Whether to match on equality (false) or regular-expression (true). Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.
                               type: boolean
                             value:
                               description: Label value to match.
@@ -90,7 +90,7 @@ spec:
                               minLength: 1
                               type: string
                             regex:
-                              description: 'Whether to match on equality (false) or regular-expression (true). Deprecated: for AlertManager >= v0.22.0, `matchType` should be used instead.'
+                              description: Whether to match on equality (false) or regular-expression (true). Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.
                               type: boolean
                             value:
                               description: Label value to match.
@@ -4263,7 +4263,7 @@ spec:
                             minLength: 1
                             type: string
                           regex:
-                            description: 'Whether to match on equality (false) or regular-expression (true). Deprecated: for AlertManager >= v0.22.0, `matchType` should be used instead.'
+                            description: Whether to match on equality (false) or regular-expression (true). Deprecated as of AlertManager >= v0.22.0 where a user should use MatchType instead.
                             type: boolean
                           value:
                             description: Label value to match.

--- a/system/prometheus-crds/crds/alertmanagers.monitoring.coreos.com.yaml
+++ b/system/prometheus-crds/crds/alertmanagers.monitoring.coreos.com.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
-    operator.prometheus.io/version: 0.71.2
+    operator.prometheus.io/version: 0.70.0
   name: alertmanagers.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -1045,7 +1045,7 @@ spec:
                   description: 'AutomountServiceAccountToken indicates whether a service account token should be automatically mounted in the pod. If the service account has `automountServiceAccountToken: true`, set the field to `false` to opt out of automounting API credentials.'
                   type: boolean
                 baseImage:
-                  description: 'Base image that is used to deploy pods, without tag. Deprecated: use ''image'' instead.'
+                  description: 'Base image that is used to deploy pods, without tag. Deprecated: use ''image'' instead'
                   type: string
                 clusterAdvertiseAddress:
                   description: 'ClusterAdvertiseAddress is the explicit address to advertise in cluster. Needs to be provided for non RFC1918 [1] (public) addresses. [1] RFC1918: https://tools.ietf.org/html/rfc1918'
@@ -1053,9 +1053,6 @@ spec:
                 clusterGossipInterval:
                   description: Interval between gossip attempts.
                   pattern: ^(0|(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
-                  type: string
-                clusterLabel:
-                  description: Defines the identifier that uniquely identifies the Alertmanager cluster. You should only set it when the Alertmanager cluster includes Alertmanager instances which are external to this Alertmanager resource. In practice, the addresses of the external instances are provided via the `.spec.additionalPeers` field.
                   type: string
                 clusterPeerTimeout:
                   description: Timeout for cluster peering.
@@ -2965,13 +2962,13 @@ spec:
                   description: ServiceAccountName is the name of the ServiceAccount to use to run the Prometheus Pods.
                   type: string
                 sha:
-                  description: 'SHA of Alertmanager container image to be deployed. Defaults to the value of `version`. Similar to a tag, but the SHA explicitly deploys an immutable container image. Version and Tag are ignored if SHA is set. Deprecated: use ''image'' instead. The image digest can be specified as part of the image URL.'
+                  description: 'SHA of Alertmanager container image to be deployed. Defaults to the value of `version`. Similar to a tag, but the SHA explicitly deploys an immutable container image. Version and Tag are ignored if SHA is set. Deprecated: use ''image'' instead.  The image digest can be specified as part of the image URL.'
                   type: string
                 storage:
                   description: Storage is the definition of how storage will be used by the Alertmanager instances.
                   properties:
                     disableMountSubPath:
-                      description: 'Deprecated: subPath usage will be removed in a future release.'
+                      description: '*Deprecated: subPath usage will be removed in a future release.*'
                       type: boolean
                     emptyDir:
                       description: 'EmptyDirVolumeSource to be used by the StatefulSet. If specified, it takes precedence over `ephemeral` and `volumeClaimTemplate`. More info: https://kubernetes.io/docs/concepts/storage/volumes/#emptydir'
@@ -3271,7 +3268,7 @@ spec:
                               type: string
                           type: object
                         status:
-                          description: 'Deprecated: this field is never set.'
+                          description: '*Deprecated: this field is never set.*'
                           properties:
                             accessModes:
                               description: 'accessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
@@ -3339,7 +3336,7 @@ spec:
                       type: object
                   type: object
                 tag:
-                  description: 'Tag of Alertmanager container image to be deployed. Defaults to the value of `version`. Version is ignored if Tag is set. Deprecated: use ''image'' instead. The image tag can be specified as part of the image URL.'
+                  description: 'Tag of Alertmanager container image to be deployed. Defaults to the value of `version`. Version is ignored if Tag is set. Deprecated: use ''image'' instead.  The image tag can be specified as part of the image URL.'
                   type: string
                 tolerations:
                   description: If specified, the pod's tolerations.

--- a/system/prometheus-crds/crds/podmonitors.monitoring.coreos.com.yaml
+++ b/system/prometheus-crds/crds/podmonitors.monitoring.coreos.com.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
-    operator.prometheus.io/version: 0.71.2
+    operator.prometheus.io/version: 0.70.0
   name: podmonitors.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/system/prometheus-crds/crds/probes.monitoring.coreos.com.yaml
+++ b/system/prometheus-crds/crds/probes.monitoring.coreos.com.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
-    operator.prometheus.io/version: 0.71.2
+    operator.prometheus.io/version: 0.70.0
   name: probes.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/system/prometheus-crds/crds/prometheusagents.monitoring.coreos.com.yaml
+++ b/system/prometheus-crds/crds/prometheusagents.monitoring.coreos.com.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
-    operator.prometheus.io/version: 0.71.2
+    operator.prometheus.io/version: 0.70.0
   name: prometheusagents.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -632,10 +632,10 @@ spec:
                           x-kubernetes-map-type: atomic
                       type: object
                     bearerToken:
-                      description: "*Warning: this field shouldn't be used because the token value appears in clear-text. Prefer using `authorization`.* \n Deprecated: this will be removed in a future release."
+                      description: "*Warning: this field shouldn't be used because the token value appears in clear-text. Prefer using `authorization`.* \n *Deprecated: this will be removed in a future release.*"
                       type: string
                     bearerTokenFile:
-                      description: "File to read bearer token for accessing apiserver. \n Cannot be set at the same time as `basicAuth`, `authorization`, or `bearerToken`. \n Deprecated: this will be removed in a future release. Prefer using `authorization`."
+                      description: "File to read bearer token for accessing apiserver. \n Cannot be set at the same time as `basicAuth`, `authorization`, or `bearerToken`. \n *Deprecated: this will be removed in a future release. Prefer using `authorization`.*"
                       type: string
                     host:
                       description: Kubernetes API address consisting of a hostname or IP address followed by an optional port number.
@@ -2570,11 +2570,6 @@ spec:
                     - warn
                     - error
                   type: string
-                maximumStartupDurationSeconds:
-                  description: Defines the maximum time that the `prometheus` container's startup probe will wait before being considered failed. The startup probe will return success after the WAL replay is complete. If set, the value should be greater than 60 (seconds). Otherwise it will be equal to 600 seconds (15 minutes).
-                  format: int32
-                  minimum: 60
-                  type: integer
                 minReadySeconds:
                   description: "Minimum number of seconds for which a newly created Pod should be ready without any of its container crashing for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready) \n This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling the StatefulSetMinReadySeconds feature gate."
                   format: int32
@@ -2886,14 +2881,11 @@ spec:
                             x-kubernetes-map-type: atomic
                         type: object
                       bearerToken:
-                        description: "*Warning: this field shouldn't be used because the token value appears in clear-text. Prefer using `authorization`.* \n Deprecated: this will be removed in a future release."
+                        description: "*Warning: this field shouldn't be used because the token value appears in clear-text. Prefer using `authorization`.* \n *Deprecated: this will be removed in a future release.*"
                         type: string
                       bearerTokenFile:
-                        description: "File from which to read bearer token for the URL. \n Deprecated: this will be removed in a future release. Prefer using `authorization`."
+                        description: "File from which to read bearer token for the URL. \n *Deprecated: this will be removed in a future release. Prefer using `authorization`.*"
                         type: string
-                      enableHTTP2:
-                        description: Whether to enable HTTP2.
-                        type: boolean
                       headers:
                         additionalProperties:
                           type: string
@@ -3535,7 +3527,7 @@ spec:
                   description: Storage defines the storage used by Prometheus.
                   properties:
                     disableMountSubPath:
-                      description: 'Deprecated: subPath usage will be removed in a future release.'
+                      description: '*Deprecated: subPath usage will be removed in a future release.*'
                       type: boolean
                     emptyDir:
                       description: 'EmptyDirVolumeSource to be used by the StatefulSet. If specified, it takes precedence over `ephemeral` and `volumeClaimTemplate`. More info: https://kubernetes.io/docs/concepts/storage/volumes/#emptydir'
@@ -3835,7 +3827,7 @@ spec:
                               type: string
                           type: object
                         status:
-                          description: 'Deprecated: this field is never set.'
+                          description: '*Deprecated: this field is never set.*'
                           properties:
                             accessModes:
                               description: 'accessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
@@ -3932,13 +3924,8 @@ spec:
                 topologySpreadConstraints:
                   description: Defines the pod's topology spread constraints if specified.
                   items:
+                    description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                     properties:
-                      additionalLabelSelectors:
-                        description: Defines what Prometheus Operator managed labels should be added to labelSelector on the topologySpreadConstraint.
-                        enum:
-                          - OnResource
-                          - OnShard
-                        type: string
                       labelSelector:
                         description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
                         properties:
@@ -5345,9 +5332,6 @@ spec:
                   description: Total number of non-terminated pods targeted by this Prometheus deployment (their labels match the selector).
                   format: int32
                   type: integer
-                selector:
-                  description: The selector used to match the pods targeted by this Prometheus resource.
-                  type: string
                 shardStatuses:
                   description: The list has one entry per shard. Each entry provides a summary of the shard status.
                   items:
@@ -5382,10 +5366,6 @@ spec:
                   x-kubernetes-list-map-keys:
                     - shardID
                   x-kubernetes-list-type: map
-                shards:
-                  description: Shards is the most recently observed number of shards.
-                  format: int32
-                  type: integer
                 unavailableReplicas:
                   description: Total number of unavailable pods targeted by this Prometheus deployment.
                   format: int32
@@ -5407,8 +5387,4 @@ spec:
       served: true
       storage: true
       subresources:
-        scale:
-          labelSelectorPath: .status.selector
-          specReplicasPath: .spec.shards
-          statusReplicasPath: .status.shards
         status: {}

--- a/system/prometheus-crds/crds/prometheuses.monitoring.coreos.com.yaml
+++ b/system/prometheus-crds/crds/prometheuses.monitoring.coreos.com.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
-    operator.prometheus.io/version: 0.71.2
+    operator.prometheus.io/version: 0.70.0
   name: prometheuses.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -669,7 +669,7 @@ spec:
                                 x-kubernetes-map-type: atomic
                             type: object
                           bearerTokenFile:
-                            description: "File to read bearer token for Alertmanager. \n Cannot be set at the same time as `basicAuth`, `authorization`, or `sigv4`. \n Deprecated: this will be removed in a future release. Prefer using `authorization`."
+                            description: "File to read bearer token for Alertmanager. \n Cannot be set at the same time as `basicAuth`, `authorization`, or `sigv4`. \n *Deprecated: this will be removed in a future release. Prefer using `authorization`.*"
                             type: string
                           enableHttp2:
                             description: Whether to enable HTTP2.
@@ -858,7 +858,7 @@ spec:
                     - alertmanagers
                   type: object
                 allowOverlappingBlocks:
-                  description: "AllowOverlappingBlocks enables vertical compaction and vertical query merge in Prometheus. \n Deprecated: this flag has no effect for Prometheus >= 2.39.0 where overlapping blocks are enabled by default."
+                  description: "AllowOverlappingBlocks enables vertical compaction and vertical query merge in Prometheus. \n *Deprecated: this flag has no effect for Prometheus >= 2.39.0 where overlapping blocks are enabled by default.*"
                   type: boolean
                 apiserverConfig:
                   description: 'APIServerConfig allows specifying a host and auth methods to access the Kuberntees API server. If null, Prometheus is assumed to run inside of the cluster: it will discover the API servers automatically and use the Pod''s CA certificate and bearer token file at /var/run/secrets/kubernetes.io/serviceaccount/.'
@@ -926,10 +926,10 @@ spec:
                           x-kubernetes-map-type: atomic
                       type: object
                     bearerToken:
-                      description: "*Warning: this field shouldn't be used because the token value appears in clear-text. Prefer using `authorization`.* \n Deprecated: this will be removed in a future release."
+                      description: "*Warning: this field shouldn't be used because the token value appears in clear-text. Prefer using `authorization`.* \n *Deprecated: this will be removed in a future release.*"
                       type: string
                     bearerTokenFile:
-                      description: "File to read bearer token for accessing apiserver. \n Cannot be set at the same time as `basicAuth`, `authorization`, or `bearerToken`. \n Deprecated: this will be removed in a future release. Prefer using `authorization`."
+                      description: "File to read bearer token for accessing apiserver. \n Cannot be set at the same time as `basicAuth`, `authorization`, or `bearerToken`. \n *Deprecated: this will be removed in a future release. Prefer using `authorization`.*"
                       type: string
                     host:
                       description: Kubernetes API address consisting of a hostname or IP address followed by an optional port number.
@@ -1051,7 +1051,7 @@ spec:
                       type: boolean
                   type: object
                 baseImage:
-                  description: 'Deprecated: use ''spec.image'' instead.'
+                  description: '*Deprecated: use ''spec.image'' instead.*'
                   type: string
                 bodySizeLimit:
                   description: BodySizeLimit defines per-scrape on response body size. Only valid in Prometheus versions 2.45.0 and newer.
@@ -2886,11 +2886,6 @@ spec:
                     - warn
                     - error
                   type: string
-                maximumStartupDurationSeconds:
-                  description: Defines the maximum time that the `prometheus` container's startup probe will wait before being considered failed. The startup probe will return success after the WAL replay is complete. If set, the value should be greater than 60 (seconds). Otherwise it will be equal to 600 seconds (15 minutes).
-                  format: int32
-                  minimum: 60
-                  type: integer
                 minReadySeconds:
                   description: "Minimum number of seconds for which a newly created Pod should be ready without any of its container crashing for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready) \n This is an alpha field from kubernetes 1.22 until 1.24 which requires enabling the StatefulSetMinReadySeconds feature gate."
                   format: int32
@@ -3076,7 +3071,7 @@ spec:
                   description: "Name of Prometheus external label used to denote the Prometheus instance name. The external label will _not_ be added when the field is set to the empty string (`\"\"`). \n Default: \"prometheus\""
                   type: string
                 prometheusRulesExcludedFromEnforce:
-                  description: 'Defines the list of PrometheusRule objects to which the namespace label enforcement doesn''t apply. This is only relevant when `spec.enforcedNamespaceLabel` is set to true. Deprecated: use `spec.excludedFromEnforcement` instead.'
+                  description: 'Defines the list of PrometheusRule objects to which the namespace label enforcement doesn''t apply. This is only relevant when `spec.enforcedNamespaceLabel` is set to true. *Deprecated: use `spec.excludedFromEnforcement` instead.*'
                   items:
                     description: PrometheusRuleExcludeConfig enables users to configure excluded PrometheusRule names and their namespaces to be ignored while enforcing namespace label for alerts and metrics.
                     properties:
@@ -3188,10 +3183,10 @@ spec:
                             x-kubernetes-map-type: atomic
                         type: object
                       bearerToken:
-                        description: "*Warning: this field shouldn't be used because the token value appears in clear-text. Prefer using `authorization`.* \n Deprecated: this will be removed in a future release."
+                        description: "*Warning: this field shouldn't be used because the token value appears in clear-text. Prefer using `authorization`.* \n *Deprecated: this will be removed in a future release.*"
                         type: string
                       bearerTokenFile:
-                        description: "File from which to read the bearer token for the URL. \n Deprecated: this will be removed in a future release. Prefer using `authorization`."
+                        description: "File from which to read the bearer token for the URL. \n *Deprecated: this will be removed in a future release. Prefer using `authorization`.*"
                         type: string
                       filterExternalLabels:
                         description: "Whether to use the external labels as selectors for the remote read endpoint. \n It requires Prometheus >= v2.34.0."
@@ -3531,14 +3526,11 @@ spec:
                             x-kubernetes-map-type: atomic
                         type: object
                       bearerToken:
-                        description: "*Warning: this field shouldn't be used because the token value appears in clear-text. Prefer using `authorization`.* \n Deprecated: this will be removed in a future release."
+                        description: "*Warning: this field shouldn't be used because the token value appears in clear-text. Prefer using `authorization`.* \n *Deprecated: this will be removed in a future release.*"
                         type: string
                       bearerTokenFile:
-                        description: "File from which to read bearer token for the URL. \n Deprecated: this will be removed in a future release. Prefer using `authorization`."
+                        description: "File from which to read bearer token for the URL. \n *Deprecated: this will be removed in a future release. Prefer using `authorization`.*"
                         type: string
-                      enableHTTP2:
-                        description: Whether to enable HTTP2.
-                        type: boolean
                       headers:
                         additionalProperties:
                           type: string
@@ -4260,7 +4252,7 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 sha:
-                  description: 'Deprecated: use ''spec.image'' instead. The image''s digest can be specified as part of the image name.'
+                  description: '*Deprecated: use ''spec.image'' instead. The image''s digest can be specified as part of the image name.*'
                   type: string
                 shards:
                   description: "EXPERIMENTAL: Number of shards to distribute targets onto. `spec.replicas` multiplied by `spec.shards` is the total number of Pods created. \n Note that scaling down shards will not reshard data onto remaining instances, it must be manually moved. Increasing shards will not reshard data either but it will continue to be available from the same instances. To query globally, use Thanos sidecar and Thanos querier or remote write data to a central location. \n Sharding is performed on the content of the `__address__` target meta-label for PodMonitors and ServiceMonitors and `__param_target__` for Probes. \n Default: 1"
@@ -4270,7 +4262,7 @@ spec:
                   description: Storage defines the storage used by Prometheus.
                   properties:
                     disableMountSubPath:
-                      description: 'Deprecated: subPath usage will be removed in a future release.'
+                      description: '*Deprecated: subPath usage will be removed in a future release.*'
                       type: boolean
                     emptyDir:
                       description: 'EmptyDirVolumeSource to be used by the StatefulSet. If specified, it takes precedence over `ephemeral` and `volumeClaimTemplate`. More info: https://kubernetes.io/docs/concepts/storage/volumes/#emptydir'
@@ -4570,7 +4562,7 @@ spec:
                               type: string
                           type: object
                         status:
-                          description: 'Deprecated: this field is never set.'
+                          description: '*Deprecated: this field is never set.*'
                           properties:
                             accessModes:
                               description: 'accessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
@@ -4638,7 +4630,7 @@ spec:
                       type: object
                   type: object
                 tag:
-                  description: 'Deprecated: use ''spec.image'' instead. The image''s tag can be specified as part of the image name.'
+                  description: '*Deprecated: use ''spec.image'' instead. The image''s tag can be specified as part of the image name.*'
                   type: string
                 targetLimit:
                   description: TargetLimit defines a limit on the number of scraped targets that will be accepted. Only valid in Prometheus versions 2.45.0 and newer.
@@ -4664,7 +4656,7 @@ spec:
                         type: object
                       type: array
                     baseImage:
-                      description: 'Deprecated: use ''image'' instead.'
+                      description: '*Deprecated: use ''image'' instead.*'
                       type: string
                     blockSize:
                       default: 2h
@@ -4796,7 +4788,7 @@ spec:
                       description: "Container image name for Thanos. If specified, it takes precedence over the `spec.thanos.baseImage`, `spec.thanos.tag` and `spec.thanos.sha` fields. \n Specifying `spec.thanos.version` is still necessary to ensure the Prometheus Operator knows which version of Thanos is being configured. \n If neither `spec.thanos.image` nor `spec.thanos.baseImage` are defined, the operator will use the latest upstream version of Thanos available at the time when the operator was released."
                       type: string
                     listenLocal:
-                      description: 'Deprecated: use `grpcListenLocal` and `httpListenLocal` instead.'
+                      description: '*Deprecated: use `grpcListenLocal` and `httpListenLocal` instead.*'
                       type: boolean
                     logFormat:
                       description: Log format for the Thanos sidecar.
@@ -4878,10 +4870,10 @@ spec:
                           type: object
                       type: object
                     sha:
-                      description: 'Deprecated: use ''image'' instead.  The image digest can be specified as part of the image name.'
+                      description: '*Deprecated: use ''image'' instead.  The image digest can be specified as part of the image name.*'
                       type: string
                     tag:
-                      description: 'Deprecated: use ''image'' instead. The image''s tag can be specified as as part of the image name.'
+                      description: '*Deprecated: use ''image'' instead. The image''s tag can be specified as part of the image name.*'
                       type: string
                     tracingConfig:
                       description: "Defines the tracing configuration for the Thanos sidecar. \n More info: https://thanos.io/tip/thanos/tracing.md/ \n This is an experimental feature, it may change in any upcoming release in a breaking way. \n tracingConfigFile takes precedence over this field."
@@ -4960,13 +4952,8 @@ spec:
                 topologySpreadConstraints:
                   description: Defines the pod's topology spread constraints if specified.
                   items:
+                    description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                     properties:
-                      additionalLabelSelectors:
-                        description: Defines what Prometheus Operator managed labels should be added to labelSelector on the topologySpreadConstraint.
-                        enum:
-                          - OnResource
-                          - OnShard
-                        type: string
                       labelSelector:
                         description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
                         properties:
@@ -6381,9 +6368,6 @@ spec:
                   description: Total number of non-terminated pods targeted by this Prometheus deployment (their labels match the selector).
                   format: int32
                   type: integer
-                selector:
-                  description: The selector used to match the pods targeted by this Prometheus resource.
-                  type: string
                 shardStatuses:
                   description: The list has one entry per shard. Each entry provides a summary of the shard status.
                   items:
@@ -6418,10 +6402,6 @@ spec:
                   x-kubernetes-list-map-keys:
                     - shardID
                   x-kubernetes-list-type: map
-                shards:
-                  description: Shards is the most recently observed number of shards.
-                  format: int32
-                  type: integer
                 unavailableReplicas:
                   description: Total number of unavailable pods targeted by this Prometheus deployment.
                   format: int32
@@ -6443,8 +6423,4 @@ spec:
       served: true
       storage: true
       subresources:
-        scale:
-          labelSelectorPath: .status.selector
-          specReplicasPath: .spec.shards
-          statusReplicasPath: .status.shards
         status: {}

--- a/system/prometheus-crds/crds/prometheusrules.monitoring.coreos.com.yaml
+++ b/system/prometheus-crds/crds/prometheusrules.monitoring.coreos.com.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
-    operator.prometheus.io/version: 0.71.2
+    operator.prometheus.io/version: 0.70.0
   name: prometheusrules.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/system/prometheus-crds/crds/scrapeconfigs.monitoring.coreos.com.yaml
+++ b/system/prometheus-crds/crds/scrapeconfigs.monitoring.coreos.com.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
-    operator.prometheus.io/version: 0.71.2
+    operator.prometheus.io/version: 0.70.0
   name: scrapeconfigs.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -228,7 +228,7 @@ spec:
                         description: Namespaces are only supported in Consul Enterprise.
                         type: string
                       noProxy:
-                        description: "`noProxy` is a comma-separated string that can contain IPs, CIDR notation, domain names that should be excluded from proxying. IP and domain names can contain port numbers. \n It requires Prometheus >= v2.43.0."
+                        description: Comma-separated string that can contain IPs, CIDR notation, domain names that should be excluded from proxying. IP and domain names can contain port numbers.
                         type: string
                       nodeMeta:
                         additionalProperties:
@@ -330,15 +330,14 @@ spec:
                             - key
                           type: object
                           x-kubernetes-map-type: atomic
-                        description: "ProxyConnectHeader optionally specifies headers to send to proxies during CONNECT requests. \n It requires Prometheus >= v2.43.0."
+                        description: Specifies headers to send to proxies during CONNECT requests.
                         type: object
                         x-kubernetes-map-type: atomic
                       proxyFromEnvironment:
-                        description: "Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY). If unset, Prometheus uses its default value. \n It requires Prometheus >= v2.43.0."
+                        description: Use proxy URL indicated by environment variables (HTTP_PROXY, https_proxy, HTTPs_PROXY, https_proxy, and no_proxy) If unset, Prometheus uses its default value.
                         type: boolean
                       proxyUrl:
-                        description: "`proxyURL` defines the HTTP proxy server to use. \n It requires Prometheus >= v2.43.0."
-                        pattern: ^http(s)?://.+$
+                        description: Optional proxy URL.
                         type: string
                       refreshInterval:
                         description: The time after which the provided names are refreshed. On large setup it might be a good idea to increase this value because the catalog will change all the time. If unset, Prometheus uses its default value.
@@ -707,36 +706,6 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                         type: object
-                      noProxy:
-                        description: "`noProxy` is a comma-separated string that can contain IPs, CIDR notation, domain names that should be excluded from proxying. IP and domain names can contain port numbers. \n It requires Prometheus >= v2.43.0."
-                        type: string
-                      proxyConnectHeader:
-                        additionalProperties:
-                          description: SecretKeySelector selects a key of a Secret.
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                            optional:
-                              description: Specify whether the Secret or its key must be defined
-                              type: boolean
-                          required:
-                            - key
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        description: "ProxyConnectHeader optionally specifies headers to send to proxies during CONNECT requests. \n It requires Prometheus >= v2.43.0."
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      proxyFromEnvironment:
-                        description: "Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY). If unset, Prometheus uses its default value. \n It requires Prometheus >= v2.43.0."
-                        type: boolean
-                      proxyUrl:
-                        description: "`proxyURL` defines the HTTP proxy server to use. \n It requires Prometheus >= v2.43.0."
-                        pattern: ^http(s)?://.+$
-                        type: string
                       refreshInterval:
                         description: RefreshInterval configures the refresh interval at which Prometheus will re-query the endpoint to update the target list.
                         pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
@@ -857,197 +826,6 @@ spec:
                   items:
                     description: KubernetesSDConfig allows retrieving scrape targets from Kubernetes' REST API. See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config
                     properties:
-                      apiServer:
-                        description: The API server address consisting of a hostname or IP address followed by an optional port number. If left empty, Prometheus is assumed to run inside of the cluster. It will discover API servers automatically and use the pod's CA certificate and bearer token file at /var/run/secrets/kubernetes.io/serviceaccount/.
-                        type: string
-                      attachMetadata:
-                        description: Optional metadata to attach to discovered targets. It requires Prometheus >= v2.35.0 for `pod` role and Prometheus >= v2.37.0 for `endpoints` and `endpointslice` roles.
-                        properties:
-                          node:
-                            description: Attaches node metadata to discovered targets. When set to true, Prometheus must have the `get` permission on the `Nodes` objects. Only valid for Pod, Endpoint and Endpointslice roles.
-                            type: boolean
-                        type: object
-                      authorization:
-                        description: Authorization header to use on every scrape request. Cannot be set at the same time as `basicAuth`, or `oauth2`.
-                        properties:
-                          credentials:
-                            description: Selects a key of a Secret in the namespace that contains the credentials for authentication.
-                            properties:
-                              key:
-                                description: The key of the secret to select from.  Must be a valid secret key.
-                                type: string
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                                type: string
-                              optional:
-                                description: Specify whether the Secret or its key must be defined
-                                type: boolean
-                            required:
-                              - key
-                            type: object
-                            x-kubernetes-map-type: atomic
-                          type:
-                            description: "Defines the authentication type. The value is case-insensitive. \n \"Basic\" is not a supported value. \n Default: \"Bearer\""
-                            type: string
-                        type: object
-                      basicAuth:
-                        description: BasicAuth information to use on every scrape request. Cannot be set at the same time as `authorization`, or `oauth2`.
-                        properties:
-                          password:
-                            description: '`password` specifies a key of a Secret containing the password for authentication.'
-                            properties:
-                              key:
-                                description: The key of the secret to select from.  Must be a valid secret key.
-                                type: string
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                                type: string
-                              optional:
-                                description: Specify whether the Secret or its key must be defined
-                                type: boolean
-                            required:
-                              - key
-                            type: object
-                            x-kubernetes-map-type: atomic
-                          username:
-                            description: '`username` specifies a key of a Secret containing the username for authentication.'
-                            properties:
-                              key:
-                                description: The key of the secret to select from.  Must be a valid secret key.
-                                type: string
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                                type: string
-                              optional:
-                                description: Specify whether the Secret or its key must be defined
-                                type: boolean
-                            required:
-                              - key
-                            type: object
-                            x-kubernetes-map-type: atomic
-                        type: object
-                      enableHTTP2:
-                        description: Whether to enable HTTP2.
-                        type: boolean
-                      followRedirects:
-                        description: Configure whether HTTP requests follow HTTP 3xx redirects.
-                        type: boolean
-                      namespaces:
-                        description: Optional namespace discovery. If omitted, Prometheus discovers targets across all namespaces.
-                        properties:
-                          names:
-                            description: List of namespaces where to watch for resources. If empty and `ownNamespace` isn't true, Prometheus watches for resources in all namespaces.
-                            items:
-                              type: string
-                            type: array
-                          ownNamespace:
-                            description: Includes the namespace in which the Prometheus pod exists to the list of watched namesapces.
-                            type: boolean
-                        type: object
-                      noProxy:
-                        description: "`noProxy` is a comma-separated string that can contain IPs, CIDR notation, domain names that should be excluded from proxying. IP and domain names can contain port numbers. \n It requires Prometheus >= v2.43.0."
-                        type: string
-                      oauth2:
-                        description: Optional OAuth 2.0 configuration. Cannot be set at the same time as `authorization`, or `basicAuth`.
-                        properties:
-                          clientId:
-                            description: '`clientId` specifies a key of a Secret or ConfigMap containing the OAuth2 client''s ID.'
-                            properties:
-                              configMap:
-                                description: ConfigMap containing data to use for the targets.
-                                properties:
-                                  key:
-                                    description: The key to select.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the ConfigMap or its key must be defined
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              secret:
-                                description: Secret containing data to use for the targets.
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.  Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the Secret or its key must be defined
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                                x-kubernetes-map-type: atomic
-                            type: object
-                          clientSecret:
-                            description: '`clientSecret` specifies a key of a Secret containing the OAuth2 client''s secret.'
-                            properties:
-                              key:
-                                description: The key of the secret to select from.  Must be a valid secret key.
-                                type: string
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                                type: string
-                              optional:
-                                description: Specify whether the Secret or its key must be defined
-                                type: boolean
-                            required:
-                              - key
-                            type: object
-                            x-kubernetes-map-type: atomic
-                          endpointParams:
-                            additionalProperties:
-                              type: string
-                            description: '`endpointParams` configures the HTTP parameters to append to the token URL.'
-                            type: object
-                          scopes:
-                            description: '`scopes` defines the OAuth2 scopes used for the token request.'
-                            items:
-                              type: string
-                            type: array
-                          tokenUrl:
-                            description: '`tokenURL` configures the URL to fetch the token from.'
-                            minLength: 1
-                            type: string
-                        required:
-                          - clientId
-                          - clientSecret
-                          - tokenUrl
-                        type: object
-                      proxyConnectHeader:
-                        additionalProperties:
-                          description: SecretKeySelector selects a key of a Secret.
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                            optional:
-                              description: Specify whether the Secret or its key must be defined
-                              type: boolean
-                          required:
-                            - key
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        description: "ProxyConnectHeader optionally specifies headers to send to proxies during CONNECT requests. \n It requires Prometheus >= v2.43.0."
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      proxyFromEnvironment:
-                        description: "Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY). If unset, Prometheus uses its default value. \n It requires Prometheus >= v2.43.0."
-                        type: boolean
-                      proxyUrl:
-                        description: "`proxyURL` defines the HTTP proxy server to use. \n It requires Prometheus >= v2.43.0."
-                        pattern: ^http(s)?://.+$
-                        type: string
                       role:
                         description: Role of the Kubernetes entities that should be discovered.
                         enum:
@@ -1096,104 +874,6 @@ spec:
                         x-kubernetes-list-map-keys:
                           - role
                         x-kubernetes-list-type: map
-                      tlsConfig:
-                        description: TLS configuration to use on every scrape request.
-                        properties:
-                          ca:
-                            description: Certificate authority used when verifying server certificates.
-                            properties:
-                              configMap:
-                                description: ConfigMap containing data to use for the targets.
-                                properties:
-                                  key:
-                                    description: The key to select.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the ConfigMap or its key must be defined
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              secret:
-                                description: Secret containing data to use for the targets.
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.  Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the Secret or its key must be defined
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                                x-kubernetes-map-type: atomic
-                            type: object
-                          cert:
-                            description: Client certificate to present when doing client-authentication.
-                            properties:
-                              configMap:
-                                description: ConfigMap containing data to use for the targets.
-                                properties:
-                                  key:
-                                    description: The key to select.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the ConfigMap or its key must be defined
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              secret:
-                                description: Secret containing data to use for the targets.
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.  Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the Secret or its key must be defined
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                                x-kubernetes-map-type: atomic
-                            type: object
-                          insecureSkipVerify:
-                            description: Disable target certificate validation.
-                            type: boolean
-                          keySecret:
-                            description: Secret containing the client key file for the targets.
-                            properties:
-                              key:
-                                description: The key of the secret to select from.  Must be a valid secret key.
-                                type: string
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                                type: string
-                              optional:
-                                description: Specify whether the Secret or its key must be defined
-                                type: boolean
-                            required:
-                              - key
-                            type: object
-                            x-kubernetes-map-type: atomic
-                          serverName:
-                            description: Used to verify the hostname for the targets.
-                            type: string
-                        type: object
                     required:
                       - role
                     type: object
@@ -1270,208 +950,6 @@ spec:
                 metricsPath:
                   description: MetricsPath HTTP path to scrape for metrics. If empty, Prometheus uses the default value (e.g. /metrics).
                   type: string
-                noProxy:
-                  description: "`noProxy` is a comma-separated string that can contain IPs, CIDR notation, domain names that should be excluded from proxying. IP and domain names can contain port numbers. \n It requires Prometheus >= v2.43.0."
-                  type: string
-                openstackSDConfigs:
-                  description: OpenStackSDConfigs defines a list of OpenStack service discovery configurations.
-                  items:
-                    description: OpenStackSDConfig allow retrieving scrape targets from OpenStack Nova instances. See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#openstack_sd_config
-                    properties:
-                      allTenants:
-                        description: Whether the service discovery should list all instances for all projects. It is only relevant for the 'instance' role and usually requires admin permissions.
-                        type: boolean
-                      applicationCredentialId:
-                        description: ApplicationCredentialID
-                        type: string
-                      applicationCredentialName:
-                        description: The ApplicationCredentialID or ApplicationCredentialName fields are required if using an application credential to authenticate. Some providers allow you to create an application credential to authenticate rather than a password.
-                        type: string
-                      applicationCredentialSecret:
-                        description: The applicationCredentialSecret field is required if using an application credential to authenticate.
-                        properties:
-                          key:
-                            description: The key of the secret to select from.  Must be a valid secret key.
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                          optional:
-                            description: Specify whether the Secret or its key must be defined
-                            type: boolean
-                        required:
-                          - key
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      availability:
-                        description: Availability of the endpoint to connect to.
-                        enum:
-                          - Public
-                          - public
-                          - Admin
-                          - admin
-                          - Internal
-                          - internal
-                        type: string
-                      domainID:
-                        description: DomainID
-                        type: string
-                      domainName:
-                        description: At most one of domainId and domainName must be provided if using username with Identity V3. Otherwise, either are optional.
-                        type: string
-                      identityEndpoint:
-                        description: IdentityEndpoint specifies the HTTP endpoint that is required to work with the Identity API of the appropriate version.
-                        type: string
-                      password:
-                        description: Password for the Identity V2 and V3 APIs. Consult with your provider's control panel to discover your account's preferred method of authentication.
-                        properties:
-                          key:
-                            description: The key of the secret to select from.  Must be a valid secret key.
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                          optional:
-                            description: Specify whether the Secret or its key must be defined
-                            type: boolean
-                        required:
-                          - key
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      port:
-                        description: The port to scrape metrics from. If using the public IP address, this must instead be specified in the relabeling rule.
-                        type: integer
-                      projectID:
-                        description: ProjectID
-                        type: string
-                      projectName:
-                        description: The ProjectId and ProjectName fields are optional for the Identity V2 API. Some providers allow you to specify a ProjectName instead of the ProjectId. Some require both. Your provider's authentication policies will determine how these fields influence authentication.
-                        type: string
-                      refreshInterval:
-                        description: Refresh interval to re-read the instance list.
-                        pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
-                        type: string
-                      region:
-                        description: The OpenStack Region.
-                        minLength: 1
-                        type: string
-                      role:
-                        description: The OpenStack role of entities that should be discovered.
-                        enum:
-                          - Instance
-                          - instance
-                          - Hypervisor
-                          - hypervisor
-                        type: string
-                      tlsConfig:
-                        description: TLS configuration applying to the target HTTP endpoint.
-                        properties:
-                          ca:
-                            description: Certificate authority used when verifying server certificates.
-                            properties:
-                              configMap:
-                                description: ConfigMap containing data to use for the targets.
-                                properties:
-                                  key:
-                                    description: The key to select.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the ConfigMap or its key must be defined
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              secret:
-                                description: Secret containing data to use for the targets.
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.  Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the Secret or its key must be defined
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                                x-kubernetes-map-type: atomic
-                            type: object
-                          cert:
-                            description: Client certificate to present when doing client-authentication.
-                            properties:
-                              configMap:
-                                description: ConfigMap containing data to use for the targets.
-                                properties:
-                                  key:
-                                    description: The key to select.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the ConfigMap or its key must be defined
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              secret:
-                                description: Secret containing data to use for the targets.
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.  Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the Secret or its key must be defined
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                                x-kubernetes-map-type: atomic
-                            type: object
-                          insecureSkipVerify:
-                            description: Disable target certificate validation.
-                            type: boolean
-                          keySecret:
-                            description: Secret containing the client key file for the targets.
-                            properties:
-                              key:
-                                description: The key of the secret to select from.  Must be a valid secret key.
-                                type: string
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                                type: string
-                              optional:
-                                description: Specify whether the Secret or its key must be defined
-                                type: boolean
-                            required:
-                              - key
-                            type: object
-                            x-kubernetes-map-type: atomic
-                          serverName:
-                            description: Used to verify the hostname for the targets.
-                            type: string
-                        type: object
-                      userid:
-                        description: UserID
-                        type: string
-                      username:
-                        description: Username is required if using Identity V2 API. Consult with your provider's control panel to discover your account's username. In Identity V3, either userid or a combination of username and domainId or domainName are needed
-                        type: string
-                    required:
-                      - region
-                      - role
-                    type: object
-                  type: array
                 params:
                   additionalProperties:
                     items:
@@ -1480,33 +958,6 @@ spec:
                   description: Optional HTTP URL parameters
                   type: object
                   x-kubernetes-map-type: atomic
-                proxyConnectHeader:
-                  additionalProperties:
-                    description: SecretKeySelector selects a key of a Secret.
-                    properties:
-                      key:
-                        description: The key of the secret to select from.  Must be a valid secret key.
-                        type: string
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                        type: string
-                      optional:
-                        description: Specify whether the Secret or its key must be defined
-                        type: boolean
-                    required:
-                      - key
-                    type: object
-                    x-kubernetes-map-type: atomic
-                  description: "ProxyConnectHeader optionally specifies headers to send to proxies during CONNECT requests. \n It requires Prometheus >= v2.43.0."
-                  type: object
-                  x-kubernetes-map-type: atomic
-                proxyFromEnvironment:
-                  description: "Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY). If unset, Prometheus uses its default value. \n It requires Prometheus >= v2.43.0."
-                  type: boolean
-                proxyUrl:
-                  description: "`proxyURL` defines the HTTP proxy server to use. \n It requires Prometheus >= v2.43.0."
-                  pattern: ^http(s)?://.+$
-                  type: string
                 relabelings:
                   description: 'RelabelConfigs defines how to rewrite the target''s labels before scraping. Prometheus Operator automatically adds relabelings for a few standard Kubernetes fields. The original scrape job''s name is available via the `__tmp_prometheus_job_name` label. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
                   items:

--- a/system/prometheus-crds/crds/servicemonitors.monitoring.coreos.com.yaml
+++ b/system/prometheus-crds/crds/servicemonitors.monitoring.coreos.com.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
-    operator.prometheus.io/version: 0.71.2
+    operator.prometheus.io/version: 0.70.0
   name: servicemonitors.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/system/prometheus-crds/crds/thanosrulers.monitoring.coreos.com.yaml
+++ b/system/prometheus-crds/crds/thanosrulers.monitoring.coreos.com.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
-    operator.prometheus.io/version: 0.71.2
+    operator.prometheus.io/version: 0.70.0
   name: thanosrulers.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -2755,7 +2755,7 @@ spec:
                   description: Storage spec to specify how storage shall be used.
                   properties:
                     disableMountSubPath:
-                      description: 'Deprecated: subPath usage will be removed in a future release.'
+                      description: '*Deprecated: subPath usage will be removed in a future release.*'
                       type: boolean
                     emptyDir:
                       description: 'EmptyDirVolumeSource to be used by the StatefulSet. If specified, it takes precedence over `ephemeral` and `volumeClaimTemplate`. More info: https://kubernetes.io/docs/concepts/storage/volumes/#emptydir'
@@ -3055,7 +3055,7 @@ spec:
                               type: string
                           type: object
                         status:
-                          description: 'Deprecated: this field is never set.'
+                          description: '*Deprecated: this field is never set.*'
                           properties:
                             accessModes:
                               description: 'accessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'


### PR DESCRIPTION
everything above v0.70.0 is introducing subresources which are not working with VPA sticking with v0.70.0 for now
see https://github.com/prometheus-operator/prometheus-operator/issues/6291