### PR TITLE
Move postfixDNS one level up

### DIFF
--- a/openstack/cronus/templates/nebula/_config.yaml.tpl
+++ b/openstack/cronus/templates/nebula/_config.yaml.tpl
@@ -162,11 +162,11 @@ nebula:
 {{- if .Values.postfix.postfixEnabled }}
   postfixEnabled: {{ .Values.postfix.postfixEnabled }}
   postfixDNS:
-    zoneID: {{ .Values.postfix.postfixDNS.zoneID }}
+    zoneID: {{ .Values.postfixDNS.zoneID }}
     auth:
-      auth_url: {{ .Values.postfix.postfixDNS.auth.auth_url }}
-      application_credential_id: {{ .Values.postfix.postfixDNS.auth.application_credential_id }}
-      application_credential_secret: {{ .Values.postfix.postfixDNS.auth.application_credential_secret }}
+      auth_url: {{ .Values.postfixDNS.auth.auth_url }}
+      application_credential_id: {{ .Values.postfixDNS.auth.application_credential_id }}
+      application_credential_secret: {{ .Values.postfixDNS.auth.application_credential_secret }}
   ldap:
     url: "{{ tpl .Values.postfix.ldap.url $ }}"
     {{- if .Values.postfix.ldap.clientKeyPath }}


### PR DESCRIPTION
postfixDNS is not part of the postfix values but has its own layer. Moving it up one level.