### PR TITLE
[Nova] Resolve OpenstackNovaComputeIdle alert

### DIFF
--- a/openstack/nova/alerts/metrics-metal/nova.alerts
+++ b/openstack/nova/alerts/metrics-metal/nova.alerts
@@ -1,16 +1,3 @@
 groups:
 - name: openstack-nova.alerts
-  rules:
-  - alert: OpenstackNovaComputeIdle
-    expr: (max(label_replace(rate(container_cpu_usage_seconds_total{pod_name=~"nova-compute-bb.*"}[5m]), 'host', '$1', 'pod_name', '(nova-compute-bb[0-9]+).*')) by (host) * 1000 < 15) AND (max(nova_compute_service_status) by (host) == 1)
-    for: 60m
-    labels:
-      severity: warning
-      support_group: compute-storage-api
-      tier: os
-      service: 'nova'
-      meta: 'Something is fishy with pod of host {{ $labels.host }}, it usually uses more CPU.'
-      playbook: docs/devops/alert/nova/#OpenstackNovaComputeIdle
-    annotations:
-      description: 'Something is fishy with pod of host {{ $labels.host }}, it usually uses more CPU.'
-      summary: 'Pod idles, but normally does not.'
+  rules: []


### PR DESCRIPTION
This alert was very generic as it checked the CPU consumption of a pod against a hard limit. By now, we have services time and time again that do not see enough load i.e. are idling most of the time. Therefore, this alerts creates seemingly only false notifications by now.

Initially, we introduced this alert to find services that do not react to RPC messages anymore. This hasn't occurred for a long time. If we need this kind of monitoring again, we should look into the RPC ping endpoint available from `oslo.messaging` and maybe into monitoring the number of greenthreads or Lock waiters.

Even though there's no alert left for the "metrics-metal" source, we keep it in place to make it easy to add new alerts again.