### PR TITLE
kube-monitoring-*: upgrade kube-state-metrics-exporter

### DIFF
--- a/system/kube-monitoring-admin-k3s/Chart.lock
+++ b/system/kube-monitoring-admin-k3s/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 4.7.0
 - name: kube-state-metrics-exporter
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.7
+  version: 0.2.0
 - name: ntp-exporter
   repository: https://charts.eu-de-2.cloud.sap
   version: 2.5.0
@@ -50,5 +50,5 @@ dependencies:
 - name: kubelet-stats-metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.5
-digest: sha256:978b8edc1cd3caec6768ce9ca5d1b3ac694ca5a9bbfd95284c8e6dd522a54bac
-generated: "2024-02-12T12:54:41.256633312+01:00"
+digest: sha256:8f75c1d88c1a6806f0d7f98fc5b47dbc7b1611ec8119dc1b0de79f85c828d67f
+generated: "2024-02-12T14:26:47.380644+01:00"

--- a/system/kube-monitoring-admin-k3s/Chart.yaml
+++ b/system/kube-monitoring-admin-k3s/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes admin k3s cluster monitoring.
 name: kube-monitoring-admin-k3s
-version: 4.4.27
+version: 4.5.0
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-admin-k3s
 dependencies:
   - condition: absent-metrics-operator.enabled
@@ -23,7 +23,7 @@ dependencies:
     version: 4.7.0
   - name: kube-state-metrics-exporter
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.7
+    version: 0.2.0
   - name: ntp-exporter
     repository: https://charts.eu-de-2.cloud.sap
     version: 2.5.0

--- a/system/kube-monitoring-kubernikus/Chart.lock
+++ b/system/kube-monitoring-kubernikus/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 4.16.0
 - name: kube-state-metrics-exporter
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.7
+  version: 0.2.0
 - name: kubernikus-monitoring
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.2.0
@@ -59,5 +59,5 @@ dependencies:
 - name: kubelet-stats-metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.5
-digest: sha256:cc94ca9db7694c1d2c290c849ffd0addaea278440a29d0dcbf85b9da61ac8160
-generated: "2024-02-12T12:55:44.063840914+01:00"
+digest: sha256:1810f262058b57c9f484e6aecafdb2cdb2444c4d7023666508af59a2e16c9177
+generated: "2024-02-12T14:27:03.9112+01:00"

--- a/system/kube-monitoring-kubernikus/Chart.yaml
+++ b/system/kube-monitoring-kubernikus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for monitoring Kubernikus.
 name: kube-monitoring-kubernikus
-version: 7.6.17
+version: 7.7.0
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-kubernikus
 dependencies:
   - condition: absent-metrics-operator.enabled
@@ -23,7 +23,7 @@ dependencies:
     version: 4.16.0
   - name: kube-state-metrics-exporter
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.7
+    version: 0.2.0
   - name: kubernikus-monitoring
     repository: https://charts.eu-de-2.cloud.sap
     version: 1.2.0

--- a/system/kube-monitoring-metal/Chart.lock
+++ b/system/kube-monitoring-metal/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 2.9.4
 - name: kube-state-metrics-exporter
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.7
+  version: 0.2.0
 - name: ntp-exporter
   repository: https://charts.eu-de-2.cloud.sap
   version: 2.5.0
@@ -50,5 +50,5 @@ dependencies:
 - name: kubelet-stats-metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.5
-digest: sha256:3ab2c487314fa56976dce06de2a1a9998512116144916aef8228ae65d0264b47
-generated: "2024-02-12T12:57:06.927621351+01:00"
+digest: sha256:a0dedced98fe33d18f774938bfbf55b02f4380a51f67d18ab0d3df279905ba66
+generated: "2024-02-12T14:27:23.723347+01:00"

--- a/system/kube-monitoring-metal/Chart.yaml
+++ b/system/kube-monitoring-metal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes metal controlplane monitoring.
 name: kube-monitoring-metal
-version: 4.5.30
+version: 4.6.0
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-metal
 dependencies:
   - condition: absent-metrics-operator.enabled
@@ -23,7 +23,7 @@ dependencies:
     version: 2.9.4
   - name: kube-state-metrics-exporter
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.7
+    version: 0.2.0
   - name: ntp-exporter
     repository: https://charts.eu-de-2.cloud.sap
     version: 2.5.0

--- a/system/kube-monitoring-scaleout/Chart.lock
+++ b/system/kube-monitoring-scaleout/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 5.13.0
 - name: kube-state-metrics-exporter
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.7
+  version: 0.2.0
 - name: ntp-exporter
   repository: https://charts.eu-de-2.cloud.sap
   version: 2.5.0
@@ -50,5 +50,5 @@ dependencies:
 - name: kubelet-stats-metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.5
-digest: sha256:a49d873ea85098095b71b9f4d72f44c222722d2c441fc60c86be0c7a7f123d9c
-generated: "2024-02-12T14:10:08.628599416+01:00"
+digest: sha256:65b97db1955c0089b4d0fcc9b2e061196f94b3be713089e1f0e0bbce762607f2
+generated: "2024-02-12T14:26:06.078493+01:00"

--- a/system/kube-monitoring-scaleout/Chart.yaml
+++ b/system/kube-monitoring-scaleout/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kubernetes scaleout cluster monitoring.
 name: kube-monitoring-scaleout
-version: 4.8.24
+version: 4.9.0
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-scaleout
 dependencies:
   - condition: absent-metrics-operator.enabled
@@ -23,7 +23,7 @@ dependencies:
     version: 5.13.0
   - name: kube-state-metrics-exporter
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.7
+    version: 0.2.0
   - name: ntp-exporter
     repository: https://charts.eu-de-2.cloud.sap
     version: 2.5.0

--- a/system/kube-monitoring-virtual/Chart.lock
+++ b/system/kube-monitoring-virtual/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 4.14.0
 - name: kube-state-metrics-exporter
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.1.7
+  version: 0.2.0
 - name: kubernikus-monitoring
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.2.0
@@ -53,5 +53,5 @@ dependencies:
 - name: kubelet-stats-metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.5
-digest: sha256:1cdbd90e754cdee151a85f2ef88931211901e306edfecd357b8f80dfa603c165
-generated: "2024-02-12T12:58:06.759942632+01:00"
+digest: sha256:f702c5be99395d750d5b5fd582c52727c9fcc4f4c422a897c74cee56ed7700b7
+generated: "2024-02-12T14:27:55.929824+01:00"

--- a/system/kube-monitoring-virtual/Chart.yaml
+++ b/system/kube-monitoring-virtual/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes virtual cluster monitoring.
 name: kube-monitoring-virtual
-version: 6.7.16
+version: 6.8.0
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-virtual
 dependencies:
   - condition: absent-metrics-operator.enabled
@@ -23,7 +23,7 @@ dependencies:
     version: 4.14.0
   - name: kube-state-metrics-exporter
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.1.7
+    version: 0.2.0
   - name: kubernikus-monitoring
     repository: https://charts.eu-de-2.cloud.sap
     version: 1.2.0


### PR DESCRIPTION
aligns with the prometheus label