### PR TITLE
avoid eph storage overutilisation

### DIFF
--- a/system/vmware-monitoring/Chart.yaml
+++ b/system/vmware-monitoring/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vmware-monitoring
-version: 1.6.4
+version: 1.6.5
 description: VMware Monitoring and Metrics Collection
 dependencies:
   - name: prometheus-server

--- a/system/vmware-monitoring/values.yaml
+++ b/system/vmware-monitoring/values.yaml
@@ -24,7 +24,7 @@ thanos:
   compactor:
     resources:
       requests:
-        ephemeralStorage: "10Gi"
+        ephemeralStorage: "15Gi"
 
 prometheus-server:
   vmware: true


### PR DESCRIPTION
This should fix the issue of pod evictions due to an overshooting of ephemeral-storage. It is going to decrease the amount of compactor pods in state Error or ContainerStatusUnknown drastically.