### PR TITLE
adding VM metrics

### DIFF
--- a/system/vmware-monitoring/templates/collector-configmap.yaml
+++ b/system/vmware-monitoring/templates/collector-configmap.yaml
@@ -434,8 +434,6 @@ data:
         key: "net|bytesRx_average"
       - metric_suffix: "network_data_transmitted_kilobytes_per_second"
         key: "net|bytesTx_average"
-      - metric_suffix: "network_usage_rate_kilobytes_per_second"
-        key: "net|usage_average"
 
     VMStatsVirtualDiskCollector:
     # INFO - Prefix: vrops_virtualmachine_
@@ -453,7 +451,7 @@ data:
         key: "virtualDisk|totalReadLatency_average"
       - metric_suffix: "virtual_disk_average_write_miliseconds"
         key: "virtualDisk|totalWriteLatency_average"
-      - metric_suffix: "virtual_disk_average_commands_per_seconds"
+      - metric_suffix: "virtual_disk_average_commands_per_second"
         key: "virtualDisk:Aggregate of all instances|commandsAveraged_average"
 
     VMStatsDefaultCollector:
@@ -542,7 +540,7 @@ data:
         key: "guestfilesystem:/|capacity"
       - metric_suffix: "guestfilesystem_percentage"
         key: "guestfilesystem:/|percentage"
-      - metric_suffix: "system_os_uptime_latest"
+      - metric_suffix: "system_os_uptime_seconds"
         key: "sys|osUptime_latest"
       - metric_suffix: "system_powered_on"
         key: "sys|poweredOn"

--- a/system/vmware-monitoring/templates/collector-configmap.yaml
+++ b/system/vmware-monitoring/templates/collector-configmap.yaml
@@ -374,6 +374,8 @@ data:
         key: "summary|oversized|memory"
       - metric_suffix: "memory_guest_usage_kilobytes"
         key: "mem|guest_usage"
+      - metric_suffix: "memory_workload_percentage"
+        key: "mem|workload"
 
     VMStatsCPUCollector:
     # INFO - Prefix: vrops_virtualmachine_
@@ -432,6 +434,8 @@ data:
         key: "net|bytesRx_average"
       - metric_suffix: "network_data_transmitted_kilobytes_per_second"
         key: "net|bytesTx_average"
+      - metric_suffix: "network_usage_rate_kilobytes_per_second"
+        key: "net|usage_average"
 
     VMStatsVirtualDiskCollector:
     # INFO - Prefix: vrops_virtualmachine_
@@ -449,6 +453,8 @@ data:
         key: "virtualDisk|totalReadLatency_average"
       - metric_suffix: "virtual_disk_average_write_miliseconds"
         key: "virtualDisk|totalWriteLatency_average"
+      - metric_suffix: "virtual_disk_average_commands_per_seconds"
+        key: "virtualDisk:Aggregate of all instances|commandsAveraged_average"
 
     VMStatsDefaultCollector:
     # INFO - Prefix: vrops_virtualmachine_
@@ -536,6 +542,10 @@ data:
         key: "guestfilesystem:/|capacity"
       - metric_suffix: "guestfilesystem_percentage"
         key: "guestfilesystem:/|percentage"
+      - metric_suffix: "system_os_uptime_latest"
+        key: "sys|osUptime_latest"
+      - metric_suffix: "system_powered_on"
+        key: "sys|poweredOn"
 
     NSXTMgmtClusterStatsCollector:
     # INFO - Prefix: vrops_nsxt_mgmt_cluster_


### PR DESCRIPTION
Following VM metrics have been added - memory_workload_percentage, virtual_disk_average_commands_per_seconds, network_usage_rate_kilobytes_per_second, system_os_uptime_latest, system_powered_on