### PR TITLE
metis: move to prometheus service url

### DIFF
--- a/system/metis/Chart.yaml
+++ b/system/metis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: metis
-version: 0.0.26
+version: 0.0.27
 description: Read-only DB for replicas of OpenStack DBs and Project Masterdata
 dependencies:
   - condition: mariadb.enabled

--- a/system/metis/templates/metis-etc-configmap.yaml
+++ b/system/metis/templates/metis-etc-configmap.yaml
@@ -21,9 +21,7 @@ data:
 {{- if .Values.metis.prometheus.enabled }}
     prometheus:
       enabled: {{ .Values.metis.prometheus.enabled }}
-      prometheusURL: "https://prometheus-openstack.{{ .Values.global.region }}.{{ .Values.global.tld }}"
-      certPath: "/etc/certs/tls.crt"
-      keyPath: "/etc/certs/tls.key"
+      prometheusURL: "http://prometheus-openstack.prometheus-openstack.svc:9090"
       cronSchedule: "*/30 * * * *"
 {{- end }}
     db:


### PR DESCRIPTION
The prometheus Ingresses will be 2FA protected soon.

## Note:
 I removed `certPath` and `keyPath`. I'm not sure if the application will fail if they are no longer present. Please vaildate.