### PR TITLE
Enable NSXT caching of transport zone ID

### DIFF
--- a/openstack/neutron/templates/vct-nsxv3-agent-configmap.yaml
+++ b/openstack/neutron/templates/vct-nsxv3-agent-configmap.yaml
@@ -38,6 +38,10 @@ template: |
       {%- endif %}
       {{- end }}
 
+      [cache]
+      enabled = true
+      backend = dogpile.cache.memory
+
       [NSXV3]
       nsxv3_login_user = osapinsxt
       {%- set bb = name | replace( "bb", "") | int %}

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -296,6 +296,7 @@ drivers:
         nsxv3_policy_migration_limit: 6
         nsxv3_remove_orphan_ports_after: 2
         nsxv3_default_policy_infrastructure_rules: true
+        nsxv3_transport_zone_id_cache_time: 86400
 
 # cisco_ucsm_bm:
 #  example.com:


### PR DESCRIPTION
Default cache time is 86400 seconds. caching is based on oslo.cache.

During the building block build up, the transport zone id, fetched during agent start, might change resulting in failing regression tests. Without the correct transport zone id, the agent is not able to bind a port correctly.