### PR TITLE
deployment for native vpa alerts

### DIFF
--- a/common/prometheus-server/CHANGELOG.md
+++ b/common/prometheus-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.4.15
+
+* only deploy VPA alerts to kubernikus and kubernetes natively
+
 ## 7.4.14
 
 * default value for shards

--- a/common/prometheus-server/CHANGELOG.md
+++ b/common/prometheus-server/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 7.4.15
 
-* only deploy VPA alerts to kubernikus and kubernetes natively
+* Added failsafe to Prometheus kubernetes and kubernikus specific alerts with hint to thanos ruler.
+* improved VPA alerts
 
 ## 7.4.14
 

--- a/common/prometheus-server/Chart.yaml
+++ b/common/prometheus-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus via operator.
 name: prometheus-server
-version: 7.4.14
+version: 7.4.15
 appVersion: v2.47.2
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
 maintainers:

--- a/common/prometheus-server/templates/alerts/_prometheus-thanos-rule.alerts.tpl
+++ b/common/prometheus-server/templates/alerts/_prometheus-thanos-rule.alerts.tpl
@@ -38,7 +38,7 @@ groups:
   {{/* This is covering all Prometheis but kubernetes. They don not have the vpa_butler metric and need to leverage thanos ruler instead. */}}
   - alert: PrometheusVpaMemoryExceeded
     expr: |
-      vpa_butler_vpa_container_recommendation_excess{verticalpodautoscaler=~"{{ include "prometheus.fullName" . }}",resource="memory"} / 1024 / 1024 / 1024 > 0
+      round(vpa_butler_vpa_container_recommendation_excess{verticalpodautoscaler=~"{{ include "prometheus.fullName" . }}",resource="memory"} / 1024 / 1024 / 1024, 0.1 ) > 0.1
     for: 15m
     labels:
       service: {{ include "alertServiceLabelOrDefault" "metrics" }}
@@ -54,7 +54,7 @@ groups:
 
   - alert: PrometheusVpaCPUExceeded
     expr: |
-      vpa_butler_vpa_container_recommendation_excess{verticalpodautoscaler=~"{{ include "prometheus.fullName" . }}", resource="cpu"} > 0
+      round(vpa_butler_vpa_container_recommendation_excess{verticalpodautoscaler=~"{{ include "prometheus.fullName" . }}",resource="cpu"}, 0.1) > 0.1
     for: 15m
     labels:
       service: {{ include "alertServiceLabelOrDefault" "metrics" }}

--- a/common/prometheus-server/templates/alerts/_prometheus.alerts.tpl
+++ b/common/prometheus-server/templates/alerts/_prometheus.alerts.tpl
@@ -234,8 +234,14 @@ groups:
       summary: Prometheus target scraped multiple times.
   {{- end }}
 
-  {{- if and (not (contains (include "prometheus.name" . ) "kubernetes")) or (not (contains (include "prometheus.name" . ) "kubernikus" ))) (not $root.Values.alerts.thanos.enabled) -}}
-  {{- fail "YOU LOOSE!" -}}
+  {{/* Only affecting all prometheus-kubernetes and kubernikus since they have the metric natively. Rest is provided with similar Thanos rules and must not have these alerts, since they can never fire and will trigger absent alerts */}}
+  {{- if and 
+  (not $root.Values.alerts.thanos.enabled)
+  (not (contains (include "prometheus.name" . ) "kubernetes"))
+  (not (contains (include "prometheus.name" . ) "kubernikus"))
+   -}}
+  {{- fail "These alerts can't fire since your Prometheus does not natively have the needed metrics. Set alerts.thanos.enabled and alerts.thanos.name to ensure proper monitoring." -}}
+  {{- end}}
   {{- if and $root.Values.alerts.multiplePodScrapes.enabled (not $root.Values.alerts.thanos.enabled) }}
   - alert: PrometheusMultiplePodScrapes
     expr: sum by(pod, namespace, label_alert_service, label_alert_tier, ccloud_support_group) (label_replace((up * on(instance) group_left() (sum by(instance) (up{job=~".*{{ include "prometheus.name" . }}.*pod-sd"}) > 1)* on(pod) group_left(label_alert_tier, label_alert_service) (max without(uid) (kube_pod_labels))) , "pod", "$1", "kubernetes_pod_name", "(.*)-[0-9a-f]{8,10}-[a-z0-9]{5}"))
@@ -251,11 +257,10 @@ groups:
       summary: Prometheus scrapes pods multiple times
   {{- end }}
 
-  {{/* Only affecting all prometheus-kubernetes and kubernikus since they have the metric natively. Rest is provided with similar Thanos rules and must not have these alerts, since they can never fire and will trigger absent alerts */}}
   {{- if and (eq $root.Values.vpaUpdateMode "Auto") (not $root.Values.alerts.thanos.enabled) }}
   - alert: PrometheusVpaMemoryExceeded
     expr: |
-      vpa_butler_vpa_container_recommendation_excess{verticalpodautoscaler=~"{{ include "prometheus.fullName" . }}",resource="memory"} / 1024 / 1024 / 1024 > 0
+      round(vpa_butler_vpa_container_recommendation_excess{verticalpodautoscaler=~"{{ include "prometheus.fullName" . }}",resource="memory"} / 1024 / 1024 / 1024, 0.1 ) > 0.1
     for: 15m
     labels:
       service: {{ include "alertServiceLabelOrDefault" "metrics" }}
@@ -271,7 +276,7 @@ groups:
 
   - alert: PrometheusVpaCPUExceeded
     expr: |
-      vpa_butler_vpa_container_recommendation_excess{verticalpodautoscaler=~"{{ include "prometheus.fullName" . }}",resource="cpu"} > 0
+      round(vpa_butler_vpa_container_recommendation_excess{verticalpodautoscaler=~"{{ include "prometheus.fullName" . }}",resource="cpu"}, 0.1) > 0.1
     for: 15m
     labels:
       service: {{ include "alertServiceLabelOrDefault" "metrics" }}
@@ -284,7 +289,6 @@ groups:
         It is hitting the VPA maxAllowed boundary and is not ensured to run properly at its current place. Consider upgrading the VPA maxAllowed
         CPU core value if the host has enough CPU cores.
       summary: Prometheus needs more CPU.
-  {{- end }}
   {{- end }}
 
   {{- if and $root.Values.alertmanagers (gt (len $root.Values.alertmanagers) 0) }}

--- a/common/prometheus-server/templates/alerts/_prometheus.alerts.tpl
+++ b/common/prometheus-server/templates/alerts/_prometheus.alerts.tpl
@@ -249,8 +249,13 @@ groups:
       summary: Prometheus scrapes pods multiple times
   {{- end }}
 
-  {{- if and (eq $root.Values.vpaUpdateMode "Auto") (not $root.Values.alerts.thanos.enabled) }}
-  {{/* Only affecting all prometheus-kubernetes and using Thanos alerts directive to distinguish */}}
+  {{/* Only affecting all prometheus-kubernetes and kubernikus since they have the metric natively. Rest is provided with similar Thanos rules and must not have these alerts, since they can never fire and will trigger absent alerts */}}
+  {{- if and 
+  (eq $root.Values.vpaUpdateMode "Auto")
+  (not $root.Values.alerts.thanos.enabled) 
+  (or 
+  (contains (include "prometheus.name" . ) "kubernetes")
+  (contains (include "prometheus.name" . ) "kubernikus" ))}}
   - alert: PrometheusVpaMemoryExceeded
     expr: |
       vpa_butler_vpa_container_recommendation_excess{verticalpodautoscaler=~"{{ include "prometheus.fullName" . }}",resource="memory"} / 1024 / 1024 / 1024 > 0

--- a/common/prometheus-server/values.yaml
+++ b/common/prometheus-server/values.yaml
@@ -302,6 +302,7 @@ vpaResources:
       cpu: "1"
       memory: "3Gi"
 
+# If set to Auto, make sure to enable alerts.thanos.enabled if you are in any Prometheus but kubernetes and kubernikus. This will deploy needed alerts to Thanos Ruler.
 vpaUpdateMode: "Off"
 
 # A security context defines privilege and access control settings for a Pod or Container.

--- a/common/prometheus-server/values.yaml
+++ b/common/prometheus-server/values.yaml
@@ -302,7 +302,7 @@ vpaResources:
       cpu: "1"
       memory: "3Gi"
 
-# If set to Auto, make sure to enable alerts.thanos.enabled if you are in any Prometheus but kubernetes and kubernikus. This will deploy needed alerts to Thanos Ruler.
+# If set to Auto, make sure to enable alerts.thanos.enabled and alerts.thanos.name if you are in any Prometheus but kubernetes and kubernikus. This will deploy needed alerts to Thanos Ruler.
 vpaUpdateMode: "Off"
 
 # A security context defines privilege and access control settings for a Pod or Container.


### PR DESCRIPTION
VPA alerts must not be installed in any prometheus but (kubernikus and kubernetes) or (the regional thanos ruler).
If thanos alerts are enabled, they are deployed to the thanos ruler.
Independently they still were deployed to prometheus-kubernetes if VPA is set to Auto. Explicitly prohibiting this will not deploy these unfulfillable alerts.