### PR TITLE
Prepare utils and rabbitmq charts for vault-injector references

### DIFF
--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 0.6.3
+version: 0.6.4
 description: A Helm chart for RabbitMQ
 sources:
 - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/templates/_helpers.tpl
+++ b/common/rabbitmq/templates/_helpers.tpl
@@ -22,7 +22,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "rabbitmq._transport_url" -}}
 {{- $envAll := index . 0 -}}
 {{- $rabbitmq := index . 1 -}}
-rabbit://{{ default "" $envAll.Values.global.user_suffix | print $rabbitmq.users.default.user }}:{{ required "$rabbitmq.users.default.password missing" $rabbitmq.users.default.password | urlquery}}@{{ include "rabbitmq.release_host" $envAll }}:{{ $rabbitmq.port | default 5672 }}{{ $rabbitmq.virtual_host | default "/" }}
+rabbit://{{ default "" $envAll.Values.global.user_suffix | print $rabbitmq.users.default.user }}:{{ required "$rabbitmq.users.default.password missing" $rabbitmq.users.default.password }}@{{ include "rabbitmq.release_host" $envAll }}:{{ $rabbitmq.port | default 5672 }}{{ $rabbitmq.virtual_host | default "/" }}
 {{- end}}
 
 {{- define "rabbitmq.shell_quote" -}}

--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.14.3
+version: 0.14.4

--- a/openstack/utils/templates/_hosts.tpl
+++ b/openstack/utils/templates/_hosts.tpl
@@ -28,12 +28,12 @@ postgresql+psycopg2://{{$user}}:{{$password | urlquery}}@{{.Chart.Name}}-postgre
             {{- $user := get .Values.mariadb.users $db | required (printf ".Values.mariadb.%v.name & .password are required (key comes from first database in .Values.mariadb.databases)" $db) }}
             {{- $user.name | required (printf ".Values.mariadb.%v.name is required!" $db ) }}:{{ $user.password | required (printf ".Values.mariadb.%v.password is required!" $db ) }}
         {{- else }}
-            {{- coalesce .Values.dbUser .Values.global.dbUser "root" }}:{{ coalesce .Values.dbPassword .Values.global.dbPassword .Values.mariadb.root_password | required ".Values.mariadb.root_password is required!" | urlquery }}
+            {{- coalesce .Values.dbUser .Values.global.dbUser "root" }}:{{ coalesce .Values.dbPassword .Values.global.dbPassword .Values.mariadb.root_password | required ".Values.mariadb.root_password is required!" }}
         {{- end }}
     {{- else }}
         {{- $user := index . 2 }}
         {{- $password := index . 3 }}
-        {{- $user }}:{{ $password | urlquery }}
+        {{- $user }}:{{ $password }}
     {{- end }}
 {{- end }}
 

--- a/openstack/utils/templates/_ini_sections.tpl
+++ b/openstack/utils/templates/_ini_sections.tpl
@@ -49,10 +49,10 @@ enabled = true
 # topics = notifications
 driver = messagingv2
             {{- if .Values.audit.central_service }}
-transport_url = rabbit://{{ .Values.audit.central_service.user | required "Please set audit.central_service.user" }}:{{ .Values.audit.central_service.password | required "Please set audit.central_service.password" | urlquery }}@{{ .Values.audit.central_service.host | default "hermes-rabbitmq-notifications.hermes" }}:{{.Values.audit.central_service.port | default 5672 }}/
+transport_url = rabbit://{{ .Values.audit.central_service.user | required "Please set audit.central_service.user" }}:{{ .Values.audit.central_service.password | required "Please set audit.central_service.password" }}@{{ .Values.audit.central_service.host | default "hermes-rabbitmq-notifications.hermes" }}:{{.Values.audit.central_service.port | default 5672 }}/
             {{- else if .Values.rabbitmq_notifications }}
                 {{- if and .Values.rabbitmq_notifications.ports .Values.rabbitmq_notifications.users }}
-transport_url = rabbit://{{ .Values.rabbitmq_notifications.users.default.user }}:{{ required ".Values.rabbitmq_notifications.users.default.password missing" .Values.rabbitmq_notifications.users.default.password | urlquery }}@{{ .Chart.Name }}-rabbitmq-notifications:{{ .Values.rabbitmq_notifications.ports.public }}/
+transport_url = rabbit://{{ .Values.rabbitmq_notifications.users.default.user }}:{{ required ".Values.rabbitmq_notifications.users.default.password missing" .Values.rabbitmq_notifications.users.default.password }}@{{ .Chart.Name }}-rabbitmq-notifications:{{ .Values.rabbitmq_notifications.ports.public }}/
                 {{- end }}
             {{- end }}
 mem_queue_size = {{ .Values.audit.mem_queue_size }}
@@ -76,4 +76,10 @@ backend_url = {{ if eq .Values.coordinationBackend "memcached" -}}
 {{- else }}
     {{ fail ".Values.coordinationBackend needs to be either \"memcached\" or \"file\"" }}
 {{- end }}
+{{- end }}
+
+{{- define "ini_sections.keystone_authtoken_credentials" }}
+[keystone_authtoken]
+username = {{"{{"}} resolve "vault+kvv2:///secrets/{{ .Values.global.region }}/{{ .Release.Name }}/keystone-user/service/username" {{"}}"}}
+password = {{"{{"}} resolve "vault+kvv2:///secrets/{{ .Values.global.region }}/{{ .Release.Name }}/keystone-user/service/password" {{"}}"}}
 {{- end }}


### PR DESCRIPTION
- unfortunately vault-injector references do not work with urlquery
- add keystone_authtoken helper into untils
- adjust/bump rabbitmq and utils charts

**WARNING:
non-URL-safe passwords can break stuff with those chart versions!
Please double-check your passwords and test deployment carefully!** 