### PR TITLE
[unbound] -- introducing the bind-rpz-proxy sidecar

### DIFF
--- a/system/unbound/ci/test-values.yaml
+++ b/system/unbound/ci/test-values.yaml
@@ -20,6 +20,21 @@ unbound:
     image: sapcc/dnstap
     image_tag: latest
 
+  bind_rpz_proxy:
+    image: sapcc/bind-rpz-proxy
+    image_tag: latest
+
+    rndc:
+      keyname: rndc-key
+      algo:    hmac-sha512
+      secret:  MDEyMzQ1Njc4OWFiY2RlZg==
+
+  rpz:
+    tsig:
+      keyname: tsig-key
+      algo:    hmac-sha512
+      secret:  MDEyMzQ1Njc4OWFiY2RlZg==
+
   image_pullPolicy: Always
   port_unbound_exporter: 9107
   interface: 0.0.0.0

--- a/system/unbound/ci/test-values.yaml
+++ b/system/unbound/ci/test-values.yaml
@@ -23,6 +23,7 @@ unbound:
   bind_rpz_proxy:
     image: sapcc/bind-rpz-proxy
     image_tag: latest
+    enabled: true
 
     rndc:
       keyname: rndc-key

--- a/system/unbound/templates/bind-rpz-proxy-config.yaml
+++ b/system/unbound/templates/bind-rpz-proxy-config.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.unbound.bind_rpz_proxy.enabled }}
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -36,3 +37,4 @@ data:
       primaries { primaries; };
     };
     {{- end }}
+{{- end }}

--- a/system/unbound/templates/bind-rpz-proxy-config.yaml
+++ b/system/unbound/templates/bind-rpz-proxy-config.yaml
@@ -1,0 +1,38 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: bind-rpz-proxy-conf
+
+data:
+  named.conf: |
+    include "/etc/bind/named.conf.options";
+    include "/etc/bind/named.conf.rpz";
+    include "/etc/bind/secrets/rndc.key";
+    include "/etc/bind/secrets/tsig.key";
+
+  named.conf.options: |
+    options {
+      directory "/var/cache/bind";
+      querylog no;
+
+      // we only serve (and notify) the unbound running next to us
+      listen-on    port 55353 { 127.0.0.1; };
+      listen-on-v6            { none; };
+      allow-transfer          { 127.0.0.1; };
+      also-notify             { 127.0.0.1; };
+      notify explicit;
+    };
+
+  named.conf.rpz: |
+    primaries primaries {
+    {{- range $rpz_prim := .Values.unbound.rpz.primaries }}
+      {{ $rpz_prim }} key {{ .Values.unbound.rpz.tsig.keyname | quote }};
+    {{- end }}
+    };
+
+    {{- range $rpz_zone := .Values.unbound.rpz.zones }}
+    zone {{ $rpz_zone | quote }} {
+      type secondary;
+      primaries { primaries; };
+    };
+    {{- end }}

--- a/system/unbound/templates/bind-rpz-proxy-secrets.yaml
+++ b/system/unbound/templates/bind-rpz-proxy-secrets.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bind-rpz-proxy-secrets
+type: Opaque
+
+stringData:
+  rndc.key: |
+    key {{ default "rndc-key" .Values.unbound.bind_rpz_proxy.rndc.keyname | quote }} {
+      algorithm {{ default "hmac-sha512" .Values.unbound.bind_rpz_proxy.rndc.algo | quote }};
+      secret {{ .Values.unbound.bind_rpz_proxy.rndc.secret | quote }};
+    };
+  tsig.key: |
+    key {{ .Values.unbound.rpz.tsig.keyname | quote }} {
+      algorithm {{ default "hmac-sha512" .Values.unbound.rpz.tsig.algo | quote }};
+      secret {{ .Values.unbound.rpz.tsig.secret | quote }};
+    };

--- a/system/unbound/templates/bind-rpz-proxy-secrets.yaml
+++ b/system/unbound/templates/bind-rpz-proxy-secrets.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.unbound.bind_rpz_proxy.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -15,3 +16,4 @@ stringData:
       algorithm {{ default "hmac-sha512" .Values.unbound.rpz.tsig.algo | quote }};
       secret {{ .Values.unbound.rpz.tsig.secret | quote }};
     };
+{{- end }}

--- a/system/unbound/templates/deployment.yaml
+++ b/system/unbound/templates/deployment.yaml
@@ -127,6 +127,21 @@ spec:
           - name: dnstap-socket
             mountPath: {{ .Values.unbound.dnstap.socket_path | default "/run/dnstap/dnstap.sock" | dir }}
 {{ end }}
+{{ if .Values.unbound.bind_rpz_proxy.enabled }}
+      - name: bind-rpz-proxy
+        image: {{ required ".Values.global.registryAlternateRegion is missing" .Values.global.registryAlternateRegion }}/{{.Values.unbound.bind_rpz_proxy.image}}:{{ .Values.unbound.bind_rpz_proxy.image_tag}}
+        imagePullPolicy: {{ .Values.unbound.image_pullPolicy }}
+{{ if ge (int .Capabilities.KubeVersion.Minor) 29 }}
+        restartPolicy: Always
+{{ end }}
+        resources:
+{{ toYaml .Values.resources.bind_rpz_proxy | indent 10 }}
+        volumeMounts:
+          - name: bind-rpz-proxy-conf
+            mountPath: /etc/bind
+          - name: bind-rpz-proxy-secrets
+            mountPath: /etc/bind/secrets
+{{ end }}
       volumes:
       - name: unbound-conf
         configMap:
@@ -135,4 +150,12 @@ spec:
       - name: dnstap-socket
         emptyDir:
           medium: Memory
+{{ end }}
+{{ if .Values.unbound.bind_rpz_proxy.enabled }}
+      - name: bind-rpz-proxy-conf
+        configMap:
+          name: bind-rpz-proxy-conf
+      - name: bind-rpz-proxy-secrets
+        secret:
+          name: bind-rpz-proxy-secrets
 {{ end }}

--- a/system/unbound/values.yaml
+++ b/system/unbound/values.yaml
@@ -18,6 +18,10 @@ unbound:
     image: dnstap
     image_tag: latest
 
+  bind_rpz_proxy:
+    image: bind-rpz-proxy
+    image_tag: latest
+
   port_unbound_exporter: 9167
   interface: 0.0.0.0
   failure_domain_zone: a
@@ -36,6 +40,10 @@ resources:
     requests:
       memory: "128Mi"
       cpu: "100m"
+  bind_rpz_proxy:
+    requests:
+      memory: "128Mi"
+      cpu: "100m"
 
 alerts:
   # Name of the Prometheus to which the alerts should be assigned to.
@@ -47,4 +55,5 @@ owner-info:
   maintainers:
     - David Hoeller
     - Benjamin Tinney
+    - Vassil Dimitrov
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/system/unbound


### PR DESCRIPTION
Sadly unbound does not support TSIG AXFR to pull RPZ zones.

As a workaround we will be starting a bind container that will be pulling the RPZ zones from the primaries per TSIG AXFR.

Unbound will be pulling those zones from bind "anonymously"