### PR TITLE
[unbound][bind-rpz-proxy] -- fix named.conf.rpz secret-injector resolution

### DIFF
--- a/system/unbound/templates/bind-rpz-proxy-config.yaml
+++ b/system/unbound/templates/bind-rpz-proxy-config.yaml
@@ -7,9 +7,9 @@ metadata:
 data:
   named.conf: |
     include "/etc/bind/named.conf.options";
-    include "/etc/bind/secrets/named.conf.rpz";
-    include "/etc/bind/secrets/rndc.key";
-    include "/etc/bind/secrets/tsig.key";
+    include "/etc/bind/named.conf.rpz";
+    include "/etc/bind/rndc.key";
+    include "/etc/bind/tsig.key";
 
   named.conf.options: |
     options {

--- a/system/unbound/templates/bind-rpz-proxy-config.yaml
+++ b/system/unbound/templates/bind-rpz-proxy-config.yaml
@@ -7,7 +7,7 @@ metadata:
 data:
   named.conf: |
     include "/etc/bind/named.conf.options";
-    include "/etc/bind/named.conf.rpz";
+    include "/etc/bind/secrets/named.conf.rpz";
     include "/etc/bind/secrets/rndc.key";
     include "/etc/bind/secrets/tsig.key";
 
@@ -23,18 +23,4 @@ data:
       also-notify             { 127.0.0.1; };
       notify explicit;
     };
-
-  named.conf.rpz: |
-    primaries primaries {
-    {{- range $rpz_prim := .Values.unbound.rpz.primaries }}
-      {{ $rpz_prim }} key {{ .Values.unbound.rpz.tsig.keyname | quote }};
-    {{- end }}
-    };
-
-    {{- range $rpz_zone := .Values.unbound.rpz.zones }}
-    zone {{ $rpz_zone | quote }} {
-      type secondary;
-      primaries { primaries; };
-    };
-    {{- end }}
 {{- end }}

--- a/system/unbound/templates/bind-rpz-proxy-secrets.yaml
+++ b/system/unbound/templates/bind-rpz-proxy-secrets.yaml
@@ -11,9 +11,24 @@ stringData:
       algorithm {{ default "hmac-sha512" .Values.unbound.bind_rpz_proxy.rndc.algo | quote }};
       secret {{ .Values.unbound.bind_rpz_proxy.rndc.secret | quote }};
     };
+
   tsig.key: |
     key {{ .Values.unbound.rpz.tsig.keyname | quote }} {
       algorithm {{ default "hmac-sha512" .Values.unbound.rpz.tsig.algo | quote }};
       secret {{ .Values.unbound.rpz.tsig.secret | quote }};
     };
+
+  named.conf.rpz: |
+    primaries primaries {
+    {{- range $rpz_prim := .Values.unbound.rpz.primaries }}
+      {{ $rpz_prim }} key {{ .Values.unbound.rpz.tsig.keyname | quote }};
+    {{- end }}
+    };
+
+    {{- range $rpz_zone := .Values.unbound.rpz.zones }}
+    zone {{ $rpz_zone | quote }} {
+      type secondary;
+      primaries { primaries; };
+    };
+    {{- end }}
 {{- end }}

--- a/system/unbound/templates/deployment.yaml
+++ b/system/unbound/templates/deployment.yaml
@@ -139,8 +139,6 @@ spec:
         volumeMounts:
           - name: bind-rpz-proxy-conf
             mountPath: /etc/bind
-          - name: bind-rpz-proxy-secrets
-            mountPath: /etc/bind/secrets
 {{ end }}
       volumes:
       - name: unbound-conf
@@ -153,9 +151,10 @@ spec:
 {{ end }}
 {{ if .Values.unbound.bind_rpz_proxy.enabled }}
       - name: bind-rpz-proxy-conf
-        configMap:
-          name: bind-rpz-proxy-conf
-      - name: bind-rpz-proxy-secrets
-        secret:
-          name: bind-rpz-proxy-secrets
+        projected:
+          sources:
+          - configMap:
+            name: bind-rpz-proxy-conf
+          - secret:
+            name: bind-rpz-proxy-secrets
 {{ end }}


### PR DESCRIPTION
- Moved named.conf.rpz from bind-rpz-proxy-conf to bind-rpz-proxy-secrets
Needed to make the secret-injector resolution work.

- Use projected volume to merge mount these two on /etc/bind