### PR TITLE
[unbound][bind-rpz-proxy] --scope issue in bind-rpz-proxy-secrets

### DIFF
--- a/system/unbound/templates/bind-rpz-proxy-secrets.yaml
+++ b/system/unbound/templates/bind-rpz-proxy-secrets.yaml
@@ -19,9 +19,10 @@ stringData:
     };
 
   named.conf.rpz: |
+    {{- $tsig := .Values.unbound.rpz.tsig.keyname }}
     primaries primaries {
     {{- range $rpz_prim := .Values.unbound.rpz.primaries }}
-      {{ $rpz_prim }} key {{ .Values.unbound.rpz.tsig.keyname | quote }};
+      {{ $rpz_prim }} key {{ $tsig | quote }};
     {{- end }}
     };
 


### PR DESCRIPTION
`range` changes the scope
If we're interested in a value falls outside of that scope we need to fetch it as a variable before diving into the range loop.