### PR TITLE
[openstack-exporter] Revise CinderShardFreeSpace alerts

### DIFF
--- a/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
+++ b/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
@@ -17,7 +17,9 @@ groups:
       description: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has no storage capacity."
       summary: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has no storage capacity."
   - alert: CinderShardFreeSpaceSSD
-    expr: count by (shard, backend) (sum(cinder_available_capacity_gib{backend="vmware"} and on (shard, pool) cinder_pool_state_info{backend="vmware", pool_state="up"}) by (shard, backend, pool)) - (count by (shard,backend) (sum(cinder_virtual_free_capacity_gib{backend="vmware"} / cinder_available_capacity_gib{backend="vmware"} and on (shard, pool) cinder_pool_state_info{backend="vmware", pool_state="up"}) by (shard, backend, pool) < .3)) <= 2
+    expr: |
+      count by (cluster, shard) (cinder_virtual_free_capacity_gib{backend="vmware"} / cinder_available_capacity_gib{backend="vmware"} > 0.3
+      and on (pool) cinder_pool_state_info{pool_state="up"}) <= 2
     for: 15m
     labels:
       severity: warning
@@ -29,7 +31,9 @@ groups:
       description: 'Cinder vmware(ssd) backend {{ $labels.shard }}/{{ $labels.backend }} has 2 or less datastores with > 30% free space left'
       summary: 'Cinder vmware(ssd) backend {{ $labels.shard }}/{{ $labels.backend }} has 2 or less datastores with > 30% free space left'
   - alert: CinderShardFreeSpaceSSD
-    expr: count by (shard, backend) (sum(cinder_available_capacity_gib{backend="vmware"} and on (shard, pool) cinder_pool_state_info{backend="vmware", pool_state="up"}) by (shard, backend, pool)) - (count by (shard,backend) (sum(cinder_virtual_free_capacity_gib{backend="vmware"} / cinder_available_capacity_gib{backend="vmware"} and on (shard, pool) cinder_pool_state_info{backend="vmware", pool_state="up"}) by (shard, backend, pool) < .3)) <= 1
+    expr: |
+      count by (cluster, shard) (cinder_virtual_free_capacity_gib{backend="vmware"} / cinder_available_capacity_gib{backend="vmware"} > 0.3
+      and on (pool) cinder_pool_state_info{pool_state="up"}) <= 1
     for: 15m
     labels:
       severity: critical
@@ -41,7 +45,9 @@ groups:
       description: 'Cinder vmware(ssd) backend {{ $labels.shard }}/{{ $labels.backend }} has 1 or less datastores with > 30% free space left'
       summary: 'Cinder vmware(ssd) backend {{ $labels.shard }}/{{ $labels.backend }} has 1 or less datastores with > 30% free space left'
   - alert: CinderShardFreeSpaceStandardHDD
-    expr:  count by (shard, backend) (sum(cinder_available_capacity_gib{backend="standard_hdd"} and on (shard, pool) cinder_pool_state_info{backend="standard_hdd", pool_state="up"}) by (shard, backend, pool)) - (count by (shard,backend) (sum(cinder_virtual_free_capacity_gib{backend="standard_hdd"} / cinder_available_capacity_gib{backend="standard_hdd"} and on (shard, pool) cinder_pool_state_info{backend="standard_hdd", pool_state="up"}) by (shard, backend, pool) < .3)) <= 1
+    expr: |
+      count by (cluster, shard) (cinder_virtual_free_capacity_gib{backend="standard_hdd"} / cinder_available_capacity_gib{backend="standard_hdd"} > 0.3
+      and on (pool) cinder_pool_state_info{pool_state="up"}) <= 1
     for: 15m
     labels:
       severity: critical


### PR DESCRIPTION
- Ensure that the datastore count of all shards is taken into consideration, not just the free percentage
- Simplify the expression and improve readability