### PR TITLE
[unbound] -- fixed the module-config construction

### DIFF
--- a/system/unbound/templates/config.yaml
+++ b/system/unbound/templates/config.yaml
@@ -13,7 +13,7 @@ data:
         {{- $unbound_modules := "validator iterator" -}}
 
         {{- if .Values.unbound.bind_rpz_proxy.enabled }}
-        {{- $unbound_modules := cat "respip" $unbound_modules -}}
+        {{- $unbound_modules = cat "respip" $unbound_modules -}}
         {{- end }}
 
         module-config: {{ $unbound_modules | quote }}


### PR DESCRIPTION
We can only declare a variable once.
If we want to change its value we use a simple assignment operator.