### PR TITLE
Enable Graceful Harakiri by default

### DIFF
--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -195,7 +195,7 @@ api:
   # minimum number of workers to keep at all times
   cheaper: 0
   uwsgi: false
-  uwsgi_enable_harakiri_graceful_signal: false
+  uwsgi_enable_harakiri_graceful_signal: true
   # time to cache the OwnerCheck's result in seconds
   # 0/nil/null results in not setting the config option at all and thus using
   # the default from Neutron


### PR DESCRIPTION
Send SIGWINCH signal if uwsgi worker process servers a request longer than 120 secondds. SIGWINCH signal triggers a GURU Meditation Report.

Enable this behaviour in every region to get more information about the status of the worker process.