### PR TITLE
[rabbitmq] make start wait timeout configurable

### DIFF
--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 0.6.3
+version: 0.6.4
 description: A Helm chart for RabbitMQ
 sources:
 - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/templates/bin/_rabbitmq-start.tpl
+++ b/common/rabbitmq/templates/bin/_rabbitmq-start.tpl
@@ -38,7 +38,7 @@ function cleanup() {
 }
 trap cleanup EXIT
 
-timeout 60 rabbitmqctl wait /var/lib/rabbitmq/mnesia/rabbit@$HOSTNAME.pid
+timeout ${RABBIT_START_TIMEOUT:-60} rabbitmqctl wait /var/lib/rabbitmq/mnesia/rabbit@$HOSTNAME.pid
 
 {{- if .Values.debug }}
 rabbitmq-plugins enable rabbitmq_tracing

--- a/common/rabbitmq/templates/deployment.yaml
+++ b/common/rabbitmq/templates/deployment.yaml
@@ -60,6 +60,9 @@ spec:
       - name: rabbitmq
         image: "{{include "dockerHubMirror" .}}/{{ .Values.image }}:{{.Values.imageTag }}"
         imagePullPolicy: {{ default "IfNotPresent" .Values.imagePullPolicy | quote }}
+        env:
+          - name: RABBIT_START_TIMEOUT
+            value: {{ .Values.livenessProbe.initialDelaySeconds | quote }}
         command:
           - bash
         args:

--- a/common/rabbitmq/templates/statefulset.yaml
+++ b/common/rabbitmq/templates/statefulset.yaml
@@ -52,6 +52,9 @@ spec:
       - name: rabbitmq
         image: "{{include "dockerHubMirror" .}}/{{ .Values.image }}:{{.Values.imageTag }}"
         imagePullPolicy: {{ default "IfNotPresent" .Values.imagePullPolicy | quote }}
+        env:
+          - name: RABBIT_START_TIMEOUT
+            value: {{ .Values.livenessProbe.initialDelaySeconds | quote }}
         command:
           - bash
         args:


### PR DESCRIPTION
couple with liveness initial delay

In lab regions, with less cpu/memory resource power, the default
60 seconds are sometimes not long enough to bring up the service.
