### PR TITLE
[unbound][bind-rpz-proxy] -- move the secrets from stringData to data

### DIFF
--- a/system/unbound/Chart.yaml
+++ b/system/unbound/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Unbound DNS Recursor 
 name: unbound
-version: 1.0.2
-appVersion: "1.17.1"
+version: 1.1.0
+appVersion: "1.19.1"
 dependencies:
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap

--- a/system/unbound/templates/bind-rpz-proxy-secrets.yaml
+++ b/system/unbound/templates/bind-rpz-proxy-secrets.yaml
@@ -5,31 +5,13 @@ metadata:
   name: bind-rpz-proxy-secrets
 type: Opaque
 
-stringData:
+data:
   rndc.key: |
-    key {{ default "rndc-key" .Values.unbound.bind_rpz_proxy.rndc.keyname | quote }} {
-      algorithm {{ default "hmac-sha512" .Values.unbound.bind_rpz_proxy.rndc.algo | quote }};
-      secret {{ .Values.unbound.bind_rpz_proxy.rndc.secret | quote }};
-    };
+    {{ include "unbound.bind-rpz-proxy.rndc.key" . | b64enc | indent 4 }}
 
   tsig.key: |
-    key {{ .Values.unbound.rpz.tsig.keyname | quote }} {
-      algorithm {{ default "hmac-sha512" .Values.unbound.rpz.tsig.algo | quote }};
-      secret {{ .Values.unbound.rpz.tsig.secret | quote }};
-    };
+    {{ include "unbound.bind-rpz-proxy.tsig.key" . | b64enc | indent 4 }}
 
   named.conf.rpz: |
-    {{- $tsig := .Values.unbound.rpz.tsig.keyname }}
-    primaries primaries {
-    {{- range $rpz_prim := .Values.unbound.rpz.primaries }}
-      {{ $rpz_prim }} key {{ $tsig | quote }};
-    {{- end }}
-    };
-
-    {{- range $rpz_zone := .Values.unbound.rpz.zones }}
-    zone {{ $rpz_zone | quote }} {
-      type secondary;
-      primaries { primaries; };
-    };
-    {{- end }}
+    {{ include "unbound.bind-rpz-proxy.named.conf.rpz" . | b64enc | indent 4 }}
 {{- end }}

--- a/system/unbound/templates/etc/_unbound.bind-rpz-proxy.named.conf.rpz.tpl
+++ b/system/unbound/templates/etc/_unbound.bind-rpz-proxy.named.conf.rpz.tpl
@@ -1,0 +1,14 @@
+{{- define "unbound.bind-rpz-proxy.named.conf.rpz" }}
+primaries primaries {
+{{- range $rpz_prim := .Values.unbound.rpz.primaries }}
+  {{ $rpz_prim }} key {{ $.Values.unbound.rpz.tsig.keyname | quote }};
+{{- end }}
+};
+
+{{- range $rpz_zone := .Values.unbound.rpz.zones }}
+zone {{ $rpz_zone | quote }} {
+  type secondary;
+  primaries { primaries; };
+};
+{{- end }}
+{{- end }}

--- a/system/unbound/templates/etc/_unbound.bind-rpz-proxy.rndc.key.tpl
+++ b/system/unbound/templates/etc/_unbound.bind-rpz-proxy.rndc.key.tpl
@@ -1,0 +1,6 @@
+{{- define "unbound.bind-rpz-proxy.rndc.key" }}
+key {{ default "rndc-key" .Values.unbound.bind_rpz_proxy.rndc.keyname | quote }} {
+  algorithm {{ default "hmac-sha512" .Values.unbound.bind_rpz_proxy.rndc.algo | quote }};
+  secret {{ .Values.unbound.bind_rpz_proxy.rndc.secret | quote }};
+};
+{{- end }}

--- a/system/unbound/templates/etc/_unbound.bind-rpz-proxy.tsig.key.tpl
+++ b/system/unbound/templates/etc/_unbound.bind-rpz-proxy.tsig.key.tpl
@@ -1,0 +1,6 @@
+{{- define "unbound.bind-rpz-proxy.tsig.key" }}
+key {{ .Values.unbound.rpz.tsig.keyname | quote }} {
+  algorithm {{ default "hmac-sha512" .Values.unbound.rpz.tsig.algo | quote }};
+  secret {{ .Values.unbound.rpz.tsig.secret | quote }};
+};
+{{- end }}


### PR DESCRIPTION
Apparently `stringData:` is broken by design [1]. We should avoid it.

The issue is that removing a stringData key will not remove it from the k8s secret object. It will just get reset to an empty string.

Might be a security issue to some extend.

But, also, using such a secret as a volume will result in orphaned empty files. That *might* break easily offended software.

Also, bumped the chart's `version` and `appVersion`.

[1] https://github.com/kubernetes/kubernetes/issues/89938#issuecomment-1033085353