### PR TITLE
[unbound][bind-rpz-proxy] -- secrets-injector double quoting 

### DIFF
--- a/system/unbound/templates/etc/_unbound.bind-rpz-proxy.named.conf.rpz.tpl
+++ b/system/unbound/templates/etc/_unbound.bind-rpz-proxy.named.conf.rpz.tpl
@@ -1,7 +1,7 @@
 {{- define "unbound.bind-rpz-proxy.named.conf.rpz" }}
 primaries primaries {
 {{- range $rpz_prim := .Values.unbound.rpz.primaries }}
-  {{ $rpz_prim }} key {{ $.Values.unbound.rpz.tsig.keyname | quote }};
+  {{ $rpz_prim }} key {{ $.Values.unbound.rpz.tsig.keyname }};
 {{- end }}
 };
 

--- a/system/unbound/templates/etc/_unbound.bind-rpz-proxy.rndc.key.tpl
+++ b/system/unbound/templates/etc/_unbound.bind-rpz-proxy.rndc.key.tpl
@@ -1,6 +1,6 @@
 {{- define "unbound.bind-rpz-proxy.rndc.key" }}
-key {{ default "rndc-key" .Values.unbound.bind_rpz_proxy.rndc.keyname | quote }} {
-  algorithm {{ default "hmac-sha512" .Values.unbound.bind_rpz_proxy.rndc.algo | quote }};
-  secret {{ .Values.unbound.bind_rpz_proxy.rndc.secret | quote }};
+key {{ default "rndc-key" .Values.unbound.bind_rpz_proxy.rndc.keyname }} {
+  algorithm {{ default "hmac-sha512" .Values.unbound.bind_rpz_proxy.rndc.algo }};
+  secret {{ .Values.unbound.bind_rpz_proxy.rndc.secret }};
 };
 {{- end }}

--- a/system/unbound/templates/etc/_unbound.bind-rpz-proxy.tsig.key.tpl
+++ b/system/unbound/templates/etc/_unbound.bind-rpz-proxy.tsig.key.tpl
@@ -1,6 +1,6 @@
 {{- define "unbound.bind-rpz-proxy.tsig.key" }}
-key {{ .Values.unbound.rpz.tsig.keyname | quote }} {
-  algorithm {{ default "hmac-sha512" .Values.unbound.rpz.tsig.algo | quote }};
-  secret {{ .Values.unbound.rpz.tsig.secret | quote }};
+key {{ .Values.unbound.rpz.tsig.keyname }} {
+  algorithm {{ default "hmac-sha512" .Values.unbound.rpz.tsig.algo }};
+  secret {{ .Values.unbound.rpz.tsig.secret }};
 };
 {{- end }}


### PR DESCRIPTION
double quoting was breaking the secrets-injector

It was resulting into something like:
```
key "{{ resolve \"vault+kvv2:///secrets/path/to/keyname\" }}" {
...
}
```

The secrets-injector was, understandingly, not happy with that.