### PR TITLE
chore(audit-poller): bump image versions

### DIFF
--- a/system/audit-logs/Chart.lock
+++ b/system/audit-logs/Chart.lock
@@ -13,12 +13,12 @@ dependencies:
   version: 0.3.1
 - name: audit-poller
   repository: file://vendor/audit-poller
-  version: 0.0.29
+  version: 0.0.30
 - name: ocb-datain-static-probes
   repository: file://vendor/ocb-datain-static-probes
   version: 0.2.3
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:45e478c6d1f3830cbc3edab09aaf11599e52ed287aa0afda74354907798e320d
-generated: "2024-01-16T14:31:46.45534+01:00"
+digest: sha256:929090117d61553768af5cd4c7659db389732121c73c8d717140d181a1d857a8
+generated: "2024-03-01T16:55:17.692895+01:00"

--- a/system/audit-logs/Chart.yaml
+++ b/system/audit-logs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Audit logging components
 name: audit-logs
-version: 0.2.14
+version: 0.2.15
 dependencies:
   - name: fluent-audit-container
     alias: fluent_audit_container
@@ -29,7 +29,7 @@ dependencies:
   - name: audit-poller
     alias: auditPoller
     repository: file://vendor/audit-poller
-    version: 0.0.29
+    version: 0.0.30
     condition: auditPoller.enabled
 
   - name: ocb-datain-static-probes

--- a/system/audit-logs/values.yaml
+++ b/system/audit-logs/values.yaml
@@ -14,7 +14,7 @@ global:
       host: Non
 logstash_audit_external:
   enabled: false
-  image_version: "20220110143833"
+  image_version: "20240227090739"
   replicas: 1
   input_netflow_port: 2055
   input_syslog_port: 514
@@ -44,7 +44,7 @@ fluent_audit_container:
   enabled: false
   port: 8887
   metrics_port: 24231
-  image_version: "20231213092430"
+  image_version: "20240227111845"
   resources:
     limits:
       memory: 500Mi
@@ -66,7 +66,7 @@ fluent_audit_container:
 
 fluent_audit_systemd:
   enabled: false
-  image_version: "20231213092430"
+  image_version: "20240227111845"
   resources:
     limits:
       memory: 500Mi

--- a/system/audit-logs/vendor/audit-poller/Chart.yaml
+++ b/system/audit-logs/vendor/audit-poller/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: audit-poller
-version: 0.0.29
+version: 0.0.30
 description: audit log poller
 maintainers:
   - name: Ivo Gosemann

--- a/system/audit-logs/vendor/audit-poller/values.yaml
+++ b/system/audit-logs/vendor/audit-poller/values.yaml
@@ -1,5 +1,5 @@
 image: "audit-poller"
-imageTag: "202401161420"
+imageTag: "202403011645"
 iasApi:
   fileName: "ias_api.log"
   interval: 5


### PR DESCRIPTION
This bumps the fluentD, logstash and audit-poller images.