### PR TITLE
[unbound][bind-rpz-proxy] -- dedicated configMap/secret per release

### DIFF
--- a/system/unbound/templates/bind-rpz-proxy-config.yaml
+++ b/system/unbound/templates/bind-rpz-proxy-config.yaml
@@ -2,7 +2,7 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: bind-rpz-proxy-conf
+  name: {{.Release.Name}}-bind-rpz-proxy-conf
 
 data:
   named.conf: |

--- a/system/unbound/templates/bind-rpz-proxy-secrets.yaml
+++ b/system/unbound/templates/bind-rpz-proxy-secrets.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: bind-rpz-proxy-secrets
+  name: {{.Release.Name}}-bind-rpz-proxy-secrets
 type: Opaque
 
 data:

--- a/system/unbound/templates/deployment.yaml
+++ b/system/unbound/templates/deployment.yaml
@@ -163,7 +163,7 @@ spec:
         projected:
           sources:
           - configMap:
-              name: bind-rpz-proxy-conf
+              name: {{.Release.Name}}-bind-rpz-proxy-conf
           - secret:
-              name: bind-rpz-proxy-secrets
+              name: {{.Release.Name}}-bind-rpz-proxy-secrets
 {{ end }}


### PR DESCRIPTION
Apparently we cannot share one configMap/secret across multiple releases.

We will have to create dedicated configMaps/secrets for each release we have. IOW one for unbound1 and one for unbound2.

Otherwise the first release will get deployed but the second one will fail with:
```
Error: UPGRADE FAILED: Unable to continue with update: Secret "bind-rpz-proxy-secrets" in namespace "dns-recursor" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-name" must equal "unbound2": current value is "unbound1"
```