### PR TITLE
feat(prometheus-monitors): allow configuration of additional targets

### DIFF
--- a/common/prometheus-monitors/Changelog.md
+++ b/common/prometheus-monitors/Changelog.md
@@ -1,4 +1,10 @@
-# 0.0.2
+# Changelog
+
+## 0.1.0
+
+- add support for additionalEndpoints. These additional endpoints are configured like the main endpoint, but under the `additionalEndpoints` key. This allows for the configuration of multiple endpoints for a single Pod|ServiceMonitor.
+
+## 0.0.2
 
 - drops default suffix from name of Pod|ServiceMonitor
 - adds explicit error for ServiceMonitor without selector
@@ -7,6 +13,6 @@
 - adds templating for basicAuth
 - fixes to ServiceMonitor template
 
-# 0.0.1
+## 0.0.1
 
 - initial release

--- a/common/prometheus-monitors/Chart.yaml
+++ b/common/prometheus-monitors/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: prometheus-monitors
-version: 0.0.2
+version: 0.1.0

--- a/common/prometheus-monitors/README.md
+++ b/common/prometheus-monitors/README.md
@@ -53,6 +53,7 @@ The following table lists the configurable parameters of the `prometheus-monitor
 | `basicAuth` | `[]` | BasicAuth allows an endpoint to authenticate over basic authentication More info: <https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.BasicAuth>
 | `customRelabelings` | `[]` | RelabelConfigs to apply to samples before scraping. Prometheus Operator automatically adds relabelings for a few standard Kubernetes fields. The original scrape job’s name is available via the __tmp_prometheus_job_name label. More info: <https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config> also see [[]RelabelConfig](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.RelabelConfig) |
 | `customMetricRelabelings` | `[]` | MetricRelabelConfigs to apply to samples before ingestion. see [[]RelabelConfig](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.RelabelConfig) |
+| `additionalEndpoints` | `[]` | AdditionalEndpoints contains additional MetricsEndpoint configuration for the target. |
 
 ### Notes
 

--- a/common/prometheus-monitors/templates/_helpers.tpl
+++ b/common/prometheus-monitors/templates/_helpers.tpl
@@ -1,11 +1,46 @@
 {{- define "prometheus.defaultRelabelConfig" -}}
 - action: replace
   targetLabel: region
-  replacement: {{ required ".Values.global.region missing" .Values.global.region }}
+  replacement: {{ required ".Values.global.region missing" .global.region }}
 - action: replace
   targetLabel: cluster_type
-  replacement: {{ required ".Values.global.clusterType missing" .Values.global.clusterType }}
+  replacement: {{ required ".Values.global.clusterType missing" .global.clusterType }}
 - action: replace
   targetLabel: cluster
-  replacement: {{ if .Values.global.cluster }}{{ .Values.global.cluster }}{{ else }}{{ .Values.global.region }}{{ end }}
+  replacement: {{ if .global.cluster }}{{ .global.cluster }}{{ else }}{{ .global.region }}{{ end }}
+{{- end -}}
+
+
+{{- define "metricsEndpoint" -}}
+- interval: {{ default "60s" .endpoint.scrapeInterval }}
+  scrapeTimeout: {{ default "55s" .endpoint.scrapeTimeout }}
+  port: {{ default "metrics" .endpoint.metricsPort }}
+  path: {{ default "/metrics" .endpoint.metricsPath }}
+  scheme: {{ default "http" .endpoint.httpScheme }}
+{{- if .endpoint.basicAuth }}
+  basicAuth:
+{{ .endpoint.basicAuth | toYaml | indent 8 }}
+{{- end }}
+  honorLabels: true
+  relabelings: 
+    - action: labelmap
+    {{- if .isService }}
+      regex: '__meta_kubernetes_service_label_(.+)'
+    {{- else }}
+      regex: '__meta_kubernetes_pod_label_(.+)'
+    {{- end }}
+    - sourceLabels:
+        - __meta_kubernetes_namespace
+      targetLabel: kubernetes_namespace
+    - sourceLabels:
+        - __meta_kubernetes_pod_name
+      targetLabel: kubernetes_pod_name
+{{ include "prometheus.defaultRelabelConfig" .root | indent 4 }}
+{{- if .endpoint.customRelabelings }}
+  {{ .endpoint.customRelabelings | toYaml | indent 4 }}
+{{- end }}
+{{- if .endpoint.customMetricRelabelings }}
+  metricRelabelings:
+    {{ .endpoint.customMetricRelabelings | toYaml | indent 4 }}
+{{- end }}
 {{- end -}}

--- a/common/prometheus-monitors/templates/_helpers.tpl
+++ b/common/prometheus-monitors/templates/_helpers.tpl
@@ -37,10 +37,10 @@
       targetLabel: kubernetes_pod_name
 {{ include "prometheus.defaultRelabelConfig" .root | indent 4 }}
 {{- if .endpoint.customRelabelings }}
-  {{ .endpoint.customRelabelings | toYaml | indent 4 }}
+{{ .endpoint.customRelabelings | toYaml | indent 4 }}
 {{- end }}
 {{- if .endpoint.customMetricRelabelings }}
   metricRelabelings:
-    {{ .endpoint.customMetricRelabelings | toYaml | indent 4 }}
+{{ .endpoint.customMetricRelabelings | toYaml | indent 4 }}
 {{- end }}
 {{- end -}}

--- a/common/prometheus-monitors/templates/podmonitor.yaml
+++ b/common/prometheus-monitors/templates/podmonitor.yaml
@@ -32,33 +32,10 @@ spec:
   namespaceSelector:
     matchNames:
 {{  default (list .Release.Namespace ) .Values.namespaces | toYaml | indent 6 }}
-  
+
   podMetricsEndpoints:
-    - interval: {{ default "60s" .Values.scrapeInterval }}
-      scrapeTimeout: {{ default "55s" .Values.scrapeTimeout }}
-      port: {{ default "metrics" .Values.metricsPort }}
-      path: {{ default "/metrics" .Values.metricsPath }}
-      scheme: {{ default "http" .Values.httpScheme }}
-    {{- if .Values.basicAuth }}
-      basicAuth:
-{{ .Values.basicAuth | toYaml | indent 8 }}
-    {{- end }}
-      honorLabels: true
-      relabelings: 
-        - action: labelmap
-          regex: '__meta_kubernetes_pod_label_(.+)'
-        - sourceLabels:
-            - __meta_kubernetes_namespace
-          targetLabel: kubernetes_namespace
-        - sourceLabels:
-            - __meta_kubernetes_pod_name
-          targetLabel: kubernetes_pod_name
-{{ include "prometheus.defaultRelabelConfig" .  | indent 8 }}
-{{- if .Values.customRelabelings }}
-{{ .Values.customRelabelings | toYaml | indent 8 }}
-{{- end }}
-{{- if .Values.customMetricRelabelings }}
-      metricRelabelings:
-{{ .Values.customMetricRelabelings | toYaml | indent 8 }}
+  {{ include "metricsEndpoint" (dict "root" .Values "endpoint" .Values "isService" false) | toYaml | indent 4 }}
+{{- range $k, $v := .Values.additionalEndpoints }}
+  {{ include "metricsEndpoint" (dict "root" .Values "endpoint" $v "isService" false) | toYaml | indent 4 }}
 {{- end }}
 {{- end }}

--- a/common/prometheus-monitors/templates/podmonitor.yaml
+++ b/common/prometheus-monitors/templates/podmonitor.yaml
@@ -34,8 +34,8 @@ spec:
 {{  default (list .Release.Namespace ) .Values.namespaces | toYaml | indent 6 }}
 
   podMetricsEndpoints:
-  {{ include "metricsEndpoint" (dict "root" .Values "endpoint" .Values "isService" false) | toYaml | indent 4 }}
+{{ include "metricsEndpoint" (dict "root" $.Values "endpoint" .Values "isService" false) | indent 4 }}
 {{- range $k, $v := .Values.additionalEndpoints }}
-  {{ include "metricsEndpoint" (dict "root" .Values "endpoint" $v "isService" false) | toYaml | indent 4 }}
+{{ include "metricsEndpoint" (dict "root" $.Values "endpoint" $v "isService" false) | indent 4 }}
 {{- end }}
 {{- end }}

--- a/common/prometheus-monitors/templates/servicemonitor.yaml
+++ b/common/prometheus-monitors/templates/servicemonitor.yaml
@@ -31,33 +31,9 @@ spec:
   namespaceSelector:
     matchNames:
 {{  default (list .Release.Namespace ) .Values.namespaces | toYaml | indent 6 }}
-  
   endpoints:
-    - interval: {{ default "60s" .Values.scrapeInterval }}
-      scrapeTimeout: {{ default "55s" .Values.scrapeTimeout }}
-      port: {{ default "metrics" .Values.metricsPort }}
-      path: {{ default "/metrics" .Values.metricsPath }}
-      scheme: {{ default "http" .Values.httpScheme }}
-    {{- if .Values.basicAuth }}
-      basicAuth:
-{{ .Values.basicAuth | toYaml | indent 8 }}
-    {{- end }}
-      honorLabels: {{ default true .Values.honorLabels }}
-      relabelings: 
-        - action: labelmap
-          regex: '__meta_kubernetes_service_label_(.+)'
-        - sourceLabels:
-            - __meta_kubernetes_namespace
-          targetLabel: kubernetes_namespace
-        - sourceLabels:
-            - __meta_kubernetes_pod_name
-          targetLabel: kubernetes_pod_name
-{{ include "prometheus.defaultRelabelConfig" .  | indent 8 }}
-{{- if .Values.customRelabelings }}
-{{ .Values.customRelabelings | toYaml | indent 8 }}
-{{- end }}
-{{- if .Values.customMetricRelabelings }}
-      metricRelabelings:
-{{ .Values.customMetricRelabelings | toYaml | indent 8 }}
+{{ include "metricsEndpoint" (dict "root" $.Values "endpoint" .Values "isService" true) | indent 4 }}
+{{- range $k, $v := .Values.additionalEndpoints }}
+{{ include "metricsEndpoint" (dict "root" $.Values "endpoint" $v "isService" true) | indent 4 }}
 {{- end }}
 {{- end }}

--- a/common/prometheus-monitors/values.yaml
+++ b/common/prometheus-monitors/values.yaml
@@ -39,3 +39,14 @@ customRelabelings: []
 # RelabelConfig allows dynamic rewriting of the label set, being applied to
 # samples before ingestion.
 customMetricRelabelings: []
+
+# additionalEndpoint that are added as additional metricsEndpoints to the Pod|ServiceMonitor
+additionalEndpoints: []
+#  - scrapeInterval:
+#    scrapeTimeout:
+#    metricsPort:
+#    metricsPath:
+#    httpScheme:
+#    basicAuth: {}
+#    customRelabelings: []
+#    customMetricRelabelings: []


### PR DESCRIPTION
Currently this helper chart gives some presets for adding very simple Pod|ServiceMonitors.
This change adds the option to add more than one endpoint to be scraped. In order to keep this compatible with existing usages the new value `additionalEndpoints` is introduced.