### PR TITLE
nova/flavors: Separate instance quota for hana-flavors everywhere

### DIFF
--- a/openstack/sap-seeds/templates/_flavors_hana_exclusive.tpl
+++ b/openstack/sap-seeds/templates/_flavors_hana_exclusive.tpl
@@ -8,6 +8,10 @@
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "24"  # used in nova-vmware as cores-per-socket (12pCPU = 24vCPU)
     "reservation:cpu": "24"
+    {{- if ( .Values.hana_flavors_quota_separate ) }}
+    "quota:instance_only": "true"
+    "quota:separate": "true"
+    {{- end }}
 - name: "hana_c48_m729"
   id: "301"
   vcpus: 48
@@ -18,6 +22,10 @@
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
     "reservation:cpu": "48"
+    {{- if ( .Values.hana_flavors_quota_separate ) }}
+    "quota:instance_only": "true"
+    "quota:separate": "true"
+    {{- end }}
 - name: "hana_c96_m1458"
   id: "302"
   vcpus: 96
@@ -28,6 +36,10 @@
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
     "reservation:cpu": "96"
+    {{- if ( .Values.hana_flavors_quota_separate ) }}
+    "quota:instance_only": "true"
+    "quota:separate": "true"
+    {{- end }}
 - name: "hana_c144_m2188"
   id: "303"
   vcpus: 144
@@ -39,6 +51,10 @@
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
     "reservation:cpu": "144"
     "vmware:hw_version": "vmx-18"
+    {{- if ( .Values.hana_flavors_quota_separate ) }}
+    "quota:instance_only": "true"
+    "quota:separate": "true"
+    {{- end }}
 - name: "hana_c192_m2917"
   id: "304"
   vcpus: 192
@@ -50,6 +66,10 @@
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
     "reservation:cpu": "192"
     "vmware:hw_version": "vmx-18"
+    {{- if ( .Values.hana_flavors_quota_separate ) }}
+    "quota:instance_only": "true"
+    "quota:separate": "true"
+    {{- end }}
 - name: "hana_c384_m5835"
   id: "305"
   vcpus: 384
@@ -61,6 +81,10 @@
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
     "reservation:cpu": "384"
     "vmware:hw_version": "vmx-18"
+    {{- if ( .Values.hana_flavors_quota_separate ) }}
+    "quota:instance_only": "true"
+    "quota:separate": "true"
+    {{- end }}
 - name: "hana_c288_m4377"
   id: "311"
   vcpus: 288
@@ -72,6 +96,10 @@
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
     "reservation:cpu": "288"
     "vmware:hw_version": "vmx-18"
+    {{- if ( .Values.hana_flavors_quota_separate ) }}
+    "quota:instance_only": "true"
+    "quota:separate": "true"
+    {{- end }}
 - name: "hana_c448_m11671"
   id: "313"
   vcpus: 448
@@ -83,3 +111,7 @@
     "hw:cpu_cores": "56"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
     "reservation:cpu": "448"
     "vmware:hw_version": "vmx-18"
+    {{- if ( .Values.hana_flavors_quota_separate ) }}
+    "quota:instance_only": "true"
+    "quota:separate": "true"
+    {{- end }}


### PR DESCRIPTION
Needed for Limes' upcoming 2024 quota revamp.

Now also for hana-exclusive regions.