### PR TITLE
add quota:separate etc. to selected old HANA flavors

### DIFF
--- a/openstack/sap-seeds/templates/_flavors_deleted.tpl
+++ b/openstack/sap-seeds/templates/_flavors_deleted.tpl
@@ -410,6 +410,11 @@
     trait:CUSTOM_NUMASIZE_C48_M1459: required
     hw:cpu_cores: '24'  # cores-per-socket
     vmware:hw_version: vmx-18
+    {{- if .Values.hana_flavors_quota_separate }}
+    "quota:instance_only": "true"
+    "quota:separate": "true"
+    "limes:allow_growth": "false" # never report capacity above the current usage
+    {{- end }}
 
 - name: hana_c48_m1459
   id: "307"
@@ -428,6 +433,11 @@
     trait:CUSTOM_NUMASIZE_C48_M1459: required
     hw:cpu_cores: '48'  # cores-per-socket
     vmware:hw_version: vmx-18
+    {{- if .Values.hana_flavors_quota_separate }}
+    "quota:instance_only": "true"
+    "quota:separate": "true"
+    "limes:allow_growth": "false" # never report capacity above the current usage
+    {{- end }}
 
 - name: hana_c96_m2918
   id: "308"
@@ -446,6 +456,11 @@
     trait:CUSTOM_NUMASIZE_C48_M1459: required
     hw:cpu_cores: '48'  # cores-per-socket
     vmware:hw_version: vmx-18
+    {{- if .Values.hana_flavors_quota_separate }}
+    "quota:instance_only": "true"
+    "quota:separate": "true"
+    "limes:allow_growth": "false" # never report capacity above the current usage
+    {{- end }}
 
 - name: hana_c192_m5835
   id: "310"
@@ -464,6 +479,11 @@
     trait:CUSTOM_NUMASIZE_C48_M1459: required
     hw:cpu_cores: '48'  # cores-per-socket
     vmware:hw_version: vmx-18
+    {{- if .Values.hana_flavors_quota_separate }}
+    "quota:instance_only": "true"
+    "quota:separate": "true"
+    "limes:allow_growth": "false" # never report capacity above the current usage
+    {{- end }}
 
 - name: x1.64xlarge
   id: "251"


### PR DESCRIPTION
Followup to #6098. We do in fact have prices for these specific 4 flavors, so we can put them as separate instance quotas without causing problems for Billing.

For the other flavors, Frank has tentatively agreed to do another push to get the customers off them.

I'm also defining a new extra spec for Limes here, which I will use to keep the capacity calculation from reporting more capacity on these flavors than absolutely necessary.