### PR TITLE
Do not require Prodel check in Tempest domains

### DIFF
--- a/openstack/keystone/templates/etc/_policy.yaml.tpl
+++ b/openstack/keystone/templates/etc/_policy.yaml.tpl
@@ -947,7 +947,7 @@
 # Intended scope(s): system, domain
 #"identity:delete_project": "(role:admin and system_scope:all) or (role:admin and domain_id:%(target.project.domain_id)s)"
 # The corresponding `prodel` service details are available on GitHub under `cc/prodel`
-"identity:delete_project": "(rule:cloud_admin or (rule:admin_required and project_id:%(project_id)s)) and {{ .Values.prodel.url }}"
+"identity:delete_project": "(rule:cloud_admin or (rule:admin_required and project_id:%(project_id)s)) and ({{- if .Values.tempest.enabled }}domain_id:{{.Values.tempest.domainId}} or {{ end }}{{ .Values.prodel.url }})"
 
 # List tags for a project.
 # GET  /v3/projects/{project_id}/tags


### PR DESCRIPTION
When `.Values.tempest.enabled` evaluates to true:

```diff
-     "identity:delete_project": "(rule:cloud_admin or (rule:admin_required and project_id:%(project_id)s)) and http://prodel.prodel.svc/check-delete_project/%(project_id)s"
+     "identity:delete_project": "(rule:cloud_admin or (rule:admin_required and project_id:%(project_id)s)) and (domain_id:abcdefghabcdefghabcdefghabcdefgh or http://prodel.prodel.svc/check-delete_project/%(project_id)s)"
```

When `.Values.tempest.enabled` evaluates to false:

```diff
-     "identity:delete_project": "(rule:cloud_admin or (rule:admin_required and project_id:%(project_id)s)) and http://prodel.prodel.svc/check-delete_project/%(project_id)s"
+     "identity:delete_project": "(rule:cloud_admin or (rule:admin_required and project_id:%(project_id)s)) and (http://prodel.prodel.svc/check-delete_project/%(project_id)s)"
```