### PR TITLE
[placement] move configuration with credentials into own secrets

### DIFF
--- a/openstack/placement/templates/db-migrate-job.yaml
+++ b/openstack/placement/templates/db-migrate-job.yaml
@@ -48,6 +48,10 @@ spec:
           {{- end }}
         - name: PYTHONWARNINGS
           value: {{ .Values.python_warnings | quote }}
+        - name: OS_PLACEMENT_CONFIG_DIR
+          value: "/etc/placement/"
+        - name: OS_PLACEMENT_CONFIG_FILES
+          value: "placement.conf;secrets.conf"
         volumeMounts:
         - mountPath: /etc/placement
           name: placement-etc
@@ -55,8 +59,15 @@ spec:
         {{- include "utils.trust_bundle.volume_mount" . | indent 8 }}
       {{- include "utils.proxysql.container" . | indent 6 }}
       volumes:
-      - name: placement-etc
-        configMap:
-          name: placement-etc
+        - name: placement-etc
+          projected:
+            sources:
+            - configMap:
+                name: placement-etc
+            - secret:
+                name: placement-secrets
+                items:
+                  - key: secrets.conf
+                    path: secrets.conf
       {{- include "utils.proxysql.volumes" . | indent 6 }}
       {{- include "utils.trust_bundle.volumes" . | indent 6 }}

--- a/openstack/placement/templates/db-online-migrate-job.yaml
+++ b/openstack/placement/templates/db-online-migrate-job.yaml
@@ -48,6 +48,10 @@ spec:
           {{- end }}
         - name: PYTHONWARNINGS
           value: {{ .Values.python_warnings | quote }}
+        - name: OS_PLACEMENT_CONFIG_DIR
+          value: "/etc/placement/"
+        - name: OS_PLACEMENT_CONFIG_FILES
+          value: "placement.conf;secrets.conf"
         volumeMounts:
         - mountPath: /etc/placement
           name: placement-etc
@@ -55,8 +59,15 @@ spec:
         {{- include "utils.trust_bundle.volume_mount" . | indent 8 }}
       {{- include "utils.proxysql.container" . | indent 6 }}
       volumes:
-      - name: placement-etc
-        configMap:
-          name: placement-etc
+        - name: placement-etc
+          projected:
+            sources:
+            - configMap:
+                name: placement-etc
+            - secret:
+                name: placement-secrets
+                items:
+                  - key: secrets.conf
+                    path: secrets.conf
       {{- include "utils.proxysql.volumes" . | indent 6 }}
       {{- include "utils.trust_bundle.volumes" . | indent 6 }}

--- a/openstack/placement/templates/etc/_placement.conf.tpl
+++ b/openstack/placement/templates/etc/_placement.conf.tpl
@@ -8,11 +8,6 @@ memcache_servers = {{ .Chart.Name }}-memcached.{{ include "svc_fqdn" . }}:{{ .Va
 {{- include "ini_sections.logging_format" . }}
 
 [placement_database]
-{{- if not .Values.mariadb.enabled }}
-connection = {{ tuple . .Values.api_db.name .Values.api_db.user .Values.api_db.password | include "db_url_mysql" }}
-{{- else }}
-connection = {{ tuple . .Values.mariadb.name .Values.global.dbUser .Values.global.dbPassword | include "db_url_mysql" }}
-{{- end }}
 {{- include "ini_sections.database_options_mysql" . }}
 
 
@@ -27,8 +22,6 @@ auth_version = v3
 auth_interface = internal
 www_authenticate_uri = https://{{include "keystone_api_endpoint_host_public" .}}/v3
 auth_url = {{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3
-username = {{ .Values.global.placement_service_user | default "placement" }}{{ .Values.global.user_suffix }}
-password = {{ required ".Values.global.placement_service_password is missing" .Values.global.placement_service_password }}
 user_domain_name = "{{.Values.global.keystone_service_domain | default "Default" }}"
 project_name = "{{.Values.global.keystone_service_project | default "service" }}"
 project_domain_name = "{{.Values.global.keystone_service_domain | default "Default" }}"

--- a/openstack/placement/templates/etc/_secrets.conf.tpl
+++ b/openstack/placement/templates/etc/_secrets.conf.tpl
@@ -1,0 +1,10 @@
+[placement_database]
+{{- if not .Values.mariadb.enabled }}
+connection = {{ tuple . .Values.api_db.name .Values.api_db.user .Values.api_db.password | include "db_url_mysql" }}
+{{- else }}
+connection = {{ tuple . .Values.mariadb.name .Values.global.dbUser .Values.global.dbPassword | include "db_url_mysql" }}
+{{- end }}
+
+[keystone_authtoken]
+username = {{ .Values.global.placement_service_user | default "placement" }}{{ .Values.global.user_suffix }}
+password = {{ required ".Values.global.placement_service_password is missing" .Values.global.placement_service_password }}

--- a/openstack/placement/templates/placement-api-deployment.yaml
+++ b/openstack/placement/templates/placement-api-deployment.yaml
@@ -29,6 +29,7 @@ spec:
         alert-service: placement
       annotations:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
+        secrets-hash: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
         {{- if .Values.proxysql.mode }}
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
@@ -60,6 +61,10 @@ spec:
         - name: PYTHONWARNINGS
           value: {{ .Values.python_warnings | quote }}
         {{- end }}
+        - name: OS_PLACEMENT_CONFIG_DIR
+          value: "/etc/placement/"
+        - name: OS_PLACEMENT_CONFIG_FILES
+          value: "placement.conf;secrets.conf"
         lifecycle:
           preStop:
               {{- include "utils.snippets.pre_stop_graceful_shutdown" . | indent 14 }}
@@ -88,8 +93,15 @@ spec:
         {{- include "utils.trust_bundle.volume_mount" . | indent 8 }}
       {{- include "utils.proxysql.container" . | indent 6 }}
       volumes:
-      - name: placement-etc
-        configMap:
-          name: placement-etc
+        - name: placement-etc
+          projected:
+            sources:
+            - configMap:
+                name: placement-etc
+            - secret:
+                name: placement-secrets
+                items:
+                  - key: secrets.conf
+                    path: secrets.conf
       {{- include "utils.proxysql.volumes" . | indent 6 }}
       {{- include "utils.trust_bundle.volumes" . | indent 6 }}

--- a/openstack/placement/templates/secrets.yaml
+++ b/openstack/placement/templates/secrets.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: placement-secrets
+  labels:
+    system: openstack
+    type: configuration
+    component: placement
+type: Opaque
+data: 
+  secrets.conf: |
+    {{ include (print .Template.BasePath "/etc/_secrets.conf.tpl") . | b64enc | indent 4 }}


### PR DESCRIPTION
- Separate config will be projected into /etc/placement/secrets.conf
- Requires wsgi changes to Placement codebase to allow multiple config files