### PR TITLE
[rabbitmq] add default container annotation

### DIFF
--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 0.6.4
+version: 0.6.5
 description: A Helm chart for RabbitMQ
 sources:
 - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/templates/deployment.yaml
+++ b/common/rabbitmq/templates/deployment.yaml
@@ -29,6 +29,7 @@ spec:
       labels:
         app: {{ template "fullname" . }}
       annotations:
+        kubectl.kubernetes.io/default-container: rabbitmq
         checksum/container.init: {{ include (print $.Template.BasePath "/bin-secret.yaml") . | sha256sum }}
 {{- if and (and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested) $.Values.linkerd.enabled }}
         linkerd.io/inject: enabled

--- a/common/rabbitmq/templates/statefulset.yaml
+++ b/common/rabbitmq/templates/statefulset.yaml
@@ -23,6 +23,7 @@ spec:
       labels:
         app: {{ template "fullname" . }}
       annotations:
+        kubectl.kubernetes.io/default-container: rabbitmq
 {{- if and (and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested) $.Values.linkerd.enabled }}
         linkerd.io/inject: enabled
 {{- end }}


### PR DESCRIPTION
useful to not have to specify the container name for
`kubectl logs` or `kubectl exec`

@Kuckkuck fyi
