### PR TITLE
[glance] move configuration with credentials into own secrets

### DIFF
--- a/openstack/glance/ci/test-values.yaml
+++ b/openstack/glance/ci/test-values.yaml
@@ -30,3 +30,6 @@ rabbitmq:
       password: defaultdefault
   metrics:
     password: metricsmetrics
+
+swift:
+  enabled: false

--- a/openstack/glance/templates/deployment.yaml
+++ b/openstack/glance/templates/deployment.yaml
@@ -34,6 +34,7 @@ spec:
       annotations:
         chart-version: {{.Chart.Version}}
         checksum/etc-configmap.conf: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
+        secrets-hash: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
         {{- if .Values.proxysql.mode }}
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
@@ -145,6 +146,9 @@ spec:
           mountPath: /etc/glance/logging.ini
           subPath: logging.ini
           readOnly: true
+        - name: glance-etc-confd
+          mountPath: /etc/glance/glance.conf.d
+          readOnly: true
         - mountPath: /glance_store
           name: image-store
         {{- if .Values.watcher.enabled }}
@@ -237,6 +241,9 @@ spec:
           mountPath: /etc/glance/logging.ini
           subPath: logging.ini
           readOnly: true
+        - name: glance-etc-confd
+          mountPath: /etc/glance/glance.conf.d
+          readOnly: true
         {{- if .Values.watcher.enabled }}
         - name: glance-etc
           mountPath: /etc/glance/watcher.yaml
@@ -296,5 +303,8 @@ spec:
       - name: glance-etc
         configMap:
           name: glance-etc
+      - name: glance-etc-confd
+        secret:
+          secretName: {{ .Release.Name }}-secrets
       {{- include "utils.proxysql.volumes" . | indent 6 }}
       {{- include "utils.trust_bundle.volumes" . | indent 6 }}

--- a/openstack/glance/templates/etc/_glance-api.conf.tpl
+++ b/openstack/glance/templates/etc/_glance-api.conf.tpl
@@ -21,16 +21,12 @@ workers = {{ .Values.workers }}
 
 wsgi_default_pool_size = {{ .Values.wsgi_default_pool_size | default 100 }}
 
-{{- include "ini_sections.database" . }}
-
 [keystone_authtoken]
 auth_plugin = v3password
 auth_version = v3
 auth_interface = internal
 www_authenticate_uri = https://{{include "keystone_api_endpoint_host_public" .}}/v3
 auth_url = {{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3
-username = {{ .Values.global.glance_service_user | default "glance" | replace "$" "$$"}}
-password = {{ required ".Values.global.glance_service_password is missing" .Values.global.glance_service_password }}
 user_domain_name = {{.Values.global.keystone_service_domain | default "Default"}}
 region_name = {{.Values.global.region}}
 project_name = {{.Values.global.keystone_service_project |  default "service"}}
@@ -67,13 +63,11 @@ swift_upload_buffer_dir = /upload
 swift_store_expire_soon_interval = 1800
 swift_store_thread_pool_size = 10
 swift_container_delete_timeout = 2
-{{- if .Values.swift.multi_tenant }}
+{{- if .values.swift.multi_tenant }}
 swift_store_multi_tenant = True
 # swift_store_large_object_size = 5120
 # swift_store_large_object_chunk_size = 200
 # the following are deprecated but needed here https://github.com/openstack/glance_store/blob/stable/queens/glance_store/_drivers/swift/utils.py#L128-L145
-swift_store_user = service:{{ .Values.global.glance_service_user | default "glance" | replace "$" "$$"}}
-swift_store_key = {{ required ".Values.global.glance_service_password is missing" .Values.global.glance_service_password }}
 swift_store_auth_version = 3
 swift_store_auth_address = {{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3
 {{- else }}
@@ -98,8 +92,6 @@ enforce_scope=False
 
 [barbican]
 auth_endpoint = {{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3
-
-{{- include "ini_sections.audit_middleware_notifications" . }}
 
 {{- if .Values.osprofiler.enabled }}
 {{- include "osprofiler" . }}

--- a/openstack/glance/templates/etc/_glance-api.conf.tpl
+++ b/openstack/glance/templates/etc/_glance-api.conf.tpl
@@ -63,7 +63,7 @@ swift_upload_buffer_dir = /upload
 swift_store_expire_soon_interval = 1800
 swift_store_thread_pool_size = 10
 swift_container_delete_timeout = 2
-{{- if .values.swift.multi_tenant }}
+{{- if .Values.swift.multi_tenant }}
 swift_store_multi_tenant = True
 # swift_store_large_object_size = 5120
 # swift_store_large_object_chunk_size = 200

--- a/openstack/glance/templates/etc/_glance-registry.conf.tpl
+++ b/openstack/glance/templates/etc/_glance-registry.conf.tpl
@@ -13,16 +13,12 @@ rpc_workers = {{ .Values.rpc_workers | default 1 }}
 
 wsgi_default_pool_size = {{ .Values.wsgi_default_pool_size | default 100 }}
 
-{{- include "ini_sections.database" . }}
-
 [keystone_authtoken]
 auth_plugin = v3password
 auth_version = v3
 auth_interface = internal
 www_authenticate_uri = https://{{include "keystone_api_endpoint_host_public" .}}/v3
 auth_url = {{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3
-username = {{ .Values.global.glance_service_user | default "glance" | replace "$" "$$"}}
-password = {{ required ".Values.global.glance_service_password is missing" .Values.global.glance_service_password }}
 user_domain_name = {{.Values.global.keystone_service_domain | default "Default"}}
 region_name = {{.Values.global.region}}
 project_name = {{.Values.global.keystone_service_project |  default "service"}}
@@ -38,8 +34,6 @@ flavor = keystone
 
 [oslo_messaging_notifications]
 driver = noop
-
-{{- include "ini_sections.audit_middleware_notifications" . }}
 
 {{- include "ini_sections.cache" . }}
 

--- a/openstack/glance/templates/etc/_secrets.conf.tpl
+++ b/openstack/glance/templates/etc/_secrets.conf.tpl
@@ -1,0 +1,22 @@
+[keystone_authtoken]
+username = {{ .Values.global.glance_service_user | default "glance" | replace "$" "$$"}}
+password = {{ required ".Values.global.glance_service_password is missing" .Values.global.glance_service_password }}
+
+{{- include "ini_sections.database" . }}
+
+{{- include "ini_sections.audit_middleware_notifications" . }}
+
+
+{{- if .Values.swift.enabled }}
+{{- if .values.swift.multi_tenant }}
+[glance_store]
+swift_store_user = service:{{ .Values.global.glance_service_user | default "glance" | replace "$" "$$"}}
+swift_store_key = {{ required ".Values.global.glance_service_password is missing" .Values.global.glance_service_password }}
+{{- end }}
+{{- end }}
+
+{{- if and .Values.swift.enabled (not .Values.swift.multi_tenant)}}
+[swift-global]
+key = {{ required ".Values.global.glance_service_password is missing" .Values.global.glance_service_password }}
+user = {{ .Values.swift.projectName }}:{{ .Values.global.glance_service_user | default "glance" | replace "$" "$$"}}
+{{- end }}

--- a/openstack/glance/templates/etc/_secrets.conf.tpl
+++ b/openstack/glance/templates/etc/_secrets.conf.tpl
@@ -8,7 +8,7 @@ password = {{ required ".Values.global.glance_service_password is missing" .Valu
 
 
 {{- if .Values.swift.enabled }}
-{{- if .values.swift.multi_tenant }}
+{{- if .Values.swift.multi_tenant }}
 [glance_store]
 swift_store_user = service:{{ .Values.global.glance_service_user | default "glance" | replace "$" "$$"}}
 swift_store_key = {{ required ".Values.global.glance_service_password is missing" .Values.global.glance_service_password }}

--- a/openstack/glance/templates/etc/_swift-store.conf.tpl
+++ b/openstack/glance/templates/etc/_swift-store.conf.tpl
@@ -4,6 +4,4 @@ auth_version = 3
 project_domain_name = {{.Values.swift.projectDomainName}}
 user_domain_name = {{.Values.swift.userDomainName}}
 auth_address = {{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3
-key = {{ required ".Values.global.glance_service_password is missing" .Values.global.glance_service_password }}
-user = {{ .Values.swift.projectName }}:{{ .Values.global.glance_service_user | default "glance" | replace "$" "$$"}}
 {{- end }}

--- a/openstack/glance/templates/migration-job.yaml
+++ b/openstack/glance/templates/migration-job.yaml
@@ -21,6 +21,7 @@ spec:
       annotations:
         chart-version: {{.Chart.Version}}
         checksum/etc-configmap.conf: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
+        secrets-hash: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
     spec:
       restartPolicy: OnFailure
       {{- include "utils.proxysql.job_pod_settings" . | indent 6 }}
@@ -55,6 +56,9 @@ spec:
             name: glance-etc
             subPath: glance-api.conf
             readOnly: true
+          - name: glance-etc-confd
+            mountPath: /etc/glance/glance.conf.d
+            readOnly: true
           {{- if not .Values.swift.multi_tenant }}
           - mountPath: /etc/glance/swift-store.conf
             name: glance-etc
@@ -73,5 +77,8 @@ spec:
       - name: glance-etc
         configMap:
           name: glance-etc
+      - name: glance-etc-confd
+        secret:
+          secretName: {{ .Release.Name }}-secrets
       {{- include "utils.proxysql.volumes" . | indent 6 }}
       {{- include "utils.trust_bundle.volumes" . | indent 6 }}

--- a/openstack/glance/templates/secrets.yaml
+++ b/openstack/glance/templates/secrets.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-secrets
+  labels:
+    app: {{ template "name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    type: api
+    component: glance
+type: Opaque
+data: 
+  secrets.conf: |
+    {{ include (print .Template.BasePath "/etc/_secrets.conf.tpl") . | b64enc | indent 4 }}


### PR DESCRIPTION
- Secrets config will be projected into /etc/glance/glance.conf.d/
- Has to be tested