### PR TITLE
[rabbitmq] fix permissions if persistence is enabled

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -3,6 +3,26 @@ Rabbitmq CHANGELOG
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+0.6.6
+-----
+maurice.escher@sap.com
+- fix permissions if persistence is enabled, does a recursive chown once
+- add owner info explicitly to pvc, clears helm diff from injected annotations
+
+0.6.5
+-----
+maurice.escher@sap.com
+- add default container annotation, useful for `kubectl logs` or `kubectl exec`
+
+0.6.4
+-----
+maurice.escher@sap.com
+- make start wait timeout configurable, coupled with liveness initial delay
+
+0.6.3
+-----
+fabian.wiesel@sap.com
+- move setup script with credentials to secret
 
 0.6.2
 -----
@@ -37,7 +57,7 @@ b.alkhateeb@sap.com
 - update rabbitmq to version 3.11.15-management (bug fixes).
 
 0.5.1
------ 
+-----
 fabian.wiesel@sap.common
 - Use just the hostname without domain for the transport-url
 

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 0.6.5
+version: 0.6.6
 description: A Helm chart for RabbitMQ
 sources:
 - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/templates/deployment.yaml
+++ b/common/rabbitmq/templates/deployment.yaml
@@ -57,6 +57,22 @@ spec:
         runAsGroup: 999
         fsGroup: 999
         fsGroupChangePolicy: "OnRootMismatch"
+      {{- if .Values.persistence.enabled }}
+      initContainers:
+      - name: volume-permissions
+        image: "{{include "dockerHubMirror" .}}/library/busybox"
+        imagePullPolicy: {{ default "IfNotPresent" .Values.imagePullPolicy | quote }}
+        command:
+        - /bin/sh
+        - -c
+        - |
+          [ $(stat -c %u /var/lib/rabbitmq) -eq 999 ] || chown -R 999:999 /var/lib/rabbitmq
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+          - mountPath: /var/lib/rabbitmq
+            name: rabbitmq-persistent-storage
+      {{- end }}
       containers:
       - name: rabbitmq
         image: "{{include "dockerHubMirror" .}}/{{ .Values.image }}:{{.Values.imageTag }}"

--- a/common/rabbitmq/templates/pvc.yaml
+++ b/common/rabbitmq/templates/pvc.yaml
@@ -13,6 +13,10 @@ metadata:
   {{- if .Values.persistence.storageClass }}
     volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
   {{- end }}
+  {{- if .Values.alerts.support_group }}
+    ccloud/support-group: {{  .Values.alerts.support_group }}
+    ccloud/service: {{ include "alerts.service" . }}
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/common/rabbitmq/templates/statefulset.yaml
+++ b/common/rabbitmq/templates/statefulset.yaml
@@ -49,6 +49,22 @@ spec:
         runAsUser: 999
         runAsGroup: 999
         fsGroup: 999
+      {{- if .Values.persistence.enabled }}
+      initContainers:
+      - name: volume-permissions
+        image: "{{include "dockerHubMirror" .}}/library/busybox"
+        imagePullPolicy: {{ default "IfNotPresent" .Values.imagePullPolicy | quote }}
+        command:
+        - /bin/sh
+        - -c
+        - |
+          [ $(stat -c %u /var/lib/rabbitmq) -eq 999 ] || chown -R 999:999 /var/lib/rabbitmq
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+          - mountPath: /var/lib/rabbitmq
+            name: rabbitmq-persistent-storage
+      {{- end }}
       containers:
       - name: rabbitmq
         image: "{{include "dockerHubMirror" .}}/{{ .Values.image }}:{{.Values.imageTag }}"


### PR DESCRIPTION
`fsGroupChangePolicy: "OnRootMismatch"`does not work for NFS mounts
(also see kubernetes/examples/issues/260)
