### PR TITLE
[utils] add owner info explicitly to coordination pvc

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.14.3
+version: 0.14.4

--- a/openstack/utils/templates/_coordination.tpl
+++ b/openstack/utils/templates/_coordination.tpl
@@ -29,6 +29,10 @@ metadata:
   {{- if .Values.coordinationBackendStorageClass }}
     volume.beta.kubernetes.io/storage-class: {{ .Values.coordinationBackendStorageClass | quote }}
   {{- end }}
+  {{- if  index .Values "owner-info" }}
+    ccloud/support-group: {{  index .Values "owner-info" "support-group" | quote }}
+    ccloud/service: {{  index .Values "owner-info" "service" | quote }}
+  {{- end }}
 spec:
   accessModes:
   - ReadWriteMany


### PR DESCRIPTION
to not have the injected annotations show up in helm diff each time
