### PR TITLE
[barbican] move configuration with credentials into own secrets

### DIFF
--- a/openstack/barbican/templates/api-deployment.yaml
+++ b/openstack/barbican/templates/api-deployment.yaml
@@ -109,6 +109,9 @@ spec:
               mountPath: /etc/barbican/logging.ini
               subPath: logging.ini
               readOnly: true
+            - mountPath: /etc/barbican/barbican.conf.d
+              name: barbican-etc-confd
+              readOnly: true
             {{- if .Values.watcher.enabled }}
             - name: barbican-etc
               mountPath: /etc/barbican/watcher.yaml
@@ -195,13 +198,22 @@ spec:
         - name: barbican-etc
           configMap:
             name: barbican-etc
+        - name: barbican-etc-confd
+          secret:
+            secretName: {{ .Release.Name }}-secrets
+            items:
+            - key: secrets.conf
+              path: secrets.conf
         - name: etcbarbican
           emptyDir: {}
         {{- if .Values.hsm.enabled }}
         - name: hsm
-          configMap:
-            name: barbican-etc
+          secret:
+            secretName: {{ .Release.Name }}-secrets
             defaultMode: 0744
+            items:
+            - key: barbican_lunaclient.sh
+              path: barbican_lunaclient.sh
         - name: luna
           emptyDir: {}
         {{ end }}

--- a/openstack/barbican/templates/etc-configmap.yaml
+++ b/openstack/barbican/templates/etc-configmap.yaml
@@ -34,7 +34,3 @@ data:
       match_type: glob
       glob_disable_ordering: false
       ttl: 0 # metrics do not expire
-{{- if .Values.hsm.enabled }}
-  barbican_lunaclient.sh: |
-{{ include (print .Template.BasePath "/etc/_barbican_lunaclient.sh.tpl") . | indent 4 }}
-{{- end }}

--- a/openstack/barbican/templates/etc/_barbican.conf.tpl
+++ b/openstack/barbican/templates/etc/_barbican.conf.tpl
@@ -34,14 +34,6 @@ backlog = 4096
 max_allowed_secret_in_bytes = 20000
 max_allowed_request_size_in_bytes = 1000000
 
-{{ if eq .Values.postgresql.enabled false }}
-sql_connection = {{ include "db_url_mysql" . }}
-{{ else }}
-sql_connection = {{ include "db_url" . }}
-{{ end }}
-
-{{ include "ini_sections.default_transport_url" . }}
-
 rpc_response_timeout = {{ .Values.rpc_response_timeout | default .Values.global.rpc_response_timeout | default 60 }}
 rpc_workers = {{ .Values.rpc_workers | default .Values.global.rpc_workers | default 1 }}
 
@@ -57,8 +49,6 @@ auth_version = v3
 auth_interface = internal
 www_authenticate_uri = https://{{include "keystone_api_endpoint_host_public" .}}/v3
 auth_url = {{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3
-username = {{ .Release.Name }}{{ .Values.global.user_suffix }}
-password = {{ required ".Values.global.barbican_service_password is missing" .Values.global.barbican_service_password }}
 user_domain_id = default
 project_name = service
 project_domain_id = default
@@ -68,8 +58,6 @@ service_token_roles_required = True
 token_cache_time = 600
 include_service_catalog = true
 service_type = key-manager
-
-{{- include "ini_sections.audit_middleware_notifications" . }}
 
 {{- include "ini_sections.cache" . }}
 
@@ -92,12 +80,4 @@ crypto_plugin = simple_crypto
 secret_store_plugin = store_crypto
 crypto_plugin = p11_crypto
 global_default = True
-
-[p11_crypto_plugin]
-library_path = {{ .Values.lunaclient.conn.library_path }}
-login = {{ .Values.lunaclient.conn.login }}
-mkek_label = {{ .Values.lunaclient.conn.mkek_label }}
-mkek_length = {{ .Values.lunaclient.conn.mkek_length }}
-hmac_label = {{ .Values.lunaclient.conn.hmac_label }}
-slot_id = {{ .Values.lunaclient.conn.slot_id }}
 {{- end }}

--- a/openstack/barbican/templates/etc/_secrets.conf.tpl
+++ b/openstack/barbican/templates/etc/_secrets.conf.tpl
@@ -1,0 +1,23 @@
+[DEFAULT]
+sql_connection = {{ include "db_url_mysql" . }}
+
+{{ include "ini_sections.default_transport_url" . }}
+
+
+[keystone_authtoken]
+username = {{ .Release.Name }}
+password = {{ required ".Values.global.barbican_service_password is missing" .Values.global.barbican_service_password }}
+
+
+{{ include "ini_sections.audit_middleware_notifications" . }}
+
+
+{{- if .Values.hsm.multistore.enabled }}
+[p11_crypto_plugin]
+library_path = {{ .Values.lunaclient.conn.library_path }}
+login = {{ .Values.lunaclient.conn.login }}
+mkek_label = {{ .Values.lunaclient.conn.mkek_label }}
+mkek_length = {{ .Values.lunaclient.conn.mkek_length }}
+hmac_label = {{ .Values.lunaclient.conn.hmac_label }}
+slot_id = {{ .Values.lunaclient.conn.slot_id }}
+{{- end }}

--- a/openstack/barbican/templates/migration-job.yaml
+++ b/openstack/barbican/templates/migration-job.yaml
@@ -64,6 +64,9 @@ spec:
               mountPath: /etc/barbican/logging.ini
               subPath: logging.ini
               readOnly: true
+            - name: barbican-etc-confd
+              mountPath: /etc/barbican/barbican.conf.d
+              readOnly: true
             {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
       volumes:
         - name: etcbarbican
@@ -71,4 +74,10 @@ spec:
         - name: barbican-etc
           configMap:
             name: barbican-etc
+        - name: barbican-etc-confd
+          secret:
+            secretName: {{ .Release.Name }}-secrets
+            items:
+            - key: secrets.conf
+              path: secrets.conf
         {{- include "utils.trust_bundle.volumes" . | indent 8 }}

--- a/openstack/barbican/templates/secrets.yaml
+++ b/openstack/barbican/templates/secrets.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-secrets
+  labels:
+    system: openstack
+    type: configuration
+    component: barbican
+type: Opaque
+data: 
+  secrets.conf: |
+    {{ include (print .Template.BasePath "/etc/_secrets.conf.tpl") . | b64enc | indent 4 }}
+{{- if .Values.hsm.enabled }}
+  barbican_lunaclient.sh: |
+    {{ include (print .Template.BasePath "/etc/_barbican_lunaclient.sh.tpl") .| b64enc | indent 4 }}
+{{- end }}


### PR DESCRIPTION
- Secrets config will be projected into /etc/barbican/barbican.conf.d/
- And /luna/barbican_lunaclient.sh
- Has to be tested