### PR TITLE
[Nova] Use linkerd for Jobs

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 0.1.5
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.13.0
+  version: 0.14.6
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.8.0
@@ -29,5 +29,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:3236186eb4f6616e6657e6221f6252d7ba1d1fb014339c911ba0e37556898dce
-generated: "2023-12-04T15:44:58.573896905+01:00"
+digest: sha256:15ec1fd24bd2cc23921187382c84bb9d72c485f31242c628dfd7d77d1f110392
+generated: "2024-03-13T14:37:43.347784721+01:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     version: 0.1.5
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.13.0
+    version: ~0.14.6
   - name: mariadb
     alias: mariadb_cell2
     condition: mariadb_cell2.enabled

--- a/openstack/nova/templates/_helpers.tpl
+++ b/openstack/nova/templates/_helpers.tpl
@@ -47,6 +47,7 @@ labels:
 {{ tuple . .Release.Name $name | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 2 }}
 annotations:
   bin-hash: {{ include (print .Template.BasePath "/bin/_" $name ".tpl") . | sha256sum }}
+  {{- include "utils.linkerd.pod_and_service_annotation" . | indent 2 }}
   {{- end }}
 {{- end }}
 

--- a/openstack/nova/templates/bin/_db-migrate.tpl
+++ b/openstack/nova/templates/bin/_db-migrate.tpl
@@ -108,4 +108,4 @@ nova-manage --config-file /etc/nova/nova-cell2.conf db sync --local_cell
 
 # online data migration run by online-migration-job
 
-{{ include "utils.proxysql.proxysql_signal_stop_script" . }}
+{{ include "utils.script.job_finished_hook" . }}

--- a/openstack/nova/templates/bin/_db-online-migrate.tpl
+++ b/openstack/nova/templates/bin/_db-online-migrate.tpl
@@ -17,4 +17,4 @@ if echo "${available_commands_text}" | grep -q -E '[{,]placement[},]'; then
   $nova_manage placement sync_aggregates
 fi
 
-{{ include "utils.proxysql.proxysql_signal_stop_script" . }}
+{{ include "utils.script.job_finished_hook" . }}


### PR DESCRIPTION
For using `linkerd` in Job-spawned Pods, we have to add a snippet at the end that will tell the `linkerd-proxy` sidecar to stop. This snippet is integrated - together with the proxysql snippet - into "utils.script.job_finished_hook" in the `utils` chart starting with version 0.14.6.

Since we need a version bump, we also get:
* add owner info explicitly to coordination pvc
* mount a trust-bundle at subpath