### PR TITLE
[vmware-monitoring] Expose compute status disabled and decommissioning information

### DIFF
--- a/system/vmware-monitoring/templates/collector-configmap.yaml
+++ b/system/vmware-monitoring/templates/collector-configmap.yaml
@@ -84,6 +84,10 @@ data:
         key: "configuration|drsconfig|affinityRules"
       - metric_suffix: "custom_attributes_hana_exclusive_info"
         key: "summary|customTag:hana_exclusive|customTagValue"
+      - metric_suffix: "summary_custom_tag_openstack_nova_traits_compute_status_disabled"
+        key: "summary|customTag:openstack.nova.traits.COMPUTE_STATUS_DISABLED|customTagValue"
+      - metric_suffix: "summary_custom_tag_openstack_nova_traits_decommissioning"
+        key: "summary|customTag:openstack.nova.traits.CUSTOM_DECOMMISSIONING|customTagValue"
       - metric_suffix: "summary_custom_tag_openstack_nova_traits_hana_exclusive_host"
         key: "summary|customTag:openstack.nova.traits.CUSTOM_HANA_EXCLUSIVE_HOST|customTagValue"
 


### PR DESCRIPTION
- Include the compute status disabled and decommissioning key from the OpenStack Nova traits in the vrops-exporter-collector-config (ClusterPropertiesCollector) for generating the Prometheus metrics
- [ ] Check if the data is available in the vROps REST API