### PR TITLE
[Placement] Support linkerd in Jobs

### DIFF
--- a/openstack/placement/Chart.lock
+++ b/openstack/placement/Chart.lock
@@ -7,12 +7,12 @@ dependencies:
   version: 0.2.0
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.13.0
+  version: 0.14.6
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:4f7036b51c6b18c4d5d26297d516e63e8d5fddd287cee08b92e95b78d1b1515d
-generated: "2023-12-04T15:37:33.379994947+01:00"
+digest: sha256:42f56130739c966574d5aa21138527088f728487e4581e91281fdaa727ac0c1c
+generated: "2024-03-14T07:41:06.178360788+01:00"

--- a/openstack/placement/Chart.yaml
+++ b/openstack/placement/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
     version: 0.2.0
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.13.0
+    version: ~0.14.6
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0

--- a/openstack/placement/templates/db-migrate-job.yaml
+++ b/openstack/placement/templates/db-migrate-job.yaml
@@ -16,6 +16,8 @@ spec:
         alert-tier: os
         alert-service: placement
 {{ tuple . "placement" "db-migrate" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
+      annotations:
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
       restartPolicy: OnFailure
       {{- include "utils.proxysql.job_pod_settings" . | indent 6 }}
@@ -37,7 +39,7 @@ spec:
               # wait for proxysql to start so we can properly kill it
               sleep 5
           fi
-          {{ include "utils.proxysql.proxysql_signal_stop_script" . | trim }}
+          {{- include "utils.script.job_finished_hook" . | nindent 10 }}
         env:
           {{- if .Values.sentry.enabled }}
         - name: SENTRY_DSN

--- a/openstack/placement/templates/db-online-migrate-job.yaml
+++ b/openstack/placement/templates/db-online-migrate-job.yaml
@@ -16,6 +16,8 @@ spec:
         alert-tier: os
         alert-service: placement
 {{ tuple . "placement" "db-online-migrate" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
+      annotations:
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
       restartPolicy: OnFailure
       {{- include "utils.proxysql.job_pod_settings" . | indent 6 }}
@@ -37,7 +39,7 @@ spec:
               # wait for proxysql to start so we can properly kill it
               sleep 5
           fi
-          {{ include "utils.proxysql.proxysql_signal_stop_script" . | trim }}
+          {{- include "utils.script.job_finished_hook" . | nindent 10 }}
         env:
           {{- if .Values.sentry.enabled }}
         - name: SENTRY_DSN


### PR DESCRIPTION
We bump the `utils` chart and switch to "utils.script.job_finished_hook" to include the commands to stop `proxysql` and `linkerd` at the end of our Jobs.

With updating `utils`, we also get the trust-bundle only overwriting "/etc/ssl/certs/ca-certificates.crt" instead of all of "/etc/ssl/certs".