### PR TITLE
[neutron] Support linkderd in Jobs

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 0.6.0
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.14.3
+  version: 0.14.6
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:056ef37daf044ee3d39c5b7f7100aa4a861fde10d55a0d9692286ef2accb6fcd
-generated: "2023-12-22T09:59:05.860714653+01:00"
+digest: sha256:29b33b5ba87bbcde84df9031cad576338098368be2391209e781b3f5182add1e
+generated: "2024-03-14T12:52:39.617075551+01:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -20,7 +20,7 @@ dependencies:
     version: 0.6.0
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.14.3
+    version: 0.14.6
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0

--- a/openstack/neutron/templates/_helper.tpl
+++ b/openstack/neutron/templates/_helper.tpl
@@ -1,5 +1,5 @@
 {{- define "neutron.migration_job_name" -}}
-  {{- $bin := include "utils.proxysql.proxysql_signal_stop_script" . | trim }}
+  {{- $bin := include "utils.script.job_finished_hook" . | trim }}
   {{- $all := list $bin (include "utils.proxysql.job_pod_settings" . ) (include "utils.proxysql.volume_mount" . ) (include "utils.proxysql.container" . ) (include "utils.proxysql.volumes" .) (tuple . (dict) | include "utils.snippets.kubernetes_entrypoint_init_container")  | join "\n" }}
   {{- $all := list $bin (include "utils.proxysql.job_pod_settings" . ) (include "utils.proxysql.volume_mount" . ) (include "utils.proxysql.container" . ) (include "utils.proxysql.volumes" .) (tuple . (dict) | include "utils.snippets.kubernetes_entrypoint_init_container") (include "utils.trust_bundle.volume_mount" . ) (include "utils.trust_bundle.volumes" . ) (include "utils.trust_bundle.env" . )  | join "\n" }}
   {{- $hash := empty .Values.proxysql.mode | ternary $bin $all | sha256sum }}

--- a/openstack/neutron/templates/job-migration.yaml
+++ b/openstack/neutron/templates/job-migration.yaml
@@ -42,7 +42,7 @@ spec:
             - |
               set -euo pipefail
               neutron-db-manage upgrade head
-{{ include "utils.proxysql.proxysql_signal_stop_script" . | trim | indent 14 }}
+              {{- include "utils.script.job_finished_hook" . | nindent 14 }}
           env:
             - name: PGAPPNAME
               valueFrom:


### PR DESCRIPTION
We bump the `utils` chart and switch to "utils.script.job_finished_hook" to include the commands to stop `proxysql` and linkerd at the end of our Jobs.