### PR TITLE
[rabbitmq] add switch to create temporary dev user

### DIFF
--- a/common/rabbitmq/values.yaml
+++ b/common/rabbitmq/values.yaml
@@ -34,6 +34,10 @@ users:
     password: null
     tag: administrator
 
+# if set true, this will create user dev with password dev for debug and development purposes
+# DANGEROUS, please make sure it is set to false unless really needed
+addDevUser: false
+
 persistence:
   enabled: false
   accessMode: ReadWriteMany


### PR DESCRIPTION
This PR adds switch that creates dev user that will be created for development use only. It is insecure and should never be used for any other purpose except development. Intention of ticket was to add passwordless access to rabbitmq, but it is not possible due rabbitmq limitation