### PR TITLE
[Cinder] Enable linkerd everywhere

### DIFF
--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -7,7 +7,7 @@ global:
   domain_seeds:
     skip_hcm_domain: false
  
-  linkerd_requested: false
+  linkerd_requested: true
   osprofiler: {}
   imagePullPolicy: IfNotPresent
 


### PR DESCRIPTION
This patch enables linkerd for cinder in all regions.