### PR TITLE
[neutron] Configure ACI sync allocations done marker

### DIFF
--- a/openstack/neutron/templates/etc/_ml2-conf-aci.ini.tpl
+++ b/openstack/neutron/templates/etc/_ml2-conf-aci.ini.tpl
@@ -47,6 +47,9 @@ enable_nullroute_sync = {{ .Values.aci.enable_nullroute_sync }}
 {{- if .Values.aci.enable_az_aware_subnet_routes_sync }}
 enable_az_aware_subnet_routes_sync = {{ .Values.aci.enable_az_aware_subnet_routes_sync }}
 {{- end }}
+{{- if .Values.aci.sync_allocations_done_file_path }}
+sync_allocations_done_file_path = {{ .Values.aci.sync_allocations_done_file_path }}
+{{- end }}
 
 {{- if .Values.aci.pc_policy_groups }}
 {{ range $i, $pc_policy_group := .Values.aci.pc_policy_groups }}

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -209,6 +209,7 @@ aci:
   apic_application_profile: converged_cloud_openstack
   support_remote_mac_clear: 'True'
   sync_allocations: 'True'
+  sync_allocations_done_file_path: "/tmp/aci-sync-allocations-done"
   # apic_hosts: null
   # apic_user: null
   # apic_password: null


### PR DESCRIPTION
To make sure only one worker in a pod syncs the ACI allocations we now have a file that is used to check if anyone else in that pod (i.e. with the same config) did already sync the allocations table.