### PR TITLE
[designate-nanny] add username to secret, for reliable rotation

### DIFF
--- a/openstack/designate-nanny/templates/deployment.yaml
+++ b/openstack/designate-nanny/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
          - name: OS_AUTH_URL
            value: "{{ .Values.global.keystone_api_endpoint_protocol_public | default "https"}}://{{include "keystone_api_endpoint_host_public" .}}/v3"
          - name: PYCCLOUD_USE_DUMMY_SECRETS
-           value: "yes"          
+           value: "yes"
          - name: OS_REGION_NAME
            value: "{{ required "missing .Values.global.region" .Values.global.region}}"
          - name: OS_PROJECT_NAME
@@ -55,7 +55,10 @@ spec:
          - name: OS_PROJECT_DOMAIN_NAME
            value:  "{{ required "missing .Values.designate_nanny.credentials.designate_api.project_domain_name" .Values.designate_nanny.credentials.designate_api.project_domain_name}}"
          - name: OS_USERNAME
-           value: "{{ required "missing .Values.designate_nanny.credentials.designate_api.user" .Values.designate_nanny.credentials.designate_api.user}}"
+           valueFrom:
+             secretKeyRef:
+               name: designate-nanny-secret
+               key:  designate_nanny_os_username
          - name: OS_PASSWORD
            valueFrom:
              secretKeyRef:

--- a/openstack/designate-nanny/templates/secret.yaml
+++ b/openstack/designate-nanny/templates/secret.yaml
@@ -8,6 +8,7 @@ metadata:
     system: openstack
     application: designate
 data:
-  designate_nanny_os_password: {{ required "set password in .Values.designate_nanny.credentials.designate_api.password" .Values.designate_nanny.credentials.designate_api.password | b64enc }}
+  designate_nanny_os_username: {{ required "missing username in .Values.designate_nanny.credentials.designate_api.user" .Values.designate_nanny.credentials.designate_api.user | b64enc }}
+  designate_nanny_os_password: {{ required "missing password in .Values.designate_nanny.credentials.designate_api.password" .Values.designate_nanny.credentials.designate_api.password | b64enc }}
 
 {{- end }}

--- a/openstack/designate/ci/test-values.yaml
+++ b/openstack/designate/ci/test-values.yaml
@@ -51,6 +51,7 @@ designate_nanny:
   credentials:
     designate_api:
       user: nobody
+      seeder_password: DeckelSecret
       password: TopfSecret
       project_name: "test_project_name"
       project_domain_name: "test_project_domain_name"

--- a/openstack/designate/templates/seeds.yaml
+++ b/openstack/designate/templates/seeds.yaml
@@ -961,7 +961,7 @@ spec:
     users:
     - name: "{{ required "missing user in .Values.designate_nanny.credentials.designate_api.user" .Values.designate_nanny.credentials.designate_api.user}}"
       description: Designate Nanny
-      password: {{ required "missing password in .Values.designate_nanny.credentials.designate_api.password" .Values.designate_nanny.credentials.designate_api.password }}
+      password: {{ required "missing password in .Values.designate_nanny.credentials.designate_api.seeder_password" .Values.designate_nanny.credentials.designate_api.seeder_password }}
 
   - name: "{{ required "missing user in .Values.designate_nanny.credentials.designate_api.project_domain_name" .Values.designate_nanny.credentials.designate_api.project_domain_name}}"
     projects:


### PR DESCRIPTION
 [designate-nanny] add username to secret, change ref for seeder

By adding the username to the secret, rotation of username and password become an atomic operation, as both are bundled in a secret.

In addition the seeder gets its own field for the initial password, because it will not be able to resolve the new injector reference yet.