### PR TITLE
[netapp] fix metrics for offline volumes

### DIFF
--- a/prometheus-exporters/netapp-exporter/charts/netapp-cap-exporter/aggregations/netapp-castellum.rules
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-cap-exporter/aggregations/netapp-castellum.rules
@@ -66,7 +66,7 @@ groups:
 
       # Scraping will fail on shares in state "offline" because their size is always reported as 0.
       - record: netapp_volume_exclusion_reason_offline
-        expr: count(netapp_volume_total_bytes{project_id!="",share_id!="",volume_state="offline"}) by (project_id, share_id) > 0
+        expr: count(netapp_volume_total_bytes{project_id!="", share_id!="", volume_state="offline"}) by (project_id, share_id) unless (count(netapp_volume_total_bytes{volume_state="online"}) by (project_id, share_id))
       - record: manila_share_exclusion_reasons_for_castellum
         expr: label_replace(netapp_volume_exclusion_reason_offline, "reason", "volume_state = offline", "share_id", ".*")
 


### PR DESCRIPTION
In the aggregation rule `netapp_volume_exclusion_reason_offline`, we are currently reporting a share as `offline` if ANY of its volume is `offline`. In the DR or migration scenario, there can be multiple volumes for a share, and one of its volumes has `online` state and the others `offline`. We should drop such shares and allow them resizable by Castellum. Using the `unless` operator, we query metrics for `online` volumes on the right side and drop them if their labels (`share_id`, `project_id`) matched to the left.