### PR TITLE
[cinder] Support linkerd in Jobs

### DIFF
--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.14.1
+  version: 0.14.6
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.8.0
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:bc6776ef85dcd8c49af8b9c07ed6bb3ad292b2c4d2a74d3d835e0105c3cf7c25
-generated: "2023-12-14T10:56:47.295467105+01:00"
+digest: sha256:8ab0cb0e2dc624291e420d5719179c081d0f0f64cc664b50fec893b2d24c1b8c
+generated: "2024-03-20T09:56:27.640022342+01:00"

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.1.2
 dependencies:
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.14.1
+    version: ~0.14.6
   - name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.8.0

--- a/openstack/cinder/templates/migration-job.yaml
+++ b/openstack/cinder/templates/migration-job.yaml
@@ -10,6 +10,8 @@ spec:
   template:
     spec:
       restartPolicy: OnFailure
+      annotations:
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
       {{- include "utils.proxysql.job_pod_settings" . | nindent 6 }}
       initContainers:
       {{- tuple . (dict "service" (print .Release.Name "-mariadb")) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
@@ -22,7 +24,7 @@ spec:
             - -c
             - |
               cinder-manage db sync
-              {{ include "utils.proxysql.proxysql_signal_stop_script" . | trim }}
+              {{- include "utils.script.job_finished_hook" . | nindent 14 }}
           volumeMounts:
             - name: etccinder
               mountPath: /etc/cinder


### PR DESCRIPTION
We bump the `utils` chart and switch to "utils.script.job_finished_hook" to include the commands to stop `proxysql` and `linkerd` at the end of our Jobs.

With updating `utils`, we also get explicit owner-info on the coordination PVC.