### PR TITLE
[Cinder] Update type-seeds

### DIFF
--- a/openstack/cinder/templates/type-seeds.yaml
+++ b/openstack/cinder/templates/type-seeds.yaml
@@ -17,7 +17,13 @@ spec:
     description: "premium_ssd"
     extra_specs:
       volume_backend_name: "vmware"
+      backend_state: "up"
+      pool_state: "up"
+      independent_snapshots: "true"
+      "provisioning:type": "thick"
       "vmware:storage_profile": "cinder-vvol"
+      "vmware:vmdk_type": "thick"
+
 
   - name: standard_hdd
     is_public: true
@@ -25,6 +31,10 @@ spec:
     extra_specs:
       volume_backend_name: "standard_hdd"
       "provisioning:min_vol_size": "500"
+      backend_state: "up"
+      pool_state: "up"
+      independent_snapshots: "true"
+      "provisioning:type": "thick"
       "vmware:storage_profile": "cinder-standard-hdd"
       "vmware:vmdk_type": "thick"
 {{- end }}


### PR DESCRIPTION
This patch updates the cinder volume type seeds
to match what is in production.  There were several missing items for each type.