### PR TITLE
[hermes] mv logstash.conf to secrets

### DIFF
--- a/openstack/hermes/templates/etc/_logstash.conf.tpl
+++ b/openstack/hermes/templates/etc/_logstash.conf.tpl
@@ -254,8 +254,8 @@ filter {
     ]
     staging_directory => "/tmp/logstash/jdbc_static/import_data"
     loader_schedule => "{{ .Values.logstash.jdbc.schedule }}"
-    jdbc_user => "{{ .Values.global.metis.user }}"
-    jdbc_password => "${METIS_PASSWORD}"
+    jdbc_user => {{ .Values.global.metis.user | default "default" | quote }}
+    jdbc_password => {{ .Values.global.metis.password | default "default" | quote }}
     jdbc_driver_class => "com.mysql.cj.jdbc.Driver"
     jdbc_driver_library => ""
     jdbc_connection_string => "jdbc:mysql://{{ .Values.logstash.jdbc.service }}.{{ .Values.logstash.jdbc.namespace }}:3306/{{ .Values.logstash.jdbc.db }}"

--- a/openstack/hermes/templates/logstash-deployment.yaml
+++ b/openstack/hermes/templates/logstash-deployment.yaml
@@ -22,7 +22,6 @@ spec:
       labels:
         component: logstash
       annotations:
-        checksum/logstash-etc-configmap.yaml: {{ include "hermes/templates/logstash-etc-configmap.yaml" . | sha256sum }}
         kubectl.kubernetes.io/default-container: "logstash"
         {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
         linkerd.io/inject: enabled
@@ -34,6 +33,10 @@ spec:
         - name: hermes-etc
           configMap:
             name: logstash-etc
+        - name: logstash-conf
+          secret:
+            secretName: logstash-secret
+            defaultMode: 420
       containers:
         - name: logstash
           image: {{.Values.global.registry}}/hermes-logstash:{{.Values.hermes_image_version_logstash}}
@@ -56,13 +59,6 @@ spec:
                   fieldPath: metadata.namespace
             - name: LS_JAVA_OPTS
               value: {{.Values.logstash.javaopts}}
-            {{ if .Values.logstash.audit -}}
-            - name: METIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: logstash-secret
-                  key: METIS_PASSWORD
-            {{- end}}
             - name: CONFIG_HASH
               valueFrom:
                 fieldRef:
@@ -70,6 +66,10 @@ spec:
           volumeMounts:
             - name: hermes-etc
               mountPath: /hermes-etc
+            - name: logstash-conf
+              mountPath: "/hermes-etc/logstash.conf"
+              subPath: logstash.conf
+              readOnly: true
           livenessProbe:
             httpGet:
               path: /

--- a/openstack/hermes/templates/logstash-etc-configmap.yaml
+++ b/openstack/hermes/templates/logstash-etc-configmap.yaml
@@ -14,8 +14,6 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation
 
 data:
-  logstash.conf: |
-{{ include "hermes/templates/etc/_logstash.conf.tpl" . | indent 4 }}
   audit.json: |
 {{ include "hermes/templates/etc/_audit.json.tpl" . | indent 4 }}
   logstash.yml: |

--- a/openstack/hermes/templates/logstash-secret.yaml
+++ b/openstack/hermes/templates/logstash-secret.yaml
@@ -1,4 +1,3 @@
-{{ if .Values.logstash.audit -}}
 kind: Secret
 apiVersion: v1
 metadata:
@@ -8,6 +7,4 @@ metadata:
     system: openstack
     service: audit
 data:
-  # If a region is not configured, default value
-  METIS_PASSWORD: {{ .Values.global.metis.password | default "default" | b64enc }}
-{{- end}}
+  logstash.conf: {{ include (print .Template.BasePath  "/etc/_logstash.conf.tpl") . | b64enc }}


### PR DESCRIPTION
Because of all the rabbitmq inputs, I have moved the logstash.conf to the secrets. Removed old env variables and this file is mounted next to the other logstash configs in the same directory. 