### PR TITLE
[Cinder] Update mysql metric chart

### DIFF
--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 0.8.0
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.2.7
+  version: 0.3.2
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:8ab0cb0e2dc624291e420d5719179c081d0f0f64cc664b50fec893b2d24c1b8c
-generated: "2024-03-20T09:56:27.640022342+01:00"
+digest: sha256:7e8d047a154395b2fdaa9afd48a1733b9ae18bc9689ef6c849fc6d0367119027
+generated: "2024-03-21T10:20:10.490811-04:00"

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
     condition: mariadb.enabled
   - name: mysql_metrics
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.2.7
+    version: 0.3.2
     condition: mariadb.enabled
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap


### PR DESCRIPTION
This patch updates the cinder chart for mysql metric to 0.3.2 for linkerd support