### PR TITLE
Revert "[ironic] harmonize ironic service user/password"

### DIFF
--- a/openstack/ironic/ci/test-values.yaml
+++ b/openstack/ironic/ci/test-values.yaml
@@ -2,6 +2,7 @@ global:
   master_password: topSecret
   dbPassword: secret
   ipmi_exporter_user_passwd: topSecret
+  ironic_service_password: topSecret
   ironicServicePassword: topSecret
   domain_seeds:
     skip_hcm_domain: false

--- a/openstack/ironic/templates/seed.yaml
+++ b/openstack/ironic/templates/seed.yaml
@@ -671,7 +671,7 @@ spec:
     users:
     - name: {{ .Values.global.ironicServiceUser }}{{ .Values.global.user_suffix | default "" }}
       description: Ironic Service
-      password: {{ required ".Values.global.ironicServicePassword is missing" .Values.global.ironicServicePassword | quote }}
+      password: {{ required ".Values.global.ironic_service_password is missing" .Values.global.ironic_service_password | quote }}
       role_assignments:
       - project: service
         role: service

--- a/openstack/neutron/templates/etc/_ironic_neutron_agent.ini.tpl
+++ b/openstack/neutron/templates/etc/_ironic_neutron_agent.ini.tpl
@@ -10,6 +10,6 @@ auth_url = {{.Values.global.keystone_api_endpoint_protocol_internal | default "h
 project_name = {{ default "service" .Values.global.keystone_service_project }}
 project_domain_name = {{ default "Default" .Values.global.keystone_service_domain }}
 username = {{ $user }}
-password = {{ required ".Values.global.ironicServicePassword is missing" .Values.global.ironicServicePassword }}
+password = {{ required ".Values.global.ironic_service_password is missing" .Values.global.ironic_service_password }}
 user_domain_name = {{ default "Default" .Values.global.keystone_service_domain }}
 # api endpoint is found via keystone catalog

--- a/openstack/nova/templates/etc/_nova-compute-ironic.conf.tpl
+++ b/openstack/nova/templates/etc/_nova-compute-ironic.conf.tpl
@@ -20,7 +20,7 @@ auth_url = {{.Values.global.keystone_api_endpoint_protocol_internal | default "h
 project_name = {{ default "service" .Values.global.keystone_service_project }}
 project_domain_name = {{ default "Default" .Values.global.keystone_service_domain }}
 username = {{ .Values.global.ironic_service_user | default "ironic" }}{{ .Values.global.user_suffix }}
-password = {{ required ".Values.global.ironicServicePassword is missing" .Values.global.ironicServicePassword }}
+password = {{ required ".Values.global.ironic_service_password is missing" .Values.global.ironic_service_password }}
 user_domain_name = {{ default "Default" .Values.global.keystone_service_domain }}
 # api endpoint is found via keystone catalog
 


### PR DESCRIPTION
Reverts sapcc/helm-charts#6200

This breaks Nova's helm-chart as the secrets are not in line with this change.