### PR TITLE
[Nova] Bump mysql_metrics chart for linkerd

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 0.8.0
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.2.7
+  version: 0.3.2
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.6.0
@@ -29,5 +29,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:15ec1fd24bd2cc23921187382c84bb9d72c485f31242c628dfd7d77d1f110392
-generated: "2024-03-13T14:37:43.347784721+01:00"
+digest: sha256:0279b43ec9e3cf0c1fc955ad30e65db7cbce59d95c0f2af1b14057db4906f4c1
+generated: "2024-03-25T10:01:09.260407107+01:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
   - name: mysql_metrics
     condition: mariadb.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.2.7
+    version: 0.3.2
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.6.0


### PR DESCRIPTION
We bump the chart to enable linkerd in it. With bumping the chart, we also move the config into a Secret and remove the prometheus annotations that would lead to double scraping with linkerd adding a second container.