### PR TITLE
cc3test: do not alert Limes when Keystone is down

### DIFF
--- a/openstack/cc3test/Chart.yaml
+++ b/openstack/cc3test/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: cc3test - for blackbox testing the CC+1
 name: cc3test
-version: 0.1.6
+version: 0.1.7
 dependencies:
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap

--- a/openstack/cc3test/alerts/ccloud-limes.alerts
+++ b/openstack/cc3test/alerts/ccloud-limes.alerts
@@ -2,8 +2,11 @@ groups:
 - name: cc3test-limes.alerts
   rules:
   - alert: CCloudLimesApiDown
+    # NOTE: Limes outages are not alerted when Keystone is also down,
+    # because then the Keystone outage is the actual problem and ringing
+    # support group "containers" will not help anything.
     expr: |
-        cc3test_status{service="limes", type="api"} == 0
+        max(cc3test_status{service="limes", type="api"} == 0) unless max(cc3test_status{service="keystone", type="api"} == 0)
     for: 16m
     labels:
       severity: critical


### PR DESCRIPTION
As discussed in Slack: https://convergedcloud.slack.com/archives/CE5NDBQDC/p1711359842260729