### PR TITLE
Disable linkerd for metadata agent

### DIFF
--- a/openstack/neutron/templates/statefulset-network-agent-apod.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent-apod.yaml
@@ -42,6 +42,7 @@ spec:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") $ | sha256sum }}
         configmap-etc-apod-hash: {{ include (print $.Template.BasePath "/configmap-etc-apod.yaml") $ | sha256sum }}
         {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 8 }}
+        config.linkerd.io/skip-inbound-ports: "53,80"
       labels:
         name: neutron-network-agent-{{ $apod }}
 {{ tuple $ "neutron" "agent" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}

--- a/openstack/neutron/templates/statefulset-network-agent.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent.yaml
@@ -42,6 +42,7 @@ spec:
         k8s.v1.cni.cncf.io/networks: '[{ "name": "cbr1-bridge", "interface":"{{$.Values.cp_network_interface}}" }]'
         configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") $ | sha256sum }}
         {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 8 }}
+        config.linkerd.io/skip-inbound-ports: "53,80"
       labels:
         name: neutron-network-agent-{{ $az }}
 {{ tuple $ "neutron" "agent" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}


### PR DESCRIPTION
 With metadata requests proxied through linkerd, metadata service does
 not work anymore. No packets are received on agent side. Temporarily we
 do not proxy those requests trough linkerd to make the service work
 again.
