### PR TITLE
[keystone] move configuration with credentials into own secrets

### DIFF
--- a/openstack/keystone/templates/bin/_bootstrap.tpl
+++ b/openstack/keystone/templates/bin/_bootstrap.tpl
@@ -2,7 +2,7 @@
 set -ex
 trap "{{ include "utils.proxysql.proxysql_signal_stop_script" . | trim }}" EXIT
 # seed just enough to have a functional v3 api
-keystone-manage --config-file=/etc/keystone/keystone.conf bootstrap \
+keystone-manage --config-file=/etc/keystone/keystone.conf --config-file=/etc/keystone/keystone.conf.d/secrets.conf bootstrap \
     --bootstrap-username {{ .Values.api.adminUser }} \
     --bootstrap-password {{ required "A valid .Values.api.adminPassword required!" .Values.api.adminPassword }} \
     --bootstrap-project-name {{ .Values.api.adminProjectName }} \

--- a/openstack/keystone/templates/bin/_db-sync.tpl
+++ b/openstack/keystone/templates/bin/_db-sync.tpl
@@ -2,12 +2,12 @@
 trap "{{ include "utils.proxysql.proxysql_signal_stop_script" . | trim }}" EXIT
 
 echo "Status before migration:"
-keystone-status --config-file=/etc/keystone/keystone.conf upgrade check
+keystone-status --config-file=/etc/keystone/keystone.conf --config-file=/etc/keystone/keystone.conf.d/secrets.conf upgrade check
 
 echo "DB Version before migration:"
-keystone-manage --config-file=/etc/keystone/keystone.conf db_version
+keystone-manage --config-file=/etc/keystone/keystone.conf --config-file=/etc/keystone/keystone.conf.d/secrets.conf db_version
 
-keystone-manage --config-file=/etc/keystone/keystone.conf db_sync --check
+keystone-manage --config-file=/etc/keystone/keystone.conf --config-file=/etc/keystone/keystone.conf.d/secrets.conf db_sync --check
 case $? in
     0)
         echo "No migration required. Database is up-2-date."
@@ -18,17 +18,17 @@ case $? in
     2)
         echo "Database update available - starting migrations"
         # expand the database schema
-        keystone-manage --config-file=/etc/keystone/keystone.conf db_sync --expand
+        keystone-manage --config-file=/etc/keystone/keystone.conf --config-file=/etc/keystone/keystone.conf.d/secrets.conf db_sync --expand
         ;&
     3)
         echo "Database expanded"
         # run migrate
-        keystone-manage --config-file=/etc/keystone/keystone.conf db_sync --migrate
+        keystone-manage --config-file=/etc/keystone/keystone.conf --config-file=/etc/keystone/keystone.conf.d/secrets.conf db_sync --migrate
         ;&
     4)
         echo "Database migrated"
         # run contraction
-        keystone-manage --config-file=/etc/keystone/keystone.conf db_sync --contract
+        keystone-manage --config-file=/etc/keystone/keystone.conf --config-file=/etc/keystone/keystone.conf.d/secrets.conf db_sync --contract
         ;;
     *)
         echo "Duno what state the database is in. grrrr"
@@ -36,10 +36,10 @@ case $? in
 esac
 
 echo "DB Version after migration:"
-keystone-manage --config-file=/etc/keystone/keystone.conf db_version
+keystone-manage --config-file=/etc/keystone/keystone.conf --config-file=/etc/keystone/keystone.conf.d/secrets.conf db_version
 
 echo "Keystone doctor:"
-keystone-manage --config-file=/etc/keystone/keystone.conf doctor
+keystone-manage --config-file=/etc/keystone/keystone.conf --config-file=/etc/keystone/keystone.conf.d/secrets.conf doctor
 
 # don't let the doctor break stuff (as usual not qualified enough and you allways need another opinion :P )
 exit 0

--- a/openstack/keystone/templates/bin/_repair_assignments.tpl
+++ b/openstack/keystone/templates/bin/_repair_assignments.tpl
@@ -4,4 +4,4 @@ export STDOUT=${STDOUT:-/proc/1/fd/1}
 export STDERR=${STDERR:-/proc/1/fd/2}
 
 # repair any role-assignments that point to orphaned objects (usually from users that have been deactivated by CAM)
-keystone-manage-extension --config-file=/etc/keystone/keystone.conf repair_assignments {{ if .Values.skipRepairRoleAssignments }} --dry-run {{ end }} > ${STDOUT} 2> ${STDERR}
+keystone-manage-extension --config-file=/etc/keystone/keystone.conf --config-file=/etc/keystone/keystone.conf.d/secrets.conf repair_assignments {{ if .Values.skipRepairRoleAssignments }} --dry-run {{ end }} > ${STDOUT} 2> ${STDERR}

--- a/openstack/keystone/templates/configmap-bin.yaml
+++ b/openstack/keystone/templates/configmap-bin.yaml
@@ -9,8 +9,6 @@ metadata:
     component: keystone
     type: config
 data:
-  bootstrap: |
-{{ include (print .Template.BasePath "/bin/_bootstrap.tpl") . | indent 4 }}
   cron: |
 {{ include (print .Template.BasePath "/bin/_cron.tpl") . | indent 4 }}
   db-sync: |

--- a/openstack/keystone/templates/deployment-api.yaml
+++ b/openstack/keystone/templates/deployment-api.yaml
@@ -250,8 +250,10 @@ spec:
             sources:
             - configMap:
                 name: keystone-bin
+                defaultMode: 0555
             - secret:
                 name: keystone-bin-secrets
+                defaultMode: 0555
                 items:
                   - key: bootstrap
                     path: bootstrap

--- a/openstack/keystone/templates/deployment-api.yaml
+++ b/openstack/keystone/templates/deployment-api.yaml
@@ -194,7 +194,6 @@ spec:
               readOnly: true
             - name: keystone-bin
               mountPath: /scripts
-              readOnly: true
             {{- if .Values.sapcc_rate_limit.enabled }}
             - name: keystone-etc
               mountPath: /etc/keystone/ratelimit.yaml
@@ -247,13 +246,12 @@ spec:
             defaultMode: 0444
         - name: keystone-bin
           projected:
+            defaultMode: 0555
             sources:
             - configMap:
                 name: keystone-bin
-                defaultMode: 0555
             - secret:
                 name: keystone-bin-secrets
-                defaultMode: 0555
                 items:
                   - key: bootstrap
                     path: bootstrap

--- a/openstack/keystone/templates/deployment-api.yaml
+++ b/openstack/keystone/templates/deployment-api.yaml
@@ -39,6 +39,8 @@ spec:
         chart-version: {{.Chart.Version}}
         configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") . | sha256sum }}
         configmap-bin-hash: {{ include (print $.Template.BasePath "/configmap-bin.yaml") . | sha256sum }}
+        secrets-bin-hash: {{ include (print $.Template.BasePath "/secret-bin.yaml") . | sha256sum }}
+        secrets-hash: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
         {{- if .Values.proxysql.mode }}
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
@@ -139,6 +141,8 @@ spec:
           volumeMounts:
             - name: etc-keystone
               mountPath: /etc/keystone
+            - name: keystone-etc-confd
+              mountPath: /etc/keystone/keystone.conf.d
             - name: wsgi-keystone
               mountPath: /var/www/cgi-bin/keystone
             - name: keystone-etc
@@ -237,10 +241,20 @@ spec:
           configMap:
             name: keystone-etc
             defaultMode: 0444
+        - name: keystone-etc-confd
+          secret:
+            secretName: {{ .Release.Name }}-secrets
+            defaultMode: 0444
         - name: keystone-bin
-          configMap:
-            name: keystone-bin
-            defaultMode: 0555
+          projected:
+            sources:
+            - configMap:
+                name: keystone-bin
+            - secret:
+                name: keystone-bin-secrets
+                items:
+                  - key: bootstrap
+                    path: bootstrap
         - name: fernet
           secret:
             secretName: keystone-fernet

--- a/openstack/keystone/templates/deployment-cron.yaml
+++ b/openstack/keystone/templates/deployment-cron.yaml
@@ -32,6 +32,8 @@ spec:
         chart-version: {{.Chart.Version}}
         configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") . | sha256sum }}
         configmap-bin-hash: {{ include (print $.Template.BasePath "/configmap-bin.yaml") . | sha256sum }}
+        secrets-bin-hash: {{ include (print $.Template.BasePath "/secret-bin.yaml") . | sha256sum }}
+        secrets-hash: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
         {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
 {{- if .Values.rbac.enabled }}
@@ -101,6 +103,8 @@ spec:
             - mountPath: /etc/keystone/keystone.conf
               subPath: keystone.conf
               name: keystone-etc
+            - mountPath: /etc/keystone/keystone.conf.d
+              name: keystone-etc-confd
             - mountPath: /etc/keystone/logging.conf
               subPath: logging.conf
               name: keystone-etc
@@ -123,9 +127,20 @@ spec:
         - name: keystone-etc
           configMap:
             name: keystone-etc
+        - name: keystone-etc-confd
+          secret:
+            secretName: {{ .Release.Name }}-secrets
+            defaultMode: 0444
         - name: keystone-bin
-          configMap:
-            name: keystone-bin
+          projected:
+            sources:
+            - configMap:
+                name: keystone-bin
+            - secret:
+                name: keystone-bin-secrets
+                items:
+                  - key: bootstrap
+                    path: bootstrap
         - name: fernet
           secret:
             secretName: keystone-fernet

--- a/openstack/keystone/templates/etc/_keystone.conf.tpl
+++ b/openstack/keystone/templates/etc/_keystone.conf.tpl
@@ -120,19 +120,6 @@ max_active_keys = {{ .Values.api.fernet.maxActiveKeys | default 3 }}
 rules_file = /etc/keystone/access_rules.json
 permissive = true
 
-[database]
-# Database connection string - MariaDB for regional setup
-# and Percona Cluster for inter-regional setup:
-{{ if .Values.percona_cluster.enabled -}}
-connection = {{ include "db_url_pxc" . }}
-{{- else if .Values.global.clusterDomain -}}
-connection = mysql+pymysql://{{ default .Release.Name .Values.global.dbUser }}:{{.Values.global.dbPassword }}@{{include "db_host" .}}/{{ default .Release.Name .Values.mariadb.name }}?charset=utf8
-{{- else if .Values.mariadb_galera.enabled -}}
-connection = mysql+pymysql://{{ .Values.mariadb_galera.mariadb.users.keystone.username }}:{{.Values.mariadb_galera.mariadb.users.keystone.password }}@{{include "db_host" .}}/{{ .Values.mariadb_galera.mariadb.galera.clustername }}?charset=utf8
-{{- else }}
-connection = {{ include "db_url_mysql" . }}
-{{- end }}
-
 [assignment]
 driver = sql
 
@@ -159,30 +146,6 @@ lockout_duration = 300
 unique_last_password_count = 5
 {{- if hasKey .Values "disable_user_account_days_inactive" }}
 disable_user_account_days_inactive = {{ .Values.disable_user_account_days_inactive }}
-{{- end }}
-
-{{- if not (and (hasKey $.Values "oslo_messaging_notifications") ($.Values.oslo_messaging_notifications.disabled)) }}
-[oslo_messaging_notifications]
-driver = messaging
-  {{- if and (.Values.audit.central_service.user) (.Values.audit.central_service.password) }}
-transport_url = rabbit://{{ .Values.audit.central_service.user }}:{{ .Values.audit.central_service.password | urlquery }}@{{ .Values.audit.central_service.host }}:{{ .Values.audit.central_service.port }}/
-
-[oslo_messaging_rabbit]
-rabbit_retry_interval = {{ .Values.audit.central_service.rabbit_retry_interval | default 1 }}
-kombu_reconnect_delay = {{ .Values.audit.central_service.kombu_reconnect_delay | default 0.1 }}
-rabbit_interval_max = {{ .Values.audit.central_service.rabbit_interval_max | default 1 }}
-rabbit_retry_backoff = {{ .Values.audit.central_service.rabbit_retry_backoff | default 0 }}
-heartbeat_timeout_threshold = {{ .Values.audit.central_service.heartbeat_timeout_threshold | default 0 }}
-{{/* The default values cause a one second delay
-      on the first try and a 0.1 second on all the other ones.
-      It is exploiting a bug in the logic which seems to be triggered
-      when rabbit_interval_max >= rabbit_retry_interval
-*/}}
-  {{- else if .Values.rabbitmq.host }}
-transport_url = rabbit://{{ .Values.rabbitmq.users.default.user | default "rabbitmq" }}:{{ .Values.rabbitmq.users.default.password }}@{{ .Values.rabbitmq.host }}:{{ .Values.rabbitmq.port | default 5672 }}
-  {{ else }}
-transport_url = rabbit://{{ .Values.rabbitmq.users.default.user | default "rabbitmq" }}:{{ .Values.rabbitmq.users.default.password }}@{{ include "rabbitmq_host" . }}:{{ .Values.rabbitmq.port | default 5672 }}
-  {{- end }}
 {{- end }}
 
 [oslo_middleware]
@@ -233,8 +196,4 @@ allowed_origin = {{ .Values.cors.allowed_origin | default "*"}}
 allow_credentials = true
 expose_headers = Content-Type,Cache-Control,Content-Language,Expires,Last-Modified,Pragma,X-Auth-Token,X-Openstack-Request-Id,X-Subject-Token
 allow_headers = Content-Type,Cache-Control,Content-Language,Expires,Last-Modified,Pragma,X-Auth-Token,X-Openstack-Request-Id,X-Subject-Token,X-Project-Id,X-Project-Name,X-Project-Domain-Id,X-Project-Domain-Name,X-Domain-Id,X-Domain-Name,X-User-Id,X-User-Name,X-User-Domain-name
-{{- end }}
-
-{{- if .Values.osprofiler.enabled }}
-{{- include "osprofiler" . }}
 {{- end }}

--- a/openstack/keystone/templates/etc/_secrets.conf.tpl
+++ b/openstack/keystone/templates/etc/_secrets.conf.tpl
@@ -1,0 +1,40 @@
+[database]
+# Database connection string - MariaDB for regional setup
+# and Percona Cluster for inter-regional setup:
+{{ if .Values.percona_cluster.enabled -}}
+connection = {{ include "db_url_pxc" . }}
+{{- else if .Values.global.clusterDomain -}}
+connection = mysql+pymysql://{{ default .Release.Name .Values.global.dbUser }}:{{.Values.global.dbPassword }}@{{include "db_host" .}}/{{ default .Release.Name .Values.mariadb.name }}?charset=utf8
+{{- else if .Values.mariadb_galera.enabled -}}
+connection = mysql+pymysql://{{ .Values.mariadb_galera.mariadb.users.keystone.username }}:{{.Values.mariadb_galera.mariadb.users.keystone.password }}@{{include "db_host" .}}/{{ .Values.mariadb_galera.mariadb.galera.clustername }}?charset=utf8
+{{- else }}
+connection = {{ include "db_url_mysql" . }}
+{{- end }}
+
+{{- if not (and (hasKey $.Values "oslo_messaging_notifications") ($.Values.oslo_messaging_notifications.disabled)) }}
+[oslo_messaging_notifications]
+driver = messaging
+  {{- if and (.Values.audit.central_service.user) (.Values.audit.central_service.password) }}
+transport_url = rabbit://{{ .Values.audit.central_service.user }}:{{ .Values.audit.central_service.password }}@{{ .Values.audit.central_service.host }}:{{ .Values.audit.central_service.port }}/
+
+[oslo_messaging_rabbit]
+rabbit_retry_interval = {{ .Values.audit.central_service.rabbit_retry_interval | default 1 }}
+kombu_reconnect_delay = {{ .Values.audit.central_service.kombu_reconnect_delay | default 0.1 }}
+rabbit_interval_max = {{ .Values.audit.central_service.rabbit_interval_max | default 1 }}
+rabbit_retry_backoff = {{ .Values.audit.central_service.rabbit_retry_backoff | default 0 }}
+heartbeat_timeout_threshold = {{ .Values.audit.central_service.heartbeat_timeout_threshold | default 0 }}
+{{/* The default values cause a one second delay
+      on the first try and a 0.1 second on all the other ones.
+      It is exploiting a bug in the logic which seems to be triggered
+      when rabbit_interval_max >= rabbit_retry_interval
+*/}}
+  {{- else if .Values.rabbitmq.host }}
+transport_url = rabbit://{{ .Values.rabbitmq.users.default.user | default "rabbitmq" }}:{{ .Values.rabbitmq.users.default.password }}@{{ .Values.rabbitmq.host }}:{{ .Values.rabbitmq.port | default 5672 }}
+  {{ else }}
+transport_url = rabbit://{{ .Values.rabbitmq.users.default.user | default "rabbitmq" }}:{{ .Values.rabbitmq.users.default.password }}@{{ include "rabbitmq_host" . }}:{{ .Values.rabbitmq.port | default 5672 }}
+  {{- end }}
+{{- end }}
+
+{{- if .Values.osprofiler.enabled }}
+{{- include "osprofiler" . }}
+{{- end }}

--- a/openstack/keystone/templates/job-bootstrap.yaml
+++ b/openstack/keystone/templates/job-bootstrap.yaml
@@ -26,6 +26,8 @@ spec:
         chart-version: {{.Chart.Version}}
         configmap-bin-hash: {{ include (print $.Template.BasePath "/configmap-bin.yaml") . | sha256sum }}
         configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") . | sha256sum }}
+        secrets-bin-hash: {{ include (print $.Template.BasePath "/secret-bin.yaml") . | sha256sum }}
+        secrets-hash: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
         # only run once on initial install
         "helm.sh/hook": post-install
     spec:
@@ -71,6 +73,8 @@ spec:
               mountPath: /etc/keystone/keystone.conf
               subPath: keystone.conf
               readOnly: true
+            - name: keystone-etc-confd
+              mountPath: /etc/keystone/keystone.conf.d
 {{- if ne .Values.api.policy "json" }}
             - name: keystone-etc
               mountPath: /etc/keystone/policy.yaml
@@ -105,10 +109,20 @@ spec:
           configMap:
             name: keystone-etc
             defaultMode: 0444
+        - name: keystone-etc-confd
+          secret:
+            secretName: {{ .Release.Name }}-secrets
+            defaultMode: 0444
         - name: keystone-bin
-          configMap:
-            name: keystone-bin
-            defaultMode: 0555
+          projected:
+            sources:
+            - configMap:
+                name: keystone-bin
+            - secret:
+                name: keystone-bin-secrets
+                items:
+                  - key: bootstrap
+                    path: bootstrap
         - name: fernet
           secret:
             secretName: keystone-fernet

--- a/openstack/keystone/templates/job-migration.yaml
+++ b/openstack/keystone/templates/job-migration.yaml
@@ -71,6 +71,8 @@ spec:
               mountPath: /etc/keystone/keystone.conf
               subPath: keystone.conf
               readOnly: true
+            - name: keystone-etc-confd
+              mountPath: /etc/keystone/keystone.conf.d
 {{- if ne .Values.api.policy "json" }}
             - name: keystone-etc
               mountPath: /etc/keystone/policy.yaml
@@ -105,10 +107,20 @@ spec:
           configMap:
             name: keystone-etc
             defaultMode: 0444
+        - name: keystone-etc-confd
+          secret:
+            secretName: {{ .Release.Name }}-secrets
+            defaultMode: 0444
         - name: keystone-bin
-          configMap:
-            name: keystone-bin
-            defaultMode: 0555
+          projected:
+            sources:
+            - configMap:
+                name: keystone-bin
+            - secret:
+                name: keystone-bin-secrets
+                items:
+                  - key: bootstrap
+                    path: bootstrap
         - name: fernet
           secret:
             secretName: keystone-fernet

--- a/openstack/keystone/templates/secret-bin.yaml
+++ b/openstack/keystone/templates/secret-bin.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keystone-bin-secrets
+  labels:
+    app: {{ template "fullname" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    component: keystone
+    type: config
+type: Opaque
+data:
+  bootstrap: |
+    {{ include (print .Template.BasePath "/bin/_bootstrap.tpl") . | b64enc | indent 4 }}

--- a/openstack/keystone/templates/secrets.yaml
+++ b/openstack/keystone/templates/secrets.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-secrets
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    component: keystone
+    type: config
+type: Opaque
+data: 
+  secrets.conf: |
+    {{ include (print .Template.BasePath "/etc/_secrets.conf.tpl") . | b64enc | indent 4 }}


### PR DESCRIPTION
- Secrets config will be projected into /etc/keystone/keystone.conf.d/
- Urlquery cannot be used in templates, should be used in vault references
- Has to be tested