### PR TITLE
[Nova] Fix ironic pods not having cell config

### DIFF
--- a/openstack/nova/templates/hypervisors/_ironic-deployment.yaml.tpl
+++ b/openstack/nova/templates/hypervisors/_ironic-deployment.yaml.tpl
@@ -116,6 +116,8 @@ spec:
           - secret:
               name: nova-etc
               items:
+              - key: cell1.conf
+                path: nova.conf.d/cell1-secrets.conf
               - key: keystoneauth-secrets.conf
                 path: nova.conf.d/keystoneauth-secrets.conf
       - name: nova-patches


### PR DESCRIPTION
When moving secrets into Secrets we missed to add cell-specific config to nova-compute-ironic pods. This lead to the driver not starting up because it couldn't reach rabbitmq.