### PR TITLE
[Nova] Add back nova_audit_map.yaml to nova-api-metadata

### DIFF
--- a/openstack/nova/templates/api-metadata-deployment.yaml
+++ b/openstack/nova/templates/api-metadata-deployment.yaml
@@ -140,6 +140,10 @@ spec:
               - key:  api_uwsgi.ini
                 path: api_uwsgi.ini
               {{- end }}
+              {{- if .Values.audit.enabled }}
+              - key:  nova_audit_map.yaml
+                path: nova_audit_map.yaml
+              {{- end }}
               {{- if .Values.watcher.enabled }}
               - key:  watcher.yaml
                 path: watcher.yaml


### PR DESCRIPTION
`nova-api-metadata` uses the same `api-paste.ini` as `nova-api` and thus requires the `nova_audit_map.yaml` file to be present.

In theory, we do not need a lot of the stuff in `api-paste.ini` for `nova-api-metadata` as the latter isn't really customer-facing. This could be changed in a follow-up. For now, we want things to work again.