### PR TITLE
nova/flavors: Use fewest-possible sockets for 64vcpu+

### DIFF
--- a/openstack/sap-seeds/templates/flavor-seed.yaml
+++ b/openstack/sap-seeds/templates/flavor-seed.yaml
@@ -204,6 +204,7 @@ spec:
     is_public: false
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
   - name: "m_c4_m64"
     id: "100"
     vcpus: 4
@@ -392,6 +393,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
   - name: "g_c64_m256"
     id: "220"
     vcpus: 64
@@ -400,6 +402,7 @@ spec:
     is_public: true
     extra_specs:
       "catalog:alias": "m5.16xlarge"
+      "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c48_m512"
     id: "221"
@@ -418,6 +421,7 @@ spec:
     extra_specs:
       "catalog:alias": "m5.32xlarge"
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
   - name: "m5.48xlarge"
     id: "231"
     vcpus: 96
@@ -426,6 +430,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
   - name: "m_c128_m1000"
     id: "240"
     vcpus: 128
@@ -435,6 +440,7 @@ spec:
     extra_specs:
       "catalog:alias": "m5.64xlarge"
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
 
   ### HANA flavors
 {{- if .Values.use_hana_exclusive }}
@@ -461,5 +467,6 @@ spec:
     is_public: false
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
 
 {{ include (print .Template.BasePath "/_flavors_deleted.tpl") . | indent 2 }}


### PR DESCRIPTION
Windows images have a socket limitation of 64, as hinted here:
https://learn.microsoft.com/en-us/archive/msdn-technet-forums/56adf991-952e-4337-8159-d632499db22b

Also, non-server windows images have even lower limits (2 or 4 sockets).

For all regular flavors with 64 vCPUS and more, set the cores-per-socket value to the vCPU/socket value of our (Cascade-Lake) hardware.
