### PR TITLE
[nova][mariadb][rabbitmq][utils] bump up mariadb,rabbitmq, utils for nova

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 0.1.5
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.14.6
+  version: 0.15.0
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.9.2
@@ -29,5 +29,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:fe65ff861267b245a17a60dd429febd6a68b18bb248bbaf4c43d8f52b32b7f6c
-generated: "2024-04-02T14:31:31.713073+02:00"
+digest: sha256:a21bda68ca1afcd02cc6e84ec716c98ed2c2e67644520e1ba889c36f4d9aed03
+generated: "2024-04-02T14:32:53.052019+02:00"

--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 0.3.2
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.6.0
+  version: 0.6.9
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.1.5
@@ -22,12 +22,12 @@ dependencies:
   version: 0.9.2
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.6.0
+  version: 0.6.9
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:ff034eef75cb10716cbb697c263d502d8fc635ae1a6d08c1543b1480313633ad
-generated: "2024-04-02T14:28:52.495966+02:00"
+digest: sha256:fe65ff861267b245a17a60dd429febd6a68b18bb248bbaf4c43d8f52b32b7f6c
+generated: "2024-04-02T14:31:31.713073+02:00"

--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.8.0
+  version: 0.9.2
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.8.0
+  version: 0.9.2
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.3.2
@@ -19,7 +19,7 @@ dependencies:
   version: 0.14.6
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.8.0
+  version: 0.9.2
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.6.0
@@ -29,5 +29,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:0279b43ec9e3cf0c1fc955ad30e65db7cbce59d95c0f2af1b14057db4906f4c1
-generated: "2024-03-25T10:01:09.260407107+01:00"
+digest: sha256:ff034eef75cb10716cbb697c263d502d8fc635ae1a6d08c1543b1480313633ad
+generated: "2024-04-02T14:28:52.495966+02:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -20,7 +20,7 @@ dependencies:
     version: 0.3.2
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.6.0
+    version: 0.6.9
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.1.5
@@ -36,7 +36,7 @@ dependencies:
     alias: rabbitmq_cell2
     condition: cell2.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.6.0
+    version: 0.6.9
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     version: 0.1.5
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.14.6
+    version: ~0.15.0
   - name: mariadb
     alias: mariadb_cell2
     condition: mariadb_cell2.enabled

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -8,12 +8,12 @@ dependencies:
   - name: mariadb
     condition: mariadb.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.8.0
+    version: 0.9.2
   - name: mariadb
     alias: mariadb_api
     condition: mariadb_api.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.8.0
+    version: 0.9.2
   - name: mysql_metrics
     condition: mariadb.enabled
     repository: https://charts.eu-de-2.cloud.sap
@@ -31,7 +31,7 @@ dependencies:
     alias: mariadb_cell2
     condition: mariadb_cell2.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.8.0
+    version: 0.9.2
   - name: rabbitmq
     alias: rabbitmq_cell2
     condition: cell2.enabled

--- a/openstack/nova/templates/proxysql-configmap.yaml
+++ b/openstack/nova/templates/proxysql-configmap.yaml
@@ -1,1 +1,0 @@
-{{- include "proxysql_configmap" . }}

--- a/openstack/nova/templates/proxysql-secret.yaml
+++ b/openstack/nova/templates/proxysql-secret.yaml
@@ -1,0 +1,1 @@
+{{- include "proxysql_secret" . }}

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -699,7 +699,7 @@ mariadb:
   buffer_pool_size: "4096M"
   log_file_size: "1024M"
   name: nova
-  initdb_configmap: true
+  initdb_secret: true
   long_query_time: 8
   vpa:
     set_main_container: true
@@ -739,7 +739,7 @@ mariadb_api:
   buffer_pool_size: "4096M"
   log_file_size: "1024M"
   name: nova-api
-  initdb_configmap: true
+  initdb_secret: true
   long_query_time: 8
   vpa:
     set_main_container: true
@@ -772,7 +772,7 @@ mariadb_cell2:
   enabled: false
   buffer_pool_size: "4096M"
   log_file_size: "1024M"
-  initdb_configmap: true
+  initdb_secret: true
   long_query_time: 8
   vpa:
     set_main_container: true

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -801,6 +801,8 @@ rabbitmq_cell2:
     enabled: true
     sidecar:
       enabled: false
+    enableDetailedMetrics: true
+    enablePerObjectMetrics: true
 audit:
   central_service:
     user: rabbitmq
@@ -824,6 +826,8 @@ rabbitmq:
     enabled: true
     sidecar:
       enabled: false
+    enableDetailedMetrics: true
+    enablePerObjectMetrics: true
   resources:
     requests:
       memory: 2Gi


### PR DESCRIPTION
- bump up subcharts :
-- rabbitmq to version 0.6.9 (rabbitmq version 3.13.0) 
-- mariadb to version 0.9.2
-- utils to version 0.15.0
- switch to set the new mariadb values initdb_secret instead of initdb_configmaps 
- replace proxysql config map with proxysql secret
- activate detailed metrics