### PR TITLE
[nova] nova-compute-ironic to use the `nova` service user

### DIFF
--- a/openstack/nova/templates/etc-secret.yaml
+++ b/openstack/nova/templates/etc-secret.yaml
@@ -48,8 +48,8 @@ stringData:
     password = {{ required ".Values.global.nova_service_password is missing" .Values.global.nova_service_password | include "resolve_secret" }}
 
     [ironic]
-    username = ironic
-    password = {{ required ".Values.global.ironic_service_password is missing" .Values.global.ironic_service_password | include "resolve_secret" }}
+    username = nova
+    password = {{ required ".Values.global.nova_service_password is missing" .Values.global.nova_service_password | include "resolve_secret" }}
   nova-api-metadata-secrets.conf: |
     [neutron]
     metadata_proxy_shared_secret = {{ .Values.global.nova_metadata_secret | include "resolve_secret" }}


### PR DESCRIPTION
nova-compute-ironic uses the ironic service user when talking to the Ironic API. Since this user is also used by Ironic itself, it's harder to coordinate password changes
(both Nova and Ironic need the new password at the same time). Additionally, it's not clear that Nova is talking to Ironic if the user is ironic.