### PR TITLE
[nova] set hana_detection_strategy for bigvm-enabled regions

### DIFF
--- a/openstack/nova/templates/etc/_nova-scheduler.conf.tpl
+++ b/openstack/nova/templates/etc/_nova-scheduler.conf.tpl
@@ -19,6 +19,9 @@ bigvm_host_size_filter_uses_flavor_extra_specs = true
 bigvm_host_size_filter_host_fractions = full:1,half:0.5,two_thirds:0.71
 vm_size_threshold_vm_size_mb = {{ .Values.scheduler.vm_size_threshold_vm_size_mb }}
 vm_size_threshold_hv_size_mb = {{ .Values.scheduler.vm_size_threshold_hv_size_mb }}
+{{- if .Values.nova_bigvm_enabled }}
+hana_detection_strategy = memory_mb
+{{- end }}
 
 cpu_weight_multiplier = {{ .Values.scheduler.cpu_weight_multiplier }}
 ram_weight_multiplier = {{ .Values.scheduler.ram_weight_multiplier }}


### PR DESCRIPTION
For regions where nova_bigvm_enabled = true, HANA flavors should be identified by looking at the flavor.memory_mb instead of the trait:CUSTOM_HANA_EXCLUSIVE_HOST extra spec.