### PR TITLE
Revert "hermes: upgrade rabbitmq chart"

### DIFF
--- a/openstack/hermes/Chart.lock
+++ b/openstack/hermes/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 0.1.3
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.6.9
+  version: 0.6.2
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
-digest: sha256:bdcdc0e032b7bd05b0dea10f3a92ab98271a6b9ea349f62dd13e040b154d7917
-generated: "2024-03-27T10:22:21.543401-07:00"
+digest: sha256:e1616b95ba81f4605a303a23871c540144e4ebd75d90910032099ecca8cc07a6
+generated: "2024-01-31T11:19:50.39058-07:00"

--- a/openstack/hermes/Chart.yaml
+++ b/openstack/hermes/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
     condition: audit.enabled
     name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.6.9
+    version: 0.6.2
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0


### PR DESCRIPTION
Reverts sapcc/helm-charts#6245 - Have to run rabbitmqctl enable_feature_flag stream_single_active_consumer before upgrade