### PR TITLE
[utils] remove urlquery from templates and helper scripts

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.15.0
+version: 0.16.0

--- a/openstack/utils/templates/_hosts.tpl
+++ b/openstack/utils/templates/_hosts.tpl
@@ -28,12 +28,12 @@ postgresql+psycopg2://{{$user}}:{{$password | urlquery}}@{{.Chart.Name}}-postgre
             {{- $user := get .Values.mariadb.users $db | required (printf ".Values.mariadb.%v.name & .password are required (key comes from first database in .Values.mariadb.databases)" $db) }}
             {{- $user.name | required (printf ".Values.mariadb.%v.name is required!" $db ) }}:{{ $user.password | required (printf ".Values.mariadb.%v.password is required!" $db ) }}
         {{- else }}
-            {{- coalesce .Values.dbUser .Values.global.dbUser "root" }}:{{ coalesce .Values.dbPassword .Values.global.dbPassword .Values.mariadb.root_password | required ".Values.mariadb.root_password is required!" | urlquery }}
+            {{- coalesce .Values.dbUser .Values.global.dbUser "root" }}:{{ coalesce .Values.dbPassword .Values.global.dbPassword .Values.mariadb.root_password | required ".Values.mariadb.root_password is required!" }}
         {{- end }}
     {{- else }}
         {{- $user := index . 2 }}
         {{- $password := index . 3 }}
-        {{- $user }}:{{ $password | urlquery }}
+        {{- $user }}:{{ $password }}
     {{- end }}
 {{- end }}
 
@@ -187,7 +187,7 @@ mysql+pymysql://{{ include "db_credentials" . }}@
     {{- $host := index . 0 }}
     {{- $user := index . 1 }}
     {{- $password := index . 2 -}}
-https://{{ $user }}:{{ $password | urlquery }}@{{ $host }}
+https://{{ $user }}:{{ $password }}@{{ $host }}
 {{- end }}
 
 {{- define "utils.bigip_url" }}

--- a/openstack/utils/templates/_ini_sections.tpl
+++ b/openstack/utils/templates/_ini_sections.tpl
@@ -49,10 +49,10 @@ enabled = true
 # topics = notifications
 driver = messagingv2
             {{- if .Values.audit.central_service }}
-transport_url = rabbit://{{ .Values.audit.central_service.user | required "Please set audit.central_service.user" }}:{{ .Values.audit.central_service.password | required "Please set audit.central_service.password" | urlquery }}@{{ .Values.audit.central_service.host | default "hermes-rabbitmq-notifications.hermes" }}:{{.Values.audit.central_service.port | default 5672 }}/
+transport_url = rabbit://{{ .Values.audit.central_service.user | required "Please set audit.central_service.user" }}:{{ .Values.audit.central_service.password | required "Please set audit.central_service.password" }}@{{ .Values.audit.central_service.host | default "hermes-rabbitmq-notifications.hermes" }}:{{.Values.audit.central_service.port | default 5672 }}/
             {{- else if .Values.rabbitmq_notifications }}
                 {{- if and .Values.rabbitmq_notifications.ports .Values.rabbitmq_notifications.users }}
-transport_url = rabbit://{{ .Values.rabbitmq_notifications.users.default.user }}:{{ required ".Values.rabbitmq_notifications.users.default.password missing" .Values.rabbitmq_notifications.users.default.password | urlquery }}@{{ .Chart.Name }}-rabbitmq-notifications:{{ .Values.rabbitmq_notifications.ports.public }}/
+transport_url = rabbit://{{ .Values.rabbitmq_notifications.users.default.user }}:{{ required ".Values.rabbitmq_notifications.users.default.password missing" .Values.rabbitmq_notifications.users.default.password }}@{{ .Chart.Name }}-rabbitmq-notifications:{{ .Values.rabbitmq_notifications.ports.public }}/
                 {{- end }}
             {{- end }}
 mem_queue_size = {{ .Values.audit.mem_queue_size }}


### PR DESCRIPTION
- because it is not compatible with the "new" secrets-injector
- urlquery will have to be applied to individual secrets inside vault references
- also bump chart