### PR TITLE
[rabbitmq][rabbitmq_cluster] remove urlquery from herlper templates

### DIFF
--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 0.6.10
+version: 0.6.11
 description: A Helm chart for RabbitMQ
 sources:
 - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/templates/_helpers.tpl
+++ b/common/rabbitmq/templates/_helpers.tpl
@@ -22,7 +22,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "rabbitmq._transport_url" -}}
 {{- $envAll := index . 0 -}}
 {{- $rabbitmq := index . 1 -}}
-rabbit://{{ default "" $envAll.Values.global.user_suffix | print $rabbitmq.users.default.user }}:{{ required "$rabbitmq.users.default.password missing" $rabbitmq.users.default.password | urlquery}}@{{ include "rabbitmq.release_host" $envAll }}:{{ $rabbitmq.port | default 5672 }}{{ $rabbitmq.virtual_host | default "/" }}
+rabbit://{{ default "" $envAll.Values.global.user_suffix | print $rabbitmq.users.default.user }}:{{ required "$rabbitmq.users.default.password missing" $rabbitmq.users.default.password }}@{{ include "rabbitmq.release_host" $envAll }}:{{ $rabbitmq.port | default 5672 }}{{ $rabbitmq.virtual_host | default "/" }}
 {{- end}}
 
 {{- define "rabbitmq.shell_quote" -}}

--- a/common/rabbitmq_cluster/Chart.yaml
+++ b/common/rabbitmq_cluster/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq_cluster
-version: 0.1.9
+version: 0.1.10
 description: A Helm chart for RabbitMQ managed with a help of operators
 sources:
 - https://www.rabbitmq.com/kubernetes/operator/operator-overview.html

--- a/common/rabbitmq_cluster/templates/_helpers.tpl
+++ b/common/rabbitmq_cluster/templates/_helpers.tpl
@@ -22,7 +22,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "rabbitmq._transport_url" -}}
 {{- $envAll := index . 0 -}}
 {{- $rabbitmq := index . 1 -}}
-rabbit://{{ default "" $envAll.Values.global.user_suffix | print $rabbitmq.users.default.user }}:{{ required "$rabbitmq.users.default.password missing" $rabbitmq.users.default.password | urlquery}}@{{ include "rabbitmq.release_host" $envAll }}:{{ $rabbitmq.port | default 5672 }}{{ $rabbitmq.virtual_host | default "/" }}
+rabbit://{{ default "" $envAll.Values.global.user_suffix | print $rabbitmq.users.default.user }}:{{ required "$rabbitmq.users.default.password missing" $rabbitmq.users.default.password }}@{{ include "rabbitmq.release_host" $envAll }}:{{ $rabbitmq.port | default 5672 }}{{ $rabbitmq.virtual_host | default "/" }}
 {{- end}}
 
 {{- define "rabbitmq.shell_quote" -}}


### PR DESCRIPTION
- because it is not compatible with the "new" secrets-injector
- urlquery will have to be applied to individual secrets inside vault references
- also bump charts