### PR TITLE
[neutron] Bump mysql_metrics chart for linkerd

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 0.2.0
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.2.7
+  version: 0.3.2
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.6.0
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:29b33b5ba87bbcde84df9031cad576338098368be2391209e781b3f5182add1e
-generated: "2024-03-14T12:52:39.617075551+01:00"
+digest: sha256:9621bb1185c05cc0e5947a67f9e86cfbbdf876b7088dd4e191b2a8f75af8c1c1
+generated: "2024-03-28T16:14:17.068820855+01:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mysql_metrics
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.2.7
+    version: 0.3.2
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.6.0


### PR DESCRIPTION
Bumping mysql_metrics chart for linkerd support 
Chart bump includes:
* mysql_metrics config moving to secret
* If the port is named 'metrics' the port annotation is not needed
    and would only lead to all containers being scraped.
    But we e.g. don't want this for the recently added linkerd container.