### PR TITLE
[nova] seed roles required by nova-compute-ironic

### DIFF
--- a/openstack/nova/templates/seed.yaml
+++ b/openstack/nova/templates/seed.yaml
@@ -31,6 +31,8 @@ spec:
   - name: cloud_baremetal_admin
   - name: objectstore_admin
   - name: cloud_dns_admin
+  - name: cloud_image_admin
+  - name: cloud_objectstore_admin
 
   services:
   - name: nova
@@ -87,6 +89,10 @@ spec:
         role: cloud_volume_admin
       - project: service
         role: cloud_dns_admin
+      - project: service
+        role: cloud_image_admin
+      - project: service
+        role: cloud_objectstore_admin
     groups:
     - name: administrators
       role_assignments:


### PR DESCRIPTION
For switching nova-compute-ironic to use the `nova` user instead of the `ironic` user, there are 2 more role assignments which are missing from the `nova` user:

* cloud_image_admin
* cloud_objectstore_admin