### PR TITLE
[mariadb] add helmhooks to fix upgrade order

### DIFF
--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.9.1
+version: 0.9.2

--- a/common/mariadb/templates/backup-verify-deploy.yaml
+++ b/common/mariadb/templates/backup-verify-deploy.yaml
@@ -49,6 +49,6 @@ spec:
             readOnly: true
       volumes:
         - name: mariadb-backup-etc
-          configMap:
-            name:  mariadb-backup-{{.Values.name}}-etc
+          secret:
+            secretName:  mariadb-backup-{{.Values.name}}-etc
 {{- end }}

--- a/common/mariadb/templates/configuredb-configmap.yaml
+++ b/common/mariadb/templates/configuredb-configmap.yaml
@@ -9,6 +9,9 @@ metadata:
     system: openstack
     type: configuration
     component: database
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "2"
 data:
   configuredb.sh: |
 {{ include (print .Template.BasePath "/initdb/_configuredb.sh.tpl") . | indent 4 }}

--- a/common/mariadb/templates/pre-change-job.yaml
+++ b/common/mariadb/templates/pre-change-job.yaml
@@ -12,7 +12,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-upgrade,pre-rollback
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-weight": "3"
 {{- if and (and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested) $.Values.linkerd.mariadb.enabled }}
     linkerd.io/inject: enabled
 {{- end }}


### PR DESCRIPTION
add helm hooks to configurator script configmap to be sure that teh configmap is created and updated befor triggering the job.
upgrade order :
1. initdb_secret
2. configuredb_configmap
3. pre-chage-job 

adapt backup verify deployment to use secrets.
