### PR TITLE
[cinder][mariadb][rabbitmq][utils] Bump up mariadb,rabbitmq, utils for Cinder

### DIFF
--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.14.6
+  version: 0.15.0
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.9.2
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:5a0b8f3a1d4a40471d3cdd244dd20dddd3645e4678e3c01c7127cfda57906937
-generated: "2024-04-02T15:16:12.155109+02:00"
+digest: sha256:6f526f2f51ee371ed4d24e7e6f98fb69efdf351be41432c7f9508c2c914bf923
+generated: "2024-04-02T15:17:27.396265+02:00"

--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.14.6
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.8.0
+  version: 0.9.2
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.3.2
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:7e8d047a154395b2fdaa9afd48a1733b9ae18bc9689ef6c849fc6d0367119027
-generated: "2024-03-21T10:20:10.490811-04:00"
+digest: sha256:280e55d15d56b645e89a7b7985ba3f64fbeecef505c9048ce2fc223ec96066fb
+generated: "2024-04-02T15:15:04.456489+02:00"

--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 0.2.0
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.6.0
+  version: 0.6.10
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.3.5
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:280e55d15d56b645e89a7b7985ba3f64fbeecef505c9048ce2fc223ec96066fb
-generated: "2024-04-02T15:15:04.456489+02:00"
+digest: sha256:5a0b8f3a1d4a40471d3cdd244dd20dddd3645e4678e3c01c7127cfda57906937
+generated: "2024-04-02T15:16:12.155109+02:00"

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.1.2
 dependencies:
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.14.6
+    version: ~0.15.0
   - name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.9.2

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
     version: ~0.14.6
   - name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.8.0
+    version: 0.9.2
     condition: mariadb.enabled
   - name: mysql_metrics
     repository: https://charts.eu-de-2.cloud.sap

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -20,7 +20,7 @@ dependencies:
     version: 0.2.0
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.6.0
+    version: 0.6.10
   - name: redis
     alias: api-ratelimit-redis
     repository: https://charts.eu-de-2.cloud.sap

--- a/openstack/cinder/templates/proxysql-configmap.yaml
+++ b/openstack/cinder/templates/proxysql-configmap.yaml
@@ -1,1 +1,0 @@
-{{ include "proxysql_configmap" . }}

--- a/openstack/cinder/templates/proxysql-secret.yaml
+++ b/openstack/cinder/templates/proxysql-secret.yaml
@@ -1,0 +1,1 @@
+{{ include "proxysql_secret" . }}

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -324,6 +324,8 @@ rabbitmq:
     enabled: &metrics true
     sidecar:
       enabled: *metrics
+  enableDetailedMetrics: true
+  enablePerObjectMetrics: true 
 rabbitmq_notifications:
   name: cinder
 logging:

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -127,7 +127,7 @@ mariadb:
       password: null
       grants:
       - "ALL PRIVILEGES on cinder.*"
-  initdb_configmap: cinder-initdb
+  initdb_secret: true
   persistence_claim:
     name: db-cinder-pvclaim
   extraConfigFiles:


### PR DESCRIPTION
Bump up subcharts :
-- rabbitmq to version 0.6.10 (rabbitmq version 3.13.0)
-- mariadb to version 0.9.1
-- utils to version 0.15.0
Switch to set the new mariadb values initdb_secret instead of initdb_configmaps
Replace proxysql config map with proxysql secret
Activate detailed metrics