### PR TITLE
[Nova] Provide vCenter username and password via Secret

### DIFF
--- a/openstack/nova/templates/hypervisors/hypervisors-vmware-configmap-vct.yaml
+++ b/openstack/nova/templates/hypervisors/hypervisors-vmware-configmap-vct.yaml
@@ -48,13 +48,6 @@ template: |
       # integration_bridge = {= bridge | quote =}
       cache_prefix= "{= name | ini_escape =}-images"
       host_ip = {= host =}
-      {{- if .Values.compute.defaults.host_username | default "" }}
-      host_username = {{ .Values.compute.defaults.host_username }}
-      host_password = {= "{{ .Values.compute.defaults.host_username }}" | derive_password | quote =}
-      {{- else }}
-      host_username = {= username | quote =}
-      host_password = {= password | quote =}
-      {{- end }}
       cluster_name = {= cluster_name | quote =}
       {{- range $key, $value := .Values.compute.defaults.vmware }}
       {{ $key }} = {{ $value }}

--- a/openstack/nova/templates/hypervisors/hypervisors-vmware-deployment-vct.yaml
+++ b/openstack/nova/templates/hypervisors/hypervisors-vmware-deployment-vct.yaml
@@ -148,6 +148,11 @@ template: |
                   path: nova.conf.d/{= cell_name =}-secrets.conf
                 - key: keystoneauth-secrets.conf
                   path: nova.conf.d/keystoneauth-secrets.conf
+            - secret:
+                name: nova-compute-vmware-{= name =}
+                items:
+                - key: nova-compute-secrets.conf
+                  path: nova.conf.d/nova-compute-secrets.conf
         - name: sudoers
           projected:
             sources:

--- a/openstack/nova/templates/hypervisors/hypervisors-vmware-secret-vct.yaml
+++ b/openstack/nova/templates/hypervisors/hypervisors-vmware-secret-vct.yaml
@@ -1,0 +1,35 @@
+{{- if or (.Capabilities.APIVersions.Has "vcenter-operator.stable.sap.cc/v1") (.Values.isImageTransportTemplating | default false) }}
+apiVersion: vcenter-operator.stable.sap.cc/v1
+kind: VCenterTemplate
+metadata:
+  name: 'vcenter-cluster-nova-compute-secret'
+options:
+  scope: 'cluster'
+  jinja2_options:
+    variable_start_string: '{='
+    variable_end_string: '=}'
+template: |
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: nova-compute-vmware-{= name =}
+    labels:
+      system: openstack
+      type: configuration
+      component: nova
+      vcenter: {= host =}
+      datacenter: {= availability_zone =}
+      vccluster: {= cluster_name =}
+  data:
+    nova-compute-secrets.conf:{= " " =}
+      {%- filter b64enc %}
+      [vmware]
+      {{- if .Values.compute.defaults.host_username | default "" }}
+      host_username = {{ .Values.compute.defaults.host_username }}
+      host_password = {= "{{ .Values.compute.defaults.host_username }}" | derive_password | quote =}
+      {{- else }}
+      host_username = {= username | quote =}
+      host_password = {= password | quote =}
+      {{- end }}
+      {%- endfilter %}
+{{ end }}


### PR DESCRIPTION
Since we have to move out all passwords into Secret objects, the vcenter-operator-provided vCenter password needs to be moved out of the ConfigMap template and into a new Secret template.