### PR TITLE
[Nova] Fix moving vCenter secrets to Secret

### DIFF
--- a/openstack/nova/templates/hypervisors/hypervisors-vmware-secret-vct.yaml
+++ b/openstack/nova/templates/hypervisors/hypervisors-vmware-secret-vct.yaml
@@ -23,13 +23,13 @@ template: |
   data:
     nova-compute-secrets.conf:{= " " =}
       {%- filter b64enc %}
-      [vmware]
-      {{- if .Values.compute.defaults.host_username | default "" }}
-      host_username = {{ .Values.compute.defaults.host_username }}
-      host_password = {= "{{ .Values.compute.defaults.host_username }}" | derive_password | quote =}
-      {{- else }}
-      host_username = {= username | quote =}
-      host_password = {= password | quote =}
-      {{- end }}
+  [vmware]
+  {{- if .Values.compute.defaults.host_username | default "" }}
+  host_username = {{ .Values.compute.defaults.host_username }}
+  host_password = {= "{{ .Values.compute.defaults.host_username }}" | derive_password | quote =}
+  {{- else }}
+  host_username = {= username | quote =}
+  host_password = {= password | quote =}
+  {{- end }}
       {%- endfilter %}
 {{ end }}


### PR DESCRIPTION
The previous version contained the indentation also in the INI-style config file - which is not allowed in INIs. Therefore, we now have to make it a bit uglier by dedenting the content section.