### PR TITLE
[neutron][mariadb][rabbitmq][utils] bump up mariadb,rabbitmq, utils for neutron

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.8.0
+  version: 0.9.2
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:9621bb1185c05cc0e5947a67f9e86cfbbdf876b7088dd4e191b2a8f75af8c1c1
-generated: "2024-03-28T16:14:17.068820855+01:00"
+digest: sha256:fa376752c1d7d7e818b8284406673f22370fd40aac089cf5cbaa10cd5f7c809c
+generated: "2024-04-02T14:41:07.783736+02:00"

--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 0.6.10
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.14.6
+  version: 0.15.0
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:e7b5557e55c97297414a18e43469213397ca525e30f28c414818f5288e0deed5
-generated: "2024-04-02T14:43:21.491343+02:00"
+digest: sha256:0c4a76ebafac4166c2e2fafcdcd2251fae8d900c9e1536605184e3ec1b6b4a56
+generated: "2024-04-02T14:49:24.88364+02:00"

--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 0.3.2
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.6.0
+  version: 0.6.10
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.14.6
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:fa376752c1d7d7e818b8284406673f22370fd40aac089cf5cbaa10cd5f7c809c
-generated: "2024-04-02T14:41:07.783736+02:00"
+digest: sha256:e7b5557e55c97297414a18e43469213397ca525e30f28c414818f5288e0deed5
+generated: "2024-04-02T14:43:21.491343+02:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.8.0
+    version: 0.9.2
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -20,7 +20,7 @@ dependencies:
     version: 0.6.10
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.14.6
+    version: 0.15.0
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
     version: 0.3.2
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.6.0
+    version: 0.6.10
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.14.6

--- a/openstack/neutron/templates/proxysql-configmap.yaml
+++ b/openstack/neutron/templates/proxysql-configmap.yaml
@@ -1,1 +1,0 @@
-{{ include "proxysql_configmap" . }}

--- a/openstack/neutron/templates/proxysql-secret.yaml
+++ b/openstack/neutron/templates/proxysql-secret.yaml
@@ -1,0 +1,1 @@
+{{ include "proxysql_secret" . }}

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -371,7 +371,7 @@ mariadb:
   buffer_pool_size: "4096M"
   log_file_size: "1024M"
   name: neutron
-  initdb_configmap: neutron-initdb
+  initdb_secret: true
   vpa:
     set_main_container: true
   persistence_claim:


### PR DESCRIPTION
- bump up subcharts :
-- rabbitmq to version 0.6.10 (rabbitmq version 3.13.0)
-- mariadb to version 0.9.2
-- utils to version 0.15.0
- switch to set the new mariadb values initdb_secret instead of initdb_configmaps
- replace proxysql config map with proxysql secret
- update rabbitmq to 3.13.0-management