### PR TITLE
[Octavia][mariadb][rabbitmq][utils] bump up mariadb,rabbitmq, utils for Octavia

### DIFF
--- a/openstack/octavia/Chart.lock
+++ b/openstack/octavia/Chart.lock
@@ -13,12 +13,12 @@ dependencies:
   version: 0.6.9
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.14.3
+  version: 0.15.0
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.3
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.4
-digest: sha256:abd2c4b749d9fe23dd397637b11e95bc0bc7fae25b18c027c45c2cc46fdf92ae
-generated: "2024-04-02T16:37:16.09697+02:00"
+digest: sha256:c27a548ba19b1968c7799adb160ed826f4fdf8ce5c1b34dfa21050adb0ea38a9
+generated: "2024-04-02T16:42:36.011335+02:00"

--- a/openstack/octavia/Chart.lock
+++ b/openstack/octavia/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 0.2.8
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.6.4
+  version: 0.6.9
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.14.3
@@ -20,5 +20,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.4
-digest: sha256:770212b183f6760f38339662fba37b2cab82c79e475b6604bd1ed7486d56b67d
-generated: "2024-04-02T16:33:16.260234+02:00"
+digest: sha256:abd2c4b749d9fe23dd397637b11e95bc0bc7fae25b18c027c45c2cc46fdf92ae
+generated: "2024-04-02T16:37:16.09697+02:00"

--- a/openstack/octavia/Chart.lock
+++ b/openstack/octavia/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.8.0
+  version: 0.9.2
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
@@ -20,5 +20,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.4
-digest: sha256:d6b6574ccc7652ddff7c3be084849bab2d57bcb68eecb5c63401094b4401a1cf
-generated: "2024-04-02T15:47:59.681834997+02:00"
+digest: sha256:770212b183f6760f38339662fba37b2cab82c79e475b6604bd1ed7486d56b67d
+generated: "2024-04-02T16:33:16.260234+02:00"

--- a/openstack/octavia/Chart.yaml
+++ b/openstack/octavia/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.8.0
+    version: 0.9.2
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0

--- a/openstack/octavia/Chart.yaml
+++ b/openstack/octavia/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     version: 0.6.9
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.14.3
+    version: 0.15.0
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.3

--- a/openstack/octavia/Chart.yaml
+++ b/openstack/octavia/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
     version: 0.2.8
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.6.4
+    version: 0.6.9
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.14.3

--- a/openstack/octavia/templates/proxysql-configmap.yaml
+++ b/openstack/octavia/templates/proxysql-configmap.yaml
@@ -1,1 +1,0 @@
-{{ include "proxysql_configmap" . }}

--- a/openstack/octavia/templates/proxysql-secret.yaml
+++ b/openstack/octavia/templates/proxysql-secret.yaml
@@ -1,0 +1,1 @@
+{{ include "proxysql_secret" . }}

--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -53,7 +53,7 @@ mariadb:
     support_group: network-api
   enabled: true
   name: octavia
-  initdb_configmap: octavia-initdb
+  initdb_secret: true
   persistence_claim:
     name: db-octavia-pvclaim
   databases:


### PR DESCRIPTION
- bump up subcharts :
-- rabbitmq to version 0.6.9 (rabbitmq version 3.13.0)
-- mariadb to version 0.9.2
-- utils to version 0.15.0
- switch to set the new mariadb values initdb_secret instead of initdb_configmaps
- replace proxysql config map with proxysql secret
- update rabbitmq to 3.13.0-management