### PR TITLE
 [nsxv3] Provide username and password via Secret

### DIFF
--- a/openstack/neutron/templates/deployment-nsxv3-logstash.yaml
+++ b/openstack/neutron/templates/deployment-nsxv3-logstash.yaml
@@ -55,6 +55,16 @@ spec:
             timeoutSeconds: 30
             periodSeconds: 60
           env:
+          - name: NEUTRON_DB_USER
+            valueFrom:
+              secretKeyRef:
+                name: neutron-nsxv3-logstash-secret
+                key: NEUTRON_DB_USER
+          - name: NEUTRON_DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: neutron-nsxv3-logstash-secret
+                key: NEUTRON_DB_PASSWORD
           - name: XPACK_MONITORING_ENABLED
             value: "false"
           {{- include "utils.trust_bundle.env" . | indent 10 }}

--- a/openstack/neutron/templates/etc/_nsxv3_logstash.conf.tpl
+++ b/openstack/neutron/templates/etc/_nsxv3_logstash.conf.tpl
@@ -25,7 +25,7 @@ filter {
 
     if "_grokparsefailure" not in [tags] {
       ruby {
-        init => 'require "sequel"; $rc = Sequel.connect("jdbc:mysql://{{include "db_host_mysql" .}}/{{.Values.db_name}}?user={{ coalesce .Values.dbUser .Values.global.dbUser "root" }}&password={{ coalesce .Values.dbPassword .Values.global.dbPassword .Values.mariadb.root_password | required ".Values.mariadb.root_password is required!" }}")'
+        init => 'require "sequel"; $rc = Sequel.connect("jdbc:mysql://{{include "db_host_mysql" .}}/{{.Values.db_name}}?user=${NEUTRON_DB_USER}&password=${NEUTRON_DB_PASSWORD}")'
         code => '
         event_map = {"PASS" => "ACCEPT", "DROP" => "DROP"}
         event.set("action", "TERM") if event.get("action").nil?

--- a/openstack/neutron/templates/secret-nsxv3-logstash.yaml
+++ b/openstack/neutron/templates/secret-nsxv3-logstash.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: neutron-nsxv3-logstash-secret
+  labels:
+    system: openstack
+    application: {{ .Release.Name }}
+type: Opaque
+data:
+  NEUTRON_DB_PASSWORD: {{ coalesce .Values.dbPassword .Values.global.dbPassword .Values.mariadb.root_password | required ".Values.mariadb.root_password is required!" | b64enc }}
+  NEUTRON_DB_USER: {{ coalesce .Values.dbUser .Values.global.dbUser "root"  | b64enc }}

--- a/openstack/neutron/templates/vct-nsxv3-agent-configmap.yaml
+++ b/openstack/neutron/templates/vct-nsxv3-agent-configmap.yaml
@@ -43,11 +43,9 @@ template: |
       backend = dogpile.cache.memory
 
       [NSXV3]
-      nsxv3_login_user = osapinsxt
       {%- set bb = name | replace( "bb", "") | int %}
       {%- set hostname = "nsx-ctl-" + "bb" + ( '%03d' % bb ) + "." + domain %}
       nsxv3_login_hostname = {= hostname =}
-      nsxv3_login_password = {= username | derive_password(hostname) | quote =}
 
       {%- set tzname = "bb" + ( '%03d' % bb ) + "-vlan" %}
       nsxv3_transport_zone_name = {= tzname =}

--- a/openstack/neutron/templates/vct-nsxv3-agent-deployment.yaml
+++ b/openstack/neutron/templates/vct-nsxv3-agent-deployment.yaml
@@ -69,7 +69,7 @@ template: |
               containerPort: 8000
           livenessProbe:
             exec:
-              command: ["neutron-agent-liveness", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/secrets/server_agent_shared_secrets", "--config-file", "/etc/neutron/plugins/ml2/ml2-nsxv3.ini", "--agent-type", "NSXv3 Agent"]
+              command: ["neutron-agent-liveness", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/secrets/neutron-common-secrets.conf", "--config-file", "/etc/neutron/plugins/ml2/ml2-nsxv3.ini", "--agent-type", "NSXv3 Agent"]
             initialDelaySeconds: 90
             periodSeconds: 30
             timeoutSeconds: 10
@@ -93,9 +93,15 @@ template: |
             - name: NSXV3_LOGIN_PORT
               value: "443"
             - name: NSXV3_LOGIN_USER
-              value: "admin"
+              valueFrom:
+                secretKeyRef:
+                  name: neutron-ml2-nsxv3-{= name =}
+                  key: NSXV3_LOGIN_USER
             - name: NSXV3_LOGIN_PASSWORD
-              value: {= username | derive_password(hostname) | quote =}
+              valueFrom:
+                secretKeyRef:
+                  name: neutron-ml2-nsxv3-{= name =}
+                  key: NSXV3_LOGIN_PASSWORD
             - name: NSXV3_REQUESTS_PER_SECOND
               value: "10"
             - name: NSXV3_REQUEST_TIMEOUT_SECONDS
@@ -134,5 +140,10 @@ template: |
                 items:
                   - key: neutron-common-secrets.conf
                     path: secrets/neutron-common-secrets.conf
+            - secret:
+                name: neutron-ml2-nsxv3-{= name =}
+                items:
+                  - key:  neutron-nsxv3-secrets.conf
+                    path: secrets/neutron-nsxv3-secrets.conf
         {{- include "utils.trust_bundle.volumes" . | indent 8 }}
 {{- end }}

--- a/openstack/neutron/templates/vct-nsxv3-agent-secret.yaml
+++ b/openstack/neutron/templates/vct-nsxv3-agent-secret.yaml
@@ -1,0 +1,34 @@
+{{- if and (.Capabilities.APIVersions.Has "vcenter-operator.stable.sap.cc/v1") (contains ",nsxv3" .Values.ml2_mechanismdrivers ) }}
+apiVersion: vcenter-operator.stable.sap.cc/v1
+kind: VCenterTemplate
+metadata:
+  name: 'neutron-nsxv3-secrets'
+options:
+  scope: 'cluster'
+  jinja2_options:
+    variable_start_string: '{='
+    variable_end_string: '=}'
+template: |
+  {%- set bb = name | replace( "bb", "") | int %}
+  {%- set hostname = "nsx-ctl-" + "bb" + ( '%03d' % bb ) + "." + domain %}
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: neutron-ml2-nsxv3-{= name =}
+    labels:
+      system: openstack
+      type: configuration
+      component: neutron
+      vcenter: {= host =}
+      datacenter: {= availability_zone =}
+      vccluster: {= cluster_name =}
+  data:
+    NSXV3_LOGIN_USER: {% filter b64enc %}osapinsxt{%- endfilter %}
+    NSXV3_LOGIN_PASSWORD: {% filter b64enc %}{= username | derive_password(hostname) =}{%- endfilter %}
+    neutron-nsxv3-secrets.conf:{= " " =}
+  {%- filter b64enc %}
+  [NSXV3]
+  nsxv3_login_user = osapinsxt
+  nsxv3_login_password = {= username | derive_password(hostname) | quote =}
+  {%- endfilter %}
+{{ end }}


### PR DESCRIPTION
Since we have to move out all passwords into Secret objects, the vcenter-operator-provided vCenter password needs to be moved out of the ConfigMap template and into a new Secret template.
