### PR TITLE
[octavia][rabbitmq] bumpup rabbitmq to version 0.6.10

### DIFF
--- a/openstack/octavia/Chart.lock
+++ b/openstack/octavia/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 0.2.8
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.6.9
+  version: 0.6.10
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.15.0
@@ -20,5 +20,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.4
-digest: sha256:c27a548ba19b1968c7799adb160ed826f4fdf8ce5c1b34dfa21050adb0ea38a9
-generated: "2024-04-02T16:42:36.011335+02:00"
+digest: sha256:1ef453d1e77bcd79c15bc85afbe8195dd24a50501767370d9f8ff3008ebde6b8
+generated: "2024-04-03T09:01:11.028247+02:00"

--- a/openstack/octavia/Chart.yaml
+++ b/openstack/octavia/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
     version: 0.2.8
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.6.9
+    version: 0.6.10
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.15.0


### PR DESCRIPTION
update dependencies of octavia to rabbitmq 0.6.10 which uses data field in the secret instead of StringData.
