### PR TITLE
[ironic][mariadb][rabbitmq][utils] bump up mariadb,rabbitmq, utils for ironic

### DIFF
--- a/openstack/ironic/Chart.lock
+++ b/openstack/ironic/Chart.lock
@@ -1,19 +1,19 @@
 dependencies:
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.8.0
+  version: 0.9.2
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.2.7
+  version: 0.2.8
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.3
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.6.3
+  version: 0.6.11
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.13.0
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:aa4ba1672dc45abf26394a5bf5548f9d60e09141634fe2c96a8261a65f411266
-generated: "2024-02-21T18:46:35.915173+01:00"
+digest: sha256:c778d0566de41de00d41519a00de11d791b9d3ade0e2a9ea5a01ddd09c8d8aeb
+generated: "2024-04-03T09:20:59.933754+02:00"

--- a/openstack/ironic/Chart.lock
+++ b/openstack/ironic/Chart.lock
@@ -16,12 +16,12 @@ dependencies:
   version: 0.6.11
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.13.0
+  version: 0.15.0
 - name: ironic-exporter
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.0.3
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:346e35a541a15d37d2595d666e5055a88a146e0155fef5b517ce371d07d230f1
-generated: "2024-04-03T09:22:40.495663+02:00"
+digest: sha256:3808a2a3e7b4160595ff89c3b313a67a225f73636a63c41bffe1d20fe3f88735
+generated: "2024-04-03T09:25:15.757343+02:00"

--- a/openstack/ironic/Chart.lock
+++ b/openstack/ironic/Chart.lock
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:c778d0566de41de00d41519a00de11d791b9d3ade0e2a9ea5a01ddd09c8d8aeb
-generated: "2024-04-03T09:20:59.933754+02:00"
+digest: sha256:346e35a541a15d37d2595d666e5055a88a146e0155fef5b517ce371d07d230f1
+generated: "2024-04-03T09:22:40.495663+02:00"

--- a/openstack/ironic/Chart.yaml
+++ b/openstack/ironic/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
     version: ~0.6.10
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.13.0
+    version: ~0.15.0
   - name: ironic-exporter
     repository: https://charts.eu-de-2.cloud.sap
     version: ~1.0.3

--- a/openstack/ironic/Chart.yaml
+++ b/openstack/ironic/Chart.yaml
@@ -20,7 +20,7 @@ dependencies:
     version: ~0.2.0
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.6.1
+    version: ~0.6.10
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
     version: ~0.13.0

--- a/openstack/ironic/Chart.yaml
+++ b/openstack/ironic/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.8.0
+    version: ~0.9.2
   - name: memcached
     repository: https://charts.eu-de-2.cloud.sap
     version: ~0.2.0

--- a/openstack/ironic/templates/proxysql-configmap.yaml
+++ b/openstack/ironic/templates/proxysql-configmap.yaml
@@ -1,1 +1,0 @@
-{{ include "proxysql_configmap" . }}

--- a/openstack/ironic/templates/proxysql-secret.yaml
+++ b/openstack/ironic/templates/proxysql-secret.yaml
@@ -1,0 +1,1 @@
+{{ include "proxysql_secret" . }}

--- a/openstack/ironic/values.yaml
+++ b/openstack/ironic/values.yaml
@@ -365,7 +365,7 @@ mariadb:
       - ironic_inspector.nodes
 
   root_password: "AHardPa55w0rd!"
-  initdb_configmap: ironic-mariadb-init
+  initdb_secret: true
   persistence_claim:
     name: db-ironic-pvclaim
 


### PR DESCRIPTION
- bump up subcharts :
-- rabbitmq to version 0.6.10 (rabbitmq version 3.13.0)
-- mariadb to version 0.9.2
-- utils to version 0.15.0
- switch to set the new mariadb values initdb_secret instead of initdb_configmaps
- replace proxysql config map with proxysql secret
- update rabbitmq to 3.13.0-management