### PR TITLE
[manila][mariadb][rabbitmq][utils] Bump up mariadb,rabbitmq, utils for Manila

### DIFF
--- a/openstack/manila/Chart.lock
+++ b/openstack/manila/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 0.2.3
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.6.11
+  version: 0.6.10
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.14.6
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.4
-digest: sha256:22ddfab8d501f6b1155bb6e448eef9ebb1b45264841c58f4ab8a157581fb8164
-generated: "2024-04-03T09:36:52.1361+01:00"
+digest: sha256:0b8bdf0fdbdc8613a397ea72874c31bd7c8015d9e13b9b836b8c3f6cb9ffff09
+generated: "2024-04-03T09:48:40.943224+01:00"

--- a/openstack/manila/Chart.lock
+++ b/openstack/manila/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.9.2
+  version: 0.9.4
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
@@ -13,15 +13,15 @@ dependencies:
   version: 0.2.3
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.6.10
+  version: 0.6.12
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.15.0
+  version: 0.16.1
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.3.13
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.4
-digest: sha256:4b0250e5b072c6a73a17098c2ac77c6d4c2f4b271d2c993725cc660a689bf6b2
-generated: "2024-04-03T09:53:52.465322+01:00"
+digest: sha256:eebd594dec69607b10ed342c253a57f611cb14e7cca66baa4d35cb8752f54929
+generated: "2024-04-09T11:33:00.099079+02:00"

--- a/openstack/manila/Chart.lock
+++ b/openstack/manila/Chart.lock
@@ -16,12 +16,12 @@ dependencies:
   version: 0.6.10
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.14.6
+  version: 0.15.0
 - name: redis
   repository: https://charts.eu-de-2.cloud.sap
   version: 1.3.13
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.4
-digest: sha256:0b8bdf0fdbdc8613a397ea72874c31bd7c8015d9e13b9b836b8c3f6cb9ffff09
-generated: "2024-04-03T09:48:40.943224+01:00"
+digest: sha256:4b0250e5b072c6a73a17098c2ac77c6d4c2f4b271d2c993725cc660a689bf6b2
+generated: "2024-04-03T09:53:52.465322+01:00"

--- a/openstack/manila/Chart.lock
+++ b/openstack/manila/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.8.0
+  version: 0.9.2
 - name: memcached
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
@@ -13,7 +13,7 @@ dependencies:
   version: 0.2.3
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.6.6
+  version: 0.6.11
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.14.6
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.4
-digest: sha256:65905379ac57cf4cab6d6591b6d6460cbce85f078b8c1089739e913d68985c54
-generated: "2024-03-18T12:00:58.759265+01:00"
+digest: sha256:22ddfab8d501f6b1155bb6e448eef9ebb1b45264841c58f4ab8a157581fb8164
+generated: "2024-04-03T09:36:52.1361+01:00"

--- a/openstack/manila/Chart.yaml
+++ b/openstack/manila/Chart.yaml
@@ -28,7 +28,7 @@ dependencies:
     version: ~0.2.3
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.6.6
+    version: 0.6.10
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
     version: ~0.14.6

--- a/openstack/manila/Chart.yaml
+++ b/openstack/manila/Chart.yaml
@@ -31,7 +31,7 @@ dependencies:
     version: 0.6.10
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.14.6
+    version: 0.15.0
   - name: redis
     alias: api-ratelimit-redis
     repository: https://charts.eu-de-2.cloud.sap

--- a/openstack/manila/Chart.yaml
+++ b/openstack/manila/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: ~0.8.0
+    version: 0.9.2
   - condition: memcached.enabled
     name: memcached
     repository: https://charts.eu-de-2.cloud.sap

--- a/openstack/manila/Chart.yaml
+++ b/openstack/manila/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.9.2
+    version: ~0.9.2
   - condition: memcached.enabled
     name: memcached
     repository: https://charts.eu-de-2.cloud.sap
@@ -28,10 +28,10 @@ dependencies:
     version: ~0.2.3
   - name: rabbitmq
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.6.10
+    version: ~0.6.10
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.15.0
+    version: ~0.16.0
   - name: redis
     alias: api-ratelimit-redis
     repository: https://charts.eu-de-2.cloud.sap

--- a/openstack/manila/templates/migration-job.yaml
+++ b/openstack/manila/templates/migration-job.yaml
@@ -6,7 +6,7 @@
      Similarily we can only use the secret if a previous helm deployment added
      it.
 */}}
-{{- $proxysql := lookup "v1" "ConfigMap" .Release.Namespace (print .Release.Name "-proxysql-etc") -}}
+{{- $proxysql := lookup "v1" "Secret" .Release.Namespace (print .Release.Name "-proxysql-etc") -}}
 {{- $secrets := lookup "v1" "Secret" .Release.Namespace (print .Release.Name "-secrets") -}}
 apiVersion: batch/v1
 kind: Job

--- a/openstack/manila/templates/proxysql-configmap.yaml
+++ b/openstack/manila/templates/proxysql-configmap.yaml
@@ -1,1 +1,0 @@
-{{ include "proxysql_configmap" . }}

--- a/openstack/manila/templates/proxysql-secret.yaml
+++ b/openstack/manila/templates/proxysql-secret.yaml
@@ -1,0 +1,1 @@
+{{ include "proxysql_secret" . }}

--- a/openstack/manila/values.yaml
+++ b/openstack/manila/values.yaml
@@ -661,6 +661,9 @@ rabbitmq:
     enabled: true
     sidecar:
       enabled: false
+  enableDetailedMetrics: false
+  enablePerObjectMetrics: false
+
 sentry:
   enabled: true
 seeds:

--- a/openstack/manila/values.yaml
+++ b/openstack/manila/values.yaml
@@ -607,7 +607,7 @@ mariadb:
   query_cache_size: "1M"
   query_cache_type: "1"
   name: manila
-  initdb_configmap: manila-initdb
+  initdb_secret: true
   databases:
   - manila
   users:


### PR DESCRIPTION
Bump up subcharts :
-- rabbitmq to version 0.6.10 (rabbitmq version 3.13.0)
-- mariadb to version 0.9.2
-- utils to version 0.15.0
Switch to set the new mariadb values initdb_secret instead of initdb_configmaps
Replace proxysql config map with proxysql secret
Activate detailed metrics