### PR TITLE
domain-seeds: remove obsolete user accounts

### DIFF
--- a/openstack/domain-seeds/templates/domain-default-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-default-seed.yaml
@@ -28,15 +28,9 @@ spec:
     - name: core_dns_registry
       description: 'Service User for Core DNS Registry'
       password: {{ .Values.coreDnsRegistryServicePassword | quote }}
-    - name: docker_registry
-      description: 'Docker Registry Service User'
-      password: {{ .Values.dockerRegistryServicePassword | quote }}
     - name: image-build
       description: 'Image building'
       password: {{ .Values.imageBuildServicePassword | quote }}
-    - name: quay
-      description: 'Quay Service User'
-      password: {{ .Values.quayServicePassword | quote }}
 
     groups:
     - name: administrators

--- a/openstack/domain-seeds/values.yaml
+++ b/openstack/domain-seeds/values.yaml
@@ -31,9 +31,7 @@ ldapUseAuthPool: true
 # default domain - service user credentials
 concourseServicePassword: DEFINE_IN_REGION_VALUES
 dbBackupServicePassword: DEFINE_IN_REGION_VALUES
-dockerRegistryServicePassword: DEFINE_IN_REGION_VALUES
 imageBuildServicePassword: DEFINE_IN_REGION_VALUES
-quayServicePassword: DEFINE_IN_REGION_VALUES
 
 # kubernikus domain - service user credentials
 kubernikusAdminPassword: DEFINE_IN_REGION_VALUES


### PR DESCRIPTION
- "docker-registry" and "quay" have been obsoleted by Keppel years ago
- "gaas" is not used anymore after #6283

Please merge together with the respective secrets PR.