### PR TITLE
[utils] add helm pre-upgrade weight to proxysql secret

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.16.0
+version: 0.16.1

--- a/openstack/utils/templates/_proxysql_secret.yaml.tpl
+++ b/openstack/utils/templates/_proxysql_secret.yaml.tpl
@@ -24,6 +24,11 @@ metadata:
     system: openstack
     type: configuration
     component: database
+  {{- if .Values.proxysql.forceSecretCreation }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-10"
+  {{- end }}
 data:
   proxysql.cnf: |
 {{ include "utils.snippets.set_proxysql_config" (dict "max_connections" $max_connections "dbs" $dbs "dbKeys" $dbKeys "global" $ )  | b64enc | trim | indent 4 }}


### PR DESCRIPTION
add annotation to proxysql secret to set helm pre upgrade hook weit of -10 to proxysql secret, that to force the creation in case of a job needs the secret to be created before running.

option activated by set value `proxysql.forceSecretCreation` to true
