### PR TITLE
[neutron] Disregard decommissioned segments in alert

### DIFF
--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -547,6 +547,7 @@ mysql_metrics:
           host AS hostgroup,
           COUNT(*) AS value
         FROM aci_port_binding_allocations
+        JOIN (SELECT physical_network pn FROM ml2_vlan_allocations GROUP BY pn) AS mva ON mva.pn = host
         GROUP BY host;
       values:
       - "value"
@@ -559,6 +560,7 @@ mysql_metrics:
           host AS hostgroup,
           SUM(segment_id IS NULL) AS value
         FROM aci_port_binding_allocations
+        JOIN (SELECT physical_network pn FROM ml2_vlan_allocations GROUP BY pn) AS mva ON mva.pn = host
         GROUP BY host;
       values:
       - "value"


### PR DESCRIPTION
When reporting segment usage we only need to report usage for hostgroups that are still in use. Since the aci sync allocation rewrite[0], we do a proper allocation table cleanup, but we still keep segments in the table that are in use, so these decommissioned hostgroups look like 100% full.

Therefore we now only look at currently active hostgroups by filtering for physical_networks mentioned in the ml2_vlan_allocations, which is also kept up to date, but does not keep orphans.

[0] https://github.com/sapcc/networking-aci/commit/b9294849093932d8f04555636290458fa60421ab