### PR TITLE
[octavia] bump utils to 0.16.1, fix migration job

### DIFF
--- a/openstack/octavia/Chart.lock
+++ b/openstack/octavia/Chart.lock
@@ -13,12 +13,12 @@ dependencies:
   version: 0.6.11
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.16.0
+  version: 0.16.1
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.3
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.4
-digest: sha256:48e5ade2b1192d31655ae8c816c662ab36d6c1c59754097eef124535651fa3ee
-generated: "2024-04-04T14:42:58.512273589+02:00"
+digest: sha256:f27b2ecb4d5198b6b509bba549de9256d2382359b6493b67c82eb887e88a7398
+generated: "2024-04-04T15:41:04.829511+02:00"

--- a/openstack/octavia/Chart.yaml
+++ b/openstack/octavia/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     version: 0.6.11
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.16.0
+    version: 0.16.1
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.3

--- a/openstack/octavia/templates/octavia-migration-job.yaml
+++ b/openstack/octavia/templates/octavia-migration-job.yaml
@@ -1,4 +1,4 @@
-{{- $proxysql := lookup "v1" "ConfigMap" .Release.Namespace (print .Release.Name "-proxysql-etc") -}}
+{{- $proxysql := lookup "v1" "Secret" .Release.Namespace (print .Release.Name "-proxysql-etc") -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -20,7 +20,7 @@ spec:
   template:
     spec:
       restartPolicy: OnFailure
-    {{- if $proxysql}}
+    {{- if $proxysql }}
       {{- include "utils.proxysql.job_pod_settings" . | nindent 6 }}
     {{- end }}
       initContainers:
@@ -34,7 +34,7 @@ spec:
             - name: DEPENDENCY_SERVICE
               value: "{{ .Release.Name }}-mariadb"
             - name: NAMESPACE
-              value: {{ .Release.Namespace }}        
+              value: {{ .Release.Namespace }}
       containers:
         - name: octavia-migration
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-octavia:{{required "Values.imageVersion is missing" .Values.imageVersion}}
@@ -65,7 +65,7 @@ spec:
               subPath: logging.ini
               readOnly: true
             {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
-    {{- if $proxysql}}
+    {{- if $proxysql }}
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
         {{- include "utils.proxysql.container" . | indent 8 }}
     {{- end }}
@@ -73,7 +73,7 @@ spec:
         - name: octavia-etc
           configMap:
             name: octavia-etc
-    {{- if $proxysql}}
+    {{- if $proxysql }}
         {{- include "utils.proxysql.volumes" . | indent 8 }}
     {{- end }}
         {{- include "utils.trust_bundle.volumes" . | indent 8 }}


### PR DESCRIPTION
- bump up to use utils v0.16.1
- force creating proxysql secret before starting the migration job
- add an or condition to configure proxysql in the job if any values are set in vaules in proxysql map, that to fix the first run issue caused by the lookup function on K8S secret which is not created on K8S side while helm generating the templates
