### PR TITLE
[ironic] move configuration with credentials into own secrets

### DIFF
--- a/openstack/ironic/templates/_conductor-configmap-secret.yaml.tpl
+++ b/openstack/ironic/templates/_conductor-configmap-secret.yaml.tpl
@@ -16,11 +16,25 @@ metadata:
 data:
   ironic-conductor.conf: |
 {{ list . $conductor | include "ironic_conductor_conf" | indent 4 }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+{{- if $conductor.name }}
+  name: ironic-conductor-{{$conductor.name}}-etc-secret
+{{- else }}
+  name: ironic-conductor-etc-secret
+{{- end }}
+  labels:
+    system: openstack
+    type: configuration
+    component: ironic
+data:
   ipxe_config.template: |
     {{- if $conductor.jinja2 }}
     {% raw -%}
     {{- end }}
-{{ list . $conductor | include "ipxe_config_template" | indent 4 }}
+{{ list . $conductor | include "ipxe_config_template" | b64enc | indent 4 }}
     {{- if $conductor.jinja2 }}
     {%- endraw %}
     {{- end }}

--- a/openstack/ironic/templates/api-deployment.yaml
+++ b/openstack/ironic/templates/api-deployment.yaml
@@ -27,6 +27,7 @@ spec:
 {{ tuple . "ironic" "api" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
       annotations:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
+        secrets-hash: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
         {{- if or .Values.watcher.enabled .Values.proxysql.mode }}
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
@@ -75,6 +76,8 @@ spec:
           name: ironic-etc
           subPath: ironic.conf
           readOnly: true
+        - mountPath: /etc/ironic/ironic.conf.d
+          name: ironic-etc-confd
         - mountPath: /etc/ironic/policy.json
           name: ironic-etc
           subPath: policy.json
@@ -128,6 +131,12 @@ spec:
         configMap:
           name: ironic-etc
           defaultMode: 0444
+      - name: ironic-etc-confd
+        secret:
+          secretName: {{ .Release.Name }}-secrets
+          items:
+          - key: secrets.conf
+            path: secrets.conf
       {{- include "utils.proxysql.volumes" . | indent 6 }}
       {{- include "utils.trust_bundle.volumes" . | indent 6 }}
       {{- tuple . .Values.api.override "ironic-api" .Values.global.ironicApiPortInternal | include "utils.snippets.debug.debug_port_volumes_and_configmap" }}

--- a/openstack/ironic/templates/db-migration-job.yaml
+++ b/openstack/ironic/templates/db-migration-job.yaml
@@ -41,6 +41,8 @@ spec:
         volumeMounts:
         - mountPath: /etc/ironic
           name: etcironic
+        - mountPath: /etc/ironic/ironic.conf.d
+          name: ironic-etc-confd
         - mountPath: /etc/ironic/ironic.conf
           name: ironic-etc
           subPath: ironic.conf
@@ -65,4 +67,10 @@ spec:
         configMap:
           name: ironic-etc
           defaultMode: 0444
+      - name: ironic-etc-confd
+        secret:
+          secretName: {{ .Release.Name }}-secrets
+          items:
+          - key: secrets.conf
+            path: secrets.conf
       {{- include "utils.trust_bundle.volumes" . | indent 6 }}

--- a/openstack/ironic/templates/etc/_inspector_secrets.conf.tpl
+++ b/openstack/ironic/templates/etc/_inspector_secrets.conf.tpl
@@ -1,0 +1,15 @@
+[DEFAULT]
+{{- include "ini_sections.default_transport_url" . }}
+
+[ironic]
+username = {{ .Values.global.ironicServiceUser }}
+password = {{ required ".Values.global.ironicServicePassword is missing" .Values.global.ironicServicePassword }}
+
+[database]
+connection = {{ tuple . .Values.mariadb.users.ironic_inspector.name .Values.mariadb.users.ironic_inspector.name .Values.mariadb.users.ironic_inspector.password | include "db_url_mysql" }}
+
+[keystone_authtoken]
+username = {{ .Values.global.ironicServiceUser }}
+password = {{ required ".Values.global.ironicServicePassword is missing" .Values.global.ironicServicePassword }}
+
+{{- include "ini_sections.audit_middleware_notifications" . }}

--- a/openstack/ironic/templates/etc/_ironic.conf.tpl
+++ b/openstack/ironic/templates/etc/_ironic.conf.tpl
@@ -21,8 +21,6 @@ versioned_notifications_topics = {{ .Values.versioned_notifications_topics  | de
 rpc_response_timeout = {{ .Values.rpc_response_timeout | default .Values.global.rpc_response_timeout | default 100 }}
 executor_thread_pool_size = {{ .Values.rpc_workers | default .Values.global.rpc_workers | default 64 }}
 
-{{- include "ini_sections.oslo_messaging_rabbit" .}}
-
 # time to live in sec of idle connections in the pool:
 conn_pool_ttl = {{ .Values.rpc_conn_pool_ttl | default 600 }}
 rpc_conn_pool_size = {{ .Values.rpc_conn_pool_size | default .Values.global.rpc_conn_pool_size | default 100 }}
@@ -55,8 +53,6 @@ public_endpoint = https://{{ include "ironic_api_endpoint_host_public" .}}
 api_workers = {{ .Values.api.api_workers }}
 
 [database]
-#connection = mysql+pymysql://ironic:{{.Values.global.dbPassword}}@ironic-mariadb.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.region}}.{{.Values.global.tld}}/ironic?charset=utf8
-connection = {{ include "db_url_mysql" . }}
 {{- include "ini_sections.database_options_mysql" . }}
 
 [keystone]
@@ -70,8 +66,6 @@ auth_version = v3
 www_authenticate_uri = https://{{include "keystone_api_endpoint_host_public" .}}/v3
 auth_url = {{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3
 user_domain_name = {{.Values.global.keystone_service_domain | default "Default"}}
-username = {{ .Values.global.ironicServiceUser }}{{ .Values.global.user_suffix }}
-password = {{ required ".Values.global.ironicServicePassword is missing" .Values.global.ironicServicePassword }}
 project_domain_name = {{.Values.global.keystone_service_domain | default "Default"}}
 project_name = {{.Values.global.keystone_service_project | default "service"}}
 region_name = {{ .Values.global.region }}
@@ -92,8 +86,6 @@ auth_version = v3
 www_authenticate_uri = https://{{include "keystone_api_endpoint_host_public" .}}/v3
 auth_url = {{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3
 user_domain_name = {{.Values.global.keystone_service_domain | default "Default"}}
-username = {{ .Values.global.ironicServiceUser }}{{ .Values.global.user_suffix }}
-password = {{ required ".Values.global.ironicServicePassword is missing" .Values.global.ironicServicePassword }}
 project_domain_name = {{.Values.global.keystone_service_domain | default "Default"}}
 project_name = {{.Values.global.keystone_service_project | default "service"}}
 insecure = True
@@ -104,15 +96,6 @@ swift_temp_url_duration = 3600
 # No terminal slash, it will break the url signing scheme
 swift_endpoint_url = {{ .Values.global.swift_endpoint_protocol | default "https" }}://{{ include "swift_endpoint_host" . }}:{{ .Values.global.swift_api_port_public | default 443 }}
 swift_api_version = v1
-{{- if .Values.swift_store_multi_tenant }}
-swift_store_multi_tenant = True
-{{- else}}
-    {{- if .Values.swift_multi_tenant }}
-swift_store_multiple_containers_seed = 32
-    {{- end }}
-swift_temp_url_key = {{required "A valid .Values.swift_tempurl required!" .Values.swift_tempurl }}
-swift_account = {{required "A valid .Values.swift_account required!" .Values.swift_account }}
-{{- end }}
 
 [swift]
 auth_section = service_catalog
@@ -152,7 +135,6 @@ ignore_req_list = GET, HEAD
 record_payloads = {{ if .Values.audit.record_payloads -}}True{{- else -}}False{{- end }}
 metrics_enabled = {{ if .Values.audit.metrics_enabled -}}True{{- else -}}False{{- end }}
 
-{{- include "ini_sections.audit_middleware_notifications" . }}
 {{- end }}
 
 {{- include "osprofiler" . }}

--- a/openstack/ironic/templates/etc/_ironic_inspector.conf.tpl
+++ b/openstack/ironic/templates/etc/_ironic_inspector.conf.tpl
@@ -2,7 +2,6 @@
 log_config_append = /etc/ironic-inspector/logging.ini
 {{- include "ini_sections.logging_format" . }}
 
-{{- include "ini_sections.default_transport_url" . }}
 clean_up_period = 120
 # Timeout after which introspection is considered failed, set to 0 to
 # disable. (integer value)
@@ -24,8 +23,6 @@ host = https://{{ include "ironic_inspector_endpoint_host_public" .}}
 region_name = {{.Values.global.region}}
 auth_url = {{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3
 auth_type = v3password
-username = {{ .Values.global.ironicServiceUser }}{{ .Values.global.user_suffix }}
-password = {{ required ".Values.global.ironicServicePassword is missing" .Values.global.ironicServicePassword }}
 user_domain_name = {{.Values.global.keystone_service_domain | default "Default"}}
 project_name = {{.Values.global.keystone_service_project | default "service"}}
 project_domain_name = {{.Values.global.keystone_service_domain | default "Default"}}
@@ -55,19 +52,13 @@ enroll_node_fields = conductor_group:testing
 driver = noop
 
 [database]
-#connection = mysql+pymysql://ironic_inspector:{{.Values.inspectordbPassword}}@ironic-mariadb.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.region}}.{{.Values.global.tld}}/ironic_inspector?charset=utf8
-connection = {{ tuple . .Values.mariadb.users.ironic_inspector.name .Values.mariadb.users.ironic_inspector.name .Values.mariadb.users.ironic_inspector.password | include "db_url_mysql" }}
 {{- include "ini_sections.database_options_mysql" . }}
-
-{{- include "ini_sections.audit_middleware_notifications" . }}
 
 [keystone_authtoken]
 www_authenticate_uri = https://{{include "keystone_api_endpoint_host_public" .}}/v3
 auth_url = {{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3
 auth_type = v3password
 auth_interface = internal
-username = {{ .Values.global.ironicServiceUser }}{{ .Values.global.user_suffix }}
-password = {{ required ".Values.global.ironicServicePassword is missing" .Values.global.ironicServicePassword }}
 user_domain_name = {{.Values.global.keystone_service_domain | default "Default"}}
 project_name = {{.Values.global.keystone_service_project | default "service"}}
 project_domain_name = {{.Values.global.keystone_service_domain | default "Default"}}

--- a/openstack/ironic/templates/etc/_secrets.conf.tpl
+++ b/openstack/ironic/templates/etc/_secrets.conf.tpl
@@ -1,0 +1,26 @@
+[DEFAULT]
+{{- include "ini_sections.oslo_messaging_rabbit" .}}
+
+[database]
+connection = {{ include "db_url_mysql" . }}
+
+[keystone_authtoken]
+username = {{ .Values.global.ironicServiceUser }}
+password = {{ required ".Values.global.ironicServicePassword is missing" .Values.global.ironicServicePassword }}
+
+[service_catalog]
+username = {{ .Values.global.ironicServiceUser }}
+password = {{ required ".Values.global.ironicServicePassword is missing" .Values.global.ironicServicePassword }}
+
+[glance]
+{{- if .Values.swift_store_multi_tenant }}
+swift_store_multi_tenant = True
+{{- else}}
+    {{- if .Values.swift_multi_tenant }}
+swift_store_multiple_containers_seed = 32
+    {{- end }}
+swift_temp_url_key = {{required "A valid .Values.swift_tempurl required!" .Values.swift_tempurl }}
+swift_account = {{required "A valid .Values.swift_account required!" .Values.swift_account }}
+{{- end }}
+
+{{ include "ini_sections.audit_middleware_notifications" . }}

--- a/openstack/ironic/templates/inspector-db-migration-job.yaml
+++ b/openstack/ironic/templates/inspector-db-migration-job.yaml
@@ -40,6 +40,8 @@ spec:
         volumeMounts:
         - mountPath: /etc/ironic-inspector
           name: etcironicinspector
+        - mountPath: /etc/ironic-inspector/ironic-inspector.conf.d
+          name: ironic-inspector-etc-confd
         - mountPath: /etc/ironic-inspector/ironic-inspector.conf
           name: ironic-inspector-etc
           subPath: ironic-inspector.conf
@@ -68,4 +70,10 @@ spec:
         configMap:
           name: ironic-inspector-etc
           defaultMode: 0444
+      - name: ironic-inspector-etc-confd
+        secret:
+          secretName: {{ .Release.Name }}-secrets
+          items:
+          - key: inspector_secrets.conf
+            path: inspector_secrets.conf
       {{- include "utils.trust_bundle.volumes" . | indent 6 }}

--- a/openstack/ironic/templates/inspector-deployment.yaml
+++ b/openstack/ironic/templates/inspector-deployment.yaml
@@ -28,6 +28,7 @@ spec:
       annotations:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
         configmap-inspector-etc-hash: {{ include (print $.Template.BasePath "/inspector-etc-configmap.yaml") . | sha256sum }}
+        secrets-hash: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
         {{- if or .Values.inspector.rpc_statsd_enabled .Values.proxysql.mode }}
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
@@ -69,6 +70,8 @@ spec:
         volumeMounts:
         - mountPath: /etc/ironic-inspector
           name: etcironic
+        - mountPath: /etc/ironic-inspector/ironic-inspector.conf.d
+          name: ironic-inspector-etc-confd
         - mountPath: /etc/ironic-inspector/ironic-inspector.conf
           name: ironic-inspector-etc
           subPath: ironic-inspector.conf
@@ -146,6 +149,12 @@ spec:
         configMap:
           name: ironic-etc
           defaultMode: 0444
+      - name: ironic-inspector-etc-confd
+        secret:
+          secretName: {{ .Release.Name }}-secrets
+          items:
+          - key: inspector_secrets.conf
+            path: inspector_secrets.conf
       - name: ironic-inspector-etc
         configMap:
           name: ironic-inspector-etc

--- a/openstack/ironic/templates/secrets.yaml
+++ b/openstack/ironic/templates/secrets.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-secrets
+  labels:
+    system: openstack
+    application: {{ .Release.Name }}
+type: Opaque
+data: 
+  secrets.conf: |
+    {{ include (print .Template.BasePath "/etc/_secrets.conf.tpl") . | b64enc | indent 4 }}
+  inspector_secrets.conf: |
+    {{ include (print .Template.BasePath "/etc/_inspector_secrets.conf.tpl") . | b64enc | indent 4 }}


### PR DESCRIPTION
- Common secrets will be projected into /etc/ironic/ironic.conf.d/ and /etc/ironic-inspector/ironic-inspector.conf.d/