### PR TITLE
[mariadb] the quotation inside helm template does not work with

### DIFF
--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.9.3
+version: 0.9.4

--- a/common/mariadb/templates/config/_backup_config.yaml.tpl
+++ b/common/mariadb/templates/config/_backup_config.yaml.tpl
@@ -42,12 +42,12 @@ storages:
   swift:
     - name: swift-{{ .Values.global.region }}
       auth_version: 3
-      auth_url:  https://identity-3.{{ .Values.global.region }}.cloud.sap/v3
+      auth_url: "https://identity-3.{{ .Values.global.region }}.cloud.sap/v3"
       user_name: db_backup
       user_domain_name: Default
       project_name: master
       project_domain_name: ccadmin
-      password: {{ .Values.backup_v2.swift.password | required "Please set .Values.backup_v2.swift.password" | quote }}
+      password: {{ .Values.backup_v2.swift.password | required "Please set .Values.backup_v2.swift.password" }}
       region: {{ .Values.global.region }}
       container_name: "mariadb-backup-{{ .Values.global.region }}"
 verification:


### PR DESCRIPTION
secret-injector

- can be used in the vault references instead
- bump chart