### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -73,8 +73,8 @@
 /openstack/cronus                                      @kayrus @dhalimi @corey-aloia @fwiesel
 /openstack/cronus-seed                                 @kayrus @dhalimi
 /openstack/db-backup-v2                                @databus23 @fwiesel
-/openstack/designate                                   @galkindmitrii @fwiesel @mutax @kpawar-sap
-/openstack/designate-nanny                             @mutax
+/openstack/designate                                   @galkindmitrii @fwiesel @mutax @kpawar-sap @vssldmtrv @mbrowny @SoenkeL
+/openstack/designate-nanny                             @mutax @vssldmtrv @mbrowny @SoenkeL @galkindmitrii
 /openstack/domain-seeds                                @BerndKue @Carthaca @fwiesel @Kuckkuck @rajivmucheli
 /openstack/elektra                                     @andypf @databus23 @ArtieReus @hgw77
 /openstack/glance                                      @fwiesel @galkindmitrii @rajivmucheli @Carthaca

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,6 +51,7 @@
 /global/thanos-global                                  @viennaa @richardtief
 /global/vault                                          @BugRoger  # old
 /global/vault-tec                                      @Nuckal777 @majewsky @SuperSandro2000 @VoigtS
+/global/volta                                          @dimtass @databus23
 /global/wham                                           @databus23
 
 /openstack/andromeda-seed                              @notandy @m-kratochvil

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -274,6 +274,7 @@
 /system/sentry                                         @databus23 @rajivmucheli
 /system/servicemesh                                    @jknipper
 /system/smee-dynakratos                                @defo89 @SchwarzM
+/system/srs-*                                          @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /system/storage-monitoring                             @viennaa @richardtief @artherd42 @geisslet
 /system/sysctl                                         @defo89
 /system/sysstat                                        @defo89

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 /ci                                                    @auhlig @Kuckkuck @businessbean @jknipper @fwiesel
 
 /common/helm3-helper                                   @SchwarzM  # old
-/common/inventory-updater                              @BerndKue @stanislav-zaprudskiy
+/common/inventory-updater                              @BerndKue
 /common/linkerd-support                                @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /common/manila-provisioner                             @jknipper  # old
 /common/mariadb                                        @galkindmitrii @stefanhipfel @Carthaca @IvoGoman @fwiesel
@@ -128,7 +128,7 @@
 /openstack/volume-claims                               @fwiesel
 
 /prometheus-exporters/apic-exporter                    @artherd42 @IvoGoman @geisslet
-/prometheus-exporters/arista-exporter                  @BerndKue @stanislav-zaprudskiy @stefanhipfel
+/prometheus-exporters/arista-exporter                  @BerndKue @stefanhipfel
 /prometheus-exporters/blackbox-exporter                @defo89 @databus23
 /prometheus-exporters/cloudprober                      @artherd42 @defo89
 /prometheus-exporters/cronus-exporter                  @dhalimi @LimorGargir @richardtief @geisslet
@@ -139,7 +139,7 @@
 /prometheus-exporters/documentation-prober             @dhalimi  # old
 /prometheus-exporters/event-exporter                   @jknipper @databus23
 /prometheus-exporters/hermes-query-exporter            @Kuckkuck
-/prometheus-exporters/ipmi-exporter                    @stefanhipfel @BerndKue @stanislav-zaprudskiy
+/prometheus-exporters/ipmi-exporter                    @stefanhipfel @BerndKue
 /prometheus-exporters/ipmi-service-discovery           @auhlig  # old
 /prometheus-exporters/ironic-exporter                  @BerndKue @stefanhipfel
 /prometheus-exporters/jumpserver-exporter              @viennaa

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -285,7 +285,6 @@
 /system/thanos-operator                                @viennaa
 /system/thanos-scaleout                                @richardtief @viennaa
 /system/thanos-seeds                                   @viennaa
-/system/tiller                                         @BugRoger @defo89 @majewsky  # old
 /system/toolbox-prepull                                @defo89 @SchwarzM
 /system/unbound                                        @galkindmitrii @vssldmtrv @dhoeller @mutax @defo89
 /system/validation                                     @artherd42 @thgrs @ashifnihalb

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -108,17 +108,17 @@
 /openstack/swift                                       @sumitarora2786 @crenduchinta88 @majewsky @SuperSandro2000 @VoigtS
 /openstack/swift-drive-autopilot                       @sumitarora2786 @crenduchinta88 @majewsky @SuperSandro2000 @VoigtS
 /openstack/swift-utils                                 @sumitarora2786 @crenduchinta88 @majewsky @SuperSandro2000 @VoigtS
-/openstack/tempest/barbican-tempest                    @misamoylov @fwiesel @rajivmucheli
-/openstack/tempest/cinder-tempest                      @misamoylov @fwiesel
-/openstack/tempest/designate-tempest                   @misamoylov @fwiesel
-/openstack/tempest/glance-tempest                      @misamoylov @fwiesel @rajivmucheli
-/openstack/tempest/ironic-tempest                      @misamoylov @fwiesel
-/openstack/tempest/keystone-tempest                    @misamoylov @fwiesel @rajivmucheli
-/openstack/tempest/manila-tempest                      @kpawar-sap @misamoylov @fwiesel
-/openstack/tempest/neutron-tempest                     @misamoylov @fwiesel
-/openstack/tempest/nova-tempest                        @misamoylov @fwiesel
-/openstack/tempest/octavia-tempest                     @misamoylov @fwiesel
-/openstack/tempest/tempest-base                        @misamoylov @fwiesel @stefanhipfel
+/openstack/tempest/barbican-tempest                    @misamoylov @fwiesel @rajivmucheli @galkindmitrii
+/openstack/tempest/cinder-tempest                      @misamoylov @fwiesel @galkindmitrii
+/openstack/tempest/designate-tempest                   @misamoylov @fwiesel @galkindmitrii
+/openstack/tempest/glance-tempest                      @misamoylov @fwiesel @rajivmucheli @galkindmitrii
+/openstack/tempest/ironic-tempest                      @misamoylov @fwiesel @galkindmitrii
+/openstack/tempest/keystone-tempest                    @misamoylov @fwiesel @rajivmucheli @galkindmitrii
+/openstack/tempest/manila-tempest                      @kpawar-sap @misamoylov @fwiesel @galkindmitrii
+/openstack/tempest/neutron-tempest                     @misamoylov @fwiesel @galkindmitrii
+/openstack/tempest/nova-tempest                        @misamoylov @fwiesel @galkindmitrii
+/openstack/tempest/octavia-tempest                     @misamoylov @fwiesel @galkindmitrii
+/openstack/tempest/tempest-base                        @misamoylov @fwiesel @stefanhipfel @galkindmitrii
 /openstack/trust-manager                               @fwiesel
 /openstack/utils                                       @fwiesel @notandy @galkindmitrii @Carthaca @joker-at-work
 /openstack/vcenter-operator                            @joker-at-work @fwiesel @databus23

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -92,8 +92,8 @@
 /openstack/lyra                                        @databus23 @ArtieReus
 /openstack/maia                                        @artherd42 @viennaa @richardtief @Kuckkuck @dhalimi1975
 /openstack/manila                                      @Carthaca @chuan137 @galkindmitrii @kpawar-sap
-/openstack/manila-antelope                             @Carthaca @dusandordevicsap
-/openstack/manila-nanny                                @chuan137 @Carthaca @dusandordevicsap
+/openstack/manila-antelope                             @Carthaca @chuan137 @galkindmitrii @kpawar-sap
+/openstack/manila-nanny                                @Carthaca @chuan137 @galkindmitrii @kpawar-sap
 /openstack/nannies                                     @thgrs @chuan137 @Carthaca @fwiesel @kpawar-sap
 /openstack/neutron                                     @notandy @fwiesel @sebageek @sven-rosenzweig @rhalina @swagner-de @mutax @BenjaminLudwigSAP @m-kratochvil @occamshatchet
 /openstack/nova                                        @joker-at-work @fwiesel @grandchild @leust

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,7 @@
 /common/inventory-updater                              @BerndKue
 /common/linkerd-support                                @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /common/manila-provisioner                             @jknipper  # old
-/common/mariadb                                        @galkindmitrii @stefanhipfel @Carthaca @IvoGoman @fwiesel
+/common/mariadb                                        @galkindmitrii @stefanhipfel @Carthaca @IvoGoman @fwiesel @businessbean
 /common/memcached                                      @auhlig @businessbean @bashar-alkhateeb
 /common/mysql_metrics                                  @galkindmitrii @Carthaca
 /common/nats                                           @notandy
@@ -23,8 +23,8 @@
 /common/prometheus-pushgateway                         @viennaa
 /common/prometheus-server                              @auhlig @viennaa @databus23 @richardtief @defo89
 /common/prometheus-server-pre7                         @viennaa @richardtief @auhlig @defo89
-/common/rabbitmq                                       @galkindmitrii @fwiesel @Carthaca @bashar-alkhateeb @dusandordevicsap
-/common/rabbitmq_cluster                               @galkindmitrii @notandy @defo89
+/common/rabbitmq                                       @galkindmitrii @fwiesel @Carthaca @bashar-alkhateeb @dusandordevicsap @businessbean
+/common/rabbitmq_cluster                               @galkindmitrii @notandy @defo89 @businessbean
 /common/redis                                          @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /common/staging/rabbitmq                               @notandy @Carthaca  # old
 /common/thanos                                         @viennaa @richardtief
@@ -137,9 +137,9 @@
 /prometheus-exporters/documentation-prober             @dhalimi1975  # old
 /prometheus-exporters/event-exporter                   @jknipper @databus23
 /prometheus-exporters/hermes-query-exporter            @Kuckkuck @notque
-/prometheus-exporters/ipmi-exporter                    @stefanhipfel @BerndKue @sandzwerg 
+/prometheus-exporters/ipmi-exporter                    @stefanhipfel @BerndKue @sandzwerg
 /prometheus-exporters/ipmi-service-discovery           @auhlig  # old
-/prometheus-exporters/ironic-exporter                  @BerndKue @stefanhipfel @sandzwerg 
+/prometheus-exporters/ironic-exporter                  @BerndKue @stefanhipfel @sandzwerg
 
 /prometheus-exporters/jumpserver-exporter              @viennaa
 /prometheus-exporters/k8s-secrets-certificate-exporter @auhlig @databus23 @jknipper
@@ -157,7 +157,7 @@
 /prometheus-exporters/openstack-exporter               @viennaa @hemna @crenduchinta88 @kevin-fischer
 /prometheus-exporters/ping-exporter                    @auhlig @defo89  # old
 /prometheus-exporters/poller-simulator                 @dhalimi1975 @corey-aloia
-/prometheus-exporters/redfish-exporter                 @BerndKue @stefanhipfel @sandzwerg 
+/prometheus-exporters/redfish-exporter                 @BerndKue @stefanhipfel @sandzwerg
 /prometheus-exporters/snmp-exporter                    @Kuckkuck @swagner-de @m-kratochvil @IvoGoman @defo89
 /prometheus-exporters/snmp-ntp-exporter                @geisslet
 /prometheus-exporters/statsd-exporter                  @artherd42 @thgrs @ashifnihalb

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,19 +5,19 @@
 
 /common/helm3-helper                                   @SchwarzM  # old
 /common/inventory-updater                              @BerndKue @stanislav-zaprudskiy
-/common/linkerd-support                                @majewsky @SuperSandro2000 @VoigtS
+/common/linkerd-support                                @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /common/manila-provisioner                             @jknipper  # old
 /common/mariadb                                        @galkindmitrii @stefanhipfel @Carthaca @IvoGoman @fwiesel
 /common/memcached                                      @auhlig @businessbean @bashar-alkhateeb
 /common/mysql_metrics                                  @galkindmitrii @Carthaca
 /common/nats                                           @notandy
-/common/owner-info                                     @majewsky @SuperSandro2000 @VoigtS
-/common/pgbackup                                       @majewsky @SuperSandro2000 @VoigtS
-/common/pgmetrics                                      @majewsky @SuperSandro2000 @VoigtS
-/common/postgresql                                     @majewsky @SuperSandro2000 @VoigtS
-/common/postgresql-ng                                  @majewsky @SuperSandro2000 @VoigtS
-/common/postgresql-ng-test                             @majewsky @SuperSandro2000 @VoigtS
-/common/postgresql-test                                @majewsky @SuperSandro2000 @VoigtS
+/common/owner-info                                     @majewsky @SuperSandro2000 @VoigtS @Nuckal777
+/common/pgbackup                                       @majewsky @SuperSandro2000 @VoigtS @Nuckal777
+/common/pgmetrics                                      @majewsky @SuperSandro2000 @VoigtS @Nuckal777
+/common/postgresql                                     @majewsky @SuperSandro2000 @VoigtS @Nuckal777
+/common/postgresql-ng                                  @majewsky @SuperSandro2000 @VoigtS @Nuckal777
+/common/postgresql-ng-test                             @majewsky @SuperSandro2000 @VoigtS @Nuckal777
+/common/postgresql-test                                @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /common/prometheus-alertmanager-base                   @auhlig @viennaa @uwe-mayer @richardtief
 /common/prometheus-monitors                            @IvoGoman
 /common/prometheus-pushgateway                         @viennaa
@@ -25,14 +25,14 @@
 /common/prometheus-server-pre7                         @viennaa @richardtief @auhlig @defo89
 /common/rabbitmq                                       @galkindmitrii @fwiesel @Carthaca @bashar-alkhateeb @dusandordevicsap
 /common/rabbitmq_cluster                               @galkindmitrii @notandy @defo89
-/common/redis                                          @majewsky @SuperSandro2000 @VoigtS
+/common/redis                                          @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /common/staging/rabbitmq                               @notandy @Carthaca  # old
 /common/thanos                                         @viennaa @richardtief
 
 /global/andromeda                                      @notandy
 /global/bootcfg                                        @BugRoger  # old
-/global/ccloud-hedgedoc                                @majewsky @SuperSandro2000 @VoigtS
-/global/chartmuseum-sapcc                              @auhlig @majewsky @SuperSandro2000 @VoigtS
+/global/ccloud-hedgedoc                                @majewsky @SuperSandro2000 @VoigtS @Nuckal777
+/global/chartmuseum-sapcc                              @auhlig @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /global/concourse-main                                 @jknipper @andypf
 /global/concourse-worker                               @databus23 @kayrus  # old
 /global/geminabox                                      @databus23
@@ -50,26 +50,26 @@
 /global/supernova                                      @andypf @ArtieReus @auhlig @databus23
 /global/thanos-global                                  @viennaa @richardtief
 /global/vault                                          @BugRoger  # old
-/global/vault-tec                                      @Nuckal777
+/global/vault-tec                                      @Nuckal777 @majewsky @SuperSandro2000 @VoigtS
 /global/volta                                          @dimtass @databus23
 /global/wham                                           @databus23
 
 /openstack/andromeda-seed                              @notandy
 /openstack/arc                                         @databus23 @ArtieReus @fwiesel
 /openstack/archer                                      @notandy
-/openstack/backup-replication                          @majewsky @SuperSandro2000 @VoigtS
+/openstack/backup-replication                          @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /openstack/barbican                                    @galkindmitrii @fwiesel @rajivmucheli @bashar-alkhateeb
 /openstack/baremetal-temper                            @databus23 @fwiesel @BerndKue
 /openstack/bastion                                     @fwiesel
-/openstack/billing                                     @majewsky @SuperSandro2000 @VoigtS
+/openstack/billing                                     @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /openstack/blackbox                                    @artherd42 @fwiesel @m-kratochvil
-/openstack/castellum                                   @majewsky @SuperSandro2000 @VoigtS
+/openstack/castellum                                   @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /openstack/cbshelf                                     @corey-aloia
 /openstack/cc3test                                     @artherd42 @thgrs @ashifnihalb @Carthaca
 /openstack/cc3test-seeds                               @artherd42 @thgrs @fwiesel
 /openstack/cerebro                                     @viennaa
 /openstack/cinder                                      @joker-at-work @hemna @fwiesel @dusandordevicsap
-/openstack/content-repo                                @majewsky @SuperSandro2000 @VoigtS
+/openstack/content-repo                                @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /openstack/cronus                                      @kayrus @dhalimi @corey-aloia @fwiesel
 /openstack/cronus-seed                                 @kayrus @dhalimi
 /openstack/db-backup-v2                                @databus23 @fwiesel
@@ -82,13 +82,13 @@
 /openstack/hermes                                      @Kuckkuck @IvoGoman @fwiesel
 /openstack/infra-seeds/kubernetes                      @BugRoger  # old
 /openstack/ironic                                      @stefanhipfel @BerndKue @fwiesel @sandzwerg
-/openstack/keppel                                      @majewsky @SuperSandro2000 @VoigtS
-/openstack/keppel-trivy                                @majewsky @SuperSandro2000 @VoigtS
+/openstack/keppel                                      @majewsky @SuperSandro2000 @VoigtS @Nuckal777
+/openstack/keppel-trivy                                @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /openstack/keystone                                    @galkindmitrii @Carthaca @bbobrov @fwiesel @rajivmucheli
 /openstack/kos-operator                                @stefanhipfel @databus23
 /openstack/kubernetes                                  @fwiesel
 /openstack/kubernikus                                  @fwiesel @jknipper
-/openstack/limes                                       @majewsky @SuperSandro2000 @VoigtS
+/openstack/limes                                       @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /openstack/lyra                                        @databus23 @ArtieReus
 /openstack/maia                                        @artherd42 @viennaa @richardtief @Kuckkuck @dhalimi
 /openstack/manila                                      @Carthaca @chuan137 @galkindmitrii @kpawar-sap
@@ -151,7 +151,7 @@
 /prometheus-exporters/network-generic-ssh-exporter     @swagner-de @Kuckkuck @artherd42 @geisslet
 /prometheus-exporters/nfs-exporter                     @auhlig  # old
 /prometheus-exporters/ns-exporter                      @databus23
-/prometheus-exporters/ntp-exporter                     @majewsky @SuperSandro2000 @VoigtS
+/prometheus-exporters/ntp-exporter                     @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /prometheus-exporters/octobus-query-exporter           @max-len @IvoGoman @Kuckkuck @christopherhans @kevin-fischer
 /prometheus-exporters/oomkill-exporter                 @jknipper @defo89
 /prometheus-exporters/opensearch-logs-query-exporter   @Kuckkuck @dimtass @chuan137 @databus23
@@ -178,7 +178,7 @@
 /px/bird                                               @swagner-de @dusandordevicsap @rhalina @defo89
 /px/lg                                                 @rhalina @swagner-de
 
-/system/absent-metrics-operator                        @majewsky @SuperSandro2000 @VoigtS
+/system/absent-metrics-operator                        @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /system/ai-cloud-guard                                 @darpan92
 /system/atlas                                          @BerndKue @Kuckkuck @viennaa @stefanhipfel @artherd42
 /system/audit-logs                                     @IvoGoman @Kuckkuck @jknipper @artherd42 @richardtief
@@ -202,18 +202,18 @@
 /system/descheduler                                    @auhlig @defo89
 /system/digicert-issuer                                @jknipper @auhlig @kayrus
 /system/disco                                          @auhlig @defo89 @databus23
-/system/doop-central                                   @majewsky @SuperSandro2000 @VoigtS
+/system/doop-central                                   @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /system/elk                                            @Kuckkuck @IvoGoman
 /system/externalip-operator                            @defo89
-/system/flatcar-linux-update-agent                     @Nuckal777 @defo89
+/system/flatcar-linux-update-agent                     @Nuckal777 @defo89 @majewsky @SuperSandro2000 @VoigtS
 /system/frrouting                                      @defo89
-/system/gatekeeper                                     @majewsky @SuperSandro2000 @VoigtS
-/system/gatekeeper-config                              @majewsky @SuperSandro2000 @VoigtS
+/system/gatekeeper                                     @majewsky @SuperSandro2000 @VoigtS @Nuckal777
+/system/gatekeeper-config                              @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /system/go-pmtud                                       @defo89
 /system/grafana-dashboards-kubernetes                  @auhlig @databus23
 /system/greenhouse-ccloud                              @auhlig @IvoGoman
-/system/hubcopter                                      @majewsky @SuperSandro2000 @VoigtS
-/system/hubcopter-seeds                                @majewsky @SuperSandro2000 @VoigtS
+/system/hubcopter                                      @majewsky @SuperSandro2000 @VoigtS @Nuckal777
+/system/hubcopter-seeds                                @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /system/infra-monitoring                               @artherd42 @viennaa @BerndKue @swagner-de @Kuckkuck
 /system/ipmasq                                         @defo89
 /system/jaeger-operator                                @chuan137 @misamoylov @Kuckkuck
@@ -247,8 +247,8 @@
 /system/kubernikus-monitoring                          @uwe-mayer @databus23 @jknipper @Nuckal777
 /system/kubernikus-rbac                                @databus23
 /system/ldap-named-user                                @defo89
-/system/maintenance-controller                         @Nuckal777 @defo89
 /system/logs                                           @Kuckkuck @IvoGoman @businessbean @corey-aloia
+/system/maintenance-controller                         @Nuckal777 @defo89 @majewsky @SuperSandro2000 @VoigtS
 /system/manila-csi-plugin                              @jknipper
 /system/metallb                                        @defo89  # old
 /system/metis                                          @IvoGoman @richardtief
@@ -270,8 +270,8 @@
 /system/provider-kubernikus                            @defo89
 /system/provider-metal3                                @defo89 @Nuckal777
 /system/rabbitmq-operator                              @galkindmitrii
-/system/runtime-extension-maintenance-controller       @Nuckal777 @defo89
-/system/secrets-injector                               @Nuckal777
+/system/runtime-extension-maintenance-controller       @Nuckal777 @defo89 @majewsky @SuperSandro2000 @VoigtS
+/system/secrets-injector                               @Nuckal777 @majewsky @SuperSandro2000 @VoigtS
 /system/sentry                                         @databus23 @notandy @rajivmucheli
 /system/servicemesh                                    @jknipper
 /system/smee-dynakratos                                @defo89 @SchwarzM
@@ -279,8 +279,8 @@
 /system/sysctl                                         @defo89
 /system/sysstat                                        @defo89
 /system/tarslite                                       @darpan92 @max-len @christopherhans
-/system/tenso                                          @majewsky @SuperSandro2000 @VoigtS
-/system/tenso-seeds                                    @majewsky @SuperSandro2000 @VoigtS
+/system/tenso                                          @majewsky @SuperSandro2000 @VoigtS @Nuckal777
+/system/tenso-seeds                                    @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /system/thanos-metal                                   @richardtief @viennaa
 /system/thanos-operator                                @viennaa
 /system/thanos-scaleout                                @richardtief @viennaa
@@ -289,8 +289,8 @@
 /system/unbound                                        @galkindmitrii @vssldmtrv @dhoeller @mutax @defo89
 /system/validation                                     @artherd42 @thgrs @ashifnihalb
 /system/velero                                         @databus23 @jknipper  # old
-/system/vertical-pod-autoscaler                        @Nuckal777
+/system/vertical-pod-autoscaler                        @Nuckal777 @majewsky @SuperSandro2000 @VoigtS
 /system/vice-president                                 @databus23
 /system/vmware-monitoring                              @viennaa @richardtief @christopherhans @himanip94 @kevin-fischer
-/system/vpa-butler                                     @Nuckal777
+/system/vpa-butler                                     @Nuckal777 @majewsky @SuperSandro2000 @VoigtS
 /system/wormhole                                       @defo89

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -137,9 +137,10 @@
 /prometheus-exporters/documentation-prober             @dhalimi1975  # old
 /prometheus-exporters/event-exporter                   @jknipper @databus23
 /prometheus-exporters/hermes-query-exporter            @Kuckkuck @notque
-/prometheus-exporters/ipmi-exporter                    @stefanhipfel @BerndKue
+/prometheus-exporters/ipmi-exporter                    @stefanhipfel @BerndKue @sandzwerg 
 /prometheus-exporters/ipmi-service-discovery           @auhlig  # old
-/prometheus-exporters/ironic-exporter                  @BerndKue @stefanhipfel
+/prometheus-exporters/ironic-exporter                  @BerndKue @stefanhipfel @sandzwerg 
+
 /prometheus-exporters/jumpserver-exporter              @viennaa
 /prometheus-exporters/k8s-secrets-certificate-exporter @auhlig @databus23 @jknipper
 /prometheus-exporters/kube-state-metrics-exporter      @richardtief
@@ -156,7 +157,7 @@
 /prometheus-exporters/openstack-exporter               @viennaa @hemna @crenduchinta88 @kevin-fischer
 /prometheus-exporters/ping-exporter                    @auhlig @defo89  # old
 /prometheus-exporters/poller-simulator                 @dhalimi1975 @corey-aloia
-/prometheus-exporters/redfish-exporter                 @BerndKue @stefanhipfel
+/prometheus-exporters/redfish-exporter                 @BerndKue @stefanhipfel @sandzwerg 
 /prometheus-exporters/snmp-exporter                    @Kuckkuck @swagner-de @m-kratochvil @IvoGoman @defo89
 /prometheus-exporters/snmp-ntp-exporter                @geisslet
 /prometheus-exporters/statsd-exporter                  @artherd42 @thgrs @ashifnihalb

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -76,7 +76,7 @@
 /openstack/designate                                   @galkindmitrii @fwiesel @mutax @kpawar-sap @vssldmtrv @mbrowny @SoenkeL @occamshatchet
 /openstack/designate-nanny                             @mutax @vssldmtrv @mbrowny @SoenkeL @galkindmitrii @occamshatchet
 /openstack/domain-seeds                                @BerndKue @Carthaca @fwiesel @Kuckkuck @rajivmucheli
-/openstack/elektra                                     @andypf @databus23 @ArtieReus @hgw77
+/openstack/elektra                                     @andypf @edda @ArtieReus @hgw77
 /openstack/glance                                      @fwiesel @galkindmitrii @rajivmucheli @Carthaca
 /openstack/grafanasix                                  @thgrs @richardtief
 /openstack/hermes                                      @notque @Kuckkuck @IvoGoman @fwiesel

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,7 +47,7 @@
 /global/prometheus-uber                                @auhlig  # old
 /global/schedules2slack                                @geisslet
 /global/slack-alert-reactions                          @uwe-mayer
-/global/supernova                                      @andypf @ArtieReus @auhlig @databus23
+/global/supernova                                      @andypf @ArtieReus @edda @hgw
 /global/thanos-global                                  @viennaa @richardtief
 /global/vault                                          @BugRoger  # old
 /global/vault-tec                                      @Nuckal777 @majewsky @SuperSandro2000 @VoigtS

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -136,7 +136,7 @@
 /prometheus-exporters/cronus-updater                   @dhalimi1975
 /prometheus-exporters/documentation-prober             @dhalimi1975  # old
 /prometheus-exporters/event-exporter                   @jknipper @databus23
-/prometheus-exporters/hermes-query-exporter            @Kuckkuck @notque
+/prometheus-exporters/hermes-query-exporter            @Kuckkuck @notque @timojohlo
 /prometheus-exporters/ipmi-exporter                    @stefanhipfel @BerndKue @sandzwerg
 /prometheus-exporters/ipmi-service-discovery           @auhlig  # old
 /prometheus-exporters/ironic-exporter                  @BerndKue @stefanhipfel @sandzwerg
@@ -147,13 +147,13 @@
 /prometheus-exporters/kubelet-stats-metrics            @jknipper
 /prometheus-exporters/masterdata-exporter              @databus23
 /prometheus-exporters/netapp-exporter                  @chuan137 @Carthaca @grandchild @stefanhipfel
-/prometheus-exporters/network-generic-ssh-exporter     @swagner-de @Kuckkuck @artherd42 @geisslet
+/prometheus-exporters/network-generic-ssh-exporter     @swagner-de @Kuckkuck @IvoGoman @geisslet
 /prometheus-exporters/nfs-exporter                     @auhlig  # old
 /prometheus-exporters/ns-exporter                      @databus23
 /prometheus-exporters/ntp-exporter                     @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /prometheus-exporters/octobus-query-exporter           @max-len @IvoGoman @Kuckkuck @christopherhans @kevin-fischer
 /prometheus-exporters/oomkill-exporter                 @jknipper @defo89
-/prometheus-exporters/opensearch-logs-query-exporter   @Kuckkuck @dimtass @chuan137 @databus23
+/prometheus-exporters/opensearch-logs-query-exporter   @Kuckkuck @dimtass @chuan137 @databus23 @IvoGoman @timojohlo
 /prometheus-exporters/openstack-exporter               @viennaa @hemna @crenduchinta88 @kevin-fischer
 /prometheus-exporters/ping-exporter                    @auhlig @defo89  # old
 /prometheus-exporters/poller-simulator                 @dhalimi1975 @corey-aloia
@@ -246,7 +246,7 @@
 /system/kubernikus-monitoring                          @uwe-mayer @databus23 @jknipper @Nuckal777
 /system/kubernikus-rbac                                @databus23
 /system/ldap-named-user                                @defo89
-/system/logs                                           @Kuckkuck @IvoGoman @businessbean @corey-aloia
+/system/logs                                           @Kuckkuck @IvoGoman @businessbean @corey-aloia @timojohlo @notque
 /system/maintenance-controller                         @Nuckal777 @defo89 @majewsky @SuperSandro2000 @VoigtS
 /system/manila-csi-plugin                              @jknipper
 /system/metallb                                        @defo89  # old
@@ -257,8 +257,8 @@
 /system/node-problem-detector                          @defo89 @databus23
 /system/nodecidr-controller                            @defo89
 /system/ntp-timeserver                                 @dhoeller  # old
-/system/opensearch-hermes                              @Kuckkuck @notque
-/system/opensearch-logs                                @Kuckkuck @IvoGoman @richardtief
+/system/opensearch-hermes                              @Kuckkuck @notque @timojohlo
+/system/opensearch-logs                                @Kuckkuck @IvoGoman @richardtief @timojohlo @notque
 /system/plutono                                        @richardtief @thgrs @misamoylov
 /system/priority-class                                 @galkindmitrii  # old
 /system/prober-static                                  @defo89

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,14 +4,20 @@
 /ci                                                    @auhlig @Kuckkuck @businessbean @jknipper @fwiesel
 
 /common/helm3-helper                                   @SchwarzM  # old
+/common/inventory-updater                              @BerndKue @stanislav-zaprudskiy
+/common/linkerd-support                                @majewsky @SuperSandro2000 @viennaa
 /common/manila-provisioner                             @jknipper  # old
 /common/mariadb                                        @galkindmitrii @stefanhipfel @Carthaca @IvoGoman @fwiesel
 /common/memcached                                      @auhlig @businessbean @majewsky @SuperSandro2000 @bashar-alkhateeb
 /common/mysql_metrics                                  @galkindmitrii @Carthaca
 /common/nats                                           @notandy
 /common/owner-info                                     @majewsky @SuperSandro2000
+/common/pgbackup                                       @majewsky @SuperSandro2000 @ArtieReus @VoigtS
 /common/pgmetrics                                      @majewsky @SuperSandro2000 @VoigtS
 /common/postgresql                                     @majewsky @fwiesel @auhlig @VoigtS @SuperSandro2000
+/common/postgresql-ng                                  @SuperSandro2000 @majewsky @stanislav-zaprudskiy @jknipper @stefanhipfel
+/common/postgresql-ng-test                             @SuperSandro2000 @majewsky
+/common/postgresql-test                                @majewsky @SuperSandro2000
 /common/prometheus-alertmanager-base                   @auhlig @viennaa @uwe-mayer @majewsky @richardtief
 /common/prometheus-monitors                            @IvoGoman
 /common/prometheus-pushgateway                         @viennaa @majewsky
@@ -22,40 +28,35 @@
 /common/redis                                          @SuperSandro2000 @majewsky @auhlig @VoigtS @fwiesel
 /common/staging/rabbitmq                               @majewsky @notandy @Carthaca  # old
 /common/thanos                                         @viennaa @richardtief @majewsky @SuperSandro2000
-/common/pgbackup                                       @majewsky @SuperSandro2000 @ArtieReus @VoigtS
-/common/inventory-updater                              @BerndKue @stanislav-zaprudskiy
-/common/postgresql-test                                @majewsky @SuperSandro2000
-/common/linkerd-support                                @majewsky @SuperSandro2000 @viennaa
-/common/postgresql-ng-test                             @SuperSandro2000 @majewsky
-/common/postgresql-ng                                  @SuperSandro2000 @majewsky @stanislav-zaprudskiy @jknipper @stefanhipfel
 
 /global/andromeda                                      @notandy @majewsky
 /global/bootcfg                                        @BugRoger  # old
+/global/ccloud-hedgedoc                                @majewsky @SuperSandro2000 @sebageek
 /global/chartmuseum-sapcc                              @auhlig @majewsky @SuperSandro2000 @reimannf
 /global/concourse-main                                 @jknipper @majewsky @SuperSandro2000 @andypf
 /global/concourse-worker                               @databus23 @kayrus  # old
 /global/geminabox                                      @databus23
+/global/gh-actions                                     @notandy @auhlig
 /global/git-cert-shim                                  @majewsky @auhlig
+/global/kibana-objecter                                @dimtass
 /global/oauth-proxy                                    @andypf @majewsky @ArtieReus @databus23
 /global/percona_cluster                                @galkindmitrii @defo89
 /global/prometheus-alertmanager-cnmp                   @auhlig @majewsky
 /global/prometheus-alertmanager-operated               @geisslet @auhlig @uwe-mayer @viennaa @majewsky
 /global/prometheus-infra                               @artherd42 @Kuckkuck @viennaa @richardtief @BerndKue
 /global/prometheus-uber                                @auhlig  # old
+/global/schedules2slack                                @geisslet
 /global/slack-alert-reactions                          @uwe-mayer
 /global/supernova                                      @andypf @majewsky @ArtieReus @auhlig @databus23
 /global/thanos-global                                  @viennaa @richardtief
 /global/vault                                          @BugRoger  # old
+/global/vault-tec                                      @Nuckal777
 /global/volta                                          @dimtass @databus23
 /global/wham                                           @databus23
-/global/ccloud-hedgedoc                                @majewsky @SuperSandro2000 @sebageek
-/global/kibana-objecter                                @dimtass
-/global/gh-actions                                     @notandy @auhlig
-/global/vault-tec                                      @Nuckal777
-/global/schedules2slack                                @geisslet
 
 /openstack/andromeda-seed                              @notandy @majewsky
 /openstack/arc                                         @databus23 @ArtieReus @majewsky @SuperSandro2000 @fwiesel
+/openstack/archer                                      @notandy @majewsky
 /openstack/backup-replication                          @majewsky @SuperSandro2000 @VoigtS
 /openstack/barbican                                    @galkindmitrii @fwiesel @majewsky @rajivmucheli @bashar-alkhateeb
 /openstack/baremetal-temper                            @majewsky @databus23 @fwiesel @BerndKue
@@ -63,6 +64,7 @@
 /openstack/billing                                     @majewsky @reimannf
 /openstack/blackbox                                    @artherd42 @majewsky @fwiesel @reimannf @m-kratochvil
 /openstack/castellum                                   @majewsky @SuperSandro2000 @VoigtS @richardtief
+/openstack/cbshelf                                     @corey-aloia @majewsky
 /openstack/cc3test                                     @artherd42 @thgrs @ashifnihalb @majewsky @Carthaca
 /openstack/cc3test-seeds                               @artherd42 @thgrs @fwiesel @reimannf
 /openstack/cerebro                                     @viennaa @majewsky
@@ -72,6 +74,7 @@
 /openstack/cronus-seed                                 @kayrus @dhalimi @majewsky
 /openstack/db-backup-v2                                @databus23 @fwiesel
 /openstack/designate                                   @galkindmitrii @fwiesel @majewsky @mutax @kpawar-sap
+/openstack/designate-nanny                             @mutax
 /openstack/domain-seeds                                @BerndKue @majewsky @Carthaca @fwiesel @Kuckkuck
 /openstack/elektra                                     @andypf @majewsky @databus23 @ArtieReus @hgw77
 /openstack/glance                                      @fwiesel @galkindmitrii @majewsky @rajivmucheli @Carthaca
@@ -80,6 +83,7 @@
 /openstack/infra-seeds/kubernetes                      @BugRoger  # old
 /openstack/ironic                                      @stefanhipfel @BerndKue @fwiesel @sandzwerg @majewsky
 /openstack/keppel                                      @majewsky @SuperSandro2000 @reimannf @VoigtS @geisslet
+/openstack/keppel-trivy                                @SuperSandro2000 @majewsky @VoigtS
 /openstack/keystone                                    @galkindmitrii @Carthaca @bbobrov @majewsky @fwiesel
 /openstack/kos-operator                                @stefanhipfel @databus23
 /openstack/kubernetes                                  @fwiesel
@@ -88,14 +92,19 @@
 /openstack/lyra                                        @databus23 @ArtieReus @majewsky @reimannf @SuperSandro2000
 /openstack/maia                                        @artherd42 @viennaa @richardtief @Kuckkuck @dhalimi
 /openstack/manila                                      @Carthaca @chuan137 @galkindmitrii @majewsky @kpawar-sap
+/openstack/manila-antelope                             @Carthaca @dusandordevicsap
+/openstack/manila-nanny                                @chuan137 @Carthaca @dusandordevicsap
 /openstack/nannies                                     @thgrs @chuan137 @Carthaca @fwiesel @kpawar-sap
 /openstack/neutron                                     @notandy @fwiesel @sebageek @majewsky @sven-rosenzweig
 /openstack/nova                                        @joker-at-work @fwiesel @grandchild @majewsky @leust
 /openstack/octavia                                     @notandy @BenjaminLudwigSAP @fwiesel @majewsky @dusandordevicsap
 /openstack/octobus                                     @majewsky @viennaa
 /openstack/openstack-seeder                            @stefanhipfel @databus23 @fwiesel
+/openstack/openstack_performance                       @misamoylov
 /openstack/placement                                   @fwiesel @joker-at-work @bashar-alkhateeb @galkindmitrii @reimannf
+/openstack/poller                                      @dhalimi @corey-aloia
 /openstack/prometheus-openstack                        @viennaa @artherd42 @richardtief @Kuckkuck @majewsky
+/openstack/pyroscope                                   @fwiesel
 /openstack/sap-seeds                                   @dhoeller @grandchild @frr2018 @joker-at-work @fwiesel
 /openstack/sre                                         @artherd42 @fwiesel
 /openstack/swift                                       @reimannf @majewsky @SuperSandro2000 @talal @crenduchinta88
@@ -112,26 +121,19 @@
 /openstack/tempest/nova-tempest                        @misamoylov @majewsky @fwiesel
 /openstack/tempest/octavia-tempest                     @misamoylov @fwiesel @majewsky
 /openstack/tempest/tempest-base                        @misamoylov @fwiesel @stefanhipfel
+/openstack/trust-manager                               @fwiesel
 /openstack/utils                                       @fwiesel @notandy @galkindmitrii @Carthaca @joker-at-work
 /openstack/vcenter-operator                            @joker-at-work @fwiesel @majewsky @databus23
 /openstack/vcf                                         @chuan137
 /openstack/volume-claims                               @majewsky @fwiesel
-/openstack/archer                                      @notandy @majewsky
-/openstack/cbshelf                                     @corey-aloia @majewsky
-/openstack/keppel-trivy                                @SuperSandro2000 @majewsky @VoigtS
-/openstack/openstack_performance                       @misamoylov
-/openstack/manila-nanny                                @chuan137 @Carthaca @dusandordevicsap
-/openstack/poller                                      @dhalimi @corey-aloia
-/openstack/designate-nanny                             @mutax
-/openstack/manila-antelope                             @Carthaca @dusandordevicsap
-/openstack/pyroscope                                   @fwiesel
-/openstack/trust-manager                               @fwiesel
 
 /prometheus-exporters/apic-exporter                    @artherd42 @IvoGoman @geisslet
 /prometheus-exporters/arista-exporter                  @BerndKue @stanislav-zaprudskiy @stefanhipfel
 /prometheus-exporters/blackbox-exporter                @defo89 @databus23
 /prometheus-exporters/cloudprober                      @artherd42 @defo89
 /prometheus-exporters/cronus-exporter                  @dhalimi @majewsky @LimorGargir @richardtief @geisslet
+/prometheus-exporters/cronus-openstack-alerts          @dhalimi
+/prometheus-exporters/cronus-reporter                  @dhalimi
 /prometheus-exporters/cronus-simulator                 @dhalimi @majewsky
 /prometheus-exporters/cronus-updater                   @dhalimi @majewsky
 /prometheus-exporters/documentation-prober             @dhalimi @majewsky  # old
@@ -143,6 +145,8 @@
 /prometheus-exporters/jumpserver-exporter              @viennaa
 /prometheus-exporters/k8s-secrets-certificate-exporter @auhlig @majewsky @databus23 @jknipper
 /prometheus-exporters/kube-state-metrics-exporter      @richardtief
+/prometheus-exporters/kubelet-stats-metrics            @jknipper
+/prometheus-exporters/masterdata-exporter              @databus23
 /prometheus-exporters/netapp-exporter                  @chuan137 @Carthaca @majewsky @grandchild @stefanhipfel
 /prometheus-exporters/network-generic-ssh-exporter     @swagner-de @Kuckkuck @artherd42 @geisslet
 /prometheus-exporters/nfs-exporter                     @auhlig @majewsky  # old
@@ -150,6 +154,7 @@
 /prometheus-exporters/ntp-exporter                     @majewsky @SuperSandro2000 @jknipper
 /prometheus-exporters/octobus-query-exporter           @max-len @IvoGoman @Kuckkuck @christopherhans @kevin-fischer
 /prometheus-exporters/oomkill-exporter                 @jknipper @defo89 @majewsky
+/prometheus-exporters/opensearch-logs-query-exporter   @Kuckkuck @dimtass @chuan137 @databus23
 /prometheus-exporters/openstack-exporter               @viennaa @hemna @majewsky @crenduchinta88 @kevin-fischer
 /prometheus-exporters/ping-exporter                    @majewsky @auhlig @defo89  # old
 /prometheus-exporters/poller-simulator                 @dhalimi @corey-aloia @majewsky
@@ -161,45 +166,59 @@
 /prometheus-exporters/tempest-exporter                 @misamoylov
 /prometheus-exporters/ucs-exporter                     @BerndKue @viennaa @richardtief
 /prometheus-exporters/watchcache-exporter              @jknipper @databus23
-/prometheus-exporters/cronus-openstack-alerts          @dhalimi
-/prometheus-exporters/cronus-reporter                  @dhalimi
-/prometheus-exporters/masterdata-exporter              @databus23
-/prometheus-exporters/opensearch-logs-query-exporter   @Kuckkuck @dimtass @chuan137 @databus23
-/prometheus-exporters/kubelet-stats-metrics            @jknipper
 
 /prometheus-rules/prometheus-controlplane-rules        @defo89 @artherd42 @majewsky @SuperSandro2000
 /prometheus-rules/prometheus-kubernetes-rules          @auhlig @databus23 @defo89 @businessbean @majewsky
+/prometheus-rules/prometheus-openstack-rules           @artherd42 @richardtief
 /prometheus-rules/prometheus-scaleout-rules            @auhlig  # old
 /prometheus-rules/prometheus-virtual-rules             @BugRoger  # old
 /prometheus-rules/prometheus-vmware-rules              @kevin-fischer @christopherhans @max-len @richardtief @himanip94
-/prometheus-rules/prometheus-openstack-rules           @artherd42 @richardtief
 
+/px/arp-discovery                                      @swagner-de
 /px/bird                                               @swagner-de @dusandordevicsap @rhalina @defo89
 /px/lg                                                 @rhalina @swagner-de @majewsky
-/px/arp-discovery                                      @swagner-de
 
 /system/absent-metrics-operator                        @talal @SuperSandro2000 @majewsky @VoigtS
+/system/ai-cloud-guard                                 @darpan92
+/system/atlas                                          @BerndKue @Kuckkuck @viennaa @stefanhipfel @artherd42
 /system/audit-logs                                     @IvoGoman @Kuckkuck @jknipper @artherd42 @richardtief
 /system/auditbeat                                      @jknipper @IvoGoman @Kuckkuck
 /system/aws-ecr-creds-helper                           @defo89  # old
+/system/baremetal-operator                             @defo89
+/system/baremetal-operator-core                        @defo89
 /system/bind                                           @galkindmitrii @mutax @mbrowny @defo89
+/system/bootstrap-kubeadm                              @defo89 @Nuckal777
+/system/calico                                         @defo89
+/system/calico-apiserver                               @defo89
+/system/calico-cni                                     @defo89
+/system/cc-cluster                                     @defo89
 /system/cc-rbac                                        @databus23 @Nuckal777 @swagner-de
 /system/ccauth                                         @onuryilmaz @databus23
 /system/cert-manager-crds                              @jknipper
+/system/cluster-api                                    @defo89 @Nuckal777
+/system/cluster-api-core                               @defo89 @Nuckal777
+/system/cni-nanny                                      @defo89
 /system/conntrack-nanny                                @defo89
 /system/descheduler                                    @auhlig @defo89 @majewsky
 /system/digicert-issuer                                @jknipper @auhlig @kayrus
 /system/disco                                          @auhlig @defo89 @databus23
 /system/doop-central                                   @majewsky @talal @SuperSandro2000 @auhlig @reimannf
 /system/elk                                            @Kuckkuck @IvoGoman @majewsky
+/system/externalip-operator                            @defo89
 /system/flatcar-linux-update-agent                     @Nuckal777 @defo89
 /system/frrouting                                      @defo89
 /system/gatekeeper                                     @majewsky @talal @SuperSandro2000 @Kuckkuck @IvoGoman
 /system/gatekeeper-config                              @majewsky @talal @SuperSandro2000
 /system/go-pmtud                                       @defo89
 /system/grafana-dashboards-kubernetes                  @auhlig @databus23
+/system/greenhouse-ccloud                              @auhlig @IvoGoman
+/system/hubcopter                                      @SuperSandro2000 @majewsky
+/system/hubcopter-seeds                                @SuperSandro2000 @majewsky
 /system/infra-monitoring                               @artherd42 @viennaa @BerndKue @swagner-de @Kuckkuck
+/system/ipmasq                                         @defo89
 /system/jaeger-operator                                @chuan137 @misamoylov @Kuckkuck
+/system/jupyter-cron-reports                           @timojohlo
+/system/jupyterhub                                     @timojohlo @majewsky @artherd42
 /system/k3s-backup                                     @defo89
 /system/k3s-restore                                    @defo89 @majewsky  # old
 /system/kube-cni                                       @defo89
@@ -216,6 +235,7 @@
 /system/kube-parrot                                    @defo89
 /system/kube-proxy                                     @defo89 @majewsky
 /system/kube-proxy-ng                                  @defo89
+/system/kube-system-addons                             @defo89
 /system/kube-system-admin-k3s                          @defo89 @Nuckal777 @jknipper @onuryilmaz @auhlig
 /system/kube-system-global                             @defo89 @kayrus @viennaa @auhlig @Nuckal777
 /system/kube-system-kubernikus                         @auhlig @Nuckal777 @jknipper @defo89 @databus23
@@ -238,20 +258,33 @@
 /system/node-problem-detector                          @defo89 @databus23
 /system/nodecidr-controller                            @defo89
 /system/ntp-timeserver                                 @dhoeller @majewsky  # old
+/system/opensearch-hermes                              @Kuckkuck @majewsky
+/system/opensearch-logs                                @Kuckkuck @IvoGoman @majewsky @richardtief
+/system/plutono                                        @richardtief @thgrs @majewsky @misamoylov
 /system/priority-class                                 @galkindmitrii  # old
 /system/prober-static                                  @defo89
 /system/prometheus-crds                                @auhlig @viennaa @richardtief
 /system/prometheus-infra                               @artherd42 @viennaa @richardtief @Kuckkuck @dhalimi
+/system/prometheus-kubernetes                          @viennaa @richardtief @Nuckal777
 /system/prometheus-operator                            @viennaa @majewsky @richardtief
+/system/provider-kubernikus                            @defo89
+/system/provider-metal3                                @defo89 @Nuckal777
 /system/rabbitmq-operator                              @galkindmitrii
+/system/runtime-extension-maintenance-controller       @Nuckal777
+/system/secrets-injector                               @Nuckal777
 /system/sentry                                         @majewsky @databus23 @notandy @SuperSandro2000
+/system/servicemesh                                    @jknipper @SuperSandro2000 @majewsky
+/system/smee-dynakratos                                @defo89 @SchwarzM @majewsky
+/system/storage-monitoring                             @viennaa @richardtief @artherd42 @geisslet
 /system/sysctl                                         @defo89
+/system/sysstat                                        @defo89
 /system/tarslite                                       @darpan92 @max-len @christopherhans @majewsky
 /system/tenso                                          @majewsky @SuperSandro2000 @VoigtS
 /system/tenso-seeds                                    @majewsky @reimannf
 /system/thanos-metal                                   @richardtief @viennaa
 /system/thanos-operator                                @viennaa
 /system/thanos-scaleout                                @richardtief @viennaa
+/system/thanos-seeds                                   @viennaa
 /system/tiller                                         @BugRoger @defo89 @majewsky  # old
 /system/toolbox-prepull                                @defo89 @SchwarzM
 /system/unbound                                        @galkindmitrii @vssldmtrv @dhoeller @mutax @defo89
@@ -259,39 +292,6 @@
 /system/velero                                         @majewsky @databus23 @jknipper  # old
 /system/vertical-pod-autoscaler                        @auhlig @Nuckal777 @majewsky
 /system/vice-president                                 @databus23
+/system/vmware-monitoring                              @viennaa @richardtief @christopherhans @himanip94 @kevin-fischer
 /system/vpa-butler                                     @Nuckal777 @auhlig @defo89 @jknipper
 /system/wormhole                                       @defo89
-/system/opensearch-logs                                @Kuckkuck @IvoGoman @majewsky @richardtief
-/system/vmware-monitoring                              @viennaa @richardtief @christopherhans @himanip94 @kevin-fischer
-/system/atlas                                          @BerndKue @Kuckkuck @viennaa @stefanhipfel @artherd42
-/system/hubcopter                                      @SuperSandro2000 @majewsky
-/system/hubcopter-seeds                                @SuperSandro2000 @majewsky
-/system/thanos-seeds                                   @viennaa
-/system/jupyterhub                                     @timojohlo @majewsky @artherd42
-/system/prometheus-kubernetes                          @viennaa @richardtief @Nuckal777
-/system/servicemesh                                    @jknipper @SuperSandro2000 @majewsky
-/system/storage-monitoring                             @viennaa @richardtief @artherd42 @geisslet
-/system/plutono                                        @richardtief @thgrs @majewsky @misamoylov
-/system/sysstat                                        @defo89
-/system/jupyter-cron-reports                           @timojohlo
-/system/opensearch-hermes                              @Kuckkuck @majewsky
-/system/smee-dynakratos                                @defo89 @SchwarzM @majewsky
-/system/ai-cloud-guard                                 @darpan92 @fyhan1
-/system/calico-apiserver                               @defo89
-/system/calico-cni                                     @defo89
-/system/calico                                         @defo89
-/system/cni-nanny                                      @defo89
-/system/externalip-operator                            @defo89
-/system/ipmasq                                         @defo89
-/system/baremetal-operator                             @defo89
-/system/bootstrap-kubeadm                              @defo89 @Nuckal777
-/system/cluster-api-core                               @defo89 @Nuckal777
-/system/cluster-api                                    @defo89 @Nuckal777
-/system/provider-kubernikus                            @defo89
-/system/provider-metal3                                @defo89 @Nuckal777
-/system/secrets-injector                               @Nuckal777
-/system/cc-cluster                                     @defo89
-/system/greenhouse-ccloud                              @auhlig @IvoGoman
-/system/baremetal-operator-core                        @defo89
-/system/kube-system-addons                             @defo89
-/system/runtime-extension-maintenance-controller       @Nuckal777

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,7 @@
 /common/inventory-updater                              @BerndKue
 /common/linkerd-support                                @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /common/manila-provisioner                             @jknipper  # old
-/common/mariadb                                        @galkindmitrii @stefanhipfel @Carthaca @IvoGoman @fwiesel @businessbean
+/common/mariadb                                        @galkindmitrii @stefanhipfel @Carthaca @IvoGoman @fwiesel @businessbean @occamshatchet
 /common/memcached                                      @auhlig @businessbean @bashar-alkhateeb
 /common/mysql-metrics                                  @galkindmitrii @Carthaca
 /common/nats                                           @notandy
@@ -40,7 +40,7 @@
 /global/git-cert-shim                                  @auhlig
 /global/kibana-objecter                                @dimtass
 /global/oauth-proxy                                    @andypf @ArtieReus @databus23
-/global/percona-cluster                                @galkindmitrii @defo89
+/global/percona-cluster                                @galkindmitrii @defo89 @occamshatchet
 /global/prometheus-alertmanager-cnmp                   @auhlig
 /global/prometheus-alertmanager-operated               @geisslet @auhlig @uwe-mayer @viennaa
 /global/prometheus-infra                               @artherd42 @Kuckkuck @viennaa @richardtief @BerndKue
@@ -72,8 +72,8 @@
 /openstack/cronus                                      @kayrus @dhalimi1975 @corey-aloia @fwiesel
 /openstack/cronus-seed                                 @kayrus @dhalimi1975
 /openstack/db-backup-v2                                @databus23 @fwiesel
-/openstack/designate                                   @galkindmitrii @fwiesel @mutax @kpawar-sap @vssldmtrv @mbrowny @SoenkeL
-/openstack/designate-nanny                             @mutax @vssldmtrv @mbrowny @SoenkeL @galkindmitrii
+/openstack/designate                                   @galkindmitrii @fwiesel @mutax @kpawar-sap @vssldmtrv @mbrowny @SoenkeL @occamshatchet
+/openstack/designate-nanny                             @mutax @vssldmtrv @mbrowny @SoenkeL @galkindmitrii @occamshatchet
 /openstack/domain-seeds                                @BerndKue @Carthaca @fwiesel @Kuckkuck @rajivmucheli
 /openstack/elektra                                     @andypf @databus23 @ArtieReus @hgw77
 /openstack/glance                                      @fwiesel @galkindmitrii @rajivmucheli @Carthaca
@@ -173,8 +173,8 @@
 /prometheus-rules/prometheus-vmware-rules              @kevin-fischer @christopherhans @max-len @richardtief @himanip94
 
 /px/arp-discovery                                      @swagner-de
-/px/bird                                               @swagner-de @dusandordevicsap @rhalina @defo89
-/px/lg                                                 @rhalina @swagner-de
+/px/bird                                               @swagner-de @dusandordevicsap @rhalina @defo89 @occamshatchet
+/px/lg                                                 @rhalina @swagner-de @occamshatchet
 
 /system/absent-metrics-operator                        @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /system/ai-cloud-guard                                 @darpan92
@@ -184,7 +184,7 @@
 /system/aws-ecr-creds-helper                           @defo89  # old
 /system/baremetal-operator                             @defo89
 /system/baremetal-operator-core                        @defo89
-/system/bind                                           @galkindmitrii @mutax @mbrowny @defo89 @vssldmtrv @SoenkeL
+/system/bind                                           @galkindmitrii @mutax @mbrowny @defo89 @vssldmtrv @SoenkeL @occamshatchet
 /system/bootstrap-kubeadm                              @defo89 @Nuckal777
 /system/calico                                         @defo89
 /system/calico-apiserver                               @defo89
@@ -284,7 +284,7 @@
 /system/thanos-scaleout                                @richardtief @viennaa
 /system/thanos-seeds                                   @viennaa
 /system/toolbox-prepull                                @defo89 @SchwarzM
-/system/unbound                                        @galkindmitrii @vssldmtrv @dhoeller @mutax @defo89 @mbrowny @SoenkeL
+/system/unbound                                        @galkindmitrii @vssldmtrv @dhoeller @mutax @defo89 @mbrowny @SoenkeL @occamshatchet
 /system/validation                                     @artherd42 @thgrs @ashifnihalb
 /system/velero                                         @databus23 @jknipper  # old
 /system/vertical-pod-autoscaler                        @Nuckal777 @majewsky @SuperSandro2000 @VoigtS

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -91,7 +91,7 @@
 /openstack/limes                                       @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /openstack/lyra                                        @databus23 @ArtieReus
 /openstack/maia                                        @notque @artherd42 @viennaa @richardtief @Kuckkuck @dhalimi1975
-/openstack/manila*                                     @Carthaca @chuan137 @galkindmitrii @kpawar-sap
+/openstack/manila*                                     @Carthaca @chuan137 @galkindmitrii @kpawar-sap @sumitarora2786 @crenduchinta88
 /openstack/nannies                                     @thgrs @chuan137 @Carthaca @fwiesel @kpawar-sap
 /openstack/neutron                                     @notandy @fwiesel @sebageek @sven-rosenzweig @rhalina @swagner-de @mutax @BenjaminLudwigSAP @m-kratochvil @occamshatchet
 /openstack/nova                                        @joker-at-work @fwiesel @grandchild @leust

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,19 +5,19 @@
 
 /common/helm3-helper                                   @SchwarzM  # old
 /common/inventory-updater                              @BerndKue @stanislav-zaprudskiy
-/common/linkerd-support                                @majewsky @SuperSandro2000 @viennaa
+/common/linkerd-support                                @majewsky @SuperSandro2000 @VoigtS
 /common/manila-provisioner                             @jknipper  # old
 /common/mariadb                                        @galkindmitrii @stefanhipfel @Carthaca @IvoGoman @fwiesel
 /common/memcached                                      @auhlig @businessbean @bashar-alkhateeb
 /common/mysql_metrics                                  @galkindmitrii @Carthaca
 /common/nats                                           @notandy
-/common/owner-info                                     @majewsky @SuperSandro2000
-/common/pgbackup                                       @majewsky @SuperSandro2000 @ArtieReus @VoigtS
+/common/owner-info                                     @majewsky @SuperSandro2000 @VoigtS
+/common/pgbackup                                       @majewsky @SuperSandro2000 @VoigtS
 /common/pgmetrics                                      @majewsky @SuperSandro2000 @VoigtS
-/common/postgresql                                     @majewsky @fwiesel @auhlig @VoigtS @SuperSandro2000
-/common/postgresql-ng                                  @SuperSandro2000 @majewsky @stanislav-zaprudskiy @jknipper @stefanhipfel
-/common/postgresql-ng-test                             @SuperSandro2000 @majewsky
-/common/postgresql-test                                @majewsky @SuperSandro2000
+/common/postgresql                                     @majewsky @SuperSandro2000 @VoigtS
+/common/postgresql-ng                                  @majewsky @SuperSandro2000 @VoigtS
+/common/postgresql-ng-test                             @majewsky @SuperSandro2000 @VoigtS
+/common/postgresql-test                                @majewsky @SuperSandro2000 @VoigtS
 /common/prometheus-alertmanager-base                   @auhlig @viennaa @uwe-mayer @richardtief
 /common/prometheus-monitors                            @IvoGoman
 /common/prometheus-pushgateway                         @viennaa
@@ -25,14 +25,14 @@
 /common/prometheus-server-pre7                         @viennaa @richardtief @auhlig @defo89
 /common/rabbitmq                                       @galkindmitrii @fwiesel @Carthaca @bashar-alkhateeb @dusandordevicsap
 /common/rabbitmq_cluster                               @galkindmitrii @notandy @defo89
-/common/redis                                          @SuperSandro2000 @majewsky @auhlig @VoigtS @fwiesel
+/common/redis                                          @majewsky @SuperSandro2000 @VoigtS
 /common/staging/rabbitmq                               @notandy @Carthaca  # old
 /common/thanos                                         @viennaa @richardtief
 
 /global/andromeda                                      @notandy
 /global/bootcfg                                        @BugRoger  # old
-/global/ccloud-hedgedoc                                @majewsky @SuperSandro2000 @sebageek
-/global/chartmuseum-sapcc                              @auhlig @majewsky @SuperSandro2000
+/global/ccloud-hedgedoc                                @majewsky @SuperSandro2000 @VoigtS
+/global/chartmuseum-sapcc                              @auhlig @majewsky @SuperSandro2000 @VoigtS
 /global/concourse-main                                 @jknipper @andypf
 /global/concourse-worker                               @databus23 @kayrus  # old
 /global/geminabox                                      @databus23
@@ -61,15 +61,15 @@
 /openstack/barbican                                    @galkindmitrii @fwiesel @rajivmucheli @bashar-alkhateeb
 /openstack/baremetal-temper                            @databus23 @fwiesel @BerndKue
 /openstack/bastion                                     @fwiesel
-/openstack/billing                                     @majewsky
+/openstack/billing                                     @majewsky @SuperSandro2000 @VoigtS
 /openstack/blackbox                                    @artherd42 @fwiesel @m-kratochvil
-/openstack/castellum                                   @majewsky @SuperSandro2000 @VoigtS @richardtief
+/openstack/castellum                                   @majewsky @SuperSandro2000 @VoigtS
 /openstack/cbshelf                                     @corey-aloia
 /openstack/cc3test                                     @artherd42 @thgrs @ashifnihalb @Carthaca
 /openstack/cc3test-seeds                               @artherd42 @thgrs @fwiesel
 /openstack/cerebro                                     @viennaa
 /openstack/cinder                                      @joker-at-work @hemna @fwiesel @dusandordevicsap
-/openstack/content-repo                                @majewsky @SuperSandro2000 @talal @VoigtS
+/openstack/content-repo                                @majewsky @SuperSandro2000 @VoigtS
 /openstack/cronus                                      @kayrus @dhalimi @corey-aloia @fwiesel
 /openstack/cronus-seed                                 @kayrus @dhalimi
 /openstack/db-backup-v2                                @databus23 @fwiesel
@@ -82,13 +82,13 @@
 /openstack/hermes                                      @Kuckkuck @IvoGoman @fwiesel
 /openstack/infra-seeds/kubernetes                      @BugRoger  # old
 /openstack/ironic                                      @stefanhipfel @BerndKue @fwiesel @sandzwerg
-/openstack/keppel                                      @majewsky @SuperSandro2000 @VoigtS @geisslet
-/openstack/keppel-trivy                                @SuperSandro2000 @majewsky @VoigtS
+/openstack/keppel                                      @majewsky @SuperSandro2000 @VoigtS
+/openstack/keppel-trivy                                @majewsky @SuperSandro2000 @VoigtS
 /openstack/keystone                                    @galkindmitrii @Carthaca @bbobrov @fwiesel @rajivmucheli
 /openstack/kos-operator                                @stefanhipfel @databus23
 /openstack/kubernetes                                  @fwiesel
 /openstack/kubernikus                                  @fwiesel @jknipper
-/openstack/limes                                       @majewsky @SuperSandro2000 @fwiesel @VoigtS
+/openstack/limes                                       @majewsky @SuperSandro2000 @VoigtS
 /openstack/lyra                                        @databus23 @ArtieReus
 /openstack/maia                                        @artherd42 @viennaa @richardtief @Kuckkuck @dhalimi
 /openstack/manila                                      @Carthaca @chuan137 @galkindmitrii @kpawar-sap
@@ -107,9 +107,9 @@
 /openstack/pyroscope                                   @fwiesel
 /openstack/sap-seeds                                   @dhoeller @grandchild @frr2018 @joker-at-work @fwiesel
 /openstack/sre                                         @artherd42 @fwiesel @rajivmucheli
-/openstack/swift                                       @majewsky @SuperSandro2000 @talal @crenduchinta88
-/openstack/swift-drive-autopilot                       @majewsky
-/openstack/swift-utils                                 @majewsky @SuperSandro2000
+/openstack/swift                                       @sumitarora2786 @crenduchinta88 @majewsky @SuperSandro2000 @VoigtS
+/openstack/swift-drive-autopilot                       @sumitarora2786 @crenduchinta88 @majewsky @SuperSandro2000 @VoigtS
+/openstack/swift-utils                                 @sumitarora2786 @crenduchinta88 @majewsky @SuperSandro2000 @VoigtS
 /openstack/tempest/barbican-tempest                    @misamoylov @fwiesel @rajivmucheli
 /openstack/tempest/cinder-tempest                      @misamoylov @fwiesel
 /openstack/tempest/designate-tempest                   @misamoylov @fwiesel
@@ -151,7 +151,7 @@
 /prometheus-exporters/network-generic-ssh-exporter     @swagner-de @Kuckkuck @artherd42 @geisslet
 /prometheus-exporters/nfs-exporter                     @auhlig  # old
 /prometheus-exporters/ns-exporter                      @databus23
-/prometheus-exporters/ntp-exporter                     @majewsky @SuperSandro2000 @jknipper
+/prometheus-exporters/ntp-exporter                     @majewsky @SuperSandro2000 @VoigtS
 /prometheus-exporters/octobus-query-exporter           @max-len @IvoGoman @Kuckkuck @christopherhans @kevin-fischer
 /prometheus-exporters/oomkill-exporter                 @jknipper @defo89
 /prometheus-exporters/opensearch-logs-query-exporter   @Kuckkuck @dimtass @chuan137 @databus23
@@ -178,7 +178,7 @@
 /px/bird                                               @swagner-de @dusandordevicsap @rhalina @defo89
 /px/lg                                                 @rhalina @swagner-de
 
-/system/absent-metrics-operator                        @talal @SuperSandro2000 @majewsky @VoigtS
+/system/absent-metrics-operator                        @majewsky @SuperSandro2000 @VoigtS
 /system/ai-cloud-guard                                 @darpan92
 /system/atlas                                          @BerndKue @Kuckkuck @viennaa @stefanhipfel @artherd42
 /system/audit-logs                                     @IvoGoman @Kuckkuck @jknipper @artherd42 @richardtief
@@ -202,18 +202,18 @@
 /system/descheduler                                    @auhlig @defo89
 /system/digicert-issuer                                @jknipper @auhlig @kayrus
 /system/disco                                          @auhlig @defo89 @databus23
-/system/doop-central                                   @majewsky @talal @SuperSandro2000 @auhlig
+/system/doop-central                                   @majewsky @SuperSandro2000 @VoigtS
 /system/elk                                            @Kuckkuck @IvoGoman
 /system/externalip-operator                            @defo89
 /system/flatcar-linux-update-agent                     @Nuckal777 @defo89
 /system/frrouting                                      @defo89
-/system/gatekeeper                                     @majewsky @talal @SuperSandro2000 @Kuckkuck @IvoGoman
-/system/gatekeeper-config                              @majewsky @talal @SuperSandro2000
+/system/gatekeeper                                     @majewsky @SuperSandro2000 @VoigtS
+/system/gatekeeper-config                              @majewsky @SuperSandro2000 @VoigtS
 /system/go-pmtud                                       @defo89
 /system/grafana-dashboards-kubernetes                  @auhlig @databus23
 /system/greenhouse-ccloud                              @auhlig @IvoGoman
-/system/hubcopter                                      @SuperSandro2000 @majewsky
-/system/hubcopter-seeds                                @SuperSandro2000 @majewsky
+/system/hubcopter                                      @majewsky @SuperSandro2000 @VoigtS
+/system/hubcopter-seeds                                @majewsky @SuperSandro2000 @VoigtS
 /system/infra-monitoring                               @artherd42 @viennaa @BerndKue @swagner-de @Kuckkuck
 /system/ipmasq                                         @defo89
 /system/jaeger-operator                                @chuan137 @misamoylov @Kuckkuck
@@ -280,7 +280,7 @@
 /system/sysstat                                        @defo89
 /system/tarslite                                       @darpan92 @max-len @christopherhans
 /system/tenso                                          @majewsky @SuperSandro2000 @VoigtS
-/system/tenso-seeds                                    @majewsky
+/system/tenso-seeds                                    @majewsky @SuperSandro2000 @VoigtS
 /system/thanos-metal                                   @richardtief @viennaa
 /system/thanos-operator                                @viennaa
 /system/thanos-scaleout                                @richardtief @viennaa

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,16 +18,16 @@
 /common/postgresql-ng                                  @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /common/postgresql-ng-test                             @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /common/postgresql-test                                @majewsky @SuperSandro2000 @VoigtS @Nuckal777
-/common/prometheus-alertmanager-base                   @auhlig @viennaa @uwe-mayer @richardtief
-/common/prometheus-monitors                            @IvoGoman
-/common/prometheus-pushgateway                         @viennaa
-/common/prometheus-server                              @auhlig @viennaa @databus23 @richardtief @defo89
-/common/prometheus-server-pre7                         @viennaa @richardtief @auhlig @defo89
+/common/prometheus-alertmanager-base                   @viennaa @richardtief @Kuckkuck @IvoGoman @timojohlo
+/common/prometheus-monitors                            @IvoGoman @auhlig
+/common/prometheus-pushgateway                         @viennaa # old
+/common/prometheus-server                              @viennaa @richardtief @Kuckkuck @IvoGoman @timojohlo
+/common/prometheus-server-pre7                         @viennaa @richardtief @Kuckkuck @IvoGoman @timojohlo
 /common/rabbitmq                                       @galkindmitrii @fwiesel @Carthaca @bashar-alkhateeb @dusandordevicsap @businessbean
 /common/rabbitmq-cluster                               @galkindmitrii @notandy @defo89 @businessbean
 /common/redis                                          @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /common/staging/rabbitmq                               @notandy @Carthaca  # old
-/common/thanos                                         @viennaa @richardtief
+/common/thanos                                         @viennaa @richardtief @Kuckkuck @IvoGoman @timojohlo
 
 /global/andromeda                                      @notandy @m-kratochvil
 /global/bootcfg                                        @BugRoger  # old
@@ -42,13 +42,13 @@
 /global/oauth-proxy                                    @andypf @ArtieReus @databus23
 /global/percona-cluster                                @galkindmitrii @defo89 @occamshatchet
 /global/prometheus-alertmanager-cnmp                   @auhlig
-/global/prometheus-alertmanager-operated               @geisslet @auhlig @uwe-mayer @viennaa
-/global/prometheus-infra                               @artherd42 @Kuckkuck @viennaa @richardtief @BerndKue
+/global/prometheus-alertmanager-operated               @viennaa @richardtief @Kuckkuck @IvoGoman @timojohlo
+/global/prometheus-infra                               @artherd42 # old
 /global/prometheus-uber                                @auhlig  # old
 /global/schedules2slack                                @geisslet
 /global/slack-alert-reactions                          @uwe-mayer
 /global/supernova                                      @andypf @ArtieReus @edda @hgw77
-/global/thanos-global                                  @viennaa @richardtief
+/global/thanos-global                                  @viennaa @richardtief @Kuckkuck @IvoGoman @timojohlo
 /global/vault                                          @BugRoger  # old
 /global/vault-tec                                      @Nuckal777 @majewsky @SuperSandro2000 @VoigtS
 /global/volta                                          @dimtass @databus23
@@ -62,12 +62,12 @@
 /openstack/baremetal-temper                            @databus23 @fwiesel @BerndKue
 /openstack/bastion                                     @fwiesel
 /openstack/billing                                     @majewsky @SuperSandro2000 @VoigtS @Nuckal777
-/openstack/blackbox                                    @artherd42 @fwiesel @m-kratochvil
+/openstack/blackbox                                    @artherd42 # old
 /openstack/castellum                                   @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /openstack/cbshelf                                     @corey-aloia
-/openstack/cc3test                                     @artherd42 @thgrs @ashifnihalb @Carthaca
-/openstack/cc3test-seeds                               @artherd42 @thgrs @fwiesel
-/openstack/cerebro                                     @viennaa
+/openstack/cc3test                                     @thgrs @ashifnihalb @artherd42
+/openstack/cc3test-seeds                               @thgrs @ashifnihalb @artherd42
+/openstack/cerebro                                     @viennaa @joker-at-work @fwiesel @grandchild
 /openstack/cinder                                      @joker-at-work @hemna @fwiesel @dusandordevicsap
 /openstack/content-repo                                @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /openstack/cronus                                      @kayrus @dhalimi1975 @corey-aloia @fwiesel
@@ -78,8 +78,8 @@
 /openstack/domain-seeds                                @BerndKue @Carthaca @fwiesel @Kuckkuck @rajivmucheli
 /openstack/elektra                                     @andypf @edda @ArtieReus @hgw77
 /openstack/glance                                      @fwiesel @galkindmitrii @rajivmucheli @Carthaca
-/openstack/grafanasix                                  @thgrs @richardtief
-/openstack/hermes                                      @notque @Kuckkuck @IvoGoman @fwiesel
+/openstack/grafanasix                                  @thgrs # old
+/openstack/hermes                                      @notque @Kuckkuck @IvoGoman
 /openstack/infra-seeds/kubernetes                      @BugRoger  # old
 /openstack/ironic                                      @stefanhipfel @BerndKue @fwiesel @sandzwerg
 /openstack/keppel                                      @majewsky @SuperSandro2000 @VoigtS @Nuckal777
@@ -90,21 +90,21 @@
 /openstack/kubernikus                                  @fwiesel @jknipper
 /openstack/limes                                       @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /openstack/lyra                                        @databus23 @ArtieReus
-/openstack/maia                                        @notque @artherd42 @viennaa @richardtief @Kuckkuck @dhalimi1975
+/openstack/maia                                        @notque @richardtief @viennaa @Kuckkuck
 /openstack/manila*                                     @Carthaca @chuan137 @galkindmitrii @kpawar-sap @sumitarora2786 @crenduchinta88
 /openstack/nannies                                     @thgrs @chuan137 @Carthaca @fwiesel @kpawar-sap
 /openstack/neutron                                     @notandy @fwiesel @sebageek @sven-rosenzweig @rhalina @swagner-de @mutax @BenjaminLudwigSAP @m-kratochvil @occamshatchet
 /openstack/nova                                        @joker-at-work @fwiesel @grandchild @leust
 /openstack/octavia                                     @notandy @BenjaminLudwigSAP @fwiesel @dusandordevicsap @velp @m-kratochvil
-/openstack/octobus                                     @viennaa
+/openstack/octobus                                     @viennaa @Kuckkuck @businessbean
 /openstack/openstack-seeder                            @stefanhipfel @databus23 @fwiesel
 /openstack/openstack-performance                       @misamoylov
 /openstack/placement                                   @fwiesel @joker-at-work @bashar-alkhateeb @galkindmitrii
 /openstack/poller                                      @dhalimi1975 @corey-aloia
-/openstack/prometheus-openstack                        @viennaa @artherd42 @richardtief @Kuckkuck
+/openstack/prometheus-openstack                        @viennaa @richardtief @Kuckkuck @IvoGoman @timojohlo
 /openstack/pyroscope                                   @fwiesel
 /openstack/sap-seeds                                   @dhoeller @grandchild @frr2018 @joker-at-work @fwiesel
-/openstack/sre                                         @artherd42 @fwiesel @rajivmucheli
+/openstack/sre                                         @artherd42 @geisslet # old
 /openstack/swift                                       @sumitarora2786 @crenduchinta88 @majewsky @SuperSandro2000 @VoigtS
 /openstack/swift-drive-autopilot                       @sumitarora2786 @crenduchinta88 @majewsky @SuperSandro2000 @VoigtS
 /openstack/swift-utils                                 @sumitarora2786 @crenduchinta88 @majewsky @SuperSandro2000 @VoigtS
@@ -128,7 +128,7 @@
 /prometheus-exporters/apic-exporter                    @artherd42 @IvoGoman
 /prometheus-exporters/arista-exporter                  @BerndKue @stefanhipfel
 /prometheus-exporters/blackbox-exporter                @defo89 @databus23
-/prometheus-exporters/cloudprober                      @artherd42 @defo89
+/prometheus-exporters/cloudprober                      @artherd42 @richardtief @viennaa
 /prometheus-exporters/cronus-exporter                  @dhalimi1975 @LimorGargir @richardtief @geisslet
 /prometheus-exporters/cronus-openstack-alerts          @dhalimi1975
 /prometheus-exporters/cronus-reporter                  @dhalimi1975
@@ -141,9 +141,9 @@
 /prometheus-exporters/ipmi-service-discovery           @auhlig  # old
 /prometheus-exporters/ironic-exporter                  @BerndKue @stefanhipfel @sandzwerg
 
-/prometheus-exporters/jumpserver-exporter              @viennaa
+/prometheus-exporters/jumpserver-exporter              @viennaa @richardtief @Kuckkuck
 /prometheus-exporters/k8s-secrets-certificate-exporter @auhlig @databus23 @jknipper
-/prometheus-exporters/kube-state-metrics-exporter      @richardtief
+/prometheus-exporters/kube-state-metrics-exporter      @richardtief @viennaa
 /prometheus-exporters/kubelet-stats-metrics            @jknipper
 /prometheus-exporters/masterdata-exporter              @databus23
 /prometheus-exporters/netapp-exporter                  @chuan137 @Carthaca @grandchild @stefanhipfel
@@ -151,27 +151,27 @@
 /prometheus-exporters/nfs-exporter                     @auhlig  # old
 /prometheus-exporters/ns-exporter                      @databus23
 /prometheus-exporters/ntp-exporter                     @majewsky @SuperSandro2000 @VoigtS @Nuckal777
-/prometheus-exporters/octobus-query-exporter           @max-len @IvoGoman @Kuckkuck @christopherhans @kevin-fischer
+/prometheus-exporters/octobus-query-exporter           @max-len @himanip94 @kevin-fischer @Kuckkuck @IvoGoman
 /prometheus-exporters/oomkill-exporter                 @jknipper @defo89
 /prometheus-exporters/opensearch-logs-query-exporter   @Kuckkuck @dimtass @chuan137 @databus23 @IvoGoman @timojohlo
-/prometheus-exporters/openstack-exporter               @viennaa @hemna @crenduchinta88 @kevin-fischer
+/prometheus-exporters/openstack-exporter               @hemna @crenduchinta88 @kevin-fischer
 /prometheus-exporters/ping-exporter                    @auhlig @defo89  # old
 /prometheus-exporters/poller-simulator                 @dhalimi1975 @corey-aloia
 /prometheus-exporters/redfish-exporter                 @BerndKue @stefanhipfel @sandzwerg
 /prometheus-exporters/snmp-exporter                    @Kuckkuck @swagner-de @m-kratochvil @IvoGoman @defo89
 /prometheus-exporters/snmp-ntp-exporter                @geisslet
-/prometheus-exporters/statsd-exporter                  @artherd42 @thgrs @ashifnihalb
+/prometheus-exporters/statsd-exporter                  @thgrs @ashifnihalb @artherd42
 /prometheus-exporters/systemd-lldp-exporter            @auhlig  # old
 /prometheus-exporters/tempest-exporter                 @misamoylov
-/prometheus-exporters/ucs-exporter                     @BerndKue @viennaa @richardtief
+/prometheus-exporters/ucs-exporter                     @BerndKue @killermoehre
 /prometheus-exporters/watchcache-exporter              @jknipper @databus23
 
-/prometheus-rules/prometheus-controlplane-rules        @defo89 @artherd42
-/prometheus-rules/prometheus-kubernetes-rules          @auhlig @databus23 @defo89 @businessbean
-/prometheus-rules/prometheus-openstack-rules           @artherd42 @richardtief
-/prometheus-rules/prometheus-scaleout-rules            @auhlig  # old
-/prometheus-rules/prometheus-virtual-rules             @BugRoger  # old
-/prometheus-rules/prometheus-vmware-rules              @kevin-fischer @christopherhans @max-len @richardtief @himanip94
+/prometheus-rules/prometheus-controlplane-rules        @vienna @richardtief @defo89
+/prometheus-rules/prometheus-kubernetes-rules          @vienna @richardtief @defo89
+/prometheus-rules/prometheus-openstack-rules           @vienna @richardtief @defo89
+/prometheus-rules/prometheus-scaleout-rules            @vienna @richardtief @defo89  # old
+/prometheus-rules/prometheus-virtual-rules             @vienna @richardtief @defo89  # old
+/prometheus-rules/prometheus-vmware-rules              @kevin-fischer @christopherhans @max-len @richardtief @vienna @himanip94
 
 /px/arp-discovery                                      @swagner-de
 /px/bird                                               @swagner-de @dusandordevicsap @rhalina @defo89 @occamshatchet
@@ -180,7 +180,7 @@
 /system/absent-metrics-operator                        @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /system/ai-cloud-guard                                 @darpan92
 /system/atlas                                          @BerndKue @Kuckkuck @viennaa @stefanhipfel @artherd42
-/system/audit-logs                                     @IvoGoman @Kuckkuck @jknipper @artherd42 @richardtief
+/system/audit-logs                                     @IvoGoman @Kuckkuck @jknipper
 /system/auditbeat                                      @jknipper @IvoGoman @Kuckkuck
 /system/aws-ecr-creds-helper                           @defo89  # old
 /system/baremetal-operator                             @defo89
@@ -202,22 +202,22 @@
 /system/digicert-issuer                                @jknipper @auhlig @kayrus
 /system/disco                                          @auhlig @defo89 @databus23
 /system/doop-central                                   @majewsky @SuperSandro2000 @VoigtS @Nuckal777
-/system/elk                                            @Kuckkuck @IvoGoman
+/system/elk                                            @Kuckkuck @IvoGoman # old
 /system/externalip-operator                            @defo89
 /system/flatcar-linux-update-agent                     @Nuckal777 @defo89 @majewsky @SuperSandro2000 @VoigtS
 /system/frrouting                                      @defo89
 /system/gatekeeper                                     @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /system/gatekeeper-config                              @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /system/go-pmtud                                       @defo89
-/system/grafana-dashboards-kubernetes                  @auhlig @databus23
+/system/grafana-dashboards-kubernetes                  @auhlig @databus23 # old
 /system/greenhouse-ccloud                              @auhlig @IvoGoman
 /system/hubcopter                                      @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /system/hubcopter-seeds                                @majewsky @SuperSandro2000 @VoigtS @Nuckal777
-/system/infra-monitoring                               @artherd42 @viennaa @BerndKue @swagner-de @Kuckkuck
+/system/infra-monitoring                               @viennaa @richardtief @BerndKue @swagner-de @Kuckkuck
 /system/ipmasq                                         @defo89
-/system/jaeger-operator                                @chuan137 @misamoylov @Kuckkuck
-/system/jupyter-cron-reports                           @timojohlo
-/system/jupyterhub                                     @timojohlo @artherd42
+/system/jaeger-operator                                @chuan137 @misamoylov
+/system/jupyter-cron-reports                           @timojohlo @IvoGoman @Kuckkuck
+/system/jupyterhub                                     @timojohlo @IvoGoman @Kuckkuck
 /system/k3s-backup                                     @defo89
 /system/k3s-restore                                    @defo89  # old
 /system/kube-cni                                       @defo89
@@ -225,46 +225,46 @@
 /system/kube-dns                                       @defo89 @databus23
 /system/kube-fip-controller                            @auhlig @jknipper @databus23
 /system/kube-flannel                                   @defo89
-/system/kube-monitoring-admin-k3s                      @defo89 @Kuckkuck @auhlig
-/system/kube-monitoring-kubernikus                     @auhlig @jknipper @databus23 @defo89
-/system/kube-monitoring-metal                          @auhlig @databus23 @defo89 @jknipper
-/system/kube-monitoring-scaleout                       @auhlig @jknipper @databus23 @defo89
-/system/kube-monitoring-virtual                        @auhlig @defo89 @databus23 @jknipper
+/system/kube-monitoring-admin-k3s                      @defo89 @Kuckkuck @auhlig @viennaa @richardtief
+/system/kube-monitoring-kubernikus                     @auhlig @jknipper @databus23 @defo89 @viennaa @richardtief
+/system/kube-monitoring-metal                          @auhlig @databus23 @defo89 @jknipper @viennaa @richardtief
+/system/kube-monitoring-scaleout                       @auhlig @jknipper @databus23 @defo89 @viennaa @richardtief
+/system/kube-monitoring-virtual                        @auhlig @defo89 @databus23 @jknipper @viennaa @richardtief
 /system/kube-network-helpers                           @defo89
 /system/kube-parrot                                    @defo89
 /system/kube-proxy                                     @defo89
 /system/kube-proxy-ng                                  @defo89
 /system/kube-system-addons                             @defo89 @Nuckal777
-/system/kube-system-admin-k3s                          @defo89 @Nuckal777 @jknipper @onuryilmaz @auhlig
-/system/kube-system-global                             @defo89 @kayrus @viennaa @auhlig @Nuckal777
-/system/kube-system-kubernikus                         @auhlig @Nuckal777 @jknipper @defo89 @databus23
-/system/kube-system-metal                              @defo89 @auhlig @Nuckal777 @jknipper @databus23
-/system/kube-system-scaleout                           @auhlig @Nuckal777 @jknipper @onuryilmaz @defo89
-/system/kube-system-virtual                            @defo89 @Nuckal777 @auhlig @jknipper @onuryilmaz
+/system/kube-system-admin-k3s                          @defo89 @Nuckal777 @jknipper @onuryilmaz @auhlig @viennaa @richardtief
+/system/kube-system-global                             @defo89 @kayrus @viennaa @auhlig @Nuckal777 @viennaa @richardtief
+/system/kube-system-kubernikus                         @auhlig @Nuckal777 @jknipper @defo89 @databus23 @viennaa @richardtief
+/system/kube-system-metal                              @defo89 @auhlig @Nuckal777 @jknipper @databus23 @viennaa @richardtief
+/system/kube-system-scaleout                           @auhlig @Nuckal777 @jknipper @onuryilmaz @defo89 @viennaa @richardtief
+/system/kube-system-virtual                            @defo89 @Nuckal777 @auhlig @jknipper @onuryilmaz @viennaa @richardtief
 /system/kubernikus-admin-k3s                           @defo89 @databus23 @Nuckal777 @jknipper @xsen84
 /system/kubernikus-metal                               @databus23 @defo89 @Nuckal777 @jknipper @xsen84
 /system/kubernikus-monitoring                          @uwe-mayer @databus23 @jknipper @Nuckal777
 /system/kubernikus-rbac                                @databus23
 /system/ldap-named-user                                @defo89
-/system/logs                                           @Kuckkuck @IvoGoman @businessbean @corey-aloia @timojohlo @notque
+/system/logs                                           @Kuckkuck @IvoGoman @timojohlo @notque
 /system/maintenance-controller                         @Nuckal777 @defo89 @majewsky @SuperSandro2000 @VoigtS
 /system/manila-csi-plugin                              @jknipper
 /system/metallb                                        @defo89  # old
 /system/metis                                          @IvoGoman @timojohlo @richardtief
 /system/metis-api                                      @IvoGoman @timojohlo
 /system/metrics-server                                 @auhlig @defo89
-/system/multicloudtest                                 @viennaa
+/system/multicloudtest                                 @viennaa # old
 /system/node-problem-detector                          @defo89 @databus23
 /system/nodecidr-controller                            @defo89
 /system/ntp-timeserver                                 @dhoeller  # old
-/system/opensearch-hermes                              @Kuckkuck @notque @timojohlo
-/system/opensearch-logs                                @Kuckkuck @IvoGoman @richardtief @timojohlo @notque
-/system/plutono                                        @richardtief @thgrs @misamoylov
+/system/opensearch-hermes                              @Kuckkuck @notque @IvoGoman @timojohlo
+/system/opensearch-logs                                @Kuckkuck @IvoGoman @timojohlo @notque
+/system/plutono                                        @thgrs @richardtief
 /system/priority-class                                 @galkindmitrii  # old
 /system/prober-static                                  @defo89
-/system/prometheus-crds                                @auhlig @viennaa @richardtief
-/system/prometheus-infra                               @artherd42 @viennaa @richardtief @Kuckkuck @dhalimi1975
-/system/prometheus-kubernetes                          @viennaa @richardtief @Nuckal777
+/system/prometheus-crds                                @viennaa @richardtief
+/system/prometheus-infra                               @viennaa @richardtief @Kuckkuck @IvoGoman @timojohlo
+/system/prometheus-kubernetes                          @viennaa @richardtief @Kuckkuck @IvoGoman @timojohlo
 /system/prometheus-operator                            @viennaa @richardtief
 /system/provider-kubernikus                            @defo89
 /system/provider-metal3                                @defo89 @Nuckal777
@@ -275,22 +275,22 @@
 /system/servicemesh                                    @jknipper
 /system/smee-dynakratos                                @defo89 @SchwarzM
 /system/srs-*                                          @majewsky @SuperSandro2000 @VoigtS @Nuckal777
-/system/storage-monitoring                             @viennaa @richardtief @artherd42 @geisslet
+/system/storage-monitoring                             @viennaa @richardtief @Kuckkuck @IvoGoman @timojohlo
 /system/sysctl                                         @defo89
 /system/sysstat                                        @defo89
 /system/tarslite                                       @darpan92 @max-len @christopherhans
 /system/tenso                                          @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /system/tenso-seeds                                    @majewsky @SuperSandro2000 @VoigtS @Nuckal777
-/system/thanos-metal                                   @richardtief @viennaa
-/system/thanos-operator                                @viennaa
-/system/thanos-scaleout                                @richardtief @viennaa
-/system/thanos-seeds                                   @viennaa
+/system/thanos-metal                                   @viennaa @richardtief @Kuckkuck @IvoGoman @timojohlo
+/system/thanos-operator                                @viennaa @richardtief
+/system/thanos-scaleout                                @viennaa @richardtief @Kuckkuck @IvoGoman @timojohlo
+/system/thanos-seeds                                   @viennaa @richardtief
 /system/toolbox-prepull                                @defo89 @SchwarzM
 /system/unbound                                        @galkindmitrii @vssldmtrv @dhoeller @mutax @defo89 @mbrowny @SoenkeL @occamshatchet
-/system/validation                                     @artherd42 @thgrs @ashifnihalb
+/system/validation                                     @thgrs @ashifnihalb
 /system/velero                                         @databus23 @jknipper  # old
 /system/vertical-pod-autoscaler                        @Nuckal777 @majewsky @SuperSandro2000 @VoigtS
 /system/vice-president                                 @databus23
-/system/vmware-monitoring                              @viennaa @richardtief @christopherhans @himanip94 @kevin-fischer
+/system/vmware-monitoring                              @viennaa @richardtief @Kuckkuck @IvoGoman @timojohlo
 /system/vpa-butler                                     @Nuckal777 @majewsky @SuperSandro2000 @VoigtS
 /system/wormhole                                       @defo89

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,7 +51,6 @@
 /global/thanos-global                                  @viennaa @richardtief
 /global/vault                                          @BugRoger  # old
 /global/vault-tec                                      @Nuckal777 @majewsky @SuperSandro2000 @VoigtS
-/global/volta                                          @dimtass @databus23
 /global/wham                                           @databus23
 
 /openstack/andromeda-seed                              @notandy @m-kratochvil

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 /common/linkerd-support                                @majewsky @SuperSandro2000 @viennaa
 /common/manila-provisioner                             @jknipper  # old
 /common/mariadb                                        @galkindmitrii @stefanhipfel @Carthaca @IvoGoman @fwiesel
-/common/memcached                                      @auhlig @businessbean @majewsky @SuperSandro2000 @bashar-alkhateeb
+/common/memcached                                      @auhlig @businessbean @bashar-alkhateeb
 /common/mysql_metrics                                  @galkindmitrii @Carthaca
 /common/nats                                           @notandy
 /common/owner-info                                     @majewsky @SuperSandro2000
@@ -18,157 +18,157 @@
 /common/postgresql-ng                                  @SuperSandro2000 @majewsky @stanislav-zaprudskiy @jknipper @stefanhipfel
 /common/postgresql-ng-test                             @SuperSandro2000 @majewsky
 /common/postgresql-test                                @majewsky @SuperSandro2000
-/common/prometheus-alertmanager-base                   @auhlig @viennaa @uwe-mayer @majewsky @richardtief
+/common/prometheus-alertmanager-base                   @auhlig @viennaa @uwe-mayer @richardtief
 /common/prometheus-monitors                            @IvoGoman
-/common/prometheus-pushgateway                         @viennaa @majewsky
+/common/prometheus-pushgateway                         @viennaa
 /common/prometheus-server                              @auhlig @viennaa @databus23 @richardtief @defo89
-/common/prometheus-server-pre7                         @viennaa @richardtief @majewsky @auhlig @defo89
+/common/prometheus-server-pre7                         @viennaa @richardtief @auhlig @defo89
 /common/rabbitmq                                       @galkindmitrii @fwiesel @Carthaca @bashar-alkhateeb @dusandordevicsap
 /common/rabbitmq_cluster                               @galkindmitrii @notandy @defo89
 /common/redis                                          @SuperSandro2000 @majewsky @auhlig @VoigtS @fwiesel
-/common/staging/rabbitmq                               @majewsky @notandy @Carthaca  # old
-/common/thanos                                         @viennaa @richardtief @majewsky @SuperSandro2000
+/common/staging/rabbitmq                               @notandy @Carthaca  # old
+/common/thanos                                         @viennaa @richardtief
 
-/global/andromeda                                      @notandy @majewsky
+/global/andromeda                                      @notandy
 /global/bootcfg                                        @BugRoger  # old
 /global/ccloud-hedgedoc                                @majewsky @SuperSandro2000 @sebageek
 /global/chartmuseum-sapcc                              @auhlig @majewsky @SuperSandro2000
-/global/concourse-main                                 @jknipper @majewsky @SuperSandro2000 @andypf
+/global/concourse-main                                 @jknipper @andypf
 /global/concourse-worker                               @databus23 @kayrus  # old
 /global/geminabox                                      @databus23
 /global/gh-actions                                     @notandy @auhlig
-/global/git-cert-shim                                  @majewsky @auhlig
+/global/git-cert-shim                                  @auhlig
 /global/kibana-objecter                                @dimtass
-/global/oauth-proxy                                    @andypf @majewsky @ArtieReus @databus23
+/global/oauth-proxy                                    @andypf @ArtieReus @databus23
 /global/percona_cluster                                @galkindmitrii @defo89
-/global/prometheus-alertmanager-cnmp                   @auhlig @majewsky
-/global/prometheus-alertmanager-operated               @geisslet @auhlig @uwe-mayer @viennaa @majewsky
+/global/prometheus-alertmanager-cnmp                   @auhlig
+/global/prometheus-alertmanager-operated               @geisslet @auhlig @uwe-mayer @viennaa
 /global/prometheus-infra                               @artherd42 @Kuckkuck @viennaa @richardtief @BerndKue
 /global/prometheus-uber                                @auhlig  # old
 /global/schedules2slack                                @geisslet
 /global/slack-alert-reactions                          @uwe-mayer
-/global/supernova                                      @andypf @majewsky @ArtieReus @auhlig @databus23
+/global/supernova                                      @andypf @ArtieReus @auhlig @databus23
 /global/thanos-global                                  @viennaa @richardtief
 /global/vault                                          @BugRoger  # old
 /global/vault-tec                                      @Nuckal777
 /global/volta                                          @dimtass @databus23
 /global/wham                                           @databus23
 
-/openstack/andromeda-seed                              @notandy @majewsky
-/openstack/arc                                         @databus23 @ArtieReus @majewsky @SuperSandro2000 @fwiesel
-/openstack/archer                                      @notandy @majewsky
+/openstack/andromeda-seed                              @notandy
+/openstack/arc                                         @databus23 @ArtieReus @fwiesel
+/openstack/archer                                      @notandy
 /openstack/backup-replication                          @majewsky @SuperSandro2000 @VoigtS
-/openstack/barbican                                    @galkindmitrii @fwiesel @majewsky @rajivmucheli @bashar-alkhateeb
-/openstack/baremetal-temper                            @majewsky @databus23 @fwiesel @BerndKue
-/openstack/bastion                                     @majewsky @fwiesel
+/openstack/barbican                                    @galkindmitrii @fwiesel @rajivmucheli @bashar-alkhateeb
+/openstack/baremetal-temper                            @databus23 @fwiesel @BerndKue
+/openstack/bastion                                     @fwiesel
 /openstack/billing                                     @majewsky
-/openstack/blackbox                                    @artherd42 @majewsky @fwiesel @m-kratochvil
+/openstack/blackbox                                    @artherd42 @fwiesel @m-kratochvil
 /openstack/castellum                                   @majewsky @SuperSandro2000 @VoigtS @richardtief
-/openstack/cbshelf                                     @corey-aloia @majewsky
-/openstack/cc3test                                     @artherd42 @thgrs @ashifnihalb @majewsky @Carthaca
+/openstack/cbshelf                                     @corey-aloia
+/openstack/cc3test                                     @artherd42 @thgrs @ashifnihalb @Carthaca
 /openstack/cc3test-seeds                               @artherd42 @thgrs @fwiesel
-/openstack/cerebro                                     @viennaa @majewsky
-/openstack/cinder                                      @joker-at-work @hemna @fwiesel @majewsky @dusandordevicsap
+/openstack/cerebro                                     @viennaa
+/openstack/cinder                                      @joker-at-work @hemna @fwiesel @dusandordevicsap
 /openstack/content-repo                                @majewsky @SuperSandro2000 @talal @VoigtS
-/openstack/cronus                                      @kayrus @dhalimi @corey-aloia @majewsky @fwiesel
-/openstack/cronus-seed                                 @kayrus @dhalimi @majewsky
+/openstack/cronus                                      @kayrus @dhalimi @corey-aloia @fwiesel
+/openstack/cronus-seed                                 @kayrus @dhalimi
 /openstack/db-backup-v2                                @databus23 @fwiesel
-/openstack/designate                                   @galkindmitrii @fwiesel @majewsky @mutax @kpawar-sap
+/openstack/designate                                   @galkindmitrii @fwiesel @mutax @kpawar-sap
 /openstack/designate-nanny                             @mutax
-/openstack/domain-seeds                                @BerndKue @majewsky @Carthaca @fwiesel @Kuckkuck @rajivmucheli
-/openstack/elektra                                     @andypf @majewsky @databus23 @ArtieReus @hgw77
-/openstack/glance                                      @fwiesel @galkindmitrii @majewsky @rajivmucheli @Carthaca
-/openstack/grafanasix                                  @thgrs @majewsky @richardtief @SuperSandro2000 @notandy
-/openstack/hermes                                      @Kuckkuck @majewsky @IvoGoman @fwiesel
+/openstack/domain-seeds                                @BerndKue @Carthaca @fwiesel @Kuckkuck @rajivmucheli
+/openstack/elektra                                     @andypf @databus23 @ArtieReus @hgw77
+/openstack/glance                                      @fwiesel @galkindmitrii @rajivmucheli @Carthaca
+/openstack/grafanasix                                  @thgrs @richardtief @notandy
+/openstack/hermes                                      @Kuckkuck @IvoGoman @fwiesel
 /openstack/infra-seeds/kubernetes                      @BugRoger  # old
-/openstack/ironic                                      @stefanhipfel @BerndKue @fwiesel @sandzwerg @majewsky
+/openstack/ironic                                      @stefanhipfel @BerndKue @fwiesel @sandzwerg
 /openstack/keppel                                      @majewsky @SuperSandro2000 @VoigtS @geisslet
 /openstack/keppel-trivy                                @SuperSandro2000 @majewsky @VoigtS
-/openstack/keystone                                    @galkindmitrii @Carthaca @bbobrov @majewsky @fwiesel @rajivmucheli
+/openstack/keystone                                    @galkindmitrii @Carthaca @bbobrov @fwiesel @rajivmucheli
 /openstack/kos-operator                                @stefanhipfel @databus23
 /openstack/kubernetes                                  @fwiesel
 /openstack/kubernikus                                  @fwiesel @jknipper
 /openstack/limes                                       @majewsky @SuperSandro2000 @fwiesel @VoigtS
-/openstack/lyra                                        @databus23 @ArtieReus @majewsky @SuperSandro2000
+/openstack/lyra                                        @databus23 @ArtieReus
 /openstack/maia                                        @artherd42 @viennaa @richardtief @Kuckkuck @dhalimi
-/openstack/manila                                      @Carthaca @chuan137 @galkindmitrii @majewsky @kpawar-sap
+/openstack/manila                                      @Carthaca @chuan137 @galkindmitrii @kpawar-sap
 /openstack/manila-antelope                             @Carthaca @dusandordevicsap
 /openstack/manila-nanny                                @chuan137 @Carthaca @dusandordevicsap
 /openstack/nannies                                     @thgrs @chuan137 @Carthaca @fwiesel @kpawar-sap
-/openstack/neutron                                     @notandy @fwiesel @sebageek @majewsky @sven-rosenzweig @rhalina @swagner-de @mutax @BenjaminLudwigSAP @m-kratochvil
-/openstack/nova                                        @joker-at-work @fwiesel @grandchild @majewsky @leust
-/openstack/octavia                                     @notandy @BenjaminLudwigSAP @fwiesel @majewsky @dusandordevicsap
-/openstack/octobus                                     @majewsky @viennaa
+/openstack/neutron                                     @notandy @fwiesel @sebageek @sven-rosenzweig @rhalina @swagner-de @mutax @BenjaminLudwigSAP @m-kratochvil
+/openstack/nova                                        @joker-at-work @fwiesel @grandchild @leust
+/openstack/octavia                                     @notandy @BenjaminLudwigSAP @fwiesel @dusandordevicsap
+/openstack/octobus                                     @viennaa
 /openstack/openstack-seeder                            @stefanhipfel @databus23 @fwiesel
 /openstack/openstack_performance                       @misamoylov
 /openstack/placement                                   @fwiesel @joker-at-work @bashar-alkhateeb @galkindmitrii
 /openstack/poller                                      @dhalimi @corey-aloia
-/openstack/prometheus-openstack                        @viennaa @artherd42 @richardtief @Kuckkuck @majewsky
+/openstack/prometheus-openstack                        @viennaa @artherd42 @richardtief @Kuckkuck
 /openstack/pyroscope                                   @fwiesel
 /openstack/sap-seeds                                   @dhoeller @grandchild @frr2018 @joker-at-work @fwiesel
 /openstack/sre                                         @artherd42 @fwiesel @rajivmucheli
 /openstack/swift                                       @majewsky @SuperSandro2000 @talal @crenduchinta88
 /openstack/swift-drive-autopilot                       @majewsky
 /openstack/swift-utils                                 @majewsky @SuperSandro2000
-/openstack/tempest/barbican-tempest                    @misamoylov @majewsky @fwiesel @rajivmucheli
-/openstack/tempest/cinder-tempest                      @misamoylov @majewsky @fwiesel
-/openstack/tempest/designate-tempest                   @misamoylov @majewsky @fwiesel
-/openstack/tempest/glance-tempest                      @majewsky @misamoylov @fwiesel @rajivmucheli
-/openstack/tempest/ironic-tempest                      @misamoylov @majewsky @fwiesel
-/openstack/tempest/keystone-tempest                    @majewsky @misamoylov @fwiesel @rajivmucheli
-/openstack/tempest/manila-tempest                      @kpawar-sap @misamoylov @majewsky @fwiesel
-/openstack/tempest/neutron-tempest                     @misamoylov @majewsky @fwiesel
-/openstack/tempest/nova-tempest                        @misamoylov @majewsky @fwiesel
-/openstack/tempest/octavia-tempest                     @misamoylov @fwiesel @majewsky
+/openstack/tempest/barbican-tempest                    @misamoylov @fwiesel @rajivmucheli
+/openstack/tempest/cinder-tempest                      @misamoylov @fwiesel
+/openstack/tempest/designate-tempest                   @misamoylov @fwiesel
+/openstack/tempest/glance-tempest                      @misamoylov @fwiesel @rajivmucheli
+/openstack/tempest/ironic-tempest                      @misamoylov @fwiesel
+/openstack/tempest/keystone-tempest                    @misamoylov @fwiesel @rajivmucheli
+/openstack/tempest/manila-tempest                      @kpawar-sap @misamoylov @fwiesel
+/openstack/tempest/neutron-tempest                     @misamoylov @fwiesel
+/openstack/tempest/nova-tempest                        @misamoylov @fwiesel
+/openstack/tempest/octavia-tempest                     @misamoylov @fwiesel
 /openstack/tempest/tempest-base                        @misamoylov @fwiesel @stefanhipfel
 /openstack/trust-manager                               @fwiesel
 /openstack/utils                                       @fwiesel @notandy @galkindmitrii @Carthaca @joker-at-work
-/openstack/vcenter-operator                            @joker-at-work @fwiesel @majewsky @databus23
+/openstack/vcenter-operator                            @joker-at-work @fwiesel @databus23
 /openstack/vcf                                         @chuan137
-/openstack/volume-claims                               @majewsky @fwiesel
+/openstack/volume-claims                               @fwiesel
 
 /prometheus-exporters/apic-exporter                    @artherd42 @IvoGoman @geisslet
 /prometheus-exporters/arista-exporter                  @BerndKue @stanislav-zaprudskiy @stefanhipfel
 /prometheus-exporters/blackbox-exporter                @defo89 @databus23
 /prometheus-exporters/cloudprober                      @artherd42 @defo89
-/prometheus-exporters/cronus-exporter                  @dhalimi @majewsky @LimorGargir @richardtief @geisslet
+/prometheus-exporters/cronus-exporter                  @dhalimi @LimorGargir @richardtief @geisslet
 /prometheus-exporters/cronus-openstack-alerts          @dhalimi
 /prometheus-exporters/cronus-reporter                  @dhalimi
-/prometheus-exporters/cronus-simulator                 @dhalimi @majewsky
-/prometheus-exporters/cronus-updater                   @dhalimi @majewsky
-/prometheus-exporters/documentation-prober             @dhalimi @majewsky  # old
+/prometheus-exporters/cronus-simulator                 @dhalimi
+/prometheus-exporters/cronus-updater                   @dhalimi
+/prometheus-exporters/documentation-prober             @dhalimi  # old
 /prometheus-exporters/event-exporter                   @jknipper @databus23 @Nuckal777
 /prometheus-exporters/hermes-query-exporter            @Kuckkuck
 /prometheus-exporters/ipmi-exporter                    @stefanhipfel @BerndKue @stanislav-zaprudskiy
-/prometheus-exporters/ipmi-service-discovery           @auhlig @majewsky  # old
+/prometheus-exporters/ipmi-service-discovery           @auhlig  # old
 /prometheus-exporters/ironic-exporter                  @BerndKue @stefanhipfel
 /prometheus-exporters/jumpserver-exporter              @viennaa
-/prometheus-exporters/k8s-secrets-certificate-exporter @auhlig @majewsky @databus23 @jknipper
+/prometheus-exporters/k8s-secrets-certificate-exporter @auhlig @databus23 @jknipper
 /prometheus-exporters/kube-state-metrics-exporter      @richardtief
 /prometheus-exporters/kubelet-stats-metrics            @jknipper
 /prometheus-exporters/masterdata-exporter              @databus23
-/prometheus-exporters/netapp-exporter                  @chuan137 @Carthaca @majewsky @grandchild @stefanhipfel
+/prometheus-exporters/netapp-exporter                  @chuan137 @Carthaca @grandchild @stefanhipfel
 /prometheus-exporters/network-generic-ssh-exporter     @swagner-de @Kuckkuck @artherd42 @geisslet
-/prometheus-exporters/nfs-exporter                     @auhlig @majewsky  # old
+/prometheus-exporters/nfs-exporter                     @auhlig  # old
 /prometheus-exporters/ns-exporter                      @databus23
 /prometheus-exporters/ntp-exporter                     @majewsky @SuperSandro2000 @jknipper
 /prometheus-exporters/octobus-query-exporter           @max-len @IvoGoman @Kuckkuck @christopherhans @kevin-fischer
-/prometheus-exporters/oomkill-exporter                 @jknipper @defo89 @majewsky
+/prometheus-exporters/oomkill-exporter                 @jknipper @defo89
 /prometheus-exporters/opensearch-logs-query-exporter   @Kuckkuck @dimtass @chuan137 @databus23
-/prometheus-exporters/openstack-exporter               @viennaa @hemna @majewsky @crenduchinta88 @kevin-fischer
-/prometheus-exporters/ping-exporter                    @majewsky @auhlig @defo89  # old
-/prometheus-exporters/poller-simulator                 @dhalimi @corey-aloia @majewsky
+/prometheus-exporters/openstack-exporter               @viennaa @hemna @crenduchinta88 @kevin-fischer
+/prometheus-exporters/ping-exporter                    @auhlig @defo89  # old
+/prometheus-exporters/poller-simulator                 @dhalimi @corey-aloia
 /prometheus-exporters/redfish-exporter                 @BerndKue @stefanhipfel
 /prometheus-exporters/snmp-exporter                    @Kuckkuck @swagner-de @m-kratochvil @IvoGoman @defo89
 /prometheus-exporters/snmp-ntp-exporter                @geisslet
-/prometheus-exporters/statsd-exporter                  @artherd42 @thgrs @ashifnihalb @majewsky
-/prometheus-exporters/systemd-lldp-exporter            @auhlig @majewsky  # old
+/prometheus-exporters/statsd-exporter                  @artherd42 @thgrs @ashifnihalb
+/prometheus-exporters/systemd-lldp-exporter            @auhlig  # old
 /prometheus-exporters/tempest-exporter                 @misamoylov
 /prometheus-exporters/ucs-exporter                     @BerndKue @viennaa @richardtief
 /prometheus-exporters/watchcache-exporter              @jknipper @databus23
 
-/prometheus-rules/prometheus-controlplane-rules        @defo89 @artherd42 @majewsky @SuperSandro2000
-/prometheus-rules/prometheus-kubernetes-rules          @auhlig @databus23 @defo89 @businessbean @majewsky
+/prometheus-rules/prometheus-controlplane-rules        @defo89 @artherd42
+/prometheus-rules/prometheus-kubernetes-rules          @auhlig @databus23 @defo89 @businessbean
 /prometheus-rules/prometheus-openstack-rules           @artherd42 @richardtief
 /prometheus-rules/prometheus-scaleout-rules            @auhlig  # old
 /prometheus-rules/prometheus-virtual-rules             @BugRoger  # old
@@ -176,7 +176,7 @@
 
 /px/arp-discovery                                      @swagner-de
 /px/bird                                               @swagner-de @dusandordevicsap @rhalina @defo89
-/px/lg                                                 @rhalina @swagner-de @majewsky
+/px/lg                                                 @rhalina @swagner-de
 
 /system/absent-metrics-operator                        @talal @SuperSandro2000 @majewsky @VoigtS
 /system/ai-cloud-guard                                 @darpan92
@@ -199,11 +199,11 @@
 /system/cluster-api-core                               @defo89 @Nuckal777
 /system/cni-nanny                                      @defo89
 /system/conntrack-nanny                                @defo89
-/system/descheduler                                    @auhlig @defo89 @majewsky
+/system/descheduler                                    @auhlig @defo89
 /system/digicert-issuer                                @jknipper @auhlig @kayrus
 /system/disco                                          @auhlig @defo89 @databus23
 /system/doop-central                                   @majewsky @talal @SuperSandro2000 @auhlig
-/system/elk                                            @Kuckkuck @IvoGoman @majewsky
+/system/elk                                            @Kuckkuck @IvoGoman
 /system/externalip-operator                            @defo89
 /system/flatcar-linux-update-agent                     @Nuckal777 @defo89
 /system/frrouting                                      @defo89
@@ -218,22 +218,22 @@
 /system/ipmasq                                         @defo89
 /system/jaeger-operator                                @chuan137 @misamoylov @Kuckkuck
 /system/jupyter-cron-reports                           @timojohlo
-/system/jupyterhub                                     @timojohlo @majewsky @artherd42
+/system/jupyterhub                                     @timojohlo @artherd42
 /system/k3s-backup                                     @defo89
-/system/k3s-restore                                    @defo89 @majewsky  # old
+/system/k3s-restore                                    @defo89  # old
 /system/kube-cni                                       @defo89
 /system/kube-detective                                 @defo89
 /system/kube-dns                                       @defo89 @databus23
 /system/kube-fip-controller                            @auhlig @jknipper @databus23
 /system/kube-flannel                                   @defo89
-/system/kube-monitoring-admin-k3s                      @defo89 @Kuckkuck @majewsky @auhlig @talal
-/system/kube-monitoring-kubernikus                     @auhlig @jknipper @databus23 @defo89 @majewsky
-/system/kube-monitoring-metal                          @auhlig @databus23 @defo89 @majewsky @jknipper
-/system/kube-monitoring-scaleout                       @auhlig @jknipper @databus23 @majewsky @defo89
-/system/kube-monitoring-virtual                        @auhlig @defo89 @databus23 @majewsky @jknipper
+/system/kube-monitoring-admin-k3s                      @defo89 @Kuckkuck @auhlig
+/system/kube-monitoring-kubernikus                     @auhlig @jknipper @databus23 @defo89
+/system/kube-monitoring-metal                          @auhlig @databus23 @defo89 @jknipper
+/system/kube-monitoring-scaleout                       @auhlig @jknipper @databus23 @defo89
+/system/kube-monitoring-virtual                        @auhlig @defo89 @databus23 @jknipper
 /system/kube-network-helpers                           @defo89
 /system/kube-parrot                                    @defo89
-/system/kube-proxy                                     @defo89 @majewsky
+/system/kube-proxy                                     @defo89
 /system/kube-proxy-ng                                  @defo89
 /system/kube-system-addons                             @defo89
 /system/kube-system-admin-k3s                          @defo89 @Nuckal777 @jknipper @onuryilmaz @auhlig
@@ -244,41 +244,41 @@
 /system/kube-system-virtual                            @defo89 @Nuckal777 @auhlig @jknipper @onuryilmaz
 /system/kubernikus-admin-k3s                           @defo89 @databus23 @Nuckal777 @jknipper @xsen84
 /system/kubernikus-metal                               @databus23 @defo89 @Nuckal777 @jknipper @xsen84
-/system/kubernikus-monitoring                          @uwe-mayer @databus23 @jknipper @majewsky
+/system/kubernikus-monitoring                          @uwe-mayer @databus23 @jknipper
 /system/kubernikus-rbac                                @databus23
-/system/ldap-named-user                                @defo89 @majewsky
+/system/ldap-named-user                                @defo89
 /system/logs                                           @Kuckkuck @IvoGoman @businessbean @corey-aloia @Nuckal777
-/system/maintenance-controller                         @Nuckal777 @majewsky @defo89
+/system/maintenance-controller                         @Nuckal777 @defo89
 /system/manila-csi-plugin                              @jknipper
-/system/metallb                                        @majewsky @defo89  # old
-/system/metis                                          @IvoGoman @majewsky @richardtief @SuperSandro2000
-/system/metis-api                                      @IvoGoman @majewsky @SuperSandro2000
-/system/metrics-server                                 @auhlig @defo89 @majewsky
-/system/multicloudtest                                 @viennaa @majewsky
+/system/metallb                                        @defo89  # old
+/system/metis                                          @IvoGoman @richardtief
+/system/metis-api                                      @IvoGoman
+/system/metrics-server                                 @auhlig @defo89
+/system/multicloudtest                                 @viennaa
 /system/node-problem-detector                          @defo89 @databus23
 /system/nodecidr-controller                            @defo89
-/system/ntp-timeserver                                 @dhoeller @majewsky  # old
-/system/opensearch-hermes                              @Kuckkuck @majewsky
-/system/opensearch-logs                                @Kuckkuck @IvoGoman @majewsky @richardtief
-/system/plutono                                        @richardtief @thgrs @majewsky @misamoylov
+/system/ntp-timeserver                                 @dhoeller  # old
+/system/opensearch-hermes                              @Kuckkuck
+/system/opensearch-logs                                @Kuckkuck @IvoGoman @richardtief
+/system/plutono                                        @richardtief @thgrs @misamoylov
 /system/priority-class                                 @galkindmitrii  # old
 /system/prober-static                                  @defo89
 /system/prometheus-crds                                @auhlig @viennaa @richardtief
 /system/prometheus-infra                               @artherd42 @viennaa @richardtief @Kuckkuck @dhalimi
 /system/prometheus-kubernetes                          @viennaa @richardtief @Nuckal777
-/system/prometheus-operator                            @viennaa @majewsky @richardtief
+/system/prometheus-operator                            @viennaa @richardtief
 /system/provider-kubernikus                            @defo89
 /system/provider-metal3                                @defo89 @Nuckal777
 /system/rabbitmq-operator                              @galkindmitrii
 /system/runtime-extension-maintenance-controller       @Nuckal777
 /system/secrets-injector                               @Nuckal777
-/system/sentry                                         @majewsky @databus23 @notandy @SuperSandro2000 @rajivmucheli
-/system/servicemesh                                    @jknipper @SuperSandro2000 @majewsky
-/system/smee-dynakratos                                @defo89 @SchwarzM @majewsky
+/system/sentry                                         @databus23 @notandy @rajivmucheli
+/system/servicemesh                                    @jknipper
+/system/smee-dynakratos                                @defo89 @SchwarzM
 /system/storage-monitoring                             @viennaa @richardtief @artherd42 @geisslet
 /system/sysctl                                         @defo89
 /system/sysstat                                        @defo89
-/system/tarslite                                       @darpan92 @max-len @christopherhans @majewsky
+/system/tarslite                                       @darpan92 @max-len @christopherhans
 /system/tenso                                          @majewsky @SuperSandro2000 @VoigtS
 /system/tenso-seeds                                    @majewsky
 /system/thanos-metal                                   @richardtief @viennaa
@@ -288,8 +288,8 @@
 /system/toolbox-prepull                                @defo89 @SchwarzM
 /system/unbound                                        @galkindmitrii @vssldmtrv @dhoeller @mutax @defo89
 /system/validation                                     @artherd42 @thgrs @ashifnihalb
-/system/velero                                         @majewsky @databus23 @jknipper  # old
-/system/vertical-pod-autoscaler                        @auhlig @Nuckal777 @majewsky
+/system/velero                                         @databus23 @jknipper  # old
+/system/vertical-pod-autoscaler                        @auhlig @Nuckal777
 /system/vice-president                                 @databus23
 /system/vmware-monitoring                              @viennaa @richardtief @christopherhans @himanip94 @kevin-fischer
 /system/vpa-butler                                     @Nuckal777 @auhlig @defo89 @jknipper

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -125,7 +125,7 @@
 /openstack/vcf                                         @chuan137
 /openstack/volume-claims                               @fwiesel
 
-/prometheus-exporters/apic-exporter                    @artherd42 @IvoGoman @geisslet
+/prometheus-exporters/apic-exporter                    @artherd42 @IvoGoman
 /prometheus-exporters/arista-exporter                  @BerndKue @stefanhipfel
 /prometheus-exporters/blackbox-exporter                @defo89 @databus23
 /prometheus-exporters/cloudprober                      @artherd42 @defo89

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,7 +29,7 @@
 /common/staging/rabbitmq                               @notandy @Carthaca  # old
 /common/thanos                                         @viennaa @richardtief
 
-/global/andromeda                                      @notandy
+/global/andromeda                                      @notandy @m-kratochvil
 /global/bootcfg                                        @BugRoger  # old
 /global/ccloud-hedgedoc                                @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /global/chartmuseum-sapcc                              @auhlig @majewsky @SuperSandro2000 @VoigtS @Nuckal777
@@ -54,9 +54,9 @@
 /global/volta                                          @dimtass @databus23
 /global/wham                                           @databus23
 
-/openstack/andromeda-seed                              @notandy
+/openstack/andromeda-seed                              @notandy @m-kratochvil
 /openstack/arc                                         @databus23 @ArtieReus @fwiesel
-/openstack/archer                                      @notandy
+/openstack/archer                                      @notandy @m-kratochvil
 /openstack/backup-replication                          @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /openstack/barbican                                    @galkindmitrii @fwiesel @rajivmucheli @bashar-alkhateeb
 /openstack/baremetal-temper                            @databus23 @fwiesel @BerndKue
@@ -78,7 +78,7 @@
 /openstack/domain-seeds                                @BerndKue @Carthaca @fwiesel @Kuckkuck @rajivmucheli
 /openstack/elektra                                     @andypf @databus23 @ArtieReus @hgw77
 /openstack/glance                                      @fwiesel @galkindmitrii @rajivmucheli @Carthaca
-/openstack/grafanasix                                  @thgrs @richardtief @notandy
+/openstack/grafanasix                                  @thgrs @richardtief
 /openstack/hermes                                      @Kuckkuck @IvoGoman @fwiesel
 /openstack/infra-seeds/kubernetes                      @BugRoger  # old
 /openstack/ironic                                      @stefanhipfel @BerndKue @fwiesel @sandzwerg
@@ -97,7 +97,7 @@
 /openstack/nannies                                     @thgrs @chuan137 @Carthaca @fwiesel @kpawar-sap
 /openstack/neutron                                     @notandy @fwiesel @sebageek @sven-rosenzweig @rhalina @swagner-de @mutax @BenjaminLudwigSAP @m-kratochvil
 /openstack/nova                                        @joker-at-work @fwiesel @grandchild @leust
-/openstack/octavia                                     @notandy @BenjaminLudwigSAP @fwiesel @dusandordevicsap
+/openstack/octavia                                     @notandy @BenjaminLudwigSAP @fwiesel @dusandordevicsap @velp @m-kratochvil
 /openstack/octobus                                     @viennaa
 /openstack/openstack-seeder                            @stefanhipfel @databus23 @fwiesel
 /openstack/openstack_performance                       @misamoylov
@@ -272,7 +272,7 @@
 /system/rabbitmq-operator                              @galkindmitrii
 /system/runtime-extension-maintenance-controller       @Nuckal777 @defo89 @majewsky @SuperSandro2000 @VoigtS
 /system/secrets-injector                               @Nuckal777 @majewsky @SuperSandro2000 @VoigtS
-/system/sentry                                         @databus23 @notandy @rajivmucheli
+/system/sentry                                         @databus23 @rajivmucheli
 /system/servicemesh                                    @jknipper
 /system/smee-dynakratos                                @defo89 @SchwarzM
 /system/storage-monitoring                             @viennaa @richardtief @artherd42 @geisslet

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -137,7 +137,7 @@
 /prometheus-exporters/cronus-simulator                 @dhalimi
 /prometheus-exporters/cronus-updater                   @dhalimi
 /prometheus-exporters/documentation-prober             @dhalimi  # old
-/prometheus-exporters/event-exporter                   @jknipper @databus23 @Nuckal777
+/prometheus-exporters/event-exporter                   @jknipper @databus23
 /prometheus-exporters/hermes-query-exporter            @Kuckkuck
 /prometheus-exporters/ipmi-exporter                    @stefanhipfel @BerndKue @stanislav-zaprudskiy
 /prometheus-exporters/ipmi-service-discovery           @auhlig  # old
@@ -235,7 +235,7 @@
 /system/kube-parrot                                    @defo89
 /system/kube-proxy                                     @defo89
 /system/kube-proxy-ng                                  @defo89
-/system/kube-system-addons                             @defo89
+/system/kube-system-addons                             @defo89 @Nuckal777
 /system/kube-system-admin-k3s                          @defo89 @Nuckal777 @jknipper @onuryilmaz @auhlig
 /system/kube-system-global                             @defo89 @kayrus @viennaa @auhlig @Nuckal777
 /system/kube-system-kubernikus                         @auhlig @Nuckal777 @jknipper @defo89 @databus23
@@ -244,11 +244,11 @@
 /system/kube-system-virtual                            @defo89 @Nuckal777 @auhlig @jknipper @onuryilmaz
 /system/kubernikus-admin-k3s                           @defo89 @databus23 @Nuckal777 @jknipper @xsen84
 /system/kubernikus-metal                               @databus23 @defo89 @Nuckal777 @jknipper @xsen84
-/system/kubernikus-monitoring                          @uwe-mayer @databus23 @jknipper
+/system/kubernikus-monitoring                          @uwe-mayer @databus23 @jknipper @Nuckal777
 /system/kubernikus-rbac                                @databus23
 /system/ldap-named-user                                @defo89
-/system/logs                                           @Kuckkuck @IvoGoman @businessbean @corey-aloia @Nuckal777
 /system/maintenance-controller                         @Nuckal777 @defo89
+/system/logs                                           @Kuckkuck @IvoGoman @businessbean @corey-aloia
 /system/manila-csi-plugin                              @jknipper
 /system/metallb                                        @defo89  # old
 /system/metis                                          @IvoGoman @richardtief
@@ -270,7 +270,7 @@
 /system/provider-kubernikus                            @defo89
 /system/provider-metal3                                @defo89 @Nuckal777
 /system/rabbitmq-operator                              @galkindmitrii
-/system/runtime-extension-maintenance-controller       @Nuckal777
+/system/runtime-extension-maintenance-controller       @Nuckal777 @defo89
 /system/secrets-injector                               @Nuckal777
 /system/sentry                                         @databus23 @notandy @rajivmucheli
 /system/servicemesh                                    @jknipper
@@ -289,8 +289,8 @@
 /system/unbound                                        @galkindmitrii @vssldmtrv @dhoeller @mutax @defo89
 /system/validation                                     @artherd42 @thgrs @ashifnihalb
 /system/velero                                         @databus23 @jknipper  # old
-/system/vertical-pod-autoscaler                        @auhlig @Nuckal777
+/system/vertical-pod-autoscaler                        @Nuckal777
 /system/vice-president                                 @databus23
 /system/vmware-monitoring                              @viennaa @richardtief @christopherhans @himanip94 @kevin-fischer
-/system/vpa-butler                                     @Nuckal777 @auhlig @defo89 @jknipper
+/system/vpa-butler                                     @Nuckal777
 /system/wormhole                                       @defo89

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,7 +47,7 @@
 /global/prometheus-uber                                @auhlig  # old
 /global/schedules2slack                                @geisslet
 /global/slack-alert-reactions                          @uwe-mayer
-/global/supernova                                      @andypf @ArtieReus @edda @hgw
+/global/supernova                                      @andypf @ArtieReus @edda @hgw77
 /global/thanos-global                                  @viennaa @richardtief
 /global/vault                                          @BugRoger  # old
 /global/vault-tec                                      @Nuckal777 @majewsky @SuperSandro2000 @VoigtS

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@
 /common/manila-provisioner                             @jknipper  # old
 /common/mariadb                                        @galkindmitrii @stefanhipfel @Carthaca @IvoGoman @fwiesel @businessbean
 /common/memcached                                      @auhlig @businessbean @bashar-alkhateeb
-/common/mysql_metrics                                  @galkindmitrii @Carthaca
+/common/mysql-metrics                                  @galkindmitrii @Carthaca
 /common/nats                                           @notandy
 /common/owner-info                                     @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /common/pgbackup                                       @majewsky @SuperSandro2000 @VoigtS @Nuckal777
@@ -24,7 +24,7 @@
 /common/prometheus-server                              @auhlig @viennaa @databus23 @richardtief @defo89
 /common/prometheus-server-pre7                         @viennaa @richardtief @auhlig @defo89
 /common/rabbitmq                                       @galkindmitrii @fwiesel @Carthaca @bashar-alkhateeb @dusandordevicsap @businessbean
-/common/rabbitmq_cluster                               @galkindmitrii @notandy @defo89 @businessbean
+/common/rabbitmq-cluster                               @galkindmitrii @notandy @defo89 @businessbean
 /common/redis                                          @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /common/staging/rabbitmq                               @notandy @Carthaca  # old
 /common/thanos                                         @viennaa @richardtief
@@ -40,7 +40,7 @@
 /global/git-cert-shim                                  @auhlig
 /global/kibana-objecter                                @dimtass
 /global/oauth-proxy                                    @andypf @ArtieReus @databus23
-/global/percona_cluster                                @galkindmitrii @defo89
+/global/percona-cluster                                @galkindmitrii @defo89
 /global/prometheus-alertmanager-cnmp                   @auhlig
 /global/prometheus-alertmanager-operated               @geisslet @auhlig @uwe-mayer @viennaa
 /global/prometheus-infra                               @artherd42 @Kuckkuck @viennaa @richardtief @BerndKue
@@ -98,7 +98,7 @@
 /openstack/octavia                                     @notandy @BenjaminLudwigSAP @fwiesel @dusandordevicsap @velp @m-kratochvil
 /openstack/octobus                                     @viennaa
 /openstack/openstack-seeder                            @stefanhipfel @databus23 @fwiesel
-/openstack/openstack_performance                       @misamoylov
+/openstack/openstack-performance                       @misamoylov
 /openstack/placement                                   @fwiesel @joker-at-work @bashar-alkhateeb @galkindmitrii
 /openstack/poller                                      @dhalimi1975 @corey-aloia
 /openstack/prometheus-openstack                        @viennaa @artherd42 @richardtief @Kuckkuck

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -79,7 +79,7 @@
 /openstack/elektra                                     @andypf @databus23 @ArtieReus @hgw77
 /openstack/glance                                      @fwiesel @galkindmitrii @rajivmucheli @Carthaca
 /openstack/grafanasix                                  @thgrs @richardtief
-/openstack/hermes                                      @Kuckkuck @IvoGoman @fwiesel
+/openstack/hermes                                      @notque @Kuckkuck @IvoGoman @fwiesel
 /openstack/infra-seeds/kubernetes                      @BugRoger  # old
 /openstack/ironic                                      @stefanhipfel @BerndKue @fwiesel @sandzwerg
 /openstack/keppel                                      @majewsky @SuperSandro2000 @VoigtS @Nuckal777
@@ -90,7 +90,7 @@
 /openstack/kubernikus                                  @fwiesel @jknipper
 /openstack/limes                                       @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /openstack/lyra                                        @databus23 @ArtieReus
-/openstack/maia                                        @artherd42 @viennaa @richardtief @Kuckkuck @dhalimi1975
+/openstack/maia                                        @notque @artherd42 @viennaa @richardtief @Kuckkuck @dhalimi1975
 /openstack/manila*                                     @Carthaca @chuan137 @galkindmitrii @kpawar-sap
 /openstack/nannies                                     @thgrs @chuan137 @Carthaca @fwiesel @kpawar-sap
 /openstack/neutron                                     @notandy @fwiesel @sebageek @sven-rosenzweig @rhalina @swagner-de @mutax @BenjaminLudwigSAP @m-kratochvil @occamshatchet
@@ -136,7 +136,7 @@
 /prometheus-exporters/cronus-updater                   @dhalimi1975
 /prometheus-exporters/documentation-prober             @dhalimi1975  # old
 /prometheus-exporters/event-exporter                   @jknipper @databus23
-/prometheus-exporters/hermes-query-exporter            @Kuckkuck
+/prometheus-exporters/hermes-query-exporter            @Kuckkuck @notque
 /prometheus-exporters/ipmi-exporter                    @stefanhipfel @BerndKue
 /prometheus-exporters/ipmi-service-discovery           @auhlig  # old
 /prometheus-exporters/ironic-exporter                  @BerndKue @stefanhipfel
@@ -256,7 +256,7 @@
 /system/node-problem-detector                          @defo89 @databus23
 /system/nodecidr-controller                            @defo89
 /system/ntp-timeserver                                 @dhoeller  # old
-/system/opensearch-hermes                              @Kuckkuck
+/system/opensearch-hermes                              @Kuckkuck @notque
 /system/opensearch-logs                                @Kuckkuck @IvoGoman @richardtief
 /system/plutono                                        @richardtief @thgrs @misamoylov
 /system/priority-class                                 @galkindmitrii  # old

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -75,7 +75,7 @@
 /openstack/db-backup-v2                                @databus23 @fwiesel
 /openstack/designate                                   @galkindmitrii @fwiesel @majewsky @mutax @kpawar-sap
 /openstack/designate-nanny                             @mutax
-/openstack/domain-seeds                                @BerndKue @majewsky @Carthaca @fwiesel @Kuckkuck
+/openstack/domain-seeds                                @BerndKue @majewsky @Carthaca @fwiesel @Kuckkuck @rajivmucheli
 /openstack/elektra                                     @andypf @majewsky @databus23 @ArtieReus @hgw77
 /openstack/glance                                      @fwiesel @galkindmitrii @majewsky @rajivmucheli @Carthaca
 /openstack/grafanasix                                  @thgrs @majewsky @richardtief @SuperSandro2000 @notandy
@@ -84,7 +84,7 @@
 /openstack/ironic                                      @stefanhipfel @BerndKue @fwiesel @sandzwerg @majewsky
 /openstack/keppel                                      @majewsky @SuperSandro2000 @VoigtS @geisslet
 /openstack/keppel-trivy                                @SuperSandro2000 @majewsky @VoigtS
-/openstack/keystone                                    @galkindmitrii @Carthaca @bbobrov @majewsky @fwiesel
+/openstack/keystone                                    @galkindmitrii @Carthaca @bbobrov @majewsky @fwiesel @rajivmucheli
 /openstack/kos-operator                                @stefanhipfel @databus23
 /openstack/kubernetes                                  @fwiesel
 /openstack/kubernikus                                  @fwiesel @jknipper
@@ -95,7 +95,7 @@
 /openstack/manila-antelope                             @Carthaca @dusandordevicsap
 /openstack/manila-nanny                                @chuan137 @Carthaca @dusandordevicsap
 /openstack/nannies                                     @thgrs @chuan137 @Carthaca @fwiesel @kpawar-sap
-/openstack/neutron                                     @notandy @fwiesel @sebageek @majewsky @sven-rosenzweig
+/openstack/neutron                                     @notandy @fwiesel @sebageek @majewsky @sven-rosenzweig @rhalina @swagner-de @mutax @BenjaminLudwigSAP @m-kratochvil
 /openstack/nova                                        @joker-at-work @fwiesel @grandchild @majewsky @leust
 /openstack/octavia                                     @notandy @BenjaminLudwigSAP @fwiesel @majewsky @dusandordevicsap
 /openstack/octobus                                     @majewsky @viennaa
@@ -106,16 +106,16 @@
 /openstack/prometheus-openstack                        @viennaa @artherd42 @richardtief @Kuckkuck @majewsky
 /openstack/pyroscope                                   @fwiesel
 /openstack/sap-seeds                                   @dhoeller @grandchild @frr2018 @joker-at-work @fwiesel
-/openstack/sre                                         @artherd42 @fwiesel
+/openstack/sre                                         @artherd42 @fwiesel @rajivmucheli
 /openstack/swift                                       @majewsky @SuperSandro2000 @talal @crenduchinta88
 /openstack/swift-drive-autopilot                       @majewsky
 /openstack/swift-utils                                 @majewsky @SuperSandro2000
-/openstack/tempest/barbican-tempest                    @misamoylov @majewsky @fwiesel
+/openstack/tempest/barbican-tempest                    @misamoylov @majewsky @fwiesel @rajivmucheli
 /openstack/tempest/cinder-tempest                      @misamoylov @majewsky @fwiesel
 /openstack/tempest/designate-tempest                   @misamoylov @majewsky @fwiesel
-/openstack/tempest/glance-tempest                      @majewsky @misamoylov @fwiesel
+/openstack/tempest/glance-tempest                      @majewsky @misamoylov @fwiesel @rajivmucheli
 /openstack/tempest/ironic-tempest                      @misamoylov @majewsky @fwiesel
-/openstack/tempest/keystone-tempest                    @majewsky @misamoylov @fwiesel
+/openstack/tempest/keystone-tempest                    @majewsky @misamoylov @fwiesel @rajivmucheli
 /openstack/tempest/manila-tempest                      @kpawar-sap @misamoylov @majewsky @fwiesel
 /openstack/tempest/neutron-tempest                     @misamoylov @majewsky @fwiesel
 /openstack/tempest/nova-tempest                        @misamoylov @majewsky @fwiesel
@@ -272,7 +272,7 @@
 /system/rabbitmq-operator                              @galkindmitrii
 /system/runtime-extension-maintenance-controller       @Nuckal777
 /system/secrets-injector                               @Nuckal777
-/system/sentry                                         @majewsky @databus23 @notandy @SuperSandro2000
+/system/sentry                                         @majewsky @databus23 @notandy @SuperSandro2000 @rajivmucheli
 /system/servicemesh                                    @jknipper @SuperSandro2000 @majewsky
 /system/smee-dynakratos                                @defo89 @SchwarzM @majewsky
 /system/storage-monitoring                             @viennaa @richardtief @artherd42 @geisslet

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,7 +32,7 @@
 /global/andromeda                                      @notandy @majewsky
 /global/bootcfg                                        @BugRoger  # old
 /global/ccloud-hedgedoc                                @majewsky @SuperSandro2000 @sebageek
-/global/chartmuseum-sapcc                              @auhlig @majewsky @SuperSandro2000 @reimannf
+/global/chartmuseum-sapcc                              @auhlig @majewsky @SuperSandro2000
 /global/concourse-main                                 @jknipper @majewsky @SuperSandro2000 @andypf
 /global/concourse-worker                               @databus23 @kayrus  # old
 /global/geminabox                                      @databus23
@@ -61,15 +61,15 @@
 /openstack/barbican                                    @galkindmitrii @fwiesel @majewsky @rajivmucheli @bashar-alkhateeb
 /openstack/baremetal-temper                            @majewsky @databus23 @fwiesel @BerndKue
 /openstack/bastion                                     @majewsky @fwiesel
-/openstack/billing                                     @majewsky @reimannf
-/openstack/blackbox                                    @artherd42 @majewsky @fwiesel @reimannf @m-kratochvil
+/openstack/billing                                     @majewsky
+/openstack/blackbox                                    @artherd42 @majewsky @fwiesel @m-kratochvil
 /openstack/castellum                                   @majewsky @SuperSandro2000 @VoigtS @richardtief
 /openstack/cbshelf                                     @corey-aloia @majewsky
 /openstack/cc3test                                     @artherd42 @thgrs @ashifnihalb @majewsky @Carthaca
-/openstack/cc3test-seeds                               @artherd42 @thgrs @fwiesel @reimannf
+/openstack/cc3test-seeds                               @artherd42 @thgrs @fwiesel
 /openstack/cerebro                                     @viennaa @majewsky
 /openstack/cinder                                      @joker-at-work @hemna @fwiesel @majewsky @dusandordevicsap
-/openstack/content-repo                                @reimannf @majewsky @SuperSandro2000 @talal @VoigtS
+/openstack/content-repo                                @majewsky @SuperSandro2000 @talal @VoigtS
 /openstack/cronus                                      @kayrus @dhalimi @corey-aloia @majewsky @fwiesel
 /openstack/cronus-seed                                 @kayrus @dhalimi @majewsky
 /openstack/db-backup-v2                                @databus23 @fwiesel
@@ -79,17 +79,17 @@
 /openstack/elektra                                     @andypf @majewsky @databus23 @ArtieReus @hgw77
 /openstack/glance                                      @fwiesel @galkindmitrii @majewsky @rajivmucheli @Carthaca
 /openstack/grafanasix                                  @thgrs @majewsky @richardtief @SuperSandro2000 @notandy
-/openstack/hermes                                      @Kuckkuck @majewsky @IvoGoman @fwiesel @reimannf
+/openstack/hermes                                      @Kuckkuck @majewsky @IvoGoman @fwiesel
 /openstack/infra-seeds/kubernetes                      @BugRoger  # old
 /openstack/ironic                                      @stefanhipfel @BerndKue @fwiesel @sandzwerg @majewsky
-/openstack/keppel                                      @majewsky @SuperSandro2000 @reimannf @VoigtS @geisslet
+/openstack/keppel                                      @majewsky @SuperSandro2000 @VoigtS @geisslet
 /openstack/keppel-trivy                                @SuperSandro2000 @majewsky @VoigtS
 /openstack/keystone                                    @galkindmitrii @Carthaca @bbobrov @majewsky @fwiesel
 /openstack/kos-operator                                @stefanhipfel @databus23
 /openstack/kubernetes                                  @fwiesel
-/openstack/kubernikus                                  @fwiesel @reimannf @jknipper
-/openstack/limes                                       @majewsky @SuperSandro2000 @reimannf @fwiesel @VoigtS
-/openstack/lyra                                        @databus23 @ArtieReus @majewsky @reimannf @SuperSandro2000
+/openstack/kubernikus                                  @fwiesel @jknipper
+/openstack/limes                                       @majewsky @SuperSandro2000 @fwiesel @VoigtS
+/openstack/lyra                                        @databus23 @ArtieReus @majewsky @SuperSandro2000
 /openstack/maia                                        @artherd42 @viennaa @richardtief @Kuckkuck @dhalimi
 /openstack/manila                                      @Carthaca @chuan137 @galkindmitrii @majewsky @kpawar-sap
 /openstack/manila-antelope                             @Carthaca @dusandordevicsap
@@ -101,15 +101,15 @@
 /openstack/octobus                                     @majewsky @viennaa
 /openstack/openstack-seeder                            @stefanhipfel @databus23 @fwiesel
 /openstack/openstack_performance                       @misamoylov
-/openstack/placement                                   @fwiesel @joker-at-work @bashar-alkhateeb @galkindmitrii @reimannf
+/openstack/placement                                   @fwiesel @joker-at-work @bashar-alkhateeb @galkindmitrii
 /openstack/poller                                      @dhalimi @corey-aloia
 /openstack/prometheus-openstack                        @viennaa @artherd42 @richardtief @Kuckkuck @majewsky
 /openstack/pyroscope                                   @fwiesel
 /openstack/sap-seeds                                   @dhoeller @grandchild @frr2018 @joker-at-work @fwiesel
 /openstack/sre                                         @artherd42 @fwiesel
-/openstack/swift                                       @reimannf @majewsky @SuperSandro2000 @talal @crenduchinta88
-/openstack/swift-drive-autopilot                       @majewsky @reimannf
-/openstack/swift-utils                                 @reimannf @majewsky @SuperSandro2000
+/openstack/swift                                       @majewsky @SuperSandro2000 @talal @crenduchinta88
+/openstack/swift-drive-autopilot                       @majewsky
+/openstack/swift-utils                                 @majewsky @SuperSandro2000
 /openstack/tempest/barbican-tempest                    @misamoylov @majewsky @fwiesel
 /openstack/tempest/cinder-tempest                      @misamoylov @majewsky @fwiesel
 /openstack/tempest/designate-tempest                   @misamoylov @majewsky @fwiesel
@@ -202,7 +202,7 @@
 /system/descheduler                                    @auhlig @defo89 @majewsky
 /system/digicert-issuer                                @jknipper @auhlig @kayrus
 /system/disco                                          @auhlig @defo89 @databus23
-/system/doop-central                                   @majewsky @talal @SuperSandro2000 @auhlig @reimannf
+/system/doop-central                                   @majewsky @talal @SuperSandro2000 @auhlig
 /system/elk                                            @Kuckkuck @IvoGoman @majewsky
 /system/externalip-operator                            @defo89
 /system/flatcar-linux-update-agent                     @Nuckal777 @defo89
@@ -280,7 +280,7 @@
 /system/sysstat                                        @defo89
 /system/tarslite                                       @darpan92 @max-len @christopherhans @majewsky
 /system/tenso                                          @majewsky @SuperSandro2000 @VoigtS
-/system/tenso-seeds                                    @majewsky @reimannf
+/system/tenso-seeds                                    @majewsky
 /system/thanos-metal                                   @richardtief @viennaa
 /system/thanos-operator                                @viennaa
 /system/thanos-scaleout                                @richardtief @viennaa

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -70,8 +70,8 @@
 /openstack/cerebro                                     @viennaa
 /openstack/cinder                                      @joker-at-work @hemna @fwiesel @dusandordevicsap
 /openstack/content-repo                                @majewsky @SuperSandro2000 @VoigtS @Nuckal777
-/openstack/cronus                                      @kayrus @dhalimi @corey-aloia @fwiesel
-/openstack/cronus-seed                                 @kayrus @dhalimi
+/openstack/cronus                                      @kayrus @dhalimi1975 @corey-aloia @fwiesel
+/openstack/cronus-seed                                 @kayrus @dhalimi1975
 /openstack/db-backup-v2                                @databus23 @fwiesel
 /openstack/designate                                   @galkindmitrii @fwiesel @mutax @kpawar-sap @vssldmtrv @mbrowny @SoenkeL
 /openstack/designate-nanny                             @mutax @vssldmtrv @mbrowny @SoenkeL @galkindmitrii
@@ -90,7 +90,7 @@
 /openstack/kubernikus                                  @fwiesel @jknipper
 /openstack/limes                                       @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /openstack/lyra                                        @databus23 @ArtieReus
-/openstack/maia                                        @artherd42 @viennaa @richardtief @Kuckkuck @dhalimi
+/openstack/maia                                        @artherd42 @viennaa @richardtief @Kuckkuck @dhalimi1975
 /openstack/manila                                      @Carthaca @chuan137 @galkindmitrii @kpawar-sap
 /openstack/manila-antelope                             @Carthaca @dusandordevicsap
 /openstack/manila-nanny                                @chuan137 @Carthaca @dusandordevicsap
@@ -102,7 +102,7 @@
 /openstack/openstack-seeder                            @stefanhipfel @databus23 @fwiesel
 /openstack/openstack_performance                       @misamoylov
 /openstack/placement                                   @fwiesel @joker-at-work @bashar-alkhateeb @galkindmitrii
-/openstack/poller                                      @dhalimi @corey-aloia
+/openstack/poller                                      @dhalimi1975 @corey-aloia
 /openstack/prometheus-openstack                        @viennaa @artherd42 @richardtief @Kuckkuck
 /openstack/pyroscope                                   @fwiesel
 /openstack/sap-seeds                                   @dhoeller @grandchild @frr2018 @joker-at-work @fwiesel
@@ -131,12 +131,12 @@
 /prometheus-exporters/arista-exporter                  @BerndKue @stefanhipfel
 /prometheus-exporters/blackbox-exporter                @defo89 @databus23
 /prometheus-exporters/cloudprober                      @artherd42 @defo89
-/prometheus-exporters/cronus-exporter                  @dhalimi @LimorGargir @richardtief @geisslet
-/prometheus-exporters/cronus-openstack-alerts          @dhalimi
-/prometheus-exporters/cronus-reporter                  @dhalimi
-/prometheus-exporters/cronus-simulator                 @dhalimi
-/prometheus-exporters/cronus-updater                   @dhalimi
-/prometheus-exporters/documentation-prober             @dhalimi  # old
+/prometheus-exporters/cronus-exporter                  @dhalimi1975 @LimorGargir @richardtief @geisslet
+/prometheus-exporters/cronus-openstack-alerts          @dhalimi1975
+/prometheus-exporters/cronus-reporter                  @dhalimi1975
+/prometheus-exporters/cronus-simulator                 @dhalimi1975
+/prometheus-exporters/cronus-updater                   @dhalimi1975
+/prometheus-exporters/documentation-prober             @dhalimi1975  # old
 /prometheus-exporters/event-exporter                   @jknipper @databus23
 /prometheus-exporters/hermes-query-exporter            @Kuckkuck
 /prometheus-exporters/ipmi-exporter                    @stefanhipfel @BerndKue
@@ -157,7 +157,7 @@
 /prometheus-exporters/opensearch-logs-query-exporter   @Kuckkuck @dimtass @chuan137 @databus23
 /prometheus-exporters/openstack-exporter               @viennaa @hemna @crenduchinta88 @kevin-fischer
 /prometheus-exporters/ping-exporter                    @auhlig @defo89  # old
-/prometheus-exporters/poller-simulator                 @dhalimi @corey-aloia
+/prometheus-exporters/poller-simulator                 @dhalimi1975 @corey-aloia
 /prometheus-exporters/redfish-exporter                 @BerndKue @stefanhipfel
 /prometheus-exporters/snmp-exporter                    @Kuckkuck @swagner-de @m-kratochvil @IvoGoman @defo89
 /prometheus-exporters/snmp-ntp-exporter                @geisslet
@@ -264,7 +264,7 @@
 /system/priority-class                                 @galkindmitrii  # old
 /system/prober-static                                  @defo89
 /system/prometheus-crds                                @auhlig @viennaa @richardtief
-/system/prometheus-infra                               @artherd42 @viennaa @richardtief @Kuckkuck @dhalimi
+/system/prometheus-infra                               @artherd42 @viennaa @richardtief @Kuckkuck @dhalimi1975
 /system/prometheus-kubernetes                          @viennaa @richardtief @Nuckal777
 /system/prometheus-operator                            @viennaa @richardtief
 /system/provider-kubernikus                            @defo89

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -163,15 +163,15 @@
 /prometheus-exporters/statsd-exporter                  @thgrs @ashifnihalb @artherd42
 /prometheus-exporters/systemd-lldp-exporter            @auhlig  # old
 /prometheus-exporters/tempest-exporter                 @misamoylov
-/prometheus-exporters/ucs-exporter                     @BerndKue @killermoehre
+/prometheus-exporters/ucs-exporter                     @BerndKue
 /prometheus-exporters/watchcache-exporter              @jknipper @databus23
 
-/prometheus-rules/prometheus-controlplane-rules        @vienna @richardtief @defo89
-/prometheus-rules/prometheus-kubernetes-rules          @vienna @richardtief @defo89
-/prometheus-rules/prometheus-openstack-rules           @vienna @richardtief @defo89
-/prometheus-rules/prometheus-scaleout-rules            @vienna @richardtief @defo89  # old
-/prometheus-rules/prometheus-virtual-rules             @vienna @richardtief @defo89  # old
-/prometheus-rules/prometheus-vmware-rules              @kevin-fischer @christopherhans @max-len @richardtief @vienna @himanip94
+/prometheus-rules/prometheus-controlplane-rules        @viennaa @richardtief @defo89
+/prometheus-rules/prometheus-kubernetes-rules          @viennaa @richardtief @defo89
+/prometheus-rules/prometheus-openstack-rules           @viennaa @richardtief @defo89
+/prometheus-rules/prometheus-scaleout-rules            @viennaa @richardtief @defo89  # old
+/prometheus-rules/prometheus-virtual-rules             @viennaa @richardtief @defo89  # old
+/prometheus-rules/prometheus-vmware-rules              @kevin-fischer @christopherhans @max-len @richardtief @viennaa @himanip94
 
 /px/arp-discovery                                      @swagner-de
 /px/bird                                               @swagner-de @dusandordevicsap @rhalina @defo89 @occamshatchet

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -250,8 +250,8 @@
 /system/maintenance-controller                         @Nuckal777 @defo89 @majewsky @SuperSandro2000 @VoigtS
 /system/manila-csi-plugin                              @jknipper
 /system/metallb                                        @defo89  # old
-/system/metis                                          @IvoGoman @richardtief
-/system/metis-api                                      @IvoGoman
+/system/metis                                          @IvoGoman @timojohlo @richardtief
+/system/metis-api                                      @IvoGoman @timojohlo
 /system/metrics-server                                 @auhlig @defo89
 /system/multicloudtest                                 @viennaa
 /system/node-problem-detector                          @defo89 @databus23

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,297 @@
+*                                                      @BugRoger @databus23 @dhoeller @edda @geisslet
+/.github/CODEOWNERS                                    @BugRoger @databus23 @dhoeller @edda @geisslet
+
+/ci                                                    @auhlig @Kuckkuck @businessbean @jknipper @fwiesel
+
+/common/helm3-helper                                   @SchwarzM  # old
+/common/manila-provisioner                             @jknipper  # old
+/common/mariadb                                        @galkindmitrii @stefanhipfel @Carthaca @IvoGoman @fwiesel
+/common/memcached                                      @auhlig @businessbean @majewsky @SuperSandro2000 @bashar-alkhateeb
+/common/mysql_metrics                                  @galkindmitrii @Carthaca
+/common/nats                                           @notandy
+/common/owner-info                                     @majewsky @SuperSandro2000
+/common/pgmetrics                                      @majewsky @SuperSandro2000 @VoigtS
+/common/postgresql                                     @majewsky @fwiesel @auhlig @VoigtS @SuperSandro2000
+/common/prometheus-alertmanager-base                   @auhlig @viennaa @uwe-mayer @majewsky @richardtief
+/common/prometheus-monitors                            @IvoGoman
+/common/prometheus-pushgateway                         @viennaa @majewsky
+/common/prometheus-server                              @auhlig @viennaa @databus23 @richardtief @defo89
+/common/prometheus-server-pre7                         @viennaa @richardtief @majewsky @auhlig @defo89
+/common/rabbitmq                                       @galkindmitrii @fwiesel @Carthaca @bashar-alkhateeb @dusandordevicsap
+/common/rabbitmq_cluster                               @galkindmitrii @notandy @defo89
+/common/redis                                          @SuperSandro2000 @majewsky @auhlig @VoigtS @fwiesel
+/common/staging/rabbitmq                               @majewsky @notandy @Carthaca  # old
+/common/thanos                                         @viennaa @richardtief @majewsky @SuperSandro2000
+/common/pgbackup                                       @majewsky @SuperSandro2000 @ArtieReus @VoigtS
+/common/inventory-updater                              @BerndKue @stanislav-zaprudskiy
+/common/postgresql-test                                @majewsky @SuperSandro2000
+/common/linkerd-support                                @majewsky @SuperSandro2000 @viennaa
+/common/postgresql-ng-test                             @SuperSandro2000 @majewsky
+/common/postgresql-ng                                  @SuperSandro2000 @majewsky @stanislav-zaprudskiy @jknipper @stefanhipfel
+
+/global/andromeda                                      @notandy @majewsky
+/global/bootcfg                                        @BugRoger  # old
+/global/chartmuseum-sapcc                              @auhlig @majewsky @SuperSandro2000 @reimannf
+/global/concourse-main                                 @jknipper @majewsky @SuperSandro2000 @andypf
+/global/concourse-worker                               @databus23 @kayrus  # old
+/global/geminabox                                      @databus23
+/global/git-cert-shim                                  @majewsky @auhlig
+/global/oauth-proxy                                    @andypf @majewsky @ArtieReus @databus23
+/global/percona_cluster                                @galkindmitrii @defo89
+/global/prometheus-alertmanager-cnmp                   @auhlig @majewsky
+/global/prometheus-alertmanager-operated               @geisslet @auhlig @uwe-mayer @viennaa @majewsky
+/global/prometheus-infra                               @artherd42 @Kuckkuck @viennaa @richardtief @BerndKue
+/global/prometheus-uber                                @auhlig  # old
+/global/slack-alert-reactions                          @uwe-mayer
+/global/supernova                                      @andypf @majewsky @ArtieReus @auhlig @databus23
+/global/thanos-global                                  @viennaa @richardtief
+/global/vault                                          @BugRoger  # old
+/global/volta                                          @dimtass @databus23
+/global/wham                                           @databus23
+/global/ccloud-hedgedoc                                @majewsky @SuperSandro2000 @sebageek
+/global/kibana-objecter                                @dimtass
+/global/gh-actions                                     @notandy @auhlig
+/global/vault-tec                                      @Nuckal777
+/global/schedules2slack                                @geisslet
+
+/openstack/andromeda-seed                              @notandy @majewsky
+/openstack/arc                                         @databus23 @ArtieReus @majewsky @SuperSandro2000 @fwiesel
+/openstack/backup-replication                          @majewsky @SuperSandro2000 @VoigtS
+/openstack/barbican                                    @galkindmitrii @fwiesel @majewsky @rajivmucheli @bashar-alkhateeb
+/openstack/baremetal-temper                            @majewsky @databus23 @fwiesel @BerndKue
+/openstack/bastion                                     @majewsky @fwiesel
+/openstack/billing                                     @majewsky @reimannf
+/openstack/blackbox                                    @artherd42 @majewsky @fwiesel @reimannf @m-kratochvil
+/openstack/castellum                                   @majewsky @SuperSandro2000 @VoigtS @richardtief
+/openstack/cc3test                                     @artherd42 @thgrs @ashifnihalb @majewsky @Carthaca
+/openstack/cc3test-seeds                               @artherd42 @thgrs @fwiesel @reimannf
+/openstack/cerebro                                     @viennaa @majewsky
+/openstack/cinder                                      @joker-at-work @hemna @fwiesel @majewsky @dusandordevicsap
+/openstack/content-repo                                @reimannf @majewsky @SuperSandro2000 @talal @VoigtS
+/openstack/cronus                                      @kayrus @dhalimi @corey-aloia @majewsky @fwiesel
+/openstack/cronus-seed                                 @kayrus @dhalimi @majewsky
+/openstack/db-backup-v2                                @databus23 @fwiesel
+/openstack/designate                                   @galkindmitrii @fwiesel @majewsky @mutax @kpawar-sap
+/openstack/domain-seeds                                @BerndKue @majewsky @Carthaca @fwiesel @Kuckkuck
+/openstack/elektra                                     @andypf @majewsky @databus23 @ArtieReus @hgw77
+/openstack/glance                                      @fwiesel @galkindmitrii @majewsky @rajivmucheli @Carthaca
+/openstack/grafanasix                                  @thgrs @majewsky @richardtief @SuperSandro2000 @notandy
+/openstack/hermes                                      @Kuckkuck @majewsky @IvoGoman @fwiesel @reimannf
+/openstack/infra-seeds/kubernetes                      @BugRoger  # old
+/openstack/ironic                                      @stefanhipfel @BerndKue @fwiesel @sandzwerg @majewsky
+/openstack/keppel                                      @majewsky @SuperSandro2000 @reimannf @VoigtS @geisslet
+/openstack/keystone                                    @galkindmitrii @Carthaca @bbobrov @majewsky @fwiesel
+/openstack/kos-operator                                @stefanhipfel @databus23
+/openstack/kubernetes                                  @fwiesel
+/openstack/kubernikus                                  @fwiesel @reimannf @jknipper
+/openstack/limes                                       @majewsky @SuperSandro2000 @reimannf @fwiesel @VoigtS
+/openstack/lyra                                        @databus23 @ArtieReus @majewsky @reimannf @SuperSandro2000
+/openstack/maia                                        @artherd42 @viennaa @richardtief @Kuckkuck @dhalimi
+/openstack/manila                                      @Carthaca @chuan137 @galkindmitrii @majewsky @kpawar-sap
+/openstack/nannies                                     @thgrs @chuan137 @Carthaca @fwiesel @kpawar-sap
+/openstack/neutron                                     @notandy @fwiesel @sebageek @majewsky @sven-rosenzweig
+/openstack/nova                                        @joker-at-work @fwiesel @grandchild @majewsky @leust
+/openstack/octavia                                     @notandy @BenjaminLudwigSAP @fwiesel @majewsky @dusandordevicsap
+/openstack/octobus                                     @majewsky @viennaa
+/openstack/openstack-seeder                            @stefanhipfel @databus23 @fwiesel
+/openstack/placement                                   @fwiesel @joker-at-work @bashar-alkhateeb @galkindmitrii @reimannf
+/openstack/prometheus-openstack                        @viennaa @artherd42 @richardtief @Kuckkuck @majewsky
+/openstack/sap-seeds                                   @dhoeller @grandchild @frr2018 @joker-at-work @fwiesel
+/openstack/sre                                         @artherd42 @fwiesel
+/openstack/swift                                       @reimannf @majewsky @SuperSandro2000 @talal @crenduchinta88
+/openstack/swift-drive-autopilot                       @majewsky @reimannf
+/openstack/swift-utils                                 @reimannf @majewsky @SuperSandro2000
+/openstack/tempest/barbican-tempest                    @misamoylov @majewsky @fwiesel
+/openstack/tempest/cinder-tempest                      @misamoylov @majewsky @fwiesel
+/openstack/tempest/designate-tempest                   @misamoylov @majewsky @fwiesel
+/openstack/tempest/glance-tempest                      @majewsky @misamoylov @fwiesel
+/openstack/tempest/ironic-tempest                      @misamoylov @majewsky @fwiesel
+/openstack/tempest/keystone-tempest                    @majewsky @misamoylov @fwiesel
+/openstack/tempest/manila-tempest                      @kpawar-sap @misamoylov @majewsky @fwiesel
+/openstack/tempest/neutron-tempest                     @misamoylov @majewsky @fwiesel
+/openstack/tempest/nova-tempest                        @misamoylov @majewsky @fwiesel
+/openstack/tempest/octavia-tempest                     @misamoylov @fwiesel @majewsky
+/openstack/tempest/tempest-base                        @misamoylov @fwiesel @stefanhipfel
+/openstack/utils                                       @fwiesel @notandy @galkindmitrii @Carthaca @joker-at-work
+/openstack/vcenter-operator                            @joker-at-work @fwiesel @majewsky @databus23
+/openstack/vcf                                         @chuan137
+/openstack/volume-claims                               @majewsky @fwiesel
+/openstack/archer                                      @notandy @majewsky
+/openstack/cbshelf                                     @corey-aloia @majewsky
+/openstack/keppel-trivy                                @SuperSandro2000 @majewsky @VoigtS
+/openstack/openstack_performance                       @misamoylov
+/openstack/manila-nanny                                @chuan137 @Carthaca @dusandordevicsap
+/openstack/poller                                      @dhalimi @corey-aloia
+/openstack/designate-nanny                             @mutax
+/openstack/manila-antelope                             @Carthaca @dusandordevicsap
+/openstack/pyroscope                                   @fwiesel
+/openstack/trust-manager                               @fwiesel
+
+/prometheus-exporters/apic-exporter                    @artherd42 @IvoGoman @geisslet
+/prometheus-exporters/arista-exporter                  @BerndKue @stanislav-zaprudskiy @stefanhipfel
+/prometheus-exporters/blackbox-exporter                @defo89 @databus23
+/prometheus-exporters/cloudprober                      @artherd42 @defo89
+/prometheus-exporters/cronus-exporter                  @dhalimi @majewsky @LimorGargir @richardtief @geisslet
+/prometheus-exporters/cronus-simulator                 @dhalimi @majewsky
+/prometheus-exporters/cronus-updater                   @dhalimi @majewsky
+/prometheus-exporters/documentation-prober             @dhalimi @majewsky  # old
+/prometheus-exporters/event-exporter                   @jknipper @databus23 @Nuckal777
+/prometheus-exporters/hermes-query-exporter            @Kuckkuck
+/prometheus-exporters/ipmi-exporter                    @stefanhipfel @BerndKue @stanislav-zaprudskiy
+/prometheus-exporters/ipmi-service-discovery           @auhlig @majewsky  # old
+/prometheus-exporters/ironic-exporter                  @BerndKue @stefanhipfel
+/prometheus-exporters/jumpserver-exporter              @viennaa
+/prometheus-exporters/k8s-secrets-certificate-exporter @auhlig @majewsky @databus23 @jknipper
+/prometheus-exporters/kube-state-metrics-exporter      @richardtief
+/prometheus-exporters/netapp-exporter                  @chuan137 @Carthaca @majewsky @grandchild @stefanhipfel
+/prometheus-exporters/network-generic-ssh-exporter     @swagner-de @Kuckkuck @artherd42 @geisslet
+/prometheus-exporters/nfs-exporter                     @auhlig @majewsky  # old
+/prometheus-exporters/ns-exporter                      @databus23
+/prometheus-exporters/ntp-exporter                     @majewsky @SuperSandro2000 @jknipper
+/prometheus-exporters/octobus-query-exporter           @max-len @IvoGoman @Kuckkuck @christopherhans @kevin-fischer
+/prometheus-exporters/oomkill-exporter                 @jknipper @defo89 @majewsky
+/prometheus-exporters/openstack-exporter               @viennaa @hemna @majewsky @crenduchinta88 @kevin-fischer
+/prometheus-exporters/ping-exporter                    @majewsky @auhlig @defo89  # old
+/prometheus-exporters/poller-simulator                 @dhalimi @corey-aloia @majewsky
+/prometheus-exporters/redfish-exporter                 @BerndKue @stefanhipfel
+/prometheus-exporters/snmp-exporter                    @Kuckkuck @swagner-de @m-kratochvil @IvoGoman @defo89
+/prometheus-exporters/snmp-ntp-exporter                @geisslet
+/prometheus-exporters/statsd-exporter                  @artherd42 @thgrs @ashifnihalb @majewsky
+/prometheus-exporters/systemd-lldp-exporter            @auhlig @majewsky  # old
+/prometheus-exporters/tempest-exporter                 @misamoylov
+/prometheus-exporters/ucs-exporter                     @BerndKue @viennaa @richardtief
+/prometheus-exporters/watchcache-exporter              @jknipper @databus23
+/prometheus-exporters/cronus-openstack-alerts          @dhalimi
+/prometheus-exporters/cronus-reporter                  @dhalimi
+/prometheus-exporters/masterdata-exporter              @databus23
+/prometheus-exporters/opensearch-logs-query-exporter   @Kuckkuck @dimtass @chuan137 @databus23
+/prometheus-exporters/kubelet-stats-metrics            @jknipper
+
+/prometheus-rules/prometheus-controlplane-rules        @defo89 @artherd42 @majewsky @SuperSandro2000
+/prometheus-rules/prometheus-kubernetes-rules          @auhlig @databus23 @defo89 @businessbean @majewsky
+/prometheus-rules/prometheus-scaleout-rules            @auhlig  # old
+/prometheus-rules/prometheus-virtual-rules             @BugRoger  # old
+/prometheus-rules/prometheus-vmware-rules              @kevin-fischer @christopherhans @max-len @richardtief @himanip94
+/prometheus-rules/prometheus-openstack-rules           @artherd42 @richardtief
+
+/px/bird                                               @swagner-de @dusandordevicsap @rhalina @defo89
+/px/lg                                                 @rhalina @swagner-de @majewsky
+/px/arp-discovery                                      @swagner-de
+
+/system/absent-metrics-operator                        @talal @SuperSandro2000 @majewsky @VoigtS
+/system/audit-logs                                     @IvoGoman @Kuckkuck @jknipper @artherd42 @richardtief
+/system/auditbeat                                      @jknipper @IvoGoman @Kuckkuck
+/system/aws-ecr-creds-helper                           @defo89  # old
+/system/bind                                           @galkindmitrii @mutax @mbrowny @defo89
+/system/cc-rbac                                        @databus23 @Nuckal777 @swagner-de
+/system/ccauth                                         @onuryilmaz @databus23
+/system/cert-manager-crds                              @jknipper
+/system/conntrack-nanny                                @defo89
+/system/descheduler                                    @auhlig @defo89 @majewsky
+/system/digicert-issuer                                @jknipper @auhlig @kayrus
+/system/disco                                          @auhlig @defo89 @databus23
+/system/doop-central                                   @majewsky @talal @SuperSandro2000 @auhlig @reimannf
+/system/elk                                            @Kuckkuck @IvoGoman @majewsky
+/system/flatcar-linux-update-agent                     @Nuckal777 @defo89
+/system/frrouting                                      @defo89
+/system/gatekeeper                                     @majewsky @talal @SuperSandro2000 @Kuckkuck @IvoGoman
+/system/gatekeeper-config                              @majewsky @talal @SuperSandro2000
+/system/go-pmtud                                       @defo89
+/system/grafana-dashboards-kubernetes                  @auhlig @databus23
+/system/infra-monitoring                               @artherd42 @viennaa @BerndKue @swagner-de @Kuckkuck
+/system/jaeger-operator                                @chuan137 @misamoylov @Kuckkuck
+/system/k3s-backup                                     @defo89
+/system/k3s-restore                                    @defo89 @majewsky  # old
+/system/kube-cni                                       @defo89
+/system/kube-detective                                 @defo89
+/system/kube-dns                                       @defo89 @databus23
+/system/kube-fip-controller                            @auhlig @jknipper @databus23
+/system/kube-flannel                                   @defo89
+/system/kube-monitoring-admin-k3s                      @defo89 @Kuckkuck @majewsky @auhlig @talal
+/system/kube-monitoring-kubernikus                     @auhlig @jknipper @databus23 @defo89 @majewsky
+/system/kube-monitoring-metal                          @auhlig @databus23 @defo89 @majewsky @jknipper
+/system/kube-monitoring-scaleout                       @auhlig @jknipper @databus23 @majewsky @defo89
+/system/kube-monitoring-virtual                        @auhlig @defo89 @databus23 @majewsky @jknipper
+/system/kube-network-helpers                           @defo89
+/system/kube-parrot                                    @defo89
+/system/kube-proxy                                     @defo89 @majewsky
+/system/kube-proxy-ng                                  @defo89
+/system/kube-system-admin-k3s                          @defo89 @Nuckal777 @jknipper @onuryilmaz @auhlig
+/system/kube-system-global                             @defo89 @kayrus @viennaa @auhlig @Nuckal777
+/system/kube-system-kubernikus                         @auhlig @Nuckal777 @jknipper @defo89 @databus23
+/system/kube-system-metal                              @defo89 @auhlig @Nuckal777 @jknipper @databus23
+/system/kube-system-scaleout                           @auhlig @Nuckal777 @jknipper @onuryilmaz @defo89
+/system/kube-system-virtual                            @defo89 @Nuckal777 @auhlig @jknipper @onuryilmaz
+/system/kubernikus-admin-k3s                           @defo89 @databus23 @Nuckal777 @jknipper @xsen84
+/system/kubernikus-metal                               @databus23 @defo89 @Nuckal777 @jknipper @xsen84
+/system/kubernikus-monitoring                          @uwe-mayer @databus23 @jknipper @majewsky
+/system/kubernikus-rbac                                @databus23
+/system/ldap-named-user                                @defo89 @majewsky
+/system/logs                                           @Kuckkuck @IvoGoman @businessbean @corey-aloia @Nuckal777
+/system/maintenance-controller                         @Nuckal777 @majewsky @defo89
+/system/manila-csi-plugin                              @jknipper
+/system/metallb                                        @majewsky @defo89  # old
+/system/metis                                          @IvoGoman @majewsky @richardtief @SuperSandro2000
+/system/metis-api                                      @IvoGoman @majewsky @SuperSandro2000
+/system/metrics-server                                 @auhlig @defo89 @majewsky
+/system/multicloudtest                                 @viennaa @majewsky
+/system/node-problem-detector                          @defo89 @databus23
+/system/nodecidr-controller                            @defo89
+/system/ntp-timeserver                                 @dhoeller @majewsky  # old
+/system/priority-class                                 @galkindmitrii  # old
+/system/prober-static                                  @defo89
+/system/prometheus-crds                                @auhlig @viennaa @richardtief
+/system/prometheus-infra                               @artherd42 @viennaa @richardtief @Kuckkuck @dhalimi
+/system/prometheus-operator                            @viennaa @majewsky @richardtief
+/system/rabbitmq-operator                              @galkindmitrii
+/system/sentry                                         @majewsky @databus23 @notandy @SuperSandro2000
+/system/sysctl                                         @defo89
+/system/tarslite                                       @darpan92 @max-len @christopherhans @majewsky
+/system/tenso                                          @majewsky @SuperSandro2000 @VoigtS
+/system/tenso-seeds                                    @majewsky @reimannf
+/system/thanos-metal                                   @richardtief @viennaa
+/system/thanos-operator                                @viennaa
+/system/thanos-scaleout                                @richardtief @viennaa
+/system/tiller                                         @BugRoger @defo89 @majewsky  # old
+/system/toolbox-prepull                                @defo89 @SchwarzM
+/system/unbound                                        @galkindmitrii @vssldmtrv @dhoeller @mutax @defo89
+/system/validation                                     @artherd42 @thgrs @ashifnihalb
+/system/velero                                         @majewsky @databus23 @jknipper  # old
+/system/vertical-pod-autoscaler                        @auhlig @Nuckal777 @majewsky
+/system/vice-president                                 @databus23
+/system/vpa-butler                                     @Nuckal777 @auhlig @defo89 @jknipper
+/system/wormhole                                       @defo89
+/system/opensearch-logs                                @Kuckkuck @IvoGoman @majewsky @richardtief
+/system/vmware-monitoring                              @viennaa @richardtief @christopherhans @himanip94 @kevin-fischer
+/system/atlas                                          @BerndKue @Kuckkuck @viennaa @stefanhipfel @artherd42
+/system/hubcopter                                      @SuperSandro2000 @majewsky
+/system/hubcopter-seeds                                @SuperSandro2000 @majewsky
+/system/thanos-seeds                                   @viennaa
+/system/jupyterhub                                     @timojohlo @majewsky @artherd42
+/system/prometheus-kubernetes                          @viennaa @richardtief @Nuckal777
+/system/servicemesh                                    @jknipper @SuperSandro2000 @majewsky
+/system/storage-monitoring                             @viennaa @richardtief @artherd42 @geisslet
+/system/plutono                                        @richardtief @thgrs @majewsky @misamoylov
+/system/sysstat                                        @defo89
+/system/jupyter-cron-reports                           @timojohlo
+/system/opensearch-hermes                              @Kuckkuck @majewsky
+/system/smee-dynakratos                                @defo89 @SchwarzM @majewsky
+/system/ai-cloud-guard                                 @darpan92 @fyhan1
+/system/calico-apiserver                               @defo89
+/system/calico-cni                                     @defo89
+/system/calico                                         @defo89
+/system/cni-nanny                                      @defo89
+/system/externalip-operator                            @defo89
+/system/ipmasq                                         @defo89
+/system/baremetal-operator                             @defo89
+/system/bootstrap-kubeadm                              @defo89 @Nuckal777
+/system/cluster-api-core                               @defo89 @Nuckal777
+/system/cluster-api                                    @defo89 @Nuckal777
+/system/provider-kubernikus                            @defo89
+/system/provider-metal3                                @defo89 @Nuckal777
+/system/secrets-injector                               @Nuckal777
+/system/cc-cluster                                     @defo89
+/system/greenhouse-ccloud                              @auhlig @IvoGoman
+/system/baremetal-operator-core                        @defo89
+/system/kube-system-addons                             @defo89
+/system/runtime-extension-maintenance-controller       @Nuckal777

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
-*                                                      @BugRoger @databus23 @dhoeller @edda @geisslet
-/.github/CODEOWNERS                                    @BugRoger @databus23 @dhoeller @edda @geisslet
+*                                                      @BugRoger @databus23 @dhoeller @edda @geisslet @FabianKroenner @artherd42 @martinpink
+/.github/CODEOWNERS                                    @BugRoger @databus23 @dhoeller @edda @geisslet @FabianKroenner @artherd42 @martinpink
 
 /ci                                                    @auhlig @Kuckkuck @businessbean @jknipper @fwiesel
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -186,7 +186,7 @@
 /system/aws-ecr-creds-helper                           @defo89  # old
 /system/baremetal-operator                             @defo89
 /system/baremetal-operator-core                        @defo89
-/system/bind                                           @galkindmitrii @mutax @mbrowny @defo89
+/system/bind                                           @galkindmitrii @mutax @mbrowny @defo89 @vssldmtrv @SoenkeL
 /system/bootstrap-kubeadm                              @defo89 @Nuckal777
 /system/calico                                         @defo89
 /system/calico-apiserver                               @defo89
@@ -286,7 +286,7 @@
 /system/thanos-scaleout                                @richardtief @viennaa
 /system/thanos-seeds                                   @viennaa
 /system/toolbox-prepull                                @defo89 @SchwarzM
-/system/unbound                                        @galkindmitrii @vssldmtrv @dhoeller @mutax @defo89
+/system/unbound                                        @galkindmitrii @vssldmtrv @dhoeller @mutax @defo89 @mbrowny @SoenkeL
 /system/validation                                     @artherd42 @thgrs @ashifnihalb
 /system/velero                                         @databus23 @jknipper  # old
 /system/vertical-pod-autoscaler                        @Nuckal777 @majewsky @SuperSandro2000 @VoigtS

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -95,7 +95,7 @@
 /openstack/manila-antelope                             @Carthaca @dusandordevicsap
 /openstack/manila-nanny                                @chuan137 @Carthaca @dusandordevicsap
 /openstack/nannies                                     @thgrs @chuan137 @Carthaca @fwiesel @kpawar-sap
-/openstack/neutron                                     @notandy @fwiesel @sebageek @sven-rosenzweig @rhalina @swagner-de @mutax @BenjaminLudwigSAP @m-kratochvil
+/openstack/neutron                                     @notandy @fwiesel @sebageek @sven-rosenzweig @rhalina @swagner-de @mutax @BenjaminLudwigSAP @m-kratochvil @occamshatchet
 /openstack/nova                                        @joker-at-work @fwiesel @grandchild @leust
 /openstack/octavia                                     @notandy @BenjaminLudwigSAP @fwiesel @dusandordevicsap @velp @m-kratochvil
 /openstack/octobus                                     @viennaa

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -91,9 +91,7 @@
 /openstack/limes                                       @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /openstack/lyra                                        @databus23 @ArtieReus
 /openstack/maia                                        @artherd42 @viennaa @richardtief @Kuckkuck @dhalimi1975
-/openstack/manila                                      @Carthaca @chuan137 @galkindmitrii @kpawar-sap
-/openstack/manila-antelope                             @Carthaca @chuan137 @galkindmitrii @kpawar-sap
-/openstack/manila-nanny                                @Carthaca @chuan137 @galkindmitrii @kpawar-sap
+/openstack/manila*                                     @Carthaca @chuan137 @galkindmitrii @kpawar-sap
 /openstack/nannies                                     @thgrs @chuan137 @Carthaca @fwiesel @kpawar-sap
 /openstack/neutron                                     @notandy @fwiesel @sebageek @sven-rosenzweig @rhalina @swagner-de @mutax @BenjaminLudwigSAP @m-kratochvil @occamshatchet
 /openstack/nova                                        @joker-at-work @fwiesel @grandchild @leust

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,10 +14,7 @@
 /common/owner-info                                     @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /common/pgbackup                                       @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /common/pgmetrics                                      @majewsky @SuperSandro2000 @VoigtS @Nuckal777
-/common/postgresql                                     @majewsky @SuperSandro2000 @VoigtS @Nuckal777
-/common/postgresql-ng                                  @majewsky @SuperSandro2000 @VoigtS @Nuckal777
-/common/postgresql-ng-test                             @majewsky @SuperSandro2000 @VoigtS @Nuckal777
-/common/postgresql-test                                @majewsky @SuperSandro2000 @VoigtS @Nuckal777
+/common/postgresql*                                    @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /common/prometheus-alertmanager-base                   @viennaa @richardtief @Kuckkuck @IvoGoman @timojohlo
 /common/prometheus-monitors                            @IvoGoman @auhlig
 /common/prometheus-pushgateway                         @viennaa # old
@@ -25,7 +22,7 @@
 /common/prometheus-server-pre7                         @viennaa @richardtief @Kuckkuck @IvoGoman @timojohlo
 /common/rabbitmq                                       @galkindmitrii @fwiesel @Carthaca @bashar-alkhateeb @dusandordevicsap @businessbean
 /common/rabbitmq-cluster                               @galkindmitrii @notandy @defo89 @businessbean
-/common/redis                                          @majewsky @SuperSandro2000 @VoigtS @Nuckal777
+/common/redis*                                         @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /common/staging/rabbitmq                               @notandy @Carthaca  # old
 /common/thanos                                         @viennaa @richardtief @Kuckkuck @IvoGoman @timojohlo
 
@@ -63,7 +60,7 @@
 /openstack/bastion                                     @fwiesel
 /openstack/billing                                     @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /openstack/blackbox                                    @artherd42 # old
-/openstack/castellum                                   @majewsky @SuperSandro2000 @VoigtS @Nuckal777
+/openstack/castellum*                                  @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /openstack/cbshelf                                     @corey-aloia
 /openstack/cc3test                                     @thgrs @ashifnihalb @artherd42
 /openstack/cc3test-seeds                               @thgrs @ashifnihalb @artherd42
@@ -82,13 +79,12 @@
 /openstack/hermes                                      @notque @Kuckkuck @IvoGoman
 /openstack/infra-seeds/kubernetes                      @BugRoger  # old
 /openstack/ironic                                      @stefanhipfel @BerndKue @fwiesel @sandzwerg
-/openstack/keppel                                      @majewsky @SuperSandro2000 @VoigtS @Nuckal777
-/openstack/keppel-trivy                                @majewsky @SuperSandro2000 @VoigtS @Nuckal777
+/openstack/keppel*                                     @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /openstack/keystone                                    @galkindmitrii @Carthaca @bbobrov @fwiesel @rajivmucheli
 /openstack/kos-operator                                @stefanhipfel @databus23
 /openstack/kubernetes                                  @fwiesel
 /openstack/kubernikus                                  @fwiesel @jknipper
-/openstack/limes                                       @majewsky @SuperSandro2000 @VoigtS @Nuckal777
+/openstack/limes*                                      @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /openstack/lyra                                        @databus23 @ArtieReus
 /openstack/maia                                        @notque @richardtief @viennaa @Kuckkuck
 /openstack/manila*                                     @Carthaca @chuan137 @galkindmitrii @kpawar-sap @sumitarora2786 @crenduchinta88
@@ -206,13 +202,11 @@
 /system/externalip-operator                            @defo89
 /system/flatcar-linux-update-agent                     @Nuckal777 @defo89 @majewsky @SuperSandro2000 @VoigtS
 /system/frrouting                                      @defo89
-/system/gatekeeper                                     @majewsky @SuperSandro2000 @VoigtS @Nuckal777
-/system/gatekeeper-config                              @majewsky @SuperSandro2000 @VoigtS @Nuckal777
+/system/gatekeeper*                                    @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /system/go-pmtud                                       @defo89
 /system/grafana-dashboards-kubernetes                  @auhlig @databus23 # old
 /system/greenhouse-ccloud                              @auhlig @IvoGoman
-/system/hubcopter                                      @majewsky @SuperSandro2000 @VoigtS @Nuckal777
-/system/hubcopter-seeds                                @majewsky @SuperSandro2000 @VoigtS @Nuckal777
+/system/hubcopter*                                     @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /system/infra-monitoring                               @viennaa @richardtief @BerndKue @swagner-de @Kuckkuck
 /system/ipmasq                                         @defo89
 /system/jaeger-operator                                @chuan137 @misamoylov
@@ -279,8 +273,7 @@
 /system/sysctl                                         @defo89
 /system/sysstat                                        @defo89
 /system/tarslite                                       @darpan92 @max-len @christopherhans
-/system/tenso                                          @majewsky @SuperSandro2000 @VoigtS @Nuckal777
-/system/tenso-seeds                                    @majewsky @SuperSandro2000 @VoigtS @Nuckal777
+/system/tenso*                                         @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /system/thanos-metal                                   @viennaa @richardtief @Kuckkuck @IvoGoman @timojohlo
 /system/thanos-operator                                @viennaa @richardtief
 /system/thanos-scaleout                                @viennaa @richardtief @Kuckkuck @IvoGoman @timojohlo

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
-*                                                      @BugRoger @databus23 @dhoeller @edda @geisslet @FabianKroenner @artherd42 @martinpink
-/.github/CODEOWNERS                                    @BugRoger @databus23 @dhoeller @edda @geisslet @FabianKroenner @artherd42 @martinpink
+*                                                      @BugRoger @databus23 @dhoeller @edda @geisslet @artherd42 @martinpink
+/.github/CODEOWNERS                                    @BugRoger @databus23 @dhoeller @edda @geisslet @artherd42 @martinpink
 
 /ci                                                    @auhlig @Kuckkuck @businessbean @jknipper @fwiesel
 


### PR DESCRIPTION
Initial autogenerated list from git history by walking tree and:
- Stop descent if directory that contains "Chart.yaml".
- Run "git shortlog -sne" to collect authors.
- Order authors by number of total commits to that path.
- Prune users who haven't committed to the path in the last two years.
- Clamp list to 5 or less, as available.
- If list is empty, use all-time author list instead and mark as #old.
