### PR TITLE
[octavia] force secret creation of proxysql

### DIFF
--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -27,6 +27,7 @@ db_name: octavia
 
 proxysql:
   mode: ""
+  forceSecretCreation: true
 
 rabbitmq:
   alerts:


### PR DESCRIPTION
octavia helmchart upgrade failed after switching to secret because the migration job creates the proxysql sidecar only if it found proxysql secret which is not created at the first run.
Ignoring that will cause octavia configuration to be build with proxysql sockets in the connection string 
but without creating the sidecar in the first run which causing the migration job to fail and prevents the upgrade.

Change-Id: Ic37a0149a466cd8a8ad999adb8d56e23a05694ff