### PR TITLE
[rabbitmq] fix escaping for secret-injector links

### DIFF
--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 0.6.11
+version: 0.6.12
 description: A Helm chart for RabbitMQ
 sources:
 - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/templates/_helpers.tpl
+++ b/common/rabbitmq/templates/_helpers.tpl
@@ -40,6 +40,10 @@ rabbit://{{ default "" $envAll.Values.global.user_suffix | print $rabbitmq.users
         {{- fail (printf "%v.password missing" $path) }}
     {{- else if hasPrefix "-" $v.password }}
         {{- fail (printf "%v.password starts with hypen" $path) }}
+    {{- else if or (contains "vault+kvv2" $v.password) (contains "vault+kvv2" $v.user)}}
+        {{- printf "%s %s %s" "upsert_user" $v.user $v.password }}
+        {{- if $v.tag }} {{ $v.tag | include "rabbitmq.shell_quote" }}
+        {{- end }}
     {{- else -}}
         upsert_user {{ $v.user | include "rabbitmq.shell_quote" }} {{ $v.password | include "rabbitmq.shell_quote" }}
         {{- if $v.tag }} {{ $v.tag | include "rabbitmq.shell_quote" }}

--- a/common/rabbitmq/templates/bin/_rabbitmq-start.tpl
+++ b/common/rabbitmq/templates/bin/_rabbitmq-start.tpl
@@ -58,7 +58,8 @@ eval $(timeout 5.0 rabbitmqctl list_users -q | awk '{printf "users[\"%s\"]=\"%s\
 {{- if and .Values.metrics.enabled (not .Values.users.metrics) }}
 {{ list ".Values.metrics" .Values.metrics | include "rabbitmq.upsert_user" }} monitoring
 {{- end }}
-upsert_user guest {{ .Values.users.default.password | include "rabbitmq.shell_quote" }} monitoring
+{{- $guestUser := dict "user" "guest" "password" .Values.users.default.password "tag" "monitoring" }}
+{{ list "guest" $guestUser | include "rabbitmq.upsert_user" }}
 
 {{- if .Values.addDevUser }}
 # if set in values file add temporary dev user for development purposes


### PR DESCRIPTION
add a condition to not escape vault injector links 
use the same macro to create guest user
