### PR TITLE
[Cinder] Fix VCenterTemplate Secret base64 encoding

### DIFF
--- a/openstack/cinder/templates/vcenter_datacenter_cinder_secret.yaml
+++ b/openstack/cinder/templates/vcenter_datacenter_cinder_secret.yaml
@@ -21,44 +21,46 @@ template: |
       datacenter: {= availability_zone =}
   type: Opaque
   data:
-    cinder-volume.conf: |
-      [DEFAULT]
-      enabled_backends = {{ .Values.backends.enabled }}
+    cinder-volume.conf: {= " " =}
+      {%- filter b64enc %}
+  [DEFAULT]
+  enabled_backends = {{ .Values.backends.enabled }}
 
-      [backend_defaults]
-      vmware_host_ip = {= host =}
-      {{- if .Values.vmware_host_username | default "" }}
-      vmware_host_username = {{ .Values.vmware_host_username }}
-      vmware_host_password = {= "{{ .Values.vmware_host_username }}" | derive_password | quote =}
-      {{- else }}
-      vmware_host_username = {= username | quote =}
-      vmware_host_password = {= password | quote =}
-      {{- end }}
-      backend_availability_zone = {= availability_zone | quote =}
-      {{- range $key, $value := .Values.backend_defaults}}
-      {{ $key }} = {{ $value }}
-      {{- end }}
+  [backend_defaults]
+  vmware_host_ip = {= host =}
+  {{- if .Values.vmware_host_username | default "" }}
+  vmware_host_username = {{ .Values.vmware_host_username }}
+  vmware_host_password = {= "{{ .Values.vmware_host_username }}" | derive_password | quote =}
+  {{- else }}
+  vmware_host_username = {= username | quote =}
+  vmware_host_password = {= password | quote =}
+  {{- end }}
+  backend_availability_zone = {= availability_zone | quote =}
+  {{- range $key, $value := .Values.backend_defaults}}
+  {{ $key }} = {{ $value }}
+  {{- end }}
 
-      [vmware]
-      volume_driver = cinder.volume.drivers.vmware.vmdk.VMwareVcVmdkDriver
-      volume_backend_name = vmware
-      vmware_storage_profile = {{ .Values.backends.vmware.vmware_storage_profile  }}
-      extra_capabilities = '{"vcenter-shard": "{= host.split(".")[0] =}"}'
+  [vmware]
+  volume_driver = cinder.volume.drivers.vmware.vmdk.VMwareVcVmdkDriver
+  volume_backend_name = vmware
+  vmware_storage_profile = {{ .Values.backends.vmware.vmware_storage_profile  }}
+  extra_capabilities = '{"vcenter-shard": "{= host.split(".")[0] =}"}'
 
-      [standard_hdd]
-      volume_driver = cinder.volume.drivers.vmware.vmdk.VMwareVcVmdkDriver
-      volume_backend_name = standard_hdd
-      vmware_storage_profile = {{ .Values.backends.standard_hdd.vmware_storage_profile }}
-      extra_capabilities = '{"vcenter-shard": "{= host.split(".")[0] =}"}'
+  [standard_hdd]
+  volume_driver = cinder.volume.drivers.vmware.vmdk.VMwareVcVmdkDriver
+  volume_backend_name = standard_hdd
+  vmware_storage_profile = {{ .Values.backends.standard_hdd.vmware_storage_profile }}
+  extra_capabilities = '{"vcenter-shard": "{= host.split(".")[0] =}"}'
 
-      {{ range $backend, $kvs := .Values.backends.additional_backends }}
-      [{{ $backend }}]
-      {{- range $key, $value := $kvs }}
-      {{ $key }} = {{ $value }}
-      {{- end }}
-      {{ end }}
+  {{ range $backend, $kvs := .Values.backends.additional_backends }}
+  [{{ $backend }}]
+  {{- range $key, $value := $kvs }}
+  {{ $key }} = {{ $value }}
+  {{- end }}
+  {{ end }}
 
-      [vstorageobject]
-      volume_driver = cinder.volume.drivers.vmware.fcd.VMwareVStorageObjectDriver
-      volume_backend_name = vstorageobject
+  [vstorageobject]
+  volume_driver = cinder.volume.drivers.vmware.fcd.VMwareVStorageObjectDriver
+  volume_backend_name = vstorageobject
+  {% endfilter -%}
 {{- end }}


### PR DESCRIPTION
We missed to encode the `data` values to base64. Since we know how to do it from Nova's helm-chart, we mimic that approach even though there might be a better one by teaching the `vcenter-operator` to expose `textwrap.dedent()` to templates.