### PR TITLE
[Cinder] Fix rendering "volume_deployment"

### DIFF
--- a/openstack/cinder/templates/volumes/_volume-deployment.yaml.tpl
+++ b/openstack/cinder/templates/volumes/_volume-deployment.yaml.tpl
@@ -31,7 +31,7 @@ spec:
       annotations:
         configmap-etc-hash: {{ include (print .Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
         configmap-volume-hash: {{ tuple . $name $volume | include "volume_configmap" | sha256sum }}
-        secrets-hash: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        secrets-hash: {{ include (print .Template.BasePath "/secrets.yaml") . | sha256sum }}
         {{- if .Values.proxysql.mode }}
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}


### PR DESCRIPTION
We used the wrong way to access `Template.BasePath` and thus helm couldn't get that value and failed.