### PR TITLE
pgbackup: remove configuration for Swift credentials

### DIFF
--- a/common/pgbackup/Chart.yaml
+++ b/common/pgbackup/Chart.yaml
@@ -1,5 +1,5 @@
 name: pgbackup
-version: 0.1.47
+version: 0.2.0
 apiVersion: v2
 description: PostgreSQL backup/restore pod
 appVersion: "v0.9.12-17-g30bfad4" # of https://github.com/sapcc/backup-tools

--- a/common/pgbackup/ci/test-values.yaml
+++ b/common/pgbackup/ci/test-values.yaml
@@ -1,12 +1,10 @@
 global:
   registry: keppel.example.com/ccloud
   region: qa-de-1
+  vaultBaseURL: vault.example.com/secrets
 
 database:
   password: secret
-
-swift:
-  os_password: supersecret
 
 alerts:
   support_group: test

--- a/common/pgbackup/templates/deployment.yaml
+++ b/common/pgbackup/templates/deployment.yaml
@@ -1,11 +1,10 @@
+{{- $region   := .Values.global.region                   | required "missing value for .Values.global.region"       -}}
 {{- $registry := .Values.global.registry                 | required "missing value for .Values.global.registry" -}}
 {{- if .Values.use_alternate_region -}}
   {{- $registry = .Values.global.registryAlternateRegion | required "missing value for .Values.global.registryAlternateRegion" -}}
 {{- end -}}
 {{- $db_name  := .Values.database.name                   | default .Release.Name -}}
 {{- $db_host  := .Values.database.host                   | default (printf "%s-postgresql" .Release.Name) -}}
-{{- $auth_url := .Values.swift.os_auth_url               | default (printf "http://keystone.%s.svc:5000/v3" (.Values.global.keystoneNamespace | default .Release.Namespace)) -}}
-{{- $region   := .Values.swift.os_region_name            | default .Values.global.region -}}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -50,7 +49,7 @@ spec:
             - name: MY_POD_NAMESPACE
               value: {{ quote .Release.Namespace }}
             - name: OS_AUTH_URL
-              value: {{ quote $auth_url }}
+              value: {{ printf "https://identity-3.%s.cloud.sap/v3" $region | quote }}
             - name: OS_AUTH_VERSION
               value: "3"
             - name: OS_USERNAME

--- a/common/pgbackup/templates/secret.yaml
+++ b/common/pgbackup/templates/secret.yaml
@@ -1,8 +1,13 @@
+{{- if .Values.swift }}
+{{- fail "pgbackup: Swift credentials are now always autodiscovered. Remove the \"pgbackup.swift\" section from your values.yaml!" }}
+{{- end }}
+
 {{- $db_pass := "" }}
 {{- if not .Values.isPostgresNG }}
-{{- $db_pass = .Values.database.password | required "missing value for .Values.database.password" -}}
+{{- $db_pass = .Values.database.password   | required "missing value for .Values.database.password"   -}}
 {{- end }}
-{{- $os_pass := .Values.swift.os_password | required "missing value for .Values.swift.os_password" -}}
+{{- $vbase  := .Values.global.vaultBaseURL | required "missing value for .Values.global.vaultBaseURL" -}}
+{{- $region := .Values.global.region       | required "missing value for .Values.global.region"       -}}
 
 apiVersion: v1
 kind: Secret
@@ -14,4 +19,4 @@ data:
 {{- if not .Values.isPostgresNG }}
   postgres-password: {{ $db_pass | b64enc | quote }}
 {{- end }}
-  swift-password:    {{ $os_pass | b64enc | quote }}
+  swift-password: {{ printf "%s/%s/shared/keystone-user/db-backup/password" $vbase $region | b64enc | quote }}

--- a/common/pgbackup/values.yaml
+++ b/common/pgbackup/values.yaml
@@ -17,11 +17,6 @@ database:
   username: postgres    # name of database user (this user must have full admin access to the DB)
   password: ""          # password for the aforementioned database user (required)
 
-swift:
-  os_auth_url: null     # Keystone URL (defaults to cluster-internal Keystone endpoint; this default is only valid in the baremetal clusters)
-  os_region_name: null  # region name (defaults to .Values.global.region)
-  os_password: null     # password for the `db_backup@Default` service user (required)
-
 # alert configuration for Prometheus
 alerts:
   enabled: true


### PR DESCRIPTION
Using the existing `global.region` value, as well as the new `global.vaultBaseURL` value, and by just always using the public Keystone endpoint, this removes the need to configure anything related to Swift authentication at all.