### PR TITLE
[Neutron] Bump utils to 0.16.1

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 0.6.12
 - name: utils
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.15.0
+  version: 0.16.1
 - name: owner-info
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.2.0
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:2cad70acb79715ae1eae4b8aae1888fa0214d76c74d93abedb3223788aeb3994
-generated: "2024-04-08T11:36:14.72403+02:00"
+digest: sha256:f5f4dda89fe9e1adaba59c0060e98fe3bc6042f557b582d126892b203fde3aea
+generated: "2024-04-09T11:00:21.870581+02:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -20,7 +20,7 @@ dependencies:
     version: 0.6.12
   - name: utils
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.15.0
+    version: 0.16.1
   - name: owner-info
     repository: https://charts.eu-de-2.cloud.sap
     version: 0.2.0


### PR DESCRIPTION
Required to support secret-injector.
Requires 'urlquery to be applied to valut reference.