### PR TITLE
[octavia] Fix worker secret: range changes scope

### DIFF
--- a/openstack/octavia/templates/secrets-worker.yaml
+++ b/openstack/octavia/templates/secrets-worker.yaml
@@ -1,5 +1,6 @@
 {{- $envAll := . }}
 {{- range $name, $val := .Values.workers -}}
+{{- with $ }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -13,4 +14,5 @@ type: Opaque
 data:
   secrets-worker.conf: |
     {{ tuple $envAll $name $val | include "octavia_worker_secret" | b64enc | indent 4 }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Change scope back to global by using `{{- with $ }}`

This is a follow-up to #6127