### PR TITLE
common/postgresql-ng et al: never put explicit resource requests on labs

### DIFF
--- a/common/pgbackup/Chart.yaml
+++ b/common/pgbackup/Chart.yaml
@@ -1,5 +1,5 @@
 name: pgbackup
-version: 0.2.0
+version: 0.2.1
 apiVersion: v2
 description: PostgreSQL backup/restore pod
 appVersion: "v0.9.12-17-g30bfad4" # of https://github.com/sapcc/backup-tools

--- a/common/pgbackup/templates/deployment.yaml
+++ b/common/pgbackup/templates/deployment.yaml
@@ -91,6 +91,8 @@ spec:
             limits:
               memory: {{ .Values.resources.memory_limit }}
               cpu: {{ .Values.resources.cpu_limit }}
+            {{- if not (.Values.global.region | regexMatch "^qa-de-[2-6]$") }}
             requests:
               memory: {{ .Values.resources.memory_limit }}
               cpu: {{ .Values.resources.cpu_request }}
+            {{- end }}

--- a/common/pgmetrics/Chart.yaml
+++ b/common/pgmetrics/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 description: A Helm chart for Postgres Metrics
 name: pgmetrics
-version: 0.4.21
+version: 0.4.22

--- a/common/pgmetrics/templates/deployment.yaml
+++ b/common/pgmetrics/templates/deployment.yaml
@@ -73,9 +73,11 @@ spec:
           limits:
             cpu:    {{ quote .Values.resources.limits.cpu }}
             memory: {{ quote .Values.resources.limits.memory }}
+          {{- if not (.Values.global.region | regexMatch "^qa-de-[2-6]$") }}
           requests:
             cpu:    {{ quote .Values.resources.requests.cpu }}
             memory: {{ quote .Values.resources.requests.memory }}
+          {{- end }}
       volumes:
       - name: custom-metrics
         configMap:

--- a/common/postgresql-ng/Chart.yaml
+++ b/common/postgresql-ng/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql-ng
-version: 1.0.16
+version: 1.0.17
 apiVersion: v2
 description: Chart for PostgreSQL
 keywords:

--- a/common/postgresql-ng/templates/deployment.yaml
+++ b/common/postgresql-ng/templates/deployment.yaml
@@ -111,7 +111,11 @@ spec:
             - "[[ -e /tmp/in-init ]] || exec pg_isready --host $POD_IP"
           initialDelaySeconds: 5
           timeoutSeconds: {{ .Values.probe_timeout_secs }}
-        resources: {{ toYaml .Values.resources | nindent 10 }}
+        resources:
+          limits: {{ toYaml .Values.resources.limits | nindent 12 }}
+          {{- if not (.Values.global.region | regexMatch "^qa-de-[2-6]$") }}
+          requests: {{ toYaml .Values.resources.requests | nindent 12 }}
+          {{- end }}
         volumeMounts:
         - name: data
           mountPath: /data


### PR DESCRIPTION
These charts (or their users) declare default resource requests that are almost always too large for the labs and thus at best pointless (if overridden by the VPA) or actively harmful (if they impact scheduling).