### PR TITLE
[neutron][cc-fabric] Pass switch credentials as secret to deployment

### DIFF
--- a/openstack/neutron/templates/deployment-cc-fabric-agent.yaml
+++ b/openstack/neutron/templates/deployment-cc-fabric-agent.yaml
@@ -34,6 +34,7 @@ spec:
         pod.beta.kubernetes.io/hostname:  cc-fabric-{{ $platform }}-agent
         configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") $ | sha256sum }}
         configmap-etc-cc-fabric: {{ include (print $.Template.BasePath "/configmap-etc-cc-fabric.yaml") $ | sha256sum }}
+        secret-cc-fabric: {{ include (print $.Template.BasePath "/secret-cc-fabric.yaml") $ | sha256sum }}
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required "$.Values.metrics.prometheus missing" $.Values.metrics.prometheus }}
         {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 8 }}
@@ -102,6 +103,8 @@ spec:
               name: neutron-etc
               subPath: logging.conf
               readOnly: true
+            - mountPath: /etc/neutron/cc-fabric-secrets/
+              name: neutron-cc-fabric-secrets
             {{- include "utils.trust_bundle.volume_mount" $ | indent 12 }}
       volumes:
         - name: empty-neutron-ml2
@@ -115,6 +118,9 @@ spec:
         - name: neutron-etc-cc-fabric
           configMap:
             name: neutron-etc-cc-fabric
+        - name: neutron-cc-fabric-secrets
+          secret:
+            secretName: neutron-cc-fabric-secrets
         {{- include "utils.trust_bundle.volumes" $ | indent 8 }}
 {{- end }}
 {{- end }}

--- a/openstack/neutron/templates/etc/_ml2-conf-cc-fabric.ini.tpl
+++ b/openstack/neutron/templates/etc/_ml2-conf-cc-fabric.ini.tpl
@@ -1,5 +1,6 @@
 [ml2_cc_fabric]
 driver_config_path = /etc/neutron/plugins/ml2/cc-fabric-driver-config.yaml
+driver_config_credentials_path = /etc/neutron/cc-fabric-secrets/cc-fabric-driver-credentials.yaml
 {{- if .Values.cc_fabric.handle_all_l3_gateways }}
 handle_all_l3_gateways = {{ .Values.cc_fabric.handle_all_l3_gateways }}
 {{- end }}

--- a/openstack/neutron/templates/secret-cc-fabric.yaml
+++ b/openstack/neutron/templates/secret-cc-fabric.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.cc_fabric.enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: neutron-cc-fabric-secrets
+  labels:
+    system: openstack
+    application: {{ .Release.Name }}
+type: Opaque
+data:
+  cc-fabric-driver-credentials.yaml: |
+{{ toYaml (required "cc_fabric.driver_credentials cannot be empty" .Values.cc_fabric.driver_credentials) | b64enc | indent 4 }}
+{{- end }}


### PR DESCRIPTION
With https://github.com/sapcc/networking-ccloud/pull/139 merged, the
driver supports reading credentials from a dedicated file. We use this
to pass the credentials along to the container as a secret, rather than
a configmap.
