### PR TITLE
[neutron] Allow to disable network agent locally

### DIFF
--- a/openstack/neutron/templates/statefulset-network-agent-apod.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent-apod.yaml
@@ -4,6 +4,7 @@
 {{- $release_requires_sec_cap:= or (hasPrefix "ussuri" (default .Values.imageVersion .Values.imageVersionServerAPI)) (hasPrefix "yoga" (default .Values.imageVersion .Values.imageVersionServerAPI)) -}}
 {{ range $az_long, $apods := .Values.global.apods }}
 {{ range $k, $apod := $apods }}
+{{- if not (has $apod ($.Values.disabled_network_agents | default list )) }}
 {{- $az := trimPrefix $.Values.global.region $az_long }}
 ---
 apiVersion: apps/v1
@@ -299,6 +300,7 @@ spec:
                   - key: neutron-metadata-secrets.conf
                     path: secrets/neutron-metadata-secrets.conf
         {{- include "utils.trust_bundle.volumes" $ | indent 8 }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -34,6 +34,9 @@ owner-info:
     - Sven Rosenzweig
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/openstack/neutron
 
+sftp:
+  server_key:
+
 pod:
   replicas:
     server: 3


### PR DESCRIPTION
The network agents are build, one deployment per apod from
$.Values.global.apods. This implements a temporary possibility to
disable an apod without having to touch the global variables, just for
the neutron deployment.
