### PR TITLE
[Cinder] Fix cinder-volume livenessProbe command

### DIFF
--- a/openstack/cinder/templates/vcenter_datacenter_cinder_deployment.yaml
+++ b/openstack/cinder/templates/vcenter_datacenter_cinder_deployment.yaml
@@ -74,7 +74,7 @@ template: |
             value: 'ignore:Unverified HTTPS request'
           livenessProbe:
             exec:
-              command: ["openstack-agent-liveness", "--component", "cinder", "--config-file", "/etc/cinder/cinder.conf", "--config-map", "/etc/cinder/cinder.conf.d/secrets.conf"]
+              command: ["openstack-agent-liveness", "--component", "cinder", "--config-file", "/etc/cinder/cinder.conf", "--config-file", "/etc/cinder/cinder.conf.d/secrets.conf"]
             initialDelaySeconds: 60
             periodSeconds: 60
             timeoutSeconds: 20


### PR DESCRIPTION
We accidentally used the non-existent `--config-map` instead of `--config-file` as option to `openstack-agent-liveness`.