### PR TITLE
[octavia] Remove driver-agent side-car because we do not use it anymore.

### DIFF
--- a/openstack/octavia/templates/octavia-worker-deployment.yaml
+++ b/openstack/octavia/templates/octavia-worker-deployment.yaml
@@ -95,42 +95,6 @@ spec:
                   name: sentry
                   key: octavia.DSN.python
             {{- end }}
-        - name: octavia-driver-agent
-          image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-octavia:{{required "Values.imageVersion is missing" .Values.imageVersion}}
-          imagePullPolicy: IfNotPresent
-          command: ['dumb-init', 'kubernetes-entrypoint']
-          resources:
-{{ toYaml .Values.pod.resources.driver_agent | indent 12 }}
-          volumeMounts:
-            - name: octavia-etc
-              mountPath: /etc/octavia/octavia.conf
-              subPath: octavia.conf
-              readOnly: true
-            - name: octavia-etc
-              mountPath: /etc/octavia/logging.ini
-              subPath: logging.ini
-              readOnly: true
-            - name: octavia-etc-confd
-              mountPath: /etc/octavia/octavia.conf.d
-              readOnly: true
-            - mountPath: /var/run/octavia
-              name: octavia-var
-            {{- include "utils.proxysql.volume_mount" . | indent 12 }}
-            {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
-          env:
-            - name: COMMAND
-              value: "octavia-driver-agent --config-file /etc/octavia/octavia.conf --config-file /etc/octavia/octavia.conf.d/secrets.conf"
-            - name: DEPENDENCY_JOBS
-              value: octavia-migration
-            - name: NAMESPACE
-              value: {{ .Release.Namespace }}
-            {{- if .Values.sentry.enabled }}
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: sentry
-                  key: octavia.DSN.python
-            {{- end }}
         - name: octavia-f5-status-manager
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-octavia:{{required "Values.imageVersion is missing" .Values.imageVersion}}
           imagePullPolicy: IfNotPresent

--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -260,13 +260,6 @@ pod:
       requests:
         memory: 256Mi
         cpu: 500m
-    driver_agent:
-      limits:
-        memory: 512Mi
-        cpu: 1000m
-      requests:
-        memory: 256Mi
-        cpu: 500m
     status_manager:
       limits:
         memory: 1024Mi


### PR DESCRIPTION
This PR removes `driver-agent` from Octavia because we disable it in https://github.com/sapcc/octavia-f5-provider-driver/pull/251