### PR TITLE
[tempest][octavia] Add status reset for octavia-tempest.

### DIFF
--- a/openstack/tempest/octavia-tempest/templates/bin/_tempest-start-and-cleanup.sh.tpl
+++ b/openstack/tempest/octavia-tempest/templates/bin/_tempest-start-and-cleanup.sh.tpl
@@ -8,6 +8,8 @@ set -x
 function cleanup_tempest_leftovers() {
 
   echo " ============ Running cleanup ============ "
+  # Reset PENDIING_* statuses of all stuck loadbalancers
+  kubectl exec -it deploy/octavia-mariadb -c mariadb -- mysql -sN octavia -e "UPDATE load_balancer SET provisioning_status='ACTIVE' WHERE provisioning_status LIKE 'PENDING_%' and name LIKE 'tempest-%';"
   # Delete loadbalancers, lb flavors, pools, members for Admin
   export OS_USERNAME='neutron-tempestadmin1'
   export OS_TENANT_NAME='neutron-tempest-admin1'

--- a/openstack/tempest/octavia-tempest/values.yaml
+++ b/openstack/tempest/octavia-tempest/values.yaml
@@ -13,3 +13,4 @@ owner-info:
     - Dmitry Galkin
   support-group: network-api
   service: octavia
+tempestKubectlAccess: true

--- a/openstack/tempest/tempest-base/templates/_tempest-pod.yaml.tpl
+++ b/openstack/tempest/tempest-base/templates/_tempest-pod.yaml.tpl
@@ -1,4 +1,51 @@
 {{- define "tempest-base.tempest_pod" }}
+{{- if hasKey .Values "tempestKubectlAccess" }} {{ .Values.tempestKubectlAccess }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Chart.Name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Chart.Name }}
+rules:
+- apiGroups:
+  - extensions
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - "pods/exec"
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Chart.Name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Chart.Name }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ .Chart.Name }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -7,6 +54,9 @@ metadata:
     system: openstack
     type: configuration
 spec:
+  {{- if hasKey .Values "tempestKubectlAccess" }} {{ .Values.tempestKubectlAccess }}
+  serviceAccountName: {{ .Chart.Name }}
+  {{- end }}
   restartPolicy: Never
   containers:
     - name: {{ .Chart.Name }}


### PR DESCRIPTION
This PR adds provisioning status reset for stuck Octavia load balancers with the direct query to MariaDB.