### PR TITLE
[manila] increase max_shares_per_share_server to 50

### DIFF
--- a/openstack/manila/templates/shares/_share-netapp.conf.tpl
+++ b/openstack/manila/templates/shares/_share-netapp.conf.tpl
@@ -112,7 +112,7 @@ netapp_delete_retention_hours = {{ $context.Values.delete_retention_hours | defa
 max_over_subscription_ratio = {{ $share.max_over_subscription_ratio | default $context.Values.max_over_subscription_ratio | default 3.0 }}
 
 # maximum number of volumes created in a SVM
-max_shares_per_share_server = {{ $share.max_shares_per_share_server | default $context.Values.max_shares_per_share_server | default 20 }}
+max_shares_per_share_server = {{ $share.max_shares_per_share_server | default $context.Values.max_shares_per_share_server | default 50 }}
 # maximum sum of gigabytes a SVM can have considering all its share instances and snapshots
 max_share_server_size  = {{ $share.max_share_server_size | default $context.Values.max_share_server_size | default 10240 }}
 


### PR DESCRIPTION
SVM migrate is supporting this, so we allow more volumes in
a vserver to avoid scattering volumes of the same customers
into too much different vservers on the same host.

This is especially interesting for customers that are creating many,
but small volumes.
