### PR TITLE
[Nova] Enable ccroot user for mariadb

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.9.2
+  version: 0.10.1
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.9.2
+  version: 0.10.1
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.3.2
@@ -19,7 +19,7 @@ dependencies:
   version: 0.15.0
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.9.2
+  version: 0.10.1
 - name: rabbitmq
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.6.9
@@ -29,5 +29,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:a21bda68ca1afcd02cc6e84ec716c98ed2c2e67644520e1ba889c36f4d9aed03
-generated: "2024-04-02T14:32:53.052019+02:00"
+digest: sha256:770252726037319073b722e856e737339e2af293d93bad758a158f90882e4e4b
+generated: "2024-04-11T13:08:42.081371255+02:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -8,12 +8,12 @@ dependencies:
   - name: mariadb
     condition: mariadb.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.9.2
+    version: 0.10.1
   - name: mariadb
     alias: mariadb_api
     condition: mariadb_api.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.9.2
+    version: 0.10.1
   - name: mysql_metrics
     condition: mariadb.enabled
     repository: https://charts.eu-de-2.cloud.sap
@@ -31,7 +31,7 @@ dependencies:
     alias: mariadb_cell2
     condition: mariadb_cell2.enabled
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.9.2
+    version: 0.10.1
   - name: rabbitmq
     alias: rabbitmq_cell2
     condition: cell2.enabled

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -703,6 +703,8 @@ mariadb:
   long_query_time: 8
   vpa:
     set_main_container: true
+  ccroot_user:
+    enabled: true
   databases:
   - nova
   - nova_cell0
@@ -743,6 +745,8 @@ mariadb_api:
   long_query_time: 8
   vpa:
     set_main_container: true
+  ccroot_user:
+    enabled: true
   databases:
   - nova_api
   users:
@@ -776,6 +780,8 @@ mariadb_cell2:
   long_query_time: 8
   vpa:
     set_main_container: true
+  ccroot_user:
+    enabled: true
   persistence_claim:
     name: db-nova-cell2-pvc
     size: "50Gi"


### PR DESCRIPTION
This user provides passwordless access to the DB from localhost, so we can administer the DB without having to read and rotate a secret.

With bumping the mariadb chart we also get some fixes regarding Secrets in.