### PR TITLE
[Placement] Enable ccroot user for mariadb

### DIFF
--- a/openstack/placement/Chart.lock
+++ b/openstack/placement/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.9.2
+  version: 0.10.1
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
@@ -14,5 +14,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:4ffc82c6fde4225e9da1128d7638af9c8305c46112a35f788f64b6c8a5f5aa88
-generated: "2024-04-12T15:52:00.171647+02:00"
+digest: sha256:f836b28d323aefa37a55019098ab03af8f0b23e0cce32e645b9977efabcd9bf9
+generated: "2024-04-15T09:02:04.644623864+02:00"

--- a/openstack/placement/Chart.yaml
+++ b/openstack/placement/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.9.2
+    version: 0.10.1
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.2.0

--- a/openstack/placement/values.yaml
+++ b/openstack/placement/values.yaml
@@ -57,6 +57,8 @@ mariadb:
   name: placement
   alerts:
     support_group: "compute-storage-api"
+  ccroot_user:
+    enabled: true
 
 memcached:
   alerts:


### PR DESCRIPTION
This user provides passwordless access to the DB from localhost, so we can administer the DB without having to read and rotate a secret.

With bumping the mariadb chart we also get some fixes regarding Secrets in.