### PR TITLE
[Cinder] Enable ccroot user for mariadb

### DIFF
--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.15.0
 - name: mariadb
   repository: https://charts.eu-de-2.cloud.sap
-  version: 0.9.2
+  version: 0.10.1
 - name: mysql_metrics
   repository: https://charts.eu-de-2.cloud.sap
   version: 0.3.2
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:6f526f2f51ee371ed4d24e7e6f98fb69efdf351be41432c7f9508c2c914bf923
-generated: "2024-04-02T15:17:27.396265+02:00"
+digest: sha256:8b766e813cd360196943bf985ee0dc3fa0626c6dc7d7abfd075afed2fe21409d
+generated: "2024-04-11T13:28:01.552833662+02:00"

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
     version: ~0.15.0
   - name: mariadb
     repository: https://charts.eu-de-2.cloud.sap
-    version: 0.9.2
+    version: 0.10.1
     condition: mariadb.enabled
   - name: mysql_metrics
     repository: https://charts.eu-de-2.cloud.sap

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -118,6 +118,8 @@ mariadb:
   max_connections: 2048
   buffer_pool_size: "2048M"
   log_file_size: "512M"
+  ccroot_user:
+    enabled: true
   name: cinder
   databases:
   - cinder


### PR DESCRIPTION
This user provides passwordless access to the DB from localhost, so we can administer the DB without having to read and rotate a secret.

With bumping the mariadb chart we also get some fixes regarding Secrets in.