### PR TITLE
ironic: enable ccroot user for mariadb

### DIFF
--- a/openstack/ironic/values.yaml
+++ b/openstack/ironic/values.yaml
@@ -366,6 +366,8 @@ mariadb:
 
   root_password: "AHardPa55w0rd!"
   initdb_secret: true
+  ccroot_user:
+    enabled: true
   persistence_claim:
     name: db-ironic-pvclaim
 


### PR DESCRIPTION
This user provides passwordless access to the DB from localhost, so we
can administer the DB without having to read and rotate a secret.
This was introduced in version 0.10.0 from the mariadb chart
