### PR TITLE
[utils] add helper to resolve secrets that need urlquery function

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.16.2
+version: 0.17.0

--- a/openstack/utils/templates/_hosts.tpl
+++ b/openstack/utils/templates/_hosts.tpl
@@ -10,7 +10,7 @@
     {{- $str := index . 0 -}}
     {{- $add_urlquery := index . 1 | default false -}}
     {{- if (hasPrefix "vault+kvv2" $str) -}}
-        {{"{{"}} resolve "{{ $str }}" {{ if $add_urlquery }}| urlquery{{ end }}{{"}}"}}
+        {{"{{"}} resolve "{{ $str }}" {{ if $add_urlquery }}| urlquery {{ end }}{{"}}"}}
     {{- else -}}
         {{ $str }}
 {{- end -}}
@@ -43,7 +43,7 @@ postgresql+psycopg2://{{$user}}:{{$password | urlquery}}@{{.Chart.Name}}-postgre
     {{- else }}
         {{- $user := index . 2 }}
         {{- $password := index . 3 }}
-        {{- $user }}:{{ include "resolve_secret" $password true }}
+        {{- $user }}:{{ include "resolve_secret" (tuple $password true) }}
     {{- end }}
 {{- end }}
 
@@ -67,7 +67,7 @@ postgresql+psycopg2://{{$user}}:{{$password | urlquery}}@{{.Chart.Name}}-postgre
             {{- $user := get .Values.mariadb.users $db | required (printf ".Values.mariadb.%v.name & .password are required (key comes from first database in .Values.mariadb.databases)" $db) }}
             {{- tuple . $db $user.name (required (printf "User with key %v requires password" $db) $user.password) | include "db_url_mysql" }}
         {{- else }}
-            {{- tuple . (coalesce .Values.dbName .Values.db_name) (coalesce .Values.dbUser .Values.global.dbUser "root") (tuple . (coalesce .Values.dbPassword .Values.global.dbPassword .Values.mariadb.root_password) true | include "resolve_secret" | required ".Values.mariadb.root_password is required!") .Values.mariadb.name | include "db_url_mysql" }}
+            {{- tuple . (coalesce .Values.dbName .Values.db_name) (coalesce .Values.dbUser .Values.global.dbUser "root") (tuple (coalesce .Values.dbPassword .Values.global.dbPassword .Values.mariadb.root_password) true | include "resolve_secret" | required ".Values.mariadb.root_password is required!") .Values.mariadb.name | include "db_url_mysql" }}
         {{- end }}
     {{- else -}}
 mysql+pymysql://{{ include "db_credentials" . }}@
@@ -197,7 +197,7 @@ mysql+pymysql://{{ include "db_credentials" . }}@
     {{- $host := index . 0 }}
     {{- $user := index . 1 }}
     {{- $password := index . 2 -}}
-https://{{ $user }}:{{ include "resolve_secret" $password true }}@{{ $host }}
+https://{{ $user }}:{{ include "resolve_secret" (tuple $password true) }}@{{ $host }}
 {{- end }}
 
 {{- define "utils.bigip_url" }}

--- a/openstack/utils/templates/_hosts.tpl
+++ b/openstack/utils/templates/_hosts.tpl
@@ -6,6 +6,16 @@
 {{ .Release.Namespace }}.svc.kubernetes.{{ include "host_fqdn" . }}
 {{- end }}
 
+{{- define "resolve_secret" -}}
+    {{- $str := index . 0 -}}
+    {{- $add_urlquery := index . 1 | default false -}}
+    {{- if (hasPrefix "vault+kvv2" $str) -}}
+        {{"{{"}} resolve "{{ $str }}" {{ if $add_urlquery }}| urlquery{{ end }}{{"}}"}}
+    {{- else -}}
+        {{ $str }}
+{{- end -}}
+{{- end -}}
+
 {{define "db_url" }}
     {{- if kindIs "map" . -}}
 postgresql+psycopg2://{{default .Values.dbUser .Values.global.dbUser}}:{{(default .Values.dbPassword .Values.global.dbPassword) | default (tuple . (default .Values.dbUser .Values.global.dbUser) | include "postgres.password_for_user")}}@{{.Chart.Name}}-postgresql.{{ include "svc_fqdn" . }}:5432/{{.Values.postgresql.postgresDatabase}}
@@ -33,7 +43,7 @@ postgresql+psycopg2://{{$user}}:{{$password | urlquery}}@{{.Chart.Name}}-postgre
     {{- else }}
         {{- $user := index . 2 }}
         {{- $password := index . 3 }}
-        {{- $user }}:{{ $password }}
+        {{- $user }}:{{ include "resolve_secret" $password true }}
     {{- end }}
 {{- end }}
 
@@ -57,7 +67,7 @@ postgresql+psycopg2://{{$user}}:{{$password | urlquery}}@{{.Chart.Name}}-postgre
             {{- $user := get .Values.mariadb.users $db | required (printf ".Values.mariadb.%v.name & .password are required (key comes from first database in .Values.mariadb.databases)" $db) }}
             {{- tuple . $db $user.name (required (printf "User with key %v requires password" $db) $user.password) | include "db_url_mysql" }}
         {{- else }}
-            {{- tuple . (coalesce .Values.dbName .Values.db_name) (coalesce .Values.dbUser .Values.global.dbUser "root") (coalesce .Values.dbPassword .Values.global.dbPassword .Values.mariadb.root_password | required ".Values.mariadb.root_password is required!") .Values.mariadb.name | include "db_url_mysql" }}
+            {{- tuple . (coalesce .Values.dbName .Values.db_name) (coalesce .Values.dbUser .Values.global.dbUser "root") (tuple . (coalesce .Values.dbPassword .Values.global.dbPassword .Values.mariadb.root_password) true | include "resolve_secret" | required ".Values.mariadb.root_password is required!") .Values.mariadb.name | include "db_url_mysql" }}
         {{- end }}
     {{- else -}}
 mysql+pymysql://{{ include "db_credentials" . }}@
@@ -187,7 +197,7 @@ mysql+pymysql://{{ include "db_credentials" . }}@
     {{- $host := index . 0 }}
     {{- $user := index . 1 }}
     {{- $password := index . 2 -}}
-https://{{ $user }}:{{ $password }}@{{ $host }}
+https://{{ $user }}:{{ include "resolve_secret" $password true }}@{{ $host }}
 {{- end }}
 
 {{- define "utils.bigip_url" }}

--- a/openstack/utils/templates/_ini_sections.tpl
+++ b/openstack/utils/templates/_ini_sections.tpl
@@ -49,10 +49,10 @@ enabled = true
 # topics = notifications
 driver = messagingv2
             {{- if .Values.audit.central_service }}
-transport_url = rabbit://{{ .Values.audit.central_service.user | required "Please set audit.central_service.user" }}:{{ .Values.audit.central_service.password | required "Please set audit.central_service.password" }}@{{ .Values.audit.central_service.host | default "hermes-rabbitmq-notifications.hermes" }}:{{.Values.audit.central_service.port | default 5672 }}/
+transport_url = rabbit://{{ .Values.audit.central_service.user | required "Please set audit.central_service.user" }}:{{ tuple . .Values.audit.central_service.password true | include "resolve_secret" | required "Please set audit.central_service.password" }}@{{ .Values.audit.central_service.host | default "hermes-rabbitmq-notifications.hermes" }}:{{.Values.audit.central_service.port | default 5672 }}/
             {{- else if .Values.rabbitmq_notifications }}
                 {{- if and .Values.rabbitmq_notifications.ports .Values.rabbitmq_notifications.users }}
-transport_url = rabbit://{{ .Values.rabbitmq_notifications.users.default.user }}:{{ required ".Values.rabbitmq_notifications.users.default.password missing" .Values.rabbitmq_notifications.users.default.password }}@{{ .Chart.Name }}-rabbitmq-notifications:{{ .Values.rabbitmq_notifications.ports.public }}/
+transport_url = rabbit://{{ .Values.rabbitmq_notifications.users.default.user }}:{{ tuple . .Values.rabbitmq_notifications.users.default.password true | include "resolve_secret" | required ".Values.rabbitmq_notifications.users.default.password missing" }}@{{ .Chart.Name }}-rabbitmq-notifications:{{ .Values.rabbitmq_notifications.ports.public }}/
                 {{- end }}
             {{- end }}
 mem_queue_size = {{ .Values.audit.mem_queue_size }}

--- a/openstack/utils/templates/_ini_sections.tpl
+++ b/openstack/utils/templates/_ini_sections.tpl
@@ -49,10 +49,10 @@ enabled = true
 # topics = notifications
 driver = messagingv2
             {{- if .Values.audit.central_service }}
-transport_url = rabbit://{{ .Values.audit.central_service.user | required "Please set audit.central_service.user" }}:{{ tuple .Values.audit.central_service.password true | include "resolve_secret" | required "Please set audit.central_service.password" }}@{{ .Values.audit.central_service.host | default "hermes-rabbitmq-notifications.hermes" }}:{{.Values.audit.central_service.port | default 5672 }}/
+transport_url = rabbit://{{ .Values.audit.central_service.user | required "Please set audit.central_service.user" }}:{{ include "resolve_secret" .Values.audit.central_service.password | required "Please set audit.central_service.password" }}@{{ .Values.audit.central_service.host | default "hermes-rabbitmq-notifications.hermes" }}:{{.Values.audit.central_service.port | default 5672 }}/
             {{- else if .Values.rabbitmq_notifications }}
                 {{- if and .Values.rabbitmq_notifications.ports .Values.rabbitmq_notifications.users }}
-transport_url = rabbit://{{ .Values.rabbitmq_notifications.users.default.user }}:{{ tuple .Values.rabbitmq_notifications.users.default.password true | include "resolve_secret" | required ".Values.rabbitmq_notifications.users.default.password missing" }}@{{ .Chart.Name }}-rabbitmq-notifications:{{ .Values.rabbitmq_notifications.ports.public }}/
+transport_url = rabbit://{{ .Values.audit.central_service.user | required "Please set audit.central_service.user" }}:{{ tuple .Values.audit.central_service.password true | include "resolve_secret" | required "Please set audit.central_service.password" }}@{{ .Values.audit.central_service.host | default "hermes-rabbitmq-notifications.hermes" }}:{{.Values.audit.central_service.port | default 5672 }}/
                 {{- end }}
             {{- end }}
 mem_queue_size = {{ .Values.audit.mem_queue_size }}

--- a/openstack/utils/templates/_ini_sections.tpl
+++ b/openstack/utils/templates/_ini_sections.tpl
@@ -49,10 +49,10 @@ enabled = true
 # topics = notifications
 driver = messagingv2
             {{- if .Values.audit.central_service }}
-transport_url = rabbit://{{ .Values.audit.central_service.user | required "Please set audit.central_service.user" }}:{{ tuple . .Values.audit.central_service.password true | include "resolve_secret" | required "Please set audit.central_service.password" }}@{{ .Values.audit.central_service.host | default "hermes-rabbitmq-notifications.hermes" }}:{{.Values.audit.central_service.port | default 5672 }}/
+transport_url = rabbit://{{ .Values.audit.central_service.user | required "Please set audit.central_service.user" }}:{{ tuple .Values.audit.central_service.password true | include "resolve_secret" | required "Please set audit.central_service.password" }}@{{ .Values.audit.central_service.host | default "hermes-rabbitmq-notifications.hermes" }}:{{.Values.audit.central_service.port | default 5672 }}/
             {{- else if .Values.rabbitmq_notifications }}
                 {{- if and .Values.rabbitmq_notifications.ports .Values.rabbitmq_notifications.users }}
-transport_url = rabbit://{{ .Values.rabbitmq_notifications.users.default.user }}:{{ tuple . .Values.rabbitmq_notifications.users.default.password true | include "resolve_secret" | required ".Values.rabbitmq_notifications.users.default.password missing" }}@{{ .Chart.Name }}-rabbitmq-notifications:{{ .Values.rabbitmq_notifications.ports.public }}/
+transport_url = rabbit://{{ .Values.rabbitmq_notifications.users.default.user }}:{{ tuple .Values.rabbitmq_notifications.users.default.password true | include "resolve_secret" | required ".Values.rabbitmq_notifications.users.default.password missing" }}@{{ .Chart.Name }}-rabbitmq-notifications:{{ .Values.rabbitmq_notifications.ports.public }}/
                 {{- end }}
             {{- end }}
 mem_queue_size = {{ .Values.audit.mem_queue_size }}

--- a/openstack/utils/templates/_ini_sections.tpl
+++ b/openstack/utils/templates/_ini_sections.tpl
@@ -52,7 +52,7 @@ driver = messagingv2
 transport_url = rabbit://{{ .Values.audit.central_service.user | required "Please set audit.central_service.user" }}:{{ include "resolve_secret" .Values.audit.central_service.password | required "Please set audit.central_service.password" }}@{{ .Values.audit.central_service.host | default "hermes-rabbitmq-notifications.hermes" }}:{{.Values.audit.central_service.port | default 5672 }}/
             {{- else if .Values.rabbitmq_notifications }}
                 {{- if and .Values.rabbitmq_notifications.ports .Values.rabbitmq_notifications.users }}
-transport_url = rabbit://{{ .Values.audit.central_service.user | required "Please set audit.central_service.user" }}:{{ tuple .Values.audit.central_service.password true | include "resolve_secret" | required "Please set audit.central_service.password" }}@{{ .Values.audit.central_service.host | default "hermes-rabbitmq-notifications.hermes" }}:{{.Values.audit.central_service.port | default 5672 }}/
+transport_url = rabbit://{{ .Values.rabbitmq_notifications.users.default.user }}:{{ include "resolve_secret" .Values.rabbitmq_notifications.users.default.password | required ".Values.rabbitmq_notifications.users.default.password missing" }}@{{ .Chart.Name }}-rabbitmq-notifications:{{ .Values.rabbitmq_notifications.ports.public }}/
                 {{- end }}
             {{- end }}
 mem_queue_size = {{ .Values.audit.mem_queue_size }}

--- a/openstack/utils/templates/snippets/_proxysql.cfg.tpl
+++ b/openstack/utils/templates/snippets/_proxysql.cfg.tpl
@@ -30,8 +30,8 @@ mysql_variables =
             {{- end }}
         {{- end }}
     monitor_enabled = true
-    monitor_username = "{{ .global.Values.mariadb.users.proxysql_monitor.name | required ".global.Values.mariadb.users.proxysql_monitor.name is required!" }}"
-    monitor_password = "{{ .global.Values.mariadb.users.proxysql_monitor.password | required ".global.Values.mariadb.users.proxysql_monitor.password is required!" }}"
+    monitor_username = "{{ include "resolve_secret" .global.Values.mariadb.users.proxysql_monitor.name | required ".global.Values.mariadb.users.proxysql_monitor.name is required!" }}"
+    monitor_password = "{{ include "resolve_secret" .global.Values.mariadb.users.proxysql_monitor.password | required ".global.Values.mariadb.users.proxysql_monitor.password is required!" }}"
     {{- end }}
     connect_retries_on_failure = {{ default 1000 .global.Values.proxysql.connect_retries_on_failure }}
     connect_retries_delay = {{ default 100 .global.Values.proxysql.connect_retries_delay }} {{- /* The default is 1ms, and that means we will run through the retries on failure in no time */}}
@@ -57,8 +57,8 @@ mysql_users =
   {{- range $userKey, $user := $db.users }}
     {{- if ne $userKey "proxysql_monitor"  }}
     {
-        username = "{{ $user.name | required (print "user name needs to be set for " $dbKey " and user " $userKey) }}"
-        password = "{{ $user.password | required (print "password needs to be set for " $dbKey " and user " $userKey)  }}"
+        username = "{{ include "resolve_secret" $user.name | required (print "user name needs to be set for " $dbKey " and user " $userKey) }}"
+        password = "{{ include "resolve_secret" $user.password | required (print "password needs to be set for " $dbKey " and user " $userKey)  }}"
         default_hostgroup = {{ $index }}
     },
     {{- end }}


### PR DESCRIPTION
- with a new secret-injector we cannot use urlquery over new secret vault references.
- with a new helper function we work around it by adding 'resolve' on the fly with optional urlquery at the end where it is needed.
- this patch also uses new helper for places where we had urlquery before. This would allow to simplify the values inside the secrets repo.