### PR TITLE
[Archer] Mount Neutron RabbitMQ Password

### DIFF
--- a/openstack/archer/Chart.yaml
+++ b/openstack/archer/Chart.yaml
@@ -43,4 +43,3 @@ dependencies:
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.1.4
-

--- a/openstack/archer/templates/deployment-ni.yaml
+++ b/openstack/archer/templates/deployment-ni.yaml
@@ -115,7 +115,7 @@ spec:
         - name: neutron-linuxbridge-agent
           image: "{{ $.Values.global.registry }}/loci-neutron:{{ $.Values.image.neutron_version | default "latest" }}"
           imagePullPolicy: IfNotPresent
-          command: ["dumb-init", "neutron-linuxbridge-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/ml2-conf.ini", "--config-file", "/etc/neutron/linux-bridge.ini"]
+          command: ["dumb-init", "neutron-linuxbridge-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-dir", "/etc/neutron/secrets", "--config-file", "/etc/neutron/ml2-conf.ini", "--config-file", "/etc/neutron/linux-bridge.ini"]
           env:
             - name: SENTRY_DSN
               valueFrom:
@@ -130,7 +130,7 @@ spec:
               value: archer-agent-{{ $name }}-{{ $az_long }}
           readinessProbe:
             exec:
-              command: ["neutron-agent-liveness", "-config-file", "/etc/neutron/neutron.conf", "-agent-type", "Linux bridge agent"]
+              command: ["neutron-agent-liveness", "-config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/secrets/neutron-common-secrets.conf", "-agent-type", "Linux bridge agent"]
             initialDelaySeconds: 30
             periodSeconds: 60
             timeoutSeconds: 10
@@ -148,7 +148,7 @@ spec:
             - mountPath: /lib/modules
               name: modules
               readOnly: true
-            - name: neutron-etc
+            - name: etc-neutron-linuxbridge-agent
               mountPath: /etc/neutron
               readOnly: true
             - name: neutron-etc
@@ -175,6 +175,28 @@ spec:
         - name: neutron-etc
           configMap:
             name: neutron-etc
+        - name: etc-neutron-linuxbridge-agent
+          projected:
+            defaultMode: 420
+            sources:
+            - configMap:
+                name: neutron-etc
+                items:
+                  - key: neutron.conf
+                    path: neutron.conf
+                  - key: logging.conf
+                    path: logging.conf
+                  - key: rootwrap.conf
+                    path: rootwrap.conf
+                  - key: ml2-conf.ini
+                    path: ml2-conf.ini
+                  - key: linux-bridge.ini
+                    path: linux-bridge.ini
+            - secret:
+                name: neutron-common-secrets
+                items:
+                  - key: neutron-common-secrets.conf
+                    path: secrets/neutron-common-secrets.conf
         - name: etc-archer
           projected:
             defaultMode: 420


### PR DESCRIPTION
With the migration to k8s secrets, the rabbitmq transport_url is no longer part of neutron.conf. Therefore the neutron password needs to be mounted as well.