### PR TITLE
[archer] bump dependencies, switch to secrets-injector

### DIFF
--- a/openstack/archer/Chart.lock
+++ b/openstack/archer/Chart.lock
@@ -1,21 +1,21 @@
 dependencies:
 - name: postgresql-ng
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.0.12
+  version: 1.0.18
 - name: pgbackup
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.1.45
+  version: 0.2.3
 - name: pgmetrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.4.21
+  version: 0.4.22
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.15.0
+  version: 0.16.1
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.3
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.4
-digest: sha256:1fc0cb5b04422d4dcf431d685c0d363d67e0c10fa74984ab9100cc631dec4749
-generated: "2024-03-25T08:53:16.362839-04:00"
+digest: sha256:66c8672e34df223a8e3f4685b87d5089e3d7b8cebc8d9c2c1be66bd089adfac1
+generated: "2024-04-11T13:01:39.532105-04:00"

--- a/openstack/archer/Chart.yaml
+++ b/openstack/archer/Chart.yaml
@@ -27,16 +27,16 @@ dependencies:
   - name: postgresql-ng
     alias: postgresql
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 1.0.12
+    version: 1.0.18
   - name: pgbackup
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.1.45
+    version: 0.2.3
   - name: pgmetrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.4.21
+    version: 0.4.22
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.15.0
+    version: 0.16.1
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.2.3

--- a/openstack/archer/ci/test-values.yaml
+++ b/openstack/archer/ci/test-values.yaml
@@ -3,6 +3,7 @@ global:
   registry: keppel.example.com/ccloud
   dockerHubMirror: keppel.example.com/dockerhub
   dockerHubMirrorAlternateRegion: registry-other.example.com/dockerhub
+  vaultBaseURL: https://vault.example.com
 
 image:
   tag: test-tag-123

--- a/openstack/archer/templates/configmap-f5.yaml
+++ b/openstack/archer/templates/configmap-f5.yaml
@@ -11,16 +11,16 @@ data:
   f5.ini: |
     [DEFAULT]
     host = {{ $name }}
-{{- if $val.availability_zone }}
+    {{- if $val.availability_zone }}
     availability_zone = {{ $val.availability_zone }}
-{{- end }}
+    {{- end }}
 
     [agent]
-{{- range $i, $value := $val.devices }}
-    device[] = {{ tuple $envAll $value | include "utils.bigip_url" }}
-{{- end }}
-{{- range $i, $value := $val.vcmps }}
-    vcmp[] = {{ tuple $envAll $value | include "utils.bigip_url" }}
-{{- end }}
+    {{- range $val.devices }}
+    device[] = https://{{.}}
+    {{- end }}
+    {{- range $val.vcmps }}
+    vcmp[] = https://{{.}}
+    {{- end }}
     physical_network = {{ .physical_network }}
 {{- end }}

--- a/openstack/archer/templates/deployment-f5.yaml
+++ b/openstack/archer/templates/deployment-f5.yaml
@@ -69,6 +69,21 @@ spec:
                 secretKeyRef:
                   name: archer-pguser-archer
                   key: postgres-password
+            - name: OS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: archer-secret
+                  key: service_user_password
+            - name: BIGIP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: archer-secret
+                  key: bigip_password
+            - name: BIGIP_USER
+              valueFrom:
+                secretKeyRef:
+                  name: archer-secret
+                  key: bigip_username
           ports:
             - name: metrics
               containerPort: {{ required ".Values.metrics.port missing" $.Values.metrics.port }}

--- a/openstack/archer/templates/deployment-ni.yaml
+++ b/openstack/archer/templates/deployment-ni.yaml
@@ -100,6 +100,11 @@ spec:
                 secretKeyRef:
                   name: archer-pguser-archer
                   key: postgres-password
+            - name: OS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: archer-secret
+                  key: service_user_password
           ports:
             - name: metrics
               containerPort: {{ required ".Values.metrics.port missing" $.Values.metrics.port }}

--- a/openstack/archer/templates/deployment.yaml
+++ b/openstack/archer/templates/deployment.yaml
@@ -74,6 +74,18 @@ spec:
                 secretKeyRef:
                   name: archer-pguser-archer
                   key: postgres-password
+            - name: OS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: archer-secret
+                  key: service_user_password
+            {{- if .Values.audit.enabled }}
+            - name: AUDIT_TRANSPORT_URL
+              valueFrom:
+                secretKeyRef:
+                  name: archer-secret
+                  key: audit_transport_url
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/openstack/archer/templates/etc/_archer.ini.tpl
+++ b/openstack/archer/templates/etc/_archer.ini.tpl
@@ -18,7 +18,6 @@ connection = postgresql://archer@archer-postgresql:5432/archer?sslmode=disable
 [service_auth]
 auth_url = {{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3
 username = {{ .Release.Name }}{{ .Values.global.user_suffix }}
-password = {{ .Values.global.archer_service_password }}
 project_name = service
 project_domain_id = default
 user_domain_id = default
@@ -32,6 +31,5 @@ endpoint = 0
 {{- if .Values.audit.enabled }}
 [audit_middleware_notifications]
 enabled = true
-transport_url = amqp://{{ .Values.audit.user }}:{{ required ".Values.audit.password missing" .Values.audit.password }}@{{ .Values.audit.host }}:{{ .Values.audit.port }}/
 queue_name = notifications.info
 {{- end }}

--- a/openstack/archer/templates/secret.yaml
+++ b/openstack/archer/templates/secret.yaml
@@ -1,0 +1,19 @@
+{{- $vbase  := .Values.global.vaultBaseURL | required "missing value for .Values.global.vaultBaseURL" }}
+{{- $region := .Values.global.region | required "missing value for .Values.global.region" }}
+{{- $audit_user := printf "%s/%s/hermes/rabbitmq-user/notifications-archer/user" $vbase $region | quote }}
+{{- $audit_pass := printf "%s/%s/hermes/rabbitmq-user/notifications-archer/password" $vbase $region | quote }}
+{{- $audit_host := .Values.audit.host | required "missing value for .Values.audit.host" }}
+{{- $audit_port := .Values.audit.port | required "missing value for .Values.audit.port" | int }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: archer-secret
+data:
+  service_user_password: {{ printf "%s/%s/archer/keystone-user/service/password" $vbase $region | b64enc }}
+  {{- if .Values.audit.enabled }}
+  audit_transport_url: {{ printf "amqp://{{resolve %s}}:{{resolve %s}}@%s:%d/" $audit_user $audit_pass $audit_host $audit_port | b64enc }}
+  {{- end }}
+  {{- if .Values.agents.f5 }}
+  bigip_username: {{ printf "%s/shared/octavia/f5-bigip-user/admin/username" $vbase | b64enc }}
+  bigip_password: {{ printf "%s/shared/octavia/f5-bigip-user/admin/password" $vbase | b64enc }}
+  {{- end }}

--- a/openstack/archer/templates/seed.yaml
+++ b/openstack/archer/templates/seed.yaml
@@ -26,7 +26,7 @@ spec:
       users:
         - name: archer
           description: 'Archer Service'
-          password: {{ .Values.global.archer_service_password | quote }}
+          password: {{ printf "%s/%s/archer/keystone-user/service/password" .Values.global.vaultBaseURL .Values.global.region | quote }}
           role_assignments:
             - project: service
               role: service

--- a/openstack/archer/values.yaml
+++ b/openstack/archer/values.yaml
@@ -15,7 +15,7 @@ image:
   pullPolicy: IfNotPresent
 
 postgresql:
-  enabled: false
+  enabled: true
   imageTag: "20240206103323"
   postgresDatabase: archer
   alerts:
@@ -64,7 +64,7 @@ metrics:
   port: 9090
 
 audit:
-  enabled: false
+  enabled: true
   user: rabbitmq
   host: hermes-rabbitmq-notifications.hermes
   port: 5672


### PR DESCRIPTION
This PR switches archer to secrets injector.
Needs to be rolled out along with https://github.wdf.sap.corp/cc/secrets/pull/14154
