### PR TITLE
[octavia] Create secret as pre-upgrade hook (for migration job)

### DIFF
--- a/openstack/octavia/templates/secrets.yaml
+++ b/openstack/octavia/templates/secrets.yaml
@@ -7,6 +7,11 @@ metadata:
     helm.sh/chart: {{ include "octavia.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    # this secret is needed by the migration job, so it needs to be a
+    # pre-upgrade hook with a lower weight than the migration job.
+    "helm.sh/hook": "pre-upgrade"
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
 type: Opaque
 data:
   secrets.conf: |


### PR DESCRIPTION
The migration job runs as a pre-upgrade hook and it needs the octavia-secrets secret. Therefore this secret needs to be created at pre-upgrade hook time as well, and with a lower weight than the migration job, so that it is guaranteed to exist before the migration job runs.