### PR TITLE
[manila] enable mariadb ccroot user

### DIFF
--- a/openstack/manila/values.yaml
+++ b/openstack/manila/values.yaml
@@ -608,6 +608,8 @@ mariadb:
   query_cache_type: "1"
   name: manila
   initdb_secret: true
+  ccroot_user:
+    enabled: true
   databases:
   - manila
   users:


### PR DESCRIPTION
This user provides passwordless access to the DB from localhost, so we
can administer the DB without having to read and rotate a secret.
