### PR TITLE
[octavia] Fix creating secret as pre-upgrade hook

### DIFF
--- a/openstack/octavia/templates/secrets.yaml
+++ b/openstack/octavia/templates/secrets.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/chart: {{ include "octavia.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
     # this secret is needed by the migration job, so it needs to be a
     # pre-upgrade hook with a lower weight than the migration job.
     "helm.sh/hook": "pre-upgrade"


### PR DESCRIPTION
We tried to make the `octavia-secrets` Secret part of the pre-upgrade phase so the migration job can run as pre-upgrade hook in ce8cfe40fbe99c76de1bfe1d93f05ee670d88c86. This didn't work, because we put in the annotations as labels instead.