### PR TITLE
Add support of `reloader` annotations in postgresql and redis

### DIFF
--- a/common/pgbackup/Chart.yaml
+++ b/common/pgbackup/Chart.yaml
@@ -1,5 +1,8 @@
 name: pgbackup
-version: 1.1.12 # this version number is SemVer as it gets used to auto bump
+# 1.2.0
+# - Added `.Values.reloader.enabled` to control consumption of
+#   `stakater/Reloader` annotations on referenced Secrets and CMs.
+version: 1.2.0 # this version number is SemVer as it gets used to auto bump
 apiVersion: v2
 description: PostgreSQL backup/restore pod
 appVersion: "v0.10.0-111-gb31fd82" # of https://github.com/sapcc/backup-tools

--- a/common/pgbackup/templates/deployment.yaml
+++ b/common/pgbackup/templates/deployment.yaml
@@ -11,6 +11,10 @@ kind: Deployment
 
 metadata:
   name: "{{ .Release.Name }}-pgbackup"
+  {{- if .Values.reloader.enabled }}
+  annotations:
+    reloader.stakater.com/search: "true"
+  {{- end }}
 
 spec:
   replicas: 1

--- a/common/pgbackup/values.yaml
+++ b/common/pgbackup/values.yaml
@@ -14,6 +14,13 @@ database:
   username: postgres    # name of database user (this user must have full admin access to the DB)
   password: ""          # password for the aforementioned database user (required)
 
+# if enabled, configures `stakater/Reloader` (annotations) to cause the
+# deployment to do a rolling restart when referenced CMs and Secrets annotated
+# with `reloader.stakater.com/match: "true"` (e.g. Secret with DB password)
+# change
+reloader:
+  enabled: false
+
 # alert configuration for Prometheus
 alerts:
   enabled: true

--- a/common/pgmetrics/Chart.yaml
+++ b/common/pgmetrics/Chart.yaml
@@ -1,4 +1,7 @@
 apiVersion: v2
 name: pgmetrics
-version: 1.1.6 # this version number is SemVer as it gets used to auto bump
+# 1.2.0
+# - Added `.Values.reloader.enabled` to control consumption of
+#   `stakater/Reloader` annotations on referenced Secrets and CMs.
+version: 1.2.0 # this version number is SemVer as it gets used to auto bump
 description: A Helm chart for Postgres Metrics

--- a/common/pgmetrics/templates/deployment.yaml
+++ b/common/pgmetrics/templates/deployment.yaml
@@ -7,6 +7,10 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: {{ .Release.Name }}-pgmetrics
+  {{- if .Values.reloader.enabled }}
+  annotations:
+    reloader.stakater.com/search: "true"
+  {{- end }}
 spec:
   replicas: 1
   revisionHistoryLimit: 3

--- a/common/pgmetrics/values.yaml
+++ b/common/pgmetrics/values.yaml
@@ -4,6 +4,13 @@ global:
   region: ""
   quayIoMirror: ""
 
+# if enabled, configures `stakater/Reloader` (annotations) to cause the
+# deployment to do a rolling restart when referenced CMs and Secrets annotated
+# with `reloader.stakater.com/match: "true"` (e.g. Secret with DB password)
+# change
+reloader:
+  enabled: false
+
 # database name (default is .Release.Name)
 db_name: ""
 # database hostname (default is "{{.Release.Name}}-postgresql")

--- a/common/postgresql-ng/Chart.yaml
+++ b/common/postgresql-ng/Chart.yaml
@@ -24,4 +24,8 @@ description: Chart for PostgreSQL
 #
 # 1.3.1
 # - Support deploying without alerts (e.g. local development)
-version: 1.3.3 # this version number is SemVer as it gets used to auto bump
+#
+# 1.4.0
+# - Added `.Values.reloader.annotateGeneratedSecrets` to control
+#   `stakater/Reloader` annotations of generated secrets.
+version: 1.4.0 # this version number is SemVer as it gets used to auto bump

--- a/common/postgresql-ng/bin/init-generate-secrets.sh
+++ b/common/postgresql-ng/bin/init-generate-secrets.sh
@@ -32,4 +32,7 @@ for USER in ${USERS:-}; do
       postgres-password: $(LC_ALL=C tr -dc '[:graph:]' </dev/urandom | head -c 30 | base64 -w0 | base64 -w0)
   " > secret.yaml
   kubectl create -f secret.yaml
+  if [[ $ANNOTATE_FOR_RELOADER -eq "true" ]]; then
+    kubectl annotate reloader.stakater.com/match="true" -f secret.yaml
+  fi
 done

--- a/common/postgresql-ng/templates/deployment.yaml
+++ b/common/postgresql-ng/templates/deployment.yaml
@@ -55,6 +55,8 @@ spec:
           value: {{ $deployment_name }}
         - name: USERS
           value: {{ keys (.Values.users | required ".Values.users must be configured") | sortAlpha | join " " | quote }}
+        - name: ANNOTATE_FOR_RELOADER
+          value: {{ .Values.reloader.annotateGeneratedSecrets }}
         command: [ ash, -c, {{ .Files.Get "bin/init-generate-secrets.sh" | quote }} ]
 
       containers:

--- a/common/postgresql-ng/values.yaml
+++ b/common/postgresql-ng/values.yaml
@@ -3,6 +3,13 @@ useAlternateRegion: false
 
 debug: false
 
+# if enabled, annotates generated password Secrets with `stakater/Reloader`
+# annotations to cause the consuming applications annotated with
+# `reloader.stakater.com/auto: "true"` to be restarted when the corresponding
+# Secrets change
+reloader:
+  annotateGeneratedSecrets: false
+
 extensions:
   pg_stat_statements:
     max: 1000

--- a/common/redis/Chart.yaml
+++ b/common/redis/Chart.yaml
@@ -37,4 +37,10 @@ name: redis
 #
 # 2.1.1
 # - Support deploying without alerts (e.g. local development)
-version: 2.1.7 # this version number is SemVer as it gets used to auto bump
+#
+# 2.2.0
+# - Added values to control `stakater/Reloader` annotations of generated
+#   secrets and consuming workloads. See
+#   `.Values.reloader.annotateGeneratedSecrets` and
+#   `.Values.metrics.reloader.enabled`
+version: 2.2.0 # this version number is SemVer as it gets used to auto bump

--- a/common/redis/bin/init-generate-secrets.sh
+++ b/common/redis/bin/init-generate-secrets.sh
@@ -32,4 +32,7 @@ for USER in ${USERS:-}; do
       password: $(LC_ALL=C tr -dc '[:graph:]' </dev/urandom | head -c 30 | base64 -w0 | base64 -w0)
   " > secret.yaml
   kubectl create -f secret.yaml
+  if [[ $ANNOTATE_FOR_RELOADER -eq "true" ]]; then
+    kubectl annotate reloader.stakater.com/match="true" -f secret.yaml
+  fi
 done

--- a/common/redis/templates/deployment.yaml
+++ b/common/redis/templates/deployment.yaml
@@ -44,6 +44,8 @@ spec:
           value: {{ $fullname }}
         - name: USERS
           value: 'default'
+        - name: ANNOTATE_FOR_RELOADER
+          value: {{ .Values.reloader.annotateGeneratedSecrets }}
         command: [ ash, -c, {{ .Files.Get "bin/init-generate-secrets.sh" | quote }} ]
       {{- end }}
       containers:

--- a/common/redis/templates/metrics-deployment.yaml
+++ b/common/redis/templates/metrics-deployment.yaml
@@ -13,6 +13,10 @@ metadata:
   name: {{ $fullname }}-exporter
   labels:
     app: {{ $fullname }}
+  {{- if .Values.metrics.reloader.enabled }}
+  annotations:
+    reloader.stakater.com/search: "true"
+  {{- end }}
 
 spec:
   selector:

--- a/common/redis/values.yaml
+++ b/common/redis/values.yaml
@@ -33,6 +33,13 @@ resources:
     memory: 128Mi
     cpu: 100m
 
+# if enabled, annotates generated password Secrets with `stakater/Reloader`
+# annotations to cause the consuming applications annotated with
+# `reloader.stakater.com/auto: "true"` to be restarted when the corresponding
+# Secrets change
+reloader:
+  annotateGeneratedSecrets: false
+
 alerts:
   enabled: true
   support_group: null # This field must be filled by the top-level chart.
@@ -58,3 +65,10 @@ metrics:
     requests:
       memory: 64Mi
       cpu: 10m
+
+  # if enabled, configures `stakater/Reloader` (annotations) to cause the
+  # deployment to do a rolling restart when referenced CMs and Secrets annotated
+  # with `reloader.stakater.com/match: "true"` (e.g. Secret with DB password)
+  # change
+  reloader:
+    enabled: false


### PR DESCRIPTION
The PR adds values to control [`reloader`](https://github.com/stakater/Reloader) annotations:
* of generated (user) password Secrets in `postgresql-ng` and `redis` charts
* and of the consuming Deployments in `pgbackup`, `pgmetrics`, `redis/metrics-deployment`


When both are configured, would cause the the consuming Deployments (`pgbackup`, `pgmetrics`, `redis/metrics-deployment`) to be restarted when the password secret changes (is regenerated) in `postgresql-ng` and `redis`.
