### PR TITLE
[ironic] fix creating secrets as pre-upgrade hook

### DIFF
--- a/openstack/ironic/templates/secrets.yaml
+++ b/openstack/ironic/templates/secrets.yaml
@@ -5,6 +5,12 @@ metadata:
   labels:
     system: openstack
     application: {{ .Release.Name }}
+  annotations:
+    # this secret is needed by the migration job, so it needs to be a
+    # pre-upgrade hook with a lower weight than the migration job.
+    "helm.sh/hook": "pre-upgrade"
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
 type: Opaque
 data: 
   secrets.conf: |


### PR DESCRIPTION
We have the same issue as octavia in #6377 and #6382 and copy their
homework.
The migration job runs as pre-upgrade hook and it needs the
ironic-secret secret. Therefore the secret needs to be available during
the pre-upgrade hook time. It needs to have a lower weight than the
migration job, so that is executed before the migration job.
This needs to happen as an annotation
