### PR TITLE
Octavia: Move missing values to secrets

### DIFF
--- a/openstack/octavia/templates/etc/_octavia-worker.conf.tpl
+++ b/openstack/octavia/templates/etc/_octavia-worker.conf.tpl
@@ -10,13 +10,6 @@ backdoor_socket = /var/lib/octavia/backdoor.socket
 {{- if $loadbalancer.physical_interface_mapping }}
 physical_interface_mapping = {{ $loadbalancer.physical_interface_mapping }}
 {{- end }}
-{{- if $loadbalancer.vcmps }}
-vcmp_urls = {{ tuple $envAll $loadbalancer.vcmps | include "utils.bigip_urls" -}}
-{{- end }}
-{{- if $loadbalancer.override_vcmp_guest_names }}
-override_vcmp_guest_names = {{ $loadbalancer.override_vcmp_guest_names | join ", " -}}
-{{- end }}
-
 
 [f5_agent]
 bigip_verify = false

--- a/openstack/octavia/templates/etc/_octavia.conf.tpl
+++ b/openstack/octavia/templates/etc/_octavia.conf.tpl
@@ -105,8 +105,6 @@ auth_url = {{.Values.global.keystone_api_endpoint_protocol_internal | default "h
 project_name = service
 project_domain_id = default
 user_domain_id = default
-username = {{ .Release.Name }}{{ .Values.global.user_suffix }}
-password = {{ .Values.global.octavia_service_password | replace "$" "" }}
 
 [keystone_authtoken]
 auth_type = v3password

--- a/openstack/octavia/templates/etc/_secrets-worker.conf.tpl
+++ b/openstack/octavia/templates/etc/_secrets-worker.conf.tpl
@@ -2,6 +2,16 @@
 {{- $envAll := index . 0 -}}
 {{- $lb_name := index . 1 -}}
 {{- $loadbalancer := index . 2 -}}
+
 [f5_agent]
 bigip_urls = {{ if $loadbalancer.devices -}}{{- tuple $envAll $loadbalancer.devices | include "utils.bigip_urls" -}}{{- else -}}{{ $loadbalancer.bigip_urls | join ", " }}{{- end }}
+
+[networking]
+{{- if $loadbalancer.vcmps }}
+vcmp_urls = {{ tuple $envAll $loadbalancer.vcmps | include "utils.bigip_urls" -}}
+{{- end }}
+{{- if $loadbalancer.override_vcmp_guest_names }}
+override_vcmp_guest_names = {{ $loadbalancer.override_vcmp_guest_names | join ", " -}}
+{{- end }}
+
 {{- end }}

--- a/openstack/octavia/templates/etc/_secrets.conf.tpl
+++ b/openstack/octavia/templates/etc/_secrets.conf.tpl
@@ -2,6 +2,10 @@
 # AMQP Transport URL
 {{ include "ini_sections.default_transport_url" . }}
 
+[service_auth]
+username = {{ .Release.Name }}{{ .Values.global.user_suffix }}
+password = {{ .Values.global.octavia_service_password | replace "$" "" }}
+
 [keystone_authtoken]
 username = {{ .Release.Name }}
 password = {{ .Values.global.octavia_service_password | replace "$" "" }}

--- a/openstack/octavia/templates/octavia-worker-deployment.yaml
+++ b/openstack/octavia/templates/octavia-worker-deployment.yaml
@@ -66,6 +66,13 @@ spec:
               mountPath: /etc/octavia/octavia-worker.conf
               subPath: octavia-worker.conf
               readOnly: true
+            - name: octavia-etc-confd
+              mountPath: /etc/octavia/octavia.conf.d
+              readOnly: true
+            - name: octavia-etc-worker-secret
+              mountPath: /etc/octavia/octavia-worker-secret.conf
+              subPath: secrets-worker.conf
+              readOnly: true
             - mountPath: /var/run/octavia
               name: octavia-var
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
@@ -102,6 +109,9 @@ spec:
             - name: octavia-etc
               mountPath: /etc/octavia/logging.ini
               subPath: logging.ini
+              readOnly: true
+            - name: octavia-etc-confd
+              mountPath: /etc/octavia/octavia.conf.d
               readOnly: true
             - mountPath: /var/run/octavia
               name: octavia-var


### PR DESCRIPTION
Several values are still not in secrets and so cannot be interpolated by the secrets-injector. Those are:
- `password` in the `[service_auth]` group, making Octavia unable to authenticate
- `vcmp_urls` in the `[networking]` group

Also: A few secrets volume mounts were missing