### PR TITLE
[ironic] use custom start/end string for jinja

### DIFF
--- a/openstack/ironic/templates/_conductor-configmap-secret.yaml.tpl
+++ b/openstack/ironic/templates/_conductor-configmap-secret.yaml.tpl
@@ -13,6 +13,10 @@ metadata:
     system: openstack
     type: configuration
     component: ironic
+  options:
+    jinja2_options:
+      variable_start_string: '{='
+      variable_end_string: '=}'
 data:
   ironic-conductor.conf: |
 {{ list . $conductor | include "ironic_conductor_conf" | indent 4 }}

--- a/openstack/ironic/templates/etc/_ipxe_config.template.tpl
+++ b/openstack/ironic/templates/etc/_ipxe_config.template.tpl
@@ -10,9 +10,9 @@ goto deploy
 
 :deploy
 imgfree
-kernel {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ "{{" }} pxe_options.ipxe_timeout {{ "}}" }} {% endif %}{{ "{{" }} pxe_options.deployment_aki_path {{ "}}" }} selinux=0 troubleshoot=0 text {{ "{{" }} pxe_options.pxe_append_params|default("", true) {{ "}}" }} BOOTIF=${mac} initrd={{ "{{" }} pxe_options.initrd_filename|default("deploy_ramdisk", true) {{ "}}" }}  || chain {{ printf "http://%v:%v/%v" .Values.global.ironic_tftp_ip .Values.conductor.deploy.port $conductor.pxe.pxe_bootfile_name }} || goto retry
+kernel {% if pxe_options.ipxe_timeout > 0 %}--timeout {= pxe_options.ipxe_timeout =} {% endif %}{= pxe_options.deployment_aki_path =} selinux=0 troubleshoot=0 text {= pxe_options.pxe_append_params|default("", true) =} BOOTIF=${mac} initrd={= pxe_options.initrd_filename|default("deploy_ramdisk", true) =}  || chain {{ printf "http://%v:%v/%v" .Values.global.ironic_tftp_ip .Values.conductor.deploy.port $conductor.pxe.pxe_bootfile_name }} || goto retry
 
-initrd {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ "{{" }} pxe_options.ipxe_timeout {{ "}}" }} {% endif %}{{ "{{" }} pxe_options.deployment_ari_path {{ "}}" }} || goto retry
+initrd {% if pxe_options.ipxe_timeout > 0 %}--timeout {= pxe_options.ipxe_timeout =} {% endif %}{= pxe_options.deployment_ari_path =} || goto retry
 boot
 
 :retry
@@ -30,23 +30,23 @@ poweroff
 
 :boot_partition
 imgfree
-kernel {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ "{{" }} pxe_options.ipxe_timeout {{ "}}" }} {% endif %}{{ "{{" }} pxe_options.aki_path {{ "}}" }} root={{ "{{" }} ROOT {{ "}}" }} ro text {{ "{{" }} pxe_options.pxe_append_params|default("", true) {{ "}}" }} initrd=ramdisk || goto boot_partition
-initrd {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ "{{" }} pxe_options.ipxe_timeout {{ "}}" }} {% endif %}{{ "{{" }} pxe_options.ari_path {{ "}}" }} || goto boot_partition
+kernel {% if pxe_options.ipxe_timeout > 0 %}--timeout {= pxe_options.ipxe_timeout =} {% endif %}{= pxe_options.aki_path =} root={= ROOT =} ro text {= pxe_options.pxe_append_params|default("", true) =} initrd=ramdisk || goto boot_partition
+initrd {% if pxe_options.ipxe_timeout > 0 %}--timeout {= pxe_options.ipxe_timeout =} {% endif %}{= pxe_options.ari_path =} || goto boot_partition
 boot
 
 :boot_anaconda
 imgfree
-kernel {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ "{{" }} pxe_options.ipxe_timeout {{ "}}" }} {% endif %}{{ "{{" }} pxe_options.aki_path {{ "}}" }} text {{ "{{" }} pxe_options.pxe_append_params|default("", true) {{ "}}" }} inst.ks={{ "{{" }} pxe_options.ks_cfg_url {{ "}}" }} inst.stage2={{ "{{" }} pxe_options.stage2_url {{ "}}" }} initrd=ramdisk || goto boot_anaconda
-initrd {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ "{{" }} pxe_options.ipxe_timeout {{ "}}" }} {% endif %}{{ "{{" }} pxe_options.ari_path {{ "}}" }} || goto boot_anaconda
+kernel {% if pxe_options.ipxe_timeout > 0 %}--timeout {= pxe_options.ipxe_timeout =} {% endif %}{= pxe_options.aki_path =} text {= pxe_options.pxe_append_params|default("", true) =} inst.ks={= pxe_options.ks_cfg_url =} inst.stage2={= pxe_options.stage2_url =} initrd=ramdisk || goto boot_anaconda
+initrd {% if pxe_options.ipxe_timeout > 0 %}--timeout {= pxe_options.ipxe_timeout =} {% endif %}{= pxe_options.ari_path =} || goto boot_anaconda
 boot
 
 :boot_ramdisk
 imgfree
 {%- if pxe_options.boot_iso_url %}
-sanboot {{ "{{" }} pxe_options.boot_iso_url {{ "}}" }}
+sanboot {= pxe_options.boot_iso_url =}
 {%- else %}
-kernel {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ "{{" }} pxe_options.ipxe_timeout {{ "}}" }} {% endif %}{{ "{{" }} pxe_options.aki_path {{ "}}" }} root=/dev/ram0 text {{ "{{" }} pxe_options.pxe_append_params|default("", true) {{ "}}" }} {{ "{{" }} pxe_options.ramdisk_opts|default('', true) {{ "}}" }} initrd=ramdisk || goto boot_ramdisk
-initrd {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ "{{" }} pxe_options.ipxe_timeout {{ "}}" }} {% endif %}{{ "{{" }} pxe_options.ari_path {{ "}}" }} || goto boot_ramdisk
+kernel {% if pxe_options.ipxe_timeout > 0 %}--timeout {= pxe_options.ipxe_timeout =} {% endif %}{= pxe_options.aki_path =} root=/dev/ram0 text {= pxe_options.pxe_append_params|default("", true) =} {= pxe_options.ramdisk_opts|default('', true) =} initrd=ramdisk || goto boot_ramdisk
+initrd {% if pxe_options.ipxe_timeout > 0 %}--timeout {= pxe_options.ipxe_timeout =} {% endif %}{= pxe_options.ari_path =} || goto boot_ramdisk
 boot
 {%- endif %}
 
@@ -54,18 +54,18 @@ boot
 
 :boot_iscsi
 imgfree
-{% if pxe_options.username %}set username {{ "{{" }} pxe_options.username {{ "}}" }}{% endif %}
-{% if pxe_options.password %}set password {{ "{{" }} pxe_options.password {{ "}}" }}{% endif %}
-{% if pxe_options.iscsi_initiator_iqn %}set initiator-iqn {{ "{{" }} pxe_options.iscsi_initiator_iqn {{ "}}" }}{% endif %}
-sanhook --drive 0x80 {{ "{{" }} pxe_options.iscsi_boot_url {{ "}}" }} || goto fail_iscsi_retry
+{% if pxe_options.username %}set username {= pxe_options.username =}{% endif %}
+{% if pxe_options.password %}set password {= pxe_options.password =}{% endif %}
+{% if pxe_options.iscsi_initiator_iqn %}set initiator-iqn {= pxe_options.iscsi_initiator_iqn =}{% endif %}
+sanhook --drive 0x80 {= pxe_options.iscsi_boot_url =} || goto fail_iscsi_retry
 {%- if pxe_options.iscsi_volumes %}{% for i, volume in enumerate(pxe_options.iscsi_volumes) %}
-set username {{ "{{" }} volume.username {{ "}}" }}
-set password {{ "{{" }} volume.password {{ "}}" }}
+set username {= volume.username =}
+set password {= volume.password =}
 {%- set drive_id = 129 + i %}
-sanhook --drive {{ "{{" }} '0x%x' % drive_id {{ "}}" }} {{ "{{" }} volume.url {{ "}}" }} || goto fail_iscsi_retry
+sanhook --drive {= '0x%x' % drive_id =} {= volume.url =} || goto fail_iscsi_retry
 {%- endfor %}{% endif %}
-{% if pxe_options.iscsi_volumes %}set username {{ "{{" }} pxe_options.username {{ "}}" }}{% endif %}
-{% if pxe_options.iscsi_volumes %}set password {{ "{{" }} pxe_options.password {{ "}}" }}{% endif %}
+{% if pxe_options.iscsi_volumes %}set username {= pxe_options.username =}{% endif %}
+{% if pxe_options.iscsi_volumes %}set password {= pxe_options.password =}{% endif %}
 sanboot --no-describe || goto fail_iscsi_retry
 
 :fail_iscsi_retry


### PR DESCRIPTION
Switch the variable string for jinja to something custom so there is no
clash with go-templates and helm tries to resolve things that are not
helm-related. We use the same string as cinder/nova.
