### PR TITLE
fix(ocb-qe): named template with unique names

### DIFF
--- a/prometheus-exporters/octobus-query-exporter/Chart.lock
+++ b/prometheus-exporters/octobus-query-exporter/Chart.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 1.0.12
 - name: octobus-query-exporter-global
   repository: file://vendor/octobus-query-exporter-global
-  version: 1.0.11
+  version: 1.0.12
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:8e34cd38851ad795a23f6d2712f3dceaa5fb013a0534281cf849c9bfe5b6f8fb
-generated: "2024-04-18T15:05:44.538178+02:00"
+digest: sha256:bfe3de4568b292896aa87ae24709debca28775725efa05bbd2ee04a2d6b99ec9
+generated: "2024-04-18T16:25:50.607932+02:00"

--- a/prometheus-exporters/octobus-query-exporter/Chart.yaml
+++ b/prometheus-exporters/octobus-query-exporter/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
   - name: octobus-query-exporter-global
     alias: octobus_query_exporter_global
     repository: file://vendor/octobus-query-exporter-global
-    version: 1.0.11
+    version: 1.0.12
     condition: octobus_query_exporter_global.enabled
 
   - name: owner-info

--- a/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter-global/Chart.yaml
+++ b/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter-global/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 1.0.11
+version: 1.0.12
 name: octobus-query-exporter-global
 description: Elasticsearch prometheus query exporter only to query Octobus global
 maintainers:

--- a/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter-global/templates/_helper.tpl
+++ b/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter-global/templates/_helper.tpl
@@ -1,3 +1,3 @@
-{{- define "config" -}}
+{{- define "config-global" -}}
 header=['Authorization: Apikey {{ required ".Values.octobus.apikey " .Values.octobus.apikey }}']
 {{- end -}}

--- a/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter-global/templates/secret.yaml
+++ b/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter-global/templates/secret.yaml
@@ -7,4 +7,4 @@ metadata:
     component: octobus-query-exporter-global
 data:
   config.cfg: |
-    {{ include "config" . | b64enc }}
+    {{ include "config-global" . | b64enc }}


### PR DESCRIPTION
see helm docs:
An important detail to keep in mind when naming templates: template names are global. If you declare two templates with the same name, whichever one is loaded last will be the one used. Because templates in subcharts are compiled together with top-level templates, you should be careful to name your templates with chart-specific names.