### PR TITLE
[ironic] change ipxe back to configmap

### DIFF
--- a/openstack/ironic/templates/_conductor-configmap.yaml.tpl
+++ b/openstack/ironic/templates/_conductor-configmap.yaml.tpl
@@ -16,25 +16,11 @@ metadata:
 data:
   ironic-conductor.conf: |
 {{ list . $conductor | include "ironic_conductor_conf" | indent 4 }}
----
-apiVersion: v1
-kind: Secret
-metadata:
-{{- if $conductor.name }}
-  name: ironic-conductor-{{$conductor.name}}-etc-secret
-{{- else }}
-  name: ironic-conductor-etc-secret
-{{- end }}
-  labels:
-    system: openstack
-    type: configuration
-    component: ironic
-data:
   ipxe_config.template: |
     {{- if $conductor.jinja2 }}
     {% raw -%}
     {{- end }}
-{{ list . $conductor | include "ipxe_config_template" | b64enc | indent 4 }}
+{{ list . $conductor | include "ipxe_config_template" | indent 4 }}
     {{- if $conductor.jinja2 }}
     {%- endraw %}
     {{- end }}

--- a/openstack/ironic/templates/_conductor-deployment.yaml.tpl
+++ b/openstack/ironic/templates/_conductor-deployment.yaml.tpl
@@ -215,20 +215,13 @@ spec:
         configMap:
           name: ironic-etc
       - name: ironic-conductor-etc
-        projected:
-          sources:
-          - configMap:
-          {{- if $conductor.name }}
-              name: ironic-conductor-{{$conductor.name}}-etc
-          {{- else }}
-              name: ironic-conductor-etc
-          {{- end }}
-          - secret:
-          {{- if $conductor.name }}
-              name: ironic-conductor-{{$conductor.name}}-etc-secret
-          {{- else }}
-              name: ironic-conductor-etc-secret
-          {{- end }}
+        configMap:
+        {{- if $conductor.name }}
+          name: ironic-conductor-{{$conductor.name}}-etc
+        {{- else }}
+          name: ironic-conductor-etc
+        {{- end }}
+
       - name: ironic-console
         configMap:
           name: ironic-console


### PR DESCRIPTION
The ipxe config does not contain any secrets but handling it as a
k8s secret breaks helm as it will interpret jinja syntax that is
supposed to be interpreted by ironic later on.
