### PR TITLE
[Neutron] Enable ccroot user for mariadb

### DIFF
--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -376,6 +376,8 @@ mariadb:
   initdb_secret: true
   vpa:
     set_main_container: true
+  ccroot_user:
+    enabled: true
   persistence_claim:
     name: db-neutron-pvclaim
   backup:


### PR DESCRIPTION
This user provides passwordless access to the DB from localhost, so we can administer the DB without having to read and rotate a secret.