### PR TITLE
[octavia] Fix: Remove user_suffix which expands to <no value>

### DIFF
--- a/openstack/octavia/templates/etc/_secrets.conf.tpl
+++ b/openstack/octavia/templates/etc/_secrets.conf.tpl
@@ -3,7 +3,7 @@
 {{ include "ini_sections.default_transport_url" . }}
 
 [service_auth]
-username = {{ .Release.Name }}{{ .Values.global.user_suffix }}
+username = {{ .Release.Name }}
 password = {{ .Values.global.octavia_service_password | replace "$" "" }}
 
 [keystone_authtoken]


### PR DESCRIPTION
`.Values.global.user_suffix` is unset, so remove it