### PR TITLE
[octavia] Fix pending LBs metric

### DIFF
--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -195,7 +195,7 @@ mysql_metrics:
         FROM load_balancer AS lb
         JOIN vip AS v ON v.load_balancer_id=lb.id
         WHERE lb.provisioning_status LIKE "PENDING_%")
-        UNION (select '0', '', '', '', '', '');
+        UNION (select '0', '', '', '', '', '', '');
       values:
         - "elapsed_time"
     - name: octavia_monitor_agents_heartbeat_seconds


### PR DESCRIPTION
The second selection (after UNION) is missing a field to compensate for the loadbalancer_project field introduced in #6233