### PR TITLE
[nannies] Mount DB secret in cinder-nanny

### DIFF
--- a/openstack/nannies/templates/cinder-nanny-deployment.yaml
+++ b/openstack/nannies/templates/cinder-nanny-deployment.yaml
@@ -31,9 +31,17 @@ spec:
       nodeSelector:
         zone: farm
       volumes:
-        - name: cinder-etc
-          configMap:
-            name: cinder-etc
+      - name: cinder-etc
+        projected:
+          defaultMode: 420
+          sources:
+          - configMap:
+              name: cinder-etc
+          - secret:
+              items:
+              - key: secrets.conf
+                path: cinder.conf.d/secrets.conf
+              name: cinder-secrets
       containers:
 {{- if .Values.cinder_nanny.db_purge.enabled }}
         - name: db-consistency-and-purge


### PR DESCRIPTION
Cinder moved their secrets and by that also their DB connection URL into a Secret named `cinder-secrets` under the key `secrets.conf`. This is usually mounted in `/etc/cinder/cinder.conf.d/secrets.conf`. We update the cinder-nanny to mount that Secret into the same place. This should make any cinder-manage commands work again, but since our custom code relies on a different config file, we have to update it, too.