### PR TITLE
[mariadb-galera] multi region option added for MariaDB Galera

### DIFF
--- a/common/mariadb-galera/CHANGELOG.md
+++ b/common/mariadb-galera/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.24.0 - 2024/04/22
+* multi region support for Galera added
+  * MariaDB Galera cluster can be deployed in 3 regions
+  * currently limited to one cluster node per region, will be extended in the future
+  * WAN configuration tweaks added
+  * helm unit tests added
+  * [documentation](README.md#multi-region-support) added
+* packages timestamp updated to `20240419150126`
+* chart version bumped
+
 ## v0.23.1 - 2024/02/12
 * helm unit tests for migration option added
 * packages timestamp updated to `20240212072432`

--- a/common/mariadb-galera/README.md
+++ b/common/mariadb-galera/README.md
@@ -24,6 +24,9 @@ Docker images and Helm chart to deploy a [MariaDB](https://mariadb.com/kb/en/get
     * [NFS backend](#nfs-backend)
   * [full database recovery](#full-database-recovery)
   * [point in time database recovery](#point-in-time-database-recovery)
+  * [multi region support](#multi-region-support)
+    * [multi region configuration](#multi-region-configuration)
+    * [multi region WAN tweaks](#multi-region-wan-tweaks)
   * [asynchronous replication config](#asynchronous-replication-config)
   * [MariaDB Galera flow charts](#mariadb-galera-flow-charts)
     * [node startup](#node-startup)
@@ -42,7 +45,7 @@ Docker images and Helm chart to deploy a [MariaDB](https://mariadb.com/kb/en/get
 ## Metadata
 | chart version | app version | type | url |
 |:--------------|:-------------|:-------------|:-------------|
-| 0.23.1 | 10.5.23 | application | [Git repo](https://github.com/sapcc/helm-charts/tree/mariadb-galera/common/mariadb-galera) |
+| 0.24.0 | 10.5.23 | application | [Git repo](https://github.com/sapcc/helm-charts/tree/mariadb-galera/common/mariadb-galera) |
 
 | Name | Email | Url |
 | ---- | ------ | --- |
@@ -152,7 +155,7 @@ docker build --build-arg BASE_SOFT_NAME=ubuntu --build-arg BASE_SOFT_VERSION=22.
   ```
 * [push](https://helm.sh/docs/topics/registries/#the-push-subcommand) the chart to the registry
   ```shell
-  helm push mariadb-galera-0.23.1.tgz oci://keppel.eu-de-1.cloud.sap/ccloud-helm/
+  helm push mariadb-galera-0.24.0.tgz oci://keppel.eu-de-1.cloud.sap/ccloud-helm/
   ```
 
 ### values description
@@ -254,7 +257,7 @@ docker build --build-arg BASE_SOFT_NAME=ubuntu --build-arg BASE_SOFT_VERSION=22.
 | hpa.proxy.minReplicas | int | 3 | minimum number of replicas allowed for the ProxySQL cluster pods |
 | image.database.databasename | string | `"mariadb-galera"` | folder/container used in the image registry and also part of the image name |
 | image.database.databaseversion | string | `"10.5.23"` | database part of the image version that should be pulled |
-| image.database.imageversion | int | `20240212072432` | image part of the image version that should be pulled |
+| image.database.imageversion | int | `20240419150126` | image part of the image version that should be pulled |
 | image.database.project | string | `"ccloud"` | project/tenant used in the image registry |
 | image.database.pullPolicy | string | IfNotPresent | `Always` to enforce that the image will be pulled even if it is already available on the worker node |
 | image.database.pullSecret | string | `nil` | name of the defined Kubernetes secret defined in `image.pullSecrets` that should be used for container registry authentication |
@@ -267,28 +270,28 @@ docker build --build-arg BASE_SOFT_NAME=ubuntu --build-arg BASE_SOFT_VERSION=22.
 | image.haproxy.registry | string | `"keppel.eu-de-1.cloud.sap"` | hostname of the image registry used to pull the proxy image that contains the Restic backup software |
 | image.kopiabackup.databasename | string | `"mariadb-galera-kopia"` | folder/container used in the image registry and also part of the image name |
 | image.kopiabackup.databaseversion | string | `"0.12.1"` | database part of the image version that should be pulled |
-| image.kopiabackup.imageversion | int | `20240212072432` | image part of the image version that should be pulled |
+| image.kopiabackup.imageversion | int | `20240419150126` | image part of the image version that should be pulled |
 | image.kopiabackup.project | string | `"ccloud"` | project/tenant used in the image registry |
 | image.kopiabackup.pullPolicy | string | IfNotPresent | `Always` to enforce that the image will be pulled even if it is already available on the worker node |
 | image.kopiabackup.pullSecret | string | `nil` | name of the defined Kubernetes secret defined in `image.pullSecrets` that should be used for container registry authentication |
 | image.kopiabackup.registry | string | `"keppel.eu-de-1.cloud.sap"` | hostname of the image registry used to pull the proxy image that contains the Kopia backup software |
 | image.monitoring.databasename | string | `"mariadb-galera-mysqld_exporter"` | folder/container used in the image registry and also part of the image name |
 | image.monitoring.databaseversion | string | `"0.14.0"` | database part of the image version that should be pulled |
-| image.monitoring.imageversion | int | `20240212072432` | image part of the image version that should be pulled |
+| image.monitoring.imageversion | int | `20240419150126` | image part of the image version that should be pulled |
 | image.monitoring.project | string | `"ccloud"` | project/tenant used in the image registry |
 | image.monitoring.pullPolicy | string | IfNotPresent | `Always` to enforce that the image will be pulled even if it is already available on the worker node |
 | image.monitoring.pullSecret | string | `nil` | name of the defined Kubernetes secret defined in `image.pullSecrets` that should be used for container registry authentication |
 | image.monitoring.registry | string | `"keppel.eu-de-1.cloud.sap"` | hostname of the image registry used to pull the monitoring image that currently contains the MySQL exporter for Prometheus |
 | image.os.databasename | string | `"mariadb-galera-ubuntu"` | folder/container used in the image registry and also part of the image name |
 | image.os.databaseversion | float | `22.04` | database part of the image version that should be pulled |
-| image.os.imageversion | int | `20240212072432` | image part of the image version that should be pulled |
+| image.os.imageversion | int | `20240419150126` | image part of the image version that should be pulled |
 | image.os.project | string | `"ccloud"` | project/tenant used in the image registry |
 | image.os.pullPolicy | string | IfNotPresent | `Always` to enforce that the image will be pulled even if it is already available on the worker node |
 | image.os.pullSecret | string | `nil` | name of the defined Kubernetes secret defined in `image.pullSecrets` that should be used for container registry authentication |
 | image.os.registry | string | `"keppel.eu-de-1.cloud.sap"` | hostname of the image registry used to pull the basic OS image that will be used for certain init steps |
 | image.proxy.databasename | string | `"mariadb-galera-proxysql"` | folder/container used in the image registry and also part of the image name |
 | image.proxy.databaseversion | string | `"2.5.5"` | database part of the image version that should be pulled |
-| image.proxy.imageversion | int | `20240212072432` | image part of the image version that should be pulled |
+| image.proxy.imageversion | int | `20240419150126` | image part of the image version that should be pulled |
 | image.proxy.project | string | `"ccloud"` | project/tenant used in the image registry |
 | image.proxy.pullPolicy | string | IfNotPresent | `Always` to enforce that the image will be pulled even if it is already available on the worker node |
 | image.proxy.pullSecret | string | `nil` | name of the defined Kubernetes secret defined in `image.pullSecrets` that should be used for container registry authentication |
@@ -380,6 +383,17 @@ docker build --build-arg BASE_SOFT_NAME=ubuntu --build-arg BASE_SOFT_VERSION=22.
 | mariadb.galera.gtidDomainIdCount | int | 1 | how many Galera cluster instances will be connected. Used for [asynchronous replication](#asynchronous-replication-config) setups. Maximum of `2` is supported |
 | mariadb.galera.gtidStrictMode | bool | false | enable [gtid_strict_mode](https://mariadb.com/kb/en/gtid/#gtid_strict_mode) |
 | mariadb.galera.logLevel | string | info | [wsrep_debug](https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_debug) |
+| mariadb.galera.multiRegion.bootstrap | bool | `false` | Enable the [Galera bootstrap](https://mariadb.com/kb/en/getting-started-with-mariadb-galera-cluster/#bootstrapping-a-new-cluster). Use it **ONLY** in case all nodes are down and the cluster needs to be started from scratch. It will cause data loss if used for a region that has not held the most recent seqno |
+| mariadb.galera.multiRegion.current | string | `nil` | Name of the region where we are currently deploying the MariaDB Galera cluster components. The `global.db_region` parameter will be used if defined by the parent chart. Otherwise something like r1, r2, r3 or names like eu-de-1, eu-de-2, eu-de-3 should be used |
+| mariadb.galera.multiRegion.enabled | bool | `false` | Enable the multi-region setup. Exactly 3 regions are supported |
+| mariadb.galera.multiRegion.inactive_check_period | float | `"2.5"` | Frequency of checks in seconds for peer inactivity (looking for nodes with delayed responses), after which nodes may be added to the delayed list, and later evicted [evs.inactive_check_period](https://mariadb.com/kb/en/wsrep_provider_options/#evsinactive_check_period) |
+| mariadb.galera.multiRegion.inactive_timeout | string | `30` | Time limit in seconds that a node can be inactive before being pronounced as dead [evs.inactive_timeout](https://mariadb.com/kb/en/wsrep_provider_options/#evsinactive_timeout) |
+| mariadb.galera.multiRegion.install_timeout | string | `8` | Wait time in seconds for install message acknowledgments [evs.install_timeout](https://mariadb.com/kb/en/wsrep_provider_options/#evsinactive_timeout) |
+| mariadb.galera.multiRegion.keepalive_period | float | `"1.6"` | How often keepalive signals should be transmitted when there's no other traffic [evs.keepalive_period](https://mariadb.com/kb/en/wsrep_provider_options/#evskeepalive_period) |
+| mariadb.galera.multiRegion.regions | object | `nil` | `r1/2/3.externalIP` (external IP address of the region. Can be exposed via a load balancer or a external IP of a ClusterIP service) and `r1/2/3.segmentId` (Define which network segment([gmcast.segment](https://galeracluster.com/library/documentation/galera-parameters.html#gmcast-segment)) this node is in) |
+| mariadb.galera.multiRegion.send_window | string | `256` | Maximum number of packets that can be replicated at a time [evs.send_window](https://mariadb.com/kb/en/wsrep_provider_options/#evssend_window) |
+| mariadb.galera.multiRegion.suspect_timeout | string | `5` | A node will be suspected to be dead after these seconds of inactivity [evs.suspect_timeout](https://mariadb.com/kb/en/wsrep_provider_options/#evssuspect_timeout) |
+| mariadb.galera.multiRegion.user_send_window | string | `128` | Maximum number of data packets that can be replicated at a time [evs.user_send_window](https://mariadb.com/kb/en/wsrep_provider_options/#evsuser_send_window) |
 | mariadb.galera.pcrecovery | bool | false | [primary component recovery](https://galeracluster.com/library/documentation/pc-recovery.html) |
 | mariadb.galera.restore.beforeTimestamp | string | `nil` | without `mariab.galera.restore.pointInTimeRecovery` only the full snapshot will be recovered |
 | mariadb.galera.restore.kopia.enabled | bool | `false` | enable the [full database restore](#full-database-restore). Should be done as described in the documentation with `--set` parameters |
@@ -394,7 +408,7 @@ docker build --build-arg BASE_SOFT_NAME=ubuntu --build-arg BASE_SOFT_VERSION=22.
 | mariadb.galera.sst_method | string | `"rsync"` | `rsync` or `mariabackup` (also requires GALERA_SST_USERNAME and GALERA_SST_PASSWORD) |
 | mariadb.galera.waitForPrimaryTimeoutInSeconds | int | 30 | [pc.wait_prim_timeout](https://galeracluster.com/library/documentation/galera-parameters.html#pc.wait_prim_timeout) |
 | mariadb.galera.weightedQuorum | string | false | configure [weighted Quorum](https://galeracluster.com/library/documentation/weighted-quorum.html#wq-three-nodes) values for the DB nodes eg: db-0: 4, db-1: 2, db-2: 1 |
-| mariadb.innodbFlushLogAtTrxCommit | int | 0 | `1` to enable [innodb_flush_log_at_trx_commit for ACID compliance](https://mariadb.com/kb/en/innodb-system-variables/#innodb_flush_log_at_trx_commit) |
+| mariadb.innodbFlushLogAtTrxCommit | int | `1` | `1` to enable [innodb_flush_log_at_trx_commit for ACID compliance](https://mariadb.com/kb/en/innodb-system-variables/#innodb_flush_log_at_trx_commit) |
 | mariadb.job.config.activeDeadlineSeconds | int | 300 | Maximum [allowed runtime](https://kubernetes.io/docs/concepts/workloads/controllers/job/#job-termination-and-cleanup) before the MariaDB config job will be stopped |
 | mariadb.job.config.backoffLimit | int | 6 | How many [retries](https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy) before the MariaDB config job will be marked as failed |
 | mariadb.job.config.jobRestartPolicy | string | OnFailure | Define how the MariaDB config job pod [will be restarted](https://kubernetes.io/docs/concepts/workloads/controllers/job/#handling-pod-and-container-failures) in case of an error. It can be on the same worker node or another |
@@ -561,8 +575,8 @@ docker build --build-arg BASE_SOFT_NAME=ubuntu --build-arg BASE_SOFT_VERSION=22.
 | readinessProbe.timeoutSeconds.kopiaserver | int | 10 | How long should Kubernetes [wait](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes) for the current check of the readiness probe for the Kopia UI pod |
 | readinessProbe.timeoutSeconds.monitoring | int | 10 | How long should Kubernetes [wait](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes) for the current check of the readiness probe for the MariaDB monitoring sidecar container |
 | readinessProbe.timeoutSeconds.proxy | int | 10 | How long should Kubernetes [wait](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes) for the current check of the readiness probe for the ProxySQL/HAProxy pods |
-| replicas.database | int | 3 | amount of pods that will [scheduled](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#creating-a-deployment) for the MariaDB Galera cluster. An uneven number will be enforced to avoid simple split brain situations. For a good balance between the write and read performance not more than 3 pods a suggested |
-| replicas.proxy | int | 3 | amount of pods that will [scheduled](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#creating-a-deployment) for the ProxySQL cluster. An uneven number will be enforced to avoid simple split brain situations |
+| replicas.database | int | 3 | amount of pods that will [scheduled](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#creating-a-deployment) for the MariaDB Galera cluster. An uneven number will be enforced to avoid simple split brain situations. For a good balance between the write and read performance not more than 3 pods a suggested. If `mariadb.galera.multiRegion.enabled` is set to `true` the amount of pods will be set to `1` |
+| replicas.proxy | int | 3 | amount of pods that will [scheduled](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#creating-a-deployment) for the ProxySQL cluster. An uneven number will be enforced to avoid simple split brain situations. If `mariadb.galera.multiRegion.enabled` is set to `true` the amount of pods will be set to `1` |
 | resourceLimits.cpu.cronjob | int | 0.25 | CPU [resource reservation(request)](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits) for the MariaDB backup cronjob |
 | resourceLimits.cpu.database | int | 0.5 | CPU [resource reservation(request)](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits) for the MariaDB containers |
 | resourceLimits.cpu.databasecfgjob | float | 0.25 | CPU [resource reservation(request)](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits) for the MariaDB configuration job |
@@ -583,7 +597,7 @@ docker build --build-arg BASE_SOFT_NAME=ubuntu --build-arg BASE_SOFT_VERSION=22.
 | scripts.maxRetries | int | 10 | how many times should script functions retry before failing |
 | scripts.useTimeDifferenceForSeqnoCheck | bool | `false` | fail if time difference between nodes for the last sequence number configmap update is too big |
 | scripts.waitTimeBetweenRetriesInSeconds | int | 6 | how long should script functions wait between retries |
-| services.database.backend.headless | bool | `true` | `false` or `true` if the IP adresses of the pods that are [endpoints for that service](https://kubernetes.io/docs/concepts/services-networking/service/#headless-services) should be advertised. Required to let the client make it's own load balancing decisions |
+| services.database.backend.headless | bool | `true` | `false` or `true` if the IP adresses of the pods that are [endpoints for that service](https://kubernetes.io/docs/concepts/services-networking/service/#headless-services) should be advertised. Required to let the client make it's own load balancing decisions. Will be set to `false` if `type` is set `LoadBalancer` |
 | services.database.backend.ports.galera.port | int | `4567` | exposed Galera [replication port](https://mariadb.com/kb/en/configuring-mariadb-galera-cluster/#network-ports) |
 | services.database.backend.ports.galera.protocol | string | `"TCP"` | Galera [replication port](https://mariadb.com/kb/en/configuring-mariadb-galera-cluster/#network-ports) protocol |
 | services.database.backend.ports.galera.targetPort | int | `4567` | Galera [replication port](https://mariadb.com/kb/en/configuring-mariadb-galera-cluster/#network-ports) configured in the container |
@@ -845,9 +859,135 @@ helm upgrade --install --namespace database mariadb-galera helm --set mariadb.wi
   * ProxySQL, the config job and the Backup cronjob will be enabled again (if they have been enabled before)
   * the MariaDB pods will be restarted and Galera will replicate the restored data
 
+### multi region support
+The cluster can be distributed across 3 different Kubernetes cluster instances. They can run in different regions or even in different cloud providers.
+
+#### multi region configuration
+
+* enable the multi region support for the regions `r1`, `r2` and `r3`
+* define the `externalIP` and the `segmentId`([gmcast.segment](https://mariadb.com/kb/en/wsrep_provider_options/#gmcastsegment)) for each region
+* with the service type `LoadBalancer` the `externalIP` will assigned to the requested load balancer. Your cloud provider has to support a reserved IP for the load balancer
+* the service can also be of type `ClusterIP`, but then your (for instance) service mesh has to route the traffic to the correct region
+* the initial rollout can be started from any region, the cluster with the segmentId 1 will bootstrap the Galera cluster
+
+**r1:**
+```yaml
+mariadb:
+  galera:
+    multiRegion:
+      enabled: true
+      current: r1
+      regions:
+        r1:
+          externalIP: "10.0.0.1"
+          segmentId: 1
+        r2:
+          externalIP: "10.0.0.2"
+          segmentId: 2
+        r3:
+          externalIP: "10.0.0.3"
+          segmentId: 3
+
+services:
+  database:
+    backend:
+      type: LoadBalancer
+```
+
+**r2:**
+```yaml
+mariadb:
+  galera:
+    multiRegion:
+      enabled: true
+      current: r2
+      regions:
+        r1:
+          externalIP: "10.0.0.1"
+          segmentId: 1
+        r2:
+          externalIP: "10.0.0.2"
+          segmentId: 2
+        r3:
+          externalIP: "10.0.0.3"
+          segmentId: 3
+
+services:
+  database:
+    backend:
+      type: LoadBalancer
+```
+
+**r3:**
+```yaml
+mariadb:
+  galera:
+    multiRegion:
+      enabled: true
+      current: r3
+      regions:
+        r1:
+          externalIP: "10.0.0.1"
+          segmentId: 1
+        r2:
+          externalIP: "10.0.0.2"
+          segmentId: 2
+        r3:
+          externalIP: "10.0.0.3"
+          segmentId: 3
+
+services:
+  database:
+    backend:
+      type: LoadBalancer
+```
+
+#### multi region WAN tweaks
+
+The following wsrep_provider_options can be configured to optimize the WAN communication between the Galera nodes
+* `mariadb.galera.multiRegion.suspect_timeout`: A node will be suspected to be dead after these seconds of inactivity [evs.suspect_timeout](https://mariadb.com/kb/en/wsrep_provider_options/#evssuspect_timeout)
+* `mariadb.galera.multiRegion.inactive_timeout`: Time limit in seconds that a node can be inactive before being pronounced as dead [evs.inactive_timeout](https://mariadb.com/kb/en/wsrep_provider_options/#evsinactive_timeout)
+* `mariadb.galera.multiRegion.inactive_check_period`: Frequency of checks in seconds for peer inactivity (looking for nodes with delayed responses), after which nodes may be added to the delayed list, and later evicted [evs.inactive_check_period](https://mariadb.com/kb/en/wsrep_provider_options/#evsinactive_check_period)
+* `mariadb.galera.multiRegion.keepalive_period`: How often keepalive signals should be transmitted when there's no other traffic [evs.keepalive_period](https://mariadb.com/kb/en/wsrep_provider_options/#evskeepalive_period)
+* `mariadb.galera.multiRegion.install_timeout`: Wait time in seconds for install message acknowledgments [evs.install_timeout](https://mariadb.com/kb/en/wsrep_provider_options/#evsinactive_timeout)
+* `mariadb.galera.multiRegion.send_window`: Maximum number of packets that can be replicated at a time [evs.send_window](https://mariadb.com/kb/en/wsrep_provider_options/#evssend_window)
+* `mariadb.galera.multiRegion.user_send_window`: Maximum number of data packets that can be replicated at a time [evs.user_send_window](https://mariadb.com/kb/en/wsrep_provider_options/#evsuser_send_window)
+
+#### multi region limitations
+
+* currently the Galera connections are not encrypted or secured
+* currently the cluster startup after losing the quorum (no primary partition available) is not automated
+* you have to manually check the galerastatus configmap in every region
+
+```shell
+kubectl get cm mariadb-galera-galerastatus -o yaml | yq .data
+
+mariadb-galera-mariadb-g-0.primary: |
+  mariadb-galera-mariadb-g-0:
+  timestamp:
+mariadb-galera-mariadb-g-0.running: |
+  mariadb-galera-mariadb-g-0:
+  timestamp:
+mariadb-galera-mariadb-g-0.seqno: |
+  mariadb-galera-mariadb-g-0:120
+  timestamp:1713780824
+```
+
+* than trigger the bootstrap process in the region with the highest seqno and wait for the other regions to catch up
+
+```shell
+helm upgrade --install --create-namespace --namespace database mariadb-galera helm --values ${region}.yaml --set mariadb.galera.multiRegion.bootstrap=true
+```
+
+* after the cluster is up and running again you have to remove the bootstrap option from the cluster where you have started the bootstrap process
+
+```shell
+helm upgrade --install --create-namespace --namespace database mariadb-galera helm --values ${region}.yaml
+```
+
 ### asynchronous replication config
 
-The Helm chart supports circular asynchronous replication between two Galera clusters. Other topologies are technical possible, but not tested.
+[THIS FEATURE WILL BE REMOVED IN THE FUTURE] The Helm chart supports circular asynchronous replication between two Galera clusters. Other topologies are technical possible, but not tested.
 
 * configure the `gtidDomainId` and `gtidDomainIdCount` in the custom configuration files `helm/custom/eu-de-2.yaml` and `helm/custom/eu-nl-1.yaml` of your Galera instances and make sure `asyncReplication.enabled=false` is defined
 * eu-de-2
@@ -1168,4 +1308,4 @@ flowchart TB;
   * [Kopia environment variables](https://github.com/kopia/kopia/search?p=1&q=envName)
 
 ----------------------------------------------
-Autogenerated from chart metadata using [helm-docs v1.11.3](https://github.com/norwoodj/helm-docs/releases/v1.11.3)
+Autogenerated from chart metadata using [helm-docs v1.13.1](https://github.com/norwoodj/helm-docs/releases/v1.13.1)

--- a/common/mariadb-galera/helm/Chart.yaml
+++ b/common/mariadb-galera/helm/Chart.yaml
@@ -3,7 +3,7 @@ name: mariadb-galera
 description: Docker images and Helm chart to deploy a [MariaDB](https://mariadb.com/kb/en/getting-installing-and-upgrading-mariadb/) HA cluster based on [Galera](https://mariadb.com/kb/en/what-is-mariadb-galera-cluster/)
 home: "https://github.com/sapcc/helm-charts/tree/mariadb-galera/common/mariadb-galera"
 appVersion: 10.5.23
-version: 0.23.1
+version: 0.24.0
 type: application
 kubeVersion: ">=1.18"
 maintainers:

--- a/common/mariadb-galera/helm/README.md.gotmpl
+++ b/common/mariadb-galera/helm/README.md.gotmpl
@@ -23,6 +23,9 @@
     * [NFS backend](#nfs-backend)
   * [full database recovery](#full-database-recovery)
   * [point in time database recovery](#point-in-time-database-recovery)
+  * [multi region support](#multi-region-support)
+    * [multi region configuration](#multi-region-configuration)
+    * [multi region WAN tweaks](#multi-region-wan-tweaks)
   * [asynchronous replication config](#asynchronous-replication-config)
   * [MariaDB Galera flow charts](#mariadb-galera-flow-charts)
     * [node startup](#node-startup)
@@ -309,9 +312,135 @@ helm upgrade --install --namespace database mariadb-galera helm --set mariadb.wi
   * ProxySQL, the config job and the Backup cronjob will be enabled again (if they have been enabled before)
   * the MariaDB pods will be restarted and Galera will replicate the restored data
 
+### multi region support
+The cluster can be distributed across 3 different Kubernetes cluster instances. They can run in different regions or even in different cloud providers.
+
+#### multi region configuration
+
+* enable the multi region support for the regions `r1`, `r2` and `r3`
+* define the `externalIP` and the `segmentId`([gmcast.segment](https://mariadb.com/kb/en/wsrep_provider_options/#gmcastsegment)) for each region
+* with the service type `LoadBalancer` the `externalIP` will assigned to the requested load balancer. Your cloud provider has to support a reserved IP for the load balancer
+* the service can also be of type `ClusterIP`, but then your (for instance) service mesh has to route the traffic to the correct region
+* the initial rollout can be started from any region, the cluster with the segmentId 1 will bootstrap the Galera cluster
+
+**r1:**
+```yaml
+mariadb:
+  galera:
+    multiRegion:
+      enabled: true
+      current: r1
+      regions:
+        r1:
+          externalIP: "10.0.0.1"
+          segmentId: 1
+        r2:
+          externalIP: "10.0.0.2"
+          segmentId: 2
+        r3:
+          externalIP: "10.0.0.3"
+          segmentId: 3
+
+services:
+  database:
+    backend:
+      type: LoadBalancer
+```
+
+**r2:**
+```yaml
+mariadb:
+  galera:
+    multiRegion:
+      enabled: true
+      current: r2
+      regions:
+        r1:
+          externalIP: "10.0.0.1"
+          segmentId: 1
+        r2:
+          externalIP: "10.0.0.2"
+          segmentId: 2
+        r3:
+          externalIP: "10.0.0.3"
+          segmentId: 3
+
+services:
+  database:
+    backend:
+      type: LoadBalancer
+```
+
+**r3:**
+```yaml
+mariadb:
+  galera:
+    multiRegion:
+      enabled: true
+      current: r3
+      regions:
+        r1:
+          externalIP: "10.0.0.1"
+          segmentId: 1
+        r2:
+          externalIP: "10.0.0.2"
+          segmentId: 2
+        r3:
+          externalIP: "10.0.0.3"
+          segmentId: 3
+
+services:
+  database:
+    backend:
+      type: LoadBalancer
+```
+
+#### multi region WAN tweaks
+
+The following wsrep_provider_options can be configured to optimize the WAN communication between the Galera nodes
+* `mariadb.galera.multiRegion.suspect_timeout`: A node will be suspected to be dead after these seconds of inactivity [evs.suspect_timeout](https://mariadb.com/kb/en/wsrep_provider_options/#evssuspect_timeout)
+* `mariadb.galera.multiRegion.inactive_timeout`: Time limit in seconds that a node can be inactive before being pronounced as dead [evs.inactive_timeout](https://mariadb.com/kb/en/wsrep_provider_options/#evsinactive_timeout)
+* `mariadb.galera.multiRegion.inactive_check_period`: Frequency of checks in seconds for peer inactivity (looking for nodes with delayed responses), after which nodes may be added to the delayed list, and later evicted [evs.inactive_check_period](https://mariadb.com/kb/en/wsrep_provider_options/#evsinactive_check_period)
+* `mariadb.galera.multiRegion.keepalive_period`: How often keepalive signals should be transmitted when there's no other traffic [evs.keepalive_period](https://mariadb.com/kb/en/wsrep_provider_options/#evskeepalive_period)
+* `mariadb.galera.multiRegion.install_timeout`: Wait time in seconds for install message acknowledgments [evs.install_timeout](https://mariadb.com/kb/en/wsrep_provider_options/#evsinactive_timeout)
+* `mariadb.galera.multiRegion.send_window`: Maximum number of packets that can be replicated at a time [evs.send_window](https://mariadb.com/kb/en/wsrep_provider_options/#evssend_window)
+* `mariadb.galera.multiRegion.user_send_window`: Maximum number of data packets that can be replicated at a time [evs.user_send_window](https://mariadb.com/kb/en/wsrep_provider_options/#evsuser_send_window)
+
+#### multi region limitations
+
+* currently the Galera connections are not encrypted or secured
+* currently the cluster startup after losing the quorum (no primary partition available) is not automated
+* you have to manually check the galerastatus configmap in every region
+
+```shell
+kubectl get cm mariadb-galera-galerastatus -o yaml | yq .data
+
+mariadb-galera-mariadb-g-0.primary: |
+  mariadb-galera-mariadb-g-0:
+  timestamp:
+mariadb-galera-mariadb-g-0.running: |
+  mariadb-galera-mariadb-g-0:
+  timestamp:
+mariadb-galera-mariadb-g-0.seqno: |
+  mariadb-galera-mariadb-g-0:120
+  timestamp:1713780824
+```
+
+* than trigger the bootstrap process in the region with the highest seqno and wait for the other regions to catch up
+
+```shell
+helm upgrade --install --create-namespace --namespace database mariadb-galera helm --values ${region}.yaml --set mariadb.galera.multiRegion.bootstrap=true
+```
+
+* after the cluster is up and running again you have to remove the bootstrap option from the cluster where you have started the bootstrap process
+
+```shell
+helm upgrade --install --create-namespace --namespace database mariadb-galera helm --values ${region}.yaml
+```
+
 ### asynchronous replication config
 
-The Helm chart supports circular asynchronous replication between two Galera clusters. Other topologies are technical possible, but not tested.
+[THIS FEATURE WILL BE REMOVED IN THE FUTURE] The Helm chart supports circular asynchronous replication between two Galera clusters. Other topologies are technical possible, but not tested.
 
 * configure the `gtidDomainId` and `gtidDomainIdCount` in the custom configuration files `helm/custom/eu-de-2.yaml` and `helm/custom/eu-nl-1.yaml` of your Galera instances and make sure `asyncReplication.enabled=false` is defined
 * eu-de-2
@@ -524,6 +653,7 @@ flowchart TB;
     id5 & id7--No-->id666[exit 1];
   end
 ```
+
 ##### recover Galera
 
 ```mermaid

--- a/common/mariadb-galera/helm/scripts/backup/kopia/entrypoint-backup.sh
+++ b/common/mariadb-galera/helm/scripts/backup/kopia/entrypoint-backup.sh
@@ -94,7 +94,7 @@ function createkopiabinlogbackup {
   fi
 }
 
-{{- range $int, $err := until ($.Values.replicas.database|int) }}
+{{- range $int, $err := until ((include "replicaCount" (dict "global" $ "type" "database")) | int) }}
 fetchseqnofromremotenode {{ (printf "%s-%d" (include "nodeNamePrefix" (dict "global" $ "component" "database")) $int) }} >>/tmp/nodelist.seqno
 {{- end }}
 selectbackupnode

--- a/common/mariadb-galera/helm/scripts/haproxy/haproxy.cfg
+++ b/common/mariadb-galera/helm/scripts/haproxy/haproxy.cfg
@@ -76,7 +76,7 @@ backend mariadb-galera
   balance {{ $.Values.proxy.haproxy.backend.balance | default "source" }}
   option mysql-check user haproxy
   {{- /* MariaDB Galera backend services */}}
-  {{- range $replicaNumber, $err := until ($.Values.replicas.database|int) }}
+  {{- range $replicaNumber, $err := until ((include "replicaCount" (dict "global" $ "type" "database")) | int) }}
     {{- $nodeName := (include "nodeNamePrefix" (dict "global" $ "component" "database")) }}
     {{- $replicaString := ($replicaNumber| toString) }}
     {{- $mysqlPort := ((required ".services.database.frontend.ports.mysql.targetPort missing" $.Values.services.database.frontend.ports.mysql.targetPort) | toString) }}

--- a/common/mariadb-galera/helm/scripts/mariadb-galera/pre-stop-hook.sh
+++ b/common/mariadb-galera/helm/scripts/mariadb-galera/pre-stop-hook.sh
@@ -60,7 +60,9 @@ checkgaleraclusterstate
 checkgaleranodeconnected
 checkgaleralocalstate
 rejectnewconnectionstogaleranode
+{{- if not $.Values.mariadb.galera.multiRegion.enabled }}
 setconfigmap "seqno" "" "Reset"
+{{- end }}
 setconfigmap "primary" "" "Reset"
 setconfigmap "running" "" "Reset"
 loginfo "null" "preStop hook done"

--- a/common/mariadb-galera/helm/templates/alerts/_kubernetes.tpl
+++ b/common/mariadb-galera/helm/templates/alerts/_kubernetes.tpl
@@ -1,7 +1,7 @@
 - name: kubernetes.alerts
   rules:
   - alert: "{{ $.Values.monitoring.prometheus.alerts.service | default $.Values.mariadb.galera.clustername | title }}DBClusterNodeNotReady"
-    expr: (sum(kube_pod_status_ready_normalized{ condition="true", pod=~"{{ (include "nodeNamePrefix" (dict "global" $ "component" "database")) }}.*" }) < {{ ($.Values.replicas.database|int) }})
+    expr: (sum(kube_pod_status_ready_normalized{ condition="true", pod=~"{{ (include "nodeNamePrefix" (dict "global" $ "component" "database")) }}.*" }) < {{ ((include "replicaCount" (dict "global" $ "type" "database")) | int) }})
     for: 30m
     labels:
       context: "availability"

--- a/common/mariadb-galera/helm/templates/alerts/_mariadb.tpl
+++ b/common/mariadb-galera/helm/templates/alerts/_mariadb.tpl
@@ -65,7 +65,7 @@
 - name: galera.alerts
   rules:
   - alert: "{{ $.Values.monitoring.prometheus.alerts.service | default $.Values.mariadb.galera.clustername | title }}GaleraClusterIncomplete"
-    expr: (mysql_global_status_wsrep_cluster_size{app="{{ $.Release.Name }}", pod=~"{{ (include "nodeNamePrefix" (dict "global" $ "component" "database")) }}.*"} < {{ ($.Values.replicas.database|int) }})
+    expr: (mysql_global_status_wsrep_cluster_size{app="{{ $.Release.Name }}", pod=~"{{ (include "nodeNamePrefix" (dict "global" $ "component" "database")) }}.*"} < {{ ((include "replicaCount" (dict "global" $ "type" "database")) | int) }})
     for: 30m
     labels:
       context: "database"
@@ -74,7 +74,7 @@
       tier: {{ required "$.Values.monitoring.prometheus.alerts missing, but required for Prometheus alert definitions" $.Values.monitoring.prometheus.alerts.tier | quote }}
       support_group: {{ required "$.Values.monitoring.prometheus.alerts.support_group missing, but required for Prometheus alert definitions" $.Values.monitoring.prometheus.alerts.support_group | quote }}
     annotations:
-      description: "{{ (include "nodeNamePrefix" (dict "global" $ "component" "database")) }} Galera cluster reports less than {{ ($.Values.replicas.database|int) }} nodes for the last 30 minutes"
+      description: "{{ (include "nodeNamePrefix" (dict "global" $ "component" "database")) }} Galera cluster reports less than {{ ((include "replicaCount" (dict "global" $ "type" "database")) | int) }} nodes for the last 30 minutes"
       summary: "{{ (include "nodeNamePrefix" (dict "global" $ "component" "database")) }} Galera cluster incomplete"
   - alert: "{{ $.Values.monitoring.prometheus.alerts.service | default $.Values.mariadb.galera.clustername | title }}GaleraClusterNodeNotReady"
     expr: (mysql_global_status_wsrep_ready{app="{{ $.Release.Name }}", pod=~"{{ (include "nodeNamePrefix" (dict "global" $ "component" "database")) }}.*"} != 1)

--- a/common/mariadb-galera/helm/templates/configmap-mariadb-job.yaml
+++ b/common/mariadb-galera/helm/templates/configmap-mariadb-job.yaml
@@ -1,4 +1,9 @@
----
+{{- if and (hasKey $.Values.mariadb "autostart") (not $.Values.mariadb.autostart) }}
+{{- else if and ($.Values.command) (hasKey $.Values.command "database") }}
+{{- else if and (hasKey $.Values.mariadb.galera.restore "kopia") ($.Values.mariadb.galera.restore.kopia.enabled) }}
+{{- else if and (hasKey $.Values.mariadb "wipeDataAndLog") ($.Values.mariadb.wipeDataAndLog) }}
+{{- else if and ($.Values.mariadb.galera.multiRegion.enabled) (ne ((index $.Values.mariadb.galera.multiRegion.regions $.Values.mariadb.galera.multiRegion.current).segmentId | int) 1) }}
+{{- else }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,3 +13,4 @@ metadata:
     app: {{ $.Release.Name }}
 data:
 {{ tpl (.Files.Glob "scripts/mariadb-galera/entrypoint-job-config.sh").AsConfig . | indent 2 }}
+{{- end }}

--- a/common/mariadb-galera/helm/templates/configmap-mariadb-my.cnf.yaml
+++ b/common/mariadb-galera/helm/templates/configmap-mariadb-my.cnf.yaml
@@ -10,13 +10,41 @@
 {{- else  }}
   {{- $_ := set $wsrepProviderOptions "gcache.recover" "gcache.recover=no" }}
 {{- end }}
+{{- if $.Values.mariadb.galera.multiRegion.enabled }}
+  {{- if and (hasKey $.Values "global") (hasKey $.Values.global "db_region") ($.Values.global.db_region) }}
+    {{- $_ := set $wsrepProviderOptions "gmcast.segment" (printf "gmcast.segment=%d" (required "mariadb.galera.multiRegion.<region_name>.segmentId has to be defined if the multiRegion parameter is enabled" (index $.Values.mariadb.galera.multiRegion.regions $.Values.global.db_region).segmentId | int)) }}
+  {{- else }}
+    {{- $_ := set $wsrepProviderOptions "gmcast.segment" (printf "gmcast.segment=%d" (required "mariadb.galera.multiRegion.<region_name>.segmentId has to be defined if the multiRegion parameter is enabled" (index $.Values.mariadb.galera.multiRegion.regions (required "mariadb.galera.multiRegion.current has to be defined if the multiRegion parameter is enabled" $.Values.mariadb.galera.multiRegion.current)).segmentId | int)) }}
+  {{- end }}
+{{- end }}
 {{- $_ := set $wsrepProviderOptions "cert.log_conflicts" "cert.log_conflicts=ON"}}
 {{- if $.Values.mariadb.galera.debug }}
   {{- $_ := set $wsrepProviderOptions "debug" "debug=YES"}}
 {{- else  }}
   {{- $_ := set $wsrepProviderOptions "debug" "debug=NO"}}
 {{- end }}
-{{- $_ := set $wsrepProviderOptions "ist.recv_addr" (printf "ist.recv_addr=${CONTAINER_IP}:%d" ((include "getNetworkPort" (dict "global" $ "type" "backend" "name" "ist")) | int)) }}
+{{- if $.Values.mariadb.galera.multiRegion.enabled }}
+  {{- if ge ($.Values.mariadb.galera.multiRegion.user_send_window | int) ($.Values.mariadb.galera.multiRegion.send_window | int) }}
+    {{- fail "mariadb.galera.multiRegion.user_send_window has to be smaller or equal to mariadb.galera.multiRegion.send_window" }}
+  {{- end }}
+  {{- if gt ($.Values.mariadb.galera.multiRegion.inactive_check_period | float64) 2.5 }}
+    {{- fail "mariadb.galera.multiRegion.inactive_check_period has to be smaller or equal to 2.5" }}
+  {{- end }}
+  {{- if gt ($.Values.mariadb.galera.multiRegion.keepalive_period | float64) 1.6 }}
+    {{- fail "mariadb.galera.multiRegion.keepalive_period has to be smaller or equal to 1.6" }}
+  {{- end }}
+  {{- $_ := set $wsrepProviderOptions "ist.recv_addr" (printf "ist.recv_addr=%s:%d" (index $.Values.mariadb.galera.multiRegion.regions $.Values.mariadb.galera.multiRegion.current).externalIP ((include "getNetworkPort" (dict "global" $ "type" "backend" "component" "database" "name" "ist")) | int)) }}
+  {{- $_ := set $wsrepProviderOptions "ist.recv_bind" "ist.recv_bind=${CONTAINER_IP}" }}
+  {{- $_ := set $wsrepProviderOptions "evs.suspect_timeout" (printf "evs.suspect_timeout=PT%dS" ($.Values.mariadb.galera.multiRegion.suspect_timeout | int)) }}
+  {{- $_ := set $wsrepProviderOptions "evs.inactive_timeout" (printf "evs.inactive_timeout=PT%dS" ($.Values.mariadb.galera.multiRegion.inactive_timeout | int)) }}
+  {{- $_ := set $wsrepProviderOptions "evs.inactive_check_period" (printf "evs.inactive_check_period=PT%.2fS" ($.Values.mariadb.galera.multiRegion.inactive_check_period | float64)) }}
+  {{- $_ := set $wsrepProviderOptions "evs.install_timeout" (printf "evs.install_timeout=PT%dS" ($.Values.mariadb.galera.multiRegion.install_timeout | int)) }}
+  {{- $_ := set $wsrepProviderOptions "evs.keepalive_period" (printf "evs.keepalive_period=PT%.2fS" ($.Values.mariadb.galera.multiRegion.keepalive_period | float64)) }}
+  {{- $_ := set $wsrepProviderOptions "evs.send_window" (printf "evs.send_window=%d" ($.Values.mariadb.galera.multiRegion.send_window | int)) }}
+  {{- $_ := set $wsrepProviderOptions "evs.user_send_window" (printf "evs.user_send_window=%d" ($.Values.mariadb.galera.multiRegion.user_send_window | int)) }}
+{{- else  }}
+  {{- $_ := set $wsrepProviderOptions "ist.recv_addr" (printf "ist.recv_addr=${CONTAINER_IP}:%d" ((include "getNetworkPort" (dict "global" $ "type" "backend" "component" "database" "name" "ist")) | int)) }}
+{{- end }}
 {{- $_ := set $wsrepProviderOptions "pc.wait_prim_timeout" (printf "pc.wait_prim_timeout=PT%dS" ($.Values.mariadb.galera.waitForPrimaryTimeoutInSeconds | default 30 | int)) }}
 {{- if hasKey $.Values.mariadb.galera "gtidDomainIdCount" }}
   {{- if or (lt ($.Values.mariadb.galera.gtidDomainIdCount | int) 1) (gt ($.Values.mariadb.galera.gtidDomainIdCount | int) 2) }}
@@ -30,7 +58,7 @@ metadata:
   name: {{ include "commonPrefix" $ }}-mariadb-my-cnf
   namespace: {{ $.Release.Namespace }}
 data:
-{{- range $int, $err := until ($.Values.replicas.database|int) }}
+{{- range $int, $err := until ((include "replicaCount" (dict "global" $ "type" "database")) | int) }}
   my.cnf.{{ $nodeNamePrefix }}-{{ $int }}.tpl: |-
     [mysqld]
     {{- if $.Values.mariadb.performance_schema }}
@@ -57,7 +85,11 @@ data:
     sync_binlog={{ $.Values.mariadb.binLogSync | default 0 | int }}
     default_storage_engine=InnoDB
     innodb_autoinc_lock_mode=2
-    innodb_flush_log_at_trx_commit={{ $.Values.mariadb.innodbFlushLogAtTrxCommit | default 0 | int }}
+    {{- if $.Values.mariadb.galera.multiRegion.enabled }}
+    innodb_flush_log_at_trx_commit=0
+    {{- else }}
+    innodb_flush_log_at_trx_commit={{ $.Values.mariadb.innodbFlushLogAtTrxCommit | int }}
+    {{- end }}
     {{- if $.Values.mariadb.galera.gtidStrictMode }}
     gtid-strict-mode=1
     {{- else }}
@@ -72,8 +104,14 @@ data:
     wsrep_cluster_address={{ include "wsrepClusterAddress" (dict "global" $) }}
     {{- $_ := set $wsrepProviderOptions "pc.weight" (printf "pc.weight=${PC_WEIGHT_%d}" $int)}}
     wsrep_provider_options={{ (join ";" (values $wsrepProviderOptions | sortAlpha)) }}
+    {{- if $.Values.mariadb.galera.multiRegion.enabled }}
+    wsrep_node_address={{ (index $.Values.mariadb.galera.multiRegion.regions $.Values.mariadb.galera.multiRegion.current).externalIP }}
+    wsrep_sst_receive_address={{ (index $.Values.mariadb.galera.multiRegion.regions $.Values.mariadb.galera.multiRegion.current).externalIP }}
+    {{- else }}
     wsrep_node_address=${CONTAINER_IP}
-    wsrep_node_name={{ $nodeNamePrefix }}-{{ $int }}
+    {{- end }}
+    wsrep_node_incoming_address=${CONTAINER_IP}
+    wsrep_node_name={{ if $.Values.mariadb.galera.multiRegion.enabled }}{{- (printf "%d-" ((index $.Values.mariadb.galera.multiRegion.regions $.Values.mariadb.galera.multiRegion.current).segmentId|int))}}{{end}}{{ $nodeNamePrefix }}-{{ $int }}
     wsrep-on=1
     wsrep_log_conflicts=ON
     {{- if eq $.Values.mariadb.galera.logLevel "debug" }}wsrep_debug=1{{- end }}
@@ -92,7 +130,7 @@ data:
       replicas(5) * DomainCount(2) = 10
       replicas(5) * DomainCount(1) = 5
     */}}
-    auto_increment_increment={{ mul ($.Values.replicas.database|int) ($.Values.mariadb.galera.gtidDomainIdCount| default 1 | int) }}
+    auto_increment_increment={{ mul ((include "replicaCount" (dict "global" $ "type" "database")) | int) ($.Values.mariadb.galera.gtidDomainIdCount| default 1 | int) }}
     {{- /*
       calculate the auto increment offset based on ((Galera domain count - Galera domain id) * amount of pod replicas + (current replica number + 1)) to ensure unique values across all database nodes in all connected clusters
       (DomainCount(2) - domainId(2) * replicas(3) + (replica(0) + 1) = 1
@@ -113,7 +151,7 @@ data:
       (DomainCount(2) - domainId(1) * replicas(5) + (replica(3) + 1) = 9
       (DomainCount(2) - domainId(1) * replicas(5) + (replica(4) + 1) = 10
     */}}
-    auto_increment_offset={{ (add (mul (sub ($.Values.mariadb.galera.gtidDomainIdCount| default 1 | int) ($.Values.mariadb.galera.gtidDomainId | default 1 | int)) ($.Values.replicas.database|int)) (add1 ($int | int))) | int }}
+    auto_increment_offset={{ (add (mul (sub ($.Values.mariadb.galera.gtidDomainIdCount| default 1 | int) ($.Values.mariadb.galera.gtidDomainId | default 1 | int)) ((include "replicaCount" (dict "global" $ "type" "database")) | int)) (add1 ($int | int))) | int }}
 
     # async replication with MariaDB instances outside of the Galera cluster
     relay_log=/opt/${SOFTWARE_NAME}/{{ $.Values.mariadb.binLogDir | default "data" }}/{{ (required "mariadb.galera.clustername is required to configure the relay_log option for MariaDB" $.Values.mariadb.galera.clustername) }}_relaylog

--- a/common/mariadb-galera/helm/templates/configmap-mariadb.yaml
+++ b/common/mariadb-galera/helm/templates/configmap-mariadb.yaml
@@ -46,7 +46,7 @@ metadata:
   name: {{ include "commonPrefix" $ }}-galerastatus
   namespace: {{ $.Release.Namespace }}
 data:
-{{- range $int, $err := until ($.Values.replicas.database|int) }}
+{{- range $int, $err := until ((include "replicaCount" (dict "global" $ "type" "database")) | int) }}
   {{ (include "nodeNamePrefix" (dict "global" $ "component" "database")) }}-{{ $int }}.seqno: |-
   {{ (include "nodeNamePrefix" (dict "global" $ "component" "database")) }}-{{ $int }}.running: |-
   {{ (include "nodeNamePrefix" (dict "global" $ "component" "database")) }}-{{ $int }}.primary: |-

--- a/common/mariadb-galera/helm/templates/configmap-proxysql.conf.yaml
+++ b/common/mariadb-galera/helm/templates/configmap-proxysql.conf.yaml
@@ -56,8 +56,8 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 data:
   proxysql_servers.cfg.tpl: |-
-    {{- range $int, $err := until ($.Values.replicas.proxy|int) }}
-      {{- $weight := (sub (sub ($.Values.replicas.database|int) $int) 1) }}
+    {{- range $int, $err := until ((include "replicaCount" (dict "global" $ "type" "proxy")) | int) }}
+      {{- $weight := (sub (sub ((include "replicaCount" (dict "global" $ "type" "database")) | int) $int) 1) }}
       {{- $calculatedWeight := 1 }}
       {{- range $_, $err := until ($weight|int) }}
         {{- /* 2^n where n is the $calculatedWeight */}}
@@ -67,7 +67,7 @@ data:
         hostname="{{ (printf "%s-%d.%s" (include "nodeNamePrefix" (dict "global" $ "component" "proxysql")) $int $.Release.Namespace) }}"
         port={{ $proxysqlAdminPort }}
         weight={{ $calculatedWeight }}
-      {{- if eq (add1 $int) ($.Values.replicas.database|int) }}
+      {{- if eq (add1 $int) ((include "replicaCount" (dict "global" $ "type" "database")) | int) }}
       }
       {{- else }}
       },
@@ -86,8 +86,8 @@ data:
       active=1
     }
   mysql_servers.cfg.tpl: |-
-    {{- range $int, $err := until ($.Values.replicas.database|int) }}
-    {{- $weight := (sub (sub ($.Values.replicas.database|int) $int) 1) }}
+    {{- range $int, $err := until ((include "replicaCount" (dict "global" $ "type" "database")) | int) }}
+    {{- $weight := (sub (sub ((include "replicaCount" (dict "global" $ "type" "database")) | int) $int) 1) }}
       {{- $calculatedWeight := 1 }}
       {{- range $_, $err := until ($weight|int) }}
         {{- /* 2^n where n is the $calculatedWeight */}}
@@ -102,7 +102,7 @@ data:
         max_connections=100
         max_replication_lag=0
         max_latency_ms=0
-      {{- if eq (add1 $int) ($.Values.replicas.database|int) }}
+      {{- if eq (add1 $int) ((include "replicaCount" (dict "global" $ "type" "database")) | int) }}
       }
       {{- else }}
       },

--- a/common/mariadb-galera/helm/templates/job-mariadb-config.yaml
+++ b/common/mariadb-galera/helm/templates/job-mariadb-config.yaml
@@ -2,6 +2,7 @@
 {{- else if and ($.Values.command) (hasKey $.Values.command "database") }}
 {{- else if and (hasKey $.Values.mariadb.galera.restore "kopia") ($.Values.mariadb.galera.restore.kopia.enabled) }}
 {{- else if and (hasKey $.Values.mariadb "wipeDataAndLog") ($.Values.mariadb.wipeDataAndLog) }}
+{{- else if and ($.Values.mariadb.galera.multiRegion.enabled) (ne ((index $.Values.mariadb.galera.multiRegion.regions $.Values.mariadb.galera.multiRegion.current).segmentId | int) 1) }}
 {{- else }}
 apiVersion: batch/v1
 kind: Job

--- a/common/mariadb-galera/helm/templates/poddisruptionbudget.yaml
+++ b/common/mariadb-galera/helm/templates/poddisruptionbudget.yaml
@@ -15,7 +15,7 @@ spec:
 {{- else if and (hasKey $.Values.mariadb "wipeDataAndLog") ($.Values.mariadb.wipeDataAndLog) }}
 {{- else if and ($.Values.proxy.enabled) (eq $.Values.proxy.type "proxysql") }}
   {{- $unevenNodeCount := "" }}
-  {{- if eq (mod ($.Values.replicas.proxy|int) 2) 1 }}
+  {{- if eq (mod ((include "replicaCount" (dict "global" $ "type" "proxy")) | int) 2) 1 }}
     {{- $unevenNodeCount = "true" }}
   {{- end }}
   {{- $_ := (required ".replicas value not an uneven integer. This is required to avoid a split brain cluster state." $unevenNodeCount) }}

--- a/common/mariadb-galera/helm/templates/secrets.yaml
+++ b/common/mariadb-galera/helm/templates/secrets.yaml
@@ -31,14 +31,16 @@
   {{- end }}
 {{- end }}
 {{- range $credentialKey, $credentialValue := $.Values.mariadb.galera.backup.kopia.users }}
-  {{- if and (hasKey $credentialValue "username") (hasKey $credentialValue "password") }}
+  {{- if and (hasKey $credentialValue "enabled") ($credentialValue.enabled) }}
+    {{- if and (hasKey $credentialValue "username") (hasKey $credentialValue "password") }}
       {{- include "generateSecret" (dict "global" $ "name" $credentialKey "credential" $credentialValue "suffix" "kopia" "type" "basic-auth") }}
     {{- else if (hasKey $credentialValue "password") }}
       {{- include "generateSecret" (dict "global" $ "name" $credentialKey "credential" $credentialValue "suffix" "kopia" "type" "Opaque") }}
     {{- end }}
+  {{- end }}
 {{- end }}
 {{- range $credentialKey, $credentialValue := $.Values.image.pullSecrets }}
-  {{- if $credentialValue.enabled }}
+  {{- if and (hasKey $credentialValue "enabled") ($credentialValue.enabled) }}
     {{- include "generateSecret" (dict "global" $ "name" $credentialKey "credential" $credentialValue "type" "Dockerconfigjson") }}
   {{- end }}
 {{- end }}

--- a/common/mariadb-galera/helm/templates/service.yaml
+++ b/common/mariadb-galera/helm/templates/service.yaml
@@ -1,7 +1,7 @@
 {{/* MariaDB services */}}
   {{/* backend */}}
     {{/* per pod service to generate per pod hostnames */}}
-    {{- range $replicaNumber, $err := until ($.Values.replicas.database|int) }}
+    {{- range $replicaNumber, $err := until ((include "replicaCount" (dict "global" $ "type" "database")) | int) }}
       {{ include "networkService" (dict "global" $ "type" "backend" "service" (required ".services.database.backend missing" $.Values.services.database.backend) "component" "database" "replica" ($replicaNumber | toString)) }}
     {{- end }}
     {{/* shared service for all pods */}}
@@ -19,7 +19,7 @@
 {{- if and ($.Values.proxy.enabled) (eq $.Values.proxy.type "proxysql") }}
   {{/* backend */}}
     {{/* per pod service to generate per pod hostnames */}}
-    {{- range $replicaNumber, $err := until ($.Values.replicas.proxy|int) }}
+    {{- range $replicaNumber, $err := until ((include "replicaCount" (dict "global" $ "type" "proxy")) | int) }}
       {{ include "networkService" (dict "global" $ "type" "backend" "service" (required ".services.proxy.proxysql.backend missing" $.Values.services.proxy.proxysql.backend) "component" "proxysql" "replica" ($replicaNumber | toString)) }}
     {{- end }}
     {{/* shared service for all pods */}}

--- a/common/mariadb-galera/helm/templates/statefulset-mariadb.yaml
+++ b/common/mariadb-galera/helm/templates/statefulset-mariadb.yaml
@@ -1,5 +1,5 @@
 {{- $unevenNodeCount := "" }}
-{{- if eq (mod ($.Values.replicas.database|int) 2) 1 }}
+{{- if eq (mod ((include "replicaCount" (dict "global" $ "type" "database")) | int) 2) 1 }}
     {{- $unevenNodeCount = "true" }}
 {{- end }}
 {{- $_ := (required ".replicas.database value not an uneven integer. This is required to avoid a split brain cluster state." $unevenNodeCount) }}
@@ -14,7 +14,7 @@ metadata:
     component: "database"
     release: {{ $.Release.Name }}
 spec:
-  replicas: {{ $.Values.replicas.database | default 3 }}
+  replicas: {{ ((include "replicaCount" (dict "global" $ "type" "database")) | int) | default 3 }}
   serviceName: {{ $.Release.Name }}
   selector:
     matchLabels:
@@ -146,10 +146,10 @@ spec:
         - name: GALERA_PORT
           value: "{{ (required ".services.database.backend.ports.galera.targetPort missing" $.Values.services.database.backend.ports.galera.targetPort) }}"
           {{- /* https://galeracluster.com/library/documentation/weighted-quorum.html#wq-three-nodes */}}
-          {{- range $int, $err := until ($.Values.replicas.database|int) }}
+          {{- range $int, $err := until ((include "replicaCount" (dict "global" $ "type" "database")) | int) }}
         - name: PC_WEIGHT_{{ $int }}
             {{- if and (hasKey $.Values.mariadb.galera "weightedQuorum") $.Values.mariadb.galera.weightedQuorum }}
-              {{- $weight := (sub (sub ($.Values.replicas.database|int) $int) 1) }}
+              {{- $weight := (sub (sub ((include "replicaCount" (dict "global" $ "type" "database")) | int) $int) 1) }}
               {{- $calculatedWeight := 1 }}
                 {{- range $_, $err := until ($weight|int) }}
                   {{- /* 2^n where n is the $calculatedWeight */}}
@@ -495,6 +495,8 @@ spec:
       {{- else }}
         {{- if or (and (hasKey $.Values.mariadb "wipeDataAndLog") ($.Values.mariadb.wipeDataAndLog)) (and (hasKey $.Values.mariadb.galera.restore "kopia") ($.Values.mariadb.galera.restore.kopia.enabled)) }}
       terminationGracePeriodSeconds: 15
+        {{- else if and ($.Values.mariadb.galera.multiRegion.enabled) (not $.Values.mariadb.galera.multiRegion.bootstrap) }}
+      terminationGracePeriodSeconds: 10
         {{- else }}
       terminationGracePeriodSeconds: {{ $.Values.terminationGracePeriodSeconds | default 86400 | int }}
         {{- end }}

--- a/common/mariadb-galera/helm/templates/statefulset-proxysql.yaml
+++ b/common/mariadb-galera/helm/templates/statefulset-proxysql.yaml
@@ -4,7 +4,7 @@
 {{- else if and (hasKey $.Values.mariadb "wipeDataAndLog") ($.Values.mariadb.wipeDataAndLog) }}
 {{- else if and ($.Values.proxy.enabled) (eq $.Values.proxy.type "proxysql") }}
   {{- $unevenNodeCount := "" }}
-  {{- if eq (mod ($.Values.replicas.proxy|int) 2) 1 }}
+  {{- if eq (mod ((include "replicaCount" (dict "global" $ "type" "proxy")) | int) 2) 1 }}
     {{- $unevenNodeCount = "true" }}
   {{- end }}
   {{- $_ := (required ".replicas value not an uneven integer. This is required to avoid a split brain cluster state." $unevenNodeCount) }}

--- a/common/mariadb-galera/helm/tests/01-default-statefulset_test.yaml
+++ b/common/mariadb-galera/helm/tests/01-default-statefulset_test.yaml
@@ -1,8 +1,8 @@
 
 ---
 checksums:
-  my.cnf: &mycnf "5154f9752a947d04e0b5884536fb7d7b488072890bba3c875b6c2afe5316bb0a"
-  configmap: &configmap "3ce595230ab36cda233e0d33a9f1ca9825d78080ada86a99198b093e6d2a7c5a"
+  my.cnf: &mycnf "1772e8e7434166eaeb4fd56eaa9ff33a358680736b225b9f1e6e67d18a5a9fb2"
+  configmap: &configmap "2e05b0bfa976ce23f9ee36612c9b42b6972b7e82ad503b27ceb85c504bf946fe"
 
 suite: statefulset-mariadb
 values:
@@ -310,7 +310,7 @@ tests:
           value: "sysctl-tcp-keepalive"
       - equal:
           path: spec.template.spec.initContainers[0].image
-          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera-ubuntu:22.04-20240212072432"
+          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera-ubuntu:22.04-20240419150126"
       - equal:
           path: spec.template.spec.initContainers[0].imagePullPolicy
           value: "IfNotPresent"
@@ -379,7 +379,7 @@ tests:
           value: "increase-map-count"
       - equal:
           path: spec.template.spec.initContainers[1].image
-          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera-ubuntu:22.04-20240212072432"
+          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera-ubuntu:22.04-20240419150126"
       - equal:
           path: spec.template.spec.initContainers[1].imagePullPolicy
           value: "IfNotPresent"
@@ -471,7 +471,7 @@ tests:
           value: "clean-os-cache"
       - equal:
           path: spec.template.spec.initContainers[2].image
-          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera-ubuntu:22.04-20240212072432"
+          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera-ubuntu:22.04-20240419150126"
       - equal:
           path: spec.template.spec.initContainers[2].imagePullPolicy
           value: "IfNotPresent"
@@ -541,7 +541,7 @@ tests:
           value: "db"
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera:10.5.23-20240212072432"
+          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera:10.5.23-20240419150126"
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: "IfNotPresent"
@@ -1640,7 +1640,7 @@ tests:
           value: "metrics"
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera-mysqld_exporter:0.14.0-20240212072432"
+          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera-mysqld_exporter:0.14.0-20240419150126"
       - equal:
           path: spec.template.spec.containers[1].imagePullPolicy
           value: "IfNotPresent"
@@ -2265,3 +2265,102 @@ tests:
       - equal:
           path: spec.volumeClaimTemplates[1].spec.resources.requests.storage
           value: "30Gi"
+
+  - it: MariaDB statefulset 1 replica limit if multi-region enabled and region r1 selected
+    template: statefulset-mariadb.yaml
+    documentIndex: 0
+    set:
+      mariadb.galera.clustername: "testname"
+      mariadb.galera.multiRegion.enabled: true
+      mariadb.galera.multiRegion.current: "r1"
+      mariadb.galera.multiRegion.regions.r1.segmentId: "1"
+      mariadb.galera.multiRegion.regions.r2.segmentId: "2"
+      mariadb.galera.multiRegion.regions.r3.segmentId: "3"
+      replicas.database: 3
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: metadata.namespace
+          value: "testnamespace"
+      - equal:
+          path: metadata.name
+          value: "testrelease-mariadb-g"
+      - equal:
+          path: metadata.labels.app
+          value: "testrelease"
+      - equal:
+          path: metadata.labels.component
+          value: "database"
+      - equal:
+          path: metadata.labels.release
+          value: "testrelease"
+      - equal:
+          path: spec.replicas
+          value: 1
+
+  - it: MariaDB statefulset 1 replica limit if multi-region enabled and region r2 selected
+    template: statefulset-mariadb.yaml
+    documentIndex: 0
+    set:
+      mariadb.galera.clustername: "testname"
+      mariadb.galera.multiRegion.enabled: true
+      mariadb.galera.multiRegion.current: "r2"
+      mariadb.galera.multiRegion.regions.r1.segmentId: "1"
+      mariadb.galera.multiRegion.regions.r2.segmentId: "2"
+      mariadb.galera.multiRegion.regions.r3.segmentId: "3"
+      replicas.database: 3
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: metadata.namespace
+          value: "testnamespace"
+      - equal:
+          path: metadata.name
+          value: "testrelease-mariadb-g"
+      - equal:
+          path: metadata.labels.app
+          value: "testrelease"
+      - equal:
+          path: metadata.labels.component
+          value: "database"
+      - equal:
+          path: metadata.labels.release
+          value: "testrelease"
+      - equal:
+          path: spec.replicas
+          value: 1
+
+  - it: MariaDB statefulset 1 replica limit if multi-region enabled and region r3 selected
+    template: statefulset-mariadb.yaml
+    documentIndex: 0
+    set:
+      mariadb.galera.clustername: "testname"
+      mariadb.galera.multiRegion.enabled: true
+      mariadb.galera.multiRegion.current: "r3"
+      mariadb.galera.multiRegion.regions.r1.segmentId: "1"
+      mariadb.galera.multiRegion.regions.r2.segmentId: "2"
+      mariadb.galera.multiRegion.regions.r3.segmentId: "3"
+      replicas.database: 3
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: metadata.namespace
+          value: "testnamespace"
+      - equal:
+          path: metadata.name
+          value: "testrelease-mariadb-g"
+      - equal:
+          path: metadata.labels.app
+          value: "testrelease"
+      - equal:
+          path: metadata.labels.component
+          value: "database"
+      - equal:
+          path: metadata.labels.release
+          value: "testrelease"
+      - equal:
+          path: spec.replicas
+          value: 1

--- a/common/mariadb-galera/helm/tests/02-services-mariadb-galera_test.yaml
+++ b/common/mariadb-galera/helm/tests/02-services-mariadb-galera_test.yaml
@@ -1016,3 +1016,135 @@ tests:
       - equal:
           path: metadata.labels.app
           value: testrelease
+
+  - it: database backend service external IP added for region 1
+    template: service.yaml
+    documentSelector:
+      path: metadata.name
+      value: testrelease-mariadb-g-backend
+    set:
+      mariadb.galera.clustername: "testclustername"
+      mariadb.galera.multiRegion.enabled: true
+      mariadb.galera.multiRegion.current: "r1"
+      mariadb.galera.multiRegion.regions.r1.externalIP: "10.0.0.1"
+      mariadb.galera.multiRegion.regions.r2.externalIP: "10.0.0.2"
+      mariadb.galera.multiRegion.regions.r3.externalIP: "10.0.0.3"
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.labels.app
+          value: testrelease
+      - equal:
+          path: spec.externalIPs[0]
+          value: "10.0.0.1"
+
+  - it: database backend service external IP added for region 2
+    template: service.yaml
+    documentSelector:
+      path: metadata.name
+      value: testrelease-mariadb-g-backend
+    set:
+      mariadb.galera.clustername: "testclustername"
+      mariadb.galera.multiRegion.enabled: true
+      mariadb.galera.multiRegion.current: "r2"
+      mariadb.galera.multiRegion.regions.r1.externalIP: "10.0.0.1"
+      mariadb.galera.multiRegion.regions.r2.externalIP: "10.0.0.2"
+      mariadb.galera.multiRegion.regions.r3.externalIP: "10.0.0.3"
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.labels.app
+          value: testrelease
+      - equal:
+          path: spec.externalIPs[0]
+          value: "10.0.0.2"
+
+  - it: database backend service external IP added for region 3
+    template: service.yaml
+    documentSelector:
+      path: metadata.name
+      value: testrelease-mariadb-g-backend
+    set:
+      mariadb.galera.clustername: "testclustername"
+      mariadb.galera.multiRegion.enabled: true
+      mariadb.galera.multiRegion.current: "r3"
+      mariadb.galera.multiRegion.regions.r1.externalIP: "10.0.0.1"
+      mariadb.galera.multiRegion.regions.r2.externalIP: "10.0.0.2"
+      mariadb.galera.multiRegion.regions.r3.externalIP: "10.0.0.3"
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.labels.app
+          value: testrelease
+      - equal:
+          path: spec.externalIPs[0]
+          value: "10.0.0.3"
+
+  - it: database backend service external IP added for eu-de-1
+    template: service.yaml
+    documentSelector:
+      path: metadata.name
+      value: testrelease-mariadb-g-backend
+    set:
+      mariadb.galera.clustername: "testclustername"
+      mariadb.galera.multiRegion.enabled: true
+      mariadb.galera.multiRegion.current: "eu-de-1"
+      mariadb.galera.multiRegion.regions.eu-de-1.externalIP: "10.0.0.1"
+      mariadb.galera.multiRegion.regions.eu-de-2.externalIP: "10.0.0.2"
+      mariadb.galera.multiRegion.regions.eu-nl-1.externalIP: "10.0.0.3"
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.labels.app
+          value: testrelease
+      - equal:
+          path: spec.externalIPs[0]
+          value: "10.0.0.1"
+
+  - it: database backend service external IP added for region eu-de-2
+    template: service.yaml
+    documentSelector:
+      path: metadata.name
+      value: testrelease-mariadb-g-backend
+    set:
+      mariadb.galera.clustername: "testclustername"
+      mariadb.galera.multiRegion.enabled: true
+      mariadb.galera.multiRegion.current: "eu-de-2"
+      mariadb.galera.multiRegion.regions.eu-de-1.externalIP: "10.0.0.1"
+      mariadb.galera.multiRegion.regions.eu-de-2.externalIP: "10.0.0.2"
+      mariadb.galera.multiRegion.regions.eu-nl-1.externalIP: "10.0.0.3"
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.labels.app
+          value: testrelease
+      - equal:
+          path: spec.externalIPs[0]
+          value: "10.0.0.2"
+
+  - it: database backend service external IP added for eu-nl-1
+    template: service.yaml
+    documentSelector:
+      path: metadata.name
+      value: testrelease-mariadb-g-backend
+    set:
+      mariadb.galera.clustername: "testclustername"
+      mariadb.galera.multiRegion.enabled: true
+      mariadb.galera.multiRegion.current: "eu-nl-1"
+      mariadb.galera.multiRegion.regions.eu-de-1.externalIP: "10.0.0.1"
+      mariadb.galera.multiRegion.regions.eu-de-2.externalIP: "10.0.0.2"
+      mariadb.galera.multiRegion.regions.eu-nl-1.externalIP: "10.0.0.3"
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.labels.app
+          value: testrelease
+      - equal:
+          path: spec.externalIPs[0]
+          value: "10.0.0.3"

--- a/common/mariadb-galera/helm/tests/04-configmap-mariadb-my-cnf_test.yaml
+++ b/common/mariadb-galera/helm/tests/04-configmap-mariadb-my-cnf_test.yaml
@@ -15,6 +15,9 @@ tests:
     documentIndex: 0
     set:
       mariadb.galera.clustername: "testname"
+      services.database.backend.ports.galera.port: 4567
+      services.database.backend.ports.ist.port: 4568
+      replicas.database: 3
     asserts:
       - isKind:
           of: ConfigMap
@@ -75,7 +78,7 @@ tests:
             wsrep_cluster_address=gcomm://testrelease-mariadb-g-0.testnamespace:4567,testrelease-mariadb-g-1.testnamespace:4567,testrelease-mariadb-g-2.testnamespace:4567,testrelease-mariadb-g-backend.testnamespace:4567
       - matchRegex:
           path: data["my.cnf.testrelease-mariadb-g-0.tpl"]
-          pattern: "wsrep_provider_options=cert.log_conflicts=ON;debug=NO;gcache.recover=no;ist.recv_addr=\\$\\{CONTAINER_IP\\}:0;pc.recovery=FALSE;pc.wait_prim_timeout=PT60S;pc.weight=\\$\\{PC_WEIGHT_0\\}"
+          pattern: "wsrep_provider_options=cert.log_conflicts=ON;debug=NO;gcache.recover=no;ist.recv_addr=\\$\\{CONTAINER_IP\\}:4568;pc.recovery=FALSE;pc.wait_prim_timeout=PT60S;pc.weight=\\$\\{PC_WEIGHT_0\\}"
       - matchRegex:
           path: data["my.cnf.testrelease-mariadb-g-0.tpl"]
           pattern: "wsrep_node_address=\\$\\{CONTAINER_IP\\}"
@@ -103,3 +106,408 @@ tests:
       - matchRegex:
           path: data["my.cnf.testrelease-mariadb-g-0.tpl"]
           pattern: "binlog-commit-wait-count=0"
+
+  - it: cluster address with multi-region enabled and region r1 selected
+    template: configmap-mariadb-my.cnf.yaml
+    documentIndex: 0
+    set:
+      mariadb.galera.clustername: "testname"
+      mariadb.galera.multiRegion.enabled: true
+      mariadb.galera.multiRegion.current: "r1"
+      mariadb.galera.multiRegion.regions.r1.externalIP: "10.0.0.1"
+      mariadb.galera.multiRegion.regions.r2.externalIP: "10.0.0.2"
+      mariadb.galera.multiRegion.regions.r3.externalIP: "10.0.0.3"
+      mariadb.galera.multiRegion.regions.r1.segmentId: "1"
+      mariadb.galera.multiRegion.regions.r2.segmentId: "2"
+      mariadb.galera.multiRegion.regions.r3.segmentId: "3"
+      services.database.backend.ports.galera.port: 4567
+      replicas.database: 3
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.namespace
+          value: testnamespace
+      - equal:
+          path: metadata.name
+          value: testrelease-mariadb-my-cnf
+      - matchRegex:
+          path: data["my.cnf.testrelease-mariadb-g-0.tpl"]
+          pattern: wsrep_cluster_address=gcomm:\/\/10\.0\.0\.2:4567,10\.0\.0\.3:4567
+
+  - it: cluster address with multi-region enabled and region r2 selected
+    template: configmap-mariadb-my.cnf.yaml
+    documentIndex: 0
+    set:
+      mariadb.galera.clustername: "testname"
+      mariadb.galera.multiRegion.enabled: true
+      mariadb.galera.multiRegion.current: "r2"
+      mariadb.galera.multiRegion.regions.r1.externalIP: "10.0.0.1"
+      mariadb.galera.multiRegion.regions.r2.externalIP: "10.0.0.2"
+      mariadb.galera.multiRegion.regions.r3.externalIP: "10.0.0.3"
+      mariadb.galera.multiRegion.regions.r1.segmentId: "1"
+      mariadb.galera.multiRegion.regions.r2.segmentId: "2"
+      mariadb.galera.multiRegion.regions.r3.segmentId: "3"
+      services.database.backend.ports.galera.port: 4567
+      replicas.database: 3
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.namespace
+          value: testnamespace
+      - equal:
+          path: metadata.name
+          value: testrelease-mariadb-my-cnf
+      - matchRegex:
+          path: data["my.cnf.testrelease-mariadb-g-0.tpl"]
+          pattern: wsrep_cluster_address=gcomm:\/\/10\.0\.0\.1:4567,10\.0\.0\.3:4567
+
+  - it: cluster address with multi-region enabled and region r3 selected
+    template: configmap-mariadb-my.cnf.yaml
+    documentIndex: 0
+    set:
+      mariadb.galera.clustername: "testname"
+      mariadb.galera.multiRegion.enabled: true
+      mariadb.galera.multiRegion.current: "r3"
+      mariadb.galera.multiRegion.regions.r1.externalIP: "10.0.0.1"
+      mariadb.galera.multiRegion.regions.r2.externalIP: "10.0.0.2"
+      mariadb.galera.multiRegion.regions.r3.externalIP: "10.0.0.3"
+      mariadb.galera.multiRegion.regions.r1.segmentId: "1"
+      mariadb.galera.multiRegion.regions.r2.segmentId: "2"
+      mariadb.galera.multiRegion.regions.r3.segmentId: "3"
+      services.database.backend.ports.galera.port: 4567
+      replicas.database: 3
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.namespace
+          value: testnamespace
+      - equal:
+          path: metadata.name
+          value: testrelease-mariadb-my-cnf
+      - matchRegex:
+          path: data["my.cnf.testrelease-mariadb-g-0.tpl"]
+          pattern: wsrep_cluster_address=gcomm:\/\/10\.0\.0\.1:4567,10\.0\.0\.2:4567
+
+  - it: cluster address with multi-region enabled and region eu-de-1 selected
+    template: configmap-mariadb-my.cnf.yaml
+    documentIndex: 0
+    set:
+      mariadb.galera.clustername: "testname"
+      mariadb.galera.multiRegion.enabled: true
+      mariadb.galera.multiRegion.current: "eu-de-1"
+      mariadb.galera.multiRegion.regions.eu-de-1.externalIP: "10.0.0.1"
+      mariadb.galera.multiRegion.regions.eu-de-2.externalIP: "10.0.0.2"
+      mariadb.galera.multiRegion.regions.eu-nl-1.externalIP: "10.0.0.3"
+      mariadb.galera.multiRegion.regions.eu-de-1.segmentId: "1"
+      mariadb.galera.multiRegion.regions.eu-de-2.segmentId: "2"
+      mariadb.galera.multiRegion.regions.eu-nl-1.segmentId: "3"
+      services.database.backend.ports.galera.port: 4567
+      replicas.database: 3
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.namespace
+          value: testnamespace
+      - equal:
+          path: metadata.name
+          value: testrelease-mariadb-my-cnf
+      - matchRegex:
+          path: data["my.cnf.testrelease-mariadb-g-0.tpl"]
+          pattern: wsrep_cluster_address=gcomm:\/\/10\.0\.0\.2:4567,10\.0\.0\.3:4567
+
+  - it: cluster address with multi-region enabled and region eu-de-2 selected
+    template: configmap-mariadb-my.cnf.yaml
+    documentIndex: 0
+    set:
+      mariadb.galera.clustername: "testname"
+      mariadb.galera.multiRegion.enabled: true
+      mariadb.galera.multiRegion.current: "eu-de-2"
+      mariadb.galera.multiRegion.regions.eu-de-1.externalIP: "10.0.0.1"
+      mariadb.galera.multiRegion.regions.eu-de-2.externalIP: "10.0.0.2"
+      mariadb.galera.multiRegion.regions.eu-nl-1.externalIP: "10.0.0.3"
+      mariadb.galera.multiRegion.regions.eu-de-1.segmentId: "1"
+      mariadb.galera.multiRegion.regions.eu-de-2.segmentId: "2"
+      mariadb.galera.multiRegion.regions.eu-nl-1.segmentId: "3"
+      services.database.backend.ports.galera.port: 4567
+      replicas.database: 3
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.namespace
+          value: testnamespace
+      - equal:
+          path: metadata.name
+          value: testrelease-mariadb-my-cnf
+      - matchRegex:
+          path: data["my.cnf.testrelease-mariadb-g-0.tpl"]
+          pattern: wsrep_cluster_address=gcomm:\/\/10\.0\.0\.1:4567,10\.0\.0\.3:4567
+
+  - it: cluster address with multi-region enabled and region eu-nl-1 selected
+    template: configmap-mariadb-my.cnf.yaml
+    documentIndex: 0
+    set:
+      mariadb.galera.clustername: "testname"
+      mariadb.galera.multiRegion.enabled: true
+      mariadb.galera.multiRegion.current: "eu-nl-1"
+      mariadb.galera.multiRegion.regions.eu-de-1.externalIP: "10.0.0.1"
+      mariadb.galera.multiRegion.regions.eu-de-2.externalIP: "10.0.0.2"
+      mariadb.galera.multiRegion.regions.eu-nl-1.externalIP: "10.0.0.3"
+      mariadb.galera.multiRegion.regions.eu-de-1.segmentId: "1"
+      mariadb.galera.multiRegion.regions.eu-de-2.segmentId: "2"
+      mariadb.galera.multiRegion.regions.eu-nl-1.segmentId: "3"
+      services.database.backend.ports.galera.port: 4567
+      replicas.database: 3
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.namespace
+          value: testnamespace
+      - equal:
+          path: metadata.name
+          value: testrelease-mariadb-my-cnf
+      - matchRegex:
+          path: data["my.cnf.testrelease-mariadb-g-0.tpl"]
+          pattern: wsrep_cluster_address=gcomm:\/\/10\.0\.0\.1:4567,10\.0\.0\.2:4567
+
+  - it: gmcast.segment added with multi-region enabled and region r1 selected
+    template: configmap-mariadb-my.cnf.yaml
+    documentIndex: 0
+    set:
+      mariadb.galera.clustername: "testname"
+      mariadb.galera.multiRegion.enabled: true
+      mariadb.galera.multiRegion.current: "r1"
+      mariadb.galera.multiRegion.regions.r1.segmentId: "1"
+      mariadb.galera.multiRegion.regions.r2.segmentId: "2"
+      mariadb.galera.multiRegion.regions.r3.segmentId: "3"
+      replicas.database: 3
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.namespace
+          value: testnamespace
+      - equal:
+          path: metadata.name
+          value: testrelease-mariadb-my-cnf
+      - matchRegex:
+          path: data["my.cnf.testrelease-mariadb-g-0.tpl"]
+          pattern: wsrep_provider_options=.+;gmcast\.segment=1;.+;pc\.weight=\${PC_WEIGHT_0}
+
+  - it: gmcast.segment added with multi-region enabled and region r2 selected
+    template: configmap-mariadb-my.cnf.yaml
+    documentIndex: 0
+    set:
+      mariadb.galera.clustername: "testname"
+      mariadb.galera.multiRegion.enabled: true
+      mariadb.galera.multiRegion.current: "r2"
+      mariadb.galera.multiRegion.regions.r1.segmentId: "1"
+      mariadb.galera.multiRegion.regions.r2.segmentId: "2"
+      mariadb.galera.multiRegion.regions.r3.segmentId: "3"
+      replicas.database: 3
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.namespace
+          value: testnamespace
+      - equal:
+          path: metadata.name
+          value: testrelease-mariadb-my-cnf
+      - matchRegex:
+          path: data["my.cnf.testrelease-mariadb-g-0.tpl"]
+          pattern: wsrep_provider_options=.+;gmcast\.segment=2;.+;pc\.weight=\${PC_WEIGHT_0}
+
+  - it: gmcast.segment added with multi-region enabled and region r3 selected
+    template: configmap-mariadb-my.cnf.yaml
+    documentIndex: 0
+    set:
+      mariadb.galera.clustername: "testname"
+      mariadb.galera.multiRegion.enabled: true
+      mariadb.galera.multiRegion.current: "r3"
+      mariadb.galera.multiRegion.regions.r1.segmentId: "1"
+      mariadb.galera.multiRegion.regions.r2.segmentId: "2"
+      mariadb.galera.multiRegion.regions.r3.segmentId: "3"
+      replicas.database: 3
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.namespace
+          value: testnamespace
+      - equal:
+          path: metadata.name
+          value: testrelease-mariadb-my-cnf
+      - matchRegex:
+          path: data["my.cnf.testrelease-mariadb-g-0.tpl"]
+          pattern: wsrep_provider_options=.+;gmcast\.segment=3;.+;pc\.weight=\${PC_WEIGHT_0}
+
+  - it: gmcast.segment added with multi-region enabled and region eu-de-1 selected
+    template: configmap-mariadb-my.cnf.yaml
+    documentIndex: 0
+    set:
+      mariadb.galera.clustername: "testname"
+      mariadb.galera.multiRegion.enabled: true
+      mariadb.galera.multiRegion.current: "eu-de-1"
+      mariadb.galera.multiRegion.regions.eu-de-1.segmentId: "1"
+      mariadb.galera.multiRegion.regions.eu-de-2.segmentId: "2"
+      mariadb.galera.multiRegion.regions.eu-nl-1.segmentId: "3"
+      replicas.database: 3
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.namespace
+          value: testnamespace
+      - equal:
+          path: metadata.name
+          value: testrelease-mariadb-my-cnf
+      - matchRegex:
+          path: data["my.cnf.testrelease-mariadb-g-0.tpl"]
+          pattern: wsrep_provider_options=.+;gmcast\.segment=1;.+;pc\.weight=\${PC_WEIGHT_0}
+
+  - it: gmcast.segment added with multi-region enabled and region eu-de-2 selected
+    template: configmap-mariadb-my.cnf.yaml
+    documentIndex: 0
+    set:
+      mariadb.galera.clustername: "testname"
+      mariadb.galera.multiRegion.enabled: true
+      mariadb.galera.multiRegion.current: "eu-de-2"
+      mariadb.galera.multiRegion.regions.eu-de-1.segmentId: "1"
+      mariadb.galera.multiRegion.regions.eu-de-2.segmentId: "2"
+      mariadb.galera.multiRegion.regions.eu-nl-1.segmentId: "3"
+      replicas.database: 3
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.namespace
+          value: testnamespace
+      - equal:
+          path: metadata.name
+          value: testrelease-mariadb-my-cnf
+      - matchRegex:
+          path: data["my.cnf.testrelease-mariadb-g-0.tpl"]
+          pattern: wsrep_provider_options=.+;gmcast\.segment=2;.+;pc\.weight=\${PC_WEIGHT_0}
+
+  - it: gmcast.segment added with multi-region enabled and region eu-nl-1 selected
+    template: configmap-mariadb-my.cnf.yaml
+    documentIndex: 0
+    set:
+      mariadb.galera.clustername: "testname"
+      mariadb.galera.multiRegion.enabled: true
+      mariadb.galera.multiRegion.current: "eu-nl-1"
+      mariadb.galera.multiRegion.regions.eu-de-1.segmentId: "1"
+      mariadb.galera.multiRegion.regions.eu-de-2.segmentId: "2"
+      mariadb.galera.multiRegion.regions.eu-nl-1.segmentId: "3"
+      replicas.database: 3
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.namespace
+          value: testnamespace
+      - equal:
+          path: metadata.name
+          value: testrelease-mariadb-my-cnf
+      - matchRegex:
+          path: data["my.cnf.testrelease-mariadb-g-0.tpl"]
+          pattern: wsrep_provider_options=.+;gmcast\.segment=3;.+;pc\.weight=\${PC_WEIGHT_0}
+
+  - it: Galera WAN connection tweaks added with multi-region enabled and region r1 selected
+    template: configmap-mariadb-my.cnf.yaml
+    documentIndex: 0
+    set:
+      mariadb.galera.clustername: "testname"
+      mariadb.galera.multiRegion.enabled: true
+      mariadb.galera.multiRegion.current: "r1"
+      mariadb.galera.multiRegion.regions.r1.segmentId: "1"
+      mariadb.galera.multiRegion.regions.r2.segmentId: "2"
+      mariadb.galera.multiRegion.regions.r3.segmentId: "3"
+      mariadb.galera.multiRegion.inactive_check_period: "2.5"
+      mariadb.galera.multiRegion.inactive_timeout: 30
+      mariadb.galera.multiRegion.install_timeout: 8
+      mariadb.galera.multiRegion.keepalive_period: "1.6"
+      mariadb.galera.multiRegion.send_window: 256
+      mariadb.galera.multiRegion.user_send_window: 128
+      mariadb.galera.multiRegion.suspect_timeout: 5
+      replicas.database: 3
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.namespace
+          value: testnamespace
+      - equal:
+          path: metadata.name
+          value: testrelease-mariadb-my-cnf
+      - matchRegex:
+          path: data["my.cnf.testrelease-mariadb-g-0.tpl"]
+          pattern: wsrep_provider_options=.+;evs\.inactive_check_period=PT2\.50S;evs\.inactive_timeout=PT30S;evs\.install_timeout=PT8S;evs\.keepalive_period=PT1\.60S;evs\.send_window=256;evs\.suspect_timeout=PT5S;evs\.user_send_window=128.+;pc\.weight=\${PC_WEIGHT_0}
+
+  - it: Galera WAN connection tweaks added with multi-region enabled and region r2 selected
+    template: configmap-mariadb-my.cnf.yaml
+    documentIndex: 0
+    set:
+      mariadb.galera.clustername: "testname"
+      mariadb.galera.multiRegion.enabled: true
+      mariadb.galera.multiRegion.current: "r2"
+      mariadb.galera.multiRegion.regions.r1.segmentId: "1"
+      mariadb.galera.multiRegion.regions.r2.segmentId: "2"
+      mariadb.galera.multiRegion.regions.r3.segmentId: "3"
+      mariadb.galera.multiRegion.inactive_check_period: "2.5"
+      mariadb.galera.multiRegion.inactive_timeout: 30
+      mariadb.galera.multiRegion.install_timeout: 8
+      mariadb.galera.multiRegion.keepalive_period: "1.6"
+      mariadb.galera.multiRegion.send_window: 256
+      mariadb.galera.multiRegion.user_send_window: 128
+      mariadb.galera.multiRegion.suspect_timeout: 5
+      replicas.database: 3
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.namespace
+          value: testnamespace
+      - equal:
+          path: metadata.name
+          value: testrelease-mariadb-my-cnf
+      - matchRegex:
+          path: data["my.cnf.testrelease-mariadb-g-0.tpl"]
+          pattern: wsrep_provider_options=.+;evs\.inactive_check_period=PT2\.50S;evs\.inactive_timeout=PT30S;evs\.install_timeout=PT8S;evs\.keepalive_period=PT1\.60S;evs\.send_window=256;evs\.suspect_timeout=PT5S;evs\.user_send_window=128.+;pc\.weight=\${PC_WEIGHT_0}
+
+  - it: Galera WAN connection tweaks added with multi-region enabled and region r3 selected
+    template: configmap-mariadb-my.cnf.yaml
+    documentIndex: 0
+    set:
+      mariadb.galera.clustername: "testname"
+      mariadb.galera.multiRegion.enabled: true
+      mariadb.galera.multiRegion.current: "r3"
+      mariadb.galera.multiRegion.regions.r1.segmentId: "1"
+      mariadb.galera.multiRegion.regions.r2.segmentId: "2"
+      mariadb.galera.multiRegion.regions.r3.segmentId: "3"
+      mariadb.galera.multiRegion.inactive_check_period: "2.5"
+      mariadb.galera.multiRegion.inactive_timeout: 30
+      mariadb.galera.multiRegion.install_timeout: 8
+      mariadb.galera.multiRegion.keepalive_period: "1.6"
+      mariadb.galera.multiRegion.send_window: 256
+      mariadb.galera.multiRegion.user_send_window: 128
+      mariadb.galera.multiRegion.suspect_timeout: 5
+      replicas.database: 3
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.namespace
+          value: testnamespace
+      - equal:
+          path: metadata.name
+          value: testrelease-mariadb-my-cnf
+      - matchRegex:
+          path: data["my.cnf.testrelease-mariadb-g-0.tpl"]
+          pattern: wsrep_provider_options=.+;evs\.inactive_check_period=PT2\.50S;evs\.inactive_timeout=PT30S;evs\.install_timeout=PT8S;evs\.keepalive_period=PT1\.60S;evs\.send_window=256;evs\.suspect_timeout=PT5S;evs\.user_send_window=128.+;pc\.weight=\${PC_WEIGHT_0}

--- a/common/mariadb-galera/helm/values.yaml
+++ b/common/mariadb-galera/helm/values.yaml
@@ -75,7 +75,6 @@ mariadb:
   # @default -- 0
   binLogSync: 1
   # -- `1` to enable [innodb_flush_log_at_trx_commit for ACID compliance](https://mariadb.com/kb/en/innodb-system-variables/#innodb_flush_log_at_trx_commit)
-  # @default -- 0
   innodbFlushLogAtTrxCommit: 1
   # -- to enable the [Performance Schema](https://mariadb.com/kb/en/performance-schema-overview/)
   # @default -- false
@@ -164,6 +163,30 @@ mariadb:
     # eg: db-0: 4, db-1: 2, db-2: 1
     # @default -- false
     weightedQuorum:
+    multiRegion:
+      # -- (bool) Enable the multi-region setup. Exactly 3 regions are supported
+      enabled: false
+      # -- (string) Name of the region where we are currently deploying the MariaDB Galera cluster components. The `global.db_region` parameter will be used if defined by the parent chart. Otherwise something like r1, r2, r3 or names like eu-de-1, eu-de-2, eu-de-3 should be used
+      current:
+      # -- (object) `r1/2/3.externalIP` (external IP address of the region. Can be exposed via a load balancer or a external IP of a ClusterIP service) and `r1/2/3.segmentId` (Define which network segment([gmcast.segment](https://galeracluster.com/library/documentation/galera-parameters.html#gmcast-segment)) this node is in)
+      regions:
+      # -- (string) A node will be suspected to be dead after these seconds of inactivity [evs.suspect_timeout](https://mariadb.com/kb/en/wsrep_provider_options/#evssuspect_timeout)
+      suspect_timeout: 5
+      # -- (string) Time limit in seconds that a node can be inactive before being pronounced as dead [evs.inactive_timeout](https://mariadb.com/kb/en/wsrep_provider_options/#evsinactive_timeout)
+      inactive_timeout: 30
+      # -- (float) Frequency of checks in seconds for peer inactivity (looking for nodes with delayed responses), after which nodes may be added to the delayed list, and later evicted [evs.inactive_check_period](https://mariadb.com/kb/en/wsrep_provider_options/#evsinactive_check_period)
+      inactive_check_period: "2.5"
+      # -- (float) How often keepalive signals should be transmitted when there's no other traffic [evs.keepalive_period](https://mariadb.com/kb/en/wsrep_provider_options/#evskeepalive_period)
+      keepalive_period: "1.6"
+      # -- (string) Wait time in seconds for install message acknowledgments [evs.install_timeout](https://mariadb.com/kb/en/wsrep_provider_options/#evsinactive_timeout)
+      install_timeout: 8
+      # -- (string) Maximum number of packets that can be replicated at a time [evs.send_window](https://mariadb.com/kb/en/wsrep_provider_options/#evssend_window)
+      send_window: 256
+      # -- (string) Maximum number of data packets that can be replicated at a time [evs.user_send_window](https://mariadb.com/kb/en/wsrep_provider_options/#evsuser_send_window)
+      user_send_window: 128
+      # -- (bool) Enable the [Galera bootstrap](https://mariadb.com/kb/en/getting-started-with-mariadb-galera-cluster/#bootstrapping-a-new-cluster).
+      # Use it **ONLY** in case all nodes are down and the cluster needs to be started from scratch. It will cause data loss if used for a region that has not held the most recent seqno
+      bootstrap: false
     backup:
       # -- enable the [database backup](#database-backup). Should be done within custom instance configuration files
       enabled: false
@@ -724,7 +747,7 @@ image:
     # -- database part of the image version that should be pulled
     databaseversion: 22.04
     # -- image part of the image version that should be pulled
-    imageversion: 20240212072432
+    imageversion: 20240419150126
     # -- (string) `Always` to enforce that the image will be pulled even if it is already available on the worker node
     # @default -- IfNotPresent
     pullPolicy:
@@ -740,7 +763,7 @@ image:
     # -- database part of the image version that should be pulled
     databaseversion: 10.5.23
     # -- image part of the image version that should be pulled
-    imageversion: 20240212072432
+    imageversion: 20240419150126
     # -- (string) `Always` to enforce that the image will be pulled even if it is already available on the worker node
     # @default -- IfNotPresent
     pullPolicy:
@@ -756,7 +779,7 @@ image:
     # -- database part of the image version that should be pulled
     databaseversion: 0.14.0
     # -- image part of the image version that should be pulled
-    imageversion: 20240212072432
+    imageversion: 20240419150126
     # -- (string) `Always` to enforce that the image will be pulled even if it is already available on the worker node
     # @default -- IfNotPresent
     pullPolicy:
@@ -772,7 +795,7 @@ image:
     # -- database part of the image version that should be pulled
     databaseversion: 2.5.5
     # -- image part of the image version that should be pulled
-    imageversion: 20240212072432
+    imageversion: 20240419150126
     # -- (string) `Always` to enforce that the image will be pulled even if it is already available on the worker node
     # @default -- IfNotPresent
     pullPolicy:
@@ -788,7 +811,7 @@ image:
     # -- database part of the image version that should be pulled
     databaseversion: 0.12.1
     # -- image part of the image version that should be pulled
-    imageversion: 20240212072432
+    imageversion: 20240419150126
     # -- (string) `Always` to enforce that the image will be pulled even if it is already available on the worker node
     # @default -- IfNotPresent
     pullPolicy:
@@ -838,7 +861,8 @@ services:
     backend:
       # -- `ClusterIP` to configure a Kubernetes internal service or `LoadBalancer` to publish the service outside of the [Kubernetes cluster network](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types)
       type: ClusterIP
-      # -- `false` or `true` if the IP adresses of the pods that are [endpoints for that service](https://kubernetes.io/docs/concepts/services-networking/service/#headless-services) should be advertised. Required to let the client make it's own load balancing decisions
+      # -- `false` or `true` if the IP adresses of the pods that are [endpoints for that service](https://kubernetes.io/docs/concepts/services-networking/service/#headless-services) should be advertised.
+      # Required to let the client make it's own load balancing decisions. Will be set to `false` if `type` is set `LoadBalancer`
       headless: true
       ports:
         galera:
@@ -1116,11 +1140,13 @@ resourceLimits:
 # Deployment rules
 replicas:
   # -- amount of pods that will [scheduled](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#creating-a-deployment) for the MariaDB Galera cluster.
-  # An uneven number will be enforced to avoid simple split brain situations. For a good balance between the write and read performance not more than 3 pods a suggested
+  # An uneven number will be enforced to avoid simple split brain situations. For a good balance between the write and read performance not more than 3 pods a suggested.
+  # If `mariadb.galera.multiRegion.enabled` is set to `true` the amount of pods will be set to `1`
   # @default -- 3
   database: 3
   # -- amount of pods that will [scheduled](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#creating-a-deployment) for the ProxySQL cluster.
-  # An uneven number will be enforced to avoid simple split brain situations
+  # An uneven number will be enforced to avoid simple split brain situations.
+  # If `mariadb.galera.multiRegion.enabled` is set to `true` the amount of pods will be set to `1`
   # @default -- 3
   proxy: 3
 maxUnavailable:


### PR DESCRIPTION
- gmcast.segment per region to avoid unnecessary replication traffic between regions
- externalIPs for Galera backend service if rolled out as internal ClusterIP service
- loadBalancerIP support added for the externalIP
- externalIPs are required for Galera communication outside of the Kubernetes cluster
- unit tests for the service and the my.cnf configmap added
- global.db_region support added to support subchart setups
- getNetworkPort function fixed
- create backup credentials only if backup is enabled
- several Galera network options added to be able to tweak WAN connections
- limit to one pod per region if multiRegion is enabled
- multiRegion.bootstrap option added for manual bootstrapping after complete shutdowns
- documentation extended with multiRegion infos
- changelog updated
- chart version bumped