### PR TITLE
openstack/limes-auto: init at 0.1.0

### DIFF
--- a/openstack/limes-auto/Chart.lock
+++ b/openstack/limes-auto/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: owner-info
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 0.2.3
+digest: sha256:c6964df357301c430710112ece81cab5b5fa3f8f9c435754a4d6259038c2164a
+generated: "2024-04-23T12:31:37.635008535+02:00"

--- a/openstack/limes-auto/Chart.yaml
+++ b/openstack/limes-auto/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+description: Auto-triggered companion deployment for Limes (config only)
+name: limes-auto
+version: 0.1.0
+dependencies:
+  - name: owner-info
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: '>= 0.0.0'

--- a/openstack/limes-auto/templates/configmap-overrides.yaml
+++ b/openstack/limes-auto/templates/configmap-overrides.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+
+metadata:
+  name: limes-auto-overrides
+
+data:
+  quota-overrides.json: |
+{{ toJson .Values.quota_overrides | indent 4 }}

--- a/openstack/limes-auto/values.yaml
+++ b/openstack/limes-auto/values.yaml
@@ -1,0 +1,12 @@
+owner-info:
+  support-group: containers
+  service: limes
+  maintainers:
+    - Stefan Majewsky
+    - Stefan Voigt
+    - Sandro Jäckel
+  helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/openstack/limes-auto
+
+# Map with entries being the contents of a Limes quota overrides file.
+# See `LIMES_QUOTA_OVERRIDES_PATH` in <https://github.com/sapcc/limes/blob/master/docs/operators/config.md>
+quota_overrides: {}

--- a/openstack/limes/templates/seed.yaml
+++ b/openstack/limes/templates/seed.yaml
@@ -1,3 +1,6 @@
+{{- $vbase  := .Values.global.vaultBaseURL | required "missing value for .Values.global.vaultBaseURL" -}}
+{{- $region := .Values.global.region       | required "missing value for .Values.global.region"       -}}
+
 {{- $domains := list "bs" "btp_fp" "cc3test" "cp" "cis" "fsn" "hcm" "hcp03" "hda" "hec" "kyma" "monsoon3" "neo" "s4" "wbs" -}}
 {{- /* WARNING: When adding a new domain, also increment the domain count in the OpenstackLimesUnexpectedCloudDnsAdminRoleAssignments alert. */ -}}
 
@@ -72,6 +75,12 @@ spec:
           role_assignments:
             - project: service
               role:    service
+        - name: limes-validation
+          description: User account for pre-deployment validation in CI
+          password: {{ printf "%s/%s/limes/keystone-user/validation/password" $vbase $region | quote }}
+          role_assignments:
+            - project: service
+              role:    resource_viewer # needs to be able to run `limesctl project show`
 
     - name: ccadmin
       projects:

--- a/openstack/limes/values.yaml
+++ b/openstack/limes/values.yaml
@@ -13,6 +13,7 @@ owner-info:
   service: limes
   maintainers:
     - Stefan Majewsky
+    - Stefan Voigt
     - Sandro Jäckel
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/openstack/limes
 


### PR DESCRIPTION
The intention here is to deliver quota-overrides.json from the secrets repo into prod without human intervention (only gated on validation). Quota overrides are supposed to be maintained by the respective service owners (e.g. the network-api team for Neutron and Octavia quotas), so involving us in the deployment is an unnecessary complication.

This is a different deployment pattern than Limes itself, so it needs to be located in a different chart.

This first step does not do anything on its own, but after this chart is deployed, I will switch Limes to using the quota-overrides.json from here instead of from its own chart.