### PR TITLE
Only use UCS secret when driver is enabled

### DIFF
--- a/openstack/neutron/templates/secret-neutron-cisco-ucs-bm.yaml
+++ b/openstack/neutron/templates/secret-neutron-cisco-ucs-bm.yaml
@@ -1,3 +1,4 @@
+{{- if contains "cisco_ucsm_bm" .Values.ml2_mechanismdrivers }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,3 +10,4 @@ type: Opaque
 data:
   neutron-ucs-bm-secrets.conf: |
     {{ include (print .Template.BasePath "/etc/_cisco-ucs-bm-ml2-agent-secrets.ini.tpl") . | b64enc | indent 4 }}
+{{- end -}}

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -34,9 +34,6 @@ owner-info:
     - Sven Rosenzweig
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/openstack/neutron
 
-sftp:
-  server_key:
-
 pod:
   replicas:
     server: 3
@@ -275,6 +272,7 @@ hypervisors_vmware: []
 # SFTP-swift bridge (e.g. for nsx-t backups in control-plane)
 sftp:
   enabled: false
+  server_key:
   externalIPs: []
   user: db_backup
   logins:


### PR DESCRIPTION
Without the if we create a secret which might just contain a newline, which the vault-injector currently doesn't like. The secret is only used by the ucsm deployment file, so we can use the same condition.