### PR TITLE
am-alertmanagerConfigMatcherStrategy

### DIFF
--- a/common/prometheus-alertmanager-base/Chart.yaml
+++ b/common/prometheus-alertmanager-base/Chart.yaml
@@ -1,6 +1,6 @@
 description: Template for a Prometheus Alertmanager via Prometheus operator.
 name: prometheus-alertmanager-base
 apiVersion: v2
-version: 3.2.0
+version: 3.2.1
 appVersion: "v0.26.0"
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/common/prometheus-alertmanager-base/templates/alertmanager.yaml
+++ b/common/prometheus-alertmanager-base/templates/alertmanager.yaml
@@ -26,6 +26,9 @@ spec:
     matchLabels:
       alertmanager: {{ include "alertmanager.name" . }}
 
+  alertmanagerConfigMatcherStrategy:
+    type: {{ .Values.alertmanagerConfigMatcherStrategy }}
+
   # AdditionalPeers allows injecting a set of additional Alertmanagers to peer with to form a highly available cluster.
   {{ if .Values.additionalPeers -}}
   additionalPeers:

--- a/common/prometheus-alertmanager-base/values.yaml
+++ b/common/prometheus-alertmanager-base/values.yaml
@@ -36,7 +36,7 @@ additionalPeers: []
 # If omitted it is generated automatically, which usually leads to different clusterLabels.
 clusterLabel: ccloud
 
-# OnNamespace or None to match all namespaces.
+# OnNamespace or None to match all namespaces. Default to None here to be independent from the deployed namespace since it would be locked to release namespace otherwise.
 alertmanagerConfigMatcherStrategy: None
 
 # Alertmanager mesh.

--- a/common/prometheus-alertmanager-base/values.yaml
+++ b/common/prometheus-alertmanager-base/values.yaml
@@ -36,6 +36,9 @@ additionalPeers: []
 # If omitted it is generated automatically, which usually leads to different clusterLabels.
 clusterLabel: ccloud
 
+# OnNamespace or None to match all namespaces.
+alertmanagerConfigMatcherStrategy: None
+
 # Alertmanager mesh.
 mesh:
   port: 9094


### PR DESCRIPTION
If set to `OnNamespace`, the operator injects a label matcher matching the  namespace of the AlertmanagerConfig object for all its routes and inhibition  rules. `None` will not add any additional matchers other than the ones specified in the AlertmanagerConfig. Default is `OnNamespace`.
