### PR TITLE
[netapp-exporter] remove probes on worker container

### DIFF
--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/templates/deployment_worker.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/templates/deployment_worker.yaml
@@ -98,19 +98,6 @@ spec:
               subPath: harvest.yaml.tpl
             - name: shared
               mountPath: /app/shared
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: liveness
-            failureThreshold: 3
-            periodSeconds: 60
-            timeoutSeconds: 10
-          startupProbe:
-            httpGet:
-              path: /healthz
-              port: liveness
-            failureThreshold: 30
-            periodSeconds: 10
       volumes:
         - name: harvest-config
           configMap:


### PR DESCRIPTION
Probes restarts worker container but not the pod. The worker fetches a new filer to work on after being restarted, but the harvest poller still works on the old filer. Besides, the master is responsible for restarting the pod after introducing [this] commit.

[this]: https://github.com/sapcc/netappsd/commit/a6bf05fc96a71a26312cb2522a25938a412e8fe6