### PR TITLE
[ironic] fix YAML Syntax

### DIFF
--- a/openstack/ironic/templates/_conductor-deployment.yaml.tpl
+++ b/openstack/ironic/templates/_conductor-deployment.yaml.tpl
@@ -93,8 +93,7 @@ spec:
           failureThreshold: 30
         livenessProbe:
           exec:
-            command:
-              openstack-agent-liveness -c ironic --config-file /etc/ironic/ironic.conf --config-file /etc/ironic/ironic.conf.d/secrets.conf  --ironic_conductor_host ironic-conductor-{{$conductor.name}}
+            command: [ "openstack-agent-liveness",  "--component", "ironic",  "--config-file", "/etc/ironic/ironic.conf", "--config-file", "/etc/ironic/ironic.conf.d/secrets.conf", "--ironic_conductor_host", "ironic-conductor-{{$conductor.name}}" ]
           periodSeconds: 120
           failureThreshold: 3
           timeoutSeconds: 12


### PR DESCRIPTION
in #6433 we dropped the "-" in the command which breaks the
chart, instead of adding it we switch to the "array" style.
This hopefully makes syntax error more prominent.
