### PR TITLE
[neutron] Increase network agent's memory limit

### DIFF
--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -129,14 +129,14 @@ pod:
         memory: "1Gi"
       limits:
         cpu: "4000m"
-        memory: "2.5Gi"
+        memory: "5Gi"
     linuxbridge_agent:
       requests:
         cpu: "256m"
         memory: "512Mi"
       limits:
         cpu: "2000m"
-        memory: "1Gi"
+        memory: "2Gi"
     nsxv3_agent:
       requests:
         cpu: "128m"


### PR DESCRIPTION
During a NFS filer downtime, with the neutron db scaled down, we noticed
that all our dhcp agents got OOM killed. The underling condition is
probably a memory leak that surfaces when neutron-rpc is not working
properly. We still haven't found it yet, but the quick
we-make-this-a-little-less-likely is to increase the memory limits. We
will still get OOM killed just a little later. The hope is that this
little extra time carries us through the filer downtime.
