### PR TITLE
[ironic] audit set default settings

### DIFF
--- a/openstack/ironic/values.yaml
+++ b/openstack/ironic/values.yaml
@@ -429,7 +429,14 @@ watcher:
   enabled: false
 
 audit:
+  central_service:
+    user: rabbitmq
+    password: DEFINED-IN-SECRETS
   enabled: false
+  # how many messages to buffer before dumping to log (when rabbit is down or too slow)
+  mem_queue_size: 100
+  record_payloads: false
+  metrics_enabled: true
 
 # Deploy Ironic Prometheus alerts.
 alerts:


### PR DESCRIPTION
We need to configure the central rabbitmq and set some sensible defaults
for other settings that we got from nova, apart from the queue size
which seems to be 100 for productive regions for most OpenStack
services.
