### PR TITLE
[mariadb-galera] wsrep_sync_wait option for Galera added

### DIFF
--- a/common/mariadb-galera/CHANGELOG.md
+++ b/common/mariadb-galera/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.26.0 - 2024/04/30
+* [wsrep_sync_wait](https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_sync_wait) option added for Galera
+  * unit tests added
+* packages timestamp updated to `20240429103636`
+* chart version bumped
+
 ## v0.25.0 - 2024/04/24
 * Add standardised Kubernetes labels accorting to:
   * [Kubernetes recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels)

--- a/common/mariadb-galera/README.md
+++ b/common/mariadb-galera/README.md
@@ -45,7 +45,7 @@ Docker images and Helm chart to deploy a [MariaDB](https://mariadb.com/kb/en/get
 ## Metadata
 | chart version | app version | type | url |
 |:--------------|:-------------|:-------------|:-------------|
-| 0.25.0 | 10.5.23 | application | [Git repo](https://github.com/sapcc/helm-charts/tree/mariadb-galera/common/mariadb-galera) |
+| 0.26.0 | 10.5.23 | application | [Git repo](https://github.com/sapcc/helm-charts/tree/mariadb-galera/common/mariadb-galera) |
 
 | Name | Email | Url |
 | ---- | ------ | --- |
@@ -155,7 +155,7 @@ docker build --build-arg BASE_SOFT_NAME=ubuntu --build-arg BASE_SOFT_VERSION=22.
   ```
 * [push](https://helm.sh/docs/topics/registries/#the-push-subcommand) the chart to the registry
   ```shell
-  helm push mariadb-galera-0.25.0.tgz oci://keppel.eu-de-1.cloud.sap/ccloud-helm/
+  helm push mariadb-galera-0.26.0.tgz oci://keppel.eu-de-1.cloud.sap/ccloud-helm/
   ```
 
 ### values description
@@ -257,7 +257,7 @@ docker build --build-arg BASE_SOFT_NAME=ubuntu --build-arg BASE_SOFT_VERSION=22.
 | hpa.proxy.minReplicas | int | 3 | minimum number of replicas allowed for the ProxySQL cluster pods |
 | image.database.databasename | string | `"mariadb-galera"` | folder/container used in the image registry and also part of the image name |
 | image.database.databaseversion | string | `"10.5.23"` | database part of the image version that should be pulled |
-| image.database.imageversion | int | `20240419150126` | image part of the image version that should be pulled |
+| image.database.imageversion | int | `20240429103636` | image part of the image version that should be pulled |
 | image.database.project | string | `"ccloud"` | project/tenant used in the image registry |
 | image.database.pullPolicy | string | IfNotPresent | `Always` to enforce that the image will be pulled even if it is already available on the worker node |
 | image.database.pullSecret | string | `nil` | name of the defined Kubernetes secret defined in `image.pullSecrets` that should be used for container registry authentication |
@@ -270,28 +270,28 @@ docker build --build-arg BASE_SOFT_NAME=ubuntu --build-arg BASE_SOFT_VERSION=22.
 | image.haproxy.registry | string | `"keppel.eu-de-1.cloud.sap"` | hostname of the image registry used to pull the proxy image that contains the Restic backup software |
 | image.kopiabackup.databasename | string | `"mariadb-galera-kopia"` | folder/container used in the image registry and also part of the image name |
 | image.kopiabackup.databaseversion | string | `"0.12.1"` | database part of the image version that should be pulled |
-| image.kopiabackup.imageversion | int | `20240419150126` | image part of the image version that should be pulled |
+| image.kopiabackup.imageversion | int | `20240429103636` | image part of the image version that should be pulled |
 | image.kopiabackup.project | string | `"ccloud"` | project/tenant used in the image registry |
 | image.kopiabackup.pullPolicy | string | IfNotPresent | `Always` to enforce that the image will be pulled even if it is already available on the worker node |
 | image.kopiabackup.pullSecret | string | `nil` | name of the defined Kubernetes secret defined in `image.pullSecrets` that should be used for container registry authentication |
 | image.kopiabackup.registry | string | `"keppel.eu-de-1.cloud.sap"` | hostname of the image registry used to pull the proxy image that contains the Kopia backup software |
 | image.monitoring.databasename | string | `"mariadb-galera-mysqld_exporter"` | folder/container used in the image registry and also part of the image name |
 | image.monitoring.databaseversion | string | `"0.14.0"` | database part of the image version that should be pulled |
-| image.monitoring.imageversion | int | `20240419150126` | image part of the image version that should be pulled |
+| image.monitoring.imageversion | int | `20240429103636` | image part of the image version that should be pulled |
 | image.monitoring.project | string | `"ccloud"` | project/tenant used in the image registry |
 | image.monitoring.pullPolicy | string | IfNotPresent | `Always` to enforce that the image will be pulled even if it is already available on the worker node |
 | image.monitoring.pullSecret | string | `nil` | name of the defined Kubernetes secret defined in `image.pullSecrets` that should be used for container registry authentication |
 | image.monitoring.registry | string | `"keppel.eu-de-1.cloud.sap"` | hostname of the image registry used to pull the monitoring image that currently contains the MySQL exporter for Prometheus |
 | image.os.databasename | string | `"mariadb-galera-ubuntu"` | folder/container used in the image registry and also part of the image name |
 | image.os.databaseversion | float | `22.04` | database part of the image version that should be pulled |
-| image.os.imageversion | int | `20240419150126` | image part of the image version that should be pulled |
+| image.os.imageversion | int | `20240429103636` | image part of the image version that should be pulled |
 | image.os.project | string | `"ccloud"` | project/tenant used in the image registry |
 | image.os.pullPolicy | string | IfNotPresent | `Always` to enforce that the image will be pulled even if it is already available on the worker node |
 | image.os.pullSecret | string | `nil` | name of the defined Kubernetes secret defined in `image.pullSecrets` that should be used for container registry authentication |
 | image.os.registry | string | `"keppel.eu-de-1.cloud.sap"` | hostname of the image registry used to pull the basic OS image that will be used for certain init steps |
 | image.proxy.databasename | string | `"mariadb-galera-proxysql"` | folder/container used in the image registry and also part of the image name |
 | image.proxy.databaseversion | string | `"2.5.5"` | database part of the image version that should be pulled |
-| image.proxy.imageversion | int | `20240419150126` | image part of the image version that should be pulled |
+| image.proxy.imageversion | int | `20240429103636` | image part of the image version that should be pulled |
 | image.proxy.project | string | `"ccloud"` | project/tenant used in the image registry |
 | image.proxy.pullPolicy | string | IfNotPresent | `Always` to enforce that the image will be pulled even if it is already available on the worker node |
 | image.proxy.pullSecret | string | `nil` | name of the defined Kubernetes secret defined in `image.pullSecrets` that should be used for container registry authentication |
@@ -406,6 +406,7 @@ docker build --build-arg BASE_SOFT_NAME=ubuntu --build-arg BASE_SOFT_VERSION=22.
 | mariadb.galera.restore.pointInTimeRecovery | bool | `nil` | use binlog backups to recover the database to the defined `mariab.galera.restore.beforeTimestamp` and not only the nearest full backup. The `snapshotId` value will be ignored |
 | mariadb.galera.slaveThreads | int | 4 | [wsrep-slave-threads](https://galeracluster.com/library/documentation/mysql-wsrep-options.html#wsrep-slave-threads) |
 | mariadb.galera.sst_method | string | `"rsync"` | `rsync` or `mariabackup` (also requires GALERA_SST_USERNAME and GALERA_SST_PASSWORD) |
+| mariadb.galera.waitForClusterSync | bool | `false` | enable [wsrep_sync_wait](https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_sync_wait) to delay queries until the cluster is in sync |
 | mariadb.galera.waitForPrimaryTimeoutInSeconds | int | 30 | [pc.wait_prim_timeout](https://galeracluster.com/library/documentation/galera-parameters.html#pc.wait_prim_timeout) |
 | mariadb.galera.weightedQuorum | string | false | configure [weighted Quorum](https://galeracluster.com/library/documentation/weighted-quorum.html#wq-three-nodes) values for the DB nodes eg: db-0: 4, db-1: 2, db-2: 1 |
 | mariadb.innodbFlushLogAtTrxCommit | int | `1` | `1` to enable [innodb_flush_log_at_trx_commit for ACID compliance](https://mariadb.com/kb/en/innodb-system-variables/#innodb_flush_log_at_trx_commit) |

--- a/common/mariadb-galera/helm/Chart.yaml
+++ b/common/mariadb-galera/helm/Chart.yaml
@@ -3,7 +3,7 @@ name: mariadb-galera
 description: Docker images and Helm chart to deploy a [MariaDB](https://mariadb.com/kb/en/getting-installing-and-upgrading-mariadb/) HA cluster based on [Galera](https://mariadb.com/kb/en/what-is-mariadb-galera-cluster/)
 home: "https://github.com/sapcc/helm-charts/tree/mariadb-galera/common/mariadb-galera"
 appVersion: 10.5.23
-version: 0.25.0
+version: 0.26.0
 type: application
 kubeVersion: ">=1.18"
 maintainers:

--- a/common/mariadb-galera/helm/templates/configmap-mariadb-my.cnf.yaml
+++ b/common/mariadb-galera/helm/templates/configmap-mariadb-my.cnf.yaml
@@ -121,6 +121,7 @@ data:
     wsrep_sst_method=mariabackup
     wsrep_sst_auth=${GALERA_SST_USERNAME}:${GALERA_SST_PASSWORD}
     {{- end }}
+    wsrep_sync_wait={{ if $.Values.mariadb.galera.waitForClusterSync }}1{{ else }}0{{ end }}
     wsrep_slave_threads={{ $.Values.mariadb.galera.slaveThreads | default 4 | int }}
     wsrep_auto_increment_control=0
     {{- /*

--- a/common/mariadb-galera/helm/tests/01-default-statefulset_test.yaml
+++ b/common/mariadb-galera/helm/tests/01-default-statefulset_test.yaml
@@ -1,8 +1,8 @@
 
 ---
 checksums:
-  my.cnf: &mycnf "1772e8e7434166eaeb4fd56eaa9ff33a358680736b225b9f1e6e67d18a5a9fb2"
-  configmap: &configmap "a98d84678f221ed171abbefd6698768201588d5a4e8d15fb22fbfd81dd2f2e1f"
+  my.cnf: &mycnf "dabcf66601755d38af76af528ba4a9be39071bbeb9b68647490e0faea105bef8"
+  configmap: &configmap "282a3595ddcb1819ccc60dd791062c881bf24f005a1255d9c6adb6ecc2a2c092"
 
 suite: statefulset-mariadb
 values:
@@ -310,7 +310,7 @@ tests:
           value: "sysctl-tcp-keepalive"
       - equal:
           path: spec.template.spec.initContainers[0].image
-          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera-ubuntu:22.04-20240419150126"
+          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera-ubuntu:22.04-20240429103636"
       - equal:
           path: spec.template.spec.initContainers[0].imagePullPolicy
           value: "IfNotPresent"
@@ -379,7 +379,7 @@ tests:
           value: "increase-map-count"
       - equal:
           path: spec.template.spec.initContainers[1].image
-          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera-ubuntu:22.04-20240419150126"
+          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera-ubuntu:22.04-20240429103636"
       - equal:
           path: spec.template.spec.initContainers[1].imagePullPolicy
           value: "IfNotPresent"
@@ -471,7 +471,7 @@ tests:
           value: "clean-os-cache"
       - equal:
           path: spec.template.spec.initContainers[2].image
-          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera-ubuntu:22.04-20240419150126"
+          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera-ubuntu:22.04-20240429103636"
       - equal:
           path: spec.template.spec.initContainers[2].imagePullPolicy
           value: "IfNotPresent"
@@ -541,7 +541,7 @@ tests:
           value: "db"
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera:10.5.23-20240419150126"
+          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera:10.5.23-20240429103636"
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: "IfNotPresent"
@@ -1640,7 +1640,7 @@ tests:
           value: "metrics"
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera-mysqld_exporter:0.14.0-20240419150126"
+          value: "keppel.eu-de-1.cloud.sap/ccloud/mariadb-galera-mysqld_exporter:0.14.0-20240429103636"
       - equal:
           path: spec.template.spec.containers[1].imagePullPolicy
           value: "IfNotPresent"

--- a/common/mariadb-galera/helm/tests/04-configmap-mariadb-my-cnf_test.yaml
+++ b/common/mariadb-galera/helm/tests/04-configmap-mariadb-my-cnf_test.yaml
@@ -88,6 +88,7 @@ tests:
             wsrep_node_name=testrelease-mariadb-g-0
             wsrep-on=1
             wsrep_log_conflicts=ON
+            wsrep_sync_wait=0
             wsrep_slave_threads=16
             wsrep_auto_increment_control=0
             auto_increment_increment=3
@@ -511,3 +512,67 @@ tests:
       - matchRegex:
           path: data["my.cnf.testrelease-mariadb-g-0.tpl"]
           pattern: wsrep_provider_options=.+;evs\.inactive_check_period=PT2\.50S;evs\.inactive_timeout=PT30S;evs\.install_timeout=PT8S;evs\.keepalive_period=PT1\.60S;evs\.send_window=256;evs\.suspect_timeout=PT5S;evs\.user_send_window=128.+;pc\.weight=\${PC_WEIGHT_0}
+
+  - it: Galera wsrep_sync_wait disabled
+    template: configmap-mariadb-my.cnf.yaml
+    documentIndex: 0
+    set:
+      mariadb.galera.clustername: "testname"
+      mariadb.galera.waitForClusterSync: false
+      replicas.database: 3
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.namespace
+          value: testnamespace
+      - equal:
+          path: metadata.name
+          value: testrelease-mariadb-my-cnf
+      - exists:
+          path: data["my.cnf.testrelease-mariadb-g-0.tpl"]
+      - exists:
+          path: data["my.cnf.testrelease-mariadb-g-1.tpl"]
+      - exists:
+          path: data["my.cnf.testrelease-mariadb-g-2.tpl"]
+      - matchRegex:
+          path: data["my.cnf.testrelease-mariadb-g-0.tpl"]
+          pattern: wsrep_sync_wait=0
+      - matchRegex:
+          path: data["my.cnf.testrelease-mariadb-g-1.tpl"]
+          pattern: wsrep_sync_wait=0
+      - matchRegex:
+          path: data["my.cnf.testrelease-mariadb-g-2.tpl"]
+          pattern: wsrep_sync_wait=0
+
+  - it: Galera wsrep_sync_wait enabled
+    template: configmap-mariadb-my.cnf.yaml
+    documentIndex: 0
+    set:
+      mariadb.galera.clustername: "testname"
+      mariadb.galera.waitForClusterSync: true
+      replicas.database: 3
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.namespace
+          value: testnamespace
+      - equal:
+          path: metadata.name
+          value: testrelease-mariadb-my-cnf
+      - exists:
+          path: data["my.cnf.testrelease-mariadb-g-0.tpl"]
+      - exists:
+          path: data["my.cnf.testrelease-mariadb-g-1.tpl"]
+      - exists:
+          path: data["my.cnf.testrelease-mariadb-g-2.tpl"]
+      - matchRegex:
+          path: data["my.cnf.testrelease-mariadb-g-0.tpl"]
+          pattern: wsrep_sync_wait=1
+      - matchRegex:
+          path: data["my.cnf.testrelease-mariadb-g-1.tpl"]
+          pattern: wsrep_sync_wait=1
+      - matchRegex:
+          path: data["my.cnf.testrelease-mariadb-g-2.tpl"]
+          pattern: wsrep_sync_wait=1

--- a/common/mariadb-galera/helm/values.yaml
+++ b/common/mariadb-galera/helm/values.yaml
@@ -163,6 +163,8 @@ mariadb:
     # eg: db-0: 4, db-1: 2, db-2: 1
     # @default -- false
     weightedQuorum:
+    # -- (bool) enable [wsrep_sync_wait](https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_sync_wait) to delay queries until the cluster is in sync
+    waitForClusterSync: false
     multiRegion:
       # -- (bool) Enable the multi-region setup. Exactly 3 regions are supported
       enabled: false
@@ -747,7 +749,7 @@ image:
     # -- database part of the image version that should be pulled
     databaseversion: 22.04
     # -- image part of the image version that should be pulled
-    imageversion: 20240419150126
+    imageversion: 20240429103636
     # -- (string) `Always` to enforce that the image will be pulled even if it is already available on the worker node
     # @default -- IfNotPresent
     pullPolicy:
@@ -763,7 +765,7 @@ image:
     # -- database part of the image version that should be pulled
     databaseversion: 10.5.23
     # -- image part of the image version that should be pulled
-    imageversion: 20240419150126
+    imageversion: 20240429103636
     # -- (string) `Always` to enforce that the image will be pulled even if it is already available on the worker node
     # @default -- IfNotPresent
     pullPolicy:
@@ -779,7 +781,7 @@ image:
     # -- database part of the image version that should be pulled
     databaseversion: 0.14.0
     # -- image part of the image version that should be pulled
-    imageversion: 20240419150126
+    imageversion: 20240429103636
     # -- (string) `Always` to enforce that the image will be pulled even if it is already available on the worker node
     # @default -- IfNotPresent
     pullPolicy:
@@ -795,7 +797,7 @@ image:
     # -- database part of the image version that should be pulled
     databaseversion: 2.5.5
     # -- image part of the image version that should be pulled
-    imageversion: 20240419150126
+    imageversion: 20240429103636
     # -- (string) `Always` to enforce that the image will be pulled even if it is already available on the worker node
     # @default -- IfNotPresent
     pullPolicy:
@@ -811,7 +813,7 @@ image:
     # -- database part of the image version that should be pulled
     databaseversion: 0.12.1
     # -- image part of the image version that should be pulled
-    imageversion: 20240419150126
+    imageversion: 20240429103636
     # -- (string) `Always` to enforce that the image will be pulled even if it is already available on the worker node
     # @default -- IfNotPresent
     pullPolicy:


### PR DESCRIPTION
- to avoid stale reads if required
- chart version bumped
- [wsrep_sync_wait](https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_sync_wait)