### PR TITLE
[neutron] Skip ports for linker on network-agent

### DIFF
--- a/openstack/neutron/templates/statefulset-network-agent-apod.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent-apod.yaml
@@ -43,7 +43,8 @@ spec:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") $ | sha256sum }}
         configmap-etc-apod-hash: {{ include (print $.Template.BasePath "/configmap-etc-apod.yaml") $ | sha256sum }}
         {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 8 }}
-        config.linkerd.io/skip-inbound-ports: "53,80"
+        config.linkerd.io/skip-inbound-ports: "22,53,80,443"
+        config.linkerd.io/skip-outbound-ports: "22,53,80,443"
       labels:
         name: neutron-network-agent-{{ $apod }}
 {{ tuple $ "neutron" "agent" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}

--- a/openstack/neutron/templates/statefulset-network-agent.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent.yaml
@@ -42,7 +42,8 @@ spec:
         k8s.v1.cni.cncf.io/networks: '[{ "name": "cbr1-bridge", "interface":"{{$.Values.cp_network_interface}}" }]'
         configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") $ | sha256sum }}
         {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 8 }}
-        config.linkerd.io/skip-inbound-ports: "53,80"
+        config.linkerd.io/skip-inbound-ports: "22,53,80,443"
+        config.linkerd.io/skip-outbound-ports: "22,53,80,443"
       labels:
         name: neutron-network-agent-{{ $az }}
 {{ tuple $ "neutron" "agent" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}


### PR DESCRIPTION
We skip outbound linkerd proxying for port 22,53,80,443 to better debug networks from the network viewpoint of our network agents. Especially port 22 will allow us to use the network agent as jumphost again.