### PR TITLE
[Limes] Align policies with elektra

### DIFF
--- a/openstack/limes/templates/configmap.yaml
+++ b/openstack/limes/templates/configmap.yaml
@@ -20,16 +20,19 @@ data:
     project_scope: project_domain_id:%(domain_id)s and project_id:%(project_id)s
     domain_scope: domain_id:%(domain_id)s
 
-    cluster_editor: role:cloud_resource_admin or (role:cloud_dns_resource_admin and 'dns':%(service_type)s)
-    cluster_viewer: role:cloud_resource_admin or role:cloud_dns_resource_admin or role:cloud_resource_viewer
+    project_view_roles": "role:member or role:_member_ or role:Member or role:resource_viewer",
+
+    cluster_editor: role:cloud_resource_admin
+    cluster_viewer: role:cloud_resource_admin or role:cloud_resource_viewer
     domain_editor: rule:cluster_editor or (rule:domain_scope and role:resource_admin)
     domain_viewer: rule:cluster_viewer or (rule:domain_scope and role:resource_viewer) or rule:domain_editor
     project_editor: rule:domain_editor or (rule:project_scope and role:resource_admin)
-    project_viewer: rule:domain_viewer or (rule:project_scope and (role:member or role:_member_ or role:Member or role:resource_viewer)) or rule:project_editor
+    project_viewer: rule:domain_viewer or (rule:project_scope and rule:project_view_roles) or rule:project_editor
+    can_goto_cluster: role:cloud_support_tools_viewer
 
-    project:list: rule:domain_viewer
     project:show: rule:project_viewer
     project:edit: rule:project_editor
+    project:goto_cluster": "rule:limes_can_goto_cluster",
     project:sync: rule:project_editor
     project:raise: rule:domain_editor
     project:raise_lowpriv: rule:project_editor


### PR DESCRIPTION
Please do not merge without approval from @majewsky !

This is a PR that aims to align the limes with the elektra policies.
Without the alignment we might have users with mismatching access rights that can access the API but not the UI or vise versa.

Done:
* Remove access rights not present in the elektra policies.
* Added a policy which exists in the elektra policies.

To note:
* The limes API rules for cluster/domain/project level that are not present in elektra are still available, since I'm not sure what exactly they are used for -> needs to be checked by the reviewer. 
