### PR TITLE
[manila] manager to check svm migration progress more often

### DIFF
--- a/openstack/manila/values.yaml
+++ b/openstack/manila/values.yaml
@@ -24,6 +24,9 @@ api_backdoor: false
 debug: "True"
 rpc_ping_enabled: true
 
+# manager config options
+server_migration_driver_continue_update_interval: 300
+
 # better debugging experience; enable it only in QA
 pyreloader_enabled: false
 


### PR DESCRIPTION
This parameter controls how often share manager polls the back end of the server migration status ([1]). Default value is 900 seconds. This PR set the interval to 300 seconds globally.

[1]:
https://github.com/sapcc/manila/blob/3aff6a6621bf265780db5ef3370741d1aac915e4/manila/share/manager.py#L116-L121