### PR TITLE
[NSXV3] Fix logstash parsing firewall logs

### DIFF
--- a/openstack/neutron/templates/etc/_nsxv3_logstash.conf.tpl
+++ b/openstack/neutron/templates/etc/_nsxv3_logstash.conf.tpl
@@ -5,9 +5,9 @@ input {
   }
 }
 filter {
-  if [type] == "esxi" and "FIREWALL_PKTLOG" in [message] {
+  if [type] == "esxi" and "FIREWALL-PKTLOG" in [message] {
     grok {
-      match => { "message" => "<%{POSINT:syslog_pri}>%{TIMESTAMP_ISO8601:timestamp}.%{IPORHOST}.FIREWALL_PKTLOG:.%{WORD:target_suffix}.%{WORD:af_value}.%{GREEDYDATA:message}" }
+      match => { "message" => "<%{POSINT:syslog_pri}>%{TIMESTAMP_ISO8601:timestamp}.%{IPORHOST}.FIREWALL-PKTLOG:.%{WORD:target_suffix}.%{WORD:af_value}.%{GREEDYDATA:message}" }
       overwrite => [ "message" ]
     }
     grok {


### PR DESCRIPTION
The log message id identifying log messages types send to a logserver has changed from FIREWALL_PKTLOG to FIREWALL-PKTLOG breaking our filtering applied in the nsxv3-logstash exporter. Thus (if configured by the openstack user) none firwall log will be processed properly.