### PR TITLE
ceph: add ceph service account and endpoints

### DIFF
--- a/openstack/ceph-seed/Chart.lock
+++ b/openstack/ceph-seed/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: owner-info
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 0.2.0
+digest: sha256:9948b42a49d86cee17b76e5d46a5677e70bf3feb9ff2a9c34691a6f82ee751db
+generated: "2024-04-12T15:50:08.679902+02:00"

--- a/openstack/ceph-seed/Chart.yaml
+++ b/openstack/ceph-seed/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: ceph-seed
+description: A Helm chart for Kubernetes
+version: 0.1.0
+dependencies:
+  - name: owner-info
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: 0.2.0

--- a/openstack/ceph-seed/ci/test-values.yaml
+++ b/openstack/ceph-seed/ci/test-values.yaml
@@ -1,0 +1,2 @@
+global:
+  ceph_service_password: foo-bar

--- a/openstack/ceph-seed/templates/seed.yaml
+++ b/openstack/ceph-seed/templates/seed.yaml
@@ -1,0 +1,29 @@
+apiVersion: "openstack.stable.sap.cc/v1"
+kind: OpenstackSeed
+metadata:
+  name: ceph-seed
+
+spec:
+  services:
+    - name:        ceph
+      type:        object-store-ceph
+      description: 'CEPH Object Store'
+      enabled:     true
+      endpoints:
+        - region:    '{{ $.Values.global.region }}'
+          interface: public
+          enabled:   true
+          url:       'https://rgw.st1.{{ $.Values.global.region }}.{{ $.Values.global.tld }}/swift/v1/AUTH_%(tenant_id)s'
+
+  domains:
+    - name: Default
+      users:
+        - name: ceph
+          description: CEPH Object Store Service
+          password: '{{ $.Values.global.ceph_service_password }}'
+    - name: Default
+      projects:
+      - name: admin
+        role_assignments:
+        - user: ceph@Default
+          role: service # for s3tokens auth access

--- a/openstack/ceph-seed/values.yaml
+++ b/openstack/ceph-seed/values.yaml
@@ -1,0 +1,3 @@
+owner-info:
+  helm-chart-url: 'https://github.com/sapcc/helm-charts/tree/master/openstack/ceph-seed'
+  support-group: storage


### PR DESCRIPTION
Introduce a seed chart, which will be running in "metal" clusters, to configure ceph service and endpoints.