### PR TITLE
[Keystone] Enable linkerd jobs

### DIFF
--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: keystone
 sources:
   - https://github.com/sapcc/keystone
-version: 0.6.2
+version: 0.6.3
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/keystone/templates/bin/_bootstrap.tpl
+++ b/openstack/keystone/templates/bin/_bootstrap.tpl
@@ -25,4 +25,4 @@ keystone-manage --config-file=/etc/keystone/keystone.conf --config-file=/etc/key
 {{- end }}
     --bootstrap-region-id {{ .Values.global.region }}
 
-{{- include "utils.script.job_finished_hook" . | trim }}
+{{ include "utils.script.job_finished_hook" . | trim }}

--- a/openstack/keystone/templates/bin/_bootstrap.tpl
+++ b/openstack/keystone/templates/bin/_bootstrap.tpl
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -ex
 trap "{{ include "utils.proxysql.proxysql_signal_stop_script" . | trim }}" EXIT
+trap "{{- include "utils.script.job_finished_hook" . | trim }}" EXIT
+
 # seed just enough to have a functional v3 api
 keystone-manage --config-file=/etc/keystone/keystone.conf --config-file=/etc/keystone/keystone.conf.d/secrets.conf bootstrap \
     --bootstrap-username {{ .Values.api.adminUser }} \

--- a/openstack/keystone/templates/bin/_bootstrap.tpl
+++ b/openstack/keystone/templates/bin/_bootstrap.tpl
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 set -ex
-trap "{{ include "utils.proxysql.proxysql_signal_stop_script" . | trim }}" EXIT
-trap "{{- include "utils.script.job_finished_hook" . | trim }}" EXIT
 
 # seed just enough to have a functional v3 api
 keystone-manage --config-file=/etc/keystone/keystone.conf --config-file=/etc/keystone/keystone.conf.d/secrets.conf bootstrap \
@@ -26,3 +24,5 @@ keystone-manage --config-file=/etc/keystone/keystone.conf --config-file=/etc/key
     --bootstrap-internal-url http://keystone.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.region}}.{{.Values.global.tld}}:5000/v3 \
 {{- end }}
     --bootstrap-region-id {{ .Values.global.region }}
+
+{{- include "utils.script.job_finished_hook" . | trim }}

--- a/openstack/keystone/templates/bin/_db-sync.tpl
+++ b/openstack/keystone/templates/bin/_db-sync.tpl
@@ -40,7 +40,7 @@ keystone-manage --config-file=/etc/keystone/keystone.conf --config-file=/etc/key
 echo "Keystone doctor:"
 keystone-manage --config-file=/etc/keystone/keystone.conf --config-file=/etc/keystone/keystone.conf.d/secrets.conf doctor
 
+{{- include "utils.script.job_finished_hook" . | trim }}
+
 # don't let the doctor break stuff (as usual not qualified enough and you allways need another opinion :P )
 exit 0
-
-{{- include "utils.script.job_finished_hook" . | trim }}

--- a/openstack/keystone/templates/bin/_db-sync.tpl
+++ b/openstack/keystone/templates/bin/_db-sync.tpl
@@ -40,7 +40,7 @@ keystone-manage --config-file=/etc/keystone/keystone.conf --config-file=/etc/key
 echo "Keystone doctor:"
 keystone-manage --config-file=/etc/keystone/keystone.conf --config-file=/etc/keystone/keystone.conf.d/secrets.conf doctor
 
-{{- include "utils.script.job_finished_hook" . | trim }}
+{{ include "utils.script.job_finished_hook" . | trim }}
 
 # don't let the doctor break stuff (as usual not qualified enough and you allways need another opinion :P )
 exit 0

--- a/openstack/keystone/templates/bin/_db-sync.tpl
+++ b/openstack/keystone/templates/bin/_db-sync.tpl
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 trap "{{ include "utils.proxysql.proxysql_signal_stop_script" . | trim }}" EXIT
+trap "{{- include "utils.script.job_finished_hook" . | trim }}" EXIT
 
 echo "Status before migration:"
 keystone-status --config-file=/etc/keystone/keystone.conf --config-file=/etc/keystone/keystone.conf.d/secrets.conf upgrade check

--- a/openstack/keystone/templates/bin/_db-sync.tpl
+++ b/openstack/keystone/templates/bin/_db-sync.tpl
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-trap "{{ include "utils.proxysql.proxysql_signal_stop_script" . | trim }}" EXIT
-trap "{{- include "utils.script.job_finished_hook" . | trim }}" EXIT
 
 echo "Status before migration:"
 keystone-status --config-file=/etc/keystone/keystone.conf --config-file=/etc/keystone/keystone.conf.d/secrets.conf upgrade check
@@ -44,3 +42,5 @@ keystone-manage --config-file=/etc/keystone/keystone.conf --config-file=/etc/key
 
 # don't let the doctor break stuff (as usual not qualified enough and you allways need another opinion :P )
 exit 0
+
+{{- include "utils.script.job_finished_hook" . | trim }}

--- a/openstack/keystone/templates/bin/_repair_assignments.tpl
+++ b/openstack/keystone/templates/bin/_repair_assignments.tpl
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-trap "{{ include "utils.proxysql.proxysql_signal_stop_script" . | trim }}" EXIT
 export STDOUT=${STDOUT:-/proc/1/fd/1}
 export STDERR=${STDERR:-/proc/1/fd/2}
 

--- a/openstack/keystone/templates/job-bootstrap.yaml
+++ b/openstack/keystone/templates/job-bootstrap.yaml
@@ -30,6 +30,7 @@ spec:
         secrets-hash: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
         # only run once on initial install
         "helm.sh/hook": post-install
+{{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
 {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ .Release.Name }}

--- a/openstack/keystone/templates/job-migration.yaml
+++ b/openstack/keystone/templates/job-migration.yaml
@@ -30,6 +30,7 @@ spec:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") . | sha256sum }}
         # only run once
         "helm.sh/hook": post-install, post-upgrade
+{{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}  
     spec:
 {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ .Release.Name }}


### PR DESCRIPTION
For using linkerd in Job-spawned Pods, we have to add a snippet at the
end that will tell the linkerd-proxy sidecar to stop. This snippet is
integrated - together with the proxysql snippet - into
"utils.script.job_finished_hook" in the utils chart starting with
version 0.14.6.

Since we need a version bump, we also get:

add owner info explicitly to coordination pvc
mount a trust-bundle at subpath
Ref : https://github.com/sapcc/helm-charts/commit/ed8e6ec64a39159a01105220d7512570419151c1

Closed PR : https://github.com/sapcc/helm-charts/pull/6414