### PR TITLE
removing pre auto-update quota alerts

### DIFF
--- a/openstack/cc3test-seeds/Chart.yaml
+++ b/openstack/cc3test-seeds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: cc3test-seeds - seeding for blackbox testing the CC+1
 name: cc3test-seeds
-version: 0.2.0
+version: 0.2.1
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/cc3test-seeds/alerts/cc3test-quota.alerts
+++ b/openstack/cc3test-seeds/alerts/cc3test-quota.alerts
@@ -1,44 +1,16 @@
 groups:
 - name: cc3test-quota.alerts
   rules:
-  - alert: CC3TestQuotaConsumption90Pct
-    expr: limes_project_usage{domain="cc3test", project=~"admin|test"} / limes_project_quota{domain="cc3test", project=~"admin|test"} > 0.9
+  - alert: CC3TestQuotaConsumptionPct
+    expr: limes_project_usage{domain="cc3test", project=~"admin|test"} / limes_project_quota{domain="cc3test", project=~"admin|test"} > 0.99
     for: 60m
     labels:
       severity: critical
       support_group: observability
       service: cc3test
       dashboard: cc3test-quota-status
-      meta: 'More than 90% of {{ $labels.service }} / {{ $labels.resource }} quota consumed in project {{ $labels.domain }} / {{ $labels.project }}'
+      meta: 'More than 99% of {{ $labels.service }} / {{ $labels.resource }} quota consumed in project {{ $labels.domain }} / {{ $labels.project }}'
       playbook: 'docs/support/playbook/cc3test/alerts'
     annotations:
-      description: 'More than 90% of {{ $labels.service }} / {{ $labels.resource }} quota consumed in project {{ $labels.domain }} / {{ $labels.project }}'
-      summary: '90% of {{ $labels.service }} / {{ $labels.resource }} quota consumed'
-
-  - alert: CC3TestQuotaConsumption75Pct
-    expr: limes_project_usage{domain="cc3test", project=~"admin|test"} / limes_project_quota{domain="cc3test", project=~"admin|test"} > 0.75
-    for: 60m
-    labels:
-      severity: warning
-      support_group: observability
-      service: cc3test
-      dashboard: cc3test-quota-status
-      meta: 'More than 75% of {{ $labels.service }} / {{ $labels.resource }} quota consumed in project {{ $labels.domain }} / {{ $labels.project }}'
-      playbook: 'docs/support/playbook/cc3test/alerts'
-    annotations:
-      description: 'More than 75% of {{ $labels.service }} / {{ $labels.resource }} quota consumed in project {{ $labels.domain }} / {{ $labels.project }}'
-      summary: '75% of {{ $labels.service }} / {{ $labels.resource }} quota consumed'
-
-  - alert: CC3TestRegressionQuotaConsumption75Pct
-    expr: limes_project_usage{domain="cc3test", project=~"^regression", resource!~"^instances_z.*"} / limes_project_quota{domain="cc3test", project=~"^regression", resource!~"^instances_z.*"} > 0.75
-    for: 60m
-    labels:
-      severity: info
-      support_group: observability
-      service: cc3test
-      dashboard: cc3test-quota-status
-      meta: 'More than 75% of {{ $labels.service }} / {{ $labels.resource }} quota consumed in project {{ $labels.domain }} / {{ $labels.project }}'
-      playbook: 'docs/support/playbook/cc3test/alerts'
-    annotations:
-      description: 'More than 75% of {{ $labels.service }} / {{ $labels.resource }} quota consumed in project {{ $labels.domain }} / {{ $labels.project }}'
-      summary: '75% of {{ $labels.service }} / {{ $labels.resource }} quota consumed'
+      description: 'More than 99% of {{ $labels.service }} / {{ $labels.resource }} quota consumed in project {{ $labels.domain }} / {{ $labels.project }}'
+      summary: '99% of {{ $labels.service }} / {{ $labels.resource }} quota consumed'


### PR DESCRIPTION
they are no longer needed since limes is auto increasing now. Leaving 99% as a safeguard
