### PR TITLE
[Neutron] Alert on mariadb endpoint not ready

### DIFF
--- a/openstack/neutron/alerts/kubernetes/neutron.alerts
+++ b/openstack/neutron/alerts/kubernetes/neutron.alerts
@@ -15,3 +15,17 @@ groups:
     annotations:
       description: 'Not all networks have been synced by agent for 5 min: {{ $labels.pod }}'
       summary: Openstack Neutron DHCP Agent lost private networks
+
+  - alert: MariaDBEndpointNotReady
+    expr: kube_endpoint_address_not_ready{endpoint=~"neutron-mariadb"} > 0
+    for: 5m
+    labels:
+      severity: warning
+      support_group: network-api
+      tier: os
+      service: neutron
+      context: '{{ $labels.context }}'
+      meta: 'Endpoint{{ $labels.endpoint }} not ready'
+    annotations:
+        description: 'Mariadb Endpoint not ready for 5 min'
+        summary: MaraiDB might not be reachable due to failing readiness checks.'


### PR DESCRIPTION
Trigger a warning alert if mariadb endpoint is not ready.

Restarting neutron-server during the mariadb
endpoint not being ready, results in a failing neutron-server pods. The kubernetes-entrypoint script checks if all dependencies (e.g. mariadb reachable) are fullfield before starting neutron.

To detect such situations, this alert fires if such a situation occurs again.