### PR TITLE
limes: use quota overrides from limes-auto deployment

### DIFF
--- a/openstack/limes/templates/_utils.tpl
+++ b/openstack/limes/templates/_utils.tpl
@@ -46,8 +46,6 @@
   value: "true"
 - name: LIMES_COLLECTOR_DATA_METRICS_SKIP_ZERO
   value: "true"
-- name: LIMES_QUOTA_OVERRIDES_PATH
-  value: "/etc/limes/quota-overrides.json"
 - name: OS_AUTH_URL
   value: "http://keystone.{{ $.Values.global.keystoneNamespace }}.svc.kubernetes.{{ $.Values.global.region }}.{{ $.Values.global.tld }}:5000/v3"
 - name: OS_INTERFACE

--- a/openstack/limes/templates/configmap.yaml
+++ b/openstack/limes/templates/configmap.yaml
@@ -13,8 +13,6 @@ data:
 {{ toYaml .Values.limes.clusters.ccloud | indent 4 }}
   constraints-ccloud.yaml: |
 {{ toYaml .Values.limes.constraints.ccloud | indent 4 }}
-  quota-overrides.json: |
-{{ toJson .Values.quota_overrides | indent 4 }}
 
   policy.yaml: |
     project_scope: project_domain_id:%(domain_id)s and project_id:%(project_id)s

--- a/openstack/limes/templates/deployment-collect.yaml
+++ b/openstack/limes/templates/deployment-collect.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     app: limes-collect
     release: "{{.Release.Name}}"
+  annotations:
+    configmap.reloader.stakater.com/reload: limes-auto-overrides
 
 spec:
   minReadySeconds: 10 # to capture errors from config/constraint parsing
@@ -34,6 +36,9 @@ spec:
         - name: config
           configMap:
             name: limes
+        - name: config-auto-overrides
+          configMap:
+            name: limes-auto-overrides
       containers:
         - name: collect
           image: {{ include "limes_image" . }}
@@ -43,21 +48,25 @@ spec:
             - /etc/limes/limes.yaml
           env:
             {{ include "limes_common_envvars" . | indent 12 }}
+            - name: LIMES_QUOTA_OVERRIDES_PATH
+              value: "/etc/limes-auto-overrides/quota-overrides.json"
           securityContext:
             runAsNonRoot: true
           volumeMounts:
             - mountPath: /etc/limes
               name: config
+            - mountPath: /etc/limes-auto
+              name: config-auto-overrides
           ports:
             - name: metrics
               containerPort: 8080
           {{- if .Values.limes.resources.enabled }}
           resources:
-            # observed usage: CPU = 50m-500m, RAM = 100-500 MiB
+            # observed usage: CPU = 50m-500m, RAM = 100 MiB in small regions, spikes up to more than 750 MiB in large regions
             limits:
                 cpu: '1000m'
-                memory: '750Mi'
+                memory: '1000Mi'
             requests:
                 cpu: '400m'
-                memory: '750Mi'
+                memory: '1000Mi'
           {{- end }}

--- a/openstack/limes/values.yaml
+++ b/openstack/limes/values.yaml
@@ -54,10 +54,6 @@ limes:
   resources:
     enabled: false
 
-# Map with entries being the contents of a Limes quota overrides file.
-# See `LIMES_QUOTA_OVERRIDES_PATH` in <https://github.com/sapcc/limes/blob/master/docs/operators/config.md>
-quota_overrides: {}
-
 postgresql:
   persistence:
     enabled: true


### PR DESCRIPTION
FYI, the reloader annotation is documented in <https://github.com/stakater/Reloader?tab=readme-ov-file#configmap>.