### PR TITLE
remove unneeded ceph global config values

### DIFF
--- a/system/cc-ceph/values.yaml
+++ b/system/cc-ceph/values.yaml
@@ -16,8 +16,6 @@ ceph:
 cephConfig:
   global:
     osd_pool_default_size: "3"
-    bdev_flock_retry: "20"
-    bluefs_buffered_io: "false"
     mon_data_avail_warn: "10"
     osd_op_queue: "wpq"
     osd_pool_default_pg_autoscale_mode: "off"


### PR DESCRIPTION
bluefs_buffered_io ... The default is better.
bdev_flock_retry... Checking the code. It's probably harmless.