### PR TITLE
ceph: avoid using split for escape helper

### DIFF
--- a/system/cc-ceph/Chart.yaml
+++ b/system/cc-ceph/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cc-ceph
 description: A Helm chart for the Rook / Ceph Objects inside the Storage Clusters
 type: application
-version: 1.0.18
+version: 1.0.19
 appVersion: "1.14.3"
 dependencies:
   - name: owner-info

--- a/system/cc-ceph/templates/_helpers.tpl
+++ b/system/cc-ceph/templates/_helpers.tpl
@@ -66,9 +66,10 @@ Create the name of the service account to use
 {{- define "cc-ceph.escapePassword" -}}
     {{- $value := . -}}
     {{- $escaped := "" -}}
-    {{- range $value | split "" -}}
-        {{- $char := . -}}
-        {{- if or (eq $char "=") (eq $char "#") (eq $char ";") (eq $char "[") -}}
+    {{- $length := len $value -}}
+    {{- range $index := until $length -}}
+        {{- $char := index $value $index -}}
+        {{- if or (eq $char '=') (eq $char '#') (eq $char ';') (eq $char '[') -}}
             {{- $escaped = printf "%s\\%s" $escaped $char -}}
         {{- else -}}
             {{- $escaped = printf "%s%s" $escaped $char -}}


### PR DESCRIPTION
split with empty delimiter behaves weird