### PR TITLE
[Octavia] Fix: Sometimes there's only one secret

### DIFF
--- a/openstack/octavia/templates/secrets-worker.yaml
+++ b/openstack/octavia/templates/secrets-worker.yaml
@@ -1,6 +1,7 @@
 {{- $envAll := . }}
 {{- range $name, $val := .Values.workers -}}
 {{- with $ }}
+---
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
In some regions the worker secrets are created correctly for every worker. But in some regions only one secret is created.

I suspect that this is because the worker secret template is missing a document separator (`---`) within the range construct. For example `octavia-worker-configmap.yaml` and `octavia-worker-deployment.yaml` have the separator within the range, respectively.

According to the helm templating guide[1] in many cases one of the separators (`---` and `...`) can be omitted, which might be (part of) the reason why this templating worked in some regions, e.g. qa-de-1.

[1] https://helm.sh/docs/chart_template_guide/yaml_techniques/#embedding-multiple-documents-in-one-file