### PR TITLE
fix(SRS): remove obsolete `alert-`  labels

### DIFF
--- a/common/pgmetrics/templates/deployment.yaml
+++ b/common/pgmetrics/templates/deployment.yaml
@@ -21,10 +21,6 @@ spec:
         app: {{ .Release.Name }}-pgmetrics
         component: {{ $db_name }}
         type: metrics
-        {{- if .Values.alerts.enabled }}
-        alert-tier: {{ required ".Values.alerts.tier missing" .Values.alerts.tier }}
-        alert-service: {{ .Values.alerts.service | default .Release.Name }}
-        {{- end }}
       annotations:
         kubectl.kubernetes.io/default-container: metrics
         configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") . | sha256sum }}

--- a/common/postgresql/templates/deployment.yaml
+++ b/common/postgresql/templates/deployment.yaml
@@ -26,10 +26,6 @@ spec:
         component: "{{ .Values.postgresDatabase }}"
         name: {{ template "fullname" . }} # just to make the ci pipeline easier, not actually used anywhere
         type: database
-        {{- if .Values.alerts.enabled }}
-        alert-tier: {{ required ".Values.alerts.tier missing" .Values.alerts.tier }}
-        alert-service: {{ include "alerts.service" . }}
-        {{- end }}
       annotations:
         kubectl.kubernetes.io/default-container: postgres
         checksum/secrets: {{ include (print $.Template.BasePath  "/secrets.yaml") . | sha256sum }}

--- a/openstack/backup-replication/templates/deployment-statsd.yaml
+++ b/openstack/backup-replication/templates/deployment-statsd.yaml
@@ -16,8 +16,6 @@ spec:
     metadata:
       labels:
         component: statsd-exporter
-        alert-tier: os
-        alert-service: backup
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap-statsd.yaml") $ | sha256sum }}
         {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}

--- a/openstack/castellum/templates/deployment-api.yaml
+++ b/openstack/castellum/templates/deployment-api.yaml
@@ -20,8 +20,6 @@ spec:
       labels:
         name: castellum-api
         app: castellum-api
-        alert-tier: os
-        alert-service: castellum
       annotations:
         checksum/configmap: {{ include "castellum/templates/configmap.yaml" $ | sha256sum }}
         checksum/secrets: {{ include "castellum/templates/secret.yaml" $ | sha256sum }}

--- a/openstack/castellum/templates/deployment-observer.yaml
+++ b/openstack/castellum/templates/deployment-observer.yaml
@@ -20,8 +20,6 @@ spec:
       labels:
         name: castellum-observer
         app: castellum-observer
-        alert-tier: os
-        alert-service: castellum
       annotations:
         checksum/configmap: {{ include "castellum/templates/configmap.yaml" $ | sha256sum }}
         checksum/secrets: {{ include "castellum/templates/secret.yaml" $ | sha256sum }}

--- a/openstack/castellum/templates/deployment-worker.yaml
+++ b/openstack/castellum/templates/deployment-worker.yaml
@@ -20,8 +20,6 @@ spec:
       labels:
         name: castellum-worker
         app: castellum-worker
-        alert-tier: os
-        alert-service: castellum
       annotations:
         checksum/configmap: {{ include "castellum/templates/configmap.yaml" $ | sha256sum }}
         checksum/secrets: {{ include "castellum/templates/secret.yaml" $ | sha256sum }}

--- a/openstack/keppel-trivy/templates/deployment-api.yaml
+++ b/openstack/keppel-trivy/templates/deployment-api.yaml
@@ -22,8 +22,6 @@ spec:
     metadata:
       labels:
         name: trivy-api
-        alert-tier: os
-        alert-service: keppel
       annotations:
         checksum/secret: {{ include "keppel-trivy/templates/secret.yaml" . | sha256sum }}
         kubectl.kubernetes.io/default-container: trivy-api

--- a/openstack/keppel-trivy/templates/deployment-server.yaml
+++ b/openstack/keppel-trivy/templates/deployment-server.yaml
@@ -19,8 +19,6 @@ spec:
     metadata:
       labels:
         name: trivy-server
-        alert-tier: os
-        alert-service: keppel
       annotations:
         checksum/secret: {{ include "keppel-trivy/templates/secret.yaml" . | sha256sum }}
         kubectl.kubernetes.io/default-container: trivy-server

--- a/openstack/keppel/templates/daemonset-keep-image-pulled.yaml
+++ b/openstack/keppel/templates/daemonset-keep-image-pulled.yaml
@@ -27,8 +27,6 @@ spec:
     metadata:
       labels:
         app: keep-image-pulled
-        alert-tier: os
-        alert-service: keppel
       annotations:
         linkerd.io/inject: disabled # This pod does not interact with the network.
     spec:

--- a/openstack/keppel/templates/deployment-anycast-monitor.yaml
+++ b/openstack/keppel/templates/deployment-anycast-monitor.yaml
@@ -17,8 +17,6 @@ spec:
     metadata:
       labels:
         name: keppel-anycast-monitor
-        alert-tier: os
-        alert-service: keppel
       annotations:
         kubectl.kubernetes.io/default-container: monitor
         prometheus.io/scrape: "true"

--- a/openstack/keppel/templates/deployment-api.yaml
+++ b/openstack/keppel/templates/deployment-api.yaml
@@ -19,8 +19,6 @@ spec:
     metadata:
       labels:
         name: keppel-api
-        alert-tier: os
-        alert-service: keppel
       annotations:
         checksum/configmap: {{ include "keppel/templates/configmap.yaml" . | sha256sum }}
         checksum/secret: {{ include "keppel/templates/secret.yaml" . | sha256sum }}

--- a/openstack/keppel/templates/deployment-health-monitor.yaml
+++ b/openstack/keppel/templates/deployment-health-monitor.yaml
@@ -19,8 +19,6 @@ spec:
     metadata:
       labels:
         name: keppel-health-monitor
-        alert-tier: os
-        alert-service: keppel
       annotations:
         checksum/secret: {{ include "keppel/templates/secret.yaml" . | sha256sum }}
         kubectl.kubernetes.io/default-container: monitor

--- a/openstack/keppel/templates/deployment-janitor.yaml
+++ b/openstack/keppel/templates/deployment-janitor.yaml
@@ -16,8 +16,6 @@ spec:
     metadata:
       labels:
         name: keppel-janitor
-        alert-tier: os
-        alert-service: keppel
       annotations:
         checksum/configmap: {{ include "keppel/templates/configmap.yaml" . | sha256sum }}
         checksum/secret: {{ include "keppel/templates/secret.yaml" . | sha256sum }}

--- a/openstack/limes/templates/deployment-api.yaml
+++ b/openstack/limes/templates/deployment-api.yaml
@@ -23,8 +23,6 @@ spec:
       labels:
         name: limes-api-ccloud
         app: limes-api
-        alert-tier: os
-        alert-service: limes
       annotations:
         checksum/configmap: {{ include "limes/templates/configmap.yaml" . | sha256sum }}
         checksum/secret: {{ include "limes/templates/secret.yaml" . | sha256sum }}

--- a/openstack/limes/templates/deployment-collect.yaml
+++ b/openstack/limes/templates/deployment-collect.yaml
@@ -23,8 +23,6 @@ spec:
       labels:
         name: limes-collect-ccloud
         app: limes-collect
-        alert-tier: os
-        alert-service: limes
       annotations:
         checksum/configmap: {{ include "limes/templates/configmap.yaml" . | sha256sum }}
         checksum/secret: {{ include "limes/templates/secret.yaml" . | sha256sum }}

--- a/openstack/swift-drive-autopilot/templates/daemonset.yaml
+++ b/openstack/swift-drive-autopilot/templates/daemonset.yaml
@@ -25,8 +25,6 @@ spec:
     metadata:
       labels:
         component: swift-drive-autopilot{{$suffix}}
-        alert-tier: os
-        alert-service: swift
         from: daemonset
         release: "{{$.Release.Name}}"
       annotations:

--- a/openstack/swift-utils/templates/account-caretaker-collect-daemonset.yaml
+++ b/openstack/swift-utils/templates/account-caretaker-collect-daemonset.yaml
@@ -21,8 +21,6 @@ spec:
     metadata:
       labels:
         component: swift-account-caretaker-collect
-        alert-tier: os
-        alert-service: swift
         from: daemonset
       annotations:
         checksum/caretaker.etc: {{ include "swift-utils/templates/caretaker-configmap.yaml" . | sha256sum }}

--- a/openstack/swift-utils/templates/account-caretaker-mergify-deployment.yaml
+++ b/openstack/swift-utils/templates/account-caretaker-mergify-deployment.yaml
@@ -20,8 +20,6 @@ spec:
     metadata:
       labels:
         component: swift-account-caretaker-mergify
-        alert-tier: os
-        alert-service: swift
       annotations:
         checksum/caretaker.etc: {{ include "swift-utils/templates/caretaker-configmap.yaml" . | sha256sum }}
         checksum/secret: {{ include "swift-utils/templates/secret.yaml" . | sha256sum }}

--- a/openstack/swift/templates/haproxy-deployment.yaml
+++ b/openstack/swift/templates/haproxy-deployment.yaml
@@ -49,8 +49,6 @@ spec:
     metadata:
       labels:
         component: swift-haproxy-{{ $.Values.cluster_name }}
-        alert-tier: os
-        alert-service: swift
         from: deployment
         os-cluster: {{ $.Values.cluster_name }}
         for-service: swift-proxy-{{ $.Values.cluster_name }}

--- a/openstack/swift/templates/health-exporter-deployment.yaml
+++ b/openstack/swift/templates/health-exporter-deployment.yaml
@@ -22,8 +22,6 @@ spec:
     metadata:
       labels:
         component: swift-health-exporter
-        alert-tier: os
-        alert-service: swift
       annotations:
         {{- include "swift_conf_annotations" . | indent 8 }}
         prometheus.io/scrape: "true"

--- a/openstack/swift/templates/keep-image-pulled-daemonset.yaml
+++ b/openstack/swift/templates/keep-image-pulled-daemonset.yaml
@@ -27,8 +27,6 @@ spec:
     metadata:
       labels:
         app: keep-image-pulled
-        alert-tier: os
-        alert-service: swift
       annotations:
         linkerd.io/inject: disabled # This pod does not interact with the network.
     spec:

--- a/openstack/swift/templates/memcached-deployment.yaml
+++ b/openstack/swift/templates/memcached-deployment.yaml
@@ -21,8 +21,6 @@ spec:
     metadata:
       labels:
         name: swift-{{ $memcached }}
-        alert-tier: os
-        alert-service: swift
     spec:
       containers:
         - name: memcached

--- a/openstack/swift/templates/object-expirer-deployment.yaml
+++ b/openstack/swift/templates/object-expirer-deployment.yaml
@@ -19,8 +19,6 @@ spec:
     metadata:
       labels:
         component: swift-object-expirer
-        alert-tier: os
-        alert-service: swift
       annotations:
         {{- include "swift_conf_annotations" . | indent 8 }}
         prometheus.io/scrape: "true"

--- a/openstack/swift/templates/proxy-daemonset.yaml
+++ b/openstack/swift/templates/proxy-daemonset.yaml
@@ -21,8 +21,6 @@ spec:
     metadata:
       labels:
         component: swift-proxy-{{ .Values.cluster_name }}
-        alert-tier: os
-        alert-service: swift
         from: daemonset
         restart: carefully
         os-cluster: {{ .Values.cluster_name }}

--- a/openstack/swift/templates/proxy-deployment.yaml
+++ b/openstack/swift/templates/proxy-deployment.yaml
@@ -28,8 +28,6 @@ spec:
     metadata:
       labels:
         component: swift-proxy-{{ $.Values.cluster_name }}
-        alert-tier: os
-        alert-service: swift
         from: deployment
         os-cluster: {{ $.Values.cluster_name }}
       annotations:

--- a/openstack/swift/templates/replicators-daemonset.yaml
+++ b/openstack/swift/templates/replicators-daemonset.yaml
@@ -22,8 +22,6 @@ spec:
     metadata:
       labels:
         component: swift-replicators
-        alert-tier: os
-        alert-service: swift
         from: daemonset
         restart: directly
       annotations:

--- a/openstack/swift/templates/rsyncd-daemonset.yaml
+++ b/openstack/swift/templates/rsyncd-daemonset.yaml
@@ -22,8 +22,6 @@ spec:
     metadata:
       labels:
         component: swift-rsyncd
-        alert-tier: os
-        alert-service: swift
         from: daemonset
         restart: directly
       annotations:

--- a/openstack/swift/templates/s3-cache-prewarmer-deployment.yaml
+++ b/openstack/swift/templates/s3-cache-prewarmer-deployment.yaml
@@ -19,8 +19,6 @@ spec:
     metadata:
       labels:
         component: swift-s3-cache-prewarmer-{{ .Values.cluster_name }}
-        alert-tier: os
-        alert-service: swift
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8080"

--- a/openstack/swift/templates/servers-daemonset.yaml
+++ b/openstack/swift/templates/servers-daemonset.yaml
@@ -21,8 +21,6 @@ spec:
     metadata:
       labels:
         component: swift-servers
-        alert-tier: os
-        alert-service: swift
         from: daemonset
         restart: carefully
       annotations:

--- a/openstack/swift/templates/statsd-exporter-daemonset.yaml
+++ b/openstack/swift/templates/statsd-exporter-daemonset.yaml
@@ -22,8 +22,6 @@ spec:
     metadata:
       labels:
         component: swift-statsd-exporter
-        alert-tier: os
-        alert-service: swift
         from: daemonset
         restart: directly
       annotations:

--- a/openstack/swift/templates/workers-daemonset.yaml
+++ b/openstack/swift/templates/workers-daemonset.yaml
@@ -22,8 +22,6 @@ spec:
     metadata:
       labels:
         component: swift-workers
-        alert-tier: os
-        alert-service: swift
         from: daemonset
         restart: directly
       annotations:

--- a/system/absent-metrics-operator/templates/deployment.yaml
+++ b/system/absent-metrics-operator/templates/deployment.yaml
@@ -21,8 +21,6 @@ spec:
         name: absent-metrics-operator
         ccloud/support-group: containers
         ccloud/service: prometheus
-        alert-tier: k8s
-        alert-service: prometheus
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/targets: "kubernetes"

--- a/system/gatekeeper/templates/deployment-doop-image-checker.yaml
+++ b/system/gatekeeper/templates/deployment-doop-image-checker.yaml
@@ -19,8 +19,6 @@ spec:
     metadata:
       labels:
         name: doop-image-checker
-        alert-tier: k8s
-        alert-service: gatekeeper
       annotations:
         kubectl.kubernetes.io/default-container: parser
         {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}

--- a/system/gatekeeper/templates/deployment-helm-manifest-parser.yaml
+++ b/system/gatekeeper/templates/deployment-helm-manifest-parser.yaml
@@ -19,8 +19,6 @@ spec:
     metadata:
       labels:
         name: helm-manifest-parser
-        alert-tier: k8s
-        alert-service: gatekeeper
       annotations:
         kubectl.kubernetes.io/default-container: parser
         {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}

--- a/system/gatekeeper/values.yaml
+++ b/system/gatekeeper/values.yaml
@@ -58,8 +58,6 @@ gatekeeper-upstream:
         cpu: 500m
         memory: 256Mi
 
-  podLabels:
-    alert-tier: k8s
   podAnnotations:
     prometheus.io/scrape: "true"
     prometheus.io/targets: kubernetes

--- a/system/hubcopter/templates/deployment-api.yaml
+++ b/system/hubcopter/templates/deployment-api.yaml
@@ -21,8 +21,6 @@ spec:
     metadata:
       labels:
         name: hubcopter-api-{{ .id }}
-        alert-tier: os
-        alert-service: hubcopter
       annotations:
         checksum/configmap: {{ include "hubcopter/templates/configmap.yaml" $ | sha256sum }}
         checksum/secret: {{ include "hubcopter/templates/secret.yaml" $ | sha256sum }}

--- a/system/hubcopter/templates/deployment-glas.yaml
+++ b/system/hubcopter/templates/deployment-glas.yaml
@@ -16,8 +16,6 @@ spec:
     metadata:
       labels:
         name: glas-api
-        alert-tier: os
-        alert-service: hubcopter
       annotations:
         kubectl.kubernetes.io/default-container: api
     spec:

--- a/system/hubcopter/templates/deployment-html.yaml
+++ b/system/hubcopter/templates/deployment-html.yaml
@@ -19,8 +19,6 @@ spec:
     metadata:
       labels:
         name: hubcopter-html
-        alert-tier: os
-        alert-service: hubcopter
       annotations:
         checksum/configmap: {{ include "hubcopter/templates/configmap-html.yaml" . | sha256sum }}
         kubectl.kubernetes.io/default-container: html

--- a/system/tenso/templates/deployment-api.yaml
+++ b/system/tenso/templates/deployment-api.yaml
@@ -19,8 +19,6 @@ spec:
     metadata:
       labels:
         name: tenso-api
-        alert-tier: os
-        alert-service: tenso
       annotations:
         kubectl.kubernetes.io/default-container: api
         checksum/configmap: {{ include "tenso/templates/configmap.yaml" . | sha256sum }}

--- a/system/tenso/templates/deployment-worker.yaml
+++ b/system/tenso/templates/deployment-worker.yaml
@@ -22,8 +22,6 @@ spec:
     metadata:
       labels:
         name: tenso-worker
-        alert-tier: os
-        alert-service: tenso
       annotations:
         kubectl.kubernetes.io/default-container: worker
         checksum/configmap: {{ include "tenso/templates/configmap.yaml" . | sha256sum }}


### PR DESCRIPTION
The alert-tier/alert-service labels have been superseded by owner-info.