### PR TITLE
ceph: fix hosting.dnsNames placement

### DIFF
--- a/system/cc-ceph/Chart.yaml
+++ b/system/cc-ceph/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cc-ceph
 description: A Helm chart for the Rook / Ceph Objects inside the Storage Clusters
 type: application
-version: 1.0.25
+version: 1.0.26
 appVersion: "1.14.3"
 dependencies:
   - name: owner-info

--- a/system/cc-ceph/templates/cephobjectstore.yaml
+++ b/system/cc-ceph/templates/cephobjectstore.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   metadataPool: {{ toYaml .Values.objectstore.metadataPool | nindent 4 }}
   dataPool: {{ toYaml .Values.objectstore.dataPool | nindent 4 }}
+  hosting:
+    dnsNames: {{ toYaml .Values.objectstore.gateway.dnsNames | nindent 8 }}
   gateway:
     instances: {{ .Values.objectstore.gateway.instances }}
     {{- if .Values.objectstore.gateway.port }}
@@ -15,8 +17,6 @@ spec:
     securePort: {{ .Values.objectstore.gateway.securePort }}
     {{- end }}
     placement:
-      hosting:
-        dnsNames: {{ toYaml .Values.objectstore.gateway.dnsNames | nindent 8 }}
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:
           nodeSelectorTerms:


### PR DESCRIPTION
This fixes the `https://rook-ceph-rgw-ceph-objectstore-XXX.rook-ceph.svc:443/admin/user?format=json&uid=cosi": tls: failed to verify certificate: x509: certificate is valid for *.XXX, XXX, not rook-ceph-rgw-ceph-objectstore-XXX.rook-ceph.svc`