### PR TITLE
ceph: override the default auth order

### DIFF
--- a/system/cc-ceph/Chart.yaml
+++ b/system/cc-ceph/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cc-ceph
 description: A Helm chart for the Rook / Ceph Objects inside the Storage Clusters
 type: application
-version: 1.0.28
+version: 1.0.29
 appVersion: "1.14.3"
 dependencies:
   - name: owner-info

--- a/system/cc-ceph/templates/ceph-config-override.yaml
+++ b/system/cc-ceph/templates/ceph-config-override.yaml
@@ -11,6 +11,7 @@ data:
     [client.rgw.{{ $name }}.a]
     rgw keystone api version = 3
     rgw s3 auth use keystone = true
+    rgw s3 auth order = {{ join "," .auth_order }}
     rgw keystone url = {{ .url }}
     rgw keystone verify ssl = {{ .verify_ssl }}
     rgw keystone implicit tenants = {{ .implicit_tenants }}

--- a/system/cc-ceph/values.yaml
+++ b/system/cc-ceph/values.yaml
@@ -103,6 +103,9 @@ objectstore:
     externalIPs:
       - 10.0.0.1
   keystone:
+    auth_order:
+      - local
+      - external
     enabled: true
     url: http://keystone.local:8083
     verify_ssl: true


### PR DESCRIPTION
This is undocumented option, at least it's not listed in https://docs.ceph.com/en/latest/radosgw/config-ref/
But this option is available in ceph source code:

```
ceph$ grep -r rgw_s3_auth_order
src/rgw/rgw_auth_s3.h:    boost::split(result, cct->_conf->rgw_s3_auth_order,
src/common/options/rgw.yaml.in:- name: rgw_s3_auth_order
```