### PR TITLE
ceph: introduce rgw pod anti affinity

### DIFF
--- a/system/cc-ceph/Chart.yaml
+++ b/system/cc-ceph/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cc-ceph
 description: A Helm chart for the Rook / Ceph Objects inside the Storage Clusters
 type: application
-version: 1.0.30
+version: 1.0.31
 appVersion: "1.14.3"
 dependencies:
   - name: owner-info

--- a/system/cc-ceph/templates/cephobjectstore.yaml
+++ b/system/cc-ceph/templates/cephobjectstore.yaml
@@ -27,6 +27,16 @@ spec:
                   operator: In
                   values:
                     - {{ .Values.osd.nodeRole }}
+      # since the CephCluster's network provider is "host", we need to isolate 80/443 port listeners from each other
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+            - key: app
+              operator: In
+              values:
+              - rook-ceph-rgw
+          topologyKey: kubernetes.io/hostname
     priorityClassName: system-cluster-critical
     sslCertificateRef: {{ .Values.objectstore.gateway.sslCertificateRef }}
     resources: {{ toYaml .Values.objectstore.gateway.resources | nindent 6 }}


### PR DESCRIPTION
since the CephCluster's network provider is "host", we need to isolate 80/443 port listeners from each other
https://github.com/sapcc/helm-charts/blob/2ad73ac764c7cc83bfdbbf8f8ca33d43e7020b3c/system/cc-ceph/templates/cephcluster.yaml#L41-L42