### PR TITLE
[ironic] Configure ESP with default bootloader

### DIFF
--- a/openstack/ironic/templates/etc/_ironic_conductor.conf.tpl
+++ b/openstack/ironic/templates/etc/_ironic_conductor.conf.tpl
@@ -6,6 +6,9 @@
 {{- $deploy_port :=  $conductor.tftp_ip | default .Values.tftp_ip | default .Values.global.ironic_tftp_ip }}
 [DEFAULT]
 host = ironic-conductor-{{$conductor.name}}
+{{- if $conductor.esp_image_path }}
+esp_image = https://repo.{{ .Values.global.region }}.{{ .Values.global.tld }}/{{ trimPrefix "/" $conductor.esp_image_path }}
+{{- end }}
 
 {{- if $conductor.enabled_drivers }}
 enabled_drivers = {{ $conductor.enabled_drivers}}

--- a/openstack/ironic/values.yaml
+++ b/openstack/ironic/values.yaml
@@ -175,6 +175,11 @@ conductor:
     port: 8088
     erase_devices_priority: 0
   defaults:
+    # Default image for ESP. Can be overridden with `driver_info.bootloader`
+    # on a node-by-node basis. OS needs to match `grub_config_path`
+    # (as long as the image is based on grub and not syslinux)
+    esp_image_path: ironic-tftp/esp-ubuntu-x86_64.img
+
     default:
       enabled_hardware_types: ipmi, idrac, redfish
       enabled_boot_interfaces: pxe, ipxe, idrac-redfish-virtual-media, redfish-virtual-media
@@ -192,6 +197,11 @@ conductor:
       # enables collecting metrics for rpc calls
       statsd_enabled: false
       statsd_port: 9125
+
+      # That depends on os version used in the bootloader image / inspector
+      # Since the our loci images are based on ubuntu default to that for now
+      # Cross-check os name with `esp_image_path`
+      grub_config_path: 'EFI/ubuntu/grub.cfg'
     dhcp: {}
     pxe:
       kernel_append_params: "ipa-hardware-initialization-delay=120 console=tty0 console=ttyS0,115200 nofb nomodeset vga=normal"


### PR DESCRIPTION
This only affects deployments with a virtual-media interface.

It is a missing input for creating a bootable iso with the ironic-python-agent inside.
The kernel and ramdisk are already specified, this just is the bootloader used in the ISO created on the fly containing also the token or certificate for authentication
This value can be overidden by setting a deploy-config value for "bootloader".