### PR TITLE
nova/flavors: Add general-purpose sapphire-rapids flavors

### DIFF
--- a/openstack/sap-seeds/templates/flavor-seed.yaml
+++ b/openstack/sap-seeds/templates/flavor-seed.yaml
@@ -6,6 +6,8 @@ spec:
   requires:
   - monsoon3/nova-flavor-seed
   flavors:
+
+  # Internal "forced" Flavor for forcing a host.
   - name: "forced"
     id: "1"
     vcpus: 1
@@ -14,6 +16,8 @@ spec:
     is_public: false
     extra_specs:
       {{- tuple . "forced" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+
+  # Regular Flavors v1 (Cascade-Lake)
   - name: "m1.tiny"
     id: "10"
     vcpus: 1
@@ -435,6 +439,461 @@ spec:
     extra_specs:
       "catalog:alias": "m5.64xlarge"
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+
+
+  # Regular Flavors v2 (Sapphire-Rapids)
+  - name: "m1.tiny_v2"
+    id: "401"
+    vcpus: 1
+    ram: 508
+    disk: 1
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" (dict "hw_video:ram_max_mb" 4) | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "g_c1_m2_v2"
+    id: "402"
+    vcpus: 1
+    ram: 2032
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "c_c2_m2_v2"
+    id: "403"
+    vcpus: 2
+    ram: 2032
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "g_c2_m4_v2"
+    id: "404"
+    vcpus: 2
+    ram: 4080
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "g_c1_m3_v2"
+    id: "405"
+    vcpus: 1
+    ram: 3056
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "g_c1_m4_v2"
+    id: "406"
+    vcpus: 1
+    ram: 4080
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "g_c2_m8_v2"
+    id: "407"
+    vcpus: 2
+    ram: 8176
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "c_c4_m4_v2"
+    id: "408"
+    vcpus: 4
+    ram: 4080
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "g_c4_m8_v2"
+    id: "409"
+    vcpus: 4
+    ram: 8176
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "g_c4_m16_v2"
+    id: "410"
+    vcpus: 4
+    ram: 16368
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "c_c16_m16_v2"
+    id: "411"
+    vcpus: 16
+    ram: 16368
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "g_c6_m24_v2"
+    id: "412"
+    vcpus: 6
+    ram: 24560
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "g_c8_m32_v2"
+    id: "413"
+    vcpus: 8
+    ram: 32752
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "g_c16_m32_v2"
+    id: "414"
+    vcpus: 16
+    ram: 32752
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "g_c12_m48_v2"
+    id: "415"
+    vcpus: 12
+    ram: 49136
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "g_c16_m64_v2"
+    id: "416"
+    vcpus: 16
+    ram: 65520
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "m1.10xlarge_v2"
+    id: "417"
+    vcpus: 40
+    ram: 163824
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "m1.10xlargesmallcpu_v2"
+    id: "418"
+    vcpus: 16
+    ram: 163824
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "m_c8_m128_v2"
+    id: "419"
+    vcpus: 8
+    ram: 131056
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "m_c16_m256_v2"
+    id: "420"
+    vcpus: 16
+    ram: 262128
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "m_c32_m512_v2"
+    id: "421"
+    vcpus: 32
+    ram: 524272
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "x1.8xmemory_v2"
+    id: "422"
+    vcpus: 64
+    ram: 1048560
+    disk: 64
+    is_public: false
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "m_c4_m64_v2"
+    id: "423"
+    vcpus: 4
+    ram: 65520
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "g_c8_m16_v2"
+    id: "424"
+    vcpus: 8
+    ram: 16368
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "m2.2xlarge_v2"
+    id: "425"
+    vcpus: 8
+    ram: 24560
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "m2.2xlarge_cpu_v2"
+    id: "426"
+    vcpus: 24
+    ram: 24560
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "m2.10xlarge_cpu_v2"
+    id: "427"
+    vcpus: 24
+    ram: 262128
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "m2.14xlarge_cpu_v2"
+    id: "428"
+    vcpus: 24
+    ram: 327680
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "m2.14xlarge_cpuhdd_v2"
+    id: "429"
+    vcpus: 24
+    ram: 327680
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "m2.3xlarge_v2"
+    id: "430"
+    vcpus: 8
+    ram: 49136
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "m_c2_m16_v2"
+    id: "431"
+    vcpus: 2
+    ram: 16368
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "m_c8_m64_v2"
+    id: "432"
+    vcpus: 8
+    ram: 65520
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "m_c8_m256_v2"
+    id: "433"
+    vcpus: 8
+    ram: 262128
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "m_c20_m160_v2"
+    id: "434"
+    vcpus: 20
+    ram: 163824
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "m_c24_m192_v2"
+    id: "435"
+    vcpus: 24
+    ram: 196592
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "m_c16_m128_v2"
+    id: "436"
+    vcpus: 16
+    ram: 131056
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "m2.16xlarge_v2"
+    id: "437"
+    vcpus: 16
+    ram: 204800
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "m_c16_m512_v2"
+    id: "438"
+    vcpus: 16
+    ram: 524272
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "g_c32_m128_v2"
+    id: "439"
+    vcpus: 32
+    ram: 131056
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "g_c48_m192_v2"
+    id: "440"
+    vcpus: 48
+    ram: 196592
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "m5.xlarge2hdd_v2"
+    id: "441"
+    vcpus: 4
+    ram: 16368
+    disk: 150
+    is_public: false
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "m5.12xlarge_v2"
+    id: "442"
+    vcpus: 48
+    ram: 524272
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "m5.14xlarge_v2"
+    id: "443"
+    vcpus: 60
+    ram: 524272
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "m_c32_m256_v2"
+    id: "444"
+    vcpus: 32
+    ram: 262128
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "m_c64_m512_v2"
+    id: "445"
+    vcpus: 64
+    ram: 524272
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "g_c64_m256_v2"
+    id: "446"
+    vcpus: 64
+    ram: 262128
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "m_c48_m512_v2"
+    id: "447"
+    vcpus: 48
+    ram: 524272
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "g_c128_m512_v2"
+    id: "448"
+    vcpus: 128
+    ram: 524272
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "m5.48xlarge_v2"
+    id: "449"
+    vcpus: 96
+    ram: 1048560
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "m_c128_m1000_v2"
+    id: "450"
+    vcpus: 128
+    ram: 1048560
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+
+
 
   ### HANA flavors
 {{- if .Values.use_hana_exclusive }}


### PR DESCRIPTION
Use a new CUSTOM_HW_SAPPHIRE_RAPIDS trait to distinguish the new generation. The flavor may change in the future, or use a true automatic COMPUTE_ flavor from nova, but use a manual trait to get started.
