### PR TITLE
[rabbitmq] sharedservices.labels component name fixed

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -3,6 +3,12 @@ Rabbitmq CHANGELOG
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+0.7.1
+------
+birk.bohne@sap.com
+- `app.kubernetes.io/component` label fixed by using the `.Chart.Name` variable instead of a hardcoded value
+- defined functions are shared between all (sub)charts and because of that hardcoded values will cause unexpected behavior
+
 0.6.13
 ------
 dusan.dordevic@sap.com

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 0.7.0
+version: 0.7.1
 description: A Helm chart for RabbitMQ
 sources:
 - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/templates/_helpers.tpl
+++ b/common/rabbitmq/templates/_helpers.tpl
@@ -92,6 +92,6 @@ rabbit://{{ default "" $envAll.Values.global.user_suffix | print $rabbitmq.users
 app.kubernetes.io/name: {{ .Chart.Name }}
 app.kubernetes.io/instance: {{ .Chart.Name }}-{{ .Release.Name }}
 app.kubernetes.io/version: {{ .Chart.Version }}
-app.kubernetes.io/component: RabbitMQ
+app.kubernetes.io/component: {{ .Chart.Name }}
 app.kubernetes.io/part-of: {{ .Release.Name }}
 {{- end }}


### PR DESCRIPTION
- defined functions are shared across all subcharts
- hardcoded values will lead to wrong results
- chart version bumped