### PR TITLE
GkVulnerableImages: group violations for linkerd sidecar pods under service "linkerd"

### DIFF
--- a/system/gatekeeper/templates/constrainttemplate-vulnerable-images.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-vulnerable-images.yaml
@@ -78,7 +78,7 @@ spec:
           check.error != ""
         }
 
-        violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
+        violation[{"msg": add_support_labels_with_overrides(iro, check, msg)}] {
           check := checks[_]
           check.error == ""
           status := trim_space(object.get(check.headers, input.parameters.vulnStatusHeader, "Unclear"))
@@ -91,4 +91,22 @@ spec:
             "image %s for container %q has \"%s: %s\"",
             [check.containerImage, check.containerName, input.parameters.vulnStatusHeader, status]
           )
+        }
+
+        # extend add_support_labels.from_k8s_object() with some special cases for this specific policy
+        add_support_labels_with_overrides(iro, check, msg) = result {
+          # default behavior
+          not is_linkerd_sidecar_pod(check)
+          result := add_support_labels.from_k8s_object(iro, msg)
+        }
+        add_support_labels_with_overrides(iro, check, msg) = result {
+          # vulns in linkerd sidecar pods are not actionable for the actual pod owner until linkerd is updated centrally
+          is_linkerd_sidecar_pod(check)
+          result := sprintf("{\"support_group\":\"containers\",\"service\":\"linkerd\"} >> %s", [msg])
+        }
+
+        default is_linkerd_sidecar_pod(check) = false
+        is_linkerd_sidecar_pod(check) = true {
+          regex.match("^keppel\\.[^/]*/ccloud/servicemesh/proxy", check.containerImage)
+          regex.match("^linkerd-", check.containerName)
         }

--- a/system/gatekeeper/tests/gatekeeper-policies/fixtures/vulnerable-images/pod-vulnerable-in-linkerd.yaml
+++ b/system/gatekeeper/tests/gatekeeper-policies/fixtures/vulnerable-images/pod-vulnerable-in-linkerd.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dummy
+  labels:
+    ccloud/support-group: foo-group
+    ccloud/service: dummy
+  # The vulnerable-images-on-pod check explicitly wants to see all the pods, without suppressing owned pods!
+  # The running pod may use different images from what the pod spec implies because referenced image tags
+  # may have been overwritten since the pod was started.
+  ownerReferences:
+  - apiVersion: apps/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: ReplicaSet
+    name: dummy-819861372
+    uid: 72aa456e-c3aa-4de7-bbb0-bb547cfaac7d
+status:
+  containerStatuses:
+    - image: keppel.example.com/ccloud/servicemesh/proxy:low
+      imageID: docker-pullable://keppel.example.com/ccloud/servicemesh/proxy:low@sha256:0000000000000000000000000000000000000000000000000000000000000000
+      name: linkerd-proxy
+      ready: true
+      restartCount: 0
+    - image: keppel.example.com/vulnerability:clean
+      imageID: docker-pullable://keppel.example.com/vulnerability:clean@sha256:0000000000000000000000000000000000000000000000000000000000000000
+      name: application
+      ready: true
+      restartCount: 0
+  initContainerStatuses:
+    - image: keppel.example.com/ccloud/servicemesh/proxy-init:high
+      imageID: docker-pullable://keppel.example.com/ccloud/servicemesh/proxy-init:high@sha256:0000000000000000000000000000000000000000000000000000000000000000
+      name: linkerd-init
+      ready: true
+      restartCount: 0

--- a/system/gatekeeper/tests/gatekeeper-policies/response-config.yaml
+++ b/system/gatekeeper/tests/gatekeeper-policies/response-config.yaml
@@ -20,6 +20,14 @@ keppel.example.com/vulnerability:old@sha256:000000000000000000000000000000000000
   # older than slightly over a year (~13 months)
   X-Keppel-Max-Layer-Created-At: "-10000h"
   X-Keppel-Min-Layer-Created-At: "-10000h"
+keppel.example.com/ccloud/servicemesh/proxy:low@sha256:0000000000000000000000000000000000000000000000000000000000000000:
+  X-Keppel-Max-Layer-Created-At: "-1h"
+  X-Keppel-Min-Layer-Created-At: "-1h"
+  X-Keppel-Vulnerability-Status: Low
+keppel.example.com/ccloud/servicemesh/proxy-init:high@sha256:0000000000000000000000000000000000000000000000000000000000000000:
+  X-Keppel-Max-Layer-Created-At: "-1h"
+  X-Keppel-Min-Layer-Created-At: "-1h"
+  X-Keppel-Vulnerability-Status: High
 
 # These entries are for image references that we pull from the container spec.
 # They do not include manifest digests, since container specs usually reference tags only.

--- a/system/gatekeeper/tests/gatekeeper-policies/suite.yaml
+++ b/system/gatekeeper/tests/gatekeeper-policies/suite.yaml
@@ -692,6 +692,13 @@ tests:
       message: '^\{"support_group":"foo-group","service":"dummy"\} >> image keppel.example.com/vulnerability:medium for container "dummymedium" has "X-Keppel-Vulnerability-Status: Medium"$'
     - violations: 1
       message: '^\{"support_group":"foo-group","service":"dummy"\} >> image keppel.example.com/vulnerability:high for container "starter" has "X-Keppel-Vulnerability-Status: High"$'
+  - name: pod-vulnerable-in-linkerd
+    object: fixtures/vulnerable-images/pod-vulnerable-in-linkerd.yaml
+    assertions:
+    - violations: 1
+      message: '^\{"support_group":"containers","service":"linkerd"\} >> image keppel.example.com/ccloud/servicemesh/proxy:low for container "linkerd-proxy" has "X-Keppel-Vulnerability-Status: Low"$'
+    - violations: 1
+      message: '^\{"support_group":"containers","service":"linkerd"\} >> image keppel.example.com/ccloud/servicemesh/proxy-init:high for container "linkerd-init" has "X-Keppel-Vulnerability-Status: High"$'
   - name: pod-unclear
     object: fixtures/vulnerable-images/pod-unclear.yaml
     assertions:


### PR DESCRIPTION
As a service owner, I don't want linkerd violations spamming my Greenhouse view if I cannot do anything about them myself until linkerd is centrally updated.