### PR TITLE
Bump fluent-bit in kube-monitoring-* charts

### DIFF
--- a/system/kube-monitoring-admin-k3s/Chart.lock
+++ b/system/kube-monitoring-admin-k3s/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 0.3.4
 - name: fluent-bit
   repository: https://fluent.github.io/helm-charts
-  version: 0.46.2
+  version: 0.46.7
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 5.19.0
@@ -50,5 +50,5 @@ dependencies:
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
   version: 3.13.0
-digest: sha256:7bf9f79ce8544276a8d3011fd22dc13c6f80a429f9efe1142fc2a5347684e243
-generated: "2024-05-14T16:24:28.206088+02:00"
+digest: sha256:1781af5925643949d803282d35d0c3a966edbd9f2bfe9dd8edb4a8b50fe05815
+generated: "2024-05-22T09:53:48.418212753+02:00"

--- a/system/kube-monitoring-admin-k3s/Chart.yaml
+++ b/system/kube-monitoring-admin-k3s/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes admin k3s cluster monitoring.
 name: kube-monitoring-admin-k3s
-version: 4.5.19
+version: 4.5.20
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-admin-k3s
 dependencies:
   - condition: absent-metrics-operator.enabled
@@ -14,7 +14,7 @@ dependencies:
     version: 0.3.4
   - name: fluent-bit
     repository: https://fluent.github.io/helm-charts
-    version: 0.46.2
+    version: 0.46.7
   - name: kube-state-metrics
     repository: https://prometheus-community.github.io/helm-charts
     version: 5.19.0

--- a/system/kube-monitoring-kubernikus/Chart.lock
+++ b/system/kube-monitoring-kubernikus/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 0.3.4
 - name: fluent-bit
   repository: https://fluent.github.io/helm-charts
-  version: 0.46.2
+  version: 0.46.7
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 5.19.0
@@ -59,5 +59,5 @@ dependencies:
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
   version: 3.13.0
-digest: sha256:0645c13222ed79e79b1422edf5d63c52716603822a35854d279fdc42702eb033
-generated: "2024-05-14T16:24:47.926249+02:00"
+digest: sha256:2a0d51de7c10d53d0be5f14d390eeee45b7fe95314f803ecdc218b4dabb42252
+generated: "2024-05-22T09:54:23.50569971+02:00"

--- a/system/kube-monitoring-kubernikus/Chart.yaml
+++ b/system/kube-monitoring-kubernikus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for monitoring Kubernikus.
 name: kube-monitoring-kubernikus
-version: 7.7.19
+version: 7.7.20
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-kubernikus
 dependencies:
   - condition: absent-metrics-operator.enabled
@@ -14,7 +14,7 @@ dependencies:
     version: 0.3.4
   - name: fluent-bit
     repository: https://fluent.github.io/helm-charts
-    version: 0.46.2
+    version: 0.46.7
   - name: kube-state-metrics
     repository: https://prometheus-community.github.io/helm-charts
     version: 5.19.0

--- a/system/kube-monitoring-scaleout/Chart.lock
+++ b/system/kube-monitoring-scaleout/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 1.0.0
 - name: fluent-bit
   repository: https://fluent.github.io/helm-charts
-  version: 0.46.2
+  version: 0.46.7
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 5.19.0
@@ -16,7 +16,7 @@ dependencies:
   version: 1.0.0
 - name: ntp-exporter
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 2.5.0
+  version: 2.6.0
 - name: oomkill-exporter
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
@@ -50,5 +50,5 @@ dependencies:
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
   version: 3.13.0
-digest: sha256:81b2e4ca0ce696bf04cdbde45aa53844fab135aa61a14551fef975508b26f8b5
-generated: "2024-05-21T11:18:26.442333+02:00"
+digest: sha256:1b44e6d87e4c17a432878d494739e7fd1263dd0ab114934cfab840d7d03390c3
+generated: "2024-05-22T09:55:07.95314237+02:00"

--- a/system/kube-monitoring-scaleout/Chart.yaml
+++ b/system/kube-monitoring-scaleout/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kubernetes scaleout cluster monitoring.
 name: kube-monitoring-scaleout
-version: 4.10.13
+version: 4.10.14
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-scaleout
 dependencies:
   - condition: absent-metrics-operator.enabled
@@ -13,7 +13,7 @@ dependencies:
     version: "^1.x"
   - name: fluent-bit
     repository: https://fluent.github.io/helm-charts
-    version: 0.46.2
+    version: 0.46.7
     condition: fluent-bit.enabled
   - name: kube-state-metrics
     repository: https://prometheus-community.github.io/helm-charts

--- a/system/kube-monitoring-virtual/Chart.lock
+++ b/system/kube-monitoring-virtual/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 0.3.4
 - name: fluent-bit
   repository: https://fluent.github.io/helm-charts
-  version: 0.46.2
+  version: 0.46.7
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 5.19.0
@@ -53,5 +53,5 @@ dependencies:
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
   version: 3.13.0
-digest: sha256:0ebc51f880582f58cef9749a03fac54aa68b9f33b6eb17d606574fc1801a77fe
-generated: "2024-05-14T16:24:06.646236+02:00"
+digest: sha256:bdba978cfd33781ee81b2b4a47dbefcd2d512c82780f2ba1a0469d85ab2eac55
+generated: "2024-05-22T09:55:40.430107852+02:00"

--- a/system/kube-monitoring-virtual/Chart.yaml
+++ b/system/kube-monitoring-virtual/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes virtual cluster monitoring.
 name: kube-monitoring-virtual
-version: 6.8.19
+version: 6.8.20
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-virtual
 dependencies:
   - condition: absent-metrics-operator.enabled
@@ -14,7 +14,7 @@ dependencies:
     version: 0.3.4
   - name: fluent-bit
     repository: https://fluent.github.io/helm-charts
-    version: 0.46.2
+    version: 0.46.7
   - name: kube-state-metrics
     repository: https://prometheus-community.github.io/helm-charts
     version: 5.19.0


### PR DESCRIPTION
Bumps the version and fixes some CVE, see https://github.com/fluent/helm-charts/pull/508