### PR TITLE
[cc3test]: skipped few inbound and outbound ports for linkerd to make compute and other tests working

### DIFF
--- a/openstack/cc3test/templates/cronjob-api.yaml
+++ b/openstack/cc3test/templates/cronjob-api.yaml
@@ -17,6 +17,8 @@ spec:
         metadata:
           annotations:
             linkerd.io/inject: enabled
+            config.linkerd.io/skip-inbound-ports: "22,443,9125"
+            config.linkerd.io/skip-outbound-ports: "22,443,9125"
         {{- end }}
         spec:
           volumes:

--- a/openstack/cc3test/templates/cronjob-automation-purger.yaml
+++ b/openstack/cc3test/templates/cronjob-automation-purger.yaml
@@ -17,6 +17,8 @@ spec:
         metadata:
           annotations:
             linkerd.io/inject: enabled
+            config.linkerd.io/skip-inbound-ports: "22,443,9125"
+            config.linkerd.io/skip-outbound-ports: "22,443,9125"
         {{- end }}
         spec:
           volumes:

--- a/openstack/cc3test/templates/cronjob-automation.yaml
+++ b/openstack/cc3test/templates/cronjob-automation.yaml
@@ -16,6 +16,8 @@ spec:
         metadata:
           annotations:
             linkerd.io/inject: enabled
+            config.linkerd.io/skip-inbound-ports: "22,443,9125"
+            config.linkerd.io/skip-outbound-ports: "22,443,9125"
         {{- end }}
         spec:
           volumes:

--- a/openstack/cc3test/templates/cronjob-baremetal-purger.yaml
+++ b/openstack/cc3test/templates/cronjob-baremetal-purger.yaml
@@ -17,6 +17,8 @@ spec:
         metadata:
           annotations:
             linkerd.io/inject: enabled
+            config.linkerd.io/skip-inbound-ports: "22,443,9125"
+            config.linkerd.io/skip-outbound-ports: "22,443,9125"
         {{- end }}
         spec:
           volumes:

--- a/openstack/cc3test/templates/cronjob-baremetal.yaml
+++ b/openstack/cc3test/templates/cronjob-baremetal.yaml
@@ -16,6 +16,8 @@ spec:
         metadata:
           annotations:
             linkerd.io/inject: enabled
+            config.linkerd.io/skip-inbound-ports: "22,443,9125"
+            config.linkerd.io/skip-outbound-ports: "22,443,9125"
         {{- end }}
         spec:
           volumes:

--- a/openstack/cc3test/templates/cronjob-blockstorage-purger.yaml
+++ b/openstack/cc3test/templates/cronjob-blockstorage-purger.yaml
@@ -17,6 +17,8 @@ spec:
         metadata:
           annotations:
             linkerd.io/inject: enabled
+            config.linkerd.io/skip-inbound-ports: "22,443,9125"
+            config.linkerd.io/skip-outbound-ports: "22,443,9125"
         {{- end }}
         spec:
           volumes:

--- a/openstack/cc3test/templates/cronjob-blockstorage-volume.yaml
+++ b/openstack/cc3test/templates/cronjob-blockstorage-volume.yaml
@@ -16,6 +16,8 @@ spec:
         metadata:
           annotations:
             linkerd.io/inject: enabled
+            config.linkerd.io/skip-inbound-ports: "22,443,9125"
+            config.linkerd.io/skip-outbound-ports: "22,443,9125"
         {{- end }}
         spec:
           volumes:

--- a/openstack/cc3test/templates/cronjob-blockstorage.yaml
+++ b/openstack/cc3test/templates/cronjob-blockstorage.yaml
@@ -16,6 +16,8 @@ spec:
         metadata:
           annotations:
             linkerd.io/inject: enabled
+            config.linkerd.io/skip-inbound-ports: "22,443,9125"
+            config.linkerd.io/skip-outbound-ports: "22,443,9125"
         {{- end }}
         spec:
           volumes:

--- a/openstack/cc3test/templates/cronjob-certificate.yaml
+++ b/openstack/cc3test/templates/cronjob-certificate.yaml
@@ -16,6 +16,8 @@ spec:
         metadata:
           annotations:
             linkerd.io/inject: enabled
+            config.linkerd.io/skip-inbound-ports: "22,443,9125"
+            config.linkerd.io/skip-outbound-ports: "22,443,9125"
         {{- end }}
         spec:
           volumes:

--- a/openstack/cc3test/templates/cronjob-compute-purger.yaml
+++ b/openstack/cc3test/templates/cronjob-compute-purger.yaml
@@ -17,6 +17,8 @@ spec:
         metadata:
           annotations:
             linkerd.io/inject: enabled
+            config.linkerd.io/skip-inbound-ports: "22,443,9125"
+            config.linkerd.io/skip-outbound-ports: "22,443,9125"
         {{- end }}
         spec:
           volumes:

--- a/openstack/cc3test/templates/cronjob-compute-server.yaml
+++ b/openstack/cc3test/templates/cronjob-compute-server.yaml
@@ -16,6 +16,8 @@ spec:
         metadata:
           annotations:
             linkerd.io/inject: enabled
+            config.linkerd.io/skip-inbound-ports: "22,443,9125"
+            config.linkerd.io/skip-outbound-ports: "22,443,9125"
         {{- end }}
         spec:
           volumes:

--- a/openstack/cc3test/templates/cronjob-compute.yaml
+++ b/openstack/cc3test/templates/cronjob-compute.yaml
@@ -16,6 +16,8 @@ spec:
         metadata:
           annotations:
             linkerd.io/inject: enabled
+            config.linkerd.io/skip-inbound-ports: "22,443,9125"
+            config.linkerd.io/skip-outbound-ports: "22,443,9125"
         {{- end }}
         spec:
           volumes:

--- a/openstack/cc3test/templates/cronjob-datapath.yaml
+++ b/openstack/cc3test/templates/cronjob-datapath.yaml
@@ -17,6 +17,8 @@ spec:
         metadata:
           annotations:
             linkerd.io/inject: enabled
+            config.linkerd.io/skip-inbound-ports: "22,443,9125"
+            config.linkerd.io/skip-outbound-ports: "22,443,9125"
         {{- end }}
         spec:
           volumes:

--- a/openstack/cc3test/templates/cronjob-datastore.yaml
+++ b/openstack/cc3test/templates/cronjob-datastore.yaml
@@ -16,6 +16,8 @@ spec:
         metadata:
           annotations:
             linkerd.io/inject: enabled
+            config.linkerd.io/skip-inbound-ports: "22,443,9125"
+            config.linkerd.io/skip-outbound-ports: "22,443,9125"
         {{- end }}
         spec:
           volumes:

--- a/openstack/cc3test/templates/cronjob-dns-purger.yaml
+++ b/openstack/cc3test/templates/cronjob-dns-purger.yaml
@@ -17,6 +17,8 @@ spec:
         metadata:
           annotations:
             linkerd.io/inject: enabled
+            config.linkerd.io/skip-inbound-ports: "22,443,9125"
+            config.linkerd.io/skip-outbound-ports: "22,443.9125"
         {{- end }}
         spec:
           volumes:

--- a/openstack/cc3test/templates/cronjob-dns.yaml
+++ b/openstack/cc3test/templates/cronjob-dns.yaml
@@ -16,6 +16,8 @@ spec:
         metadata:
           annotations:
             linkerd.io/inject: enabled
+            config.linkerd.io/skip-inbound-ports: "22,443,9125"
+            config.linkerd.io/skip-outbound-ports: "22,443,9125"
         {{- end }}
         spec:
           volumes:

--- a/openstack/cc3test/templates/cronjob-fileshare-purger.yaml
+++ b/openstack/cc3test/templates/cronjob-fileshare-purger.yaml
@@ -17,6 +17,8 @@ spec:
         metadata:
           annotations:
             linkerd.io/inject: enabled
+            config.linkerd.io/skip-inbound-ports: "22,443,9125"
+            config.linkerd.io/skip-outbound-ports: "22,443,9125"
         {{- end }}
         spec:
           volumes:

--- a/openstack/cc3test/templates/cronjob-fileshare.yaml
+++ b/openstack/cc3test/templates/cronjob-fileshare.yaml
@@ -16,6 +16,8 @@ spec:
         metadata:
           annotations:
             linkerd.io/inject: enabled
+            config.linkerd.io/skip-inbound-ports: "22,443,9125"
+            config.linkerd.io/skip-outbound-ports: "22,443,9125"
         {{- end }}
         spec:
           volumes:

--- a/openstack/cc3test/templates/cronjob-hermes.yaml
+++ b/openstack/cc3test/templates/cronjob-hermes.yaml
@@ -16,6 +16,8 @@ spec:
         metadata:
           annotations:
             linkerd.io/inject: enabled
+            config.linkerd.io/skip-inbound-ports: "22,443,9125"
+            config.linkerd.io/skip-outbound-ports: "22,443,9125"
         {{- end }}
         spec:
           volumes:

--- a/openstack/cc3test/templates/cronjob-integrity.yaml
+++ b/openstack/cc3test/templates/cronjob-integrity.yaml
@@ -16,6 +16,8 @@ spec:
         metadata:
           annotations:
             linkerd.io/inject: enabled
+            config.linkerd.io/skip-inbound-ports: "22,443,9125"
+            config.linkerd.io/skip-outbound-ports: "22,443,9125"
         {{- end }}
         spec:
           volumes:

--- a/openstack/cc3test/templates/cronjob-key-manager-purger.yaml
+++ b/openstack/cc3test/templates/cronjob-key-manager-purger.yaml
@@ -17,6 +17,8 @@ spec:
         metadata:
           annotations:
             linkerd.io/inject: enabled
+            config.linkerd.io/skip-inbound-ports: "22,443,9125"
+            config.linkerd.io/skip-outbound-ports: "22,443,9125"
         {{- end }}
         spec:
           volumes:

--- a/openstack/cc3test/templates/cronjob-key-manager.yaml
+++ b/openstack/cc3test/templates/cronjob-key-manager.yaml
@@ -16,6 +16,8 @@ spec:
         metadata:
           annotations:
             linkerd.io/inject: enabled
+            config.linkerd.io/skip-inbound-ports: "22,443,9125"
+            config.linkerd.io/skip-outbound-ports: "22,443,9125"
         {{- end }}
         spec:
           volumes:

--- a/openstack/cc3test/templates/cronjob-loadbalancer-purger.yaml
+++ b/openstack/cc3test/templates/cronjob-loadbalancer-purger.yaml
@@ -17,6 +17,8 @@ spec:
         metadata:
           annotations:
             linkerd.io/inject: enabled
+            config.linkerd.io/skip-inbound-ports: "22,443,9125"
+            config.linkerd.io/skip-outbound-ports: "22,443,9125"
         {{- end }}
         spec:
           volumes:

--- a/openstack/cc3test/templates/cronjob-loadbalancer.yaml
+++ b/openstack/cc3test/templates/cronjob-loadbalancer.yaml
@@ -16,6 +16,8 @@ spec:
         metadata:
           annotations:
             linkerd.io/inject: enabled
+            config.linkerd.io/skip-inbound-ports: "22,443,9125"
+            config.linkerd.io/skip-outbound-ports: "22,443,9125"
         {{- end }}
         spec:
           volumes:

--- a/openstack/cc3test/templates/cronjob-network-segmentation.yaml
+++ b/openstack/cc3test/templates/cronjob-network-segmentation.yaml
@@ -16,6 +16,8 @@ spec:
           metadata:
             annotations:
               linkerd.io/inject: enabled
+              config.linkerd.io/skip-inbound-ports: "22,443,9125"
+              config.linkerd.io/skip-outbound-ports: "22,443,9125"
           {{- end }}
           spec:
             volumes:

--- a/openstack/cc3test/templates/cronjob-neutron-purger.yaml
+++ b/openstack/cc3test/templates/cronjob-neutron-purger.yaml
@@ -17,6 +17,8 @@ spec:
         metadata:
           annotations:
             linkerd.io/inject: enabled
+            config.linkerd.io/skip-inbound-ports: "22,443,9125"
+            config.linkerd.io/skip-outbound-ports: "22,443,9125"
         {{- end }}
         spec:
           volumes:

--- a/openstack/cc3test/templates/cronjob-neutron.yaml
+++ b/openstack/cc3test/templates/cronjob-neutron.yaml
@@ -16,6 +16,8 @@ spec:
         metadata:
           annotations:
             linkerd.io/inject: enabled
+            config.linkerd.io/skip-inbound-ports: "22,443,9125"
+            config.linkerd.io/skip-outbound-ports: "22,443,9125"
         {{- end }}
         spec:
           volumes:


### PR DESCRIPTION
ports that are skipped 
22,443,9125