### PR TITLE
limes: increase collector memory limit yet again

### DIFF
--- a/openstack/limes/templates/deployment-collect.yaml
+++ b/openstack/limes/templates/deployment-collect.yaml
@@ -63,8 +63,8 @@ spec:
             # observed usage: CPU = 50m-500m, RAM = 100 MiB in small regions, spikes up to more than 750 MiB in large regions
             limits:
                 cpu: '1000m'
-                memory: '1000Mi'
+                memory: '1500Mi'
             requests:
                 cpu: '400m'
-                memory: '1000Mi'
+                memory: '1500Mi'
           {{- end }}


### PR DESCRIPTION
This is getting out of hand. I will make a ticket to investigate the ridiculously high memory usage.