### PR TITLE
nova/flavors: Remove CUSTOM_BIGVM=2 requirement from < 1024 GiB flavors

### DIFF
--- a/openstack/sap-seeds/templates/_flavors_hana_no_exclusive.tpl
+++ b/openstack/sap-seeds/templates/_flavors_hana_no_exclusive.tpl
@@ -115,7 +115,6 @@
   disk: 64
   extra_specs:
     {{ tuple . "vmware_common" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
-    "resources:CUSTOM_BIGVM": "2"
     "trait:CUSTOM_NUMASIZE_C60_M480": "required"
     "hw:cpu_cores": "30"   # used in nova-vmware as cores-per-socket (15pCPU = 30vCPU)
     "vmware:hw_version": "vmx-18"
@@ -130,7 +129,6 @@
   disk: 64
   extra_specs:
     {{ tuple . "vmware_common" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
-    "resources:CUSTOM_BIGVM": "2"
     "trait:CUSTOM_NUMASIZE_C60_M480": "required"
     "hw:cpu_cores": "60"   # used in nova-vmware as cores-per-socket (30pCPU = 60vCPU)
     "vmware:hw_version": "vmx-18"
@@ -145,7 +143,6 @@
   disk: 64
   extra_specs:
     {{ tuple . "vmware_common" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
-    "resources:CUSTOM_BIGVM": "2"
     "trait:CUSTOM_NUMASIZE_C60_M480": "required"
     "hw:cpu_cores": "60"   # used in nova-vmware as cores-per-socket (30pCPU = 60vCPU)
     "vmware:hw_version": "vmx-18"
@@ -160,7 +157,6 @@
   disk: 64
   extra_specs:
     {{ tuple . "vmware_common" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
-    "resources:CUSTOM_BIGVM": "2"
     "trait:CUSTOM_NUMASIZE_C60_M960": "required"
     "hw:cpu_cores": "30"   # used in nova-vmware as cores-per-socket (15pCPU = 30vCPU)
     "vmware:hw_version": "vmx-18"
@@ -175,7 +171,6 @@
   disk: 64
   extra_specs:
     {{ tuple . "vmware_common" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
-    "resources:CUSTOM_BIGVM": "2"
     "trait:CUSTOM_NUMASIZE_C60_M960": "required"
     "hw:cpu_cores": "60"   # used in nova-vmware as cores-per-socket (30pCPU = 60vCPU)
     "vmware:hw_version": "vmx-18"


### PR DESCRIPTION
Some of the new sapphire rapids hana_* flavors required `resources:CUSTOM_BIGVM` while they are too small to be seen as big VMs by Nova. Therefore, they allocated the resource in Placement, but Nova didn't run the cleanup that's necessary after spawn.

Therefore, we're removing the `resources:CUSTOM_BIGVM` requirement from all hana_* flavors with < 1024 GiB RAM again.