### PR TITLE
[Nova] Set sapphire_rapids_weight_multiplier

### DIFF
--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -274,6 +274,11 @@ scheduler:
   # Hosts having the CUSTOM_DECOMMISSIONING trait should be used only if it's
   # absolutely necessary. Positive values are decreasing the weight in this case.
   decommissioning_weight_multiplier: 150.0
+  # Hosts having the CUSTOM_HW_SAPPHIRE_RAPIDS trait should be used only if
+  # there are no other usable hosts for this flavor. Positive values decrease
+  # the weight in this case.
+  sapphire_rapids_weight_multiplier: 100.0
+
   image_properties_default_architecture: "x86_64"
 
 compute:


### PR DESCRIPTION
We want old general purpose flavors to land on old hardware if possible. Therefore, we increase the weight of the SapphireRapidsWeigher - which decreases their priority.

I decided to use the same value as we use for
`hv_ram_class_weight_multiplier` as they seem to be pretty similar in what they want to achieve to me. I still want CUSTOM_DECOMMISSIONING to be higher. Going lower than 100, we might end up on small sapphire rapids (which can exist in theory) much easier.