### PR TITLE
openstack-seeder: allow ignoring or focusing on multiple namespaces

### DIFF
--- a/openstack/openstack-seeder/templates/bin/_start.tpl
+++ b/openstack/openstack-seeder/templates/bin/_start.tpl
@@ -37,4 +37,4 @@ export OS_DOMAIN_ID={{ .Values.keystone.domainId }}
 export OS_REGION={{.Values.global.region}}
 
 echo "Starting openstack-seeder.."
-/usr/local/bin/openstack-seeder --logtostderr --v {{ default 1 .Values.logLevel }} --resync {{ default "24h" .Values.resync | quote }} {{- if .Values.dryRun }} --dry-run{{- end }} {{- if .Values.ignoreNamespace }} --ignorenamespace={{- .Values.ignoreNamespace }}{{- end }} {{- if .Values.onlyNamespace }} --onlynamespace={{- .Values.onlyNamespace }}{{- end }}
+/usr/local/bin/openstack-seeder --logtostderr --v {{ default 1 .Values.logLevel }} --resync {{ default "24h" .Values.resync | quote }} {{- if .Values.dryRun }} --dry-run{{- end }} {{- range (.Values.ignoreNamespace | splitList ",") }}{{- if . }} --ignorenamespace={{- . }}{{- end }}{{- end }} {{- range (.Values.onlyNamespace | splitList ",") }}{{- if . }} --onlynamespace={{- . }}{{- end }}{{- end }}

--- a/openstack/openstack-seeder/values.yaml
+++ b/openstack/openstack-seeder/values.yaml
@@ -34,10 +34,10 @@ owner-info:
 
 # only simulate, don't actually seed
 # dryRun: true
-# ignore seeds from a certain k8s namespace
-ignoreNamespace: monsoon3global
-# only apply seeds from a certain k8s namespace
-# onlyNamespace: monsoon3global
+# ignore seeds from a certain k8s namespace (or multiple namespaces, if a comma-separated list is given like below)
+ignoreNamespace: "limes-global,monsoon3global"
+# only apply seeds from a certain k8s namespace (or multiple namespaces, if a comma-separated list is given like above)
+onlyNamespace: ""
 
 keystone:
   #authUrl: http://identity.cluster.cloud.sap/v3


### PR DESCRIPTION
This requires the patch from <https://github.com/sapcc/kubernetes-operators/pull/105> to be applied.

I chose to leave `ignoreNamespace` and `onlyNamespace` as stringly-typed for backwards compatibility with the existing regional values files. If desired, I can also change this to take array arguments, in which case slightly more care needs to merge and deploy this and the respective secrets PR at the same time.

I tested this with `helm diff upgrade` in eu-de-2 (both normal and global deployment) and saw the desired diff.