### PR TITLE
Update cephcluster.yaml

### DIFF
--- a/system/cc-ceph/Chart.yaml
+++ b/system/cc-ceph/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cc-ceph
 description: A Helm chart for the Rook / Ceph Objects inside the Storage Clusters
 type: application
-version: 1.0.46
+version: 1.0.47
 appVersion: "1.14.3"
 dependencies:
   - name: owner-info

--- a/system/cc-ceph/templates/cephcluster.yaml
+++ b/system/cc-ceph/templates/cephcluster.yaml
@@ -12,7 +12,7 @@ spec:
     count: {{ .Values.mon.count }}
     allowMultiplePerNode: false
   mgr:
-    count: 1
+    count: 2
     allowMultiplePerNode: false
     modules:
       - name: rook
@@ -64,6 +64,15 @@ spec:
                   operator: In
                   values:
                     - {{ .Values.mgr.nodeRole }}
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+            - key: app
+              operator: In
+              values:
+              - rook-ceph-mgr
+          topologyKey: kubernetes.io/hostname
     mon:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:
@@ -73,6 +82,15 @@ spec:
                   operator: In
                   values:
                     - {{ .Values.mon.nodeRole }}
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+            - key: app
+              operator: In
+              values:
+              - rook-ceph-mon
+          topologyKey: kubernetes.io/hostname
     osd:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
podantiaffinity is required rule when host network is used or when AllowMultiplePerNode is false.  good to have 2 mgr pods for HA.