### PR TITLE
[Octavia] Enable ccroot DB user

### DIFF
--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -368,3 +368,7 @@ vpa:
   # The maximum available capacity is split evenly across containers specified in the Deployment, StatefulSet or DaemonSet to derive the upper recommendation bound. This does not work out for pods with a single resource-hungry container with several sidecar containers
   # Annotate the Deployment, StatefulSet or DaemonSet with vpa-butler.cloud.sap/main-container=$MAIN_CONTAINER. That will distribute 75% of the maximum available capacity to the main container and the rest evenly across all others
   set_main_container: true
+
+# root DB access
+ccroot_user:
+  enabled: true


### PR DESCRIPTION
Similar to Neutron (#6406), enable ccroot DB user (mariadb chart feature introduced in #6297).