### PR TITLE
[designate-nanny] adding designate-global permissions for designate nanny user

### DIFF
--- a/openstack/designate/templates/seeds.yaml
+++ b/openstack/designate/templates/seeds.yaml
@@ -986,6 +986,11 @@ spec:
     - user: admin@Default
       role: cloud_dns_admin
       inherited: true
+{{- if .Values.nanny_enabled }}
+    - user: {{ required "missing user for designate_nanny in .Values.designate_nanny.credentials.designate_api.user" .Values.designate_nanny.credentials.designate_api.user}}@{{.Values.designate_nanny.credentials.designate_api.project_user_domain_name }}
+      role: cloud_dns_viewer
+      inherited: true
+{{- end }}
 {{- end }}
 
 {{- if .Values.nanny_enabled }}


### PR DESCRIPTION
This gives the configured designate nanny user in the `Default ` namespace the `cloud_dns_viewer` role in the global namespace.

This follows roles assignment for the other users and should enable dumping the dns zones there as well for backing them up.