### PR TITLE
[manila] configure vpa for mariadb

### DIFF
--- a/openstack/manila/values.yaml
+++ b/openstack/manila/values.yaml
@@ -632,6 +632,8 @@ mariadb:
   resources:
     requests:
       memory: 6144Mi
+  vpa:
+    set_main_container: true
   backup_v2:
     enabled: true
     databases:


### PR DESCRIPTION
Enable `set_main_container` config for mariadb chart, giving the
mariadb container 75% of its pod's resources.
