### PR TITLE
explicitly enabling cors delete

### DIFF
--- a/global/prometheus-alertmanager-operated/Chart.yaml
+++ b/global/prometheus-alertmanager-operated/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 description: Prometheus Alertmanager via operator.
 name: prometheus-alertmanager-operated
-version: 4.1.0
+version: 4.1.1
 
 dependencies:
   - alias: prometheus-alertmanager

--- a/global/prometheus-alertmanager-operated/values.yaml
+++ b/global/prometheus-alertmanager-operated/values.yaml
@@ -38,6 +38,11 @@ prometheus-alertmanager:
     # Will be expanded to https://alertmanager-internal.$region.$domain .
     host: alertmanager-internal
 
+    annotations:
+      ingress.kubernetes.io/cors-allow-headers: Content-Type
+      ingress.kubernetes.io/cors-allow-methods: DELETE
+      ingress.kubernetes.io/enable-cors: "true"
+
   alerts:
     prometheus: infra-frontend
 


### PR DESCRIPTION
this is needed for accepting DELETE requests against AM api. Previously our nginx didn\’t let them through