### PR TITLE
[ironic] Fix bootloader location

### DIFF
--- a/openstack/ironic/py/ironic-node-update.py
+++ b/openstack/ironic/py/ironic-node-update.py
@@ -1,10 +1,15 @@
 from contextlib import contextmanager
+from urllib.parse import urlparse
+
 from ironicclient import client as bmclient
 
 # import openstack # To test it locally
 # os = openstack.connect()
 
 bm = bmclient.get_client(1, session=os.session, os_ironic_api_version="1.78")
+
+parsed = urlparse(os.session.auth.auth_url)
+domain = parsed.netloc.split(".", 1)[-1]
 
 states = ["enroll", "active", "manageable", "available"]
 
@@ -127,6 +132,10 @@ for node in bm.node.list(
             {
                 "path": "/driver_info/redfish_password",
                 "value": password,
+            },
+            {
+                "path": "/driver_info/bootloader",
+                "value": f"https://repo.{domain}/ironic-tftp/esp-ubuntu-x86_64.img",
             },
         ]
 

--- a/openstack/ironic/templates/etc/_ironic_conductor.conf.tpl
+++ b/openstack/ironic/templates/etc/_ironic_conductor.conf.tpl
@@ -6,9 +6,6 @@
 {{- $deploy_port :=  $conductor.tftp_ip | default .Values.tftp_ip | default .Values.global.ironic_tftp_ip }}
 [DEFAULT]
 host = ironic-conductor-{{$conductor.name}}
-{{- if $conductor.esp_image_path }}
-esp_image = https://repo.{{ .Values.global.region }}.{{ .Values.global.tld }}/{{ trimPrefix "/" $conductor.esp_image_path }}
-{{- end }}
 
 {{- if $conductor.enabled_drivers }}
 enabled_drivers = {{ $conductor.enabled_drivers}}

--- a/openstack/ironic/values.yaml
+++ b/openstack/ironic/values.yaml
@@ -175,11 +175,6 @@ conductor:
     port: 8088
     erase_devices_priority: 0
   defaults:
-    # Default image for ESP. Can be overridden with `driver_info.bootloader`
-    # on a node-by-node basis. OS needs to match `grub_config_path`
-    # (as long as the image is based on grub and not syslinux)
-    esp_image_path: ironic-tftp/esp-ubuntu-x86_64.img
-
     default:
       enabled_hardware_types: ipmi, idrac, redfish
       enabled_boot_interfaces: pxe, ipxe, idrac-redfish-virtual-media, redfish-virtual-media


### PR DESCRIPTION
The esp_image_path needs to be local to the conductor, the driver_info.bootloader can be remote.

One option might be to add it simply to the image, but this seems quicker.