### PR TITLE
[archer] - update fastl4 profile name

### DIFF
--- a/openstack/archer/templates/configmap-f5.yaml
+++ b/openstack/archer/templates/configmap-f5.yaml
@@ -24,5 +24,5 @@ data:
     {{- end }}
     physical_network = {{ .physical_network }}
     tcp_profile = /Common/cc_tcp_archer_profile
-    l4_profile = /Common/cc_fastL4_profile
+    l4_profile = /Common/cc_fastL4_noaging_profile
 {{- end }}


### PR DESCRIPTION
Due to the need to be "nice" to the long running connections commonly used between for example IBP and HanaCloud, we crafted the "noaging" fastL4 profile, with adjusted PVA handling, TCP idle timeout and TCP keep alive interval.
Profile name is `cc_fastL4_noaging_profile` and it's already rolled out to all Archer Big-IPs globally.