### PR TITLE
[ironic] Increase timeout for ramdisks

### DIFF
--- a/openstack/ironic/templates/etc/_ironic_conductor.conf.tpl
+++ b/openstack/ironic/templates/etc/_ironic_conductor.conf.tpl
@@ -60,6 +60,11 @@ tftp_root = /tftpboot
 
 ipxe_config_template = /etc/ironic/ipxe_config.template
 
+[redfish]
+{{- range $k, $v :=  $conductor.redfish }}
+{{ $k }} = {{ $v }}
+{{- end }}
+
 {{- if $conductor.jinja2 }}
 {{`
 {%- for section in block %}

--- a/openstack/ironic/values.yaml
+++ b/openstack/ironic/values.yaml
@@ -206,6 +206,8 @@ conductor:
       ipxe_bootfile_name: "undionly.kpxe"
       uefi_pxe_bootfile_name: "ipxe.efi"
       uefi_ipxe_bootfile_name: "ipxe.efi"
+    redfish:
+      swift_object_expiry_timeout: "5400"
 
 agent:
   deploy_logs:


### PR DESCRIPTION
The default of 15minutes is quite sporty for our use-case. Increasing the the timeout to 1.5hours to be on the safe-side.