### PR TITLE
[memcached] increase default cpu limit to 0,5

### DIFF
--- a/common/memcached/Chart.yaml
+++ b/common/memcached/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: memcached
-version: 0.3.1
+version: 0.3.2
 description: Free & open source, high-performance, distributed memory object caching system.
 home: http://memcached.org/
 sources:

--- a/common/memcached/values.yaml
+++ b/common/memcached/values.yaml
@@ -40,7 +40,7 @@ resources:
   enabled: true
   limits:
     memory: 2048Mi
-    cpu: 100m
+    cpu: 500m
   requests:
     memory: 1024Mi
     cpu: 50m


### PR DESCRIPTION
- default 0,1 is even less than the limit for metrics container.
- cpu-throttled at least for nova in large regions.