### PR TITLE
[keystone] blocklist dns_hostmaster, dns_zonemaster, dns_mailmaster

### DIFF
--- a/openstack/keystone/templates/etc/_policy.yaml.tpl
+++ b/openstack/keystone/templates/etc/_policy.yaml.tpl
@@ -39,6 +39,9 @@
   'cloud_dns_admin':%(target.role.name)s or
   'cloud_dns_viewer':%(target.role.name)s or
   'dns_admin':%(target.role.name)s or
+  'dns_hostmaster':%(target.role.name)s or
+  'dns_zonemaster':%(target.role.name)s or
+  'dns_mailmaster':%(target.role.name)s or
   'cloud_image_admin':%(target.role.name)s or
   'cloud_compute_admin':%(target.role.name)s or
   'cloud_keymanager_admin':%(target.role.name)s or


### PR DESCRIPTION
A normal project admin should not be able to give themselves and others these roles.

The CoreDNS team is granting them per ticket:
https://documentation.global.cloud.sap/docs/customer/networking/dns/dns-start-roles/