### PR TITLE
limes: Increase RAM limit

### DIFF
--- a/openstack/limes/templates/deployment-api.yaml
+++ b/openstack/limes/templates/deployment-api.yaml
@@ -88,7 +88,7 @@ spec:
               memory: '700Mi'
               {{- else }}
               cpu: '500m'
-              memory: '1Gi'
+              memory: '700Mi'
               {{- end }}
             requests:
               cpu: '250m'

--- a/openstack/limes/templates/deployment-api.yaml
+++ b/openstack/limes/templates/deployment-api.yaml
@@ -85,7 +85,7 @@ spec:
               # deployments. A full project report with `?detail` for that
               # domain is about 160 MiB of pure JSON.
               cpu: '1'
-              memory: '1Gi'
+              memory: '700Mi'
               {{- else }}
               cpu: '500m'
               memory: '1Gi'

--- a/openstack/limes/templates/deployment-api.yaml
+++ b/openstack/limes/templates/deployment-api.yaml
@@ -85,10 +85,10 @@ spec:
               # deployments. A full project report with `?detail` for that
               # domain is about 160 MiB of pure JSON.
               cpu: '1'
-              memory: '500Mi'
+              memory: '1Gi'
               {{- else }}
               cpu: '500m'
-              memory: '500Mi'
+              memory: '1Gi'
               {{- end }}
             requests:
               cpu: '250m'


### PR DESCRIPTION
The limes API Pod gets OOM killed. This PR increase the limit from 500Mi to ~~1Gi~~ 700Mi.