### PR TITLE
[memcached] bump version to 1.6.28; add external_ip option.

### DIFF
--- a/common/memcached/Chart.yaml
+++ b/common/memcached/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: memcached
-version: 0.3.2
+version: 0.3.3
 description: Free & open source, high-performance, distributed memory object caching system.
 home: http://memcached.org/
 sources:

--- a/common/memcached/Chart.yaml
+++ b/common/memcached/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: memcached
-version: 0.3.3
+version: 0.4.0
 description: Free & open source, high-performance, distributed memory object caching system.
 home: http://memcached.org/
 sources:

--- a/common/memcached/templates/service.yaml
+++ b/common/memcached/templates/service.yaml
@@ -19,9 +19,13 @@ metadata:
     prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
     {{- end }}
 spec:
+  selector:
+    app: {{ template "fullname" . }}
   ports:
   - name: memcache
     port: {{ default "11211" .Values.memcached.port }}
     targetPort: memcache
-  selector:
-    app: {{ template "fullname" . }}
+{{- if .Values.external_ip }}
+  externalIPs:
+    - {{ .Values.external_ip }}
+{{- end }}

--- a/common/memcached/values.yaml
+++ b/common/memcached/values.yaml
@@ -2,7 +2,7 @@
 ## ref: https://hub.docker.com/r/library/memcached/tags/
 ##
 image: library/memcached
-imageTag: 1.6.21-alpine
+imageTag: 1.6.28-alpine
 # set to true to use .Values.global.dockerHubMirrorAlternateRegion instead of .Values.global.dockerHubMirror
 use_alternate_registry: false
 
@@ -17,6 +17,9 @@ imagePullPolicy: IfNotPresent
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 ##
 nodeAffinity: {}
+
+# Optionally set externalIP for service:
+#external_ip: ''
 
 # name of priorityClass to influence scheduling priority
 # false = disabled


### PR DESCRIPTION
- 1.6.21 is 1-year old by now.
- external_ip needed for global designate/keystone