### PR TITLE
[mariadb]: tcp_keepalive options added

### DIFF
--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.11.1
+version: 0.12.0

--- a/common/mariadb/templates/etc-configmap.yaml
+++ b/common/mariadb/templates/etc-configmap.yaml
@@ -59,6 +59,9 @@ data:
     log_bin                   = mysqld-bin
     log_slow_admin_statements = OFF
 {{- end }}
+    tcp_keepalive_time        = {{ .Values.tcp_keepalive.time | default 0 | int }}
+    tcp_keepalive_probes      = {{ .Values.tcp_keepalive.probes | default 0 | int }}
+    tcp_keepalive_interval    = {{ .Values.tcp_keepalive.interval | default 0 | int }}
 {{- if .Values.extraConfigFiles }}
 {{ toYaml .Values.extraConfigFiles | indent 2 }}
 {{- end }}

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -188,3 +188,14 @@ linkerd:
     #linkerd annotation for the backup pod (true/false)
     enabled: true
 global: {}
+
+tcp_keepalive:
+  # Timeout, in seconds, with no activity until the first TCP keep-alive packet is sent. If set to 0, a system dependent default is used https://mariadb.com/kb/en/server-system-variables/#tcp_keepalive_time
+  # default is 0
+  time:
+  # The number of unacknowledged probes to send before considering the connection dead and notifying the application layer. If set to 0, a system dependent default is used https://mariadb.com/kb/en/server-system-variables/#tcp_keepalive_probes
+  # default is 0
+  probes:
+  # Time between retries of unacknowledged keepalive packets. If set to 0, the system dependent default is used https://mariadb.com/kb/en/server-system-variables/#tcp_keepalive_interval
+  # default is 0
+  interval:


### PR DESCRIPTION
- to support network setups that close idle connections after some time
- default values kept at `0`
- documentation snippets added
- tested locally with `helm template`
- chart version bumped