### PR TITLE
[manila] fix prom alert OpenstackManilaApiRatelimitExceeded

### DIFF
--- a/openstack/manila/alerts/openstack/manila.alerts
+++ b/openstack/manila/alerts/openstack/manila.alerts
@@ -267,7 +267,7 @@ groups:
       meta: manila api rate limits exceeded
       service: manila
       severity: info
-      no_alert_on_absence: true
+      no_alert_on_absence: "true"
       tier: os
       support_group: compute-storage-api
     annotations:


### PR DESCRIPTION
```
labels.no_alert_on_absence in body must be of type starting
```
