### PR TITLE
Keystone: subproject management

### DIFF
--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: keystone
 sources:
   - https://github.com/sapcc/keystone
-version: 0.6.4
+version: 0.6.5
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/keystone/templates/etc/_policy.yaml.tpl
+++ b/openstack/keystone/templates/etc/_policy.yaml.tpl
@@ -937,7 +937,7 @@
 # POST  /v3/projects
 # Intended scope(s): system, domain
 #"identity:create_project": "(role:admin and system_scope:all) or (role:admin and domain_id:%(target.project.domain_id)s)"
-"identity:create_project": "rule:cloud_admin or (role:admin and domain_id:%(target.project.domain_id)s)"
+"identity:create_project": "rule:cloud_admin or (role:admin and domain_id:%(target.project.domain_id)s) or (role:admin and project_id:%(target.project.parent_id)s)"
 
 # Update project.
 # PATCH  /v3/projects/{project_id}

--- a/openstack/keystone/templates/etc/_policy.yaml.tpl
+++ b/openstack/keystone/templates/etc/_policy.yaml.tpl
@@ -1362,7 +1362,9 @@
 # Intended scope(s): system, domain
 #"identity:list_users": "(role:reader and system_scope:all) or (role:reader and domain_id:%(target.domain_id)s)"
 "identity:list_users": "rule:cloud_reader or
-  (role:reader and domain_id:%(target.domain_id)s)"
+  (role:reader and domain_id:%(target.domain_id)s) or
+  project_domain_id:%(target.domain_id)s or
+  user_domain_id:%(target.domain_id)s"
 
 # List all projects a user has access to via role assignments.
 # GET   /v3/auth/projects

--- a/openstack/keystone/templates/etc/_policy.yaml.tpl
+++ b/openstack/keystone/templates/etc/_policy.yaml.tpl
@@ -443,10 +443,10 @@
 "domain_admin_for_domain_role_grants": "rule:admin_required and domain_id:%(target.role.domain_id)s and rule:domain_admin_grant_match"
 "domain_admin_grant_match": "domain_id:%(domain_id)s or domain_id:%(target.project.domain_id)s"
 "project_admin_for_grants": "(rule:project_admin_for_global_role_grants or rule:project_admin_for_domain_role_grants) and not rule:blocklist_roles and not rule:blocklist_projects"
-"project_admin_for_global_role_grants": "(rule:admin_required or role:role_admin) and None:%(target.role.domain_id)s and project_id:%(project_id)s"
-"project_admin_for_domain_role_grants": "(rule:admin_required or role:role_admin) and project_domain_id:%(target.role.domain_id)s and project_id:%(project_id)s"
+"project_admin_for_global_role_grants": "(rule:admin_required or role:role_admin) and None:%(target.role.domain_id)s and (project_id:%(project_id)s or project_id:%(target.project.parent_id)s)"
+"project_admin_for_domain_role_grants": "(rule:admin_required or role:role_admin) and project_domain_id:%(target.role.domain_id)s and (project_id:%(project_id)s or project_id:%(target.project.parent_id)s)"
 "domain_admin_for_list_grants": "rule:admin_required and rule:domain_admin_grant_match"
-"project_admin_for_list_grants": "(rule:admin_required or role:role_admin or role:role_viewer) and project_id:%(project_id)s"
+"project_admin_for_list_grants": "(rule:admin_required or role:role_admin or role:role_viewer) and (project_id:%(project_id)s or project_id:%(target.project.parent_id)s)"
 
 # Check a role grant between a target and an actor. A target can be
 # either a domain or a project. An actor can be either a user or a

--- a/openstack/keystone/templates/etc/_policy.yaml.tpl
+++ b/openstack/keystone/templates/etc/_policy.yaml.tpl
@@ -950,7 +950,7 @@
 # Intended scope(s): system, domain
 #"identity:delete_project": "(role:admin and system_scope:all) or (role:admin and domain_id:%(target.project.domain_id)s)"
 # The corresponding `prodel` service details are available on GitHub under `cc/prodel`
-"identity:delete_project": "(rule:cloud_admin or (rule:admin_required and project_id:%(project_id)s)) and ({{- if .Values.tempest.enabled }}domain_id:{{.Values.tempest.domainId}} or {{ end }}{{ .Values.prodel.url }})"
+"identity:delete_project": "(rule:cloud_admin or (rule:admin_required and (project_id:%(project_id)s or project_id:%(target.project.parent_id)s))) and ({{- if .Values.tempest.enabled }}domain_id:{{.Values.tempest.domainId}} or {{ end }}{{ .Values.prodel.url }})"
 
 # List tags for a project.
 # GET  /v3/projects/{project_id}/tags

--- a/openstack/keystone/templates/etc/_policy.yaml.tpl
+++ b/openstack/keystone/templates/etc/_policy.yaml.tpl
@@ -923,7 +923,8 @@
 # Intended scope(s): system, domain
 #"identity:list_projects": "(role:reader and system_scope:all) or (role:reader and domain_id:%(target.domain_id)s)"
 "identity:list_projects": "rule:cloud_reader or
-  (role:reader and domain_id:%(target.domain_id)s)"
+  (role:reader and domain_id:%(target.domain_id)s) or
+  (role:reader and project_id:%(target.parent_id)s)"
 
 # List projects for user.
 # GET  /v3/users/{user_id}/projects


### PR DESCRIPTION
This set of patches allows project admins to manage their projects and role assignments on these projects without having to scope to the subprojets