### PR TITLE
limes: alert when extremely high usage disables quota overcommit

### DIFF
--- a/openstack/limes/alerts/openstack/capacity.alerts
+++ b/openstack/limes/alerts/openstack/capacity.alerts
@@ -7,7 +7,7 @@ groups:
   rules:
 
   - alert: LimesBlockedCapacityAbove80Percent
-    expr: last_over_time(limes_capacity_blocked_percent[15m]) > 80 and on (service, resource) (last_over_time(limes_autogrow_growth_multiplier[15m])) > 1
+    expr: (last_over_time(limes_capacity_blocked_percent[15m]) > 80) and on (service, resource) (last_over_time(limes_autogrow_growth_multiplier[15m]) > 1)
     for: 10m
     labels:
       severity: info
@@ -18,6 +18,21 @@ groups:
       description: |
         In AZ {{ $labels.availability_zone }}, more than 80% of all {{ $labels.service }}/{{ $labels.resource }}
         capacity is blocked by commitments or provisioned usage. Please check if hardware needs to be ordered.
+
+  - alert: LimesBlockedCapacityDangerouslyHigh
+    expr: (last_over_time(limes_capacity_blocked_percent[15m]) > on (service, resource) last_over_time(limes_autogrow_quota_overcommit_threshold_percent[15m])) and on (service, resource) (last_over_time(limes_autogrow_growth_multiplier[15m]) > 1)
+    for: 10m
+    labels:
+      severity: warning
+      service: capacity-ops
+      support_group: capacity-ops
+    annotations:
+      summary: "Blocked capacity approaching 100% on an autogrowing resource"
+      description: |
+        In AZ {{ $labels.availability_zone }}, nearly all {{ $labels.service }}/{{ $labels.resource }}
+        capacity is blocked by commitments or provisioned usage.
+        Limes has disabled quota overcommit to safeguard the deployability of committed resources, so new projects will not get any base quota anymore.
+        Please check if hardware needs to be ordered.
 
   - alert: LimesPendingCommitments
     expr: sum by (availability_zone, service, resource) (last_over_time(limes_project_committed_per_az{state="pending"}[15m])) > 0


### PR DESCRIPTION
This depends on the `limes_autogrow_quota_overcommit_threshold_percent` metric which is introduced by <https://github.com/sapcc/limes/pull/484>.