### PR TITLE
[mariadb-galera] fix persistent volume permissions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,7 @@
 /common/linkerd-support                                @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /common/manila-provisioner                             @jknipper  # old
 /common/mariadb                                        @galkindmitrii @stefanhipfel @Carthaca @IvoGoman @fwiesel @businessbean @occamshatchet
+/common/mariadb-galera                                 @businessbean @bashar-alkhateeb
 /common/memcached                                      @auhlig @businessbean @bashar-alkhateeb
 /common/mysql-metrics                                  @galkindmitrii @Carthaca
 /common/nats                                           @notandy

--- a/common/mariadb-galera/CHANGELOG.md
+++ b/common/mariadb-galera/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.27.1 - 2024/06/18
+* fix fs permissions of persistent volumes
+  * add privileged init container to mariadb statefulset to change files owner of the persistent volumes
+  * add privileged init container to proxysql statefulset to change files owner of the persistent volumes
 ## v0.27.0 - 2024/04/30
 * [wsrep_desync](https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_desync) for backups made optional
   * `mariadb.galera.backup.desyncBackupNode` controls that feature

--- a/common/mariadb-galera/README.md
+++ b/common/mariadb-galera/README.md
@@ -46,7 +46,7 @@ Docker images and Helm chart to deploy a [MariaDB](https://mariadb.com/kb/en/get
 ## Metadata
 | chart version | app version | type | url |
 |:--------------|:-------------|:-------------|:-------------|
-| 0.27.0 | 10.5.23 | application | [Git repo](https://github.com/sapcc/helm-charts/tree/mariadb-galera/common/mariadb-galera) |
+| 0.27.1 | 10.5.23 | application | [Git repo](https://github.com/sapcc/helm-charts/tree/mariadb-galera/common/mariadb-galera) |
 
 | Name | Email | Url |
 | ---- | ------ | --- |
@@ -166,7 +166,7 @@ docker build --build-arg BASE_SOFT_NAME=ubuntu --build-arg BASE_SOFT_VERSION=22.
   ```
 * [push](https://helm.sh/docs/topics/registries/#the-push-subcommand) the chart to the registry
   ```shell
-  helm push mariadb-galera-0.27.0.tgz oci://keppel.eu-de-1.cloud.sap/ccloud-helm/
+  helm push mariadb-galera-0.27.1.tgz oci://keppel.eu-de-1.cloud.sap/ccloud-helm/
   ```
 
 ### values description
@@ -312,6 +312,10 @@ docker build --build-arg BASE_SOFT_NAME=ubuntu --build-arg BASE_SOFT_VERSION=22.
 | image.pullSecrets.secretname.registry | string | `nil` | the hostname of the container registry that should be used for the pull secret |
 | initContainers.cleanoscache.securityContext.privileged | bool | `true` | required to configure `/proc/sys/vm/drop_caches` in the init phase |
 | initContainers.cleanoscache.securityContext.runAsUser | int | 0 | required to configure `/proc/sys/vm/drop_caches` in the init phase |
+| initContainers.fixMariaDBFsPermissions.securityContext.privileged | bool | `true` | required to fix FS permissions of mariadb persistent volumes in the init phase |
+| initContainers.fixMariaDBFsPermissions.securityContext.runAsUser | int | 0 | required to fix FS permissions of mariadb persistent volumes in the init phase |
+| initContainers.fixProxysqlFsPermissions.securityContext.privileged | bool | `true` | required to fix FS permissions of porxysql persistent volumes in the init phase |
+| initContainers.fixProxysqlFsPermissions.securityContext.runAsUser | int | 0 | required to fix FS permissions of porxysql persistent volumes in the init phase |
 | initContainers.increaseMapCount.securityContext.privileged | bool | `true` | required to configure `/proc/sys/vm/max_map_count` in the init phase |
 | initContainers.increaseMapCount.securityContext.runAsUser | int | 0 | required to configure `/proc/sys/vm/max_map_count` in the init phase |
 | initContainers.tcpKeepAlive.securityContext.privileged | bool | `true` | required to configure `net.ipv4.tcp_keepalive_time` in the init phase |
@@ -347,6 +351,7 @@ docker build --build-arg BASE_SOFT_NAME=ubuntu --build-arg BASE_SOFT_VERSION=22.
 | mariadb.databases.sb_oltp_ro.enabled | bool | `false` | enable this database |
 | mariadb.databases.sb_oltp_ro.overwrite | bool | false | overwrite the database if it already exists |
 | mariadb.errorLogWarningVerbosity | int | 2 | to define the [verbosity](https://mariadb.com/kb/en/error-log/#configuring-the-error-log-verbosity) of the MariaDB logs |
+| mariadb.fixFsPermissions | bool | `false` | fix the permissions of the persistent volumes and set the ownership of the FS to mariadb the value defined in `mariadb.database.userId:mariadb.database.groupId` or to default `uid:gid - 101:101` |
 | mariadb.galera.backup.desyncBackupNode | bool | `true` | Enable [wsrep_desync](https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_desync) before the backup and disable it after the backup. This can avoid performance issues during the backup, because flow control will be disabled for the backup node. The disadvantage is that the backup node is not usable for queries during the backup. |
 | mariadb.galera.backup.enabled | bool | `false` | enable the [database backup](#database-backup). Should be done within custom instance configuration files |
 | mariadb.galera.backup.kopia.backend | string | `"s3"` | Openstack Swift and others provide an S3 compatible interface |
@@ -554,6 +559,7 @@ docker build --build-arg BASE_SOFT_NAME=ubuntu --build-arg BASE_SOFT_VERSION=22.
 | proxy.haproxy.users.stats.username | string | `nil` | HAProxy stats user username |
 | proxy.proxysql.adminui.enabled | bool | `true` | the [ProxySQL Admin UI](https://proxysql.com/documentation/http-web-server/) |
 | proxy.proxysql.adminui.verbosity | int | `0` | the variable defines the [verbosity level](https://proxysql.com/documentation/global-variables/admin-variables/#admin-web_verbosity) of the web server |
+| proxy.proxysql.fixFsPermissions | bool | `false` | fix the permissions of the persistent volumes and set the ownership of the FS to mariadb the value defined in `Values.userId.proxy:Values.groupId.proxy` or to default `uid:gid - 3100:3100` |
 | proxy.proxysql.linkerd.enabled | bool | false | enable the [annotation](https://linkerd.io/2.14/tasks/adding-your-service/#meshing-a-service-with-annotations) for linkerd to inject the sidecar container for transport encryption |
 | proxy.proxysql.queryRules.genericReadWriteSplit.enabled | bool | `false` | check the "Generic Read/Write split using regex" section in the [howto](https://proxysql.com/documentation/proxysql-read-write-split-howto/) for details |
 | proxy.proxysql.restapi.enabled | bool | `true` | the [ProxySQL RestAPI](https://proxysql.com/documentation/REST-API/) |

--- a/common/mariadb-galera/helm/Chart.yaml
+++ b/common/mariadb-galera/helm/Chart.yaml
@@ -3,7 +3,7 @@ name: mariadb-galera
 description: Docker images and Helm chart to deploy a [MariaDB](https://mariadb.com/kb/en/getting-installing-and-upgrading-mariadb/) HA cluster based on [Galera](https://mariadb.com/kb/en/what-is-mariadb-galera-cluster/)
 home: "https://github.com/sapcc/helm-charts/tree/mariadb-galera/common/mariadb-galera"
 appVersion: 10.5.23
-version: 0.27.0
+version: 0.27.1
 type: application
 kubeVersion: ">=1.18"
 maintainers:

--- a/common/mariadb-galera/helm/templates/statefulset-mariadb.yaml
+++ b/common/mariadb-galera/helm/templates/statefulset-mariadb.yaml
@@ -115,6 +115,33 @@ spec:
           privileged: {{ $.Values.initContainers.cleanoscache.securityContext.privileged }}
           runAsUser: {{ $.Values.initContainers.cleanoscache.securityContext.runAsUser | default 0 | int }}
       {{- end }}
+      {{- if $.Values.mariadb.fixFsPermissions}}
+      - name: fix-mariadb-fs-permissions
+        image: "{{ $.Values.image.os.registry }}/{{ $.Values.image.os.project }}/{{ $.Values.image.os.databasename }}:{{ $.Values.image.os.databaseversion }}-{{ $.Values.image.os.imageversion | int }}"
+        imagePullPolicy: {{ $.Values.image.os.pullPolicy | default "IfNotPresent" | quote }}
+        command:
+        - sh
+        - -c
+        - 'chown -R {{ $.Values.userId.database | default 101 | int }}:{{ $.Values.groupId.database | default 101 | int }} /mnt/*'
+        securityContext:
+          runAsUser: {{ $.Values.initContainers.fixMariaDBFsPermissions.securityContext.runAsUser | default 0 | int }}
+        volumeMounts:
+          {{- range $volumeMountsKey, $volumeMountsValue := $.Values.volumeMounts.database }}
+            {{- if $volumeMountsValue.enabled }}
+              {{- if (hasKey $volumeMountsValue "claimName") }}
+                {{- range $volumeClaimTemplatesKey, $volumeClaimTemplatesValue := $.Values.volumeClaimTemplates }}
+                  {{- if eq $volumeClaimTemplatesKey $volumeMountsValue.claimName }}
+          - name: {{ include "commonPrefix" $ }}-{{ $volumeMountsKey }}-{{ $volumeMountsValue.claimName | lower }}
+            mountPath: "/mnt{{ $volumeMountsValue.mountPath }}"
+                  {{- end }}
+                {{- end }}
+              {{- else }}
+          - name: {{ include "commonPrefix" $ }}-{{ $volumeMountsKey | lower }}
+            mountPath: "/mnt{{ $volumeMountsValue.mountPath }}"
+              {{- end }}
+            {{- end }}
+          {{- end }}
+      {{- end }}
       containers:
       - name: db
         image: "{{ $.Values.image.database.registry }}/{{ $.Values.image.database.project }}/{{ $.Values.image.database.databasename }}:{{ $.Values.image.database.databaseversion }}-{{ $.Values.image.database.imageversion | int }}"

--- a/common/mariadb-galera/helm/templates/statefulset-proxysql.yaml
+++ b/common/mariadb-galera/helm/templates/statefulset-proxysql.yaml
@@ -107,6 +107,33 @@ spec:
         securityContext:
           privileged: {{ $.Values.initContainers.increaseMapCount.securityContext.privileged | default true }}
           runAsUser: {{ $.Values.initContainers.increaseMapCount.securityContext.runAsUser | default 0 | int }}
+      {{- if $.Values.proxy.proxysql.fixFsPermissions}}
+      - name: fix-proxysql-fs-permissions
+        image: "{{ $.Values.image.os.regiostry }}/{{ $.Values.image.os.project }}/{{ $.Values.image.os.databasename }}:{{ $.Values.image.os.databaseversion }}-{{ $.Values.image.os.imageversion | int }}"
+        imagePullPolicy: {{ $.Values.image.os.pullPolicy | default "IfNotPresent" | quote }}
+        command:
+        - sh
+        - -c
+        - 'chown -R {{ $.Values.userId.proxy | default 3100 | int }}:{{ $.Values.groupId.proxy | default 3100 | int }} /mnt/*'
+        securityContext:
+          runAsUser: {{ $.Values.initContainers.fixProxysqlFsPermissions.securityContext.runAsUser | default 0 | int }}
+        volumeMounts:
+        {{- range $volumeMountsKey, $volumeMountsValue := $.Values.volumeMounts.proxy.proxysql }}
+          {{- if $volumeMountsValue.enabled }}
+            {{- if (hasKey $volumeMountsValue "claimName") }}
+              {{- range $volumeClaimTemplatesKey, $volumeClaimTemplatesValue := $.Values.volumeClaimTemplates }}
+                {{- if eq $volumeClaimTemplatesKey $volumeMountsValue.claimName }}
+          - name: {{ include "commonPrefix" $ }}-{{ $volumeMountsKey }}-{{ $volumeMountsValue.claimName | lower }}
+            mountPath: "/mnt{{ $volumeMountsValue.mountPath }}"
+                {{- end }}
+              {{- end }}
+            {{- else }}
+          - name: {{ include "commonPrefix" $ }}-{{ $volumeMountsKey | lower }}
+            mountPath: "/mnt{{ $volumeMountsValue.mountPath }}"
+            {{- end }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
       containers:
       - name: {{ (include "nodeNamePrefix" (dict "global" $ "component" "proxysql")) }}
         image: "{{ $.Values.image.proxy.registry }}/{{ $.Values.image.proxy.project }}/{{ $.Values.image.proxy.databasename }}:{{ $.Values.image.proxy.databaseversion }}-{{ $.Values.image.proxy.imageversion | int }}"

--- a/common/mariadb-galera/helm/tests/01-default-statefulset_test.yaml
+++ b/common/mariadb-galera/helm/tests/01-default-statefulset_test.yaml
@@ -1,8 +1,8 @@
 
 ---
 checksums:
-  my.cnf: &mycnf "aa4470cd829b593ee9f3ecb95e82f4cfe7e4f20c96222b75a5248888762f037f"
-  configmap: &configmap "349d60c53d32d91a26896952345243063505fef9c85981e42812a799af6a23c0"
+  my.cnf: &mycnf "d79b00a96982ebe5351b39135e2fdf2acb1a63045b694ce5d3534939cbebc618"
+  configmap: &configmap "7fdf8ef65f36b0f01a713ae0ec5f063c02741c4f2137471dfe3e41f489a3332f"
 
 suite: statefulset-mariadb
 values:

--- a/common/mariadb-galera/helm/values.yaml
+++ b/common/mariadb-galera/helm/values.yaml
@@ -64,6 +64,8 @@ scripts:
   # -- fail if time difference between nodes for the last sequence number configmap update is too big
   useTimeDifferenceForSeqnoCheck: false
 mariadb:
+  # -- fix the permissions of the persistent volumes and set the ownership of the FS to mariadb the value defined in `mariadb.database.userId:mariadb.database.groupId` or to default `uid:gid - 101:101`
+  fixFsPermissions: false
   # -- run the default entrypoint.sh script or just sleep to be able to troubleshoot and debug
   autostart: true
   # -- will trigger a pod restart and remove all content from the data and log dir. This option will cause data loss and should only be used before triggering a [full database restore](#full-database-restore)
@@ -691,6 +693,8 @@ proxy:
       # @default -- false
       enabled:
   proxysql:
+    # -- fix the permissions of the persistent volumes and set the ownership of the FS to mariadb the value defined in `Values.userId.proxy:Values.groupId.proxy` or to default `uid:gid - 3100:3100`
+    fixFsPermissions: false
     restapi:
       # -- the [ProxySQL RestAPI](https://proxysql.com/documentation/REST-API/)
       enabled: true
@@ -860,6 +864,21 @@ initContainers:
       # -- (int) required to configure `/proc/sys/vm/drop_caches` in the init phase
       # @default -- 0
       runAsUser:
+  fixMariaDBFsPermissions:
+    securityContext:
+      # -- (bool) required to fix FS permissions of mariadb persistent volumes in the init phase
+      privileged: true
+      # -- (int) required to fix FS permissions of mariadb persistent volumes in the init phase
+      # @default -- 0
+      runAsUser:
+  fixProxysqlFsPermissions:
+    securityContext:
+      # -- (bool) required to fix FS permissions of porxysql persistent volumes in the init phase
+      privileged: true
+      # -- (int) required to fix FS permissions of porxysql persistent volumes in the init phase
+      # @default -- 0
+      runAsUser:
+
 
 # network services
 services:


### PR DESCRIPTION
our Backplane  NFS driver does not support the change of fsGroup in case of root mismatch that's why we need to change the owner of the root directory of the volumes if we want to use persistent volumes with none root containers.
add privileged init container with all persistent volume mounted on it, which runs chown -R over all mounts.

Change-Id: I8c0d7dd94d7d24f4cd2ef1a7e2af10ed11d6139d