### PR TITLE
nova/flavors: Minimal socket count for flavors >= 64vCPUs

### DIFF
--- a/openstack/sap-seeds/templates/flavor-seed.yaml
+++ b/openstack/sap-seeds/templates/flavor-seed.yaml
@@ -208,6 +208,7 @@ spec:
     is_public: false
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "hw:cpu_cores": "64"  # used in nova-vmware as cores-per-socket (32pCPU = 64vCPU)
   - name: "m_c4_m64"
     id: "100"
     vcpus: 4
@@ -396,6 +397,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "hw:cpu_cores": "64"  # used in nova-vmware as cores-per-socket (32pCPU = 64vCPU)
   - name: "g_c64_m256"
     id: "220"
     vcpus: 64
@@ -404,6 +406,7 @@ spec:
     is_public: true
     extra_specs:
       "catalog:alias": "m5.16xlarge"
+      "hw:cpu_cores": "64"  # used in nova-vmware as cores-per-socket (32pCPU = 64vCPU)
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c48_m512"
     id: "221"
@@ -421,6 +424,7 @@ spec:
     is_public: true
     extra_specs:
       "catalog:alias": "m5.32xlarge"
+      "hw:cpu_cores": "64"  # used in nova-vmware as cores-per-socket (32pCPU = 64vCPU)
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m5.48xlarge"
     id: "231"
@@ -430,6 +434,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
   - name: "m_c128_m1000"
     id: "240"
     vcpus: 128
@@ -438,6 +443,7 @@ spec:
     is_public: true
     extra_specs:
       "catalog:alias": "m5.64xlarge"
+      "hw:cpu_cores": "64"  # used in nova-vmware as cores-per-socket (32pCPU = 64vCPU)
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
 
 
@@ -639,6 +645,7 @@ spec:
     is_public: false
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "hw:cpu_cores": "64"  # used in nova-vmware as cores-per-socket (32pCPU = 64vCPU)
       "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
   - name: "m_c4_m64_v2"
     id: "423"
@@ -846,6 +853,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "hw:cpu_cores": "64"  # used in nova-vmware as cores-per-socket (32pCPU = 64vCPU)
       "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
   - name: "g_c64_m256_v2"
     id: "446"
@@ -855,6 +863,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "hw:cpu_cores": "64"  # used in nova-vmware as cores-per-socket (32pCPU = 64vCPU)
       "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
   - name: "m_c48_m512_v2"
     id: "447"
@@ -873,6 +882,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "hw:cpu_cores": "64"  # used in nova-vmware as cores-per-socket (32pCPU = 64vCPU)
       "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
   - name: "m5.48xlarge_v2"
     id: "449"
@@ -882,6 +892,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
       "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
   - name: "m_c128_m1000_v2"
     id: "450"
@@ -891,6 +902,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "hw:cpu_cores": "64"  # used in nova-vmware as cores-per-socket (32pCPU = 64vCPU)
       "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
 
 
@@ -920,5 +932,6 @@ spec:
     is_public: false
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "hw:cpu_cores": "64"  # used in nova-vmware as cores-per-socket (32pCPU = 64vCPU)
 
 {{ include (print .Template.BasePath "/_flavors_deleted.tpl") . | indent 2 }}


### PR DESCRIPTION
We now want larger general purpose flavors to keep their cores together instead of spreading them across sockets.

The underlying hypervisor topology is unrelated to the values that are settable: Valid cores-per-socket numbers are the ones that result in integer socket counts with the total number of CPUs, with a maximum of 64 cores.

E.g. with 96 vCPUs possible cores-per-socket values are:
48, 32, 24, 16, 12, 8, 6, 4, 3, 2, 1

The resulting socket-size can be larger than the socket-size of the underlying hardware. The number of _NUMA nodes_ is influenced by the underlying hardware, and the number of NUMA nodes can curiously enough be greater than the number of sockets.