### PR TITLE
[octavia] Enable HTTP2 profile by default everywhere.

### DIFF
--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -281,6 +281,7 @@ providers: "noop_driver: 'The No-Op driver.', f5: 'F5 BigIP driver.', F5Networks
 default_provider: "f5"
 default_profiles:
   profile_http: cc_http_profile
+  profile_http2: cc_http2_profile
   profile_http_compression: cc_httpcompression_profile
   profile_l4: cc_fastL4_profile
   profile_tcp: cc_tcp_profile


### PR DESCRIPTION
This PR enables HTTP2 profile for all of the regions by default because F5 were upgraded.