### PR TITLE
keppel: use customer_domains list from values/globals.yaml

### DIFF
--- a/openstack/keppel/ci/test-values.yaml
+++ b/openstack/keppel/ci/test-values.yaml
@@ -9,6 +9,9 @@ global:
   quayIoMirror: registry.example.com/quayio
   vaultBaseURL: vault.example.com/secrets
 
+  domain_seeds:
+    customer_domains: [foo, bar]
+
 keppel:
   image_tag: '12345'
   trivy:

--- a/openstack/keppel/templates/seed.yaml
+++ b/openstack/keppel/templates/seed.yaml
@@ -1,7 +1,7 @@
-{{- $vbase  := .Values.global.vaultBaseURL | required "missing value for .Values.global.vaultBaseURL" -}}
-{{- $region := .Values.global.region       | required "missing value for .Values.global.region"       -}}
-
-{{- $domains := list "cc3test" "bs" "btp_fp" "cis" "cp" "fsn" "hcm" "hcp03" "hda" "hec" "kyma" "monsoon3" "neo" "s4" "wbs" }}
+{{- $vbase    := .Values.global.vaultBaseURL                  | required "missing value for .Values.global.vaultBaseURL" -}}
+{{- $region   := .Values.global.region                        | required "missing value for .Values.global.region"       -}}
+{{- $cdomains := .Values.global.domain_seeds.customer_domains | required "missing value for .Values.global.domain_seeds.customer_domains" -}}
+{{- $domains  := concat (list "cc3test") $cdomains -}}
 
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: OpenstackSeed

--- a/openstack/keppel/templates/support_seed.yaml
+++ b/openstack/keppel/templates/support_seed.yaml
@@ -1,7 +1,5 @@
-{{- $domains := list "ccadmin" "bs" "cis" "cp" "fsn" "hcp03" "hec" "monsoon3" "neo" "s4" "wbs"}}
-{{- if not .Values.global.domain_seeds.skip_hcm_domain -}}
-  {{- $domains = append $domains "hcm" }}
-{{- end -}}
+{{- $cdomains := .Values.global.domain_seeds.customer_domains | required "missing value for .Values.global.domain_seeds.customer_domains" -}}
+{{- $domains := concat (list "ccadmin") $cdomains -}}
 
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: OpenstackSeed


### PR DESCRIPTION
This is a cleanup that I've been meaning to do for a while, and it still needs to be done for the other services. Instead of having the customer domain list hardcoded everywhere, I had it added to values/globals.yaml to reference across the board.