### PR TITLE
[keystone]pump up mariadb-galera dependencies

### DIFF
--- a/openstack/keystone/Chart.lock
+++ b/openstack/keystone/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.10.1
 - name: mariadb-galera
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.27.0
+  version: 0.27.1
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
@@ -26,5 +26,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.4
-digest: sha256:f0b6c535d8c0e4dec90924ed4a5c24a35c5e73ee6a60208a87221a47f2fd9d1f
-generated: "2024-05-17T08:37:35.958088+02:00"
+digest: sha256:6f573eba72b071dad3e60ff4dab65ffbaca90a91849516eef1493ef4f307e212
+generated: "2024-06-19T15:39:54.361274+02:00"

--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: keystone
 sources:
   - https://github.com/sapcc/keystone
-version: 0.6.5
+version: 0.6.6
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
@@ -19,7 +19,7 @@ dependencies:
     name: mariadb-galera
     alias: mariadb_galera
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.27.0
+    version: 0.27.1
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.2.0


### PR DESCRIPTION
pump up dependencies to mariadb-galera 0.27.1
 - add feature to fix persistent volume fs permissions

Change-Id: Ic78187936d14c1c4f7b44f5e590917ea95ea908f