### PR TITLE
[unbound] let log_client_response_messages default to "yes"

### DIFF
--- a/system/unbound/templates/config.yaml
+++ b/system/unbound/templates/config.yaml
@@ -95,7 +95,7 @@ data:
         dnstap-send-identity: {{ .Values.unbound.dnstap.send_identity | default "no" }}
         dnstap-send-version: {{ .Values.unbound.dnstap.send_version | default "no" }}
         dnstap-log-client-query-messages: {{ .Values.unbound.dnstap.log_client_query_messages | default "yes" }}
-        dnstap-log-client-response-messages: {{ .Values.unbound.dnstap.log_client_response_messages | default "no" }}
+        dnstap-log-client-response-messages: {{ .Values.unbound.dnstap.log_client_response_messages | default "yes" }}
 {{- else }}
         dnstap-enable: no
 {{- end }}


### PR DESCRIPTION
If we're going to be logging the dns traffic then we will most likely want to see both the queries and the responses.