### PR TITLE
limes: less flapping on capacity alerts

### DIFF
--- a/openstack/limes/aggregations/openstack/consolidation.rules
+++ b/openstack/limes/aggregations/openstack/consolidation.rules
@@ -42,7 +42,21 @@ groups:
 
     ############################################################################
     # for capacity alerts
+    #
+    # "Stabilization" refers to these metrics not flapping and changing labels on restarts of limes-collect (e.g. because of deployment):
+    # - Each raw metric is wrapped in `last_over_time(<metric>[15m])` to avoid alerts disappearing when the collector is restarted and the metrics vanish because the new collector takes a few moments to start up.
+    # - Each raw metric is then also wrapped in `max by (<relevant labels>) (<expr>)` to avoid time series from the old and new collector appearing at the same time. This would cause many-to-many matching errors and also cause the alert to flap.
 
     # How much capacity of a resource is blocked by existing usage and/or confirmed commitments.
-    - record: limes_capacity_blocked_percent
-      expr: 100 * sum by (availability_zone, service, resource) (limes_project_used_and_or_committed_per_az) / max by (availability_zone, service, resource) (limes_cluster_capacity_per_az)
+    - record: stabilized:limes_capacity_blocked_percent_per_az
+      expr: 100 * sum by (availability_zone, service, resource) (max by (project_id, availability_zone, service, resource) (last_over_time(limes_project_used_and_or_committed_per_az[15m]))) / max by (availability_zone, service, resource) (last_over_time(limes_cluster_capacity_per_az[15m]))
+
+    # Total amount of all commitments pending confirmation for a resource.
+    - record: stabilized:limes_pending_commitments_per_az
+      expr: sum by (availability_zone, service, resource) (max by (project_id, availability_zone, service, resource) (last_over_time(limes_project_committed_per_az{state="pending"}[15m])))
+
+    # misc.
+    - record: stabilized:limes_autogrow_quota_overcommit_threshold_percent
+      expr: max by (service, resource) (last_over_time(limes_autogrow_quota_overcommit_threshold_percent[15m]))
+    - record: stabilized:limes_autogrow_growth_multiplier
+      expr: max by (service, resource) (last_over_time(limes_autogrow_growth_multiplier[15m]))

--- a/openstack/limes/alerts/openstack/capacity.alerts
+++ b/openstack/limes/alerts/openstack/capacity.alerts
@@ -1,13 +1,11 @@
 # vim: set ft=yaml:
 
-# NOTE: All metrics in these alert expressions are wrapped in `last_over_time(...[15m])` to avoid alert flapping when Limes restarts e.g. due to a deployment.
-
 groups:
 - name: openstack-limes-capacity.alerts
   rules:
 
   - alert: LimesBlockedCapacityAbove80Percent
-    expr: (last_over_time(limes_capacity_blocked_percent[15m]) > 80) and on (service, resource) (last_over_time(limes_autogrow_growth_multiplier[15m]) > 1)
+    expr: (stabilized:limes_capacity_blocked_percent_per_az > 80) and on (service, resource) (stabilized:limes_autogrow_growth_multiplier > 1)
     for: 10m
     labels:
       severity: info
@@ -20,7 +18,7 @@ groups:
         capacity is blocked by commitments or provisioned usage. Please check if hardware needs to be ordered.
 
   - alert: LimesBlockedCapacityDangerouslyHigh
-    expr: (last_over_time(limes_capacity_blocked_percent[15m]) > on (service, resource) last_over_time(limes_autogrow_quota_overcommit_threshold_percent[15m])) and on (service, resource) (last_over_time(limes_autogrow_growth_multiplier[15m]) > 1)
+    expr: (stabilized:limes_capacity_blocked_percent_per_az > on (service, resource) stabilized:limes_autogrow_quota_overcommit_threshold_percent) and on (service, resource) (stabilized:limes_autogrow_growth_multiplier > 1)
     for: 10m
     labels:
       severity: warning
@@ -35,7 +33,7 @@ groups:
         Please check if hardware needs to be ordered.
 
   - alert: LimesPendingCommitments
-    expr: sum by (availability_zone, service, resource) (last_over_time(limes_project_committed_per_az{state="pending"}[15m])) > 0
+    expr: stabilized:limes_pending_commitments_per_az > 0
     for: 10m
     labels:
       severity: warning


### PR DESCRIPTION
As explained in the code comments, the `last_over_time(...[15m])` fixes one type of flapping, but then introduces a different type.

Because this proliferation of wrapping all metrics in several layers of sanitization causes alert expressions to become just outright unreadable, I have split all of this off into aggregation rules.