### PR TITLE
nova/flavors: Use vmx-18 for all HANA flavors

### DIFF
--- a/openstack/sap-seeds/templates/_flavors_hana_no_exclusive.tpl
+++ b/openstack/sap-seeds/templates/_flavors_hana_no_exclusive.tpl
@@ -53,7 +53,7 @@
     "resources:CUSTOM_BIGVM": "2"
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
-    "vmware:hw_version": "vmx-15"
+    "vmware:hw_version": "vmx-18"
     {{- if ( .Values.hana_flavors_quota_separate ) }}
     "quota:instance_only": "true"
     "quota:separate": "true"
@@ -69,7 +69,7 @@
     "resources:CUSTOM_BIGVM": "2"
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
-    "vmware:hw_version": "vmx-15"
+    "vmware:hw_version": "vmx-18"
     {{- if ( .Values.hana_flavors_quota_separate ) }}
     "quota:instance_only": "true"
     "quota:separate": "true"


### PR DESCRIPTION
Two HANA flavors still had vmx-15 set, but vmx-18 is the default now, so let's make it consistent. It's not strictly needed though.
