### PR TITLE
[Neutron] Disable eventlet patching in neutron-server

### DIFF
--- a/openstack/neutron/templates/deployment-server.yaml
+++ b/openstack/neutron/templates/deployment-server.yaml
@@ -89,6 +89,8 @@ spec:
 {{- if .Values.api.uwsgi }}
             - name: OS_OSLO_MESSAGING_RABBIT__HEARTBEAT_IN_PTHREAD
               value: "true"
+            - name: DISABLE_EVENTLET_PATCHING
+              value: "true"
 {{- end }}
             - name: NAMESPACE
               value: {{ .Release.Namespace }}

--- a/openstack/neutron/templates/etc/_uwsgi.ini.tpl
+++ b/openstack/neutron/templates/etc/_uwsgi.ini.tpl
@@ -2,7 +2,12 @@
 # This is running standalone
 master = true
 pyargv = --config-file /etc/neutron/neutron.conf --config-dir /etc/neutron/secrets --config-file /etc/neutron/plugins/ml2/ml2-conf.ini --config-file /etc/neutron/plugins/ml2/ml2-conf-aci.ini --config-file /etc/neutron/plugins/ml2/ml2-conf-manila.ini --config-file /etc/neutron/plugins/ml2/ml2-conf-arista.ini --config-file /etc/neutron/plugins/ml2/ml2-conf-asr1k.ini --config-file /etc/neutron/plugins/asr1k-global.ini {{- if .Values.bgp_vpn.enabled }} --config-file /etc/neutron/networking-bgpvpn.conf{{- end }}{{- if .Values.interconnection.enabled }} --config-file /etc/neutron/networking-interconnection.conf{{- end }}{{- if .Values.fwaas.enabled }} --config-file /etc/neutron/neutron-fwaas.ini{{- end }}{{- if .Values.cc_fabric.enabled }} --config-file /etc/neutron/plugins/ml2/ml2_conf_cc-fabric.ini {{- end }}
+{{- if .Values.api.uwsgi }}
+venv = /var/lib/openstack/
+eval = from neutron.server import boot_server; from neutron.server.api_eventlet import eventlet_api_server; application = boot_server(eventlet_api_server)
+{{- else }}
 wsgi-file = /var/lib/openstack/bin/neutron-api
+{{- end }}
 enable-threads = true
 processes = {{.Values.api.processes}}
 auto-procname = true


### PR DESCRIPTION
We set the environment variable DISABLE_EVENTLET_PATCHING, which is honored by our own drivers and disables calls to
`eventlet.monkey_patch()`.

Additionally, we switch away from letting uWSGI use the WSGI file `neutron-api`. The reason is, that `neutron.cmd.eventlet` uses `eventlet.monkey_patch()` unconditionally - and is imported in the `neutron-api` WSGI file. We switch instead to an `eval` setting for uWSGI, because this makes it immediately visible what we're calling. The code we're calling is also just three lines.

All of this only happens if we run with uWSGI. If we use the old eventlet-wsgi server, we need the monkey-patching.