### PR TITLE
fix: remove awx index from deadletter query

### DIFF
--- a/prometheus-exporters/octobus-query-exporter/Chart.lock
+++ b/prometheus-exporters/octobus-query-exporter/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: octobus-query-exporter
   repository: file://vendor/octobus-query-exporter
-  version: 1.0.12
+  version: 1.0.13
 - name: octobus-query-exporter-global
   repository: file://vendor/octobus-query-exporter-global
   version: 1.0.12
@@ -11,5 +11,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:bfe3de4568b292896aa87ae24709debca28775725efa05bbd2ee04a2d6b99ec9
-generated: "2024-04-18T16:25:50.607932+02:00"
+digest: sha256:91c64bcc894bb31e73411e4ff1eb54bfb3d6593ff0da7815873795eda85b0106
+generated: "2024-06-24T09:31:18.092895+02:00"

--- a/prometheus-exporters/octobus-query-exporter/Chart.yaml
+++ b/prometheus-exporters/octobus-query-exporter/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 1.0.15
+version: 1.0.16
 name: octobus-query-exporter
 description: Elasticsearch prometheus query exporter
 maintainers:
@@ -9,7 +9,7 @@ dependencies:
   - name: octobus-query-exporter
     alias: octobus_query_exporter
     repository: file://vendor/octobus-query-exporter
-    version: 1.0.12
+    version: 1.0.13
     condition: octobus_query_exporter.enabled
 
   - name: octobus-query-exporter-global

--- a/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/Chart.yaml
+++ b/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 1.0.12
+version: 1.0.13
 name: octobus-query-exporter
 description: Elasticsearch prometheus query exporter
 maintainers:

--- a/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/files/queries/audit/audit_deadletter.cfg
+++ b/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/files/queries/audit/audit_deadletter.cfg
@@ -32,12 +32,12 @@ QueryJson = {
             "match_phrase": {
               "sap.ocb.deadletter.original_index": "c0001_log_audit_auditbeat"
             }
-          },
-          {
-            "match_phrase": {
-              "sap.ocb.deadletter.original_index": "c0001_log_audit_awx"
-            }
           }
+          # {
+          #   "match_phrase": {
+          #     "sap.ocb.deadletter.original_index": "c0001_log_audit_awx"
+          #   }
+          # }
         ],
         "minimum_should_match": 1
       }


### PR DESCRIPTION
there are frequent occurences of events ending up in deadletter.
excluding the index will reduce the noise in the observability alerting.
