### PR TITLE
Bump kube-monitoring-metal, remove endpoint alert

### DIFF
--- a/system/kube-monitoring-metal/Chart.lock
+++ b/system/kube-monitoring-metal/Chart.lock
@@ -28,7 +28,7 @@ dependencies:
   version: 6.4.0
 - name: prometheus-kubernetes-rules
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.9.7
+  version: 1.9.8
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 4.6.0
@@ -50,5 +50,5 @@ dependencies:
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
   version: 3.13.0
-digest: sha256:7eeaaeb1fbbefb4b07f09137ef71d8ab46cc1fcef8e9e3857e74b8051e9fd6ff
-generated: "2024-06-10T11:23:49.227155123+02:00"
+digest: sha256:0781173ea6a8a2475689b8d4c35393fc8bad168e43160935753eeb9d0b0bd4b1
+generated: "2024-06-25T09:05:49.11451606+02:00"

--- a/system/kube-monitoring-metal/Chart.yaml
+++ b/system/kube-monitoring-metal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes metal controlplane monitoring.
 name: kube-monitoring-metal
-version: 4.7.5
+version: 4.7.6
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-metal
 dependencies:
   - condition: absent-metrics-operator.enabled
@@ -35,7 +35,7 @@ dependencies:
     version: 6.4.0
   - name: prometheus-kubernetes-rules
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 1.9.7
+    version: 1.9.8
   - name: prometheus-node-exporter
     repository: https://prometheus-community.github.io/helm-charts
     version: 4.6.0


### PR DESCRIPTION
Removes the `MissingServiceEndpoints` alert from kube-monitoring-metal umbrella chart.