### PR TITLE
[unbound] let unbound log the RPZ actions

### DIFF
--- a/system/unbound/templates/config.yaml
+++ b/system/unbound/templates/config.yaml
@@ -109,6 +109,8 @@ data:
         for-downstream: yes
         allow-notify: 127.0.0.1
         primary: 127.0.0.1@55353
+        rpz-log: yes
+        rpz-log-name: {{ $rpz_zone | quote }}
     {{- end }}
 {{- end }}
 


### PR DESCRIPTION
That should help with troubleshooting if somebody complains they cannot resolve stuff. It can be they've hit a blocklisted entry.

TODO: We might want to toggle the logging on RPZ zone basis, e.g. log blocklisted actions and stay quiet on allowlisted ones.