### PR TITLE
[unbound] make it possible to toggle the RPZ logging on a zone basis

### DIFF
--- a/system/unbound/templates/config.yaml
+++ b/system/unbound/templates/config.yaml
@@ -109,7 +109,7 @@ data:
         for-downstream: yes
         allow-notify: 127.0.0.1
         primary: 127.0.0.1@55353
-        rpz-log: yes
+        rpz-log: {{ has $rpz_zone $.Values.unbound.rpz.log | ternary "yes" "no" }}
         rpz-log-name: {{ $rpz_zone | quote }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
We might want to log just the blocklisting actions.