### PR TITLE
[mariadb-galera] deploy storageclasses only if requested

### DIFF
--- a/common/mariadb-galera/CHANGELOG.md
+++ b/common/mariadb-galera/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.29.0 - 2024/06/26
+* the supported storageclasses `cinder` and `nfs` will only be enabled if a persistent volume has been defined with `volumeClaimTemplates.volume.storageClassName` option
+  * to avoid unexpected and not required storageclasses in the cluster
+  * unit tests added
+* chart version bumped
+
 ## v0.28.0 - 2024/06/18
 * ccroot user added
   * for passwordless local root access

--- a/common/mariadb-galera/README.md
+++ b/common/mariadb-galera/README.md
@@ -46,7 +46,7 @@ Docker images and Helm chart to deploy a [MariaDB](https://mariadb.com/kb/en/get
 ## Metadata
 | chart version | app version | type | url |
 |:--------------|:-------------|:-------------|:-------------|
-| 0.28.0 | 10.5.25 | application | [Git repo](https://github.com/sapcc/helm-charts/tree/master/common/mariadb-galera) |
+| 0.29.0 | 10.5.25 | application | [Git repo](https://github.com/sapcc/helm-charts/tree/master/common/mariadb-galera) |
 
 | Name | Email | Url |
 | ---- | ------ | --- |
@@ -166,7 +166,7 @@ docker build --build-arg BASE_SOFT_NAME=ubuntu --build-arg BASE_SOFT_VERSION=22.
   ```
 * [push](https://helm.sh/docs/topics/registries/#the-push-subcommand) the chart to the registry
   ```shell
-  helm push mariadb-galera-0.28.0.tgz oci://keppel.eu-de-1.cloud.sap/ccloud-helm/
+  helm push mariadb-galera-0.29.0.tgz oci://keppel.eu-de-1.cloud.sap/ccloud-helm/
   ```
 
 ### values description
@@ -693,16 +693,16 @@ docker build --build-arg BASE_SOFT_NAME=ubuntu --build-arg BASE_SOFT_VERSION=22.
 | userId.proxy | string | 3100 | run the ProxySQL/HAProxy containers with that [user id](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | volumeClaimTemplates.mariabackup.accessModes | list | `["ReadWriteMany"]` | [access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) for the MariaDB backup volume (used by Kopia) |
 | volumeClaimTemplates.mariabackup.capacity | string | `"100Gi"` | capacity for the MariaDB backup volume |
-| volumeClaimTemplates.mariabackup.storageClassName | string | `"nfs"` | custom storageclass (currently `nfs` is supported) for the MariaDB backup volume to allow the shared access for all Kopia pods |
+| volumeClaimTemplates.mariabackup.storageClassName | string | `nil` | custom storageclass (currently `nfs` is supported) for the MariaDB backup volume to allow the shared access for all Kopia pods |
 | volumeClaimTemplates.mariadb.accessModes | list | `["ReadWriteOnce"]` | [access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) for the MariaDB data volume |
 | volumeClaimTemplates.mariadb.capacity | string | `"10Gi"` | capacity for the MariaDB data volume |
-| volumeClaimTemplates.mariadb.storageClassName | bool | `false` | custom storageclass (currently `cinder` and `nfs` are supported) for the MariaDB data volume |
+| volumeClaimTemplates.mariadb.storageClassName | string | `nil` | custom storageclass (currently `cinder` and `nfs` are supported) for the MariaDB data volume |
 | volumeClaimTemplates.marialog.accessModes | list | `["ReadWriteOnce"]` | [access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) for the MariaDB log volume |
 | volumeClaimTemplates.marialog.capacity | string | `"30Gi"` | capacity for the MariaDB log volume |
-| volumeClaimTemplates.marialog.storageClassName | bool | `false` | custom storageclass (currently `cinder` and `nfs` are supported) for the MariaDB log volume |
+| volumeClaimTemplates.marialog.storageClassName | string | `nil` | custom storageclass (currently `cinder` and `nfs` are supported) for the MariaDB log volume |
 | volumeClaimTemplates.proxysql.accessModes | list | `["ReadWriteOnce"]` | [access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) for the ProxySQL data volume |
 | volumeClaimTemplates.proxysql.capacity | string | `"128Mi"` | capacity for the ProxySQL data volume |
-| volumeClaimTemplates.proxysql.storageClassName | bool | `false` | custom storageclass (currently `cinder` and `nfs` are supported) for the ProxySQL data volume |
+| volumeClaimTemplates.proxysql.storageClassName | string | `nil` | custom storageclass (currently `cinder` and `nfs` are supported) for the ProxySQL data volume |
 | volumeMounts.backup.kopia.data.claimName | string | `"mariabackup"` | name for the [persistent volume claim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims) requested for the Kopia [data directory](https://mariadb.com/kb/en/server-system-variables/#datadir) |
 | volumeMounts.backup.kopia.data.enabled | bool | `false` | enable this volume |
 | volumeMounts.backup.kopia.data.mountPath | string | `"/opt/kopia/data"` | mount path of the persistent volume in the container used for the MariaDB data directory |

--- a/common/mariadb-galera/helm/Chart.yaml
+++ b/common/mariadb-galera/helm/Chart.yaml
@@ -3,7 +3,7 @@ name: mariadb-galera
 description: Docker images and Helm chart to deploy a [MariaDB](https://mariadb.com/kb/en/getting-installing-and-upgrading-mariadb/) HA cluster based on [Galera](https://mariadb.com/kb/en/what-is-mariadb-galera-cluster/)
 home: "https://github.com/sapcc/helm-charts/tree/master/common/mariadb-galera"
 appVersion: 10.5.25
-version: 0.28.0
+version: 0.29.0
 type: application
 kubeVersion: ">=1.18"
 maintainers:

--- a/common/mariadb-galera/helm/templates/_helpers.tpl
+++ b/common/mariadb-galera/helm/templates/_helpers.tpl
@@ -315,3 +315,37 @@ app.kubernetes.io/version: {{ $.Chart.Version }}
 app.kubernetes.io/component: MariaDB-Galera
 app.kubernetes.io/part-of: {{ $.Release.Name }}
 {{- end }}
+
+{{- define "storageclassCinder" }}
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ include "commonPrefix" $ }}-cinder
+  labels:
+    {{- include "sharedservices.labels" $ | indent 4 }}
+parameters:
+  type: vmware
+provisioner: cinder.csi.openstack.org
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+{{- end }}
+
+{{- define "storageclassNfs" }}
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ include "commonPrefix" $ }}-nfs
+  labels:
+    {{- include "sharedservices.labels" $ | indent 4 }}
+parameters:
+  pathPattern: "${.PVC.namespace}-${.PVC.name}"
+  onDelete: "delete"
+  archiveOnDelete: "true"
+provisioner: cluster.local/nfs-subdir-external-provisioner
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+{{- end }}

--- a/common/mariadb-galera/helm/templates/storageclass.yaml
+++ b/common/mariadb-galera/helm/templates/storageclass.yaml
@@ -1,28 +1,58 @@
----
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: {{ include "commonPrefix" $ }}-cinder
-  labels:
-    {{- include "sharedservices.labels" $ | indent 4 }}
-parameters:
-  type: vmware
-provisioner: cinder.csi.openstack.org
-reclaimPolicy: Delete
-volumeBindingMode: WaitForFirstConsumer
-allowVolumeExpansion: true
----
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: {{ include "commonPrefix" $ }}-nfs
-  labels:
-    {{- include "sharedservices.labels" $ | indent 4 }}
-parameters:
-  pathPattern: "${.PVC.namespace}-${.PVC.name}"
-  onDelete: "delete"
-  archiveOnDelete: "true"
-provisioner: cluster.local/nfs-subdir-external-provisioner
-reclaimPolicy: Delete
-volumeBindingMode: WaitForFirstConsumer
-allowVolumeExpansion: true
+{{- $cinderEnabled := false }}
+{{- $nfsEnabled := false }}
+{{- range $volumeClaimTemplatesKey, $volumeClaimTemplatesValue := $.Values.volumeClaimTemplates }}
+  {{- range $volumeMountsKey, $volumeMountsValue := index $.Values.volumeMounts.database }}
+    {{- if $volumeMountsValue.enabled }}
+      {{- if and (hasKey $volumeMountsValue "type") (eq $volumeMountsValue.type "persistentVolume") }}
+        {{- if (hasKey $volumeMountsValue "claimName") }}
+          {{- if eq $volumeClaimTemplatesKey $volumeMountsValue.claimName }}
+            {{- if and (eq $volumeClaimTemplatesValue.storageClassName "cinder") (not $cinderEnabled) }}
+            {{- $cinderEnabled = true }}
+{{- include "storageclassCinder" $ }}
+            {{- end }}
+            {{- if and (eq $volumeClaimTemplatesValue.storageClassName "nfs") (not $nfsEnabled) }}
+            {{- $nfsEnabled = true }}
+{{- include "storageclassNfs" $ }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- range $volumeMountsKey, $volumeMountsValue := index $.Values.volumeMounts.proxy.proxysql }}
+    {{- if $volumeMountsValue.enabled }}
+      {{- if and (hasKey $volumeMountsValue "type") (eq $volumeMountsValue.type "persistentVolume") }}
+        {{- if (hasKey $volumeMountsValue "claimName") }}
+          {{- if eq $volumeClaimTemplatesKey $volumeMountsValue.claimName }}
+            {{- if and (eq $volumeClaimTemplatesValue.storageClassName "cinder") (not $cinderEnabled) }}
+            {{- $cinderEnabled = true }}
+{{- include "storageclassCinder" $ }}
+            {{- end }}
+            {{- if and (eq $volumeClaimTemplatesValue.storageClassName "nfs") (not $nfsEnabled) }}
+            {{- $nfsEnabled = true }}
+{{- include "storageclassNfs" $ }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- range $volumeMountsKey, $volumeMountsValue := index $.Values.volumeMounts.backup.kopia }}
+    {{- if $volumeMountsValue.enabled }}
+      {{- if and (hasKey $volumeMountsValue "type") (eq $volumeMountsValue.type "persistentVolume") }}
+        {{- if (hasKey $volumeMountsValue "claimName") }}
+          {{- if eq $volumeClaimTemplatesKey $volumeMountsValue.claimName }}
+            {{- if and (eq $volumeClaimTemplatesValue.storageClassName "cinder") (not $cinderEnabled) }}
+            {{- $cinderEnabled = true }}
+{{- include "storageclassCinder" $ }}
+            {{- end }}
+            {{- if and (eq $volumeClaimTemplatesValue.storageClassName "nfs") (not $nfsEnabled) }}
+            {{- $nfsEnabled = true }}
+{{- include "storageclassNfs" $ }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/common/mariadb-galera/helm/tests/01-default-statefulset_test.yaml
+++ b/common/mariadb-galera/helm/tests/01-default-statefulset_test.yaml
@@ -1,8 +1,8 @@
 
 ---
 checksums:
-  my.cnf: &mycnf "597210e81a33a3b8f1e4ce464092d60cb400cb3ac6b3b98c87f24ac64963a353"
-  configmap: &configmap "041467ed8dba9aad366498617e7be867b417bfcd45b766c08a2ed061d7c4d0bc"
+  my.cnf: &mycnf "9b94cba39a3d7f92f240b695f6539950a4eeea12f679f6fef9c77fbcf7f41aec"
+  configmap: &configmap "df3f527b725cc932e321241e69ea5bcb4546d7457cc2b465a6ac5e98fa82a9b2"
 
 suite: statefulset-mariadb
 values:
@@ -2179,7 +2179,7 @@ tests:
           path: spec.template.spec.volumes[0].secret.secretName
           value: "testrelease-testvolume"
 
-  - it: set volumes in persistentVolumw type
+  - it: set volumes in persistentVolume type
     template: statefulset-mariadb.yaml
     set:
       mariadb.galera.clustername: "testclustername"
@@ -2210,8 +2210,6 @@ tests:
       - equal:
           path: spec.volumeClaimTemplates[0].metadata.name
           value: "testrelease-data-mariadb"
-      - notExists:
-          path: spec.volumeClaimTemplates[0].spec.storageClassName
       - equal:
           path: spec.volumeClaimTemplates[0].spec.accessModes[0]
           value: "ReadWriteOnce"
@@ -2223,8 +2221,6 @@ tests:
       - equal:
           path: spec.volumeClaimTemplates[1].metadata.name
           value: "testrelease-log-marialog"
-      - notExists:
-          path: spec.volumeClaimTemplates[1].spec.storageClassName
       - equal:
           path: spec.volumeClaimTemplates[1].spec.accessModes[0]
           value: "ReadWriteOnce"

--- a/common/mariadb-galera/helm/tests/07-storageclass_test.yaml
+++ b/common/mariadb-galera/helm/tests/07-storageclass_test.yaml
@@ -1,0 +1,309 @@
+---
+suite: storageclass
+values:
+  - default_values.yaml
+set:
+  mariadb.galera.clustername: "testname"
+release:
+  name: testrelease
+  namespace: testnamespace
+templates:
+  - storageclass.yaml
+tests:
+  - it: storageclass cinder for mariadb data defined
+    documentSelector:
+      path: metadata.name
+      value: testrelease-cinder
+    set:
+      volumeMounts.database.data.enabled: true
+      volumeMounts.database.data.claimName: mariadb
+      volumeMounts.database.data.type: persistentVolume
+      volumeClaimTemplates.mariadb.storageClassName: cinder
+    asserts:
+      - isKind:
+          of: StorageClass
+      - equal:
+          path: metadata.name
+          value: testrelease-cinder
+      - equal:
+          path: provisioner
+          value: cinder.csi.openstack.org
+      - equal:
+          path: reclaimPolicy
+          value: Delete
+      - equal:
+          path: volumeBindingMode
+          value: WaitForFirstConsumer
+      - equal:
+          path: allowVolumeExpansion
+          value: true
+  - it: storageclass nfs for mariadb data defined
+    documentSelector:
+      path: metadata.name
+      value: testrelease-nfs
+    set:
+      volumeMounts.database.data.enabled: true
+      volumeMounts.database.data.claimName: mariadb
+      volumeMounts.database.data.type: persistentVolume
+      volumeClaimTemplates.mariadb.storageClassName: nfs
+    asserts:
+      - isKind:
+          of: StorageClass
+      - equal:
+          path: metadata.name
+          value: testrelease-nfs
+      - equal:
+          path: parameters.pathPattern
+          value: "${.PVC.namespace}-${.PVC.name}"
+      - equal:
+          path: parameters.onDelete
+          value: "delete"
+      - equal:
+          path: parameters.archiveOnDelete
+          value: "true"
+      - equal:
+          path: provisioner
+          value: cluster.local/nfs-subdir-external-provisioner
+      - equal:
+          path: reclaimPolicy
+          value: Delete
+      - equal:
+          path: volumeBindingMode
+          value: WaitForFirstConsumer
+      - equal:
+          path: allowVolumeExpansion
+          value: true
+  - it: no storageclass for mariadb data defined
+    set:
+      volumeMounts.database.data.enabled: true
+      volumeMounts.database.data.claimName: mariadb
+      volumeMounts.database.data.type: persistentVolume
+      volumeClaimTemplates.mariadb.storageClassName:
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: invalid storageclass for mariadb data defined
+    set:
+      volumeMounts.database.data.enabled: true
+      volumeMounts.database.data.claimName: mariadb
+      volumeMounts.database.data.type: persistentVolume
+      volumeClaimTemplates.mariadb.storageClassName: invalid
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: storageclass cinder for mariadb log defined
+    documentSelector:
+      path: metadata.name
+      value: testrelease-cinder
+    set:
+      volumeMounts.database.log.enabled: true
+      volumeMounts.database.log.claimName: marialog
+      volumeMounts.database.log.type: persistentVolume
+      volumeClaimTemplates.marialog.storageClassName: cinder
+    asserts:
+      - isKind:
+          of: StorageClass
+      - equal:
+          path: metadata.name
+          value: testrelease-cinder
+      - equal:
+          path: provisioner
+          value: cinder.csi.openstack.org
+      - equal:
+          path: reclaimPolicy
+          value: Delete
+      - equal:
+          path: volumeBindingMode
+          value: WaitForFirstConsumer
+      - equal:
+          path: allowVolumeExpansion
+          value: true
+  - it: storageclass nfs for mariadb log defined
+    documentSelector:
+      path: metadata.name
+      value: testrelease-nfs
+    set:
+      volumeMounts.database.log.enabled: true
+      volumeMounts.database.log.claimName: marialog
+      volumeMounts.database.log.type: persistentVolume
+      volumeClaimTemplates.marialog.storageClassName: nfs
+    asserts:
+      - isKind:
+          of: StorageClass
+      - equal:
+          path: metadata.name
+          value: testrelease-nfs
+      - equal:
+          path: parameters.pathPattern
+          value: "${.PVC.namespace}-${.PVC.name}"
+      - equal:
+          path: parameters.onDelete
+          value: "delete"
+      - equal:
+          path: parameters.archiveOnDelete
+          value: "true"
+      - equal:
+          path: provisioner
+          value: cluster.local/nfs-subdir-external-provisioner
+      - equal:
+          path: reclaimPolicy
+          value: Delete
+      - equal:
+          path: volumeBindingMode
+          value: WaitForFirstConsumer
+      - equal:
+          path: allowVolumeExpansion
+          value: true
+  - it: no storageclass for mariadb log defined
+    set:
+      volumeMounts.database.log.enabled: true
+      volumeMounts.database.log.claimName: marialog
+      volumeMounts.database.log.type: persistentVolume
+      volumeClaimTemplates.marialog.storageClassName:
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: invalid storageclass for mariadb log defined
+    set:
+      volumeMounts.database.log.enabled: true
+      volumeMounts.database.log.claimName: marialog
+      volumeMounts.database.log.type: persistentVolume
+      volumeClaimTemplates.marialog.storageClassName: invalid
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: storageclass nfs for kopia backups defined
+    documentSelector:
+      path: metadata.name
+      value: testrelease-nfs
+    set:
+      volumeMounts.backup.kopia.data.enabled: true
+      volumeMounts.backup.kopia.data.claimName: mariabackup
+      volumeMounts.backup.kopia.data.type: persistentVolume
+      volumeClaimTemplates.mariabackup.storageClassName: nfs
+    asserts:
+      - isKind:
+          of: StorageClass
+      - equal:
+          path: metadata.name
+          value: testrelease-nfs
+      - equal:
+          path: parameters.pathPattern
+          value: "${.PVC.namespace}-${.PVC.name}"
+      - equal:
+          path: parameters.onDelete
+          value: "delete"
+      - equal:
+          path: parameters.archiveOnDelete
+          value: "true"
+      - equal:
+          path: provisioner
+          value: cluster.local/nfs-subdir-external-provisioner
+      - equal:
+          path: reclaimPolicy
+          value: Delete
+      - equal:
+          path: volumeBindingMode
+          value: WaitForFirstConsumer
+      - equal:
+          path: allowVolumeExpansion
+          value: true
+  - it: no storageclass for kopia backups defined
+    set:
+      volumeMounts.backup.kopia.data.enabled: true
+      volumeMounts.backup.kopia.data.claimName: mariabackup
+      volumeMounts.backup.kopia.data.type: persistentVolume
+      volumeClaimTemplates.mariabackup.storageClassName:
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: invalid storageclass for kopia backups defined
+    set:
+      volumeMounts.backup.kopia.data.enabled: true
+      volumeMounts.backup.kopia.data.claimName: mariabackup
+      volumeMounts.backup.kopia.data.type: persistentVolume
+      volumeClaimTemplates.mariabackup.storageClassName: invalid
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: storageclass cinder for proxysql data defined
+    documentSelector:
+      path: metadata.name
+      value: testrelease-cinder
+    set:
+      volumeMounts.proxy.proxysql.data.enabled: true
+      volumeMounts.proxy.proxysql.data.claimName: proxysql
+      volumeMounts.proxy.proxysql.data.type: persistentVolume
+      volumeClaimTemplates.proxysql.storageClassName: cinder
+    asserts:
+      - isKind:
+          of: StorageClass
+      - equal:
+          path: metadata.name
+          value: testrelease-cinder
+      - equal:
+          path: provisioner
+          value: cinder.csi.openstack.org
+      - equal:
+          path: reclaimPolicy
+          value: Delete
+      - equal:
+          path: volumeBindingMode
+          value: WaitForFirstConsumer
+      - equal:
+          path: allowVolumeExpansion
+          value: true
+  - it: storageclass nfs for proxysql data defined
+    documentSelector:
+      path: metadata.name
+      value: testrelease-nfs
+    set:
+      volumeMounts.proxy.proxysql.data.enabled: true
+      volumeMounts.proxy.proxysql.data.claimName: proxysql
+      volumeMounts.proxy.proxysql.data.type: persistentVolume
+      volumeClaimTemplates.proxysql.storageClassName: nfs
+    asserts:
+      - isKind:
+          of: StorageClass
+      - equal:
+          path: metadata.name
+          value: testrelease-nfs
+      - equal:
+          path: parameters.pathPattern
+          value: "${.PVC.namespace}-${.PVC.name}"
+      - equal:
+          path: parameters.onDelete
+          value: "delete"
+      - equal:
+          path: parameters.archiveOnDelete
+          value: "true"
+      - equal:
+          path: provisioner
+          value: cluster.local/nfs-subdir-external-provisioner
+      - equal:
+          path: reclaimPolicy
+          value: Delete
+      - equal:
+          path: volumeBindingMode
+          value: WaitForFirstConsumer
+      - equal:
+          path: allowVolumeExpansion
+          value: true
+  - it: no storageclass for proxysql data defined
+    set:
+      volumeMounts.proxy.proxysql.data.enabled: true
+      volumeMounts.proxy.proxysql.data.claimName: proxysql
+      volumeMounts.proxy.proxysql.data.type: persistentVolume
+      volumeClaimTemplates.proxysql.storageClassName:
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: invalid storageclass for proxysql data defined
+    set:
+      volumeMounts.proxy.proxysql.data.enabled: true
+      volumeMounts.proxy.proxysql.data.claimName: proxysql
+      volumeMounts.proxy.proxysql.data.type: persistentVolume
+      volumeClaimTemplates.proxysql.storageClassName: invalid
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/common/mariadb-galera/helm/values.yaml
+++ b/common/mariadb-galera/helm/values.yaml
@@ -1098,29 +1098,29 @@ volumeClaimTemplates:
     accessModes: [ReadWriteOnce]
     # -- capacity for the MariaDB data volume
     capacity: 10Gi
-    # -- custom storageclass (currently `cinder` and `nfs` are supported) for the MariaDB data volume
-    storageClassName: false
+    # -- (string) custom storageclass (currently `cinder` and `nfs` are supported) for the MariaDB data volume
+    storageClassName:
   marialog:
     # -- [access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) for the MariaDB log volume
     accessModes: [ReadWriteOnce]
     # -- capacity for the MariaDB log volume
     capacity: 30Gi
-    # -- custom storageclass (currently `cinder` and `nfs` are supported) for the MariaDB log volume
-    storageClassName: false
+    # -- (string) custom storageclass (currently `cinder` and `nfs` are supported) for the MariaDB log volume
+    storageClassName:
   mariabackup:
     # -- [access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) for the MariaDB backup volume (used by Kopia)
     accessModes: [ReadWriteMany]
     # -- capacity for the MariaDB backup volume
     capacity: 100Gi
-    # -- custom storageclass (currently `nfs` is supported) for the MariaDB backup volume to allow the shared access for all Kopia pods
-    storageClassName: nfs
+    # -- (string) custom storageclass (currently `nfs` is supported) for the MariaDB backup volume to allow the shared access for all Kopia pods
+    storageClassName:
   proxysql:
     # -- [access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) for the ProxySQL data volume
     accessModes: [ReadWriteOnce]
     # -- capacity for the ProxySQL data volume
     capacity: 128Mi
-    # -- custom storageclass (currently `cinder` and `nfs` are supported) for the ProxySQL data volume
-    storageClassName: false
+    # -- (string) custom storageclass (currently `cinder` and `nfs` are supported) for the ProxySQL data volume
+    storageClassName:
 
 # Resource limits per container
 resourceLimits:


### PR DESCRIPTION
- to avoid unexpected and not required storageclasses in the cluster
- unit tests added
- chart version bumped