### PR TITLE
[designate-nanny-global] change pull policy in global setup

### DIFF
--- a/openstack/designate-nanny/templates/deployment.yaml
+++ b/openstack/designate-nanny/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
      containers:
      - name: {{ .Release.Name }}
        image: {{ required ".Values.global.registry is missing" .Values.global.registry }}/{{ .Values.image.name }}:{{required "missing .Values.image.image_tag" .Values.image.image_tag }}
-       {{- if or (eq .Values.global.region "qa-de-1") (eq .Values.global.region "qa-de-2") }}
+       {{- if or (eq .Values.global.region "qa-de-1") (eq .Values.global.region "qa-de-2") (eq .Values.global_setup true) }}
        imagePullPolicy: Always
        {{- else }}
        imagePullPolicy: IfNotPresent


### PR DESCRIPTION
until image transport somehow works in the global pipeline, lets always pull the image.