### PR TITLE
[Nova] Switch from raven-python to sentry-python

### DIFF
--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -870,33 +870,37 @@ logging:
       args: "()"
       formatter: default
     sentry:
-      class: raven.handlers.logging.SentryHandler
+      class: raven.handlers.logging.EventHandler
       level: ERROR
+      args: "()"
+    sentry_breadcrumb:
+      class: raven.handlers.logging.BreadcrumbHandler
+      level: DEBUG
       args: "()"
   loggers:
     root:
-      handlers: stdout, sentry
+      handlers: stdout, sentry, sentry_breadcrumb
       level: WARNING
     migrate:
-      handlers: stdout, sentry
+      handlers: stdout, sentry, sentry_breadcrumb
       level: INFO
     nova:
-      handlers: stdout, sentry
+      handlers: stdout, sentry, sentry_breadcrumb
       level: INFO
     nova.scheduler:
-      handlers: stdout, sentry
+      handlers: stdout, sentry, sentry_breadcrumb
       level: DEBUG
     nova.scheduler.host_manager: # You might get problems with unicodedecode errors if you decrease that
-      handlers: stdout, sentry
+      handlers: stdout, sentry, sentry_breadcrumb
       level: INFO
     nova.virt.vmwareapi:
-      handlers: stdout, sentry
+      handlers: stdout, sentry, sentry_breadcrumb
       level: DEBUG
     eventlet.wsgi.server:
-      handlers: stdout, sentry
+      handlers: stdout, sentry, sentry_breadcrumb
       level: INFO
     oslo.privsep:
-      handlers: stdout, sentry
+      handlers: stdout, sentry, sentry_breadcrumb
       level: INFO
     suds:
       handlers: "null"


### PR DESCRIPTION
The old raven package is deprecated and out of maintenance since a while. While it will stay mostly compatible, we can get a little more information into Sentry, if we also configure the `BreadcrumbHandler`. We want it to pick up any log line, so we configure it with DEBUG level. This will only add breadcrumbs to an event that's actually sent in the end. Which log lines get sent as event is configured by the level of the `EventHandler`.