### PR TITLE
[octavia] - add ccloud_special_xfh_override ESD

### DIFF
--- a/openstack/octavia/templates/etc/_esd.json.tpl
+++ b/openstack/octavia/templates/etc/_esd.json.tpl
@@ -52,5 +52,9 @@
   },
   "ccloud_special_fastl4_noaging": {
     "lbaas_fastl4": "cc_fastL4_noaging_profile"
+  },
+  "ccloud_special_xfh_override": {
+    "lbaas_ctcp": "cc_tcp_profile",
+    "lbaas_irule": ["cc_xfh_override"]
   }
 }

--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -108,7 +108,11 @@ mysql_metrics:
           OR tag='cookie_encryption_b82a_v1_0'
           OR tag='sso_22b0_v1_0'
           OR tag='sso_required_f544_v1_0'
-          OR tag='http_redirect_a26c_v1_0';
+          OR tag='http_redirect_a26c_v1_0'
+          OR tag='ccloud_special_udp_stateless'
+          OR tag='ccloud_special_fastl4_noaging'
+          OR tag='ccloud_special_l4_deactivate_snat'
+          OR tag='ccloud_special_xfh_override';
       values:
         - "count_gauge"
     - name: octavia_esd_l7policies_count_gauge


### PR DESCRIPTION
In this PR I'm adding an ESD `ccloud_special_xfh_override`, to be available as a listener tag.
This is a follow up to recent PR https://github.com/sapcc/octavia-f5-provider-driver/pull/264, background and more details are described in that PR.

I am also adding the ESD, together with some older, missing ESDs to the mysql metrics `octavia_esd_tags_count_gauge`
