### PR TITLE
content-repo: write key servers explicitly and remove default pgp.mit…

### DIFF
--- a/openstack/content-repo/templates/configmap.yaml
+++ b/openstack/content-repo/templates/configmap.yaml
@@ -22,6 +22,9 @@ data:
 
     gpg:
       cache_container_name: repo-gpg-cache
+      keyserver_urls:
+        - "https://keyserver.ubuntu.com/pks/lookup?search=0x{keyid}&options=mr&op=get"
+        - "https://keys.openpgp.org/pks/lookup?search=0x{keyid}&options=mr&op=get"
 
     statsd:
       hostname: {{$.Values.statsd_hostname}}


### PR DESCRIPTION
….edu which is usually terribly slow