### PR TITLE
[rabbitmq] Add an option to enable all stable feature flags in the RabbitMQ instance

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -3,6 +3,10 @@ Rabbitmq CHANGELOG
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+0.7.3
+-----
+- add option enableAllFeatureFlags to enable all stable feature flags after service has started
+
 0.7.2
 -----
 - Fix RabbitMQRPCUnackTotal alert to support both old and new unack metric name

--- a/common/rabbitmq/ci/test-values.yaml
+++ b/common/rabbitmq/ci/test-values.yaml
@@ -17,6 +17,8 @@ users:
     user: test2
     password: test
 
+enableAllFeatureFlags: false
+
 persistence:
   enabled: false
 

--- a/common/rabbitmq/templates/bin/_rabbitmq-start.tpl
+++ b/common/rabbitmq/templates/bin/_rabbitmq-start.tpl
@@ -49,6 +49,10 @@ rabbitmq-plugins enable rabbitmq_tracing
 rabbitmqctl trace_on
 {{- end }}
 
+{{- if and .Values.enableAllFeatureFlags .Values.persistence.enabled }}
+rabbitmqctl enable_feature_flag all
+{{- end }}
+
 eval $(timeout 5.0 rabbitmqctl list_users -q | awk '{printf "users[\"%s\"]=\"%s\"\n", $1, substr($2, 2, length($2)-2)}')
 
 {{- range $k, $v := .Values.users }}

--- a/common/rabbitmq/values.yaml
+++ b/common/rabbitmq/values.yaml
@@ -38,6 +38,8 @@ users:
 # DANGEROUS, please make sure it is set to false unless really needed
 addDevUser: false
 
+enableAllFeatureFlags: true
+
 persistence:
   enabled: false
   accessMode: ReadWriteMany


### PR DESCRIPTION
Add an option to execute rabbitmqctl enable_feature_flag all on rabbitmq-server startup.

It only needed and might be used on instances with persistence enabled. This also makes downgrades impossible.