### PR TITLE
[rabbitmq] Add support for RABBITMQ_FEATURE_FLAGS env variable in RabbitMQ

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -3,6 +3,10 @@ Rabbitmq CHANGELOG
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+0.7.3
+-----
+- add forcedFeatureFlags with default list of 3.13.0 features to allow forced feature activation on rabbitmq instance init
+
 0.7.2
 -----
 - Fix RabbitMQRPCUnackTotal alert to support both old and new unack metric name

--- a/common/rabbitmq/ci/test-values.yaml
+++ b/common/rabbitmq/ci/test-values.yaml
@@ -20,6 +20,9 @@ users:
 persistence:
   enabled: false
 
+forcedFeatureFlags:
+  enabled: true
+
 resources:
   requests:
     memory: 1Mi

--- a/common/rabbitmq/templates/deployment.yaml
+++ b/common/rabbitmq/templates/deployment.yaml
@@ -82,6 +82,10 @@ spec:
         env:
           - name: RABBIT_START_TIMEOUT
             value: {{ .Values.livenessProbe.initialDelaySeconds | quote }}
+          {{- if and .Values.forcedFeatureFlags.enabled .Values.persistence.enabled }}
+          - name: RABBITMQ_FEATURE_FLAGS
+            value: {{ join "," .Values.forcedFeatureFlags.flags | quote }}
+          {{- end }}
         command:
           - bash
         args:

--- a/common/rabbitmq/values.yaml
+++ b/common/rabbitmq/values.yaml
@@ -38,6 +38,16 @@ users:
 # DANGEROUS, please make sure it is set to false unless really needed
 addDevUser: false
 
+forcedFeatureFlags:
+  enabled: true
+  flags:
+    - stream_sac_coordinator_unblock_group
+    - restart_streams
+    - stream_update_config_command
+    - stream_filtering
+    - detailed_queues_endpoint
+    - message_containers
+
 persistence:
   enabled: false
   accessMode: ReadWriteMany


### PR DESCRIPTION
Populate it by default with all stable feature flags from 3.13.0