### PR TITLE
[Nova] Actually configure some weigh multipliers

### DIFF
--- a/openstack/nova/templates/etc/_nova-scheduler.conf.tpl
+++ b/openstack/nova/templates/etc/_nova-scheduler.conf.tpl
@@ -32,4 +32,6 @@ prefer_same_host_resize_weight_multiplier = {{ .Values.scheduler.prefer_same_hos
 prefer_same_shard_resize_weight_multiplier = {{ .Values.scheduler.prefer_same_shard_resize_weight_multiplier }}
 hv_ram_class_weight_multiplier = {{ .Values.scheduler.hv_ram_class_weight_multiplier }}
 hv_ram_class_weights_gib = {{ .Values.scheduler.hv_ram_class_weights_gib }}
+decommissioning_weight_multiplier = {{ .Values.scheduler.decommissioning_weight_multiplier }}
+sapphire_rapids_weight_multiplier = {{ .Values.scheduler.sapphire_rapids_weight_multiplier }}
 image_properties_default_architecture = {{ .Values.scheduler.image_properties_default_architecture }}


### PR DESCRIPTION
The configuration for the `SapphireRapidsWeigher` and for the `DecommissioningWeigher` was set in the values file but no template used them. Therefore, the weight for these weighers was never changed away from 1.