### PR TITLE
[barbican] enable get audit events

### DIFF
--- a/openstack/barbican/templates/etc/_barbican-api-paste.ini.tpl
+++ b/openstack/barbican/templates/etc/_barbican-api-paste.ini.tpl
@@ -86,7 +86,7 @@ config_file = /etc/barbican/watcher.yaml
 [filter:audit]
 paste.filter_factory = auditmiddleware:filter_factory
 audit_map_file = /etc/barbican/barbican_audit_map.yaml
-ignore_req_list = GET
+ignore_req_list = HEAD
 record_payloads = {{ if .Values.audit.record_payloads -}}True{{- else -}}False{{- end }}
 metrics_enabled = {{ if .Values.audit.metrics_enabled -}}True{{- else -}}False{{- end }}
 {{- end }}

--- a/openstack/barbican/templates/etc/_barbican_audit_map.yaml
+++ b/openstack/barbican/templates/etc/_barbican_audit_map.yaml
@@ -3,6 +3,11 @@ service_name: 'barbican'
 
 prefix: '/v1'
 
+# Default is to ignore READ, and HEAD requests
+# We are turning on GET requests, this is usually
+# not recommended due to massive load on the system
+ignore_req_list: HEAD
+
 resources:
   secrets:
     payloads:

--- a/openstack/barbican/templates/etc/_barbican_audit_map.yaml
+++ b/openstack/barbican/templates/etc/_barbican_audit_map.yaml
@@ -3,11 +3,6 @@ service_name: 'barbican'
 
 prefix: '/v1'
 
-# Default is to ignore READ, and HEAD requests
-# We are turning on GET requests, this is usually
-# not recommended due to massive load on the system
-ignore_req_list: HEAD
-
 resources:
   secrets:
     payloads:

--- a/openstack/hermes/templates/etc/_logstash.conf.tpl
+++ b/openstack/hermes/templates/etc/_logstash.conf.tpl
@@ -25,7 +25,7 @@ filter {
   # Drop events with action "read/list"
   # Barbican records reads, but has multiple events per read. 
   # This will keep it to one event per action 
-  if [action] == "read/list" {
+  if [action] == "read/list" or [action] == "read/get" {
     drop { }
   }
 

--- a/openstack/hermes/templates/etc/_logstash.conf.tpl
+++ b/openstack/hermes/templates/etc/_logstash.conf.tpl
@@ -22,6 +22,13 @@ rabbitmq {
 
 
 filter {
+  # Drop events with action "read/list"
+  # Barbican records reads, but has multiple events per read. 
+  # This will keep it to one event per action 
+  if [action] == "read/list" {
+    drop { }
+  }
+
   # unwrap messagingv2 envelope
   if [oslo.message] {
     json {

--- a/openstack/hermes/templates/etc/_logstash.conf.tpl
+++ b/openstack/hermes/templates/etc/_logstash.conf.tpl
@@ -25,7 +25,7 @@ filter {
   # Drop events with action "read/list"
   # Barbican records reads, but has multiple events per read. 
   # This will keep it to one event per action 
-  if [action] == "read/list" or [action] == "read/get" {
+  if ([action] == "read/list" or [action] == "read/get") {
     drop { }
   }
 


### PR DESCRIPTION
@rajivmucheli This is the configuration to test the read audit events for Barbican. I need this deployed in QA first before we deploy this completely to test and validate. We need to see what the load is, if it works correctly, and if we can handle the load. 

It may also be that we only require a subset of events with read, and then will need to add to the logstash conf to drop other events. 

So next steps are, can you please deploy this change just to a QA region for evaluation? If it makes sense, and we agree, we can deploy to all regions. If it has issues, or we need to make additional config changes, we can do so. 