### PR TITLE
[keystone] optionally enable auth and service ips for memcached

### DIFF
--- a/openstack/keystone/Chart.lock
+++ b/openstack/keystone/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 0.28.0
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.2.0
+  version: 0.5.0
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.3.3
@@ -26,5 +26,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.4
-digest: sha256:bf0e16fcaa2579922aa3a4df367bdca49820fdad0ebd1ab348a5686e465c085c
-generated: "2024-06-25T15:26:22.862277+02:00"
+digest: sha256:b9d0d34b21f644547a321b59fd24a952580c3d97a1ca1119dd6cefdc610efd65
+generated: "2024-07-03T11:22:05.060182+02:00"

--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -22,7 +22,7 @@ dependencies:
     version: 0.28.0
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.2.0
+    version: 0.5.0
   - condition: mysql_metrics.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/keystone/templates/etc/_keystone.conf.tpl
+++ b/openstack/keystone/templates/etc/_keystone.conf.tpl
@@ -80,7 +80,9 @@ access_token_duration = {{ .Values.api.oauth1.access_token_duration | default "0
 
 [cache]
 backend = dogpile.cache.memcached
-{{- if .Values.memcached.host }}
+{{- if .Values.global_setup }}
+memcached_servers = "{{ include "helm-toolkit.utils.joinListWithComma" .Values.memcached.server_ips_ports }}"
+{{- else if .Values.memcached.host }}
 memcache_servers = {{ .Values.memcached.host }}:{{.Values.memcached.port | default 11211}}
 {{ else }}
 memcache_servers = {{ include "memcached_host" . }}:{{.Values.memcached.port | default 11211}}

--- a/openstack/keystone/templates/etc/_secrets.conf.tpl
+++ b/openstack/keystone/templates/etc/_secrets.conf.tpl
@@ -16,6 +16,13 @@ connection = mysql+pymysql://{{ .Values.mariadb_galera.mariadb.users.keystone.us
 connection = {{ include "db_url_mysql" . }}
 {{- end }}
 
+{{- if and .Values.memcached.auth.username .Values.memcached.auth.password }}
+[cache]
+memcache_sasl_enabled = True
+memcache_username = {{ .Values.memcached.auth.username }}
+memcache_password = {{ .Values.memcached.auth.password }}
+{{- end }}
+
 {{- if not (and (hasKey $.Values "oslo_messaging_notifications") ($.Values.oslo_messaging_notifications.disabled)) }}
 [oslo_messaging_notifications]
 driver = messaging


### PR DESCRIPTION
- service ips are needed for global setup
- memcached auth can optionally be enabled from 0.5.0 chart version