### PR TITLE
[rabbitmq][Cinder] Use RabbitMQ prometheus plugin metrics

### DIFF
--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -323,9 +323,9 @@ rabbitmq:
     ready_total_wait_for: 60m
     support_group: compute-storage-api
   metrics:
-    enabled: &metrics true
+    enabled: true
     sidecar:
-      enabled: *metrics
+      enabled: false
   enableDetailedMetrics: true
   enablePerObjectMetrics: true 
 rabbitmq_notifications:


### PR DESCRIPTION
Stop using deprecated management API sidecar exporter