### PR TITLE
[rabbitmq] Remove support of the insecure rabbitmq-exporter sidecar

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -3,6 +3,13 @@ Rabbitmq CHANGELOG
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+0.8.0
+-----
+- Remove support of the insecure rabbitmq-exporter sidecar container
+  1. Sidecar uses plaintext credentials in environment variables
+  2. Sidecar utilises Management API metrics
+  3. Management API metrics will not be supported in future RabbitMQ releases
+
 0.7.5
 -----
 - remove shared service labels from volumeClaimTemplates, because it's immutable

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 0.7.5
+version: 0.8.0
 description: A Helm chart for RabbitMQ
 sources:
 - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/templates/bin/_rabbitmq-start.tpl
+++ b/common/rabbitmq/templates/bin/_rabbitmq-start.tpl
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-{{- if and .Values.metrics.enabled (not .Values.metrics.sidecar.enabled) .Values.metrics.port }}
+{{- if and .Values.metrics.enabled .Values.metrics.port }}
 echo "prometheus.tcp.port = {{ .Values.metrics.port }}" >> /etc/rabbitmq/conf.d/10-defaults.conf
 {{- end}}
 {{- if .Values.addDevUser }}

--- a/common/rabbitmq/templates/deployment.yaml
+++ b/common/rabbitmq/templates/deployment.yaml
@@ -115,7 +115,7 @@ spec:
             containerPort: {{ default "5672" .Values.ports.public }}
           - name: management
             containerPort: {{ default "15672" .Values.ports.management }}
-{{- if and (not .Values.metrics.sidecar.enabled) .Values.metrics.enabled }}
+{{- if .Values.metrics.enabled }}
           - name: metrics
             containerPort: {{ default "15692" .Values.metrics.port }}
 {{- end }}
@@ -129,25 +129,6 @@ spec:
             name: rabbitmq-custom-config
             subPath: 20-custom.conf
         {{- end }}
-{{- if and .Values.metrics.sidecar.enabled .Values.metrics.enabled }}
-      - name: metrics
-        image: {{include "dockerHubMirror" .}}/{{ .Values.metrics.image }}:{{ .Values.metrics.imageTag }}
-        imagePullPolicy: {{ default "IfNotPresent" .Values.metrics.imagePullPolicy | quote }}
-        env:
-          - name: PUBLISH_PORT
-            value: {{ default "9150" .Values.metrics.port | quote }}
-          - name: RABBIT_USER
-            value: {{ .Values.metrics.user | quote }}
-          - name: RABBIT_PASSWORD
-            value: {{ required ".Values.metrics.password missing" .Values.metrics.password | quote }}
-          - name: RABBIT_URL
-            value: "http://127.0.0.1:{{.Values.ports.management}}"
-        resources:
-{{ toYaml .Values.metrics.resources | indent 10 }}
-        ports:
-          - name: metrics
-            containerPort: {{ default "9150" .Values.metrics.port }}
-{{- end }}
       priorityClassName: {{ default "openstack-service-critical" .Values.priority_class | quote }}
       volumes:
         - name: rabbitmq-persistent-storage

--- a/common/rabbitmq/templates/statefulset.yaml
+++ b/common/rabbitmq/templates/statefulset.yaml
@@ -107,7 +107,7 @@ spec:
             containerPort: {{ default "5672" .Values.ports.public }}
           - name: management
             containerPort: {{ default "15672" .Values.ports.management }}
-{{- if and (not .Values.metrics.sidecar.enabled) .Values.metrics.enabled }}
+{{- if .Values.metrics.enabled }}
           - name: metrics
             containerPort: {{ default "15692" .Values.metrics.port }}
 {{- end }}
@@ -121,25 +121,6 @@ spec:
             name: rabbitmq-custom-config
             subPath: 20-custom.conf
         {{- end }}
-{{- if and .Values.metrics.sidecar.enabled .Values.metrics.enabled }}
-      - name: metrics
-        image: {{include "dockerHubMirror" .}}/{{ .Values.metrics.image }}:{{ .Values.metrics.imageTag }}
-        imagePullPolicy: {{ default "IfNotPresent" .Values.metrics.imagePullPolicy | quote }}
-        env:
-          - name: PUBLISH_PORT
-            value: {{ default "9150" .Values.metrics.port | quote }}
-          - name: RABBIT_USER
-            value: {{ .Values.metrics.user | quote }}
-          - name: RABBIT_PASSWORD
-            value: {{ required ".Values.metrics.password missing" .Values.metrics.password | quote }}
-          - name: RABBIT_URL
-            value: "http://127.0.0.1:{{.Values.ports.management}}"
-        resources:
-{{ toYaml .Values.metrics.resources | indent 10 }}
-        ports:
-          - name: metrics
-            containerPort: {{ default "9150" .Values.metrics.port }}
-{{- end }}
       priorityClassName: {{ default "openstack-service-critical" .Values.priority_class | quote }}
       volumes:
       {{- if not .Values.persistence.enabled }}

--- a/common/rabbitmq/values.yaml
+++ b/common/rabbitmq/values.yaml
@@ -75,21 +75,10 @@ resources:
 nodeAffinity: {}
 
 metrics:
-  enabled: &metrics true
-  sidecar:
-    enabled: *metrics
-  image: kbudde/rabbitmq-exporter
-  imageTag: 0.16.0
+  enabled: true
   user: monitoring
   password: null
   port: 9150
-  resources:
-    limits:
-      memory: 512Mi
-      cpu: 500m
-    requests:
-      memory: 64Mi
-      cpu: 100m
   enableDetailedMetrics: false
   enablePerObjectMetrics: false
 


### PR DESCRIPTION
Remove support of the insecure rabbitmq-exporter sidecar container:
1. Sidecar uses plaintext credentials in environment variables
2. Sidecar utilises Management API metrics
3. Management API metrics will not be supported in future RabbitMQ releases

Always use rabbitmq prometheus plugin instead