### PR TITLE
[rabbitmq] Fix RabbitMQRPCUnackTotal alert

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -3,6 +3,10 @@ Rabbitmq CHANGELOG
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+0.7.2
+-----
+- Fix RabbitMQRPCUnackTotal alert to support both old and new unack metric name
+
 0.7.1
 ------
 birk.bohne@sap.com

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 0.7.1
+version: 0.7.2
 description: A Helm chart for RabbitMQ
 sources:
 - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/templates/alerts/_rabbitmq.alerts.tpl
+++ b/common/rabbitmq/templates/alerts/_rabbitmq.alerts.tpl
@@ -2,7 +2,14 @@ groups:
 - name: {{ include "alerts.service" . | title }}-rabbitmq.alerts
   rules:
   - alert: {{ include "alerts.service" . | title }}RabbitMQRPCUnackTotal
-    expr: sum(rabbitmq_queue_messages_unacknowledged{app=~"{{ include "alerts.service" . }}-rabbitmq"}) by (app) > {{ .Values.alerts.rabbit_queue_length | default 1000 }}
+    expr: |
+      (
+        sum(rabbitmq_queue_messages_unacknowledged{app=~"{{ include "alerts.service" . }}-rabbitmq"}) by (app) > {{ .Values.alerts.rabbit_queue_length | default 1000 }}
+      )
+      or
+      (
+        sum(rabbitmq_queue_messages_unacked{app=~"{{ include "alerts.service" . }}-rabbitmq"}) by (app) > {{ .Values.alerts.rabbit_queue_length | default 1000 }}
+      )
     for: {{ .Values.alerts.unacknowledged_total_wait_for | default "1m" }}
     labels:
       severity: critical


### PR DESCRIPTION
RabbitMQRPCUnackTotal alert should support both sidecar exporter metric name and prometheus plugin
