### PR TITLE
Keystone: add back a check for domain id to list_projects API

### DIFF
--- a/openstack/keystone/templates/etc/_policy.yaml.tpl
+++ b/openstack/keystone/templates/etc/_policy.yaml.tpl
@@ -923,6 +923,7 @@
 # Intended scope(s): system, domain
 #"identity:list_projects": "(role:reader and system_scope:all) or (role:reader and domain_id:%(target.domain_id)s)"
 "identity:list_projects": "rule:cloud_reader or
+  (role:reader and domain_id:%(target.domain_id)s) or
   (role:reader and domain_id:%(domain_id)s) or
   (role:reader and project_id:%(parent_id)s)"
 


### PR DESCRIPTION
This was missed when subproject management policies were added in #6720 and some users got affected