### PR TITLE
Revert ceph enable rgw logs

### DIFF
--- a/system/cc-ceph/Chart.yaml
+++ b/system/cc-ceph/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cc-ceph
 description: A Helm chart for the Rook / Ceph Objects inside the Storage Clusters
 type: application
-version: 1.0.62
+version: 1.0.63
 appVersion: "1.14.3"
 dependencies:
   - name: owner-info

--- a/system/cc-ceph/values.yaml
+++ b/system/cc-ceph/values.yaml
@@ -23,10 +23,6 @@ cephConfig:
     mon_data_avail_warn: "10"
     osd_op_queue: "wpq"
     osd_pool_default_pg_autoscale_mode: "off"
-    rgw_enable_ops_log: "true"
-    rgw_ops_log_rados: "false"
-    rgw_ops_log_file_path: "/dev/stderr"
-    rgw_enable_usage_log: "true"
   mon:
     ms_client_mode: "secure"
     ms_cluster_mode: "secure"


### PR DESCRIPTION
revert #6694 due to massive logging of
`debug 2024-07-05T10:03:15.659+0000 7fcb75509700  0 rgw OpsLogFile: ERROR: failed to log RGW ops log file entry `