### PR TITLE
[octavia] Match cc3test alerts correctly

### DIFF
--- a/openstack/octavia/alerts/octavia.alerts
+++ b/openstack/octavia/alerts/octavia.alerts
@@ -90,7 +90,7 @@ groups:
       description: 'The Load Balancer `{{ $labels.loadbalancer_name }} ({{ $labels.loadbalancer_id }})` of agent `{{ $labels.loadbalancer_host }}` stuck in {{ $labels.loadbalancer_status }} state (<https://dashboard.{{ $externalLabels.region }}.cloud.sap/ccadmin/cloud_admin/cloudops#/universal-search/?searchTerm={{ $labels.loadbalancer_id }}&type=loadbalancer|Dashboard>)'
       summary: Octavia Load-Balancer stuck in PENDING_*_KubeServices state
   - alert: OctaviaLoadBalancerStuckInPendingcc3test
-    expr: octavia_seconds_since_last_nonpending_status{loadbalancer_name=~"c3test.*"} > 30 * 60
+    expr: octavia_seconds_since_last_nonpending_status{loadbalancer_name=~"cc3test.*"} > 30 * 60
     labels:
       no_alert_on_absence: "true"
       context: Load-Balancer stuck
@@ -106,7 +106,7 @@ groups:
       description: 'The Load Balancer `{{ $labels.loadbalancer_name }} ({{ $labels.loadbalancer_id }})` of agent `{{ $labels.loadbalancer_host }}` stuck in {{ $labels.loadbalancer_status }} state (<https://dashboard.{{ $externalLabels.region }}.cloud.sap/ccadmin/cloud_admin/cloudops#/universal-search/?searchTerm={{ $labels.loadbalancer_id }}&type=loadbalancer|Dashboard>)'
       summary: Octavia Load-Balancer stuck in PENDING_*_c3test state
   - alert: OctaviaLoadBalancerStuckInPending
-    expr: octavia_seconds_since_last_nonpending_status{loadbalancer_name!~"kube_service_e2e.*|kube_service_shoot.*|c3test.*"} > 30 * 60 
+    expr: octavia_seconds_since_last_nonpending_status{loadbalancer_name!~"kube_service_e2e.*|kube_service_shoot.*|cc3test.*"} > 30 * 60 
     labels:
       no_alert_on_absence: "true"
       context: Load-Balancer stuck


### PR DESCRIPTION
Fix a typo in the alert matching definition, it was `c3test` which is incorrect.