### PR TITLE
add nodelete noresize to pools

### DIFF
--- a/system/cc-ceph/templates/cephobjectstore-placement-pools.yaml
+++ b/system/cc-ceph/templates/cephobjectstore-placement-pools.yaml
@@ -25,6 +25,8 @@ spec:
   parameters:
     pg_num: "1024"
     pgp_num: "1024"
+    nodelete: {{ $.Values.pool.nodelete | quote }}
+    nosizechange: {{ $.Values.pool.nosizechange | quote }}
 ---
 apiVersion: ceph.rook.io/v1
 kind: CephBlockPool
@@ -50,6 +52,8 @@ spec:
   parameters:
     pg_num: "128"
     pgp_num: "128"
+    nodelete: {{ $.Values.pool.nodelete | quote }}
+    nosizechange: {{ $.Values.pool.nosizechange | quote }}
 ---
 apiVersion: ceph.rook.io/v1
 kind: CephBlockPool
@@ -73,5 +77,7 @@ spec:
   parameters:
     pg_num: "32"
     pgp_num: "32"
+    nodelete: {{ $.Values.pool.nodelete | quote }}
+    nosizechange: {{ $.Values.pool.nosizechange | quote }}
 {{- end }}
 {{- end }}

--- a/system/cc-ceph/templates/cephpool.yaml
+++ b/system/cc-ceph/templates/cephpool.yaml
@@ -23,6 +23,8 @@ spec:
   parameters:
     pg_num: "4"
     pgp_num: "4"
+    nodelete: {{ .Values.pool.nodelete | quote }}
+    nosizechange: {{ .Values.pool.nosizechange | quote }}
 
 
     

--- a/system/cc-ceph/templates/default_rgw_pools.yaml
+++ b/system/cc-ceph/templates/default_rgw_pools.yaml
@@ -16,6 +16,8 @@ spec:
   parameters:
     pg_num: "8"
     pgp_num: "8"
+    nodelete: {{ .Values.pool.nodelete | quote }}
+    nosizechange: {{ .Values.pool.nosizechange | quote }}
 ---
 apiVersion: ceph.rook.io/v1
 kind: CephBlockPool
@@ -34,6 +36,8 @@ spec:
   parameters:
     pg_num: "8"
     pgp_num: "8"
+    nodelete: {{ .Values.pool.nodelete | quote }}
+    nosizechange: {{ .Values.pool.nosizechange | quote }}
 ---
 apiVersion: ceph.rook.io/v1
 kind: CephBlockPool
@@ -52,6 +56,8 @@ spec:
   parameters:
     pg_num: "8"
     pgp_num: "8"
+    nodelete: {{ .Values.pool.nodelete | quote }}
+    nosizechange: {{ .Values.pool.nosizechange | quote }}
 ---
 apiVersion: ceph.rook.io/v1
 kind: CephBlockPool
@@ -70,6 +76,8 @@ spec:
   parameters:
     pg_num: "8"
     pgp_num: "8"
+    nodelete: {{ .Values.pool.nodelete | quote }}
+    nosizechange: {{ .Values.pool.nosizechange | quote }}
 ---
 apiVersion: ceph.rook.io/v1
 kind: CephBlockPool
@@ -88,6 +96,8 @@ spec:
   parameters:
     pg_num: "32"
     pgp_num: "32"
+    nodelete: {{ .Values.pool.nodelete | quote }}
+    nosizechange: {{ .Values.pool.nosizechange | quote }}
 ---
 apiVersion: ceph.rook.io/v1
 kind: CephBlockPool
@@ -106,6 +116,8 @@ spec:
   parameters:
     pg_num: "8"
     pgp_num: "8"
+    nodelete: {{ .Values.pool.nodelete | quote }}
+    nosizechange: {{ .Values.pool.nosizechange | quote }}
 ---
 apiVersion: ceph.rook.io/v1
 kind: CephBlockPool
@@ -124,6 +136,8 @@ spec:
   parameters:
     pg_num: "8"
     pgp_num: "8"
+    nodelete: {{ .Values.pool.nodelete | quote }}
+    nosizechange: {{ .Values.pool.nosizechange | quote }}
 ---
 apiVersion: ceph.rook.io/v1
 kind: CephBlockPool
@@ -142,5 +156,7 @@ spec:
   parameters:
     pg_num: "8"
     pgp_num: "8"
+    nodelete: {{ .Values.pool.nodelete | quote }}
+    nosizechange: {{ .Values.pool.nosizechange | quote }}
 {{- end }}
     

--- a/system/cc-ceph/values.yaml
+++ b/system/cc-ceph/values.yaml
@@ -53,6 +53,12 @@ prepareosd:
 pool:
   mgr:
     replicated: 3
+  # Sets "ceph osd pool set nodelete" to all CephBolckPools. Valid values: "0" | "1"
+  # Set to "1" to to prevent unintended pool changes in production
+  nodelete: "1"
+  # Sets "ceph osd pool set nodelete" to all CephBolckPools. Valid values: "0" | "1"
+  # Set to "1" to to prevent unintended pool changes in production
+  nosizechange: "1"
 
 mgr:
   nodeRole: ceph-mon


### PR DESCRIPTION
Fixes ceph-analyzer warnings. See https://github.com/cobaltcore-dev/cloud-storage/issues/18
