### PR TITLE
[keystone]bump up mysql_metrics to version 0.3.4

### DIFF
--- a/openstack/keystone/Chart.lock
+++ b/openstack/keystone/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 0.5.2
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.3.3
+  version: 0.3.4
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.3
@@ -26,5 +26,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.4
-digest: sha256:bb13197b8561554dcb9aa0ba51955734e75ec8a25167457b2db8c2bfceb6cac5
-generated: "2024-07-05T10:39:23.545272+02:00"
+digest: sha256:3d8c66265e6f8f3dbfe3c2b4269b55606bde9e3a43d21a7d4c02476b736bd91c
+generated: "2024-07-08T13:36:37.59075+02:00"

--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: keystone
 sources:
   - https://github.com/sapcc/keystone
-version: 0.6.10
+version: 0.6.11
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
@@ -26,7 +26,7 @@ dependencies:
   - condition: mysql_metrics.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.3.3
+    version: 0.3.4
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.2.3


### PR DESCRIPTION
bump up keystone helmchart dependencies to use mesql_metrics helm chart version 0.3.4
- fix new line issue in connection string

Change-Id: I44e6614c1db9a292bf1e634ccfa65da090b6f93e