### PR TITLE
bumps backupv2 image version

### DIFF
--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.12.0
+version: 0.12.1

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -119,7 +119,7 @@ backup_v2:
   enabled: false
   backup_dir: "./backup"
   image: maria-back-me-up
-  image_version: "20230623092741"
+  image_version: "20240708140352"
   full_backup_cron_schedule: "0 0 * * *"
   incremental_backup_in_minutes: 5
   purge_binlog_after_minutes: 60


### PR DESCRIPTION
- fixes issue that swift segments do not contain ttl
- updates to go version 1.22
- updates to latest go lint 