### PR TITLE
[Neutron] Suspend request hitting rate limit

### DIFF
--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -609,7 +609,7 @@ watcher:
 rate_limit:
   enabled: false
   rate_limit_by: target_project_id
-  max_sleep_time_seconds: 0
+  max_sleep_time_seconds: 61
   log_sleep_time_seconds: 10
   backend_timeout_seconds: 1
   whitelist:


### PR DESCRIPTION
Setting the max_sleep_time_seconds > 0, configures the rate limiting middleware to suspend a request for maximal that time.

Before suspending a call, the middleware calculates the actual waiting time of a request at which it can be raised again without hitting the rate limit. Request pausing happens if this time is smaller than the max pausing time. Otherwise no suspension happens, but rather the response header contains a HTTP Retry. Value is 2 *max_sleep_time_seconds. In this case customers must handle rate limiting hits on their own. E.g. the OpenStack Terraform provider utilizes the Retry-Header and waits accordingly.

The neutron service rate limits are calculated on a minuted based sliding window. Therefore max_sleep_time_seconds is set to 61.
60 seconds marks the max time until when calls without hitting a limit can be requested. For this rather border case, all occurring requests tend to cluster at the end of a sliding window.
It is most likely customers do not have to wait more than 60 seconds until raising requests again.