### PR TITLE
AbsentNetworkAsrHighMemoryUtilization

### DIFF
--- a/prometheus-exporters/network-generic-ssh-exporter/alerts/asr.alerts
+++ b/prometheus-exporters/network-generic-ssh-exporter/alerts/asr.alerts
@@ -256,19 +256,3 @@ groups:
       annotations:
         description: "Cisco ASR990x device `{{ $labels.name }}` has a high NTP offset."
         summary: "Cisco ASR990x device `{{ $labels.name }}` has a high NTP offset."
-
-    - alert: AbsentNetworkAsrHighMemoryUtilization
-      expr: >-
-        absent(ssh_memory_util_stats)
-      for: 10m
-      labels:
-        severity: warning
-        support_group: network-data
-        tier: net
-        service: asr
-        context: asr
-        playbook: 'docs/devops/alert/network/router.html#AbsentNetworkAsrHighMemoryUtilization'
-        dashboard: neutron-router
-      annotations:
-        summary: "Control Processor Memory Utilization for `{{ $labels.name }}` is Absent"
-        description: "Control Processor Memory Utilization for `{{ $labels.name }}` cannot be scraped"


### PR DESCRIPTION
This Absent metric is not needed as there will be alert generated automatically based on metric absence