### PR TITLE
[rabbitmq][Hermes] Don't use metrics sidecar container in Hermes

### DIFF
--- a/openstack/hermes/Chart.lock
+++ b/openstack/hermes/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 0.1.3
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.6.11
+  version: 0.7.2
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
-digest: sha256:d5d44194b1337927b0050bc66ac9893400a9a3029f204ddb8a6e724b181ecda0
-generated: "2024-04-12T15:50:36.442342+02:00"
+digest: sha256:0151608dda11e34c33510447e5e30d15e6b32946b9ec132dfc81d9067d180ea2
+generated: "2024-07-10T11:42:12.372216+03:00"

--- a/openstack/hermes/Chart.yaml
+++ b/openstack/hermes/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm audit management for Openstack
 maintainers:
   - name: notque
 name: hermes
-version: 0.1.1
+version: 0.1.2
 dependencies:
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
@@ -13,7 +13,7 @@ dependencies:
     condition: audit.enabled
     name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.6.11
+    version: 0.7.2
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.2.0

--- a/openstack/hermes/alerts/openstack/api.alerts
+++ b/openstack/hermes/alerts/openstack/api.alerts
@@ -46,7 +46,7 @@ groups:
       summary: Hermes availability affected by storage errors while accessing Elasticsearch
 
   - alert: OpenstackHermesRabbitMQUnack
-    expr: sum(rabbitmq_queue_messages_unacknowledged{kubernetes_name=~".*rabbitmq-notifications"}) by (kubernetes_name) > 10000
+    expr: sum(rabbitmq_queue_messages_unacked{kubernetes_name=~".*rabbitmq-notifications"}) by (kubernetes_name) > 10000
     labels:
       context: rabbitmq
       severity: warning

--- a/openstack/hermes/values.yaml
+++ b/openstack/hermes/values.yaml
@@ -73,6 +73,10 @@ rabbitmq_notifications:
     minAvailable: "51%"
   persistence: 
     enabled: true
+  metrics:
+    enabled: true
+    sidecar:
+      enabled: false
   users:
     default:
       user: openstack


### PR DESCRIPTION
Bump rabbitmq dependency chart to 0.7.2

Update RabbitMQRPCUnackTotal alert to use prometheus plugin metric names