### PR TITLE
[rabbitmq][Cinder] bump rabbitmq dependency chart to 0.7.3

### DIFF
--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 0.2.0
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.6.10
+  version: 0.7.3
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.3.5
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:c702b19aa85ada36ba4b67a85dc34558df59d985c374cc5e90015cd195c80d89
-generated: "2024-04-12T15:49:55.942491+02:00"
+digest: sha256:4648c9ab8a1d5360a3dbf4f01e95585d22eb40f6cd86bcb2fa70c51b96529378
+generated: "2024-07-15T11:20:41.345828+03:00"

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Cinder/OpenStack_Project_Cinder_mascot.png
 name: cinder
-version: 0.2.0
+version: 0.2.1
 dependencies:
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
@@ -20,7 +20,7 @@ dependencies:
     version: 0.2.0
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.6.10
+    version: 0.7.3
   - name: redis
     alias: api-ratelimit-redis
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm


### PR DESCRIPTION
Fix for RabbitMQRPCUnackTotal alert (0.7.2), add standard labels (0.6.13, 0.7.1)

This PR will also disable rabbitmq-exporter container and turn on prometheus plugin ( https://github.com/sapcc/helm-charts/pull/6759 )
0.7.2 change is needed for this transition to work properly
