### PR TITLE
[ssh-exporter] Hackaround to get statistics about netconf datastores

### DIFF
--- a/prometheus-exporters/network-generic-ssh-exporter/templates/_config.yaml.tpl
+++ b/prometheus-exporters/network-generic-ssh-exporter/templates/_config.yaml.tpl
@@ -513,6 +513,20 @@ metrics:
     metric_type_name: gauge
     command: show policy-firewall stats vrf | in (VRF|Total|UDP|ICMP|TCP)
     timeout_secs: 4
+  
+  logging_dmiauthd_sync:
+    regex: >-
+      ^(\d+/\d+/\d+\s\d+:\d+\d:\d+\.\d+)\s.*%DMI-5-(\w+)(?:.+?Configuration change requiring running configuration sync detected - '(.+)')?
+    multi_value: true
+    value: $1
+    labels:
+      action: $2
+      reason: $3
+    description: Parse timestamp of sync needed messages
+    metric_type_name: time
+    time_format: 2006/01/02 15:04:05.999999
+    command: show logging process dmiauthd start last 180
+    timeout_secs: 4
 
   nx_ntp_configured:
     regex: >-
@@ -690,6 +704,7 @@ batches:
     - arp_drop_input_queue_full
     - memory_util_stats
     - dynamic_mac_count
+    - logging_dmiauthd_sync
 
 
   cisco-nx-os_core-router:


### PR DESCRIPTION
We have some actions that lock the datastore more often than others. If
such actions occur, the api performance of the device degrades severely.
To monitor such occuerences and also gather intelligence, we implement
this hacky way to do log watching. Why? Because running it through our
regular log infra does not allow us to graph the timing between 2
events.
