### PR TITLE
[mariadb-galera]add new value to indicate db name

### DIFF
--- a/common/mariadb-galera/README.md
+++ b/common/mariadb-galera/README.md
@@ -46,7 +46,7 @@ Docker images and Helm chart to deploy a [MariaDB](https://mariadb.com/kb/en/get
 ## Metadata
 | chart version | app version | type | url |
 |:--------------|:-------------|:-------------|:-------------|
-| 0.29.1 | 10.5.25 | application | [Git repo](https://github.com/sapcc/helm-charts/tree/master/common/mariadb-galera) |
+| 0.29.2 | 10.5.25 | application | [Git repo](https://github.com/sapcc/helm-charts/tree/master/common/mariadb-galera) |
 
 | Name | Email | Url |
 | ---- | ------ | --- |
@@ -166,7 +166,7 @@ docker build --build-arg BASE_SOFT_NAME=ubuntu --build-arg BASE_SOFT_VERSION=22.
   ```
 * [push](https://helm.sh/docs/topics/registries/#the-push-subcommand) the chart to the registry
   ```shell
-  helm push mariadb-galera-0.29.1.tgz oci://keppel.eu-de-1.cloud.sap/ccloud-helm/
+  helm push mariadb-galera-0.29.2.tgz oci://keppel.eu-de-1.cloud.sap/ccloud-helm/
   ```
 
 ### values description
@@ -346,6 +346,7 @@ docker build --build-arg BASE_SOFT_NAME=ubuntu --build-arg BASE_SOFT_VERSION=22.
 | mariadb.binLogDir | string | `"log"` | if not defined the data dir will be used. Needs a log volume mount to be configured too |
 | mariadb.binLogSync | int | 0 | `1` to enable [sync_binlog for ACID compliance](https://mariadb.com/kb/en/replication-and-binary-log-system-variables/#sync_binlog) |
 | mariadb.ccroot_user.enabled | bool | `false` | enable the passwordless `ccroot` user. If enabled a 'ccroot'@'127.0.0.1' user with all privileges and without password will be created to allow passwordless local connections. If disabled, the user will be dropped from the DB if existing |
+| mariadb.database_name_to_connect | string | `""` | database name to be used in connection string of the service |
 | mariadb.databases.sb_oltp_ro.CharacterSetName | string | utf8 | database character set |
 | mariadb.databases.sb_oltp_ro.collationName | string | utf8_general_ci | database collation |
 | mariadb.databases.sb_oltp_ro.comment | string | custom DB | database comment |

--- a/common/mariadb-galera/helm/Chart.yaml
+++ b/common/mariadb-galera/helm/Chart.yaml
@@ -3,7 +3,7 @@ name: mariadb-galera
 description: Docker images and Helm chart to deploy a [MariaDB](https://mariadb.com/kb/en/getting-installing-and-upgrading-mariadb/) HA cluster based on [Galera](https://mariadb.com/kb/en/what-is-mariadb-galera-cluster/)
 home: "https://github.com/sapcc/helm-charts/tree/master/common/mariadb-galera"
 appVersion: 10.5.25
-version: 0.29.1
+version: 0.29.2
 type: application
 kubeVersion: ">=1.18"
 maintainers:

--- a/common/mariadb-galera/helm/tests/08-containerimages_test.yaml
+++ b/common/mariadb-galera/helm/tests/08-containerimages_test.yaml
@@ -1,5 +1,4 @@
 ---
----
 image.registry: &imageRegistry "keppel.eu-de-1.cloud.sap"
 image.project: &imageProject "ccloud"
 image.version: &imageVersion "20240618114008"

--- a/common/mariadb-galera/helm/values.yaml
+++ b/common/mariadb-galera/helm/values.yaml
@@ -592,6 +592,8 @@ mariadb:
       object: "*.*"
       # -- (bool) allow to grant the [privileges](https://mariadb.com/kb/en/grant/#the-grant-option-privilege) to other users
       grant: false
+  # -- (string) database name to be used in connection string of the service
+  database_name_to_connect: ""
   databases:
     sb_oltp_ro:
       # -- enable this database


### PR DESCRIPTION
Add a new value to indicate the name of the database needed to be used in the connection string of the service.
Because the helm chart supports multiple database we added this value to simplifies the logic on wraper helm-chart side to get the correct database,for building the connection string to it. That instead adding a flag to each database in mariadb.databases section which indicates if the database connection relevant or not. This value as well insures that only one value will be set and used.

Change-Id: I760714b4e63917462982d4b262468fea96ce0662