### PR TITLE
[keystone][mariadb-galera]use database name instead of clustername

### DIFF
--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: keystone
 sources:
   - https://github.com/sapcc/keystone
-version: 0.6.11
+version: 0.6.12
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/keystone/templates/etc/_secrets.conf.tpl
+++ b/openstack/keystone/templates/etc/_secrets.conf.tpl
@@ -4,14 +4,14 @@
 {{ if .Values.percona_cluster.enabled -}}
   {{/* in caase percona is active and we need to switch the connection string to mariadb-galera cluster without removing the percona cluster objects */}}
   {{- if and .Values.mariadb_galera.enabled .Values.databaseKind (eq .Values.databaseKind "galera") -}}
-connection = mysql+pymysql://{{ .Values.mariadb_galera.mariadb.users.keystone.username }}:{{.Values.mariadb_galera.mariadb.users.keystone.password }}@{{include "db_host" .}}/{{ .Values.mariadb_galera.mariadb.galera.clustername }}?charset=utf8
+connection = mysql+pymysql://{{ .Values.mariadb_galera.mariadb.users.keystone.username }}:{{.Values.mariadb_galera.mariadb.users.keystone.password }}@{{include "db_host" .}}/{{ .Values.mariadb_galera.mariadb.database_name_to_connect }}?charset=utf8
   {{- else }}
 connection = {{ include "db_url_pxc" . }}
   {{- end }}
 {{- else if .Values.global.clusterDomain -}}
 connection = mysql+pymysql://{{ default .Release.Name .Values.global.dbUser }}:{{.Values.global.dbPassword }}@{{include "db_host" .}}/{{ default .Release.Name .Values.mariadb.name }}?charset=utf8
 {{- else if and .Values.mariadb_galera.enabled .Values.databaseKind (eq .Values.databaseKind "galera") -}}
-connection = mysql+pymysql://{{ .Values.mariadb_galera.mariadb.users.keystone.username }}:{{.Values.mariadb_galera.mariadb.users.keystone.password }}@{{include "db_host" .}}/{{ .Values.mariadb_galera.mariadb.galera.clustername }}?charset=utf8
+connection = mysql+pymysql://{{ .Values.mariadb_galera.mariadb.users.keystone.username }}:{{.Values.mariadb_galera.mariadb.users.keystone.password }}@{{include "db_host" .}}/{{ .Values.mariadb_galera.mariadb.database_name_to_connect }}?charset=utf8
 {{- else }}
 connection = {{ include "db_url_mysql" . }}
 {{- end }}


### PR DESCRIPTION
In some cases we have clustername different than the Database name e.g **keystone-global** for that we need to use `database_name_to_connect`to get the database name, to be built in the connection string.

Change-Id: I1c9ecf9ad53401a0092d4efeb8f8d5af3d6339f3