### PR TITLE
hermes opensearch: cpu thottled, add requests

### DIFF
--- a/system/opensearch-hermes/values.yaml
+++ b/system/opensearch-hermes/values.yaml
@@ -145,8 +145,12 @@ opensearch_hermes_dashboards:
   ingress:
     enabled: false
   resources:
+    requests:
+      memory: 1024M
+      cpu: 500m
     limits:
       memory: 4096M
+      cpu: 1000m
   envFrom:
     - secretRef:
         name: openid-secrets


### PR DESCRIPTION
Opensearch Dashboards are throttled at almost 100%, and it's impossible to make large changes on the systems. 

My ILM commands have taken over 24 hours, and are still in process. 

We need to enable more cpu, and I believe setting a request will do this properly? 

@Kuckkuck Please evaluate if this is reasonable, and approve if so. I need the Opensearch Dashboards to be functional. 