### PR TITLE
[rabbitmq] Don't try create metrics user if metrics password is not set

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -3,6 +3,11 @@ Rabbitmq CHANGELOG
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+0.7.4
+-----
+- Don't try create metrics user if metrics are enabled, but metrics password is not set
+- Enable metrics/alerts in ci/test-values.yaml
+
 0.7.3
 -----
 - add option enableAllFeatureFlags to enable all stable feature flags after service has started

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 0.7.3
+version: 0.7.4
 description: A Helm chart for RabbitMQ
 sources:
 - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/ci/test-values.yaml
+++ b/common/rabbitmq/ci/test-values.yaml
@@ -32,4 +32,10 @@ resources:
 replicas: 1
 
 metrics:
-  enabled: false
+  enabled: true
+  sidecar:
+    enabled: false
+  password: null
+
+alerts:
+  support_group: 'test'

--- a/common/rabbitmq/templates/bin/_rabbitmq-start.tpl
+++ b/common/rabbitmq/templates/bin/_rabbitmq-start.tpl
@@ -59,7 +59,7 @@ eval $(timeout 5.0 rabbitmqctl list_users -q | awk '{printf "users[\"%s\"]=\"%s\
 {{ list (printf ".Values.users.%v" $k) $v | include "rabbitmq.upsert_user" }}
 {{- end }}
 
-{{- if and .Values.metrics.enabled (not .Values.users.metrics) }}
+{{- if and .Values.metrics.enabled (not .Values.users.metrics) .Values.metrics.password }}
 {{ list ".Values.metrics" .Values.metrics | include "rabbitmq.upsert_user" }} monitoring
 {{- end }}
 {{- $guestUser := dict "user" "guest" "password" .Values.users.default.password "tag" "monitoring" }}


### PR DESCRIPTION
This only applies for the transitional period when for some service metrics user is still needed, but in the future will not be required, because we are disabling the sidecar container