### PR TITLE
neutron_playbook_update

### DIFF
--- a/prometheus-exporters/network-generic-ssh-exporter/alerts/asr.alerts
+++ b/prometheus-exporters/network-generic-ssh-exporter/alerts/asr.alerts
@@ -66,24 +66,6 @@ groups:
       annotations:
         description: "Split brain! All ASR routers in the cluster `{{ $labels.cluster }}` are active."
         summary: "Split brain! All ASR routers in the cluster `{{ $labels.cluster }}` are active."
-
-    - alert: NetworkAsrDynamicNatStopWorking
-      expr: >-
-        (increase(ssh_qfp_nat_datapath_stats{subcode=~"(18|30)"}[5m]) > 0)
-        AND ignoring(subcode, reason) (abs(ssh_qfp_classification_ce_data_nat_1001_classes - ssh_qfp_classification_client_nat_1001_classes) > 0)
-      for: 0m
-      labels:
-        severity: critical
-        support_group: network-data
-        tier: net
-        service: asr
-        context: asr
-        meta: "Policy download failure, Dynamic Interface NAT stops working for `{{ $labels.name }}`."
-        playbook: 'docs/devops/alert/network/router#asr-nat-class-diff-datapath-drops'
-        dashboard: neutron-router
-      annotations:
-        description: "Policy download failure, Dynamic Interface NAT stops working for `{{ $labels.name }}`."
-        summary: "Policy download failure, Dynamic Interface NAT stops working for `{{ $labels.name }}`."
     
     - alert: NetworkAsrRedundancyReplicationErrors
       expr: >-

--- a/prometheus-exporters/snmp-exporter/alerts/snmp-asr.alerts
+++ b/prometheus-exporters/snmp-exporter/alerts/snmp-asr.alerts
@@ -3,7 +3,8 @@ groups:
     rules:
     
     - alert: NetworkAsrInterfaceOverUtilization
-      expr: ((rate(snmp_asr_ifHCOutOctets{ifAlias=~"NEUTRON-UPLINK.*|NEUTRON-LOOPBACK.*"}[5m])  * 8 /1000^ 2) /snmp_asr_ifHighSpeed) > 0.85
+      expr: ((rate(snmp_asr_ifHCOutOctets{ifAlias=~"NEUTRON-UPLINK.*|NEUTRON-LOOPBACK.*"}[5m])  * 8 /1000^ 2) /snmp_asr_ifHighSpeed) > 0.85 or 
+            ((rate(snmp_asr_ifHCInOctets{ifAlias=~"NEUTRON-UPLINK.*|NEUTRON-LOOPBACK.*"}[5m])  * 8 /1000^ 2) /snmp_asr_ifHighSpeed) > 0.85 
       for: 15m
       labels:
         severity: critical


### PR DESCRIPTION
Alert "NetworkAsrDynamicNatStopWorking" is no longer required.
"NetworkAsrInterfaceOverUtilization" alert expression updated to include inbound traffic check