### PR TITLE
[Rabbitmq] fix statefulset immutable with shared service tags

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -3,6 +3,11 @@ Rabbitmq CHANGELOG
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+0.7.4
+-----
+nathan.oyler@sap.com
+- remove shared service tags for statefulsets, statefulsets are immutable.
+
 0.7.3
 -----
 - add option enableAllFeatureFlags to enable all stable feature flags after service has started

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 0.7.3
+version: 0.7.4
 description: A Helm chart for RabbitMQ
 sources:
 - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/templates/statefulset.yaml
+++ b/common/rabbitmq/templates/statefulset.yaml
@@ -11,7 +11,6 @@ metadata:
     type: rabbitmq
     component: {{ .Release.Name }}
     system: openstack
-    {{- include "sharedservices.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.replicas }}
   revisionHistoryLimit: {{ .Values.upgrades.revisionHistory }}


### PR DESCRIPTION
statefulsets are immutable. Can't use shared service tags. 