### PR TITLE
neutron_interface_util_alert_updated

### DIFF
--- a/prometheus-exporters/snmp-exporter/alerts/snmp-asr.alerts
+++ b/prometheus-exporters/snmp-exporter/alerts/snmp-asr.alerts
@@ -2,9 +2,8 @@ groups:
   - name: asr
     rules:
     
-    - alert: NetworkAsrInterfaceOverUtilization
-      expr: ((rate(snmp_asr_ifHCOutOctets{ifAlias=~"NEUTRON-UPLINK.*|NEUTRON-LOOPBACK.*"}[5m])  * 8 /1000^ 2) /snmp_asr_ifHighSpeed) > 0.85 or 
-            ((rate(snmp_asr_ifHCInOctets{ifAlias=~"NEUTRON-UPLINK.*|NEUTRON-LOOPBACK.*"}[5m])  * 8 /1000^ 2) /snmp_asr_ifHighSpeed) > 0.85 
+    - alert: NetworkAsrInterfaceOverUtilizationOut
+      expr: ((rate(snmp_asr_ifHCOutOctets{ifAlias=~"NEUTRON-UPLINK.*|NEUTRON-LOOPBACK.*"}[5m])  * 8 /1000^ 2) /snmp_asr_ifHighSpeed) > 0.85
       for: 15m
       labels:
         severity: critical
@@ -16,7 +15,23 @@ groups:
         playbook: 'docs/devops/alert/network/router#NetworkAsrInterfaceOverUtilization'
         dashboard: neutron-datapath-bandwith
       annotations:
-        description: "Interface `{{ $labels.ifDescr }}` of ASR devicename `{{ $labels.devicename }}` experiencing high bandwidth utilization.Immediate action required"
+        description: "Interface `{{ $labels.ifDescr }}` of ASR devicename `{{ $labels.devicename }}` experiencing high egress bandwidth utilization.Immediate action required"
+        summary: "Interface `{{ $labels.ifDescr }}` of ASR devicename `{{ $labels.devicename }}` crossed bandwidth threshold"
+
+    - alert: NetworkAsrInterfaceOverUtilizationIn
+      expr: ((rate(snmp_asr_ifHCInOctets{ifAlias=~"NEUTRON-UPLINK.*|NEUTRON-LOOPBACK.*"}[5m])  * 8 /1000^ 2) /snmp_asr_ifHighSpeed) > 0.85
+      for: 15m
+      labels:
+        severity: critical
+        support_group: network-data
+        tier: net
+        service: asr
+        context: asr
+        meta: "Interface `{{ $labels.ifDescr }}` of ASR devicename `{{ $labels.devicename }}` experiencing high bandwidth utilization."
+        playbook: 'docs/devops/alert/network/router#NetworkAsrInterfaceOverUtilization'
+        dashboard: neutron-datapath-bandwith
+      annotations:
+        description: "Interface `{{ $labels.ifDescr }}` of ASR devicename `{{ $labels.devicename }}` experiencing high ingress bandwidth utilization.Immediate action required"
         summary: "Interface `{{ $labels.ifDescr }}` of ASR devicename `{{ $labels.devicename }}` crossed bandwidth threshold"
     
     - alert: NetworkAsrHighIosdCpuUtilization


### PR DESCRIPTION
Created two separate alerts for "NetworkAsrInterfaceOverUtilization" ingress and egress utilization as the `or` condition does not work.