### PR TITLE
[rabbitmq] remove shared service labels from immutable volumeClaimTemplates

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -3,6 +3,11 @@ Rabbitmq CHANGELOG
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+0.7.5
+-----
+- remove shared service labels from volumeClaimTemplates, because it's immutable
+- return mutable shared service labels to statefulset metadata
+
 0.7.4
 -----
 nathan.oyler@sap.com
@@ -25,7 +30,7 @@ birk.bohne@sap.com
 0.6.13
 ------
 dusan.dordevic@sap.com
--Adding standardized labels to all objects, according to https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels and https://helm.sh/docs/chart_best_practices/labels/
+- Adding standardized labels to all objects, according to https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels and https://helm.sh/docs/chart_best_practices/labels/
 
 0.6.9
 -----

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 0.7.4
+version: 0.7.5
 description: A Helm chart for RabbitMQ
 sources:
 - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/templates/statefulset.yaml
+++ b/common/rabbitmq/templates/statefulset.yaml
@@ -11,6 +11,7 @@ metadata:
     type: rabbitmq
     component: {{ .Release.Name }}
     system: openstack
+    {{- include "sharedservices.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.replicas }}
   revisionHistoryLimit: {{ .Values.upgrades.revisionHistory }}
@@ -165,7 +166,6 @@ spec:
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
         component: rabbitmq
-        {{- include "sharedservices.labels" . | indent 8 }}
     spec:
       accessModes:
       - {{ .Values.persistence.accessMode | quote }}


### PR DESCRIPTION
- remove shared service labels from volumeClaimTemplates, it's immutable
- return mutable shared service labels to statefulset metadata