### PR TITLE
[openstack-exporter] Update CinderShardFreeSpace alerts

### DIFF
--- a/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
+++ b/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
@@ -18,8 +18,9 @@ groups:
       summary: "Cinder backend {{ $labels.shard }}/{{ $labels.backend }} has no storage capacity."
   - alert: CinderShardFreeSpaceSSD
     expr: |
-      count by (backend, cluster, shard) (cinder_virtual_free_capacity_gib{backend="vmware"} / cinder_available_capacity_gib{backend="vmware"} > 0.3
-      and on (pool) cinder_pool_state_info{pool_state="up"}) <= 2
+      count by (backend, cluster, shard) (cinder_available_capacity_gib{backend="vmware"} and on (pool) cinder_pool_state_info{pool_state="up"})
+      - count by (backend, cluster, shard) (cinder_virtual_free_capacity_gib{backend="vmware"} / cinder_available_capacity_gib{backend="vmware"} < 0.3 and on (pool) cinder_pool_state_info{pool_state="up"}) <= 2
+      or count by (backend, cluster, shard) (cinder_available_capacity_gib{backend="vmware"} and on (pool) cinder_pool_state_info{pool_state="up"}) <= 2
     for: 15m
     labels:
       severity: warning
@@ -32,8 +33,9 @@ groups:
       summary: 'Cinder vmware(ssd) backend {{ $labels.shard }}/{{ $labels.backend }} has 2 or less datastores with > 30% free space left'
   - alert: CinderShardFreeSpaceSSD
     expr: |
-      count by (backend, cluster, shard) (cinder_virtual_free_capacity_gib{backend="vmware"} / cinder_available_capacity_gib{backend="vmware"} > 0.3
-      and on (pool) cinder_pool_state_info{pool_state="up"}) <= 1
+      count by (backend, cluster, shard) (cinder_available_capacity_gib{backend="vmware"} and on (pool) cinder_pool_state_info{pool_state="up"})
+      - count by (backend, cluster, shard) (cinder_virtual_free_capacity_gib{backend="vmware"} / cinder_available_capacity_gib{backend="vmware"} < 0.3 and on (pool) cinder_pool_state_info{pool_state="up"}) <= 1
+      or count by (backend, cluster, shard) (cinder_available_capacity_gib{backend="vmware"} and on (pool) cinder_pool_state_info{pool_state="up"}) <= 1
     for: 15m
     labels:
       severity: critical
@@ -46,8 +48,9 @@ groups:
       summary: 'Cinder vmware(ssd) backend {{ $labels.shard }}/{{ $labels.backend }} has 1 or less datastores with > 30% free space left'
   - alert: CinderShardFreeSpaceStandardHDD
     expr: |
-      count by (backend, cluster, shard) (cinder_virtual_free_capacity_gib{backend="standard_hdd"} / cinder_available_capacity_gib{backend="standard_hdd"} > 0.3
-      and on (pool) cinder_pool_state_info{pool_state="up"}) <= 1
+      count by (backend, cluster, shard) (cinder_available_capacity_gib{backend="standard_hdd"} and on (pool) cinder_pool_state_info{pool_state="up"})
+      - count by (backend, cluster, shard) (cinder_virtual_free_capacity_gib{backend="standard_hdd"} / cinder_available_capacity_gib{backend="standard_hdd"} < 0.3 and on (pool) cinder_pool_state_info{pool_state="up"}) <= 1
+      or count by (backend, cluster, shard) (cinder_available_capacity_gib{backend="standard_hdd"} and on (pool) cinder_pool_state_info{pool_state="up"}) <= 1
     for: 15m
     labels:
       severity: critical


### PR DESCRIPTION
- Triggers an alert if either the capacity ratio falls below 30%
or if the number of available storage units per shard meets the specified threshold