### PR TITLE
[Nova] Add weight for AggregateMultitenancyIsolation weigher

### DIFF
--- a/openstack/nova/templates/etc/_nova-scheduler.conf.tpl
+++ b/openstack/nova/templates/etc/_nova-scheduler.conf.tpl
@@ -34,4 +34,5 @@ hv_ram_class_weight_multiplier = {{ .Values.scheduler.hv_ram_class_weight_multip
 hv_ram_class_weights_gib = {{ .Values.scheduler.hv_ram_class_weights_gib }}
 decommissioning_weight_multiplier = {{ .Values.scheduler.decommissioning_weight_multiplier }}
 sapphire_rapids_weight_multiplier = {{ .Values.scheduler.sapphire_rapids_weight_multiplier }}
+aggregate_multi_tenancy_isolation_weight_multiplier = {{ .Values.scheduler.aggregate_multi_tenancy_isolation_weight_multiplier }}
 image_properties_default_architecture = {{ .Values.scheduler.image_properties_default_architecture }}

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -278,6 +278,11 @@ scheduler:
   # there are no other usable hosts for this flavor. Positive values decrease
   # the weight in this case.
   sapphire_rapids_weight_multiplier: 100.0
+  # When we dedicate hardware to customers, we want them to use it preferrably.
+  # But flavors not meant for SR should still try to go onto non-SR BBs. BBs
+  # currently getting decommissioned, even if they're dedicated to a customer,
+  # should not be preferred.
+  aggregate_multi_tenancy_isolation_weight_multiplier: 50.0
 
   image_properties_default_architecture: "x86_64"
 


### PR DESCRIPTION
We want BBs dedicated to certain customers to be preferred by these customers over generally available BBs. This makes sure that as much as possible generally available resources are available. We still want BBs marked for decommissioning to be freed, though.