### PR TITLE
common/alertmanager: receiver name on metrics

### DIFF
--- a/common/prometheus-alertmanager-base/Chart.yaml
+++ b/common/prometheus-alertmanager-base/Chart.yaml
@@ -1,6 +1,6 @@
 description: Template for a Prometheus Alertmanager via Prometheus operator.
 name: prometheus-alertmanager-base
 apiVersion: v2
-version: 3.3.0
+version: 3.4.0
 appVersion: "v0.27.0"
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/common/prometheus-alertmanager-base/templates/alertmanager.yaml
+++ b/common/prometheus-alertmanager-base/templates/alertmanager.yaml
@@ -28,6 +28,9 @@ spec:
 
   alertmanagerConfigMatcherStrategy:
     type: {{ .Values.alertmanagerConfigMatcherStrategy }}
+    
+  enableFeatures:
+    - receiver-name-in-metrics
 
   # AdditionalPeers allows injecting a set of additional Alertmanagers to peer with to form a highly available cluster.
   {{ if .Values.additionalPeers -}}


### PR DESCRIPTION
This PR adds a second label to all notification metrics so that we not only have the type of notification, but also the `receiver_name` to which the notification belongs. Due to the proliferation of Slack channels, this is necessary to properly diagnose errors based on metrics - currently we get one metric for all Slack channels, regardless of the fact that they may represent completely different notification paths.