### PR TITLE
GkVulnerableImages: add "status" field to object identity

### DIFF
--- a/system/doop-central/values.yaml
+++ b/system/doop-central/values.yaml
@@ -19,7 +19,7 @@ doop:
   # URL of new DOOP UI within Greenhouse
   greenhouse_url: null
   # keys whose values will be carried over from `object_identity` into the label set of the violation count metrics
-  object_identity_labels: [ support_group, service ]
+  object_identity_labels: [ support_group, service, status ]
 
 # We have one deployment for the controlplane, scaleout and v-clusters, where this flag is set to "false".
 # Then we have another separate deployment for the k-clusters, where this flag is set to "true" in the CI pipeline.

--- a/system/gatekeeper/lib/add-support-labels.rego
+++ b/system/gatekeeper/lib/add-support-labels.rego
@@ -13,3 +13,15 @@ from_helm_release(body, msg) = result {
   service := object.get(body, ["owner_info", "service"], "none")
   result := sprintf("{\"support_group\":%s,\"service\":%s} >> %s", [json.marshal(support_group), json.marshal(service), msg])
 }
+
+# Adds an additional label to a message that already had support labels added with one of the above methods.
+# For example:
+#
+# ```rego
+# msgWithLabels := add_support_labels.extra("severity", "warning", add_support_labels.from_k8s_object(iro, msg))
+# ```
+#
+# Test coverage for this function is obtained in the policies using it.
+extra(key, value, msg) = result {
+  result := sprintf("{%s:%s,%s", [json.marshal(key), json.marshal(value), trim_prefix(msg, "{")])
+}

--- a/system/gatekeeper/templates/constrainttemplate-vulnerable-images.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-vulnerable-images.yaml
@@ -78,7 +78,7 @@ spec:
           check.error != ""
         }
 
-        violation[{"msg": add_support_labels_with_overrides(iro, check, msg)}] {
+        violation[{"msg": add_support_labels.extra("status", status, add_support_labels_with_overrides(iro, check, msg))}] {
           check := checks[_]
           check.error == ""
           status := trim_space(object.get(check.headers, input.parameters.vulnStatusHeader, "Unclear"))

--- a/system/gatekeeper/tests/gatekeeper-policies/suite.yaml
+++ b/system/gatekeeper/tests/gatekeeper-policies/suite.yaml
@@ -676,16 +676,16 @@ tests:
     object: fixtures/vulnerable-images/deployment-vulnerable.yaml
     assertions:
     - violations: 1
-      message: '^\{"support_group":"foo-group","service":"dummy"\} >> image keppel.example.com/vulnerability-unpinned:low for container "dummylow" has "X-Keppel-Vulnerability-Status: Low"$'
+      message: '^\{"status":"Low","support_group":"foo-group","service":"dummy"\} >> image keppel.example.com/vulnerability-unpinned:low for container "dummylow" has "X-Keppel-Vulnerability-Status: Low"$'
     - violations: 1
-      message: '^\{"support_group":"foo-group","service":"dummy"\} >> image keppel.example.com/vulnerability-unpinned:medium for container "dummymedium" has "X-Keppel-Vulnerability-Status: Medium"$'
+      message: '^\{"status":"Medium","support_group":"foo-group","service":"dummy"\} >> image keppel.example.com/vulnerability-unpinned:medium for container "dummymedium" has "X-Keppel-Vulnerability-Status: Medium"$'
     - violations: 1
-      message: '^\{"support_group":"foo-group","service":"dummy"\} >> image keppel.example.com/vulnerability-unpinned:high for container "starter" has "X-Keppel-Vulnerability-Status: High"$'
+      message: '^\{"status":"High","support_group":"foo-group","service":"dummy"\} >> image keppel.example.com/vulnerability-unpinned:high for container "starter" has "X-Keppel-Vulnerability-Status: High"$'
   - name: pod-unclear
     object: fixtures/vulnerable-images/deployment-unclear.yaml
     assertions:
     - violations: 1
-      message: '^\{"support_group":"foo-group","service":"dummy"\} >> image keppel.example.com/vulnerability-unpinned:unclear for container "dummy" has "X-Keppel-Vulnerability-Status: Unclear"$'
+      message: '^\{"status":"Unclear","support_group":"foo-group","service":"dummy"\} >> image keppel.example.com/vulnerability-unpinned:unclear for container "dummy" has "X-Keppel-Vulnerability-Status: Unclear"$'
   - name: pod-clean
     object: fixtures/vulnerable-images/deployment-clean.yaml
     assertions:
@@ -699,23 +699,23 @@ tests:
     object: fixtures/vulnerable-images/pod-vulnerable.yaml
     assertions:
     - violations: 1
-      message: '^\{"support_group":"foo-group","service":"dummy"\} >> image keppel.example.com/vulnerability:low for container "dummylow" has "X-Keppel-Vulnerability-Status: Low"$'
+      message: '^\{"status":"Low","support_group":"foo-group","service":"dummy"\} >> image keppel.example.com/vulnerability:low for container "dummylow" has "X-Keppel-Vulnerability-Status: Low"$'
     - violations: 1
-      message: '^\{"support_group":"foo-group","service":"dummy"\} >> image keppel.example.com/vulnerability:medium for container "dummymedium" has "X-Keppel-Vulnerability-Status: Medium"$'
+      message: '^\{"status":"Medium","support_group":"foo-group","service":"dummy"\} >> image keppel.example.com/vulnerability:medium for container "dummymedium" has "X-Keppel-Vulnerability-Status: Medium"$'
     - violations: 1
-      message: '^\{"support_group":"foo-group","service":"dummy"\} >> image keppel.example.com/vulnerability:high for container "starter" has "X-Keppel-Vulnerability-Status: High"$'
+      message: '^\{"status":"High","support_group":"foo-group","service":"dummy"\} >> image keppel.example.com/vulnerability:high for container "starter" has "X-Keppel-Vulnerability-Status: High"$'
   - name: pod-vulnerable-in-linkerd
     object: fixtures/vulnerable-images/pod-vulnerable-in-linkerd.yaml
     assertions:
     - violations: 1
-      message: '^\{"support_group":"containers","service":"linkerd"\} >> image keppel.example.com/ccloud/servicemesh/proxy:low for container "linkerd-proxy" has "X-Keppel-Vulnerability-Status: Low"$'
+      message: '^\{"status":"Low","support_group":"containers","service":"linkerd"\} >> image keppel.example.com/ccloud/servicemesh/proxy:low for container "linkerd-proxy" has "X-Keppel-Vulnerability-Status: Low"$'
     - violations: 1
-      message: '^\{"support_group":"containers","service":"linkerd"\} >> image keppel.example.com/ccloud/servicemesh/proxy-init:high for container "linkerd-init" has "X-Keppel-Vulnerability-Status: High"$'
+      message: '^\{"status":"High","support_group":"containers","service":"linkerd"\} >> image keppel.example.com/ccloud/servicemesh/proxy-init:high for container "linkerd-init" has "X-Keppel-Vulnerability-Status: High"$'
   - name: pod-unclear
     object: fixtures/vulnerable-images/pod-unclear.yaml
     assertions:
     - violations: 1
-      message: '^\{"support_group":"foo-group","service":"dummy"\} >> image keppel.example.com/vulnerability:unclear for container "dummy" has "X-Keppel-Vulnerability-Status: Unclear"$'
+      message: '^\{"status":"Unclear","support_group":"foo-group","service":"dummy"\} >> image keppel.example.com/vulnerability:unclear for container "dummy" has "X-Keppel-Vulnerability-Status: Unclear"$'
   - name: pod-clean
     object: fixtures/vulnerable-images/pod-clean.yaml
     assertions:


### PR DESCRIPTION
This makes the vulnerability status accessible as a label on the DOOP metrics.

I am using a rather generic name here, rather than the more specific "vulnerability_status" or "vuln_status". This label will now have to appear on all DOOP metrics, so I want to use a name that might be useful for other types of violations as well.