### PR TITLE
[designate-nanny] adjusting memory due to OOMs observed

### DIFF
--- a/openstack/designate-nanny/values.yaml
+++ b/openstack/designate-nanny/values.yaml
@@ -13,10 +13,10 @@ image:
 
 resources:
   requests:
-    memory: "128Mi"
+    memory: "256Mi"
     cpu: "100m"
   limits:
-    memory: "512Mi"
+    memory: "1Gi"
     cpu: "800m"
 
 global_setup: false


### PR DESCRIPTION
There have been frequent OOM kills observed. This should give enough headroom.