### PR TITLE
adding an opensearch user for the orabos kvm project

### DIFF
--- a/system/opensearch-logs/templates/config/_internal_users.yml.tpl
+++ b/system/opensearch-logs/templates/config/_internal_users.yml.tpl
@@ -32,6 +32,12 @@ compute:
   backend_roles:
   - "compute"
 
+oraboskvm:
+  hash: "{{ .Values.users.oraboskvm.hash }}"
+  reserved: true
+  backend_roles:
+  - "oraboskvm"
+
 otel:
   hash: "{{ .Values.users.otel.hash }}"
   reserved: true

--- a/system/opensearch-logs/templates/config/_roles.yml.tpl
+++ b/system/opensearch-logs/templates/config/_roles.yml.tpl
@@ -388,6 +388,35 @@ promrole:
     allowed_actions:
     - "kibana_all_write"
 
+oraboskvmrole:
+  reserved: false
+  hidden: false
+  cluster_permissions:
+    - "cluster:monitor/prometheus/metrics"
+    - "cluster:monitor/health"
+    - "cluster:monitor/state"
+    - "cluster:monitor/nodes/info"
+    - "cluster:monitor/nodes/stats"
+    - "indices:data/read/scroll*"
+    - "indices:data/read/msearch"
+  index_permissions:
+  - index_patterns:
+    - "*"
+    allowed_actions:
+    - "indices:monitor/stats"
+    - "indices:admin/mappings/get"
+    - "indices:admin/aliases/get"
+    - "indices:data/read/scroll"
+    - "indices:data/read/scroll/clear"
+    - "indices:data/read/search"
+    - "indices:data/read/search*"
+    - "read"
+  tenant_permissions:
+  - tenant_patterns:
+    - "*"
+    allowed_actions:
+    - "kibana_all_write"
+
 maillog:
   reserved: false
   cluster_permissions:

--- a/system/opensearch-logs/templates/config/_roles_mapping.yml.tpl
+++ b/system/opensearch-logs/templates/config/_roles_mapping.yml.tpl
@@ -105,6 +105,13 @@ promrole:
   backend_roles:
   - CC_IAS_OPERATIONS_UI_KIBANA_SUPPORT
 
+oraboskvmrole:
+  reserved: false
+  users:
+  - "oraboskvm"
+  backend_roles:
+  - CC_IAS_OPERATIONS_UI_KIBANA_SUPPORT
+
 jupyterhub:
   reserved: false
   users:


### PR DESCRIPTION
this is the `helm-charts` part of an opensearch user that will be provided by a helm rollout in helm-charts
@d042653

see https://github.wdf.sap.corp/cc/secrets/pull/14848