### PR TITLE
[keystone][mariadb-galera] bump up mariadb-galera in dependencies

### DIFF
--- a/openstack/keystone/Chart.lock
+++ b/openstack/keystone/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.10.1
 - name: mariadb-galera
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.29.1
+  version: 0.29.3
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.5.2
@@ -26,5 +26,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.4
-digest: sha256:3d8c66265e6f8f3dbfe3c2b4269b55606bde9e3a43d21a7d4c02476b736bd91c
-generated: "2024-07-08T13:36:37.59075+02:00"
+digest: sha256:d0f64430c9e02fa7fb664695d1db5e47ae28ab391106b579b50ab24c77923921
+generated: "2024-07-23T17:58:17.946683+03:00"

--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: keystone
 sources:
   - https://github.com/sapcc/keystone
-version: 0.6.12
+version: 0.6.13
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
@@ -19,7 +19,7 @@ dependencies:
     name: mariadb-galera
     alias: mariadb_galera
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.29.1
+    version: 0.29.3
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.5.2


### PR DESCRIPTION
Bump up mariadb-galera in dependencies to 0.29.3 with a small fix for linkerd timeout