### PR TITLE
[netapp] add alert for manila filer when number of volumes is close to limit

### DIFF
--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/alerts/storage.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/alerts/storage.yaml
@@ -13,5 +13,21 @@ groups:
           support_group: compute-storage-api
           support_component: manila_netapp
         annotations:
-          description: 'Number of NetApp LIFs in use is above 950'
-          summary: 'High NetApp LIF Usage on filer {{$labels.filer}}'
+          description: "Number of NetApp LIFs in use is above 950"
+          summary: "High NetApp LIF Usage on filer {{ $labels.filer }}"
+
+      # NetApp Volumes limit is 5000 per cluster
+      - alert: ManilaStorageVolumeCountHigh
+        expr: max_over_time(count by (filer) (netapp_volume_labels{app="netapp-harvest-exporter-manila"})[2h:5m]) > 4500
+        for: 1h
+        labels:
+          severity: info
+          context: netapp-usage
+          service: manila
+          tier: os
+          support_group: compute-storage-api
+          support_component: manila_netapp
+        annotations:
+          description: "Number of Volumes on NetApp filer is above 4500"
+          summary: "High number of Volumes created on filer {{ $labels.filer }}"
+


### PR DESCRIPTION
The limit per filer is 5000. Adding a info alert when volume count is
above 4500.
