### PR TITLE
keppel: fix reference to monsoon3/domain-btp-fp-seed

### DIFF
--- a/openstack/keppel/templates/support_seed.yaml
+++ b/openstack/keppel/templates/support_seed.yaml
@@ -10,7 +10,7 @@ spec:
   requires:
   - keppel/keppel-seed
   {{- range $domains }}
-  - monsoon3/domain-{{ . | lower }}-seed
+  - monsoon3/domain-{{replace "_" "-" .}}-seed
   {{- end }}
 
   domains:


### PR DESCRIPTION
The domain is called "btp_fp", so we need to do the same string replacement like in `openstack/keppel/templates/seed.yaml`.