### PR TITLE
[rabbitmq] add secret-injector support to helper

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -3,6 +3,10 @@ Rabbitmq CHANGELOG
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+0.10.1
+-----
+- add urlquery escaped transport function to the helpers to be used while switching to secret-injector
+
 0.10.0
 -----
 - add ability to change service type and set externalTrafficPolicy

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 0.10.0
+version: 0.10.1
 description: A Helm chart for RabbitMQ
 sources:
 - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/templates/_helpers.tpl
+++ b/common/rabbitmq/templates/_helpers.tpl
@@ -15,7 +15,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | replace "_" "-" | trimSuffix "-" -}}
 {{- end -}}
 
-{{- define "_resolve_secret" -}}
+{{- define "rabbitmq.resolve_secret_urlquery" -}}
     {{- $str := . -}}
     {{- if (hasPrefix "vault+kvv2" $str ) -}}
         {{"{{"}} resolve "{{ $str }}" | urlquery {{"}}"}}
@@ -32,8 +32,8 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $envAll := index . 0 -}}
 {{- $rabbitmq := index . 1 -}}
 {{- $_prefix := default "" $envAll.Values.global.user_suffix -}}
-{{- $_username := include "_resolve_secret" $rabbitmq.users.default.user -}}
-{{- $_password := include "_resolve_secret" (required "$rabbitmq.users.default.password missing" $rabbitmq.users.default.password) -}}
+{{- $_username := include "rabbitmq.resolve_secret_urlquery" (required "$rabbitmq.users.default.user missing" $rabbitmq.users.default.user) -}}
+{{- $_password := include "rabbitmq.resolve_secret_urlquery" (required "$rabbitmq.users.default.password missing" $rabbitmq.users.default.password) -}}
 {{- $_rhost := include "rabbitmq.release_host" $envAll -}}
 rabbit://{{- $_prefix -}}{{- $_username -}}:{{- $_password -}}@{{- $_rhost -}}:{{ $rabbitmq.port | default 5672 }}{{ $rabbitmq.virtual_host | default "/" }}
 {{- end}}


### PR DESCRIPTION
add support for secret injector links in the transport helper scripts

Change-Id: I8a0bc32e816d1e856645835ea6a0c5863521c73a