### PR TITLE
[barbican] update audit map to skip binary payload of secret retreival

### DIFF
--- a/openstack/barbican/templates/etc/_barbican_audit_map.yaml
+++ b/openstack/barbican/templates/etc/_barbican_audit_map.yaml
@@ -18,6 +18,11 @@ resources:
         type_name: meta
       acl:
         singleton: true
+      payload:
+        singleton: true
+        payloads:
+          # Disable payload recording for this endpoint
+          enabled: False
   secret-stores:
     children:
       preferred:


### PR DESCRIPTION
Problem:
The audit middleware is attempting to log the binary payload when retrieving secrets from Barbican. This causes a UnicodeDecodeError as the binary data cannot be decoded as UTF-8, leading to incomplete audit logs and potential error flooding.

Solution:
Update the audit mapping for Barbican to specifically exclude payload recording for the secret payload retrieval endpoint. This change allows the audit middleware to log the occurrence of the request and its metadata without attempting to include the binary payload itself.

@rajivmucheli This is my attempted fix. We'd need to test it, but I believe this will work. 