### PR TITLE
[rabbitmq] Update RabbitMQ to 3.13.6, add helm.sh/chart label

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -3,6 +3,12 @@ Rabbitmq CHANGELOG
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+0.11.0
+------
+- Update RabbitMQ to version 3.13.6-management
+- Add `helm.sh/chart` label
+- `app.kubernetes.io/version` is now an application version
+
 0.10.1
 -----
 - add urlquery escaped transport function to the helpers to be used while switching to secret-injector

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 name: rabbitmq
-version: 0.10.1
+version: 0.11.0
+appVersion: 3.13.6
 description: A Helm chart for RabbitMQ
 sources:
 - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/templates/_helpers.tpl
+++ b/common/rabbitmq/templates/_helpers.tpl
@@ -90,10 +90,18 @@ rabbit://{{- $_prefix -}}{{- $_username -}}:{{- $_password -}}@{{- $_rhost -}}:{
                 - reinstalling
 {{- end }}
 
-{{- define "sharedservices.labels" }}
+{{- define "rabbitmq.labels" }}
 app.kubernetes.io/name: {{ .Chart.Name }}
 app.kubernetes.io/instance: {{ .Chart.Name }}-{{ .Release.Name }}
-app.kubernetes.io/version: {{ .Chart.Version }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
 app.kubernetes.io/component: {{ .Chart.Name }}
 app.kubernetes.io/part-of: {{ .Release.Name }}
+helm.sh/chart: {{ include "rabbitmq.chart" . }}
 {{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "rabbitmq.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/common/rabbitmq/templates/alerts.yaml
+++ b/common/rabbitmq/templates/alerts.yaml
@@ -12,7 +12,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
     component: rabbitmq
     prometheus: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus }}
-    {{- include "sharedservices.labels" . | indent 4 }}
+    {{- include "rabbitmq.labels" . | indent 4 }}
 spec:
 {{ include (print .Template.BasePath "/alerts/_rabbitmq.alerts.tpl") . | indent 2 }}
 

--- a/common/rabbitmq/templates/bin-configmap.yaml
+++ b/common/rabbitmq/templates/bin-configmap.yaml
@@ -7,7 +7,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     component: rabbitmq
-    {{- include "sharedservices.labels" . | indent 4 }}
+    {{- include "rabbitmq.labels" . | indent 4 }}
 data:
   rabbitmq-start: |
 {{ include (print .Template.BasePath "/bin/_rabbitmq-start.tpl") . | indent 4 }}

--- a/common/rabbitmq/templates/custom-conf-configmap.yaml
+++ b/common/rabbitmq/templates/custom-conf-configmap.yaml
@@ -9,7 +9,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     component: rabbitmq
-    {{- include "sharedservices.labels" . | indent 4 }}
+    {{- include "rabbitmq.labels" . | indent 4 }}
 data:
   20-custom.conf: |
 {{ include (print .Template.BasePath "/etc/_rabbitmq-custom-config.tpl") . | indent 4 }}

--- a/common/rabbitmq/templates/deployment.yaml
+++ b/common/rabbitmq/templates/deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     type: rabbitmq
     component: {{ .Release.Name }}
     system: openstack
-    {{- include "sharedservices.labels" . | indent 4 }}
+    {{- include "rabbitmq.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.replicas }}
   revisionHistoryLimit: {{ .Values.upgrades.revisionHistory }}
@@ -29,7 +29,7 @@ spec:
     metadata:
       labels:
         app: {{ template "fullname" . }}
-      {{- include "sharedservices.labels" . | indent 8 }}  
+      {{- include "rabbitmq.labels" . | indent 8 }}
       annotations:
         kubectl.kubernetes.io/default-container: rabbitmq
         checksum/container.init: {{ include (print $.Template.BasePath "/bin-configmap.yaml") . | sha256sum }}

--- a/common/rabbitmq/templates/headless-service.yaml
+++ b/common/rabbitmq/templates/headless-service.yaml
@@ -11,7 +11,7 @@ metadata:
     type: rabbitmq
     component: {{ .Release.Name }}
     system: openstack
-    {{- include "sharedservices.labels" . | indent 4 }}
+    {{- include "rabbitmq.labels" . | indent 4 }}
   annotations:
 {{- if and (and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested) $.Values.linkerd.enabled }}
     linkerd.io/inject: enabled

--- a/common/rabbitmq/templates/poddisruptionbudget.yml
+++ b/common/rabbitmq/templates/poddisruptionbudget.yml
@@ -11,7 +11,7 @@ metadata:
     type: rabbitmq
     component: {{ .Release.Name }}
     system: openstack
-    {{- include "sharedservices.labels" . | indent 4 }}
+    {{- include "rabbitmq.labels" . | indent 4 }}
 spec:
   minAvailable: {{ .Values.pdr.minAvailable | quote }}
   selector:

--- a/common/rabbitmq/templates/pvc.yaml
+++ b/common/rabbitmq/templates/pvc.yaml
@@ -9,7 +9,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     component: rabbitmq
-    {{- include "sharedservices.labels" . | indent 4 }}
+    {{- include "rabbitmq.labels" . | indent 4 }}
   annotations:
   {{- if .Values.persistence.storageClass }}
     volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}

--- a/common/rabbitmq/templates/service.yaml
+++ b/common/rabbitmq/templates/service.yaml
@@ -10,7 +10,7 @@ metadata:
     type: rabbitmq
     component: {{ .Release.Name }}
     system: openstack
-    {{- include "sharedservices.labels" . | indent 4 }}
+    {{- include "rabbitmq.labels" . | indent 4 }}
   annotations:
 {{- if .Values.metrics.enabled }}
     prometheus.io/scrape: "true"

--- a/common/rabbitmq/templates/servicemonitor.yaml
+++ b/common/rabbitmq/templates/servicemonitor.yaml
@@ -12,7 +12,7 @@ metadata:
     component: {{ .Release.Name }}
     system: openstack
     prometheus: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus }}
-    {{- include "sharedservices.labels" . | indent 4 }}
+    {{- include "rabbitmq.labels" . | indent 4 }}
 spec:
   endpoints:
     {{- if .Values.metrics.enableDetailedMetrics }}

--- a/common/rabbitmq/templates/statefulset.yaml
+++ b/common/rabbitmq/templates/statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     type: rabbitmq
     component: {{ .Release.Name }}
     system: openstack
-    {{- include "sharedservices.labels" . | indent 4 }}
+    {{- include "rabbitmq.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.replicas }}
   revisionHistoryLimit: {{ .Values.upgrades.revisionHistory }}
@@ -23,7 +23,7 @@ spec:
     metadata:
       labels:
         app: {{ template "fullname" . }}
-      {{- include "sharedservices.labels" . | indent 8 }}  
+      {{- include "rabbitmq.labels" . | indent 8 }}
       annotations:
         kubectl.kubernetes.io/default-container: rabbitmq
 {{- if and (and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested) $.Values.linkerd.enabled }}

--- a/common/rabbitmq/values.yaml
+++ b/common/rabbitmq/values.yaml
@@ -8,7 +8,7 @@ global:
   master_password: ""
 
 image: library/rabbitmq
-imageTag: 3.13.0-management
+imageTag: 3.13.6-management
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
- Update RabbitMQ to version 3.13.6-management
- Add `helm.sh/chart` label
- `app.kubernetes.io/version` is now an application version