### PR TITLE
[mariadb] update mysqld-exporter to version 0.15.1

### DIFF
--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.12.1
+version: 0.13.0

--- a/common/mariadb/ci/test-values.yaml
+++ b/common/mariadb/ci/test-values.yaml
@@ -4,6 +4,8 @@ global:
   registry: my.docker.registry
   dockerHubMirror: my.dockerhub.mirror
   dockerHubMirrorAlternateRegion: other.dockerhub.mirror
+  tld: ""
+  region: local
 
 test_db_host: testRelease-mariadb.svc
 root_password: secret123
@@ -15,3 +17,6 @@ backup:
 
 backup_v2:
   enabled: false
+
+alerts:
+  support_group: test

--- a/common/mariadb/templates/_helpers.tpl
+++ b/common/mariadb/templates/_helpers.tpl
@@ -20,7 +20,9 @@
 {{- required ".Values.root_password missing" .Values.root_password }}
 {{- end -}}
 
-{{ define "mariadb.metrics_data_source" }}root:{{ required ".Values.root_password missing" .Values.root_password }}@tcp({{.Values.name}}-mariadb.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.region}}.{{.Values.global.tld}}:3306)/{{ end }}
+{{- define "mariadb.exporter_scrape_target_address" -}}
+{{.Values.name}}-mariadb.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.region}}.{{.Values.global.tld}}:3306
+{{- end -}}
 
 {{- define "db_password" -}}
 {{- .Values.global.dbPassword }}

--- a/common/mariadb/templates/alerts/_mysql.alerts.tpl
+++ b/common/mariadb/templates/alerts/_mysql.alerts.tpl
@@ -28,7 +28,7 @@
       summary: {{ include "fullName" . }} reports slow queries.
 
   - alert: {{ include "alerts.service" . | title }}MariaDBWaitingForLock
-    expr: (mysql_info_schema_threads_seconds{app=~"{{ include "fullName" . }}", state=~"waiting for lock"} / 1000  > 15)
+    expr: (mysql_info_schema_processlist_seconds{app=~"{{ include "fullName" . }}", state=~"waiting for lock"} / 1000  > 15)
     for: 10m
     labels:
       context: database

--- a/common/mariadb/templates/deployment.yaml
+++ b/common/mariadb/templates/deployment.yaml
@@ -134,6 +134,8 @@ spec:
         image: "{{ required ".Values.global.dockerHubMirrorAlternateRegion is missing" .Values.global.dockerHubMirrorAlternateRegion }}/{{ .Values.metrics.image }}:{{ .Values.metrics.image_version }}"
         imagePullPolicy: {{ default "IfNotPresent" .Values.imagePullPolicy | quote }}
         args:
+          - "--mysqld.username=root"
+          - "--mysqld.address={{ include "mariadb.exporter_scrape_target_address" . }}"
         {{- range $flag := .Values.metrics.flags }}
           - "--{{$flag}}"
         {{- end }}
@@ -152,11 +154,11 @@ spec:
           periodSeconds: 20
           timeoutSeconds: 10
         env:
-          - name: DATA_SOURCE_NAME
+          - name: MYSQLD_EXPORTER_PASSWORD
             valueFrom:
               secretKeyRef:
                 name: mariadb-{{.Values.name}}
-                key: metrics-data-source
+                key: root-password
           - name: LOGLEVEL
             value: {{ default "info" .Values.metrics.loglevel }}
         ports:

--- a/common/mariadb/templates/secret.yaml
+++ b/common/mariadb/templates/secret.yaml
@@ -10,7 +10,6 @@ metadata:
 type: Opaque
 data:
   root-password: {{ include "mariadb.root_password" . | b64enc | quote }}
-  metrics-data-source: {{ include "mariadb.metrics_data_source" . | b64enc | quote }}
 {{- if .Values.backup_v2.enabled }}
 {{- if .Values.backup_v2.oauth.enabled }}
   OAUTH_CLIENT_ID: {{ default "" .Values.backup_v2.oauth.client_id | b64enc | quote }}

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -142,7 +142,7 @@ backup_v2:
 metrics:
   enabled: true
   image: prom/mysqld-exporter
-  image_version: v0.12.1
+  image_version: v0.15.1
   port: "9104"
   flags:
     - collect.binlog_size


### PR DESCRIPTION
Remove DATA_SOURCE_NAME secret, use MYSQLD_EXPORTER_PASSWORD and constructed mysqld.address option

Update alerts:

The metric mysql_info_schema_threads_seconds has been renamed to mysql_info_schema_processlist_seconds with exporter v0.14.0+ see prometheus/mysqld_exporter#603