### PR TITLE
add liquid-swift deployment to Limes, deploy Keppel/Limes catalog entries via separate seeds

### DIFF
--- a/openstack/keppel/templates/seed-catalog.yaml
+++ b/openstack/keppel/templates/seed-catalog.yaml
@@ -1,0 +1,40 @@
+{{- $region := .Values.global.region | required "missing value for .Values.global.region" -}}
+{{- $tld    := .Values.global.tld    | required "missing value for .Values.global.tld"    -}}
+
+apiVersion: "openstack.stable.sap.cc/v1"
+kind: OpenstackSeed
+metadata:
+  # This is separate from the big keppel-seed in order to be easier to reapply.
+  name: keppel-catalog-seed
+
+spec:
+  requires: []
+
+  services:
+    - name:        keppel
+      type:        keppel
+      description: 'Multi-tenant container image registry'
+      enabled:     true
+      endpoints:
+        - region:    '{{ $region }}'
+          interface: public
+          enabled:   true
+          url:       'https://keppel.{{ $region }}.{{ $tld }}'
+        - region:    '{{ $region }}'
+          interface: internal
+          enabled:   true
+          url:       'http://keppel-api.{{ .Release.Namespace }}.svc'
+
+    - name:        liquid-keppel
+      type:        liquid-keppel
+      description: 'Limes integration for Keppel <https://pkg.go.dev/github.com/sapcc/go-api-declarations/liquid>'
+      enabled:     true
+      endpoints:
+        - region:    '{{ $region }}'
+          interface: public
+          enabled:   true
+          url:       'https://keppel.{{ $region }}.{{ $tld }}/liquid/'
+        - region:    '{{ $region }}'
+          interface: internal
+          enabled:   true
+          url:       'http://keppel-api.{{ .Release.Namespace }}.svc/liquid/'

--- a/openstack/keppel/templates/seed.yaml
+++ b/openstack/keppel/templates/seed.yaml
@@ -23,35 +23,6 @@ spec:
     - name: registry_admin
     - name: registry_viewer
 
-  services:
-    - name:        keppel
-      type:        keppel
-      description: 'Multi-tenant container image registry'
-      enabled:     true
-      endpoints:
-        - region:    '{{ $region }}'
-          interface: public
-          enabled:   true
-          url:       'https://keppel.{{ $region }}.{{ .Values.global.tld }}'
-        - region:    '{{ $region }}'
-          interface: internal
-          enabled:   true
-          url:       'http://keppel-api.{{ .Release.Namespace }}.svc'
-
-    - name:        liquid-keppel
-      type:        liquid-keppel
-      description: 'Limes integration for Keppel <https://pkg.go.dev/github.com/sapcc/go-api-declarations/liquid>'
-      enabled:     true
-      endpoints:
-        - region:    '{{ $region }}'
-          interface: public
-          enabled:   true
-          url:       'https://keppel.{{ $region }}.{{ .Values.global.tld }}/liquid/'
-        - region:    '{{ $region }}'
-          interface: internal
-          enabled:   true
-          url:       'http://keppel-api.{{ .Release.Namespace }}.svc/liquid/'
-
   domains:
     - name: Default
       users:

--- a/openstack/limes/templates/_utils.tpl
+++ b/openstack/limes/templates/_utils.tpl
@@ -42,6 +42,10 @@
   value: "limes-postgresql.{{ .Release.Namespace }}.svc"
 - name: LIMES_DB_CONNECTION_OPTIONS
   value: "sslmode=disable"
+{{ include "limes_openstack_envvars" . }}
+{{- end -}}
+
+{{- define "limes_openstack_envvars" }}
 - name: OS_AUTH_URL
   value: "http://keystone.{{ $.Values.global.keystoneNamespace }}.svc.kubernetes.{{ $.Values.global.region }}.{{ $.Values.global.tld }}:5000/v3"
 - name: OS_INTERFACE

--- a/openstack/limes/templates/configmap-liquids.yaml
+++ b/openstack/limes/templates/configmap-liquids.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+
+metadata:
+  name: limes-liquids
+
+data:
+  policy.yaml: |
+    "readwrite": "role:cloud_resource_admin or (user_name:limes and user_domain_name:Default)"
+    "readonly": "role:cloud_resource_viewer or rule:readwrite"
+
+    "liquid:get_info": "rule:readonly"
+    "liquid:get_capacity": "rule:readonly"
+    "liquid:get_usage": "rule:readonly"
+    "liquid:set_quota": "rule:readwrite"

--- a/openstack/limes/templates/deployment-liquids.yaml
+++ b/openstack/limes/templates/deployment-liquids.yaml
@@ -1,0 +1,73 @@
+{{- range $name, $config := .Values.limes.local_liquids }}
+
+---
+
+kind: Deployment
+apiVersion: apps/v1
+
+metadata:
+  name: liquid-{{ $name }}
+
+spec:
+  revisionHistoryLimit: 5
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      name: liquid-{{ $name }}
+  template:
+    metadata:
+      labels:
+        name: liquid-{{ $name }}
+      annotations:
+        checksum/configmap: {{ include "limes/templates/configmap-liquids.yaml" . | sha256sum }}
+        kubectl.kubernetes.io/default-container: liquid
+    spec:
+      volumes:
+        - name: config
+          configMap:
+            name: limes-liquids
+      containers:
+        - name: liquid
+          image: {{ include "limes_image" $ }}
+          imagePullPolicy: IfNotPresent
+          args: [ liquid, "{{ $name }}" ]
+          env:
+            {{ include "limes_openstack_envvars" $ | indent 12 }}
+            - name: LIQUID_CONFIG_PATH
+              value: "/etc/liquid/{{ $name }}.json"
+              # ^ NOTE: For liquids that do not take config (e.g. liquid-swift), this variable is ignored,
+              # so it is not an error that the respective file does not exist in the configmap.
+            - name: LIQUID_POLICY_PATH
+              value: "/etc/liquid/policy.yaml"
+          securityContext:
+            runAsNonRoot: true
+          volumeMounts:
+            - mountPath: /etc/liquid
+              name: config
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 80
+            timeoutSeconds: 10
+            periodSeconds: 60
+            initialDelaySeconds: 60
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 80
+            timeoutSeconds: 5
+            periodSeconds: 5
+          resources:
+            limits:
+              cpu: '1'
+              memory: {{ $config.memory_limit }}
+            requests:
+              cpu: {{ $config.cpu_request }}
+              memory: {{ $config.memory_limit }}
+
+{{- end }}

--- a/openstack/limes/templates/ingress-liquids.yaml
+++ b/openstack/limes/templates/ingress-liquids.yaml
@@ -1,0 +1,36 @@
+{{- range $name, $config := .Values.limes.local_liquids }}
+
+{{- $domain := printf "liquid-%s.%s.%s" $name $.Values.global.region $.Values.global.tld -}}
+
+---
+
+kind: Ingress
+apiVersion: networking.k8s.io/v1
+
+metadata:
+  name: liquid-{{ $name }}
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    disco: "true"
+    {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
+    ingress.kubernetes.io/service-upstream: "true"
+    nginx.ingress.kubernetes.io/service-upstream: "true"
+    {{- end }}
+
+spec:
+  tls:
+    - secretName: tls-liquid-{{ $name }}
+      hosts: [ {{ $domain }} ]
+  rules:
+    - host: {{ $domain }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: liquid-{{ $name }}
+                port:
+                  number: 80
+
+{{- end }}

--- a/openstack/limes/templates/seed-catalog.yaml
+++ b/openstack/limes/templates/seed-catalog.yaml
@@ -1,0 +1,56 @@
+{{- $region := .Values.global.region       | required "missing value for .Values.global.region"       -}}
+{{- $tld    := .Values.global.tld          | required "missing value for .Values.global.tld"          -}}
+
+apiVersion: "openstack.stable.sap.cc/v1"
+kind: OpenstackSeed
+metadata:
+  # This is separate from the big limes-seed in order to be easier to reapply.
+  name: limes-catalog-seed
+
+spec:
+  requires: []
+
+  services:
+    - name:        limes
+      type:        resources
+      description: 'Hierarchical quota/usage tracking'
+      enabled:     true
+      endpoints:
+        - region:    '{{ $region }}'
+          interface: public
+          enabled:   true
+          url:       '{{.Values.limes.clusters.ccloud.catalog_url}}'
+        - region:    '{{ $region }}'
+          interface: internal
+          enabled:   true
+          url:       'http://limes-api-ccloud.{{.Release.Namespace}}.svc'
+
+    - name:        limes-rates
+      type:        sapcc-rates
+      description: 'Hierarchical rate limit/usage tracking'
+      enabled:     true
+      endpoints:
+        - region:    '{{ $region }}'
+          interface: public
+          enabled:   true
+          url:       '{{.Values.limes.clusters.ccloud.catalog_url}}/rates'
+        - region:    '{{ $region }}'
+          interface: internal
+          enabled:   true
+          url:       'http://limes-api-ccloud.{{.Release.Namespace}}.svc/rates'
+
+    {{- range $name := keys .Values.limes.local_liquids }}
+    - name:        liquid-{{ $name }}
+      type:        liquid-{{ $name }}
+      description: 'Limes integration for {{ title $name }} <https://pkg.go.dev/github.com/sapcc/go-api-declarations/liquid>'
+      enabled:     true
+      endpoints:
+        - region:    '{{ $region }}'
+          interface: public
+          enabled:   true
+          url:       'https://liquid-{{ $name }}.{{ $region }}.cloud.sap'
+        - region:    '{{ $region }}'
+          interface: internal
+          enabled:   true
+          url:       'http://liquid-swift.{{ $.Release.Namespace }}.svc'
+    {{- end }}

--- a/openstack/limes/templates/seed.yaml
+++ b/openstack/limes/templates/seed.yaml
@@ -1,6 +1,5 @@
 {{- $vbase  := .Values.global.vaultBaseURL | required "missing value for .Values.global.vaultBaseURL" -}}
 {{- $region := .Values.global.region       | required "missing value for .Values.global.region"       -}}
-{{- $tld    := .Values.global.tld          | required "missing value for .Values.global.tld"          -}}
 
 {{- $domains := list "bs" "btp_fp" "cc3test" "cp" "cis" "fsn" "hcm" "hcp03" "hda" "hec" "kyma" "monsoon3" "neo" "s4" "wbs" -}}
 {{- /* WARNING: When adding a new domain, also increment the domain count in the OpenstackLimesUnexpectedCloudDnsAdminRoleAssignments alert. */ -}}
@@ -37,51 +36,6 @@ spec:
     - name: cloud_objectstore_admin
     - name: cloud_sharedfilesystem_admin
     - name: cloud_volume_admin
-
-  services:
-    - name:        limes
-      type:        resources
-      description: 'Hierarchical quota/usage tracking'
-      enabled:     true
-      endpoints:
-        - region:    '{{.Values.global.region}}'
-          interface: public
-          enabled:   true
-          url:       '{{.Values.limes.clusters.ccloud.catalog_url}}'
-        - region:    '{{.Values.global.region}}'
-          interface: internal
-          enabled:   true
-          url:       'http://limes-api-ccloud.{{.Release.Namespace}}.svc'
-
-    - name:        limes-rates
-      type:        sapcc-rates
-      description: 'Hierarchical rate limit/usage tracking'
-      enabled:     true
-      endpoints:
-        - region:    '{{.Values.global.region}}'
-          interface: public
-          enabled:   true
-          url:       '{{.Values.limes.clusters.ccloud.catalog_url}}/rates'
-        - region:    '{{.Values.global.region}}'
-          interface: internal
-          enabled:   true
-          url:       'http://limes-api-ccloud.{{.Release.Namespace}}.svc/rates'
-
-    {{- range $name := keys .Values.limes.local_liquids }}
-    - name:        liquid-{{ $name }}
-      type:        liquid-{{ $name }}
-      description: 'Limes integration for {{ title $name }} <https://pkg.go.dev/github.com/sapcc/go-api-declarations/liquid>'
-      enabled:     true
-      endpoints:
-        - region:    '{{ $region }}'
-          interface: public
-          enabled:   true
-          url:       'https://liquid-{{ $name }}.{{ $region }}.{{ $tld }}/'
-        - region:    '{{ $region }}'
-          interface: internal
-          enabled:   true
-          url:       'http://liquid-swift.{{ $.Release.Namespace }}.svc/'
-    {{- end }}
 
   domains:
     - name: Default

--- a/openstack/limes/templates/seed.yaml
+++ b/openstack/limes/templates/seed.yaml
@@ -1,5 +1,6 @@
 {{- $vbase  := .Values.global.vaultBaseURL | required "missing value for .Values.global.vaultBaseURL" -}}
 {{- $region := .Values.global.region       | required "missing value for .Values.global.region"       -}}
+{{- $tld    := .Values.global.tld          | required "missing value for .Values.global.tld"          -}}
 
 {{- $domains := list "bs" "btp_fp" "cc3test" "cp" "cis" "fsn" "hcm" "hcp03" "hda" "hec" "kyma" "monsoon3" "neo" "s4" "wbs" -}}
 {{- /* WARNING: When adding a new domain, also increment the domain count in the OpenstackLimesUnexpectedCloudDnsAdminRoleAssignments alert. */ -}}
@@ -65,6 +66,22 @@ spec:
           interface: internal
           enabled:   true
           url:       'http://limes-api-ccloud.{{.Release.Namespace}}.svc/rates'
+
+    {{- range $name := keys .Values.limes.local_liquids }}
+    - name:        liquid-{{ $name }}
+      type:        liquid-{{ $name }}
+      description: 'Limes integration for {{ title $name }} <https://pkg.go.dev/github.com/sapcc/go-api-declarations/liquid>'
+      enabled:     true
+      endpoints:
+        - region:    '{{ $region }}'
+          interface: public
+          enabled:   true
+          url:       'https://liquid-{{ $name }}.{{ $region }}.{{ $tld }}/'
+        - region:    '{{ $region }}'
+          interface: internal
+          enabled:   true
+          url:       'http://liquid-swift.{{ $.Release.Namespace }}.svc/'
+    {{- end }}
 
   domains:
     - name: Default

--- a/openstack/limes/templates/service-liquids.yaml
+++ b/openstack/limes/templates/service-liquids.yaml
@@ -1,0 +1,19 @@
+{{- range $name, $config := .Values.limes.local_liquids }}
+
+---
+
+kind: Service
+apiVersion: v1
+
+metadata:
+  name: liquid-{{ $name }}
+
+spec:
+  selector:
+    name: liquid-{{ $name }}
+  ports:
+    - name: liquid
+      port: 80
+      protocol: TCP
+
+{{- end }}

--- a/openstack/limes/values.yaml
+++ b/openstack/limes/values.yaml
@@ -21,6 +21,10 @@ limes:
   image_tag: DEFINED_IN_VALUES_FILE
   has_audit_trail: true
 
+  # List of liquids that we will deploy as part of this Helm release by running `limes liquid $NAME`.
+  local_liquids:
+    swift: { cpu_request: 50m, memory_limit: 128Mi }
+
   # Map with entries like:
   #
   #   cluster_id:


### PR DESCRIPTION
The seed split thing is because the openstack-seeder domain seeds are currently in shambles, and by splitting off the catalog seeds into their own seed objects, I can apply them separately without having to depend on any seed dependencies.