### PR TITLE
feat(snmp-exporter): add service to owner-info

### DIFF
--- a/prometheus-exporters/snmp-exporter/Chart.lock
+++ b/prometheus-exporters/snmp-exporter/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.2.0
+  version: 1.0.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:715fa239379e2996a47eddbf4444f8d5303649cfd5ab4ca57e8d5c1c6f47f664
-generated: "2024-04-12T15:14:39.625802+02:00"
+digest: sha256:e7067ab42c9fb4dec0368196021ebe62a4f31cf44c48ae63fa146a35dee60e8c
+generated: "2024-08-02T18:24:55.214314+02:00"

--- a/prometheus-exporters/snmp-exporter/Chart.yaml
+++ b/prometheus-exporters/snmp-exporter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: snmp-exporter
-version: 0.1.8
+version: 0.1.9
 description: Prometheus snmp-exporter
 maintainers:
   - name: Olaf Heydorn (D042653)
@@ -8,7 +8,7 @@ maintainers:
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.2.0
+    version: 1.0.0
 
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/prometheus-exporters/snmp-exporter/alerts/snmp-hsm.alerts
+++ b/prometheus-exporters/snmp-exporter/alerts/snmp-hsm.alerts
@@ -94,7 +94,7 @@ groups:
 
   - alert: hsm01B700IsUnReachable
     expr: irate(snmp_hsm_hsmUpTime{hsmModel="Luna G7",devicename=~"hsm01.*"}[5m]) != 0
-    for: 1hr
+    for: 1h
     labels:
       severity: info
       service: barbican
@@ -109,7 +109,7 @@ groups:
 
   - alert: hsm02B700IsUnReachable
     expr: irate(snmp_hsm_hsmUpTime{hsmModel="Luna G7",devicename=~"hsm02.*"}[5m]) != 0
-    for: 1hr
+    for: 1h
     labels:
       severity: info
       service: barbican

--- a/prometheus-exporters/snmp-exporter/values.yaml
+++ b/prometheus-exporters/snmp-exporter/values.yaml
@@ -1,5 +1,6 @@
 owner-info:
   support-group: observability
+  service: exporter
   maintainers:
     - Olaf Heydorn
     - Ivo Gosemann


### PR DESCRIPTION
fixes configuration error in HSM alerts introduced by https://github.com/sapcc/helm-charts/commit/f0277f967b163bb2cdba5a0555e552a79cb1673f