### PR TITLE
[mariadb] mysqld-exporter scrapes localhost pod-local mysql target

### DIFF
--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.13.0
+version: 0.13.1

--- a/common/mariadb/templates/_helpers.tpl
+++ b/common/mariadb/templates/_helpers.tpl
@@ -20,10 +20,6 @@
 {{- required ".Values.root_password missing" .Values.root_password }}
 {{- end -}}
 
-{{- define "mariadb.exporter_scrape_target_address" -}}
-{{.Values.name}}-mariadb.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.region}}.{{.Values.global.tld}}:3306
-{{- end -}}
-
 {{- define "db_password" -}}
 {{- .Values.global.dbPassword }}
 {{- end -}}

--- a/common/mariadb/templates/deployment.yaml
+++ b/common/mariadb/templates/deployment.yaml
@@ -135,7 +135,7 @@ spec:
         imagePullPolicy: {{ default "IfNotPresent" .Values.imagePullPolicy | quote }}
         args:
           - "--mysqld.username=root"
-          - "--mysqld.address={{ include "mariadb.exporter_scrape_target_address" . }}"
+          - "--mysqld.address=localhost:3306"
         {{- range $flag := .Values.metrics.flags }}
           - "--{{$flag}}"
         {{- end }}


### PR DESCRIPTION
No need to target cluster service for pod-only mysqld-exporter scrapes