### PR TITLE
feat(alerts): added predefindedFilters to pluginConfig for alerts

### DIFF
--- a/system/greenhouse-ccloud/templates/_predefinedfilters.conf.tpl
+++ b/system/greenhouse-ccloud/templates/_predefinedfilters.conf.tpl
@@ -1,0 +1,16 @@
+- name: "prod"
+  displayName: "Prod"
+  matchers:
+    region: "^(?!qa-de-).*"
+- name: "prod-qa"
+  displayName: "Prod + QA"
+  matchers:
+    region: "^(?!qa-de-(?!1$)\\d+).*"
+- name: "labs"
+  displayName: "Labs"
+  matchers:
+    region: "^qa-de-(?!1$)\\d+"
+- name: "all"
+  displayName: "All"
+  matchers:
+    region: ".*"

--- a/system/greenhouse-ccloud/templates/alerts-plugin.yaml
+++ b/system/greenhouse-ccloud/templates/alerts-plugin.yaml
@@ -26,4 +26,7 @@ spec:
     - name: silenceTemplates
       value:
         {{ include (print .Template.BasePath "/_silence.conf.tpl") . | nindent 8 }}
+    - name: predefinedFilters
+      value:
+        {{ include (print .Template.BasePath "/_predefinedfilters.conf.tpl") . | nindent 8 }}
 {{ end }}


### PR DESCRIPTION
Allow configuration of filter tabs in Alerts via predefinedFilters. Part of: https://github.com/cloudoperators/greenhouse-extensions/issues/258