### PR TITLE
[mysql_metrics] Use resolve for mysql-metrics connection string

### DIFF
--- a/common/mysql_metrics/Chart.yaml
+++ b/common/mysql_metrics/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for MySQL Metrics
 name: mysql_metrics
-version: 0.3.4
+version: 0.3.5
 dependencies:
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/common/mysql_metrics/ci/test-values.yaml
+++ b/common/mysql_metrics/ci/test-values.yaml
@@ -1,3 +1,6 @@
+global:
+  registry: test
+
 test_db_host: testRelease-mariadb.svc
 
 db_password: secret!

--- a/common/mysql_metrics/templates/_helpers.tpl
+++ b/common/mysql_metrics/templates/_helpers.tpl
@@ -25,8 +25,34 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{end}}
 
-{{- define "mysql_metrics.db_password" -}}
-{{ .Values.global.dbPassword }}
+{{/*
+Resolve secret and replace single quote with double single quote
+This resolved secret could be put inside the single-quoted string inside yaml
+*/}}
+{{- define "mysql_metrics.resolve_secret_for_yaml" -}}
+    {{- $str := . -}}
+    {{- if (hasPrefix "vault+kvv2" $str ) -}}
+        {{"{{"}} resolve "{{ $str }}" | replace "'" "''" {{"}}"}}
+    {{- else -}}
+        {{ $str | replace "'" "''" }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Construct the go-mysql driver DSN string
+*/}}
+{{- define "mysql_metrics.db_path_for_exporter" -}}
+{{- $protocol := "mysql" -}}
+{{- $username := include "mysql_metrics.resolve_secret_for_yaml" (required ".Values.db_user missing" .Values.db_user) -}}
+{{- $password := "" -}}
+{{- $address := include "metrics_db_host" . -}}
+{{- $database := (required ".Values.db_name missing" .Values.db_name) -}}
+{{- if hasKey .Values "db_password" -}}
+    {{- $password = include "mysql_metrics.resolve_secret_for_yaml" .Values.db_password -}}
+{{- else -}}
+    {{- $password = include "mysql_metrics.resolve_secret_for_yaml" .Values.global.dbPassword -}}
+{{- end -}}
+{{ $protocol }}://{{ $username }}:{{ $password }}@tcp({{ $address }}:3306)/{{ $database }}
 {{- end -}}
 
 {{/* Needed for testing purposes only. */}}

--- a/common/mysql_metrics/templates/etc/_config.yml.tpl
+++ b/common/mysql_metrics/templates/etc/_config.yml.tpl
@@ -3,9 +3,9 @@ jobs:
 - name: "default"
   interval: '1m'
   connections:
-  - "mysql://{{ required ".Values.db_user missing" .Values.db_user }}:{{if hasKey .Values "db_password"}}{{ .Values.db_password }}{{ else }}{{include "mysql_metrics.db_password" .}}{{- end -}}@tcp({{ include "metrics_db_host" . }}:3306)/{{ required ".Values.db_name missing" .Values.db_name }}"
+  - '{{ include "mysql_metrics.db_path_for_exporter" . }}'
   {{- if .Values.queryCell2 }}
-  - "{{ include "cell2_db_path_for_exporter" . }}"
+  - '{{ include "cell2_db_path_for_exporter" . }}'
   {{- end }}
   {{- if .Values.customSources }}
   {{- range $customSource := .Values.customSources }}


### PR DESCRIPTION
We use single quoted literal strings to avoid any unnecessary escaping

go-mysql DSN itself doesn't require any escaping for username and password