### PR TITLE
fix misplaced owner-info

### DIFF
--- a/prometheus-rules/prometheus-controlplane-rules/Chart.lock
+++ b/prometheus-rules/prometheus-controlplane-rules/Chart.lock
@@ -1,6 +1,3 @@
-dependencies:
-- name: owner-info
-  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.2.0
-digest: sha256:9948b42a49d86cee17b76e5d46a5677e70bf3feb9ff2a9c34691a6f82ee751db
-generated: "2024-04-12T15:11:33.058146+02:00"
+dependencies: []
+digest: sha256:643d5437104296e21d906ecb15b2c96ad278f20cfc4af53b12bb6069bd853726
+generated: "2024-08-08T13:29:22.247927582+02:00"

--- a/prometheus-rules/prometheus-controlplane-rules/Chart.yaml
+++ b/prometheus-rules/prometheus-controlplane-rules/Chart.yaml
@@ -1,8 +1,5 @@
 apiVersion: v2
 name: prometheus-controlplane-rules
-version: 1.0.23
+version: 1.0.24
 description: A collection of Prometheus alerting and aggregation rules for controlplane.
-dependencies:
-  - name: owner-info
-    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.2.0
+dependencies: []

--- a/prometheus-rules/prometheus-controlplane-rules/values.yaml
+++ b/prometheus-rules/prometheus-controlplane-rules/values.yaml
@@ -18,11 +18,3 @@ slo:
     manila-api:
       warning: 99.9
       critical: 99.8
-
-owner-info:
-  service: controlplane
-  support-group: services
-  maintainers:
-    - Dmitri Fedotov
-    - Martin Vossen
-  helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/prometheus-rules/prometheus-controlplane-rules


### PR DESCRIPTION
The owner-info dependency belongs in the top-level chart, and only there. At best, putting it in a subchart will be ignored. At worst, it will override the owner-info of the top-level chart.