### PR TITLE
[manila] metrics for castellum's exclusion resons

### DIFF
--- a/openstack/manila/aggregates/openstack/castellum.yaml
+++ b/openstack/manila/aggregates/openstack/castellum.yaml
@@ -1,0 +1,23 @@
+# aggregates rules for castellum
+
+groups:
+  - name: manila-castellum
+    rules:
+      - record: manila_share_exclusion_reasons_for_castellum
+        expr: |
+          max (
+            label_replace(
+              label_replace(openstack_manila_shares_size_gauge{status="error"},
+                "share_id", "$1", "id", "(.*)"),
+              "reason", "status = error", ".*", ".*")
+          ) by (project_id, share_id, reason)
+
+      - record: manila_share_exclusion_reasons_for_castellum
+        expr: |
+          max (
+            label_replace(
+              label_replace(openstack_manila_shares_size_gauge{snapmirror="1"},
+                "share_id", "$1", "id", "(.*)"),
+              "reason", "snapmirror = 1", ".*", ".*")
+          ) by (project_id, share_id, reason)
+

--- a/openstack/manila/templates/prometheus-aggregates.yaml
+++ b/openstack/manila/templates/prometheus-aggregates.yaml
@@ -1,0 +1,17 @@
+{{- range $target, $unused := .Values.aggregates.prometheus }}
+{{- range $path, $bytes := $.Files.Glob (printf "aggregates/%s/*.yaml" $target) }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: {{ $.Release.Name }}-{{ printf "%s" $path | replace "/" "-" }}
+  labels:
+    type: aggregation-rules
+    prometheus: {{ index $.Values.alerts.prometheus $target | required (printf ".Values.alerts.prometheus.%s missing" $target) }}
+
+spec:
+{{ printf "%s" $bytes | indent 2 }}
+
+{{- end }}
+{{- end }}

--- a/openstack/manila/values.yaml
+++ b/openstack/manila/values.yaml
@@ -748,6 +748,10 @@ alerts:
     kubernetes: kubernetes
   support_group: compute-storage-api
 
+aggregates:
+  prometheus:
+    openstack: openstack
+
 # osprofiler
 osprofiler:
   enabled: false


### PR DESCRIPTION
Metrics to list shares that are in "error" status and shares that are
snapmirror targets. Currently, Castellum calls manila API's to filter
those shares. We provides these metrics for better performance.
