### PR TITLE
[Nova] Bump versions of dependencies

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -1,33 +1,33 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.10.1
+  version: 0.14.1
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.10.1
+  version: 0.14.1
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.3.2
+  version: 0.3.5
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.6.9
+  version: 0.11.0
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.1.5
+  version: 0.4.0
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.15.0
+  version: 0.17.0
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.10.1
+  version: 0.14.1
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.6.9
+  version: 0.11.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.2.0
+  version: 1.0.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.1.3
-digest: sha256:2175a095573348f73825c0b659f1803d0bf936fc176b816b8f2d35000fc7ae36
-generated: "2024-04-12T15:51:43.471084+02:00"
+  version: 1.0.0
+digest: sha256:ef1369d86173dd6a3c2115831915b6c21690b44c9c463ec6cf8eb268732fb081
+generated: "2024-08-08T15:47:22.619697116+02:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -8,38 +8,38 @@ dependencies:
   - name: mariadb
     condition: mariadb.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.10.1
+    version: 0.14.1
   - name: mariadb
     alias: mariadb_api
     condition: mariadb_api.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.10.1
+    version: 0.14.1
   - name: mysql_metrics
     condition: mariadb.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.3.2
+    version: 0.3.5
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.6.9
+    version: 0.11.0
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.1.5
+    version: 0.4.0
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.15.0
+    version: ~0.17.0
   - name: mariadb
     alias: mariadb_cell2
     condition: mariadb_cell2.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.10.1
+    version: 0.14.1
   - name: rabbitmq
     alias: rabbitmq_cell2
     condition: cell2.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.6.9
+    version: 0.11.0
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.2.0
+    version: 1.0.0
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.1.3
+    version: 1.0.0

--- a/openstack/nova/ci/test-values.yaml
+++ b/openstack/nova/ci/test-values.yaml
@@ -11,6 +11,7 @@ global:
     
   master_password: topSecret
   nova_service_password: topSecret
+  ironic_service_password: topSecret
   availability_zones:
     - foo
     - bar
@@ -29,6 +30,10 @@ mariadb:
     nova:
       name: nova
       password: password
+
+dbPassword: top-secret
+cell0dbPassword: very-secret
+apidbPassword: much-secret
 
 mariadb_api:
   enabled: false


### PR DESCRIPTION
Main goal is to get the versions with secrets-injector support, but if there are other sensible improvements, we take them, too.

bump mariadb from 0.10.1 to 0.14.1
  * Add standardised labels
  * bump backupv2 image version
  * update mysqld_exporter to 0.15.1
  * mysqld_exporter scrapes from localhost
  * support secrets-injector

bump mysql_metrics from 0.3.2 to 0.3.5
  * support secrets-injector

bump rabbitmq from 0.6.9 to 0.11.0
  * switch Secret from stringData to data
  * add standardised labels
  * support secrets-injector
  * support new and old metrics in RabbitMQRPCUnackTotal alert
  * remove rabbitmq-exporter sidecar in favor of rabbitmq prometheus plugin
  * update rabbitmq from 3.13.0 to 3.13.6

bump memcached from 0.1.5 to 0.4.0
  * add linkerd annotation
  * add standardised labels
  * bump memcached-exporter to v0.14.1
  * increase default cpu limit from 0.1 to 0.5
  * bump memcached from 1.6.21 to 1.6.28

bump openstack/utils from 0.15.0 to 0.17.0
  * add helm pre-upgrade weight to proxysql
  * better error message on missing proxysql password
  * support secrets-injector

bump owner-info from 0.2.0 to 1.0.0
  * delete hook CM on post-delete
  * srs: bump all library charts to a stable version number

bump linkerd-support from 0.1.3 to 1.0.0
  * delete hook job before creating it to fix helm rollback
  * srs: bump all library charts to a stable version number