### PR TITLE
[memcached] Use resolve for  sasl-db secret string

### DIFF
--- a/common/memcached/Chart.yaml
+++ b/common/memcached/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: memcached
-version: 0.5.2
+version: 0.5.3
 description: Free & open source, high-performance, distributed memory object caching system.
 home: http://memcached.org/
 sources:

--- a/common/memcached/ci/test-values.yaml
+++ b/common/memcached/ci/test-values.yaml
@@ -4,3 +4,6 @@ global:
 auth:
   username: test
   password: secure
+
+alerts:
+  support_group: test

--- a/common/memcached/templates/_helpers.tpl
+++ b/common/memcached/templates/_helpers.tpl
@@ -32,6 +32,31 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 
+{{- define "memcached.resolve_secret" -}}
+    {{- $str := . -}}
+    {{- if (hasPrefix "vault+kvv2" $str ) -}}
+        {{"{{"}} resolve "{{ $str }}" {{"}}"}}
+    {{- else -}}
+        {{ $str }}
+    {{- end -}}
+{{- end -}}
+
+{{/*
+Create a string with sasl pwdb secret
+This string can't contain a colon symbol (`:`), because:
+- the first colon acts as a delimiter between username and password
+- the second colon acts as an end of the password
+See source: https://github.com/memcached/memcached/blob/1.6.28/sasl_defs.c#L74
+Memcached doesn't provide any means to use escaping in the string, so we only have a few options:
+- transform username and password with urlquery BOTH in sasl pwdb and oslo.cache [cache]
+- remove a colon from the username and password
+Note: In oslo.cache services [cache] configuration $ symbol should be escaped as \$ or $$
+We've chosen not to use colons in these memcache secrets
+*/}}
+{{- define "memcached.sasl_pwdb" -}}
+{{ include "memcached.resolve_secret" .Values.auth.username }}:{{ include "memcached.resolve_secret" .Values.auth.password }}
+{{- end -}}
+
 {{- define "memcached_maintenance_affinity" }}
           - weight: 1
             preference:

--- a/common/memcached/templates/secrets.yaml
+++ b/common/memcached/templates/secrets.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     type: configuration
     application: {{ .Release.Name }}
-stringData:
-  memcached-sasl-db: |
-    "{{ .Values.auth.username }}:{{ .Values.auth.password }}"
+data:
+  memcached-sasl-db: {{ include "memcached.sasl_pwdb" . | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
Use urlquery both for username and password

* These values are consumed literally in urlqueried form by memcached
* These values should be urlqueried in `[cache]` section of the services configuration and consumed literally there, because they can't contain `$` sign.