### PR TITLE
[manila] use harvest metrics in castellum rules

### DIFF
--- a/openstack/manila/aggregates/storage/castellum.rules
+++ b/openstack/manila/aggregates/storage/castellum.rules
@@ -5,56 +5,64 @@ groups:
     rules:
       # Case one: default provision style, where snapshot reserve is allocated AS PART OF the target share size and snapshot reserve percentage is 5.
       # Logical space reporting and enforcement are always disabled for them. Once resized, the share will be converted to case two or three.
-      # Share size = netapp_volume_total_bytes + netapp_volume_snapshot_reserved_bytes
-      # Share usage = netapp_volume_used_bytes
-      # Share minimal size = netapp_volume_used_bytes + netapp_volume_snapshot_reserved_bytes
+      # Share size = NetApp Volume size = netapp_volume_size_total +  netapp_volume_snapshot_reserve_size
+      # Share usage = netapp_volume_size_used
+      # Share minimal size = netapp_volume_size_used +  netapp_volume_snapshot_reserve_size
 
       - record: netapp_volume_provision_case_one
-        expr: netapp_volume_percentage_snapshot_reserve{share_id!="", volume=~"share_[0-9a-f]{8}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{12}", volume_type="rw"} / 5 == 1
+        expr: netapp_volume_snapshot_reserve_percent{share_id!="", type="rw",
+          volume=~"share_[0-9a-f]{8}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{12}"} / 5 == 1
 
       - record: manila_share_size_bytes_for_castellum
-        expr: netapp_volume_provision_case_one * (netapp_volume_total_bytes + netapp_volume_snapshot_reserved_bytes)
+        expr: netapp_volume_provision_case_one * netapp_volume_size
 
       - record: manila_share_used_bytes_for_castellum
-        expr: netapp_volume_provision_case_one * netapp_volume_used_bytes
+        expr: netapp_volume_provision_case_one * netapp_volume_size_used
 
       - record: manila_share_minimal_size_bytes_for_castellum
-        expr: netapp_volume_provision_case_one * (netapp_volume_used_bytes + netapp_volume_snapshot_reserved_bytes)
+        expr: netapp_volume_provision_case_one * (netapp_volume_size_used + netapp_volume_snapshot_reserve_size)
 
       # Case two: new provision style and logical space is NOT enabled
       # New provision style means snapshot reserve is allocated side by side to the share space.
       # The volume is provisioned with double of share size and sanpshot reserve percentage is set to 50.
       # To avoid snapshot spill, share's minimal size must be larger than the snapshot used size or share used size, whichever is larger.
-      # Share size = netapp_volume_total_bytes
+      # Share size = netapp volume total size (snapshot reserve excluded)
       # Share usage = netapp_volume_used_bytes
       # Share minimal size = max(netapp_volume_used_bytes, netapp_volume_snapshot_used_bytes)
       - record: netapp_volume_provision_case_two
-        expr: (netapp_volume_percentage_snapshot_reserve{share_id!="", volume=~"share_[0-9a-f]{8}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{12}", volume_type="rw"} / 50 == 1) * ((1 + netapp_volume_is_space_enforcement_logical) == 1)
+        expr: (netapp_volume_snapshot_reserve_percent{share_id!="", type="rw",
+          volume=~"share_[0-9a-f]{8}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{12}"} / 50 == 1)
+          * on (app, aggr, svm, volume) group_left() netapp_volume_labels{is_space_enforcement_logical="false"}
 
       - record: manila_share_size_bytes_for_castellum
-        expr: netapp_volume_provision_case_two * netapp_volume_total_bytes
+        expr: netapp_volume_provision_case_two * netapp_volume_size_total
 
       - record: manila_share_used_bytes_for_castellum
-        expr: netapp_volume_provision_case_two * netapp_volume_used_bytes
+        expr: netapp_volume_provision_case_two * netapp_volume_size_used
 
       - record: manila_share_minimal_size_bytes_for_castellum
-        expr: netapp_volume_provision_case_two * on (share_id) group_left max({__name__=~"netapp_volume_used_bytes|netapp_volume_snapshot_used_bytes"}) by (share_id)
+        expr: netapp_volume_provision_case_two * on (share_id) group_left() max by (share_id) (
+          {__name__=~"netapp_volume_size_used|netapp_volume_snapshot_size_used"})
 
       # Case three: same as case two, but logical space reporting and enforcement are enabled.
-      # Share size = netapp_volume_total_bytes
-      # Share usage = netapp_volume_logical_used_bytes
-      # Share minimal size = max(netapp_volume_logical_used_bytes, netapp_volume_snapshot_used_bytes)
+      # Share size = netapp volume total size (snapshot reserve excluded)
+      # Share usage = logical space used by file system
+      # Share minimal size = max of logical space used by file system or snapshot size
       - record: netapp_volume_provision_case_three
-        expr: (netapp_volume_percentage_snapshot_reserve{share_id!="", volume=~"share_[0-9a-f]{8}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{12}", volume_type="rw"} / 50 == 1) * (netapp_volume_is_space_enforcement_logical == 1)
+        expr: (netapp_volume_snapshot_reserve_percent{share_id!="", type="rw",
+          volume=~"share_[0-9a-f]{8}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{12}"} / 50 == 1)
+          * on (app, aggr, svm, volume) group_left() netapp_volume_labels{is_space_enforcement_logical="true"}
 
       - record: manila_share_size_bytes_for_castellum
-        expr: netapp_volume_provision_case_three * netapp_volume_total_bytes
+        expr: netapp_volume_provision_case_three * netapp_volume_size_total
 
+      # netapp_volume_space_logical_used_by_afs considers no snapshot spill
       - record: manila_share_used_bytes_for_castellum
-        expr: netapp_volume_provision_case_three * netapp_volume_logical_used_bytes
+        expr: netapp_volume_provision_case_three * netapp_volume_space_logical_used_by_afs
 
       - record: manila_share_minimal_size_bytes_for_castellum
-        expr: netapp_volume_provision_case_three * on (share_id) group_left max({__name__=~"netapp_volume_logical_used_bytes|netapp_volume_snapshot_used_bytes"}) by (share_id)
+        expr: netapp_volume_provision_case_three * on (share_id) group_left() max by (share_id) (
+          {__name__=~"netapp_volume_space_logical_used_by_afs|netapp_volume_snapshot_size_used"})
 
       # If the `manila_share_exclusion_reasons_for_castellum` metric has entries, Castellum will ignore the respective share.
       # This is required because Castellum discovers shares through the Manila API, but some shares do not have
@@ -64,13 +72,17 @@ groups:
       #
       # The `reason` label in the final aggregation rule is used by Castellum for logging ignored shares.
 
-      # Scraping will fail on shares in state "offline" because their size is always reported as 0.
+      # Exclude shares that has exclusive "offline" volume.
+      # There can be two volumes for the same share, one online and one offline.
+      # We Use 'unless {volume_state="online"}' to make sure the offline volume is the only one for the share.
       - record: netapp_volume_exclusion_reason_offline
-        expr: count(netapp_volume_total_bytes{project_id!="", share_id!="", volume_state="offline", volume=~"share_[0-9a-f]{8}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{12}"}) by (project_id, share_id) unless (count(netapp_volume_total_bytes{volume_state="online", volume=~"share_[0-9a-f]{8}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{12}"}) by (project_id, share_id))
+        expr: max by (project_id, share_id) (netapp_volume_labels{project_id!="", share_id!="", state="offline",
+          volume=~"share_[0-9a-f]{8}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{12}"}
+          unless on (project_id, share_id) netapp_volume_labels{state="online"})
       - record: manila_share_exclusion_reasons_for_castellum
-        expr: label_replace(netapp_volume_exclusion_reason_offline, "reason", "volume_state = offline", "share_id", ".*")
+        expr: label_replace(netapp_volume_exclusion_reason_offline, "reason", "volume_state = offline", ".*", ".*")
 
-      # We want to ignore "shares" that are actually snapmirror targets.
+      # Exclude "shares" that are exclusive snapmirror targets.
       # It's possible that we have metrics with both volume_type="dp" and other volume_type values for same share (e.g. share with multiple replicas).
       # In this case Castellum will only use the non-dp metrics. This check is specifically about excluding shares that are *only* snapmirrors.
       #
@@ -79,6 +91,8 @@ groups:
       #
       # NOTE: Explicitly requiring the volume label to match the share_id regex to avoid missing shares that have other volumes tagged with the same share_id.
       - record: netapp_volume_exclusion_reason_dponly
-        expr: (count(netapp_volume_total_bytes{project_id!="",share_id!="",volume_type="dp",volume=~"share_[0-9a-f]{8}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{12}"}) by (project_id, share_id) > 0) unless (count(netapp_volume_total_bytes{project_id!="",share_id!="",volume_type!="dp",volume=~"share_[0-9a-f]{8}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{12}"}) by (project_id, share_id) > 0)
+        expr: max by (project_id, share_id) (netapp_volume_labels{project_id!="", share_id!="", type="dp",
+          volume=~"share_[0-9a-f]{8}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{12}"}
+          unless on (project_id, share_id) netapp_volume_labels{type!="dp"})
       - record: manila_share_exclusion_reasons_for_castellum
-        expr: label_replace(netapp_volume_exclusion_reason_dponly, "reason", "volume_type = dp", "share_id", ".*")
+        expr: label_replace(netapp_volume_exclusion_reason_dponly, "reason", "volume_type = dp", ".*", ".*")


### PR DESCRIPTION
Follow up of migrating netapp exporters to netapp harvest

The rules are duplicated in previous PR. The identical rules does not produce multiple metrics. With this pr, we migrate the rules to use harvest metrics, producing different set of labels. And there will be two set of castellum metrics.