### PR TITLE
[cronus][rabbitmq] Add support for secrets-inejctor resolve for RabbitMQ URIs

### DIFF
--- a/openstack/cronus/Chart.lock
+++ b/openstack/cronus/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.7.3
+  version: 0.11.0
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.7.3
+  version: 0.11.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
 - name: maillog
   repository: file://sub-charts/maillog
   version: 0.1.0
-digest: sha256:27b3bbb7a91df24a08ee529ce337b44e184c2adcfea8de63125c4be7e81f3a40
-generated: "2024-07-15T11:18:50.978955+03:00"
+digest: sha256:b067cb5dbe41912bc63a8d70f1c3d53b59bfdcdb05080c6d908bfa5e17abf4e5
+generated: "2024-08-13T16:25:13.759768+03:00"

--- a/openstack/cronus/Chart.yaml
+++ b/openstack/cronus/Chart.yaml
@@ -1,14 +1,14 @@
 apiVersion: v2
 name: cronus
 description: proxying hyperscaler statless services
-version: 0.1.14
+version: 0.1.15
 dependencies:
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.7.3
+    version: 0.11.0
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.7.3
+    version: 0.11.0
     alias: rhea_rabbitmq
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/cronus/ci/test-values.yaml
+++ b/openstack/cronus/ci/test-values.yaml
@@ -1,5 +1,6 @@
 global:
   region: regionOne
+  tld: cloud
   alerts:
     prometheus: prometheus
   cronus_service_password: ""
@@ -10,6 +11,16 @@ rhea:
     pullPolicy: IfNotPresent
     tag: latest
 
+rhea_rabbitmq:
+  users:
+    default:
+      user: rhea_rabbitmq
+      password: super-secret
+  metrics:
+    password: super-secret
+  alerts:
+    support_group: test
+
 nebula:
   sentryDsn: ""
   cors:
@@ -17,12 +28,25 @@ nebula:
     allowedOrigins:
     allowedHeaders:
 
-
 cronus:
   sentryDsn: ""
+
+rabbitmq:
+  users:
+    default:
+      user: rabbitmq
+      password: super-secret
+  metrics:
+    password: super-secret
+  alerts:
+    support_group: test
 
 rabbitmq_notifications:
   users:
     default:
-      user:
-    
+      user: rabbitmq
+      password: super-secret
+  metrics:
+    password: super-secret
+  alerts:
+    support_group: test

--- a/openstack/cronus/templates/_helpers.tpl
+++ b/openstack/cronus/templates/_helpers.tpl
@@ -1,0 +1,15 @@
+{{- define "cronus.resolve_secret_urlquery" -}}
+    {{- $str := . -}}
+    {{- if (hasPrefix "vault+kvv2" $str ) -}}
+        {{"{{"}} resolve "{{ $str }}" | urlquery {{"}}"}}
+    {{- else -}}
+        {{ $str }}
+    {{- end -}}
+{{- end -}}
+
+{{- define "cronus.amqp_url" -}}
+{{- $username := include "cronus.resolve_secret_urlquery" .username -}}
+{{- $password := include "cronus.resolve_secret_urlquery" .password -}}
+{{- $host := .host -}}
+amqp://{{- $username -}}:{{- $password -}}@{{- $host -}}/
+{{- end}}

--- a/openstack/cronus/templates/cronus/secrets.yaml
+++ b/openstack/cronus/templates/cronus/secrets.yaml
@@ -11,9 +11,9 @@ metadata:
 type: Opaque
 data:
   SENTRY_DSN: {{ .Values.cronus.sentryDsn | b64enc }}
-  RABBITMQ_URI: {{ printf "amqp://%s:%s@%s/" .Values.rabbitmq.users.default.user .Values.rabbitmq.users.default.password .Values.rabbitmq.host | b64enc }}
-  {{- $host := printf "%s.%s.%s:5672" "hermes-rabbitmq-notifications" $.Values.global.region $.Values.global.tld }}
-  RABBITMQ_URL: {{ printf "amqp://%s:%s@%s/" .Values.rabbitmq_notifications.users.default.user .Values.rabbitmq_notifications.users.default.password $host | b64enc }}
+  RABBITMQ_URI: {{ include "cronus.amqp_url" (dict "username" .Values.rabbitmq.users.default.user "password" .Values.rabbitmq.users.default.password "host" .Values.rabbitmq.host) | b64enc }}
+  {{- $_notifications_host := printf "%s.%s.%s:5672" "hermes-rabbitmq-notifications" $.Values.global.region $.Values.global.tld }}
+  RABBITMQ_URL: {{ include "cronus.amqp_url" (dict "username" .Values.rabbitmq_notifications.users.default.user "password" .Values.rabbitmq_notifications.users.default.password "host" $_notifications_host) | b64enc }}
   {{- if .Values.config.keystone }}
   KEYSTONE_PASSWORD: {{ .Values.global.cronus_service_password | b64enc}}
   {{- end }}

--- a/openstack/cronus/templates/nebula/secrets.yaml
+++ b/openstack/cronus/templates/nebula/secrets.yaml
@@ -12,8 +12,8 @@ metadata:
 type: Opaque
 data:
   SENTRY_DSN: {{ .Values.nebula.sentryDsn | b64enc }}
-  {{- $host := printf "%s.%s.%s:5672" "hermes-rabbitmq-notifications" $.Values.global.region $.Values.global.tld }}
-  RABBITMQ_URL: {{ printf "amqp://%s:%s@%s/" .Values.rabbitmq_notifications.users.default.user .Values.rabbitmq_notifications.users.default.password $host | b64enc }}
+  {{- $_notifications_host := printf "%s.%s.%s:5672" "hermes-rabbitmq-notifications" $.Values.global.region $.Values.global.tld }}
+  RABBITMQ_URL: {{ include "cronus.amqp_url" (dict "username" .Values.rabbitmq_notifications.users.default.user "password" .Values.rabbitmq_notifications.users.default.password "host" $_notifications_host) | b64enc }}
   SMTP_USERNAME: {{ .Values.notifier.smtpUsername | b64enc}}
   SMTP_PASSWORD: {{ .Values.notifier.smtpPassword | b64enc}}
   KEYSTONE_PASSWORD: {{ .Values.global.cronus_service_password | b64enc }}

--- a/openstack/cronus/templates/rhea/secrets.yaml
+++ b/openstack/cronus/templates/rhea/secrets.yaml
@@ -11,7 +11,7 @@ metadata:
     heritage: {{ .Release.Service }}
 type: Opaque
 data:
-  RABBITMQ_URI: {{ printf "amqp://%s:%s@%s/" .Values.rhea_rabbitmq.users.default.user .Values.rhea_rabbitmq.users.default.password .Values.rhea_rabbitmq.host | b64enc }}
+  RABBITMQ_URI: {{ include "cronus.amqp_url" (dict "username" .Values.rhea_rabbitmq.users.default.user "password" .Values.rhea_rabbitmq.users.default.password "host" .Values.rhea_rabbitmq.host) | b64enc }}
   {{- if .Values.config.keystone }}
   KEYSTONE_PASSWORD: {{ .Values.global.cronus_service_password | b64enc}}
   {{- end }}


### PR DESCRIPTION
* Add helper helm functions with secrets-injector resolve support
* Pass username, password and host as arguments for the helper function
* Add CI test-values
* Update rabbitmq helm dependency to 0.11.0: full secrets-injector support

Note: rabbitmq chart 0.7.3 -> 0.11.0 upgrade could require service rabbitmq statefulset removal because this chart contained the bug in version 0.6.13-0.7.5, which made upgrade impossible.