### PR TITLE
keppel-auto: init

### DIFF
--- a/openstack/keppel-auto/Chart.lock
+++ b/openstack/keppel-auto/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: owner-info
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 1.0.0
+digest: sha256:ca7c19b16632950e17c13dc4e5dbda8c7006ad9178f511fefe25bc57e69ad033
+generated: "2024-08-14T11:19:58.228208802+02:00"

--- a/openstack/keppel-auto/Chart.yaml
+++ b/openstack/keppel-auto/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+description: Auto-triggered companion deployment for Keppel (config only)
+name: keppel-auto
+version: 0.1.0
+dependencies:
+  - name: owner-info
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: '>= 0.0.0'

--- a/openstack/keppel-auto/ci/test-values.yaml
+++ b/openstack/keppel-auto/ci/test-values.yaml
@@ -1,0 +1,3 @@
+global:
+  region: qa-de-1
+  tld: example.com

--- a/openstack/keppel-auto/templates/configmap-managed-accounts.yaml
+++ b/openstack/keppel-auto/templates/configmap-managed-accounts.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: ConfigMap
+
+metadata:
+  name: keppel-auto-managed-accounts
+
+data:
+  config.json: {{ include "build_managed_accounts" $ | fromYaml | toJson }}
+
+{{- define "build_managed_accounts" }}
+# Keppel takes a JSON config here, but YAML is way easier to template,
+# so we generate YAML here and then convert it to JSON up above.
+{{- $region := .Values.global.region | required "missing required config value: .Values.global.region" }}
+{{- $tld    := .Values.global.tld    | required "missing required config value: .Values.global.tld" }}
+
+accounts:
+  {{- range $account := .Values.accounts }}
+  {{- $is_primary := eq $account.primary_region $region }}
+  {{- $project_id := index $.Values.project_refs $account.project_ref $region }}
+  {{- if $project_id }}
+
+  - name: {{ quote $account.name }}
+    auth_tenant_id: {{ $project_id }}
+
+    {{- if and $is_primary $account.gc_policies }}
+    gc_policies: {{ toJson $account.gc_policies }}
+    {{- end }}
+
+    rbac_policies:
+      {{- range $policy := $account.rbac_policies }}
+      {{- $only_valid_on_primary := $policy.permissions | has "anonymous_first_pull" }}
+      {{- if or $is_primary (not $only_valid_on_primary) }}
+      - {{ toJson $policy }}
+      {{- end }}
+      {{- end }}
+
+    {{- if and $is_primary $account.replication }}
+    replication: {{ toJson $account.replication }}
+    {{- else if not $is_primary }}
+    replication:
+      strategy: on_first_use
+      upstream: keppel.{{ $account.primary_region }}.{{ $tld }}
+    {{- end }}
+
+    {{- if $account.security_scan_policies }}
+    security_scan_policies: {{ toJson $account.security_scan_policies }}
+    {{- end }}
+
+    {{- if and $is_primary $account.validation }}
+    validation: {{ toJson $account.validation }}
+    {{- end }}
+
+    {{- if and $is_primary $account.platform_filter }}
+    platform_filter: {{ toJson $account.platform_filter }}
+    {{- end }}
+
+  {{- end }}
+  {{- end }}
+
+{{- end }}

--- a/openstack/keppel-auto/values.yaml
+++ b/openstack/keppel-auto/values.yaml
@@ -1,0 +1,12 @@
+owner-info:
+  support-group: containers
+  service: keppel
+  maintainers:
+    - Stefan Majewsky
+    - Sandro Jäckel
+    - Stefan Voigt
+  helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/openstack/keppel-auto
+
+# See docstring on keppel-managed-accounts.yaml in the secrets repo for details.
+accounts: {}
+project_refs: {}


### PR DESCRIPTION
Similar to the limes-auto chart, this is for automatic deployments of certain configuration files, specifically the seed configuration for managed accounts.

On its own, this deployment will do nothing until we change the main Keppel chart to consume this configmap.