### PR TITLE
limes: adjust for new ApplyQuotaOverrides cronjob

### DIFF
--- a/openstack/limes/alerts/openstack/api.alerts
+++ b/openstack/limes/alerts/openstack/api.alerts
@@ -194,6 +194,20 @@ groups:
         Check the `kubectl logs` for limes-collect-ccloud for additional info.
       summary: Limes cannot sync from Keystone.
 
+  - alert: OpenstackLimesFailedQuotaOverrideSyncs
+    expr: sum(increase(limes_quota_override_syncs{task_outcome="failure"}[10m])) > 0 or sum(increase(limes_quota_override_syncs{task_outcome="success"}[10m])) == 0
+    for: 10m
+    labels:
+      context: quotaoverridesync
+      dashboard: limes-overview
+      service: limes
+      severity: warning
+      support_group: containers
+    annotations:
+      description: Limes cannot sync quota overrides from its config into the DB.
+        Check the `kubectl logs` for limes-collect-ccloud for errors (esp. from parsing the overrides file).
+      summary: Limes cannot sync quota overrides.
+
   - alert: OpenstackLimesAuditEventPublishFailing
     # Usually, you would check increase() here, but audit events *can* be quite
     # rare, so we alert if there are any failed audit events at all. To clear this alert,

--- a/openstack/limes/templates/deployment-collect.yaml
+++ b/openstack/limes/templates/deployment-collect.yaml
@@ -6,8 +6,6 @@ metadata:
   labels:
     app: limes-collect
     release: "{{.Release.Name}}"
-  annotations:
-    configmap.reloader.stakater.com/reload: limes-auto-overrides
 
 spec:
   minReadySeconds: 10 # to capture errors from config/override parsing


### PR DESCRIPTION
Companion for https://github.com/sapcc/limes/pull/535

- alert when the limes_quota_override_syncs metric indicates problems
- do not restart the collector on changes to the config file, since the new job reloads the config file on each run anyway