### PR TITLE
chore(cc3test): warn and info for cert alerts

### DIFF
--- a/openstack/cc3test/alerts/ccloud-prometheus.alerts
+++ b/openstack/cc3test/alerts/ccloud-prometheus.alerts
@@ -62,7 +62,7 @@ groups:
       summary: 'CCloud Prometheus {{ $labels.name }} is flapping'
 
   - alert: PrometheusSSOCertificateExpiresInLessThan2Week
-    expr: cc3test_cert_expires_in_days{type="prometheus-sso"} < 15
+    expr: cc3test_cert_expires_in_days{type="prometheus-sso"} < 10
     # we want a critical alert 15 days before (fixing during business hours is sufficient -> warning)
     labels:
       severity: warning
@@ -80,7 +80,7 @@ groups:
     expr: cc3test_cert_expires_in_days{type="prometheus-sso"} < 30
     # we want a warning alert 30 days before
     labels:
-      severity: warning
+      severity: info
       support_group: observability
       tier: os
       service: prometheus


### PR DESCRIPTION
I want the alert to be warning only if there is a more immanent action required. Default goes with info and this is visible in our dashboard already, as info alerts are taken care of too.