### PR TITLE
[Placement] Support secrets-injector

### DIFF
--- a/openstack/placement/Chart.lock
+++ b/openstack/placement/Chart.lock
@@ -1,18 +1,18 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.10.1
+  version: 0.14.1
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.2.0
+  version: 0.4.0
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.15.0
+  version: 0.18.1
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.2.0
+  version: 1.0.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.1.3
-digest: sha256:f836b28d323aefa37a55019098ab03af8f0b23e0cce32e645b9977efabcd9bf9
-generated: "2024-04-15T09:02:04.644623864+02:00"
+  version: 1.0.0
+digest: sha256:1626ca2b7b82cee98948755b22098889f3bd92884f1f7453f0dc54369badac38
+generated: "2024-08-13T11:37:21.323270755+02:00"

--- a/openstack/placement/Chart.yaml
+++ b/openstack/placement/Chart.yaml
@@ -8,16 +8,16 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.10.1
+    version: 0.14.1
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.2.0
+    version: 0.4.0
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.15.0
+    version: ~0.18.1
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.2.0
+    version: 1.0.0
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.1.3
+    version: 1.0.0

--- a/openstack/placement/ci/test-values.yaml
+++ b/openstack/placement/ci/test-values.yaml
@@ -17,3 +17,8 @@ mariadb:
     enabled: false
   backup_v2:
     enabled: false
+
+
+api_db:
+  user: a_name
+  password: a_password

--- a/openstack/placement/templates/etc/_secrets.conf.tpl
+++ b/openstack/placement/templates/etc/_secrets.conf.tpl
@@ -6,5 +6,5 @@ connection = {{ tuple . .Values.mariadb.name .Values.global.dbUser .Values.globa
 {{- end }}
 
 [keystone_authtoken]
-username = {{ .Values.global.placement_service_user | default "placement" }}
-password = {{ required ".Values.global.placement_service_password is missing" .Values.global.placement_service_password }}
+username = {{ .Values.global.placement_service_user | default "placement" | include "resolve_secret" }}
+password = {{ required ".Values.global.placement_service_password is missing" .Values.global.placement_service_password | include "resolve_secret" }}

--- a/openstack/placement/templates/seed.yaml
+++ b/openstack/placement/templates/seed.yaml
@@ -34,7 +34,7 @@ spec:
     users:
     - name: placement
       description: Placement API Service User
-      password: {{ required ".Values.global.placement_service_password is missing" .Values.global.placement_service_password }}
+      password: '{{ required ".Values.global.placement_service_password is missing" .Values.global.placement_service_password | include "resolve_secret" }}'
       role_assignments:
       - project: service
         role: service


### PR DESCRIPTION
We need to bump our charts, especially the `utils` chart, to get support for vault+kkv2 secret references. We enable this support inside our chart by using the `resolve_secret` helper, which can work with the old, literal values and the new vault+kkv2 references.

Bump mariadb from 0.10.1 to 0.14.1
    * Add standardised labels
    * bump backupv2 image version
    * update mysqld_exporter to 0.15.1
    * mysqld_exporter scrapes from localhost
    * support secrets-injector

Bump memcached from 0.2.0 to 0.4.0
    * add linkerd annotation
    * add standardised labels
    * bump memcached-exporter to v0.14.1
    * increase default cpu limit from 0.1 to 0.5
    * bump memcached from 1.6.21 to 1.6.28

Bump utils from 0.15.0 to 0.18.1
    * add helm pre-upgrade weight to proxysql
    * better error message on missing proxysql password
    * support secrets-injector

Bump owner-info from 0.2.0 to 1.0.0
    * delete hook CM on post-delete
    * srs: bump all library charts to a stable version number

Bump linkerd-support from 0.1.3 to 1.0.0
    * delete hook job before creating it to fix helm rollback
    * srs: bump all library charts to a stable version number