### PR TITLE
[neutron] Honor override_vlan_pool in fabric config

### DIFF
--- a/openstack/neutron/templates/etc/_ml2-conf.ini.tpl
+++ b/openstack/neutron/templates/etc/_ml2-conf.ini.tpl
@@ -34,7 +34,7 @@ network_vlan_ranges = {{ range $i, $aci_hostgroup := .Values.aci.aci_hostgroups.
         {{- if or (ne $i 0) ((($.Values.aci|default).aci_hostgroups|default).hostgroups|default) }},{{ end -}}
         {{- range $x, $range := $switchgroup.vlan_ranges | default $.Values.cc_fabric.driver_config.global_config.default_vlan_ranges -}}
             {{- if ne $x 0 }},{{ end -}}
-            {{ $switchgroup.name}}:{{ $range }}
+            {{ default $switchgroup.name $switchgroup.override_vlan_pool }}:{{ $range }}
         {{- end -}}
     {{- end -}}
 {{- end }}


### PR DESCRIPTION
When a hostgroup overrides its vlan pool we need to pick that name for the list of network_vlan_ranges instead of the switchgroup name. This might lead to duplicate names in the list for now, but as in some cases we might also override the vlan ranges we can't just deduplicate this. As this is only relevant for qa for now we'll leave it as is and rethink this once it becomes a problem.