### PR TITLE
First step to prep PX for IPv6

### DIFF
--- a/px/bird/templates/_configmap-bird.tpl
+++ b/px/bird/templates/_configmap-bird.tpl
@@ -5,12 +5,12 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-    name: cfg-{{ $config_name }}
+    name: {{ $config_name }}
     annotations:
         px.cloud.sap/configPath: {{ $config_path | quote }}
         px.cloud.sap/configChecksumSha1: {{ .top.Files.Get $config_path | sha1sum | quote }}
 data:
-    "{{ $config_name }}.conf": |
+    "bird.conf": |
 {{- if not (.top.Files.Glob $config_path) -}}
 {{- fail (printf "bird config file %s does not exist."  $config_path ) -}}
 {{- end }}

--- a/px/bird/templates/_configmap-bird.tpl
+++ b/px/bird/templates/_configmap-bird.tpl
@@ -1,19 +1,14 @@
 {{- define "configmap_bird" -}}
-{{ $config_name := include "bird.domain.config_name" . }}
-{{ $config_path := include "bird.domain.config_path" . }}
+{{- $config_path := include "bird.domain.config_path" . }}
 ---
 kind: ConfigMap
 apiVersion: v1
 metadata:
-    name: {{ $config_name }}
+    name: {{ include "bird.domain.configMapName" . }}
     annotations:
         px.cloud.sap/configPath: {{ $config_path | quote }}
         px.cloud.sap/configChecksumSha1: {{ .top.Files.Get $config_path | sha1sum | quote }}
 data:
     "bird.conf": |
-{{- if not (.top.Files.Glob $config_path) -}}
-{{- fail (printf "bird config file %s does not exist."  $config_path ) -}}
-{{- end }}
 {{ .top.Files.Get $config_path | indent 6 }}
-
 {{ end }}

--- a/px/bird/templates/_deployment-bird.tpl
+++ b/px/bird/templates/_deployment-bird.tpl
@@ -1,16 +1,19 @@
 {{- define "deployment_bird" -}}
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "bird.instance.deployment_name" . }}
   labels: {{ include "bird.instance.labels" . | nindent 4 }}
 spec:
   replicas: 1
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: OrderedReady
+  ordinals:
+    start: 1
   selector:
     matchLabels: {{ include "bird.instance.labels" . | nindent 8 }}
-  strategy:
-    type: Recreate
   template:
     metadata:
       labels: {{ include "bird.instance.labels" . | nindent 8 }}

--- a/px/bird/templates/_deployment-bird.tpl
+++ b/px/bird/templates/_deployment-bird.tpl
@@ -25,20 +25,20 @@ spec:
       affinity: {{ include "bird.domain.affinity" . | nindent 8 }}
       tolerations: {{ include "bird.domain.tolerations" . | nindent 8 }}
       initContainers:
-      - name: {{ include "bird.instance.deployment_name" .}}-init
+      - name: init-network
         image: keppel.{{ required "A registry mus be set" .top.Values.registry }}.cloud.sap/ccloud-dockerhub-mirror/library/alpine:latest
         command: ["sh", "-c", "ip link set vlan{{ .domain_config.multus_vlan }} promisc on"]
         securityContext:
           privileged: true
       containers:
-      - name: {{ include "bird.instance.deployment_name" .}}
+      - name: bird
         image: keppel.{{ required "A registry mus be set" .top.Values.registry }}.cloud.sap/{{ required "A bird_image must be set" .top.Values.bird_image }}
         securityContext:
           capabilities:
             add: ["NET_ADMIN"]
         imagePullPolicy: Always
         volumeMounts:
-        - name: vol-{{ include "bird.instance.deployment_name" .}}
+        - name: config
           mountPath: /etc/bird
         - name: bird-socket
           mountPath: /var/run/bird
@@ -48,7 +48,7 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 5
         resources: {{ toYaml .top.Values.resources.bird | nindent 10 }}
-      - name: {{ include "bird.instance.deployment_name" .}}-exporter
+      - name: exporter
         image: keppel.{{ .top.Values.registry }}.cloud.sap/{{required "bird_exporter_image must be set" .top.Values.bird_exporter_image}}
         args: ["-format.new=true", "-bird.v2", "-bird.socket=/var/run/bird/bird.ctl", "-proto.ospf=false", "-proto.direct=false"]
         resources: {{ toYaml .top.Values.resources.exporter | nindent 10 }}
@@ -59,7 +59,7 @@ spec:
         ports:
         - containerPort: 9324
           name: metrics
-      - name: {{ include "bird.instance.deployment_name" .}}-lgproxy
+      - name: lgproxy
         image: keppel.{{ .top.Values.registry }}.cloud.sap/{{ required "lg_image must be set" .top.Values.lg_image }}
         command: ["python3"]
         args: ["lgproxy.py"]
@@ -71,7 +71,7 @@ spec:
         ports:
         - containerPort: 5000
           name: lgproxy
-      - name: {{ include "bird.instance.deployment_name" .}}-lgadminproxy
+      - name: lgadminproxy
         image: keppel.{{ .top.Values.registry }}.cloud.sap/{{ .top.Values.lg_image }}
         command: ["python3"]
         args: ["lgproxy.py", "priv"]
@@ -84,9 +84,9 @@ spec:
         - containerPort: 5005
           name: lgadminproxy
       volumes:
-        - name: vol-{{ include "bird.instance.deployment_name" .}}
+        - name: config
           configMap:
-            name: cfg-{{ include "bird.domain.config_name" . }}
+            name: {{ include "bird.domain.config_name" . }}
         - name: bird-socket
           emptyDir: {}
 {{- end }}

--- a/px/bird/templates/_deployment-bird.tpl
+++ b/px/bird/templates/_deployment-bird.tpl
@@ -87,7 +87,7 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: {{ include "bird.domain.config_name" . }}
+            name: {{ include "bird.domain.configMapName" . }}
         - name: bird-socket
           emptyDir: {}
 {{- end }}

--- a/px/bird/templates/_deployment-bird.tpl
+++ b/px/bird/templates/_deployment-bird.tpl
@@ -19,6 +19,7 @@ spec:
       labels: {{ include "bird.instance.labels" . | nindent 8 }}
         {{ include "bird.alert.labels" . | nindent 8 }}
         app.kubernetes.io/name: px
+        kubectl.kubernetes.io/default-container: "bird"
       annotations:
         k8s.v1.cni.cncf.io/networks: '[{ "name": "{{ include "bird.statefulset.deployment_name" . }}", "interface": "vlan{{ .domain_config.multus_vlan }}"}]'
     spec:

--- a/px/bird/templates/_deployment-bird.tpl
+++ b/px/bird/templates/_deployment-bird.tpl
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "bird.instance.deployment_name" . }}
+  name: {{ include "bird.statefulset.deployment_name" . }}
   labels: {{ include "bird.instance.labels" . | nindent 4 }}
 spec:
   replicas: 1
@@ -20,7 +20,7 @@ spec:
         {{ include "bird.alert.labels" . | nindent 8 }}
         app.kubernetes.io/name: px
       annotations:
-        k8s.v1.cni.cncf.io/networks: '[{ "name": "{{ include "bird.instance.deployment_name" . }}", "interface": "vlan{{ .domain_config.multus_vlan }}"}]'
+        k8s.v1.cni.cncf.io/networks: '[{ "name": "{{ include "bird.statefulset.deployment_name" . }}", "interface": "vlan{{ .domain_config.multus_vlan }}"}]'
     spec:
       affinity: {{ include "bird.domain.affinity" . | nindent 8 }}
       tolerations: {{ include "bird.domain.tolerations" . | nindent 8 }}

--- a/px/bird/templates/_helpers.tpl
+++ b/px/bird/templates/_helpers.tpl
@@ -17,26 +17,18 @@ domain_config: everything nested under .Values.service_1.domain_1
 {{- printf "%s%s.conf" .top.Values.bird_config_path  (include "bird.domain.config_name" .) -}}
 {{- end }}
 
-{{- /*
-All bird.instance.* expect a instance-context that should be consisted of
-:<< domainCtx
-instance_number: 1
-instance: instance_1
-instance_config: everything nested under .Values.service_1.domain_1.instance_1
-*/}}
-
-{{- define "bird.instance.deployment_name" }}
-{{- printf "%s-pxrs-%d-s%d-%d" .top.Values.global.region .domain_number .service_number .instance_number}}
+{{- define "bird.statefulset.deployment_name" }}
+{{- printf "routeserver-v4-service-%d-domain-%d-%d" .service_number .domain_number .instance_number }}
 {{- end }}
 
 {{- define "bird.domain.labels" }}
-app: {{ include "bird.instance.deployment_name" . | quote }}
+app: {{ include "bird.statefulset.deployment_name" . | quote }}
 pxservice: '{{ .service_number }}'
 pxdomain: '{{ .domain_number }}'
 {{- end }}
 
 {{- define "bird.instance.labels" }}
-app: {{ include "bird.instance.deployment_name" . | quote }}
+app: {{ include "bird.statefulset.deployment_name" . | quote }}
 pxservice: '{{ .service_number }}'
 pxdomain: '{{ .domain_number }}'
 pxinstance: '{{ .instance_number }}'

--- a/px/bird/templates/_nad_multus.tpl
+++ b/px/bird/templates/_nad_multus.tpl
@@ -5,7 +5,7 @@
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:
-  name: {{ include "bird.instance.deployment_name" . }}
+  name: {{ include "bird.statefulset.deployment_name" . }}
   namespace: px
 spec:
   config: |

--- a/px/bird/templates/_service_pxrs.tpl
+++ b/px/bird/templates/_service_pxrs.tpl
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "bird.instance.deployment_name" . }}
+  name: {{ include "bird.statefulset.deployment_name" . }}
 spec:
   ports:
 {{- range $lg, $lg_config := .top.Values.looking_glass }}
@@ -13,5 +13,5 @@ spec:
     targetPort: {{ $lg }}proxy
 {{- end }}
   selector:
-    app: {{ include "bird.instance.deployment_name" . }}
+    app: {{ include "bird.statefulset.deployment_name" . }}
 {{ end }}

--- a/px/bird/templates/podmonitor.yaml
+++ b/px/bird/templates/podmonitor.yaml
@@ -25,27 +25,6 @@ spec:
     interval: 60s
     metricRelabelings: 
     - action: replace
-      regex: ^bird_.+;{{ $.Values.global.region }}-pxrs-([0-9])-s([0-9])-([0-9])
-      replacement: $1
-      sourceLabels: 
-      - __name__
-      - app
-      targetLabel: pxdomain
-    - action: replace
-      regex: ^bird_.+;{{ $.Values.global.region }}-pxrs-([0-9])-s([0-9])-([0-9])
-      replacement: $2
-      sourceLabels: 
-      - __name__
-      - app
-      targetLabel: pxservice
-    - action: replace
-      regex: ^bird_.+;{{ $.Values.global.region }}-pxrs-([0-9])-s([0-9])-([0-9])
-      replacement: $3
-      sourceLabels: 
-      - __name__
-      - app
-      targetLabel: pxinstance
-    - action: replace
       regex: ^bird_.+;BGP;(PL|TP|MN)-([A-Z0-9]*)-(.*)
       replacement: $1
       sourceLabels: 

--- a/px/lg/templates/configmap-communities.yaml
+++ b/px/lg/templates/configmap-communities.yaml
@@ -3,7 +3,7 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-    name: cfg-{{ $.Values.global.region }}-pxrs-lg-communities
+    name: lg-communities
 data:
     "lg_px_communities_v2.json": |
-{{ $.Files.Get $config_path | indent 8}}
+{{ $.Files.Get $config_path | indent 8 }}

--- a/px/lg/templates/configmap.yaml
+++ b/px/lg/templates/configmap.yaml
@@ -3,9 +3,9 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-    name: cfg-{{ $.Values.global.region }}-pxrs-{{ $lg }}
+    name: {{ $lg }}
 data:
-    "{{ $.Values.global.region }}-pxrs-{{ $lg }}.cfg": |
-{{ tuple $.Values.global.region $lg_config | include "lg_conf" | indent 8 }}
+    "lg_config.cfg": |
+{{ include "lg_conf" $lg_config | indent 8 }}
 
 {{ end }}

--- a/px/lg/templates/deployment.yaml
+++ b/px/lg/templates/deployment.yaml
@@ -3,14 +3,14 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ $.Values.global.region }}-pxrs-{{ $lg }}
+  name: {{ $lg }}
   labels:
-    app: {{ $.Values.global.region }}-pxrs-{{ $lg }}
+    app: {{ $lg }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ $.Values.global.region }}-pxrs-{{ $lg }}
+      app: {{ $lg }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -21,33 +21,35 @@ spec:
       labels:
         alert-tier: px
         alert-service: px
-        app: {{ $.Values.global.region }}-pxrs-{{ $lg }}
+        app: {{ $lg }}
+      annotations:
+        checksum/configmap-config: {{ include "lg_conf" $lg_config  | sha256sum }}
     spec:
       containers:
-      - name: {{ $.Values.global.region }}-pxrs-{{ $lg }}
+      - name: {{ $lg }}
         image: keppel.{{ $.Values.registry }}.cloud.sap/{{ $.Values.lg_image }}
         imagePullPolicy: Always
         resources:
 {{ toYaml $.Values.resources.lg | indent 10 }}
         volumeMounts:
-        - name: vol-{{ $.Values.global.region }}-pxrs-{{ $lg }}
+        - name: config
           mountPath: /etc/bird-lg
-        - name: vol-{{ $.Values.global.region }}-pxrs-lg-communities
+        - name: lg-communities
           mountPath: /etc/bird-lg-communities
         command: ["python3"]
 {{- if $lg_config.privileged }}
-        args: ["lg.py", "{{ $.Values.global.region }}-pxrs-{{ $lg }}.cfg", "priv"]
+        args: ["lg.py", "lg_config.cfg", "priv"]
 {{- else }}
-        args: ["lg.py", "{{ $.Values.global.region }}-pxrs-{{ $lg }}.cfg"]
+        args: ["lg.py", "lg_config.cfg"]
 {{- end }}
         ports:
         - containerPort: 80
           name: {{ $lg }}web
       volumes:
-        - name: vol-{{ $.Values.global.region }}-pxrs-{{ $lg }}
+        - name: config
           configMap:
-            name: cfg-{{ $.Values.global.region }}-pxrs-{{ $lg }}
-        - name: vol-{{ $.Values.global.region }}-pxrs-lg-communities
+            name: {{ $lg }}
+        - name: lg-communities
           configMap:
-            name: cfg-{{ $.Values.global.region }}-pxrs-lg-communities
+            name: lg-communities
 {{ end }}

--- a/px/lg/templates/ingress.yaml
+++ b/px/lg/templates/ingress.yaml
@@ -3,7 +3,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ $.Values.global.region }}-pxrs-{{ $lg }}
+  name: {{ $lg }}
   namespace: px
   annotations:
     disco: "true"
@@ -31,12 +31,12 @@ spec:
           path: /
           backend:
             service:
-              name: {{ $.Values.global.region }}-pxrs-{{ $lg }}
+              name: {{ $lg }}
               port:
                 number: 80
 
   tls:
   - hosts:
     - {{ $lg_config.subdomain }}.{{ $.Values.global.region }}.cloud.sap
-    secretName: {{ $.Values.global.region }}-pxrs-{{ $lg }}
+    secretName: {{ $lg }}
 {{ end -}}

--- a/px/lg/templates/lg.conf.tpl
+++ b/px/lg/templates/lg.conf.tpl
@@ -1,11 +1,9 @@
 {{- define "lg_conf" -}}
-{{- $region := index . 0 -}}
-{{- $lg_config := index . 1 -}}
 DEBUG = False
 LOG_FILE="/var/log/lg.log"
 LOG_LEVEL="WARNING"
 
-DOMAIN = "px.svc.kubernetes.{{ $region }}.cloud.sap"
+DOMAIN = "px.svc"
 
 BIND_IP = "0.0.0.0"
 BIND_PORT = 80
@@ -20,5 +18,5 @@ PROXY = {
     {{- end -}}
 }
 
-SESSION_KEY = '{{ $lg_config.session_key }}'
+SESSION_KEY = '{{ .session_key }}'
 {{- end }}

--- a/px/lg/templates/lg.conf.tpl
+++ b/px/lg/templates/lg.conf.tpl
@@ -12,7 +12,7 @@ PROXY = {
     {{ range $i, $domain := list "1" "2" -}}
     {{- range $service := list "1" "2" "3" -}}
     {{- range $instance := list "1" "2" -}}
-    "{{ $region }}-pxrs-{{ $domain }}-s{{ $service }}-{{ $instance }}": {{ $lg_config.proxy_port }},
+    "routeserver-v4-service-{{ $service }}-domain-{{ $domain }}-{{ $instance }}": {{ $.proxy_port }},
     {{ end -}}
     {{- end -}}
     {{- end -}}

--- a/px/lg/templates/service.yaml
+++ b/px/lg/templates/service.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ $.Values.global.region }}-pxrs-{{ $lg }}
+  name: {{ $lg }}
   namespace: px
 spec:
   ports:
@@ -11,5 +11,5 @@ spec:
     port: 80
     targetPort: {{ $lg }}web
   selector:
-    app: {{ $.Values.global.region }}-pxrs-{{ $lg }}
+    app: {{ $lg }}
 {{ end -}}


### PR DESCRIPTION
I'd rather roll out multiple small changes than a single large one. Hence this is prep work in order to introduce IPv6 statefulsets to the PX deployments. Details to be found in the individual commit message.

- Use StatefulSet instead of deployments
- Simplify PX charts: Region names not put all over all places
- Use different naming for statefulset
- [PX] Set bird as default container
- Remove metricRelabelings as the same labels are already created


