### PR TITLE
nova/flavors: Add m_c4_m32 for BTP

### DIFF
--- a/openstack/sap-seeds/templates/flavor-seed.yaml
+++ b/openstack/sap-seeds/templates/flavor-seed.yaml
@@ -283,6 +283,14 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  - name: "m_c4_m32"
+    id: "145"
+    vcpus: 4
+    ram: 32752
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c8_m64"
     id: "140"
     vcpus: 8
@@ -731,6 +739,15 @@ spec:
     id: "431"
     vcpus: 2
     ram: 16368
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  - name: "m_c4_m32_v2"
+    id: "452"
+    vcpus: 4
+    ram: 32752
     disk: 64
     is_public: true
     extra_specs:


### PR DESCRIPTION
BTP requested this flavor with 8-to-1 RAM-to-CPU ratio.

While it is outside of the hardware RAM-CPU ratio, it's a small flavor, and it's high-memory which is not as TCO-sensitive as high-CPU flavors.

Create m_c4_m32_v2 for Sapphire-Rapids clusters as well.
