### PR TITLE
[unbound] toggle the rpz-signal-nxdomain-ra flag for the RPZ zones

### DIFF
--- a/system/unbound/templates/config.yaml
+++ b/system/unbound/templates/config.yaml
@@ -111,6 +111,7 @@ data:
         primary: 127.0.0.1@55353
         rpz-log: {{ has $rpz_zone $.Values.unbound.rpz.log | ternary "yes" "no" }}
         rpz-log-name: {{ $rpz_zone | quote }}
+        rpz-signal-nxdomain-ra: yes
     {{- end }}
 {{- end }}
 


### PR DESCRIPTION
That will unset the RA bit in the NXDOMAIN response for a blocked domain.

That will help clients deduce whether an NXDOMAIN is a result of an RPZ match (RA unset) or an actual, authoritative NXDOMAIN (RA set).