### PR TITLE
[openstack/utils] Do not drop "host" from default_transport_url

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.18.2
+version: 0.18.3

--- a/openstack/utils/templates/_ini_sections.tpl
+++ b/openstack/utils/templates/_ini_sections.tpl
@@ -6,7 +6,7 @@ heartbeat_in_pthread = False
 {{- end }}
 
 {{- define "ini_sections.default_transport_url" }}
-{{- $data := merge (pick .Values.rabbitmq "port" "virtual_host") .Values.rabbitmq.users.default }}
+{{- $data := merge (pick .Values.rabbitmq "host" "port" "virtual_host") .Values.rabbitmq.users.default }}
 {{- $_ := required ".Values.rabbitmq.users.default.user is required" .Values.rabbitmq.users.default.user }}
 {{- $_ := required ".Values.rabbitmq.users.default.password is required" .Values.rabbitmq.users.default.password }}
 {{- include "ini_sections._transport_url" (tuple . $data) }}


### PR DESCRIPTION
`utils.rabbitmq_url` takes a `host` argument, but
`default_transport_url` drops it, leaving no option to change the host for default transport url.