### PR TITLE
[bind] support secret injector (auto-resolve)

### DIFF
--- a/system/bind/Chart.lock
+++ b/system/bind/Chart.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
-digest: sha256:9948b42a49d86cee17b76e5d46a5677e70bf3feb9ff2a9c34691a6f82ee751db
-generated: "2024-04-12T15:24:09.246634+02:00"
+- name: utils
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 0.18.2
+digest: sha256:27a12e303ed6a516b4a3df66a162aa8c7f039068b72af0c0f6d32fc91fa756cb
+generated: "2024-09-02T14:15:02.267003+02:00"

--- a/system/bind/Chart.yaml
+++ b/system/bind/Chart.yaml
@@ -1,9 +1,12 @@
 apiVersion: v2
 description: Bind DNS software. 
 name: bind
-version: 1.0.1
+version: 1.0.2
 appVersion: "9.18.24"
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.2.0
+  - name: utils
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: 0.18.2

--- a/system/bind/templates/etc/_nsi.key.tpl
+++ b/system/bind/templates/etc/_nsi.key.tpl
@@ -1,4 +1,4 @@
 key "nsi-key" {
     algorithm hmac-sha512;
-    secret "{{ .Values.nsi_key }}";
+    secret "{{ .Values.nsi_key | include "resolve_secret" }}";
 };

--- a/system/bind/templates/etc/_rndc.key.tpl
+++ b/system/bind/templates/etc/_rndc.key.tpl
@@ -1,4 +1,4 @@
 key "{{ .Values.rndc_key_name | default "rndc-key" }}" {
     algorithm "{{ .Values.rndc_key_algorithm | default "hmac-md5" }}";
-    secret "{{ .Values.rndc_key }}";
+    secret "{{ .Values.rndc_key | include "resolve_secret" }}";
 };

--- a/system/bind/templates/etc/_tsig.key.tpl
+++ b/system/bind/templates/etc/_tsig.key.tpl
@@ -1,4 +1,4 @@
 key "tsig-key" {
     algorithm hmac-md5;
-    secret "{{ .Values.tsig_key }}";
+    secret "{{ .Values.tsig_key | include "resolve_secret" }}";
 };


### PR DESCRIPTION
With the recent version bump we got a new helper in the `utils` chart that makes it possible to support `secrets-injector` secrets will still maintaining compatibility with not-yet-migrated secret values. In this commit, we use this helper to make the `Bind` chart compatible with `secrets-injector`.