### PR TITLE
[trust-manager] monitor certs' expiration dates

### DIFF
--- a/openstack/trust-manager/templates/exporter.yaml
+++ b/openstack/trust-manager/templates/exporter.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: trust-manager
+    app.kubernetes.io/name: cert-exporter
+    app.kubernetes.io/version: v2.13.0
+    cert-exporter.io/type: deployment
+    helm.sh/chart: cert-exporter-3.8.0
+  name: trust-manager-cert-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: trust-manager
+      app.kubernetes.io/name: cert-exporter
+      cert-exporter.io/type: deployment
+  template:
+    annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/targets: openstack
+    metadata:
+      labels:
+        app.kubernetes.io/instance: trust-manager
+        app.kubernetes.io/name: cert-exporter
+        cert-exporter.io/type: deployment
+    spec:
+      containers:
+      - args:
+        - --configmaps-label-selector=trust.cert-manager.io/bundle
+        - --logtostderr
+        command:
+        - ./app
+        image: keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/joeelliott/cert-exporter:v2.13.0
+        imagePullPolicy: IfNotPresent
+        name: cert-exporter
+        ports:
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
+        livenessProbe:
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          tcpSocket:
+            port: 8080
+        readinessProbe:
+          failureThreshold: 1
+          httpGet:
+            path: /metrics
+            port: 8080
+          periodSeconds: 10


### PR DESCRIPTION
This PR add cert-exporter [1] to trust manager. It reviews the configmaps created by the trust manager bundle and checks the expiration dates of the certificats. Available metrics `cert_exporter_configmap_expires_in_seconds`, `cert_exporter_configmap_not_after_timestamp` and `cert_exporter_configmap_not_before_timestamp`.

[1] https://github.com/joe-elliott/cert-exporter