### PR TITLE
Add owner-label-injector-staging config to knownBrokenReleases

### DIFF
--- a/system/gatekeeper-config/templates/constraint-owner-info-on-helm-releases.yaml
+++ b/system/gatekeeper-config/templates/constraint-owner-info-on-helm-releases.yaml
@@ -24,7 +24,7 @@ spec:
       {{- if eq .Values.cluster_type "test" }}
       - testing/known-broken # used for testing the exception mechanism
       {{- end }}
-      {{- if eq .Values.cluster_phase "verification" }}
+      {{- if and (eq .Values.cluster_type "baremetal") (eq .Values.global.region "qa-de-1") }}
       - owner-label-injector-staging/owner-label-injector-staging   # staging deployment of owner-label-injector
       - owner-label-injector-staging/test-chart-without-owner-info  # dummy chart for testing for owner-label-injector
       - owner-label-injector-staging/test-chart-with-owner-info     # dummy chart for testing for owner-label-injector

--- a/system/gatekeeper-config/templates/constraint-owner-info-on-helm-releases.yaml
+++ b/system/gatekeeper-config/templates/constraint-owner-info-on-helm-releases.yaml
@@ -24,3 +24,8 @@ spec:
       {{- if eq .Values.cluster_type "test" }}
       - testing/known-broken # used for testing the exception mechanism
       {{- end }}
+      {{- if eq .Values.cluster_phase "verification" }}
+      - owner-label-injector-staging/owner-label-injector-staging   # staging deployment of owner-label-injector
+      - owner-label-injector-staging/test-chart-without-owner-info  # dummy chart for testing for owner-label-injector
+      - owner-label-injector-staging/test-chart-with-owner-info     # dummy chart for testing for owner-label-injector
+      {{- end }}


### PR DESCRIPTION
These namespace and charts are used to test owner-label-injector in qa-de-1