### PR TITLE
elektra: use postgresql-ng version from library chart

### DIFF
--- a/openstack/elektra/Chart.lock
+++ b/openstack/elektra/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: postgresql-ng
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.0.37
+  version: 1.0.38
 - name: pgbackup
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
@@ -14,5 +14,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:4b04407e824b205239495937f502e55dd09ca5b9aa35db259d5419b2cbe7d640
-generated: "2024-08-26T14:10:46.181942567+02:00"
+digest: sha256:c84d73043891cb6eae3549d105dd37c3c372901a8cee3500a09a64692b8464c0
+generated: "2024-09-03T11:24:52.546499379+02:00"

--- a/openstack/elektra/values.yaml
+++ b/openstack/elektra/values.yaml
@@ -54,10 +54,7 @@ postgresql:
   log_min_duration_statement: 250
   # less than the postgresql chart's default; I want to know early when connections start getting out of hand
   max_connections: 128
-  
-  # Please update following imageTag witgh the latest version of the postgresql (see in elektras keppel plugin under path ccloud/postgres-ng)
-  # It may happen in the future that PostgreSQL versions are removed, causing PostgreSQL to crash when deploying. In such cases, a rollback should suffice.
-  imageTag: "20240813032238"
+
   persistence:
     enabled: true
     accessMode: ReadWriteMany


### PR DESCRIPTION
We recommend not pinning the image version and using the default that is hardcoded into the library chart. Updates can be received by bumping the chart dependency with `helm dep up` (which can be automated with the respective shared CI task).