### PR TITLE
redis: make Deployment roll out on configuration changes

### DIFF
--- a/common/redis/Chart.yaml
+++ b/common/redis/Chart.yaml
@@ -13,7 +13,15 @@ name: redis
 sources:
 - https://github.com/bitnami/bitnami-docker-redis
 
-# NOTE: When upgrading from 1.3.x, please note the following backwards-incompatible changes to the values.yaml:
-# - image.repository and metrics.image.repository as well as their imagePullPolicy settings are now hardcoded.
-# - The Redis image now comes from ccloud/shared-app-images/redis. Please update your image.tag pins accordingly (see comment in values.yaml).
-version: 1.4.12 # this version number is SemVer as it gets used to auto bump
+# NOTE: When upgrading please note the following changes:
+#
+# from 1.3.x
+# - image.repository and metrics.image.repository as well as their
+#   imagePullPolicy settings are now hardcoded.
+# - The Redis image now comes from ccloud/shared-app-images/redis. Please update
+#   your image.tag pins accordingly (see comment in values.yaml).
+#
+# from 1.4.x
+# - the deployment will be rolled out (restarted) on password and configuration
+#   Secrets changes.
+version: 1.5.0 # this version number is SemVer as it gets used to auto bump

--- a/common/redis/templates/deployment.yaml
+++ b/common/redis/templates/deployment.yaml
@@ -29,6 +29,12 @@ spec:
         {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
         linkerd.io/inject: enabled
         {{- end }}
+        {{- if .Values.config }}
+        checksum/configmap: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if .Values.redisPassword }}
+        checksum/secrets: {{ include (print .Template.BasePath "/secrets.yaml") . | sha256sum }}
+        {{- end }}
     spec:
       containers:
       - name: {{ template "redis.fullname" . }}


### PR DESCRIPTION
The mechanics of how the annotation causes the deployment to roll out is explained here - https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments.

Without this PR any changes of Redis configuaration or password require additional intervention (e.g. manual `kubectl rollout restart deployment`) to make them picked up, which doesn't scale well on frequent changes or with numerous deployments.