### PR TITLE
[designate-nanny] using secrets injector for seeder as well

### DIFF
--- a/openstack/designate-nanny/ci/test-values.yaml
+++ b/openstack/designate-nanny/ci/test-values.yaml
@@ -13,7 +13,7 @@ designate_nanny:
       project_domain_name: "test_project_domain_name"
       project_user_domain_name: "test_user_domain_name"
   config:
-    nanny-config: 
+    nanny-config:
       key-1: "value-1"
     opaque_yaml_values: here
 

--- a/openstack/designate-nanny/templates/secret.yaml
+++ b/openstack/designate-nanny/templates/secret.yaml
@@ -8,7 +8,7 @@ metadata:
     system: openstack
     application: designate
 data:
-  designate_nanny_os_username: {{ required "missing username in .Values.designate_nanny.credentials.designate_api.user" .Values.designate_nanny.credentials.designate_api.user | b64enc }}
-  designate_nanny_os_password: {{ required "missing password in .Values.designate_nanny.credentials.designate_api.password" .Values.designate_nanny.credentials.designate_api.password | b64enc }}
+  designate_nanny_os_username: {{ required "missing .Values.designate_nanny.credentials.designate_api.user"     .Values.designate_nanny.credentials.designate_api.user     | b64enc }}
+  designate_nanny_os_password: {{ required "missing .Values.designate_nanny.credentials.designate_api.password" .Values.designate_nanny.credentials.designate_api.password | b64enc }}
 
 {{- end }}

--- a/openstack/designate/ci/test-values.yaml
+++ b/openstack/designate/ci/test-values.yaml
@@ -67,7 +67,6 @@ designate_nanny:
   credentials:
     designate_api:
       user: nobody
-      seeder_password: DeckelSecret
       password: TopfSecret
       project_name: "test_project_name"
       project_domain_name: "test_project_domain_name"

--- a/openstack/designate/templates/seeds.yaml
+++ b/openstack/designate/templates/seeds.yaml
@@ -1008,18 +1008,18 @@ spec:
   domains:
   - name: {{ required "missing user domain in .Values.designate_nanny.credentials.designate_api.project_user_domain_name" .Values.designate_nanny.credentials.designate_api.project_user_domain_name }}
     users:
-    - name: {{ required "missing user in .Values.designate_nanny.credentials.designate_api.user" .Values.designate_nanny.credentials.designate_api.user }}
+    - name: {{ required "missing username in .Values.designate_nanny.credentials.designate_api.user" .Values.designate_nanny.credentials.designate_api.user | include "resolve_secret" }}
       description: Designate Nanny
-      password: {{ required "missing initial password in .Values.designate_nanny.credentials.designate_api.seeder_password" .Values.designate_nanny.credentials.designate_api.seeder_password }}
+      password: {{ required "missing password in .Values.designate_nanny.credentials.designate_api.password" .Values.designate_nanny.credentials.designate_api.password | include "resolve_secret" }}
   - name: {{ required "missing project domain name in .Values.designate_nanny.credentials.designate_api.project_domain_name" .Values.designate_nanny.credentials.designate_api.project_domain_name }}
     projects:
     - name: {{ required "missing project name in .Values.designate_nanny.credentials.designate_api.project_name" .Values.designate_nanny.credentials.designate_api.project_name }}
       role_assignments:
-      - user: {{ .Values.designate_nanny.credentials.designate_api.user}}@{{.Values.designate_nanny.credentials.designate_api.project_user_domain_name }}
+      - user: {{ .Values.designate_nanny.credentials.designate_api.user | include "resolve_secret" }}@{{.Values.designate_nanny.credentials.designate_api.project_user_domain_name }}
         role: cloud_dns_viewer
     - name: master
       role_assignments:
-      - user: {{ .Values.designate_nanny.credentials.designate_api.user}}@{{.Values.designate_nanny.credentials.designate_api.project_user_domain_name }}
+      - user: {{ .Values.designate_nanny.credentials.designate_api.user | include "resolve_secret" }}@{{.Values.designate_nanny.credentials.designate_api.project_user_domain_name }}
         role: objectstore_admin
 
 {{- end }}


### PR DESCRIPTION
Seeder supports the new secrets injector as well, so initial credentials can be seeded as well.