### PR TITLE
limes: rename several service_type constants for LIQUIDation, phase 1

### DIFF
--- a/openstack/limes/alerts/openstack/api.alerts
+++ b/openstack/limes/alerts/openstack/api.alerts
@@ -163,7 +163,7 @@ groups:
       summary: Limes cannot scrape {{ title $labels.service_name }}
 
   - alert: OpenstackLimesMissingSwiftMetrics
-    expr: (limes_project_usage{service="object-store",resource="capacity"} > 0) unless on(project_id) (limes_plugin_metrics_ok{service="object-store"} == 1)
+    expr: (limes_project_usage{service="object-store",resource="capacity"} > 0) unless on(project_id) (limes_plugin_metrics_ok{service="swift"} == 1)
     for: 5m
     labels:
       context: swiftmetrics

--- a/openstack/limes/values.yaml
+++ b/openstack/limes/values.yaml
@@ -151,7 +151,7 @@ pgmetrics:
             JOIN project_az_resources par ON par.resource_id = pr.id
            GROUP BY ps.id, ps.type, pr.name, pr.quota
           HAVING SUM(par.usage) > pr.quota
-             AND NOT (ps.type = 'object-store' AND pr.name = 'capacity' AND SUM(par.usage) < pr.quota + 1099511627776)
+             AND NOT (ps.type = 'swift' AND pr.name = 'capacity' AND SUM(par.usage) < pr.quota + 1099511627776)
         ) SELECT COUNT(*) AS count FROM tmp
       metrics:
         - count:
@@ -193,7 +193,7 @@ pgmetrics:
           JOIN project_services ps ON ps.project_id = p.id
           JOIN project_resources pr ON pr.service_id = ps.id
           JOIN project_az_resources par ON par.resource_id = pr.id
-         WHERE ps.type = 'object-store' AND par.az = 'any'
+         WHERE ps.type = 'swift' AND par.az = 'any'
       metrics:
         - gauge:
             usage: "GAUGE"
@@ -211,10 +211,10 @@ pgmetrics:
     limes_support_group:
       query: >
         SELECT 1 AS mapping, type AS service, CASE
-          WHEN type IN ('compute', 'sharev2', 'volumev2')      THEN 'compute-storage-api'
-          WHEN type IN ('network', 'dns', 'endpoint-services') THEN 'network-api'
-          WHEN type IN ('email-aws')                           THEN 'email'
-          WHEN type IN ('object-store')                        THEN 'storage'
+          WHEN type IN ('compute', 'sharev2', 'volumev2')            THEN 'compute-storage-api'
+          WHEN type IN ('archer', 'designate', 'neutron', 'octavia') THEN 'network-api'
+          WHEN type IN ('email-aws')                                 THEN 'email'
+          WHEN type IN ('ceph', 'swift')                             THEN 'storage'
           ELSE 'containers' END AS support_group
         FROM project_services GROUP BY type
       metrics:


### PR DESCRIPTION
No idea why these alerts did not complain in QA, but they sure are complaining in Bronze.