### PR TITLE
postgresql-ng: fix apiVersion in ownerReferences

### DIFF
--- a/common/postgresql-ng/Chart.yaml
+++ b/common/postgresql-ng/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: postgresql-ng
-version: 1.0.39 # this version number is SemVer as it gets used to auto bump
+version: 1.1.0 # this version number is SemVer as it gets used to auto bump
 description: Chart for PostgreSQL
 keywords:
 - postgresql

--- a/common/postgresql-ng/bin/init-generate-secrets.sh
+++ b/common/postgresql-ng/bin/init-generate-secrets.sh
@@ -23,7 +23,7 @@ for USER in ${USERS:-}; do
     metadata:
       name: $SECRET
       ownerReferences:
-        - apiVersion: v1
+        - apiVersion: apps/v1
           blockOwnerDeletion: true
           kind: Deployment
           name: $DEPLOYMENT_NAME


### PR DESCRIPTION
This might be why these never worked....... I saw related errors in a random controller-manager log that I was checking for a different reason.

```
E0906 11:59:09.695844      11 garbagecollector.go:406] "error syncing item" err="unable to get REST mapping for v1/Deployment." item="[v1/Secret, namespace: codimd, name: codi-pguser-metrics, uid: 0b87eb36-4a85-4f7c-9018-878a3e7c615a]"
```

If this fixes the problem of these secrets not getting cleaned up with the deployment, we can make a followup PR to get rid of the delete-secrets job hook.