### PR TITLE
Update NSX-T Logstash Image to 8.15.1

### DIFF
--- a/openstack/neutron/templates/etc/_nsxv3_logstash.conf.tpl
+++ b/openstack/neutron/templates/etc/_nsxv3_logstash.conf.tpl
@@ -25,7 +25,7 @@ filter {
 
     if "_grokparsefailure" not in [tags] {
       ruby {
-        init => 'require "sequel"; $rc = Sequel.connect("jdbc:mysql://{{include "db_host_mysql" .}}/{{.Values.db_name}}?user=${NEUTRON_DB_USER}&password=${NEUTRON_DB_PASSWORD}")'
+        init => 'require "sequel"; $rc = Sequel.connect("jdbc:mysql://{{include "db_host_mysql" .}}/{{.Values.db_name}}?user=%s&password=%s" % [ENV["NEUTRON_DB_USER"], ENV["NEUTRON_DB_PASSWORD"]])'
         code => '
         event_map = {"PASS" => "ACCEPT", "DROP" => "DROP"}
         event.set("action", "TERM") if event.get("action").nil?

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -179,7 +179,7 @@ imageNameNetworkAgentDHCPInit: alpine
 # imageVersionNetworkAgentOVS:
 # imageVersionIronicAgent:
 imageVersionRedis: 7.0.0-alpine
-imageVersionLogstash: 8.2.0
+imageVersionLogstash: 8.15.1
 imageVersionNetworkAgentDHCPInit: 3.8
 
 api:


### PR DESCRIPTION
Updating Logstash to version 8.15.1 caused an error in the ruby filter, specifically in
the init section, resulting in pod crashes.
The issue was due to the way used to retrieve `DB_USER` and `DB_PASSWORD`.

Switching to ruby-formatted strings resolves the problem.