### PR TITLE
revert 1e5f8f2

### DIFF
--- a/system/greenhouse-ccloud/Chart.yaml
+++ b/system/greenhouse-ccloud/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: ccloud
 description: A Helm chart for the CCloud organization in Greenhouse.
 type: application
-version: 1.3.4
+version: 1.3.5

--- a/system/greenhouse-ccloud/templates/kube-monitoring-storage-pluginpreset.yaml
+++ b/system/greenhouse-ccloud/templates/kube-monitoring-storage-pluginpreset.yaml
@@ -63,23 +63,6 @@ spec:
         fsGroup: 0
         runAsNonRoot: false
         runAsUser: 0
-    - name: kubeMonitoring.kube-state-metrics
-      value:
-        metricLabelsAllowlist:
-        - cronjobs=[*]
-        - daemonsets=[*]
-        - deployments=[*]
-        - endpoints=[*]
-        - ingresses=[*]
-        - jobs=[*]
-        - namespaces=[*]
-        - nodes=[*]
-        - persistentvolumes=[*]
-        - persistentvolumeclaims=[*]
-        - pods=[*]
-        - secrets=[*]
-        - services=[*]
-        - statefulsets=[*]
     pluginDefinition: kube-monitoring
     releaseNamespace: kube-monitoring
 {{- end -}}


### PR DESCRIPTION
kube-state-metrics are pulled in kube-monitoring chart already, with values for kube-state-metrics subchart of kube-prometheus-stack.