### PR TITLE
[manila] cleanup migration job

### DIFF
--- a/openstack/manila/templates/migration-job.yaml
+++ b/openstack/manila/templates/migration-job.yaml
@@ -3,11 +3,8 @@
      So if we want to switch to or from a proxysql.mode=unix_socket setting, we need
      first to deploy with proxysql.mode=host_alias as an intermediate step,
      so this script can still work with the previous setting.
-     Similarily we can only use the secret if a previous helm deployment added
-     it.
 */}}
 {{- $proxysql := lookup "v1" "Secret" .Release.Namespace (print .Release.Name "-proxysql-etc") -}}
-{{- $secrets := lookup "v1" "Secret" .Release.Namespace (print .Release.Name "-secrets") -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -60,10 +57,8 @@ spec:
               mountPath: /etc/manila/manila.conf
               subPath: manila.conf
               readOnly: true
-{{- if $secrets }}
             - name: manila-etc-confd
               mountPath: /etc/manila/manila.conf.d
-{{- end }}
             - name: manila-etc
               mountPath: /etc/manila/policy.yaml
               subPath: policy.yaml
@@ -85,11 +80,9 @@ spec:
         - name: manila-etc
           configMap:
             name: {{ .Release.Name }}-etc
-{{- if $secrets }}
         - name: manila-etc-confd
           secret:
             secretName: {{ .Release.Name }}-secrets
-{{- end }}
         - name: container-init
           configMap:
             name: {{ .Release.Name }}-bin


### PR DESCRIPTION
remove condition for secret config.
All secrets have been moved, so it is no longer needed for
'pre-upgrade'.
And the condition is wrong for 'post-install',
because the lookup happens before install and the migration script
would fail to run without the secrets on a fresh installation now.
