### PR TITLE
chore(kube-monitoring): use version constraint for oomkill

### DIFF
--- a/system/kube-monitoring-admin-k3s/Chart.lock
+++ b/system/kube-monitoring-admin-k3s/Chart.lock
@@ -19,7 +19,7 @@ dependencies:
   version: 2.6.2
 - name: oomkill-exporter
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.5.11
+  version: 1.0.1
 - name: ping-exporter
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.1
@@ -50,5 +50,5 @@ dependencies:
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
   version: 3.13.0
-digest: sha256:f1ab2b42a2c76a1d27841fa24938aecb9527ecd8d96a0363d982fa8eb1022b90
-generated: "2024-09-13T09:09:43.323566748Z"
+digest: sha256:92d848a100141f0f83101c9416e11c747c2018555218b317d7ee28ece973d8e3
+generated: "2024-09-16T10:43:18.43124+02:00"

--- a/system/kube-monitoring-admin-k3s/Chart.yaml
+++ b/system/kube-monitoring-admin-k3s/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     version: "^2.5"
   - name: oomkill-exporter
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.5.11
+    version: "^1.x"
   - name: ping-exporter
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.1.1

--- a/system/kube-monitoring-kubernikus/Chart.lock
+++ b/system/kube-monitoring-kubernikus/Chart.lock
@@ -25,7 +25,7 @@ dependencies:
   version: 2.6.2
 - name: oomkill-exporter
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.5.11
+  version: 1.0.1
 - name: ping-exporter
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.1
@@ -59,5 +59,5 @@ dependencies:
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
   version: 3.13.0
-digest: sha256:041c0ecd3b8be9501e58974e78009296267035cd8b8c43841ab3ef1dfa1ee0b6
-generated: "2024-09-13T09:16:32.975742766Z"
+digest: sha256:21f03642226f454d77eb10d5c56d12528e5f3fb228191faafffb25f37aa58349
+generated: "2024-09-16T10:43:42.071958+02:00"

--- a/system/kube-monitoring-kubernikus/Chart.yaml
+++ b/system/kube-monitoring-kubernikus/Chart.yaml
@@ -33,7 +33,7 @@ dependencies:
     version: "^2.5"
   - name: oomkill-exporter
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.5.11
+    version: "^1.x"
   - condition: ping-exporter.enabled
     name: ping-exporter
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/system/kube-monitoring-metal/Chart.lock
+++ b/system/kube-monitoring-metal/Chart.lock
@@ -19,7 +19,7 @@ dependencies:
   version: 2.6.2
 - name: oomkill-exporter
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.5.11
+  version: 1.0.1
 - name: prometheus-controlplane-rules
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.23
@@ -50,5 +50,5 @@ dependencies:
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
   version: 3.13.0
-digest: sha256:2b29423564a2aa6ce426d559709b2503105b138f43e1f96bb7257686333ed813
-generated: "2024-09-13T09:16:30.884750349Z"
+digest: sha256:478b2ff7674d59e88939c6b266a76302bba4a74add12491303f943227c2f4c25
+generated: "2024-09-16T10:44:06.057046+02:00"

--- a/system/kube-monitoring-metal/Chart.yaml
+++ b/system/kube-monitoring-metal/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     version: "^2.5"
   - name: oomkill-exporter
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.5.11
+    version: "^1.x"
   - name: prometheus-controlplane-rules
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.23

--- a/system/kube-monitoring-virtual/Chart.lock
+++ b/system/kube-monitoring-virtual/Chart.lock
@@ -22,7 +22,7 @@ dependencies:
   version: 2.6.2
 - name: oomkill-exporter
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.5.11
+  version: 1.0.1
 - name: ping-exporter
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.1
@@ -53,5 +53,5 @@ dependencies:
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
   version: 3.13.0
-digest: sha256:e57d8c96074e53f9f243635a38c4afa202b4c47ae9b6654a468190bd5548c970
-generated: "2024-09-13T09:16:34.693586147Z"
+digest: sha256:58b55953564e0dd4bf5bdd7263a6625011d731d83ca28da7bfe3f238195236b9
+generated: "2024-09-16T10:44:23.911828+02:00"

--- a/system/kube-monitoring-virtual/Chart.yaml
+++ b/system/kube-monitoring-virtual/Chart.yaml
@@ -29,7 +29,7 @@ dependencies:
     version: "^2.5"
   - name: oomkill-exporter
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.5.11
+    version: "^1.x"
   - name: ping-exporter
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.1.1


### PR DESCRIPTION
version constraints was introduced for scaleout, this add them for the other contexts as well.
This makes sure the routing fix for `PodOOMKill` will be made available for the other clusters as well. 
If you feel this is to pushy, I am also fine with replacing the `appVersion` with `version` and setting it to latest.