### PR TITLE
nova/flavors: Add intel-cascadelake evc mode on GP flavors

### DIFF
--- a/openstack/sap-seeds/templates/flavor-seed.yaml
+++ b/openstack/sap-seeds/templates/flavor-seed.yaml
@@ -26,6 +26,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" (dict "hw_video:ram_max_mb" 4) | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "g_c1_m2"
     id: "19"
     vcpus: 1
@@ -35,6 +36,7 @@ spec:
     extra_specs:
       "catalog:alias": "m1.xsmallcpuhdd"
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "c_c2_m2"
     id: "20"
     vcpus: 2
@@ -44,6 +46,7 @@ spec:
     extra_specs:
       "catalog:alias": "m1.small,m1.smallhdd"
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "g_c2_m4"
     id: "22"
     vcpus: 2
@@ -53,6 +56,7 @@ spec:
     extra_specs:
       "catalog:alias": "m1.xsmall,m1.xsmallhdd"
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "g_c1_m3"
     id: "24"
     vcpus: 1
@@ -61,6 +65,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "g_c1_m4"
     id: "25"
     vcpus: 1
@@ -69,6 +74,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "g_c2_m8"
     id: "32"
     vcpus: 2
@@ -78,6 +84,7 @@ spec:
     extra_specs:
       "catalog:alias": "m1.xmedium"
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "c_c4_m4"
     id: "30"
     vcpus: 4
@@ -87,6 +94,7 @@ spec:
     extra_specs:
       "catalog:alias": "m1.medium"
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "g_c4_m8"
     id: "40"
     vcpus: 4
@@ -96,6 +104,7 @@ spec:
     extra_specs:
       "catalog:alias": "m1.large"
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "g_c4_m16"
     id: "50"
     vcpus: 4
@@ -105,6 +114,7 @@ spec:
     extra_specs:
       "catalog:alias": "m1.xlarge"
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "c_c16_m16"
     id: "52"
     vcpus: 16
@@ -114,6 +124,7 @@ spec:
     extra_specs:
       "catalog:alias": "m1.xlarge_cpu"
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "g_c6_m24"
     id: "53"
     vcpus: 6
@@ -122,6 +133,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "g_c8_m32"
     id: "60"
     vcpus: 8
@@ -131,6 +143,7 @@ spec:
     extra_specs:
       "catalog:alias": "m1.2xlarge"
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "g_c16_m32"
     id: "61"
     vcpus: 16
@@ -140,6 +153,7 @@ spec:
     extra_specs:
       "catalog:alias": "m1.2xlargecpu"
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "g_c12_m48"
     id: "62"
     vcpus: 12
@@ -148,6 +162,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "g_c16_m64"
     id: "70"
     vcpus: 16
@@ -157,6 +172,7 @@ spec:
     extra_specs:
       "catalog:alias": "m1.4xlarge"
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "m1.10xlarge"
     id: "80"
     vcpus: 40
@@ -165,6 +181,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "m1.10xlargesmallcpu"
     id: "81"
     vcpus: 16
@@ -173,6 +190,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "m_c8_m128"
     id: "90"
     vcpus: 8
@@ -182,6 +200,7 @@ spec:
     extra_specs:
       "catalog:alias": "x1.memory"
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "m_c16_m256"
     id: "99"
     vcpus: 16
@@ -191,6 +210,7 @@ spec:
     extra_specs:
       "catalog:alias": "x1.2xmemory"
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "m_c32_m512"
     id: "150"
     vcpus: 32
@@ -200,6 +220,7 @@ spec:
     extra_specs:
       "catalog:alias": "x1.4xmemory"
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "x1.8xmemory"
     id: "151"
     vcpus: 64
@@ -208,6 +229,7 @@ spec:
     is_public: false
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
       "hw:cpu_cores": "64"  # used in nova-vmware as cores-per-socket (32pCPU = 64vCPU)
   - name: "m_c4_m64"
     id: "100"
@@ -218,6 +240,7 @@ spec:
     extra_specs:
       "catalog:alias": "m2.large"
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "g_c8_m16"
     id: "110"
     vcpus: 8
@@ -227,6 +250,7 @@ spec:
     extra_specs:
       "catalog:alias": "m2.xlarge"
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "m2.2xlarge"
     id: "120"
     vcpus: 8
@@ -235,6 +259,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "m2.2xlarge_cpu"
     id: "122"
     vcpus: 24
@@ -243,6 +268,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "m2.10xlarge_cpu"
     id: "123"
     vcpus: 24
@@ -251,6 +277,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "m2.14xlarge_cpu"
     id: "124"
     vcpus: 24
@@ -259,6 +286,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "m2.14xlarge_cpuhdd"
     id: "125"
     vcpus: 24
@@ -267,6 +295,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "m2.3xlarge"
     id: "130"
     vcpus: 8
@@ -275,6 +304,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "m_c2_m16"
     id: "138"
     vcpus: 2
@@ -283,6 +313,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "m_c4_m32"
     id: "145"
     vcpus: 4
@@ -291,6 +322,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "m_c8_m64"
     id: "140"
     vcpus: 8
@@ -300,6 +332,7 @@ spec:
     extra_specs:
       "catalog:alias": "m2.4xlarge"
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "m_c8_m256"
     id: "141"
     vcpus: 8
@@ -308,6 +341,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "m_c20_m160"
     id: "143"
     vcpus: 20
@@ -316,6 +350,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "g_c24_m96"
     id: "144"
     vcpus: 24
@@ -324,6 +359,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "m_c24_m192"
     id: "142"
     vcpus: 24
@@ -332,6 +368,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "m_c16_m128"
     id: "160"
     vcpus: 16
@@ -341,6 +378,7 @@ spec:
     extra_specs:
       "catalog:alias": "m2.8xlarge"
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "m2.16xlarge"
     id: "161"
     vcpus: 16
@@ -349,6 +387,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "m_c16_m512"
     id: "164"
     vcpus: 16
@@ -357,6 +396,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "g_c32_m128"
     id: "162"
     vcpus: 32
@@ -365,6 +405,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "g_c48_m192"
     id: "166"
     vcpus: 48
@@ -373,6 +414,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "m5.xlarge2hdd"
     id: "210"
     vcpus: 4
@@ -381,6 +423,7 @@ spec:
     is_public: false
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "m5.12xlarge"
     id: "211"
     vcpus: 48
@@ -389,6 +432,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "m5.14xlarge"
     id: "212"
     vcpus: 60
@@ -397,6 +441,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "m_c32_m256"
     id: "163"
     vcpus: 32
@@ -405,6 +450,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "m_c64_m512"
     id: "165"
     vcpus: 64
@@ -413,6 +459,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
       "hw:cpu_cores": "64"  # used in nova-vmware as cores-per-socket (32pCPU = 64vCPU)
   - name: "g_c64_m256"
     id: "220"
@@ -424,6 +471,7 @@ spec:
       "catalog:alias": "m5.16xlarge"
       "hw:cpu_cores": "64"  # used in nova-vmware as cores-per-socket (32pCPU = 64vCPU)
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "m_c48_m512"
     id: "221"
     vcpus: 48
@@ -432,6 +480,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "g_c128_m512"
     id: "230"
     vcpus: 128
@@ -442,6 +491,7 @@ spec:
       "catalog:alias": "m5.32xlarge"
       "hw:cpu_cores": "64"  # used in nova-vmware as cores-per-socket (32pCPU = 64vCPU)
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
   - name: "m5.48xlarge"
     id: "231"
     vcpus: 96
@@ -450,6 +500,7 @@ spec:
     is_public: true
     extra_specs:
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
       "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
   - name: "m_c128_m1000"
     id: "240"
@@ -461,6 +512,7 @@ spec:
       "catalog:alias": "m5.64xlarge"
       "hw:cpu_cores": "64"  # used in nova-vmware as cores-per-socket (32pCPU = 64vCPU)
       {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "vmware:evc_mode": "intel-cascadelake"
 
 
   # Regular Flavors v2 (Sapphire-Rapids)


### PR DESCRIPTION
Not for Sapphire-Rapids flavors yet, because the VCenters aren't upgraded to 8.0 and don't know about this CPU generation yet.
