### PR TITLE
kubernikus: remove cloud_resource_admin role assignment

### DIFF
--- a/openstack/kubernikus/templates/seed.yaml
+++ b/openstack/kubernikus/templates/seed.yaml
@@ -20,8 +20,6 @@ spec:
         role: admin
       - project: cloud_admin@ccadmin
         role: cloud_network_admin
-      - project: cloud_admin@ccadmin
-        role: cloud_resource_admin
       - project: master@ccadmin
         role: cloud_dns_admin
       - project: master@ccadmin


### PR DESCRIPTION
Not needed anymore after quota editing has been removed from Limes.