### PR TITLE
[Nova] Enable token caching for openstack-agent-liveness

### DIFF
--- a/openstack/nova/templates/bigvm-deployment.yaml
+++ b/openstack/nova/templates/bigvm-deployment.yaml
@@ -67,7 +67,7 @@ spec:
           {{- end }}
           livenessProbe:
             exec:
-              command: ["openstack-agent-liveness", "--component", "nova", "--config-file", "/etc/nova/nova.conf", "--config-file", "/etc/nova/nova.conf.d/keystoneauth-secrets.conf"]
+              command: ["openstack-agent-liveness", "--component", "nova", "--config-file", "/etc/nova/nova.conf", "--config-file", "/etc/nova/nova.conf.d/keystoneauth-secrets.conf", "--token_cache_file", "/tmp/liveness-token.cache"]
             initialDelaySeconds: 60
             periodSeconds: 60
             timeoutSeconds: 20

--- a/openstack/nova/templates/cell2-conductor-deployment.yaml
+++ b/openstack/nova/templates/cell2-conductor-deployment.yaml
@@ -69,7 +69,7 @@ spec:
             {{- end }}
           livenessProbe:
             exec:
-              command: ["openstack-agent-liveness", "--component", "nova", "--config-file", "/etc/nova/nova.conf", "--config-file", "/etc/nova/nova.conf.d/keystoneauth-secrets.conf"]
+              command: ["openstack-agent-liveness", "--component", "nova", "--config-file", "/etc/nova/nova.conf", "--config-file", "/etc/nova/nova.conf.d/keystoneauth-secrets.conf", "--token_cache_file", "/tmp/liveness-token.cache"]
             initialDelaySeconds: 60
             periodSeconds: 60
             timeoutSeconds: 20

--- a/openstack/nova/templates/conductor-deployment.yaml
+++ b/openstack/nova/templates/conductor-deployment.yaml
@@ -68,7 +68,7 @@ spec:
 {{- end }}
           livenessProbe:
             exec:
-              command: ["openstack-agent-liveness", "--component", "nova", "--config-file", "/etc/nova/nova.conf", "--config-file", "/etc/nova/nova.conf.d/keystoneauth-secrets.conf"]
+              command: ["openstack-agent-liveness", "--component", "nova", "--config-file", "/etc/nova/nova.conf", "--config-file", "/etc/nova/nova.conf.d/keystoneauth-secrets.conf", "--token_cache_file", "/tmp/liveness-token.cache"]
             initialDelaySeconds: 60
             periodSeconds: 60
             timeoutSeconds: 20

--- a/openstack/nova/templates/scheduler-deployment.yaml
+++ b/openstack/nova/templates/scheduler-deployment.yaml
@@ -67,7 +67,7 @@ spec:
           {{- end }}
           livenessProbe:
             exec:
-              command: ["openstack-agent-liveness", "--component", "nova", "--config-file", "/etc/nova/nova.conf", "--config-file", "/etc/nova/nova.conf.d/keystoneauth-secrets.conf"]
+              command: ["openstack-agent-liveness", "--component", "nova", "--config-file", "/etc/nova/nova.conf", "--config-file", "/etc/nova/nova.conf.d/keystoneauth-secrets.conf", "--token_cache_file", "/tmp/liveness-token.cache"]
             initialDelaySeconds: 60
             periodSeconds: 60
             timeoutSeconds: 20


### PR DESCRIPTION
With [0] the `python-agentliveness` command got the ability to cache the token and re-use it. We would like to use that functionality, because requesting a new token every liveness check a) puts more load on keystone for getting the token and b) puts more load on keystone for the service not having cached the token and thus asking keystone for its validity.

[0] https://github.com/sapcc/python-agentliveness/pull/7

---

Tested by manual deployment in a lab.