### PR TITLE
limes: remove assignment of cloud_resource_admin to limes itself

### DIFF
--- a/openstack/limes/templates/prometheus-alerts.yaml
+++ b/openstack/limes/templates/prometheus-alerts.yaml
@@ -58,13 +58,11 @@ spec:
         # allowed role assignments for the `cloud_resource_admin` role:
         # - group CCADMIN_CLOUD_ADMINS@ccadmin in project cloud_admin@ccadmin
         # - user dashboard@Default             in project cloud_admin@ccadmin (TODO: remove once the seed changes were deployed)
-        # - user limes@Default                 in project cloud_admin@ccadmin (TODO: looks unnecessary, remove?)
         # - user kubernikus-terraform@Default  in project cloud_admin@ccadmin (TODO: remove once the seed changes were deployed)
         # - user TCC_BM_ANSL@ccadmin           in project cloud_admin@ccadmin
         # - user TCC_BM_TMPR@ccadmin           in project cloud_admin@ccadmin
         - alert: OpenstackLimesUnexpectedCloudAdminRoleAssignments
-          {{- $r := .Values.global.region }}
-          expr: max(openstack_assignments_per_role{role_name="cloud_resource_admin"}) > 6
+          expr: max(openstack_assignments_per_role{role_name="cloud_resource_admin"}) > 5
           for: 10m
           labels:
             support_group: containers


### PR DESCRIPTION
This was already removed from the seed a while ago, and a few newer regions (ap-sa-2 and na-us-2) did not have it, so that proves that everything works fine without it.