### PR TITLE
keystone: do not rely on db version check

### DIFF
--- a/openstack/keystone/templates/bin/_db-sync.tpl
+++ b/openstack/keystone/templates/bin/_db-sync.tpl
@@ -6,33 +6,7 @@ keystone-status --config-file=/etc/keystone/keystone.conf --config-file=/etc/key
 echo "DB Version before migration:"
 keystone-manage --config-file=/etc/keystone/keystone.conf --config-file=/etc/keystone/keystone.conf.d/secrets.conf db_version
 
-keystone-manage --config-file=/etc/keystone/keystone.conf --config-file=/etc/keystone/keystone.conf.d/secrets.conf db_sync --check
-case $? in
-    0)
-        echo "No migration required. Database is up-2-date."
-        ;;
-    1)
-        echo "Uhoh, Houston we have a problem."
-        ;;
-    2)
-        echo "Database update available - starting migrations"
-        # expand the database schema
-        keystone-manage --config-file=/etc/keystone/keystone.conf --config-file=/etc/keystone/keystone.conf.d/secrets.conf db_sync --expand
-        ;&
-    3)
-        echo "Database expanded"
-        # run migrate
-        keystone-manage --config-file=/etc/keystone/keystone.conf --config-file=/etc/keystone/keystone.conf.d/secrets.conf db_sync --migrate
-        ;&
-    4)
-        echo "Database migrated"
-        # run contraction
-        keystone-manage --config-file=/etc/keystone/keystone.conf --config-file=/etc/keystone/keystone.conf.d/secrets.conf db_sync --contract
-        ;;
-    *)
-        echo "Duno what state the database is in. grrrr"
-        ;;
-esac
+keystone-manage --config-file=/etc/keystone/keystone.conf --config-file=/etc/keystone/keystone.conf.d/secrets.conf db_sync
 
 echo "DB Version after migration:"
 keystone-manage --config-file=/etc/keystone/keystone.conf --config-file=/etc/keystone/keystone.conf.d/secrets.conf db_version


### PR DESCRIPTION
The --check seems to be broken upstream. Until it is fixed, lets just run the upgrade when possible. It will not re-run them if it is already done, so we should be safe.

https://bugs.launchpad.net/keystone/+bug/2080542