### PR TITLE
Switch Nova + Cinder to `vsphere.local` users

### DIFF
--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -47,7 +47,7 @@ sentry:
 
 port_metrics: 9102
 
-vmware_host_username: m3cinderapiuser
+vmware_host_username: m3cinderapiuser@vsphere.local
 backend_defaults:
   reserved_percentage: 20
   suppress_requests_ssl_warnings: True

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -288,7 +288,7 @@ scheduler:
 
 compute:
   defaults:
-    host_username: m3novaapiuser
+    host_username: m3novaapiuser@vsphere.local
     default:
       max_concurrent_builds_per_project: 20
       max_concurrent_builds: 50


### PR DESCRIPTION
We need to switch away from `localos` users to `vsphere.local` users with vSphere 8.