### PR TITLE
[mysql-galera] Helm chart to provide pcx-operator and pxc-db with CC specific extensions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,7 @@
 /common/manila-provisioner                             @jknipper  # old
 /common/mariadb                                        @galkindmitrii @stefanhipfel @Carthaca @IvoGoman @fwiesel @businessbean @occamshatchet
 /common/mariadb-galera                                 @businessbean @bashar-alkhateeb
+/common/percona-operator                               @s10 @businessbean @bashar-alkhateeb
 /common/memcached                                      @auhlig @businessbean @bashar-alkhateeb
 /common/mysql_metrics                                  @galkindmitrii @Carthaca @businessbean @bashar-alkhateeb
 /common/nats                                           @notandy

--- a/common/percona-operator/README.md
+++ b/common/percona-operator/README.md
@@ -1,0 +1,27 @@
+# percona-operator
+A Helm chart to deploy MySQL instances using Percona Operator For MySQL custom resource definitions.
+
+## Prerequisites
+```shell=bash
+helm dependency update helm
+```
+
+## Validate the Operator templates
+```shell=bash
+helm template percona-operator helm --namespace pxc-operator --values helm/operator.yaml
+```
+
+## Validate the Database templates
+```shell=bash
+helm template keystone-mysql helm --namespace keystone-pxc --values helm/database.yaml
+```
+
+## Installing the Operator resources
+```shell=bash
+helm upgrade percona-operator helm --install --namespace pxc-operator --create-namespace --values helm/operator.yaml
+```
+
+## Installing the database
+```shell=bash
+helm upgrade keystone-mysql helm --install --namespace keystone-pxc --create-namespace --values helm/database.yaml
+```

--- a/common/percona-operator/helm/.helmignore
+++ b/common/percona-operator/helm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/common/percona-operator/helm/Chart.lock
+++ b/common/percona-operator/helm/Chart.lock
@@ -1,0 +1,12 @@
+dependencies:
+- name: pxc-operator
+  repository: https://percona.github.io/percona-helm-charts/
+  version: 1.15.0
+- name: pxc-db
+  repository: https://percona.github.io/percona-helm-charts/
+  version: 1.15.0
+- name: owner-info
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 0.2.3
+digest: sha256:5ea9c17e3217754412e76bb6bb6e205126d61178e70a9525a2944ee58e25c54e
+generated: "2024-09-12T13:55:53.648279+02:00"

--- a/common/percona-operator/helm/Chart.lock
+++ b/common/percona-operator/helm/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 1.15.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.2.3
-digest: sha256:5ea9c17e3217754412e76bb6bb6e205126d61178e70a9525a2944ee58e25c54e
-generated: "2024-09-12T13:55:53.648279+02:00"
+  version: 1.0.0
+digest: sha256:b3b7ef78948308c4719a4244ccd523af44066ec9c0b49313229c583ea33656ce
+generated: "2024-09-16T12:59:29.61974+02:00"

--- a/common/percona-operator/helm/Chart.yaml
+++ b/common/percona-operator/helm/Chart.yaml
@@ -29,5 +29,5 @@ dependencies:
     condition: pxcdb.enabled
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.2.3
+    version: 1.0.0
     condition: owner_info.enabled

--- a/common/percona-operator/helm/Chart.yaml
+++ b/common/percona-operator/helm/Chart.yaml
@@ -1,0 +1,33 @@
+apiVersion: v2
+name: percona-operator
+description: A Helm chart to deploy MySQL instances using Percona Operator For MySQL custom resource definitions.
+home: "https://github.com/sapcc/helm-charts/tree/master/common/percona-operator"
+type: application
+version: 0.1.0
+appVersion: "1.15.0"
+kubeVersion: ">=1.26.0-0"
+maintainers:
+  - name: Birk Bohne
+    url: https://github.com/businessbean
+  - name: Vlad Gusev
+    url: https://github.com/s10
+keywords:
+  - pxc-operator
+  - database
+sources:
+  - https://github.com/percona/percona-helm-charts/tree/main
+dependencies:
+  - name: pxc-operator
+    alias: pxcoperator
+    version: 1.15.0
+    repository: https://percona.github.io/percona-helm-charts/
+    condition: pxcoperator.enabled
+  - name: pxc-db
+    alias: pxcdb
+    version: 1.15.0
+    repository: https://percona.github.io/percona-helm-charts/
+    condition: pxcdb.enabled
+  - name: owner-info
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: 0.2.3
+    condition: owner_info.enabled

--- a/common/percona-operator/helm/Chart.yaml
+++ b/common/percona-operator/helm/Chart.yaml
@@ -28,6 +28,7 @@ dependencies:
     repository: https://percona.github.io/percona-helm-charts/
     condition: pxcdb.enabled
   - name: owner-info
+    alias: ownerinfo
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0
-    condition: owner_info.enabled
+    condition: ownerinfo.enabled

--- a/common/percona-operator/helm/database.yaml
+++ b/common/percona-operator/helm/database.yaml
@@ -1,0 +1,28 @@
+owner_info:
+  enabled: true
+
+pxcdb:
+  enabled: true
+  pxc:
+    image:
+      repository: keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/percona/percona-xtradb-cluster
+      tag: 8.0.36-28.1
+    unsafeFlags:
+      tls: true
+    tls:
+      enabled: false
+  haproxy:
+    image: keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/percona/haproxy:2.8.5
+  logcollector:
+    image: keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/percona/percona-xtradb-cluster-operator:1.15.0-logcollector-fluentbit3.1.4
+  backup:
+    image:
+      repository: keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/percona/percona-xtradb-cluster-operator
+      tag: 1.15.0-pxc8.0-backup-pxb8.0.35
+
+owner-info:
+  helm-chart-url: 'https://github.com/sapcc/helm-charts/tree/master/common/mariadb-operator'
+  maintainers:
+    - Birk Bohne
+  support-group: identity
+  service: keystone

--- a/common/percona-operator/helm/database.yaml
+++ b/common/percona-operator/helm/database.yaml
@@ -1,4 +1,4 @@
-owner_info:
+ownerinfo:
   enabled: true
 
 pxcdb:

--- a/common/percona-operator/helm/database.yaml
+++ b/common/percona-operator/helm/database.yaml
@@ -24,5 +24,6 @@ owner-info:
   helm-chart-url: 'https://github.com/sapcc/helm-charts/tree/master/common/mariadb-operator'
   maintainers:
     - Birk Bohne
+    - Vlad Gusev
   support-group: identity
   service: keystone

--- a/common/percona-operator/helm/database.yaml
+++ b/common/percona-operator/helm/database.yaml
@@ -4,21 +4,10 @@ ownerinfo:
 pxcdb:
   enabled: true
   pxc:
-    image:
-      repository: keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/percona/percona-xtradb-cluster
-      tag: 8.0.36-28.1
     unsafeFlags:
       tls: true
     tls:
       enabled: false
-  haproxy:
-    image: keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/percona/haproxy:2.8.5
-  logcollector:
-    image: keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/percona/percona-xtradb-cluster-operator:1.15.0-logcollector-fluentbit3.1.4
-  backup:
-    image:
-      repository: keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/percona/percona-xtradb-cluster-operator
-      tag: 1.15.0-pxc8.0-backup-pxb8.0.35
 
 owner-info:
   helm-chart-url: 'https://github.com/sapcc/helm-charts/tree/master/common/mariadb-operator'

--- a/common/percona-operator/helm/operator.yaml
+++ b/common/percona-operator/helm/operator.yaml
@@ -16,5 +16,6 @@ owner-info:
   helm-chart-url: 'https://github.com/sapcc/helm-charts/tree/master/common/percona-operator'
   maintainers:
     - Birk Bohne
+    - Vlad Gusev
   support-group: shared-services
   service: percona-operator

--- a/common/percona-operator/helm/operator.yaml
+++ b/common/percona-operator/helm/operator.yaml
@@ -3,10 +3,7 @@ ownerinfo:
 
 pxcoperator:
   enabled: true
-  image: keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/percona/percona-xtradb-cluster-operator:1.15.0
-  crVersion: 1.15.0
   watchNamespace: keystone-pxc
-  disableTelemetry: true
   unsafeFlags:
     tls: true
   tls:

--- a/common/percona-operator/helm/operator.yaml
+++ b/common/percona-operator/helm/operator.yaml
@@ -1,0 +1,20 @@
+owner_info:
+  enabled: true
+
+pxcoperator:
+  enabled: true
+  image: keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/percona/percona-xtradb-cluster-operator:1.15.0
+  crVersion: 1.15.0
+  watchNamespace: keystone-pxc
+  disableTelemetry: true
+  unsafeFlags:
+    tls: true
+  tls:
+    enabled: false
+
+owner-info:
+  helm-chart-url: 'https://github.com/sapcc/helm-charts/tree/master/common/percona-operator'
+  maintainers:
+    - Birk Bohne
+  support-group: shared-services
+  service: percona-operator

--- a/common/percona-operator/helm/operator.yaml
+++ b/common/percona-operator/helm/operator.yaml
@@ -1,4 +1,4 @@
-owner_info:
+ownerinfo:
   enabled: true
 
 pxcoperator:

--- a/common/percona-operator/helm/values.yaml
+++ b/common/percona-operator/helm/values.yaml
@@ -2,5 +2,5 @@ pxcoperator:
   enabled: false
 pxcdb:
   enabled: false
-owner_info:
+ownerinfo:
   enabled: false

--- a/common/percona-operator/helm/values.yaml
+++ b/common/percona-operator/helm/values.yaml
@@ -1,0 +1,6 @@
+pxcoperator:
+  enabled: false
+pxcdb:
+  enabled: false
+owner_info:
+  enabled: false

--- a/common/percona-operator/helm/values.yaml
+++ b/common/percona-operator/helm/values.yaml
@@ -1,6 +1,22 @@
 pxcoperator:
   enabled: false
+  image: keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/percona/percona-xtradb-cluster-operator:1.15.0
+  disableTelemetry: true
+
 pxcdb:
   enabled: false
+  pxc:
+    image:
+      repository: keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/percona/percona-xtradb-cluster
+      tag: 8.0.36-28.1
+  haproxy:
+    image: keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/percona/haproxy:2.8.5
+  logcollector:
+    image: keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/percona/percona-xtradb-cluster-operator:1.15.0-logcollector-fluentbit3.1.4
+  backup:
+    image:
+      repository: keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/percona/percona-xtradb-cluster-operator
+      tag: 1.15.0-pxc8.0-backup-pxb8.0.35
+
 ownerinfo:
   enabled: false


### PR DESCRIPTION
- options to roll out the `Percona Operator For MySQL` based on the [pxc-operator Helm chart](https://github.com/percona/percona-helm-charts/tree/main/charts/pxc-operator)
- options to roll out a `Percona XtraDB Cluster` based on the [pxc-db Helm chart](https://github.com/percona/percona-helm-charts/tree/main/charts/pxc-db)
- `owner-info` support added