### PR TITLE
feat(gh-ccloud): add plugin-developer TRB, remove cluster-admin

### DIFF
--- a/system/greenhouse-ccloud/Chart.yaml
+++ b/system/greenhouse-ccloud/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: ccloud
 description: A Helm chart for the CCloud organization in Greenhouse.
 type: application
-version: 1.4.7
+version: 1.5.0

--- a/system/greenhouse-ccloud/ci/test-values.yaml
+++ b/system/greenhouse-ccloud/ci/test-values.yaml
@@ -20,6 +20,15 @@ teamRoleBindings:
       matchLabels:
         cluster-type: compute
         environment: production
+  - teamRef: team2
+    teamRoleRef: role1
+    clusterSelector:
+      matchLabels:
+        cluster-type: compute
+        environment: labs
+    namespaces:
+      - foo
+      - bar
 
 oidc:
   issuer: https://top.secret

--- a/system/greenhouse-ccloud/templates/team-rolebindings.yaml
+++ b/system/greenhouse-ccloud/templates/team-rolebindings.yaml
@@ -12,6 +12,12 @@ spec:
   teamRoleRef: {{ $roleBinding.teamRoleRef }}
   clusterSelector:
     {{- $roleBinding.clusterSelector | toYaml | nindent 4 }}
+{{- if $roleBinding.namespaces }}
+  namespaces:
+{{- range $namespace := $roleBinding.namespaces }}
+    - {{ $namespace }}
+{{- end }}
+{{- end }}
 {{- else }}
 {{- printf "Error: Missing teamRef, teamRoleRef, or clusterSelector in teamRoleBinding: %#v" $roleBinding | fail }}
 {{- end }}

--- a/system/greenhouse-ccloud/templates/team-roles.yaml
+++ b/system/greenhouse-ccloud/templates/team-roles.yaml
@@ -1,13 +1,37 @@
 apiVersion: greenhouse.sap/v1alpha1
 kind: TeamRole
 metadata:
-  name: cluster-admin
-  namespace: {{ .Chart.Name }}
+  name: plugin-developer
+  namespace: {{ .Release.Namespace }}
 spec:
   rules:
     - apiGroups:
-        - "*"
+      - '*'
       resources:
-        - "*"
+      - '*'
       verbs:
-        - "*"
+      - get
+      - list
+      - watch
+    - nonResourceURLs:
+      - '*'
+      verbs:
+      - get
+      - list
+      - watch
+    # Allow deleting and exec'ing, port-frowarding into pods & reading logs
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - pods/exec
+      - pods/portforward
+      - pods/eviction
+      - pods/proxy
+      - pods/log
+      verbs:
+      - '*'
+    # allow scaling
+    - apiGroups: ["apps"]
+      resources: ["deployments/scale", "statefulsets/scale"]
+      verbs: ["patch"]

--- a/system/greenhouse-ccloud/values.yaml
+++ b/system/greenhouse-ccloud/values.yaml
@@ -15,10 +15,12 @@ teams: {}
 teamRoleBindings: []
   # - teamRef: team1
   #   teamRoleRef: role1
-  #   clusterSelector
+  #   clusterSelector:
   #     matchLabels:
   #       cluster-type: compute
   #       environment: production
+  #   namespaces: # optional, for namespace'd access instead of cluster-wide
+  #     - kube-system
 
 oidc:
   issuer:


### PR DESCRIPTION
- plugin-developer teamrolebinding can be used to give devs the ability to debug in their plugin's namespace

- cluster-admin teamrole is seeded for each org by greenhouse

- add ability to specify namespaces for TeamRoleBindings