### PR TITLE
feat(kube-monitoring): don't manage preset externally

### DIFF
--- a/system/greenhouse-ccloud/Chart.yaml
+++ b/system/greenhouse-ccloud/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: ccloud
 description: A Helm chart for the CCloud organization in Greenhouse.
 type: application
-version: 1.4.6
+version: 1.4.7

--- a/system/greenhouse-ccloud/templates/kube-monitoring-storage-pluginpreset.yaml
+++ b/system/greenhouse-ccloud/templates/kube-monitoring-storage-pluginpreset.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.pluginPreset.enabled .Values.kubeMonitoring.enabled -}}
+{{- if .Values.kubeMonitoring.enabled -}}
 
 apiVersion: v1
 kind: Secret
@@ -27,7 +27,7 @@ spec:
   {{- end }}
   clusterSelector:
     matchLabels:
-      greenhouse.sap/cluster-presets-enabled: "true"
+      greenhouse.sap/pluginpreset: "true"
       cluster-type: "storage"
   plugin:
     disabled: false


### PR DESCRIPTION
* preset should be maintained with the cluster selector and the cluster

* this is obfuscating what actually matches

* switch to generic label