### PR TITLE
[Neutron] Explicitly set user for NSX-T password generation

### DIFF
--- a/openstack/neutron/templates/vct-nsxv3-agent-secret.yaml
+++ b/openstack/neutron/templates/vct-nsxv3-agent-secret.yaml
@@ -24,11 +24,11 @@ template: |
       vccluster: {= cluster_name =}
   data:
     NSXV3_LOGIN_USER: {% filter b64enc %}osapinsxt{%- endfilter %}
-    NSXV3_LOGIN_PASSWORD: {% filter b64enc %}{= username | derive_password(hostname) =}{%- endfilter %}
+    NSXV3_LOGIN_PASSWORD: {% filter b64enc %}{= "{{ .Values.nsxv3_pw_user }}" | derive_password(hostname) =}{%- endfilter %}
     neutron-nsxv3-secrets.conf:{= " " =}
   {%- filter b64enc %}
   [NSXV3]
   nsxv3_login_user = osapinsxt
-  nsxv3_login_password = {= username | derive_password(hostname) | quote =}
+  nsxv3_login_password = {= "{{ .Values.nsxv3_pw_user }}" | derive_password(hostname) | quote =}
   {%- endfilter %}
 {{ end }}

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -292,6 +292,8 @@ drivers:
         nsxv3_default_policy_infrastructure_rules: true
         nsxv3_transport_zone_id_cache_time: 86400
 
+nsxv3_pw_user: m3apiuser0
+
 logging:
   formatters:
     context:


### PR DESCRIPTION
nsxv3-agents use the `vcenter-operator` to get deployed. The `vcenter-operator` is responsible for generating the individual agent's password with the masterpassword algorithm. While we use the user "admin" to log into the NSX-T agents, we used the current `vcenter-operator`'s user to generate the password.

With changing the `vcenter-operator`'s user to using a user from the `vsphere.local` domain, we now can't use the from there anymore. Instead, we introduce a new variable to read the user from and set the old user there.