### PR TITLE
[ironic]: multiple dependency updates

### DIFF
--- a/openstack/ironic/Chart.lock
+++ b/openstack/ironic/Chart.lock
@@ -1,27 +1,27 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.14.0
+  version: 0.14.2
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.5.2
+  version: 0.5.3
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.3.4
+  version: 0.3.5
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.11.0
+  version: 0.11.1
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.16.2
+  version: 0.18.3
 - name: ironic-exporter
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.3
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:b5291d2b09dfd73ee0ab9eaf6cf5ecf06e2f8287dd6a14a15ff5413d18da1463
-generated: "2024-08-06T16:22:18.454875111+02:00"
+digest: sha256:779c746792ddf33fb65ca2da90f6d0910f5eb41ddc3c1a0434595d5689753270
+generated: "2024-09-17T16:06:19.224770281+02:00"

--- a/openstack/ironic/Chart.yaml
+++ b/openstack/ironic/Chart.yaml
@@ -7,23 +7,23 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.14.0
+    version: ~0.14.2
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.5.2
+    version: ~0.5.3
   - condition: mysql_metrics.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.3.4
+    version: ~0.3.5
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: ~1.0.0
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.11.0
+    version: ~0.11.1
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.16.2
+    version: ~0.18.3
   - name: ironic-exporter
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: ~1.0.3

--- a/openstack/ironic/ci/test-values.yaml
+++ b/openstack/ironic/ci/test-values.yaml
@@ -21,11 +21,11 @@ console:
 rabbitmq:
   users:
     default:
-      password: 'null'
+      password: thisisapassword
     admin:
-      password: 'null'
+      password: thisisanotherpassword
   metrics:
-    password: 'null'
+    password: onemorepassword
 
 swift_tempurl: my-swift-url
 swift_account: my-swift-acc

--- a/openstack/ironic/ci/test-values.yaml
+++ b/openstack/ironic/ci/test-values.yaml
@@ -1,7 +1,10 @@
 global:
+  registry: keppel.regionOne.cloud
+  dockerHubMirrorAlternateRegion: myRegistry/dockerhubalternate
   master_password: topSecret
   dbPassword: secret
   ipmi_exporter_user_passwd: topSecret
+  ironicServiceUser: ironic
   ironic_service_password: topSecret
   ironicServicePassword: topSecret
   domain_seeds:
@@ -10,9 +13,17 @@ global:
 imageVersion: train
 
 mariadb:
+  root_password: password
   enabled: true
   backup_v2:
     enabled: false
+  users:
+    ironic:
+      name: ironic
+      password: password
+    ironic_inspector:
+      name: ironic_inspector
+      password: password
 inspectordbPassword: secret!
 console:
   secret: another-secret

--- a/openstack/ironic/templates/etc/_inspector_secrets.conf.tpl
+++ b/openstack/ironic/templates/etc/_inspector_secrets.conf.tpl
@@ -2,14 +2,14 @@
 {{- include "ini_sections.default_transport_url" . }}
 
 [ironic]
-username = {{ .Values.global.ironicServiceUser }}
-password = {{ required ".Values.global.ironicServicePassword is missing" .Values.global.ironicServicePassword }}
+username = {{ include "resolve_secret" .Values.global.ironicServiceUser }}
+password = {{ required ".Values.global.ironicServicePassword is missing" .Values.global.ironicServicePassword | include "resolve_secret" }}
 
 [database]
 connection = {{ tuple . .Values.mariadb.users.ironic_inspector.name .Values.mariadb.users.ironic_inspector.name .Values.mariadb.users.ironic_inspector.password | include "db_url_mysql" }}
 
 [keystone_authtoken]
-username = {{ .Values.global.ironicServiceUser }}
-password = {{ required ".Values.global.ironicServicePassword is missing" .Values.global.ironicServicePassword }}
+username = {{ include "resolve_secret" .Values.global.ironicServiceUser }}
+password = {{ required ".Values.global.ironicServicePassword is missing" .Values.global.ironicServicePassword | include "resolve_secret" }}
 
 {{- include "ini_sections.audit_middleware_notifications" . }}

--- a/openstack/ironic/templates/etc/_inspector_secrets.conf.tpl
+++ b/openstack/ironic/templates/etc/_inspector_secrets.conf.tpl
@@ -2,14 +2,14 @@
 {{- include "ini_sections.default_transport_url" . }}
 
 [ironic]
-username = {{ include "resolve_secret" .Values.global.ironicServiceUser }}
-password = {{ required ".Values.global.ironicServicePassword is missing" .Values.global.ironicServicePassword | include "resolve_secret" }}
+username = {{ .Values.global.ironicServiceUser }}
+password = {{ required ".Values.global.ironicServicePassword is missing" .Values.global.ironicServicePassword }}
 
 [database]
 connection = {{ tuple . .Values.mariadb.users.ironic_inspector.name .Values.mariadb.users.ironic_inspector.name .Values.mariadb.users.ironic_inspector.password | include "db_url_mysql" }}
 
 [keystone_authtoken]
-username = {{ include "resolve_secret" .Values.global.ironicServiceUser }}
-password = {{ required ".Values.global.ironicServicePassword is missing" .Values.global.ironicServicePassword | include "resolve_secret" }}
+username = {{ .Values.global.ironicServiceUser }}
+password = {{ required ".Values.global.ironicServicePassword is missing" .Values.global.ironicServicePassword }}
 
 {{- include "ini_sections.audit_middleware_notifications" . }}

--- a/openstack/ironic/templates/etc/_secrets.conf.tpl
+++ b/openstack/ironic/templates/etc/_secrets.conf.tpl
@@ -6,11 +6,11 @@ connection = {{ include "db_url_mysql" . }}
 
 [keystone_authtoken]
 username = {{ .Values.global.ironicServiceUser }}
-password = {{ required ".Values.global.ironicServicePassword is missing" .Values.global.ironicServicePassword }}
+password = {{ required ".Values.global.ironicServicePassword is missing" .Values.global.ironicServicePassword | include "resolve_secret" }}
 
 [service_catalog]
 username = {{ .Values.global.ironicServiceUser }}
-password = {{ required ".Values.global.ironicServicePassword is missing" .Values.global.ironicServicePassword }}
+password = {{ required ".Values.global.ironicServicePassword is missing" .Values.global.ironicServicePassword | include "resolve_secret" }}
 
 [glance]
 {{- if .Values.swift_store_multi_tenant }}


### PR DESCRIPTION
* [mariadb][backup] Use resolve helper for backup_v2 secrets
* [mariadb] initdb secret is required during install
* [memcached] Use resolve for sasl-db secret string
* [mysql_metrics] Use resolve for mysql-metrics connection string
* [rabbitmq] remove unused unacknowledged alert from rename
* [utils] add helper to resolve secrets that need urlquery function
* utils: Resolve no-longer-used "identity.password_for_user"
* utils: Resolve username for mysql and F5 URls
* [utils] Add support for secrets-injector for db_url_pxc function
* [openstack/utils] Do not drop "host" from default_transport_url
