### PR TITLE
Add timeout and retries options for Octavia keystone_authtoken.

### DIFF
--- a/openstack/octavia/templates/etc/_octavia.conf.tpl
+++ b/openstack/octavia/templates/etc/_octavia.conf.tpl
@@ -124,6 +124,10 @@ service_token_roles_required = True
 token_cache_time = 600
 include_service_catalog = true
 service_type = load-balancer
+http_request_max_retries = {{ .Values.keystone_authtoken.http_request_max_retries | default 3 }}
+{{ if .Values.keystone_authtoken.http_connect_timeout -}}
+http_connect_timeout = {{ .Values.keystone_authtoken.http_connect_timeout }}
+{{- end }}
 
 {{- include "ini_sections.cache" . }}
 

--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -23,6 +23,9 @@ global:
 osprofiler:
   enabled: false
 
+keystone_authtoken:
+  http_request_max_retries: 10
+
 db_name: octavia
 
 proxysql:


### PR DESCRIPTION
This PR adds new options `http_request_max_retries` and `http_connect_timeout` to Octavia's configuration to control connection failures to keystone.