### PR TITLE
elektra: bump postgres dependencies

### DIFF
--- a/openstack/elektra/Chart.lock
+++ b/openstack/elektra/Chart.lock
@@ -1,18 +1,18 @@
 dependencies:
 - name: postgresql-ng
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.0.38
+  version: 1.1.0
 - name: pgbackup
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.1.0
+  version: 1.1.2
 - name: pgmetrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.1.0
+  version: 1.1.1
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:c84d73043891cb6eae3549d105dd37c3c372901a8cee3500a09a64692b8464c0
-generated: "2024-09-03T11:24:52.546499379+02:00"
+digest: sha256:737fcd4da14679c2ad698d157b836ad89f8e1fc69aaf72e0a8eb12a576227636
+generated: "2024-09-18T14:44:08.882763221+02:00"


### PR DESCRIPTION
- various image rebuilds to fix security vulnerabilities
- fix ownerReferences in pguser secrets

Please set up a helm-dep-up job in your pipeline to reduce the amount of PRs like this.