### PR TITLE
Keystone: Remove old `SSO_CA` from trusted issuers upon SSO auth cert validation

### DIFF
--- a/openstack/keystone/templates/etc/_keystone.conf.tpl
+++ b/openstack/keystone/templates/etc/_keystone.conf.tpl
@@ -43,7 +43,6 @@ url = {{ required "missing global.api.cc_password.url" .Values.global.api.cc_pas
 {{- end }}
 
 [cc_x509]
-trusted_issuer = CN=SSO_CA,O=SAP-AG,C=DE
 trusted_issuer = CN=SAP SSO CA G2,O=SAP SE,L=Walldorf,C=DE
 user_domain_id_header: HTTP_X_USER_DOMAIN_ID
 user_domain_name_header: HTTP_X_USER_DOMAIN_NAME


### PR DESCRIPTION
The corresponding check is done here -
https://github.com/sapcc/keystone-extensions/blob/225d920c1b623365588a145319a060242a7b4d9d/cc/keystone/auth/plugins/cc_x509.py#L73

Additionally, see `cc/secrets/pull/15277`.