### PR TITLE
[ironic] Add VMDK to the list of permitted image formats

### DIFF
--- a/openstack/ironic/values.yaml
+++ b/openstack/ironic/values.yaml
@@ -208,6 +208,8 @@ conductor:
       uefi_ipxe_bootfile_name: "ipxe.efi"
     redfish:
       swift_object_expiry_timeout: "5400"
+    conductor:
+      permitted_image_formats: 'raw,qcow2,iso,vmdk'
 
 agent:
   deploy_logs:


### PR DESCRIPTION
Most often, we actually use VMDKs. Stream-optimized ones are actually smaller than QCOW2 files (presumably without compression).