### PR TITLE
Bump kubernikus image

### DIFF
--- a/system/kubernikus-admin-k3s/Chart.lock
+++ b/system/kubernikus-admin-k3s/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kubernikus
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.3.17
+  version: 0.3.19
 - name: kubernikus-dex
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.5
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.2.3
-digest: sha256:82970c64b6da4dc70298140198dd535a04b4068d79b3eec5fdbe4d3d6408d67d
-generated: "2024-07-30T17:26:54.054838+03:00"
+  version: 1.0.0
+digest: sha256:6afd4c07dfbc70840cd545f8c3e91971afbfcc2794da3251d74da1dde1b755b3
+generated: "2024-09-23T11:42:53.363828873+02:00"

--- a/system/kubernikus-admin-k3s/Chart.yaml
+++ b/system/kubernikus-admin-k3s/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.31
+version: 2.0.32
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
@@ -22,10 +22,10 @@ version: 2.0.31
 dependencies:
   - name: kubernikus
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.3.17
+    version: 0.3.19
   - name: kubernikus-dex
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.1.5
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.2.3
+    version: 1.0.0

--- a/system/kubernikus-admin-k3s/values.yaml
+++ b/system/kubernikus-admin-k3s/values.yaml
@@ -1,5 +1,5 @@
 kubernikus:
-  imageTag: 47c713479027932fd80473705d1f86fa2bf92a02 
+  imageTag: 101556538c1eb5334cdc01813ab7da632c77d75a
   image: keppel.global.cloud.sap/ccloud/kubernikus
 
   #use a dedicated serviceaccount and proper RBAC rules for this deployment

--- a/system/kubernikus-metal/Chart.lock
+++ b/system/kubernikus-metal/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kubernikus
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.3.14
+  version: 0.3.19
 - name: kubernikus-dex
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.5
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.2.0
-digest: sha256:7ef0134a9843b9ed004969661774ea131619d69e1d84b6c6137434022ecc8b13
-generated: "2024-07-30T17:29:55.657593+03:00"
+  version: 1.0.0
+digest: sha256:6afd4c07dfbc70840cd545f8c3e91971afbfcc2794da3251d74da1dde1b755b3
+generated: "2024-09-23T11:43:25.516546022+02:00"

--- a/system/kubernikus-metal/Chart.yaml
+++ b/system/kubernikus-metal/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.28
+version: 2.0.29
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
@@ -22,10 +22,10 @@ version: 2.0.28
 dependencies:
   - name: kubernikus
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.3.14
+    version: 0.3.19
   - name: kubernikus-dex
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.1.5
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.2.0
+    version: 1.0.0

--- a/system/kubernikus-metal/values.yaml
+++ b/system/kubernikus-metal/values.yaml
@@ -1,5 +1,5 @@
 kubernikus:
-  imageTag: 47c713479027932fd80473705d1f86fa2bf92a02 
+  imageTag: 101556538c1eb5334cdc01813ab7da632c77d75a
   image: keppel.global.cloud.sap/ccloud/kubernikus
 
   #use a dedicated serviceaccount and proper RBAC rules for this deployment


### PR DESCRIPTION
Brings k8s 1.28.14, 1.29.9 and 1.30.5 which fixes the init container regression. Also bumps the kubernikus and owner-info chart.