### PR TITLE
plutono: bump postgres dependencies

### DIFF
--- a/system/plutono/Chart.lock
+++ b/system/plutono/Chart.lock
@@ -1,18 +1,18 @@
 dependencies:
 - name: postgresql-ng
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.0.11
+  version: 1.1.0
 - name: pgbackup
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.1.45
+  version: 1.1.2
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.2.0
+  version: 1.0.0
 - name: prometheus-monitors
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.0.2
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.1.3
-digest: sha256:fad3807c6b707802d1ba0be44e396d5130b0063e8921b319088286e0ab46d3af
-generated: "2024-04-12T15:28:25.631138+02:00"
+  version: 1.0.0
+digest: sha256:e03c7b26fcfa1d56eb2df16384c3995be840538c3cc232aee285a3533d298905
+generated: "2024-09-23T14:35:15.725028302+02:00"

--- a/system/plutono/Chart.yaml
+++ b/system/plutono/Chart.yaml
@@ -6,17 +6,17 @@ dependencies:
   - name: postgresql-ng
     alias: postgresql
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 1.0.11
+    version: ^1.1
   - name: pgbackup
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.1.45
+    version: ^1.1
     condition: pgbackup.enabled
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.2.0
+    version: ^1.0
   - name: prometheus-monitors
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.0.2
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.1.3
+    version: ^1.0


### PR DESCRIPTION
Your previous version selection was behind by several months. I suggest setting up the helm-dep-up CI task to handle bugfix updates automatically (see Keppel pipeline for what to copy, Ctrl-F "helm-dep-up").