### PR TITLE
[Ironic][seeds] remove quota_class_sets

### DIFF
--- a/openstack/ironic/templates/seed.yaml
+++ b/openstack/ironic/templates/seed.yaml
@@ -63,37 +63,6 @@ spec:
       region: {{ .Values.global.region }}
       url: https://{{ include "ironic_inspector_endpoint_host_public" .}}
 
-  quota_class_sets:
-    flavors:
-      instances_zg1bcm1.medium: 0
-      instances_zg1bcm1.1medium: 0
-      instances_zh2mlx1.large: 0
-      instances_zh2mlx1.xlarge: 0
-      instances_zh2mlx1.1xlarge: 0
-      instances_zh2mlx1.2xlarge: 0
-      instances_zh2mlx1.3xlarge: 0
-      instances_hv_s2_c4_m128: 0
-      instances_hv_s2_c14_m256: 0
-      instances_hv_s2_c20_m384: 0
-      instances_hv_s2_c26_m384: 0
-      instances_hv_s2_c26_m768: 0
-      instances_hv_s4_c24_m3072: 0
-      instances_hv_s4_c24_m6144: 0
-      instances_hv_s8_c24_m6144: 0
-      instances_bm_s8_c24_m6144: 0
-      instances_hv_s8_c28_m12288: 0
-      instances_bm_s8_c28_m12288: 0
-      instances_hv_s2_c32_m1024_v0: 0
-      instances_hv_s2_c32_m512_v0: 0
-      instances_bg_s2_c48_m1024_v0: 0
-      instances_bm_s2_c32_m1024_v0: 0
-      instances_hv_s4_c32_m4096_v0: 0
-      instances_bm_s4_c32_m4096_v0: 0
-      instances_bm_s4_c32_m2048_v0: 0
-      instances_hv_s1_c32_m512_v0: 0
-      instances_hv_s8_c32_m2048_v0: 0
-      instances_hv_s8_c32_m8192_v0: 0
-
 ## we decided to count up the flavor ID continously for baremetal
 ## new bm flavors start at 1000 historically and are public (former zh*, zg*; now bm_*, bg_*)
 ## new hv_ flavors start at 2020 and are private


### PR DESCRIPTION
No longer needed for Nova. Since https://github.com/sapcc/nova/pull/493, Nova reads quota:separate from the flavors.