### PR TITLE
Keystone: switch tempest to project scope

### DIFF
--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: keystone
 sources:
   - https://github.com/sapcc/keystone
-version: 0.7.0
+version: 0.7.1
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/keystone/templates/etc/_policy.yaml.tpl
+++ b/openstack/keystone/templates/etc/_policy.yaml.tpl
@@ -21,7 +21,7 @@
 
 # ccloud: added these to allow a smooth transitioning from old cloud-admin to new system scopes
 "cloud_admin": "(role:admin and system_scope:all) or
-  (role:admin and ((is_admin_project:True or domain_id:default){{- if .Values.tempest.enabled }} or domain_id:{{.Values.tempest.domainId}}{{- end}}))"
+  (role:admin and ((is_admin_project:True or domain_id:default){{- if .Values.tempest.enabled }} or project_id:{{.Values.tempest.adminProjectId}}{{- end}}))"
 
 "cloud_reader": "(role:reader and system_scope:all) or
   role:cloud_identity_viewer or
@@ -951,7 +951,7 @@
 # Intended scope(s): system, domain
 #"identity:delete_project": "(role:admin and system_scope:all) or (role:admin and domain_id:%(target.project.domain_id)s)"
 # The corresponding `prodel` service details are available on GitHub under `cc/prodel`
-"identity:delete_project": "(rule:cloud_admin or (rule:admin_required and (project_id:%(project_id)s or project_id:%(target.project.parent_id)s))) and ({{- if .Values.tempest.enabled }}domain_id:{{.Values.tempest.domainId}} or {{ end }}{{ .Values.prodel.url }})"
+"identity:delete_project": "(rule:cloud_admin or (rule:admin_required and (project_id:%(project_id)s or project_id:%(target.project.parent_id)s))) and ({{- if .Values.tempest.enabled }}project_id:{{.Values.tempest.adminProjectId}} or {{ end }}{{ .Values.prodel.url }})"
 
 # List tags for a project.
 # GET  /v3/projects/{project_id}/tags

--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -196,6 +196,7 @@ tempest:
   userPassword: ""
   # tempest domain-id  -- do not set in production environments!
   domainId: not_set_this_in_production
+  adminProjectId: not_set_in_production
 
 sentry:
   enabled: true


### PR DESCRIPTION
After https://review.opendev.org/c/openstack/keystone/+/900028 got accepted, domain-scoped tokens can no longer list all domains, only the domain of the scope will be returned. Our tempest uses scope on domain to run some tests, and it fails with the change.

Add a new value to help configure project scope for tempest. The new value .Values.tempest.adminProjectId needs to be set to the `admin` project id.

The corresponding change in tempest to use this is done in a different repo/pr.