### PR TITLE
nova/flavors: Require vmx-18 hw version for all flavors

### DIFF
--- a/openstack/sap-seeds/templates/_flavors_hana_exclusive.tpl
+++ b/openstack/sap-seeds/templates/_flavors_hana_exclusive.tpl
@@ -51,7 +51,6 @@
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
     "reservation:cpu": "136"
-    "vmware:hw_version": "vmx-18"
     {{- if ( .Values.hana_flavors_quota_separate ) }}
     "quota:instance_only": "true"
     "quota:separate": "true"
@@ -66,7 +65,6 @@
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
     "reservation:cpu": "182"
-    "vmware:hw_version": "vmx-18"
     {{- if ( .Values.hana_flavors_quota_separate ) }}
     "quota:instance_only": "true"
     "quota:separate": "true"
@@ -81,7 +79,6 @@
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
     "reservation:cpu": "364"
-    "vmware:hw_version": "vmx-18"
     {{- if ( .Values.hana_flavors_quota_separate ) }}
     "quota:instance_only": "true"
     "quota:separate": "true"
@@ -96,7 +93,6 @@
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
     "reservation:cpu": "273"
-    "vmware:hw_version": "vmx-18"
     {{- if ( .Values.hana_flavors_quota_separate ) }}
     "quota:instance_only": "true"
     "quota:separate": "true"
@@ -111,7 +107,6 @@
     "trait:CUSTOM_NUMASIZE_C56_M1459": "required"
     "hw:cpu_cores": "56"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
     "reservation:cpu": "425"
-    "vmware:hw_version": "vmx-18"
     {{- if ( .Values.hana_flavors_quota_separate ) }}
     "quota:instance_only": "true"
     "quota:separate": "true"
@@ -128,7 +123,6 @@
     "trait:CUSTOM_NUMASIZE_C60_M480": "required"
     "hw:cpu_cores": "30"   # used in nova-vmware as cores-per-socket (15pCPU = 30vCPU)
     "reservation:cpu": "28"
-    "vmware:hw_version": "vmx-18"
     {{- if ( .Values.hana_flavors_quota_separate ) }}
     "quota:instance_only": "true"
     "quota:separate": "true"
@@ -143,7 +137,6 @@
     "trait:CUSTOM_NUMASIZE_C60_M480": "required"
     "hw:cpu_cores": "60"   # used in nova-vmware as cores-per-socket (30pCPU = 60vCPU)
     "reservation:cpu": "57"
-    "vmware:hw_version": "vmx-18"
     {{- if ( .Values.hana_flavors_quota_separate ) }}
     "quota:instance_only": "true"
     "quota:separate": "true"
@@ -158,7 +151,6 @@
     "trait:CUSTOM_NUMASIZE_C60_M480": "required"
     "hw:cpu_cores": "60"   # used in nova-vmware as cores-per-socket (30pCPU = 60vCPU)
     "reservation:cpu": "114"
-    "vmware:hw_version": "vmx-18"
     {{- if ( .Values.hana_flavors_quota_separate ) }}
     "quota:instance_only": "true"
     "quota:separate": "true"
@@ -173,7 +165,6 @@
     "trait:CUSTOM_NUMASIZE_C60_M960": "required"
     "hw:cpu_cores": "30"   # used in nova-vmware as cores-per-socket (15pCPU = 30vCPU)
     "reservation:cpu": "28"
-    "vmware:hw_version": "vmx-18"
     {{- if ( .Values.hana_flavors_quota_separate ) }}
     "quota:instance_only": "true"
     "quota:separate": "true"
@@ -188,7 +179,6 @@
     "trait:CUSTOM_NUMASIZE_C60_M960": "required"
     "hw:cpu_cores": "60"   # used in nova-vmware as cores-per-socket (30pCPU = 60vCPU)
     "reservation:cpu": "57"
-    "vmware:hw_version": "vmx-18"
     {{- if ( .Values.hana_flavors_quota_separate ) }}
     "quota:instance_only": "true"
     "quota:separate": "true"
@@ -203,7 +193,6 @@
     "trait:CUSTOM_NUMASIZE_C60_M960": "required"
     "hw:cpu_cores": "60"   # used in nova-vmware as cores-per-socket (30pCPU = 60vCPU)
     "reservation:cpu": "114"
-    "vmware:hw_version": "vmx-18"
     {{- if ( .Values.hana_flavors_quota_separate ) }}
     "quota:instance_only": "true"
     "quota:separate": "true"
@@ -218,7 +207,6 @@
     "trait:CUSTOM_NUMASIZE_C60_M960": "required"
     "hw:cpu_cores": "60"   # used in nova-vmware as cores-per-socket (30pCPU = 60vCPU)
     "reservation:cpu": "171"
-    "vmware:hw_version": "vmx-18"
     {{- if ( .Values.hana_flavors_quota_separate ) }}
     "quota:instance_only": "true"
     "quota:separate": "true"
@@ -233,7 +221,6 @@
     "trait:CUSTOM_NUMASIZE_C60_M960": "required"
     "hw:cpu_cores": "60"   # used in nova-vmware as cores-per-socket (30pCPU = 60vCPU)
     "reservation:cpu": "228"
-    "vmware:hw_version": "vmx-18"
     {{- if ( .Values.hana_flavors_quota_separate ) }}
     "quota:instance_only": "true"
     "quota:separate": "true"

--- a/openstack/sap-seeds/templates/_flavors_hana_no_exclusive.tpl
+++ b/openstack/sap-seeds/templates/_flavors_hana_no_exclusive.tpl
@@ -53,7 +53,6 @@
     "resources:CUSTOM_BIGVM": "2"
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
-    "vmware:hw_version": "vmx-18"
     {{- if ( .Values.hana_flavors_quota_separate ) }}
     "quota:instance_only": "true"
     "quota:separate": "true"
@@ -69,7 +68,6 @@
     "resources:CUSTOM_BIGVM": "2"
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
-    "vmware:hw_version": "vmx-18"
     {{- if ( .Values.hana_flavors_quota_separate ) }}
     "quota:instance_only": "true"
     "quota:separate": "true"
@@ -85,7 +83,6 @@
     "resources:CUSTOM_BIGVM": "2"
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
-    "vmware:hw_version": "vmx-18"
     {{- if ( .Values.hana_flavors_quota_separate ) }}
     "quota:instance_only": "true"
     "quota:separate": "true"
@@ -101,7 +98,6 @@
     "resources:CUSTOM_BIGVM": "2"
     "trait:CUSTOM_NUMASIZE_C48_M729": "required"
     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
-    "vmware:hw_version": "vmx-18"
     {{- if ( .Values.hana_flavors_quota_separate ) }}
     "quota:instance_only": "true"
     "quota:separate": "true"
@@ -117,7 +113,6 @@
     {{ tuple . "vmware_common" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "trait:CUSTOM_NUMASIZE_C60_M480": "required"
     "hw:cpu_cores": "30"   # used in nova-vmware as cores-per-socket (15pCPU = 30vCPU)
-    "vmware:hw_version": "vmx-18"
     {{- if ( .Values.hana_flavors_quota_separate ) }}
     "quota:instance_only": "true"
     "quota:separate": "true"
@@ -131,7 +126,6 @@
     {{ tuple . "vmware_common" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "trait:CUSTOM_NUMASIZE_C60_M480": "required"
     "hw:cpu_cores": "60"   # used in nova-vmware as cores-per-socket (30pCPU = 60vCPU)
-    "vmware:hw_version": "vmx-18"
     {{- if ( .Values.hana_flavors_quota_separate ) }}
     "quota:instance_only": "true"
     "quota:separate": "true"
@@ -145,7 +139,6 @@
     {{ tuple . "vmware_common" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "trait:CUSTOM_NUMASIZE_C60_M480": "required"
     "hw:cpu_cores": "60"   # used in nova-vmware as cores-per-socket (30pCPU = 60vCPU)
-    "vmware:hw_version": "vmx-18"
     {{- if ( .Values.hana_flavors_quota_separate ) }}
     "quota:instance_only": "true"
     "quota:separate": "true"
@@ -159,7 +152,6 @@
     {{ tuple . "vmware_common" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "trait:CUSTOM_NUMASIZE_C60_M960": "required"
     "hw:cpu_cores": "30"   # used in nova-vmware as cores-per-socket (15pCPU = 30vCPU)
-    "vmware:hw_version": "vmx-18"
     {{- if ( .Values.hana_flavors_quota_separate ) }}
     "quota:instance_only": "true"
     "quota:separate": "true"
@@ -173,7 +165,6 @@
     {{ tuple . "vmware_common" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
     "trait:CUSTOM_NUMASIZE_C60_M960": "required"
     "hw:cpu_cores": "60"   # used in nova-vmware as cores-per-socket (30pCPU = 60vCPU)
-    "vmware:hw_version": "vmx-18"
     {{- if ( .Values.hana_flavors_quota_separate ) }}
     "quota:instance_only": "true"
     "quota:separate": "true"
@@ -188,7 +179,6 @@
     "resources:CUSTOM_BIGVM": "2"
     "trait:CUSTOM_NUMASIZE_C60_M960": "required"
     "hw:cpu_cores": "60"   # used in nova-vmware as cores-per-socket (30pCPU = 60vCPU)
-    "vmware:hw_version": "vmx-18"
     {{- if ( .Values.hana_flavors_quota_separate ) }}
     "quota:instance_only": "true"
     "quota:separate": "true"
@@ -203,7 +193,6 @@
     "resources:CUSTOM_BIGVM": "2"
     "trait:CUSTOM_NUMASIZE_C60_M960": "required"
     "hw:cpu_cores": "60"   # used in nova-vmware as cores-per-socket (30pCPU = 60vCPU)
-    "vmware:hw_version": "vmx-18"
     {{- if ( .Values.hana_flavors_quota_separate ) }}
     "quota:instance_only": "true"
     "quota:separate": "true"
@@ -218,7 +207,6 @@
     "resources:CUSTOM_BIGVM": "2"
     "trait:CUSTOM_NUMASIZE_C60_M960": "required"
     "hw:cpu_cores": "60"   # used in nova-vmware as cores-per-socket (30pCPU = 60vCPU)
-    "vmware:hw_version": "vmx-18"
     {{- if ( .Values.hana_flavors_quota_separate ) }}
     "quota:instance_only": "true"
     "quota:separate": "true"

--- a/openstack/sap-seeds/values.yaml
+++ b/openstack/sap-seeds/values.yaml
@@ -25,6 +25,7 @@ extra_specs:
   vmware_common: &vmware_common
     "capabilities:hypervisor_type": "VMware vCenter Server"
     "hw_video:ram_max_mb": "16"
+    "vmware:hw_version": "vmx-18"
     "vmware:hv_enabled": "True"
   vmware:
     <<: *vmware_common


### PR DESCRIPTION
We added EVC mode to VM creation/resize for flexible VM migratability across CPU generations. However, only newer hw_versions support the `ApplyEvcModeVM_Task` API which is needed to wipe any preexisting EVC mode on a VM.

This change will unconditionally upgrade the hw_version on every resize to vmx-18. This allows us to handle EVC modes as desired, with the tradeoff that some hardware specifics reported to the VM OS may be different after a resize.
