### PR TITLE
[Keystone] Introduce OpenstackKeystoneApiCPUThrottlingExceeds80Percen…

### DIFF
--- a/openstack/keystone/alerts/kubernetes/keystone.alerts
+++ b/openstack/keystone/alerts/kubernetes/keystone.alerts
@@ -33,3 +33,21 @@ groups:
     annotations:
       description: 'The keystone ingress API endpoint is throwing 5xx for 15 min. Check if the keystone-api k8s pods are OK ASAP.'
       summary: 'Keystone API ingress endpoint is in Critical State'
+
+  - alert: OpenstackKeystoneApiCPUThrottlingExceeds80Percentage
+    expr: rate(container_cpu_cfs_throttled_periods_total{container="keystone-api"}[5m]) / rate(container_cpu_cfs_periods_total{container="keystone-api"}[5m]) > 0.8
+    for: 10m
+    labels:
+      no_alert_on_absence: "true" # small regions may have no throttled containers at all, so this may legitimately occur
+      support_group: identity
+      tier: os
+      service: keystone
+      severity: medium
+      context: cpu
+      sentry: 'keystone'
+      meta: "{{ $labels.pod }}/{{ $labels.container }}"
+    annotations:
+      summary: API Container is constantly CPU-throttled
+      description: The container {{ $labels.pod }}/{{ $labels.container }} is being CPU-throttled
+        constantly. This is probably impacting performance, so check if we can increase the number
+        of replicas or the resource requests/limits.


### PR DESCRIPTION
…tage Alert

Openstack Services are impacted if CPU Usage and Throttle Ratio exceeds 100%, i have set this alert to fire at 80%. Except eude1, all regions have an average Usage is 50%.