### PR TITLE
[neutron] Bump memcached from 0.2.0 -> 0.5.3

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.10.1
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.2.0
+  version: 0.5.3
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.3.2
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:ced6a1f693a4bca28cdbf393c09a87b73a1acebe9a8af4f31700a06e82a8b011
-generated: "2024-04-12T15:51:37.997505+02:00"
+digest: sha256:8b658169ac445d06b2ee235bad36679c5cb9f6e8e6f56271a283fe95719c5f36
+generated: "2024-09-25T13:55:27.685666084+02:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -10,7 +10,7 @@ dependencies:
     version: 0.10.1
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.2.0
+    version: 0.5.3 
   - condition: mariadb.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm


### PR DESCRIPTION
- 0.3.0: Add standardised labels to objects https://github.com/sapcc/helm-charts/commit/edf6ab131fb698353e4979fe4e7299a72a22a4f7

- 0.4.0: https://github.com/sapcc/helm-charts/commit/ce4382d01b6440596812f71b4795c2069b08d5ea

- 0.5.0: enable SASL (Simple Authentication and Security Layer) https://github.com/sapcc/helm-charts/commit/03fd3656bde0b4c76abea22314125a420b67d19a

- 0.5.3:
* change secret data to datastring https://github.com/sapcc/helm-charts/commit/cc2acebe1cc9f756bbe3d5e544434dc9cc7f5390
* volume identation fix https://github.com/sapcc/helm-charts/commit/890a455f32fdcc802cd32d5620aefafed736f6a2
* Use resolve for sasl-db secret string https://github.com/sapcc/helm-charts/commit/e70252ee7bd86e7c8eb9a53017a854e8b11e81d2