### PR TITLE
[Keystone] Fix for migration job failure

### DIFF
--- a/openstack/keystone/templates/_helpers.tpl
+++ b/openstack/keystone/templates/_helpers.tpl
@@ -69,10 +69,12 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- define "job_name" }}
   {{- $name := index . 1 }}
   {{- with index . 0 }}
+    {{- $bin := include "utils.proxysql.proxysql_signal_stop_script" . | trim }}
     {{- $dbBackend := ternary "percona-pxc" "mariadb" .Values.percona_cluster.enabled }}
-    {{- $standard := list $dbBackend (include (print $.Template.BasePath "/configmap-bin.yaml") .) (include (print $.Template.BasePath "/configmap-etc.yaml") . )}}
-    {{- $proxysql := list $bin (include "utils.proxysql.job_pod_settings" . ) (include "utils.proxysql.volume_mount" . ) (include "utils.proxysql.container" . ) (include "utils.proxysql.volumes" .) $annotations | join "\n" }}
-    {{- $hash := empty .Values.proxysql.mode | ternary $standard (concat $standard $proxysql) | join "\n" | sha256sum }}
+    {{- $standard := list $dbBackend (include (print .Template.BasePath "/configmap-bin.yaml") . | indent 4 ) (include (print .Template.BasePath "/configmap-etc.yaml") . | indent 4 )}}
+    {{- $proxysql := list $bin (include "utils.proxysql.job_pod_settings" . ) (include "utils.proxysql.volume_mount" . ) (include "utils.proxysql.container" . ) (include "utils.proxysql.volumes" .) $dbBackend }}
+    {{- $combined := concat $standard $proxysql }}
+    {{- $hash := empty .Values.proxysql.mode | ternary $standard ($combined | join "\n") | sha256sum }}
     {{ .Release.Name }}-{{ $name }}-{{ substr 0 4 $hash }}-{{ .Values.api.imageTag | required "Please set api.imageTag or similar"}}
   {{- end }}
 {{- end }}

--- a/openstack/keystone/templates/_helpers.tpl
+++ b/openstack/keystone/templates/_helpers.tpl
@@ -75,6 +75,6 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
     {{- $proxysql := list $bin (include "utils.proxysql.job_pod_settings" . ) (include "utils.proxysql.volume_mount" . ) (include "utils.proxysql.container" . ) (include "utils.proxysql.volumes" .) $dbBackend }}
     {{- $combined := concat $standard $proxysql }}
     {{- $hash := empty .Values.proxysql.mode | ternary $standard ($combined | join "\n") | sha256sum }}
-    {{ .Release.Name }}-{{ $name }}-{{ substr 0 4 $hash }}-{{ .Values.api.imageTag | required "Please set api.imageTag or similar"}}
+    {{- .Release.Name }}-{{ $name }}-{{ substr 0 4 $hash }}-{{ .Values.api.imageTag | required "Please set api.imageTag or similar"}}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
the migration job name changes appropriately when certain configurations are updated, such as annotations, volumes, or database backend,  can include these values in the job name's hash calculation. This would cause a new Job name to be generated whenever these key settings are changed, ensuring that a new Job is created for updated configurations.