### PR TITLE
Fix incorrect indention for prevented host

### DIFF
--- a/px/bird/templates/_helpers.tpl
+++ b/px/bird/templates/_helpers.tpl
@@ -66,8 +66,7 @@ nodeAffinity:
           {{- if .top.Values.prevent_hosts }}
         - key: kubernetes.cloud.sap/host
           operator: NotIn
-          values:
-          {{ .top.Values.prevent_hosts | toYaml | indent  16 }}
+          values: {{ .top.Values.prevent_hosts | toYaml | nindent  10 }}
           {{- end }}
 podAntiAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
If multiple host were prevented (due to miscabling) the first one would
print with a correct indent, due to the contnrol instruction being
indented, yet the second host would have a different indent. That lead
to a YAML parse error. To fix that, we are using `nindent` which inserts
a line break and then start with the values indented by `nindent`s
value.
