### PR TITLE
[openstack/utils] Use secrets-injector for osprofiler

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.18.3
+version: 0.18.4

--- a/openstack/utils/templates/_helpers.tpl
+++ b/openstack/utils/templates/_helpers.tpl
@@ -35,7 +35,7 @@ propagate=0
 [profiler]
 enabled = true
 connection_string = jaeger://localhost:6831
-hmac_keys = {{ .Values.global.osprofiler.hmac_keys }}
+hmac_keys = {{ .Values.global.osprofiler.hmac_keys | include "resolve_secret" }}
 trace_sqlalchemy = {{ .Values.global.osprofiler.trace_sqlalchemy }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
The "osprofiler" helper needs to resolve the `hmac_keys` setting from Vault.