### PR TITLE
[Cinder] Support secrets-injector

### DIFF
--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -1,27 +1,27 @@
 dependencies:
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.15.0
+  version: 0.18.4
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.10.1
+  version: 0.14.2
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.3.2
+  version: 0.3.5
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.2.0
+  version: 0.5.3
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.7.3
+  version: 0.11.1
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.3.5
+  version: 1.5.2
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.2.0
+  version: 1.0.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.1.3
-digest: sha256:4648c9ab8a1d5360a3dbf4f01e95585d22eb40f6cd86bcb2fa70c51b96529378
-generated: "2024-07-15T11:20:41.345828+03:00"
+  version: 1.0.0
+digest: sha256:49c61b998768421d8cdd026a0c886ec850bfcdc9ed89204f64c812470605b17b
+generated: "2024-09-27T14:13:49.162697106+02:00"

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -6,29 +6,29 @@ version: 0.2.1
 dependencies:
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.15.0
+    version: ~0.18.4
   - name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.10.1
+    version: 0.14.2
     condition: mariadb.enabled
   - name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.3.2
+    version: 0.3.5
     condition: mariadb.enabled
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.2.0
+    version: 0.5.3
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.7.3
+    version: 0.11.1
   - name: redis
     alias: api-ratelimit-redis
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 1.3.5
+    version: 1.5.2
     condition: api_rate_limit.enabled
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.2.0
+    version: 1.0.0
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.1.3
+    version: ~1

--- a/openstack/cinder/ci/test-values.yaml
+++ b/openstack/cinder/ci/test-values.yaml
@@ -1,0 +1,47 @@
+global:
+  accessControlAllowOrigin: '*'
+  region: regionOne
+  domain: evil.corp
+  registry: keppel.regionOne.cloud
+  dockerHubMirror: myRegistry/dockerhub
+  dockerHubMirrorAlternateRegion: myRegistry/dockerhubalternate
+  tld: regionOne.cloud
+  domain_seeds:
+    skip_hcm_domain: false
+    
+  cinder_service_password: topSecret
+  availability_zones:
+    - foo
+    - bar
+
+imageVersion: myTag
+imageVersionVspc: vspc-latest-tag
+
+mariadb:
+  root_password: rootroot
+  enabled: false
+  backup:
+    enabled: false
+  backup_v2:
+    enabled: false
+  users:
+    cinder:
+      name: cinder
+      password: password
+
+rabbitmq:
+  users:
+    admin:
+      password: adminadmin
+    default:
+      password: defaultdefault
+  metrics:
+    password: metricsmetrics
+
+cors:
+  enabled: true
+  additional_allow_headers: 'X-No-Real-Header'
+
+utils:
+  cors:
+    allowed_origin: 'https://test.domain'

--- a/openstack/cinder/templates/backup_deployment.yaml
+++ b/openstack/cinder/templates/backup_deployment.yaml
@@ -62,8 +62,13 @@ template: |
           - dumb-init
           - cinder-backup
           env:
+          {{- if .Values.sentry.enabled }}
           - name: SENTRY_DSN
-            value: {{ .Values.sentry_dsn | quote }}
+            valueFrom:
+              secretKeyRef:
+                name: sentry
+                key: {{ .Chart.Name }}.DSN.python
+          {{- end }}
           - name: PYTHONWARNINGS
             value: 'ignore:Unverified HTTPS request'
           livenessProbe:

--- a/openstack/cinder/templates/etc/_secrets.conf.tpl
+++ b/openstack/cinder/templates/etc/_secrets.conf.tpl
@@ -6,15 +6,15 @@
 {{- include "osprofiler" . }}
 
 [keystone_authtoken]
-username = {{ .Values.global.cinder_service_user | default "cinder"}}
-password = {{ required ".Values.global.cinder_service_password is missing" .Values.global.cinder_service_password | replace "$" "$$" }}
+username = {{ .Values.global.cinder_service_user | default "cinder" | include "resolve_secret" }}
+password = {{ required ".Values.global.cinder_service_password is missing" .Values.global.cinder_service_password | replace "$" "$$" | include "resolve_secret" }}
 
 [service_user]
-username = {{ .Values.global.cinder_service_user | default "cinder" }}
-password = {{ required ".Values.global.cinder_service_password is missing" .Values.global.cinder_service_password }}
+username = {{ .Values.global.cinder_service_user | default "cinder" | include "resolve_secret" }}
+password = {{ required ".Values.global.cinder_service_password is missing" .Values.global.cinder_service_password | include "resolve_secret" }}
 
 [nova]
-username = {{ .Values.global.cinder_service_user | default "cinder" }}
-password = {{ required ".Values.global.cinder_service_password is missing" .Values.global.cinder_service_password }}
+username = {{ .Values.global.cinder_service_user | default "cinder" | include "resolve_secret" }}
+password = {{ required ".Values.global.cinder_service_password is missing" .Values.global.cinder_service_password | include "resolve_secret" }}
 
 {{- include "ini_sections.audit_middleware_notifications" . }}

--- a/openstack/cinder/templates/etc/_volume-secrets.conf.tpl
+++ b/openstack/cinder/templates/etc/_volume-secrets.conf.tpl
@@ -1,9 +1,13 @@
-{{- define "cinder.iniValues" -}}
+{{- define "cinder.SecretiniValues" -}}
     {{- $values := index . 1 -}}
     {{- $name := index . 0 -}}
     {{- range $key, $value := $values }}
         {{- if kindIs "string" $value }}
+          {{- if hasPrefix "vault+kvv2://" $value }}
+{{ $key }} = "{{ $value | required (print "Please set the value for [" $name "]" $key) | include "resolve_secret" }}"
+          {{- else }}
 {{ $key }} = {{ $value | required (print "Please set the value for [" $name "]" $key) | replace "$" "$$" | quote }}
+          {{- end }}
         {{- else if kindIs "map" $value }}
 {{ $key }} = {{ $value | required (print "Please set the value for [" $name "]" $key) | toJson | squote }}
         {{- else }}
@@ -17,7 +21,16 @@
 {{- with $envAll := index . 0 -}}
 [backend_defaults]
 {{- $backend_defaults := merge (default (dict) $volume.backend_defaults) $envAll.Values.defaults.backends.common }}
-{{- tuple "backend_defaults" $backend_defaults | include "cinder.iniValues" }}
+{{- tuple "backend_defaults" $backend_defaults | include "cinder.SecretiniValues" }}
+
+{{- range $name, $backend := $volume.backends }}
+    {{- $values := merge $backend (get $envAll.Values.defaults.backends $backend.volume_driver) }}
+
+[{{$name}}]
+volume_backend_name = {{ $name | quote }}
+    {{- tuple $name $values | include "cinder.SecretiniValues" }}
+
+{{- end }}
 
 {{- end }}
 {{- end }}

--- a/openstack/cinder/templates/etc/_volume.conf.tpl
+++ b/openstack/cinder/templates/etc/_volume.conf.tpl
@@ -18,14 +18,5 @@
 [DEFAULT]
 enabled_backends = {{ keys $volume.backends | sortAlpha | join ", " | quote }}
 
-{{- range $name, $backend := $volume.backends }}
-    {{- $values := merge $backend (get $envAll.Values.defaults.backends $backend.volume_driver) }}
-
-[{{$name}}]
-volume_backend_name = {{ $name | quote }}
-    {{- tuple $name $values | include "cinder.iniValues" }}
-
-{{- end }}
-
 {{- end }}
 {{- end }}

--- a/openstack/cinder/templates/seed.yaml
+++ b/openstack/cinder/templates/seed.yaml
@@ -61,7 +61,7 @@ spec:
     users:
     - name: cinder
       description: Cinder Service
-      password: '{{.Values.global.cinder_service_password}}'
+      password: '{{ .Values.global.cinder_service_password | include "resolve_secret" }}'
       role_assignments:
       - project: service
         role: service


### PR DESCRIPTION
For supporting resolving Vault secrets via `secrets-injector`, we have to bump the charts we're depending on. This includes the following changes:

utils 0.15.0 -> 0.18.4:
   * add helm pre-upgrade weight to proxysql
   * better error message on missing proxysql password
   * support secrets-injector

mariadb 0.10.1 -> 0.14.2:
  * Add standardised labels
  * bump backupv2 image version
  * update mysqld_exporter to 0.15.1
  * mysqld_exporter scrapes from localhost
  * support secrets-injector

mysql_metrics 0.3.2 -> 0.3.5:
  * support secrets-injector

memcached 0.2.0 -> 0.5.3:
  * add standardised labels
  * bump memcached-exporter to v0.14.1
  * increase default cpu limit from 0.1 to 0.5
  * bump memcached from 1.6.21 to 1.6.28
  * sasl support

rabbitmq 0.7.3 -> 0.11.1:
  * switch Secret from stringData to data
  * add standardised labels
  * support secrets-injector
  * remove rabbitmq-exporter sidecar in favor of rabbitmq prometheus plugin
  * update rabbitmq from 3.13.0 to 3.13.6

redis 1.3.5 -> 1.5.2:
  * add annotation for logs
  * bump exporter from v1.54.0 to v1.63.0
  * bump from 7.2.1-alpine to 7.2-20240908161915
  * switch from library/redis to shared-app-images/redis
  * remove obsolete alert labels
  * deployment restarts on configuration changes

owner-info 0.2.0 -> 1.0.0:
  * srs: bump all library charts to a stable version number

linkerd-support 0.2.0 -> 1.0.0:
  * srs: bump all library charts to a stable version number

We also have to move the custom volume backend configuration to a k8s Secret, because Vault references are not resolved outside of Secrets and passwords are not allowed in ConfigMaps.