### PR TITLE
[Nova] Bump rabbitmq and utils Chart

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -10,24 +10,24 @@ dependencies:
   version: 0.3.5
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.11.0
+  version: 0.11.1
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.4.0
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.18.1
+  version: 0.18.4
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.14.1
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.11.0
+  version: 0.11.1
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:c693a6b1d5ef38e4fc6f23e257fb02eaf18165247ce3eb9b5d19a56ffae8d4bd
-generated: "2024-08-12T14:35:36.846468538+02:00"
+digest: sha256:d07e7cfa505d125538b9fc3103ce327f8db8b62417d5316bc3c9a8bbf3d35402
+generated: "2024-09-27T15:26:33.908323963+02:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -20,7 +20,7 @@ dependencies:
     version: 0.3.5
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.11.0
+    version: 0.11.1
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.4.0
@@ -36,7 +36,7 @@ dependencies:
     alias: rabbitmq_cell2
     condition: cell2.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.11.0
+    version: 0.11.1
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0


### PR DESCRIPTION
The `utils` chart bumped itself automatically. The changes are `secrets-injector`-related fixes we do not really need.

Bumping the `rabbitmq` chart version makes the
`AbsentComputeStorageApiNovaRabbitmqQueueMessagesUnacknowledged` go away.