### PR TITLE
fix(prometheus): remove no longer needed thanos rule

### DIFF
--- a/common/prometheus-server/CHANGELOG.md
+++ b/common/prometheus-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.6.1
+
+* VPAexceeded alerts adjusted; no Thanos rule anymore
+
 ## 7.6.0
 
 * Upgrade to v2.53.0

--- a/common/prometheus-server/Chart.yaml
+++ b/common/prometheus-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus via operator.
 name: prometheus-server
-version: 7.6.0
+version: 7.6.1
 appVersion: v2.53.0
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
 maintainers:

--- a/common/prometheus-server/templates/alerts/_prometheus-thanos-rule.alerts.tpl
+++ b/common/prometheus-server/templates/alerts/_prometheus-thanos-rule.alerts.tpl
@@ -34,38 +34,3 @@ groups:
       description: Prometheus is scraping `{{`{{ $labels.pod }}`}}` pods in namespace `{{`{{ $labels.namespace }}`}}` multiple times. This is likely caused due to incorrectly placed scrape annotations. <https://{{ include "prometheus.externalURL" . }}/graph?g0.expr={{ urlquery `up * on(instance) group_left() (sum by(instance) (up{kubernetes_pod_name=~"PLACEHOLDER.*"}) > 1)` | replace "PLACEHOLDER" "{{ $labels.pod }}"}}|Affected targets>
       summary: Prometheus scrapes pods multiple times
   {{- end }}
-  {{- if and (eq $root.Values.vpaUpdateMode "Auto") $root.Values.alerts.thanos.enabled }}
-  {{/* This is covering all Prometheis but kubernetes. They don not have the vpa_butler metric and need to leverage thanos ruler instead. */}}
-  - alert: PrometheusVpaMemoryExceeded
-    expr: |
-      round(vpa_butler_vpa_container_recommendation_excess{verticalpodautoscaler=~"{{ include "prometheus.fullName" . }}",resource="memory"} / 1024 / 1024 / 1024, 0.1 ) > 0.1
-    for: 15m
-    labels:
-      service: {{ default "metrics" $root.Values.alerts.service }}
-      support_group: {{ default "observability" $root.Values.alerts.support_group }}
-      severity: info
-      meta: Prometheus VPA for `{{`{{ $labels.verticalpodautoscaler }}`}}` in `{{`{{ $labels.namespace }}`}}` is recommending more memory.
-    annotations:
-      description: |
-        `{{`{{ $labels.verticalpodautoscaler }}`}}` in `{{`{{ $labels.cluster }}/{{ $labels.namespace }}`}}` needs more `{{`{{ $labels.resource }}`}}`. It is overutilized by `{{`{{ $value }}`}}` GiB.
-        It is hitting the VPA maxAllowed boundary and is not ensured to run properly at its current place. Consider upgrading the VPA maxAllowed
-        memory value if the host memory size permits.
-      summary: Prometheus needs more memory.
-
-  - alert: PrometheusVpaCPUExceeded
-    expr: |
-      round(vpa_butler_vpa_container_recommendation_excess{verticalpodautoscaler=~"{{ include "prometheus.fullName" . }}",resource="cpu"}, 0.1) > 0.1
-    for: 15m
-    labels:
-      service: {{ default "metrics" $root.Values.alerts.service }}
-      support_group: {{ default "observability" $root.Values.alerts.support_group }}
-      severity: info
-      meta: Prometheus VPA for `{{`{{ $labels.verticalpodautoscaler }}`}}` in `{{`{{ $labels.namespace }}`}}` is recommending more CPUs.
-    annotations:
-      description: |
-        `{{`{{ $labels.verticalpodautoscaler }}`}}` in `{{`{{ $labels.cluster }}/{{ $labels.namespace }}`}}` needs more `{{`{{ $labels.resource }}`}}`. It is overutilized by `{{`{{ $value }}`}}` cores.
-        It is hitting the VPA maxAllowed boundary and is not ensured to run properly at its current place. Consider upgrading the VPA maxAllowed
-        CPU core value if the host has enough CPU cores.
-      summary: Prometheus needs more CPU.
-{{- end }}
-

--- a/common/prometheus-server/templates/alerts/_prometheus.alerts.tpl
+++ b/common/prometheus-server/templates/alerts/_prometheus.alerts.tpl
@@ -257,11 +257,11 @@ groups:
       summary: Prometheus scrapes pods multiple times
   {{- end }}
 
-  {{- if and (eq $root.Values.vpaUpdateMode "Auto") (not $root.Values.alerts.thanos.enabled) }}
+  {{- if eq $root.Values.vpaUpdateMode "Auto" }}
   - alert: PrometheusVpaMemoryExceeded
     expr: |
       round(vpa_butler_vpa_container_recommendation_excess{verticalpodautoscaler=~"{{ include "prometheus.fullName" . }}",resource="memory"} / 1024 / 1024 / 1024, 0.1 ) > 5
-    for: 4d
+    for: 3h
     labels:
       service: {{ default "metrics" $root.Values.alerts.service }}
       support_group: {{ default "observability" $root.Values.alerts.support_group }}
@@ -277,7 +277,7 @@ groups:
   - alert: PrometheusVpaCPUExceeded
     expr: |
       round(vpa_butler_vpa_container_recommendation_excess{verticalpodautoscaler=~"{{ include "prometheus.fullName" . }}",resource="cpu"}, 0.1) > 0.5
-    for: 4d
+    for: 3h
     labels:
       service: {{ default "metrics" $root.Values.alerts.service }}
       support_group: {{ default "observability" $root.Values.alerts.support_group }}


### PR DESCRIPTION
* metrics are all available to Prometheus itself, hence the switch makes no sense anymore.

* fixing the unsoftened condition for prometheus-kubernetes (was still on trigger > 0.1) which actually triggered permanent alerts

* removing thanos condition, has no impact anymore

* adjusting time from 4d to hours, since 4d could never be met anymor (12h retention)