### PR TITLE
[pxc-db] Follow-up cosmetic improvements

### DIFF
--- a/common/pxc-db/Chart.yaml
+++ b/common/pxc-db/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/common/pxc-db/templates/_helpers.tpl
+++ b/common/pxc-db/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Expand the name of the chart.
 */}}
 {{- define "pxc-db.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | replace "_" "-" | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -12,13 +12,13 @@ If release name contains chart name it will be used as a full name.
 */}}
 {{- define "pxc-db.fullname" -}}
 {{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- .Values.fullnameOverride | trunc 63 | replace "_" "-" | trimSuffix "-" }}
 {{- else }}
 {{- $name := default .Chart.Name .Values.nameOverride }}
 {{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- .Release.Name | trunc 63 | replace "_" "-" | trimSuffix "-" }}
 {{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | replace "_" "-" | trimSuffix "-" }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -37,7 +37,7 @@ Common labels
 helm.sh/chart: {{ include "pxc-db.chart" . }}
 {{ include "pxc-db.selectorLabels" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-app.kubernetes.io/component: {{ .Chart.Name }}
+app.kubernetes.io/component: {{ include "pxc-db.name" . }}
 app.kubernetes.io/part-of: {{ .Release.Name }}
 {{- end }}
 
@@ -47,7 +47,7 @@ Selector labels
 {{- define "pxc-db.selectorLabels" -}}
 app: {{ .Release.Name }}
 app.kubernetes.io/name: {{ include "pxc-db.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/instance: {{ include "pxc-db.name" . }}-{{ .Release.Name }}
 {{- end }}
 
 {{/*

--- a/common/pxc-db/templates/cluster.yaml
+++ b/common/pxc-db/templates/cluster.yaml
@@ -20,9 +20,9 @@ spec:
   ignoreLabels:
 {{ .Values.ignoreLabels | toYaml | indent 4 }}
   {{- end }}
-  secretsName: pxc-{{.Values.name}}-secrets
-  sslSecretName: pxc-{{.Values.name}}-ssl
-  sslInternalSecretName: pxc-{{.Values.name}}-ssl-internal
+  secretsName: pxc-db-{{.Values.name}}-secrets
+  sslSecretName: pxc-db-{{.Values.name}}-ssl
+  sslInternalSecretName: pxc-db-{{.Values.name}}-ssl-internal
   {{- if .Values.initContainer }}
   initContainer:
     {{- if $.Values.initContainer.image.override }}
@@ -129,7 +129,7 @@ spec:
         - name: MYSQLD_EXPORTER_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: pxc-{{.Values.name}}-secrets
+              name: pxc-db-{{.Values.name}}-secrets
               key: monitor
       ports:
         - name: metrics

--- a/common/pxc-db/templates/initdb-bin.yaml
+++ b/common/pxc-db/templates/initdb-bin.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: pxc-{{ .Values.name }}-init-db-bin
+  name: pxc-db-{{ .Values.name }}-init-db-bin
   labels:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/common/pxc-db/templates/initdb-job.yaml
+++ b/common/pxc-db/templates/initdb-job.yaml
@@ -51,7 +51,7 @@ spec:
           - name: MYSQL_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: pxc-{{.Values.name}}-secrets
+                name: pxc-db-{{.Values.name}}-secrets
                 key: operator
         volumeMounts:
           - name: initdb
@@ -61,10 +61,10 @@ spec:
       volumes:
         - name: initdb
           secret:
-            secretName: pxc-{{ .Values.name }}-db-mysql-init
+            secretName: pxc-db-{{ .Values.name }}-init-sql
             defaultMode: 0666
         - name: init-db-configmap
           configMap:
-            name: pxc-{{ .Values.name }}-init-db-bin
+            name: pxc-db-{{ .Values.name }}-init-db-bin
             defaultMode: 0755
 {{- end }}

--- a/common/pxc-db/templates/initdb-secret.yaml
+++ b/common/pxc-db/templates/initdb-secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: pxc-{{ .Values.name }}-db-mysql-init
+  name: pxc-db-{{ .Values.name }}-init-sql
   labels:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/common/pxc-db/templates/secrets.yaml
+++ b/common/pxc-db/templates/secrets.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   namespace: {{ $.Release.Namespace }}
-  name: pxc-{{.Values.name}}-secrets
+  name: pxc-db-{{.Values.name}}-secrets
   labels:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -28,7 +28,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   namespace: {{ $.Release.Namespace }}
-  name: pxc-{{.Values.name}}-backup-s3
+  name: pxc-db-{{.Values.name}}-backup-s3
   labels:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/common/pxc-db/values.yaml
+++ b/common/pxc-db/values.yaml
@@ -19,20 +19,21 @@ unsafeFlags: {}
 #  proxySize: false
 #  backupIfUnhealthy: false
 
+# Enable init.sql job
+initdb_job: null
+# Set charachter set and collation in init.sql
 character_set_server: "utf8mb4"
 collation_server: "utf8mb4_0900_ai_ci"
 
-initdb_job: null
-
 databases: {}
-users:
-  backup:
-    name: backup
-    password: null
-    limits:
-      max_user_connections: 4
-    grants:
-      - ALL PRIVILEGES ON *.*
+users: {}
+#  backup:
+#    name: backup
+#    password: null
+#    limits:
+#      max_user_connections: 4
+#    grants:
+#      - ALL PRIVILEGES ON *.*
 #  example:
 #    name: example1 # This looks repetitive, but the point is that they key is the name
 #                   # you refer to in your charts, while the field 'name' is the actual name
@@ -339,7 +340,7 @@ backup:
       limits: {}
   s3:
     config:
-      credentialsSecret: "pxc-{{ .Values.name }}-backup-s3"
+      credentialsSecret: "pxc-db-{{ .Values.name }}-backup-s3"
       region: "{{ .Values.global.region }}"
       endpointUrl: null
     secrets:


### PR DESCRIPTION
* Replace underscores with dashes in name labels

* Don't create backup user by default. System xtrabackus is being used

* Rename secrets - use pxc-db suffix consistently
