### PR TITLE
[utils][pxc-db] Use db-haproxy suffix for pxc services consistently

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.19.1
+version: 0.19.2

--- a/openstack/utils/proxysql_sidecar.md
+++ b/openstack/utils/proxysql_sidecar.md
@@ -15,7 +15,7 @@ The two modes differ in the following way:
 - `unix_socket` connects to the side-car container via a unix socket file on a shared volume.
    This should be the fastest, but has the disadvantage that works only with the side-car present, as the url
    is referring to said file.
-- `host_alias`  uses a host alias for the short hostname (ie. `<app>-mariadb` or `<app>-db`) to redirect the application to the localhost
+- `host_alias`  uses a host alias for the short hostname (ie. `<app>-mariadb` or `<app>-db-haproxy`) to redirect the application to the localhost
   where the side-car container is listening on the default port. But the very same url also works without a side-car
   container, if the host-alias is not set. So we do not have to annotate all pods, we just have to make sure,
   that the annotations are consistent for a single pod.

--- a/openstack/utils/templates/_hosts.tpl
+++ b/openstack/utils/templates/_hosts.tpl
@@ -95,7 +95,12 @@ Example: service-mariadb
 
 {{/*
 Service hostname for pxc-db
-Example: service-db
+pxc-db provides following services:
+- service-db-haproxy (*)
+- service-db-haproxy-replicas
+- service-db-pxc
+- service-db-pxc-unready
+Example: service-db-haproxy
 */}}
 {{- define "utils._db_host_pxc_db" }}
     {{- if kindIs "map" . }}
@@ -107,7 +112,7 @@ Example: service-db
         {{- else }}
             {{- $envAll.Values.pxc_db.name }}
         {{- end }}
-    {{- end }}-db
+    {{- end }}-db-haproxy
 {{- end }}
 
 {{/*

--- a/openstack/utils/templates/_proxysql.tpl
+++ b/openstack/utils/templates/_proxysql.tpl
@@ -95,7 +95,7 @@
           {{- $_ := set $dbs $d.Name (merge (get $envAll.Values $d.Name) (dict "hostAliasesSuffix" "mariadb")) }}
         {{- end }}
         {{- if hasPrefix "pxc" $d.Name }}
-          {{- $_ := set $dbs $d.Name (merge (get $envAll.Values $d.Name) (dict "hostAliasesSuffix" "db")) }}
+          {{- $_ := set $dbs $d.Name (merge (get $envAll.Values $d.Name) (dict "hostAliasesSuffix" "db-haproxy")) }}
         {{- end }}
       {{- end }}
       {{/* Option: add hostAliases base on proxysql.force_enable values */}}
@@ -103,7 +103,7 @@
         {{- if hasPrefix "mariadb" $d }}
           {{- $_ := set $dbs $d (merge (get $envAll.Values $d) (dict "hostAliasesSuffix" "mariadb")) }}
         {{- else if hasPrefix "pxc" $d }}
-          {{- $_ := set $dbs $d (merge (get $envAll.Values $d) (dict "hostAliasesSuffix" "db")) }}
+          {{- $_ := set $dbs $d (merge (get $envAll.Values $d) (dict "hostAliasesSuffix" "db-haproxy")) }}
         {{- else }}
           {{ fail (printf "unknown database type: %s" $d) }}
         {{- end }}


### PR DESCRIPTION
hostAlias and ProxySQL configuration should be identical to the db service