### PR TITLE
[utils][pxc-db] Add an option to have all DBs in ProxySQL configuration

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.19.2
+version: 0.19.3


### PR DESCRIPTION
ProxySQL configuration now could be in the following states:
- if .Values.dbType isn't set and mariadb present in chart dependencies
  -> only mariadb is left in proxysql configuration

- if pxc is present in chart dependencies and proxysq.multiDestination=true:
  -> both mariadb and pxc present in proxysql configuration

- if pxc is present in chart dependencies, dbType=pxc-db and proxysq.multiDestination=false
  -> only pxc is left in proxysql configuration
 
These states will be used during data migration from one database to another.
