### PR TITLE
[neutron] set external service `externalTrafficPolicy` to Local

### DIFF
--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Openstack Neutron
 name: neutron
-version: 0.2.2
+version: 0.2.3
 appVersion: "yoga"
 dependencies:
   - condition: mariadb.enabled

--- a/openstack/neutron/templates/service-nsxv3-logstash.yaml
+++ b/openstack/neutron/templates/service-nsxv3-logstash.yaml
@@ -23,5 +23,6 @@ spec:
   selector:
     name: neutron-nsxv3-logstash
   sessionAffinity: None
-  type: ClusterIP
+  type: LoadBalancer
+  externalTrafficPolicy: Local
 {{- end }}

--- a/openstack/neutron/templates/sftp-service.yaml
+++ b/openstack/neutron/templates/sftp-service.yaml
@@ -9,6 +9,8 @@ metadata:
     disco/record: {{ include "sftp_api_endpoint_host" . }}.
     {{- include "utils.linkerd.pod_and_service_annotation" . | indent 4 }}
 spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
   selector:
     component: neutron-sftp-backup
   ports:


### PR DESCRIPTION
With calico BGP, we need to advertise the external service IPs /32 IP to upstream switches to make it more preferred than a summary route.