### PR TITLE
[utils][pxc-db] Add support for multiple ProxySQL secrets creation

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.19.3
+version: 0.19.4


### PR DESCRIPTION
If proxysql.multiSecret is set and multiple database types are enabled, then proxysql_secret helper will additionally create two ProxySQL secrets:
- for all pxc-db dependencies
- for all mariadb dependencies