### PR TITLE
[CINDER] update fcd name and add quality type

### DIFF
--- a/openstack/cinder/templates/vcenter_datacenter_cinder_secret.yaml
+++ b/openstack/cinder/templates/vcenter_datacenter_cinder_secret.yaml
@@ -44,13 +44,13 @@ template: |
   volume_driver = cinder.volume.drivers.vmware.vmdk.VMwareVcVmdkDriver
   volume_backend_name = vmware
   vmware_storage_profile = {{ .Values.backends.vmware.vmware_storage_profile  }}
-  extra_capabilities = '{"vcenter-shard": "{= host.split(".")[0] =}"}'
+  extra_capabilities = '{"vcenter-shard": "{= host.split(".")[0] =}", "quality_type": "premium"}'
 
   [standard_hdd]
   volume_driver = cinder.volume.drivers.vmware.vmdk.VMwareVcVmdkDriver
   volume_backend_name = standard_hdd
   vmware_storage_profile = {{ .Values.backends.standard_hdd.vmware_storage_profile }}
-  extra_capabilities = '{"vcenter-shard": "{= host.split(".")[0] =}"}'
+  extra_capabilities = '{"vcenter-shard": "{= host.split(".")[0] =}", "quality_type": "standard"}'
 
   {{ range $backend, $kvs := .Values.backends.additional_backends }}
   [{{ $backend }}]
@@ -59,8 +59,10 @@ template: |
   {{- end }}
   {{ end }}
 
-  [vstorageobject]
+  [vmware_fcd]
   volume_driver = cinder.volume.drivers.vmware.fcd.VMwareVStorageObjectDriver
-  volume_backend_name = vstorageobject
+  volume_backend_name = vmware_fcd
+  vmware_storage_profile: vmware-fcd
+  extra_capabilities = '{"vcenter-shard": "{= host.split(".")[0] =}", "quality_type": "premium"}'
   {% endfilter -%}
 {{- end }}


### PR DESCRIPTION
This patch updates the name of the cinder backend definition for cinder-volume.conf for the fcd driver and adds the proper storage profile setting.

This also adds the new extra_capability reporting for each backend called quality_type.  For vmware and fcd the quality type is set to premium.  For standard_hdd the quality type is set to standard.

This allows us to add volume type extra specs to distinguish on backend based on quality_type.