### PR TITLE
ironic: enable audit as default

### DIFF
--- a/openstack/ironic/values.yaml
+++ b/openstack/ironic/values.yaml
@@ -441,7 +441,7 @@ audit:
   central_service:
     user: rabbitmq
     password: DEFINED-IN-SECRETS
-  enabled: false
+  enabled: true
   # how many messages to buffer before dumping to log (when rabbit is down or too slow)
   mem_queue_size: 100
   record_payloads: false


### PR DESCRIPTION
We somehow apparently never enabled audit. Now we enable it by default.