### PR TITLE
update ironic api audit map for new endpoints

### DIFF
--- a/openstack/ironic/templates/etc/_api_audit_map.yaml.tpl
+++ b/openstack/ironic/templates/etc/_api_audit_map.yaml.tpl
@@ -4,6 +4,7 @@ prefix: '/v1'
 
 resources:
   allocations:
+  chassis:
   deploy_templates:
   nodes:
     children:
@@ -14,8 +15,10 @@ resources:
       states:
       traits:
       vifs:
+      vmedia:
   ports:
   portgroups:
+  runbooks:
   volumes:
     children:
       connectors:


### PR DESCRIPTION
Update audit map with api reference additions to Ironic

If you'd like to check my work (appreciated) here is the [api reference](https://docs.openstack.org/api-ref/baremetal/)

I added chassis even though it's depercated because it's still callable. You may prefer a different decision based on the context you have for if it is still callable or usable. 