### PR TITLE
[Neutron] Remove dogstatsd plugin from uwsgi

### DIFF
--- a/openstack/neutron/templates/etc/_uwsgi.ini.tpl
+++ b/openstack/neutron/templates/etc/_uwsgi.ini.tpl
@@ -11,7 +11,7 @@ uid = neutron
 gid = neutron
 http = :{{.Values.global.neutron_api_port_internal | default 9696}}
 plugins-dir = /var/lib/openstack/lib
-need-plugins = dogstatsd,shortmsecs
+need-plugins = shortmsecs
 
 # Connection tuning
 vacuum = true
@@ -35,9 +35,6 @@ log-x-forwarded-for = true
 log-date = %%Y-%%m-%%d %%H:%%M:%%S
 log-format-strftime = true
 log-format = %(ftime),%(shortmsecs) %(pid) INFO uWSGI [%(request_id) g%(global_request_id) %(user_id) %(project) %(domain) %(user_domain) %(project_domain)] %(addr) "%(method) %(uri) %(proto)" status: %(status) len: %(size) time: %(secs) agent: %(uagent)
-plugin = dogstatsd
-stats-push = dogstatsd:127.0.0.1:9125
-dogstatsd-all-gauges = true
 memory-report = true
 
 # HTTP-Socket Timeout


### PR DESCRIPTION
Starting with uwsgi version >=2.0.27, the dogstatsd plugin (https://github.com/DataDog/uwsgi-dogstatsd)  breaks causing Neutron Server pods to crashloop.  Also it was noticed that this plugin was not maintained for the last 5 years.

With the plugin removal no uwsgi related metrics (like free/busy workers, avg. response time, etc.) are available anymore. In the near future the missing plugin will be replaced by another uwsgi exporter.