### PR TITLE
limes: remove non-growing-quota alert for committable resources

### DIFF
--- a/openstack/limes/alerts/openstack/api.alerts
+++ b/openstack/limes/alerts/openstack/api.alerts
@@ -279,7 +279,7 @@ groups:
   - alert: OpenstackNonGrowingQuotaAlmostExhausted
     expr: max by (support_group, service_name, service, resource, domain, project_id, project) (
         ((limes_project_usage{resource!~"instances_.*"} > 0.9 * limes_project_quota) and on (service, resource) (limes_autogrow_growth_multiplier == 1)) * on (service) group_left (support_group) (limes_support_group_mapping)
-      )
+      ) unless on (service, resource) (limes_available_commitment_duration == 1)
     for: 5m
     labels:
       severity: warning


### PR DESCRIPTION
This alert is intended only for resources where regular users have no way to extend the quota themselves.

Tested on firing alert in eu-de-2, works as intended there.