### PR TITLE
[glance] Update mariadb to 0.14.2 for secrets-injector

### DIFF
--- a/openstack/glance/Chart.lock
+++ b/openstack/glance/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.12.1
+  version: 0.14.2
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.5.3
@@ -20,5 +20,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:38c4de6c6e740d9cdd0b60658d28edc0ae5a16ffea08ddcc1b1ea9197f555952
-generated: "2024-09-30T20:48:23.657806+05:30"
+digest: sha256:f09bf07ebe434e7cb64223d6c06b33a0b4641794bf7c04986c90cc0bc42d2396
+generated: "2024-10-09T14:43:36.010960398+02:00"

--- a/openstack/glance/Chart.yaml
+++ b/openstack/glance/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.12.1
+    version: 0.14.2
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.5.3

--- a/openstack/glance/ci/test-values.yaml
+++ b/openstack/glance/ci/test-values.yaml
@@ -21,6 +21,13 @@ mariadb:
   backup_v2:
     swift:
       password: topSecret
+  users:
+    glance:
+      name: glance
+      password: password
+    backup:
+      name: backup
+      password:  password
 
 rabbitmq:
   users:
@@ -30,6 +37,11 @@ rabbitmq:
       password: defaultdefault
   metrics:
     password: metricsmetrics
+
+audit:
+  central_service:
+    user: glance
+    password: password
 
 swift:
   enabled: false


### PR DESCRIPTION
That will cause a db restart due mysqld-exporter sidecar v0.12.1 -> v0.15.1