### PR TITLE
[barbican] Update mariadb to 0.14.2 for secrets-injector

### DIFF
--- a/openstack/barbican/Chart.lock
+++ b/openstack/barbican/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.12.1
+  version: 0.14.2
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.5.3
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.0
-digest: sha256:d011851440a547026c314bd2c634245189e68f9e4e0bb8238ad1a9b3f6af1c36
-generated: "2024-09-30T20:48:08.782921+05:30"
+digest: sha256:323602dbbeab0fe17f37e035e2c5b8efd458968bea6f578de0a84389f80ff6cd
+generated: "2024-10-09T14:59:36.890382024+02:00"

--- a/openstack/barbican/Chart.yaml
+++ b/openstack/barbican/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.12.1
+    version: 0.14.2
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.5.3

--- a/openstack/barbican/ci/test-values.yaml
+++ b/openstack/barbican/ci/test-values.yaml
@@ -12,6 +12,13 @@ imageVersionBarbicanApi: yoga
 dbPassword: topSecret
 mariadb:
   root_password: topSecret
+  users:
+    barbican:
+      name: barbican
+      password: password
+    backup:
+      name: backup
+      password:  password
 
 rabbitmq_notifications:
   users:
@@ -31,3 +38,8 @@ rabbitmq:
       password: defaultdefault
   metrics:
     password: metricsmetrics
+
+audit:
+  central_service:
+    user: barbican
+    password: password


### PR DESCRIPTION
That will cause a db restart due mysqld-exporter sidecar v0.12.1 -> v0.15.1