### PR TITLE
[system/metis] Update mariadb chart to 0.14.2

### DIFF
--- a/system/metis/Chart.lock
+++ b/system/metis/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.10.1
+  version: 0.14.2
 - name: prometheus-monitors
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.0.2
@@ -11,5 +11,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:a3bc84968b89309ed126a9acc2981b284ef3fabe4acde9570a84afd18b462f88
-generated: "2024-04-12T15:28:00.508899+02:00"
+digest: sha256:0ea030392ae252319f18d8b2b7044a84c705cd722f86bc548653ec2dc107aca1
+generated: "2024-10-11T13:13:55.615915872+02:00"

--- a/system/metis/Chart.yaml
+++ b/system/metis/Chart.yaml
@@ -6,7 +6,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.10.1
+    version: 0.14.2
   - name: prometheus-monitors
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.0.2

--- a/system/metis/ci/test-values.yaml
+++ b/system/metis/ci/test-values.yaml
@@ -4,5 +4,13 @@ global:
   metis:
     user: test123
     password: test123
+
 mariadb:
   root_password: secret123
+  users:
+    glance:
+      name: glance
+      password: password
+    backup:
+      name: backup
+      password:  password


### PR DESCRIPTION
This is needed for the switch to secrets-injector. It will cause a reboot of the db due to a different sidecar image version.