### PR TITLE
[kmip] Update mariadb chart to 0.14.2

### DIFF
--- a/openstack/kmip/Chart.lock
+++ b/openstack/kmip/Chart.lock
@@ -7,12 +7,12 @@ dependencies:
   version: 1.0.0
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.16.1
+  version: 0.19.3
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.11.1
+  version: 0.14.2
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.3.2
-digest: sha256:0efeedef7de88a75ce4e10d37ab1b0360e3c7d26255c26cb778dfd0590cfd430
-generated: "2024-07-04T12:12:00.349812+05:30"
+digest: sha256:4c18fa6fdb423a5c130b82de1fdff742d3c76098eee9069176a021672df09b96
+generated: "2024-10-11T13:19:45.483617763+02:00"

--- a/openstack/kmip/Chart.yaml
+++ b/openstack/kmip/Chart.yaml
@@ -36,7 +36,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.11.1
+    version: 0.14.2
   - condition: mariadb.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/kmip/ci/test-values.yaml
+++ b/openstack/kmip/ci/test-values.yaml
@@ -9,5 +9,5 @@ global:
 
 certs:
   server_cert: topSecret
-  server.key: topSecret
-  ca.crt: topSecret
+  server_key: topSecret
+  ca_crt: topSecret

--- a/openstack/kmip/templates/deployment.yaml
+++ b/openstack/kmip/templates/deployment.yaml
@@ -90,11 +90,11 @@ spec:
               readOnly: true
             - name: kmip-certificates
               mountPath: /etc/pykmip/certs/server.crt
-              subPath: server.crt
+              subPath: tls.crt
               readOnly: true
             - name: kmip-certificates
               mountPath: /etc/pykmip/certs/server.key
-              subPath: server.key
+              subPath: tls.key
               readOnly: true
             - name: kmip-certificates
               mountPath: /etc/pykmip/certs/ca.crt

--- a/openstack/kmip/templates/secrets.yaml
+++ b/openstack/kmip/templates/secrets.yaml
@@ -9,4 +9,4 @@ data:
   tls.key: |
     {{ .Values.certs.server_key | indent 4 }}
   ca.crt: |
-    {{ .Values.certs.ca_crt | quote | indent 4 }}
+    {{ .Values.certs.ca_crt | indent 4 }}

--- a/openstack/kmip/templates/secrets.yaml
+++ b/openstack/kmip/templates/secrets.yaml
@@ -2,11 +2,11 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: kmip-certificates
-type: Opaque
+type: kubernetes.io/tls
 data:
-  server.crt: |
+  tls.crt: |
     {{ .Values.certs.server_cert | indent 4 }}
-  server.key: |
+  tls.key: |
     {{ .Values.certs.server_key | indent 4 }}
   ca.crt: |
     {{ .Values.certs.ca_crt | indent 4 }}


### PR DESCRIPTION
This is needed for the switch to secrets-injector. It will cause a reboot of the db due to a different sidecar image version.