### PR TITLE
[Neutron] Bump charts

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -4,24 +4,24 @@ dependencies:
   version: 0.14.2
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.2.0
+  version: 0.5.3
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.3.2
+  version: 0.3.6
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.6.12
+  version: 0.11.1
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.16.1
+  version: 0.19.3
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.2.0
+  version: 1.0.0
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.3.5
+  version: 1.5.3
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.1.3
-digest: sha256:c0703e406202116967ad4171f133c9a954da1085718af1ec360aef4c015c9cbc
-generated: "2024-10-11T12:30:01.471323+02:00"
+  version: 1.0.0
+digest: sha256:a31805b51639baeaef1939b8fc8e9979b2b6b273d9b6e98a0915325328219dc7
+generated: "2024-10-14T15:00:38.117921+02:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -10,25 +10,25 @@ dependencies:
     version: 0.14.2
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.2.0
+    version: 0.5.3
   - condition: mariadb.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.3.2
+    version: 0.3.6
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.6.12
+    version: 0.11.1
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.16.1
+    version: 0.19.3
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.2.0
+    version: 1.0.0
   - name: redis
     alias: api-ratelimit-redis
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 1.3.5
+    version: 1.5.3
     condition: rate_limit.enabled
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.1.3
+    version: 1.0.0


### PR DESCRIPTION
For supporting resolving Vault secrets via `secrets-injector`, we have to bump the charts we're depending on. This includes the following changes:

-    utils >= 0.18.4
-    mariadb >= 0.14.2
-    mysql_metrics >= 0.3.5
-    rabbitmq >= 0.11.1

Additionally, bumping redis, owner-info and linkerd-support to the latest version.