### PR TITLE
Change openstack-service-critical to critical-infrastructure PriorityClass

### DIFF
--- a/common/memcached/values.yaml
+++ b/common/memcached/values.yaml
@@ -47,10 +47,10 @@ resources:
 
 metrics:
   enabled: true
-  image: 'prom/memcached-exporter'
-  imageTag: 'v0.14.1'
+  image: "prom/memcached-exporter"
+  imageTag: "v0.14.1"
 
-  port: '9150'
+  port: "9150"
   resources:
     enabled: true
     limits:
@@ -66,8 +66,8 @@ replicas: 1
 # the client should connect using this username/password combination to
 # connect to memcached.
 auth:
-  username: ''
-  password: ''
+  username: ""
+  password: ""
 
 upgrades:
   revisionHistory: 3
@@ -75,7 +75,6 @@ upgrades:
   rollingUpdate:
     maxUnavailable: 1
     maxSurge: 3
-
 
 # Default Prometheus alerts and rules.
 alerts:

--- a/common/pxc-db/values.yaml
+++ b/common/pxc-db/values.yaml
@@ -130,15 +130,15 @@ pxc:
       wsrep_applier_threads: 4
       wsrep_retry_autocommit: 3
       binlog_format: ROW
-      binlog_expire_logs_seconds: 345600  # default 30 days -> 4 days
+      binlog_expire_logs_seconds: 345600 # default 30 days -> 4 days
       net_read_timeout: 120
       net_write_timeout: 300
       connect_timeout: 30
       wait_timeout: 3800
       interactive_timeout: 1800
-      innodb_lock_wait_timeout: 30  # default 50 seconds -> 30 seconds
+      innodb_lock_wait_timeout: 30 # default 50 seconds -> 30 seconds
       max_connections: 1024
-      max_connect_errors: "4294967295"  # to avoid failed connections because of loadbalancer health checks
+      max_connect_errors: "4294967295" # to avoid failed connections because of loadbalancer health checks
       innodb_flush_log_at_trx_commit: 0
       innodb_flush_method: O_DIRECT
       innodb_file_per_table: 1
@@ -160,20 +160,20 @@ pxc:
     advanced:
       nodeAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:
-        - preference:
-            matchExpressions:
-            - key: cloud.sap/maintenance-state
-              operator: In
-              values:
-              - operational
-          weight: 1
-        - preference:
-            matchExpressions:
-            - key: cloud.sap/deployment-state
-              operator: NotIn
-              values:
-              - reinstalling
-          weight: 1
+          - preference:
+              matchExpressions:
+                - key: cloud.sap/maintenance-state
+                  operator: In
+                  values:
+                    - operational
+            weight: 1
+          - preference:
+              matchExpressions:
+                - key: cloud.sap/deployment-state
+                  operator: NotIn
+                  values:
+                    - reinstalling
+            weight: 1
       podAntiAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 50
@@ -271,20 +271,20 @@ haproxy:
     advanced:
       nodeAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:
-        - preference:
-            matchExpressions:
-            - key: cloud.sap/maintenance-state
-              operator: In
-              values:
-              - operational
-          weight: 1
-        - preference:
-            matchExpressions:
-            - key: cloud.sap/deployment-state
-              operator: NotIn
-              values:
-              - reinstalling
-          weight: 1
+          - preference:
+              matchExpressions:
+                - key: cloud.sap/maintenance-state
+                  operator: In
+                  values:
+                    - operational
+            weight: 1
+          - preference:
+              matchExpressions:
+                - key: cloud.sap/deployment-state
+                  operator: NotIn
+                  values:
+                    - reinstalling
+            weight: 1
       podAntiAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 50

--- a/common/rabbitmq/values.yaml
+++ b/common/rabbitmq/values.yaml
@@ -99,8 +99,8 @@ alerts:
   # Configurable service label of the alerts. Defaults to `.Release.Name`.
   # service:
 
-kind: deployment  # needs to be statefulset with persistence.enabled and ...
-replicas: 1       # replicas more than one. Clustering is currently not implemented
+kind: deployment # needs to be statefulset with persistence.enabled and ...
+replicas: 1 # replicas more than one. Clustering is currently not implemented
 pdr:
   enabled: true
   minAvailable: "51%" # 50% should technically be enough, but just to be safe

--- a/common/rabbitmq_cluster/Chart.yaml
+++ b/common/rabbitmq_cluster/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq_cluster
-version: 0.1.10
+version: 0.1.11
 description: A Helm chart for RabbitMQ managed with a help of operators
 sources:
 - https://www.rabbitmq.com/kubernetes/operator/operator-overview.html

--- a/common/rabbitmq_cluster/ci/test-values.yaml
+++ b/common/rabbitmq_cluster/ci/test-values.yaml
@@ -4,7 +4,7 @@ global:
   dockerHubMirror: "some.mirror.com"
   dockerHubMirrorAlternateRegion: "other.dockerhub.mirror"
 
-priority_class: "openstack-service-critical"
+priority_class: "critical-infrastructure"
 
 ssl_options:
   verify: test

--- a/common/rabbitmq_cluster/templates/cluster.yaml
+++ b/common/rabbitmq_cluster/templates/cluster.yaml
@@ -69,7 +69,7 @@ spec:
         template:
           spec:
             containers: []
-            priorityClassName: {{ default "openstack-service-critical" .Values.priority_class | quote }}
+            priorityClassName: {{ default "critical-infrastructure" .Values.priority_class | quote }}
             topologySpreadConstraints:
             - maxSkew: 1
               topologyKey: "topology.kubernetes.io/zone"

--- a/common/rabbitmq_cluster/values.yaml
+++ b/common/rabbitmq_cluster/values.yaml
@@ -5,7 +5,7 @@ image: library/rabbitmq
 imageTag: 3.9-management
 
 # name of priorityClass to influence scheduling priority
-# priority_class: "openstack-service-critical"
+# priority_class: "critical-infrastructure"
 
 users:
   default:

--- a/global/percona_cluster/Chart.yaml
+++ b/global/percona_cluster/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: percona_cluster
-version: 1.1.7
+version: 1.1.8
 appVersion: 5.7.19
 description: free, fully compatible, enhanced, open source drop-in replacement for
   MySQL with Galera Replication (xtradb)

--- a/global/percona_cluster/templates/statefulset.yaml
+++ b/global/percona_cluster/templates/statefulset.yaml
@@ -207,7 +207,7 @@ spec:
           initialDelaySeconds: 30
           timeoutSeconds: 2
       {{ end }}
-      priorityClassName: {{ default "openstack-service-critical" .Values.priority_class | quote }}
+      priorityClassName: {{ default "critical-infrastructure" .Values.priority_class | quote }}
       volumes:
       - name: slash-root
         emptyDir: {}

--- a/system/descheduler/values.yaml
+++ b/system/descheduler/values.yaml
@@ -45,25 +45,25 @@ deschedulerPolicy:
     RemoveDuplicates:
       enabled: true
       params:
-        thresholdPriorityClassName: openstack-service-critical
+        thresholdPriorityClassName: critical-infrastructure
     RemovePodsViolatingNodeTaints:
       enabled: true
       params:
-        thresholdPriorityClassName: openstack-service-critical
+        thresholdPriorityClassName: critical-infrastructure
     RemovePodsViolatingNodeAffinity:
       enabled: true
       params:
-        thresholdPriorityClassName: openstack-service-critical
+        thresholdPriorityClassName: critical-infrastructure
         nodeAffinityType:
         - requiredDuringSchedulingIgnoredDuringExecution
     RemovePodsViolatingInterPodAntiAffinity:
       enabled: true
       params:
-        thresholdPriorityClassName: openstack-service-critical
+        thresholdPriorityClassName: critical-infrastructure
     LowNodeUtilization:
       enabled: true
       params:
-        thresholdPriorityClassName: openstack-service-critical
+        thresholdPriorityClassName: critical-infrastructure
         nodeResourceUtilizationThresholds:
           thresholds:
             cpu: 20
@@ -76,7 +76,7 @@ deschedulerPolicy:
     HighNodeUtilization:
       enabled: true
       params:
-        thresholdPriorityClassName: openstack-service-critical
+        thresholdPriorityClassName: critical-infrastructure
         nodeResourceUtilizationThresholds:
           thresholds:
             "cpu" : 20


### PR DESCRIPTION
Migrate old PriorityClass to the equivalent one in the new scheme. openstack-service-critical will stay in the metal cluster for now.