### PR TITLE
[mariadb] remove user and password from readyness and lifeness probes

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.16.1 - 2025/02/18
+* enquote password in /root/.my.cnf
+  * this would allow to use `=` and `#` symbols in password
+* chart version bumped
+
 ## v0.16.0 - 2025/02/17
 * remove user and password from readiness and liveness probes
   * `/root/.my.cnf` is used instead

--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.16.0 - 2025/02/17
+* remove user and password from readiness and liveness probes
+  * `/root/.my.cnf` is used instead
+  * this helps avoiding problems with shell escaping and showing passwords in the processlist of the k8s nodes
+* chart version bumped
+
 ## v0.15.5 - 2025/02/14
 * `maria-back-me-up` (backup-v2) oauth secret moved to a separate `Secret`
 * chart version bumped

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.16.0
+version: 0.16.1

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.15.5
+version: 0.16.0

--- a/common/mariadb/templates/_helpers.tpl
+++ b/common/mariadb/templates/_helpers.tpl
@@ -34,6 +34,19 @@
 {{- end -}}
 {{- end -}}
 
+{{/*
+This function resolves a secret and escapes it for use in a my.cnf file.
+It replaces backslashes with double backslashes.
+ */}}
+{{- define "mariadb.resolve_secret_for_ini" }}
+    {{- $str := . -}}
+    {{- if (hasPrefix "vault+kvv2" $str ) -}}
+        {{"{{"}} resolve "{{ $str }}" | replace "\\" "\\\\" | squote {{"}}"}}
+    {{- else -}}
+        {{ $str | replace "\\" "\\\\" | squote }}
+{{- end }}
+{{- end }}
+
 {{- define "mariadb.root_password" -}}
 {{- include "mariadb.resolve_secret" (required ".Values.root_password missing" .Values.root_password) }}
 {{- end -}}

--- a/common/mariadb/templates/client-secret.yaml
+++ b/common/mariadb/templates/client-secret.yaml
@@ -6,4 +6,4 @@ metadata:
     {{- include "mariadb.labels" (list $ "version" "mariadb" "secret" "database") | indent 4 }}
 data:
   .my.cnf: |
-{{ include ( print .Template.BasePath "/config/_client.cnf.tpl" ) . | trim | b64enc | indent 4 }}
+{{ include ( print .Template.BasePath "/config/_client.cnf.tpl" ) . | b64enc | indent 4 }}

--- a/common/mariadb/templates/config/_client.cnf.tpl
+++ b/common/mariadb/templates/config/_client.cnf.tpl
@@ -1,4 +1,4 @@
 [client]
 port     = 3306
 socket   = /var/run/mysqld/mysqld.sock
-password = {{ include "mariadb.root_password" . }}
+password = {{ include "mariadb.resolve_secret_for_ini" (required ".Values.root_password missing" .Values.root_password) }}

--- a/common/mariadb/templates/deployment.yaml
+++ b/common/mariadb/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
         lifecycle:
           postStart:
             exec:
-              command: ["sh", "-c", "while ! mysqladmin ping -uroot -p$MYSQL_ROOT_PASSWORD --silent; do sleep 1; done; mysql_upgrade"]
+              command: ["sh", "-c", "while ! mysqladmin ping --silent; do sleep 1; done; mysql_upgrade"]
         env:
         - name: MYSQL_ROOT_PASSWORD
           valueFrom:
@@ -73,7 +73,7 @@ spec:
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           exec:
-            command: ["sh", "-c", "exec mysqladmin status -uroot -p$MYSQL_ROOT_PASSWORD"]
+            command: ["sh", "-c", "exec mysqladmin status"]
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -83,7 +83,7 @@ spec:
         {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
           exec:
-            command: ["sh", "-c", "exec mysqladmin status -uroot -p$MYSQL_ROOT_PASSWORD"]
+            command: ["sh", "-c", "exec mysqladmin status"]
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}


### PR DESCRIPTION
With the credentials for the root user present in /root/.my.cnf we do not need to give them as parameters for the probes, avoiding problems with shell escaping and showing passwords in the processlist of the k8s nodes.