### PR TITLE
Nova: Set PYTHONWARNINGS by default

### DIFF
--- a/openstack/nova/templates/hypervisors/hypervisors-vmware-deployment-vct.yaml
+++ b/openstack/nova/templates/hypervisors/hypervisors-vmware-deployment-vct.yaml
@@ -82,8 +82,10 @@ template: |
             value: "localhost"
           - name: STATSD_PORT
             value: "9125"
+          {{- if .Values.python_warnings }}
           - name: PYTHONWARNINGS
-            value: "ignore:Unverified HTTPS request"
+            value: {{ .Values.python_warnings | quote }}
+          {{- end }}
           {{- if .Values.pod.resources.hv_vmware }}
           resources:
 {{ toYaml .Values.pod.resources.hv_vmware | indent 12 }}

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -985,3 +985,7 @@ vpa:
   # The maximum available capacity is split evenly across containers specified in the Deployment, StatefulSet or DaemonSet to derive the upper recommendation bound. This does not work out for pods with a single resource-hungry container with several sidecar containers
   # Annotate the Deployment, StatefulSet or DaemonSet with vpa-butler.cloud.sap/main-container=$MAIN_CONTAINER. That will distribute 75% of the maximum available capacity to the main container and the rest evenly across all others
   set_main_container: true
+
+
+# used to set the PYTHONWARNINGS environment variable everywhere
+python_warnings: "ignore:Unverified HTTPS request,ignore::SyntaxWarning"


### PR DESCRIPTION
We want to ignore certain warnings from Python, especially the `SyntaxWarning`, because it gets logged for `pymemcache` seemingly outside of a `GreenThread` which can lead to services hanging in locks.

We also switch the VMware Hypervisor Deployment to use the same value `python_warnings` as we already use for any other Deployment.