### PR TITLE
[memcached] version bumped to 1.6.31-alpine3.20

### DIFF
--- a/common/memcached/CHANGELOG.md
+++ b/common/memcached/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+## v0.6.0 - 2024/10/15
+* version info added to labels
+  * to allow gatekeeper rules based on them
+* old (non-standard) labels removed
+* memcached version bumped to `1.6.31-alpine3.20`
+  * added alpine version to the tag to enforce exactly this version
+* chart version bumped
+
+### label example
+```yaml
+labels:
+  app.kubernetes.io/name: memcached
+  app.kubernetes.io/instance: keystone-memcached
+  app.kubernetes.io/component: memcached-deployment-kvstore
+  app.kubernetes.io/part-of: keystone
+  app.kubernetes.io/version: 1.6.31
+  app.kubernetes.io/managed-by: "helm"
+  helm.sh/chart: memcached-0.6.0
+```
+### removed labels
+```yaml
+labels:
+   app: keystone-memcached
+   component: memcached
+   chart: "memcached-0.5.3"
+   release: "keystone"
+   heritage: "Helm"
+   type: configuration
+   application: keystone
+```
+### Prometheus label names that must be updated
+These labels must be updated if you use them in your Prometheus alerts definitions.
+- `app` must be `app_kubernetes_io_instance`
+- `component` must be `app_kubernetes_io_name`

--- a/common/memcached/Chart.yaml
+++ b/common/memcached/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: memcached
-version: 0.5.4
+version: 0.6.0
 description: Free & open source, high-performance, distributed memory object caching system.
 home: http://memcached.org/
 sources:
-- https://github.com/sapcc/helm-charts/common/memcached
+  - https://github.com/sapcc/helm-charts/common/memcached

--- a/common/memcached/templates/_helpers.tpl
+++ b/common/memcached/templates/_helpers.tpl
@@ -11,8 +11,8 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "fullname" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | replace "_" "-" | trimSuffix "-" -}}
+{{- $name := default $.Chart.Name $.Values.nameOverride -}}
+{{- printf "%s-%s" $.Release.Name $name | trunc 63 | replace "_" "-" | trimSuffix "-" -}}
 {{- end -}}
 
 {{/* Generate the service label for the templated Prometheus alerts. */}}
@@ -77,10 +77,43 @@ We've chosen not to use colons in these memcache secrets
                 - reinstalling
 {{- end }}
 
-{{- define "sharedservices.labels" }}
-app.kubernetes.io/name: {{ .Chart.Name }}
-app.kubernetes.io/instance: {{ .Chart.Name }}-{{ .Release.Name }}
-app.kubernetes.io/version: {{ .Chart.Version }}
-app.kubernetes.io/component: {{ .Chart.Name }}
-app.kubernetes.io/part-of: {{ .Release.Name }}
+{{/*
+  Generate labels
+  $ = global values
+  version/noversion = enable/disable version fields in labels
+  memcached = desired component name
+  job = object type
+  config = provided function
+  include "memcached.labels" (list $ "version" "memcached" "deployment" "kvstore")
+  include "memcached.labels" (list $ "version" "memcached" "job" "config")
+*/}}
+{{- define "memcached.labels" }}
+{{- $ := index . 0 }}
+{{- $component := index . 2 }}
+{{- $type := index . 3 }}
+{{- $function := index . 4 }}
+app.kubernetes.io/name: {{ $.Chart.Name }}
+app.kubernetes.io/instance: {{ template "fullname" $ }}
+app.kubernetes.io/component: {{ include "label.component" (list $component $type $function) }}
+app.kubernetes.io/part-of: {{ $.Release.Name }}
+  {{- if eq (index . 1) "version" }}
+app.kubernetes.io/version: {{ $.Values.imageTag | regexFind "[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}" }}
+app.kubernetes.io/managed-by: "helm"
+helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}
+  {{- end }}
+{{- end }}
+
+{{/*
+  Generate labels
+  memcached = desired component name
+  job = object type
+  config = provided function
+  include "label.component" (list "memcached" "deployment" "kvstore")
+  include "label.component" (list "memcached" "job" "config")
+*/}}
+{{- define "label.component" }}
+{{- $component := index . 0 }}
+{{- $type := index . 1 }}
+{{- $function := index . 2 }}
+{{- $component }}-{{ $type }}-{{ $function }}
 {{- end }}

--- a/common/memcached/templates/alerts.yaml
+++ b/common/memcached/templates/alerts.yaml
@@ -6,12 +6,8 @@ kind: PrometheusRule
 metadata:
   name: {{ template "fullname" . }}-memcached-alerts
   labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
     prometheus: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus }}
-    {{- include "sharedservices.labels" . | indent 4 }}
+    {{- include "memcached.labels" (list $ "version" "memcached" "prometheusrule" "alert") | indent 4 }}
 
 spec:
 {{ include (print .Template.BasePath "/alerts/_memcached.alerts.tpl") . | indent 2 }}

--- a/common/memcached/templates/alerts/_memcached.alerts.tpl
+++ b/common/memcached/templates/alerts/_memcached.alerts.tpl
@@ -2,7 +2,7 @@ groups:
 - name: memcached.alerts
   rules:
   - alert: {{ include "alerts.service" . | title }}MemcachedManyConnectionsThrottled
-    expr: (rate(memcached_connections_yielded_total{app="{{ template "fullname" . }}"}[5m]) * 60) > {{ .Values.alerts.yielded_connections_threshold }}
+    expr: (rate(memcached_connections_yielded_total{app_kubernetes_io_instance="{{ template "fullname" . }}"}[5m]) * 60) > {{ .Values.alerts.yielded_connections_threshold }}
     for: 5m
     labels:
       context: database
@@ -11,5 +11,5 @@ groups:
       tier: {{ required ".Values.alerts.tier missing" .Values.alerts.tier }}
       support_group: {{ required ".Values.alerts.support_group missing" .Values.alerts.support_group }}
     annotations:
-      description: 'Many client connections throttled in memcache of {{`{{ $labels.app }}`}}.'
+      description: 'Many client connections throttled in memcache of {{`{{ $labels.app_kubernetes_io_instance }}`}}.'
       summary: Many throttled client connections

--- a/common/memcached/templates/configmap.yaml
+++ b/common/memcached/templates/configmap.yaml
@@ -4,8 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-memcached-config
   labels:
-    type: configuration
-    application: {{ .Release.Name }}
+    {{- include "memcached.labels" (list $ "version" "memcached" "configmap" "kvstore") | indent 4 }}
 stringData:
   memcached.conf: |
     mech_list: plain

--- a/common/memcached/templates/deployment.yaml
+++ b/common/memcached/templates/deployment.yaml
@@ -3,11 +3,7 @@ apiVersion: apps/v1
 metadata:
   name: {{ template "fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
-    {{- include "sharedservices.labels" . | indent 4 }}
+    {{- include "memcached.labels" (list $ "version" "memcached" "deployment" "kvstore") | indent 4 }}
 spec:
   replicas: {{ .Values.replicas }}
   revisionHistoryLimit: {{ .Values.upgrades.revisionHistory }}
@@ -20,13 +16,11 @@ spec:
     {{ end }}
   selector:
     matchLabels:
-      app: {{ template "fullname" . }}
+      app.kubernetes.io/instance: {{ template "fullname" . }}
   template:
     metadata:
       labels:
-        app: {{ template "fullname" . }}
-        component: memcached
-        {{- include "sharedservices.labels" . | indent 8 }}
+        {{- include "memcached.labels" (list $ "version" "memcached" "deployment" "kvstore") | indent 8 }}
       annotations:
         {{- if and (and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested) $.Values.linkerd.enabled }}
         linkerd.io/inject: enabled

--- a/common/memcached/templates/secrets.yaml
+++ b/common/memcached/templates/secrets.yaml
@@ -4,8 +4,7 @@ kind: Secret
 metadata:
   name: {{ .Release.Name }}-memcached-secrets
   labels:
-    type: configuration
-    application: {{ .Release.Name }}
+    {{- include "memcached.labels" (list $ "version" "memcached" "secret" "kvstore") | indent 4 }}
 data:
   memcached-sasl-db: {{ include "memcached.sasl_pwdb" . | b64enc | quote }}
 {{- end }}

--- a/common/memcached/templates/service.yaml
+++ b/common/memcached/templates/service.yaml
@@ -3,12 +3,7 @@ kind: Service
 metadata:
   name: {{ template "fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
-    component: memcached
-    {{- include "sharedservices.labels" . | indent 4 }}
+    {{- include "memcached.labels" (list $ "version" "memcached" "service" "kvstore") | indent 4 }}
   annotations:
     {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
     linkerd.io/inject: enabled
@@ -20,7 +15,7 @@ metadata:
     {{- end }}
 spec:
   selector:
-    app: {{ template "fullname" . }}
+    app.kubernetes.io/instance: {{ template "fullname" . }}
   ports:
   - name: memcache
     port: {{ default "11211" .Values.memcached.port }}

--- a/common/memcached/values.yaml
+++ b/common/memcached/values.yaml
@@ -2,7 +2,7 @@
 ## ref: https://hub.docker.com/r/library/memcached/tags/
 ##
 image: library/memcached
-imageTag: 1.6.28-alpine
+imageTag: 1.6.31-alpine3.20
 # set to true to use .Values.global.dockerHubMirrorAlternateRegion instead of .Values.global.dockerHubMirror
 use_alternate_registry: false
 


### PR DESCRIPTION
- Memcached [1.6.31 Release Notes](https://github.com/memcached/memcached/wiki/ReleaseNotes1631)
- added alpine version tag to enforce exactly this version
- version info added to labels
  - to allow gatekeeper rules based on them
- old (non-standard) labels removed
- chart version bumped

## label example
```yaml
labels:
  app.kubernetes.io/name: memcached
  app.kubernetes.io/instance: keystone-memcached
  app.kubernetes.io/component: memcached-deployment-kvstore
  app.kubernetes.io/part-of: keystone
  app.kubernetes.io/version: 1.6.31
  app.kubernetes.io/managed-by: "helm"
  helm.sh/chart: memcached-0.6.0
```

## removed labels
```yaml
labels:
   app: keystone-memcached
   component: memcached
   chart: "memcached-0.5.3"
   release: "keystone"
   heritage: "Helm"
   type: configuration
   application: keystone
```