### PR TITLE
[Utils] Append urlencode in resolve_secret_urlencode

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.19.3
+version: 0.19.4

--- a/openstack/utils/templates/_hosts.tpl
+++ b/openstack/utils/templates/_hosts.tpl
@@ -11,9 +11,11 @@
     {{- $add_urlquery := index . 1 -}}
     {{- if (hasPrefix "vault+kvv2" $str) -}}
         {{"{{"}} resolve "{{ $str }}" {{ if $add_urlquery }}| urlquery {{ end }}{{"}}"}}
-    {{- else -}}
-        {{ $str }}
-{{- end -}}
+    {{- else if $add_urlquery }}
+        {{- $str | urlquery }}
+    {{- else }}
+        {{- $str  }}
+    {{- end }}
 {{- end -}}
 
 {{- define "resolve_secret" -}}


### PR DESCRIPTION
Using an old vault reference '*vault(path:..)' as input for resolve_secret_urlencode does not append an urlencode as the function name might indicate.

During the migration from old vault-injector to the new secret-injector, we observed this problem with some Neutron passwords. Removing the urlencode from our Chart (replacing it with a 'resolve_secret_urlencode') lead to an unencoded password. Simply appending an 'urlencode' back in our Chart does not work either if we migrate to the new vault reference would
urlencode the string '{{ resolve vault+kvv2:///some/path }}'. Assuming the secret-injector does not pick this up.