### PR TITLE
[rabbitmq] Use urlquery in `resolve_secret_urlquery` for non-vault values

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -3,6 +3,10 @@ Rabbitmq CHANGELOG
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+0.11.2
+------
+- Append urlquery in `rabbitmq.resolve_secret_urlquery` function for non-vault values
+
 0.11.1
 ------
 nathan.oyler@sap.com

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 0.11.1
+version: 0.11.2
 appVersion: 3.13.6
 description: A Helm chart for RabbitMQ
 sources:

--- a/common/rabbitmq/templates/_helpers.tpl
+++ b/common/rabbitmq/templates/_helpers.tpl
@@ -20,8 +20,8 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
     {{- if (hasPrefix "vault+kvv2" $str ) -}}
         {{"{{"}} resolve "{{ $str }}" | urlquery {{"}}"}}
     {{- else -}}
-        {{ $str }}
-{{- end -}}
+        {{ $str | urlquery }}
+    {{- end -}}
 {{- end -}}
 
 {{define "rabbitmq.release_host"}}{{.Release.Name}}-rabbitmq{{end}}


### PR DESCRIPTION
Append urlquery in `rabbitmq.resolve_secret_urlquery` function for non-vault values

Similar to https://github.com/sapcc/helm-charts/pull/7250