### PR TITLE
[manila][rabbitmq] Use utils helper for rabbitmq transport_url

### DIFF
--- a/openstack/manila/Chart.lock
+++ b/openstack/manila/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 0.5.3
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.3.5
+  version: 0.3.6
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.3
@@ -16,12 +16,12 @@ dependencies:
   version: 0.11.1
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.16.2
+  version: 0.19.4
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.5.2
+  version: 1.5.3
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.4
-digest: sha256:9cf5f40b29b548fe1af2fa972d2e205dd4d3553473a3271aa1713129aa54a030
-generated: "2024-09-25T11:24:34.972135+02:00"
+digest: sha256:041744ef8ab83146dc2e7ea0f90b120d7f3159b7e3aab7ff4a4d6bd5d8b269fa
+generated: "2024-10-16T13:58:36.087751+03:00"

--- a/openstack/manila/Chart.yaml
+++ b/openstack/manila/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: manila
 sources:
   - https://github.com/sapcc/manila
-version: 0.3.16
+version: 0.3.17
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
@@ -31,7 +31,7 @@ dependencies:
     version: ~0.11.1
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.16.0
+    version: ~0.19.0
   - name: redis
     alias: api-ratelimit-redis
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/manila/templates/etc/_secrets.conf.tpl
+++ b/openstack/manila/templates/etc/_secrets.conf.tpl
@@ -1,5 +1,5 @@
 [DEFAULT]
-transport_url = {{ include "rabbitmq.transport_url" . }}
+{{- include "ini_sections.default_transport_url" . }}
 
 {{- include "ini_sections.database" . }}
 


### PR DESCRIPTION
* Use utils `ini_sections.default_transport_url` helper instead of rabbitmq
* Update utils chart from 0.16.0 to 0.19.4 (secrets-injector support)
* Update mysql_metrics chart to 0.3.6 (pxc-db support)
* Update redis chart to 1.5.3 (update redis-exporter version)