### PR TITLE
[neutron] typo in conf file name for dhcp readiness probe

### DIFF
--- a/openstack/neutron/templates/statefulset-network-agent.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent.yaml
@@ -104,7 +104,7 @@ spec:
             {{- include "utils.trust_bundle.env" $ | indent 12 }}
           readinessProbe:
             exec:
-              command: ["neutron-dhcp-readiness", "-config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/secrets/neutron-common-secrets.conff"]
+              command: ["neutron-dhcp-readiness", "-config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/secrets/neutron-common-secrets.conf"]
             initialDelaySeconds: 30
             periodSeconds: 60
             timeoutSeconds: 10


### PR DESCRIPTION
There was a typo in the neutron-dhcp-agent readiness probe call making it look for neutron-common-secrets.conff.

Introduced in commit ada6dae2ffe02438f3f1362c5896512928b679db