### PR TITLE
[Neutron] Use SFTP secrets with secrets-injector

### DIFF
--- a/openstack/neutron/templates/etc/_sftp.conf.tpl
+++ b/openstack/neutron/templates/etc/_sftp.conf.tpl
@@ -20,7 +20,7 @@ swift_expire = 1209600
 # OpenStack configurations
 os_identity_endpoint   = "http://keystone.{{ default .Release.Namespace .Values.global.keystoneNamespace }}.svc.kubernetes.{{.Values.global.region}}.{{.Values.global.tld}}:5000/v3"
 os_username            = "{{.Values.sftp.user}}"
-os_password            = {{ .Values.sftp.os_password | required "Please set .Values.sftp.os_password" | include "resolve_secret" | quote }}
+os_password            = "{{ .Values.sftp.os_password | required "Please set .Values.sftp.os_password" | include "resolve_secret"}}"
 os_user_domain_name    = "Default"
 os_project_name        = "master"
 os_project_domain_name = "ccadmin"

--- a/openstack/neutron/templates/etc/_ssh_host_id_ec.tpl
+++ b/openstack/neutron/templates/etc/_ssh_host_id_ec.tpl
@@ -1,1 +1,1 @@
-{{ .Values.sftp.server_key | required "Please set .Values.sftp.server_key" }}
+{{- .Values.sftp.server_key | required "Please set .Values.sftp.server_key" -}}


### PR DESCRIPTION
[Neutron] Use SFTP secrets with secrets-injector
1. Remove leading and trailing white spaces from sftp_server key.
2. Quoting a vault reference, created via the helper function resolve_secret helper, 'quote'
causes the secrets-injector failure resolving the reference.