### PR TITLE
nova/flavors: Add KVM v1 (Cascade-Lake) flavors

### DIFF
--- a/openstack/sap-seeds/templates/_flavors_hana_exclusive.tpl
+++ b/openstack/sap-seeds/templates/_flavors_hana_exclusive.tpl
@@ -225,3 +225,111 @@
     "quota:instance_only": "true"
     "quota:separate": "true"
     {{- end }}
+
+# KVM HANA Flavors
+{{- if .Values.kvm_enabled }}
+- name: "hana_c30_m240_k1"
+  id: "320"
+  vcpus: 30
+  ram: 245760
+  disk: 64
+  extra_specs:
+    {{ tuple . "kvm_hana" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
+    "trait:CUSTOM_NUMASIZE_C48_M729": "required"
+    "reservation:cpu": "28"
+    {{- if ( .Values.hana_flavors_quota_separate ) }}
+    "quota:instance_only": "true"
+    "quota:separate": "true"
+    {{- end }}
+- name: "hana_c60_m480_k1"
+  id: "321"
+  vcpus: 60
+  ram: 491520
+  disk: 64
+  extra_specs:
+    {{ tuple . "kvm_hana" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
+    "trait:CUSTOM_NUMASIZE_C48_M729": "required"
+    "reservation:cpu": "57"
+    {{- if ( .Values.hana_flavors_quota_separate ) }}
+    "quota:instance_only": "true"
+    "quota:separate": "true"
+    {{- end }}
+- name: "hana_c120_m960_k1"
+  id: "322"
+  vcpus: 120
+  ram: 983040
+  disk: 64
+  extra_specs:
+    {{ tuple . "kvm_hana" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
+    "trait:CUSTOM_NUMASIZE_C48_M729": "required"
+    "reservation:cpu": "114"
+    {{- if ( .Values.hana_flavors_quota_separate ) }}
+    "quota:instance_only": "true"
+    "quota:separate": "true"
+    {{- end }}
+- name: "hana_c30_m480_k1"
+  id: "323"
+  vcpus: 30
+  ram: 491520
+  disk: 64
+  extra_specs:
+    {{ tuple . "kvm_hana" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
+    "trait:CUSTOM_NUMASIZE_C48_M729": "required"
+    "reservation:cpu": "28"
+    {{- if ( .Values.hana_flavors_quota_separate ) }}
+    "quota:instance_only": "true"
+    "quota:separate": "true"
+    {{- end }}
+- name: "hana_c60_m960_k1"
+  id: "324"
+  vcpus: 60
+  ram: 983040
+  disk: 64
+  extra_specs:
+    {{ tuple . "kvm_hana" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
+    "trait:CUSTOM_NUMASIZE_C48_M729": "required"
+    "reservation:cpu": "57"
+    {{- if ( .Values.hana_flavors_quota_separate ) }}
+    "quota:instance_only": "true"
+    "quota:separate": "true"
+    {{- end }}
+- name: "hana_c120_m1920_k1"
+  id: "325"
+  vcpus: 120
+  ram: 1966080
+  disk: 64
+  extra_specs:
+    {{ tuple . "kvm_hana" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
+    "trait:CUSTOM_NUMASIZE_C48_M729": "required"
+    "reservation:cpu": "114"
+    {{- if ( .Values.hana_flavors_quota_separate ) }}
+    "quota:instance_only": "true"
+    "quota:separate": "true"
+    {{- end }}
+- name: "hana_c180_m2880_k1"
+  id: "326"
+  vcpus: 180
+  ram: 2949120
+  disk: 64
+  extra_specs:
+    {{ tuple . "kvm_hana" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
+    "trait:CUSTOM_NUMASIZE_C48_M729": "required"
+    "reservation:cpu": "171"
+    {{- if ( .Values.hana_flavors_quota_separate ) }}
+    "quota:instance_only": "true"
+    "quota:separate": "true"
+    {{- end }}
+- name: "hana_c240_m3840_k1"
+  id: "327"
+  vcpus: 240
+  ram: 3932160
+  disk: 64
+  extra_specs:
+    {{ tuple . "kvm_hana" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
+    "trait:CUSTOM_NUMASIZE_C48_M729": "required"
+    "reservation:cpu": "228"
+    {{- if ( .Values.hana_flavors_quota_separate ) }}
+    "quota:instance_only": "true"
+    "quota:separate": "true"
+    {{- end }}
+{{- end}}  # kvm_enabled

--- a/openstack/sap-seeds/templates/_flavors_hana_no_exclusive.tpl
+++ b/openstack/sap-seeds/templates/_flavors_hana_no_exclusive.tpl
@@ -211,3 +211,106 @@
     "quota:instance_only": "true"
     "quota:separate": "true"
     {{- end }}
+
+# KVM HANA flavors
+{{- if .Values.kvm_enabled }}
+- name: "hana_k_c30_m240_v1"
+  id: "320"
+  vcpus: 30
+  ram: 245760
+  disk: 64
+  extra_specs:
+    {{ tuple . "kvm_common" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
+    "trait:CUSTOM_NUMASIZE_C48_M729": "required"
+    {{- if ( .Values.hana_flavors_quota_separate ) }}
+    "quota:instance_only": "true"
+    "quota:separate": "true"
+    {{- end }}
+- name: "hana_k_c60_m480_v1"
+  id: "321"
+  vcpus: 60
+  ram: 491520
+  disk: 64
+  extra_specs:
+    {{ tuple . "kvm_common" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
+    "trait:CUSTOM_NUMASIZE_C48_M729": "required"
+    {{- if ( .Values.hana_flavors_quota_separate ) }}
+    "quota:instance_only": "true"
+    "quota:separate": "true"
+    {{- end }}
+- name: "hana_k_c120_m960_v1"
+  id: "322"
+  vcpus: 120
+  ram: 983040
+  disk: 64
+  extra_specs:
+    {{ tuple . "kvm_common" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
+    "trait:CUSTOM_NUMASIZE_C48_M729": "required"
+    {{- if ( .Values.hana_flavors_quota_separate ) }}
+    "quota:instance_only": "true"
+    "quota:separate": "true"
+    {{- end }}
+- name: "hana_k_c30_m480_v1"
+  id: "323"
+  vcpus: 30
+  ram: 491520
+  disk: 64
+  extra_specs:
+    {{ tuple . "kvm_common" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
+    "trait:CUSTOM_NUMASIZE_C48_M729": "required"
+    {{- if ( .Values.hana_flavors_quota_separate ) }}
+    "quota:instance_only": "true"
+    "quota:separate": "true"
+    {{- end }}
+- name: "hana_k_c60_m960_v1"
+  id: "324"
+  vcpus: 60
+  ram: 983040
+  disk: 64
+  extra_specs:
+    {{ tuple . "kvm_common" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
+    "trait:CUSTOM_NUMASIZE_C48_M729": "required"
+    {{- if ( .Values.hana_flavors_quota_separate ) }}
+    "quota:instance_only": "true"
+    "quota:separate": "true"
+    {{- end }}
+- name: "hana_k_c120_m1920_v1"
+  id: "325"
+  vcpus: 120
+  ram: 1966080
+  disk: 64
+  extra_specs:
+    {{ tuple . "kvm_common" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
+    "resources:CUSTOM_BIGVM": "2"
+    "trait:CUSTOM_NUMASIZE_C48_M729": "required"
+    {{- if ( .Values.hana_flavors_quota_separate ) }}
+    "quota:instance_only": "true"
+    "quota:separate": "true"
+    {{- end }}
+- name: "hana_k_c180_m2880_v1"
+  id: "326"
+  vcpus: 180
+  ram: 2949120
+  disk: 64
+  extra_specs:
+    {{ tuple . "kvm_common" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
+    "resources:CUSTOM_BIGVM": "2"
+    "trait:CUSTOM_NUMASIZE_C48_M729": "required"
+    {{- if ( .Values.hana_flavors_quota_separate ) }}
+    "quota:instance_only": "true"
+    "quota:separate": "true"
+    {{- end }}
+- name: "hana_k_c240_m3840_v1"
+  id: "327"
+  vcpus: 240
+  ram: 3932160
+  disk: 64
+  extra_specs:
+    {{ tuple . "kvm_common" | include "sap_seeds.helpers.extra_specs" | indent 4 }}
+    "resources:CUSTOM_BIGVM": "2"
+    "trait:CUSTOM_NUMASIZE_C48_M729": "required"
+    {{- if ( .Values.hana_flavors_quota_separate ) }}
+    "quota:instance_only": "true"
+    "quota:separate": "true"
+    {{- end }}
+{{- end}}  # kvm_enabled

--- a/openstack/sap-seeds/templates/flavor-seed.yaml
+++ b/openstack/sap-seeds/templates/flavor-seed.yaml
@@ -991,7 +991,431 @@ spec:
       "hw:cpu_cores": "64"  # used in nova-vmware as cores-per-socket (32pCPU = 64vCPU)
       "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
 
-
+  ### KVM flavors
+{{- if .Values.kvm_enabled }}
+  # - name: "k_m1.tiny_v1"  # m1.tiny
+  #   id: "601"
+  #   vcpus: 1
+  #   ram: 512
+  #   disk: 1
+  #   is_public: true
+  #   extra_specs:
+  #     {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  - name: "g_k_c1_m2_v1"
+    id: "602"
+    vcpus: 1
+    ram: 2032
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  - name: "c_k_c2_m2_v1"
+    id: "603"
+    vcpus: 2
+    ram: 2032
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  - name: "g_k_c2_m4_v1"
+    id: "604"
+    vcpus: 2
+    ram: 4080
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  - name: "g_k_c1_m3_v1"
+    id: "605"
+    vcpus: 1
+    ram: 3056
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  - name: "g_k_c1_m4_v1"
+    id: "606"
+    vcpus: 1
+    ram: 4080
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  - name: "g_k_c2_m8_v1"
+    id: "607"
+    vcpus: 2
+    ram: 8176
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  - name: "c_k_c4_m4_v1"
+    id: "608"
+    vcpus: 4
+    ram: 4080
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  - name: "g_k_c4_m8_v1"
+    id: "609"
+    vcpus: 4
+    ram: 8176
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  - name: "g_k_c4_m16_v1"
+    id: "610"
+    vcpus: 4
+    ram: 16368
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  - name: "c_k_c16_m16_v1"
+    id: "611"
+    vcpus: 16
+    ram: 16368
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  - name: "g_k_c6_m24_v1"
+    id: "612"
+    vcpus: 6
+    ram: 24560
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  - name: "g_k_c8_m32_v1"
+    id: "613"
+    vcpus: 8
+    ram: 32752
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  - name: "g_k_c16_m32_v1"
+    id: "614"
+    vcpus: 16
+    ram: 32752
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  - name: "g_k_c12_m48_v1"
+    id: "615"
+    vcpus: 12
+    ram: 49136
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  - name: "g_k_c16_m64_v1"
+    id: "616"
+    vcpus: 16
+    ram: 65520
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  # - name: "g_k_c40_m160_v1"  # m1.10xlarge
+  #   id: "617"
+  #   vcpus: 40
+  #   ram: 163824
+  #   disk: 64
+  #   is_public: true
+  #   extra_specs:
+  #     {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  # - name: "m_k_c16_m160_v1"  # m1.10xlargesmallcpu
+  #   id: "618"
+  #   vcpus: 16
+  #   ram: 163824
+  #   disk: 64
+  #   is_public: true
+  #   extra_specs:
+  #     {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  - name: "m_k_c8_m128_v1"
+    id: "619"
+    vcpus: 8
+    ram: 131056
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  - name: "m_k_c16_m256_v1"
+    id: "620"
+    vcpus: 16
+    ram: 262128
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  - name: "m_k_c32_m512_v1"
+    id: "621"
+    vcpus: 32
+    ram: 524272
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  # - name: "m_k_c64_m1024_v1"  # x1.8xmemory
+  #   id: "622"
+  #   vcpus: 64
+  #   ram: 1048560
+  #   disk: 64
+  #   is_public: false
+  #   extra_specs:
+  #     {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  #     "hw:cpu_cores": "64"  # used in nova-vmware as cores-per-socket (32pCPU = 64vCPU)
+  - name: "m_k_c4_m64_v1"
+    id: "623"
+    vcpus: 4
+    ram: 65520
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  - name: "g_k_c8_m16_v1"
+    id: "624"
+    vcpus: 8
+    ram: 16368
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  # - name: "g_k_c8_m24_v1"  # m2.2xlarge
+  #   id: "625"
+  #   vcpus: 8
+  #   ram: 24560
+  #   disk: 64
+  #   is_public: true
+  #   extra_specs:
+  #     {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  # - name: "c_k_c24_m24_v1"  # m2.2xlarge_cpu
+  #   id: "626"
+  #   vcpus: 24
+  #   ram: 24560
+  #   disk: 64
+  #   is_public: true
+  #   extra_specs:
+  #     {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  # - name: "m_k_c24_m256_v1"  # m2.10xlarge_cpu
+  #   id: "627"
+  #   vcpus: 24
+  #   ram: 262128
+  #   disk: 64
+  #   is_public: true
+  #   extra_specs:
+  #     {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  # - name: "m_k_c24_m320_v1"  # m2.14xlarge_cpu
+  #   id: "628"
+  #   vcpus: 24
+  #   ram: 327680
+  #   disk: 64
+  #   is_public: true
+  #   extra_specs:
+  #     {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  # - name: "m_k_c24_m320_v1"  # m2.14xlarge_cpuhdd
+  #   id: "629"
+  #   vcpus: 24
+  #   ram: 327680
+  #   disk: 64
+  #   is_public: true
+  #   extra_specs:
+  #     {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  # - name: "m_k_c8_m48_v1"  # m2.3xlarge
+  #   id: "630"
+  #   vcpus: 8
+  #   ram: 49136
+  #   disk: 64
+  #   is_public: true
+  #   extra_specs:
+  #     {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  - name: "m_k_c2_m16_v1"
+    id: "631"
+    vcpus: 2
+    ram: 16368
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  - name: "m_k_c4_m32_v1"
+    id: "652"
+    vcpus: 4
+    ram: 32752
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  - name: "m_k_c8_m64_v1"
+    id: "632"
+    vcpus: 8
+    ram: 65520
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  - name: "m_k_c8_m256_v1"
+    id: "633"
+    vcpus: 8
+    ram: 262128
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  - name: "m_k_c20_m160_v1"
+    id: "634"
+    vcpus: 20
+    ram: 163824
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  - name: "m_k_c24_m192_v1"
+    id: "635"
+    vcpus: 24
+    ram: 196592
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  - name: "m_k_c16_m128_v1"
+    id: "636"
+    vcpus: 16
+    ram: 131056
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  # - name: "m_k_c16_m200_v1"  # m2.16xlarge
+  #   id: "637"
+  #   vcpus: 16
+  #   ram: 204800
+  #   disk: 64
+  #   is_public: true
+  #   extra_specs:
+  #     {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  - name: "m_k_c16_m512_v1"
+    id: "638"
+    vcpus: 16
+    ram: 524272
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  - name: "g_k_c24_m96_v1"
+    id: "651"
+    vcpus: 24
+    ram: 98288
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  - name: "g_k_c32_m128_v1"
+    id: "639"
+    vcpus: 32
+    ram: 131056
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  - name: "g_k_c48_m192_v1"
+    id: "640"
+    vcpus: 48
+    ram: 196592
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  # - name: "g_k_c4_m16_v1"  # m5.xlarge2hdd
+  #   id: "641"
+  #   vcpus: 4
+  #   ram: 16368
+  #   disk: 150
+  #   is_public: false
+  #   extra_specs:
+  #     {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  # - name: "m_k_c48_m512_v1"  # m5.12xlarge
+  #   id: "642"
+  #   vcpus: 48
+  #   ram: 524272
+  #   disk: 64
+  #   is_public: true
+  #   extra_specs:
+  #     {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  # - name: "m_k_c60_m512_v1"  # m5.14xlarge
+  #   id: "643"
+  #   vcpus: 60
+  #   ram: 524272
+  #   disk: 64
+  #   is_public: true
+  #   extra_specs:
+  #     {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  - name: "m_k_c32_m256_v1"
+    id: "644"
+    vcpus: 32
+    ram: 262128
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  - name: "m_k_c64_m512_v1"
+    id: "645"
+    vcpus: 64
+    ram: 524272
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "hw:cpu_cores": "64"  # used in nova-vmware as cores-per-socket (32pCPU = 64vCPU)
+  - name: "g_k_c64_m256_v1"
+    id: "646"
+    vcpus: 64
+    ram: 262128
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "hw:cpu_cores": "64"  # used in nova-vmware as cores-per-socket (32pCPU = 64vCPU)
+  - name: "m_k_c48_m512_v1"
+    id: "647"
+    vcpus: 48
+    ram: 524272
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  - name: "g_k_c128_m512_v1"
+    id: "648"
+    vcpus: 128
+    ram: 524272
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "hw:cpu_cores": "64"  # used in nova-vmware as cores-per-socket (32pCPU = 64vCPU)
+  # - name: "m_k_c96_m1024_v1"  # m5.48xlarge
+  #   id: "649"
+  #   vcpus: 96
+  #   ram: 1048560
+  #   disk: 64
+  #   is_public: true
+  #   extra_specs:
+  #     {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+  #     "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
+  - name: "m_k_c128_m1000_v1"
+    id: "650"
+    vcpus: 128
+    ram: 1048560
+    disk: 64
+    is_public: true
+    extra_specs:
+      {{- tuple . "kvm" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "hw:cpu_cores": "64"  # used in nova-vmware as cores-per-socket (32pCPU = 64vCPU)
+{{- end }}  # kvm_enabled
 
   ### HANA flavors
 {{- if .Values.use_hana_exclusive }}

--- a/openstack/sap-seeds/values.yaml
+++ b/openstack/sap-seeds/values.yaml
@@ -3,6 +3,8 @@
 use_hana_exclusive: false
 # whether to use separate quota for each hana-flavor for pay-per-use billing
 hana_flavors_quota_separate: false
+# whether to seed KVM flavors
+kvm_enabled: false
 
 owner-info:
   support-group: compute-storage-api
@@ -32,4 +34,14 @@ extra_specs:
     "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
   vmware_hana_exclusive:
     <<: *vmware_common
+    "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "required"
+  kvm_common: &kvm_common
+    "capabilities:hypervisor_type": "QEMU"
+    "hw:mem_page_size": "large"
+    "hw_video:ram_max_mb": "16"
+  kvm:
+    <<: *kvm_common
+    "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
+  kvm_hana:
+    <<: *kvm_common
     "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "required"


### PR DESCRIPTION
As agreed in ADR core/nova/0008 "KVM flavor naming scheme" the KVM flavors (and eventually, but not in this change, the VMware flavors too) gain a new hypervisor field after the g/c/m purpose field. It's "k" for KVM/Qemu (and will be "v" for VMware).

Also the flavors will be suffixed with a "v1" hardware generation number for Cascade Lake right away.

So, the KVM counterpart for "g_c4_m16" is named "g_k_c4_m16_v1".

A per-region config flag `kvm_enabled` is introduced, defaulting to false, to allow per-region enablement of KVM flavors.

---

Note that there are a few flavors still commented out, those are legacy flavors with the AWS naming schema that are still in use, and we should decide whether we still want some of these or close variants thereof.
