### PR TITLE
Keystone: allow everyone to create projects

### DIFF
--- a/openstack/keystone/templates/etc/_policy.yaml.tpl
+++ b/openstack/keystone/templates/etc/_policy.yaml.tpl
@@ -938,7 +938,7 @@
 # POST  /v3/projects
 # Intended scope(s): system, domain
 #"identity:create_project": "(role:admin and system_scope:all) or (role:admin and domain_id:%(target.project.domain_id)s)"
-"identity:create_project": "rule:cloud_admin or (role:admin and domain_id:%(target.project.domain_id)s) or (role:admin and project_id:%(target.project.parent_id)s)"
+"identity:create_project": ""
 
 # Update project.
 # PATCH  /v3/projects/{project_id}


### PR DESCRIPTION
We want to allow everyone to be able to create new projects. This was triggered by customers in a SCoCH ticket and agreed with Esther.