### PR TITLE
[pxc-db] Change default timeouts

### DIFF
--- a/common/pxc-db/Chart.yaml
+++ b/common/pxc-db/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.10
+version: 0.1.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/common/pxc-db/values.yaml
+++ b/common/pxc-db/values.yaml
@@ -131,6 +131,11 @@ pxc:
       wsrep_retry_autocommit: 3
       binlog_format: ROW
       binlog_expire_logs_seconds: 345600  # default 30 days -> 4 days
+      net_read_timeout: 120
+      net_write_timeout: 300
+      connect_timeout: 30
+      wait_timeout: 3800
+      interactive_timeout: 1800
       max_connections: 1024
       max_connect_errors: "4294967295"  # to avoid failed connections because of loadbalancer health checks
       innodb_flush_log_at_trx_commit: 0


### PR DESCRIPTION
* Increase default net_read_timeout and net_write_timeout

net_write_timeout limits the max size of binlog sent to mysqlbinlog

180s in my tests were enough for 1GB binlog file

* Set connect_timeout to 30s

* Set wait_timeout and interactive_timeout to the same values as in MariaDB