### PR TITLE
[manila] set reserve down to 25%

### DIFF
--- a/openstack/manila/templates/shares/_share-netapp.conf.tpl
+++ b/openstack/manila/templates/shares/_share-netapp.conf.tpl
@@ -79,7 +79,7 @@ netapp_hardware_state = {{ $share.hardware_state | default "live" }}
 {{- if eq 100 (int $share.reserved_share_percentage)}}
 reserved_share_percentage = 100
 {{- else }}
-reserved_share_percentage = {{ $share.reserved_share_percentage | default 30 }}
+reserved_share_percentage = {{ $share.reserved_share_percentage | default 25 }}
 {{- end }}
 
 {{- if eq 100 (int $share.reserved_share_extend_percentage)}}

--- a/prometheus-exporters/openstack-exporter/alerts/manila.alerts
+++ b/prometheus-exporters/openstack-exporter/alerts/manila.alerts
@@ -2,12 +2,13 @@ groups:
 - name: manila
   rules:
     # 1. Sum usable capacity by host, i.e. look at NetApp cluster, summing up the aggregates aka pools
-    # 2. Count clusters that have more than 5 TB usable capacity per availability zone
+    # 2. Count clusters that have more than 3.5 TB usable capacity per availability zone
+    # (3.5 TB is roughly 5% capacity on our normal 70TB aggregates)
     #
     # Alert if there are less than 3 clusters
     # or if the total number of clusters in a zone is smaller than 3: less than the total amount of clusters
   - alert: ManilaAvailabilityZoneUsageHigh
-    expr: count by(zone) (sum by (zone, host) (manila_usable_capacity) > 5*1024) < ((manila_live_backend_count:per_zone < manila_anti_affinity_set_limit:per_zone) OR manila_anti_affinity_set_limit:per_zone)
+    expr: count by(zone) (sum by (zone, host) (manila_usable_capacity) > 3.5*1024) < ((manila_live_backend_count:per_zone < manila_anti_affinity_set_limit:per_zone) OR manila_anti_affinity_set_limit:per_zone)
     for: 1h
     labels:
         severity: warning
@@ -19,5 +20,5 @@ groups:
         playbook: 'docs/support/playbook/manila/az_usage_high'
         support_component: manila_netapp
     annotations:
-        description: '{{ $labels.zone }} has not enough clusters with 5 TB capacity left for new shares'
+        description: '{{ $labels.zone }} has not enough clusters with 3.5 TB capacity left for new shares'
         summary: '{{ $labels.zone }} usage high'


### PR DESCRIPTION
storage team is rebalancing on 70% usage, so we have a 5% buffer
for new share creations, e.g. to fulfil anti-affinity constraints.

Without the buffer we would get too much 'no valid host' situations.
