### PR TITLE
chore(violation.alert): encode support_group label with ~S

### DIFF
--- a/system/doop-central/alerts/infra-frontend/violation.alerts
+++ b/system/doop-central/alerts/infra-frontend/violation.alerts
@@ -23,7 +23,7 @@ groups:
         annotations:
           summary: "Significant vulnerable images used in prod deployments"
           description: |
-            Service {{ $labels.the_service }} is running container images with significant vulnerabilities. Please check <https://ccloud.dashboard.greenhouse.global.cloud.sap/?__s=(doop:(f:((key:check~Isupport~Sgroup,label:support_group,value:{{ $labels.support_group }}),(key:check~Iservice,label:service,value:{{ $labels.the_service }}),(key:check~Istatus,value:Rotten),(key:check~Istatus,value:Critical),(key:cluster~Ilayer,value:prod)),s:-+,v:GkVulnerableImages),greenhouse~Fdashboard:(a:doop),,supernova:(d:-+,f:(support~Sgroup:({{ $labels.support_group }})),p:prod,s:%27%27))|this view in Greenhouse> for details.
+            Service {{ $labels.the_service }} is running container images with significant vulnerabilities. Please check <https://ccloud.dashboard.greenhouse.global.cloud.sap/?__s=(doop:(f:((key:check~Isupport~Sgroup,label:support_group,value:{{ label_replace($labels.support_group, "~S", "(.*)", "$1") }}),(key:check~Iservice,label:service,value:{{ $labels.the_service }}),(key:check~Istatus,value:Rotten),(key:check~Istatus,value:Critical),(key:cluster~Ilayer,value:prod)),s:-+,v:GkVulnerableImages),greenhouse~Fdashboard:(a:doop),supernova:(d:-+,f:(support~Sgroup:({{ label_replace($labels.support_group, "~S", "(.*)", "$1") }})),p:prod,s:%27%27))|this view in Greenhouse> for details.
 
       # alert for vulnerable images in productive deployments of workgroup "Storage & Resource Services"
       - alert: GkVulnerableImagesForSRS


### PR DESCRIPTION
### Description

This commit modifies the Helm chart annotations to include the `label_replace()` function for encoding the `support_group` label with the `~S`. The change impacts the annotations for the Greenhouse dashboard view link, ensuring that the `support_group` value follows the required encoding format.

#### Key Changes:
- Used `label_replace()` to append `~S` to the `support_group` label in the description annotation.
- Improved the clarity of variable usage in the Greenhouse dashboard link by encoding support group labels consistently across deployments.
