### PR TITLE
adds tls_cacertdir: '/etc/ssl/certs/' to all domain ldap configs

### DIFF
--- a/openstack/domain-seeds/templates/domain-bs-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-bs-seed.yaml
@@ -132,6 +132,7 @@ spec:
       ldap:
         page_size: 1000
         use_tls: false
+        tls_cacertdir: "/etc/ssl/certs/"
         tls_req_cert: allow
         url: {{ .Values.ldapUrl | quote }}
         user: {{ .Values.ldapUser | quote }}

--- a/openstack/domain-seeds/templates/domain-btp-fp-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-btp-fp-seed.yaml
@@ -91,6 +91,7 @@ spec:
       ldap:
         page_size: 1000
         use_tls: false
+        tls_cacertdir: "/etc/ssl/certs/"
         tls_req_cert: allow
         url: {{ .Values.ldapUrl | quote }}
         user: {{ .Values.ldapUser | quote }}

--- a/openstack/domain-seeds/templates/domain-cc3test-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-cc3test-seed.yaml
@@ -166,6 +166,7 @@ spec:
       ldap:
         page_size: 1000
         use_tls: false
+        tls_cacertdir: "/etc/ssl/certs/"
         tls_req_cert: allow
         query_scope: one
         url: {{ .Values.ldapUrl | quote }}

--- a/openstack/domain-seeds/templates/domain-ccadmin-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-ccadmin-seed.yaml
@@ -26,6 +26,7 @@ spec:
       ldap:
         page_size: 1000
         use_tls: false
+        tls_cacertdir: "/etc/ssl/certs/"
         tls_req_cert: allow
         url: {{ .Values.ldapUrl | quote }}
         user: {{ .Values.ldapUser | quote }}

--- a/openstack/domain-seeds/templates/domain-cis-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-cis-seed.yaml
@@ -132,6 +132,7 @@ spec:
       ldap:
         page_size: 1000
         use_tls: false
+        tls_cacertdir: "/etc/ssl/certs/"
         tls_req_cert: allow
         url: {{ .Values.ldapUrl | quote }}
         user: {{ .Values.ldapUser | quote }}

--- a/openstack/domain-seeds/templates/domain-cp-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-cp-seed.yaml
@@ -131,6 +131,7 @@ spec:
       ldap:
         page_size: 1000
         use_tls: false
+        tls_cacertdir: "/etc/ssl/certs/"
         tls_req_cert: allow
         url: {{ .Values.ldapUrl | quote }}
         user: {{ .Values.ldapUser | quote }}

--- a/openstack/domain-seeds/templates/domain-fsn-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-fsn-seed.yaml
@@ -131,6 +131,7 @@ spec:
       ldap:
         page_size: 1000
         use_tls: false
+        tls_cacertdir: "/etc/ssl/certs/"
         tls_req_cert: allow
         url: {{ .Values.ldapUrl | quote }}
         user: {{ .Values.ldapUser | quote }}

--- a/openstack/domain-seeds/templates/domain-hcm-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-hcm-seed.yaml
@@ -134,6 +134,7 @@ spec:
       ldap:
         page_size: 1000
         use_tls: false
+        tls_cacertdir: "/etc/ssl/certs/"
         tls_req_cert: allow
         url: {{ .Values.ldapUrl | quote }}
         user: {{ .Values.ldapUser | quote }}

--- a/openstack/domain-seeds/templates/domain-hcp03-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-hcp03-seed.yaml
@@ -131,6 +131,7 @@ spec:
       ldap:
         page_size: 1000
         use_tls: false
+        tls_cacertdir: "/etc/ssl/certs/"
         tls_req_cert: allow
         url: {{ .Values.ldapUrl | quote }}
         user: {{ .Values.ldapUser | quote }}

--- a/openstack/domain-seeds/templates/domain-hda-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-hda-seed.yaml
@@ -132,6 +132,7 @@ spec:
       ldap:
         page_size: 1000
         use_tls: false
+        tls_cacertdir: "/etc/ssl/certs/"
         tls_req_cert: allow
         url: {{ .Values.ldapUrl | quote }}
         user: {{ .Values.ldapUser | quote }}

--- a/openstack/domain-seeds/templates/domain-hec-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-hec-seed.yaml
@@ -132,6 +132,7 @@ spec:
       ldap:
         page_size: 1000
         use_tls: false
+        tls_cacertdir: "/etc/ssl/certs/"
         tls_req_cert: allow
         url: {{ .Values.ldapUrl | quote }}
         user: {{ .Values.ldapUser | quote }}

--- a/openstack/domain-seeds/templates/domain-kyma-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-kyma-seed.yaml
@@ -91,6 +91,7 @@ spec:
       ldap:
         page_size: 1000
         use_tls: false
+        tls_cacertdir: "/etc/ssl/certs/"
         tls_req_cert: allow
         url: {{ .Values.ldapUrl | quote }}
         user: {{ .Values.ldapUser | quote }}

--- a/openstack/domain-seeds/templates/domain-monsoon3-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-monsoon3-seed.yaml
@@ -22,6 +22,7 @@ spec:
       ldap:
         page_size: 1000
         use_tls: false
+        tls_cacertdir: "/etc/ssl/certs/"
         tls_req_cert: allow
         url: {{ .Values.ldapUrl | quote }}
         user: {{ .Values.ldapUser | quote }}

--- a/openstack/domain-seeds/templates/domain-neo-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-neo-seed.yaml
@@ -132,6 +132,7 @@ spec:
       ldap:
         page_size: 1000
         use_tls: false
+        tls_cacertdir: "/etc/ssl/certs/"
         tls_req_cert: allow
         url: {{ .Values.ldapUrl | quote }}
         user: {{ .Values.ldapUser | quote }}

--- a/openstack/domain-seeds/templates/domain-ora-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-ora-seed.yaml
@@ -59,6 +59,7 @@ spec:
       ldap:
         page_size: 1000
         use_tls: false
+        tls_cacertdir: "/etc/ssl/certs/"
         tls_req_cert: allow
         url: {{ .Values.ldapUrl | quote }}
         user: {{ .Values.ldapUser | quote }}

--- a/openstack/domain-seeds/templates/domain-s4-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-s4-seed.yaml
@@ -133,6 +133,7 @@ spec:
       ldap:
         page_size: 1000
         use_tls: false
+        tls_cacertdir: "/etc/ssl/certs/"
         tls_req_cert: allow
         url: {{ .Values.ldapUrl | quote }}
         user: {{ .Values.ldapUser | quote }}

--- a/openstack/domain-seeds/templates/domain-wbs-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-wbs-seed.yaml
@@ -131,6 +131,7 @@ spec:
       ldap:
         page_size: 1000
         use_tls: false
+        tls_cacertdir: "/etc/ssl/certs/"
         tls_req_cert: allow
         url: {{ .Values.ldapUrl | quote }}
         user: {{ .Values.ldapUser | quote }}


### PR DESCRIPTION
this is for our global domains in qa1 and de2