### PR TITLE
doop-central: fix interpolation of label values into Greenhouse URLs

### DIFF
--- a/system/doop-central/alerts/infra-frontend/violation.alerts
+++ b/system/doop-central/alerts/infra-frontend/violation.alerts
@@ -12,7 +12,14 @@ groups:
         # 1. We want multiple alerts for the same support group to be grouped together in Alertmanager to avoid Slack spam.
         # 2. BUT having different "service" labels would force no grouping.
         # 3. BUT ALSO we cannot just take away the "service" label entirely because we want to refer to the affected service in the alert description.
-        expr: 'sum by (support_group, the_service) (label_join(max_over_time(doop_raw_violations{template_kind="GkVulnerableImages",cluster!~".*qa.*",status=~"Critical|Rotten"}[10m]), "the_service", ",", "service")) > 0'
+        #
+        # NOTE 3: I am incredibly sorry for the gigantic mess of label_replace() that this is wrapped in.
+        # This is necessitated by the positively bizarre encoding of parameters in Greenhouse URLs. In some places, dashes need to be escaped like `foo-bar -> foo~Fbar`.
+        # Unfortunately, Prometheus does not have a function to replace any number of occurrences of a search pattern. label_replace() will do exactly one match and replace and that's it.
+        # Because we have up to two dashes in support group names ("compute-storage-api"), there are two label_replace() rounds that escape dashes.
+        # An additional label_replace() is required to populate the `support_group_escaped_for_greenhouse` label in a way that also works for support groups without dashes in them ("containers", "identity", etc.).
+        # And then, we need to do the same for the `service` label. (╯°□°）╯︵ ┻━┻
+        expr: 'label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(sum by (support_group, the_service) (label_join(max_over_time(doop_raw_violations{template_kind="GkVulnerableImages",cluster!~".*qa.*",status=~"Critical|Rotten"}[10m]), "the_service", ",", "service")) > 0, "support_group_escaped_for_greenhouse", "$0", "support_group", ".*"), "support_group_escaped_for_greenhouse", "$1~F$2", "support_group_escaped_for_greenhouse", "([^-]*)-(.*)"), "support_group_escaped_for_greenhouse", "$1~F$2", "support_group_escaped_for_greenhouse", "([^-]*)-(.*)"), "the_service_escaped_for_greenhouse", "$0", "the_service", ".*"), "the_service_escaped_for_greenhouse", "$1~F$2", "the_service_escaped_for_greenhouse", "([^-]*)-(.*)"), "the_service_escaped_for_greenhouse", "$1~F$2", "the_service_escaped_for_greenhouse", "([^-]*)-(.*)")'
         for: 15m
         labels:
           context: GkSignificantVulnerableImages
@@ -23,7 +30,7 @@ groups:
         annotations:
           summary: "Significant vulnerable images used in prod deployments"
           description: |
-            Service {{ $labels.the_service }} is running container images with significant vulnerabilities. Please check <https://ccloud.dashboard.greenhouse.global.cloud.sap/?__s=(doop:(f:((key:check~Isupport~Sgroup,label:support_group,value:{{ $labels.support_group }}),(key:check~Iservice,label:service,value:{{ $labels.the_service }}),(key:check~Istatus,value:Rotten),(key:check~Istatus,value:Critical),(key:cluster~Ilayer,value:prod)),s:-+,v:GkVulnerableImages),greenhouse~Fdashboard:(a:doop),,supernova:(d:-+,f:(support~Sgroup:({{ $labels.support_group }})),p:prod,s:%27%27))|this view in Greenhouse> for details.
+            Service {{ $labels.the_service }} is running container images with significant vulnerabilities. Please check <https://ccloud.dashboard.greenhouse.global.cloud.sap/?__s=(doop:(f:((key:check~Isupport~Sgroup,label:support_group,value:{{ $labels.support_group_escaped_for_greenhouse }}),(key:check~Iservice,label:service,value:{{ $labels.the_service_escaped_for_greenhouse }}),(key:check~Istatus,value:Rotten),(key:check~Istatus,value:Critical),(key:cluster~Ilayer,value:prod)),s:-+,v:GkVulnerableImages),greenhouse~Fdashboard:(a:doop),supernova:(d:-+,f:(support~Sgroup:({{ $labels.support_group }})),p:prod,s:%27%27))|this view in Greenhouse> for details.
 
       # alert for vulnerable images in productive deployments of workgroup "Storage & Resource Services"
       - alert: GkVulnerableImagesForSRS


### PR DESCRIPTION
Obsoletes #7305.

@TilmanHaupt FYI: A personal story about why the rollout of the new URL format for Greenhouse would be hugely appreciated.