### PR TITLE
ironic: remove jaeger

### DIFF
--- a/openstack/ironic/templates/_conductor-deployment.yaml.tpl
+++ b/openstack/ironic/templates/_conductor-deployment.yaml.tpl
@@ -196,7 +196,6 @@ spec:
           subPath: statsd-rpc-exporter.yaml
           readOnly: true
       {{- end }}
- {{- include "jaeger_agent_sidecar" . | indent 6 }}
       volumes:
       - name: etcironic
         emptyDir: {}

--- a/openstack/ironic/templates/api-deployment.yaml
+++ b/openstack/ironic/templates/api-deployment.yaml
@@ -130,7 +130,6 @@ spec:
             subPath: statsd-exporter.yaml
             readOnly: true
 {{- tuple . .Values.api.override "ironic-api" | include "utils.snippets.debug.debug_port_container" | indent 6 }}
-{{- include "jaeger_agent_sidecar" . | indent 6 }}
       volumes:
       - name: etcironic
         emptyDir: {}


### PR DESCRIPTION
jaeger is deprecated and no longer used according to Chuan in slack.
Thus we remove it. The images were outdated as well.
