### PR TITLE
Adjust gatekeeper policies to handle new PX setup

### DIFF
--- a/system/gatekeeper/templates/constrainttemplate-pod-security.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-pod-security.yaml
@@ -663,6 +663,9 @@ spec:
 
         {{- if eq .Values.cluster_type "baremetal" "test" }}
         default isPXBirdPod = false
+        
+        # TODO: Legacy setup, cleanup after 2024-11-30
+        # BEGIN LEGACY SETUP, CLEANUP AFTER 2024-11-30
         isPXBirdPod = true {
           iro.kind == "Deployment"
           iro.metadata.namespace == "px"
@@ -678,10 +681,39 @@ spec:
           isPXBirdPod
           container.name == sprintf("%s-init", [iro.metadata.name])
         }
+
         # Bird needs to be able to send and receive BGP announcements.
         isContainerAllowedToUseCapability(container, "NET_ADMIN") = true {
           isPXBirdPod
           container.name == iro.metadata.name
+        }
+
+        # TODO: transistion StatefulsetName, cleanup after 2024-11-30
+        isPXBirdPod = true {
+          iro.kind == "StatefulSet"
+          iro.metadata.namespace == "px"
+          regex.match("^routeserver-v(4|6)-service-[1-3]-domain-[1-2]-[1-2]$", iro.metadata.name)
+          regex.match("^bird-domain[0-2]$", helmReleaseName)
+        }
+        # END OF LEGACY SETUP, CLEANUP AFTER 2024-11-30
+
+        # Final PX setup
+        isPXBirdPod = true {
+          iro.kind == "StatefulSet"
+          iro.metadata.namespace == "px"
+          regex.match("^routeserver-v(4|6)-service-[1-3]-domain-[1-2]$", iro.metadata.name)
+          regex.match("^bird-domain[0-2]$", helmReleaseName)
+        }
+
+        isContainerAllowedToBePrivileged(container) = true {
+          isPXBirdPod
+          container.name == "init-network"
+        }
+
+        # Bird needs to be able to send and receive BGP announcements.
+        isContainerAllowedToUseCapability(container, "NET_ADMIN") = true {
+          isPXBirdPod
+          container.name == "bird"
         }
         {{- end }}
 

--- a/system/gatekeeper/tests/gatekeeper-policies/fixtures/pod-security/px-bird-legacy.yaml
+++ b/system/gatekeeper/tests/gatekeeper-policies/fixtures/pod-security/px-bird-legacy.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   annotations:
     meta.helm.sh/release-name: bird-domain1
@@ -8,22 +8,22 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     ccloud/service: px
     ccloud/support-group: network-api
-  name: routeserver-v4-service-1-domain-1
+  name: qa-de-1-pxrs-1-s3-2
   namespace: px
 spec:
   template:
     spec:
       containers:
-      - name: bird
+      - name: qa-de-1-pxrs-1-s3-2
         securityContext:
           capabilities:
             add:
             - NET_ADMIN
-      - name: exporter
-      - name: lgproxy
-      - name: lgadminproxy
+      - name: qa-de-1-pxrs-1-s3-2-exporter
+      - name: qa-de-1-pxrs-1-s3-2-lgproxy
+      - name: qa-de-1-pxrs-1-s3-2-lgadminproxy
       initContainers:
-      - name: init-network
+      - name: qa-de-1-pxrs-1-s3-2-init
         securityContext:
           privileged: true # runs `ip link set $VLAN_INTERFACE promisc on`
       securityContext: {}

--- a/system/gatekeeper/tests/gatekeeper-policies/fixtures/pod-security/px-bird-transistion.yaml
+++ b/system/gatekeeper/tests/gatekeeper-policies/fixtures/pod-security/px-bird-transistion.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     ccloud/service: px
     ccloud/support-group: network-api
-  name: routeserver-v4-service-1-domain-1
+  name: routeserver-v4-service-1-domain-1-1
   namespace: px
 spec:
   template:

--- a/system/gatekeeper/tests/gatekeeper-policies/suite.yaml
+++ b/system/gatekeeper/tests/gatekeeper-policies/suite.yaml
@@ -501,6 +501,14 @@ tests:
     object: fixtures/pod-security/px-bird.yaml
     assertions:
     - violations: no
+  - name: pod-security-accept-px-bird-legacy
+    object: fixtures/pod-security/px-bird-legacy.yaml
+    assertions:
+    - violations: no
+  - name: pod-security-accept-px-bird-transistion
+    object: fixtures/pod-security/px-bird-transistion.yaml
+    assertions:
+    - violations: no
   - name: pod-security-accept-project-aurora
     object: fixtures/pod-security/project-aurora-dhcp.yaml
     assertions:


### PR DESCRIPTION
In order to make PX v6 compatible we are adjusting our charts.
* We are removing all references to the region name from the deployments
  and containers
* We are migrating each deployment to a statefulset in the first step
* In the second step we are cutting the number of statefulsets in half
  by running the statefulset with replicas = 2.

Since the naming and the workload type changed gatekeeper policies must
be adjusted to handle the future and the transition state.
