### PR TITLE
fix: add service kube-system to kube-system charts

### DIFF
--- a/system/kube-system-addons/values.yaml
+++ b/system/kube-system-addons/values.yaml
@@ -2,6 +2,7 @@ global:
 
 owner-info:
   support-group: containers
+  service: kube-system
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-addons
 
 go-pmtud:

--- a/system/kube-system-admin-k3s/values.yaml
+++ b/system/kube-system-admin-k3s/values.yaml
@@ -69,6 +69,7 @@ cert-manager:
 
 owner-info:
   support-group: containers
+  service: kube-system
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-admin-k3s
 
 velero:

--- a/system/kube-system-kubernikus/values.yaml
+++ b/system/kube-system-kubernikus/values.yaml
@@ -1,3 +1,8 @@
+owner-info:
+  support-group: containers
+  service: kubernikus
+  helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-kubernikus
+
 ingress:
   tls_client_auth:
     ca_cert:

--- a/system/kube-system-kubernikus/values.yaml
+++ b/system/kube-system-kubernikus/values.yaml
@@ -1,6 +1,6 @@
 owner-info:
   support-group: containers
-  service: kubernikus
+  service: kube-system
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-kubernikus
 
 ingress:

--- a/system/kube-system-metal/values.yaml
+++ b/system/kube-system-metal/values.yaml
@@ -280,6 +280,7 @@ metrics-server:
 
 owner-info:
   support-group: containers
+  service: kube-system
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-metal
 
 velero:

--- a/system/kube-system-scaleout/values.yaml
+++ b/system/kube-system-scaleout/values.yaml
@@ -64,6 +64,7 @@ metrics-server:
 
 owner-info:
   support-group: containers
+  service: kube-system
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-scaleout
 
 vpa-butler:

--- a/system/kube-system-virtual/values.yaml
+++ b/system/kube-system-virtual/values.yaml
@@ -114,6 +114,7 @@ metrics-server:
 
 owner-info:
   support-group: containers
+  service: kube-system
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-virtual
 
 velero:

--- a/system/kubernikus-admin-k3s/values.yaml
+++ b/system/kubernikus-admin-k3s/values.yaml
@@ -22,4 +22,5 @@ kubernikus-dex:
 
 owner-info:
   support-group: containers
+  service: kubernikus
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/system/kubernikus-admin-k3s

--- a/system/kubernikus-metal/values.yaml
+++ b/system/kubernikus-metal/values.yaml
@@ -22,4 +22,5 @@ kubernikus-dex:
 
 owner-info:
   support-group: containers
+  service: kubernikus
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/system/kubernikus-metal


### PR DESCRIPTION
To reduce the number of vulnerable image alerts that are tagged as `service: none` this PR proposes to mark all kube-system charts with `service: kube-system`. Additionally added `service: kubernikus` for a few charts that are clearly kubernikus charts.

### Changes made
 - added `service: kube-system` to owner-info of kube-system helm charts
 - added `service: kubernikus` to owner-info of kubernikus charts