### PR TITLE
[Neutron] Resolve correct password in seeder

### DIFF
--- a/openstack/neutron/templates/seed.yaml
+++ b/openstack/neutron/templates/seed.yaml
@@ -112,7 +112,7 @@ spec:
         role: cloud_network_admin
     - name: master
       role_assignments:
-      - user: {{ .Values.global.neutron_service_user }}@Default
+      - user: {{ .Values.global.neutron_service_user | include "resolve_secret" }}@Default
         role: cloud_dns_admin
     groups:
     - name: CCADMIN_CLOUD_ADMINS


### PR DESCRIPTION
The secret injector tries to resolve the full string 'vault+kvv2:///secrets/qa-de-1/neutron/keystone-user/service/user@Default' which fails.
Encoding this as Go Template (by calling the helper resolve_conf) will fix the issue.