### PR TITLE
[Neutron] Seeder fix secret injector issue

### DIFF
--- a/openstack/neutron/templates/seed.yaml
+++ b/openstack/neutron/templates/seed.yaml
@@ -112,7 +112,7 @@ spec:
         role: cloud_network_admin
     - name: master
       role_assignments:
-      - user: {{ .Values.global.neutron_service_user | include "resolve_secret" }}@Default
+      - user: '{{ .Values.global.neutron_service_user | include "resolve_secret" }}@Default'
         role: cloud_dns_admin
     groups:
     - name: CCADMIN_CLOUD_ADMINS


### PR DESCRIPTION
Force yaml to use encode the user value as String. Otherwise it fails with 'found character that cannot start any token'