### PR TITLE
[Neutron] Fix Keystone Service User Injection

### DIFF
--- a/openstack/neutron/templates/etc/_server_agent_shared_secrets.ini.tpl
+++ b/openstack/neutron/templates/etc/_server_agent_shared_secrets.ini.tpl
@@ -2,5 +2,5 @@
 {{ include "ini_sections.default_transport_url" . }}
 
 [keystone_authtoken]
-username = {{ .Values.global.neutron_service_user | default "neutron" | replace "$" "$$" }}
+username = {{ .Values.global.neutron_service_user | default "neutron" | include "resolve_secret" }}
 password = {{ .Values.global.neutron_service_password | default "" | include "resolve_secret" }}

--- a/openstack/neutron/templates/etc/_server_secrets.ini.tpl
+++ b/openstack/neutron/templates/etc/_server_secrets.ini.tpl
@@ -1,9 +1,9 @@
 [nova]
-username = {{ .Values.global.neutron_service_user | default "neutron" | replace "$" "$$" }}
+username = {{ .Values.global.neutron_service_user | default "neutron" | include "resolve_secret" }}
 password = {{ .Values.global.neutron_service_password | default "" | include "resolve_secret" }}
 
 [designate]
-username = {{ .Values.global.neutron_service_user | default "neutron" | replace "$" "$$" }}
+username = {{ .Values.global.neutron_service_user | default "neutron" | include "resolve_secret" }}
 password = {{ .Values.global.neutron_service_password | default "" | include "resolve_secret" }}
 
 [database]


### PR DESCRIPTION
The neutron keystone user, also injected by the secret-injector, requires
to be wrapped in a template '{{ valu+kvv ...}}' as it is part of a complex secret. Not
calling the helper resolve_secret does not lead to correct injection by
the secrets-injector.