### PR TITLE
common/postgresql-ng: fix ownership of custom enum types

### DIFF
--- a/common/postgresql-ng/Chart.yaml
+++ b/common/postgresql-ng/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: postgresql-ng
-version: 1.2.2 # this version number is SemVer as it gets used to auto bump
+version: 1.2.3 # this version number is SemVer as it gets used to auto bump
 description: Chart for PostgreSQL
 keywords:
 - postgresql

--- a/common/postgresql-ng/templates/configmap.yaml
+++ b/common/postgresql-ng/templates/configmap.yaml
@@ -96,5 +96,7 @@ data:
     ALTER DATABASE "%PGDATABASE%" OWNER TO "{{ .Values.tableOwner }}";
     SELECT format('ALTER TABLE %I.%I.%I OWNER TO %I;', table_catalog, table_schema, table_name, '{{ .Values.tableOwner }}')
       FROM information_schema.tables WHERE table_schema = 'public'\gexec
+    SELECT FORMAT('ALTER TYPE %I.%I.%I OWNER TO %I;', current_database()::information_schema.sql_identifier, n.nspname, t.typname, '{{ .Values.tableOwner }}')
+      FROM pg_catalog.pg_type t JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace WHERE t.typtype = 'e' AND n.nspname = 'public'\gexec
 
     {{ .Values.sqlOnStartup }}


### PR DESCRIPTION
We only have these in Castellum at the moment. The most recent schema migration there is blocked by this because the tableOwner does not own these types anymore (the superuser does, for historic reasons).