### PR TITLE
[designate] Move worker per pod configuration to values

### DIFF
--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes to deploy Openstack Designate  (DNSaaS)
 name: designate
-version: 0.3.7
+version: 0.3.8
 appVersion: "xena"
 dependencies:
   - condition: percona_cluster.enabled

--- a/openstack/designate/templates/api-deployment.yaml
+++ b/openstack/designate/templates/api-deployment.yaml
@@ -44,7 +44,6 @@ spec:
       serviceAccountName: {{ .Release.Name }}
 {{- end }}
 {{ tuple . "designate" "api" | include "kubernetes_pod_anti_affinity" | indent 6 }}
-      {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       initContainers:
       {{- tuple . (dict "service" (include "designate.service_dependencies" . ) "jobs" (include "migration_job_name" . )) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
       containers:
@@ -116,9 +115,7 @@ spec:
             - name: designate-etc-wsgi
               mountPath: /etc/apache2/conf-enabled/wsgi-designate.conf
               subPath: wsgi-designate.conf
-            {{- include "utils.proxysql.volume_mount" . | indent 12 }}
             {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
-        {{- include "utils.proxysql.container" . | indent 8 }}
         - name: statsd
           image: {{ required ".Values.global.dockerHubMirror is missing" .Values.global.dockerHubMirror }}/prom/statsd-exporter:v0.8.1
           imagePullPolicy: IfNotPresent
@@ -157,5 +154,4 @@ spec:
           configMap:
             name: designate-bin
             defaultMode: 0755
-        {{- include "utils.proxysql.volumes" . | indent 8 }}
         {{- include "utils.trust_bundle.volumes" . | indent 8 }}

--- a/openstack/designate/templates/central-deployment.yaml
+++ b/openstack/designate/templates/central-deployment.yaml
@@ -78,7 +78,7 @@ spec:
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
             {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
             {{- include "utils.coordination.volume_mount" . | indent 12 }}
-        {{- include "utils.proxysql.container" . | indent 8 }}
+        {{- tuple . .Values.central_workers | include "utils.proxysql.container" | indent 8 }}
         {{- include "jaeger_agent_sidecar" . | indent 8 }}
       volumes:
         - name: designate-etc

--- a/openstack/designate/templates/etc/_designate.conf.tpl
+++ b/openstack/designate/templates/etc/_designate.conf.tpl
@@ -80,7 +80,7 @@ driver = noop
 #-----------------------
 [service:central]
 # Number of central worker processes to spawn
-workers = 2
+workers = {{ .Values.central_workers }}
 
 # Number of central greenthreads to spawn
 #threads = 1000
@@ -113,7 +113,7 @@ scheduler_filters = {{ .Values.scheduler_filters }}
 #-----------------------
 [service:api]
 # Number of api worker processes to spawn
-workers = 2
+workers = {{ .Values.api_workers }}
 
 # Number of api greenthreads to spawn
 #threads = 1000
@@ -262,7 +262,7 @@ allow_headers = X-Auth-Token,X-Auth-Sudo-Tenant-ID,X-Auth-Sudo-Project-ID,X-Auth
 #-----------------------
 [service:mdns]
 # Number of mdns worker processes to spawn
-workers = 2
+workers = {{ .Values.mdns_workers }}
 
 # Number of mdns greenthreads to spawn
 threads = 1000
@@ -304,7 +304,7 @@ query_enforce_tsig = {{ .Values.query_enforce_tsig }}
 #-----------------------
 [service:producer]
 # Number of Producer worker processes to spawn (integer value)
-workers = 2
+workers = {{ .Values.producer_workers }}
 
 # Number of Producer greenthreads to spawn (integer value)
 #threads = 1000
@@ -360,7 +360,7 @@ batch_size = 200
 enabled = {{.Values.worker_enabled}}
 
 # Number of Worker processes to spawn
-workers = 2
+workers = {{ .Values.worker_workers }}
 
 # Number of Worker greenthreads to spawn
 threads = 200

--- a/openstack/designate/templates/mdns-deployment.yaml
+++ b/openstack/designate/templates/mdns-deployment.yaml
@@ -88,7 +88,7 @@ spec:
               name: container-init
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
             {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
-        {{- include "utils.proxysql.container" . | indent 8 }}
+        {{- tuple . .Values.mdns_workers | include "utils.proxysql.container" | indent 8 }}
       volumes:
         - name: designate-etc
           projected:

--- a/openstack/designate/templates/producer-deployment.yaml
+++ b/openstack/designate/templates/producer-deployment.yaml
@@ -43,7 +43,6 @@ spec:
 {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ .Release.Name }}
 {{- end }}
-      {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       initContainers:
       {{- tuple . (dict "service" (include "designate.service_dependencies" . )) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
       containers:
@@ -89,10 +88,8 @@ spec:
               name: designate-etc
             - mountPath: /container.init
               name: container-init
-            {{- include "utils.proxysql.volume_mount" . | indent 12 }}
             {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
             {{- include "utils.coordination.volume_mount" . | indent 12 }}
-        {{- include "utils.proxysql.container" . | indent 8 }}
       volumes:
         - name: designate-etc
           projected:
@@ -111,6 +108,5 @@ spec:
             name: designate-bin
             defaultMode: 0755
         {{- include "utils.coordination.volumes" . | indent 8 }}
-        {{- include "utils.proxysql.volumes" . | indent 8 }}
         {{- include "utils.trust_bundle.volumes" . | indent 8 }}
 {{- end }}

--- a/openstack/designate/templates/worker-deployment.yaml
+++ b/openstack/designate/templates/worker-deployment.yaml
@@ -78,7 +78,7 @@ spec:
               name: container-init
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
             {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
-        {{- include "utils.proxysql.container" . | indent 8 }}
+        {{- tuple . .Values.worker_workers | include "utils.proxysql.container" | indent 8 }}
       volumes:
         - name: designate-etc
           projected:

--- a/openstack/designate/values.yaml
+++ b/openstack/designate/values.yaml
@@ -49,6 +49,12 @@ pod:
           max_unavailable: 0
           max_surge: 1
 
+mdns_workers: 2
+producer_workers: 2
+worker_workers: 2
+central_workers: 2
+api_workers: 2
+
 # image_version_designate:  DEFINED-IN-REGION-CHART
 imageVersionTempest: "latest"
 


### PR DESCRIPTION
* Move worker per pod configuration to values
* Adjust the number of connections per proxysql to the number of workers
* Remove proxysql sidecar from deployments without DB usage