### PR TITLE
[designate] Add mpm_event_module configuration for Designate wsgi

### DIFF
--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes to deploy Openstack Designate  (DNSaaS)
 name: designate
-version: 0.3.8
+version: 0.3.9
 appVersion: "xena"
 dependencies:
   - condition: percona_cluster.enabled

--- a/openstack/designate/templates/api-deployment.yaml
+++ b/openstack/designate/templates/api-deployment.yaml
@@ -81,9 +81,9 @@ spec:
             httpGet:
               path: /healthcheck
               port: {{.Values.global.designate_api_port_internal}}
-            initialDelaySeconds: 15
-            periodSeconds: 15
-            timeoutSeconds: 10
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 20
           readinessProbe:
             exec:
               command:
@@ -96,7 +96,7 @@ spec:
 {{- end }}
             initialDelaySeconds: 5
             periodSeconds: 10
-            timeoutSeconds: 5
+            timeoutSeconds: 20
           ports:
             - name: designate-api
               containerPort: {{.Values.global.designate_api_port_internal}}
@@ -115,6 +115,11 @@ spec:
             - name: designate-etc-wsgi
               mountPath: /etc/apache2/conf-enabled/wsgi-designate.conf
               subPath: wsgi-designate.conf
+              readOnly: true
+            - name: designate-etc-wsgi
+              mountPath: /etc/apache2/mods-available/mpm_event.conf
+              subPath: mpm_event.conf
+              readOnly: true
             {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
         - name: statsd
           image: {{ required ".Values.global.dockerHubMirror is missing" .Values.global.dockerHubMirror }}/prom/statsd-exporter:v0.8.1

--- a/openstack/designate/templates/etc-wsgi-configmap.yaml
+++ b/openstack/designate/templates/etc-wsgi-configmap.yaml
@@ -10,3 +10,5 @@ metadata:
 data:
   wsgi-designate.conf: |
 {{ include (print .Template.BasePath "/etc/_wsgi-designate.conf.tpl") . | indent 4 }}
+  mpm_event.conf: |
+{{ include (print .Template.BasePath "/etc/_mpm_event.conf.tpl") . | indent 4 }}

--- a/openstack/designate/templates/etc/_mpm_event.conf.tpl
+++ b/openstack/designate/templates/etc/_mpm_event.conf.tpl
@@ -1,0 +1,22 @@
+# Copyright 2017 The Openstack-Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+<IfModule mpm_event_module>
+  ServerLimit         1024
+  StartServers        32
+  MinSpareThreads     32
+  MaxSpareThreads     256
+  ThreadsPerChild     25
+  ThreadLimit         720
+</IfModule>

--- a/openstack/designate/templates/etc/_wsgi-designate.conf.tpl
+++ b/openstack/designate/templates/etc/_wsgi-designate.conf.tpl
@@ -10,7 +10,7 @@ CustomLog /dev/stdout combined env=!forwarded
 CustomLog /dev/stdout proxy env=forwarded
 
 <VirtualHost *:{{.Values.global.designate_api_port_internal}}>
-    WSGIDaemonProcess designate-api-wsgi processes=4 threads=1 user=designate display-name=%{GROUP}
+    WSGIDaemonProcess designate-api-wsgi processes=8 threads=1 user=designate display-name=%{GROUP}
     WSGIProcessGroup designate-api-wsgi
     WSGIScriptAlias / /var/www/cgi-bin/designate/designate-api-wsgi
     WSGIApplicationGroup %{GLOBAL}

--- a/openstack/designate/values.yaml
+++ b/openstack/designate/values.yaml
@@ -360,7 +360,7 @@ resources:
       memory: "256Mi"
       cpu: "100m"
     limits:
-      memory: "2048Mi"
+      memory: "3072Mi"
       cpu: "2000m"
   central:
     requests:


### PR DESCRIPTION
* Add mpm_event.conf with the limits similar to Keystone's
* Increase number of apache2 processes from 4 to 8
* Increase API pod memory limits for peak loads
* Increase liveness and readiness timeouts to avoid failing under load

mpm_event.conf default:
```
<IfModule mpm_event_module>
	StartServers			 2
	MinSpareThreads		 25
	MaxSpareThreads		 75
	ThreadLimit			 64
	ThreadsPerChild		 25
	MaxRequestWorkers	  150
	MaxConnectionsPerChild   0
</IfModule>
```
New one:
```
<IfModule mpm_event_module>
  ServerLimit         1024
  StartServers        32
  MinSpareThreads     32
  MaxSpareThreads     256
  ThreadsPerChild     25
  ThreadLimit         720
</IfModule>
```