### PR TITLE
[barbican] add versions to audit map

### DIFF
--- a/openstack/barbican/templates/etc/_barbican_audit_map.yaml
+++ b/openstack/barbican/templates/etc/_barbican_audit_map.yaml
@@ -35,3 +35,5 @@ resources:
   project-quotas:
   consumers:
   orders:
+  versions:
+    singleton: true


### PR DESCRIPTION
Add versions api endpoint to the audit map. We didn't require this before because it's just a read endpoint, but we've turned on read events, and thus it needs to be mapped accordingly. 