### PR TITLE
[rabbitmq] Add config.linkerd.io/opaque-ports annotation

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -3,6 +3,10 @@ Rabbitmq CHANGELOG
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+0.11.3
+------
+- Add linkerd opaque ports annotation for RabbitMQ deployment/statefulset and service
+
 0.11.2
 ------
 - Append urlquery in `rabbitmq.resolve_secret_urlquery` function for non-vault values

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 0.11.2
+version: 0.11.3
 appVersion: 3.13.6
 description: A Helm chart for RabbitMQ
 sources:

--- a/common/rabbitmq/templates/deployment.yaml
+++ b/common/rabbitmq/templates/deployment.yaml
@@ -36,6 +36,7 @@ spec:
         checksum/users: {{ include (print $.Template.BasePath "/users-secret.yaml") . | sha256sum }}
 {{- if and (and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested) $.Values.linkerd.enabled }}
         linkerd.io/inject: enabled
+        config.linkerd.io/opaque-ports: "{{ default 5672 .Values.ports.public }}"
 {{- end }}
 {{- if .Values.customConfig }}
         checksum/custom.conf: {{ include (print .Template.BasePath "/etc/_rabbitmq-custom-config.tpl") . | sha256sum }}

--- a/common/rabbitmq/templates/service.yaml
+++ b/common/rabbitmq/templates/service.yaml
@@ -19,6 +19,7 @@ metadata:
 {{- end }}
 {{- if and (and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested) $.Values.linkerd.enabled }}
     linkerd.io/inject: enabled
+    config.linkerd.io/opaque-ports: "{{ default 5672 .Values.ports.public }}"
 {{- end }}
 spec:
   type: {{ .Values.serviceType }}

--- a/common/rabbitmq/templates/statefulset.yaml
+++ b/common/rabbitmq/templates/statefulset.yaml
@@ -28,6 +28,7 @@ spec:
         kubectl.kubernetes.io/default-container: rabbitmq
 {{- if and (and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested) $.Values.linkerd.enabled }}
         linkerd.io/inject: enabled
+        config.linkerd.io/opaque-ports: "{{ default 5672 .Values.ports.public }}"
 {{- end }}
         checksum/container.init: {{ include (print $.Template.BasePath "/bin-configmap.yaml") . | sha256sum }}
         checksum/users: {{ include (print $.Template.BasePath "/users-secret.yaml") . | sha256sum }}


### PR DESCRIPTION
Add config.linkerd.io/opaque-ports annotation to avoid protocol detection delay, 10s on every connection to RabbitMQ

https://linkerd.io/2.16/features/protocol-detection/