### PR TITLE
[keystone] Disable apache2 server-status endpoint

### DIFF
--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: keystone
 sources:
   - https://github.com/sapcc/keystone
-version: 0.7.2
+version: 0.7.3
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/keystone/templates/bin/_keystone_api.sh.tpl
+++ b/openstack/keystone/templates/bin/_keystone_api.sh.tpl
@@ -24,6 +24,8 @@ function start () {
     cp -a $(type -p ${KEYSTONE_WSGI_SCRIPT}) /var/www/cgi-bin/keystone/
   done
 
+  a2dismod status
+
   if [ -f /etc/apache2/envvars ]; then
      # Loading Apache2 ENV variables
      source /etc/apache2/envvars


### PR DESCRIPTION
Disables the server status page of Apache.
This page contains internal information about working process.
