### PR TITLE
[manila] Disable apache2 server-status endpoint

### DIFF
--- a/openstack/manila/Chart.yaml
+++ b/openstack/manila/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: manila
 sources:
   - https://github.com/sapcc/manila
-version: 0.4.1
+version: 0.4.2
 dependencies:
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/manila/templates/bin/_manila_api.sh.tpl
+++ b/openstack/manila/templates/bin/_manila_api.sh.tpl
@@ -24,6 +24,8 @@ function start () {
     cp -a $(type -p ${MANILA_WSGI_SCRIPT}) /var/www/cgi-bin/manila/
   done
 
+  a2dismod status
+
   if [ -f /etc/apache2/envvars ]; then
      # Loading Apache2 ENV variables
      source /etc/apache2/envvars


### PR DESCRIPTION
Disables the server status page of Apache.
This page contains internal information about working process.