### PR TITLE
[designate] Health probe for Designate components

### DIFF
--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes to deploy Openstack Designate  (DNSaaS)
 name: designate
-version: 0.3.18
+version: 0.4.0
 appVersion: "xena"
 dependencies:
   - condition: percona_cluster.enabled

--- a/openstack/designate/bin/health-probe.py
+++ b/openstack/designate/bin/health-probe.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Health probe script for OpenStack service that uses RPC/unix domain socket for
+communication. Check's the RPC tcp socket status on the process and send
+message to service through rpc call method and expects a reply.
+Uses oslo's ping method that is designed just for such simple purpose.
+
+For API service script:
+  a. checks if there are any established RabbitMQ connections in a pod.
+  b. checks if the RabbitMQ and DB are reachable over TCP.
+These two checks succeed or timeout within 5 seconds.
+
+For other RPC services script:
+  a. checks if there are any TCP ESTABLISHED connections to RabbitMQ and DB.
+  b. checks if the service can consume message from the queue.
+
+With this (b) RPC check script returns failure to Kubernetes only when
+  a. TCP sockets for the RPC communication are not established.
+  b. service is not reachable or
+  c. service times out sending a reply.
+
+sys.stderr.write() writes to pod's events on failures.
+
+Usage example for Designate Central:
+# python health-probe.py --config-file /etc/designate/secrets.conf \
+#  --config-file /etc/designate/hostname.conf \
+#  --service-name central \
+#  --liveness-probe
+
+"""
+
+import json
+import os
+import psutil
+import signal
+import socket
+import sys
+from typing import Optional, Set, Tuple
+
+from sqlalchemy.engine.url import make_url
+
+from oslo_config import cfg
+from oslo_context import context
+from oslo_log import log
+import oslo_messaging
+
+rpc_timeout = int(os.getenv("RPC_PROBE_TIMEOUT", "30"))
+rpc_retries = int(os.getenv("RPC_PROBE_RETRIES", "1"))
+
+tcp_probe_timeout = float(os.getenv("TCP_PROBE_TIMEOUT", "5"))
+tcp_established = "ESTABLISHED"
+
+
+def check_service_status(transport: oslo_messaging.Transport) -> None:
+    """Verify service status. Return success if service consumes message"""
+    try:
+        service_queue_name = cfg.CONF.service_name
+        service_hostname = cfg.CONF.host or socket.gethostname()
+        target = oslo_messaging.Target(
+            topic=service_queue_name,
+            server=service_hostname,
+        )
+        if hasattr(oslo_messaging, "get_rpc_client"):
+            client = oslo_messaging.get_rpc_client(transport, target, timeout=rpc_timeout, retry=rpc_retries)
+        else:
+            client = oslo_messaging.RPCClient(transport, target, timeout=rpc_timeout, retry=rpc_retries)
+        client.call(context.RequestContext(), "oslo_rpc_server_ping", arg=None)
+    except oslo_messaging.exceptions.MessageDeliveryFailure:
+        # Log to pod events
+        sys.stderr.write("Health probe unable to reach message bus")
+        sys.exit(0)  # return success
+    except oslo_messaging.rpc.client.RemoteError as re:
+        message = getattr(re, "message", str(re))
+        if ("Endpoint does not support RPC method" in message) or ("Endpoint does not support RPC version" in message):
+            sys.exit(0)  # Call reached the service
+        else:
+            sys.stderr.write("Health probe unable to reach service")
+            sys.exit(1)  # return failure
+    except oslo_messaging.exceptions.MessagingTimeout:
+        sys.stderr.write("Health probe timed out. Agent is down or response timed out")
+        sys.exit(1)  # return failure
+    except Exception as ex:
+        message = getattr(ex, "message", str(ex))
+        sys.stderr.write("Health probe caught exception sending message to service: %s" % message)
+        sys.exit(0)
+    except:
+        sys.stderr.write("Health probe caught exception sending message to service")
+        sys.exit(0)
+    finally:
+        if client.transport:
+            client.transport.cleanup()
+
+
+def is_tcp_reachable(host: str, port: int, timeout: float = tcp_probe_timeout) -> bool:
+    """Check if TCP socket is reachable"""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(timeout)
+    try:
+        sock.connect((host, port))
+        return True
+    except Exception:
+        return False
+    finally:
+        sock.close()
+
+
+def tcp_socket_status(process: Optional[str], ports: Set[int]) -> int:
+    """Check the TCP socket status for specific target ports on a process"""
+    for p in psutil.process_iter():
+        try:
+            with p.oneshot():
+                if process in " ".join(p.cmdline()):
+                    pcon = p.connections()
+                    for con in pcon:
+                        try:
+                            rport = con.raddr[1]
+                            status = con.status
+                        except IndexError:
+                            # Skip if raddr is empty tuple: connection is not ESTABLISED or connection is LISTEN
+                            continue
+                        if rport in ports and status == tcp_established:
+                            return 1
+        except psutil.Error:
+            continue
+    return 0
+
+
+def tcp_connection_established(ports: Set[int]) -> int:
+    """Check the presence of established TCP connections to remote ports"""
+    scon = psutil.net_connections(kind="tcp")
+    for con in scon:
+        try:
+            rport = con.raddr[1]
+            status = con.status
+        except IndexError:
+            # Skip if raddr is empty tuple: connection is not ESTABLISED or connection is LISTEN
+            continue
+        if rport in ports and status == tcp_established:
+            return 1
+    return 0
+
+
+def check_tcp_socket(
+    service: str,
+    rabbits: Set[Tuple[str, int]],
+    databases: Set[Tuple[str, int]],
+) -> None:
+    """Check TCP socket to RabbitMQ/DB is in ESTABLISHED state"""
+    dict_services = {
+        "central": "designate-central",
+        "producer": "designate-producer",
+        "worker": "designate-worker",
+        "mdns": "designate-mdns",
+    }
+
+    r_ports, d_ports = {port for _, port in rabbits}, {port for _, port in databases}
+
+    if service in dict_services:
+        proc = dict_services[service]
+        if r_ports and tcp_socket_status(proc, r_ports) == 0:
+            sys.stderr.write(f"RabbitMQ socket not established for service {proc}")
+            # Do not kill the pod if RabbitMQ is not reachable/down
+            if not cfg.CONF.liveness_probe:
+                sys.exit(1)
+
+        # let's do the db check
+        # producer service doesn't have a db connection
+        if service not in ["producer"]:
+            if d_ports and tcp_socket_status(proc, d_ports) == 0:
+                sys.stderr.write(f"Database socket not established for service {proc}")
+                # Do not kill the pod if database is not reachable/down
+                # there could be no socket as well as typically connections
+                # get closed after an idle timeout
+                # Just log it to pod events
+                if not cfg.CONF.liveness_probe:
+                    sys.exit(1)
+
+
+def check_rabbitmq_tcp_socket(rabbits: Set[Tuple[str, int]]) -> None:
+    """Check RabbitMQ TCP socket in ESTABLISHED state is present"""
+    r_ports = {port for _, port in rabbits}
+    # Check that there are any established RabbitMQ connections
+    # Apache2 wsgi RabbitMQ connections doesn't belong to any process in pods netstat
+    if r_ports and tcp_connection_established(r_ports) == 0:
+        sys.stderr.write(f"RabbitMQ socket not established")
+        # Do not kill the pod if RabbitMQ is not reachable/down
+        if not cfg.CONF.liveness_probe:
+            sys.exit(1)
+
+
+def check_tcp_connectivity(
+    rabbits: Set[Tuple[str, int]],
+    databases: Set[Tuple[str, int]],
+) -> None:
+    """Check TCP connectivity to RabbitMQ/DB"""
+    for host, port in databases:
+        if not is_tcp_reachable(host, port):
+            sys.stderr.write(f"Database not reachable from service")
+            # Do not kill the pod if database is not reachable/down
+            if not cfg.CONF.liveness_probe:
+                sys.exit(1)
+    for host, port in rabbits:
+        if not is_tcp_reachable(host, port):
+            sys.stderr.write(f"RabbitMQ not reachable from service")
+            # Do not kill the pod if database is not reachable/down
+            if not cfg.CONF.liveness_probe:
+                sys.exit(1)
+
+
+def configured_services_in_conf() -> Tuple[Set[Tuple[str, int]], Set[Tuple[str, int]]]:
+    """Get the rabbitmq/db port configured in config file"""
+
+    rabbits: Set[Tuple[str, int]] = set()
+    databases: Set[Tuple[str, int]] = set()
+
+    try:
+        transport_url = oslo_messaging.TransportURL.parse(cfg.CONF)
+        for host in transport_url.hosts:
+            rabbits.add((host.hostname, host.port))
+    except Exception as ex:
+        message = getattr(ex, "message", str(ex))
+        sys.stderr.write("Health probe caught exception reading RabbitMQs: %s" % message)
+
+    try:
+        url = make_url(cfg.CONF["storage:sqlalchemy"].connection)
+        databases.add((url.host, url.port or 3306))
+    except Exception as ex:
+        message = getattr(ex, "message", str(ex))
+        sys.stderr.write("Health probe caught exception reading DBs: %s" % message)
+
+    return rabbits, databases
+
+
+def test_liveness() -> None:
+    """Test if service can connect to dependency services and can consume message from queue"""
+    oslo_messaging.set_transport_defaults(control_exchange="designate")
+
+    # workaround oslo.messaging always starting metrics thread
+    metrics_group = cfg.OptGroup(name="oslo_messaging_metrics")
+    cfg.CONF.register_group(metrics_group)
+    cfg.CONF.set_override("metrics_enabled", False, metrics_group)
+    cfg.CONF.set_override("metrics_thread_stop_timeout", 0, metrics_group)
+
+    rabbit_group = cfg.OptGroup(name="oslo_messaging_rabbit", title="RabbitMQ options")
+    cfg.CONF.register_group(rabbit_group)
+
+    cfg.CONF.register_cli_opt(cfg.StrOpt("service-name"))
+    cfg.CONF.register_cli_opt(cfg.BoolOpt("liveness-probe", default=False, required=False))
+    cfg.CONF.register_cli_opt(cfg.StrOpt("host", default=None))
+
+    cfg.CONF(sys.argv[1:])
+
+    database_group = cfg.OptGroup(name="storage:sqlalchemy", title="Database options")
+    cfg.CONF.register_group(database_group)
+    cfg.CONF.register_opt(cfg.StrOpt("connection"), group=database_group)
+
+    log.logging.basicConfig(level=log.INFO)
+
+    try:
+        transport = oslo_messaging.get_rpc_transport(cfg.CONF)
+    except Exception as ex:
+        message = getattr(ex, "message", str(ex))
+        sys.stderr.write("Message bus driver load error: %s" % message)
+        sys.exit(0)  # return success
+
+    if not cfg.CONF.transport_url or not cfg.CONF.service_name:
+        sys.stderr.write("Both message bus URL and service's name are required for health probe to work")
+        sys.exit(0)  # return success
+
+    service = cfg.CONF.service_name
+
+    rabbits, databases = configured_services_in_conf()
+
+    api_services = ["api"]
+    rpc_services = ["central", "producer", "worker", "mdns"]
+
+    if service in rpc_services:
+        check_tcp_socket(service, rabbits, databases)
+        check_service_status(transport)
+
+    if service in api_services:
+        check_rabbitmq_tcp_socket(rabbits)
+        check_tcp_connectivity(rabbits, databases)
+
+
+def check_pid_running(pid: int) -> bool:
+    if psutil.pid_exists(pid):
+        return True
+    else:
+        return False
+
+
+if __name__ == "__main__":
+
+    if "liveness-probe" in ",".join(sys.argv):
+        pidfile = "/tmp/liveness.pid"  # nosec
+    else:
+        pidfile = "/tmp/readiness.pid"  # nosec
+    data = {}
+    if os.path.isfile(pidfile):
+        with open(pidfile, "r") as f:
+            file_content = f.read().strip()
+            if file_content:
+                data = json.loads(file_content)
+
+    if "pid" in data and check_pid_running(int(data["pid"])):
+        if "exit_count" in data and data["exit_count"] > 1:
+            # Third time in, kill the previous process
+            os.kill(int(data["pid"]), signal.SIGTERM)
+        else:
+            data["exit_count"] = data.get("exit_count", 0) + 1
+            with open(pidfile, "w") as f:
+                json.dump(data, f)
+            sys.exit(0)
+    data["pid"] = os.getpid()
+    data["exit_count"] = 0
+    with open(pidfile, "w") as f:
+        json.dump(data, f)
+
+    test_liveness()
+
+    sys.exit(0)  # return success

--- a/openstack/designate/templates/api-deployment.yaml
+++ b/openstack/designate/templates/api-deployment.yaml
@@ -85,21 +85,22 @@ spec:
             tcpSocket:
               port: designate-api
             initialDelaySeconds: 30
-            periodSeconds: 20
-            timeoutSeconds: 20
+            periodSeconds: 15
+            timeoutSeconds: 10
           readinessProbe:
             exec:
               command:
-              - bash
-              - -c
-{{- if .Values.global_setup }}
-              - "set -e; curl --fail 127.0.0.1:{{.Values.global.designate_api_port_internal}}/healthcheck; nc -zvw3 designate-global-percona-pxc 3306"
-{{- else }}
-              - "set -e; curl --fail 127.0.0.1:{{.Values.global.designate_api_port_internal}}/healthcheck; nc -zvw3 {{ include "utils.db_host" . }} 3306"
-{{- end }}
-            initialDelaySeconds: 5
+              - python3
+              - /container.init/health-probe.py
+              - --config-file
+              - /etc/designate/secrets.conf
+              - --config-file
+              - /etc/designate/hostname.conf
+              - --service-name
+              - api
+            initialDelaySeconds: 30
             periodSeconds: 10
-            timeoutSeconds: 20
+            timeoutSeconds: 10
           ports:
             - name: designate-api
               containerPort: {{.Values.global.designate_api_port_internal}}

--- a/openstack/designate/templates/bin-configmap.yaml
+++ b/openstack/designate/templates/bin-configmap.yaml
@@ -29,3 +29,5 @@ data:
   designate-tempest-start: |
 {{ .Files.Get "bin/designate-tempest-start" | indent 4 }}
 {{- end }}
+  health-probe.py: |
+{{ .Files.Get "bin/health-probe.py" | indent 4 }}

--- a/openstack/designate/templates/central-deployment.yaml
+++ b/openstack/designate/templates/central-deployment.yaml
@@ -74,6 +74,35 @@ spec:
             - name: PYTHONWARNINGS
               value: {{ .Values.python_warnings | quote }}
             {{- end }}
+          livenessProbe:
+            exec:
+              command:
+              - python3
+              - /container.init/health-probe.py
+              - --config-file
+              - /etc/designate/secrets.conf
+              - --config-file
+              - /etc/designate/hostname.conf
+              - --service-name
+              - central
+              - --liveness-probe
+            initialDelaySeconds: 30
+            periodSeconds: 45
+            timeoutSeconds: 40
+          readinessProbe:
+            exec:
+              command:
+              - python3
+              - /container.init/health-probe.py
+              - --config-file
+              - /etc/designate/secrets.conf
+              - --config-file
+              - /etc/designate/hostname.conf
+              - --service-name
+              - central
+            initialDelaySeconds: 30
+            periodSeconds: 45
+            timeoutSeconds: 40
           volumeMounts:
             - mountPath: /designate-etc
               name: designate-etc

--- a/openstack/designate/templates/etc/_designate.conf.tpl
+++ b/openstack/designate/templates/etc/_designate.conf.tpl
@@ -52,7 +52,7 @@ quota_api_export_size = {{ .Values.quota_api_export_size | default 1000 }}
 
 rpc_response_timeout = {{ .Values.rpc_response_timeout | default .Values.global.rpc_response_timeout | default 300 }}
 
-rpc_ping_enabled = True
+rpc_ping_enabled = true
 
 wsgi_default_pool_size = {{ .Values.wsgi_default_pool_size | default .Values.global.wsgi_default_pool_size | default 100 }}
 

--- a/openstack/designate/templates/mdns-deployment.yaml
+++ b/openstack/designate/templates/mdns-deployment.yaml
@@ -79,9 +79,24 @@ spec:
             {{- end }}
           livenessProbe:
             tcpSocket:
-              port: {{.Values.global.designate_mdns_port_public}}
-            initialDelaySeconds: 15
+              port: designate-mdns
+            initialDelaySeconds: 30
+            periodSeconds: 10
             timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+              - python3
+              - /container.init/health-probe.py
+              - --config-file
+              - /etc/designate/secrets.conf
+              - --config-file
+              - /etc/designate/hostname.conf
+              - --service-name
+              - mdns
+            initialDelaySeconds: 30
+            periodSeconds: 45
+            timeoutSeconds: 40
           ports:
             - name: designate-mdns
               containerPort: {{.Values.global.designate_mdns_port_public}}

--- a/openstack/designate/templates/producer-deployment.yaml
+++ b/openstack/designate/templates/producer-deployment.yaml
@@ -75,18 +75,16 @@ spec:
           livenessProbe:
             exec:
               command:
-              - bash
-              - -c
-{{- if .Values.global_setup }}
-              - "set -e; nc -zvw3 designate-global-percona-pxc 3306; nc -zvw3 designate-global-memcached 11211"
-{{- else }}
-              - "set -e; nc -zvw3 {{ include "utils.db_host" . }} 3306; nc -zvw3 designate-memcached 11211"
-{{- end }}
-            failureThreshold: 3
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 5
+              - python3
+              - /container.init/health-probe.py
+              - --config-file
+              - /etc/designate/secrets.conf
+              - --service-name
+              - producer
+              - --liveness-probe
+            initialDelaySeconds: 60
+            periodSeconds: 45
+            timeoutSeconds: 40
           volumeMounts:
             - mountPath: /designate-etc
               name: designate-etc

--- a/openstack/designate/templates/worker-deployment.yaml
+++ b/openstack/designate/templates/worker-deployment.yaml
@@ -75,6 +75,21 @@ spec:
             - name: PYTHONWARNINGS
               value: {{ .Values.python_warnings | quote }}
             {{- end }}
+          livenessProbe:
+            exec:
+              command:
+              - python3
+              - /container.init/health-probe.py
+              - --config-file
+              - /etc/designate/secrets.conf
+              - --config-file
+              - /etc/designate/hostname.conf
+              - --service-name
+              - worker
+              - --liveness-probe
+            initialDelaySeconds: 60
+            periodSeconds: 45
+            timeoutSeconds: 40
           volumeMounts:
             - mountPath: /designate-etc
               name: designate-etc


### PR DESCRIPTION
* Add health-probe.py script

This script checks DB/RabbitMQ sockets and checks TCP connectivity

For services with RPC servers it uses oslo_rpc_server_ping call
to check, that service responds at all over messaging bug