### PR TITLE
[designate] Set PYTHONWARNINGS by default

### DIFF
--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes to deploy Openstack Designate  (DNSaaS)
 name: designate
-version: 0.3.13
+version: 0.3.14
 appVersion: "xena"
 dependencies:
   - condition: percona_cluster.enabled

--- a/openstack/designate/templates/api-deployment.yaml
+++ b/openstack/designate/templates/api-deployment.yaml
@@ -74,6 +74,10 @@ spec:
                   name: sentry
                   key: {{ .Release.Name }}.DSN.python
             {{- end }}
+            {{- if .Values.python_warnings }}
+            - name: PYTHONWARNINGS
+              value: {{ .Values.python_warnings | quote }}
+            {{- end }}
           lifecycle:
             preStop:
               {{- include "utils.snippets.pre_stop_graceful_shutdown" . | indent 14 }}

--- a/openstack/designate/templates/central-deployment.yaml
+++ b/openstack/designate/templates/central-deployment.yaml
@@ -70,6 +70,10 @@ spec:
                   name: sentry
                   key: {{ .Release.Name }}.DSN.python
             {{- end }}
+            {{- if .Values.python_warnings }}
+            - name: PYTHONWARNINGS
+              value: {{ .Values.python_warnings | quote }}
+            {{- end }}
           volumeMounts:
             - mountPath: /designate-etc
               name: designate-etc

--- a/openstack/designate/templates/mdns-deployment.yaml
+++ b/openstack/designate/templates/mdns-deployment.yaml
@@ -73,6 +73,10 @@ spec:
                   name: sentry
                   key: {{ .Release.Name }}.DSN.python
             {{- end }}
+            {{- if .Values.python_warnings }}
+            - name: PYTHONWARNINGS
+              value: {{ .Values.python_warnings | quote }}
+            {{- end }}
           livenessProbe:
             tcpSocket:
               port: {{.Values.global.designate_mdns_port_public}}

--- a/openstack/designate/templates/producer-deployment.yaml
+++ b/openstack/designate/templates/producer-deployment.yaml
@@ -68,6 +68,10 @@ spec:
                   name: sentry
                   key: {{ .Release.Name }}.DSN.python
             {{- end }}
+            {{- if .Values.python_warnings }}
+            - name: PYTHONWARNINGS
+              value: {{ .Values.python_warnings | quote }}
+            {{- end }}
           livenessProbe:
             exec:
               command:

--- a/openstack/designate/templates/sink-deployment.yaml
+++ b/openstack/designate/templates/sink-deployment.yaml
@@ -67,6 +67,10 @@ spec:
                   name: sentry
                   key: {{ .Release.Name }}.DSN.python
             {{- end }}
+            {{- if .Values.python_warnings }}
+            - name: PYTHONWARNINGS
+              value: {{ .Values.python_warnings | quote }}
+            {{- end }}
           volumeMounts:
             - mountPath: /designate-etc
               name: designate-etc

--- a/openstack/designate/templates/worker-deployment.yaml
+++ b/openstack/designate/templates/worker-deployment.yaml
@@ -71,6 +71,10 @@ spec:
                   name: sentry
                   key: {{ .Release.Name }}.DSN.python
             {{- end }}
+            {{- if .Values.python_warnings }}
+            - name: PYTHONWARNINGS
+              value: {{ .Values.python_warnings | quote }}
+            {{- end }}
           volumeMounts:
             - mountPath: /designate-etc
               name: designate-etc

--- a/openstack/designate/values.yaml
+++ b/openstack/designate/values.yaml
@@ -426,3 +426,6 @@ vpa:
   # The maximum available capacity is split evenly across containers specified in the Deployment, StatefulSet or DaemonSet to derive the upper recommendation bound. This does not work out for pods with a single resource-hungry container with several sidecar containers
   # Annotate the Deployment, StatefulSet or DaemonSet with vpa-butler.cloud.sap/main-container=$MAIN_CONTAINER. That will distribute 75% of the maximum available capacity to the main container and the rest evenly across all others
   set_main_container: true
+
+# used to set the PYTHONWARNINGS environment variable everywhere
+python_warnings: "ignore:Unverified HTTPS request,ignore::SyntaxWarning"


### PR DESCRIPTION
We want to ignore certain warnings from Python, especially the `SyntaxWarning` and `Unverified HTTPS request`