### PR TITLE
[barbican] Update snmp-hsm alerts

### DIFF
--- a/prometheus-exporters/snmp-exporter/alerts/snmp-hsm.alerts
+++ b/prometheus-exporters/snmp-exporter/alerts/snmp-hsm.alerts
@@ -92,62 +92,17 @@ groups:
       description: "HSM Client License in {{ $labels.devicename }} is {{ $value }}"
       summary: "HSM Client License in {{ $labels.devicename }} is {{ $value }}"
 
-  - alert: hsm01B700IsUnReachable
-    expr: irate(snmp_hsm_hsmUpTime{hsmModel="Luna G7",devicename=~"hsm01.*"}[5m]) != 0
+  - alert: hsmIsUnReachable
+    expr: count(up{job="scrapeConfig/infra-monitoring/snmp-exporter-hsm"} == 0 or absent(up{job="scrapeConfig/infra-monitoring/snmp-exporter-hsm"})) by (name, device_type)
     for: 1h
     labels:
-      severity: info
+      severity: warning
       service: barbican
       context: hsm
-      meta: "HSM01 B700 Device is UnReachable"
+      meta: "{{ $labels.name }} {{ $labels.device_type }} Device is UnReachable"
       dashboard: hsm
       no_alert_on_absence: "true"
       support_group: foundation
     annotations:
-      description: "HSM01 B700 Device is UnReachable"
-      summary: "HSM01 B700 Device is UnReachable"
-
-  - alert: hsm02B700IsUnReachable
-    expr: irate(snmp_hsm_hsmUpTime{hsmModel="Luna G7",devicename=~"hsm02.*"}[5m]) != 0
-    for: 1h
-    labels:
-      severity: info
-      service: barbican
-      context: hsm
-      meta: "HSM02 B700 Device is UnReachable"
-      dashboard: hsm
-      no_alert_on_absence: "true"
-      support_group: foundation
-    annotations:
-      description: "HSM02 B700 Device is UnReachable"
-      summary: "HSM02 B700 Device is UnReachable"
-
-  - alert: hsm01A790IsUnReachable
-    expr: irate(snmp_hsm_hsmUpTime{hsmModel="Luna K7",devicename=~"hsm01.*"}[5m]) < 0.95
-    for: 15m
-    labels:
-      severity: info
-      service: barbican
-      context: hsm
-      meta: "HSM01 A790 Device is UnReachable"
-      dashboard: hsm
-      no_alert_on_absence: "true"
-      support_group: foundation
-    annotations:
-      description: "HSM01 A790 Device is UnReachable"
-      summary: "HSM01 A790 Device is UnReachable"
-
-  - alert: hsm02A790IsUnReachable
-    expr: irate(snmp_hsm_hsmUpTime{hsmModel="Luna K7",devicename=~"hsm02.*"}[5m]) < 0.95
-    for: 15m
-    labels:
-      severity: info
-      service: barbican
-      context: hsm
-      meta: "HSM02 A790 Device is UnReachable"
-      dashboard: hsm
-      no_alert_on_absence: "true"
-      support_group: foundation
-    annotations:
-      description: "HSM02 A790 Device is UnReachable"
-      summary: "HSM02 A790 Device is UnReachable"
+      description: "{{ $labels.name }} {{ $labels.device_type }} Device is UnReachable"
+      summary: "{{ $labels.name }} {{ $labels.device_type }} Device is UnReachable"

--- a/prometheus-exporters/snmp-exporter/alerts/snmp-hsm.alerts
+++ b/prometheus-exporters/snmp-exporter/alerts/snmp-hsm.alerts
@@ -92,9 +92,9 @@ groups:
       description: "HSM Client License in {{ $labels.devicename }} is {{ $value }}"
       summary: "HSM Client License in {{ $labels.devicename }} is {{ $value }}"
 
-  - alert: hsmIsUnReachable
+  - alert: hsmDeviceIsUnReachable
     expr: count(up{job="scrapeConfig/infra-monitoring/snmp-exporter-hsm"} == 0 or absent(up{job="scrapeConfig/infra-monitoring/snmp-exporter-hsm"})) by (name, device_type)
-    for: 1h
+    for: 15m
     labels:
       severity: warning
       service: barbican


### PR DESCRIPTION
Alert for device down or metric absence.