### PR TITLE
castellum, keppel, limes: use policy.json instead of policy.yaml

### DIFF
--- a/openstack/castellum/templates/_utils.tpl
+++ b/openstack/castellum/templates/_utils.tpl
@@ -34,7 +34,7 @@
   value: "http://thanos-metal-query.thanos.svc:10902"
 {{- end }}
 - name: CASTELLUM_OSLO_POLICY_PATH
-  value: /etc/castellum/policy.yaml
+  value: /etc/castellum/policy.json
 - name: CASTELLUM_RABBITMQ_QUEUE_NAME
   value: notifications.info
 - name: CASTELLUM_RABBITMQ_USERNAME

--- a/openstack/castellum/templates/configmap.yaml
+++ b/openstack/castellum/templates/configmap.yaml
@@ -19,5 +19,5 @@ data:
       {{- toYaml .Values.castellum.project_seeds | nindent 6 }}
     {{- end }}
 
-  policy.yaml: |
-    {{- .Files.Get "files/policy.yaml" | nindent 4 }}
+  policy.json: |
+    {{- .Files.Get "files/policy.yaml" | fromYaml | toPrettyJson | nindent 4 }}

--- a/openstack/keppel/templates/_utils.tpl
+++ b/openstack/keppel/templates/_utils.tpl
@@ -137,7 +137,7 @@
 - name:  KEPPEL_JANITOR_LISTEN_ADDRESS
   value: ':80'
 - name:  KEPPEL_OSLO_POLICY_PATH
-  value: '/etc/keppel/policy.yaml'
+  value: '/etc/keppel/policy.json'
 - name:  KEPPEL_PEERS
   value: {{ index (include "build_peers" $ | fromYaml) "peers" | toJson | quote }}
 - name:  KEPPEL_RATELIMIT_ANYCAST_BLOB_PULL_BYTES

--- a/openstack/keppel/templates/configmap.yaml
+++ b/openstack/keppel/templates/configmap.yaml
@@ -5,5 +5,5 @@ metadata:
   name: keppel
 
 data:
-  policy.yaml: |
-{{ .Files.Get "files/policy.yaml" | indent 4 }}
+  policy.json: |
+    {{- .Files.Get "files/policy.yaml" | fromYaml | toPrettyJson | nindent 4 }}

--- a/openstack/limes/files/policy.yaml
+++ b/openstack/limes/files/policy.yaml
@@ -1,0 +1,27 @@
+project_scope: project_domain_id:%(domain_id)s and project_id:%(project_id)s
+domain_scope: domain_id:%(domain_id)s
+
+cluster_editor: role:cloud_resource_admin
+cluster_viewer: role:cloud_resource_admin or role:cloud_resource_viewer
+domain_editor: rule:cluster_editor or (rule:domain_scope and role:resource_admin)
+domain_viewer: rule:cluster_viewer or (rule:domain_scope and role:resource_viewer) or rule:domain_editor
+project_editor: rule:domain_editor or (rule:project_scope and role:resource_admin)
+project_viewer: rule:domain_viewer or (rule:project_scope and (role:member or role:_member_ or role:Member or role:resource_viewer)) or rule:project_editor
+
+project:list: rule:domain_viewer
+project:show: rule:project_viewer
+project:edit: rule:project_editor
+project:edit_max_quota: rule:domain_editor
+project:sync: rule:project_editor
+project:discover: rule:domain_editor
+project:uncommit: rule:cluster_editor
+
+domain:list: rule:cluster_viewer
+domain:show: rule:domain_viewer
+domain:sync: rule:domain_editor
+domain:discover: rule:cluster_editor
+
+cluster:show: rule:cluster_viewer
+cluster:show_basic: rule:cluster_viewer or role:admin or role:resource_admin or role:resource_viewer or role:member or role:_member_ or role:Member
+cluster:show_subcapacity: "'compute':%(service)s and ('cores':%(resource)s or 'instances':%(resource)s or 'ram':%(resource)s)"
+cluster:show_errors: rule:cluster_viewer or role:cloud_support_tools_viewer

--- a/openstack/limes/templates/configmap-liquids.yaml
+++ b/openstack/limes/templates/configmap-liquids.yaml
@@ -5,14 +5,16 @@ metadata:
   name: limes-liquids
 
 data:
-  policy.yaml: |
-    "readwrite": "role:cloud_resource_admin or (user_name:limes and user_domain_name:Default)"
-    "readonly": "role:cloud_resource_viewer or rule:readwrite"
+  policy.json: |
+    {
+      "readwrite": "role:cloud_resource_admin or (user_name:limes and user_domain_name:Default)",
+      "readonly": "role:cloud_resource_viewer or rule:readwrite",
 
-    "liquid:get_info": "rule:readonly"
-    "liquid:get_capacity": "rule:readonly"
-    "liquid:get_usage": "rule:readonly"
-    "liquid:set_quota": "rule:readwrite"
+      "liquid:get_info": "rule:readonly",
+      "liquid:get_capacity": "rule:readonly",
+      "liquid:get_usage": "rule:readonly",
+      "liquid:set_quota": "rule:readwrite"
+    }
 
   {{- range $name, $config := .Values.limes.local_liquid_configs }}
   {{- if not (index $.Values.limes.local_liquids $name "skip") }}

--- a/openstack/limes/templates/configmap.yaml
+++ b/openstack/limes/templates/configmap.yaml
@@ -14,31 +14,5 @@ data:
   constraints-ccloud.yaml: |
 {{ toYaml .Values.limes.constraints.ccloud | indent 4 }}
 
-  policy.yaml: |
-    project_scope: project_domain_id:%(domain_id)s and project_id:%(project_id)s
-    domain_scope: domain_id:%(domain_id)s
-
-    cluster_editor: role:cloud_resource_admin
-    cluster_viewer: role:cloud_resource_admin or role:cloud_resource_viewer
-    domain_editor: rule:cluster_editor or (rule:domain_scope and role:resource_admin)
-    domain_viewer: rule:cluster_viewer or (rule:domain_scope and role:resource_viewer) or rule:domain_editor
-    project_editor: rule:domain_editor or (rule:project_scope and role:resource_admin)
-    project_viewer: rule:domain_viewer or (rule:project_scope and (role:member or role:_member_ or role:Member or role:resource_viewer)) or rule:project_editor
-
-    project:list: rule:domain_viewer
-    project:show: rule:project_viewer
-    project:edit: rule:project_editor
-    project:edit_max_quota: rule:domain_editor
-    project:sync: rule:project_editor
-    project:discover: rule:domain_editor
-    project:uncommit: rule:cluster_editor
-
-    domain:list: rule:cluster_viewer
-    domain:show: rule:domain_viewer
-    domain:sync: rule:domain_editor
-    domain:discover: rule:cluster_editor
-
-    cluster:show: rule:cluster_viewer
-    cluster:show_basic: rule:cluster_viewer or role:admin or role:resource_admin or role:resource_viewer or role:member or role:_member_ or role:Member
-    cluster:show_subcapacity: "'compute':%(service)s and ('cores':%(resource)s or 'instances':%(resource)s or 'ram':%(resource)s)"
-    cluster:show_errors: rule:cluster_viewer or role:cloud_support_tools_viewer
+  policy.json: |
+    {{- .Files.Get "files/policy.yaml" | fromYaml | toPrettyJson | nindent 4 }}

--- a/openstack/limes/templates/deployment-api.yaml
+++ b/openstack/limes/templates/deployment-api.yaml
@@ -53,6 +53,8 @@ spec:
             - /etc/limes/limes.yaml
           env:
             {{ include "limes_common_envvars" . | indent 12 }}
+            - name: LIMES_API_POLICY_PATH
+              value: /etc/limes/policy.json
           securityContext:
             runAsNonRoot: true
           volumeMounts:

--- a/openstack/limes/templates/deployment-liquids.yaml
+++ b/openstack/limes/templates/deployment-liquids.yaml
@@ -44,7 +44,7 @@ spec:
               # ^ NOTE: For liquids that do not take config (e.g. liquid-swift), this variable is ignored,
               # so it is not an error that the respective file does not exist in the configmap.
             - name: LIQUID_POLICY_PATH
-              value: "/etc/liquid/policy.yaml"
+              value: "/etc/liquid/policy.json"
           securityContext:
             runAsNonRoot: true
           volumeMounts:


### PR DESCRIPTION
This does not entirely remove the YAML parser library from these applications yet, but it's a prerequisite to getting there and reducing our dependency tree a little bit.

This change is immediately deployable because JSON is a subset of YAML to a sufficient extent.