### PR TITLE
[px] feat: spread pods in multiple AZs

### DIFF
--- a/px/bird/templates/_deployment-bird.tpl
+++ b/px/bird/templates/_deployment-bird.tpl
@@ -24,6 +24,7 @@ spec:
       annotations:
         k8s.v1.cni.cncf.io/networks: '[{ "name": "vlan{{ .domain_config.multus_vlan }}", "interface": "vlan{{ .domain_config.multus_vlan }}"}]'
     spec:
+      topologySpreadConstraints: {{ include "bird.topology_spread" . | nindent 8 }}
       affinity: {{ include "bird.domain.affinity" . | nindent 8 }}
       tolerations: {{ include "bird.domain.tolerations" . | nindent 8 }}
       initContainers:

--- a/px/bird/templates/_helpers.tpl
+++ b/px/bird/templates/_helpers.tpl
@@ -65,6 +65,31 @@ alert-tier: px
 alert-service: px
 {{- end }}
 
+
+{{- define "bird.topology_spread" }}
+- maxSkew: 1
+  # minDomains: {{ len .top.Values.global.availability_zones }} 
+  topologyKey: topology.kubernetes.io/zone
+  whenUnsatisfiable: ScheduleAnyway
+  labelSelector: 
+    matchExpressions:
+      - key: px.cloud.sap/component
+        operator: In
+        values:
+        - routeserver
+      - key: px.cloud.sap/afi
+        operator: In
+        values:
+        - {{ .afi | quote }}
+      - key: px.cloud.sap/service
+        operator: In
+        values:
+        - {{ .service_number | quote }}
+  # matchLabelKeys: <list> # optional; beta since v1.27
+  nodeAffinityPolicy: Honor # respect affinities below
+  nodeTaintsPolicy: Ignore # default value 
+{{- end }}
+
 {{- define "bird.domain.affinity" }}
 {{- if len .top.Values.apods  | eq 0 }}
 {{- fail "You must supply at least one apod for scheduling" -}}


### PR DESCRIPTION
* Currently we have a set of nodeAffinity to pin PX pods to apods that are cabled for PX. We have podAntiAffinity to make sure that a PX service does not run with a pod of the same service on the same phyiscal node. Another podAntiAffinity makes sure that an PX instance (PX has 2 instances per domain and service) of the same PX service never runs in the same AZ. This leads to the each PX Domain being spread over at least 2 AZs. 
  See original issue: https://github.wdf.sap.corp/cc/px/issues/181
* Add topology spread contraints such that pods are spread over more than 2 AZs, considering each time only the pods  that belong to the same service and AFI. 
  See: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints