### PR TITLE
i511559_remove_railing_slash

### DIFF
--- a/prometheus-exporters/network-generic-ssh-exporter/alerts/asr.alerts
+++ b/prometheus-exporters/network-generic-ssh-exporter/alerts/asr.alerts
@@ -219,7 +219,7 @@ groups:
         service: asr
         context: asr
         meta: "Cisco ASR990x device `{{ $labels.name }}` with reference clock `{{ $labels.reference_clock }}` has a high root dispersion."
-        playbook: /docs/devops/alert/network/ntp
+        playbook: 'docs/devops/alert/network/ntp'
       annotations:
         description: "Cisco ASR990x device `{{ $labels.name }}` has a high root dispersion."
         summary: "Cisco ASR990x  device `{{ $labels.name }}` has a high root dispersion."
@@ -234,7 +234,7 @@ groups:
         service: asr
         context: asr
         meta: "Cisco ASR990x device `{{ $labels.name }}` with reference clock `{{ $labels.reference_clock }}` has a high NTP offset."
-        playbook: /docs/devops/alert/network/ntp
+        playbook: 'docs/devops/alert/network/ntp'
       annotations:
         description: "Cisco ASR990x device `{{ $labels.name }}` has a high NTP offset."
         summary: "Cisco ASR990x device `{{ $labels.name }}` has a high NTP offset."


### PR DESCRIPTION
Removed trailing slash in the playbook [URL](https://operations.global.cloud.sap/docs/devops/alert/network/ntp/)