### PR TITLE
[designate] reduce number of central workers back to 2 by default

### DIFF
--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes to deploy Openstack Designate  (DNSaaS)
 name: designate
-version: 0.3.15
+version: 0.3.16
 appVersion: "xena"
 dependencies:
   - condition: percona_cluster.enabled

--- a/openstack/designate/values.yaml
+++ b/openstack/designate/values.yaml
@@ -30,11 +30,11 @@ global:
   domain_seeds:
     skip_hcm_domain: false
   linkerd_requested: false
-  
+
 pod:
   replicas:
     api: 3
-    central: 4
+    central: 3
     mdns: 2
     poolmanager: 1
     producer: 4
@@ -52,7 +52,7 @@ pod:
 mdns_workers: 2
 producer_workers: 2
 worker_workers: 2
-central_workers: 4
+central_workers: 2
 api_workers: 2
 
 # image_version_designate:  DEFINED-IN-REGION-CHART
@@ -331,7 +331,7 @@ rabbitmq:
   metrics:
     enabled: true
     sidecar:
-      enabled: false 
+      enabled: false
     enableDetailedMetrics: true
     enablePerObjectMetrics: true
 
@@ -423,7 +423,7 @@ owner-info:
 utils:
   trust_bundle:
     enabled: true
-    
+
 vpa:
   # https://github.com/sapcc/vpa_butler
   # The maximum available capacity is split evenly across containers specified in the Deployment, StatefulSet or DaemonSet to derive the upper recommendation bound. This does not work out for pods with a single resource-hungry container with several sidecar containers


### PR DESCRIPTION
Reduce default number of workers per pod to 2
Reduce back default number of pods to 3 per region