### PR TITLE
[designate] Make periodic deleted zone purge configuration changeable

### DIFF
--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes to deploy Openstack Designate  (DNSaaS)
 name: designate
-version: 0.3.16
+version: 0.3.17
 appVersion: "xena"
 dependencies:
   - condition: percona_cluster.enabled

--- a/openstack/designate/templates/etc/_designate.conf.tpl
+++ b/openstack/designate/templates/etc/_designate.conf.tpl
@@ -331,17 +331,17 @@ topic = producer
 #
 
 # Run interval in seconds (integer value)
-interval = 3600
+interval = {{ .Values.zone_purge.interval }}
 
 # Default amount of results returned per page (integer value)
-per_page = 200
+per_page = {{ .Values.zone_purge.per_page }}
 
 # How old deleted zones should be (deleted_at) to be purged, in seconds (integer
 # value)
-time_threshold = 2592000
+time_threshold = {{ .Values.zone_purge.time_threshold }}
 
 # How many zones to be purged on each run (integer value)
-batch_size = 200
+batch_size = {{ .Values.zone_purge.batch_size }}
 
 #------------------------
 # Delayed zones NOTIFY

--- a/openstack/designate/values.yaml
+++ b/openstack/designate/values.yaml
@@ -85,6 +85,12 @@ worker_poll_max_prop_time: '100'
 worker_poll_delay: '3'
 worker_all_tcp: True
 
+zone_purge:
+  interval: '3600'
+  per_page: '200'
+  time_threshold: '2592000'
+  batch_size: '200'
+
 percona_cluster:
   enabled: false
   db_name: designate


### PR DESCRIPTION
This would allow us to set a shorter time_threshold for deleted zone purge in QA environments.

In these QA environments, it might be reasonable to set a 5-day threshold (432000) instead of the default 30.