### PR TITLE
[utils][proxysql] Set default transaction and query timeouts

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.19.7
+version: 0.20.0

--- a/openstack/utils/templates/snippets/_proxysql.cfg.tpl
+++ b/openstack/utils/templates/snippets/_proxysql.cfg.tpl
@@ -42,6 +42,8 @@ mysql_variables =
     connect_retries_on_failure = {{ default 1000 .global.Values.proxysql.connect_retries_on_failure }}
     connect_retries_delay = {{ default 100 .global.Values.proxysql.connect_retries_delay }} {{- /* The default is 1ms, and that means we will run through the retries on failure in no time */}}
     connect_timeout_server_max = {{ default 100000 .global.Values.proxysql.connect_timeout_server_max }}
+    max_transaction_time = {{ default 60000 .global.Values.proxysql.max_transaction_time }}
+    default_query_timeout = {{ default 90000 .global.Values.proxysql.default_query_timeout }}
 }
 
 mysql_servers =


### PR DESCRIPTION
Currently, default values are the following:
- transaction: 4h
- query: 24h

In very rare cases under high load caused by locust we've faced an issue when some sqlalchemy transactions acted as follows:
1 Began
2 Some blocking query was executed (they held a row lock)
3 No commit/rollback follows
4 Transaction continues to hang indefinitely in an idle state
5 All parallel requests modifying these rows were blocked because of (2)

This deadlock could be resolved by:
- killing this idle transaction on DB side manually
- killing application process
- killing transactions on the ProxySQL side

The proposed solution is to introduce query and transaction timeouts in the ProxySQL sidecar with the following values:
- transaction: 60s
- query: 90s

From the application perspective, after reaching these timeouts the error would be:
- transaction: `DBConnectionError: (pymysql.err.OperationalError) (2013, 'Lost connection to MySQL server during query')`
- query: `sqlalchemy.exc.OperationalError: (pymysql.err.OperationalError) (1907, 'Query execution was interrupted, query_timeout exceeded')`