### PR TITLE
[bind] base64 encode just the key values within secret-env

### DIFF
--- a/system/bind/templates/etc/_secret_env.tpl
+++ b/system/bind/templates/etc/_secret_env.tpl
@@ -1,6 +1,6 @@
 {{- if .Values.secret_env }}
 {{- range .Values.secret_env }}
-{{ .name }}: {{ .value | include "resolve_secret" }}
+{{ .name }}: {{ .value | include "resolve_secret" | b64enc }}
 {{- end }}
 {{- else }}
 {}

--- a/system/bind/templates/secrets.yaml
+++ b/system/bind/templates/secrets.yaml
@@ -53,5 +53,5 @@ metadata:
   labels:
     type: configuration
     component: bind
-data: |
-  {{ include (print .Template.BasePath "/etc/_secret_env.tpl") .  | b64enc | indent 2 }}
+data:
+  {{ include (print .Template.BasePath "/etc/_secret_env.tpl") . | indent 2 }}


### PR DESCRIPTION
IOW, if we have:
---
data:
  foo: bar
  john: doe
---
it's just 'bar' and 'doe' we need to encode and not the whole thing within 'data:'