### PR TITLE
[bind] the secrev-env secret is of type Opaque

### DIFF
--- a/system/bind/templates/secrets.yaml
+++ b/system/bind/templates/secrets.yaml
@@ -47,7 +47,7 @@ data:
 ---
 apiVersion: v1
 kind: Secret
-type: kubernetes.io/tls
+type: Opaque
 metadata:
   name: {{ .Release.Name }}-secret-env
   labels:


### PR DESCRIPTION
The "kubernetes.io/tls" type was a copy/paste error.

With it the deployment was failing with the following error: Error: UPGRADE FAILED: failed to create resource: Secret "bind-nsd-qa-de-1-secret-env" is invalid: [data[tls.crt]: Required value, data[tls.key]: Required value]