### PR TITLE
[bind] do no create and load the secret-env secret if empty

### DIFF
--- a/system/bind/templates/deployment.yaml
+++ b/system/bind/templates/deployment.yaml
@@ -87,9 +87,11 @@ spec:
 {{ toYaml .Values.extra_env | indent 8 }}
         {{ end }}
 
+{{- if .Values.secret_env }}
         envFrom:
           - secretRef:
               name: {{ .Release.Name }}-secret-env
+{{- end }}
 
         volumeMounts:
           - name: persistent-storage

--- a/system/bind/templates/secrets.yaml
+++ b/system/bind/templates/secrets.yaml
@@ -43,8 +43,9 @@ type: Opaque
 data:
   rndc.key: |
     {{ include (print .Template.BasePath "/etc/_rndc.key.tpl") . | b64enc | indent 4 }}
-{{ end }}
 ---
+{{ end }}
+{{ if .Values.secret_env }}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -55,3 +56,5 @@ metadata:
     component: bind
 data:
   {{ include (print .Template.BasePath "/etc/_secret_env.tpl") . | indent 2 }}
+---
+{{ end }}


### PR DESCRIPTION
Not all bind instances will have a secret env, so no need to create it and load it.