### PR TITLE
fixes unnecessary quotes for sse_customer_key

### DIFF
--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.14.2
+version: 0.14.3

--- a/common/mariadb/templates/config/_backup_config.yaml.tpl
+++ b/common/mariadb/templates/config/_backup_config.yaml.tpl
@@ -38,7 +38,7 @@ storages:
       region: {{ .Values.global.mariadb.backup_v2.aws.region }}
       bucket_name: "mariadb-backup-{{ .Values.global.region }}"
       sse_customer_algorithm: "AES256"
-      sse_customer_key: "{{ include "mariadb.resolve_secret_squote" .Values.global.mariadb.backup_v2.aws.sse_customer_key }}"
+      sse_customer_key: {{ include "mariadb.resolve_secret_squote" .Values.global.mariadb.backup_v2.aws.sse_customer_key }}
   swift:
     - name: swift-{{ .Values.global.region }}
       auth_version: 3


### PR DESCRIPTION
fixes error in AWS S3:

`InvalidArgument: The secret key was invalid for the specified algorithm.`