### PR TITLE
limes: temporary fix for oomkill in liquid-ironic

### DIFF
--- a/openstack/limes/values.yaml
+++ b/openstack/limes/values.yaml
@@ -28,7 +28,7 @@ limes:
     cinder:    { skip: false, cpu_request: 100m, memory_limit: 128Mi }
     cronus:    { skip: false, cpu_request:  20m, memory_limit:  64Mi }
     designate: { skip: false, cpu_request:  20m, memory_limit:  64Mi }
-    ironic:    { skip: false, cpu_request:  20m, memory_limit: 128Mi }
+    ironic:    { skip: false, cpu_request:  20m, memory_limit: 512Mi } # TODO: why so much memory consumption? we have seen oomkills in large regions with 128Mi and even 256Mi
     manila:    { skip: false, cpu_request:  20m, memory_limit:  64Mi }
     neutron:   { skip: false, cpu_request:  20m, memory_limit:  64Mi }
     octavia:   { skip: false, cpu_request:  20m, memory_limit:  64Mi }


### PR DESCRIPTION
This ought not take this much memory. I will check with a profiler when I have the chance.