### PR TITLE
[snmp exporter] - update f5mgmt oid indexes

### DIFF
--- a/prometheus-exporters/snmp-exporter/generator/f5mgmt-generator.yaml
+++ b/prometheus-exporters/snmp-exporter/generator/f5mgmt-generator.yaml
@@ -2,26 +2,9 @@ modules:
   f5mgmt:
     walk:
       - ltmVirtualServStatClientCurConns
-      - ltmVirtualServStatTotPvaAssistConn
-      - ltmVirtualServStatTotRequests
+      - ltmNodeAddrStatServerCurConns
       - ltmVsStatusAvailState
       - ltmPoolMbrStatusAvailState
-      - ltmDnsProfileStatQueries
-      - ltmDnsProfileStatAReqs
-      - ltmDnsProfileStatAaaaReqs
-      - ltmDnsProfileStatCnameReqs
-      - ltmDnsProfileStatNsReqs
-      - ltmDnsProfileStatPtrReqs
-      - ltmDnsProfileStatSoaReqs
-      - ltmDnsProfileStatSrvReqs
-      - ltmDnsProfileStatResponses
-      - ltmDnsProfileStatTruncated
-      - ltmDnsProfileStatRcodeNoerror
-      - ltmDnsProfileStatRcodeNxdomain
-      - ltmDnsProfileStatRcodeServfail
-      - ltmDnsCacheStatMsgHits
-      - ltmDnsCacheStatMsgMisses
-      - ltmDnsCacheStatFwdQueries
       - sysCmFailoverStatusStatus
       - sysCmSyncStatusColor
       - sysCmSyncStatusStatus


### PR DESCRIPTION
The DNS cache function was moved from the F5s to the unbound servers in the backend.
The related DNS oids are not needed anymore.
Adding new node oid to monitor the current connection count to the unbounds.
Also removing unused oids.