### PR TITLE
[designate] Use api_workers for WSGI API processes limit

### DIFF
--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes to deploy Openstack Designate  (DNSaaS)
 name: designate
-version: 0.3.17
+version: 0.3.18
 appVersion: "xena"
 dependencies:
   - condition: percona_cluster.enabled

--- a/openstack/designate/templates/etc/_wsgi-designate.conf.tpl
+++ b/openstack/designate/templates/etc/_wsgi-designate.conf.tpl
@@ -10,7 +10,7 @@ CustomLog /dev/stdout combined env=!forwarded
 CustomLog /dev/stdout proxy env=forwarded
 
 <VirtualHost *:{{.Values.global.designate_api_port_internal}}>
-    WSGIDaemonProcess designate-api-wsgi processes=8 threads=1 user=designate display-name=%{GROUP}
+    WSGIDaemonProcess designate-api-wsgi processes={{.Values.api_workers}} threads=1 user=designate display-name=%{GROUP}
     WSGIProcessGroup designate-api-wsgi
     WSGIScriptAlias / /var/www/cgi-bin/designate/designate-api-wsgi
     WSGIApplicationGroup %{GLOBAL}

--- a/openstack/designate/values.yaml
+++ b/openstack/designate/values.yaml
@@ -53,7 +53,7 @@ mdns_workers: 2
 producer_workers: 2
 worker_workers: 2
 central_workers: 2
-api_workers: 2
+api_workers: 4
 
 # image_version_designate:  DEFINED-IN-REGION-CHART
 imageVersionTempest: "latest"
@@ -366,7 +366,7 @@ resources:
       memory: "256Mi"
       cpu: "100m"
     limits:
-      memory: "3072Mi"
+      memory: "2048Mi"
       cpu: "4000m"
   central:
     requests:


### PR DESCRIPTION
Reduces the number of processes from 8 per pod down to expected 4