### PR TITLE
[designate] Remove RabbitMQ connection check from API health-probe

### DIFF
--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes to deploy Openstack Designate  (DNSaaS)
 name: designate
-version: 0.4.0
+version: 0.4.1
 appVersion: "xena"
 dependencies:
   - condition: percona_cluster.enabled


### PR DESCRIPTION
Unfortunately, neither RabbitMQ connection is established nor heartbeats are working before any request arrives to the wsgi apache process.

So for this check to work some of the following is required:
- Constant stream of incoming requests triggering the connection to Rabbit
- API should run as a native eventlet application (designate-api)
- API should run as uwsgi application with pthreads enabled for heartbeats

Neither of these options is good for us, so disabling this part of health probe for API service for now.