### PR TITLE
[bind] introducing the "setup_secret_env" helper

### DIFF
--- a/system/bind/templates/_helpers.tpl
+++ b/system/bind/templates/_helpers.tpl
@@ -28,3 +28,17 @@ Create chart name and version as used by the chart label.
                 values:
                 - reinstalling
 {{- end }}
+
+{{/*
+Convert the supplied secret_env structure into a name: value list
+used by envFrom.secretRef.
+*/}}
+{{- define "setup_secret_env" -}}
+{{- if . }}
+{{- range . }}
+{{ .name }}: {{ .value | include "resolve_secret" | b64enc }}
+{{- end }}
+{{- else }}
+{}
+{{- end }}
+{{- end }}

--- a/system/bind/templates/deployment.yaml
+++ b/system/bind/templates/deployment.yaml
@@ -174,8 +174,18 @@ spec:
         imagePullPolicy: {{ .Values.image_pullPolicy }}
         resources:
 {{ toYaml .Values.resources.sshd | indent 10 }}
+
+{{- if .Values.sshd.secret_env }}
         env:
 {{ toYaml .Values.sshd.env | indent 10 }}
+{{- end }}
+
+{{- if .Values.sshd.secret_env }}
+        envFrom:
+          - secretRef:
+              name: {{ .Release.Name }}-sshd-secret-env
+{{- end }}
+
         volumeMounts:
           - name: persistent-storage
             mountPath: {{ .Values.storage_mountpoint | default "/var/lib/bind" }}

--- a/system/bind/templates/etc/_secret_env.tpl
+++ b/system/bind/templates/etc/_secret_env.tpl
@@ -1,7 +1,0 @@
-{{- if .Values.secret_env }}
-{{- range .Values.secret_env }}
-{{ .name }}: {{ .value | include "resolve_secret" | b64enc }}
-{{- end }}
-{{- else }}
-{}
-{{- end }}

--- a/system/bind/templates/secrets.yaml
+++ b/system/bind/templates/secrets.yaml
@@ -55,6 +55,19 @@ metadata:
     type: configuration
     component: bind
 data:
-  {{ include (print .Template.BasePath "/etc/_secret_env.tpl") . | indent 2 }}
+  {{ .Values.secret_env | include "setup_secret_env" | indent 2 }}
+---
+{{ end }}
+{{ if .Values.sshd.secret_env }}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ .Release.Name }}-sshd-secret-env
+  labels:
+    type: configuration
+    component: bind
+data:
+  {{ .Values.sshd.secret_env | include "setup_secret_env" | indent 2 }}
 ---
 {{ end }}


### PR DESCRIPTION
It will convert the supplied secret_env structure into a name: value list consumable by envFrom.secretFrom, e.g.
```yaml
secret_env:
- name: foo
  value: bar
- name: a
  value: b
```

is converted to
```yaml
foo: bar
a: b
```

The values are passed thru the secrets injector and base64 encoded, too.

Also, the sshd container may also use sensitive env vars, i.e. make use of secret_env. Create the secret if that's the case.