### PR TITLE
gatekeeper: allow severity none

### DIFF
--- a/system/gatekeeper/templates/constrainttemplate-prometheusrule-alert-labels.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-prometheusrule-alert-labels.yaml
@@ -31,10 +31,11 @@ spec:
         violation[{"msg": add_support_labels.from_k8s_object(iro, msg)}] {
           alert := alert_rule[_]
           # warn if we don't have a valid labels.severity
-          not regex.match("^(?:critical|warning|info)$", object.get(alert.rule, ["labels", "severity"], ""))
+          not regex.match("^(?:critical|warning|info|none)$", object.get(alert.rule, ["labels", "severity"], ""))
 
+          # the special value none is used by alerts which are only used for inhibition rules like NodeInMaintenance
           msg := sprintf(
-            "rule %s in group %s does not have a valid value for labels.severity (\"critical\", \"warning\" or \"info\")",
+            "rule %s in group %s does not have a valid value for labels.severity (\"critical\", \"warning\", \"info\" or \"none\")",
             [alert.rule.alert, alert.group_name]
           )
         }

--- a/system/gatekeeper/tests/gatekeeper-policies/suite.yaml
+++ b/system/gatekeeper/tests/gatekeeper-policies/suite.yaml
@@ -579,7 +579,7 @@ tests:
     object: fixtures/prometheusrule-alert-labels/prometheus-rule-no-label.yaml
     assertions:
     - violations: 1
-      message: '^\{"support_group":"foo-group","service":"dummy"\} >> rule DummyBackupWentMissing in group backup.alerts does not have a valid value for labels.severity \("critical", "warning" or "info"\)$'
+      message: '^\{"support_group":"foo-group","service":"dummy"\} >> rule DummyBackupWentMissing in group backup.alerts does not have a valid value for labels.severity \("critical", "warning", "info" or "none"\)$'
     - violations: 1
       message: '^\{"support_group":"foo-group","service":"dummy"\} >> rule DummyBackupWentMissing in group backup.alerts does not have labels.support_group$'
   - name: prometheus-rule-only-severity


### PR DESCRIPTION
This is used by alerts which are only used for inhibition eg https://github.com/sapcc/helm-charts/blob/ecfe198278070e69e2b36d1d91d2d415916faa32/prometheus-rules/prometheus-kubernetes-rules/alerts/maintenance.alerts.tpl#L13