### PR TITLE
[alert][snmp-exporter] - remove value variable references from meta field

### DIFF
--- a/prometheus-exporters/snmp-exporter/alerts/f5.alerts
+++ b/prometheus-exporters/snmp-exporter/alerts/f5.alerts
@@ -99,7 +99,7 @@ groups:
           tier: net
           service: f5
           context: f5
-          meta: "Big-IP device {{ $labels.devicename }} reports that {{ $value }}% of all pools on the device are flapping."
+          meta: "Big-IP device {{ $labels.devicename }} reports that some pools are constantly flapping."
           playbook: 'docs/devops/alert/network/f5#f5_pool_flapping'
         annotations:
           description: "Big-IP device {{ $labels.devicename }} reports {{ $value }}% of pools are flapping."
@@ -142,7 +142,7 @@ groups:
           tier: net
           service: f5
           context: f5
-          meta: "Current active connections to {{ $labels.ltmNodeAddrStatNodeName }} on F5 {{ $labels.devicename }} are reaching critical threshold of 65536 (currently at {{ $value }})."
+          meta: "Current active connections to {{ $labels.ltmNodeAddrStatNodeName }} on F5 {{ $labels.devicename }} are reaching critical threshold."
           dashboard: dns-f5-and-unbound-performance
           support_group: network-api
         annotations:


### PR DESCRIPTION
Some of the F5 alerts were not firing, due to incorrect use of `$value` variable inside the `meta` field.
Thanks to @Kuckkuck for pointing that out!