### PR TITLE
[pxc-db] Add ccloud labels to hook and backup resources

### DIFF
--- a/common/pxc-db/Chart.yaml
+++ b/common/pxc-db/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.15
+version: 0.1.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/common/pxc-db/templates/_helpers.tpl
+++ b/common/pxc-db/templates/_helpers.tpl
@@ -59,6 +59,25 @@ name: {{ include "pxc-db.fullname" . }}
 {{- end }}
 
 {{/*
+owner-info lables
+*/}}
+{{- define "pxc-db.ownerLabels" -}}
+{{- if index .Values "owner-info" }}
+ccloud/support-group: {{  index .Values "owner-info" "support-group" | quote }}
+ccloud/service: {{  index .Values "owner-info" "service" | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
+Backup labels
+Add owner-info if exists
+Backup jobs are created by operator and are not inherited from the parent cluster resource
+*/}}
+{{- define "pxc-db.backupLabels" -}}
+{{- include "pxc-db.ownerLabels" . }}
+{{- end }}
+
+{{/*
 Prometheus labels
 */}}
 {{- define "pxc-db.metricsAnnotations" -}}

--- a/common/pxc-db/templates/cluster.yaml
+++ b/common/pxc-db/templates/cluster.yaml
@@ -267,6 +267,8 @@ spec:
         type: s3
         annotations:
 {{ merge (include "pxc-db.linkerdPodAnnotations" $ | fromYaml) ($backup.annotations) | toYaml | indent 10 }}
+        labels:
+{{ merge (include "pxc-db.backupLabels" $ | fromYaml) ($backup.labels) | toYaml | indent 10 }}
         resources:
           requests:
 {{ tpl ($backup.resources.requests | toYaml) $ | indent 12 }}

--- a/common/pxc-db/templates/initdb-bin.yaml
+++ b/common/pxc-db/templates/initdb-bin.yaml
@@ -10,6 +10,8 @@ metadata:
     system: openstack
     type: configuration
     component: database
+    # hooks are not annotated as belonging to the Helm release, so we cannot rely on owner-info injection
+{{- include "pxc-db.ownerLabels" . | indent 4 }}
 {{ include "pxc-db.labels" . | indent 4 }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade

--- a/common/pxc-db/templates/initdb-job.yaml
+++ b/common/pxc-db/templates/initdb-job.yaml
@@ -6,6 +6,8 @@ metadata:
   name: "{{ include "pxc-db.fullname" . }}-init-db"
   namespace:  {{.Release.Namespace}}
   labels:
+    # hooks are not annotated as belonging to the Helm release, so we cannot rely on owner-info injection
+{{- include "pxc-db.ownerLabels" . | indent 4 }}
 {{ include "pxc-db.labels" . | indent 4 }}
   annotations:
 {{- if and (and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested) $.Values.linkerd.enabled }}

--- a/common/pxc-db/templates/initdb-secret.yaml
+++ b/common/pxc-db/templates/initdb-secret.yaml
@@ -9,6 +9,8 @@ metadata:
     system: openstack
     type: configuration
     component: database
+    # hooks are not annotated as belonging to the Helm release, so we cannot rely on owner-info injection
+{{- include "pxc-db.ownerLabels" . | indent 4 }}
 {{ include "pxc-db.labels" . | indent 4 }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade

--- a/common/pxc-db/values.yaml
+++ b/common/pxc-db/values.yaml
@@ -329,6 +329,7 @@ initdb:
 backup:
   enabled: false
   annotations: {}
+  labels: {}
   image:
     name: percona/percona-xtradb-cluster-operator
     tag: 1.15.0-pxc8.0-backup-pxb8.0.35


### PR DESCRIPTION
owner-info injector doesn't handle them