### PR TITLE
[utils][proxysql] Use ProxySQL 2.7.1 as a default version

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.19.6
+version: 0.19.7

--- a/openstack/utils/templates/_proxysql.tpl
+++ b/openstack/utils/templates/_proxysql.tpl
@@ -26,7 +26,7 @@
             {{ .Values.proxysql.imageRepository }}
         {{- else -}}
           {{ required ".Values.global.dockerHubMirror is missing" .Values.global.dockerHubMirror }}/{{ default "proxysql/proxysql" .Values.proxysql.image }}
-        {{- end }}:{{ .Values.proxysql.imageTag | default "2.4.7-debian" }}
+        {{- end }}:{{ .Values.proxysql.imageTag | default "2.7.1-debian" }}
   imagePullPolicy: IfNotPresent
   command: ["proxysql"]
   args: ["--config", "/etc/proxysql/proxysql.cnf", "--exit-on-error", "--foreground", "--idle-threads", "--admin-socket", "/run/proxysql/admin.sock", "--no-version-check", "-D", "/run/proxysql"]


### PR DESCRIPTION
Use ProxySQL 2.7.1 release as a default release if no override is set