### PR TITLE
[rabbitmq] Option to enable SSL for amqp server

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+## 0.13.0
+[@fwiesel](https://github.com/fwiesel)
+- Add options to enable ssl in rabbitmq
+
+The following options need to be set:
+```yaml
+enableSsl: true
+certificate:
+  issuerRef:
+    name: <issuer-name>
+externalNames:
+- <optional-fqdn>
+```
+
+The default is a `ClusterIssuer`, but it can be changed with the respective value
+`certificate.issuerRef.kind`
+
+`externalNames` is optional, and specifies the SAN in the certificate.
+It is imporant there, that all names entered are accepted by the certificate-issuer.
+
 ## 0.12.1
 - `app` selector label returned, because deployment selector is immutable
 - chart version bumped

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: rabbitmq
-version: 0.12.1
+version: 0.13.0
 appVersion: 3.13.7
 description: A Helm chart for RabbitMQ
 sources:

--- a/common/rabbitmq/ci/test-values.yaml
+++ b/common/rabbitmq/ci/test-values.yaml
@@ -4,6 +4,8 @@ global:
   user_suffix: ""
   master_password: ""
   dockerHubMirrorAlternateRegion: "other.dockerhub.mirror"
+  region: "region"
+  tld: "tld"
 
 ports:
   public: 5672
@@ -33,3 +35,15 @@ replicas: 1
 
 metrics:
   enabled: false
+
+
+externalIPs:
+  - "127.0.0.1"
+
+externalNames:
+  - "rabbitmq.example.com"
+
+enableSsl: true
+certificate:
+  issuerRef:
+    name: "test-issuer"

--- a/common/rabbitmq/templates/certificate.yaml
+++ b/common/rabbitmq/templates/certificate.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.enableSsl }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: tls-{{ template "fullname" . }}
+  labels:
+    {{- include "rabbitmq.labels" (list $ "version" "rabbitmq" "deployment" "messagequeue") | indent 4 }}
+spec:
+  secretName: tls-{{ template "fullname" . }}
+  secretTemplate:
+    labels:
+      {{- include "rabbitmq.labels" (list $ "version" "rabbitmq" "deployment" "messagequeue") | indent 6 }}
+  commonName: "{{ template "fullname" . }}.{{ .Release.Namespace }}.svc.kubernetes.{{ .Values.global.region | required "global.region missing" }}.{{ .Values.global.tld | required "global.tld missing" }}"
+  dnsNames:
+    - "{{ template "fullname" . }}.{{ .Release.Namespace }}.svc.kubernetes.{{ .Values.global.region | required "global.region missing" }}.{{ .Values.global.tld | required "global.tld missing" }}"
+  {{- if .Values.externalNames }}
+    {{- range .Values.externalNames }}
+    - "{{ . }}"
+    {{- end }}
+  {{- end }}
+  {{- if .Values.externalIPs }}
+  ipAddresses:
+    {{- range .Values.externalIPs }}
+    - "{{ . }}"
+    {{- end }}
+  {{- end }}
+  {{- .Values.certificate | toYaml | nindent 2 }}
+{{- end }}

--- a/common/rabbitmq/templates/custom-conf-configmap.yaml
+++ b/common/rabbitmq/templates/custom-conf-configmap.yaml
@@ -1,5 +1,5 @@
 ---
-{{ if $.Values.customConfig }}
+{{ if or $.Values.customConfig $.Values.enableSsl }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,6 +7,14 @@ metadata:
   labels:
     {{- include "rabbitmq.labels" (list $ "version" "rabbitmq" "configmap" "messagequeue") | indent 4 }}
 data:
+  {{- if $.Values.customConfig }}
   20-custom.conf: |
-{{ include (print .Template.BasePath "/etc/_rabbitmq-custom-config.tpl") . | indent 4 }}
+  {{- include (print .Template.BasePath "/etc/_rabbitmq-custom-config.tpl") . | nindent 4 }}
+  {{- end }}
+  {{- if $.Values.enableSsl }}
+  30-ssl.conf: |
+    listeners.ssl.default={{ $.Values.ports.amqps }}
+    ssl_options.certfile=/etc/rabbitmq/ssl/tls.crt
+    ssl_options.keyfile=/etc/rabbitmq/ssl/tls.key
+  {{- end }}
 {{ end }}

--- a/common/rabbitmq/templates/deployment.yaml
+++ b/common/rabbitmq/templates/deployment.yaml
@@ -106,12 +106,16 @@ spec:
 {{ toYaml .Values.resources | indent 10 }}
         ports:
           - name: public
-            containerPort: {{ default "5672" .Values.ports.public }}
+            containerPort: {{ .Values.ports.public }}
           - name: management
-            containerPort: {{ default "15672" .Values.ports.management }}
+            containerPort: {{ .Values.ports.management }}
+{{- if .Values.enableSsl }}
+          - name: amqps
+            containerPort: {{ .Values.ports.amqps }}
+{{- end }}
 {{- if .Values.metrics.enabled }}
           - name: metrics
-            containerPort: {{ default "15692" .Values.metrics.port }}
+            containerPort: {{ .Values.metrics.port }}
 {{- end }}
         volumeMounts:
           - mountPath: /var/lib/rabbitmq
@@ -124,6 +128,13 @@ spec:
           - mountPath: /etc/rabbitmq/conf.d/20-custom.conf
             name: rabbitmq-custom-config
             subPath: 20-custom.conf
+        {{- end }}
+        {{- if .Values.enableSsl }}
+          - mountPath: /etc/rabbitmq/conf.d/30-ssl.conf
+            name: rabbitmq-custom-config
+            subPath: 30-ssl.conf
+          - mountPath: /etc/rabbitmq/ssl
+            name: ssl
         {{- end }}
       priorityClassName: {{ .Values.priority_class | default "critical-infrastructure" | quote }}
       volumes:
@@ -145,9 +156,14 @@ spec:
             sources:
             - secret:
                 name: {{ template "fullname" . }}-users
-      {{- if .Values.customConfig }}
+      {{- if or .Values.customConfig .Values.enableSsl }}
         - name: rabbitmq-custom-config
           configMap:
             name: {{ template "fullname" . }}-custom-conf
+      {{- end }}
+      {{- if .Values.enableSsl }}
+        - name: ssl
+          secret:
+            secretName: tls-{{ template "fullname" . }}
       {{- end }}
 {{- end }}

--- a/common/rabbitmq/templates/service.yaml
+++ b/common/rabbitmq/templates/service.yaml
@@ -21,9 +21,13 @@ spec:
 {{- end }}
   ports:
     - name: public
-      port: {{ default 5672 .Values.ports.public }}
+      port: {{ .Values.ports.public }}
     - name: management
-      port: {{ default 15672 .Values.ports.management }}
+      port: {{ .Values.ports.management }}
+{{- if .Values.enableSsl }}
+    - name: amqps
+      port: {{ .Values.ports.amqps }}
+{{- end }}
   selector:
     app.kubernetes.io/instance: {{ template "fullname" . }}
   {{- if .Values.externalIPs }}

--- a/common/rabbitmq/templates/statefulset.yaml
+++ b/common/rabbitmq/templates/statefulset.yaml
@@ -101,6 +101,10 @@ spec:
             containerPort: {{ default "5672" .Values.ports.public }}
           - name: management
             containerPort: {{ default "15672" .Values.ports.management }}
+{{- if .Values.enableSsl }}
+          - name: amqps
+            containerPort: {{ .Values.ports.amqps }}
+{{- end }}
 {{- if .Values.metrics.enabled }}
           - name: metrics
             containerPort: {{ default "15692" .Values.metrics.port }}
@@ -117,6 +121,13 @@ spec:
             name: rabbitmq-custom-config
             subPath: 20-custom.conf
         {{- end }}
+        {{- if .Values.enableSsl }}
+          - mountPath: /etc/rabbitmq/conf.d/30-ssl.conf
+            name: rabbitmq-custom-config
+            subPath: 30-ssl.conf
+          - mountPath: /etc/rabbitmq/ssl
+            name: ssl
+        {{- end }}
       priorityClassName: {{ .Values.priority_class | default "critical-infrastructure" | quote }}
       volumes:
       {{- if not .Values.persistence.enabled }}
@@ -131,10 +142,15 @@ spec:
             sources:
             - secret:
                 name: {{ template "fullname" . }}-users
-      {{- if .Values.customConfig }}
+      {{- if or .Values.customConfig .Values.enableSsl }}
         - name: rabbitmq-custom-config
           configMap:
             name: {{ template "fullname" . }}-custom-conf
+      {{- end }}
+      {{- if .Values.enableSsl }}
+        - name: ssl
+          secret:
+            secretName: tls-{{ template "fullname" . }}
       {{- end }}
   {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:

--- a/common/rabbitmq/values.yaml
+++ b/common/rabbitmq/values.yaml
@@ -19,6 +19,7 @@ imageTag: 3.13.7-management
 priority_class: "critical-infrastructure"
 
 ports:
+  amqps: 5671
   public: 5672
   management: 15672
 
@@ -117,7 +118,18 @@ linkerd:
   enabled: true
 
 # RabbitMQ custom configuration to be added under /etc/rabbitmq/conf.d/20-custom.conf
-customConfig:
+customConfig: {}
   # to set a custom limit please use the following format: 50MB or 1GB
   # if not set default value of 50MB will be used
   # disk_free_limit.absolute: 500MB
+
+enableSsl: false
+certificate:
+  issuerRef:
+    name: nil
+    kind: "ClusterIssuer"
+    group: "cert-manager.io"
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth


### PR DESCRIPTION
The option `enableSsl` configures a certificate with the same name as
the rabbitmq with the prefix `tls-`, which will in turn generate a
secret of the same name.

The only other missing value is the name of the cluster-issuer to
be specified with `certificate.issuerRef.name`

Erlang should automatically reload the certificate, when the file
changes. So, certificate rotation should also be handled.