### PR TITLE
Elektra: more soft probes

### DIFF
--- a/openstack/elektra/templates/deployment.yaml
+++ b/openstack/elektra/templates/deployment.yaml
@@ -85,6 +85,7 @@ spec:
                 - name: host
                   value: elektra.cloud.sap # from rails 6 only hosts defined in config.host are allowed. We are simulating a valid host here.
             timeoutSeconds: 10
+            failureThreshold: 3
             periodSeconds: 60
             initialDelaySeconds: 60
           readinessProbe:
@@ -96,6 +97,7 @@ spec:
                   value: elektra.cloud.sap # from rails 6 only hosts defined in config.host are allowed. We are simulating a valid host here.
             timeoutSeconds: 5
             periodSeconds: 5
+            failureThreshold: 3
           lifecycle:
             preStop:
               exec:


### PR DESCRIPTION
This change should help prevent an Elektra pod from being restarted if we experience more than 10 concurrent requests that take longer than 5 seconds to process. By relaxing the readiness probe parameters, we allow for temporary spikes in response time without unnecessarily marking the pod as unready.

We can play also with the `timeoutSeconds` and `initialDelaySeconds`

related issue https://github.com/sapcc/elektra/issues/1466