### PR TITLE
[pxc-db] Set pxc_strict_mode to MASTER by default

### DIFF
--- a/common/pxc-db/Chart.yaml
+++ b/common/pxc-db/Chart.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v2
 name: pxc-db
 description: A Helm chart for Kubernetes
@@ -15,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.17
+version: 0.1.18
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/common/pxc-db/values.yaml
+++ b/common/pxc-db/values.yaml
@@ -129,6 +129,7 @@ pxc:
       wsrep_provider_options: "gcache.size=1G; gcache.recover=yes"
       wsrep_applier_threads: 4
       wsrep_retry_autocommit: 3
+      pxc_strict_mode: MASTER  # default is ENFORCING
       binlog_format: ROW
       binlog_expire_logs_seconds: 345600 # default 30 days -> 4 days
       sync_binlog: 1 # default value for PXC


### PR DESCRIPTION
Set pxc_strict_mode to MASTER by default

This would allow:
* Sync database from MariaDB backup using go-maria-sync to allow close to zero downtime on migration
* Use database as a tooz coordination backend instead of shared coordination volume or memcached/redis, it requires GET_LOCK()

Excerpt from PXC documentation:
>MASTER: The same as ENFORCING except that the validation of [explicit table locking](https://docs.percona.com/percona-xtradb-cluster/8.0/strict-mode.html?h=strict#explicit-table-locking) is not performed. This mode can be used with clusters in which write operations are isolated to a single node.
