### PR TITLE
[prometheus-vmware-rules] Revise HostWithRunningVMsNotResponding alert

### DIFF
--- a/prometheus-rules/prometheus-vmware-rules/alerts/host.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/host.alerts
@@ -6,7 +6,7 @@ groups:
       avg_over_time(vrops_hostsystem_runtime_connectionstate{state="notResponding"}[5m])
       and on (hostsystem) avg_over_time(vrops_hostsystem_runtime_powerstate{state!="Powered Off"}[5m])
       and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"}
-      and on (hostsystem) count(vrops_virtualmachine_runtime_powerstate{virtualmachine!~"vCLS.*", state="Powered On"}) by (hostsystem) > 0
+      and on (hostsystem) count(vrops_virtualmachine_runtime_powerstate{virtualmachine!~"vCLS.*", state!="Powered Off"}) by (hostsystem) > 0
     for: 5m
     labels:
       severity: critical


### PR DESCRIPTION
- Include the unknown state for VM(s) when disconnected