### PR TITLE
[utils][proxysql] Configure Galera monitor in ProxySQL sidecars

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.20.0
+version: 0.21.0

--- a/openstack/utils/templates/_proxysql_secret.yaml.tpl
+++ b/openstack/utils/templates/_proxysql_secret.yaml.tpl
@@ -18,16 +18,12 @@
       {{/* Determine which database to include based on configuration */}}
       {{- $defaultDbType := .Values.dbType | default "mariadb" }}
       {{- $dbs := dict }}
-      {{- if $envAll.Values.proxysql.multiDestination }}
-        {{- $dbs = $_dbs }}
-      {{- else }}
-        {{- range $dbKey, $db := $_dbs }}
-          {{- if and (eq $defaultDbType "mariadb") (hasPrefix "mariadb" $dbKey) }}
-            {{- $_ := set $dbs $dbKey $db }}
-          {{- end }}
-          {{- if and (eq $defaultDbType "pxc-db") (hasPrefix "pxc" $dbKey) }}
-            {{- $_ := set $dbs $dbKey $db }}
-          {{- end }}
+      {{- range $dbKey, $db := $_dbs }}
+        {{- if and (eq $defaultDbType "mariadb") (hasPrefix "mariadb" $dbKey) }}
+          {{- $_ := set $dbs $dbKey $db }}
+        {{- end }}
+        {{- if and (eq $defaultDbType "pxc-db") (hasPrefix "pxc" $dbKey) }}
+          {{- $_ := set $dbs $dbKey $db }}
         {{- end }}
       {{- end }}
       {{/* Option: use override from proxysql.force_enable value */}}

--- a/openstack/utils/templates/snippets/_proxysql.cfg.tpl
+++ b/openstack/utils/templates/snippets/_proxysql.cfg.tpl
@@ -15,11 +15,21 @@ mysql_variables =
     {{- $monitorEnabled := false }}
     {{- $monitorUsername := "" }}
     {{- $monitorPassword := "" }}
+    {{- $monitorGalera := false }}
     {{- /*
     Check that proxysql_monitor user exists in all DB instances
     Check that proxysql_monitor credentials are the same in all DB instances
     */}}
     {{- range $dbKey, $db := $dbs }}
+        {{- if hasKey $db "pxc" }}
+            {{- $monitorEnabled = true }}
+            {{- $monitorUsername = "monitor" }}
+            {{- $monitorPassword = $db.system_users.monitor.password }}
+            {{- $monitorGalera = true }}
+            {{- if (ne $monitorPassword $db.system_users.monitor.password) }}
+                {{- fail (printf "system_users.monitor.password needs to be the same in %s as in other databases" $dbKey) }}
+            {{- end }}
+        {{- end }}
         {{- if and $db.users $db.users.proxysql_monitor }}
             {{- if not $monitorEnabled }}
                 {{- $monitorEnabled = true }}
@@ -28,7 +38,7 @@ mysql_variables =
             {{- else if or (ne $monitorUsername $db.users.proxysql_monitor.name) (ne $monitorPassword $db.users.proxysql_monitor.password) }}
                 {{- fail (printf "users.proxysql_monitor.password needs to be the same in %s as in other databases" $dbKey) }}
             {{- end }}
-        {{- else if $monitorEnabled }}
+        {{- else if and $monitorEnabled (not $monitorGalera) }}
             {{- fail (printf "users.proxysql_monitor.password is missing in database %s but present in others" $dbKey) }}
         {{- end }}
     {{- end }}
@@ -49,12 +59,78 @@ mysql_variables =
 mysql_servers =
 (
 {{- range $index, $dbKey:= $.dbKeys }}
-  {{- $db := get $dbs $dbKey }}
+{{- /*
+Example for Galera cluster:
+    {
+        address = "test-db-pxc-0.domain.svc.cluster.local"
+        hostgroup = 11
+        max_connections = 20
+        weight = 101
+    }
+*/}}
+    {{- $db := get $dbs $dbKey }}
+    {{- if hasKey $db "pxc" }}
+    {{- if gt (int $db.pxc.size) 7 }}
+    {{- fail "The Galera cluster must not be bigger than 7 nodes" }}
+    {{- end }}
+    {{- range $i := until (int $db.pxc.size) }}
+    {
+        address = "{{ $db.name }}-db-pxc-{{ $i }}.{{ include "svc_fqdn" $.global }}"
+        hostgroup = {{ add 1 (mul 10 (add1 $index)) }}
+        max_connections = {{ $max_connections }}
+        weight = {{ ternary 101 100 (eq $i 0) }}
+    },
+    {{- end }}
+    {{- else }}
+{{- /*
+Example for MariaDB:
+    {
+        address = "test-mariadb.domain.svc.cluster.local"
+        hostgroup = 11
+        max_connections = 20
+        weight = 101
+    }
+*/}}
     {
         address = "{{ $db.name }}-{{ $db.serviceSuffix }}.{{ include "svc_fqdn" $.global }}"
-        hostgroup = {{ $index }}
+        hostgroup = {{ add 1 (mul 10 (add1 $index)) }}
         max_connections = {{ $max_connections }}
     },
+    {{- end }}
+{{- end }}
+)
+
+mysql_galera_hostgroups =
+(
+{{- range $index, $dbKey := $.dbKeys }}
+    {{- $db := get $dbs $dbKey }}
+    {{- if hasKey $db "pxc" }}
+{{- /*
+Example for Galera cluster:
+    {
+        writer_hostgroup=11
+        backup_writer_hostgroup=12
+        reader_hostgroup=13
+        offline_hostgroup=199
+        max_writers=1
+        writer_is_also_reader=1
+        max_transactions_behind=30
+        active=1
+        comment="test"
+    }
+*/}}
+    {
+      writer_hostgroup={{ add 1 (mul 10 (add1 $index)) }}
+      backup_writer_hostgroup={{ add 2 (mul 10 (add1 $index)) }}
+      reader_hostgroup={{ add 3 (mul 10 (add1 $index)) }}
+      offline_hostgroup={{ add 99 (mul 100 (add1 $index)) }}
+      max_writers=1
+      writer_is_also_reader=1
+      max_transactions_behind=30
+      active=1
+      comment="{{ $db.name }}"
+    },
+    {{- end }}
 {{- end }}
 )
 
@@ -67,7 +143,7 @@ mysql_users =
     {
         username = "{{ include "resolve_secret" $user.name | required (print "user name needs to be set for " $dbKey " and user " $userKey) }}"
         password = "{{ include "resolve_secret" $user.password | required (print "password needs to be set for " $dbKey " and user " $userKey)  }}"
-        default_hostgroup = {{ $index }}
+        default_hostgroup = {{ add 1 (mul 10 (add1 $index)) }}
     },
     {{- end }}
   {{- end }}


### PR DESCRIPTION
* Enables monitor if DB is pxc
* Adds all cluster members to `mysql_servers` configuration
* Configures `mysql_galera_hostgroups`
* Remove `multiDestination` option: the same could be done with `force_enable`
