### PR TITLE
[pxc-db] Use internal secret for mysql-exporter sidecar

### DIFF
--- a/common/pxc-db/Chart.yaml
+++ b/common/pxc-db/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.18
+version: 0.1.19
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/common/pxc-db/templates/cluster.yaml
+++ b/common/pxc-db/templates/cluster.yaml
@@ -129,7 +129,7 @@ spec:
         - name: MYSQLD_EXPORTER_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: pxc-db-{{.Values.name}}-secrets
+              name: internal-{{ .Values.name }}-db
               key: monitor
       ports:
         - name: metrics


### PR DESCRIPTION
Use internal secret for mysql-exporter sidecar.

This is required by the updated upstream change for pods to be restarted after `monitor` user password update.