### PR TITLE
castellum/keppel/limes: rework audit logging failure alerts

### DIFF
--- a/openstack/castellum/alerts/openstack/errors.alerts
+++ b/openstack/castellum/alerts/openstack/errors.alerts
@@ -268,11 +268,11 @@ groups:
         summary: Castellum encountered backend errors while resizing some assets
 
     - alert: OpenstackCastellumAuditEventPublishFailing
-      # Usually, you would check increase() here, but audit events *can* be quite
-      # rare, so we alert if there are any failed audit events at all. To clear this alert,
-      # delete the respective
-      expr: max by (pod) (castellum_failed_auditevent_publish > 0)
-      for: 1h
+      # The underlying metric counts failed submission attempts, e.g. because the hermes-rabbitmq server is restarting.
+      # These are not necessarily fatal because the process will hold them in memory to retry the submission later.
+      # The alert will clear up on its own once submissions start working again.
+      expr: sum by (pod) (changes(audittools_failed_submissions{namespace="castellum"}[1h]) > 0)
+      for: 5m
       labels:
         context: auditeventpublish
         service: castellum
@@ -283,4 +283,4 @@ groups:
         meta: '{{ $labels.pod }}'
       annotations:
         summary: "{{ $labels.pod }} cannot publish audit events"
-        description: "Audit events from {{ $labels.pod }} could not be published to the RabbitMQ server. Check the pod log for details. Once the underlying issue was addressed, delete the offending pod to clear this alert."
+        description: "Audit events from {{ $labels.pod }} could not be published to the RabbitMQ server. Check the pod log for detailed error messages. Affected audit events are held in memory until publishing succeeds."

--- a/openstack/keppel/alerts/openstack/api.alerts
+++ b/openstack/keppel/alerts/openstack/api.alerts
@@ -126,11 +126,11 @@ groups:
         starved for CPU time, so try checking the CPU throttling metrics.
 
   - alert: OpenstackKeppelAuditEventPublishFailing
-    # Usually, you would check increase() here, but audit events *can* be quite
-    # rare, so we alert if there are any failed audit events at all. To clear this alert,
-    # delete the respective
-    expr: max by (pod) (keppel_failed_auditevent_publish > 0)
-    for: 1h
+    # The underlying metric counts failed submission attempts, e.g. because the hermes-rabbitmq server is restarting.
+    # These are not necessarily fatal because the process will hold them in memory to retry the submission later.
+    # The alert will clear up on its own once submissions start working again.
+    expr: sum by (pod) (changes(audittools_failed_submissions{namespace="keppel"}[1h]) > 0)
+    for: 5m
     labels:
       context: auditeventpublish
       dashboard: keppel-overview
@@ -141,4 +141,4 @@ groups:
       meta: '{{ $labels.pod }}'
     annotations:
       summary: "{{ $labels.pod }} cannot publish audit events"
-      description: "Audit events from {{ $labels.pod }} could not be published to the RabbitMQ server. Check the pod log for details. Once the underlying issue was addressed, delete the offending pod to clear this alert."
+      description: "Audit events from {{ $labels.pod }} could not be published to the RabbitMQ server. Check the pod log for detailed error messages. Affected audit events are held in memory until publishing succeeds."

--- a/openstack/limes/alerts/openstack/api.alerts
+++ b/openstack/limes/alerts/openstack/api.alerts
@@ -209,11 +209,11 @@ groups:
       summary: Limes cannot sync quota overrides.
 
   - alert: OpenstackLimesAuditEventPublishFailing
-    # Usually, you would check increase() here, but audit events *can* be quite
-    # rare, so we alert if there are any failed audit events at all. To clear this alert,
-    # delete the respective
-    expr: max by (pod) (limes_failed_auditevent_publish > 0)
-    for: 1h
+    # The underlying metric counts failed submission attempts, e.g. because the hermes-rabbitmq server is restarting.
+    # These are not necessarily fatal because the process will hold them in memory to retry the submission later.
+    # The alert will clear up on its own once submissions start working again.
+    expr: sum by (pod) (changes(audittools_failed_submissions{namespace="limes"}[1h]) > 0)
+    for: 5m
     labels:
       context: auditeventpublish
       dashboard: limes-overview
@@ -224,7 +224,7 @@ groups:
       meta: '{{ $labels.pod }}'
     annotations:
       summary: "{{ $labels.pod }} cannot publish audit events"
-      description: "Audit events from {{ $labels.pod }} could not be published to the RabbitMQ server. Check the pod log for details. Once the underlying issue was addressed, delete the offending pod to clear this alert."
+      description: "Audit events from {{ $labels.pod }} could not be published to the RabbitMQ server. Check the pod log for detailed error messages. Affected audit events are held in memory until publishing succeeds."
 
   - alert: OpenstackLimesIncompleteProjectResourceData
     expr: max by (service, resource) (limes_project_resources_by_type_count) != on () group_left max(limes_project_count)


### PR DESCRIPTION
- The go-bits/audittools changes have changed the metric names.
- I have been meaning to fix these stupid alert expressions for a long time.