### PR TITLE
[unbound] accept both externalIP (singular) and externalIPs (plural)

### DIFF
--- a/system/unbound/templates/service.yaml
+++ b/system/unbound/templates/service.yaml
@@ -23,4 +23,13 @@ spec:
       protocol: UDP
       port: 53
       targetPort: dns-udp
-  externalIPs: ["{{ required "A valid .Values.unbound.externalIP required!" .Values.unbound.externalIP }}"]
+  externalIPs:
+  {{- if and ( not $.Values.unbound.externalIP ) ( not $.Values.unbound.externalIPs ) }}
+  {{- fail "Neither $.Values.unbound.externalIP nor $.Values.unbound.externalIPs defined" }}
+  {{- end }}
+  {{- if $.Values.unbound.externalIP }}
+  {{- list $.Values.unbound.externalIP | toYaml | nindent 2 }}
+  {{- end }}
+  {{- if $.Values.unbound.externalIPs }}
+  {{- $.Values.unbound.externalIPs | toYaml | nindent 2 }}
+  {{- end }}


### PR DESCRIPTION
Keeping externalIP for backwards compatibility's sake. We might think about retiring it completely later on.

The externalIP value is expected to be a string, i.e. a single IP. The externalIPs value is expected to be a list.

If both are defined then the values will be merged. If none are defined then we error out.

Q: Why we need this?
A: There might be a situation where we need to expose unbound over multiple IPs.