### PR TITLE
[unbound] switching from single service IP to multiple

### DIFF
--- a/system/unbound/ci/test-values.yaml
+++ b/system/unbound/ci/test-values.yaml
@@ -41,7 +41,8 @@ unbound:
   port_unbound_exporter: 9107
   interface: 0.0.0.0
   failure_domain_zone: a
-  externalIP: 127.0.0.1
+  externalIPs:
+    - 127.0.0.1
   control:
     socket_path: "/run/unbound/control.sock"
 

--- a/system/unbound/templates/service.yaml
+++ b/system/unbound/templates/service.yaml
@@ -23,4 +23,5 @@ spec:
       protocol: UDP
       port: 53
       targetPort: dns-udp
-  externalIPs: ["{{ required "A valid .Values.unbound.externalIP required!" .Values.unbound.externalIP }}"]
+  externalIPs:
+    {{- required "A valid .Values.unbound.externalIPs required!" .Values.unbound.externalIPs | toYaml | nindent 2 }}


### PR DESCRIPTION
The key has been renamed from externalIP to externalIPs. The new one is expecting a list as opposed to the literal value used by the old one.