### PR TITLE
[PX] Use correct python interpreter for lgproxy

### DIFF
--- a/px/bird/templates/_deployment-bird.tpl
+++ b/px/bird/templates/_deployment-bird.tpl
@@ -78,7 +78,7 @@ spec:
           name: metrics
       - name: lgproxy
         image: keppel.{{ .top.Values.registry }}.cloud.sap/{{ required "lg_image must be set" .top.Values.lg_image }}
-        command: ["python3"]
+        command: ["/venv/bin/python3"]
         args: ["lgproxy.py"]
         resources: {{ toYaml .top.Values.resources.proxy | nindent 10 }}
         volumeMounts:
@@ -90,7 +90,7 @@ spec:
           name: lgproxy
       - name: lgadminproxy
         image: keppel.{{ .top.Values.registry }}.cloud.sap/{{ .top.Values.lg_image }}
-        command: ["python3"]
+        command: ["/venv/bin/python3"]
         args: ["lgproxy.py", "priv"]
         resources: {{ toYaml .top.Values.resources.proxy | nindent 10 }}
         volumeMounts:


### PR DESCRIPTION
With the new looking glass image, we use a distroless image. Instead of
running and installing everything into system python as before, we need
to specify the python in the venv that we copied into the runtime
container at the build stage.

This wasn't uncovered in testing as we only ever tested that image in
the lg pod where we would rely on the ENTRYPOINT directive from the
dockerfile. As a sidecar, we start a different pyhton file though but
still called that from system python.
