### PR TITLE
[ironic] Run certrobot twice a day

### DIFF
--- a/openstack/ironic/values.yaml
+++ b/openstack/ironic/values.yaml
@@ -34,7 +34,7 @@ kos_conductor: true
 
 cert_robot:
   image_tag: "latest"
-  schedule: "0 8 * * 1,3,5" # Monday, Wednesday, and Friday at 8:00 (am)
+  schedule: "13 8,14 * * 1-5" # Monday till Friday at 8:13 and 14:13
   env:
     issuer:
     designate:


### PR DESCRIPTION
The prior settings were assuming that we rarely
change the certificates, so no need to run it often. But we also build up new hardware, and configure
it right away with redfish, so this job becomes
a dependency for the build-up.
Doing it twice a day reduces the time people
have to wait for it to work.