### PR TITLE
limes: add support for deployments into the global clusters

### DIFF
--- a/openstack/limes/ci/test-values.yaml
+++ b/openstack/limes/ci/test-values.yaml
@@ -11,7 +11,7 @@ limes:
 
   clusters:
     ccloud:
-      capacitors:
+      catalog_url: https://limes-3.example.com
 
   passwords:
     ccloud:

--- a/openstack/limes/templates/_utils.tpl
+++ b/openstack/limes/templates/_utils.tpl
@@ -44,10 +44,19 @@
 {{- end -}}
 
 {{- define "limes_openstack_envvars" }}
+{{- $limes_url := .Values.limes.clusters.ccloud.catalog_url }}
+{{- $is_global := $limes_url | contains "global" }}
+{{- if $is_global }}
+- name: OS_AUTH_URL
+  value: "{{ $limes_url | replace "limes" "identity" }}/v3"
+- name: OS_INTERFACE
+  value: "public"
+{{- else }}
 - name: OS_AUTH_URL
   value: "http://keystone.{{ $.Values.global.keystoneNamespace }}.svc.kubernetes.{{ $.Values.global.region }}.{{ $.Values.global.tld }}:5000/v3"
 - name: OS_INTERFACE
   value: "internal"
+{{- end }}
 - name: OS_USER_DOMAIN_NAME
   value: "Default"
 - name: OS_USERNAME

--- a/openstack/limes/templates/ingress-api.yaml
+++ b/openstack/limes/templates/ingress-api.yaml
@@ -1,4 +1,5 @@
-{{- $domain := printf "limes-3.%s.%s" .Values.global.region .Values.global.tld -}}
+{{- $domain := .Values.limes.clusters.ccloud.catalog_url | trimPrefix "https://" -}}
+{{- $is_global := $domain | contains "global" -}}
 
 kind: Ingress
 apiVersion: networking.k8s.io/v1
@@ -14,8 +15,14 @@ metadata:
     ingress.kubernetes.io/service-upstream: "true"
     nginx.ingress.kubernetes.io/service-upstream: "true"
     {{- end }}
+    {{- if $is_global }}
+    kubernetes.io/ingress.class: "nginx-external"
+    {{- end }}
 
 spec:
+  {{- if $is_global }}
+  ingressClassName: "nginx-external"
+  {{- end }}
   tls:
     - secretName: limes-api-ccloud
       hosts: [ {{ $domain }} ]

--- a/openstack/limes/templates/ingress-liquids.yaml
+++ b/openstack/limes/templates/ingress-liquids.yaml
@@ -1,7 +1,9 @@
 {{- range $name, $config := .Values.limes.local_liquids }}
 {{- if not $config.skip }}
 
-{{- $domain := printf "liquid-%s.%s.%s" $name $.Values.global.region $.Values.global.tld }}
+{{- $limes_domain := $.Values.limes.clusters.ccloud.catalog_url | trimPrefix "https://" -}}
+{{- $is_global := $limes_domain | contains "global" -}}
+{{- $domain := $limes_domain | replace "limes-3" (printf "liquid-%s" $name) }}
 
 ---
 
@@ -17,8 +19,14 @@ metadata:
     ingress.kubernetes.io/service-upstream: "true"
     nginx.ingress.kubernetes.io/service-upstream: "true"
     {{- end }}
+    {{- if $is_global }}
+    kubernetes.io/ingress.class: "nginx-external"
+    {{- end }}
 
 spec:
+  {{- if $is_global }}
+  ingressClassName: "nginx-external"
+  {{- end }}
   tls:
     - secretName: tls-liquid-{{ $name }}
       hosts: [ {{ $domain }} ]

--- a/openstack/limes/templates/seed-catalog.yaml
+++ b/openstack/limes/templates/seed-catalog.yaml
@@ -1,5 +1,7 @@
-{{- $region := .Values.global.region       | required "missing value for .Values.global.region"       -}}
-{{- $tld    := .Values.global.tld          | required "missing value for .Values.global.tld"          -}}
+{{- $region := .Values.global.region | required "missing value for .Values.global.region" -}}
+{{- $tld    := .Values.global.tld    | required "missing value for .Values.global.tld"    -}}
+{{- $limes_url := .Values.limes.clusters.ccloud.catalog_url | required ".Values.limes.clusters.ccloud.catalog_url" -}}
+{{- $is_global := $limes_url | contains "global" -}}
 
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: OpenstackSeed
@@ -19,11 +21,13 @@ spec:
         - region:    '{{ $region }}'
           interface: public
           enabled:   true
-          url:       '{{.Values.limes.clusters.ccloud.catalog_url}}'
+          url:       '{{ $limes_url }}'
+        {{- if not $is_global }}
         - region:    '{{ $region }}'
           interface: internal
           enabled:   true
           url:       'http://limes-api-ccloud.{{.Release.Namespace}}.svc'
+        {{- end }}
 
     - name:        limes-rates
       type:        sapcc-rates
@@ -33,11 +37,13 @@ spec:
         - region:    '{{ $region }}'
           interface: public
           enabled:   true
-          url:       '{{.Values.limes.clusters.ccloud.catalog_url}}/rates'
+          url:       '{{ $limes_url }}/rates'
+        {{- if not $is_global }}
         - region:    '{{ $region }}'
           interface: internal
           enabled:   true
           url:       'http://limes-api-ccloud.{{.Release.Namespace}}.svc/rates'
+        {{- end }}
 
     {{- range $name := sortAlpha (keys .Values.limes.local_liquids) }}
     {{- $config := index $.Values.limes.local_liquids $name }}
@@ -50,10 +56,12 @@ spec:
         - region:    '{{ $region }}'
           interface: public
           enabled:   true
-          url:       'https://liquid-{{ $name }}.{{ $region }}.cloud.sap'
+          url:       '{{ $limes_url | replace "limes-3" (printf "liquid-%s" $name) }}'
+        {{- if not $is_global }}
         - region:    '{{ $region }}'
           interface: internal
           enabled:   true
           url:       'http://liquid-{{ $name }}.{{ $.Release.Namespace }}.svc'
+        {{- end }}
     {{- end }}
     {{- end }}


### PR DESCRIPTION
The global clusters use non-standard domain naming schemes, so this commit switches to generating all domain names from the basic structure of the limes-api domain name. This is a no-op for existing deployments.