### PR TITLE
[memcached] version bumped to 1.6.33-alpine3.21

### DIFF
--- a/common/memcached/CHANGELOG.md
+++ b/common/memcached/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.6.2 - 2024/12/16
+
+* memcached [version](https://github.com/memcached/memcached/wiki/ReleaseNotes1633) bumped to `1.6.33-alpine3.21`
+* chart version bumped
+
 ## v0.6.1 - 2024/11/28
 * `app` selector label returned, because deployment selector is immutable
 * chart version bumped

--- a/common/memcached/Chart.yaml
+++ b/common/memcached/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: memcached
-version: 0.6.1
+version: 0.6.2
 description: Free & open source, high-performance, distributed memory object caching system.
 home: http://memcached.org/
 sources:

--- a/common/memcached/values.yaml
+++ b/common/memcached/values.yaml
@@ -2,7 +2,7 @@
 ## ref: https://hub.docker.com/r/library/memcached/tags/
 ##
 image: library/memcached
-imageTag: 1.6.31-alpine3.20
+imageTag: 1.6.33-alpine3.21
 # set to true to use .Values.global.dockerHubMirrorAlternateRegion instead of .Values.global.dockerHubMirror
 use_alternate_registry: false
 


### PR DESCRIPTION
- [changelog](https://github.com/memcached/memcached/wiki/ReleaseNotes1633)
- chart version bumped