### PR TITLE
[designate] fix unbound missing endpoint alert

### DIFF
--- a/openstack/designate/alerts/kubernetes/kube.alerts
+++ b/openstack/designate/alerts/kubernetes/kube.alerts
@@ -2,7 +2,7 @@ groups:
 - name: designate-unbound.alerts
   rules:
   - alert: OpenstackDesignateDnsUnboundEndpointNotAvailable
-    expr: max(kube_endpoint_address_available{namespace=~"dns-recursor"}) BY (region,endpoint) < 1
+    expr: max(kube_endpoint_address{namespace=~"dns-recursor"}) BY (region,endpoint) < 1
     for: 15m
     labels:
       context: unbound


### PR DESCRIPTION
- the old metric name is not available