### PR TITLE
[rabbitmq] version bumped to 4.0.5-management

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+## 0.14.0
+
+[@businessbean](https://github.com/businessbean)
+- RabbitMQ [4.0.5 Release Notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.0.5)
+- [What's new?](https://www.rabbitmq.com/docs/whats-new)
+- in version [4.0.1](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.0.1) the default maximum message size reduced from 256 to 16MiB
+  - use `customConfig.max_message_size` to set a different value if required
+- chart version bumped
+
 ## 0.13.0
+
 [@fwiesel](https://github.com/fwiesel)
 - Add options to enable ssl in rabbitmq
 

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: v1
 name: rabbitmq
-version: 0.13.0
-appVersion: 3.13.7
+version: 0.14.0
+appVersion: 4.0.5
 description: A Helm chart for RabbitMQ
 sources:
   - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/values.yaml
+++ b/common/rabbitmq/values.yaml
@@ -8,7 +8,7 @@ global:
   master_password: ""
 
 image: library/rabbitmq
-imageTag: 3.13.7-management
+imageTag: 4.0.5-management
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
- major version upgrade from 3.13.x to 4.0.x to avoid having to do all these version steps later
- 3.13.x development has ended
- better AMQP performance
- RabbitMQ [4.0.5 Release Notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.0.5)
- [What's new?](https://www.rabbitmq.com/docs/whats-new)
- in [version 4.0.1](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.0.1) the default maximum message size reduced from `256` to `16MiB`
- chart version bumped