### PR TITLE
ironic: change traffic policy for pxe-service

### DIFF
--- a/openstack/ironic/Chart.yaml
+++ b/openstack/ironic/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Ironic/OpenStack_Project_Ironic_vertical.png
 name: ironic
-version: 0.1.6
+version: 0.1.7
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/ironic/templates/pxe-service.yaml
+++ b/openstack/ironic/templates/pxe-service.yaml
@@ -11,6 +11,7 @@ metadata:
     {{- include "utils.linkerd.pod_and_service_annotation" . | indent 4 }}
 spec:
   type: NodePort
+  externalTrafficPolicy: Local
   selector:
     name: ironic-pxe
   ports:


### PR DESCRIPTION
Calico now uses a additional BGPFilter that will surpress service
subnets announcements (147.204.35.128/27, 130.214.232.16/28,
10.46.101.0/24). Only /32 host routes for Services will be
announced by nodes. Thus breaking TFTP/iPXE traffic. The traffic
would reach the cluster but not the service. We need to add the
`externalTrafficPolicy: local` to make this work.

Increasing the chart version to track this.
