### PR TITLE
newer traefik requires h2c

### DIFF
--- a/common/thanos/Chart.yaml
+++ b/common/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: Deploy Thanos via operator
 type: application
-version: 1.1.0
+version: 1.1.1
 appVersion: v0.36.1
 maintainers:
   - name: Tommy Sauer (viennaa)

--- a/common/thanos/templates/thanos.yaml
+++ b/common/thanos/templates/thanos.yaml
@@ -25,9 +25,15 @@ spec:
       metadata:
         labels:
           thanos: {{ include "thanos.name" (list $name $root) }}
-        {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
+        {{- if or (and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested)
+                  (and $.Values.traefik.enabled $.Values.traefik.annotations) }}
         annotations:
+        {{- end }}
+        {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
           linkerd.io/inject: enabled
+        {{- end }}
+        {{- if and $.Values.traefik.enabled $.Values.traefik.annotations }}
+          {{ toYaml $.Values.traefik.annotations | indent 10 }}
         {{- end }}
     deploymentOverrides:
       spec:

--- a/common/thanos/values.yaml
+++ b/common/thanos/values.yaml
@@ -372,3 +372,6 @@ traefik:
     enabled: false
     # service the route should point to. Needs to match Thanos Query.
     serviceName: thanos-kubernetes-query
+
+  annotations:
+    traefik.ingress.kubernetes.io/service.serversscheme: h2c


### PR DESCRIPTION
without this option, requests which are coming in from outside the cluster will have a malformed header in their reply.