### PR TITLE
[unbound] introducing multiple external ports

### DIFF
--- a/system/unbound/templates/service.yaml
+++ b/system/unbound/templates/service.yaml
@@ -15,13 +15,15 @@ spec:
     app: {{ .Values.unbound.name }}
     type: dns
   ports: 
-    - name: dns-tcp
+{{- range $.Values.unbound.externalPorts | required ".Values.unbound.externalPorts missing" }}
+    - name: dns-tcp-{{.}}
       protocol: TCP
-      port: 53
+      port: {{.}}
       targetPort: dns-tcp
-    - name: dns-udp
+    - name: dns-udp-{{.}}
       protocol: UDP
-      port: 53
+      port: {{.}}
       targetPort: dns-udp
+{{- end }}
   externalIPs:
     {{- required "A valid .Values.unbound.externalIPs required!" .Values.unbound.externalIPs | toYaml | nindent 2 }}

--- a/system/unbound/values.yaml
+++ b/system/unbound/values.yaml
@@ -37,6 +37,9 @@ unbound:
     tsig:
       keyname: "tsig-key"
 
+  externalPorts:
+    - 53
+
 resources:
   unbound:
     requests:


### PR DESCRIPTION
We can now expose the unbound ports (53/tcp, 53/udp) over multiple external ports.

That might came handy if the clients connecting to the unbounds are behind a load balancers and get NAT-ed. A lot of clients could cause the LB NAT tables to get exhausted.

Using multiple ports and/or multiple service IPs we can increase the service endpoints as required in order to accomodate those clients.