### PR TITLE
[netapp-harvest] exclude particular filer for alert

### DIFF
--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/alerts/thanos-metal/netapp.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/alerts/thanos-metal/netapp.yaml
@@ -1,9 +1,17 @@
 groups:
   - name: netapp-harvest
     rules:
+      # filer stnpca3.cc.eu-de-1.cloud.sap is scraped with host stnpca3-cp001.cc.eu-de-1.cloud.sap
       - alert: NetappHarvestManilaFilerNotScraped
-        expr: label_replace(manila_total_capacity_gb, "host", "$1", "share_backend_fqdn", "(.*)") unless on(host) netapp_volume_size
-        for: 15m
+        expr: |
+          count by (share_backend_name, host) (
+            label_replace(
+              label_replace(
+                manila_total_capacity_gb{share_backend_name!~"integration"},
+                "share_backend_fqdn", "stnpca3-cp001.cc.eu-de-1.cloud.sap", "share_backend_fqdn", "stnpca3.cc.eu-de-1.cloud.sap"),
+                "host", "$1", "share_backend_fqdn", "(.*)"))
+          unless on (host) netapp_volume_size
+        for: 30m
         labels:
           context: netapp-exporter
           no_alert_on_absence: "true"


### PR DESCRIPTION
The name for this filer (stnpca3-cp001) follows old name convention. We
use alternative name in manila-vendor.yaml than how it is configured in
netbox. Replace host label for it to avoid false alert.
