### PR TITLE
[unbound] make unbound listen on multiple ports

### DIFF
--- a/system/unbound/templates/config.yaml
+++ b/system/unbound/templates/config.yaml
@@ -18,8 +18,12 @@ data:
 
         module-config: {{ $unbound_modules | quote }}
 
-        interface: {{.Values.unbound.interface}}
-        port: 53
+        # let unbound listen on all the ports we've defined as external
+        # so that we can map them one-to-one
+{{- range $.Values.unbound.externalPorts | required ".Values.unbound.externalPorts missing" }}
+        interface: {{$.Values.unbound.interface}}@{{.}}
+{{- end }}
+
         do-ip4: yes
         do-ip6: no
         do-udp: yes

--- a/system/unbound/templates/deployment.yaml
+++ b/system/unbound/templates/deployment.yaml
@@ -47,12 +47,14 @@ spec:
         securityContext:
          privileged: true
         ports:
-          - name: dns-tcp
-            containerPort: 53
+{{- range $.Values.unbound.externalPorts | required "externalPorts missing" }}
+          - name: dns-tcp-{{.}}
+            containerPort: {{.}}
             protocol: TCP
-          - name: dns-udp
-            containerPort: 53
+          - name: dns-udp-{{.}}
+            containerPort: {{.}}
             protocol: UDP
+{{- end }}
         volumeMounts:
           - name: unbound-conf
             mountPath: /etc/unbound

--- a/system/unbound/templates/service.yaml
+++ b/system/unbound/templates/service.yaml
@@ -19,11 +19,11 @@ spec:
     - name: dns-tcp-{{.}}
       protocol: TCP
       port: {{.}}
-      targetPort: dns-tcp
+      targetPort: dns-tcp-{{.}}
     - name: dns-udp-{{.}}
       protocol: UDP
       port: {{.}}
-      targetPort: dns-udp
+      targetPort: dns-udp-{{.}}
 {{- end }}
   externalIPs:
     {{- required "A valid .Values.unbound.externalIPs required!" .Values.unbound.externalIPs | toYaml | nindent 2 }}


### PR DESCRIPTION
The goal is to use 1-to-1 service port mappings as having multiple external ports mapping to the same backend port is not a supported feature. See:
https://github.com/kubernetes/kubernetes/issues/47222

Also, we use the interface unbound config clause as it can be specified multiple times as opposed to the port clause.