### PR TITLE
[designate] bump charts

### DIFF
--- a/openstack/designate/Chart.lock
+++ b/openstack/designate/Chart.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: percona_cluster
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.1.8
+  version: 1.1.9
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.1.20
+  version: 0.1.22
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.15.2
@@ -29,5 +29,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:5e1ada2b1e04c06603f2429f4d9e22a119cb88c8c95168dddb7ee12a48bde67b
-generated: "2024-12-16T17:44:50.470177+02:00"
+digest: sha256:846a31a104e64691eb61d27224e2b559207054bdd972603c35557cb85fd66810
+generated: "2024-12-18T13:33:16.963527+02:00"

--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -8,12 +8,12 @@ dependencies:
   - condition: percona_cluster.enabled
     name: percona_cluster
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 1.1.8
+    version: 1.1.9
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.1.20
+    version: 0.1.22
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm


### PR DESCRIPTION
* percona_cluster 1.1.8 -> 1.1.9: add linkerd opaque ports
* pxc-db 0.1.20 -> 0.1.22: update CRD to 1.15.1