### PR TITLE
[ironic] Set agent relevant conductor parameters in api too

### DIFF
--- a/openstack/ironic/templates/etc/_ironic.conf.tpl
+++ b/openstack/ironic/templates/etc/_ironic.conf.tpl
@@ -132,3 +132,15 @@ metrics_enabled = {{ if .Values.audit.metrics_enabled -}}True{{- else -}}False{{
 {{- include "osprofiler" . }}
 
 {{- include "ini_sections.cache" . }}
+
+
+{{- if or .Values.conductor.defaults.conductor.permitted_image_formats .Values.conductor.defaults.conductor.disable_deep_image_inspection }}
+
+[conductor]
+  {{- if .Values.conductor.defaults.conductor.disable_deep_image_inspection }}
+disable_deep_image_inspection = {{ .Values.conductor.defaults.conductor.disable_deep_image_inspection }}
+  {{- end }}
+  {{- if .Values.conductor.defaults.conductor.permitted_image_formats }}
+permitted_image_formats = {{ .Values.conductor.defaults.conductor.permitted_image_formats }}
+  {{- end }}
+{{- end }}

--- a/openstack/ironic/values.yaml
+++ b/openstack/ironic/values.yaml
@@ -209,6 +209,7 @@ conductor:
     redfish:
       swift_object_expiry_timeout: "5400"
     conductor:
+      conductor_always_validates_images: False # We only use the direct interface, so leave it to the agent
       permitted_image_formats: 'raw,qcow2,iso,vmdk'
 
 agent:


### PR DESCRIPTION
The ironic-python-agent gets some config values over the lookup api as 'config' in the json.
And two values are unintuitively taken from the
conductor config section.
So, we have to set them in the api node as well,
in order to have the settings take hold in the agent.