### PR TITLE
[pxc-db] Update PXC CRD to v1.16.0 major release

### DIFF
--- a/common/pxc-db/Chart.yaml
+++ b/common/pxc-db/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.22
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.15.1"
+appVersion: "1.16.0"
 
 dependencies:
   - name: owner-info

--- a/common/pxc-db/templates/cluster.yaml
+++ b/common/pxc-db/templates/cluster.yaml
@@ -30,7 +30,7 @@ spec:
     {{- if $.Values.initContainer.image.override }}
     image: {{ $.Values.initContainer.image.override }}
     {{- else }}
-    image: {{ required ".Values.global.dockerHubMirrorAlternateRegion is missing" .Values.global.dockerHubMirrorAlternateRegion }}/{{ $.Values.initContainer.image.name }}:{{ $.Values.initContainer.image.tag }}
+    image: {{ required ".Values.global.registryAlternateRegion is missing" .Values.global.registryAlternateRegion }}/{{ $.Values.initContainer.image.name }}:{{ $.Values.initContainer.image.tag }}
     {{- end }}
     {{- if .Values.initContainer.resources }}
     resources:
@@ -250,6 +250,9 @@ spec:
     {{- end }}
     {{- if $backup.backoffLimit }}
     backoffLimit: {{ $backup.backoffLimit }}
+    {{- end }}
+    {{- if $backup.activeDeadlineSeconds }}
+    activeDeadlineSeconds: {{ $backup.activeDeadlineSeconds }}
     {{- end }}
     pitr:
     {{- if not $backup.pitr.enabled }}

--- a/common/pxc-db/values.yaml
+++ b/common/pxc-db/values.yaml
@@ -1,3 +1,4 @@
+---
 # Default values for percona-xtradb-cluster.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
@@ -72,8 +73,8 @@ pause: false
 
 initContainer:
   image:
-    name: percona/percona-xtradb-cluster-operator
-    tag: 1.15.1
+    name: percona-xtradb-cluster-operator
+    tag: 1.16.0
     override: null
   resources:
     requests:
@@ -87,7 +88,7 @@ pxc:
   size: 3
   image:
     name: percona/percona-xtradb-cluster
-    tag: 8.0.36-28.1
+    tag: 8.0.39-30.1
     override: null
   imagePullPolicy: IfNotPresent
   annotations: {}
@@ -131,17 +132,17 @@ pxc:
       wsrep_retry_autocommit: 3
       pxc_strict_mode: MASTER  # default is ENFORCING
       binlog_format: ROW
-      binlog_expire_logs_seconds: 345600 # default 30 days -> 4 days
-      sync_binlog: 1 # default value for PXC
+      binlog_expire_logs_seconds: 345600  # default 30 days -> 4 days
+      sync_binlog: 1  # default value for PXC
       net_read_timeout: 30
       net_write_timeout: 60
       connect_timeout: 30
       wait_timeout: 3800
       interactive_timeout: 1800
-      innodb_lock_wait_timeout: 30 # default 50 seconds -> 30 seconds
+      innodb_lock_wait_timeout: 30  # default 50 seconds -> 30 seconds
       max_connections: 1024
-      max_connect_errors: "4294967295" # to avoid failed connections because of loadbalancer health checks
-      innodb_flush_log_at_trx_commit: 1 # for better performance set (2): write at commit, flush once per second
+      max_connect_errors: "4294967295"  # to avoid failed connections because of loadbalancer health checks
+      innodb_flush_log_at_trx_commit: 1  # for better performance set (2): write at commit, flush once per second
       innodb_flush_method: O_DIRECT
       innodb_file_per_table: 1
       innodb_autoinc_lock_mode: 2
@@ -228,7 +229,7 @@ haproxy:
   size: 2
   image:
     name: percona/haproxy
-    tag: 2.8.5
+    tag: 2.8.11
     override: null
   imagePullPolicy: Always
   annotations: {}
@@ -325,7 +326,7 @@ haproxy:
 initdb:
   image:
     name: percona/percona-xtradb-cluster-operator
-    tag: 1.15.1-pxc8.0-backup-pxb8.0.35
+    tag: 1.16.0-pxc8.0-backup-pxb8.0.35
 
 backup:
   enabled: false
@@ -333,10 +334,11 @@ backup:
   labels: {}
   image:
     name: percona/percona-xtradb-cluster-operator
-    tag: 1.15.1-pxc8.0-backup-pxb8.0.35
+    tag: 1.16.0-pxc8.0-backup-pxb8.0.35
     override: null
   imagePullPolicy: Always
-  backoffLimit: 1
+  backoffLimit: 2
+  activeDeadlineSeconds: 3600
   priority_class: "critical-infrastructure"
   resources:
     requests: {}


### PR DESCRIPTION
* Update operator image from 1.15.1 to 1.16.0
* Update pxc image from 8.0.36 to 8.0.39
* Use custom build image for cluster init containers
* Update default haproxy image from 2.8.5 to 2.8.11
* Use 1.16.0-pxc8.0-backup-pxb8.0.35 for backup and init jobs
* Set backup jobs activeDeadlineSeconds to 1 hour (default is infinite)
* Increase backoffLimit from 1 to 2