### PR TITLE
[keystone][pxc-db] Add support for PXC galera cluster

### DIFF
--- a/openstack/keystone/Chart.lock
+++ b/openstack/keystone/Chart.lock
@@ -2,26 +2,26 @@ dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.16.9
-- name: mariadb-galera
+- name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.29.3
+  version: 0.3.1
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.6.9
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.3.5
+  version: 0.4.2
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.2.3
+  version: 1.0.0
 - name: percona_cluster
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.11
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.19.6
+  version: 0.25.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.1.4
-digest: sha256:29cf58d1acb4e095214b913b8b81ae87a0fd52c8cb9cc14dce65dc283232d650
-generated: "2025-03-25T11:40:50.354152+01:00"
+  version: 1.1.0
+digest: sha256:b9a56b25cf79c1c9871d20caa3887a158c514b3e671d6b94c533948a019936f9
+generated: "2025-03-25T17:12:07.427279+02:00"

--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -9,34 +9,34 @@ maintainers:
 name: keystone
 sources:
   - https://github.com/sapcc/keystone
-version: 0.9.0
+version: 0.9.1
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.16.9
-  - condition: mariadb_galera.enabled
-    name: mariadb-galera
-    alias: mariadb_galera
+  - condition: pxc_db.enabled
+    name: pxc-db
+    alias: pxc_db
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.29.3
+    version: 0.3.1
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.6.9
   - condition: mysql_metrics.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.3.5
+    version: 0.4.2
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.2.3
+    version: 1.0.0
   - condition: percona_cluster.enabled
     name: percona_cluster
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.1.11
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.19.6
+    version: 0.25.0
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.1.4
+    version: 1.1.0

--- a/openstack/keystone/ci/test-values.yaml
+++ b/openstack/keystone/ci/test-values.yaml
@@ -1,15 +1,17 @@
+---
 global:
   dbPassword: topSecret
   db_region: local
-  region: test
+  tld: example.com
+  region: regionOne
   master_password: test
-  registryAlternateRegion: test
-  dockerHubMirror: mirror0
-  dockerHubMirrorAlternateRegion: test2
+  registry: my.docker.registry
+  registryAlternateRegion: other.docker.registry
+  dockerHubMirror: my.dockerhub.mirror
+  dockerHubMirrorAlternateRegion: other.dockerhub.mirror
   osprofiler:
     jager:
       enabled: true
-  registry: test
 
 api:
   cloudAdminProjectId: default
@@ -22,3 +24,42 @@ cron:
 osprofiler:
   jager:
     enabled: true
+
+mariadb:
+  root_password: topSecret!
+  backup_v2:
+    enabled: false
+  users:
+    keystone:
+      name: keystone
+      password: topSecret!
+    backup:
+      name: backup
+      password:  topSecret!
+
+pxc_db:
+  enabled: true
+  users:
+    keystone:
+      password: topSecret!
+  system_users:
+    root:
+      password: topSecret!
+    xtrabackup:
+      password: topSecret!
+    monitor:
+      password: topSecret!
+    proxyadmin:
+      password: topSecret!
+    operator:
+      password: topSecret!
+    replication:
+      password: topSecret!
+  backup:
+    s3:
+      secrets:
+        aws_access_key_id: topSecret!
+        aws_secret_access_key: topSecret!
+
+mysql_metrics:
+  db_password: topSecret!

--- a/openstack/keystone/templates/_helpers.tpl
+++ b/openstack/keystone/templates/_helpers.tpl
@@ -15,32 +15,29 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | replace "_" "-" | trimSuffix "-" -}}
 {{- end -}}
 
-{{- define "db_host" -}}
-{{- if .Values.global.clusterDomain -}}
-{{.Release.Name}}-mariadb.{{.Release.Namespace}}.svc.{{.Values.global.clusterDomain}}
-{{- else if and .Values.mariadb_galera.enabled .Values.databaseKind (eq .Values.databaseKind "galera") -}}
-{{.Release.Name}}-mariadb.{{.Release.Namespace}}
-{{- else -}}
-{{.Release.Name}}-mariadb.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.region}}.{{.Values.global.tld}}
-{{- end -}}
-{{- end -}}
-
-{{- define "memcached_host" -}}
-{{- if .Values.global.clusterDomain -}}
-{{.Release.Name}}-memcached.{{.Release.Namespace}}.svc.{{.Values.global.clusterDomain}}
-{{- else if .Values.global_setup -}}
+{{- define "keystone.memcached_host" -}}
+{{- if .Values.global_setup -}}
 {{.Release.Name}}-memcached.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.db_region}}.{{.Values.global.tld}}
 {{- else -}}
 {{.Release.Name}}-memcached.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.region}}.{{.Values.global.tld}}
 {{- end -}}
 {{- end -}}
 
-{{/*
-To satisfy common/mysql_metrics :(
-*/}}
+{{- define "keystone.service_dependencies" }}
+  {{- template "keystone.db_service" . }},{{ template "keystone.memcached_service" . }}
+{{- end }}
 
-{{define "keystone_db_host"}}{{- if .Values.global.clusterDomain }}{{.Release.Name}}-mariadb.{{.Release.Namespace}}.svc.{{.Values.global.clusterDomain}}{{ else }}{{.Release.Name}}-mariadb.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.region}}.{{.Values.global.tld}}{{- end -}}{{end}}
+{{- define "keystone.db_service" }}
+  {{- if or .Values.percona_cluster.enabled (eq .Values.dbType "pxc-global") }}
+    {{- .Release.Name }}-percona-pxc
+  {{- else }}
+    {{- include "utils.db_host" . }}
+  {{- end }}
+{{- end }}
 
+{{- define "keystone.memcached_service" }}
+{{- .Release.Name }}-memcached
+{{- end }}
 
 {{- define "2faproxy.selectorLabels" -}}
 app.kubernetes.io/name: 2faproxy

--- a/openstack/keystone/templates/deployment-api.yaml
+++ b/openstack/keystone/templates/deployment-api.yaml
@@ -73,11 +73,7 @@ spec:
   {{- end }}
 {{- end }}
         - name: DEPENDENCY_SERVICE
-{{- if .Values.percona_cluster.enabled }}
-          value: "{{ .Release.Name }}-percona-pxc,{{ .Release.Name }}-memcached"
-{{- else }}
-          value: "{{ .Release.Name }}-mariadb,{{ .Release.Name }}-memcached"
-{{- end }}
+          value: {{ include "keystone.service_dependencies" . | quote }}
         - name: COMMAND
           value: "true"
       containers:
@@ -123,11 +119,7 @@ spec:
               command:
               - bash
               - -c
-{{- if .Values.global_setup }}
-              - "set -e; curl --fail 127.0.0.1:5000/healthcheck; nc -zvw3 keystone-global-percona-pxc 3306"
-{{- else }}
-              - "set -e; curl --fail 127.0.0.1:5000/healthcheck; nc -zvw3 keystone-mariadb 3306"
-{{- end }}
+              - "set -e; curl --fail 127.0.0.1:5000/healthcheck; nc -zvw3 {{ include "keystone.db_service" . }} 3306"
             initialDelaySeconds: 5
             periodSeconds: 10
             timeoutSeconds: 20

--- a/openstack/keystone/templates/deployment-cron.yaml
+++ b/openstack/keystone/templates/deployment-cron.yaml
@@ -60,11 +60,7 @@ spec:
   {{- end }}
 {{- end }}
         - name: DEPENDENCY_SERVICE
-{{- if .Values.percona_cluster.enabled }}
-          value: "{{ .Release.Name }}-percona-pxc,{{ .Release.Name }}-memcached"
-{{- else }}
-          value: "{{ .Release.Name }}-mariadb,{{ .Release.Name }}-memcached"
-{{- end }}
+          value: {{ include "keystone.service_dependencies" . | quote }}
         - name: COMMAND
           value: "true"
       containers:

--- a/openstack/keystone/templates/etc/_keystone.conf.tpl
+++ b/openstack/keystone/templates/etc/_keystone.conf.tpl
@@ -67,7 +67,7 @@ memcached_servers = "{{ include "helm-toolkit.utils.joinListWithComma" .Values.m
 {{- else if .Values.memcached.host }}
 memcache_servers = {{ .Values.memcached.host }}:{{.Values.memcached.port | default 11211}}
 {{ else }}
-memcache_servers = {{ include "memcached_host" . }}:{{.Values.memcached.port | default 11211}}
+memcache_servers = {{ include "keystone.memcached_host" . }}:{{.Values.memcached.port | default 11211}}
 {{- end }}
 config_prefix = cache.keystone
 expiration_time = {{ .Values.cache.expiration_time | default 600 }}
@@ -151,7 +151,7 @@ enabled = {{ .Values.lifesaver.enabled }}
 {{- if .Values.memcached.host }}
 memcached = {{ .Values.memcached.host }}:{{ .Values.memcached.port | default 11211}}
 {{ else }}
-memcached = {{ include "memcached_host" . }}:{{ .Values.memcached.port | default 11211}}
+memcached = {{ include "keystone.memcached_host" . }}:{{ .Values.memcached.port | default 11211}}
 {{- end }}
 # deprecated
 domain_whitelist = {{ .Values.lifesaver.domain_allowlist | default "Default, tempest" }}

--- a/openstack/keystone/templates/etc/_secrets.conf.tpl
+++ b/openstack/keystone/templates/etc/_secrets.conf.tpl
@@ -1,19 +1,10 @@
 [database]
 # Database connection string - MariaDB for regional setup
 # and Percona Cluster for inter-regional setup:
-{{ if .Values.percona_cluster.enabled -}}
-  {{/* in caase percona is active and we need to switch the connection string to mariadb-galera cluster without removing the percona cluster objects */}}
-  {{- if and .Values.mariadb_galera.enabled .Values.databaseKind (eq .Values.databaseKind "galera") -}}
-connection = mysql+pymysql://{{ .Values.mariadb_galera.mariadb.users.keystone.username }}:{{.Values.mariadb_galera.mariadb.users.keystone.password | include "resolve_secret_urlquery" }}@{{include "db_host" .}}/{{ .Values.mariadb_galera.mariadb.database_name_to_connect }}?charset=utf8
-  {{- else }}
+{{- if or .Values.percona_cluster.enabled (eq .Values.dbType "pxc-global") }}
 connection = {{ include "db_url_pxc" . }}
-  {{- end }}
-{{- else if .Values.global.clusterDomain -}}
-connection = mysql+pymysql://{{ default .Release.Name .Values.global.dbUser }}:{{.Values.global.dbPassword | include "resolve_secret_urlquery" }}@{{include "db_host" .}}/{{ default .Release.Name .Values.mariadb.name }}?charset=utf8
-{{- else if and .Values.mariadb_galera.enabled .Values.databaseKind (eq .Values.databaseKind "galera") -}}
-connection = mysql+pymysql://{{ .Values.mariadb_galera.mariadb.users.keystone.username }}:{{.Values.mariadb_galera.mariadb.users.keystone.password | include "resolve_secret_urlquery" }}@{{include "db_host" .}}/{{ .Values.mariadb_galera.mariadb.database_name_to_connect }}?charset=utf8
 {{- else }}
-connection = {{ include "db_url_mysql" . }}
+connection = {{ include "utils.db_url" . }}
 {{- end }}
 
 {{- if and .Values.memcached.auth.username .Values.memcached.auth.password }}

--- a/openstack/keystone/templates/job-bootstrap.yaml
+++ b/openstack/keystone/templates/job-bootstrap.yaml
@@ -49,11 +49,7 @@ spec:
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
             - name: DEPENDENCY_SERVICE
-{{- if .Values.percona_cluster.enabled }}
-              value: "{{ .Release.Name }}-percona-pxc"
-{{- else }}
-              value: "{{ .Release.Name }}-mariadb"
-{{- end }}
+              value: {{ include "keystone.db_service" . | quote }}
             - name: DEPENDENCY_JOBS
               value: "{{ tuple . "job-migration" | include "job_name" }}"
             {{- if .Values.sentry.enabled }}

--- a/openstack/keystone/templates/job-migration.yaml
+++ b/openstack/keystone/templates/job-migration.yaml
@@ -30,7 +30,7 @@ spec:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") . | sha256sum }}
         # only run once
         "helm.sh/hook": post-install, post-upgrade
-{{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}  
+{{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
 {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ .Release.Name }}
@@ -49,11 +49,7 @@ spec:
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
             - name: DEPENDENCY_SERVICE
-{{- if .Values.percona_cluster.enabled }}
-              value: "{{ .Release.Name }}-percona-pxc"
-{{- else }}
-              value: "{{ .Release.Name }}-mariadb"
-{{- end }}
+              value: {{ include "keystone.db_service" . | quote }}
             {{- if .Values.sentry.enabled }}
             - name: SENTRY_DSN
             {{- if .Values.sentry.dsn }}

--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -300,10 +300,29 @@ mariadb:
           enabled: true
           allTables: true
 
-# MariaDB Galera cluster as database backend
-# mariadb.enabled has to be false if Galera is enabled
-mariadb_galera:
+pxc_db:
   enabled: false
+  name: keystone
+  alerts:
+    support_group: identity
+  databases:
+    - keystone
+  users:
+    keystone:
+      name: keystone
+      grants:
+        - "ALL PRIVILEGES on keystone.*"
+  pxc:
+    persistence:
+      size: 10Gi
+  backup:
+    enabled: true
+    s3:
+      secrets:
+        aws_access_key_id: null
+        aws_secret_access_key: null
+    pitr:
+      enabled: true
 
 mysql_metrics:
   enabled: true


### PR DESCRIPTION
* Add support for PXC galera cluster URL
* Update mysql-metrics and utils charts to support galera cluster
* Remove mariadb-galera support
* Remove unused helm helper functions db_host and keystone_db_host
* Update linkerd-support and owner-info to release versions


The initial change adds an option to enable Galera cluster for the service in parallel with the existing MariaDB. Without setting `pxc_db.enabled=true` this PR causes no change in deployment.