### PR TITLE
[pxc-operator] Bump chart version and update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,7 +21,7 @@
 /common/prometheus-pushgateway                         @viennaa # old
 /common/prometheus-server                              @viennaa @richardtief @Kuckkuck @IvoGoman @timojohlo
 /common/prometheus-server-pre7                         @viennaa @richardtief @Kuckkuck @IvoGoman @timojohlo
-/common/pxc-db                                         @s10 @businessbean @bashar-alkhateeb
+/common/pxc-db                                         @s10 @businessbean @galkindmitrii
 /common/rabbitmq                                       @galkindmitrii @fwiesel @Carthaca @bashar-alkhateeb @dusandordevicsap @businessbean
 /common/rabbitmq-cluster                               @galkindmitrii @notandy @defo89 @businessbean
 /common/redis*                                         @majewsky @SuperSandro2000 @VoigtS @Nuckal777
@@ -266,8 +266,8 @@
 /system/prometheus-operator                            @viennaa @richardtief
 /system/provider-kubernikus                            @defo89
 /system/provider-metal3                                @defo89 @Nuckal777
-/system/percona-xtradb-cluster-crds                    @s10 @businessbean @bashar-alkhateeb
-/system/percona-xtradb-cluster-operator                @s10 @businessbean @bashar-alkhateeb
+/system/percona-xtradb-cluster-crds                    @s10 @businessbean @galkindmitrii
+/system/percona-xtradb-cluster-operator                @s10 @businessbean @galkindmitrii
 /system/rabbitmq-operator                              @galkindmitrii
 /system/runtime-extension-maintenance-controller       @Nuckal777 @defo89 @majewsky @SuperSandro2000 @VoigtS
 /system/secrets-injector                               @Nuckal777 @majewsky @SuperSandro2000 @VoigtS

--- a/system/percona-xtradb-cluster-operator/Chart.lock
+++ b/system/percona-xtradb-cluster-operator/Chart.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 1.0.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.0.0
+  version: 1.1.0
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 5.27.0
-digest: sha256:6be0b9a595266078f58be0e459f3165d29fcf6082604ba7745b80f22e34df935
-generated: "2024-12-20T10:20:46.691862+02:00"
+digest: sha256:178152c2db0f6266d3722718e06dea813c2798442244b4c0a095e22c4164794b
+generated: "2024-12-20T12:29:55.128909+02:00"

--- a/system/percona-xtradb-cluster-operator/Chart.yaml
+++ b/system/percona-xtradb-cluster-operator/Chart.yaml
@@ -4,7 +4,7 @@ name: percona-xtradb-cluster-operator
 description: A Helm chart to install Percona XtraDB Cluster Operator.
 home: "https://github.com/sapcc/helm-charts/tree/master/system/percona-xtradb-cluster-operator"
 type: application
-version: 0.2.3
+version: 0.3.0
 appVersion: "1.16.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
@@ -26,7 +26,7 @@ dependencies:
     version: 1.0.0
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 1.0.0
+    version: 1.1.0
   - name: kube-state-metrics
     repository: https://prometheus-community.github.io/helm-charts
     version: 5.27.0

--- a/system/percona-xtradb-cluster-operator/templates/_helpers.tpl
+++ b/system/percona-xtradb-cluster-operator/templates/_helpers.tpl
@@ -6,3 +6,16 @@ app.kubernetes.io/version: {{ .Chart.AppVersion }}
 app.kubernetes.io/managed-by: "helm"
 helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}
 {{- end }}
+
+{{/*
+Override function returns image URI according to parameters set
+*/}}
+{{- define "pxc-operator.image" -}}
+{{- if .Values.image }}
+{{- .Values.image }}
+{{- else if .Values.imageTag }}
+{{- printf "%s:%s" .Values.operatorImageRepository .Values.imageTag }}
+{{- else }}
+{{- printf "%s:%s" .Values.operatorImageRepository .Chart.AppVersion }}
+{{- end }}
+{{- end -}}

--- a/system/percona-xtradb-cluster-operator/values.yaml
+++ b/system/percona-xtradb-cluster-operator/values.yaml
@@ -7,7 +7,7 @@ pxc-operator:
 
   replicaCount: 1
 
-  operatorImageRepository: keppel.global.cloud.sap/ccloud-dockerhub-mirror/percona/percona-xtradb-cluster-operator
+  operatorImageRepository: keppel.global.cloud.sap/ccloud/percona-xtradb-cluster-operator
   imagePullPolicy: IfNotPresent
   image: ""
 


### PR DESCRIPTION
* Add version override function to be able to set imageTag in values
* Use ccloud repository instead of mirror by default
* Bump chart version to 0.3.0
* Update CODEOWNERS
* Bump linkerd-support dependency