### PR TITLE
[designate] bump pxc-db chart

### DIFF
--- a/openstack/designate/Chart.lock
+++ b/openstack/designate/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.1.9
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.1.22
+  version: 0.2.0
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.15.2
@@ -29,5 +29,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:846a31a104e64691eb61d27224e2b559207054bdd972603c35557cb85fd66810
-generated: "2024-12-18T13:33:16.963527+02:00"
+digest: sha256:07e3fe91666e0333a6d4cf70f2badd53461a4b0737de76156e87e1c854e7e396
+generated: "2024-12-20T14:18:27.9057+02:00"

--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes to deploy Openstack Designate  (DNSaaS)
 name: designate
-version: 0.4.5
+version: 0.4.6
 appVersion: "xena"
 dependencies:
   - condition: percona_cluster.enabled
@@ -13,7 +13,7 @@ dependencies:
     name: pxc-db
     alias: pxc_db
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.1.22
+    version: 0.2.0
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/designate/values.yaml
+++ b/openstack/designate/values.yaml
@@ -148,7 +148,6 @@ pxc_db:
   users:
     designate:
       name: designate
-      auth_plugin: 'mysql_native_password'
       grants:
       - "ALL PRIVILEGES on designate.*"
   pxc:


### PR DESCRIPTION
* Update pxc-db chart for designate
  - PXC 8.0.36 to 8.0.39
  - HAProxy 2.8.5 to 2.8.11
  - Backup improvements and fixes
* Don't use mysql_native_password for designate user
  - It's no longer needed with proxysql 2.7.1