### PR TITLE
[unbound] don't use named ports

### DIFF
--- a/system/unbound/templates/deployment.yaml
+++ b/system/unbound/templates/deployment.yaml
@@ -46,15 +46,6 @@ spec:
 {{ toYaml .Values.resources.unbound | indent 10 }}
         securityContext:
          privileged: true
-        ports:
-{{- range $.Values.unbound.externalPorts | required "externalPorts missing" }}
-          - name: dns-tcp-{{.}}
-            containerPort: {{.}}
-            protocol: TCP
-          - name: dns-udp-{{.}}
-            containerPort: {{.}}
-            protocol: UDP
-{{- end }}
         volumeMounts:
           - name: unbound-conf
             mountPath: /etc/unbound

--- a/system/unbound/templates/service.yaml
+++ b/system/unbound/templates/service.yaml
@@ -19,11 +19,9 @@ spec:
     - name: dns-tcp-{{.}}
       protocol: TCP
       port: {{.}}
-      targetPort: dns-tcp-{{.}}
     - name: dns-udp-{{.}}
       protocol: UDP
       port: {{.}}
-      targetPort: dns-udp-{{.}}
 {{- end }}
   externalIPs:
     {{- required "A valid .Values.unbound.externalIPs required!" .Values.unbound.externalIPs | toYaml | nindent 2 }}


### PR DESCRIPTION
No need for the named ports. Let's simplify things.

We're mapping the unbound ports 1-to-1, i.e. service port 53 maps to unbound port 53, etc.