### PR TITLE
[pxc-db] Move linkerd service annotations out of values

### DIFF
--- a/common/pxc-db/Chart.yaml
+++ b/common/pxc-db/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.6
+version: 0.2.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/common/pxc-db/templates/cluster.yaml
+++ b/common/pxc-db/templates/cluster.yaml
@@ -73,10 +73,13 @@ spec:
 {{ merge (include "pxc-db.linkerdPodAnnotations" $ | fromYaml) (include "pxc-db.metricsAnnotations" $ | fromYaml ) ($pxc.annotations) | toYaml | indent 6 }}
     labels:
 {{ merge (include "pxc-db.appLabels" $ | fromYaml) ($pxc.labels) | toYaml | indent 6 }}
-    {{- if $pxc.expose }}
     expose:
-{{ tpl ($pxc.expose | toYaml) $ | indent 6 }}
-    {{- end }}
+      enabled: {{ $pxc.expose.enabled }}
+      type: {{ $pxc.expose.type }}
+      externalTrafficPolicy: {{ $pxc.expose.externalTrafficPolicy }}
+      internalTrafficPolicy: {{ $pxc.expose.internalTrafficPolicy }}
+      annotations:
+{{ merge (include "pxc-db.linkerdServiceAnnotations" $ | fromYaml) ($pxc.expose.annotations) | toYaml | indent 8 }}
     autoRecovery: {{ $pxc.autoRecovery }}
     readinessDelaySec: 15
     livenessDelaySec: 600
@@ -221,9 +224,19 @@ spec:
 {{ tpl ($haproxy.podSecurityContext | toYaml) $ | indent 6 }}
     {{- end }}
     exposePrimary:
-{{ $haproxy.service.primary | toYaml | indent 6 }}
+      enabled: {{ $haproxy.service.primary.enabled }}
+      type: {{ $haproxy.service.primary.type }}
+      externalTrafficPolicy: {{ $haproxy.service.primary.externalTrafficPolicy }}
+      internalTrafficPolicy: {{ $haproxy.service.primary.internalTrafficPolicy }}
+      annotations:
+{{ merge (include "pxc-db.linkerdServiceAnnotations" $ | fromYaml) ($haproxy.service.primary.annotations) | toYaml | indent 8 }}
     exposeReplicas:
-{{ $haproxy.service.replicas | toYaml | indent 6 }}
+      enabled: {{ $haproxy.service.replicas.enabled }}
+      type: {{ $haproxy.service.replicas.type }}
+      externalTrafficPolicy: {{ $haproxy.service.replicas.externalTrafficPolicy }}
+      internalTrafficPolicy: {{ $haproxy.service.replicas.internalTrafficPolicy }}
+      annotations:
+{{ merge (include "pxc-db.linkerdServiceAnnotations" $ | fromYaml) ($haproxy.service.replicas.annotations) | toYaml | indent 8 }}
     resources:
       requests:
 {{ tpl ($haproxy.resources.requests | toYaml) $ | indent 8 }}

--- a/common/pxc-db/values.yaml
+++ b/common/pxc-db/values.yaml
@@ -172,12 +172,11 @@ pxc:
   # -- Expose cluster pods as separate services
   # https://docs.percona.com/percona-operator-for-mysql/pxc/expose.html#service-per-pod
   expose:
-    enabled: false
+    enabled: true
     type: ClusterIP
     externalTrafficPolicy: Cluster
     internalTrafficPolicy: Cluster
-    annotations:
-      config.linkerd.io/opaque-ports: "3306,3307,3009,4444,4567,4568,33060,33062"
+    annotations: {}
   # -- Automatic crash recovery
   # https://docs.percona.com/percona-operator-for-mysql/pxc/recovery.html#automatic-crash-recovery
   autoRecovery: true
@@ -329,8 +328,7 @@ haproxy:
       type: ClusterIP
       externalTrafficPolicy: Cluster
       internalTrafficPolicy: Cluster
-      annotations:
-        config.linkerd.io/opaque-ports: "3306,3307,3009,4444,4567,4568,33060,33062"
+      annotations: {}
     # --  Replicas HAPRoxy service configuration
     # Exposes *all* cluster members
     # https://docs.percona.com/percona-operator-for-mysql/pxc/operator.html?#haproxyexposereplicasenabled
@@ -339,8 +337,7 @@ haproxy:
       type: ClusterIP
       externalTrafficPolicy: Cluster
       internalTrafficPolicy: Cluster
-      annotations:
-        config.linkerd.io/opaque-ports: "3306,3307,3009,4444,4567,4568,33060,33062"
+      annotations: {}
   priority_class: "critical-infrastructure"
   # -- Advanced affinity configuration for HAProxy pods
   # https://docs.percona.com/percona-operator-for-mysql/pxc/constraints.html#simple-approach-use-topologykey-of-the-percona-operator-for-mysql


### PR DESCRIPTION
* Make linkerd service annotation optional
* Enable pxc service exposure by default, because it's mandatory by openstack/utils