### PR TITLE
[unbound] moved the prometheus annotations to the deployment

### DIFF
--- a/system/unbound/templates/deployment.yaml
+++ b/system/unbound/templates/deployment.yaml
@@ -18,6 +18,8 @@ spec:
         type: dns
       annotations:
         checksum/unbound.config: {{ include "unbound/templates/config.yaml" . | sha256sum }}
+        prometheus.io/scrape: "true"
+        prometheus.io/targets: {{ required "$.Values.alerts.prometheus missing" $.Values.alerts.prometheus | quote }}
     spec:
       affinity:
         nodeAffinity:

--- a/system/unbound/templates/service.yaml
+++ b/system/unbound/templates/service.yaml
@@ -6,9 +6,6 @@ kind: Service
 metadata:
   name: {{ $.Values.unbound.name }}-{{ $proto }}
   annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "{{$.Values.unbound.port_unbound_exporter}}"
-    prometheus.io/targets: {{ required "$.Values.alerts.prometheus missing" $.Values.alerts.prometheus | quote }}
     parrot.sap.cc/announce: 'true'
     service.alpha.kubernetes.io/reject-traffic-on-external-ip: "false"
 spec:


### PR DESCRIPTION
This is making sure the scrape targets are not discovered twice.

We've also removed the "prometheus.io/port" annotation and relying on the metrics port definition.

This way the prometheus service discovery will be ending up with the metric container.

The monitors will have to be adjusted.