### PR TITLE
[pxc-operator] Set correct target for the OperatorNotReady alerts

### DIFF
--- a/system/percona-xtradb-cluster-operator/Chart.yaml
+++ b/system/percona-xtradb-cluster-operator/Chart.yaml
@@ -4,9 +4,8 @@ name: percona-xtradb-cluster-operator
 description: A Helm chart to install Percona XtraDB Cluster Operator.
 home: "https://github.com/sapcc/helm-charts/tree/master/system/percona-xtradb-cluster-operator"
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: "1.16.1"
-kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: Birk Bohne
     url: https://github.com/businessbean

--- a/system/percona-xtradb-cluster-operator/templates/alerts.yaml
+++ b/system/percona-xtradb-cluster-operator/templates/alerts.yaml
@@ -2,12 +2,12 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: percona-xtradb-cluster-operator-alerts
+  name: percona-xtradb-cluster-operator-kubernetes-alerts
   labels:
-    prometheus: openstack
-    app.kubernetes.io/component: percona-xtradb-cluster-operator-alerts
+    prometheus: kubernetes
+    app.kubernetes.io/component: percona-xtradb-cluster-operator-kubernetes-alerts
     {{- include "percona-xtradb-cluster-operator.labels" . | indent 4}}
 spec:
   groups:
-{{ include (print .Template.BasePath "/alerts/_pxc-operator.alerts.tpl") . | indent 2 }}
+{{ include (print .Template.BasePath "/alerts/kubernetes/_pxc-operator.alerts.tpl") . | indent 2 }}
 {{- end }}

--- a/system/percona-xtradb-cluster-operator/templates/alerts/kubernetes/_pxc-operator.alerts.tpl
+++ b/system/percona-xtradb-cluster-operator/templates/alerts/kubernetes/_pxc-operator.alerts.tpl
@@ -1,4 +1,4 @@
-- name: pxc-operator.alerts
+- name: pxc-operator-kubernetes.alerts
   rules:
   - alert: PerconaXtraDBClusterOperatorNotReady
     expr: (sum(kube_pod_status_ready_normalized{condition="true", pod=~"percona-xtradb-cluster-operator.*"}) < 1)

--- a/system/percona-xtradb-cluster-operator/values.yaml
+++ b/system/percona-xtradb-cluster-operator/values.yaml
@@ -245,6 +245,5 @@ owner-info:
   support-group: network-api
   maintainers:
     - Vladislav Gusev
-    - Bashar Alkhateeb
     - Birk Bohne
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/system/percona-xtradb-cluster-operator


### PR DESCRIPTION
* Set correct target for the OperatorNotReady alerts
* Update maintainers list

Pods metrics from kube-state-metrics present only in kubernetes prometheus