### PR TITLE
[octavia][pxc-db] Add support for PXC galera cluster: part 1

### DIFF
--- a/openstack/octavia/Chart.lock
+++ b/openstack/octavia/Chart.lock
@@ -2,23 +2,26 @@ dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.14.2
+- name: pxc-db
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 0.3.1
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.5.3
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.3.5
+  version: 0.4.2
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.11.1
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.19.7
+  version: 0.23.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:8b764e30a05b01f227c6825be05c39f916ad22137a19ede4bd70cf2ab4de185e
-generated: "2024-11-29T11:48:17.569776618+01:00"
+digest: sha256:85fb2f4ac262dd78c8d01c045cfce1215c26af410f089b6ce77a48dd734db356
+generated: "2025-03-20T12:37:09.650574+02:00"

--- a/openstack/octavia/Chart.yaml
+++ b/openstack/octavia/Chart.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v2
 appVersion: "yoga"
 description: A Helm chart for OpenStack Octavia
@@ -8,25 +9,30 @@ sources:
   - https://git.openstack.org/cgit/openstack/octavia
   - https://git.openstack.org/cgit/openstack/openstack-helm
 # The versions are defined in the changelog: https://docs.openstack.org/releasenotes/octavia/yoga.html
-version: 10.0.2
+version: 10.1.0
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.14.2
+  - condition: pxc_db.enabled
+    name: pxc-db
+    alias: pxc_db
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: 0.3.1
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.5.3
   - condition: mariadb.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.3.5
+    version: 0.4.2
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.11.1
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.19.7
+    version: 0.23.0
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0

--- a/openstack/octavia/ci/test-values.yaml
+++ b/openstack/octavia/ci/test-values.yaml
@@ -1,9 +1,11 @@
+---
 global:
   registry: myRegistry
   dbPassword: secret!
   master_password: topSecret!
   octavia_service_password: topSecret!!
-  dockerHubMirrorAlternateRegion: some_region
+  registryAlternateRegion: other.docker.registry
+  dockerHubMirrorAlternateRegion: other.dockerhub.mirror
   availability_zones:
     - foo
     - bar
@@ -12,8 +14,35 @@ imageVersion: train
 
 mariadb:
   root_password: topSecret
+  users:
+    octavia:
+      password: topSecret
   backup_v2:
     enabled: false
+
+pxc_db:
+  enabled: true
+  users:
+    octavia:
+      password: topSecret!
+  system_users:
+    root:
+      password: topSecret!
+    xtrabackup:
+      password: topSecret!
+    monitor:
+      password: topSecret!
+    proxyadmin:
+      password: topSecret!
+    operator:
+      password: topSecret!
+    replication:
+      password: topSecret!
+  backup:
+    s3:
+      secrets:
+        aws_access_key_id: topSecret!
+        aws_secret_access_key: topSecret!
 
 rabbitmq:
   metrics:

--- a/openstack/octavia/templates/_helpers.tpl
+++ b/openstack/octavia/templates/_helpers.tpl
@@ -30,3 +30,7 @@ Create chart name and version as used by the chart label.
 {{- define "octavia.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "octavia.db_service" }}
+  {{- include "utils.db_host" . }}
+{{- end }}

--- a/openstack/octavia/templates/etc/_secrets.conf.tpl
+++ b/openstack/octavia/templates/etc/_secrets.conf.tpl
@@ -11,7 +11,7 @@ username = {{ .Release.Name }}
 password = {{ .Values.global.octavia_service_password | replace "$" "" }}
 
 [database]
-connection = {{ include "db_url_mysql" . }}
+connection = {{ include "utils.db_url" . }}
 
 {{ if .Values.audit.enabled -}}
 [audit]

--- a/openstack/octavia/templates/octavia-migration-job.yaml
+++ b/openstack/octavia/templates/octavia-migration-job.yaml
@@ -32,7 +32,7 @@ spec:
             - name: COMMAND
               value: "true"
             - name: DEPENDENCY_SERVICE
-              value: "{{ .Release.Name }}-mariadb"
+              value: {{ include "octavia.db_service" . }}
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
       containers:

--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -80,6 +80,32 @@ mariadb:
   ccroot_user:
     enabled: true
 
+pxc_db:
+  enabled: false
+  name: octavia
+  alerts:
+    support_group: network-api
+  ccroot_user:
+    enabled: true
+  databases:
+    - octavia
+  users:
+    octavia:
+      name: octavia
+      grants:
+        - "ALL PRIVILEGES on octavia.*"
+  pxc:
+    persistence:
+      size: 10Gi
+  backup:
+    enabled: true
+    s3:
+      secrets:
+        aws_access_key_id: null
+        aws_secret_access_key: null
+    pitr:
+      enabled: true
+
 status_manager:
   health_check_interval: 120
 
@@ -212,9 +238,9 @@ mysql_metrics:
       labels:
         - "octavia_host"
       query: |
-        SELECT 
-          compute_flavor AS octavia_host, 
-          IFNULL((UNIX_TIMESTAMP(NOW()) - UNIX_TIMESTAMP(MAX(updated_at))), 1000) AS heartbeat_seconds 
+        SELECT
+          compute_flavor AS octavia_host,
+          IFNULL((UNIX_TIMESTAMP(NOW()) - UNIX_TIMESTAMP(MAX(updated_at))), 1000) AS heartbeat_seconds
         FROM amphora
         WHERE role = 'MASTER' or role = 'BACKUP'
         GROUP BY compute_flavor;
@@ -225,13 +251,13 @@ mysql_metrics:
       labels:
         - "agent"
       query: |
-        SELECT 
+        SELECT
           compute_flavor as agent,
-          sum(case role WHEN 'MASTER' THEN 1 WHEN 'BACKUP' THEN 0 END) AS schedulable 
-        FROM amphora 
-        WHERE 
-          (vrrp_interface != 'enabled' OR vrrp_interface IS Null) AND 
-          cached_zone is not NULL 
+          sum(case role WHEN 'MASTER' THEN 1 WHEN 'BACKUP' THEN 0 END) AS schedulable
+        FROM amphora
+        WHERE
+          (vrrp_interface != 'enabled' OR vrrp_interface IS Null) AND
+          cached_zone is not NULL
         GROUP BY compute_flavor;
       values:
         - "schedulable"
@@ -313,7 +339,7 @@ watcher:
   enabled: false
 
 audit:
-  enabled: true 
+  enabled: true
   # how many messages to buffer before dumping to log (when rabbit is down or too slow)
   mem_queue_size: 1000
 


### PR DESCRIPTION
* Add support for PXC galera cluster URL
* Update mysql-metrics and utils charts to support galera cluster
  * mysql-metrics 0.3.5 -> 0.4.2, minimum 0.3.6 is required because of the https://github.com/sapcc/helm-charts/pull/7130
  * utils  0.19.7 -> 0.23.0, minimum 0.21.0 is required because of the https://github.com/sapcc/helm-charts/pull/7505

The initial change adds an option to enable Galera cluster for the service in parallel with the existing MariaDB. Without setting `pxc_db.enabled=true` this PR causes no change in deployment.