### PR TITLE
[pxc-db] Use template for endpointUrl s3 backups storage configuration

### DIFF
--- a/common/pxc-db/Chart.yaml
+++ b/common/pxc-db/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.7
+version: 0.2.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/common/pxc-db/ci/test-values.yaml
+++ b/common/pxc-db/ci/test-values.yaml
@@ -3,6 +3,7 @@ global:
   dbUser: admin
   dbPassword: secret!
   region: regionOne
+  tld: test.corp
   registryAlternateRegion: my.docker.registry
   dockerHubMirrorAlternateRegion: my.dockerhub.mirror
 
@@ -11,9 +12,6 @@ name: test
 backup:
   enabled: true
   s3:
-    config:
-      region: regionOne
-      endpointUrl: http://s3.default.svc.cluster.local
     secrets:
       aws_access_key_id: 'super-secret'
       aws_secret_access_key: 'super-secret'

--- a/common/pxc-db/values.yaml
+++ b/common/pxc-db/values.yaml
@@ -449,7 +449,7 @@ backup:
       # This option must be set explicitly
       # Example: https://objectstore-3.REGION.DOMAIN
       # https://docs.percona.com/percona-operator-for-mysql/pxc/operator.html?#backupstoragesstorage-names3endpointurl
-      endpointUrl: null
+      endpointUrl: "https://objectstore-3.{{ .Values.global.region }}.{{ .Values.global.tld }}"
     # -- S3 credentials
     # This map is being used by the chart k8s secret creation
     secrets:


### PR DESCRIPTION
Use template for endpointUrl s3 backups storage configuration

This helps to avoid writing this common configuration for every service in each region