### PR TITLE
Mount ServiceAccount tokens of ironcore operators directly

### DIFF
--- a/system/Makefile
+++ b/system/Makefile
@@ -127,10 +127,8 @@ build-metal-operator-remote:
 	@cp kustomize/metal-operator-managedresources/rbac.yaml metal-operator-remote/managedresources
 	@yq -i '.controllerManager.manager.image.tag="$(METAL_OPERATOR_VERSION)"' metal-operator-remote/values.yaml
 	@yq -i '.fullnameOverride="metal-operator"' metal-operator-remote/values.yaml
-	@yq -i '.remote.ca=""' metal-operator-remote/values.yaml
-	@yq -i '.remote.server=""' metal-operator-remote/values.yaml
 	@echo 'macdb: {}' >> metal-operator-remote/values.yaml
-	@yq -i '.version="0.1.2"' metal-operator-remote/Chart.yaml
+	@yq -i '.version="0.2.0"' metal-operator-remote/Chart.yaml
 	@$(SED) -i 's/serviceAccountName.*$$/serviceAccountName: default/g' metal-operator-remote/templates/deployment.yaml
 	@$(SED) -i 's/kind: Role/kind: ClusterRole/g' metal-operator-remote/managedresources/kustomize.yaml
 
@@ -152,9 +150,7 @@ build-boot-operator-remote:
 	@kubectl kustomize kustomize/boot-operator-managedresources > boot-operator-remote/managedresources/kustomize.yaml
 	@yq -i '.controllerManager.manager.image.tag="$(BOOT_OPERATOR_VERSION)"' boot-operator-remote/values.yaml
 	@yq -i '.fullnameOverride="boot-operator"' boot-operator-remote/values.yaml
-	@yq -i '.remote.ca=""' boot-operator-remote/values.yaml
-	@yq -i '.remote.server=""' boot-operator-remote/values.yaml
-	@yq -i '.version="0.1.2"' boot-operator-remote/Chart.yaml
+	@yq -i '.version="0.2.0"' boot-operator-remote/Chart.yaml
 	@$(SED) -i 's/serviceAccountName.*$$/serviceAccountName: default/g' boot-operator-remote/templates/deployment.yaml
 	@$(SED) -i 's/kind: Role/kind: ClusterRole/g' boot-operator-remote/managedresources/kustomize.yaml
 

--- a/system/Makefile
+++ b/system/Makefile
@@ -127,6 +127,7 @@ build-metal-operator-remote:
 	@cp kustomize/metal-operator-managedresources/rbac.yaml metal-operator-remote/managedresources
 	@yq -i '.controllerManager.manager.image.tag="$(METAL_OPERATOR_VERSION)"' metal-operator-remote/values.yaml
 	@yq -i '.fullnameOverride="metal-operator"' metal-operator-remote/values.yaml
+	@yq -i '.remote.ca=""' metal-operator-remote/values.yaml
 	@echo 'macdb: {}' >> metal-operator-remote/values.yaml
 	@yq -i '.version="0.2.0"' metal-operator-remote/Chart.yaml
 	@$(SED) -i 's/serviceAccountName.*$$/serviceAccountName: default/g' metal-operator-remote/templates/deployment.yaml

--- a/system/boot-operator-remote/Chart.yaml
+++ b/system/boot-operator-remote/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.2.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/boot-operator-remote/templates/deployment.yaml
+++ b/system/boot-operator-remote/templates/deployment.yaml
@@ -27,6 +27,8 @@ spec:
         command:
         - /manager
         env:
+        - name: KUBERNETES_SERVICE_HOST
+          value: {{ quote .Values.controllerManager.manager.env.kubernetesServiceHost }}
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
         image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag
@@ -53,7 +55,7 @@ spec:
         securityContext: {{- toYaml .Values.controllerManager.manager.containerSecurityContext
           | nindent 10 }}
         volumeMounts:
-        - mountPath: /kubeconfig
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
           name: remote-kubeconfig
           readOnly: true
       hostNetwork: true
@@ -64,4 +66,9 @@ spec:
       volumes:
       - name: remote-kubeconfig
         secret:
+          items:
+          - key: token
+            path: token
+          - key: bundle.crt
+            path: ca.crt
           secretName: boot-operator-remote-kubeconfig

--- a/system/boot-operator-remote/templates/remote-kubeconfig.yaml
+++ b/system/boot-operator-remote/templates/remote-kubeconfig.yaml
@@ -8,24 +8,7 @@ metadata:
   annotations:
     serviceaccount.resources.gardener.cloud/name: boot-operator-controller-manager
     serviceaccount.resources.gardener.cloud/namespace: kube-system
+    serviceaccount.resources.gardener.cloud/inject-ca-bundle: "true"
 stringData:
-  kubeconfig: |
-    apiVersion: v1
-    clusters:
-    - cluster:
-        certificate-authority-data: {{ .Values.remote.ca }}
-        server: {{ .Values.remote.server }}
-      name: remote-cluster
-    contexts:
-    - context:
-        cluster: remote-cluster
-        user: boot-operator-controller-manager
-        namespace: kube-system
-      name: remote-cluster
-    current-context: remote-cluster
-    kind: Config
-    preferences: {}
-    users:
-    - name: boot-operator-controller-manager
-      user:
-        token: ""
+  token: ""
+  bundle.crt: ""

--- a/system/boot-operator-remote/values.yaml
+++ b/system/boot-operator-remote/values.yaml
@@ -12,15 +12,16 @@ controllerManager:
       - --metrics-bind-address=127.0.0.1:8080
       - --leader-elect
       - --controllers=httpbootconfig,ipxebootconfig,serverbootconfighttp,serverbootconfigpxe
-      - --kubeconfig=/kubeconfig/kubeconfig
     containerSecurityContext:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
           - ALL
+    env:
+      kubernetesServiceHost: apiserver-url
     image:
       repository: controller
-      tag: 9ad7325e76fc00b1b6e5b5535404d732539ecbce
+      tag: 4f2452ce450dc65342d68daf611edfb182585020
     resources:
       limits:
         cpu: 500m
@@ -33,6 +34,3 @@ controllerManager:
   replicas: 1
 kubernetesClusterDomain: cluster.local
 fullnameOverride: boot-operator
-remote:
-  ca: ""
-  server: ""

--- a/system/kustomize/boot-operator-remote/manager-remote-patch.yaml
+++ b/system/kustomize/boot-operator-remote/manager-remote-patch.yaml
@@ -14,7 +14,6 @@ spec:
             - --metrics-bind-address=127.0.0.1:8080
             - --leader-elect
             - --controllers=httpbootconfig,ipxebootconfig,serverbootconfighttp,serverbootconfigpxe
-            - --kubeconfig=/kubeconfig/kubeconfig
           livenessProbe:
             httpGet:
               port: 8087
@@ -27,9 +26,17 @@ spec:
               protocol: TCP
           volumeMounts:
           - name: remote-kubeconfig
-            mountPath: /kubeconfig
+            mountPath: /var/run/secrets/kubernetes.io/serviceaccount
             readOnly: true
+          env:
+          - name: KUBERNETES_SERVICE_HOST
+            value: "apiserver-url"
       volumes:
       - name: remote-kubeconfig
         secret:
           secretName: boot-operator-remote-kubeconfig
+          items:
+          - key: token
+            path: token
+          - key: bundle.crt
+            path: ca.crt

--- a/system/kustomize/boot-operator-remote/remote-kubeconfig.yaml
+++ b/system/kustomize/boot-operator-remote/remote-kubeconfig.yaml
@@ -8,24 +8,7 @@ metadata:
   annotations:
     serviceaccount.resources.gardener.cloud/name: boot-operator-controller-manager
     serviceaccount.resources.gardener.cloud/namespace: kube-system
+    serviceaccount.resources.gardener.cloud/inject-ca-bundle: "true"
 stringData:
-  kubeconfig: |
-    apiVersion: v1
-    clusters:
-    - cluster:
-        certificate-authority-data: {{ .Values.remote.ca }}
-        server: {{ .Values.remote.server }}
-      name: remote-cluster
-    contexts:
-    - context:
-        cluster: remote-cluster
-        user: boot-operator-controller-manager
-        namespace: kube-system
-      name: remote-cluster
-    current-context: remote-cluster
-    kind: Config
-    preferences: {}
-    users:
-    - name: boot-operator-controller-manager
-      user:
-        token: ""
+  token: ""
+  bundle.crt: ""

--- a/system/kustomize/metal-operator-remote/manager-remote-patch.yaml
+++ b/system/kustomize/metal-operator-remote/manager-remote-patch.yaml
@@ -15,18 +15,25 @@ spec:
         - --probe-os-image=ghcr.io/ironcore-dev/os-images/gardenlinux:1443.3
         - --insecure=false
         - --registry-url=http://[2a10:afc0:e013:d002::]:30010
-        - --kubeconfig=/kubeconfig/kubeconfig
         - --manager-namespace=metal-operator-system
         volumeMounts:
         - name: remote-kubeconfig
-          mountPath: /kubeconfig
+          mountPath: /var/run/secrets/kubernetes.io/serviceaccount
           readOnly: true
         - mountPath: /etc/macdb/
           name: macdb
+        env:
+        - name: KUBERNETES_SERVICE_HOST
+          value: "apiserver-url"
       volumes:
       - name: remote-kubeconfig
         secret:
           secretName: metal-operator-remote-kubeconfig
+          items:
+          - key: token
+            path: token
+          - key: bundle.crt
+            path: ca.crt
       - name: macdb
         secret:
           secretName: macdb

--- a/system/kustomize/metal-operator-remote/remote-kubeconfig.yaml
+++ b/system/kustomize/metal-operator-remote/remote-kubeconfig.yaml
@@ -8,24 +8,7 @@ metadata:
   annotations:
     serviceaccount.resources.gardener.cloud/name: metal-operator-controller-manager
     serviceaccount.resources.gardener.cloud/namespace: kube-system
+    serviceaccount.resources.gardener.cloud/inject-ca-bundle: "true"
 stringData:
-  kubeconfig: |
-    apiVersion: v1
-    clusters:
-    - cluster:
-        certificate-authority-data: {{ .Values.remote.ca }}
-        server: {{ .Values.remote.server }}
-      name: remote-cluster
-    contexts:
-    - context:
-        cluster: remote-cluster
-        user: metal-operator-controller-manager
-        namespace: kube-system
-      name: remote-cluster
-    current-context: remote-cluster
-    kind: Config
-    preferences: {}
-    users:
-    - name: metal-operator-controller-manager
-      user:
-        token: ""
+  token: ""
+  bundle.crt: ""

--- a/system/metal-operator-remote/Chart.yaml
+++ b/system/metal-operator-remote/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.2.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/metal-operator-remote/managedresources/kustomize.yaml
+++ b/system/metal-operator-remote/managedresources/kustomize.yaml
@@ -991,8 +991,13 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              systemUUID:
+                description: SystemUUID is the unique identifier for the server.
+                type: string
               uuid:
-                description: UUID is the unique identifier for the server.
+                description: |-
+                  UUID is the unique identifier for the server.
+                  Deprecated in favor of systemUUID.
                 type: string
             required:
             - uuid

--- a/system/metal-operator-remote/templates/deployment.yaml
+++ b/system/metal-operator-remote/templates/deployment.yaml
@@ -27,6 +27,8 @@ spec:
         command:
         - /manager
         env:
+        - name: KUBERNETES_SERVICE_HOST
+          value: {{ quote .Values.controllerManager.manager.env.kubernetesServiceHost }}
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
         image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag
@@ -49,7 +51,7 @@ spec:
         securityContext: {{- toYaml .Values.controllerManager.manager.containerSecurityContext
           | nindent 10 }}
         volumeMounts:
-        - mountPath: /kubeconfig
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
           name: remote-kubeconfig
           readOnly: true
         - mountPath: /etc/macdb/
@@ -62,6 +64,11 @@ spec:
       volumes:
       - name: remote-kubeconfig
         secret:
+          items:
+          - key: token
+            path: token
+          - key: bundle.crt
+            path: ca.crt
           secretName: metal-operator-remote-kubeconfig
       - name: macdb
         secret:

--- a/system/metal-operator-remote/templates/remote-kubeconfig.yaml
+++ b/system/metal-operator-remote/templates/remote-kubeconfig.yaml
@@ -8,24 +8,7 @@ metadata:
   annotations:
     serviceaccount.resources.gardener.cloud/name: metal-operator-controller-manager
     serviceaccount.resources.gardener.cloud/namespace: kube-system
+    serviceaccount.resources.gardener.cloud/inject-ca-bundle: "true"
 stringData:
-  kubeconfig: |
-    apiVersion: v1
-    clusters:
-    - cluster:
-        certificate-authority-data: {{ .Values.remote.ca }}
-        server: {{ .Values.remote.server }}
-      name: remote-cluster
-    contexts:
-    - context:
-        cluster: remote-cluster
-        user: metal-operator-controller-manager
-        namespace: kube-system
-      name: remote-cluster
-    current-context: remote-cluster
-    kind: Config
-    preferences: {}
-    users:
-    - name: metal-operator-controller-manager
-      user:
-        token: ""
+  token: ""
+  bundle.crt: ""

--- a/system/metal-operator-remote/values.yaml
+++ b/system/metal-operator-remote/values.yaml
@@ -6,16 +6,17 @@ controllerManager:
       - --probe-os-image=ghcr.io/ironcore-dev/os-images/gardenlinux:1443.3
       - --insecure=false
       - --registry-url=http://[2a10:afc0:e013:d002::]:30010
-      - --kubeconfig=/kubeconfig/kubeconfig
       - --manager-namespace=metal-operator-system
     containerSecurityContext:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
           - ALL
+    env:
+      kubernetesServiceHost: apiserver-url
     image:
       repository: controller
-      tag: 05f9869ffd931027435514002d9b8f3ee9b009d3
+      tag: 4dc7a47f2cf412966e6362aa5da5624845dadd46
     resources:
       limits:
         cpu: 500m
@@ -35,7 +36,4 @@ metalRegistryService:
       targetPort: 10000
   type: NodePort
 fullnameOverride: metal-operator
-remote:
-  ca: ""
-  server: ""
 macdb: {}

--- a/system/metal-operator-remote/values.yaml
+++ b/system/metal-operator-remote/values.yaml
@@ -36,4 +36,6 @@ metalRegistryService:
       targetPort: 10000
   type: NodePort
 fullnameOverride: metal-operator
+remote:
+  ca: ""
 macdb: {}


### PR DESCRIPTION
This enables token rotation within client-go. See: client-go/transport/round_trippers.go
line 296.