### PR TITLE
content-replication: bump statsd-exporter to 0.28.0

### DIFF
--- a/openstack/backup-replication/values.yaml
+++ b/openstack/backup-replication/values.yaml
@@ -19,7 +19,7 @@ swift_http_import:
   image_repository: null
 
 statsd:
-  exporter_image_version: 'v0.26.1'
+  exporter_image_version: 'v0.28.0'
 
 alerts:
   enabled: true

--- a/openstack/content-repo/values.yaml
+++ b/openstack/content-repo/values.yaml
@@ -18,7 +18,7 @@ owner-info:
 image_version: DEFINED_IN_VALUES_FILE
 debug: false
 
-image_version_auxiliary_statsd_exporter: 'v0.26.1'
+image_version_auxiliary_statsd_exporter: 'v0.28.0'
 
 auth_url: DEFINED_IN_VALUES_FILE
 


### PR DESCRIPTION
The changelog reads like there are no significant changes that are relevant to us. Mostly just library updates: https://github.com/prometheus/statsd_exporter/releases