### PR TITLE
[ironic] dependency updates

### DIFF
--- a/openstack/ironic/Chart.lock
+++ b/openstack/ironic/Chart.lock
@@ -1,27 +1,27 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.14.2
+  version: 0.15.2
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.5.3
+  version: 0.6.1
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.3.5
+  version: 0.4.1
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.11.1
+  version: 0.12.1
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.18.3
+  version: 0.21.0
 - name: ironic-exporter
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.3
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.0.0
-digest: sha256:779c746792ddf33fb65ca2da90f6d0910f5eb41ddc3c1a0434595d5689753270
-generated: "2024-09-17T16:06:19.224770281+02:00"
+  version: 1.1.0
+digest: sha256:ffd6daea23296f101996ad5971d1dc7246209c1645f8a1c3cbd2ee91ccc86e89
+generated: "2025-01-07T13:09:51.01360416+01:00"

--- a/openstack/ironic/Chart.yaml
+++ b/openstack/ironic/Chart.yaml
@@ -7,26 +7,26 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.14.2
+    version: ~0.15.2
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.5.3
+    version: ~0.6.1
   - condition: mysql_metrics.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.3.5
+    version: ~0.4.1
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: ~1.0.0
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.11.1
+    version: ~0.12.1
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.18.3
+    version: ~0.21.0
   - name: ironic-exporter
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: ~1.0.3
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~1.0.0
+    version: ~1.1.0


### PR DESCRIPTION
mariadb:
- return immutable deployment selector label
- Update mysqld-exporter to 0.16.0
- version info added to labels
- Update MariaDB to the 10.5.27 version
- priorityClassName updated to new naming convention
-  fixes unnecessary quotes for sse_customer_key
memcached:
- [memcached] return immutable deployment selector label
- Change openstack-service-critical to critical-infrastructure PriorityClass
- memcached version bumped to 1.6.31-alpine3.20
- priorityClassName updated to new naming convention
mysql_metrics:
-Fix imageTag should be a string, not a number
- Update to the latest 0.5.8 ts build
rabiitmq:
- return immutable deployment selector label
- Change openstack-service-critical to critical-infrastructure PriorityClass
- rabbitmq version bumped to 3.13.7-management
- priorityClassName updated to new naming convention
utils:
- Configure Galera monitor in ProxySQL sidecars
- Set default transaction and query timeouts
- Use ProxySQL 2.7.1 as a default version
