### PR TITLE
[cinder] Change default name of storage_profile

### DIFF
--- a/openstack/cinder/templates/vcenter_datacenter_cinder_secret.yaml
+++ b/openstack/cinder/templates/vcenter_datacenter_cinder_secret.yaml
@@ -62,7 +62,7 @@ template: |
   [vmware_fcd]
   volume_driver = cinder.volume.drivers.vmware.fcd.VMwareVStorageObjectDriver
   volume_backend_name = vmware_fcd
-  vmware_storage_profile: vmware-fcd
+  vmware_storage_profile: cinder-fcd
   extra_capabilities = '{"vcenter-shard": "{= host.split(".")[0] =}", "quality_type": "premium"}'
   {% endfilter -%}
 {{- end }}


### PR DESCRIPTION
This patch updates the default name of the FCD storage profile from vmware-fcd to cinder-fcd.