### PR TITLE
[pxc-operator] Remove prometheus.io/port annotation from operator pods

### DIFF
--- a/system/percona-xtradb-cluster-operator/Chart.yaml
+++ b/system/percona-xtradb-cluster-operator/Chart.yaml
@@ -4,7 +4,7 @@ name: percona-xtradb-cluster-operator
 description: A Helm chart to install Percona XtraDB Cluster Operator.
 home: "https://github.com/sapcc/helm-charts/tree/master/system/percona-xtradb-cluster-operator"
 type: application
-version: 0.3.2
+version: 0.3.3
 appVersion: "1.16.1"
 maintainers:
   - name: Birk Bohne

--- a/system/percona-xtradb-cluster-operator/values.yaml
+++ b/system/percona-xtradb-cluster-operator/values.yaml
@@ -73,7 +73,6 @@ pxc-operator:
 
   podAnnotations:
     prometheus.io/scrape: "true"
-    prometheus.io/port: "8080"
     prometheus.io/targets: "openstack"
     linkerd.io/inject: enabled
 


### PR DESCRIPTION
Remove prometheus.io/port annotation from operator pods to avoid multiple scraping

We have multiple containers in pxc-operator pods and metrics port already named `metrics`, so this annotation is not needed