### PR TITLE
[manila][pxc-db] Add support for PXC galera cluster: part 1

### DIFF
--- a/openstack/manila/Chart.lock
+++ b/openstack/manila/Chart.lock
@@ -5,6 +5,9 @@ dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.15.5
+- name: pxc-db
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 0.3.1
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.6.6
@@ -22,6 +25,6 @@ dependencies:
   version: 1.6.2
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.21.0
-digest: sha256:a2936f81ca5799446f8d336af0b543d8915623a52f8ae22cec53e36b67597021
-generated: "2025-03-10T09:34:58.046425+01:00"
+  version: 0.23.0
+digest: sha256:225ed2f681f7c8463b5a35315dff72beadbc5a12c424de1890b4674451263e48
+generated: "2025-03-20T12:50:20.071148+02:00"

--- a/openstack/manila/Chart.yaml
+++ b/openstack/manila/Chart.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v2
 appVersion: xena
 description: A Helm chart for OpenStack Manila
@@ -9,7 +10,7 @@ maintainers:
 name: manila
 sources:
   - https://github.com/sapcc/manila
-version: 0.4.5
+version: 0.5.1
 dependencies:
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
@@ -18,6 +19,11 @@ dependencies:
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: ~0.15.3
+  - condition: pxc_db.enabled
+    name: pxc-db
+    alias: pxc_db
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: 0.3.1
   - condition: memcached.enabled
     name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
@@ -39,4 +45,4 @@ dependencies:
     condition: api_rate_limit.enabled
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.21.0
+    version: 0.23.0

--- a/openstack/manila/ci/test-values.yaml
+++ b/openstack/manila/ci/test-values.yaml
@@ -1,6 +1,8 @@
+---
 global:
   default_availability_zone: co-lu-1a
   dockerHubMirror: earth
+  registryAlternateRegion: other.docker.registry
   dockerHubMirrorAlternateRegion: mars
   master_password: topSecret
   netapp:
@@ -34,6 +36,30 @@ mariadb:
 
 mysql_metrics:
   db_password: secret!
+
+pxc_db:
+  enabled: true
+  users:
+    manila:
+      password: topSecret!
+  system_users:
+    root:
+      password: topSecret!
+    xtrabackup:
+      password: topSecret!
+    monitor:
+      password: topSecret!
+    proxyadmin:
+      password: topSecret!
+    operator:
+      password: topSecret!
+    replication:
+      password: topSecret!
+  backup:
+    s3:
+      secrets:
+        aws_access_key_id: topSecret!
+        aws_secret_access_key: topSecret!
 
 rabbitmq:
   users:

--- a/openstack/manila/templates/_helpers.tpl
+++ b/openstack/manila/templates/_helpers.tpl
@@ -1,10 +1,8 @@
-{{- define "memcached_host" }}
-{{.Release.Name}}-memcached.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.region}}.{{.Values.global.tld}}
-{{- end}}
 {{- define "manila_type_seed.specs" }}
 driver_handles_share_servers: true
 snapshot_support: true
 {{- end }}
+
 {{- define "manila_type_seed.extra_specs" }}
 compression: "<is> True"
 dedupe: "<is> True"
@@ -17,4 +15,31 @@ netapp:thin_provisioned: "True"     # netapp_flexvol_encryption: "True"
 create_share_from_snapshot_support: "True"
 revert_to_snapshot_support: "True"
 replication_type: "dr"
+{{- end }}
+
+{{/*
+Define the Manila API dependency services for kubernetes-entrypoint init container
+memcached is being used only by API via keystoneauth
+*/}}
+{{- define "manila.api_service_dependencies" }}
+  {{- template "manila.db_service" . }},{{ template "manila.rabbitmq_service" . }},{{ template "manila.memcached_service" . }}
+{{- end }}
+
+{{/*
+Define the Manila dependency services for kubernetes-entrypoint init container
+*/}}
+{{- define "manila.service_dependencies" }}
+  {{- template "manila.db_service" . }},{{ template "manila.rabbitmq_service" . }}
+{{- end }}
+
+{{- define "manila.db_service" }}
+  {{- include "utils.db_host" . }}
+{{- end }}
+
+{{- define "manila.rabbitmq_service" }}
+  {{- .Release.Name }}-rabbitmq
+{{- end }}
+
+{{- define "manila.memcached_service" }}
+  {{- .Release.Name }}-memcached
 {{- end }}

--- a/openstack/manila/templates/api-deployment.yaml
+++ b/openstack/manila/templates/api-deployment.yaml
@@ -52,7 +52,7 @@ spec:
       {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       priorityClassName: {{ .Values.pod.priority_class.default }}
       initContainers:
-      {{- tuple . (dict "jobs" (print .Release.Name "-migration") "service" (print .Release.Name "-mariadb," .Release.Name "-rabbitmq," .Release.Name "-memcached")) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
+      {{- tuple . (dict "jobs" (print .Release.Name "-migration") "service" (include "manila.api_service_dependencies" . )) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       - name: fetch-rabbitmqadmin
         image: {{.Values.global.dockerHubMirror}}/library/busybox
         command: ["/scripts/fetch-rabbitmqadmin.sh"]
@@ -98,7 +98,7 @@ spec:
             - name: STATSD_PORT
               value: "9125"
             - name: DEPENDENCY_SERVICE
-              value: "{{ .Release.Name }}-mariadb,{{ .Release.Name }}-rabbitmq,{{ .Release.Name }}-memcached"
+              value: "{{ include "manila.api_service_dependencies" . }}"
             {{- if .Values.sentry.enabled }}
             - name: SENTRY_DSN_SSL
               valueFrom:

--- a/openstack/manila/templates/migration-job.yaml
+++ b/openstack/manila/templates/migration-job.yaml
@@ -34,7 +34,7 @@ spec:
 {{- end }}
       priorityClassName: {{ .Values.pod.priority_class.low }}
       initContainers:
-      {{- tuple . (dict "service" (print .Release.Name "-mariadb")) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
+      {{- tuple . (dict "service" (include "manila.db_service" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
         - name: manila-migration
           image: {{.Values.global.registry}}/loci-manila:{{.Values.loci.imageVersion}}

--- a/openstack/manila/templates/scheduler-deployment.yaml
+++ b/openstack/manila/templates/scheduler-deployment.yaml
@@ -54,7 +54,7 @@ spec:
                   - {{ .Release.Name }}-scheduler
               topologyKey: "topology.kubernetes.io/zone"
       initContainers:
-        {{- tuple . (dict "jobs" (print .Release.Name "-migration") "service" (print .Release.Name "-mariadb," .Release.Name "-rabbitmq")) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
+        {{- tuple . (dict "jobs" (print .Release.Name "-migration") "service" (include "manila.service_dependencies" . )) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
         - name: fetch-rabbitmqadmin
           image: {{.Values.global.dockerHubMirror}}/library/busybox
           command: ["/scripts/fetch-rabbitmqadmin.sh"]

--- a/openstack/manila/templates/shares/_netapp-deployment.yaml.tpl
+++ b/openstack/manila/templates/shares/_netapp-deployment.yaml.tpl
@@ -46,7 +46,7 @@ spec:
 {{ include "utils.proxysql.pod_settings" . | indent 6 }}
       priorityClassName: {{ .Values.pod.priority_class.default }}
       initContainers:
-      {{- tuple . (dict "service" (print .Release.Name "-mariadb," .Release.Name "-rabbitmq")) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
+      {{- tuple . (dict "service" (include "manila.service_dependencies" . )) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
         - name: fetch-rabbitmqadmin
           image: {{.Values.global.dockerHubMirror}}/library/busybox
           command: ["/scripts/fetch-rabbitmqadmin.sh"]

--- a/openstack/manila/templates/shares/_netapp-ensure-deployment.yaml.tpl
+++ b/openstack/manila/templates/shares/_netapp-ensure-deployment.yaml.tpl
@@ -51,7 +51,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       priorityClassName: {{ .Values.pod.priority_class.low }}
       initContainers:
-      {{- tuple . (dict "service" (print .Release.Name "-mariadb")) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
+      {{- tuple . (dict "service" (include "manila.db_service" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
       containers:
         - name: reexport
           image: "{{.Values.global.registry}}/loci-manila:{{.Values.loci.imageVersion}}"

--- a/openstack/manila/values.yaml
+++ b/openstack/manila/values.yaml
@@ -652,6 +652,41 @@ mariadb:
       net_read_timeout = 300
       net_write_timeout = 300
 
+pxc_db:
+  alerts:
+    support_group: compute-storage-api
+  enabled: false
+  name: manila
+  ccroot_user:
+    enabled: true
+  databases:
+    - manila
+  users:
+    manila:
+      name: manila
+      grants:
+        - "ALL PRIVILEGES on manila.*"
+  pxc:
+    configuration:
+      options:
+        innodb_buffer_pool_size: "4096M"
+        innodb_log_file_size: "2048M"
+        net_read_timeout: "300"
+        net_write_timeout: "300"
+    resources:
+      requests:
+        memory: 6Gi
+    persistence:
+      size: 10Gi
+  backup:
+    enabled: true
+    s3:
+      secrets:
+        aws_access_key_id: null
+        aws_secret_access_key: null
+    pitr:
+      enabled: true
+
 # needed for utils ini_sections
 postgresql:
   enabled: false


### PR DESCRIPTION
Add default values for pxc-db chart dependency
Update utils charts to support galera cluster


The initial change adds an option to enable Galera cluster for the service in parallel with the existing MariaDB. Without setting `pxc_db.enabled=true` this PR causes no change in deployment.