### PR TITLE
[barbican][pxc-db] Add support for PXC galera cluster: part 1

### DIFF
--- a/openstack/barbican/Chart.lock
+++ b/openstack/barbican/Chart.lock
@@ -2,6 +2,9 @@ dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.15.3
+- name: pxc-db
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 0.3.1
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.6.3
@@ -13,7 +16,7 @@ dependencies:
   version: 0.13.0
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.19.6
+  version: 0.23.0
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.6.2
@@ -23,5 +26,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.0
-digest: sha256:12e137cb1c86b2ab6e3a172c4d9e5018867b852aac6a61bc99899b78b58916b3
-generated: "2025-01-20T09:08:23.329203+05:30"
+digest: sha256:f1aea0a26bc31d39a390a8b9eb67c7869fc8a612ce01a9359837e5b1e961ae94
+generated: "2025-03-20T12:53:35.200317+02:00"

--- a/openstack/barbican/Chart.yaml
+++ b/openstack/barbican/Chart.yaml
@@ -1,14 +1,20 @@
+---
 apiVersion: v2
 appVersion: dalmatian
 description: A Helm chart for Openstack Barbican
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Barbican/OpenStack_Project_Barbican_vertical.png
 name: barbican
-version: 0.6.0
+version: 0.6.1
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.15.3
+  - condition: pxc_db.enabled
+    name: pxc-db
+    alias: pxc_db
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: 0.3.1
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.6.3
@@ -21,7 +27,7 @@ dependencies:
     version: 0.13.0
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.19.6
+    version: 0.23.0
   - name: redis
     alias: sapcc_rate_limit
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/barbican/ci/test-values.yaml
+++ b/openstack/barbican/ci/test-values.yaml
@@ -1,13 +1,15 @@
+---
 global:
   registry: myImage
   dbPassword: topSecret
   barbican_service_password: topSecret
+  registryAlternateRegion: other.docker.registry
   dockerHubMirror: myRegistry/dockerhub
   dockerHubMirrorAlternateRegion: myRegistry/dockerhubalternate
   domain_seeds:
     skip_hcm_domain: false
   availability_zones: []
-    
+
 imageVersionBarbicanApi: yoga
 
 dbPassword: topSecret
@@ -19,7 +21,31 @@ mariadb:
       password: password
     backup:
       name: backup
-      password:  password
+      password: password
+
+pxc_db:
+  enabled: true
+  users:
+    barbican:
+      password: topSecret!
+  system_users:
+    root:
+      password: topSecret!
+    xtrabackup:
+      password: topSecret!
+    monitor:
+      password: topSecret!
+    proxyadmin:
+      password: topSecret!
+    operator:
+      password: topSecret!
+    replication:
+      password: topSecret!
+  backup:
+    s3:
+      secrets:
+        aws_access_key_id: topSecret!
+        aws_secret_access_key: topSecret!
 
 rabbitmq_notifications:
   users:
@@ -44,4 +70,3 @@ audit:
   central_service:
     user: barbican
     password: password
-    

--- a/openstack/barbican/templates/_helpers.tpl
+++ b/openstack/barbican/templates/_helpers.tpl
@@ -14,3 +14,15 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | replace "_" "-" | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "barbican.db_service" }}
+  {{- include "utils.db_host" . }}
+{{- end }}
+
+{{- define "barbican.rabbitmq_service" }}
+  {{- .Release.Name }}-rabbitmq
+{{- end }}
+
+{{- define "barbican.service_dependencies" }}
+  {{- template "barbican.db_service" . }},{{ template "barbican.rabbitmq_service" . }}
+{{- end }}

--- a/openstack/barbican/templates/api-deployment.yaml
+++ b/openstack/barbican/templates/api-deployment.yaml
@@ -45,7 +45,7 @@ spec:
       {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       {{- tuple . (dict "name" "barbican-api") | include "utils.topology.constraints" | indent 6 }}
       initContainers:
-      {{- tuple . (dict "service" "barbican-mariadb,barbican-rabbitmq") | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
+      {{- tuple . (dict "service" (include "barbican.service_dependencies" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
         - name: barbican-api
           image: {{required ".Values.global.registry is missing" .Values.global.registry }}/loci-barbican:{{required "Values.imageVersionBarbicanApi is missing" .Values.imageVersionBarbicanApi}}
@@ -166,7 +166,7 @@ spec:
               readOnly: true
             - name: luna
               mountPath: /thales/
-        {{- end }}       
+        {{- end }}
         - name: statsd
           {{- if hasKey .Values.global "dockerHubMirror"}}
           image: {{.Values.global.dockerHubMirror}}/{{ .Values.statsd.image.repository }}:{{ .Values.statsd.image.tag }}

--- a/openstack/barbican/templates/etc/_secrets.conf.tpl
+++ b/openstack/barbican/templates/etc/_secrets.conf.tpl
@@ -3,7 +3,7 @@
 {{ include "ini_sections.default_transport_url" . }}
 
 [database]
-connection = {{ include "db_url_mysql" . }}
+connection = {{ include "utils.db_url" . }}
 
 [keystone_authtoken]
 username = {{ .Release.Name }}

--- a/openstack/barbican/templates/migration-job.yaml
+++ b/openstack/barbican/templates/migration-job.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       restartPolicy: OnFailure
       initContainers:
-      {{- tuple . (dict "service" "barbican-mariadb") | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
+      {{- tuple . (dict "service" (include "barbican.db_service" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
         - name: barbican-migration
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-barbican:{{required ".Values.imageVersionBarbicanApi is missing" .Values.imageVersionBarbicanApi}}
@@ -81,7 +81,7 @@ spec:
         - name: barbican-etc
           configMap:
             name: barbican-etc
-{{- if $secrets }}            
+{{- if $secrets }}
         - name: barbican-etc-confd
           secret:
             secretName: {{ .Release.Name }}-secrets

--- a/openstack/barbican/values.yaml
+++ b/openstack/barbican/values.yaml
@@ -75,6 +75,32 @@ mariadb:
   alerts:
     support_group: identity
 
+pxc_db:
+  enabled: false
+  name: barbican
+  alerts:
+    support_group: identity
+  ccroot_user:
+    enabled: true
+  databases:
+    - barbican
+  users:
+    barbican:
+      name: barbican
+      grants:
+        - "ALL PRIVILEGES on barbican.*"
+  pxc:
+    persistence:
+      size: 10Gi
+  backup:
+    enabled: true
+    s3:
+      secrets:
+        aws_access_key_id: null
+        aws_secret_access_key: null
+    pitr:
+      enabled: true
+
 mysql_metrics:
   db_name: barbican
   db_user: barbican
@@ -148,7 +174,7 @@ mysql_metrics:
       - "secret_type"
       name: openstack_barbican_hsm_secrets_count_gauge
       query: |
-        SELECT 
+        SELECT
           secrets.id,
           secrets.status,
           COALESCE(secrets.name, "No Secret Name") AS secret_name,
@@ -157,11 +183,11 @@ mysql_metrics:
           projects.external_id  AS project_id,
           secrets.secret_type,
           COUNT(*) AS count_gauge
-        FROM encrypted_data 
-        JOIN kek_data 
-        ON encrypted_data.kek_id = kek_data.id 
-        JOIN secrets 
-        ON secrets.id = encrypted_data.secret_id 
+        FROM encrypted_data
+        JOIN kek_data
+        ON encrypted_data.kek_id = kek_data.id
+        JOIN secrets
+        ON secrets.id = encrypted_data.secret_id
         JOIN projects
         ON secrets.project_id=projects.id
         WHERE kek_data.plugin_name='barbican.plugin.crypto.p11_crypto.P11CryptoPlugin' AND secrets.deleted='false'


### PR DESCRIPTION
Add support for PXC galera cluster URL
Update mysql-metrics and utils charts to support galera cluster


The initial change adds an option to enable Galera cluster for the service in parallel with the existing MariaDB. Without setting `pxc_db.enabled=true` this PR causes no change in deployment.