### PR TITLE
[glance][pxc-db] Add support for PXC galera cluster: part 1

### DIFF
--- a/openstack/glance/Chart.lock
+++ b/openstack/glance/Chart.lock
@@ -2,6 +2,9 @@ dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.18.2
+- name: pxc-db
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 0.3.1
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.6.9
@@ -20,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:6ef3583e0c22849491ccb32c225c32020c1d518129dabbc07a9b4253577649ed
-generated: "2025-03-25T17:06:08.636189+02:00"
+digest: sha256:20a2dd01d7babcffe948348993c59aae8dbe3550710532775ffb264c7b8f10ff
+generated: "2025-03-26T13:50:30.294875+02:00"

--- a/openstack/glance/Chart.yaml
+++ b/openstack/glance/Chart.yaml
@@ -1,14 +1,20 @@
+---
 apiVersion: v2
 appVersion: dalmatian
 description: A Helm chart Openstack Glance
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Glance/OpenStack_Project_Glance_vertical.png
 name: glance
-version: 0.6.7
+version: 0.7.0
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.18.2
+  - condition: pxc_db.enabled
+    name: pxc-db
+    alias: pxc_db
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: 0.3.1
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.6.9

--- a/openstack/glance/ci/test-values.yaml
+++ b/openstack/glance/ci/test-values.yaml
@@ -1,6 +1,8 @@
+---
 global:
-  registry: myRegistry
   dbPassword: topSecret
+  registry: myRegistry
+  registryAlternateRegion: other.docker.registry
   dockerHubMirror: myRegistry/dockerhub
   dockerHubMirrorAlternateRegion: myRegistry/dockerhubalternate
   glance_service_password: secret
@@ -10,7 +12,8 @@ global:
   domain_seeds:
     customer_domains: [bar, foo, baz]
     customer_domains_without_support_projects: [baz]
-    
+    skip_hcm_domain: false
+
 imageVersion: rocky
 
 rabbitmq_notifications:
@@ -29,7 +32,31 @@ mariadb:
       password: password
     backup:
       name: backup
-      password:  password
+      password: password
+
+pxc_db:
+  enabled: true
+  users:
+    glance:
+      password: topSecret!
+  system_users:
+    root:
+      password: topSecret!
+    xtrabackup:
+      password: topSecret!
+    monitor:
+      password: topSecret!
+    proxyadmin:
+      password: topSecret!
+    operator:
+      password: topSecret!
+    replication:
+      password: topSecret!
+  backup:
+    s3:
+      secrets:
+        aws_access_key_id: topSecret!
+        aws_secret_access_key: topSecret!
 
 rabbitmq:
   users:

--- a/openstack/glance/templates/_helpers.tpl
+++ b/openstack/glance/templates/_helpers.tpl
@@ -15,9 +15,6 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | replace "_" "-" | trimSuffix "-" -}}
 {{- end -}}
 
-{{define "memcached_host"}}{{.Release.Name}}-memcached.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.region}}.{{.Values.global.tld}}{{end}}
-
-
 {{- define "job_name" }}
   {{- $name := index . 1 }}
   {{- with index . 0 }}
@@ -26,4 +23,16 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
     {{- $hash := empty .Values.proxysql.mode | ternary $bin $all | sha256sum }}
 {{- .Release.Name }}-{{ $name }}-{{ substr 0 4 $hash }}-{{ .Values.imageVersion | required "Please set glance.imageVersion or similar"}}
   {{- end }}
+{{- end }}
+
+{{- define "glance.service_dependencies" }}
+  {{- template "glance.db_service" . }},{{ template "glance.memcached_service" . }}
+{{- end }}
+
+{{- define "glance.db_service" }}
+  {{- include "utils.db_host" . }}
+{{- end }}
+
+{{- define "glance.memcached_service" }}
+  {{- .Release.Name }}-memcached
 {{- end }}

--- a/openstack/glance/templates/deployment.yaml
+++ b/openstack/glance/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
       {{ include "utils.proxysql.pod_settings" . | indent 6 }}
       {{- tuple . (dict "name" "glance") | include "utils.topology.constraints" | indent 6 }}
       initContainers:
-      {{- tuple . (dict "jobs" (tuple . "migration-job" | include "job_name") "service" (print .Release.Name "-mariadb," .Release.Name "-memcached")) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
+      {{- tuple . (dict "jobs" (tuple . "migration-job" | include "job_name") "service" (include "glance.service_dependencies" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       {{- if .Values.file.persistence.enabled }}
       - name: permissions
         securityContext:

--- a/openstack/glance/templates/migration-job.yaml
+++ b/openstack/glance/templates/migration-job.yaml
@@ -27,7 +27,7 @@ spec:
       restartPolicy: OnFailure
       {{- include "utils.proxysql.job_pod_settings" . | indent 6 }}
       initContainers:
-      {{- tuple . (dict "service" (print .Release.Name "-mariadb" )) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
+      {{- tuple . (dict "service" (include "glance.db_service" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
       - name: glance-migration
         image: {{ required ".Values.global.registry is missing" .Values.global.registry }}/loci-glance:{{ required "Please set glance.imageVersion or similar" .Values.imageVersion }}

--- a/openstack/glance/values.yaml
+++ b/openstack/glance/values.yaml
@@ -154,6 +154,32 @@ mariadb:
   alerts:
     support_group: compute-storage-api
 
+pxc_db:
+  enabled: false
+  name: glance
+  alerts:
+    support_group: compute-storage-api
+  ccroot_user:
+    enabled: true
+  databases:
+    - glance
+  users:
+    glance:
+      name: glance
+      grants:
+        - "ALL PRIVILEGES on glance.*"
+  pxc:
+    persistence:
+      size: 10Gi
+  backup:
+    enabled: true
+    s3:
+      secrets:
+        aws_access_key_id: null
+        aws_secret_access_key: null
+    pitr:
+      enabled: true
+
 memcached:
   alerts:
     support_group: compute-storage-api


### PR DESCRIPTION
Add support for PXC galera cluster URL

The initial change adds an option to enable Galera cluster for the service in parallel with the existing MariaDB. Without setting `pxc_db.enabled=true` this PR causes no change in deployment.