### PR TITLE
[cinder][pxc-db] Add support for PXC galera cluster: part 1

### DIFF
--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -5,6 +5,9 @@ dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.23.0
+- name: pxc-db
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 0.4.0
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.4.4
@@ -23,5 +26,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:8ee8399355c79d0ddbf1fac5f5f4f9858594d7ae6afc5b9cf8c0ea27b157d03a
-generated: "2025-04-21T12:49:40.962761+03:00"
+digest: sha256:8c273a6be583a0527fe604362769daf3668ab4de9b4f7b6f5a556e3526225b22
+generated: "2025-05-14T12:45:10.74762+03:00"

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -1,8 +1,9 @@
+---
 apiVersion: v2
 description: A Helm chart for Kubernetes
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Cinder/OpenStack_Project_Cinder_mascot.png
 name: cinder
-version: 0.2.2
+version: 0.3.0
 dependencies:
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
@@ -11,6 +12,11 @@ dependencies:
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.23.0
     condition: mariadb.enabled
+  - name: pxc-db
+    alias: pxc_db
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: 0.4.0
+    condition: pxc_db.enabled
   - name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.4.4

--- a/openstack/cinder/ci/test-values.yaml
+++ b/openstack/cinder/ci/test-values.yaml
@@ -1,15 +1,17 @@
+---
 global:
   accessControlAllowOrigin: '*'
   region: regionOne
   domain: evil.corp
   registry: keppel.regionOne.cloud
+  registryAlternateRegion: other.docker.registry
   dockerHubMirror: myRegistry/dockerhub
   dockerHubMirrorAlternateRegion: myRegistry/dockerhubalternate
   tld: regionOne.cloud
   domain_seeds:
     customer_domains: [bar, foo, baz]
     customer_domains_without_support_projects: [baz]
-    
+
   cinder_service_password: topSecret
   availability_zones:
     - foo
@@ -29,6 +31,30 @@ mariadb:
     cinder:
       name: cinder
       password: password
+
+pxc_db:
+  enabled: false
+  users:
+    cinder:
+      password: topSecret!
+  system_users:
+    root:
+      password: topSecret!
+    xtrabackup:
+      password: topSecret!
+    monitor:
+      password: topSecret!
+    proxyadmin:
+      password: topSecret!
+    operator:
+      password: topSecret!
+    replication:
+      password: topSecret!
+  backup:
+    s3:
+      secrets:
+        aws_access_key_id: topSecret!
+        aws_secret_access_key: topSecret!
 
 rabbitmq:
   users:

--- a/openstack/cinder/templates/_helpers.tpl
+++ b/openstack/cinder/templates/_helpers.tpl
@@ -4,3 +4,19 @@
 {{- $hash := empty .Values.proxysql.mode | ternary $bin $all | sha256sum }}
 {{- .Release.Name }}-migration-job-{{ substr 0 4 $hash }}-{{ .Values.imageVersion | required "Please set cinder.imageVersion or similar" }}
 {{- end }}
+
+{{- define "cinder.service_dependencies" }}
+  {{- template "cinder.db_service" . }},{{ template "cinder.rabbitmq_service" . }}
+{{- end }}
+
+{{- define "cinder.scheduler_service_dependencies" }}
+  {{- template "cinder.rabbitmq_service" . }},cinder-api
+{{- end }}
+
+{{- define "cinder.db_service" }}
+  {{- include "utils.db_host" . }}
+{{- end }}
+
+{{- define "cinder.rabbitmq_service" }}
+  {{- .Release.Name }}-rabbitmq
+{{- end }}

--- a/openstack/cinder/templates/api-deployment.yaml
+++ b/openstack/cinder/templates/api-deployment.yaml
@@ -39,7 +39,7 @@ spec:
       {{- include "utils.proxysql.pod_settings" . | nindent 6 }}
       {{- tuple . (dict "name" "cinder-api") | include "utils.topology.constraints" | indent 6 }}
       initContainers:
-      {{- tuple . (dict "service" (print .Release.Name "-mariadb," .Release.Name "-rabbitmq") "jobs" (include "cinder.migration_job_name" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
+      {{- tuple . (dict "service" (include "cinder.service_dependencies" . ) "jobs" (include "cinder.migration_job_name" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
         - name: cinder-api
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{.Values.imageVersionCinderApi | default .Values.imageVersion | required "Please set cinder.imageVersion or similar" }}

--- a/openstack/cinder/templates/backup_deployment.yaml
+++ b/openstack/cinder/templates/backup_deployment.yaml
@@ -50,7 +50,7 @@ template: |
         {{- include "utils.proxysql.pod_settings" . | nindent 8 }}
         {{- tuple . "{= availability_zone =}" | include "utils.kubernetes_pod_az_affinity" | nindent 8 }}
         initContainers:
-        {{- tuple . (dict "service" (print .Release.Name "-mariadb," .Release.Name "-rabbitmq") "jobs" (include "cinder.migration_job_name" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
+        {{- tuple . (dict "service" (include "cinder.service_dependencies" . ) "jobs" (include "cinder.migration_job_name" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
         containers:
         - name: cinder-volume-backup-vmware-{= name =}
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{.Values.imageVersionCinderVolumeBackup | default .Values.imageVersion | required "Please set cinder.imageVersion or similar" }}

--- a/openstack/cinder/templates/migration-job.yaml
+++ b/openstack/cinder/templates/migration-job.yaml
@@ -15,7 +15,7 @@ spec:
       restartPolicy: OnFailure
       {{- include "utils.proxysql.job_pod_settings" . | nindent 6 }}
       initContainers:
-      {{- tuple . (dict "service" (print .Release.Name "-mariadb")) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
+      {{- tuple . (dict "service" (include "cinder.db_service" . )) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
         - name: cinder-migration
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{.Values.imageVersionCinderApi | default .Values.imageVersion | required "Please set cinder.imageVersion or similar" }}

--- a/openstack/cinder/templates/scheduler-deployment.yaml
+++ b/openstack/cinder/templates/scheduler-deployment.yaml
@@ -38,7 +38,7 @@ spec:
       {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       hostname: cinder-scheduler
       initContainers:
-      {{- tuple . (dict "service" (print "cinder-api," .Release.Name "-rabbitmq")) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
+      {{- tuple . (dict "service" (include "cinder.scheduler_service_dependencies" . )) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
         - name: cinder-scheduler
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{.Values.imageVersionCinderScheduler | default .Values.imageVersion | required "Please set cinder.imageVersion or similar" }}

--- a/openstack/cinder/templates/vcenter_datacenter_cinder_deployment.yaml
+++ b/openstack/cinder/templates/vcenter_datacenter_cinder_deployment.yaml
@@ -51,7 +51,7 @@ template: |
         {{- tuple . "{= availability_zone =}" | include "utils.kubernetes_pod_az_affinity" | nindent 8 }}
         {{- include "utils.proxysql.pod_settings" . | nindent 8 }}
         initContainers:
-        {{- tuple . (dict "service" (print .Release.Name "-mariadb," .Release.Name "-rabbitmq")) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
+        {{- tuple . (dict "service" (include "cinder.service_dependencies" . )) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
         containers:
         - name: cinder-volume-vmware-{= name =}
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{.Values.imageVersionCinderScheduler | default .Values.imageVersion | required "Please set cinder.imageVersion or similar" }}

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -154,6 +154,38 @@ mariadb:
           enabled: true
           allTables: true
 
+pxc_db:
+  enabled: false
+  name: cinder
+  alerts:
+    support_group: compute-storage-api
+  ccroot_user:
+    enabled: true
+  databases:
+    - cinder
+  users:
+    cinder:
+      name: cinder
+      grants:
+        - "ALL PRIVILEGES on cinder.*"
+  pxc:
+    configuration:
+      options:
+        max_connections: "2048"
+        innodb_buffer_pool_size: "2048M"
+        innodb_log_file_size: "512M"
+        connect_timeout: "15"
+    persistence:
+      size: 10Gi
+  backup:
+    enabled: true
+    s3:
+      secrets:
+        aws_access_key_id: null
+        aws_secret_access_key: null
+    pitr:
+      enabled: true
+
 max_pool_size: 15
 max_overflow: 5
 


### PR DESCRIPTION
Add default values for pxc-db chart dependency

The initial change adds an option to enable Galera cluster for the service in parallel with the existing MariaDB. Without setting `pxc_db.enabled=true` this PR causes no change in deployment.