### PR TITLE
[neutron] Change alert severity for API rate-limited projects

### DIFF
--- a/openstack/neutron/alerts/openstack/api.alerts
+++ b/openstack/neutron/alerts/openstack/api.alerts
@@ -42,7 +42,7 @@ groups:
             sum by (target_type_uri, action, target_project_id) (rate(openstack_watcher_api_requests_total{service="network", container="statsd"}[1m])) > 0.1
     for: 5m
     labels:
-      severity: warning
+      severity: info
       support_group: network-api
       tier: os
       service: neutron


### PR DESCRIPTION
The alert channel is getting too many notifications for projects exceeding the neutron API limits. 

This PR changes the severity from `warning` to `info` only for alerts triggered by projects exceeding their quotas (local/per-project rate limits): 
1) no more per-project live notifications: `info` alerts do not get routed to the alerting system  
2) alerts are accessible and persisted on Thanos via GreenHouse