### PR TITLE
[pxc-db] Use operator custom resource option to create users

### DIFF
--- a/common/pxc-db/Chart.yaml
+++ b/common/pxc-db/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.14
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/common/pxc-db/ci/test-values.yaml
+++ b/common/pxc-db/ci/test-values.yaml
@@ -16,8 +16,6 @@ backup:
       aws_access_key_id: 'super-secret'
       aws_secret_access_key: 'super-secret'
 
-initdb_job: true
-
 system_users:
   root:
     password: 'pa$$word!'

--- a/common/pxc-db/templates/cluster.yaml
+++ b/common/pxc-db/templates/cluster.yaml
@@ -191,6 +191,19 @@ spec:
           requests:
             storage: {{ $pxc.persistence.size | quote }}
     gracePeriod: 600
+{{- if .Values.custom_users }}
+  users:
+  {{- range $username, $values := .Values.users }}
+    {{- $username := default $username $values.name }}
+    {{- if $values.password }}
+    - name: {{ $values.name }}
+      hosts: []
+      passwordSecretRef:
+        name: pxc-db-{{$.Values.name}}-custom-users-secret
+        key: {{ $username }}
+    {{- end }}
+  {{- end }}
+{{- end }}
   proxysql:
     enabled: false
   {{- $haproxy := .Values.haproxy }}

--- a/common/pxc-db/templates/initdb-bin.yaml
+++ b/common/pxc-db/templates/initdb-bin.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.initdb_job }}
+{{- if .Values.job.initdb.enabled }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/common/pxc-db/templates/initdb-job.yaml
+++ b/common/pxc-db/templates/initdb-job.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.initdb_job }}
+{{- if .Values.job.initdb.enabled }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -17,17 +17,19 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "3"
 spec:
+  backoffLimit: {{ .Values.job.initdb.jobBackoffLimit | default 1 }}
   template:
     metadata:
       name: "{{ include "pxc-db.fullname" . }}-init-db"
       labels:
 {{ include "pxc-db.labels" . | indent 8 }}
     spec:
-      restartPolicy: Never
+      restartPolicy: {{ .Values.job.initdb.jobRestartPolicy | default "Never" | quote }}
       serviceAccountName: {{ .Values.name }}-init-db
+      priorityClassName: {{ .Values.job.initdb.priority_class | default "critical-infrastructure" | quote }}
       initContainers:
       - name: kubernetes-entrypoint
-        image: {{ $.Values.global.registryAlternateRegion }}/kubernetes-entrypoint:v0.3.1
+        image: {{ required ".Values.global.registryAlternateRegion is missing" $.Values.global.registryAlternateRegion }}/{{ .Values.kubernetes_entrypoint.image.name }}:{{ .Values.kubernetes_entrypoint.image.tag }}
         command:
         - /kubernetes-entrypoint
         env:
@@ -39,7 +41,7 @@ spec:
           value: {{ .Values.name }}-db-haproxy
       containers:
       - name: init-db-job
-        image: {{ required ".Values.global.dockerHubMirrorAlternateRegion is missing" .Values.global.dockerHubMirrorAlternateRegion }}/{{ .Values.initdb.image.name }}:{{ .Values.initdb.image.tag }}
+        image: {{ required ".Values.global.dockerHubMirrorAlternateRegion is missing" $.Values.global.dockerHubMirrorAlternateRegion }}/{{ .Values.job.initdb.image.name }}:{{ .Values.job.initdb.image.tag }}
         command:
           - /bin/bash
           - -c
@@ -55,6 +57,13 @@ spec:
               secretKeyRef:
                 name: pxc-db-{{ .Values.name }}-init-sql
                 key: operator
+        resources:
+          requests:
+            cpu: {{ .Values.job.initdb.resources.requests.cpu | default 0.5 }}
+            memory: {{ .Values.job.initdb.resources.requests.memory | default "128Mi" | quote }}
+          limits:
+            cpu: {{ .Values.job.initdb.resources.limits.cpu | default 0.5 }}
+            memory: {{ .Values.job.initdb.resources.limits.memory | default "128Mi" | quote }}
         volumeMounts:
           - name: initdb
             mountPath: /var/lib/initdb

--- a/common/pxc-db/templates/initdb-rbac.yaml
+++ b/common/pxc-db/templates/initdb-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.initdb_job }}
+{{- if .Values.job.initdb.enabled }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/common/pxc-db/templates/initdb-secret.yaml
+++ b/common/pxc-db/templates/initdb-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.initdb_job }}
+{{- if .Values.job.initdb.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/common/pxc-db/templates/initdb/_init.sql.tpl
+++ b/common/pxc-db/templates/initdb/_init.sql.tpl
@@ -1,28 +1,17 @@
-SET character_set_server = '{{ .Values.character_set_server }}';
-SET collation_server = '{{ .Values.collation_server }}';
+SET character_set_server = '{{ .Values.job.initdb.character_set_server }}';
+SET collation_server = '{{ .Values.job.initdb.collation_server }}';
 SET sql_mode = CONCAT(@@sql_mode, ',NO_BACKSLASH_ESCAPES');
 {{- $dbs := coalesce .Values.databases (list .Values.name) }}
 {{- range $dbs }}
 CREATE DATABASE IF NOT EXISTS {{ . }};
 {{- end }}
 
-{{- if and .Values.global.dbUser .Values.global.dbPassword (not (hasKey .Values.users (default "" .Values.global.dbUser))) }}
-CREATE DATABASE IF NOT EXISTS `{{ .Values.name }}`;
-CREATE USER IF NOT EXISTS {{ .Values.global.dbUser }};
-ALTER USER {{ include "pxc-db.resolve_secret_squote" (.Values.global.dbUser) }}
-    IDENTIFIED WITH {{ $.Values.global.dbAuthPlugin | default "caching_sha2_password" }} BY {{ include "pxc-db.resolve_secret_squote" .Values.global.dbPassword }};
-GRANT ALL PRIVILEGES ON `{{ .Values.name }}`.* TO {{ include "pxc-db.resolve_secret_squote" (.Values.global.dbUser) }};
-{{- end }}
-
 {{- range $username, $values := .Values.users }}
     {{- $username := default $username $values.name }}
-    {{- $auth_plugin := default "caching_sha2_password" $values.auth_plugin }}
     {{- if not $values.password }}
 -- Skipping user {{ $username }} without password
     {{- else }}
 CREATE USER IF NOT EXISTS {{ include "pxc-db.resolve_secret_squote" $username }};
-ALTER USER {{ include "pxc-db.resolve_secret_squote" $username }}
-    IDENTIFIED WITH {{ $auth_plugin }} BY {{ include "pxc-db.resolve_secret_squote" $values.password }};
 {{- if $values.limits }}
 ALTER USER {{ include "pxc-db.resolve_secret_squote" $username }}
   WITH

--- a/common/pxc-db/templates/secrets.yaml
+++ b/common/pxc-db/templates/secrets.yaml
@@ -37,4 +37,24 @@ type: Opaque
 data:
   AWS_ACCESS_KEY_ID: {{ (required (printf "backup.s3.secrets.aws_access_key_id needs to be set") .Values.backup.s3.secrets.aws_access_key_id) | b64enc }}
   AWS_SECRET_ACCESS_KEY: {{ (required (printf "backup.s3.secrets.aws_secret_access_key needs to be set") .Values.backup.s3.secrets.aws_secret_access_key) | b64enc }}
-{{- end -}}
+{{- end }}
+{{- if $.Values.custom_users }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: {{ $.Release.Namespace }}
+  name: pxc-db-{{$.Values.name}}-custom-users-secret
+  labels:
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    system: openstack
+    type: configuration
+    component: database
+{{ include "pxc-db.labels" . | indent 4 }}
+type: Opaque
+data:
+  {{- range $username, $data := $.Values.users }}
+  {{ $username }}: {{ (required (printf "users.%s.password is required to configure the Kubernetes secret for the '%s' user" $username) $data.password) | b64enc }}
+  {{- end }}
+{{- end }}

--- a/common/pxc-db/values.yaml
+++ b/common/pxc-db/values.yaml
@@ -32,19 +32,16 @@ tls:
 #   backupIfUnhealthy: false
 unsafeFlags: {}
 
-### InitDB configuration
-# -- InitDB job options
-# -- Image used by the initdb job
-initdb:
+# -- Image used by kubernetes-entrypoint init container
+kubernetes_entrypoint:
   image:
-    name: percona/percona-xtradb-cluster-operator
-    tag: 1.16.1-pxc8.0-backup-pxb8.0.35
-# -- Enable InitDB job that creates databases and users
-# Disabled by default
-initdb_job: null
-# -- Set default character set and collation in init.sql
-character_set_server: "utf8mb4"
-collation_server: "utf8mb4_0900_ai_ci"
+    name: kubernetes-entrypoint
+    tag: v0.3.1
+
+### InitDB configuration
+# -- Use CRD to create application users and set their passwords
+# Enabled by default
+custom_users: true
 # -- Enable the creation of a local-only root user `ccroot` without a password
 ccroot_user:
   enabled: false
@@ -72,6 +69,47 @@ users: {}
 #    grants:
 #    - ALL ON example.*
 ### End of InitDB configuration
+
+job:
+  initdb:
+    # -- Whether to enable the init-db job
+    # @default -- true
+    enabled: true
+    # -- Define the image used by the init-db job
+    # @default -- operator image
+    image:
+      name: percona/percona-xtradb-cluster-operator
+      tag: 1.16.1-pxc8.0-backup-pxb8.0.35
+    # -- Set default character set in init.sql
+    character_set_server: utf8mb4
+    # -- Set default collation in init.sql
+    collation_server: utf8mb4_0900_ai_ci
+    # -- Define the init-db job backoff limit
+    # @default -- 1
+    backoffLimit:
+    # -- Define how the init-db job pod [will be restarted](https://kubernetes.io/docs/concepts/workloads/controllers/job/#handling-pod-and-container-failures) in case of an error.
+    # It can be on the same worker node or another
+    # @default -- Never
+    jobRestartPolicy:
+    # -- Define the priority class for the maintenance job pod
+    # @default -- critical-infrastructure
+    priority_class:
+    # -- Define the resource requests and limits for init-db job
+    resources:
+      requests:
+        # -- Define how much memory the MariaDB init-db job container will request
+        # @default -- 128Mi
+        memory:
+        # -- Define how much CPU the MariaDB init-db job container will request
+        # @default -- 0.5
+        cpu:
+      limits:
+        # -- Define memory limit for the MariaDB init-db job container
+        # @default -- 128Mi
+        memory:
+        # -- Define CPU limit for the MariaDB init-db job container
+        # @default -- 0.5
+        cpu:
 
 # -- Default system-level Percona XtraDB Cluster users
 # All credentials are mandatory


### PR DESCRIPTION
* Use operator custom resource to create and set application user password

init-db job is still being used to create grants because the operator can't handle `ALL PRIVILEGES` grant
