### PR TITLE
[designate] bump chart dependencies

### DIFF
--- a/openstack/designate/Chart.lock
+++ b/openstack/designate/Chart.lock
@@ -4,16 +4,16 @@ dependencies:
   version: 1.1.9
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.2.9
+  version: 0.2.10
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.15.2
+  version: 0.15.3
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.6.1
+  version: 0.6.3
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.4.1
+  version: 0.4.2
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.12.1
@@ -29,5 +29,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:24f3a3722d109558c030acc84e5003cf44d77890fc8714fd067eb307c2df4189
-generated: "2025-01-06T15:22:41.779968+02:00"
+digest: sha256:d5f9d9dfac9ec60d59da4f16a69450b6bd02f0a3cea49d1edbaf7f24a17f0b78
+generated: "2025-01-14T14:16:56.015529+02:00"

--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes to deploy Openstack Designate  (DNSaaS)
 name: designate
-version: 0.4.9
+version: 0.4.10
 appVersion: "xena"
 dependencies:
   - condition: percona_cluster.enabled
@@ -13,18 +13,18 @@ dependencies:
     name: pxc-db
     alias: pxc_db
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.2.9
+    version: 0.2.10
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.15.2
+    version: 0.15.3
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.6.1
+    version: 0.6.3
   - condition: mysql_metrics.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.4.1
+    version: 0.4.2
   - name: rabbitmq
     condition: rabbitmq.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm


### PR DESCRIPTION
* fixes mariadb service label selector
* updates mysql-metrics
* updates memcached and memcached-exporter
* update pxc-db alerts with links to playbooks