### PR TITLE
bump thanos and prometheus version

### DIFF
--- a/common/prometheus-server-pre7/CHANGELOG.md
+++ b/common/prometheus-server-pre7/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 6.7.3 
+
+* Prometheus bump to v2.55.1
+* Thanos bump to v0.37.2
+
 ## 6.6.2
 
 * another fix for ThanosStoreSeriesGateLatencyHigh 

--- a/common/prometheus-server-pre7/Chart.yaml
+++ b/common/prometheus-server-pre7/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Prometheus via operator.
 name: prometheus-server-pre7
-version: 6.7.2
-appVersion: v2.54.1
+version: 6.7.3
+appVersion: v2.55.1
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
 maintainers:
   - name: viennaa

--- a/common/prometheus-server-pre7/values.yaml
+++ b/common/prometheus-server-pre7/values.yaml
@@ -229,12 +229,12 @@ thanos:
   # See https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#thanosspec .
   spec:
     baseImage: keppel.eu-de-1.cloud.sap/ccloud-quay-mirror/thanos/thanos
-    version: v0.36.1
+    version: v0.37.2
 
   # Image for Thanos components.
   components:
     baseImage: keppel.eu-de-1.cloud.sap/ccloud-quay-mirror/thanos/thanos
-    version: v0.36.1
+    version: v0.37.2
 
   # Specification for Thanos components.
   compactor:

--- a/common/prometheus-server/CHANGELOG.md
+++ b/common/prometheus-server/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 7.7.2
+
+* Prometheus bump to v2.55.1
+* Thanos bump to v0.37.2
+
 ## 7.7.1
 
 * Fix scraping of apiserver_request_duration_seconts histogram

--- a/common/prometheus-server/Chart.yaml
+++ b/common/prometheus-server/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Prometheus via operator.
 name: prometheus-server
-version: 7.7.1
-appVersion: v2.54.1
+version: 7.7.2
+appVersion: v2.55.1
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
 maintainers:
   - name: Tommy Sauer (viennaa)

--- a/common/prometheus-server/values.yaml
+++ b/common/prometheus-server/values.yaml
@@ -227,7 +227,7 @@ thanos:
   # See https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#thanosspec .
   spec:
     baseImage: keppel.eu-de-1.cloud.sap/ccloud-quay-mirror/thanos/thanos
-    version: v0.36.1
+    version: v0.37.2
 
   # Being one of debug, info, warn, error. Defaults to warn.
   # logLevel: info


### PR DESCRIPTION
this is the bump prior to prometheus 3.x to ensure backwards tsdb compatibility