### PR TITLE
[ironic] update chart dependencies

### DIFF
--- a/openstack/ironic/Chart.lock
+++ b/openstack/ironic/Chart.lock
@@ -1,13 +1,13 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.15.2
+  version: 0.15.3
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.6.1
+  version: 0.6.3
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.4.1
+  version: 0.4.2
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:ffd6daea23296f101996ad5971d1dc7246209c1645f8a1c3cbd2ee91ccc86e89
-generated: "2025-01-07T13:09:51.01360416+01:00"
+digest: sha256:923d38665af49bed9ae82c71af46bdd28692c58f6537c7d9f7e7b5e7ab587a1e
+generated: "2025-01-15T10:55:29.950058+02:00"

--- a/openstack/ironic/Chart.yaml
+++ b/openstack/ironic/Chart.yaml
@@ -2,19 +2,19 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Ironic/OpenStack_Project_Ironic_vertical.png
 name: ironic
-version: 0.1.7
+version: 0.1.8
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.15.2
+    version: ~0.15.3
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.6.1
+    version: ~0.6.3
   - condition: mysql_metrics.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.4.1
+    version: ~0.4.2
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: ~1.0.0


### PR DESCRIPTION
* mariadb 0.15.2 to 0.15.3: fixes service selector
* memcached 0.6.1 to 0.6.3: updates memcached and memcached-exporter
* mysql-metrics: 0.4.1 to 0.4.2: updates sql-expoter to 2025-01-07