### PR TITLE
ceph: fix rook cert loop delimiter

### DIFF
--- a/system/cc-ceph/Chart.yaml
+++ b/system/cc-ceph/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cc-ceph
 description: A Helm chart for the Rook / Ceph Objects inside the Storage Clusters
 type: application
-version: 1.1.4
+version: 1.1.5
 appVersion: "1.16.1"
 dependencies:
   - name: owner-info

--- a/system/cc-ceph/templates/certificate.yaml
+++ b/system/cc-ceph/templates/certificate.yaml
@@ -1,4 +1,5 @@
 {{- range $key, $record := .Values.objectstore.gateway.dnsNames }}
+---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:


### PR DESCRIPTION
split certificates using yaml `---` splitter