### PR TITLE
ceph: ability to skip DNS record and Cert creation for dnsNames

### DIFF
--- a/system/cc-ceph/Chart.yaml
+++ b/system/cc-ceph/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cc-ceph
 description: A Helm chart for the Rook / Ceph Objects inside the Storage Clusters
 type: application
-version: 1.1.5
+version: 1.1.6
 appVersion: "1.16.1"
 dependencies:
   - name: owner-info

--- a/system/cc-ceph/templates/certificate-extra.yaml
+++ b/system/cc-ceph/templates/certificate-extra.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.objectstore.multiInstance.enabled }}
 {{- range $instance := .Values.objectstore.multiInstance.extraInstances }}
 {{- range $key, $record := $instance.gateway.dnsNames }}
+{{- if or (not $.Values.dnsNamesSkipCertificate) (not (has $record $.Values.dnsNamesSkipCertificate)) }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -20,6 +21,7 @@ spec:
   usages:
     - digital signature
     - key encipherment
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/system/cc-ceph/templates/certificate.yaml
+++ b/system/cc-ceph/templates/certificate.yaml
@@ -1,4 +1,5 @@
 {{- range $key, $record := .Values.objectstore.gateway.dnsNames }}
+{{- if or (not $.Values.dnsNamesSkipCertificate) (not (has $record $.Values.dnsNamesSkipCertificate)) }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -18,4 +19,5 @@ spec:
   usages:
     - digital signature
     - key encipherment
+{{- end }}
 {{- end }}

--- a/system/cc-ceph/templates/record-extra.yaml
+++ b/system/cc-ceph/templates/record-extra.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.objectstore.multiInstance.enabled }}
 {{- range $instance := .Values.objectstore.multiInstance.extraInstances }}
 {{- range $key, $record := $instance.gateway.dnsNames }}
+{{- if or (not $.Values.dnsNamesSkipRecord) (not (has $record $.Values.dnsNamesSkipRecord)) }}
 ---
 apiVersion: disco.stable.sap.cc/v1
 kind: Record
@@ -21,6 +22,7 @@ spec:
   record: "{{ $record }}."
   hosts:
     - "*.{{ $record }}."
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/system/cc-ceph/templates/record.yaml
+++ b/system/cc-ceph/templates/record.yaml
@@ -1,4 +1,5 @@
 {{- range $key, $record := .Values.objectstore.gateway.dnsNames }}
+{{- if or (not $.Values.dnsNamesSkipRecord) (not (has $record $.Values.dnsNamesSkipRecord)) }}
 ---
 apiVersion: disco.stable.sap.cc/v1
 kind: Record
@@ -19,4 +20,5 @@ spec:
   record: "{{ $record }}."
   hosts:
     - "*.{{ $record }}."
+{{- end }}
 {{- end }}

--- a/system/cc-ceph/values.yaml
+++ b/system/cc-ceph/values.yaml
@@ -194,3 +194,8 @@ defaultRgwPools:
   replicasPerFailureDomain: 2
   subFailureDomain: host
   deviceClass: nvme
+
+# a list of dnsNames to skip DNS record creation for RGW instances
+dnsNamesSkipRecord: []
+# a list of dnsNames to skip certificate creation for RGW instances
+dnsNamesSkipCertificate: []


### PR DESCRIPTION
some `dnsNames` are needed to be registered on the RGW side, but they're managed separately.