### PR TITLE
[cc-cluster] Set cni bin-dir explicitly

### DIFF
--- a/system/cc-cluster/Chart.yaml
+++ b/system/cc-cluster/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: cc-cluster
 description: A Helm chart for the cc clusters.
 type: application
-version: 1.0.23
+version: 1.0.24

--- a/system/cc-cluster/templates/kubeadmconfigtemplate.yaml
+++ b/system/cc-cluster/templates/kubeadmconfigtemplate.yaml
@@ -52,6 +52,10 @@ spec:
                         runtime_type = "io.containerd.runc.v2"
                       [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
                         SystemdCgroup = true
+                      [plugins."io.containerd.grpc.v1.cri".cni]
+                        bin_dir = "/opt/cni/bin"
+                        conf_dir = "/etc/cni/net.d"
+                        conf_template = ""                        
               - path: /etc/ssh/sshd_config
                 filesystem: root
                 mode: 393


### PR DESCRIPTION
Debian (and therefor Gardenlinux) defaults to `/usr/lib/cni` In order to stay with the upstream default, we need to specify that explicitly. For flatcar, the change should be a no-op.

 
For more details see:
https://github.com/containerd/containerd/issues/6600