### PR TITLE
[pxc-db] Set max_binlog_size option to 100M

### DIFF
--- a/common/pxc-db/Chart.yaml
+++ b/common/pxc-db/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.10
+version: 0.2.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/common/pxc-db/values.yaml
+++ b/common/pxc-db/values.yaml
@@ -192,6 +192,7 @@ pxc:
       pxc_strict_mode: MASTER  # default is ENFORCING
       binlog_format: ROW
       binlog_expire_logs_seconds: 345600  # default 30 days -> 4 days
+      max_binlog_size: 104857600  # default 1G -> 100M
       sync_binlog: 1  # default value for PXC
       net_read_timeout: 30
       net_write_timeout: 60


### PR DESCRIPTION
Lowers default value of the max_binlog_size option from 1G to 100M

This would help to avoid timeouts on binlog upload if binlog is big enough, so it couldn't be uploaded within the upload timeout