### PR TITLE
limes: move all cloud_resource_* assignments from billing-seed to limes-seed

### DIFF
--- a/openstack/billing/templates/seeds.yaml
+++ b/openstack/billing/templates/seeds.yaml
@@ -17,7 +17,6 @@ spec:
     {{- end }}
     - monsoon3/domain-cc3test-seed
     - swift/swift-seed
-    - limes/limes-seed
 
   roles:
   - name: masterdata_admin
@@ -97,21 +96,13 @@ spec:
       role_assignments:
       - user: billing@Default
         role: objectstore_admin
-      - user: billing@Default
-        role: cloud_resource_viewer
+        # NOTE: The cloud_resource_viewer role is given by the limes seed.
       swift:
         enabled: true
     - name: cloud_admin
       role_assignments:
         - user: masterdata_scanner@Default
           role: cloud_identity_viewer
-        {{- if ($.Values.global.region | contains "qa") }}
-        - user: {{ $.Values.ccadmin.readwriteUserForPlutus }}@ccadmin
-          role: cloud_resource_admin
-        {{- else }}
-        - user: {{ $.Values.ccadmin.readonlyUserForIBP }}@ccadmin
-          role: cloud_resource_viewer
-        {{- end }}
     {{- end }}
     groups:
     {{- if eq . "monsoon3" }}

--- a/openstack/billing/values.yaml
+++ b/openstack/billing/values.yaml
@@ -9,7 +9,3 @@ owner-info:
     - Stefan Majewsky
     - Sandro Jäckel
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/openstack/billing
-
-ccadmin:
-  readonlyUserForIBP: null # see values.yaml in secrets
-  readwriteUserForPlutus: null # see values.yaml in secrets

--- a/openstack/limes/templates/_utils.tpl
+++ b/openstack/limes/templates/_utils.tpl
@@ -25,8 +25,6 @@
 {{- end }}
 - name: LIMES_AUTHORITATIVE
   value: "true"
-- name: LIMES_CONSTRAINTS_PATH
-  value: "/etc/limes/constraints-ccloud.yaml"
 - name: LIMES_DEBUG
   value: '0'
 - name: LIMES_DB_USERNAME

--- a/openstack/limes/templates/configmap.yaml
+++ b/openstack/limes/templates/configmap.yaml
@@ -11,8 +11,6 @@ data:
       - {{ . }}
     {{- end }}
 {{ toYaml .Values.limes.clusters.ccloud | indent 4 }}
-  constraints-ccloud.yaml: |
-{{ toYaml .Values.limes.constraints.ccloud | indent 4 }}
 
   policy.json: |
     {{- .Files.Get "files/policy.yaml" | fromYaml | toPrettyJson | nindent 4 }}

--- a/openstack/limes/templates/prometheus-alerts.yaml
+++ b/openstack/limes/templates/prometheus-alerts.yaml
@@ -57,9 +57,9 @@ spec:
 
         # allowed role assignments for the `cloud_resource_admin` role:
         # - group CCADMIN_CLOUD_ADMINS@ccadmin in project cloud_admin@ccadmin
-        # - user $PLUTUS_READWRITE@ccadmin     in project cloud_admin@ccadmin (for management of commitments by Plutus, see billing-seed for details; QA only)
+        # - all in .Values.limes.external_role_assignments.cloud_resource_admin
         - alert: OpenstackLimesUnexpectedCloudAdminRoleAssignments
-          expr: max(openstack_assignments_per_role{role_name="cloud_resource_admin"}) > {{ if hasPrefix "qa" .Values.global.region }}2{{ else }}1{{ end }}
+          expr: max(openstack_assignments_per_role{role_name="cloud_resource_admin"}) > {{ add 1 (len .Values.limes.external_role_assignments.cloud_resource_admin) }}
           for: 10m
           labels:
             support_group: containers
@@ -73,11 +73,10 @@ spec:
             description: 'The Keystone role "cloud_resource_admin" is assigned to more users/groups than expected.'
 
         # allowed role assignments for the `cloud_resource_viewer` role:
-        # - user billing@Default                         in project billing@ccadmin (for data transfer from Limes to CBR)
-        # - user $IBP_READONLY@ccadmin                   in project cloud_admin@ccadmin (for data transfer from Limes to IBP, see billing-seed for details; prod only)
-        # - group CCADMIN_CLOUD_ADMINS@ccadmin           in project cloud_admin@ccadmin
+        # - group CCADMIN_CLOUD_ADMINS@ccadmin in project cloud_admin@ccadmin
+        # - all in .Values.limes.external_role_assignments.cloud_resource_viewer
         - alert: OpenstackLimesUnexpectedCloudViewerRoleAssignments
-          expr: max(openstack_assignments_per_role{role_name="cloud_resource_viewer"}) > {{ if hasPrefix "qa" .Values.global.region }}2{{ else }}3{{ end }}
+          expr: max(openstack_assignments_per_role{role_name="cloud_resource_viewer"}) > {{ add 1 (len .Values.limes.external_role_assignments.cloud_resource_viewer) }}
           for: 10m
           labels:
             support_group: containers

--- a/openstack/limes/templates/seed-grants.yaml
+++ b/openstack/limes/templates/seed-grants.yaml
@@ -1,0 +1,62 @@
+apiVersion: "openstack.stable.sap.cc/v1"
+kind: OpenstackSeed
+metadata:
+  # This seed is for granting cloud_resource_admin and cloud_resource_viewer
+  # to the chosen few permitted to wield such powers.
+  name: limes-grants-seed
+
+{{/* If a domain is mentioned in the external_role_assignments, we need to add a dependency on its domain seed. */}}
+{{- $relevant_domain_names := list }}
+{{- range $role, $grants := $.Values.limes.external_role_assignments }}
+  {{- range $grant := $grants }}
+    {{- $relevant_domain_names = append $relevant_domain_names $grant.user_domain_name }}
+    {{- $relevant_domain_names = append $relevant_domain_names $grant.project_domain_name }}
+  {{- end }}
+{{- end }}
+{{- $relevant_domain_names = sortAlpha (uniq $relevant_domain_names) }}
+
+spec:
+  {{- if $relevant_domain_names }}
+  requires:
+    {{- $is_global := $.Values.limes.clusters.ccloud.catalog_url | contains "global" -}}
+    {{- $base_seed_namespace := $is_global | ternary "monsoon3global" "monsoon3" }}
+    {{- range $relevant_domain_names }}
+    - {{ $base_seed_namespace }}/domain-{{replace "_" "-" .}}-seed
+    {{- end }}
+
+  roles:
+    # NOTE: These role declarations are duplicated from limes-seed.
+    # I don't want to depend on limes-seed here because its dependency tree is huge and slow.
+    - name: cloud_resource_admin
+    - name: cloud_resource_viewer
+
+  {{/* The big pile of templating here is to restructure from "roles -> assignments" into "domains -> projects -> assignments". */}}
+  domains:
+    {{- range $domain_name := $relevant_domain_names }}
+    - name: {{ $domain_name }}
+      {{- $relevant_project_names := list }}
+      {{- range $role, $grants := $.Values.limes.external_role_assignments }}
+        {{- range $grant := $grants }}
+          {{- if eq $grant.project_domain_name $domain_name }}
+            {{- $relevant_project_names = append $relevant_project_names $grant.project_name }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+      {{- $relevant_project_names = sortAlpha (uniq $relevant_project_names) }}
+      {{- if $relevant_project_names }}
+      projects:
+        {{- range $project_name := $relevant_project_names }}
+        - name: {{ $project_name }}
+          role_assignments:
+          {{- range $role := sortAlpha (keys $.Values.limes.external_role_assignments) }}
+          {{- range $grant := index $.Values.limes.external_role_assignments $role }}
+          {{- if and (eq $grant.project_domain_name $domain_name) (eq $grant.project_name $project_name) }}
+            - user: {{ $grant.user_name }}@{{ $grant.user_domain_name }}
+              role: {{ $role }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}

--- a/openstack/limes/values.yaml
+++ b/openstack/limes/values.yaml
@@ -70,21 +70,6 @@ limes:
   clusters:
     ccloud: {}
 
-  # Map with entries being the contents of a Limes quota constraint file.
-  # <https://github.com/sapcc/limes/blob/master/docs/operators/constraints.md>
-  # e.g.
-  #
-  #   constraints:
-  #     ccloud:
-  #       domains: ...
-  #       projects: ...
-  #
-  # To use this constraint in a cluster, set:
-  #
-  #    .Values.limes.clusters.ccloud.constraints = "/etc/limes/constraints-ccloud.yaml"
-  constraints:
-    ccloud: {}
-
   # Whether to apply resource requests/limits to containers.
   resources:
     enabled: false

--- a/openstack/limes/values.yaml
+++ b/openstack/limes/values.yaml
@@ -70,6 +70,12 @@ limes:
   clusters:
     ccloud: {}
 
+  # Additional role assignments for the respective roles to external users of the Limes API.
+  # Each entry must be an object with the keys "user_name", "user_domain_name", "project_name", "project_domain_name".
+  external_role_assignments:
+    cloud_resource_admin: []
+    cloud_resource_viewer: []
+
   # Whether to apply resource requests/limits to containers.
   resources:
     enabled: false


### PR DESCRIPTION
I started touching this because billing is getting new technical users (coming from CAM instead of our own seeds; we only seed the role assignments). Then I was dissatisfied with the structure of everything.

Having the role assignments hardcoded in the billing seed makes some sense, but then this requires also maintaining the role-assignment alert on the Limes side. This commit moves all of this into the Limes chart, and changes it from hardcoded individual assignments to a configurable list. The templating in the seed is a bit of a mess, but the alert
definition and the seed do different forms of lookup, so one of them had to be a mess.

There is a related secrets PR that needs to be merged at the same time.