### PR TITLE
limes: do not render grants-seed if there are no grants to be made

### DIFF
--- a/openstack/limes/templates/seed-grants.yaml
+++ b/openstack/limes/templates/seed-grants.yaml
@@ -1,3 +1,9 @@
+{{- $num_grants := 0 }}
+{{- range $role, $grants := $.Values.limes.external_role_assignments }}
+  {{- $num_grants = add $num_grants (len $grants) }}
+{{- end }}
+{{- if gt $num_grants 0 }}
+
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: OpenstackSeed
 metadata:
@@ -60,3 +66,5 @@ spec:
       {{- end }}
     {{- end }}
   {{- end }}
+
+{{- end }}


### PR DESCRIPTION
Helm can deal with this just fine, and the seeder might be able to handle it, too, but `secrets-injector validate` chokes on `spec:` being absent (i.e. null).