### PR TITLE
[cluster-api] cc-cluster update with setting cni_bin_dir explicitly

### DIFF
--- a/system/cluster-api/Chart.lock
+++ b/system/cluster-api/Chart.lock
@@ -28,12 +28,12 @@ dependencies:
   version: 0.1.8
 - name: cc-cluster
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.0.23
+  version: 1.0.24
 - name: runtime-extension-maintenance-controller
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.8
 - name: argora
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.0.1
-digest: sha256:1752aa65b640fd5fc750fe7b2bf49f34ebbcaeb15709a9903eedd2b2af1a9c97
-generated: "2024-11-21T13:28:31.235226599+01:00"
+digest: sha256:0d6b6df8dc7cf0ae706022b68245e38130b9a0784ae770c72648c01c9fa1382d
+generated: "2025-01-16T16:57:26.385135528+01:00"

--- a/system/cluster-api/Chart.yaml
+++ b/system/cluster-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-api
 description: A Helm chart for the Cluster API.
 type: application
-version: 4.0.4
+version: 4.0.5
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm


### PR DESCRIPTION
Debian (and therefor gardenlinux) set the default bin dir to /usr/lib/cni/bin