### PR TITLE
[ironic] add states power to audit middleware mapping

### DIFF
--- a/openstack/ironic/templates/etc/_api_audit_map.yaml.tpl
+++ b/openstack/ironic/templates/etc/_api_audit_map.yaml.tpl
@@ -13,6 +13,8 @@ resources:
       maintenance:
       management:
       states:
+        children:
+          power:
       traits:
       vifs:
       vmedia:

--- a/openstack/ironic/templates/etc/_api_audit_map.yaml.tpl
+++ b/openstack/ironic/templates/etc/_api_audit_map.yaml.tpl
@@ -7,6 +7,7 @@ resources:
   chassis:
   deploy_templates:
   nodes:
+    custom_id: id
     children:
       allocation:
       validate:


### PR DESCRIPTION
This corrects the unmapped path for states/power in ironic audit events. 