### PR TITLE
[manila] remove unused rabbitmq_notifications config

### DIFF
--- a/openstack/manila/values.yaml
+++ b/openstack/manila/values.yaml
@@ -714,9 +714,6 @@ audit:
   # how many messages to buffer before dumping to log (when rabbit is down or too slow)
   mem_queue_size: 1000
 
-rabbitmq_notifications:
-  name: manila
-
 # openstack-ratelimit-middleware
 api_rate_limit:
   enabled: false


### PR DESCRIPTION
this dependency is gone since
https://github.com/sapcc/helm-charts/commit/cf320ccba281405bde2109630c80c22509d5b177
