### PR TITLE
limes: fix role-assignment alerts being confused about global vs. local

### DIFF
--- a/openstack/limes/templates/prometheus-alerts.yaml
+++ b/openstack/limes/templates/prometheus-alerts.yaml
@@ -33,6 +33,11 @@ metadata:
     type: alerting-rules
     prometheus: {{ required ".Values.alerts.prometheus.openstack missing" $values.alerts.prometheus.openstack }}
 
+{{/* If there is a global deployment in this region, different limits may apply for it vs. for the regular deployment.
+     We need to restrict the PromQL expressions to match only the Keystone that our own deployment is interested in. */}}
+{{- $is_global := $.Values.limes.clusters.ccloud.catalog_url | contains "global" -}}
+{{- $keystone_namespace := $is_global | ternary "monsoon3global" "monsoon3" }}
+
 spec:
   groups:
   - name: openstack-limes-roleassignment.alerts
@@ -42,7 +47,7 @@ spec:
         # - user limes@Default in project cloud_admin@ccadmin
         # HOWEVER admin@Default is covered by a system role assignment that does not count towards this metric
         - alert: OpenstackLimesUnexpectedServiceRoleAssignments
-          expr: max(openstack_assignments_per_role{role_name="resource_service"}) > 1
+          expr: max(openstack_assignments_per_role{role_name="resource_service",namespace="{{ $keystone_namespace }}"}) > 1
           for: 10m
           labels:
             support_group: containers
@@ -59,7 +64,7 @@ spec:
         # - group CCADMIN_CLOUD_ADMINS@ccadmin in project cloud_admin@ccadmin
         # - all in .Values.limes.external_role_assignments.cloud_resource_admin
         - alert: OpenstackLimesUnexpectedCloudAdminRoleAssignments
-          expr: max(openstack_assignments_per_role{role_name="cloud_resource_admin"}) > {{ add 1 (len .Values.limes.external_role_assignments.cloud_resource_admin) }}
+          expr: max(openstack_assignments_per_role{role_name="cloud_resource_admin",namespace="{{ $keystone_namespace }}"}) > {{ add 1 (len .Values.limes.external_role_assignments.cloud_resource_admin) }}
           for: 10m
           labels:
             support_group: containers
@@ -76,7 +81,7 @@ spec:
         # - group CCADMIN_CLOUD_ADMINS@ccadmin in project cloud_admin@ccadmin
         # - all in .Values.limes.external_role_assignments.cloud_resource_viewer
         - alert: OpenstackLimesUnexpectedCloudViewerRoleAssignments
-          expr: max(openstack_assignments_per_role{role_name="cloud_resource_viewer"}) > {{ add 1 (len .Values.limes.external_role_assignments.cloud_resource_viewer) }}
+          expr: max(openstack_assignments_per_role{role_name="cloud_resource_viewer",namespace="{{ $keystone_namespace }}"}) > {{ add 1 (len .Values.limes.external_role_assignments.cloud_resource_viewer) }}
           for: 10m
           labels:
             support_group: containers


### PR DESCRIPTION
Ref: https://convergedcloud.slack.com/archives/CE5NDBQDC/p1737365384373869