### PR TITLE
[pxc-db] Pass binlog config values as strings to avoid sci notation

### DIFF
--- a/common/pxc-db/Chart.yaml
+++ b/common/pxc-db/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.11
+version: 0.2.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/common/pxc-db/values.yaml
+++ b/common/pxc-db/values.yaml
@@ -191,8 +191,8 @@ pxc:
       wsrep_retry_autocommit: 3
       pxc_strict_mode: MASTER  # default is ENFORCING
       binlog_format: ROW
-      binlog_expire_logs_seconds: 345600  # default 30 days -> 4 days
-      max_binlog_size: 104857600  # default 1G -> 100M
+      binlog_expire_logs_seconds: "345600"  # default 30 days -> 4 days
+      max_binlog_size: "104857600"  # default 1G -> 100M
       sync_binlog: 1  # default value for PXC
       net_read_timeout: 30
       net_write_timeout: 60


### PR DESCRIPTION
Pass binlog config values as strings to avoid scientific notation for numbers in the resulting generated config