### PR TITLE
[nova] Fix shellinabox console

### DIFF
--- a/openstack/nova/console/shellinabox/revproxy.lua
+++ b/openstack/nova/console/shellinabox/revproxy.lua
@@ -1,7 +1,9 @@
 local _M = {}
 
 local token_lookup = require "token_lookup"
-
+local get_token = token_lookup.get_token
+local lookup = token_lookup.lookup
+local host_from_entry = token_lookup.token_lookup.lookup
 local url_base = "/cell1/shellinabox/" -- TODO: Get the "shellinabox" from the proxy dynamically somehow
 
 -- The server may respond with a redirect, and we

--- a/openstack/nova/templates/console-shellinabox-deployment.yaml
+++ b/openstack/nova/templates/console-shellinabox-deployment.yaml
@@ -36,7 +36,7 @@ spec:
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
         {{- end }}
         {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
-        config-hash: {{ print (.Files.Glob "shellinabox/*").AsConfig (include "nova.etc_config_lua" .) | sha256sum }}
+        config-hash: {{ print (.Files.Glob "console/shellinabox/*").AsConfig (.Files.Glob "console/common/*").AsConfig (include "nova.etc_config_lua" .) | sha256sum }}
     spec:
       securityContext:
         runAsUser: 33


### PR DESCRIPTION
Some functions were moved common/token_lookup.lua without the references for shellinabox.
The common part now also needs to trigger an update of the deployment of shellinabox deployments.