### PR TITLE
[pxc-db] Increase net_read_timeout and net_write_timeout

### DIFF
--- a/common/pxc-db/Chart.yaml
+++ b/common/pxc-db/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.12
+version: 0.2.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/common/pxc-db/values.yaml
+++ b/common/pxc-db/values.yaml
@@ -194,8 +194,8 @@ pxc:
       binlog_expire_logs_seconds: "345600"  # default 30 days -> 4 days
       max_binlog_size: "104857600"  # default 1G -> 100M
       sync_binlog: 1  # default value for PXC
-      net_read_timeout: 30
-      net_write_timeout: 60
+      net_read_timeout: 120
+      net_write_timeout: 300  # net_write_timeout limits the maximum size of binlog sent to mysqlbinlog, 180s is required for 1G binlog
       connect_timeout: 30
       wait_timeout: 3800
       interactive_timeout: 1800


### PR DESCRIPTION
Increase net_read_timeout and net_write_timeout

Return change from PR #7290, that has been accidentally lost:
At least 180s timeout is required for binlog-collector processing of 1G