### PR TITLE
[sap-seeds] Move vmware v1 & v2 related things to values

### DIFF
--- a/openstack/sap-seeds/templates/flavor-seed.yaml
+++ b/openstack/sap-seeds/templates/flavor-seed.yaml
@@ -15,7 +15,9 @@ spec:
     disk: 64
     is_public: false
     extra_specs:
-      {{- tuple . "forced" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      "resources:VCPU": "0"
+      "resources:MEMORY_MB": "0"
+      "resources:DISK_GB": "0"
 
   # Regular Flavors v1 (Cascade-Lake)
   - name: "m1.tiny"
@@ -25,8 +27,7 @@ spec:
     disk: 1
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" (dict "hw_video:ram_max_mb" 4) | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" (dict "hw_video:ram_max_mb" 4) | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c1_m2"
     id: "19"
     vcpus: 1
@@ -35,8 +36,7 @@ spec:
     is_public: true
     extra_specs:
       "catalog:alias": "m1.xsmallcpuhdd"
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "c_c2_m2"
     id: "20"
     vcpus: 2
@@ -45,8 +45,7 @@ spec:
     is_public: true
     extra_specs:
       "catalog:alias": "m1.small,m1.smallhdd"
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c2_m4"
     id: "22"
     vcpus: 2
@@ -55,8 +54,7 @@ spec:
     is_public: true
     extra_specs:
       "catalog:alias": "m1.xsmall,m1.xsmallhdd"
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c1_m3"
     id: "24"
     vcpus: 1
@@ -64,8 +62,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c1_m4"
     id: "25"
     vcpus: 1
@@ -73,8 +70,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c2_m8"
     id: "32"
     vcpus: 2
@@ -83,8 +79,7 @@ spec:
     is_public: true
     extra_specs:
       "catalog:alias": "m1.xmedium"
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "c_c4_m4"
     id: "30"
     vcpus: 4
@@ -93,8 +88,7 @@ spec:
     is_public: true
     extra_specs:
       "catalog:alias": "m1.medium"
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c4_m8"
     id: "40"
     vcpus: 4
@@ -103,8 +97,7 @@ spec:
     is_public: true
     extra_specs:
       "catalog:alias": "m1.large"
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c4_m16"
     id: "50"
     vcpus: 4
@@ -113,8 +106,7 @@ spec:
     is_public: true
     extra_specs:
       "catalog:alias": "m1.xlarge"
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "c_c16_m16"
     id: "52"
     vcpus: 16
@@ -123,8 +115,7 @@ spec:
     is_public: true
     extra_specs:
       "catalog:alias": "m1.xlarge_cpu"
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c6_m24"
     id: "53"
     vcpus: 6
@@ -132,8 +123,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c8_m32"
     id: "60"
     vcpus: 8
@@ -142,8 +132,7 @@ spec:
     is_public: true
     extra_specs:
       "catalog:alias": "m1.2xlarge"
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c16_m32"
     id: "61"
     vcpus: 16
@@ -152,8 +141,7 @@ spec:
     is_public: true
     extra_specs:
       "catalog:alias": "m1.2xlargecpu"
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c12_m48"
     id: "62"
     vcpus: 12
@@ -161,8 +149,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c16_m64"
     id: "70"
     vcpus: 16
@@ -171,8 +158,7 @@ spec:
     is_public: true
     extra_specs:
       "catalog:alias": "m1.4xlarge"
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m1.10xlarge"
     id: "80"
     vcpus: 40
@@ -180,8 +166,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m1.10xlargesmallcpu"
     id: "81"
     vcpus: 16
@@ -189,8 +174,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c8_m128"
     id: "90"
     vcpus: 8
@@ -199,8 +183,7 @@ spec:
     is_public: true
     extra_specs:
       "catalog:alias": "x1.memory"
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c16_m256"
     id: "99"
     vcpus: 16
@@ -209,8 +192,7 @@ spec:
     is_public: true
     extra_specs:
       "catalog:alias": "x1.2xmemory"
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c32_m512"
     id: "150"
     vcpus: 32
@@ -219,8 +201,7 @@ spec:
     is_public: true
     extra_specs:
       "catalog:alias": "x1.4xmemory"
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "x1.8xmemory"
     id: "151"
     vcpus: 64
@@ -228,8 +209,7 @@ spec:
     disk: 64
     is_public: false
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
       "hw:cpu_cores": "64"  # used in nova-vmware as cores-per-socket (32pCPU = 64vCPU)
   - name: "m_c4_m64"
     id: "100"
@@ -239,8 +219,7 @@ spec:
     is_public: true
     extra_specs:
       "catalog:alias": "m2.large"
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c8_m16"
     id: "110"
     vcpus: 8
@@ -249,8 +228,7 @@ spec:
     is_public: true
     extra_specs:
       "catalog:alias": "m2.xlarge"
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m2.2xlarge"
     id: "120"
     vcpus: 8
@@ -258,8 +236,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m2.2xlarge_cpu"
     id: "122"
     vcpus: 24
@@ -267,8 +244,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m2.10xlarge_cpu"
     id: "123"
     vcpus: 24
@@ -276,8 +252,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m2.14xlarge_cpu"
     id: "124"
     vcpus: 24
@@ -285,8 +260,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m2.14xlarge_cpuhdd"
     id: "125"
     vcpus: 24
@@ -294,8 +268,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m2.3xlarge"
     id: "130"
     vcpus: 8
@@ -303,8 +276,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c2_m16"
     id: "138"
     vcpus: 2
@@ -312,8 +284,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c4_m32"
     id: "145"
     vcpus: 4
@@ -321,8 +292,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c8_m64"
     id: "140"
     vcpus: 8
@@ -331,8 +301,7 @@ spec:
     is_public: true
     extra_specs:
       "catalog:alias": "m2.4xlarge"
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c8_m256"
     id: "141"
     vcpus: 8
@@ -340,8 +309,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c20_m160"
     id: "143"
     vcpus: 20
@@ -349,8 +317,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c24_m96"
     id: "144"
     vcpus: 24
@@ -358,8 +325,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c24_m192"
     id: "142"
     vcpus: 24
@@ -367,8 +333,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c16_m128"
     id: "160"
     vcpus: 16
@@ -377,8 +342,7 @@ spec:
     is_public: true
     extra_specs:
       "catalog:alias": "m2.8xlarge"
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m2.16xlarge"
     id: "161"
     vcpus: 16
@@ -386,8 +350,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c16_m512"
     id: "164"
     vcpus: 16
@@ -395,8 +358,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c32_m128"
     id: "162"
     vcpus: 32
@@ -404,8 +366,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c48_m192"
     id: "166"
     vcpus: 48
@@ -413,8 +374,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m5.xlarge2hdd"
     id: "210"
     vcpus: 4
@@ -422,8 +382,7 @@ spec:
     disk: 150
     is_public: false
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m5.12xlarge"
     id: "211"
     vcpus: 48
@@ -431,8 +390,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m5.14xlarge"
     id: "212"
     vcpus: 60
@@ -440,8 +398,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c32_m256"
     id: "163"
     vcpus: 32
@@ -449,8 +406,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c64_m512"
     id: "165"
     vcpus: 64
@@ -458,9 +414,8 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
       "hw:cpu_cores": "64"  # used in nova-vmware as cores-per-socket (32pCPU = 64vCPU)
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c64_m256"
     id: "220"
     vcpus: 64
@@ -470,8 +425,7 @@ spec:
     extra_specs:
       "catalog:alias": "m5.16xlarge"
       "hw:cpu_cores": "64"  # used in nova-vmware as cores-per-socket (32pCPU = 64vCPU)
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c48_m512"
     id: "221"
     vcpus: 48
@@ -479,8 +433,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c128_m512"
     id: "230"
     vcpus: 128
@@ -490,8 +443,7 @@ spec:
     extra_specs:
       "catalog:alias": "m5.32xlarge"
       "hw:cpu_cores": "64"  # used in nova-vmware as cores-per-socket (32pCPU = 64vCPU)
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m5.48xlarge"
     id: "231"
     vcpus: 96
@@ -499,9 +451,8 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
       "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c128_m1000"
     id: "240"
     vcpus: 128
@@ -511,9 +462,7 @@ spec:
     extra_specs:
       "catalog:alias": "m5.64xlarge"
       "hw:cpu_cores": "64"  # used in nova-vmware as cores-per-socket (32pCPU = 64vCPU)
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "vmware:evc_mode": "intel-cascadelake"
-
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
 
   # Regular Flavors v2 (Sapphire-Rapids)
   - name: "m1.tiny_v2"
@@ -523,8 +472,7 @@ spec:
     disk: 1
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" (dict "hw_video:ram_max_mb" 4) | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" (dict "hw_video:ram_max_mb" 4) | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c1_m2_v2"
     id: "402"
     vcpus: 1
@@ -532,8 +480,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "c_c2_m2_v2"
     id: "403"
     vcpus: 2
@@ -541,8 +488,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c2_m4_v2"
     id: "404"
     vcpus: 2
@@ -550,8 +496,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c1_m3_v2"
     id: "405"
     vcpus: 1
@@ -559,8 +504,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c1_m4_v2"
     id: "406"
     vcpus: 1
@@ -568,8 +512,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c2_m8_v2"
     id: "407"
     vcpus: 2
@@ -577,8 +520,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "c_c4_m4_v2"
     id: "408"
     vcpus: 4
@@ -586,8 +528,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c4_m8_v2"
     id: "409"
     vcpus: 4
@@ -595,8 +536,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c4_m16_v2"
     id: "410"
     vcpus: 4
@@ -604,8 +544,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "c_c16_m16_v2"
     id: "411"
     vcpus: 16
@@ -613,8 +552,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c6_m24_v2"
     id: "412"
     vcpus: 6
@@ -622,8 +560,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c8_m32_v2"
     id: "413"
     vcpus: 8
@@ -631,8 +568,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c16_m32_v2"
     id: "414"
     vcpus: 16
@@ -640,8 +576,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c12_m48_v2"
     id: "415"
     vcpus: 12
@@ -649,8 +584,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c16_m64_v2"
     id: "416"
     vcpus: 16
@@ -658,8 +592,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m1.10xlarge_v2"
     id: "417"
     vcpus: 40
@@ -667,8 +600,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m1.10xlargesmallcpu_v2"
     id: "418"
     vcpus: 16
@@ -676,8 +608,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c8_m128_v2"
     id: "419"
     vcpus: 8
@@ -685,8 +616,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c16_m256_v2"
     id: "420"
     vcpus: 16
@@ -694,8 +624,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c32_m512_v2"
     id: "421"
     vcpus: 32
@@ -703,8 +632,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "x1.8xmemory_v2"
     id: "422"
     vcpus: 64
@@ -712,9 +640,8 @@ spec:
     disk: 64
     is_public: false
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
       "hw:cpu_cores": "64"  # used in nova-vmware as cores-per-socket (32pCPU = 64vCPU)
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
   - name: "m_c4_m64_v2"
     id: "423"
     vcpus: 4
@@ -722,8 +649,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c8_m16_v2"
     id: "424"
     vcpus: 8
@@ -731,8 +657,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m2.2xlarge_v2"
     id: "425"
     vcpus: 8
@@ -740,8 +665,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m2.2xlarge_cpu_v2"
     id: "426"
     vcpus: 24
@@ -749,8 +673,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m2.10xlarge_cpu_v2"
     id: "427"
     vcpus: 24
@@ -758,8 +681,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m2.14xlarge_cpu_v2"
     id: "428"
     vcpus: 24
@@ -767,8 +689,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m2.14xlarge_cpuhdd_v2"
     id: "429"
     vcpus: 24
@@ -776,8 +697,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m2.3xlarge_v2"
     id: "430"
     vcpus: 8
@@ -785,8 +705,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c2_m16_v2"
     id: "431"
     vcpus: 2
@@ -794,8 +713,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c4_m32_v2"
     id: "452"
     vcpus: 4
@@ -803,8 +721,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c8_m64_v2"
     id: "432"
     vcpus: 8
@@ -812,8 +729,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c8_m256_v2"
     id: "433"
     vcpus: 8
@@ -821,8 +737,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c20_m160_v2"
     id: "434"
     vcpus: 20
@@ -830,8 +745,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c24_m192_v2"
     id: "435"
     vcpus: 24
@@ -839,8 +753,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c16_m128_v2"
     id: "436"
     vcpus: 16
@@ -848,8 +761,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m2.16xlarge_v2"
     id: "437"
     vcpus: 16
@@ -857,8 +769,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c16_m512_v2"
     id: "438"
     vcpus: 16
@@ -866,8 +777,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c24_m96_v2"
     id: "451"
     vcpus: 24
@@ -875,8 +785,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c32_m128_v2"
     id: "439"
     vcpus: 32
@@ -884,8 +793,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c48_m192_v2"
     id: "440"
     vcpus: 48
@@ -893,8 +801,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m5.xlarge2hdd_v2"
     id: "441"
     vcpus: 4
@@ -902,8 +809,7 @@ spec:
     disk: 150
     is_public: false
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m5.12xlarge_v2"
     id: "442"
     vcpus: 48
@@ -911,8 +817,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m5.14xlarge_v2"
     id: "443"
     vcpus: 60
@@ -920,8 +825,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c32_m256_v2"
     id: "444"
     vcpus: 32
@@ -929,8 +833,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "m_c64_m512_v2"
     id: "445"
     vcpus: 64
@@ -938,9 +841,8 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
       "hw:cpu_cores": "64"  # used in nova-vmware as cores-per-socket (32pCPU = 64vCPU)
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
   - name: "g_c64_m256_v2"
     id: "446"
     vcpus: 64
@@ -948,9 +850,8 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
       "hw:cpu_cores": "64"  # used in nova-vmware as cores-per-socket (32pCPU = 64vCPU)
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
   - name: "m_c48_m512_v2"
     id: "447"
     vcpus: 48
@@ -958,8 +859,7 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
   - name: "g_c128_m512_v2"
     id: "448"
     vcpus: 128
@@ -967,9 +867,8 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
       "hw:cpu_cores": "64"  # used in nova-vmware as cores-per-socket (32pCPU = 64vCPU)
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
   - name: "m5.48xlarge_v2"
     id: "449"
     vcpus: 96
@@ -977,9 +876,8 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
       "hw:cpu_cores": "48"  # used in nova-vmware as cores-per-socket (24pCPU = 48vCPU)
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
   - name: "m_c128_m1000_v2"
     id: "450"
     vcpus: 128
@@ -987,10 +885,8 @@ spec:
     disk: 64
     is_public: true
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      {{- tuple . "vmware_v2" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
       "hw:cpu_cores": "64"  # used in nova-vmware as cores-per-socket (32pCPU = 64vCPU)
-      "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
-
 
 
   ### HANA flavors
@@ -1017,7 +913,7 @@ spec:
     disk: 64
     is_public: false
     extra_specs:
-      {{- tuple . "vmware" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
+      {{- tuple . "vmware_v1" | include "sap_seeds.helpers.extra_specs" | indent 6 }}
       "hw:cpu_cores": "64"  # used in nova-vmware as cores-per-socket (32pCPU = 64vCPU)
 
 {{ include (print .Template.BasePath "/_flavors_deleted.tpl") . | indent 2 }}

--- a/openstack/sap-seeds/values.yaml
+++ b/openstack/sap-seeds/values.yaml
@@ -18,18 +18,34 @@ global:
     skip_hcm_domain: false
 
 extra_specs:
-  forced:
-    "resources:VCPU": "0"
-    "resources:MEMORY_MB": "0"
-    "resources:DISK_GB": "0"
   vmware_common: &vmware_common
     "capabilities:hypervisor_type": "VMware vCenter Server"
     "hw_video:ram_max_mb": "16"
     "vmware:hw_version": "vmx-18"
     "vmware:hv_enabled": "True"
-  vmware:
+  vmware: &vmware
     <<: *vmware_common
     "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "forbidden"
-  vmware_hana_exclusive:
+  vmware_hana_exclusive: &vmware_hana_exclusive
     <<: *vmware_common
     "trait:CUSTOM_HANA_EXCLUSIVE_HOST": "required"
+
+  vmware_common_v1: &vmware_common_v1
+    <<: *vmware_common
+    "vmware:evc_mode": "intel-cascadelake"
+  vmware_v1:
+    <<: *vmware_common_v1
+    <<: *vmware
+  vmware_hana_exclusive_v1:
+    <<: *vmware_common_v1
+    <<: *vmware_hana_exclusive
+
+  vmware_common_v2: &vmware_common_v2
+    <<: *vmware_common
+    "trait:CUSTOM_HW_SAPPHIRE_RAPIDS": "required"
+  vmware_v2:
+    <<: *vmware_common_v2
+    <<: *vmware
+  vmware_hana_exclusive_v1:
+    <<: *vmware_common_v2
+    <<: *vmware_hana_exclusive


### PR DESCRIPTION
This fixes two inconsistencies:
- hana_c24_m365: Adds 'vmware:evc_mode': 'intel-cascadelake'
- m1.10xlargesmallcpu_v2: Adds 'trait:CUSTOM_HW_SAPPHIRE_RAPIDS': 'required'