### PR TITLE
[vcenter-operator] Support secrets-injector

### DIFF
--- a/openstack/vcenter-operator/Chart.lock
+++ b/openstack/vcenter-operator/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.3.0
+  version: 0.21.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
-digest: sha256:0307149a5c535514f5e8a0f8ab360dbe52408ac672f5ffa8eb87ce76d2cb2904
-generated: "2024-04-12T15:52:35.683199+02:00"
+digest: sha256:7dc806b18d84aa60c796dac490f77e4e858bc07bfc421911a6247e6e7ae39cea
+generated: "2025-01-22T12:18:05.456123139+01:00"

--- a/openstack/vcenter-operator/Chart.yaml
+++ b/openstack/vcenter-operator/Chart.yaml
@@ -5,7 +5,7 @@ version: 0.1.0
 dependencies:
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.3.0
+    version: ~0.21.0
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.2.0

--- a/openstack/vcenter-operator/templates/secret.yaml
+++ b/openstack/vcenter-operator/templates/secret.yaml
@@ -6,9 +6,9 @@ metadata:
     {{- tuple . "vcenter-operator" "operator" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | nindent 4 }}
 data:
   namespace: {{ .Values.global.keystoneNamespace | b64enc }}
-  username: {{ .Values.username | b64enc }}
-  password: {{ .Values.global.vcenter_operator_master_password | b64enc }}
-  tsig_key: {{ .Values.tsig_key | b64enc }}
+  username: {{ .Values.username | include "resolve_secret" | b64enc }}
+  password: {{ .Values.global.vcenter_operator_master_password | include "resolve_secret" | b64enc }}
+  tsig_key: {{ .Values.tsig_key | include "resolve_secret" | b64enc }}
 {{- range $key, $value := .Values.variables }}
-  {{ $key }}: {{ $value | b64enc }}
+  {{ $key }}: {{ $value | include "resolve_secret" | b64enc }}
 {{- end }}


### PR DESCRIPTION
We need to support `secrets-injector` references coming from the values files. Since some values might be changed already while others may not, we bump the `utils` chart to the latest version and use its `resolve_secret` helper on every value that could be a secret. This takes care of including the proper syntax for the `secrets-injector` if the secret is a reference.

Since we haven't bumped the `utils` chart in quite some time, we will also get some other changes. Other than `resolve_secret`, we only use `helm-toolkit.snippets.kubernetes_metadata_labels` from the `utils` chart.