### PR TITLE
[Andromeda] Added missing keys to `test-values.yaml`.

### DIFF
--- a/global/andromeda/ci/test-values.yaml
+++ b/global/andromeda/ci/test-values.yaml
@@ -5,6 +5,10 @@ global:
   dockerHubMirrorAlternateRegion: registry-other.example.com/dockerhub
   vaultBaseURL: https://vault.example.com
 
+nats:
+  cluster:
+    password: foo
+
 image:
   tag: "test"
 postgresql:


### PR DESCRIPTION
Without this patch the following command fails:

```sh
helm template --values ./global/andromeda/ci/test-values.yaml global/andromeda
```

with:

```
Error: execution error at (andromeda/charts/nats/templates/configmap.yaml:9:3): cluster.password required
```
