### PR TITLE
[manila] bump dependencies

### DIFF
--- a/openstack/manila/Chart.lock
+++ b/openstack/manila/Chart.lock
@@ -4,24 +4,24 @@ dependencies:
   version: 1.1.0
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.14.3
+  version: 0.15.3
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.5.4
+  version: 0.6.3
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.3.6
+  version: 0.4.2
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.11.4
-- name: utils
-  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.19.6
+  version: 0.14.0
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.5.3
-digest: sha256:2072db9105b92d3ae331863e044a2c80f45de17a1f4a580f6a25705ee82e3060
-generated: "2024-11-26T16:45:21.461609+01:00"
+  version: 1.6.2
+- name: utils
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 0.21.0
+digest: sha256:b13c81b80bca275479dddaaeeae2e74647b4948bf86be65c3bd6566b55e85c76
+generated: "2025-01-24T15:09:28.410897+01:00"

--- a/openstack/manila/Chart.yaml
+++ b/openstack/manila/Chart.yaml
@@ -17,26 +17,26 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.14.2
+    version: ~0.15.3
   - condition: memcached.enabled
     name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.5.3
+    version: ~0.6.3
   - condition: mariadb.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.3.0
+    version: ~0.4.2
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: ~1.0.0
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.11.1
-  - name: utils
-    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.19.0
+    version: ~0.14.0
   - name: redis
     alias: api-ratelimit-redis
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~1.5.0
+    version: ~1.6.2
     condition: api_rate_limit.enabled
+  - name: utils
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: ~0.21.0

--- a/openstack/manila/alerts/openstack/manila.alerts
+++ b/openstack/manila/alerts/openstack/manila.alerts
@@ -274,21 +274,6 @@ groups:
       description: "Rate limit for {{ $labels.target_type_uri }} with action {{ $labels.action }} exceeded. Target project: {{ $labels.domain_name }}/{{ $labels.project_name }} ({{ $labels.project_id }})."
       summary: Manila API rate limit exceeded
 
-# row locks
-  - alert: OpenstackManilaMariadbRowLocks
-    expr: mysql_global_status_innodb_row_lock_current_waits{app="manila-mariadb"} > 0
-    for: 5m
-    labels:
-      severity: info
-      tier: os
-      service: manila
-      context: manila-db-locks
-      meta: '{{ $labels.service }} db row locks'
-      support_group: compute-storage-api
-    annotations:
-      description: '{{ $labels.service }} db row locks'
-      summary: '{{ $labels.service }} db row locks'
-
   - alert: OpenstackManilaUnresolvedSentryIssues
     expr: delta(sentry_unresolved_issues_count{project="manila"}[1d]) > 0
     for: 10m

--- a/openstack/manila/alerts/openstack/mariadb.alerts
+++ b/openstack/manila/alerts/openstack/mariadb.alerts
@@ -1,0 +1,17 @@
+groups:
+- name: manila-mariadb.alerts
+  rules:
+# row locks
+  - alert: OpenstackManilaMariadbRowLocks
+    expr: mysql_global_status_innodb_row_lock_current_waits{app_kubernetes_io_part_of="manila"} > 0
+    for: 5m
+    labels:
+      severity: info
+      tier: os
+      service: manila
+      context: manila-db-locks
+      meta: '{{ $labels.app_kubernetes_io_instance }} db row locks'
+      support_group: compute-storage-api
+    annotations:
+      description: '{{ $labels.app_kubernetes_io_instance }} db row locks'
+      summary: '{{ $labels.app_kubernetes_io_instance }} db row locks'


### PR DESCRIPTION
* mariadb:
    * bumped to 10.5.27
    * labels updated -> hence updated the alert and moved to own group
* memcached:
    * bumped to 1.6.34-alpine3.21 (Release Notes https://github.com/memcached/memcached/wiki/ReleaseNotes1634)
    * exporter bumped to v0.15.0 (Release Notes https://github.com/prometheus/memcached_exporter/releases/tag/v0.15.0)
* mysql_metrics:
    * bumped sql-exporter version to 0.5.9 (2025-01-07)
* rabbitmq:
    * bump to 3.13.7 (Release Notes https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.13.7)
    * Add options to enable ssl in rabbitmq
* redis:
    * bump redis-exporter to 1.67.0
    * switch to valkey
* utils:
    * proxysql: Set default transaction and query timeouts
