### PR TITLE
[designate] bump pxc and rabbitmq dependencies

### DIFF
--- a/openstack/designate/Chart.lock
+++ b/openstack/designate/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.1.9
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.2.10
+  version: 0.2.13
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.15.3
@@ -16,7 +16,7 @@ dependencies:
   version: 0.4.2
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.12.1
+  version: 0.14.0
 - name: rabbitmq_cluster
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.10
@@ -29,5 +29,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:d5f9d9dfac9ec60d59da4f16a69450b6bd02f0a3cea49d1edbaf7f24a17f0b78
-generated: "2025-01-14T14:16:56.015529+02:00"
+digest: sha256:4e2fe5b8af20e8c75e7a56037a977f9c686e769557a3294f790e098de43208f8
+generated: "2025-01-24T18:39:49.156726+02:00"

--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes to deploy Openstack Designate  (DNSaaS)
 name: designate
-version: 0.4.10
+version: 0.4.11
 appVersion: "xena"
 dependencies:
   - condition: percona_cluster.enabled
@@ -13,7 +13,7 @@ dependencies:
     name: pxc-db
     alias: pxc_db
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.2.10
+    version: 0.2.13
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
@@ -28,7 +28,7 @@ dependencies:
   - name: rabbitmq
     condition: rabbitmq.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.12.1
+    version: 0.14.0
   - name: rabbitmq_cluster
     condition: rabbitmq_cluster.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm


### PR DESCRIPTION
Bump Designate pxc and rabbitmq dependencies:
* pxc-db: 0.2.10 -> 0.2.13 (binlog size and timeouts fix)
* rabbitmq: 0.12.1 -> 0.14.0 (updates rabbitmq to 4.0.5)