### PR TITLE
andromeda secrets injector fix

### DIFF
--- a/global/andromeda/templates/configmap-akamai.yaml
+++ b/global/andromeda/templates/configmap-akamai.yaml
@@ -9,5 +9,3 @@ metadata:
 data:
   akamai.yaml: |
 {{ include (print .Template.BasePath "/etc/_akamai.yaml.tpl") . | indent 4 }}
-  edgerc.conf: |
-{{ include (print .Template.BasePath "/etc/_edgerc.tpl") . | indent 4 }}

--- a/global/andromeda/templates/deployment-akamai.yaml
+++ b/global/andromeda/templates/deployment-akamai.yaml
@@ -40,10 +40,6 @@ spec:
         command: ["/usr/bin/andromeda-akamai-agent"]
         args: ["--config-file", "/etc/andromeda/andromeda.yaml", "--config-file", "/etc/andromeda/akamai.yaml"]
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        lifecycle:
-          poststart:
-            exec:
-              command: ["/bin/sh", "-c", "cp /etc/edgerc-secret/edgerc /etc/andromeda/edgerc.conf"]
         env:
           - name: AKAMAI_LOG
             value: info
@@ -77,9 +73,6 @@ spec:
           - name: etc-andromeda
             mountPath: /etc/andromeda
             readOnly: true
-          - name: etc-edgerc-secret
-            mountPath: /etc/edgerc-secret
-            readOnly: true
       volumes:
       - name: etc-edgerc-secret
         secret:
@@ -98,5 +91,8 @@ spec:
                 items:
                   - key: akamai.yaml
                     path: akamai.yaml
-                  - key: edgerc.conf
+            - secret:
+                name: andromeda-secret
+                items:
+                  - key: edgerc
                     path: edgerc.conf

--- a/global/andromeda/templates/deployment-akamai.yaml
+++ b/global/andromeda/templates/deployment-akamai.yaml
@@ -40,6 +40,10 @@ spec:
         command: ["/usr/bin/andromeda-akamai-agent"]
         args: ["--config-file", "/etc/andromeda/andromeda.yaml", "--config-file", "/etc/andromeda/akamai.yaml"]
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        lifecycle:
+          poststart:
+            exec:
+              command: ["/bin/sh", "-c", "cp /etc/edgerc-secret/edgerc /etc/andromeda/edgerc.conf"]
         env:
           - name: AKAMAI_LOG
             value: info
@@ -73,7 +77,13 @@ spec:
           - name: etc-andromeda
             mountPath: /etc/andromeda
             readOnly: true
+          - name: etc-edgerc-secret
+            mountPath: /etc/edgerc-secret
+            readOnly: true
       volumes:
+      - name: etc-edgerc-secret
+        secret:
+          secretName: edgerc
       - name: etc-andromeda
         projected:
           defaultMode: 420

--- a/global/andromeda/templates/deployment-akamai.yaml
+++ b/global/andromeda/templates/deployment-akamai.yaml
@@ -58,6 +58,11 @@ spec:
               secretKeyRef:
                 name: sentry
                 key: {{ include "andromeda.fullname" . }}.DSN
+          - name: OS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: andromeda-secret
+                key: service_user_password
         ports:
           - containerPort: 9090
             name: metrics

--- a/global/andromeda/templates/deployment-housekeeping.yaml
+++ b/global/andromeda/templates/deployment-housekeeping.yaml
@@ -60,6 +60,13 @@ spec:
               secretKeyRef:
                 name: andromeda-secret
                 key: service_user_password
+          {{- if .Values.mariadb.enabled }}
+          - name: DATABASE_CONNECTION
+            valueFrom:
+              secretKeyRef:
+                name: andromeda-secret
+                key: database_connection
+          {{- end }}
         ports:
           - containerPort: 9090
             name: metrics

--- a/global/andromeda/templates/deployment-housekeeping.yaml
+++ b/global/andromeda/templates/deployment-housekeeping.yaml
@@ -55,6 +55,11 @@ spec:
               secretKeyRef:
                 name: sentry
                 key: {{ include "andromeda.fullname" . }}.DSN
+          - name: OS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: andromeda-secret
+                key: service_user_password
         ports:
           - containerPort: 9090
             name: metrics

--- a/global/andromeda/templates/deployment.yaml
+++ b/global/andromeda/templates/deployment.yaml
@@ -67,6 +67,13 @@ spec:
                 secretKeyRef:
                   name: andromeda-secret
                   key: service_user_password
+            {{- if .Values.mariadb.enabled }}
+            - name: DATABASE_CONNECTION
+              valueFrom:
+                secretKeyRef:
+                  name: andromeda-secret
+                  key: database_connection
+            {{- end }}
             {{- if .Values.audit.enabled }}
             - name: AUDIT_TRANSPORT_URL
               valueFrom:

--- a/global/andromeda/templates/deployment.yaml
+++ b/global/andromeda/templates/deployment.yaml
@@ -44,6 +44,10 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           args: ["--config-file", "/etc/andromeda/andromeda.yaml", "--config-file", "/etc/andromeda/akamai.yaml", "--port", "8000"]
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          lifecycle:
+            poststart:
+              exec:
+                command: ["/bin/sh", "-c", "cp /etc/edgerc-secret/edgerc /etc/andromeda/edgerc.conf"]
           env:
             - name: HOST
               value: 0.0.0.0
@@ -102,7 +106,13 @@ spec:
             - name: etc-andromeda
               mountPath: /etc/andromeda
               readOnly: true
+            - name: etc-edgerc-secret
+              mountPath: /etc/edgerc-secret
+              readOnly: true
       volumes:
+        - name: etc-edgerc-secret
+          secret:
+            secretName: edgerc
         - name: etc-andromeda
           projected:
             defaultMode: 420

--- a/global/andromeda/templates/deployment.yaml
+++ b/global/andromeda/templates/deployment.yaml
@@ -62,6 +62,18 @@ spec:
                 secretKeyRef:
                   name: sentry
                   key: {{ include "andromeda.fullname" . }}.DSN
+            - name: OS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: andromeda-secret
+                  key: service_user_password
+            {{- if .Values.audit.enabled }}
+            - name: AUDIT_TRANSPORT_URL
+              valueFrom:
+                secretKeyRef:
+                  name: andromeda-secret
+                  key: audit_transport_url
+            {{- end }}
           ports:
             - name: http
               containerPort: 8000

--- a/global/andromeda/templates/deployment.yaml
+++ b/global/andromeda/templates/deployment.yaml
@@ -44,10 +44,6 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           args: ["--config-file", "/etc/andromeda/andromeda.yaml", "--config-file", "/etc/andromeda/akamai.yaml", "--port", "8000"]
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          lifecycle:
-            poststart:
-              exec:
-                command: ["/bin/sh", "-c", "cp /etc/edgerc-secret/edgerc /etc/andromeda/edgerc.conf"]
           env:
             - name: HOST
               value: 0.0.0.0
@@ -106,13 +102,7 @@ spec:
             - name: etc-andromeda
               mountPath: /etc/andromeda
               readOnly: true
-            - name: etc-edgerc-secret
-              mountPath: /etc/edgerc-secret
-              readOnly: true
       volumes:
-        - name: etc-edgerc-secret
-          secret:
-            secretName: edgerc
         - name: etc-andromeda
           projected:
             defaultMode: 420

--- a/global/andromeda/templates/etc/_andromeda.yaml.tpl
+++ b/global/andromeda/templates/etc/_andromeda.yaml.tpl
@@ -26,7 +26,6 @@ service_auth:
   auth_url: {{ .Values.global.keystone_api_endpoint_protocol_public | default "https"}}://{{include "keystone_api_endpoint_host_public" .}}/v3
 {{- end }}
   username: {{ .Release.Name }}{{ .Values.global.user_suffix }}
-  password: {{ .Values.global.andromeda_service_password }}
   project_name: service
   project_domain_id: default
   user_domain_id: default
@@ -46,7 +45,6 @@ quota:
 audit_middleware_notifications:
   enabled: true
   queue_name: {{.Values.audit.queue_name}}
-  transport_url: rabbit://{{.Values.audit.user}}:{{.Values.audit.password | required "audit.password required"}}@:{{.Values.audit.port}}
 {{- end }}
 
 house_keeping:

--- a/global/andromeda/templates/etc/_andromeda.yaml.tpl
+++ b/global/andromeda/templates/etc/_andromeda.yaml.tpl
@@ -4,11 +4,6 @@ DEFAULT:
   prometheus: true
   prometheus_listen: 0.0.0.0:9090
 
-database:
-{{- if .Values.mariadb.enabled }}
-  connection: mysql://andromeda:{{ required ".Values.mariadb.users.andromeda.password variable missing" .Values.mariadb.users.andromeda.password | urlquery }}@{{.Release.Name}}-mariadb/andromeda?sql_mode=%27ANSI_QUOTES%27
-{{- end }}
-
 api_settings:
   auth_strategy: keystone
   policy_engine: goslo

--- a/global/andromeda/templates/job-migration.yaml
+++ b/global/andromeda/templates/job-migration.yaml
@@ -48,6 +48,13 @@ spec:
                 secretKeyRef:
                   name: sentry
                   key: {{ include "andromeda.fullname" . }}.DSN
+            {{- if .Values.mariadb.enabled }}
+            - name: DATABASE_CONNECTION
+              valueFrom:
+                secretKeyRef:
+                  name: andromeda-secret
+                  key: database_connection
+            {{- end }}
           volumeMounts:
             - name: etc-andromeda
               mountPath: /etc/andromeda

--- a/global/andromeda/templates/secret.yaml
+++ b/global/andromeda/templates/secret.yaml
@@ -1,0 +1,15 @@
+{{- $vbase  := .Values.global.vaultBaseURL | required "missing value for .Values.global.vaultBaseURL" }}
+{{- $region := .Values.global.region | required "missing value for .Values.global.region" }}
+{{- $audit_user := printf "%s/%s/hermes/rabbitmq-user/notifications-andromeda/user" $vbase $region | quote }}
+{{- $audit_pass := printf "%s/%s/hermes/rabbitmq-user/notifications-andromeda/password" $vbase $region | quote }}
+{{- $audit_host := .Values.audit.host | required "missing value for .Values.audit.host" }}
+{{- $audit_port := .Values.audit.port | required "missing value for .Values.audit.port" | int }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: andromeda-secret
+data:
+  service_user_password: {{ printf "%s/%s/andromeda/keystone-user/service/password" $vbase $region | b64enc }}
+  {{- if .Values.audit.enabled }}
+  audit_transport_url: {{ printf "amqp://{{resolve %s}}:{{resolve %s}}@%s:%d/" $audit_user $audit_pass $audit_host $audit_port | b64enc }}
+  {{- end }}

--- a/global/andromeda/templates/secret.yaml
+++ b/global/andromeda/templates/secret.yaml
@@ -4,12 +4,17 @@
 {{- $audit_pass := printf "%s/%s/hermes/rabbitmq-user/notifications-andromeda/password" $vbase $region | quote }}
 {{- $audit_host := .Values.audit.host | required "missing value for .Values.audit.host" }}
 {{- $audit_port := .Values.audit.port | required "missing value for .Values.audit.port" | int }}
+{{- $db_pass := .Values.mariadb.users.andromeda.password | required "missing value for .Values.mariadb.users.andromeda.password" }}
+{{- $sql_mode := "'ANSI_QUOTES'" | urlquery }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: andromeda-secret
 data:
   service_user_password: {{ printf "%s/%s/andromeda/keystone-user/service/password" $vbase $region | b64enc }}
+  {{- if .Values.mariadb.enabled }}
+  database_connection: {{ printf "mysql://andromeda:%s@%s-mariadb/andromeda?sql_mode=%s" $db_pass .Release.Name $sql_mode | b64enc }}
+  {{- end }}
   {{- if .Values.audit.enabled }}
   audit_transport_url: {{ printf "amqp://{{resolve %s}}:{{resolve %s}}@%s:%d/" $audit_user $audit_pass $audit_host $audit_port | b64enc }}
   {{- end }}

--- a/global/andromeda/templates/secret.yaml
+++ b/global/andromeda/templates/secret.yaml
@@ -18,3 +18,4 @@ data:
   {{- if .Values.audit.enabled }}
   audit_transport_url: {{ printf "amqp://{{resolve %s}}:{{resolve %s}}@%s:%d/" $audit_user $audit_pass $audit_host $audit_port | b64enc }}
   {{- end }}
+  edgerc: {{ include (print $.Template.BasePath "/etc/_edgerc.tpl") . | b64enc }}

--- a/global/andromeda/templates/seed.yaml
+++ b/global/andromeda/templates/seed.yaml
@@ -49,7 +49,7 @@ spec:
               role: gtm_admin
         - name: andromeda
           description: 'Andromeda Service User'
-          password: {{ .Values.global.andromeda_service_password | quote }}
+          password: {{ printf "%s/%s/andromeda/keystone-user/service/password" .Values.global.vaultBaseURL .Values.global.region | quote }}
           role_assignments:
             - project: service
               role: service


### PR DESCRIPTION
- **[andromeda] switch to secrets-injector.**
- **Provide database connection string as environment variable.**
- **Added missing `DATABASE_CONNECTION` env var to housekeeping.**
- **Added missing `DATABASE_CONNECTION` env var to migration runner.**
- **Created `data.edgerc` secret key, mounted at `/etc/andromeda/edgerc.conf`...**
