### PR TITLE
fix(greenhouse-ccloud): revert templating mirror url

### DIFF
--- a/system/greenhouse-ccloud/Chart.yaml
+++ b/system/greenhouse-ccloud/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: ccloud
 description: A Helm chart for the CCloud organization in Greenhouse.
 type: application
-version: 1.13.1
+version: 1.13.2

--- a/system/greenhouse-ccloud/templates/ingress-plugins.yaml
+++ b/system/greenhouse-ccloud/templates/ingress-plugins.yaml
@@ -12,7 +12,7 @@ spec:
   displayName: ingress nginx {{ $plugin.cluster }}
   optionValues:
   - name: global.image.registry
-    value: {{ required ".Values.global.registryK8sIoMirror is missing" $.Values.global.registryK8sIoMirror }}
+    value: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror
   - name: controller.ingressClassResource.default
     value: true
   - name: controller.scope.enabled


### PR DESCRIPTION
use the global keppel instead of templating the url. Templating does not work since the ci uses the regional values