### PR TITLE
[snmp-exporter] - add poolmbr metric to f5mgmt generator

### DIFF
--- a/prometheus-exporters/snmp-exporter/generator/f5mgmt-generator.yaml
+++ b/prometheus-exporters/snmp-exporter/generator/f5mgmt-generator.yaml
@@ -1,28 +1,29 @@
 modules:
   f5mgmt:
     walk:
-      - ltmVirtualServStatClientCurConns
       - ltmNodeAddrStatServerCurConns
-      - ltmVsStatusAvailState
+      - ltmPoolMemberStatServerCurConns
       - ltmPoolMbrStatusAvailState
+      - ltmVirtualServStatClientCurConns
+      - ltmVsStatusAvailState
       - sysCmFailoverStatusStatus
       - sysCmSyncStatusColor
       - sysCmSyncStatusStatus
-      - sysGlobalTmmStatMemoryTotalKb
-      - sysGlobalTmmStatMemoryUsedKb
       - sysGlobalHostOtherMemTotalKb
       - sysGlobalHostOtherMemUsedKb
       - sysGlobalHostSwapTotalKb
       - sysGlobalHostSwapUsedKb
-      - sysMultiHostCpuUsageRatio5s
-      - sysMultiHostCpuUsageRatio1m
-      - sysProductVersion
+      - sysGlobalTmmStatMemoryTotalKb
+      - sysGlobalTmmStatMemoryUsedKb
       - sysHostDiskPartition
       - sysHostDiskBlockSize
       - sysHostDiskTotalBlocks
       - sysHostDiskFreeBlocks
-      - sysStatClientCurConns
+      - sysMultiHostCpuUsageRatio5s
+      - sysMultiHostCpuUsageRatio1m
       - sysName
+      - sysProductVersion
+      - sysStatClientCurConns
       - sysSystemUptimeInSec
     max_repetitions: 25
     retries: 3


### PR DESCRIPTION
Adding new metric `ltmPoolMemberStatServerCurConns` to get number of current connections for each pool member. This is needed to monitor overall connection "load" on the unbound servers, to prevent port exhaustion.

I also reordered all the metrics alphabetically for better readability of the file.