### PR TITLE
[Barbican] adapt barbican.conf for hsm firmware upgrade to 7.7.1 version

### DIFF
--- a/openstack/barbican/Chart.yaml
+++ b/openstack/barbican/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: bobcat
 description: A Helm chart for Openstack Barbican
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Barbican/OpenStack_Project_Barbican_vertical.png
 name: barbican
-version: 0.5.15
+version: 0.5.16
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/barbican/templates/etc/_secrets.conf.tpl
+++ b/openstack/barbican/templates/etc/_secrets.conf.tpl
@@ -20,4 +20,10 @@ mkek_label = {{ .Values.lunaclient.conn.mkek_label | include "resolve_secret" }}
 mkek_length = {{ .Values.lunaclient.conn.mkek_length }}
 hmac_label = {{ .Values.lunaclient.conn.hmac_label | include "resolve_secret" }}
 slot_id = {{ .Values.lunaclient.conn.slot_id }}
+encryption_mechanism = CKM_AES_GCM
+hmac_key_type = CKK_GENERIC_SECRET
+hmac_keygen_mechanism = CKM_GENERIC_SECRET_KEY_GEN
+hmac_mechanism = CKM_SHA256_HMAC
+key_wrap_mechanism = CKM_AES_KEY_WRAP_KWP
+aes_gcm_generate_iv = False
 {{- end }}

--- a/openstack/barbican/templates/etc/_secrets.conf.tpl
+++ b/openstack/barbican/templates/etc/_secrets.conf.tpl
@@ -25,5 +25,5 @@ hmac_key_type = CKK_GENERIC_SECRET
 hmac_keygen_mechanism = CKM_GENERIC_SECRET_KEY_GEN
 hmac_mechanism = CKM_SHA256_HMAC
 key_wrap_mechanism = CKM_AES_KEY_WRAP_KWP
-aes_gcm_generate_iv = False
+aes_gcm_generate_iv = True
 {{- end }}

--- a/openstack/barbican/templates/etc/_secrets.conf.tpl
+++ b/openstack/barbican/templates/etc/_secrets.conf.tpl
@@ -20,10 +20,10 @@ mkek_label = {{ .Values.lunaclient.conn.mkek_label | include "resolve_secret" }}
 mkek_length = {{ .Values.lunaclient.conn.mkek_length }}
 hmac_label = {{ .Values.lunaclient.conn.hmac_label | include "resolve_secret" }}
 slot_id = {{ .Values.lunaclient.conn.slot_id }}
-encryption_mechanism = CKM_AES_GCM
-hmac_key_type = CKK_GENERIC_SECRET
-hmac_keygen_mechanism = CKM_GENERIC_SECRET_KEY_GEN
-hmac_mechanism = CKM_SHA256_HMAC
-key_wrap_mechanism = CKM_AES_KEY_WRAP_KWP
-aes_gcm_generate_iv = True
+encryption_mechanism = {{ .Values.lunaclient.conn.encryption_mechanism }}
+# hmac_key_type = {{ .Values.lunaclient.conn.hmac_key_type }} --> need to be enabled if new keys are generated
+# hmac_keygen_mechanism = {{ .Values.lunaclient.conn.hmac_keygen_mechanism }}
+hmac_mechanism = {{ .Values.lunaclient.conn.hmac_mechanism }}
+key_wrap_mechanism = {{ .Values.lunaclient.conn.key_wrap_mechanism }}
+aes_gcm_generate_iv = {{ .Values.lunaclient.conn.aes_gcm_generate_iv }}
 {{- end }}


### PR DESCRIPTION
Openstack Ref : https://docs.openstack.org/barbican/latest/install/barbican-backend.html#thales-luna-network-hsm
Thales Ref : https://www.thalesdocs.com/gphsm/integrations/guides/openstack_barbican/index.html#configure-openstack-barbican-with-thales-luna-hsm-or-luna-cloud-hsm