### PR TITLE
[placement][pxc-db] Add support for PXC galera cluster: part 1

### DIFF
--- a/openstack/placement/Chart.lock
+++ b/openstack/placement/Chart.lock
@@ -2,17 +2,20 @@ dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.14.1
+- name: pxc-db
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 0.2.13
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.4.0
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.18.1
+  version: 0.21.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:1626ca2b7b82cee98948755b22098889f3bd92884f1f7453f0dc54369badac38
-generated: "2024-08-13T11:37:21.323270755+02:00"
+digest: sha256:7e45df6e077c846ad8ddd528cc1ee003059a63cf1787bd68c5ca8519ffcae3c8
+generated: "2025-01-29T16:48:59.150045+02:00"

--- a/openstack/placement/Chart.yaml
+++ b/openstack/placement/Chart.yaml
@@ -1,20 +1,26 @@
+---
 apiVersion: v2
 description: A Helm chart for the Openstack Placement Service
 name: placement
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/project-mascots/Placement/OpenStack_Project_Placement_horizontal.jpg
-version: 0.1.0
+version: 0.2.0
 appVersion: "yoga"
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.14.1
+  - condition: pxc_db.enabled
+    name: pxc-db
+    alias: pxc_db
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: 0.2.13
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.4.0
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.18.1
+    version: 0.21.0
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0

--- a/openstack/placement/ci/test-values.yaml
+++ b/openstack/placement/ci/test-values.yaml
@@ -13,11 +13,38 @@ imageVersion: myTag
 
 mariadb:
   enabled: false
+  root_password: topSecret
+  users:
+    placement:
+      password: topSecret
   backup:
     enabled: false
   backup_v2:
     enabled: false
 
+pxc_db:
+  enabled: false
+  users:
+    placement:
+      password: topSecret!
+  system_users:
+    root:
+      password: topSecret!
+    xtrabackup:
+      password: topSecret!
+    monitor:
+      password: topSecret!
+    proxyadmin:
+      password: topSecret!
+    operator:
+      password: topSecret!
+    replication:
+      password: topSecret!
+  backup:
+    s3:
+      secrets:
+        aws_access_key_id: topSecret!
+        aws_secret_access_key: topSecret!
 
 api_db:
   user: a_name

--- a/openstack/placement/templates/_helpers.tpl
+++ b/openstack/placement/templates/_helpers.tpl
@@ -1,4 +1,4 @@
-{{- define "job_name" }}
+{{- define "placement.job_name" }}
   {{- $name := index . 1 }}
   {{- with index . 0 }}
     {{- $all := list (include "utils.proxysql.job_pod_settings" . ) (include "utils.proxysql.volume_mount" . ) (include "utils.proxysql.container" . ) (include "utils.proxysql.volumes" .) (tuple . (dict) | include "utils.snippets.kubernetes_entrypoint_init_container") (include "utils.trust_bundle.volume_mount" . ) (include "utils.trust_bundle.volumes" .) | join "\n" }}
@@ -8,9 +8,10 @@
 {{- end }}
 
 
-{{- define "db_name" }}
-  {{- if .Values.mariadb.enabled -}}
-"{{ .Values.mariadb.name }}-mariadb"
+{{- define "placement.db_name" }}
+  {{- if or (eq .Values.dbType "mariadb") (eq .Values.dbType "pxc-db") }}
+{{- include "utils.db_host" . -}}
+{{/* Use nova-api-mariadb database, if no database is selected explicitly */}}
   {{- else -}}
 "nova-api-mariadb"
   {{- end }}

--- a/openstack/placement/templates/db-migrate-job.yaml
+++ b/openstack/placement/templates/db-migrate-job.yaml
@@ -4,7 +4,7 @@ metadata:
   # since this name changes with every image change, removal and creation of
   # this Job happens on nearly every deployment. Check the helm-chart changes
   # to see if this needs more review.
-  name: {{ tuple . "db-migrate" | include "job_name" }}
+  name: {{ tuple . "db-migrate" | include "placement.job_name" }}
   labels:
     system: openstack
     type: configuration
@@ -22,7 +22,7 @@ spec:
       restartPolicy: OnFailure
       {{- include "utils.proxysql.job_pod_settings" . | indent 6 }}
       initContainers:
-      {{- tuple . (dict "service" (include "db_name" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
+      {{- tuple . (dict "service" (include "placement.db_name" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
       - name: db-migrate
         image: {{ required ".Values.global.registry is missing" .Values.global.registry}}/loci-placement:{{.Values.imageVersion | required "Please set .imageVersion or similar" }}

--- a/openstack/placement/templates/db-online-migrate-job.yaml
+++ b/openstack/placement/templates/db-online-migrate-job.yaml
@@ -4,7 +4,7 @@ metadata:
   # since this name changes with every image change, removal and creation of
   # this Job happens on nearly every deployment. Check the helm-chart changes
   # to see if this needs more review.
-  name: {{ tuple . "db-online-migrate" | include "job_name" }}
+  name: {{ tuple . "db-online-migrate" | include "placement.job_name" }}
   labels:
     system: openstack
     type: configuration
@@ -22,7 +22,7 @@ spec:
       restartPolicy: OnFailure
       {{- include "utils.proxysql.job_pod_settings" . | indent 6 }}
       initContainers:
-      {{- tuple . (dict "service" (include "db_name" .) "jobs" (tuple . "db-migrate" | include "job_name") ) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
+      {{- tuple . (dict "service" (include "placement.db_name" .) "jobs" (tuple . "db-migrate" | include "placement.job_name") ) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
       - name: db-online-migrate
         image: {{ required ".Values.global.registry is missing" .Values.global.registry}}/loci-placement:{{.Values.imageVersion | required "Please set .imageVersion or similar" }}

--- a/openstack/placement/templates/etc/_secrets.conf.tpl
+++ b/openstack/placement/templates/etc/_secrets.conf.tpl
@@ -1,8 +1,9 @@
 [placement_database]
-{{- if not .Values.mariadb.enabled }}
-connection = {{ tuple . .Values.api_db.name .Values.api_db.user .Values.api_db.password | include "db_url_mysql" }}
+{{- if or (eq .Values.dbType "mariadb") (eq .Values.dbType "pxc-db") }}
+connection = {{ include "utils.db_url" . }}
+{{/* Use nova-api-mariadb database, if no database is selected explicitly */}}
 {{- else }}
-connection = {{ tuple . .Values.mariadb.name .Values.global.dbUser .Values.global.dbPassword | include "db_url_mysql" }}
+connection = {{ tuple . .Values.api_db.name .Values.api_db.user .Values.api_db.password | include "db_url_mysql" }}
 {{- end }}
 
 [keystone_authtoken]

--- a/openstack/placement/templates/placement-api-deployment.yaml
+++ b/openstack/placement/templates/placement-api-deployment.yaml
@@ -39,7 +39,7 @@ spec:
 {{ tuple . "placement" "api" | include "kubernetes_pod_anti_affinity" | indent 6 }}
       {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       initContainers:
-      {{- tuple . (dict "service" (include "db_name" .) "jobs" (tuple . "db-migrate" | include "job_name") ) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
+      {{- tuple . (dict "service" (include "placement.db_name" .) "jobs" (tuple . "db-migrate" | include "placement.job_name") ) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
       - name: placement-api
         image: {{ required ".Values.global.registry is missing" .Values.global.registry}}/loci-placement:{{.Values.imageVersion | required "Please set .imageVersion or similar" }}

--- a/openstack/placement/values.yaml
+++ b/openstack/placement/values.yaml
@@ -1,8 +1,11 @@
+---
 # Default values for placement
 # This is a YAML-formatted file.
 # Declare name/value pairs to be passed into your templates.
 # name: value
 global:
+  registryAlternateRegion: other.docker.registry
+  dockerHubMirrorAlternateRegion: other.dockerhub.mirror
   placementApiPortAdmin: '8778'
   placementApiPortInternal: '8778'
   placementApiPortPublic: '443'
@@ -47,10 +50,12 @@ uwsgi:
 max_pool_size: 10
 max_overflow: 5
 
-api_db: # Only used when mariadb.enabled=False to connect to the nova-api-mariadb
+api_db:  # Only used when mariadb.enabled=False to connect to the nova-api-mariadb
   name: placement
   user: placement
   password: null
+
+dbType: ""
 
 mariadb:
   enabled: true
@@ -59,6 +64,33 @@ mariadb:
     support_group: "compute-storage-api"
   ccroot_user:
     enabled: true
+
+pxc_db:
+  enabled: false
+  name: placement
+  initdb_job: true
+  alerts:
+    support_group: "compute-storage-api"
+  ccroot_user:
+    enabled: true
+  databases:
+    - placement
+  users:
+    placement:
+      name: placement
+      grants:
+        - "ALL PRIVILEGES on placement.*"
+  pxc:
+    persistence:
+      size: 10Gi
+  backup:
+    enabled: true
+    s3:
+      secrets:
+        aws_access_key_id: null
+        aws_secret_access_key: null
+    pitr:
+      enabled: true
 
 memcached:
   alerts:


### PR DESCRIPTION
Add default values for pxc-db chart dependency
Update utils charts to support galera cluster

Add an explicit dbType option to be able to force the usage of service DB.

Without setting pxc_db.enabled=true this PR causes no change in deployment.