### PR TITLE
[ironic][[pxc-db] Add support for PXC galera cluster: part 1

### DIFF
--- a/openstack/ironic/Chart.lock
+++ b/openstack/ironic/Chart.lock
@@ -2,6 +2,9 @@ dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.15.3
+- name: pxc-db
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 0.2.13
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.6.3
@@ -23,5 +26,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:923d38665af49bed9ae82c71af46bdd28692c58f6537c7d9f7e7b5e7ab587a1e
-generated: "2025-01-15T10:55:29.950058+02:00"
+digest: sha256:4f8b37f96a876826beb37c2a0c4f8d7ebade6c8910800a3b501dadbf454e5d98
+generated: "2025-01-29T17:51:43.459114+02:00"

--- a/openstack/ironic/Chart.yaml
+++ b/openstack/ironic/Chart.yaml
@@ -2,12 +2,17 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Ironic/OpenStack_Project_Ironic_vertical.png
 name: ironic
-version: 0.1.8
+version: 0.2.0
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: ~0.15.3
+  - condition: pxc_db.enabled
+    name: pxc-db
+    alias: pxc_db
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: ~0.2.13
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: ~0.6.3

--- a/openstack/ironic/ci/test-values.yaml
+++ b/openstack/ironic/ci/test-values.yaml
@@ -1,5 +1,7 @@
+---
 global:
   registry: keppel.regionOne.cloud
+  registryAlternateRegion: other.docker.registry
   dockerHubMirrorAlternateRegion: myRegistry/dockerhubalternate
   master_password: topSecret
   dbPassword: secret
@@ -28,6 +30,32 @@ inspectordbPassword: secret!
 console:
   secret: another-secret
   ssl_dhparam: again-a-secret
+
+pxc_db:
+  enabled: true
+  users:
+    ironic:
+      password: topSecret!
+    ironic_inspector:
+      password: topSecret!
+  system_users:
+    root:
+      password: topSecret!
+    xtrabackup:
+      password: topSecret!
+    monitor:
+      password: topSecret!
+    proxyadmin:
+      password: topSecret!
+    operator:
+      password: topSecret!
+    replication:
+      password: topSecret!
+  backup:
+    s3:
+      secrets:
+        aws_access_key_id: topSecret!
+        aws_secret_access_key: topSecret!
 
 rabbitmq:
   users:

--- a/openstack/ironic/templates/_helpers.tpl
+++ b/openstack/ironic/templates/_helpers.tpl
@@ -10,3 +10,15 @@
 {{ $k | quote }}: {{ $v | quote }}
 {{- end }}
 {{- end }}
+
+{{- define "ironic.service_dependencies" }}
+{{- include "ironic.db_service" . }},{{ include "ironic.rabbitmq_service" . -}}
+{{- end }}
+
+{{- define "ironic.db_service" }}
+{{- include "utils.db_host" . }}
+{{- end }}
+
+{{- define "ironic.rabbitmq_service" -}}
+ironic-rabbitmq
+{{- end }}

--- a/openstack/ironic/templates/api-deployment.yaml
+++ b/openstack/ironic/templates/api-deployment.yaml
@@ -38,7 +38,7 @@ spec:
 {{ tuple . "ironic" "api" | include "kubernetes_pod_anti_affinity" | indent 6 }}
       {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       initContainers:
-      {{- tuple . (dict "service" "ironic-mariadb,ironic-rabbitmq") | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
+      {{- tuple . (dict "service" (include "ironic.service_dependencies" . | quote)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
       - name: ironic-api
         image: {{ .Values.global.registry }}/loci-ironic:{{ .Values.imageVersion }}

--- a/openstack/ironic/templates/db-migration-job.yaml
+++ b/openstack/ironic/templates/db-migration-job.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     spec:
       initContainers:
-      {{- tuple . (dict "service" "ironic-mariadb") | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
+      {{- tuple . (dict "service" (include "ironic.db_service" . | quote)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       restartPolicy: OnFailure
       containers:
       - name: ironic-dbsync

--- a/openstack/ironic/templates/etc/_inspector_secrets.conf.tpl
+++ b/openstack/ironic/templates/etc/_inspector_secrets.conf.tpl
@@ -6,7 +6,13 @@ username = {{ .Values.global.ironicServiceUser }}
 password = {{ required ".Values.global.ironicServicePassword is missing" .Values.global.ironicServicePassword }}
 
 [database]
-connection = {{ tuple . .Values.mariadb.users.ironic_inspector.name .Values.mariadb.users.ironic_inspector.name .Values.mariadb.users.ironic_inspector.password | include "db_url_mysql" }}
+{{- if eq .Values.dbType "mariadb" }}
+connection = {{ tuple . .Values.mariadb.users.ironic_inspector.name .Values.mariadb.users.ironic_inspector.name .Values.mariadb.users.ironic_inspector.password | include "utils._db_url_mariadb" }}
+{{- else if eq .Values.dbType "pxc-db" }}
+connection = {{ tuple . .Values.pxc_db.users.ironic_inspector.name .Values.pxc_db.users.ironic_inspector.name .Values.pxc_db.users.ironic_inspector.password | include "utils._db_url_pxc_db" }}
+{{- else }}
+{{ fail "Unknown database type" }}
+{{- end }}
 
 [keystone_authtoken]
 username = {{ .Values.global.ironicServiceUser }}

--- a/openstack/ironic/templates/etc/_secrets.conf.tpl
+++ b/openstack/ironic/templates/etc/_secrets.conf.tpl
@@ -2,7 +2,7 @@
 {{- include "ini_sections.oslo_messaging_rabbit" .}}
 
 [database]
-connection = {{ include "db_url_mysql" . }}
+connection = {{ include "utils.db_url" . }}
 
 [keystone_authtoken]
 username = {{ .Values.global.ironicServiceUser }}

--- a/openstack/ironic/templates/inspector-db-migration-job.yaml
+++ b/openstack/ironic/templates/inspector-db-migration-job.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       restartPolicy: OnFailure
       initContainers:
-      {{- tuple . (dict "service" "ironic-mariadb") | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
+      {{- tuple . (dict "service" (include "ironic.db_service" . | quote)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
       - name: dbsync
         image: {{ .Values.global.registry }}/loci-ironic:{{ .Values.imageVersion }}

--- a/openstack/ironic/values.yaml
+++ b/openstack/ironic/values.yaml
@@ -273,13 +273,13 @@ mysql_metrics:
         - "name"
         - "provision_state"
       query: |
-        SELECT 
-          uuid, 
-          name, 
+        SELECT
+          uuid,
+          name,
           provision_state,
           COUNT(*) AS in_24hrs_gauge
-        FROM nodes 
-        WHERE updated_at >= NOW() - INTERVAL 1 DAY 
+        FROM nodes
+        WHERE updated_at >= NOW() - INTERVAL 1 DAY
         GROUP BY uuid, provision_state, name;
       values:
         - "in_24hrs_gauge"
@@ -292,10 +292,10 @@ mysql_metrics:
       values:
         - "node_not_in_maint"
       query: |
-        SELECT 
-          COUNT(case when maintenance = 0 then 1 end) AS node_not_in_maint, 
-          uuid, 
-          name, 
+        SELECT
+          COUNT(case when maintenance = 0 then 1 end) AS node_not_in_maint,
+          uuid,
+          name,
           COALESCE(maintenance_reason,'reason unknown') AS maintenance_reason
         FROM nodes
         GROUP BY
@@ -311,10 +311,10 @@ mysql_metrics:
       values:
         - "node_in_maint"
       query: |
-        SELECT 
-          COUNT(case when maintenance = 1 then 1 end) AS node_in_maint, 
-          uuid, 
-          name, 
+        SELECT
+          COUNT(case when maintenance = 1 then 1 end) AS node_in_maint,
+          uuid,
+          name,
           COALESCE(maintenance_reason,'reason unknown') AS maintenance_reason
         FROM nodes
         GROUP BY
@@ -328,21 +328,23 @@ mysql_metrics:
         - "name"
         - "conductor_group"
       query: |
-        SELECT 
-          uuid, 
-          name, 
+        SELECT
+          uuid,
+          name,
           conductor_group,
           COUNT(conductor_group) AS groups
         FROM nodes
-        GROUP BY 
-          name, 
-          uuid, 
+        GROUP BY
+          name,
+          uuid,
           conductor_group;
       values:
         - "groups"
 
 proxysql:
   mode: ""
+
+dbType: "mariadb"
 
 mariadb:
   enabled: true
@@ -373,13 +375,44 @@ mariadb:
     verify_tables:
       - ironic.nodes
       - ironic_inspector.nodes
-
-  root_password: "AHardPa55w0rd!"
+  root_password: null
   initdb_secret: true
   ccroot_user:
     enabled: true
   persistence_claim:
     name: db-ironic-pvclaim
+
+pxc_db:
+  alerts:
+    support_group: foundation
+  enabled: false
+  name: ironic
+  initdb_job: true
+  ccroot_user:
+    enabled: true
+  databases:
+    - ironic
+    - ironic_inspector
+  users:
+    ironic:
+      name: ironic
+      grants:
+        - "ALL PRIVILEGES on ironic.*"
+    ironic_inspector:
+      name: ironic_inspector
+      grants:
+        - "ALL PRIVILEGES on ironic_inspector.*"
+  pxc:
+    persistence:
+      size: 10Gi
+  backup:
+    enabled: true
+    s3:
+      secrets:
+        aws_access_key_id: null
+        aws_secret_access_key: null
+    pitr:
+      enabled: true
 
 dbName: ironic
 #dbPassword: null


### PR DESCRIPTION
Add default values for pxc-db chart dependency

Add an explicit dbType option to be able to force the usage of service DB.

Without setting pxc_db.enabled=true this PR causes no change in deployment