### PR TITLE
[kmip][pxc-db] Add support for PXC galera cluster: part 1

### DIFF
--- a/openstack/kmip/Chart.lock
+++ b/openstack/kmip/Chart.lock
@@ -7,12 +7,15 @@ dependencies:
   version: 1.1.0
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.22.0
+  version: 0.23.0
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.15.3
+- name: pxc-db
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 0.3.1
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.4.2
-digest: sha256:41ad3755afc2099659287c8c0a05f1c849c4695252e7e97c697c51b509bfd4a1
-generated: "2025-02-04T17:17:58.783061+05:30"
+digest: sha256:650548989cca89fd746f8442dd2b8e547226670f1dd39d4a50f434cec24cb4b2
+generated: "2025-03-20T13:37:49.009693+02:00"

--- a/openstack/kmip/Chart.yaml
+++ b/openstack/kmip/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Chart Version
-version: 0.2.2
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -39,6 +39,11 @@ dependencies:
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.15.3
+  - condition: pxc_db.enabled
+    name: pxc-db
+    alias: pxc_db
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: 0.3.1
   - condition: mariadb.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/kmip/ci/test-values.yaml
+++ b/openstack/kmip/ci/test-values.yaml
@@ -5,6 +5,7 @@ global:
   registry: myImage
   dbPassword: topSecret
   barbican_service_password: topSecret
+  registryAlternateRegion: other.docker.registry
   dockerHubMirror: myRegistry/dockerhub
   dockerHubMirrorAlternateRegion: myRegistry/dockerhubalternate
   domain_seeds:
@@ -38,3 +39,30 @@ mariadb:
     barbican:
       user: barbican
       password: topSecret
+
+pxc_db:
+  enabled: true
+  users:
+    kmip:
+      password: topSecret!
+    barbican:
+      user: barbican
+      password: topSecret
+  system_users:
+    root:
+      password: topSecret!
+    xtrabackup:
+      password: topSecret!
+    monitor:
+      password: topSecret!
+    proxyadmin:
+      password: topSecret!
+    operator:
+      password: topSecret!
+    replication:
+      password: topSecret!
+  backup:
+    s3:
+      secrets:
+        aws_access_key_id: topSecret!
+        aws_secret_access_key: topSecret!

--- a/openstack/kmip/values.yaml
+++ b/openstack/kmip/values.yaml
@@ -113,6 +113,32 @@ mariadb:
   backup_v2:
     enable_init_restore: true
 
+pxc_db:
+  enabled: false
+  name: kmip
+  alerts:
+    support_group: identity
+  ccroot_user:
+    enabled: true
+  databases:
+    - kmip
+  users:
+    kmip:
+      name: kmip
+      grants:
+        - "ALL PRIVILEGES on kmip.*"
+  pxc:
+    persistence:
+      size: 10Gi
+  backup:
+    enabled: true
+    s3:
+      secrets:
+        aws_access_key_id: null
+        aws_secret_access_key: null
+    pitr:
+      enabled: true
+
 mysql_metrics:
   db_name: kmip
   db_user: kmip


### PR DESCRIPTION
Add default values for pxc-db chart dependency

Without setting pxc_db.enabled=true this PR causes no change in deployment