### PR TITLE
greenhouse-ccloud: pin kube-monitoring prometheus version to v2.55.1

### DIFF
--- a/system/greenhouse-ccloud/Chart.yaml
+++ b/system/greenhouse-ccloud/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: ccloud
 description: A Helm chart for the CCloud organization in Greenhouse.
 type: application
-version: 1.13.4
+version: 1.13.5

--- a/system/greenhouse-ccloud/templates/kube-monitoring-pluginpreset.yaml
+++ b/system/greenhouse-ccloud/templates/kube-monitoring-pluginpreset.yaml
@@ -192,6 +192,8 @@ spec:
       value: 30d
     - name: kubeMonitoring.prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage
       value: 100Gi
+    - name: kubeMonitoring.prometheus.prometheusSpec.image.tag
+      value: v2.55.1
     pluginDefinition: kube-monitoring
     releaseNamespace: kube-monitoring
 {{- end -}}


### PR DESCRIPTION
This is the last version before Prometheus v3.