### PR TITLE
fix(opensearch): replace max_docs with min_doc_count in transitions

### DIFF
--- a/system/opensearch-logs/templates/config/_ds-ism.json.tpl
+++ b/system/opensearch-logs/templates/config/_ds-ism.json.tpl
@@ -24,7 +24,7 @@
                     {
                         "state_name": "rollover",
                         "conditions": {
-                            "max_docs": "50000000"
+                            "min_doc_count": "50000000"
                         }
                     }
                 ]


### PR DESCRIPTION
Small fix for an invalid condition in the ISM policy by replacing max_docs with min_doc_count