### PR TITLE
[netapp-harvest-exporter] add snapmirror destinations

### DIFF
--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/aggregations/maia.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/aggregations/maia.yaml
@@ -158,6 +158,9 @@ groups:
     #
     # snampirror relationship
     #
+    # on(filer, destination_volume):
+    #     leads to only looking at volumes on destination side,
+    #     because on source side volume filer and snapmirror filer will not match
 
     - record: netapp_snapmirror_labels:maia
       expr: |

--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/etc/rest.custom_snapmirror.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/etc/rest.custom_snapmirror.yaml
@@ -1,0 +1,70 @@
+name:                     SnapmirrorDestination
+query:                    api/snapmirror/relationships
+object:                   snapmirror_destination
+
+counters:
+  - ^^uuid                               => relationship_id
+  - ^^destination.path                   => destination_location
+  - ^destination.cluster.name            => destination_cluster
+  - ^destination.svm.name                => destination_vserver
+  - ^policy.type                         => policy_type
+  - ^source.path                         => source_location
+  - ^source.svm.name                     => source_vserver
+  - filter:
+    - list_destinations_only=true
+
+plugins:
+  - LabelAgent:
+      split:
+      # vserver_a:volume_a
+      # -> volume_a
+        - destination_location `:` ,destination_volume
+        - source_location `:` ,source_volume
+
+export_options:
+  instance_keys:
+    - destination_location
+    - destination_cluster
+    - destination_volume
+    - destination_vserver
+    - relationship_id
+    - source_location
+    - source_volume
+    - source_vserver
+  instance_labels:
+    - policy_type
+
+# example response of GET api/snapmirror/relationships?list_destinations_only=true
+# there is not much more info available
+# in big contrast to the rich dataset you get without the `list_destinations_only` filter
+
+  #  {
+  #   "destination": {
+  #    "cluster": {
+  #     "_link": {
+  #      "self": {
+  #       "href": "/api/cluster/peers/3de03572-c1f8-11eb-ae3b-d039ea28826e"
+  #      }
+  #     },
+  #     "name": "my-destination-cluster-name",
+  #     "uuid": "3de03572-c1f8-11eb-ae3b-d039ea28826e"
+  #    },
+  #    "path": "vserver_a:volume_a",
+  #    "svm": {
+  #     "name": "vserver_a",
+  #     "uuid": "781a3bdd-a828-11ef-aa28-d039ea28826e"
+  #    }
+  #   },
+  #   "group_type": "none",
+  #   "policy": {
+  #    "type": "async"
+  #   },
+  #   "source": {
+  #    "path": "vserver_b:volume_b",
+  #    "svm": {
+  #     "name": "vserver_b",
+  #     "uuid": "7b78027e-8ea9-11ee-b22a-d039ea4cc3f4"
+  #    }
+  #   },
+  #   "uuid": "c3c06aac-a829-11ef-aa28-d039ea28826e"
+  #  }

--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/templates/configmap.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/templates/configmap.yaml
@@ -19,6 +19,8 @@ data:
     {{- include (print .Template.BasePath "/_rest.limited.yaml.tpl") .Values.apps.manila | nindent 4}}
   rest.limited.yaml.apod: |
     {{- include (print .Template.BasePath "/_rest.limited.yaml.tpl") .Values.apps.apod | nindent 4}}
+  rest.custom_snapmirror.yaml: |
+    {{- .Files.Get "etc/rest.custom_snapmirror.yaml" | nindent 4}}
   rest.custom_snapshot.yaml: |
     {{- .Files.Get "etc/rest.custom_snapshot.yaml" | nindent 4}}
   rest.custom_volume.yaml: |

--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/templates/deployment_worker.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/templates/deployment_worker.yaml
@@ -52,6 +52,9 @@ spec:
               subPath: rest.limited.yaml.{{ $appName }}
               mountPath: /opt/harvest/conf/rest/limited.yaml
             - name: harvest-config
+              subPath: rest.custom_snapmirror.yaml
+              mountPath: /opt/harvest/conf/rest/9.12.0/custom_snapmirror.yaml
+            - name: harvest-config
               subPath: rest.custom_snapshot.yaml
               mountPath: /opt/harvest/conf/rest/9.12.0/custom_snapshot.yaml
             - name: harvest-config

--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/values.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/values.yaml
@@ -15,6 +15,7 @@ apps:
       LIF: lif.yaml
       NFSClients: nfs_clients.yaml
       SnapMirror: snapmirror.yaml
+      SnapmirrorDestination: custom_snapmirror.yaml
       Snapshot: custom_snapshot.yaml
       Volume: custom_volume.yaml
 


### PR DESCRIPTION
Regular snapmirror metrics do not include the destinations.
I think that is the case, because traditionally snapmirrors are
observed from the target cluster.
But in certain scenarios, e.g. cross-region setups, we want to monitor
from the source cluster, too.

Manually deployed to qa, you may have a look there at the new metric netapp_snapmirror_destination_labels