### PR TITLE
set default which is 1000 for mem_queue

### DIFF
--- a/openstack/ironic/values.yaml
+++ b/openstack/ironic/values.yaml
@@ -444,7 +444,7 @@ audit:
     password: DEFINED-IN-SECRETS
   enabled: true
   # how many messages to buffer before dumping to log (when rabbit is down or too slow)
-  mem_queue_size: 100
+  mem_queue_size: 1000
   record_payloads: false
   metrics_enabled: true
 


### PR DESCRIPTION
Anything over the queue gets dropped and just sent to logging. This should be the default queue number of 1000 instead of 100. 