### PR TITLE
default audit to true, with default mem_queue_size

### DIFF
--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -313,7 +313,10 @@ watcher:
   enabled: false
 
 audit:
-  enabled: false
+  enabled: true 
+  # how many messages to buffer before dumping to log (when rabbit is down or too slow)
+  mem_queue_size: 1000
+
 
 cors:
   enabled: true


### PR DESCRIPTION
default values on, and with the default queue size to remove the specified lower queue size in secrets. 

Connected with this PR 
https://github.wdf.sap.corp/cc/secrets/pull/16126