### PR TITLE
prometheus-kubernetes-rules: remove last usage of event-exporter metrics

### DIFF
--- a/prometheus-rules/prometheus-kubernetes-rules/Chart.yaml
+++ b/prometheus-rules/prometheus-kubernetes-rules/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A collection of Prometheus alerting and aggregation rules for Kubernetes.
 name: prometheus-kubernetes-rules
-version: 1.9.14
+version: 1.10.0

--- a/prometheus-rules/prometheus-kubernetes-rules/alerts/health.alerts.tpl
+++ b/prometheus-rules/prometheus-kubernetes-rules/alerts/health.alerts.tpl
@@ -79,8 +79,8 @@ groups:
       description: Container {{`{{ $labels.container }}`}} of pod {{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}} is restarting constantly.{{`{{ if eq $labels.support_group "containers"}}`}} Is `owner-info` set --> Contact respective service owner! If not, try finding him/her and make sure, `owner-info` is set!{{`{{ end }}`}}
       summary: Pod is in a restart loop
 
-  - alert: KubernetesPodCannotPullImage
-    expr: label_replace((sum by(pod_name, namespace) (rate(kube_pod_image_pull_backoff_total[15m]))), "pod", "$1", "pod_name", "(.*)") * on (pod) group_left(label_alert_tier, label_alert_service, label_ccloud_support_group, label_ccloud_service) (max without (uid) (kube_pod_labels)) > 0
+  - alert: KubernetesPodCannotPullContainerImage
+    expr: max by (namespace, pod) (kube_pod_container_status_waiting_reason{reason="ImagePullBackOff"} == 1) * on (namespace, pod) group_left(label_alert_tier, label_alert_service, label_ccloud_support_group, label_ccloud_service) (max without (uid) (kube_pod_labels)) > 0
     for: 1h
     labels:
       tier: {{ include "alertTierLabelOrDefault" .Values.tier }}
@@ -88,10 +88,24 @@ groups:
       support_group: {{ include "supportGroupFromLabelsOrDefault" .Values.supportGroup }}
       severity: warning
       context: pod
-      meta: "Pod {{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}} cannot pull all images"
+      meta: "Pod {{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}} cannot pull all container images"
     annotations:
-      description: The pod {{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}} cannot pull all images.{{`{{ if eq $labels.support_group "containers"}}`}} Is `owner-info` set --> Contact respective service owner! If not, try finding him/her and make sure, `owner-info` is set!{{`{{ end }}`}}
-      summary: Pod cannot pull all iamges
+      description: The pod {{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}} cannot pull all container images.{{`{{ if eq $labels.support_group "containers"}}`}} Is `owner-info` set --> Contact respective service owner! If not, try finding him/her and make sure, `owner-info` is set!{{`{{ end }}`}}
+      summary: Pod cannot pull all container images
+
+  - alert: KubernetesPodCannotPullInitContainerImage
+    expr: max by (namespace, pod) (kube_pod_init_container_status_waiting_reason{reason="ImagePullBackOff"} == 1) * on (namespace, pod) group_left(label_alert_tier, label_alert_service, label_ccloud_support_group, label_ccloud_service) (max without (uid) (kube_pod_labels)) > 0
+    for: 1h
+    labels:
+      tier: {{ include "alertTierLabelOrDefault" .Values.tier }}
+      service: {{ include "serviceFromLabelsOrDefault" "k8s" }}
+      support_group: {{ include "supportGroupFromLabelsOrDefault" .Values.supportGroup }}
+      severity: warning
+      context: pod
+      meta: "Pod {{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}} cannot pull all init container images"
+    annotations:
+      description: The pod {{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}} cannot pull all init container images.{{`{{ if eq $labels.support_group "containers"}}`}} Is `owner-info` set --> Contact respective service owner! If not, try finding him/her and make sure, `owner-info` is set!{{`{{ end }}`}}
+      summary: Pod cannot pull all init container images
 
   - alert: KubernetesTooManyOpenFiles
     expr: 100*process_open_fds{job=~"kubernetes-kubelet|kubernetes-apiserver"} / process_max_fds > 50


### PR DESCRIPTION
In a PodStatus, ImagePullBackOff appears as a reason for why a container is in status "waiting":

```
$ k get -o json pod test-imagepullbackoff-6c787c4445-hrt4h | gron | grep ImagePullBackOff
json.status.containerStatuses[0].state.waiting.reason = "ImagePullBackOff";
```

Therefore, containers in status ImagePullBackOff can be found with `kube_pod_container_status_waiting_reason{reason="ImagePullBackOff"} == 1`. As a minor complication, we need to have a second mostly identical check for init containers using the metric `kube_pod_init_container_status_waiting_reason{reason="ImagePullBackOff"} == 1`.