### PR TITLE
[mariadb] Change default binary log format from MIXED to ROW

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.36.0 - 2026/05/11
+* default binary log format changed from MIXED to ROW
+* chart version bumped
+
 ## v0.35.1 - 2026/05/06
 * fixed pvc storage_class templating
 * chart version bumped

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.35.1
+version: 0.36.0
 # scripts/docker-entyrpoint.sh should be updated when appVersion is updated
 appVersion: 10.11.16
 dependencies:

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -20,7 +20,7 @@ query_cache_size: "0"
 query_cache_type: "0"
 join_buffer_size: "4M"
 long_query_time: 5
-binlog_format: "MIXED"
+binlog_format: "ROW"
 expire_logs_days: 10
 character_set_server: "utf8" # Should be utf8mb4, but we started with this
 collation_server: "utf8_general_ci"


### PR DESCRIPTION
mariadb: Change default binary log format from MIXED to ROW
This will increase the size of binary logs but will make them more consistent and usable for mariadb->galera migration when AUTO_INCREMENT is being used.
Note: the overall size of binary logs and binary log backups will increase after this change