### PR TITLE
kube-monitoring-*: remove event-exporter

### DIFF
--- a/system/kube-monitoring-admin-k3s/Chart.lock
+++ b/system/kube-monitoring-admin-k3s/Chart.lock
@@ -2,9 +2,6 @@ dependencies:
 - name: absent-metrics-operator
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.2
-- name: event-exporter
-  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.3.4
 - name: fluent-bit
   repository: https://fluent.github.io/helm-charts
   version: 0.48.3
@@ -28,7 +25,7 @@ dependencies:
   version: 6.5.0
 - name: prometheus-kubernetes-rules
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.9.14
+  version: 1.10.1
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 4.40.0
@@ -40,7 +37,7 @@ dependencies:
   version: 2.3.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.2.0
+  version: 1.0.0
 - name: falco
   repository: https://falcosecurity.github.io/charts
   version: 4.19.0
@@ -50,5 +47,5 @@ dependencies:
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
   version: 3.13.0
-digest: sha256:262e611cfbb6e2b03ba7143530571b6bce3f1edfec6f9e3bdd063d69c41ca5e7
-generated: "2025-02-03T13:49:46.834201514+01:00"
+digest: sha256:b892d4f5aed7015decc854f1ea9a75100501ef621a6ce2d13a4b944015be3851
+generated: "2025-02-04T15:56:40.525136664+01:00"

--- a/system/kube-monitoring-admin-k3s/Chart.yaml
+++ b/system/kube-monitoring-admin-k3s/Chart.yaml
@@ -2,16 +2,13 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes admin k3s cluster monitoring.
 name: kube-monitoring-admin-k3s
-version: 4.5.42
+version: 4.6.0
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-admin-k3s
 dependencies:
   - condition: absent-metrics-operator.enabled
     name: absent-metrics-operator
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^1"
-  - name: event-exporter
-    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.3.4
   - name: fluent-bit
     repository: https://fluent.github.io/helm-charts
     version: 0.48.3
@@ -35,7 +32,7 @@ dependencies:
     version: 6.5.0
   - name: prometheus-kubernetes-rules
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: "^1.9"
+    version: "^1.10"
   - name: prometheus-node-exporter
     repository: https://prometheus-community.github.io/helm-charts
     version: 4.40.0
@@ -47,7 +44,7 @@ dependencies:
     version: 2.3.0
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.2.0
+    version: "^1"
   - name: falco
     repository: https://falcosecurity.github.io/charts
     version: 4.19.0

--- a/system/kube-monitoring-kubernikus/Chart.lock
+++ b/system/kube-monitoring-kubernikus/Chart.lock
@@ -2,9 +2,6 @@ dependencies:
 - name: absent-metrics-operator
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.2
-- name: event-exporter
-  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.3.4
 - name: fluent-bit
   repository: https://fluent.github.io/helm-charts
   version: 0.48.3
@@ -34,7 +31,7 @@ dependencies:
   version: 6.5.0
 - name: prometheus-kubernetes-rules
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.9.14
+  version: 1.10.1
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 4.40.0
@@ -46,7 +43,7 @@ dependencies:
   version: 2.3.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.2.0
+  version: 1.0.0
 - name: masterdata-exporter
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.2
@@ -59,5 +56,5 @@ dependencies:
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
   version: 3.13.0
-digest: sha256:f71597e8b5229ca5f32aea642bc5dfa394302c96ea125c67b930986cdc1b60d1
-generated: "2025-02-03T13:51:44.213409351+01:00"
+digest: sha256:284e622df900cfea134d6c33eba2d0267abf02d3407c63b8dd3f5235d9da6c48
+generated: "2025-02-04T15:56:51.138345252+01:00"

--- a/system/kube-monitoring-kubernikus/Chart.yaml
+++ b/system/kube-monitoring-kubernikus/Chart.yaml
@@ -2,16 +2,13 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for monitoring Kubernikus.
 name: kube-monitoring-kubernikus
-version: 7.7.41
+version: 7.8.0
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-kubernikus
 dependencies:
   - condition: absent-metrics-operator.enabled
     name: absent-metrics-operator
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^1"
-  - name: event-exporter
-    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.3.4
   - name: fluent-bit
     repository: https://fluent.github.io/helm-charts
     version: 0.48.3
@@ -43,7 +40,7 @@ dependencies:
     version: 6.5.0
   - name: prometheus-kubernetes-rules
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: "^1.9"
+    version: "^1.10"
   - name: prometheus-node-exporter
     repository: https://prometheus-community.github.io/helm-charts
     version: 4.40.0
@@ -56,7 +53,7 @@ dependencies:
     version: 2.3.0
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.2.0
+    version: "^1"
   - name: masterdata-exporter
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.1.2

--- a/system/kube-monitoring-metal/Chart.lock
+++ b/system/kube-monitoring-metal/Chart.lock
@@ -5,9 +5,6 @@ dependencies:
 - name: blackbox-exporter
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.3.0
-- name: event-exporter
-  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.3.4
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 5.27.0
@@ -28,7 +25,7 @@ dependencies:
   version: 6.5.0
 - name: prometheus-kubernetes-rules
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.9.14
+  version: 1.10.1
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 4.40.0
@@ -40,7 +37,7 @@ dependencies:
   version: 0.1.8
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.2.0
+  version: 1.0.0
 - name: falco
   repository: https://falcosecurity.github.io/charts
   version: 4.19.0
@@ -50,5 +47,5 @@ dependencies:
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
   version: 3.13.0
-digest: sha256:3ee34e251d09a8b0964b33f67e31711f8c6b1cd10af6821df71843a51938248f
-generated: "2025-02-03T13:53:03.028666542+01:00"
+digest: sha256:feee0910ba1efaf4d4478dd3dcef780e3ef6a6883047f133bfa5d2ad31f65ee5
+generated: "2025-02-04T15:57:03.780614786+01:00"

--- a/system/kube-monitoring-metal/Chart.yaml
+++ b/system/kube-monitoring-metal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes metal controlplane monitoring.
 name: kube-monitoring-metal
-version: 4.8.9
+version: 4.9.0
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-metal
 dependencies:
   - condition: absent-metrics-operator.enabled
@@ -12,9 +12,6 @@ dependencies:
   - name: blackbox-exporter
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 2.3.0
-  - name: event-exporter
-    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.3.4
   - name: kube-state-metrics
     repository: https://prometheus-community.github.io/helm-charts
     version: 5.27.0
@@ -35,7 +32,7 @@ dependencies:
     version: 6.5.0
   - name: prometheus-kubernetes-rules
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: "^1.9"
+    version: "^1.10"
   - name: prometheus-node-exporter
     repository: https://prometheus-community.github.io/helm-charts
     version: 4.40.0
@@ -47,7 +44,7 @@ dependencies:
     version: 0.1.8
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.2.0
+    version: "^1"
   - name: falco
     repository: https://falcosecurity.github.io/charts
     version: 4.19.0

--- a/system/kube-monitoring-scaleout/Chart.lock
+++ b/system/kube-monitoring-scaleout/Chart.lock
@@ -2,9 +2,6 @@ dependencies:
 - name: absent-metrics-operator
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.2
-- name: event-exporter
-  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.0.0
 - name: fluent-bit
   repository: https://fluent.github.io/helm-charts
   version: 0.48.3
@@ -25,7 +22,7 @@ dependencies:
   version: 6.5.0
 - name: prometheus-kubernetes-rules
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.9.14
+  version: 1.10.1
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 4.40.0
@@ -40,7 +37,7 @@ dependencies:
   version: 2.3.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.2.0
+  version: 1.0.0
 - name: falco
   repository: https://falcosecurity.github.io/charts
   version: 4.19.0
@@ -50,5 +47,5 @@ dependencies:
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
   version: 3.13.0
-digest: sha256:af64e94112debb39329334874a5dae01924934668a74e41fa9290659d8a12226
-generated: "2025-02-03T13:54:57.912034455+01:00"
+digest: sha256:1a837573534c7f8dda120b0be89331bb3c06ff6d9d6bafe4b2b96d65fe82d9cc
+generated: "2025-02-04T15:57:13.226584935+01:00"

--- a/system/kube-monitoring-scaleout/Chart.yaml
+++ b/system/kube-monitoring-scaleout/Chart.yaml
@@ -1,16 +1,13 @@
 apiVersion: v2
 description: Kubernetes scaleout cluster monitoring.
 name: kube-monitoring-scaleout
-version: 4.10.37
+version: 4.11.0
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-scaleout
 dependencies:
   - condition: absent-metrics-operator.enabled
     name: absent-metrics-operator
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^1"
-  - name: event-exporter
-    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: "^1.x"
   - name: fluent-bit
     repository: https://fluent.github.io/helm-charts
     version: 0.48.3
@@ -32,7 +29,7 @@ dependencies:
     version: "^6.4"
   - name: prometheus-kubernetes-rules
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: "^1.9"
+    version: "^1.10"
   - name: prometheus-node-exporter
     repository: https://prometheus-community.github.io/helm-charts
     version: 4.40.0
@@ -47,7 +44,7 @@ dependencies:
     version: "^2.3"
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.2.0
+    version: "^1"
   - name: falco
     repository: https://falcosecurity.github.io/charts
     version: 4.19.0

--- a/system/kube-monitoring-virtual/Chart.lock
+++ b/system/kube-monitoring-virtual/Chart.lock
@@ -2,9 +2,6 @@ dependencies:
 - name: absent-metrics-operator
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.2
-- name: event-exporter
-  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.3.4
 - name: fluent-bit
   repository: https://fluent.github.io/helm-charts
   version: 0.48.3
@@ -31,7 +28,7 @@ dependencies:
   version: 6.5.0
 - name: prometheus-kubernetes-rules
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.9.14
+  version: 1.10.1
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 4.40.0
@@ -43,7 +40,7 @@ dependencies:
   version: 2.3.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.2.0
+  version: 1.0.0
 - name: falco
   repository: https://falcosecurity.github.io/charts
   version: 4.19.0
@@ -53,5 +50,5 @@ dependencies:
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
   version: 3.13.0
-digest: sha256:27ecdd88ab98ba60816ab888c019ed86da7a4c21f5f7b12374094c1e70ad04b9
-generated: "2025-02-03T14:14:49.413762101+01:00"
+digest: sha256:b50ff8feb3d35b62908c86022b245ff1b2cc606b60027ce000d92ac5ec874903
+generated: "2025-02-04T15:57:22.736534347+01:00"

--- a/system/kube-monitoring-virtual/Chart.yaml
+++ b/system/kube-monitoring-virtual/Chart.yaml
@@ -2,16 +2,13 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes virtual cluster monitoring.
 name: kube-monitoring-virtual
-version: 6.8.42
+version: 6.9.0
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-virtual
 dependencies:
   - condition: absent-metrics-operator.enabled
     name: absent-metrics-operator
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^1"
-  - name: event-exporter
-    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.3.4
   - name: fluent-bit
     repository: https://fluent.github.io/helm-charts
     version: 0.48.3
@@ -38,7 +35,7 @@ dependencies:
     version: 6.5.0
   - name: prometheus-kubernetes-rules
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: "^1.9"
+    version: "^1.10"
   - name: prometheus-node-exporter
     repository: https://prometheus-community.github.io/helm-charts
     version: 4.40.0
@@ -50,7 +47,7 @@ dependencies:
     version: 2.3.0
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.2.0
+    version: "^1"
   - name: falco
     repository: https://falcosecurity.github.io/charts
     version: 4.19.0


### PR DESCRIPTION
As of prometheus-kubernetes-rules 1.10.1, all our usecases for event-exporter metrics are covered by kube-state-metrics instead.

I also saw that the owner-info dep was outdated, so I bumped that too.