### PR TITLE
billing: define cloud_masterdata_{admin,viewer} roles

### DIFF
--- a/openstack/billing/templates/prometheus-alerts.yaml
+++ b/openstack/billing/templates/prometheus-alerts.yaml
@@ -1,0 +1,46 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+# This rule is in here, rather than in a file in alerts/, because we need to use templating.
+metadata:
+  name: billing-roleassignment.alerts
+  labels:
+    type: alerting-rules
+    prometheus: openstack
+
+{{- $keystone_namespace := .Values.is_global | ternary "monsoon3global" "monsoon3" }}
+
+spec:
+  groups:
+  - name: openstack-billing-roleassignment.alerts
+    rules:
+        # allowed role assignments for the `cloud_masterdata_admin` role:
+        # - none yet
+        - alert: CBRMasterdataUnexpectedCloudAdminRoleAssignments
+          expr: max(openstack_assignments_per_role{role_name="cloud_masterdata_admin",namespace="{{ $keystone_namespace }}"}) > 0
+          for: 10m
+          labels:
+            support_group: containers
+            service: limes
+            severity: info
+            playbook: 'docs/support/playbook/unexpected-role-assignments'
+            meta: 'Unexpected role assignments found for Keystone role "cloud_masterdata_admin"'
+          annotations:
+            summary: 'Unexpected role assignments'
+            description: 'The Keystone role "cloud_masterdata_admin" is assigned to more users/groups than expected.'
+
+        # allowed role assignments for the `cloud_masterdata_viewer` role:
+        # - user limes@Default                 in project cloud_admin@ccadmin
+        # - group CCADMIN_CLOUD_ADMINS@ccadmin in project cloud_admin@ccadmin
+        - alert: CBRMasterdataUnexpectedCloudViewerRoleAssignments
+          expr: max(openstack_assignments_per_role{role_name="cloud_masterdata_viewer",namespace="{{ $keystone_namespace }}"}) > 2
+          for: 10m
+          labels:
+            support_group: containers
+            service: limes
+            severity: info
+            playbook: 'docs/support/playbook/unexpected-role-assignments'
+            meta: 'Unexpected role assignments found for Keystone role "cloud_masterdata_viewer"'
+          annotations:
+            summary: 'Unexpected role assignments'
+            description: 'The Keystone role "cloud_masterdata_viewer" is assigned to more users/groups than expected.'

--- a/openstack/billing/templates/seeds.yaml
+++ b/openstack/billing/templates/seeds.yaml
@@ -26,6 +26,10 @@ spec:
     {{- end }}
 
   roles:
+  - name: cloud_masterdata_admin
+    description: Master data administrator (global)
+  - name: cloud_masterdata_viewer
+    description: Master data read-only (global)
   - name: masterdata_admin
     description: Master data administrator
   - name: masterdata_viewer
@@ -122,6 +126,12 @@ spec:
           role: cloud_identity_viewer
     {{- end }}
     groups:
+    {{- if eq . "ccadmin" }}
+    - name: CCADMIN_CLOUD_ADMINS
+      role_assignments:
+      - project: cloud_admin
+        role: cloud_masterdata_viewer # we will start with only viewer here; the admin role can be added if the need arises
+    {{- end }}
     {{- if eq . "monsoon3" }}
     - name: MONSOON3_DOMAIN_ADMINS
       role_assignments:

--- a/openstack/limes/templates/seed.yaml
+++ b/openstack/limes/templates/seed.yaml
@@ -9,7 +9,7 @@
 {{- end -}}
 
 {{- $liquid_roles := list -}}
-{{- if not $is_global -}}{{/* TODO: use "if not .Values.limes.local_liquids.nova.skip" here once we have liquid-nova */}}
+{{- if not .Values.limes.local_liquids.nova.skip -}}
   {{- /* NOTE: cloud_image_admin is required to determine the OS type for images of running instances */ -}}
   {{- $liquid_roles = concat $liquid_roles (list "cloud_compute_admin" "cloud_image_admin" "cloud_keymanager_admin") -}}
 {{- end -}}
@@ -53,6 +53,7 @@ spec:
     - name: resource_service
     # roles defined by other services (instead of adding complicated seed
     # dependencies between services, we just redefine these roles here)
+    - name: cloud_masterdata_viewer
     {{- range (sortAlpha $liquid_roles) }}
     - name: {{ . }}
     {{- end }}
@@ -84,6 +85,9 @@ spec:
           # permission to enumerate all projects and domains
           - user: limes@Default
             role: admin
+          # permission to read project masterdata (used for e-mail notifications)
+          - user: limes@Default
+            role: cloud_masterdata_viewer
           # (new-style) permission to manage all services' quotas
           - user: limes@Default
             role: resource_service


### PR DESCRIPTION
This is a necessary prerequisite for adding support for these roles in the CBR masterdata API.