### PR TITLE
[CODEOWNERS] update 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -63,8 +63,8 @@
 /openstack/blackbox                                    @artherd42 # old
 /openstack/castellum*                                  @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /openstack/cbshelf                                     @corey-aloia
-/openstack/cc3test                                     @thgrs @ashifnihalb @artherd42
-/openstack/cc3test-seeds                               @thgrs @ashifnihalb @artherd42
+/openstack/cc3test                                     @ashifnihalb @artherd42
+/openstack/cc3test-seeds                               @ashifnihalb @artherd42
 /openstack/cerebro                                     @viennaa @joker-at-work @fwiesel @grandchild
 /openstack/cinder                                      @joker-at-work @hemna @fwiesel @dusandordevicsap
 /openstack/content-repo                                @majewsky @SuperSandro2000 @VoigtS @Nuckal777
@@ -76,7 +76,7 @@
 /openstack/domain-seeds                                @BerndKue @Carthaca @fwiesel @Kuckkuck @rajivmucheli
 /openstack/elektra                                     @andypf @edda @ArtieReus @hgw77
 /openstack/glance                                      @fwiesel @galkindmitrii @rajivmucheli @Carthaca
-/openstack/grafanasix                                  @thgrs # old
+/openstack/grafanasix                                  @viennaa @richardtief @Kuckkuck @IvoGoman @timojohlo # old
 /openstack/hermes                                      @notque @Kuckkuck @IvoGoman
 /openstack/infra-seeds/kubernetes                      @BugRoger  # old
 /openstack/ironic                                      @stefanhipfel @BerndKue @fwiesel @sandzwerg
@@ -90,7 +90,7 @@
 /openstack/lyra                                        @databus23 @ArtieReus
 /openstack/maia                                        @notque @richardtief @viennaa @Kuckkuck
 /openstack/manila*                                     @Carthaca @chuan137 @galkindmitrii @kpawar-sap @sumitarora2786 @crenduchinta88 @harsharavuri99 @RockSolidScripts
-/openstack/nannies                                     @thgrs @chuan137 @Carthaca @fwiesel @kpawar-sap
+/openstack/nannies                                     @chuan137 @Carthaca @fwiesel @kpawar-sap
 /openstack/neutron                                     @notandy @fwiesel @sebageek @sven-rosenzweig @rhalina @swagner-de @mutax @BenjaminLudwigSAP @m-kratochvil @occamshatchet
 /openstack/nova                                        @joker-at-work @fwiesel @grandchild @leust
 /openstack/octavia                                     @notandy @BenjaminLudwigSAP @fwiesel @dusandordevicsap @velp @m-kratochvil
@@ -158,7 +158,7 @@
 /prometheus-exporters/redfish-exporter                 @BerndKue @stefanhipfel @sandzwerg
 /prometheus-exporters/snmp-exporter                    @Kuckkuck @swagner-de @m-kratochvil @IvoGoman @defo89
 /prometheus-exporters/snmp-ntp-exporter                @geisslet
-/prometheus-exporters/statsd-exporter                  @thgrs @ashifnihalb @artherd42
+/prometheus-exporters/statsd-exporter                  @ashifnihalb @artherd42
 /prometheus-exporters/systemd-lldp-exporter            @auhlig  # old
 /prometheus-exporters/tempest-exporter                 @misamoylov
 /prometheus-exporters/ucs-exporter                     @BerndKue
@@ -256,7 +256,7 @@
 /system/opensearch-hermes                              @Kuckkuck @notque @IvoGoman @timojohlo
 /system/opensearch-logs                                @Kuckkuck @IvoGoman @timojohlo @notque
 /system/opentelemetry                                  @Kuckkuck @timojohlo @IvoGoman @notque @olandr
-/system/plutono                                        @thgrs @richardtief
+/system/plutono                                        @viennaa @richardtief @Kuckkuck @IvoGoman @timojohlo
 /system/priority-class                                 @galkindmitrii  # old
 /system/prober-static                                  @defo89
 /system/prometheus-crds                                @viennaa @richardtief
@@ -285,7 +285,7 @@
 /system/thanos-seeds                                   @viennaa @richardtief
 /system/toolbox-prepull                                @defo89 @SchwarzM
 /system/unbound                                        @galkindmitrii @vssldmtrv @dhoeller @mutax @defo89 @mbrowny @SoenkeL @occamshatchet
-/system/validation                                     @thgrs @ashifnihalb
+/system/validation                                     @ashifnihalb @artherd42
 /system/velero                                         @databus23 @jknipper  # old
 /system/vertical-pod-autoscaler                        @Nuckal777 @majewsky @SuperSandro2000 @VoigtS
 /system/vice-president                                 @databus23

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -89,7 +89,7 @@
 /openstack/limes*                                      @majewsky @SuperSandro2000 @VoigtS @Nuckal777
 /openstack/lyra                                        @databus23 @ArtieReus
 /openstack/maia                                        @notque @richardtief @viennaa @Kuckkuck
-/openstack/manila*                                     @Carthaca @chuan137 @galkindmitrii @kpawar-sap @sumitarora2786 @crenduchinta88
+/openstack/manila*                                     @Carthaca @chuan137 @galkindmitrii @kpawar-sap @sumitarora2786 @crenduchinta88 @harsharavuri99 @RockSolidScripts
 /openstack/nannies                                     @thgrs @chuan137 @Carthaca @fwiesel @kpawar-sap
 /openstack/neutron                                     @notandy @fwiesel @sebageek @sven-rosenzweig @rhalina @swagner-de @mutax @BenjaminLudwigSAP @m-kratochvil @occamshatchet
 /openstack/nova                                        @joker-at-work @fwiesel @grandchild @leust
@@ -112,7 +112,7 @@
 /openstack/tempest/glance-tempest                      @misamoylov @fwiesel @rajivmucheli @galkindmitrii
 /openstack/tempest/ironic-tempest                      @misamoylov @fwiesel @galkindmitrii
 /openstack/tempest/keystone-tempest                    @misamoylov @fwiesel @rajivmucheli @galkindmitrii
-/openstack/tempest/manila-tempest                      @kpawar-sap @misamoylov @fwiesel @galkindmitrii
+/openstack/tempest/manila-tempest                      @kpawar-sap @misamoylov @fwiesel @galkindmitrii @Carthaca @chuan137
 /openstack/tempest/neutron-tempest                     @misamoylov @fwiesel @galkindmitrii
 /openstack/tempest/nova-tempest                        @misamoylov @fwiesel @galkindmitrii
 /openstack/tempest/octavia-tempest                     @misamoylov @fwiesel @galkindmitrii
@@ -144,7 +144,7 @@
 /prometheus-exporters/kube-state-metrics-exporter      @richardtief @viennaa
 /prometheus-exporters/kubelet-stats-metrics            @jknipper
 /prometheus-exporters/masterdata-exporter              @databus23
-/prometheus-exporters/netapp-exporter                  @chuan137 @Carthaca @grandchild @stefanhipfel
+/prometheus-exporters/netapp-exporter                  @chuan137 @Carthaca @kpawar-sap @sumitarora2786 @crenduchinta88 @harsharavuri99 @RockSolidScripts
 /prometheus-exporters/network-generic-ssh-exporter     @swagner-de @Kuckkuck @IvoGoman @geisslet
 /prometheus-exporters/nfs-exporter                     @auhlig  # old
 /prometheus-exporters/ns-exporter                      @databus23


### PR DESCRIPTION
- manila and netapp exporter: add some DevOps colleagues from Storage Operations
- remove Thomas Graichen


There are more errors, but I can't/don't want to judge those