### PR TITLE
[maia] enable honor_timestamps: true in scrape config

### DIFF
--- a/openstack/maia/templates/etc/_maia_scrape_config.yaml.tpl
+++ b/openstack/maia/templates/etc/_maia_scrape_config.yaml.tpl
@@ -2,6 +2,7 @@
 - job_name: 'maia-exporters'
   scrape_interval: 1m
   scrape_timeout: 55s
+  honor_timestamps: true
   kubernetes_sd_configs:
     - role: endpoints
   relabel_configs:
@@ -86,6 +87,7 @@
 - job_name: 'prometheus-openstack'
   scrape_interval: 1m
   scrape_timeout: 55s
+  honor_timestamps: true
   static_configs:
     - targets: ['prometheus-openstack.prometheus-openstack:9090']
   metric_relabel_configs:
@@ -104,6 +106,7 @@
 - job_name: 'prometheus-infra-collector'
   scrape_interval: 1m
   scrape_timeout: 55s
+  honor_timestamps: true
   static_configs:
     - targets: ['prometheus-infra-collector.infra-monitoring:9090']
   metric_relabel_configs:
@@ -153,6 +156,7 @@
 - job_name: 'prometheus-storage'
   scrape_interval: 1m
   scrape_timeout: 55s
+  honor_timestamps: true
   static_configs:
     - targets: ['prometheus-storage.infra-monitoring:9090']
   metric_relabel_configs:
@@ -182,6 +186,7 @@
   scheme: http
   scrape_interval: "{{ $root.Values.prometheus_vmware.scrape_interval }}"
   scrape_timeout: "{{ $root.Values.prometheus_vmware.scrape_timeout }}"
+  honor_timestamps: true
   tls_config:
     cert_file: /etc/prometheus/secrets/prometheus-auth-sso-cert/sso.crt
     key_file: /etc/prometheus/secrets/prometheus-auth-sso-cert/sso.key
@@ -215,6 +220,7 @@
   scheme: https
   scrape_interval: 1m
   scrape_timeout: 55s
+  honor_timestamps: true
   tls_config:
     cert_file: /etc/prometheus/secrets/prometheus-auth-sso-cert/sso.crt
     key_file: /etc/prometheus/secrets/prometheus-auth-sso-cert/sso.key
@@ -253,6 +259,7 @@
   scheme: https
   scrape_interval: "{{ $root.Values.prometheus_ceph.scrape_interval }}"
   scrape_timeout: "{{ $root.Values.prometheus_ceph.scrape_timeout }}"
+  honor_timestamps: true
   tls_config:
     cert_file: /etc/prometheus/secrets/prometheus-auth-sso-cert/sso.crt
     key_file: /etc/prometheus/secrets/prometheus-auth-sso-cert/sso.key


### PR DESCRIPTION
This is considered a potential fix to our out of order timestamps. But the default setting is true, so really, this shouldn't change anything except make it explicit this is in use. 

There are some other options as well, but I feel like we should do each one individually and validate. 