### PR TITLE
ironic: fix Kibana link for OpenstackIronicUnmatchedNodes alert

### DIFF
--- a/openstack/ironic/alerts/openstack-ironic.alerts
+++ b/openstack/ironic/alerts/openstack-ironic.alerts
@@ -1,3 +1,5 @@
+# vim: set ft=yaml:
+
 groups:
 - name: openstack-ironic.alerts
   rules:
@@ -11,7 +13,7 @@ groups:
       context: test
       tier: os
       meta: "{{ $value }} Ironic nodes do not match any Nova baremetal flavor"
-      kibana: "app/kibana#/discover?_g=(filters:!(),refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-20m,to:now))&_a=(columns:!(kubernetes_labels_name,log),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes_labels_name,negate:!f,params:(query:limes-collect-ccloud),type:phrase),query:(match_phrase:(kubernetes_labels_name:limes-collect-ccloud)))),index:'logstash-*',interval:auto,query:(language:lucene,query:ironic),sort:!(time,desc))"
+      kibana: "app/kibana#/discover?_g=(filters:!(),refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-20m,to:now))&_a=(columns:!(kubernetes_labels_name,log),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes_labels_name,negate:!f,params:(query:liquid-ironic),type:phrase),query:(match_phrase:(kubernetes_labels_name:liquid-ironic)))),index:'logstash-*',interval:auto,query:(language:lucene,query:ironic),sort:!(time,desc))"
     annotations:
       description: "{{ $value }} active/available Ironic nodes do not match any Nova
         baremetal flavor. Make sure that the resource class is maintained on the node,

--- a/openstack/ironic/alerts/openstack-ironic.alerts
+++ b/openstack/ironic/alerts/openstack-ironic.alerts
@@ -13,7 +13,7 @@ groups:
       context: test
       tier: os
       meta: "{{ $value }} Ironic nodes do not match any Nova baremetal flavor"
-      kibana: "app/kibana#/discover?_g=(filters:!(),refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-20m,to:now))&_a=(columns:!(kubernetes_labels_name,log),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes_labels_name,negate:!f,params:(query:liquid-ironic),type:phrase),query:(match_phrase:(kubernetes_labels_name:liquid-ironic)))),index:'logstash-*',interval:auto,query:(language:lucene,query:ironic),sort:!(time,desc))"
+      kibana: "app/data-explorer/discover/#?_g=(filters:!(),refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-20m,to:now))&_a=(discover:(columns:!(kubernetes_labels_name,log),interval:auto,sort:!(time,desc)),metadata:(indexPattern:'logstash-*',view:discover))&_q=(filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes_labels_name,negate:!f,params:(query:liquid-ironic),type:phrase),query:(match_phrase:(kubernetes_labels_name:liquid-ironic)))),query:(language:kuery,query:'log:%22baremetal%20flavor%22'))"
     annotations:
       description: "{{ $value }} active/available Ironic nodes do not match any Nova
         baremetal flavor. Make sure that the resource class is maintained on the node,


### PR DESCRIPTION
This log now shows up in liquid-ironic instead of limes-collect-ccloud