### PR TITLE
[limes] remove old billing user, add global role for qa (srs #540)

### DIFF
--- a/openstack/billing/templates/prometheus-alerts.yaml
+++ b/openstack/billing/templates/prometheus-alerts.yaml
@@ -32,9 +32,10 @@ spec:
         # allowed role assignments for the `cloud_masterdata_viewer` role:
         # - user limes@Default                 in project cloud_admin@ccadmin
         # - group CCADMIN_CLOUD_ADMINS@ccadmin in project cloud_admin@ccadmin
+        # - used TCC_BILLING_001               in project cloud_admin@ccadmin (only in qa-de-1)
         - alert: CBRMasterdataUnexpectedCloudViewerRoleAssignments
-          expr: max(openstack_assignments_per_role{role_name="cloud_masterdata_viewer",namespace="{{ $keystone_namespace }}"}) > 2
-          for: 10m
+          expr: max(openstack_assignments_per_role{role_name="cloud_masterdata_viewer",namespace="{{ $keystone_namespace }}"}) > {{if and (not .Values.is_global) (eq .Values.global.region "qa-de-1")}}3{{else}}2{{end}}
+          for: 10mx
           labels:
             support_group: containers
             service: limes

--- a/openstack/billing/templates/prometheus-alerts.yaml
+++ b/openstack/billing/templates/prometheus-alerts.yaml
@@ -35,7 +35,7 @@ spec:
         # - used TCC_BILLING_001               in project cloud_admin@ccadmin (only in qa-de-1)
         - alert: CBRMasterdataUnexpectedCloudViewerRoleAssignments
           expr: max(openstack_assignments_per_role{role_name="cloud_masterdata_viewer",namespace="{{ $keystone_namespace }}"}) > {{if and (not .Values.is_global) (eq .Values.global.region "qa-de-1")}}3{{else}}2{{end}}
-          for: 10mx
+          for: 10m
           labels:
             support_group: containers
             service: limes

--- a/openstack/billing/templates/seeds.yaml
+++ b/openstack/billing/templates/seeds.yaml
@@ -52,15 +52,6 @@ spec:
   domains:
   - name: Default
     users:
-    {{/* TODO: remove the billing@Default user account once CBR has migrated to their new technical user */}}
-    {{- if not .Values.is_global }}
-    - name: billing # service user for the billing API itself
-      description: 'Billing Service'
-      password: {{ printf "%s/%s/billing/keystone-user/service/password" $vbase $region | quote }}
-      role_assignments:
-      - project: service
-        role: service
-    {{- end }}
     - name: masterdata_scanner # service user for a data quality check job
       description: 'Masterdata Scanner (Data Quality Validation)'
       password: {{ printf "%s/%s/billing/keystone-user/masterdata-scanner/password" $vbase $region | quote }}
@@ -124,6 +115,10 @@ spec:
       role_assignments:
         - user: masterdata_scanner@Default
           role: cloud_identity_viewer
+        {{- if and (eq $.Values.global.region "qa-de-1") (not $.Values.is_global)}}
+        - user: TCC_BILLING_001
+          role: cloud_masterdata_viewer
+        {{end}}
     {{- end }}
     groups:
     {{- if eq . "ccadmin" }}


### PR DESCRIPTION
Output seems to be syntactically correct (qa-de-1 diff):

```
...
        annotations:
          description: The Keystone role "cloud_masterdata_viewer" is assigned to more
            users/groups than expected.
          summary: Unexpected role assignments
        expr: max(openstack_assignments_per_role{role_name="cloud_masterdata_viewer",namespace="monsoon3"})
-         > 2
+         > 3
        labels:
          meta: Unexpected role assignments found for Keystone role "cloud_masterdata_viewer"
          playbook: docs/support/playbook/unexpected-role-assignments
          service: limes
          severity: info
...
billing, billing-seed, OpenstackSeed (openstack.stable.sap.cc) has changed:
...
    name: billing-seed
  spec:
    domains:
    - name: Default
      users:
-     - description: Billing Service
-       name: billing
-       password: vault+kvv2:///secrets/qa-de-1/billing/keystone-user/service/password
-       role_assignments:
-       - project: service
-         role: service
      - description: Masterdata Scanner (Data Quality Validation)
        name: masterdata_scanner
        password: vault+kvv2:///secrets/qa-de-1/billing/keystone-user/masterdata-scanner/password
    - groups:
      - name: CC3TEST_DOMAIN_ADMINS
...
          enabled: true
      - name: cloud_admin
        role_assignments:
        - role: cloud_identity_viewer
          user: masterdata_scanner@Default
+       - role: cloud_masterdata_viewer
+         user: TCC_BILLING_001
      role_assignments:
      - inherited: true
        role: masterdata_admin
        user: masterdata_scanner@Default
    - groups:
...
```

I have one question in a comment, see below.