### PR TITLE
[memcached] version bumped to 1.6.36-alpine3.21

### DIFF
--- a/common/memcached/CHANGELOG.md
+++ b/common/memcached/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.6.4 - 2025/02/07
+
+* memcached [version](https://github.com/memcached/memcached/wiki/ReleaseNotes1636) bumped to `1.6.36-alpine3.21`
+  * `Critical bugfix for the proxy when using an "internal" backend with extstore enabled. Does not affect the system otherwise.`
+* chart version bumped
+
 ## v0.6.3 - 2025/01/07
 
 * memcached [version](https://github.com/memcached/memcached/wiki/ReleaseNotes1634) bumped to `1.6.34-alpine3.21`

--- a/common/memcached/Chart.yaml
+++ b/common/memcached/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: memcached
-version: 0.6.3
+version: 0.6.4
 description: Free & open source, high-performance, distributed memory object caching system.
 home: http://memcached.org/
 sources:

--- a/common/memcached/values.yaml
+++ b/common/memcached/values.yaml
@@ -2,7 +2,7 @@
 ## ref: https://hub.docker.com/r/library/memcached/tags/
 ##
 image: library/memcached
-imageTag: 1.6.34-alpine3.21
+imageTag: 1.6.36-alpine3.21
 # set to true to use .Values.global.dockerHubMirrorAlternateRegion instead of .Values.global.dockerHubMirror
 use_alternate_registry: false
 


### PR DESCRIPTION
- because of a critical bugfix
- bumped memcached version
- chart version bumped