### PR TITLE
[mariadb] version updated to 10.5.28

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.15.4 - 2025/02/07
+* MariaDB version bumped to [10.5.28](https://mariadb.com/kb/en/mariadb-10-5-28-release-notes/)
+  * several fixes for INNODB and other components
+  * memory leaks have been fixed
+  * [CVE-2025-21490](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-21490) has been fixed
+    * a DOS can be triggered from an unauthorized connection
+* chart version bumped
+
 ## v0.15.3 - 2025/01/14
 - fixed service selector: added `app.kubernetes.io/instance` label to make service target specific service instance
 - chart version bumped

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.15.3
+version: 0.15.4

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -4,7 +4,7 @@
 # name: value
 
 name: null
-image: library/mariadb:10.5.27
+image: library/mariadb:10.5.28
 imagePullPolicy: IfNotPresent
 port_public: 3306
 max_connections: 1024


### PR DESCRIPTION
- several fixes for INNODB and other components
- memory leaks have been fixed
- CVE-2025-21490 has been fixed
- chart version bumped