### PR TITLE
feat(gh-ccloud): configurable clusters for config generator

### DIFF
--- a/system/greenhouse-ccloud/Chart.yaml
+++ b/system/greenhouse-ccloud/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: ccloud
 description: A Helm chart for the CCloud organization in Greenhouse.
 type: application
-version: 1.13.12
+version: 1.14.0

--- a/system/greenhouse-ccloud/ci/test-values.yaml
+++ b/system/greenhouse-ccloud/ci/test-values.yaml
@@ -79,6 +79,9 @@ kubeconfigGenerator:
     container: "container-one"
     region: "testing"
     password: "TopSecret!"
+  clusters:
+    - foo
+    - bar
 
 kubeMonitoring:
   enabled: true

--- a/system/greenhouse-ccloud/templates/kubeconfig-generator-plugin.yaml
+++ b/system/greenhouse-ccloud/templates/kubeconfig-generator-plugin.yaml
@@ -24,6 +24,20 @@ spec:
   disabled: false
   displayName: Kubeconfig generator
   optionValues:
+  {{- if .Values.kubeconfigGenerator.clusters }}
+  - name: cluster
+    value:
+    {{- range .Values.kubeconfigGenerator.clusters }}
+    - clientIdRef:
+        key: clientID
+        name: {{ $.Chart.Name }}-kubeconfig-generator
+      clientSecretRef:
+        key: clientSecret
+        name: {{ $.Chart.Name }}-kubeconfig-generator
+      name: {{ . }}
+      namespace: ccloud
+    {{- end }}
+  {{- else }}
   - name: cluster
     value:
     - clientIdRef:
@@ -34,6 +48,7 @@ spec:
         name: {{ .Chart.Name }}-kubeconfig-generator
       name: '*'
       namespace: ccloud
+  {{- end }}
   - name: image.registry
     value: keppel.eu-de-1.cloud.sap/ccloud
   - name: swift.authUrl


### PR DESCRIPTION
In our greenhouse-qa environment we do not want to have all cluster uploaded to the registry this allows to allowlist the clusters