### PR TITLE
backup-replication: change concurrency policy

### DIFF
--- a/openstack/backup-replication/templates/cronjob.yaml
+++ b/openstack/backup-replication/templates/cronjob.yaml
@@ -8,7 +8,7 @@ metadata:
     component: backup-replication
 
 spec:
-  concurrencyPolicy: Replace # restarting a hung s-h-i should be safe (Swift will not store objects if the upload connection resets)
+  concurrencyPolicy: Forbid # if large files take longer than 60m to transfer (which can happen esp. with multiple concurrent transfers), we will be stuck in a loop if we replace the job every 60m
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   schedule: "59 * * * *"


### PR DESCRIPTION
As explained in the comment, if there are multiple large files to transfer and the link is slow, we might get stuck in a loop if the replace kills the process before it can fully transfer any files.