### PR TITLE
[utils] Add missing default value for mem_queue_size audit option

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.22.0
+version: 0.22.1

--- a/openstack/utils/templates/_ini_sections.tpl
+++ b/openstack/utils/templates/_ini_sections.tpl
@@ -70,7 +70,7 @@ driver = messagingv2
                     {{- include "ini_sections._transport_url" (tuple . $data) }}
                 {{- end }}
             {{- end }}
-mem_queue_size = {{ .Values.audit.mem_queue_size }}
+mem_queue_size = {{ .Values.audit.mem_queue_size | default 1000 | int }}
         {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
Add missing default value for mem_queue_size audit option.
In general, values in utils templates should be either `required` or they should have a `default` value set to avoid misconfiguration errors.