### PR TITLE
common/postgresql: bump image

### DIFF
--- a/common/postgresql-ng/Chart.yaml
+++ b/common/postgresql-ng/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: postgresql-ng
-version: 1.2.7 # this version number is SemVer as it gets used to auto bump
+version: 1.2.8 # this version number is SemVer as it gets used to auto bump
 description: Chart for PostgreSQL
 keywords:
 - postgresql

--- a/common/postgresql-ng/values.yaml
+++ b/common/postgresql-ng/values.yaml
@@ -9,7 +9,7 @@ extensions:
     track: all
 
 # Refer to the "ccloud/postgres-ng" repository in Keppel to see which image tags exist.
-imageTag: '20241125095451'
+imageTag: '20250204061358'
 
 # The version of postgres to start.
 # This will be bumped over time and auto upgrade the database.


### PR DESCRIPTION
Trivy found a libtasn1 vuln in the old image.