### PR TITLE
[manila] add netapp_flexgroup_pools option

### DIFF
--- a/openstack/manila/templates/shares/_share-netapp.conf.tpl
+++ b/openstack/manila/templates/shares/_share-netapp.conf.tpl
@@ -70,6 +70,7 @@ netapp_enable_flexgroup = {{ $share.enable_flexgroup | default "False" }}
 {{- if $share.flexgroup_pools }}
 netapp_flexgroup_pools = {{ $share.flexgroup_pools }}
 {{- end }}
+netapp_flexgroup_aggregate_multiplier = {{ $share.flexgroup_aggregate_multiplier | default 4 }}
 # Specify if the FlexVol pools must not be reported when the
 # netapp_enable_flexgroup is enabled. (boolean value)
 netapp_flexgroup_pool_only = {{ $share.disable_flexvol | default "False" }}

--- a/openstack/manila/templates/shares/_share-netapp.conf.tpl
+++ b/openstack/manila/templates/shares/_share-netapp.conf.tpl
@@ -67,6 +67,9 @@ netapp_volume_snapshot_reserve_percent = {{ $share.netapp_volume_snapshot_reserv
 # placement is done either by ONTAP or Manila, not both. (boolean
 # value)
 netapp_enable_flexgroup = {{ $share.enable_flexgroup | default "False" }}
+{{- if $share.flexgroup_pools }}
+netapp_flexgroup_pools = {{ $share.flexgroup_pools }}
+{{- end }}
 # Specify if the FlexVol pools must not be reported when the
 # netapp_enable_flexgroup is enabled. (boolean value)
 netapp_flexgroup_pool_only = {{ $share.disable_flexvol | default "False" }}


### PR DESCRIPTION
allow to control aggregate selection for flexgroups.
This also means the aggr-list-multiplier will default to 4
(the default of that setting, currently not changeable)
instead of something else that would be automatically set by ONTAP.
Leading to 4 times number of aggregates constituents
(i.e. often 8 in our case).
