### PR TITLE
feat[elektra]: autogenerate rails token

### DIFF
--- a/openstack/elektra/bin/init-generate-secrets.sh
+++ b/openstack/elektra/bin/init-generate-secrets.sh
@@ -22,8 +22,7 @@ SECRET_KEY_BASE=$(head -c 64 /dev/urandom | base64 | tr -d '\n' | cut -c1-64)
 if [[ -n "$(kubectl get secret "$OLD_SECRET" --ignore-not-found)" ]]; then
   EXISTING_TOKEN=$(kubectl get secret "$OLD_SECRET" -o jsonpath="{.data.monsoon\.rails\.secret\.token}" 2>/dev/null || echo "")
   if [[ -n "$EXISTING_TOKEN" ]]; then
-    # Decode the existing token (Kubernetes stores secrets in base64)
-    SECRET_KEY_BASE=$(echo "$EXISTING_TOKEN" | base64 -d)    
+    SECRET_KEY_BASE=$EXISTING_TOKEN
   fi
 fi
 

--- a/openstack/elektra/bin/init-generate-secrets.sh
+++ b/openstack/elektra/bin/init-generate-secrets.sh
@@ -19,7 +19,7 @@ fi
 SECRET_KEY_BASE=$(head -c 64 /dev/urandom | base64 | tr -d '\n' | cut -c1-64)
 
 # check if the old secret exists and if it does, copy the token from it
-if kubectl get secret "$OLD_SECRET" >/dev/null 2>&1; then
+if [[ -n "$(kubectl get secret "$OLD_SECRET" --ignore-not-found)" ]]; then
   EXISTING_TOKEN=$(kubectl get secret "$OLD_SECRET" -o jsonpath="{.data.monsoon\.rails\.secret\.token}" 2>/dev/null || echo "")
   if [[ -n "$EXISTING_TOKEN" ]]; then
     # Decode the existing token (Kubernetes stores secrets in base64)

--- a/openstack/elektra/bin/init-generate-secrets.sh
+++ b/openstack/elektra/bin/init-generate-secrets.sh
@@ -15,15 +15,15 @@ if [[ "$(kubectl get secrets "$SECRET" --ignore-not-found)" != "" ]]; then
   continue
 fi
 
-if kubectl get secret "$OLD_SECRET" >/dev/null 2>&1; then
-  EXISTING_TOKEN=$(kubectl get secret "$OLD_SECRET" -o jsonpath="{.data.$KEY}" 2>/dev/null || echo "")
-  if [[ -n "$EXISTING_TOKEN" ]]; then
-    # Decode the existing token (Kubernetes stores secrets in base64)
-    SECRET_KEY_BASE=$(echo "$EXISTING_TOKEN" | base64 -d)
-  else
-    SECRET_KEY_BASE=$(head -c 64 /dev/urandom | base64 | tr -d '\n' | cut -c1-64)
-  fi
-fi
+# if kubectl get secret "$OLD_SECRET" >/dev/null 2>&1; then
+#   EXISTING_TOKEN=$(kubectl get secret "$OLD_SECRET" -o jsonpath="{.data.$KEY}" 2>/dev/null || echo "")
+#   if [[ -n "$EXISTING_TOKEN" ]]; then
+#     # Decode the existing token (Kubernetes stores secrets in base64)
+#     SECRET_KEY_BASE=$(echo "$EXISTING_TOKEN" | base64 -d)
+#   else
+#     SECRET_KEY_BASE=$(head -c 64 /dev/urandom | base64 | tr -d '\n' | cut -c1-64)
+#   fi
+# fi
 
 # create new secret with randomly generated token
 echo -n "
@@ -38,7 +38,7 @@ echo -n "
         name: $DEPLOYMENT_NAME
         uid: $(kubectl get deployment "$DEPLOYMENT_NAME" -o jsonpath='{.metadata.uid}')
   data:
-    token: $(SECRET_KEY_BASE)
+    token: $(head -c 64 /dev/urandom | base64 | tr -d '\n' | cut -c1-64)
 " > secret.yaml
   kubectl create -f secret.yaml
 

--- a/openstack/elektra/bin/init-generate-secrets.sh
+++ b/openstack/elektra/bin/init-generate-secrets.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env ash
+# shellcheck shell=ash
+# shellcheck disable=SC3010
+
+# This is the entrypoint script for the "generate-secrets" init container of the elektra pod.
+
+set -eou pipefail
+[[ ${DEBUG:-} != false ]] && set -x
+
+OLD_SECRET="$RELEASE"
+SECRET="$RELEASE-rails-token"
+
+# if we already have a secret, we can stop here
+if [[ "$(kubectl get secrets "$SECRET" --ignore-not-found)" != "" ]]; then
+  continue
+fi
+
+if kubectl get secret "$OLD_SECRET" >/dev/null 2>&1; then
+  EXISTING_TOKEN=$(kubectl get secret "$OLD_SECRET" -o jsonpath="{.data.$KEY}" 2>/dev/null || echo "")
+  if [[ -n "$EXISTING_TOKEN" ]]; then
+    # Decode the existing token (Kubernetes stores secrets in base64)
+    SECRET_KEY_BASE=$(echo "$EXISTING_TOKEN" | base64 -d)
+  else
+    SECRET_KEY_BASE=$(head -c 64 /dev/urandom | base64 | tr -d '\n' | cut -c1-64)
+  fi
+fi
+
+# create new secret with randomly generated token
+echo -n "
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: $SECRET
+    ownerReferences:
+      - apiVersion: apps/v1
+        blockOwnerDeletion: true
+        kind: Deployment
+        name: $DEPLOYMENT_NAME
+        uid: $(kubectl get deployment "$DEPLOYMENT_NAME" -o jsonpath='{.metadata.uid}')
+  data:
+    token: $(SECRET_KEY_BASE)
+" > secret.yaml
+  kubectl create -f secret.yaml
+

--- a/openstack/elektra/bin/init-generate-secrets.sh
+++ b/openstack/elektra/bin/init-generate-secrets.sh
@@ -15,9 +15,6 @@ if [[ "$(kubectl get secrets "$SECRET" --ignore-not-found)" != "" ]]; then
   exit 0
 fi
 
-J6Q7yjnhFA5Hix6bImjA3d4jFHVDyWuDcuYk8GrhVhzUMCCJjFSO5HwAt3Z5wxJhULf2AMT5fqtlUOtKHQ5HkOOOqfg9BJl3mvdUsvExLKXxiJolTq61vkrpgnNRzBuA
-
-
 # sets a new secret key
 # double base64 encode to get a string without newlines and 128 characters long after being decoded when deploying
 SECRET_KEY_BASE=$(head -c 96 /dev/urandom | base64 -w 0 | tr -d '\n' | base64 -w 0)

--- a/openstack/elektra/bin/init-generate-secrets.sh
+++ b/openstack/elektra/bin/init-generate-secrets.sh
@@ -39,7 +39,7 @@ echo -n "
         name: $DEPLOYMENT_NAME
         uid: $(kubectl get deployment "$DEPLOYMENT_NAME" -o jsonpath='{.metadata.uid}')
   data:
-    token: $(head -c 64 /dev/urandom | base64 | tr -d '\n' | cut -c1-64)
+    token: $SECRET_KEY_BASE
 " > secret.yaml
   kubectl create -f secret.yaml
 

--- a/openstack/elektra/bin/init-generate-secrets.sh
+++ b/openstack/elektra/bin/init-generate-secrets.sh
@@ -15,15 +15,17 @@ if [[ "$(kubectl get secrets "$SECRET" --ignore-not-found)" != "" ]]; then
   exit 0
 fi
 
-# if kubectl get secret "$OLD_SECRET" >/dev/null 2>&1; then
-#   EXISTING_TOKEN=$(kubectl get secret "$OLD_SECRET" -o jsonpath="{.data.$KEY}" 2>/dev/null || echo "")
-#   if [[ -n "$EXISTING_TOKEN" ]]; then
-#     # Decode the existing token (Kubernetes stores secrets in base64)
-#     SECRET_KEY_BASE=$(echo "$EXISTING_TOKEN" | base64 -d)
-#   else
-#     SECRET_KEY_BASE=$(head -c 64 /dev/urandom | base64 | tr -d '\n' | cut -c1-64)
-#   fi
-# fi
+# sets a new secret key
+SECRET_KEY_BASE=$(head -c 64 /dev/urandom | base64 | tr -d '\n' | cut -c1-64)
+
+# check if the old secret exists and if it does, copy the token from it
+if kubectl get secret "$OLD_SECRET" >/dev/null 2>&1; then
+  EXISTING_TOKEN=$(kubectl get secret "$OLD_SECRET" -o jsonpath="{.data.$KEY}" 2>/dev/null || echo "")
+  if [[ -n "$EXISTING_TOKEN" ]]; then
+    # Decode the existing token (Kubernetes stores secrets in base64)
+    SECRET_KEY_BASE=$(echo "$EXISTING_TOKEN" | base64 -d)    
+  fi
+fi
 
 # create new secret with randomly generated token
 echo -n "

--- a/openstack/elektra/bin/init-generate-secrets.sh
+++ b/openstack/elektra/bin/init-generate-secrets.sh
@@ -12,7 +12,7 @@ SECRET="$RELEASE-secrets"
 
 # if we already have a secret, we can stop here
 if [[ "$(kubectl get secrets "$SECRET" --ignore-not-found)" != "" ]]; then
-  continue
+  exit 0
 fi
 
 # if kubectl get secret "$OLD_SECRET" >/dev/null 2>&1; then

--- a/openstack/elektra/bin/init-generate-secrets.sh
+++ b/openstack/elektra/bin/init-generate-secrets.sh
@@ -8,7 +8,7 @@ set -eou pipefail
 [[ ${DEBUG:-} != false ]] && set -x
 
 OLD_SECRET="$RELEASE"
-SECRET="$RELEASE-rails-token"
+SECRET="$RELEASE-secrets"
 
 # if we already have a secret, we can stop here
 if [[ "$(kubectl get secrets "$SECRET" --ignore-not-found)" != "" ]]; then

--- a/openstack/elektra/bin/init-generate-secrets.sh
+++ b/openstack/elektra/bin/init-generate-secrets.sh
@@ -15,8 +15,12 @@ if [[ "$(kubectl get secrets "$SECRET" --ignore-not-found)" != "" ]]; then
   exit 0
 fi
 
+J6Q7yjnhFA5Hix6bImjA3d4jFHVDyWuDcuYk8GrhVhzUMCCJjFSO5HwAt3Z5wxJhULf2AMT5fqtlUOtKHQ5HkOOOqfg9BJl3mvdUsvExLKXxiJolTq61vkrpgnNRzBuA
+
+
 # sets a new secret key
-SECRET_KEY_BASE=$(head -c 64 /dev/urandom | base64 | tr -d '\n' | cut -c1-64)
+# double base64 encode to get a string without newlines and 128 characters long after being decoded when deploying
+SECRET_KEY_BASE=$(head -c 96 /dev/urandom | base64 -w 0 | tr -d '\n' | base64 -w 0)
 
 # check if the old secret exists and if it does, copy the token from it
 if [[ -n "$(kubectl get secret "$OLD_SECRET" --ignore-not-found)" ]]; then

--- a/openstack/elektra/bin/init-generate-secrets.sh
+++ b/openstack/elektra/bin/init-generate-secrets.sh
@@ -20,7 +20,7 @@ SECRET_KEY_BASE=$(head -c 64 /dev/urandom | base64 | tr -d '\n' | cut -c1-64)
 
 # check if the old secret exists and if it does, copy the token from it
 if kubectl get secret "$OLD_SECRET" >/dev/null 2>&1; then
-  EXISTING_TOKEN=$(kubectl get secret "$OLD_SECRET" -o jsonpath="{.data.$KEY}" 2>/dev/null || echo "")
+  EXISTING_TOKEN=$(kubectl get secret "$OLD_SECRET" -o jsonpath="{.data.monsoon\.rails\.secret\.token}" 2>/dev/null || echo "")
   if [[ -n "$EXISTING_TOKEN" ]]; then
     # Decode the existing token (Kubernetes stores secrets in base64)
     SECRET_KEY_BASE=$(echo "$EXISTING_TOKEN" | base64 -d)    

--- a/openstack/elektra/bin/init-generate-secrets.sh
+++ b/openstack/elektra/bin/init-generate-secrets.sh
@@ -3,7 +3,6 @@
 # shellcheck disable=SC3010
 
 # This is the entrypoint script for the "generate-secrets" init container of the elektra pod.
-
 set -eou pipefail
 [[ ${DEBUG:-} != false ]] && set -x
 
@@ -17,6 +16,7 @@ fi
 
 # sets a new secret key
 # double base64 encode to get a string without newlines and 128 characters long after being decoded when deploying
+# 96×3/4 = 128 characters
 SECRET_KEY_BASE=$(head -c 96 /dev/urandom | base64 -w 0 | tr -d '\n' | base64 -w 0)
 
 # check if the old secret exists and if it does, copy the token from it

--- a/openstack/elektra/bin/init-generate-token-secret.sh
+++ b/openstack/elektra/bin/init-generate-token-secret.sh
@@ -6,8 +6,8 @@
 set -eou pipefail
 [[ ${DEBUG:-} != false ]] && set -x
 
-OLD_SECRET="$RELEASE"
-SECRET="$RELEASE-secrets"
+OLD_SECRET="elektra"
+SECRET="elektra-token-secret"
 
 # if we already have a secret, we can stop here
 if [[ "$(kubectl get secrets "$SECRET" --ignore-not-found)" != "" ]]; then
@@ -37,8 +37,8 @@ echo -n "
       - apiVersion: apps/v1
         blockOwnerDeletion: true
         kind: Deployment
-        name: $DEPLOYMENT_NAME
-        uid: $(kubectl get deployment "$DEPLOYMENT_NAME" -o jsonpath='{.metadata.uid}')
+        name: elektra
+        uid: $(kubectl get deployment elektra -o jsonpath='{.metadata.uid}')
   data:
     token: $SECRET_KEY_BASE
 " > secret.yaml

--- a/openstack/elektra/templates/deployment.yaml
+++ b/openstack/elektra/templates/deployment.yaml
@@ -48,11 +48,11 @@ spec:
             name: support-config
       # The preStop hook below sleeps 30 seconds, extend the gracePeriod accordingly
       terminationGracePeriodSeconds: 60
+      serviceAccountName: elektra
       initContainers:
         - name: generate-secrets
           image: "{{.Values.global.registry}}/shared-app-images/alpine-kubectl:3.21-latest"
           imagePullPolicy: "Always"
-          serviceAccountName: elektra
           env:
           - name: DEBUG
             value: {{ quote .Values.debug }}

--- a/openstack/elektra/templates/deployment.yaml
+++ b/openstack/elektra/templates/deployment.yaml
@@ -50,17 +50,13 @@ spec:
       terminationGracePeriodSeconds: 60
       serviceAccountName: elektra
       initContainers:
-        - name: generate-secrets
+        - name: generate-token-secret
           image: "{{.Values.global.registry}}/shared-app-images/alpine-kubectl:3.21-latest"
           imagePullPolicy: "Always"
           env:
           - name: DEBUG
-            value: {{ quote .Values.debug }}
-          - name: RELEASE
-            value: {{ quote .Release.Name }}
-          - name: DEPLOYMENT_NAME
-            value: elektra
-          command: [ ash, -c, {{ .Files.Get "bin/init-generate-secrets.sh" | quote }} ]      
+            value: {{ quote .Values.init_container_debug }}
+          command: [ ash, -c, {{ .Files.Get "bin/init-generate-token-secret.sh" | quote }} ]      
         - name: init-database
           image: {{.Values.global.registry}}/elektra:{{.Values.image.tag}}
           command: ['script/init-db.sh']

--- a/openstack/elektra/templates/deployment.yaml
+++ b/openstack/elektra/templates/deployment.yaml
@@ -52,6 +52,7 @@ spec:
         - name: generate-secrets
           image: "{{.Values.global.registry}}/shared-app-images/alpine-kubectl:3.21-latest"
           imagePullPolicy: "Always"
+          serviceAccountName: elektra
           env:
           - name: DEBUG
             value: {{ quote .Values.debug }}

--- a/openstack/elektra/templates/deployment.yaml
+++ b/openstack/elektra/templates/deployment.yaml
@@ -29,6 +29,8 @@ spec:
         checksum/configmap: {{ include "elektra/templates/support-config-map.yaml" . | sha256sum }}
         # ensure mail port is skipeed by linkerd. This is required to allow the mail server to be accessed
         config.linkerd.io/skip-outbound-ports: {{ .Values.monsoon_dashboard_mail_server_port | quote }}
+        # redeploy on secret "elektra-token-secret" change so all the elektra pods gets the same token
+        secret.reloader.stakater.com/reload: elektra-token-secret
     spec:
       affinity:
         podAntiAffinity:

--- a/openstack/elektra/templates/deployment.yaml
+++ b/openstack/elektra/templates/deployment.yaml
@@ -49,6 +49,17 @@ spec:
       # The preStop hook below sleeps 30 seconds, extend the gracePeriod accordingly
       terminationGracePeriodSeconds: 60
       initContainers:
+        - name: generate-secrets
+          image: "{{.Values.global.registry}}/shared-app-images/alpine-kubectl:3.21-latest"
+          imagePullPolicy: "Always"
+          env:
+          - name: DEBUG
+            value: {{ quote .Values.debug }}
+          - name: RELEASE
+            value: {{ quote .Release.Name }}
+          - name: DEPLOYMENT_NAME
+            value: elektra
+          command: [ ash, -c, {{ .Files.Get "bin/init-generate-secrets.sh" | quote }} ]      
         - name: init-database
           image: {{.Values.global.registry}}/elektra:{{.Values.image.tag}}
           command: ['script/init-db.sh']

--- a/openstack/elektra/templates/rbac.yaml
+++ b/openstack/elektra/templates/rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  # This service account is used by elektra pod itself.
+  name: elektra
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: elektra-secrets
+rules:
+  # The init container of elektra generates the
+  # `elektra-token` secrets on first start.
+  - apiGroups: [ "" ]
+    resources: [ secrets ]
+    verbs:     [ get, delete ]
+    resourceNames: [ elektra-secrets ]
+
+  # "create" permission cannot be restricted to specific resourceNames
+  # Ref: <https://stackoverflow.com/a/65203104>
+  - apiGroups: [ "" ]
+    resources: [ secrets ]
+    verbs:     [ create ]
+
+  # need the UID of the postgres deployment to render an owner reference
+  - apiGroups: [ apps ]
+    resources: [ deployments ]
+    verbs:     [ get ]
+    resourceNames: [ elektra ]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: elektra-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: elektra-secrets
+subjects:
+  - kind: ServiceAccount
+    name: elektra

--- a/openstack/elektra/templates/rbac.yaml
+++ b/openstack/elektra/templates/rbac.yaml
@@ -12,10 +12,10 @@ metadata:
 rules:
   # The init container of elektra generates the
   # `elektra-token` secrets on first start.
-  - apiGroups: [ "" ]
-    resources: [ secrets ]
-    verbs:     [ get, delete ]
-    resourceNames: [ elektra-token-secret ]
+  # - apiGroups: [ "" ]
+  #   resources: [ secrets ]
+  #   verbs:     [ get, delete ]
+  #   resourceNames: [ elektra-token-secret ]
 
   # "create" permission cannot be restricted to specific resourceNames
   # Ref: <https://stackoverflow.com/a/65203104>

--- a/openstack/elektra/templates/rbac.yaml
+++ b/openstack/elektra/templates/rbac.yaml
@@ -15,7 +15,7 @@ rules:
   - apiGroups: [ "" ]
     resources: [ secrets ]
     verbs:     [ get, delete ]
-    resourceNames: [ elektra-secrets ]
+    resourceNames: [ elektra-token-secret ]
 
   # "create" permission cannot be restricted to specific resourceNames
   # Ref: <https://stackoverflow.com/a/65203104>

--- a/openstack/elektra/templates/rbac.yaml
+++ b/openstack/elektra/templates/rbac.yaml
@@ -8,7 +8,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: elektra-secrets
+  name: elektra-token-secret
 rules:
   # The init container of elektra generates the `elektra-token` secrets on first start.
   # "create" permission cannot be restricted to specific resourceNames
@@ -32,11 +32,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: elektra-secrets
+  name: elektra-token-secret
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: elektra-secrets
+  name: elektra-token-secret
 subjects:
   - kind: ServiceAccount
     name: elektra

--- a/openstack/elektra/templates/rbac.yaml
+++ b/openstack/elektra/templates/rbac.yaml
@@ -27,7 +27,6 @@ rules:
   - apiGroups: [ "" ]
     resources: [ secrets ]
     verbs:     [ get, list ]
-    resourceNames: [ elektra ]
 
   # need the UID of the postgres deployment to render an owner reference
   - apiGroups: [ apps ]

--- a/openstack/elektra/templates/rbac.yaml
+++ b/openstack/elektra/templates/rbac.yaml
@@ -26,7 +26,7 @@ rules:
   # add temporary permission to read the elektra secret until we switch to
   - apiGroups: [ "" ]
     resources: [ secrets ]
-    verbs:     [ get ]
+    verbs:     [ get, list ]
     resourceNames: [ elektra ]
 
   # need the UID of the postgres deployment to render an owner reference

--- a/openstack/elektra/templates/rbac.yaml
+++ b/openstack/elektra/templates/rbac.yaml
@@ -10,13 +10,7 @@ kind: Role
 metadata:
   name: elektra-secrets
 rules:
-  # The init container of elektra generates the
-  # `elektra-token` secrets on first start.
-  # - apiGroups: [ "" ]
-  #   resources: [ secrets ]
-  #   verbs:     [ get, delete ]
-  #   resourceNames: [ elektra-token-secret ]
-
+  # The init container of elektra generates the `elektra-token` secrets on first start.
   # "create" permission cannot be restricted to specific resourceNames
   # Ref: <https://stackoverflow.com/a/65203104>
   - apiGroups: [ "" ]

--- a/openstack/elektra/templates/rbac.yaml
+++ b/openstack/elektra/templates/rbac.yaml
@@ -23,6 +23,12 @@ rules:
     resources: [ secrets ]
     verbs:     [ create ]
 
+  # add temporary permission to read the elektra secret until we switch to
+  - apiGroups: [ "" ]
+    resources: [ secrets ]
+    verbs:     [ get ]
+    resourceNames: [ elektra ]
+
   # need the UID of the postgres deployment to render an owner reference
   - apiGroups: [ apps ]
     resources: [ deployments ]

--- a/openstack/elektra/values.yaml
+++ b/openstack/elektra/values.yaml
@@ -8,8 +8,6 @@ image:
 
 rails_env: production
 has_keystone_router: 1
-#monsoon_dashboard_region: staging
-#monsoon_dashboard_landscape: staging
 monsoon_dashboard_mail_server: defined_in_secrets
 monsoon_dashboard_mail_server_port: defined_in_secrets
 monsoon_dashboard_mail_domain: defined_in_secrets
@@ -17,10 +15,10 @@ monsoon_dashboard_mail_sender: defined_in_secrets
 monsoon_dashboard_mail_authentication: defined_in_secrets
 monsoon_dashboard_mail_user: defined_in_secrets
 monsoon_dashboard_mail_password: defined_in_secrets
+debug: true
 
 monsoon_dashboard_avatar_url: https://avatars.wdf.sap.corp/avatar/#{current_user.name}?size=24x24
 monsoon_dashboard_cam_url: https://cam.int.sap/cam/ui/admin
-#monsoon_openstack_auth_api_endpoint:
 monsoon_openstack_auth_api_userid: dashboard
 monsoon_openstack_auth_api_domain: Default
 two_factor_authentication: "off"

--- a/openstack/elektra/values.yaml
+++ b/openstack/elektra/values.yaml
@@ -15,7 +15,7 @@ monsoon_dashboard_mail_sender: defined_in_secrets
 monsoon_dashboard_mail_authentication: defined_in_secrets
 monsoon_dashboard_mail_user: defined_in_secrets
 monsoon_dashboard_mail_password: defined_in_secrets
-debug: true
+init_container_debug: true
 
 monsoon_dashboard_avatar_url: https://avatars.wdf.sap.corp/avatar/#{current_user.name}?size=24x24
 monsoon_dashboard_cam_url: https://cam.int.sap/cam/ui/admin


### PR DESCRIPTION
## Summary
Automated process to generate and manage a Rails token as a Kubernetes secret.

## Changes Made
- A Kubernetes **Secret** resource is created by a script run by an **initContainer**, but only if it does not already exist. The secret will persist and will not be recreated by any deployment as long as it exists. This prevents generating a new token on each deployment and avoids consuming a Vault secret that requires rotation.  

- The script first checks if the secret exists. If it does, the process exits. If the secret is missing, the script attempts to copy the key from an existing secret containing the Vault value. If the Vault value is not found, it generates a random 128-character string.  

- A **ServiceAccount**, along with the necessary **roles** and **role bindings**, has been created to allow the deployment to create the secret.  

- The Rails container retrieves the token via an **environment variable** that references the newly created Secret resource.  

- The deployment includes the new **initContainer** and the relevant parameters.  

- The deployment has an annotation to **reschedule itself when the secret changes**.  

See documentation [link](https://ui-team.global.cloud.sap/docs/projects/elektra/secrets/rails_token/).