### PR TITLE
Added VMWare alert: VCClusterMemoryDistrubutionOverVMs

### DIFF
--- a/prometheus-rules/prometheus-vmware-rules/Chart.yaml
+++ b/prometheus-rules/prometheus-vmware-rules/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A collection of Prometheus alert rules.
 name: prometheus-vmware-rules
-version: 1.1.0
+version: 1.1.1
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/prometheus-rules/prometheus-vmware-rules/alerts/vccluster.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/vccluster.alerts
@@ -117,3 +117,20 @@ groups:
     annotations:
       description: "The HANA-exclusive {{ $labels.vccluster }} cluster DRS configuration is not set to partially automated in the *{{ $labels.datacenter }}* availability zone\nLink to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>"
       summary: "The HANA-exclusive {{ $labels.vccluster }} cluster DRS configuration is not set to partially automated in the *{{ $labels.datacenter }}* availability zone\nLink to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>"
+
+  - alert: VCClusterMemoryDistrubutionOverVMs
+    expr: |
+      (   sum by (vccluster)(vrops_virtualmachine_config_hardware_memory_kilobytes{vccluster=~"productionbb.*"}))
+          / (sum by (vccluster)(vrops_cluster_memory_capacity_total{vccluster=~"productionbb.*"})
+      ) * 100 > 90
+    for: 48h
+    labels:
+      severity: info
+      tier: vmware
+      service: compute
+      support_group: compute
+      context: "Cluster Memory consumption"
+      meta: "Cluster {{ $labels.vccluster }} Memory consumption of VMs is above 90%."
+    annotations:
+      description: "Cluster {{ $labels.vccluster }} Memory consumption of VMs is above 90%."
+      summary: "Cluster {{ $labels.vccluster }} Memory consumption of VMs is above 90%."


### PR DESCRIPTION
- Added alert for Memory consumption of VMs within Cluster > 90 (48h existence)
- The alerts is fired to the `alert-vmware-info` channel