### PR TITLE
fix(gatekeeper): adds more allowed scopes for the OpenTelemetry logs-collector resources

### DIFF
--- a/system/gatekeeper/templates/constrainttemplate-pod-security.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-pod-security.yaml
@@ -412,7 +412,7 @@ spec:
         ########################################################################
         # allowlist for opentelemetry
 
-        {{- if eq .Values.cluster_type "baremetal" "scaleout" "test" }}
+        {{- if eq .Values.cluster_type "admin" "baremetal" "cloudshell" "concourse" "gh-actions" "internet" "kubernikus" "scaleout" "test" "virtual" }}
         isOtelPod = true {
           # In the "main" clusters (baremetal and the original scaleouts), Team
           # Supervision deploys several otel daemonsets in the "logs"


### PR DESCRIPTION
The OpenTelemetry logs-collector will be deployed to more clusters than just baremetal and scaleout. This adds all of the currently
required scopes that the logs-collector resources needs to run.

---------

Signed off by: Simon Olander (simon.olander@sap.com)
