### PR TITLE
Revert "GkPodSecurity: restrict otel exception to the relevant clusters"

### DIFF
--- a/system/gatekeeper/templates/constrainttemplate-pod-security.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-pod-security.yaml
@@ -412,7 +412,6 @@ spec:
         ########################################################################
         # allowlist for opentelemetry
 
-        {{- if eq .Values.cluster_type "baremetal" "scaleout" "test" }}
         isOtelPod = true {
           # In the "main" clusters (baremetal and the original scaleouts), Team
           # Supervision deploys several otel daemonsets in the "logs"
@@ -429,8 +428,7 @@ spec:
           hostPath == "/var/log"
           readOnly
         }
-        {{- end }}
-
+        
         ########################################################################
         # allowlist for Ironic pods
 


### PR DESCRIPTION
This reverts commit c256c1a64f8a0820b5c04785b34b56c8e511e8d9.

Instead of #7891 