### PR TITLE
[ns-exporter] feat: add filter by age to alerts

### DIFF
--- a/prometheus-exporters/ns-exporter/alerts/probe.alerts
+++ b/prometheus-exporters/ns-exporter/alerts/probe.alerts
@@ -2,7 +2,16 @@ groups:
 - name: namespace-probe.alerts
   rules:
   - alert: NetworkNamespaceProbesFailed
-    expr: sum(changes(ns_exporter_probe_failure_total{network_name !~ "^shoot--.*"}[10m])) by (network_id, network_name, region, router) > 0 unless sum(changes(ns_exporter_probe_success_total{network_name !~ "^shoot--.*"}[5m])) by (network_id, network_name, region, router) > 0
+    expr: |
+            (
+              sum(changes(ns_exporter_probe_failure_total{network_name !~ "^shoot--.*"}[10m])) by (network_id, network_name, region, router_id) > 0
+              and on (network_id) ns_exporter_network_age_seconds > 3600
+              and on (router_id) ns_exporter_router_age_seconds > 3600
+            ) unless (
+              sum(changes(ns_exporter_probe_success_total{network_name !~ "^shoot--.*"}[5m])) by (network_id, network_name, region, router_id) > 0
+              and on (network_id) ns_exporter_network_age_seconds > 3600
+              and on (router_id) ns_exporter_router_age_seconds > 3600
+            )
     for: 10m
     labels:
       context: availability


### PR DESCRIPTION
Add a a filter to NetworkNamespaceProbesFailed alert to exclude recently created routers and networks. These objects were previously filtered by the ns-exporter binary itself. Moving this filter to the alert provides more flexibility, e.g., to add monitoring to recently created routers.