### PR TITLE
[rabbitmq] version bumped to 4.0.6-management

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+## 0.14.1
+
+[@businessbean](https://github.com/businessbean)
+- RabbitMQ [4.0.6 Release Notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.0.6)
+  - several bugs have been fixed and improvements have been made in the server and Prometheus plugin
+- chart version bumped
+
 ## 0.14.0
 
 [@businessbean](https://github.com/businessbean)

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: v1
 name: rabbitmq
-version: 0.14.0
-appVersion: 4.0.5
+version: 0.14.1
+appVersion: 4.0.6
 description: A Helm chart for RabbitMQ
 sources:
   - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/values.yaml
+++ b/common/rabbitmq/values.yaml
@@ -8,7 +8,7 @@ global:
   master_password: ""
 
 image: library/rabbitmq
-imageTag: 4.0.5-management
+imageTag: 4.0.6-management
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
- RabbitMQ [4.0.6 Release Notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.0.6)
  - several bugs have been fixed and improvements have been made in the server and Prometheus plugin
- chart version bumped