### PR TITLE
[Cinder] Enable API rate limit

### DIFF
--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -371,7 +371,7 @@ logging:
 
 # openstack-rate-limit-middleware
 api_rate_limit:
-  enabled: false
+  enabled: true
   rate_limit_by: "target_project_id"
   max_sleep_time_seconds: 15
   log_sleep_time_seconds: 10


### PR DESCRIPTION
This patch updates the helm chart for cinder to
enable api rate limiting on by default for all
regions.