### PR TITLE
add rgw custom config to ceph chart

### DIFF
--- a/system/cc-ceph/Chart.yaml
+++ b/system/cc-ceph/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cc-ceph
 description: A Helm chart for the Rook / Ceph Objects inside the Storage Clusters
 type: application
-version: 1.1.36
+version: 1.1.37
 appVersion: "1.16.2"
 dependencies:
   - name: owner-info

--- a/system/cc-ceph/templates/cephobjectstore-extra.yaml
+++ b/system/cc-ceph/templates/cephobjectstore-extra.yaml
@@ -67,6 +67,12 @@ spec:
     dnsNames: {{ toYaml $instance.gateway.dnsNames | nindent 8 }}
 {{- end }}
   gateway:
+  {{- if not (empty $instance.gateway.rgwConfig) }}
+    rgwConfig: {{ toYaml $instance.gateway.rgwConfig | nindent 6 }}
+  {{- end }}
+  {{- if not (empty $instance.gateway.rgwCommandFlags) }}
+    rgwCommandFlags: {{ toYaml $instance.gateway.rgwCommandFlags | nindent 6 }}
+  {{- end }}
     instances: {{ $instance.gateway.instances | default $.Values.objectstore.gateway.instances }}
     {{- if or $instance.gateway.port $.Values.objectstore.gateway.port }}
     port: {{ $instance.gateway.port | default $.Values.objectstore.gateway.port }}

--- a/system/cc-ceph/templates/cephobjectstore.yaml
+++ b/system/cc-ceph/templates/cephobjectstore.yaml
@@ -39,6 +39,12 @@ spec:
     dnsNames: {{ toYaml .Values.objectstore.gateway.dnsNames | nindent 8 }}
 {{- end }}
   gateway:
+  {{- if not (empty .Values.objectstore.gateway.rgwConfig) }}
+    rgwConfig: {{ toYaml .Values.objectstore.gateway.rgwConfig | nindent 6 }}
+  {{- end }}
+  {{- if not (empty .Values.objectstore.gateway.rgwCommandFlags) }}
+    rgwCommandFlags: {{ toYaml .Values.objectstore.gateway.rgwCommandFlags | nindent 6 }}
+  {{- end }}
     annotations:
       checksum/config: {{ include (print $.Template.BasePath "/ceph-config-override.yaml") . | sha256sum }}
     instances: {{ .Values.objectstore.gateway.instances }}

--- a/system/cc-ceph/values.yaml
+++ b/system/cc-ceph/values.yaml
@@ -92,6 +92,15 @@ objectstore:
   name: objectstore
   enabledAPIs: [] # empty - all enabled. See: https://docs.ceph.com/en/reef/radosgw/config-ref/#confval-rgw_enable_apis
   gateway:
+    # Here we can set RGW config options without restarting RGW daemon
+    # Listed options will be set to mon config db to not restart daemon
+    # All option values should be strings - should be quoted ""
+    # See: https://rook.io/docs/rook/v1.16/CRDs/Object-Storage/ceph-object-store-crd/?h=rgwcon#advanced-configuration
+    rgwConfig: {}
+    # Here we can set RGW config options which requires RGW restart to be applied
+    # Listed options will be set as command line flags to RGW deployment to trigger RGW pod restarts
+    # All option values should be strings - should be quoted ""
+    rgwCommandFlags: {}
     instances: 6
     port: 80
     securePort: 443
@@ -156,6 +165,8 @@ objectstore:
       # can inherit/override all config options from objectstore:
     # - name: objectstore-admin
     #   gateway:
+    #     rgwConfig: {}
+    #     rgwCommandFlags: {}
     #     instances: 2
     #     sslCertificateRef: ""
     #     dnsNames:


### PR DESCRIPTION
supprt helm templates for rgw instace config overrides.
See: https://rook.io/docs/rook/v1.16/CRDs/Object-Storage/ceph-object-store-crd/?h=rgwcon#advanced-configuration

```yaml
spec:
  gateway:
    # ...
    rgwConfig:
      debug_rgw: "10" # int
      # debug-rgw: "20" # equivalent config keys can have dashes or underscores
      rgw_s3_auth_use_ldap: "true" # bool
    rgwCommandFlags:
      rgw_dmclock_auth_res: "100.0" # float
      rgw_d4n_l1_datacache_persistent_path: /var/log/rook/rgwd4ncache # string
      rgw_d4n_address: "127.0.0.1:6379" # IP string
```