### PR TITLE
[ns-exporter] fix: update clause "for" value

### DIFF
--- a/prometheus-exporters/ns-exporter/alerts/probe.alerts
+++ b/prometheus-exporters/ns-exporter/alerts/probe.alerts
@@ -12,7 +12,7 @@ groups:
               and on (network_id) ns_exporter_network_age_seconds > 3600
               and on (router_id) ns_exporter_router_age_seconds > 3600
             )
-    for: 10m
+    for: 5m
     labels:
       context: availability
       service: neutron


### PR DESCRIPTION
Update the value of the "for" clause for alert "NetworkNamespaceProbesFailed": 5 min.