### PR TITLE
[manila] allow share type extra specs overrides

### DIFF
--- a/openstack/manila/templates/shares/_share-netapp.conf.tpl
+++ b/openstack/manila/templates/shares/_share-netapp.conf.tpl
@@ -56,7 +56,7 @@ netapp_trace_flags=api,method
 {{- end }}
 
 # Enable the net_capacity provisioning
-netapp_volume_provision_net_capacity = True
+netapp_volume_provision_net_capacity = {{ $share.provision_net_capacity | default "True" }}
 netapp_volume_snapshot_reserve_percent = {{ $share.netapp_volume_snapshot_reserve_percent | default $context.Values.netapp_volume_snapshot_reserve_percent | default 50 }}
 
 # Specify if the FlexGroup pool is enabled. When it is enabled, the

--- a/openstack/manila/templates/type-seeds.yaml
+++ b/openstack/manila/templates/type-seeds.yaml
@@ -34,19 +34,36 @@ spec:
       provisioning:max_share_size: "32768"
       provisioning:max_share_extend_size: "32768" # keep this in sync with value "max_asset_sizes" of "- asset_type: 'nfs-shares.*'" in openstack/castellum/templates/configmap.yaml
     {{- include "manila_type_seed.extra_specs" . | indent 6 }}
-  {{- range $shareTypeName, $shareTypeEnabled := .Values.share_types }}
-  {{- if $shareTypeEnabled }}
-  {{- if $shareTypeName | hasPrefix "hypervisor_storage" }}
+  {{- range $shareTypeName, $shareTypeValues := .Values.share_types }}
+    {{- $enabled := false }}
+    {{- $old_style := false }}
+    {{- if not (kindIs "bool" $shareTypeValues) }}
+      {{- $enabled = $shareTypeValues.enabled }}
+    {{- else }}
+      {{- $old_style = true }}
+      {{- $enabled = $shareTypeValues }}
+    {{- end }}
+    {{- if $enabled }}
+      {{- if $shareTypeName | hasPrefix "hypervisor_storage" }}
   - name: {{ $shareTypeName }}
     is_public: false
     specs:
     {{- include "manila_type_seed.specs" . | indent 6 }}
     extra_specs:
       share_backend_name: {{ $shareTypeName | quote }}
+    {{- include "manila_type_seed.extra_specs" . | indent 6 }}
+        {{- if not $old_style}}
+          {{- if hasKey $shareTypeValues "extra_specs" }}
+            {{- $shareTypeValues.extra_specs | toYaml | nindent 6 }}
+          {{- else }}
       provisioning:max_share_size: "32768"
       provisioning:max_share_extend_size: "32768" # keep this in sync with value "max_asset_sizes" of "- asset_type: 'nfs-shares.*'" in openstack/castellum/templates/configmap.yaml
-    {{- include "manila_type_seed.extra_specs" . | indent 6 }}
-  {{- else if $shareTypeName | eq "standard" }} ## share type "standard"
+          {{- end }}
+        {{- else }}
+      provisioning:max_share_size: "32768"
+      provisioning:max_share_extend_size: "32768" # keep this in sync with value "max_asset_sizes" of "- asset_type: 'nfs-shares.*'" in openstack/castellum/templates/configmap.yaml
+        {{- end }}
+      {{- else if $shareTypeName | eq "standard" }} ## share type "standard"
   - name: {{ $shareTypeName }}
     is_public: false
     description: "Standard"
@@ -54,11 +71,20 @@ spec:
     {{- include "manila_type_seed.specs" . | indent 6 }}
     extra_specs:
       share_backend_name: {{ $shareTypeName | quote }}
+    {{- include "manila_type_seed.extra_specs" . | indent 6 }}
+        {{- if not $old_style}}
+          {{- if hasKey $shareTypeValues "extra_specs" }}
+            {{- $shareTypeValues.extra_specs | toYaml | nindent 6 }}
+          {{- else }}
       provisioning:max_share_size: "65536"
       provisioning:max_share_extend_size: "65536" # keep this in sync with value "max_asset_sizes" of "- asset_type: 'nfs-shares.*'" in openstack/castellum/templates/configmap.yaml
-    {{- include "manila_type_seed.extra_specs" . | indent 6 }}
-  {{- end }}
-  {{- end }}
+          {{- end }}
+        {{- else }}
+      provisioning:max_share_size: "65536"
+      provisioning:max_share_extend_size: "65536" # keep this in sync with value "max_asset_sizes" of "- asset_type: 'nfs-shares.*'" in openstack/castellum/templates/configmap.yaml
+        {{- end }}
+      {{- end }}
+    {{- end }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/openstack/manila/values.yaml
+++ b/openstack/manila/values.yaml
@@ -687,8 +687,12 @@ share_ensure:
   enabled: true
 
 share_types:
-  hypervisor_storage: false
-  btp_backup: false
+  hypervisor_storage:
+    enabled: false
+    extra_specs:
+      provisioning:min_share_size: "2048"
+      provisioning:max_share_size: "40960"
+  btp_backup: false # old style -> move to specifying a key 'enabled: false'
 
 # netapp filer back ends, required input
 # netapp:


### PR DESCRIPTION
for standard and hypervisor_storage types.

We need to make a map out of the bool kind 'share_types',
but also want to keep backwards compatible to not necessarily have
to coordinate the value changes at the same time.
