### PR TITLE
[manila][proxysql] double proxysql transaction timeout

### DIFF
--- a/openstack/manila/Chart.yaml
+++ b/openstack/manila/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: manila
 sources:
   - https://github.com/sapcc/manila
-version: 0.4.2
+version: 0.4.3
 dependencies:
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/manila/values.yaml
+++ b/openstack/manila/values.yaml
@@ -101,6 +101,7 @@ memcached:
 
 proxysql:
   mode: ""
+  max_transaction_time: "120000"
 
 mysql_metrics:
   db_name: manila


### PR DESCRIPTION
Increase proxysql sidecar transaction timeout from 60s to 120s until services query performance is fixed or improved.