### PR TITLE
feat(opensearch-logs-query-exporter): add secondary auth fallback mechanism

### DIFF
--- a/prometheus-exporters/opensearch-logs-query-exporter/Chart.yaml
+++ b/prometheus-exporters/opensearch-logs-query-exporter/Chart.yaml
@@ -1,14 +1,16 @@
 apiVersion: v2
 name: opensearch-logs-query-exporter
-version: 1.0.4
+version: 1.0.5
 description: Opensearch prometheus query exporter for Logs
 maintainers:
   - name: Olaf Heydorn
+  - name: Jonathan Schwarze
+  - name: Timo Johner
+  - name: Simon Olander
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0
-
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.1.3

--- a/prometheus-exporters/opensearch-logs-query-exporter/templates/deployment.yaml
+++ b/prometheus-exporters/opensearch-logs-query-exporter/templates/deployment.yaml
@@ -53,6 +53,16 @@ spec:
               secretKeyRef:
                 name: logs-query-exporter-secrets
                 key: password
+          - name: ES_EXPORTER_FAILOVER_BASIC_USER
+            valueFrom:
+              secretKeyRef:
+                name: logs-query-exporter-secrets
+                key: failover_username
+          - name: ES_EXPORTER_FAILOVER_BASIC_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: logs-query-exporter-secrets
+                key: failover_password
           ports:
             - name: metrics
               containerPort: {{ .Values.listen_port }}

--- a/prometheus-exporters/opensearch-logs-query-exporter/templates/deployment.yaml
+++ b/prometheus-exporters/opensearch-logs-query-exporter/templates/deployment.yaml
@@ -22,6 +22,7 @@ spec:
         component: opensearch-logs-query-exporter
       annotations:
         checksum/configmap.yaml: {{ include  (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secrets.yaml: {{ include  (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
         {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
         linkerd.io/inject: enabled
         {{- end }}
@@ -39,8 +40,8 @@ spec:
             name: opensearch-logs-query-exporter
       containers:
         - name: opensearch-logs-query-exporter
-          image: {{.Values.global.registry}}/prometheus-es-exporter:{{ .Values.version }}
-          imagePullPolicy: Always
+          image: prometheus-es-exporter:latest
+          imagePullPolicy: Never
           command: [ "prometheus-es-exporter", "-p", "{{.Values.listen_port}}", "--config-dir", "/opensearch-logs-query-exporter/", "--cluster-health-disable", "--indices-stats-disable", "-e", "{{.Values.protocol}}://{{.Values.hostname}}:{{.Values.port}}", "--log-level", "{{.Values.log_level}}", "--nodes-stats-disable" ]
           env:
           - name: ES_EXPORTER_BASIC_USER

--- a/prometheus-exporters/opensearch-logs-query-exporter/templates/deployment.yaml
+++ b/prometheus-exporters/opensearch-logs-query-exporter/templates/deployment.yaml
@@ -40,8 +40,8 @@ spec:
             name: opensearch-logs-query-exporter
       containers:
         - name: opensearch-logs-query-exporter
-          image: prometheus-es-exporter:latest
-          imagePullPolicy: Never
+          image: {{.Values.global.registry}}/prometheus-es-exporter:{{ .Values.version }}
+          imagePullPolicy: Always
           command: [ "prometheus-es-exporter", "-p", "{{.Values.listen_port}}", "--config-dir", "/opensearch-logs-query-exporter/", "--cluster-health-disable", "--indices-stats-disable", "-e", "{{.Values.protocol}}://{{.Values.hostname}}:{{.Values.port}}", "--log-level", "{{.Values.log_level}}", "--nodes-stats-disable" ]
           env:
           - name: ES_EXPORTER_BASIC_USER

--- a/prometheus-exporters/opensearch-logs-query-exporter/templates/secrets.yaml
+++ b/prometheus-exporters/opensearch-logs-query-exporter/templates/secrets.yaml
@@ -7,3 +7,5 @@ metadata:
 data:
   username: {{ .Values.global.prom_user | b64enc | quote }}
   password: {{ .Values.global.prom_password | b64enc | quote }}
+  failover_username: {{ .Values.global.prom_user_failover | b64enc | quote }}
+  failover_password: {{ .Values.global.prom_password_failover | b64enc | quote }}

--- a/prometheus-exporters/opensearch-logs-query-exporter/templates/secrets.yaml
+++ b/prometheus-exporters/opensearch-logs-query-exporter/templates/secrets.yaml
@@ -7,5 +7,5 @@ metadata:
 data:
   username: {{ .Values.global.prom_user | b64enc | quote }}
   password: {{ .Values.global.prom_password | b64enc | quote }}
-  failover_username: {{ .Values.global.prom_user_failover | b64enc | quote }}
-  failover_password: {{ .Values.global.prom_password_failover | b64enc | quote }}
+  failover_username: {{ .Values.global.prom_user2 | b64enc | quote }}
+  failover_password: {{ .Values.global.prom_password2 | b64enc | quote }}

--- a/prometheus-exporters/opensearch-logs-query-exporter/values.yaml
+++ b/prometheus-exporters/opensearch-logs-query-exporter/values.yaml
@@ -3,10 +3,17 @@ owner-info:
   service: exporter
   maintainers:
     - "Olaf Heydorn"
+    - "Jonathan Schwarze"
+    - "Timo Johner"
+    - "Simon Olander"
   helm-chart-url: "https://github.com/sapcc/helm-charts/tree/master/prometheus-exporters/elk-query-exporter"
 
 global:
   linkerd_requested: true
+  prom_user: '<defined-in-pipeline>'
+  prom_password: '<defined-in-pipeline>'
+  prom_user2: '<defined-in-pipeline>'
+  prom_password2: '<defined-in-pipeline>'
 
 enabled: false
 version: "20240902113149"


### PR DESCRIPTION
Add two more `env` for failover credentials used in https://github.com/sapcc/prometheus-es-exporter/pull/2