### PR TITLE
[mariadb] move backup-v2 oauth secret to a separate secret

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.15.5 - 2025/02/14
+* `maria-back-me-up` (backup-v2) oauth secret moved to a separate `Secret`
+* chart version bumped
+
 ## v0.15.4 - 2025/02/07
 * MariaDB version bumped to [10.5.28](https://mariadb.com/kb/en/mariadb-10-5-28-release-notes/)
   * several fixes for INNODB and other components

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.15.4
+version: 0.15.5

--- a/common/mariadb/templates/backup-v2-deployment.yaml
+++ b/common/mariadb/templates/backup-v2-deployment.yaml
@@ -68,17 +68,17 @@ spec:
         - name: OAUTH_CLIENT_ID
           valueFrom:
             secretKeyRef:
-              name: mariadb-{{.Values.name}}
+              name: mariadb-{{.Values.name}}-backup-oauth
               key: OAUTH_CLIENT_ID
         - name: OAUTH_CLIENT_SECRET
           valueFrom:
             secretKeyRef:
-              name: mariadb-{{.Values.name}}
+              name: mariadb-{{.Values.name}}-backup-oauth
               key: OAUTH_CLIENT_SECRET
         - name: OAUTH_COOKIE_SECRET
           valueFrom:
             secretKeyRef:
-              name: mariadb-{{.Values.name}}
+              name: mariadb-{{.Values.name}}-backup-oauth
               key: OAUTH_COOKIE_SECRET
 {{- end }}
         - name: CONFIG_FILE

--- a/common/mariadb/templates/backup-v2-secret.yaml
+++ b/common/mariadb/templates/backup-v2-secret.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.backup_v2.enabled }}
+{{- if .Values.backup_v2.oauth.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mariadb-{{.Values.name}}-backup-oauth
+  labels:
+    {{- include "mariadb.labels" (list $ "noversion" "mariadb" "secret" "backup") | indent 4 }}
+type: Opaque
+data:
+  OAUTH_CLIENT_ID: {{ default "" .Values.backup_v2.oauth.client_id | b64enc | quote }}
+  OAUTH_CLIENT_SECRET: {{ default "" .Values.global.mariadb.backup_v2.oauth.client_secret | b64enc | quote }}
+  OAUTH_COOKIE_SECRET: {{ default "" .Values.global.mariadb.backup_v2.oauth.cookie_secret | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/common/mariadb/templates/secret.yaml
+++ b/common/mariadb/templates/secret.yaml
@@ -7,10 +7,3 @@ metadata:
 type: Opaque
 data:
   root-password: {{ include "mariadb.root_password" . | b64enc | quote }}
-{{- if .Values.backup_v2.enabled }}
-{{- if .Values.backup_v2.oauth.enabled }}
-  OAUTH_CLIENT_ID: {{ default "" .Values.backup_v2.oauth.client_id | b64enc | quote }}
-  OAUTH_CLIENT_SECRET: {{ default "" .Values.global.mariadb.backup_v2.oauth.client_secret | b64enc | quote }}
-  OAUTH_COOKIE_SECRET: {{ default "" .Values.global.mariadb.backup_v2.oauth.cookie_secret | b64enc | quote }}
-{{- end }}
-{{- end }}


### PR DESCRIPTION
`mariadb-servicename` deployment is annotated to be restarted after `mariadb-servicename` secret change, but oauth credentials are only being used in `mariadb-backup`, so these oauth secrets should be moved to separate secret.
