### PR TITLE
[Cinder] Update chart deps

### DIFF
--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -1,27 +1,27 @@
 dependencies:
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.18.4
+  version: 0.22.1
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.14.2
+  version: 0.15.5
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.3.5
+  version: 0.4.2
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.5.3
+  version: 0.6.4
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.11.1
+  version: 0.14.1
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.5.2
+  version: 1.6.2
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.0.0
-digest: sha256:49c61b998768421d8cdd026a0c886ec850bfcdc9ed89204f64c812470605b17b
-generated: "2024-09-27T14:13:49.162697106+02:00"
+  version: 1.1.0
+digest: sha256:bbc5363a7081e030b710a12cbddc8bf81b69f84d6d1d701a9ebbb0bfa93fcd3d
+generated: "2025-02-17T10:15:25.002858-05:00"

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -6,25 +6,25 @@ version: 0.2.1
 dependencies:
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.18.4
+    version: ~0.22.1
   - name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.14.2
+    version: 0.15.5
     condition: mariadb.enabled
   - name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.3.5
+    version: 0.4.2
     condition: mariadb.enabled
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.5.3
+    version: 0.6.4
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.11.1
+    version: 0.14.1
   - name: redis
     alias: api-ratelimit-redis
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 1.5.2
+    version: 1.6.2
     condition: api_rate_limit.enabled
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm


### PR DESCRIPTION
This patch updates various chart dependencies to their latest version.  It's been a while since cinder deps have been updated.

Update:
utils 0.18.4 -> 0.22.1
mariadb 0.14.2 -> 0.15.5
mysql_metrics 0.3.5 -> 0.4.2
memcached 0.5.3 -> 0.6.4
rabbitmq 0.11.1 -> 0.14.1
redis 1.5.2 -> 1.6.2

