### PR TITLE
alertmanager: fix bedrock slack route

### DIFF
--- a/global/prometheus-alertmanager-operated/Chart.yaml
+++ b/global/prometheus-alertmanager-operated/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 description: Prometheus Alertmanager via operator.
 name: prometheus-alertmanager-operated
-version: 4.5.4
+version: 4.5.5
 
 dependencies:
   - alias: prometheus-alertmanager

--- a/global/prometheus-alertmanager-operated/templates/am-config-route-slack.yaml
+++ b/global/prometheus-alertmanager-operated/templates/am-config-route-slack.yaml
@@ -484,7 +484,7 @@ spec:
             value: compute
           - name: bedrock
             matchType: "="
-            value: true
+            value: "true"
           
       - receiver: slack_bedrock_warning
         continue: true
@@ -503,7 +503,7 @@ spec:
             value: compute
           - name: bedrock
             matchType: "="
-            value: true
+            value: "true"
 
       # Test Channel for CC KVM Alerting slack_alert_kvm_test
       - receiver: slack_alert_kvm_test


### PR DESCRIPTION
`msg="skipping alertmanagerconfig" error="route[35]: json: cannot unmarshal bool into Go struct field Matcher.matchers.value of type string"`