### PR TITLE
[Nova] Fix bump-compute-service-version Secret

### DIFF
--- a/openstack/nova/templates/bump-compute-service-version-xena.yaml
+++ b/openstack/nova/templates/bump-compute-service-version-xena.yaml
@@ -16,7 +16,7 @@ type: Opaque
 data:
   db_password: {{ default .Values.dbPassword .Values.global.dbPassword | required ".Values.dbPassword is missing" | include "resolve_secret" | b64enc }}
   {{- if .Values.cell2.enabled }}
-db_password_cell2: {{ default .Values.cell2dbPassword .Values.global.dbPassword | required ".Values.cell2dbPassword is missing" | include "resolve_secret" | b64enc }}
+  db_password_cell2: {{ default .Values.cell2dbPassword .Values.global.dbPassword | required ".Values.cell2dbPassword is missing" | include "resolve_secret" | b64enc }}
   {{- end }}
 ---
 apiVersion: batch/v1


### PR DESCRIPTION
The key `db_password_cell2` was indented wrongly.