### PR TITLE
[Nova] Fix nova-bump-service-version Job for cell2

### DIFF
--- a/openstack/nova/templates/bump-compute-service-version-xena.yaml
+++ b/openstack/nova/templates/bump-compute-service-version-xena.yaml
@@ -55,7 +55,7 @@ spec:
           UPDATE services SET version = 66 WHERE deleted = 0 AND `binary` = "nova-compute" AND version < 66;
           ';
           {{- if .Values.cell2.enabled }}
-          mariadb -v -hnova-{{ .Values.cell2.name }}-mariadb -u{{ .Values.cell2dbUser }} --password="${DB_PASSWORD_CELL2}}" '{{ .Values.cell2dbName }}' -e '
+          mariadb -v -hnova-{{ .Values.cell2.name }}-mariadb -u{{ .Values.cell2dbUser }} --password="${DB_PASSWORD_CELL2}" '{{ .Values.cell2dbName }}' -e '
           UPDATE services SET version = 66 WHERE deleted = 0 AND `binary` = "nova-compute" AND version < 66;
           '
           {{- end }}


### PR DESCRIPTION
The job definition had a bug, where we would add an additional `}` to the password.