### PR TITLE
chore(elektra): increase resource limits

### DIFF
--- a/openstack/elektra/values.yaml
+++ b/openstack/elektra/values.yaml
@@ -87,7 +87,6 @@ pgbackup:
     service: elektra
 
 pgmetrics:
-  isPostgresNG: true
   db_name: monsoon-dashboard_production
   alerts:
     support_group: containers

--- a/openstack/elektra/values.yaml
+++ b/openstack/elektra/values.yaml
@@ -93,6 +93,14 @@ pgmetrics:
     support_group: containers
     service: elektra
 
+  resources:
+    limits:
+      memory: 256Mi
+      cpu: 500m
+    requests:
+      memory: 128Mi
+      cpu: 250m
+
 owner-info:
   support-group: containers
   service: elektra


### PR DESCRIPTION
This PR increases the resource limits to address the ElektraPredictHighNumberOfDatabaseConnections - High alert and ensure stable application performance under increased workload.

## Changes

**From:**
```yaml
resources:
  limits:
    memory: 128Mi
    cpu: 100m
  requests:
    memory: 64Mi
    cpu: 50m
```

**To:**
```yaml
  resources:
    limits:
      memory: 256Mi
      cpu: 500m
    requests:
      memory: 128Mi
      cpu: 250m
```