### PR TITLE
[limes] use new group for default access of billing@ccadmin (srs #540)

### DIFF
--- a/openstack/billing/templates/seeds.yaml
+++ b/openstack/billing/templates/seeds.yaml
@@ -105,9 +105,9 @@ spec:
     - name: billing
       description: 'Billing Administration for Converged Cloud'
       role_assignments:
-      - user: billing@Default
-        role: objectstore_admin
-        # NOTE: The cloud_resource_viewer role is given by the limes seed.
+      # Role provisioned from CAM to enable takeover of seeded project by billing admins
+      - group: CCADMIN_BILLING_ADMIN
+        role: admin
       swift:
         enabled: true
     {{- end }}


### PR DESCRIPTION
I missed this line on the initial PR.

`helm diff`:

```
billing, billing-seed, OpenstackSeed (openstack.stable.sap.cc) has changed:
      name: ccadmin
      projects:
      - description: Billing Administration for Converged Cloud
        name: billing
        role_assignments:
-       - role: objectstore_admin
-         user: billing@Default
+       - group: CCADMIN_BILLING_ADMIN
+         role: admin
        swift:
          enabled: true
      - name: cloud_admin
        role_assignments:
        - role: cloud_identity_viewer
```