### PR TITLE
[ceph] move auth order to rgwCommandFlags

### DIFF
--- a/system/cc-ceph/Chart.yaml
+++ b/system/cc-ceph/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cc-ceph
 description: A Helm chart for the Rook / Ceph Objects inside the Storage Clusters
 type: application
-version: 1.1.38
+version: 1.1.39
 appVersion: "1.16.2"
 dependencies:
   - name: owner-info

--- a/system/cc-ceph/templates/ceph-config-override.yaml
+++ b/system/cc-ceph/templates/ceph-config-override.yaml
@@ -13,7 +13,9 @@ data:
 {{- else }}
     [client.rgw.{{ $name }}.a]
 {{- end }}
+{{- if gt (len .auth_order) 0 }}
     rgw s3 auth order = {{ join "," .auth_order }}
+{{- end }}
     rgw keystone verify ssl = {{ .verify_ssl }}
 {{- if .accepted_admin_roles }}
     rgw keystone accepted admin roles = {{ join "," .accepted_admin_roles }}

--- a/system/cc-ceph/values.yaml
+++ b/system/cc-ceph/values.yaml
@@ -135,9 +135,7 @@ objectstore:
   keystone:
     enabled: true
     global_config: true
-    auth_order:
-      - local
-      - external
+    auth_order: []
     url: http://keystone.local:8083
     verify_ssl: true
     implicit_tenants: true


### PR DESCRIPTION
set empty the default `keystone.auth_order` value