### PR TITLE
[Placement] Support dalmatian release

### DIFF
--- a/openstack/placement/Chart.yaml
+++ b/openstack/placement/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart for the Openstack Placement Service
 name: placement
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/project-mascots/Placement/OpenStack_Project_Placement_horizontal.jpg
 version: 0.1.0
-appVersion: "yoga"
+appVersion: "dalmatian"
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/placement/templates/etc/_policy.yaml.tpl
+++ b/openstack/placement/templates/etc/_policy.yaml.tpl
@@ -1,184 +1,31 @@
 # CCloud-specific admin identification
 "context_is_cloud_admin": "role:cloud_compute_admin"
 
-# Default rule for System Admin APIs.
-#"system_admin_api": "role:admin and system_scope:all"
+###
+# dalmatian changes to the policy
+###
+# Default rule for service-to-service placement APIs.
+# Intended scope(s): project
+#"service_api": "role:service"
+"service_api": "rule:context_is_cloud_admin"
+
+# Default rule for most placement APIs.
+# Intended scope(s): project
+#"admin_or_service_api": "role:admin or role:service"
+"admin_or_service_api": "rule:context_is_cloud_admin"
+
+# Default rule for Project level reader APIs.
+# only used in rule:admin_or_project_reader_or_service_api
+#"project_reader_api": "role:compute_viewer and project_id:%(project_id)s"
+
+# Default rule for project level reader APIs.
+# Intended scope(s): project
+# only used for /usages
+#"admin_or_project_reader_or_service_api": "role:admin or rule:project_reader_api or role:service"
+"admin_or_project_reader_or_service_api": "rule:context_is_cloud_admin or rule:project_reader_api"
+
+###
+# yoga-specific changes to the policy
+###
 "system_admin_api": "( role:admin and system_scope:all ) or rule:context_is_cloud_admin"
-
-# Default rule for System level read only APIs.
-#"system_reader_api": "role:reader and system_scope:all"
 "system_reader_api": "( role:reader and system_scope:all ) or rule:system_admin_api"
-
-# Default rule for Project level read only APIs.
-#"project_reader_api": "role:reader and project_id:%(project_id)s"
-
-# Default rule for System+Project read only APIs.
-#"system_or_project_reader": "rule:system_reader_api or rule:project_reader_api"
-
-# List resource providers.
-# GET  /resource_providers
-# Intended scope(s): system
-#"placement:resource_providers:list": "rule:system_reader_api"
-
-# Create resource provider.
-# POST  /resource_providers
-# Intended scope(s): system
-#"placement:resource_providers:create": "rule:system_admin_api"
-
-# Show resource provider.
-# GET  /resource_providers/{uuid}
-# Intended scope(s): system
-#"placement:resource_providers:show": "rule:system_reader_api"
-
-# Update resource provider.
-# PUT  /resource_providers/{uuid}
-# Intended scope(s): system
-#"placement:resource_providers:update": "rule:system_admin_api"
-
-# Delete resource provider.
-# DELETE  /resource_providers/{uuid}
-# Intended scope(s): system
-#"placement:resource_providers:delete": "rule:system_admin_api"
-
-# List resource classes.
-# GET  /resource_classes
-# Intended scope(s): system
-#"placement:resource_classes:list": "rule:system_reader_api"
-
-# Create resource class.
-# POST  /resource_classes
-# Intended scope(s): system
-#"placement:resource_classes:create": "rule:system_admin_api"
-
-# Show resource class.
-# GET  /resource_classes/{name}
-# Intended scope(s): system
-#"placement:resource_classes:show": "rule:system_reader_api"
-
-# Update resource class.
-# PUT  /resource_classes/{name}
-# Intended scope(s): system
-#"placement:resource_classes:update": "rule:system_admin_api"
-
-# Delete resource class.
-# DELETE  /resource_classes/{name}
-# Intended scope(s): system
-#"placement:resource_classes:delete": "rule:system_admin_api"
-
-# List resource provider inventories.
-# GET  /resource_providers/{uuid}/inventories
-# Intended scope(s): system
-#"placement:resource_providers:inventories:list": "rule:system_reader_api"
-
-# Create one resource provider inventory.
-# POST  /resource_providers/{uuid}/inventories
-# Intended scope(s): system
-#"placement:resource_providers:inventories:create": "rule:system_admin_api"
-
-# Show resource provider inventory.
-# GET  /resource_providers/{uuid}/inventories/{resource_class}
-# Intended scope(s): system
-#"placement:resource_providers:inventories:show": "rule:system_reader_api"
-
-# Update resource provider inventory.
-# PUT  /resource_providers/{uuid}/inventories
-# PUT  /resource_providers/{uuid}/inventories/{resource_class}
-# Intended scope(s): system
-#"placement:resource_providers:inventories:update": "rule:system_admin_api"
-
-# Delete resource provider inventory.
-# DELETE  /resource_providers/{uuid}/inventories
-# DELETE  /resource_providers/{uuid}/inventories/{resource_class}
-# Intended scope(s): system
-#"placement:resource_providers:inventories:delete": "rule:system_admin_api"
-
-# List resource provider aggregates.
-# GET  /resource_providers/{uuid}/aggregates
-# Intended scope(s): system
-#"placement:resource_providers:aggregates:list": "rule:system_reader_api"
-
-# Update resource provider aggregates.
-# PUT  /resource_providers/{uuid}/aggregates
-# Intended scope(s): system
-#"placement:resource_providers:aggregates:update": "rule:system_admin_api"
-
-# List resource provider usages.
-# GET  /resource_providers/{uuid}/usages
-# Intended scope(s): system
-#"placement:resource_providers:usages": "rule:system_reader_api"
-
-# List total resource usages for a given project.
-# GET  /usages
-# Intended scope(s): system, project
-#"placement:usages": "rule:system_or_project_reader"
-
-# List traits.
-# GET  /traits
-# Intended scope(s): system
-#"placement:traits:list": "rule:system_reader_api"
-
-# Show trait.
-# GET  /traits/{name}
-# Intended scope(s): system
-#"placement:traits:show": "rule:system_reader_api"
-
-# Update trait.
-# PUT  /traits/{name}
-# Intended scope(s): system
-#"placement:traits:update": "rule:system_admin_api"
-
-# Delete trait.
-# DELETE  /traits/{name}
-# Intended scope(s): system
-#"placement:traits:delete": "rule:system_admin_api"
-
-# List resource provider traits.
-# GET  /resource_providers/{uuid}/traits
-# Intended scope(s): system
-#"placement:resource_providers:traits:list": "rule:system_reader_api"
-
-# Update resource provider traits.
-# PUT  /resource_providers/{uuid}/traits
-# Intended scope(s): system
-#"placement:resource_providers:traits:update": "rule:system_admin_api"
-
-# Delete resource provider traits.
-# DELETE  /resource_providers/{uuid}/traits
-# Intended scope(s): system
-#"placement:resource_providers:traits:delete": "rule:system_admin_api"
-
-# Manage allocations.
-# POST  /allocations
-# Intended scope(s): system
-#"placement:allocations:manage": "rule:system_admin_api"
-
-# List allocations.
-# GET  /allocations/{consumer_uuid}
-# Intended scope(s): system
-#"placement:allocations:list": "rule:system_reader_api"
-
-# Update allocations.
-# PUT  /allocations/{consumer_uuid}
-# Intended scope(s): system
-#"placement:allocations:update": "rule:system_admin_api"
-
-# Delete allocations.
-# DELETE  /allocations/{consumer_uuid}
-# Intended scope(s): system
-#"placement:allocations:delete": "rule:system_admin_api"
-
-# List resource provider allocations.
-# GET  /resource_providers/{uuid}/allocations
-# Intended scope(s): system
-#"placement:resource_providers:allocations:list": "rule:system_reader_api"
-
-# List allocation candidates.
-# GET  /allocation_candidates
-# Intended scope(s): system
-#"placement:allocation_candidates:list": "rule:system_reader_api"
-
-# Reshape Inventory and Allocations.
-# POST  /reshaper
-# Intended scope(s): system
-#"placement:reshaper:reshape": "rule:system_admin_api"
-


### PR DESCRIPTION
The only change we need to do is in the policy, which has switched the rules they use for validation. Since we only ever changed the generic rules that define an admin, we remove the defaults - they don't match between yoga and dalmatian and can be easily generated with `tox -e genpolicy` in Placements repo.

We set both the old (yoga) and the new (dalmatian) generic rules that define an admin to support smooth upgrading.

We also bump the `appVersion` of the chart to "dalmatian", because that's the newest we support.