### PR TITLE
[neutron] Use IP instead of DNS for OVN DB connection

### DIFF
--- a/openstack/neutron/templates/etc/_ml2-conf.ini.tpl
+++ b/openstack/neutron/templates/etc/_ml2-conf.ini.tpl
@@ -60,6 +60,10 @@ enable_vxlan = false
 {{- if .Values.ovn.enabled }}
 
 [ovn]
-ovn_nb_connection = tcp:ovnkube-db.{{ include "svc_fqdn" . }}:{{ .Values.ovn.nbPort }}
-ovn_sb_connection = tcp:ovnkube-db.{{ include "svc_fqdn" . }}:{{ .Values.ovn.sbPort }}
+{{- $numIPs := len .Values.ovn.externalIPs }}
+{{- if le $numIPs 0 }}
+    {{- fail "Need at least one IP in ovn.externalIPs" }}
+{{- end}}
+ovn_nb_connection = tcp:{{ first .Values.ovn.externalIPs }}:{{ .Values.ovn.nbPort }}
+ovn_sb_connection = tcp:{{ first .Values.ovn.externalIPs }}:{{ .Values.ovn.sbPort }}
 {{- end }}


### PR DESCRIPTION
OVS only can resolve DNS names, when the optional unbound
package is installed, as it wants to do its own DNS resolution
for some reason.

