### PR TITLE
[ironic] move rabbitmq url to secrets

### DIFF
--- a/openstack/ironic/templates/etc/_ironic.conf.tpl
+++ b/openstack/ironic/templates/etc/_ironic.conf.tpl
@@ -16,7 +16,7 @@ notification_level = {{ .Values.notification_level }}
 versioned_notifications_topics = {{ .Values.versioned_notifications_topics  | default "ironic_versioned_notifications" | quote }}
 {{- end }}
 
-{{- include "ini_sections.default_transport_url" . }}
+
 
 rpc_response_timeout = {{ .Values.rpc_response_timeout | default .Values.global.rpc_response_timeout | default 100 }}
 executor_thread_pool_size = {{ .Values.rpc_workers | default .Values.global.rpc_workers | default 64 }}

--- a/openstack/ironic/templates/etc/_secrets.conf.tpl
+++ b/openstack/ironic/templates/etc/_secrets.conf.tpl
@@ -1,4 +1,5 @@
 [DEFAULT]
+{{- include "ini_sections.default_transport_url" . }}
 {{- include "ini_sections.oslo_messaging_rabbit" .}}
 
 [database]


### PR DESCRIPTION
The transport_url from rabbitmq includes secrets. Having this in the
config is wrong and breaks with the switch to the secrets-injector. Thus
we move this to the secrets. Doing so is the recommended way by the
shared-services.
