### PR TITLE
common/redis: cleanup clutter, add password autogeneration on first startup

### DIFF
--- a/common/postgresql-ng/Chart.yaml
+++ b/common/postgresql-ng/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: postgresql-ng
-version: 1.2.8 # this version number is SemVer as it gets used to auto bump
+version: 1.2.9 # this version number is SemVer as it gets used to auto bump
 description: Chart for PostgreSQL
 keywords:
 - postgresql

--- a/common/postgresql-ng/templates/deployment.yaml
+++ b/common/postgresql-ng/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
 
       initContainers:
       - name: generate-secrets
-        image: "{{ include "preferredRegistry" . }}/shared-app-images/alpine-kubectl:3.21-latest"
+        image: "{{ include "preferredRegistry" . }}/shared-app-images/alpine-kubectl:latest-latest"
         imagePullPolicy: "Always"
         env:
         - name: DEBUG

--- a/common/redis/Chart.yaml
+++ b/common/redis/Chart.yaml
@@ -18,4 +18,17 @@ name: redis
 # - Switched from Redis to its fork Valkey because of the Redis license change.
 #   The image now comes from ccloud/shared-app-images/valkey.
 #   If you have image.tag pins (which we recommend against), please update them accordingly.
-version: 1.6.2 # this version number is SemVer as it gets used to auto bump
+#
+# 2.0.0
+# - Cleaned up useless variability and other clutter:
+#   - The field `.Values.nameOverride` was removed.
+#     If you need multiple Redis instances in a single chart, use dependency aliasing.
+#   - The fields `.Values.redisPort` and `Values.metrics.port` were removed.
+#     Apps now always use their default ports (6379 for Redis, 9121 for metrics).
+#   - The redis-exporter deployment was renamed from `...-redis-metrics` to `...-redis-exporter`
+#     to allow for a cleanup of the pod labels. Other than that, the pod behaves the same.
+# - Passwords can now be auto-generated instead of pulling them from Vault.
+#   See documentation on field `.Values.redisPassword` for details.
+# - Support for setting `.Values.redisPassword` explicitly is deprecated.
+#   This field may be removed in a subsequent major version bump.
+version: 2.0.0 # this version number is SemVer as it gets used to auto bump

--- a/common/redis/bin/init-generate-secrets.sh
+++ b/common/redis/bin/init-generate-secrets.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env ash
+# shellcheck shell=ash
+# shellcheck disable=SC3010
+
+# This is the entrypoint script for the "generate-secrets" init container of the redis pod.
+
+set -eou pipefail
+[[ ${DEBUG:-} != false ]] && set -x
+
+for USER in ${USERS:-}; do
+  SECRET="${DEPLOYMENT_NAME}-user-$USER"
+
+  # if we already have a secret, we can stop here
+  if [[ "$(kubectl get secrets "$SECRET" --ignore-not-found)" != "" ]]; then
+    continue
+  fi
+
+  # create new secret with randomly generated password
+  # NOTE: make sure that the generated password contains no newline
+  echo -n "
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: $SECRET
+      ownerReferences:
+        - apiVersion: apps/v1
+          blockOwnerDeletion: true
+          kind: Deployment
+          name: $DEPLOYMENT_NAME
+          uid: $(kubectl get deployment "$DEPLOYMENT_NAME" -o jsonpath='{.metadata.uid}')
+    data:
+      password: $(LC_ALL=C tr -dc '[:graph:]' </dev/urandom | head -c 30 | base64 -w0 | base64 -w0)
+  " > secret.yaml
+  kubectl create -f secret.yaml
+done

--- a/common/redis/templates/_helpers.tpl
+++ b/common/redis/templates/_helpers.tpl
@@ -1,15 +1,5 @@
-{{/* Expand the name of the chart. */}}
-{{- define "redis.name" -}}
-{{- .Chart.Name | trunc 63 | replace "_" "-" | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-*/}}
 {{- define "redis.fullname" -}}
-{{- $name := .Chart.Name -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | replace "_" "-" | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name -}}
 {{- end -}}
 
 {{- if .Values.nameOverride }}

--- a/common/redis/templates/_helpers.tpl
+++ b/common/redis/templates/_helpers.tpl
@@ -1,6 +1,6 @@
 {{/* Expand the name of the chart. */}}
 {{- define "redis.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | replace "_" "-" | trimSuffix "-" -}}
+{{- .Chart.Name | trunc 63 | replace "_" "-" | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -8,6 +8,10 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "redis.fullname" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- $name := .Chart.Name -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | replace "_" "-" | trimSuffix "-" -}}
 {{- end -}}
+
+{{- if .Values.nameOverride }}
+{{- fail "redis: The nameOverride option is no longer supported because we did not see it anyone needing it." }}
+{{- end }}

--- a/common/redis/templates/configmap.yaml
+++ b/common/redis/templates/configmap.yaml
@@ -1,13 +1,10 @@
+{{- $fullname := include "redis.fullname" . -}}
+
 {{- if .Values.config }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "redis.fullname" . }}
-  labels:
-    app: {{ template "redis.fullname" . }}
-    chart: "{{ .Chart.Name }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+  name: {{ $fullname }}
 data:
   redis.conf: |
 {{- range $key, $value := .Values.config }}

--- a/common/redis/templates/deployment.yaml
+++ b/common/redis/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
       {{- if not .Values.redisPassword }}
       initContainers:
       - name: generate-secrets
-        image: {{ $registry }}/shared-app-images/alpine-kubectl:3.21-latest
+        image: {{ $registry }}/shared-app-images/alpine-kubectl:latest-latest
         imagePullPolicy: Always
         env:
         - name: DEBUG

--- a/common/redis/templates/deployment.yaml
+++ b/common/redis/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
         {{ end }}
         ports:
         - name: redis
-          containerPort: {{ required ".Values.redisPort missing" .Values.redisPort }}
+          containerPort: 6379
         livenessProbe:
           exec:
             command:

--- a/common/redis/templates/deployment.yaml
+++ b/common/redis/templates/deployment.yaml
@@ -32,6 +32,20 @@ spec:
         checksum/secrets: {{ include (print .Template.BasePath "/secrets.yaml") . | sha256sum }}
         {{- end }}
     spec:
+      {{- if not .Values.redisPassword }}
+      initContainers:
+      - name: generate-secrets
+        image: {{ $registry }}/shared-app-images/alpine-kubectl:3.21-latest
+        imagePullPolicy: Always
+        env:
+        - name: DEBUG
+          value: 'false'
+        - name: DEPLOYMENT_NAME
+          value: {{ $fullname }}
+        - name: USERS
+          value: 'default'
+        command: [ ash, -c, {{ .Files.Get "bin/init-generate-secrets.sh" | quote }} ]
+      {{- end }}
       containers:
       - name: {{ $fullname }}
         image: {{ $registry }}/shared-app-images/alpine-valkey:{{ .Values.image.tag }}
@@ -40,16 +54,19 @@ spec:
         {{- if .Values.config }}
         - /etc/redis/redis.conf
         {{- end }}
-        {{- if .Values.redisPassword }}
         - --requirepass
         - $(REDIS_PASSWORD)
         env:
         - name: REDIS_PASSWORD
           valueFrom:
             secretKeyRef:
+              {{- if .Values.redisPassword }}
               name: {{ $fullname }}
               key: redis-password
-        {{ end }}
+              {{- else }}
+              name: {{ $fullname }}-user-default
+              key: password
+              {{- end }}
         ports:
         - name: redis
           containerPort: 6379
@@ -82,6 +99,7 @@ spec:
         - name: redis-config
           mountPath: /etc/redis
       {{- end }}
+      serviceAccountName: {{ $fullname }}
       volumes:
       - name: redis-data
       {{- if .Values.persistence.enabled }}

--- a/common/redis/templates/deployment.yaml
+++ b/common/redis/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $fullname := include "redis.fullname" . -}}
 {{- $registry := .Values.global.registry | required ".Values.global.registry missing" -}}
 {{- if .Values.useAlternateRegion -}}
   {{- $registry = .Values.global.registryAlternateRegion | required ".Values.global.registryAlternateRegion missing" -}}
@@ -6,12 +7,7 @@
 kind: Deployment
 apiVersion: apps/v1
 metadata:
-  name: {{ template "redis.fullname" . }}
-  labels:
-    app: {{ template "redis.fullname" . }}
-    chart: "{{ .Chart.Name }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+  name: {{ $fullname }}
 spec:
 {{- if .Values.persistence.enabled }}
   strategy:
@@ -19,13 +15,13 @@ spec:
 {{- end }}
   selector:
     matchLabels:
-      app: {{ template "redis.fullname" . }}
+      app: {{ $fullname }}
   template:
     metadata:
       labels:
-        app: {{ template "redis.fullname" . }}
+        app: {{ $fullname }}
       annotations:
-        kubectl.kubernetes.io/default-container: {{ template "redis.fullname" . }}
+        kubectl.kubernetes.io/default-container: {{ $fullname }}
         {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
         linkerd.io/inject: enabled
         {{- end }}
@@ -37,7 +33,7 @@ spec:
         {{- end }}
     spec:
       containers:
-      - name: {{ template "redis.fullname" . }}
+      - name: {{ $fullname }}
         image: {{ $registry }}/shared-app-images/alpine-valkey:{{ .Values.image.tag }}
         imagePullPolicy: {{ if contains "latest" .Values.image.tag }}Always{{ else }}IfNotPresent{{ end }}
         args:
@@ -51,7 +47,7 @@ spec:
         - name: REDIS_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "redis.fullname" . }}
+              name: {{ $fullname }}
               key: redis-password
         {{ end }}
         ports:
@@ -78,8 +74,7 @@ spec:
             - ping
           initialDelaySeconds: 5
           timeoutSeconds: 1
-        resources:
-{{ toYaml .Values.resources | indent 10 }}
+        resources: {{ toYaml .Values.resources | nindent 10 }}
         volumeMounts:
         - name: redis-data
           mountPath: /data
@@ -91,7 +86,7 @@ spec:
       - name: redis-data
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:
-          claimName: {{ template "redis.fullname" . }}
+          claimName: {{ $fullname }}
       {{- else }}
         emptyDir:
           medium: Memory
@@ -99,6 +94,6 @@ spec:
       {{- if .Values.config }}
       - name: redis-config
         configMap:
-          name: {{ template "redis.fullname" . }}
+          name: {{ $fullname }}
           defaultMode: 0444
       {{- end }}

--- a/common/redis/templates/metrics-deployment.yaml
+++ b/common/redis/templates/metrics-deployment.yaml
@@ -42,13 +42,16 @@ spec:
               value: "{{ $fullname }}:6379"
             - name: REDIS_ALIAS
               value: {{ $fullname }}
-            {{ if .Values.redisPassword }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
+                  {{- if .Values.redisPassword }}
                   name: {{ $fullname }}
                   key: redis-password
-            {{ end }}
+                  {{- else }}
+                  name: {{ $fullname }}-user-default
+                  key: password
+                  {{- end }}
           ports:
             - name: metrics
               containerPort: 9121

--- a/common/redis/templates/metrics-deployment.yaml
+++ b/common/redis/templates/metrics-deployment.yaml
@@ -39,7 +39,7 @@ spec:
           imagePullPolicy: Always
           env:
             - name: REDIS_ADDR
-              value: {{ printf "%s:%d" $fullname (int .Values.redisPort) | quote }}
+              value: "{{ $fullname }}:6379"
             - name: REDIS_ALIAS
               value: {{ $fullname }}
             {{ if .Values.redisPassword }}
@@ -51,6 +51,6 @@ spec:
             {{ end }}
           ports:
             - name: metrics
-              containerPort: {{ required ".Values.metrics.port missing" .Values.metrics.port }}
+              containerPort: 9121
           resources: {{ toYaml .Values.metrics.resources | nindent 12 }}
 {{ end }}

--- a/common/redis/templates/metrics-deployment.yaml
+++ b/common/redis/templates/metrics-deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.metrics.enabled }}
+{{- $fullname := include "redis.fullname" . -}}
 
 {{- $dockerHubMirror := .Values.global.dockerHubMirror | required ".Values.global.dockerHubMirror missing" -}}
 {{- if .Values.useAlternateRegion -}}
@@ -9,39 +10,28 @@ kind: Deployment
 apiVersion: apps/v1
 
 metadata:
-  name: {{ template "redis.fullname" . }}-metrics
+  name: {{ $fullname }}-exporter
   labels:
-    app: {{ template "redis.fullname" . }}
-    chart: "{{ .Chart.Name }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: {{ $fullname }}
 
 spec:
   selector:
     matchLabels:
-      app: {{ template "redis.fullname" . }}
-      chart: "{{ .Chart.Name }}-1.0.1"
-      # ^ this is a lie, same reason as below
-      release: "{{ .Release.Name }}"
-      heritage: "Tiller"
-      # ^ this is not true when deploying with Helm 3, but existing matchLabels
-      # may not be changed by a Helm upgrade, so we have to stick with this
-      # legacy value (TODO: figure out a way to remove this label entirely)
+      app: {{ $fullname }}
   template:
     metadata:
       labels:
-        app: {{ template "redis.fullname" . }}
-        chart: "{{ .Chart.Name }}-1.0.1"
-        release: "{{ .Release.Name }}"
-        heritage: "Tiller"
+        app: {{ $fullname }}
       annotations:
-        kubectl.kubernetes.io/default-container: {{ template "redis.fullname" . }}
+        kubectl.kubernetes.io/default-container: {{ $fullname }}
+        {{- if .Values.redisPassword }}
         checksum/secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        {{- end }}
         {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
         linkerd.io/inject: enabled
         {{- end }}
         prometheus.io/scrape: "true"
-        prometheus.io/targets: {{ required ".Values.metrics.prometheus missing" .Values.metrics.prometheus | quote }}
+        prometheus.io/targets: {{ quote .Values.metrics.prometheus }}
     spec:
       containers:
         - name: metrics
@@ -49,19 +39,18 @@ spec:
           imagePullPolicy: Always
           env:
             - name: REDIS_ADDR
-              value: {{ printf "%s:%d" ( include "redis.fullname" . ) (int .Values.redisPort) | quote }}
+              value: {{ printf "%s:%d" $fullname (int .Values.redisPort) | quote }}
             - name: REDIS_ALIAS
-              value: {{ template "redis.fullname" . }}
+              value: {{ $fullname }}
             {{ if .Values.redisPassword }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "redis.fullname" . }}
+                  name: {{ $fullname }}
                   key: redis-password
             {{ end }}
           ports:
             - name: metrics
               containerPort: {{ required ".Values.metrics.port missing" .Values.metrics.port }}
-          resources:
-{{ toYaml .Values.metrics.resources | indent 12 }}
+          resources: {{ toYaml .Values.metrics.resources | nindent 12 }}
 {{ end }}

--- a/common/redis/templates/pvc.yaml
+++ b/common/redis/templates/pvc.yaml
@@ -1,12 +1,14 @@
 {{- if .Values.persistence.enabled }}
+{{- $fullname := include "redis.fullname" . -}}
+
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ template "redis.fullname" . }}
+  name: {{ $fullname }}
 spec:
   accessModes:
-    - {{ required ".Values.persistence.accessMode missing" .Values.persistence.accessMode | quote }}
+    - {{ quote .Values.persistence.accessMode }}
   resources:
     requests:
-      storage: {{ required ".Values.persistence.size missing" .Values.persistence.size | quote }}
+      storage: {{ quote .Values.persistence.size }}
 {{- end }}

--- a/common/redis/templates/rbac.yaml
+++ b/common/redis/templates/rbac.yaml
@@ -1,0 +1,49 @@
+{{- if not .Values.redisPassword }}
+{{- $fullname := include "redis.fullname" . -}}
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  # This service account is used by the redis pod itself.
+  name: {{ $fullname }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $fullname }}-secrets
+rules:
+  # The init container of the redis pods generates the
+  # `$RELEASE-redis-user-$USERNAME` secrets on first start.
+  - apiGroups: [ "" ]
+    resources: [ secrets ]
+    verbs:     [ get, delete ]
+    resourceNames:
+      - {{ $fullname }}-user-default
+
+  # "create" permission cannot be restricted to specific resourceNames
+  # Ref: <https://stackoverflow.com/a/65203104>
+  - apiGroups: [ "" ]
+    resources: [ secrets ]
+    verbs:     [ create ]
+
+  # need the UID of the redis deployment to render an owner reference
+  - apiGroups: [ apps ]
+    resources: [ deployments ]
+    verbs:     [ get ]
+    resourceNames: [ {{ $fullname }} ]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $fullname }}-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $fullname }}-secrets
+subjects:
+  - kind: ServiceAccount
+    name: {{ $fullname }}
+
+{{- end }}

--- a/common/redis/templates/secrets.yaml
+++ b/common/redis/templates/secrets.yaml
@@ -1,13 +1,10 @@
 {{- if .Values.redisPassword }}
+{{- $fullname := include "redis.fullname" . -}}
+
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "redis.fullname" . }}
-  labels:
-    app: {{ template "redis.fullname" . }}
-    chart: "{{ .Chart.Name }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+  name: {{ $fullname }}
 type: Opaque
 data:
   redis-password: {{ .Values.redisPassword | b64enc | quote }}

--- a/common/redis/templates/svc.yaml
+++ b/common/redis/templates/svc.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   ports:
   - name: redis
-    port: {{ .Values.redisPort }}
+    port: 6379
     targetPort: redis
   selector:
     app: {{ $fullname }}

--- a/common/redis/templates/svc.yaml
+++ b/common/redis/templates/svc.yaml
@@ -1,12 +1,9 @@
+{{- $fullname := include "redis.fullname" . -}}
+
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "redis.fullname" . }}
-  labels:
-    app: {{ template "redis.fullname" . }}
-    chart: "{{ .Chart.Name }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+  name: {{ $fullname }}
   annotations:
     {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
     linkerd.io/inject: enabled
@@ -14,7 +11,7 @@ metadata:
 spec:
   ports:
   - name: redis
-    port: {{ required ".Values.redisPort missing" .Values.redisPort }}
+    port: {{ .Values.redisPort }}
     targetPort: redis
   selector:
-    app: {{ template "redis.fullname" . }}
+    app: {{ $fullname }}

--- a/common/redis/values.yaml
+++ b/common/redis/values.yaml
@@ -1,7 +1,3 @@
-## Bitnami Redis image version
-## ref: https://hub.docker.com/r/bitnami/redis/tags/
-##
-
 # If enabled, image references use `.Values.registryAlternateRegion` etc. instead of `.Values.registry` etc.
 useAlternateRegion: false
 
@@ -9,9 +5,6 @@ image:
   # This tag must be valid within the Keppel repo ccloud/shared-app-images/alpine-valkey.
   # To pin to a specific image, replace this with a timestamped tag from there in values.yaml of the parent chart.
   tag: 8.0-20241028165807
-
-# Port for the Redis.
-redisPort: 6379
 
 ## Redis password
 ## ref: https://github.com/bitnami/bitnami-docker-redis#setting-the-server-password-on-first-run
@@ -44,9 +37,6 @@ metrics:
   image:
     # This tag must be valid within the Docker Hub repo oliver006/redis_exporter.
     tag: v1.67.0
-
-  # Port to expose metrics on.
-  port: 9121
 
   # Name of the Prometheus by which the metrics will be scraped.
   prometheus: openstack

--- a/common/redis/values.yaml
+++ b/common/redis/values.yaml
@@ -7,9 +7,12 @@ image:
   tag: 8.0-20241028165807
 
 ## Redis password
-## ref: https://github.com/bitnami/bitnami-docker-redis#setting-the-server-password-on-first-run
 ##
-# redisPassword:
+## WARNING: Setting this password explicitly is deprecated.
+## Leave this field unfilled to have the redis server autogenerate a password on first startup.
+## The password can be consumed from the secret "$RELEASE-redis-user-default" in the key "password".
+## To rotate the secret, delete it and restart the redis container to generate a new one.
+redisPassword: null
 
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/

--- a/common/redis/values.yaml
+++ b/common/redis/values.yaml
@@ -48,8 +48,8 @@ metrics:
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources
   resources:
     limits:
-      memory: 512Mi
+      memory: 64Mi
       cpu: 100m
     requests:
-      memory: 128Mi
+      memory: 64Mi
       cpu: 10m


### PR DESCRIPTION
Most of the changes are as described in the `Chart.yaml` diff.

Removing the label clutter from the metrics deployment podspec cannot be done as an in-place edit (in Deployment objects, `.spec.selector.matchLabels` is immutable for good reason), so this renames the deployment from "redis-metrics" to "redis-exporter" to allow the cleanup to proceed.

The password autogeneration capability is mostly copied from the respective capability in the `common/postgresql-ng` chart. The name pattern is slightly different in case users want to deploy multiple separate Redis instances (i.e., multiple instances of this chart) inside a single application chart.