### PR TITLE
[ceph] remove rgw exporter service account

### DIFF
--- a/system/cc-ceph/Chart.yaml
+++ b/system/cc-ceph/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cc-ceph
 description: A Helm chart for the Rook / Ceph Objects inside the Storage Clusters
 type: application
-version: 1.1.40
+version: 1.1.41
 appVersion: "1.16.2"
 dependencies:
   - name: owner-info

--- a/system/cc-ceph/templates/rgw-exporter-deployment.yaml
+++ b/system/cc-ceph/templates/rgw-exporter-deployment.yaml
@@ -19,6 +19,9 @@ spec:
       labels:
         app: {{ .Values.objectstore.name }}-ext-rgw-exporter
     spec:
+      # ensure that we use the default service account
+      serviceAccountName: ""
+      serviceAccount: ""
       containers:
       - name: prysm
         image: {{ .Values.objectstore.prysm.repository.image }}:{{ .Values.objectstore.prysm.repository.tag }}


### PR DESCRIPTION
otherwise the service account is being kept from the previous deployment