### PR TITLE
[ironic] switch to serial console for dell nodes

### DIFF
--- a/openstack/ironic/py/ironic-node-update.py
+++ b/openstack/ironic/py/ironic-node-update.py
@@ -21,7 +21,7 @@ patch_idrac = [
         "value": "idrac-redfish-virtual-media",
         "path": "/boot_interface",
     },
-    {"value": "idrac-redfish-kvm", "path": "/console_interface"},
+    {"value": "ipmitool-shellinabox", "path": "/console_interface"},
 ] + [
     {"value": "idrac-redfish", "path": i}
     for i in [


### PR DESCRIPTION
The idrac-redfish-kvm console is much more powerful than the serial
console but sadly it's also not properly working. We get logging issue
all the time so we switch back to the serial-console for dell nodes
which seems to work much better.
