### PR TITLE
[limes+billing] use global.domain_seeds.customer_domains (srs #485)

### DIFF
--- a/openstack/billing/ci/test-values.yaml
+++ b/openstack/billing/ci/test-values.yaml
@@ -1,4 +1,5 @@
 global:
   region: xx-yy-1
   vaultBaseURL: vault.example.com/secrets
-
+  domain_seeds:
+    customer_domains: [ bar, foo ]

--- a/openstack/billing/templates/seeds.yaml
+++ b/openstack/billing/templates/seeds.yaml
@@ -1,11 +1,9 @@
 {{- $vbase  := .Values.global.vaultBaseURL | required "missing value for .Values.global.vaultBaseURL" -}}
 {{- $region := .Values.global.region       | required "missing value for .Values.global.region"       -}}
 {{- $tld    := .Values.global.tld          | required "missing value for .Values.global.tld"          -}}
+{{- $cdomains := .Values.global.domain_seeds.customer_domains | required "missing value for .Values.global.domain_seeds.customer_domains" -}}
+{{- $domains  := concat (list "ccadmin") $cdomains -}}
 
-{{- $domains := list "ccadmin" "bs" "cis" "cp" "fsn" "hcp03" "hec" "monsoon3" "neo" "s4" "wbs"}}
-{{- if not .Values.global.domain_seeds.skip_hcm_domain -}}
-  {{- $domains = append $domains "hcm" }}
-{{- end -}}
 {{- if .Values.is_global -}}
   {{- $domains = list "ccadmin" "global" -}}
 {{- end -}}

--- a/openstack/limes/ci/test-values.yaml
+++ b/openstack/limes/ci/test-values.yaml
@@ -5,6 +5,8 @@ global:
   registry: registry.example.com
   quayIoMirror: registry.example.com/quayio
   vaultBaseURL: vault.example.com/secrets
+  domain_seeds:
+    customer_domains: [ bar, foo ]
 
 limes:
   image_tag: '19700101000000'

--- a/openstack/limes/templates/seed.yaml
+++ b/openstack/limes/templates/seed.yaml
@@ -1,9 +1,9 @@
 {{- $vbase  := .Values.global.vaultBaseURL | required "missing value for .Values.global.vaultBaseURL" -}}
 {{- $region := .Values.global.region       | required "missing value for .Values.global.region"       -}}
 {{- $is_global := $.Values.limes.clusters.ccloud.catalog_url | contains "global" -}}
+{{- $cdomains := .Values.global.domain_seeds.customer_domains | required "missing value for .Values.global.domain_seeds.customer_domains" -}}
+{{- $domains  := concat (list "cc3test") $cdomains -}}
 
-{{- $domains := list "bs" "btp_fp" "cc3test" "cp" "cis" "fsn" "hcm" "hcp03" "hda" "hec" "kyma" "monsoon3" "neo" "s4" "wbs" -}}
-{{- /* WARNING: When adding a new domain, also increment the domain count in the OpenstackLimesUnexpectedCloudDnsAdminRoleAssignments alert. */ -}}
 {{- if $is_global -}}
   {{- $domains = list "cc3test" "global" -}}
 {{- end -}}

--- a/openstack/limes/templates/support_seed.yaml
+++ b/openstack/limes/templates/support_seed.yaml
@@ -1,10 +1,8 @@
 {{- $is_global := $.Values.limes.clusters.ccloud.catalog_url | contains "global" -}}
 {{- $base_seed_namespace := $is_global | ternary "monsoon3global" "monsoon3" }}
 
-{{- $domains := list "ccadmin" "bs" "cis" "cp" "fsn" "hcp03" "hda" "hec" "monsoon3" "neo" "ora" "s4" "wbs"}}
-{{- if not .Values.global.domain_seeds.skip_hcm_domain -}}
-  {{- $domains = append $domains "hcm" }}
-{{- end -}}
+{{- $cdomains := .Values.global.domain_seeds.customer_domains | required "missing value for .Values.global.domain_seeds.customer_domains" -}}
+{{- $domains  := concat (list "ccadmin") $cdomains -}}
 {{- if $is_global -}}
   {{- $domains = list "ccadmin" "global" -}}
 {{- end -}}


### PR DESCRIPTION
I checked the diff and if you redact the ordering changes between the lists, the two diffs come out like this:
[limesdiff.txt](https://github.com/user-attachments/files/18863172/limesdiff.txt)
[billingdiff.txt](https://github.com/user-attachments/files/18863173/billingdiff.txt)

executive summary:
* there are only role additions, if I looked correctly nothing is missing afterwards
* billing: add roles `[DOMAIN]_API_SUPPORT`, `[DOMAIN]_COMPUTE_SUPPORT`, `[DOMAIN]_NETWORK_SUPPORT`, `[DOMAIN]_STORAGE_SUPPORT`, `[DOMAIN]_SERVICE_DESK` for `btp_fp, hcm, hcp03, kyma, iaas-... (bedrock)` domains
* limes: 
  * add roles `[DOMAIN]_DOMAIN_RESOURCE_ADMINS` for `ora, iaas-... (bedrock)` domains
  * add roles `[DOMAIN]_API_SUPPORT`,  `[DOMAIN]_COMPUTE_SUPPORT`, `[DOMAIN]_NETWORK_SUPPORT`, `[DOMAIN]_STORAGE_SUPPORT`, `[DOMAIN]_SERVICE_DESK` for `btp_fp, kyma, iaas-... (bedrock)`