### PR TITLE
[manila] rework share type seeding

### DIFF
--- a/openstack/manila/Chart.yaml
+++ b/openstack/manila/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: manila
 sources:
   - https://github.com/sapcc/manila
-version: 0.4.3
+version: 0.4.4
 dependencies:
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/manila/templates/type-seeds.yaml
+++ b/openstack/manila/templates/type-seeds.yaml
@@ -15,76 +15,22 @@ spec:
   requires:
   - monsoon3/manila-seed
   share_types:
-  - name: default
-    is_public: true
-    description: "High Performance"
-    specs:
-    {{- include "manila_type_seed.specs" . | indent 6 }}
-    extra_specs:
-      share_backend_name: "netapp-multi"
-      provisioning:max_share_size: "32768"
-      provisioning:max_share_extend_size: "32768" # keep this in sync with value "max_asset_sizes" of "- asset_type: 'nfs-shares.*'" in openstack/castellum/templates/configmap.yaml
-    {{- include "manila_type_seed.extra_specs" . | indent 6 }}
-  - name: integration
-    is_public: false
-    specs:
-    {{- include "manila_type_seed.specs" . | indent 6 }}
-    extra_specs:
-      share_backend_name: "integration"
-      provisioning:max_share_size: "32768"
-      provisioning:max_share_extend_size: "32768" # keep this in sync with value "max_asset_sizes" of "- asset_type: 'nfs-shares.*'" in openstack/castellum/templates/configmap.yaml
-    {{- include "manila_type_seed.extra_specs" . | indent 6 }}
   {{- range $shareTypeName, $shareTypeValues := .Values.share_types }}
-    {{- $enabled := false }}
-    {{- $old_style := false }}
-    {{- if not (kindIs "bool" $shareTypeValues) }}
-      {{- $enabled = $shareTypeValues.enabled }}
-    {{- else }}
-      {{- $old_style = true }}
-      {{- $enabled = $shareTypeValues }}
-    {{- end }}
-    {{- if $enabled }}
-      {{- if $shareTypeName | hasPrefix "hypervisor_storage" }}
+  {{- $shareTypeValues := kindIs "bool" $shareTypeValues | ternary (dict "enabled" $shareTypeValues) $shareTypeValues }}
+  {{- if $shareTypeValues.enabled }}
   - name: {{ $shareTypeName }}
-    is_public: false
+    is_public: {{ $shareTypeValues.is_public | default false }}
+    {{- if $shareTypeValues.description }}
+    description: {{ $shareTypeValues.description | quote }}
+    {{- end }}
     specs:
     {{- include "manila_type_seed.specs" . | indent 6 }}
     extra_specs:
-      share_backend_name: {{ $shareTypeName | quote }}
-    {{- include "manila_type_seed.extra_specs" . | indent 6 }}
-        {{- if not $old_style}}
-          {{- if hasKey $shareTypeValues "extra_specs" }}
-            {{- $shareTypeValues.extra_specs | toYaml | nindent 6 }}
-          {{- else }}
-      provisioning:max_share_size: "32768"
-      provisioning:max_share_extend_size: "32768" # keep this in sync with value "max_asset_sizes" of "- asset_type: 'nfs-shares.*'" in openstack/castellum/templates/configmap.yaml
-          {{- end }}
-        {{- else }}
-      provisioning:max_share_size: "32768"
-      provisioning:max_share_extend_size: "32768" # keep this in sync with value "max_asset_sizes" of "- asset_type: 'nfs-shares.*'" in openstack/castellum/templates/configmap.yaml
-        {{- end }}
-      {{- else if $shareTypeName | eq "standard" }} ## share type "standard"
-  - name: {{ $shareTypeName }}
-    is_public: false
-    description: "Standard"
-    specs:
-    {{- include "manila_type_seed.specs" . | indent 6 }}
-    extra_specs:
-      share_backend_name: {{ $shareTypeName | quote }}
-    {{- include "manila_type_seed.extra_specs" . | indent 6 }}
-        {{- if not $old_style}}
-          {{- if hasKey $shareTypeValues "extra_specs" }}
-            {{- $shareTypeValues.extra_specs | toYaml | nindent 6 }}
-          {{- else }}
-      provisioning:max_share_size: "65536"
-      provisioning:max_share_extend_size: "65536" # keep this in sync with value "max_asset_sizes" of "- asset_type: 'nfs-shares.*'" in openstack/castellum/templates/configmap.yaml
-          {{- end }}
-        {{- else }}
-      provisioning:max_share_size: "65536"
-      provisioning:max_share_extend_size: "65536" # keep this in sync with value "max_asset_sizes" of "- asset_type: 'nfs-shares.*'" in openstack/castellum/templates/configmap.yaml
-        {{- end }}
-      {{- end }}
+    {{ $extraSpecs :=  $.Values.share_type_extra_specs | merge (dict "share_backend_name" $shareTypeName) | merge (default (dict) $shareTypeValues.extra_specs) }}
+    {{- range $key, $value := $extraSpecs }}
+      {{ $key }}: {{ $value | quote }}
     {{- end }}
+  {{- end }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/openstack/manila/values.yaml
+++ b/openstack/manila/values.yaml
@@ -687,13 +687,50 @@ seeds:
 share_ensure:
   enabled: true
 
+share_type_extra_specs:
+  compression: "<is> True"
+  create_share_from_snapshot_support: "True"
+  dedupe: "<is> True"
+  replication_type: "dr"
+  revert_to_snapshot_support: "True"
+  netapp:hide_snapdir: "True"
+  netapp:max_files_multiplier: "4.813"  # 33.6925 / 7 -> roughly 1 inode per 7 KB
+  netapp:snapshot_policy: "none"
+  netapp:split_clone_on_create: "True"
+  netapp:tcp_max_xfer_size: "262144"  # ccloud 256 KB, system default for ONTAP 9.5 was 64 KB
+  netapp:thin_provisioned: "True"     # netapp_flexvol_encryption: "True"
+  provisioning:max_share_size: "32768"
+  provisioning:max_share_extend_size: "32768" # keep this in sync with value "max_asset_sizes" of "- asset_type: 'nfs-shares.*'" in openstack/castellum/templates/configmap.yaml
+
 share_types:
-  hypervisor_storage:
+  default:
+    enabled: true
+    is_public: true
+    description: "High Performance"
+    extra_specs:
+      share_backend_name: "netapp-multi"
+  integration:
+    enabled: true
+  standard:
+    enabled: false
+    description: "Standard"
+    extra_specs:
+      provisioning:max_share_size: "65536"
+      provisioning:max_share_extend_size: "65536" # keep this in sync with castellum
+  hypervisor_storage_hana_qa:
     enabled: false
     extra_specs:
       provisioning:min_share_size: "2048"
       provisioning:max_share_size: "40960"
-  btp_backup: false # old style -> move to specifying a key 'enabled: false'
+  hypervisor_storage:
+    enabled: false
+  hypervisor_storage_hanalytics:
+    enabeld: false
+  hypervisor_storage_vim:
+    enabeld: false
+  btp_backup:
+    enabled: false
+
 
 # netapp filer back ends, required input
 # netapp:


### PR DESCRIPTION
This PR moves customisation of share type's extra_specs to value files.
We merge `share_type_extra_specs` into `share_types.*.extra_specs`, with latter takes precedence.
The share type name is used as `share_backend_name` if otherwise not specified.
We can also set bool value to any item in the share type list,
but then default `share_type_extra_specs` is used, and  any customisation would be lost.