### PR TITLE
fix(logs): changes failover retry

### DIFF
--- a/system/logs/templates/opentelemetry-logs-collector.yaml
+++ b/system/logs/templates/opentelemetry-logs-collector.yaml
@@ -249,8 +249,8 @@ spec:
         priority_levels:
           - [logs/failover_a]
           - [logs/failover_b]
-        retry_interval: 1h
-        retry_gap: 15m
+        retry_interval: 20m
+        retry_gap: 5m
         max_retries: 0
     service:
       extensions:


### PR DESCRIPTION
In-case of OpenSearch (logs sink) is experiencing any kind of downtimes we sometimes get errors such as:


```
error    internal/base_exporter.go:139    Exporting failed. Rejecting data.    {"kind": "exporter", "data_type": "logs", "name": "opensearch/failover_a"....
```
The [failover connector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/failoverconnector) will retry this with a backoff of `retry_interval` and `retry_gap`. This PR reduces both of these parameters in favour of having quicker retry attempts, both when backing off (test-sleep-test) and attempting secondary failover credentials (a-sleep-b).