### PR TITLE
[mariadb] fix maintenance cronjob resource names

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.16.3 - 2025/02/19
+* fix names of the maintenance cronjob resources
+  * make cm names unique
+* chart version bumped
+
 ## v0.16.2 - 2025/02/14
 - maintenance job added
   - currently the [analyze table](https://mariadb.com/kb/en/analyze-table/) task is supported

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.16.2
+version: 0.16.3

--- a/common/mariadb/templates/configmap-mariadb-maintenance.yaml
+++ b/common/mariadb/templates/configmap-mariadb-maintenance.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   namespace: {{ $.Release.Namespace }}
-  name: mariadb-cronjob-maintenance
+  name: mariadb-{{ .Values.name }}-cronjob-maintenance
   labels:
     {{- include "mariadb.labels" (list $ "version" "mariadb" "cm" "maintenance") | indent 4 }}
 data:

--- a/common/mariadb/templates/cronjob-mariadb-maintenance.yaml
+++ b/common/mariadb/templates/cronjob-mariadb-maintenance.yaml
@@ -3,7 +3,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   namespace: {{ $.Release.Namespace }}
-  name: {{ include "fullName" . }}-maint-{{ randAlphaNum 4 | lower }}
+  name: {{ include "fullName" . }}-maintenance-{{ randAlphaNum 4 | lower }}
   labels:
     {{- include "mariadb.labels" (list $ "version" "mariadb" "cronjob" "maintenance") | indent 4 }}
 spec:


### PR DESCRIPTION
* fix names of the maintenance cronjob resources
  * make names unique
* chart version bumped