### PR TITLE
[limes+billing] fix domain_seeds.customer_domains requires (srs #547)

### DIFF
--- a/openstack/billing/templates/seeds.yaml
+++ b/openstack/billing/templates/seeds.yaml
@@ -16,7 +16,7 @@ spec:
   requires:
     {{- $base_seed_namespace := .Values.is_global | ternary "monsoon3global" "monsoon3" }}
     {{- range $domains }}
-    - {{ $base_seed_namespace }}/domain-{{ . | lower }}-seed
+    - {{ $base_seed_namespace }}/domain-{{replace "_" "-" .|lower}}-seed
     {{- end }}
     - {{ $base_seed_namespace }}/domain-cc3test-seed
     {{- if not .Values.is_global }}

--- a/openstack/limes/templates/support_seed.yaml
+++ b/openstack/limes/templates/support_seed.yaml
@@ -16,7 +16,7 @@ spec:
   requires:
   - {{ .Release.Namespace }}/limes-seed
   {{- range $domains }}
-  - {{ $base_seed_namespace }}/domain-{{ . | lower }}-seed
+  - {{ $base_seed_namespace }}/domain-{{replace "_" "-" .|lower}}-seed
   {{- end }}
 
   domains:


### PR DESCRIPTION
```
0219 14:05:30.933068      11 controller.go:437] ERROR: dependency 'monsoon3/domain-btp_fp-seed' of 'billing/billing-seed' not found
```