### PR TITLE
[limes+billing+keppel] fix iaas-domain group name lcase (srs #485)

### DIFF
--- a/openstack/billing/templates/seeds.yaml
+++ b/openstack/billing/templates/seeds.yaml
@@ -131,7 +131,7 @@ spec:
       - project: cc-demo
         role: masterdata_admin
     {{- end }}
-    - name: {{ . | upper }}_API_SUPPORT
+    - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_API_SUPPORT
       role_assignments:
       - project: api_support
         role: masterdata_admin
@@ -143,7 +143,7 @@ spec:
         role: masterdata_admin
         inherited: true
   {{- if ne . "global" }}
-    - name: {{ . | upper }}_COMPUTE_SUPPORT
+    - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_COMPUTE_SUPPORT
       role_assignments:
       - project: compute_support
         role: masterdata_admin
@@ -154,7 +154,7 @@ spec:
       - domain: {{ . | lower }}
         role: masterdata_viewer
         inherited: true
-    - name: {{ . | upper }}_NETWORK_SUPPORT
+    - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_NETWORK_SUPPORT
       role_assignments:
       - project: network_support
         role: masterdata_admin
@@ -165,7 +165,7 @@ spec:
       - domain: {{ . | lower }}
         role: masterdata_viewer
         inherited: true
-    - name: {{ . | upper }}_STORAGE_SUPPORT
+    - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_STORAGE_SUPPORT
       role_assignments:
       - project: storage_support
         role: masterdata_admin
@@ -176,7 +176,7 @@ spec:
       - domain: {{ . | lower }}
         role: masterdata_viewer
         inherited: true
-    - name: {{ . | upper }}_SERVICE_DESK
+    - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_SERVICE_DESK
       role_assignments:
       - project: service_desk
         role: masterdata_admin

--- a/openstack/keppel/templates/seed.yaml
+++ b/openstack/keppel/templates/seed.yaml
@@ -89,7 +89,7 @@ spec:
     {{- range $domains }}
     - name: {{.}}
       groups:
-        - name: {{. | upper}}_DOMAIN_REGISTRY_ADMINS
+        - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_DOMAIN_REGISTRY_ADMINS
           role_assignments:
             - domain: {{.}}
               role: registry_admin

--- a/openstack/keppel/templates/support_seed.yaml
+++ b/openstack/keppel/templates/support_seed.yaml
@@ -17,7 +17,7 @@ spec:
     {{- range $domains }}
     - name: {{ . | lower }}
       groups:
-      - name: {{ . | upper }}_API_SUPPORT
+      - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_API_SUPPORT
         role_assignments:
         - project: api_support
           role: registry_admin
@@ -29,7 +29,7 @@ spec:
         - domain: {{ . | lower }}
           role: registry_viewer
           inherited: true
-      - name: {{ . | upper }}_STORAGE_SUPPORT
+      - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_STORAGE_SUPPORT
         role_assignments:
         - project: storage_support
           role: registry_admin
@@ -41,7 +41,7 @@ spec:
         - domain: {{ . | lower }}
           role: registry_viewer
           inherited: true
-      - name: {{ . | upper }}_SERVICE_DESK
+      - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_SERVICE_DESK
         role_assignments:
         - project: service_desk
           role: registry_admin

--- a/openstack/limes/templates/seed.yaml
+++ b/openstack/limes/templates/seed.yaml
@@ -113,7 +113,7 @@ spec:
     {{- range $domains }}
     - name: {{ . | lower }}
       groups:
-      - name: {{ . | upper }}_DOMAIN_RESOURCE_ADMINS
+      - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_DOMAIN_RESOURCE_ADMINS
         role_assignments:
         - domain: {{ . | lower }}
           role: resource_admin

--- a/openstack/limes/templates/support_seed.yaml
+++ b/openstack/limes/templates/support_seed.yaml
@@ -23,7 +23,7 @@ spec:
     {{- range $domains }}
     - name: {{ . | lower }}
       groups:
-      - name: {{ . | upper }}_API_SUPPORT
+      - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_API_SUPPORT
         role_assignments:
         - project: api_support
           role: resource_admin
@@ -36,7 +36,7 @@ spec:
           role: resource_viewer
           inherited: true
       {{- if ne . "global" }}
-      - name: {{ . | upper }}_COMPUTE_SUPPORT
+      - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_COMPUTE_SUPPORT
         role_assignments:
         - project: compute_support
           role: resource_admin
@@ -48,7 +48,7 @@ spec:
         - domain: {{ . | lower }}
           role: resource_viewer
           inherited: true
-      - name: {{ . | upper }}_NETWORK_SUPPORT
+      - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_NETWORK_SUPPORT
         role_assignments:
         - project: network_support
           role: resource_admin
@@ -60,7 +60,7 @@ spec:
         - domain: {{ . | lower }}
           role: resource_viewer
           inherited: true
-      - name: {{ . | upper }}_STORAGE_SUPPORT
+      - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_STORAGE_SUPPORT
         role_assignments:
         - project: storage_support
           role: resource_admin
@@ -72,7 +72,7 @@ spec:
         - domain: {{ . | lower }}
           role: resource_viewer
           inherited: true
-      - name: {{ . | upper }}_SERVICE_DESK
+      - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_SERVICE_DESK
         role_assignments:
         - project: service_desk
           role: resource_admin


### PR DESCRIPTION
I hope I caught everything:

[keppeldiff.txt](https://github.com/user-attachments/files/18884997/keppeldiff.txt)
[limesdiff.txt](https://github.com/user-attachments/files/18884998/limesdiff.txt)
[billingdiff.txt](https://github.com/user-attachments/files/18885000/billingdiff.txt)

If you have a nicer way to write this, let me know. I thought about `mustRegexReplaceAll`, but turns out that advanced replacements to something like `\L$1` are not supported.