### PR TITLE
[keystone][rabbitmq] remove unused rabbitmq from templates

### DIFF
--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: keystone
 sources:
   - https://github.com/sapcc/keystone
-version: 0.8.1
+version: 0.8.2
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/keystone/ci/test-values.yaml
+++ b/openstack/keystone/ci/test-values.yaml
@@ -3,7 +3,7 @@ global:
   db_region: local
   region: test
   master_password: test
-  registryAlternateRegion: test  
+  registryAlternateRegion: test
   dockerHubMirror: mirror0
   dockerHubMirrorAlternateRegion: test2
   osprofiler:
@@ -22,12 +22,3 @@ cron:
 osprofiler:
   jager:
     enabled: true
-
-rabbitmq:
-  users:
-    default:
-      password: topSecret
-    admin:
-      password: topSecret
-  metrics:
-    password: topSecret

--- a/openstack/keystone/templates/_helpers.tpl
+++ b/openstack/keystone/templates/_helpers.tpl
@@ -35,16 +35,6 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 
-{{- define "rabbitmq_host" -}}
-{{- if .Values.global.clusterDomain -}}
-{{.Release.Name}}-rabbitmq.{{.Release.Namespace}}.svc.{{.Values.global.clusterDomain}}
-{{- else if .Values.global_setup -}}
-{{.Release.Name}}-rabbitmq.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.db_region}}.{{.Values.global.tld}}
-{{- else -}}
-{{.Release.Name}}-rabbitmq.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.region}}.{{.Values.global.tld}}
-{{- end -}}
-{{- end -}}
-
 {{/*
 To satisfy common/mysql_metrics :(
 */}}

--- a/openstack/keystone/templates/etc/_secrets.conf.tpl
+++ b/openstack/keystone/templates/etc/_secrets.conf.tpl
@@ -40,10 +40,6 @@ heartbeat_timeout_threshold = {{ .Values.audit.central_service.heartbeat_timeout
       It is exploiting a bug in the logic which seems to be triggered
       when rabbit_interval_max >= rabbit_retry_interval
 */}}
-  {{- else if .Values.rabbitmq.host }}
-transport_url = rabbit://{{ .Values.rabbitmq.users.default.user | default "rabbitmq" }}:{{ .Values.rabbitmq.users.default.password | include "resolve_secret_urlquery" }}@{{ .Values.rabbitmq.host }}:{{ .Values.rabbitmq.port | default 5672 }}
-  {{ else }}
-transport_url = rabbit://{{ .Values.rabbitmq.users.default.user | default "rabbitmq" }}:{{ .Values.rabbitmq.users.default.password | include "resolve_secret_urlquery" }}@{{ include "rabbitmq_host" . }}:{{ .Values.rabbitmq.port | default 5672 }}
   {{- end }}
 {{- end }}
 


### PR DESCRIPTION
remove unused rabbitmq from templates, because it was removed in PR #3859