### PR TITLE
[keystone] MariaDB chart version bumped to 0.16.3

### DIFF
--- a/openstack/keystone/Chart.lock
+++ b/openstack/keystone/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.14.2
+  version: 0.16.3
 - name: mariadb-galera
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.29.3
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.4
-digest: sha256:6e608d38f5aed8d81e803f77462f441132614f6487e6ca037e7dc61a2b47ae60
-generated: "2024-11-27T16:00:14.156431+05:30"
+digest: sha256:eed657eef58fbecbd29256c844b0a9e1a027799e162919cf9a6a30406c278bca
+generated: "2025-02-21T10:13:01.500957+01:00"

--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -9,12 +9,12 @@ maintainers:
 name: keystone
 sources:
   - https://github.com/sapcc/keystone
-version: 0.8.2
+version: 0.9.0
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.14.2
+    version: 0.16.3
   - condition: mariadb_galera.enabled
     name: mariadb-galera
     alias: mariadb_galera

--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -292,6 +292,13 @@ mariadb:
     # The maximum available capacity is split evenly across containers specified in the Deployment, StatefulSet or DaemonSet to derive the upper recommendation bound. This does not work out for pods with a single resource-hungry container with several sidecar containers
     # Annotate the Deployment, StatefulSet or DaemonSet with vpa-butler.cloud.sap/main-container=$MAIN_CONTAINER. That will distribute 75% of the maximum available capacity to the main container and the rest evenly across all others
     set_main_container: true
+  job:
+    maintenance:
+      enabled: false
+      function:
+        analyzeTable:
+          enabled: true
+          allTables: true
 
 # MariaDB Galera cluster as database backend
 # mariadb.enabled has to be false if Galera is enabled


### PR DESCRIPTION
- to be able to use the new maintenance job feature
- job options added to values.yaml (disabled by default)