### PR TITLE
Fixed bedrock alerting template

### DIFF
--- a/prometheus-rules/prometheus-vmware-rules/Chart.yaml
+++ b/prometheus-rules/prometheus-vmware-rules/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A collection of Prometheus alert rules.
 name: prometheus-vmware-rules
-version: 1.1.2
+version: 1.1.3
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/prometheus-rules/prometheus-vmware-rules/alerts/host.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/host.alerts
@@ -196,7 +196,7 @@ groups:
 
   - alert: HADetectedAPossibleHostFailure
     expr: |
-      vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) has detected a possible host failure"} 
+      vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) has detected a possible host failure"}
       and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!~"inMaintenance", vccluster!~".*controlplane-swift"}
     labels:
       severity: critical

--- a/prometheus-rules/prometheus-vmware-rules/templates/_helper.tpl
+++ b/prometheus-rules/prometheus-vmware-rules/templates/_helper.tpl
@@ -17,12 +17,12 @@ Description:
 {{- define "bedrockConfirm.expr" -}}
 {{- $expr := index . 0 -}}
 {{- $mappingKey := index . 1 -}}
-expr: >
+expr: |
   label_replace(
       {{ $expr }} unless on({{ $mappingKey }})
       (
           group by (project, {{ $mappingKey }}) (
-              vrops_virtualmachine_system_powered_on{region="eu-de-1", vccluster=~"^productionbb\\d+$"}
+              vrops_virtualmachine_system_powered_on{region="eu-de-1", vccluster=~"productionbb\\d+"}
           )
           and on(project) 
           group by (project) (
@@ -38,7 +38,7 @@ expr: >
       {{ $expr }} and on({{ $mappingKey }})
       (
           group by (project, {{ $mappingKey }}) (
-              vrops_virtualmachine_system_powered_on{region="eu-de-1", vccluster=~"^productionbb\\d+$"}
+              vrops_virtualmachine_system_powered_on{region="eu-de-1", vccluster=~"productionbb\\d+"}
           )
           and on(project) 
           group by (project) (

--- a/prometheus-rules/prometheus-vmware-rules/templates/_helper.tpl
+++ b/prometheus-rules/prometheus-vmware-rules/templates/_helper.tpl
@@ -17,37 +17,36 @@ Description:
 {{- define "bedrockConfirm.expr" -}}
 {{- $expr := index . 0 -}}
 {{- $mappingKey := index . 1 -}}
-expr: |
-  label_replace(
-      {{ $expr }} unless on({{ $mappingKey }})
-      (
-          group by (project, {{ $mappingKey }}) (
-              vrops_virtualmachine_system_powered_on{region="eu-de-1", vccluster=~"productionbb\\d+"}
-          )
-          and on(project) 
-          group by (project) (
-              label_replace(
-                  limes_project_usage{domain=~"iaas-.*"},
-                  "project", "$$1", "project_id", "(.*)"
-              )
-          )
-      ),
-      "bedrock", "false", "bedrock", "")
-  or
-  label_replace(
-      {{ $expr }} and on({{ $mappingKey }})
-      (
-          group by (project, {{ $mappingKey }}) (
-              vrops_virtualmachine_system_powered_on{region="eu-de-1", vccluster=~"productionbb\\d+"}
-          )
-          and on(project) 
-          group by (project) (
-              label_replace(
-                  limes_project_usage{domain=~"iaas-.*"},
-                  "project", "$$1", "project_id", "(.*)"
-              )
-          )
-      ),
-      "bedrock", "true", "bedrock", ""
-  )
+label_replace(
+    {{ $expr }} unless on({{ $mappingKey }})
+    (
+        group by (project, {{ $mappingKey }}) (
+            vrops_virtualmachine_system_powered_on{region="eu-de-1", vccluster=~"productionbb\\d+"}
+        )
+        and on(project)
+        group by (project) (
+            label_replace(
+                limes_project_usage{domain=~"iaas-.*"},
+                "project", "$$1", "project_id", "(.*)"
+            )
+        )
+    ),
+    "bedrock", "false", "bedrock", "")
+or
+label_replace(
+    {{ $expr }} and on({{ $mappingKey }})
+    (
+        group by (project, {{ $mappingKey }}) (
+            vrops_virtualmachine_system_powered_on{region="eu-de-1", vccluster=~"productionbb\\d+"}
+        )
+        and on(project)
+        group by (project) (
+            label_replace(
+                limes_project_usage{domain=~"iaas-.*"},
+                "project", "$$1", "project_id", "(.*)"
+            )
+        )
+    ),
+    "bedrock", "true", "bedrock", ""
+)
 {{- end -}}

--- a/prometheus-rules/prometheus-vmware-rules/templates/prometheus-alerts.yaml
+++ b/prometheus-rules/prometheus-vmware-rules/templates/prometheus-alerts.yaml
@@ -28,6 +28,9 @@ Get all rules in group
 */}}
 {{- range $rule := $group.rules }}
 {{- if has $rule.alert (keys $filteredBedrockAlerts) }}
+{{- /*
+Replace expression for alerts matching alert name in $bedrockAlerts
+*/}}
       {{- $mappingKey := (printf "%s" (get $bedrockAlerts $rule.alert)) }}
       {{- $updatedExpression := (include "bedrockConfirm.expr" (list $rule.expr $mappingKey)) }}
       {{- $_ := set $rule "expr" $updatedExpression }}

--- a/prometheus-rules/prometheus-vmware-rules/templates/prometheus-alerts.yaml
+++ b/prometheus-rules/prometheus-vmware-rules/templates/prometheus-alerts.yaml
@@ -30,7 +30,7 @@ This fix applies replacements in place.
 {{- if has $alertname (keys $filteredBedrockAlerts) }}
 {{- $mappingKey := (printf "%s" (get $bedrockAlerts $alertname)) }}
 {{ regexReplaceAll "([\\s\\S]+?- alert: \\S+)\\n([\\s\\S]+?expr:[\\s\\S]+)" $alert "${1}" | indent 2 }}
-{{ regexReplaceAll "[\\s\\S]+expr.+?(>\\n|\\w|\\|\\n)\\s+([\\s\\S]+?)\\s+\\S+:[\\s\\S]+" $alert (include "bedrockConfirm.expr" (list "$2" $mappingKey)) | indent 6 }}
+{{ regexReplaceAll "[\\s\\S]+expr:.(\\|\\n|\\>\\n|)([\\s\\S]+?)\\s+\\S+:[\\s\\S]+" $alert (include "bedrockConfirm.expr" (list "$2" $mappingKey)) | indent 6 }}
 {{- regexReplaceAll "([\\s\\S]+?expr:[\\s\\S]+?)\\n(\\s+\\S+:[\\s\\S]+)" $alert "${2}" | nindent 2 }}
 {{- else }}
 {{ printf "%s" $alert | indent 2 }}

--- a/prometheus-rules/prometheus-vmware-rules/templates/prometheus-alerts.yaml
+++ b/prometheus-rules/prometheus-vmware-rules/templates/prometheus-alerts.yaml
@@ -18,23 +18,22 @@ metadata:
     prometheus: {{ include "prometheusVMware.name" (list $target $root) }}
 
 spec:
-{{- $string := $bytes | toString }}
+{{- $yaml := $bytes | toString | fromYaml }}
 {{- /* 
-Replaces special whitespace characters to ensure correct YAML formatting. 
-Previously, improper indentation and line breaks caused alerts to be unmatched. 
-This fix applies replacements in place. 
+Iterate over group elements
 */}}
-{{- $string := (regexReplaceAll "\\n\\s+\\n" $string "\n\n") }}
-{{- range $alert := splitList "\n\n" $string }}
-{{- $alertname := (regexReplaceAll "[\\s\\S]+?alert: (\\S+)\\n[\\s\\S]+" $alert "${1}") }}
-{{- if has $alertname (keys $filteredBedrockAlerts) }}
-{{- $mappingKey := (printf "%s" (get $bedrockAlerts $alertname)) }}
-{{ regexReplaceAll "([\\s\\S]+?- alert: \\S+)\\n([\\s\\S]+?expr:[\\s\\S]+)" $alert "${1}" | indent 2 }}
-{{ regexReplaceAll "[\\s\\S]+expr:.(\\|\\n|\\>\\n|)([\\s\\S]+?)\\s+\\S+:[\\s\\S]+" $alert (include "bedrockConfirm.expr" (list "$2" $mappingKey)) | indent 6 }}
-{{- regexReplaceAll "([\\s\\S]+?expr:[\\s\\S]+?)\\n(\\s+\\S+:[\\s\\S]+)" $alert "${2}" | nindent 2 }}
-{{- else }}
-{{ printf "%s" $alert | indent 2 }}
+{{- range $group := $yaml.groups }} 
+{{- /*
+Get all rules in group
+*/}}
+{{- range $rule := $group.rules }}
+{{- if has $rule.alert (keys $filteredBedrockAlerts) }}
+      {{- $mappingKey := (printf "%s" (get $bedrockAlerts $rule.alert)) }}
+      {{- $updatedExpression := (include "bedrockConfirm.expr" (list $rule.expr $mappingKey)) }}
+      {{- $_ := set $rule "expr" $updatedExpression }}
+{{- end }} 
 {{- end }}
 {{- end }}
+  groups: {{- $yaml.groups | toYaml | nindent 2 }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
- Updated regex in `prometheus-alerts.yaml` to match expresssions like `expr: mymetric1 > mymetric2` correctly in past the regex produced wrong output.

_Example_
```bash
      expr: |   
      > mymetric2...
```

- Updated `_helper.tpl` replace `expr: >` to `expr: |` for bedrock alertings