### PR TITLE
[mariadb] Fix maria_backup_status alerts

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.16.4 - 2025/02/21
+* fix maria-back-me-up alert rules
+* chart version bumped
+
 ## v0.16.3 - 2025/02/19
 * fix names of the maintenance cronjob resources
   * make cm names unique

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.16.3
+version: 0.16.4

--- a/common/mariadb/templates/alerts/_backup-v2.alerts.tpl
+++ b/common/mariadb/templates/alerts/_backup-v2.alerts.tpl
@@ -1,7 +1,7 @@
 - name: backup-v2.alerts
   rules:
   - alert: {{ include "alerts.service" . | title }}MariaDatabaseFullBackupMissing
-    expr: maria_backup_status{kind="full_backup", release={{ include "alerts.service" . | quote }} } != 1
+    expr: maria_backup_status{kind="full_backup", app_kubernetes_io_instance=~"{{ include "fullName" . }}" } != 1
     for: 4h
     labels:
       context: "{{ .Release.Name }}"
@@ -14,7 +14,7 @@
       summary: {{ include "fullName" . }} full backup missing
 
   - alert: {{ include "alerts.service" . | title }}MariaDatabaseIncBackupMissing
-    expr: maria_backup_status{kind="inc_backup", release={{ include "alerts.service" . | quote }} } != 1
+    expr: maria_backup_status{kind="inc_backup", app_kubernetes_io_instance=~"{{ include "fullName" . }}" } != 1
     for: {{ mul .Values.backup_v2.incremental_backup_in_minutes 5 }}m
     labels:
       context: "{{ .Release.Name }}"
@@ -28,7 +28,7 @@
 
 {{- if .Values.backup_v2.verification.enabled }}
   - alert: {{ include "alerts.service" . | title }}MariaDatabaseBackupVerificationFailed
-    expr: sum(maria_backup_verify_status{service=~"{{  include "alerts.service" . }}.*" }) < 1
+    expr: sum(maria_backup_verify_status{app_kubernetes_io_instance=~"{{ include "fullName" . }}" }) < 1
     for: 16h
     labels:
       context: "{{ .Release.Name }}"


### PR DESCRIPTION
Fix backup-v2 maria_backup_status alerts.

There never were `release` labels on a backup-v2 deployment.

`app_kubernetes_io_instance` should be used, same as for mysqld-exporter alerts.