### PR TITLE
[ns-exporter] Fix time in ns-prober alert message

### DIFF
--- a/prometheus-exporters/ns-exporter/alerts/probe.alerts
+++ b/prometheus-exporters/ns-exporter/alerts/probe.alerts
@@ -23,7 +23,7 @@ groups:
       meta: 'Network {{ $labels.network_name }} failed all probes'
       cloudops: "?searchTerm={{ $labels.network_id }}&type=network"
     annotations:
-      description: 'The network `{{ $labels.network_name }} ({{ $labels.network_id }})` on agent `{{ $labels.agent }}` failed all DNS probes for more than 10 minutes. (<https://dashboard.{{ $externalLabels.region }}.cloud.sap/ccadmin/cloud_admin/cloudops#/universal-search/?searchTerm={{ $labels.router }}&type=router|Router {{ $labels.router }}>). Please run ```hammer -r {{ $externalLabels.region }} net check {{ $labels.network_id }}``` and post it on the alert Slack thread.'
+      description: 'The network `{{ $labels.network_name }} ({{ $labels.network_id }})` on agent `{{ $labels.agent }}` failed all DNS probes for more than 5 minutes. (<https://dashboard.{{ $externalLabels.region }}.cloud.sap/ccadmin/cloud_admin/cloudops#/universal-search/?searchTerm={{ $labels.router }}&type=router|Router {{ $labels.router }}>). Please run ```hammer -r {{ $externalLabels.region }} net check {{ $labels.network_id }}``` and post it on the alert Slack thread.'
       summary: Network probes failed
   - alert: NetworkNamespaceProbesFailedForShootNetworkWeekdays
     expr: |
@@ -50,7 +50,7 @@ groups:
       meta: 'Network {{ $labels.network_name }} failed all probes'
       cloudops: "?searchTerm={{ $labels.network_id }}&type=network"
     annotations:
-      description: 'The network `{{ $labels.network_name }} ({{ $labels.network_id }})` on agent `{{ $labels.agent }}` failed all DNS probes for more than 10 minutes. (<https://dashboard.{{ $externalLabels.region }}.cloud.sap/ccadmin/cloud_admin/cloudops#/universal-search/?searchTerm={{ $labels.router }}&type=router|Router {{ $labels.router }}>).
+      description: 'The network `{{ $labels.network_name }} ({{ $labels.network_id }})` on agent `{{ $labels.agent }}` failed all DNS probes for more than 5 minutes. (<https://dashboard.{{ $externalLabels.region }}.cloud.sap/ccadmin/cloud_admin/cloudops#/universal-search/?searchTerm={{ $labels.router }}&type=router|Router {{ $labels.router }}>).
 Please run ```hammer -r {{ $externalLabels.region }} net check {{ $labels.network_id }}``` and post it on the alert Slack thread.'
       summary: Network probes failed for `shoot--` networks.
   - alert: NetworkNamespaceProbesFailedForShootNetworkWeekend
@@ -78,7 +78,7 @@ Please run ```hammer -r {{ $externalLabels.region }} net check {{ $labels.networ
       meta: 'Network {{ $labels.network_name }} failed all probes'
       cloudops: "?searchTerm={{ $labels.network_id }}&type=network"
     annotations:
-      description: 'The network `{{ $labels.network_name }} ({{ $labels.network_id }})` on agent `{{ $labels.agent }}` failed all DNS probes for more than 10 minutes. (<https://dashboard.{{ $externalLabels.region }}.cloud.sap/ccadmin/cloud_admin/cloudops#/universal-search/?searchTerm={{ $labels.router }}&type=router|Router {{ $labels.router }}>).
+      description: 'The network `{{ $labels.network_name }} ({{ $labels.network_id }})` on agent `{{ $labels.agent }}` failed all DNS probes for more than 5 minutes. (<https://dashboard.{{ $externalLabels.region }}.cloud.sap/ccadmin/cloud_admin/cloudops#/universal-search/?searchTerm={{ $labels.router }}&type=router|Router {{ $labels.router }}>).
 Please run ```hammer -r {{ $externalLabels.region }} net check {{ $labels.network_id }}``` and post it on the alert Slack thread.'
       summary: Network probes failed for `shoot` networks.
   - alert: NetworkNamespaceProbeMetricsMissing


### PR DESCRIPTION
As we're now alerting after 5 minutes for problematic networks our alert message should also say 5 minutes.