### PR TITLE
[mariadb] set default ignore_db_dirs value

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.16.5 - 2025/02/21
+* add `lost+found` to `ignore_db_dirs` list
+* chart version bumped
+
 ## v0.16.4 - 2025/02/21
 * fix maria-back-me-up alert rules
 * chart version bumped

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.16.4
+version: 0.16.5

--- a/common/mariadb/templates/etc-configmap.yaml
+++ b/common/mariadb/templates/etc-configmap.yaml
@@ -24,6 +24,7 @@ data:
     query_cache_size          = {{ .Values.query_cache_size }}
     query_cache_type          = {{ .Values.query_cache_type }}
     join_buffer_size          = {{ .Values.join_buffer_size }}
+    ignore_db_dirs            = "lost+found"
     table_definition_cache    = 800
     sql_mode                  = "TRADITIONAL"
     slow_query_log            = 1


### PR DESCRIPTION
Add "lost+found" directory to the ignored list to avoid it being displayed as a database.