### PR TITLE
[Octavia] octavia.conf: Fix typo

### DIFF
--- a/openstack/octavia/templates/etc/_octavia.conf.tpl
+++ b/openstack/octavia/templates/etc/_octavia.conf.tpl
@@ -48,7 +48,7 @@ default_pool_tls_versions = {{ .Values.tls.versions.default.pools | join ", " }}
 backends = octavia_db_check
 
 [controller_worker]
-worker = {{ .Values.worker | default 1 }}
+workers = {{ .Values.worker | default 1 }}
 amphora_driver = {{ .Values.amphora_driver  | default "amphora_noop_driver" }}
 compute_driver = {{ .Values.compute_driver  | default "compute_noop_driver" }}
 network_driver = {{ .Values.network_driver  | default "network_noop_driver" }}


### PR DESCRIPTION
The option was wrongly named, see [1]

This change does not have any effect, because .Values.worker is not defined (don't confuse it with .Values.workers!) and so this defaults to 1, which is also the default value defined by Octavia[1]. So it doesn't change, it's just explicitly defined now.

[1] https://github.com/sapcc/octavia/blob/600b5bae7537bc2fcf36c597818bfc4b7d48de10/octavia/common/config.py#L458-L460