### PR TITLE
[prometheus-exporters] Migrate queries from logstash->OpenTelemetry / ElasticSearch->OpenSearch

### DIFF
--- a/global/concourse-main/alerts/concourse.alerts
+++ b/global/concourse-main/alerts/concourse.alerts
@@ -18,7 +18,7 @@ groups:
       summary: Concourse database is too large
 
   - alert: ConcoursePostgresSharedMemoryError
-    expr: increase(elasticsearch_database_memory_allocation_failed_doc_count{failed="concourse-postgresql-0"}[6h]) > 0
+    expr: increase(opensearch_database_memory_allocation_failed_doc_count{failed="concourse-postgresql-0"}[6h]) > 0
     for: 5m
     labels:
       tier: ci

--- a/prometheus-exporters/opensearch-logs-query-exporter/aggregations/snmp.rules
+++ b/prometheus-exporters/opensearch-logs-query-exporter/aggregations/snmp.rules
@@ -1,5 +1,5 @@
 groups:
 - name: snmp
   rules:
-  - record: elasticsearch_snmp_error_reason
-    expr: sum(elasticsearch_snmp_reason_module_ip_doc_count) by (reason, region)
+  - record: opensearch_snmp_error_reason
+    expr: sum(opensearch_snmp_reason_module_ip_doc_count) by (reason, region)

--- a/prometheus-exporters/opensearch-logs-query-exporter/alerts/concourse.alerts
+++ b/prometheus-exporters/opensearch-logs-query-exporter/alerts/concourse.alerts
@@ -2,7 +2,7 @@ groups:
 - name: concourse.alerts
   rules:
   - alert: ConcoursePostgresSharedMemoryError
-    expr: increase(elasticsearch_database_memory_allocation_failed_doc_count{failed="concourse-postgresql-0"}[6h]) > 0
+    expr: increase(opensearch_database_memory_allocation_failed_doc_count{failed="concourse-postgresql-0"}[6h]) > 0
     for: 5m
     labels:
       tier: ci

--- a/prometheus-exporters/opensearch-logs-query-exporter/alerts/opensearch-logs-query.alerts
+++ b/prometheus-exporters/opensearch-logs-query-exporter/alerts/opensearch-logs-query.alerts
@@ -24,7 +24,7 @@ groups:
       summary: 'octobus-logs-query-exporter had an error in the pod log.'
 
   - alert: OpenstackGlanceReturn50xCode
-    expr: sum(rate(elasticsearch_openstack_glance_query_return_code_doc_count{glance="/v2/images", code=~"50.*"}[30m]))by(query, code) > 0
+    expr: sum(rate(opensearch_openstack_glance_query_return_code_doc_count{glance="/v2/images", code=~"50.*"}[30m]))by(query, code) > 0
     for: 5m
     labels:
       context: nodes
@@ -37,7 +37,7 @@ groups:
       summary: 'Openstack Glance Returned HTTP {{ $labels.query }} {{ $labels.code }}'
 
   - alert: EsxRootPasswordWrong
-    expr: elasticsearch_esxi_exporter_login_error_container_name_doc_count > 0
+    expr: opensearch_esxi_exporter_login_error_container_name_doc_count > 0
     for: 5m
     labels:
       severity: info
@@ -65,7 +65,7 @@ groups:
       summary: 'cluster: *{{ $labels.elastic_cluster }}* opensearch-logs-query-exporter in `{{ $labels.region }}` is missing.'
 
   - alert: SrcSiemRulesUpdaterLogError
-    expr: elasticsearch_siem_error_doc_count > 0
+    expr: opensearch_siem_error_doc_count > 0
     labels:
       context: nodes
       service: logs

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/defaults.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/defaults.cfg
@@ -11,7 +11,7 @@ QueryTimeoutSecs = 10
 
 # The indices to run the query on.
 
-# Any way of specifying indices supported by your Elasticsearch version can be used.
+# Any way of specifying indices supported by your OpenSearch version can be used.
 QueryIndices = _all
 
 QueryOnMissing = zero

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_database.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_database.cfg
@@ -1,4 +1,4 @@
-[query_elasticsearch_database]
+[query_opensearch_database]
 # The DEFAULT settings can be overridden.
 QueryIntervalSecs = 60
 QueryTimeoutSecs = 15

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_database.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_database.cfg
@@ -32,20 +32,9 @@ QueryJson = {
               }
             },
             "aggs": {
-              "aggregation": {
-                "terms": {
-                  "field": "kubernetes_pod_name.keyword",
-                  "order": {
-                    "_count": "desc"
-                  },
-                  "size": 20
-                }
-              }
-            },
-            "aggs": {
               "failed": {
                 "terms": {
-                  "field": "kubernetes_pod_name.keyword",
+                  "field": "resource.k8s.pod.name.keyword",
                   "order": {
                     "_count": "desc"
                   },
@@ -80,7 +69,7 @@ QueryJson = {
                 "range": {
                   "@timestamp": {
                     "format": "epoch_millis",
-                    "gte": "now-5m"
+                    "gte": "now-15d"
                   }
                 }
               }

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_dbconnection_error.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_dbconnection_error.cfg
@@ -1,9 +1,9 @@
-[query_elasticsearch_dbconnection]
+[query_opensearch_dbconnection]
 # The DEFAULT settings can be overridden.
 QueryIntervalSecs = 300
 QueryTimeoutSecs = 15
 QueryOnMissing = zero
-QueryIndices = logstash-*
+QueryIndices = logs-ds
 QueryJson = {
               "size": 0,
               "query": {

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_dbconnection_error.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_dbconnection_error.cfg
@@ -21,6 +21,6 @@ QueryJson = {
                 }
               },
               "aggs": {
-                "error": { "terms": { "field": "kubernetes_container_name.keyword", "size": 1000 }}
+                "error": { "terms": { "field": "resource.k8s.container.name.keyword", "size": 1000 }}
               }
             }

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_dboperational_error.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_dboperational_error.cfg
@@ -1,9 +1,9 @@
-[query_elasticsearch_dboperational]
+[query_opensearch_dboperational]
 # The DEFAULT settings can be overridden.
 QueryIntervalSecs = 300
 QueryTimeoutSecs = 15
 QueryOnMissing = zero
-QueryIndices = logstash-*
+QueryIndices = logs-ds
 QueryJson = {
               "size": 0,
               "query": {

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_dboperational_error.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_dboperational_error.cfg
@@ -21,6 +21,6 @@ QueryJson = {
                 }
               },
               "aggs": {
-                "error": { "terms": { "field": "kubernetes_container_name.keyword", "size": 1000 }}
+                "error": { "terms": { "field": "resource.k8s.container.name.keyword", "size": 1000 }}
               }
             }

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_esxi_exporter_login_error.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_esxi_exporter_login_error.cfg
@@ -1,7 +1,7 @@
-[query_elasticsearch_esxi_exporter_login_error]
+[query_opensearch_esxi_exporter_login_error]
 QueryIntervalSecs = 300
 QueryTimeoutSecs = 290
-QueryIndices = logstash-*
+QueryIndices = logs-ds
 QueryOnMissing = drop
 QueryJson = {
       "aggs": {

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_esxi_exporter_login_error.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_esxi_exporter_login_error.cfg
@@ -7,7 +7,7 @@ QueryJson = {
       "aggs": {
           "container_name": {
               "terms": {
-                  "field": "kubernetes_container_name.keyword"
+                  "field": "resource.k8s.container.name.keyword"
               }
           }
       },
@@ -22,7 +22,7 @@ QueryJson = {
                   },
                   {
                       "term": {
-                          "kubernetes_container_name.keyword": "esxi-host-exporter"
+                          "resource.k8s.container.name.keyword": "esxi-host-exporter"
                       }
                   },
                   {

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_jump.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_jump.cfg
@@ -1,4 +1,4 @@
-[query_elasticsearch_jump]
+[query_opensearch_jump]
 # The DEFAULT settings can be overridden.
 QueryIntervalSecs = 300
 QueryTimeoutSecs = 15

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_jump_ldap_error.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_jump_ldap_error.cfg
@@ -1,4 +1,4 @@
-[query_elasticsearch_jump_ldap]
+[query_opensearch_jump_ldap]
 # The DEFAULT settings can be overridden.
 QueryIntervalSecs = 300
 QueryTimeoutSecs = 15

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_kubernikus.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_kubernikus.cfg
@@ -1,4 +1,4 @@
-[query_elasticsearch_kubernikus]
+[query_opensearch_kubernikus]
 # The DEFAULT settings can be overridden.
 QueryIntervalSecs = 300
 QueryTimeoutSecs = 15

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_kubernikus_csi_error.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_kubernikus_csi_error.cfg
@@ -1,4 +1,4 @@
-[query_elasticsearch_kubernikus_csi_error]
+[query_opensearch_kubernikus_csi_error]
 # The DEFAULT settings can be overridden.
 QueryIntervalSecs = 290
 QueryTimeoutSecs = 30

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_kubernikus_expired_client.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_kubernikus_expired_client.cfg
@@ -1,4 +1,4 @@
-[query_elasticsearch_kubernikus_expired_client]
+[query_opensearch_kubernikus_expired_client]
 # The DEFAULT settings can be overridden.
 QueryIntervalSecs = 58
 QueryTimeoutSecs = 10

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_logsds_derby_error.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_logsds_derby_error.cfg
@@ -1,8 +1,8 @@
-[query_elasticsearch_logstash_derby]
+[query_opensearch_logsds_derby]
 # The DEFAULT settings can be overridden.
 QueryIntervalSecs = 300
 QueryTimeoutSecs = 15
-QueryIndices = logstash-*
+QueryIndices = logs-ds
 QueryJson = {
               "size": 0,
               "aggs": {

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_logstash_derby_error.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_logstash_derby_error.cfg
@@ -8,7 +8,7 @@ QueryJson = {
               "aggs": {
                 "error": {
                   "terms": {
-                    "field": "kubernetes_namespace_name.keyword"
+                    "field": "resource.k8s.namespace.name.keyword"
                   }
                 }
               },

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_manila.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_manila.cfg
@@ -35,7 +35,7 @@ QueryJson = {
             "aggs": {
               "aggregation": {
                 "terms": {
-                  "field": "kubernetes_labels_name.keyword",
+                  "field": "resource.app.label.name.keyword",
                   "order": {
                     "_count": "desc"
                   },

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_manila.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_manila.cfg
@@ -1,9 +1,9 @@
-[query_elasticsearch_manila_replica]
+[query_opensearch_manila_replica]
 # The DEFAULT settings can be overridden.
 QueryIntervalSecs = 300
 QueryTimeoutSecs = 15
 QueryOnMissing = zero
-QueryIndices = logstash-*
+QueryIndices = logs-ds
 QueryJson = {
         "aggs": {
           "error": {

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_memcached_toozconnection_error.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_memcached_toozconnection_error.cfg
@@ -21,6 +21,6 @@ QueryJson = {
                 }
               },
               "aggs": {
-                "error": { "terms": { "field": "kubernetes_labels_name.keyword", "size": 1000 }}
+                "error": { "terms": { "field": "resource.app.label.name.keyword", "size": 1000 }}
               }
             }

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_memcached_toozconnection_error.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_memcached_toozconnection_error.cfg
@@ -1,9 +1,9 @@
-[query_elasticsearch_memcached_toozconnection]
+[query_opensearch_memcached_toozconnection]
 # The DEFAULT settings can be overridden.
 QueryIntervalSecs = 300
 QueryTimeoutSecs = 15
 QueryOnMissing = zero
-QueryIndices = logstash-*
+QueryIndices = logs-ds
 QueryJson = {
               "size": 0,
               "query": {

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_octobus_exporter_error.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_octobus_exporter_error.cfg
@@ -9,7 +9,7 @@ QueryJson = {
       "bool": {
         "filter": [
           { "match": { "log": "prometheus_es_exporter.ERROR" }},
-          { "term": { "kubernetes_container_name.keyword": "opensearch-logs-query-exporter" }},
+          { "term": { "resource.k8s.container.name.keyword": "opensearch-logs-query-exporter" }},
           { "range": { "@timestamp": { "gte": "now-5m" }}}
         ]
       }

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_octobus_exporter_error.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_octobus_exporter_error.cfg
@@ -1,7 +1,7 @@
 [query_opensearch_logs_octobus_exporter_error]
 QueryIntervalSecs = 300
 QueryTimeoutSecs = 290
-QueryIndices = logstash-*
+QueryIndices = logs-ds
 QueryOnMissing = zero
 LabelsFromHits = [ "@timestamp", "log" ]
 QueryJson = {

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_opensearch.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_opensearch.cfg
@@ -25,7 +25,7 @@ QueryJson = {
                       "aggs": {
                         "timeouts": {
                           "terms": {
-                            "field": "kubernetes_pod_name.keyword",
+                            "field": "resource.k8s.pod.name.keyword",
                             "order": {
                               "_count": "desc"
                             },

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_opensearch.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_opensearch.cfg
@@ -2,7 +2,7 @@
 # The DEFAULT settings can be overridden.
 QueryIntervalSecs = 1800
 QueryTimeoutSecs = 30
-QueryIndices = logstash-*
+QueryIndices = logs-ds
 QueryJson = {
               "aggs": {
                 "communication": {

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_openstack_glance.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_openstack_glance.cfg
@@ -1,8 +1,8 @@
-[query_elasticsearch_openstack]
+[query_opensearch_openstack]
 # The DEFAULT settings can be overridden.
 QueryIntervalSecs = 280
 QueryTimeoutSecs = 15
-QueryIndices = logstash-*
+QueryIndices = logs-ds
 QueryJson = {
         "aggs": {
           "glance": {

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_openstack_glance.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_openstack_glance.cfg
@@ -16,7 +16,7 @@ QueryJson = {
             "aggs": {
               "query": {
                 "terms": {
-                  "field": "method.keyword",
+                  "field": "attributes.request_method.keyword",
                   "order": {
                     "_count": "desc"
                   },
@@ -25,7 +25,7 @@ QueryJson = {
                 "aggs": {
                   "return": {
                     "terms": {
-                      "field": "kubernetes_labels_app_name.keyword",
+                      "field": "resource.app.label.name.keyword",
                       "order": {
                         "_count": "desc"
                       },
@@ -34,7 +34,7 @@ QueryJson = {
                   "aggs": {
                     "code": {
                       "terms": {
-                        "field": "response.keyword",
+                        "field": "attributes.response.keyword",
                         "order": {
                           "_count": "desc"
                         },

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_px_bird.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_px_bird.cfg
@@ -1,8 +1,8 @@
-[query_elasticsearch_px_bird]
+[query_opensearch_px_bird]
 # The DEFAULT settings can be overridden.
 QueryIntervalSecs = 360
 QueryTimeoutSecs = 10
-QueryIndices = logstash-*
+QueryIndices = logs-ds
 QueryJson = {
     "query": {
       "bool": {

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_px_bird.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_px_bird.cfg
@@ -28,7 +28,7 @@ QueryJson = {
       }
     },
     "aggs": {
-      "import": { "terms": { "field": "kubernetes_labels_app_name.keyword" }}
+      "import": { "terms": { "field": "resource.app.label.name.keyword" }}
     }
   }
 

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_rabbitmq_econnrefused_error.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_rabbitmq_econnrefused_error.cfg
@@ -18,7 +18,7 @@ QueryJson = {
                   "must_not": [
                   {
                     "match_phrase" : {
-                      "kubernetes_namespace_name": "swift"
+                      "resource.k8s.namespace.name.keyword": "swift"
                     }
                   }
                   ],
@@ -28,9 +28,9 @@ QueryJson = {
                 }
               },
               "aggs": {
-                "error": { "terms": { "field": "kubernetes_namespace_name.keyword", "size": 1000 },
+                "error": { "terms": { "field": "resource.k8s.namespace.name.keyword", "size": 1000 },
               "aggs": {
-                "failed": { "terms": { "field": "kubernetes_container_name.keyword", "size": 1000 }}
+                "failed": { "terms": { "field": "resource.k8s.container.name.keyword", "size": 1000 }}
               }
                 }
               }

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_rabbitmq_econnrefused_error.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_rabbitmq_econnrefused_error.cfg
@@ -1,9 +1,9 @@
-[query_elasticsearch_rabbitmq_econnrefused]
+[query_opensearch_rabbitmq_econnrefused]
 # The DEFAULT settings can be overridden.
 QueryIntervalSecs = 300
 QueryTimeoutSecs = 15
 QueryOnMissing = zero
-QueryIndices = logstash-*
+QueryIndices = logs-ds
 QueryJson = {
               "size": 0,
               "query": {

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_rabbitmq_timeout_error.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_rabbitmq_timeout_error.cfg
@@ -1,9 +1,9 @@
-[query_elasticsearch_rabbitmq_timeout]
+[query_opensearch_rabbitmq_timeout]
 # The DEFAULT settings can be overridden.
 QueryIntervalSecs = 300
 QueryTimeoutSecs = 15
 QueryOnMissing = zero
-QueryIndices = logstash-*
+QueryIndices = logs-ds
 QueryJson = {
               "size": 0,
               "query": {

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_rabbitmq_timeout_error.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_rabbitmq_timeout_error.cfg
@@ -21,6 +21,6 @@ QueryJson = {
                 }
               },
               "aggs": {
-                "error": { "terms": { "field": "kubernetes_labels_name.keyword", "size": 1000 }}
+                "error": { "terms": { "field": "resource.app.label.name.keyword", "size": 1000 }}
               }
             }

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_rabbitmq_vhost_connect_error.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_rabbitmq_vhost_connect_error.cfg
@@ -7,7 +7,7 @@ QueryJson = {
                   "aggs": {
                       "container_name": {
                           "terms": {
-                              "field": "kubernetes_pod_name.keyword"
+                              "field": "resource.k8s.pod.name.keyword"
                           }
                       }
                   },

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_rabbitmq_vhost_connect_error.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_rabbitmq_vhost_connect_error.cfg
@@ -2,7 +2,7 @@
 # The DEFAULT settings can be overridden.
 QueryIntervalSecs = 295
 QueryTimeoutSecs = 15
-QueryIndices = logstash-*
+QueryIndices = logs-ds
 QueryJson = {
                   "aggs": {
                       "container_name": {

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_scaleout.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_scaleout.cfg
@@ -7,7 +7,7 @@ QueryJson = {
         "aggs": {
           "logs": {
              "terms": {
-               "field": "kubernetes.host.keyword",
+               "field": "resource.k8s.node.name.keyword",
                "size": 30
             }
           }

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_scaleout_csi_error.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_scaleout_csi_error.cfg
@@ -1,4 +1,4 @@
-[query_elasticsearch_scaleout_csi_error]
+[query_opensearch_scaleout_csi_error]
 # The DEFAULT settings can be overridden.
 QueryIntervalSecs = 290
 QueryTimeoutSecs = 30

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_scaleout_csi_error.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_scaleout_csi_error.cfg
@@ -21,7 +21,7 @@ QueryJson = {
       }
     },
     "aggs": {
-      "node": { "terms": { "field": "hostname.keyword" }}
+      "node": { "terms": { "field": "resource.k8s.node.name.keyword" }}
     }
   }
 

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_siem_error.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_siem_error.cfg
@@ -1,9 +1,9 @@
-[query_elasticsearch_siem]
+[query_opensearch_siem]
 # The DEFAULT settings can be overridden.
 QueryIntervalSecs = 300
 QueryTimeoutSecs = 15
 QueryOnMissing = zero
-QueryIndices = logstash-*
+QueryIndices = logs-ds
 QueryJson = {
               "size": 0,
               "query": {

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_siem_error.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_siem_error.cfg
@@ -35,7 +35,7 @@ QueryJson = {
               "aggs": {
                 "error": {
                   "terms": {
-                    "field": "kubernetes_container_name.keyword",
+                    "field": "resource.k8s.container.name.keyword",
                     "size": 1000
                   }
                 }

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_snmp.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_snmp.cfg
@@ -1,8 +1,8 @@
-[query_elasticsearch_snmp]
+[query_opensearch_snmp]
 # The DEFAULT settings can be overridden.
 QueryIntervalSecs = 600
 QueryTimeoutSecs = 30
-QueryIndices = logstash-*
+QueryIndices = logs-ds
 QueryJson = {
             "aggs": {
               "reason": {

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_snmp.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_snmp.cfg
@@ -25,7 +25,7 @@ QueryJson = {
                         "aggs": {
                           "scraped_by": {
                             "terms": {
-                              "field": "kubernetes_labels_app_name.keyword",
+                              "field": "resource.app.label.name.keyword",
                               "size": 10
                             }
                           }

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_syslog.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_syslog.cfg
@@ -1,4 +1,4 @@
-[query_elasticsearch_syslog]
+[query_opensearch_syslog]
 # The DEFAULT settings can be overridden.
 QueryIntervalSecs = 300
 QueryTimeoutSecs = 15


### PR DESCRIPTION
### Changes
- refactor(opensearch-logs-query-exporter): migrates from ES labels to OS
  This changes the ES labels, keywords etc. to canonical OpenSearch ones. For some situations there are not log hits due to OtelCol not ingesting them yet.
- refactor(opensearch-logs-query-exporter): adds a partial migration for 'query_opensearch'
  A partial fix as 'fault_detection.keyword' and 'opensearch_name.keyword' are labels that have not been seen/indexed by logs-ds at this moment. So this might be revised in the future
- refactor(opensearch-logs-query-exporter): renames 'query_elasticsearch_' to 'query_opensearch_' for all queries 