### PR TITLE
postgresql-ng, redis: add alerts when auto-issued secrets expire

### DIFF
--- a/common/postgresql-ng/Chart.yaml
+++ b/common/postgresql-ng/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: postgresql-ng
-version: 1.2.9 # this version number is SemVer as it gets used to auto bump
+version: 1.3.0 # this version number is SemVer as it gets used to auto bump
 description: Chart for PostgreSQL
 keywords:
 - postgresql

--- a/common/postgresql-ng/ci/test-values.yaml
+++ b/common/postgresql-ng/ci/test-values.yaml
@@ -7,3 +7,6 @@ global:
 tableOwner: acme-user
 users:
   acme-user:
+
+alerts:
+  support_group: foobar

--- a/common/postgresql-ng/templates/prometheus-alerts.yaml
+++ b/common/postgresql-ng/templates/prometheus-alerts.yaml
@@ -1,0 +1,41 @@
+{{- $fullname := include "postgres.fullname" . -}}
+{{- $service  := .Values.alerts.service       | default  .Release.Name -}}
+{{- $sgroup   := .Values.alerts.support_group | required "missing value for .Values.postgresql.alerts.support_group" -}}
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: {{ $fullname }}
+  labels:
+    prometheus: kubernetes
+
+spec:
+  groups:
+    - name: {{ $fullname }}.alerts
+      rules:
+        - alert: PostgresSecretAboutToExpire
+          expr: max by (namespace, secret) ((time() - kube_secret_created{namespace="{{ .Release.Namespace }}",secret=~"{{ .Release.Name }}-pguser-.*"}) / 86400) >= 330
+          for: 5m
+          labels:
+            context: secret-rotation
+            playbook: docs/support/playbook/rotate-local-kubernetes-secret
+            service: {{ quote $service }}
+            severity: info
+            support_group: {{ quote $sgroup }}
+          annotations:
+            summary: 'PostgreSQL user secret will expire soon'
+            description: 'The secret {{`{{`}} $labels.namespace {{`}}/{{`}} $labels.secret {{`}}`}} is nearly 365 days old. Please rotate it soon by following the attached playbook.'
+
+        - alert: PostgresSecretAboutToExpire
+          expr: max by (namespace, secret) ((time() - kube_secret_created{namespace="{{ .Release.Namespace }}",secret=~"{{ .Release.Name }}-pguser-.*"}) / 86400) >= 365
+          for: 5m
+          labels:
+            context: secret-rotation
+            playbook: docs/support/playbook/rotate-local-kubernetes-secret
+            service: {{ quote $service }}
+            severity: warning
+            support_group: {{ quote $sgroup }}
+          annotations:
+            summary: 'PostgreSQL user secret is expired'
+            description: 'The secret {{`{{`}} $labels.namespace {{`}}/{{`}} $labels.secret {{`}}`}} is over 365 days old. Please rotate it as soon as possible by following the attached playbook.'

--- a/common/postgresql-ng/values.yaml
+++ b/common/postgresql-ng/values.yaml
@@ -72,6 +72,10 @@ sharedMemoryLimit: null
 probe_timeout_secs: 3
 probe_failure_threshold: 6 # number of liveness probes that need to fail to trigger a pod restart
 
+alerts:
+  support_group: null # This field must be filled by the top-level chart.
+  service: null       # defaults to .Release.Name if not set
+
 # Configure resource requests and limits
 # ref: http://kubernetes.io/docs/user-guide/compute-resources/
 resources: {}

--- a/common/redis/Chart.yaml
+++ b/common/redis/Chart.yaml
@@ -31,4 +31,7 @@ name: redis
 #   See documentation on field `.Values.redisPassword` for details.
 # - Support for setting `.Values.redisPassword` explicitly is deprecated.
 #   This field may be removed in a subsequent major version bump.
-version: 2.0.0 # this version number is SemVer as it gets used to auto bump
+#
+# 2.1.0
+# - The field `.Values.redis.alerts.support_group` must now be provided by the parent chart.
+version: 2.1.0 # this version number is SemVer as it gets used to auto bump

--- a/common/redis/ci/test-values.yaml
+++ b/common/redis/ci/test-values.yaml
@@ -1,3 +1,6 @@
 global:
   registry: registry.example.com
   dockerHubMirror: ci.example.com
+
+alerts:
+  support_group: foobar

--- a/common/redis/templates/prometheus-alerts.yaml
+++ b/common/redis/templates/prometheus-alerts.yaml
@@ -1,0 +1,41 @@
+{{- $fullname := include "redis.fullname" . -}}
+{{- $service  := .Values.alerts.service       | default  .Release.Name -}}
+{{- $sgroup   := .Values.alerts.support_group | required "missing value for .Values.redis.alerts.support_group" -}}
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: {{ $fullname }}
+  labels:
+    prometheus: kubernetes
+
+spec:
+  groups:
+    - name: {{ $fullname }}.alerts
+      rules:
+        - alert: PostgresSecretAboutToExpire
+          expr: max by (namespace, secret) ((time() - kube_secret_created{namespace="{{ .Release.Namespace }}",secret=~"{{ $fullname }}-user-.*"}) / 86400) >= 330
+          for: 5m
+          labels:
+            context: secret-rotation
+            playbook: docs/support/playbook/rotate-local-kubernetes-secret
+            service: {{ quote $service }}
+            severity: info
+            support_group: {{ quote $sgroup }}
+          annotations:
+            summary: 'PostgreSQL user secret will expire soon'
+            description: 'The secret {{`{{`}} $labels.namespace {{`}}/{{`}} $labels.secret {{`}}`}} is nearly 365 days old. Please rotate it soon by following the attached playbook.'
+
+        - alert: PostgresSecretAboutToExpire
+          expr: max by (namespace, secret) ((time() - kube_secret_created{namespace="{{ .Release.Namespace }}",secret=~"{{ $fullname }}-user-.*"}) / 86400) >= 365
+          for: 5m
+          labels:
+            context: secret-rotation
+            playbook: docs/support/playbook/rotate-local-kubernetes-secret
+            service: {{ quote $service }}
+            severity: warning
+            support_group: {{ quote $sgroup }}
+          annotations:
+            summary: 'PostgreSQL user secret is expired'
+            description: 'The secret {{`{{`}} $labels.namespace {{`}}/{{`}} $labels.secret {{`}}`}} is over 365 days old. Please rotate it as soon as possible by following the attached playbook.'

--- a/common/redis/values.yaml
+++ b/common/redis/values.yaml
@@ -33,6 +33,10 @@ resources:
     memory: 128Mi
     cpu: 100m
 
+alerts:
+  support_group: null # This field must be filled by the top-level chart.
+  service: null       # defaults to .Release.Name if not set
+
 # Prometheus metrics via oliver006/redis_exporter sidecar.
 metrics:
   enabled: true


### PR DESCRIPTION
To ensure PCI/DSS compliance for those credentials.