### PR TITLE
all srs: bump postgresql-ng and redis charts

### DIFF
--- a/openstack/castellum/Chart.lock
+++ b/openstack/castellum/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.1.0
 - name: postgresql-ng
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.2.9
+  version: 1.3.0
 - name: pgbackup
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.11
@@ -14,5 +14,5 @@ dependencies:
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:b40db11b5ccbe504d1b2d03913257a126ce57c0dbe03cb30bbfadf4814827478
-generated: "2025-02-25T12:14:47.816437937Z"
+digest: sha256:139cf2918220bbda8d5155be76f56e195789804b4a88a6d8aa5b083ab74f629e
+generated: "2025-02-25T14:13:44.956210946+01:00"

--- a/openstack/keppel/Chart.lock
+++ b/openstack/keppel/Chart.lock
@@ -4,18 +4,18 @@ dependencies:
   version: 1.1.0
 - name: postgresql-ng
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.2.9
+  version: 1.3.0
 - name: pgbackup
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.11
 - name: pgmetrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.1.3
+  version: 1.1.4
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 2.0.0
+  version: 2.1.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:78e73ef752f50a215cfc5d690eb4a75320e368db54458e35c40140c8b47f38bd
-generated: "2025-02-18T15:41:36.166438082+01:00"
+digest: sha256:836bef42b80c17a735cc79630cb32d8fc504e52a5d9627081ad408141ef6374c
+generated: "2025-02-25T14:13:46.692692532+01:00"

--- a/openstack/keppel/values.yaml
+++ b/openstack/keppel/values.yaml
@@ -67,6 +67,9 @@ redis:
     maxmemory-policy: allkeys-lru
     maxmemory-samples: 5
 
+  alerts:
+    support_group: containers
+
   # observed resource usage for keppel-redis pod as of 2024-05:
   #   CPU up to 0.32% = 5m (average, but we must avoid throttling)
   #   MEM up to 16Mi

--- a/openstack/limes/Chart.lock
+++ b/openstack/limes/Chart.lock
@@ -4,15 +4,15 @@ dependencies:
   version: 1.1.0
 - name: postgresql-ng
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.2.9
+  version: 1.3.0
 - name: pgbackup
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.11
 - name: pgmetrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.1.3
+  version: 1.1.4
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:c40c4bc26aa090b75c76599980c9fb13ec88bc67391cb122d931b270e931c4ab
-generated: "2025-02-24T05:35:01.556198686Z"
+digest: sha256:139cf2918220bbda8d5155be76f56e195789804b4a88a6d8aa5b083ab74f629e
+generated: "2025-02-25T14:13:48.393285698+01:00"


### PR DESCRIPTION
This is not automated because Keppel needs a values.yaml change.