### PR TITLE
[swift] use global.domain_seeds.customer_domains (srs #547)

### DIFF
--- a/openstack/swift-utils/ci/test-values.yaml
+++ b/openstack/swift-utils/ci/test-values.yaml
@@ -2,5 +2,7 @@ global:
   tld: example.com
   region: regionOne
   registryAlternateRegion: registry.example.com
+  domain_seeds:
+    customer_domains: [ bar, foo ]
 
 image_version: stein-20190101094554

--- a/openstack/swift-utils/templates/seed.yaml
+++ b/openstack/swift-utils/templates/seed.yaml
@@ -1,3 +1,6 @@
+{{- $cdomains := .Values.global.domain_seeds.customer_domains | required "missing value for .Values.global.domain_seeds.customer_domains" -}}
+{{- $domains  := concat (list "cc3test ccadmin Default") $cdomains -}}
+
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:
@@ -13,37 +16,10 @@ metadata:
 spec:
   requires:
     - swift/swift-seed #  and all its dependencies
-    - monsoon3/domain-default-seed
-    - monsoon3/domain-bs-seed
-    - monsoon3/domain-btp-fp-seed
-    - monsoon3/domain-cis-seed
-    - monsoon3/domain-cp-seed
-    - monsoon3/domain-ccadmin-seed
-    - monsoon3/domain-fsn-seed
-    - monsoon3/domain-hcp03-seed
-    - monsoon3/domain-hda-seed
-    - monsoon3/domain-hcm-seed
-    - monsoon3/domain-hec-seed
-    - monsoon3/domain-kyma-seed
-    - monsoon3/domain-monsoon3-seed
-    - monsoon3/domain-neo-seed
-    - monsoon3/domain-s4-seed
-    - monsoon3/domain-wbs-seed
-    - monsoon3/domain-cc3test-seed
-    - monsoon3/domain-tempest-seed
-    - monsoon3/domain-ora-seed
-    - monsoon3/domain-kubernikus-seed
-    - monsoon3/domain-iaas-20e8bf-seed
-    - monsoon3/domain-iaas-34a24e-seed
-    - monsoon3/domain-iaas-45b91f-seed
-    - monsoon3/domain-iaas-7ff5dd-seed
-    - monsoon3/domain-iaas-90876f-seed
-    - monsoon3/domain-iaas-9d6a56-seed
-    - monsoon3/domain-iaas-b56735-seed
-    - monsoon3/domain-iaas-d3495f-seed
-    - monsoon3/domain-iaas-de5955-seed
-    - monsoon3/domain-iaas-ec5a3e-seed
-    
+    {{- range $domains }}
+    - monsoon3/domain-{{replace "_" "-" .|lower}}-seed
+    {{- end }}
+
   domains:
     - name: Default
       users:
@@ -60,68 +36,10 @@ spec:
           - project: service
             role: service
           # needs to be admin in all domains to list projects
-          - domain: Default
+          {{- range $domains }}
+          - domain: {{ . }}
             role: admin
-          - domain: ccadmin
-            role: admin
-          - domain: bs
-            role: admin
-          - domain: btp_fp
-            role: admin
-          - domain: cis
-            role: admin
-          - domain: cp
-            role: admin
-          - domain: fsn
-            role: admin
-          - domain: hcp03
-            role: admin
-          - domain: hda
-            role: admin
-          - domain: hcm
-            role: admin
-          - domain: hec
-            role: admin
-          - domain: kyma
-            role: admin
-          - domain: monsoon3
-            role: admin
-          - domain: neo
-            role: admin
-          - domain: s4
-            role: admin
-          - domain: wbs
-            role: admin
-          - domain: cc3test
-            role: admin
-          - domain: tempest
-            role: admin
-          - domain: ora
-            role: admin
-          - domain: kubernikus
-            role: admin
-          - domain: tempest
-            role: admin
-          - domain: iaas-20e8bf
-            role: admin
-          - domain: iaas-34a24e
-            role: admin
-          - domain: iaas-45b91f
-            role: admin
-          - domain: iaas-7ff5dd
-            role: admin
-          - domain: iaas-90876f
-            role: admin
-          - domain: iaas-9d6a56
-            role: admin
-          - domain: iaas-b56735
-            role: admin
-          - domain: iaas-d3495f
-            role: admin
-          - domain: iaas-de5955
-            role: admin
-          - domain: iaas-ec5a3e
-            role: admin
+          {{- end }}
       {{- if $.Values.velero_backup_password }}
       - name: velero_backup
         description: 'Velero Backup'

--- a/openstack/swift/ci/test-values.yaml
+++ b/openstack/swift/ci/test-values.yaml
@@ -2,6 +2,8 @@ global:
   tld: example.com
   region: regionOne
   registryAlternateRegion: registry.example.com
+  domain_seeds:
+    customer_domains: [ bar, foo ]
 
 image_version: stein-20190101094554
 rings_image_version: regionOne-20230101234200

--- a/openstack/swift/templates/support_seed.yaml
+++ b/openstack/swift/templates/support_seed.yaml
@@ -1,7 +1,6 @@
-{{- $domains := list "ccadmin" "bs" "cis" "cp" "fsn" "hcp03" "hec" "monsoon3" "neo" "s4" "wbs"}}
-{{- if not .Values.global.domain_seeds.skip_hcm_domain -}}
-  {{- $domains = append $domains "hcm" }}
-{{- end -}}
+{{- $cdomains := .Values.global.domain_seeds.customer_domains | required "missing value for .Values.global.domain_seeds.customer_domains" -}}
+{{- $domains  := concat (list "ccadmin") $cdomains -}}
+{{- $internalDomainsWithoutAllProjects := list "btp_fp" "kyma" "ora"}}
 
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
@@ -18,26 +17,29 @@ spec:
   requires:
   - swift/swift-seed
   {{- range $domains }}
-  - monsoon3/domain-{{ . | lower }}-seed
+  - monsoon3/domain-{{replace "_" "-" .|lower}}-seed
   {{- end }}
 
   domains:
     {{- range $domains }}
     - name: {{ . | lower }}
       groups:
-      - name: {{ . | upper }}_API_SUPPORT
+      - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_API_SUPPORT
         role_assignments:
+        {{- if not (or (contains "iaas-" .) (has . $internalDomainsWithoutAllProjects)) }}
         - project: api_support
           role: objectstore_admin
         {{- if eq . "ccadmin" }}
         - project: api_tools
           role: objectstore_admin
         {{- end }}
+        {{- end }}
         # Inherit admin role within domain
         - domain: {{ . | lower }}
           role: objectstore_admin
           inherited: true
-      - name: {{ . | upper }}_COMPUTE_SUPPORT
+      {{- if not (or (contains "iaas-" .) (has . $internalDomainsWithoutAllProjects)) }}
+      - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_COMPUTE_SUPPORT
         role_assignments:
         - project: compute_support
           role: objectstore_admin
@@ -45,8 +47,10 @@ spec:
         - project: compute_tools
           role: objectstore_admin
         {{- end }}
+      {{- end }}
+      {{- if not (or (contains "iaas-" .) (has . $internalDomainsWithoutAllProjects)) }}
         # No readonly role to inherit within domain
-      - name: {{ . | upper }}_NETWORK_SUPPORT
+      - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_NETWORK_SUPPORT
         role_assignments:
         - project: network_support
           role: objectstore_admin
@@ -54,22 +58,27 @@ spec:
         - project: network_tools
           role: objectstore_admin
         {{- end }}
+      {{- end }}
         # No readonly role to inherit within domain
-      - name: {{ . | upper }}_STORAGE_SUPPORT
+      - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_STORAGE_SUPPORT
         role_assignments:
+        {{- if not (or (contains "iaas-" .) (has . $internalDomainsWithoutAllProjects)) }}
         - project: storage_support
           role: objectstore_admin
         {{- if eq . "ccadmin" }}
         - project: storage_tools
           role: objectstore_admin
         {{- end }}
+        {{- end }}
         # Inherit admin role within domain
         - domain: {{ . | lower }}
           role: objectstore_admin
           inherited: true
-      - name: {{ . | upper }}_SERVICE_DESK
+      {{- if not (or (contains "iaas-" .) (has . $internalDomainsWithoutAllProjects)) }}
+      - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_SERVICE_DESK
         role_assignments:
         - project: service_desk
           role: objectstore_admin
         # No readonly role to inherit within domain
+      {{- end }}
     {{- end }}


### PR DESCRIPTION
partly a replacement to shorten the seed, partly extending to the new domains (`iaas-...`) as with billing/ limes/ keppel.

`h3 diff`: [swiftdiff.txt](https://github.com/user-attachments/files/18966113/swiftdiff.txt)
