### PR TITLE
[keystone] MariaDB chart version bumped to 0.16.8

### DIFF
--- a/openstack/keystone/Chart.lock
+++ b/openstack/keystone/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.16.3
+  version: 0.16.8
 - name: mariadb-galera
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.29.3
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.4
-digest: sha256:eed657eef58fbecbd29256c844b0a9e1a027799e162919cf9a6a30406c278bca
-generated: "2025-02-21T10:13:01.500957+01:00"
+digest: sha256:ff6533603b3a2e245fa05cbbbd414113a1dfe6117715d3988ce0ae97d5b370bb
+generated: "2025-02-26T12:11:11.836425+01:00"

--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.16.3
+    version: 0.16.8
   - condition: mariadb_galera.enabled
     name: mariadb-galera
     alias: mariadb_galera


### PR DESCRIPTION
- configmap name for the maintenance job fixed