### PR TITLE
feat(cinder): add grants for user metis

### DIFF
--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Cinder/OpenStack_Project_Cinder_mascot.png
 name: cinder
-version: 0.2.1
+version: 0.2.2
 dependencies:
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -129,6 +129,9 @@ mariadb:
       password: null
       grants:
       - "ALL PRIVILEGES on cinder.*"
+    metis:
+      grants:
+      - "REPLICATION REPLICA on *.*"
   initdb_secret: true
   persistence_claim:
     name: db-cinder-pvclaim


### PR DESCRIPTION
the metis user requires 'replication replica' to access the binlog