### PR TITLE
feat(glance): add grants for user metis

### DIFF
--- a/openstack/glance/Chart.yaml
+++ b/openstack/glance/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: dalmatian
 description: A Helm chart Openstack Glance
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Glance/OpenStack_Project_Glance_vertical.png
 name: glance
-version: 0.6.5
+version: 0.6.6
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/glance/values.yaml
+++ b/openstack/glance/values.yaml
@@ -142,6 +142,9 @@ mariadb:
       name: glance
       grants:
       - "ALL PRIVILEGES ON glance.*"
+    metis:
+      grants:
+        - "REPLICATION REPLICA on *.*"
   metrics:
     resources:
       enabled: true


### PR DESCRIPTION
the metis user requires 'replication replica' to access the binlog