### PR TITLE
feat(keystone): add grants for user metis

### DIFF
--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: keystone
 sources:
   - https://github.com/sapcc/keystone
-version: 0.9.0
+version: 0.9.1
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -281,6 +281,9 @@ mariadb:
       password: null
       grants:
       - "ALL PRIVILEGES on keystone.*"
+    metis:
+      grants:
+        - "REPLICATION REPLICA on *.*"
   resources:
     requests:
       cpu: 1000m


### PR DESCRIPTION
the metis user requires 'replication replica' to access the binlog