### PR TITLE
feat(neutron): add grants for user metis

### DIFF
--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Openstack Neutron
 name: neutron
-version: 0.2.3
+version: 0.2.4
 appVersion: "yoga"
 dependencies:
   - condition: mariadb.enabled

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -410,6 +410,10 @@ mariadb:
     enabled: true
   persistence_claim:
     name: db-neutron-pvclaim
+  users:
+    metis:
+      grants:
+      - "REPLICATION REPLICA on *.*"
   backup:
     enabled: false
   backup_v2:


### PR DESCRIPTION
the metis user requires 'replication replica' to access the binlog