### PR TITLE
feat(nova): add grants for user metis

### DIFF
--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 name: nova
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Nova/OpenStack_Project_Nova_mascot.png
-version: 0.3.0
+version: 0.3.1
 appVersion: "rocky"
 dependencies:
   - name: mariadb

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -798,6 +798,9 @@ mariadb_api:
       name: nova_api
       grants:
       - "ALL PRIVILEGES on nova_api.*"
+    metis:
+      grants:
+        - "REPLICATION REPLICA on *.*"
   persistence_claim:
     name: db-nova-api-pvc
     size: "50Gi"
@@ -826,6 +829,10 @@ mariadb_cell2:
     set_main_container: true
   ccroot_user:
     enabled: true
+  users:
+    metis:
+      grants:
+        - "REPLICATION REPLICA on *.*"
   persistence_claim:
     name: db-nova-cell2-pvc
     size: "50Gi"

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -758,6 +758,9 @@ mariadb:
       name: nova_cell0
       grants:
       - "ALL PRIVILEGES on nova_cell0.*"
+    metis:
+      grants:
+        - "REPLICATION REPLICA on *.*"
   persistence_claim:
     name: db-nova-pvc
     size: "50Gi"


### PR DESCRIPTION
the metis user requires 'replication replica' to access the binlog
this adds the grants to nova, nova_api and nova_cell mariadbs