### PR TITLE
[system/cc-cluster] Allow extra node-labels for clusters

### DIFF
--- a/system/cc-cluster/Chart.yaml
+++ b/system/cc-cluster/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: cc-cluster
 description: A Helm chart for the cc clusters.
 type: application
-version: 1.0.26
+version: 1.1.0

--- a/system/cc-cluster/templates/kubeadmconfigtemplate.yaml
+++ b/system/cc-cluster/templates/kubeadmconfigtemplate.yaml
@@ -12,6 +12,11 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             node-labels: kubernikus.cloud.sap/cni=true,metal3.io/uuid=${uuid},kubernetes.metal.cloud.sap/node-ip=${IP},kubernetes.metal.cloud.sap/host=${name_bmh},kubernetes.metal.cloud.sap/bb=${bb},kubernetes.metal.cloud.sap/role=${role},topology.kubernetes.io/region=${region},topology.kubernetes.io/zone=${zone} {{- if $cluster.maintenanceProfile -}} ,cloud.sap/maintenance-profile={{ $cluster.maintenanceProfile }} {{- end }}
+              {{- with $cluster.extraLabels }}
+                {{- range $label := $cluster.extraLabels -}}
+                  ,{{ $label }}
+                {{- end }}
+              {{- end }}
             cloud-provider: ""
             node-ip: ${IP}
           name: ${name_bmh}


### PR DESCRIPTION
This allows to add extra labels to clusters. This would allow dedicated
labels to be added e.g. for metal3 clusters.

The values syntax needs to be an array like following:

```
extraLabels:
  - key=value
  - asdf=qwer
```
