### PR TITLE
limes-campfire: fix CRONUS_USERNAME

### DIFF
--- a/openstack/limes-campfire/templates/deployment.yaml
+++ b/openstack/limes-campfire/templates/deployment.yaml
@@ -72,7 +72,11 @@ spec:
             - name: CRONUS_USER_DOMAIN_NAME
               value: Default
             - name: CRONUS_USERNAME
+              {{- if $is_global }}
+              value: {{ contains "qa" $region | ternary "campfire-global-qa" "campfire-global" | quote }}
+              {{- else }}
               value: {{ printf "campfire-%s" $region | quote }}
+              {{- end }}
             - name: CRONUS_PASSWORD
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
I have read through the `helm diff` for global-qa and this appears to be the only remaining bug.