### PR TITLE
limes: disable mail notifications in lab regions and global regions

### DIFF
--- a/openstack/limes/templates/configmap.yaml
+++ b/openstack/limes/templates/configmap.yaml
@@ -10,6 +10,7 @@ data:
     {{- range .Values.global.availability_zones }}
       - {{ . }}
     {{- end }}
+    {{- if not (or (.Values.global.region | match "qa-de-[2-6]") (eq .Release.Namespace "limes-global")) }}
     mail_notifications:
       endpoint: {{ .Values.limes.clusters.ccloud.catalog_url | replace "limes-3" "limes-campfire" | trimSuffix "/" }}/
       templates:
@@ -19,6 +20,7 @@ data:
         expiring_commitments:
          subject: {{ .Values.campfire.mail_type.expire.subject }}
          body: {{ tpl (.Files.Get "files/commitment_mail.tpl") (dict "region" .Values.global.region "condition" .Values.campfire.mail_type.expire.condition) | toJson }}
+    {{- end }}
 {{ toYaml .Values.limes.clusters.ccloud | indent 4 }}
 
   policy.json: |


### PR DESCRIPTION
- Lab regions do not have a Campfire because there is no CBR.
- Global regions are disabled temporarily until we figure out the credential situation for Campfire.