### PR TITLE
[Keystone] enforce sentryProject creation for keystone

### DIFF
--- a/openstack/keystone/templates/sentry.yaml
+++ b/openstack/keystone/templates/sentry.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.sentry.enabled }}
-{{- if not .Values.sentry.dsn }}
 apiVersion: "sentry.sap.cc/v1"
 kind: "SentryProject"
 metadata:

--- a/openstack/keystone/templates/sentry.yaml
+++ b/openstack/keystone/templates/sentry.yaml
@@ -8,4 +8,3 @@ spec:
   name: {{ .Release.Name }} #slug of the project you want to use (or create
   team: openstack #slug of the team where the project should be created (if it doesn't exist)
 {{- end }}
-{{- end }}


### PR DESCRIPTION
- 6/17 regions dont have DSN in secrets, we need to standardise