### PR TITLE
[mariadb] verbose logging option for the analyzetables job

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.16.10 - 2025/02/27
+* verbose logging option for the analyzetables job added
+* chart version bumped
+
 ## v0.16.9 - 2025/02/26
 * maintenance job configmap condition fixed
 * chart version bumped

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.16.9
+version: 0.16.10

--- a/common/mariadb/scripts/mariadb-cronjob-maintenance.sh
+++ b/common/mariadb/scripts/mariadb-cronjob-maintenance.sh
@@ -28,6 +28,9 @@ function analyzeTable {
     MYSQL_RESPONSE=$(mysql ${mysqlOpts} --execute="ANALYZE TABLE ${tblName} PERSISTENT FOR ALL;")
     MYSQL_STATUS=$?
     MYSQL_QUERY_STATUS=$(echo "${MYSQL_RESPONSE}" | grep "Error" | wc -l)
+    {{- if $.Values.job.maintenance.function.analyzeTable.verbose }}
+    echo "${MYSQL_RESPONSE}"
+    {{- end }}
 
     if [ "${MYSQL_STATUS}" -ne 0 ] || [ "${MYSQL_QUERY_STATUS}" -ne 0 ]; then
       logerror "${FUNCNAME[0]}" "analyze table ${tblName} failed"

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -75,6 +75,9 @@ job:
         # -- Query all tables in all non system databases(information_schema, performance_schema, mysql, sys, innodb) and analyze them. This will skip the analyzeTable.tables option
         # @default -- false
         allTables:
+        # -- Whether to enable verbose logging
+        # @default -- false
+        verbose:
     # -- [Schedule](https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#schedule) for the maintenance job based on that [syntax](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#cron-schedule-syntax)
     # @default -- [5 9 * * 2](https://crontab.guru/#5_9_*_*_2)
     schedule:


### PR DESCRIPTION
- chart version bumped
- if enabled the reponse from MariaDB will be added to the logs like here
```
{"@timestamp":"2025-02-27T11:58:00+UTC","ecs.version":"1.6.0","log.logger":"/usr/bin/mariadb-cronjob-maintenance.sh","log.origin.function":"analyzeTable","log.level":"info","message":"analyze table `keystone`.`project`"}
Table	Op	Msg_type	Msg_text
keystone.project	analyze	status	Engine-independent statistics collected
keystone.project	analyze	status	OK
{"@timestamp":"2025-02-27T11:58:00+UTC","ecs.version":"1.6.0","log.logger":"/usr/bin/mariadb-cronjob-maintenance.sh","log.origin.function":"analyzeTable","log.level":"info","message":"analyze table `keystone`.`project` done"}
```