### PR TITLE
[mariadb] use passwordless local connections for healthchecks and exporter

### DIFF
--- a/common/mariadb/templates/_helpers.tpl
+++ b/common/mariadb/templates/_helpers.tpl
@@ -34,19 +34,6 @@
 {{- end -}}
 {{- end -}}
 
-{{/*
-This function resolves a secret and escapes it for use in a my.cnf file.
-It replaces backslashes with double backslashes.
- */}}
-{{- define "mariadb.resolve_secret_for_ini" }}
-    {{- $str := . -}}
-    {{- if (hasPrefix "vault+kvv2" $str ) -}}
-        {{"{{"}} resolve "{{ $str }}" | replace "\\" "\\\\" | squote {{"}}"}}
-    {{- else -}}
-        {{ $str | replace "\\" "\\\\" | squote }}
-{{- end }}
-{{- end }}
-
 {{- define "mariadb.root_password" -}}
 {{- include "mariadb.resolve_secret" (required ".Values.root_password missing" .Values.root_password) }}
 {{- end -}}

--- a/common/mariadb/templates/config/_client.cnf.tpl
+++ b/common/mariadb/templates/config/_client.cnf.tpl
@@ -1,4 +1,4 @@
 [client]
-port     = 3306
-socket   = /var/run/mysqld/mysqld.sock
-password = {{ include "mariadb.resolve_secret_for_ini" (required ".Values.root_password missing" .Values.root_password) }}
+user     = root
+protocol = socket
+socket   = /run/mysqld/mysqld.sock

--- a/common/mariadb/templates/deployment.yaml
+++ b/common/mariadb/templates/deployment.yaml
@@ -131,8 +131,8 @@ spec:
         image: "{{ required ".Values.global.dockerHubMirrorAlternateRegion is missing" .Values.global.dockerHubMirrorAlternateRegion }}/{{ .Values.metrics.image }}:{{ .Values.metrics.image_version }}"
         imagePullPolicy: {{ default "IfNotPresent" .Values.imagePullPolicy | quote }}
         args:
-          - "--mysqld.username=root"
-          - "--mysqld.address=localhost:3306"
+          - "--mysqld.username=monitor"
+          - "--mysqld.address=127.0.0.1:3306"
         {{- range $flag := .Values.metrics.flags }}
           - "--{{$flag}}"
         {{- end }}
@@ -151,11 +151,6 @@ spec:
           periodSeconds: 20
           timeoutSeconds: 10
         env:
-          - name: MYSQLD_EXPORTER_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: mariadb-{{.Values.name}}
-                key: root-password
           - name: LOGLEVEL
             value: {{ default "info" .Values.metrics.loglevel }}
         ports:

--- a/common/mariadb/templates/initdb/_init.sql.tpl
+++ b/common/mariadb/templates/initdb/_init.sql.tpl
@@ -32,6 +32,15 @@ GRANT {{ . }} TO {{ include "mariadb.resolve_secret_squote" $username }};
     {{- end }}
 {{- end }}
 
+ALTER USER 'root'@'localhost' IDENTIFIED VIA unix_socket;
+
+{{- if .Values.metrics.enabled }}
+CREATE USER IF NOT EXISTS 'monitor'@'127.0.0.1' WITH MAX_USER_CONNECTIONS 5;
+GRANT SLAVE MONITOR, PROCESS, REPLICATION CLIENT, SELECT ON *.* TO 'monitor'@'127.0.0.1';
+{{- else }}
+DROP USER IF EXISTS 'monitor'@'127.0.0.1';
+{{- end }}
+
 {{- if (and (hasKey .Values "ccroot_user") (.Values.ccroot_user.enabled)) }}
 CREATE USER IF NOT EXISTS 'ccroot'@'127.0.0.1';
 GRANT ALL PRIVILEGES ON *.* TO 'ccroot'@'127.0.0.1';


### PR DESCRIPTION
* use local unix_socket connection for all status checks and mysqld_upgrade
  * this would allow to change root password without intermittent check failure
  * this would allow to use `'` and `\` in root password in mysqld_upgrade
* use monitor user with limited privileges for metrics sidecar