### PR TITLE
[mariadb] use `shared-app-images/alpine-kubectl` for pre-change job

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.17.2 - 2025/03/05
+* use `shared-app-images/alpine-kubectl` image for pre-change job instead of outdated `unified-kubernetes-toolbox`, that is supposed to be used in CI
+
 ## v0.17.1 - 2025/03/04
 * use local unix_socket connection for all status checks and mysqld_upgrade
   * this would allow to change root password without intermittent liveness check failure

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,6 +2,6 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.17.1
+version: 0.17.2
 # scripts/docker-entyrpoint.sh should be updated when appVersion is updated
 appVersion: 10.5.28

--- a/common/mariadb/templates/initdb/_configuredb.sh.tpl
+++ b/common/mariadb/templates/initdb/_configuredb.sh.tpl
@@ -1,33 +1,36 @@
-VERSION={{ .Values.pre_change_hook.kubectl_version }}
+#!/usr/bin/env ash
+# shellcheck shell=ash
+# shellcheck disable=SC2154
+# shellcheck disable=SC1083
+
+set -eou pipefail
+set -x
+
 DEPLOYMENT_NAME={{ include "fullName" . }}
 
 # Get the pod name associated with the deployment
-# becuase the pod name is dynamic, and kubectl cp command is working only with pods 
+# becuase the pod name is dynamic, and kubectl cp command is working only with pods
 # we need to get the pod name from the deployment
 
-POD_NAME=$(kubectl-v${VERSION} get pods -l app=${DEPLOYMENT_NAME} -o jsonpath='{.items[0].metadata.name}')
+POD_NAME=$(kubectl get pods -l app="${DEPLOYMENT_NAME}" -o jsonpath='{.items[0].metadata.name}')
 
-echo "POD_NAME: ${POD_NAME}"
+# Copy the secret file into the jobs /tmp directory
+# The original secret files can not be copied directly via kubectl cp
+cp -L /var/lib/initdb/init.sql /tmp/init.sql
 
-# Copy the file to the containers secret files can not be copied
-echo "prepare file to copy"
-cat /var/lib/initdb/init.sql > /tmp/init.sql
-
-echo "Copying init.sql to ${POD_NAME}:/tmp/init.sql"
-kubectl-v${VERSION} cp /tmp/init.sql ${POD_NAME}:/var/opt/initdb.sql -c mariadb
+# Copy the SQL script to the MariaDB container
+kubectl cp /tmp/init.sql "${POD_NAME}":/var/opt/initdb.sql -c mariadb
 
 # Run the SQL script
-echo "Running init.sql"
-kubectl-v${VERSION} exec -c mariadb ${POD_NAME} -- mariadb -uroot --batch -e "source /var/opt/initdb.sql"
+kubectl exec -c mariadb "${POD_NAME}" -- mariadb -uroot --batch -e "source /var/opt/initdb.sql"
 
-# shutdown linkerd containers
 {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
+# shutdown linkerd containers
 if command -v curl > /dev/null; then
   curl -X POST http://localhost:4191/shutdown || true
+elif command -v wget > /dev/null; then
+  wget -O- --post-data hello=shutdown http://0.0.0.0:4191/shutdown || true
 else
-# this section opens a local file descriptor to the linkerd admin port and sends a POST request to /shutdown
- ( exec 3<>/dev/tcp/localhost/4191 && 
-   printf "POST /shutdown HTTP/1.0\r\n\r\n" 1>&3  && 
-   cat <&3 || true )
+  printf "POST /shutdown HTTP/1.0\r\n\r\n" | nc localhost 4191 || true
 fi
 {{- end }}

--- a/common/mariadb/templates/pre-change-job.yaml
+++ b/common/mariadb/templates/pre-change-job.yaml
@@ -24,9 +24,9 @@ spec:
       serviceAccountName: {{ .Values.name }}-db-exec
       containers:
       - name: pre-change-job
-        image: "{{ required ".Values.global.dockerHubMirrorAlternateRegion is missing" .Values.global.dockerHubMirrorAlternateRegion }}/{{ .Values.pre_change_hook.image }}:{{ .Values.pre_change_hook.image_version }}"
+        image: "{{ required ".Values.global.registryAlternateRegion missing" .Values.global.registryAlternateRegion }}/{{ .Values.pre_change_hook.image.name }}:{{ .Values.pre_change_hook.image.tag }}"
         command:
-          - /bin/bash
+          - /bin/sh
           - -c
           - |
             /configurator/configuredb.sh

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -113,9 +113,9 @@ job:
         cpu:
 
 pre_change_hook:
-  image: "sapcc/unified-kubernetes-toolbox"
-  image_version: "20220613150453"
-  kubectl_version: "1.23"
+  image:
+    name: "shared-app-images/alpine-kubectl"
+    tag: "3.21-20250214202620"
 
 # name of priorityClass to influence scheduling priority
 priority_class: "critical-infrastructure"


### PR DESCRIPTION
* use `shared-app-images/alpine-kubectl` image for a pre-change job instead of the outdated `unified-kubernetes-toolbox`
