### PR TITLE
[campfire] add domain exclusion list

### DIFF
--- a/openstack/limes-campfire/templates/deployment.yaml
+++ b/openstack/limes-campfire/templates/deployment.yaml
@@ -41,6 +41,8 @@ spec:
               value: ":80"
             - name: CAMPFIRE_OSLO_POLICY_PATH
               value: /etc/campfire/policy.json
+            - name: CAMPFIRE_DOMAIN_EXCLUSION_LIST: 
+              value: "monsoon3,hcp03"
 
             # credentials for authenticating incoming requests and talking to the regional masterdata API
             {{- if $is_global }}

--- a/openstack/limes-campfire/templates/deployment.yaml
+++ b/openstack/limes-campfire/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
               value: ":80"
             - name: CAMPFIRE_OSLO_POLICY_PATH
               value: /etc/campfire/policy.json
-            - name: CAMPFIRE_DOMAIN_EXCLUSION_LIST: 
+            - name: CAMPFIRE_DOMAIN_EXCLUSION_LIST
               value: "monsoon3,hcp03"
 
             # credentials for authenticating incoming requests and talking to the regional masterdata API


### PR DESCRIPTION
Campfire aims to resolve projectIDs of subprojects recursively in order to retrieve possible mail recipients.
If the top level project also does not include any data, the domain level will be queried.
This list contains the exclusions where this query should be avoided."