### PR TITLE
limes-campfire: seed users for global regions in a different way

### DIFF
--- a/openstack/limes-campfire/templates/secret.yaml
+++ b/openstack/limes-campfire/templates/secret.yaml
@@ -1,16 +1,10 @@
 {{- $vbase  := .Values.global.vaultBaseURL | required "missing value for .Values.global.vaultBaseURL" -}}
 {{- $region := .Values.global.region       | required "missing value for .Values.global.region"       -}}
-{{- $is_global := eq .Release.Namespace "limes-global" -}}
 
 apiVersion: v1
 kind: Secret
 metadata:
   name: campfire-secret
 data:
-  {{- if $is_global }}
-  os_password:     {{ printf "%s/%s/limes-global/keystone-user/service/password" $vbase $region | b64enc }}
-  cronus_password: {{ printf "%s/%s/limes/keystone-user/campfire/password" $vbase (contains "qa" $region | ternary "global-qa" "global") | b64enc }}
-  {{- else }}
-  os_password:     {{ printf "%s/%s/limes/keystone-user/service/password"  $vbase $region | b64enc }}
-  cronus_password: {{ printf "%s/%s/limes/keystone-user/campfire/password" $vbase $region | b64enc }}
-  {{- end }}
+  os_password:     {{ printf "%s/%s/%s/keystone-user/service/password"  $vbase $region .Release.Namespace | b64enc }}
+  cronus_password: {{ printf "%s/%s/%s/keystone-user/campfire/password" $vbase $region .Release.Namespace | b64enc }}

--- a/openstack/limes/templates/configmap.yaml
+++ b/openstack/limes/templates/configmap.yaml
@@ -10,7 +10,7 @@ data:
     {{- range .Values.global.availability_zones }}
       - {{ . }}
     {{- end }}
-    {{- if not (or (.Values.global.region | regexMatch "qa-de-[2-6]") (eq .Release.Namespace "limes-global")) }}
+    {{- if and (eq .Values.global.region "qa-de-1") (ne .Release.Namespace "limes-global") }}
     mail_notifications:
       endpoint: {{ .Values.limes.clusters.ccloud.catalog_url | replace "limes-3" "limes-campfire" | trimSuffix "/" }}/
       templates:

--- a/openstack/limes/templates/seed-campfire.yaml
+++ b/openstack/limes/templates/seed-campfire.yaml
@@ -23,4 +23,14 @@ spec:
               role:    email_user
         {{- end }}
 
+        {{- range $d := keys .Values.campfire.all_global_deployments | sortAlpha }}
+        {{- $r := index $.Values.campfire.all_global_deployments $d }}
+        - name: campfire-{{$r}}-global
+          description: Campfire in {{$r}} for {{$d}} sending mails through {{$region}}
+          password: {{ printf "%s/%s/limes-global/keystone-user/campfire/password" $vbase $r | quote }}
+          role_assignments:
+            - project: master@ccadmin
+              role:    email_user
+        {{- end }}
+
 {{- end }}


### PR DESCRIPTION
Because of the way that the Vault permissions are set up, it's easier if we use passwords that are stored under the region where the Campfire is running.

Also, this temporarily limits Limes' usage of Campfire to qa-de-1, in order to enable a rollout to prod while Campfire is not deployed to prod yet.