### PR TITLE
[Nova] Remove ironic_service_password from CI values

### DIFF
--- a/openstack/nova/ci/test-values.yaml
+++ b/openstack/nova/ci/test-values.yaml
@@ -11,7 +11,6 @@ global:
     
   master_password: topSecret
   nova_service_password: topSecret
-  ironic_service_password: topSecret
   availability_zones:
     - foo
     - bar


### PR DESCRIPTION
We do not require this value to be set anymore and thus remove it to not confuse anybody searching for that string.