### PR TITLE
fix(opensearch): use .netrc in opensearch scripts

### DIFF
--- a/system/opensearch-logs/templates/config/_index_cleanup.sh.tpl
+++ b/system/opensearch-logs/templates/config/_index_cleanup.sh.tpl
@@ -5,39 +5,45 @@ export CLEANUP_INDEXES="kubernikus virtual scaleout logstash"
 
 export LC_ALL=C.UTF-8; export LANG=C.UTF-8
 
-curl -s -u "${ADMIN_USER}:${ADMIN_PASSWORD}" ${CLUSTER_HOST}/
+export CLUSTER_HOST_BASE=$(echo ${CLUSTER_HOST} | sed -E 's|https://([^:/]+).*|\1|')
+
+# Create a temporary netrc file
+export NETRC_FILE=$(mktemp)
+trap "rm -f ${NETRC_FILE}" EXIT
+
+# Try first user
+echo "machine ${CLUSTER_HOST_BASE} login ${ADMIN_USER} password ${ADMIN_PASSWORD}" > ${NETRC_FILE}
+curl -s --netrc-file ${NETRC_FILE} ${CLUSTER_HOST}/
 if [ $? -ne 0 ]; then
   echo "First user failed, trying second user"
-  # Second attempt with user2 if user1 fails
-  curl -s -u "${ADMIN2_USER}:${ADMIN2_PASSWORD}" ${CLUSTER_HOST}/
+
+  # Try second user
+  echo "machine ${CLUSTER_HOST_BASE} login ${ADMIN2_USER} password ${ADMIN2_PASSWORD}" > ${NETRC_FILE}
+  curl -s --netrc-file ${NETRC_FILE} ${CLUSTER_HOST}/
   if [ $? -ne 0 ]; then
     echo "Second user failed, giving up..."
     exit 1
-  else
-    export BASIC_AUTH_HEADER=${ADMIN2_USER}:${ADMIN2_PASSWORD}
   fi
-else
-  export BASIC_AUTH_HEADER=${ADMIN_USER}:${ADMIN_PASSWORD}
 fi
 
 for i in ${CLEANUP_INDEXES}
 do
-  export TO_DELETE_NEAR_FUTURE=`curl -s -u "${BASIC_AUTH_HEADER}" ${CLUSTER_HOST}/_aliases?pretty=true|grep $i | grep '20[0,1,3-9]'|awk '{ print $1}'|tr -d ':"'`
+  export TO_DELETE_NEAR_FUTURE=`curl -s --netrc-file ${NETRC_FILE} ${CLUSTER_HOST}/_aliases?pretty=true|grep $i | grep '20[0,1,3-9]'|awk '{ print $1}'|tr -d ':"'`
   for e in ${TO_DELETE_NEAR_FUTURE}
     do
       echo -e "Deleting index $e"
-      curl -u "${BASIC_AUTH_HEADER}" -X DELETE ${CLUSTER_HOST}/$e?pretty
+      curl --netrc-file ${NETRC_FILE} -X DELETE ${CLUSTER_HOST}/$e?pretty
   done
-  export TO_DELETE_FUTURE=`curl -s -u "${BASIC_AUTH_HEADER}" ${CLUSTER_HOST}/_aliases?pretty=true|grep $i | grep '2[1-9][0-9][0-9]'|awk '{ print $1}'|tr -d ':"'`
+  export TO_DELETE_FUTURE=`curl -s --netrc-file ${NETRC_FILE} ${CLUSTER_HOST}/_aliases?pretty=true|grep $i | grep '2[1-9][0-9][0-9]'|awk '{ print $1}'|tr -d ':"'`
   for p in ${TO_DELETE_FUTURE}
     do
       echo -e "Deleting index $p"
-      curl -u "${BASIC_AUTH_HEADER}" -X DELETE ${CLUSTER_HOST}/$p?pretty
+      curl --netrc-file ${NETRC_FILE} -X DELETE ${CLUSTER_HOST}/$p?pretty
   done
-  export TO_DELETE_PAST=`curl -s -u "${BASIC_AUTH_HEADER}" ${CLUSTER_HOST}/_aliases?pretty=true|grep $i | grep '19[0-9][0-9]'|awk '{ print $1}'|tr -d ':"'`
+  export TO_DELETE_PAST=`curl -s --netrc-file ${NETRC_FILE} ${CLUSTER_HOST}/_aliases?pretty=true|grep $i | grep '19[0-9][0-9]'|awk '{ print $1}'|tr -d ':"'`
   for d in ${TO_DELETE_FUTURE}
     do
       echo -e "Deleting index $d"
-      curl -u "${BASIC_AUTH_HEADER}" -X DELETE ${CLUSTER_HOST}/$d?pretty
+      curl --netrc-file ${NETRC_FILE} -X DELETE ${CLUSTER_HOST}/$d?pretty
   done
 done

--- a/system/opensearch-logs/templates/config/_install-ds-templates.sh.tpl
+++ b/system/opensearch-logs/templates/config/_install-ds-templates.sh.tpl
@@ -1,21 +1,25 @@
 #!/bin/bash
 
+export CLUSTER_HOST_BASE=$(echo ${CLUSTER_HOST} | sed -E 's|https://([^:/]+).*|\1|')
+
+# Create a temporary netrc file
+export NETRC_FILE=$(mktemp)
+trap "rm -f ${NETRC_FILE}" EXIT
+
 ####
 ##Check which admin user is active
 ####
-curl -s -u "${ADMIN_USER}:${ADMIN_PASSWORD}" ${CLUSTER_HOST}/
+echo "machine ${CLUSTER_HOST_BASE} login ${ADMIN_USER} password ${ADMIN_PASSWORD}" > "${NETRC_FILE}"
+curl -s --netrc-file "${NETRC_FILE}" "${CLUSTER_HOST}/"
 if [ $? -ne 0 ]; then
   echo "First user failed, trying second user"
   # Second attempt with user2 if user1 fails
-  curl -s -u "${ADMIN2_USER}:${ADMIN2_PASSWORD}" ${CLUSTER_HOST}/
+  echo "machine ${CLUSTER_HOST_BASE} login ${ADMIN2_USER} password ${ADMIN2_PASSWORD}" > "${NETRC_FILE}"
+  curl -s --netrc-file "${NETRC_FILE}" "${CLUSTER_HOST}/"
   if [ $? -ne 0 ]; then
     echo "Second user failed, giving up..."
     exit 1
-  else
-    export BASIC_AUTH_HEADER=${ADMIN2_USER}:${ADMIN2_PASSWORD}
   fi
-else
-  export BASIC_AUTH_HEADER=${ADMIN_USER}:${ADMIN_PASSWORD}
 fi
 
 ####
@@ -29,11 +33,11 @@ if [ "${DATA_STREAM_ENABLED}" = true ]; then
      export DS_ISM_TEMPLATE=ds-ism.json
 
      echo "creating file FILE=${TMPPATH}/${e}"
-     cp /${FILEPATH}/${DS_TEMPLATE} ${TMPPATH}/${e}-${DS_TEMPLATE}
+     cp "/${FILEPATH}/${DS_TEMPLATE}" "${TMPPATH}/${e}-${DS_TEMPLATE}"
      echo "Applying ${e}-${DS_TEMPLATE} to ${CLUSTER_HOST}"
-     sed -i "s/_DS_NAME_/${e}/g" ${TMPPATH}/${e}-${DS_TEMPLATE}
+     sed -i "s/_DS_NAME_/${e}/g" "${TMPPATH}/${e}-${DS_TEMPLATE}"
      if  grep -q "$e" "${TMPPATH}/${e}-${DS_TEMPLATE}" ; then
-         curl -u "${BASIC_AUTH_HEADER}" -H 'Content-Type: application/json' -XPUT "${CLUSTER_HOST}/_index_template/${e}-datastream" -d @${TMPPATH}/${e}-${DS_TEMPLATE}
+         curl --netrc-file "${NETRC_FILE}" -H 'Content-Type: application/json' -XPUT "${CLUSTER_HOST}/_index_template/${e}-datastream" -d @"${TMPPATH}/${e}-${DS_TEMPLATE}"
          echo -e "\nUpload of ds template for datastream ${e} done"
      else
        echo "\n${TMPPATH}/${e}-${DS_TEMPLATE} is missing or the replacement was not successful."
@@ -57,30 +61,30 @@ if [ "${DATA_STREAM_ENABLED}" = true ]; then
    echo "Datastream ism template creation"
    for e in ${DATA_STREAMS}; do
      # we have to copy the template from the scripts secrets to a directory, where we can change the template.
-     cp /${FILEPATH}/${DS_ISM_TEMPLATE} ${TMPPATH}/ds-${e}-${DS_ISM_TEMPLATE}
+     cp "/${FILEPATH}/${DS_ISM_TEMPLATE}" "${TMPPATH}/ds-${e}-${DS_ISM_TEMPLATE}"
      echo "Applying ${TMPPATH}/ds-${e}-${DS_ISM_TEMPLATE} to ${CLUSTER_HOST}"
      sed -i "s/_DS_NAME_/${e}/g" ${TMPPATH}/ds-${e}-${DS_ISM_TEMPLATE}
      sed -i "s/_SCHEMAVERSION_/${FILE_RETENTION_SCHEMA_VERSION}/g" ${TMPPATH}/ds-${e}-${DS_ISM_TEMPLATE}
      # initial upload or test if ism policy exists
-     export POLICY_RETURN_CODE=$( curl -s -o /dev/null -s -w "%{http_code}\n" -u "${BASIC_AUTH_HEADER}" -XGET "${CLUSTER_HOST}/_plugins/_ism/policies/ds-${e}-ism")
+     export POLICY_RETURN_CODE=$( curl -s -o /dev/null -s -w "%{http_code}\n" --netrc-file "${NETRC_FILE}" -XGET "${CLUSTER_HOST}/_plugins/_ism/policies/ds-${e}-ism")
      echo -e "\nReturn code is $POLICY_RETURN_CODE\n"
      if [ "${POLICY_RETURN_CODE}" -eq 404 ]; then
         # 1. Part: install of new ds ism policy
         echo -e "inital upload of datastream ism policy"
-        echo -e "Upload ds policy, there is no policy "ds-${e}-ism" installed"
-        curl -u "${BASIC_AUTH_HEADER}" -XPUT "${CLUSTER_HOST}/_plugins/_ism/policies/ds-${e}-ism" -H 'Content-Type: application/json' -d @${TMPPATH}/ds-${e}-${DS_ISM_TEMPLATE}
+        echo -e "Upload ds policy, there is no policy \"ds-${e}-ism\" installed"
+        curl --netrc-file "${NETRC_FILE}" -XPUT "${CLUSTER_HOST}/_plugins/_ism/policies/ds-${e}-ism" -H 'Content-Type: application/json' -d @"${TMPPATH}/ds-${e}-${DS_ISM_TEMPLATE}"
 
         # 2. create datastream, if missing. It's done here, because the normal template has no versioning and can be overwritten during each run.
         #    data_stream example: otellogs-datastream
 
-        export EXISTING_DS=`curl -s -u "${BASIC_AUTH_HEADER}" -XGET "${CLUSTER_HOST}/_data_stream"|jq .data_streams[].name|awk ' {gsub("-datastream","") } 1'|tr  -d \"`
+        export EXISTING_DS=`curl -s --netrc-file "${NETRC_FILE}" -XGET "${CLUSTER_HOST}/_data_stream"|jq .data_streams[].name|awk ' {gsub("-datastream","") } 1'|tr  -d \"`
         echo "\nExisting datastreams: $EXISTING_DS\n"
         echo "$EXISTING_DS" | grep -q "^$e$"
         if [ $? -eq 1 ]; then
            echo "\nCreating datastream $e\n"
-           curl -u "${BASIC_AUTH_HEADER}" -XPUT "${CLUSTER_HOST}/_data_stream/${e}-datastream"
+           curl --netrc-file "${NETRC_FILE}" -XPUT "${CLUSTER_HOST}/_data_stream/${e}-datastream"
            # Assign ISM policy to newly created datastream
-           curl --header 'content-type: application/JSON' --silent -u "${BASIC_AUTH_HEADER}" -XPOST "${CLUSTER_HOST}/_plugins/_ism/add/.ds-${e}-datastream-000001" -d "{ \"policy_id\": \"ds-${e}-ism\" }"
+           curl --header 'content-type: application/JSON' --silent --netrc-file "${NETRC_FILE}" -XPOST "${CLUSTER_HOST}/_plugins/_ism/add/.ds-${e}-datastream-000001" -d "{ \"policy_id\": \"ds-${e}-ism\" }"
         else
            echo "No datastream creation return code was not 1 for datastream $e"
         fi
@@ -89,28 +93,28 @@ if [ "${DATA_STREAM_ENABLED}" = true ]; then
        # update of policy based on existing SEQ_NUMBER and PRIM_TERM, both have to be the same as the one, which is installed. Otherwise an update is not possible.
        # Only update ism template, if schema_version has a new version number
 
-       export CLUSTER_RETENTION_RESPONSE=$(curl -s -u "${BASIC_AUTH_HEADER}" -XGET "${CLUSTER_HOST}/_plugins/_ism/policies/ds-${e}-ism")
+       export CLUSTER_RETENTION_RESPONSE=$(curl -s --netrc-file "${NETRC_FILE}" -XGET "${CLUSTER_HOST}/_plugins/_ism/policies/ds-${e}-ism")
        export CLUSTER_RETENTION_SCHEMA_VERSION=$(echo ${CLUSTER_RETENTION_RESPONSE} | jq .policy.schema_version?)
        export CLUSTER_RETENTION_RUN_PRIM_TERM=$(echo ${CLUSTER_RETENTION_RESPONSE} | jq ._primary_term?)
        export CLUSTER_RETENTION_SEQ_NUMBER=$(echo ${CLUSTER_RETENTION_RESPONSE} | jq ._seq_no?)
-      
-       if [ -z ${FILE_RETENTION_SCHEMA_VERSION} ]; then
+
+       if [ -z "${FILE_RETENTION_SCHEMA_VERSION}" ]; then
          echo -e "Variable FILE_RETENTION_SCHEMA_VERSION is empty or not existing\n"
        else
          echo -e "secret env variable schema_version: ${FILE_RETENTION_SCHEMA_VERSION}"
        fi
-       if [ -z ${CLUSTER_RETENTION_SCHEMA_VERSION} ]; then
+       if [ -z "${CLUSTER_RETENTION_SCHEMA_VERSION}" ]; then
          echo -e "variable CLUSTER_RETENTION_SCHEMA_VERSION is empty or not existing\n"
        else
          echo "secret database schema_version: ${CLUSTER_RETENTION_SCHEMA_VERSION}"
        fi
        if [ "${FILE_RETENTION_SCHEMA_VERSION}" -gt "${CLUSTER_RETENTION_SCHEMA_VERSION}" ]; then
          #echo "Deleting old policy ds-${e}-ism"
-         #curl -u "${BASIC_AUTH_HEADER}" -XDELETE "${CLUSTER_HOST}/_plugins/_ism/policies/ds-${e}-ism"
+         #curl --netrc-file "${NETRC_FILE}" -XDELETE "${CLUSTER_HOST}/_plugins/_ism/policies/ds-${e}-ism"
          echo -e "\nupload of new ism template with primary number: ${CLUSTER_RETENTION_RUN_PRIM_TERM} and existing sequence number: ${CLUSTER_RETENTION_SEQ_NUMBER}\n"
-         curl -u "${BASIC_AUTH_HEADER}" -XPUT "${CLUSTER_HOST}/_plugins/_ism/policies/ds-${e}-ism?if_seq_no=${CLUSTER_RETENTION_SEQ_NUMBER}&if_primary_term=${CLUSTER_RETENTION_RUN_PRIM_TERM}" -H 'Content-Type: application/json' -d @${TMPPATH}/ds-${e}-${DS_ISM_TEMPLATE}
-         cat ${TMPPATH}/ds-${e}-${DS_ISM_TEMPLATE}
-         export NEW_CLUSTER_RETENTION_SCHEMA_VERSION=$(curl -s -u "${BASIC_AUTH_HEADER}" -XGET "${CLUSTER_HOST}/_plugins/_ism/policies/ds-${e}-ism"|jq .policy.schema_version?)
+         curl --netrc-file "${NETRC_FILE}" -XPUT "${CLUSTER_HOST}/_plugins/_ism/policies/ds-${e}-ism?if_seq_no=${CLUSTER_RETENTION_SEQ_NUMBER}&if_primary_term=${CLUSTER_RETENTION_RUN_PRIM_TERM}" -H 'Content-Type: application/json' -d @"${TMPPATH}/ds-${e}-${DS_ISM_TEMPLATE}"
+         cat "${TMPPATH}/ds-${e}-${DS_ISM_TEMPLATE}"
+         export NEW_CLUSTER_RETENTION_SCHEMA_VERSION=$(curl -s --netrc-file "${NETRC_FILE}" -XGET "${CLUSTER_HOST}/_plugins/_ism/policies/ds-${e}-ism"|jq .policy.schema_version?)
          echo -e "\nNew schema_version is: ${NEW_CLUSTER_RETENTION_SCHEMA_VERSION}\n, increase this value by 1 to install new ism policy for ds-${e}-ism\n"
        else
          echo "No changes, ism template is not updated. Increase the version number to upload a new ism template"

--- a/system/opensearch-logs/templates/config/_install-index-templates.sh.tpl
+++ b/system/opensearch-logs/templates/config/_install-index-templates.sh.tpl
@@ -12,92 +12,102 @@
 # This script is used for OpenSearch Hermes and logs, because of different requirements and settings there are if
 # sections for Hermes and logs.
 #
-# After a new index template is installed the new index template is assigned to all existing indexes, which are listed in  the secrets variable ism_indexes.
+# After a new index template is installed the new index template is assigned to all existing indexes, which are listed in the secrets variable ism_indexes.
 
-####
+export CLUSTER_HOST_BASE=$(echo ${CLUSTER_HOST} | sed -E 's|https://([^:/]+).*|\1|')
+
+# Create a temporary netrc file
+export NETRC_FILE=$(mktemp)
+trap "rm -f ${NETRC_FILE}" EXIT
+
 echo -e "0.0 Check which admin user is active"
-curl -s -u "${ADMIN_USER}:${ADMIN_PASSWORD}" ${CLUSTER_HOST}/
+echo "machine ${CLUSTER_HOST_BASE} login ${ADMIN_USER} password ${ADMIN_PASSWORD}" > "${NETRC_FILE}"
+curl -s --netrc-file "${NETRC_FILE}" ${CLUSTER_HOST}/
 if [ $? -ne 0 ]; then
   echo "First user failed, trying second user"
   # Second attempt with user2 if user1 fails
-  curl -s -u "${ADMIN2_USER}:${ADMIN2_PASSWORD}" ${CLUSTER_HOST}/
+  echo "machine ${CLUSTER_HOST_BASE} login ${ADMIN2_USER} password ${ADMIN2_PASSWORD}" > "${NETRC_FILE}"
+  curl -s --netrc-file "${NETRC_FILE}" ${CLUSTER_HOST}/
   if [ $? -ne 0 ]; then
     echo "Second user failed, giving up..."
     exit 1
-  else
-    export BASIC_AUTH_HEADER=${ADMIN2_USER}:${ADMIN2_PASSWORD}
   fi
-else
-  export BASIC_AUTH_HEADER=${ADMIN_USER}:${ADMIN_PASSWORD}
 fi
 
 echo -e "0. Check for index policy\n"
 
 export ISM_FILE=/scripts/index-ism.json
 
-export POLICY_RETURN_CODE=$( curl -s -o /dev/null -s -w "%{http_code}\n" -u "${BASIC_AUTH_HEADER}" -XGET "${CLUSTER_HOST}/_plugins/_ism/policies/${RETENTION_NAME}retention")
+export POLICY_RETURN_CODE=$(curl -s -o /dev/null -s -w "%{http_code}\n" --netrc-file "${NETRC_FILE}" -XGET "${CLUSTER_HOST}/_plugins/_ism/policies/${RETENTION_NAME}retention")
 echo -e "Return code is $POLICY_RETURN_CODE"
 if [ "${POLICY_RETURN_CODE}" -eq 404 ]; then
   # 1. Part: install of new index policy
   echo -e "inital upload of index policy\n"
-  echo -e "Upload index policy, there is no policy "${RETENTION_NAME}retention" installed"
-  curl -u "${BASIC_AUTH_HEADER}" -XPUT "${CLUSTER_HOST}/_plugins/_ism/policies/${RETENTION_NAME}retention" -H 'Content-Type: application/json' -d @${ISM_FILE}
+  echo -e "Upload index policy, there is no policy \"${RETENTION_NAME}retention\" installed"
+  curl --netrc-file "${NETRC_FILE}" -XPUT "${CLUSTER_HOST}/_plugins/_ism/policies/${RETENTION_NAME}retention" -H 'Content-Type: application/json' -d @${ISM_FILE}
 
   # add all indexes, which need a retention
   echo "\nManaged indexes are ${ISM_INDEXES}\n"
 
   # get all indexes without a policy
-  export MISSING_INDEXES=$(for l in ${ISM_INDEXES}; do    curl -s -u "${BASIC_AUTH_HEADER}" -XGET "${CLUSTER_HOST}/_plugins/_ism/explain/${l}-*"|jq|grep -B4 "enabled\": null"|grep ${l}|awk -F: '{ print $1}'|awk -F\" '{ print $2}'; done)
+  export MISSING_INDEXES=$(for l in ${ISM_INDEXES}; do \
+    curl -s --netrc-file "${NETRC_FILE}" -XGET "${CLUSTER_HOST}/_plugins/_ism/explain/${l}-*" | \
+    jq | grep -B4 "enabled\": null" | grep ${l} | awk -F: '{ print $1 }' | awk -F\" '{ print $2 }'; \
+  done)
+
   if [ -z "$MISSING_INDEXES" ]; then
-    echo -e "\nNo index without policy\n";
+    echo -e "\nNo index without policy\n"
   else
-for i in ${MISSING_INDEXES}
-do
-  echo -e "\nindex without a policy ${i}, appying ism policy\n"
-  curl --header 'content-type: application/JSON' --silent -u "${BASIC_AUTH_HEADER}" -XPOST "${CLUSTER_HOST}/_plugins/_ism/add/${i}" -d "{ \"policy_id\": \"${RETENTION_NAME}retention\" }"
-done;
-  fi;
+    for i in ${MISSING_INDEXES}; do
+      echo -e "\nindex without a policy ${i}, appying ism policy\n"
+      curl --header 'content-type: application/JSON' --silent -u "${BASIC_AUTH_HEADER}" -XPOST "${CLUSTER_HOST}/_plugins/_ism/add/${i}" -d "{ \"policy_id\": \"${RETENTION_NAME}retention\" }"
+    done
+  fi
 elif [ "${POLICY_RETURN_CODE}" -eq 401 ]; then
   echo -e "Unauthorized, please check roles for user or password"
 else
-  echo -e "\nISM policy already exists, return code is ${POLICY_RETURN_CODE}\n";
+  echo -e "\nISM policy already exists, return code is ${POLICY_RETURN_CODE}\n"
   # get all indexes without a policy
-  export MISSING_INDEXES=$(for l in ${ISM_INDEXES}; do    curl -s -u "${BASIC_AUTH_HEADER}" -XGET "${CLUSTER_HOST}/_plugins/_ism/explain/${l}-*"|jq|grep -B4 "enabled\": null"|grep ${l}|awk -F: '{ print $1}'|awk -F\" '{ print $2}'; done)
+  export MISSING_INDEXES=$(for l in ${ISM_INDEXES}; do \
+    curl -s --netrc-file "${NETRC_FILE}" -XGET "${CLUSTER_HOST}/_plugins/_ism/explain/${l}-*" | \
+    jq | grep -B4 "enabled\": null" | grep ${l} | awk -F: '{ print $1 }' | awk -F\" '{ print $2 }'; \
+  done)
+
   if [ -z "$MISSING_INDEXES" ]; then
-    echo -e "\nNo index without policy\n";
+    echo -e "\nNo index without policy\n"
   else
-for i in ${MISSING_INDEXES}
-do
-  echo -e "\nindex without a policy ${i}, appying ism policy\n"
-  curl --header 'content-type: application/JSON' --silent -u "${BASIC_AUTH_HEADER}" -XPOST "${CLUSTER_HOST}/_plugins/_ism/add/${i}" -d "{ \"policy_id\": \"${RETENTION_NAME}retention\" }"
-done;
-  fi;
+    for i in ${MISSING_INDEXES}; do
+      echo -e "\nindex without a policy ${i}, appying ism policy\n"
+      curl --header 'content-type: application/JSON' --silent --netrc-file "${NETRC_FILE}" -XPOST "${CLUSTER_HOST}/_plugins/_ism/add/${i}" -d "{ \"policy_id\": \"${RETENTION_NAME}retention\" }"
+    done
+  fi
 fi
 
 # 2. Part update of existing policy
 # update of policy based on existing SEQ_NUMBER and PRIM_TERM, both have to be the same as the one, which is installed. Otherwise an update is not possible.
 # Only update ism template, if schema_version has a new version number
 
-export CLUSTER_RETENTION_SCHEMA_VERSION=$(curl -s -u "${BASIC_AUTH_HEADER}" -XGET "${CLUSTER_HOST}/_plugins/_ism/policies/${RETENTION_NAME}retention"|jq ._version?)
+export CLUSTER_RETENTION_SCHEMA_VERSION=$(curl -s --netrc-file "${NETRC_FILE}" -XGET "${CLUSTER_HOST}/_plugins/_ism/policies/${RETENTION_NAME}retention" | jq ._version?)
 
 echo -e "secret file schema_version: ${FILE_RETENTION_SCHEMA_VERSION}"
 echo -e "secret installed schema_version: ${CLUSTER_RETENTION_SCHEMA_VERSION}"
 
-
 if [ "$FILE_RETENTION_SCHEMA_VERSION" -gt "$CLUSTER_RETENTION_SCHEMA_VERSION" ]; then
-  export RUN_PRIM_TERM=$(curl -s -u "${BASIC_AUTH_HEADER}" -XGET "${CLUSTER_HOST}/_plugins/_ism/policies/${RETENTION_NAME}retention" |jq ._primary_term)
-  export RUN_SEQ_NUMBER=$(curl -s -u "${BASIC_AUTH_HEADER}" -XGET "${CLUSTER_HOST}/_plugins/_ism/policies/${RETENTION_NAME}retention" |jq ._seq_no )
+  export RUN_PRIM_TERM=$(curl -s --netrc-file "${NETRC_FILE}" -XGET "${CLUSTER_HOST}/_plugins/_ism/policies/${RETENTION_NAME}retention" | jq ._primary_term)
+  export RUN_SEQ_NUMBER=$(curl -s --netrc-file "${NETRC_FILE}" -XGET "${CLUSTER_HOST}/_plugins/_ism/policies/${RETENTION_NAME}retention" | jq ._seq_no)
   echo -e "\nupload of new ism template with primary number: ${RUN_PRIM_TERM} and existing sequence number: ${RUN_SEQ_NUMBER}\n"
-  curl -u "${BASIC_AUTH_HEADER}" -XPUT "${CLUSTER_HOST}/_plugins/_ism/policies/${RETENTION_NAME}retention?if_seq_no=${RUN_SEQ_NUMBER}&if_primary_term=${RUN_PRIM_TERM}" -H 'Content-Type: application/json' -d @${ISM_FILE};
+  curl --netrc-file "${NETRC_FILE}" -XPUT "${CLUSTER_HOST}/_plugins/_ism/policies/${RETENTION_NAME}retention?if_seq_no=${RUN_SEQ_NUMBER}&if_primary_term=${RUN_PRIM_TERM}" -H 'Content-Type: application/json' -d @${ISM_FILE}
 
   # update all indexes with new policy
-  export UPDATE_INDEXES=$(for l in ${ISM_INDEXES}; do curl -s -u "${BASIC_AUTH_HEADER}" -XGET "${CLUSTER_HOST}/_cat/indices?v"|grep ${l}|awk '{ print $3 }'  ; done)
+  export UPDATE_INDEXES=$(for l in ${ISM_INDEXES}; do \
+    curl -s --netrc-file "${NETRC_FILE}" -XGET "${CLUSTER_HOST}/_cat/indices?v" | grep ${l} | awk '{ print $3 }'; \
+  done)
+
   for e in ${UPDATE_INDEXES}; do
-     echo -e "\nAssigning new ism policy version to index: ${e}\n"
-     curl -u "${BASIC_AUTH_HEADER}" -H 'Content-Type: application/json' -XPOST "${CLUSTER_HOST}/_plugins/_ism/change_policy/${e}" -d "{ \"policy_id\": \"${RETENTION_NAME}retention\" }"
-  done;
+    echo -e "\nAssigning new ism policy version to index: ${e}\n"
+    curl --netrc-file "${NETRC_FILE}" -H 'Content-Type: application/json' -XPOST "${CLUSTER_HOST}/_plugins/_ism/change_policy/${e}" -d "{ \"policy_id\": \"${RETENTION_NAME}retention\" }"
+  done
 fi
 
-export NEW_CLUSTER_RETENTION_SCHEMA_VERSION=$(curl -s -u "${BASIC_AUTH_HEADER}" -XGET "${CLUSTER_HOST}/_plugins/_ism/policies/${RETENTION_NAME}retention"|jq ._version?)
-echo -e "\nNew schema_version is: ${NEW_CLUSTER_RETENTION_SCHEMA_VERSION}\n, increase this value by 1 to install new ism policy for ${RETENTION_NAME}etention\n"
-#####
+export NEW_CLUSTER_RETENTION_SCHEMA_VERSION=$(curl -s --netrc-file "${NETRC_FILE}" -XGET "${CLUSTER_HOST}/_plugins/_ism/policies/${RETENTION_NAME}retention" | jq ._version?)
+echo -e "\nNew schema_version is: ${NEW_CLUSTER_RETENTION_SCHEMA_VERSION}\n, increase this value by 1 to install new ism policy for ${RETENTION_NAME}retention\n"


### PR DESCRIPTION
To prevent a [Command line leakage](https://everything.curl.dev/cmdline/passwords.html#command-line-leakage) replacing `curl -u` with netrc in current OpenSearch scripts.