### PR TITLE
postgresql, redis: support no alerts

### DIFF
--- a/common/postgresql-ng/Chart.yaml
+++ b/common/postgresql-ng/Chart.yaml
@@ -1,13 +1,27 @@
 apiVersion: v2
 name: postgresql-ng
-version: 1.3.1 # this version number is SemVer as it gets used to auto bump
 description: Chart for PostgreSQL
-keywords:
-- postgresql
-- postgres
-- database
-- sql
-home: https://www.postgresql.org/
-sources:
-- https://github.com/kubernetes/charts
-- https://github.com/docker-library/postgres
+#
+# NOTE: When upgrading please note the following changes:
+#
+# 1.1.0
+# - Fix owner reference deletion
+#
+# 1.2.0
+# - Drop PostgreSQL 9.5
+#
+# 1.2.1
+# - Drop PostgreSQL 12, install Postgres 17
+#
+# 1.2.2
+# - Bump default PostgreSQL to 17
+#
+# 1.2.3
+# - Fix ownership of custom enum types
+#
+# 1.3.0
+# - Alert when auto issued secrets are about to expire (1 year)
+#
+# 1.3.1
+# - Support deploying without alerts (e.g. local development)
+version: 1.3.1 # this version number is SemVer as it gets used to auto bump

--- a/common/postgresql-ng/Chart.yaml
+++ b/common/postgresql-ng/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: postgresql-ng
-version: 1.3.0 # this version number is SemVer as it gets used to auto bump
+version: 1.3.1 # this version number is SemVer as it gets used to auto bump
 description: Chart for PostgreSQL
 keywords:
 - postgresql

--- a/common/postgresql-ng/templates/prometheus-alerts.yaml
+++ b/common/postgresql-ng/templates/prometheus-alerts.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.alerts.enabled -}}
+
 {{- $fullname := include "postgres.fullname" . -}}
 {{- $service  := .Values.alerts.service       | default  .Release.Name -}}
 {{- $sgroup   := .Values.alerts.support_group | required "missing value for .Values.postgresql.alerts.support_group" -}}
@@ -39,3 +41,4 @@ spec:
           annotations:
             summary: 'PostgreSQL user secret is expired'
             description: 'The secret {{`{{`}} $labels.namespace {{`}}/{{`}} $labels.secret {{`}}`}} is over 365 days old. Please rotate it as soon as possible by following the attached playbook.'
+{{- end -}}

--- a/common/postgresql-ng/values.yaml
+++ b/common/postgresql-ng/values.yaml
@@ -73,6 +73,7 @@ probe_timeout_secs: 3
 probe_failure_threshold: 6 # number of liveness probes that need to fail to trigger a pod restart
 
 alerts:
+  enabled: true
   support_group: null # This field must be filled by the top-level chart.
   service: null       # defaults to .Release.Name if not set
 

--- a/common/redis/Chart.yaml
+++ b/common/redis/Chart.yaml
@@ -34,4 +34,7 @@ name: redis
 #
 # 2.1.0
 # - The field `.Values.redis.alerts.support_group` must now be provided by the parent chart.
-version: 2.1.0 # this version number is SemVer as it gets used to auto bump
+#
+# 2.1.1
+# - Support deploying without alerts (e.g. local development)
+version: 2.1.1 # this version number is SemVer as it gets used to auto bump

--- a/common/redis/templates/prometheus-alerts.yaml
+++ b/common/redis/templates/prometheus-alerts.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.alerts.enabled -}}
+
 {{- $fullname := include "redis.fullname" . -}}
 {{- $service  := .Values.alerts.service       | default  .Release.Name -}}
 {{- $sgroup   := .Values.alerts.support_group | required "missing value for .Values.redis.alerts.support_group" -}}
@@ -39,3 +41,4 @@ spec:
           annotations:
             summary: 'PostgreSQL user secret is expired'
             description: 'The secret {{`{{`}} $labels.namespace {{`}}/{{`}} $labels.secret {{`}}`}} is over 365 days old. Please rotate it as soon as possible by following the attached playbook.'
+{{- end -}}

--- a/common/redis/values.yaml
+++ b/common/redis/values.yaml
@@ -34,6 +34,7 @@ resources:
     cpu: 100m
 
 alerts:
+  enabled: true
   support_group: null # This field must be filled by the top-level chart.
   service: null       # defaults to .Release.Name if not set
 


### PR DESCRIPTION
The need to deploy without `PrometheusRule` comes from the cases where the corresponding CRDs aren't registered - typically, in local throw-away development clusters.