### PR TITLE
[ironic] fix secrets-injector syntax

### DIFF
--- a/openstack/ironic/templates/etc/_inspector_secrets.conf.tpl
+++ b/openstack/ironic/templates/etc/_inspector_secrets.conf.tpl
@@ -2,8 +2,8 @@
 {{- include "ini_sections.default_transport_url" . }}
 
 [ironic]
-username = {{ .Values.global.ironicServiceUser }}
-password = {{ required ".Values.global.ironicServicePassword is missing" .Values.global.ironicServicePassword }}
+username = {{ .Values.global.ironicServiceUser | include "resolve_secret" }}
+password = {{ required ".Values.global.ironicServicePassword is missing" .Values.global.ironicServicePassword | include "resolve_secret" }}
 
 [database]
 {{- if eq .Values.dbType "mariadb" }}
@@ -15,7 +15,7 @@ connection = {{ tuple . .Values.pxc_db.users.ironic_inspector.name .Values.pxc_d
 {{- end }}
 
 [keystone_authtoken]
-username = {{ .Values.global.ironicServiceUser }}
-password = {{ required ".Values.global.ironicServicePassword is missing" .Values.global.ironicServicePassword }}
+username = {{ .Values.global.ironicServiceUser | include "resolve_secret" }}
+password = {{ required ".Values.global.ironicServicePassword is missing" .Values.global.ironicServicePassword  | include "resolve_secret" }}
 
 {{- include "ini_sections.audit_middleware_notifications" . }}

--- a/openstack/ironic/templates/etc/_netrc.tpl
+++ b/openstack/ironic/templates/etc/_netrc.tpl
@@ -1,3 +1,3 @@
 machine ironic-rabbitmq
-login {{ .Values.rabbitmq.metrics.user }}
-password "{{ .Values.rabbitmq.metrics.password }}"
+login {{ .Values.rabbitmq.metrics.user | include "resolve_secret" }}
+password "{{ .Values.rabbitmq.metrics.password | include "resolve_secret" }}"

--- a/openstack/ironic/templates/etc/_nginx.conf.tpl
+++ b/openstack/ironic/templates/etc/_nginx.conf.tpl
@@ -45,7 +45,7 @@ server {
     # We obviously do not have to secure any static resources
     location ~* "/[^/]*/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/([0-9]*)/([^/]*)/?$" {
         secure_link $3,$2;
-        secure_link_md5 "$secure_link_expires$1 {{required "A valid .Values.console.secret required!" .Values.console.secret}}";
+        secure_link_md5 "$secure_link_expires$1 {{required "A valid .Values.console.secret required!" .Values.console.secret | include "resolve_secret" }}";
 
         set $check $secure_link;
 

--- a/openstack/ironic/templates/etc/_secrets.conf.tpl
+++ b/openstack/ironic/templates/etc/_secrets.conf.tpl
@@ -3,17 +3,17 @@
 {{- include "ini_sections.oslo_messaging_rabbit" .}}
 
 [console]
-url_auth_digest_secret = {{required "A valid .Values.console.secret required!" .Values.console.secret}}
+url_auth_digest_secret = {{required "A valid .Values.console.secret required!" .Values.console.secret | include "resolve_secret" }}
 
 [database]
 connection = {{ include "utils.db_url" . }}
 
 [keystone_authtoken]
-username = {{ .Values.global.ironicServiceUser }}
+username = {{ .Values.global.ironicServiceUser | include "resolve_secret" }}
 password = {{ required ".Values.global.ironicServicePassword is missing" .Values.global.ironicServicePassword | include "resolve_secret" }}
 
 [service_catalog]
-username = {{ .Values.global.ironicServiceUser }}
+username = {{ .Values.global.ironicServiceUser | include "resolve_secret" }}
 password = {{ required ".Values.global.ironicServicePassword is missing" .Values.global.ironicServicePassword | include "resolve_secret" }}
 
 [glance]
@@ -23,8 +23,8 @@ swift_store_multi_tenant = True
     {{- if .Values.swift_multi_tenant }}
 swift_store_multiple_containers_seed = 32
     {{- end }}
-swift_temp_url_key = {{required "A valid .Values.swift_tempurl required!" .Values.swift_tempurl }}
-swift_account = {{required "A valid .Values.swift_account required!" .Values.swift_account }}
+swift_temp_url_key = {{required "A valid .Values.swift_tempurl required!" .Values.swift_tempurl  | include "resolve_secret"}}
+swift_account = {{required "A valid .Values.swift_account required!" .Values.swift_account | include "resolve_secret" }}
 {{- end }}
 
 {{ include "ini_sections.audit_middleware_notifications" . }}

--- a/openstack/ironic/templates/redfish-certrobot-secret.yaml
+++ b/openstack/ironic/templates/redfish-certrobot-secret.yaml
@@ -5,6 +5,6 @@ metadata:
 type: Opaque
 stringData:
   common: |
-{{ toYaml .Values.cert_robot.cloud_common | indent 4 }}
+{{ toYaml .Values.cert_robot.cloud_common | include "resolve_secret" | indent 4 }}
   sdk: |
 {{ toYaml .Values.cert_robot.cloud_sdk | indent 4 }}


### PR DESCRIPTION
Add missing resolve_secret everywhere the validator complains about.
Found with the help of the secrets-inejector-validator:
helm-template-app ironic | secrets-injector-validator -kinds=OpenstackSeed
