### PR TITLE
feat(opensearch-manager): Add dynamic credential selection via init container

### DIFF
--- a/system/opensearch-logs/vendor/manager/templates/_application.conf.tpl
+++ b/system/opensearch-logs/vendor/manager/templates/_application.conf.tpl
@@ -29,8 +29,8 @@ hosts = [
     host = "https://opensearch-logs-client.opensearch-logs:9200"
     name = "{{ .Values.global.cluster }} OpenSearch Logs Cluster"
     auth = {
-      username = "{{.Values.global.users.admin.name}}"
-      password = "{{.Values.global.users.admin.password}}"
+      username = "USERNAME_PLACEHOLDER"
+      password = "PASSWORD_PLACEHOLDER"
     }
   },
 {{- end }}

--- a/system/opensearch-logs/vendor/manager/templates/deployment.yaml
+++ b/system/opensearch-logs/vendor/manager/templates/deployment.yaml
@@ -43,6 +43,56 @@ spec:
           secret:
             defaultMode: 420
             secretName: admin-cert-manager
+        - name: dynamic-config
+          emptyDir: {}
+      initContainers:
+        - name: credential-checker
+          image: curlimages/curl:8.12.1
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              # Read credentials from secrets
+              user=$(cat /secrets/username)
+              pass=$(cat /secrets/password)
+              failover_user=$(cat /secrets/failover_username)
+              failover_pass=$(cat /secrets/failover_password)
+
+              # Create temporary .netrc files
+              mkdir -p /tmp/netrc
+              printf "machine opensearch-logs-client.opensearch-logs login %s password %s" \
+                "$user" "$pass" > /tmp/netrc/auth1
+              printf "machine opensearch-logs-client.opensearch-logs login %s password %s" \
+                "$failover_user" "$failover_pass" > /tmp/netrc/auth2
+
+              # Test credentials
+              test_connection() {
+                curl -s -o /dev/null -w "%{http_code}" \
+                  --netrc-file "$1" \
+                  --max-time 5 \
+                  --fail \
+                  "https://opensearch-logs-client.opensearch-logs:9200"
+              }
+
+              # Try credentials in sequence
+              for auth in /tmp/netrc/auth1 /tmp/netrc/auth2; do
+                if [ "$(test_connection $auth)" = "200" ]; then
+                  echo "Using valid credentials from ${auth}"
+                  valid_user=$(awk '/login/ {print $2}' $auth)
+                  valid_pass=$(awk '/password/ {print $2}' $auth)
+                  sed -e "s/USERNAME_PLACEHOLDER/$valid_user/g" \
+                      -e "s/PASSWORD_PLACEHOLDER/$valid_pass/g" \
+                      /secrets/application.conf > /dynamic-config/application.conf
+                  exit 0
+                fi
+              done
+
+              echo "All credential checks failed"
+              exit 1
+          volumeMounts:
+            - name: manager-secrets
+              mountPath: /secrets
+            - name: dynamic-config
+              mountPath: /dynamic-config
       containers:
       - name: manager
         image: {{.Values.global.registry}}/{{.Values.image_manager}}
@@ -66,7 +116,7 @@ spec:
             name: manager-etc
             subPath: logback.xml
           - mountPath: /manager-etc/application.conf
-            name: manager-secrets
+            name: dynamic-config
             subPath: application.conf
           - mountPath: /opt/certs/ca.crt
             name: admin-cert-manager

--- a/system/opensearch-logs/vendor/manager/templates/secrets.yaml
+++ b/system/opensearch-logs/vendor/manager/templates/secrets.yaml
@@ -1,8 +1,10 @@
 apiVersion: v1
 kind: Secret
-
 metadata:
   name: manager-secrets
-
 data:
- application.conf: {{ include (print .Template.BasePath  "/_application.conf.tpl") . | b64enc }}
+  application.conf: {{ include (print .Template.BasePath  "/_application.conf.tpl") . | b64enc }}
+  username: {{.Values.global.users.admin.name}}
+  password: {{.Values.global.users.admin.password}}
+  failover_username: {{.Values.global.users.admin2.name}}
+  failover_password: {{.Values.global.users.admin2.password}}


### PR DESCRIPTION
- Add init container to test Opensearch credentials
- Implement credential validation
- Update deployment to use dynamic configuration volume for credential injection
