### PR TITLE
[neutron] Resolve interconnection user in secret

### DIFF
--- a/openstack/neutron/templates/etc/_networking_interconnection_secrets.conf.tpl
+++ b/openstack/neutron/templates/etc/_networking_interconnection_secrets.conf.tpl
@@ -1,3 +1,3 @@
 [interconnection]
-username = {{ .Values.interconnection.user }}
+username = {{ .Values.interconnection.user | include "resolve_secret" }}
 password = {{ required "Interconnection password is missing" .Values.interconnection.password | include "resolve_secret" }}


### PR DESCRIPTION
Our interconnection user might be a vault reference, so we need to make sure to resolve it in the given secret.