### PR TITLE
[nova] remove pre_change_hook from nova chart values

### DIFF
--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -11,7 +11,7 @@ global:
   master_password: null
   domain_seeds:
     skip_hcm_domain: false
-    
+
   nova_service_user: nova
 
   hypervisors: []
@@ -952,11 +952,6 @@ sentry:
   enabled: true
 
 nova_bigvm_enabled: true
-
-pre_change_hook:
-  image: "sapcc/unified-kubernetes-toolbox"
-  image_version: "20220525082919"
-  kubectl_version: 1.21.8
 
 cors:
   enabled: true


### PR DESCRIPTION
Clean pre_change_hook from the nova chart values

These values were left after https://github.com/sapcc/helm-charts/pull/3660
