### PR TITLE
Settings for keystone federation via OIDC

### DIFF
--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: keystone
 sources:
   - https://github.com/sapcc/keystone
-version: 0.9.1
+version: 0.10.0
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/keystone/templates/deployment-api.yaml
+++ b/openstack/keystone/templates/deployment-api.yaml
@@ -41,7 +41,9 @@ spec:
         configmap-bin-hash: {{ include (print $.Template.BasePath "/configmap-bin.yaml") . | sha256sum }}
         secrets-bin-hash: {{ include (print $.Template.BasePath "/secret-bin.yaml") . | sha256sum }}
         secrets-hash: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        {{- if .Values.federation.oidc.enabled }}
         federation-hash: {{ include (print $.Template.BasePath "/federation.yaml") . | sha256sum }}
+        {{- end }}
         {{- if .Values.proxysql.mode }}
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}

--- a/openstack/keystone/templates/deployment-api.yaml
+++ b/openstack/keystone/templates/deployment-api.yaml
@@ -41,6 +41,7 @@ spec:
         configmap-bin-hash: {{ include (print $.Template.BasePath "/configmap-bin.yaml") . | sha256sum }}
         secrets-bin-hash: {{ include (print $.Template.BasePath "/secret-bin.yaml") . | sha256sum }}
         secrets-hash: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        federation-hash: {{ include (print $.Template.BasePath "/federation.yaml") . | sha256sum }}
         {{- if .Values.proxysql.mode }}
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
@@ -163,6 +164,12 @@ spec:
               mountPath: /etc/apache2/conf-enabled/wsgi-keystone.conf
               subPath: wsgi-keystone.conf
               readOnly: true
+            {{- if .Values.federation.oidc.enabled }}
+            - name: keystone-federation
+              mountPath: /etc/apache2/conf-enabled/federation-oidc.conf
+              subPath: federation-oidc.conf
+              readOnly: true
+            {{- end }}
             - name: keystone-etc
               mountPath: /etc/apache2/mods-available/mpm_event.conf
               subPath: mpm_event.conf
@@ -223,6 +230,12 @@ spec:
           secret:
             secretName: {{ .Release.Name }}-secrets
             defaultMode: 0444
+        {{- if .Values.federation.oidc.enabled }}
+        - name: keystone-federation
+          secret:
+            secretName: {{ .Release.Name }}-federation
+            defaultMode: 0444
+        {{- end }}
         - name: keystone-bin
           projected:
             defaultMode: 0555

--- a/openstack/keystone/templates/etc/_federation-oidc.conf.tpl
+++ b/openstack/keystone/templates/etc/_federation-oidc.conf.tpl
@@ -1,0 +1,24 @@
+{{- if .Values.federation.oidc.enabled }}
+
+OIDCClaimDelimiter ;
+OIDCClaimPrefix "OIDC-"
+OIDCResponseType "id_token"
+OIDCXForwardedHeaders X-Forwarded-Host X-Forwarded-Proto
+# List of attributes that the user will authorize the Identity Provider to send to the Service Provider
+OIDCScope "openid email profile"
+OIDCProviderMetadataURL "https://{{ .Values.federation.oidc.provider }}/.well-known/openid-configuration"
+OIDCOAuthVerifyJwksUri "https:///{{ .Values.federation.oidc.provider }}/oauth2/certs"
+# Data (client_id and secret) of the Client created in the IdP
+OIDCClientID "{{ .Values.federation.oidc.client_id | include "resolve_secret_urlquery" }}"
+OIDCClientSecret "{{ .Values.federation.oidc.client_secret | include "resolve_secret_urlquery" }}"
+
+# mod_auth_oidc internal data protection (no effect on the client)
+OIDCPKCEMethod "S256"
+OIDCCryptoPassphrase "{{ .Values.federation.oidc.crypto_passphrase | include "resolve_secret_urlquery" }}"
+OIDCAuthRequestParams idp=#
+
+# vanity URL that must point to a protected path that does not have any content, such as an extension of the protected federated auth path.
+# you should use it as a redirect_uri in the IDP
+OIDCRedirectURI "https://{{ .Values.services.public.host }}.{{ .Values.global.region }}.{{ .Values.global.tld }}/v3/auth/OS-FEDERATION/websso/openid"
+
+{{- end }}

--- a/openstack/keystone/templates/etc/_keystone.conf.tpl
+++ b/openstack/keystone/templates/etc/_keystone.conf.tpl
@@ -29,6 +29,11 @@ default_tag = vc-{{ $az }}-0
 
 {{- if .Values.api.auth }}
 [auth]
+{{- /*
+Note: the federation-related methods must be in the beginning of the list.
+This goes against the official keystone documentation.
+This allows them to work even if the "external" method is present.
+*/}}
 methods = {{ if .Values.federation.oidc.enabled }}openid,{{ end }}{{ .Values.api.auth.methods | default "password,token,application_credential" }}
 {{ if .Values.api.auth.external }}external = {{ .Values.api.auth.external }}{{ end }}
 {{ if .Values.api.auth.password }}password = {{ .Values.api.auth.password }}{{ end }}

--- a/openstack/keystone/templates/etc/_keystone.conf.tpl
+++ b/openstack/keystone/templates/etc/_keystone.conf.tpl
@@ -29,7 +29,7 @@ default_tag = vc-{{ $az }}-0
 
 {{- if .Values.api.auth }}
 [auth]
-methods = {{ .Values.api.auth.methods | default "password,token,application_credential" }}
+methods = {{ if .Values.federation.oidc.enabled }}openid,{{ end }}{{ .Values.api.auth.methods | default "password,token,application_credential" }}
 {{ if .Values.api.auth.external }}external = {{ .Values.api.auth.external }}{{ end }}
 {{ if .Values.api.auth.password }}password = {{ .Values.api.auth.password }}{{ end }}
 {{ if .Values.api.auth.totp }}totp = {{ .Values.api.auth.totp }}{{ end }}
@@ -176,4 +176,8 @@ allowed_origin = {{ .Values.cors.allowed_origin | default "*"}}
 allow_credentials = true
 expose_headers = Content-Type,Cache-Control,Content-Language,Expires,Last-Modified,Pragma,X-Auth-Token,X-Openstack-Request-Id,X-Subject-Token
 allow_headers = Content-Type,Cache-Control,Content-Language,Expires,Last-Modified,Pragma,X-Auth-Token,X-Openstack-Request-Id,X-Subject-Token,X-Project-Id,X-Project-Name,X-Project-Domain-Id,X-Project-Domain-Name,X-Domain-Id,X-Domain-Name,X-User-Id,X-User-Name,X-User-Domain-name
+{{- end }}
+{{- if .Values.federation.oidc.enabled }}
+[federation]
+remote_id_attribute = HTTP_OIDC_ISS
 {{- end }}

--- a/openstack/keystone/templates/etc/_keystone.conf.tpl
+++ b/openstack/keystone/templates/etc/_keystone.conf.tpl
@@ -185,4 +185,5 @@ allow_headers = Content-Type,Cache-Control,Content-Language,Expires,Last-Modifie
 {{- if .Values.federation.oidc.enabled }}
 [federation]
 remote_id_attribute = HTTP_OIDC_ISS
+trusted_dashboard = https://dashboard.{{ .Values.global.region }}.cloud.sap/verify-auth-token
 {{- end }}

--- a/openstack/keystone/templates/etc/_sso_callback_template.html.tpl
+++ b/openstack/keystone/templates/etc/_sso_callback_template.html.tpl
@@ -1,17 +1,3 @@
-# Copyright 2017 The Openstack-Helm Authors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>

--- a/openstack/keystone/templates/etc/_wsgi-keystone.conf.tpl
+++ b/openstack/keystone/templates/etc/_wsgi-keystone.conf.tpl
@@ -23,6 +23,31 @@ SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
 CustomLog /dev/stdout combined env=!forwarded
 CustomLog /dev/stdout proxy env=forwarded
 
+{{- if .Values.federation.oidc.enabled }}
+<Location "/v3/auth/OS-FEDERATION/websso/openid">
+    AuthType "openid-connect"
+    Require valid-user
+</Location>
+
+<Location "/v3/auth/OS-FEDERATION/identity_providers/sap-ias/protocols/openid/websso">
+    AuthType "openid-connect"
+    Require valid-user
+</Location>
+
+<Location "/v3/auth/OS-FEDERATION/identity_providers/sap-ias/protocols/openid/auth">
+    AuthType "openid-connect"
+    Require valid-user
+</Location>
+
+# Location a non-browser apps can communicate with
+<Location "/v3/OS-FEDERATION/identity_providers/sap-ias/protocols/openid/auth">
+    # AuthType here is not "openid-connect" since apps going here do not support browser flow
+    AuthType "auth-openidc"
+    Require valid-user
+</Location>
+
+{{- end }}
+
 <VirtualHost *:5000>
     ServerName {{ .Values.services.public.host }}.{{ .Values.global.region }}.{{ .Values.global.tld }}
     WSGIDaemonProcess keystone-public processes=8 threads=1 user=keystone group=keystone display-name=%{GROUP}

--- a/openstack/keystone/templates/federation.yaml
+++ b/openstack/keystone/templates/federation.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.federation.oidc.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-federation
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    component: keystone
+    type: config
+type: Opaque
+data:
+  federation-oidc.conf: |
+    {{ include (print .Template.BasePath "/etc/_federation-oidc.conf.tpl") . | b64enc | indent 4 }}
+{{- end }}

--- a/openstack/keystone/templates/ingress-api.yaml
+++ b/openstack/keystone/templates/ingress-api.yaml
@@ -46,6 +46,18 @@ metadata:
     component: keystone
     type: api
   annotations:
+    {{- if .Values.federation.oidc.enabled }}
+    # the affinity bits are required for federation; they do not affect the
+    # cases when the API is used, but will affect browser-based workflows
+    ingress.kubernetes.io/affinity: cookie
+    ingress.kubernetes.io/session-cookie-expires: "3600"
+    ingress.kubernetes.io/session-cookie-max-age: "3600"
+    ingress.kubernetes.io/session-cookie-name: route
+    nginx.ingress.kubernetes.io/affinity: cookie
+    nginx.ingress.kubernetes.io/session-cookie-expires: "3600"
+    nginx.ingress.kubernetes.io/session-cookie-max-age: "3600"
+    nginx.ingress.kubernetes.io/session-cookie-name: route
+    {{- end }}
     # clear the trusted key header from external requests
     ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header X-Trusted-Key        "";

--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -39,6 +39,14 @@ nodeAffinity: {}
 osprofiler:
   enabled: false
 
+federation:
+  oidc:
+    enabled: false
+    provider: ""
+    client_id: ""
+    client_secret: ""
+    crypto_passphrase: ""
+
 api:
   image: "loci-keystone"
   #imageTag: latest

--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -101,6 +101,8 @@ api:
 
   auth:
     # Allowed authentication methods. (list value)
+    # NOTE: this is not the complete list of applied authentication methods.
+    # Depending on the federation configuration, there might be more of them.
     methods: password,token,totp,external,oauth1,application_credential
     password: cc_password # CCloud password auth method with EWS mirroring
     totp: cc_radius # SecurID via totp auth method/plugin


### PR DESCRIPTION
* Implemented support for Keystone federation using OpenID Connect (OIDC).
* Updated the Keystone Chart to version 0.10.0 reflecting the new feature.
* Added a new _federation-oidc.conf.tpl template to support OIDC configurations.
* Modified the wsgi-keystone.conf.tpl to add location blocks for OIDC endpoints.
* Created a new federation.yaml file to manage OIDC-related secrets within
  Kubernetes.
* Extended ingress configuration in ingress-api.yaml to handle session affinity
  required for browser-based federation workflows.
* Updated values.yaml to include federation configuration options with
  placeholders for provider, client_id, client_secret, and crypto_passphrase.
* Update keystone.conf to include the necessary federation bits

Right now the setup makes several assumptions:

* SAP IAS with OpenID Connect are used for the federation
* IDP name is sap-ias, protocol name is openid
* They are pre-created manually by the operator using the following
commands:

```
openstack identity provider create --remote-id <url-provided-in-secrets> --domain <any-domain> sap-ias
openstack mapping create --rules mapping.json --schema-version 2.0 sap-ias-mapping
openstack federation protocol create openid --mapping sap-ias-mapping --identity-provider sap-ias

```