### PR TITLE
Add argora-operator-remote make target and helm templates

### DIFF
--- a/system/Makefile
+++ b/system/Makefile
@@ -10,6 +10,7 @@ BOOT_OPERATOR_VERSION ?= 4f2452ce450dc65342d68daf611edfb182585020
 IPXE_OPERATOR_VERSION ?= 61c6898bfd7772008835bdcca8d8a64c1dfc3b32
 FEDHCP_VERSION ?= a59539c62aaa11a96c82fe792c87daaac4cb75bf
 IPAM_VERSION ?= 6faf501000c5d7ff9744a3c111ca5ecf3339c00c
+ARGORA_VERSION ?= 1133b6d2dd30ae6f1335b2fe5570d99b6c491410
 
 SHELL := bash
 .ONESHELL:
@@ -213,6 +214,27 @@ build-ipam-operator-remote:
 	@yq -i '.version="0.2.2"' ipam-operator-remote/Chart.yaml
 	@$(SED) -i 's/serviceAccountName.*$$/serviceAccountName: default/g' ipam-operator-remote/templates/deployment.yaml
 	@$(SED) -i 's/kind: Role/kind: ClusterRole/g' ipam-operator-remote/managedresources/kustomize.yaml
+
+# build-argora-operator:
+# 	@cat kustomize/argora-operator/kustomization.yaml >> kustomization.yaml
+# 	$(call build-chart,argora-operator,https://github.com/sapcc/argora//config/default,$(ARGORA_VERSION))
+# 	@yq -i '.controllerManager.manager.image.tag="$(ARGORA_VERSION)"' argora-operator/values.yaml
+# 	@yq -i '.fullnameOverride="argora-operator"' argora-operator/values.yaml
+# 	@yq -i '.version="0.0.1"' argora-operator/Chart.yaml
+
+build-argora-operator-remote:
+	@rm -rf argora-operator-remote
+	@cat kustomize/argora-operator-remote/kustomization.yaml > kustomization.yaml
+	@kubectl kustomize | helmify -crd-dir argora-operator-remote
+	@cp kustomize/argora-operator-remote/remote-kubeconfig.yaml argora-operator-remote/templates
+	@cp kustomize/argora-operator-remote/managedresource.yaml argora-operator-remote/templates
+	@mkdir argora-operator-remote/managedresources
+	@kubectl kustomize kustomize/argora-operator-managedresources > argora-operator-remote/managedresources/kustomize.yaml
+	@yq -i '.controllerManager.manager.image.tag="$(ARGORA_VERSION)"' argora-operator-remote/values.yaml
+	@yq -i '.fullnameOverride="argora-operator"' argora-operator-remote/values.yaml
+	@yq -i '.version="0.0.1"' argora-operator-remote/Chart.yaml
+	@$(SED) -i 's/serviceAccountName.*$$/serviceAccountName: default/g' argora-operator-remote/templates/deployment.yaml
+	@$(SED) -i 's/kind: Role/kind: ClusterRole/g' argora-operator-remote/managedresources/kustomize.yaml
 
 # chart name, source url, tag
 define build-chart

--- a/system/Makefile
+++ b/system/Makefile
@@ -223,7 +223,7 @@ build-argora-operator-remote:
 	@cp kustomize/argora-operator-remote/managedresource.yaml argora-operator-remote/templates
 	@mkdir argora-operator-remote/managedresources
 	@kubectl kustomize kustomize/argora-operator-managedresources > argora-operator-remote/managedresources/kustomize.yaml
-	@yq -i '.controllerManager.manager.image.tag="sha-$(ARGORA_VERSION)"' argora-operator-remote/values.yaml
+	@yq -i '.controllerManager.manager.image.tag="$(ARGORA_VERSION)"' argora-operator-remote/values.yaml
 	@yq -i '.fullnameOverride="argora-operator"' argora-operator-remote/values.yaml
 	@mkdir argora-operator-remote/ci
 	@echo 'config:' >> argora-operator-remote/ci/test-values.yaml

--- a/system/Makefile
+++ b/system/Makefile
@@ -230,7 +230,7 @@ build-argora-operator-remote:
 	@cp kustomize/argora-operator-remote/managedresource.yaml argora-operator-remote/templates
 	@mkdir argora-operator-remote/managedresources
 	@kubectl kustomize kustomize/argora-operator-managedresources > argora-operator-remote/managedresources/kustomize.yaml
-	@yq -i '.controllerManager.manager.image.tag="$(ARGORA_VERSION)"' argora-operator-remote/values.yaml
+	@yq -i '.controllerManager.manager.image.tag="sha-$(ARGORA_VERSION)"' argora-operator-remote/values.yaml
 	@yq -i '.fullnameOverride="argora-operator"' argora-operator-remote/values.yaml
 	@yq -i '.version="0.0.1"' argora-operator-remote/Chart.yaml
 	@$(SED) -i 's/serviceAccountName.*$$/serviceAccountName: default/g' argora-operator-remote/templates/deployment.yaml

--- a/system/Makefile
+++ b/system/Makefile
@@ -215,13 +215,6 @@ build-ipam-operator-remote:
 	@$(SED) -i 's/serviceAccountName.*$$/serviceAccountName: default/g' ipam-operator-remote/templates/deployment.yaml
 	@$(SED) -i 's/kind: Role/kind: ClusterRole/g' ipam-operator-remote/managedresources/kustomize.yaml
 
-# build-argora-operator:
-# 	@cat kustomize/argora-operator/kustomization.yaml >> kustomization.yaml
-# 	$(call build-chart,argora-operator,https://github.com/sapcc/argora//config/default,$(ARGORA_VERSION))
-# 	@yq -i '.controllerManager.manager.image.tag="$(ARGORA_VERSION)"' argora-operator/values.yaml
-# 	@yq -i '.fullnameOverride="argora-operator"' argora-operator/values.yaml
-# 	@yq -i '.version="0.0.1"' argora-operator/Chart.yaml
-
 build-argora-operator-remote:
 	@rm -rf argora-operator-remote
 	@cat kustomize/argora-operator-remote/kustomization.yaml > kustomization.yaml
@@ -232,6 +225,16 @@ build-argora-operator-remote:
 	@kubectl kustomize kustomize/argora-operator-managedresources > argora-operator-remote/managedresources/kustomize.yaml
 	@yq -i '.controllerManager.manager.image.tag="sha-$(ARGORA_VERSION)"' argora-operator-remote/values.yaml
 	@yq -i '.fullnameOverride="argora-operator"' argora-operator-remote/values.yaml
+	@mkdir argora-operator-remote/ci
+	@echo 'config:' >> argora-operator-remote/ci/test-values.yaml
+	@echo '  ironCoreRoles: foo' >> argora-operator-remote/ci/test-values.yaml
+	@echo '  ironCoreRegion: ab-cd-1' >> argora-operator-remote/ci/test-values.yaml
+	@echo '  serverController: foo' >> argora-operator-remote/ci/test-values.yaml
+	@echo '  netboxURL: http://foo.bar' >> argora-operator-remote/ci/test-values.yaml
+	@echo 'credentials:' >> argora-operator-remote/ci/test-values.yaml
+	@echo '  bmcUser: foo' >> argora-operator-remote/ci/test-values.yaml
+	@echo '  bmcPassword: bar' >> argora-operator-remote/ci/test-values.yaml
+	@echo '  netboxToken: foo' >> argora-operator-remote/ci/test-values.yaml
 	@yq -i '.version="0.0.1"' argora-operator-remote/Chart.yaml
 	@$(SED) -i 's/serviceAccountName.*$$/serviceAccountName: default/g' argora-operator-remote/templates/deployment.yaml
 	@$(SED) -i 's/kind: Role/kind: ClusterRole/g' argora-operator-remote/managedresources/kustomize.yaml

--- a/system/argora-operator-remote/.helmignore
+++ b/system/argora-operator-remote/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/system/argora-operator-remote/Chart.yaml
+++ b/system/argora-operator-remote/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: argora-operator-remote
+description: A Helm chart for Kubernetes
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.1
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.1.0"

--- a/system/argora-operator-remote/ci/test-values.yaml
+++ b/system/argora-operator-remote/ci/test-values.yaml
@@ -1,0 +1,9 @@
+config:
+  ironCoreRoles: foo
+  ironCoreRegion: ab-cd-1
+  serverController: foo
+  netboxURL: http://foo.bar
+credentials:
+  bmcUser: foo
+  bmcPassword: bar
+  netboxToken: foo

--- a/system/argora-operator-remote/managedresources/kustomize.yaml
+++ b/system/argora-operator-remote/managedresources/kustomize.yaml
@@ -1,0 +1,315 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: updates.argora.cloud.sap
+spec:
+  group: argora.cloud.sap
+  names:
+    kind: Update
+    listKind: UpdateList
+    plural: updates
+    singular: update
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.state
+      name: State
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Update is the Schema for the updates API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: UpdateSpec defines the desired state of Update.
+            properties:
+              clusters:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    region:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - region
+                  - type
+                  type: object
+                type: array
+            type: object
+          status:
+            description: UpdateStatus defines the observed state of Update.
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              description:
+                type: string
+              state:
+                enum:
+                - Ready
+                - Error
+                type: string
+            required:
+            - state
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: argora
+  name: argora-operator-controller-manager
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: argora
+  name: argora-operator-leader-election-role
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: argora-operator-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - argora.cloud.sap
+  resources:
+  - updates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - argora.cloud.sap
+  resources:
+  - updates/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - argora.cloud.sap
+  resources:
+  - updates/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - metal.ironcore.dev
+  resources:
+  - bmcs
+  - bmcsecrets
+  - servers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - metal3.io
+  resources:
+  - baremetalhosts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: argora
+  name: argora-operator-leader-election-rolebinding
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argora-operator-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: argora-operator-controller-manager
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: argora
+  name: argora-operator-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argora-operator-manager-role
+subjects:
+- kind: ServiceAccount
+  name: argora-operator-controller-manager
+  namespace: kube-system
+---
+apiVersion: v1
+data:
+  config.json: '{{ toJson .Values.config }}'
+kind: ConfigMap
+metadata:
+  name: argora-operator-config
+  namespace: kube-system
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argora-operator-secret
+  namespace: kube-system
+stringData:
+  credentials.json: '{{ toJson .Values.credentials}}'
+type: Opaque

--- a/system/argora-operator-remote/templates/_helpers.tpl
+++ b/system/argora-operator-remote/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "argora-operator-remote.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "argora-operator-remote.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "argora-operator-remote.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "argora-operator-remote.labels" -}}
+helm.sh/chart: {{ include "argora-operator-remote.chart" . }}
+{{ include "argora-operator-remote.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "argora-operator-remote.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "argora-operator-remote.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "argora-operator-remote.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "argora-operator-remote.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/system/argora-operator-remote/templates/deployment.yaml
+++ b/system/argora-operator-remote/templates/deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "argora-operator-remote.fullname" . }}-controller-manager
+  labels:
+    control-plane: controller-manager
+  {{- include "argora-operator-remote.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.controllerManager.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argora
+      control-plane: controller-manager
+    {{- include "argora-operator-remote.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: argora
+        control-plane: controller-manager
+      {{- include "argora-operator-remote.selectorLabels" . | nindent 8 }}
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+    spec:
+      containers:
+      - args: {{- toYaml .Values.controllerManager.manager.args | nindent 8 }}
+        command:
+        - /manager
+        env:
+        - name: ENABLE_WEBHOOKS
+          value: {{ quote .Values.controllerManager.manager.env.enableWebhooks }}
+        - name: KUBERNETES_SERVICE_HOST
+          value: {{ quote .Values.controllerManager.manager.env.kubernetesServiceHost }}
+        - name: KUBERNETES_CLUSTER_DOMAIN
+          value: {{ quote .Values.kubernetesClusterDomain }}
+        image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag
+          | default .Chart.AppVersion }}
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 30081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 30081
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources: {{- toYaml .Values.controllerManager.manager.resources | nindent 10
+          }}
+        securityContext: {{- toYaml .Values.controllerManager.manager.containerSecurityContext
+          | nindent 10 }}
+        volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: remote-kubeconfig
+          readOnly: true
+      hostNetwork: true
+      securityContext: {{- toYaml .Values.controllerManager.podSecurityContext | nindent
+        8 }}
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: remote-kubeconfig
+        secret:
+          items:
+          - key: token
+            path: token
+          - key: bundle.crt
+            path: ca.crt
+          secretName: argora-operator-remote-kubeconfig

--- a/system/argora-operator-remote/templates/managedresource.yaml
+++ b/system/argora-operator-remote/templates/managedresource.yaml
@@ -1,0 +1,31 @@
+{{- define "mrname" }}
+{{- /* use uppercase letters of kind as prefix to avoid some naming clashes */ -}}
+{{- $kind := regexFindAll "[A-Z]" .kind -1 | join "" | lower }}
+{{- $name := .metadata.name | replace "." "-" | replace ":" "-" -}}
+mr-{{ $kind }}-{{ $name }}
+{{- end }}
+
+{{- range $path, $_ := .Files.Glob "managedresources/*.yaml" }}
+{{- range $_, $doc := (tpl ($.Files.Get $path) $ | splitList "---\n") }}
+{{- $obj := $doc | fromYaml }}
+{{- if not $obj }}
+{{- continue }}
+{{- end }}
+---
+apiVersion: resources.gardener.cloud/v1alpha1
+kind: ManagedResource
+metadata:
+  name: {{ template "mrname" $obj }}
+spec:
+  secretRefs:
+  - name: {{ template "mrname" $obj }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "mrname" $obj }}
+type: Opaque
+data:
+  objects.yaml: {{ $doc | b64enc }}
+{{- end }}
+{{- end }}

--- a/system/argora-operator-remote/templates/remote-kubeconfig.yaml
+++ b/system/argora-operator-remote/templates/remote-kubeconfig.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argora-operator-remote-kubeconfig
+  labels:
+    resources.gardener.cloud/purpose: token-requestor
+    resources.gardener.cloud/class: shoot
+  annotations:
+    serviceaccount.resources.gardener.cloud/name: argora-operator-controller-manager
+    serviceaccount.resources.gardener.cloud/namespace: kube-system
+    serviceaccount.resources.gardener.cloud/inject-ca-bundle: "true"
+stringData:
+  token: ""
+  bundle.crt: ""

--- a/system/argora-operator-remote/values.yaml
+++ b/system/argora-operator-remote/values.yaml
@@ -13,7 +13,7 @@ controllerManager:
       kubernetesServiceHost: apiserver-url
     image:
       repository: controller
-      tag: 1133b6d2dd30ae6f1335b2fe5570d99b6c491410
+      tag: sha-1133b6d2dd30ae6f1335b2fe5570d99b6c491410
     resources:
       limits:
         cpu: 500m

--- a/system/argora-operator-remote/values.yaml
+++ b/system/argora-operator-remote/values.yaml
@@ -1,0 +1,30 @@
+controllerManager:
+  manager:
+    args:
+      - --health-probe-bind-address=:30081
+      - --metrics-bind-address=127.0.0.1:30082
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+    env:
+      enableWebhooks: "false"
+      kubernetesServiceHost: apiserver-url
+    image:
+      repository: controller
+      tag: 1133b6d2dd30ae6f1335b2fe5570d99b6c491410
+    resources:
+      limits:
+        cpu: 500m
+        memory: 128Mi
+      requests:
+        cpu: 10m
+        memory: 64Mi
+  podSecurityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  replicas: 1
+kubernetesClusterDomain: cluster.local
+fullnameOverride: argora-operator

--- a/system/argora-operator-remote/values.yaml
+++ b/system/argora-operator-remote/values.yaml
@@ -13,7 +13,7 @@ controllerManager:
       kubernetesServiceHost: apiserver-url
     image:
       repository: controller
-      tag: sha-1133b6d2dd30ae6f1335b2fe5570d99b6c491410
+      tag: 1133b6d2dd30ae6f1335b2fe5570d99b6c491410
     resources:
       limits:
         cpu: 500m

--- a/system/kustomize/argora-operator-managedresources/kustomization.yaml
+++ b/system/kustomize/argora-operator-managedresources/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kube-system
+namePrefix: argora-operator-
+resources:
+- github.com/sapcc/argora//config/crd
+- github.com/sapcc/argora//config/rbac
+- github.com/sapcc/argora//config/configmap
+- github.com/sapcc/argora//config/secret

--- a/system/kustomize/argora-operator-remote/kustomization.yaml
+++ b/system/kustomize/argora-operator-remote/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- github.com/sapcc/argora//config/manager
+patches:
+- path: kustomize/argora-operator-remote/manager-remote-patch.yaml

--- a/system/kustomize/argora-operator-remote/managedresource.yaml
+++ b/system/kustomize/argora-operator-remote/managedresource.yaml
@@ -1,0 +1,31 @@
+{{- define "mrname" }}
+{{- /* use uppercase letters of kind as prefix to avoid some naming clashes */ -}}
+{{- $kind := regexFindAll "[A-Z]" .kind -1 | join "" | lower }}
+{{- $name := .metadata.name | replace "." "-" | replace ":" "-" -}}
+mr-{{ $kind }}-{{ $name }}
+{{- end }}
+
+{{- range $path, $_ := .Files.Glob "managedresources/*.yaml" }}
+{{- range $_, $doc := (tpl ($.Files.Get $path) $ | splitList "---\n") }}
+{{- $obj := $doc | fromYaml }}
+{{- if not $obj }}
+{{- continue }}
+{{- end }}
+---
+apiVersion: resources.gardener.cloud/v1alpha1
+kind: ManagedResource
+metadata:
+  name: {{ template "mrname" $obj }}
+spec:
+  secretRefs:
+  - name: {{ template "mrname" $obj }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "mrname" $obj }}
+type: Opaque
+data:
+  objects.yaml: {{ $doc | b64enc }}
+{{- end }}
+{{- end }}

--- a/system/kustomize/argora-operator-remote/manager-remote-patch.yaml
+++ b/system/kustomize/argora-operator-remote/manager-remote-patch.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      hostNetwork: true
+      containers:
+        - name: manager
+          args:
+            - --health-probe-bind-address=:30081
+            - --metrics-bind-address=127.0.0.1:30082
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 30081
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: 30081
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          env:
+          - name: ENABLE_WEBHOOKS
+            value: "false"
+          - name: KUBERNETES_SERVICE_HOST
+            value: "apiserver-url"
+          volumeMounts:
+          - name: remote-kubeconfig
+            mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            readOnly: true
+      volumes:
+      - name: remote-kubeconfig
+        secret:
+          secretName: argora-operator-remote-kubeconfig
+          items:
+          - key: token
+            path: token
+          - key: bundle.crt
+            path: ca.crt

--- a/system/kustomize/argora-operator-remote/remote-kubeconfig.yaml
+++ b/system/kustomize/argora-operator-remote/remote-kubeconfig.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argora-operator-remote-kubeconfig
+  labels:
+    resources.gardener.cloud/purpose: token-requestor
+    resources.gardener.cloud/class: shoot
+  annotations:
+    serviceaccount.resources.gardener.cloud/name: argora-operator-controller-manager
+    serviceaccount.resources.gardener.cloud/namespace: kube-system
+    serviceaccount.resources.gardener.cloud/inject-ca-bundle: "true"
+stringData:
+  token: ""
+  bundle.crt: ""

--- a/system/kustomize/argora-operator/kustomization.yaml
+++ b/system/kustomize/argora-operator/kustomization.yaml
@@ -1,0 +1,9 @@
+# Adds namespace to all resources.
+namespace: argora-system
+
+# Value of this field is prepended to the
+# names of all resources, e.g. a deployment named
+# "wordpress" becomes "alices-wordpress".
+# Note that it should also match with the prefix (text before '-') of the namespace
+# field above.
+namePrefix: argora-operator-


### PR DESCRIPTION
* Adds new make target for `argora-operator-remote` in similar way as other operators, based on kustomize from extern repos and helmify