### PR TITLE
[rabbitmq] version bumped to 4.0.7-management

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
-## 0.16.0
+## 0.16.1 - 2025/03/18
+
+- RabbitMQ [4.0.7 Release Notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.0.7)
+  * Classic queue message store did not remove segment files with large messages (over 4 MB) in some cases
+  * Reduced memory usage and GC pressure for workloads where large (4 MB or greater) messages were published to classic queues
+* chart version bumped
+
+## 0.16.0 - 2025/03/15
 
 - Creation of the `metrics` user with `monitoring` tag no longer coupled with enabling prometheus metrics
 

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: v1
 name: rabbitmq
-version: 0.16.0
-appVersion: 4.0.6
+version: 0.16.1
+appVersion: 4.0.7
 description: A Helm chart for RabbitMQ
 sources:
   - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/values.yaml
+++ b/common/rabbitmq/values.yaml
@@ -8,7 +8,7 @@ global:
   master_password: ""
 
 image: library/rabbitmq
-imageTag: 4.0.6-management
+imageTag: 4.0.7-management
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
- bugfix and reduced mem usage for the classic queue
- chart version bumped