### PR TITLE
[Neutron] Bump MariaDB, RabbitMQ, MemcacheD, Redis, SQL Metrics, Utils

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 0.6.9
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.3.6
+  version: 0.4.2
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.17.1
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:f329f8f8cd8c2085d5c82c3c0bd4bc487c3d035db91ff3004ef2ee0158b4370a
-generated: "2025-03-25T15:24:38.872985+01:00"
+digest: sha256:c984cc4660d9ab11a40720d61f75dcf635bf05f7610ce053d5f5ea40daf50f3a
+generated: "2025-03-25T15:25:50.918897+01:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.3.6
+    version: 0.4.2
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.17.1


### PR DESCRIPTION
Update share neutron chart dependencies:

```
mariadb 0.14.2 -> 0.18.2
updates default k8s labels
updates mariadb and mysqld-exporter to the latest bugfix releases
adds user-credential-updater sidecar
allows to update mariab root password
fixes maria-back-me-up backup uploading to aws
```

```
memcached 0.5.3 -> 0.6.8
updates memcached and memcached-exporter to latest bugifx releases
```

```
mysql-metrics 0.3.6 -> 0.4.2
updates sql-exporter to latest bugfix releases with security fixes
```

```
rabbitmq 0.11.1 -> 0.17.1
updates rabbitmq to 4.0.7
add user-credential-updater with online user password updates
```