### PR TITLE
[nova] Allow GET on os-attach-interfaces for viewers

### DIFF
--- a/openstack/nova/templates/etc/_nova-policy.yaml.tpl
+++ b/openstack/nova/templates/etc/_nova-policy.yaml.tpl
@@ -252,12 +252,12 @@ os_compute_api:os-attach-interfaces:delete: rule:context_is_editor
 # List port interfaces attached to a server
 #   GET /servers/{server_id}/os-interface
 #os_compute_api:os-attach-interfaces:list: rule:system_or_project_reader
-os_compute_api:os-attach-interfaces:list: rule:context_is_editor
+os_compute_api:os-attach-interfaces:list: rule:context_is_viewer
 
 # Show details of a port interface attached to a server
 #   GET /servers/{server_id}/os-interface/{port_id}
 #os_compute_api:os-attach-interfaces:show: rule:system_or_project_reader
-os_compute_api:os-attach-interfaces:show: rule:context_is_editor
+os_compute_api:os-attach-interfaces:show: rule:context_is_viewer
 
 # Show action details for a server.
 #   GET /os-baremetal-nodes/{node_id}


### PR DESCRIPTION
Upstream allows listing and showing os-attach-interface i.e. Nova-known virtual interfaces to readers. We didn't allow it for our equivalent (viewers) until know. I couldn't find a specific reason. It looks like we made them "inherit" what we had before when they got split up into multiple policies.