### PR TITLE
Chore: Rename PostgreSQL to Redis in prometheus-alerts.yaml

### DIFF
--- a/common/redis/templates/prometheus-alerts.yaml
+++ b/common/redis/templates/prometheus-alerts.yaml
@@ -16,7 +16,7 @@ spec:
   groups:
     - name: {{ $fullname }}.alerts
       rules:
-        - alert: PostgresSecretAboutToExpire
+        - alert: RedisSecretAboutToExpire
           expr: max by (namespace, secret) ((time() - kube_secret_created{namespace="{{ .Release.Namespace }}",secret=~"{{ $fullname }}-user-.*"}) / 86400) >= 330
           for: 5m
           labels:
@@ -26,10 +26,10 @@ spec:
             severity: info
             support_group: {{ quote $sgroup }}
           annotations:
-            summary: 'PostgreSQL user secret will expire soon'
+            summary: 'Redis user secret will expire soon'
             description: 'The secret {{`{{`}} $labels.namespace {{`}}/{{`}} $labels.secret {{`}}`}} is nearly 365 days old. Please rotate it soon by following the attached playbook.'
 
-        - alert: PostgresSecretAboutToExpire
+        - alert: RedisSecretAboutToExpire
           expr: max by (namespace, secret) ((time() - kube_secret_created{namespace="{{ .Release.Namespace }}",secret=~"{{ $fullname }}-user-.*"}) / 86400) >= 365
           for: 5m
           labels:
@@ -39,6 +39,6 @@ spec:
             severity: warning
             support_group: {{ quote $sgroup }}
           annotations:
-            summary: 'PostgreSQL user secret is expired'
+            summary: 'Redis user secret is expired'
             description: 'The secret {{`{{`}} $labels.namespace {{`}}/{{`}} $labels.secret {{`}}`}} is over 365 days old. Please rotate it as soon as possible by following the attached playbook.'
 {{- end -}}


### PR DESCRIPTION
This PR changes the PostgreSQL names in the prometheus alerts to Redis.