### PR TITLE
[ironic] fix syntax

### DIFF
--- a/openstack/ironic/templates/_conductor-deployment.yaml.tpl
+++ b/openstack/ironic/templates/_conductor-deployment.yaml.tpl
@@ -237,8 +237,6 @@ spec:
           items:
           - key: nginx.conf
             path: nginx.conf
-        configMap:
-          name: ironic-console
       - name: ironic-console-dhparam
         secret:
           secretName: {{ .Release.Name }}-secrets


### PR DESCRIPTION
This was left over from a00eba274ffbe2f4a42ae0d2028f07ff27f5a973 leading
to a single volume having two different volume types which is wrong.
