### PR TITLE
[ironic] multiple dependency updates

### DIFF
--- a/openstack/ironic/Chart.lock
+++ b/openstack/ironic/Chart.lock
@@ -1,13 +1,13 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.15.3
+  version: 0.17.3
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.2.13
+  version: 0.3.0
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.6.3
+  version: 0.6.6
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.4.2
@@ -16,15 +16,15 @@ dependencies:
   version: 1.0.0
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.12.1
+  version: 0.15.0
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.21.0
+  version: 0.22.1
 - name: ironic-exporter
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.3
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:4f8b37f96a876826beb37c2a0c4f8d7ebade6c8910800a3b501dadbf454e5d98
-generated: "2025-01-29T17:51:43.459114+02:00"
+digest: sha256:526767f29e01664da3f6f32c0991b83ce20c4eb62fa124efbec9a6ab74b1fb9c
+generated: "2025-03-11T16:50:15.11169769+01:00"

--- a/openstack/ironic/Chart.yaml
+++ b/openstack/ironic/Chart.yaml
@@ -7,15 +7,15 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.15.3
+    version: ~0.17.3
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.2.13
+    version: ~0.3.0
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.6.3
+    version: ~0.6.6
   - condition: mysql_metrics.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
@@ -25,10 +25,10 @@ dependencies:
     version: ~1.0.0
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.12.1
+    version: ~0.15.0
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.21.0
+    version: ~0.22.1
   - name: ironic-exporter
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: ~1.0.3


### PR DESCRIPTION
mariadb ~0.15.3  to ~0.17.3
- set root password on every database start
- use shared-app-images/alpine-kubectl for pre-change job
- use passwordless local connections for healthchecks and exporter
- use custom entrypoint script for mariadb deployment
- verbose logging option for the analyzetables job
- maintenance job configmap condition fixed
- update pod-readiness container image
- mysqld_exporter updated to 0.17.1
- set default ignore_db_dirs value
- Fix maria_backup_status alerts
- fix maintenance cronjob resource names
- maintenance job added
- enquote password in my.cnf
- remove user and password from readyness and lifeness probes
- move backup-v2 oauth secret to a separate secret
- version updated to 10.5.28

pxc-db ~0.2.13  to ~0.3.0
- Use operator custom resource option to create users
- bump mysqld-exporter to latest release v0.17.1

memcached ~0.6.3   to ~0.6.6
- update memcached-exporter to 0.15.1
- version bumped to 1.6.37-alpine3.21

rabbitmq ~0.12.1  to ~0.15.0
- remove unused rabbitmq template helper function
- rabbitmq version bumped to 4.0.6-management
- rabbitmq version bumped to 4.0.5-management
- Option to enable SSL for amqp server

utils ~0.21.0  to ~0.22.1
- Add missing default value for mem_queue_size audit option
- New host entry for Andromeda Liquid Server API
