### PR TITLE
[nannies] Replace master password with keystone passwords

### DIFF
--- a/openstack/nannies/templates/cinder-nanny-secrets.yaml
+++ b/openstack/nannies/templates/cinder-nanny-secrets.yaml
@@ -4,6 +4,6 @@ apiVersion: v1
 metadata:
   name: cinder-nanny-secret
 data:
-  cinder_nanny_os_password: {{ derivePassword 1 "long" .Values.nannies.master_password "cinder_nanny" (include "keystone_api_endpoint_host_public" .) | b64enc }}
-  nova_nanny_os_password: {{ derivePassword 1 "long" .Values.nannies.master_password "nova_nanny" (include "keystone_api_endpoint_host_public" .) | b64enc }}
+  cinder_nanny_os_password: {{ required ".Values.cinder_nanny.keystone_password is missing" .Values.cinder_nanny.keystone_password | b64enc }}
+  nova_nanny_os_password: {{ required ".Values.nova_nanny.keystone_password is missing" .Values.nova_nanny.keystone_password | b64enc }}
 {{- end }}

--- a/openstack/nannies/templates/nova-nanny-secrets.yaml
+++ b/openstack/nannies/templates/nova-nanny-secrets.yaml
@@ -4,5 +4,5 @@ apiVersion: v1
 metadata:
   name: nova-nanny-secret
 data:
-  nova_nanny_os_password: {{ derivePassword 1 "long" .Values.nannies.master_password "nova_nanny" (include "keystone_api_endpoint_host_public" .) | b64enc }}
+  nova_nanny_os_password: {{ required ".Values.nova_nanny.keystone_password is missing" .Values.nova_nanny.keystone_password | b64enc }}
 {{- end }}

--- a/openstack/nannies/templates/seed.yaml
+++ b/openstack/nannies/templates/seed.yaml
@@ -10,9 +10,6 @@ spec:
   domains:
   - name: Default
     users:
-    - name: vcenter_nanny
-      description: Vcenter Nanny
-      password: {{ derivePassword 1 "long" .Values.nannies.master_password "vcenter_nanny" (include "keystone_api_endpoint_host_public" .) | quote }}
     - name: nova_nanny{{ .Values.global.user_suffix | default "" }}
       description: Nova Nanny
       password: {{ derivePassword 1 "long" .Values.nannies.master_password "nova_nanny" (include "keystone_api_endpoint_host_public" .) | quote }}
@@ -24,18 +21,6 @@ spec:
     projects:
     - name: cloud_admin
       role_assignments:
-      # permission to enumerate all projects and domains
-      - user: vcenter_nanny@Default
-        role: admin
-      # permission to manage all ressources checked by the nanny
-      - user: vcenter_nanny@Default
-        role: cloud_compute_admin
-      - user: vcenter_nanny@Default
-        role: cloud_volume_admin
-      - user: vcenter_nanny@Default
-        role: cloud_image_admin
-      - user: vcenter_nanny@Default
-        role: cloud_network_admin
       # permission to enumerate all projects and domains
       - user: nova_nanny{{ .Values.global.user_suffix | default "" }}@Default
         role: admin

--- a/openstack/nannies/templates/seed.yaml
+++ b/openstack/nannies/templates/seed.yaml
@@ -12,10 +12,10 @@ spec:
     users:
     - name: nova_nanny{{ .Values.global.user_suffix | default "" }}
       description: Nova Nanny
-      password: {{ derivePassword 1 "long" .Values.nannies.master_password "nova_nanny" (include "keystone_api_endpoint_host_public" .) | quote }}
+      password: {{ required ".Values.nova_nanny.keystone_password is missing" .Values.nova_nanny.keystone_password | quote }}
     - name: cinder_nanny{{ .Values.global.user_suffix | default "" }}
       description: Cinder Nanny
-      password: {{ derivePassword 1 "long" .Values.nannies.master_password "cinder_nanny" (include "keystone_api_endpoint_host_public" .) | quote }}
+      password: {{ required ".Values.cinder_nanny.keystone_password is missing" .Values.cinder_nanny.keystone_password | quote }}
 
   - name: ccadmin
     projects:


### PR DESCRIPTION
The cinder and nova nanny are no longer maintained by the observability team
but by the cinder and nova team, respectively. To simplify password and
rotation management, we replace the master password used for keystone password
generation with the actual keystone passwords.