### PR TITLE
[andromeda] mariadb bump

### DIFF
--- a/global/andromeda/Chart.lock
+++ b/global/andromeda/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.15.3
+  version: 0.17.3
 - name: nats
   repository: file://../../common/nats
   version: 0.18.2


### PR DESCRIPTION
version 0.17.3 specifically will allow the `root` user password to be rotated in Vault and, with a chart redeployment, it will be applied to the MariaDB server without further manual intervention.
