### PR TITLE
[andromeda] dep bump

### DIFF
--- a/global/andromeda/Chart.lock
+++ b/global/andromeda/Chart.lock
@@ -7,12 +7,12 @@ dependencies:
   version: 0.18.2
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.22.0
+  version: 0.22.1
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.4.2
-digest: sha256:5fb1f117815265301c8b3fc561b1bf049206187c8601d0ae39d6dc6becf2c1fa
-generated: "2025-01-31T15:24:04.157239+01:00"
+digest: sha256:c5d432e128303bb8e5bd3d073a9e4c4c59b1d0a1f3737f2200c3935419dafd72
+generated: "2025-03-12T14:52:03.986736+01:00"


### PR DESCRIPTION
the `utils` bump is not necessary but my previous commit was created incorrectly so the `mariadb` bump cannot be applied yet.
