### PR TITLE
[utils] Add support for different db types in `utils.db_url` helper

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.22.1
+version: 0.23.0


### PR DESCRIPTION
Add support for different db types in `utils.db_url` helper by passing an optional sixth item

This change is required for `nova`, `placement` and `ironic-inspector` database url configuration