### PR TITLE
fix(logs): adds jump.json configmap for logstash to keep backwards compatibility in the transition phase

### DIFF
--- a/system/logs/vendor/logstash-external/templates/configmap.yaml
+++ b/system/logs/vendor/logstash-external/templates/configmap.yaml
@@ -13,4 +13,5 @@ data:
 {{ include (print .Template.BasePath "/_logstash.conf.tpl") . | indent 4 }}
   start.sh: |
 {{ include (print .Template.BasePath "/_start.sh.tpl") . | indent 4 }}
+  jump.json: |
 {{ include (print .Template.BasePath "/_jump.json.tpl") . | indent 4 }}


### PR DESCRIPTION
This got accidentally removed in https://github.com/sapcc/helm-charts/pull/8186. Until the jump server has migrated I will re-add this section

---------

Signed off by: Simon Olander (simon.olander@sap.com)
