### PR TITLE
[rabbitmq] don't create metrics user if not needed

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+## 0.16.0
+
+- Creation of the `metrics` user with `monitoring` tag no longer coupled with enabling prometheus metrics
+
+Native Prometheus RabbitMQ metrics don't rely on any user
+
+To create `metrics` user, if needed, set `.Values.rabbitmq.monitoring.addMetricsUser: true`
+The username for `metrics` user is taken from `.Values.rabbitmq.metrics.user`, and the password from `.Values.rabbitmq.metrics.password`
+
 ## 0.15.0
 
 - Remove the following helm template helper functions:

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: rabbitmq
-version: 0.15.0
+version: 0.16.0
 appVersion: 4.0.6
 description: A Helm chart for RabbitMQ
 sources:

--- a/common/rabbitmq/templates/users-secret.yaml
+++ b/common/rabbitmq/templates/users-secret.yaml
@@ -11,7 +11,7 @@ data:
   user_{{ $key }}_password: {{ $user.password | b64enc }}
   user_{{ $key }}_tag: {{ $user.tag | default "" | b64enc }}
 {{- end }}
-{{- if and .Values.metrics.enabled (not .Values.users.metrics) }}
+{{- if and .Values.metrics.addMetricsUser (not .Values.users.metrics) }}
   user_metrics_username: {{ .Values.metrics.user | b64enc }}
   user_metrics_password: {{ .Values.metrics.password | b64enc }}
   user_metrics_tag: {{ "monitoring" | b64enc }}

--- a/common/rabbitmq/values.yaml
+++ b/common/rabbitmq/values.yaml
@@ -81,6 +81,7 @@ metrics:
   enabled: true
   user: monitoring
   password: null
+  addMetricsUser: false
   port: 9150
   enableDetailedMetrics: false
   enablePerObjectMetrics: false


### PR DESCRIPTION
Creation of the `metrics` user with `monitoring` tag no longer coupled with enabling prometheus metrics

Native Prometheus RabbitMQ metrics don't rely on any user

To create `metrics` user, if needed, set:
`.Values.rabbitmq.monitoring.addMetricsUser: true`