### PR TITLE
[hermes+maia] seed generic domains using global.domains_seeds

### DIFF
--- a/openstack/hermes/ci/test-values.yaml
+++ b/openstack/hermes/ci/test-values.yaml
@@ -9,6 +9,9 @@ global:
   user_suffix: ""
   dockerHubMirror: "another-region"
   dockerHubMirrorAlternateRegion: "other.dockerhub.mirror"
+  domain_seeds:
+    customer_domains: [bar, foo, baz]
+    customer_domains_without_support_projects: [baz]
 
 hermes_image_version_elasticsearch: latest
 hermes_image_version_elasticsearch_manager: latest

--- a/openstack/hermes/templates/keystone-seed.yaml
+++ b/openstack/hermes/templates/keystone-seed.yaml
@@ -1,3 +1,7 @@
+{{- $cdomains := .Values.global.domain_seeds.customer_domains | required "missing value for .Values.global.domain_seeds.customer_domains" -}}
+{{- $domains  := concat (list "cc3test" "ccadmin" "Default") $cdomains -}}
+{{- $cdomainsWithoutSupportProjects := .Values.global.domain_seeds.customer_domains_without_support_projects | required "missing value for .Values.global.domain_seeds.customer_domains_without_support_projects" -}}
+
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: OpenstackSeed
 metadata:
@@ -6,7 +10,11 @@ metadata:
     component: hermes
 spec:
   requires:
-  - monsoon3/domain-default-seed
+  {{- range $domains}}
+  {{- if not (contains "iaas-" .)}}
+  - monsoon3/domain-{{ replace "_" "-" . | lower }}-seed
+  {{- end}}
+  {{- end}}
 
   roles:
     - name: audit_viewer
@@ -21,6 +29,10 @@ spec:
           interface: public
           enabled:   true
           url:       '{{.Values.hermes.catalog_url}}'
+
+  # Default and cc3test get special handling
+  # ccadmin gets additional role assignments for the master project
+  # iaas- is excluded
 
   domains:
     - name: Default
@@ -45,510 +57,88 @@ spec:
             - project: admin
               role: audit_viewer
 
-    - name: ccadmin
-      projects:
-        - name: master
-          role_assignments:
-          - group: CCADMIN_CLOUD_ADMINS
-            role: audit_viewer
-          - group: CCADMIN_DOMAIN_ADMINS
-            role: audit_viewer
-          - group: CCADMIN_MONITORING_USERS
-            role: audit_viewer
-      groups:
-        - name: CCADMIN_API_SUPPORT
-          role_assignments:
-          - project: api_support
-            role: audit_viewer
-          - project: api_tools
-            role: audit_viewer
-          - domain: ccadmin
-            role: audit_viewer
-            inherited: true
-        - name: CCADMIN_COMPUTE_SUPPORT
-          role_assignments:
-          - project: compute_support
-            role: audit_viewer
-          - project: compute_tools
-            role: audit_viewer
-          - domain: ccadmin
-            role: audit_viewer
-            inherited: true
-        - name: CCADMIN_NETWORK_SUPPORT
-          role_assignments:
-          - project: network_support
-            role: audit_viewer
-          - project: network_tools
-            role: audit_viewer
-          - domain: ccadmin
-            role: audit_viewer
-            inherited: true
-        - name: CCADMIN_STORAGE_SUPPORT
-          role_assignments:
-          - project: storage_support
-            role: audit_viewer
-          - project: storage_tools
-            role: audit_viewer
-          - domain: ccadmin
-            role: audit_viewer
-            inherited: true
-        - name: CCADMIN_SERVICE_DESK
-          role_assignments:
-          - project: service_desk
-            role: audit_viewer
-          - domain: ccadmin
-            role: audit_viewer
-            inherited: true
-
-    - name: bs
-      groups:
-      - name: BS_API_SUPPORT
-        role_assignments:
-        - project: api_support
-          role: audit_viewer
-        - domain: bs
-          role: audit_viewer
-          inherited: true
-      - name: BS_COMPUTE_SUPPORT
-        role_assignments:
-        - project: compute_support
-          role: audit_viewer
-        - domain: bs
-          role: audit_viewer
-          inherited: true
-      - name: BS_NETWORK_SUPPORT
-        role_assignments:
-        - project: network_support
-          role: audit_viewer
-        - domain: bs
-          role: audit_viewer
-          inherited: true
-      - name: BS_STORAGE_SUPPORT
-        role_assignments:
-        - project: storage_support
-          role: audit_viewer
-        - domain: bs
-          role: audit_viewer
-          inherited: true
-      - name: BS_SERVICE_DESK
-        role_assignments:
-        - project: service_desk
-          role: audit_viewer
-        - domain: bs
-          role: audit_viewer
-          inherited: true
-
-    - name: btp_fp
-      groups:
-      - name: BTP_FP_API_SUPPORT
-        role_assignments:
-        - domain: btp_fp
-          role: audit_viewer
-          inherited: true
-      - name: BTP_FP_COMPUTE_SUPPORT
-        role_assignments:
-        - domain: btp_fp
-          role: audit_viewer
-          inherited: true
-      - name: BTP_FP_NETWORK_SUPPORT
-        role_assignments:
-        - domain: btp_fp
-          role: audit_viewer
-          inherited: true
-      - name: BTP_FP_STORAGE_SUPPORT
-        role_assignments:
-        - domain: btp_fp
-          role: audit_viewer
-          inherited: true
-      - name: BTP_FP_SERVICE_DESK
-        role_assignments:
-        - domain: btp_fp
-          role: audit_viewer
-          inherited: true
-
-    - name: cis
-      groups:
-      - name: CIS_API_SUPPORT
-        role_assignments:
-        - project: api_support
-          role: audit_viewer
-        - domain: cis
-          role: audit_viewer
-          inherited: true
-      - name: CIS_COMPUTE_SUPPORT
-        role_assignments:
-        - project: compute_support
-          role: audit_viewer
-        - domain: cis
-          role: audit_viewer
-          inherited: true
-      - name: CIS_NETWORK_SUPPORT
-        role_assignments:
-        - project: network_support
-          role: audit_viewer
-        - domain: cis
-          role: audit_viewer
-          inherited: true
-      - name: CIS_STORAGE_SUPPORT
-        role_assignments:
-        - project: storage_support
-          role: audit_viewer
-        - domain: cis
-          role: audit_viewer
-          inherited: true
-      - name: CIS_SERVICE_DESK
-        role_assignments:
-        - project: service_desk
-          role: audit_viewer
-        - domain: cis
-          role: audit_viewer
-          inherited: true
-
-    - name: cp
-      groups:
-      - name: CP_API_SUPPORT
-        role_assignments:
-        - project: api_support
-          role: audit_viewer
-        - domain: cp
-          role: audit_viewer
-          inherited: true
-      - name: CP_COMPUTE_SUPPORT
-        role_assignments:
-        - project: compute_support
-          role: audit_viewer
-        - domain: cp
-          role: audit_viewer
-          inherited: true
-      - name: CP_NETWORK_SUPPORT
-        role_assignments:
-        - project: network_support
-          role: audit_viewer
-        - domain: cp
-          role: audit_viewer
-          inherited: true
-      - name: CP_STORAGE_SUPPORT
-        role_assignments:
-        - project: storage_support
-          role: audit_viewer
-        - domain: cp
-          role: audit_viewer
-          inherited: true
-      - name: CP_SERVICE_DESK
-        role_assignments:
-        - project: service_desk
-          role: audit_viewer
-        - domain: cp
-          role: audit_viewer
-          inherited: true
-
-    - name: hcm
-      groups:
-      - name: HCM_API_SUPPORT
-        role_assignments:
-        - project: api_support
-          role: audit_viewer
-        - domain: hcm
-          role: audit_viewer
-          inherited: true
-      - name: HCM_COMPUTE_SUPPORT
-        role_assignments:
-        - project: compute_support
-          role: audit_viewer
-        - domain: hcm
-          role: audit_viewer
-          inherited: true
-      - name: HCM_NETWORK_SUPPORT
-        role_assignments:
-        - project: network_support
-          role: audit_viewer
-        - domain: hcm
-          role: audit_viewer
-          inherited: true
-      - name: HCM_STORAGE_SUPPORT
-        role_assignments:
-        - project: storage_support
-          role: audit_viewer
-        - domain: hcm
-          role: audit_viewer
-          inherited: true
-      - name: HCM_SERVICE_DESK
-        role_assignments:
-        - project: service_desk
-          role: audit_viewer
-        - domain: hcm
-          role: audit_viewer
-          inherited: true
-
-    - name: hda
-      groups:
-      - name: HDA_API_SUPPORT
-        role_assignments:
-        - project: api_support
-          role: audit_viewer
-        - domain: hda
-          role: audit_viewer
-          inherited: true
-      - name: HDA_COMPUTE_SUPPORT
-        role_assignments:
-        - project: compute_support
-          role: audit_viewer
-        - domain: hda
-          role: audit_viewer
-          inherited: true
-      - name: HDA_NETWORK_SUPPORT
-        role_assignments:
-        - project: network_support
-          role: audit_viewer
-        - domain: hda
-          role: audit_viewer
-          inherited: true
-      - name: HDA_STORAGE_SUPPORT
-        role_assignments:
-        - project: storage_support
-          role: audit_viewer
-        - domain: hda
-          role: audit_viewer
-          inherited: true
-      - name: HDA_SERVICE_DESK
-        role_assignments:
-        - project: service_desk
-          role: audit_viewer
-        - domain: hda
-          role: audit_viewer
-          inherited: true
-
-    - name: hcp03
-      groups:
-      - name: HCP03_API_SUPPORT
-        role_assignments:
-        - project: api_support
-          role: audit_viewer
-        - domain: hcp03
-          role: audit_viewer
-          inherited: true
-      - name: HCP03_COMPUTE_SUPPORT
-        role_assignments:
-        - project: compute_support
-          role: audit_viewer
-        - domain: hcp03
-          role: audit_viewer
-          inherited: true
-      - name: HCP03_NETWORK_SUPPORT
-        role_assignments:
-        - project: network_support
-          role: audit_viewer
-        - domain: hcp03
-          role: audit_viewer
-          inherited: true
-      - name: HCP03_STORAGE_SUPPORT
-        role_assignments:
-        - project: storage_support
-          role: audit_viewer
-        - domain: hcp03
-          role: audit_viewer
-          inherited: true
-      - name: HCP03_SERVICE_DESK
-        role_assignments:
-        - project: service_desk
-          role: audit_viewer
-        - domain: hcp03
-          role: audit_viewer
-          inherited: true
-
-    - name: hec
-      groups:
-      - name: HEC_API_SUPPORT
-        role_assignments:
-        - project: api_support
-          role: audit_viewer
-        - domain: hec
-          role: audit_viewer
-          inherited: true
-      - name: HEC_COMPUTE_SUPPORT
-        role_assignments:
-        - project: compute_support
-          role: audit_viewer
-        - domain: hec
-          role: audit_viewer
-          inherited: true
-      - name: HEC_NETWORK_SUPPORT
-        role_assignments:
-        - project: network_support
-          role: audit_viewer
-        - domain: hec
-          role: audit_viewer
-          inherited: true
-      - name: HEC_STORAGE_SUPPORT
-        role_assignments:
-        - project: storage_support
-          role: audit_viewer
-        - domain: hec
-          role: audit_viewer
-          inherited: true
-      - name: HEC_SERVICE_DESK
-        role_assignments:
-        - project: service_desk
-          role: audit_viewer
-        - domain: hec
-          role: audit_viewer
-          inherited: true
-
-    - name: monsoon3
-      groups:
-      - name: MONSOON3_API_SUPPORT
-        role_assignments:
-        - project: api_support
-          role: audit_viewer
-        - domain: monsoon3
-          role: audit_viewer
-          inherited: true
-      - name: MONSOON3_COMPUTE_SUPPORT
-        role_assignments:
-        - project: compute_support
-          role: audit_viewer
-        - domain: monsoon3
-          role: audit_viewer
-          inherited: true
-      - name: MONSOON3_NETWORK_SUPPORT
-        role_assignments:
-        - project: network_support
-          role: audit_viewer
-        - domain: monsoon3
-          role: audit_viewer
-          inherited: true
-      - name: MONSOON3_STORAGE_SUPPORT
-        role_assignments:
-        - project: storage_support
-          role: audit_viewer
-        - domain: monsoon3
-          role: audit_viewer
-          inherited: true
-      - name: MONSOON3_SERVICE_DESK
-        role_assignments:
-        - project: service_desk
-          role: audit_viewer
-        - domain: monsoon3
-          role: audit_viewer
-          inherited: true
-
-    - name: neo
-      groups:
-      - name: NEO_API_SUPPORT
-        role_assignments:
-        - project: api_support
-          role: audit_viewer
-        - domain: neo
-          role: audit_viewer
-          inherited: true
-      - name: NEO_COMPUTE_SUPPORT
-        role_assignments:
-        - project: compute_support
-          role: audit_viewer
-        - domain: neo
-          role: audit_viewer
-          inherited: true
-      - name: NEO_NETWORK_SUPPORT
-        role_assignments:
-        - project: network_support
-          role: audit_viewer
-        - domain: neo
-          role: audit_viewer
-          inherited: true
-      - name: NEO_STORAGE_SUPPORT
-        role_assignments:
-        - project: storage_support
-          role: audit_viewer
-        - domain: neo
-          role: audit_viewer
-          inherited: true
-      - name: NEO_SERVICE_DESK
-        role_assignments:
-        - project: service_desk
-          role: audit_viewer
-        - domain: neo
-          role: audit_viewer
-          inherited: true
-
-    - name: s4
-      groups:
-      - name: S4_API_SUPPORT
-        role_assignments:
-        - project: api_support
-          role: audit_viewer
-        - domain: s4
-          role: audit_viewer
-          inherited: true
-      - name: S4_COMPUTE_SUPPORT
-        role_assignments:
-        - project: compute_support
-          role: audit_viewer
-        - domain: s4
-          role: audit_viewer
-          inherited: true
-      - name: S4_NETWORK_SUPPORT
-        role_assignments:
-        - project: network_support
-          role: audit_viewer
-        - domain: s4
-          role: audit_viewer
-          inherited: true
-      - name: S4_STORAGE_SUPPORT
-        role_assignments:
-        - project: storage_support
-          role: audit_viewer
-        - domain: s4
-          role: audit_viewer
-          inherited: true
-      - name: S4_SERVICE_DESK
-        role_assignments:
-        - project: service_desk
-          role: audit_viewer
-        - domain: s4
-          role: audit_viewer
-          inherited: true
-
-    - name: wbs
-      groups:
-      - name: WBS_API_SUPPORT
-        role_assignments:
-        - project: api_support
-          role: audit_viewer
-        - domain: wbs
-          role: audit_viewer
-          inherited: true
-      - name: WBS_COMPUTE_SUPPORT
-        role_assignments:
-        - project: compute_support
-          role: audit_viewer
-        - domain: wbs
-          role: audit_viewer
-          inherited: true
-      - name: WBS_NETWORK_SUPPORT
-        role_assignments:
-        - project: network_support
-          role: audit_viewer
-        - domain: wbs
-          role: audit_viewer
-          inherited: true
-      - name: WBS_STORAGE_SUPPORT
-        role_assignments:
-        - project: storage_support
-          role: audit_viewer
-        - domain: wbs
-          role: audit_viewer
-          inherited: true
-      - name: WBS_SERVICE_DESK
-        role_assignments:
-        - project: service_desk
-          role: audit_viewer
-        - domain: wbs
-          role: audit_viewer
-          inherited: true
-
     - name: cc3test
       groups:
       - name: CC3TEST_DOMAIN_ADMINS
         role_assignments:
         - project: admin
           role: audit_viewer
+
+    {{- range $domains}}
+    {{- if and (not (eq . "Default")) (not (eq . "cc3test")) (not (contains "iaas-" .))}}
+    - name: {{ . }}
+      {{- if eq . "ccadmin"}}
+      projects:
+      - name: master
+        role_assignments:
+        - group: CCADMIN_CLOUD_ADMINS
+          role: audit_viewer
+        - group: CCADMIN_DOMAIN_ADMINS
+          role: audit_viewer
+        - group: CCADMIN_MONITORING_USERS
+          role: audit_viewer
+      {{- end }}
+      groups:
+      - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_API_SUPPORT
+        role_assignments:
+        {{- if not (has . $cdomainsWithoutSupportProjects) }}
+        - project: api_support
+          role: audit_viewer
+        {{- end }}
+        {{- if eq . "ccadmin"}}
+        - project: api_tools
+          role: audit_viewer
+        {{- end }}
+        - domain: {{ . }}
+          role: audit_viewer
+          inherited: true
+      - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_COMPUTE_SUPPORT
+        role_assignments:
+        {{- if not (has . $cdomainsWithoutSupportProjects) }}
+        - project: compute_support
+          role: audit_viewer
+        {{- end }}
+        {{- if eq . "ccadmin"}}
+        - project: compute_tools
+          role: audit_viewer
+        {{- end }}
+        - domain: {{ . }}
+          role: audit_viewer
+          inherited: true
+      - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_NETWORK_SUPPORT
+        role_assignments:
+        {{- if not (has . $cdomainsWithoutSupportProjects) }}
+        - project: network_support
+          role: audit_viewer
+        {{- end }}
+        {{- if eq . "ccadmin"}}
+        - project: network_tools
+          role: audit_viewer
+        {{- end }}
+        - domain: {{ . }}
+          role: audit_viewer
+          inherited: true
+      - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_STORAGE_SUPPORT
+        role_assignments:
+        {{- if not (has . $cdomainsWithoutSupportProjects) }}
+        - project: storage_support
+          role: audit_viewer
+        {{- end }}
+        {{- if eq . "ccadmin"}}
+        - project: storage_tools
+          role: audit_viewer
+        {{- end }}
+        - domain: {{ . }}
+          role: audit_viewer
+          inherited: true
+      - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_SERVICE_DESK
+        role_assignments:
+        {{- if not (has . $cdomainsWithoutSupportProjects) }}
+        - project: service_desk
+          role: audit_viewer
+        {{- end }}
+        - domain: {{ . }}
+          role: audit_viewer
+          inherited: true
+    {{- end }}
+    {{- end }}

--- a/openstack/maia/ci/test-values.yaml
+++ b/openstack/maia/ci/test-values.yaml
@@ -2,7 +2,9 @@ global:
   region: earth
   os_auth_url: my_keystone_url
   domain_seeds:
-    skip_hcm_domain: false
+    customer_domains: [ bar, foo, baz ]
+    customer_domains_without_support_projects: [ baz ]
+
 prometheus-server:
   name: my_prom_name
 maia:

--- a/openstack/maia/templates/seed.yaml
+++ b/openstack/maia/templates/seed.yaml
@@ -1,4 +1,8 @@
 {{- if .Values.maia.enabled }}
+{{- $cdomains := .Values.global.domain_seeds.customer_domains | required "missing value for .Values.global.domain_seeds.customer_domains" -}}
+{{- $domains  := concat (list "cc3test" "ccadmin" "Default") $cdomains -}}
+{{- $cdomainsWithoutSupportProjects := .Values.global.domain_seeds.customer_domains_without_support_projects | required "missing value for .Values.global.domain_seeds.customer_domains_without_support_projects" -}}
+
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:
@@ -7,24 +11,11 @@ metadata:
     component: maia
 spec:
   requires:
-#  - keystone-seed
-  - monsoon3/domain-cc3test-seed
-  - monsoon3/domain-ccadmin-seed
-  - monsoon3/domain-default-seed
-  - monsoon3/domain-monsoon3-seed
-  - monsoon3/domain-bs-seed
-  - monsoon3/domain-btp-fp-seed
-  - monsoon3/domain-cis-seed
-  - monsoon3/domain-cp-seed
-  - monsoon3/domain-fsn-seed
-  - monsoon3/domain-hda-seed
-  - monsoon3/domain-hcm-seed
-  - monsoon3/domain-hcp03-seed
-  - monsoon3/domain-hec-seed
-  - monsoon3/domain-kyma-seed
-  - monsoon3/domain-neo-seed
-  - monsoon3/domain-s4-seed
-  - monsoon3/domain-wbs-seed
+  {{- range $domains}}
+  {{- if not (contains "iaas-" .)}}
+  - monsoon3/domain-{{ replace "_" "-" . | lower }}-seed
+  {{- end}}
+  {{- end}}
 
   roles:
   # TODO: these roles are no longer used by Maia, but by Grafana (indirectly)
@@ -41,6 +32,10 @@ spec:
       region: {{.Values.global.region}}
       url: '{{.Values.maia.endpoint_protocol_public}}://{{.Values.maia.endpoint_host_public}}:{{.Values.maia.endpoint_port_public}}'
 
+  # Default and cc3test get special handling
+  # ccadmin gets additional role assignments for the master project and tools project
+  # iaas- is excluded
+
   domains:
   # seed technical service user
   - name: {{.Values.maia.service_user.user_domain_name}}
@@ -52,8 +47,18 @@ spec:
       - project: {{.Values.maia.service_user.project_name}}
         role: service
 
+  - name: cc3test
+    groups:
+    - name: CC3TEST_DOMAIN_ADMINS
+      role_assignments:
+      - project: admin
+        role: monitoring_admin
+
   # grant -Maia- Grafana specific roles to CC groups
-  - name: ccadmin
+  {{- range $domains}}
+  {{- if and (not (eq . "Default")) (not (eq . "cc3test")) (not (contains "iaas-" .))}}
+  - name: {{ . }}
+    {{- if eq . "ccadmin"}}
     projects:
     - name: master
       role_assignments:
@@ -63,570 +68,69 @@ spec:
         role: monitoring_admin
       - group: CCADMIN_MONITORING_USERS
         role: monitoring_viewer
+    {{- end }}
     groups:
-    - name: CCADMIN_API_SUPPORT
+    - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_API_SUPPORT
       role_assignments:
+      {{- if not (has . $cdomainsWithoutSupportProjects) }}
       - project: api_support
         role: monitoring_admin
+      {{- end }}
+      {{- if eq . "ccadmin"}}
       - project: api_tools
         role: monitoring_admin
-      - domain: ccadmin
+      {{- end }}
+      - domain: {{ . }}
         role: monitoring_admin
         inherited: true
-    - name: CCADMIN_COMPUTE_SUPPORT
+    - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_COMPUTE_SUPPORT
       role_assignments:
+      {{- if not (has . $cdomainsWithoutSupportProjects) }}
       - project: compute_support
         role: monitoring_admin
+      {{- end }}
+      {{- if eq . "ccadmin"}}
       - project: compute_tools
         role: monitoring_admin
-      - domain: ccadmin
+      {{- end }}
+      - domain: {{ . }}
         role: monitoring_viewer
         inherited: true
-    - name: CCADMIN_NETWORK_SUPPORT
+    - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_NETWORK_SUPPORT
       role_assignments:
+      {{- if not (has . $cdomainsWithoutSupportProjects) }}
       - project: network_support
         role: monitoring_admin
+      {{- end }}
+      {{- if eq . "ccadmin"}}
       - project: network_tools
         role: monitoring_admin
-      - domain: ccadmin
+      {{- end }}
+      - domain: {{ . }}
         role: monitoring_viewer
         inherited: true
-    - name: CCADMIN_STORAGE_SUPPORT
+    - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_STORAGE_SUPPORT
       role_assignments:
+      {{- if not (has . $cdomainsWithoutSupportProjects) }}
       - project: storage_support
         role: monitoring_admin
+      {{- end }}
+      {{- if eq . "ccadmin"}}
       - project: storage_tools
         role: monitoring_admin
-      - domain: ccadmin
+      {{- end }}
+      - domain: {{.}}
         role: monitoring_viewer
         inherited: true
-    - name: CCADMIN_SERVICE_DESK
+    - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_SERVICE_DESK
       role_assignments:
+      {{- if not (has . $cdomainsWithoutSupportProjects) }}
       - project: service_desk
         role: monitoring_admin
-      - domain: ccadmin
+      {{- end }}
+      - domain: {{ . }}
         role: monitoring_viewer
         inherited: true
-
-  - name: bs
-    groups:
-    - name: BS_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: monitoring_admin
-      - domain: bs
-        role: monitoring_admin
-        inherited: true
-    - name: BS_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: monitoring_admin
-      - domain: bs
-        role: monitoring_viewer
-        inherited: true
-    - name: BS_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: monitoring_admin
-      - domain: bs
-        role: monitoring_viewer
-        inherited: true
-    - name: BS_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: monitoring_admin
-      - domain: bs
-        role: monitoring_viewer
-        inherited: true
-    - name: BS_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: monitoring_admin
-      - domain: bs
-        role: monitoring_viewer
-        inherited: true
-
-  - name: btp_fp
-    groups:
-    - name: BTP_FP_API_SUPPORT
-      role_assignments:
-      - domain: btp_fp
-        role: monitoring_admin
-        inherited: true
-    - name: BTP_FP_COMPUTE_SUPPORT
-      role_assignments:
-      - domain: btp_fp
-        role: monitoring_viewer
-        inherited: true
-    - name: BTP_FP_NETWORK_SUPPORT
-      role_assignments:
-      - domain: btp_fp
-        role: monitoring_viewer
-        inherited: true
-    - name: BTP_FP_STORAGE_SUPPORT
-      role_assignments:
-      - domain: btp_fp
-        role: monitoring_viewer
-        inherited: true
-    - name: BTP_FP_SERVICE_DESK
-      role_assignments:
-      - domain: btp_fp
-        role: monitoring_viewer
-        inherited: true
-
-  - name: cis
-    groups:
-    - name: CIS_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: monitoring_admin
-      - domain: cis
-        role: monitoring_admin
-        inherited: true
-    - name: CIS_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: monitoring_admin
-      - domain: cis
-        role: monitoring_viewer
-        inherited: true
-    - name: CIS_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: monitoring_admin
-      - domain: cis
-        role: monitoring_viewer
-        inherited: true
-    - name: CIS_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: monitoring_admin
-      - domain: cis
-        role: monitoring_viewer
-        inherited: true
-    - name: CIS_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: monitoring_admin
-      - domain: cis
-        role: monitoring_viewer
-        inherited: true
-
-  - name: cp
-    groups:
-    - name: CP_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: monitoring_admin
-      - domain: cp
-        role: monitoring_admin
-        inherited: true
-    - name: CP_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: monitoring_admin
-      - domain: cp
-        role: monitoring_viewer
-        inherited: true
-    - name: CP_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: monitoring_admin
-      - domain: cp
-        role: monitoring_viewer
-        inherited: true
-    - name: CP_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: monitoring_admin
-      - domain: cp
-        role: monitoring_viewer
-        inherited: true
-    - name: CP_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: monitoring_admin
-      - domain: cp
-        role: monitoring_viewer
-        inherited: true
-
-  - name: fsn
-    groups:
-    - name: FSN_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: monitoring_admin
-      - domain: fsn
-        role: monitoring_admin
-        inherited: true
-    - name: FSN_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: monitoring_admin
-      - domain: fsn
-        role: monitoring_viewer
-        inherited: true
-    - name: FSN_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: monitoring_admin
-      - domain: fsn
-        role: monitoring_viewer
-        inherited: true
-    - name: FSN_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: monitoring_admin
-      - domain: fsn
-        role: monitoring_viewer
-        inherited: true
-    - name: FSN_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: monitoring_admin
-      - domain: fsn
-        role: monitoring_viewer
-        inherited: true
-
-  - name: hda
-    groups:
-    - name: HDA_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: monitoring_admin
-      - domain: hda
-        role: monitoring_admin
-        inherited: true
-    - name: HDA_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: monitoring_admin
-      - domain: hda
-        role: monitoring_viewer
-        inherited: true
-    - name: HDA_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: monitoring_admin
-      - domain: hda
-        role: monitoring_viewer
-        inherited: true
-    - name: HDA_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: monitoring_admin
-      - domain: hda
-        role: monitoring_viewer
-        inherited: true
-    - name: HDA_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: monitoring_admin
-      - domain: hda
-        role: monitoring_viewer
-        inherited: true
-
-{{- if not .Values.global.domain_seeds.skip_hcm_domain }}
-  - name: hcm
-    groups:
-    - name: HCM_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: monitoring_admin
-      - domain: hcm
-        role: monitoring_admin
-        inherited: true
-    - name: HCM_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: monitoring_admin
-      - domain: hcm
-        role: monitoring_viewer
-        inherited: true
-    - name: HCM_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: monitoring_admin
-      - domain: hcm
-        role: monitoring_viewer
-        inherited: true
-    - name: HCM_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: monitoring_admin
-      - domain: hcm
-        role: monitoring_viewer
-        inherited: true
-    - name: HCM_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: monitoring_admin
-      - domain: hcm
-        role: monitoring_viewer
-        inherited: true
-{{- end }}
-
-  - name: hcp03
-    groups:
-    - name: HCP03_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: monitoring_admin
-      - domain: hcp03
-        role: monitoring_admin
-        inherited: true
-    - name: HCP03_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: monitoring_admin
-      - domain: hcp03
-        role: monitoring_viewer
-        inherited: true
-    - name: HCP03_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: monitoring_admin
-      - domain: hcp03
-        role: monitoring_viewer
-        inherited: true
-    - name: HCP03_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: monitoring_admin
-      - domain: hcp03
-        role: monitoring_viewer
-        inherited: true
-    - name: HCP03_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: monitoring_admin
-      - domain: hcp03
-        role: monitoring_viewer
-        inherited: true
-
-  - name: hec
-    groups:
-    - name: HEC_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: monitoring_admin
-      - domain: hec
-        role: monitoring_admin
-        inherited: true
-    - name: HEC_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: monitoring_admin
-      - domain: hec
-        role: monitoring_viewer
-        inherited: true
-    - name: HEC_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: monitoring_admin
-      - domain: hec
-        role: monitoring_viewer
-        inherited: true
-    - name: HEC_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: monitoring_admin
-      - domain: hec
-        role: monitoring_viewer
-        inherited: true
-    - name: HEC_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: monitoring_admin
-      - domain: hec
-        role: monitoring_viewer
-        inherited: true
-
-  - name: kyma
-    groups:
-    - name: KYMA_API_SUPPORT
-      role_assignments:
-      - domain: kyma
-        role: monitoring_admin
-        inherited: true
-    - name: KYMA_COMPUTE_SUPPORT
-      role_assignments:
-      - domain: kyma
-        role: monitoring_viewer
-        inherited: true
-    - name: KYMA_NETWORK_SUPPORT
-      role_assignments:
-      - domain: kyma
-        role: monitoring_viewer
-        inherited: true
-    - name: KYMA_STORAGE_SUPPORT
-      role_assignments:
-      - domain: kyma
-        role: monitoring_viewer
-        inherited: true
-    - name: KYMA_SERVICE_DESK
-      role_assignments:
-      - domain: kyma
-        role: monitoring_viewer
-        inherited: true
-
-  - name: monsoon3
-    groups:
-    - name: MONSOON3_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: monitoring_admin
-      - domain: monsoon3
-        role: monitoring_admin
-        inherited: true
-    - name: MONSOON3_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: monitoring_admin
-      - domain: monsoon3
-        role: monitoring_viewer
-        inherited: true
-    - name: MONSOON3_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: monitoring_admin
-      - domain: monsoon3
-        role: monitoring_viewer
-        inherited: true
-    - name: MONSOON3_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: monitoring_admin
-      - domain: monsoon3
-        role: monitoring_viewer
-        inherited: true
-    - name: MONSOON3_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: monitoring_admin
-      - domain: monsoon3
-        role: monitoring_viewer
-        inherited: true
-
-  - name: neo
-    groups:
-    - name: NEO_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: monitoring_admin
-      - domain: neo
-        role: monitoring_admin
-        inherited: true
-    - name: NEO_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: monitoring_admin
-      - domain: neo
-        role: monitoring_viewer
-        inherited: true
-    - name: NEO_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: monitoring_admin
-      - domain: neo
-        role: monitoring_viewer
-        inherited: true
-    - name: NEO_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: monitoring_admin
-      - domain: neo
-        role: monitoring_viewer
-        inherited: true
-    - name: NEO_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: monitoring_admin
-      - domain: neo
-        role: monitoring_viewer
-        inherited: true
-
-  - name: s4
-    groups:
-    - name: S4_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: monitoring_admin
-      - domain: s4
-        role: monitoring_admin
-        inherited: true
-    - name: S4_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: monitoring_admin
-      - domain: s4
-        role: monitoring_viewer
-        inherited: true
-    - name: S4_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: monitoring_admin
-      - domain: s4
-        role: monitoring_viewer
-        inherited: true
-    - name: S4_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: monitoring_admin
-      - domain: s4
-        role: monitoring_viewer
-        inherited: true
-    - name: S4_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: monitoring_admin
-      - domain: s4
-        role: monitoring_viewer
-        inherited: true
-
-  - name: wbs
-    groups:
-    - name: WBS_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: monitoring_admin
-      - domain: wbs
-        role: monitoring_admin
-        inherited: true
-    - name: WBS_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: monitoring_admin
-      - domain: wbs
-        role: monitoring_viewer
-        inherited: true
-    - name: WBS_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: monitoring_admin
-      - domain: wbs
-        role: monitoring_viewer
-        inherited: true
-    - name: WBS_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: monitoring_admin
-      - domain: wbs
-        role: monitoring_viewer
-        inherited: true
-    - name: WBS_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: monitoring_admin
-      - domain: wbs
-        role: monitoring_viewer
-        inherited: true
-
-  - name: cc3test
-    groups:
-    - name: CC3TEST_DOMAIN_ADMINS
-      role_assignments:
-      - project: admin
-        role: monitoring_admin
-
+  {{- end }}
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
In an attempt to make deployment of new domains easier, @majewsky recently introduced global.domain_seeds.customer_domains. As this could replace the old skip_hcm_domain, poses the opportunity to distinguish between internal and external domains in future and accommodate other specialties we would like to suggest this on seeds of other services too.

The expressions are technically equal, only the ora domain was added for Maia and fsn, kyma, ora for Hermes. If they were excluded on purpose, let me know and I can change it. I excluded `iaas-` for now.
I ran `h3 diff` with `dyff` option against qa-de-1 and eu-de-1, you can have a look at the output here:
[maiaDE1diff.txt](https://github.com/user-attachments/files/19349459/maiaDE1diff.txt)
[maiaQA1diff.txt](https://github.com/user-attachments/files/19349461/maiaQA1diff.txt)
[hermesDE1diff.txt](https://github.com/user-attachments/files/19349463/hermesDE1diff.txt)
[hermesQA1diff.txt](https://github.com/user-attachments/files/19349464/hermesQA1diff.txt)
