### PR TITLE
[ironic] seed generic domains using global.domains_seeds

### DIFF
--- a/openstack/ironic/ci/test-values.yaml
+++ b/openstack/ironic/ci/test-values.yaml
@@ -10,7 +10,8 @@ global:
   ironic_service_password: topSecret
   ironicServicePassword: topSecret
   domain_seeds:
-    skip_hcm_domain: false
+    customer_domains: [ bar, foo, baz ]
+    customer_domains_without_support_projects: [ baz ]
 
 imageVersion: train
 

--- a/openstack/ironic/templates/seed.yaml
+++ b/openstack/ironic/templates/seed.yaml
@@ -1,29 +1,21 @@
+{{- $cdomains := .Values.global.domain_seeds.customer_domains | required "missing value for .Values.global.domain_seeds.customer_domains" -}}
+{{- $domains  := concat (list "ccadmin" "Default") $cdomains -}}
+{{- $cdomainsWithoutSupportProjects := .Values.global.domain_seeds.customer_domains_without_support_projects | required "missing value for .Values.global.domain_seeds.customer_domains_without_support_projects" -}}
+
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:
   name: ironic-seed
 spec:
   requires:
-  - monsoon3/domain-default-seed
-  - monsoon3/domain-cc3test-seed
-  - monsoon3/domain-ccadmin-seed
-  - monsoon3/domain-bs-seed
-  - monsoon3/domain-btp-fp-seed
-  - monsoon3/domain-cis-seed
-  - monsoon3/domain-cp-seed
-  - monsoon3/domain-fsn-seed
-  - monsoon3/domain-hda-seed
-  - monsoon3/domain-hcm-seed
-  - monsoon3/domain-hcp03-seed
-  - monsoon3/domain-hec-seed
-  - monsoon3/domain-kyma-seed
-  - monsoon3/domain-monsoon3-seed
-  - monsoon3/domain-neo-seed
-  - monsoon3/domain-s4-seed
-  - monsoon3/domain-wbs-seed
-{{- if .Values.tempest_enabled }}
+  {{- range $domains}}
+  {{- if not (hasPrefix "iaas-" .)}}
+  - monsoon3/domain-{{replace "_" "-" . | lower}}-seed
+  {{- end }}
+  {{- end }}
+  {{- if .Values.tempest_enabled }}
   - monsoon3/domain-tempest-seed
-{{- end }}
+  {{- end }}
   - monsoon3/nova-seed
   - monsoon3/neutron-seed
   - swift/swift-seed
@@ -591,6 +583,14 @@ spec:
       "resources:CUSTOM_HV_S4_C32_M1024_V0": "1"
       {{- tuple . "baremetal" | include "ironic.helpers.extra_specs" | indent 6 }}
 
+
+  # Default and tempest are special
+  # cc3test does not get seeds
+  # ccadmin gets role assignments for the master project and some additional project assignments
+  # monsoon3 gets a special role assignment for cc-demo project
+  # s4 gets a special role assignment for S4_CFM_ADMINS group
+  # iaas is excluded completely
+
   domains:
   - name: Default
     users:
@@ -614,7 +614,7 @@ spec:
       description: IPMI Exporter for MB Monitoring
       password: '{{ required ".Values.global.ipmi_exporter_user_passwd is missing" .Values.global.ipmi_exporter_user_passwd | include "resolve_secret" }}'
 
-{{- if .Values.tempest_enabled }}
+  {{- if .Values.tempest_enabled }}
   - name: tempest
     projects:
     - name: tempest1
@@ -638,9 +638,12 @@ spec:
         role: baremetal_admin
       - domain: tempest
         role: baremetal_admin
-{{- end }}
+  {{- end }}
 
-  - name: ccadmin
+  {{- range $domains}}
+  {{- if and (not (hasPrefix "iaas-" .)) (not (eq . "Default"))}}
+  - name: {{ . }}
+    {{- if eq . "ccadmin"}}
     projects:
     - name: master
       role_assignments:
@@ -652,580 +655,93 @@ spec:
         role: cloud_compute_admin
       - user: ironic@Default
         role: objectstore_admin
+    {{- end }}
     groups:
+    {{- if eq . "ccadmin"}}
     - name: CCADMIN_CLOUD_ADMINS
       role_assignments:
       - project: master
         role: cloud_baremetal_admin
       - project: cloud_admin
         role: cloud_baremetal_admin
-    - name: CCADMIN_API_SUPPORT
+    {{- end }}
+    {{- if eq . "monsoon3"}}
+    - name: MONSOON3_DOMAIN_ADMINS
       role_assignments:
+      - project: cc-demo
+        role: baremetal_admin
+    {{- end }}
+    {{- if eq . "s4"}}
+    - name: S4_CFM_ADMINS
+      role_assignments:
+      - domain: s4
+        role: cloud_baremetal_admin
+        inherited: true
+    {{- end }}
+    - name: {{ hasPrefix "iaas-" . | ternary . ( upper . ) }}_API_SUPPORT
+      role_assignments:
+      {{- if not (has . $cdomainsWithoutSupportProjects) }}
       - project: api_support
         role: baremetal_admin
+      {{- end }}
+      {{- if eq . "ccadmin"}}
       - project: api_tools
         role: baremetal_admin
-      - domain: ccadmin
+      {{- end }}
+      - domain: {{ . }}
         role: baremetal_admin
         inherited: true
-    - name: CCADMIN_COMPUTE_SUPPORT
+    - name: {{ hasPrefix "iaas-" . | ternary . ( upper . ) }}_COMPUTE_SUPPORT
       role_assignments:
+      {{- if not (has . $cdomainsWithoutSupportProjects) }}
       - project: compute_support
         role: baremetal_admin
+      {{- end }}
+      {{- if eq . "ccadmin"}}
       - project: compute_tools
         role: cloud_baremetal_admin
       - project: master
         role: cloud_baremetal_admin
       - project: cloud_admin
         role: cloud_baremetal_admin
-      - domain: ccadmin
+      {{- end }}
+      - domain: {{ . }}
         role: baremetal_admin
         inherited: true
-    - name: CCADMIN_NETWORK_SUPPORT
+    - name: {{ hasPrefix "iaas-" . | ternary . ( upper . ) }}_NETWORK_SUPPORT
       role_assignments:
+      {{- if not (has . $cdomainsWithoutSupportProjects) }}
       - project: network_support
         role: baremetal_admin
+      {{- end }}
+      {{- if eq . "ccadmin"}}
       - project: network_tools
         role: baremetal_admin
-      - domain: ccadmin
+      {{- end }}
+      - domain: {{ . }}
         role: baremetal_viewer
         inherited: true
-    - name: CCADMIN_STORAGE_SUPPORT
+    - name: {{ hasPrefix "iaas-" . | ternary . ( upper . ) }}_STORAGE_SUPPORT
       role_assignments:
+      {{- if not (has . $cdomainsWithoutSupportProjects) }}
       - project: storage_support
         role: baremetal_admin
+      {{- end }}
+      {{- if eq . "ccadmin"}}
       - project: storage_tools
         role: baremetal_admin
-      - domain: ccadmin
+      {{- end }}
+      - domain: {{ . }}
         role: baremetal_viewer
         inherited: true
-    - name: CCADMIN_SERVICE_DESK
+    - name: {{ hasPrefix "iaas-" . | ternary . ( upper . ) }}_SERVICE_DESK
       role_assignments:
+      {{- if not (has . $cdomainsWithoutSupportProjects) }}
       - project: service_desk
         role: baremetal_admin
-      - domain: ccadmin
+      {{- end}}
+      - domain: {{ . }}
         role: baremetal_viewer
         inherited: true
-
-  - name: cis
-    groups:
-    - name: CIS_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: baremetal_admin
-      - domain: cis
-        role: baremetal_admin
-        inherited: true
-    - name: CIS_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: baremetal_admin
-      - domain: cis
-        role: baremetal_admin
-        inherited: true
-    - name: CIS_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: baremetal_admin
-      - domain: cis
-        role: baremetal_viewer
-        inherited: true
-    - name: CIS_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: baremetal_admin
-      - domain: cis
-        role: baremetal_viewer
-        inherited: true
-    - name: CIS_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: baremetal_admin
-      - domain: cis
-        role: baremetal_viewer
-        inherited: true
-
-  - name: bs
-    groups:
-    - name: BS_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: baremetal_admin
-      - domain: bs
-        role: baremetal_admin
-        inherited: true
-    - name: BS_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: baremetal_admin
-      - domain: bs
-        role: baremetal_admin
-        inherited: true
-    - name: BS_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: baremetal_admin
-      - domain: bs
-        role: baremetal_viewer
-        inherited: true
-    - name: BS_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: baremetal_admin
-      - domain: bs
-        role: baremetal_viewer
-        inherited: true
-    - name: BS_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: baremetal_admin
-      - domain: bs
-        role: baremetal_viewer
-        inherited: true
-
-  - name: btp_fp
-    groups:
-    - name: BTP_FP_API_SUPPORT
-      role_assignments:
-      - domain: btp_fp
-        role: baremetal_admin
-        inherited: true
-    - name: BTP_FP_COMPUTE_SUPPORT
-      role_assignments:
-      - domain: btp_fp
-        role: baremetal_admin
-        inherited: true
-    - name: BTP_FP_NETWORK_SUPPORT
-      role_assignments:
-      - domain: btp_fp
-        role: baremetal_viewer
-        inherited: true
-    - name: BTP_FP_STORAGE_SUPPORT
-      role_assignments:
-      - domain: btp_fp
-        role: baremetal_viewer
-        inherited: true
-    - name: BTP_FP_SERVICE_DESK
-      role_assignments:
-      - domain: btp_fp
-        role: baremetal_viewer
-        inherited: true
-
-  - name: cp
-    groups:
-    - name: CP_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: baremetal_admin
-      - domain: cp
-        role: baremetal_admin
-        inherited: true
-    - name: CP_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: baremetal_admin
-      - domain: cp
-        role: baremetal_admin
-        inherited: true
-    - name: CP_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: baremetal_admin
-      - domain: cp
-        role: baremetal_viewer
-        inherited: true
-    - name: CP_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: baremetal_admin
-      - domain: cp
-        role: baremetal_viewer
-        inherited: true
-    - name: CP_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: baremetal_admin
-      - domain: cp
-        role: baremetal_viewer
-        inherited: true
-
-  - name: fsn
-    groups:
-    - name: FSN_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: baremetal_admin
-      - domain: fsn
-        role: baremetal_admin
-        inherited: true
-    - name: FSN_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: baremetal_admin
-      - domain: fsn
-        role: baremetal_admin
-        inherited: true
-    - name: FSN_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: baremetal_admin
-      - domain: fsn
-        role: baremetal_viewer
-        inherited: true
-    - name: FSN_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: baremetal_admin
-      - domain: fsn
-        role: baremetal_viewer
-        inherited: true
-    - name: FSN_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: baremetal_admin
-      - domain: fsn
-        role: baremetal_viewer
-        inherited: true
-
-  - name: hda
-    groups:
-    - name: HDA_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: baremetal_admin
-      - domain: hda
-        role: baremetal_admin
-        inherited: true
-    - name: HDA_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: baremetal_admin
-      - domain: hda
-        role: baremetal_admin
-        inherited: true
-    - name: HDA_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: baremetal_admin
-      - domain: hda
-        role: baremetal_viewer
-        inherited: true
-    - name: HDA_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: baremetal_admin
-      - domain: hda
-        role: baremetal_viewer
-        inherited: true
-    - name: HDA_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: baremetal_admin
-      - domain: hda
-        role: baremetal_viewer
-        inherited: true
-
-{{- if not .Values.global.domain_seeds.skip_hcm_domain }}
-  - name: hcm
-    groups:
-    - name: HCM_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: baremetal_admin
-      - domain: hcm
-        role: baremetal_admin
-        inherited: true
-    - name: HCM_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: baremetal_admin
-      - domain: hcm
-        role: baremetal_admin
-        inherited: true
-    - name: HCM_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: baremetal_admin
-      - domain: hcm
-        role: baremetal_viewer
-        inherited: true
-    - name: HCM_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: baremetal_admin
-      - domain: hcm
-        role: baremetal_viewer
-        inherited: true
-    - name: HCM_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: baremetal_admin
-      - domain: hcm
-        role: baremetal_viewer
-        inherited: true
-{{- end }}
-
-  - name: hcp03
-    groups:
-    - name: HCP03_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: baremetal_admin
-      - domain: hcp03
-        role: baremetal_admin
-        inherited: true
-    - name: HCP03_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: baremetal_admin
-      - domain: hcp03
-        role: baremetal_admin
-        inherited: true
-    - name: HCP03_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: baremetal_admin
-      - domain: hcp03
-        role: baremetal_viewer
-        inherited: true
-    - name: HCP03_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: baremetal_admin
-      - domain: hcp03
-        role: baremetal_viewer
-        inherited: true
-    - name: HCP03_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: baremetal_admin
-      - domain: hcp03
-        role: baremetal_viewer
-        inherited: true
-
-  - name: hec
-    groups:
-    - name: HEC_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: baremetal_admin
-      - domain: hec
-        role: baremetal_admin
-        inherited: true
-    - name: HEC_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: baremetal_admin
-      - domain: hec
-        role: baremetal_admin
-        inherited: true
-    - name: HEC_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: baremetal_admin
-      - domain: hec
-        role: baremetal_viewer
-        inherited: true
-    - name: HEC_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: baremetal_admin
-      - domain: hec
-        role: baremetal_viewer
-        inherited: true
-    - name: HEC_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: baremetal_admin
-      - domain: hec
-        role: baremetal_viewer
-        inherited: true
-
-  - name: kyma
-    groups:
-    - name: KYMA_API_SUPPORT
-      role_assignments:
-      - domain: kyma
-        role: baremetal_admin
-        inherited: true
-    - name: KYMA_COMPUTE_SUPPORT
-      role_assignments:
-      - domain: kyma
-        role: baremetal_admin
-        inherited: true
-    - name: KYMA_NETWORK_SUPPORT
-      role_assignments:
-      - domain: kyma
-        role: baremetal_viewer
-        inherited: true
-    - name: KYMA_STORAGE_SUPPORT
-      role_assignments:
-      - domain: kyma
-        role: baremetal_viewer
-        inherited: true
-    - name: KYMA_SERVICE_DESK
-      role_assignments:
-      - domain: kyma
-        role: baremetal_viewer
-        inherited: true
-
-  - name: monsoon3
-    groups:
-    - name: MONSOON3_DOMAIN_ADMINS
-      role_assignments:
-      - project: cc-demo
-        role: baremetal_admin
-    - name: MONSOON3_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: baremetal_admin
-      - domain: monsoon3
-        role: baremetal_admin
-        inherited: true
-    - name: MONSOON3_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: baremetal_admin
-      - domain: monsoon3
-        role: baremetal_admin
-        inherited: true
-    - name: MONSOON3_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: baremetal_admin
-      - domain: monsoon3
-        role: baremetal_viewer
-        inherited: true
-    - name: MONSOON3_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: baremetal_admin
-      - domain: monsoon3
-        role: baremetal_viewer
-        inherited: true
-    - name: MONSOON3_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: baremetal_admin
-      - domain: monsoon3
-        role: baremetal_viewer
-        inherited: true
-
-  - name: neo
-    groups:
-    - name: NEO_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: baremetal_admin
-      - domain: neo
-        role: baremetal_admin
-        inherited: true
-    - name: NEO_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: baremetal_admin
-      - domain: neo
-        role: baremetal_admin
-        inherited: true
-    - name: NEO_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: baremetal_admin
-      - domain: neo
-        role: baremetal_viewer
-        inherited: true
-    - name: NEO_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: baremetal_admin
-      - domain: neo
-        role: baremetal_viewer
-        inherited: true
-    - name: NEO_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: baremetal_admin
-      - domain: neo
-        role: baremetal_viewer
-        inherited: true
-
-  - name: s4
-    groups:
-    - name: S4_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: baremetal_admin
-      - domain: s4
-        role: baremetal_admin
-        inherited: true
-    - name: S4_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: baremetal_admin
-      - domain: s4
-        role: baremetal_admin
-        inherited: true
-    - name: S4_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: baremetal_admin
-      - domain: s4
-        role: baremetal_viewer
-        inherited: true
-    - name: S4_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: baremetal_admin
-      - domain: s4
-        role: baremetal_viewer
-        inherited: true
-    - name: S4_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: baremetal_admin
-      - domain: s4
-        role: baremetal_viewer
-        inherited: true
-    - name: S4_CFM_ADMINS
-      role_assignments:
-      - domain: s4
-        role: cloud_baremetal_admin
-        inherited: true
-
-  - name: wbs
-    groups:
-    - name: WBS_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: baremetal_admin
-      - domain: wbs
-        role: baremetal_admin
-        inherited: true
-    - name: WBS_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: baremetal_admin
-      - domain: wbs
-        role: baremetal_admin
-        inherited: true
-    - name: WBS_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: baremetal_admin
-      - domain: wbs
-        role: baremetal_viewer
-        inherited: true
-    - name: WBS_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: baremetal_admin
-      - domain: wbs
-        role: baremetal_viewer
-        inherited: true
-    - name: WBS_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: baremetal_admin
-      - domain: wbs
-        role: baremetal_viewer
-        inherited: true
+  {{- end }}
+  {{- end }}


### PR DESCRIPTION
In an attempt to make deployment of new domains easier, @majewsky recently introduced global.domain_seeds.customer_domains. As this could replace the old skip_hcm_domain, poses the opportunity to distinguish between internal and external domains in future and accommodate other specialties we would like to suggest this on seeds of other services too.

The expressions are technically equal, only the ora domain was added. If they were excluded on purpose, let me know and I can change it. I excluded `iaas-` for now.
I ran `h3 diff` with `dyff` option against qa-de-1 and eu-de-1 you can have a look at the output here:
[ironicDE1diff.txt](https://github.com/user-attachments/files/19349338/ironicDE1diff.txt)
[ironicQA1diff.txt](https://github.com/user-attachments/files/19349339/ironicQA1diff.txt)
