### PR TITLE
fix: message in neutron ns-exporter alerts

### DIFF
--- a/prometheus-exporters/ns-exporter/alerts/probe.alerts
+++ b/prometheus-exporters/ns-exporter/alerts/probe.alerts
@@ -23,7 +23,7 @@ groups:
       meta: 'Network {{ $labels.network_name }} failed all probes'
       cloudops: "?searchTerm={{ $labels.network_id }}&type=network"
     annotations:
-      description: 'The network `{{ $labels.network_name }} ({{ $labels.network_id }})` on agent `{{ $labels.agent }}` failed all DNS probes for more than 5 minutes. (<https://dashboard.{{ $externalLabels.region }}.cloud.sap/ccadmin/cloud_admin/cloudops#/universal-search/?searchTerm={{ $labels.router }}&type=router|Router {{ $labels.router }}>). Please run ```hammer -r {{ $externalLabels.region }} net check {{ $labels.network_id }}``` and post it on the alert Slack thread.'
+      description: 'The network `{{ $labels.network_name }} ({{ $labels.network_id }})` failed all DNS probes for more than 5 minutes. (<https://dashboard.{{ $externalLabels.region }}.cloud.sap/ccadmin/cloud_admin/cloudops#/universal-search/?searchTerm={{ $labels.router_id }}&type=router|Router {{ $labels.router_id }}>). Please run ```hammer -r {{ $externalLabels.region }} net check {{ $labels.network_id }}``` and post it on the alert Slack thread.'
       summary: Network probes failed
   - alert: NetworkNamespaceProbesFailedForShootNetworkWeekdays
     expr: |
@@ -50,7 +50,7 @@ groups:
       meta: 'Network {{ $labels.network_name }} failed all probes'
       cloudops: "?searchTerm={{ $labels.network_id }}&type=network"
     annotations:
-      description: 'The network `{{ $labels.network_name }} ({{ $labels.network_id }})` on agent `{{ $labels.agent }}` failed all DNS probes for more than 5 minutes. (<https://dashboard.{{ $externalLabels.region }}.cloud.sap/ccadmin/cloud_admin/cloudops#/universal-search/?searchTerm={{ $labels.router }}&type=router|Router {{ $labels.router }}>).
+      description: 'The network `{{ $labels.network_name }} ({{ $labels.network_id }})` failed all DNS probes for more than 5 minutes. (<https://dashboard.{{ $externalLabels.region }}.cloud.sap/ccadmin/cloud_admin/cloudops#/universal-search/?searchTerm={{ $labels.router_id }}&type=router|Router {{ $labels.router_id }}>).
 Please run ```hammer -r {{ $externalLabels.region }} net check {{ $labels.network_id }}``` and post it on the alert Slack thread.'
       summary: Network probes failed for `shoot--` networks.
   - alert: NetworkNamespaceProbesFailedForShootNetworkWeekend
@@ -78,7 +78,7 @@ Please run ```hammer -r {{ $externalLabels.region }} net check {{ $labels.networ
       meta: 'Network {{ $labels.network_name }} failed all probes'
       cloudops: "?searchTerm={{ $labels.network_id }}&type=network"
     annotations:
-      description: 'The network `{{ $labels.network_name }} ({{ $labels.network_id }})` on agent `{{ $labels.agent }}` failed all DNS probes for more than 5 minutes. (<https://dashboard.{{ $externalLabels.region }}.cloud.sap/ccadmin/cloud_admin/cloudops#/universal-search/?searchTerm={{ $labels.router }}&type=router|Router {{ $labels.router }}>).
+      description: 'The network `{{ $labels.network_name }} ({{ $labels.network_id }})` failed all DNS probes for more than 5 minutes. (<https://dashboard.{{ $externalLabels.region }}.cloud.sap/ccadmin/cloud_admin/cloudops#/universal-search/?searchTerm={{ $labels.router_id }}&type=router|Router {{ $labels.router_id }}>).
 Please run ```hammer -r {{ $externalLabels.region }} net check {{ $labels.network_id }}``` and post it on the alert Slack thread.'
       summary: Network probes failed for `shoot` networks.
   - alert: NetworkNamespaceProbeMetricsMissing


### PR DESCRIPTION
* agent_id is currently empty because we do not consider the label in the aggregation function. We remove it from the message as it only pollutes the message.
* fix missing router ID