### PR TITLE
fix(logs): changes alert rule to exlude 'debug', 'deployment' exporters

### DIFF
--- a/system/logs/templates/alerts/_otel-alerts.tpl
+++ b/system/logs/templates/alerts/_otel-alerts.tpl
@@ -2,7 +2,7 @@ groups:
 - name: logs-otel.alerts
   rules:
   - alert: LogsOTelLogsMissing
-    expr: rate(otelcol_exporter_sent_log_records_total{job="logs/opentelemetry-collector-logs"}[60m]) == 0
+    expr: sum by (region, k8s_node_name, pod, exporter) (rate(otelcol_exporter_sent_log_records_total{job="logs/opentelemetry-collector-logs", exporter !~"debug|opensearch/failover_a_external_deployments"}[60m])) == 0
     for: 120m
     labels:
       context: logshipping


### PR DESCRIPTION
We received redundant alerts for the 'debug' and the 'deployments' exporters. The former is
not a exporter we care about in a prod environment, and the latter receives inconsistent and very little
traffic (<1 log per h).

---------

Signed off by: Simon Olander (simon.olander@sap.com)