### PR TITLE
[netapp-harvest-exporter] improve alert NetappHarvestManilaFilerNotScraped

### DIFF
--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/alerts/thanos-metal/netapp.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/alerts/thanos-metal/netapp.yaml
@@ -7,7 +7,7 @@ groups:
           count by (share_backend_name, host) (
             label_replace(
               label_replace(
-                manila_total_capacity_gb{share_backend_name!~"integration"},
+                manila_total_capacity_gb{share_backend_name!~"integration", hardware_state!~"in_decom|in_build"},
                 "share_backend_fqdn", "stnpca3-cp001.cc.eu-de-1.cloud.sap", "share_backend_fqdn", "stnpca3.cc.eu-de-1.cloud.sap"),
                 "host", "$1", "share_backend_fqdn", "(.*)"))
           unless on (host) netapp_volume_size


### PR DESCRIPTION
We can ignore the alert when filer being decommissioned or in build.
