### PR TITLE
Change threshold for DatastoreHostCountMismatch Alert

### DIFF
--- a/prometheus-rules/prometheus-vmware-rules/Chart.yaml
+++ b/prometheus-rules/prometheus-vmware-rules/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A collection of Prometheus alert rules.
 name: prometheus-vmware-rules
-version: 1.1.5
+version: 1.1.6
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/prometheus-rules/prometheus-vmware-rules/alerts/datastore.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/datastore.alerts
@@ -413,7 +413,7 @@ groups:
       vrops_datastore_hostcount{datastore=~"^vmfs_vc_.+"} < on (vcenter) group_left
       count by (vcenter) (vrops_hostsystem_runtime_connectionstate{state="connected", vccluster=~"^productionbb\\d+$"}
       unless on (hostsystem) (vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}))
-    for: 30m
+    for: 60m
     labels:
       severity: warning
       tier: vmware
@@ -429,7 +429,7 @@ groups:
     expr: |
       vrops_datastore_hostcount{datastore=~"^nfs_.+"} < on (vcenter) group_left
       count by (vcenter) (vrops_hostsystem_runtime_connectionstate{state="connected", vccluster=~"^productionbb\\d+$"})
-    for: 30m
+    for: 60m
     labels:
       severity: info
       tier: vmware


### PR DESCRIPTION
Increased threshold for DatastoreHostCountMismatch Alert from 30 minutes to 60 minutes and bumped the chart version