### PR TITLE
feat(opensearch): override ism policy in values

### DIFF
--- a/system/opensearch-logs/templates/config/_ds-alerts-ism.json.tpl
+++ b/system/opensearch-logs/templates/config/_ds-alerts-ism.json.tpl
@@ -1,0 +1,80 @@
+{
+    "policy": {
+        "policy_id": "ds-alerts-ism",
+        "description": "Datastream (ds) ism policy for alerts-ds",
+        "schema_version": "{{ .Values.global.data_stream.schema_version }}",
+        "default_state": "initial",
+        "states": [
+            {
+                "name": "initial",
+                "actions": [],
+                "transitions": [
+                    {
+                        "state_name": "rollover",
+                        "conditions": {
+                            "min_index_age": "{{ .Values.global.data_stream.alerts.min_index_age }}"
+                        }
+                    },
+                    {
+                        "state_name": "rollover",
+                        "conditions": {
+                            "min_size": "{{ .Values.global.data_stream.alerts.min_size }}"
+                        }
+                    },
+                    {
+                        "state_name": "rollover",
+                        "conditions": {
+                            "min_doc_count": "{{ .Values.global.data_stream.alerts.min_doc_count }}"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "rollover",
+                "actions": [
+                    {
+                        "retry": {
+                            "count": 5,
+                            "backoff": "exponential",
+                            "delay": "1m"
+                        },
+                        "rollover": {
+                            "min_doc_count": 5,
+                            "min_index_age": "1d",
+                            "copy_alias": false
+                        }
+                    }
+                ],
+                "transitions": [
+                    {
+                        "state_name": "delete",
+                        "conditions": {
+                            "min_index_age": "{{ .Values.retention.ds }}"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "delete",
+                "actions": [
+                    {
+                        "retry": {
+                            "count": 3,
+                            "backoff": "exponential",
+                            "delay": "1m"
+                        },
+                        "delete": {}
+                    }
+                ],
+                "transitions": []
+            }
+        ],
+        "ism_template":
+            {
+                "index_patterns": [
+                    "alerts-datastream"
+                ],
+                "priority": 2
+            }
+    }
+}

--- a/system/opensearch-logs/templates/config/_ds-audit-ism.json.tpl
+++ b/system/opensearch-logs/templates/config/_ds-audit-ism.json.tpl
@@ -1,8 +1,8 @@
 {
     "policy": {
-        "policy_id": "otel-_DS_NAME_-ism",
-        "description": "Datastream (ds) ism policy for _DS_NAME_-ds",
-        "schema_version": _SCHEMAVERSION_,
+        "policy_id": "ds-audit-ism",
+        "description": "Datastream (ds) ism policy for audit-ds",
+        "schema_version": "{{ .Values.global.data_stream.schema_version }}",
         "default_state": "initial",
         "states": [
             {
@@ -12,19 +12,19 @@
                     {
                         "state_name": "rollover",
                         "conditions": {
-                            "min_index_age": "_MIN_INDEX_AGE_"
+                            "min_index_age": "{{ .Values.global.data_stream.audit.min_index_age }}"
                         }
                     },
                     {
                         "state_name": "rollover",
                         "conditions": {
-                            "min_size": "_MIN_SIZE_"
+                            "min_size": "{{ .Values.global.data_stream.audit.min_size }}"
                         }
                     },
                     {
                         "state_name": "rollover",
                         "conditions": {
-                            "min_doc_count": "_MIN_DOC_COUNT_"
+                            "min_doc_count": "{{ .Values.global.data_stream.audit.min_doc_count }}"
                         }
                     }
                 ]
@@ -72,9 +72,9 @@
         "ism_template":
             {
                 "index_patterns": [
-                    "_DS_NAME_-datastream"
+                    "audit-datastream"
                 ],
-                "priority": 1
+                "priority": 2
             }
     }
 }

--- a/system/opensearch-logs/templates/config/_ds-compute-ism.json.tpl
+++ b/system/opensearch-logs/templates/config/_ds-compute-ism.json.tpl
@@ -1,0 +1,80 @@
+{
+    "policy": {
+        "policy_id": "ds-compute-ism",
+        "description": "Datastream (ds) ism policy for compute-ds",
+        "schema_version": "{{ .Values.global.data_stream.schema_version }}",
+        "default_state": "initial",
+        "states": [
+            {
+                "name": "initial",
+                "actions": [],
+                "transitions": [
+                    {
+                        "state_name": "rollover",
+                        "conditions": {
+                            "min_index_age": "{{ .Values.global.data_stream.compute.min_index_age }}"
+                        }
+                    },
+                    {
+                        "state_name": "rollover",
+                        "conditions": {
+                            "min_size": "{{ .Values.global.data_stream.compute.min_size }}"
+                        }
+                    },
+                    {
+                        "state_name": "rollover",
+                        "conditions": {
+                            "min_doc_count": "{{ .Values.global.data_stream.compute.min_doc_count }}"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "rollover",
+                "actions": [
+                    {
+                        "retry": {
+                            "count": 5,
+                            "backoff": "exponential",
+                            "delay": "1m"
+                        },
+                        "rollover": {
+                            "min_doc_count": 5,
+                            "min_index_age": "1d",
+                            "copy_alias": false
+                        }
+                    }
+                ],
+                "transitions": [
+                    {
+                        "state_name": "delete",
+                        "conditions": {
+                            "min_index_age": "{{ .Values.retention.ds }}"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "delete",
+                "actions": [
+                    {
+                        "retry": {
+                            "count": 3,
+                            "backoff": "exponential",
+                            "delay": "1m"
+                        },
+                        "delete": {}
+                    }
+                ],
+                "transitions": []
+            }
+        ],
+        "ism_template":
+            {
+                "index_patterns": [
+                    "compute-datastream"
+                ],
+                "priority": 2
+            }
+    }
+}

--- a/system/opensearch-logs/templates/config/_ds-deployments-ism.json.tpl
+++ b/system/opensearch-logs/templates/config/_ds-deployments-ism.json.tpl
@@ -1,0 +1,80 @@
+{
+    "policy": {
+        "policy_id": "ds-deployments-ism",
+        "description": "Datastream (ds) ism policy for deployments-ds",
+        "schema_version": "{{ .Values.global.data_stream.schema_version }}",
+        "default_state": "initial",
+        "states": [
+            {
+                "name": "initial",
+                "actions": [],
+                "transitions": [
+                    {
+                        "state_name": "rollover",
+                        "conditions": {
+                            "min_index_age": "{{ .Values.global.data_stream.deployments.min_index_age }}"
+                        }
+                    },
+                    {
+                        "state_name": "rollover",
+                        "conditions": {
+                            "min_size": "{{ .Values.global.data_stream.deployments.min_size }}"
+                        }
+                    },
+                    {
+                        "state_name": "rollover",
+                        "conditions": {
+                            "min_doc_count": "{{ .Values.global.data_stream.deployments.min_doc_count }}"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "rollover",
+                "actions": [
+                    {
+                        "retry": {
+                            "count": 5,
+                            "backoff": "exponential",
+                            "delay": "1m"
+                        },
+                        "rollover": {
+                            "min_doc_count": 5,
+                            "min_index_age": "1d",
+                            "copy_alias": false
+                        }
+                    }
+                ],
+                "transitions": [
+                    {
+                        "state_name": "delete",
+                        "conditions": {
+                            "min_index_age": "{{ .Values.retention.ds }}"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "delete",
+                "actions": [
+                    {
+                        "retry": {
+                            "count": 3,
+                            "backoff": "exponential",
+                            "delay": "1m"
+                        },
+                        "delete": {}
+                    }
+                ],
+                "transitions": []
+            }
+        ],
+        "ism_template":
+            {
+                "index_patterns": [
+                    "deployments-datastream"
+                ],
+                "priority": 2
+            }
+    }
+}

--- a/system/opensearch-logs/templates/config/_ds-jump-ism.json.tpl
+++ b/system/opensearch-logs/templates/config/_ds-jump-ism.json.tpl
@@ -1,0 +1,80 @@
+{
+    "policy": {
+        "policy_id": "ds-jump-ism",
+        "description": "Datastream (ds) ism policy for jump-ds",
+        "schema_version": "{{ .Values.global.data_stream.schema_version }}",
+        "default_state": "initial",
+        "states": [
+            {
+                "name": "initial",
+                "actions": [],
+                "transitions": [
+                    {
+                        "state_name": "rollover",
+                        "conditions": {
+                            "min_index_age": "{{ .Values.global.data_stream.jump.min_index_age }}"
+                        }
+                    },
+                    {
+                        "state_name": "rollover",
+                        "conditions": {
+                            "min_size": "{{ .Values.global.data_stream.jump.min_size }}"
+                        }
+                    },
+                    {
+                        "state_name": "rollover",
+                        "conditions": {
+                            "min_doc_count": "{{ .Values.global.data_stream.jump.min_doc_count }}"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "rollover",
+                "actions": [
+                    {
+                        "retry": {
+                            "count": 5,
+                            "backoff": "exponential",
+                            "delay": "1m"
+                        },
+                        "rollover": {
+                            "min_doc_count": 5,
+                            "min_index_age": "1d",
+                            "copy_alias": false
+                        }
+                    }
+                ],
+                "transitions": [
+                    {
+                        "state_name": "delete",
+                        "conditions": {
+                            "min_index_age": "{{ .Values.retention.ds }}"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "delete",
+                "actions": [
+                    {
+                        "retry": {
+                            "count": 3,
+                            "backoff": "exponential",
+                            "delay": "1m"
+                        },
+                        "delete": {}
+                    }
+                ],
+                "transitions": []
+            }
+        ],
+        "ism_template":
+            {
+                "index_patterns": [
+                    "jump-datastream"
+                ],
+                "priority": 2
+            }
+    }
+}

--- a/system/opensearch-logs/templates/config/_ds-logs-ism.json.tpl
+++ b/system/opensearch-logs/templates/config/_ds-logs-ism.json.tpl
@@ -1,0 +1,80 @@
+{
+    "policy": {
+        "policy_id": "ds-logs-ism",
+        "description": "Datastream (ds) ism policy for logs-ds",
+        "schema_version": "{{ .Values.global.data_stream.schema_version }}",
+        "default_state": "initial",
+        "states": [
+            {
+                "name": "initial",
+                "actions": [],
+                "transitions": [
+                    {
+                        "state_name": "rollover",
+                        "conditions": {
+                            "min_index_age": "{{ .Values.global.data_stream.logs.min_index_age }}"
+                        }
+                    },
+                    {
+                        "state_name": "rollover",
+                        "conditions": {
+                            "min_size": "{{ .Values.global.data_stream.logs.min_size }}"
+                        }
+                    },
+                    {
+                        "state_name": "rollover",
+                        "conditions": {
+                            "min_doc_count": "{{ .Values.global.data_stream.logs.min_doc_count }}"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "rollover",
+                "actions": [
+                    {
+                        "retry": {
+                            "count": 5,
+                            "backoff": "exponential",
+                            "delay": "1m"
+                        },
+                        "rollover": {
+                            "min_doc_count": 5,
+                            "min_index_age": "1d",
+                            "copy_alias": false
+                        }
+                    }
+                ],
+                "transitions": [
+                    {
+                        "state_name": "delete",
+                        "conditions": {
+                            "min_index_age": "{{ .Values.retention.ds }}"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "delete",
+                "actions": [
+                    {
+                        "retry": {
+                            "count": 3,
+                            "backoff": "exponential",
+                            "delay": "1m"
+                        },
+                        "delete": {}
+                    }
+                ],
+                "transitions": []
+            }
+        ],
+        "ism_template":
+            {
+                "index_patterns": [
+                    "logs-datastream"
+                ],
+                "priority": 2
+            }
+    }
+}

--- a/system/opensearch-logs/templates/config/_ds-logs-swift-ism.json.tpl
+++ b/system/opensearch-logs/templates/config/_ds-logs-swift-ism.json.tpl
@@ -1,0 +1,80 @@
+{
+    "policy": {
+        "policy_id": "ds-logs-swift-ism",
+        "description": "Datastream (ds) ism policy for logs-swift-ds",
+        "schema_version": "{{ .Values.global.data_stream.schema_version }}",
+        "default_state": "initial",
+        "states": [
+            {
+                "name": "initial",
+                "actions": [],
+                "transitions": [
+                    {
+                        "state_name": "rollover",
+                        "conditions": {
+                            "min_index_age": "{{ .Values.global.data_stream.logs_swift.min_index_age }}"
+                        }
+                    },
+                    {
+                        "state_name": "rollover",
+                        "conditions": {
+                            "min_size": "{{ .Values.global.data_stream.logs_swift.min_size }}"
+                        }
+                    },
+                    {
+                        "state_name": "rollover",
+                        "conditions": {
+                            "min_doc_count": "{{ .Values.global.data_stream.logs_swift.min_doc_count }}"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "rollover",
+                "actions": [
+                    {
+                        "retry": {
+                            "count": 5,
+                            "backoff": "exponential",
+                            "delay": "1m"
+                        },
+                        "rollover": {
+                            "min_doc_count": 5,
+                            "min_index_age": "1d",
+                            "copy_alias": false
+                        }
+                    }
+                ],
+                "transitions": [
+                    {
+                        "state_name": "delete",
+                        "conditions": {
+                            "min_index_age": "{{ .Values.retention.ds }}"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "delete",
+                "actions": [
+                    {
+                        "retry": {
+                            "count": 3,
+                            "backoff": "exponential",
+                            "delay": "1m"
+                        },
+                        "delete": {}
+                    }
+                ],
+                "transitions": []
+            }
+        ],
+        "ism_template":
+            {
+                "index_patterns": [
+                    "logs-swift-datastream"
+                ],
+                "priority": 2
+            }
+    }
+}

--- a/system/opensearch-logs/templates/config/_ds-otel-ism.json.tpl
+++ b/system/opensearch-logs/templates/config/_ds-otel-ism.json.tpl
@@ -1,0 +1,80 @@
+{
+    "policy": {
+        "policy_id": "ds-otel-ism",
+        "description": "Datastream (ds) ism policy for otel-ds",
+        "schema_version": "{{ .Values.global.data_stream.schema_version }}",
+        "default_state": "initial",
+        "states": [
+            {
+                "name": "initial",
+                "actions": [],
+                "transitions": [
+                    {
+                        "state_name": "rollover",
+                        "conditions": {
+                            "min_index_age": "{{ .Values.global.data_stream.otel.min_index_age }}"
+                        }
+                    },
+                    {
+                        "state_name": "rollover",
+                        "conditions": {
+                            "min_size": "{{ .Values.global.data_stream.otel.min_size }}"
+                        }
+                    },
+                    {
+                        "state_name": "rollover",
+                        "conditions": {
+                            "min_doc_count": "{{ .Values.global.data_stream.otel.min_doc_count }}"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "rollover",
+                "actions": [
+                    {
+                        "retry": {
+                            "count": 5,
+                            "backoff": "exponential",
+                            "delay": "1m"
+                        },
+                        "rollover": {
+                            "min_doc_count": 5,
+                            "min_index_age": "1d",
+                            "copy_alias": false
+                        }
+                    }
+                ],
+                "transitions": [
+                    {
+                        "state_name": "delete",
+                        "conditions": {
+                            "min_index_age": "{{ .Values.retention.ds }}"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "delete",
+                "actions": [
+                    {
+                        "retry": {
+                            "count": 3,
+                            "backoff": "exponential",
+                            "delay": "1m"
+                        },
+                        "delete": {}
+                    }
+                ],
+                "transitions": []
+            }
+        ],
+        "ism_template":
+            {
+                "index_patterns": [
+                    "otel-datastream"
+                ],
+                "priority": 2
+            }
+    }
+}

--- a/system/opensearch-logs/templates/config/_ds-storage-ism.json.tpl
+++ b/system/opensearch-logs/templates/config/_ds-storage-ism.json.tpl
@@ -1,0 +1,80 @@
+{
+    "policy": {
+        "policy_id": "ds-storage-ism",
+        "description": "Datastream (ds) ism policy for storage-ds",
+        "schema_version": "{{ .Values.global.data_stream.schema_version }}",
+        "default_state": "initial",
+        "states": [
+            {
+                "name": "initial",
+                "actions": [],
+                "transitions": [
+                    {
+                        "state_name": "rollover",
+                        "conditions": {
+                            "min_index_age": "{{ .Values.global.data_stream.storage.min_index_age }}"
+                        }
+                    },
+                    {
+                        "state_name": "rollover",
+                        "conditions": {
+                            "min_size": "{{ .Values.global.data_stream.storage.min_size }}"
+                        }
+                    },
+                    {
+                        "state_name": "rollover",
+                        "conditions": {
+                            "min_doc_count": "{{ .Values.global.data_stream.storage.min_doc_count }}"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "rollover",
+                "actions": [
+                    {
+                        "retry": {
+                            "count": 5,
+                            "backoff": "exponential",
+                            "delay": "1m"
+                        },
+                        "rollover": {
+                            "min_doc_count": 5,
+                            "min_index_age": "1d",
+                            "copy_alias": false
+                        }
+                    }
+                ],
+                "transitions": [
+                    {
+                        "state_name": "delete",
+                        "conditions": {
+                            "min_index_age": "{{ .Values.retention.ds }}"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "delete",
+                "actions": [
+                    {
+                        "retry": {
+                            "count": 3,
+                            "backoff": "exponential",
+                            "delay": "1m"
+                        },
+                        "delete": {}
+                    }
+                ],
+                "transitions": []
+            }
+        ],
+        "ism_template":
+            {
+                "index_patterns": [
+                    "storage-datastream"
+                ],
+                "priority": 2
+            }
+    }
+}

--- a/system/opensearch-logs/templates/config/_install-ds-templates.sh.tpl
+++ b/system/opensearch-logs/templates/config/_install-ds-templates.sh.tpl
@@ -30,7 +30,6 @@ if [ "${DATA_STREAM_ENABLED}" = true ]; then
      export FILEPATH=/scripts
      export TMPPATH=/tmp
      export DS_TEMPLATE=ds.json
-     export DS_ISM_TEMPLATE=ds-ism.json
 
      echo "creating file FILE=${TMPPATH}/${e}"
      cp "/${FILEPATH}/${DS_TEMPLATE}" "${TMPPATH}/${e}-${DS_TEMPLATE}"
@@ -60,29 +59,10 @@ if [ "${DATA_STREAM_ENABLED}" = true ]; then
    # After a new ds ism template is installed, it is only active after a rollover of the datastream, This means after the default 24h period or a manuall rover, which can also be triggered by a job.
    echo "Datastream ism template creation"
    for e in ${DATA_STREAMS}; do
+     export DS_ISM_TEMPLATE=ds-${e}-ism.json
      # we have to copy the template from the scripts secrets to a directory, where we can change the template.
-     cp "/${FILEPATH}/${DS_ISM_TEMPLATE}" "${TMPPATH}/ds-${e}-${DS_ISM_TEMPLATE}"
-     echo "Applying ${TMPPATH}/ds-${e}-${DS_ISM_TEMPLATE} to ${CLUSTER_HOST}"
-
-     # common substitutions
-     sed -i "s/_DS_NAME_/${e}/g" ${TMPPATH}/ds-${e}-${DS_ISM_TEMPLATE}
-     sed -i "s/_SCHEMAVERSION_/${FILE_RETENTION_SCHEMA_VERSION}/g" ${TMPPATH}/ds-${e}-${DS_ISM_TEMPLATE}
-
-     # set condition values based on data stream
-     if [ "$e" = "logs-swift" ]; then
-       MIN_SIZE="120gb"
-       MIN_DOC_COUNT="200000000"
-       MIN_INDEX_AGE="14d"
-     else
-       MIN_SIZE="30gb"
-       MIN_DOC_COUNT="50000000"
-       MIN_INDEX_AGE="7d"
-     fi
-
-     # apply condition values
-     sed -i "s/_MIN_SIZE_/${MIN_SIZE}/g" "${TMPPATH}/ds-${e}-${DS_ISM_TEMPLATE}"
-     sed -i "s/_MIN_DOC_COUNT_/${MIN_DOC_COUNT}/g" "${TMPPATH}/ds-${e}-${DS_ISM_TEMPLATE}"
-     sed -i "s/_MIN_INDEX_AGE_/${MIN_INDEX_AGE}/g" "${TMPPATH}/ds-${e}-${DS_ISM_TEMPLATE}"
+     cp "/${FILEPATH}/${DS_ISM_TEMPLATE}" "${TMPPATH}/${DS_ISM_TEMPLATE}"
+     echo "Applying ${TMPPATH}/${DS_ISM_TEMPLATE} to ${CLUSTER_HOST}"
 
      # initial upload or test if ism policy exists
      export POLICY_RETURN_CODE=$( curl -s -o /dev/null -s -w "%{http_code}\n" --netrc-file "${NETRC_FILE}" -XGET "${CLUSTER_HOST}/_plugins/_ism/policies/ds-${e}-ism")
@@ -91,7 +71,7 @@ if [ "${DATA_STREAM_ENABLED}" = true ]; then
         # 1. Part: install of new ds ism policy
         echo -e "inital upload of datastream ism policy"
         echo -e "Upload ds policy, there is no policy \"ds-${e}-ism\" installed"
-        curl --netrc-file "${NETRC_FILE}" -XPUT "${CLUSTER_HOST}/_plugins/_ism/policies/ds-${e}-ism" -H 'Content-Type: application/json' -d @"${TMPPATH}/ds-${e}-${DS_ISM_TEMPLATE}"
+        curl --netrc-file "${NETRC_FILE}" -XPUT "${CLUSTER_HOST}/_plugins/_ism/policies/ds-${e}-ism" -H 'Content-Type: application/json' -d @"${TMPPATH}/${DS_ISM_TEMPLATE}"
 
         # 2. create datastream, if missing. It's done here, because the normal template has no versioning and can be overwritten during each run.
         #    data_stream example: otellogs-datastream
@@ -131,8 +111,8 @@ if [ "${DATA_STREAM_ENABLED}" = true ]; then
          #echo "Deleting old policy ds-${e}-ism"
          #curl --netrc-file "${NETRC_FILE}" -XDELETE "${CLUSTER_HOST}/_plugins/_ism/policies/ds-${e}-ism"
          echo -e "\nupload of new ism template with primary number: ${CLUSTER_RETENTION_RUN_PRIM_TERM} and existing sequence number: ${CLUSTER_RETENTION_SEQ_NUMBER}\n"
-         curl --netrc-file "${NETRC_FILE}" -XPUT "${CLUSTER_HOST}/_plugins/_ism/policies/ds-${e}-ism?if_seq_no=${CLUSTER_RETENTION_SEQ_NUMBER}&if_primary_term=${CLUSTER_RETENTION_RUN_PRIM_TERM}" -H 'Content-Type: application/json' -d @"${TMPPATH}/ds-${e}-${DS_ISM_TEMPLATE}"
-         cat "${TMPPATH}/ds-${e}-${DS_ISM_TEMPLATE}"
+         curl --netrc-file "${NETRC_FILE}" -XPUT "${CLUSTER_HOST}/_plugins/_ism/policies/ds-${e}-ism?if_seq_no=${CLUSTER_RETENTION_SEQ_NUMBER}&if_primary_term=${CLUSTER_RETENTION_RUN_PRIM_TERM}" -H 'Content-Type: application/json' -d @"${TMPPATH}/${DS_ISM_TEMPLATE}"
+         cat "${TMPPATH}/${DS_ISM_TEMPLATE}"
          export NEW_CLUSTER_RETENTION_SCHEMA_VERSION=$(curl -s --netrc-file "${NETRC_FILE}" -XGET "${CLUSTER_HOST}/_plugins/_ism/policies/ds-${e}-ism"|jq .policy.schema_version?)
          echo -e "\nNew schema_version is: ${NEW_CLUSTER_RETENTION_SCHEMA_VERSION}\n, increase this value by 1 to install new ism policy for ds-${e}-ism\n"
        else

--- a/system/opensearch-logs/templates/security-config-secrets.yaml
+++ b/system/opensearch-logs/templates/security-config-secrets.yaml
@@ -24,7 +24,15 @@ data:
   index-ism.json: {{ include (print .Template.BasePath  "/config/_index-ism.json.tpl") . | b64enc }}
   {{- if .Values.global.data_stream.enabled }}
   install-ds-templates.sh: {{ include (print .Template.BasePath  "/config/_install-ds-templates.sh.tpl") . | b64enc }}
-  ds-ism.json: {{ include (print .Template.BasePath  "/config/_ds-ism.json.tpl") . | b64enc }}
+  ds-alerts-ism.json: {{ include (print .Template.BasePath  "/config/_ds-alerts-ism.json.tpl") . | b64enc }}
+  ds-audit-ism.json: {{ include (print .Template.BasePath  "/config/_ds-audit-ism.json.tpl") . | b64enc }}
+  ds-compute-ism.json: {{ include (print .Template.BasePath  "/config/_ds-compute-ism.json.tpl") . | b64enc }}
+  ds-deployments-ism.json: {{ include (print .Template.BasePath  "/config/_ds-deployments-ism.json.tpl") . | b64enc }}
+  ds-jump-ism.json: {{ include (print .Template.BasePath  "/config/_ds-jump-ism.json.tpl") . | b64enc }}
+  ds-logs-swift-ism.json: {{ include (print .Template.BasePath  "/config/_ds-logs-swift-ism.json.tpl") . | b64enc }}
+  ds-logs-ism.json: {{ include (print .Template.BasePath  "/config/_ds-logs-ism.json.tpl") . | b64enc }}
+  ds-otel-ism.json: {{ include (print .Template.BasePath  "/config/_ds-otel-ism.json.tpl") . | b64enc }}
+  ds-storage-ism.json: {{ include (print .Template.BasePath  "/config/_ds-storage-ism.json.tpl") . | b64enc }}
   ds.json: {{ include (print .Template.BasePath  "/config/_ds.json.tpl") . | b64enc }}
   {{- end }}
 {{- end }}

--- a/system/opensearch-logs/values.yaml
+++ b/system/opensearch-logs/values.yaml
@@ -10,6 +10,42 @@ global:
     prometheus: infra-frontend
   data_stream:
     enabled: false
+    alerts:
+      min_index_age: "7d"
+      min_size: "30gb"
+      min_doc_count: 50000000
+    deployments:
+      min_index_age: "7d"
+      min_size: "30gb"
+      min_doc_count: 50000000
+    storage:
+      min_index_age: "7d"
+      min_size: "30gb"
+      min_doc_count: 50000000
+    compute:
+      min_index_age: "7d"
+      min_size: "30gb"
+      min_doc_count: 50000000
+    otel:
+      min_index_age: "7d"
+      min_size: "30gb"
+      min_doc_count: 50000000
+    audit:
+      min_index_age: "7d"
+      min_size: "30gb"
+      min_doc_count: 50000000
+    logs:
+      min_index_age: "7d"
+      min_size: "30gb"
+      min_doc_count: 50000000
+    logs_swift:
+      min_index_age: "14d"
+      min_size: "120gb"
+      min_doc_count: 200000000
+    jump:
+      min_index_age: "7d"
+      min_size: "30gb"
+      min_doc_count: 50000000
   index:
     ism_indexes: "logstash"
     schema_version: "1"


### PR DESCRIPTION
Override values for `min_index_age`, `min_size` and `min_doc_count` in secrets values to allow specific values per region. 