### PR TITLE
[designate][rabbitmq] increase maximum rabbitmq message size to 256M

### DIFF
--- a/openstack/designate/Chart.lock
+++ b/openstack/designate/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 0.4.2
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.16.1
+  version: 0.17.1
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.21.0
@@ -29,5 +29,5 @@ dependencies:
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.1.3
-digest: sha256:4006b600aed4d4737cfbb24ea5a2fab245e45182352f37cf039b504fa349328a
-generated: "2025-03-18T15:15:46.783498+01:00"
+digest: sha256:209500db0e2ec6c4bb20d42a74f7824bac6e4b49914d42946143365fda134466
+generated: "2025-03-19T16:07:34.414259+02:00"

--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes to deploy Openstack Designate  (DNSaaS)
 name: designate
-version: 0.4.13
+version: 0.4.14
 appVersion: "xena"
 dependencies:
   - condition: percona_cluster.enabled
@@ -28,7 +28,7 @@ dependencies:
   - name: rabbitmq
     condition: rabbitmq.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.16.1
+    version: 0.17.1
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.21.0


### PR DESCRIPTION
* increase maximum rabbitmq message size from 16M to 256M
  * in rabbitmq 4.0 this default value has been changed from 256M to 16M

* bump rabbitmq chart to 0.17.1
  * updates rabbitmq to 4.0.7
  * add user-credential-updater sidecar