### PR TITLE
[rabbitmq] set default `max_message_size` option to 256M

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+## 0.17.1 - 2025/03/19
+
+- Set default `max_message_size` option to pre 4.0 default value of 256M
+  - This fixes a possible problem introduced in chart version 0.14.0 by a silent default change
+- Chart version bumped
+
 ## 0.17.0 - 2025/03/19
 
 - Add [user-credential-updater](https://github.com/sapcc/rabbitmq-user-credential-updater) sidecar container
@@ -13,7 +19,7 @@ This file is used to list changes made in each version of the common chart rabbi
 - RabbitMQ [4.0.7 Release Notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.0.7)
   * Classic queue message store did not remove segment files with large messages (over 4 MB) in some cases
   * Reduced memory usage and GC pressure for workloads where large (4 MB or greater) messages were published to classic queues
-* chart version bumped
+- chart version bumped
 
 ## 0.16.0 - 2025/03/15
 

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: rabbitmq
-version: 0.17.0
+version: 0.17.1
 appVersion: 4.0.7
 description: A Helm chart for RabbitMQ
 sources:

--- a/common/rabbitmq/values.yaml
+++ b/common/rabbitmq/values.yaml
@@ -122,7 +122,8 @@ linkerd:
   enabled: true
 
 # RabbitMQ custom configuration to be added under /etc/rabbitmq/conf.d/20-custom.conf
-customConfig: {}
+customConfig:
+  max_message_size: '268435456'  # 256M; default value since 4.0 was 16M
   # to set a custom limit please use the following format: 50MB or 1GB
   # if not set default value of 50MB will be used
   # disk_free_limit.absolute: 500MB


### PR DESCRIPTION
- Set default `max_message_size` option to pre 4.0 default value of 256M
  - This fixes a possible problem introduced in chart version 0.14.0 by a silent default value change

- Chart version bumped