### PR TITLE
feat(opensearch): upgrade to latest version

### DIFF
--- a/system/opensearch-logs/Chart.lock
+++ b/system/opensearch-logs/Chart.lock
@@ -1,19 +1,19 @@
 dependencies:
 - name: opensearch
   repository: https://opensearch-project.github.io/helm-charts
-  version: 2.30.0
+  version: 2.32.0
 - name: opensearch
   repository: https://opensearch-project.github.io/helm-charts
-  version: 2.30.0
+  version: 2.32.0
 - name: opensearch
   repository: https://opensearch-project.github.io/helm-charts
-  version: 2.30.0
+  version: 2.32.0
 - name: opensearch
   repository: https://opensearch-project.github.io/helm-charts
-  version: 2.30.0
+  version: 2.32.0
 - name: opensearch-dashboards
   repository: https://opensearch-project.github.io/helm-charts
-  version: 2.26.0
+  version: 2.27.1
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
@@ -26,5 +26,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:acf4ade9b58c086b32e45cf638c69100075e74b3b292c60cd3ecb2b75ec3e5b2
-generated: "2025-03-19T11:41:54.358875+01:00"
+digest: sha256:51a796492c2a41a3b9992a41af5ab37c1baa7c2cc9f9f16a0ef14ab5b428f83e
+generated: "2025-03-19T15:07:53.648819+01:00"

--- a/system/opensearch-logs/Chart.yaml
+++ b/system/opensearch-logs/Chart.yaml
@@ -8,27 +8,27 @@ dependencies:
     alias: opensearch_master
     condition: opensearch_master.enabled
     repository: https://opensearch-project.github.io/helm-charts
-    version: 2.30.0
+    version: 2.32.0
   - name: opensearch
     alias: opensearch_client
     condition: opensearch_client.enabled
     repository: https://opensearch-project.github.io/helm-charts
-    version: 2.30.0
+    version: 2.32.0
   - name: opensearch
     alias: opensearch_data
     condition: opensearch_data.enabled
     repository: https://opensearch-project.github.io/helm-charts
-    version: 2.30.0
+    version: 2.32.0
   - name: opensearch
     alias: opensearch_ml
     condition: opensearch_ml.enabled
     repository: https://opensearch-project.github.io/helm-charts
-    version: 2.30.0
+    version: 2.32.0
   - name: opensearch-dashboards
     alias: opensearch_dashboards
     condition: opensearch_dashboards.enabled
     repository: https://opensearch-project.github.io/helm-charts
-    version: 2.26.0
+    version: 2.27.1
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.2.0

--- a/system/opensearch-logs/values.yaml
+++ b/system/opensearch-logs/values.yaml
@@ -45,7 +45,7 @@ opensearch_master:
   nodeGroup: "master"
   masterService: "opensearch-logs-master"
   image:
-    tag: 2.18.0
+    tag: 2.19.1
   roles:
     - master
   replicas: 3
@@ -72,12 +72,12 @@ opensearch_master:
   plugins:
     enabled: true
     installList:
-      - https://github.com/Virtimo/prometheus-exporter-plugin-for-opensearch/releases/download/v2.18.0/prometheus-exporter-2.18.0.0.zip
+      - https://github.com/Virtimo/prometheus-exporter-plugin-for-opensearch/releases/download/v2.19.1/prometheus-exporter-2.19.1.0.zip
 
 opensearch_client:
   enabled: false
   image:
-    tag: 2.18.0
+    tag: 2.19.1
   replicas: 3
   nameOverride: "opensearch-logs-client"
   fullnameOverride: "opensearch-logs-client"
@@ -118,12 +118,12 @@ opensearch_client:
   plugins:
     enabled: true
     installList:
-      - https://github.com/Virtimo/prometheus-exporter-plugin-for-opensearch/releases/download/v2.18.0/prometheus-exporter-2.18.0.0.zip
+      - https://github.com/Virtimo/prometheus-exporter-plugin-for-opensearch/releases/download/v2.19.1/prometheus-exporter-2.19.1.0.zip
 
 opensearch_data:
   enabled: false
   image:
-    tag: 2.18.0
+    tag: 2.19.1
   nameOverride: "opensearch-logs-data"
   fullnameOverride: "opensearch-logs-data"
   nodeGroup: "data"
@@ -147,7 +147,7 @@ opensearch_data:
   plugins:
     enabled: true
     installList:
-      - https://github.com/Virtimo/prometheus-exporter-plugin-for-opensearch/releases/download/v2.18.0/prometheus-exporter-2.18.0.0.zip
+      - https://github.com/Virtimo/prometheus-exporter-plugin-for-opensearch/releases/download/v2.19.1/prometheus-exporter-2.19.1.0.zip
   securityConfig:
     enabled: false
     path: "/usr/share/opensearch/config/opensearch-security"
@@ -160,7 +160,7 @@ opensearch_data:
 opensearch_ml:
   enabled: false
   image:
-    tag: 2.18.0
+    tag: 2.19.1
   replicas: 2
   nameOverride: "opensearch-logs-ml"
   fullnameOverride: "opensearch-logs-ml"
@@ -201,12 +201,12 @@ opensearch_ml:
   plugins:
     enabled: true
     installList:
-      - https://github.com/Virtimo/prometheus-exporter-plugin-for-opensearch/releases/download/v2.18.0/prometheus-exporter-2.18.0.0.zip
+      - https://github.com/Virtimo/prometheus-exporter-plugin-for-opensearch/releases/download/v2.19.1/prometheus-exporter-2.19.1.0.zip
 
 opensearch_dashboards:
   enabled: false
   image:
-    tag: "2.18.0"
+    tag: "2.19.1"
   fullnameOverride: opensearch-logs-dashboards
   nameOverride: opensearch-logs-dashboards
   serviceAccount:


### PR DESCRIPTION
Upgrade opensearch to the latest versions `2.19.1`, dashboard to `2.27.1` and helm chart to `2.32.0`.