### PR TITLE
[designate] move osprofiler config section to secrets

### DIFF
--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes to deploy Openstack Designate  (DNSaaS)
 name: designate
-version: 0.4.14
+version: 0.4.15
 appVersion: "xena"
 dependencies:
   - condition: percona_cluster.enabled

--- a/openstack/designate/templates/etc/_designate.conf.tpl
+++ b/openstack/designate/templates/etc/_designate.conf.tpl
@@ -553,6 +553,3 @@ disable_by_file_path = /etc/designate/healthcheck_disable
 #   name = '%s.%s' % (func.__module__, func.__name__)
 
 # [hook_point:designate.api.v2.controllers.zones.get_one]
-
-# Tracing
-{{- include "osprofiler" . }}

--- a/openstack/designate/templates/etc/_secrets.conf.tpl
+++ b/openstack/designate/templates/etc/_secrets.conf.tpl
@@ -11,3 +11,6 @@ password = {{ .Values.global.designate_service_password | include "resolve_secre
 {{ include "designate.db_url" . }}
 
 {{ include "ini_sections.audit_middleware_notifications" . }}
+
+# Tracing
+{{- include "osprofiler" . }}


### PR DESCRIPTION
[osprofiler] configuration contains hmac_keys option, that should be resolved by secrets-injector and moved to secret resource

another change required to switch to secrets-injector is tempest_accounts.yaml, tempest_deployment_config.json and tempest_extra_options in `designate-etc`, they might be changed in future pull requests