### PR TITLE
[kubernikus] remove mail sending for quota alert

### DIFF
--- a/system/kubernikus-monitoring/Chart.yaml
+++ b/system/kubernikus-monitoring/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart containing Prometheus alert and aggregation rules for Kubernikus.
 name: kubernikus-monitoring
-version: 1.2.0
+version: 1.2.1

--- a/system/kubernikus-monitoring/alerts/kluster.alerts
+++ b/system/kubernikus-monitoring/alerts/kluster.alerts
@@ -55,7 +55,7 @@ groups:
       summary: "{{ $labels.kubernetes_name }} is unavailable"
 
   - alert: KubernikusKlusterLowOnObjectStoreQuota
-    expr: label_replace(max(kubernikus_kluster_info{phase="Running", backup="swift"}) by (kluster_name, creator, project_id), "shortname", "$1", "kluster_name", "(.*)-[a-f0-9]{32}") * on(project_id) group_left(project, domain) (min(limes_free_swift_quota_gauge) by (project_id, project, domain) < 90 * 1024 * 1024) * on(project_id) group_left(business_criticality,primary_contact_email,operator_contact_email,primary_contact_id,operator_contact_id) (project_masterdata) or on (project_id) label_replace(max(kubernikus_kluster_info{phase="Running", backup="swift"}) by (kluster_name, creator, project_id), "shortname", "$1", "kluster_name", "(.*)-[a-f0-9]{32}") * on(project_id) group_left(project, domain) (min(limes_free_swift_quota_gauge) by (project_id, project, domain) < 90 * 1024 * 1024)
+    expr: label_replace(max(kubernikus_kluster_info{phase="Running", backup="swift"}) by (kluster_name, creator, project_id), "shortname", "$1", "kluster_name", "(.*)-[a-f0-9]{32}") * on(project_id) group_left(project, domain) (min(limes_free_swift_quota_gauge) by (project_id, project, domain) < 90 * 1024 * 1024)
     for: 10m
     labels:
       tier: kks
@@ -65,27 +65,9 @@ groups:
       meta: "Kluster {{ $labels.kluster_name }} is low on object-store quota"
       playbook: docs/support/playbook/kubernikus/low_object_store_quota
       kluster_name: "{{ $labels.kluster_name }}"
-      primary_email_recipients: "{{ $labels.primary_contact_email }},{{ $labels.operator_contact_email}}"
-      bcc_email_recipients: "DL_645B919A5407AA8EFFC0269D@global.corp.sap"
-      visibility: "hidden"
     annotations:
-      storage_left: "{{ humanize1024 $value }}B"
-      dashboard_url: "https://dashboard.{{ $externalLabels.region }}.cloud.sap/_/{{ $labels.project_id }}/object-storage/"
       summary: "Kluster {{ $labels.kluster_name }} is low on object-store quota"
-      description: "Kluster {{ $labels.kluster_name }} in `{{ $labels.domain }}/{{ $labels.project }}` has *{{ humanize1024 $value }}B* of object-store quota left. If the quota is exhausted the etcd backup of the cluster will fail. This can also cause an outage. The project admin needs to raise quota or free up space. <https://dashboard.{{ $externalLabels.region }}.cloud.sap/_/{{ $labels.project_id }}/masterdata-cockpit/project|Masterdata>, cluster creator:  <https://people.wdf.sap.corp/profiles/{{$labels.creator}}|{{$labels.creator}}>"
-      mail_subject: "ACTION REQUIRED: Object store capacity low in project {{ $labels.domain }}/{{ $labels.project }} in {{ $externalLabels.region }}" 
-      mail_body: |
-        Dear Converged Cloud customer,
-        the project {{ $labels.domain }}/{{ $labels.project }} has {{ humanize1024 $value }}B of object-store capacity left.
-
-        https://dashboard.{{ $externalLabels.region }}.cloud.sap/_/{{ $labels.project_id }}/object-storage/
-
-        The kubernetes cluster {{ $labels.shortname }} relies on the object store to continously backup its etcd data.
-        If the quota is exhausted the backup will fail and recovering the cluster from data loss or corruption will be impossible.
-        For the correct functionining of the provisioned cluster please make sure you always have >200MB of object-store capacity available.
-
-        Kind regards,
-        Converged Cloud support team
+      description: "Kluster {{ $labels.kluster_name }} in `{{ $labels.domain }}/{{ $labels.project }}` has *{{ humanize1024 $value }}B* of object-store quota left. If the quota is exhausted the etcd backup of the cluster will fail. This can also cause an outage. The project admin needs to free up space or a cloud admin must apply a quota override. <https://dashboard.{{ $externalLabels.region }}.cloud.sap/_/{{ $labels.project_id }}/masterdata-cockpit/project|Masterdata>, cluster creator: <https://people.wdf.sap.corp/profiles/{{$labels.creator}}|{{$labels.creator}}>"
 
   - alert: KubernikusSeedReconciliationFailed
     expr: increase(kubernikus_seed_reconciliation_failures_total[35m])>6


### PR DESCRIPTION
As discussed with @majewsky it does not make sense to alert customers, because they cannot raise quota themselves anymore. I will update the playbook to link the support staff how to create a quota override.