### PR TITLE
thanos: allow more store naming patterns

### DIFF
--- a/common/thanos/Chart.yaml
+++ b/common/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: Deploy Thanos via operator
 type: application
-version: 1.1.3
+version: 1.1.4
 appVersion: v0.37.2
 maintainers:
   - name: Tommy Sauer (viennaa)

--- a/common/thanos/templates/_thanos_helpers.tpl
+++ b/common/thanos/templates/_thanos_helpers.tpl
@@ -190,6 +190,10 @@ cluster.local
 {{- $storeItem := printf "thanos-%s-grpc.%s.%s" $cluster $root.Values.global.region $root.Values.global.tld -}}
 {{- $regionalList = append $regionalList $storeItem -}}
 {{- end }}
+{{- range $store := $root.Values.query.stores -}}
+{{- $storeItem := printf "%s.%s.%s" $store $root.Values.global.region $root.Values.global.tld -}}
+{{- $regionalList = append $regionalList $storeItem -}}
+{{- end -}}
 {{- range $regionalList | sortAlpha }}
   - {{ . }}:443
 {{- end }}


### PR DESCRIPTION
This pattern is inflexible: `thanos-%s-grpc.%s.%s`