### PR TITLE
[kmip][shared] bump kmip dependencies

### DIFF
--- a/openstack/kmip/Chart.lock
+++ b/openstack/kmip/Chart.lock
@@ -7,15 +7,15 @@ dependencies:
   version: 1.1.0
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.23.0
+  version: 0.24.1
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.15.3
+  version: 0.18.2
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.3.1
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.4.2
-digest: sha256:650548989cca89fd746f8442dd2b8e547226670f1dd39d4a50f434cec24cb4b2
-generated: "2025-03-20T13:37:49.009693+02:00"
+digest: sha256:447dff1641b5c95213fb636743e5a5cfe4826966db13b562fdf2806a6155974b
+generated: "2025-03-24T14:18:33.3576+02:00"

--- a/openstack/kmip/Chart.yaml
+++ b/openstack/kmip/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Chart Version
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -38,7 +38,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.15.3
+    version: 0.18.2
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db


### PR DESCRIPTION
* bumps mariadb chart to 0.18.2

adds user-credential-updater sidecar and allows to update root password