### PR TITLE
[barbican][shared] bump mariadb chart dependency and remove rabbitmq

### DIFF
--- a/openstack/barbican/Chart.lock
+++ b/openstack/barbican/Chart.lock
@@ -1,22 +1,19 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.15.3
+  version: 0.18.2
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.3.1
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.6.3
+  version: 0.6.9
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.4.2
-- name: rabbitmq
-  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.13.0
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.23.0
+  version: 0.25.0
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.6.2
@@ -26,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.0
-digest: sha256:f1aea0a26bc31d39a390a8b9eb67c7869fc8a612ce01a9359837e5b1e961ae94
-generated: "2025-03-20T12:53:35.200317+02:00"
+digest: sha256:db10637de30daf191aad7ac3a3864cbe0e78498c39372ecc89fc347a26024bc3
+generated: "2025-03-27T13:30:23.853125+02:00"

--- a/openstack/barbican/Chart.yaml
+++ b/openstack/barbican/Chart.yaml
@@ -4,12 +4,12 @@ appVersion: dalmatian
 description: A Helm chart for Openstack Barbican
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Barbican/OpenStack_Project_Barbican_vertical.png
 name: barbican
-version: 0.6.1
+version: 0.7.0
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.15.3
+    version: 0.18.2
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db
@@ -17,17 +17,14 @@ dependencies:
     version: 0.3.1
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.6.3
+    version: 0.6.9
   - condition: mariadb.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.4.2
-  - name: rabbitmq
-    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.13.0
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.23.0
+    version: 0.25.0
   - name: redis
     alias: sapcc_rate_limit
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/barbican/ci/test-values.yaml
+++ b/openstack/barbican/ci/test-values.yaml
@@ -47,24 +47,10 @@ pxc_db:
         aws_access_key_id: topSecret!
         aws_secret_access_key: topSecret!
 
-rabbitmq_notifications:
-  users:
-    default:
-      password: topSecret
-
 api:
   replicas: 2
   resources:
     enabled: false
-
-rabbitmq:
-  users:
-    admin:
-      password: adminadmin
-    default:
-      password: defaultdefault
-  metrics:
-    password: metricsmetrics
 
 audit:
   central_service:

--- a/openstack/barbican/templates/_helpers.tpl
+++ b/openstack/barbican/templates/_helpers.tpl
@@ -19,10 +19,6 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
   {{- include "utils.db_host" . }}
 {{- end }}
 
-{{- define "barbican.rabbitmq_service" }}
-  {{- .Release.Name }}-rabbitmq
-{{- end }}
-
 {{- define "barbican.service_dependencies" }}
-  {{- template "barbican.db_service" . }},{{ template "barbican.rabbitmq_service" . }}
+  {{- template "barbican.db_service" . }}
 {{- end }}

--- a/openstack/barbican/templates/etc/_secrets.conf.tpl
+++ b/openstack/barbican/templates/etc/_secrets.conf.tpl
@@ -1,7 +1,5 @@
 [DEFAULT]
 
-{{ include "ini_sections.default_transport_url" . }}
-
 [database]
 connection = {{ include "utils.db_url" . }}
 

--- a/openstack/barbican/values.yaml
+++ b/openstack/barbican/values.yaml
@@ -241,23 +241,6 @@ mysql_metrics:
       values:
       - "expiration_date"
 
-rabbitmq:
-  name: barbican
-  persistence:
-    enabled: false
-  alerts:
-    support_group: identity
-  metrics:
-    enabled: true
-    sidecar:
-      enabled: false
-memcached:
-  alerts:
-    support_group: identity
-  enabled: true
-  metrics:
-    enabled: true
-
 logging:
   formatters:
     context:


### PR DESCRIPTION
* bump mariadb chart dependency

adds support for root password update and user-credential-updater sidecar

* remove rabbitmq dependency

it seems to be not being used
