### PR TITLE
[designate][shared] bump service dependency

### DIFF
--- a/openstack/designate/Chart.lock
+++ b/openstack/designate/Chart.lock
@@ -4,13 +4,13 @@ dependencies:
   version: 1.1.10
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.2.13
+  version: 0.3.1
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.15.3
+  version: 0.18.2
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.6.3
+  version: 0.6.8
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.4.2
@@ -19,7 +19,7 @@ dependencies:
   version: 0.17.1
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.21.0
+  version: 0.24.1
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
@@ -29,5 +29,5 @@ dependencies:
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.1.3
-digest: sha256:5389a37bda70988485011cd2543ed3e16b97c37e73451f495838705e99cb81ce
-generated: "2025-03-24T11:53:33.983235+01:00"
+digest: sha256:51c27cf88853e70f4777935bfda2dc258beb4141b48c14ca9b978849d66314b9
+generated: "2025-03-24T14:05:20.845379+02:00"

--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes to deploy Openstack Designate  (DNSaaS)
 name: designate
-version: 0.4.15
+version: 0.4.16
 appVersion: "xena"
 dependencies:
   - condition: percona_cluster.enabled
@@ -13,14 +13,14 @@ dependencies:
     name: pxc-db
     alias: pxc_db
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.2.13
+    version: 0.3.1
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.15.3
+    version: 0.18.2
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.6.3
+    version: 0.6.8
   - condition: mysql_metrics.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
@@ -31,7 +31,7 @@ dependencies:
     version: 0.17.1
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.21.0
+    version: 0.24.1
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0


### PR DESCRIPTION
* bump pxc-db chart to 0.3.1

moves user creation to operator configuration via crd

* bump mariadb chart to 0.18.0

allows to update root password and add user-credential-updater sidecar

* bump utils to 0.23.0

* bump memcached to 0.6.6

updates memcached and memcached-exporter