### PR TITLE
[manila][shared] update mariadb and rabbitmq chart dependencies

### DIFF
--- a/openstack/manila/Chart.lock
+++ b/openstack/manila/Chart.lock
@@ -4,13 +4,13 @@ dependencies:
   version: 1.1.0
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.15.5
+  version: 0.18.2
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.3.1
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.6.6
+  version: 0.6.8
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.4.2
@@ -19,12 +19,12 @@ dependencies:
   version: 1.0.0
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.14.1
+  version: 0.17.1
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.6.2
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.23.0
-digest: sha256:225ed2f681f7c8463b5a35315dff72beadbc5a12c424de1890b4674451263e48
-generated: "2025-03-20T12:50:20.071148+02:00"
+  version: 0.24.1
+digest: sha256:f802d4c840ce4a9eec04eacf3ee82a43d04580a005b6164fd2434431956960aa
+generated: "2025-03-24T14:11:31.305189+02:00"

--- a/openstack/manila/Chart.yaml
+++ b/openstack/manila/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 name: manila
 sources:
   - https://github.com/sapcc/manila
-version: 0.5.1
+version: 0.5.2
 dependencies:
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
@@ -18,7 +18,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.15.3
+    version: ~0.18.2
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db
@@ -27,7 +27,7 @@ dependencies:
   - condition: memcached.enabled
     name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.6.3
+    version: ~0.6.8
   - condition: mariadb.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
@@ -37,7 +37,7 @@ dependencies:
     version: ~1.0.0
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.14.0
+    version: ~0.17.1
   - name: redis
     alias: api-ratelimit-redis
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
@@ -45,4 +45,4 @@ dependencies:
     condition: api_rate_limit.enabled
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.23.0
+    version: 0.24.1


### PR DESCRIPTION
* adds user-credential-updater sidecars to both services
* allows to update root user password in mariadb
* allows to use secrets-injector for backup-v2 secrets
* bumps mariadb and rabbitmq to latest bugfix releases