### PR TITLE
[unbound] the sidecar capability logic is a bit more complex

### DIFF
--- a/system/unbound/templates/deployment.yaml
+++ b/system/unbound/templates/deployment.yaml
@@ -40,6 +40,17 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       nodeSelector:
         topology.kubernetes.io/zone: {{ .Values.global.region}}{{ .Values.unbound.failure_domain_zone}}
+{{- $sidecars := true }}
+{{- if eq (int .Capabilities.KubeVersion.Major) 0 }}
+{{- $sidecars = false }}
+{{- end }}
+{{- if eq (int .Capabilities.KubeVersion.Major) 1 }}
+{{- $sidecars = and $sidecars (ge (int .Capabilities.KubeVersion.Minor) 29) }}
+{{- end }}
+{{- if ge (int .Capabilities.KubeVersion.Major) 2 }}
+{{- $sidecars = and $sidecars true }}
+{{- end }}
+{{- $sidecars = and $sidecars (dig "sidecars" true .Values.unbound) }}
       containers:
       - name: unbound
         image: {{ required ".Values.global.registryAlternateRegion is missing" .Values.global.registryAlternateRegion }}/{{.Values.unbound.unbound.image}}:{{ .Values.unbound.unbound.image_tag}}
@@ -69,13 +80,13 @@ spec:
           initialDelaySeconds: 5
           timeoutSeconds: 3
           periodSeconds: 10
-{{- if ge (int .Capabilities.KubeVersion.Minor) 29 }}
+{{- if $sidecars }}
       initContainers:
 {{- end }}
       - name: metric
         image: {{ required ".Values.global.registryAlternateRegion is missing" .Values.global.registryAlternateRegion }}/{{.Values.unbound.unbound_exporter.image}}:{{ .Values.unbound.unbound_exporter.image_tag}}
         imagePullPolicy: {{ .Values.unbound.image_pullPolicy }}
-{{- if ge (int .Capabilities.KubeVersion.Minor) 29 }}
+{{- if $sidecars }}
         restartPolicy: Always
 {{- end }}
         resources:
@@ -91,7 +102,7 @@ spec:
       - name: dnstap
         image: {{ required ".Values.global.registryAlternateRegion is missing" .Values.global.registryAlternateRegion }}/{{.Values.unbound.dnstap.image}}:{{ .Values.unbound.dnstap.image_tag}}
         imagePullPolicy: {{ .Values.unbound.image_pullPolicy }}
-{{- if ge (int .Capabilities.KubeVersion.Minor) 29 }}
+{{- if $sidecars }}
         restartPolicy: Always
 {{- end }}
         resources:
@@ -137,7 +148,7 @@ spec:
       - name: bind-rpz-proxy
         image: {{ required ".Values.global.registryAlternateRegion is missing" .Values.global.registryAlternateRegion }}/{{.Values.unbound.bind_rpz_proxy.image}}:{{ .Values.unbound.bind_rpz_proxy.image_tag}}
         imagePullPolicy: {{ .Values.unbound.image_pullPolicy }}
-{{- if ge (int .Capabilities.KubeVersion.Minor) 29 }}
+{{- if $sidecars }}
         restartPolicy: Always
 {{- end }}
         resources:


### PR DESCRIPTION
Also, implemented the ability to disable the sidecars as such and run the containers along the main one.

This is all in the context of
https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/