### PR TITLE
[mariadb] add missing license headers and remove unused option

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.18.2 - 2025/03/21
+* add missing headers to the mariadb-credential-updater.py
+* remove unused `credentialUpdater.enabled` option from values - this sidecar is non-optional
+
 ## v0.18.1 - 2025/03/21
 * make backup storage to AWS and Swift flexibel via enablement in `backup-v2` configuration
 

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,6 +2,6 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.18.1
+version: 0.18.2
 # scripts/docker-entyrpoint.sh should be updated when appVersion is updated
 appVersion: 10.5.28

--- a/common/mariadb/scripts/mariadb-credential-updater.py
+++ b/common/mariadb/scripts/mariadb-credential-updater.py
@@ -1,3 +1,20 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright 2025 SAP SE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import time
 import subprocess

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -171,7 +171,6 @@ readiness:
   useSidecar: false
 
 credentialUpdater:
-  enabled: true
   image: 'shared-app-images/alpine-mariadb'
   imageTag: 'python3.13-alpine3.21-20250305175417'
   checkInterval: '10'


### PR DESCRIPTION
* add missing headers to the mariadb-credential-updater.py
* remove unused `credentialUpdater.enabled` option from values, this sidecar is non-optional