### PR TITLE
[cinder] seed generic domains using global.domains_seeds

### DIFF
--- a/openstack/cinder/ci/test-values.yaml
+++ b/openstack/cinder/ci/test-values.yaml
@@ -7,7 +7,8 @@ global:
   dockerHubMirrorAlternateRegion: myRegistry/dockerhubalternate
   tld: regionOne.cloud
   domain_seeds:
-    skip_hcm_domain: false
+    customer_domains: [bar, foo, baz]
+    customer_domains_without_support_projects: [baz]
     
   cinder_service_password: topSecret
   availability_zones:

--- a/openstack/cinder/templates/seed.yaml
+++ b/openstack/cinder/templates/seed.yaml
@@ -1,26 +1,18 @@
+{{- $cdomains := .Values.global.domain_seeds.customer_domains | required "missing value for .Values.global.domain_seeds.customer_domains" -}}
+{{- $domains  := concat (list "Default" "ccadmin") $cdomains -}}
+{{- $cdomainsWithoutSupportProjects := .Values.global.domain_seeds.customer_domains_without_support_projects | required "missing value for .Values.global.domain_seeds.customer_domains_without_support_projects" -}}
+
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:
   name: cinder-seed
 spec:
   requires:
-  - monsoon3/domain-default-seed
-  - monsoon3/domain-cc3test-seed
-  - monsoon3/domain-ccadmin-seed
-  - monsoon3/domain-bs-seed
-  - monsoon3/domain-btp-fp-seed
-  - monsoon3/domain-cis-seed
-  - monsoon3/domain-cp-seed
-  - monsoon3/domain-fsn-seed
-  - monsoon3/domain-hda-seed
-  - monsoon3/domain-hcm-seed
-  - monsoon3/domain-hcp03-seed
-  - monsoon3/domain-hec-seed
-  - monsoon3/domain-kyma-seed
-  - monsoon3/domain-monsoon3-seed
-  - monsoon3/domain-neo-seed
-  - monsoon3/domain-s4-seed
-  - monsoon3/domain-wbs-seed
+  {{- range $domains}}
+  {{- if not (hasPrefix "iaas-" .)}}
+  - monsoon3/domain-{{replace "_" "-" . | lower}}-seed
+  {{- end }}
+  {{- end }}
 
   roles:
   - name: cloud_volume_admin
@@ -56,6 +48,13 @@ spec:
       region: '{{.Values.global.region}}'
       url: 'https://{{include "cinder_api_endpoint_host_public" .}}:{{.Values.cinderApiPortPublic}}/v3/%(tenant_id)s'
 
+
+  # Default is special
+  # cc3test does not get seeds
+  # ccadmin gets role assignments for the cloud_admin project and some additional project assignments
+  # iaas is excluded completely
+  # some domains don't have the support projects
+
   domains:
   - name: Default
     users:
@@ -83,577 +82,90 @@ spec:
       - domain: Default
         role: cloud_volume_admin
 
-  - name: ccadmin
+  {{- range $domains}}
+  {{- if and (ne . "Default") (not (hasPrefix "iaas-" .))}}
+  - name: {{ . }}
+    {{- if eq . "ccadmin"}}
     projects:
     - name: cloud_admin
       role_assignments:
       - user: admin@Default
         role: cloud_volume_admin
       # permission to enumerate all projects and domains
+    {{- end }}
     groups:
+    {{- if eq . "ccadmin"}}
     - name: CCADMIN_CLOUD_ADMINS
       role_assignments:
       - project: cloud_admin
         role: cloud_volume_admin
-    - name: CCADMIN_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: volume_admin
-      - project: api_tools
-        role: volume_admin
-      - domain: ccadmin
-        role: volume_admin
-        inherited: true
-    - name: CCADMIN_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: volume_admin
-      - project: compute_tools
-        role: volume_admin
-      - domain: ccadmin
-        role: volume_viewer
-        inherited: true
-    - name: CCADMIN_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: volume_admin
-      - project: network_tools
-        role: volume_admin
-      - domain: ccadmin
-        role: volume_viewer
-        inherited: true
-    - name: CCADMIN_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: volume_admin
-      - project: storage_tools
-        role: volume_admin
-      - domain: ccadmin
-        role: volume_admin
-        inherited: true
-    - name: CCADMIN_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: volume_admin
-      - domain: ccadmin
-        role: volume_viewer
-        inherited: true
-
-  - name: bs
-    groups:
-    - name: BS_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: volume_admin
-      - domain: bs
-        role: volume_admin
-        inherited: true
-    - name: BS_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: volume_admin
-      - domain: bs
-        role: volume_viewer
-        inherited: true
-    - name: BS_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: volume_admin
-      - domain: bs
-        role: volume_viewer
-        inherited: true
-    - name: BS_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: volume_admin
-      - domain: bs
-        role: volume_admin
-        inherited: true
-    - name: BS_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: volume_admin
-      - domain: bs
-        role: volume_viewer
-        inherited: true
-
-  - name: btp_fp
-    groups:
-    - name: BTP_FP_API_SUPPORT
-      role_assignments:
-      - domain: btp_fp
-        role: volume_admin
-        inherited: true
-    - name: BTP_FP_COMPUTE_SUPPORT
-      role_assignments:
-      - domain: btp_fp
-        role: volume_viewer
-        inherited: true
-    - name: BTP_FP_NETWORK_SUPPORT
-      role_assignments:
-      - domain: btp_fp
-        role: volume_viewer
-        inherited: true
-    - name: BTP_FP_STORAGE_SUPPORT
-      role_assignments:
-      - domain: btp_fp
-        role: volume_admin
-        inherited: true
-    - name: BTP_FP_SERVICE_DESK
-      role_assignments:
-      - domain: btp_fp
-        role: volume_viewer
-        inherited: true
-
-  - name: cis
-    groups:
-    - name: CIS_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: volume_admin
-      - domain: cis
-        role: volume_admin
-        inherited: true
-    - name: CIS_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: volume_admin
-      - domain: cis
-        role: volume_viewer
-        inherited: true
-    - name: CIS_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: volume_admin
-      - domain: cis
-        role: volume_viewer
-        inherited: true
-    - name: CIS_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: volume_admin
-      - domain: cis
-        role: volume_admin
-        inherited: true
-    - name: CIS_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: volume_admin
-      - domain: cis
-        role: volume_viewer
-        inherited: true
-        
-  - name: cp
-    groups:
-    - name: CP_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: volume_admin
-      - domain: cp
-        role: volume_admin
-        inherited: true
-    - name: CP_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: volume_admin
-      - domain: cp
-        role: volume_viewer
-        inherited: true
-    - name: CP_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: volume_admin
-      - domain: cp
-        role: volume_viewer
-        inherited: true
-    - name: CP_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: volume_admin
-      - domain: cp
-        role: volume_admin
-        inherited: true
-    - name: CP_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: volume_admin
-      - domain: cp
-        role: volume_viewer
-        inherited: true
-
-  - name: fsn
-    groups:
-    - name: FSN_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: volume_admin
-      - domain: fsn
-        role: volume_admin
-        inherited: true
-    - name: FSN_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: volume_admin
-      - domain: fsn
-        role: volume_viewer
-        inherited: true
-    - name: FSN_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: volume_admin
-      - domain: fsn
-        role: volume_viewer
-        inherited: true
-    - name: FSN_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: volume_admin
-      - domain: fsn
-        role: volume_admin
-        inherited: true
-    - name: FSN_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: volume_admin
-      - domain: fsn
-        role: volume_viewer
-        inherited: true
-
-  - name: hda
-    groups:
-    - name: HDA_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: volume_admin
-      - domain: hda
-        role: volume_admin
-        inherited: true
-    - name: HDA_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: volume_admin
-      - domain: hda
-        role: volume_viewer
-        inherited: true
-    - name: HDA_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: volume_admin
-      - domain: hda
-        role: volume_viewer
-        inherited: true
-    - name: HDA_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: volume_admin
-      - domain: hda
-        role: volume_admin
-        inherited: true
-    - name: HDA_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: volume_admin
-      - domain: hda
-        role: volume_viewer
-        inherited: true
-
-{{- if not .Values.global.domain_seeds.skip_hcm_domain }}
-  - name: hcm
-    groups:
-    - name: HCM_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: volume_admin
-      - domain: hcm
-        role: volume_admin
-        inherited: true
-    - name: HCM_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: volume_admin
-      - domain: hcm
-        role: volume_viewer
-        inherited: true
-    - name: HCM_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: volume_admin
-      - domain: hcm
-        role: volume_viewer
-        inherited: true
-    - name: HCM_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: volume_admin
-      - domain: hcm
-        role: volume_admin
-        inherited: true
-    - name: HCM_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: volume_admin
-      - domain: hcm
-        role: volume_viewer
-        inherited: true
-{{- end }}
-
-  - name: hcp03
-    groups:
-    - name: HCP03_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: volume_admin
-      - domain: hcp03
-        role: volume_admin
-        inherited: true
-    - name: HCP03_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: volume_admin
-      - domain: hcp03
-        role: volume_viewer
-        inherited: true
-    - name: HCP03_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: volume_admin
-      - domain: hcp03
-        role: volume_viewer
-        inherited: true
-    - name: HCP03_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: volume_admin
-      - domain: hcp03
-        role: volume_admin
-        inherited: true
-    - name: HCP03_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: volume_admin
-      - domain: hcp03
-        role: volume_viewer
-        inherited: true
-
-  - name: hec
-    groups:
-    - name: HEC_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: volume_admin
-      - domain: hec
-        role: volume_admin
-        inherited: true
-    - name: HEC_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: volume_admin
-      - domain: hec
-        role: volume_viewer
-        inherited: true
-    - name: HEC_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: volume_admin
-      - domain: hec
-        role: volume_viewer
-        inherited: true
-    - name: HEC_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: volume_admin
-      - domain: hec
-        role: volume_admin
-        inherited: true
-    - name: HEC_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: volume_admin
-      - domain: hec
-        role: volume_viewer
-        inherited: true
-
-  - name: kyma
-    groups:
-    - name: KYMA_API_SUPPORT
-      role_assignments:
-      - domain: kyma
-        role: volume_admin
-        inherited: true
-    - name: KYMA_COMPUTE_SUPPORT
-      role_assignments:
-      - domain: kyma
-        role: volume_viewer
-        inherited: true
-    - name: KYMA_NETWORK_SUPPORT
-      role_assignments:
-      - domain: kyma
-        role: volume_viewer
-        inherited: true
-    - name: KYMA_STORAGE_SUPPORT
-      role_assignments:
-      - domain: kyma
-        role: volume_admin
-        inherited: true
-    - name: KYMA_SERVICE_DESK
-      role_assignments:
-      - domain: kyma
-        role: volume_viewer
-        inherited: true
-
-  - name: monsoon3
-    groups:
+    {{- end }}
+    {{- if eq . "monsoon3"}}
     - name: MONSOON3_DOMAIN_ADMINS
       role_assignments:
       - project: cc-demo
         role: volume_admin
-
-    - name: MONSOON3_API_SUPPORT
+    {{- end }}
+    - name: {{ hasPrefix "iaas-" . | ternary . ( upper . ) }}_API_SUPPORT
       role_assignments:
+      {{- if not (has . $cdomainsWithoutSupportProjects) }}
       - project: api_support
         role: volume_admin
-      - domain: monsoon3
+      {{- end }}
+      {{- if eq . "ccadmin"}}
+      - project: api_tools
+        role: volume_admin
+      {{- end }}
+      - domain: {{ . }}
         role: volume_admin
         inherited: true
-    - name: MONSOON3_COMPUTE_SUPPORT
+    - name: {{ hasPrefix "iaas-" . | ternary . ( upper . ) }}_COMPUTE_SUPPORT
       role_assignments:
+      {{- if not (has . $cdomainsWithoutSupportProjects) }}
       - project: compute_support
         role: volume_admin
-      - domain: monsoon3
+      {{- end }}
+      {{- if eq . "ccadmin"}}
+      - project: compute_tools
+        role: volume_admin
+      {{- end }}
+      - domain: {{ . }}
         role: volume_viewer
         inherited: true
-    - name: MONSOON3_NETWORK_SUPPORT
+    - name: {{ hasPrefix "iaas-" . | ternary . ( upper . ) }}_NETWORK_SUPPORT
       role_assignments:
+      {{- if not (has . $cdomainsWithoutSupportProjects) }}
       - project: network_support
         role: volume_admin
-      - domain: monsoon3
+      {{- end }}
+      {{- if eq . "ccadmin"}}
+      - project: network_tools
+        role: volume_admin
+      {{- end }}
+      - domain: {{ . }}
         role: volume_viewer
         inherited: true
-    - name: MONSOON3_STORAGE_SUPPORT
+    - name: {{ hasPrefix "iaas-" . | ternary . ( upper . ) }}_STORAGE_SUPPORT
       role_assignments:
+      {{- if not (has . $cdomainsWithoutSupportProjects) }}
       - project: storage_support
         role: volume_admin
-      - domain: monsoon3
+      {{- end }}
+      {{- if eq . "ccadmin"}}
+      - project: storage_tools
+        role: volume_admin
+      {{- end }}
+      - domain: {{ . }}
         role: volume_admin
         inherited: true
-    - name: MONSOON3_SERVICE_DESK
+    - name: {{ hasPrefix "iaas-" . | ternary . ( upper . ) }}_SERVICE_DESK
       role_assignments:
+      {{- if not (has . $cdomainsWithoutSupportProjects) }}
       - project: service_desk
         role: volume_admin
-      - domain: monsoon3
+      {{- end }}
+      - domain: {{ . }}
         role: volume_viewer
         inherited: true
-
-  - name: neo
-    groups:
-    - name: NEO_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: volume_admin
-      - domain: neo
-        role: volume_admin
-        inherited: true
-    - name: NEO_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: volume_admin
-      - domain: neo
-        role: volume_viewer
-        inherited: true
-    - name: NEO_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: volume_admin
-      - domain: neo
-        role: volume_viewer
-        inherited: true
-    - name: NEO_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: volume_admin
-      - domain: neo
-        role: volume_admin
-        inherited: true
-    - name: NEO_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: volume_admin
-      - domain: neo
-        role: volume_viewer
-        inherited: true
-
-  - name: s4
-    groups:
-    - name: S4_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: volume_admin
-      - domain: s4
-        role: volume_admin
-        inherited: true
-    - name: S4_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: volume_admin
-      - domain: s4
-        role: volume_viewer
-        inherited: true
-    - name: S4_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: volume_admin
-      - domain: s4
-        role: volume_viewer
-        inherited: true
-    - name: S4_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: volume_admin
-      - domain: s4
-        role: volume_admin
-        inherited: true
-    - name: S4_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: volume_admin
-      - domain: s4
-        role: volume_viewer
-        inherited: true
-
-  - name: wbs
-    groups:
-    - name: WBS_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: volume_admin
-      - domain: wbs
-        role: volume_admin
-        inherited: true
-    - name: WBS_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: volume_admin
-      - domain: wbs
-        role: volume_viewer
-        inherited: true
-    - name: WBS_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: volume_admin
-      - domain: wbs
-        role: volume_viewer
-        inherited: true
-    - name: WBS_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: volume_admin
-      - domain: wbs
-        role: volume_admin
-        inherited: true
-    - name: WBS_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: volume_admin
-      - domain: wbs
-        role: volume_viewer
-        inherited: true
+  {{- end }}
+  {{- end }}


### PR DESCRIPTION
In an attempt to make deployment of new domains easier, @majewsky recently introduced `global.domain_seeds.customer_domains`. As this could replace the old `skip_hcm_domain`, poses the opportunity to distinguish between internal and external domains in future and accommodate other specialties we would like to suggest this on seeds of other services too.

The expressions are technically equal, only the ora domain was added to the seed. If it was excluded on purpose, let me know and I can change it. I excluded iaas- for now.
I ran h3 diff with dyff option against qa-de-1 and eu-de-1, you can have a look at the output here:
[cinderDE1diff.txt](https://github.com/user-attachments/files/19389140/cinderDE1diff.txt)
[cinderQA1diff.txt](https://github.com/user-attachments/files/19389142/cinderQA1diff.txt)
