### PR TITLE
[memcached] if using external ip set externalTrafficPolicy: Local

### DIFF
--- a/common/memcached/CHANGELOG.md
+++ b/common/memcached/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.6.8 - 2025/03/24
+
+* Set Service 'externalTrafficPolicy: Local' when using external IP.
+* needed for calico rollout
+* chart version bumped
+
 ## v0.6.7 - 2025/03/21
 
 memcached [version](https://github.com/memcached/memcached/wiki/ReleaseNotes1638) bumped to `1.6.38-alpine3.21`

--- a/common/memcached/Chart.yaml
+++ b/common/memcached/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: memcached
-version: 0.6.6
+version: 0.6.7
 description: Free & open source, high-performance, distributed memory object caching system.
 home: http://memcached.org/
 sources:

--- a/common/memcached/templates/service.yaml
+++ b/common/memcached/templates/service.yaml
@@ -23,4 +23,5 @@ spec:
 {{- if .Values.external_ip }}
   externalIPs:
     - {{ .Values.external_ip }}
+  externalTrafficPolicy: Local
 {{- end }}


### PR DESCRIPTION
- needed for calico rollout
- also bump chart