### PR TITLE
[keystone] bump memcached requirement

### DIFF
--- a/openstack/keystone/Chart.lock
+++ b/openstack/keystone/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 0.29.3
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.5.3
+  version: 0.6.8
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.3.5
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.4
-digest: sha256:36d32a0c2c4c2f95faba108948f08297b10a7186fd6f6d8ad4b6b81e8e7650af
-generated: "2025-03-24T11:53:57.053229+01:00"
+digest: sha256:15b64b6c26740569c218da7e0e8100055d744a5a321185655cc478423c9c93ce
+generated: "2025-03-24T13:12:42.14091+01:00"

--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -22,7 +22,7 @@ dependencies:
     version: 0.29.3
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.5.3
+    version: 0.6.8
   - condition: mysql_metrics.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm


### PR DESCRIPTION
- ver 0.6.8 is required for global and calico rollout
- for the rest see https://github.com/sapcc/helm-charts/blob/master/common/memcached/CHANGELOG.md