### PR TITLE
[nova] minor helm dependencies bump

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.18.1
+  version: 0.18.2
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.18.1
+  version: 0.18.2
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.4.2
@@ -13,13 +13,13 @@ dependencies:
   version: 0.17.1
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.6.6
+  version: 0.6.8
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.24.1
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.18.1
+  version: 0.18.2
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.17.1
@@ -29,5 +29,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:f3e632bb3d014539b6f4ec45fe9703b70103e3f1f1583d2f67d2e749ded7c7e3
-generated: "2025-03-24T09:32:10.751334+01:00"
+digest: sha256:d3af75f45a7a63591606b3087f1bd04aee1ee2d779c9a413cc2c6bd138cc21b7
+generated: "2025-03-24T15:36:23.710172+02:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -2,18 +2,18 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 name: nova
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Nova/OpenStack_Project_Nova_mascot.png
-version: 0.4.0
+version: 0.4.1
 appVersion: "rocky"
 dependencies:
   - name: mariadb
     condition: mariadb.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.18.1
+    version: 0.18.2
   - name: mariadb
     alias: mariadb_api
     condition: mariadb_api.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.18.1
+    version: 0.18.2
   - name: mysql_metrics
     condition: mariadb.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
@@ -23,7 +23,7 @@ dependencies:
     version: 0.17.1
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.6.6
+    version: 0.6.8
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.24.1
@@ -31,7 +31,7 @@ dependencies:
     alias: mariadb_cell2
     condition: mariadb_cell2.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.18.1
+    version: 0.18.2
   - name: rabbitmq
     alias: rabbitmq_cell2
     condition: cell2.enabled

--- a/openstack/nova/ci/test-values.yaml
+++ b/openstack/nova/ci/test-values.yaml
@@ -3,12 +3,13 @@ global:
   region: regionOne
   domain: evil.corp
   registry: keppel.regionOne.cloud
+  registryAlternateRegion: keppel.regionTwo.cloud
   dockerHubMirror: myRegistry/dockerhub
   dockerHubMirrorAlternateRegion: myRegistry/dockerhubalternate
   tld: regionOne.cloud
   domain_seeds:
     skip_hcm_domain: false
-    
+
   master_password: topSecret
   nova_service_password: topSecret
   availability_zones:


### PR DESCRIPTION
* update mariadb chart to 0.18.2
  * updates user-credential-updater.py

* update memcached chart to 0.6.8
  * updates memcached to latest bugfix release