### PR TITLE
[octavia][shared] bump service dependencies

### DIFF
--- a/openstack/octavia/Chart.lock
+++ b/openstack/octavia/Chart.lock
@@ -1,27 +1,27 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.14.2
+  version: 0.19.1
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.3.1
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.5.3
+  version: 0.6.9
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.4.2
+  version: 0.4.3
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.11.1
+  version: 0.17.1
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.23.0
+  version: 0.25.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:85fb2f4ac262dd78c8d01c045cfce1215c26af410f089b6ce77a48dd734db356
-generated: "2025-03-20T12:37:09.650574+02:00"
+digest: sha256:05b9ec215a66887f2309f49232a8458d46591152670e71376df5814041d7a31c
+generated: "2025-04-03T11:50:26.78812+03:00"

--- a/openstack/octavia/Chart.yaml
+++ b/openstack/octavia/Chart.yaml
@@ -9,12 +9,12 @@ sources:
   - https://git.openstack.org/cgit/openstack/octavia
   - https://git.openstack.org/cgit/openstack/openstack-helm
 # The versions are defined in the changelog: https://docs.openstack.org/releasenotes/octavia/yoga.html
-version: 10.1.0
+version: 10.1.1
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.14.2
+    version: 0.19.1
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db
@@ -22,17 +22,17 @@ dependencies:
     version: 0.3.1
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.5.3
+    version: 0.6.9
   - condition: mariadb.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.4.2
+    version: 0.4.3
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.11.1
+    version: 0.17.1
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.23.0
+    version: 0.25.0
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0

--- a/openstack/octavia/ci/test-values.yaml
+++ b/openstack/octavia/ci/test-values.yaml
@@ -1,9 +1,9 @@
 ---
 global:
-  registry: myRegistry
   dbPassword: secret!
   master_password: topSecret!
   octavia_service_password: topSecret!!
+  registry: my.docker.registry
   registryAlternateRegion: other.docker.registry
   dockerHubMirrorAlternateRegion: other.dockerhub.mirror
   availability_zones:


### PR DESCRIPTION
* mariadb 0.14.2 -> 0.19.1

* memcached 0.5.3 -> 0.6.9

* mysql-metrics 0.3.5 -> 0.4.3

* rabbitmq 0.11.1 -> 0.17.1

* utils 0.19.7 -> 0.25.0

This change:
* adds user-credential-updater sidecars to mariadb and rabbitmq services
* allows to update root user password in mariadb
* allows to use secrets-injector for backup-v2 secrets
* bumps mariadb, rabbitmq, mysql-metrics, memcached to latest bugfix releases