### PR TITLE
[utils] add an option to select default user for rabbitmq and db

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.25.0
+version: 0.26.0

--- a/openstack/utils/templates/_hosts.tpl
+++ b/openstack/utils/templates/_hosts.tpl
@@ -40,10 +40,14 @@
         {{- end }}
         {{- if and $dbConfig.users $dbConfig.databases }}
             {{- $db := first $dbConfig.databases }}
-            {{- $user := get $dbConfig.users $db | required (printf ".Values.db.%v.name & .password are required (key comes from first database in databases array)" $db) }}
-            {{- $user.name | required (printf ".Values.db.%v.name is required!" $db ) }}:{{ $user.password | required (printf ".Values.db.%v.password is required!" $db ) }}
+            {{- $defaultUser := default $db $dbConfig.defaultUser }}
+            {{- if and (hasKey .Values.global "db") (hasKey .Values.global.db "defaultUser") (hasKey $dbConfig "defaultUser") }}
+                {{- $defaultUser = coalesce .Values.global.db.defaultUser $dbConfig.defaultUser $db }}
+            {{- end }}
+            {{- $user := get $dbConfig.users $defaultUser | required (printf ".Values.%s.users.%s is required (selected via .Values.%s.defaultUser)" $dbType $defaultUser $dbType) }}
+            {{- $user.name | required (printf ".Values.%s.users.%s.name is required!" $dbType $defaultUser) }}:{{ $user.password | required (printf ".Values.%s.users.%s.password is required!" $dbType $defaultUser) }}
         {{- else }}
-            {{- coalesce $envAll.Values.dbUser $envAll.Values.global.dbUser "root" }}:{{ coalesce $envAll.Values.dbPassword $envAll.Values.global.dbPassword $dbConfig.root_password | required ".Values.db.root_password is required!" }}
+            {{- coalesce $envAll.Values.dbUser $envAll.Values.global.dbUser "root" }}:{{ coalesce $envAll.Values.dbPassword $envAll.Values.global.dbPassword $dbConfig.root_password | required (printf ".Values.%s.root_password is required!" $dbType) }}
         {{- end }}
     {{- else }}
         {{- $user := index $envAll 2 }}
@@ -170,8 +174,13 @@ Tuple example: tuple . .Values.apidbName .Values.apidbUser .Values.apidbPassword
     {{- if kindIs "map" . }}
         {{- if and .Values.mariadb.users .Values.mariadb.databases }}
             {{- $db := first .Values.mariadb.databases }}
-            {{- $user := get .Values.mariadb.users $db | required (printf ".Values.mariadb.%v.name & .password are required (key comes from first database in .Values.mariadb.databases)" $db) }}
-            {{- tuple . $db $user.name (required (printf "User with key %v requires password" $db) $user.password) | include "utils._db_url_mariadb" }}
+            {{- $dbConfig := .Values.mariadb }}
+            {{- $defaultUser := default $db $dbConfig.defaultUser }}
+            {{- if and (hasKey .Values.global "db") (hasKey .Values.global.db "defaultUser") (hasKey $dbConfig "defaultUser") }}
+                {{- $defaultUser = coalesce .Values.global.db.defaultUser $dbConfig.defaultUser $db }}
+            {{- end }}
+            {{- $user := get .Values.mariadb.users $defaultUser | required (printf ".Values.mariadb.users.%s is required (selected via .Values.mariadb.defaultUser)" $defaultUser) }}
+            {{- tuple . $db $user.name (required (printf "User with key %v requires password" $defaultUser) $user.password) | include "utils._db_url_mariadb" }}
         {{- else }}
             {{- tuple . (coalesce .Values.dbName .Values.db_name) (coalesce .Values.dbUser .Values.global.dbUser "root" ) (coalesce .Values.dbPassword .Values.global.dbPassword .Values.mariadb.root_password | required ".Values.mariadb.root_password is required!") .Values.mariadb.name | include "utils._db_url_mariadb" }}
         {{- end }}
@@ -212,8 +221,13 @@ Tuple example: tuple . .Values.apidbName .Values.apidbUser .Values.apidbPassword
     {{- if kindIs "map" . }}
         {{- if and .Values.pxc_db.users .Values.pxc_db.databases }}
             {{- $db := first .Values.pxc_db.databases }}
-            {{- $user := get .Values.pxc_db.users $db | required (printf ".Values.pxc_db.%v.name & .password are required (key comes from first database in .Values.pxc_db.databases)" $db) }}
-            {{- tuple . $db $user.name (required (printf "User with key %v requires password" $db) $user.password) | include "utils._db_url_pxc_db" }}
+            {{- $dbConfig := .Values.pxc_db }}
+            {{- $defaultUser := default $db $dbConfig.defaultUser }}
+            {{- if and (hasKey .Values.global "db") (hasKey .Values.global.db "defaultUser") (hasKey $dbConfig "defaultUser") }}
+                {{- $defaultUser = coalesce .Values.global.db.defaultUser $dbConfig.defaultUser $db }}
+            {{- end }}
+            {{- $user := get .Values.pxc_db.users $defaultUser | required (printf ".Values.pxc_db.users.%s is required (selected via .Values.pxc_db.defaultUser)" $defaultUser) }}
+            {{- tuple . $db $user.name (required (printf "User with key %v requires password" $defaultUser) $user.password) | include "utils._db_url_pxc_db" }}
         {{- else }}
             {{- tuple . (coalesce .Values.dbName .Values.db_name) (coalesce .Values.dbUser .Values.global.dbUser "root") (coalesce .Values.dbPassword .Values.global.dbPassword .Values.pxc_db.root_password | required ".Values.pxc_db.root_password is required!") .Values.pxc_db.name | include "utils._db_url_pxc_db" }}
         {{- end }}

--- a/openstack/utils/templates/_ini_sections.tpl
+++ b/openstack/utils/templates/_ini_sections.tpl
@@ -6,9 +6,14 @@ heartbeat_in_pthread = False
 {{- end }}
 
 {{- define "ini_sections.default_transport_url" }}
-{{- $data := merge (pick .Values.rabbitmq "host" "port" "virtual_host") .Values.rabbitmq.users.default }}
-{{- $_ := required ".Values.rabbitmq.users.default.user is required" .Values.rabbitmq.users.default.user }}
-{{- $_ := required ".Values.rabbitmq.users.default.password is required" .Values.rabbitmq.users.default.password }}
+{{- $defaultUser := default "default" .Values.rabbitmq.defaultUser }}
+{{- if and (hasKey .Values.global "rabbitmq") (hasKey .Values.global.rabbitmq "defaultUser") (hasKey .Values.rabbitmq "defaultUser") }}
+    {{- $defaultUser = coalesce .Values.global.rabbitmq.defaultUser .Values.rabbitmq.defaultUser "default" }}
+{{- end }}
+{{- $user := index .Values.rabbitmq.users $defaultUser }}
+{{- $data := merge (pick .Values.rabbitmq "host" "port" "virtual_host") $user }}
+{{- $_ := required (printf ".Values.rabbitmq.users.%s.user is required" $defaultUser) $data.user }}
+{{- $_ := required (printf ".Values.rabbitmq.users.%s.password is required" $defaultUser) $data.password }}
 {{- include "ini_sections._transport_url" (tuple . $data) }}
 {{- end }}
 


### PR DESCRIPTION
This change introduces an option to select the default user for RabbitMQ and MariaDB template function:
* `ini_sections.default_transport_url`
* `utils.db_url` with sub-functions

Currently, these functions select the default user the following way:
* RabbitMQ selects the 'default' user.
* MariaDB selects the `first` defined database and then chooses the key from users with the same name as the database.

After this change, `defaultUser` option (`.Values.rabbitmq.defaultUser` or `.Values.mariadb.defaultUser`) could be used to select another user when required.

After this change, this user could be selected two ways:
* `defaultUser` option (`.Values.rabbitmq.defaultUser`, `.Values.mariadb.defaultUser`) could be used in service values to select another user when required
* `.Values.global.db.defaultUser` for database and `.Values.global.rabbitmq.defaultUser` for rabbitmq
  * this options should be set in `region/values/openstack-globals.yaml` and used to select default user for all OpenStack services in region

