### PR TITLE
[utils] Add helper to configure sentry

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.24.1
+version: 0.25.0

--- a/openstack/utils/templates/_helpers.tpl
+++ b/openstack/utils/templates/_helpers.tpl
@@ -76,3 +76,15 @@ trace_sqlalchemy = {{ .Values.global.osprofiler.trace_sqlalchemy }}
 {{- include "utils.proxysql.proxysql_signal_stop_script" . }}
 {{- include "utils.linkerd.signal_stop_script" . }}
 {{- end }}
+
+{{- define "utils.sentry_config" -}}
+- name: SENTRY_DSN
+  valueFrom:
+    secretKeyRef:
+      name: sentry
+      key: {{ .Chart.Name }}.DSN.python
+{{- if .Values.sentry.release }}
+- name: SENTRY_RELEASE
+  value: {{ .Values.sentry.release }}
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
Add a helper to configure sentry. This will configure SENTRY_DSN. If the variable sentry.release is specified, a SENTRY_RELEASE environment variable will be set as well.