### PR TITLE
Extend compute-storage-api services' CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -66,7 +66,7 @@
 /openstack/cc3test                                     @ashifnihalb @artherd42
 /openstack/cc3test-seeds                               @ashifnihalb @artherd42
 /openstack/cerebro                                     @viennaa @joker-at-work @fwiesel @grandchild
-/openstack/cinder                                      @joker-at-work @hemna @fwiesel @dusandordevicsap
+/openstack/cinder                                      @joker-at-work @hemna @fwiesel @jagoleni
 /openstack/content-repo                                @majewsky @SuperSandro2000 @VoigtS @wagnerd3 @Nuckal777
 /openstack/cronus                                      @kayrus @dhalimi1975 @corey-aloia @fwiesel
 /openstack/cronus-seed                                 @kayrus @dhalimi1975
@@ -92,12 +92,12 @@
 /openstack/manila*                                     @Carthaca @chuan137 @galkindmitrii @kpawar-sap @sumitarora2786 @crenduchinta88 @harsharavuri99 @RockSolidScripts
 /openstack/nannies                                     @chuan137 @Carthaca @fwiesel @kpawar-sap
 /openstack/neutron                                     @notandy @fwiesel @sebageek @sven-rosenzweig @rhalina @swagner-de @mutax @BenjaminLudwigSAP @m-kratochvil @occamshatchet
-/openstack/nova                                        @joker-at-work @fwiesel @grandchild @leust
+/openstack/nova                                        @joker-at-work @fwiesel @grandchild @leust @seb-kro @PaulPickhardt @CordulaGuder
 /openstack/octavia                                     @notandy @BenjaminLudwigSAP @fwiesel @dusandordevicsap @velp @m-kratochvil
 /openstack/octobus                                     @viennaa @Kuckkuck @businessbean
 /openstack/openstack-seeder                            @stefanhipfel @databus23 @fwiesel
 /openstack/openstack-performance                       @misamoylov
-/openstack/placement                                   @fwiesel @joker-at-work @bashar-alkhateeb @galkindmitrii
+/openstack/placement                                   @fwiesel @joker-at-work @bashar-alkhateeb @leust @grandchild @seb-kro @PaulPickhardt @CordulaGuder
 /openstack/poller                                      @dhalimi1975 @corey-aloia
 /openstack/prometheus-openstack                        @viennaa @richardtief @Kuckkuck @timojohlo
 /openstack/pyroscope                                   @fwiesel
@@ -120,7 +120,7 @@
 /openstack/tempest/tempest-base                        @misamoylov @fwiesel @stefanhipfel @galkindmitrii
 /openstack/trust-manager                               @fwiesel
 /openstack/utils                                       @fwiesel @notandy @galkindmitrii @Carthaca @joker-at-work @s10
-/openstack/vcenter-operator                            @joker-at-work @fwiesel @databus23
+/openstack/vcenter-operator                            @joker-at-work @fwiesel @PaulPickhardt
 /openstack/vcf                                         @chuan137
 /openstack/volume-claims                               @fwiesel
 


### PR DESCRIPTION
We got a couple of new colleagues that should get notified and able to approve work on the helm-charts of the services managed by compute-storage-api.