### PR TITLE
[placement] Bump chart dependencies to newest versions

### DIFF
--- a/openstack/placement/Chart.lock
+++ b/openstack/placement/Chart.lock
@@ -1,18 +1,18 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.14.1
+  version: 0.18.2
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.4.0
+  version: 0.6.8
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.18.1
+  version: 0.24.1
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.0.0
-digest: sha256:1626ca2b7b82cee98948755b22098889f3bd92884f1f7453f0dc54369badac38
-generated: "2024-08-13T11:37:21.323270755+02:00"
+  version: 1.1.0
+digest: sha256:dc51fa41a20e9e64a92552c0a6a13be770bb6e4697ae267708cca1d9bb931a8d
+generated: "2025-03-24T18:10:02.071857+01:00"

--- a/openstack/placement/Chart.yaml
+++ b/openstack/placement/Chart.yaml
@@ -8,16 +8,16 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.14.1
+    version: 0.18.2
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.4.0
+    version: 0.6.8
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.18.1
+    version: 0.24.1
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 1.0.0
+    version: 1.1.0

--- a/openstack/placement/values.yaml
+++ b/openstack/placement/values.yaml
@@ -59,6 +59,13 @@ mariadb:
     support_group: "compute-storage-api"
   ccroot_user:
     enabled: true
+  job:
+    maintenance:
+      enabled: false
+      function:
+        analyzeTable:
+          enabled: true
+          allTables: true
 
 memcached:
   alerts:


### PR DESCRIPTION
Bump mariadb 0.14.1 to 0.18.2
* standardize labels
* fixed service selector
* update mariadb app 10.5.17 to 10.5.28
  * fix vulnerabilities against DOS attacks and other exploits:
    * CVE-2022-47015
    * CVE-2024-21096
    * CVE-2023-22084
    * CVE-2025-21490
* configurable enablement of AWS backup storage
* avoid showing passwords in processlist of k8s nodes
* add maintenance job to boost performance
* add `.Values.mariadb.job` values for maintenance job configuration
* fix `maria-back-me-up` alert rules
* allow to change root password without intermittent check failure
* update root password on database start
* add `credential-updater` sidecar
* `.Values.mariadb.initdb_secret` becomes redundant
* configurable enablement of Swift backup storage
* remove support for value `.Values.mariadb.credentialUpdater.enabled`

Bump utils 0.18.4 to 0.24.1
* support secrets-injector usage for `.Values.global.osprofiler.hmac_keys`
* set transaction and query timeouts for ProxySQL
* default `.Values.audit.mem_queue_size` to 1000
* use `project` instead of `tenant` for user logging
* add `system_scope` to user logging

Bump linkerd-support 1.0.0 to 1.1.0
* switch from bitnami/kubectl to internal kubectl image

Bump memcached 0.4.0 to 0.6.8
* allow enabling SASL (Simple Authentication and Security Layer)
  * requires setting user and password
* standardized labels
* bump memcached 1.6.28 to 1.6.37
  * performance fixes, stability fixes, critical bug fixes
  * reduced security vulnerability
* bump memcached-exporter 0.14.1 to 0.15.1 including security fixes:
  * CVE-2023-48795
  * CVE-2024-24786
  * CVE-2023-45288
  * CVE-2024-45337
  * CVE-2024-45338
* set service 'externalTrafficPolicy: Local' when using external IP
  * needed for calico rollout