### PR TITLE
[openstack-exporter] Bump chart dependencies to newest versions

### DIFF
--- a/prometheus-exporters/openstack-exporter/Chart.lock
+++ b/prometheus-exporters/openstack-exporter/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.14.4
+  version: 0.24.1
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.2.0
+  version: 1.0.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.1.3
-digest: sha256:1afb1ee9d3bd90b1818bb9b842fa7895f2e8f0c206c5255fe7dc246a11fc0186
-generated: "2024-04-12T15:14:30.014979+02:00"
+  version: 1.1.0
+digest: sha256:ac18e83ad7659a3793488fd687dbc2df3ba116b294964e6941626910d4c2f451
+generated: "2025-03-24T23:48:51.04641+01:00"

--- a/prometheus-exporters/openstack-exporter/Chart.yaml
+++ b/prometheus-exporters/openstack-exporter/Chart.yaml
@@ -8,10 +8,10 @@ maintainers:
 dependencies:
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.14.4
+    version: 0.24.1
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.2.0
+    version: 1.0.0
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.1.3
+    version: 1.1.0


### PR DESCRIPTION
Bump utils 0.18.4 to 0.24.1
* use `project` instead of `tenant` for user logging
* add `system_scope` to user logging

Bump linkerd-support 1.0.0 to 1.1.0
* delete hook job before creating it to fix helm rollbacks
* switch from bitnami/kubectl to internal kubectl image

Bump owner-info 0.2.0 to 1.0.0
* add configmap delete hook on `post-delete`