### PR TITLE
[cinder] Bump chart dependencies to newest versions

### DIFF
--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -1,27 +1,27 @@
 dependencies:
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.22.1
+  version: 0.24.1
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.15.5
+  version: 0.18.2
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.4.2
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.6.4
+  version: 0.6.8
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.14.1
+  version: 0.17.1
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.6.2
+  version: 2.1.4
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:bbc5363a7081e030b710a12cbddc8bf81b69f84d6d1d701a9ebbb0bfa93fcd3d
-generated: "2025-02-17T10:15:25.002858-05:00"
+digest: sha256:30e4c6a975fcb2a8307ded829e45b862ef7179bcb47910b5bb6c6dde1a7789e2
+generated: "2025-03-24T23:45:23.287069+01:00"

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -6,10 +6,10 @@ version: 0.2.1
 dependencies:
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.22.1
+    version: 0.24.1
   - name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.15.5
+    version: 0.18.2
     condition: mariadb.enabled
   - name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
@@ -17,14 +17,14 @@ dependencies:
     condition: mariadb.enabled
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.6.4
+    version: 0.6.8
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.14.1
+    version: 0.17.1
   - name: redis
     alias: api-ratelimit-redis
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 1.6.2
+    version: 2.1.4
     condition: api_rate_limit.enabled
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -6,7 +6,7 @@ global:
   dbUser: cinder
   domain_seeds:
     skip_hcm_domain: false
- 
+
   linkerd_requested: true
   osprofiler: {}
   imagePullPolicy: IfNotPresent
@@ -129,7 +129,6 @@ mariadb:
       password: null
       grants:
       - "ALL PRIVILEGES on cinder.*"
-  initdb_secret: true
   persistence_claim:
     name: db-cinder-pvclaim
   extraConfigFiles:
@@ -138,6 +137,13 @@ mariadb:
       connect_timeout = 15
   alerts:
     support_group: compute-storage-api
+  job:
+    maintenance:
+      enabled: false
+      function:
+        analyzeTable:
+          enabled: true
+          allTables: true
 
 max_pool_size: 15
 max_overflow: 5
@@ -306,8 +312,6 @@ mysql_metrics:
 
 audit:
   enabled: false
-  # how many messages to buffer before dumping to log (when rabbit is down or too slow)
-  mem_queue_size: 1000
   record_payloads: false
   metrics_enabled: true
   central_service:
@@ -324,10 +328,11 @@ rabbitmq:
     support_group: compute-storage-api
   metrics:
     enabled: true
+    addMetricsUser: true
     sidecar:
       enabled: false
   enableDetailedMetrics: true
-  enablePerObjectMetrics: true 
+  enablePerObjectMetrics: true
 rabbitmq_notifications:
   name: cinder
 logging:
@@ -406,3 +411,7 @@ owner-info:
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/openstack/cinder
 
 coordinationBackend: "file"
+
+api-ratelimit-redis:
+  alerts:
+    support_group: compute-storage-api


### PR DESCRIPTION
Bump mariadb 0.15.5 to 0.18.2
* configurable enablement of AWS backup storage
* avoid showing passwords in processlist of k8s nodes
* add maintenance job to boost performance
* add `.Values.mariadb.job` values for maintenance job configuration
* fix `maria-back-me-up` alert rules
* allow to change root password without intermittent check failure
* update root password on database start
* add `credential-updater` sidecar
* `.Values.mariadb.initdb_secret` becomes redundant
* configurable enablement of Swift backup storage
* remove support for value `.Values.mariadb.credentialUpdater.enabled`

Bump rabbitmq 0.14.1 to 0.17.1
* default to not creating a `metrics` user even with `metrics` enabled
* add `.Values.rabbitmq.metrics.addMetricsUser` to enable `metrics` user
* bump rabbitmq app 4.0.6 to 4.0.7
* add sidecar container for runtime password updates
* default `Values.rabbitmq.customConfig.max_message_size` to pre 4.0 default

Bump utils 0.22.1 to 0.24.1
* remove `.Values.audit.mem_queue_size` for new v0.22.1 default of same value
* use `project` instead of `tenant` for user logging
* add `system_scope` to user logging

Bump memcached 0.6.4 to 0.6.8
* bump memcached 1.6.36 to 1.6.37
  * reduced security vulnerability
* bump memcached-exporter 0.15.0 to 0.15.1 including security fixes:
  * CVE-2024-45337
  * CVE-2024-45338
* set service 'externalTrafficPolicy: Local' when using external IP
      * needed for calico rollout

Bump redis 1.6.2 to 2.1.4
* remove support for values
  * `.Values.redis.nameOverride`
  * `.Values.redis.redisPort`
  * `.Values.redis.metrics.port`
* deprecate support for value `.Values.redis.redisPassword`
* rename deployment from `...-redis-metrics` to `...-redis-exporter`
* add password autogeneration on first startup
* reduce `redis-exporter` memory limit to 64 MiB
* add alerts when auto-issued secrets expire
* bump redis_exporter from 1.67 to 1.69
* rename `Postgres...` to `Redis...` in Prometheus alerts