### PR TITLE
[mariadb] remove unused internal functions

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.19.0 - 2025/03/25
+* Remove the following internal helm template helper functions:
+  * `keystone_url`
+  * `mariadb.db_host`
+  * `mariadb.root_password`
+  * `mariadb.resolve_secret`
+
 ## v0.18.2 - 2025/03/21
 * add missing headers to the mariadb-credential-updater.py
 * remove unused `credentialUpdater.enabled` option from values - this sidecar is non-optional

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,6 +2,6 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.18.2
+version: 0.19.0
 # scripts/docker-entyrpoint.sh should be updated when appVersion is updated
 appVersion: 10.5.28

--- a/common/mariadb/templates/_helpers.tpl
+++ b/common/mariadb/templates/_helpers.tpl
@@ -12,19 +12,6 @@
 {{- end -}}
 {{- end -}}
 
-{{define "keystone_url"}}http://keystone.{{ default .Release.Namespace .Values.global.keystoneNamespace }}.svc.kubernetes.{{.Values.global.region}}.{{.Values.global.tld}}:5000/v3{{end}}
-
-{{- define "mariadb.db_host"}}{{.Release.Name}}-mariadb.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.region}}.{{.Values.global.tld}}{{- end}}
-
-{{- define "mariadb.resolve_secret" -}}
-    {{- $str := . -}}
-    {{- if (hasPrefix "vault+kvv2" $str ) -}}
-        {{"{{"}} resolve "{{ $str }}" {{"}}"}}
-    {{- else -}}
-        {{ $str }}
-{{- end -}}
-{{- end -}}
-
 {{- define "mariadb.resolve_secret_squote" -}}
     {{- $str := . -}}
     {{- if (hasPrefix "vault+kvv2" $str ) -}}
@@ -32,10 +19,6 @@
     {{- else -}}
         {{ $str | replace "'" "''" | squote }}
 {{- end -}}
-{{- end -}}
-
-{{- define "mariadb.root_password" -}}
-{{- include "mariadb.resolve_secret" (required ".Values.root_password missing" .Values.root_password) }}
 {{- end -}}
 
 {{- define "registry" -}}

--- a/common/mariadb/templates/secret.yaml
+++ b/common/mariadb/templates/secret.yaml
@@ -7,4 +7,4 @@ metadata:
     {{- include "mariadb.labels" (list $ "noversion" "mariadb" "secret" "database") | indent 4 }}
 type: Opaque
 data:
-  root-password: {{ include "mariadb.root_password" . | b64enc | quote }}
+  root-password: {{ required ".Values.root_password missing" .Values.root_password | b64enc | quote }}


### PR DESCRIPTION
* Remove the following internal helm template helper functions:
  * `keystone_url`
  * `mariadb.db_host`
  * `mariadb.root_password`
  * `mariadb.resolve_secret`