### PR TITLE
[glance][shared] bump service dependencies

### DIFF
--- a/openstack/glance/Chart.lock
+++ b/openstack/glance/Chart.lock
@@ -1,16 +1,16 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.15.3
+  version: 0.18.2
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.6.3
+  version: 0.6.9
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.4.2
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.19.6
+  version: 0.25.0
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.6.2
@@ -20,5 +20,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:24085cef1641f95fd2b5da8b47efc1195732d03e72da4e8a859066c5082969f7
-generated: "2025-02-18T14:58:24.348888+02:00"
+digest: sha256:6ef3583e0c22849491ccb32c225c32020c1d518129dabbc07a9b4253577649ed
+generated: "2025-03-25T17:06:08.636189+02:00"

--- a/openstack/glance/Chart.yaml
+++ b/openstack/glance/Chart.yaml
@@ -3,22 +3,22 @@ appVersion: dalmatian
 description: A Helm chart Openstack Glance
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Glance/OpenStack_Project_Glance_vertical.png
 name: glance
-version: 0.6.5
+version: 0.6.6
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.15.3
+    version: 0.18.2
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.6.3
+    version: 0.6.9
   - condition: mariadb.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.4.2
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.19.6
+    version: 0.25.0
   - name: redis
     alias: sapcc_rate_limit
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm


### PR DESCRIPTION
* mariadb 0.15.3 to 0.18.2
  * updates mariadb and mysqld-exporter to the latest bugfix releases
  * adds user-credential-updater sidecar
  * allows to update mariab root password

* memcached 0.6.3 to 0.6.9
  * updates to the latest bugfix versions

* utils 0.19.6 to 0.25.0