### PR TITLE
[designate] update hermes audit map file with unmapped endpoints

### DIFF
--- a/openstack/designate/templates/etc/_designate_audit_map.yaml
+++ b/openstack/designate/templates/etc/_designate_audit_map.yaml
@@ -11,9 +11,33 @@ resources:
   zones:
     children:
       recordsets:
+      tasks:
+        api_name: 'tasks'
+        children:
+          transfer_requests:
+          transfer_accepts:
+          imports:
+          exports:
+        custom_actions:
+          abandon: 'update/abandon'
+          xfr: 'update/xfr'
+          pool_move: 'update/pool_move'
+      shares:
+        # Zone sharing resources
+        api_name: 'shares'
+      nameservers:
+        # Endpoint for retrieving nameservers
+        singleton: true
   tlds:
   tsigkeys:
   blacklists:
   quotas:
-  # this path is reverse/floatingips, needs mapping adjustment
-  floatingips:
+  reverse:
+    children:
+      floatingips:
+  pools:
+  limits:
+    singleton: true
+  recordsets:
+    # For the global recordsets endpoint
+  service_statuses:


### PR DESCRIPTION
Our DRAFT external documentation had unmapped endpoints in the list. This led me to check the full mapping, and many endpoints are missing. This is updated, and I've communicated the DRAFT documentation required correction. 