### PR TITLE
[glance] seed generic domains using global.domain_seeds

### DIFF
--- a/openstack/glance/ci/test-values.yaml
+++ b/openstack/glance/ci/test-values.yaml
@@ -8,7 +8,8 @@ global:
     - foo
     - bar
   domain_seeds:
-    skip_hcm_domain: false
+    customer_domains: [bar, foo, baz]
+    customer_domains_without_support_projects: [baz]
     
 imageVersion: rocky
 

--- a/openstack/glance/templates/seeds.yaml
+++ b/openstack/glance/templates/seeds.yaml
@@ -1,3 +1,8 @@
+{{- $cdomains := .Values.global.domain_seeds.customer_domains | required "missing value for .Values.global.domain_seeds.customer_domains" -}}
+{{- $domains  := concat (list "Default" "ccadmin") $cdomains -}}
+{{- $cdomainsWithoutSupportProjects := .Values.global.domain_seeds.customer_domains_without_support_projects | required "missing value for .Values.global.domain_seeds.customer_domains_without_support_projects" -}}
+
+
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:
@@ -9,24 +14,14 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   requires:
-  - domain-default-seed
-  - domain-ccadmin-seed
-  - monsoon3/domain-ccadmin-seed
-  - monsoon3/domain-cis-seed
-  - monsoon3/domain-bs-seed
-  - monsoon3/domain-btp-fp-seed
-  - monsoon3/domain-fsn-seed
-  - monsoon3/domain-hda-seed
-  - monsoon3/domain-hcm-seed
-  - monsoon3/domain-hcp03-seed
-  - monsoon3/domain-hec-seed
-  - monsoon3/domain-kyma-seed
-  - monsoon3/domain-monsoon3-seed
-  - monsoon3/domain-s4-seed
-  - monsoon3/domain-wbs-seed
-{{- if .Values.tempest.enabled }}
+  {{- range $domains}}
+  {{- if not (contains "iaas-" .)}}
+  - monsoon3/domain-{{replace "_" "-" . | lower}}-seed
+  {{- end }}
+  {{- end }}
+  {{- if .Values.tempest.enabled }}
   - monsoon3/domain-tempest-seed
-{{- end }}
+  {{- end }}
   - swift/swift-seed
 
   roles:
@@ -49,6 +44,10 @@ spec:
     - interface: internal
       region: {{ .Values.global.region | quote }}
       url: http://{{include "glance_api_endpoint_host_internal" .}}:{{.Values.api_port_internal}}
+
+  # default and tempest get special handling
+  # ccadmin gets additional role assignments for projects and some group assignments
+  # iaas- is excluded
 
   domains:
   - name: Default
@@ -73,7 +72,29 @@ spec:
       - project: admin
         role: cloud_image_admin
 
-  - name: ccadmin
+  {{- if .Values.tempest.enabled }}
+  - name: tempest
+    projects:
+    - name: admin
+      role_assignments:
+      - user: admin
+        role: cloud_image_admin
+      - user: admin@Default
+        role: cloud_image_admin
+    - name: tempest1
+      role_assignments:
+      - user: admin@Default
+        role: cloud_image_admin
+    - name: tempest2
+      role_assignments:
+      - user: admin@Default
+        role: cloud_image_admin
+  {{- end }}
+
+  {{- range $domains}}
+  {{- if and (ne . "Default") (not (contains "iaas-" .))}}
+  - name: {{ . }}
+    {{- if eq . "ccadmin" }}
     projects:
     - name: master
       role_assignments:
@@ -86,512 +107,84 @@ spec:
       role_assignments:
       - user: image-build@Default
         role: cloud_image_admin
+    {{- end}}
     groups:
+    {{- if eq . "ccadmin" }}
     - name: CCADMIN_CLOUD_ADMINS
       role_assignments:
       - project: master
         role: cloud_image_admin
       - project: cloud_admin
         role: cloud_image_admin
-    - name: CCADMIN_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: image_admin
-      - project: api_tools
-        role: image_admin
-      - domain: ccadmin
-        role: image_admin
-        inherited: true
-    - name: CCADMIN_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: image_admin
-      - project: compute_tools
-        role: image_admin
-      - domain: ccadmin
-        role: image_admin
-        inherited: true
-    - name: CCADMIN_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: image_admin
-      - project: network_tools
-        role: image_admin
-      - domain: ccadmin
-        role: image_viewer
-        inherited: true
-    - name: CCADMIN_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: image_admin
-      - project: storage_tools
-        role: image_admin
-      - domain: ccadmin
-        role: image_viewer
-        inherited: true
-    - name: CCADMIN_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: image_admin
-
-  - name: cis
-    groups:
-    - name: CIS_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: image_admin
-      - domain: cis
-        role: image_admin
-        inherited: true
-    - name: CIS_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: image_admin
-      - domain: cis
-        role: image_admin
-        inherited: true
-    - name: CIS_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: image_admin
-      - domain: cis
-        role: image_viewer
-        inherited: true
-    - name: CIS_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: image_admin
-      - domain: cis
-        role: image_viewer
-        inherited: true
-    - name: CIS_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: image_admin
-      - domain: cis
-        role: image_viewer
-        inherited: true
-
-  - name: bs
-    groups:
-    - name: BS_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: image_admin
-      - domain: bs
-        role: image_admin
-        inherited: true
-    - name: BS_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: image_admin
-      - domain: bs
-        role: image_admin
-        inherited: true
-    - name: BS_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: image_admin
-      - domain: bs
-        role: image_viewer
-        inherited: true
-    - name: BS_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: image_admin
-      - domain: bs
-        role: image_viewer
-        inherited: true
-    - name: BS_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: image_admin
-      - domain: bs
-        role: image_viewer
-        inherited: true
-
-  - name: btp_fp
-    groups:
-    - name: BTP_FP_API_SUPPORT
-      role_assignments:
-      - domain: btp_fp
-        role: image_admin
-        inherited: true
-    - name: BTP_FP_COMPUTE_SUPPORT
-      role_assignments:
-      - domain: btp_fp
-        role: image_admin
-        inherited: true
-    - name: BTP_FP_NETWORK_SUPPORT
-      role_assignments:
-      - domain: btp_fp
-        role: image_viewer
-        inherited: true
-    - name: BTP_FP_STORAGE_SUPPORT
-      role_assignments:
-      - domain: btp_fp
-        role: image_viewer
-        inherited: true
-    - name: BTP_FP_SERVICE_DESK
-      role_assignments:
-      - domain: btp_fp
-        role: image_viewer
-        inherited: true
-
-  - name: fsn
-    groups:
-    - name: FSN_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: image_admin
-      - domain: fsn
-        role: image_admin
-        inherited: true
-    - name: FSN_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: image_admin
-      - domain: fsn
-        role: image_admin
-        inherited: true
-    - name: FSN_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: image_admin
-      - domain: fsn
-        role: image_viewer
-        inherited: true
-    - name: FSN_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: image_admin
-      - domain: fsn
-        role: image_viewer
-        inherited: true
-    - name: FSN_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: image_admin
-      - domain: fsn
-        role: image_viewer
-        inherited: true
-
-  - name: hda
-    groups:
-    - name: HDA_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: image_admin
-      - domain: hda
-        role: image_admin
-        inherited: true
-    - name: HDA_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: image_admin
-      - domain: hda
-        role: image_admin
-        inherited: true
-    - name: HDA_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: image_admin
-      - domain: hda
-        role: image_viewer
-        inherited: true
-    - name: HDA_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: image_admin
-      - domain: hda
-        role: image_viewer
-        inherited: true
-    - name: HDA_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: image_admin
-      - domain: hda
-        role: image_viewer
-        inherited: true
-
-{{- if not .Values.global.domain_seeds.skip_hcm_domain }}
-  - name: hcm
-    groups:
-    - name: HCM_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: image_admin
-      - domain: hcm
-        role: image_admin
-        inherited: true
-    - name: HCM_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: image_admin
-      - domain: hcm
-        role: image_admin
-        inherited: true
-    - name: HCM_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: image_admin
-      - domain: hcm
-        role: image_viewer
-        inherited: true
-    - name: HCM_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: image_admin
-      - domain: hcm
-        role: image_viewer
-        inherited: true
-    - name: HCM_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: image_admin
-      - domain: hcm
-        role: image_viewer
-        inherited: true
-{{- end }}
-
-  - name: hcp03
-    groups:
-    - name: HCP03_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: image_admin
-      - domain: hcp03
-        role: image_admin
-        inherited: true
-    - name: HCP03_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: image_admin
-      - domain: hcp03
-        role: image_admin
-        inherited: true
-    - name: HCP03_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: image_admin
-      - domain: hcp03
-        role: image_viewer
-        inherited: true
-    - name: HCP03_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: image_admin
-      - domain: hcp03
-        role: image_viewer
-        inherited: true
-    - name: HCP03_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: image_admin
-      - domain: hcp03
-        role: image_viewer
-        inherited: true
-
-
-  - name: hec
-    groups:
-    - name: HEC_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: image_admin
-      - domain: hec
-        role: image_admin
-        inherited: true
-    - name: HEC_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: image_admin
-      - domain: hec
-        role: image_admin
-        inherited: true
-    - name: HEC_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: image_admin
-      - domain: hec
-        role: image_viewer
-        inherited: true
-    - name: HEC_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: image_admin
-      - domain: hec
-        role: image_viewer
-        inherited: true
-    - name: HEC_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: image_admin
-      - domain: hec
-        role: image_viewer
-        inherited: true
-
-  - name: kyma
-    groups:
-    - name: KYMA_API_SUPPORT
-      role_assignments:
-      - domain: kyma
-        role: image_admin
-        inherited: true
-    - name: KYMA_COMPUTE_SUPPORT
-      role_assignments:
-      - domain: kyma
-        role: image_admin
-        inherited: true
-    - name: KYMA_NETWORK_SUPPORT
-      role_assignments:
-      - domain: kyma
-        role: image_viewer
-        inherited: true
-    - name: KYMA_STORAGE_SUPPORT
-      role_assignments:
-      - domain: kyma
-        role: image_viewer
-        inherited: true
-    - name: KYMA_SERVICE_DESK
-      role_assignments:
-      - domain: kyma
-        role: image_viewer
-        inherited: true
-
-  - name: monsoon3
-    groups:
+    {{- end}}
+    {{- if eq . "monsoon3"}}
     - name: MONSOON3_DOMAIN_ADMINS
       role_assignments:
       - project: cc-demo
         role: image_admin
-    - name: MONSOON3_API_SUPPORT
+    {{- end}}
+    - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_API_SUPPORT
       role_assignments:
+      {{- if not (has . $cdomainsWithoutSupportProjects) }}
       - project: api_support
         role: image_admin
-      - domain: monsoon3
+      {{- end}}
+      {{- if eq . "ccadmin" }}
+      - project: api_tools
+        role: image_admin
+      {{- end}}
+      - domain: {{ . }}
         role: image_admin
         inherited: true
-    - name: MONSOON3_COMPUTE_SUPPORT
+    - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_COMPUTE_SUPPORT
       role_assignments:
+      {{- if not (has . $cdomainsWithoutSupportProjects) }}
       - project: compute_support
         role: image_admin
-      - domain: monsoon3
+      {{- end}}
+      {{- if eq . "ccadmin" }}
+      - project: compute_tools
+        role: image_admin
+      {{- end}}
+      - domain: {{ . }}
         role: image_admin
         inherited: true
-    - name: MONSOON3_NETWORK_SUPPORT
+    - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_NETWORK_SUPPORT
       role_assignments:
+      {{- if not (has . $cdomainsWithoutSupportProjects) }}
       - project: network_support
         role: image_admin
-      - domain: monsoon3
+      {{- end}}
+      {{- if eq . "ccadmin" }}
+      - project: network_tools
+        role: image_admin
+      {{- end}}
+      - domain: {{ . }}
         role: image_viewer
         inherited: true
-    - name: MONSOON3_STORAGE_SUPPORT
+    - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_STORAGE_SUPPORT
       role_assignments:
+      {{- if not (has . $cdomainsWithoutSupportProjects) }}
       - project: storage_support
         role: image_admin
-      - domain: monsoon3
+      {{- end}}
+      {{- if eq . "ccadmin" }}
+      - project: storage_tools
+        role: image_admin
+      {{- end}}
+      - domain: {{ . }}
         role: image_viewer
         inherited: true
-    - name: MONSOON3_SERVICE_DESK
+    - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_SERVICE_DESK
       role_assignments:
+      {{- if not (has . $cdomainsWithoutSupportProjects) }}
       - project: service_desk
         role: image_admin
-      - domain: monsoon3
+      {{- end}}
+      {{- if ne . "ccadmin" }}
+      - domain: {{ .}}
         role: image_viewer
         inherited: true
-
-  - name: s4
-    groups:
-    - name: S4_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: image_admin
-      - domain: s4
-        role: image_admin
-        inherited: true
-    - name: S4_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: image_admin
-      - domain: s4
-        role: image_admin
-        inherited: true
-    - name: S4_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: image_admin
-      - domain: s4
-        role: image_viewer
-        inherited: true
-    - name: S4_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: image_admin
-      - domain: s4
-        role: image_viewer
-        inherited: true
-    - name: S4_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: image_admin
-      - domain: s4
-        role: image_viewer
-        inherited: true
-
-  - name: wbs
-    groups:
-    - name: WBS_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: image_admin
-      - domain: wbs
-        role: image_admin
-        inherited: true
-    - name: WBS_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: image_admin
-      - domain: wbs
-        role: image_admin
-        inherited: true
-    - name: WBS_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: image_admin
-      - domain: wbs
-        role: image_viewer
-        inherited: true
-    - name: WBS_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: image_admin
-      - domain: wbs
-        role: image_viewer
-        inherited: true
-    - name: WBS_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: image_admin
-      - domain: wbs
-        role: image_viewer
-        inherited: true
-
-{{- if .Values.tempest.enabled }}
-  - name: tempest
-    projects:
-    - name: admin
-      role_assignments:
-        - user: admin
-          role: cloud_image_admin
-        - user: admin@Default
-          role: cloud_image_admin
-    - name: tempest1
-      role_assignments:
-        - user: admin@Default
-          role: cloud_image_admin
-    - name: tempest2
-      role_assignments:
-        - user: admin@Default
-          role: cloud_image_admin
-{{- end }}
+      {{- end}}
+  {{- end}}
+  {{- end}}


### PR DESCRIPTION
In an attempt to make deployment of new domains easier, @majewsky recently introduced `global.domain_seeds.customer_domains`. As this could replace the old `skip_hcm_domain`, poses the opportunity to distinguish between internal and external domains in future and accommodate other specialties we would like to suggest this on seeds of other services too.