### PR TITLE
[arc] seed generic domains using global.domain_seeds

### DIFF
--- a/openstack/arc/ci/test-values.yaml
+++ b/openstack/arc/ci/test-values.yaml
@@ -4,7 +4,8 @@ global:
   dockerHubMirror: keppel.example.com/dockerhub
   quayIoMirror: keppel.example.com/quayio
   domain_seeds:
-    skip_hcm_domain: false
+    customer_domains: [bar, foo, baz]
+    customer_domains_without_support_projects: [baz]
 
 api:
   tls:

--- a/openstack/arc/templates/seed.yaml
+++ b/openstack/arc/templates/seed.yaml
@@ -1,3 +1,7 @@
+{{- $cdomains := .Values.global.domain_seeds.customer_domains | required "missing value for .Values.global.domain_seeds.customer_domains" -}}
+{{- $domains  := concat (list "ccadmin" "cc3test") $cdomains -}}
+{{- $cdomainsWithoutSupportProjects := .Values.global.domain_seeds.customer_domains_without_support_projects | required "missing value for .Values.global.domain_seeds.customer_domains_without_support_projects" -}}
+
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:
@@ -8,6 +12,13 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+  requires:
+    requires:
+      {{- range $domains}}
+      {{- if not (hasPrefix "iaas-" .)}}
+    - monsoon3/domain-{{replace "_" "-" . | lower}}-seed
+      {{- end }}
+      {{- end }}
   services:
     - name: Arc
       type: arc
@@ -19,442 +30,12 @@ spec:
   roles:
   - name: automation_admin
   - name: automation_viewer
+
+  # cc3test gets special handling
+  # ccadmin gets additional role assignments for projects and some group assignments
+  # iaas- is excluded
+
   domains:
-  - name: ccadmin
-{{- if .Values.updatesProxy.createContainers }}
-    projects:
-    - name: master
-      swift:
-        enabled: true
-        containers:
-{{- range $channel := .Values.updatesProxy.channels  }}
-        - name: {{ $channel.container }}
-          metadata:
-            meta-web-listings: 'true'
-            read: .r:*,.rlistings
-{{- end }}
-{{- end }}
-    groups:
-    - name: CCADMIN_API_SUPPORT
-      role_assignments:
-      - domain: ccadmin
-        role: automation_admin
-        inherited: true
-    - name: CCADMIN_COMPUTE_SUPPORT
-      role_assignments:
-      - domain: ccadmin
-        role: automation_viewer
-        inherited: true
-    - name: CCADMIN_NETWORK_SUPPORT
-      role_assignments:
-      - domain: ccadmin
-        role: automation_viewer
-        inherited: true
-    - name: CCADMIN_STORAGE_SUPPORT
-      role_assignments:
-      - domain: ccadmin
-        role: automation_viewer
-        inherited: true
-    - name: CCADMIN_SERVICE_DESK
-      role_assignments:
-      - domain: ccadmin
-        role: automation_viewer
-        inherited: true
-
-  - name: btp_fp
-    groups:
-    - name: BTP_FP_API_SUPPORT
-      role_assignments:
-      - domain: btp_fp
-        role: automation_admin
-        inherited: true
-    - name: BTP_FP_COMPUTE_SUPPORT
-      role_assignments:
-      - domain: btp_fp
-        role: automation_viewer
-        inherited: true
-    - name: BTP_FP_NETWORK_SUPPORT
-      role_assignments:
-      - domain: btp_fp
-        role: automation_viewer
-        inherited: true
-    - name: BTP_FP_STORAGE_SUPPORT
-      role_assignments:
-      - domain: btp_fp
-        role: automation_viewer
-        inherited: true
-    - name: BTP_FP_SERVICE_DESK
-      role_assignments:
-      - domain: btp_fp
-        role: automation_viewer
-        inherited: true
-
-  - name: bs
-    groups:
-    - name: BS_API_SUPPORT
-      role_assignments:
-      - domain: bs
-        role: automation_admin
-        inherited: true
-    - name: BS_COMPUTE_SUPPORT
-      role_assignments:
-      - domain: bs
-        role: automation_viewer
-        inherited: true
-    - name: BS_NETWORK_SUPPORT
-      role_assignments:
-      - domain: bs
-        role: automation_viewer
-        inherited: true
-    - name: BS_STORAGE_SUPPORT
-      role_assignments:
-      - domain: bs
-        role: automation_viewer
-        inherited: true
-    - name: BS_SERVICE_DESK
-      role_assignments:
-      - domain: bs
-        role: automation_viewer
-        inherited: true
-
-  - name: cis
-    groups:
-    - name: CIS_API_SUPPORT
-      role_assignments:
-      - domain: cis
-        role: automation_admin
-        inherited: true
-    - name: CIS_COMPUTE_SUPPORT
-      role_assignments:
-      - domain: cis
-        role: automation_viewer
-        inherited: true
-    - name: CIS_NETWORK_SUPPORT
-      role_assignments:
-      - domain: cis
-        role: automation_viewer
-        inherited: true
-    - name: CIS_STORAGE_SUPPORT
-      role_assignments:
-      - domain: cis
-        role: automation_viewer
-        inherited: true
-    - name: CIS_SERVICE_DESK
-      role_assignments:
-      - domain: cis
-        role: automation_viewer
-        inherited: true
-
-  - name: cp
-    groups:
-    - name: CP_API_SUPPORT
-      role_assignments:
-      - domain: cp
-        role: automation_admin
-        inherited: true
-    - name: CP_COMPUTE_SUPPORT
-      role_assignments:
-      - domain: cp
-        role: automation_viewer
-        inherited: true
-    - name: CP_NETWORK_SUPPORT
-      role_assignments:
-      - domain: cp
-        role: automation_viewer
-        inherited: true
-    - name: CP_STORAGE_SUPPORT
-      role_assignments:
-      - domain: cp
-        role: automation_viewer
-        inherited: true
-    - name: CP_SERVICE_DESK
-      role_assignments:
-      - domain: cp
-        role: automation_viewer
-        inherited: true
-
-  - name: fsn
-    groups:
-    - name: FSN_API_SUPPORT
-      role_assignments:
-      - domain: fsn
-        role: automation_admin
-        inherited: true
-    - name: FSN_COMPUTE_SUPPORT
-      role_assignments:
-      - domain: fsn
-        role: automation_viewer
-        inherited: true
-    - name: FSN_NETWORK_SUPPORT
-      role_assignments:
-      - domain: fsn
-        role: automation_viewer
-        inherited: true
-    - name: FSN_STORAGE_SUPPORT
-      role_assignments:
-      - domain: fsn
-        role: automation_viewer
-        inherited: true
-    - name: FSN_SERVICE_DESK
-      role_assignments:
-      - domain: fsn
-        role: automation_viewer
-        inherited: true
-
-{{- if not .Values.global.domain_seeds.skip_hcm_domain }}
-  - name: hcm
-    groups:
-    - name: HCM_API_SUPPORT
-      role_assignments:
-      - domain: hcm
-        role: automation_admin
-        inherited: true
-    - name: HCM_COMPUTE_SUPPORT
-      role_assignments:
-      - domain: hcm
-        role: automation_viewer
-        inherited: true
-    - name: HCM_NETWORK_SUPPORT
-      role_assignments:
-      - domain: hcm
-        role: automation_viewer
-        inherited: true
-    - name: HCM_STORAGE_SUPPORT
-      role_assignments:
-      - domain: hcm
-        role: automation_viewer
-        inherited: true
-    - name: HCM_SERVICE_DESK
-      role_assignments:
-      - domain: hcm
-        role: automation_viewer
-        inherited: true
-{{- end }}
-
-  - name: hda
-    groups:
-    - name: HDA_API_SUPPORT
-      role_assignments:
-      - domain: hda
-        role: automation_admin
-        inherited: true
-    - name: HDA_COMPUTE_SUPPORT
-      role_assignments:
-      - domain: hda
-        role: automation_viewer
-        inherited: true
-    - name: HDA_NETWORK_SUPPORT
-      role_assignments:
-      - domain: hda
-        role: automation_viewer
-        inherited: true
-    - name: HDA_STORAGE_SUPPORT
-      role_assignments:
-      - domain: hda
-        role: automation_viewer
-        inherited: true
-    - name: HDA_SERVICE_DESK
-      role_assignments:
-      - domain: hda
-        role: automation_viewer
-        inherited: true
-
-  - name: hcp03
-    groups:
-    - name: HCP03_API_SUPPORT
-      role_assignments:
-      - domain: hcp03
-        role: automation_admin
-        inherited: true
-    - name: HCP03_COMPUTE_SUPPORT
-      role_assignments:
-      - domain: hcp03
-        role: automation_viewer
-        inherited: true
-    - name: HCP03_NETWORK_SUPPORT
-      role_assignments:
-      - domain: hcp03
-        role: automation_viewer
-        inherited: true
-    - name: HCP03_STORAGE_SUPPORT
-      role_assignments:
-      - domain: hcp03
-        role: automation_viewer
-        inherited: true
-    - name: HCP03_SERVICE_DESK
-      role_assignments:
-      - domain: hcp03
-        role: automation_viewer
-        inherited: true
-
-  - name: hec
-    groups:
-    - name: HEC_API_SUPPORT
-      role_assignments:
-      - domain: hec
-        role: automation_admin
-        inherited: true
-    - name: HEC_COMPUTE_SUPPORT
-      role_assignments:
-      - domain: hec
-        role: automation_viewer
-        inherited: true
-    - name: HEC_NETWORK_SUPPORT
-      role_assignments:
-      - domain: hec
-        role: automation_viewer
-        inherited: true
-    - name: HEC_STORAGE_SUPPORT
-      role_assignments:
-      - domain: hec
-        role: automation_viewer
-        inherited: true
-    - name: HEC_SERVICE_DESK
-      role_assignments:
-      - domain: hec
-        role: automation_viewer
-        inherited: true
-
-  - name: kyma
-    groups:
-    - name: KYMA_API_SUPPORT
-      role_assignments:
-      - domain: kyma
-        role: automation_admin
-        inherited: true
-    - name: KYMA_COMPUTE_SUPPORT
-      role_assignments:
-      - domain: kyma
-        role: automation_viewer
-        inherited: true
-    - name: KYMA_NETWORK_SUPPORT
-      role_assignments:
-      - domain: kyma
-        role: automation_viewer
-        inherited: true
-    - name: KYMA_STORAGE_SUPPORT
-      role_assignments:
-      - domain: kyma
-        role: automation_viewer
-        inherited: true
-    - name: KYMA_SERVICE_DESK
-      role_assignments:
-      - domain: kyma
-        role: automation_viewer
-        inherited: true
-
-  - name: monsoon3
-    groups:
-    - name: MONSOON3_API_SUPPORT
-      role_assignments:
-      - domain: monsoon3
-        role: automation_admin
-        inherited: true
-    - name: MONSOON3_COMPUTE_SUPPORT
-      role_assignments:
-      - domain: monsoon3
-        role: automation_viewer
-        inherited: true
-    - name: MONSOON3_NETWORK_SUPPORT
-      role_assignments:
-      - domain: monsoon3
-        role: automation_viewer
-        inherited: true
-    - name: MONSOON3_STORAGE_SUPPORT
-      role_assignments:
-      - domain: monsoon3
-        role: automation_viewer
-        inherited: true
-    - name: MONSOON3_SERVICE_DESK
-      role_assignments:
-      - domain: monsoon3
-        role: automation_viewer
-        inherited: true
-
-  - name: neo
-    groups:
-    - name: NEO_API_SUPPORT
-      role_assignments:
-      - domain: neo
-        role: automation_admin
-        inherited: true
-    - name: NEO_COMPUTE_SUPPORT
-      role_assignments:
-      - domain: neo
-        role: automation_viewer
-        inherited: true
-    - name: NEO_NETWORK_SUPPORT
-      role_assignments:
-      - domain: neo
-        role: automation_viewer
-        inherited: true
-    - name: NEO_STORAGE_SUPPORT
-      role_assignments:
-      - domain: neo
-        role: automation_viewer
-        inherited: true
-    - name: NEO_SERVICE_DESK
-      role_assignments:
-      - domain: neo
-        role: automation_viewer
-        inherited: true
-
-  - name: s4
-    groups:
-    - name: S4_API_SUPPORT
-      role_assignments:
-      - domain: s4
-        role: automation_admin
-        inherited: true
-    - name: S4_COMPUTE_SUPPORT
-      role_assignments:
-      - domain: s4
-        role: automation_viewer
-        inherited: true
-    - name: S4_NETWORK_SUPPORT
-      role_assignments:
-      - domain: s4
-        role: automation_viewer
-        inherited: true
-    - name: S4_STORAGE_SUPPORT
-      role_assignments:
-      - domain: s4
-        role: automation_viewer
-        inherited: true
-    - name: S4_SERVICE_DESK
-      role_assignments:
-      - domain: s4
-        role: automation_viewer
-        inherited: true
-
-  - name: wbs
-    groups:
-    - name: WBS_API_SUPPORT
-      role_assignments:
-      - domain: wbs
-        role: automation_admin
-        inherited: true
-    - name: WBS_COMPUTE_SUPPORT
-      role_assignments:
-      - domain: wbs
-        role: automation_viewer
-        inherited: true
-    - name: WBS_NETWORK_SUPPORT
-      role_assignments:
-      - domain: wbs
-        role: automation_viewer
-        inherited: true
-    - name: WBS_STORAGE_SUPPORT
-      role_assignments:
-      - domain: wbs
-        role: automation_viewer
-        inherited: true
-    - name: WBS_SERVICE_DESK
-      role_assignments:
-      - domain: wbs
-        role: automation_viewer
-        inherited: true
-
   - name: cc3test
     groups:
     - name: CC3TEST_API_SUPPORT
@@ -462,3 +43,48 @@ spec:
       - domain: cc3test
         role: automation_admin
         inherited: true
+
+  {{- range $domains }}
+  {{- if and (ne . "cc3test") (not (hasPrefix "iaas-" .))}}
+  - name: {{ . }}
+    {{- if and $.Values.updatesProxy.createContainers (eq . "ccadmin")}}
+    projects:
+    - name: master
+      swift:
+        enabled: true
+        containers:
+        {{- range $channel := $.Values.updatesProxy.channels  }}
+        - name: {{ $channel.container }}
+          metadata:
+            meta-web-listings: 'true'
+            read: .r:*,.rlistings
+        {{- end }}
+    {{- end }}
+    groups:
+    - name: {{ hasPrefix "iaas-" . | ternary . ( upper . ) }}_API_SUPPORT
+      role_assignments:
+      - domain: {{ . }}
+        role: automation_admin
+        inherited: true
+    - name: {{ hasPrefix "iaas-" . | ternary . ( upper . ) }}_COMPUTE_SUPPORT
+      role_assignments:
+      - domain: {{ . }}
+        role: automation_viewer
+        inherited: true
+    - name: {{ hasPrefix "iaas-" . | ternary . ( upper . ) }}_NETWORK_SUPPORT
+      role_assignments:
+      - domain: {{ . }}
+        role: automation_viewer
+        inherited: true
+    - name: {{ hasPrefix "iaas-" . | ternary . ( upper . ) }}_STORAGE_SUPPORT
+      role_assignments:
+      - domain: {{ . }}
+        role: automation_viewer
+        inherited: true
+    - name: {{ hasPrefix "iaas-" . | ternary . ( upper . ) }}_SERVICE_DESK
+      role_assignments:
+      - domain: {{ . }}
+        role: automation_viewer
+        inherited: true
+  {{- end }}
+  {{- end }}


### PR DESCRIPTION
In an attempt to make deployment of new domains easier, @majewsky recently introduced `global.domain_seeds.customer_domains`. As this could replace the old `skip_hcm_domain`, poses the opportunity to distinguish between internal and external domains in future and accommodate other specialties we would like to suggest this on seeds of other services too.

The expressions are technically equal, only the `ora` domain was added. If it was excluded on purpose, let me know and I can change it. I excluded iaas- for now.
I ran h3 diff with dyff option against qa-de-1 and eu-de-1 you can have a look at the output here:
[arcQA1diff.txt](https://github.com/user-attachments/files/19465110/arcQA1diff.txt)
[arcDE1diff.txt](https://github.com/user-attachments/files/19465111/arcDE1diff.txt)
