### PR TITLE
[glance] don't add mutable annotations to the immutable job spec

### DIFF
--- a/openstack/glance/Chart.yaml
+++ b/openstack/glance/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: dalmatian
 description: A Helm chart Openstack Glance
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Glance/OpenStack_Project_Glance_vertical.png
 name: glance
-version: 0.6.6
+version: 0.6.7
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/glance/templates/migration-job.yaml
+++ b/openstack/glance/templates/migration-job.yaml
@@ -19,9 +19,6 @@ spec:
         alert-service: glance
 {{ tuple . "glance" "migration" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
       annotations:
-        chart-version: {{.Chart.Version}}
-        checksum/etc-configmap.conf: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
-        secrets-hash: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
 {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
       restartPolicy: OnFailure


### PR DESCRIPTION
Don't add annotations that could be changed on configuration or chart change, but can't be updated, because Job is immutable.

This prevents helm upgrade failure, when we have only configuration or chart update without a glance image tag change