### PR TITLE
[keystone][mariadb] bump chart dependency

### DIFF
--- a/openstack/keystone/Chart.lock
+++ b/openstack/keystone/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.16.9
+  version: 0.19.1
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.3.1
@@ -10,7 +10,7 @@ dependencies:
   version: 0.6.9
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.4.2
+  version: 0.4.3
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:b9a56b25cf79c1c9871d20caa3887a158c514b3e671d6b94c533948a019936f9
-generated: "2025-03-25T17:12:07.427279+02:00"
+digest: sha256:76c5dabd8dbf31dfd75edec0e1733864727d39ae90ea84d39e3a72c437ef7aa0
+generated: "2025-04-03T12:40:00.143144+03:00"

--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -9,12 +9,12 @@ maintainers:
 name: keystone
 sources:
   - https://github.com/sapcc/keystone
-version: 0.10.0
+version: 0.10.1
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.16.9
+    version: 0.19.1
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db
@@ -26,7 +26,7 @@ dependencies:
   - condition: mysql_metrics.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.4.2
+    version: 0.4.3
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0


### PR DESCRIPTION
Updates mariadb chart from 0.16.9 to 0.19.1:
* adds user-credential-updater sidecar
* allows to update root user password without database downtime

Updates mysql-metrics chart to 0.4.3:
* adds option to set vpa main container
