### PR TITLE
[Nova] Set external_customer_domain_name_prefixes

### DIFF
--- a/openstack/nova/templates/etc/_nova-scheduler.conf.tpl
+++ b/openstack/nova/templates/etc/_nova-scheduler.conf.tpl
@@ -10,6 +10,7 @@ discover_hosts_in_cells_interval = 60
 workers = {{ .Values.scheduler.workers }}
 driver_task_period = {{ .Values.scheduler.driver_task_period | default 60 }}
 query_placement_for_availability_zone = {{ not (contains "AvailabilityZoneFilter" .Values.scheduler.default_filters) }}
+external_customer_domain_name_prefixes = {{ .Values.scheduler.external_customer_domain_name_prefixes }}
 
 [filter_scheduler]
 available_filters = {{ .Values.scheduler.available_filters | default "nova.scheduler.filters.all_filters" }}

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -288,6 +288,8 @@ scheduler:
   aggregate_multi_tenancy_isolation_weight_multiplier: 50.0
 
   image_properties_default_architecture: "x86_64"
+  # comma-separated list of prefixes for external domains
+  external_customer_domain_name_prefixes: "iaas-"
 
 compute:
   defaults:


### PR DESCRIPTION
We need to keep external customers on specific hosts for licensing reasons. We do this in `nova-scheduler` by prefix-matching domain names in a special filter, which adds the `CUSTOM_EXTERNAL_CUSTOMER_SUPPORTED` to filter hosts in Placement.

This commit configures the default for all regions to "iaas-".

---

This is configuring the feature we add in https://github.com/sapcc/nova/pull/536