### PR TITLE
[nova][pxc-db] Add support for PXC galera cluster: part 1

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -2,9 +2,15 @@ dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.18.2
+- name: pxc-db
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 0.3.1
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.18.2
+- name: pxc-db
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 0.3.1
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.4.2
@@ -20,6 +26,9 @@ dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.18.2
+- name: pxc-db
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 0.3.1
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.17.1
@@ -29,5 +38,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:d3af75f45a7a63591606b3087f1bd04aee1ee2d779c9a413cc2c6bd138cc21b7
-generated: "2025-03-24T15:36:23.710172+02:00"
+digest: sha256:f97d54bed24e21fb5239ccb5f30182d65abd6073c764bb83a27efb085832fa6c
+generated: "2025-03-26T17:15:15.480775+02:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -1,19 +1,30 @@
+---
 apiVersion: v2
 description: A Helm chart for Kubernetes
 name: nova
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Nova/OpenStack_Project_Nova_mascot.png
-version: 0.4.2
+version: 0.5.0
 appVersion: "rocky"
 dependencies:
   - name: mariadb
     condition: mariadb.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.18.2
+  - condition: pxc_db.enabled
+    name: pxc-db
+    alias: pxc_db
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: 0.3.1
   - name: mariadb
     alias: mariadb_api
     condition: mariadb_api.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.18.2
+  - condition: pxc_db_api.enabled
+    name: pxc-db
+    alias: pxc_db_api
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: 0.3.1
   - name: mysql_metrics
     condition: mariadb.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
@@ -32,6 +43,11 @@ dependencies:
     condition: mariadb_cell2.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.18.2
+  - condition: pxc_db_cell2.enabled
+    name: pxc-db
+    alias: pxc_db_cell2
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: 0.3.1
   - name: rabbitmq
     alias: rabbitmq_cell2
     condition: cell2.enabled

--- a/openstack/nova/ci/test-values.yaml
+++ b/openstack/nova/ci/test-values.yaml
@@ -1,3 +1,4 @@
+---
 global:
   accessControlAllowOrigin: '*'
   region: regionOne
@@ -9,7 +10,6 @@ global:
   tld: regionOne.cloud
   domain_seeds:
     skip_hcm_domain: false
-
   master_password: topSecret
   nova_service_password: topSecret
   availability_zones:
@@ -33,11 +33,41 @@ mariadb:
       name: nova
       password: password
 
+pxc_db:
+  enabled: false
+  users:
+    nova:
+      password: topSecret!
+    nova_cell0:
+      password: topSecret!
+  system_users:
+    root:
+      password: topSecret!
+    xtrabackup:
+      password: topSecret!
+    monitor:
+      password: topSecret!
+    proxyadmin:
+      password: topSecret!
+    operator:
+      password: topSecret!
+    replication:
+      password: topSecret!
+  backup:
+    s3:
+      secrets:
+        aws_access_key_id: topSecret!
+        aws_secret_access_key: topSecret!
+
+mysql_metrics:
+  db_password: topSecret!
+
 dbPassword: top-secret
 cell0dbPassword: very-secret
 apidbPassword: much-secret
 
 mariadb_api:
+  root_password: rootroot
   enabled: false
   backup:
     enabled: false

--- a/openstack/nova/templates/_helpers.tpl
+++ b/openstack/nova/templates/_helpers.tpl
@@ -1,16 +1,16 @@
 {{- define "nova.helpers.ini_sections.api_database" }}
 
 [api_database]
-connection = {{ tuple . .Values.apidbName .Values.apidbUser .Values.apidbPassword .Values.mariadb_api.name | include "db_url_mysql" }}
+connection = {{ tuple . .Values.apidbName .Values.apidbUser .Values.apidbPassword .Values.mariadb_api.name .Values.apidbType | include "utils.db_url" }}
 {{- include "ini_sections.database_options_mysql" . }}
 {{- end }}
 
 {{- define "cell0_db_path" }}
-    {{- tuple . .Values.cell0dbName .Values.cell0dbUser (default .Values.cell0dbPassword .Values.global.dbPassword) | include "db_url_mysql" }}
+    {{- tuple . .Values.cell0dbName .Values.cell0dbUser (default .Values.cell0dbPassword .Values.global.dbPassword) .Values.mariadb.name .Values.cell0dbType | include "utils.db_url" }}
 {{- end }}
 
 {{- define "cell1_db_path" -}}
-    {{- tuple . .Values.dbName .Values.dbUser (default .Values.dbPassword .Values.global.dbPassword) | include "db_url_mysql" }}
+    {{- tuple . .Values.dbName .Values.dbUser (default .Values.dbPassword .Values.global.dbPassword) .Values.mariadb.name .Values.cell1dbType | include "utils.db_url" }}
 {{- end }}
 
 {{- define "cell1_transport_url" -}}
@@ -23,7 +23,7 @@ connection = {{ tuple . .Values.apidbName .Values.apidbUser .Values.apidbPasswor
 
 {{- define "cell2_db_path" -}}
     {{- if eq .Values.cell2.enabled true -}}
-        {{- tuple . .Values.cell2dbName .Values.cell2dbUser (default .Values.cell2dbPassword .Values.global.dbPassword) .Values.mariadb_cell2.name | include "db_url_mysql" }}
+        {{- tuple . .Values.cell2dbName .Values.cell2dbUser (default .Values.cell2dbPassword .Values.global.dbPassword) .Values.mariadb_cell2.name .Values.cell2dbType | include "utils.db_url" }}
     {{- end }}
 {{- end }}
 

--- a/openstack/nova/templates/_helpers.tpl
+++ b/openstack/nova/templates/_helpers.tpl
@@ -77,21 +77,6 @@ annotations:
   {{- end }}
 {{- end }}
 
-
-{{- define "nova.helpers.database_services" }}
-  {{- $envAll := . }}
-  {{- $dbs := dict }}
-  {{- range $d := $envAll.Chart.Dependencies }}
-    {{- if and (hasPrefix "mariadb" $d.Name) }}
-        {{- $db := get $envAll.Values $d.Name }}
-        {{- if get $db "enabled" }}
-          {{- $_ := set $dbs (print (get $db "name") "-mariadb") $db }}
-        {{- end }}
-    {{- end }}
-  {{- end }}
-  {{- keys $dbs | sortAlpha | join "," }}
-{{- end }}
-
 {{/* TODO: Expose and use the logic in the rabbitmq subchart */}}
 {{- define "nova.helpers.rabbitmq_name" }}
   {{- $vals := index . 1 }}
@@ -109,17 +94,56 @@ annotations:
   {{- tuple . .Values.rabbitmq_cell2 | include "nova.helpers.rabbitmq_name" }}
 {{- end }}
 
+{{- define "nova.helpers.api_db" }}
+  {{- if eq .Values.apidbType "mariadb" }}
+    {{- print .Values.mariadb_api.name "-mariadb" }}
+  {{- else if eq .Values.apidbType "pxc-db" }}
+    {{- print .Values.pxc_db_api.name "-db-haproxy" }}
+  {{- else }}
+    {{- fail (print "Unsupported database type for api_db") }}
+  {{- end }}
+{{- end }}
+
+{{- define "nova.helpers.cell01_db"}}
+  {{- if eq .Values.cell1dbType "mariadb" }}
+    {{- print .Values.mariadb.name "-mariadb" }}
+  {{- else if eq .Values.cell1dbType "pxc-db" }}
+    {{- print .Values.pxc_db.name "-db-haproxy" }}
+  {{- else }}
+    {{- fail (print "Unsupported database type for cell0 and cell1") }}
+  {{- end }}
+{{- end }}
+
+{{- define "nova.helpers.cell2_db"}}
+{{- if .Values.cell2.enabled }}
+  {{- if eq .Values.cell2dbType "mariadb" }}
+    {{- print .Values.mariadb_cell2.name "-mariadb" }}
+  {{- else if eq .Values.cell2dbType "pxc-db" }}
+    {{- print .Values.pxc_db_cell2.name "-db-haproxy" }}
+  {{- else }}
+    {{- fail (print "Unsupported database type for cell2") }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
 {{- define "nova.helpers.cell01_services" }}
-  {{- print .Values.mariadb_api.name "-mariadb," .Values.mariadb.name "-mariadb," (include "nova.helpers.cell01_rabbitmq" .) }}
+  {{- print (include "nova.helpers.api_db" .) "," (include "nova.helpers.cell01_db" .) "," (include "nova.helpers.cell01_rabbitmq" .) }}
 {{- end }}
 
 {{- define "nova.helpers.cell1_services" }}
-  {{- print .Values.mariadb.name "-mariadb," (include "nova.helpers.cell01_rabbitmq" .) }}
+  {{- print (include "nova.helpers.cell01_db" .) "," (include "nova.helpers.cell01_rabbitmq" .) }}
 {{- end }}
 
 {{- define "nova.helpers.cell2_services" }}
   {{- if .Values.cell2.enabled }}
-    {{- print .Values.mariadb_cell2.name "-mariadb," (include "nova.helpers.cell2_rabbitmq" .) }}
+    {{- print (include "nova.helpers.cell2_db" .) "," (include "nova.helpers.cell2_rabbitmq" .) }}
+  {{- end }}
+{{- end }}
+
+{{- define "nova.helpers.all_database_services" }}
+  {{- include "nova.helpers.api_db" . }},{{ include "nova.helpers.cell01_db" . }}
+  {{- if .Values.cell2.enabled }}
+    ,{{ include "nova.helpers.cell2_db" . }}
   {{- end }}
 {{- end }}
 

--- a/openstack/nova/templates/db-migrate-job.yaml
+++ b/openstack/nova/templates/db-migrate-job.yaml
@@ -17,7 +17,7 @@ spec:
       restartPolicy: OnFailure
       {{- include "utils.proxysql.job_pod_settings" . | indent 6 }}
       initContainers:
-      {{- tuple . (dict "service" (include "nova.helpers.database_services" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
+      {{- tuple . (dict "service" (include "nova.helpers.all_database_services" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
       - name: nova-migration
         image: {{ tuple . "api" | include "container_image_nova" }}

--- a/openstack/nova/templates/db-online-migrate-job.yaml
+++ b/openstack/nova/templates/db-online-migrate-job.yaml
@@ -17,7 +17,7 @@ spec:
       restartPolicy: OnFailure
       {{- include "utils.proxysql.job_pod_settings" . | indent 6 }}
       initContainers:
-      {{- $dependencies := dict "jobs" (tuple . "db-migrate" | include "job_name") "service" (include "nova.helpers.database_services" .) }}
+      {{- $dependencies := dict "jobs" (tuple . "db-migrate" | include "job_name") "service" (include "nova.helpers.all_database_services" .) }}
       {{- tuple . $dependencies | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
       - name: nova-migrate

--- a/openstack/nova/templates/etc-secret.yaml
+++ b/openstack/nova/templates/etc-secret.yaml
@@ -14,10 +14,10 @@ stringData:
     connection = {{ include "cell0_db_path" . }}
   cell1.conf: |
     [DEFAULT]
-    {{- include "ini_sections.default_transport_url" . | indent 4 }}
+    transport_url = {{ include "cell1_transport_url" . }}
 
     [database]
-    connection = {{ include "db_url_mysql" . }}
+    connection = {{ include "cell1_db_path" . }}
   {{- if .Values.cell2.enabled }}
   {{ .Values.cell2.name }}.conf: |
     [DEFAULT]

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -127,19 +127,23 @@ debug: "True"
 dbName: nova
 dbUser: nova
 dbPassword: null
+cell1dbType: mariadb
 
 cell0dbName: nova_cell0
 cell0dbUser: nova_cell0
 cell0dbPassword: null
+cell0dbType: mariadb
 
 # cell2dbName should be the same as mariadb_cell2 backup_v2 DB name!
 cell2dbName: nova_cell2
 cell2dbUser: nova_cell2
 cell2dbPassword: null
+cell2dbType: mariadb
 
 apidbName: nova_api
 apidbUser: nova_api
 apidbPassword: null
+apidbType: mariadb
 
 loci:
   nova: false
@@ -783,6 +787,43 @@ mariadb:
           enabled: true
           allTables: true
 
+pxc_db:
+  enabled: false
+  name: nova
+  alerts:
+    support_group: "compute-storage-api"
+  ccroot_user:
+    enabled: true
+  databases:
+    - nova
+    - nova_cell0
+  users:
+    nova:
+      name: nova
+      grants:
+        - "ALL PRIVILEGES on nova.*"
+    nova_cell0:
+      name: nova_cell0
+      grants:
+        - "ALL PRIVILEGES on nova_cell0.*"
+  pxc:
+    configuration:
+      options:
+        max_connections: "2048"
+        innodb_buffer_pool_size: "4096M"
+        innodb_log_file_size: "1024M"
+        long_query_time: "8"
+    persistence:
+      size: 50Gi
+  backup:
+    enabled: true
+    s3:
+      secrets:
+        aws_access_key_id: null
+        aws_secret_access_key: null
+    pitr:
+      enabled: true
+
 mariadb_api:
   enabled: false
   buffer_pool_size: "4096M"
@@ -825,6 +866,38 @@ mariadb_api:
           enabled: true
           allTables: true
 
+pxc_db_api:
+  enabled: false
+  name: nova-api
+  alerts:
+    support_group: "compute-storage-api"
+  ccroot_user:
+    enabled: true
+  databases:
+    - nova_api
+  users:
+    nova_api:
+      name: nova_api
+      grants:
+        - "ALL PRIVILEGES on nova_api.*"
+  pxc:
+    configuration:
+      options:
+        max_connections: "2048"
+        innodb_buffer_pool_size: "4096M"
+        innodb_log_file_size: "1024M"
+        long_query_time: "8"
+    persistence:
+      size: 50Gi
+  backup:
+    enabled: true
+    s3:
+      secrets:
+        aws_access_key_id: null
+        aws_secret_access_key: null
+    pitr:
+      enabled: true
+
 mariadb_cell2:
   enabled: false
   buffer_pool_size: "4096M"
@@ -852,6 +925,32 @@ mariadb_cell2:
         analyzeTable:
           enabled: true
           allTables: true
+
+pxc_db_cell2:
+  enabled: false
+  alerts:
+    support_group: "compute-storage-api"
+  ccroot_user:
+    enabled: true
+  databases: []
+  users: []
+  pxc:
+    configuration:
+      options:
+        max_connections: "2048"
+        innodb_buffer_pool_size: "4096M"
+        innodb_log_file_size: "1024M"
+        long_query_time: "8"
+    persistence:
+      size: 50Gi
+  backup:
+    enabled: true
+    s3:
+      secrets:
+        aws_access_key_id: null
+        aws_secret_access_key: null
+    pitr:
+      enabled: true
 
 rabbitmq_cell2:
   nameOverride: cell2-rabbitmq


### PR DESCRIPTION
* Add optional pxc-db chart dependencies and sample values
* Add required ci/test-values.yaml values
* Use `cell1_transport_url` and `cell1_db_path` helper for cell1.conf similar to the way how cell0 and cell2 are configured
* Replace `db_url_mysql` helper with `utils.db_url` and explicitly pass database name and type to this helper function