### PR TITLE
[glance] move osprofiler configuration to secrets

### DIFF
--- a/openstack/glance/Chart.yaml
+++ b/openstack/glance/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: dalmatian
 description: A Helm chart Openstack Glance
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Glance/OpenStack_Project_Glance_vertical.png
 name: glance
-version: 0.6.6
+version: 0.6.7
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/glance/templates/etc/_glance-api.conf.tpl
+++ b/openstack/glance/templates/etc/_glance-api.conf.tpl
@@ -94,7 +94,3 @@ enforce_scope=False
 
 [barbican]
 auth_endpoint = {{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3
-
-{{- if .Values.osprofiler.enabled }}
-{{- include "osprofiler" . }}
-{{- end }}

--- a/openstack/glance/templates/etc/_secrets.conf.tpl
+++ b/openstack/glance/templates/etc/_secrets.conf.tpl
@@ -19,3 +19,7 @@ swift_store_key = {{ required ".Values.global.glance_service_password is missing
 key = {{ required ".Values.global.glance_service_password is missing" .Values.global.glance_service_password }}
 user = {{ .Values.swift.projectName }}:{{ .Values.global.glance_service_user | default "glance" | replace "$" "$$"}}
 {{- end }}
+
+{{- if .Values.osprofiler.enabled }}
+{{- include "osprofiler" . }}
+{{- end }}


### PR DESCRIPTION
osprofiler configuration contains a secret hmac value, so it should be in the secret instead of a configmap