### PR TITLE
[octavia] move osprofiler configuration to secrets

### DIFF
--- a/openstack/octavia/Chart.yaml
+++ b/openstack/octavia/Chart.yaml
@@ -9,7 +9,7 @@ sources:
   - https://git.openstack.org/cgit/openstack/octavia
   - https://git.openstack.org/cgit/openstack/openstack-helm
 # The versions are defined in the changelog: https://docs.openstack.org/releasenotes/octavia/yoga.html
-version: 10.1.0
+version: 10.1.1
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/octavia/templates/etc/_octavia.conf.tpl
+++ b/openstack/octavia/templates/etc/_octavia.conf.tpl
@@ -10,9 +10,6 @@ octavia_plugins = f5_plugin
 # oslo_messaging rpc timeout
 rpc_response_timeout = {{ .Values.rpc_response_timeout | default .Values.global.rpc_response_timeout | default 60 }}
 
-# Tracing
-{{- include "osprofiler" . }}
-
 [api_settings]
 bind_host = 0.0.0.0
 bind_port = {{.Values.global.octavia_port_internal | default 9876}}

--- a/openstack/octavia/templates/etc/_secrets.conf.tpl
+++ b/openstack/octavia/templates/etc/_secrets.conf.tpl
@@ -22,3 +22,8 @@ record_payloads = {{ if .Values.audit.record_payloads -}}True{{- else -}}False{{
 metrics_enabled = {{ if .Values.audit.metrics_enabled -}}True{{- else -}}False{{- end }}
 {{- include "ini_sections.audit_middleware_notifications" . }}
 {{- end }}
+
+{{- if .Values.osprofiler.enabled }}
+# Tracing
+{{- include "osprofiler" . }}
+{{- end }}


### PR DESCRIPTION
osprofiler configuration contains a secret hmac value, so it should be in the secret instead of a configmap