### PR TITLE
[manila] move osprofiler configuration to secrets

### DIFF
--- a/openstack/manila/Chart.yaml
+++ b/openstack/manila/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 name: manila
 sources:
   - https://github.com/sapcc/manila
-version: 0.5.2
+version: 0.5.3
 dependencies:
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/manila/templates/etc/_manila.conf.tpl
+++ b/openstack/manila/templates/etc/_manila.conf.tpl
@@ -120,7 +120,3 @@ service_type = sharev2
 {{- if .Values.memcached.enabled }}
 {{- include "ini_sections.cache" . }}
 {{- end }}
-
-{{- if .Values.osprofiler.enabled }}
-{{- include "osprofiler" . }}
-{{- end }}

--- a/openstack/manila/templates/etc/_secrets.conf.tpl
+++ b/openstack/manila/templates/etc/_secrets.conf.tpl
@@ -14,3 +14,7 @@ password = {{ .Values.global.manila_service_password | default "" | include "res
 
 
 {{ include "ini_sections.audit_middleware_notifications" . }}
+
+{{- if .Values.osprofiler.enabled }}
+{{- include "osprofiler" . }}
+{{- end }}


### PR DESCRIPTION
osprofiler configuration contains a secret hmac value, so it should be in the secret instead of a configmap.