### PR TITLE
[placement] move osprofiler configuration to secrets

### DIFF
--- a/openstack/placement/Chart.yaml
+++ b/openstack/placement/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart for the Openstack Placement Service
 name: placement
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/project-mascots/Placement/OpenStack_Project_Placement_horizontal.jpg
-version: 0.1.0
+version: 0.1.1
 appVersion: "dalmatian"
 dependencies:
   - condition: mariadb.enabled

--- a/openstack/placement/templates/etc/_placement.conf.tpl
+++ b/openstack/placement/templates/etc/_placement.conf.tpl
@@ -10,9 +10,6 @@ memcache_servers = {{ .Chart.Name }}-memcached.{{ include "svc_fqdn" . }}:{{ .Va
 [placement_database]
 {{- include "ini_sections.database_options_mysql" . }}
 
-
-{{- include "osprofiler" . }}
-
 [oslo_concurrency]
 lock_path = /var/lib/placement/tmp
 

--- a/openstack/placement/templates/etc/_secrets.conf.tpl
+++ b/openstack/placement/templates/etc/_secrets.conf.tpl
@@ -8,3 +8,5 @@ connection = {{ tuple . .Values.mariadb.name .Values.global.dbUser .Values.globa
 [keystone_authtoken]
 username = {{ .Values.global.placement_service_user | default "placement" | include "resolve_secret" }}
 password = {{ required ".Values.global.placement_service_password is missing" .Values.global.placement_service_password | include "resolve_secret" }}
+
+{{- include "osprofiler" . }}


### PR DESCRIPTION
osprofiler configuration contains a secret hmac value, so it should be in the secret instead of a configmap.