### PR TITLE
[nova] move osprofiler configuration to secrets

### DIFF
--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 name: nova
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Nova/OpenStack_Project_Nova_mascot.png
-version: 0.4.1
+version: 0.4.2
 appVersion: "rocky"
 dependencies:
   - name: mariadb

--- a/openstack/nova/templates/_console_deployment.yaml.tpl
+++ b/openstack/nova/templates/_console_deployment.yaml.tpl
@@ -67,6 +67,10 @@ spec:
                 path: nova.conf.d/api-db.conf
               - key: {{ $cell_name }}.conf
                 path: nova.conf.d/{{ $cell_name }}.conf
+              {{- if .Values.osprofiler.enabled }}
+              - key: osprofiler.conf
+                path: nova.conf.d/osprofiler.conf
+              {{- end }}
           - configMap:
               name: nova-console
               items:

--- a/openstack/nova/templates/api-deployment.yaml
+++ b/openstack/nova/templates/api-deployment.yaml
@@ -177,6 +177,10 @@ spec:
               - key: audit-middleware.conf
                 path: nova.conf.d/audit-middleware.conf
               {{- end }}
+              {{- if .Values.osprofiler.enabled }}
+              - key: osprofiler.conf
+                path: nova.conf.d/osprofiler.conf
+              {{- end }}
       - name: statsd-etc
         projected:
           sources:

--- a/openstack/nova/templates/api-metadata-deployment.yaml
+++ b/openstack/nova/templates/api-metadata-deployment.yaml
@@ -159,6 +159,10 @@ spec:
                 path: nova.conf.d/keystoneauth-secrets.conf
               - key: nova-api-metadata-secrets.conf
                 path: nova.conf.d/nova-api-metadata-secrets.conf
+              {{- if .Values.osprofiler.enabled }}
+              - key: osprofiler.conf
+                path: nova.conf.d/osprofiler.conf
+              {{- end }}
       - name: statsd-etc
         projected:
           sources:

--- a/openstack/nova/templates/bigvm-deployment.yaml
+++ b/openstack/nova/templates/bigvm-deployment.yaml
@@ -103,6 +103,10 @@ spec:
                 path: nova.conf.d/cell1.conf
               - key: keystoneauth-secrets.conf
                 path: nova.conf.d/keystoneauth-secrets.conf
+              {{- if .Values.osprofiler.enabled }}
+              - key: osprofiler.conf
+                path: nova.conf.d/osprofiler.conf
+              {{- end }}
       {{- include "utils.proxysql.volumes" . | indent 6 }}
       {{- include "utils.trust_bundle.volumes" . | indent 6 }}
 {{- end }}

--- a/openstack/nova/templates/cell2-conductor-deployment.yaml
+++ b/openstack/nova/templates/cell2-conductor-deployment.yaml
@@ -122,6 +122,10 @@ spec:
                 path: nova.conf.d/{{ .Values.cell2.name }}.conf
               - key: keystoneauth-secrets.conf
                 path: nova.conf.d/keystoneauth-secrets.conf
+              {{- if .Values.osprofiler.enabled }}
+              - key: osprofiler.conf
+                path: nova.conf.d/osprofiler.conf
+              {{- end }}
       {{- if .Values.cell2.conductor.config_file.DEFAULT.statsd_enabled }}
       - name: statsd-etc
         projected:

--- a/openstack/nova/templates/conductor-deployment.yaml
+++ b/openstack/nova/templates/conductor-deployment.yaml
@@ -121,6 +121,10 @@ spec:
                 path: nova.conf.d/cell1.conf
               - key: keystoneauth-secrets.conf
                 path: nova.conf.d/keystoneauth-secrets.conf
+              {{- if .Values.osprofiler.enabled }}
+              - key: osprofiler.conf
+                path: nova.conf.d/osprofiler.conf
+              {{- end }}
 {{- if .Values.conductor.config_file.DEFAULT.statsd_enabled }}
       - name: statsd-etc
         projected:

--- a/openstack/nova/templates/etc-secret.yaml
+++ b/openstack/nova/templates/etc-secret.yaml
@@ -55,3 +55,5 @@ stringData:
     metadata_proxy_shared_secret = {{ .Values.global.nova_metadata_secret | include "resolve_secret" }}
   audit-middleware.conf: |
     {{- include "ini_sections.audit_middleware_notifications" . | indent 4}}
+  osprofiler.conf: |
+    {{- include "osprofiler" . | indent 4}}

--- a/openstack/nova/templates/etc/_nova.conf.tpl
+++ b/openstack/nova/templates/etc/_nova.conf.tpl
@@ -56,8 +56,6 @@ max_age = {{ .Values.usage_max_age | default 0 }}
 # count of reservations until usage is refreshed
 until_refresh = {{ .Values.usage_until_refresh | default 0 }}
 
-{{- include "osprofiler" . }}
-
 {{ include "ini_sections.oslo_messaging_rabbit" .}}
 
 [oslo_concurrency]

--- a/openstack/nova/templates/hypervisors/_ironic-deployment.yaml.tpl
+++ b/openstack/nova/templates/hypervisors/_ironic-deployment.yaml.tpl
@@ -120,6 +120,10 @@ spec:
                 path: nova.conf.d/cell1-secrets.conf
               - key: keystoneauth-secrets.conf
                 path: nova.conf.d/keystoneauth-secrets.conf
+              {{- if .Values.osprofiler.enabled }}
+              - key: osprofiler.conf
+                path: nova.conf.d/osprofiler.conf
+              {{- end }}
       - name: nova-patches
         projected:
           sources:

--- a/openstack/nova/templates/hypervisors/_kvm-deployment.yaml.tpl
+++ b/openstack/nova/templates/hypervisors/_kvm-deployment.yaml.tpl
@@ -110,6 +110,12 @@ spec:
               name: nova-etc-secret
               subPath: keystoneauth-secrets.conf
               readOnly: true
+            {{- if .Values.osprofiler.enabled }}
+            - mountPath: /etc/nova/nova.conf.d/osprofiler.conf
+              name: nova-etc-secret
+              subPath: osprofiler.conf
+              readOnly: true
+            {{- end }}
             {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
         - name: nova-libvirt
           image: {{ tuple . "libvirt" | include "container_image_nova" }}

--- a/openstack/nova/templates/hypervisors/hypervisors-vmware-deployment-vct.yaml
+++ b/openstack/nova/templates/hypervisors/hypervisors-vmware-deployment-vct.yaml
@@ -150,6 +150,10 @@ template: |
                   path: nova.conf.d/{= cell_name =}-secrets.conf
                 - key: keystoneauth-secrets.conf
                   path: nova.conf.d/keystoneauth-secrets.conf
+                {{- if .Values.osprofiler.enabled }}
+                - key: osprofiler.conf
+                  path: nova.conf.d/osprofiler.conf
+                {{- end }}
             - secret:
                 name: nova-compute-vmware-{= name =}
                 items:

--- a/openstack/nova/templates/scheduler-deployment.yaml
+++ b/openstack/nova/templates/scheduler-deployment.yaml
@@ -118,6 +118,10 @@ spec:
                 path: nova.conf.d/cell1.conf
               - key: keystoneauth-secrets.conf
                 path: nova.conf.d/keystoneauth-secrets.conf
+              {{- if .Values.osprofiler.enabled }}
+              - key: osprofiler.conf
+                path: nova.conf.d/osprofiler.conf
+              {{- end }}
           - configMap:
               name: nova-scheduler-etc
               items:


### PR DESCRIPTION
osprofiler configuration contains a secret hmac value, so it should be in the secret instead of a configmap.

This change moves [osprofiler] configuration section to a separate `osprofiler.conf` file in `nova-etc-secret` and mounts it into containers.