### PR TITLE
[barbican] seed generic domains using global.domains_seeds

### DIFF
--- a/openstack/barbican/ci/test-values.yaml
+++ b/openstack/barbican/ci/test-values.yaml
@@ -7,7 +7,8 @@ global:
   dockerHubMirror: myRegistry/dockerhub
   dockerHubMirrorAlternateRegion: myRegistry/dockerhubalternate
   domain_seeds:
-    skip_hcm_domain: false
+    customer_domains: [ bar, foo, baz ]
+    customer_domains_without_support_projects: [ baz ]
   availability_zones: []
 
 imageVersionBarbicanApi: yoga

--- a/openstack/barbican/templates/seed.yaml
+++ b/openstack/barbican/templates/seed.yaml
@@ -1,3 +1,7 @@
+{{- $cdomains := .Values.global.domain_seeds.customer_domains | required "missing value for .Values.global.domain_seeds.customer_domains" -}}
+{{- $domains  := concat (list "ccadmin" "Default") $cdomains -}}
+{{- $cdomainsWithoutSupportProjects := .Values.global.domain_seeds.customer_domains_without_support_projects | required "missing value for .Values.global.domain_seeds.customer_domains_without_support_projects" -}}
+
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:
@@ -10,23 +14,11 @@ metadata:
 spec:
   requires:
   - {{ default .Release.Namespace .Values.global.keystoneNamespace }}/keystone-seed
-  - monsoon3/domain-default-seed
-  - monsoon3/domain-cc3test-seed
-  - monsoon3/domain-ccadmin-seed
-  - monsoon3/domain-btp-fp-seed
-  - monsoon3/domain-bs-seed
-  - monsoon3/domain-cp-seed
-  - monsoon3/domain-fsn-seed
-  - monsoon3/domain-hda-seed
-  - monsoon3/domain-hcm-seed
-  - monsoon3/domain-hcp03-seed
-  - monsoon3/domain-hec-seed
-  - monsoon3/domain-kyma-seed
-  - monsoon3/domain-monsoon3-seed
-  - monsoon3/domain-neo-seed
-  - monsoon3/domain-s4-seed
-  - monsoon3/domain-wbs-seed
-  - monsoon3/domain-cis-seed
+  {{- range $domains }}
+  {{- if not (hasPrefix "iaas-" .)}}
+  - monsoon3/domain-{{ replace "_" "-" . | lower }}-seed
+  {{- end }}
+  {{- end }}
 
   roles:
   - name: keymanager_viewer
@@ -50,6 +42,11 @@ spec:
     - interface: internal
       region: '{{.Values.global.region}}'
       url: 'http://{{include "barbican_api_endpoint_host_internal" .}}:{{.Values.api_port_internal}}'
+
+
+  # default gets special handling
+  # ccadmin gets additional role assignments for projects and some group assignments
+  # iaas- is excluded
 
   domains:
   - name: Default
@@ -75,563 +72,97 @@ spec:
       - project: admin
         role: cloud_keymanager_admin
 
-  - name: ccadmin
+  {{- range $domains }}
+  {{- if and (ne . "Default") (not (hasPrefix "iaas-" .)) }}
+  - name: {{ . }}
+    {{- if eq . "ccadmin" }}
     projects:
     - name: cloud_admin
       role_assignments:
       - user: admin@Default
         role: cloud_keymanager_admin
+    {{- end }}
     groups:
+    {{- if eq . "ccadmin" }}
     - name: CCADMIN_CLOUD_ADMINS
       role_assignments:
       - project: cloud_admin
         role: cloud_keymanager_admin
-    - name: CCADMIN_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: keymanager_admin
-      - project: api_tools
-        role: keymanager_admin
-      - domain: ccadmin
-        role: keymanager_viewer
-        inherited: true
-    - name: CCADMIN_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: keymanager_admin
-      - project: compute_tools
-        role: keymanager_admin
-      #- domain: ccadmin
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: CCADMIN_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: keymanager_admin
-      - project: network_tools
-        role: keymanager_admin
-      #- domain: ccadmin
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: CCADMIN_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: keymanager_admin
-      - project: storage_tools
-        role: keymanager_admin
-      #- domain: ccadmin
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: CCADMIN_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: keymanager_admin
-      #- domain: ccadmin
-      #  role: keymanager_viewer
-      #  inherited: true
-
-  - name: cis
-    groups:
-    - name: CIS_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: keymanager_admin
-      - domain: cis
-        role: keymanager_viewer
-        inherited: true
-    - name: CIS_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: keymanager_admin
-    - name: CIS_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: keymanager_admin
-    - name: CIS_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: keymanager_admin
-    - name: CIS_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: keymanager_admin
-
-  - name: bs
-    groups:
-    - name: BS_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: keymanager_admin
-      - domain: bs
-        role: keymanager_viewer
-        inherited: true
-    - name: BS_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: keymanager_admin
-      #- domain: bs
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: BS_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: keymanager_admin
-      #- domain: bs
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: BS_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: keymanager_admin
-      #- domain: bs
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: BS_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: keymanager_admin
-      #- domain: bs
-      #  role: keymanager_viewer
-      #  inherited: true
-
-  - name: btp_fp
-    groups:
-    - name: BTP_FP_API_SUPPORT
-      role_assignments:
-      - domain: btp_fp
-        role: keymanager_viewer
-        inherited: true
-    - name: BTP_FP_COMPUTE_SUPPORT
-      role_assignments:
-      - domain: btp_fp
-        role: keymanager_viewer
-        inherited: true
-    - name: BTP_FP_NETWORK_SUPPORT
-      role_assignments:
-      - domain: btp_fp
-        role: keymanager_viewer
-        inherited: true
-    - name: BTP_FP_STORAGE_SUPPORT
-      role_assignments:
-      - domain: btp_fp
-        role: keymanager_viewer
-        inherited: true
-    - name: BTP_FP_SERVICE_DESK
-      role_assignments:
-      - domain: btp_fp
-        role: keymanager_viewer
-        inherited: true
-
-  - name: cp
-    groups:
-    - name: CP_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: keymanager_admin
-      - domain: cp
-        role: keymanager_viewer
-        inherited: true
-    - name: CP_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: keymanager_admin
-      #- domain: cp
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: CP_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: keymanager_admin
-      #- domain: cp
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: CP_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: keymanager_admin
-      #- domain: cp
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: CP_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: keymanager_admin
-      #- domain: cp
-      #  role: keymanager_viewer
-      #  inherited: true
-
-  - name: fsn
-    groups:
-    - name: FSN_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: keymanager_admin
-      - domain: fsn
-        role: keymanager_viewer
-        inherited: true
-    - name: FSN_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: keymanager_admin
-      #- domain: fsn
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: FSN_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: keymanager_admin
-      #- domain: fsn
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: FSN_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: keymanager_admin
-      #- domain: fsn
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: FSN_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: keymanager_admin
-      #- domain: fsn
-      #  role: keymanager_viewer
-      #  inherited: true
-
-  - name: hda
-    groups:
-    - name: HDA_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: keymanager_admin
-      - domain: hda
-        role: keymanager_viewer
-        inherited: true
-    - name: HDA_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: keymanager_admin
-      #- domain: hda
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: HDA_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: keymanager_admin
-      #- domain: hda
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: HDA_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: keymanager_admin
-      #- domain: hda
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: HDA_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: keymanager_admin
-      #- domain: hda
-      #  role: keymanager_viewer
-      #  inherited: true
-
-{{- if not .Values.global.domain_seeds.skip_hcm_domain }}
-  - name: hcm
-    groups:
-    - name: HCM_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: keymanager_admin
-      - domain: hcm
-        role: keymanager_viewer
-        inherited: true
-    - name: HCM_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: keymanager_admin
-      #- domain: hcm
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: HCM_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: keymanager_admin
-      #- domain: hcm
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: HCM_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: keymanager_admin
-      #- domain: hcm
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: HCM_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: keymanager_admin
-      #- domain: hcm
-      #  role: keymanager_viewer
-      #  inherited: true
-{{- end }}
-
-  - name: hcp03
-    groups:
-    - name: HCP03_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: keymanager_admin
-      - domain: hcp03
-        role: keymanager_viewer
-        inherited: true
-    - name: HCP03_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: keymanager_admin
-      #- domain: hcp03
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: HCP03_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: keymanager_admin
-      #- domain: hcp03
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: HCP03_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: keymanager_admin
-      #- domain: hcp03
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: HCP03_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: keymanager_admin
-      #- domain: hcp03
-      #  role: keymanager_viewer
-      #  inherited: true
-
-  - name: hec
-    groups:
-    - name: HEC_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: keymanager_admin
-      - domain: hec
-        role: keymanager_viewer
-        inherited: true
-    - name: HEC_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: keymanager_admin
-      #- domain: hec
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: HEC_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: keymanager_admin
-      #- domain: hec
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: HEC_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: keymanager_admin
-      #- domain: hec
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: HEC_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: keymanager_admin
-      #- domain: hec
-      #  role: keymanager_viewer
-      #  inherited: true
-
-  - name: kyma
-    groups:
-    - name: KYMA_API_SUPPORT
-      role_assignments:
-      - domain: kyma
-        role: keymanager_viewer
-        inherited: true
-    - name: KYMA_COMPUTE_SUPPORT
-      role_assignments:
-      - domain: kyma
-        role: keymanager_viewer
-        inherited: true
-    - name: KYMA_NETWORK_SUPPORT
-      role_assignments:
-      - domain: kyma
-        role: keymanager_viewer
-        inherited: true
-    - name: KYMA_STORAGE_SUPPORT
-      role_assignments:
-      - domain: kyma
-        role: keymanager_viewer
-        inherited: true
-    - name: KYMA_SERVICE_DESK
-      role_assignments:
-      - domain: kyma
-        role: keymanager_viewer
-        inherited: true
-
-  - name: monsoon3
-    groups:
+    {{- end }}
+    {{- if eq . "monsoon3"}}
     - name: MONSOON3_DOMAIN_ADMINS
       role_assignments:
       - project: cc-demo
         role: keymanager_admin
-    - name: MONSOON3_API_SUPPORT
+    {{- end }}
+    - name: {{ hasPrefix "iaas-" . | ternary . ( upper . ) }}_API_SUPPORT
       role_assignments:
+      {{- if not (has . $cdomainsWithoutSupportProjects) }}
       - project: api_support
         role: keymanager_admin
-      - domain: monsoon3
+      {{- end }}
+      {{- if eq . "ccadmin" }}
+      - project: api_tools
+        role: keymanager_admin
+      {{- end }}
+      - domain: {{ . }}
         role: keymanager_viewer
         inherited: true
-    - name: MONSOON3_COMPUTE_SUPPORT
+    - name: {{ hasPrefix "iaas-" . | ternary . ( upper . ) }}_COMPUTE_SUPPORT
       role_assignments:
+      {{- if not (has . $cdomainsWithoutSupportProjects) }}
       - project: compute_support
         role: keymanager_admin
-      #- domain: monsoon3
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: MONSOON3_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
+      {{- end }}
+      {{- if eq . "ccadmin" }}
+      - project: compute_tools
         role: keymanager_admin
-      #- domain: monsoon3
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: MONSOON3_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: keymanager_admin
-      #- domain: monsoon3
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: MONSOON3_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: keymanager_admin
-      #- domain: monsoon3
-      #  role: keymanager_viewer
-      #  inherited: true
-
-  - name: neo
-    groups:
-    - name: NEO_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: keymanager_admin
-      - domain: neo
+      {{- end }}
+      {{- if (has . $cdomainsWithoutSupportProjects) }}
+      - domain: {{ . }}
         role: keymanager_viewer
         inherited: true
-    - name: NEO_COMPUTE_SUPPORT
+      {{- end }}
+    - name: {{ hasPrefix "iaas-" . | ternary . ( upper . ) }}_NETWORK_SUPPORT
       role_assignments:
-      - project: compute_support
-        role: keymanager_admin
-      #- domain: neo
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: NEO_NETWORK_SUPPORT
-      role_assignments:
+      {{- if not (has . $cdomainsWithoutSupportProjects) }}
       - project: network_support
         role: keymanager_admin
-      #- domain: neo
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: NEO_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
+      {{- end }}
+      {{- if eq . "ccadmin" }}
+      - project: network_tools
         role: keymanager_admin
-      #- domain: neo
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: NEO_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: keymanager_admin
-      #- domain: neo
-      #  role: keymanager_viewer
-      #  inherited: true
-
-  - name: s4
-    groups:
-    - name: S4_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: keymanager_admin
-      - domain: s4
+      {{- end }}
+      {{- if (has . $cdomainsWithoutSupportProjects) }}
+      - domain: {{ . }}
         role: keymanager_viewer
         inherited: true
-    - name: S4_COMPUTE_SUPPORT
+      {{- end }}
+    - name: {{ hasPrefix "iaas-" . | ternary . ( upper . ) }}_STORAGE_SUPPORT
       role_assignments:
-      - project: compute_support
-        role: keymanager_admin
-      #- domain: s4
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: S4_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: keymanager_admin
-      #- domain: s4
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: S4_STORAGE_SUPPORT
-      role_assignments:
+      {{- if not (has . $cdomainsWithoutSupportProjects) }}
       - project: storage_support
         role: keymanager_admin
-      #- domain: s4
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: S4_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
+      {{- end }}
+      {{- if eq . "ccadmin" }}
+      - project: storage_tools
         role: keymanager_admin
-      #- domain: s4
-      #  role: keymanager_viewer
-      #  inherited: true
-
-  - name: wbs
-    groups:
-    - name: WBS_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: keymanager_admin
-      - domain: wbs
+      {{- end }}
+      {{- if (has . $cdomainsWithoutSupportProjects) }}
+      - domain: {{ . }}
         role: keymanager_viewer
         inherited: true
-    - name: WBS_COMPUTE_SUPPORT
+      {{- end }}
+    - name: {{ hasPrefix "iaas-" . | ternary . ( upper . ) }}_SERVICE_DESK
       role_assignments:
-      - project: compute_support
-        role: keymanager_admin
-      #- domain: wbs
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: WBS_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: keymanager_admin
-      #- domain: wbs
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: WBS_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: keymanager_admin
-      #- domain: wbs
-      #  role: keymanager_viewer
-      #  inherited: true
-    - name: WBS_SERVICE_DESK
-      role_assignments:
+      {{- if not (has . $cdomainsWithoutSupportProjects) }}
       - project: service_desk
         role: keymanager_admin
-      #- domain: wbs
-      #  role: keymanager_viewer
-      #  inherited: true
+      {{- end }}
+      {{- if (has . $cdomainsWithoutSupportProjects) }}
+      - domain: {{ . }}
+        role: keymanager_viewer
+        inherited: true
+      {{- end }}
+  {{- end}}
+  {{- end}}


### PR DESCRIPTION
In an attempt to make deployment of new domains easier, @majewsky recently introduced `global.domain_seeds.customer_domains`. As this could replace the old `skip_hcm_domain`, poses the opportunity to distinguish between internal and external domains in future and accommodate other specialties we would like to suggest this on seeds of other services too.

The expressions are technically equal, only the `ora` domain was added. If it was excluded on purpose, let me know and I can change it. I excluded iaas- for now.
I ran h3 diff with dyff option against qa-de-1 and eu-de-1 you can have a look at the output here:
[barbicanQA1diff.txt](https://github.com/user-attachments/files/19487805/barbicanQA1diff.txt)
[barbicanDE1diff.txt](https://github.com/user-attachments/files/19487806/barbicanDE1diff.txt)
