### PR TITLE
[neutron] seed generic domains using global.domain_seeds

### DIFF
--- a/openstack/neutron/ci/test-values.yaml
+++ b/openstack/neutron/ci/test-values.yaml
@@ -12,7 +12,8 @@ global:
     - foo
     - bar
   domain_seeds:
-    skip_hcm_domain: false
+    customer_domains: [bar, foo, baz]
+    customer_domains_without_support_projects: [baz]
 
 mariadb:
   root_password: john

--- a/openstack/neutron/templates/seed.yaml
+++ b/openstack/neutron/templates/seed.yaml
@@ -1,3 +1,7 @@
+{{- $cdomains := .Values.global.domain_seeds.customer_domains | required "missing value for .Values.global.domain_seeds.customer_domains" -}}
+{{- $domains  := concat (list "Default" "ccadmin") $cdomains -}}
+{{- $cdomainsWithoutSupportProjects := .Values.global.domain_seeds.customer_domains_without_support_projects | required "missing value for .Values.global.domain_seeds.customer_domains_without_support_projects" -}}
+
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:
@@ -10,23 +14,11 @@ metadata:
 spec:
   requires:
   - monsoon3/barbican-seed
-  - monsoon3/domain-default-seed
-  - monsoon3/domain-cc3test-seed
-  - monsoon3/domain-ccadmin-seed
-  - monsoon3/domain-bs-seed
-  - monsoon3/domain-btp-fp-seed
-  - monsoon3/domain-cis-seed
-  - monsoon3/domain-cp-seed
-  - monsoon3/domain-fsn-seed
-  - monsoon3/domain-hda-seed
-  - monsoon3/domain-hcm-seed
-  - monsoon3/domain-hcp03-seed
-  - monsoon3/domain-hec-seed
-  - monsoon3/domain-kyma-seed
-  - monsoon3/domain-monsoon3-seed
-  - monsoon3/domain-neo-seed
-  - monsoon3/domain-s4-seed
-  - monsoon3/domain-wbs-seed
+  {{- range $domains}}
+  {{- if not (hasPrefix "iaas-" .)}}
+  - monsoon3/domain-{{ replace "_" "-" . | lower}}-seed
+  {{- end }}
+  {{- end }}
 
   roles:
   - name: network_admin
@@ -51,6 +43,11 @@ spec:
     - interface: internal
       region: {{ .Values.global.region }}
       url: http://neutron-server.{{ .Release.Namespace }}.svc.kubernetes.{{ .Values.global.region }}.{{ .Values.global.tld }}:9696
+
+  # default gets special handling
+  # ccadmin and monsoon3 get some additional role assignments
+  # Default gets a few role assignment less
+  # iaas- is excluded
 
   domains:
   - name: Default
@@ -104,7 +101,10 @@ spec:
       - project: admin
         role: cloud_network_admin
 
-  - name: ccadmin
+  {{- range $domains}}
+  {{- if and (not (hasPrefix "iaas-" .)) (not (eq "Default" .))}}
+  - name: {{ . }}
+    {{- if eq . "ccadmin" }}
     projects:
     - name: cloud_admin
       role_assignments:
@@ -112,693 +112,96 @@ spec:
         role: cloud_network_admin
     - name: master
       role_assignments:
-      - user: '{{ .Values.global.neutron_service_user | include "resolve_secret" }}@Default'
+      - user: '{{ $.Values.global.neutron_service_user | include "resolve_secret" }}@Default'
         role: cloud_dns_admin
+    {{- end }}
     groups:
+    {{- if eq . "ccadmin" }}
     - name: CCADMIN_CLOUD_ADMINS
       role_assignments:
       - project: cloud_admin
         role: cloud_network_admin
-    - name: CCADMIN_DOMAIN_NETWORK_ADMINS
-      role_assignments:
-      - project: ccadmin-net-infra
-        role: network_admin
-      - project: ccadmin-net-infra
-        role: cloud_network_admin
-      - project: ccadmin-shared-infra
-        role: network_admin
-    - name: CCADMIN_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: network_admin
-      - project: api_tools
-        role: network_admin
-      - domain: ccadmin
-        role: network_admin
-        inherited: true
-    - name: CCADMIN_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: network_admin
-      - project: compute_tools
-        role: network_admin
-      - domain: ccadmin
-        role: network_admin
-        inherited: true
-    - name: CCADMIN_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: network_admin
-      - project: network_tools
-        role: network_admin
-      - domain: ccadmin
-        role: network_admin
-        inherited: true
-    - name: CCADMIN_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: network_admin
-      - project: storage_tools
-        role: network_admin
-      - domain: ccadmin
-        role: network_viewer
-        inherited: true
-    - name: CCADMIN_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: network_admin
-      - domain: ccadmin
-        role: network_viewer
-        inherited: true
-
-  - name: bs
-    groups:
-    - name: BS_DOMAIN_NETWORK_ADMINS
-      role_assignments:
-      - project: bs-net-infra
-        role: network_admin
-      - project: bs-net-infra
-        role: cloud_network_admin
-      - project: bs-shared-infra
-        role: network_admin
-    - name: BS_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: network_admin
-      - domain: bs
-        role: network_admin
-        inherited: true
-    - name: BS_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: network_admin
-      - domain: bs
-        role: network_viewer
-        inherited: true
-    - name: BS_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: network_admin
-      - domain: bs
-        role: network_admin
-        inherited: true
-    - name: BS_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: network_admin
-      - domain: bs
-        role: network_viewer
-        inherited: true
-    - name: BS_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: network_admin
-      - domain: bs
-        role: network_viewer
-        inherited: true
-
-  - name: btp_fp
-    groups:
-    - name: BTP_FP_DOMAIN_NETWORK_ADMINS
-      role_assignments:
-      - project: btp_fp-net-infra
-        role: network_admin
-      - project: btp_fp-net-infra
-        role: cloud_network_admin
-      - project: btp_fp-shared-infra
-        role: network_admin
-    - name: BTP_FP_API_SUPPORT
-      role_assignments:
-      - domain: btp_fp
-        role: network_admin
-        inherited: true
-    - name: BTP_FP_COMPUTE_SUPPORT
-      role_assignments:
-      - domain: btp_fp
-        role: network_viewer
-        inherited: true
-    - name: BTP_FP_NETWORK_SUPPORT
-      role_assignments:
-      - domain: btp_fp
-        role: network_admin
-        inherited: true
-    - name: BTP_FP_STORAGE_SUPPORT
-      role_assignments:
-      - domain: btp_fp
-        role: network_viewer
-        inherited: true
-    - name: BTP_FP_SERVICE_DESK
-      role_assignments:
-      - domain: btp_fp
-        role: network_viewer
-        inherited: true
-
-  - name: cis
-    groups:
-    - name: CIS_DOMAIN_NETWORK_ADMINS
-      role_assignments:
-      - project: cis-net-infra
-        role: network_admin
-      - project: cis-net-infra
-        role: cloud_network_admin
-      - project: cis-shared-infra
-        role: network_admin
-    - name: CIS_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: network_admin
-      - domain: cis
-        role: network_admin
-        inherited: true
-    - name: CIS_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: network_admin
-      - domain: cis
-        role: network_viewer
-        inherited: true
-    - name: CIS_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: network_admin
-      - domain: cis
-        role: network_admin
-        inherited: true
-    - name: CIS_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: network_admin
-      - domain: cis
-        role: network_viewer
-        inherited: true
-    - name: CIS_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: network_admin
-      - domain: cis
-        role: network_viewer
-        inherited: true
-
-  - name: cp
-    groups:
-    - name: CP_DOMAIN_NETWORK_ADMINS
-      role_assignments:
-      - project: cp-net-infra
-        role: network_admin
-      - project: cp-net-infra
-        role: cloud_network_admin
-      - project: cp-shared-infra
-        role: network_admin
-    - name: CP_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: network_admin
-      - domain: cp
-        role: network_admin
-        inherited: true
-    - name: CP_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: network_admin
-      - domain: cp
-        role: network_viewer
-        inherited: true
-    - name: CP_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: network_admin
-      - domain: cp
-        role: network_admin
-        inherited: true
-    - name: CP_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: network_admin
-      - domain: cp
-        role: network_viewer
-        inherited: true
-    - name: CP_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: network_admin
-      - domain: cp
-        role: network_viewer
-        inherited: true
-
-  - name: fsn
-    groups:
-    - name: FSN_DOMAIN_NETWORK_ADMINS
-      role_assignments:
-      - project: fsn-net-infra
-        role: network_admin
-      - project: fsn-net-infra
-        role: cloud_network_admin
-      - project: fsn-shared-infra
-        role: network_admin
-    - name: FSN_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: network_admin
-      - domain: fsn
-        role: network_admin
-        inherited: true
-    - name: FSN_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: network_admin
-      - domain: fsn
-        role: network_viewer
-        inherited: true
-    - name: FSN_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: network_admin
-      - domain: fsn
-        role: network_admin
-        inherited: true
-    - name: FSN_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: network_admin
-      - domain: fsn
-        role: network_viewer
-        inherited: true
-    - name: FSN_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: network_admin
-      - domain: fsn
-        role: network_viewer
-        inherited: true
-
-  - name: hda
-    groups:
-    - name: HDA_DOMAIN_NETWORK_ADMINS
-      role_assignments:
-      - project: hda-net-infra
-        role: network_admin
-      - project: hda-net-infra
-        role: cloud_network_admin
-      - project: hda-shared-infra
-        role: network_admin
-    - name: HDA_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: network_admin
-      - domain: hda
-        role: network_admin
-        inherited: true
-    - name: HDA_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: network_admin
-      - domain: hda
-        role: network_viewer
-        inherited: true
-    - name: HDA_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: network_admin
-      - domain: hda
-        role: network_admin
-        inherited: true
-    - name: HDA_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: network_admin
-      - domain: hda
-        role: network_viewer
-        inherited: true
-    - name: HDA_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: network_admin
-      - domain: hda
-        role: network_viewer
-        inherited: true
-
-{{- if not .Values.global.domain_seeds.skip_hcm_domain }}
-  - name: hcm
-    groups:
-    - name: HCM_DOMAIN_NETWORK_ADMINS
-      role_assignments:
-      - project: hcm-net-infra
-        role: network_admin
-      - project: hcm-net-infra
-        role: cloud_network_admin
-      - project: hcm-shared-infra
-        role: network_admin
-    - name: HCM_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: network_admin
-      - domain: hcm
-        role: network_admin
-        inherited: true
-    - name: HCM_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: network_admin
-      - domain: hcm
-        role: network_viewer
-        inherited: true
-    - name: HCM_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: network_admin
-      - domain: hcm
-        role: network_admin
-        inherited: true
-    - name: HCM_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: network_admin
-      - domain: hcm
-        role: network_viewer
-        inherited: true
-    - name: HCM_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: network_admin
-      - domain: hcm
-        role: network_viewer
-        inherited: true
-{{- end }}
-
-  - name: hcp03
-    groups:
-    - name: HCP03_DOMAIN_NETWORK_ADMINS
-      role_assignments:
-      - project: hcp03-net-infra
-        role: network_admin
-      - project: hcp03-net-infra
-        role: cloud_network_admin
-      - project: hcp03-shared-infra
-        role: network_admin
-    - name: HCP03_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: network_admin
-      - domain: hcp03
-        role: network_admin
-        inherited: true
-    - name: HCP03_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: network_admin
-      - domain: hcp03
-        role: network_viewer
-        inherited: true
-    - name: HCP03_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: network_admin
-      - domain: hcp03
-        role: network_admin
-        inherited: true
-    - name: HCP03_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: network_admin
-      - domain: hcp03
-        role: network_viewer
-        inherited: true
-    - name: HCP03_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: network_admin
-      - domain: hcp03
-        role: network_viewer
-        inherited: true
-
-  - name: hec
-    groups:
-    - name: HEC_DOMAIN_NETWORK_ADMINS
-      role_assignments:
-      - project: hec-net-infra
-        role: network_admin
-      - project: hec-net-infra
-        role: cloud_network_admin
-      - project: hec-shared-infra
-        role: network_admin
-    - name: HEC_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: network_admin
-      - domain: hec
-        role: network_admin
-        inherited: true
-    - name: HEC_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: network_admin
-      - domain: hec
-        role: network_viewer
-        inherited: true
-    - name: HEC_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: network_admin
-      - domain: hec
-        role: network_admin
-        inherited: true
-    - name: HEC_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: network_admin
-      - domain: hec
-        role: network_viewer
-        inherited: true
-    - name: HEC_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: network_admin
-      - domain: hec
-        role: network_viewer
-        inherited: true
-
-  - name: kyma
-    groups:
-    - name: KYMA_DOMAIN_NETWORK_ADMINS
-      role_assignments:
-      - project: kyma-net-infra
-        role: network_admin
-      - project: kyma-net-infra
-        role: cloud_network_admin
-      - project: kyma-shared-infra
-        role: network_admin
-    - name: KYMA_API_SUPPORT
-      role_assignments:
-      - domain: kyma
-        role: network_admin
-        inherited: true
-    - name: KYMA_COMPUTE_SUPPORT
-      role_assignments:
-      - domain: kyma
-        role: network_viewer
-        inherited: true
-    - name: KYMA_NETWORK_SUPPORT
-      role_assignments:
-      - domain: kyma
-        role: network_admin
-        inherited: true
-    - name: KYMA_STORAGE_SUPPORT
-      role_assignments:
-      - domain: kyma
-        role: network_viewer
-        inherited: true
-    - name: KYMA_SERVICE_DESK
-      role_assignments:
-      - domain: kyma
-        role: network_viewer
-        inherited: true
-
-  - name: monsoon3
-    groups:
+    {{- end }}
+    {{- if eq . "monsoon3" }}
     - name: MONSOON3_DOMAIN_ADMINS
       role_assignments:
       - project: cc-demo
         role: network_admin
-    - name: MONSOON3_DOMAIN_NETWORK_ADMINS
+    {{- end }}
+    {{- if ne . "default" }}
+    - name: {{ hasPrefix "iaas-" . | ternary . (upper .) }}_DOMAIN_NETWORK_ADMINS
       role_assignments:
+      - project: {{ . }}-net-infra
+        role: network_admin
+      - project: {{ . }}-net-infra
+        role: cloud_network_admin
+      - project: {{ . }}-shared-infra
+        role: network_admin
+      {{- if eq . "monsoon3" }}
       - project: cc-demo
         role: network_admin
-      - project: monsoon3-net-infra
-        role: network_admin
-      - project: monsoon3-net-infra
-        role: cloud_network_admin
-      - project: monsoon3-shared-infra
-        role: network_admin
-    - name: MONSOON3_API_SUPPORT
+      {{- end }}
+    {{- end }}
+    - name: {{ hasPrefix "iaas-" . | ternary . (upper .) }}_API_SUPPORT
       role_assignments:
+      {{- if not (has . $cdomainsWithoutSupportProjects) }}
       - project: api_support
         role: network_admin
-      - domain: monsoon3
+      {{- end }}
+      {{- if eq . "ccadmin" }}
+      - project: api_tools
+        role: network_admin
+      {{- end }}
+      - domain: {{ . }}
         role: network_admin
         inherited: true
-    - name: MONSOON3_COMPUTE_SUPPORT
+    - name: {{ hasPrefix "iaas-" . | ternary . (upper .) }}_COMPUTE_SUPPORT
       role_assignments:
+      {{- if not (has . $cdomainsWithoutSupportProjects) }}
       - project: compute_support
         role: network_admin
-      - domain: monsoon3
-        role: network_viewer
+      {{- end }}
+      {{- if eq . "ccadmin" }}
+      - project: compute_tools
+        role: network_admin
+      {{- end }}
+      - domain: {{ . }}
+        role: {{ eq . "ccadmin" | ternary "network_admin" "network_viewer" }}
         inherited: true
-    - name: MONSOON3_NETWORK_SUPPORT
+    - name: {{ hasPrefix "iaas-" . | ternary . (upper .) }}_NETWORK_SUPPORT
       role_assignments:
+      {{- if not (has . $cdomainsWithoutSupportProjects) }}
       - project: network_support
         role: network_admin
-      - domain: monsoon3
+      {{- end }}
+      {{- if eq . "ccadmin" }}
+      - project: network_tools
+        role: network_admin
+      {{- end }}
+      - domain: {{ . }}
         role: network_admin
         inherited: true
-    - name: MONSOON3_STORAGE_SUPPORT
+    - name: {{ hasPrefix "iaas-" . | ternary . (upper .) }}_STORAGE_SUPPORT
       role_assignments:
+      {{- if not (has . $cdomainsWithoutSupportProjects) }}
       - project: storage_support
         role: network_admin
-      - domain: monsoon3
+      {{- end }}
+      {{- if eq . "ccadmin" }}
+      - project: storage_tools
+        role: network_admin
+      {{- end }}
+      - domain: {{ . }}
         role: network_viewer
         inherited: true
-    - name: MONSOON3_SERVICE_DESK
+    - name: {{ hasPrefix "iaas-" . | ternary . (upper .) }}_SERVICE_DESK
       role_assignments:
+      {{- if not (has . $cdomainsWithoutSupportProjects) }}
       - project: service_desk
         role: network_admin
-      - domain: monsoon3
+      {{- end }}
+      - domain: {{ . }}
         role: network_viewer
         inherited: true
-
-  - name: neo
-    groups:
-    - name: NEO_DOMAIN_NETWORK_ADMINS
-      role_assignments:
-      - project: neo-net-infra
-        role: network_admin
-      - project: neo-net-infra
-        role: cloud_network_admin
-      - project: neo-shared-infra
-        role: network_admin
-    - name: NEO_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: network_admin
-      - domain: neo
-        role: network_admin
-        inherited: true
-    - name: NEO_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: network_admin
-      - domain: neo
-        role: network_viewer
-        inherited: true
-    - name: NEO_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: network_admin
-      - domain: neo
-        role: network_admin
-        inherited: true
-    - name: NEO_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: network_admin
-      - domain: neo
-        role: network_viewer
-        inherited: true
-    - name: NEO_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: network_admin
-      - domain: neo
-        role: network_viewer
-        inherited: true
-
-  - name: s4
-    groups:
-    - name: S4_DOMAIN_NETWORK_ADMINS
-      role_assignments:
-      - project: s4-net-infra
-        role: network_admin
-      - project: s4-net-infra
-        role: cloud_network_admin
-      - project: s4-shared-infra
-        role: network_admin
-    - name: S4_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: network_admin
-      - domain: s4
-        role: network_admin
-        inherited: true
-    - name: S4_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: network_admin
-      - domain: s4
-        role: network_viewer
-        inherited: true
-    - name: S4_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: network_admin
-      - domain: s4
-        role: network_admin
-        inherited: true
-    - name: S4_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: network_admin
-      - domain: s4
-        role: network_viewer
-        inherited: true
-    - name: S4_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: network_admin
-      - domain: s4
-        role: network_viewer
-        inherited: true
-
-  - name: wbs
-    groups:
-    - name: WBS_DOMAIN_NETWORK_ADMINS
-      role_assignments:
-      - project: wbs-net-infra
-        role: network_admin
-      - project: wbs-net-infra
-        role: cloud_network_admin
-      - project: wbs-shared-infra
-        role: network_admin
-    - name: WBS_API_SUPPORT
-      role_assignments:
-      - project: api_support
-        role: network_admin
-      - domain: wbs
-        role: network_admin
-        inherited: true
-    - name: WBS_COMPUTE_SUPPORT
-      role_assignments:
-      - project: compute_support
-        role: network_admin
-      - domain: wbs
-        role: network_viewer
-        inherited: true
-    - name: WBS_NETWORK_SUPPORT
-      role_assignments:
-      - project: network_support
-        role: network_admin
-      - domain: wbs
-        role: network_admin
-        inherited: true
-    - name: WBS_STORAGE_SUPPORT
-      role_assignments:
-      - project: storage_support
-        role: network_admin
-      - domain: wbs
-        role: network_viewer
-        inherited: true
-    - name: WBS_SERVICE_DESK
-      role_assignments:
-      - project: service_desk
-        role: network_admin
-      - domain: wbs
-        role: network_viewer
-        inherited: true
+  {{- end }}
+  {{- end }}


### PR DESCRIPTION
In an attempt to make deployment of new domains easier, @majewsky recently introduced `global.domain_seeds.customer_domains`. As this could replace the old `skip_hcm_domain`, poses the opportunity to distinguish between internal and external domains in future and accommodate other specialties we would like to suggest this on seeds of other services too.

The expressions are technically equal, only the `ora` domain was added. If it was excluded on purpose, let me know and I can change it. I excluded iaas- for now.
I ran h3 diff with dyff option against qa-de-1 and eu-de-1 you can have a look at the output here:
[neutronQA1diff.txt](https://github.com/user-attachments/files/19488580/neutronQA1diff.txt)
[neutronDE1diff.txt](https://github.com/user-attachments/files/19488581/neutronDE1diff.txt)
