### PR TITLE
[andromeda] limit andromeda access rights

### DIFF
--- a/global/andromeda/Chart.yaml
+++ b/global/andromeda/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: andromeda
-version: 0.1.1
+version: 0.1.2
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/global/andromeda/templates/etc/_policy.json.tpl
+++ b/global/andromeda/templates/etc/_policy.json.tpl
@@ -1,5 +1,5 @@
 {
-  "cloud_admin": "(project_domain_name:ccadmin and project_name:cloud_admin) or user_domain_id:default",
+  "cloud_admin": "(project_domain_name:ccadmin and project_name:cloud_admin) or (role:admin and (is_admin_project:True or domain_id:default))",
   "project_scope": "project_id:%(project_id)s",
   "public_scope": "'public':%(scope)s",
   "shared_scope": "'shared':%(scope)s",


### PR DESCRIPTION
if the user's domain ID is default doesn't mean it should have an access to andromeda resources.