### PR TITLE
[domains] switch Values.global_setup to Values.global.is_global_region

### DIFF
--- a/openstack/domain-seeds/README.md
+++ b/openstack/domain-seeds/README.md
@@ -27,5 +27,5 @@ Only the following domains should be seeded:
 - ccadmin
 - global
 
-Set **global_setup** value to **true** for such scenario. All other domain seeds will be ignored.
+Check for **global.is_global_region** value equals **true** for such scenario. All other domain seeds will be ignored.
 **Important** to set a correct kubernetes namespace where keystone will be deployed **(keystoneNamespace: 'monsoon3global', not 'monsoon3')**

--- a/openstack/domain-seeds/ci/test-values.yaml
+++ b/openstack/domain-seeds/ci/test-values.yaml
@@ -1,5 +1,5 @@
 ldapPassword: topSecret
-global_setup: false
 global:
+  is_global_region: false
   domain_seeds:
     skip_hcm_domain: false

--- a/openstack/domain-seeds/templates/domain-bs-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-bs-seed.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.global_setup true }}
+{{- if not .Values.global.is_global_region }}
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:

--- a/openstack/domain-seeds/templates/domain-btp-fp-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-btp-fp-seed.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.global_setup true }}
+{{- if not .Values.global.is_global_region }}
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:

--- a/openstack/domain-seeds/templates/domain-cc3test-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-cc3test-seed.yaml
@@ -9,7 +9,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   requires:
-{{- if eq .Values.global_setup true }}
+{{- if .Values.global.is_global_region }}
     - {{.Values.global.keystoneNamespace}}/keystone-global-seed
 {{- else }}
     - {{.Values.global.keystoneNamespace}}/keystone-seed

--- a/openstack/domain-seeds/templates/domain-ccadmin-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-ccadmin-seed.yaml
@@ -9,7 +9,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   requires:
-{{- if eq .Values.global_setup true }}
+{{- if .Values.global.is_global_region }}
     - {{.Values.global.keystoneNamespace}}/keystone-global-seed
 {{- else }}
     - {{.Values.global.keystoneNamespace}}/keystone-seed

--- a/openstack/domain-seeds/templates/domain-cis-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-cis-seed.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.global_setup true }}
+{{- if not .Values.global.is_global_region }}
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:

--- a/openstack/domain-seeds/templates/domain-cp-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-cp-seed.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.global_setup true }}
+{{- if not .Values.global.is_global_region }}
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:

--- a/openstack/domain-seeds/templates/domain-default-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-default-seed.yaml
@@ -9,7 +9,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   requires:
-{{- if eq .Values.global_setup true }}
+{{- if .Values.global.is_global_region }}
     - {{.Values.global.keystoneNamespace}}/keystone-global-seed
 {{- else }}
     - {{.Values.global.keystoneNamespace}}/keystone-seed

--- a/openstack/domain-seeds/templates/domain-fsn-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-fsn-seed.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.global_setup true }}
+{{- if not .Values.global.is_global_region }}
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:

--- a/openstack/domain-seeds/templates/domain-global-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-global-seed.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global_setup }}
+{{- if .Values.global.is_global_region }}
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:

--- a/openstack/domain-seeds/templates/domain-hcm-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-hcm-seed.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.global_setup true }}
+{{- if not .Values.global.is_global_region }}
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:

--- a/openstack/domain-seeds/templates/domain-hcp03-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-hcp03-seed.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.global_setup true }}
+{{- if not .Values.global.is_global_region }}
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:

--- a/openstack/domain-seeds/templates/domain-hda-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-hda-seed.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.global_setup true }}
+{{- if not .Values.global.is_global_region }}
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:

--- a/openstack/domain-seeds/templates/domain-hec-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-hec-seed.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.global_setup true }}
+{{- if not .Values.global.is_global_region }}
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:

--- a/openstack/domain-seeds/templates/domain-iaas-20e8bf-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-iaas-20e8bf-seed.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.global_setup true }}
+{{- if not .Values.global.is_global_region }}
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:

--- a/openstack/domain-seeds/templates/domain-iaas-34a24e-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-iaas-34a24e-seed.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.global_setup true }}
+{{- if not .Values.global.is_global_region }}
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:

--- a/openstack/domain-seeds/templates/domain-iaas-45b91f-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-iaas-45b91f-seed.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.global_setup true }}
+{{- if not .Values.global.is_global_region }}
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:

--- a/openstack/domain-seeds/templates/domain-iaas-7ff5dd-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-iaas-7ff5dd-seed.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.global_setup true }}
+{{- if not .Values.global.is_global_region }}
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:

--- a/openstack/domain-seeds/templates/domain-iaas-90876f-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-iaas-90876f-seed.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.global_setup true }}
+{{- if not .Values.global.is_global_region }}
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:

--- a/openstack/domain-seeds/templates/domain-iaas-9d6a56-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-iaas-9d6a56-seed.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.global_setup true }}
+{{- if not .Values.global.is_global_region }}
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:

--- a/openstack/domain-seeds/templates/domain-iaas-b56735-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-iaas-b56735-seed.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.global_setup true }}
+{{- if not .Values.global.is_global_region }}
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:

--- a/openstack/domain-seeds/templates/domain-iaas-d3495f-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-iaas-d3495f-seed.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.global_setup true }}
+{{- if not .Values.global.is_global_region }}
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:

--- a/openstack/domain-seeds/templates/domain-iaas-de5955-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-iaas-de5955-seed.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.global_setup true }}
+{{- if not .Values.global.is_global_region }}
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:

--- a/openstack/domain-seeds/templates/domain-iaas-ec5a3e-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-iaas-ec5a3e-seed.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.global_setup true }}
+{{- if not .Values.global.is_global_region }}
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:

--- a/openstack/domain-seeds/templates/domain-kubernikus-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-kubernikus-seed.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.global_setup true }}
+{{- if not .Values.global.is_global_region }}
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:

--- a/openstack/domain-seeds/templates/domain-kyma-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-kyma-seed.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.global_setup true }}
+{{- if not .Values.global.is_global_region }}
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:

--- a/openstack/domain-seeds/templates/domain-monsoon3-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-monsoon3-seed.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.global_setup true }}
+{{- if not .Values.global.is_global_region }}
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:

--- a/openstack/domain-seeds/templates/domain-neo-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-neo-seed.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.global_setup true }}
+{{- if not .Values.global.is_global_region }}
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:

--- a/openstack/domain-seeds/templates/domain-ora-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-ora-seed.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.global_setup true }}
+{{- if not .Values.global.is_global_region }}
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:

--- a/openstack/domain-seeds/templates/domain-s4-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-s4-seed.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.global_setup true }}
+{{- if not .Values.global.is_global_region }}
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:

--- a/openstack/domain-seeds/templates/domain-tempest-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-tempest-seed.yaml
@@ -10,7 +10,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   requires:
-{{- if eq .Values.global_setup true }}
+{{- if .Values.global.is_global_region }}
     - {{.Values.global.keystoneNamespace}}/keystone-global-seed
 {{- else }}
     - {{.Values.global.keystoneNamespace}}/keystone-seed

--- a/openstack/domain-seeds/templates/domain-wbs-seed.yaml
+++ b/openstack/domain-seeds/templates/domain-wbs-seed.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.global_setup true }}
+{{- if not .Values.global.is_global_region }}
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:

--- a/openstack/domain-seeds/values.yaml
+++ b/openstack/domain-seeds/values.yaml
@@ -12,11 +12,10 @@ owner-info:
 global:
 # specify the k8s keystone namespace if it differs from the current chart
   keystoneNamespace: monsoon3
+  # a switch for multi-regional keystone and designate setup
+  is_global_region: false
   domain_seeds:
     skip_hcm_domain: false
-
-# a switch for multi-regional keystone and designate setup
-global_setup: false
 
 # AD/LDAP connection details
 ldapUrl: ldaps://ldap.global.cloud.sap:636


### PR DESCRIPTION
When working on https://github.com/sapcc/helm-charts/pull/8193 I noticed that the `global_setup` variable is misplaced so I created `global.is_global_region` in the values.
This handles all usages of this new variable in all domain seeds.

The diff is in line with the current diff in the pipe for global + DE2. 

related:
https://github.com/sapcc/helm-charts/pull/8385
https://github.com/sapcc/helm-charts/pull/8384