### PR TITLE
[keystone] switch Values.global_setup to Values.global.is_global_region

### DIFF
--- a/openstack/keystone/ci/test-values.yaml
+++ b/openstack/keystone/ci/test-values.yaml
@@ -9,6 +9,7 @@ global:
   registryAlternateRegion: other.docker.registry
   dockerHubMirror: my.dockerhub.mirror
   dockerHubMirrorAlternateRegion: other.dockerhub.mirror
+  is_global_region: false
   osprofiler:
     jager:
       enabled: true

--- a/openstack/keystone/templates/_helpers.tpl
+++ b/openstack/keystone/templates/_helpers.tpl
@@ -16,7 +16,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "keystone.memcached_host" -}}
-{{- if .Values.global_setup -}}
+{{- if .Values.global.is_global_region -}}
 {{.Release.Name}}-memcached.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.db_region}}.{{.Values.global.tld}}
 {{- else -}}
 {{.Release.Name}}-memcached.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.region}}.{{.Values.global.tld}}

--- a/openstack/keystone/templates/bin/_bootstrap.tpl
+++ b/openstack/keystone/templates/bin/_bootstrap.tpl
@@ -18,7 +18,7 @@ keystone-manage --config-file=/etc/keystone/keystone.conf --config-file=/etc/key
 {{- end }}
 {{- if .Values.global.clusterDomain }}
     --bootstrap-internal-url http://keystone.{{.Release.Namespace}}.svc.{{.Values.global.clusterDomain}}:5000/v3 \
-{{- else if .Values.global_setup }}
+{{- else if .Values.global.is_global_region }}
     --bootstrap-internal-url http://{{ .Values.global.keystone_internal_ip }}:5000/v3 \
 {{- else }}
     --bootstrap-internal-url http://keystone.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.region}}.{{.Values.global.tld}}:5000/v3 \

--- a/openstack/keystone/templates/deployment-2faproxy.yaml
+++ b/openstack/keystone/templates/deployment-2faproxy.yaml
@@ -37,7 +37,7 @@ spec:
             {{- end}}
           env:
             - name: OS_AUTH_URL
-{{- if .Values.global_setup }}
+{{- if .Values.global.is_global_region }}
               value: "http://$(KEYSTONE_GLOBAL_SERVICE_HOST):$(KEYSTONE_GLOBAL_SERVICE_PORT)/v3"
 {{- else }}
               value: "http://$(KEYSTONE_SERVICE_HOST):$(KEYSTONE_SERVICE_PORT)/v3"

--- a/openstack/keystone/templates/etc/_keystone.conf.tpl
+++ b/openstack/keystone/templates/etc/_keystone.conf.tpl
@@ -67,7 +67,7 @@ access_token_duration = {{ .Values.api.oauth1.access_token_duration | default "0
 
 [cache]
 backend = dogpile.cache.memcached
-{{- if .Values.global_setup }}
+{{- if .Values.global.is_global_region }}
 memcached_servers = "{{ include "helm-toolkit.utils.joinListWithComma" .Values.memcached.server_ips_ports }}"
 {{- else if .Values.memcached.host }}
 memcache_servers = {{ .Values.memcached.host }}:{{.Values.memcached.port | default 11211}}

--- a/openstack/keystone/templates/ingress-api.yaml
+++ b/openstack/keystone/templates/ingress-api.yaml
@@ -84,7 +84,7 @@ metadata:
     {{- if .Values.services.ingress.tlsacme }}
     kubernetes.io/tls-acme: "true"
     {{- end }}
-    {{- if .Values.global_setup }}
+    {{- if .Values.global.is_global_region }}
     kubernetes.io/ingress.class: "nginx-external"
     {{- end }}
     {{- if .Values.services.ingress.disco }}
@@ -92,7 +92,7 @@ metadata:
     {{- end }}
     {{- include "utils.linkerd.ingress_annotation" . | indent 4 }}
 spec:
-{{- if .Values.global_setup }}
+{{- if .Values.global.is_global_region }}
   ingressClassName: "nginx-external"
 {{- end }}
   tls:
@@ -123,7 +123,7 @@ spec:
           pathType: Prefix
           backend:
             service:
-              name: "{{if .Values.global_setup }}keystone-global{{else}}keystone{{end}}"
+              name: "{{if .Values.global.is_global_region }}keystone-global{{else}}keystone{{end}}"
               port:
                 number: 5000
 {{- end }}

--- a/openstack/keystone/templates/seed.yaml
+++ b/openstack/keystone/templates/seed.yaml
@@ -1,5 +1,7 @@
 {{- if and (hasKey $.Values "seed") (hasKey $.Values.seed "disabled") ($.Values.seed.disabled) }}
 {{- else }}
+{{/* seeding of global region only happens once */}}
+{{- if or (not .Values.global.is_global_region) (eq .Values.global.db_region "eu-de-2") (eq .Values.global.db_region "qa-de-1") }}
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:
@@ -120,7 +122,7 @@ spec:
       region: {{ .Values.global.region }}
 {{- if .Values.global.clusterDomain }}
       url: http://keystone.{{.Release.Namespace}}.svc.{{.Values.global.clusterDomain}}:5000/v3
-{{- else if .Values.global_setup }}
+{{- else if .Values.global.is_global_region }}
       url: http://{{ .Values.global.keystone_internal_ip }}:5000/v3
 {{- else }}
       url: http://{{ .Release.Name }}.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.region}}.{{.Values.global.tld}}:5000/v3
@@ -169,4 +171,5 @@ spec:
       description: Administrator Project
     - name: service
       description: Services Project
+{{- end }}
 {{- end }}

--- a/openstack/keystone/templates/service-api.yaml
+++ b/openstack/keystone/templates/service-api.yaml
@@ -18,7 +18,7 @@ metadata:
 {{- end }}
     {{- include "utils.linkerd.pod_and_service_annotation" . | indent 4 }}
 spec:
-{{- if .Values.global_setup }}
+{{- if .Values.global.is_global_region }}
   type: LoadBalancer
   externalTrafficPolicy: Local
 {{- end }}

--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -11,6 +11,7 @@ global:
   dbPassword: ""
 # registryAlternateRegion: keppel.$REGION.cloud.sap
   linkerd_requested: false
+  is_global_region: false
 
 owner-info:
   support-group: identity
@@ -22,7 +23,6 @@ owner-info:
 
 debug: false
 insecure_debug: false
-global_setup: false
 
 # run a db_sync to migrate the db schema ?
 run_db_migration: true


### PR DESCRIPTION
When working on https://github.com/sapcc/helm-charts/pull/8193 I noticed that the `global_setup` variable is misplaced so I created `global.is_global_region` in the values.
This handles all usages of this new variable in keystone service.

The diff is in line with the current diff in the pipe for global + DE2. 

related:
https://github.com/sapcc/helm-charts/pull/8385
https://github.com/sapcc/helm-charts/pull/8383