### PR TITLE
[designate] switch Values.global_setup to Values.global.is_global_region

### DIFF
--- a/openstack/designate-nanny/ci/test-values.yaml
+++ b/openstack/designate-nanny/ci/test-values.yaml
@@ -1,6 +1,7 @@
 global:
   registry: https://example.org/registry-url
   region: qa-de-99
+  is_global_region: false
 
 nanny_enabled: true
 

--- a/openstack/designate-nanny/templates/_helpers.tpl
+++ b/openstack/designate-nanny/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{define "keystone_api_endpoint_host_public"}}
-{{- if and (eq .Values.global_setup true) (eq .Values.global.db_region "qa-de-1") -}}
+{{- if and .Values.global.is_global_region (eq .Values.global.db_region "qa-de-1") -}}
 identity-3-qa.{{.Values.global.region}}.{{.Values.global.tld}}
 {{- else -}}
 identity-3.{{.Values.global.region}}.{{.Values.global.tld}}

--- a/openstack/designate-nanny/templates/deployment.yaml
+++ b/openstack/designate-nanny/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
      containers:
      - name: {{ .Release.Name }}
        image: {{ required ".Values.global.registry is missing" .Values.global.registry }}/{{ .Values.image.name }}:{{required "missing .Values.image.image_tag" .Values.image.image_tag }}
-       {{- if or (eq .Values.global.region "qa-de-1") (eq .Values.global.region "qa-de-2") (eq .Values.global_setup true) }}
+       {{- if or (eq .Values.global.region "qa-de-1") (eq .Values.global.region "qa-de-2") (.Values.global.is_global_region) }}
        imagePullPolicy: Always
        {{- else }}
        imagePullPolicy: IfNotPresent

--- a/openstack/designate-nanny/values.yaml
+++ b/openstack/designate-nanny/values.yaml
@@ -19,12 +19,11 @@ resources:
     memory: "1Gi"
     cpu: "800m"
 
-global_setup: false
-
 nanny_enabled: false
 
 global:
   linkerd_requested: false # overwritten in regions where enabled
+  is_global_region: false
 
 designate_nanny:
 # defined in secrets:

--- a/openstack/designate/ci/test-values.yaml
+++ b/openstack/designate/ci/test-values.yaml
@@ -9,6 +9,7 @@ global:
   registry: registry
   dockerHubMirror: dockerHubMirror
   dockerHubMirrorAlternateRegion: dockerHubMirrorAlternateRegion
+  is_global_region: false
   domain_seeds:
     customer_domains: [ bar, foo, baz ]
 

--- a/openstack/designate/templates/_helpers.tpl
+++ b/openstack/designate/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{define "designate_api_endpoint_host_public"}}dns-3.{{.Values.global.region}}.{{.Values.global.tld}}{{end}}
 
 {{define "keystone_api_endpoint_host_public"}}
-{{- if and (eq .Values.global_setup true) (eq .Values.global.db_region "qa-de-1") -}}
+{{- if and .Values.global.is_global_region (eq .Values.global.db_region "qa-de-1") -}}
 identity-3-qa.{{.Values.global.region}}.{{.Values.global.tld}}
 {{- else -}}
 identity-3.{{.Values.global.region}}.{{.Values.global.tld}}

--- a/openstack/designate/templates/api-deployment.yaml
+++ b/openstack/designate/templates/api-deployment.yaml
@@ -111,7 +111,7 @@ spec:
               name: container-init
             - name: wsgi-designate
               mountPath: /var/www/cgi-bin/designate
-{{- if .Values.global_setup }}
+{{- if .Values.global.is_global_region }}
             - mountPath: /var/www/html/test.html
               name: designate-etc
               subPath: test.html

--- a/openstack/designate/templates/api-ingress.yaml
+++ b/openstack/designate/templates/api-ingress.yaml
@@ -9,12 +9,12 @@ metadata:
     component: designate
   annotations:
     kubernetes.io/tls-acme: "true"
-    {{- if .Values.global_setup }}
+    {{- if .Values.global.is_global_region }}
     kubernetes.io/ingress.class: "nginx-external"
     {{- end }}
     {{- include "utils.linkerd.ingress_annotation" . | indent 4 }}
 spec:
-{{- if .Values.global_setup }}
+{{- if .Values.global.is_global_region }}
   ingressClassName: "nginx-external"
 {{- end }}
   tls:
@@ -37,15 +37,15 @@ spec:
           pathType: Prefix
           backend:
             service:
-              name: {{ if .Values.global_setup }}designate-global-api{{ else }}designate-api{{ end }}
+              name: {{ if .Values.global.is_global_region }}designate-global-api{{ else }}designate-api{{ end }}
               port:
                 number: {{.Values.global.designate_api_port_internal}}
-{{- if .Values.global_setup }}
+{{- if .Values.global.is_global_region }}
         - path: /test.html
           pathType: Exact
           backend:
             service:
-              name: {{ if .Values.global_setup }}designate-global-api{{ else }}designate-api{{ end }}
+              name: {{ if .Values.global.is_global_region }}designate-global-api{{ else }}designate-api{{ end }}
               port:
                 number: 80
 {{- end }}

--- a/openstack/designate/templates/api-service.yaml
+++ b/openstack/designate/templates/api-service.yaml
@@ -12,7 +12,7 @@ metadata:
     prometheus.io/targets: {{ required ".Values.metrics.prometheus missing" .Values.metrics.prometheus | quote }}
     {{- include "utils.linkerd.pod_and_service_annotation" . | indent 4 }}
 spec:
-{{- if .Values.global_setup }}
+{{- if .Values.global.is_global_region }}
   type: LoadBalancer
   externalTrafficPolicy: Local
 {{- end }}
@@ -23,7 +23,7 @@ spec:
       port: {{ .Values.global.designate_api_port_internal }}
     - name: metrics
       port: {{ .Values.global.designate_metrics_port }}
-{{- if .Values.global_setup }}
+{{- if .Values.global.is_global_region }}
     - name: static
       port: 80
   externalIPs:

--- a/openstack/designate/templates/etc-configmap.yaml
+++ b/openstack/designate/templates/etc-configmap.yaml
@@ -22,7 +22,7 @@ data:
 {{ include (print .Template.BasePath "/etc/_designate_audit_map.yaml") . | indent 4 }}
 {{- end }}
 
-{{- if .Values.global_setup }}
+{{- if .Values.global.is_global_region }}
   test.html: |
 {{ include (print .Template.BasePath "/etc/_test.html.tpl") . | indent 4 }}
 {{- end }}

--- a/openstack/designate/templates/etc/_designate.conf.tpl
+++ b/openstack/designate/templates/etc/_designate.conf.tpl
@@ -189,7 +189,7 @@ auth_type = v3password
 auth_version = v3
 auth_interface = internal
 www_authenticate_uri = https://{{include "keystone_api_endpoint_host_public" .}}/v3
-{{- if .Values.global_setup }}
+{{- if .Values.global.is_global_region }}
 auth_url = {{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{ .Values.global.keystone_internal_ip }}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3
 {{- else }}
 auth_url = {{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3
@@ -198,7 +198,7 @@ user_domain_name = {{.Values.global.keystone_service_domain | default "Default"}
 project_name = {{.Values.global.keystone_service_project | default "service"}}
 project_domain_name = {{.Values.global.keystone_service_domain | default "Default"}}
 region_name = {{.Values.global.region}}
-{{- if .Values.global_setup }}
+{{- if .Values.global.is_global_region }}
 memcached_servers = "{{ include "helm-toolkit.utils.joinListWithComma" .Values.memcached.server_ips_ports }}"
 {{- else }}
 memcached_servers = {{.Release.Name}}-memcached.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.region}}.{{.Values.global.tld}}:{{.Values.global.memcached_port_public | default 11211}}
@@ -432,7 +432,7 @@ all_tcp = {{ .Values.worker_all_tcp }}
 ##############
 [network_api:neutron]
 # Comma separated list of values, formatted "<name>|<neutron_uri>"
-{{- if eq .Values.global_setup false }}
+{{- if not .Values.global.is_global_region }}
 endpoints = {{ .Values.global.region }}|https://network-3.{{ .Values.global.region }}.{{ .Values.global.tld }}
 endpoint_type = publicURL
 timeout = 30

--- a/openstack/designate/templates/etc/_designate_audit_map.yaml
+++ b/openstack/designate/templates/etc/_designate_audit_map.yaml
@@ -1,5 +1,5 @@
 service_type: 'service/dns'
-{{- if .Values.global_setup }}
+{{- if .Values.global.is_global_region }}
 service_name: 'designate-global'
 {{- else }}
 service_name: 'designate'

--- a/openstack/designate/templates/prometheus-alerts.yaml
+++ b/openstack/designate/templates/prometheus-alerts.yaml
@@ -6,7 +6,7 @@
 apiVersion: "monitoring.coreos.com/v1"
 kind: "PrometheusRule"
 metadata:
-{{- if eq $values.global_setup true }}
+{{- if $values.global.is_global_region }}
   name: {{ printf "desginate-global-%s" $path | replace "/" "-" }}
 {{- else }}
   name: {{ printf "desginate-%s" $path | replace "/" "-" }}

--- a/openstack/designate/templates/seeds.yaml
+++ b/openstack/designate/templates/seeds.yaml
@@ -2,6 +2,8 @@
 {{- $cdomains := .Values.global.domain_seeds.customer_domains | required "missing value for .Values.global.domain_seeds.customer_domains" -}}
 {{- $domains  := concat (list "ccadmin" "Default" "cc3test") $cdomains -}}
 
+{{/* seeding of global region only happens once */}}
+{{- if or (not .Values.global.is_global_region) (eq .Values.global.db_region "eu-de-2") (eq .Values.global.db_region "qa-de-1") }}
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
 metadata:
@@ -59,14 +61,14 @@ spec:
 {{- end }}
     - interface: internal
       region: {{ .Values.global.region }}
-{{- if .Values.global_setup }}
+{{- if .Values.global.is_global_region }}
       url: http://{{ .Values.global.designate_internal_ip }}:9001
 {{- else }}
       url: http://{{ .Release.Name }}-api.{{ .Release.Namespace }}.svc.kubernetes.{{ .Values.global.region }}.{{ .Values.global.tld }}:9001
 {{- end }}
     - interface: admin
       region: {{ .Values.global.region }}
-{{- if .Values.global_setup }}
+{{- if .Values.global.is_global_region }}
       url: http://{{ .Values.global.designate_admin_ip }}:9001
 {{- else }}
       url: http://{{ .Release.Name }}-api.{{ .Release.Namespace }}.svc.kubernetes.{{ .Values.global.region }}.{{ .Values.global.tld }}:9001
@@ -284,7 +286,7 @@ spec:
   requires:
   - {{ .Release.Namespace }}/domain-default-seed
   - {{ .Release.Namespace }}/domain-ccadmin-seed
-{{- if .Values.global_setup }}
+{{- if .Values.global.is_global_region }}
   - {{ .Release.Namespace }}/designate-global-seed
   - {{ .Release.Namespace }}/domain-global-seed
 {{- else}}
@@ -308,4 +310,5 @@ spec:
       - user: '{{ .Values.designate_nanny.credentials.designate_api.user | include "resolve_secret" }}@{{.Values.designate_nanny.credentials.designate_api.project_user_domain_name }}'
         role: objectstore_admin
 
+{{- end }}
 {{- end }}

--- a/openstack/designate/values.yaml
+++ b/openstack/designate/values.yaml
@@ -5,7 +5,6 @@
 #
 debug: "True"
 
-global_setup: false
 tempest_enabled: false
 nanny_enabled: false
 
@@ -29,8 +28,9 @@ global:
   designate_mdns_service_ip:
   designate_mdns_akamai_ip:
   designate_service_user: designate
+  is_global_region: false
   domain_seeds:
-    skip_hcm_domain: false
+    customer_domains: []
   linkerd_requested: false
 
 pod:


### PR DESCRIPTION
When working on https://github.com/sapcc/helm-charts/pull/8193 I noticed that the `global_setup` variable is misplaced so I created `global.is_global_region` in the values.
This handles all usages of this new variable in designate service.

Additionally, I added here the fix for the designate seed to only seed `global` from `eu-de-2` to prevent the missing dependency errors in the seeder.

The diff is in line with the current diff in the pipe for global + DE2. 

related:
https://github.com/sapcc/helm-charts/pull/8384
https://github.com/sapcc/helm-charts/pull/8383