### PR TITLE
[Neutron]Add Support_Group label for Redis

### DIFF
--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -836,6 +836,10 @@ memcached:
   alerts:
     support_group: network-api
 
+api-ratelimit-redis:
+  alerts:
+    support_group: network-api
+
 utils:
   trust_bundle:
     enable: false


### PR DESCRIPTION
Starting with helm chart version 2.1.0, redis requires a support_group label.