### PR TITLE
[ironic] move osprofiler configuration to secrets

### DIFF
--- a/openstack/ironic/Chart.yaml
+++ b/openstack/ironic/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Ironic/OpenStack_Project_Ironic_vertical.png
 name: ironic
-version: 0.2.1
+version: 0.2.2
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/ironic/templates/etc/_ironic.conf.tpl
+++ b/openstack/ironic/templates/etc/_ironic.conf.tpl
@@ -123,7 +123,6 @@ record_payloads = {{ if .Values.audit.record_payloads -}}True{{- else -}}False{{
 metrics_enabled = {{ if .Values.audit.metrics_enabled -}}True{{- else -}}False{{- end }}
 {{- end }}
 
-{{- include "osprofiler" . }}
 
 {{- include "ini_sections.cache" . }}
 

--- a/openstack/ironic/templates/etc/_secrets.conf.tpl
+++ b/openstack/ironic/templates/etc/_secrets.conf.tpl
@@ -28,3 +28,5 @@ swift_account = {{required "A valid .Values.swift_account required!" .Values.swi
 {{- end }}
 
 {{ include "ini_sections.audit_middleware_notifications" . }}
+
+{{- include "osprofiler" . }}


### PR DESCRIPTION
osprofiler configuration contains a secret hmac value, so it should be in the secret instead of a configmap.