### PR TITLE
[neutron] move osprofiler configuration to secrets

### DIFF
--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Openstack Neutron
 name: neutron
-version: 0.2.3
+version: 0.2.4
 appVersion: "yoga"
 dependencies:
   - condition: mariadb.enabled

--- a/openstack/neutron/templates/etc/_neutron.conf.tpl
+++ b/openstack/neutron/templates/etc/_neutron.conf.tpl
@@ -139,10 +139,6 @@ quota_security_group_rule = 4
 # Minimum value: 1
 thread_pool_size = 3
 
-{{- if .Values.osprofiler.enabled }}
-{{- include "osprofiler" . }}
-{{- end }}
-
 {{- include "ini_sections.cache" . }}
 
 {{- if hasPrefix "caracal" .Values.imageVersion }}

--- a/openstack/neutron/templates/etc/_server_agent_shared_secrets.ini.tpl
+++ b/openstack/neutron/templates/etc/_server_agent_shared_secrets.ini.tpl
@@ -4,3 +4,7 @@
 [keystone_authtoken]
 username = {{ .Values.global.neutron_service_user | default "neutron" | include "resolve_secret" }}
 password = {{ .Values.global.neutron_service_password | default "" | include "resolve_secret" }}
+
+{{- if .Values.osprofiler.enabled }}
+{{- include "osprofiler" . }}
+{{- end }}


### PR DESCRIPTION
osprofiler configuration contains a secret hmac value, so it should be in the secret instead of a configmap.