### PR TITLE
[billing] seed new billing role and cleanup seeding to global

### DIFF
--- a/openstack/billing/ci/test-values.yaml
+++ b/openstack/billing/ci/test-values.yaml
@@ -1,5 +1,8 @@
 global:
+  is_global_region: false
+  keystoneNamespace: monsoon3
   region: xx-yy-1
+  db_region: zz-xx-1
   vaultBaseURL: vault.example.com/secrets
   domain_seeds:
     customer_domains: [ bar, foo, baz ]

--- a/openstack/billing/templates/prometheus-alerts.yaml
+++ b/openstack/billing/templates/prometheus-alerts.yaml
@@ -8,7 +8,7 @@ metadata:
     type: alerting-rules
     prometheus: openstack
 
-{{- $keystone_namespace := .Values.is_global | ternary "monsoon3global" "monsoon3" }}
+{{- $keystone_namespace := .Values.global.is_global_region | ternary "monsoon3global" "monsoon3" }}
 
 spec:
   groups:
@@ -34,7 +34,7 @@ spec:
         # - group CCADMIN_CLOUD_ADMINS@ccadmin in project cloud_admin@ccadmin
         # - used TCC_BILLING_001               in project cloud_admin@ccadmin (only in qa-de-1)
         - alert: CBRMasterdataUnexpectedCloudViewerRoleAssignments
-          expr: max(openstack_assignments_per_role{role_name="cloud_masterdata_viewer",namespace="{{ $keystone_namespace }}"}) > {{if and (not .Values.is_global) (eq .Values.global.region "qa-de-1")}}3{{else}}2{{end}}
+          expr: max(openstack_assignments_per_role{role_name="cloud_masterdata_viewer",namespace="{{ $keystone_namespace }}"}) > {{if and (not .Values.global.is_global_region) (eq .Values.global.region "qa-de-1")}}3{{else}}2{{end}}
           for: 10m
           labels:
             support_group: containers

--- a/openstack/billing/templates/prometheus-alerts.yaml
+++ b/openstack/billing/templates/prometheus-alerts.yaml
@@ -8,8 +8,6 @@ metadata:
     type: alerting-rules
     prometheus: openstack
 
-{{- $keystone_namespace := .Values.global.is_global_region | ternary "monsoon3global" "monsoon3" }}
-
 spec:
   groups:
   - name: openstack-billing-roleassignment.alerts
@@ -17,7 +15,7 @@ spec:
         # allowed role assignments for the `cloud_masterdata_admin` role:
         # - none yet
         - alert: CBRMasterdataUnexpectedCloudAdminRoleAssignments
-          expr: max(openstack_assignments_per_role{role_name="cloud_masterdata_admin",namespace="{{ $keystone_namespace }}"}) > 0
+          expr: max(openstack_assignments_per_role{role_name="cloud_masterdata_admin",namespace="{{ .Values.global.keystoneNamespace }}"}) > 0
           for: 10m
           labels:
             support_group: containers
@@ -34,7 +32,7 @@ spec:
         # - group CCADMIN_CLOUD_ADMINS@ccadmin in project cloud_admin@ccadmin
         # - used TCC_BILLING_001               in project cloud_admin@ccadmin (only in qa-de-1)
         - alert: CBRMasterdataUnexpectedCloudViewerRoleAssignments
-          expr: max(openstack_assignments_per_role{role_name="cloud_masterdata_viewer",namespace="{{ $keystone_namespace }}"}) > {{if and (not .Values.global.is_global_region) (eq .Values.global.region "qa-de-1")}}3{{else}}2{{end}}
+          expr: max(openstack_assignments_per_role{role_name="cloud_masterdata_viewer",namespace="{{ .Values.global.keystoneNamespace }}"}) > {{if eq .Values.global.region "qa-de-1"}}3{{else}}2{{end}}
           for: 10m
           labels:
             support_group: containers

--- a/openstack/billing/templates/seeds.yaml
+++ b/openstack/billing/templates/seeds.yaml
@@ -1,13 +1,10 @@
 {{- $vbase  := .Values.global.vaultBaseURL | required "missing value for .Values.global.vaultBaseURL" -}}
 {{- $region := .Values.global.region       | required "missing value for .Values.global.region"       -}}
 {{- $tld    := .Values.global.tld          | required "missing value for .Values.global.tld"          -}}
+{{/* cdomains equals [ "global" ] in global region */}}
 {{- $cdomains := .Values.global.domain_seeds.customer_domains | required "missing value for .Values.global.domain_seeds.customer_domains" -}}
 {{- $domains  := concat (list "ccadmin") $cdomains -}}
 {{- $cdomainsWithoutSupportProjects := .Values.global.domain_seeds.customer_domains_without_support_projects | required "missing value for .Values.global.domain_seeds.customer_domains_without_support_projects" -}}
-
-{{- if .Values.is_global -}}
-  {{- $domains = list "ccadmin" "global" -}}
-{{- end -}}
 
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: OpenstackSeed
@@ -15,12 +12,12 @@ metadata:
   name: billing-seed
 spec:
   requires:
-    {{- $base_seed_namespace := .Values.is_global | ternary "monsoon3global" "monsoon3" }}
+    {{- $base_seed_namespace := .Values.global.is_global_region | ternary "monsoon3global" "monsoon3" }}
     {{- range $domains }}
     - {{ $base_seed_namespace }}/domain-{{replace "_" "-" .|lower}}-seed
     {{- end }}
     - {{ $base_seed_namespace }}/domain-cc3test-seed
-    {{- if not .Values.is_global }}
+    {{- if not .Values.global.is_global_region }}
     - swift/swift-seed
     {{- end }}
 
@@ -40,7 +37,7 @@ spec:
     description: 'SAP Converged Cloud Billing services'
     endpoints:
     - interface: public
-      {{- if .Values.is_global }}
+      {{- if .Values.global.is_global_region }}
       region: global
       url: 'https://{{ $region | contains "qa" | ternary "billing-qa" "billing" }}.global.{{ $tld }}:64000'
       {{- else }}
@@ -49,21 +46,26 @@ spec:
       {{- end }}
 
   domains:
+  # we are unsure who mantains this, so as long as nobody requests it and there is no secret in vault, we don't deploy this part to global
+  {{- if not .Values.global.is_global_region}}
   - name: Default
     users:
     - name: masterdata_scanner # service user for a data quality check job
       description: 'Masterdata Scanner (Data Quality Validation)'
       password: {{ printf "%s/%s/billing/keystone-user/masterdata-scanner/password" $vbase $region | quote }}
+  {{- end }}
 
   - name: cc3test
+  {{- if not .Values.global.is_global_region}}
     role_assignments:
     - user: masterdata_scanner@Default
       role: masterdata_admin
       inherited: true
-  {{- if and (eq $region "qa-de-1") (not .Values.is_global) }}
+  {{- end }}
+  {{- if and (eq $region "qa-de-1") (not .Values.global.is_global_region) }}
     projects:
     - name: billing_test
-      description: 'project for used for testing the billing service'
+      description: 'project used for testing the billing service'
       # Role provisioned from CAM to enable takeover of seeded project by billing admins
       role_assignments:
       - group: CCADMIN_BILLING_ADMIN@ccadmin
@@ -76,6 +78,7 @@ spec:
   {{- end }}
 
   {{- range $domains }}
+  {{- if not (hasPrefix "iaas-" .) }}
   - name: {{ . | lower }}
     role_assignments:
     - user: masterdata_scanner@Default
@@ -83,7 +86,7 @@ spec:
       inherited: true
     {{- if eq . "ccadmin" }}
     projects:
-    {{- if not $.Values.is_global }}
+    {{- if not $.Values.global.is_global_region }}
     - name: billing
       description: 'Billing Administration for Converged Cloud'
       role_assignments:
@@ -97,10 +100,13 @@ spec:
       role_assignments:
         - user: masterdata_scanner@Default
           role: cloud_identity_viewer
-        {{- if and (eq $.Values.global.region "qa-de-1") (not $.Values.is_global)}}
+        # this role is necessary to view a complete flavor list across the region with GET compute-3.$REGION.cloud.sap/$VERSION/flavors, there is currently no cloud_compute_viewer role
+        - user: TCC_BILLING_001
+          role: cloud_compute_admin
+        {{- if and (eq $.Values.global.region "qa-de-1") (not $.Values.global.is_global_region)}}
         - user: TCC_BILLING_001
           role: cloud_masterdata_viewer
-        {{end}}
+        {{- end }}
     {{- end }}
     groups:
     {{- if eq . "ccadmin" }}
@@ -115,7 +121,7 @@ spec:
       - project: cc-demo
         role: masterdata_admin
     {{- end }}
-    - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_API_SUPPORT
+    - name: {{ hasPrefix "iaas-" . | ternary . ( upper . ) }}_API_SUPPORT
       role_assignments:
       {{- if not (has . $cdomainsWithoutSupportProjects) }}
       - project: api_support
@@ -129,7 +135,7 @@ spec:
         role: masterdata_admin
         inherited: true
   {{- if ne . "global" }}
-    - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_COMPUTE_SUPPORT
+    - name: {{ hasPrefix "iaas-" . | ternary . ( upper . ) }}_COMPUTE_SUPPORT
       role_assignments:
       {{- if not (has . $cdomainsWithoutSupportProjects) }}
       - project: compute_support
@@ -142,7 +148,7 @@ spec:
       - domain: {{ . | lower }}
         role: masterdata_viewer
         inherited: true
-    - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_NETWORK_SUPPORT
+    - name: {{ hasPrefix "iaas-" . | ternary . ( upper . ) }}_NETWORK_SUPPORT
       role_assignments:
       {{- if not (has . $cdomainsWithoutSupportProjects) }}
       - project: network_support
@@ -155,7 +161,7 @@ spec:
       - domain: {{ . | lower }}
         role: masterdata_viewer
         inherited: true
-    - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_STORAGE_SUPPORT
+    - name: {{ hasPrefix "iaas-" . | ternary . ( upper . ) }}_STORAGE_SUPPORT
       role_assignments:
       {{- if not (has . $cdomainsWithoutSupportProjects) }}
       - project: storage_support
@@ -168,7 +174,7 @@ spec:
       - domain: {{ . | lower }}
         role: masterdata_viewer
         inherited: true
-    - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_SERVICE_DESK
+    - name: {{ hasPrefix "iaas-" . | ternary . ( upper . ) }}_SERVICE_DESK
       role_assignments:
       {{- if not (has . $cdomainsWithoutSupportProjects) }}
       - project: service_desk
@@ -189,5 +195,6 @@ spec:
       - domain: bs
         role: masterdata_viewer
         inherited: true
+  {{- end }}
   {{- end }}
   {{- end }}

--- a/openstack/billing/templates/seeds.yaml
+++ b/openstack/billing/templates/seeds.yaml
@@ -1,5 +1,6 @@
-{{- $vbase  := .Values.global.vaultBaseURL | required "missing value for .Values.global.vaultBaseURL" -}}
+{{- $vbase  := .Values.global.vaultBaseURL   | required "missing value for .Values.global.vaultBaseURL" -}}
 {{- $region := .Values.global.region       | required "missing value for .Values.global.region"       -}}
+{{- $dbRegion := .Values.global.db_region  | required "missing value for .Values.global.db_region"    -}}
 {{- $tld    := .Values.global.tld          | required "missing value for .Values.global.tld"          -}}
 {{/* cdomains equals [ "global" ] in global region */}}
 {{- $cdomains := .Values.global.domain_seeds.customer_domains | required "missing value for .Values.global.domain_seeds.customer_domains" -}}
@@ -12,11 +13,10 @@ metadata:
   name: billing-seed
 spec:
   requires:
-    {{- $base_seed_namespace := .Values.global.is_global_region | ternary "monsoon3global" "monsoon3" }}
     {{- range $domains }}
-    - {{ $base_seed_namespace }}/domain-{{replace "_" "-" .|lower}}-seed
+    - {{ $.Values.global.keystoneNamespace }}/domain-{{replace "_" "-" .|lower}}-seed
     {{- end }}
-    - {{ $base_seed_namespace }}/domain-cc3test-seed
+    - {{ $.Values.global.keystoneNamespace }}/domain-cc3test-seed
     {{- if not .Values.global.is_global_region }}
     - swift/swift-seed
     {{- end }}
@@ -37,13 +37,8 @@ spec:
     description: 'SAP Converged Cloud Billing services'
     endpoints:
     - interface: public
-      {{- if .Values.global.is_global_region }}
-      region: global
-      url: 'https://{{ $region | contains "qa" | ternary "billing-qa" "billing" }}.global.{{ $tld }}:64000'
-      {{- else }}
-      region: '{{ $region }}'
-      url: 'https://billing.{{ $region }}.{{ $tld }}:64000'
-      {{- end }}
+      region: {{ $region }}
+      url: 'https://{{ and (contains "qa" $dbRegion) .Values.global.is_global_region | ternary "billing-qa" "billing" }}.{{ $region }}.{{ $tld }}:64000'
 
   domains:
   # we are unsure who mantains this, so as long as nobody requests it and there is no secret in vault, we don't deploy this part to global
@@ -62,7 +57,7 @@ spec:
       role: masterdata_admin
       inherited: true
   {{- end }}
-  {{- if and (eq $region "qa-de-1") (not .Values.global.is_global_region) }}
+  {{- if eq $region "qa-de-1"}}
     projects:
     - name: billing_test
       description: 'project used for testing the billing service'
@@ -103,7 +98,7 @@ spec:
         # this role is necessary to view a complete flavor list across the region with GET compute-3.$REGION.cloud.sap/$VERSION/flavors, there is currently no cloud_compute_viewer role
         - user: TCC_BILLING_001
           role: cloud_compute_admin
-        {{- if and (eq $.Values.global.region "qa-de-1") (not $.Values.global.is_global_region)}}
+        {{- if eq $region "qa-de-1"}}
         - user: TCC_BILLING_001
           role: cloud_masterdata_viewer
         {{- end }}
@@ -184,7 +179,7 @@ spec:
         role: masterdata_viewer
         inherited: true
   {{- end }}
-  {{- if and (eq . "bs") (ne $.Values.global.region "qa-de-1") }}
+  {{- if and (eq . "bs") (ne $region "qa-de-1") }}
     - name: BS_CCloud_SO_TLO
       role_assignments:
       - domain: bs

--- a/openstack/billing/values.yaml
+++ b/openstack/billing/values.yaml
@@ -1,5 +1,9 @@
 global:
   is_global_region: false
+  keystoneNamespace: DEFINED_IN_VALUES_FILE
+  region: DEFINED_IN_VALUES_FILE
+  db_region: DEFINED_IN_VALUES_FILE
+  vaultBaseURL: DEFINED_IN_VALUES_FILE
   domain_seeds:
     customer_domains: []
     customer_domains_without_support_projects: []

--- a/openstack/billing/values.yaml
+++ b/openstack/billing/values.yaml
@@ -1,6 +1,8 @@
 global:
+  is_global_region: false
   domain_seeds:
-    skip_hcm_domain: false
+    customer_domains: []
+    customer_domains_without_support_projects: []
 
 owner-info:
   support-group: containers
@@ -9,6 +11,3 @@ owner-info:
     - Stefan Majewsky
     - Sandro Jäckel
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/openstack/billing
-
-# will be set to true by the CI for the respective deployments
-is_global: false


### PR DESCRIPTION
This does a few things:
* add new role for listing flavors
* use `is_global_region` from values (needs pipeline change)
* fix `missing project api_support@global` error in global region
* remove `masterdata_scanner` from global (probably not in use ATM)
* remove `iaas-` support seeding (not necessary according to @majewsky )

[billingDE1diff.txt](https://github.com/user-attachments/files/19503967/billingDE1diff.txt)
[billingGlobalDE2diff.txt](https://github.com/user-attachments/files/19503969/billingGlobalDE2diff.txt)

