### PR TITLE
alertmanager: use support groups from values

### DIFF
--- a/global/prometheus-alertmanager-operated/Chart.yaml
+++ b/global/prometheus-alertmanager-operated/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 description: Prometheus Alertmanager via operator.
 name: prometheus-alertmanager-operated
-version: 4.5.7
+version: 4.6.0
 
 dependencies:
   - alias: prometheus-alertmanager

--- a/global/prometheus-alertmanager-operated/templates/am-config-route-slack.yaml
+++ b/global/prometheus-alertmanager-operated/templates/am-config-route-slack.yaml
@@ -311,7 +311,7 @@ spec:
             value: global|{{ without .Values.regions "qa-de-1" | join "|" }}
           - name: support_group
             matchType: "=~"
-            value: src|network-data|network-security|network-lb|network-wan|storage|capacity-ops
+            value: {{ without .Values.supportGroups "compute" "compute-storage-api" "email" "identity" "foundation"  "network-api" "observability" "containers" | join "|" }}
 
       - receiver: support_group_alerts_warning
         continue: true

--- a/global/prometheus-alertmanager-operated/values.yaml
+++ b/global/prometheus-alertmanager-operated/values.yaml
@@ -110,19 +110,20 @@ regions:
 
 # Please keep this list in sync with `system/gatekeeper-config/values.yaml` field "known_support_groups".
 supportGroups:
+  - capacity-ops
   - compute
   - compute-storage-api
   - containers
+  - coredns
   - email
-  - identity
   - foundation
+  - identity
   - network-api
+  - network-data
+  - network-lb
+  - network-security
+  - network-wan
   - observability
   - src
-  - network-data
-  - network-security
-  - network-lb
-  - network-wan
   - storage
-  - capacity-ops
   - workload-management

--- a/system/gatekeeper-config/values.yaml
+++ b/system/gatekeeper-config/values.yaml
@@ -23,19 +23,20 @@ helm_manifest_parser_url: http://helm-manifest-parser.kube-system.svc
 
 # Please keep this list in sync with `global/prometheus-alertmanager-operated/values.yaml` field "supportGroups".
 known_support_groups:
+  - capacity-ops
   - compute
   - compute-storage-api
   - containers
+  - coredns
   - email
-  - identity
   - foundation
+  - identity
   - network-api
+  - network-data
+  - network-lb
+  - network-security
+  - network-wan
   - observability
   - src
-  - network-data
-  - network-security
-  - network-lb
-  - network-wan
   - storage
-  - capacity-ops
   - workload-management


### PR DESCRIPTION
- Use support group from values.
- adds `coredns` support group
- Ignore support groups which do have a dedicated slack webhook for critical alerts.

```diff
prometheus-alertmanager, route-slack, AlertmanagerConfig (monitoring.coreos.com) has changed:
...
      - continue: true
        matchers:
        - matchType: =
          name: severity
          value: critical
        - matchType: =~
          name: region
          value: global|ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|ap-sa-2|eu-de-1|eu-de-2|eu-nl-1|la-br-1|na-ca-1|na-us-1|na-us-2|na-us-3
        - matchType: =~
          name: support_group
-         value: src|network-data|network-security|network-lb|network-wan|storage|capacity-ops
+         value: capacity-ops|coredns|network-data|network-lb|network-security|network-wan|src|storage|workload-management
        receiver: support_group_alerts_critical
      - continue: true
        matchers:
        - matchType: =
          name: severity
          value: warning
        - matchType: =~
          name: region
          value: global|ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|ap-sa-2|eu-de-1|eu-de-2|eu-nl-1|la-br-1|na-ca-1|na-us-1|na-us-2|na-us-3
        - matchType: =~
          name: support_group
-         value: compute|compute-storage-api|containers|email|identity|foundation|network-api|observability|src|network-data|network-security|network-lb|network-wan|storage|capacity-ops|workload-management
+         value: capacity-ops|compute|compute-storage-api|containers|coredns|email|foundation|identity|network-api|network-data|network-lb|network-security|network-wan|observability|src|storage|workload-management
        receiver: support_group_alerts_warning
      - continue: true
        matchers:
        - matchType: =~
          name: severity
          value: critical|warning
        - matchType: =
          name: region
          value: qa-de-1
        - matchType: =~
          name: support_group
-         value: compute|compute-storage-api|containers|email|identity|foundation|network-api|observability|src|network-data|network-security|network-lb|network-wan|storage|capacity-ops|workload-management
+         value: capacity-ops|compute|compute-storage-api|containers|coredns|email|foundation|identity|network-api|network-data|network-lb|network-security|network-wan|observability|src|storage|workload-management
        receiver: support_group_alerts_qa
      - continue: true
        matchers:
        - matchType: =~
          name: severity
          value: critical|warning
        - matchType: =~
          name: region
          value: qa-de-2|qa-de-3|qa-de-4|qa-de-5|qa-de-6
        - matchType: =~
          name: support_group
-         value: compute|compute-storage-api|containers|email|identity|foundation|network-api|observability|src|network-data|network-security|network-lb|network-wan|storage|capacity-ops|workload-management
+         value: capacity-ops|compute|compute-storage-api|containers|coredns|email|foundation|identity|network-api|network-data|network-lb|network-security|network-wan|observability|src|storage|workload-management
        receiver: support_group_alerts_labs
      - continue: true
        matchers:
        - matchType: =
          name: tier
          value: ad
        - matchType: =
          name: severity
          value: warning
        - matchType: =~
...
```