### PR TITLE
keppel: add technical user for pushing from Concourse CI

### DIFF
--- a/openstack/keppel/templates/seed.yaml
+++ b/openstack/keppel/templates/seed.yaml
@@ -41,6 +41,14 @@ spec:
           description: Keppel End-to-End Test User
           password: {{ printf "%s/%s/keppel/keystone-user/e2e-test/password" $vbase $region | quote }}
         {{- end }}
+        {{- if eq $region "eu-de-1" }}
+        - name: keppel-concourse
+          description: Keppel Access User for Concourse CI
+          password: {{ printf "%s/%s/keppel/keystone-user/concourse/password" $vbase $region | quote }}
+          role_assignments:
+            - project: service
+              role:    registry_viewer # worthless role assignment, used only to enable Keystone login (actual access to relevant Keppel accounts is given by RBAC policies)
+        {{- end }}
 
     - name: ccadmin
       groups:


### PR DESCRIPTION
Concourse currently uses an application credential issued from my personal account, so the audit log looks like I'm pushing everything. I would like to get rid of this.

Also, the newer Keppel accounts will be configured so that only this specific user may push.

This user is only provisioned in eu-de-1 because every other region only holds replica accounts where pushing does not work.