### PR TITLE
[Neutron] Increase Rate Limit - SG Rule Create

### DIFF
--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -762,7 +762,7 @@ rate_limit:
           limit: 200r/m
       security-group-rules:
         - action: create
-          limit: 100r/m
+          limit: 1000r/m
         - action: read/list
           limit: 7700r/m
       security-group-rules/security-group-rule:


### PR DESCRIPTION
Increase create security group rule limit for all qa, bronze and silver regions.