### PR TITLE
chore(elektra): add exception for keystone federation

### DIFF
--- a/openstack/elektra/templates/ingress_public.yaml
+++ b/openstack/elektra/templates/ingress_public.yaml
@@ -34,3 +34,10 @@ spec:
                 name: elektra
                 port:
                   number: 80
+          - path: /verify-auth-token
+            pathType: ImplementationSpecific 
+            backend:
+              service:
+                name: elektra
+                port:
+                  number: 80                  


### PR DESCRIPTION
This pull request introduces an exception to the Elektra ingress configuration to bypass OIDC (OpenID Connect) authentication for the path /verify-auth-token. This adjustment is necessary because the path is utilized by the Keystone federation for authentication purposes, and OIDC should not interfere with its operation.