### PR TITLE
[Neutron] Run rabbitmq credential-helper as sidecar

### DIFF
--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -9,6 +9,9 @@ osprofiler:
   enabled: false
 
 global:
+  rabbitmq:
+    native_sidecar:
+      enabled: false
   neutron_service_user: neutron
   dbUser: neutron
   # dbPassword:


### PR DESCRIPTION
The RabbitMQ chart offers a credential updater helper, which is executed either as init or sidecar container. The first option is the default setting (based on the global values).

Acutally the rabbitmq container never starts as the credential-update initcontianer never terminates. Seems like it is constantly checking for credential updates.