### PR TITLE
[persephone] added new roles to blocklist_roles

### DIFF
--- a/openstack/keystone/templates/etc/_policy.yaml.tpl
+++ b/openstack/keystone/templates/etc/_policy.yaml.tpl
@@ -56,7 +56,9 @@
   'cloud_identity_viewer':%(target.role.name)s or
   'cloud_support_tools_viewer':%(target.role.name)s or
   'cloud_email_admin':%(target.role.name)s or
-  'cloud_inventory_viewer':%(target.role.name)s"
+  'cloud_inventory_viewer':%(target.role.name)s" or
+  'cloud_persephone_admin':%(target.role.name)s or
+  'cloud_persephone_viewer':%(target.role.name)s
 
 "blocklist_projects": "'{{required ".Values.api.cloudAdminProjectId is missing" .Values.api.cloudAdminProjectId}}':%(target.project.id)s"
 


### PR DESCRIPTION
[Persephone](https://github.wdf.sap.corp/cc/persephone/) is a new project/service meant to serve as an "API proxy" to the Gardener API, so that customers can easily set up new Shoots in SCI in a couple straight-forward steps.

cc @jknipper @SuperSandro2000 