### PR TITLE
Update cinder.alerts

### DIFF
--- a/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
+++ b/prometheus-exporters/openstack-exporter/alerts/cinder.alerts
@@ -3,7 +3,7 @@ groups:
   rules:
   - alert: CinderBackendStorageEmpty
     expr: >
-      sum(cinder_free_capacity_gib == 0) by (region, shard, backend) or sum(cinder_total_capacity_gib == 0) by (region, shard, backend)
+      sum(cinder_free_capacity_gib{backend="standard_hdd"} == 0) by (region, shard, backend) or sum(cinder_total_capacity_gib{backend="standard_hdd"} == 0) by (region, shard, backend)
     for: 15m
     labels:
       severity: critical


### PR DESCRIPTION
CinderBackendStorageEmpty alerts will only fire if backend is Standard_HDD. Added filter to remove alerts for SSD and FCD.