### PR TITLE
[Neutron] Fix nsxv3-agent sentry env indentation

### DIFF
--- a/openstack/neutron/templates/vct-nsxv3-agent-deployment.yaml
+++ b/openstack/neutron/templates/vct-nsxv3-agent-deployment.yaml
@@ -53,7 +53,7 @@ template: |
           command: ["dumb-init"]
           args: ["neutron-nsxv3-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-dir", "/etc/neutron/secrets", "--config-file", "/etc/neutron/plugins/ml2/ml2-conf.ini", "--config-file", "/etc/neutron/plugins/ml2/ml2-nsxv3.ini"]
           env:
-          {{- include "utils.sentry_config" . | nindent 12 }}
+          {{- include "utils.sentry_config" . | nindent 10 }}
           - name: PYTHONWARNINGS
             value: "ignore:Unverified HTTPS request"
           - name: PGAPPNAME


### PR DESCRIPTION
The indentation needs to be 10 like in the "utils.trust_bundle.env" later in the file. Otherwise, rendering the template generates invalid YAML.

		yaml.parser.ParserError: while parsing a block mapping
		  in "<file>", line 41, column 9
		expected <block end>, but found '-'
		  in "<file>", line 52, column 9