### PR TITLE
[Neutron] Support Password Ratelimit Backend

### DIFF
--- a/openstack/neutron/templates/deployment-server.yaml
+++ b/openstack/neutron/templates/deployment-server.yaml
@@ -139,6 +139,11 @@ spec:
             - mountPath: /etc/neutron/secrets/neutron-arista-secrets.conf
               name: neutron-arista-secrets
               subPath: neutron-arista-secrets.conf
+{{- if .Values.rate_limit.enabled }}
+            - mountPath: {{ .Values.rate_limit.backend_secret_file }}
+              name: neutron-ratelimit-backend-secret
+              subPath: ratelimit-backend-secret.conf
+{{- end }}
             - mountPath: /etc/neutron/plugins/asr1k-global.ini
               name: neutron-etc
               subPath: asr1k-global.ini
@@ -296,6 +301,11 @@ spec:
         - name: neutron-cc-fabric-secrets
           secret:
             secretName: neutron-cc-fabric-secrets
+{{- end }}
+{{- if .Values.rate_limit.enabled }}
+        - name: neutron-ratelimit-backend-secret
+          secret:
+            secretName: neutron-ratelimit-backend-secret
 {{- end }}
         - name: neutron-etc-vendor
           configMap:

--- a/openstack/neutron/templates/etc/_api-paste.ini.tpl
+++ b/openstack/neutron/templates/etc/_api-paste.ini.tpl
@@ -103,6 +103,7 @@ clock_accuracy = 1ns
 log_sleep_time_seconds: {{ .Values.rate_limit.log_sleep_time_seconds }}
 backend_host = {{ .Release.Name }}-api-ratelimit-redis
 backend_port = 6379
+backend_secret_file =  {{ .Values.rate_limit.backend_secret_file }}
 backend_timeout_seconds = {{ .Values.rate_limit.backend_timeout_seconds }}
 {{- end }}
 

--- a/openstack/neutron/templates/secret-neutron-ratelimit.yaml
+++ b/openstack/neutron/templates/secret-neutron-ratelimit.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.rate_limit.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: neutron-ratelimit-backend-secret
+  labels:
+    system: openstack
+    application: {{ .Release.Name }}
+type: Opaque
+data:
+  ratelimit-backend-secret.conf: {{ required "Rate Limit Middleware requires a Backend Password" (index .Values "api-ratelimit-redis" "redisPassword") | b64enc | quote }}
+{{- end }}

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -655,6 +655,7 @@ watcher:
 # openstack-rate-limit
 rate_limit:
   enabled: false
+  backend_secret_file: /etc/neutron/ratelimit-backend-secret.conf
   rate_limit_by: target_project_id
   max_sleep_time_seconds: 0
   log_sleep_time_seconds: 10


### PR DESCRIPTION
    [Neutron] Support Password Ratelimit Backend
    
    The Redis helm chart enforces the access via a password. If no
    password is set, a random pw is created by container start
    automatically.
    
    So far the openstack-ratelimit middleware does not support connecting to
    a Redis backend with a password set. Requires https://github.com/sapcc/openstack-rate-limit-middleware/pull/29
    The middleware loads the backend password from a file. With this PR we
    mount the Redis password into the neutron-server so it will be picked up
    by the ratelimit middleware.
