### PR TITLE
[mariadb] always try to create root user on pod init

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.19.1 - 2025/04/02
+* `set-root-password` init container now always tries to create `'root'@'localhost'` and `'root'@'%'` user if it doesn't exist
+  * this helps to avoid lock-out issue, if this user was previously deleted
+
 ## v0.19.0 - 2025/03/25
 * Remove the following internal helm template helper functions:
   * `keystone_url`

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,6 +2,6 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.19.0
+version: 0.19.1
 # scripts/docker-entyrpoint.sh should be updated when appVersion is updated
 appVersion: 10.5.28

--- a/common/mariadb/scripts/mariadb-set-root-password.sh
+++ b/common/mariadb/scripts/mariadb-set-root-password.sh
@@ -15,7 +15,11 @@ MYSQL_PASSWORD="${mysql_pass:-$MYSQL_ROOT_PASSWORD}"
 
 cat > /etc/mysql/init-file/init.sql <<-EOSQL || true
 SET SESSION sql_log_bin=0;
+CREATE USER IF NOT EXISTS 'root'@'localhost';
+CREATE USER IF NOT EXISTS 'root'@'%';
 ALTER USER 'root'@'localhost' IDENTIFIED VIA unix_socket;
 ALTER USER 'root'@'%' IDENTIFIED BY '$(escape_special "${MYSQL_PASSWORD}")';
+GRANT ALL ON *.* TO 'root'@'localhost' WITH GRANT OPTION;
+GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION;
 FLUSH PRIVILEGES;
 EOSQL


### PR DESCRIPTION
* `set-root-password` init container now always tries to create `'root'@'localhost'` and `'root'@'%'` user if it doesn't exist

This helps to avoid lock-out issue, if this user was previously deleted