### PR TITLE
[unbound] introducing the DnsUnbound{1,2}DisproportionateAmountOfTraffic

### DIFF
--- a/system/unbound/templates/prometheus-alerts.yaml
+++ b/system/unbound/templates/prometheus-alerts.yaml
@@ -61,6 +61,22 @@ spec:
         description: 'DNS {{ $.Values.unbound.name }} recursor in {{ $.Values.global.region }} is getting less than 10% of the usual traffic.'
         summary: 'DNS {{ $.Values.unbound.name }} recursor in {{ $.Values.global.region }} is getting less than 10% of the usual traffic compared to the 24h avegrage.'
 
+    - alert: Dns{{ $.Values.unbound.name | title }}DisproportionateAmountOfTraffic
+      expr: abs(sum(rate(unbound_queries_total{app="{{ $.Values.unbound.name }}", namespace="dns-recursor"}[5m]))/sum(rate(unbound_queries_total{namespace="dns-recursor"}[5m])) - 0.5) > {{ $.Values.unbound.tolerable_traffic_distribution_deviation | default 10 }}/100
+      for: 5m
+      labels:
+        context: unbound
+        dashboard: dns-unbound-and-f5-performance
+        meta: {{ $.Values.unbound.name }}
+        service: unbound
+        severity: warning
+        support_group: coredns
+        tier: os
+        playbook: 'docs/devops/alert/designate/#test_unbound_endpoint'
+      annotations:
+        description: 'DNS {{ $.Values.unbound.name }} recursor in {{ $.Values.global.region }} is getting a disproportionate amount of traffic.'
+        summary: 'DNS {{ $.Values.unbound.name }} recursor in {{ $.Values.global.region }} is getting a disproportionate amount of traffic. Expected between {{ sub 50 $.Values.unbound.tolerable_traffic_distribution_deviation | default 10 }}% and {{ add 50 $.Values.unbound.tolerable_traffic_distribution_deviation | default 10}}% of the total traffic, ideally as close to 50% as possible.'
+
 ---
 apiVersion: "monitoring.coreos.com/v1"
 kind: "PrometheusRule"


### PR DESCRIPTION
Normally we expoect both unbounds to get close to 50% of the total traffic. IOW it should be evenly devided between the two unbounds.

The default tolerance is 10%, meaning that the alert will fire if the traffic drops below 40% or jumps above 60%.

We can change that by setting ```$.Values.unbound.tolerable_traffic_distribution_deviation```