### PR TITLE
chore(greenhouse): Adds cert-manager webhook timeout

### DIFF
--- a/system/greenhouse-ccloud/ci/test-values.yaml
+++ b/system/greenhouse-ccloud/ci/test-values.yaml
@@ -64,6 +64,10 @@ alerts:
     hosts:
       - "alertmanager.foo.bar"
 
+certManager:
+  webhook:
+    timeoutSeconds: 15
+
 digicert:
   enabled: true
   provisioner:

--- a/system/greenhouse-ccloud/templates/cert-manager-pluginpreset.yaml
+++ b/system/greenhouse-ccloud/templates/cert-manager-pluginpreset.yaml
@@ -12,24 +12,26 @@ spec:
     disabled: false
     displayName: cert manager
     optionValues:
-    - name: cert-manager.extraArgs[0]
-      value: --enable-certificate-owner-ref=true
-    - name: cert-manager.ingressShim.defaultIssuerGroup
-      value: certmanager.cloud.sap
-    - name: cert-manager.ingressShim.defaultIssuerKind
-      value: DigicertIssuer
-    - name: cert-manager.ingressShim.defaultIssuerName
-      value: digicert-issuer
-    - name: cert-manager.installCRDs
-      value: false
-    - name: cert-manager.prometheus.enabled
-      value: true
-    - name: cert-manager.image.repository
-      value: {{ .Values.global.quayIoMirror }}/jetstack/cert-manager-controller
-    - name: cert-manager.webhook.image.repository
-      value: {{ .Values.global.quayIoMirror }}/jetstack/cert-manager-webhook
-    - name: cert-manager.cainjector.image.repository
-      value: {{ .Values.global.quayIoMirror }}/jetstack/cert-manager-cainjector
+      - name: cert-manager.webhook.timeoutSeconds
+        value: {{ .Values.certManager.webhook.timeoutSeconds }}
+      - name: cert-manager.extraArgs[0]
+        value: --enable-certificate-owner-ref=true
+      - name: cert-manager.ingressShim.defaultIssuerGroup
+        value: certmanager.cloud.sap
+      - name: cert-manager.ingressShim.defaultIssuerKind
+        value: DigicertIssuer
+      - name: cert-manager.ingressShim.defaultIssuerName
+        value: digicert-issuer
+      - name: cert-manager.installCRDs
+        value: false
+      - name: cert-manager.prometheus.enabled
+        value: true
+      - name: cert-manager.image.repository
+        value: {{ .Values.global.quayIoMirror }}/jetstack/cert-manager-controller
+      - name: cert-manager.webhook.image.repository
+        value: {{ .Values.global.quayIoMirror }}/jetstack/cert-manager-webhook
+      - name: cert-manager.cainjector.image.repository
+        value: {{ .Values.global.quayIoMirror }}/jetstack/cert-manager-cainjector
     pluginDefinition: cert-manager
     releaseNamespace: kube-system
 {{- end -}}

--- a/system/greenhouse-ccloud/values.yaml
+++ b/system/greenhouse-ccloud/values.yaml
@@ -90,6 +90,10 @@ cephOperations:
 kvmMonitoring:
   enabled: false
 
+certManager:
+  webhook:
+    timeoutSeconds: 15
+
 digicert:
   enabled: false
   provisioner:


### PR DESCRIPTION
Adds `cert-manager` webhook timeout option to plugin preset