### PR TITLE
[Openstack-exporter] add values config for cinder

### DIFF
--- a/prometheus-exporters/openstack-exporter/templates/openstack-exporter-openstack-config.yaml
+++ b/prometheus-exporters/openstack-exporter/templates/openstack-exporter-openstack-config.yaml
@@ -17,6 +17,8 @@ data:
       cinderbackend:
         collector: openstack_exporter.collectors.cinderbackend.CinderBackendCollector
         enabled: True
+        expected_sharding_backends: {{- .Values.collectors.cinderbackend.expected_sharding_backends }}
+        allow_unexpected_backends: {{- .Values.collectors.cinderbackend.set_allow_unexpected_backends }}
       novaservice:
         collector: openstack_exporter.collectors.novaservice.NovaServiceCollector
         enabled: True

--- a/prometheus-exporters/openstack-exporter/values.yaml
+++ b/prometheus-exporters/openstack-exporter/values.yaml
@@ -30,3 +30,8 @@ global:
   # openstack_exporter_master_password:
   # registry:
   linkerd_requested: true
+
+collectors:
+  cinderbackend:
+    expected_sharding_backends: standard_hdd, vmware, vmware_fcd
+    set_allow_unexpected_backends: true


### PR DESCRIPTION
This adds the ability to change the 2 following values for the cinderbackend collector:

expected_sharding_backends
allow_unexpected_backends