### PR TITLE
keppel: move reloader annotation to correct annotation

### DIFF
--- a/openstack/keppel-trivy/templates/deployment-api.yaml
+++ b/openstack/keppel-trivy/templates/deployment-api.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 
 metadata:
   name: trivy-api
+  annotations:
+    secret.reloader.stakater.com/reload: trivy-secret
 
 spec:
   revisionHistoryLimit: 5
@@ -25,7 +27,6 @@ spec:
       annotations:
         checksum/secret: {{ include "keppel-trivy/templates/secret.yaml" . | sha256sum }}
         kubectl.kubernetes.io/default-container: trivy-api
-        secret.reloader.stakater.com/reload: trivy-secret
     spec:
       containers:
         - name: trivy-api

--- a/openstack/keppel-trivy/templates/deployment-server.yaml
+++ b/openstack/keppel-trivy/templates/deployment-server.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 
 metadata:
   name: trivy-server
+  annotations:
+    secret.reloader.stakater.com/reload: trivy-secret
 
 spec:
   revisionHistoryLimit: 5
@@ -22,7 +24,6 @@ spec:
       annotations:
         checksum/secret: {{ include "keppel-trivy/templates/secret.yaml" . | sha256sum }}
         kubectl.kubernetes.io/default-container: trivy-server
-        secret.reloader.stakater.com/reload: trivy-secret
     spec:
       containers:
         - name: trivy-server

--- a/openstack/keppel/templates/deployment-api.yaml
+++ b/openstack/keppel/templates/deployment-api.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 
 metadata:
   name: keppel-api
+  annotations:
+    secret.reloader.stakater.com/reload: keppel-keys,keppel-secret
 
 spec:
   revisionHistoryLimit: 5
@@ -24,7 +26,6 @@ spec:
         checksum/secret: {{ include "keppel/templates/secret.yaml" . | sha256sum }}
         checksum/secret-keys: {{ include "keppel/templates/secret-keys.yaml" . | sha256sum }}
         kubectl.kubernetes.io/default-container: api
-        secret.reloader.stakater.com/reload: keppel-keys,keppel-secret
     spec:
       affinity:
         podAntiAffinity:

--- a/openstack/keppel/templates/deployment-janitor.yaml
+++ b/openstack/keppel/templates/deployment-janitor.yaml
@@ -5,6 +5,7 @@ metadata:
   name: keppel-janitor
   annotations:
     configmap.reloader.stakater.com/reload: keppel-auto-managed-accounts
+    secret.reloader.stakater.com/reload: keppel-keys,keppel-secret
 
 spec:
   revisionHistoryLimit: 5
@@ -25,7 +26,6 @@ spec:
         kubectl.kubernetes.io/default-container: janitor
         prometheus.io/scrape: "true"
         prometheus.io/targets: "openstack"
-        secret.reloader.stakater.com/reload: keppel-keys,keppel-secret
     spec:
       volumes:
         - name: config


### PR DESCRIPTION
Why are there two annotations 💀