### PR TITLE
[limes] use global.is_global_region in helm-charts

### DIFF
--- a/openstack/limes/templates/_utils.tpl
+++ b/openstack/limes/templates/_utils.tpl
@@ -43,8 +43,7 @@
 
 {{- define "limes_openstack_envvars" }}
 {{- $limes_url := .Values.limes.clusters.ccloud.catalog_url }}
-{{- $is_global := $limes_url | contains "global" }}
-{{- if $is_global }}
+{{- if .Values.global.is_global_region }}
 - name: OS_AUTH_URL
   value: "{{ $limes_url | replace "limes" "identity" }}/v3"
 - name: OS_INTERFACE
@@ -68,7 +67,7 @@
   value: "ccadmin"
 - name: OS_PROJECT_NAME
   value: "cloud_admin"
-{{- if $is_global }}
+{{- if .Values.global.is_global_region }}
 - name: OS_REGION_NAME
   value: global
 {{- else }}

--- a/openstack/limes/templates/ingress-api.yaml
+++ b/openstack/limes/templates/ingress-api.yaml
@@ -1,5 +1,4 @@
 {{- $domain := .Values.limes.clusters.ccloud.catalog_url | trimPrefix "https://" -}}
-{{- $is_global := $domain | contains "global" -}}
 
 kind: Ingress
 apiVersion: networking.k8s.io/v1
@@ -15,12 +14,12 @@ metadata:
     ingress.kubernetes.io/service-upstream: "true"
     nginx.ingress.kubernetes.io/service-upstream: "true"
     {{- end }}
-    {{- if $is_global }}
+    {{- if .Values.global.is_global_region }}
     kubernetes.io/ingress.class: "nginx-external"
     {{- end }}
 
 spec:
-  {{- if $is_global }}
+  {{- if .Values.global.is_global_region }}
   ingressClassName: "nginx-external"
   {{- end }}
   tls:

--- a/openstack/limes/templates/ingress-liquids.yaml
+++ b/openstack/limes/templates/ingress-liquids.yaml
@@ -2,7 +2,6 @@
 {{- if not $config.skip }}
 
 {{- $limes_domain := $.Values.limes.clusters.ccloud.catalog_url | trimPrefix "https://" -}}
-{{- $is_global := $limes_domain | contains "global" -}}
 {{- $domain := $limes_domain | replace "limes-3" (printf "liquid-%s" $name) }}
 
 ---
@@ -19,12 +18,12 @@ metadata:
     ingress.kubernetes.io/service-upstream: "true"
     nginx.ingress.kubernetes.io/service-upstream: "true"
     {{- end }}
-    {{- if $is_global }}
+    {{- if $.Values.global.is_global_region }}
     kubernetes.io/ingress.class: "nginx-external"
     {{- end }}
 
 spec:
-  {{- if $is_global }}
+  {{- if $.Values.global.is_global_region }}
   ingressClassName: "nginx-external"
   {{- end }}
   tls:

--- a/openstack/limes/templates/prometheus-alerts.yaml
+++ b/openstack/limes/templates/prometheus-alerts.yaml
@@ -35,8 +35,7 @@ metadata:
 
 {{/* If there is a global deployment in this region, different limits may apply for it vs. for the regular deployment.
      We need to restrict the PromQL expressions to match only the Keystone that our own deployment is interested in. */}}
-{{- $is_global := $.Values.limes.clusters.ccloud.catalog_url | contains "global" -}}
-{{- $keystone_namespace := $is_global | ternary "monsoon3global" "monsoon3" }}
+{{- $keystone_namespace := .Values.global.is_global_region | ternary "monsoon3global" "monsoon3" }}
 
 spec:
   groups:

--- a/openstack/limes/templates/seed-catalog.yaml
+++ b/openstack/limes/templates/seed-catalog.yaml
@@ -1,7 +1,6 @@
 {{- $region := .Values.global.region | required "missing value for .Values.global.region" -}}
 {{- $tld    := .Values.global.tld    | required "missing value for .Values.global.tld"    -}}
 {{- $limes_url := .Values.limes.clusters.ccloud.catalog_url | required ".Values.limes.clusters.ccloud.catalog_url" -}}
-{{- $is_global := $limes_url | contains "global" -}}
 
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: OpenstackSeed
@@ -18,11 +17,11 @@ spec:
       description: 'Hierarchical quota/usage tracking'
       enabled:     true
       endpoints:
-        - region:    '{{ if $is_global }}global{{ else }}{{ $region }}{{ end }}'
+        - region:    '{{ if .Values.global.is_global_region }}global{{ else }}{{ $region }}{{ end }}'
           interface: public
           enabled:   true
           url:       '{{ $limes_url }}'
-        {{- if not $is_global }}
+        {{- if not .Values.global.is_global_region }}
         - region:    '{{ $region }}'
           interface: internal
           enabled:   true
@@ -34,11 +33,11 @@ spec:
       description: 'Hierarchical rate limit/usage tracking'
       enabled:     true
       endpoints:
-        - region:    '{{ if $is_global }}global{{ else }}{{ $region }}{{ end }}'
+        - region:    '{{ if .Values.global.is_global_region }}global{{ else }}{{ $region }}{{ end }}'
           interface: public
           enabled:   true
           url:       '{{ $limes_url }}/rates'
-        {{- if not $is_global }}
+        {{- if not .Values.global.is_global_region }}
         - region:    '{{ $region }}'
           interface: internal
           enabled:   true
@@ -53,11 +52,11 @@ spec:
       description: 'Limes integration for {{ title $name }} <https://pkg.go.dev/github.com/sapcc/go-api-declarations/liquid>'
       enabled:     true
       endpoints:
-        - region:    '{{ if $is_global }}global{{ else }}{{ $region }}{{ end }}'
+        - region:    '{{ if $.Values.global.is_global_region }}global{{ else }}{{ $region }}{{ end }}'
           interface: public
           enabled:   true
           url:       '{{ $limes_url | replace "limes-3" (printf "liquid-%s" $name) }}'
-        {{- if not $is_global }}
+        {{- if not $.Values.global.is_global_region }}
         - region:    '{{ $region }}'
           interface: internal
           enabled:   true

--- a/openstack/limes/templates/seed-grants.yaml
+++ b/openstack/limes/templates/seed-grants.yaml
@@ -24,8 +24,7 @@ metadata:
 spec:
   {{- if $relevant_domain_names }}
   requires:
-    {{- $is_global := $.Values.limes.clusters.ccloud.catalog_url | contains "global" -}}
-    {{- $base_seed_namespace := $is_global | ternary "monsoon3global" "monsoon3" }}
+    {{- $base_seed_namespace := .Values.global.is_global_region | ternary "monsoon3global" "monsoon3" }}
     {{- range $relevant_domain_names }}
     - {{ $base_seed_namespace }}/domain-{{ . | lower | replace "_" "-" }}-seed
     {{- end }}

--- a/openstack/limes/templates/seed.yaml
+++ b/openstack/limes/templates/seed.yaml
@@ -1,12 +1,8 @@
 {{- $vbase  := .Values.global.vaultBaseURL | required "missing value for .Values.global.vaultBaseURL" -}}
 {{- $region := .Values.global.region       | required "missing value for .Values.global.region"       -}}
-{{- $is_global := $.Values.limes.clusters.ccloud.catalog_url | contains "global" -}}
+{{/* cdomains equals [ "global" ] in global region */}}
 {{- $cdomains := .Values.global.domain_seeds.customer_domains | required "missing value for .Values.global.domain_seeds.customer_domains" -}}
 {{- $domains  := concat (list "cc3test") $cdomains -}}
-
-{{- if $is_global -}}
-  {{- $domains = list "cc3test" "global" -}}
-{{- end -}}
 
 {{- $liquid_roles := list -}}
 {{- if not .Values.limes.local_liquids.nova.skip -}}
@@ -36,8 +32,8 @@ metadata:
 
 spec:
   requires:
-  {{- $base_seed_namespace := $is_global | ternary "monsoon3global" "monsoon3" }}
-  - {{ $base_seed_namespace }}/{{ $is_global | ternary "keystone-global-seed" "keystone-seed" }}
+  {{- $base_seed_namespace := .Values.global.is_global_region | ternary "monsoon3global" "monsoon3" }}
+  - {{ $base_seed_namespace }}/{{ .Values.global.is_global_region | ternary "keystone-global-seed" "keystone-seed" }}
   - {{ $base_seed_namespace }}/domain-ccadmin-seed
   - {{ $base_seed_namespace }}/domain-default-seed
   {{- range $domains }}
@@ -70,7 +66,7 @@ spec:
         - name: limes-validation
           description: User account for pre-deployment validation in CI
           {{- $vault_path := printf "%s/limes" $region }}
-          {{- if $is_global }}
+          {{- if .Values.global.is_global_region }}
             {{- $vault_path = printf "%s/limes-global" (($region | contains "qa") | ternary $region "global") }}
           {{- end }}
           password: {{ printf "%s/%s/keystone-user/validation/password" $vbase $vault_path | quote }}
@@ -113,7 +109,7 @@ spec:
     {{- range $domains }}
     - name: {{ . | lower }}
       groups:
-      - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_DOMAIN_RESOURCE_ADMINS
+      - name: {{ hasPrefix "iaas-" . | ternary . ( upper . ) }}_DOMAIN_RESOURCE_ADMINS
         role_assignments:
         - domain: {{ . | lower }}
           role: resource_admin

--- a/openstack/limes/templates/support_seed.yaml
+++ b/openstack/limes/templates/support_seed.yaml
@@ -1,12 +1,8 @@
-{{- $is_global := $.Values.limes.clusters.ccloud.catalog_url | contains "global" -}}
-{{- $base_seed_namespace := $is_global | ternary "monsoon3global" "monsoon3" }}
-
+{{- $base_seed_namespace := .Values.global.is_global_region | ternary "monsoon3global" "monsoon3" }}
+{{/* cdomains equals [ "global" ] in global region */}}
 {{- $cdomains := .Values.global.domain_seeds.customer_domains | required "missing value for .Values.global.domain_seeds.customer_domains" -}}
 {{- $domains  := concat (list "ccadmin") $cdomains -}}
 {{- $cdomainsWithoutSupportProjects := .Values.global.domain_seeds.customer_domains_without_support_projects | required "missing value for .Values.global.domain_seeds.customer_domains_without_support_projects" -}}
-{{- if $is_global -}}
-  {{- $domains = list "ccadmin" "global" -}}
-{{- end -}}
 
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
@@ -24,7 +20,7 @@ spec:
     {{- range $domains }}
     - name: {{ . | lower }}
       groups:
-      - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_API_SUPPORT
+      - name: {{ hasPrefix "iaas-" . | ternary . ( upper . ) }}_API_SUPPORT
         role_assignments:
         {{- if not (has . $cdomainsWithoutSupportProjects) }}
         - project: api_support
@@ -39,7 +35,7 @@ spec:
           role: resource_viewer
           inherited: true
       {{- if ne . "global" }}
-      - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_COMPUTE_SUPPORT
+      - name: {{ hasPrefix "iaas-" . | ternary . ( upper . ) }}_COMPUTE_SUPPORT
         role_assignments:
         {{- if not (has . $cdomainsWithoutSupportProjects) }}
         - project: compute_support
@@ -53,7 +49,7 @@ spec:
         - domain: {{ . | lower }}
           role: resource_viewer
           inherited: true
-      - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_NETWORK_SUPPORT
+      - name: {{ hasPrefix "iaas-" . | ternary . ( upper . ) }}_NETWORK_SUPPORT
         role_assignments:
         {{- if not (has . $cdomainsWithoutSupportProjects) }}
         - project: network_support
@@ -67,7 +63,7 @@ spec:
         - domain: {{ . | lower }}
           role: resource_viewer
           inherited: true
-      - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_STORAGE_SUPPORT
+      - name: {{ hasPrefix "iaas-" . | ternary . ( upper . ) }}_STORAGE_SUPPORT
         role_assignments:
         {{- if not (has . $cdomainsWithoutSupportProjects) }}
         - project: storage_support
@@ -81,7 +77,7 @@ spec:
         - domain: {{ . | lower }}
           role: resource_viewer
           inherited: true
-      - name: {{ contains "iaas-" . | ternary . ( upper . ) }}_SERVICE_DESK
+      - name: {{ hasPrefix "iaas-" . | ternary . ( upper . ) }}_SERVICE_DESK
         role_assignments:
         {{- if not (has . $cdomainsWithoutSupportProjects) }}
         - project: service_desk

--- a/openstack/limes/values.yaml
+++ b/openstack/limes/values.yaml
@@ -1,9 +1,10 @@
 global:
   region: DEFINED_IN_VALUES_FILE
   linkerd_requested: true
-
+  is_global_region: false
   domain_seeds:
-    skip_hcm_domain: false
+    customer_domains: []
+    customer_domains_without_support_projects: []
 
 campfire:
   mail_type:


### PR DESCRIPTION
* use `global.is_global_region` instead of deriving this info from the `limes_url`
* use `customer_domains = ["global"]` from the values for the global region (less special logic)
* replace `contains "iaas-"` with `hasPrefix "iaas-"` for more robustness