### PR TITLE
[nova] fix openstack_compute_service_version metric

### DIFF
--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -694,7 +694,7 @@ mysql_metrics:
       name: openstack_compute_service_version
       query: |
         SELECT
-          id, coalesce(host, 'N/A') AS nova_host, `binary`, version
+          cast(id as char), coalesce(host, 'N/A') AS nova_host, `binary`, version
         FROM services
         WHERE deleted_at is NULL;
       values:


### PR DESCRIPTION
sql_exporter needs the labels to be strings,
so we convert it beforehand.

Fixes:
"column 'id' must be type text (string)"

Metric is consumed by OpenstackNovaComputeServiceVersionsMismatch alert
