### PR TITLE
[Cinder] Support password ratelimit backend

### DIFF
--- a/openstack/cinder/templates/api-deployment.yaml
+++ b/openstack/cinder/templates/api-deployment.yaml
@@ -130,6 +130,10 @@ spec:
               mountPath: /etc/cinder/ratelimit.yaml
               subPath: ratelimit.yaml
               readOnly: true
+            - name: redis-ratelimit-secret
+              mountPath: /etc/cinder/ratelimit-backend-secret.conf
+              subPath: ratelimit-backend-secret.conf
+              readOnly: true
             {{- end }}
             {{- if .Values.watcher.enabled }}
             - name: cinder-etc
@@ -167,3 +171,11 @@ spec:
             secretName: {{ .Release.Name }}-secrets
         {{- include "utils.proxysql.volumes" . | indent 8 }}
         {{- include "utils.coordination.volumes" . | indent 8 }}
+
+        {{- if .Values.api_rate_limit.enabled }}
+        - name: redis-ratelimit-secret
+          secret:
+            secretName: ratelimit-backend-secret.conf
+        {{- end }}
+
+

--- a/openstack/cinder/templates/etc/_api-paste.ini.tpl
+++ b/openstack/cinder/templates/etc/_api-paste.ini.tpl
@@ -123,11 +123,12 @@ config_file = /etc/cinder/watcher.yaml
 use = egg:rate-limit-middleware#rate-limit
 config_file = /etc/cinder/ratelimit.yaml
 service_type = volume
-rate_limit_by: {{ .Values.api_rate_limit.rate_limit_by }}
-max_sleep_time_seconds: {{ .Values.api_rate_limit.max_sleep_time_seconds }}
-clock_accuracy: 1ns
-log_sleep_time_seconds: {{ .Values.api_rate_limit.log_sleep_time_seconds }}
+rate_limit_by = {{ .Values.api_rate_limit.rate_limit_by }}
+max_sleep_time_seconds = {{ .Values.api_rate_limit.max_sleep_time_seconds }}
+clock_accuracy = 1ns
+log_sleep_time_seconds = {{ .Values.api_rate_limit.log_sleep_time_seconds }}
 backend_host = {{ .Release.Name }}-api-ratelimit-redis
-backend_port: 6379
-backend_timeout_seconds: {{ .Values.api_rate_limit.backend_timeout_seconds }}
+backend_port = 6379
+backend_secret_file = {{ .Values.api_rate_limit.backend_secret_file }}
+backend_timeout_seconds = {{ .Values.api_rate_limit.backend_timeout_seconds }}
 {{- end }}

--- a/openstack/cinder/templates/secret-cinder-ratelimit.yml
+++ b/openstack/cinder/templates/secret-cinder-ratelimit.yml
@@ -1,0 +1,12 @@
+{{- if .Values.api_rate_limit.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cinder-api-ratelimit-secret
+  labels:
+    system: openstack
+    application: {{ .Release.Name }}
+type: Opaque
+data:
+  ratelimit-backend-secret.conf: {{ required "Rate Limit Middleware requires a Backend Password" (index .Values "api-ratelimit-redis" "redisPassword") | b64enc | quote }}
+{{- end }}

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -429,6 +429,7 @@ logging:
 # openstack-rate-limit-middleware
 api_rate_limit:
   enabled: true
+  backend_secret_file: /etc/cinder/ratelimit-backend-secret.conf
   rate_limit_by: "target_project_id"
   max_sleep_time_seconds: 15
   log_sleep_time_seconds: 10


### PR DESCRIPTION
The Redis helm chart enforces the access via a password. If no password is set, a random pw is created by container start automatically.

So far the openstack-ratelimit middleware does not support connecting to a Redis backend with a password set. Requires https://github.com/sapcc/openstack-rate-limit-middleware/pull/29 The middleware loads the backend password from a file. With this PR we mount the Redis password into the neutron-server so it will be picked up by the ratelimit middleware.

reference:
https://github.com/sapcc/helm-charts/pull/8408