### PR TITLE
[pxc-db] update to 1.17 pxc-operator release image version

### DIFF
--- a/common/pxc-db/Chart.yaml
+++ b/common/pxc-db/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.1"
+appVersion: "1.17.0"
 
 dependencies:
   - name: owner-info

--- a/common/pxc-db/values.yaml
+++ b/common/pxc-db/values.yaml
@@ -79,7 +79,7 @@ job:
     # @default -- operator image
     image:
       name: percona/percona-xtradb-cluster-operator
-      tag: 1.16.1-pxc8.0-backup-pxb8.0.35
+      tag: 1.17.0-pxc8.0-backup-pxb8.0.35
     # -- Set default character set in init.sql
     character_set_server: utf8mb4
     # -- Set default collation in init.sql
@@ -151,7 +151,7 @@ pause: false
 initContainer:
   image:
     name: percona-xtradb-cluster-operator
-    tag: 1.16.1
+    tag: 1.17.0
     override: null
   resources:
     requests:
@@ -180,7 +180,7 @@ pxc:
   size: 3
   image:
     name: percona/percona-xtradb-cluster
-    tag: 8.0.39-30.1
+    tag: 8.0.41-32.1
     override: null
   imagePullPolicy: IfNotPresent
   annotations: {}
@@ -332,7 +332,7 @@ haproxy:
   size: 2
   image:
     name: percona/haproxy
-    tag: 2.8.11
+    tag: 2.8.14
     override: null
   imagePullPolicy: Always
   annotations: {}
@@ -440,7 +440,7 @@ backup:
   labels: {}
   image:
     name: percona/percona-xtradb-cluster-operator
-    tag: 1.16.1-pxc8.0-backup-pxb8.0.35
+    tag: 1.17.0-pxc8.0-backup-pxb8.0.35
     override: null
   imagePullPolicy: Always
   # -- The number of retries to make a backup


### PR DESCRIPTION
Update pxc-db database chart to 1.17.0 pxc-operator release tags