### PR TITLE
[Nova] Move external customer domain prefix config

### DIFF
--- a/openstack/nova/templates/etc/_nova-scheduler.conf.tpl
+++ b/openstack/nova/templates/etc/_nova-scheduler.conf.tpl
@@ -10,7 +10,6 @@ discover_hosts_in_cells_interval = 60
 workers = {{ .Values.scheduler.workers }}
 driver_task_period = {{ .Values.scheduler.driver_task_period | default 60 }}
 query_placement_for_availability_zone = {{ not (contains "AvailabilityZoneFilter" .Values.scheduler.default_filters) }}
-external_customer_domain_name_prefixes = {{ .Values.scheduler.external_customer_domain_name_prefixes }}
 
 [filter_scheduler]
 available_filters = {{ .Values.scheduler.available_filters | default "nova.scheduler.filters.all_filters" }}

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -288,8 +288,6 @@ scheduler:
   aggregate_multi_tenancy_isolation_weight_multiplier: 50.0
 
   image_properties_default_architecture: "x86_64"
-  # comma-separated list of prefixes for external domains
-  external_customer_domain_name_prefixes: "iaas-"
 
 compute:
   defaults:
@@ -995,6 +993,8 @@ owner-info:
 default:
   password_all_group_samples: 2
   rpc_ping_enabled: true
+  # comma-separated list of prefixes for external domains
+  external_customer_domain_name_prefixes: "iaas-"
 
 utils:
   trust_bundle:


### PR DESCRIPTION
We changed Nova to read the config from `nova.conf`, because we figured out that more than `nova-scheduler` will have to implement special handling based on the domain name of the VM.