### PR TITLE
[elektra] remove SOV_SUPPORT_TOOL_VIEWERS

### DIFF
--- a/openstack/elektra/templates/seed.yaml
+++ b/openstack/elektra/templates/seed.yaml
@@ -1,6 +1,6 @@
 {{- $cdomains := .Values.global.domain_seeds.customer_domains | required "missing value for .Values.global.domain_seeds.customer_domains" -}}
 {{- $domains  := concat (list "cc3test" "ccadmin" "Default") $cdomains -}}
-{{- $domainsWithoutSupportToolViewers  := list "cis" "ccadmin" -}}
+{{- $domainsWithoutSupportToolViewers  := list "cis" "ccadmin" "sov" -}}
 
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"


### PR DESCRIPTION
I have no idea how this group was generated for the other domains, no seed has a reference for this, I assume via CAM. Might revert after @rajivmucheli returns.