### PR TITLE
[mariadb] delete unmanaged localhost users

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.22.0 - 2025/04/09
+* delete unmanaged localhost users like 'username'@'localhost'
+
+Previously, init.sql script was creating a pair of users: 'username'@'%' and 'username'@'localhost'. The second one stopped being managed since the introduction of granular user configuration in 2022. These @'localhost' users will be removed now.
+
 ## v0.21.0 - 2025/04/08
 * remove version label from mariadb deployment pod template and related configmaps to avoid unnecessary database restarts on simple chart version update
 

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,6 +2,6 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.21.0
+version: 0.22.0
 # scripts/docker-entyrpoint.sh should be updated when appVersion is updated
 appVersion: 10.5.28

--- a/common/mariadb/templates/initdb/_init.sql.tpl
+++ b/common/mariadb/templates/initdb/_init.sql.tpl
@@ -18,7 +18,8 @@ GRANT ALL PRIVILEGES ON {{ .Values.name }}.*
     {{- if not $values.password }}
 -- Skipping user {{ $username }} without password
     {{- else }}
-CREATE USER IF NOT EXISTS {{ include "mariadb.resolve_secret_squote" $username }};
+DROP USER IF EXISTS {{ include "mariadb.resolve_secret_squote" $username }}@'localhost';
+CREATE USER IF NOT EXISTS {{ include "mariadb.resolve_secret_squote" $username }}@'%';
 ALTER USER {{ include "mariadb.resolve_secret_squote" $username }} IDENTIFIED BY {{ include "mariadb.resolve_secret_squote" $values.password }}
 {{- if $values.limits }}
   WITH


### PR DESCRIPTION
Previously, init.sql script was creating a pair of users: 'username'@'%' and 'username'@'localhost'.

The second one stopped being managed since the introduction of the granular user configuration.
See https://github.com/sapcc/helm-charts/pull/3598

These @'localhost' users will be removed now.