### PR TITLE
[mariadb] remove version label from mariadb deployment pod template

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.21.0 - 2025/04/08
+* remove version label from mariadb deployment pod template and related configmaps to avoid unnecessary database restarts on simple chart version update
+
 ## v0.20.0 - 2025/04/03
 * add `renameCheckConstraints`  job, which allows to rename constraints, created by sqlalchemy with names like `CONSTRAINT_*`, to constraints with a unique name, as MySQL does
 

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,6 +2,6 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.20.0
+version: 0.21.0
 # scripts/docker-entyrpoint.sh should be updated when appVersion is updated
 appVersion: 10.5.28

--- a/common/mariadb/templates/configmap-mariadb-credential-updater.yaml
+++ b/common/mariadb/templates/configmap-mariadb-credential-updater.yaml
@@ -5,6 +5,6 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   name: mariadb-{{ .Values.name }}-credential-updater
   labels:
-    {{- include "mariadb.labels" (list $ "version" "mariadb" "cm" "credential-updater") | indent 4 }}
+    {{- include "mariadb.labels" (list $ "noversion" "mariadb" "cm" "credential-updater") | indent 4 }}
 data:
 {{ tpl (.Files.Glob "scripts/mariadb-credential-updater.py").AsConfig . | indent 2 }}

--- a/common/mariadb/templates/deployment.yaml
+++ b/common/mariadb/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     metadata:
       labels:
         app: {{ include "fullName" . }}
-        {{- include "mariadb.labels" (list $ "version" "mariadb" "deployment" "database") | indent 8 }}
+        {{- include "mariadb.labels" (list $ "noversion" "mariadb" "deployment" "database") | indent 8 }}
       annotations:
         checksum/etc: {{ include (print $.Template.BasePath  "/etc-configmap.yaml") . | sha256sum }}
         checksum/credential-updater: {{ include (print $.Template.BasePath  "/configmap-mariadb-credential-updater.yaml") . | sha256sum }}

--- a/common/mariadb/templates/etc-configmap.yaml
+++ b/common/mariadb/templates/etc-configmap.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: mariadb-{{.Values.name}}-etc
   labels:
-    {{- include "mariadb.labels" (list $ "version" "mariadb" "configmap" "database") | indent 4 }}
+    {{- include "mariadb.labels" (list $ "noversion" "mariadb" "configmap" "database") | indent 4 }}
 data:
   mariadb.cnf: |
     [mysqld]


### PR DESCRIPTION
Remove version label from mariadb deployment pod template and related configmaps to avoid unnecessary database restarts on simple chart version update.