### PR TITLE
Nfs datastore exclusion

### DIFF
--- a/prometheus-rules/prometheus-vmware-rules/alerts/datastore.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/datastore.alerts
@@ -1,56 +1,6 @@
 groups:
 - name: datastore.alerts
   rules:
-  - alert: VVolDatastoreNotAccessible
-    expr: |
-      vrops_datastore_summary_datastore_accessible{type='vVOL'} == 0
-    for: 5m
-    labels:
-      severity: critical
-      tier: vmware
-      service: storage
-      support_group: compute
-      context: "{{ $labels.datastore }}"
-      meta: 'Datastore {{ $labels.datastore }} is not accessible. ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
-      playbook: docs/devops/alert/vcenter/vvol_datastore#vvol_1
-    annotations:
-      description: 'Datastore {{ $labels.datastore }} is not accessible. ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
-      summary: 'Datastore {{ $labels.datastore }} is not accessible. ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
-
-  - alert: VVolDatastoreZeroFreeSpace
-    expr: |
-      vrops_datastore_diskspace_freespace_gigabytes{type="vVOL"} == 0
-    for: 10m
-    labels:
-      severity: critical
-      tier: vmware
-      service: storage
-      support_group: compute
-      context: "{{ $labels.datastore }}"
-      meta: 'Datastore {{ $labels.datastore }} has no free space. ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
-      dashboard: vcenter-datastore-utilization
-      playbook: docs/devops/alert/vcenter/vvol_datastore#vvol_4
-    annotations:
-      description: 'Datastore {{ $labels.datastore }} has no free space. ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
-      summary: 'Datastore {{ $labels.datastore }} has no free space. ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
-
-  - alert: VVolDatastoreZeroCapacity
-    expr: |
-      vrops_datastore_diskspace_capacity_gigabytes{type="vVOL"} == 0
-    for: 10m
-    labels:
-      severity: critical
-      tier: vmware
-      service: storage
-      support_group: compute
-      context: "{{ $labels.datastore }}"
-      meta: 'Datastore {{ $labels.datastore }} has zero capacity. ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
-      dashboard: vcenter-datastore-utilization
-      playbook: docs/devops/alert/vcenter/vvol_datastore#vvol_3
-    annotations:
-      description: 'Datastore {{ $labels.datastore }} has zero capacity. ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
-      summary: 'Datastore {{ $labels.datastore }} has zero capacity. ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
-
   - alert: EphemeralDataStoreCapacity
     expr: >
       vrops_datastore_diskspace_total_usage_gigabytes{type=~"ephemeral"} / vrops_datastore_diskspace_capacity_gigabytes >= 0.85
@@ -85,40 +35,6 @@ groups:
       description: "Eph Datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})"
       summary: "Eph Datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})"
 
-  - alert: VVolDataStoreCapacity
-    expr: >
-      vrops_datastore_diskspace_total_usage_gigabytes{type="vVOL"} / vrops_datastore_diskspace_capacity_gigabytes >= 0.8
-    for: 20m
-    labels:
-      severity: warning
-      tier: os
-      service: storage
-      support_group: compute
-      context: "{{ $labels.datastore }}"
-      meta: "vVOL Datastore {{ $labels.datastore }} utilization > 80%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})"
-      dashboard: vcenter-datastore-utilization
-      playbook: docs/support/playbook/cinder/balancing/cinder_balance_alert
-    annotations:
-      description: "vVOL Datastore {{ $labels.datastore }} utilization > 80%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})"
-      summary: "vVOL Datastore {{ $labels.datastore }} utilization > 80%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})"
-
-  - alert: VVolDataStoreCapacity
-    expr: >
-      vrops_datastore_diskspace_total_usage_gigabytes{type="vVOL"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.9
-    for: 20m
-    labels:
-      severity: critical
-      tier: os
-      service: storage
-      support_group: compute
-      context: "{{ $labels.datastore }}"
-      meta: "vVOL Datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})"
-      dashboard: vcenter-datastore-utilization
-      playbook: docs/support/playbook/cinder/balancing/cinder_balance_alert
-    annotations:
-      description: "vVOL Datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})"
-      summary: "vVOL Datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})"
-
   - alert: AverageVmfsDataStoreCapacity
     expr: >
       avg by (type, vcenter) (vrops_datastore_diskspace_total_usage_gigabytes{type=~"vmfs_p_ssd|vmfs_s_hdd"} / vrops_datastore_diskspace_capacity_gigabytes) > 0.85
@@ -138,7 +54,7 @@ groups:
 
   - alert: DataStoreCapacity
     expr: >
-      vrops_datastore_diskspace_total_usage_gigabytes{type!~"ephemeral|vVOL|vmfs.+", datastore!~".+swap"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.8
+      vrops_datastore_diskspace_total_usage_gigabytes{type!~"ephemeral|vmfs.+|nfs", datastore!~".+swap"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.8
     for: 20m
     labels:
       severity: warning
@@ -155,7 +71,7 @@ groups:
 
   - alert: DataStoreCapacity
     expr: >
-      vrops_datastore_diskspace_total_usage_gigabytes{type!~"ephemeral|vVOL|vmfs.+", datastore!~".+swap"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.9
+      vrops_datastore_diskspace_total_usage_gigabytes{type!~"ephemeral|vmfs.+|nfs", datastore!~".+swap"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.9
     for: 20m
     labels:
       severity: critical

--- a/prometheus-rules/prometheus-vmware-rules/alerts/datastore.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/datastore.alerts
@@ -54,7 +54,7 @@ groups:
 
   - alert: DataStoreCapacity
     expr: >
-      vrops_datastore_diskspace_total_usage_gigabytes{type!~"ephemeral|vmfs.+|nfs", datastore!~".+swap"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.8
+      vrops_datastore_diskspace_total_usage_gigabytes{type!~"ephemeral|vmfs.+|nfs", datastore!~".+swap", datastore!~"nfs.*"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.8
     for: 20m
     labels:
       severity: warning
@@ -71,7 +71,7 @@ groups:
 
   - alert: DataStoreCapacity
     expr: >
-      vrops_datastore_diskspace_total_usage_gigabytes{type!~"ephemeral|vmfs.+|nfs", datastore!~".+swap"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.9
+      vrops_datastore_diskspace_total_usage_gigabytes{type!~"ephemeral|vmfs.+|nfs", datastore!~".+swap", datastore!~"nfs.*"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.9
     for: 20m
     labels:
       severity: critical

--- a/prometheus-rules/prometheus-vmware-rules/alerts/datastore.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/datastore.alerts
@@ -54,7 +54,7 @@ groups:
 
   - alert: DataStoreCapacity
     expr: >
-      vrops_datastore_diskspace_total_usage_gigabytes{type!~"ephemeral|vmfs.+|nfs", datastore!~".+swap", datastore!~"nfs.*"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.8
+      vrops_datastore_diskspace_total_usage_gigabytes{type!~"ephemeral|vmfs.+|nfs", datastore!~".+swap"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.8
     for: 20m
     labels:
       severity: warning
@@ -71,7 +71,7 @@ groups:
 
   - alert: DataStoreCapacity
     expr: >
-      vrops_datastore_diskspace_total_usage_gigabytes{type!~"ephemeral|vmfs.+|nfs", datastore!~".+swap", datastore!~"nfs.*"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.9
+      vrops_datastore_diskspace_total_usage_gigabytes{type!~"ephemeral|vmfs.+|nfs", datastore!~".+swap"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.9
     for: 20m
     labels:
       severity: critical

--- a/prometheus-rules/prometheus-vmware-rules/alerts/virtualmachine.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/virtualmachine.alerts
@@ -1,22 +1,6 @@
 groups:
 - name: virtualmachine.alerts
   rules:
-  # - alert: VMDiskIOReadLatencyIsHigh
-  #   expr: >
-  #     vrops_virtualmachine_alert_info{alert_name="Virtual machine disk I/O read latency is high", vccluster=~".*management.*"}
-  #   labels:
-  #     severity: info
-  #     tier: vmware
-  #     service: compute
-  #     support_group: compute
-  #     context: "{{ $labels.virtualmachine }}"
-  #     meta: "Virtual machine `{{ $labels.virtualmachine }}` disk I/O read latency is high. ({{ $labels.vcenter }}, {{ $labels.hostsystem }})"
-  #     playbook: docs/devops/alert/vcenter/#test_vvol_ds_7
-  #     no_alert_on_absence: "true"
-  #   annotations:
-  #     description: "Virtual machine `{{ $labels.virtualmachine }}` disk I/O read latency is high. ({{ $labels.vcenter }}, {{ $labels.hostsystem }})"
-  #     summary: "Virtual machine `{{ $labels.virtualmachine }}` disk I/O read latency is high. ({{ $labels.vcenter }}, {{ $labels.hostsystem }})"
-
   - alert: VMHasMemoryContention
     expr: >
       vrops_virtualmachine_alert_info{alert_name="Virtual machine has memory contention due to memory compression, ballooning, or swapping", vccluster=~".*management.*"}


### PR DESCRIPTION
pull request to add nfs datastore type from vrops exporter and also a temp fix of nfs in datastore name until it's pushed to the vrops exported in production
as required by multiple false positive alert of datastore space usage on NFS datastore, we are excluding them in the alerting for datastore space usage
also removed most of vvol reference since there are no more vvol in production