### PR TITLE
[andromeda] reverted Oslo policy hardening.

### DIFF
--- a/global/andromeda/templates/etc/_policy.json.tpl
+++ b/global/andromeda/templates/etc/_policy.json.tpl
@@ -1,5 +1,5 @@
 {
-  "cloud_admin": "(project_domain_name:ccadmin and project_name:cloud_admin) or (role:admin and (is_admin_project:True or domain_id:default))",
+  "cloud_admin": "(project_domain_name:ccadmin and project_name:cloud_admin) or user_domain_id:default",
   "project_scope": "project_id:%(project_id)s",
   "public_scope": "'public':%(scope)s",
   "shared_scope": "'shared':%(scope)s",


### PR DESCRIPTION
Unfortunately the [previous change](https://github.com/sapcc/helm-charts/pull/8381) makes the Andromeda Liquid Server
unable to perform requests on behalf of Limes. A different rule will
have to be applied.
