### PR TITLE
[octavia][mariadb] bump database dependency chart version

### DIFF
--- a/openstack/octavia/Chart.lock
+++ b/openstack/octavia/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.19.1
+  version: 0.23.0
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.3.1
@@ -10,18 +10,18 @@ dependencies:
   version: 0.6.9
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.4.3
+  version: 0.4.4
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.17.1
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.25.0
+  version: 0.26.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:05b9ec215a66887f2309f49232a8458d46591152670e71376df5814041d7a31c
-generated: "2025-04-03T11:50:26.78812+03:00"
+digest: sha256:15b09b6bef03811249c13edd2d2375c4dda7eed4ad5e355886929fbb5dd1d519
+generated: "2025-04-21T12:52:26.002778+03:00"

--- a/openstack/octavia/Chart.yaml
+++ b/openstack/octavia/Chart.yaml
@@ -9,12 +9,12 @@ sources:
   - https://git.openstack.org/cgit/openstack/octavia
   - https://git.openstack.org/cgit/openstack/openstack-helm
 # The versions are defined in the changelog: https://docs.openstack.org/releasenotes/octavia/yoga.html
-version: 10.1.1
+version: 10.1.2
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.19.1
+    version: 0.23.0
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db
@@ -26,13 +26,13 @@ dependencies:
   - condition: mariadb.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.4.3
+    version: 0.4.4
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.17.1
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.25.0
+    version: 0.26.0
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0


### PR DESCRIPTION
Bump database dependency chart version 0.19.1 -> 0.23.0:
* removes unused and unmanaged username@localhost user
* fixes unnecessary restarts on every chart version update
* adds an option to run a job to rename CHECK constraints to unique names
* adds reloader annotation for backup-v2 deployment

Bump utils chart to 0.26.0:
* adds optional defaultUser option for RabbitMQ and MariaDB configuration

Bump mysql-metrics chart to 0.4.4: adds reloader annotation