### PR TITLE
[andromeda] auto-reload deployments upon secret update

### DIFF
--- a/global/andromeda/templates/deployment-akamai-reports.yaml
+++ b/global/andromeda/templates/deployment-akamai-reports.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "andromeda.fullname" . }}-reports-akamai
+  annotations:
+    secret.reloader.stakater.com/reload: "andromeda-secret"
   labels:
 {{ include "andromeda.labels" . | indent 4 }}
 spec:

--- a/global/andromeda/templates/deployment-akamai.yaml
+++ b/global/andromeda/templates/deployment-akamai.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "andromeda.fullname" . }}-agent-akamai
+  annotations:
+    secret.reloader.stakater.com/reload: "andromeda-secret"
   labels:
 {{ include "andromeda.labels" . | indent 4 }}
 spec:

--- a/global/andromeda/templates/deployment-housekeeping.yaml
+++ b/global/andromeda/templates/deployment-housekeeping.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "andromeda.fullname" . }}-agent-housekeeping
+  annotations:
+    secret.reloader.stakater.com/reload: "andromeda-secret"
   labels:
 {{ include "andromeda.labels" . | indent 4 }}
 spec:


### PR DESCRIPTION
This annotation has been recently added to `andromeda-liquid-server` and now it's applied to the remaining deployments.