### PR TITLE
[manila][mariadb] bump database dependency chart version

### DIFF
--- a/openstack/manila/Chart.lock
+++ b/openstack/manila/Chart.lock
@@ -4,16 +4,16 @@ dependencies:
   version: 1.1.0
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.18.2
+  version: 0.22.0
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.3.1
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.6.8
+  version: 0.6.9
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.4.2
+  version: 0.4.3
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
@@ -25,6 +25,6 @@ dependencies:
   version: 1.6.2
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.24.1
-digest: sha256:f802d4c840ce4a9eec04eacf3ee82a43d04580a005b6164fd2434431956960aa
-generated: "2025-03-24T14:11:31.305189+02:00"
+  version: 0.26.0
+digest: sha256:acddd44f48cfa7f65f259855d5142e79bbefe7fb9c7cb5930c7fa172b1a7e6b0
+generated: "2025-04-09T16:58:11.989457+03:00"

--- a/openstack/manila/Chart.yaml
+++ b/openstack/manila/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 name: manila
 sources:
   - https://github.com/sapcc/manila
-version: 0.5.3
+version: 0.5.4
 dependencies:
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
@@ -18,7 +18,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.18.2
+    version: ~0.22.0
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db
@@ -45,4 +45,4 @@ dependencies:
     condition: api_rate_limit.enabled
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.24.1
+    version: 0.26.0


### PR DESCRIPTION
Bump database dependency chart version 0.19.1 -> 0.22.0:
* removes unused and unmanaged username@localhost user
* fixes unnecessary restarts on every chart version update
* adds an option to run a job to rename CHECK constraints to unique names

Bump utils chart to 0.26.0:
* adds optional defaultUser option for RabbitMQ and MariaDB configuration