### PR TITLE
[glance][mariadb] bump database dependency chart version

### DIFF
--- a/openstack/glance/Chart.lock
+++ b/openstack/glance/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.18.2
+  version: 0.23.0
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.3.1
@@ -10,10 +10,10 @@ dependencies:
   version: 0.6.9
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.4.2
+  version: 0.4.3
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.25.0
+  version: 0.26.0
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.6.2
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:20a2dd01d7babcffe948348993c59aae8dbe3550710532775ffb264c7b8f10ff
-generated: "2025-03-26T13:50:30.294875+02:00"
+digest: sha256:6344c042b053445bc65d25bb487f728590647bdd23494f8a34bb863638632d95
+generated: "2025-04-14T12:32:34.515418+03:00"

--- a/openstack/glance/Chart.yaml
+++ b/openstack/glance/Chart.yaml
@@ -4,12 +4,12 @@ appVersion: dalmatian
 description: A Helm chart Openstack Glance
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Glance/OpenStack_Project_Glance_vertical.png
 name: glance
-version: 0.7.0
+version: 0.7.1
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.18.2
+    version: 0.23.0
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db
@@ -21,10 +21,10 @@ dependencies:
   - condition: mariadb.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.4.2
+    version: 0.4.3
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.25.0
+    version: 0.26.0
   - name: redis
     alias: sapcc_rate_limit
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm


### PR DESCRIPTION
Bump database dependency chart version 0.18.2 -> 0.23.0:
* removes unused and unmanaged username@localhost user
* fixes unnecessary restarts on every chart version update
* adds an option to run a job to rename CHECK constraints to unique names
* adds reloader annotation for backup-v2 deployment


Bump utils chart to 0.26.0:
* adds optional defaultUser option for RabbitMQ and MariaDB configuration