### PR TITLE
[cinder][mariadb] bump database dependency chart version

### DIFF
--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -1,13 +1,13 @@
 dependencies:
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.24.1
+  version: 0.26.0
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.18.2
+  version: 0.23.0
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.4.2
+  version: 0.4.4
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.6.8
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:30e4c6a975fcb2a8307ded829e45b862ef7179bcb47910b5bb6c6dde1a7789e2
-generated: "2025-03-24T23:45:23.287069+01:00"
+digest: sha256:8ee8399355c79d0ddbf1fac5f5f4f9858594d7ae6afc5b9cf8c0ea27b157d03a
+generated: "2025-04-21T12:49:40.962761+03:00"

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -2,18 +2,18 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Cinder/OpenStack_Project_Cinder_mascot.png
 name: cinder
-version: 0.2.1
+version: 0.2.2
 dependencies:
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.24.1
+    version: 0.26.0
   - name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.18.2
+    version: 0.23.0
     condition: mariadb.enabled
   - name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.4.2
+    version: 0.4.4
     condition: mariadb.enabled
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm


### PR DESCRIPTION
Bump database dependency chart version 0.18.2 -> 0.23.0:
* removes unused and unmanaged username@localhost user
* fixes unnecessary restarts on every chart version update
* adds an option to run a job to rename CHECK constraints to unique names
* adds reloader annotation for backup-v2 deployment

Bump utils chart to 0.26.0:
* adds optional defaultUser option for RabbitMQ and MariaDB configuration

Bump mysql-metrics chart to 0.4.4: adds an option to set vpa main container
and reloader annotation