### PR TITLE
[limes] Add mailing for expiring commitments

### DIFF
--- a/openstack/limes/templates/configmap.yaml
+++ b/openstack/limes/templates/configmap.yaml
@@ -10,7 +10,7 @@ data:
     {{- range .Values.global.availability_zones }}
       - {{ . }}
     {{- end }}
-    {{- if and (eq .Values.global.region "qa-de-1") (ne .Release.Namespace "limes-global") }}
+    {{- if and (ne .Release.Namespace "limes-global") }}
     mail_notifications:
       endpoint: {{ .Values.limes.clusters.ccloud.catalog_url | replace "limes-3" "limes-campfire" | trimSuffix "/" }}/
       templates:

--- a/openstack/limes/templates/configmap.yaml
+++ b/openstack/limes/templates/configmap.yaml
@@ -10,7 +10,7 @@ data:
     {{- range .Values.global.availability_zones }}
       - {{ . }}
     {{- end }}
-    {{- if and (ne .Release.Namespace "limes-global") }}
+    {{- if (ne .Release.Namespace "limes-global") }}
     mail_notifications:
       endpoint: {{ .Values.limes.clusters.ccloud.catalog_url | replace "limes-3" "limes-campfire" | trimSuffix "/" }}/
       templates:

--- a/openstack/limes/templates/deployment-collect.yaml
+++ b/openstack/limes/templates/deployment-collect.yaml
@@ -45,7 +45,7 @@ spec:
           env:
             {{ include "limes_common_envvars" . | indent 12 }}
             - name: LIMES_BLOCK_EXPIRY_NOTIFICATIONS
-              value: "false" # TODO: remove when the "Renew" button is ready on the UI
+              value: "false" # Enable or disable the limes mail functionality for expiring commitments.
             - name: LIMES_QUOTA_OVERRIDES_PATH
               value: "/etc/limes-auto-overrides/quota-overrides.json"
           livenessProbe:

--- a/openstack/limes/templates/deployment-collect.yaml
+++ b/openstack/limes/templates/deployment-collect.yaml
@@ -45,7 +45,7 @@ spec:
           env:
             {{ include "limes_common_envvars" . | indent 12 }}
             - name: LIMES_BLOCK_EXPIRY_NOTIFICATIONS
-              value: "true" # TODO: remove when the "Renew" button is ready on the UI
+              value: "false" # TODO: remove when the "Renew" button is ready on the UI
             - name: LIMES_QUOTA_OVERRIDES_PATH
               value: "/etc/limes-auto-overrides/quota-overrides.json"
           livenessProbe:


### PR DESCRIPTION
Due to the fact that the updated LimesUI is available in elektra prod, we can now enable the mailing functionality in Limes.
I'm unsure if we should leave global out or enable it as well, a hint would be appreciated.