### PR TITLE
[ironic][mariadb] bump database dependency chart version

### DIFF
--- a/openstack/ironic/Chart.lock
+++ b/openstack/ironic/Chart.lock
@@ -1,30 +1,30 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.18.2
+  version: 0.23.0
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.3.1
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.6.8
+  version: 0.6.10
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.4.2
+  version: 0.4.4
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.17.1
+  version: 0.17.2
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.24.1
+  version: 0.26.0
 - name: ironic-exporter
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.3
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:d0c8b0b8e47b46213c2ef7c9bec88e3daba8f8aed1ae375f6c508ec6f5eb7a8d
-generated: "2025-03-24T14:16:08.925397+02:00"
+digest: sha256:5e73fff23c7acd944bed8468b24cd02da89f31363130bf9f44e8cea65a6cafff
+generated: "2025-04-21T12:39:32.148803+03:00"

--- a/openstack/ironic/Chart.yaml
+++ b/openstack/ironic/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Ironic/OpenStack_Project_Ironic_vertical.png
 name: ironic
-version: 0.2.2
+version: 0.2.3
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.18.2
+    version: ~0.23.0
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db
@@ -28,7 +28,7 @@ dependencies:
     version: ~0.17.1
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.24.1
+    version: ~0.26.0
   - name: ironic-exporter
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: ~1.0.3


### PR DESCRIPTION
Bump database dependency chart version 0.18.2 -> 0.23.0:
* removes unused and unmanaged username@localhost user
* fixes unnecessary restarts on every chart version update
* adds an option to run a job to rename CHECK constraints to unique names
* adds reloader annotation for backup-v2 deployment

Bump utils chart to 0.26.0:
* adds optional defaultUser option for RabbitMQ and MariaDB configuration

Bump rabbitmq, memcached and mysql-metrics chart to latest releases
