### PR TITLE
[nova][mariadb] bump database dependency chart version

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -1,13 +1,13 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.18.2
+  version: 0.23.0
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.18.2
+  version: 0.23.0
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.4.2
+  version: 0.4.4
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.17.1
@@ -16,10 +16,10 @@ dependencies:
   version: 0.6.8
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.24.1
+  version: 0.26.0
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.18.2
+  version: 0.23.0
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.17.1
@@ -29,5 +29,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:d3af75f45a7a63591606b3087f1bd04aee1ee2d779c9a413cc2c6bd138cc21b7
-generated: "2025-03-24T15:36:23.710172+02:00"
+digest: sha256:5ba45ffec3a4a4af089488c6d60411d64db453912754c39a672f53b47ca10fda
+generated: "2025-04-21T12:57:26.499534+03:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -2,22 +2,22 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 name: nova
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Nova/OpenStack_Project_Nova_mascot.png
-version: 0.4.2
+version: 0.4.3
 appVersion: "rocky"
 dependencies:
   - name: mariadb
     condition: mariadb.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.18.2
+    version: 0.23.0
   - name: mariadb
     alias: mariadb_api
     condition: mariadb_api.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.18.2
+    version: 0.23.0
   - name: mysql_metrics
     condition: mariadb.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.4.2
+    version: 0.4.4
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.17.1
@@ -26,12 +26,12 @@ dependencies:
     version: 0.6.8
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.24.1
+    version: 0.26.0
   - name: mariadb
     alias: mariadb_cell2
     condition: mariadb_cell2.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.18.2
+    version: 0.23.0
   - name: rabbitmq
     alias: rabbitmq_cell2
     condition: cell2.enabled


### PR DESCRIPTION
Bump database dependency chart version 0.18.2 -> 0.23.0:
* removes unused and unmanaged username@localhost user
* fixes unnecessary restarts on every chart version update
* adds an option to run a job to rename CHECK constraints to unique names
* adds reloader annotation for backup-v2 deployment

Bump mysql-metrics chart to 0.4.4: adds an option to set vpa main container and reloader annotation

Bump utils chart to 0.26.0:
* adds optional defaultUser option for RabbitMQ and MariaDB configuration
    (though will not be used in Nova)
