### PR TITLE
[Redis] Ignore ServiceAccount for custom redisPW

### DIFF
--- a/common/redis/Chart.yaml
+++ b/common/redis/Chart.yaml
@@ -37,4 +37,4 @@ name: redis
 #
 # 2.1.1
 # - Support deploying without alerts (e.g. local development)
-version: 2.1.6 # this version number is SemVer as it gets used to auto bump
+version: 2.1.7 # this version number is SemVer as it gets used to auto bump

--- a/common/redis/templates/deployment.yaml
+++ b/common/redis/templates/deployment.yaml
@@ -99,7 +99,9 @@ spec:
         - name: redis-config
           mountPath: /etc/redis
       {{- end }}
+      {{- if not .Values.redisPassword }}
       serviceAccountName: {{ $fullname }}
+      {{- end }}
       volumes:
       - name: redis-data
       {{- if .Values.persistence.enabled }}


### PR DESCRIPTION
Explicitly setting the redisPassword, not relying on an auto-generated PW, does not create the ServiceAccount, Role and RoleBinding causing the deployment to fail.

In case as PW is explicitly set, we simply ignore the SerivceAcount.