### PR TITLE
[nova] update hermes audit map with unmapped resources

### DIFF
--- a/openstack/nova/templates/etc/_nova_audit_map.yaml.tpl
+++ b/openstack/nova/templates/etc/_nova_audit_map.yaml.tpl
@@ -58,16 +58,28 @@ resources:
     migrations_legacy_api:
         api_name: os-migrations
         type_uri: compute/migrations
+    # os-floating-ips is deprecated, but it's still being called so it needs to be mapped.
+    os-floating-ips:
+        type_uri: compute/floating-ips
+        el_type_uri: compute/floating-ip
     os-server-external-events:
         type_uri: compute/servers/external-events
         type_name: events
         custom_id: tag
         custom_attributes:
           server_uuid: compute/server
+    # os-security-group-rules is deprecated, but it's still being called, must be mapped.
+    os-security-group-rules
+        type_uri: compute/security-group-rules
+        el_type_uri: compute/security-group-rule
     os-volumes_boot:
         # this is a legacy alternative to POST /servers used still in Devstack
         type_uri: compute/servers
         type_name: servers
+    # deprecated but still called, must be mapped.
+    os-volumes:
+        type_uri: compute/volumes
+        el_type_uri: compute/volume
     quotas:
         api_name: os-quota-sets
         children:

--- a/openstack/nova/templates/etc/_nova_audit_map.yaml.tpl
+++ b/openstack/nova/templates/etc/_nova_audit_map.yaml.tpl
@@ -61,7 +61,6 @@ resources:
     # os-floating-ips is deprecated, but it's still being called so it needs to be mapped.
     os-floating-ips:
         type_uri: compute/floating-ips
-        el_type_uri: compute/floating-ip
     os-server-external-events:
         type_uri: compute/servers/external-events
         type_name: events
@@ -71,7 +70,6 @@ resources:
     # os-security-group-rules is deprecated, but it's still being called, must be mapped.
     os-security-group-rules
         type_uri: compute/security-group-rules
-        el_type_uri: compute/security-group-rule
     os-volumes_boot:
         # this is a legacy alternative to POST /servers used still in Devstack
         type_uri: compute/servers
@@ -79,7 +77,6 @@ resources:
     # deprecated but still called, must be mapped.
     os-volumes:
         type_uri: compute/volumes
-        el_type_uri: compute/volume
     quotas:
         api_name: os-quota-sets
         children:


### PR DESCRIPTION
The unmapped resources are deprecated in the nova api, but they are still being called in production environments and require mapping.