### PR TITLE
Exclude cert-manager owned secrets from secrets-injector webhook

### DIFF
--- a/system/secrets-injector/Chart.yaml
+++ b/system/secrets-injector/Chart.yaml
@@ -3,7 +3,7 @@ name: secrets-injector
 description: Secrets Injector
 
 type: application
-version: 1.1.9
+version: 1.1.10
 appVersion: "0.1.0"
 
 dependencies:

--- a/system/secrets-injector/templates/webhook.yaml
+++ b/system/secrets-injector/templates/webhook.yaml
@@ -26,6 +26,8 @@ webhooks:
   matchConditions: # webhook is called, when all conditions are true
   - name: 'exclude-opt-out-secrets'
     expression: 'object.metadata.?annotations["cloud.sap/inject-secrets"].orValue("") != "false"'
+  - name: 'exclude-owner-cert-manager'
+    expression: 'object.metadata.?ownerReferences.optMap(l, !("cert-manager.io" in l.map(r, r.apiVersion))).orValue(true)'
   {{- end }}
 {{- if .Values.webhook.genericRules }}
 - name: "generic.secrets-injector.cloud.sap"


### PR DESCRIPTION
This avoids issues with certificates
during chart installation.