### PR TITLE
[pgbackup] add option to use db_region to fix limes in global

### DIFF
--- a/common/pgbackup/Chart.yaml
+++ b/common/pgbackup/Chart.yaml
@@ -2,7 +2,7 @@ name: pgbackup
 # 1.2.0
 # - Added `.Values.reloader.enabled` to control consumption of
 #   `stakater/Reloader` annotations on referenced Secrets and CMs.
-version: 1.2.0 # this version number is SemVer as it gets used to auto bump
+version: 1.2.1 # this version number is SemVer as it gets used to auto bump
 apiVersion: v2
 description: PostgreSQL backup/restore pod
 appVersion: "v0.10.0-111-gb31fd82" # of https://github.com/sapcc/backup-tools

--- a/common/pgbackup/ci/test-values.yaml
+++ b/common/pgbackup/ci/test-values.yaml
@@ -1,6 +1,7 @@
 global:
   registry: keppel.example.com/ccloud
   region: qa-de-1
+  db_region: qa-de-1
   vaultBaseURL: vault.example.com/secrets
 
 database:

--- a/common/pgbackup/templates/deployment.yaml
+++ b/common/pgbackup/templates/deployment.yaml
@@ -1,4 +1,5 @@
-{{- $region   := .Values.global.region                   | required "missing value for .Values.global.region"       -}}
+{{/* in case of the global region, the dbRegion is different than region=global */}}
+{{- $dbRegion := coalesce .Values.global.db_region .Values.global.region  | required "missing value for .Values.global.region and db_region" -}}
 {{- $registry := .Values.global.registry                 | required "missing value for .Values.global.registry" -}}
 {{- if .Values.use_alternate_region -}}
   {{- $registry = .Values.global.registryAlternateRegion | required "missing value for .Values.global.registryAlternateRegion" -}}
@@ -53,7 +54,7 @@ spec:
             - name: MY_POD_NAMESPACE
               value: {{ quote .Release.Namespace }}
             - name: OS_AUTH_URL
-              value: {{ printf "https://identity-3.%s.cloud.sap/v3" $region | quote }}
+              value: {{ printf "https://identity-3.%s.cloud.sap/v3" $dbRegion | quote }}
             - name: OS_AUTH_VERSION
               value: "3"
             - name: OS_USERNAME
@@ -65,7 +66,7 @@ spec:
             - name: OS_PROJECT_DOMAIN_NAME
               value: ccadmin
             - name: OS_REGION_NAME
-              value: {{ quote $region }}
+              value: {{ quote $dbRegion }}
             - name: OS_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -87,7 +88,7 @@ spec:
             limits:
               memory: {{ .Values.resources.memory_limit }}
               cpu: {{ .Values.resources.cpu_limit }}
-            {{- if not (.Values.global.region | regexMatch "^qa-de-[2-6]$") }}
+            {{- if not ($dbRegion | regexMatch "^qa-de-[2-6]$") }}
             requests:
               memory: {{ .Values.resources.memory_limit }}
               cpu: {{ .Values.resources.cpu_request }}

--- a/common/pgbackup/templates/secret.yaml
+++ b/common/pgbackup/templates/secret.yaml
@@ -3,7 +3,8 @@
 {{- end }}
 
 {{- $vbase  := .Values.global.vaultBaseURL | required "missing value for .Values.global.vaultBaseURL" -}}
-{{- $region := .Values.global.region       | required "missing value for .Values.global.region"       -}}
+{{/* in case of the global region, the dbRegion is different than region=global */}}
+{{- $dbRegion := coalesce .Values.global.db_region .Values.global.region  | required "missing value for .Values.global.region and db_region" -}}
 
 apiVersion: v1
 kind: Secret
@@ -12,4 +13,4 @@ metadata:
 
 type: Opaque
 data:
-  swift-password: {{ printf "%s/%s/shared/keystone-user/db-backup/password" $vbase $region | b64enc | quote }}
+  swift-password: {{ printf "%s/%s/shared/keystone-user/db-backup/password" $vbase $dbRegion | b64enc | quote }}


### PR DESCRIPTION
For the `global` region, it is necessary to distinguish the "virtual region" (global) from the real region where the db is running and to be backed up (which has e.g. a storage service available). We already introduced the variable but this should be downwards compatible for all usecases where the `$REGION/values/globals.yaml` is not used.