### PR TITLE
[Neutron] Bump Redis

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -19,9 +19,9 @@ dependencies:
   version: 1.0.0
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 2.1.5
+  version: 2.1.7
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:c984cc4660d9ab11a40720d61f75dcf635bf05f7610ce053d5f5ea40daf50f3a
-generated: "2025-03-25T15:25:50.918897+01:00"
+digest: sha256:dd86b06ddb0519bd3f3f231c0e54bcf8b368691d1115c77b4d5d1e0954cf93f9
+generated: "2025-04-10T10:13:43.44042+02:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -27,7 +27,7 @@ dependencies:
   - name: redis
     alias: api-ratelimit-redis
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 2.1.5
+    version: 2.1.7
     condition: rate_limit.enabled
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm


### PR DESCRIPTION
Using redisPassword via vault breaks the redis deployment as some older version 2.x.x requires a k8s service account which only is created if the password is auto-generated.