### PR TITLE
[mariadb][backup-v2] add reloader annotation for maria-back-me-up

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.23.0 - 2025/04/10
+* reloader annotation has been added to the backup-v2 deployment, so backup-v2 deployment always uses updated credentials
+
 ## v0.22.0 - 2025/04/09
 * delete unmanaged localhost users like 'username'@'localhost'
 

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,6 +2,6 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.22.0
+version: 0.23.0
 # scripts/docker-entyrpoint.sh should be updated when appVersion is updated
 appVersion: 10.5.28

--- a/common/mariadb/templates/backup-v2-deployment.yaml
+++ b/common/mariadb/templates/backup-v2-deployment.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     app: {{ include "fullName" . }}-backup
     {{- include "mariadb.labels" (list $ "version" "mariadb" "deployment" "backup") | indent 4 }}
+  annotations:
+    secret.reloader.stakater.com/reload: "mariadb-backup-{{.Values.name}}-etc,mariadb-{{.Values.name}}-backup-oauth"
 spec:
   replicas: 1
   revisionHistoryLimit: 5

--- a/common/mariadb/templates/backup-verify-deploy.yaml
+++ b/common/mariadb/templates/backup-verify-deploy.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "fullName" . }}-verification
   labels:
     {{- include "mariadb.labels" (list $ "version" "mariadb" "deployment" "backupverification") | indent 4 }}
+  annotations:
+    secret.reloader.stakater.com/reload: "mariadb-backup-{{.Values.name}}-etc"
 spec:
   replicas: 1
   revisionHistoryLimit: 5


### PR DESCRIPTION
Add reloader annotation for maria-back-me-up, so backup-v2 deployment always uses updated credentials