### PR TITLE
[postgres + redis] fix type of reloader annotation

### DIFF
--- a/common/postgresql-ng/Chart.yaml
+++ b/common/postgresql-ng/Chart.yaml
@@ -28,4 +28,4 @@ description: Chart for PostgreSQL
 # 1.4.0
 # - Added `.Values.reloader.annotateGeneratedSecrets` to control
 #   `stakater/Reloader` annotations of generated secrets.
-version: 1.4.0 # this version number is SemVer as it gets used to auto bump
+version: 1.4.1 # this version number is SemVer as it gets used to auto bump

--- a/common/postgresql-ng/templates/deployment.yaml
+++ b/common/postgresql-ng/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
         - name: USERS
           value: {{ keys (.Values.users | required ".Values.users must be configured") | sortAlpha | join " " | quote }}
         - name: ANNOTATE_FOR_RELOADER
-          value: {{ .Values.reloader.annotateGeneratedSecrets }}
+          value: {{ .Values.reloader.annotateGeneratedSecrets | quote }}
         command: [ ash, -c, {{ .Files.Get "bin/init-generate-secrets.sh" | quote }} ]
 
       containers:

--- a/common/redis/Chart.yaml
+++ b/common/redis/Chart.yaml
@@ -43,4 +43,4 @@ name: redis
 #   secrets and consuming workloads. See
 #   `.Values.reloader.annotateGeneratedSecrets` and
 #   `.Values.metrics.reloader.enabled`
-version: 2.2.0 # this version number is SemVer as it gets used to auto bump
+version: 2.2.1 # this version number is SemVer as it gets used to auto bump

--- a/common/redis/templates/deployment.yaml
+++ b/common/redis/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
         - name: USERS
           value: 'default'
         - name: ANNOTATE_FOR_RELOADER
-          value: {{ .Values.reloader.annotateGeneratedSecrets }}
+          value: {{ .Values.reloader.annotateGeneratedSecrets | quote }}
         command: [ ash, -c, {{ .Files.Get "bin/init-generate-secrets.sh" | quote }} ]
       {{- end }}
       containers:


### PR DESCRIPTION
Should fix:
```
json: cannot unmarshal bool into Go struct field EnvVar.spec.template.spec.initContainers.env.value of type string
```