### PR TITLE
[limes] Add dashboard link to expiring commitment mail

### DIFF
--- a/openstack/limes/files/commitment_mail.tpl
+++ b/openstack/limes/files/commitment_mail.tpl
@@ -29,6 +29,7 @@
                 <li>Project: {{"{{"}} .ProjectName {{"}}"}}</li>
             </ul>
         </p>
+        {{ .dashboardInfo }}
 
         <div style="overflow-x: auto;">
             <table>

--- a/openstack/limes/templates/configmap.yaml
+++ b/openstack/limes/templates/configmap.yaml
@@ -22,7 +22,7 @@ data:
          body: {{ tpl (.Files.Get "files/commitment_mail.tpl") (dict "region" .Values.global.region "condition" .Values.campfire.mail_type.confirmed.condition) | toJson }}
         expiring_commitments:
          subject: {{ .Values.campfire.mail_type.expire.subject }}
-         body: {{ tpl (.Files.Get "files/commitment_mail.tpl") (dict "region" .Values.global.region "condition" .Values.campfire.mail_type.expire.condition "dashboardInfo" $dashboardInfo )| toJson }}
+         body: {{ tpl (.Files.Get "files/commitment_mail.tpl") (dict "region" .Values.global.region "condition" .Values.campfire.mail_type.expire.condition "dashboardInfo" $dashboardInfo)| toJson }}
     {{- end }}
 {{ toYaml .Values.limes.clusters.ccloud | indent 4 }}
 

--- a/openstack/limes/templates/configmap.yaml
+++ b/openstack/limes/templates/configmap.yaml
@@ -1,3 +1,6 @@
+{{- $dashboardURL := printf "https://dashboard.%s.%s/{{ .DomainName }}/{{ .ProjectName }}/resources/v2/project#/Renewal" $.Values.global.region $.Values.global.tld -}}
+{{- $dashboardInfo := printf "<p>Commitments can be renewed through the resource management <a href=%s>dashboard</a></p>." $dashboardURL -}}
+
 apiVersion: v1
 kind: ConfigMap
 
@@ -19,7 +22,7 @@ data:
          body: {{ tpl (.Files.Get "files/commitment_mail.tpl") (dict "region" .Values.global.region "condition" .Values.campfire.mail_type.confirmed.condition) | toJson }}
         expiring_commitments:
          subject: {{ .Values.campfire.mail_type.expire.subject }}
-         body: {{ tpl (.Files.Get "files/commitment_mail.tpl") (dict "region" .Values.global.region "condition" .Values.campfire.mail_type.expire.condition) | toJson }}
+         body: {{ tpl (.Files.Get "files/commitment_mail.tpl") (dict "region" .Values.global.region "condition" .Values.campfire.mail_type.expire.condition "dashboardInfo" $dashboardInfo )| toJson }}
     {{- end }}
 {{ toYaml .Values.limes.clusters.ccloud | indent 4 }}
 

--- a/openstack/limes/templates/configmap.yaml
+++ b/openstack/limes/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{- $dashboardURL := printf "https://dashboard.%s.%s/{{ .DomainName }}/{{ .ProjectName }}/resources/v2/project#/Renewal" $.Values.global.region $.Values.global.tld -}}
-{{- $dashboardInfo := printf "<p>Commitments can be renewed through the resource management <a href=%s>dashboard</a></p>." $dashboardURL -}}
+{{- $dashboardInfo := printf "<p>Commitments can be renewed through the resource management <a href=\"%s\">dashboard</a></p>." $dashboardURL -}}
 
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
Mails for expiring commitments can include a link to the dashboard.