### PR TITLE
Keystone: Add configuration for `report_invalid_password_hash`

### DIFF
--- a/openstack/keystone/templates/etc/_secrets.conf.tpl
+++ b/openstack/keystone/templates/etc/_secrets.conf.tpl
@@ -55,3 +55,10 @@ trusted_key_header = {{ .Values.api.cc_external.trusted_key_header | default "HT
 trusted_key_value = {{ .Values.api.cc_external.trusted_key_value }}
 {{- end }}
 {{- end }}
+
+{{- if .Values.report_invalid_password_hash.enabled }}
+[security_compliance]
+report_invalid_password_hash = "event"
+invalid_password_hash_secret_key = {{ required "invalid_password_hash_secret_key value is required when .Values.report_invalid_password_hash.enabled is true" .Values.report_invalid_password_hash.invalid_password_hash_secret_key | include "resolve_secret" }}
+invalid_password_hash_max_chars = 5
+{{- end }}

--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -528,6 +528,11 @@ sre:
 # optional flag to disable users that have not authenticated for 100 years.
 disable_user_account_days_inactive: 36500
 
+# https://docs.openstack.org/keystone/latest/admin/event_notifications.html#example-notification-invalid-password-authentication
+report_invalid_password_hash:
+  enabled: false
+  # invalid_password_hash_secret_key: ""
+
 2fa:
   enabled: false
   replicaCount: 3


### PR DESCRIPTION
The feature is described here - https://docs.openstack.org/keystone/latest/admin/event_notifications.html#example-notification-invalid-password-authentication.

Requires: https://github.com/sapcc/keystone/pull/31