### PR TITLE
feat(greenhouse): add pod log viewer teamrole

### DIFF
--- a/system/greenhouse-ccloud/Chart.yaml
+++ b/system/greenhouse-ccloud/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: ccloud
 description: A Helm chart for the CCloud organization in Greenhouse.
 type: application
-version: 1.19.5
+version: 1.20.0

--- a/system/greenhouse-ccloud/templates/team-roles.yaml
+++ b/system/greenhouse-ccloud/templates/team-roles.yaml
@@ -1,3 +1,4 @@
+---
 # Greenhouse does not provide "pod/exec" permission by default, so we need to create a custom TeamRole to grant this permission.
 apiVersion: greenhouse.sap/v1alpha1
 kind: TeamRole
@@ -22,3 +23,21 @@ spec:
         - "get"
         - "list"
         - "watch"
+---
+apiVersion: greenhouse.sap/v1alpha1
+kind: TeamRole
+metadata:
+  name: pod-log-viewer
+  namespace: {{ .Release.Namespace }}
+spec:
+  rules:
+    - apiGroups:
+        - ""
+      resources:
+        - pods
+        - pods/log
+      verbs:
+        - "get"
+        - "list"
+        - "watch"
+---


### PR DESCRIPTION
this role is needed to give out permissions to view logs
access to the logs is required for the observability team
to be able to develop the specific log parser for kvm/ceph
