### PR TITLE
[manila] snapmirror capacity for multiple targets

### DIFF
--- a/openstack/manila/aggregates/storage/limes.rules
+++ b/openstack/manila/aggregates/storage/limes.rules
@@ -5,10 +5,22 @@ groups:
       # we look at the source (volume_type is not dp)
       # we only look at volumes that have dedicated snapshot policy: case insensitive hxm_backups or ec2_backups
       # we require share type and project id to be able to associate to valid billing targets.
+      # we multiply the source bytes with the count of target snapmirrors, that are not matching the manila naming pattern
+      # such EC2DR (different region) or EC2BKP (same region) snapmirrors are setup outside of manila
+      # and have a (not so easily predictable) suffix at the vserver name.
       # last over time to bridge gaps of missing metrics.
       # max by the labels that limes is expecting: availability_zone, project_id, share_id, share_type
 
-      - record: netapp_snapmirror_capacity_total_bytes
+      - record: netapp_snapmirror_capacity_count
+        expr: |
+            count by (volume) (label_replace(
+                    last_over_time(
+                        netapp_snapmirror_endpoint_labels{
+                            destination_vserver!~"ma_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"}[15m]
+                    ),
+                    "volume", "$1", "source_volume", "(.*)"))
+
+      - record: netapp_snapmirror_capacity_total_bytes:single
         expr: |
             netapp_volume_total_bytes:pre * on (app, host, svm, volume)
                 group_left(snapshot_policy, state) netapp_volume_labels{
@@ -18,12 +30,16 @@ groups:
                     state="online",
                     volume_type!="dp"}
 
+      - record: netapp_snapmirror_capacity_total_bytes
+        expr: |
+            netapp_snapmirror_capacity_total_bytes:single * on(volume) group_left() netapp_snapmirror_capacity_count
+
       - record: netapp_snapmirror_capacity_total_bytes_for_limes
         expr: |
             max by (availability_zone, project_id, share_id, share_type) (
                 last_over_time(netapp_snapmirror_capacity_total_bytes[15m]))
 
-      - record: netapp_snapmirror_capacity_used_bytes
+      - record: netapp_snapmirror_capacity_used_bytes:single
         expr: |
             netapp_volume_used_bytes:pre * on (app, host, svm, volume)
                 group_left(snapshot_policy, state) netapp_volume_labels{
@@ -32,6 +48,10 @@ groups:
                     snapshot_policy=~"(?i:(hxm|ec2))_(?i:(backups))",
                     state="online",
                     volume_type!="dp"}
+
+      - record: netapp_snapmirror_capacity_used_bytes
+        expr: |
+            netapp_snapmirror_capacity_used_bytes:single * on(volume) group_left() netapp_snapmirror_capacity_count
 
       - record: netapp_snapmirror_capacity_used_bytes_for_limes
         expr: |

--- a/openstack/manila/alerts/storage/ec2.alerts
+++ b/openstack/manila/alerts/storage/ec2.alerts
@@ -1,0 +1,18 @@
+groups:
+- name: manila-ec2.alerts
+  rules:
+  - alert: SnapmirrorSetupBroken
+    expr: >
+            count by (volume) (label_replace(
+            netapp_snapmirror_endpoint_labels{destination_vserver!~"ma_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"},
+            "volume", "$1", "source_volume", "(.*)")) unless count(netapp_snapmirror_capacity_total_bytes:single) by (volume)  > 0
+    for: 5m
+    labels:
+      service: manila
+      context: netapp-snapmirror-broken
+      severity: info
+      tier: os
+      support_group: compute-storage-api
+    annotations:
+      description: Snapmirror setup is inconsistent, please have a look. Having snapmirror endpoint, but not a source.
+      summary: Snapmirror setup is inconsistent


### PR DESCRIPTION
Some setups have more than one snapmirror destination endpoint,
so we multiply now by the number of snapmirror relationships.
But only those that are not under control of manila,
i.e. only if the share server does not follow the naming pattern of
`ma_<UUID>`
