### PR TITLE
[manila] fix audit for subnets

### DIFF
--- a/openstack/manila/templates/etc/_manila_audit_map.yaml
+++ b/openstack/manila/templates/etc/_manila_audit_map.yaml
@@ -110,7 +110,10 @@ resources:
         api_name: export_locations
   share-networks:
     children:
-      subnets
+      subnets:
+        children:
+          metadata:
+            singleton: true
     custom_actions:
       # model details listing a action
       detail: read/list/details


### PR DESCRIPTION
child cannot be a string, but must be a dict

Since we are touching it anyway, noticed that we can also add metadata.
