### PR TITLE
[designate] bump chart dependencies

### DIFF
--- a/openstack/designate/Chart.lock
+++ b/openstack/designate/Chart.lock
@@ -7,16 +7,16 @@ dependencies:
   version: 0.3.1
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.22.0
+  version: 0.23.0
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.6.9
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.4.2
+  version: 0.4.3
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.17.1
+  version: 0.17.2
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.26.0
@@ -29,5 +29,5 @@ dependencies:
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.1.4
-digest: sha256:cd9c45be336d9463efdc634b767f3afdbf39e71c02a2842473b0d85dae0f92b2
-generated: "2025-04-09T17:21:23.341554+03:00"
+digest: sha256:2a3cd9291a0d010d1e962f0753fd2aef6b4e6f0a6c8807043ac6be46ba65973e
+generated: "2025-04-14T13:25:24.611359+03:00"

--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes to deploy Openstack Designate  (DNSaaS)
 name: designate
-version: 0.5.1
+version: 0.5.2
 appVersion: "dalmatian"
 dependencies:
   - condition: percona_cluster.enabled
@@ -17,18 +17,18 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.22.0
+    version: 0.23.0
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.6.9
   - condition: mysql_metrics.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.4.2
+    version: 0.4.3
   - name: rabbitmq
     condition: rabbitmq.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.17.1
+    version: 0.17.2
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.26.0


### PR DESCRIPTION
* mariadb 0.22.0 -> 0.23.0: adds reloader for backup-v2
* mysql-metrics 0.4.2 -> 0.4.3: add vpa annotation support
* rabbitmq 0.17.1 -> 0.17.2: updates rabbitmq to 4.0.8