### PR TITLE
[mariadb] Update database to the 10.6 release

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.24.0 - 2025/04/16
+* MariaDB has been updated to the 10.6.21 version
+  * delete removed `innodb_thread_concurrency` variable from my.cnf
+
+See related documentation at https://mariadb.com/kb/en/upgrading-from-mariadb-10-5-to-mariadb-10-6/
+
+The default value of the `old_mode` variable is `UTF8_IS_UTF8MB3` until MariaDB 11.2.
+
 ## v0.23.0 - 2025/04/10
 * reloader annotation has been added to the backup-v2 deployment, so backup-v2 deployment always uses updated credentials
 

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,6 +2,6 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.23.0
+version: 0.24.0
 # scripts/docker-entyrpoint.sh should be updated when appVersion is updated
-appVersion: 10.5.28
+appVersion: 10.6.21

--- a/common/mariadb/scripts/docker-entrypoint.sh
+++ b/common/mariadb/scripts/docker-entrypoint.sh
@@ -100,7 +100,7 @@ docker_process_init_files() {
 	done
 }
 
-# arguments necessary to run "mysqld --verbose --help" successfully (used for testing configuration validity and for extracting default/configured values)
+# arguments necessary to run "mariadbd --verbose --help" successfully (used for testing configuration validity and for extracting default/configured values)
 _verboseHelpArgs=(
 	--verbose --help
 )
@@ -108,12 +108,12 @@ _verboseHelpArgs=(
 mysql_check_config() {
 	local toRun=( "$@" "${_verboseHelpArgs[@]}" ) errors
 	if ! errors="$("${toRun[@]}" 2>&1 >/dev/null)"; then
-		mysql_error $'mysqld failed while attempting to check config\n\tcommand was: '"${toRun[*]}"$'\n\t'"$errors"
+		mysql_error $'mariadbd failed while attempting to check config\n\tcommand was: '"${toRun[*]}"$'\n\t'"$errors"
 	fi
 }
 
 # Fetch value from server config
-# We use mysqld --verbose --help instead of my_print_defaults because the
+# We use mariadbd --verbose --help instead of my_print_defaults because the
 # latter only show values present in config files, and not server defaults
 mysql_get_config() {
 	local conf="$1"; shift
@@ -151,7 +151,7 @@ docker_temp_server_start() {
 	fi
 }
 
-# Stop the server. When using a local socket file mysqladmin will block until
+# Stop the server. When using a local socket file mariadb-admin will block until
 # the shutdown is complete.
 docker_temp_server_stop() {
 	kill "$MARIADB_PID"
@@ -220,27 +220,28 @@ docker_create_db_directories() {
 }
 
 _mariadb_version() {
-	echo -n "10.5.28-MariaDB"
+	echo -n "10.6.21-MariaDB"
 }
 
 # initializes the database directory
 docker_init_database_dir() {
 	mysql_note "Initializing database files"
 	installArgs=( --datadir="$DATADIR" --rpm --auth-root-authentication-method=normal )
-	# "Other options are passed to mysqld." (so we pass all "mysqld" arguments directly here)
+	# "Other options are passed to mariadbd." (so we pass all "mariadbd" arguments directly here)
 
-	local mysqldArgs=()
+	local mariadbdArgs=()
 	for arg in "${@:2}"; do
 		# Check if the argument contains whitespace
 		if [[ "$arg" =~ [[:space:]] ]]; then
-			mysql_warn "Not passing argument \'$arg\' to mysql_install_db because mysql_install_db does not support arguments with whitespace."
+			mysql_warn "Not passing argument \'$arg\' to mariadb-install-db because mariadb-install-db does not support arguments with whitespace."
 		else
-			mysqldArgs+=("$arg")
+			mariadbdArgs+=("$arg")
 		fi
 	done
-	mysql_install_db "${installArgs[@]}" "${mysqldArgs[@]}" \
+	mariadb-install-db "${installArgs[@]}" "${mariadbdArgs[@]}" \
 		--cross-bootstrap \
 		--skip-test-db \
+		--old-mode='UTF8_IS_UTF8MB3' \
 		--default-time-zone=SYSTEM --enforce-storage-engine= \
 		--skip-log-bin \
 		--expire-logs-days=0 \
@@ -296,7 +297,7 @@ docker_exec_client() {
 	if [ -n "$MYSQL_DATABASE" ]; then
 		set -- --database="$MYSQL_DATABASE" "$@"
 	fi
-	mysql --protocol=socket -uroot -hlocalhost --socket="${SOCKET}" "$@"
+	mariadb --protocol=socket -uroot -hlocalhost --socket="${SOCKET}" "$@"
 }
 
 # Execute sql script, passed via stdin
@@ -341,7 +342,7 @@ docker_setup_db() {
 		# --skip-write-binlog usefully disables binary logging
 		# but also outputs LOCK TABLES to improve the IO of
 		# Aria (MDEV-23326) for 10.4+.
-		mysql_tzinfo_to_sql --skip-write-binlog /usr/share/zoneinfo \
+		mariadb-tzinfo-to-sql --skip-write-binlog /usr/share/zoneinfo \
 			| docker_process_sql --dont-use-mysql-root-password --database=mysql
 		# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is not set yet
 	fi
@@ -550,7 +551,7 @@ docker_mariadb_backup_system()
 	fi
 
 	mysql_note "Backing up system database to $backup_db"
-	if ! mysqldump --skip-lock-tables --replace --databases mysql --socket="${SOCKET}" | zstd > "${DATADIR}/${backup_db}"; then
+	if ! mariadb-dump --skip-lock-tables --replace --databases mysql --socket="${SOCKET}" | zstd > "${DATADIR}/${backup_db}"; then
 		mysql_error "Unable backup system database for upgrade from $oldfullversion."
 	fi
 	mysql_note "Backing up complete"
@@ -561,7 +562,7 @@ docker_mariadb_backup_system()
 docker_mariadb_upgrade() {
 	if [ -z "$MARIADB_AUTO_UPGRADE" ] \
 		|| [ "$MARIADB_AUTO_UPGRADE" = 0 ]; then
-		mysql_note "MariaDB upgrade (mysql_upgrade) required, but skipped due to \$MARIADB_AUTO_UPGRADE setting"
+		mysql_note "MariaDB upgrade (mariadb-upgrade or creating healthcheck users) required, but skipped due to \$MARIADB_AUTO_UPGRADE setting"
 		return
 	fi
 	mysql_note "Starting temporary server"
@@ -572,7 +573,7 @@ docker_mariadb_upgrade() {
 	docker_mariadb_backup_system
 
 	mysql_note "Starting mariadb-upgrade"
-	mysql_upgrade --upgrade-system-tables
+	mariadb-upgrade --upgrade-system-tables
 	mysql_note "Finished mariadb-upgrade"
 
 	mysql_note "Stopping temporary server"
@@ -600,7 +601,7 @@ _check_if_upgrade_is_needed() {
 	return 1
 }
 
-# check arguments for an option that would cause mysqld to stop
+# check arguments for an option that would cause mariadbd to stop
 # return true if there is one
 _mysql_want_help() {
 	local arg
@@ -615,9 +616,9 @@ _mysql_want_help() {
 }
 
 _main() {
-	# if command starts with an option, prepend mysqld
+	# if command starts with an option, prepend mariadbd
 	if [ "${1:0:1}" = '-' ]; then
-		set -- mysqld "$@"
+		set -- mariadbd "$@"
 	fi
 
 	#ENDOFSUBSTITUTIONS
@@ -642,7 +643,7 @@ _main() {
 
 			docker_mariadb_init "$@"
 		# MDEV-27636 mariadb_upgrade --check-if-upgrade-is-needed cannot be run offline
-		#elif mysql_upgrade --check-if-upgrade-is-needed; then
+		#elif mariadb-upgrade --check-if-upgrade-is-needed; then
 		elif _check_if_upgrade_is_needed; then
 			docker_mariadb_upgrade "$@"
 		fi

--- a/common/mariadb/templates/deployment.yaml
+++ b/common/mariadb/templates/deployment.yaml
@@ -78,7 +78,7 @@ spec:
         lifecycle:
           postStart:
             exec:
-              command: ["sh", "-c", "while ! mysqladmin ping --silent; do sleep 1; done; mysql_upgrade"]
+              command: ["sh", "-c", "while ! mariadb-admin ping --silent; do sleep 1; done; mariadb-upgrade"]
         env:
         - name: MYSQL_ROOT_PASSWORD
           valueFrom:
@@ -91,7 +91,7 @@ spec:
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           exec:
-            command: ["sh", "-c", "exec mysqladmin status"]
+            command: ["sh", "-c", "exec mariadb-admin status"]
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -101,7 +101,7 @@ spec:
         {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
           exec:
-            command: ["sh", "-c", "exec mysqladmin status"]
+            command: ["sh", "-c", "exec mariadb-admin status"]
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/common/mariadb/templates/etc-configmap.yaml
+++ b/common/mariadb/templates/etc-configmap.yaml
@@ -16,7 +16,6 @@ data:
     innodb_log_file_size      = {{ .Values.log_file_size }}
     innodb_open_files         = 4000
     innodb_stats_on_metadata  = 0
-    innodb_thread_concurrency = 0
     innodb_read_io_threads    = 8
     innodb_write_io_threads   = 8
     innodb_print_all_deadlocks = 1

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -4,7 +4,7 @@
 # name: value
 
 name: null
-image: library/mariadb:10.5.28
+image: library/mariadb:10.6.21
 imagePullPolicy: IfNotPresent
 port_public: 3306
 max_connections: 1024


### PR DESCRIPTION
* MariaDB has been updated to the 10.6.21 version
  * delete removed `innodb_thread_concurrency` variable from my.cnf

See related documentation at https://mariadb.com/kb/en/upgrading-from-mariadb-10-5-to-mariadb-10-6/

The default value of the `old_mode` variable is `UTF8_IS_UTF8MB3` until MariaDB 11.2.
