### PR TITLE
[metis][mariadb] update database chart dependency

### DIFF
--- a/system/metis/Chart.lock
+++ b/system/metis/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.17.2
+  version: 0.23.0
 - name: prometheus-monitors
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.0.2
@@ -11,5 +11,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:8ce9fd7f8622890ba8e15f7346a51373a82aeb16d66a2db16b27a789a97de859
-generated: "2025-03-06T09:34:42.608258+01:00"
+digest: sha256:ec730a8c4a8358da29952987f5c80af1e40e579468738d03715c6692449170df
+generated: "2025-04-14T18:21:02.181466+03:00"

--- a/system/metis/Chart.yaml
+++ b/system/metis/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
 name: metis
-version: 1.6.0
+version: 1.6.1
 description: Read-only DB for replicas of OpenStack DBs and Project Masterdata
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.17.2
+    version: 0.23.0
   - name: prometheus-monitors
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.0.2


### PR DESCRIPTION
Update mariadb chart to 0.23.0:
* add user-credential-updater sidecar, that can update credentials after a secret update by secrets-injector
* removes unused and unmanaged username@localhost user
* fixes unnecessary restarts on every chart version update
* adds reloader annotation for backup-v2 deployment