### PR TITLE
Keystone: fail db-sync script if subcommands fail

### DIFF
--- a/openstack/keystone/templates/bin/_db-sync.tpl
+++ b/openstack/keystone/templates/bin/_db-sync.tpl
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 echo "Status before migration:"
 keystone-status --config-file=/etc/keystone/keystone.conf --config-file=/etc/keystone/keystone.conf.d/secrets.conf upgrade check
 
@@ -15,6 +17,3 @@ echo "Keystone doctor:"
 keystone-manage --config-file=/etc/keystone/keystone.conf --config-file=/etc/keystone/keystone.conf.d/secrets.conf doctor
 
 {{ include "utils.script.job_finished_hook" . | trim }}
-
-# don't let the doctor break stuff (as usual not qualified enough and you allways need another opinion :P )
-exit 0


### PR DESCRIPTION
The script is pretty important and we must act if it fails. Otherwise we
shall live with unupgraded database for years before we find that out, and
upgrading it might be impossible.

We don't add any logic here, but rather expect keystone to fail loudly
if something goes wrong.