### PR TITLE
[unbound] firewall support, server identity

### DIFF
--- a/system/unbound/templates/config.yaml
+++ b/system/unbound/templates/config.yaml
@@ -84,6 +84,9 @@ data:
        include: /etc/unbound/regional.conf
        include: /etc/unbound/global.conf
 
+       # firewall
+       include: /etc/unbound/firewall.conf
+
        # dnstap.conf
        include: /etc/unbound/dnstap.conf
 
@@ -144,6 +147,14 @@ data:
        {{- range $ldata := .Values.unbound.local_data}}
        local-data: {{ $ldata.local_data | quote }}
        {{- end}}
+
+  firewall.conf: |
+       {{- range $blocklisted := .Values.unbound.blocklisted_zones }}
+       local-zone: {{ tpl $blocklisted $ | quote }} refuse
+       {{- end }}
+       {{- range $allowlisted := .Values.unbound.allowlisted_zones }}
+       local-zone: {{ tpl $allowlisted $ | quote }} transparent
+       {{- end }}
 
   regional.conf: |
        {{- range $forward := .Values.unbound.forward_zones }}

--- a/system/unbound/templates/config.yaml
+++ b/system/unbound/templates/config.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   unbound.conf: |
        server:
-        identity: "{{ .Values.unbound.name }}.{{ .Values.global.region }}"
+        identity: "{{ $.Release.Name }}.{{ .Values.global.region }}"
 
         {{- $unbound_modules := "validator iterator" -}}
 

--- a/system/unbound/templates/config.yaml
+++ b/system/unbound/templates/config.yaml
@@ -70,22 +70,23 @@ data:
         logfile: ""
         log-time-ascii: yes
         log-servfail: yes
-        include: /etc/unbound/hosts.conf
 
         # enable extended statistics (query types, answer codes, status)
         extended-statistics: {{.Values.unbound.ext_stats}}
+
+        include: /etc/unbound/hosts.conf
+
+        # firewall
+        include: /etc/unbound/firewall.conf
+
+        # Stub and Forward zones
+        include: /etc/unbound/regional.conf
+        include: /etc/unbound/global.conf
 
        # Remote control config section.
        remote-control:
         control-enable: yes
         control-interface: {{ .Values.unbound.control.socket_path | default "/run/unbound/control.sock" }}
-
-       # Stub and Forward zones
-       include: /etc/unbound/regional.conf
-       include: /etc/unbound/global.conf
-
-       # firewall
-       include: /etc/unbound/firewall.conf
 
        # dnstap.conf
        include: /etc/unbound/dnstap.conf

--- a/system/unbound/templates/config.yaml
+++ b/system/unbound/templates/config.yaml
@@ -151,7 +151,7 @@ data:
 
   firewall.conf: |
        {{- range $blocklisted := .Values.unbound.blocklisted_zones }}
-       local-zone: {{ tpl $blocklisted $ | quote }} refuse
+       local-zone: {{ tpl $blocklisted $ | quote }} always_nxdomain
        {{- end }}
        {{- range $allowlisted := .Values.unbound.allowlisted_zones }}
        local-zone: {{ tpl $allowlisted $ | quote }} transparent


### PR DESCRIPTION
We can now blocklist/allowlist zones if need be.

Also, the server identity is now based on the release name.
We can now distinguish between parallel, independent deployments.