### PR TITLE
[unbound] tidy up the prometheus alerts and make them more informative

### DIFF
--- a/system/unbound/templates/prometheus-alerts.yaml
+++ b/system/unbound/templates/prometheus-alerts.yaml
@@ -26,8 +26,8 @@ spec:
         tier: os
         playbook: 'docs/devops/alert/designate'
       annotations:
-        description: 'Recursor {{ $.Values.unbound.name }} returns lots of SERVFAIL responses in {{ $.Values.global.region }} region.'
-        summary: '{{ $.Values.unbound.name }} returned a lot of SERVFAIL responses in the last hour. Check the logs.'
+        description: '{{ $.Release.Name }} in {{ $.Values.global.region }} returns lots of SERVFAIL responses.'
+        summary: '{{ $.Release.Name }} in {{ $.Values.global.region }} returned a lot of SERVFAIL responses in the last hour. Check the logs.'
 
     - alert: Dns{{ $.Values.unbound.name | title }}Down
       expr: absent(unbound_up{app="{{ $.Values.unbound.name }}"}) == 1 or unbound_up{app="{{ $.Values.unbound.name }}"} != 1
@@ -42,8 +42,8 @@ spec:
         tier: os
         playbook: 'docs/devops/alert/designate/#test_unbound_endpoint'
       annotations:
-        description: 'DNS {{ $.Values.unbound.name }} recursor is down.'
-        summary: DNS {{ $.Values.unbound.name }} recursor is down. DNS resolution might be handled by another region.
+        description: '{{ $.Release.Name }} in {{ $.Values.global.region }} is down.'
+        summary: '{{ $.Release.Name }} in {{ $.Values.global.region }} is down. DNS resolution might be handled by another region.'
 
     - alert: Dns{{ $.Values.unbound.name | title }}LowTraffic
       expr: sum(rate(unbound_queries_total{app="{{ $.Values.unbound.name }}", namespace="{{ $.Release.Namespace }}"}[1m]) or vector(0))/sum(rate(unbound_queries_total{app="{{ $.Values.unbound.name }}", namespace="{{ $.Release.Namespace }}"}[24h]) or vector(0)) < 0.10
@@ -58,11 +58,14 @@ spec:
         tier: os
         playbook: 'docs/devops/alert/designate/#test_unbound_endpoint'
       annotations:
-        description: 'DNS {{ $.Values.unbound.name }} recursor in {{ $.Values.global.region }} is getting less than 10% of the usual traffic.'
-        summary: 'DNS {{ $.Values.unbound.name }} recursor in {{ $.Values.global.region }} is getting less than 10% of the usual traffic compared to the 24h avegrage.'
+        description: '{{ $.Release.Name }} in {{ $.Values.global.region }} is getting {{ "{{" }} $value | humanizePercentage {{ "}}" }} of the usual traffic.'
+        summary: '{{ $.Release.Name }} in {{ $.Values.global.region }} is getting {{ "{{" }} $value | humanizePercentage {{ "}}" }} of the usual traffic compared to the 24h avegrage.'
 
     - alert: Dns{{ $.Values.unbound.name | title }}DisproportionateAmountOfTraffic
-      expr: abs(sum(rate(unbound_queries_total{app="{{ $.Values.unbound.name }}", namespace="{{ $.Release.Namespace }}"}[5m]))/sum(rate(unbound_queries_total{namespace="{{ $.Release.Namespace }}"}[5m])) - 0.5) > {{ $.Values.unbound.tolerable_traffic_distribution_deviation | default 10 }}/100
+      expr: sum(rate(unbound_queries_total{app="{{ $.Values.unbound.name }}", namespace="{{ $.Release.Namespace }}"}[5m]))/sum(rate(unbound_queries_total{namespace="{{ $.Release.Namespace }}"}[5m]))
+        > {{ add 50 (.Values.unbound.tolerable_traffic_distribution_deviation | default 10) }}/100
+        or  sum(rate(unbound_queries_total{app="{{ $.Values.unbound.name }}", namespace="{{ $.Release.Namespace }}"}[5m]))/sum(rate(unbound_queries_total{namespace="{{ $.Release.Namespace }}"}[5m]))
+        < {{ sub 50 (.Values.unbound.tolerable_traffic_distribution_deviation | default 10) }}/100
       for: 5m
       labels:
         context: unbound
@@ -74,8 +77,15 @@ spec:
         tier: os
         playbook: 'docs/devops/alert/designate/#test_unbound_endpoint'
       annotations:
-        description: 'DNS {{ $.Values.unbound.name }} recursor in {{ $.Values.global.region }} is getting a disproportionate amount of traffic.'
-        summary: 'DNS {{ $.Values.unbound.name }} recursor in {{ $.Values.global.region }} is getting a disproportionate amount of traffic. Expected between {{ sub 50 ($.Values.unbound.tolerable_traffic_distribution_deviation | default 10) }}% and {{ add 50 ($.Values.unbound.tolerable_traffic_distribution_deviation | default 10) }}% of the total traffic, ideally as close to 50% as possible.'
+        description: '{{ $.Release.Name }} in {{ $.Values.global.region }} is getting a disproportionate amount of traffic.'
+        summary: '{{ $.Release.Name }} in {{ $.Values.global.region }}
+          has been getting a disproportionate amount of traffic in the past 5 minutes.
+          Expected between
+          {{ sub 50 ($.Values.unbound.tolerable_traffic_distribution_deviation | default 10) }}%
+          and
+          {{ add 50 ($.Values.unbound.tolerable_traffic_distribution_deviation | default 10) }}%
+          of the total traffic, ideally as close to 50% as possible.
+          Currently getting {{ "{{" }} $value | humanizePercentage {{ "}}" }}.'
 
 ---
 apiVersion: "monitoring.coreos.com/v1"
@@ -109,5 +119,5 @@ spec:
         tier: os
         playbook: 'docs/devops/alert/designate/#test_unbound_endpoint'
       annotations:
-        description: 'DNS Unbound {{ $.Values.unbound.name }}: unexpected number of endpoints found in {{ $.Values.global.region }}.'
-        summary: 'DNS Unbound {{ $.Values.unbound.name }}: unexpected number of endpoints found in {{ $.Values.global.region }}. Expected {{ $num_expected_endpoints }}.'
+        description: '{{ $.Release.Name }} in {{ $.Values.global.region }} exposing an unexpected number of endpoints.'
+        summary: '{{ $.Release.Name }} in {{ $.Values.global.region }} exposing an unexpected number of endpoints. Expected {{ $num_expected_endpoints }}. Got {{ "{{" }} $value {{ "}}" }}.'


### PR DESCRIPTION
Show the discovered value in the alert description/summary where it makes sense.

Also, use ```$.Release.Name``` instead of ```$.Values.unbound.name``` in order to be able to distinguish between different setups.