### PR TITLE
[unbound] getting ready to purge the AS112 zones from hosts.conf

### DIFF
--- a/system/unbound/templates/config.yaml
+++ b/system/unbound/templates/config.yaml
@@ -76,6 +76,9 @@ data:
 
         include: /etc/unbound/hosts.conf
 
+        # AS112 zones
+        include: /etc/unbound/as112.conf
+
         # firewall
         include: /etc/unbound/firewall.conf
 
@@ -155,6 +158,28 @@ data:
        {{- end }}
        {{- range $allowlisted := .Values.unbound.allowlisted_zones }}
        local-zone: {{ tpl $allowlisted $ | quote }} transparent
+       {{- end }}
+
+  as112.conf: |
+       {{- range $forward := .Values.unbound.forward_zones }}
+       {{- if $forward.expose_as112 }}
+       local-zone: {{ $forward.forward_zone_name | quote }} {{ $forward.expose_as112 }}
+       {{- end }}
+       {{- end }}
+       {{- range $stub := .Values.unbound.stub_zones }}
+       {{- if $stub.expose_as112 }}
+       local-zone: {{ $stub.stub_zone_name | quote }} {{ $stub.expose_as112 }}
+       {{- end }}
+       {{- end }}
+       {{- range $forward := .Values.unbound.forward_zones_global }}
+       {{- if $forward.expose_as112 }}
+       local-zone: {{ $forward.forward_zone_name | quote }} {{ $forward.expose_as112 }}
+       {{- end }}
+       {{- end }}
+       {{- range $stub := .Values.unbound.stub_zones_global }}
+       {{- if $stub.expose_as112 }}
+       local-zone: {{ $stub.stub_zone_name | quote }} {{ $stub.expose_as112 }}
+       {{- end }}
        {{- end }}
 
   regional.conf: |

--- a/system/unbound/templates/config.yaml
+++ b/system/unbound/templates/config.yaml
@@ -161,24 +161,14 @@ data:
        {{- end }}
 
   as112.conf: |
-       {{- range $forward := .Values.unbound.forward_zones }}
-       {{- if $forward.expose_as112 }}
-       local-zone: {{ $forward.forward_zone_name | quote }} {{ $forward.expose_as112 }}
+       {{- range $zone := concat ( $.Values.unbound.forward_zones_global | default list ) ( $.Values.unbound.forward_zones | default list )}}
+       {{- if $zone.expose_as112 }}
+       local-zone: {{ $zone.forward_zone_name | quote }} {{ $zone.expose_as112 }}
        {{- end }}
        {{- end }}
-       {{- range $stub := .Values.unbound.stub_zones }}
-       {{- if $stub.expose_as112 }}
-       local-zone: {{ $stub.stub_zone_name | quote }} {{ $stub.expose_as112 }}
-       {{- end }}
-       {{- end }}
-       {{- range $forward := .Values.unbound.forward_zones_global }}
-       {{- if $forward.expose_as112 }}
-       local-zone: {{ $forward.forward_zone_name | quote }} {{ $forward.expose_as112 }}
-       {{- end }}
-       {{- end }}
-       {{- range $stub := .Values.unbound.stub_zones_global }}
-       {{- if $stub.expose_as112 }}
-       local-zone: {{ $stub.stub_zone_name | quote }} {{ $stub.expose_as112 }}
+       {{- range $zone := concat ( $.Values.unbound.stub_zones_global | default list ) ( $.Values.unbound.stub_zones | default list )}}
+       {{- if $zone.expose_as112 }}
+       local-zone: {{ $zone.stub_zone_name | quote }} {{ $zone.expose_as112 }}
        {{- end }}
        {{- end }}
 


### PR DESCRIPTION
No need to maintain a static list of AS112 zones in hosts.conf.
Let's generate as112.conf dynamically based on what has been exposed.

Each AS112 zone, global or regional, stub or forward, will have
to be explicitly exposed by having the ```expose_as112``` value set
to one of the types listed in [1], normally ```transparent``` or
```nodefault```.

[1] https://unbound.docs.nlnetlabs.nl/en/latest/manpages/unbound.conf.html#unbound-conf-local-zone