### PR TITLE
[mysql_metrics] add reloader annotation

### DIFF
--- a/common/mysql_metrics/CHANGELOG.md
+++ b/common/mysql_metrics/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.4.4 - 2025/04/17
+* add reloader annotation to the deployment
+
 ## v0.4.3 - 2025/02/25
 * add option to set vpa main container
 

--- a/common/mysql_metrics/Chart.yaml
+++ b/common/mysql_metrics/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for MySQL Metrics
 name: mysql_metrics
-version: 0.4.3
+version: 0.4.4
 dependencies:
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/common/mysql_metrics/templates/deployment.yaml
+++ b/common/mysql_metrics/templates/deployment.yaml
@@ -8,8 +8,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-{{- if .Values.vpa.set_main_container }}
   annotations:
+    secret.reloader.stakater.com/reload: "{{ template "fullname" . }}-etc"
+{{- if .Values.vpa.set_main_container }}
     vpa-butler.cloud.sap/main-container: metrics
 {{- end }}
 spec:


### PR DESCRIPTION
Add reloader annotation to the sql-exporter deployment, so it will be restarted on the database secret update