### PR TITLE
[unbound] purge the RFC1918 zones from hosts.conf

### DIFF
--- a/system/unbound/templates/config.yaml
+++ b/system/unbound/templates/config.yaml
@@ -127,24 +127,6 @@ data:
 {{- end }}
 
   hosts.conf: |
-       local-zone: "168.192.in-addr.arpa." transparent
-       local-zone: "10.in-addr.arpa." transparent
-       local-zone: "16.172.in-addr.arpa." transparent
-       local-zone: "17.172.in-addr.arpa." transparent
-       local-zone: "18.172.in-addr.arpa." transparent
-       local-zone: "19.172.in-addr.arpa." transparent
-       local-zone: "20.172.in-addr.arpa." transparent
-       local-zone: "21.172.in-addr.arpa." transparent
-       local-zone: "22.172.in-addr.arpa." transparent
-       local-zone: "23.172.in-addr.arpa." transparent
-       local-zone: "24.172.in-addr.arpa." transparent
-       local-zone: "25.172.in-addr.arpa." transparent
-       local-zone: "26.172.in-addr.arpa." transparent
-       local-zone: "27.172.in-addr.arpa." transparent
-       local-zone: "28.172.in-addr.arpa." transparent
-       local-zone: "29.172.in-addr.arpa." transparent
-       local-zone: "30.172.in-addr.arpa." transparent
-       local-zone: "31.172.in-addr.arpa." transparent
        {{- range $lzone := .Values.unbound.local_zone}}
        local-zone: {{ $lzone.local_zone | quote }} nodefault
        {{- end}}


### PR DESCRIPTION
These zones are being exposed in ```as112.conf``` if so configured now.