### PR TITLE
[vmware-monitoring] Expose customTag:IAAS-HostGroup

### DIFF
--- a/system/vmware-monitoring/Chart.yaml
+++ b/system/vmware-monitoring/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vmware-monitoring
-version: 2.1.7
+version: 2.1.8
 description: VMware Monitoring and Metrics Collection
 dependencies:
   - name: prometheus-server

--- a/system/vmware-monitoring/templates/collector-configmap.yaml
+++ b/system/vmware-monitoring/templates/collector-configmap.yaml
@@ -297,6 +297,8 @@ data:
         key: "summary|customTag:Change_Request|customTagValue"
       - metric_suffix: "summary_custom_tag_nvme"
         key: "summary|customTag:nvme|customTagValue"
+      - metric_suffix: "summary_custom_tag_iaas_hostgroup"
+        key: "summary|customTag:IAAS-HostGroup|customTagValue"
 
     VCenterStatsCollector:
     # INFO - Prefix: vrops_vcenter_


### PR DESCRIPTION
- added vmware-hostsystem metric for custom tag `IAAS-HostGroup` on exporter configmap