### PR TITLE
[rabbitmq] version bumped to 4.1.0-management

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+## 0.18.0 - 2025/04/22
+
+- RabbitMQ [4.1.0 Release Notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.1.0)
+  * [performance improvements](https://www.rabbitmq.com/blog/2025/04/08/4.1-performance-improvements)
+  * This release series supports upgrades from 4.0.x and 3.13.x
+  * rabbitmqadmin has been updated to [2.0](https://github.com/rabbitmq/rabbitmqadmin-ng/releases/tag/v2.0.0), but is not yet included in the image
+  * RabbitMQ nodes now provide a Prometheus histogram for message sizes published by applications
+- Chart version bumped
+
+
 ## 0.17.2 - 2025/04/10
 
 - RabbitMQ [4.0.8 Release Notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.0.8)

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: v1
 name: rabbitmq
-version: 0.17.2
-appVersion: 4.0.8
+version: 0.18.0
+appVersion: 4.1.0
 description: A Helm chart for RabbitMQ
 sources:
   - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/values.yaml
+++ b/common/rabbitmq/values.yaml
@@ -11,7 +11,7 @@ global:
       enabled: true
 
 image: library/rabbitmq
-imageTag: 4.0.8-management
+imageTag: 4.1.0-management
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
- performance improvements
- upgrades from 4.0.x and 3.13.x are supported
- rabbitmqadmin has been updated to 2.0 but is not yet included in the image
- RabbitMQ nodes now provide a Prometheus histogram for message sizes published by applications
- chart version bumped