### PR TITLE
[openstack-exporter] Fix config generation

### DIFF
--- a/prometheus-exporters/openstack-exporter/templates/openstack-exporter-openstack-config.yaml
+++ b/prometheus-exporters/openstack-exporter/templates/openstack-exporter-openstack-config.yaml
@@ -17,8 +17,8 @@ data:
       cinderbackend:
         collector: openstack_exporter.collectors.cinderbackend.CinderBackendCollector
         enabled: True
-        expected_sharding_backends: {{- .Values.collectors.cinderbackend.expected_sharding_backends }}
-        allow_unexpected_backends: {{- .Values.collectors.cinderbackend.set_allow_unexpected_backends }}
+        expected_sharding_backends: {{ .Values.collectors.cinderbackend.expected_sharding_backends }}
+        allow_unexpected_backends: {{ .Values.collectors.cinderbackend.set_allow_unexpected_backends }}
       novaservice:
         collector: openstack_exporter.collectors.novaservice.NovaServiceCollector
         enabled: True


### PR DESCRIPTION
This removes the - in the template for the openstack-config.yml template.  The 2 values

expected_sharding_backends
allow_unexpected_backends

Were being generated without a space after the : causing a failure in reading the yaml file at startup.