### PR TITLE
openstack/backup-replication: add .Values.image_refs

### DIFF
--- a/openstack/backup-replication/templates/cronjob.yaml
+++ b/openstack/backup-replication/templates/cronjob.yaml
@@ -33,11 +33,10 @@ spec:
               name: swift-http-import
           containers:
           - name: swift-http-import
-            {{- $image_tag := $.Values.swift_http_import.image_tag | required ".Values.swift_http_import.image_tag not found" }}
-            {{- if $.Values.swift_http_import.image_repository }}
-            image: {{ $.Values.swift_http_import.image_repository }}:{{ $image_tag }}
+            {{- if $.Values.image_refs.swift_http_import }}
+            image: {{ quote $.Values.image_refs.swift_http_import }}
             {{- else }}
-            image: {{ $.Values.global.registry | required ".Values.global.registry not found" }}/swift-http-import:{{ $image_tag }}
+            image: {{ $.Values.global.registry | required ".Values.global.registry not found" }}/swift-http-import:{{ $.Values.swift_http_import.image_tag | required ".Values.swift_http_import.image_tag not found" }}
             {{- end }}
             imagePullPolicy: IfNotPresent
             args:

--- a/openstack/backup-replication/templates/deployment-statsd.yaml
+++ b/openstack/backup-replication/templates/deployment-statsd.yaml
@@ -28,7 +28,11 @@ spec:
           name: statsd
       containers:
       - name: statsd
+        {{- if .Values.image_refs.statsd_exporter }}
+        image: {{ quote .Values.image_refs.statsd_exporter }}
+        {{- else }}
         image: {{ .Values.global.dockerHubMirror | required ".Values.global.dockerHubMirror is missing" }}/prom/statsd-exporter:{{ .Values.statsd.exporter_image_version }}
+        {{- end }}
         args: [ --statsd.mapping-config=/etc/statsd/statsd-exporter.yaml ]
         securityContext:
           runAsNonRoot: true

--- a/openstack/backup-replication/values.yaml
+++ b/openstack/backup-replication/values.yaml
@@ -11,12 +11,13 @@ owner-info:
     - Sandro Jäckel
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/openstack/backup-replication
 
+# NOTE: When deploying from an OCM bundle, the deployment will supply image refs here to override the legacy image ref templating logic.
+image_refs:
+  swift_http_import: null
+  statsd_exporter: null
+
 swift_http_import:
   image_tag: null # must be set by the pipeline
-
-  # By default, the repository path for the swift-http-import image is derived from `.Values.global.registry`.
-  # This override is only used for a PoC where the image is bundled into an OCM component archive.
-  image_repository: null
 
 statsd:
   exporter_image_version: 'v0.28.0'


### PR DESCRIPTION
When deploying from an OCM bundle, we want for the image refs in the OCM bundle to take precedence over our usual mirror selection logic based on `.Values.global.registry` and friends.

I am not sure if this is a pattern that we will recommend to everyone. For now, backup-replication is our field test for OCM bundles, and we will see how this pattern feels.