### PR TITLE
greenhouse - change kvm monitoring namespace

### DIFF
--- a/system/greenhouse-ccloud/templates/kvm-monitoring-pluginpreset.yaml
+++ b/system/greenhouse-ccloud/templates/kvm-monitoring-pluginpreset.yaml
@@ -12,7 +12,7 @@ spec:
   plugin:
     disabled: false
     pluginDefinition: kvm-monitoring
-    releaseNamespace: kube-monitoring
+    releaseNamespace: kvm-monitoring
     optionValues:
       - name: serviceMonitorLabels
         value:


### PR DESCRIPTION
change the namespace for the KVM monitoring plugin to use it's own namespace instead of using the kube-monitoring namespace