### PR TITLE
[campfire] utilize global.is_global_region

### DIFF
--- a/openstack/limes-campfire/ci/test-values.yaml
+++ b/openstack/limes-campfire/ci/test-values.yaml
@@ -4,6 +4,7 @@ global:
   tld: example.org
   registry: registry.example.com
   vaultBaseURL: example.com
+  is_global_region: false
 
 campfire:
   image_tag: '19700101000000'

--- a/openstack/limes-campfire/templates/deployment.yaml
+++ b/openstack/limes-campfire/templates/deployment.yaml
@@ -1,7 +1,7 @@
 {{- $tld     := $.Values.global.tld              | required "missing value for .Values.global.tld"              }}
 {{- $region  := $.Values.global.region           | required "missing value for .Values.global.region"           }}
+{{- $dbRegion  := $.Values.global.db_region      | required "missing value for .Values.global.db_region"        }}
 {{- $cregion := $.Values.campfire.central_region | required "missing value for .Values.campfire.central_region" }}
-{{- $is_global := eq .Release.Namespace "limes-global" }}
 
 kind: Deployment
 apiVersion: apps/v1
@@ -45,9 +45,9 @@ spec:
               value: "monsoon3,hcp03"
 
             # credentials for authenticating incoming requests and talking to the regional masterdata API
-            {{- if $is_global }}
+            {{- if .Values.global.is_global_region }}
             - name: OS_AUTH_URL
-              value: "https://{{ contains "qa" $region | ternary "identity-3-qa" "identity-3" }}.global.{{ $tld }}/v3"
+              value: "https://{{ contains "qa" $dbRegion | ternary "identity-3-qa" "identity-3" }}.global.{{ $tld }}/v3"
             {{- else }}
             - name: OS_AUTH_URL
               value: "http://keystone.{{ $.Values.global.keystoneNamespace }}.svc.kubernetes.{{ $region }}.{{ $tld }}:5000/v3"
@@ -66,7 +66,7 @@ spec:
             - name: OS_PROJECT_NAME
               value: cloud_admin
             - name: OS_REGION_NAME
-              value: {{ quote ($is_global | ternary "global" $region) }}
+              value: {{ quote $region }}
 
             # credentials and configuration for sending mails using Cronus
             - name: CRONUS_AUTH_URL
@@ -74,8 +74,8 @@ spec:
             - name: CRONUS_USER_DOMAIN_NAME
               value: Default
             - name: CRONUS_USERNAME
-              {{- if $is_global }}
-              value: {{ printf "campfire-%s-global" $region | quote }}
+              {{- if .Values.global.is_global_region }}
+              value: {{ printf "campfire-%s-global" $dbRegion | quote }}
               {{- else }}
               value: {{ printf "campfire-%s" $region | quote }}
               {{- end }}

--- a/openstack/limes-campfire/templates/ingress.yaml
+++ b/openstack/limes-campfire/templates/ingress.yaml
@@ -1,10 +1,8 @@
-{{- $tld    := $.Values.global.tld    | required "missing value for .Values.global.tld"    -}}
-{{- $region := $.Values.global.region | required "missing value for .Values.global.region" -}}
+{{- $tld    := $.Values.global.tld         | required "missing value for .Values.global.tld"       -}}
+{{- $region := $.Values.global.region      | required "missing value for .Values.global.region"    -}}
+{{- $dbRegion := $.Values.global.db_region | required "missing value for .Values.global.db_region" -}}
 
-{{- $domain := printf "%s.%s.%s" "limes-campfire" $region $tld -}}
-{{- if eq .Release.Namespace "limes-global" -}}
-  {{- $domain = printf "%s.global.%s" (contains "qa" $region | ternary "limes-campfire-qa" "limes-campfire") $tld -}}
-{{- end -}}
+{{- $domain := printf "%s.%s.%s" (and (contains "qa" $dbRegion) .Values.global.is_global_region | ternary "limes-campfire-qa" "limes-campfire") $region $tld -}}
 
 kind: Ingress
 apiVersion: networking.k8s.io/v1

--- a/openstack/limes-campfire/templates/secret.yaml
+++ b/openstack/limes-campfire/templates/secret.yaml
@@ -1,10 +1,10 @@
 {{- $vbase  := .Values.global.vaultBaseURL | required "missing value for .Values.global.vaultBaseURL" -}}
-{{- $region := .Values.global.region       | required "missing value for .Values.global.region"       -}}
+{{- $dbRegion := .Values.global.db_region       | required "missing value for .Values.global.db_region"       -}}
 
 apiVersion: v1
 kind: Secret
 metadata:
   name: campfire-secret
 data:
-  os_password:     {{ printf "%s/%s/%s/keystone-user/service/password"  $vbase $region .Release.Namespace | b64enc }}
-  cronus_password: {{ printf "%s/%s/%s/keystone-user/campfire/password" $vbase $region .Release.Namespace | b64enc }}
+  os_password:     {{ printf "%s/%s/%s/keystone-user/service/password"  $vbase $dbRegion .Release.Namespace | b64enc }}
+  cronus_password: {{ printf "%s/%s/%s/keystone-user/campfire/password" $vbase $dbRegion .Release.Namespace | b64enc }}

--- a/openstack/limes-campfire/values.yaml
+++ b/openstack/limes-campfire/values.yaml
@@ -1,5 +1,6 @@
 global:
   linkerd_requested: true
+  is_global_region: false
 
 campfire:
   image_tag: null # defined in values file


### PR DESCRIPTION
This needs a companion PR for the pipeline, because it relies on `global:globals` values.