### PR TITLE
[prysm-wh] objectSelector added

### DIFF
--- a/system/cc-ceph/templates/prysm-rgw-sidecar-webhook-mutating-webhook.yaml
+++ b/system/cc-ceph/templates/prysm-rgw-sidecar-webhook-mutating-webhook.yaml
@@ -20,4 +20,8 @@ webhooks:
         apiGroups: ["apps"]
         apiVersions: ["v1"]
         resources: ["deployments"]
+    objectSelector:
+      matchExpressions:
+        - key: prysm-sidecar
+          operator: Exists
 {{- end }}


### PR DESCRIPTION
- objectSelector added to handle only rgw deployments with label prysm-sidecar=yes/no