### PR TITLE
fix(octobus-query-exporter): Rollback secondary header support for failover password

### DIFF
--- a/prometheus-exporters/octobus-query-exporter/Chart.lock
+++ b/prometheus-exporters/octobus-query-exporter/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: octobus-query-exporter
   repository: file://vendor/octobus-query-exporter
-  version: 1.0.18
+  version: 1.0.19
 - name: octobus-query-exporter-global
   repository: file://vendor/octobus-query-exporter-global
-  version: 1.0.13
+  version: 1.0.14
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:dde54357bffaf6b506ff861d5c14c519d1f482f5f2f076eeb276fd011cbd526e
-generated: "2025-04-25T14:13:57.720662128Z"
+digest: sha256:9505b654a2052c40cb37f0029b92ce555d8fd2dc1ba069fdd8da770adc7423b4
+generated: "2025-04-28T16:35:49.027068+02:00"

--- a/prometheus-exporters/octobus-query-exporter/Chart.yaml
+++ b/prometheus-exporters/octobus-query-exporter/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 1.0.20
+version: 1.0.21
 name: octobus-query-exporter
 description: Elasticsearch prometheus query exporter
 maintainers:

--- a/prometheus-exporters/octobus-query-exporter/Chart.yaml
+++ b/prometheus-exporters/octobus-query-exporter/Chart.yaml
@@ -11,13 +11,13 @@ dependencies:
   - name: octobus-query-exporter
     alias: octobus_query_exporter
     repository: file://vendor/octobus-query-exporter
-    version: 1.0.18
+    version: 1.0.19
     condition: octobus_query_exporter.enabled
 
   - name: octobus-query-exporter-global
     alias: octobus_query_exporter_global
     repository: file://vendor/octobus-query-exporter-global
-    version: 1.0.13
+    version: 1.0.14
     condition: octobus_query_exporter_global.enabled
 
   - name: owner-info

--- a/prometheus-exporters/octobus-query-exporter/values.yaml
+++ b/prometheus-exporters/octobus-query-exporter/values.yaml
@@ -4,8 +4,6 @@ global:
     image:
       repo: 'prometheus-es-exporter'
       tag: '<defined-in-pipeline>'
-    apikey: '<defined-in-pipeline>'
-    failover_apikey: '<defined-in-pipeline>'
 
 octobus_query_exporter:
   enabled: false

--- a/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter-global/Chart.yaml
+++ b/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter-global/Chart.yaml
@@ -1,6 +1,9 @@
 apiVersion: v2
-version: 1.0.12
+version: 1.0.14
 name: octobus-query-exporter-global
 description: Elasticsearch prometheus query exporter only to query Octobus global
 maintainers:
   - name: Olaf Heydorn
+  - name: Jonathan Schwarze
+  - name: Timo Johner
+  - name: Simon Olander

--- a/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter-global/Chart.yaml
+++ b/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter-global/Chart.yaml
@@ -1,9 +1,6 @@
 apiVersion: v2
-version: 1.0.13
+version: 1.0.12
 name: octobus-query-exporter-global
 description: Elasticsearch prometheus query exporter only to query Octobus global
 maintainers:
   - name: Olaf Heydorn
-  - name: Jonathan Schwarze
-  - name: Timo Johner
-  - name: Simon Olander

--- a/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter-global/templates/_helper.tpl
+++ b/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter-global/templates/_helper.tpl
@@ -1,0 +1,3 @@
+{{- define "config-global" -}}
+header=['Authorization: Apikey {{ required ".Values.octobus.apikey " .Values.octobus.apikey }}']
+{{- end -}}

--- a/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter-global/templates/deployment.yaml
+++ b/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter-global/templates/deployment.yaml
@@ -37,6 +37,9 @@ spec:
         - name: octobus-query-exporter-global
           configMap:
             name: octobus-query-exporter-global
+        - name: config
+          secret:
+            secretName: octobus-query-exporter-global
       containers:
         - name: octobus-query-exporter-global
           image: {{ .Values.global.registry }}/{{ .Values.global.octobus.image.repo }}:{{ .Values.global.octobus.image.tag }}
@@ -49,23 +52,15 @@ spec:
                      "--port", "{{ .Values.listen_port }}",
                      "--log-level", "{{ .Values.log_level }}",
                      "--es-cluster", "{{ .Values.octobus.target }}" ]
-          env:
-          - name: ES_EXPORTER_HEADER
-            valueFrom:
-              secretKeyRef:
-                name: octobus-query-exporter
-                key: header
-          - name: ES_EXPORTER_FAILOVER_HEADER
-            valueFrom:
-              secretKeyRef:
-                name: octobus-query-exporter
-                key: failover_header
           ports:
             - name: metrics
               containerPort: {{ .Values.listen_port }}
           volumeMounts:
             - mountPath: /octobus-query-exporter-global
               name: octobus-query-exporter-global
+            - mountPath: /config.cfg
+              name: config
+              subPath: config.cfg
           securityContext:
             capabilities:
               drop:

--- a/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter-global/templates/secret.yaml
+++ b/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter-global/templates/secret.yaml
@@ -6,5 +6,5 @@ metadata:
   labels:
     component: octobus-query-exporter-global
 data:
-  header: {{ printf "['Authorization: Apikey %s']" (required ".Values.global.octobus.apikey" .Values.global.octobus.apikey) | b64enc | quote }}
-  failover_header: {{ printf "['Authorization: Apikey %s']" (required ".Values.global.octobus.failover_apikey" .Values.global.octobus.failover_apikey) | b64enc | quote }}
+  config.cfg: |
+    {{ include "config-global" . | b64enc }}

--- a/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter-global/values.yaml
+++ b/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter-global/values.yaml
@@ -1,0 +1,14 @@
+enabled: false
+metrics:
+  prometheus: infra-frontend
+alerts:
+  enabled: false
+  prometheus:
+    - name: infra-frontend
+      type: prometheus
+    - name: scaleout
+      type: thanos-ruler
+auditSources:
+  enabled: false
+listen_port: 9206
+log_level: 'ERROR'

--- a/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter-global/values.yaml
+++ b/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter-global/values.yaml
@@ -12,3 +12,12 @@ auditSources:
   enabled: false
 listen_port: 9206
 log_level: 'ERROR'
+octobus:
+  apikey: '<defined-in-pipeline>'
+
+global:
+  linkerd_requested: false
+  octobus:
+    image:
+      repo: '<defined-in-pipeline>'
+      tag: '<defined-in-pipeline>'

--- a/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/Chart.yaml
+++ b/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/Chart.yaml
@@ -4,6 +4,4 @@ name: octobus-query-exporter
 description: Elasticsearch prometheus query exporter
 maintainers:
   - name: Olaf Heydorn
-  - name: Jonathan Schwarze
-  - name: Timo Johner
-  - name: Simon Olander
+  - name: Max Lendrich

--- a/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/Chart.yaml
+++ b/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/Chart.yaml
@@ -1,7 +1,9 @@
 apiVersion: v2
-version: 1.0.18
+version: 1.0.19
 name: octobus-query-exporter
 description: Elasticsearch prometheus query exporter
 maintainers:
   - name: Olaf Heydorn
-  - name: Max Lendrich
+  - name: Jonathan Schwarze
+  - name: Timo Johner
+  - name: Simon Olander

--- a/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/templates/_helper.tpl
+++ b/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/templates/_helper.tpl
@@ -1,0 +1,3 @@
+{{- define "config" -}}
+header=['Authorization: Apikey {{ required ".Values.global.octobus.apikey" .Values.global.octobus.apikey }}']
+{{- end -}}

--- a/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/templates/deployment.yaml
+++ b/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/templates/deployment.yaml
@@ -37,6 +37,9 @@ spec:
         - name: octobus-query-exporter
           configMap:
             name: octobus-query-exporter
+        - name: config
+          secret:
+            secretName: octobus-query-exporter
       containers:
         - name: octobus-query-exporter
           image: {{ .Values.global.registry }}/{{ .Values.global.octobus.image.repo }}:{{ .Values.global.octobus.image.tag }}
@@ -49,23 +52,15 @@ spec:
                      "--port", "{{ .Values.listen_port }}",
                      "--log-level", "{{ .Values.log_level }}",
                      "--es-cluster", "{{ .Values.global.octobus.protocol }}://{{ .Values.global.octobus.host }}.{{ regexReplaceAll "-" .Values.global.region "" | replace "qade1" "eude2" }}.{{ .Values.global.octobus.domain }}:{{ .Values.global.octobus.port }}" ]
-          env:
-          - name: ES_EXPORTER_HEADER
-            valueFrom:
-              secretKeyRef:
-                name: octobus-query-exporter
-                key: header
-          - name: ES_EXPORTER_FAILOVER_HEADER
-            valueFrom:
-              secretKeyRef:
-                name: octobus-query-exporter
-                key: failover_header
           ports:
             - name: metrics
               containerPort: {{ .Values.listen_port }}
           volumeMounts:
             - mountPath: /octobus-query-exporter
               name: octobus-query-exporter
+            - mountPath: /config.cfg
+              name: config
+              subPath: config.cfg
           securityContext:
             capabilities:
               drop:

--- a/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/templates/secret.yaml
+++ b/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/templates/secret.yaml
@@ -6,5 +6,5 @@ metadata:
   labels:
     component: octobus-query-exporter
 data:
-  header: {{ printf "['Authorization: Apikey %s']" (required ".Values.global.octobus.apikey" .Values.global.octobus.apikey) | b64enc | quote }}
-  failover_header: {{ printf "['Authorization: Apikey %s']" (required ".Values.global.octobus.failover_apikey" .Values.global.octobus.failover_apikey) | b64enc | quote }}
+  config.cfg: |
+    {{ include "config" . | b64enc }}

--- a/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/values.yaml
+++ b/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/values.yaml
@@ -1,0 +1,16 @@
+enabled: false
+metrics:
+  prometheus: infra-frontend
+alerts:
+  enabled: false
+  prometheus:
+    - name: infra-frontend
+      type: prometheus
+    - name: scaleout
+      type: thanos-ruler
+    - name: regional
+      type: thanos-ruler
+auditSources:
+  enabled: false
+listen_port: 9206
+log_level: 'ERROR'

--- a/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/values.yaml
+++ b/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/values.yaml
@@ -23,46 +23,11 @@ global:
     image:
       repo: '<defined-in-pipeline>'
       tag: '<defined-in-pipeline>'
+    host: '<defined-in-pipeline>'
+    protocol: '<defined-in-pipeline>'
+    port: 443
+    apikey: '<defined-in-pipeline>'
+    domain: '<defined-in-pipeline>'
   region: '<defined-in-pipeline>'
-  domain: cloud.sap
-  tld: cloud.sap
-  cluster: s-qa-de-1
-  clusterType: scaleout
-  vaultBaseURL: vault+kvv2:///secrets
-
-  # Keppel and its depedencies, esp. Keystone and Swift, need to pull their images from a different region.
-  # Otherwise there would be a deadlock where Keppel could not come up because it cannot pull its image from itself.
-  # This is the designated alternate region for this specific requirement.
-  alternateRegion: eu-de-1
-
-  # Keppel account where images for this region are stored
-  # (eu-de-1 for non-prod regions, local replica for prod regions)
-  registry: keppel.eu-de-1.cloud.sap/ccloud
-  registryAlternateRegion: keppel.eu-de-1.cloud.sap/ccloud
-
-# offical opensearch helm-charts globals value
-  dockerRegistry: keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror
-
-  # same as above, but for the various mirror accounts
-  dockerHubMirror: keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror
-  dockerHubMirrorAlternateRegion: keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror
-  crNetappIoMirror: keppel.eu-de-1.cloud.sap/ccloud-cr-netapp-io-mirror
-  crNetappIoMirrorAlternateRegion: keppel.eu-de-1.cloud.sap/ccloud-cr-netapp-io-mirror
-  elasticCoMirror: keppel.eu-de-1.cloud.sap/ccloud-elastic-mirror
-  elasticCoMirrorAlternateRegion: keppel.eu-de-1.cloud.sap/ccloud-elastic-mirror
-  gcrIoMirror: keppel.eu-de-1.cloud.sap/ccloud-gcr-mirror
-  gcrIoMirrorAlternateRegion: keppel.eu-de-1.cloud.sap/ccloud-gcr-mirror
-  ghcrIoMirror: keppel.eu-de-1.cloud.sap/ccloud-ghcr-io-mirror
-  ghcrIoMirrorAlternateRegion: keppel.eu-de-1.cloud.sap/ccloud-ghcr-io-mirror
-  registryK8sIoMirror: keppel.eu-de-1.cloud.sap/ccloud-registry-k8s-io-mirror
-  registryK8sIoMirrorAlternateRegion: keppel.eu-de-1.cloud.sap/ccloud-registry-k8s-io-mirror
-  quayIoMirror: keppel.eu-de-1.cloud.sap/ccloud-quay-mirror
-  quayIoMirrorAlternateRegion: keppel.eu-de-1.cloud.sap/ccloud-quay-mirror
-  zalandoMirror: keppel.eu-de-1.cloud.sap/ccloud-zalando-mirror
-  zalandoMirrorAlternateRegion: keppel.eu-de-1.cloud.sap/ccloud-zalando-mirror
-
-  linkerd_enabled: true
-
-###
-### Before adding new values to this file, please read the explanation at the top!
-###
+  domain: '<defined-in-pipeline>'
+  registry: '<defined-in-pipeline>'

--- a/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/values.yaml
+++ b/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/values.yaml
@@ -14,3 +14,11 @@ auditSources:
   enabled: false
 listen_port: 9206
 log_level: 'ERROR'
+
+global:
+  linkerd_requested: false
+  octobus:
+    apikey: '<defined-in-pipeline>'
+    image:
+      repo: '<defined-in-pipeline>'
+      tag: '<defined-in-pipeline>'

--- a/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/values.yaml
+++ b/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/values.yaml
@@ -26,7 +26,6 @@ global:
     host: '<defined-in-pipeline>'
     protocol: '<defined-in-pipeline>'
     port: 443
-    apikey: '<defined-in-pipeline>'
     domain: '<defined-in-pipeline>'
   region: '<defined-in-pipeline>'
   domain: '<defined-in-pipeline>'

--- a/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/values.yaml
+++ b/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/values.yaml
@@ -17,8 +17,52 @@ log_level: 'ERROR'
 
 global:
   linkerd_requested: false
+  linkerd_enabled: false
   octobus:
     apikey: '<defined-in-pipeline>'
     image:
       repo: '<defined-in-pipeline>'
       tag: '<defined-in-pipeline>'
+  region: '<defined-in-pipeline>'
+  domain: cloud.sap
+  tld: cloud.sap
+  cluster: s-qa-de-1
+  clusterType: scaleout
+  vaultBaseURL: vault+kvv2:///secrets
+
+  # Keppel and its depedencies, esp. Keystone and Swift, need to pull their images from a different region.
+  # Otherwise there would be a deadlock where Keppel could not come up because it cannot pull its image from itself.
+  # This is the designated alternate region for this specific requirement.
+  alternateRegion: eu-de-1
+
+  # Keppel account where images for this region are stored
+  # (eu-de-1 for non-prod regions, local replica for prod regions)
+  registry: keppel.eu-de-1.cloud.sap/ccloud
+  registryAlternateRegion: keppel.eu-de-1.cloud.sap/ccloud
+
+# offical opensearch helm-charts globals value
+  dockerRegistry: keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror
+
+  # same as above, but for the various mirror accounts
+  dockerHubMirror: keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror
+  dockerHubMirrorAlternateRegion: keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror
+  crNetappIoMirror: keppel.eu-de-1.cloud.sap/ccloud-cr-netapp-io-mirror
+  crNetappIoMirrorAlternateRegion: keppel.eu-de-1.cloud.sap/ccloud-cr-netapp-io-mirror
+  elasticCoMirror: keppel.eu-de-1.cloud.sap/ccloud-elastic-mirror
+  elasticCoMirrorAlternateRegion: keppel.eu-de-1.cloud.sap/ccloud-elastic-mirror
+  gcrIoMirror: keppel.eu-de-1.cloud.sap/ccloud-gcr-mirror
+  gcrIoMirrorAlternateRegion: keppel.eu-de-1.cloud.sap/ccloud-gcr-mirror
+  ghcrIoMirror: keppel.eu-de-1.cloud.sap/ccloud-ghcr-io-mirror
+  ghcrIoMirrorAlternateRegion: keppel.eu-de-1.cloud.sap/ccloud-ghcr-io-mirror
+  registryK8sIoMirror: keppel.eu-de-1.cloud.sap/ccloud-registry-k8s-io-mirror
+  registryK8sIoMirrorAlternateRegion: keppel.eu-de-1.cloud.sap/ccloud-registry-k8s-io-mirror
+  quayIoMirror: keppel.eu-de-1.cloud.sap/ccloud-quay-mirror
+  quayIoMirrorAlternateRegion: keppel.eu-de-1.cloud.sap/ccloud-quay-mirror
+  zalandoMirror: keppel.eu-de-1.cloud.sap/ccloud-zalando-mirror
+  zalandoMirrorAlternateRegion: keppel.eu-de-1.cloud.sap/ccloud-zalando-mirror
+
+  linkerd_enabled: true
+
+###
+### Before adding new values to this file, please read the explanation at the top!
+###


### PR DESCRIPTION
Reverts the change that introduced an additional header option for a failover password. Parsing multiple headers caused issues and requires a different approach.