### PR TITLE
[Neutron] Update MariaDB to 0.24.0

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.23.0
+  version: 0.24.0
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.6.9
@@ -29,5 +29,5 @@ dependencies:
 - name: ovsdb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.0
-digest: sha256:fae447ab7e8bf4d11ff52f4c1cd518bf9793432c756007dbf83a67edbff1ce8e
-generated: "2025-04-17T14:07:17.092211-04:00"
+digest: sha256:58e58fd2ba87e1e394ab6c5262d95874768f8ad32570ed109c6e4aac334f92d1
+generated: "2025-04-29T13:14:12.691924+02:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.23.0
+    version: 0.24.0
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.6.9


### PR DESCRIPTION
MariaDB has been updated to the 10.6.21 version
* delete removed `innodb_thread_concurrency` variable from my.cnf