### PR TITLE
kos crd: always yield

### DIFF
--- a/openstack/ironic/py/ironic-node-update.py
+++ b/openstack/ironic/py/ironic-node-update.py
@@ -46,6 +46,7 @@ def maintenance_mode(bm, node):
         yield
     except Exception as e:
         print(e)
+        yield
     finally:
         if unset_maintenance:
             bm.node.set_maintenance(node.uuid, "false")


### PR DESCRIPTION
In ap-cn-1 the kos is running into an error because:
  Error executing kos crd: ('KosQuery', 'monsoon3', 'ironic-node-update').
  Error: Error executing query: generator didn't yield
So it seems that whenever kos is unable to set a node to maintenace the
kos itself fails and it then also fails to update deployments. So we
also yield in an error case.
