### PR TITLE
[ironic] also yield for disable_console

### DIFF
--- a/openstack/ironic/py/ironic-node-update.py
+++ b/openstack/ironic/py/ironic-node-update.py
@@ -65,6 +65,7 @@ def disabled_console(bm, node):
         import sys
 
         traceback.print_exception(e, limit=2, file=sys.stdout)
+        yield
     finally:
         if reenable_console:
             bm.node.set_console_mode(node.uuid, "true")


### PR DESCRIPTION
As with the maintenance we should also yield when we run into an error
when trying to set the console. We haven't seen one yet but it should be
the same as with the maintenance.
