### PR TITLE
[Nova] Fix vpa-butler main-container for nova-compute

### DIFF
--- a/openstack/nova/templates/hypervisors/hypervisors-vmware-deployment-vct.yaml
+++ b/openstack/nova/templates/hypervisors/hypervisors-vmware-deployment-vct.yaml
@@ -3,10 +3,6 @@ apiVersion: vcenter-operator.stable.sap.cc/v1
 kind: VCenterTemplate
 metadata:
   name: 'vcenter-cluster-nova-compute-deployment'
-  {{- if .Values.vpa.set_main_container }}
-  annotations:
-    vpa-butler.cloud.sap/main-container: nova-compute
-  {{- end }}
 options:
   scope: 'cluster'
   jinja2_options:
@@ -33,6 +29,10 @@ template: |
       vcenter: {= host =}
       datacenter: {= availability_zone =}
       vccluster: {= cluster_name =}
+    {{- if .Values.vpa.set_main_container }}
+    annotations:
+      vpa-butler.cloud.sap/main-container: nova-compute
+    {{- end }}
   spec:
     replicas: 1
     revisionHistoryLimit: 5


### PR DESCRIPTION
We've set the annotation on the `VCenterTemplate` instead of on the resulting `Deployment` rendered from the template and thus it never had an effect.