### PR TITLE
[neutron/ovsdb] make externalTrafficPolicy configurable for Calico

### DIFF
--- a/common/ovsdb/Chart.yaml
+++ b/common/ovsdb/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.0"
+appVersion: "0.2.0"

--- a/common/ovsdb/templates/service.yaml
+++ b/common/ovsdb/templates/service.yaml
@@ -17,6 +17,9 @@ spec:
       protocol: TCP
   selector:
     {{- include "ovsdb.selectorLabels" . | nindent 4 }}
-{{- with .Values.EXTERNAL_IP }}
+  {{- with .Values.EXTERNAL_IP }}
   externalIPs: [ {{ . | quote }} ]
-{{- end }}
+  {{- end }}
+  {{- with .Values.service.external_traffic_policy }}
+  externalTrafficPolicy: {{ . | quote }}
+  {{- end }}

--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -25,9 +25,9 @@ dependencies:
   version: 1.0.0
 - name: ovsdb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.1.0
+  version: 0.2.0
 - name: ovsdb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.1.0
-digest: sha256:58e58fd2ba87e1e394ab6c5262d95874768f8ad32570ed109c6e4aac334f92d1
-generated: "2025-04-29T13:14:12.691924+02:00"
+  version: 0.2.0
+digest: sha256:85be85c3b5aa337ed3d5bfb5e15189f5850cb05b04df57e5933f6ac9dcd6bba2
+generated: "2025-05-02T10:42:53.883947-04:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -35,10 +35,10 @@ dependencies:
   - name: ovsdb
     alias: ovsdb-sb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.1.0
+    version: 0.2.0
     condition: ovn.enabled
   - name: ovsdb
     alias: ovsdb-nb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.1.0
+    version: 0.2.0
     condition: ovn.enabled

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -259,6 +259,10 @@ ovsdb-sb:
   OVN_ELECTION_TIMER: "10000"
   OVN_INACTIVITY_PROBE: "60000"
   OVN_PROBE_INTERVAL_TO_ACTIVE: "60000"
+  service:
+    # requirements to be accessible from outside with Calico
+    type: Loadbalancer
+    external_traffic_policy: Local
 
 ovsdb-nb:
   RAFT_PORT: 6643


### PR DESCRIPTION
this is needed since the switch to Calico to make externalIPs accessible
from outside the cluster.
