### PR TITLE
[kube-system-*][reloader] update helm chart and add default repository value

### DIFF
--- a/system/kube-system-admin-k3s/Chart.lock
+++ b/system/kube-system-admin-k3s/Chart.lock
@@ -40,9 +40,9 @@ dependencies:
   version: 1.0.7
 - name: secrets-injector
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.1.7
+  version: 1.1.10
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
-  version: 1.2.0
-digest: sha256:5ba2fdca7a3b92fec429a7348ab5a8c89e29982405d271ec8184ea330fec4544
-generated: "2025-03-27T16:47:01.275698452Z"
+  version: 2.1.3
+digest: sha256:fe20b61bdcc2cea762ca74362f71c6b79fe1fb431f1d429ec4cfa99aa25d90a7
+generated: "2025-05-05T14:30:14.23747+03:00"

--- a/system/kube-system-admin-k3s/Chart.yaml
+++ b/system/kube-system-admin-k3s/Chart.yaml
@@ -50,5 +50,5 @@ dependencies:
     condition: secrets-injector.enabled
   - name: reloader
     repository: oci://ghcr.io/stakater/charts
-    version: 1.2.0
+    version: 2.1.3
     condition: reloader.enabled

--- a/system/kube-system-admin-k3s/values.yaml
+++ b/system/kube-system-admin-k3s/values.yaml
@@ -13,7 +13,7 @@ ingress:
 
 traefik:
   instanceLabelOverride: kube-system
-  updateStrategy: 
+  updateStrategy:
     type: Recreate
   ingressRoute:
     dashboard:
@@ -79,3 +79,7 @@ owner-info:
 
 secrets-injector:
   enabled: false
+
+reloader:
+  image:
+    repository: 'keppel.global.cloud.sap/ccloud-ghcr-io-mirror/stakater/reloader'

--- a/system/kube-system-kubernikus/Chart.lock
+++ b/system/kube-system-kubernikus/Chart.lock
@@ -40,9 +40,9 @@ dependencies:
   version: 1.0.7
 - name: secrets-injector
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.1.7
+  version: 1.1.10
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
-  version: 1.2.0
-digest: sha256:3e611e2fb5e8c73064f24f6ea862b8c24699120c0198524765694ee98d9918ce
-generated: "2025-03-27T16:47:01.479930333Z"
+  version: 2.1.3
+digest: sha256:42ba3deb250a2ead6a41f55a21db71a706321cf6beaa133b452cc30f14d30338
+generated: "2025-05-05T14:32:12.066728+03:00"

--- a/system/kube-system-kubernikus/Chart.yaml
+++ b/system/kube-system-kubernikus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for Kubernikus control-plane clusters.
 name: kube-system-kubernikus
-version: 3.8.12
+version: 3.8.13
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-kubernikus
 dependencies:
   - name: cc-rbac
@@ -50,5 +50,5 @@ dependencies:
     condition: secrets-injector.enabled
   - name: reloader
     repository: oci://ghcr.io/stakater/charts
-    version: 1.2.0
+    version: 2.1.3
     condition: reloader.enabled

--- a/system/kube-system-kubernikus/values.yaml
+++ b/system/kube-system-kubernikus/values.yaml
@@ -70,3 +70,7 @@ vertical-pod-autoscaler:
 
 secrets-injector:
   enabled: false
+
+reloader:
+  image:
+    repository: 'keppel.global.cloud.sap/ccloud-ghcr-io-mirror/stakater/reloader'

--- a/system/kube-system-metal/Chart.lock
+++ b/system/kube-system-metal/Chart.lock
@@ -73,9 +73,9 @@ dependencies:
   version: 0.1.3
 - name: secrets-injector
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.1.9
+  version: 1.1.10
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
-  version: 1.2.0
-digest: sha256:6d5b0e20ed3e017a2462e3ff4bde41b7d5f61439ab395ddb87fe694468817e4a
-generated: "2025-04-03T12:09:49.373412795Z"
+  version: 2.1.3
+digest: sha256:05481b438797f8bfe2b76a6677dee642ca60d8cce28e5e5f1fc78d048689f2da
+generated: "2025-05-05T12:28:25.512355+03:00"

--- a/system/kube-system-metal/Chart.yaml
+++ b/system/kube-system-metal/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for metal clusters.
 name: kube-system-metal
-version: 6.12.18
+version: 6.12.19
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-metal
 dependencies:
   - name: cc-rbac
@@ -101,5 +101,5 @@ dependencies:
     condition: secrets-injector.enabled
   - name: reloader
     repository: oci://ghcr.io/stakater/charts
-    version: 1.2.0
+    version: 2.1.3
     condition: reloader.enabled

--- a/system/kube-system-metal/values.yaml
+++ b/system/kube-system-metal/values.yaml
@@ -282,3 +282,7 @@ owner-info:
 
 secrets-injector:
   enabled: false
+
+reloader:
+  image:
+    repository: 'keppel.global.cloud.sap/ccloud-ghcr-io-mirror/stakater/reloader'

--- a/system/kube-system-scaleout/Chart.lock
+++ b/system/kube-system-scaleout/Chart.lock
@@ -46,6 +46,6 @@ dependencies:
   version: 1.1.11
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
-  version: 1.2.0
-digest: sha256:d30f99ca365cba5522afc858f2b016e2175470f8d6d808f87cb1ba3eecc9b481
-generated: "2025-05-06T00:33:28.885765+02:00"
+  version: 2.1.3
+digest: sha256:e387a602d1970b1738748a5a90162b629c2584f160756fcafa7725ae02a33e9c
+generated: "2025-05-06T12:16:28.524971+03:00"

--- a/system/kube-system-scaleout/Chart.yaml
+++ b/system/kube-system-scaleout/Chart.yaml
@@ -56,5 +56,5 @@ dependencies:
     condition: secrets-injector.enabled
   - name: reloader
     repository: oci://ghcr.io/stakater/charts
-    version: 1.2.0
+    version: 2.1.3
     condition: reloader.enabled

--- a/system/kube-system-scaleout/values.yaml
+++ b/system/kube-system-scaleout/values.yaml
@@ -75,4 +75,3 @@ reloader:
   enabled: false
   image:
     name: keppel.global.cloud.sap/ccloud-ghcr-io-mirror/stakater/reloader
-    tag: v1.0.72

--- a/system/kube-system-virtual/Chart.lock
+++ b/system/kube-system-virtual/Chart.lock
@@ -52,9 +52,9 @@ dependencies:
   version: 0.0.24
 - name: secrets-injector
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.1.7
+  version: 1.1.10
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
-  version: 1.2.0
-digest: sha256:d75301347519f628d1e4837b700bfdfdbca6c584ebd5a83d2f0c9d38faf9a742
-generated: "2025-03-27T16:47:15.805230037Z"
+  version: 2.1.3
+digest: sha256:e9c4601c32af7670f99b700a0ce276dae6512b294ef783a5f204816c2d1d352e
+generated: "2025-05-05T14:31:09.491597+03:00"

--- a/system/kube-system-virtual/Chart.yaml
+++ b/system/kube-system-virtual/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for virtual clusters.
 name: kube-system-virtual
-version: 4.7.14
+version: 4.7.15
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-virtual
 dependencies:
   - name: cc-rbac
@@ -62,5 +62,5 @@ dependencies:
     condition: secrets-injector.enabled
   - name: reloader
     repository: oci://ghcr.io/stakater/charts
-    version: 1.2.0
+    version: 2.1.3
     condition: reloader.enabled

--- a/system/kube-system-virtual/values.yaml
+++ b/system/kube-system-virtual/values.yaml
@@ -2,8 +2,8 @@ global:
   region:
   domain:
 
-externalIPs: 
-  ingress: 
+externalIPs:
+  ingress:
 
 ingress:
   tls_client_auth:
@@ -17,7 +17,7 @@ kube-proxy:
   selector:   false
   toleration: false
   images:
-    proxy: 
+    proxy:
       repository: sapcc/hyperkube
       tag: v1.15.2
   clusterCIDR: 10.180.0.0/17
@@ -32,7 +32,7 @@ kube-proxy-capi:
   selector:   false
   toleration: false
   images:
-    proxy: 
+    proxy:
       repository: sapcc/hyperkube
       tag: v1.15.2
   clusterCIDR: 10.180.0.0/17
@@ -42,7 +42,7 @@ kube-proxy-capi:
     externalip: false
     nanny:      false
     ipmasq:     false
-  
+
 kube-flannel:
   image:
     repository: quay.io/coreos/flannel
@@ -118,3 +118,7 @@ owner-info:
 
 secrets-injector:
   enabled: false
+
+reloader:
+  image:
+    repository: 'keppel.global.cloud.sap/ccloud-ghcr-io-mirror/stakater/reloader'


### PR DESCRIPTION
* bump reloader chart to 2.1.3
* bump secrets-injector chart to 1.1.10
* add default `reloader.image.repository` value