### PR TITLE
[netapp-exporter] enhance snapmirror metrics

### DIFF
--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/aggregations/snapmirror.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/aggregations/snapmirror.yaml
@@ -5,11 +5,12 @@ groups:
     #
     # netapp_snapmirror_labels: destinations only in LOCAL region (from 'snapmirror show' - rich snapmirror details).
     # netapp_snapmirror_endpoint_labels: destinations in LOCAL and REMOTE regions (from 'snapmirror list-destinations' - endpoints only no details).
-    #
-    # It's important for netapp_volume_labels to be available for following rules.
-    # We record them from past 2 hours to avoid incorrect "join" operations for the local and cross-region snapmirrors.
+    # 
+    # Volumes that are known to Manila, including active and secondary replicas.
+    # It's important that they are available for following snapmirror rules, therefore we use `last_over_time`.
     - record: netapp_volume_labels:manila
-      expr: last_over_time(netapp_volume_labels{app="netapp-harvest-exporter-manila", volume=~"share.*"}[2h])
+      expr: |
+        last_over_time(netapp_volume_labels{app="netapp-harvest-exporter-manila", volume=~"share_[0-9a-f]{8}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{12}"}[2h])
  
     # Enrich netapp_snapmirror_labels within a region.
     # First with share_id, share_name and project_id, then with destination_cluster.
@@ -46,6 +47,8 @@ groups:
           "destination_volume", "$1", "volume", "(.*)")
 
     # Enrich netapp_snapmirror_endpoint_labels.
+    # Add openstack labels, such as project_id, share_id and share_name.
+    # Add source_cluster label.
     - record: netapp_snapmirror_endpoint_labels:enhanced
       expr: |
         netapp_snapmirror_endpoint_labels
@@ -57,6 +60,19 @@ groups:
           "source_volume", "$1", "volume", "(.*)"),
           "source_vserver", "$1", "svm", "(.*)"),
           "source_cluster", "$1", "filer", "(.*)")
+
+    # Add destination_cluster label, which is the filer label from harvester.
+    - record: netapp_snapmirror_lag_time:enhanced
+      expr: |
+        label_replace(netapp_snapmirror_lag_time, "destination_cluster", "$1", "filer", "(.*)")
+
+    - record: netapp_snapmirror_last_transfer_duration:enhanced
+      expr: |
+        label_replace(netapp_snapmirror_last_transfer_duration, "destination_cluster", "$1", "filer", "(.*)")
+
+    - record: netapp_snapmirror_last_transfer_size:enhanced
+      expr: |
+        label_replace(netapp_snapmirror_last_transfer_size, "destination_cluster", "$1", "filer", "(.*)")
 
     # With above enriched metrics, we can query snapmirror in global thanos:
     #


### PR DESCRIPTION
Add destination_cluster label, which is just the filer where the metrics
generated from. NetApp only reports source_cluster in the snapmirror
metrics.
