### PR TITLE
[kube-system-metal][reloader] update helm chart and add default repository

### DIFF
--- a/system/kube-system-metal/Chart.lock
+++ b/system/kube-system-metal/Chart.lock
@@ -73,9 +73,9 @@ dependencies:
   version: 0.1.3
 - name: secrets-injector
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.1.9
+  version: 1.1.11
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
-  version: 1.2.0
-digest: sha256:6d5b0e20ed3e017a2462e3ff4bde41b7d5f61439ab395ddb87fe694468817e4a
-generated: "2025-04-03T12:09:49.373412795Z"
+  version: 2.1.3
+digest: sha256:866167537dd9e584aa6b028eb07438a3419a0b2341e47e5fbf7033e929e10774
+generated: "2025-05-06T13:58:16.99442+03:00"

--- a/system/kube-system-metal/Chart.yaml
+++ b/system/kube-system-metal/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for metal clusters.
 name: kube-system-metal
-version: 6.12.18
+version: 6.12.19
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-metal
 dependencies:
   - name: cc-rbac
@@ -101,5 +101,5 @@ dependencies:
     condition: secrets-injector.enabled
   - name: reloader
     repository: oci://ghcr.io/stakater/charts
-    version: 1.2.0
+    version: 2.1.3
     condition: reloader.enabled

--- a/system/kube-system-metal/values.yaml
+++ b/system/kube-system-metal/values.yaml
@@ -282,3 +282,7 @@ owner-info:
 
 secrets-injector:
   enabled: false
+
+reloader:
+  image:
+    repository: 'keppel.global.cloud.sap/ccloud-ghcr-io-mirror/stakater/reloader'


### PR DESCRIPTION
* bump reloader chart to 2.1.3
* bump secrets-injector chart to 1.1.11
* add default `reloader.image.repository` value