### PR TITLE
[Nova] Clean up after bobcat upgrade

### DIFF
--- a/openstack/nova/templates/etc/_nova-scheduler.conf.tpl
+++ b/openstack/nova/templates/etc/_nova-scheduler.conf.tpl
@@ -9,7 +9,6 @@ statsd_enabled = {{ .Values.scheduler.rpc_statsd_enabled }}
 discover_hosts_in_cells_interval = 60
 workers = {{ .Values.scheduler.workers }}
 driver_task_period = {{ .Values.scheduler.driver_task_period | default 60 }}
-query_placement_for_availability_zone = {{ not (contains "AvailabilityZoneFilter" .Values.scheduler.default_filters) }}
 
 [filter_scheduler]
 available_filters = {{ .Values.scheduler.available_filters | default "nova.scheduler.filters.all_filters" }}

--- a/openstack/nova/templates/etc/_nova.conf.tpl
+++ b/openstack/nova/templates/etc/_nova.conf.tpl
@@ -143,9 +143,6 @@ region_name = {{.Values.global.region}}
 [wsgi]
 default_pool_size = {{ .Values.wsgi_default_pool_size | default .Values.global.wsgi_default_pool_size | default 100 }}
 
-[workarounds]
-enable_live_migration_to_old_hypervisor = True
-
 [compute]
 initial_cpu_allocation_ratio = 1.0
 initial_ram_allocation_ratio = 1.0


### PR DESCRIPTION
While upgrading to `bobcat`, we had to keep the old, removed config options in place for all regions still running `xena`. Now that Nova is on `bobcat` in all regions, we can clean them up.

* `query_placement_for_availability_zone` was removed from Nova as the `AvailabilityZoneFilter` was removed and thus there's no other option than using Placement to filter by availability zone
* `[workarounds]/enable_live_migration_to_old_hypervisor` is downstream code that we could replace with upstream code which uses `[workarounds]/skip_hypervisor_version_check_on_lm` which is set in the conductor's config via `values.yaml`