### PR TITLE
snapmirror

### DIFF
--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/aggregations/snapmirror.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/aggregations/snapmirror.yaml
@@ -6,23 +6,25 @@ groups:
     # netapp_snapmirror_labels: destinations only in LOCAL region (from 'snapmirror show' - rich snapmirror details).
     # netapp_snapmirror_endpoint_labels: destinations in LOCAL and REMOTE regions (from 'snapmirror list-destinations' - endpoints only no details).
     # 
-    # Volumes that are known to Manila, including active and secondary replicas.
-    # It's important that they are available for following snapmirror rules, therefore we use `last_over_time`.
+    # To make sure the metric vectors have unique labels in below queries.
+    # Include metrics manila exporter ONLY and exclude volumes such as "root", "vol0" and other cinder volumes.
+    # Use `last_over_time` to make sure they are always available even during exporter rolling upgrade.
     - record: netapp_volume_labels:manila
-      expr: |
-        last_over_time(netapp_volume_labels{app="netapp-harvest-exporter-manila", volume=~"share_[0-9a-f]{8}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{12}"}[2h])
+      expr: last_over_time(netapp_volume_labels{app="netapp-harvest-exporter-manila", volume=~"share_.*"}[2h])
  
     # Enrich netapp_snapmirror_labels within a region.
     # First with share_id, share_name and project_id, then with destination_cluster.
     - record: netapp_snapmirror_labels:enhanced
       expr: |
         netapp_snapmirror_labels 
-        * on (app, source_vserver, source_volume) group_left(project_id, share_id, share_name)
+        * on (app, source_vserver, source_volume) group_left(project_id, share_id, share_name, reason)
+        label_replace (
         label_replace (
         label_replace (
           max by (app, filer, project_id, share_id, share_name, svm, volume) (netapp_volume_labels:manila),
           "source_volume", "$1", "volume", "(.*)"),
-          "source_vserver", "$1", "svm", "(.*)")
+          "source_vserver", "$1", "svm", "(.*)"),
+          "reason", "local-snapmirror", "", ".*")
         * on (app, filer, destination_volume) group_left(destination_availability_zone, destination_cluster)
         label_replace (
         label_replace (
@@ -38,13 +40,15 @@ groups:
       expr: |
         (netapp_snapmirror_labels unless on (source_cluster)
           label_replace(netapp_volume_labels:manila, "source_cluster", "$1", "filer", "(.*)"))
-        * on (filer, destination_volume) group_left(destination_availability_zone, destination_cluster) 
+        * on (filer, destination_volume) group_left(destination_availability_zone, destination_cluster, reason) 
+        label_replace(
         label_replace(
         label_replace(
         label_replace(netapp_volume_labels:manila,
           "destination_availability_zone", "$1", "availability_zone", "(.*)"),
           "destination_cluster", "$1", "filer", "(.*)"),
           "destination_volume", "$1", "volume", "(.*)")
+          "reason", "remote-snapmirror", "", ".*")
 
     # Enrich netapp_snapmirror_endpoint_labels.
     # Add openstack labels, such as project_id, share_id and share_name.
@@ -61,7 +65,7 @@ groups:
           "source_vserver", "$1", "svm", "(.*)"),
           "source_cluster", "$1", "filer", "(.*)")
 
-    # Add destination_cluster label, which is the filer label from harvester.
+    # Add destination_cluster label, which is the filer label from harvester. 
     - record: netapp_snapmirror_lag_time:enhanced
       expr: |
         label_replace(netapp_snapmirror_lag_time, "destination_cluster", "$1", "filer", "(.*)")


### PR DESCRIPTION
 the helper metrics `netapp_volume_labels:enhanced` should include the
 backup targets as well, not just volumes known to manila.
