### PR TITLE
[netapp-exporter][snapmirror] maia metrics with enriched labels

### DIFF
--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/aggregations/maia.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/aggregations/maia.yaml
@@ -158,116 +158,19 @@ groups:
     #
     # snampirror relationship
     #
-    # NOTE:
-    #
-    # netapp_snapmirror_labels: Local destinations ONLY (from 'snapmirror show' - relationship details).
-    # netapp_snapmirror_endpoint_labels: Local sources AND remote destinations (from 'snapmirror list-destinations' - endpoints only).
-    #
-    # The cross region snapmirror relationships 'EC2DR' cannot be exported to Maia from destination region, because the project_id belongs to the source region.
-    # So we need to export the cross region snapmirror relationships from the source region.
-    #
-    # Below rules are to export snapmirror relationships to maia a) from destination side and b) source side.
-    # a) from destination side:
-    #     1. include local destinations only (using netapp_snapmirror_labels)
-    #     2. extract volume labels from destination_volume
-    # b) from source side:
-    #     1. include local sources only (using netapp_snapmirror_endpoint_labels WITH unless)
-    #     2. extract volume labels from source_volume
-
+    # NOTE: We enrich snapmirror metrics using exported metrics from target region.
+    # It's done via the promquery exporter in `netapp_metrics_federation` subchart.
     - record: netapp_snapmirror_labels:maia
-      expr: |
-        sum by (
-          availability_zone, project_id, share_id, share_name,
-          derived_relationship_type,
-          destination_cluster, destination_location, destination_node,
-          destination_volume, destination_vserver,
-          group_type, healthy, last_transfer_error,
-          last_transfer_type, local,  region, policy_type,
-          protectedBy, protectionSourceType, relationship_id,
-          relationship_status, relationship_type, schedule, source_cluster,
-          source_volume, source_vserver, unhealthy_reason
-        ) (
-          netapp_snapmirror_labels *
-            on(filer, destination_volume) group_left(destination_cluster, share_name, share_id, project_id)
-            label_replace(
-            label_replace(
-              max by (filer, project_id, share_id, share_name, svm, volume)
-                (netapp_volume_labels{app="netapp-harvest-exporter-manila", volume=~"share.*"}),
-              "destination_cluster", "$1", "filer", "(.*)"),
-              "destination_volume", "$1", "volume", "(.*)")
-        )
-
-    - record: netapp_snapmirror_labels:maia
-      expr: |
-          sum by (
-            availability_zone, project_id, share_id, share_name,
-            policy_type, relationship_id,
-            source_cluster, source_location, source_vserver, source_volume,
-            destination_cluster, destination_location, destination_vserver, destination_volume,
-          ) (
-            (netapp_snapmirror_endpoint_labels unless on (destination_vserver, destination_volume, source_vserver, source_volume) netapp_snapmirror_labels)
-              * on (filer, source_volume) group_left(source_cluster, share_id, share_name, project_id)
-                label_replace (
-                label_replace (
-                  max by (filer, project_id, share_id, share_name, svm, volume)
-                    (netapp_volume_labels{app="netapp-harvest-exporter-manila", volume=~"share.*"}),
-                  "source_cluster", "$1", "filer", "(.*)"),
-                  "source_volume", "$1", "volume", "(.*)")
-          )
+      expr: {__name__=~"netapp_snapmirror_labels:localbkp|netapp_snapmirror_labels:remotebkp"}
 
     - record: netapp_snapmirror_lag_time:maia
-      expr: |
-        sum(
-          netapp_snapmirror_lag_time *
-            on(filer, destination_volume) group_left(
-              destination_cluster, destination_share_id, destination_share_name,
-              destination_project_id, project_id)
-            label_join(
-            label_replace(
-            label_replace(
-            label_replace(
-            label_replace(
-              max (
-                netapp_volume_labels{app="netapp-harvest-exporter-manila", volume=~"share.*"}
-              ) by (filer, project_id, share_id, share_name, svm, volume),
-              "destination_cluster", "$1", "filer", "(.*)"),
-              "destination_share_id", "$1", "share_id", "(.*)"),
-              "destination_share_name", "$1", "share_name", "(.*)"),
-              "destination_volume", "$1", "volume", "(.*)"),
-              "destination_project_id", "", "project_id")
-        ) by (
-          destination_cluster, destination_location, destination_node,
-          destination_project_id, destination_share_id, destination_share_name,
-          destination_volume, destination_vserver, source_cluster,
-          source_volume, source_vserver, project_id
-        )
+      expr: netapp_snapmirror_lag_time:federated
+
+    - record: netapp_snapmirror_last_transfer_size:maia
+      expr: netapp_snapmirror_last_transfer_size:federated
 
     - record: netapp_snapmirror_last_transfer_duration:maia
-      expr: |
-        sum(
-          netapp_snapmirror_last_transfer_duration *
-            on(filer, destination_volume) group_left(
-              destination_cluster, destination_share_id, destination_share_name,
-              destination_project_id, project_id)
-            label_join(
-            label_replace(
-            label_replace(
-            label_replace(
-            label_replace(
-              max (
-                netapp_volume_labels{app="netapp-harvest-exporter-manila", volume=~"share.*"}
-              ) by (filer, project_id, share_id, share_name, svm, volume),
-              "destination_cluster", "$1", "filer", "(.*)"),
-              "destination_share_id", "$1", "share_id", "(.*)"),
-              "destination_share_name", "$1", "share_name", "(.*)"),
-              "destination_volume", "$1", "volume", "(.*)"),
-              "destination_project_id", "", "project_id")
-        ) by (
-          destination_cluster, destination_location, destination_node,
-          destination_project_id, destination_share_id, destination_share_name,
-          destination_volume, destination_vserver, source_cluster,
-          source_volume, source_vserver, project_id
-        )
+      expr: netapp_snapmirror_last_transfer_duration:federated
 
     #
     # nfs connection metrics

--- a/prometheus-exporters/netapp-exporter/charts/netapp-metrics-federation/templates/configmap.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-metrics-federation/templates/configmap.yaml
@@ -22,6 +22,21 @@ data:
         - type: fill
           label_name: unhealthy_reason
         help: "netapp snapmirror labels for local backup targets"
+      - export_name: netapp_snapmirror_lag_time:federated
+        query: |
+          netapp_snapmirror_endpoint_labels:enhanced{region="{{ .Values.global.region }}", project_id!="", share_id!=""}
+            * on (source_vserver, source_volume, destination_cluster, destination_vserver, destination_volume)
+            group_left() netapp_snapmirror_lag_time:enhanced
+      - export_name: netapp_snapmirror_last_transfer_duration:federated
+        query: |
+          netapp_snapmirror_endpoint_labels:enhanced{region="{{ .Values.global.region }}", project_id!="", share_id!=""}
+            * on (source_vserver, source_volume, destination_cluster, destination_vserver, destination_volume)
+            group_left() netapp_snapmirror_last_transfer_duration:enhanced
+      - export_name: netapp_snapmirror_last_transfer_size:federated
+        query: |
+          netapp_snapmirror_endpoint_labels:enhanced{region="{{ .Values.global.region }}", project_id!="", share_id!=""}
+            * on (source_vserver, source_volume, destination_cluster, destination_vserver, destination_volume)
+            group_left() netapp_snapmirror_last_transfer_size:enhanced
     label_rules:
       - type: drop
         label_prefix: linkerd_


### PR DESCRIPTION
Federating in global thanos using promquery exporter, we fetch detail info
for the snapmirror relationship from target regions. Include lag time and transfer
duration/size as well.