### PR TITLE
openstack/content-repo: add .Values.image_refs

### DIFF
--- a/openstack/content-repo/templates/cronjob.yaml
+++ b/openstack/content-repo/templates/cronjob.yaml
@@ -38,7 +38,11 @@ spec:
               secretName: swift-http-import-certs
           containers:
           - name: swift-http-import
+            {{- if $.Values.image_refs.swift_http_import }}
+            image: {{ quote $.Values.image_refs.swift_http_import }}
+            {{- else }}
             image: {{ $.Values.global.registry }}/swift-http-import:{{ include "image_version" $.Values }}
+            {{- end }}
             imagePullPolicy: IfNotPresent
             args:
               - /etc/http-import/config/{{ $repo }}.yaml

--- a/openstack/content-repo/templates/deployment-check.yaml
+++ b/openstack/content-repo/templates/deployment-check.yaml
@@ -37,8 +37,13 @@ spec:
       containers:
       {{- range $release, $config := .Values.rhn_entitlement_checks }}
       - name: check-{{ $release }}
+        {{- if $.Values.image_refs.alpine_curl }}
+        image: {{ quote $.Values.image_refs.alpine_curl }}
+        imagePullPolicy: IfNotPresent
+        {{- else }}
         image: {{$.Values.global.registry}}/shared-app-images/alpine-curl:3.21-latest
         imagePullPolicy: Always
+        {{- end }}
         args:
           - /bin/sh
           - /bin-check/check-rhn

--- a/openstack/content-repo/templates/deployment-statsd.yaml
+++ b/openstack/content-repo/templates/deployment-statsd.yaml
@@ -29,7 +29,11 @@ spec:
           name: statsd-content-repo
       containers:
       - name: statsd
+        {{- if .Values.image_refs.statsd_exporter }}
+        image: {{ quote .Values.image_refs.statsd_exporter }}
+        {{- else }}
         image: {{$.Values.global.dockerHubMirror}}/prom/statsd-exporter:{{.Values.image_version_auxiliary_statsd_exporter}}
+        {{- end }}
         args: [ --statsd.mapping-config=/config/statsd-exporter.yaml ]
         securityContext:
           runAsNonRoot: true

--- a/openstack/content-repo/values.yaml
+++ b/openstack/content-repo/values.yaml
@@ -15,6 +15,12 @@ owner-info:
     - Sandro Jäckel
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/openstack/content-repo
 
+# NOTE: When deploying from an OCM bundle, the deployment will supply image refs here to override the legacy image ref templating logic.
+image_refs:
+  swift_http_import: null
+  alpine_curl: null
+  statsd_exporter: null
+
 image_version: DEFINED_IN_VALUES_FILE
 debug: false
 


### PR DESCRIPTION
When deploying from an OCM bundle, we want for the image refs in the OCM bundle to take precedence over our usual mirror selection logic based on `.Values.global.registry` and friends.

I am not sure if this is a pattern that we will recommend to everyone. For now, content-repo and backup-replication are our field test for OCM bundles, and we will see how this pattern feels.

cf. https://github.com/sapcc/helm-charts/pull/8575 (the same change for openstack/backup-replication)

For alpine-curl, going with `image_refs` switches the imagePullPolicy to IfNotPresent, because we are not going to use the "latest" tag there. "latest" is fundamentally incompatible with how `ocm transfer ctf --copy-resources` copies images: It will refuse to copy the current "latest" image if a different image with tag "latest" already exists in the target repo.

**Edit:** For validation, I checked that this produces an empty `helm diff` in QA (as long as the `--values` are not changed to refer to the new values).