### PR TITLE
[designate] bump chart shared dependencies

### DIFF
--- a/openstack/designate/Chart.lock
+++ b/openstack/designate/Chart.lock
@@ -4,10 +4,10 @@ dependencies:
   version: 1.1.11
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.3.1
+  version: 0.4.0
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.23.0
+  version: 0.24.1
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.6.9
@@ -16,7 +16,7 @@ dependencies:
   version: 0.4.4
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.17.2
+  version: 0.18.0
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.26.0
@@ -29,5 +29,5 @@ dependencies:
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.1.4
-digest: sha256:58ae292d7cba03f9615555ed925658dbccbd163cc53943f4d08b6b75618ed719
-generated: "2025-04-17T13:28:58.916991+02:00"
+digest: sha256:e74060ce8c2e8e56e4345a0080f5edab5520f7b5c8a8d0261d76d264231e9636
+generated: "2025-05-15T15:55:02.2439+03:00"

--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -13,11 +13,11 @@ dependencies:
     name: pxc-db
     alias: pxc_db
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.3.1
+    version: 0.4.0
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.23.0
+    version: 0.24.1
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.6.9
@@ -28,7 +28,7 @@ dependencies:
   - name: rabbitmq
     condition: rabbitmq.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.17.2
+    version: 0.18.0
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.26.0


### PR DESCRIPTION
* bump rabbitmq chart: updates rabbitmq to 4.1.0
* bump mariadb chart: updates mariadb to 10.6.21
* bump pxc-db chart: updates cluster to 1.17.0 pxc-operator release