### PR TITLE
Hermes: update rabbitmq chart to 0.18.0

### DIFF
--- a/openstack/hermes/Chart.lock
+++ b/openstack/hermes/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 0.1.3
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.15.0
+  version: 0.18.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
-digest: sha256:c6daf4dc7289e50572c1e77ee8c1a7106673aa28a11e85f3446ed99b4e0ac922
-generated: "2025-02-26T11:30:50.571927-07:00"
+digest: sha256:4defda4976f5df764bb6bd7e310b866af76454eda8a8e4bd97c4c140ce5cc703
+generated: "2025-05-09T09:53:22.811708-07:00"

--- a/openstack/hermes/Chart.yaml
+++ b/openstack/hermes/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
     condition: audit.enabled
     name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.15.0
+    version: 0.18.0
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.2.0


### PR DESCRIPTION
This includes the rabbitmq credential update sidecar, and other needed improvements. 