### PR TITLE
hermes: adjust user sidecar for rabbitmq

### DIFF
--- a/openstack/hermes/values.yaml
+++ b/openstack/hermes/values.yaml
@@ -77,6 +77,12 @@ rabbitmq_notifications:
     enabled: true
     sidecar:
       enabled: false
+  global:
+    rabbitmq:
+      native_sidecar:
+        enabled: false
+  credentialUpdater:
+    enabled: true
   users:
     default:
       user: openstack


### PR DESCRIPTION
Trying to fix the user credential sidecar, it shouldn't be in init containers, and is failing.