### PR TITLE
postgresql-ng: bump image

### DIFF
--- a/common/postgresql-ng/Chart.yaml
+++ b/common/postgresql-ng/Chart.yaml
@@ -41,4 +41,4 @@ description: Chart for PostgreSQL
 #     With multitenancy, it is not clear which database these scripts run in.
 #     >> Please use `.Values.databases[].sqlOnStartup` instead.
 #
-version: 2.0.0 # this version number is SemVer as it gets used to auto bump
+version: 2.0.1 # this version number is SemVer as it gets used to auto bump

--- a/common/postgresql-ng/values.yaml
+++ b/common/postgresql-ng/values.yaml
@@ -16,7 +16,7 @@ extensions:
     track: all
 
 # Refer to the "ccloud/postgres-ng" repository in Keppel to see which image tags exist.
-imageTag: '20250508140938'
+imageTag: '20250513093049'
 
 # The version of postgres to start.
 # This will be bumped over time and auto upgrade the database.


### PR DESCRIPTION
This is the first proper image for the v2 series. A weird consequence of us holding the Dockerfile for this image inside the chart is that we needed to merge the PR with the content updates first, and then we could build the image. In hindside, #8644 should not have bumped the chart version yet...