### PR TITLE
all srs: upgrade to postgresql-ng chart 2.0.x

### DIFF
--- a/global/ccloud-hedgedoc/Chart.lock
+++ b/global/ccloud-hedgedoc/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.1.11
 - name: postgresql-ng
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.5.3
+  version: 2.0.2
 - name: pgbackup
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.2.3
@@ -14,5 +14,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:7eee21d701a559c57675e82dddbf0e0a392c3fe705c4491ce704515946afe344
-generated: "2025-05-09T12:23:32.472253309Z"
+digest: sha256:e5743dabced8094fb7e0b16174ca5a66dc31fa45f67a95218e53dceeff5498c0
+generated: "2025-05-13T15:55:01.374979039+02:00"

--- a/global/ccloud-hedgedoc/ci/test-values.yaml
+++ b/global/ccloud-hedgedoc/ci/test-values.yaml
@@ -1,0 +1,9 @@
+global:
+  region: xx-yy-1
+  registry: registry.example.com
+  vaultBaseURL: vault.example.com/secrets
+
+codimd:
+  codimd:
+    database:
+      type: postgres

--- a/global/ccloud-hedgedoc/values.yaml
+++ b/global/ccloud-hedgedoc/values.yaml
@@ -18,10 +18,10 @@ postgresql:
     enabled: true
     size: 10Gi
     accessMode: ReadWriteOnce
-  postgresDatabase: codimd
+  databases:
+    codimd: {}
   users:
     codimd: {}
-  tableOwner: codimd
 
   alerts:
     enabled: true
@@ -29,7 +29,6 @@ postgresql:
 
 pgbackup:
   database:
-    name: codimd
     host: codi-postgresql
   alerts:
     support_group: containers

--- a/openstack/castellum/values.yaml
+++ b/openstack/castellum/values.yaml
@@ -52,8 +52,6 @@ postgresql:
     requests: *postgres-limits
 
 pgbackup:
-  database:
-    name: castellum
   alerts:
     support_group: containers
 

--- a/openstack/keppel/Chart.lock
+++ b/openstack/keppel/Chart.lock
@@ -4,18 +4,18 @@ dependencies:
   version: 1.1.0
 - name: postgresql-ng
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.5.3
+  version: 2.0.2
 - name: pgbackup
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.2.3
 - name: pgmetrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.2.2
+  version: 2.0.2
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.2.5
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:25a680e2e329b789dcfa0ad3387a80fb3a4990b8ae69488713753105e7fc141b
-generated: "2025-05-08T14:54:17.143326168Z"
+digest: sha256:6dd17399e6e6b8dbb6aa499e11926180fa5284c44d401afba1beb7635b981f42
+generated: "2025-05-13T15:39:23.992238281+02:00"

--- a/openstack/keppel/values.yaml
+++ b/openstack/keppel/values.yaml
@@ -104,22 +104,20 @@ postgresql:
   # time is in UTC
   crontab: |
     30 12 * * 1,2,3,4,5 psql -tAd keppel -c "VACUUM ANALYZE"
+  databases:
+    keppel: {}
   persistence:
     enabled: true
     accessMode: ReadWriteOnce # compatibility to allow easy upgrades
     size: 100Gi
-  postgresDatabase: keppel
   probe_timeout_secs: 5
   sharedMemoryLimit: 256Mi
   users:
     keppel: {}
-  tableOwner: keppel
 
 pgbackup:
   alerts:
     support_group: containers
-  database:
-    name: keppel
   resources:
     # complete backups rather fast, to relieve strain on the postgres
     cpu_limit: 2
@@ -127,8 +125,6 @@ pgbackup:
   use_alternate_region: true
 
 pgmetrics:
-  db_name: keppel
-
   alerts:
     support_group: containers
 
@@ -139,175 +135,177 @@ pgmetrics:
     limits:
       cpu: 200m
 
-  customMetrics:
-    keppel_accounts:
-      query: >
-        SELECT COUNT(*) AS count,
-               COALESCE(EXTRACT(epoch FROM MIN(next_blob_sweep_at)), 0) AS min_next_blob_sweep_at,
-               COALESCE(EXTRACT(epoch FROM MIN(next_enforcement_at)), 0) AS min_next_enforcement_at,
-               COALESCE(EXTRACT(epoch FROM MIN(next_storage_sweep_at)), 0) AS min_next_storage_sweep_at,
-               COALESCE(EXTRACT(epoch FROM MIN(next_federation_announcement_at)), 0) AS min_next_federation_announcement_at
-          FROM accounts
-      metrics:
-        - count:
-            usage: "GAUGE"
-            description: "Total number of accounts managed by Keppel"
-        - min_next_blob_sweep_at:
-            usage: "GAUGE"
-            description: "UNIX timestamp of next scheduled blob sweep, or 0 if no accounts have ever been sweeped"
-        - min_next_enforcement_at:
-            usage: "GAUGE"
-            description: "UNIX timestamp of next scheduled managed account run, or 0 if no accounts have ever been managed"
-        - min_next_storage_sweep_at:
-            usage: "GAUGE"
-            description: "UNIX timestamp of next scheduled storage sweep, or 0 if no accounts have ever been sweeped"
-        - min_next_federation_announcement_at:
-            usage: "GAUGE"
-            description: "UNIX timestamp of next scheduled federation announcement, or 0 if no accounts have ever been announced to federation"
-    keppel_blobs:
-      query: "SELECT COUNT(*) AS count, COALESCE(EXTRACT(epoch FROM MIN(can_be_deleted_at)), 0) AS min_can_be_deleted_at, EXTRACT(epoch FROM MIN(next_validation_at)) AS min_next_validation_at, SUM(CASE WHEN validation_error_message = '' THEN 0 ELSE 1 END) AS validation_errors FROM blobs WHERE storage_id != ''"
-      metrics:
-        - count:
-            usage: "GAUGE"
-            description: "Total number of blobs stored in Keppel (except for unbacked blobs)"
-        - min_can_be_deleted_at:
-            usage: "GAUGE"
-            description: "UNIX timestamp of next scheduled blob deletion, or 0 if no blobs are currently marked for deletion"
-        - min_next_validation_at:
-            usage: "GAUGE"
-            description: "UNIX timestamp of oldest blob validation"
-        - validation_errors:
-            usage: "GAUGE"
-            description: "Number of blobs stored in Keppel that failed their last validation"
-    keppel_blob_mounts:
-      query: 'SELECT COALESCE(EXTRACT(epoch FROM MIN(can_be_deleted_at)), 0) AS min_can_be_deleted_at FROM blob_mounts'
-      metrics:
-        - min_can_be_deleted_at:
-            usage: "GAUGE"
-            description: "UNIX timestamp of next scheduled blob mount deletion, or 0 if no blob mounts are currently marked for deletion"
-    keppel_repos:
-      query: 'SELECT COUNT(*) AS count, COALESCE(EXTRACT(epoch FROM MIN(next_blob_mount_sweep_at)), 0) AS min_next_blob_mount_sweep_at, COALESCE(EXTRACT(epoch FROM MIN(next_gc_at)), 0) AS min_next_gc_at FROM repos'
-      metrics:
-        - count:
-            usage: "GAUGE"
-            description: "Total number of repositories stored in Keppel"
-        - min_next_blob_mount_sweep_at:
-            usage: "GAUGE"
-            description: "UNIX timestamp of next scheduled blob mount sweep, or 0 if no repos have ever been sweeped"
-        - min_next_gc_at:
-            usage: "GAUGE"
-            description: "UNIX timestamp of next scheduled image GC, or 0 if no repos have ever been garbage-collected"
-    keppel_replicated_repos:
-      query: "SELECT COUNT(r.id) AS count, COALESCE(EXTRACT(epoch FROM MIN(r.next_manifest_sync_at)), 0) AS min_next_manifest_sync_at FROM repos r JOIN accounts a ON r.account_name = a.name WHERE a.upstream_peer_hostname != ''"
-      metrics:
-        - count:
-            usage: "GAUGE"
-            description: "Total number of repositories in replica accounts stored in Keppel"
-        - min_next_manifest_sync_at:
-            usage: "GAUGE"
-            description: "UNIX timestamp of next scheduled manifest sync, or 0 if no replica repos have ever been synced"
-    keppel_manifests:
-      query: >
-        SELECT COUNT(*) AS count,
-               EXTRACT(epoch FROM MIN(next_validation_at)) AS min_next_validation_at,
-               SUM(CASE WHEN validation_error_message = '' THEN 0 ELSE 1 END) AS validation_errors,
-               COALESCE(EXTRACT(epoch FROM MIN(trivy_security_info.next_check_at)), 0) AS min_next_trivy_check_at,
-               SUM(CASE WHEN trivy_security_info.next_check_at > NOW() THEN 0 ELSE 1 END) AS pending_trivy_checks
-          FROM manifests
-         INNER JOIN trivy_security_info ON trivy_security_info.repo_id = manifests.repo_id AND trivy_security_info.digest = manifests.digest
-      metrics:
-        - count:
-            usage: "GAUGE"
-            description: "Total number of manifests stored in Keppel"
-        - min_next_validation_at:
-            usage: "GAUGE"
-            description: "UNIX timestamp of oldest manifest validation"
-        - validation_errors:
-            usage: "GAUGE"
-            description: "Number of manifests stored in Keppel that failed their last validation"
-        - min_next_trivy_check_at:
-            usage: "GAUGE"
-            description: "UNIX timestamp of next scheduled Trivy security check, or 0 if no manifests have ever been checked for vulnerabilities"
-        - pending_trivy_checks:
-            usage: "GAUGE"
-            description: "Number of manifests stored in Keppel that are currently overdue for their next scheduled Trivy check"
-    keppel_unknown_blobs:
-      query: 'SELECT COALESCE(EXTRACT(epoch FROM MIN(can_be_deleted_at)), 0) AS min_can_be_deleted_at FROM unknown_blobs'
-      metrics:
-        - min_can_be_deleted_at:
-            usage: "GAUGE"
-            description: "UNIX timestamp of next scheduled deletion of an unknown blob, or 0 if there are no unknown blobs at the moment"
-    keppel_unknown_manifests:
-      query: 'SELECT COALESCE(EXTRACT(epoch FROM MIN(can_be_deleted_at)), 0) AS min_can_be_deleted_at FROM unknown_manifests'
-      metrics:
-        - min_can_be_deleted_at:
-            usage: "GAUGE"
-            description: "UNIX timestamp of next scheduled deletion of an unknown manifest, or 0 if there are no unknown manifests at the moment"
-    keppel_tags:
-      query: 'SELECT COUNT(*) AS count FROM tags'
-      metrics:
-        - count:
-            usage: "GAUGE"
-            description: "Total number of tags stored in Keppel"
-    keppel_peers:
-      query: >
-        SELECT hostname, COALESCE(EXTRACT(epoch FROM last_peered_at), 0) AS last_peered_at FROM peers
-      metrics:
-        - hostname:
-            usage: "LABEL"
-            description: "Peer hostname"
-        - last_peered_at:
-            usage: "GAUGE"
-            description: "UNIX timestamp of when we last issued a password for this peer (should happen every 10 minutes)"
-    keppel_blob_replication:
-      query: >
-        SELECT COALESCE(EXTRACT(epoch FROM MIN(since)), 0) AS min_started_at FROM pending_blobs
-      metrics:
-        - min_started_at:
-            usage: "GAUGE"
-            description: "UNIX timestamp when oldest still-running blob replication was started (or 0 when no replication is in progress)"
-    keppel_upload:
-      query: >
-        SELECT COALESCE(EXTRACT(epoch FROM MIN(updated_at)), 0) AS min_updated_at FROM uploads
-      metrics:
-        - min_updated_at:
-            usage: "GAUGE"
-            description: "UNIX timestamp when oldest still-active upload was started (or 0 when no upload is in progress)"
-    keppel_trivy_scan_error:
-      # The UNION SELECT adds a dummy row to satisfy the absent-metrics-operator.
-      query: >
-        SELECT vuln_status, COUNT(*) AS counts FROM trivy_security_info WHERE message != '' GROUP BY vuln_status
-         UNION SELECT 'none' AS vuln_status, 0 AS counts
-      metrics:
-        - vuln_status:
-            usage: "LABEL"
-            description: "Vulnerability status computed by Keppel"
-        - counts:
-            usage: "GAUGE"
-            description: "Total number of manifests where Trivy failed with a specific error message"
-    keppel_manifests_with_unclean_vuln_status:
-      # NOTE: This metric is also exported to Maia and therefore visible to customers. Do not break compatibility unless strictly necessary!
-      query: >
-        SELECT a.name AS account, a.auth_tenant_id AS project_id, r.name AS repo, t.vuln_status AS vuln_status, COUNT(*) AS count
-          FROM manifests m
-          JOIN trivy_security_info t ON t.repo_id = m.repo_id AND t.digest = m.digest
-          JOIN repos r ON m.repo_id = r.id
-          JOIN accounts a ON r.account_name = a.name
-         WHERE t.vuln_status != 'Clean'
-         GROUP BY a.name, a.auth_tenant_id, r.name, t.vuln_status
-      metrics:
-        - account:
-            usage: LABEL
-            description: 'Name of Keppel account'
-        - project_id:
-            usage: LABEL
-            description: 'Project that owns the Keppel account'
-        - repo:
-            usage: LABEL
-            description: 'Name of repository within Keppel account'
-        - vuln_status:
-            usage: LABEL
-            description: 'Vulnerability status by Trivy (or "Pending" for newly pushed images, or "Unsupported" if vulnerability scanning is not possible for this image)'
-        - count:
-            usage: GAUGE
-            description: 'Number of Keppel images per repo and vulnerability status (excluding images with vulnerability status "Clean")'
+  databases:
+    keppel:
+      customMetrics:
+        keppel_accounts:
+          query: >
+            SELECT COUNT(*) AS count,
+                   COALESCE(EXTRACT(epoch FROM MIN(next_blob_sweep_at)), 0) AS min_next_blob_sweep_at,
+                   COALESCE(EXTRACT(epoch FROM MIN(next_enforcement_at)), 0) AS min_next_enforcement_at,
+                   COALESCE(EXTRACT(epoch FROM MIN(next_storage_sweep_at)), 0) AS min_next_storage_sweep_at,
+                   COALESCE(EXTRACT(epoch FROM MIN(next_federation_announcement_at)), 0) AS min_next_federation_announcement_at
+              FROM accounts
+          metrics:
+            - count:
+                usage: "GAUGE"
+                description: "Total number of accounts managed by Keppel"
+            - min_next_blob_sweep_at:
+                usage: "GAUGE"
+                description: "UNIX timestamp of next scheduled blob sweep, or 0 if no accounts have ever been sweeped"
+            - min_next_enforcement_at:
+                usage: "GAUGE"
+                description: "UNIX timestamp of next scheduled managed account run, or 0 if no accounts have ever been managed"
+            - min_next_storage_sweep_at:
+                usage: "GAUGE"
+                description: "UNIX timestamp of next scheduled storage sweep, or 0 if no accounts have ever been sweeped"
+            - min_next_federation_announcement_at:
+                usage: "GAUGE"
+                description: "UNIX timestamp of next scheduled federation announcement, or 0 if no accounts have ever been announced to federation"
+        keppel_blobs:
+          query: "SELECT COUNT(*) AS count, COALESCE(EXTRACT(epoch FROM MIN(can_be_deleted_at)), 0) AS min_can_be_deleted_at, EXTRACT(epoch FROM MIN(next_validation_at)) AS min_next_validation_at, SUM(CASE WHEN validation_error_message = '' THEN 0 ELSE 1 END) AS validation_errors FROM blobs WHERE storage_id != ''"
+          metrics:
+            - count:
+                usage: "GAUGE"
+                description: "Total number of blobs stored in Keppel (except for unbacked blobs)"
+            - min_can_be_deleted_at:
+                usage: "GAUGE"
+                description: "UNIX timestamp of next scheduled blob deletion, or 0 if no blobs are currently marked for deletion"
+            - min_next_validation_at:
+                usage: "GAUGE"
+                description: "UNIX timestamp of oldest blob validation"
+            - validation_errors:
+                usage: "GAUGE"
+                description: "Number of blobs stored in Keppel that failed their last validation"
+        keppel_blob_mounts:
+          query: 'SELECT COALESCE(EXTRACT(epoch FROM MIN(can_be_deleted_at)), 0) AS min_can_be_deleted_at FROM blob_mounts'
+          metrics:
+            - min_can_be_deleted_at:
+                usage: "GAUGE"
+                description: "UNIX timestamp of next scheduled blob mount deletion, or 0 if no blob mounts are currently marked for deletion"
+        keppel_repos:
+          query: 'SELECT COUNT(*) AS count, COALESCE(EXTRACT(epoch FROM MIN(next_blob_mount_sweep_at)), 0) AS min_next_blob_mount_sweep_at, COALESCE(EXTRACT(epoch FROM MIN(next_gc_at)), 0) AS min_next_gc_at FROM repos'
+          metrics:
+            - count:
+                usage: "GAUGE"
+                description: "Total number of repositories stored in Keppel"
+            - min_next_blob_mount_sweep_at:
+                usage: "GAUGE"
+                description: "UNIX timestamp of next scheduled blob mount sweep, or 0 if no repos have ever been sweeped"
+            - min_next_gc_at:
+                usage: "GAUGE"
+                description: "UNIX timestamp of next scheduled image GC, or 0 if no repos have ever been garbage-collected"
+        keppel_replicated_repos:
+          query: "SELECT COUNT(r.id) AS count, COALESCE(EXTRACT(epoch FROM MIN(r.next_manifest_sync_at)), 0) AS min_next_manifest_sync_at FROM repos r JOIN accounts a ON r.account_name = a.name WHERE a.upstream_peer_hostname != ''"
+          metrics:
+            - count:
+                usage: "GAUGE"
+                description: "Total number of repositories in replica accounts stored in Keppel"
+            - min_next_manifest_sync_at:
+                usage: "GAUGE"
+                description: "UNIX timestamp of next scheduled manifest sync, or 0 if no replica repos have ever been synced"
+        keppel_manifests:
+          query: >
+            SELECT COUNT(*) AS count,
+                   EXTRACT(epoch FROM MIN(next_validation_at)) AS min_next_validation_at,
+                   SUM(CASE WHEN validation_error_message = '' THEN 0 ELSE 1 END) AS validation_errors,
+                   COALESCE(EXTRACT(epoch FROM MIN(trivy_security_info.next_check_at)), 0) AS min_next_trivy_check_at,
+                   SUM(CASE WHEN trivy_security_info.next_check_at > NOW() THEN 0 ELSE 1 END) AS pending_trivy_checks
+              FROM manifests
+             INNER JOIN trivy_security_info ON trivy_security_info.repo_id = manifests.repo_id AND trivy_security_info.digest = manifests.digest
+          metrics:
+            - count:
+                usage: "GAUGE"
+                description: "Total number of manifests stored in Keppel"
+            - min_next_validation_at:
+                usage: "GAUGE"
+                description: "UNIX timestamp of oldest manifest validation"
+            - validation_errors:
+                usage: "GAUGE"
+                description: "Number of manifests stored in Keppel that failed their last validation"
+            - min_next_trivy_check_at:
+                usage: "GAUGE"
+                description: "UNIX timestamp of next scheduled Trivy security check, or 0 if no manifests have ever been checked for vulnerabilities"
+            - pending_trivy_checks:
+                usage: "GAUGE"
+                description: "Number of manifests stored in Keppel that are currently overdue for their next scheduled Trivy check"
+        keppel_unknown_blobs:
+          query: 'SELECT COALESCE(EXTRACT(epoch FROM MIN(can_be_deleted_at)), 0) AS min_can_be_deleted_at FROM unknown_blobs'
+          metrics:
+            - min_can_be_deleted_at:
+                usage: "GAUGE"
+                description: "UNIX timestamp of next scheduled deletion of an unknown blob, or 0 if there are no unknown blobs at the moment"
+        keppel_unknown_manifests:
+          query: 'SELECT COALESCE(EXTRACT(epoch FROM MIN(can_be_deleted_at)), 0) AS min_can_be_deleted_at FROM unknown_manifests'
+          metrics:
+            - min_can_be_deleted_at:
+                usage: "GAUGE"
+                description: "UNIX timestamp of next scheduled deletion of an unknown manifest, or 0 if there are no unknown manifests at the moment"
+        keppel_tags:
+          query: 'SELECT COUNT(*) AS count FROM tags'
+          metrics:
+            - count:
+                usage: "GAUGE"
+                description: "Total number of tags stored in Keppel"
+        keppel_peers:
+          query: >
+            SELECT hostname, COALESCE(EXTRACT(epoch FROM last_peered_at), 0) AS last_peered_at FROM peers
+          metrics:
+            - hostname:
+                usage: "LABEL"
+                description: "Peer hostname"
+            - last_peered_at:
+                usage: "GAUGE"
+                description: "UNIX timestamp of when we last issued a password for this peer (should happen every 10 minutes)"
+        keppel_blob_replication:
+          query: >
+            SELECT COALESCE(EXTRACT(epoch FROM MIN(since)), 0) AS min_started_at FROM pending_blobs
+          metrics:
+            - min_started_at:
+                usage: "GAUGE"
+                description: "UNIX timestamp when oldest still-running blob replication was started (or 0 when no replication is in progress)"
+        keppel_upload:
+          query: >
+            SELECT COALESCE(EXTRACT(epoch FROM MIN(updated_at)), 0) AS min_updated_at FROM uploads
+          metrics:
+            - min_updated_at:
+                usage: "GAUGE"
+                description: "UNIX timestamp when oldest still-active upload was started (or 0 when no upload is in progress)"
+        keppel_trivy_scan_error:
+          # The UNION SELECT adds a dummy row to satisfy the absent-metrics-operator.
+          query: >
+            SELECT vuln_status, COUNT(*) AS counts FROM trivy_security_info WHERE message != '' GROUP BY vuln_status
+             UNION SELECT 'none' AS vuln_status, 0 AS counts
+          metrics:
+            - vuln_status:
+                usage: "LABEL"
+                description: "Vulnerability status computed by Keppel"
+            - counts:
+                usage: "GAUGE"
+                description: "Total number of manifests where Trivy failed with a specific error message"
+        keppel_manifests_with_unclean_vuln_status:
+          # NOTE: This metric is also exported to Maia and therefore visible to customers. Do not break compatibility unless strictly necessary!
+          query: >
+            SELECT a.name AS account, a.auth_tenant_id AS project_id, r.name AS repo, t.vuln_status AS vuln_status, COUNT(*) AS count
+              FROM manifests m
+              JOIN trivy_security_info t ON t.repo_id = m.repo_id AND t.digest = m.digest
+              JOIN repos r ON m.repo_id = r.id
+              JOIN accounts a ON r.account_name = a.name
+             WHERE t.vuln_status != 'Clean'
+             GROUP BY a.name, a.auth_tenant_id, r.name, t.vuln_status
+          metrics:
+            - account:
+                usage: LABEL
+                description: 'Name of Keppel account'
+            - project_id:
+                usage: LABEL
+                description: 'Project that owns the Keppel account'
+            - repo:
+                usage: LABEL
+                description: 'Name of repository within Keppel account'
+            - vuln_status:
+                usage: LABEL
+                description: 'Vulnerability status by Trivy (or "Pending" for newly pushed images, or "Unsupported" if vulnerability scanning is not possible for this image)'
+            - count:
+                usage: GAUGE
+                description: 'Number of Keppel images per repo and vulnerability status (excluding images with vulnerability status "Clean")'

--- a/openstack/limes/Chart.lock
+++ b/openstack/limes/Chart.lock
@@ -4,15 +4,15 @@ dependencies:
   version: 1.1.0
 - name: postgresql-ng
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.5.3
+  version: 2.0.2
 - name: pgbackup
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.2.3
 - name: pgmetrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.2.2
+  version: 2.0.2
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:59d8bdce882d1f1de2a64cbaa969d20b64c9b190322c54dc155c3cd1ced8a883
-generated: "2025-05-08T14:56:33.559181147Z"
+digest: sha256:79483a6bb61b030f09297bde222ead61973993031d92f84e75dabb4438b567d0
+generated: "2025-05-13T15:47:37.592332099+02:00"

--- a/openstack/limes/values.yaml
+++ b/openstack/limes/values.yaml
@@ -113,11 +113,11 @@ postgresql:
   persistence:
     enabled: true
     size: 10Gi
-  postgresDatabase: limes
+  databases:
+    limes: {}
   users:
     limes: {}
   sharedMemoryLimit: 128Mi
-  tableOwner: limes
 
   config:
     log_min_duration_statement: 250
@@ -128,158 +128,156 @@ postgresql:
     support_group: containers
 
 pgbackup:
-  database:
-    name: limes
   alerts:
     support_group: containers
 
 pgmetrics:
-  db_name: limes
-
   alerts:
     support_group: containers
 
   collectors:
     stat_bgwriter: false
 
-  customMetrics:
-    limes_failing_scrapes:
-      # The `SUM(...)` has mostly the same effect as `COUNT(*) ... WHERE
-      # ps.scrape_error_message != ''`, but generates zero-valued results for
-      # all service types without scrape errors. This ensures that an absence
-      # of errors does not trigger a metric absence alert.
-      query: >
-        SELECT ps.type AS service_name, SUM(CASE WHEN ps.scrape_error_message = '' THEN 0 ELSE 1 END) AS gauge
-          FROM project_services ps
-         GROUP BY ps.type
-      metrics:
-        - service_name:
-            usage: "LABEL"
-            description: "Service type"
-        - gauge:
-            usage: "GAUGE"
-            description: "Total number of projects that are failing quota/usage scrape"
+  databases:
+    limes:
+      customMetrics:
+        limes_failing_scrapes:
+          # The `SUM(...)` has mostly the same effect as `COUNT(*) ... WHERE
+          # ps.scrape_error_message != ''`, but generates zero-valued results for
+          # all service types without scrape errors. This ensures that an absence
+          # of errors does not trigger a metric absence alert.
+          query: >
+            SELECT ps.type AS service_name, SUM(CASE WHEN ps.scrape_error_message = '' THEN 0 ELSE 1 END) AS gauge
+              FROM project_services ps
+             GROUP BY ps.type
+          metrics:
+            - service_name:
+                usage: "LABEL"
+                description: "Service type"
+            - gauge:
+                usage: "GAUGE"
+                description: "Total number of projects that are failing quota/usage scrape"
 
-    limes_failing_rate_scrapes:
-      # Same strategy as above for `limes_failing_scrapes`.
-      query: >
-        SELECT ps.type AS service_name, SUM(CASE WHEN ps.rates_scrape_error_message = '' THEN 0 ELSE 1 END) AS gauge
-          FROM project_services ps
-         GROUP BY ps.type
-      metrics:
-        - service_name:
-            usage: "LABEL"
-            description: "Service type"
-        - gauge:
-            usage: "GAUGE"
-            description: "Total number of projects that are failing rate data scrape"
+        limes_failing_rate_scrapes:
+          # Same strategy as above for `limes_failing_scrapes`.
+          query: >
+            SELECT ps.type AS service_name, SUM(CASE WHEN ps.rates_scrape_error_message = '' THEN 0 ELSE 1 END) AS gauge
+              FROM project_services ps
+             GROUP BY ps.type
+          metrics:
+            - service_name:
+                usage: "LABEL"
+                description: "Service type"
+            - gauge:
+                usage: "GAUGE"
+                description: "Total number of projects that are failing rate data scrape"
 
-    limes_mismatch_project_quota:
-      # The UNION SELECT adds a dummy row to satisfy the absent-metrics-operator.
-      query: >
-        SELECT ps.type AS service_name, COUNT(*) as count
-          FROM project_resources pr
-          JOIN project_services ps ON ps.id = pr.service_id
-         WHERE pr.backend_quota != pr.quota
-         GROUP BY ps.type
-         UNION SELECT 'none' AS service_name, 0 AS count
-      metrics:
-        - service_name:
-            usage: "LABEL"
-            description: "Service type"
-        - count:
-            usage: "GAUGE"
-            description: "Total number of project resources that have mismatched quota"
+        limes_mismatch_project_quota:
+          # The UNION SELECT adds a dummy row to satisfy the absent-metrics-operator.
+          query: >
+            SELECT ps.type AS service_name, COUNT(*) as count
+              FROM project_resources pr
+              JOIN project_services ps ON ps.id = pr.service_id
+             WHERE pr.backend_quota != pr.quota
+             GROUP BY ps.type
+             UNION SELECT 'none' AS service_name, 0 AS count
+          metrics:
+            - service_name:
+                usage: "LABEL"
+                description: "Service type"
+            - count:
+                usage: "GAUGE"
+                description: "Total number of project resources that have mismatched quota"
 
-    limes_overspent_project_quota:
-      # Swift does quota checks decentralized, in the individual proxy instances. When multiple parallel uploads each
-      # fit into the remaining quota, they will therefore all be permitted, even if the total sum exceeds the available
-      # quota. This causes overspent quotas on a fairly regular basis, and we don't really want (or need) to do anything
-      # about it. Just like eventual consistency in general, this is just how Swift behaves. Therefore this metric only
-      # considers quota inconsistencies in Swift if they are large (in specific, larger than 1 TiB = 1099511627776 byte).
-      query: >
-        WITH tmp AS (
-          SELECT 1 FROM project_services ps
-            JOIN project_resources pr ON pr.service_id = ps.id
-            JOIN project_az_resources par ON par.resource_id = pr.id
-           GROUP BY ps.id, ps.type, pr.name, pr.quota
-          HAVING SUM(par.usage) > pr.quota
-             AND NOT (ps.type = 'swift' AND pr.name = 'capacity' AND SUM(par.usage) < pr.quota + 1099511627776)
-        ) SELECT COUNT(*) AS count FROM tmp
-      metrics:
-        - count:
-            usage: "GAUGE"
-            description: "Total number of project resources that have overspent quota"
+        limes_overspent_project_quota:
+          # Swift does quota checks decentralized, in the individual proxy instances. When multiple parallel uploads each
+          # fit into the remaining quota, they will therefore all be permitted, even if the total sum exceeds the available
+          # quota. This causes overspent quotas on a fairly regular basis, and we don't really want (or need) to do anything
+          # about it. Just like eventual consistency in general, this is just how Swift behaves. Therefore this metric only
+          # considers quota inconsistencies in Swift if they are large (in specific, larger than 1 TiB = 1099511627776 byte).
+          query: >
+            WITH tmp AS (
+              SELECT 1 FROM project_services ps
+                JOIN project_resources pr ON pr.service_id = ps.id
+                JOIN project_az_resources par ON par.resource_id = pr.id
+               GROUP BY ps.id, ps.type, pr.name, pr.quota
+              HAVING SUM(par.usage) > pr.quota
+                 AND NOT (ps.type = 'swift' AND pr.name = 'capacity' AND SUM(par.usage) < pr.quota + 1099511627776)
+            ) SELECT COUNT(*) AS count FROM tmp
+          metrics:
+            - count:
+                usage: "GAUGE"
+                description: "Total number of project resources that have overspent quota"
 
-    limes_project:
-      query: >
-        SELECT COUNT(*) AS count FROM projects
-      metrics:
-        - count:
-            usage: "GAUGE"
-            description: "Number of projects in the Limes DB"
+        limes_project:
+          query: >
+            SELECT COUNT(*) AS count FROM projects
+          metrics:
+            - count:
+                usage: "GAUGE"
+                description: "Number of projects in the Limes DB"
 
-    limes_project_resources_by_type:
-      query: >
-        SELECT ps.type AS service, pr.name AS resource, COUNT(*) AS count
-          FROM project_resources pr JOIN project_services ps ON ps.id = pr.service_id
-         GROUP BY ps.type, pr.name
-      metrics:
-        - service:
-            usage: "LABEL"
-            description: "Service type"
-        - resource:
-            usage: "LABEL"
-            description: "Resource name"
-        - count:
-            usage: "GAUGE"
-            description: "Number of projects that have a project_resources entry for this service and resource"
+        limes_project_resources_by_type:
+          query: >
+            SELECT ps.type AS service, pr.name AS resource, COUNT(*) AS count
+              FROM project_resources pr JOIN project_services ps ON ps.id = pr.service_id
+             GROUP BY ps.type, pr.name
+          metrics:
+            - service:
+                usage: "LABEL"
+                description: "Service type"
+            - resource:
+                usage: "LABEL"
+                description: "Resource name"
+            - count:
+                usage: "GAUGE"
+                description: "Number of projects that have a project_resources entry for this service and resource"
 
-    # This metric is federated into prometheus-kubernetes for alerting in
-    # Kubernikus. (Low free Swift quota means Kubernikus might become unable to
-    # do etcd backups.)
-    limes_free_swift_quota:
-      query: >
-        SELECT p.uuid AS project_id, p.name AS project, d.name AS domain, GREATEST(pr.backend_quota - par.usage, 0) AS gauge
-          FROM domains d
-          JOIN projects p ON p.domain_id = d.id
-          JOIN project_services ps ON ps.project_id = p.id
-          JOIN project_resources pr ON pr.service_id = ps.id
-          JOIN project_az_resources par ON par.resource_id = pr.id
-         WHERE ps.type = 'swift' AND par.az = 'any'
-      metrics:
-        - gauge:
-            usage: "GAUGE"
-            description: "Free backend quota for Swift capacity"
-        - project_id:
-            usage: "LABEL"
-            description: "Project ID"
-        - project:
-            usage: "LABEL"
-            description: "Project name"
-        - domain:
-            usage: "LABEL"
-            description: "Domain name"
+        # This metric is federated into prometheus-kubernetes for alerting in
+        # Kubernikus. (Low free Swift quota means Kubernikus might become unable to
+        # do etcd backups.)
+        limes_free_swift_quota:
+          query: >
+            SELECT p.uuid AS project_id, p.name AS project, d.name AS domain, GREATEST(pr.backend_quota - par.usage, 0) AS gauge
+              FROM domains d
+              JOIN projects p ON p.domain_id = d.id
+              JOIN project_services ps ON ps.project_id = p.id
+              JOIN project_resources pr ON pr.service_id = ps.id
+              JOIN project_az_resources par ON par.resource_id = pr.id
+             WHERE ps.type = 'swift' AND par.az = 'any'
+          metrics:
+            - gauge:
+                usage: "GAUGE"
+                description: "Free backend quota for Swift capacity"
+            - project_id:
+                usage: "LABEL"
+                description: "Project ID"
+            - project:
+                usage: "LABEL"
+                description: "Project name"
+            - domain:
+                usage: "LABEL"
+                description: "Domain name"
 
-    limes_support_group:
-      query: >
-        SELECT 1 AS mapping, type AS service, CASE
-          WHEN type IN ('compute', 'cinder', 'ironic', 'manila', 'nova') THEN 'compute-storage-api'
-          WHEN type IN ('archer', 'designate', 'neutron', 'octavia')     THEN 'network-api'
-          WHEN type IN ('cronus')                                        THEN 'email'
-          WHEN type IN ('ceph', 'swift')                                 THEN 'storage'
-          ELSE 'containers' END AS support_group
-        FROM project_services GROUP BY type
-      metrics:
-        - mapping:
-            usage: "GAUGE"
-            description: "Mapping between Limes service types and support group names"
-        - service:
-            usage: "LABEL"
-            description: "Service type in Limes"
-        - support_group:
-            usage: "LABEL"
-            description: "Support group for alerts"
+        limes_support_group:
+          query: >
+            SELECT 1 AS mapping, type AS service, CASE
+              WHEN type IN ('compute', 'cinder', 'ironic', 'manila', 'nova') THEN 'compute-storage-api'
+              WHEN type IN ('archer', 'designate', 'neutron', 'octavia')     THEN 'network-api'
+              WHEN type IN ('cronus')                                        THEN 'email'
+              WHEN type IN ('ceph', 'swift')                                 THEN 'storage'
+              ELSE 'containers' END AS support_group
+            FROM project_services GROUP BY type
+          metrics:
+            - mapping:
+                usage: "GAUGE"
+                description: "Mapping between Limes service types and support group names"
+            - service:
+                usage: "LABEL"
+                description: "Service type in Limes"
+            - support_group:
+                usage: "LABEL"
+                description: "Support group for alerts"
 
 # Deploy limes Prometheus alerts.
 alerts:

--- a/system/tenso/Chart.lock
+++ b/system/tenso/Chart.lock
@@ -4,15 +4,15 @@ dependencies:
   version: 1.1.0
 - name: postgresql-ng
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.5.3
+  version: 2.0.2
 - name: pgbackup
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.2.3
 - name: pgmetrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.2.2
+  version: 2.0.2
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:59d8bdce882d1f1de2a64cbaa969d20b64c9b190322c54dc155c3cd1ced8a883
-generated: "2025-05-08T14:57:24.126992002Z"
+digest: sha256:79483a6bb61b030f09297bde222ead61973993031d92f84e75dabb4438b567d0
+generated: "2025-05-13T15:48:49.116102527+02:00"

--- a/system/tenso/values.yaml
+++ b/system/tenso/values.yaml
@@ -34,10 +34,10 @@ postgresql:
     enabled: true
     accessMode: ReadWriteOnce
     size: 10Gi
-  postgresDatabase: tenso
+  databases:
+    tenso: {}
   users:
     tenso: {}
-  tableOwner: tenso
 
   config:
     log_min_duration_statement: 250
@@ -59,15 +59,11 @@ postgresql:
       cpu: '0.5'
 
 pgbackup:
-  database:
-    name: tenso
   alerts:
     prometheus: infra-frontend # see above
     support_group: containers
 
 pgmetrics:
-  db_name: tenso
-
   alerts:
     prometheus: infra-frontend # see above
     support_group: containers
@@ -75,46 +71,48 @@ pgmetrics:
   collectors:
     stat_bgwriter: false
 
-  customMetrics:
-    tenso_events:
-      # The final UNION SELECT adds a dummy row to ensure that all derived
-      # timeseries always exist.  Therefore we can have absence alerts that are
-      # useful, but do not mis-trigger when the event queue is empty.
-      query: >
-        SELECT payload_type, COUNT(*) AS count, EXTRACT(epoch FROM MIN(created_at)) AS min_created_at
-          FROM events
-         GROUP BY payload_type
-         UNION SELECT 'none' AS payload_type, 0 AS count, EXTRACT(epoch FROM NOW()) as min_created_at
-      metrics:
-        - payload_type:
-            usage: LABEL
-            description: "Payload type of ingested event"
-        - count:
-            usage: GAUGE
-            description: "Total number of events currently enqueued in the Tenso database"
-        - min_created_at:
-            usage: GAUGE
-            description: "UNIX timestamp on oldest event that currently exists in the Tenso database"
-    tenso_pending_deliveries:
-      # See above for why we have a UNION SELECT at the end.
-      query: >
-        SELECT d.payload_type AS payload_type, COUNT(*) AS count, EXTRACT(epoch FROM MIN(e.created_at)) AS min_created_at, SUM(failed_conversions) AS conversion_failures, SUM(failed_deliveries) AS delivery_failures
-          FROM pending_deliveries d JOIN events e ON d.event_id = e.id
-         GROUP BY d.payload_type
-         UNION SELECT 'none' AS payload_type, 0 AS count, EXTRACT(epoch FROM NOW()) AS min_created_at, 0 AS conversion_failures, 0 AS delivery_failures
-      metrics:
-        - payload_type:
-            usage: LABEL
-            description: "Deliverable payload type"
-        - count:
-            usage: GAUGE
-            description: "Total number of deliveries currently enqueued in the Tenso database"
-        - min_created_at:
-            usage: GAUGE
-            description: "UNIX timestamp on oldest ingested event that did not have its converted payload delivered"
-        - failed_conversions:
-            usage: GAUGE
-            description: "Total number of failed conversion operations for payloads of this type that are still pending delivery"
-        - failed_deliveries:
-            usage: GAUGE
-            description: "Total number of failed delivery operations for payloads of this type that are still pending delivery"
+  databases:
+    tenso:
+    customMetrics:
+      tenso_events:
+        # The final UNION SELECT adds a dummy row to ensure that all derived
+        # timeseries always exist.  Therefore we can have absence alerts that are
+        # useful, but do not mis-trigger when the event queue is empty.
+        query: >
+          SELECT payload_type, COUNT(*) AS count, EXTRACT(epoch FROM MIN(created_at)) AS min_created_at
+            FROM events
+           GROUP BY payload_type
+           UNION SELECT 'none' AS payload_type, 0 AS count, EXTRACT(epoch FROM NOW()) as min_created_at
+        metrics:
+          - payload_type:
+              usage: LABEL
+              description: "Payload type of ingested event"
+          - count:
+              usage: GAUGE
+              description: "Total number of events currently enqueued in the Tenso database"
+          - min_created_at:
+              usage: GAUGE
+              description: "UNIX timestamp on oldest event that currently exists in the Tenso database"
+      tenso_pending_deliveries:
+        # See above for why we have a UNION SELECT at the end.
+        query: >
+          SELECT d.payload_type AS payload_type, COUNT(*) AS count, EXTRACT(epoch FROM MIN(e.created_at)) AS min_created_at, SUM(failed_conversions) AS conversion_failures, SUM(failed_deliveries) AS delivery_failures
+            FROM pending_deliveries d JOIN events e ON d.event_id = e.id
+           GROUP BY d.payload_type
+           UNION SELECT 'none' AS payload_type, 0 AS count, EXTRACT(epoch FROM NOW()) AS min_created_at, 0 AS conversion_failures, 0 AS delivery_failures
+        metrics:
+          - payload_type:
+              usage: LABEL
+              description: "Deliverable payload type"
+          - count:
+              usage: GAUGE
+              description: "Total number of deliveries currently enqueued in the Tenso database"
+          - min_created_at:
+              usage: GAUGE
+              description: "UNIX timestamp on oldest ingested event that did not have its converted payload delivered"
+          - failed_conversions:
+              usage: GAUGE
+              description: "Total number of failed conversion operations for payloads of this type that are still pending delivery"
+          - failed_deliveries:
+              usage: GAUGE
+              description: "Total number of failed delivery operations for payloads of this type that are still pending delivery"


### PR DESCRIPTION
The chart now supports multiple databases in the same server, which requires moving some variables around. Full changelog is in `common/postgresql-ng/Chart.yaml`.

- The big changes on `customMetrics` are only indentation changes. I recommend to view with `?w=1`.
- This has been tested on the Castellum deployment. The one remaining change on Castellum is to remove a setting which has not been recognized by pgbackup for a long time (backup-tools enumerates databases by itself, so an explicit declaration is not necessary).