### PR TITLE
concourse: upgrade to postgresql-ng chart 2.0.x

### DIFF
--- a/global/concourse-main/Chart.lock
+++ b/global/concourse-main/Chart.lock
@@ -10,9 +10,9 @@ dependencies:
   version: 1.0.0
 - name: postgresql-ng
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.3.3
+  version: 2.0.2
 - name: pgbackup
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.1.12
-digest: sha256:b3bd0a84c8628cbe70cd05a66ded71f517b9f9ecbc8b1c1b4fdd104944c87e7f
-generated: "2025-03-24T15:18:30.617538+01:00"
+  version: 1.2.3
+digest: sha256:1b92b6be122e6d2a803b13d5a51c23f4d2b0bb5c39ea81cd846fba265e8fabd2
+generated: "2025-05-13T15:57:37.854399924+02:00"

--- a/global/concourse-main/Chart.yaml
+++ b/global/concourse-main/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
   version: 1.0.0
 - name: postgresql-ng
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.3.3
+  version: 2.0.2
 - name: pgbackup
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.1.12
+  version: 1.2.3

--- a/global/concourse-main/values.yaml
+++ b/global/concourse-main/values.yaml
@@ -119,12 +119,8 @@ alerts:
   prometheus: kubernetes
 
 pgbackup:
-  isPostgresNG: true
   global:
     registry: keppel.global.cloud.sap/ccloud
-  database:
-    name: concourse
-    username: concourse
   alerts:
     prometheus: kubernetes
     support_group: containers
@@ -188,10 +184,9 @@ postgresql-ng:
   alerts:
     support_group: containers
   postgresVersion: "16"
-  postgresUser: concourse
-  postgresDatabase: concourse
-  tableOwner: concourse
   createMetricsUser: false
+  databases:
+    concourse: {}
   users:
     concourse: {}
   config:


### PR DESCRIPTION
The chart now supports multiple databases in the same server, which requires moving some variables around. Full changelog is in `common/postgresql-ng/Chart.yaml`.

- This removes several obsolete values settings that the respective charts do not recognize anymore. I did my best guess of what a `helm diff upgrade` cmdline needs to look like for this chart, and I did not see any unexpected diffs. Please verify my work before rolling out.