### PR TITLE
archer: upgrade to postgresql-ng chart 2.0.x

### DIFF
--- a/openstack/archer/Chart.lock
+++ b/openstack/archer/Chart.lock
@@ -1,13 +1,13 @@
 dependencies:
 - name: postgresql-ng
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.5.3
+  version: 2.0.2
 - name: pgbackup
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.2.3
 - name: pgmetrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.2.2
+  version: 2.0.2
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.26.0
@@ -17,5 +17,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:2449f67238db8c31012ac8316e8f0f29fb07f8e1142ad900e20265a0ea7a4bcd
-generated: "2025-05-12T04:20:37.509152694Z"
+digest: sha256:1ee16f215cd413519ca41fe845344960cffd09c8d7ee1ed196d0e790def65ad5
+generated: "2025-05-13T16:18:43.533699879+02:00"

--- a/openstack/archer/values.yaml
+++ b/openstack/archer/values.yaml
@@ -16,12 +16,12 @@ image:
 
 postgresql:
   enabled: true
-  postgresDatabase: archer
   alerts:
     support_group: network-api
+  databases:
+    archer: {}
   extensions:
     pgcrypto: []
-  tableOwner: archer
   persistence:
     accessMode: ReadWriteMany
     size: 1Gi
@@ -29,17 +29,14 @@ postgresql:
     archer: {}
 
 pgbackup:
-  isPostgresNG: true
-  database:
-    name: archer
   alerts:
     support_group: containers
 
 pgmetrics:
-  isPostgresNG: true
-  db_name: archer
   alerts:
     support_group: network-api
+  databases:
+    archer: {}
 
 alerts:
   enabled: true


### PR DESCRIPTION
The chart now supports multiple databases in the same server, which requires moving some variables around. Full changelog is in `common/postgresql-ng/Chart.yaml`. This also removes several obsolete values settings that the respective charts do not recognize anymore.