### PR TITLE
plutono: upgrade to postgresql-ng chart 2.0.x

### DIFF
--- a/system/plutono/Chart.lock
+++ b/system/plutono/Chart.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: postgresql-ng
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.2.9
+  version: 1.5.3
 - name: pgbackup
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.1.11
+  version: 1.2.3
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
@@ -14,5 +14,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:124942e787ed19877bcd39a14f4da186e207f6fdbf92fe5d5a6125a5a44fd548
-generated: "2025-02-20T12:04:21.475977+01:00"
+digest: sha256:85e1e5745417567914a99d7b8f0430e6a1c19e331c38bc054538486cf3b46070
+generated: "2025-05-13T16:30:20.905339686+02:00"

--- a/system/plutono/values.yaml
+++ b/system/plutono/values.yaml
@@ -89,22 +89,17 @@ nginx:
       public: '@/cc/secrets'
 
 postgresql:
-  postgresDatabase: plutono
-  postgresUser: plutono
-  postgresPassword: '@/cc/secrets'
   persistence:
     enabled: false
   alerts:
     support_group: observability
+  databases:
+    plutono: {}
   users:
     plutono: {}
-  tableOwner: plutono
 
 pgbackup:
   enabled: false # can be enabled in values.yaml
-  isPostgresNG: true
-  database:
-    name: plutono
   alerts:
     support_group: observability
 


### PR DESCRIPTION
The chart now supports multiple databases in the same server, which requires moving some variables around. Full changelog is in `common/postgresql-ng/Chart.yaml`. This also removes several obsolete values settings that the respective charts do not recognize anymore.