### PR TITLE
sentry: upgrade to postgresql-ng chart 2.0.x

### DIFF
--- a/system/sentry/Chart.lock
+++ b/system/sentry/Chart.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: pgbackup
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.1.12
+  version: 1.2.3
 - name: pgmetrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.1.6
+  version: 2.0.2
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
@@ -13,9 +13,9 @@ dependencies:
   version: 2.1.4
 - name: postgresql-ng
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.3.1
+  version: 2.0.2
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:a5e3c8c4ffaebbf259b834c0bf592d1aa32c28490553fcce8af102a0193e1ca8
-generated: "2025-04-15T12:07:45.58744+05:30"
+digest: sha256:bb37254450c5b0cdba0603f09acc8215856122b3d583a0448e501923d13ca3cc
+generated: "2025-05-13T16:34:01.913225023+02:00"

--- a/system/sentry/Chart.yaml
+++ b/system/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes
 name: sentry
-version: 0.3.6
+version: 0.3.7
 dependencies:
   - name: pgbackup
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/system/sentry/Chart.yaml
+++ b/system/sentry/Chart.yaml
@@ -5,10 +5,10 @@ version: 0.3.6
 dependencies:
   - name: pgbackup
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 1.1.12
+    version: 1.2.3
   - name: pgmetrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 1.1.6
+    version: 2.0.2
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0
@@ -18,7 +18,7 @@ dependencies:
   - name: postgresql-ng
     alias: postgresql
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 1.3.1
+    version: 2.0.2
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0

--- a/system/sentry/values.yaml
+++ b/system/sentry/values.yaml
@@ -70,7 +70,7 @@ operator:
 postgresql:
     postgresVersion: 16
     databases:
-      sentry: {}
+        sentry: {}
     persistence:
         enabled: true
         accessMode: ReadWriteMany

--- a/system/sentry/values.yaml
+++ b/system/sentry/values.yaml
@@ -69,7 +69,8 @@ operator:
 
 postgresql:
     postgresVersion: 16
-    postgresDatabase: sentry
+    databases:
+      sentry: {}
     persistence:
         enabled: true
         accessMode: ReadWriteMany
@@ -83,11 +84,8 @@ postgresql:
             cpu: 4
     alerts:
         support_group: identity
-  # postgresql image:
-    imageTag: '20240307100654'
     users:
         sentry: {}
-    tableOwner: sentry
     debug: true
 
 redis:
@@ -124,48 +122,45 @@ serviceAccount:
 # Deploy Sentry Prometheus alerts.
 alerts:
     enabled: true
-  # Name of the Prometheus to which the alerts should be assigned to.
+    # Name of the Prometheus to which the alerts should be assigned to.
     prometheus: openstack
 
 pgbackup:
-    isPostgresNG: true
-    database:
-        name: sentry
     alerts:
         support_group: identity
 
 pgmetrics:
-    isPostgresNG: true
-    db_name: sentry
     alerts:
         large_database_size_enabled: false
         support_group: identity
 
-    customMetrics:
-        sentry_unresolved_issues:
-            query: >
-                SELECT o.slug AS organization, p.slug AS project, COUNT(*) FROM sentry_groupedmessage gm
-                    JOIN sentry_project p ON gm.project_id = p.id
-                    JOIN sentry_organization o ON p.organization_id = o.id
-                WHERE gm.status = 0
-                GROUP BY o.slug, p.slug
-            metrics:
-                - organization: {usage: LABEL, description: "Sentry organization"}
-                - project: {usage: LABEL, description: "Sentry project"}
-                - gauge: {usage: GAUGE, description: "Number of unresolved issues in project"}
+    databases:
+        sentry:
+            customMetrics:
+                sentry_unresolved_issues:
+                    query: >
+                        SELECT o.slug AS organization, p.slug AS project, COUNT(*) FROM sentry_groupedmessage gm
+                            JOIN sentry_project p ON gm.project_id = p.id
+                            JOIN sentry_organization o ON p.organization_id = o.id
+                        WHERE gm.status = 0
+                        GROUP BY o.slug, p.slug
+                    metrics:
+                        - organization: {usage: LABEL, description: "Sentry organization"}
+                        - project: {usage: LABEL, description: "Sentry project"}
+                        - gauge: {usage: GAUGE, description: "Number of unresolved issues in project"}
 
-        sentry_unresolved_issues_nova:
-            query: >
-                SELECT o.slug AS organization, p.slug AS project, message, COUNT(*) FROM sentry_groupedmessage gm
-                    JOIN sentry_project p ON gm.project_id = p.id
-                    JOIN sentry_organization o ON p.organization_id = o.id
-                WHERE gm.status = 0 AND p.slug = 'nova'
-                GROUP BY o.slug, p.slug, message
-            metrics:
-                - organization: {usage: LABEL, description: "Sentry organization"}
-                - project: {usage: LABEL, description: "Sentry project"}
-                - message: {usage: LABEL, description: "Issue message"}
-                - gauge: {usage: GAUGE, description: "Number of unresolved issues in project"}
+                sentry_unresolved_issues_nova:
+                    query: >
+                        SELECT o.slug AS organization, p.slug AS project, message, COUNT(*) FROM sentry_groupedmessage gm
+                            JOIN sentry_project p ON gm.project_id = p.id
+                            JOIN sentry_organization o ON p.organization_id = o.id
+                        WHERE gm.status = 0 AND p.slug = 'nova'
+                        GROUP BY o.slug, p.slug, message
+                    metrics:
+                        - organization: {usage: LABEL, description: "Sentry organization"}
+                        - project: {usage: LABEL, description: "Sentry project"}
+                        - message: {usage: LABEL, description: "Issue message"}
+                        - gauge: {usage: GAUGE, description: "Number of unresolved issues in project"}
 
 probe:
     enabled: false


### PR DESCRIPTION
The chart now supports multiple databases in the same server, which requires moving some variables around. Full changelog is in `common/postgresql-ng/Chart.yaml`.

- This also removes several obsolete values settings that the respective charts do not recognize anymore.
- This removes the manual override of `postgresql.imageTag`. Manipulating this value is dangerous because the scripts in the image need to match the templates in the Helm chart. Please only use the imageTag specified by the postgresql-ng chart.