### PR TITLE
[nova][vmware-rebalancer] introduce alert for (almost) full vCenters

### DIFF
--- a/openstack/nova/alerts/openstack/vmware-rebalancer.alerts
+++ b/openstack/nova/alerts/openstack/vmware-rebalancer.alerts
@@ -10,8 +10,7 @@ groups:
           support_group: compute
           tier: vmware
           context: "vCenter Capacity {{ $labels.vcenter }}"
-          meta: "The vCenter `{{ $labels.vcenter }}` is (almost) full and only allows scheduling less than 4 VMs."
-          playbook: docs/support/playbook/nova/alerts/alert-vcenter-full.md
+          meta: "The vCenter `{{ $labels.vcenter }}` is (almost) full and only allows scheduling less than 4 VMs of flavor {{ $labels.flavor }}."
         annotations:
-          description: "The vCenter `{{ $labels.vcenter }}` is (almost) full and only allows scheduling less than 4 VMs."
-          summary: VMware Rebalancer Metric to check if the vCenter has enough remaining capacity.
+          description: "The vCenter `{{ $labels.vcenter }}` is (almost) full and only allows scheduling less than 4 VMs of flavor {{ $labels.flavor }}."
+          summary: "VMware Rebalancer Metric to check if the vCenter has enough remaining capacity."

--- a/openstack/nova/alerts/openstack/vmware-rebalancer.alerts
+++ b/openstack/nova/alerts/openstack/vmware-rebalancer.alerts
@@ -2,7 +2,7 @@ groups:
   - name: vmware-rebalancer.alerts
     rules:
       - alert: VcenterLowNumberOfPlaceableVms
-        expr: wm_vmware_rebalancer_placeable_vms_per_vcenter{has_bbs_with_custom_hana_exclusive_host="False",has_bbs_without_custom_hana_exclusive_host="True",flavor="g_c128_m512"} <= 3
+        expr: wm_vmware_rebalancer_placeable_vms_per_vcenter{has_bbs_without_custom_hana_exclusive_host="True",flavor="g_c128_m512"} <= 3
         for: 30m
         labels:
           severity: info

--- a/openstack/nova/alerts/openstack/vmware-rebalancer.alerts
+++ b/openstack/nova/alerts/openstack/vmware-rebalancer.alerts
@@ -1,0 +1,17 @@
+groups:
+  - name: vmware-rebalancer.alerts
+    rules:
+      - alert: VmwareRebalancerLowPlacableVMsPerVcenter
+        expr: wm_vmware_rebalancer_placeable_vms_per_vcenter{has_bbs_with_custom_hana_exclusive_host="False",has_bbs_without_custom_hana_exclusive_host="True",flavor="g_c128_m512"} <= 3
+        for: 30m
+        labels:
+          severity: warning
+          service: compute
+          support_group: compute
+          tier: vmware
+          context: "vCenter Capacity {{ $labels.vcenter }}"
+          meta: "The vCenter `{{ $labels.vcenter }}` is (almost) full and only allows scheduling less than 4 VMs."
+          playbook: docs/support/playbook/nova/alerts/cc3test-alert-vcenter-full.md
+        annotations:
+          description: "The vCenter `{{ $labels.vcenter }}` is (almost) full and only allows scheduling less than 4 VMs."
+          summary: VMware Rebalancer Metric to check if the vCenter has enough remaining capacity.

--- a/openstack/nova/alerts/openstack/vmware-rebalancer.alerts
+++ b/openstack/nova/alerts/openstack/vmware-rebalancer.alerts
@@ -9,7 +9,7 @@ groups:
           service: compute
           support_group: compute
           tier: vmware
-          playbook: docs/devops/alert/vcenter/#alert-vcenterlownumberofplaceablevms
+          playbook: docs/devops/alert/vcenter/#vcenterlownumberofplaceablevms
           context: "vCenter Capacity {{ $labels.vcenter }}"
           meta: "The vCenter `{{ $labels.vcenter }}` is (almost) full and only allows scheduling less than 4 VMs of flavor {{ $labels.flavor }}."
         annotations:

--- a/openstack/nova/alerts/openstack/vmware-rebalancer.alerts
+++ b/openstack/nova/alerts/openstack/vmware-rebalancer.alerts
@@ -1,17 +1,17 @@
 groups:
   - name: vmware-rebalancer.alerts
     rules:
-      - alert: VmwareRebalancerLowPlacableVMsPerVcenter
+      - alert: VcenterLowNumberOfPlaceableVms
         expr: wm_vmware_rebalancer_placeable_vms_per_vcenter{has_bbs_with_custom_hana_exclusive_host="False",has_bbs_without_custom_hana_exclusive_host="True",flavor="g_c128_m512"} <= 3
         for: 30m
         labels:
-          severity: warning
+          severity: info
           service: compute
           support_group: compute
           tier: vmware
           context: "vCenter Capacity {{ $labels.vcenter }}"
           meta: "The vCenter `{{ $labels.vcenter }}` is (almost) full and only allows scheduling less than 4 VMs."
-          playbook: docs/support/playbook/nova/alerts/cc3test-alert-vcenter-full.md
+          playbook: docs/support/playbook/nova/alerts/alert-vcenter-full.md
         annotations:
           description: "The vCenter `{{ $labels.vcenter }}` is (almost) full and only allows scheduling less than 4 VMs."
           summary: VMware Rebalancer Metric to check if the vCenter has enough remaining capacity.

--- a/openstack/nova/alerts/openstack/vmware-rebalancer.alerts
+++ b/openstack/nova/alerts/openstack/vmware-rebalancer.alerts
@@ -5,10 +5,11 @@ groups:
         expr: wm_vmware_rebalancer_placeable_vms_per_vcenter{has_bbs_without_custom_hana_exclusive_host="True",flavor="g_c128_m512"} <= 3
         for: 30m
         labels:
-          severity: info
+          severity: warning
           service: compute
           support_group: compute
           tier: vmware
+          playbook: docs/devops/alert/vcenter/#alert-vcenterlownumberofplaceablevms
           context: "vCenter Capacity {{ $labels.vcenter }}"
           meta: "The vCenter `{{ $labels.vcenter }}` is (almost) full and only allows scheduling less than 4 VMs of flavor {{ $labels.flavor }}."
         annotations:


### PR DESCRIPTION
Consuming the newly introduced metrics from VMware Rebalancer, this change set will alert somebody to take action when VCs run critically low on resources.