### PR TITLE
plutono: fix version bump for postgres-ng 2.0.x

### DIFF
--- a/system/plutono/Chart.lock
+++ b/system/plutono/Chart.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: postgresql-ng
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.5.3
+  version: 2.0.2
 - name: pgbackup
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.2.3
+  version: 1.2.4
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
@@ -14,5 +14,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:85e1e5745417567914a99d7b8f0430e6a1c19e331c38bc054538486cf3b46070
-generated: "2025-05-13T16:30:20.905339686+02:00"
+digest: sha256:5df806aed049abec65031041887f195dab66088d4db9fb2bb50210ac7f90fa01
+generated: "2025-05-14T14:05:40.178042536+02:00"

--- a/system/plutono/Chart.yaml
+++ b/system/plutono/Chart.yaml
@@ -6,10 +6,10 @@ dependencies:
   - name: postgresql-ng
     alias: postgresql
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ^1.1
+    version: ^2
   - name: pgbackup
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ^1.1
+    version: ^1
     condition: pgbackup.enabled
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm


### PR DESCRIPTION
I did not notice that the Chart.yaml here had a pin on major version.