### PR TITLE
[mariadb] Set `max_connect_errors` config option to the maximum value

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.24.1 - 2025/05/14
+* Set `max_connect_errors` option in my.cnf to maximal possible value `4294967295`.
+* Set `skip_name_resolve` option to `ON` and `host_cache_size` to 0.
+
+This will prevent blocking database connections because of the failed monitor checks or other network issues.
+
+See related documentation at https://mariadb.com/kb/en/server-system-variables/#max_connect_errors
+
 ## v0.24.0 - 2025/04/16
 * MariaDB has been updated to the 10.6.21 version
   * delete removed `innodb_thread_concurrency` variable from my.cnf

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,6 +2,6 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.24.0
+version: 0.24.1
 # scripts/docker-entyrpoint.sh should be updated when appVersion is updated
 appVersion: 10.6.21

--- a/common/mariadb/templates/etc-configmap.yaml
+++ b/common/mariadb/templates/etc-configmap.yaml
@@ -9,6 +9,9 @@ data:
     [mysqld]
     bind_address              = 0.0.0.0
     max_connections           = {{ .Values.max_connections | default 1024 }}
+    max_connect_errors        = 4294967295
+    skip_name_resolve         = ON
+    host_cache_size           = 0
     connect_timeout           = 30
     wait_timeout              = 3800
     interactive_timeout       = 1800


### PR DESCRIPTION
* Set `max_connect_errors` option in my.cnf to maximal possible value of `4294967295`.
* Set `skip_name_resolve` option to `ON` and `host_cache_size` to 0.

This will prevent blocking database connections because of the failed monitor checks or other network issues.

See related documentation at https://mariadb.com/kb/en/server-system-variables/#max_connect_errors