### PR TITLE
chore(opensearch-logs): fine tune rollover values for datastreams

### DIFF
--- a/system/opensearch-logs/Chart.lock
+++ b/system/opensearch-logs/Chart.lock
@@ -28,6 +28,6 @@ dependencies:
   version: 0.1.3
 - name: prober
   repository: file://vendor/prober
-  version: 0.1.0
-digest: sha256:f2a721ac50624a070b645dfbb6bd2afb726e27dd87d2ec90df360c5fc3c63f2f
-generated: "2025-04-23T09:23:10.702178+02:00"
+  version: 0.1.1
+digest: sha256:46a39af21a0638546e67952cb37288f402b6b7f3dd620f4fb66c9595af7ed205
+generated: "2025-04-25T15:31:01.672858+02:00"

--- a/system/opensearch-logs/Chart.yaml
+++ b/system/opensearch-logs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for the Opensearch stack
 name: opensearch-logs
-version: 0.0.40
+version: 0.0.39
 home: https://github.com/sapcc/helm-charts/tree/master/system/opensearch-logs
 dependencies:
   - name: opensearch

--- a/system/opensearch-logs/Chart.yaml
+++ b/system/opensearch-logs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for the Opensearch stack
 name: opensearch-logs
-version: 0.0.38
+version: 0.0.39
 home: https://github.com/sapcc/helm-charts/tree/master/system/opensearch-logs
 dependencies:
   - name: opensearch
@@ -45,4 +45,5 @@ dependencies:
     version: 0.1.3
   - name: prober
     repository: file://vendor/prober
-    version: 0.1.0
+    version: 0.1.1
+    condition: prober.enabled

--- a/system/opensearch-logs/Chart.yaml
+++ b/system/opensearch-logs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for the Opensearch stack
 name: opensearch-logs
-version: 0.0.39
+version: 0.0.40
 home: https://github.com/sapcc/helm-charts/tree/master/system/opensearch-logs
 dependencies:
   - name: opensearch

--- a/system/opensearch-logs/values.yaml
+++ b/system/opensearch-logs/values.yaml
@@ -12,40 +12,40 @@ global:
     enabled: false
     alerts:
       min_index_age: "365d"
-      min_size: "30gb"
-      min_doc_count: 50000000
+      min_size: "20gb"
+      min_doc_count: 10000000
     deployments:
       min_index_age: "365d"
       min_size: "30gb"
       min_doc_count: 50000000
     storage:
       min_index_age: "7d"
-      min_size: "30gb"
-      min_doc_count: 50000000
+      min_size: "80gb"
+      min_doc_count: 100000000
     compute:
       min_index_age: "7d"
-      min_size: "30gb"
-      min_doc_count: 50000000
+      min_size: "80gb"
+      min_doc_count: 100000000
     otel:
       min_index_age: "7d"
-      min_size: "30gb"
-      min_doc_count: 50000000
+      min_size: "20gb"
+      min_doc_count: 10000000
     audit:
       min_index_age: "7d"
-      min_size: "30gb"
-      min_doc_count: 50000000
+      min_size: "20gb"
+      min_doc_count: 10000000
     logs:
       min_index_age: "7d"
-      min_size: "30gb"
-      min_doc_count: 50000000
+      min_size: "80gb"
+      min_doc_count: 100000000
     logs_swift:
       min_index_age: "14d"
       min_size: "120gb"
       min_doc_count: 200000000
     jump:
       min_index_age: "7d"
-      min_size: "30gb"
-      min_doc_count: 50000000
+      min_size: "80gb"
+      min_doc_count: 100000000
   index:
     ism_indexes: "logstash"
     schema_version: "1"

--- a/system/opensearch-logs/vendor/prober/Chart.yaml
+++ b/system/opensearch-logs/vendor/prober/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prober
-version: 0.1.0
+version: 0.1.1
 description: Probes for Opensearch endpoints
 maintainers:
   - name: Olaf Heydorn

--- a/system/opensearch-logs/vendor/prober/templates/probe.yaml
+++ b/system/opensearch-logs/vendor/prober/templates/probe.yaml
@@ -30,6 +30,9 @@ spec:
         {{ if $values.global.region -}}
         region: {{ $values.global.region }}
         {{- end }}
+        {{ if $values.global.cluster -}}
+        cluster: {{ $values.global.cluster }}
+        {{- end }}
 ---
 {{ end -}}
 {{ end -}}


### PR DESCRIPTION
Adjust rollover values for datastreams to avoid undersized shards, improve shard efficiency and resource utilization

Previous: 30 GB per index (4 shards ≈ 7–8 GB per shard)
New: 80 GB per index (4 shards ≈ 20 GB per shard)

Exclude / reduce low volume / testing indexes `alerts`, `otel` and `audit`.