### PR TITLE
[keystone] bump database dependencies

### DIFF
--- a/openstack/keystone/Chart.lock
+++ b/openstack/keystone/Chart.lock
@@ -1,16 +1,16 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.23.0
+  version: 0.24.1
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.3.1
+  version: 0.4.0
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.6.9
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.4.3
+  version: 0.4.4
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:a5ef87d5dc095526d1a489fcf8590fc70f8e459d77d9b65c0a8dae7f720255de
-generated: "2025-04-14T11:52:28.917098+03:00"
+digest: sha256:9f55da11451e22686afaeb217192f90aa535efdfdcf68ed137e24ec59aee11aa
+generated: "2025-05-15T17:19:42.657768+03:00"

--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -9,24 +9,24 @@ maintainers:
 name: keystone
 sources:
   - https://github.com/sapcc/keystone
-version: 0.10.2
+version: 0.10.3
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.23.0
+    version: 0.24.1
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.3.1
+    version: 0.4.0
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.6.9
   - condition: mysql_metrics.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.4.3
+    version: 0.4.4
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0


### PR DESCRIPTION
* update mariadb to 0.24.1

Updates mariadb to 10.6.21 and seta max_connection_errors options to prevent blocking database connections because of the failed monitor checks or other network issues

* update pxc-db to 0.4.0

Updates pxc custom resource to 1.18.0 version

* update mysql-metrics to 0.4.4

Adds reloader annotation to sql-exporter deployment