### PR TITLE
[prometheus-alertmanager-operated] - Slack alerting for bedrock removed region filter

### DIFF
--- a/global/prometheus-alertmanager-operated/Chart.yaml
+++ b/global/prometheus-alertmanager-operated/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 description: Prometheus Alertmanager via operator.
 name: prometheus-alertmanager-operated
-version: 4.6.0
+version: 4.6.1
 
 dependencies:
   - alias: prometheus-alertmanager

--- a/global/prometheus-alertmanager-operated/templates/am-config-route-slack.yaml
+++ b/global/prometheus-alertmanager-operated/templates/am-config-route-slack.yaml
@@ -477,8 +477,9 @@ spec:
             matchType: "="
             value: critical
           # Removed for testing purpose
-          # - name: region
-          #   matchType: "=~"
+          - name: region
+            matchType: "=~"
+            value: {{ .Values.regions | join "|" }}
           #   value: {{ without .Values.regions "qa-de-1" | join "|" }}
           - name: support_group
             matchType: "="
@@ -497,8 +498,9 @@ spec:
             matchType: "="
             value: warning
           # Removed for testing purpose
-          # - name: region
-          #   matchType: "=~"
+          - name: region
+            matchType: "=~"
+            value: {{ .Values.regions | join "|" }}
           #   value: {{ without .Values.regions "qa-de-1" | join "|" }}
           - name: support_group
             matchType: "="
@@ -517,8 +519,9 @@ spec:
             matchType: "="
             value: info
           # Removed for testing purpose
-          # - name: region
-          #   matchType: "=~"
+          - name: region
+            matchType: "=~"
+            value: {{ .Values.regions | join "|" }}
           #   value: {{ without .Values.regions "qa-de-1" | join "|" }}
           - name: support_group
             matchType: "="

--- a/global/prometheus-alertmanager-operated/templates/am-config-route-slack.yaml
+++ b/global/prometheus-alertmanager-operated/templates/am-config-route-slack.yaml
@@ -476,9 +476,10 @@ spec:
           - name: severity
             matchType: "="
             value: critical
-          - name: region
-            matchType: "=~"
-            value: {{ without .Values.regions "qa-de-1" | join "|" }}
+          # Removed for testing purpose
+          # - name: region
+          #   matchType: "=~"
+          #   value: {{ without .Values.regions "qa-de-1" | join "|" }}
           - name: support_group
             matchType: "="
             value: compute
@@ -495,9 +496,10 @@ spec:
           - name: severity
             matchType: "="
             value: warning
-          - name: region
-            matchType: "=~"
-            value: {{ without .Values.regions "qa-de-1" | join "|" }}
+          # Removed for testing purpose
+          # - name: region
+          #   matchType: "=~"
+          #   value: {{ without .Values.regions "qa-de-1" | join "|" }}
           - name: support_group
             matchType: "="
             value: compute
@@ -514,9 +516,10 @@ spec:
           - name: severity
             matchType: "="
             value: info
-          - name: region
-            matchType: "=~"
-            value: {{ without .Values.regions "qa-de-1" | join "|" }}
+          # Removed for testing purpose
+          # - name: region
+          #   matchType: "=~"
+          #   value: {{ without .Values.regions "qa-de-1" | join "|" }}
           - name: support_group
             matchType: "="
             value: compute

--- a/global/prometheus-alertmanager-operated/templates/am-config-route-slack.yaml
+++ b/global/prometheus-alertmanager-operated/templates/am-config-route-slack.yaml
@@ -476,10 +476,10 @@ spec:
           - name: severity
             matchType: "="
             value: critical
-          # Removed for testing purpose
           - name: region
             matchType: "=~"
             value: {{ .Values.regions | join "|" }}
+          # Removed for testing purpose
           #   value: {{ without .Values.regions "qa-de-1" | join "|" }}
           - name: support_group
             matchType: "="
@@ -497,10 +497,10 @@ spec:
           - name: severity
             matchType: "="
             value: warning
-          # Removed for testing purpose
           - name: region
             matchType: "=~"
             value: {{ .Values.regions | join "|" }}
+          # Removed for testing purpose
           #   value: {{ without .Values.regions "qa-de-1" | join "|" }}
           - name: support_group
             matchType: "="
@@ -518,10 +518,10 @@ spec:
           - name: severity
             matchType: "="
             value: info
-          # Removed for testing purpose
           - name: region
             matchType: "=~"
             value: {{ .Values.regions | join "|" }}
+          # Removed for testing purpose
           #   value: {{ without .Values.regions "qa-de-1" | join "|" }}
           - name: support_group
             matchType: "="


### PR DESCRIPTION
Removed region filter `qa-de-1` for bedrock alerting channels:
- `slack_bedrock_critical`
- `slack_bedrock_warning`
- `slack_bedrock_info`