### PR TITLE
[glance] update database dependencies

### DIFF
--- a/openstack/glance/Chart.lock
+++ b/openstack/glance/Chart.lock
@@ -1,16 +1,16 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.23.0
+  version: 0.24.1
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.3.1
+  version: 0.4.0
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.6.9
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.4.3
+  version: 0.4.4
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.26.0
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:6344c042b053445bc65d25bb487f728590647bdd23494f8a34bb863638632d95
-generated: "2025-04-14T12:32:34.515418+03:00"
+digest: sha256:2d4d8b5572f05fb3033a088afdfc054deb55c82b212f130c701701456da8da2d
+generated: "2025-05-16T14:15:19.022625+03:00"

--- a/openstack/glance/Chart.yaml
+++ b/openstack/glance/Chart.yaml
@@ -4,24 +4,24 @@ appVersion: dalmatian
 description: A Helm chart Openstack Glance
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Glance/OpenStack_Project_Glance_vertical.png
 name: glance
-version: 0.7.1
+version: 0.7.2
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.23.0
+    version: 0.24.1
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.3.1
+    version: 0.4.0
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.6.9
   - condition: mariadb.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.4.3
+    version: 0.4.4
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.26.0


### PR DESCRIPTION
* update mariadb to 0.24.1

Updates mariadb to 10.6.21 and set max_connection_errors options to avoid prevent blocking database connections because of the failed monitor checks or other network issues

* update pxc-db to 0.4.0

Updates pxc custom resource to 1.18.0 version

* update mysql-metrics to 0.4.4

Adds reloader annotation to sql-exporter deployment