### PR TITLE
[cinder] update database dependencies

### DIFF
--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.26.0
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.23.0
+  version: 0.24.1
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.4.0
@@ -26,5 +26,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:8c273a6be583a0527fe604362769daf3668ab4de9b4f7b6f5a556e3526225b22
-generated: "2025-05-14T12:45:10.74762+03:00"
+digest: sha256:0c7b59abe09627509c2b72c0ae250e95ec14c707ecd3f3a4a3a4595f63e4e662
+generated: "2025-05-16T14:19:45.573191+03:00"

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -3,14 +3,14 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Cinder/OpenStack_Project_Cinder_mascot.png
 name: cinder
-version: 0.3.0
+version: 0.3.1
 dependencies:
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.26.0
   - name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.23.0
+    version: 0.24.1
     condition: mariadb.enabled
   - name: pxc-db
     alias: pxc_db


### PR DESCRIPTION
* update mariadb to 0.24.1

Updates mariadb to 10.6.21 and set max_connection_errors options to avoid prevent blocking database connections because of the failed monitor checks or other network issues