### PR TITLE
[manila] update shared dependencies

### DIFF
--- a/openstack/manila/Chart.lock
+++ b/openstack/manila/Chart.lock
@@ -4,27 +4,27 @@ dependencies:
   version: 1.1.0
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.22.0
+  version: 0.24.1
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.3.1
+  version: 0.4.0
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.6.9
+  version: 0.6.10
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.4.3
+  version: 0.4.4
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.17.2
+  version: 0.18.0
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 2.2.2
+  version: 2.2.7
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.26.0
-digest: sha256:c2a2f70b3a81cdf1c463fec3f302ab028dcc2144934c0505870bed0d3a9bdadd
-generated: "2025-04-15T14:56:53.311794+02:00"
+digest: sha256:700790f32dbd4cbb28f64e372508d3260fea1982b8734784bca62018b53266cd
+generated: "2025-05-16T17:54:25.801994+03:00"

--- a/openstack/manila/Chart.yaml
+++ b/openstack/manila/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 name: manila
 sources:
   - https://github.com/sapcc/manila
-version: 0.5.6
+version: 0.5.7
 dependencies:
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
@@ -18,12 +18,12 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.22.0
+    version: ~0.24.1
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.3.1
+    version: ~0.4.0
   - condition: memcached.enabled
     name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
@@ -37,7 +37,7 @@ dependencies:
     version: ~1.0.0
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.17.1
+    version: ~0.18.0
   - name: redis
     alias: api-ratelimit-redis
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm


### PR DESCRIPTION
* update mariadb to 0.24.1

Updates mariadb to 10.6.21 and set max_connection_errors options to avoid prevent blocking database connections because of the failed monitor checks or other network issues

Adds reloader annotation for maria-back-me-up

* update pxc-db to 0.4.0

Updates pxc custom resource to 1.18.0 version

* update mysql-metrics to 0.4.4

Adds reloader annotation to sql-exporter deployment

* update memcached to 0.6.10

Adds option to set vpa main container

* update rabbitmq to 0.18.0

Updates RabbitMQ to 4.1.0 release

* update redis to 2.2.6

Updates valkey to 8.1.1, makes rbacs for the current namespace only, updates redis exporter to v1.72.0