### PR TITLE
[neutron] update database dependencies

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -1,13 +1,13 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.24.0
+  version: 0.24.1
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.6.9
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.4.3
+  version: 0.4.4
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.17.1
@@ -29,5 +29,5 @@ dependencies:
 - name: ovsdb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
-digest: sha256:85be85c3b5aa337ed3d5bfb5e15189f5850cb05b04df57e5933f6ac9dcd6bba2
-generated: "2025-05-02T10:42:53.883947-04:00"
+digest: sha256:1618b4ed15d37d4a5c8f6b69165e29c6af7d2b54961cf291e8ed4d22538456a1
+generated: "2025-05-16T15:00:40.586381+03:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -1,20 +1,20 @@
 apiVersion: v2
 description: A Helm chart for Openstack Neutron
 name: neutron
-version: 0.2.5
+version: 0.2.6
 appVersion: "yoga"
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.24.0
+    version: 0.24.1
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.6.9
   - condition: mariadb.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.4.3
+    version: 0.4.4
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.17.1


### PR DESCRIPTION
* update mariadb chart from 0.24.0 to 0.24.1

Sets max_connection_errors options to avoid prevent blocking database connections because of the failed monitor checks or other network issues.

* update mysql-metrics chart to 0.4.4

Adds reloader annotation to sql-exporter deployment