### PR TITLE
[ironic] bump shared dependencies

### DIFF
--- a/openstack/ironic/Chart.lock
+++ b/openstack/ironic/Chart.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.23.0
+  version: 0.24.1
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.3.1
+  version: 0.4.0
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.6.10
@@ -16,7 +16,7 @@ dependencies:
   version: 1.0.0
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.17.2
+  version: 0.18.0
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.26.0
@@ -26,5 +26,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:5e73fff23c7acd944bed8468b24cd02da89f31363130bf9f44e8cea65a6cafff
-generated: "2025-04-21T12:39:32.148803+03:00"
+digest: sha256:9c9b9b30cd278e27e8540e72837aa57b0e085a81a7dd6a80929b0ef6c4accd2b
+generated: "2025-05-16T15:14:03.406972+03:00"

--- a/openstack/ironic/Chart.yaml
+++ b/openstack/ironic/Chart.yaml
@@ -2,17 +2,17 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Ironic/OpenStack_Project_Ironic_vertical.png
 name: ironic
-version: 0.2.3
+version: 0.2.4
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.23.0
+    version: ~0.24.1
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.3.1
+    version: ~0.4.0
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: ~0.6.8
@@ -25,7 +25,7 @@ dependencies:
     version: ~1.0.0
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.17.1
+    version: ~0.18.0
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: ~0.26.0


### PR DESCRIPTION
* update mariadb to 0.24.1

Updates mariadb to 10.6.21 and set max_connection_errors options to avoid prevent blocking database connections because of the failed monitor checks or other network issues

* update pxc-db to 0.4.0

Updates pxc custom resource to 1.18.0 version

* update rabbitmq to 0.18.0

Updates RabbitMQ to 4.1.0 release