### PR TITLE
[cronus][rabbitmq] update rabbitmq chart dependency

### DIFF
--- a/openstack/cronus/Chart.lock
+++ b/openstack/cronus/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.11.0
+  version: 0.19.1
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.11.0
+  version: 0.19.1
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
 - name: maillog
   repository: file://sub-charts/maillog
   version: 0.2.2
-digest: sha256:1636ae8aa55421223f8b62ba2642438a3ceb2d46347c044e668182481589cfed
-generated: "2025-03-24T12:31:51.556338+01:00"
+digest: sha256:5af71597b04cc85f967e397df761a991e9a5c606dfdb590aec27e87a82be4985
+generated: "2025-08-06T13:47:31.929783+03:00"

--- a/openstack/cronus/Chart.yaml
+++ b/openstack/cronus/Chart.yaml
@@ -1,14 +1,14 @@
 apiVersion: v2
 name: cronus
 description: proxying hyperscaler statless services
-version: 0.1.15
+version: 0.1.16
 dependencies:
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.11.0
+    version: 0.19.1
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.11.0
+    version: 0.19.1
     alias: rhea_rabbitmq
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/cronus/ci/test-values.yaml
+++ b/openstack/cronus/ci/test-values.yaml
@@ -16,8 +16,6 @@ rhea_rabbitmq:
     default:
       user: rhea_rabbitmq
       password: super-secret
-  metrics:
-    password: super-secret
   alerts:
     support_group: test
 
@@ -36,8 +34,6 @@ rabbitmq:
     default:
       user: rabbitmq
       password: super-secret
-  metrics:
-    password: super-secret
   alerts:
     support_group: test
 
@@ -46,7 +42,5 @@ rabbitmq_notifications:
     default:
       user: rabbitmq
       password: super-secret
-  metrics:
-    password: super-secret
   alerts:
     support_group: test

--- a/openstack/cronus/values.yaml
+++ b/openstack/cronus/values.yaml
@@ -180,7 +180,7 @@ config:
   technicalUsername: aws-username
   iamPolicies: {}
   _iamPolicies: #example for multiple policies
-    cronusSes: | 
+    cronusSes: |
         {
           "Version": "2012-10-17",
           "Statement": [
@@ -209,7 +209,7 @@ config:
             }
           ]
         }
-    cronusSqs: |    
+    cronusSqs: |
         {
           "Version": "2012-10-17",
           "Statement": [
@@ -479,8 +479,6 @@ rabbitmq:
     size: 10Gi
   metrics:
     enabled: true
-    sidecar:
-      enabled: false
     enableDetailedMetrics: true
     enablePerObjectMetrics: true
 rhea:
@@ -562,8 +560,6 @@ rhea_rabbitmq:
     size: 10Gi
   metrics:
     enabled: true
-    sidecar:
-      enabled: false
     enableDetailedMetrics: true
     enablePerObjectMetrics: true
 


### PR DESCRIPTION
Update rabbitmq chart dependency to 0.19.1 version

* Updates RabbitMQ from 3.13.6 to 4.1.3
* Adds user-credential-updater sidecar
* Updates labels for all chart resources