### PR TITLE
chore(elektra): assign resource_service role to dashboard user as cloud-admin

### DIFF
--- a/openstack/elektra/templates/seed.yaml
+++ b/openstack/elektra/templates/seed.yaml
@@ -34,6 +34,7 @@ spec:
       {{- end }}
 
   roles:
+  - name: cloud_resource_admin
   - name: cloud_compute_admin
   - name: cloud_network_admin
   - name: cloud_dns_admin
@@ -62,6 +63,8 @@ spec:
         role: service
       - project: cloud_admin@ccadmin
         role: admin
+      - project: cloud_admin@ccadmin
+        role: cloud_resource_admin        
       - project: cloud_admin@ccadmin
         role: cloud_compute_admin
       - project: cloud_admin@ccadmin

--- a/openstack/elektra/templates/seed.yaml
+++ b/openstack/elektra/templates/seed.yaml
@@ -34,7 +34,7 @@ spec:
       {{- end }}
 
   roles:
-  - name: cloud_resource_admin
+  - name: resource_service
   - name: cloud_compute_admin
   - name: cloud_network_admin
   - name: cloud_dns_admin
@@ -64,7 +64,7 @@ spec:
       - project: cloud_admin@ccadmin
         role: admin
       - project: cloud_admin@ccadmin
-        role: cloud_resource_admin        
+        role: resource_service        
       - project: cloud_admin@ccadmin
         role: cloud_compute_admin
       - project: cloud_admin@ccadmin


### PR DESCRIPTION
## Summary

As a cloud admin, the dashboard user should be granted the `resource_service` role to allow usage of the Lime email service. The role is granted via the group CCADMIN_CLOUD_ADMINS@ccadmin.








