### PR TITLE
[prometheus-rules] - prometheus-vmware-rules | Updated template for bedrock labeling

### DIFF
--- a/prometheus-rules/prometheus-vmware-rules/Chart.yaml
+++ b/prometheus-rules/prometheus-vmware-rules/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A collection of Prometheus alert rules.
 name: prometheus-vmware-rules
-version: 1.3.0
+version: 1.4.0
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/prometheus-rules/prometheus-vmware-rules/Chart.yaml
+++ b/prometheus-rules/prometheus-vmware-rules/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A collection of Prometheus alert rules.
 name: prometheus-vmware-rules
-version: 1.4.0
+version: 1.3.1
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/prometheus-rules/prometheus-vmware-rules/templates/prometheus-alerts.yaml
+++ b/prometheus-rules/prometheus-vmware-rules/templates/prometheus-alerts.yaml
@@ -34,6 +34,7 @@ Replace expression for alerts matching alert name in $bedrockAlerts
       {{- $mappingKey := (printf "%s" (get $bedrockAlerts $rule.alert)) }}
       {{- $updatedExpression := (include "bedrockConfirm.expr" (list $rule.expr $mappingKey)) }}
       {{- $_ := set $rule "expr" $updatedExpression }}
+      {{- $_ := set $rule.labels "bedrock" "{{ $labels.bedrock }}" }}
 {{- end }} 
 {{- end }}
 {{- end }}


### PR DESCRIPTION
The current code just templates the expression we need to add also the label for bedrock.

Testing done:
- [x] local helm template
- [x] lint code
- [x] updated template manual in `qa-de-1`
- [x] check labels are assigned correctly in alertmanager on `qa-de-1` after manual changes

When `bedrock: nil`, the label simply doesn't appear in Alertmanager, which is acceptable.
Can you confirm that the same behavior is implemented across all environments except `qa-de-1`?