### PR TITLE
[audit-logs] Adds node affinities, default values, secret names

### DIFF
--- a/system/audit-logs/values.yaml
+++ b/system/audit-logs/values.yaml
@@ -66,9 +66,6 @@ fluent_audit_container:
   resources:
     limits:
       memory: 500Mi
-    requests:
-      cpu: 100m
-      memory: 250Mi
   forwarding:
     keystone:
       host: none
@@ -88,9 +85,6 @@ fluent_audit_systemd:
   resources:
     limits:
       memory: 500Mi
-    requests:
-      cpu: 100m
-      memory: 250Mi
   metrics_port: 24231
   alerts:
     enabled: false

--- a/system/audit-logs/values.yaml
+++ b/system/audit-logs/values.yaml
@@ -8,12 +8,22 @@ owner-info:
   helm-chart-url: "https://github.com/sapcc/helm-charts/tree/master/system/audit-logs"
 
 global:
-  linkerd_requested: false
   https_port: 443
   prometheus: kubernetes
+  logstash_external_http_user: DEFINED-IN-SECRETS
+  logstash_external_http_password: DEFINED-IN-SECRETS
+  linkerd_requested: false
   forwarding:
     audit:
-      host: Non
+      host: DEFINED-IN-SECRETS
+    audit_awx:
+      host: DEFINED-IN-SECRETS
+    audit_tools:
+      host: DEFINED-IN-SECRETS
+    audit_auditbeat:
+      host: DEFINED-IN-SECRETS
+  probe_targets:
+    - DEFINED-IN-SECRETS
 
 linkerd-support:
   annotate_namespace: true

--- a/system/audit-logs/values.yaml
+++ b/system/audit-logs/values.yaml
@@ -24,6 +24,31 @@ global:
       host: DEFINED-IN-SECRETS
   probe_targets:
     - DEFINED-IN-SECRETS
+  region: DEFINED-IN-SECRETS
+  tld: DEFINED-IN-SECRETS
+  cluster: DEFINED-IN-SECRETS
+  clusterType: DEFINED-IN-SECRETS
+  vaultBaseURL: DEFINED-IN-SECRETS
+  alternateRegion: DEFINED-IN-SECRETS
+  registry: DEFINED-IN-SECRETS
+  registryAlternateRegion: DEFINED-IN-SECRETS
+  dockerHubMirror: DEFINED-IN-SECRETS
+  dockerHubMirrorAlternateRegion: DEFINED-IN-SECRETS
+  crNetappIoMirror: DEFINED-IN-SECRETS
+  crNetappIoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  elasticCoMirror: DEFINED-IN-SECRETS
+  elasticCoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  gcrIoMirror: DEFINED-IN-SECRETS
+  gcrIoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  ghcrIoMirror: DEFINED-IN-SECRETS
+  ghcrIoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  registryK8sIoMirror: DEFINED-IN-SECRETS
+  registryK8sIoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  quayIoMirror: DEFINED-IN-SECRETS
+  quayIoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  zalandoMirror: DEFINED-IN-SECRETS
+  zalandoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  linkerd_enabled: DEFINED-IN-SECRETS
 
 linkerd-support:
   annotate_namespace: true

--- a/system/audit-logs/vendor/audit-poller/values.yaml
+++ b/system/audit-logs/vendor/audit-poller/values.yaml
@@ -18,3 +18,46 @@ sidecar:
     imageTag: 3.1.4
     metricsPort: 8080
 metricsPort: 9298
+
+global:
+  https_port: 443
+  prometheus: kubernetes
+  logstash_external_http_user: DEFINED-IN-SECRETS
+  logstash_external_http_password: DEFINED-IN-SECRETS
+  linkerd_requested: false
+  forwarding:
+    audit:
+      host: DEFINED-IN-SECRETS
+    audit_awx:
+      host: DEFINED-IN-SECRETS
+    audit_tools:
+      host: DEFINED-IN-SECRETS
+    audit_auditbeat:
+      host: DEFINED-IN-SECRETS
+  probe_targets:
+    - DEFINED-IN-SECRETS
+  region: DEFINED-IN-SECRETS
+  tld: DEFINED-IN-SECRETS
+  cluster: DEFINED-IN-SECRETS
+  clusterType: DEFINED-IN-SECRETS
+  vaultBaseURL: DEFINED-IN-SECRETS
+  alternateRegion: DEFINED-IN-SECRETS
+  registry: DEFINED-IN-SECRETS
+  registryAlternateRegion: DEFINED-IN-SECRETS
+  dockerHubMirror: DEFINED-IN-SECRETS
+  dockerHubMirrorAlternateRegion: DEFINED-IN-SECRETS
+  crNetappIoMirror: DEFINED-IN-SECRETS
+  crNetappIoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  elasticCoMirror: DEFINED-IN-SECRETS
+  elasticCoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  gcrIoMirror: DEFINED-IN-SECRETS
+  gcrIoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  ghcrIoMirror: DEFINED-IN-SECRETS
+  ghcrIoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  registryK8sIoMirror: DEFINED-IN-SECRETS
+  registryK8sIoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  quayIoMirror: DEFINED-IN-SECRETS
+  quayIoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  zalandoMirror: DEFINED-IN-SECRETS
+  zalandoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  linkerd_enabled: DEFINED-IN-SECRETS

--- a/system/audit-logs/vendor/fluent-audit-container/templates/daemonset.yaml
+++ b/system/audit-logs/vendor/fluent-audit-container/templates/daemonset.yaml
@@ -61,7 +61,7 @@ spec:
             path: /var/lib/docker/containers
       containers:
         - name: fluent-audit-container
-          image: {{.Values.global.registry}}/elk-fluent:{{.Values.image_version}}
+          image: "{{.Values.global.registry}}/elk-fluent:{{.Values.image_version}}"
           imagePullPolicy: IfNotPresent
           env:
             - name: NAMESPACE

--- a/system/audit-logs/vendor/fluent-audit-container/templates/daemonset.yaml
+++ b/system/audit-logs/vendor/fluent-audit-container/templates/daemonset.yaml
@@ -30,6 +30,24 @@ spec:
       serviceAccountName: fluentd-audit
       tolerations:
       - operator: "Exists"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: cloud.sap/deployment-state
+                operator: NotIn
+                values:
+                - reinstalling
+              - key: cloud.sap/esx-in-maintenance
+                operator: NotIn
+                values:
+                - alarm
+                - "true"
+              - key: cloud.sap/maintenance-state
+                operator: NotIn
+                values:
+                - in-maintenance
       terminationGracePeriodSeconds: 30
       volumes:
         - name: fluent-bin

--- a/system/audit-logs/vendor/fluent-audit-container/values.yaml
+++ b/system/audit-logs/vendor/fluent-audit-container/values.yaml
@@ -1,0 +1,6 @@
+fluent_audit_container:
+  enabled: DEFINED-IN-SECRETS
+  alerts:
+    enabled: DEFINED-IN-SECRETS
+  default_container_logs: []
+  additional_container_logs: []

--- a/system/audit-logs/vendor/fluent-audit-container/values.yaml
+++ b/system/audit-logs/vendor/fluent-audit-container/values.yaml
@@ -4,3 +4,46 @@ fluent_audit_container:
     enabled: DEFINED-IN-SECRETS
   default_container_logs: []
   additional_container_logs: []
+
+global:
+  https_port: 443
+  prometheus: kubernetes
+  logstash_external_http_user: DEFINED-IN-SECRETS
+  logstash_external_http_password: DEFINED-IN-SECRETS
+  linkerd_requested: false
+  forwarding:
+    audit:
+      host: DEFINED-IN-SECRETS
+    audit_awx:
+      host: DEFINED-IN-SECRETS
+    audit_tools:
+      host: DEFINED-IN-SECRETS
+    audit_auditbeat:
+      host: DEFINED-IN-SECRETS
+  probe_targets:
+    - DEFINED-IN-SECRETS
+  region: DEFINED-IN-SECRETS
+  tld: DEFINED-IN-SECRETS
+  cluster: DEFINED-IN-SECRETS
+  clusterType: DEFINED-IN-SECRETS
+  vaultBaseURL: DEFINED-IN-SECRETS
+  alternateRegion: DEFINED-IN-SECRETS
+  registry: DEFINED-IN-SECRETS
+  registryAlternateRegion: DEFINED-IN-SECRETS
+  dockerHubMirror: DEFINED-IN-SECRETS
+  dockerHubMirrorAlternateRegion: DEFINED-IN-SECRETS
+  crNetappIoMirror: DEFINED-IN-SECRETS
+  crNetappIoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  elasticCoMirror: DEFINED-IN-SECRETS
+  elasticCoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  gcrIoMirror: DEFINED-IN-SECRETS
+  gcrIoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  ghcrIoMirror: DEFINED-IN-SECRETS
+  ghcrIoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  registryK8sIoMirror: DEFINED-IN-SECRETS
+  registryK8sIoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  quayIoMirror: DEFINED-IN-SECRETS
+  quayIoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  zalandoMirror: DEFINED-IN-SECRETS
+  zalandoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  linkerd_enabled: DEFINED-IN-SECRETS

--- a/system/audit-logs/vendor/fluent-audit-systemd/templates/daemonset.yaml
+++ b/system/audit-logs/vendor/fluent-audit-systemd/templates/daemonset.yaml
@@ -26,6 +26,24 @@ spec:
     spec:
       tolerations:
       - operator: "Exists"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: cloud.sap/deployment-state
+                operator: NotIn
+                values:
+                - reinstalling
+              - key: cloud.sap/esx-in-maintenance
+                operator: NotIn
+                values:
+                - alarm
+                - "true"
+              - key: cloud.sap/maintenance-state
+                operator: NotIn
+                values:
+                - in-maintenance
       volumes:
         - name: fluent-etc
           configMap:

--- a/system/audit-logs/vendor/fluent-audit-systemd/templates/daemonset.yaml
+++ b/system/audit-logs/vendor/fluent-audit-systemd/templates/daemonset.yaml
@@ -53,7 +53,7 @@ spec:
             path: /var/log
       containers:
         - name: fluent-audit-systemd
-          image: {{.Values.global.registry}}/elk-fluent:{{.Values.image_version}}
+          image: "{{.Values.global.registry}}/elk-fluent:{{.Values.image_version}}"
           imagePullPolicy: IfNotPresent
           env:
             - name: NAMESPACE

--- a/system/audit-logs/vendor/fluent-audit-systemd/templates/prometheus-alerts.yaml
+++ b/system/audit-logs/vendor/fluent-audit-systemd/templates/prometheus-alerts.yaml
@@ -1,4 +1,5 @@
 {{- $values := .Values }}
+{{- if $values.alerts }}
 {{- if $values.alerts.enabled }}
 {{- range $path, $bytes := .Files.Glob "alerts/*.alerts" }}
 ---
@@ -16,5 +17,6 @@ metadata:
 spec:
 {{ printf "%s" $bytes | indent 2 }}
 
+{{- end }}
 {{- end }}
 {{- end }}

--- a/system/audit-logs/vendor/fluent-audit-systemd/values.yaml
+++ b/system/audit-logs/vendor/fluent-audit-systemd/values.yaml
@@ -1,0 +1,2 @@
+fluent_audit_systemd:
+  enabled: DEFINED-IN-SECRETS

--- a/system/audit-logs/vendor/fluent-audit-systemd/values.yaml
+++ b/system/audit-logs/vendor/fluent-audit-systemd/values.yaml
@@ -1,2 +1,45 @@
 fluent_audit_systemd:
   enabled: DEFINED-IN-SECRETS
+
+global:
+  https_port: 443
+  prometheus: kubernetes
+  logstash_external_http_user: DEFINED-IN-SECRETS
+  logstash_external_http_password: DEFINED-IN-SECRETS
+  linkerd_requested: false
+  forwarding:
+    audit:
+      host: DEFINED-IN-SECRETS
+    audit_awx:
+      host: DEFINED-IN-SECRETS
+    audit_tools:
+      host: DEFINED-IN-SECRETS
+    audit_auditbeat:
+      host: DEFINED-IN-SECRETS
+  probe_targets:
+    - DEFINED-IN-SECRETS
+  region: DEFINED-IN-SECRETS
+  tld: DEFINED-IN-SECRETS
+  cluster: DEFINED-IN-SECRETS
+  clusterType: DEFINED-IN-SECRETS
+  vaultBaseURL: DEFINED-IN-SECRETS
+  alternateRegion: DEFINED-IN-SECRETS
+  registry: DEFINED-IN-SECRETS
+  registryAlternateRegion: DEFINED-IN-SECRETS
+  dockerHubMirror: DEFINED-IN-SECRETS
+  dockerHubMirrorAlternateRegion: DEFINED-IN-SECRETS
+  crNetappIoMirror: DEFINED-IN-SECRETS
+  crNetappIoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  elasticCoMirror: DEFINED-IN-SECRETS
+  elasticCoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  gcrIoMirror: DEFINED-IN-SECRETS
+  gcrIoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  ghcrIoMirror: DEFINED-IN-SECRETS
+  ghcrIoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  registryK8sIoMirror: DEFINED-IN-SECRETS
+  registryK8sIoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  quayIoMirror: DEFINED-IN-SECRETS
+  quayIoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  zalandoMirror: DEFINED-IN-SECRETS
+  zalandoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  linkerd_enabled: DEFINED-IN-SECRETS

--- a/system/audit-logs/vendor/logstash-audit-external/templates/_logstash.conf.tpl
+++ b/system/audit-logs/vendor/logstash-audit-external/templates/_logstash.conf.tpl
@@ -16,8 +16,8 @@ input {
     id => "input_http"
     port  => {{.Values.input_http_port}}
     tags => ["audit"]
-    user => '{{.Values.global.logstash_external_http_user}}'
-    password => '${AUDIT_HTTP_IN}'
+    user => '${AUDIT_HTTP_USER}'
+    password => '${AUDIT_HTTP_PWD}'
 {{ if eq .Values.global.clusterType "metal" -}}
     ssl_enabled => true
     ssl_certificate => '/tls-secret/tls.crt'

--- a/system/audit-logs/vendor/logstash-audit-external/templates/configmap.yaml
+++ b/system/audit-logs/vendor/logstash-audit-external/templates/configmap.yaml
@@ -9,10 +9,10 @@ metadata:
     component: configuration
 
 data:
-  logstash.conf: |
-{{ include (print .Template.BasePath "/_logstash.conf.tpl") . | indent 4 }}
   logstash.yml: |
 {{ include (print .Template.BasePath "/_logstash.yml.tpl") . | indent 4 }}
+  logstash.conf: |
+{{ include (print .Template.BasePath "/_logstash.conf.tpl") . | indent 4 }}
   start.sh: |
 {{ include (print .Template.BasePath "/_start.sh.tpl") . | indent 4 }}
   audit.json: |

--- a/system/audit-logs/vendor/logstash-audit-external/templates/secret.yaml
+++ b/system/audit-logs/vendor/logstash-audit-external/templates/secret.yaml
@@ -4,4 +4,5 @@ metadata:
   name: logstash-audit-external
   namespace: {{ .Values.namespace }}
 data:
-  auditHTTPIn: {{ required "missing .Values.global.logstash_external_http_password" .Values.global.logstash_external_http_password | b64enc }}
+  audit_http_user: {{ required "missing .Values.global.logstash_external_http_user" .Values.global.logstash_external_http_user | b64enc }}
+  audit_http_pwd: {{ required "missing .Values.global.logstash_external_http_password" .Values.global.logstash_external_http_password | b64enc }}

--- a/system/audit-logs/vendor/logstash-audit-external/templates/statefulset.yaml
+++ b/system/audit-logs/vendor/logstash-audit-external/templates/statefulset.yaml
@@ -49,7 +49,7 @@ spec:
       {{- end }}
       containers:
         - name: logstash
-          image: {{ .Values.global.registry }}/elk-logstash:{{ .Values.image_version }}
+          image: "{{ .Values.global.registry }}/elk-logstash:{{ .Values.image_version }}"
           imagePullPolicy: IfNotPresent
           ports:
           {{- if .Values.syslog.enabled }}

--- a/system/audit-logs/vendor/logstash-audit-external/templates/statefulset.yaml
+++ b/system/audit-logs/vendor/logstash-audit-external/templates/statefulset.yaml
@@ -77,11 +77,16 @@ spec:
               protocol: TCP
           command: ["/bin/bash","/audit-etc/start.sh"]
           env:
-            - name: AUDIT_HTTP_IN
+            - name: AUDIT_HTTP_USER
               valueFrom:
                 secretKeyRef:
                   name: logstash-audit-external
-                  key: auditHTTPIn
+                  key: audit_http_user
+            - name: AUDIT_HTTP_PWD
+              valueFrom:
+                secretKeyRef:
+                  name: logstash-audit-external
+                  key: audit_http_pwd
             - name: NAMESPACE
               valueFrom:
                 fieldRef:

--- a/system/audit-logs/vendor/logstash-audit-external/values.yaml
+++ b/system/audit-logs/vendor/logstash-audit-external/values.yaml
@@ -1,21 +1,3 @@
-global:
-  region: DEFINED-IN-SECRETS
-  tld: DEFINED-IN-SECRETS
-  cluster: DEFINED-IN-SECRETS
-  clusterType: DEFINED-IN-SECRETS
-  registry: DEFINED-IN-SECRETS
-  logstash_external_http_user: DEFINED-IN-SECRETS
-  logstash_external_http_password: DEFINED-IN-SECRETS
-  forwarding:
-    audit:
-      host: DEFINED-IN-SECRETS
-    audit_awx:
-      host: DEFINED-IN-SECRETS
-    audit_tools:
-      host: DEFINED-IN-SECRETS
-    audit_auditbeat:
-      host: DEFINED-IN-SECRETS
-
 enabled: false
 external_ip: DEFINED-IN-SECRETS
 image_version: DEFINED-IN-SECRETS

--- a/system/audit-logs/vendor/logstash-audit-external/values.yaml
+++ b/system/audit-logs/vendor/logstash-audit-external/values.yaml
@@ -46,3 +46,46 @@ resources:
   requests:
     memory: 2Gi
     cpu: 200m
+
+global:
+  https_port: 443
+  prometheus: kubernetes
+  logstash_external_http_user: DEFINED-IN-SECRETS
+  logstash_external_http_password: DEFINED-IN-SECRETS
+  linkerd_requested: false
+  forwarding:
+    audit:
+      host: DEFINED-IN-SECRETS
+    audit_awx:
+      host: DEFINED-IN-SECRETS
+    audit_tools:
+      host: DEFINED-IN-SECRETS
+    audit_auditbeat:
+      host: DEFINED-IN-SECRETS
+  probe_targets:
+    - DEFINED-IN-SECRETS
+  region: DEFINED-IN-SECRETS
+  tld: DEFINED-IN-SECRETS
+  cluster: DEFINED-IN-SECRETS
+  clusterType: DEFINED-IN-SECRETS
+  vaultBaseURL: DEFINED-IN-SECRETS
+  alternateRegion: DEFINED-IN-SECRETS
+  registry: DEFINED-IN-SECRETS
+  registryAlternateRegion: DEFINED-IN-SECRETS
+  dockerHubMirror: DEFINED-IN-SECRETS
+  dockerHubMirrorAlternateRegion: DEFINED-IN-SECRETS
+  crNetappIoMirror: DEFINED-IN-SECRETS
+  crNetappIoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  elasticCoMirror: DEFINED-IN-SECRETS
+  elasticCoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  gcrIoMirror: DEFINED-IN-SECRETS
+  gcrIoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  ghcrIoMirror: DEFINED-IN-SECRETS
+  ghcrIoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  registryK8sIoMirror: DEFINED-IN-SECRETS
+  registryK8sIoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  quayIoMirror: DEFINED-IN-SECRETS
+  quayIoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  zalandoMirror: DEFINED-IN-SECRETS
+  zalandoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  linkerd_enabled: DEFINED-IN-SECRETS

--- a/system/audit-logs/vendor/ocb-datain-static-probes/values.yaml
+++ b/system/audit-logs/vendor/ocb-datain-static-probes/values.yaml
@@ -2,3 +2,46 @@ scrapeInterval: 60s
 scrapeTimeout: 55s
 scheme: https
 module: tcp_connect
+
+global:
+  https_port: 443
+  prometheus: kubernetes
+  logstash_external_http_user: DEFINED-IN-SECRETS
+  logstash_external_http_password: DEFINED-IN-SECRETS
+  linkerd_requested: false
+  forwarding:
+    audit:
+      host: DEFINED-IN-SECRETS
+    audit_awx:
+      host: DEFINED-IN-SECRETS
+    audit_tools:
+      host: DEFINED-IN-SECRETS
+    audit_auditbeat:
+      host: DEFINED-IN-SECRETS
+  probe_targets:
+    - DEFINED-IN-SECRETS
+  region: DEFINED-IN-SECRETS
+  tld: DEFINED-IN-SECRETS
+  cluster: DEFINED-IN-SECRETS
+  clusterType: DEFINED-IN-SECRETS
+  vaultBaseURL: DEFINED-IN-SECRETS
+  alternateRegion: DEFINED-IN-SECRETS
+  registry: DEFINED-IN-SECRETS
+  registryAlternateRegion: DEFINED-IN-SECRETS
+  dockerHubMirror: DEFINED-IN-SECRETS
+  dockerHubMirrorAlternateRegion: DEFINED-IN-SECRETS
+  crNetappIoMirror: DEFINED-IN-SECRETS
+  crNetappIoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  elasticCoMirror: DEFINED-IN-SECRETS
+  elasticCoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  gcrIoMirror: DEFINED-IN-SECRETS
+  gcrIoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  ghcrIoMirror: DEFINED-IN-SECRETS
+  ghcrIoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  registryK8sIoMirror: DEFINED-IN-SECRETS
+  registryK8sIoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  quayIoMirror: DEFINED-IN-SECRETS
+  quayIoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  zalandoMirror: DEFINED-IN-SECRETS
+  zalandoMirrorAlternateRegion: DEFINED-IN-SECRETS
+  linkerd_enabled: DEFINED-IN-SECRETS

--- a/system/auditbeat/templates/auditbeat-daemonset.yaml
+++ b/system/auditbeat/templates/auditbeat-daemonset.yaml
@@ -24,6 +24,24 @@ spec:
     spec:
       tolerations:
       - operator: Exists
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: cloud.sap/deployment-state
+                operator: NotIn
+                values:
+                - reinstalling
+              - key: cloud.sap/esx-in-maintenance
+                operator: NotIn
+                values:
+                - alarm
+                - "true"
+              - key: cloud.sap/maintenance-state
+                operator: NotIn
+                values:
+                - in-maintenance
       serviceAccountName: {{ include "auditbeat.serviceAccountName" . }}
       terminationGracePeriodSeconds: 30
       hostPID: true  # Required by auditd module


### PR DESCRIPTION
- Adds affinities to the pods to disable hanging scheduling onto unready nodes.
- Adds secrets and changes default values.