### PR TITLE
[openstack-exporter] Bump chart dependencies

### DIFF
--- a/prometheus-exporters/openstack-exporter/Chart.lock
+++ b/prometheus-exporters/openstack-exporter/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.24.1
+  version: 0.26.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:ac18e83ad7659a3793488fd687dbc2df3ba116b294964e6941626910d4c2f451
-generated: "2025-03-24T23:48:51.04641+01:00"
+digest: sha256:07159b2d357d4b46bb2272a5bae6b4be108a4995b3c4ba913088cfd8d937c2b6
+generated: "2025-04-15T14:26:54.192877+02:00"

--- a/prometheus-exporters/openstack-exporter/Chart.yaml
+++ b/prometheus-exporters/openstack-exporter/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 dependencies:
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.24.1
+    version: 0.26.0
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0


### PR DESCRIPTION
Bump utils to 0.26.0:
* add a helper to configure sentry
* add optional defaultUser option for RabbitMQ and MariaDB configuration