### PR TITLE
[placement] set memcached main container

### DIFF
--- a/openstack/placement/values.yaml
+++ b/openstack/placement/values.yaml
@@ -100,6 +100,8 @@ pxc_db:
 memcached:
   alerts:
     support_group: "compute-storage-api"
+  vpa:
+    set_main_container: true
 
 logging:
   formatters:


### PR DESCRIPTION
memcached v0.6.10 introduced the option to set memcached as the main container of the deployment to provide it more resources than the corresponding sidecar containers. We activate this setting.