### PR TITLE
[nova] Bump memcached, set main containers

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 0.17.1
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.6.8
+  version: 0.6.10
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.26.0
@@ -29,5 +29,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:9c98a5bc4dc39f6dd2fa443cf17272d28e081053cd470adbb6e241663f62810d
-generated: "2025-05-19T11:02:49.372354+02:00"
+digest: sha256:a0b9f7e2d7fe6e261e0716661c9a09d6cd567999dbeb48296c3218a4c86510ee
+generated: "2025-05-20T13:28:44.925076+02:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
     version: 0.17.1
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.6.8
+    version: 0.6.10
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.26.0

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -353,6 +353,8 @@ quota:
 mysql_metrics:
   db_name: nova
   db_user: nova
+  vpa:
+    set_main_container: true
   customMetrics:
     - help: Total Nova VM count
       labels:

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -981,6 +981,8 @@ memcached:
   alerts:
     support_group: compute-storage-api
     yielded_connections_threshold: 100
+  vpa:
+    set_main_container: true
 
 owner-info:
   support-group: compute-storage-api


### PR DESCRIPTION
We bump memcached 0.6.8 to 0.6.10 and activate the new main container setting for both `mysql_metrics` and `memcached` to improve resource usage.