### PR TITLE
[Neutron] New default logging conf

### DIFF
--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -407,15 +407,16 @@ logging_sapccsentry:
       args: "()"
     sentry_breadcrumbs:
       class: "sapcc_sentrylogger.handler.BreadcrumbHandler"
-      level: ERROR
+      level: INFO
       args: "()"
   loggers:
     root:
+      formatter: context
       handlers: stdout, sentry_events, sentry_breadcrumbs
-      level: WARNING
+      level: ERROR
     neutron:
       handlers: stdout, sentry_events, sentry_breadcrumbs
-      level: WARNING
+      level: DEBUG
     neutron.pecan_wsgi.hooks.policy_enforcement:
       handlers: stdout, sentry_events, sentry_breadcrumbs
       level: INFO
@@ -443,6 +444,27 @@ logging_sapccsentry:
     neutron_fwaas:
       handlers: stdout, sentry_events, sentry_breadcrumbs
       level: WARNING
+    paste:
+      handlers: stdout, sentry_events, sentry_breadcrumbs
+      level: ERROR
+    networking_aci:
+      handlers: stdout, sentry_events, sentry_breadcrumbs
+      level: INFO
+    networking_nsxv3:
+      handlers: stdout, sentry_events, sentry_breadcrumbs
+      level: INFO
+    neutron.plugins.ml2.drivers.mech_agent:
+      handlers: stdout, sentry_events, sentry_breadcrumbs
+      level: DEBUG
+    asr1k_neutron_l3:
+      handlers: stdout, sentry_events, sentry_breadcrumbs
+      level: DEBUG
+    networking_f5:
+      handlers: stdout, sentry_events, sentry_breadcrumbs
+      level: DEBUG
+    networking_arista:
+      handlers: stdout, sentry_events, sentry_breadcrumbs
+      level: DEBUG
 
 
 pgmetrics:


### PR DESCRIPTION
Introduce new basic logging config for new sapccsentry logger. Regions requiring different setup can override values in the secret.vaules.

For most of the prod regions logging config is as most the same as the default. In some regions the networking_arista logger is configured. Furthermore in some regions the networking_aci logger has DEBUG log level and not INFO.