### PR TITLE
[cinder][mariadb] bump database dependency chart version

### DIFF
--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.26.0
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.23.0
+  version: 0.24.1
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.4.0
@@ -26,5 +26,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:8c273a6be583a0527fe604362769daf3668ab4de9b4f7b6f5a556e3526225b22
-generated: "2025-05-14T12:45:10.74762+03:00"
+digest: sha256:0c7b59abe09627509c2b72c0ae250e95ec14c707ecd3f3a4a3a4595f63e4e662
+generated: "2025-05-20T17:04:02.625564+02:00"

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -10,7 +10,7 @@ dependencies:
     version: 0.26.0
   - name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.23.0
+    version: 0.24.1
     condition: mariadb.enabled
   - name: pxc-db
     alias: pxc_db


### PR DESCRIPTION
Bump database dependency chart 0.23.0 -> 0.24.1
* Set max_connect_errors option in my.cnf to maximal possible value 4294967295
* Set skip_name_resolve option to ON and host_cache_size to 0.
* MariaDB has been updated to the 10.6.21 version