### PR TITLE
feat(secrets-injector): Set webhook timeout to expected gardener default

### DIFF
--- a/system/secrets-injector/Chart.yaml
+++ b/system/secrets-injector/Chart.yaml
@@ -3,7 +3,7 @@ name: secrets-injector
 description: Secrets Injector
 
 type: application
-version: 1.1.12
+version: 1.1.13
 appVersion: "0.1.0"
 
 dependencies:

--- a/system/secrets-injector/values.yaml
+++ b/system/secrets-injector/values.yaml
@@ -15,7 +15,7 @@ image:
 webhook:
   failurePolicy: Fail
   # between 1 and 30 seconds: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#timeouts
-  timeoutSeconds: 30
+  timeoutSeconds: 15
   genericRules: []
   matchConditions: false
   extraConditions: []


### PR DESCRIPTION
Gardener expects webhook timeouts to be `15sec`:

```
gardener.cloud/warning: |-
      ATTENTION: This webhook configuration has been modified by Gardener since it does not follow the best practices recommended by Kubernetes (https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#best-practices-and-warnings) and might interfere with the cluster operations. Please make sure to follow these recommendations to prevent future interventions. When you are done, please remove this annotation. See also https://github.com/gardener/gardener/blob/master/docs/usage/shoot/shoot_status.md#constraints for further information.
      The following modifications have been made:
      - timeoutSeconds of webhook "secrets-injector.cloud.sap" was set to 15
```

I would suggest to align on this common standard