### PR TITLE
elektra: revert cloud_resource_admin assignment

### DIFF
--- a/openstack/elektra/templates/seed.yaml
+++ b/openstack/elektra/templates/seed.yaml
@@ -34,7 +34,6 @@ spec:
       {{- end }}
 
   roles:
-  - name: cloud_resource_admin
   - name: cloud_compute_admin
   - name: cloud_network_admin
   - name: cloud_dns_admin
@@ -63,8 +62,6 @@ spec:
         role: service
       - project: cloud_admin@ccadmin
         role: admin
-      - project: cloud_admin@ccadmin
-        role: cloud_resource_admin        
       - project: cloud_admin@ccadmin
         role: cloud_compute_admin
       - project: cloud_admin@ccadmin


### PR DESCRIPTION
Campfire does not look at this role anymore since #8770.