### PR TITLE
fix(greenhouse-ccloud): add region override

### DIFF
--- a/system/greenhouse-ccloud/Chart.yaml
+++ b/system/greenhouse-ccloud/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ccloud
 description: A Helm chart for the CCloud organization in Greenhouse.
 type: application
-version: 1.23.2
+version: 1.23.3
 

--- a/system/greenhouse-ccloud/ci/test-values.yaml
+++ b/system/greenhouse-ccloud/ci/test-values.yaml
@@ -112,6 +112,8 @@ kubeMonitoring:
   computeClusters:
     cluster-1:
       thanos: false
+    cluster-2:
+      region: test
 
 teams2slack:
   enabled: true

--- a/system/greenhouse-ccloud/templates/kube-monitoring-pluginpreset.yaml
+++ b/system/greenhouse-ccloud/templates/kube-monitoring-pluginpreset.yaml
@@ -30,7 +30,7 @@ spec:
       value:
         cluster: {{ $cluster }}
         cluster_type: storage
-        region: {{ regexReplaceAll "^(\\w+\\-)" $cluster "" }}
+        region: {{ default (regexReplaceAll "^(\\w+\\-)" $cluster "") (index $additionalSettings "region") }}
   {{- if index $additionalSettings "serviceProxyUrl" }}
     - name: kubeMonitoring.prometheus.prometheusSpec.externalUrl
       value: {{ index $additionalSettings "serviceProxyUrl" }}
@@ -66,7 +66,7 @@ spec:
       value:
         cluster: {{ $cluster }}
         cluster_type: compute
-        region: {{ regexReplaceAll "^(\\w+\\-)" $cluster "" }}
+        region: {{ default (regexReplaceAll "^(\\w+\\-)" $cluster "") (index $additionalSettings "region") }}
     # NFS volumes need more permissions to work
     - name: kubeMonitoring.prometheus.prometheusSpec.securityContext
       value:
@@ -103,7 +103,7 @@ spec:
         cluster: {{ $cluster }}
         cluster_type: observability
         organization: ccloud
-        region: {{ regexReplaceAll "^(\\w+\\-)" $cluster "" }}
+        region: {{ default (regexReplaceAll "^(\\w+\\-)" $cluster "") (index $additionalSettings "region") }}
   {{- if index $additionalSettings "serviceProxyUrl" }}
     - name: kubeMonitoring.prometheus.prometheusSpec.externalUrl
       value: {{ index $additionalSettings "serviceProxyUrl" }}
@@ -146,7 +146,7 @@ spec:
       value:
         cluster: {{ $cluster }}
         cluster_type: sci-k8s-runtime
-        region: {{ regexReplaceAll "^(\\w+\\-)" $cluster "" }}
+        region: {{ default (regexReplaceAll "^(\\w+\\-)" $cluster "") (index $additionalSettings "region") }}
   {{- if index $additionalSettings "serviceProxyUrl" }}
     - name: kubeMonitoring.prometheus.prometheusSpec.externalUrl
       value: {{ index $additionalSettings "serviceProxyUrl" }}


### PR DESCRIPTION
some types of clusters do not have a common naming convention
this allows to override the region for these clusters.
