### PR TITLE
[neutron] remove static vpa value and always set annotation

### DIFF
--- a/openstack/neutron/templates/asr_config_agents/_deployment-asr1k.yaml.tpl
+++ b/openstack/neutron/templates/asr_config_agents/_deployment-asr1k.yaml.tpl
@@ -11,10 +11,8 @@ metadata:
     system: openstack
     type: backend
     component: neutron
-  {{- if $context.Values.vpa.set_main_container }}
   annotations:
     vpa-butler.cloud.sap/main-container: neutron-asr1k
-  {{- end }}
 spec:
   replicas: 1
   revisionHistoryLimit: 5

--- a/openstack/neutron/templates/deployment-aci-agent.yaml
+++ b/openstack/neutron/templates/deployment-aci-agent.yaml
@@ -7,10 +7,8 @@ metadata:
     system: openstack
     type: backend
     component: neutron
-  {{- if .Values.vpa.set_main_container }}
   annotations:
     vpa-butler.cloud.sap/main-container: neutron-aci-agent
-  {{- end }}
 spec:
   replicas: 1
   revisionHistoryLimit: 5

--- a/openstack/neutron/templates/deployment-cc-fabric-agent.yaml
+++ b/openstack/neutron/templates/deployment-cc-fabric-agent.yaml
@@ -10,10 +10,8 @@ metadata:
     system: openstack
     type: backend
     component: neutron
-  {{- if $.Values.vpa.set_main_container }}
   annotations:
     vpa-butler.cloud.sap/main-container: neutron-cc-fabric-{{ $platform }}-agent
-  {{- end }}
 spec:
   replicas: 1
   revisionHistoryLimit: 5

--- a/openstack/neutron/templates/deployment-ironic-agent.yaml
+++ b/openstack/neutron/templates/deployment-ironic-agent.yaml
@@ -10,9 +10,7 @@ metadata:
     component: neutron
   annotations:
     {{- include "utils.linkerd.ingress_annotation" . | indent 4 }}
-    {{- if .Values.vpa.set_main_container }}
     vpa-butler.cloud.sap/main-container: neutron-ironic-agent
-    {{- end }}
 spec:
   replicas: 1
   revisionHistoryLimit: 5

--- a/openstack/neutron/templates/deployment-nsxv3-logstash.yaml
+++ b/openstack/neutron/templates/deployment-nsxv3-logstash.yaml
@@ -8,10 +8,8 @@ metadata:
     system: openstack
     type: backend
     component: neutron
-  {{- if .Values.vpa.set_main_container }}
   annotations:
     vpa-butler.cloud.sap/main-container: neutron-nsxv3-logstash
-  {{- end }}
 spec:
   replicas: {{ .Values.logger.logstash.replicas | default 3 }}
   revisionHistoryLimit: {{ .Values.pod.lifecycle.upgrades.deployments.revision_history }}

--- a/openstack/neutron/templates/deployment-rpc-server.yaml
+++ b/openstack/neutron/templates/deployment-rpc-server.yaml
@@ -8,10 +8,8 @@ metadata:
     system: openstack
     type: rpc
     component: neutron
-  {{- if .Values.vpa.set_main_container }}
   annotations:
     vpa-butler.cloud.sap/main-container: neutron-rpc-server
-  {{- end }}
 spec:
   replicas: {{ if not .Values.pod.debug.rpc_server }}{{ .Values.pod.replicas.rpc_server }}{{ else }} 1 {{ end }}
   revisionHistoryLimit: {{ .Values.pod.lifecycle.upgrades.deployments.revision_history }}

--- a/openstack/neutron/templates/deployment-server.yaml
+++ b/openstack/neutron/templates/deployment-server.yaml
@@ -7,10 +7,8 @@ metadata:
     system: openstack
     type: api
     component: neutron
-  {{- if .Values.vpa.set_main_container }}
   annotations:
     vpa-butler.cloud.sap/main-container: neutron-server
-  {{- end }}
 spec:
   replicas: {{ if not .Values.pod.debug.server }}{{ .Values.pod.replicas.server }}{{ else }} 1 {{ end }}
   revisionHistoryLimit: {{ .Values.pod.lifecycle.upgrades.deployments.revision_history }}

--- a/openstack/neutron/templates/sftp-deployment.yaml
+++ b/openstack/neutron/templates/sftp-deployment.yaml
@@ -5,10 +5,8 @@ metadata:
   name: neutron-sftp-backup
   labels:
     release: "{{.Release.Name}}"
-  {{- if .Values.vpa.set_main_container }}
   annotations:
     vpa-butler.cloud.sap/main-container: sftp
-  {{- end }}
 spec:
   revisionHistoryLimit: 5
   replicas: 1

--- a/openstack/neutron/templates/statefulset-network-agent-apod.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent-apod.yaml
@@ -14,10 +14,8 @@ metadata:
     system: openstack
     application: neutron
     component: agent
-  {{- if $.Values.vpa.set_main_container }}
   annotations:
     vpa-butler.cloud.sap/main-container: neutron-dhcp-agent
-  {{- end }}
 spec:
   updateStrategy:
 {{- if or (eq $.Values.global.region "qa-de-1") (eq $.Values.global.region "qa-de-2") }}

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -923,12 +923,6 @@ utils:
   trust_bundle:
     enable: false
 
-vpa:
-  # https://github.com/sapcc/vpa_butler
-  # The maximum available capacity is split evenly across containers specified in the Deployment, StatefulSet or DaemonSet to derive the upper recommendation bound. This does not work out for pods with a single resource-hungry container with several sidecar containers
-  # Annotate the Deployment, StatefulSet or DaemonSet with vpa-butler.cloud.sap/main-container=$MAIN_CONTAINER. That will distribute 75% of the maximum available capacity to the main container and the rest evenly across all others
-  set_main_container: true
-
 customdns:
   enabled: false
   upstream_dns_servers: []


### PR DESCRIPTION
The `vpa-butler.cloud.sap/main-container` annotation for [sapcc/vpa_butler](https://github.com/sapcc/vpa_butler) has been guarded by a corresponding value, but was never altered beyond its default value. With this patch, we remove the unnecessary logic inside the helm templates to always set the annotation in order to reduce complexity.