### PR TITLE
[netapp-harvest-exporter] fix snapmirror relationship

### DIFF
--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/aggregations/snapmirror.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/aggregations/snapmirror.yaml
@@ -15,7 +15,7 @@ groups:
         label_replace (
         label_replace (
         label_replace (
-          max by (app, availability_zone, filer, project_id, share_id, share_name, svm, volume) (netapp_volume_labels:manila),
+          max by (app, availability_zone, project_id, share_id, share_name, svm, volume) (netapp_volume_labels:manila{volume_type="rw"}),
           "source_availability_zone", "$1", "availability_zone", "(.*)"),
           "source_volume", "$1", "volume", "(.*)"),
           "source_vserver", "$1", "svm", "(.*)"),
@@ -57,7 +57,7 @@ groups:
         label_replace(
         label_replace(
         label_replace(
-          max by (availability_zone, filer, project_id, share_id, share_name, svm, volume) (netapp_volume_labels:manila),
+          max by (availability_zone, project_id, share_id, share_name, svm, volume) (netapp_volume_labels:manila{volume_type="rw"}),
           "source_availability_zone", "$1", "availability_zone", "(.*)"),
           "source_volume", "$1", "volume", "(.*)"),
           "source_vserver", "$1", "svm", "(.*)"),


### PR DESCRIPTION
Snapmirror rules are broken for shares being migrated.
`netapp_volume_labels:manila` is not unique for such shares, i.e.
multiple entries exists for (svm, volume). We add the volume_type="rw"
filter to avoid such errors.
