### PR TITLE
[octavia] remove static vpa value and always set annotation

### DIFF
--- a/openstack/octavia/templates/octavia-api-deployment.yaml
+++ b/openstack/octavia/templates/octavia-api-deployment.yaml
@@ -10,9 +10,7 @@ metadata:
   annotations:
     secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets"
     deployment.reloader.stakater.com/pause-period: "60s"
-  {{- if .Values.vpa.set_main_container }}
     vpa-butler.cloud.sap/main-container: {{ .Chart.Name }}-api
-  {{- end }}
 spec:
   replicas: {{ .Values.pod.replicas.api }}
   revisionHistoryLimit: {{ .Values.pod.lifecycle.upgrades.deployments.revision_history }}

--- a/openstack/octavia/templates/octavia-f5-as3-deployment.yaml
+++ b/openstack/octavia/templates/octavia-f5-as3-deployment.yaml
@@ -8,10 +8,8 @@ metadata:
     helm.sh/chart: {{ include "octavia.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-  {{- if .Values.vpa.set_main_container }}
   annotations:
     vpa-butler.cloud.sap/main-container: f5-as3-container
-  {{- end }}
 spec:
   replicas: 1
   selector:

--- a/openstack/octavia/templates/octavia-housekeeping.yaml
+++ b/openstack/octavia/templates/octavia-housekeeping.yaml
@@ -10,9 +10,7 @@ metadata:
   annotations:
     secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets"
     deployment.reloader.stakater.com/pause-period: "60s"
-  {{- if .Values.vpa.set_main_container }}
     vpa-butler.cloud.sap/main-container: octavia-f5-housekeeping
-  {{- end }}
 spec:
   replicas: 1
   selector:

--- a/openstack/octavia/templates/octavia-worker-deployment.yaml
+++ b/openstack/octavia/templates/octavia-worker-deployment.yaml
@@ -13,9 +13,7 @@ metadata:
   annotations:
     secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets,{{ .Release.Name }}-secrets-{{ $name }}"
     deployment.reloader.stakater.com/pause-period: "60s"
-  {{- if .Values.vpa.set_main_container }}
     vpa-butler.cloud.sap/main-container: octavia-worker
-  {{- end }}
 spec:
   replicas: 1
   selector:

--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -424,11 +424,6 @@ logging:
 utils:
   trust_bundle:
     enable: true
-vpa:
-  # https://github.com/sapcc/vpa_butler
-  # The maximum available capacity is split evenly across containers specified in the Deployment, StatefulSet or DaemonSet to derive the upper recommendation bound. This does not work out for pods with a single resource-hungry container with several sidecar containers
-  # Annotate the Deployment, StatefulSet or DaemonSet with vpa-butler.cloud.sap/main-container=$MAIN_CONTAINER. That will distribute 75% of the maximum available capacity to the main container and the rest evenly across all others
-  set_main_container: true
 
 
 # openstack-rate-limit


### PR DESCRIPTION
The vpa-butler.cloud.sap/main-container annotation for [sapcc/vpa_butler](github.com/sapcc/vpa_butler) has been guarded by a corresponding value, but was never altered beyond its default value. With this patch, we remove the unnecessary logic inside the helm templates to always set the annotation in order to reduce complexity.