### PR TITLE
keppel-auto: allow seeding tag_policies

### DIFF
--- a/openstack/keppel-auto/templates/configmap-managed-accounts.yaml
+++ b/openstack/keppel-auto/templates/configmap-managed-accounts.yaml
@@ -46,6 +46,10 @@ accounts:
     security_scan_policies: {{ toJson $account.security_scan_policies }}
     {{- end }}
 
+    {{- if and $is_primary $account.tag_policies }}
+    tag_policies: {{ toJson $account.tag_policies }}
+    {{- end }}
+
     {{- if and $is_primary $account.validation }}
     validation: {{ toJson $account.validation }}
     {{- end }}


### PR DESCRIPTION
This new capability was added in https://github.com/sapcc/keppel/pull/538.