### PR TITLE
[neutron] remove redundant whitespace in templates

### DIFF
--- a/openstack/neutron/templates/configmap-bin.yaml
+++ b/openstack/neutron/templates/configmap-bin.yaml
@@ -11,5 +11,3 @@ data:
 {{ include (print .Template.BasePath "/bin/_neutron-server-start.tpl") . | indent 4 }}
   common.sh: |
 {{ include "common.sh" .| indent 4 }}
-
-

--- a/openstack/neutron/templates/configmap-etc-api.yaml
+++ b/openstack/neutron/templates/configmap-etc-api.yaml
@@ -7,7 +7,6 @@ metadata:
     system: openstack
     type: configuration
     component: neutron
-
 data:
   uwsgi.ini: |
 {{ include (print .Template.BasePath "/etc/_uwsgi.ini.tpl") . | indent 4 }}

--- a/openstack/neutron/templates/configmap-etc-apod.yaml
+++ b/openstack/neutron/templates/configmap-etc-apod.yaml
@@ -8,8 +8,6 @@ metadata:
     system: openstack
     type: configuration
     component: neutron
-
-
 data:
 {{ range $az_long, $apods := .Values.global.apods }}
 {{ range $k, $apod := $apods }}

--- a/openstack/neutron/templates/configmap-etc-cc-fabric.yaml
+++ b/openstack/neutron/templates/configmap-etc-cc-fabric.yaml
@@ -8,7 +8,6 @@ metadata:
     system: openstack
     type: configuration
     component: neutron
-
 data:
   ml2_conf_cc-fabric.ini: |
 {{ include (print .Template.BasePath "/etc/_ml2-conf-cc-fabric.ini.tpl") . | indent 4 }}

--- a/openstack/neutron/templates/configmap-etc-vendor.yaml
+++ b/openstack/neutron/templates/configmap-etc-vendor.yaml
@@ -6,7 +6,6 @@ metadata:
     system: openstack
     type: configuration
     component: neutron
-
 data:
   ml2-conf-arista.ini: |
 {{ include (print .Template.BasePath "/etc/_ml2-conf-arista.ini.tpl") . | indent 4 }}

--- a/openstack/neutron/templates/configmap-etc.yaml
+++ b/openstack/neutron/templates/configmap-etc.yaml
@@ -6,7 +6,6 @@ metadata:
     system: openstack
     type: configuration
     component: neutron
-
 data:
   api-paste.ini: |
 {{ include (print .Template.BasePath "/etc/_api-paste.ini.tpl") . | indent 4 }}

--- a/openstack/neutron/templates/deployment-aci-agent.yaml
+++ b/openstack/neutron/templates/deployment-aci-agent.yaml
@@ -1,6 +1,5 @@
 kind: Deployment
 apiVersion: apps/v1
-
 metadata:
   name: neutron-aci-agent
   labels:

--- a/openstack/neutron/templates/deployment-cc-fabric-agent.yaml
+++ b/openstack/neutron/templates/deployment-cc-fabric-agent.yaml
@@ -3,7 +3,6 @@
 ---
 kind: Deployment
 apiVersion: apps/v1
-
 metadata:
   name: neutron-cc-fabric-{{ $platform }}-agent
   labels:

--- a/openstack/neutron/templates/deployment-nsxv3-logstash.yaml
+++ b/openstack/neutron/templates/deployment-nsxv3-logstash.yaml
@@ -1,7 +1,6 @@
 {{- if .Values.logger.enabled }}
 kind: Deployment
 apiVersion: apps/v1
-
 metadata:
   name: neutron-nsxv3-logstash
   labels:

--- a/openstack/neutron/templates/deployment-rpc-server.yaml
+++ b/openstack/neutron/templates/deployment-rpc-server.yaml
@@ -1,7 +1,6 @@
 {{- if .Values.api.uwsgi }}
 kind: Deployment
 apiVersion: apps/v1
-
 metadata:
   name: neutron-rpc-server
   labels:

--- a/openstack/neutron/templates/deployment-server.yaml
+++ b/openstack/neutron/templates/deployment-server.yaml
@@ -1,6 +1,5 @@
 kind: Deployment
 apiVersion: apps/v1
-
 metadata:
   name: neutron-server
   labels:

--- a/openstack/neutron/templates/ingress-server.yaml
+++ b/openstack/neutron/templates/ingress-server.yaml
@@ -1,6 +1,5 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
-
 metadata:
   name: neutron-server
   labels:

--- a/openstack/neutron/templates/prometheus-alerts.yaml
+++ b/openstack/neutron/templates/prometheus-alerts.yaml
@@ -5,7 +5,6 @@
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
-
 metadata:
   name: {{ printf "neutron-%s" $path | replace "/" "-" }}
   labels:
@@ -13,10 +12,8 @@ metadata:
     tier: os
     type: alerting-rules
     {{ $target.type | required (printf "$values.alerts.prometheus.[%v].type missing" $i) }}: {{ $target.name | required (printf "$values.alerts.prometheus.[%v].name missing" $i) }}
-
 spec:
 {{ printf "%s" $bytes | indent 2 }}
-
 {{- end }}
 {{- end }}
 {{- end }}

--- a/openstack/neutron/templates/sentry.yaml
+++ b/openstack/neutron/templates/sentry.yaml
@@ -3,7 +3,6 @@ apiVersion: "sentry.sap.cc/v1"
 kind: "SentryProject"
 metadata:
   name: neutron-sentry
-
 spec:
   name: neutron #slug of the project you want to use (or create
   team: openstack #slug of the team where the project should be created (if it doesn't exist)

--- a/openstack/neutron/templates/service-nsxv3-logstash.yaml
+++ b/openstack/neutron/templates/service-nsxv3-logstash.yaml
@@ -1,7 +1,6 @@
 {{- if .Values.logger.enabled }}
 kind: Service
 apiVersion: v1
-
 metadata:
   name: neutron-nsxv3-logstash
   labels:

--- a/openstack/neutron/templates/service-server.yaml
+++ b/openstack/neutron/templates/service-server.yaml
@@ -1,6 +1,5 @@
 kind: Service
 apiVersion: v1
-
 metadata:
   name: neutron-server
   labels:

--- a/openstack/neutron/templates/sftp-deployment.yaml
+++ b/openstack/neutron/templates/sftp-deployment.yaml
@@ -1,6 +1,5 @@
 kind: Deployment
 apiVersion: apps/v1
-
 metadata:
   name: neutron-sftp-backup
   labels:


### PR DESCRIPTION
This patch ensures a more consistent format of the neutron manifests, removing redundant whitespace.