### PR TITLE
[utils][proxysql] Add restartPolicy to support native sidecar mode

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.26.0
+version: 0.27.0

--- a/openstack/utils/templates/_proxysql.tpl
+++ b/openstack/utils/templates/_proxysql.tpl
@@ -28,6 +28,9 @@
           {{ required ".Values.global.dockerHubMirror is missing" .Values.global.dockerHubMirror }}/{{ default "proxysql/proxysql" .Values.proxysql.image }}
         {{- end }}:{{ .Values.proxysql.imageTag | default "2.7.1-debian" }}
   imagePullPolicy: IfNotPresent
+  {{- if .Values.proxysql.native_sidecar }}
+  restartPolicy: Always
+  {{- end }}
   command: ["proxysql"]
   args: ["--config", "/etc/proxysql/proxysql.cnf", "--exit-on-error", "--foreground", "--idle-threads", "--admin-socket", "/run/proxysql/admin.sock", "--no-version-check", "-D", "/run/proxysql"]
         {{- if gt $scale 1 }}


### PR DESCRIPTION
Add restartPolicy option, which is enabled when the `proxysql.native_sidecar` option is set.

This would allow us to move the proxysql sidecar from the `containers` deployment section to `initContainers` and run it as a native sidecar.