### PR TITLE
[designate][proxysql] use native sidecars for proxysql

### DIFF
--- a/openstack/designate/Chart.lock
+++ b/openstack/designate/Chart.lock
@@ -19,7 +19,7 @@ dependencies:
   version: 0.18.0
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.26.0
+  version: 0.27.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
@@ -29,5 +29,5 @@ dependencies:
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.1.4
-digest: sha256:e74060ce8c2e8e56e4345a0080f5edab5520f7b5c8a8d0261d76d264231e9636
-generated: "2025-05-15T15:55:02.2439+03:00"
+digest: sha256:4c9bd130f47cfe5209e1b2740e5ed282061815624962fbd0d7e1cd333705234d
+generated: "2025-05-29T10:54:46.556854+03:00"

--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes to deploy Openstack Designate  (DNSaaS)
 name: designate
-version: 0.5.3
+version: 0.5.5
 appVersion: "dalmatian"
 dependencies:
   - condition: percona_cluster.enabled
@@ -31,7 +31,7 @@ dependencies:
     version: 0.18.0
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.26.0
+    version: 0.27.0
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0

--- a/openstack/designate/templates/central-deployment.yaml
+++ b/openstack/designate/templates/central-deployment.yaml
@@ -49,6 +49,9 @@ spec:
       {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       initContainers:
       {{- tuple . (dict "service" (include "designate.service_dependencies" . ) "jobs" (include "migration_job_name" . )) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
+      {{- if .Values.proxysql.native_sidecar }}
+      {{- tuple . .Values.central_workers | include "utils.proxysql.container" | indent 8 }}
+      {{- end }}
       containers:
         - name: designate-central
           image: {{ required ".Values.global.registry is missing" .Values.global.registry }}/loci-designate:{{ required ".Values.global.image_version_designate is missing" .Values.image_version_designate }}
@@ -115,7 +118,9 @@ spec:
             {{- if .Values.coordination.central.enabled }}
             {{- include "utils.coordination.volume_mount" . | indent 12 }}
             {{- end }}
+        {{- if not .Values.proxysql.native_sidecar }}
         {{- tuple . .Values.central_workers | include "utils.proxysql.container" | indent 8 }}
+        {{- end }}
         {{- include "jaeger_agent_sidecar" . | indent 8 }}
       volumes:
         - name: designate-etc

--- a/openstack/designate/templates/mdns-deployment.yaml
+++ b/openstack/designate/templates/mdns-deployment.yaml
@@ -52,6 +52,9 @@ spec:
       {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       initContainers:
       {{- tuple . (dict "service" (include "designate.service_dependencies" . ) "jobs" (include "migration_job_name" . )) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
+      {{- if .Values.proxysql.native_sidecar }}
+      {{- tuple . .Values.mdns_workers | include "utils.proxysql.container" | indent 8 }}
+      {{- end }}
       containers:
         - name: designate-mdns
           image: {{ required ".Values.global.registry is missing" .Values.global.registry }}/loci-designate:{{ required ".Values.image_version_designate is missing" .Values.image_version_designate }}
@@ -109,7 +112,9 @@ spec:
               name: container-init
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
             {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
+        {{- if not .Values.proxysql.native_sidecar }}
         {{- tuple . .Values.mdns_workers | include "utils.proxysql.container" | indent 8 }}
+        {{- end }}
       volumes:
         - name: designate-etc
           projected:

--- a/openstack/designate/templates/sink-deployment.yaml
+++ b/openstack/designate/templates/sink-deployment.yaml
@@ -53,6 +53,10 @@ spec:
                 values:
                 - designate-sink
             topologyKey: "kubernetes.io/hostname"
+      initContainers:
+      {{- if .Values.proxysql.native_sidecar }}
+      {{- include "utils.proxysql.container" . | indent 8 }}
+      {{- end }}
       containers:
         - name: designate-sink
           image: {{ required ".Values.global.registry is missing" .Values.global.registry }}/loci-designate:{{ required ".Values.global.image_version_designate is missing" .Values.image_version_designate }}
@@ -79,7 +83,9 @@ spec:
             - mountPath: /container.init
               name: container-init
             {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
+        {{- if not .Values.proxysql.native_sidecar }}
         {{- include "utils.proxysql.container" . | indent 8 }}
+        {{- end }}
       volumes:
         - name: designate-etc
           configMap:

--- a/openstack/designate/templates/worker-deployment.yaml
+++ b/openstack/designate/templates/worker-deployment.yaml
@@ -50,6 +50,9 @@ spec:
       {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       initContainers:
       {{- tuple . (dict "service" (include "designate.rabbitmq_dependencies" . )) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
+      {{- if .Values.proxysql.native_sidecar }}
+      {{- tuple . .Values.worker_workers | include "utils.proxysql.container" | indent 8 }}
+      {{- end }}
       containers:
         - name: designate-worker
           image: {{ required ".Values.global.registry is missing" .Values.global.registry }}/loci-designate:{{ required ".Values.global.image_version_designate is missing" .Values.image_version_designate }}
@@ -99,7 +102,9 @@ spec:
               name: container-init
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
             {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
+        {{- if not .Values.proxysql.native_sidecar }}
         {{- tuple . .Values.worker_workers | include "utils.proxysql.container" | indent 8 }}
+        {{- end }}
       volumes:
         - name: designate-etc
           projected:

--- a/openstack/designate/values.yaml
+++ b/openstack/designate/values.yaml
@@ -104,6 +104,7 @@ proxysql:
   mode: host_alias
   connect_retries_delay: 1000
   max_connections_per_proc: 20
+  native_sidecar: true
 
 mariadb:
   enabled: true


### PR DESCRIPTION
Run proxysql sidecars as native sidecars.

This would ensure that proxysql container is always stopped after the main container on each deployment.