### PR TITLE
postgresql, redis: fix annotateGeneratedSecrets

### DIFF
--- a/common/postgresql-ng/Chart.yaml
+++ b/common/postgresql-ng/Chart.yaml
@@ -43,4 +43,7 @@ description: Chart for PostgreSQL
 #
 # 2.0.3
 # - Fix DB name double quoting issues in startup sql script
-version: 2.0.4 # this version number is SemVer as it gets used to auto bump
+#
+# 2.0.5
+# - Fix reloader.annotateGeneratedSecrets not annotating generated secrets
+version: 2.0.5 # this version number is SemVer as it gets used to auto bump

--- a/common/postgresql-ng/bin/init-generate-secrets.sh
+++ b/common/postgresql-ng/bin/init-generate-secrets.sh
@@ -32,7 +32,7 @@ for USER in ${USERS:-}; do
       postgres-password: $(LC_ALL=C tr -dc '[:graph:]' </dev/urandom | head -c 30 | base64 -w0 | base64 -w0)
   " > secret.yaml
   kubectl create -f secret.yaml
-  if [[ $ANNOTATE_FOR_RELOADER -eq "true" ]]; then
+  if [[ "$ANNOTATE_FOR_RELOADER" == "true" ]]; then
     kubectl annotate reloader.stakater.com/match="true" -f secret.yaml
   fi
 done

--- a/common/redis/Chart.yaml
+++ b/common/redis/Chart.yaml
@@ -43,4 +43,7 @@ name: redis
 #   secrets and consuming workloads. See
 #   `.Values.reloader.annotateGeneratedSecrets` and
 #   `.Values.metrics.reloader.enabled`
-version: 2.2.9 # this version number is SemVer as it gets used to auto bump
+#
+# 2.2.10
+# - Fix reloader.annotateGeneratedSecrets not annotating generated secrets
+version: 2.2.10 # this version number is SemVer as it gets used to auto bump

--- a/common/redis/bin/init-generate-secrets.sh
+++ b/common/redis/bin/init-generate-secrets.sh
@@ -32,7 +32,7 @@ for USER in ${USERS:-}; do
       password: $(LC_ALL=C tr -dc '[:graph:]' </dev/urandom | head -c 30 | base64 -w0 | base64 -w0)
   " > secret.yaml
   kubectl create -f secret.yaml
-  if [[ $ANNOTATE_FOR_RELOADER -eq "true" ]]; then
+  if [[ "$ANNOTATE_FOR_RELOADER" == "true" ]]; then
     kubectl annotate reloader.stakater.com/match="true" -f secret.yaml
   fi
 done


### PR DESCRIPTION
The feature originally introduced in #6396 was not working properly because of the conditional always mistakenly evaluating to false.

```console
$ docker run --rm -it keppel.eu-de-1.cloud.sap/ccloud/shared-app-images/alpine-kubectl:latest-latest ash -c '[[ "true" -eq "true" ]] && echo "yes" || echo "no"'
ash: true: out of range
no
```

The issue appears to be `ash` specific.
```console
$ bash -c '[[ "true" -eq "true" ]] && echo "yes" || echo "no"'
yes
```
