### PR TITLE
[neutron-network-agent] define replicas in values

### DIFF
--- a/openstack/neutron/templates/statefulset-network-agent-apod.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent-apod.yaml
@@ -30,11 +30,7 @@ spec:
       name: neutron-network-agent-{{ $apod }}
   serviceName: neutron-network-agent
   podManagementPolicy: "Parallel"
-{{- if $.Values.pod.replicas.network_agent_apod }}
-  replicas: {{ $.Values.pod.replicas.network_agent_apod }}
-{{- else }}
-  replicas: 15
-{{- end }}
+  replicas: {{ $.Values.pod.replicas.network_agent }}
   template:
     metadata:
       annotations:

--- a/openstack/neutron/templates/statefulset-network-agent.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent.yaml
@@ -24,17 +24,7 @@ spec:
       name: neutron-network-agent-{{ $az }}
   serviceName: neutron-network-agent
   podManagementPolicy: "Parallel"
-{{- if $.Values.pod.replicas.network_agent }}
   replicas: {{ $.Values.pod.replicas.network_agent }}
-{{- else if and (ge $az_count 2) (eq $az "a") }}
-  replicas: 5
-{{- else if and (ge $az_count 2) (eq $az "b") }}
-  replicas: 5
-{{- else if eq $az_count 1 }}
-  replicas: 10
-{{- else }}
-  replicas: 3
-{{- end }}
   template:
     metadata:
       annotations:

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -38,6 +38,7 @@ pod:
   replicas:
     server: 3
     rpc_server: 2
+    network_agent: 15
     ovn_db: 3
   lifecycle:
     upgrades:


### PR DESCRIPTION
This patch changes the definition for the replicas of the neutron-network-agent statefulset to come from the values in order to reduce the logic done within our templates.