### PR TITLE
[reloader][openstack] add reloader annotations

### DIFF
--- a/openstack/barbican/templates/api-deployment.yaml
+++ b/openstack/barbican/templates/api-deployment.yaml
@@ -11,6 +11,9 @@ metadata:
     system: openstack
     type: api
     component: barbican
+  annotations:
+    secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets"
+    deployment.reloader.stakater.com/pause-period: "60s"
 spec:
   replicas: {{ required ".Values.api.replicas is missing" .Values.api.replicas }}
   revisionHistoryLimit: {{ .Values.pod.lifecycle.upgrades.deployments.revisionHistory }}

--- a/openstack/barbican/templates/barbican-nanny-deployment.yaml
+++ b/openstack/barbican/templates/barbican-nanny-deployment.yaml
@@ -11,6 +11,9 @@ metadata:
     heritage: "{{ .Release.Service }}"
     type: nanny
     component: barbican
+  annotations:
+    secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets"
+    deployment.reloader.stakater.com/pause-period: "60s"
 spec:
   replicas: {{ .Values.barbican_nanny.replicas }}
   revisionHistoryLimit: {{ .Values.pod.lifecycle.upgrades.deployments.revisionHistory }}

--- a/openstack/cinder/templates/api-deployment.yaml
+++ b/openstack/cinder/templates/api-deployment.yaml
@@ -7,6 +7,9 @@ metadata:
     system: openstack
     type: api
     component: cinder
+  annotations:
+    secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets"
+    deployment.reloader.stakater.com/pause-period: "60s"
 spec:
   replicas: {{ .Values.pod.replicas.api }}
   revisionHistoryLimit: {{ .Values.pod.lifecycle.upgrades.deployments.revisionHistory }}

--- a/openstack/cinder/templates/backup_deployment.yaml
+++ b/openstack/cinder/templates/backup_deployment.yaml
@@ -19,6 +19,9 @@ template: |
       component: cinder
       vcenter: {= host =}
       datacenter: {= availability_zone =}
+    annotations:
+      secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets"
+      deployment.reloader.stakater.com/pause-period: "60s"
   spec:
     replicas: 1
     revisionHistoryLimit: 5

--- a/openstack/cinder/templates/scheduler-deployment.yaml
+++ b/openstack/cinder/templates/scheduler-deployment.yaml
@@ -7,6 +7,9 @@ metadata:
     system: openstack
     type: backend
     component: cinder
+  annotations:
+    secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets"
+    deployment.reloader.stakater.com/pause-period: "60s"
 spec:
   replicas: {{ .Values.pod.replicas.scheduler }}
   revisionHistoryLimit: {{ .Values.pod.lifecycle.upgrades.deployments.revisionHistory }}

--- a/openstack/cinder/templates/vcenter_datacenter_cinder_deployment.yaml
+++ b/openstack/cinder/templates/vcenter_datacenter_cinder_deployment.yaml
@@ -19,6 +19,9 @@ template: |
       component: cinder
       vcenter: {= host =}
       datacenter: {= availability_zone =}
+    annotations:
+      secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets"
+      deployment.reloader.stakater.com/pause-period: "60s"
   spec:
     replicas: 1
     revisionHistoryLimit: 5

--- a/openstack/cinder/templates/volumes/_volume-deployment.yaml.tpl
+++ b/openstack/cinder/templates/volumes/_volume-deployment.yaml.tpl
@@ -10,6 +10,9 @@ metadata:
     system: openstack
     type: backend
     component: cinder
+  annotations:
+    secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets,{{ .Release.Name }}-volume-{{ $name }}-secret"
+    deployment.reloader.stakater.com/pause-period: "60s"
 spec:
   replicas: 1
   revisionHistoryLimit: {{ .Values.pod.lifecycle.upgrades.deployments.revisionHistory }}

--- a/openstack/glance/templates/deployment.yaml
+++ b/openstack/glance/templates/deployment.yaml
@@ -10,6 +10,9 @@ metadata:
     heritage: "{{ .Release.Service }}"
     type: api
     component: glance
+  annotations:
+    secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets"
+    deployment.reloader.stakater.com/pause-period: "60s"
 spec:
   replicas: {{ .Values.replicas }}
   revisionHistoryLimit: {{ .Values.upgrades.revisionHistory }}

--- a/openstack/glance/templates/glance-nanny-deployment.yaml
+++ b/openstack/glance/templates/glance-nanny-deployment.yaml
@@ -11,6 +11,9 @@ metadata:
     heritage: "{{ .Release.Service }}"
     type: nanny
     component: glance
+  annotations:
+    secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets"
+    deployment.reloader.stakater.com/pause-period: "60s"
 spec:
   replicas: {{ .Values.glance_nanny.replicas }}
   revisionHistoryLimit: {{ .Values.upgrades.revisionHistory }}

--- a/openstack/ironic/templates/_conductor-deployment.yaml.tpl
+++ b/openstack/ironic/templates/_conductor-deployment.yaml.tpl
@@ -13,6 +13,9 @@ metadata:
     system: openstack
     type: conductor
     component: ironic
+  annotations:
+    secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets"
+    deployment.reloader.stakater.com/pause-period: "60s"
 spec:
   replicas: 1
   revisionHistoryLimit: {{ .Values.pod.lifecycle.upgrades.deployments.revisionHistory }}

--- a/openstack/ironic/templates/api-deployment.yaml
+++ b/openstack/ironic/templates/api-deployment.yaml
@@ -7,6 +7,9 @@ metadata:
     system: openstack
     type: api
     component: ironic
+  annotations:
+    secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets"
+    deployment.reloader.stakater.com/pause-period: "60s"
 spec:
   replicas: {{ .Values.pod.replicas.api }}
   revisionHistoryLimit: {{ .Values.pod.lifecycle.upgrades.deployments.revisionHistory }}

--- a/openstack/ironic/templates/inspector-deployment.yaml
+++ b/openstack/ironic/templates/inspector-deployment.yaml
@@ -7,6 +7,9 @@ metadata:
     system: openstack
     type: backend
     component: ironic
+  annotations:
+    secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets"
+    deployment.reloader.stakater.com/pause-period: "60s"
 spec:
   replicas: {{ .Values.pod.replicas.inspector }}
   revisionHistoryLimit: {{ .Values.pod.lifecycle.upgrades.deployments.revisionHistory }}

--- a/openstack/keystone/templates/deployment-api.yaml
+++ b/openstack/keystone/templates/deployment-api.yaml
@@ -11,6 +11,9 @@ metadata:
     system: openstack
     component: keystone
     type: api
+  annotations:
+    secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets,{{ .Release.Name }}-federation"
+    deployment.reloader.stakater.com/pause-period: "60s"
 spec:
   replicas: {{ .Values.api.replicas }}
   minReadySeconds: {{ .Values.api.minReadySeconds | default 5}}

--- a/openstack/keystone/templates/deployment-cron.yaml
+++ b/openstack/keystone/templates/deployment-cron.yaml
@@ -11,6 +11,9 @@ metadata:
     system: openstack
     component: keystone
     type: operations
+  annotations:
+    secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets"
+    deployment.reloader.stakater.com/pause-period: "60s"
 spec:
   replicas: {{ .Values.cron.replicas }}
   revisionHistoryLimit: {{ .Values.cron.upgrades.revisionHistory }}

--- a/openstack/kmip/templates/deployment.yaml
+++ b/openstack/kmip/templates/deployment.yaml
@@ -11,6 +11,9 @@ metadata:
     system: openstack
     type: api
     component: barbican
+  annotations:
+    secret.reloader.stakater.com/reload: "kmip-secrets,kmip-barbican-etc"
+    deployment.reloader.stakater.com/pause-period: "60s"
 spec:
   replicas: {{ .Values.replicaCount }}
 

--- a/openstack/manila/templates/api-deployment.yaml
+++ b/openstack/manila/templates/api-deployment.yaml
@@ -11,8 +11,10 @@ metadata:
     system: openstack
     component: manila
     type: api
-  {{- if .Values.vpa.set_main_container }}
   annotations:
+    secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets"
+    deployment.reloader.stakater.com/pause-period: "60s"
+  {{- if .Values.vpa.set_main_container }}
     vpa-butler.cloud.sap/main-container: manila-api
   {{- end }}
 spec:

--- a/openstack/manila/templates/scheduler-deployment.yaml
+++ b/openstack/manila/templates/scheduler-deployment.yaml
@@ -7,8 +7,10 @@ metadata:
     system: openstack
     type: backend
     component: manila
-  {{- if .Values.vpa.set_main_container }}
   annotations:
+    secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets"
+    deployment.reloader.stakater.com/pause-period: "60s"
+  {{- if .Values.vpa.set_main_container }}
     vpa-butler.cloud.sap/main-container: manila-scheduler
   {{- end }}
 spec:

--- a/openstack/manila/templates/shares/_netapp-deployment.yaml.tpl
+++ b/openstack/manila/templates/shares/_netapp-deployment.yaml.tpl
@@ -10,8 +10,10 @@ metadata:
     system: openstack
     type: backend
     component: manila
-  {{- if .Values.vpa.set_main_container }}
   annotations:
+    secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets,{{ .Release.Name }}-share-netapp-{{$share.name}}-secret"
+    deployment.reloader.stakater.com/pause-period: "60s"
+  {{- if .Values.vpa.set_main_container }}
     vpa-butler.cloud.sap/main-container: manila-share-netapp-{{$share.name}}
   {{- end }}
 spec:

--- a/openstack/manila/templates/shares/_netapp-ensure-deployment.yaml.tpl
+++ b/openstack/manila/templates/shares/_netapp-ensure-deployment.yaml.tpl
@@ -8,8 +8,10 @@ metadata:
   labels:
     system: openstack
     component: manila
-  {{- if .Values.vpa.set_main_container }}
   annotations:
+    secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets,{{ .Release.Name }}-share-netapp-{{$share.name}}-secret"
+    deployment.reloader.stakater.com/pause-period: "60s"
+  {{- if .Values.vpa.set_main_container }}
     vpa-butler.cloud.sap/main-container: reexport
   {{- end }}
 spec:

--- a/openstack/octavia/templates/octavia-api-deployment.yaml
+++ b/openstack/octavia/templates/octavia-api-deployment.yaml
@@ -7,8 +7,10 @@ metadata:
     helm.sh/chart: {{ include "octavia.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-  {{- if .Values.vpa.set_main_container }}
   annotations:
+    secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets"
+    deployment.reloader.stakater.com/pause-period: "60s"
+  {{- if .Values.vpa.set_main_container }}
     vpa-butler.cloud.sap/main-container: {{ .Chart.Name }}-api
   {{- end }}
 spec:
@@ -39,7 +41,7 @@ spec:
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
         {{- end }}
         {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
-        
+
     spec:
       priorityClassName: critical-payload
       {{- include "utils.proxysql.pod_settings" . | nindent 6 }}

--- a/openstack/octavia/templates/octavia-housekeeping.yaml
+++ b/openstack/octavia/templates/octavia-housekeeping.yaml
@@ -7,10 +7,12 @@ metadata:
     helm.sh/chart: {{ include "octavia.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-  {{- if .Values.vpa.set_main_container }}
   annotations:
+  {{- if .Values.vpa.set_main_container }}
     vpa-butler.cloud.sap/main-container: octavia-f5-housekeeping
   {{- end }}
+    secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets"
+    deployment.reloader.stakater.com/pause-period: "60s"
 spec:
   replicas: 1
   selector:

--- a/openstack/octavia/templates/octavia-worker-deployment.yaml
+++ b/openstack/octavia/templates/octavia-worker-deployment.yaml
@@ -10,8 +10,10 @@ metadata:
     helm.sh/chart: {{ include "octavia.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-  {{- if .Values.vpa.set_main_container }}
   annotations:
+    secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets,{{ .Release.Name }}-secrets-{{ $name }}"
+    deployment.reloader.stakater.com/pause-period: "60s"
+  {{- if .Values.vpa.set_main_container }}
     vpa-butler.cloud.sap/main-container: octavia-worker
   {{- end }}
 spec:

--- a/openstack/placement/templates/placement-api-deployment.yaml
+++ b/openstack/placement/templates/placement-api-deployment.yaml
@@ -7,6 +7,9 @@ metadata:
     system: openstack
     type: api
     component: placement
+  annotations:
+    secret.reloader.stakater.com/reload: "placement-etc"
+    deployment.reloader.stakater.com/pause-period: "60s"
 spec:
   replicas: {{ .Values.pod.replicas.placement }}
   revisionHistoryLimit: {{ .Values.pod.lifecycle.upgrades.deployments.revision_history }}


### PR DESCRIPTION
Add reloader annotations to OpenStack services.

This will ensure that services are restarted on respective DB or RabbitMQ credentials update