### PR TITLE
[reloader][barbican] add reloader annotations

### DIFF
--- a/openstack/barbican/Chart.yaml
+++ b/openstack/barbican/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: dalmatian
 description: A Helm chart for Openstack Barbican
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Barbican/OpenStack_Project_Barbican_vertical.png
 name: barbican
-version: 0.7.3
+version: 0.7.4
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/barbican/templates/api-deployment.yaml
+++ b/openstack/barbican/templates/api-deployment.yaml
@@ -11,6 +11,9 @@ metadata:
     system: openstack
     type: api
     component: barbican
+  annotations:
+    secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets"
+    deployment.reloader.stakater.com/pause-period: "60s"
 spec:
   replicas: {{ required ".Values.api.replicas is missing" .Values.api.replicas }}
   revisionHistoryLimit: {{ .Values.pod.lifecycle.upgrades.deployments.revisionHistory }}

--- a/openstack/barbican/templates/barbican-nanny-deployment.yaml
+++ b/openstack/barbican/templates/barbican-nanny-deployment.yaml
@@ -11,6 +11,9 @@ metadata:
     heritage: "{{ .Release.Service }}"
     type: nanny
     component: barbican
+  annotations:
+    secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets"
+    deployment.reloader.stakater.com/pause-period: "60s"
 spec:
   replicas: {{ .Values.barbican_nanny.replicas }}
   revisionHistoryLimit: {{ .Values.pod.lifecycle.upgrades.deployments.revisionHistory }}


### PR DESCRIPTION
Add reloader annotations to the service deployments.

This would ensure that services are restarted on the respective DB or RabbitMQ credentials update.

Annotations added:
* `secret.reloader.stakater.com/reload` - list of secrets to track
* `deployment.reloader.stakater.com/pause-period` - pause interval before deployment rollout. E.g., if we have different credentials changed within one minute, then only one restart would be triggered. This will also help with kubelet sync interval, on which the time to apply vault change depends