### PR TITLE
[reloader][glance] add reloader annotations

### DIFF
--- a/openstack/glance/Chart.yaml
+++ b/openstack/glance/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: dalmatian
 description: A Helm chart Openstack Glance
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Glance/OpenStack_Project_Glance_vertical.png
 name: glance
-version: 0.7.2
+version: 0.7.3
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/glance/templates/deployment.yaml
+++ b/openstack/glance/templates/deployment.yaml
@@ -10,6 +10,9 @@ metadata:
     heritage: "{{ .Release.Service }}"
     type: api
     component: glance
+  annotations:
+    secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets"
+    deployment.reloader.stakater.com/pause-period: "60s"
 spec:
   replicas: {{ .Values.replicas }}
   revisionHistoryLimit: {{ .Values.upgrades.revisionHistory }}

--- a/openstack/glance/templates/glance-nanny-deployment.yaml
+++ b/openstack/glance/templates/glance-nanny-deployment.yaml
@@ -11,6 +11,9 @@ metadata:
     heritage: "{{ .Release.Service }}"
     type: nanny
     component: glance
+  annotations:
+    secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets"
+    deployment.reloader.stakater.com/pause-period: "60s"
 spec:
   replicas: {{ .Values.glance_nanny.replicas }}
   revisionHistoryLimit: {{ .Values.upgrades.revisionHistory }}


### PR DESCRIPTION
Add reloader annotations to the service deployments.

This would ensure that services are restarted on the respective DB or RabbitMQ credentials update.

Annotations added:
* `secret.reloader.stakater.com/reload` - list of secrets to track
* `deployment.reloader.stakater.com/pause-period` - pause interval before deployment rollout. E.g., if we have different credentials changed within one minute, then only one restart would be triggered. This will also help with kubelet sync interval, on which the time to apply vault change depends