### PR TITLE
[reloader][ironic] add reloader annotations

### DIFF
--- a/openstack/ironic/Chart.yaml
+++ b/openstack/ironic/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Ironic/OpenStack_Project_Ironic_vertical.png
 name: ironic
-version: 0.2.4
+version: 0.2.5
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/ironic/templates/_conductor-deployment.yaml.tpl
+++ b/openstack/ironic/templates/_conductor-deployment.yaml.tpl
@@ -13,6 +13,9 @@ metadata:
     system: openstack
     type: conductor
     component: ironic
+  annotations:
+    secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets"
+    deployment.reloader.stakater.com/pause-period: "60s"
 spec:
   replicas: 1
   revisionHistoryLimit: {{ .Values.pod.lifecycle.upgrades.deployments.revisionHistory }}

--- a/openstack/ironic/templates/api-deployment.yaml
+++ b/openstack/ironic/templates/api-deployment.yaml
@@ -7,6 +7,9 @@ metadata:
     system: openstack
     type: api
     component: ironic
+  annotations:
+    secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets"
+    deployment.reloader.stakater.com/pause-period: "60s"
 spec:
   replicas: {{ .Values.pod.replicas.api }}
   revisionHistoryLimit: {{ .Values.pod.lifecycle.upgrades.deployments.revisionHistory }}

--- a/openstack/ironic/templates/inspector-deployment.yaml
+++ b/openstack/ironic/templates/inspector-deployment.yaml
@@ -7,6 +7,9 @@ metadata:
     system: openstack
     type: backend
     component: ironic
+  annotations:
+    secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets"
+    deployment.reloader.stakater.com/pause-period: "60s"
 spec:
   replicas: {{ .Values.pod.replicas.inspector }}
   revisionHistoryLimit: {{ .Values.pod.lifecycle.upgrades.deployments.revisionHistory }}


### PR DESCRIPTION
Add reloader annotations to the service deployments.

This would ensure that services are restarted on the respective DB or RabbitMQ credentials update.

Annotations added:
* `secret.reloader.stakater.com/reload` - list of secrets to track
* `deployment.reloader.stakater.com/pause-period` - pause interval before deployment rollout. E.g., if we have different credentials changed within one minute, then only one restart would be triggered. This will also help with kubelet sync interval, on which the time to apply vault change depends