### PR TITLE
[reloader][kmip] add reloader annotations

### DIFF
--- a/openstack/kmip/Chart.yaml
+++ b/openstack/kmip/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Chart Version
-version: 0.3.3
+version: 0.3.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/openstack/kmip/templates/deployment.yaml
+++ b/openstack/kmip/templates/deployment.yaml
@@ -11,6 +11,9 @@ metadata:
     system: openstack
     type: api
     component: barbican
+  annotations:
+    secret.reloader.stakater.com/reload: "kmip-secrets,kmip-barbican-etc"
+    deployment.reloader.stakater.com/pause-period: "60s"
 spec:
   replicas: {{ .Values.replicaCount }}
 


### PR DESCRIPTION
Add reloader annotations to the service deployment.

This would ensure that services are restarted on the respective DB or RabbitMQ credentials update.

Annotations added:
* `secret.reloader.stakater.com/reload` - list of secrets to track
* `deployment.reloader.stakater.com/pause-period` - pause interval before deployment rollout. E.g., if we have different credentials changed within one minute, then only one restart would be triggered. This will also help with kubelet sync interval, on which the time to apply vault change depends