### PR TITLE
[reloader][placement] add reloader annotations

### DIFF
--- a/openstack/placement/Chart.yaml
+++ b/openstack/placement/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 description: A Helm chart for the Openstack Placement Service
 name: placement
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/project-mascots/Placement/OpenStack_Project_Placement_horizontal.jpg
-version: 0.2.2
+version: 0.2.3
 appVersion: "dalmatian"
 dependencies:
   - condition: mariadb.enabled

--- a/openstack/placement/templates/placement-api-deployment.yaml
+++ b/openstack/placement/templates/placement-api-deployment.yaml
@@ -7,6 +7,9 @@ metadata:
     system: openstack
     type: api
     component: placement
+  annotations:
+    secret.reloader.stakater.com/reload: "placement-etc"
+    deployment.reloader.stakater.com/pause-period: "60s"
 spec:
   replicas: {{ .Values.pod.replicas.placement }}
   revisionHistoryLimit: {{ .Values.pod.lifecycle.upgrades.deployments.revision_history }}


### PR DESCRIPTION
Add reloader annotations to the service deployment.

This would ensure that services are restarted on the respective DB or RabbitMQ credentials update.

Annotations added:
* `secret.reloader.stakater.com/reload` - list of secrets to track
* `deployment.reloader.stakater.com/pause-period` - pause interval before deployment rollout. E.g., if we have different credentials changed within one minute, then only one restart would be triggered. This will also help with kubelet sync interval, on which the time to apply vault change depends