### PR TITLE
[mariadb] version bumped to 10.11.13

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.25.0 - 2025-07-02
+* MariaDB version updated to [10.11.13](https://mariadb.com/kb/en/mariadb-10-11-13-release-notes/)
+  * See https://mariadb.com/kb/en/changes-improvements-in-mariadb-1011/
+* mysql-exporter version updated to [v0.17.2](https://github.com/prometheus/mysqld_exporter/releases/tag/v0.17.2)
+* chart version bumped
+
 ## v0.24.2 - 2025/05/27
 * MariaDB version bumped to [10.6.22](https://mariadb.com/kb/en/mariadb-10-6-22-release-notes/)
   * InnoDB race condition has been fixed

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,6 +2,6 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.24.2
+version: 0.25.0
 # scripts/docker-entyrpoint.sh should be updated when appVersion is updated
-appVersion: 10.6.22
+appVersion: 10.11.13

--- a/common/mariadb/scripts/docker-entrypoint.sh
+++ b/common/mariadb/scripts/docker-entrypoint.sh
@@ -216,6 +216,14 @@ docker_create_db_directories() {
 			find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
 		fi
 
+		# memory.pressure
+		local cgroup; cgroup=$(</proc/self/cgroup)
+		local mempressure="/sys/fs/cgroup/${cgroup:3}/memory.pressure"
+		if [ -w "$mempressure" ]; then
+			chown mysql: "$mempressure" || mysql_warn "unable to change ownership of $mempressure, functionality unavailable to MariaDB"
+		else
+			mysql_warn "$mempressure not writable, functionality unavailable to MariaDB"
+		fi
 	fi
 }
 
@@ -503,7 +511,7 @@ docker_mariadb_init()
 			if [ -f "$DATADIR/.init/backup-my.cnf" ]; then
 				mv "$DATADIR/.init/backup-my.cnf" "$DATADIR/.my.cnf"
 				mysql_note "Adding startup configuration:"
-				my_print_defaults --defaults-file="$DATADIR/.my.cnf" --mysqld
+				my_print_defaults --defaults-file="$DATADIR/.my.cnf" --mariadbd
 			fi
 			rm -rf "$DATADIR"/.init "$DATADIR"/.restore
 			if [ "$(id -u)" = "0" ]; then

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -4,7 +4,7 @@
 # name: value
 
 name: null
-image: library/mariadb:10.6.22
+image: library/mariadb:10.11.13
 imagePullPolicy: IfNotPresent
 port_public: 3306
 max_connections: 1024
@@ -227,7 +227,7 @@ backup_v2:
 metrics:
   enabled: true
   image: prom/mysqld-exporter
-  image_version: v0.17.1
+  image_version: v0.17.2
   port: "9104"
   flags:
     - collect.binlog_size


### PR DESCRIPTION
* MariaDB version updated to [10.11.13](https://mariadb.com/kb/en/mariadb-10-11-13-release-notes/)
  * See https://mariadb.com/kb/en/changes-improvements-in-mariadb-1011/
  * See https://mariadb.com/kb/en/upgrading-from-mariadb-10-6-to-mariadb-10-11/
  * Please note that in-place downgrade between major MariaDB versions isn't supported, so logical backup needs to be restored if rollback is done.
* mysql-exporter version updated to [v0.17.2](https://github.com/prometheus/mysqld_exporter/releases/tag/v0.17.2)
* chart version bumped