### PR TITLE
[Nova] Bump mariadb chart version

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.24.1
+  version: 0.24.2
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.24.1
+  version: 0.24.2
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.4.4
@@ -19,7 +19,7 @@ dependencies:
   version: 0.26.0
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.24.1
+  version: 0.24.2
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.17.1
@@ -29,5 +29,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:a0b9f7e2d7fe6e261e0716661c9a09d6cd567999dbeb48296c3218a4c86510ee
-generated: "2025-05-20T13:28:44.925076+02:00"
+digest: sha256:22b49429de08fb51656352f073ef0346c07060bab7e07c6ed82619f0ad42a413
+generated: "2025-06-03T15:40:52.681379507+02:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -8,12 +8,12 @@ dependencies:
   - name: mariadb
     condition: mariadb.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.24.1
+    version: 0.24.2
   - name: mariadb
     alias: mariadb_api
     condition: mariadb_api.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.24.1
+    version: 0.24.2
   - name: mysql_metrics
     condition: mariadb.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
@@ -31,7 +31,7 @@ dependencies:
     alias: mariadb_cell2
     condition: mariadb_cell2.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.24.1
+    version: 0.24.2
   - name: rabbitmq
     alias: rabbitmq_cell2
     condition: cell2.enabled


### PR DESCRIPTION
This upgrades mariadb to 10.6.22 which fixes a race-condition and multiple CVEs.