### PR TITLE
[Nova] Disable considering free disk during scheduling

### DIFF
--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -258,7 +258,7 @@ scheduler:
   vm_size_threshold_hv_size_mb: "819200"
   ram_weight_multiplier: 1.0
   cpu_weight_multiplier: 1.0
-  disk_weight_multiplier: 1.0
+  disk_weight_multiplier: 0.0
   io_ops_weight_multiplier: 0.0
   soft_affinity_weight_multiplier: 1.0
   # The following weighers are crutches, but we can't express it otherwise


### PR DESCRIPTION
We usually have enough free space and it's way more important to us how much RAM/VCPUs we have free on a host than how much disk we have free.

With vastly differing disk space usage of up to 50% this has some impact.