### PR TITLE
[Neutron] Use old policy setting

### DIFF
--- a/openstack/neutron/templates/etc/_neutron.conf.tpl
+++ b/openstack/neutron/templates/etc/_neutron.conf.tpl
@@ -53,6 +53,10 @@ owner_check_cache_expiration_time = {{ .Values.api.owner_check_cache_expiration_
 
 {{- template "utils.snippets.debug.eventlet_backdoor_ini" "neutron" }}
 
+[oslo_policy]
+enforce_scope = False
+enforce_new_defaults = False
+
 [nova]
 auth_url = {{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000 }}/v3
 # DEPRECATED: auth_plugin


### PR DESCRIPTION
With the Neutron Caracal release two things changes with respect to policies:
1. Per default, Neutron enforces the token scope (e.g. project, domain or system) check.
2. Per default, the old deprecated rules are not evaluated anymore.

With enforcing the new default rules (2) causes PolicyNotAuthorized errors on our side. To minimize the migration risk, we decided to go on with the old policy setting (as it currently is) and migrate to the new defaults in a later step.