### PR TITLE
ironic dependency updates

### DIFF
--- a/openstack/ironic/Chart.lock
+++ b/openstack/ironic/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.24.1
+  version: 0.24.2
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.4.0
@@ -19,12 +19,12 @@ dependencies:
   version: 0.18.0
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.26.0
+  version: 0.27.0
 - name: ironic-exporter
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.3
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:9c9b9b30cd278e27e8540e72837aa57b0e085a81a7dd6a80929b0ef6c4accd2b
-generated: "2025-05-16T15:14:03.406972+03:00"
+digest: sha256:e6eae7fe739b2f58fe72172c1f373097a29d76703fbf23c425637a9a7fef929b
+generated: "2025-06-03T18:36:45.223346026+02:00"

--- a/openstack/ironic/Chart.yaml
+++ b/openstack/ironic/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Ironic/OpenStack_Project_Ironic_vertical.png
 name: ironic
-version: 0.2.5
+version: 0.2.6
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.24.1
+    version: ~0.24.2
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db
@@ -15,11 +15,11 @@ dependencies:
     version: ~0.4.0
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.6.8
+    version: ~0.6.10
   - condition: mysql_metrics.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.4.2
+    version: ~0.4.4
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: ~1.0.0
@@ -28,7 +28,7 @@ dependencies:
     version: ~0.18.0
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.26.0
+    version: ~0.27.0
   - name: ironic-exporter
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: ~1.0.3


### PR DESCRIPTION
mariadb
- [mariadb] version bumped to 10.6.22
memcached
- add option to set vpa main container
- Set type: LoadBalancer in case of external IP
- needed for global/calico rollout
- chart version bumped
mysql_metrics
- add reloader annotation to the deployment
- add option to set vpa main container
utils
- [utils][proxysql] Add restartPolicy for native sidecar mode
