### PR TITLE
Update RBAC to allow annotation of Secrets

### DIFF
--- a/common/postgresql-ng/Chart.yaml
+++ b/common/postgresql-ng/Chart.yaml
@@ -44,6 +44,6 @@ description: Chart for PostgreSQL
 # 2.0.3
 # - Fix DB name double quoting issues in startup sql script
 #
-# 2.0.5
+# 2.0.5, 2.0.6
 # - Fix reloader.annotateGeneratedSecrets not annotating generated secrets
-version: 2.0.5 # this version number is SemVer as it gets used to auto bump
+version: 2.0.6 # this version number is SemVer as it gets used to auto bump

--- a/common/postgresql-ng/templates/rbac.yaml
+++ b/common/postgresql-ng/templates/rbac.yaml
@@ -14,7 +14,7 @@ rules:
   # `$RELEASE-pguser-$USERNAME` secrets on first start.
   - apiGroups: [ "" ]
     resources: [ secrets ]
-    verbs:     [ get, delete ]
+    verbs:     [ get, delete, patch, update ]
     resourceNames:
       {{- if .Values.persistence.createBackupUser }}
       - {{ $.Release.Name }}-pguser-backup

--- a/common/redis/Chart.yaml
+++ b/common/redis/Chart.yaml
@@ -44,6 +44,6 @@ name: redis
 #   `.Values.reloader.annotateGeneratedSecrets` and
 #   `.Values.metrics.reloader.enabled`
 #
-# 2.2.10
+# 2.2.10, 2.2.11
 # - Fix reloader.annotateGeneratedSecrets not annotating generated secrets
-version: 2.2.10 # this version number is SemVer as it gets used to auto bump
+version: 2.2.11 # this version number is SemVer as it gets used to auto bump

--- a/common/redis/templates/rbac.yaml
+++ b/common/redis/templates/rbac.yaml
@@ -17,7 +17,7 @@ rules:
   # `$RELEASE-redis-user-$USERNAME` secrets on first start.
   - apiGroups: [ "" ]
     resources: [ secrets ]
-    verbs:     [ get, delete ]
+    verbs:     [ get, delete, patch, update ]
     resourceNames:
       - {{ $fullname }}-user-default
 


### PR DESCRIPTION
Follow-up for #8816.

Without `patch` it fails with:

```
Error from server (Forbidden): secrets "<release>-pguser-backup" is forbidden: User "system:serviceaccount:<release-ns>:<release>-postgresql" cannot patch resource "secrets" in API group "" in the namespace "<release-ns>"
```

`update` is added for the sake of completeness - e.g. if `kubectl` decides to switch to `update` when annotating in future, or if something else is added to the script that might require `update`.