### PR TITLE
[octavia] Add failover_timeout and raise it from default 5s to 10s

### DIFF
--- a/openstack/octavia/templates/etc/_octavia.conf.tpl
+++ b/openstack/octavia/templates/etc/_octavia.conf.tpl
@@ -59,6 +59,9 @@ health_update_threads = {{ .Values.status_manager.health_update_threads }}
 {{- if .Values.status_manager.stats_update_threads }}
 stats_update_threads = {{ .Values.status_manager.stats_update_threads }}
 {{- end }}
+{{- if .Values.status_manager.failover_timeout }}
+failover_timeout = {{ .Values.status_manager.failover_timeout }}
+{{- end }}
 {{- end }}
 
 {{ if .Values.house_keeping }}

--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -108,7 +108,6 @@ pxc_db:
 
 status_manager:
   health_check_interval: 120
-  failover_timeout: 10
 
 ingress:
   annotations:

--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -108,6 +108,7 @@ pxc_db:
 
 status_manager:
   health_check_interval: 120
+  failover_timeout: 10
 
 ingress:
   annotations:


### PR DESCRIPTION
Our Octavia F5 provider driver is measuring the availability of its backend (F5 devices) regularly [via a GET request to /](https://github.com/sapcc/octavia-f5-provider-driver/blob/4a82c96f8a2797a19682fbac956c811c7d665f2b/octavia_f5/restclient/bigip/bigip_restclient.py#L86) with a [default timeout of five seconds](https://github.com/sapcc/octavia-f5-provider-driver/blob/4a82c96f8a2797a19682fbac956c811c7d665f2b/octavia_f5/common/config.py#L229).
We're seeing lots of instances where devices have such high CPU load that they fail to respond within this default timeout.

Override the default timeout with a higher value (10s).