### PR TITLE
feat(opensearch): add opensearch user credentials

### DIFF
--- a/system/greenhouse-ccloud/Chart.yaml
+++ b/system/greenhouse-ccloud/Chart.yaml
@@ -2,5 +2,4 @@ apiVersion: v2
 name: ccloud
 description: A Helm chart for the CCloud organization in Greenhouse.
 type: application
-version: 1.24.3
-
+version: 1.24.4

--- a/system/greenhouse-ccloud/templates/opensearch-users.yaml
+++ b/system/greenhouse-ccloud/templates/opensearch-users.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.plugins.enabled .Values.opensearch.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: opensearch-users-credentials
+  namespace: {{ $.Release.Namespace }}
+data:
+  logs_username: {{ required ".Values.opensearch.users.logs.username missing" .Values.opensearch.users.logs.username | b64enc }}
+  logs_password: {{ required ".Values.opensearch.users.logs.password missing" .Values.opensearch.users.logs.password | b64enc }}
+  logs2_username: {{ required ".Values.opensearch.users.logs2.username missing" .Values.opensearch.users.logs2.username | b64enc }}
+  logs2_password: {{ required ".Values.opensearch.users.logs2.password missing" .Values.opensearch.users.logs2.password | b64enc }}
+{{- end }}

--- a/system/greenhouse-ccloud/values.yaml
+++ b/system/greenhouse-ccloud/values.yaml
@@ -1,7 +1,7 @@
 mappedOrgAdminIdPGroup:
 
 # enabling pluginPreset.enabled will render PluginPreset
-# These will deploy DigiCert Issuer, CertManager, KubeMonitoring to 
+# These will deploy DigiCert Issuer, CertManager, KubeMonitoring to
 # all Clusters with label greenhouse.sap/cluster-presets-enabled: "true"
 pluginPreset:
   enabled: false
@@ -30,7 +30,7 @@ oidc:
   clientSecret:
 scim:
   enabled: false
-  # baseURL: 
+  # baseURL:
   # username:
   # password
 
@@ -155,7 +155,7 @@ openTelemetry:
     serviceMonitor:
       enabled: true
   admissionWebhooks:
-    certManager: 
+    certManager:
       enabled: true
     autoGenerateCert:
       enabled: false
@@ -167,7 +167,10 @@ openTelemetry:
       defaultRules:
         enabled: false
       enabled: false
-  
+
+opensearch:
+  enabled: false
+
 thanos:
   enabled: true
   # The cluster to which the global Thanos Query is deployed to


### PR DESCRIPTION
This PR adds a secret for OpenSearch user credentials. The secret can be selected in the OpenSearch plugin configuration to create a logs user (+ fail over user) with appropriate username and password retrieved from Vault for log ingestion.