### PR TITLE
[Neutron] Exclude Neutron Tempest from rate limiting

### DIFF
--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -742,6 +742,20 @@ rate_limit:
     - Default/service
     - Default/admin
     - ccadmin/cloud_admin
+    - tempest/neutron-tempest-admin1
+    - tempest/neutron-tempest-admin2
+    - tempest/neutron-tempest-admin3
+    - tempest/neutron-tempest-admin4
+    - tempest/neutron-tempest1
+    - tempest/neutron-tempest2
+    - tempest/neutron-tempest3
+    - tempest/neutron-tempest4
+    - tempest/neutron-tempest5
+    - tempest/neutron-tempest6
+    - tempest/neutron-tempest7
+    - tempest/neutron-tempest8
+    - tempest/neutron-tempest9
+    - tempest/neutron-tempest10
   whitelist_users: null
   blacklist: null
   blacklist_users: null


### PR DESCRIPTION
During some of our tempest runs, tests fail with an HTTP 429 error. Excluding them from rate limiting should increase tempest robustness.

Unfortunately, our rate limit middleware does not support wildcards for allowlists.