### PR TITLE
Create cron-ops-docu-rag-upload.yaml

### DIFF
--- a/system/jupyter-cron-reports/templates/cron-ops-docu-rag-upload.yaml
+++ b/system/jupyter-cron-reports/templates/cron-ops-docu-rag-upload.yaml
@@ -1,0 +1,67 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: "cron-ops-docu-rag-upload"
+  namespace: jupyterhub
+spec:
+  schedule: "0 6 * * 1-7"
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 1800
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: "cron-ops-docu-rag-upload"
+            image: "{{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ .Values.jupyterhub_cron.images.application.name }}:{{ .Values.jupyterhub_cron.images.application.tag }}"
+            command: ['sh', '-c']
+            args:
+            - >
+              papermill script_uploading_ops_doc_weekly.ipynb - -r swift_url $(swift_url) && /linkerd-await --shutdown echo "shutdown linkerd-proxy" \
+            volumeMounts:
+            - name: notebooks-git
+              mountPath: /home/jovyan
+            env:
+            {{- if not (and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested) }}
+            - name: LINKERD_AWAIT_DISABLED
+              value: "Linkerd was not enabled or not requested"
+            {{- end }}
+            - name: approle_role_id
+              valueFrom:
+                secretKeyRef:
+                  name: jupyter-cron-reports-secrets
+                  key: approle_role_id
+            - name: approle_secret_id
+              valueFrom:
+                secretKeyRef:
+                  name: jupyter-cron-reports-secrets
+                  key: approle_secret_id
+            - name: swift_url
+              valueFrom:
+                secretKeyRef:
+                  name: jupyter-cron-reports-secrets
+                  key: swift_url
+            securityContext:
+              allowPrivilegeEscalation: false
+          initContainers:
+          - name: "clone-notebooks"
+            volumeMounts:
+            - name: notebooks-git
+              mountPath: /notebooks-git
+            env:
+            - name: github_token
+              valueFrom:
+                secretKeyRef:
+                  name: jupyter-cron-reports-secrets
+                  key: github_token
+            - name: github_url
+              value: "https://github.wdf.sap.corp/api/v3/repos/cc/devsupport-scripts/contents"
+            image: "{{ required ".Values.global.dockerHubMirror variable missing" .Values.global.dockerHubMirror }}/{{ .Values.jupyterhub_cron.images.init.name }}:{{ .Values.jupyterhub_cron.images.init.tag }}"
+            command: ['sh', '-c']
+            args:
+            - >
+              curl -L -k -o \   -H "Accept: application/vnd.github.raw+json" \   -H "Authorization: Bearer $(github_token)" \   -H "X-GitHub-Api-Version: 2022-11-28" \   "$(github_url)/LLM_PoC/RAG_langchain_HANA/script_uploading_ops_doc_weekly.ipynb" > /notebooks-git/script_uploading_ops_doc_weekly.ipynb
+          volumes:
+          - name: notebooks-git
+            emptyDir: {}


### PR DESCRIPTION
Create cron-ops-docu-rag-upload cron job for RAG delta changes of ops docu to HANA DB. For devsupport chatbot. 