### PR TITLE
[seeder] extend ignore ns list for regional openstack-seeder

### DIFF
--- a/openstack/openstack-seeder/values.yaml
+++ b/openstack/openstack-seeder/values.yaml
@@ -35,7 +35,7 @@ owner-info:
 # only simulate, don't actually seed
 # dryRun: true
 # ignore seeds from a certain k8s namespace (or multiple namespaces, if a comma-separated list is given like below)
-ignoreNamespace: "limes-global,monsoon3global"
+ignoreNamespace: "limes-global,monsoon3global,maia-global,hermes-global,cc3test-global"
 # only apply seeds from a certain k8s namespace (or multiple namespaces, if a comma-separated list is given like above)
 onlyNamespace: ""
 


### PR DESCRIPTION
added ns: maia-global, hermes-global, cc3test-global.