### PR TITLE
[cinder] Add cinder permissions for mounting volumes

### DIFF
--- a/openstack/cinder/templates/backup_deployment.yaml
+++ b/openstack/cinder/templates/backup_deployment.yaml
@@ -57,7 +57,13 @@ template: |
           imagePullPolicy: {{ required ".Values.global.imagePullPolicy is missing" .Values.global.imagePullPolicy }}
           securityContext:
             capabilities:
-              add: ["SYS_ADMIN"]
+              add: 
+              - SYS_ADMIN
+              - NET_ADMIN
+              - FOWNER
+              - DAC_READ_SEARCH
+              - DAC_OVERRIDE
+              - CHOWN
           command:
           - dumb-init
           - cinder-backup


### PR DESCRIPTION
Cinder needs certain permissions to mount a volume locally (within the container). The priviledges are selectively escalated with `oslo.privsep`.

This is for the backup service