### PR TITLE
[cortex/rebalancer] Grant scheduler technical user access to Manila

### DIFF
--- a/openstack/cortex/Chart.yaml
+++ b/openstack/cortex/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Helm chart for cortex
 name: scheduler
-version: 0.0.1
+version: 0.0.2
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/cortex/templates/seed.yaml
+++ b/openstack/cortex/templates/seed.yaml
@@ -33,3 +33,5 @@ spec:
         role: cloud_volume_admin
       - user: scheduler_service@Default
         role: cloud_network_admin
+      - user: scheduler_service@Default
+        role: cloud_sharedfilesystem_admin


### PR DESCRIPTION
This change is needed to fully access Manila resources in Cortex.