### PR TITLE
[rabbitmq] version bumped to 4.1.1-management

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+## 0.18.1 - 2025/06/12
+
+- RabbitMQ [4.1.1 Release Notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.1.1)
+  - only `4.1.x` releases are [supported](https://www.rabbitmq.com/release-information#currently-supported)
+  - [4.1.1 Release Notes](https://github.com/rabbitmq/rabbitmq-server/blob/v4.1.x/release-notes/4.1.1.md)
+  - faster startup with empty classic queues
+  - classic queue compaction performance improvements
+- Chart version bumped
+
 ## 0.18.0 - 2025/04/22
 
 - RabbitMQ [4.1.0 Release Notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.1.0)
@@ -10,7 +19,6 @@ This file is used to list changes made in each version of the common chart rabbi
   * rabbitmqadmin has been updated to [2.0](https://github.com/rabbitmq/rabbitmqadmin-ng/releases/tag/v2.0.0), but is not yet included in the image
   * RabbitMQ nodes now provide a Prometheus histogram for message sizes published by applications
 - Chart version bumped
-
 
 ## 0.17.2 - 2025/04/10
 

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: v1
 name: rabbitmq
-version: 0.18.0
-appVersion: 4.1.0
+version: 0.18.1
+appVersion: 4.1.1
 description: A Helm chart for RabbitMQ
 sources:
   - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/values.yaml
+++ b/common/rabbitmq/values.yaml
@@ -11,7 +11,7 @@ global:
       enabled: true
 
 image: library/rabbitmq
-imageTag: 4.1.0-management
+imageTag: 4.1.1-management
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
- faster startup with empty classic queues
- classic queue compaction performance improvements
- chart version bumped