### PR TITLE
system/surveyor: init

### DIFF
--- a/system/surveyor/Chart.lock
+++ b/system/surveyor/Chart.lock
@@ -1,0 +1,18 @@
+dependencies:
+- name: linkerd-support
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 1.1.0
+- name: postgresql-ng
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 2.0.7
+- name: pgbackup
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 1.2.6
+- name: pgmetrics
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 2.0.4
+- name: owner-info
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 1.0.0
+digest: sha256:866435917550b5a3e0b040b0fbcc63df3fe8204061b7a69814ca0ff66cf12579
+generated: "2025-06-04T16:47:10.016519487+02:00"

--- a/system/surveyor/Chart.yaml
+++ b/system/surveyor/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+description: Surveyor
+name: surveyor
+version: 0.0.1
+dependencies:
+  - name: linkerd-support
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: '>= 0.0.0'
+  - name: postgresql-ng
+    alias: postgresql
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: '>= 0.0.0'
+  - name: pgbackup
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: '>= 0.0.0'
+  - name: pgmetrics
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: '>= 0.0.0'
+  - name: owner-info
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: '>= 0.0.0'

--- a/system/surveyor/ci/test-values.yaml
+++ b/system/surveyor/ci/test-values.yaml
@@ -1,0 +1,9 @@
+global:
+  tld: example.com
+  region: xx-yy-1
+  registry: registry.example.com
+  vaultBaseURL: vault.example.com/secrets
+
+surveyor:
+  public_hostname: surveyor.example.com
+  image_tag: 'v1.0.0'

--- a/system/surveyor/templates/_utils.tpl
+++ b/system/surveyor/templates/_utils.tpl
@@ -1,0 +1,22 @@
+{{- define "surveyor_image" -}}
+  {{- $registry := $.Values.global.registry    | required "missing value for .Values.global.registry" -}}
+  {{- $tag      := $.Values.surveyor.image_tag | required "This release should be installed by the deployment pipeline!" -}}
+  {{- printf "%s/surveyor:%s" $registry $tag -}}
+{{- end -}}
+
+{{- define "surveyor_environment" }}
+# TODO: SURVEYOR_AUDIT_*
+- name: SURVEYOR_DB_CONNECTION_OPTIONS
+  value: "sslmode=disable"
+- name: SURVEYOR_DB_HOSTNAME
+  value: "surveyor-postgresql.{{ .Release.Namespace }}.svc"
+- name:  SURVEYOR_DB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: '{{ $.Release.Name }}-pguser-surveyor'
+      key: 'postgres-password'
+- name:  SURVEYOR_DB_USERNAME
+  value: 'surveyor'
+- name:  SURVEYOR_DEBUG
+  value: 'false'
+{{- end }}

--- a/system/surveyor/templates/configmap.yaml
+++ b/system/surveyor/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+
+metadata:
+  name: surveyor-etc
+
+data:
+  # NOTE: Surveyor already auto-reloads this file by itself, so no checksum annotation is needed on the deployment.
+  config.json: |
+    {{ toPrettyJson .Values.surveyor.config | nindent 4 }}

--- a/system/surveyor/templates/deployment-frontend.yaml
+++ b/system/surveyor/templates/deployment-frontend.yaml
@@ -1,0 +1,62 @@
+kind: Deployment
+apiVersion: apps/v1
+
+metadata:
+  name: surveyor-frontend
+
+spec:
+  revisionHistoryLimit: 5
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      name: surveyor-frontend
+  template:
+    metadata:
+      labels:
+        name: surveyor-frontend
+        app.kubernetes.io/name: surveyor-frontend
+      annotations:
+        kubectl.kubernetes.io/default-container: frontend
+        prometheus.io/scrape: "true"
+        prometheus.io/targets: {{ .Values.prometheus.target }}
+    spec:
+      containers:
+        - name: frontend
+          image: {{ include "surveyor_image" . }}
+          imagePullPolicy: IfNotPresent
+          args: [ frontend ]
+          env: {{ include "surveyor_environment" . | indent 12 }}
+          securityContext:
+            runAsNonRoot: true
+          ports:
+            - name: metrics # this specific name is required for Prometheus scraping
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 8080
+            timeoutSeconds: 10
+            periodSeconds: 60
+            initialDelaySeconds: 60
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 8080
+            timeoutSeconds: 5
+            periodSeconds: 5
+          resources:
+            # TODO: adjust once we have some operating experience
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "1"
+              memory: "128Mi"
+

--- a/system/surveyor/templates/deployment-worker.yaml
+++ b/system/surveyor/templates/deployment-worker.yaml
@@ -1,0 +1,94 @@
+kind: Deployment
+apiVersion: apps/v1
+
+metadata:
+  name: surveyor-worker
+
+spec:
+  revisionHistoryLimit: 5
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      name: surveyor-worker
+  template:
+    metadata:
+      labels:
+        name: surveyor-worker
+        app.kubernetes.io/name: surveyor-worker
+      annotations:
+        kubectl.kubernetes.io/default-container: worker
+        prometheus.io/scrape: "true"
+        prometheus.io/targets: {{ .Values.prometheus.target }}
+    spec:
+      volumes:
+        - name: config
+          configMap:
+            name: surveyor-etc
+        - name: cache
+          persistentVolumeClaim:
+            claimName: surveyor-cache
+      initContainers:
+        - name: init-fs-ownership
+          image: {{ .Values.global.registry }}/shared-app-images/alpine-busybox:3.22-latest
+          imagePullPolicy: Always
+          command: [ /bin/sh ]
+          args: [ -c, 'chown -R 4200:4200 /var/cache/surveyor' ]
+          volumeMounts:
+            - mountPath: /var/cache/surveyor
+              name: cache
+          # ^ To the best of my knowledge, Kubernetes does not offer a builtin facility for this.
+          # Technically, there is spec.securityPolicy.fsGroup, but that seems to be intended for volume sources that use a non-root GID in fresh volumes, which ours do not:
+          # ```
+          # stat /var/cache/surveyor | grep Uid
+          # Access: (0755/drwxr-xr-x)  Uid: (    0/    root)   Gid: (    0/    root)
+          # ```
+      containers:
+        - name: worker
+          image: {{ include "surveyor_image" . }}
+          imagePullPolicy: IfNotPresent
+          args: [ worker ]
+          env: {{ include "surveyor_environment" . | indent 12 }}
+            - name: SURVEYOR_CONFIG_PATH
+              value: /etc/surveyor/config.json
+            - name: SURVEYOR_GIT_CACHE_DIR
+              value: /var/cache/surveyor
+            {{- range (keys .Values.surveyor.secrets | sortAlpha) }}
+            - name: {{ quote . }}
+              valueFrom:
+                secretKeyRef:
+                  name: surveyor-worker
+                  key:  {{ quote . }}
+            {{- end }}
+          securityContext:
+            runAsNonRoot: true
+          volumeMounts:
+            - mountPath: /etc/surveyor
+              name: config
+            - mountPath: /var/cache/surveyor
+              name: cache
+          ports:
+            - name: metrics # this specific name is required for Prometheus scraping
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 8080
+            timeoutSeconds: 10
+            periodSeconds: 60
+            initialDelaySeconds: 60
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 8080
+            timeoutSeconds: 5
+            periodSeconds: 5
+          resources:
+            # TODO: adjust once we have some operating experience
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+            limits:
+              cpu: "1"
+              memory: "256Mi"

--- a/system/surveyor/templates/ingress-frontend.yaml
+++ b/system/surveyor/templates/ingress-frontend.yaml
@@ -1,0 +1,39 @@
+{{- $tld := $.Values.global.tld                   | required "missing value for .Values.global.tld" }}
+{{- $hostname := .Values.surveyor.public_hostname | required "missing value for .Values.surveyor.public_hostname" -}}
+
+kind: Ingress
+apiVersion: networking.k8s.io/v1
+
+metadata:
+  name: surveyor-frontend
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    disco: "true"
+    ingress.kubernetes.io/auth-url: "https://auth-internal.eu-de-2.{{ $tld }}/oauth2/auth"
+    nginx.ingress.kubernetes.io/auth-url: "https://auth-internal.eu-de-2.{{ $tld }}/oauth2/auth"
+    ingress.kubernetes.io/auth-signin: "https://auth-internal.eu-de-2.{{ $tld }}/oauth2/start"
+    nginx.ingress.kubernetes.io/auth-signin: "https://auth-internal.eu-de-2.{{ $tld }}/oauth2/start"
+    ingress.kubernetes.io/auth-request-redirect: $escaped_request_uri
+    nginx.ingress.kubernetes.io/auth-request-redirect: $escaped_request_uri
+    ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-Email, X-Auth-Request-User"
+    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-Email, X-Auth-Request-User"
+    {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
+    ingress.kubernetes.io/service-upstream: "true"
+    nginx.ingress.kubernetes.io/service-upstream: "true"
+    {{- end }}
+
+spec:
+  tls:
+    - secretName: tls-surveyor-frontend
+      hosts: [ '{{ $hostname }}' ]
+  rules:
+    - host: '{{ $hostname }}'
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: surveyor-frontend
+                port:
+                  number: 8080

--- a/system/surveyor/templates/pvc-cache.yaml
+++ b/system/surveyor/templates/pvc-cache.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+
+metadata:
+  name: surveyor-cache
+
+spec:
+  accessModes: [ ReadWriteOnce ]
+  resources:
+    requests:
+      storage: 10Gi

--- a/system/surveyor/templates/secret.yaml
+++ b/system/surveyor/templates/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+
+metadata:
+  name: surveyor-worker
+
+data:
+  {{- range (keys .Values.surveyor.secrets | sortAlpha) }}
+  {{ . }}: {{ index $.Values.surveyor.secrets . | b64enc | quote }}
+  {{- end }}

--- a/system/surveyor/templates/service-frontend.yaml
+++ b/system/surveyor/templates/service-frontend.yaml
@@ -1,0 +1,13 @@
+kind: Service
+apiVersion: v1
+
+metadata:
+  name: surveyor-frontend
+
+spec:
+  selector:
+    name: surveyor-frontend
+  ports:
+    - name: http # this specific name is required for Prometheus scraping
+      port: 8080
+      protocol: TCP

--- a/system/surveyor/values.yaml
+++ b/system/surveyor/values.yaml
@@ -1,0 +1,74 @@
+global:
+  linkerd_requested: true
+linkerd-support:
+  annotate_namespace: true
+
+owner-info:
+  support-group: containers
+  service: surveyor
+  maintainers:
+    - Stefan Majewsky
+    - Sandro Jäckel
+    - Stefan Voigt
+    - Daniel Wagner
+  helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/system/surveyor
+
+surveyor:
+  # See <https://github.com/sapcc/surveyor/blob/main/README.md#configuration-via-json-file> for the structure of this field.
+  config: {}
+  # This is a map[string]string. Keys should be written in ALL_CAPS. These secrets will be made available as env variables
+  # in the surveyor-worker process, in order to make { "fromEnv": "FOO" } statements in the configuration file work.
+  secrets: {}
+  # The hostname where users will reach the Surveyor instance via HTTPS.
+  public_hostname: null
+
+  # supplied by pipeline, do not set in values.yaml
+  image_tag: null
+
+prometheus:
+  target: infra-frontend # there is no prometheus-openstack in scaleout, so we need to improvise :|
+
+postgresql:
+  persistence:
+    enabled: true
+    accessMode: ReadWriteOnce
+    size: 10Gi
+  databases:
+    surveyor: {}
+  users:
+    surveyor: {}
+
+  config:
+    log_min_duration_statement: 250
+    # less than the postgresql chart's default; I want to know early when connections start getting out of hand
+    max_connections: 64
+
+  alerts:
+    prometheus: infra-frontend # see above
+    support_group: containers
+
+  resources:
+    # estimated based on resource usage of other Postgres instances; may be useful to adjust later on
+    limits:
+      memory: 512Mi
+      cpu: '0.5'
+    requests:
+      memory: 512Mi
+      cpu: '0.5'
+
+pgbackup:
+  alerts:
+    prometheus: infra-frontend # see above
+    support_group: containers
+
+pgmetrics:
+  alerts:
+    prometheus: infra-frontend # see above
+    support_group: containers
+
+  collectors:
+    stat_bgwriter: false
+
+  databases:
+    surveyor:
+      customMetrics: {}


### PR DESCRIPTION
Ironically, Surveyor is not deployed as an OCM bundle for now, because that would require making changes to all the PostgreSQL subcharts. Those have not been done, and will not be done until we have fully settled on how we propagate image versions through the OCM bundles.