### PR TITLE
[manila] stop new share provisionings at 70% usage

### DIFF
--- a/openstack/manila/templates/shares/_share-netapp.conf.tpl
+++ b/openstack/manila/templates/shares/_share-netapp.conf.tpl
@@ -99,7 +99,7 @@ netapp_hardware_state = {{ $share.hardware_state | default "live" }}
 {{- if eq 100 (int $share.reserved_share_percentage)}}
 reserved_share_percentage = 100
 {{- else }}
-reserved_share_percentage = {{ $share.reserved_share_percentage | default 25 }}
+reserved_share_percentage = {{ $share.reserved_share_percentage | default 30 }}
 {{- end }}
 
 {{- if eq 100 (int $share.reserved_share_extend_percentage)}}


### PR DESCRIPTION
but still allow to extend existing shares and create shares from
snapshot up to 75% usage.

Storage team is trying to balance at 65% usage to always keep the
filers schedulable.
