### PR TITLE
[utils] Add flag for enabling ssl for rabbitmq

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.27.0
+version: 0.28.0


### PR DESCRIPTION
The flag needs to be global, as the setting is on the driver and will affect all amqp connections, including the one used in the audit middleware.