### PR TITLE
[hermes] Enable SSL for rabbitmq

### DIFF
--- a/openstack/hermes/Chart.lock
+++ b/openstack/hermes/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 0.1.3
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.18.5
+  version: 0.18.8
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
-digest: sha256:683c560f093fa5a00c54049679e6eb24d7d7c6596f16563ec906bcec151aa14d
-generated: "2025-07-28T10:39:25.057311-07:00"
+digest: sha256:59a119913b36974fdb642529c854aa9a09dfc4023aa4f73d85ea4c0002b2bbe9
+generated: "2025-08-01T13:40:38.687925107+02:00"

--- a/openstack/hermes/Chart.yaml
+++ b/openstack/hermes/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
     condition: audit.enabled
     name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.18.5 
+    version: 0.18.8
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.2.0

--- a/openstack/hermes/values.yaml
+++ b/openstack/hermes/values.yaml
@@ -113,6 +113,7 @@ rabbitmq_notifications:
   # service options
   serviceType: LoadBalancer
   serviceExternalTrafficPolicy: Local
+  enableSsl: true
 
 # Pod Monitor
 exporter:


### PR DESCRIPTION
This only enables the option for clients to connect to rabbitmq
using AMQPS, so with TLS encryption. As other services might
want to switch to SSL, and we only can enable it for all AMQP
connections at once, we need this in place before the services
switch TLS on for AMQP.