### PR TITLE
[nova] Enable ssl on rabbitmq

### DIFF
--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -856,6 +856,7 @@ mariadb_cell2:
           allTables: true
 
 rabbitmq_cell2:
+  enableSsl: true
   nameOverride: cell2-rabbitmq
   persistence:
     enabled: false
@@ -871,6 +872,7 @@ rabbitmq_cell2:
       enabled: false
     enableDetailedMetrics: true
     enablePerObjectMetrics: true
+
 audit:
   central_service:
     user: rabbitmq
@@ -880,6 +882,7 @@ audit:
   metrics_enabled: true
 
 rabbitmq:
+  enableSsl: true
   users:
     default:
       password: null


### PR DESCRIPTION
This change is mostly preparatory.

Internal use requires another commit, which has a dependency on a roll out of hermes enabling AMQPS, but also when rolled out before we won't have a race between the two changes.

Main purpose is to enable external use of the rabbitmq for KVM.