### PR TITLE
[neutron] Enable ssl on rabbitmq

### DIFF
--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -708,6 +708,7 @@ audit:
   mem_queue_size: 1000
 
 rabbitmq:
+  enableSsl: true
   name: neutron
   persistence:
     enabled: false


### PR DESCRIPTION
This change is mostly preparatory.

Internal use requires another commit, which has a dependency on a roll out of hermes enabling AMQPS, but also when rolled out before we won't have a race between the two changes.

Main purpose is to enable external use of the rabbitmq for KVM.