### PR TITLE
[nova] Add database nanny to Nova

### DIFF
--- a/openstack/nova/templates/bin-configmap.yaml
+++ b/openstack/nova/templates/bin-configmap.yaml
@@ -9,6 +9,12 @@ metadata:
 data:
 {{ (.Files.Glob "bin/*").AsConfig | indent 2 }}
   db-migrate: |
-{{ include (print .Template.BasePath "/bin/_db-migrate.tpl") . | indent 4 }}
+{{ include (include "job_bin_path" (tuple . "db-migrate")) . | indent 4 }}
   db-online-migrate: |
-{{ include (print .Template.BasePath "/bin/_db-online-migrate.tpl") . | indent 4 }}
+{{ include (include "job_bin_path" (tuple . "db-online-migrate")) . | indent 4 }}
+  nanny-db-archive-deleted-rows: |
+{{ include (include "job_bin_path" (tuple . "nanny-db-archive-deleted-rows" "nanny")) . | indent 4 }}
+  nanny-db-purge: |
+{{ include (include "job_bin_path" (tuple . "nanny-db-purge" "nanny")) . | indent 4 }}
+  nanny-db-soft-delete-excessive-instance-faults: |
+{{ include (include "job_bin_path" (tuple . "nanny-db-soft-delete-excessive-instance-faults" "nanny")) . | indent 4 }}

--- a/openstack/nova/templates/bin/nanny/_nanny-db-archive-deleted-rows.tpl
+++ b/openstack/nova/templates/bin/nanny/_nanny-db-archive-deleted-rows.tpl
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+archive_before=$(date -u --date "{{ .Values.nanny.db_archive_deleted_rows.older_than }} days ago" \
+  "+%Y-%m-%d %H:%M:%S")
+echo "INFO: archiving db rows deleted before ${archive_before} to shadow tables with batch size" \
+  "{{ .Values.nanny.db_archive_deleted_rows.max_rows }}"
+
+# Command "nova-manage db archive_deleted_rows" returns exit code 1 if rows were
+# archived. Catch this to prevent job failure.
+nova-manage db archive_deleted_rows --until-complete --max_rows {{ .Values.nanny.db_archive_deleted_rows.max_rows }} \
+  --all-cells --verbose --before "${archive_before}" || [[ "$?" == "1" ]]

--- a/openstack/nova/templates/bin/nanny/_nanny-db-purge.tpl
+++ b/openstack/nova/templates/bin/nanny/_nanny-db-purge.tpl
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+purge_before=$(date -u --date "{{ .Values.nanny.db_purge.older_than }} days ago" \
+  "+%Y-%m-%d %H:%M:%S")
+echo "INFO: purging archived db rows deleted before ${purge_before} from shadow tables"
+
+# Command "nova-manage db purge" returns exit code 3 if no rows were deleted.
+# Catch this to prevent script failure.
+nova-manage db purge --verbose --all-cells --before "${purge_before}" || [[ "$?" == "3" ]]

--- a/openstack/nova/templates/bin/nanny/_nanny-db-soft-delete-excessive-instance-faults.tpl
+++ b/openstack/nova/templates/bin/nanny/_nanny-db-soft-delete-excessive-instance-faults.tpl
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "INFO: soft-deleting db rows exceeding {{ .Values.nanny.db_soft_delete_excessive_instance_faults.max_faults }} " \
+  "instance faults per instance with batch size {{ .Values.nanny.db_soft_delete_excessive_instance_faults.max_rows }}"
+
+# Command "nova-manage db delete_excessive_instance_faults" returns exit code 1
+# if rows were soft-deleted. Catch this to prevent job failure.
+nova-manage db soft_delete_excessive_instance_faults --until-complete \
+  --max_rows {{ .Values.nanny.db_soft_delete_excessive_instance_faults.max_rows }} --all-cells --verbose \
+  --max_faults {{ .Values.nanny.db_soft_delete_excessive_instance_faults.max_faults }} || [[ "$?" == "1" ]]

--- a/openstack/nova/templates/nanny-db-archive-deleted-rows-cronjob.yaml
+++ b/openstack/nova/templates/nanny-db-archive-deleted-rows-cronjob.yaml
@@ -1,0 +1,76 @@
+{{- if .Values.nanny.db_archive_deleted_rows.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: nova-nanny-db-archive-deleted-rows
+  labels:
+    system: openstack
+    component: nova
+    type: nanny
+spec:
+  schedule: {{ .Values.nanny.db_archive_deleted_rows.schedule | quote }}
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          {{- tuple . "nanny-db-archive-deleted-rows" "nanny" | include "job_metadata" | indent 10 }}
+        spec:
+          restartPolicy: OnFailure
+          volumes:
+          - name: container-init
+            configMap:
+              name: nova-bin
+              defaultMode: 0755
+              items:
+              - key: nanny-db-archive-deleted-rows
+                path: nanny-script
+          {{- include "utils.trust_bundle.volumes" . | indent 10 }}
+          - name: nova-etc
+            projected:
+              sources:
+              - configMap:
+                  name: nova-etc
+                  items:
+                  - key:  nova.conf
+                    path: nova.conf
+                  - key:  logging.ini
+                    path: logging.ini
+                  - key:  release
+                    path: release
+              - secret:
+                  name: nova-etc
+                  items:
+                  - key: api-db.conf
+                    path: nova.conf.d/api-db.conf
+          initContainers:
+          {{- tuple . (dict "service" (include "nova.helpers.database_services" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 10 }}
+          containers:
+          - name: nanny
+            image: {{ tuple . "nanny" | include "container_image_nova" }}
+            imagePullPolicy: IfNotPresent
+            command:
+            - /bin/sh
+            - -c
+            - |
+              /container.init/nanny-script
+              exit_code=$?
+              {{- include "utils.script.job_finished_hook" . | nindent 14 }}
+              exit $exit_code
+            env:
+            {{- if .Values.sentry.enabled }}
+            {{- include "utils.sentry_config" . | nindent 12 }}
+            {{- end }}
+            - name: PYTHONWARNINGS
+              value: {{ .Values.python_warnings | quote }}
+            volumeMounts:
+            - mountPath: /etc/nova
+              name: nova-etc
+            - mountPath: /container.init
+              name: container-init
+            {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
+            resources:
+              requests:
+                memory: "500Mi"
+                cpu: "100m"
+{{- end }}

--- a/openstack/nova/templates/nanny-db-purge-cronjob.yaml
+++ b/openstack/nova/templates/nanny-db-purge-cronjob.yaml
@@ -1,0 +1,76 @@
+{{- if .Values.nanny.db_purge.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: nova-nanny-db-purge
+  labels:
+    system: openstack
+    component: nova
+    type: nanny
+spec:
+  schedule: {{ .Values.nanny.db_purge.schedule | quote }}
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          {{- tuple . "nanny-db-purge" "nanny" | include "job_metadata" | indent 10 }}
+        spec:
+          restartPolicy: OnFailure
+          volumes:
+          - name: container-init
+            configMap:
+              name: nova-bin
+              defaultMode: 0755
+              items:
+              - key: nanny-db-purge
+                path: nanny-script
+          {{- include "utils.trust_bundle.volumes" . | indent 10 }}
+          - name: nova-etc
+            projected:
+              sources:
+              - configMap:
+                  name: nova-etc
+                  items:
+                  - key:  nova.conf
+                    path: nova.conf
+                  - key:  logging.ini
+                    path: logging.ini
+                  - key:  release
+                    path: release
+              - secret:
+                  name: nova-etc
+                  items:
+                  - key: api-db.conf
+                    path: nova.conf.d/api-db.conf
+          initContainers:
+          {{- tuple . (dict "service" (include "nova.helpers.database_services" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 10 }}
+          containers:
+          - name: nanny
+            image: {{ tuple . "nanny" | include "container_image_nova" }}
+            imagePullPolicy: IfNotPresent
+            command:
+            - /bin/sh
+            - -c
+            - |
+              /container.init/nanny-script
+              exit_code=$?
+              {{- include "utils.script.job_finished_hook" . | nindent 14 }}
+              exit $exit_code
+            env:
+            {{- if .Values.sentry.enabled }}
+            {{- include "utils.sentry_config" . | nindent 12 }}
+            {{- end }}
+            - name: PYTHONWARNINGS
+              value: {{ .Values.python_warnings | quote }}
+            volumeMounts:
+            - mountPath: /etc/nova
+              name: nova-etc
+            - mountPath: /container.init
+              name: container-init
+            {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
+            resources:
+              requests:
+                memory: "500Mi"
+                cpu: "100m"
+{{- end }}

--- a/openstack/nova/templates/nanny-db-soft-delete-excessive-instance-faults-cronjob.yaml
+++ b/openstack/nova/templates/nanny-db-soft-delete-excessive-instance-faults-cronjob.yaml
@@ -1,0 +1,76 @@
+{{- if .Values.nanny.db_soft_delete_excessive_instance_faults.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: nova-nanny-db-soft-delete-excessive-instance-faults
+  labels:
+    system: openstack
+    component: nova
+    type: nanny
+spec:
+  schedule: {{ .Values.nanny.db_soft_delete_excessive_instance_faults.schedule | quote }}
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          {{- tuple . "nanny-db-soft-delete-excessive-instance-faults" "nanny" | include "job_metadata" | indent 10 }}
+        spec:
+          restartPolicy: OnFailure
+          volumes:
+          - name: container-init
+            configMap:
+              name: nova-bin
+              defaultMode: 0755
+              items:
+              - key: nanny-db-soft-delete-excessive-instance-faults
+                path: nanny-script
+          {{- include "utils.trust_bundle.volumes" . | indent 10 }}
+          - name: nova-etc
+            projected:
+              sources:
+              - configMap:
+                  name: nova-etc
+                  items:
+                  - key:  nova.conf
+                    path: nova.conf
+                  - key:  logging.ini
+                    path: logging.ini
+                  - key:  release
+                    path: release
+              - secret:
+                  name: nova-etc
+                  items:
+                  - key: api-db.conf
+                    path: nova.conf.d/api-db.conf
+          initContainers:
+          {{- tuple . (dict "service" (include "nova.helpers.database_services" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 10 }}
+          containers:
+          - name: nanny
+            image: {{ tuple . "nanny" | include "container_image_nova" }}
+            imagePullPolicy: IfNotPresent
+            command:
+            - /bin/sh
+            - -c
+            - |
+              /container.init/nanny-script
+              exit_code=$?
+              {{- include "utils.script.job_finished_hook" . | nindent 14 }}
+              exit $exit_code
+            env:
+            {{- if .Values.sentry.enabled }}
+            {{- include "utils.sentry_config" . | nindent 12 }}
+            {{- end }}
+            - name: PYTHONWARNINGS
+              value: {{ .Values.python_warnings | quote }}
+            volumeMounts:
+            - mountPath: /etc/nova
+              name: nova-etc
+            - mountPath: /container.init
+              name: container-init
+            {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
+            resources:
+              requests:
+                memory: "500Mi"
+                cpu: "100m"
+{{- end }}

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -162,6 +162,7 @@ imageVersionNovaNovncproxy: null
 imageVersionNovaShellinaboxproxy: null
 imageVersionNovaSpicehtml5proxy: null
 imageVersionNovaScheduler: null
+imageVersionNovaNanny: null
 imageVersionBitnamiOpenResty: 1.21.4-1-debian-11-r57
 
 imageVersionVspc: null
@@ -1013,3 +1014,29 @@ vpa:
 
 # used to set the PYTHONWARNINGS environment variable everywhere
 python_warnings: "ignore:Unverified HTTPS request,ignore::SyntaxWarning"
+
+# maintenance cronjobs
+nanny:
+  # Archive db rows soft-deleted before more than older_than days to shadow
+  # tables. Use batch size max_rows to limit transaction size.
+  db_archive_deleted_rows:
+    enabled: true
+    # cron schedule (minute | hour | day of month | month | day of week)
+    schedule: "0 * * * *"
+    older_than: 21
+    max_rows: 250
+  # Delete db rows soft-deleted before more than older_than days from shadow
+  # tables.
+  db_purge:
+    enabled: true
+    # cron schedule (minute | hour | day of month | month | day of week)
+    schedule: "15 * * * *"
+    older_than: 42
+  # For each instance, soft-delete the instance_faults db rows that exceed the
+  # count of max_faults. Use batch size max_rows to limit query size.
+  db_soft_delete_excessive_instance_faults:
+    enabled: true
+    # cron schedule (minute | hour | day of month | month | day of week)
+    schedule: "30 * * * *"
+    max_faults: 10
+    max_rows: 25


### PR DESCRIPTION
We include the Nova database maintenance tasks from the`openstack/nannies` chart directly into the Nova chart via new cronjobs.

Both the previous nanny and the new nanny run the commands `archive_deleted_rows` and `purge` from `nova-manage db`. Unlike the previous nanny, the new nanny passes the complete daytime as the `before` parameter to these commands instead of the rounded date. That way the cleanup is performed in smaller batches if the nanny runs more than once a day.

The previous nanny additionally executed two Python scripts from [https://github.com/sapcc/openstack-nannies/tree/master/scripts](https://github.com/sapcc/openstack-nannies/tree/master/scripts) for further cleanup.

The previous script `nova-queens-instance-mapping.py` was only executed in dry-run mode without performing any changes in all regions other than qa-de-1. We therefore skip the corresponding cell mapping in the `instance_mappings` for now, as well as the cleanup of the
`build_requests` table. We are still planning to implement the instance mapping as a next step due to a recent issue with a missing cell ID in `instance_mappings`.

The previous script `nova-consistency.py` performed various other cleanup tasks.

The soft-deletion of leftover BDMs for already deleted volumes is no longer required since we are now on the Bobcat release which implements corresponding cleanup upon instance reboot via `_delete_dangling_bdms` in `nova/compute/manager.py` (https://docs.openstack.org/releasenotes/nova/2023.2.html, https://specs.openstack.org/openstack/nova-specs/specs/2023.2/implemented/cleanup-dangling-volume-attachments.html)

Function `purge_instance_faults` is replaced by the newly implemented `nova-manage db soft_delete_excessive_instance_faults` command: https://github.com/sapcc/nova/pull/552

Custom purging of tables `block_device_mapping`, `reservations` and `instance_id_mappings` is no longer required because testing shows that the commands `archive_deleted_rows` and `purge` do now consider these tables as well.