### PR TITLE
[opensearch-logs] add alert if a index rollover failed

### DIFF
--- a/system/opensearch-logs/Chart.yaml
+++ b/system/opensearch-logs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for the Opensearch stack
 name: opensearch-logs
-version: 0.0.40
+version: 0.0.41
 home: https://github.com/sapcc/helm-charts/tree/master/system/opensearch-logs
 dependencies:
   - name: opensearch

--- a/system/opensearch-logs/alerts/opensearch.alerts
+++ b/system/opensearch-logs/alerts/opensearch.alerts
@@ -62,3 +62,18 @@ groups:
     annotations:
       description: 'Opensearch cluster *opensearch-logs* is *RED*. Please check all nodes.'
       summary: '*opensearch-logs* cluster is *RED*'
+
+  - alert: OpenSearchIndexSizeTooLarge
+    expr: opensearch_index_store_size_bytes{index=~".ds.*", context="primaries"} / (1024^3) > 200
+    for: 30m
+    labels:
+      context: nodes
+      service: opensearch-logs
+      severity: warning
+      support_group: observability
+      tier: os
+      playbook: 'docs/support/playbook/opensearch/generic/index-too-large'
+      dashboard: health-opensearch?var-cluster=opensearch-logs
+    annotations:
+      description: "The index {{ $labels.index }} has exceeded 200 GB in size. Please check the rollover status."
+      summary: "Index size is too large ({{ $labels.index }})"

--- a/system/opensearch-logs/alerts/opensearch.alerts
+++ b/system/opensearch-logs/alerts/opensearch.alerts
@@ -76,4 +76,4 @@ groups:
       dashboard: health-opensearch?var-cluster=opensearch-logs
     annotations:
       description: "The index {{ $labels.index }} has exceeded 200 GB in size. Please check the rollover status."
-      summary: "Index size is too large ({{ $labels.index }})"
+      summary: "Index size of ({{ $labels.index }}) has exceeeded the threshold."


### PR DESCRIPTION
This will currently fire in eu-de-1 as the problem was present there last week. We can create a silence for the affected indices until they are deleted (~1 month)