### PR TITLE
[logs] rm duplicate label for namespace.name

### DIFF
--- a/system/logs/Chart.yaml
+++ b/system/logs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for all log shippers
 name: logs
-version: 0.0.68
+version: 0.0.69
 home: https://github.com/sapcc/helm-charts/tree/master/system/logs
 dependencies:
   - name: opentelemetry-operator

--- a/system/logs/templates/_k8sevents-config.tpl
+++ b/system/logs/templates/_k8sevents-config.tpl
@@ -4,9 +4,6 @@ attributes/k8sevents:
     - action: insert
       key: k8s.node.name
       value: ${KUBE_NODE_NAME}
-    - key: k8s.namespace.name
-      from_attribute: k8s.namespace.name
-      action: insert
     - action: insert
       key: k8s.cluster.name
       value: ${cluster}


### PR DESCRIPTION
We currently ship two labels. 
- resource.k8s.namespace.name (through k8sattributes processor)
- attributes.k8s.namespace.name (through k8sevents receiver)
The latter (through k8sevent) can be removed in favor of the former (through the processor).
