### PR TITLE
[designate] enable rate limiting by default

### DIFF
--- a/openstack/designate/values.yaml
+++ b/openstack/designate/values.yaml
@@ -441,7 +441,7 @@ api-ratelimit-redis:
     support_group: network-api
 
 rate_limit:
-  enabled: false
+  enabled: true
   backend_secret_file: /etc/designate/ratelimit-backend-secret.conf
   rate_limit_by: target_project_id
   max_sleep_time_seconds: 0
@@ -450,6 +450,7 @@ rate_limit:
   whitelist:
     - Default/service
     - Default/admin
+    - tempest/performance-testing
     - ccadmin/cloud_admin
     - ccadmin/master
   whitelist_users: null


### PR DESCRIPTION
- return back the tempest/performance-testing project to the whitelist