### PR TITLE
feat(opensearch): add admin user credentials

### DIFF
--- a/system/greenhouse-ccloud/templates/opensearch-users.yaml
+++ b/system/greenhouse-ccloud/templates/opensearch-users.yaml
@@ -5,6 +5,9 @@ metadata:
   name: opensearch-users-credentials
   namespace: {{ $.Release.Namespace }}
 data:
+  admin_username: {{ required ".Values.opensearch.users.logs2.password missing" .Values.opensearch.users.admin.username | b64enc }}
+  admin_password: {{ required ".Values.opensearch.users.logs2.password missing" .Values.opensearch.users.admin.password | b64enc }}
+  admin_hash: {{ required ".Values.opensearch.users.logs2.password missing" .Values.opensearch.users.admin.hash | b64enc }}
   logs_username: {{ required ".Values.opensearch.users.logs.username missing" .Values.opensearch.users.logs.username | b64enc }}
   logs_password: {{ required ".Values.opensearch.users.logs.password missing" .Values.opensearch.users.logs.password | b64enc }}
   logs2_username: {{ required ".Values.opensearch.users.logs2.username missing" .Values.opensearch.users.logs2.username | b64enc }}

--- a/system/greenhouse-ccloud/values.yaml
+++ b/system/greenhouse-ccloud/values.yaml
@@ -171,6 +171,10 @@ openTelemetry:
 opensearch:
   enabled: false
   users:
+    admin:
+      username:
+      password:
+      hash:
     logs:
       username:
       password:


### PR DESCRIPTION
Added support for setting admin user credentials in operator-managed OpenSearch deployments