### PR TITLE
[logs] fix naming for operator to align be align with upstream chart

### DIFF
--- a/system/gatekeeper/templates/constrainttemplate-pod-security.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-pod-security.yaml
@@ -411,7 +411,7 @@ spec:
                   # namespace.
                   iro.kind == "DaemonSet"
                   iro.metadata.namespace in {"logs"}
-                  iro.metadata.name in {"logs-operator", "logs-collector"}
+                  iro.metadata.name in {"opentelemetry-operator", "logs-collector"}
                   helmReleaseName == "logs"
               }
 

--- a/system/greenhouse-ccloud/templates/logs-pluginpreset.yaml
+++ b/system/greenhouse-ccloud/templates/logs-pluginpreset.yaml
@@ -103,11 +103,11 @@ spec:
     - name: openTelemetry.manager.prometheusRule.enabled
       value: {{ .Values.openTelemetry.manager.prometheusRule.enabled }}
   {{- if .Values.global.ghcrIoMirror }}
-    - name: logs-operator.manager.image.repository
+    - name: opentelemetry-operator.manager.image.repository
       value: {{ .Values.global.ghcrIoMirror }}/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    - name: logs-operator.manager.collectorImage.repository
+    - name: opentelemetry-operator.manager.collectorImage.repository
       value: {{ .Values.global.ghcrIoMirror }}/cloudoperators/opentelemetry-collector-contrib
-    - name: logs-operator.testFramework.image.repository
+    - name: opentelemetry-operator.testFramework.image.repository
       value: {{ .Values.global.dockerHubMirror }}/library/busybox
     - name: testFramework.image.registry
       value: {{ .Values.global.ghcrIoMirror }}

--- a/system/logs/Chart.lock
+++ b/system/logs/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
-- name: logs-operator
+- name: opentelemetry-operator
   repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-  version: 0.10.0
+  version: 0.10.1
 - name: fluent-prometheus
   repository: file://vendor/fluent-prometheus
   version: 1.0.8
@@ -11,5 +11,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:c27aa0df90cf4f945ce476b91982c7d00536126a00569748710f731860a2b3ed
-generated: "2025-06-23T08:59:56.688114+02:00"
+digest: sha256:c30194744fbdf5b760403d48cecc8568ff583321c4e2cf330ea6b3a1cf2a8dc4
+generated: "2025-06-23T13:17:34.893105+02:00"

--- a/system/logs/Chart.yaml
+++ b/system/logs/Chart.yaml
@@ -1,13 +1,13 @@
 apiVersion: v2
 description: A Helm chart for all log shippers
 name: logs
-version: 0.0.72
+version: 0.0.73
 home: https://github.com/sapcc/helm-charts/tree/master/system/logs
 dependencies:
-  - name: logs-operator
+  - name: opentelemetry-operator
     alias: openTelemetryPlugin
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.10.0
+    version: 0.10.1
     condition: openTelemetry.enabled
 
   - name: fluent-prometheus

--- a/system/logs/templates/external-service.yaml
+++ b/system/logs/templates/external-service.yaml
@@ -10,7 +10,7 @@ spec:
   selector:
     app.kubernetes.io/component: opentelemetry-collector
     app.kubernetes.io/instance: {{ .Release.Namespace }}.logs
-    app.kubernetes.io/managed-by: logs-operator
+    app.kubernetes.io/managed-by: opentelemetry-operator
     app.kubernetes.io/part-of: opentelemetry
   type: NodePort
   externalTrafficPolicy: Local

--- a/system/logs/templates/opentelemetry-logs-collector.yaml
+++ b/system/logs/templates/opentelemetry-logs-collector.yaml
@@ -54,7 +54,7 @@ spec:
     - name: prometheus
       port: 9999
 {{- end }}
-  image: {{ index .Values "openTelemetryPlugin" "logs-operator" "manager" "collectorImage" "repository" }}:{{ index .Values "openTelemetryPlugin" "logs-operator" "manager" "collectorImage" "tag" }}
+  image: {{ index .Values "openTelemetryPlugin" "opentelemetry-operator" "manager" "collectorImage" "repository" }}:{{ index .Values "openTelemetryPlugin" "opentelemetry-operator" "manager" "collectorImage" "tag" }}
   volumeMounts:
   - mountPath: /var/log
     name: varlog

--- a/system/logs/values.yaml
+++ b/system/logs/values.yaml
@@ -32,7 +32,7 @@ global:
 openTelemetryPlugin:
   alerts:
     enabled: false
-  logs-operator:
+  opentelemetry-operator:
     admissionWebhooks:
       failurePolicy: 'Ignore'
       create: true


### PR DESCRIPTION
- This is necessary so the reference to the upstream chart becomes more clear.
- Also includes a change of a gatekeeper policy for OTel