### PR TITLE
Change gatekeeper policy to allow kvm, netapp deployments

### DIFF
--- a/system/gatekeeper/templates/constrainttemplate-pod-security.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-pod-security.yaml
@@ -193,7 +193,7 @@ spec:
               isCinderVolumePod if {
                   iro.kind == "Deployment"
                   iro.metadata.namespace == "monsoon3"
-                  regex.match("^cinder-volume(?:-backup)?-vmware-vc-[a-z]-[0-9]+$", iro.metadata.name)
+                  regex.match("^cinder-volume(?:-backup)?-(?:vmware-vc)?(?:netapp|kvm)?-(stnpca[0-9]+-st[0-9]+|[a-z]-[0-9]+)$", iro.metadata.name)
                   helmReleaseName == "<none>" # comes from VCenterTemplate
               }
 
@@ -202,7 +202,7 @@ spec:
                   isCinderVolumePod
                   regex.match("^keppel\\.[a-z0-9-.]+/ccloud/loci-cinder:", container.image)
                   container.name == iro.metadata.name
-                  capability == "SYS_ADMIN"
+                  capability in {"CHOWN", "DAC_OVERRIDE", "DAC_READ_SEARCH", "FOWNER", "NET_ADMIN", "SYS_ADMIN" }
               }
               {{- end }}
 

--- a/system/gatekeeper/tests/gatekeeper-policies/fixtures/pod-security/cinder-volume-kvm-stnpca2-st051.yaml
+++ b/system/gatekeeper/tests/gatekeeper-policies/fixtures/pod-security/cinder-volume-kvm-stnpca2-st051.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - image: keppel.example.com/ccloud/loci-cinder:antelope-20250617182642
-        name: cinder-volume-kvm-st051
+        name: cinder-volume-kvm-stnpca2-st051
         securityContext:
           capabilities:
             add:

--- a/system/gatekeeper/tests/gatekeeper-policies/fixtures/pod-security/cinder-volume-kvm-stnpca2-st051.yaml
+++ b/system/gatekeeper/tests/gatekeeper-policies/fixtures/pod-security/cinder-volume-kvm-stnpca2-st051.yaml
@@ -1,15 +1,14 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  # NOTE: not part of a Helm release (spawned by a VCenterTemplate)
-  name: cinder-volume-vmware-vc-a-0
+  name: cinder-volume-kvm-stnpca2-st051
   namespace: monsoon3
 spec:
   template:
     spec:
       containers:
       - image: keppel.example.com/ccloud/loci-cinder:antelope-20250617182642
-        name: cinder-volume-vmware-vc-a-0
+        name: cinder-volume-kvm-st051
         securityContext:
           capabilities:
             add:

--- a/system/gatekeeper/tests/gatekeeper-policies/fixtures/pod-security/cinder-volume-netapp.yaml
+++ b/system/gatekeeper/tests/gatekeeper-policies/fixtures/pod-security/cinder-volume-netapp.yaml
@@ -1,15 +1,14 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  # NOTE: not part of a Helm release (spawned by a VCenterTemplate)
-  name: cinder-volume-vmware-vc-a-0
+  name: cinder-volume-netapp-a-0
   namespace: monsoon3
 spec:
   template:
     spec:
       containers:
       - image: keppel.example.com/ccloud/loci-cinder:antelope-20250617182642
-        name: cinder-volume-vmware-vc-a-0
+        name: cinder-volume-netapp-a-0
         securityContext:
           capabilities:
             add:


### PR DESCRIPTION
Change the volume pod detection regex and add required capability to cinder volume-pods.
Include tests