### PR TITLE
[gatekeeper] revert changes introduced in #9006

### DIFF
--- a/system/gatekeeper/templates/constrainttemplate-pod-security.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-pod-security.yaml
@@ -411,7 +411,7 @@ spec:
                   # namespace.
                   iro.kind == "DaemonSet"
                   iro.metadata.namespace in {"logs"}
-                  iro.metadata.name in {"opentelemetry-operator", "logs-collector"}
+                  iro.metadata.name in {"logs-operator", "logs-collector"}
                   helmReleaseName == "logs"
               }
 


### PR DESCRIPTION
This was not needed as the operator name is a combination of `<namespace>` and `operator`