### PR TITLE
[cinder] Add quota sync nanny helm chart

### DIFF
--- a/openstack/cinder/templates/cinder-nanny-quota-sync.yaml
+++ b/openstack/cinder/templates/cinder-nanny-quota-sync.yaml
@@ -1,0 +1,71 @@
+{{- if .Values.nanny.quota_sync.enabled }}
+kind: CronJob
+apiVersion: batch/v1
+metadata:
+  name: cinder-nanny-quota-sync
+  labels:
+    system: openstack
+    service: cinder-nanny
+spec:
+  schedule: "{{ .Values.nanny.quota_sync.crontab_schedule }}"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    metadata:
+      annotations:
+      labels:
+        component: cinder-nanny
+    spec:
+      template:
+        metadata:
+          annotations:
+            {{- include "utils.linkerd.pod_and_service_annotation" . | indent 12 }}
+          labels:
+            component: cinder-nanny
+        spec:
+          {{- include "utils.proxysql.job_pod_settings" . | nindent 10 }}
+          restartPolicy: Never
+          volumes:
+          - name: etccinder
+            emptyDir: {}
+          - name: cinder-etc
+            configMap:
+              name: cinder-etc
+          - name: cinder-etc-confd
+            secret:
+              secretName: {{ .Release.Name }}-secrets
+          {{- include "utils.proxysql.volumes" . | indent 10 }}
+          containers:
+            - name: quota-sync
+              image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{required ".Values.imageVersion is missing" .Values.imageVersion}}
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  cinder-manage sap quota_sync {{- if .Values.nanny.quota_sync.dry_run }} --dry-run {{- end }} {{- if .Values.nanny.quota_sync.silent }} --silent {{- end }}
+                  exit_code=$?
+                  {{- include "utils.script.job_finished_hook" . | nindent 18 }}
+                  exit $exit_code
+              volumeMounts:
+                - name: etccinder
+                  mountPath: /etc/cinder
+                - name: cinder-etc
+                  mountPath: /etc/cinder/cinder.conf
+                  subPath: cinder.conf
+                  readOnly: true
+                - name: cinder-etc-confd
+                  mountPath: /etc/cinder/cinder.conf.d
+                - name: cinder-etc
+                  mountPath: /etc/cinder/logging.ini
+                  subPath: logging.ini
+                  readOnly: true
+                  {{- include "utils.proxysql.volume_mount" . | indent 16 }}
+              resources:
+                requests:
+                  memory: "250Mi"
+                  cpu: "100m"
+                limits:
+                  memory: "250Mi"
+                  cpu: "100m"
+          {{- include "utils.proxysql.container" . | indent 12 }}
+{{- end }}

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -123,6 +123,12 @@ nanny:
     # daily at 22:10' 
     crontab_schedule: '10 22 * * *' 
     age_in_days: 14
+  quota_sync:
+    enabled: false
+    # hourly at 30 minutes past the hour
+    crontab_schedule: '30 * * * *' 
+    dry_run: false
+    silent: false
 
 proxysql:
   mode: null # Disabled by default


### PR DESCRIPTION
Cinder nannies are moved into the cinder helm chart. The helm chart executes the sap quota_sync command which is a wrapper of the openstack cinder-manage quota sync command. The old nanny quota_sync command executed a non-open stack custom script.