### PR TITLE
[neutron][proxysql] use native sidecars for proxysql

### DIFF
--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for Openstack Neutron
 name: neutron
-version: 0.3.2
+version: 0.3.3
 appVersion: "caracal"
 dependencies:
   - condition: mariadb.enabled

--- a/openstack/neutron/templates/deployment-rpc-server.yaml
+++ b/openstack/neutron/templates/deployment-rpc-server.yaml
@@ -48,6 +48,10 @@ spec:
     spec:
 {{ tuple . "neutron" "rpc" | include "kubernetes_pod_anti_affinity" | indent 6 }}
       {{- include "utils.proxysql.pod_settings" . | indent 6 }}
+      initContainers:
+        {{- if .Values.proxysql.native_sidecar }}
+        {{- tuple . (add .Values.rpc_workers .Values.rpc_state_workers)| include "utils.proxysql.container" | indent 8 }}
+        {{- end }}
       containers:
         - name: neutron-rpc-server
           image: {{.Values.global.registry}}/loci-neutron:{{.Values.imageVersionServerRPC | default .Values.imageVersionServer | default .Values.imageVersion | required "Please set neutron.imageVersion or similar"}}
@@ -156,7 +160,9 @@ spec:
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
             {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
             {{- include "utils.coordination.volume_mount"  . | indent 12 }}
+        {{- if not .Values.proxysql.native_sidecar }}
         {{- tuple . (add .Values.rpc_workers .Values.rpc_state_workers)| include "utils.proxysql.container" | indent 8 }}
+        {{- end }}
 {{- include "jaeger_agent_sidecar" . | indent 8 }}
       volumes:
         - name: empty-dir

--- a/openstack/neutron/templates/deployment-server.yaml
+++ b/openstack/neutron/templates/deployment-server.yaml
@@ -49,6 +49,14 @@ spec:
     spec:
 {{ tuple . "neutron" "api" | include "kubernetes_pod_anti_affinity" | indent 6 }}
       {{- include "utils.proxysql.pod_settings" . | indent 6 }}
+      initContainers:
+{{- if .Values.proxysql.native_sidecar }}
+{{- if not .Values.api.uwsgi }}
+        {{- tuple . (add .Values.api_workers .Values.rpc_workers .Values.rpc_state_workers) | include "utils.proxysql.container" | indent 8 }}
+{{- else }}
+        {{- tuple . .Values.api.processes | include "utils.proxysql.container" | indent 8 }}
+{{- end }}
+{{- end }}
       containers:
         - name: neutron-server
           image: {{.Values.global.registry}}/loci-neutron:{{.Values.imageVersionServerAPI | default .Values.imageVersionServer | default .Values.imageVersion | required "Please set neutron.imageVersion or similar"}}
@@ -254,10 +262,12 @@ spec:
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
             {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
             {{- include "utils.coordination.volume_mount"  . | indent 12 }}
+{{- if not .Values.proxysql.native_sidecar }}
 {{- if not .Values.api.uwsgi }}
         {{- tuple . (add .Values.api_workers .Values.rpc_workers .Values.rpc_state_workers) | include "utils.proxysql.container" | indent 8 }}
 {{- else }}
         {{- tuple . .Values.api.processes | include "utils.proxysql.container" | indent 8 }}
+{{- end }}
 {{- end }}
         - name: statsd
           image: {{.Values.global.dockerHubMirror}}/prom/statsd-exporter:v0.8.1

--- a/openstack/neutron/templates/job-migration.yaml
+++ b/openstack/neutron/templates/job-migration.yaml
@@ -31,6 +31,9 @@ spec:
               value: {{ .Release.Namespace }}
             - name: DEPENDENCY_SERVICE
               value: "{{ include "neutron.db_service" . }}"
+        {{- if .Values.proxysql.native_sidecar }}
+        {{- include "utils.proxysql.container" . | indent 8 }}
+        {{- end }}
       containers:
         - name: neutron-migration
           image: {{.Values.global.registry}}/loci-neutron:{{default .Values.imageVersion | required "Please set neutron.imageVersion or similar"}}
@@ -55,7 +58,9 @@ spec:
               readOnly: true
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
             {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
+        {{- if not .Values.proxysql.native_sidecar }}
         {{- include "utils.proxysql.container" . | indent 8 }}
+        {{- end }}
       volumes:
         - name: etc-neutron
           projected:

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -480,6 +480,7 @@ pgmetrics:
 
 proxysql:
   mode: ""
+  native_sidecar: true
 
 db_name: neutron
 


### PR DESCRIPTION
Run proxysql sidecars as native sidecars.

This would ensure that proxysql container is always stopped after the main container on each rollout.
