### PR TITLE
[manila][proxysql] use native sidecars for proxysql

### DIFF
--- a/openstack/manila/Chart.lock
+++ b/openstack/manila/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.1.0
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.24.1
+  version: 0.24.2
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.4.0
@@ -19,12 +19,12 @@ dependencies:
   version: 1.0.0
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.18.0
+  version: 0.18.1
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 2.2.7
+  version: 2.2.12
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.26.0
-digest: sha256:700790f32dbd4cbb28f64e372508d3260fea1982b8734784bca62018b53266cd
-generated: "2025-05-16T17:54:25.801994+03:00"
+  version: 0.27.0
+digest: sha256:c7855503871a33599b9fabbdaa2fe447a02e757c79ccd06d936594f503f24b56
+generated: "2025-06-24T17:35:49.280155+03:00"

--- a/openstack/manila/Chart.yaml
+++ b/openstack/manila/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 name: manila
 sources:
   - https://github.com/sapcc/manila
-version: 0.5.8
+version: 0.5.9
 dependencies:
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
@@ -45,4 +45,4 @@ dependencies:
     condition: api_rate_limit.enabled
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.26.0
+    version: 0.27.0

--- a/openstack/manila/templates/api-deployment.yaml
+++ b/openstack/manila/templates/api-deployment.yaml
@@ -70,6 +70,9 @@ spec:
         volumeMounts:
         {{- include "utils.coordination.volume_mount" . | indent 10 }}
       {{- end }}
+      {{- if .Values.proxysql.native_sidecar }}
+      {{- tuple . .Values.wsgi_processes | include "utils.proxysql.container" | indent 6 }}
+      {{- end }}
       containers:
         - name: manila-api
           image: {{.Values.global.registry}}/loci-manila:{{.Values.loci.imageVersion}}
@@ -214,7 +217,9 @@ spec:
           resources:
             {{- toYaml .Values.pod.resources.api_statsd | trim | nindent 12 }}
           {{- end }}
+        {{- if not .Values.proxysql.native_sidecar }}
         {{- tuple . .Values.wsgi_processes | include "utils.proxysql.container" | indent 8 }}
+        {{- end }}
  {{- if .Values.osprofiler.enabled }}
  {{- include "jaeger_agent_sidecar" . | indent 8 }}
  {{- end }}

--- a/openstack/manila/templates/migration-job.yaml
+++ b/openstack/manila/templates/migration-job.yaml
@@ -35,6 +35,9 @@ spec:
       priorityClassName: {{ .Values.pod.priority_class.low }}
       initContainers:
       {{- tuple . (dict "service" (include "manila.db_service" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
+      {{- if not .Values.proxysql.native_sidecar }}
+      {{- include "utils.proxysql.container" . | indent 6 }}
+      {{- end }}
       containers:
         - name: manila-migration
           image: {{.Values.global.registry}}/loci-manila:{{.Values.loci.imageVersion}}
@@ -73,7 +76,9 @@ spec:
             {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
 {{- if $proxysql }}
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+        {{- if not .Values.proxysql.native_sidecar }}
         {{- include "utils.proxysql.container" . | indent 8 }}
+        {{- end }}
 {{- end }}
       volumes:
         - name: etcmanila

--- a/openstack/manila/templates/scheduler-deployment.yaml
+++ b/openstack/manila/templates/scheduler-deployment.yaml
@@ -65,6 +65,9 @@ spec:
             - name: etcmanila
               mountPath: /shared
         {{- end }}
+        {{- if .Values.proxysql.native_sidecar }}
+        {{- tuple . .Values.rpc_workers | include "utils.proxysql.container" | indent 8 }}
+        {{- end }}
       containers:
         - name: manila-scheduler
           image: {{.Values.global.registry}}/loci-manila:{{.Values.loci.imageVersion}}
@@ -145,7 +148,9 @@ spec:
               readOnly: true
         {{- end }}
         {{- include "jaeger_agent_sidecar" . | indent 8 }}
+        {{- if .Values.proxysql.native_sidecar }}
         {{- tuple . .Values.rpc_workers | include "utils.proxysql.container" | indent 8 }}
+        {{- end }}
       volumes:
         - name: etcmanila
           emptyDir: {}

--- a/openstack/manila/templates/shares/_netapp-ensure-deployment.yaml.tpl
+++ b/openstack/manila/templates/shares/_netapp-ensure-deployment.yaml.tpl
@@ -54,6 +54,9 @@ spec:
       priorityClassName: {{ .Values.pod.priority_class.low }}
       initContainers:
       {{- tuple . (dict "service" (include "manila.db_service" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
+      {{- if .Values.proxysql.native_sidecar }}
+      {{- include "utils.proxysql.container" . | indent 8 }}
+      {{- end }}
       containers:
         - name: reexport
           image: "{{.Values.global.registry}}/loci-manila:{{.Values.loci.imageVersion}}"
@@ -129,7 +132,9 @@ spec:
             periodSeconds: 5
             initialDelaySeconds: 5
         {{- include "jaeger_agent_sidecar" . | indent 8 }}
+        {{- if not .Values.proxysql.native_sidecar }}
         {{- include "utils.proxysql.container" . | indent 8 }}
+        {{- end }}
       volumes:
         - name: etcmanila
           emptyDir: {}

--- a/openstack/manila/values.yaml
+++ b/openstack/manila/values.yaml
@@ -102,6 +102,7 @@ memcached:
 proxysql:
   mode: ""
   max_transaction_time: "120000"
+  native_sidecar: true
 
 mysql_metrics:
   db_name: manila


### PR DESCRIPTION
Run proxysql sidecars as native sidecars.

This would ensure that proxysql container is always stopped after the main container on each rollout.

Update openstack/utils helm chart to 0.27.0 version with native sidecar support for proxysql