### PR TITLE
[keystone][proxysql] use native sidecars for proxysql

### DIFF
--- a/openstack/keystone/Chart.lock
+++ b/openstack/keystone/Chart.lock
@@ -19,9 +19,9 @@ dependencies:
   version: 1.1.11
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.26.0
+  version: 0.27.2
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:8b87abe8e3541ed6b32624e346e80d4264103fb8191e05d69068de5613ca0ffe
-generated: "2025-07-24T12:33:12.362437+03:00"
+digest: sha256:e7632b3a8180c17b73ac6718a82518abacfa8f4c65416f15bc8ccff982ce49bf
+generated: "2025-07-24T15:50:11.936034+03:00"

--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: keystone
 sources:
   - https://github.com/sapcc/keystone
-version: 0.10.6
+version: 0.10.7
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
@@ -36,7 +36,7 @@ dependencies:
     version: 1.1.11
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.26.0
+    version: 0.27.2
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.1.0

--- a/openstack/keystone/templates/deployment-api.yaml
+++ b/openstack/keystone/templates/deployment-api.yaml
@@ -82,6 +82,9 @@ spec:
           value: {{ include "keystone.service_dependencies" . | quote }}
         - name: COMMAND
           value: "true"
+      {{- if .Values.proxysql.native_sidecar }}
+      {{- include "utils.proxysql.container" . | indent 6 }}
+      {{- end }}
       containers:
         - name: keystone-api
           image: {{ required ".Values.global.registryAlternateRegion is missing" .Values.global.registryAlternateRegion }}/{{ .Values.api.image }}:{{ required ".Values.api.imageTag is missing" .Values.api.imageTag }}
@@ -220,8 +223,10 @@ spec:
 {{ toYaml .Values.api.metrics.resources | indent 12 }}
           {{- end }}
         {{- end }}
-{{- include "jaeger_agent_sidecar" . | indent 8 }}
-{{- include "utils.proxysql.container" . | indent 8 }}
+      {{- include "jaeger_agent_sidecar" . | indent 8 }}
+      {{- if not .Values.proxysql.native_sidecar }}
+      {{- include "utils.proxysql.container" . | indent 8 }}
+      {{- end }}
       volumes:
         - name: etc-keystone
           emptyDir: {}

--- a/openstack/keystone/templates/deployment-cron.yaml
+++ b/openstack/keystone/templates/deployment-cron.yaml
@@ -66,6 +66,9 @@ spec:
           value: {{ include "keystone.service_dependencies" . | quote }}
         - name: COMMAND
           value: "true"
+      {{- if .Values.proxysql.native_sidecar }}
+      {{- include "utils.proxysql.container" . | indent 6 }}
+      {{- end }}
       containers:
         - name: keystone-cron
           image: {{ required ".Values.global.registryAlternateRegion is missing" .Values.global.registryAlternateRegion }}/{{ .Values.cron.image }}:{{ required ".Values.cron.imageTag is missing" .Values.cron.imageTag }}
@@ -114,7 +117,9 @@ spec:
           resources:
 {{ toYaml .Values.cron.resources | indent 12 }}
           {{- end }}
-{{- include "utils.proxysql.container" . | indent 8 }}
+      {{- if not .Values.proxysql.native_sidecar }}
+      {{- include "utils.proxysql.container" . | indent 8 }}
+      {{- end }}
       volumes:
         - name: keystone-etc
           configMap:

--- a/openstack/keystone/templates/job-bootstrap.yaml
+++ b/openstack/keystone/templates/job-bootstrap.yaml
@@ -37,6 +37,10 @@ spec:
 {{- end }}
       restartPolicy: OnFailure
       {{- include "utils.proxysql.job_pod_settings" . | indent 6 }}
+      initContainers:
+      {{- if .Values.proxysql.native_sidecar }}
+      {{- include "utils.proxysql.container" . | indent 6 }}
+      {{- end }}
       containers:
         - name: keystone-bootstrap
           image: {{ required ".Values.global.registryAlternateRegion is missing" .Values.global.registryAlternateRegion }}/{{ .Values.api.image }}:{{ .Values.api.imageTag }}
@@ -91,7 +95,9 @@ spec:
               readOnly: true
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
             {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
+        {{- if not .Values.proxysql.native_sidecar }}
         {{- include "utils.proxysql.container" . | indent 8 }}
+        {{- end }}
       volumes:
         - name: etc-keystone
           emptyDir: {}

--- a/openstack/keystone/templates/job-migration.yaml
+++ b/openstack/keystone/templates/job-migration.yaml
@@ -37,6 +37,10 @@ spec:
 {{- end }}
       restartPolicy: OnFailure
       {{- include "utils.proxysql.job_pod_settings" . | indent 6 }}
+      initContainers:
+      {{- if .Values.proxysql.native_sidecar }}
+      {{- include "utils.proxysql.container" . | indent 6 }}
+      {{- end }}
       containers:
         - name: keystone-migration
           image: {{ required ".Values.global.registryAlternateRegion is missing" .Values.global.registryAlternateRegion }}/{{ .Values.api.image }}:{{ .Values.api.imageTag }}
@@ -89,7 +93,9 @@ spec:
               readOnly: true
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
             {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
+        {{- if not .Values.proxysql.native_sidecar }}
         {{- include "utils.proxysql.container" . | indent 8 }}
+        {{- end }}
       volumes:
         - name: etc-keystone
           emptyDir: {}

--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -263,6 +263,7 @@ memcached:
 
 proxysql:
   mode: null  # Disabled
+  native_sidecar: true
 
 percona_cluster:
   enabled: false


### PR DESCRIPTION
Run proxysql sidecars as native sidecars.

This would ensure that proxysql container is always stopped after the main container on each rollout.

Update openstack/utils helm chart to 0.27.2 version with native sidecar support for proxysql