### PR TITLE
[cinder][proxysql] use native sidecars for proxysql

### DIFF
--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.26.0
+  version: 0.27.2
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.26.1
@@ -26,5 +26,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:270f55c9158a629183aa393c05e7826a7461acbe7d0d67d1b56f76304fd03cb2
-generated: "2025-07-25T09:13:19.365289-04:00"
+digest: sha256:e8cd32c50cd8c292a1af554bd30d769cee50cab15aef79f669ab544f428d8d41
+generated: "2025-08-01T16:35:26.472072+03:00"

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -3,11 +3,11 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Cinder/OpenStack_Project_Cinder_mascot.png
 name: cinder
-version: 0.3.1
+version: 0.3.2
 dependencies:
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.26.0
+    version: 0.27.2
   - name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.26.1

--- a/openstack/cinder/templates/api-deployment.yaml
+++ b/openstack/cinder/templates/api-deployment.yaml
@@ -43,6 +43,9 @@ spec:
       {{- tuple . (dict "name" "cinder-api") | include "utils.topology.constraints" | indent 6 }}
       initContainers:
       {{- tuple . (dict "service" (include "cinder.service_dependencies" . ) "jobs" (include "cinder.migration_job_name" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
+      {{- if .Values.proxysql.native_sidecar }}
+      {{- include "utils.proxysql.container" . | indent 6 }}
+      {{- end }}
       containers:
         - name: cinder-api
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{.Values.imageVersionCinderApi | default .Values.imageVersion | required "Please set cinder.imageVersion or similar" }}
@@ -142,7 +145,9 @@ spec:
             {{- end }}
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
             {{- include "utils.coordination.volume_mount" . | indent 12 }}
+        {{- if not .Values.proxysql.native_sidecar }}
         {{- include "utils.proxysql.container" . | indent 8 }}
+        {{- end }}
         - name: statsd
           image: {{ required ".Values.global.dockerHubMirror is missing" .Values.global.dockerHubMirror}}/prom/statsd-exporter:v0.8.1
           imagePullPolicy: IfNotPresent
@@ -158,7 +163,7 @@ spec:
               mountPath: /etc/statsd/statsd-exporter.yaml
               subPath: statsd-exporter.yaml
               readOnly: true
- {{- include "jaeger_agent_sidecar" . | indent 8 }}
+{{- include "jaeger_agent_sidecar" . | indent 8 }}
       volumes:
         - name: etccinder
           emptyDir: {}

--- a/openstack/cinder/templates/backup_deployment.yaml
+++ b/openstack/cinder/templates/backup_deployment.yaml
@@ -54,13 +54,16 @@ template: |
         {{- tuple . "{= availability_zone =}" | include "utils.kubernetes_pod_az_affinity" | nindent 8 }}
         initContainers:
         {{- tuple . (dict "service" (include "cinder.service_dependencies" . ) "jobs" (include "cinder.migration_job_name" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
+        {{- if .Values.proxysql.native_sidecar }}
+        {{- include "utils.proxysql.container" . | indent 8 }}
+        {{- end }}
         containers:
         - name: cinder-volume-backup-vmware-{= name =}
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{.Values.imageVersionCinderVolumeBackup | default .Values.imageVersion | required "Please set cinder.imageVersion or similar" }}
           imagePullPolicy: {{ required ".Values.global.imagePullPolicy is missing" .Values.global.imagePullPolicy }}
           securityContext:
             capabilities:
-              add: 
+              add:
               - SYS_ADMIN
               - NET_ADMIN
               - FOWNER
@@ -121,7 +124,9 @@ template: |
             readOnly: true
             {{- include "utils.proxysql.volume_mount" . | indent 10 }}
             {{- include "utils.coordination.volume_mount" . | indent 10 }}
+        {{- if not .Values.proxysql.native_sidecar }}
         {{- include "utils.proxysql.container" . | indent 8 }}
+        {{- end }}
         {{- include "jaeger_agent_sidecar" . | indent 8 }}
         volumes:
         - name: etccinder

--- a/openstack/cinder/templates/cinder-nanny-consistency.yaml
+++ b/openstack/cinder/templates/cinder-nanny-consistency.yaml
@@ -34,6 +34,10 @@ spec:
             secret:
               secretName: {{ .Release.Name }}-secrets
           {{- include "utils.proxysql.volumes" . | indent 10 }}
+          initContainers:
+          {{- if .Values.proxysql.native_sidecar }}
+          {{- include "utils.proxysql.container" . | indent 12 }}
+          {{- end }}
           containers:
             - name: consistency
               image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{required ".Values.imageVersion is missing" .Values.imageVersion}}
@@ -67,5 +71,7 @@ spec:
                 limits:
                   memory: "250Mi"
                   cpu: "100m"
+          {{- if not .Values.proxysql.native_sidecar }}
           {{- include "utils.proxysql.container" . | indent 12 }}
+          {{- end }}
 {{- end }}

--- a/openstack/cinder/templates/cinder-nanny-db-purge.yaml
+++ b/openstack/cinder/templates/cinder-nanny-db-purge.yaml
@@ -34,6 +34,10 @@ spec:
             secret:
               secretName: {{ .Release.Name }}-secrets
           {{- include "utils.proxysql.volumes" . | indent 10 }}
+          initContainers:
+          {{- if .Values.proxysql.native_sidecar }}
+          {{- include "utils.proxysql.container" . | indent 12 }}
+          {{- end }}
           containers:
             - name: db-purge
               image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{required ".Values.imageVersion is missing" .Values.imageVersion}}
@@ -67,5 +71,7 @@ spec:
                 limits:
                   memory: "250Mi"
                   cpu: "100m"
+          {{- if not .Values.proxysql.native_sidecar }}
           {{- include "utils.proxysql.container" . | indent 12 }}
+          {{- end }}
 {{- end }}

--- a/openstack/cinder/templates/cinder-nanny-lockfiles.yaml
+++ b/openstack/cinder/templates/cinder-nanny-lockfiles.yaml
@@ -35,7 +35,11 @@ spec:
             secret:
               secretName: {{ .Release.Name }}-secrets
           {{- include "utils.proxysql.volumes" . | indent 10 }}
-          {{- include "utils.coordination.volumes" . | indent 10 }} 
+          {{- include "utils.coordination.volumes" . | indent 10 }}
+          initContainers:
+          {{- if .Values.proxysql.native_sidecar }}
+          {{- include "utils.proxysql.container" . | indent 12 }}
+          {{- end }}
           containers:
             - name: lock-files
               image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{required ".Values.imageVersion is missing" .Values.imageVersion}}
@@ -69,5 +73,7 @@ spec:
                 limits:
                   memory: "2000Mi"
                   cpu: "200m"
+          {{- if not .Values.proxysql.native_sidecar }}
           {{- include "utils.proxysql.container" . | indent 12 }}
+          {{- end }}
 {{- end }}

--- a/openstack/cinder/templates/cinder-nanny-quota-sync.yaml
+++ b/openstack/cinder/templates/cinder-nanny-quota-sync.yaml
@@ -34,6 +34,10 @@ spec:
             secret:
               secretName: {{ .Release.Name }}-secrets
           {{- include "utils.proxysql.volumes" . | indent 10 }}
+          initContainers:
+          {{- if .Values.proxysql.native_sidecar }}
+          {{- include "utils.proxysql.container" . | indent 12 }}
+          {{- end }}
           containers:
             - name: quota-sync
               image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{required ".Values.imageVersion is missing" .Values.imageVersion}}
@@ -67,5 +71,7 @@ spec:
                 limits:
                   memory: "250Mi"
                   cpu: "100m"
+          {{- if not .Values.proxysql.native_sidecar }}
           {{- include "utils.proxysql.container" . | indent 12 }}
+          {{- end }}
 {{- end }}

--- a/openstack/cinder/templates/migration-job.yaml
+++ b/openstack/cinder/templates/migration-job.yaml
@@ -16,6 +16,9 @@ spec:
       {{- include "utils.proxysql.job_pod_settings" . | nindent 6 }}
       initContainers:
       {{- tuple . (dict "service" (include "cinder.db_service" . )) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
+      {{- if .Values.proxysql.native_sidecar }}
+      {{- include "utils.proxysql.container" . | indent 6 }}
+      {{- end }}
       containers:
         - name: cinder-migration
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{.Values.imageVersionCinderApi | default .Values.imageVersion | required "Please set cinder.imageVersion or similar" }}
@@ -48,7 +51,9 @@ spec:
               subPath: logging.ini
               readOnly: true
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+        {{- if not .Values.proxysql.native_sidecar }}
         {{- include "utils.proxysql.container" . | indent 8 }}
+        {{- end }}
       volumes:
         - name: etccinder
           emptyDir: {}

--- a/openstack/cinder/templates/scheduler-deployment.yaml
+++ b/openstack/cinder/templates/scheduler-deployment.yaml
@@ -42,6 +42,9 @@ spec:
       hostname: cinder-scheduler
       initContainers:
       {{- tuple . (dict "service" (include "cinder.scheduler_service_dependencies" . )) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
+      {{- if .Values.proxysql.native_sidecar }}
+      {{- include "utils.proxysql.container" . | indent 6 }}
+      {{- end }}
       containers:
         - name: cinder-scheduler
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{.Values.imageVersionCinderScheduler | default .Values.imageVersion | required "Please set cinder.imageVersion or similar" }}
@@ -89,7 +92,9 @@ spec:
               readOnly: true
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
             {{- include "utils.coordination.volume_mount" . | indent 12 }}
+        {{- if not .Values.proxysql.native_sidecar }}
         {{- include "utils.proxysql.container" . | indent 8 }}
+        {{- end }}
         {{- include "jaeger_agent_sidecar" . | indent 8 }}
       volumes:
         - name: etccinder

--- a/openstack/cinder/templates/vcenter_datacenter_cinder_deployment.yaml
+++ b/openstack/cinder/templates/vcenter_datacenter_cinder_deployment.yaml
@@ -55,6 +55,9 @@ template: |
         {{- include "utils.proxysql.pod_settings" . | nindent 8 }}
         initContainers:
         {{- tuple . (dict "service" (include "cinder.service_dependencies" . )) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
+        {{- if .Values.proxysql.native_sidecar }}
+        {{- include "utils.proxysql.container" . | indent 8 }}
+        {{- end }}
         containers:
         - name: cinder-volume-vmware-{= name =}
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{.Values.imageVersionCinderScheduler | default .Values.imageVersion | required "Please set cinder.imageVersion or similar" }}
@@ -120,7 +123,9 @@ template: |
             readOnly: true
           {{- include "utils.proxysql.volume_mount" . | indent 10 }}
           {{- include "utils.coordination.volume_mount" . | indent 10 }}
+        {{- if not .Values.proxysql.native_sidecar }}
         {{- include "utils.proxysql.container" . | indent 8 }}
+        {{- end }}
         {{- include "jaeger_agent_sidecar" . | indent 8 }}
         volumes:
         - name: etccinder

--- a/openstack/cinder/templates/volumes/_volume-deployment.yaml.tpl
+++ b/openstack/cinder/templates/volumes/_volume-deployment.yaml.tpl
@@ -42,6 +42,10 @@ spec:
     spec:
       hostname: {{ .Release.Name }}-volume-{{ $name }}
 {{ include "utils.proxysql.pod_settings" . | indent 6 }}
+      initContainers:
+      {{- if .Values.proxysql.native_sidecar }}
+      {{- include "utils.proxysql.container" . | indent 8 }}
+      {{- end }}
       containers:
       - name: cinder-volume-{{ $name }}
         image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-cinder:{{.Values.imageVersionCinderVolume | default .Values.imageVersion | required "Please set cinder.imageVersion or similar" }}
@@ -112,7 +116,9 @@ spec:
         {{- end }}
         {{- include "utils.coordination.volume_mount" . | indent 8 }}
         {{- include "utils.proxysql.volume_mount" . | indent 8 }}
+      {{- if not .Values.proxysql.native_sidecar }}
       {{- include "utils.proxysql.container" . | indent 6 }}
+      {{- end }}
       {{- include "jaeger_agent_sidecar" . | indent 6 }}
       volumes:
       - name: etccinder

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -142,7 +142,8 @@ nanny:
     fix_limit: null
 
 proxysql:
-  mode: null # Disabled by default
+  mode: null  # Disabled by default
+  native_sidecar: true
 
 mariadb:
   enabled: true


### PR DESCRIPTION
Run proxysql sidecars as native sidecars.

This would ensure that proxysql container is always stopped after the main container on each rollout.

Update openstack/utils helm chart to 0.27.2 version with native sidecar support for proxysql