### PR TITLE
[barbican][proxysql] use native sidecars for proxysql

### DIFF
--- a/openstack/barbican/Chart.lock
+++ b/openstack/barbican/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 0.5.1
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.27.0
+  version: 0.27.2
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.6.2
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.1
-digest: sha256:0dbfce413d30778822e9c7f00c2881b9d8ba78632e2c5210ad3ff907e4efa021
-generated: "2025-08-05T09:17:27.623775+05:30"
+digest: sha256:45f117550168c43eabec9044d6ae0a6fb5db8339d8defdfbda70ac10700c27bc
+generated: "2025-08-07T12:20:07.981558+03:00"

--- a/openstack/barbican/Chart.yaml
+++ b/openstack/barbican/Chart.yaml
@@ -24,7 +24,7 @@ dependencies:
     version: 0.5.1
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.27.0
+    version: 0.27.2
   - name: redis
     alias: sapcc_rate_limit
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/barbican/templates/api-deployment.yaml
+++ b/openstack/barbican/templates/api-deployment.yaml
@@ -49,6 +49,9 @@ spec:
       {{- tuple . (dict "name" "barbican-api") | include "utils.topology.constraints" | indent 6 }}
       initContainers:
       {{- tuple . (dict "service" (include "barbican.service_dependencies" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
+      {{- if .Values.proxysql.native_sidecar }}
+      {{- include "utils.proxysql.container" . | indent 6 }}
+      {{- end }}
       containers:
         - name: barbican-api
           image: {{required ".Values.global.registry is missing" .Values.global.registry }}/loci-barbican:{{required "Values.imageVersionBarbicanApi is missing" .Values.imageVersionBarbicanApi}}
@@ -140,7 +143,9 @@ spec:
               mountPath: /thales/
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
             {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
+        {{- if not .Values.proxysql.native_sidecar }}
         {{- include "utils.proxysql.container" . | indent 8 }}
+        {{- end }}
         - name: lunaclient
           image: {{required ".Values.global.registry is missing" .Values.global.registry }}/loci-barbican:{{required "Values.hsm.luna.image is missing" .Values.hsm.luna.image }}
           imagePullPolicy: Always

--- a/openstack/barbican/templates/barbican-nanny-deployment.yaml
+++ b/openstack/barbican/templates/barbican-nanny-deployment.yaml
@@ -47,6 +47,10 @@ spec:
         {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
       {{ include "utils.proxysql.pod_settings" . | indent 6 }}
+      initContainers:
+      {{- if .Values.proxysql.native_sidecar }}
+      {{- tuple . 1 | include "utils.proxysql.container" | indent 6 }}
+      {{- end }}
       containers:
 {{- if .Values.barbican_nanny.db_secret_move.enabled }}
       - name: move-secrets
@@ -98,7 +102,9 @@ spec:
           readOnly: true
         {{- include "utils.proxysql.volume_mount" . | indent 8 }}
         {{- include "utils.trust_bundle.volume_mount" . | indent 8 }}
+      {{- if not .Values.proxysql.native_sidecar }}
       {{- tuple . 1 | include "utils.proxysql.container" | indent 6 }}
+      {{- end }}
       volumes:
       - name: barbican-etc
         configMap:

--- a/openstack/barbican/values.yaml
+++ b/openstack/barbican/values.yaml
@@ -53,7 +53,8 @@ postgresql:
   enabled: false
 
 proxysql:
-  mode: "" # Cannot use unix_socket, as migration-job is a helm-hook which runs prior to the configmap creation/update
+  mode: ""  # Cannot use unix_socket, as migration-job is a helm-hook which runs prior to the configmap creation/update
+  native_sidecar: true
 
 mariadb:
   enabled: true


### PR DESCRIPTION
Run proxysql sidecars as native sidecars.

This would ensure that proxysql container is always stopped after the main container on each rollout.

Update openstack/utils helm chart to 0.27.2 version with native sidecar support for proxysql