### PR TITLE
[octavia][proxysql] use native sidecars for proxysql

### DIFF
--- a/openstack/octavia/Chart.lock
+++ b/openstack/octavia/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 0.17.1
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.26.0
+  version: 0.27.2
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
@@ -26,5 +26,5 @@ dependencies:
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.1.3
-digest: sha256:7f4adacc1d492ea000720db3840f3a22453888051f85391378b4949482a5207d
-generated: "2025-07-04T20:26:33.916563+04:00"
+digest: sha256:74e9abb5b8e28b9046f1bde501b84b875476c4272bd401d52e14c22c86aad616
+generated: "2025-08-07T12:16:36.765547+03:00"

--- a/openstack/octavia/Chart.yaml
+++ b/openstack/octavia/Chart.yaml
@@ -9,7 +9,7 @@ sources:
   - https://git.openstack.org/cgit/openstack/octavia
   - https://git.openstack.org/cgit/openstack/openstack-helm
 # The versions are defined in the changelog: https://docs.openstack.org/releasenotes/octavia/yoga.html
-version: 10.1.4
+version: 10.1.5
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
@@ -32,7 +32,7 @@ dependencies:
     version: 0.17.1
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.26.0
+    version: 0.27.2
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0

--- a/openstack/octavia/ci/test-values.yaml
+++ b/openstack/octavia/ci/test-values.yaml
@@ -5,6 +5,7 @@ global:
   octavia_service_password: topSecret!!
   registry: my.docker.registry
   registryAlternateRegion: other.docker.registry
+  dockerHubMirror: my.dockerhub.mirror
   dockerHubMirrorAlternateRegion: other.dockerhub.mirror
   availability_zones:
     - foo
@@ -16,6 +17,8 @@ mariadb:
   root_password: topSecret
   users:
     octavia:
+      password: topSecret
+    backup:
       password: topSecret
   backup_v2:
     enabled: false

--- a/openstack/octavia/templates/octavia-api-deployment.yaml
+++ b/openstack/octavia/templates/octavia-api-deployment.yaml
@@ -46,6 +46,10 @@ spec:
       priorityClassName: critical-payload
       {{- include "utils.proxysql.pod_settings" . | nindent 6 }}
       {{- tuple . (dict "app.kubernetes.io/name" "octavia-api") | include "utils.topology.constraints" | indent 6 }}
+      initContainers:
+      {{- if .Values.proxysql.native_sidecar }}
+      {{- include "utils.proxysql.container" . | indent 6 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-api
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-octavia:{{required "Values.imageVersion is missing" .Values.imageVersion}}
@@ -140,7 +144,9 @@ spec:
             {{- end }}
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
             {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
+        {{- if not .Values.proxysql.native_sidecar }}
         {{- include "utils.proxysql.container" . | indent 8 }}
+        {{- end }}
         {{- include "jaeger_agent_sidecar" . | indent 8 }}
 {{- if .Values.watcher.enabled }}
         - name: statsd

--- a/openstack/octavia/templates/octavia-housekeeping.yaml
+++ b/openstack/octavia/templates/octavia-housekeeping.yaml
@@ -33,6 +33,10 @@ spec:
         {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
 {{ include "utils.proxysql.pod_settings" . | indent 6 }}
+      initContainers:
+      {{- if .Values.proxysql.native_sidecar }}
+      {{- include "utils.proxysql.container" . | indent 6 }}
+      {{- end }}
       containers:
         - name: octavia-f5-housekeeping
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-octavia:{{required "Values.imageVersion is missing" .Values.imageVersion}}
@@ -75,7 +79,9 @@ spec:
                   name: sentry
                   key: octavia.DSN.python
             {{- end }}
+        {{- if not .Values.proxysql.native_sidecar }}
         {{- include "utils.proxysql.container" . | indent 8 }}
+        {{- end }}
       volumes:
         - name: octavia-etc
           configMap:

--- a/openstack/octavia/templates/octavia-migration-job.yaml
+++ b/openstack/octavia/templates/octavia-migration-job.yaml
@@ -35,6 +35,9 @@ spec:
               value: {{ include "octavia.db_service" . }}
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
+        {{- if .Values.proxysql.native_sidecar }}
+        {{- include "utils.proxysql.container" . | indent 8 }}
+        {{- end }}
       containers:
         - name: octavia-migration
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-octavia:{{required "Values.imageVersion is missing" .Values.imageVersion}}
@@ -70,7 +73,9 @@ spec:
             {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
     {{- if $proxysql }}
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+        {{- if not .Values.proxysql.native_sidecar }}
         {{- include "utils.proxysql.container" . | indent 8 }}
+        {{- end }}
     {{- end }}
       volumes:
         - name: octavia-etc

--- a/openstack/octavia/templates/octavia-worker-deployment.yaml
+++ b/openstack/octavia/templates/octavia-worker-deployment.yaml
@@ -42,6 +42,10 @@ spec:
     spec:
       priorityClassName: critical-payload
 {{ include "utils.proxysql.pod_settings" . | indent 6 }}
+      initContainers:
+      {{- if .Values.proxysql.native_sidecar }}
+      {{- include "utils.proxysql.container" . | indent 6 }}
+      {{- end }}
       containers:
         - name: octavia-worker
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-octavia:{{required "Values.imageVersion is missing" .Values.imageVersion}}
@@ -149,7 +153,9 @@ spec:
             {{- end }}
             - name: OS_F5_AGENT__PROMETHEUS_PORT
               value: "8001"
+        {{- if not .Values.proxysql.native_sidecar }}
         {{- include "utils.proxysql.container" . | indent 8 }}
+        {{- end }}
       volumes:
         - name: octavia-etc
           configMap:

--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -31,6 +31,7 @@ db_name: octavia
 proxysql:
   mode: ""
   forceSecretCreation: true
+  native_sidecar: true
 
 rabbitmq:
   alerts:


### PR DESCRIPTION
Run proxysql sidecars as native sidecars.

This would ensure that proxysql container is always stopped after the main container on each rollout.

Update openstack/utils helm chart to 0.27.2 version with native sidecar support for proxysql