### PR TITLE
[placement][proxysql] use native sidecars for proxysql

### DIFF
--- a/openstack/placement/Chart.lock
+++ b/openstack/placement/Chart.lock
@@ -10,12 +10,12 @@ dependencies:
   version: 0.6.10
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.26.0
+  version: 0.27.2
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:31ce18904522853f8187ed36bc1f152fc700ea2dcae95b23568404195181371b
-generated: "2025-05-16T16:14:01.219378+03:00"
+digest: sha256:8048352519f176b98326d24c50c948888a780d397d70a64d8200a373deedc640
+generated: "2025-07-10T17:30:44.63441+03:00"

--- a/openstack/placement/Chart.yaml
+++ b/openstack/placement/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 description: A Helm chart for the Openstack Placement Service
 name: placement
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/project-mascots/Placement/OpenStack_Project_Placement_horizontal.jpg
-version: 0.2.2
+version: 0.2.3
 appVersion: "dalmatian"
 dependencies:
   - condition: mariadb.enabled
@@ -20,7 +20,7 @@ dependencies:
     version: 0.6.10
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.26.0
+    version: 0.27.2
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0

--- a/openstack/placement/templates/db-migrate-job.yaml
+++ b/openstack/placement/templates/db-migrate-job.yaml
@@ -23,6 +23,9 @@ spec:
       {{- include "utils.proxysql.job_pod_settings" . | indent 6 }}
       initContainers:
       {{- tuple . (dict "service" (include "placement.db_name" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
+      {{- if .Values.proxysql.native_sidecar }}
+      {{- include "utils.proxysql.container" . | indent 6 }}
+      {{- end }}
       containers:
       - name: db-migrate
         image: {{ required ".Values.global.registry is missing" .Values.global.registry}}/loci-placement:{{.Values.imageVersion | required "Please set .imageVersion or similar" }}
@@ -57,7 +60,9 @@ spec:
           name: placement-etc-confd
         {{- include "utils.proxysql.volume_mount" . | indent 8 }}
         {{- include "utils.trust_bundle.volume_mount" . | indent 8 }}
+      {{- if not .Values.proxysql.native_sidecar }}
       {{- include "utils.proxysql.container" . | indent 6 }}
+      {{- end }}
       volumes:
       - name: placement-etc
         configMap:

--- a/openstack/placement/templates/db-online-migrate-job.yaml
+++ b/openstack/placement/templates/db-online-migrate-job.yaml
@@ -23,6 +23,9 @@ spec:
       {{- include "utils.proxysql.job_pod_settings" . | indent 6 }}
       initContainers:
       {{- tuple . (dict "service" (include "placement.db_name" .) "jobs" (tuple . "db-migrate" | include "placement.job_name") ) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
+      {{- if .Values.proxysql.native_sidecar }}
+      {{- include "utils.proxysql.container" . | indent 6 }}
+      {{- end }}
       containers:
       - name: db-online-migrate
         image: {{ required ".Values.global.registry is missing" .Values.global.registry}}/loci-placement:{{.Values.imageVersion | required "Please set .imageVersion or similar" }}
@@ -57,7 +60,9 @@ spec:
           name: placement-etc-confd
         {{- include "utils.proxysql.volume_mount" . | indent 8 }}
         {{- include "utils.trust_bundle.volume_mount" . | indent 8 }}
+      {{- if not .Values.proxysql.native_sidecar }}
       {{- include "utils.proxysql.container" . | indent 6 }}
+      {{- end }}
       volumes:
       - name: placement-etc
         configMap:

--- a/openstack/placement/templates/placement-api-deployment.yaml
+++ b/openstack/placement/templates/placement-api-deployment.yaml
@@ -40,6 +40,9 @@ spec:
       {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       initContainers:
       {{- tuple . (dict "service" (include "placement.db_name" .) "jobs" (tuple . "db-migrate" | include "placement.job_name") ) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
+      {{- if .Values.proxysql.native_sidecar }}
+      {{- include "utils.proxysql.container" . | indent 6 }}
+      {{- end }}
       containers:
       - name: placement-api
         image: {{ required ".Values.global.registry is missing" .Values.global.registry}}/loci-placement:{{.Values.imageVersion | required "Please set .imageVersion or similar" }}
@@ -89,7 +92,9 @@ spec:
           name: placement-etc-confd
         {{- include "utils.proxysql.volume_mount" . | indent 8 }}
         {{- include "utils.trust_bundle.volume_mount" . | indent 8 }}
+      {{- if not .Values.proxysql.native_sidecar }}
       {{- include "utils.proxysql.container" . | indent 6 }}
+      {{- end }}
       volumes:
       - name: placement-etc
         configMap:

--- a/openstack/placement/values.yaml
+++ b/openstack/placement/values.yaml
@@ -19,6 +19,7 @@ use_tls_acme: true
 
 proxysql:
   mode: ""
+  native_sidecar: true
 
 defaults:
   default:


### PR DESCRIPTION
Run proxysql sidecars as native sidecars.

This would ensure that proxysql container is always stopped after the main container on each rollout.

Update openstack/utils helm chart to 0.27.2 version with native sidecar support for proxysql