### PR TITLE
[manila][proxysql] fix migration-job proxysql sidecar configuration

### DIFF
--- a/openstack/manila/templates/migration-job.yaml
+++ b/openstack/manila/templates/migration-job.yaml
@@ -35,6 +35,9 @@ spec:
       priorityClassName: {{ .Values.pod.priority_class.low }}
       initContainers:
       {{- tuple . (dict "service" (include "manila.db_service" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
+      {{- if .Values.proxysql.native_sidecar }}
+      {{- include "utils.proxysql.container" . | indent 6 }}
+      {{- end }}
       containers:
         - name: manila-migration
           image: {{.Values.global.registry}}/loci-manila:{{.Values.loci.imageVersion}}
@@ -73,7 +76,9 @@ spec:
             {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
 {{- if $proxysql }}
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
+        {{- if not .Values.proxysql.native_sidecar }}
         {{- include "utils.proxysql.container" . | indent 8 }}
+        {{- end }}
 {{- end }}
       volumes:
         - name: etcmanila


### PR DESCRIPTION
The current openstack/utils sidecar option enables restartPolicy=Always for all proxysql sidecars within a chart, so not only deployments but jobs also needs to be modified.