### PR TITLE
[nova][mysql-metrics] remove cell2 db path helper function

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 0.24.2
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.4.4
+  version: 0.5.0
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.17.1
@@ -29,5 +29,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:22b49429de08fb51656352f073ef0346c07060bab7e07c6ed82619f0ad42a413
-generated: "2025-06-03T15:40:52.681379507+02:00"
+digest: sha256:5787581f8836b7a459ed87ea164aca59c53df2d5e1ea6862546e4af03d71629e
+generated: "2025-06-26T15:26:42.891199+03:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 name: nova
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Nova/OpenStack_Project_Nova_mascot.png
-version: 0.4.3
+version: 0.4.4
 appVersion: "bobcat"
 dependencies:
   - name: mariadb
@@ -17,7 +17,7 @@ dependencies:
   - name: mysql_metrics
     condition: mariadb.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.4.4
+    version: 0.5.0
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.17.1

--- a/openstack/nova/templates/_helpers.tpl
+++ b/openstack/nova/templates/_helpers.tpl
@@ -27,12 +27,6 @@ connection = {{ tuple . .Values.apidbName .Values.apidbUser .Values.apidbPasswor
     {{- end }}
 {{- end }}
 
-{{- define "cell2_db_path_for_exporter" -}}
-{{- if eq .Values.cell2.enabled true -}}
-mysql://{{ .Values.cell2dbUser | include "mysql_metrics.resolve_secret_for_yaml" }}:{{ default .Values.cell2dbPassword .Values.global.dbPassword | include "mysql_metrics.resolve_secret_for_yaml" }}@tcp(nova-{{.Values.cell2.name}}-mariadb.{{include "svc_fqdn" .}}:3306)/{{.Values.cell2dbName}}
-{{- end -}}
-{{- end -}}
-
 {{- define "cell2_transport_url" -}}
 {{- $data := merge (pick .Values.rabbitmq_cell2 "port" "virtual_host") .Values.rabbitmq_cell2.users.default }}
 {{- $_ := set $data "host" (printf "%s-%s-rabbitmq" .Release.Name .Values.cell2.name) }}


### PR DESCRIPTION
Remove cell2 db path helper function, which is being used in mysql-metrics chart.

This PR could be merged after the related secrets PR is merged, in which we define `connections` configuration.