### PR TITLE
[manila] change file type of ratelimit_backend_secret

### DIFF
--- a/openstack/manila/values.yaml
+++ b/openstack/manila/values.yaml
@@ -806,7 +806,7 @@ audit:
 # openstack-ratelimit-middleware
 api_rate_limit:
   enabled: false
-  backend_secret_file: /etc/manila/ratelimit-backend-secret.conf
+  backend_secret_file: /etc/manila/ratelimit-backend-secret.txt
   rate_limit_by: "target_project_id"
   max_sleep_time_seconds: 15
   log_sleep_time_seconds: 10


### PR DESCRIPTION
Tools that are operating with .conf expect a certain key value format.
But this secret file holds a plain single value.

In my case it was the oslo config parser that choked like:

oslo_config.cfg.ParseError: at /etc/manila/ratelimit-backend-secret.conf:1, No ':' or '=' found in assignment
