### PR TITLE
[absent-metrics-operator] update registry to ghcr

### DIFF
--- a/system/absent-metrics-operator/Chart.yaml
+++ b/system/absent-metrics-operator/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 description: Absent Metrics Operator
 name: absent-metrics-operator
-version: 1.0.4
+version: 1.0.5

--- a/system/absent-metrics-operator/ci/test-values.yaml
+++ b/system/absent-metrics-operator/ci/test-values.yaml
@@ -2,4 +2,4 @@ global:
   keystoneNamespace: keystone
   region: xx-yy-1
   tld: example.org
-  registry: registry.example.com
+  ghcrIoMirror: registry.example.com

--- a/system/absent-metrics-operator/templates/deployment.yaml
+++ b/system/absent-metrics-operator/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: absent-metrics-operator-service-user
       containers:
         - name: operator
-          image: {{ .Values.global.registry }}/absent-metrics-operator:{{ .Values.imageTag }}
+          image: {{ .Values.global.ghcrIoMirror }}/sapcc/absent-metrics-operator:{{ .Values.imageTag }}
           imagePullPolicy: IfNotPresent
           {{- with .Values.args }}
           args:

--- a/system/absent-metrics-operator/values.yaml
+++ b/system/absent-metrics-operator/values.yaml
@@ -1,6 +1,6 @@
 global:
   ghcrIoMirror: DEFINED_IN_VALUES_FILE
 
-imageTag: "20250515130640"
+imageTag: "v0.9.6"
 # args:
 # - --keep-labels=app

--- a/system/absent-metrics-operator/values.yaml
+++ b/system/absent-metrics-operator/values.yaml
@@ -1,6 +1,6 @@
 global:
-  registry: DEFINED_IN_VALUES_FILE
+  ghcrIoMirror: DEFINED_IN_VALUES_FILE
 
-imageTag: "20250212104340"
+imageTag: "20250515130640"
 # args:
 # - --keep-labels=app


### PR DESCRIPTION
updating registry to ghcr to deprecate concourse build pipeline for absent metrics operator