### PR TITLE
[trust-manager] multiple namespaces as target

### DIFF
--- a/openstack/trust-manager/values.yaml
+++ b/openstack/trust-manager/values.yaml
@@ -18,8 +18,12 @@ trust-manager:
       memory: 128Mi
 
 namespaces:
-  matchLabels:
-    kubernetes.io/metadata.name: monsoon3
+  matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: In
+      values:
+        - monsoon3
+        - netapp-credential-rotator
 
 cert_exporter:
   namespaces:


### PR DESCRIPTION
Although `matchExpressions` not mentioned in main document,
trust-manager does support it as mentioned in its referenece.
See
https://cert-manager.io/docs/trust/trust-manager/api-reference/#bundlespectargetnamespaceselectormatchexpressionsindex.
