### PR TITLE
[rabbitmq] Fix certificate for ssl mode

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+## 0.18.2 - 2025/06/30
+
+- Removed the default for CN (common name) from the certificate, as it is too long
+- Switched ClusterIssuer group from `cert-manager.io` to `certmanager.cloud.sap`
+
 ## 0.18.1 - 2025/06/12
 
 - RabbitMQ [4.1.1 Release Notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.1.1)

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: rabbitmq
-version: 0.18.1
+version: 0.18.2
 appVersion: 4.1.1
 description: A Helm chart for RabbitMQ
 sources:

--- a/common/rabbitmq/templates/certificate.yaml
+++ b/common/rabbitmq/templates/certificate.yaml
@@ -10,7 +10,6 @@ spec:
   secretTemplate:
     labels:
       {{- include "rabbitmq.labels" (list $ "version" "rabbitmq" "deployment" "messagequeue") | indent 6 }}
-  commonName: "{{ template "fullname" . }}.{{ .Release.Namespace }}.svc.kubernetes.{{ .Values.global.region | required "global.region missing" }}.{{ .Values.global.tld | required "global.tld missing" }}"
   dnsNames:
     - "{{ template "fullname" . }}.{{ .Release.Namespace }}.svc.kubernetes.{{ .Values.global.region | required "global.region missing" }}.{{ .Values.global.tld | required "global.tld missing" }}"
   {{- if .Values.externalNames }}

--- a/common/rabbitmq/values.yaml
+++ b/common/rabbitmq/values.yaml
@@ -138,7 +138,7 @@ certificate:
   issuerRef:
     name: nil
     kind: "ClusterIssuer"
-    group: "cert-manager.io"
+    group: "certmanager.cloud.sap"
   usages:
     - digital signature
     - key encipherment


### PR DESCRIPTION
The common name could become too long and isn't needed. We use a different clusterissuer resource in the group certmanager.cloud.sap instead of cert-manager.io