### PR TITLE
[nova] Update rabbitmq for ssl-enablement (0.17.2 -> 0.18.2)

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 0.4.4
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.17.1
+  version: 0.18.2
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.6.10
@@ -22,12 +22,12 @@ dependencies:
   version: 0.24.2
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.17.1
+  version: 0.18.2
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:22b49429de08fb51656352f073ef0346c07060bab7e07c6ed82619f0ad42a413
-generated: "2025-06-03T15:40:52.681379507+02:00"
+digest: sha256:6213361c4c1b0e43bf12b82dcdb1d97aa2b700caa161e489f89c1dd14579d3ea
+generated: "2025-06-30T15:47:27.918001157+02:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -20,7 +20,7 @@ dependencies:
     version: 0.4.4
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.17.1
+    version: 0.18.2
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.6.10
@@ -36,7 +36,7 @@ dependencies:
     alias: rabbitmq_cell2
     condition: cell2.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.17.1
+    version: 0.18.2
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0


### PR DESCRIPTION
It doesn't enable ssl itself, but pulls in the changes needed for it.
It also pulls in an update of rabbitmq from 4.0.8 to 4.1.1.