### PR TITLE
[neutron] Update rabbitmq for ssl-enablement (0.17.2 -> 0.18.2)

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 0.4.4
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.17.1
+  version: 0.18.2
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.26.0
@@ -29,5 +29,5 @@ dependencies:
 - name: ovsdb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
-digest: sha256:1618b4ed15d37d4a5c8f6b69165e29c6af7d2b54961cf291e8ed4d22538456a1
-generated: "2025-05-16T15:00:40.586381+03:00"
+digest: sha256:354d2cc06a823807fafaa71e47853326d47f96a6aeaac22cfc3d1b2bb2e8f956
+generated: "2025-06-30T15:51:47.242295182+02:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
     version: 0.4.4
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.17.1
+    version: 0.18.2
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.26.0


### PR DESCRIPTION
It doesn't enable ssl itself, but pulls in the changes needed for it. 
It also pulls in an update of rabbitmq from 4.0.8 to 4.1.1.