### PR TITLE
[neutron] Enable ssl for rabbitmq

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 0.4.4
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.18.2
+  version: 0.18.3
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.26.0
@@ -29,5 +29,5 @@ dependencies:
 - name: ovsdb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
-digest: sha256:354d2cc06a823807fafaa71e47853326d47f96a6aeaac22cfc3d1b2bb2e8f956
-generated: "2025-06-30T15:51:47.242295182+02:00"
+digest: sha256:db5365e1c80f08c51bd175fa090ce491c93161fd5be6610c7ebb551ffe49e1ac
+generated: "2025-07-01T15:26:27.823277157+02:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
     version: 0.4.4
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.18.2
+    version: 0.18.3
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.26.0

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -709,6 +709,7 @@ audit:
 
 rabbitmq:
   name: neutron
+  enableSsl: true
   persistence:
     enabled: false
   default:


### PR DESCRIPTION
This only enables it on the rabbitmq server,
but not the clients.