### PR TITLE
[utils][proxysql] don't use pkill if proxysql is a native sidecar

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,5 @@
+---
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.27.0
+version: 0.27.1

--- a/openstack/utils/templates/_proxysql.tpl
+++ b/openstack/utils/templates/_proxysql.tpl
@@ -130,9 +130,11 @@ hostAliases:
   {{- if .Values.proxysql }}
     {{- if .Values.proxysql.mode }}
 {{- include "utils.proxysql.pod_settings" . }}
+      {{- if not .Values.proxysql.native_sidecar }}
 shareProcessNamespace: true
 securityContext:
   runAsUser: 65534
+      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}
@@ -142,7 +144,9 @@ securityContext:
 {{- define "utils.proxysql.proxysql_signal_stop_script" }}
   {{- if .Values.proxysql }}
     {{- if .Values.proxysql.mode -}}
+      {{- if not .Values.proxysql.native_sidecar }}
 pkill proxysql || true
+      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Don't use pkill to stop proxysql from job scripts, if ProxySQL runs as a native sidecar.

Disable `shareProcessNamespace` option in that case, as it's needed for an unused pkill.