### PR TITLE
[netapp-credential-rotator] remove resolve functions for secrets

### DIFF
--- a/openstack/netapp-credential-rotator/templates/secrets.yaml
+++ b/openstack/netapp-credential-rotator/templates/secrets.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: netapp-credential-rotator
 data:
   vault_addr: {{ .Values.vault.addr | b64enc | quote }}
-  vault_role_id: {{ .Values.vault.approle.roleId | printf `{{ resolve %s }}` | b64enc }}
-  vault_secret_id: {{ .Values.vault.approle.secretId | printf `{{ resolve %s }}` | b64enc }}
+  vault_role_id: {{ .Values.vault.approle.roleId |  b64enc }}
+  vault_secret_id: {{ .Values.vault.approle.secretId | b64enc }}


### PR DESCRIPTION
Not needed in Secret.
