### PR TITLE
[nova] Bump chart dependencies

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 0.24.2
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.4.4
+  version: 0.5.0
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.18.3
@@ -29,5 +29,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:3ee22c47641679fa7789229de6b401472f89a87ba8205a8c48e9e33f2d5a0c66
-generated: "2025-07-01T15:36:33.634068653+02:00"
+digest: sha256:0c7d81484dae8f4ee5a2c15a76e25954598b0f1b735bb193375f2f4af9cd8e0d
+generated: "2025-07-07T18:47:24.068773+02:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
   - name: mysql_metrics
     condition: mariadb.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.4.4
+    version: 0.5.0
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.18.3


### PR DESCRIPTION
- Bump mysql_metrics chart 0.4.4 to 0.5.0
  - Bump sql-exporter 0.5.9 to 0.6.0
  - Add new optional `connections` value for multiple database targets
  - Remove unused `customSources` value