### PR TITLE
Feat/secrets injector add labeling

### DIFF
--- a/system/secrets-injector/Chart.yaml
+++ b/system/secrets-injector/Chart.yaml
@@ -3,7 +3,7 @@ name: secrets-injector
 description: Secrets Injector
 
 type: application
-version: 1.1.13
+version: 1.1.14
 appVersion: "0.1.0"
 
 dependencies:

--- a/system/secrets-injector/Chart.yaml
+++ b/system/secrets-injector/Chart.yaml
@@ -3,7 +3,7 @@ name: secrets-injector
 description: Secrets Injector
 
 type: application
-version: 1.1.12
+version: 1.1.13
 appVersion: "0.1.0"
 
 dependencies:

--- a/system/secrets-injector/ci/test-values.yaml
+++ b/system/secrets-injector/ci/test-values.yaml
@@ -1,6 +1,9 @@
 global:
   registry: someregistry.local
 webhook:
+  labels:
+    foo: bar
+    test: value
   genericRules:
   - apiGroups:   [""]
     apiVersions: ["v1"]
@@ -16,3 +19,9 @@ webhook:
     resourceType: secret
     resourceName: abc
     keyName: client-ca.crt
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: In
+      values:
+      - kube-system

--- a/system/secrets-injector/templates/webhook.yaml
+++ b/system/secrets-injector/templates/webhook.yaml
@@ -4,6 +4,10 @@ metadata:
   name: "secrets-injector.cloud.sap"
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/secrets-injector
+    {{- if .Values.webhook.labels }}
+  labels:
+    {{- toYaml .Values.webhook.labels | nindent 4 }}
+    {{- end }}
 webhooks:
 - name: "secrets-injector.cloud.sap"
   failurePolicy: {{ .Values.webhook.failurePolicy }}
@@ -33,6 +37,10 @@ webhooks:
   {{- if .Values.webhook.extraConditions }}
   {{- toYaml .Values.webhook.extraConditions | nindent 2 }}
   {{- end }}
+  {{- end }}
+  {{- if .Values.webhook.namespaceSelector }}
+  namespaceSelector:
+  {{- toYaml .Values.webhook.namespaceSelector | nindent 4 }}
   {{- end }}
 {{- if .Values.webhook.genericRules }}
 - name: "generic.secrets-injector.cloud.sap"

--- a/system/secrets-injector/values.yaml
+++ b/system/secrets-injector/values.yaml
@@ -15,7 +15,7 @@ image:
 webhook:
   failurePolicy: Fail
   # between 1 and 30 seconds: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#timeouts
-  timeoutSeconds: 30
+  timeoutSeconds: 15
   genericRules: []
   matchConditions: false
   extraConditions: []


### PR DESCRIPTION
This adds 

- `.Values.webhook.labels`
- `.Values.webhook.namespaceSelector`

to the Chart to be able to template both on the webhook.

Context:
Gardener disallows webhooks in `kube-system` namespace. You can either label your webhook with `remediation.webhook.shoot.gardener.cloud/exclude: "true"` or you can exclude your webhook from `kube-system`

https://github.com/gardener/gardener/blob/master/docs/usage/shoot/shoot_status.md#constraints
