### PR TITLE
[Cinder] fix volumes template loop

### DIFF
--- a/openstack/cinder/templates/volumes/volumes.yaml
+++ b/openstack/cinder/templates/volumes/volumes.yaml
@@ -1,5 +1,5 @@
 {{- $envAll := . }}
-{{- range $name, $volume := .Values.volumes -}}
+{{- range $name, $volume := .Values.volumes }}
 ---
 {{ tuple $envAll $name $volume | include "volume_configmap" }}
 ---


### PR DESCRIPTION
The volumes template loop was not giving the iteration of the loop a newline, so when it printed out the next ConfigMap entry it put the --- on the end of the previous line, making an invalid deployment for the first pass through the loop.