### PR TITLE
[logs] fix duplicate labels for k8sevents

### DIFF
--- a/system/logs/Chart.yaml
+++ b/system/logs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for all log shippers
 name: logs
-version: 0.0.75
+version: 0.0.76
 home: https://github.com/sapcc/helm-charts/tree/master/system/logs
 dependencies:
   - name: opentelemetry-operator

--- a/system/logs/templates/_k8sevents-config.tpl
+++ b/system/logs/templates/_k8sevents-config.tpl
@@ -17,11 +17,22 @@ attributes/k8sevents:
       key: log.type
       value: "k8sevents"
 
+transform/consolidate_label:
+# consolidates the k8s labels coming from resource and attributes into a single label
+  error_mode: ignore
+  log_statements:
+    - context: log
+      statements:
+        - set(resource.attributes["k8s.namespace.name"], attributes["k8s.namespace.name"])
+        - set(resource.attributes["k8s.node.name"], attributes["k8s.node.name"])
+        - delete_key(attributes, "k8s.namespace.name") 
+        - delete_key(attributes, "k8s.node.name") 
+
 {{- end }}
 
 {{- define "k8sevents.pipeline" }}
 logs/k8sevents:
   receivers: [k8s_events]
-  processors: [attributes/k8sevents]
+  processors: [attributes/k8sevents,transform/consolidate_label]
   exporters: [forward]
 {{- end }}


### PR DESCRIPTION
We currently ship two labels twice when going through the k8sevents pipeline.

- resource.k8s.namespace.name and resource.k8s.node.name and (through k8sattributes processor)
- attributes.k8s.namespace.name and attributes.k8s.node.name (through k8sevents receiver)

The labels through k8sevent can be replaced in favor of the labels through the processor. See [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/transformprocessor/README.md#rename-attribute) for more examples. 