### PR TITLE
Allow users to create projects only in their domains

### DIFF
--- a/openstack/keystone/templates/etc/_policy.yaml.tpl
+++ b/openstack/keystone/templates/etc/_policy.yaml.tpl
@@ -940,7 +940,7 @@
 # POST  /v3/projects
 # Intended scope(s): system, domain
 #"identity:create_project": "(role:admin and system_scope:all) or (role:admin and domain_id:%(target.project.domain_id)s)"
-"identity:create_project": ""
+"identity:create_project": "rule:cloud_admin or (role:admin and domain_id:%(target.project.domain_id)s) or (role:admin and project_id:%(target.project.parent_id)s) or user_domain_id:%(target.project.domain_id)s"
 
 # Update project.
 # PATCH  /v3/projects/{project_id}


### PR DESCRIPTION
This change partially restores the policy of project creation. It allows users to create projects only in their domains. However, it still allows project creation for certain other admins even across domains.

This is needed because we don't want external users to create projects everywhere, and we don't want our projects to be created in their domains.