### PR TITLE
Revert "[nova] Enable ssl on rabbitmq"

### DIFF
--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -856,7 +856,6 @@ mariadb_cell2:
           allTables: true
 
 rabbitmq_cell2:
-  enableSsl: true
   nameOverride: cell2-rabbitmq
   persistence:
     enabled: false
@@ -872,7 +871,6 @@ rabbitmq_cell2:
       enabled: false
     enableDetailedMetrics: true
     enablePerObjectMetrics: true
-
 audit:
   central_service:
     user: rabbitmq
@@ -882,7 +880,6 @@ audit:
   metrics_enabled: true
 
 rabbitmq:
-  enableSsl: true
   users:
     default:
       password: null


### PR DESCRIPTION
This reverts commit e4efd82b5df09d94b142680b97d9331efcbf430e.

We have problems with getting certs created while rolling this out, but need to be able to roll out further for other changes.