### PR TITLE
[tempest] Switch glance to tempestuser[3-4].

### DIFF
--- a/openstack/tempest/glance-tempest/templates/etc/_tempest_accounts.yaml.tpl
+++ b/openstack/tempest/glance-tempest/templates/etc/_tempest_accounts.yaml.tpl
@@ -1,11 +1,11 @@
-- username: 'tempestuser1'
+- username: 'tempestuser3'
   password: {{ .Values.tempestAdminPassword | quote }}
-  tenant_name: 'tempest1'
-  project_name: 'tempest1'
-- username: 'tempestuser2'
+  tenant_name: 'tempest3'
+  project_name: 'tempest3'
+- username: 'tempestuser4'
   password: {{ .Values.tempestAdminPassword | quote }}
-  tenant_name: 'tempest2'
-  project_name: 'tempest2'
+  tenant_name: 'tempest4'
+  project_name: 'tempest4'
 - username: 'admin'
   password: {{ .Values.tempestAdminPassword | quote }}
   tenant_name: 'admin'

--- a/openstack/tempest/glance-tempest/templates/etc/_tempest_deployment_config.json.tpl
+++ b/openstack/tempest/glance-tempest/templates/etc/_tempest_deployment_config.json.tpl
@@ -11,17 +11,17 @@
     },
     "users": [
         {
-            "username": "tempestuser1",
+            "username": "tempestuser3",
             "password": {{ .Values.tempestAdminPassword | quote }},
             "user_domain_name": "tempest",
-            "project_name": "tempest1",
+            "project_name": "tempest3",
             "project_domain_name": "tempest"
         },
         {
-            "username": "tempestuser2",
+            "username": "tempestuser4",
             "password": {{ .Values.tempestAdminPassword | quote }},
             "user_domain_name": "tempest",
-            "project_name": "tempest2",
+            "project_name": "tempest4",
             "project_domain_name": "tempest"
         }
     ],


### PR DESCRIPTION
To avoid conflicts with keystone tempest users and their roles assignments we need to move glance to different users.