### PR TITLE
[neutron] set ptr_zone_email for reverse zones created by Neutron

### DIFF
--- a/openstack/neutron/templates/etc/_neutron.conf.tpl
+++ b/openstack/neutron/templates/etc/_neutron.conf.tpl
@@ -91,6 +91,7 @@ project_domain_name = ccadmin
 insecure = True
 allow_reverse_dns_lookup = {{.Values.global.designate_allow_reverse_dns_lookup | default "False"}}
 ipv4_ptr_zone_prefix_size = 24
+ptr_zone_email = dns@sap-ag.de
 
 [oslo_concurrency]
 lock_path = /var/lib/neutron/tmp


### PR DESCRIPTION
- Without this setting all reverse zones created when providing dns options for floating IPs are created with default "hostmaster@example.com" e-mail address.