### PR TITLE
[common/rabbitmq] No externalIPs in certificates

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+## 0.18.4 - 2025/07/01
+
+- Drop `externalIps` from certificate, as they are unsupported by our certificate provider.
+  They still can be added with `certificate.ipAddresses`
+
+
 ## 0.18.3 - 2025/07/01
 
 - Default to ClusterIssuer with the name "digicert-issuer"

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: rabbitmq
-version: 0.18.3
+version: 0.18.4
 appVersion: 4.1.1
 description: A Helm chart for RabbitMQ
 sources:

--- a/common/rabbitmq/templates/certificate.yaml
+++ b/common/rabbitmq/templates/certificate.yaml
@@ -17,11 +17,5 @@ spec:
     - "{{ . }}"
     {{- end }}
   {{- end }}
-  {{- if .Values.externalIPs }}
-  ipAddresses:
-    {{- range .Values.externalIPs }}
-    - "{{ . }}"
-    {{- end }}
-  {{- end }}
   {{- .Values.certificate | toYaml | nindent 2 }}
 {{- end }}


### PR DESCRIPTION
Our certificate provider doesn't support these IPs, so that part never worked. If you want to add them still, you can do that explicitly by adding them via `certificate.ipAddresses`