### PR TITLE
[designate] bump shared chart dependencies

### DIFF
--- a/openstack/designate/Chart.lock
+++ b/openstack/designate/Chart.lock
@@ -7,16 +7,16 @@ dependencies:
   version: 0.4.0
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.24.1
+  version: 0.25.0
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.6.9
+  version: 0.6.10
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.4.4
+  version: 0.5.0
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.18.0
+  version: 0.18.4
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.27.2
@@ -29,5 +29,5 @@ dependencies:
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.1.4
-digest: sha256:fbe7b83785f3767b9d8832be0623e93da5c6daf513b50a16fb992210850ed0fe
-generated: "2025-07-10T13:59:32.600621+03:00"
+digest: sha256:066b5da035e3e1a5891c7154dd07cd5361ac61da3de9bb1f78a91523af97887c
+generated: "2025-07-10T14:30:19.192254+03:00"

--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -17,18 +17,18 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.24.1
+    version: 0.25.0
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.6.9
+    version: 0.6.10
   - condition: mysql_metrics.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.4.4
+    version: 0.5.0
   - name: rabbitmq
     condition: rabbitmq.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.18.0
+    version: 0.18.4
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.27.2


### PR DESCRIPTION
* Upgrades MariaDB to 10.11.13
* Upgrades RabbitMQ to 4.1.1
* Upgrades sql-exporter to 0.6 2025-06-10