### PR TITLE
[Cinder] Remove v2 endpoint from seeding

### DIFF
--- a/openstack/cinder/templates/seed.yaml
+++ b/openstack/cinder/templates/seed.yaml
@@ -21,19 +21,6 @@ spec:
   - name: cloud_compute_admin
 
   services:
-  - name: cinderv2
-    type: volumev2
-    description: Openstack Block Storage
-    endpoints:
-    - interface: admin
-      region: '{{.Values.global.region}}'
-      url: 'http://{{include "cinder_api_endpoint_host_admin" .}}:{{.Values.cinderApiPortAdmin}}/v2/%(tenant_id)s'
-    - interface: internal
-      region: '{{.Values.global.region}}'
-      url: 'http://{{include "cinder_api_endpoint_host_internal" .}}:{{.Values.cinderApiPortInternal}}/v2/%(tenant_id)s'
-    - interface: public
-      region: '{{.Values.global.region}}'
-      url: 'https://{{include "cinder_api_endpoint_host_public" .}}:{{.Values.cinderApiPortPublic}}/v2/%(tenant_id)s'
   - name: cinderv3
     type: volumev3
     description: Openstack Block Storage


### PR DESCRIPTION
The cinder v2 API was removed in Xena release.
We have rolled out Antelop and the v2 api is now gone. This patch removes the v2 endpoint from the seeder.