### PR TITLE
[desginate] increase default_limit_v2 from 20 to 200.

### DIFF
--- a/openstack/designate/templates/etc/_designate.conf.tpl
+++ b/openstack/designate/templates/etc/_designate.conf.tpl
@@ -156,10 +156,10 @@ enabled_extensions_v2 = quotas, reports
 
 # Default per-page limit for the V2 API, a value of None means show all results
 # by default
-#default_limit_v2 = 20
+default_limit_v2 = 200
 
 # Max page size in the V2 API
-#max_limit_v2 = 1000
+max_limit_v2 = 1000
 
 # Enable Admin API (experimental)
 #enable_api_admin = True


### PR DESCRIPTION
- because for large DNS zones the client will use a lot of API requests if not specifing the limit explicitely to be more than default 20.
- this becomes a problem with rate limiting enabled and large DNS zones holding 1000s of records as the rate limiting budget runs out quickly.