### PR TITLE
enforce limits on cc action runners

### DIFF
--- a/global/gh-actions/Chart.yaml
+++ b/global/gh-actions/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.8.3"
 description: Helm chart for GitHub Actions Runner Controller on SAPs Enterprise GitHub
 name: gh-actions
-version: 1.0.3
+version: 1.0.4
 maintainers:
   - name: auhlig
   - name: notandyk

--- a/global/gh-actions/values.yaml
+++ b/global/gh-actions/values.yaml
@@ -66,6 +66,11 @@ gha-runner-scale-set:
               mountPath: /run/docker
             - name: dind-externals
               mountPath: /home/runner/externals
+          resources:
+            requests:
+              ephemeral-storage: "1Gi"
+            limits:
+              ephemeral-storage: "5Gi"
       volumes:
         - name: work
           emptyDir: {}
@@ -120,6 +125,11 @@ gha-runner-scale-set-rootless:
               mountPath: /run/docker
             - name: dind-externals
               mountPath: /home/runner/externals
+          resources:
+            requests:
+              ephemeral-storage: "1Gi"
+            limits:
+              ephemeral-storage: "5Gi"
       volumes:
         - name: work
           emptyDir: {}


### PR DESCRIPTION
Still observing NodeDiskPressure conditions and evicted pods. Let's enforce some resource constraints.
Would you mind reviewing @notandy?