### PR TITLE
[nova] Bump mariadb

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.24.2
+  version: 0.25.0
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.24.2
+  version: 0.25.0
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.5.0
@@ -19,7 +19,7 @@ dependencies:
   version: 0.26.0
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.24.2
+  version: 0.25.0
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.18.3
@@ -29,5 +29,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:0c7d81484dae8f4ee5a2c15a76e25954598b0f1b735bb193375f2f4af9cd8e0d
-generated: "2025-07-07T18:47:24.068773+02:00"
+digest: sha256:34d6760b3b11ef1421dce4781e7d1caef9810a4c1d354f5484bc11f1e932145f
+generated: "2025-07-09T16:24:31.037053+02:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -8,12 +8,12 @@ dependencies:
   - name: mariadb
     condition: mariadb.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.24.2
+    version: 0.25.0
   - name: mariadb
     alias: mariadb_api
     condition: mariadb_api.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.24.2
+    version: 0.25.0
   - name: mysql_metrics
     condition: mariadb.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
@@ -31,7 +31,7 @@ dependencies:
     alias: mariadb_cell2
     condition: mariadb_cell2.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.24.2
+    version: 0.25.0
   - name: rabbitmq
     alias: rabbitmq_cell2
     condition: cell2.enabled


### PR DESCRIPTION
- Bump mariadb chart 0.24.2 to 0.25.0:
  - Bump mariadb 10.6.22 to 10.11.13
  - Bump mysqld-exporter 0.17.1 to 0.17.2