### PR TITLE
[manila] fix backend secrets

### DIFF
--- a/openstack/manila/templates/shares/_helpers.tpl
+++ b/openstack/manila/templates/shares/_helpers.tpl
@@ -1,3 +1,31 @@
 {{- define "filerNameFromHost" -}}
 {{- regexSplit "\\.cc" . -1 | first }}
 {{- end -}}
+
+{{- define "upper" -}}
+{{ . | upper | replace "-" "_" }}
+{{- end -}}
+
+{{- define "backendCredentialEnvs" -}}
+{{- range .filers }}
+- name: {{ include "filerNameFromHost" .host | include "upper" }}_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: manila-share-netapp-{{ include "filerNameFromHost" .host }}
+      key: username
+- name: {{ include "filerNameFromHost" .host | include "upper" }}_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: manila-share-netapp-{{ include "filerNameFromHost" .host }}
+      key: password
+{{- end -}}
+{{- end -}}
+
+{{- define "backendCredentialConf" -}}
+{{- range .filers }}
+[{{ .name }}]
+netapp_login=${{ include "filerNameFromHost" .host | include "upper" }}_USERNAME
+netapp_password=${{ include "filerNameFromHost" .host | include "upper" }}_PASSWORD
+{{- "\n" }}
+{{- end -}}
+{{- end -}}

--- a/openstack/manila/templates/shares/_netapp-deployment.yaml.tpl
+++ b/openstack/manila/templates/shares/_netapp-deployment.yaml.tpl
@@ -67,21 +67,10 @@ spec:
           - -c
           - |
             cat <<EOF > /shared/backend-secret.conf
-            [{{ $share.name }}]
-            netapp_login=${NETAPP_USERNAME}
-            netapp_password=${NETAPP_PASSWORD}
+            {{- include "backendCredentialConf" .Values.global.netapp | indent 12 }}
             EOF
           env:
-            - name: NETAPP_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: manila-share-netapp-{{ include "filerNameFromHost" $share.host }}
-                  key: username
-            - name: NETAPP_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: manila-share-netapp-{{ include "filerNameFromHost" $share.host }}
-                  key: password
+            {{- include "backendCredentialEnvs" .Values.global.netapp | indent 12 }}
           volumeMounts:
             - name: etcmanila
               mountPath: /shared

--- a/openstack/manila/templates/shares/_netapp-ensure-deployment.yaml.tpl
+++ b/openstack/manila/templates/shares/_netapp-ensure-deployment.yaml.tpl
@@ -64,21 +64,10 @@ spec:
           - -c
           - |
             cat <<EOF > /shared/backend-secret.conf
-            [{{ $share.name }}]
-            netapp_login=${NETAPP_USERNAME}
-            netapp_password=${NETAPP_PASSWORD}
+            {{- include "backendCredentialConf" .Values.global.netapp | indent 12 }}
             EOF
           env:
-            - name: NETAPP_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: manila-share-netapp-{{ include "filerNameFromHost" $share.host }}
-                  key: username
-            - name: NETAPP_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: manila-share-netapp-{{ include "filerNameFromHost" $share.host }}
-                  key: password
+            {{- include "backendCredentialEnvs" .Values.global.netapp | indent 12 }}
           volumeMounts:
             - name: etcmanila
               mountPath: /shared


### PR DESCRIPTION
Include credential for remote filers, which are needed for replica
related operations.
