### PR TITLE
[mariadb] collect user statistics

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
 
+## v0.26.0 - 2025/07/22
+* MariaDB `userstat` plugin is enabled
+* mysqld-exporter now collects user statistics
+* chart version bumped
+
 ## v0.25.1 - 2025/07/09
 * Set `kubectl.kubernetes.io/default-container` annotation for all chart deployments, cronjobs and jobs
 * chart version bumped
 
-## v0.25.0 - 2025-07-02
+## v0.25.0 - 2025/07/02
 * MariaDB version updated to [10.11.13](https://mariadb.com/kb/en/mariadb-10-11-13-release-notes/)
   * See https://mariadb.com/kb/en/changes-improvements-in-mariadb-1011/
 * mysql-exporter version updated to [v0.17.2](https://github.com/prometheus/mysqld_exporter/releases/tag/v0.17.2)

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,6 +2,6 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.25.1
+version: 0.26.0
 # scripts/docker-entyrpoint.sh should be updated when appVersion is updated
 appVersion: 10.11.13

--- a/common/mariadb/templates/etc-configmap.yaml
+++ b/common/mariadb/templates/etc-configmap.yaml
@@ -33,6 +33,7 @@ data:
     long_query_time           = {{ .Values.long_query_time }}
     log_warnings              = {{ .Values.log_warnings }}
     general_log_file          = /var/log/mysql/mariadb_general.log
+    userstat                  = ON
 {{- if .Values.db_performance_schema.enabled}}
     performance_schema        = ON
 {{ else }}

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -234,6 +234,7 @@ metrics:
     - collect.info_schema.processlist
     - collect.info_schema.query_response_time
     - collect.info_schema.innodb_tablespaces
+    - collect.info_schema.userstats
   resources:
     enabled: true
     limits:


### PR DESCRIPTION
* MariaDB `userstat` plugin is enabled
* mysqld-exporter now collects user statistics
* chart version bumped
