### PR TITLE
[neutron-hypervisor-agents] Default to fix a nil pointer in the chart

### DIFF
--- a/openstack/neutron-hypervisor-agents/ci/test-values.yaml
+++ b/openstack/neutron-hypervisor-agents/ci/test-values.yaml
@@ -53,7 +53,6 @@ sftp:
   password: swordfish
   os_password: secret
 
-cc_fabric: {}
 osprofiler: {}
 ml2_mechanismdrivers: myDriver
 dns_forwarders: myDNS

--- a/openstack/neutron-hypervisor-agents/values.yaml
+++ b/openstack/neutron-hypervisor-agents/values.yaml
@@ -30,6 +30,8 @@ ovn:
   external_ids: {}
 vpods: {}
 
+cc_fabric: {}
+
 vpods_conf:
   ovs:
     # bridge_mappings: "{{ segment }}:br-ex" Set dynamically script


### PR DESCRIPTION
The cc_fabric value is accessed, like it  is in the neutron charts. That one has a dict in the values, so we get one here as well.