### PR TITLE
[manila] fix env variable name

### DIFF
--- a/openstack/manila/templates/shares/_helpers.tpl
+++ b/openstack/manila/templates/shares/_helpers.tpl
@@ -8,12 +8,12 @@
 
 {{- define "backendCredentialEnvs" -}}
 {{- range .filers }}
-- name: {{ include "filerNameFromHost" .host | include "upper" }}_USERNAME
+- name: {{ .name | include "upper" }}_USERNAME
   valueFrom:
     secretKeyRef:
       name: manila-share-netapp-{{ include "filerNameFromHost" .host }}
       key: username
-- name: {{ include "filerNameFromHost" .host | include "upper" }}_PASSWORD
+- name: {{ .name | include "upper" }}_PASSWORD
   valueFrom:
     secretKeyRef:
       name: manila-share-netapp-{{ include "filerNameFromHost" .host }}
@@ -22,10 +22,10 @@
 {{- end -}}
 
 {{- define "backendCredentialConf" -}}
-{{- range .filers }}
-[{{ .name }}]
-netapp_login=${{ include "filerNameFromHost" .host | include "upper" }}_USERNAME
-netapp_password=${{ include "filerNameFromHost" .host | include "upper" }}_PASSWORD
+{{- range .filers -}}
 {{- "\n" }}
+[{{ .name }}]
+netapp_login=${{ .name | include "upper" }}_USERNAME
+netapp_password=${{ .name | include "upper" }}_PASSWORD
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
In case multiple share services run on same filer, we need to create
different var names.
