### PR TITLE
[mariadb] add `kubectl.kubernetes.io/default-container` annotations

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.25.1 - 2025/07/09
+* Set `kubectl.kubernetes.io/default-container` annotation for all chart deployments, cronjobs and jobs
+* chart version bumped
+
 ## v0.25.0 - 2025-07-02
 * MariaDB version updated to [10.11.13](https://mariadb.com/kb/en/mariadb-10-11-13-release-notes/)
   * See https://mariadb.com/kb/en/changes-improvements-in-mariadb-1011/

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,6 +2,6 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.25.0
+version: 0.25.1
 # scripts/docker-entyrpoint.sh should be updated when appVersion is updated
 appVersion: 10.11.13

--- a/common/mariadb/templates/backup-v2-deployment.yaml
+++ b/common/mariadb/templates/backup-v2-deployment.yaml
@@ -22,6 +22,7 @@ spec:
         app: {{ include "fullName" . }}-backup
         {{- include "mariadb.labels" (list $ "version" "mariadb" "deployment" "backup") | indent 8 }}
       annotations:
+        kubectl.kubernetes.io/default-container: backup
         checksum/etc: {{ include (print $.Template.BasePath  "/config/_backup_config.yaml.tpl") . | sha256sum }}
 {{- if .Values.metrics.enabled }}
         prometheus.io/scrape: "true"

--- a/common/mariadb/templates/backup-verify-deploy.yaml
+++ b/common/mariadb/templates/backup-verify-deploy.yaml
@@ -20,6 +20,7 @@ spec:
       labels:
         {{- include "mariadb.labels" (list $ "version" "mariadb" "deployment" "backupverification") | indent 8 }}
       annotations:
+        kubectl.kubernetes.io/default-container: mariabackup-verification
 {{- if .Values.metrics.enabled }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "8082"

--- a/common/mariadb/templates/cronjob-mariadb-maintenance.yaml
+++ b/common/mariadb/templates/cronjob-mariadb-maintenance.yaml
@@ -21,6 +21,7 @@ spec:
             app: {{ include "fullName" . }}-maint
             {{- include "mariadb.labels" (list $ "version" "mariadb" "cronjob" "maintenance") | indent 12 }}
           annotations:
+            kubectl.kubernetes.io/default-container: maintenance
             {{- if and (and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested) $.Values.linkerd.mariadb.enabled }}
             linkerd.io/inject: enabled
             {{- end }}

--- a/common/mariadb/templates/deployment.yaml
+++ b/common/mariadb/templates/deployment.yaml
@@ -23,6 +23,7 @@ spec:
         app: {{ include "fullName" . }}
         {{- include "mariadb.labels" (list $ "noversion" "mariadb" "deployment" "database") | indent 8 }}
       annotations:
+        kubectl.kubernetes.io/default-container: mariadb
         checksum/etc: {{ include (print $.Template.BasePath  "/etc-configmap.yaml") . | sha256sum }}
         checksum/credential-updater: {{ include (print $.Template.BasePath  "/configmap-mariadb-credential-updater.yaml") . | sha256sum }}
 {{- if .Values.metrics.enabled }}

--- a/common/mariadb/templates/rename-check-constraints-job.yaml
+++ b/common/mariadb/templates/rename-check-constraints-job.yaml
@@ -21,6 +21,7 @@ spec:
       labels:
 {{- include "mariadb.labels" (list $ "version" "mariadb" "job" "rename-check-constraints") | indent 8 }}
       annotations:
+        kubectl.kubernetes.io/default-container: rename-check-constraints
 {{- if and (and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested) $.Values.linkerd.mariadb.enabled }}
         linkerd.io/inject: enabled
         config.alpha.linkerd.io/proxy-enable-native-sidecar: "true"
@@ -29,7 +30,7 @@ spec:
       restartPolicy: {{ .Values.job.renameCheckConstraints.jobRestartPolicy | default "Never" | quote }}
       priorityClassName: {{ .Values.job.renameCheckConstraints.priority_class | default "common-payload" | quote }}
       containers:
-      - name: rename-check-constraints-job
+      - name: rename-check-constraints
         image: {{ required ".Values.global.dockerHubMirrorAlternateRegion is missing" .Values.global.dockerHubMirrorAlternateRegion }}/{{ .Values.image }}
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
Add `kubectl.kubernetes.io/default-container` annotations for all chart's deployments, cronjobs and jobs.