### PR TITLE
[keystone] don't fail on warning in db upgrade check

### DIFF
--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: keystone
 sources:
   - https://github.com/sapcc/keystone
-version: 0.10.4
+version: 0.10.5
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/keystone/templates/bin/_db-sync.tpl
+++ b/openstack/keystone/templates/bin/_db-sync.tpl
@@ -1,9 +1,19 @@
 #!/usr/bin/env bash
 
-set -e
-
 echo "Status before migration:"
 keystone-status --config-file=/etc/keystone/keystone.conf --config-file=/etc/keystone/keystone.conf.d/secrets.conf upgrade check
+status=$?
+if [ $status -eq 2 ]; then
+  echo "ERROR: upgrade check failed with exit code 2. Aborting."
+  exit 2
+elif [ $status -eq 1 ]; then
+  echo "WARNING: upgrade check returned warning (exit code 1). Continuing."
+elif [ $status -ne 0 ]; then
+  echo "ERROR: upgrade check failed with exit code $status. Aborting."
+  exit $status
+fi
+
+set -e
 
 echo "DB Version before migration:"
 keystone-manage --config-file=/etc/keystone/keystone.conf --config-file=/etc/keystone/keystone.conf.d/secrets.conf db_version


### PR DESCRIPTION
Don't fail on the warning in the Keystone db upgrade check

https://docs.openstack.org/keystone/latest/cli/keystone-status.html#categories-and-commands
>At least one check encountered an issue and requires further investigation. This is considered a warning but the upgrade may be OK.
