### PR TITLE
[neutron] Enable flavors + traits for asr1k l3

### DIFF
--- a/openstack/neutron/templates/etc/_asr1k.conf.tpl
+++ b/openstack/neutron/templates/etc/_asr1k.conf.tpl
@@ -50,6 +50,12 @@ use_bdvif = {{$hosting_device.use_bdvif | default "True"}}
 
 [AGENT]
 scheduling_disabled = {{ or ($config_agent.scheduling_disabled | default false) ($config_agent.decommissioning | default false) }}
+{{- if $config_agent.required_traits }}
+required_traits = {{ $config_agent.required_traits | join "," }}
+{{- end }}
+{{- if $config_agent.optional_traits }}
+optional_traits = {{ $config_agent.optional_traits | join "," }}
+{{- end }}
 {{- if $config_agent.availability_zone  }}
 availability_zone = {{$config_agent.availability_zone}}
 {{ end }}

--- a/openstack/neutron/templates/etc/_neutron.conf.tpl
+++ b/openstack/neutron/templates/etc/_neutron.conf.tpl
@@ -15,7 +15,7 @@ max_routes = {{.Values.max_routes | default 256}}
 allow_overlapping_ips = true
 core_plugin = ml2
 
-service_plugins = {{required "A valid .Values.service_plugins required!" .Values.service_plugins}}{{- if .Values.interconnection.enabled }},networking-interconnection{{- end}}
+service_plugins = {{required "A valid .Values.service_plugins required!" .Values.service_plugins}},flavors{{- if .Values.interconnection.enabled }},networking-interconnection{{- end}}
 
 default_router_type = {{required "A valid .Values.default_router_type required!" .Values.default_router_type}}
 router_scheduler_driver = {{required "A valid .Values.router_scheduler_driver required!" .Values.router_scheduler_driver}}
@@ -52,6 +52,9 @@ owner_check_cache_expiration_time = {{ .Values.api.owner_check_cache_expiration_
 {{- end }}
 
 {{- template "utils.snippets.debug.eventlet_backdoor_ini" "neutron" }}
+
+[service_providers]
+service_provider = L3_ROUTER_NAT:asr1k:asr1k_neutron_l3.neutron.services.service_providers.asr1k_router.ASR1KRouterDriver:default
 
 [oslo_policy]
 enforce_scope = False


### PR DESCRIPTION
Our custom l3 router driver will soon support flavors. For this to properly work we need to enable the flavors plugin and define a default service_provider for L3_ROUTER_NAT (i.e. the default l3 router service type). The agents now have the ability to advertise optional and required traits given to them via config. This is then used to do a proper flavor-based scheduling decision.