### PR TITLE
[keystone] don't fail db migration on doctor check

### DIFF
--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: keystone
 sources:
   - https://github.com/sapcc/keystone
-version: 0.10.5
+version: 0.10.6
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/keystone/templates/bin/_db-sync.tpl
+++ b/openstack/keystone/templates/bin/_db-sync.tpl
@@ -23,6 +23,7 @@ keystone-manage --config-file=/etc/keystone/keystone.conf --config-file=/etc/key
 echo "DB Version after migration:"
 keystone-manage --config-file=/etc/keystone/keystone.conf --config-file=/etc/keystone/keystone.conf.d/secrets.conf db_version
 
+set +e
 echo "Keystone doctor:"
 keystone-manage --config-file=/etc/keystone/keystone.conf --config-file=/etc/keystone/keystone.conf.d/secrets.conf doctor
 


### PR DESCRIPTION
Don't fail db migration job on keystone-manage doctor check, because it prevents keystone-api from starting and is expected to fail in some environments (eg, debug is enabled in qa or memcached check is failing in keystone-global)