### PR TITLE
Revert "[utils][proxysql] don't use pkill if proxysql is a native sidecar"

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,5 +1,4 @@
----
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.27.1
+version: 0.27.0

--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.27.0
+version: 0.27.2

--- a/openstack/utils/templates/_proxysql.tpl
+++ b/openstack/utils/templates/_proxysql.tpl
@@ -130,11 +130,9 @@ hostAliases:
   {{- if .Values.proxysql }}
     {{- if .Values.proxysql.mode }}
 {{- include "utils.proxysql.pod_settings" . }}
-      {{- if not .Values.proxysql.native_sidecar }}
 shareProcessNamespace: true
 securityContext:
   runAsUser: 65534
-      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}
@@ -144,9 +142,7 @@ securityContext:
 {{- define "utils.proxysql.proxysql_signal_stop_script" }}
   {{- if .Values.proxysql }}
     {{- if .Values.proxysql.mode -}}
-      {{- if not .Values.proxysql.native_sidecar }}
 pkill proxysql || true
-      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Revert https://github.com/sapcc/helm-charts/pull/9097
This reverts commit https://github.com/sapcc/helm-charts/commit/4de4d1f342b4c956b9912bc405359c15d7fb2137.

Unfortunately, it's still better to have pkill proxysql, when proxysql is a native sidecar, because of the following jobs' behaviour when linkerd is enabled and it is not a native sidecar:
1. The main job container finishes and sends a shutdown signal to linkerd-proxy
2. Linkerd has `config.linkerd.io/shutdown-grace-period` with a default 120s
3. Linkerd stops responding to liveness/readiness checks after shutdown
4. ProxySQL continues to run, because the non-native sidecar linkerd-proxy is still running
5. After 30 seconds, the liveness check causes linkerd-proxy sidecar container to be marked as dead _and restarts it_
6. The job never finishes


To prevent such behaviour, we either have to:
- run linkerd-proxy as a native sidecar (but it's still under `alpha` feature flag: `config.alpha.linkerd.io/proxy-enable-native-sidecar`)
- or continue to do pkill proxysql
- or change in every job with proxysql sidecar the value of `config.linkerd.io/shutdown-grace-period` to a value less than the liveness check failure time (30s)