### PR TITLE
[opensearch-logs]: refactor indexsize alert

### DIFF
--- a/system/opensearch-logs/Chart.yaml
+++ b/system/opensearch-logs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for the Opensearch stack
 name: opensearch-logs
-version: 0.0.42
+version: 0.0.43
 home: https://github.com/sapcc/helm-charts/tree/master/system/opensearch-logs
 dependencies:
   - name: opensearch

--- a/system/opensearch-logs/alerts/opensearch.alerts
+++ b/system/opensearch-logs/alerts/opensearch.alerts
@@ -64,7 +64,7 @@ groups:
       summary: '*opensearch-logs* cluster is *RED*'
 
   - alert: OpenSearchIndexSizeTooLarge
-    expr: opensearch_index_store_size_bytes{index=~".ds.*", context="primaries"} / (1024^3) > 200
+    expr: max by (index) (opensearch_index_store_size_bytes{index=~".ds.*", context="primaries"} / (1024^3) > 200)
     for: 30m
     labels:
       context: nodes


### PR DESCRIPTION
Previously the alert message printed out the index multiple times (for each shard). This reduces the message to one line per index.