### PR TITLE
[andromeda] re-enable MariaDB backup alerts

### DIFF
--- a/global/andromeda/values.yaml
+++ b/global/andromeda/values.yaml
@@ -28,7 +28,7 @@ alerts:
 mariadb:
   priority_class: ""
   alerts:
-    enabled: false
+    enabled: true
     support_group: containers
   enabled: false
   name: andromeda


### PR DESCRIPTION
This was disabled due to the new "global" S3 bucket not having the proper policy, which caused uploads from the backup pod to the bucket to fail. The correct policy was applied to the bucket around Thursday, 2025-07-10 16:55 CET and since then the pod is uploading to S3 as expected.