### PR TITLE
Add option to control number of WSGI threads of octavia-api

### DIFF
--- a/openstack/octavia/templates/etc/_octavia-api.conf.tpl
+++ b/openstack/octavia/templates/etc/_octavia-api.conf.tpl
@@ -12,7 +12,7 @@ CustomLog /dev/stdout proxy env=forwarded
 <VirtualHost *:{{.Values.api_port_internal}}>
     KeepAliveTimeout 61
 
-    WSGIDaemonProcess octavia-wsgi user=octavia group=octavia processes=1 threads=100 display-name=%{GROUP}
+    WSGIDaemonProcess octavia-wsgi user=octavia group=octavia processes=1 threads={{.Values.api_wsgi_threads}} display-name=%{GROUP}
     WSGIProcessGroup octavia-wsgi
     WSGIScriptAlias / /var/lib/openstack/bin/octavia-wsgi
     WSGIApplicationGroup %{GLOBAL}

--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -12,6 +12,7 @@ owner-info:
 
 api_port_internal: 9876
 api_backdoor: false
+api_wsgi_threads: 100
 
 global:
   imageNamespace: monsoon


### PR DESCRIPTION
This PR adds variable `api_wsgi_threads` to control the number of threads spawned for octavia-wsgi. We need it because when proxysql was added, this number should be less than the `max_connections` value otherwise we will hit QueuePool limit with log messages like:
```
sqlalchemy.exc.TimeoutError: QueuePool limit of size 30 overflow 50 reached, connection timed out, timeout 10.00 (Background on this error at: https://sqlalche.me/e/20/3o7r)
```

Current values:
- number of threads spawned by Apache = **100**
- `max_connections` in proxysql config = **80**
- `max_pool_size` in SQLalchemy config = **30**
- `max_overflow` in SQLalchemy config = **50**