### PR TITLE
[prometheus-kubernetes-rules] add ContainerHighNumberOfThreads 

### DIFF
--- a/common/prometheus-server/Chart.yaml
+++ b/common/prometheus-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus via operator.
 name: prometheus-server
-version: 8.0.1
+version: 8.0.2
 appVersion: v3.2.1
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
 maintainers:

--- a/common/prometheus-server/values.yaml
+++ b/common/prometheus-server/values.yaml
@@ -399,6 +399,7 @@ serviceDiscoveries:
       - container_network_receive_bytes_total
       - container_network_transmit_bytes_total
       - container_start_time_seconds
+      - container_threads
       - container_oom_events_total
 
   # Scrape kubelet metrics.

--- a/prometheus-rules/prometheus-kubernetes-rules/Chart.yaml
+++ b/prometheus-rules/prometheus-kubernetes-rules/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A collection of Prometheus alerting and aggregation rules for Kubernetes.
 name: prometheus-kubernetes-rules
-version: 1.10.2
+version: 1.10.3

--- a/prometheus-rules/prometheus-kubernetes-rules/alerts/pod.alerts.tpl.disabled
+++ b/prometheus-rules/prometheus-kubernetes-rules/alerts/pod.alerts.tpl.disabled
@@ -112,3 +112,27 @@ groups:
     annotations:
       summary: No CPU requests configured for container
       description: "The container {{`{{ $labels.container }}`}} of pod {{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}} has no `resources.requests.cpu` configured."
+  - alert: ContainerHighNumberOfThreads
+    expr: |
+        sum by (pod, namespace, container,
+                label_alert_service, label_alert_tier,
+                label_ccloud_service, label_ccloud_support_group) (
+          (
+            container_threads{container!=""} > 8000
+          )
+          * on (pod) group_left (label_alert_tier, label_alert_service,
+                                 label_ccloud_support_group, label_ccloud_service)
+            (max without (uid) (kube_pod_labels))
+        )
+    for: 1h
+    labels:
+      tier: {{ include "alertTierLabelOrDefault" .Values.tier }}
+      service: {{ include "serviceFromLabelsOrDefault" "k8s" }}
+      support_group: {{ include "supportGroupFromLabelsOrDefault" .Values.supportGroup }}
+      severity: info
+      context: threads
+      meta: "Very high number of threads in {{`{{ $labels.container }}`}}"
+      playbook: docs/support/playbook/kubernetes/k8s_high_threads
+    annotations:
+      summary: Very high number of threads in container
+      description: "Very high number of threads in container {{`{{ $labels.container }}`}} of pod {{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}}. Forking problems are imminent."


### PR DESCRIPTION
This PR adds `container_threads` metric to prometheus-server and adds a new alert `ContainerHighNumberOfThreads` -- with info criticality as it is newly added.