### PR TITLE
Add variable for tempest public subnet_id

### DIFF
--- a/openstack/tempest/octavia-tempest/templates/etc/_tempest_extra_options.tpl
+++ b/openstack/tempest/octavia-tempest/templates/etc/_tempest_extra_options.tpl
@@ -48,7 +48,7 @@ security_compliance = True
 [network]
 project_network_cidr = 10.199.0.0/16
 public_network_id = {{ .Values.tempest_common.public_network_id }}
-subnet_id = a5703f23-ffcb-4ca7-9dfe-ab9861d91bf5
+subnet_id = {{ .Values.tempest_common.public_subnet_id }}
 endpoint_type = public
 shared_physical_network= {{ .Values.tempest_common.shared_physical_network | default true }}
 

--- a/openstack/tempest/octavia-tempest/values.yaml
+++ b/openstack/tempest/octavia-tempest/values.yaml
@@ -15,5 +15,5 @@ owner-info:
   service: octavia
 
 tempestKubectlAccess: true
-
-public_subnet_id: a5703f23-ffcb-4ca7-9dfe-ab9861d91bf5
+tempest_common:
+  public_subnet_id: a5703f23-ffcb-4ca7-9dfe-ab9861d91bf5

--- a/openstack/tempest/octavia-tempest/values.yaml
+++ b/openstack/tempest/octavia-tempest/values.yaml
@@ -15,3 +15,5 @@ owner-info:
   service: octavia
 
 tempestKubectlAccess: true
+
+public_subnet_id: a5703f23-ffcb-4ca7-9dfe-ab9861d91bf5


### PR DESCRIPTION
This PR adds a variable for Octavia config file to control `[network]/subnet_id` value.