### PR TITLE
[utils][proxysql] add support for unlimited transactions time in jobs

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -1,4 +1,5 @@
+---
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.27.2
+version: 0.28.0

--- a/openstack/utils/templates/_proxysql.tpl
+++ b/openstack/utils/templates/_proxysql.tpl
@@ -16,8 +16,13 @@
 {{- end }}
 
 {{- define "utils.proxysql._container" }}
+  {{- $tupleLen := len .  }}
   {{- $envAll := index . 0 }}
   {{- $scale := index . 1 | int }}
+  {{- $longTimeouts := false }}
+  {{- if (eq $tupleLen 3) }}
+  {{- $longTimeouts = index . 2 }}
+  {{- end }}
   {{- with $envAll }}
     {{- if .Values.proxysql }}
       {{- if .Values.proxysql.mode }}
@@ -33,7 +38,7 @@
   {{- end }}
   command: ["proxysql"]
   args: ["--config", "/etc/proxysql/proxysql.cnf", "--exit-on-error", "--foreground", "--idle-threads", "--admin-socket", "/run/proxysql/admin.sock", "--no-version-check", "-D", "/run/proxysql"]
-        {{- if gt $scale 1 }}
+        {{- if or (gt $scale 1) ($longTimeouts) }}
           {{- $max_pool_size := coalesce .Values.max_pool_size .Values.global.max_pool_size 50 }}
           {{- $max_overflow := coalesce .Values.max_overflow .Values.global.max_overflow 5 }}
           {{- $max_connections := .Values.proxysql.max_connections_per_proc | default (add $max_pool_size $max_overflow) | mul $scale }}
@@ -51,6 +56,11 @@
             mysql --wait -S /run/proxysql/admin.sock -uadmin -padmin -e '
               UPDATE mysql_servers SET max_connections={{ $max_connections }};
               LOAD MYSQL SERVERS TO RUNTIME;
+              {{- if $longTimeouts }}
+              SET mysql-max_transaction_time=14400000;
+              SET mysql-default_query_timeout=36000000;
+              LOAD MYSQL VARIABLES TO RUNTIME;
+              {{- end }}
             ' && exit 0 || sleep 1
           done
           exit 1


### PR DESCRIPTION
Add support for setting max_transaction_time and default_query_timeout variables to default large values, which can be used in Jobs, in which some transactions or queries might run longer than 60-120s.

For example, it might be useful for some ALTER TABLE queries.