### PR TITLE
[cc-metallb] speaker to ignore `exclude-from-external-load-balancers`

### DIFF
--- a/system/cc-metallb/Chart.yaml
+++ b/system/cc-metallb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cc-metallb
 description: A Helm chart for Metallb
 type: application
-version: 1.0.0
+version: 1.0.1
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/system/cc-metallb/values.yaml
+++ b/system/cc-metallb/values.yaml
@@ -5,3 +5,5 @@ owner-info:
 metallb:
   crds:
     enabled: false
+  speaker:
+    ignoreExcludeLB: true


### PR DESCRIPTION
* Fixing for L2 ARP environments where metallb-speaker runs on all nodes.

LB advertisement is broken for `externalTrafficPolicy: Cluster` services or `externalTrafficPolicy: Local` with pods being scheduled on CP nodes.