### PR TITLE
[CODEOWNERS] adjust openstack/nannies owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -90,7 +90,7 @@
 /openstack/labels-injector                             @joker-at-work @fwiesel @grandchild @leust @seb-kro @PaulPickhardt @CordulaGuder @notandy @mchristianl
 /openstack/maia                                        @notque @richardtief @viennaa @Kuckkuck @timojohlo
 /openstack/manila*                                     @Carthaca @chuan137 @galkindmitrii @kpawar-sap @sumitarora2786 @crenduchinta88 @hvr999 @RockSolidScripts
-/openstack/nannies                                     @chuan137 @Carthaca @fwiesel @kpawar-sap
+/openstack/nannies                                     @joker-at-work @fwiesel @grandchild @leust @seb-kro @PaulPickhardt @CordulaGuder @hemna @jagoleni
 /openstack/netapp-credential-rotator                   @Carthaca @chuan137 @kpawar-sap @sumitarora2786 @crenduchinta88 @hvr999 @RockSolidScripts @Scsabiii @hemna @jagoleni
 /openstack/neutron                                     @notandy @fwiesel @sapcc/network-api-contributors
 /openstack/neutron-hypervisor-agents                   @sapcc/network-api-contributors @notandy @fwiesel @mchristianl


### PR DESCRIPTION
Only the Cinder and Nova nanny are/were still in use from the openstack/nannies chart. Responsibility was therefore moved from team Observability to Compute and Storage API. We adjust the owners to those of the Cinder and Nova chart.