### PR TITLE
[nova-hypervisor-agents] Breaking change to allow multiple release

### DIFF
--- a/openstack/nova-hypervisor-agents/templates/_kvm-configmap.yaml.tpl
+++ b/openstack/nova-hypervisor-agents/templates/_kvm-configmap.yaml.tpl
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nova-compute-kvm
+  name: {{ .Release.Name }}-compute
   labels:
     system: openstack
     type: configuration

--- a/openstack/nova-hypervisor-agents/templates/hypervisors-kvm-daemonset.yaml
+++ b/openstack/nova-hypervisor-agents/templates/hypervisors-kvm-daemonset.yaml
@@ -11,12 +11,12 @@ spec:
   revisionHistoryLimit: {{ .Values.pod.lifecycle.upgrades.deployments.revision_history }}
   selector:
     matchLabels:
-      name: nova-compute-kvm
+      name: {{ .Release.Name }}
   template:
     metadata:
       labels:
 {{ tuple . "nova" "compute" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
-        name: nova-compute-kvm
+        name: {{ .Release.Name }}
         alert-tier: os
         alert-service: nova
         hypervisor: "kvm"
@@ -327,7 +327,7 @@ spec:
               - key: compute.filters
                 path: rootwrap.conf.d/compute.filters
           - configMap:
-              name: nova-compute-kvm
+              name: {{ .Release.Name }}-compute
               items:
               - key: nova-compute.conf
                 path: nova-compute.conf


### PR DESCRIPTION
The labels cannot be changed on daemonset without re-rereating it, so it requires a manual step.

The labels and configmap are now (hopefully) chosen in a way that two releases can run in parallel, such as having one for qemu and another for cloudhypervisor.