### PR TITLE
[nova-hypervisor-agents] Annotate hostpaths with type for better errors

### DIFF
--- a/openstack/nova-hypervisor-agents/templates/hypervisors-kvm-daemonset.yaml
+++ b/openstack/nova-hypervisor-agents/templates/hypervisors-kvm-daemonset.yaml
@@ -258,6 +258,7 @@ spec:
       - name: modules
         hostPath:
           path: /lib/modules
+          type: Directory
       - name: etclibvirt
         emptyDir:
           medium: Memory
@@ -265,21 +266,27 @@ spec:
       - name: instances
         hostPath:
           path: /var/lib/nova/instances
+          type: DirectoryOrCreate
       - name: nova-ssh
         hostPath:
           path: /var/lib/nova/.ssh
+          type: DirectoryOrCreate
       - name: libvirt
         hostPath:
           path: /var/lib/libvirt
+          type: Directory
       - name: run
         hostPath:
           path: /run
+          type: Directory
       - name: host
         hostPath:
           path: /
+          type: Directory
       - name: usr-share-qemu
         hostPath:
           path: /usr/share/qemu
+          type: Directory
 {{- end }}
       - name: mnt
 {{- if not .Values.hypervisor_on_host }}
@@ -288,22 +295,28 @@ spec:
 {{- else }}
         hostPath:
           path: /var/lib/nova/mnt
+          type: DirectoryOrCreate
 {{- end }}
       - name: sys
         hostPath:
           path: /sys
+          type: Directory
       - name: dev
         hostPath:
           path: /dev
+          type: Directory
       - name: multipath-etc
         hostPath:
           path: /etc/multipath
+          type: Directory
       - name: iscsi-etc
         hostPath:
           path: /etc/iscsi
+          type: Directory
       - name: nfs
         hostPath:
           path: /var/lib/nfs
+          type: Directory
       - name: sudoers-etc
         projected:
           sources:


### PR DESCRIPTION
The 'untyped' hostpath doesn't do any checks. The ones with type do, and should give the operator clearer indications of what went wrong.