### PR TITLE
nova: switch Secret templates from stringData to data with base64

### DIFF
--- a/openstack/nova/templates/console-mks-secret.yaml
+++ b/openstack/nova/templates/console-mks-secret.yaml
@@ -15,8 +15,7 @@ metadata:
     type: nova-console
     component: nova
 type: Opaque
-stringData:
-  config.lua: |
-{{ include "nova.etc_config_lua" . | indent 4 }}
+data:
+  config.lua: {{ include "nova.etc_config_lua" . | b64enc }}
 {{- end }}
 {{- end }}

--- a/openstack/nova/templates/console-shellinabox-secret.yaml
+++ b/openstack/nova/templates/console-shellinabox-secret.yaml
@@ -7,6 +7,5 @@ metadata:
     type: nova-console
     component: nova
 type: Opaque
-stringData:
-  config.lua: |
-{{ include "nova.etc_config_lua" . | indent 4 }}
+data:
+  config.lua: {{ include "nova.etc_config_lua" . | b64enc }}

--- a/openstack/nova/templates/etc-secret.yaml
+++ b/openstack/nova/templates/etc-secret.yaml
@@ -6,56 +6,22 @@ metadata:
     system: openstack
     type: configuration
     component: nova
-stringData:
+data:
   api-db.conf: |
-    [api_database]
-    connection = {{ include "api_db_path" . }}
-    {{- include "ini_sections.database_options_mysql" . | indent 4 }}
+    {{ include (print .Template.BasePath "/etc/_api-db.conf.tpl") . | b64enc | indent 4 }}
   cell0.conf: |
-    [database]
-    connection = {{ include "cell0_db_path" . }}
+    {{ include (print .Template.BasePath "/etc/_cell0.conf.tpl") . | b64enc | indent 4 }}
   cell1.conf: |
-    [DEFAULT]
-    transport_url = {{ include "cell1_transport_url" . }}
-
-    [database]
-    connection = {{ include "cell1_db_path" . }}
+    {{ include (print .Template.BasePath "/etc/_cell1.conf.tpl") . | b64enc | indent 4 }}
   {{- if .Values.cell2.enabled }}
   {{ .Values.cell2.name }}.conf: |
-    [DEFAULT]
-    transport_url = {{ include "cell2_transport_url" . }}
-
-    [database]
-    connection = {{ include "cell2_db_path" . }}
+    {{ include (print .Template.BasePath "/etc/_cell2.conf.tpl") . | b64enc | indent 4 }}
   {{- end }}
   keystoneauth-secrets.conf: |
-    [cinder]
-    username = nova
-    password = {{ required ".Values.global.nova_service_password is missing" .Values.global.nova_service_password | include "resolve_secret" }}
-
-    [neutron]
-    username = nova
-    password = {{ required ".Values.global.nova_service_password is missing" .Values.global.nova_service_password | include "resolve_secret" }}
-
-    [keystone_authtoken]
-    username = nova
-    password = {{ required ".Values.global.nova_service_password is missing" .Values.global.nova_service_password | include "resolve_secret" }}
-
-    [placement]
-    username = nova
-    password = {{ required ".Values.global.nova_service_password is missing" .Values.global.nova_service_password | include "resolve_secret" }}
-
-    [service_user]
-    username = nova
-    password = {{ required ".Values.global.nova_service_password is missing" .Values.global.nova_service_password | include "resolve_secret" }}
-
-    [ironic]
-    username = nova
-    password = {{ required ".Values.global.nova_service_password is missing" .Values.global.nova_service_password | include "resolve_secret" }}
+    {{ include (print .Template.BasePath "/etc/_keystoneauth-secrets.conf.tpl") . | b64enc | indent 4 }}
   nova-api-metadata-secrets.conf: |
-    [neutron]
-    metadata_proxy_shared_secret = {{ .Values.global.nova_metadata_secret | include "resolve_secret" }}
+    {{ include (print .Template.BasePath "/etc/_nova-api-metadata-secrets.conf.tpl") . | b64enc | indent 4 }}
   audit-middleware.conf: |
-    {{- include "ini_sections.audit_middleware_notifications" . | indent 4}}
+    {{ include "ini_sections.audit_middleware_notifications" . | b64enc | indent 4 }}
   osprofiler.conf: |
-    {{- include "osprofiler" . | indent 4}}
+    {{ include "osprofiler" . | b64enc | indent 4 }}

--- a/openstack/nova/templates/etc/_api-db.conf.tpl
+++ b/openstack/nova/templates/etc/_api-db.conf.tpl
@@ -1,0 +1,3 @@
+[api_database]
+connection = {{ include "api_db_path" . }}
+{{- include "ini_sections.database_options_mysql" . | indent 0 }}

--- a/openstack/nova/templates/etc/_cell0.conf.tpl
+++ b/openstack/nova/templates/etc/_cell0.conf.tpl
@@ -1,0 +1,2 @@
+[database]
+connection = {{ include "cell0_db_path" . }}

--- a/openstack/nova/templates/etc/_cell1.conf.tpl
+++ b/openstack/nova/templates/etc/_cell1.conf.tpl
@@ -1,0 +1,5 @@
+[DEFAULT]
+transport_url = {{ include "cell1_transport_url" . }}
+
+[database]
+connection = {{ include "cell1_db_path" . }}

--- a/openstack/nova/templates/etc/_cell2.conf.tpl
+++ b/openstack/nova/templates/etc/_cell2.conf.tpl
@@ -1,0 +1,5 @@
+[DEFAULT]
+transport_url = {{ include "cell2_transport_url" . }}
+
+[database]
+connection = {{ include "cell2_db_path" . }}

--- a/openstack/nova/templates/etc/_keystoneauth-secrets.conf.tpl
+++ b/openstack/nova/templates/etc/_keystoneauth-secrets.conf.tpl
@@ -1,0 +1,23 @@
+[cinder]
+username = nova
+password = {{ required ".Values.global.nova_service_password is missing" .Values.global.nova_service_password | include "resolve_secret" }}
+
+[neutron]
+username = nova
+password = {{ required ".Values.global.nova_service_password is missing" .Values.global.nova_service_password | include "resolve_secret" }}
+
+[keystone_authtoken]
+username = nova
+password = {{ required ".Values.global.nova_service_password is missing" .Values.global.nova_service_password | include "resolve_secret" }}
+
+[placement]
+username = nova
+password = {{ required ".Values.global.nova_service_password is missing" .Values.global.nova_service_password | include "resolve_secret" }}
+
+[service_user]
+username = nova
+password = {{ required ".Values.global.nova_service_password is missing" .Values.global.nova_service_password | include "resolve_secret" }}
+
+[ironic]
+username = nova
+password = {{ required ".Values.global.nova_service_password is missing" .Values.global.nova_service_password | include "resolve_secret" }}

--- a/openstack/nova/templates/etc/_nova-api-metadata-secrets.conf.tpl
+++ b/openstack/nova/templates/etc/_nova-api-metadata-secrets.conf.tpl
@@ -1,0 +1,2 @@
+[neutron]
+metadata_proxy_shared_secret = {{ .Values.global.nova_metadata_secret | include "resolve_secret" }}


### PR DESCRIPTION
Switch nova Secret templates from stringData to data attribute to resolve Vault secrets-injector compatibility issues. Using stringData is broken by design as removing keys from stringData does not remove them from data.