### PR TITLE
Reapply "[nova] Bump rabbitmq to fix certificate"

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 0.5.0
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.18.3
+  version: 0.18.4
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.6.10
@@ -22,12 +22,12 @@ dependencies:
   version: 0.25.0
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.18.3
+  version: 0.18.4
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:34d6760b3b11ef1421dce4781e7d1caef9810a4c1d354f5484bc11f1e932145f
-generated: "2025-07-09T16:24:31.037053+02:00"
+digest: sha256:90faba2af8aabf158cfcf703853e10ee07ff991e5d69d39aa8aa2e3d37d0d5ad
+generated: "2025-07-17T12:05:49.173815716+02:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -20,7 +20,7 @@ dependencies:
     version: 0.5.0
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.18.3
+    version: 0.18.4
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.6.10
@@ -36,7 +36,7 @@ dependencies:
     alias: rabbitmq_cell2
     condition: cell2.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.18.3
+    version: 0.18.4
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0


### PR DESCRIPTION
The certificate CRD in the prior release contained
external ips, which the certificate provider didn't accept.
The change does not pull in new versions of rabbitmq,
so is non-disruptive by itself.

This reverts commit b1a450859bbdd382d4d4bf0ccbc91dc472c56c1a.