### PR TITLE
[neutron] Bump rabbitmq to fix certificate

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 0.4.4
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.18.2
+  version: 0.18.4
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.26.0
@@ -32,5 +32,5 @@ dependencies:
 - name: ovsdb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
-digest: sha256:36e0fb1c30c102106ac4bc2c969237ca41ce775acc99af26539ab471465b67be
-generated: "2025-07-01T13:04:47.588005+03:00"
+digest: sha256:13307b587cfded94d8239f29b33acbddcd0a7ccc17610532b6530dae179d7988
+generated: "2025-07-17T12:26:29.667339707+02:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
     version: 0.4.4
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.18.2
+    version: 0.18.4
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.26.0


### PR DESCRIPTION
The certificate CRD in the prior release contained external ips, which the certificate provider didn't accept, and a wrong issuer name.
The change does not pull in new versions of rabbitmq, so is non-disruptive by itself.