### PR TITLE
global/andromeda: add policy rule for liquid:change_commitments

### DIFF
--- a/global/andromeda/templates/etc/_liquid-policy.json.tpl
+++ b/global/andromeda/templates/etc/_liquid-policy.json.tpl
@@ -4,5 +4,6 @@
   "liquid:get_info": "rule:readonly",
   "liquid:get_capacity": "rule:readonly",
   "liquid:get_usage": "rule:readonly",
-  "liquid:set_quota": "rule:readwrite"
+  "liquid:set_quota": "rule:readwrite",
+  "liquid:change_commitments": "rule:readwrite"
 }


### PR DESCRIPTION
This is being added by sapcc/go-bits#239. I will also do the respective code change in Andromeda once the go-bits PR is merged, but this is safe to apply right away.