### PR TITLE
[placement] use mariadb values for database connection

### DIFF
--- a/openstack/placement/Chart.yaml
+++ b/openstack/placement/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 description: A Helm chart for the Openstack Placement Service
 name: placement
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/project-mascots/Placement/OpenStack_Project_Placement_horizontal.jpg
-version: 0.2.3
+version: 0.3.0
 appVersion: "dalmatian"
 dependencies:
   - condition: mariadb.enabled

--- a/openstack/placement/ci/test-values.yaml
+++ b/openstack/placement/ci/test-values.yaml
@@ -14,12 +14,11 @@ imageVersion: myTag
 
 mariadb:
   enabled: false
+  name: placement  # can be changed
   root_password: topSecret
   users:
     placement:
       password: topSecret
-  backup:
-    enabled: false
   backup_v2:
     enabled: false
 
@@ -46,7 +45,3 @@ pxc_db:
       secrets:
         aws_access_key_id: topSecret!
         aws_secret_access_key: topSecret!
-
-api_db:
-  user: a_name
-  password: a_password

--- a/openstack/placement/templates/_helpers.tpl
+++ b/openstack/placement/templates/_helpers.tpl
@@ -9,10 +9,5 @@
 
 
 {{- define "placement.db_name" }}
-  {{- if or (eq .Values.dbType "mariadb") (eq .Values.dbType "pxc-db") }}
 {{- include "utils.db_host" . -}}
-{{/* Use nova-api-mariadb database, if no database is selected explicitly */}}
-  {{- else -}}
-"nova-api-mariadb"
-  {{- end }}
 {{- end }}

--- a/openstack/placement/templates/etc/_secrets.conf.tpl
+++ b/openstack/placement/templates/etc/_secrets.conf.tpl
@@ -1,10 +1,5 @@
 [placement_database]
-{{- if or (eq .Values.dbType "mariadb") (eq .Values.dbType "pxc-db") }}
 connection = {{ include "utils.db_url" . }}
-{{/* Use nova-api-mariadb database, if no database is selected explicitly */}}
-{{- else }}
-connection = {{ tuple . .Values.api_db.name .Values.api_db.user .Values.api_db.password | include "utils.db_url" }}
-{{- end }}
 
 [keystone_authtoken]
 username = {{ .Values.global.placement_service_user | default "placement" | include "resolve_secret" }}

--- a/openstack/placement/values.yaml
+++ b/openstack/placement/values.yaml
@@ -60,6 +60,7 @@ dbName: "placement"
 mariadb:
   enabled: true
   name: placement
+  defaultUser: placement
   alerts:
     support_group: "compute-storage-api"
   ccroot_user:
@@ -75,6 +76,7 @@ mariadb:
 pxc_db:
   enabled: false
   name: placement
+  defaultUser: placement
   alerts:
     support_group: "compute-storage-api"
   ccroot_user:


### PR DESCRIPTION
* Use `mariadb.users` and `mariadb.defaultUser` values for the Placement DB connection template.

* Stop using empty `dbType` option to force the use of `nova-api-mariadb` service, because `utils.db_host` uses `mariadb.name` for service name, which for regions with `nova-api-mariadb` already points to the right database.
