### PR TITLE
[prometheus-vmware-alerting] - improvement of bedrock alerting 

### DIFF
--- a/prometheus-rules/prometheus-vmware-rules/Chart.yaml
+++ b/prometheus-rules/prometheus-vmware-rules/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A collection of Prometheus alert rules.
 name: prometheus-vmware-rules
-version: 1.3.5
+version: 1.3.6
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/prometheus-rules/prometheus-vmware-rules/templates/_helper.tpl
+++ b/prometheus-rules/prometheus-vmware-rules/templates/_helper.tpl
@@ -16,5 +16,5 @@ Description:
 {{- define "bedrockConfirm.expr" -}}
 {{- $expr := index . 0 -}}
 {{- $mappingKey := index . 1 -}}
-({{ $expr }}) + on({{ $mappingKey }}) group_left(bedrock) label_replace(vrops_hostsystem_vsphere_tags, "bedrock", "true", "vsphere_tags", ".*IAAS.*") * 0
+({{ $expr }}) + on({{ $mappingKey }}) group_left(bedrock) label_replace(vrops_hostsystem_hostgroups, "bedrock", "true", "hostgroups", ".*iaas.*") * 0
 {{- end -}}


### PR DESCRIPTION
Switch from vSphere tags to VMware hostgroups for Bedrock host identification

Replaced the use of `vrops_hostsystem_vsphere_tags ` with `vrops_hostsystem_hostgroups ` as the primary identifier for Bedrock hosts, aligning with affinity rule usage in Nova. Tags were previously managed manually, which posed a risk of incomplete or inconsistent host coverage.
