### PR TITLE
[nova-hypervisor-agents] Only support predictable hash

### DIFF
--- a/openstack/nova-hypervisor-agents/bin/nova-compute-init
+++ b/openstack/nova-hypervisor-agents/bin/nova-compute-init
@@ -1,44 +1,13 @@
 #!/var/lib/openstack/bin/python3
-import configparser
 import pathlib
 import platform
-import socket
 import uuid
-
-from novaclient import client as novaclient
-from novaclient import exceptions as novaexceptions
-
-
-def _get_hypervisor():
-    config = configparser.ConfigParser()
-    config.read("/etc/nova/nova.conf.d/keystoneauth-secrets.conf")
-    authtoken = config["service_user"]
-    auth_endpoint = socket.gethostbyname_ex("identity-3")[1][0]
-    client = novaclient.Client(
-        "2.53",
-        authtoken["username"],
-        authtoken["password"],
-        user_domain_name="default",
-        project_domain_name="default",
-        project_name="service",
-        auth_url=f"https://{auth_endpoint}/v3",
-    )
-    node = platform.node().split(".", 1)[0]
-    try:
-        return client.hypervisors.search(node, detailed=True)[0]
-    except (novaexceptions.NotFound, IndexError):
-        return None
-
 
 compute_id = pathlib.Path("/var/lib/nova/compute_id")
 
 if not compute_id.exists():
-    hypervisor = _get_hypervisor()
-    if hypervisor:
-        compute_id.write_text(hypervisor.id)
-    else:
-        node = platform.node().split(".", 1)[0]
-        compute_uuid = uuid.uuid5(
-            uuid.UUID("408adaa7-5ff0-4740-b8c8-c46f79f09080"), node
-        )
-        compute_id.write_text(str(compute_uuid))
+    node = platform.node().split(".", 1)[0]
+    compute_uuid = uuid.uuid5(
+        uuid.UUID("408adaa7-5ff0-4740-b8c8-c46f79f09080"), node
+    )
+    compute_id.write_text(str(compute_uuid))

--- a/openstack/nova-hypervisor-agents/templates/hypervisors-kvm-daemonset.yaml
+++ b/openstack/nova-hypervisor-agents/templates/hypervisors-kvm-daemonset.yaml
@@ -54,12 +54,9 @@ spec:
       - name: nova-compute-init
         image: {{ required ".Values.global.registry is missing" .Values.global.registry }}/{{ .Values.imageName }}:{{ .Values.imageVersion | required "Please set imageVersion similar" }}
         command: ["/container.init/nova-compute-init"]
-        workingDir: /etc/nova
         volumeMounts:
           - mountPath: /container.init
             name: bin
-          - mountPath: /etc/nova
-            name: nova-etc
           - mountPath: /var/lib/nova
             name: var-lib-nova
       {{- if and .Values.hypervisor_on_host .Values.defaults.hypervisor.kvm.instance_nfs_share }}


### PR DESCRIPTION
All hosts have been migrated. This eliminates the need to have an api call during startup, which is another error source and requires the api to be up before creating compute nodes.