### PR TITLE
[nova-hypervisor-agents] Support Nova's password rotation

### DIFF
--- a/openstack/nova-hypervisor-agents/ci/test-values.yaml
+++ b/openstack/nova-hypervisor-agents/ci/test-values.yaml
@@ -5,6 +5,9 @@ global:
 
 imageVersion: latest
 
+defaultUsersRabbitMQ:
+  cell1: default
+
 rabbitmq:
   users:
     default:

--- a/openstack/nova-hypervisor-agents/templates/_helpers.tpl
+++ b/openstack/nova-hypervisor-agents/templates/_helpers.tpl
@@ -13,3 +13,58 @@ novncproxy_base_url = https://{{include "nova_console_endpoint_host_public" .}}:
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{- define "cell1_transport_url" -}}
+  {{- $context := dict "target" "cell1" "defaultUsers" .Values.defaultUsersRabbitMQ "users" .Values.rabbitmq.users }}
+  {{- $data := dict
+      "user" (include "nova.helpers.default_rabbitmq_user" $context)
+      "password" (include "nova.helpers.default_user_password" $context)
+      "port" .Values.rabbitmq.port
+      "virtual_host" .Values.rabbitmq.virtual_host
+      "host" (printf "%s-rabbitmq" .Release.Name)
+    }}
+  {{- include "utils.rabbitmq_url" (tuple . $data) }}
+{{- end -}}
+
+{{- /*
+Helper function to fetch a value (e.g., password, name, user) from a user object in a users map.
+Params:
+  .target: the target (e.g., cell0, cell1, cell2, api)
+  .users: the users map
+  .defaultUsers: the defaultUsers map
+  .key: the key to fetch from the user object (e.g., "password", "name", "user")
+*/ -}}
+{{- define "nova.helpers.default_user_value" }}
+  {{- $target := .target | lower }}
+  {{- $users := .users }}
+  {{- $defaultUsers := .defaultUsers }}
+  {{- $key := .key }}
+  {{- if not $users }}
+    {{ fail (printf "No users map defined for target '%s'. Check your values for .users." $target) }}
+  {{- end }}
+  {{- if not $defaultUsers }}
+    {{ fail (printf "No defaultUsers map defined for target '%s'. Check your values for .defaultUsers." $target) }}
+  {{- end }}
+  {{- $userKey := index $defaultUsers $target }}
+  {{- if not $userKey }}
+    {{ fail (printf "No default user mapping for target '%s' in defaultUsers. Check your .Values.defaultUsers* for a key '%s'." $target $target) }}
+  {{- end }}
+  {{- $user := index $users $userKey }}
+  {{- if not $user }}
+    {{ fail (printf "No user '%s' found in users map for target '%s'. Check your .users for a key '%s'." $userKey $target $userKey) }}
+  {{- end }}
+  {{- if not (hasKey $user $key) }}
+    {{ fail (printf "No key '%s' for user '%s' in users map for target '%s'. Check your .users['%s'] for a key '%s'." $key $userKey $target $userKey $key) }}
+  {{- end }}
+  {{- index $user $key }}
+{{- end }}
+
+{{- define "nova.helpers.default_rabbitmq_user" }}
+  {{- $params := dict "target" .target "users" .users "defaultUsers" .defaultUsers "key" "user" }}
+  {{- include "nova.helpers.default_user_value" $params }}
+{{- end }}
+
+{{- define "nova.helpers.default_user_password" }}
+  {{- $params := dict "target" .target "users" .users "defaultUsers" .defaultUsers "key" "password" }}
+  {{- include "nova.helpers.default_user_value" $params }}
+{{- end }}

--- a/openstack/nova-hypervisor-agents/templates/etc-secret.yaml
+++ b/openstack/nova-hypervisor-agents/templates/etc-secret.yaml
@@ -9,7 +9,7 @@ metadata:
 stringData:
   cell.conf: |
     [DEFAULT]
-    {{- include "ini_sections.default_transport_url" . | nindent 4 }}
+    transport_url = {{ include "cell1_transport_url" . }}
   keystoneauth-secrets.conf: |
     [cinder]
     username = nova


### PR DESCRIPTION
The nova chart uses dual-user password rotation and has a couple of helpers defined to accommodate that. We copy the helpers over to be able to consume Nova's values the same way to define the transport_url for rabbitmq.