### PR TITLE
[ldap-named-user] make sssd services configurable via values

### DIFF
--- a/system/ldap-named-user/Chart.yaml
+++ b/system/ldap-named-user/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: ldap-named-user
 description: LDAP named user sssd config
 type: application
-version: 0.1.3
+version: 0.2.0

--- a/system/ldap-named-user/templates/secret.yaml
+++ b/system/ldap-named-user/templates/secret.yaml
@@ -9,7 +9,9 @@ stringData:
   sssd.conf: |-
     [sssd]
     config_file_version = 2
-    services = nss, pam, ssh
+    {{- with .Values.sssd.startServices }}
+    services = {{ join ", " . }}
+    {{- end }}
     domains = ldap
 
     [nss]

--- a/system/ldap-named-user/values.yaml
+++ b/system/ldap-named-user/values.yaml
@@ -4,3 +4,10 @@
 #ldapBindPassword:
 #ldapAccessFilter:
 #sudoersGroup:
+
+# sssd services to start
+sssd:
+  startServices:
+    - nss
+    - pam
+    - ssh


### PR DESCRIPTION
The default for the services is moved to the values.yaml and includes
nss, pam and ssh. In case no services should be started or only being
socket activated then these values need to be set to an empty list,
i.e.:

```
sssd:
  startServices: []
```
