### PR TITLE
openstack/keppel: increase log_min_duration_statement

### DIFF
--- a/openstack/keppel/values.yaml
+++ b/openstack/keppel/values.yaml
@@ -101,7 +101,7 @@ postgresql:
   alerts:
     support_group: containers
   config:
-    log_min_duration_statement: 500
+    log_min_duration_statement: 400
     # We previously had 128, which should technically be enough for 8 API pods and 1 janitor pod (with max. 16 conns each)
     # as well as the pgmetrics and pgbackup pods with 1-2 conns each, but we still had a "too many clients already" issue regardless.
     max_connections: 180

--- a/openstack/keppel/values.yaml
+++ b/openstack/keppel/values.yaml
@@ -101,7 +101,7 @@ postgresql:
   alerts:
     support_group: containers
   config:
-    log_min_duration_statement: 250
+    log_min_duration_statement: 500
     # We previously had 128, which should technically be enough for 8 API pods and 1 janitor pod (with max. 16 conns each)
     # as well as the pgmetrics and pgbackup pods with 1-2 conns each, but we still had a "too many clients already" issue regardless.
     max_connections: 180


### PR DESCRIPTION
We don't do anything with slower queries and it just spams the log.