### PR TITLE
[nova] Add a bogus row to satisfy the collector

### DIFF
--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -716,6 +716,7 @@ mysql_metrics:
         FROM instances i
         INNER JOIN instance_migrations im ON i.uuid = im.instance_uuid
         WHERE i.deleted = 0 AND i.vm_state = 'error' AND im.rn = 1 AND im.status = 'error'
+        UNION ALL SELECT 'i-uuid', 'im-uuid', 'None', 0;
       values:
         - "gauge"
 


### PR DESCRIPTION
The sql-collector doesn't like empty row-sets, and returns then still the last result via prometheus, which leads to bogus alerts.