### PR TITLE
[kube-monitoring-*] bump kubernikus-monitoring

### DIFF
--- a/system/kube-monitoring-admin-k3s/Chart.lock
+++ b/system/kube-monitoring-admin-k3s/Chart.lock
@@ -28,7 +28,7 @@ dependencies:
   version: 4.46.0
 - name: kubernikus-monitoring
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.2.0
+  version: 1.2.1
 - name: blackbox-exporter
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.3.3
@@ -44,5 +44,5 @@ dependencies:
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
   version: 3.13.0
-digest: sha256:b4db165a74a83b0b3fd66a39ed788cb42934cb3ad49988867faa8b9555575777
-generated: "2025-07-14T14:16:03.186476991Z"
+digest: sha256:59def0dc3c94a12e56c778afa134c941beb0a23b3b1f33b263f4234ee356264f
+generated: "2025-07-23T11:01:28.936449+02:00"

--- a/system/kube-monitoring-admin-k3s/Chart.yaml
+++ b/system/kube-monitoring-admin-k3s/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes admin k3s cluster monitoring.
 name: kube-monitoring-admin-k3s
-version: 4.6.16
+version: 4.6.17
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-admin-k3s
 dependencies:
   - condition: absent-metrics-operator.enabled
@@ -36,7 +36,7 @@ dependencies:
     version: 4.46.0
   - name: kubernikus-monitoring
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 1.2.0
+    version: 1.2.1
   - name: blackbox-exporter
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^2.3"

--- a/system/kube-monitoring-kubernikus/Chart.lock
+++ b/system/kube-monitoring-kubernikus/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 0.2.1
 - name: kubernikus-monitoring
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.2.0
+  version: 1.2.1
 - name: loki
   repository: https://grafana.github.io/helm-charts
   version: 0.25.1
@@ -53,5 +53,5 @@ dependencies:
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
   version: 3.13.0
-digest: sha256:4d0062a69c22ad617ab4a79f09b3536a2fe37243643ebadf985b29e5a0c60213
-generated: "2025-07-14T14:16:08.382271337Z"
+digest: sha256:7962c5129bebed30e851210c4982314ebfa729a2d9ccf9cc90d7c435790ab3df
+generated: "2025-07-23T11:02:15.525942+02:00"

--- a/system/kube-monitoring-kubernikus/Chart.yaml
+++ b/system/kube-monitoring-kubernikus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for monitoring Kubernikus.
 name: kube-monitoring-kubernikus
-version: 7.8.12
+version: 7.8.13
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-kubernikus
 dependencies:
   - condition: absent-metrics-operator.enabled
@@ -17,7 +17,7 @@ dependencies:
     version: 0.2.1
   - name: kubernikus-monitoring
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 1.2.0
+    version: 1.2.1
   - name: loki
     repository: https://grafana.github.io/helm-charts
     version: 0.25.1

--- a/system/kube-monitoring-virtual/Chart.lock
+++ b/system/kube-monitoring-virtual/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 0.2.1
 - name: kubernikus-monitoring
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.2.0
+  version: 1.2.1
 - name: ntp-exporter
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.6.2
@@ -47,5 +47,5 @@ dependencies:
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
   version: 3.13.0
-digest: sha256:1ab293f20428c7cd696a30886ccfbfc0d8cffc973e9a51bd10e0f2e3f3d30541
-generated: "2025-07-14T14:16:19.519894356Z"
+digest: sha256:69b47ff180467c1daab8fae01611bd393ee8644d4ccfe2bb5ebb8be70acdd859
+generated: "2025-07-23T11:03:02.407325+02:00"

--- a/system/kube-monitoring-virtual/Chart.yaml
+++ b/system/kube-monitoring-virtual/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes virtual cluster monitoring.
 name: kube-monitoring-virtual
-version: 6.9.12
+version: 6.9.13
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-virtual
 dependencies:
   - condition: absent-metrics-operator.enabled
@@ -17,7 +17,7 @@ dependencies:
     version: 0.2.1
   - name: kubernikus-monitoring
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 1.2.0
+    version: 1.2.1
   - name: ntp-exporter
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^2.5"


### PR DESCRIPTION
We removed an obsolete alerting on quota from the `kubernikus-monitoring` chart.