### PR TITLE
[designate] bump shared dependencies

### DIFF
--- a/openstack/designate/Chart.lock
+++ b/openstack/designate/Chart.lock
@@ -4,19 +4,19 @@ dependencies:
   version: 1.1.11
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.4.0
+  version: 0.4.1
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.25.0
+  version: 0.26.1
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.6.10
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.5.0
+  version: 0.5.2
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.18.4
+  version: 0.18.5
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.27.2
@@ -29,5 +29,5 @@ dependencies:
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.1.4
-digest: sha256:066b5da035e3e1a5891c7154dd07cd5361ac61da3de9bb1f78a91523af97887c
-generated: "2025-07-10T14:30:19.192254+03:00"
+digest: sha256:1422b181bfc6ab84479099d90a9177f6db99dffefb7b6a36582193209d50807c
+generated: "2025-07-23T15:10:49.379299+03:00"

--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes to deploy Openstack Designate  (DNSaaS)
 name: designate
-version: 0.5.6
+version: 0.5.7
 appVersion: "dalmatian"
 dependencies:
   - condition: percona_cluster.enabled
@@ -13,22 +13,22 @@ dependencies:
     name: pxc-db
     alias: pxc_db
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.4.0
+    version: 0.4.1
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.25.0
+    version: 0.26.1
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.6.10
   - condition: mysql_metrics.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.5.0
+    version: 0.5.2
   - name: rabbitmq
     condition: rabbitmq.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.18.4
+    version: 0.18.5
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.27.2


### PR DESCRIPTION
* pxc-db: 0.4.0 -> 0.4.1
Fixes linkerd annotations and backups

* mariadb: 0.25.0 -> 0.26.1
Updates maria-back-me-up, sets default-container annotations, enables userstat metrics

* mysql-metrics: 0.5.0 -> 0.5.2
Updates sql-exporter version to 0.8.0 (2025-07-07)

* rabbitmq: 0.18.4 -> 0.18.5
Updates RabbitMQ from 4.1.1 to 4.1.2