### PR TITLE
[Nova] Update VcenterLowNumberOfPlaceableVms

### DIFF
--- a/openstack/nova/alerts/openstack/vmware-rebalancer.alerts
+++ b/openstack/nova/alerts/openstack/vmware-rebalancer.alerts
@@ -2,8 +2,8 @@ groups:
   - name: vmware-rebalancer.alerts
     rules:
       - alert: VcenterLowNumberOfPlaceableVms
-        expr: wm_vmware_rebalancer_placeable_vms_per_vcenter{has_bbs_without_custom_hana_exclusive_host="True",flavor="g_c128_m512"} <= 3
-        for: 30m
+        expr: sum(wm_vmware_rebalancer_placeable_vms_per_vcenter{flavor="g_c128_m512",has_bbs_without_custom_hana_exclusive_host="True"}) by (flavor, vcenter, az) < 3
+        for: 3h
         labels:
           severity: warning
           service: compute


### PR DESCRIPTION
The alert retriggered, because "app_kubernetes_io_version" and "helm_sh_chart" values change with deployments of the migration-recommender-service. We can get rid of the re-trigger by limiting the columns we report using `sum()`. We have to include all the columns that we use as `$labels.*` in the alert.

Additionally, there was an overlap in the value
migration-recommender-service optimizes for and this alert. While the alert would already fire for 3 placable flavors,
migration-recommender-service only optimized for 3 and thus would not free up more. We change the alert to check for less than 3 flavors now.

Since freeing up resources is taking quite long, we don't want to act on short-term resource-shortage. Therefore, we require the metric to be in alerting range for 3h instead of 30min now.