### PR TITLE
feat(opensearch): use keppel registry for opensearch images

### DIFF
--- a/system/greenhouse-ccloud/Chart.yaml
+++ b/system/greenhouse-ccloud/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: ccloud
 description: A Helm chart for the CCloud organization in Greenhouse.
 type: application
-version: 1.26.0
+version: 1.26.1

--- a/system/greenhouse-ccloud/templates/opensearch-pluginpreset.yaml
+++ b/system/greenhouse-ccloud/templates/opensearch-pluginpreset.yaml
@@ -119,6 +119,12 @@ spec:
     pluginDefinition: opensearch
     releaseNamespace: opensearch-logs
     optionValues:
+      - name: operator.manager.image.repository
+        value: "{{ .Values.global.dockerHubMirror }}/opensearchproject/opensearch-operator"
+      - name: operator.kubeRbacProxy.image.repository
+        value: "{{ .Values.global.quayIoMirror }}/brancz/kube-rbac-proxy"
+      - name: cluster.cluster.general.image
+        value: "{{ .Values.global.dockerHubMirror }}/opensearchproject/opensearch"
       - name: cluster.cluster.general.monitoring.additionalRuleLabels
         value: {{ .Values.opensearch.additionalRuleLabels | toYaml | nindent 10 }}
       - name: cluster.cluster.dashboards.service.labels


### PR DESCRIPTION
Use keppel registry for opensearch images in ccloud greenhouse.
Follows https://github.com/cloudoperators/greenhouse-extensions/pull/1051