### PR TITLE
[keystone] bump memcached dependency

### DIFF
--- a/openstack/keystone/Chart.lock
+++ b/openstack/keystone/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 0.4.0
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.6.9
+  version: 0.6.11
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.4.4
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:9f55da11451e22686afaeb217192f90aa535efdfdcf68ed137e24ec59aee11aa
-generated: "2025-05-15T17:19:42.657768+03:00"
+digest: sha256:8b87abe8e3541ed6b32624e346e80d4264103fb8191e05d69068de5613ca0ffe
+generated: "2025-07-24T12:31:06.712867+03:00"

--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -22,7 +22,7 @@ dependencies:
     version: 0.4.0
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.6.9
+    version: 0.6.11
   - condition: mysql_metrics.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm


### PR DESCRIPTION
Update memcached chart dependency to 0.6.11 version: fixes SASL