### PR TITLE
[utils][proxysql] skip disabled database users and null password

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.28.0
+version: 0.29.0

--- a/openstack/utils/templates/snippets/_proxysql.cfg.tpl
+++ b/openstack/utils/templates/snippets/_proxysql.cfg.tpl
@@ -139,7 +139,13 @@ mysql_users =
 {{- range $index, $dbKey := $.dbKeys }}
   {{- $db := get $.dbs $dbKey }}
   {{- range $userKey, $user := $db.users }}
-    {{- if ne $userKey "proxysql_monitor"  }}
+    {{- if or
+        (not $user.password)
+        (eq $userKey "proxysql_monitor")
+        (and (hasKey $user "enabled") (eq (typeOf $user.enabled) "bool") (eq $user.enabled false))
+    }}
+    {{- /* skip user */}}
+    {{- else }}
     {
         username = "{{ include "resolve_secret" $user.name | required (print "user name needs to be set for " $dbKey " and user " $userKey) }}"
         password = "{{ include "resolve_secret" $user.password | required (print "password needs to be set for " $dbKey " and user " $userKey)  }}"


### PR DESCRIPTION
Skip database users in ProxySQL configuration:
* with `password` value set to `null`
* with `enabled` value set to `false`

Examples:

```yaml
mariadb:
  users:
    test:
      password: null
```

```yaml
mariadb:
  users:
    test:
      password: secret
      enabled: false
```

Currently, in MariaDB chart we don't create users with `null` password, but utils/proxysql chart doesn't support this and causes template failure.

This change fixes this problem and adds two ways to remove a user from ProxySQL config.