### PR TITLE
[Nova] api-metadata multi-secret with auto-restart

### DIFF
--- a/openstack/nova/templates/api-metadata-deployment.yaml
+++ b/openstack/nova/templates/api-metadata-deployment.yaml
@@ -7,8 +7,10 @@ metadata:
     system: openstack
     type: api
     component: nova
-  {{- if .Values.vpa.set_main_container }}
   annotations:
+    secret.reloader.stakater.com/reload: "nova-api-metadata"
+    deployment.reloader.stakater.com/pause-period: "60s"
+  {{- if .Values.vpa.set_main_container }}
     vpa-butler.cloud.sap/main-container: nova-api-metadata
   {{- end }}
 spec:
@@ -154,12 +156,15 @@ spec:
                 path: nova.conf.d/cell1.conf
               - key: keystoneauth-secrets.conf
                 path: nova.conf.d/keystoneauth-secrets.conf
-              - key: nova-api-metadata-secrets.conf
-                path: nova.conf.d/nova-api-metadata-secrets.conf
               {{- if .Values.osprofiler.enabled }}
               - key: osprofiler.conf
                 path: nova.conf.d/osprofiler.conf
               {{- end }}
+          - secret:
+              name: nova-api-metadata
+              items:
+              - key: nova-api-metadata-secrets.conf
+                path: nova.conf.d/nova-api-metadata-secrets.conf
       - name: statsd-etc
         projected:
           sources:

--- a/openstack/nova/templates/api-metadata-secret.yaml
+++ b/openstack/nova/templates/api-metadata-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nova-api-metadata
+  labels:
+    system: openstack
+    type: configuration
+    component: nova
+data:
+  nova-api-metadata-secrets.conf: |
+    {{ include (print .Template.BasePath "/etc/_nova-api-metadata-secrets.conf.tpl") . | b64enc | indent 4 }}

--- a/openstack/nova/templates/etc-secret.yaml
+++ b/openstack/nova/templates/etc-secret.yaml
@@ -19,8 +19,6 @@ data:
   {{- end }}
   keystoneauth-secrets.conf: |
     {{ include (print .Template.BasePath "/etc/_keystoneauth-secrets.conf.tpl") . | b64enc | indent 4 }}
-  nova-api-metadata-secrets.conf: |
-    {{ include (print .Template.BasePath "/etc/_nova-api-metadata-secrets.conf.tpl") . | b64enc | indent 4 }}
   audit-middleware.conf: |
     {{ include "ini_sections.audit_middleware_notifications" . | b64enc | indent 4 }}
   osprofiler.conf: |

--- a/openstack/nova/templates/etc/_nova-api-metadata-secrets.conf.tpl
+++ b/openstack/nova/templates/etc/_nova-api-metadata-secrets.conf.tpl
@@ -1,2 +1,8 @@
 [neutron]
+{{- if kindIs "string" .Values.global.nova_metadata_secret }}
 metadata_proxy_shared_secret = {{ .Values.global.nova_metadata_secret | include "resolve_secret" }}
+{{- else }}
+{{- range $secret := .Values.global.nova_metadata_secret }}
+metadata_proxy_shared_secret = {{ $secret | include "resolve_secret" }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
nova-api-metadata pods will automatically restart through reloader, when the newly-introduce nova-api-metadata k8s Secret changes. This Secret contains the shared metadata secret Neutron also knows.

It should be safe to restart nova-api-metadata on Vault secret change, because it's a multi-replica service. Changing MariaDB/RabbitMQ secrets requires an explicit rollout, so these wouldn't be picked up with the restart. The only change it could pick, is Keystone credentials, but those won't change for a while and even then switch to application credentials and by that should support old/new dual-credentials like with MariaDB/RabbitMQ and what we try to build here.

We also support setting multiple secrets here, because Nova gets support for that in our fork. This enables smoother secret rotation. Since the current settings do not use a list but only a string, we had to add some code used during the migration, so we can safely roll this change out without having the values change in place.