### PR TITLE
[designate] use region-local memcached for keystoneauth token cache

### DIFF
--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes to deploy Openstack Designate  (DNSaaS)
 name: designate
-version: 0.5.7
+version: 0.5.8
 appVersion: "dalmatian"
 dependencies:
   - condition: percona_cluster.enabled

--- a/openstack/designate/templates/etc/_designate.conf.tpl
+++ b/openstack/designate/templates/etc/_designate.conf.tpl
@@ -228,11 +228,7 @@ user_domain_name = {{.Values.global.keystone_service_domain | default "Default"}
 project_name = {{.Values.global.keystone_service_project | default "service"}}
 project_domain_name = {{.Values.global.keystone_service_domain | default "Default"}}
 region_name = {{.Values.global.region}}
-{{- if .Values.global.is_global_region }}
-memcached_servers = "{{ include "helm-toolkit.utils.joinListWithComma" .Values.memcached.server_ips_ports }}"
-{{- else }}
 memcached_servers = {{.Release.Name}}-memcached.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.region}}.{{.Values.global.tld}}:{{.Values.global.memcached_port_public | default 11211}}
-{{- end }}
 {{- if .Values.global.is_global_region }}
 insecure = False
 {{- else }}


### PR DESCRIPTION
Use only region-local memcached for keystoneauth token cache instead of all memcached in global regions