### PR TITLE
[Cinder] Upgrade MariaDB and RabbitMQ

### DIFF
--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.26.0
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.24.2
+  version: 0.26.1
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.4.0
@@ -16,7 +16,7 @@ dependencies:
   version: 0.6.8
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.17.1
+  version: 0.18.5
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.1.4
@@ -26,5 +26,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:84fc1178ebd303627a9110b3318502d8c5854e982681d1990a2f9f8cecec3cdb
-generated: "2025-06-02T09:41:52.560833-04:00"
+digest: sha256:270f55c9158a629183aa393c05e7826a7461acbe7d0d67d1b56f76304fd03cb2
+generated: "2025-07-25T09:13:19.365289-04:00"

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -10,7 +10,7 @@ dependencies:
     version: 0.26.0
   - name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.24.2
+    version: 0.26.1
     condition: mariadb.enabled
   - name: pxc-db
     alias: pxc_db
@@ -26,7 +26,7 @@ dependencies:
     version: 0.6.8
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.17.1
+    version: 0.18.5
   - name: redis
     alias: api-ratelimit-redis
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm


### PR DESCRIPTION
This updates the MariaDB and RabbitMQ helm charts for cinder for fixes including CVE's