### PR TITLE
[mariadb] add and option to disable a user

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.27.0 - 2025/07/31
+* Added an option to drop the database user using the values configuration
+
+Example:
+```yaml
+mariadb:
+  users:
+    test:
+      enabled: false
+```
+This will result in the `test` user being dropped from the MariaDB.
+
 ## v0.26.1 - 2025/07/22
 * `maria-back-me-up` updated to `20250722132533`
 * chart version bumped

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,6 +2,6 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.26.1
+version: 0.27.0
 # scripts/docker-entyrpoint.sh should be updated when appVersion is updated
 appVersion: 10.11.13

--- a/common/mariadb/ci/test-values.yaml
+++ b/common/mariadb/ci/test-values.yaml
@@ -1,5 +1,5 @@
 global:
-  dbUser: admin
+  dbUser: test
   dbPassword: secret!
   registry: my.docker.registry
   registryAlternateRegion: other.docker.registry
@@ -30,6 +30,14 @@ backup_v2:
     password: superSecret
 
 users:
+  test:
+    name: test
+    password: superSecret
+  skipme:
+    name: skipme
+    password: null
+  deleteme:
+    enabled: false
   backup:
     password: superSecret
 

--- a/common/mariadb/templates/initdb/_init.sql.tpl
+++ b/common/mariadb/templates/initdb/_init.sql.tpl
@@ -15,7 +15,11 @@ GRANT ALL PRIVILEGES ON {{ .Values.name }}.*
 
 {{- range $username, $values := .Values.users }}
     {{- $username := default $username $values.name }}
-    {{- if not $values.password }}
+    {{- if (and (hasKey $values "enabled") (eq (typeOf $values.enabled) "bool") (eq $values.enabled false)) }}
+-- Dropping user {{ $username }} as it is disabled
+DROP USER IF EXISTS {{ include "mariadb.resolve_secret_squote" $username }}@'%';
+--
+    {{- else if not $values.password }}
 -- Skipping user {{ $username }} without password
     {{- else }}
 DROP USER IF EXISTS {{ include "mariadb.resolve_secret_squote" $username }}@'localhost';


### PR DESCRIPTION

* Added an option to drop the database user using the values configuration

Example:
```yaml
mariadb:
  users:
    test:
      enabled: false
```

This will result in the `test` user being dropped from the MariaDB.