### PR TITLE
fix policy for share types

### DIFF
--- a/openstack/castellum/files/policy.yaml
+++ b/openstack/castellum/files/policy.yaml
@@ -10,8 +10,8 @@ project_nfs_viewer: role:cloud_sharedfilesystem_viewer or (rule:project_or_domai
 
 project:edit:nfs-shares: rule:project_nfs_editor
 project:show:nfs-shares: rule:project_nfs_viewer
-project:edit:nfs-shares-group: rule:project_nfs_editor
-project:show:nfs-shares-group: rule:project_nfs_viewer
+project:edit:nfs-shares-type: rule:project_nfs_editor
+project:show:nfs-shares-type: rule:project_nfs_viewer
 
 project_barbican_viewer: rule:project_scope and (role:keymanager_admin or role:keymanager_viewer)
 project_compute_editor: rule:project_scope and (role:compute_admin or role:compute_admin_wsg or role:member)


### PR DESCRIPTION
Ref: https://github.com/sapcc/castellum/pull/353
The naming of `nsf-shares-types` is the more correct one of both naming schemes.