### PR TITLE
[openstack/nova] Nanny for orphaned migrations

### DIFF
--- a/openstack/nova/templates/bin-configmap.yaml
+++ b/openstack/nova/templates/bin-configmap.yaml
@@ -13,11 +13,10 @@ data:
 {{ include (include "job_bin_path" (tuple . "db-online-migrate")) . | indent 4 }}
   nanny-db-archive-deleted-rows: |
 {{ include (include "job_bin_path" (tuple . "nanny-db-archive-deleted-rows" "nanny")) . | indent 4 }}
-  nanny-db-archive-deleted-rows-cell0: |
-{{ include (include "job_bin_path" (tuple . "nanny-db-archive-deleted-rows-cell0" "nanny")) . | indent 4 }}
   nanny-db-purge: |
 {{ include (include "job_bin_path" (tuple . "nanny-db-purge" "nanny")) . | indent 4 }}
   nanny-db-soft-delete-excessive-instance-faults: |
 {{ include (include "job_bin_path" (tuple . "nanny-db-soft-delete-excessive-instance-faults" "nanny")) . | indent 4 }}
-  nanny-sap-map-instances: |
-{{ include (include "job_bin_path" (tuple . "nanny-sap-map-instances" "nanny")) . | indent 4 }}
+  nanny-db-error-out-orphaned-migrations: |
+{{ include (include "job_bin_path" (tuple . "nanny-db-error-out-orphaned-migrations" "nanny")) . | indent 4 }}
+

--- a/openstack/nova/templates/bin/nanny/_nanny-db-error-out-orphaned-migrations.tpl
+++ b/openstack/nova/templates/bin/nanny/_nanny-db-error-out-orphaned-migrations.tpl
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "INFO: Erroring out all orphaned migrations"
+exec nova-manage db error_out_orphaned_migrations

--- a/openstack/nova/templates/nanny-db-error-out-orphaned-migrations-cronjob.yaml
+++ b/openstack/nova/templates/nanny-db-error-out-orphaned-migrations-cronjob.yaml
@@ -1,0 +1,82 @@
+{{- if .Values.nanny.error_out_orphaned_migrations.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: nova-nanny-db-error-out-orphaned-migrations
+  labels:
+    system: openstack
+    component: nova
+    type: nanny
+spec:
+  schedule: {{ .Values.nanny.error_out_orphaned_migrations.schedule | quote }}
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          {{- tuple . "nanny-db-error-out-orphaned-migrations" "nanny" | include "job_metadata" | indent 10 }}
+        spec:
+          restartPolicy: OnFailure
+          podFailurePolicy:
+            rules:
+            - action: Ignore
+              onExitCodes:
+                operator: In
+                values: [1]
+          volumes:
+          - name: container-init
+            configMap:
+              name: nova-bin
+              defaultMode: 0755
+              items:
+              - key: nanny-db-error-out-orphaned-migrations
+                path: nanny-script
+          {{- include "utils.trust_bundle.volumes" . | indent 10 }}
+          - name: nova-etc
+            projected:
+              sources:
+              - configMap:
+                  name: nova-etc
+                  items:
+                  - key:  nova.conf
+                    path: nova.conf
+                  - key:  logging.ini
+                    path: logging.ini
+                  - key:  release
+                    path: release
+              - secret:
+                  name: nova-etc
+                  items:
+                  - key: api-db.conf
+                    path: nova.conf.d/api-db.conf
+          initContainers:
+          {{- tuple . (dict "service" (include "nova.helpers.database_services" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 10 }}
+          containers:
+          - name: nanny
+            image: {{ tuple . "nanny" | include "container_image_nova" }}
+            imagePullPolicy: IfNotPresent
+            command:
+            - /bin/sh
+            - -c
+            - |
+              /container.init/nanny-script
+              exit_code=$?
+              {{- include "utils.script.job_finished_hook" . | nindent 14 }}
+              exit $exit_code
+            env:
+            {{- if .Values.sentry.enabled }}
+            {{- include "utils.sentry_config" . | nindent 12 }}
+            {{- end }}
+            - name: PYTHONWARNINGS
+              value: {{ .Values.python_warnings | quote }}
+            volumeMounts:
+            - mountPath: /etc/nova
+              name: nova-etc
+            - mountPath: /container.init
+              name: container-init
+            {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
+            resources:
+              requests:
+                memory: "500Mi"
+                cpu: "100m"
+{{- end }}

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -25,25 +25,9 @@ global:
 
 osprofiler: {}
 
-rbac:
-  enabled: true
-
 auto_assign_aggregates: 'dry_run'
 
 use_tls_acme: true
-
-cell1:
-  name: cell1
-  conductor:
-    config_file:
-      DEFAULT:
-        statsd_port: 9125
-        # enables collecting metrics for rpc calls
-        statsd_enabled: true
-      workarounds:
-        skip_hypervisor_version_check_on_lm: true
-      conductor:
-        workers: 8
 
 cell2:
   name: cell2
@@ -56,22 +40,6 @@ cell2:
         statsd_enabled: true
       workarounds:
         skip_hypervisor_version_check_on_lm: true
-      conductor:
-        workers: 8
-
-cell3:
-  name: cell3
-  enabled: false
-  conductor:
-    config_file:
-      DEFAULT:
-        statsd_port: 9125
-        # enables collecting metrics for rpc calls
-        statsd_enabled: true
-      workarounds:
-        skip_hypervisor_version_check_on_lm: true
-      conductor:
-        workers: 8
 
 defaults:
   default:
@@ -109,7 +77,6 @@ pod:
         rollingUpdate:
           maxUnavailable: 0
           maxSurge: 1
-        overrides: {}  # e.g., { api: { podReplacementStrategy: Recreate } }
   debug:
     api: false
   resources:
@@ -153,29 +120,32 @@ debug: "True"
 defaultUsersRabbitMQ:
   cell1: default
   cell2: default
-  cell3: default
 
 defaultUsersMariaDB:
   api: nova_api
   cell0: nova_cell0
   cell1: nova
   cell2: null
-  cell3: null
 
-cell0dbType: mariadb
-cell1dbType: mariadb
-cell2dbType: mariadb
-cell3dbType: mariadb
-apidbType: mariadb
+dbName: nova
 
-# Target database instance for cell0
-# - "api": uses nova-api-mariadb (mariadb_api)
-# - "cell1": shares with cell1 on nova-mariadb (mariadb) [default]
-cell0dbTarget: "cell1"
+cell0dbName: nova_cell0
+
+# cell2dbName should be the same as mariadb_cell2 backup_v2 DB name!
+cell2dbName: nova_cell2
+
+apidbName: nova_api
 
 loci:
   nova: false
   # neutron images use loci by default
+
+#TODO we need to move to global or find another way to share image versions
+imageNameNeutron: loci-neutron
+
+imageNameOpenvswitch: loci-neutron
+imageVersionOpenvswitchVswitchd: null
+imageVersionOpenvswitchDbServer: null
 
 imageNameNova: loci-nova
 imageVersionNova: null
@@ -188,12 +158,12 @@ imageVersionNovaShellinaboxproxy: null
 imageVersionNovaSpicehtml5proxy: null
 imageVersionNovaScheduler: null
 imageVersionNovaNanny: null
-imageVersionOpenResty: 1.25.3.2-5-bookworm
+imageVersionBitnamiOpenResty: 1.21.4-1-debian-11-r57
+
+imageVersionVspc: null
 
 vspc:
-  image:
-    tag: null
-  enabled: true
+  enabled: false
   telnet:
     portInternal: 1333
     portExternal: 1333
@@ -213,9 +183,6 @@ cross_az_attach: 'False'
 cinder_http_retries: 10
 neutron_http_retries: 10
 neutron_timeout: 600
-placement_timeout: 600
-rpc_response_timeout: 300
-rabbit_transient_queues_ttl: 190
 
 api:
   config_file:
@@ -263,7 +230,6 @@ consoles:
   serial:
     enabled: true
     portInternal: '6083'
-    args: "--web /var/lib/openstack/serialproxy-web/"
   shellinabox:
     enabled: true
     portInternal: '6084'
@@ -283,8 +249,8 @@ scheduler:
   rpc_statsd_port: 9125
   # enables collecting metrics for RPC calls
   rpc_statsd_enabled: true
-  default_filters: "ShardFilter, VolumeSizeSameShardResizeFilter, AggregateMultiTenancyIsolation, ComputeFilter, ComputeCapabilitiesFilter, HANAMemoryMaxUnitFilter, ResizeVcpuMaxUnitFilter, BigVmFlavorHostSizeFilter, VmSizeThresholdFilter, ImagePropertiesFilter, ServerGroupAntiAffinityFilter, ServerGroupAffinityFilter"
-  vm_size_threshold_vm_size_mb: "32769"
+  default_filters: "CpuInfoMigrationFilter, ShardFilter, AggregateMultiTenancyIsolation, ComputeFilter, ComputeCapabilitiesFilter, HANAMemoryMaxUnitFilter, ResizeVcpuMaxUnitFilter, BigVmFlavorHostSizeFilter, VmSizeThresholdFilter, ImagePropertiesFilter, ServerGroupAntiAffinityFilter, ServerGroupAffinityFilter"
+  vm_size_threshold_vm_size_mb: "16385"
   vm_size_threshold_hv_size_mb: "819200"
   ram_weight_multiplier: 1.0
   cpu_weight_multiplier: 1.0
@@ -318,15 +284,10 @@ scheduler:
   aggregate_multi_tenancy_isolation_weight_multiplier: 50.0
 
   image_properties_default_architecture: "x86_64"
-  config:
-    scheduler:
-      enable_external_customer_exclusive_filter: true
-      forbidden_on_external_customer_hosts_ignored_domain_names: cc3test
-
-  external_scheduler_retries: 4
 
 compute:
   defaults:
+    host_username: m3novaapiuser@vsphere.local
     default:
       max_concurrent_builds_per_project: 20
       max_concurrent_builds: 50
@@ -348,8 +309,8 @@ compute:
       bigvm_deployment_free_host_hostgroup_name: "bigvm_free_host_antiaffinity_hostroup"
       clone_from_snapshot: false
       full_clone_snapshots: true
-      # maximum of vSphere 8
-      default_hw_version: vmx-21
+      # maximum of vSphere 7.0u1c
+      default_hw_version: vmx-18
       memory_reservation_cluster_hosts_max_fail: 2
       memory_reservation_max_ratio_fallback: 0.8
       # set this to (a little above) the maximum a flavor ever had in our env
@@ -359,16 +320,11 @@ compute:
       #   WHERE resource_class_id = 2 AND r.name like 'domain-%' ORDER BY a.used DESC LIMIT 2;
       # additionally, the sap-seeds chart contains the flavors we currently have
       resource_disk_gb_max_unit_limit: 700
-      serial_port_connected_default: false
-      min_disk_size_kb: 4000
-      mirror_instance_logs_to_syslog: true
-      special_spawning_vm_group: ''
   vmware:
     vnc:
       enabled: false
 
 conductor:
-  legacy: true
   config_file:
     DEFAULT:
       statsd_port: 9125
@@ -763,131 +719,19 @@ mysql_metrics:
         UNION ALL SELECT 'i-uuid', 'im-uuid', 'None', 0;
       values:
         - "gauge"
-    - help: Retried migrations
-      name: openstack_compute_retried_migration_gauge
-      labels:
-        - "instance_uuid"
-        - "source_compute"
-        - "dest_compute"
-      query: |
-        SELECT
-          instance_uuid,
-          source_compute,
-          dest_compute,
-          count(*) AS gauge
-        FROM migrations
-        WHERE
-          deleted=0
-          AND updated_at > NOW() - INTERVAL 15 minute
-        GROUP BY instance_uuid, source_compute, dest_compute
-        HAVING gauge > 1
-        UNION ALL SELECT 'i-uuid', 'source', 'dest', 0;
-      values:
-        - "gauge"
-    - help: Multiple BDM Volume Attachments
-      name: openstack_compute_multiple_bdm_attachments_gauge
-      labels:
-        - "instance_uuid"
-        - "volume_id"
-      query: |
-        SELECT count(*) AS gauge, bdm.instance_uuid, bdm.volume_id
-        FROM
-          block_device_mapping AS bdm
-          JOIN instances AS i ON i.uuid=bdm.instance_uuid
-        WHERE
-          i.deleted=0
-          AND bdm.deleted=0
-          AND bdm.volume_id IS NOT NULL
-          AND (i.task_state IS NULL OR i.task_state NOT IN ('MIGRATING'))
-        GROUP BY bdm.instance_uuid, volume_id
-        HAVING gauge>1
-        UNION ALL SELECT 'i-uuid', 'v-uuid', 0;
-      values:
-        - "gauge"
-    - help: Compute nodes without service
-      labels:
-      - "uuid"
-      - "nova_host"
-      name: openstack_compute_nodes_no_valid_service
-      query: |
-        SELECT
-          cn.uuid AS uuid, cn.host AS nova_host, 1 AS gauge
-        FROM compute_nodes AS cn
-        LEFT OUTER JOIN services AS s ON s.id = cn.service_id
-        WHERE cn.deleted = 0 AND (s.id IS NULL OR s.deleted <> 0)
-        UNION ALL SELECT 'cn-uuid', 'cn-host', 0;
-      values:
-        - "gauge"
-    - help: Instance task states
-      name: openstack_compute_instances_task_state_gauge
-      labels:
-        - "task_state"
-      query: |
-        SELECT
-          COALESCE(task_state, 'None') AS task_state, count(*) AS gauge
-        FROM instances
-        WHERE deleted = 0
-        GROUP BY task_state;
-      values:
-        - "gauge"
-    - help: Nova oldest soft deleted instance in days
-      name: openstack_compute_oldest_soft_deleted_instance
-      query: |
-        SELECT COALESCE(DATEDIFF(NOW(), MIN(deleted_at)), 0) AS age_of_oldest_instance_in_days
-        FROM instances;
-      values:
-        - "age_of_oldest_instance_in_days"
 
+postgresql:
+  enabled: false
 
-max_pool_size: 50
-max_overflow: -1
+postgresql_cell2:
+  enabled: false
+
+db_name: nova
+max_pool_size: 10
+max_overflow: 5
 
 proxysql:
-  native_sidecar: true
-  ignore_users:
-    - backup
-    - metrics
-    - metis
-  imageRepository: keppel.global.cloud.sap/ccloud/shared-app-images/proxysql
-  connect_retries_delay: 1000
-  mode: host_alias
-  max_connections_per_proc: 15
-
-mariadb_api:
-  enabled: false
-  buffer_pool_size: "4096M"
-  log_file_size: "1024M"
-  name: nova-api
-  long_query_time: 8
-  vpa:
-    set_main_container: true
-  ccroot_user:
-    enabled: true
-  databases:
-  - nova_api
-  persistence_claim:
-    name: db-nova-api-pvc
-    size: "50Gi"
-  backup:
-    enabled: false
-  backup_v2:
-    enabled: true
-    databases:
-      - nova_api
-    verify_tables:
-      - nova_api.flavors
-      - nova_api.key_pairs
-    oauth:
-      client_id: "nova-api"
-  alerts:
-    support_group: compute-storage-api
-  job:
-    maintenance:
-      enabled: false
-      function:
-        analyzeTable:
-          enabled: true
-          allTables: true
+  mode: ""
 
 mariadb:
   enabled: false
@@ -903,6 +747,15 @@ mariadb:
   databases:
   - nova
   - nova_cell0
+  users:
+    nova:
+      name: nova
+      grants:
+      - "ALL PRIVILEGES on nova.*"
+    nova_cell0:
+      name: nova_cell0
+      grants:
+      - "ALL PRIVILEGES on nova_cell0.*"
   persistence_claim:
     name: db-nova-pvc
     size: "50Gi"
@@ -929,24 +782,38 @@ mariadb:
           enabled: true
           allTables: true
 
-mariadb_cell1:
+mariadb_api:
   enabled: false
   buffer_pool_size: "4096M"
   log_file_size: "1024M"
+  name: nova-api
   long_query_time: 8
   vpa:
     set_main_container: true
   ccroot_user:
     enabled: true
+  databases:
+  - nova_api
+  users:
+    nova_api:
+      name: nova_api
+      grants:
+      - "ALL PRIVILEGES on nova_api.*"
   persistence_claim:
-    name: db-nova-cell1-pvc
+    name: db-nova-api-pvc
     size: "50Gi"
   backup:
     enabled: false
   backup_v2:
     enabled: true
+    databases:
+      - nova_api
+      - placement
+    verify_tables:
+      - nova_api.flavors
+      - nova_api.key_pairs
     oauth:
-      client_id: "nova-cell1"
+      client_id: "nova-api"
   alerts:
     support_group: compute-storage-api
   job:
@@ -985,208 +852,6 @@ mariadb_cell2:
           enabled: true
           allTables: true
 
-mariadb_cell3:
-  enabled: false
-  buffer_pool_size: "4096M"
-  log_file_size: "1024M"
-  long_query_time: 8
-  vpa:
-    set_main_container: true
-  ccroot_user:
-    enabled: true
-  persistence_claim:
-    name: db-nova-cell3-pvc
-    size: "50Gi"
-  backup:
-    enabled: false
-  backup_v2:
-    enabled: true
-    oauth:
-      client_id: "nova-cell3"
-  alerts:
-    support_group: compute-storage-api
-  job:
-    maintenance:
-      enabled: false
-      function:
-        analyzeTable:
-          enabled: true
-          allTables: true
-
-pxc_db_api:
-  enabled: false
-  name: nova-api
-  alerts:
-    support_group: "compute-storage-api"
-  ccroot_user:
-    enabled: true
-  databases:
-    - nova_api
-  users:
-    nova_api:
-      name: nova_api
-      grants:
-        - "ALL PRIVILEGES on nova_api.*"
-  pxc:
-    configuration:
-      options:
-        innodb_buffer_pool_size: "4096M"
-        innodb_log_file_size: "1024M"
-        long_query_time: "8"
-    persistence:
-      size: 50Gi
-  backup:
-    enabled: true
-    s3:
-      secrets:
-        aws_access_key_id: null
-        aws_secret_access_key: null
-    pitr:
-      enabled: true
-
-pxc_db:
-  enabled: false
-  name: nova
-  alerts:
-    support_group: "compute-storage-api"
-  ccroot_user:
-    enabled: true
-  databases:
-    - nova
-    - nova_cell0
-  users:
-    nova:
-      name: nova
-      grants:
-        - "ALL PRIVILEGES on nova.*"
-    nova_cell0:
-      name: nova_cell0
-      grants:
-        - "ALL PRIVILEGES on nova_cell0.*"
-  pxc:
-    configuration:
-      options:
-        max_connections: "2048"
-        innodb_buffer_pool_size: "4096M"
-        innodb_log_file_size: "1024M"
-        long_query_time: "8"
-    persistence:
-      size: 50Gi
-  backup:
-    enabled: true
-    s3:
-      secrets:
-        aws_access_key_id: null
-        aws_secret_access_key: null
-    pitr:
-      enabled: true
-
-pxc_db_cell2:
-  enabled: false
-  alerts:
-    support_group: "compute-storage-api"
-  ccroot_user:
-    enabled: true
-  databases: []
-  users: []
-  pxc:
-    configuration:
-      options:
-        innodb_buffer_pool_size: "4096M"
-        innodb_log_file_size: "1024M"
-        long_query_time: "8"
-    persistence:
-      size: 50Gi
-  backup:
-    enabled: true
-    s3:
-      secrets:
-        aws_access_key_id: null
-        aws_secret_access_key: null
-    pitr:
-      enabled: true
-
-pxc_db_cell3:
-  enabled: false
-  alerts:
-    support_group: "compute-storage-api"
-  ccroot_user:
-    enabled: true
-  databases: []
-  users: []
-  pxc:
-    configuration:
-      options:
-        innodb_buffer_pool_size: "4096M"
-        innodb_log_file_size: "1024M"
-        long_query_time: "8"
-    persistence:
-      size: 50Gi
-  backup:
-    enabled: true
-    s3:
-      secrets:
-        aws_access_key_id: null
-        aws_secret_access_key: null
-    pitr:
-      enabled: true
-
-rabbitmq:
-  enabled: true
-  users:
-    default:
-      password: null
-    admin:
-      password: null
-  persistence:
-    enabled: false
-  metrics:
-    enabled: true
-    enableDetailedMetrics: true
-    enablePerObjectMetrics: true
-  resources:
-    requests:
-      memory: 2Gi
-      cpu: 1000m
-  alerts:
-    # unacked/ready messages in rabbitmq
-    rabbit_queue_length: 50
-    unacknowledged_total_wait_for: 10m
-    ready_total_wait_for: 10m
-    support_group: compute-storage-api
-
-rabbitmq_api:
-  enabled: false
-  nameOverride: api-rabbitmq
-  persistence:
-    enabled: false
-  alerts:
-    # unacked/ready messages in rabbitmq
-    rabbit_queue_length: 50
-    unacknowledged_total_wait_for: 10m
-    ready_total_wait_for: 10m
-    support_group: compute-storage-api
-  metrics:
-    enabled: true
-    enableDetailedMetrics: true
-    enablePerObjectMetrics: true
-
-rabbitmq_cell1:
-  enabled: false
-  nameOverride: cell1-rabbitmq
-  persistence:
-    enabled: false
-  alerts:
-    # unacked/ready messages in rabbitmq
-    rabbit_queue_length: 50
-    unacknowledged_total_wait_for: 10m
-    ready_total_wait_for: 10m
-    support_group: compute-storage-api
-  metrics:
-    enabled: true
-    enableDetailedMetrics: true
-    enablePerObjectMetrics: true
-
 rabbitmq_cell2:
   nameOverride: cell2-rabbitmq
   persistence:
@@ -1199,24 +864,10 @@ rabbitmq_cell2:
     support_group: compute-storage-api
   metrics:
     enabled: true
+    sidecar:
+      enabled: false
     enableDetailedMetrics: true
     enablePerObjectMetrics: true
-
-rabbitmq_cell3:
-  nameOverride: cell3-rabbitmq
-  persistence:
-    enabled: false
-  alerts:
-    # unacked/ready messages in rabbitmq
-    rabbit_queue_length: 50
-    unacknowledged_total_wait_for: 10m
-    ready_total_wait_for: 10m
-    support_group: compute-storage-api
-  metrics:
-    enabled: true
-    enableDetailedMetrics: true
-    enablePerObjectMetrics: true
-
 audit:
   central_service:
     user: rabbitmq
@@ -1224,6 +875,34 @@ audit:
   enabled: false
   record_payloads: false
   metrics_enabled: true
+
+rabbitmq:
+  users:
+    default:
+      password: null
+    admin:
+      password: null
+  persistence:
+    enabled: false
+  metrics:
+    password: null
+    enabled: true
+    addMetricsUser: true
+    sidecar:
+      enabled: false
+    enableDetailedMetrics: true
+    enablePerObjectMetrics: true
+  resources:
+    requests:
+      memory: 2Gi
+      cpu: 1000m
+
+  alerts:
+    # unacked/ready messages in rabbitmq
+    rabbit_queue_length: 50
+    unacknowledged_total_wait_for: 10m
+    ready_total_wait_for: 10m
+    support_group: compute-storage-api
 
 logging:
   formatters:
@@ -1289,7 +968,7 @@ alerts:
 sentry:
   enabled: true
 
-nova_bigvm_enabled: false
+nova_bigvm_enabled: true
 
 cors:
   enabled: true
@@ -1317,7 +996,6 @@ default:
   rpc_ping_enabled: true
   # comma-separated list of prefixes for external domains
   external_customer_domain_name_prefixes: "iaas-"
-  instance_name_template: "instance-%(uuid)s"
 
 utils:
   trust_bundle:
@@ -1335,107 +1013,30 @@ python_warnings: "ignore:Unverified HTTPS request,ignore::SyntaxWarning"
 
 # maintenance cronjobs
 nanny:
-  # Defaults for all nanny cronjobs
-  default:
-    enabled: true
-    add_cell0_conf: false
-    resources:
-      requests:
-        memory: "500Mi"
-        cpu: "100m"
   # Archive db rows soft-deleted before more than older_than days to shadow
   # tables. Use batch size max_rows to limit transaction size.
   db_archive_deleted_rows:
+    enabled: true
     # cron schedule (minute | hour | day of month | month | day of week)
     schedule: "0 * * * *"
     older_than: 21
     max_rows: 250
-  # Purge (with --purge flag) db rows from cell0 that were soft-deleted before
-  # more than older_than days. Cell0 contains instances that failed to get
-  # created. This job uses a shorter older_than to purge data sooner and handle
-  # the high volume of failed creations.
-  db_archive_deleted_rows_cell0:
-    # cron schedule (minute | hour | day of month | month | day of week)
-    schedule: "20 * * * *"
-    older_than: 3
-    max_rows: 1000
-    add_cell0_conf: true
   # Delete db rows soft-deleted before more than older_than days from shadow
   # tables.
   db_purge:
+    enabled: true
     # cron schedule (minute | hour | day of month | month | day of week)
     schedule: "15 * * * *"
     older_than: 42
   # For each instance, soft-delete the instance_faults db rows that exceed the
   # count of max_faults. Use batch size max_rows to limit query size.
   db_soft_delete_excessive_instance_faults:
+    enabled: true
     # cron schedule (minute | hour | day of month | month | day of week)
     schedule: "30 * * * *"
     max_faults: 10
     max_rows: 25
-  sap_map_instances:
+  error_out_orphaned_migrations:
+    enabled: true
     # cron schedule (minute | hour | day of month | month | day of week)
-    schedule: "45 * * * *"
-    # Requires only a single cell config to derive the DB type in
-    # _regex_instance_filter()
-    add_cell0_conf: true
-    max_rows: 250
-    fetch_instances_max_retries: 100
-
-# openstack-rate-limit
-rate_limit:
-  enabled: false
-  rate_limit_by: target_project_id
-  max_sleep_time_seconds: 0
-  log_sleep_time_seconds: 10
-  backend_timeout_seconds: 1
-  whitelist:
-    - Default/service
-    - Default/admin
-    - tempest/performance-testing
-    - ccadmin/cloud_admin
-    - ccadmin/master
-  whitelist_users: null
-  blacklist: null
-  blacklist_users: null
-  groups:
-    write:
-      - delete
-      - update
-  rates:
-    default:
-      servers:
-        - action: read/list
-          limit: 100r/m
-        - action: create
-          limit: 100r/m
-      servers/server:
-        - action: read/list
-          limit: 100r/m
-        - action: write
-          limit: 100r/m
-      servers/server/migrations:
-        - action: read/list
-          limit: 100r/m
-      servers/server/migrations/migration:
-        - action: read/list
-          limit: 100r/m
-      servers/server/action:
-        - action: create
-          limit: 100r/m
-      flavors:
-        - action: read/list
-          limit: 100r/m
-      servers/server/remote-consoles:
-        - action: create
-          limit: 100r/m
-
-manage_service_user_passwords: true
-
-api-ratelimit-redis:
-  alerts:
-    support_group: compute-storage-api
-
-statsd:
-  image: 'shared-app-images/statsd-exporter'
-  imageTag: '0.28.0-latest'
+    schedule: "7,22,37,52 * * * *"


### PR DESCRIPTION
Since we should only have few migrations ongoing, the query should be quite fast. We trigger it often as it will be a blocker to re-installing kvm hosts, as they get decomissioned each time, but have to wait for no migrations being associated with the compute-host.