### PR TITLE
[octavia] Bump subcharts mariadb and rabbitmq

### DIFF
--- a/openstack/octavia/Chart.lock
+++ b/openstack/octavia/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.24.1
+  version: 0.26.1
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.3.1
@@ -13,7 +13,7 @@ dependencies:
   version: 0.4.4
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.17.1
+  version: 0.18.5
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.26.0
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:0a9f61958be137696b38525e85e8fd9cd2c2bcd90af91f20bc981e0d8b33bb87
-generated: "2025-05-15T14:18:53.473335536+02:00"
+digest: sha256:cdd7ab788f2048b5e7fd87cb5158d0536c316af04ec7cfb66c41956851b92acc
+generated: "2025-07-28T13:54:02.576627591+02:00"

--- a/openstack/octavia/Chart.yaml
+++ b/openstack/octavia/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.24.1
+    version: 0.26.1
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db
@@ -29,7 +29,7 @@ dependencies:
     version: 0.4.4
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.17.1
+    version: 0.18.5
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.26.0


### PR DESCRIPTION
This updates MariaDB to version 10.11.13 and RabbitMQ to 4.1.2 They provide important fixes, including for CVEs.