### PR TITLE
[limes] fix alert metric definitions for DB schema v2

### DIFF
--- a/openstack/limes/values.yaml
+++ b/openstack/limes/values.yaml
@@ -148,9 +148,10 @@ pgmetrics:
           # all service types without scrape errors. This ensures that an absence
           # of errors does not trigger a metric absence alert.
           query: >
-            SELECT ps.type AS service_name, SUM(CASE WHEN ps.scrape_error_message = '' THEN 0 ELSE 1 END) AS gauge
-              FROM project_services ps
-             GROUP BY ps.type
+            SELECT cs.type AS service_name, SUM(CASE WHEN ps.scrape_error_message = '' THEN 0 ELSE 1 END) AS gauge
+            FROM project_services_v2 ps
+            JOIN cluster_services cs ON cs.id = ps.service_id
+            GROUP BY cs.type
           metrics:
             - service_name:
                 usage: "LABEL"
@@ -162,12 +163,13 @@ pgmetrics:
         limes_mismatch_project_quota:
           # The UNION SELECT adds a dummy row to satisfy the absent-metrics-operator.
           query: >
-            SELECT ps.type AS service_name, COUNT(*) as count
-              FROM project_resources pr
-              JOIN project_services ps ON ps.id = pr.service_id
-             WHERE pr.backend_quota != pr.quota
-             GROUP BY ps.type
-             UNION SELECT 'none' AS service_name, 0 AS count
+            SELECT cs.type AS service_name, COUNT(*) as count
+            FROM project_resources_v2 pr
+            JOIN cluster_resources cr ON cr.id = pr.resource_id
+            JOIN cluster_services cs ON cs.id = cr.service_id
+            WHERE pr.backend_quota != pr.quota
+            GROUP BY cs.type
+            UNION SELECT 'none' AS service_name, 0 AS count
           metrics:
             - service_name:
                 usage: "LABEL"
@@ -184,13 +186,18 @@ pgmetrics:
           # considers quota inconsistencies in Swift if they are large (in specific, larger than 1 TiB = 1099511627776 byte).
           query: >
             WITH tmp AS (
-              SELECT 1 FROM project_services ps
-                JOIN project_resources pr ON pr.service_id = ps.id
-                JOIN project_az_resources par ON par.resource_id = pr.id
-               GROUP BY ps.id, ps.type, pr.name, pr.quota
-              HAVING SUM(par.usage) > pr.quota
-                 AND NOT (ps.type = 'swift' AND pr.name = 'capacity' AND SUM(par.usage) < pr.quota + 1099511627776)
-            ) SELECT COUNT(*) AS count FROM tmp
+              SELECT 1 
+              FROM project_az_resources_v2 pazr
+              JOIN cluster_az_resources cazr ON cazr.id = pazr.az_resource_id
+              JOIN cluster_resources cr ON cr.id = cazr.resource_id
+              JOIN cluster_services cs ON cs.id = cr.service_id
+              JOIN project_resources_v2 pr ON pr.resource_id = cr.id AND pr.project_id = pazr.project_id
+              JOIN project_services_v2 ps ON ps.service_id = cs.id AND ps.project_id = pr.project_id
+              GROUP BY ps.id, cs.type, cr.name, pr.quota
+              HAVING SUM(pazr.usage) > pr.quota
+                AND NOT (cs.type = 'swift' AND cr.name = 'capacity' AND SUM(pazr.usage) < pr.quota + 1099511627776)
+            )
+            SELECT COUNT(*) AS count FROM tmp
           metrics:
             - count:
                 usage: "GAUGE"
@@ -206,9 +213,11 @@ pgmetrics:
 
         limes_project_resources_by_type:
           query: >
-            SELECT ps.type AS service, pr.name AS resource, COUNT(*) AS count
-              FROM project_resources pr JOIN project_services ps ON ps.id = pr.service_id
-             GROUP BY ps.type, pr.name
+            SELECT cs.type AS service, cr.name AS resource, COUNT(*) AS count
+            FROM project_resources_v2 pr
+            JOIN cluster_resources cr ON cr.id = pr.resource_id
+            JOIN cluster_services cs ON cs.id = cr.service_id
+            GROUP BY cs.type, cr.name
           metrics:
             - service:
                 usage: "LABEL"
@@ -225,13 +234,15 @@ pgmetrics:
         # do etcd backups.)
         limes_free_swift_quota:
           query: >
-            SELECT p.uuid AS project_id, p.name AS project, d.name AS domain, GREATEST(pr.backend_quota - par.usage, 0) AS gauge
-              FROM domains d
-              JOIN projects p ON p.domain_id = d.id
-              JOIN project_services ps ON ps.project_id = p.id
-              JOIN project_resources pr ON pr.service_id = ps.id
-              JOIN project_az_resources par ON par.resource_id = pr.id
-             WHERE ps.type = 'swift' AND par.az = 'any'
+            SELECT p.uuid AS project_id, p.name AS project, d.name AS domain, GREATEST(pr.backend_quota - pazr.usage, 0) AS gauge
+            FROM domains d
+            JOIN projects p ON p.domain_id = d.id
+            JOIN project_az_resources_v2 pazr ON pazr.project_id = p.id
+            JOIN cluster_az_resources cazr ON cazr.id = pazr.az_resource_id
+            JOIN cluster_resources cr ON cr.id = cazr.resource_id 
+            JOIN cluster_services cs ON cs.id = cr.service_id
+            JOIN project_resources_v2 pr ON pr.resource_id = cr.id AND pr.project_id = pazr.project_id
+            WHERE cs.type = 'swift' AND cazr.az = 'any'
           metrics:
             - gauge:
                 usage: "GAUGE"
@@ -254,7 +265,7 @@ pgmetrics:
               WHEN type IN ('cronus')                                        THEN 'email'
               WHEN type IN ('ceph', 'swift')                                 THEN 'storage'
               ELSE 'containers' END AS support_group
-            FROM project_services GROUP BY type
+            FROM cluster_services GROUP BY type
           metrics:
             - mapping:
                 usage: "GAUGE"


### PR DESCRIPTION
I tested all the SQLs manually. This is to fix the alert on `limes_project_resources_by_type_count`, because this is old and new projects were created in the meantime.