### PR TITLE
[nova-hypervisor-agents] Support Rabbitmq Alias

### DIFF
--- a/openstack/nova-hypervisor-agents/templates/_helpers.tpl
+++ b/openstack/nova-hypervisor-agents/templates/_helpers.tpl
@@ -21,7 +21,7 @@ novncproxy_base_url = https://{{include "nova_console_endpoint_host_public" .}}:
       "password" (include "nova.helpers.default_user_password" $context)
       "port" .Values.rabbitmq.port
       "virtual_host" .Values.rabbitmq.virtual_host
-      "host" (printf "%s-rabbitmq" .Release.Name)
+      "host" (default (printf "%s-rabbitmq" .Release.Name) .Values.rabbitmq.host)
     }}
   {{- include "utils.rabbitmq_url" (tuple . $data) }}
 {{- end -}}


### PR DESCRIPTION
One can override the rabbitmq hostname with a value, and since we use one not one from the sub-chart, that is actually the default.