### PR TITLE
[Neutron] Bump MariaDB, Rabbitmq, utils, mysql-metrics

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.24.1
+  version: 0.26.1
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.4.0
@@ -10,13 +10,13 @@ dependencies:
   version: 0.6.9
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.4.4
+  version: 0.5.2
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.18.4
+  version: 0.18.5
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.26.0
+  version: 0.28.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
@@ -32,5 +32,5 @@ dependencies:
 - name: ovsdb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
-digest: sha256:13307b587cfded94d8239f29b33acbddcd0a7ccc17610532b6530dae179d7988
-generated: "2025-07-17T12:26:29.667339707+02:00"
+digest: sha256:6ce8a5121def19ed6ee9970a7bef607fa6cd1908790e77c5aea24578b5613c80
+generated: "2025-07-29T13:36:54.367266+02:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.24.1
+    version: 0.26.1
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db
@@ -20,13 +20,13 @@ dependencies:
   - condition: mariadb.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.4.4
+    version: 0.5.2
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.18.4
+    version: 0.18.5
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.26.0
+    version: 0.28.0
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0


### PR DESCRIPTION
```
Rabbitmq: 
* Update to version 4.1.2

MariaDB
* Update to version 10.11.13
* Add default container annotation
* mysqld-exporter now collects user statistics
* update maria backup tool to `20250722132533`

utils
* Add restartPolicy for native sidecar mode
*  add support for unlimited transactions time in jobs

metrics
* Update sql-exporter version to 0.8.0

```