### PR TITLE
disable thanos vpa

### DIFF
--- a/common/thanos/Chart.yaml
+++ b/common/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: Deploy Thanos via operator
 type: application
-version: 1.1.7
+version: 1.1.8
 appVersion: v0.37.2
 maintainers:
   - name: Tommy Sauer (viennaa)

--- a/common/thanos/templates/thanos.yaml
+++ b/common/thanos/templates/thanos.yaml
@@ -39,9 +39,10 @@ spec:
       spec:
         replicas: {{ $.Values.query.replicas }}
         template:
-          {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
           metadata:
             annotations:
+              vpa-butler.cloud.sap/update-mode: Off
+          {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
               linkerd.io/inject: enabled
               config.linkerd.io/proxy-ephemeral-storage-request: 10M
           {{- end }}


### PR DESCRIPTION
very fast growth due to query load can lead to unexpected side effects of adjacent workloads.