### PR TITLE
[neutron-swift-injector] define replicas for statefulset in values

### DIFF
--- a/openstack/neutron/templates/statefulset-swift-injector.yaml
+++ b/openstack/neutron/templates/statefulset-swift-injector.yaml
@@ -18,7 +18,7 @@ spec:
       name: neutron-swift-injector-{{ $apod }}
   serviceName: neutron-swift-injector
   podManagementPolicy: "Parallel"
-  replicas: {{ $.Values.pod.replicas.network_agent | default "1" }}
+  replicas: {{ $.Values.pod.replicas.swift_injector }}
   template:
     metadata:
       annotations:

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -39,6 +39,7 @@ pod:
     server: 3
     rpc_server: 2
     network_agent: 15
+    swift_injector: 1
     ovn_db: 3
   lifecycle:
     upgrades:


### PR DESCRIPTION
This patch removes the logic for determining the replicas of the neutron-swift-injector statefulset in favor of using a defined value from the values.

This is currently only deployed in qa-de-1.