### PR TITLE
Nova: Fix VcenterLowNumberOfPlaceableVms description

### DIFF
--- a/openstack/nova/alerts/openstack/vmware-rebalancer.alerts
+++ b/openstack/nova/alerts/openstack/vmware-rebalancer.alerts
@@ -11,7 +11,7 @@ groups:
           tier: vmware
           playbook: docs/devops/alert/vcenter/#vcenterlownumberofplaceablevms
           context: "vCenter Capacity {{ $labels.vcenter }}"
-          meta: "The vCenter `{{ $labels.vcenter }}` is (almost) full and only allows scheduling less than 4 VMs of flavor {{ $labels.flavor }}."
+          meta: "The vCenter `{{ $labels.vcenter }}` is (almost) full and only allows scheduling less than 3 VMs of flavor {{ $labels.flavor }}."
         annotations:
-          description: "The vCenter `{{ $labels.vcenter }}` in AZ `{{ $labels.az }}` is (almost) full and only allows scheduling less than 4 VMs of flavor {{ $labels.flavor }}."
+          description: "The vCenter `{{ $labels.vcenter }}` in AZ `{{ $labels.az }}` is (almost) full and only allows scheduling less than 3 VMs of flavor {{ $labels.flavor }}."
           summary: "VMware Rebalancer Metric to check if the vCenter has enough remaining capacity."


### PR DESCRIPTION
We still had the old number (4) in the description, but changed the comparison to < 3 - so we need 3 instead of 4 everywhere.