### PR TITLE
[rabbitmq] bump user-credential-updater version

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+## 0.18.6 - 2025/07/30
+
+- Update [user-credential-updater](https://github.com/sapcc/rabbitmq-user-credential-updater) sidecar container to `20250730094138` version with bugfixes.
+- Chart version bumped
+
 ## 0.18.5 - 2025/07/07
 
 - RabbitMQ [4.1.2 Release notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.1.2)

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: rabbitmq
-version: 0.18.5
+version: 0.18.6
 appVersion: 4.1.2
 description: A Helm chart for RabbitMQ
 sources:

--- a/common/rabbitmq/values.yaml
+++ b/common/rabbitmq/values.yaml
@@ -131,7 +131,7 @@ customConfig:
 credentialUpdater:
   enabled: true
   image: rabbitmq-user-credential-updater
-  imageTag: '20250317121126'
+  imageTag: '20250730094138'
 
 enableSsl: false
 certificate:


### PR DESCRIPTION
- Update user-credential-updater sidecar container to `20250730094138` version with bugfixes.
- Chart version bumped.