### PR TITLE
[nova] console-mks to use the openresty/openresty based image

### DIFF
--- a/openstack/nova/templates/console-mks-deployment.yaml
+++ b/openstack/nova/templates/console-mks-deployment.yaml
@@ -53,17 +53,15 @@ spec:
       - name: nova-console-mks
         image: {{ required ".Values.global.registry is missing" .Values.global.registry}}/nova-console-mks:{{ required ".Values.imageVersionConsoleMks is missing" .Values.imageVersionConsoleMks }}
         imagePullPolicy: IfNotPresent
-        command:
-        - /opt/bitnami/scripts/openresty/run.sh
         ports:
         - name: mks
           containerPort: {{ .Values.consoles.mks.portInternal }}
         volumeMounts:
-        - mountPath: /opt/bitnami/openresty/site/lualib
+        - mountPath: /usr/local/openresty/site/lualib
           name: lualib
-        - mountPath: /opt/bitnami/openresty/nginx/conf/server_blocks
+        - mountPath: /etc/nginx/conf.d
           name: config
-        - mountPath: /opt/bitnami/openresty/nginx/tmp
+        - mountPath: /usr/local/openresty/nginx/tmp
           name: temp
         {{- include "utils.proxysql.volume_mount" . | indent 8 }}
         livenessProbe:


### PR DESCRIPTION
We [switched away](https://github.com/sapcc/noVNC/pull/2) from the bitnami/openresty image, so the lualib and nginx directories have changed.