### PR TITLE
[oauth-proxy]: Bump from 7.10 to 7.11

### DIFF
--- a/global/oauth-proxy/values.yaml
+++ b/global/oauth-proxy/values.yaml
@@ -4,7 +4,7 @@
 image:
   registry: quay.io
   name: oauth2-proxy/oauth2-proxy
-  tag: v7.10.0
+  tag: v7.11.0
   pullPolicy: IfNotPresent
 replica_count: 2
 


### PR DESCRIPTION
<7.11 has a critical security vulnerability:

https://github.com/oauth2-proxy/oauth2-proxy/security/advisories/GHSA-7rh7-c77v-6434