### PR TITLE
[nova][rabbitmq] bump rabbitmq chart dependency

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 0.5.1
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.18.4
+  version: 0.18.6
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.6.10
@@ -22,12 +22,12 @@ dependencies:
   version: 0.25.0
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.18.4
+  version: 0.18.6
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:4bf6182c06b2384626dc62a304ee8f6d49bcd221d86e9bcb934061c41b666953
-generated: "2025-07-18T15:41:15.440888+03:00"
+digest: sha256:1c15734213f6233220feeb36a8ca4f2d90080e97a79efa6f39e9e8c440a08bc1
+generated: "2025-07-31T11:55:16.732146+03:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 name: nova
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Nova/OpenStack_Project_Nova_mascot.png
-version: 0.5.1
+version: 0.5.2
 appVersion: "bobcat"
 dependencies:
   - name: mariadb
@@ -20,7 +20,7 @@ dependencies:
     version: 0.5.1
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.18.4
+    version: 0.18.6
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.6.10
@@ -36,7 +36,7 @@ dependencies:
     alias: rabbitmq_cell2
     condition: cell2.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.18.4
+    version: 0.18.6
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0


### PR DESCRIPTION
* Updates RabbitMQ version to 4.1.2

* Updates user-credential-updater sidecar image:
  * underscore in user key bugfix
  * fixes MEDIUM CVEs in the image