### PR TITLE
[rabbitmq] add an option to skip creation of default user

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+## 0.19.0 - 2025/07/31
+
+- Added an option to skip creation of default user
+
+Usage example:
+```yaml
+rabbitmq:
+  addDefaultUser: false
+  users:
+    default:
+      user: test
+      password: secret
+    user1:
+      user: user1
+      password: secret
+    user2:
+      user: user2
+      password: secret
+```
+This will result in the `default` user not being added to the RabbitMQ
+users secret
+
 ## 0.18.6 - 2025/07/30
 
 - Update [user-credential-updater](https://github.com/sapcc/rabbitmq-user-credential-updater) sidecar container to `20250730094138` version with bugfixes.

--- a/common/rabbitmq/templates/_helpers.tpl
+++ b/common/rabbitmq/templates/_helpers.tpl
@@ -16,16 +16,20 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "rabbitmq._validate_users" -}}
-    {{- $users := . -}}
-    {{- range $path, $v := $users }}
-      {{- if not $v.user }}
-          {{- fail (printf "%v.user missing" $path) }}
-      {{- else if hasPrefix "-" $v.user }}
-          {{- fail (printf "%v.user starts with hypen" $path) }}
-      {{- else if not $v.password }}
-          {{- fail (printf "%v.password missing" $path) }}
-      {{- else if hasPrefix "-" $v.password }}
-          {{- fail (printf "%v.password starts with hypen" $path) }}
+    {{- $envAll := . }}
+    {{- $users := $envAll.users }}
+    {{- $addDefaultUser := $envAll.addDefaultUser }}
+    {{- range $key, $user := $users }}
+      {{- if or (ne $key "default") $addDefaultUser }}
+        {{- if not $user.user }}
+            {{- fail (printf "%v.user missing" $key) }}
+        {{- else if hasPrefix "-" $user.user }}
+            {{- fail (printf "%v.user starts with hypen" $key) }}
+        {{- else if not $user.password }}
+            {{- fail (printf "%v.password missing" $key) }}
+        {{- else if hasPrefix "-" $user.password }}
+            {{- fail (printf "%v.password starts with hypen" $key) }}
+        {{- end }}
       {{- end }}
     {{- end }}
 {{- end }}

--- a/common/rabbitmq/templates/users-secret.yaml
+++ b/common/rabbitmq/templates/users-secret.yaml
@@ -1,4 +1,4 @@
-{{- include "rabbitmq._validate_users" .Values.users -}}
+{{- include "rabbitmq._validate_users" . }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,10 +6,13 @@ metadata:
   labels:
     {{- include "rabbitmq.labels" (list $ "version" "rabbitmq" "secret" "messagequeue") | indent 4 }}
 data:
+{{- $addDefaultUser := .Values.addDefaultUser }}
 {{- range $key, $user := .Values.users }}
+  {{- if or (ne $key "default") (and (eq $key "default") $addDefaultUser) }}
   user_{{ $key }}_username: {{ $user.user | b64enc }}
   user_{{ $key }}_password: {{ $user.password | b64enc }}
   user_{{ $key }}_tag: {{ $user.tag | default "" | b64enc }}
+  {{- end }}
 {{- end }}
 {{- if and .Values.metrics.addMetricsUser (not .Values.users.metrics) }}
   user_metrics_username: {{ .Values.metrics.user | b64enc }}

--- a/common/rabbitmq/values.yaml
+++ b/common/rabbitmq/values.yaml
@@ -40,6 +40,9 @@ users:
     password: null
     tag: administrator
 
+# if set to true, this will create a default defined in `.Values.users.default`
+addDefaultUser: true
+
 # if set true, this will create user dev with password dev for debug and development purposes
 # DANGEROUS, please make sure it is set to false unless really needed
 addDevUser: false


### PR DESCRIPTION
- Added an option to skip creation of default user

Usage example:
```yaml
rabbitmq:
  addDefaultUser: false
  users:
    default:
      user: test
      password: secret
    user1:
      user: user1
      password: secret
    user2:
      user: user2
      password: secret
```
This will result in the `default` user not being added to the RabbitMQ users secret.