### PR TITLE
[rabbitmq] Limit default common name to 64 chars

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+## 0.18.7 - 2025/07/31
+
+- Limit default commonName in certificate to 64 characters as that is the limit.
+
+
 ## 0.18.6 - 2025/07/30
 
 - Update [user-credential-updater](https://github.com/sapcc/rabbitmq-user-credential-updater) sidecar container to `20250730094138` version with bugfixes.

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: rabbitmq
-version: 0.18.6
+version: 0.18.7
 appVersion: 4.1.2
 description: A Helm chart for RabbitMQ
 sources:

--- a/common/rabbitmq/templates/_helpers.tpl
+++ b/common/rabbitmq/templates/_helpers.tpl
@@ -30,6 +30,21 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
     {{- end }}
 {{- end }}
 
+{{- define "rabbitmq.serviceName" -}}
+"{{ template "fullname" . }}.{{ .Release.Namespace }}.svc.kubernetes.{{ .Values.global.region | required "global.region missing" }}.{{ .Values.global.tld | required "global.tld missing" }}"
+{{- end }}
+
+{{/* By default, the name is the dns name, but that may be too long, so we might to have to shorten it.
+     If the actual value matters to you, set it directly. */}}
+{{- define "rabbitmq.defaultCommonName" -}}
+{{- $serviceName := include "rabbitmq.serviceName" . }}
+  {{- if le (len $serviceName) 64 }}
+    {{- $serviceName }}
+  {{- else -}}
+    "{{ template "fullname" . }}.{{ .Values.global.region | required "global.region missing" }}.{{ .Values.global.tld | required "global.tld missing" }}"
+  {{- end }}
+{{- end }}
+
 {{/* Generate the service label for the templated Prometheus alerts. */}}
 {{- define "alerts.service" -}}
 {{- if .Values.alerts.service -}}

--- a/common/rabbitmq/templates/certificate.yaml
+++ b/common/rabbitmq/templates/certificate.yaml
@@ -11,11 +11,14 @@ spec:
     labels:
       {{- include "rabbitmq.labels" (list $ "version" "rabbitmq" "deployment" "messagequeue") | indent 6 }}
   dnsNames:
-    - "{{ template "fullname" . }}.{{ .Release.Namespace }}.svc.kubernetes.{{ .Values.global.region | required "global.region missing" }}.{{ .Values.global.tld | required "global.tld missing" }}"
+    - {{ include "rabbitmq.serviceName" . }}
   {{- if .Values.externalNames }}
     {{- range .Values.externalNames }}
     - "{{ . }}"
     {{- end }}
+  {{- end }}
+  {{- if not .Values.certificate.commonName }}
+  commonName: {{ include "rabbitmq.defaultCommonName" . }}
   {{- end }}
   {{- .Values.certificate | toYaml | nindent 2 }}
 {{- end }}


### PR DESCRIPTION
Without setting the commonName to something, the first DNS name is used, which may be too long. By setting it to a shortened version, we cover the issue that the certificate may not be provisioned due to a overly long common name.