### PR TITLE
alert down should only trigger for correct node exporter

### DIFF
--- a/system/infra-monitoring/Chart.yaml
+++ b/system/infra-monitoring/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: infra-monitoring
-version: 2.5.20
+version: 2.5.21
 description: Prometheus Infrastructure Monitoring and Metrics Collection
 dependencies:
   - name: prometheus-server

--- a/system/infra-monitoring/alerts/jumpserver.alerts
+++ b/system/infra-monitoring/alerts/jumpserver.alerts
@@ -80,7 +80,7 @@ groups:
       description: '{{ $labels.server_name }} fs {{ $labels.mountpoint }} is 100% utilized for 10m.'
       summary: 'Check mentioned mount point for a possible cleanup'
   - alert: JumpserverDown
-    expr: up{job="jumpserver"} == 0
+    expr: up{job="jumpserver", instance=~".*:9100"} == 0
     for: 5m
     labels:
       context: availability


### PR DESCRIPTION
node-exporter runs on 9100, if there are different jobs, don't trigger