### PR TITLE
[octavia] add default-container annotation to all pods

### DIFF
--- a/openstack/octavia/templates/octavia-api-deployment.yaml
+++ b/openstack/octavia/templates/octavia-api-deployment.yaml
@@ -34,6 +34,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         {{- include "utils.topology.pod_label" . | indent 8 }}
       annotations:
+        kubectl.kubernetes.io/default-container: {{ .Chart.Name }}-api
         configmap-etc-hash: {{ include (print $.Template.BasePath "/octavia-etc-configmap.yaml") . | sha256sum }}
         secrets-hash: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
         {{- if or .Values.watcher.enabled .Values.proxysql.mode }}

--- a/openstack/octavia/templates/octavia-f5-as3-deployment.yaml
+++ b/openstack/octavia/templates/octavia-f5-as3-deployment.yaml
@@ -24,8 +24,8 @@ spec:
         app.kubernetes.io/name: octavia-f5-as3
         app.kubernetes.io/instance: {{ .Release.Name }}
       annotations:
+        kubectl.kubernetes.io/default-container: f5-as3-container
         {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
-
     spec:
       priorityClassName: critical-payload
       containers:

--- a/openstack/octavia/templates/octavia-housekeeping.yaml
+++ b/openstack/octavia/templates/octavia-housekeeping.yaml
@@ -25,6 +25,7 @@ spec:
         app.kubernetes.io/name: octavia-housekeeping
         app.kubernetes.io/instance: {{ .Release.Name }}
       annotations:
+        kubectl.kubernetes.io/default-container: octavia-f5-housekeeping
         configmap-etc-hash: {{ include (print $.Template.BasePath "/octavia-etc-configmap.yaml") . | sha256sum }}
         configmap-worker-hash: {{ include (print $.Template.BasePath "/octavia-worker-configmap.yaml") . | sha256sum }}
         secrets-hash: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}

--- a/openstack/octavia/templates/octavia-migration-job.yaml
+++ b/openstack/octavia/templates/octavia-migration-job.yaml
@@ -18,6 +18,9 @@ metadata:
     "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: octavia-migration
     spec:
       restartPolicy: OnFailure
     {{- if $proxysql }}

--- a/openstack/octavia/templates/octavia-worker-deployment.yaml
+++ b/openstack/octavia/templates/octavia-worker-deployment.yaml
@@ -32,6 +32,7 @@ spec:
         # AZ value "any" corresponds to the enum symbol used by Limes: https://pkg.go.dev/github.com/sapcc/go-api-declarations/limes#AvailabilityZone
         availability-zone: {{ $v.availability_zone | default "any" }}
       annotations:
+        kubectl.kubernetes.io/default-container: octavia-worker
         configmap-etc-hash: {{ include (print $.Template.BasePath "/octavia-etc-configmap.yaml") . | sha256sum }}
         configmap-worker-hash: {{ include (print $.Template.BasePath "/octavia-worker-configmap.yaml") . | sha256sum }}
         secrets-hash: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}


### PR DESCRIPTION
The value of the `kubectl.kubernetes.io/default-container` annotation is the container name that is default for the Pod. It will be picked up by commands such as `kubectl logs` or `kubectl exec` if no `-c/--container` flag is specified.

Ref: https://kubernetes.io/docs/reference/labels-annotations-taints/#kubectl-kubernetes-io-default-container