### PR TITLE
[rabbitmq] remove version label from rabbitmq deployment pod template

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+## 0.18.8 - 2025/08/01
+
+- Remove version label from RabbitMQ deployment pod template, related configmaps and secrets to avoid unnecessary  restarts on simple chart version update
+
 ## 0.18.7 - 2025/07/31
 
 - Limit default commonName in certificate to 64 characters as that is the limit.

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: rabbitmq
-version: 0.18.7
+version: 0.18.8
 appVersion: 4.1.2
 description: A Helm chart for RabbitMQ
 sources:

--- a/common/rabbitmq/templates/bin-configmap.yaml
+++ b/common/rabbitmq/templates/bin-configmap.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "fullname" . }}-bin
   labels:
-    {{- include "rabbitmq.labels" (list $ "version" "rabbitmq" "configmap" "messagequeue") | indent 4 }}
+    {{- include "rabbitmq.labels" (list $ "noversion" "rabbitmq" "configmap" "messagequeue") | indent 4 }}
 data:
   rabbitmq-start: |
 {{ include (print .Template.BasePath "/bin/_rabbitmq-start.tpl") . | indent 4 }}

--- a/common/rabbitmq/templates/custom-conf-configmap.yaml
+++ b/common/rabbitmq/templates/custom-conf-configmap.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "fullname" . }}-custom-conf
   labels:
-    {{- include "rabbitmq.labels" (list $ "version" "rabbitmq" "configmap" "messagequeue") | indent 4 }}
+    {{- include "rabbitmq.labels" (list $ "noversion" "rabbitmq" "configmap" "messagequeue") | indent 4 }}
 data:
   {{- if $.Values.customConfig }}
   20-custom.conf: |

--- a/common/rabbitmq/templates/deployment.yaml
+++ b/common/rabbitmq/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "rabbitmq.labels" (list $ "version" "rabbitmq" "deployment" "messagequeue") | indent 8 }}
+        {{- include "rabbitmq.labels" (list $ "noversion" "rabbitmq" "deployment" "messagequeue") | indent 8 }}
       annotations:
         kubectl.kubernetes.io/default-container: rabbitmq
         checksum/container.init: {{ include (print $.Template.BasePath "/bin-configmap.yaml") . | sha256sum }}

--- a/common/rabbitmq/templates/users-secret.yaml
+++ b/common/rabbitmq/templates/users-secret.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: {{ template "fullname" . }}-users
   labels:
-    {{- include "rabbitmq.labels" (list $ "version" "rabbitmq" "secret" "messagequeue") | indent 4 }}
+    {{- include "rabbitmq.labels" (list $ "noversion" "rabbitmq" "secret" "messagequeue") | indent 4 }}
 data:
 {{- range $key, $user := .Values.users }}
   user_{{ $key }}_username: {{ $user.user | b64enc }}


### PR DESCRIPTION
Remove version label from RabbitMQ deployment pod template, related configmaps and secrets to avoid unnecessary  restarts on simple chart version update.