### PR TITLE
[CODEOWNERS] remove openstack/nannies

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -90,7 +90,6 @@
 /openstack/labels-injector                             @joker-at-work @fwiesel @grandchild @leust @seb-kro @PaulPickhardt @CordulaGuder @notandy @mchristianl
 /openstack/maia                                        @notque @richardtief @viennaa @Kuckkuck @timojohlo
 /openstack/manila*                                     @Carthaca @chuan137 @galkindmitrii @kpawar-sap @sumitarora2786 @crenduchinta88 @hvr999 @RockSolidScripts
-/openstack/nannies                                     @joker-at-work @fwiesel @grandchild @leust @seb-kro @PaulPickhardt @CordulaGuder @hemna @jagoleni
 /openstack/netapp-credential-rotator                   @Carthaca @chuan137 @kpawar-sap @sumitarora2786 @crenduchinta88 @hvr999 @RockSolidScripts @Scsabiii @hemna @jagoleni
 /openstack/neutron                                     @notandy @fwiesel @sapcc/network-api-contributors
 /openstack/neutron-hypervisor-agents                   @sapcc/network-api-contributors @notandy @fwiesel @mchristianl


### PR DESCRIPTION
The `openstack/nannies` Chart has been removed via PR https://github.com/sapcc/helm-charts/pull/9290 and consequently the directory can be removed from the `CODEOWNERS`.