### PR TITLE
[manila] bump shared chart dependencies

### DIFF
--- a/openstack/manila/Chart.lock
+++ b/openstack/manila/Chart.lock
@@ -1,30 +1,30 @@
 dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.1.0
+  version: 1.1.1
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.24.2
+  version: 0.27.0
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.4.0
+  version: 0.4.1
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.6.10
+  version: 0.6.12
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.5.0
+  version: 0.5.2
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.18.1
+  version: 0.19.0
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 2.2.12
+  version: 2.2.13
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.27.0
-digest: sha256:8bbe6c164c20d33f211c166959718fa076169796e6def0e3e6abc514d032a68d
-generated: "2025-06-26T10:45:06.296263+02:00"
+  version: 0.28.0
+digest: sha256:99f61dbe3d7e8e127d63191febecfd39df58df6548b5b5e6afd1983355c75817
+generated: "2025-08-05T11:36:40.136327+03:00"

--- a/openstack/manila/Chart.yaml
+++ b/openstack/manila/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 name: manila
 sources:
   - https://github.com/sapcc/manila
-version: 0.6.0
+version: 0.6.1
 dependencies:
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
@@ -18,26 +18,26 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.24.1
+    version: ~0.27.0
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.4.0
+    version: ~0.4.1
   - condition: memcached.enabled
     name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.6.8
+    version: ~0.6.12
   - condition: mariadb.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.5.0
+    version: ~0.5.2
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: ~1.0.0
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.18.0
+    version: ~0.19.0
   - name: redis
     alias: api-ratelimit-redis
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
@@ -45,4 +45,4 @@ dependencies:
     condition: api_rate_limit.enabled
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.27.0
+    version: 0.28.0


### PR DESCRIPTION
* updates maria-back-me-up to 20250722132533

* updates memcached to 1.6.39

* updates rabbitmq to 4.1.2

* updates sql-exporter to 0.8.0 (2025-07-07)