### PR TITLE
[placement] add placement database name to mariadb configuration

### DIFF
--- a/openstack/placement/Chart.yaml
+++ b/openstack/placement/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 description: A Helm chart for the Openstack Placement Service
 name: placement
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/project-mascots/Placement/OpenStack_Project_Placement_horizontal.jpg
-version: 0.3.0
+version: 0.3.1
 appVersion: "dalmatian"
 dependencies:
   - condition: mariadb.enabled

--- a/openstack/placement/ci/test-values.yaml
+++ b/openstack/placement/ci/test-values.yaml
@@ -15,10 +15,11 @@ imageVersion: myTag
 mariadb:
   enabled: false
   name: placement  # can be changed
-  root_password: topSecret
+  root_password: topRootSecret
   users:
     placement:
-      password: topSecret
+      name: placement
+      password: topUserSecret
   backup_v2:
     enabled: false
 

--- a/openstack/placement/values.yaml
+++ b/openstack/placement/values.yaml
@@ -61,6 +61,8 @@ mariadb:
   enabled: true
   name: placement
   defaultUser: placement
+  databases:
+    - placement
   alerts:
     support_group: "compute-storage-api"
   ccroot_user:


### PR DESCRIPTION
Add `placement` database to `mariadb.databases`.

This would make openstack/utils `utils.db_url` helper work as expected, so it doesn't try to use root or .global.db secrets for connection string