### PR TITLE
[octavia] values.yaml: Add redis.alerts.support_group for ratelimiting

### DIFF
--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -48,6 +48,10 @@ rabbitmq_notifications:
     sidecar:
       enabled: false
 
+redis:
+  alerts:
+    support_group: network-api
+
 memcached:
   alerts:
     support_group: network-api


### PR DESCRIPTION
When templating, we get `Error: execution error at (octavia/charts/api-ratelimit-redis/templates/prometheus-alerts.yaml:5:48): missing value for .Values.redis.alerts.support_group`
Add the missing value.