### PR TITLE
[octavia] Fix values.yaml: Subchart values not using subchart alias

### DIFF
--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -48,7 +48,7 @@ rabbitmq_notifications:
     sidecar:
       enabled: false
 
-redis:
+api-ratelimit-redis:
   alerts:
     support_group: network-api
 


### PR DESCRIPTION
This fixes #9432

Turns out, the values need to use the subchart alias, which in this case for `redis` is `api-ratelimit-redis`, as defined in Chart.yaml
I was able to reproduce the templating error locally and check that this fix works.