### PR TITLE
Fix retelimit.yaml file mount for octavia-api

### DIFF
--- a/openstack/octavia/templates/octavia-api-deployment.yaml
+++ b/openstack/octavia/templates/octavia-api-deployment.yaml
@@ -118,6 +118,12 @@ spec:
               subPath: watcher.yaml
               readOnly: true
             {{- end }}
+            {{- if .Values.rate_limit.enabled }}
+            - name: octavia-etc
+              mountPath: /etc/octavia/ratelimit.yaml
+              subPath: ratelimit.yaml
+              readOnly: true
+            {{- end }}
             {{- if not .Values.api_backdoor }}
             - name: octavia-etc
               mountPath: /etc/apache2/conf-enabled/octavia-api.conf


### PR DESCRIPTION
This PR fixes ratelimit.yaml file mount for octavia-api POD:
```
 $ ke -it deploy/octavia-api -c octavia-api -- bash -c "cat /etc/octavia/ratelimit.yaml"
cat: /etc/octavia/ratelimit.yaml: No such file or directory
command terminated with exit code 1
```