### PR TITLE
Add redis config and credentials for Octavia rate-limit

### DIFF
--- a/openstack/octavia/templates/etc/_octavia.conf.tpl
+++ b/openstack/octavia/templates/etc/_octavia.conf.tpl
@@ -151,4 +151,12 @@ config_file = /etc/octavia/watcher.yaml
 enabled = true
 service_type = loadbalancer
 config_file = /etc/octavia/ratelimit.yaml
+rate_limit_by = {{ .Values.rate_limit.rate_limit_by }}
+max_sleep_time_seconds: {{ .Values.rate_limit.max_sleep_time_seconds }}
+clock_accuracy = 1ns
+log_sleep_time_seconds: {{ .Values.rate_limit.log_sleep_time_seconds }}
+backend_host = {{ .Release.Name }}-api-ratelimit-redis
+backend_port = 6379
+backend_secret_file = {{ .Values.rate_limit.backend_secret_file }}
+backend_timeout_seconds = {{ .Values.rate_limit.backend_timeout_seconds }}
 {{- end }}

--- a/openstack/octavia/templates/octavia-api-deployment.yaml
+++ b/openstack/octavia/templates/octavia-api-deployment.yaml
@@ -123,6 +123,10 @@ spec:
               mountPath: /etc/octavia/ratelimit.yaml
               subPath: ratelimit.yaml
               readOnly: true
+            - name: redis-ratelimit-secret
+              mountPath: {{ .Values.rate_limit.backend_secret_file }}
+              subPath: password
+              readOnly: true
             {{- end }}
             {{- if not .Values.api_backdoor }}
             - name: octavia-etc
@@ -158,5 +162,10 @@ spec:
         - name: octavia-etc-confd
           secret:
             secretName: {{ .Release.Name }}-secrets
+{{- if .Values.rate_limit.enabled }}
+        - name: redis-ratelimit-secret
+          secret:
+            secretName: {{ .Release.Name }}-api-ratelimit-redis-user-default
+{{- end }}
         {{- include "utils.proxysql.volumes" . | indent 8 }}
         {{- include "utils.trust_bundle.volumes" . | indent 8 }}

--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -434,6 +434,7 @@ vpa:
 # openstack-rate-limit
 rate_limit:
   enabled: false
+  backend_secret_file: /etc/octavia/ratelimit-backend-secret.conf
   rate_limit_by: target_project_id
   max_sleep_time_seconds: 0
   log_sleep_time_seconds: 10


### PR DESCRIPTION
This PR adds config file and credentials for Redis backend rate-limit