### PR TITLE
fix(secrets-injector): failsafe deployment

### DIFF
--- a/system/secrets-injector/Chart.yaml
+++ b/system/secrets-injector/Chart.yaml
@@ -3,7 +3,7 @@ name: secrets-injector
 description: Secrets Injector
 
 type: application
-version: 1.1.15
+version: 1.1.16
 appVersion: "0.1.0"
 
 dependencies:

--- a/system/secrets-injector/templates/alerts.yaml
+++ b/system/secrets-injector/templates/alerts.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.alerts.enabled (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "prometheusrules.monitoring.coreos.com") }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -45,3 +46,4 @@ spec:
         service: secrets-injector
         severity: warning
         support_group: "{{`{{ if $labels.label_ccloud_support_group }}{{ $labels.label_ccloud_support_group }}{{ else }}containers{{ end }}`}}"
+{{- end -}}

--- a/system/secrets-injector/values.yaml
+++ b/system/secrets-injector/values.yaml
@@ -27,5 +27,6 @@ webhook:
     # resourceName: abc
     # keyName: client-ca.crt
 alerts:
+  enabled: true
   ruleSelector:
     prometheus: kubernetes


### PR DESCRIPTION
* failsafe deployment if kube-monitoring crds are not present
* add option to disable deployment of alerts