### PR TITLE
all srs: switch playbook links to absolute URLs

### DIFF
--- a/common/pgbackup/Chart.yaml
+++ b/common/pgbackup/Chart.yaml
@@ -2,7 +2,7 @@ name: pgbackup
 # 1.2.0
 # - Added `.Values.reloader.enabled` to control consumption of
 #   `stakater/Reloader` annotations on referenced Secrets and CMs.
-version: 1.2.14 # this version number is SemVer as it gets used to auto bump
+version: 1.2.15 # this version number is SemVer as it gets used to auto bump
 apiVersion: v2
 description: PostgreSQL backup/restore pod
 appVersion: "v0.10.0-166-g4572f71" # of https://github.com/sapcc/backup-tools

--- a/common/pgbackup/templates/prometheus-alerts.yaml
+++ b/common/pgbackup/templates/prometheus-alerts.yaml
@@ -41,7 +41,7 @@ spec:
         severity: info
         support_group: {{ $support_group }}
         tier: os # for backward-compatibility, only
-        playbook: docs/support/playbook/db_backup_issues
+        playbook: 'https://operations.global.cloud.sap/docs/support/playbook/db_backup_issues'
       annotations:
         description: The last successful database backup for {{ $db_host }} is {{`{{ $value }}`}} hours old.
         summary: Database Backup too old
@@ -56,7 +56,7 @@ spec:
         severity: warning
         support_group: {{ $support_group }}
         tier: os # for backward-compatibility, only
-        playbook: docs/support/playbook/db_backup_issues
+        playbook: 'https://operations.global.cloud.sap/docs/support/playbook/db_backup_issues'
       annotations:
         description: The last successful database backup for {{ $db_host }} is {{`{{ $value }}`}} hours old.
         summary: Database Backup too old

--- a/common/postgresql-ng/Chart.yaml
+++ b/common/postgresql-ng/Chart.yaml
@@ -40,10 +40,4 @@ description: Chart for PostgreSQL
 # - Removed `.Values.sqlOnCreate`, `.Values.sqlOnStartup` and `.Values.users[].grant`:
 #     With multitenancy, it is not clear which database these scripts run in.
 #     >> Please use `.Values.databases[].sqlOnStartup` instead.
-#
-# 2.0.3
-# - Fix DB name double quoting issues in startup sql script
-#
-# 2.0.5, 2.0.6
-# - Fix reloader.annotateGeneratedSecrets not annotating generated secrets
-version: 2.0.15 # this version number is SemVer as it gets used to auto bump
+version: 2.0.16 # this version number is SemVer as it gets used to auto bump

--- a/common/postgresql-ng/templates/prometheus-alerts.yaml
+++ b/common/postgresql-ng/templates/prometheus-alerts.yaml
@@ -21,7 +21,7 @@ spec:
           for: 5m
           labels:
             context: secret-rotation
-            playbook: docs/support/playbook/rotate-local-kubernetes-secret
+            playbook: 'https://operations.global.cloud.sap/docs/support/playbook/rotate-local-kubernetes-secret'
             service: {{ quote $service }}
             severity: info
             support_group: {{ quote $sgroup }}
@@ -34,7 +34,7 @@ spec:
           for: 5m
           labels:
             context: secret-rotation
-            playbook: docs/support/playbook/rotate-local-kubernetes-secret
+            playbook: 'https://operations.global.cloud.sap/docs/support/playbook/rotate-local-kubernetes-secret'
             service: {{ quote $service }}
             severity: warning
             support_group: {{ quote $sgroup }}

--- a/common/redis/Chart.yaml
+++ b/common/redis/Chart.yaml
@@ -43,7 +43,4 @@ name: redis
 #   secrets and consuming workloads. See
 #   `.Values.reloader.annotateGeneratedSecrets` and
 #   `.Values.metrics.reloader.enabled`
-#
-# 2.2.10, 2.2.11
-# - Fix reloader.annotateGeneratedSecrets not annotating generated secrets
-version: 2.2.14 # this version number is SemVer as it gets used to auto bump
+version: 2.2.15 # this version number is SemVer as it gets used to auto bump

--- a/common/redis/templates/prometheus-alerts.yaml
+++ b/common/redis/templates/prometheus-alerts.yaml
@@ -21,7 +21,7 @@ spec:
           for: 5m
           labels:
             context: secret-rotation
-            playbook: docs/support/playbook/rotate-local-kubernetes-secret
+            playbook: 'https://operations.global.cloud.sap/docs/support/playbook/rotate-local-kubernetes-secret'
             service: {{ quote $service }}
             severity: info
             support_group: {{ quote $sgroup }}
@@ -34,7 +34,7 @@ spec:
           for: 5m
           labels:
             context: secret-rotation
-            playbook: docs/support/playbook/rotate-local-kubernetes-secret
+            playbook: 'https://operations.global.cloud.sap/docs/support/playbook/rotate-local-kubernetes-secret'
             service: {{ quote $service }}
             severity: warning
             support_group: {{ quote $sgroup }}

--- a/openstack/backup-replication/alerts/backup-replication.alerts
+++ b/openstack/backup-replication/alerts/backup-replication.alerts
@@ -16,7 +16,7 @@ groups:
       support_group: containers
       tier: os
       no_alert_on_absence: "true"
-      playbook: docs/support/playbook/database/db_backup_replication
+      playbook: 'https://operations.global.cloud.sap/docs/support/playbook/database/db_backup_replication'
     annotations:
       description: Database backup failed to replicate from {{ $labels.source_region }} to {{ $labels.region }}.
       summary: Database Backup Replication Failed in {{ $labels.region }}

--- a/openstack/billing/templates/prometheus-alerts.yaml
+++ b/openstack/billing/templates/prometheus-alerts.yaml
@@ -21,7 +21,7 @@ spec:
             support_group: containers
             service: limes
             severity: info
-            playbook: 'docs/support/playbook/unexpected-role-assignments'
+            playbook: 'https://operations.global.cloud.sap/docs/support/playbook/unexpected-role-assignments'
             meta: 'Unexpected role assignments found for Keystone role "cloud_masterdata_admin"'
           annotations:
             summary: 'Unexpected role assignments'
@@ -38,7 +38,7 @@ spec:
             support_group: containers
             service: limes
             severity: info
-            playbook: 'docs/support/playbook/unexpected-role-assignments'
+            playbook: 'https://operations.global.cloud.sap/docs/support/playbook/unexpected-role-assignments'
             meta: 'Unexpected role assignments found for Keystone role "cloud_masterdata_viewer"'
           annotations:
             summary: 'Unexpected role assignments'

--- a/openstack/castellum/alerts/openstack/errors.alerts
+++ b/openstack/castellum/alerts/openstack/errors.alerts
@@ -45,7 +45,7 @@ groups:
         severity: warning
         support_group: containers
         tier: os
-        playbook: 'docs/support/playbook/castellum/missing_database_metrics'
+        playbook: 'https://operations.global.cloud.sap/docs/support/playbook/castellum/missing_database_metrics'
       annotations:
         description: The pgmetrics deployment is not sending all expected metrics.
           Other Castellum alerts may not fire because of missing timeseries.
@@ -102,7 +102,7 @@ groups:
         support_group: containers
         tier: os
         dashboard: castellum
-        playbook: 'docs/support/playbook/castellum/resource_scraping_failing'
+        playbook: 'https://operations.global.cloud.sap/docs/support/playbook/castellum/resource_scraping_failing'
         meta: "Some resource scrapes are failing!"
       annotations:
         description: |
@@ -166,7 +166,7 @@ groups:
         support_group: containers
         tier: os
         dashboard: castellum
-        playbook: 'docs/support/playbook/castellum/asset_scraping_failing'
+        playbook: 'https://operations.global.cloud.sap/docs/support/playbook/castellum/asset_scraping_failing'
         meta: "Some asset scrapes of fresh assets are failing!"
       annotations:
         description: |
@@ -184,7 +184,7 @@ groups:
         support_group: containers
         tier: os
         dashboard: castellum
-        playbook: 'docs/support/playbook/castellum/asset_scraping_failing'
+        playbook: 'https://operations.global.cloud.sap/docs/support/playbook/castellum/asset_scraping_failing'
         meta: "Some asset scrapes of existing assets are failing!"
       annotations:
         description: |
@@ -258,7 +258,7 @@ groups:
         severity: warning
         support_group: containers
         tier: os
-        playbook: 'docs/support/playbook/castellum/asset_resizing_failing'
+        playbook: 'https://operations.global.cloud.sap/docs/support/playbook/castellum/asset_resizing_failing'
         dashboard: castellum
         meta: "Some non-Manila asset resizes are failing!"
       annotations:
@@ -277,7 +277,7 @@ groups:
         severity: warning
         support_group: compute-storage-api
         tier: os
-        playbook: 'docs/support/playbook/castellum/manila_asset_resizing_failing'
+        playbook: 'https://operations.global.cloud.sap/docs/support/playbook/castellum/manila_asset_resizing_failing'
         dashboard: castellum
         meta: "Some Manila asset resizes are failing!"
       annotations:

--- a/openstack/content-repo/alerts/content-repo.alerts
+++ b/openstack/content-repo/alerts/content-repo.alerts
@@ -57,7 +57,7 @@ groups:
       severity: info
       context: repo-{{ $labels.repo }}-entitlement
       meta: "invalid entitlement for {{ $labels.repo }}"
-      playbook: 'docs/support/playbook/repo_rhel_entitlement'
+      playbook: 'https://operations.global.cloud.sap/docs/support/playbook/repo_rhel_entitlement'
     annotations:
       description: Repo {{ $labels.repo }} the entitlement became invalid
       summary: Repo {{ $labels.repo }} entitlement lost

--- a/openstack/keppel/alerts/openstack/api.alerts
+++ b/openstack/keppel/alerts/openstack/api.alerts
@@ -15,7 +15,7 @@ groups:
       support_group: containers
       tier: os
       meta: 'Keppel health check is not reporting success'
-      playbook: docs/support/playbook/keppel/down
+      playbook: 'https://operations.global.cloud.sap/docs/support/playbook/keppel/down'
     annotations:
       summary: Keppel health check is not reporting success.
       description: |

--- a/openstack/keppel/alerts/openstack/roleassignment.alerts
+++ b/openstack/keppel/alerts/openstack/roleassignment.alerts
@@ -14,7 +14,7 @@ groups:
       tier: os
       service: keppel
       severity: info
-      playbook: 'docs/support/playbook/unexpected-role-assignments'
+      playbook: 'https://operations.global.cloud.sap/docs/support/playbook/unexpected-role-assignments'
       meta: 'Unexpected role assignments found for Keystone role "cloud_registry_admin"'
     annotations:
       summary: 'Unexpected role assignments'
@@ -30,7 +30,7 @@ groups:
       tier: os
       service: keppel
       severity: info
-      playbook: 'docs/support/playbook/unexpected-role-assignments'
+      playbook: 'https://operations.global.cloud.sap/docs/support/playbook/unexpected-role-assignments'
       meta: 'Unexpected role assignments found for Keystone role "cloud_registry_viewer"'
     annotations:
       summary: 'Unexpected role assignments'

--- a/openstack/limes/alerts/openstack/api.alerts
+++ b/openstack/limes/alerts/openstack/api.alerts
@@ -104,7 +104,7 @@ groups:
       severity: info
       support_group: '{{ if eq $labels.service_name "cinder" "ironic" "nova" "manila" -}} compute-storage-api {{- else if eq $labels.service_name "archer" "designate" "neutron" "octavia" -}} network-api {{- else if eq $labels.service_name "ceph" "swift" -}} storage {{- else -}} containers {{- end -}}'
       tier: os
-      playbook: docs/support/playbook/limes/alerts/failed_scrapes
+      playbook: 'https://operations.global.cloud.sap/docs/support/playbook/limes/alerts/failed_scrapes'
     annotations:
       description: Limes cannot scrape data from {{ title $labels.service_name }}
         for more than an hour. Please check if {{ title $labels.service_name }} is working.
@@ -121,7 +121,7 @@ groups:
       severity: warning
       support_group: containers
       tier: os
-      playbook: docs/support/playbook/limes/alerts/failed_scrapes
+      playbook: 'https://operations.global.cloud.sap/docs/support/playbook/limes/alerts/failed_scrapes'
     annotations:
       description: Limes cannot scrape data for projects from {{ title $labels.service_name }}
         for more than an hour. Please check if {{ title $labels.service_name }} is working.
@@ -203,7 +203,7 @@ groups:
       service: limes
       context: data-completeness
       meta: "Incomplete project resource data for {{$labels.service}}/{{$labels.resource}}"
-      playbook: docs/support/playbook/limes/alerts/incomplete_project_resource_data
+      playbook: 'https://operations.global.cloud.sap/docs/support/playbook/limes/alerts/incomplete_project_resource_data'
     annotations:
       summary: Incomplete project resource data in Limes DB
       description: Some or all projects are missing an entry in the "project_resources" table for resource
@@ -252,7 +252,7 @@ groups:
       support_group: '{{ $labels.support_group }}'
       tier: os
       service: '{{ $labels.service_name }}'
-      playbook: docs/support/playbook/limes/alerts/non_growing_quota
+      playbook: 'https://operations.global.cloud.sap/docs/support/playbook/limes/alerts/non_growing_quota'
     annotations:
       summary: Non-growing quota almost exhausted
       description: |

--- a/openstack/limes/templates/prometheus-alerts.yaml
+++ b/openstack/limes/templates/prometheus-alerts.yaml
@@ -52,7 +52,7 @@ spec:
             tier: os
             service: limes
             severity: info
-            playbook: 'docs/support/playbook/unexpected-role-assignments'
+            playbook: 'https://operations.global.cloud.sap/docs/support/playbook/unexpected-role-assignments'
             meta: 'Unexpected role assignments found for Keystone role "resource_service"'
           annotations:
             summary: 'Unexpected role assignments'
@@ -69,7 +69,7 @@ spec:
             tier: os
             service: limes
             severity: info
-            playbook: 'docs/support/playbook/unexpected-role-assignments'
+            playbook: 'https://operations.global.cloud.sap/docs/support/playbook/unexpected-role-assignments'
             meta: 'Unexpected role assignments found for Keystone role "cloud_resource_admin"'
           annotations:
             summary: 'Unexpected role assignments'
@@ -86,7 +86,7 @@ spec:
             tier: os
             service: limes
             severity: info
-            playbook: 'docs/support/playbook/unexpected-role-assignments'
+            playbook: 'https://operations.global.cloud.sap/docs/support/playbook/unexpected-role-assignments'
             meta: 'Unexpected role assignments found for Keystone role "cloud_resource_viewer"'
           annotations:
             summary: 'Unexpected role assignments'

--- a/openstack/swift/alerts/openstack/api.alerts
+++ b/openstack/swift/alerts/openstack/api.alerts
@@ -12,7 +12,7 @@ groups:
       service: swift
       severity: info
       support_group: storage
-      playbook: 'docs/operation/storage/swift/swift_health'
+      playbook: 'https://operations.global.cloud.sap/docs/operation/storage/swift/swift_health'
       tier: os
       meta: first byte timing for {{ $labels.type }} in {{ $labels.os_cluster }} increased
     annotations:
@@ -29,7 +29,7 @@ groups:
       service: swift
       severity: warning
       support_group: storage
-      playbook: 'docs/operation/storage/swift/swift_health'
+      playbook: 'https://operations.global.cloud.sap/docs/operation/storage/swift/swift_health'
       tier: os
       meta: 503 responses from Swift in {{ $labels.os_cluster }}
     annotations:
@@ -106,7 +106,7 @@ groups:
       service: swift
       severity: warning
       support_group: storage
-      playbook: 'docs/operation/storage/swift/swift_health'
+      playbook: 'https://operations.global.cloud.sap/docs/operation/storage/swift/swift_health'
       tier: os
       meta: some health checks for Swift are failing
     annotations:
@@ -122,7 +122,7 @@ groups:
       service: swift
       severity: warning
       support_group: storage
-      playbook: 'docs/operation/storage/swift/swift_health'
+      playbook: 'https://operations.global.cloud.sap/docs/operation/storage/swift/swift_health'
       tier: os
       meta: 'Swift dispersion is reporting {{ $value }} errors'
     annotations:
@@ -138,7 +138,7 @@ groups:
       service: swift
       severity: warning
       support_group: storage
-      playbook: 'docs/operation/storage/swift/swift_ring'
+      playbook: 'https://operations.global.cloud.sap/docs/operation/storage/swift/swift_ring'
       tier: os
       meta: Rings are not equal on all Swift nodes
     annotations:
@@ -170,7 +170,7 @@ groups:
       severity: warning
       support_group: storage
       tier: os
-      playbook: 'docs/operation/storage/swift/swift_node_error'
+      playbook: 'https://operations.global.cloud.sap/docs/operation/storage/swift/swift_node_error'
       meta: Swift node {{ $labels.storage_ip }} not reachable
     annotations:
       description: Swift node error. Node with IP {{ $labels.storage_ip }} is not reachable.
@@ -204,7 +204,7 @@ groups:
       support_group: storage
       tier: metal
       meta: '{{ $value }} Swift drive failures'
-      playbook: 'docs/operation/storage/swift/swift_broken_disks'
+      playbook: 'https://operations.global.cloud.sap/docs/operation/storage/swift/swift_broken_disks'
     annotations:
       description: Swift drive failures. Run swift-recon --driveaudit to get details
       summary: swift disk failures on the server IP {{ $labels.storage_ip }}

--- a/openstack/swift/templates/prometheus-alerts.yaml
+++ b/openstack/swift/templates/prometheus-alerts.yaml
@@ -55,7 +55,7 @@ spec:
           tier: os
           service: swift
           severity: info
-          playbook: 'docs/support/playbook/unexpected-role-assignments'
+          playbook: 'https://operations.global.cloud.sap/docs/support/playbook/unexpected-role-assignments'
           meta: 'Unexpected role assignments found for Keystone role "cloud_objectstore_admin"'
         annotations:
           summary: 'Unexpected role assignments'
@@ -73,7 +73,7 @@ spec:
           tier: os
           service: swift
           severity: info
-          playbook: 'docs/support/playbook/unexpected-role-assignments'
+          playbook: 'https://operations.global.cloud.sap/docs/support/playbook/unexpected-role-assignments'
           meta: 'Unexpected role assignments found for Keystone role "cloud_objectstore_viewer"'
         annotations:
           summary: 'Unexpected role assignments'


### PR DESCRIPTION
This is split from #9446 because that PR has an extremely large set of code owners, so merging it seems very unlikely. This commit touches only the alerts that my workgroup can approve.

Also, #9446 missed several playbook links in our charts.

Also also, clean up some irrelevant changelog entries in library charts. (The changelogs there are only for significant changes, not every random bugfix.)