### PR TITLE
[cinder] Make nanny alerts report to correct prometheus instance

### DIFF
--- a/openstack/cinder/alerts/kubernetes/cinder.alerts
+++ b/openstack/cinder/alerts/kubernetes/cinder.alerts
@@ -1,51 +1,7 @@
 groups:
-- name: openstack-cinder.alerts
+- name: kubernetes-cinder.alerts
   rules:
-  - alert: OpenstackCinderVolumeInDeletingState
-    expr: count(sum(openstack_stuck_volumes_max_duration_gauge{status="deleting"}) BY (id,display_name) > 120) by (id, display_name)
-    for: 5m
-    labels:
-      dashboard: cinder
-      meta: 'Volume {{ $labels.display_name }} in Deleting state since {{ $value }}s'
-      playbook: docs/support/playbook/volumes
-      support_group: compute-storage-api
-      service: cinder
-      severity: info
-      tier: os
-    annotations:
-      description: Volume {{ $labels.display_name }} with {{ $labels.id }} in Deleting State
-      summary: Cinder Volumes taking more than 2 minutes to delete
-
-  - alert: OpenstackCinderVolumeInAttachingState
-    expr: count(sum(openstack_stuck_volumes_max_duration_gauge{status="attaching"}) BY (id,display_name) > 3600) by (id, display_name)
-    for: 5m
-    labels:
-      dashboard: cinder
-      meta: 'Volume {{ $labels.display_name }} in Attaching state since {{ $value }}s'
-      playbook: docs/support/playbook/cinder/cinder_attaching_stuck
-      support_group: compute-storage-api
-      service: cinder
-      severity: warning
-      tier: os
-    annotations:
-      description: Volume {{ $labels.display_name }} with {{ $labels.id }} in Attaching State
-      summary: Cinder Volumes taking more than 1 hour to attach
-
-  - alert: OpenstackCinderVolumeInDetachingState
-    expr: count(sum(openstack_stuck_volumes_max_duration_gauge{status="detaching"}) BY (id,display_name) > 15) by (id, display_name)
-    for: 5m
-    labels:
-      dashboard: cinder
-      meta: 'Volume {{ $labels.display_name }} in Detaching state since {{ $value }}s'
-      playbook: docs/support/playbook/volumes
-      support_group: compute-storage-api
-      service: cinder
-      severity: info
-      tier: os
-    annotations:
-      description: Volume {{ $labels.display_name }} with {{ $labels.id }} in Detaching State
-      summary: Cinder Volumes taking more than 15s to detach
-
+  
   - alert: OpenstackCinderNannyCronjobNotCompleting
     # This is a copy of [Sebastian Krott's](https://github.com/seb-kro) 
     # [nova nanny alert](https://github.com/sapcc/helm-charts/commit/b9cfda5fa068221c19d56d7d34e2bcbf50e214da).

--- a/openstack/cinder/alerts/openstack/cinder.alerts
+++ b/openstack/cinder/alerts/openstack/cinder.alerts
@@ -1,0 +1,48 @@
+groups:
+- name: openstack-cinder.alerts
+  rules:
+  
+  - alert: OpenstackCinderVolumeInDeletingState
+    expr: count(sum(openstack_stuck_volumes_max_duration_gauge{status="deleting"}) BY (id,display_name) > 120) by (id, display_name)
+    for: 5m
+    labels:
+      dashboard: cinder
+      meta: 'Volume {{ $labels.display_name }} in Deleting state since {{ $value }}s'
+      playbook: docs/support/playbook/volumes
+      support_group: compute-storage-api
+      service: cinder
+      severity: info
+      tier: os
+    annotations:
+      description: Volume {{ $labels.display_name }} with {{ $labels.id }} in Deleting State
+      summary: Cinder Volumes taking more than 2 minutes to delete
+
+  - alert: OpenstackCinderVolumeInAttachingState
+    expr: count(sum(openstack_stuck_volumes_max_duration_gauge{status="attaching"}) BY (id,display_name) > 3600) by (id, display_name)
+    for: 5m
+    labels:
+      dashboard: cinder
+      meta: 'Volume {{ $labels.display_name }} in Attaching state since {{ $value }}s'
+      playbook: docs/support/playbook/cinder/cinder_attaching_stuck
+      support_group: compute-storage-api
+      service: cinder
+      severity: warning
+      tier: os
+    annotations:
+      description: Volume {{ $labels.display_name }} with {{ $labels.id }} in Attaching State
+      summary: Cinder Volumes taking more than 1 hour to attach
+
+  - alert: OpenstackCinderVolumeInDetachingState
+    expr: count(sum(openstack_stuck_volumes_max_duration_gauge{status="detaching"}) BY (id,display_name) > 15) by (id, display_name)
+    for: 5m
+    labels:
+      dashboard: cinder
+      meta: 'Volume {{ $labels.display_name }} in Detaching state since {{ $value }}s'
+      playbook: docs/support/playbook/volumes
+      support_group: compute-storage-api
+      service: cinder
+      severity: info
+      tier: os
+    annotations:
+      description: Volume {{ $labels.display_name }} with {{ $labels.id }} in Detaching State
+      summary: Cinder Volumes taking more than 15s to detach

--- a/openstack/cinder/templates/prometheus-alerts.yaml
+++ b/openstack/cinder/templates/prometheus-alerts.yaml
@@ -1,6 +1,7 @@
 {{- $values := .Values }}
 {{- if $values.alerts.enabled }}
-{{- range $path, $bytes := .Files.Glob "alerts/*.alerts" }}
+{{- range $target := list "kubernetes" "openstack" }}
+{{- range $path, $bytes := $.Files.Glob (printf "alerts/%s/*.alerts" $target) }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
@@ -11,10 +12,11 @@ metadata:
     app: cinder
     tier: os
     type: alerting-rules
-    prometheus: {{ required ".Values.alerts.prometheus missing" $values.alerts.prometheus }}
+    prometheus: {{ $target }}
 
 spec:
 {{ printf "%s" $bytes | indent 2 }}
 
+{{- end }}
 {{- end }}
 {{- end }}

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -454,7 +454,8 @@ watcher:
 # Deploy Cinder Prometheus alerts.
 alerts:
   enabled: true
-  # Name of the Prometheus to which the alerts should be assigned to.
+  # Used for annotation (prometheus.io/targets) value to route metric
+  # scraping to the correct prometheus instance
   prometheus: openstack
 
 cors:


### PR DESCRIPTION
Added subdirectories to cinder/alerts directory that correspond to the respective prometheus instance. E.g. Alerts in cinder/alerts/kubernetes use the kubernetes prometheus instance.