### PR TITLE
[netapp-metrics-federation] fix matching labels are not unique in remote snapmirror query

### DIFF
--- a/prometheus-exporters/netapp-exporter/charts/netapp-metrics-federation/templates/configmap.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-metrics-federation/templates/configmap.yaml
@@ -10,7 +10,7 @@ data:
       - export_name: netapp_snapmirror_labels:remotebkp
         query: |
           netapp_snapmirror_endpoint_labels:enhanced{region="{{ .Values.global.region }}", project_id!="", share_id!=""}
-            * on(source_cluster, source_vserver, source_volume, destination_cluster, destination_vserver, destination_volume)
+            * on(relationship_id)
             group_right(project_id, share_id, share_name) netapp_snapmirror_labels:enhanced{share_id=""}
         label_rules:
         - type: fill


### PR DESCRIPTION
Use relationship_id as the matching labels. The query is broken for some
special test cases, where the group of source/destination labels are not
unique.
