### PR TITLE
[greenhouse-ccloud] - Updated kvm-monitoring pluginpreset with kvm support_group 

### DIFF
--- a/system/greenhouse-ccloud/Chart.yaml
+++ b/system/greenhouse-ccloud/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: ccloud
 description: A Helm chart for the CCloud organization in Greenhouse.
 type: application
-version: 1.26.3
+version: 1.26.4

--- a/system/greenhouse-ccloud/templates/kvm-monitoring-pluginpreset.yaml
+++ b/system/greenhouse-ccloud/templates/kvm-monitoring-pluginpreset.yaml
@@ -24,5 +24,5 @@ spec:
         value:
           service: kvm
           # Uncoment this to fire alerts to the slack compute slack channels 
-          # support_group: "compute"
+          support_group: "kvm"
 {{- end -}}


### PR DESCRIPTION
Added `support_group`: `kvm` to prometheus.AlertLabels to match slack routing.

**Old Slack channels:**
- `#alert-kvm-test`

**Slack channels:**
- `#alert-kvm-info`
- `#alert-kvm-warning`
- `#alert-kvm-critical`

Ref. https://github.com/sapcc/helm-charts/pull/9453