### PR TITLE
[octavia] increase memory limit for octavia-worker

### DIFF
--- a/openstack/octavia/Chart.yaml
+++ b/openstack/octavia/Chart.yaml
@@ -9,7 +9,7 @@ sources:
   - https://git.openstack.org/cgit/openstack/octavia
   - https://git.openstack.org/cgit/openstack/openstack-helm
 # The versions are defined in the changelog: https://docs.openstack.org/releasenotes/octavia/yoga.html
-version: 10.1.3
+version: 10.1.4
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -312,7 +312,7 @@ pod:
         cpu: 50m
     worker:
       limits:
-        memory: 512Mi
+        memory: 1024Mi
         cpu: 1000m
       requests:
         memory: 256Mi


### PR DESCRIPTION
Double memory limit for octavia-worker container based on the current usage being close to 90-100% of the active limit in some regions.