### PR TITLE
[neutron-netns-prober] update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -152,6 +152,7 @@
 /prometheus-exporters/masterdata-exporter              @databus23
 /prometheus-exporters/netapp-exporter                  @chuan137 @Carthaca @kpawar-sap @sumitarora2786 @crenduchinta88 @hvr999 @RockSolidScripts
 /prometheus-exporters/network-generic-ssh-exporter     @swagner-de @Kuckkuck @geisslet @timojohlo
+/prometheus-exporters/neutron-netns-prober             @sapcc/network-api-contributors
 /prometheus-exporters/nfs-exporter                     @auhlig  # old
 /prometheus-exporters/ns-exporter                      @databus23 @sapcc/network-api-contributors
 /prometheus-exporters/ntp-exporter                     @majewsky @SuperSandro2000 @VoigtS @wagnerd3 @Nuckal777


### PR DESCRIPTION
We introduce this chart to begin the replacement of the ns-exporter.