### PR TITLE
[neutron-netns-prober] provide initial chart

### DIFF
--- a/prometheus-exporters/neutron-netns-prober/Chart.lock
+++ b/prometheus-exporters/neutron-netns-prober/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: owner-info
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 0.2.0
+digest: sha256:9948b42a49d86cee17b76e5d46a5677e70bf3feb9ff2a9c34691a6f82ee751db
+generated: "2025-08-08T09:42:34.165357+02:00"

--- a/prometheus-exporters/neutron-netns-prober/Chart.yaml
+++ b/prometheus-exporters/neutron-netns-prober/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+description: A prober to test connectivity from within OpenStack Neutron's network namespaces
+name: neutron-netns-prober
+version: 1.0.0
+dependencies:
+- name: owner-info
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 0.2.0

--- a/prometheus-exporters/neutron-netns-prober/alerts/probe.alerts
+++ b/prometheus-exporters/neutron-netns-prober/alerts/probe.alerts
@@ -1,0 +1,40 @@
+groups:
+- name: neutron-netns-prober.alerts
+  rules:
+  - alert: NeutronNetworkNamespaceProbesFailed
+    expr: |
+            (
+              sum(changes(neutron_netns_prober_failure_total[5m])) by (network_id, network_name, region, router_id) > 0
+              and on (network_id) neutron_netns_prober_network_age_seconds > 3600
+              and on (router_id) neutron_netns_prober_router_age_seconds > 3600
+            ) unless (
+              sum(changes(neutron_netns_prober_success_total[150s])) by (network_id, network_name, region, router_id) > 0
+              and on (network_id) neutron_netns_prober_network_age_seconds > 3600
+              and on (router_id) neutron_netns_prober_router_age_seconds > 3600
+            )
+    for: 5m
+    labels:
+      context: availability
+      service: neutron-hidden
+      severity: critical
+      support_group: network-api
+      tier: os
+      playbook: 'docs/support/playbook/neutron/networknamespaceprobesfailed'
+      meta: 'Network {{ $labels.network_name }} failed all probes'
+      cloudops: "?searchTerm={{ $labels.network_id }}&type=network"
+    annotations:
+      description: 'The network `{{ $labels.network_name }} ({{ $labels.network_id }})` failed all DNS probes for more than 5 minutes. (<https://dashboard.{{ $externalLabels.region }}.cloud.sap/ccadmin/cloud_admin/cloudops#/universal-search/?searchTerm={{ $labels.router_id }}&type=router|Router {{ $labels.router_id }}>). Please run ```hammer -r {{ $externalLabels.region }} net check {{ $labels.network_id }}``` and post it on the alert Slack thread.'
+      summary: Network probes failed
+  - alert: NeutronNetworkNamespaceProbeMetricsMissing
+    expr: absent(neutron_netns_prober_success_total)
+    for: 10m
+    labels:
+      context: availability
+      service: neutron-hidden
+      severity: warning
+      support_group: network-api
+      tier: os
+      meta: 'Metrics for the namespace prober are missing'
+    annotations:
+      description: 'The metrics from the neutron-neutwork-namespace prober are missing. This suggests there is a problem with its deployment. Check the neutron-netns-prober namespace for running pods.'
+      summary: Metrics for namespace prober are missing

--- a/prometheus-exporters/neutron-netns-prober/ci/test-values.yaml
+++ b/prometheus-exporters/neutron-netns-prober/ci/test-values.yaml
@@ -1,0 +1,8 @@
+global:
+  registry: keppel.registry.url/account
+
+image:
+  tag: "abc123"
+
+authURL: https://identity.evil.corp:5000/v3
+password: topSecret

--- a/prometheus-exporters/neutron-netns-prober/templates/daemonset.yaml
+++ b/prometheus-exporters/neutron-netns-prober/templates/daemonset.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: neutron-netns-prober
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  name: neutron-netns-prober
+spec:
+  revisionHistoryLimit: 3
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: neutron-netns-prober
+  template:
+    metadata:
+      labels:
+        app: neutron-netns-prober
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: {{ required ".Values.metrics.port missing" .Values.metrics.port | quote }}
+        prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
+      name: neutron-netns-prober
+    spec:
+      hostPID: true
+      containers:
+      - image: "{{ required ".Values.global.registry missing" .Values.global.registry }}/ns-exporter:{{ required ".Values.image.tag missing" .Values.image.tag }}"
+        args:
+          - -concurrency={{ default 1  .Values.concurrency }}
+          - -interval={{ default "1m" .Values.interval }}
+        ports:
+        - containerPort: {{ required ".Values.metrics.port missing" .Values.metrics.port }}
+          name: metrics
+          protocol: TCP
+        env:
+          - name: OS_AUTH_URL
+            value: {{ required ".Values.authURL missing" .Values.authURL }}
+          - name: OS_USERNAME
+            value: {{ .Values.username }}
+          - name: OS_DOMAIN_NAME
+            value: {{ .Values.userDomainName }}
+          - name: OS_PROJECT_NAME
+            value: {{ .Values.projectName }}
+          - name: OS_PROJECT_DOMAIN_NAME
+            value: {{ .Values.projectDomainName }}
+          - name: OS_PASSWORD
+            valueFrom: { secretKeyRef:    { name: neutron-netns-prober, key: password } }
+        imagePullPolicy: IfNotPresent
+        name: prober
+        securityContext:
+          privileged: true
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+      {{- end }}

--- a/prometheus-exporters/neutron-netns-prober/templates/prometheus-alerts.yaml
+++ b/prometheus-exporters/neutron-netns-prober/templates/prometheus-alerts.yaml
@@ -1,0 +1,18 @@
+{{- $values := .Values }}
+{{- if $values.alerts.enabled }}
+{{- range $path, $bytes := .Files.Glob "alerts/*.alerts" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: {{ printf "neutron-netns-prober-%s" $path | replace "/" "-" }}
+  labels:
+    app: neutron-netns-prober
+    prometheus: {{ required ".Values.alerts.prometheus missing" $values.alerts.prometheus }}
+
+spec:
+{{ printf "%s" $bytes | indent 2 }}
+
+{{- end }}
+{{- end }}

--- a/prometheus-exporters/neutron-netns-prober/templates/secret.yaml
+++ b/prometheus-exporters/neutron-netns-prober/templates/secret.yaml
@@ -1,0 +1,9 @@
+kind: Secret
+apiVersion: v1
+
+metadata:
+  name: neutron-netns-prober
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+data:
+  password: {{ required ".Values.password missing" .Values.password | b64enc }}

--- a/prometheus-exporters/neutron-netns-prober/templates/seed.yaml
+++ b/prometheus-exporters/neutron-netns-prober/templates/seed.yaml
@@ -1,0 +1,23 @@
+apiVersion: "openstack.stable.sap.cc/v1"
+kind: "OpenstackSeed"
+metadata:
+  name: neutron-netns-prober-seed
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+spec:
+  requires:
+    - monsoon3/domain-default-seed
+    - monsoon3/domain-ccadmin-seed
+
+  roles:
+    - name: cloud_network_admin
+
+  domains:
+    - name: {{ required ".Values.userDomainName" .Values.userDomainName }}
+      users:
+        - name: {{ required ".Values.username missing" .Values.username | quote }}
+          description: 'Neutron network namespace prober'
+          password: {{ required ".Values.password missing" .Values.password | quote }}
+          role_assignments:
+            - project: {{ required ".Values.projectName missing" .Values.projectName }}@{{ required ".Values.projectDomainName" .Values.projectDomainName }}
+              role: cloud_network_admin

--- a/prometheus-exporters/neutron-netns-prober/values.yaml
+++ b/prometheus-exporters/neutron-netns-prober/values.yaml
@@ -1,0 +1,32 @@
+# global:
+#   registry: DEFINED_IN_VALUES_FILE
+
+# image:
+#   tag: DEFINED_BY_PIPELINE
+
+owner-info:
+  support-group: REPLACE_ME
+  helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/prometheus-exporter/neutron-netns-prober
+
+concurrency: 1
+interval: "1m"
+
+#authURL:
+username: REPLACE_ME
+userDomainName: REPLACE_ME
+#password:
+projectName: REPLACE_ME
+projectDomainName: REPLACE_ME
+
+metrics:
+  port: 9191
+
+# Enable Prometheus alerts for the metrics collected by the prober
+alerts:
+  enabled: true
+  # Name of the Prometheus to which the alerts should be assigned to
+  prometheus: REPLACE_ME
+
+nodeSelector: {}
+
+tolerations: []


### PR DESCRIPTION
* We introduce this chart as a replacement for ns-exporter (for now it is essentially a copy of this chart). The new version of the "ns-exporter" binary introduces breaking changes affecting our monitoring and alerting. For example: we use a different naming scheme for some alerts and as a consequence some of these alerts would not reach the incident management system.
* We will use this new chart to deploy and validate newer versions of the ns-exporter without interfering with the current deployment.
* We opt for a new chart to make the relation to neutron more explicitly in the name.  There will we a follow up to remove all artifacts related to ns-exporter once the shift is completed.