### PR TITLE
Update gatekeeper policies to allow neutron-netns-prober

### DIFF
--- a/system/gatekeeper/templates/constrainttemplate-pod-security.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-pod-security.yaml
@@ -606,6 +606,29 @@ spec:
               }
 
               ########################################################################
+              # allowlist for neutron-netns-prober
+
+              {{- if eq .Values.cluster_type "baremetal" "test" }}
+              default isNeutronNetnsProberPod := false
+              isNeutronNetnsProberPod if {
+                  iro.kind == "DaemonSet"
+                  iro.metadata.namespace == "neutron-netns-prober"
+                  iro.metadata.name == "neutron-netns-prober"
+                  helmReleaseName == "neutron-netns-prober"
+              }
+
+              # The neutron-netns-prober needs to reach into all network namespaces.
+              isPodAllowedToUseHostPID if {
+                  isNeutronNetnsProberPod
+              }
+
+              isContainerAllowedToBePrivileged(container) if {
+                  isNeutronNetnsProberPod
+                  container.name == "prober"
+              }
+              {{- end }}
+
+              ########################################################################
               # allowlist for neutron-network-agent
 
               {{- if eq .Values.cluster_type "baremetal" "test" }}

--- a/system/gatekeeper/tests/gatekeeper-policies/fixtures/pod-security/neutron-netns-prober.yaml
+++ b/system/gatekeeper/tests/gatekeeper-policies/fixtures/pod-security/neutron-netns-prober.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  annotations:
+    meta.helm.sh/release-name: neutron-netns-prober
+    meta.helm.sh/release-namespace: neutron-netns-prober
+  labels:
+    app.kubernetes.io/managed-by: Helm
+  name: neutron-netns-prober
+  namespace: neutron-netns-prober
+spec:
+  template:
+    spec:
+      containers:
+      - name: prober
+        securityContext:
+          privileged: true
+      hostPID: true
+      securityContext: {}

--- a/system/gatekeeper/tests/gatekeeper-policies/suite.yaml
+++ b/system/gatekeeper/tests/gatekeeper-policies/suite.yaml
@@ -477,6 +477,10 @@ tests:
     object: fixtures/pod-security/logs-fluent-systemd.yaml
     assertions:
     - violations: no
+  - name: pod-security-accept-neutron-netns-prober
+    object: fixtures/pod-security/neutron-netns-prober.yaml
+    assertions:
+    - violations: no
   - name: pod-security-accept-neutron-network-agent
     object: fixtures/pod-security/neutron-network-agent.yaml
     assertions:
@@ -570,7 +574,7 @@ tests:
   - name: pod-security-v2-allow-host-network
     object: fixtures/pod-security-v2/host-network-allow.yaml
     assertions:
-    - violations: no  
+    - violations: no
   - name: pod-security-v2-reject-host-pid
     object: fixtures/pod-security-v2/host-pid-reject.yaml
     assertions:
@@ -626,7 +630,7 @@ tests:
   - name: pod-security-v2-allow-capabilities
     object: fixtures/pod-security-v2/capabilities-allow.yaml
     assertions:
-    - violations: no 
+    - violations: no
   - name: pod-security-v2-reject-host-path-volumes-r
     object: fixtures/pod-security-v2/host-path-volumes-reject-r.yaml
     assertions:


### PR DESCRIPTION
The neutron-netns-prober is a replacement for the ns-exporter. It needs to access network namespaces created by the neutron dhcp agents and run probes from there, e.g., pings and DNS queries. Thus, it requires 1) to be deployed on the same nodes where these agents run, and 2) run with privileged access to realize its function.