### PR TITLE
[bind] introducing tsig/rndc/nsi secret path templating

### DIFF
--- a/system/bind/templates/etc/_nsi.key.tpl
+++ b/system/bind/templates/etc/_nsi.key.tpl
@@ -1,4 +1,4 @@
 key "nsi-key" {
     algorithm hmac-sha512;
-    secret "{{ .Values.nsi_key | include "resolve_secret" }}";
+    secret {{ tpl $.Values.nsi_key $ | include "resolve_secret" | quote }};
 };

--- a/system/bind/templates/etc/_rndc.key.tpl
+++ b/system/bind/templates/etc/_rndc.key.tpl
@@ -1,4 +1,4 @@
-key "{{ .Values.rndc_key_name | default "rndc-key" }}" {
-    algorithm "{{ .Values.rndc_key_algorithm | default "hmac-md5" }}";
-    secret "{{ .Values.rndc_key | include "resolve_secret" }}";
+key {{ $.Values.rndc_key_name | default "rndc-key" | quote }} {
+    algorithm {{ $.Values.rndc_key_algorithm | default "hmac-md5" | quote }};
+    secret {{ tpl $.Values.rndc_key $ | include "resolve_secret" | quote }};
 };

--- a/system/bind/templates/etc/_tsig.key.tpl
+++ b/system/bind/templates/etc/_tsig.key.tpl
@@ -1,4 +1,4 @@
 key "tsig-key" {
     algorithm hmac-md5;
-    secret "{{ .Values.tsig_key | include "resolve_secret" }}";
+    secret {{ tpl $.Values.tsig_key $ | include "resolve_secret" | quote }};
 };


### PR DESCRIPTION
now we can use a global value like:
```rndc_key: "vault+kvv2:///secrets/{{ $.Values.global.region }}/bind/rndc-key/default/key"```