### PR TITLE
[prometheus-alertmanager-operated] - Removed unused alertrouting for alert-bedrock-info

### DIFF
--- a/global/prometheus-alertmanager-operated/Chart.yaml
+++ b/global/prometheus-alertmanager-operated/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 description: Prometheus Alertmanager via operator.
 name: prometheus-alertmanager-operated
-version: 4.7.3
+version: 4.7.4
 
 dependencies:
   - alias: prometheus-alertmanager

--- a/global/prometheus-alertmanager-operated/templates/am-config-route-slack.yaml
+++ b/global/prometheus-alertmanager-operated/templates/am-config-route-slack.yaml
@@ -541,25 +541,6 @@ spec:
           - name: bedrock
             matchType: "="
             value: "true"
-
-      - receiver: slack_bedrock_info
-        continue: true
-        matchers:
-          - name: severity
-            matchType: "="
-            value: info
-          - name: region
-            matchType: "=~"
-            value: {{ .Values.regions | join "|" }}
-          # Removed for testing purpose
-          #   value: {{ without .Values.regions "qa-de-1" | join "|" }}
-          - name: support_group
-            matchType: "="
-            value: compute
-          - name: bedrock
-            matchType: "="
-            value: "true"
-
   receivers:
     - name: slack
 


### PR DESCRIPTION
Removed unused alertrouting `#alert-bedrock-info`

Resolves:
```time=2025-08-12T12:32:52.943Z level=ERROR source=dispatch.go:360 msg="Notify for alerts failed" component=dispatcher num_alerts=1 err="prometheus-alertmanager/route-slack/slack_bedrock_info/slack[0]: notify retry canceled due to unrecoverable error after 1 attempts: channel \"#alert-bedrock-info\": unexpected status c```