### PR TITLE
[bind] set the service externalIPs only if defined

### DIFF
--- a/system/bind/templates/service.yaml
+++ b/system/bind/templates/service.yaml
@@ -43,4 +43,6 @@ spec:
       port: {{ .Values.sshd.sixc.port | default 5487 }}
       targetPort: sshd-6c-tcp
 {{ end }}
+{{ if .Values.externalIP }}
   externalIPs: ["{{.Values.externalIP}}"]
+{{ end }}


### PR DESCRIPTION
There might be situation where we do not have (yet) an IP. We still want to be able to deploy.