### PR TITLE
disable rate limit for moonson3/ml-benchmarks to barbican whitelist

### DIFF
--- a/openstack/barbican/templates/etc/_ratelimit.yaml.tpl
+++ b/openstack/barbican/templates/etc/_ratelimit.yaml.tpl
@@ -2,6 +2,7 @@
 whitelist:
   - Default/service
   - monsoon3/cc-demo
+  - monsoon3/ml-benchmarks
 
 whitelist_users:
   - TS4_S4_SMTP_01


### PR DESCRIPTION
we need to disable the rate limit to test SSE Barbican cache on Ceph RGW side