### PR TITLE
feat(alerts): add other category to predefined region filters

### DIFF
--- a/system/greenhouse-ccloud/values.yaml
+++ b/system/greenhouse-ccloud/values.yaml
@@ -58,11 +58,11 @@ alerts:
     - name: "prod"
       displayName: "Prod"
       matchers:
-        region:  "^(ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|ap-sa-2|ap-sg-1|eu-de-1|eu-de-2|eu-de-3|eu-nl-1|la-br-1|na-ca-1|na-us-1|na-us-2|na-us-3)$"
+        region: "^(ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|ap-sa-2|ap-sg-1|eu-de-1|eu-de-2|eu-de-3|eu-nl-1|la-br-1|na-ca-1|na-us-1|na-us-2|na-us-3)$"
     - name: "prod-qa"
       displayName: "Prod + QA"
       matchers:
-        region: "^(ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|ap-sa-2|ap-sg-1|eu-de-1|eu-de-2|eu-nl-1|la-br-1|na-ca-1|na-us-1|na-us-2|na-us-3|qa-de-1)$"
+        region: "^(ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|ap-sa-2|ap-sg-1|eu-de-1|eu-de-2|eu-de-3|eu-nl-1|la-br-1|na-ca-1|na-us-1|na-us-2|na-us-3|qa-de-1)$"
     - name: "labs"
       displayName: "Labs"
       matchers:
@@ -70,7 +70,7 @@ alerts:
     - name: "other"
       displayName: "Other"
       matchers:
-        region: "^(?!(ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|ap-sa-2|ap-sg-1|eu-de-1|eu-de-2|eu-nl-1|la-br-1|na-ca-1|na-us-1|na-us-2|na-us-3|qa-de-1|qa-de-(?!1$)\\d+)$).*"
+        region: "^(?!(ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|ap-sa-2|ap-sg-1|eu-de-1|eu-de-2|eu-de-3|eu-nl-1|la-br-1|na-ca-1|na-us-1|na-us-2|na-us-3|qa-de-1|qa-de-(?!1$)\\d+)$).*"
     - name: "all"
       displayName: "All"
       matchers:


### PR DESCRIPTION
## Problem description

People misuse region labels on new clusters and add nonsensical region labels. This PR proposes a fix for Supernova which ensures that non-standard regions don't clutter the alerts views.

## Proposed fix

This PR adjusts the existing predefined filter categories for "Prod" and "Prod+QA" to match exactly only our prod or prod and qa regions. Additionally it adds a new category "other" which acts as a dump group for everything that doesn't match real regions.

## Screenshots
<img width="1546" height="436" alt="Screenshot 2025-08-15 at 14 12 31" src="https://github.com/user-attachments/assets/6adba46b-5baa-4542-b5a4-6dc8a01667a0" />
<img width="1540" height="491" alt="Screenshot 2025-08-15 at 14 12 48" src="https://github.com/user-attachments/assets/fda886c4-253d-4dd1-a335-6ed47f8698a9" />
