### PR TITLE
Adjust MetalRedfishCertInfo to count

### DIFF
--- a/prometheus-exporters/redfish-exporter/alerts/metal-redfish.alerts
+++ b/prometheus-exporters/redfish-exporter/alerts/metal-redfish.alerts
@@ -40,7 +40,7 @@ groups:
       service: baremetal
       support_group: foundation
       context: "{{ $labels.host }}"
-      meta: "The certificates of {{ $value }} the Remote Boards in region {{ $labels.region }} will expire or are already expired."
+      meta: "The certificates of the Remote Boards in region {{ $labels.region }} will expire or are already expired."
     annotations:
-      description: "The certificates of {{ $value }} the Remote Boards in region {{ $labels.region }} will expire or are already expired."
-      summary: "Count Remote Board Certificate expiration for servers in {{ $labels.region }}."
+      description: "Remote Board certificates are expired or will expire less than 10 days. Affected Remote Boards: {{ $value }}"
+      summary: "Remote Board Certificates are expired. in {{ $labels.region }}."


### PR DESCRIPTION
Count the BMCs with a outdated certificate instead of creating a alert per node so the alert number is lower. The information which nodes are affected can still be access by just removing the first count. Should decrease the load on the monitoring.