### PR TITLE
[Cinder] update the name access for ratelimit

### DIFF
--- a/openstack/cinder/templates/api-deployment.yaml
+++ b/openstack/cinder/templates/api-deployment.yaml
@@ -183,7 +183,7 @@ spec:
         {{- if .Values.api_rate_limit.enabled }}
         - name: redis-ratelimit-secret
           secret:
-            secretName: ratelimit-backend-secret.conf
+            secretName: cinder-api-ratelimit-secret
         {{- end }}
 
 


### PR DESCRIPTION
This updates the name of the api deployment access to the ratelimit secret.