### PR TITLE
[neutron] bump shared dependencies to allow db and rabbit user deletion

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.26.1
+  version: 0.27.1
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.4.0
@@ -13,10 +13,10 @@ dependencies:
   version: 0.5.2
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.18.8
+  version: 0.19.1
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.28.0
+  version: 0.29.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
@@ -32,5 +32,5 @@ dependencies:
 - name: ovsdb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
-digest: sha256:762ba6bbd79d57dccb80a5ff3874aa68ccb1d78cba2d6310de0e5226ab5ba22e
-generated: "2025-08-01T14:18:21.539808+03:00"
+digest: sha256:5f11cdf2ba578f6e19dd3df6bdbefa38a3a2a32d25c0ff8c6d561ccd114e782d
+generated: "2025-08-20T15:03:13.556742+03:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -2,13 +2,13 @@
 apiVersion: v2
 description: A Helm chart for Openstack Neutron
 name: neutron
-version: 0.3.1
+version: 0.3.2
 appVersion: "caracal"
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.26.1
+    version: 0.27.1
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db
@@ -23,10 +23,10 @@ dependencies:
     version: 0.5.2
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.18.8
+    version: 0.19.1
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.28.0
+    version: 0.29.0
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0


### PR DESCRIPTION
Bump shared dependencies to allow MariaDB and RabbitMQ deletion.

* Bump mariadb chart to 0.27.1
  - updates mariadb to 10.11.14
  - enables userstat metrics `mysql_info_schema_user_statistics_*`

* Bump rabbitmq chart to 0.19.1
  - updates rabbitmq to 4.1.3

* Bump utils chart to 0.29.0
  - removes deleted users from proxysql sidecar config