### PR TITLE
neutron-netns-prober: add username to secret

### DIFF
--- a/prometheus-exporters/neutron-netns-prober/templates/daemonset.yaml
+++ b/prometheus-exporters/neutron-netns-prober/templates/daemonset.yaml
@@ -35,8 +35,6 @@ spec:
         env:
           - name: OS_AUTH_URL
             value: {{ required ".Values.authURL missing" .Values.authURL }}
-          - name: OS_USERNAME
-            value: {{ .Values.username }}
           - name: OS_DOMAIN_NAME
             value: {{ .Values.userDomainName }}
           - name: OS_PROJECT_NAME
@@ -45,6 +43,8 @@ spec:
             value: {{ .Values.projectDomainName }}
           - name: OS_PASSWORD
             valueFrom: { secretKeyRef:    { name: neutron-netns-prober, key: password } }
+          - name: OS_USERNAME
+            valueFrom: { secretKeyRef:    { name: neutron-netns-prober, key: username } }
         imagePullPolicy: IfNotPresent
         name: prober
         securityContext:

--- a/prometheus-exporters/neutron-netns-prober/templates/secret.yaml
+++ b/prometheus-exporters/neutron-netns-prober/templates/secret.yaml
@@ -7,3 +7,4 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 data:
   password: {{ required ".Values.password missing" .Values.password | b64enc }}
+  username: {{ required ".Values.username missing" .Values.username | b64enc }}


### PR DESCRIPTION
Adding the user to the secret facilitates the rotation of credentials.