### PR TITLE
keppel/swift: do not autoscale keep-image-pulled daemonsets

### DIFF
--- a/openstack/keppel/templates/daemonset-keep-image-pulled.yaml
+++ b/openstack/keppel/templates/daemonset-keep-image-pulled.yaml
@@ -8,12 +8,17 @@
 # The condition above skips this daemonset on QA and lab regions, because high
 # availability is not a concern there. By omitting the daemonset there, the
 # Helm deployment will finish faster since it does not have to wait on it.
+# This also avoids wasting resources in small lab clusters.
 
 kind: DaemonSet
 apiVersion: apps/v1
 
 metadata:
   name: keep-image-pulled
+  annotations:
+    # This pod intentionally has extremely tight resource requests.
+    # The VerticalPodAutoscaler should never waste resources by increasing those.
+    vpa-butler.cloud.sap/update-mode: "Off"
 
 spec:
   updateStrategy:

--- a/openstack/swift/templates/keep-image-pulled-daemonset.yaml
+++ b/openstack/swift/templates/keep-image-pulled-daemonset.yaml
@@ -8,12 +8,17 @@
 # The condition above skips this daemonset on QA and lab regions, because high
 # availability is not a concern there. By omitting the daemonset there, the
 # Helm deployment will finish faster since it does not have to wait on it.
+# This also avoids wasting resources in small lab clusters.
 
 kind: DaemonSet
 apiVersion: apps/v1
 
 metadata:
   name: keep-image-pulled
+  annotations:
+    # This pod intentionally has extremely tight resource requests.
+    # The VerticalPodAutoscaler should never waste resources by increasing those.
+    vpa-butler.cloud.sap/update-mode: "Off"
 
 spec:
   updateStrategy:


### PR DESCRIPTION
While we were chatting about the resource crunch in qa-de-1, I noticed that our keep-image-pulled daemonsets allow autoscaling, which in this case means autowasting resources. This is not a problem in QA because we do not deploy those there at all, but let's try not wasting prod resources, too.