### PR TITLE
keppel: fix calculation of keppel_manifests_pending_trivy_checks

### DIFF
--- a/openstack/keppel/values.yaml
+++ b/openstack/keppel/values.yaml
@@ -214,7 +214,7 @@ pgmetrics:
                    EXTRACT(epoch FROM MIN(next_validation_at)) AS min_next_validation_at,
                    SUM(CASE WHEN validation_error_message = '' THEN 0 ELSE 1 END) AS validation_errors,
                    COALESCE(EXTRACT(epoch FROM MIN(trivy_security_info.next_check_at)), 0) AS min_next_trivy_check_at,
-                   SUM(CASE WHEN trivy_security_info.next_check_at > NOW() THEN 0 ELSE 1 END) AS pending_trivy_checks
+                   SUM(CASE WHEN trivy_security_info.next_check_at <= NOW() THEN 1 ELSE 0 END) AS pending_trivy_checks
               FROM manifests
              INNER JOIN trivy_security_info ON trivy_security_info.repo_id = manifests.repo_id AND trivy_security_info.digest = manifests.digest
           metrics:


### PR DESCRIPTION
Records with `next_check_at IS NULL` should not be considered. This change rearranges the condition so that NULL values (which always yield false in any comparison) yield 0 and thus are not counted.