### PR TITLE
[designate] bump shared dependencies

### DIFF
--- a/openstack/designate/Chart.lock
+++ b/openstack/designate/Chart.lock
@@ -4,22 +4,22 @@ dependencies:
   version: 1.1.11
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.4.1
+  version: 0.5.0
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.26.1
+  version: 0.27.1
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.6.10
+  version: 0.6.12
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.5.2
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.18.5
+  version: 0.19.1
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.27.2
+  version: 0.29.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
@@ -29,5 +29,5 @@ dependencies:
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.1.4
-digest: sha256:1422b181bfc6ab84479099d90a9177f6db99dffefb7b6a36582193209d50807c
-generated: "2025-07-23T15:10:49.379299+03:00"
+digest: sha256:1765d3c927da024970deda3d6481b0e0764e52adab70fd2df24d57e9c6f93e51
+generated: "2025-08-21T12:26:35.92329+03:00"

--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes to deploy Openstack Designate  (DNSaaS)
 name: designate
-version: 0.5.7
+version: 0.5.8
 appVersion: "dalmatian"
 dependencies:
   - condition: percona_cluster.enabled
@@ -13,14 +13,14 @@ dependencies:
     name: pxc-db
     alias: pxc_db
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.4.1
+    version: 0.5.0
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.26.1
+    version: 0.27.1
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.6.10
+    version: 0.6.12
   - condition: mysql_metrics.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
@@ -28,10 +28,10 @@ dependencies:
   - name: rabbitmq
     condition: rabbitmq.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.18.5
+    version: 0.19.1
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.27.2
+    version: 0.29.0
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0


### PR DESCRIPTION
This PR updates charts and related shared services to the current tags.

* bump mariadb chart to 0.27.1 - updates to `10.11.14`

* bump rabbitmq chart to 0.19.1 - updates to `4.1.3`

* bump utils chart to 0.29.0

* bump memcached chart to 0.6.12 - updates to `1.6.39-alpine3.22`

* bump pxc-db chart to 0.5.0 - updates pxc-operator to `1.18.0`