### PR TITLE
fix(snmp-exporter): change moved directive

### DIFF
--- a/prometheus-exporters/snmp-exporter/Chart.yaml
+++ b/prometheus-exporters/snmp-exporter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: snmp-exporter
-version: 0.1.18
+version: 0.1.19
 description: Prometheus snmp-exporter
 maintainers:
   - name: Olaf Heydorn (D042653)

--- a/prometheus-exporters/snmp-exporter/ci/test-values.yaml
+++ b/prometheus-exporters/snmp-exporter/ci/test-values.yaml
@@ -1,3 +1,7 @@
+http_sd_configs:
+  netbox_url: some_random.url.url.url
+  refresh_interval: 60m
+
 snmp_exporter:
   arista:
     snmpv3:

--- a/prometheus-exporters/snmp-exporter/values.yaml
+++ b/prometheus-exporters/snmp-exporter/values.yaml
@@ -9,9 +9,12 @@ owner-info:
 global:
   asa:
     enabled: false
-  http_sd_configs:
-    netbox_url: DEFINED-IN-REGION-SECRECTS
   linkerd_requested: true
+
+http_sd_configs:
+  netbox_url:
+  refresh_interval:
+
 snmp_exporter:
   image_version: "20250422083503"
   listen_port: 9116


### PR DESCRIPTION
http_sd_configs does not belong to global and has been changed during #9348 and this exporter uses it too. Change is to adhere to the other PR.