### PR TITLE
[placement][mariadb] update chart dependencies

### DIFF
--- a/openstack/placement/Chart.lock
+++ b/openstack/placement/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.25.0
+  version: 0.27.1
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.4.0
@@ -10,12 +10,12 @@ dependencies:
   version: 0.6.10
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.27.2
+  version: 0.29.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:72aa848ffce75fc278f5acdb2f4ec9f114518542be0b5a4fa42286725342ca6a
-generated: "2025-08-05T10:39:48.639354+02:00"
+digest: sha256:e482c4fa728e0b098f222b708dd6afb00e471a1eb6ad60a85cd8e4813ff80271
+generated: "2025-08-25T13:48:52.624613+03:00"

--- a/openstack/placement/Chart.yaml
+++ b/openstack/placement/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.25.0
+    version: 0.27.1
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db
@@ -20,7 +20,7 @@ dependencies:
     version: 0.6.10
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.27.2
+    version: 0.29.0
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0


### PR DESCRIPTION
Update MariaDB and openstack/utils chart to get a support for user deletion from ProxySQL sidecar configuration, when user is disabled in mariadb configuration.