### PR TITLE
[glance] bump shared dependencies

### DIFF
--- a/openstack/glance/Chart.lock
+++ b/openstack/glance/Chart.lock
@@ -1,19 +1,19 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.25.0
+  version: 0.27.1
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.4.0
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.6.10
+  version: 0.6.12
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.5.1
+  version: 0.5.2
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.27.2
+  version: 0.29.0
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.6.2
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:4c63e2219d47d83190eea82f70b441a551a779084a1e70e47e069f0276a68007
-generated: "2025-08-01T16:33:41.546525+03:00"
+digest: sha256:ab57102c9d6557ac3398baa5853685455973493bfc7adf02d5406cbd4b665070
+generated: "2025-08-25T15:41:45.774058+03:00"

--- a/openstack/glance/Chart.yaml
+++ b/openstack/glance/Chart.yaml
@@ -4,12 +4,12 @@ appVersion: dalmatian
 description: A Helm chart Openstack Glance
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Glance/OpenStack_Project_Glance_vertical.png
 name: glance
-version: 0.7.4
+version: 0.7.5
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.25.0
+    version: 0.27.1
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db
@@ -17,14 +17,14 @@ dependencies:
     version: 0.4.0
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.6.10
+    version: 0.6.12
   - condition: mariadb.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.5.1
+    version: 0.5.2
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.27.2
+    version: 0.29.0
   - name: redis
     alias: sapcc_rate_limit
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm


### PR DESCRIPTION
* Updates MariaDB to 10.11.14
* Updates memcached to 1.6.39
* Updates sql-exporter to 2025-07-07