### PR TITLE
[kmip] use mariadb kmip credentials for kmip service configuration

### DIFF
--- a/openstack/kmip/Chart.yaml
+++ b/openstack/kmip/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Chart Version
-version: 0.3.5
+version: 0.3.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/openstack/kmip/templates/etc/_kmip-server.conf.tpl
+++ b/openstack/kmip/templates/etc/_kmip-server.conf.tpl
@@ -1,5 +1,5 @@
 [server]
-database_path=mysql://kmip:{{ .Values.kmip.database.password | include "resolve_secret" }}@{{include "kmip.db_host" . }}:3306/kmip
+database_path=mysql://{{ .Values.mariadb.users.kmip.user | include "resolve_secret" }}:{{ .Values.mariadb.users.kmip.password | include "resolve_secret" }}@{{include "kmip.db_host" . }}:3306/kmip
 hostname=0.0.0.0
 port=5696
 certificate_path=/etc/pykmip/certs/server.crt


### PR DESCRIPTION
Change database_path in kmip to use credentials actually configured on `kmip-mariadb` MariaDB instance.
This would make password rotation possible, because now we will reference the same secrets in two places, where secret is supposed to be the same.