### PR TITLE
[mariadb] add missing secret resolve in drop comment line

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.27.2 - 2025/08/23
+Add missing secret resolve in `init.sql`, when user is disabled, so the generated comment would contain the actual username instead of the vault reference if the vault secret is being used for the username value
+* chart version bumped
+
 ## v0.27.1 - 2025/08/13
 * MariaDB version updated to [10.11.14](https://mariadb.com/docs/release-notes/community-server/mariadb-10-11-series/mariadb-10.11.14-release-notes)
   * several critical (InnoDB) fixes

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,6 +2,6 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.27.1
+version: 0.27.2
 # scripts/docker-entyrpoint.sh should be updated when appVersion is updated
 appVersion: 10.11.14

--- a/common/mariadb/templates/initdb/_init.sql.tpl
+++ b/common/mariadb/templates/initdb/_init.sql.tpl
@@ -16,11 +16,11 @@ GRANT ALL PRIVILEGES ON {{ .Values.name }}.*
 {{- range $username, $values := .Values.users }}
     {{- $username := default $username $values.name }}
     {{- if (and (hasKey $values "enabled") (eq (typeOf $values.enabled) "bool") (eq $values.enabled false)) }}
--- Dropping user {{ $username }} as it is disabled
+-- Dropping user {{ include "mariadb.resolve_secret_squote" $username }} as it is disabled
 DROP USER IF EXISTS {{ include "mariadb.resolve_secret_squote" $username }}@'%';
 --
     {{- else if not $values.password }}
--- Skipping user {{ $username }} without password
+-- Skipping user {{ include "mariadb.resolve_secret_squote" $username }} without password
     {{- else }}
 DROP USER IF EXISTS {{ include "mariadb.resolve_secret_squote" $username }}@'localhost';
 CREATE USER IF NOT EXISTS {{ include "mariadb.resolve_secret_squote" $username }}@'%';


### PR DESCRIPTION
Add missing secret resolve, so the generated comment would contain actual username instead of the vault reference