### PR TITLE
[designate] assign new openstack role to the nanny service user

### DIFF
--- a/openstack/designate/templates/seeds.yaml
+++ b/openstack/designate/templates/seeds.yaml
@@ -260,7 +260,7 @@ spec:
     - name: '{{ required "missing project name in .Values.designate_nanny.credentials.designate_api.project_name" .Values.designate_nanny.credentials.designate_api.project_name }}'
       role_assignments:
       - user: '{{ .Values.designate_nanny.credentials.designate_api.user | include "resolve_secret" }}@{{.Values.designate_nanny.credentials.designate_api.project_user_domain_name }}'
-        role: cloud_dns_viewer
+        role: cloud_dns_backup
     - name: master
       role_assignments:
       - user: '{{ .Values.designate_nanny.credentials.designate_api.user | include "resolve_secret" }}@{{.Values.designate_nanny.credentials.designate_api.project_user_domain_name }}'


### PR DESCRIPTION
We introduced a  new OpenStack rule for zone backups -- this commit assigns it to the service user.