### PR TITLE
[neutron] adding explicit values for nsxv3 logstash db access

### DIFF
--- a/openstack/neutron/ci/test-values.yaml
+++ b/openstack/neutron/ci/test-values.yaml
@@ -21,6 +21,9 @@ mariadb:
   backup_v2:
     enabled: false
 
+nsxv3_logstash:
+  dbPassword: topSecret
+
 pxc_db:
   enabled: false
   users:

--- a/openstack/neutron/templates/secret-nsxv3-logstash.yaml
+++ b/openstack/neutron/templates/secret-nsxv3-logstash.yaml
@@ -7,5 +7,5 @@ metadata:
     application: {{ .Release.Name }}
 type: Opaque
 data:
-  NEUTRON_DB_PASSWORD: {{ coalesce .Values.dbPassword .Values.global.dbPassword .Values.mariadb.root_password | required ".Values.mariadb.root_password is required!" | b64enc }}
-  NEUTRON_DB_USER: {{ coalesce .Values.dbUser .Values.global.dbUser "root"  | b64enc }}
+  NEUTRON_DB_PASSWORD: {{ coalesce .Values.nsxv3_logstash.dbPassword .Values.dbPassword .Values.global.dbPassword | required ".Values.nsxv3_logstash.dbPassword is required!" | b64enc }}
+  NEUTRON_DB_USER: {{ coalesce .Values.nsxv3_logstash.dbUser .Values.dbUser .Values.global.dbUser | required ".Values.nsxv3_logstash.dbUser is required!" | b64enc }}

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -511,6 +511,10 @@ mariadb:
   alerts:
     support_group: network-api
 
+nsxv3_logstash:
+  dbUser: neutron
+  # dbPassword: _replace_me_
+
 pxc_db:
   enabled: false
   name: neutron


### PR DESCRIPTION
To be able to give the nsxv3 logstash service its own dedicated user, this introduces new values - for now with fallback to the current default credentials.