### PR TITLE
Thanos ruler vmware alert update to the query

### DIFF
--- a/prometheus-rules/prometheus-vmware-rules/Chart.yaml
+++ b/prometheus-rules/prometheus-vmware-rules/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A collection of Prometheus alert rules.
 name: prometheus-vmware-rules
-version: 1.3.13
+version: 1.3.14
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/prometheus-rules/prometheus-vmware-rules/alerts-scaleout-ruler/host.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts-scaleout-ruler/host.alerts
@@ -6,8 +6,8 @@
           count_over_time((present_over_time(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}[1d]))[15d:1d]) >= 10
           and on (hostsystem) (vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"})
           unless on (hostsystem) (vrops_hostsystem_custom_attributes_hw_info == 1 )
-          unless on (hostsystem) (vrops_cluster_summary_custom_tag_openstack_nova_traits_decommissioning == 1)
           unless on (hostsystem) (vrops_hostsystem_custom_attributes_change_request_info == 1)
+          unless on (vccluster) (vrops_cluster_summary_custom_tag_openstack_nova_traits_decommissioning == 1)
         labels:
           severity: warning
           service: compute


### PR DESCRIPTION
update to the query for alert host in maintenance mode for more than 10 days to read correctly the openstack decommissioning tag that is set at the cluster level