### PR TITLE
Bump git-proxy image

### DIFF
--- a/global/concourse-main/values.yaml
+++ b/global/concourse-main/values.yaml
@@ -140,7 +140,7 @@ gitResourceProxy:
   timeout: 60s
   debug: true
   image: keppel.global.cloud.sap/ccloud/concourse-git-resource-proxy
-  imageTag: 0.8.0
+  imageTag: 0.9.0
   imagePullPolicy: IfNotPresent
 
 kubernetes-ingress:


### PR DESCRIPTION
fixes false alerts when a remote branch is not found