### PR TITLE
Updating NAT port allocation alert

### DIFF
--- a/prometheus-exporters/network-generic-ssh-exporter/alerts/asr.alerts
+++ b/prometheus-exporters/network-generic-ssh-exporter/alerts/asr.alerts
@@ -158,8 +158,9 @@ groups:
 
     - alert: NetworkAsrNatTcpPortPreAllocationLow
       expr: >-
-        sum by (name)
-        (ssh_nat_portblock_tcp_end - ssh_nat_portblock_tcp_start)
+        (sum by (name) (ssh_nat_portblock_tcp_end - ssh_nat_portblock_tcp_start))
+        * on(name) group_left()
+        (snmp_asr_sysDescr{image_version=~"17.6.3.*"})
         < 45000
       for: 5m
       labels:
@@ -176,8 +177,9 @@ groups:
 
     - alert: NetworkAsrNatUdpPortPreAllocationLow
       expr: >-
-        sum by (name)
-        (ssh_nat_portblock_udp_end - ssh_nat_portblock_udp_start)
+        (sum by (name) (ssh_nat_portblock_udp_end - ssh_nat_portblock_udp_start))
+        * on(name) group_left()
+        (snmp_asr_sysDescr{image_version=~"17.6.3.*"})
         < 45000
       for: 5m
       labels:


### PR DESCRIPTION
This alert is applicable to firmware versions prior to 17.15.x. In version 17.6.3, the metric is used to verify the NAT port chunks downloaded to the data plane. At router bootup, 45K ports were immediately downloaded from the Port-Manager.

From version 17.15.x onward, NAT requests all 45K ports from the Port-Manager, but the ports are downloaded to the data plane only when traffic requires them.

This alert applies only to Neutron routers running firmware version 17.6.3.