### PR TITLE
[greenhouse-ccloud] - Fixed pluginpreset kvm-monitoring selectors match new syntax

### DIFF
--- a/system/greenhouse-ccloud/Chart.yaml
+++ b/system/greenhouse-ccloud/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: ccloud
 description: A Helm chart for the CCloud organization in Greenhouse.
 type: application
-version: 1.26.6
+version: 1.26.7

--- a/system/greenhouse-ccloud/templates/kvm-monitoring-pluginpreset.yaml
+++ b/system/greenhouse-ccloud/templates/kvm-monitoring-pluginpreset.yaml
@@ -15,11 +15,11 @@ spec:
     optionValues:
       - name: serviceMonitorLabels
         value:
-          plugin: 'kube-monitoring-{{ "{{ .Values.global.greenhouse.clusterName }}" }}'
+          plugin: kube-monitoring
       - name: prometheusRules.ruleSelectors
         value:
           - name: plugin
-            value: 'kube-monitoring-{{ "{{ .Values.global.greenhouse.clusterName }}" }}'
+            value: kube-monitoring
       - name: prometheusRules.additionalRuleLabels
         value:
           service: kvm


### PR DESCRIPTION
- Bumped minor version
- removed cluster reference on `kube-monitoring` selectors