### PR TITLE
[utils] Add option for linkerd native sidecar

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.29.0
+version: 0.30.0

--- a/openstack/utils/templates/_linkerd.tpl
+++ b/openstack/utils/templates/_linkerd.tpl
@@ -1,6 +1,9 @@
 {{- define "utils.linkerd.pod_and_service_annotation" }}
 {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
 linkerd.io/inject: enabled
+{{- if $.Values.global.linkerd_use_native_sidecar }}
+config.alpha.linkerd.io/proxy-enable-native-sidecar: "true"
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/openstack/utils/values.yaml
+++ b/openstack/utils/values.yaml
@@ -6,6 +6,7 @@
 global:
   user_suffix: ""
   master_password: ""
+  linkerd_use_native_sidecar: false
 
 cors:
   # default headers. additional headers can be specified via {cors:


### PR DESCRIPTION
The "alpha" configuration setting for linkerd's native sidecar can help with linkerd shutting down after the main pod for which it is a sidecar container. Setting linkerd_use_native_sidecar enables this behavior.