### PR TITLE
[Nova] Remove default mariadb users

### DIFF
--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -748,15 +748,6 @@ mariadb:
   databases:
   - nova
   - nova_cell0
-  users:
-    nova:
-      name: nova
-      grants:
-      - "ALL PRIVILEGES on nova.*"
-    nova_cell0:
-      name: nova_cell0
-      grants:
-      - "ALL PRIVILEGES on nova_cell0.*"
   persistence_claim:
     name: db-nova-pvc
     size: "50Gi"
@@ -795,11 +786,6 @@ mariadb_api:
     enabled: true
   databases:
   - nova_api
-  users:
-    nova_api:
-      name: nova_api
-      grants:
-      - "ALL PRIVILEGES on nova_api.*"
   persistence_claim:
     name: db-nova-api-pvc
     size: "50Gi"


### PR DESCRIPTION
We will not use them anymore and it thus doesn't make sense to keep them around.