### PR TITLE
[rabbitmq] update to 4.1.4 release

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+## 0.19.2 - 2025/09/04
+
+- RabbitMQ [4.1.4 Release notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.1.4)
+- `rabbitmq-user-credential-updater` updated to `20250904100127` version
+- Chart version bumped
+
 ## 0.19.1 - 2025/08/06
 
 - RabbitMQ [4.1.3 Release notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.1.3)

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: v1
 name: rabbitmq
-version: 0.19.1
-appVersion: 4.1.3
+version: 0.19.2
+appVersion: 4.1.4
 description: A Helm chart for RabbitMQ
 sources:
   - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/values.yaml
+++ b/common/rabbitmq/values.yaml
@@ -11,7 +11,7 @@ global:
       enabled: true
 
 image: library/rabbitmq
-imageTag: 4.1.3-management
+imageTag: 4.1.4-management
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -131,7 +131,7 @@ customConfig:
 credentialUpdater:
   enabled: true
   image: rabbitmq-user-credential-updater
-  imageTag: '20250730094138'
+  imageTag: '20250904100127'
 
 enableSsl: false
 certificate:


### PR DESCRIPTION
- RabbitMQ updated to `4.1.4` version
- `rabbitmq-user-credential-updater` updated to `20250904100127` version
- Chart version bumped