### PR TITLE
[nova][rabbitmq] don't create unused monitoring user

### DIFF
--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 name: nova
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Nova/OpenStack_Project_Nova_mascot.png
-version: 0.5.4
+version: 0.5.5
 appVersion: "bobcat"
 dependencies:
   - name: mariadb

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -851,8 +851,6 @@ rabbitmq_cell2:
     support_group: compute-storage-api
   metrics:
     enabled: true
-    sidecar:
-      enabled: false
     enableDetailedMetrics: true
     enablePerObjectMetrics: true
 audit:
@@ -872,11 +870,7 @@ rabbitmq:
   persistence:
     enabled: false
   metrics:
-    password: null
     enabled: true
-    addMetricsUser: true
-    sidecar:
-      enabled: false
     enableDetailedMetrics: true
     enablePerObjectMetrics: true
   resources:


### PR DESCRIPTION
* Disable `monitoring` user in nova's RabbitMQ, as this read-only user isn't being used
* Remove obsolete `metrics.sidecar` values