### PR TITLE
[Nova] Temporarily add key back to nova-etc Secret

### DIFF
--- a/openstack/nova/templates/etc-secret.yaml
+++ b/openstack/nova/templates/etc-secret.yaml
@@ -23,3 +23,5 @@ data:
     {{ include "ini_sections.audit_middleware_notifications" . | b64enc | indent 4 }}
   osprofiler.conf: |
     {{ include "osprofiler" . | b64enc | indent 4 }}
+  nova-api-metadata-secrets.conf: |
+    {{ "temporary value to overwrite stale data" | b64enc | indent 4 }}


### PR DESCRIPTION
When switching from stringData to data in 8844453cf19, we in some regions also rolled out the change to move
nova-api-metadata-secrets.conf to its own Secret. This left stale data in the clusters, because you cannot remove keys via removing them from stringData - and since we didn't add it to `data`, it also couldn't get removed there.

Therefore, we now temporarily add the `nova-api-metadata-secrets.conf` key back with some garbage value. It's not consumed by anyone anyways. We will remove it again after we rolled this through all regions.