### PR TITLE
[maia] Fix missing cluster labels in prometheus-openstack job labeldrop configuration

### DIFF
--- a/openstack/maia/templates/etc/_maia_scrape_config.yaml.tpl
+++ b/openstack/maia/templates/etc/_maia_scrape_config.yaml.tpl
@@ -80,7 +80,7 @@
   static_configs:
     - targets: ['prometheus-openstack.prometheus-openstack:9090']
   metric_relabel_configs:
-    - regex: "instance|job|kubernetes_namespace|kubernetes_pod_name|kubernetes_name|pod_template_hash|exported_instance|exported_job|type|name|component|app|system|alert_tier|alert_service"
+    - regex: "cluster|cluster_type|instance|job|kubernetes_namespace|kubernetes_pod_name|kubernetes_name|pod_template_hash|exported_instance|exported_job|type|name|component|app|system|thanos_cluster|thanos_cluster_type|thanos_region|alert_tier|alert_service"
       action: labeldrop
   metrics_path: '/federate'
   params:


### PR DESCRIPTION
__Changes:__

- Updated labeldrop regex in `prometheus-openstack` job to include: `cluster|cluster_type|thanos_cluster|thanos_cluster_type|thanos_region`
- This ensures consistent label dropping across all federation jobs in the Maia scrape configuration

__Impact:__

- Infrastructure labels will now be properly dropped from metrics federated through the `prometheus-openstack` job
- Reduces metric cardinality and removes non-tenant-relevant labels from tenant-facing metrics
- Brings `prometheus-openstack` job configuration in line with other federation jobs
