### PR TITLE
Keystone: set LimitRequestFieldSize

### DIFF
--- a/openstack/keystone/templates/etc/_wsgi-keystone.conf.tpl
+++ b/openstack/keystone/templates/etc/_wsgi-keystone.conf.tpl
@@ -56,6 +56,8 @@ CustomLog /dev/stdout proxy env=forwarded
     WSGIApplicationGroup %{GLOBAL}
     WSGIPassAuthorization On
     LimitRequestBody 114688
+    # LimitRequestFieldSize is needed because of OIDC, 2*default
+    LimitRequestFieldSize 16380
     <IfVersion >= 2.4>
       ErrorLogFormat "%{cu}t %M"
     </IfVersion>


### PR DESCRIPTION
It is needed because oidc headers and parameters can be huge, and users get an error that the server cannot process their request.