### PR TITLE
[ironic] increase parallelism for cleaning

### DIFF
--- a/openstack/ironic/templates/etc/_ironic.conf.tpl
+++ b/openstack/ironic/templates/etc/_ironic.conf.tpl
@@ -127,9 +127,8 @@ metrics_enabled = {{ if .Values.audit.metrics_enabled -}}True{{- else -}}False{{
 {{- include "ini_sections.cache" . }}
 
 
-{{- if or .Values.conductor.defaults.conductor.permitted_image_formats .Values.conductor.defaults.conductor.disable_deep_image_inspection }}
-
 [conductor]
+{{- if or .Values.conductor.defaults.conductor.permitted_image_formats .Values.conductor.defaults.conductor.disable_deep_image_inspection }}
   {{- if .Values.conductor.defaults.conductor.disable_deep_image_inspection }}
 disable_deep_image_inspection = {{ .Values.conductor.defaults.conductor.disable_deep_image_inspection }}
   {{- end }}
@@ -137,3 +136,5 @@ disable_deep_image_inspection = {{ .Values.conductor.defaults.conductor.disable_
 permitted_image_formats = {{ .Values.conductor.defaults.conductor.permitted_image_formats }}
   {{- end }}
 {{- end }}
+# Make sure to set it in api and conductor
+max_concurrent_clean = {{ .Values.conductor.defaults.conductor.max_concurrent_clean }}

--- a/openstack/ironic/values.yaml
+++ b/openstack/ironic/values.yaml
@@ -216,6 +216,8 @@ conductor:
     conductor:
       conductor_always_validates_images: false # We only use the direct interface, so leave it to the agent
       permitted_image_formats: 'raw,qcow2,iso,vmdk'
+      # HDA has a parallelism of 50 nodes, we give a buffer of 10
+      max_concurrent_clean: 60
 
 agent:
   deploy_logs:


### PR DESCRIPTION
With max_concurrent_clean it's possible to set the parallelism level for
cleaning. By default it's 50 but we have HDA who work on 50 nodes in
parallel, so a single node that was in cleaning before might break their
deployment. So we give a buffer of 10, which should hopefully be enough.
As we have multiple conductors it might be safe to increase it further.
With the current setup no conductor will have more nodes than around 28.
