### PR TITLE
Fixing linting errors, Copy Bedrock alerts and rewrite support group …

### DIFF
--- a/prometheus-rules/prometheus-vmware-rules/Chart.yaml
+++ b/prometheus-rules/prometheus-vmware-rules/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A collection of Prometheus alert rules.
 name: prometheus-vmware-rules
-version: 1.3.15
+version: 1.3.16
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/prometheus-rules/prometheus-vmware-rules/alerts/datastore.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/datastore.alerts
@@ -3,7 +3,7 @@ groups:
   rules:
   - alert: EphemeralDataStoreCapacity
     expr: >
-      vrops_datastore_diskspace_total_usage_gigabytes{type=~"ephemeral"} / vrops_datastore_diskspace_capacity_gigabytes >= 0.85
+      vrops_datastore_diskspace_total_usage_gigabytes{type="ephemeral"} / vrops_datastore_diskspace_capacity_gigabytes >= 0.85
     for: 20m
     labels:
       severity: info
@@ -20,7 +20,7 @@ groups:
 
   - alert: EphemeralDataStoreCapacity
     expr: >
-      vrops_datastore_diskspace_total_usage_gigabytes{type=~"ephemeral"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.9
+      vrops_datastore_diskspace_total_usage_gigabytes{type="ephemeral"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.9
     for: 20m
     labels:
       severity: info
@@ -125,7 +125,7 @@ groups:
   - alert: DatastoreDisconnectedWithVmsOnIt
     expr: >
       (label_replace(vrops_datastore_summary_total_number_vms, "hostsystem", "$1", "datastore", "(node[0-9]{3}-[^-]*).*") > 0 and on(datastore)
-      vrops_datastore_summary_datastore_accessible{state="PoweredOff",type!~"local"}) unless on (hostsystem)
+      vrops_datastore_summary_datastore_accessible{state="PoweredOff",type!="local"}) unless on (hostsystem)
       label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
     for: 20m
     labels:
@@ -143,7 +143,7 @@ groups:
   - alert: DatastoreDisconnectedWithoutVmsOnIt
     expr: >
       (label_replace(vrops_datastore_summary_total_number_vms, "hostsystem", "$1", "datastore", "(node[0-9]{3}-[^-]*).*") == 0 and on(datastore)
-      vrops_datastore_summary_datastore_accessible{state="PoweredOff",type!~"local"}) unless on (hostsystem)
+      vrops_datastore_summary_datastore_accessible{state="PoweredOff",type!="local"}) unless on (hostsystem)
       label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
     for: 20m
     labels:
@@ -261,7 +261,7 @@ groups:
 
   - alert: EphemeralDatastorePartOfIncorrectSDRSCluster
     expr: >
-      vrops_datastore_summary_datastore_accessible{type="ephemeral", storagepod=~".*hgb.*", datastore=~"eph.*hga"} or vrops_datastore_summary_datastore_accessible{type="ephemeral", storagepod=~".*hga.*", datastore=~"eph.*hgb"} > 0
+      (vrops_datastore_summary_datastore_accessible{type="ephemeral", storagepod=~".*hgb.*", datastore=~"eph.*hga"} or vrops_datastore_summary_datastore_accessible{type="ephemeral", storagepod=~".*hga.*", datastore=~"eph.*hgb"}) > 0
     for: 20m
     labels:
       severity: warning

--- a/prometheus-rules/prometheus-vmware-rules/alerts/datastore.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/datastore.alerts
@@ -105,7 +105,7 @@ groups:
 
   - alert: NVMeSwapDatastoreMissing
     expr: |
-      vrops_hostsystem_hardware_model{vccluster=~"^productionbb\\d+$", hardware_model!~"^Cisco Systems Inc.+"}
+      vrops_hostsystem_hardware_model{vccluster=~"productionbb\\d+", hardware_model!~"Cisco Systems Inc.+"}
       and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
       unless on (hostsystem) (label_replace(label_join(vrops_datastore_summary_datastore_accessible{type="NVMe"}, "hostsystem", "", "datastore", "vcenter"), "hostsystem", "$1$2", "hostsystem", "(.+)-swapvc-[a-z]-\\d+(.+)")
       or vrops_hostsystem_summary_custom_tag_nvme{summary_custom_tag_nvme="false"})
@@ -309,7 +309,7 @@ groups:
 
   - alert: CinderTagAddedForReservedDatastore
     expr: |
-      vrops_datastore_summary_custom_tag_cinder_state{type=~"^(vmfs_s_hdd|vmfs_p_ssd)$", summary_custom_tag_cinder_state="reserved"}
+      vrops_datastore_summary_custom_tag_cinder_state{type=~"(vmfs_s_hdd|vmfs_p_ssd)", summary_custom_tag_cinder_state="reserved"} > 0
       and on (datastore) vrops_datastore_summary_tag{tag_cinder=~"cinder|slow"}
     for: 1h
     labels:
@@ -325,8 +325,8 @@ groups:
 
   - alert: VMFSDatastoreHostcountMismatch
     expr: |
-      vrops_datastore_hostcount{type=~"^(vmfs_s_hdd|vmfs_p_ssd)$"} < on (vcenter) group_left
-      count by (vcenter) (vrops_hostsystem_runtime_connectionstate{state="connected", vccluster=~"^productionbb\\d+$"}
+      vrops_datastore_hostcount{type=~"(vmfs_s_hdd|vmfs_p_ssd)"} < on (vcenter) group_left
+      count by (vcenter) (vrops_hostsystem_runtime_connectionstate{state="connected", vccluster=~"productionbb\\d+"}
       unless on (hostsystem) (vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}))
     for: 60m
     labels:
@@ -343,7 +343,7 @@ groups:
   - alert: NFSDatastoreHostcountMismatch
     expr: |
       vrops_datastore_hostcount{type="nfs"} < on (vcenter) group_left
-      count by (vcenter) (vrops_hostsystem_runtime_connectionstate{state="connected", vccluster=~"^productionbb\\d+$"})
+      count by (vcenter) (vrops_hostsystem_runtime_connectionstate{state="connected", vccluster=~"productionbb\\d+"})
     for: 60m
     labels:
       severity: info

--- a/prometheus-rules/prometheus-vmware-rules/alerts/host.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/host.alerts
@@ -110,7 +110,7 @@ groups:
   - alert: HostHasLostRedundantConnectivityToDVPort
     expr: |
       vrops_hostsystem_alert_info{alert_name="The host has lost redundant connectivity to a dvPort"}
-      and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!~"inMaintenance"}
+      and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
     labels:
       severity: info
       tier: vmware
@@ -126,8 +126,8 @@ groups:
   
   - alert: HostNicDown
     expr: |
-      vrops_hostsystem_alert_info{alert_name=~"ESXi host has detected a link status down on a physical NIC"}
-      and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!~"inMaintenance"}
+      vrops_hostsystem_alert_info{alert_name="ESXi host has detected a link status down on a physical NIC"}
+      and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
     for: 20m
     labels:
       severity: warning
@@ -163,7 +163,7 @@ groups:
   - alert: HostHasLostConnectivityToPhysicalNetwork
     expr: |
       vrops_hostsystem_alert_info{alert_name="The host has lost connectivity to physical network"}
-      and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!~"inMaintenance"}
+      and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
     labels:
       severity: warning
       tier: vmware
@@ -214,7 +214,7 @@ groups:
   - alert: HADetectedAPossibleHostFailure
     expr: |
       vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) has detected a possible host failure"}
-      and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!~"inMaintenance", vccluster!~".*controlplane-swift"}
+      and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance", vccluster!~".*controlplane-swift"}
     labels:
       severity: critical
       tier: vmware
@@ -259,7 +259,7 @@ groups:
   - alert: HostHighNumberOfPacketsDropped
     expr: |
       vrops_hostsystem_alert_info{alert_name="Host is experiencing high number of packets dropped"}
-      and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!~"inMaintenance"}
+      and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
     labels:
       severity: info
       tier: vmware
@@ -275,7 +275,7 @@ groups:
   - alert: HostNicLinkFlappingAlert
     expr: |
       vrops_hostsystem_alert_info{alert_name=~"ESXi host has detected a link status.*flapping.*on a physical NIC"}
-      and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!~"inMaintenance"}
+      and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
     labels:
       severity: info
       tier: vmware
@@ -291,7 +291,7 @@ groups:
   - alert: HostSystemEventLogSensorAlert
     expr: |
       vrops_hostsystem_alert_info{alert_name="IPMI System Event Log for the host is becoming full"}
-      and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!~"inMaintenance"}
+      and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
     labels:
       severity: info
       tier: vmware
@@ -337,7 +337,7 @@ groups:
   - alert: HAHostAgentError
     expr: |
       vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) host agent has encountered an error", vccluster!~".*-controlplane-swift"}
-      and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!~"inMaintenance"}
+      and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
     labels:
       severity: warning
       tier: vmware
@@ -354,7 +354,7 @@ groups:
   - alert: HAHostNetworkPartitioned
     expr: |
       vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) has detected a network-partitioned host"}
-      and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!~"inMaintenance"}
+      and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
     labels:
       severity: warning
       tier: vmware

--- a/prometheus-rules/prometheus-vmware-rules/alerts/iaas.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/iaas.alerts
@@ -78,24 +78,38 @@ groups:
       description: "Non IaaS virtual machine(s) running on IaaS ESXi host {{ $labels.hostsystem }}"
       summary: "Non IaaS virtual machine(s) running on IaaS ESXi host {{ $labels.hostsystem }}"
 
-  - alert: IaasVmOnNonIaasHost
+  - alert: IaasHostsAlmostOutOfMemory
     expr: |
-      count by (hostsystem) (
-        (
-          group by (project, hostsystem, virtualmachine)(vrops_virtualmachine_system_powered_on{}==1)
-          and on(project)
-          group by(project) (label_replace(limes_project_usage{domain=~"iaas-.*"}, "project", "$1", "project_id", "(.*)"))
-        )
+      count by (vccluster) (
+        (vrops_hostsystem_memory_usage_percentage > 75)
+        and on(hostsystem)
+        vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+        unless on(hostsystem)
+        vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{} == 1
       )
-      and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups!~".*iaas.*"}
-    for: 30m
+      == on(vccluster)
+      count by (vccluster) (
+        vrops_hostsystem_memory_usage_percentage
+        and on(hostsystem)
+        vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+        unless on(hostsystem)
+        vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{} == 1
+      )
+      and on(vccluster)
+      count by (vccluster) (
+        vrops_hostsystem_memory_usage_percentage
+        and on(hostsystem)
+        vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+        unless on(hostsystem)
+        vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{} == 1
+      ) > 0
+    for: 60m
     labels:
-      severity: warning
+      severity: critical
       service: compute
       support_group: iaas-support
-      context: "IaaS vm on non IaaS cluster"
-      meta: "IaaS virtual machine(s) running on Non IaaS ESXi host {{ $labels.hostsystem }}"
+      context: "IaaS hosts in cluster are almost out of memory"
+      meta: "All IaaS hosts in cluster {{ $labels.vccluster }} are above 75% memory"
     annotations:
-      description: "IaaS virtual machine(s) running on non IaaS ESXi host {{ $labels.hostsystem }}"
-      summary: "IaaS virtual machine(s) running on non IaaS ESXi host {{ $labels.hostsystem }}"
-
+      description: "All IaaS hosts in cluster {{ $labels.vccluster }} are above 75% memory"
+      summary: "All IaaS hosts in cluster {{ $labels.vccluster }} are above 75% memory"

--- a/prometheus-rules/prometheus-vmware-rules/alerts/iaas.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/iaas.alerts
@@ -105,7 +105,7 @@ groups:
       ) > 0
     for: 60m
     labels:
-      severity: critical
+      severity: warning
       service: compute
       support_group: iaas-support
       context: "IaaS hosts in cluster are almost out of memory"

--- a/prometheus-rules/prometheus-vmware-rules/alerts/iaas.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/iaas.alerts
@@ -1,3 +1,4 @@
+# Check also iaas-templated-alerts.yaml if you dont find a alert.
 groups:
 - name: iaas.alerts
   rules:
@@ -97,3 +98,4 @@ groups:
     annotations:
       description: "IaaS virtual machine(s) running on non IaaS ESXi host {{ $labels.hostsystem }}"
       summary: "IaaS virtual machine(s) running on non IaaS ESXi host {{ $labels.hostsystem }}"
+

--- a/prometheus-rules/prometheus-vmware-rules/alerts/k8s-vc-mgmt.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/k8s-vc-mgmt.alerts
@@ -11,7 +11,7 @@ groups:
       support_group: containers
       context: vccluster
       no_alert_on_absence: "true"
-      meta: "The VCCluster {{ $labels.vccluster}} is using {{ $value }} CPU and VM's are fighting for it"
+      meta: "The VCCluster {{ $labels.vccluster}} is using too much CPU and VM's are fighting for it"
     annotations:
       description: "The VCCluster {{ $labels.vccluster}} is using {{ $value }} CPU and VM's are fighting for it"
       summary: "{{ $labels.vccluster}} cpu contention critical"

--- a/prometheus-rules/prometheus-vmware-rules/alerts/vccluster.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/vccluster.alerts
@@ -91,8 +91,9 @@ groups:
 
   - alert: VCClusterCannotDistributeNSXTControllers
     expr: |
-      count(
-        (   max_over_time(vrops_hostsystem_memory_capacity_available_to_vms_kilobytes{vccluster=~".*management"}[1h])
+      count by(vccluster, vcenter) (
+        (
+          max_over_time(vrops_hostsystem_memory_capacity_available_to_vms_kilobytes{vccluster=~".*management"}[1h])
           - max_over_time(vrops_hostsystem_memory_consumed_by_vms_kilobytes[1h])
         ) / 1024 / 1024 >= 48
       ) < 3

--- a/prometheus-rules/prometheus-vmware-rules/alerts/vccluster.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/vccluster.alerts
@@ -3,10 +3,10 @@ groups:
   rules:
   - alert: VCenterRedundancyLostHAPolicyFaulty
     expr: |
-      vrops_cluster_configuration_dasconfig_enabled{vccluster=~"^productionbb\\d+$"}
-      unless on (vccluster) ((vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{vccluster=~"^productionbb\\d+$"} != 0
+      vrops_cluster_configuration_dasconfig_enabled{vccluster=~"productionbb\\d+"}
+      unless on (vccluster) ((vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{vccluster=~"productionbb\\d+"} != 0
       and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"})
-      or (vrops_cluster_summary_custom_tag_openstack_nova_traits_decommissioning{summary_custom_tag_openstack_nova_traits_decommissioning="true", vccluster=~"^productionbb\\d+$"}
+      or (vrops_cluster_summary_custom_tag_openstack_nova_traits_decommissioning{summary_custom_tag_openstack_nova_traits_decommissioning="true", vccluster=~"productionbb\\d+"}
       and on (vccluster) vrops_cluster_cluster_running_vms == 0))
     for: 30m
     labels:
@@ -38,10 +38,10 @@ groups:
 
   - alert: VCClusterFailoverHostCountMismatch
     expr: |
-      (count by (vccluster, vcenter) (vrops_hostsystem_runtime_connectionstate{vccluster=~"^productionbb\\d+$"}) <= 10
-      and on (vccluster) sum by (vccluster) (vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{vccluster=~"^productionbb\\d+$"}) > 1)
-      or (sum by (vccluster, vcenter) (vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{vccluster=~"^productionbb\\d+$"}) > 2)
-      unless on (vccluster) (vrops_cluster_summary_custom_tag_openstack_nova_traits_decommissioning{summary_custom_tag_openstack_nova_traits_decommissioning="true", vccluster=~"^productionbb\\d+$"}
+      (count by (vccluster, vcenter) (vrops_hostsystem_runtime_connectionstate{vccluster=~"productionbb\\d+"}) <= 10
+      and on (vccluster) sum by (vccluster) (vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{vccluster=~"productionbb\\d+"}) > 1)
+      or (sum by (vccluster, vcenter) (vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{vccluster=~"productionbb\\d+"}) > 2)
+      unless on (vccluster) (vrops_cluster_summary_custom_tag_openstack_nova_traits_decommissioning{summary_custom_tag_openstack_nova_traits_decommissioning="true", vccluster=~"productionbb\\d+"}
       and vrops_cluster_cluster_running_vms == 0)
     for: 30m
     labels:

--- a/prometheus-rules/prometheus-vmware-rules/alerts/virtualmachine.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/virtualmachine.alerts
@@ -154,14 +154,14 @@ groups:
 
   - alert: NSXTMgmtVMsOddDistributionSDRSAntiaffinity
     expr: >
-      count (vrops_storagepod_config_sdrsconfig_vmstorageantiaffinityrules{storagepod!~"SDRS_MGMT_BB\\d+"}) by (rule_name, vcenter) != 3
+      count  (vrops_storagepod_config_sdrsconfig_vmstorageantiaffinityrules{storagepod!~"SDRS_MGMT_BB\\d+"}) by (rule_name, vccluster, vcenter) != 3
     labels:
       severity: warning
       tier: vmware
       service: network
       support_group: compute
       context: "NSXTMgmtVMsOddDistributionSDRS"
-      dashboard: management-cluster-resources/management-cluster-resources?orgId=1&var-pod=All&var-clusters={{ $labels.vccluster }}&var-hosts={{ $labels.hostsystem }}
+      dashboard: management-cluster-resources/management-cluster-resources?orgId=1&var-pod=All&var-clusters={{ $labels.vccluster }}
       meta: "NSX-T VMs not part of SDRS anti-affinity rule  {{ $labels.rule_name }}. ({{ $labels.vcenter }})"
       playbook: docs/devops/alert/vcenter/#nsxtmgmtvmsodddistributionsdrs
       no_alert_on_absence: "true"

--- a/prometheus-rules/prometheus-vmware-rules/templates/_helper.tpl
+++ b/prometheus-rules/prometheus-vmware-rules/templates/_helper.tpl
@@ -4,17 +4,3 @@
 {{- $vropshostname := split "." $name -}}
 vmware-{{ $vropshostname._0 | trimPrefix "vrops-" }}
 {{- end -}}
-
-{{- /* 
-Template around bedrock alerts 
-Author: <Christoph Richter christoph.richter@sap.com>
-Description: 
-              The original alerting rule is then wrapped by a label_replace function.
-              The label_replace adds a new label "bedrock" with the value "true" if the alert is relevant for bedrock.
-              The mappingKey is dynamically set within values.yaml for each alertname.
-*/}}
-{{- define "bedrockConfirm.expr" -}}
-{{- $expr := index . 0 -}}
-{{- $mappingKey := index . 1 -}}
-({{ $expr }}) + on({{ $mappingKey }}) group_left(bedrock) label_replace(vrops_hostsystem_hostgroups, "bedrock", "true", "hostgroups", ".*iaas.*") * 0
-{{- end -}}

--- a/prometheus-rules/prometheus-vmware-rules/templates/iaas-templated-alerts.yaml
+++ b/prometheus-rules/prometheus-vmware-rules/templates/iaas-templated-alerts.yaml
@@ -8,7 +8,7 @@ groups:
   }}
 
   {{- range $level := $alertLevels }}
-    - alert: IaasVmOnNonIaasHost{{ $level.severity | title }}
+    - alert: IaasVmOnNonIaasHost
       expr: |
         count by (hostsystem) (
           (

--- a/prometheus-rules/prometheus-vmware-rules/templates/iaas-templated-alerts.yaml
+++ b/prometheus-rules/prometheus-vmware-rules/templates/iaas-templated-alerts.yaml
@@ -1,0 +1,31 @@
+groups:
+- name: iaas.templated.alerts
+  rules:
+
+  {{- $alertLevels := list
+        (dict "for" "30m" "severity" "warning")
+        (dict "for" "90m" "severity" "critical")
+  }}
+
+  {{- range $level := $alertLevels }}
+    - alert: IaasVmOnNonIaasHost{{ $level.severity | title }}
+      expr: |
+        count by (hostsystem) (
+          (
+            group by (project, hostsystem, virtualmachine)(vrops_virtualmachine_system_powered_on{}==1)
+            and on(project)
+            group by(project) (label_replace(limes_project_usage{domain=~"iaas-.*"}, "project", "$1", "project_id", "(.*)"))
+          )
+        )
+        and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups!~".*iaas.*"}
+      for: {{ $level.for }}
+      labels:
+        severity: {{$level.severity}}
+        service: compute
+        support_group: iaas-support
+        context: "IaaS vm on non IaaS cluster"
+        meta: "IaaS virtual machine(s) running on Non IaaS ESXi host {{ `{{ $labels.hostsystem }}` }}"
+        annotations:
+          description: "IaaS virtual machine(s) running on non IaaS ESXi host {{ `{{ $labels.hostsystem }}` }}"
+          summary: "IaaS virtual machine(s) running on non IaaS ESXi host {{ `{{ $labels.hostsystem }}` }}"
+  {{- end }}

--- a/prometheus-rules/prometheus-vmware-rules/templates/iaas-templated-alerts.yaml
+++ b/prometheus-rules/prometheus-vmware-rules/templates/iaas-templated-alerts.yaml
@@ -25,7 +25,7 @@ groups:
         support_group: iaas-support
         context: "IaaS vm on non IaaS cluster"
         meta: "IaaS virtual machine(s) running on Non IaaS ESXi host {{ `{{ $labels.hostsystem }}` }}"
-        annotations:
-          description: "IaaS virtual machine(s) running on non IaaS ESXi host {{ `{{ $labels.hostsystem }}` }}"
-          summary: "IaaS virtual machine(s) running on non IaaS ESXi host {{ `{{ $labels.hostsystem }}` }}"
+      annotations:
+        description: "IaaS virtual machine(s) running on non IaaS ESXi host {{ `{{ $labels.hostsystem }}` }}"
+        summary: "IaaS virtual machine(s) running on non IaaS ESXi host {{ `{{ $labels.hostsystem }}` }}"
   {{- end }}

--- a/prometheus-rules/prometheus-vmware-rules/templates/prometheus-alerts.yaml
+++ b/prometheus-rules/prometheus-vmware-rules/templates/prometheus-alerts.yaml
@@ -6,6 +6,7 @@
     {{- $filteredBedrockAlerts = merge $filteredBedrockAlerts (dict $key $value) }}
   {{- end }}
 {{- end }}
+
 {{- range $target := .Values.global.targets }}
 {{- range $path, $bytes := $.Files.Glob "alerts/*.alerts" }}
 ---
@@ -18,26 +19,40 @@ metadata:
     prometheus: {{ include "prometheusVMware.name" (list $target $root) }}
 
 spec:
-{{- $yaml := $bytes | toString | fromYaml }}
-{{- /* 
-Iterate over group elements
-*/}}
-{{- range $group := $yaml.groups }} 
-{{- /*
-Get all rules in group
-*/}}
-{{- range $rule := $group.rules }}
-{{- if has $rule.alert (keys $filteredBedrockAlerts) }}
-{{- /*
-Replace expression for alerts matching alert name in $bedrockAlerts
-*/}}
-      {{- $mappingKey := (printf "%s" (get $bedrockAlerts $rule.alert)) }}
-      {{- $updatedExpression := (include "bedrockConfirm.expr" (list $rule.expr $mappingKey)) }}
-      {{- $_ := set $rule "expr" $updatedExpression }}
-      {{- $_ := set $rule.labels "bedrock" "{{ $labels.bedrock }}" }}
-{{- end }} 
-{{- end }}
-{{- end }}
-  groups: {{- $yaml.groups | toYaml | nindent 2 }}
+  {{- $yaml := $bytes | toString | fromYaml }}
+  {{- $finalGroups := list }}
+
+  {{- range $group := $yaml.groups }}
+    {{- $allRulesForGroup := list }}
+    {{- range $rule := $group.rules }}
+      {{- /* append the original rule to the slice of rules */}}
+      {{- $allRulesForGroup = append $allRulesForGroup $rule }}
+
+      {{- /* check, if it is a bedrock related alert */}}
+      {{- if has $rule.alert (keys $filteredBedrockAlerts) }}
+        {{- /* create a copy from the alert */}}
+        {{- $copiedAlert := deepCopy $rule }}
+
+        {{- /* add a prefix to the alert name and override/set the needed labels  */}}
+        {{- $_ := set $copiedAlert "alert" (printf "Iaas%s" $rule.alert) }}
+        {{- $_ := set $copiedAlert.labels "support_group" "iaas_support" }}
+        {{- $_ := set $copiedAlert.labels "bedrock" "true" }}
+
+        {{- /* Modify the expression to only fire, if the host is in the iaas hostgroup as well. */}}
+        {{- $newExpr := printf "(%s) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}" $rule.expr }}
+        {{- $_ := set $copiedAlert "expr" $newExpr }}
+
+        {{- /* add the copied and modified rule to the group of rules */}}
+        {{- $allRulesForGroup = append $allRulesForGroup $copiedAlert }}
+      {{- end }}
+    {{- end }}
+
+    {{- $newGroup := deepCopy $group }}
+    {{- $_ := set $newGroup "rules" $allRulesForGroup }}
+    {{- $finalGroups = append $finalGroups $newGroup }}
+  {{- end }}
+
+  {{- /* write all rules */}}
+  groups: {{- toYaml $finalGroups | nindent 4 }}
 {{- end }}
 {{- end }}

--- a/tmp.yaml
+++ b/tmp.yaml
@@ -1,0 +1,12672 @@
+---
+# Source: prometheus-vmware-rules/charts/owner-info/templates/configmap.yaml
+kind: ConfigMap
+apiVersion: v1
+
+metadata:
+  name: owner-of-prometheus-vmware-rules
+  labels:
+    # This can be used to validate via policy that everyone uses a reasonably up-to-date version of this chart.
+    owner-info-version: "0.2.0"
+
+data:
+  helm-chart-url: "https://github.com/sapcc/helm-charts/tree/master/global/prometheus-alertmanager-operated"
+  maintainers: "Tommy Sauer, Richard Tief"
+
+  support-group: "observability"
+  service: "alertmanager"
+---
+# Source: prometheus-vmware-rules/templates/iaas-templated-alerts.yaml
+groups:
+- name: iaas.templated.alerts
+  rules:
+    - alert: IaasVmOnNonIaasHost
+      expr: |
+        count by (hostsystem) (
+          (
+            group by (project, hostsystem, virtualmachine)(vrops_virtualmachine_system_powered_on{}==1)
+            and on(project)
+            group by(project) (label_replace(limes_project_usage{domain=~"iaas-.*"}, "project", "$1", "project_id", "(.*)"))
+          )
+        )
+        and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups!~".*iaas.*"}
+      for: 30m
+      labels:
+        severity: warning
+        service: compute
+        support_group: iaas-support
+        context: "IaaS vm on non IaaS cluster"
+        meta: "IaaS virtual machine(s) running on Non IaaS ESXi host {{ $labels.hostsystem }}"
+      annotations:
+        description: "IaaS virtual machine(s) running on non IaaS ESXi host {{ $labels.hostsystem }}"
+        summary: "IaaS virtual machine(s) running on non IaaS ESXi host {{ $labels.hostsystem }}"
+    - alert: IaasVmOnNonIaasHost
+      expr: |
+        count by (hostsystem) (
+          (
+            group by (project, hostsystem, virtualmachine)(vrops_virtualmachine_system_powered_on{}==1)
+            and on(project)
+            group by(project) (label_replace(limes_project_usage{domain=~"iaas-.*"}, "project", "$1", "project_id", "(.*)"))
+          )
+        )
+        and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups!~".*iaas.*"}
+      for: 90m
+      labels:
+        severity: critical
+        service: compute
+        support_group: iaas-support
+        context: "IaaS vm on non IaaS cluster"
+        meta: "IaaS virtual machine(s) running on Non IaaS ESXi host {{ $labels.hostsystem }}"
+      annotations:
+        description: "IaaS virtual machine(s) running on non IaaS ESXi host {{ $labels.hostsystem }}"
+        summary: "IaaS virtual machine(s) running on non IaaS ESXi host {{ $labels.hostsystem }}"
+---
+# Source: prometheus-vmware-rules/templates/prometheus-aggregations.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-mgmt-d-0-aggregations-virtualmachine.rules
+  labels:
+    prometheus: vmware-vc-mgmt-d-0
+
+spec:
+  groups:
+  - name: virtualmachine.rules
+    rules:
+    - record: vrops_bigvm_runtime_powerstate
+      expr: sum(vrops_virtualmachine_runtime_powerstate AND on (virtualmachine, hostsystem) vrops_virtualmachine_config_hardware_memory_kilobytes > 256000000)
+            BY (vcenter, vccluster, hostsystem, virtualmachine)
+    - record: vrops_bigvm_number_vcpus_total
+      expr: sum(vrops_virtualmachine_number_vcpus_total AND on (virtualmachine, hostsystem) vrops_virtualmachine_config_hardware_memory_kilobytes > 256000000)
+            BY (vcenter, vccluster, hostsystem, virtualmachine)
+    - record: vrops_bigvm_cpu_demand_ratio
+      expr: sum(vrops_virtualmachine_cpu_demand_ratio AND on (virtualmachine, hostsystem) vrops_virtualmachine_config_hardware_memory_kilobytes > 256000000)
+            BY (vcenter, vccluster, hostsystem, virtualmachine)
+    - record: vrops_bigvm_cpu_io_wait_percentage
+      expr: sum(vrops_virtualmachine_cpu_io_wait_percentage AND on (virtualmachine, hostsystem) vrops_virtualmachine_config_hardware_memory_kilobytes > 256000000)
+            BY (vcenter, vccluster, hostsystem, virtualmachine)
+    - record: vrops_bigvm_cpu_usage_ratio
+      expr: sum(vrops_virtualmachine_cpu_usage_ratio AND on (virtualmachine, hostsystem) vrops_virtualmachine_config_hardware_memory_kilobytes > 256000000)
+            BY (vcenter, vccluster, hostsystem, virtualmachine)
+    - record: vrops_bigvm_memory_nonzero_active_kilobytes
+      expr: sum(vrops_virtualmachine_memory_nonzero_active_kilobytes AND on (virtualmachine, hostsystem) vrops_virtualmachine_config_hardware_memory_kilobytes > 256000000)
+            BY (vcenter, vccluster, hostsystem, virtualmachine)
+    - record: vrops_bigvm_memory_activewrite_kilobytes
+      expr: sum(vrops_virtualmachine_memory_activewrite_kilobytes AND on (virtualmachine, hostsystem) vrops_virtualmachine_config_hardware_memory_kilobytes > 256000000)
+            BY (vcenter, vccluster, hostsystem, virtualmachine)
+---
+# Source: prometheus-vmware-rules/templates/prometheus-aggregations.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-mgmt-a-0-aggregations-virtualmachine.rules
+  labels:
+    prometheus: vmware-vc-mgmt-a-0
+
+spec:
+  groups:
+  - name: virtualmachine.rules
+    rules:
+    - record: vrops_bigvm_runtime_powerstate
+      expr: sum(vrops_virtualmachine_runtime_powerstate AND on (virtualmachine, hostsystem) vrops_virtualmachine_config_hardware_memory_kilobytes > 256000000)
+            BY (vcenter, vccluster, hostsystem, virtualmachine)
+    - record: vrops_bigvm_number_vcpus_total
+      expr: sum(vrops_virtualmachine_number_vcpus_total AND on (virtualmachine, hostsystem) vrops_virtualmachine_config_hardware_memory_kilobytes > 256000000)
+            BY (vcenter, vccluster, hostsystem, virtualmachine)
+    - record: vrops_bigvm_cpu_demand_ratio
+      expr: sum(vrops_virtualmachine_cpu_demand_ratio AND on (virtualmachine, hostsystem) vrops_virtualmachine_config_hardware_memory_kilobytes > 256000000)
+            BY (vcenter, vccluster, hostsystem, virtualmachine)
+    - record: vrops_bigvm_cpu_io_wait_percentage
+      expr: sum(vrops_virtualmachine_cpu_io_wait_percentage AND on (virtualmachine, hostsystem) vrops_virtualmachine_config_hardware_memory_kilobytes > 256000000)
+            BY (vcenter, vccluster, hostsystem, virtualmachine)
+    - record: vrops_bigvm_cpu_usage_ratio
+      expr: sum(vrops_virtualmachine_cpu_usage_ratio AND on (virtualmachine, hostsystem) vrops_virtualmachine_config_hardware_memory_kilobytes > 256000000)
+            BY (vcenter, vccluster, hostsystem, virtualmachine)
+    - record: vrops_bigvm_memory_nonzero_active_kilobytes
+      expr: sum(vrops_virtualmachine_memory_nonzero_active_kilobytes AND on (virtualmachine, hostsystem) vrops_virtualmachine_config_hardware_memory_kilobytes > 256000000)
+            BY (vcenter, vccluster, hostsystem, virtualmachine)
+    - record: vrops_bigvm_memory_activewrite_kilobytes
+      expr: sum(vrops_virtualmachine_memory_activewrite_kilobytes AND on (virtualmachine, hostsystem) vrops_virtualmachine_config_hardware_memory_kilobytes > 256000000)
+            BY (vcenter, vccluster, hostsystem, virtualmachine)
+---
+# Source: prometheus-vmware-rules/templates/prometheus-aggregations.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-mgmt-b-0-aggregations-virtualmachine.rules
+  labels:
+    prometheus: vmware-vc-mgmt-b-0
+
+spec:
+  groups:
+  - name: virtualmachine.rules
+    rules:
+    - record: vrops_bigvm_runtime_powerstate
+      expr: sum(vrops_virtualmachine_runtime_powerstate AND on (virtualmachine, hostsystem) vrops_virtualmachine_config_hardware_memory_kilobytes > 256000000)
+            BY (vcenter, vccluster, hostsystem, virtualmachine)
+    - record: vrops_bigvm_number_vcpus_total
+      expr: sum(vrops_virtualmachine_number_vcpus_total AND on (virtualmachine, hostsystem) vrops_virtualmachine_config_hardware_memory_kilobytes > 256000000)
+            BY (vcenter, vccluster, hostsystem, virtualmachine)
+    - record: vrops_bigvm_cpu_demand_ratio
+      expr: sum(vrops_virtualmachine_cpu_demand_ratio AND on (virtualmachine, hostsystem) vrops_virtualmachine_config_hardware_memory_kilobytes > 256000000)
+            BY (vcenter, vccluster, hostsystem, virtualmachine)
+    - record: vrops_bigvm_cpu_io_wait_percentage
+      expr: sum(vrops_virtualmachine_cpu_io_wait_percentage AND on (virtualmachine, hostsystem) vrops_virtualmachine_config_hardware_memory_kilobytes > 256000000)
+            BY (vcenter, vccluster, hostsystem, virtualmachine)
+    - record: vrops_bigvm_cpu_usage_ratio
+      expr: sum(vrops_virtualmachine_cpu_usage_ratio AND on (virtualmachine, hostsystem) vrops_virtualmachine_config_hardware_memory_kilobytes > 256000000)
+            BY (vcenter, vccluster, hostsystem, virtualmachine)
+    - record: vrops_bigvm_memory_nonzero_active_kilobytes
+      expr: sum(vrops_virtualmachine_memory_nonzero_active_kilobytes AND on (virtualmachine, hostsystem) vrops_virtualmachine_config_hardware_memory_kilobytes > 256000000)
+            BY (vcenter, vccluster, hostsystem, virtualmachine)
+    - record: vrops_bigvm_memory_activewrite_kilobytes
+      expr: sum(vrops_virtualmachine_memory_activewrite_kilobytes AND on (virtualmachine, hostsystem) vrops_virtualmachine_config_hardware_memory_kilobytes > 256000000)
+            BY (vcenter, vccluster, hostsystem, virtualmachine)
+---
+# Source: prometheus-vmware-rules/templates/prometheus-aggregations.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-a-0-aggregations-virtualmachine.rules
+  labels:
+    prometheus: vmware-vc-a-0
+
+spec:
+  groups:
+  - name: virtualmachine.rules
+    rules:
+    - record: vrops_bigvm_runtime_powerstate
+      expr: sum(vrops_virtualmachine_runtime_powerstate AND on (virtualmachine, hostsystem) vrops_virtualmachine_config_hardware_memory_kilobytes > 256000000)
+            BY (vcenter, vccluster, hostsystem, virtualmachine)
+    - record: vrops_bigvm_number_vcpus_total
+      expr: sum(vrops_virtualmachine_number_vcpus_total AND on (virtualmachine, hostsystem) vrops_virtualmachine_config_hardware_memory_kilobytes > 256000000)
+            BY (vcenter, vccluster, hostsystem, virtualmachine)
+    - record: vrops_bigvm_cpu_demand_ratio
+      expr: sum(vrops_virtualmachine_cpu_demand_ratio AND on (virtualmachine, hostsystem) vrops_virtualmachine_config_hardware_memory_kilobytes > 256000000)
+            BY (vcenter, vccluster, hostsystem, virtualmachine)
+    - record: vrops_bigvm_cpu_io_wait_percentage
+      expr: sum(vrops_virtualmachine_cpu_io_wait_percentage AND on (virtualmachine, hostsystem) vrops_virtualmachine_config_hardware_memory_kilobytes > 256000000)
+            BY (vcenter, vccluster, hostsystem, virtualmachine)
+    - record: vrops_bigvm_cpu_usage_ratio
+      expr: sum(vrops_virtualmachine_cpu_usage_ratio AND on (virtualmachine, hostsystem) vrops_virtualmachine_config_hardware_memory_kilobytes > 256000000)
+            BY (vcenter, vccluster, hostsystem, virtualmachine)
+    - record: vrops_bigvm_memory_nonzero_active_kilobytes
+      expr: sum(vrops_virtualmachine_memory_nonzero_active_kilobytes AND on (virtualmachine, hostsystem) vrops_virtualmachine_config_hardware_memory_kilobytes > 256000000)
+            BY (vcenter, vccluster, hostsystem, virtualmachine)
+    - record: vrops_bigvm_memory_activewrite_kilobytes
+      expr: sum(vrops_virtualmachine_memory_activewrite_kilobytes AND on (virtualmachine, hostsystem) vrops_virtualmachine_config_hardware_memory_kilobytes > 256000000)
+            BY (vcenter, vccluster, hostsystem, virtualmachine)
+---
+# Source: prometheus-vmware-rules/templates/prometheus-aggregations.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-b-0-aggregations-virtualmachine.rules
+  labels:
+    prometheus: vmware-vc-b-0
+
+spec:
+  groups:
+  - name: virtualmachine.rules
+    rules:
+    - record: vrops_bigvm_runtime_powerstate
+      expr: sum(vrops_virtualmachine_runtime_powerstate AND on (virtualmachine, hostsystem) vrops_virtualmachine_config_hardware_memory_kilobytes > 256000000)
+            BY (vcenter, vccluster, hostsystem, virtualmachine)
+    - record: vrops_bigvm_number_vcpus_total
+      expr: sum(vrops_virtualmachine_number_vcpus_total AND on (virtualmachine, hostsystem) vrops_virtualmachine_config_hardware_memory_kilobytes > 256000000)
+            BY (vcenter, vccluster, hostsystem, virtualmachine)
+    - record: vrops_bigvm_cpu_demand_ratio
+      expr: sum(vrops_virtualmachine_cpu_demand_ratio AND on (virtualmachine, hostsystem) vrops_virtualmachine_config_hardware_memory_kilobytes > 256000000)
+            BY (vcenter, vccluster, hostsystem, virtualmachine)
+    - record: vrops_bigvm_cpu_io_wait_percentage
+      expr: sum(vrops_virtualmachine_cpu_io_wait_percentage AND on (virtualmachine, hostsystem) vrops_virtualmachine_config_hardware_memory_kilobytes > 256000000)
+            BY (vcenter, vccluster, hostsystem, virtualmachine)
+    - record: vrops_bigvm_cpu_usage_ratio
+      expr: sum(vrops_virtualmachine_cpu_usage_ratio AND on (virtualmachine, hostsystem) vrops_virtualmachine_config_hardware_memory_kilobytes > 256000000)
+            BY (vcenter, vccluster, hostsystem, virtualmachine)
+    - record: vrops_bigvm_memory_nonzero_active_kilobytes
+      expr: sum(vrops_virtualmachine_memory_nonzero_active_kilobytes AND on (virtualmachine, hostsystem) vrops_virtualmachine_config_hardware_memory_kilobytes > 256000000)
+            BY (vcenter, vccluster, hostsystem, virtualmachine)
+    - record: vrops_bigvm_memory_activewrite_kilobytes
+      expr: sum(vrops_virtualmachine_memory_activewrite_kilobytes AND on (virtualmachine, hostsystem) vrops_virtualmachine_config_hardware_memory_kilobytes > 256000000)
+            BY (vcenter, vccluster, hostsystem, virtualmachine)
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-mgmt-d-0-alerts-datastore.alerts
+  labels:
+    prometheus: vmware-vc-mgmt-d-0
+
+spec:
+  groups:
+    - name: datastore.alerts
+      rules:
+      - alert: EphemeralDataStoreCapacity
+        annotations:
+          description: Eph Datastore {{ $labels.datastore }} utilization > 85%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          summary: Eph Datastore {{ $labels.datastore }} utilization > 85%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+        expr: |
+          vrops_datastore_diskspace_total_usage_gigabytes{type="ephemeral"} / vrops_datastore_diskspace_capacity_gigabytes >= 0.85
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          dashboard: vcenter-datastore-utilization
+          meta: Eph Datastore {{ $labels.datastore }} utilization > 85%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          playbook: docs/support/playbook/datastore/datastorediskusagealarm
+          service: storage
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: EphemeralDataStoreCapacity
+        annotations:
+          description: Eph Datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          summary: Eph Datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+        expr: |
+          vrops_datastore_diskspace_total_usage_gigabytes{type="ephemeral"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.9
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          dashboard: vcenter-datastore-utilization
+          meta: Eph Datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          playbook: docs/support/playbook/datastore/datastorediskusagealarm
+          service: storage
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: AverageVmfsDataStoreCapacity
+        annotations:
+          description: Average utilization for `{{ $labels.type }}` Datastores per vCenter
+            is above 70%. ({{ $labels.vcenter }})
+          summary: Average utilization for `{{ $labels.type }}` Datastores per vCenter
+            is above 70%. ({{ $labels.vcenter }})
+        expr: |
+          avg by (type, vcenter) (vrops_datastore_diskspace_total_usage_gigabytes{type=~"vmfs_p_ssd|vmfs_s_hdd"} / vrops_datastore_diskspace_capacity_gigabytes) > 0.85
+        for: 20m
+        labels:
+          context: '{{ $labels.type }} storage'
+          dashboard: vcenter-datastore-utilization
+          meta: Average utilization for `{{ $labels.type }}` Datastores per vCenter is
+            above 70%. ({{ $labels.vcenter }})
+          playbook: docs/support/playbook/storage/new_storage_lun_request
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: DataStoreCapacity
+        annotations:
+          description: '{{ $labels.type }} datastore {{ $labels.datastore }} utilization
+            > 80%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
+          summary: '{{ $labels.type }} datastore {{ $labels.datastore }} utilization >
+            80%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
+        expr: |
+          vrops_datastore_diskspace_total_usage_gigabytes{type!~"ephemeral|vmfs.+|nfs", datastore!~".+swap"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.8
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          dashboard: vcenter-datastore-utilization
+          meta: '{{ $labels.type }} datastore {{ $labels.datastore }} utilization > 80%.
+            ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
+          playbook: docs/support/playbook/datastore/datastorediskusagealarm
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: DataStoreCapacity
+        annotations:
+          description: '{{ $labels.type }} datastore {{ $labels.datastore }} utilization
+            > 90%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
+          summary: '{{ $labels.type }} datastore {{ $labels.datastore }} utilization >
+            90%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
+        expr: |
+          vrops_datastore_diskspace_total_usage_gigabytes{type!~"ephemeral|vmfs.+|nfs", datastore!~".+swap"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.9
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          dashboard: vcenter-datastore-utilization
+          meta: '{{ $labels.type }} datastore {{ $labels.datastore }} utilization > 90%.
+            ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
+          playbook: docs/support/playbook/datastore/datastorediskusagealarm
+          service: storage
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: SwapDataStoreUsageWithoutVMs
+        annotations:
+          description: NVMe swap datastore {{ $labels.datastore }} is utilized without
+            associated VMs. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: NVMe swap datastore {{ $labels.datastore }} is utilized without associated
+            VMs. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: |
+          vrops_datastore_diskspace_total_usage_gigabytes{datastore=~".*-swap"} > 10 and vrops_datastore_summary_total_number_vms == 0 unless on (datastore) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "datastore", "$1-swap", "hostsystem", "(node...-bb...).*")
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          meta: NVMe swap datastore {{ $labels.datastore }} is utilized without associated
+            VMs. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#swap-files-exist-on-local-ds-without-running-vms
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NVMeSwapDatastoreMissing
+        annotations:
+          description: |-
+            NVMe swap datastore on `{{ $labels.hostsystem }}` is missing. Model is _{{$labels.hardware_model}}_ and located in cluster *{{ $labels.vccluster }}*
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            NVMe swap datastore on `{{ $labels.hostsystem }}` is missing. Model is _{{$labels.hardware_model}}_ and located in cluster *{{ $labels.vccluster }}*
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_hostsystem_hardware_model{vccluster=~"productionbb\\d+", hardware_model!~"Cisco Systems Inc.+"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          unless on (hostsystem) (label_replace(label_join(vrops_datastore_summary_datastore_accessible{type="NVMe"}, "hostsystem", "", "datastore", "vcenter"), "hostsystem", "$1$2", "hostsystem", "(.+)-swapvc-[a-z]-\\d+(.+)")
+          or vrops_hostsystem_summary_custom_tag_nvme{summary_custom_tag_nvme="false"})
+        for: 5m
+        labels:
+          context: '{{ $labels.hostsystem }}'
+          meta: |-
+            NVMe swap datastore on `{{ $labels.hostsystem }}` is missing. Model is _{{$labels.hardware_model}}_ and located in cluster *{{ $labels.vccluster }}*
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          playbook: docs/support/playbook/datastore/nvmeswapdatastoremissing
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: DatastoreDisconnectedWithVmsOnIt
+        annotations:
+          description: Datastore {{ $labels.datastore }} is disconnected and has virtual
+            machines on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: Datastore {{ $labels.datastore }} is disconnected and has virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: |
+          (label_replace(vrops_datastore_summary_total_number_vms, "hostsystem", "$1", "datastore", "(node[0-9]{3}-[^-]*).*") > 0 and on(datastore) vrops_datastore_summary_datastore_accessible{state="PoweredOff",type!="local"}) unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          meta: Datastore {{ $labels.datastore }} is disconnected and has virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#datastoredisconnectedwithvmsonit
+          service: storage
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: IaasDatastoreDisconnectedWithVmsOnIt
+        annotations:
+          description: Datastore {{ $labels.datastore }} is disconnected and has virtual
+            machines on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: Datastore {{ $labels.datastore }} is disconnected and has virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: |-
+          ((label_replace(vrops_datastore_summary_total_number_vms, "hostsystem", "$1", "datastore", "(node[0-9]{3}-[^-]*).*") > 0 and on(datastore) vrops_datastore_summary_datastore_accessible{state="PoweredOff",type!="local"}) unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 20m
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.datastore }}'
+          meta: Datastore {{ $labels.datastore }} is disconnected and has virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#datastoredisconnectedwithvmsonit
+          service: storage
+          severity: critical
+          support_group: iaas_support
+          tier: vmware
+      - alert: DatastoreDisconnectedWithoutVmsOnIt
+        annotations:
+          description: Datastore {{ $labels.datastore }} is disconnected without virtual
+            machines on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: Datastore {{ $labels.datastore }} is disconnected without virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: |
+          (label_replace(vrops_datastore_summary_total_number_vms, "hostsystem", "$1", "datastore", "(node[0-9]{3}-[^-]*).*") == 0 and on(datastore) vrops_datastore_summary_datastore_accessible{state="PoweredOff",type!="local"}) unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          meta: Datastore {{ $labels.datastore }} is disconnected without virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#datastoredisconnectedwithoutvmsonit
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasDatastoreDisconnectedWithoutVmsOnIt
+        annotations:
+          description: Datastore {{ $labels.datastore }} is disconnected without virtual
+            machines on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: Datastore {{ $labels.datastore }} is disconnected without virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: |-
+          ((label_replace(vrops_datastore_summary_total_number_vms, "hostsystem", "$1", "datastore", "(node[0-9]{3}-[^-]*).*") == 0 and on(datastore) vrops_datastore_summary_datastore_accessible{state="PoweredOff",type!="local"}) unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 20m
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.datastore }}'
+          meta: Datastore {{ $labels.datastore }} is disconnected without virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#datastoredisconnectedwithoutvmsonit
+          service: storage
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: DatastoreHasLostConnectivityToAStorageDevice
+        annotations:
+          description: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has lost connectivity to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has lost connectivity to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          label_replace(vrops_datastore_alert_info{alert_name="Datastore has lost connectivity to a storage device"}, "hostsystem", "$1", "datastore", "(node.*)(-.*)") unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+        labels:
+          meta: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has lost connectivity to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#datastorehashoststhathavelostredundantpathsanddatastorehaslostconnectivitytoastoragedevice
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasDatastoreHasLostConnectivityToAStorageDevice
+        annotations:
+          description: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has lost connectivity to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has lost connectivity to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |-
+          (label_replace(vrops_datastore_alert_info{alert_name="Datastore has lost connectivity to a storage device"}, "hostsystem", "$1", "datastore", "(node.*)(-.*)") unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          meta: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has lost connectivity to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#datastorehashoststhathavelostredundantpathsanddatastorehaslostconnectivitytoastoragedevice
+          service: storage
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: DatastoreHasHostsThatHaveLostRedundantPathsToAStorageDevice
+        annotations:
+          description: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has hosts that have lost redundant paths to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has hosts that have lost redundant paths to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          label_replace(vrops_datastore_alert_info{alert_name="Datastore has one or more hosts that have lost redundant paths to a storage device"}, "hostsystem", "$1", "datastore", "(node.*)(-.*)") unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+        labels:
+          meta: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has hosts that have lost redundant paths to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#datastorehashoststhathavelostredundantpathsanddatastorehaslostconnectivitytoastoragedevice
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasDatastoreHasHostsThatHaveLostRedundantPathsToAStorageDevice
+        annotations:
+          description: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has hosts that have lost redundant paths to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has hosts that have lost redundant paths to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |-
+          (label_replace(vrops_datastore_alert_info{alert_name="Datastore has one or more hosts that have lost redundant paths to a storage device"}, "hostsystem", "$1", "datastore", "(node.*)(-.*)") unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          meta: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has hosts that have lost redundant paths to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#datastorehashoststhathavelostredundantpathsanddatastorehaslostconnectivitytoastoragedevice
+          service: storage
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: SDRSClusterCapacity
+        annotations:
+          description: DataStore Cluster {{ $labels.storagepod }} utilization > 80%. ({{
+            $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: DataStore Cluster {{ $labels.storagepod }} utilization > 80%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+        expr: |
+          vrops_storagepod_capacity_available_space / vrops_storagepod_capacity_total * 100 <= 20
+        for: 20m
+        labels:
+          context: '{{ $labels.storagepod }}'
+          dashboard: vcenter-datastore-utilization
+          meta: DataStore Cluster {{ $labels.storagepod }} utilization > 80%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          playbook: docs/support/playbook/datastore/datastorediskusagealarm
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: SDRSClusterCapacity
+        annotations:
+          description: DataStore Cluster {{ $labels.storagepod }} utilization > 90%. ({{
+            $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: DataStore Cluster {{ $labels.storagepod }} utilization > 90%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+        expr: |
+          vrops_storagepod_capacity_available_space / vrops_storagepod_capacity_total * 100 <= 10
+        for: 20m
+        labels:
+          context: '{{ $labels.storagepod }}'
+          dashboard: vcenter-datastore-utilization
+          meta: DataStore Cluster {{ $labels.storagepod }} utilization > 90%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          playbook: docs/support/playbook/datastore/datastorediskusagealarm
+          service: storage
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: NVMeDatastoreNotAccessible
+        annotations:
+          description: Datastore {{ $labels.datastore }} is not accessible. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          summary: Datastore {{ $labels.datastore }} is not accessible. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+        expr: |
+          vrops_datastore_summary_datastore_accessible{type='NVMe'} == 0
+        for: 5m
+        labels:
+          context: '{{ $labels.datastore }}'
+          meta: Datastore {{ $labels.datastore }} is not accessible. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          service: storage
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: EphemeralDatastoreNotPartOfSDRSCluster
+        annotations:
+          description: Eph Datastore {{ $labels.datastore }} is not a part of SDRS Cluster.
+            ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: Eph Datastore {{ $labels.datastore }} is not a part of SDRS Cluster.
+            ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: |
+          vrops_datastore_summary_datastore_accessible{type="ephemeral", storagepod=~"none|None|NONE", datastore=~"eph.*"} > 0
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          meta: Eph Datastore {{ $labels.datastore }} is not a part of SDRS cluster. ({{
+            $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#ephemeraldatastorenotpartofsdrscluster
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: EphemeralDatastorePartOfIncorrectSDRSCluster
+        annotations:
+          description: Eph Datastore {{ $labels.datastore }} is not a part of correct
+            SDRS Cluster. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: Eph Datastore {{ $labels.datastore }} is not a part of correct SDRS
+            Cluster. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: |
+          (vrops_datastore_summary_datastore_accessible{type="ephemeral", storagepod=~".*hgb.*", datastore=~"eph.*hga"} or vrops_datastore_summary_datastore_accessible{type="ephemeral", storagepod=~".*hga.*", datastore=~"eph.*hgb"}) > 0
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          meta: Eph Datastore {{ $labels.datastore }} is not a part of correct SDRS cluster.
+            ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#ephemeraldatastorepartofincorrectsdrscluster
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: CinderTagMissingForDatastoreSSD
+        annotations:
+          description: |-
+            There is no Cinder tag present for the `{{ $labels.datastore }}` datastore in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            There is no Cinder tag present for the `{{ $labels.datastore }}` datastore in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_datastore_summary_tag{type="vmfs_p_ssd", summary_tag="none"}
+          unless on (datastore) vrops_datastore_summary_custom_tag_cinder_state{summary_custom_tag_cinder_state="reserved"}
+        for: 1h
+        labels:
+          meta: |-
+            There is no Cinder tag present for the `{{ $labels.datastore }}` datastore in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          playbook: docs/support/playbook/cinder/cinder-tag-missing
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: CinderTagMissingForDatastoreHDD
+        annotations:
+          description: |-
+            There is no Cinder tag present for the `{{ $labels.datastore }}` datastore in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            There is no Cinder tag present for the `{{ $labels.datastore }}` datastore in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_datastore_summary_tag{type="vmfs_s_hdd", summary_tag="none"}
+          unless on (datastore) vrops_datastore_summary_custom_tag_cinder_state{summary_custom_tag_cinder_state="reserved"}
+        for: 1h
+        labels:
+          meta: |-
+            There is no Cinder tag present for the `{{ $labels.datastore }}` datastore in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          playbook: docs/support/playbook/cinder/cinder-tag-missing
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: CinderTagAddedForReservedDatastore
+        annotations:
+          description: |-
+            The Cinder state is reserved but the Cinder tag still exists for the `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The Cinder state is reserved but the Cinder tag still exists for the `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_datastore_summary_custom_tag_cinder_state{type=~"(vmfs_s_hdd|vmfs_p_ssd)", summary_custom_tag_cinder_state="reserved"} > 0
+          and on (datastore) vrops_datastore_summary_tag{tag_cinder=~"cinder|slow"}
+        for: 1h
+        labels:
+          meta: |-
+            The Cinder state is reserved but the Cinder tag still exists for the `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          playbook: docs/support/playbook/cinder/cinder-tag-added
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VMFSDatastoreHostcountMismatch
+        annotations:
+          description: |-
+            The `{{ $labels.datastore }}` VMFS datastore is not connected to all production ESXi hosts in *{{ $labels.vcenter }}* vCenter.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The `{{ $labels.datastore }}` VMFS datastore is not connected to all production ESXi hosts in *{{ $labels.vcenter }}* vCenter.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_datastore_hostcount{type=~"(vmfs_s_hdd|vmfs_p_ssd)"} < on (vcenter) group_left
+          count by (vcenter) (vrops_hostsystem_runtime_connectionstate{state="connected", vccluster=~"productionbb\\d+"}
+          unless on (hostsystem) (vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}))
+        for: 60m
+        labels:
+          meta: |-
+            The `{{ $labels.datastore }}` VMFS datastore is not connected to all production ESXi hosts in *{{ $labels.vcenter }}* vCenter.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          playbook: docs/devops/alert/vcenter/#vmfsdatastorehostcountmismatch
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NFSDatastoreHostcountMismatch
+        annotations:
+          description: |-
+            The `{{ $labels.datastore }}` NFS datastore is not connected to all production ESXi hosts in *{{ $labels.vcenter }}* vCenter.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The `{{ $labels.datastore }}` NFS datastore is not connected to all production ESXi hosts in *{{ $labels.vcenter }}* vCenter.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_datastore_hostcount{type="nfs"} < on (vcenter) group_left
+          count by (vcenter) (vrops_hostsystem_runtime_connectionstate{state="connected", vccluster=~"productionbb\\d+"})
+        for: 60m
+        labels:
+          meta: |-
+            The `{{ $labels.datastore }}` NFS datastore is not connected to all production ESXi hosts in *{{ $labels.vcenter }}* vCenter.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          playbook: docs/devops/alert/vcenter/#nfsdatastorehostcountmismatch
+          service: storage
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: NFSDatastoreCinderAggregateIDNotSet
+        annotations:
+          description: |-
+            cinder_aggregate_id is not set for the `{{ $labels.datastore }}` NFS datastore in *{{ $labels.datacenter }}* availability zone.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            cinder_aggregate_id is not set for the `{{ $labels.datastore }}` NFS datastore in *{{ $labels.datacenter }}* availability zone.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_datastore_summary_datastore_accessible{type="nfs"}
+          unless on(datastore) vrops_datastore_summary_custom_tag_cinder_aggregate_id{type="nfs", summary_custom_tag_cinder_aggregate_id!=""}
+        for: 1h
+        labels:
+          meta: |-
+            cinder_aggregate_id is not set for the `{{ $labels.datastore }}` NFS datastore in *{{ $labels.datacenter }}* availability zone.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          playbook: docs/support/playbook/cinder/cinder-fcd-operations/#nfsdatastorecinderaggregateidnotset
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-mgmt-d-0-alerts-host.alerts
+  labels:
+    prometheus: vmware-vc-mgmt-d-0
+
+spec:
+  groups:
+    - name: host.alerts
+      rules:
+      - alert: HostWithRunningVMsNotResponding
+        annotations:
+          description: Host {{ $labels.hostsystem }} with running VMs not responding.
+            ({{ $labels.vcenter }}, {{ $labels.vccluster }})
+          summary: Host {{ $labels.hostsystem }} with running VMs not responding. ({{
+            $labels.vcenter }}, {{ $labels.vccluster }})
+        expr: |
+          avg_over_time(vrops_hostsystem_runtime_connectionstate{state="notResponding"}[5m])
+          and on (hostsystem) avg_over_time(vrops_hostsystem_runtime_powerstate{state!="Powered Off"}[5m])
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"}
+          and on (hostsystem) count(vrops_virtualmachine_runtime_powerstate{virtualmachine!~"vCLS.*", state!="Powered Off"}) by (hostsystem) > 0
+        for: 5m
+        labels:
+          context: ESXi not responding
+          dashboard: esxi-host-disconnected/esxi-host-disconnected?&var-host={{ $labels.hostsystem
+            }}
+          meta: Host {{ $labels.hostsystem }} with running VMs not responding. ({{ $labels.vcenter
+            }}, {{ $labels.vccluster }})
+          playbook: docs/devops/alert/vcenter/#hostwithrunningvmsnotresponding
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostWithRunningVMsNotResponding
+        annotations:
+          description: Host {{ $labels.hostsystem }} with running VMs not responding.
+            ({{ $labels.vcenter }}, {{ $labels.vccluster }})
+          summary: Host {{ $labels.hostsystem }} with running VMs not responding. ({{
+            $labels.vcenter }}, {{ $labels.vccluster }})
+        expr: |-
+          (avg_over_time(vrops_hostsystem_runtime_connectionstate{state="notResponding"}[5m])
+          and on (hostsystem) avg_over_time(vrops_hostsystem_runtime_powerstate{state!="Powered Off"}[5m])
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"}
+          and on (hostsystem) count(vrops_virtualmachine_runtime_powerstate{virtualmachine!~"vCLS.*", state!="Powered Off"}) by (hostsystem) > 0
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 5m
+        labels:
+          bedrock: "true"
+          context: ESXi not responding
+          dashboard: esxi-host-disconnected/esxi-host-disconnected?&var-host={{ $labels.hostsystem
+            }}
+          meta: Host {{ $labels.hostsystem }} with running VMs not responding. ({{ $labels.vcenter
+            }}, {{ $labels.vccluster }})
+          playbook: docs/devops/alert/vcenter/#hostwithrunningvmsnotresponding
+          service: compute
+          severity: critical
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostNotResponding
+        annotations:
+          description: Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter
+            }}, {{ $labels.vccluster }})
+          summary: Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter }},
+            {{ $labels.vccluster }})
+        expr: |
+          vrops_hostsystem_summary_running_vms_number == 0 and
+          on (hostsystem) vrops_hostsystem_runtime_connectionstate{state="notResponding"} and
+          on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"} and
+          on (hostsystem) vrops_hostsystem_runtime_powerstate{state!="Powered Off"}
+        labels:
+          context: ESXi not responding
+          dashboard: esxi-host-disconnected/esxi-host-disconnected?&var-host={{ $labels.hostsystem
+            }}
+          meta: Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter }},
+            {{ $labels.vccluster }})
+          playbook: docs/devops/alert/vcenter/#hostnotresponding
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostNotResponding
+        annotations:
+          description: Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter
+            }}, {{ $labels.vccluster }})
+          summary: Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter }},
+            {{ $labels.vccluster }})
+        expr: |-
+          (vrops_hostsystem_summary_running_vms_number == 0 and
+          on (hostsystem) vrops_hostsystem_runtime_connectionstate{state="notResponding"} and
+          on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"} and
+          on (hostsystem) vrops_hostsystem_runtime_powerstate{state!="Powered Off"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: ESXi not responding
+          dashboard: esxi-host-disconnected/esxi-host-disconnected?&var-host={{ $labels.hostsystem
+            }}
+          meta: Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter }},
+            {{ $labels.vccluster }})
+          playbook: docs/devops/alert/vcenter/#hostnotresponding
+          service: compute
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: VMsOnFailoverHost
+        annotations:
+          description: Failover Host {{ $labels.hostsystem }} has Virtual Machines on
+            it. Free up the host. ({{ $labels.vcenter }}, {{ $labels.vccluster }})
+          summary: Failover Host {{ $labels.hostsystem }} has Virtual Machines on it.
+            ({{ $labels.vcenter }}, {{ $labels.vccluster }})
+        expr: |
+          vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost == 1
+          and on (hostsystem) count(vrops_virtualmachine_runtime_powerstate{virtualmachine!~"vCLS.*", state="Powered On"}) by (hostsystem) > 0
+        for: 10m
+        labels:
+          context: Failover host
+          meta: Failover Host {{ $labels.hostsystem }} has Virtual Machines on it. ({{
+            $labels.vcenter }}, {{ $labels.vccluster }})
+          playbook: docs/devops/alert/vcenter/#vmsonfailoverhost
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: IaasVMsOnFailoverHost
+        annotations:
+          description: Failover Host {{ $labels.hostsystem }} has Virtual Machines on
+            it. Free up the host. ({{ $labels.vcenter }}, {{ $labels.vccluster }})
+          summary: Failover Host {{ $labels.hostsystem }} has Virtual Machines on it.
+            ({{ $labels.vcenter }}, {{ $labels.vccluster }})
+        expr: |-
+          (vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost == 1
+          and on (hostsystem) count(vrops_virtualmachine_runtime_powerstate{virtualmachine!~"vCLS.*", state="Powered On"}) by (hostsystem) > 0
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 10m
+        labels:
+          bedrock: "true"
+          context: Failover host
+          meta: Failover Host {{ $labels.hostsystem }} has Virtual Machines on it. ({{
+            $labels.vcenter }}, {{ $labels.vccluster }})
+          playbook: docs/devops/alert/vcenter/#vmsonfailoverhost
+          service: compute
+          severity: critical
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostHasLostRedundantConnectivityToDVPort
+        annotations:
+          description: Host `{{ $labels.hostsystem }}` has lost redundant connectivity
+            to a dvPort. ({{ $labels.vcenter }}).
+          summary: Host `{{ $labels.hostsystem }}` has lost redundant connectivity to
+            a dvPort. ({{ $labels.vcenter }}).
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="The host has lost redundant connectivity to a dvPort"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        labels:
+          context: '{{ $labels.hostsystem }} dvPort connection'
+          meta: Host `{{ $labels.hostsystem }}` has lost redundant connectivity to a dvPort.
+            ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#host_has_lost_connectivity_to_a_dv_port
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostHasLostRedundantConnectivityToDVPort
+        annotations:
+          description: Host `{{ $labels.hostsystem }}` has lost redundant connectivity
+            to a dvPort. ({{ $labels.vcenter }}).
+          summary: Host `{{ $labels.hostsystem }}` has lost redundant connectivity to
+            a dvPort. ({{ $labels.vcenter }}).
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="The host has lost redundant connectivity to a dvPort"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} dvPort connection'
+          meta: Host `{{ $labels.hostsystem }}` has lost redundant connectivity to a dvPort.
+            ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#host_has_lost_connectivity_to_a_dv_port
+          service: compute
+          severity: info
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostNicDown
+        annotations:
+          description: '`{{ $labels.hostsystem }}` has detected a link status down on
+            a physical NIC. ({{ $labels.vcenter }}).'
+          summary: '`{{ $labels.hostsystem }}` has detected a link status down on a physical
+            NIC. ({{ $labels.vcenter }}).'
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="ESXi host has detected a link status down on a physical NIC"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        for: 20m
+        labels:
+          context: '{{ $labels.hostsystem }} network connection'
+          meta: '`{{ $labels.hostsystem }}` has detected a link status down on a physical
+            NIC. ({{ $labels.vcenter }}).'
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hostnicdown
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostNicDown
+        annotations:
+          description: '`{{ $labels.hostsystem }}` has detected a link status down on
+            a physical NIC. ({{ $labels.vcenter }}).'
+          summary: '`{{ $labels.hostsystem }}` has detected a link status down on a physical
+            NIC. ({{ $labels.vcenter }}).'
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="ESXi host has detected a link status down on a physical NIC"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 20m
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} network connection'
+          meta: '`{{ $labels.hostsystem }}` has detected a link status down on a physical
+            NIC. ({{ $labels.vcenter }}).'
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hostnicdown
+          service: compute
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostHasLostConnectionToVCenterServer
+        annotations:
+          description: '`{{ $labels.hostsystem }}` has been unexpectedly disconnected
+            from vCenter Server {{ $labels.vcenter }}.'
+          summary: '`{{ $labels.hostsystem }}` has been unexpectedly disconnected from
+            vCenter Server {{ $labels.vcenter }}.'
+        expr: |
+          vrops_hostsystem_runtime_connectionstate{state="disconnected"} AND on (hostsystem)
+          vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"} AND on (hostsystem)
+          vrops_hostsystem_runtime_powerstate{state!="Standby"}
+        labels:
+          context: '{{ $labels.hostsystem }} vCenter connection'
+          meta: '`{{ $labels.hostsystem }}` has been unexpectedly disconnected from vCenter
+            Server {{ $labels.vcenter }}.'
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hosthaslostconnectiontovcenterserver
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostHasLostConnectionToVCenterServer
+        annotations:
+          description: '`{{ $labels.hostsystem }}` has been unexpectedly disconnected
+            from vCenter Server {{ $labels.vcenter }}.'
+          summary: '`{{ $labels.hostsystem }}` has been unexpectedly disconnected from
+            vCenter Server {{ $labels.vcenter }}.'
+        expr: |-
+          (vrops_hostsystem_runtime_connectionstate{state="disconnected"} AND on (hostsystem)
+          vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"} AND on (hostsystem)
+          vrops_hostsystem_runtime_powerstate{state!="Standby"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} vCenter connection'
+          meta: '`{{ $labels.hostsystem }}` has been unexpectedly disconnected from vCenter
+            Server {{ $labels.vcenter }}.'
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hosthaslostconnectiontovcenterserver
+          service: compute
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostHasLostConnectivityToPhysicalNetwork
+        annotations:
+          description: Host `{{ $labels.hostsystem }}` has lost connectivity to physical
+            network. ({{ $labels.vcenter }}).
+          summary: Host `{{ $labels.hostsystem }}` has lost connectivity to physical network.
+            ({{ $labels.vcenter }}).
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="The host has lost connectivity to physical network"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        labels:
+          context: '{{ $labels.hostsystem }} network connection'
+          meta: Host `{{ $labels.hostsystem }}` has lost connectivity to physical network.
+            ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#host_has_lost_connectivity_to_physical_network
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostHasLostConnectivityToPhysicalNetwork
+        annotations:
+          description: Host `{{ $labels.hostsystem }}` has lost connectivity to physical
+            network. ({{ $labels.vcenter }}).
+          summary: Host `{{ $labels.hostsystem }}` has lost connectivity to physical network.
+            ({{ $labels.vcenter }}).
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="The host has lost connectivity to physical network"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} network connection'
+          meta: Host `{{ $labels.hostsystem }}` has lost connectivity to physical network.
+            ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#host_has_lost_connectivity_to_physical_network
+          service: compute
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: HADetectedAPossibleHostFailure-testing
+        annotations:
+          description: vSphere High Availability (HA) has detected a possible host failure
+            for `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+          summary: vSphere High Availability (HA) has detected a possible host failure
+            for `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) has detected a possible host failure"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{vccluster!~".*controlplane-swift"}
+        labels:
+          context: '{{ $labels.hostsystem }} failure'
+          meta: vSphere High Availability (HA) has detected a possible host failure for
+            `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hadetectedapossiblehostfailure
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: HADetectedAPossibleHostFailure
+        annotations:
+          description: vSphere High Availability (HA) has detected a possible host failure
+            for `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+          summary: vSphere High Availability (HA) has detected a possible host failure
+            for `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) has detected a possible host failure"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance", vccluster!~".*controlplane-swift"}
+        labels:
+          context: '{{ $labels.hostsystem }} failure'
+          meta: vSphere High Availability (HA) has detected a possible host failure for
+            `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hadetectedapossiblehostfailure
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: IaasHADetectedAPossibleHostFailure
+        annotations:
+          description: vSphere High Availability (HA) has detected a possible host failure
+            for `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+          summary: vSphere High Availability (HA) has detected a possible host failure
+            for `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) has detected a possible host failure"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance", vccluster!~".*controlplane-swift"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} failure'
+          meta: vSphere High Availability (HA) has detected a possible host failure for
+            `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hadetectedapossiblehostfailure
+          service: compute
+          severity: critical
+          support_group: iaas_support
+          tier: vmware
+      - alert: APodMemoryUtilizationHigh
+        annotations:
+          description: Memory utilization of host {{ $labels.hostsystem }} is above 90%.
+            ({{ $labels.vcenter }})
+          summary: Memory utilization of host {{ $labels.hostsystem }} is above 90%. ({{
+            $labels.vcenter }})
+        expr: vrops_hostsystem_memory_usage_percentage{vccluster=~".*-management.*"} >
+          95
+        for: 30m
+        labels:
+          context: '{{ $labels.hostsystem }} memory'
+          meta: Memory utilization of host {{ $labels.hostsystem }} is above 90%. ({{
+            $labels.vcenter }})
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: APodCPUUtilizationHigh
+        annotations:
+          description: CPU utilization of host {{ $labels.hostsystem }} is above 90%.
+            ({{ $labels.vcenter }})
+          summary: CPU utilization of host {{ $labels.hostsystem }} is above 90%. ({{
+            $labels.vcenter }})
+        expr: vrops_hostsystem_cpu_usage_average_percentage{vccluster=~".*-management.*"}
+          > 80
+        for: 30m
+        labels:
+          context: '{{ $labels.hostsystem }} cpu'
+          meta: CPU utilization of host {{ $labels.hostsystem }} is above 90%. ({{ $labels.vcenter
+            }})
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: HostHighNumberOfPacketsDropped
+        annotations:
+          description: '`{{ $labels.hostsystem }}` is experiencing high number of packets
+            dropped. ({{ $labels.vcenter }}).'
+          summary: '`{{ $labels.hostsystem }}` is experiencing high number of packets
+            dropped. ({{ $labels.vcenter }}).'
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="Host is experiencing high number of packets dropped"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        labels:
+          context: '{{ $labels.hostsystem }} packets dropped'
+          meta: '`{{ $labels.hostsystem }}` is experiencing high number of packets dropped.
+            ({{ $labels.vcenter }}).'
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostHighNumberOfPacketsDropped
+        annotations:
+          description: '`{{ $labels.hostsystem }}` is experiencing high number of packets
+            dropped. ({{ $labels.vcenter }}).'
+          summary: '`{{ $labels.hostsystem }}` is experiencing high number of packets
+            dropped. ({{ $labels.vcenter }}).'
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="Host is experiencing high number of packets dropped"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} packets dropped'
+          meta: '`{{ $labels.hostsystem }}` is experiencing high number of packets dropped.
+            ({{ $labels.vcenter }}).'
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostNicLinkFlappingAlert
+        annotations:
+          description: '`{{ $labels.hostsystem }}` has detected a link status flapping
+            on a physical NIC. ({{ $labels.vcenter }}).'
+          summary: '`{{ $labels.hostsystem }}` has detected a link status flapping on
+            a physical NIC. ({{ $labels.vcenter }}).'
+        expr: |
+          vrops_hostsystem_alert_info{alert_name=~"ESXi host has detected a link status.*flapping.*on a physical NIC"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        labels:
+          context: '{{ $labels.hostsystem }} link flapping'
+          meta: '`{{ $labels.hostsystem }}` has detected a link status flapping on a physical
+            NIC. ({{ $labels.vcenter }}).'
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostNicLinkFlappingAlert
+        annotations:
+          description: '`{{ $labels.hostsystem }}` has detected a link status flapping
+            on a physical NIC. ({{ $labels.vcenter }}).'
+          summary: '`{{ $labels.hostsystem }}` has detected a link status flapping on
+            a physical NIC. ({{ $labels.vcenter }}).'
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name=~"ESXi host has detected a link status.*flapping.*on a physical NIC"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} link flapping'
+          meta: '`{{ $labels.hostsystem }}` has detected a link status flapping on a physical
+            NIC. ({{ $labels.vcenter }}).'
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostSystemEventLogSensorAlert
+        annotations:
+          description: IPMI System Event Log for `{{ $labels.hostsystem }}` is becoming
+            full. ({{ $labels.vcenter }}) {{ $labels.recommendation_1 }}
+          summary: IPMI System Event Log for `{{ $labels.hostsystem }}` is becoming full.
+            ({{ $labels.vcenter }}) {{ $labels.recommendation_1 }}
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="IPMI System Event Log for the host is becoming full"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        labels:
+          context: '{{ $labels.hostsystem }} IPMI log'
+          meta: IPMI System Event Log for `{{ $labels.hostsystem }}` is becoming full.
+            ({{ $labels.vcenter }}) {{ $labels.recommendation_1 }}
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostSystemEventLogSensorAlert
+        annotations:
+          description: IPMI System Event Log for `{{ $labels.hostsystem }}` is becoming
+            full. ({{ $labels.vcenter }}) {{ $labels.recommendation_1 }}
+          summary: IPMI System Event Log for `{{ $labels.hostsystem }}` is becoming full.
+            ({{ $labels.vcenter }}) {{ $labels.recommendation_1 }}
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="IPMI System Event Log for the host is becoming full"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} IPMI log'
+          meta: IPMI System Event Log for `{{ $labels.hostsystem }}` is becoming full.
+            ({{ $labels.vcenter }}) {{ $labels.recommendation_1 }}
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostStoragePathsDown
+        annotations:
+          description: More than 4 active storage paths for `{{ $labels.hostsystem }}`
+            down. ({{ $labels.vcenter }})
+          summary: More than 4 active storage paths for `{{ $labels.hostsystem }}` down.
+            ({{ $labels.vcenter }})
+        expr: vrops_hostsystem_storage_number_of_path - vrops_hostsystem_storage_number_of_active_path
+          > 4
+        for: 30m
+        labels:
+          context: '{{ $labels.hostsystem }} storage paths'
+          meta: More than 4 active storage paths for `{{ $labels.hostsystem }}` down.
+            ({{ $labels.vcenter }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostStoragePathsDown
+        annotations:
+          description: More than 4 active storage paths for `{{ $labels.hostsystem }}`
+            down. ({{ $labels.vcenter }})
+          summary: More than 4 active storage paths for `{{ $labels.hostsystem }}` down.
+            ({{ $labels.vcenter }})
+        expr: (vrops_hostsystem_storage_number_of_path - vrops_hostsystem_storage_number_of_active_path
+          > 4) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 30m
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} storage paths'
+          meta: More than 4 active storage paths for `{{ $labels.hostsystem }}` down.
+            ({{ $labels.vcenter }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostAllRedundantStoragePathsDown
+        annotations:
+          description: All active storage paths for `{{ $labels.hostsystem }}` down. ({{
+            $labels.vcenter }})
+          summary: All active storage paths for `{{ $labels.hostsystem }}` down. ({{ $labels.vcenter
+            }})
+        expr: vrops_hostsystem_storage_number_of_active_path == 0
+        for: 10m
+        labels:
+          context: '{{ $labels.hostsystem }} storage paths'
+          meta: All active storage paths for `{{ $labels.hostsystem }}` down. ({{ $labels.vcenter
+            }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostAllRedundantStoragePathsDown
+        annotations:
+          description: All active storage paths for `{{ $labels.hostsystem }}` down. ({{
+            $labels.vcenter }})
+          summary: All active storage paths for `{{ $labels.hostsystem }}` down. ({{ $labels.vcenter
+            }})
+        expr: (vrops_hostsystem_storage_number_of_active_path == 0) and on(hostsystem)
+          vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 10m
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} storage paths'
+          meta: All active storage paths for `{{ $labels.hostsystem }}` down. ({{ $labels.vcenter
+            }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: iaas_support
+          tier: vmware
+      - alert: HAHostAgentError
+        annotations:
+          description: HA agent on Host `{{ $labels.hostsystem }}` has encountered an
+            error. ({{ $labels.vcenter }}).
+          summary: HA agent on Host `{{ $labels.hostsystem }}` has encountered an error.
+            ({{ $labels.vcenter }}).
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) host agent has encountered an error", vccluster!~".*-controlplane-swift"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        labels:
+          context: '{{ $labels.hostsystem }} HA agent error'
+          meta: HA agent on Host `{{ $labels.hostsystem }}` has encountered an error.
+            ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#troubleshooting-vsphere-ha-host-states
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasHAHostAgentError
+        annotations:
+          description: HA agent on Host `{{ $labels.hostsystem }}` has encountered an
+            error. ({{ $labels.vcenter }}).
+          summary: HA agent on Host `{{ $labels.hostsystem }}` has encountered an error.
+            ({{ $labels.vcenter }}).
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) host agent has encountered an error", vccluster!~".*-controlplane-swift"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} HA agent error'
+          meta: HA agent on Host `{{ $labels.hostsystem }}` has encountered an error.
+            ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#troubleshooting-vsphere-ha-host-states
+          service: compute
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: HAHostNetworkPartitioned
+        annotations:
+          description: HA on Host `{{ $labels.hostsystem }}` has detected a network-partitioned
+            host. ({{ $labels.vcenter }}).
+          summary: HA on Host `{{ $labels.hostsystem }}` has detected a network-partitioned
+            host. ({{ $labels.vcenter }}).
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) has detected a network-partitioned host"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        labels:
+          context: '{{ $labels.hostsystem }} HA network-partitioned host'
+          meta: HA on Host `{{ $labels.hostsystem }}` has detected a network-partitioned
+            host. ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#troubleshooting-vsphere-ha-host-states
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasHAHostNetworkPartitioned
+        annotations:
+          description: HA on Host `{{ $labels.hostsystem }}` has detected a network-partitioned
+            host. ({{ $labels.vcenter }}).
+          summary: HA on Host `{{ $labels.hostsystem }}` has detected a network-partitioned
+            host. ({{ $labels.vcenter }}).
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) has detected a network-partitioned host"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} HA network-partitioned host'
+          meta: HA on Host `{{ $labels.hostsystem }}` has detected a network-partitioned
+            host. ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#troubleshooting-vsphere-ha-host-states
+          service: compute
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: APodHostRunsMultipleVCenters
+        annotations:
+          description: aPod node `{{ $labels.hostsystem }}` runs multiple vCenter VMs.
+            ({{ $labels.vcenter }})
+          summary: aPod node `{{ $labels.hostsystem }}` runs multiple vCenter VMs. ({{
+            $labels.vcenter }})
+        expr: count(vrops_virtualmachine_runtime_connectionstate{vccluster=~".*-management",
+          virtualmachine=~"vc-.*"}) by(hostsystem, vcenter) > 1
+        for: 30m
+        labels:
+          context: '{{ $labels.hostsystem }} multiple vCenters'
+          meta: aPod node `{{ $labels.hostsystem }}` runs multiple vCenter VMs. ({{ $labels.vcenter
+            }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: HostStoragePathCheck
+        annotations:
+          description: storage paths for `{{ $labels.hostsystem }}` is less than other
+            hosts in the `{{ $labels.vccluster }}`. ({{ $labels.vcenter }})
+          summary: storage paths for `{{ $labels.hostsystem }}` is less than other hosts
+            in the `{{ $labels.vccluster }}`. ({{ $labels.vcenter }})
+        expr: vrops_hostsystem_storage_number_of_path < on(vccluster) group_left() (max(vrops_hostsystem_storage_number_of_path)
+          by(vccluster))
+        for: 30m
+        labels:
+          context: '{{ $labels.hostsystem }} storage paths'
+          meta: storage paths for `{{ $labels.hostsystem }}` is less than other hosts
+            in the `{{ $labels.vccluster }}`. ({{ $labels.vcenter }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostStoragePathCheck
+        annotations:
+          description: storage paths for `{{ $labels.hostsystem }}` is less than other
+            hosts in the `{{ $labels.vccluster }}`. ({{ $labels.vcenter }})
+          summary: storage paths for `{{ $labels.hostsystem }}` is less than other hosts
+            in the `{{ $labels.vccluster }}`. ({{ $labels.vcenter }})
+        expr: (vrops_hostsystem_storage_number_of_path < on(vccluster) group_left() (max(vrops_hostsystem_storage_number_of_path)
+          by(vccluster))) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 30m
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} storage paths'
+          meta: storage paths for `{{ $labels.hostsystem }}` is less than other hosts
+            in the `{{ $labels.vccluster }}`. ({{ $labels.vcenter }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: iaas_support
+          tier: vmware
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-mgmt-d-0-alerts-iaas.alerts
+  labels:
+    prometheus: vmware-vc-mgmt-d-0
+
+spec:
+  groups:
+    - name: iaas.alerts
+      rules:
+      - alert: IaasHostMemoryUsage
+        annotations:
+          description: Memory usage of ESXi host {{ $labels.hostsystem}} is above 75%
+          summary: Memory usage of ESXi host {{ $labels.hostsystem}} is above 75%
+        expr: vrops_hostsystem_memory_usage_percentage > 75 and on (hostsystem) vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+        for: 30m
+        labels:
+          context: esxi host memory usage
+          meta: Memory usage of ESXi host {{ $labels.hostsystem}} is above 75%
+          service: compute
+          severity: warning
+          support_group: iaas-support
+      - alert: IaasHostMemoryUsage
+        annotations:
+          description: Memory usage of ESXi host {{ $labels.hostsystem}} is above 90%
+          summary: Memory usage of ESXi host {{ $labels.hostsystem}} is above 90%
+        expr: vrops_hostsystem_memory_usage_percentage > 90 and on (hostsystem) vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+        for: 30m
+        labels:
+          context: esxi host memory usage
+          meta: Memory usage of ESXi host {{ $labels.hostsystem}} is above 90%
+          service: compute
+          severity: critical
+          support_group: iaas-support
+      - alert: IaasHostLicenseKey
+        annotations:
+          description: IaaS ESXi host {{ $labels.hostsystem }} in IaaS host group without
+            valid license
+          summary: IaaS ESXi host {{ $labels.hostsystem }} in IaaS host group without
+            valid license
+        expr: vrops_hostsystem_license_key{license_key!~"GM693.*"} + on (hostsystem) group_right(license_key)
+          vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"} > 0
+        for: 30m
+        labels:
+          context: esxi host license key
+          meta: IaaS ESXi host {{ $labels.hostsystem }} in IaaS host group without valid
+            license
+          service: compute
+          severity: warning
+          support_group: iaas-support
+      - alert: IaasClusterWithoutFailoverHost
+        annotations:
+          description: IaaS cluster {{ $labels.vccluster }} has NO failover host configured
+          summary: IaaS cluster {{ $labels.vccluster }} has NO failover host configured
+        expr: |
+          (count by (vccluster) (vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}) > 0)
+          unless (count by (vccluster) (vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+          and on(hostsystem) vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{} == 1 ) > 0)
+        for: 15m
+        labels:
+          context: IaaS cluster HA policy
+          meta: IaaS cluster {{ $labels.vccluster }} has NO failover host configured
+          service: compute
+          severity: critical
+          support_group: iaas-support
+      - alert: NonIaasVmOnIaasHost
+        annotations:
+          description: Non IaaS virtual machine(s) running on IaaS ESXi host {{ $labels.hostsystem
+            }}
+          summary: Non IaaS virtual machine(s) running on IaaS ESXi host {{ $labels.hostsystem
+            }}
+        expr: |
+          count by (hostsystem) (
+            (
+              group by (project, hostsystem, virtualmachine)(vrops_virtualmachine_system_powered_on{}==1)
+              and on(project)
+              group by(project) (label_replace(limes_project_usage{domain!~"iaas-.*"}, "project", "$1", "project_id", "(.*)"))
+            )
+          )
+          and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+        for: 30m
+        labels:
+          context: non IaaS vm on IaaS cluster
+          meta: Non IaaS virtual machine(s) running on IaaS ESXi host {{ $labels.hostsystem
+            }}
+          service: compute
+          severity: warning
+          support_group: iaas-support
+      - alert: IaasHostsAlmostOutOfMemory
+        annotations:
+          description: All IaaS hosts in cluster {{ $labels.vccluster }} are above 75%
+            memory
+          summary: All IaaS hosts in cluster {{ $labels.vccluster }} are above 75% memory
+        expr: |
+          count by (vccluster) (
+            (vrops_hostsystem_memory_usage_percentage > 75)
+            and on(hostsystem)
+            vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+            unless on(hostsystem)
+            vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{} == 1
+          )
+          == on(vccluster)
+          count by (vccluster) (
+            vrops_hostsystem_memory_usage_percentage
+            and on(hostsystem)
+            vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+            unless on(hostsystem)
+            vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{} == 1
+          )
+          and on(vccluster)
+          count by (vccluster) (
+            vrops_hostsystem_memory_usage_percentage
+            and on(hostsystem)
+            vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+            unless on(hostsystem)
+            vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{} == 1
+          ) > 0
+        for: 60m
+        labels:
+          context: IaaS hosts in cluster are almost out of memory
+          meta: All IaaS hosts in cluster {{ $labels.vccluster }} are above 75% memory
+          service: compute
+          severity: warning
+          support_group: iaas-support
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-mgmt-d-0-alerts-k8s-vc-mgmt.alerts
+  labels:
+    prometheus: vmware-vc-mgmt-d-0
+
+spec:
+  groups:
+    - name: k8s-vc-mgmt.alerts
+      rules:
+      - alert: VCClusterCPUContention
+        annotations:
+          description: The VCCluster {{ $labels.vccluster}} is using {{ $value }} CPU
+            and VM's are fighting for it
+          summary: '{{ $labels.vccluster}} cpu contention critical'
+        expr: vrops_cluster_cpu_contention_percentage{vcenter=~"vc-mgmt-.*"} > 5
+        for: 15m
+        labels:
+          context: vccluster
+          meta: The VCCluster {{ $labels.vccluster}} is using too much CPU and VM's are
+            fighting for it
+          no_alert_on_absence: "true"
+          service: cc-cp
+          severity: info
+          support_group: containers
+          tier: k8s
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-mgmt-d-0-alerts-nsxt.alerts
+  labels:
+    prometheus: vmware-vc-mgmt-d-0
+
+spec:
+  groups:
+    - name: nsxt.alerts
+      rules:
+      - alert: NSXTDistributedFirewallSectionUsageLimitExceeded
+        annotations:
+          description: NSX-T cluster {{ $labels.nsxt_adapter }} firewall sections usage
+            exceeded the supported limit. https://{{ $labels.target }}
+          summary: NSX-T cluster {{ $labels.nsxt_adapter }} firewall sections usage exceeded
+            the supported limit. https://{{ $labels.target }}
+        expr: |
+          vrops_nsxt_mgmt_cluster_sys_capacity_distributed_firewall_section_usage_count /
+          vrops_nsxt_mgmt_cluster_sys_capacity_distributed_firewall_section_max_supported_count > 0.9
+        for: 10m
+        labels:
+          dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
+          meta: NSX-T cluster {{ $labels.nsxt_adapter }} firewall sections usage exceeded
+            the supported limit. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTDistributedFirewallRulesUsageLimitExceeded
+        annotations:
+          description: NSX-T cluster {{ $labels.nsxt_adapter }} firewall rules usage exceeded
+            the supported limit. https://{{ $labels.target }}
+          summary: NSX-T cluster {{ $labels.nsxt_adapter }} firewall sections rules exceeded
+            the supported limit. https://{{ $labels.target }}
+        expr: |
+          vrops_nsxt_mgmt_cluster_sys_capacity_distributed_firewall_rules_usage_count /
+          vrops_nsxt_mgmt_cluster_sys_capacity_distributed_firewall_rules_max_supported_count > 0.9
+        for: 10m
+        labels:
+          dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
+          meta: NSX-T cluster {{ $labels.nsxt_adapter }} firewall rules usage exceeded
+            the supported limit. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTLogicalSwitchesUsageLimitExceeded
+        annotations:
+          description: NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switches
+            exceeded the supported limit. https://{{ $labels.target }}
+          summary: NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switches
+            exceeded the supported limit. https://{{ $labels.target }}
+        expr: |
+          vrops_nsxt_mgmt_cluster_sys_capacity_logical_switches_usage_count /
+          vrops_nsxt_mgmt_cluster_sys_capacity_logical_switches_max_supported_count > 0.9
+        for: 10m
+        labels:
+          dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
+          meta: NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switches exceeded
+            the supported limit. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTLogicalSwitchPortsUsageWarningLimitExceeded
+        annotations:
+          description: NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switch
+            ports exceeded the supported limit. https://{{ $labels.target }}
+          summary: NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switch ports
+            exceeded the supported limit. https://{{ $labels.target }}
+        expr: |
+          vrops_nsxt_mgmt_cluster_sys_capacity_logical_switch_ports_usage_count /
+          vrops_nsxt_mgmt_cluster_sys_capacity_logical_switch_ports_max_supported_count > 0.9
+        for: 10m
+        labels:
+          dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
+          meta: NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switch ports
+            exceeded the supported limit. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTGroupsUsageLimitExceeded
+        annotations:
+          description: NSX-T cluster {{ $labels.nsxt_adapter }} count of NSGroups exceeded
+            the supported limit. https://{{ $labels.target }}
+          summary: NSX-T cluster {{ $labels.nsxt_adapter }} count of NSGroups exceeded
+            the supported limit. https://{{ $labels.target }}
+        expr: |
+          vrops_nsxt_mgmt_cluster_sys_capacity_nsgroups_max_usage_count /
+          vrops_nsxt_mgmt_cluster_sys_capacity_nsgroups_max_supported_count > 0.9
+        for: 10m
+        labels:
+          dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
+          meta: NSX-T cluster {{ $labels.nsxt_adapter }} count of NSGroups exceeded the
+            supported limit. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTIPSetsUsageLimitExceeded
+        annotations:
+          description: NSX-T cluster {{ $labels.nsxt_adapter }} count of IP sets exceeded
+            the supported limit. https://{{ $labels.target }}
+          summary: NSX-T cluster {{ $labels.nsxt_adapter }} count of IP sets exceeded
+            the supported limit. https://{{ $labels.target }}
+        expr: |
+          vrops_nsxt_mgmt_cluster_sys_capacity_ip_sets_usage_count /
+          vrops_nsxt_mgmt_cluster_sys_capacity_ip_sets_max_supported_count > 0.9
+        for: 10m
+        labels:
+          dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
+          meta: NSX-T cluster {{ $labels.nsxt_adapter }} count of IP sets exceeded the
+            supported limit. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTGroupsBasedInIPUsageLimitExceeded
+        annotations:
+          description: NSX-T cluster {{ $labels.nsxt_adapter }} count of groups based
+            in IP exceeded the supported limit. https://{{ $labels.target }}
+          summary: NSX-T cluster {{ $labels.nsxt_adapter }} count of groups based in IP
+            exceeded the supported limit. https://{{ $labels.target }}
+        expr: |
+          vrops_nsxt_mgmt_cluster_sys_capacity_groups_based_in_ip_usage_count /
+          vrops_nsxt_mgmt_cluster_sys_capacity_groups_based_in_ip_max_supported_count > 0.9
+        for: 10m
+        labels:
+          dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
+          meta: NSX-T cluster {{ $labels.nsxt_adapter }} count of groups based in IP exceeded
+            the supported limit. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTMgmtNodeImageFilesystemCapacity
+        annotations:
+          description: NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage
+            `/image` > 80%. {{ $labels.nsxt_adapter}} https://{{ $labels.target }}
+          summary: NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage
+            `/image` > 80%. {{ $labels.nsxt_adapter}} https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_node_filesystems_image_usedpercentage > 80
+        for: 10m
+        labels:
+          meta: NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage `/image`
+            > 80%. {{ $labels.nsxt_adapter}} https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#NSXTMgmtNodeImageFilesystemCapacityCritical
+          service: network
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: NSXTMgmtNodeLogFilesystemCapacity
+        annotations:
+          description: NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage
+            `/var/log` > 80%. {{ $labels.nsxt_adapter}} https://{{ $labels.target }}
+          summary: NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage
+            `/var/log` > 80%. {{ $labels.nsxt_adapter}} https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_node_filesystems_var_log_usedpercentage > 80
+        for: 10m
+        labels:
+          meta: NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage `/var/log`
+            > 80%. {{ $labels.nsxt_adapter}} https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#NSXTMgmtNodeLogFilesystemCapacityCritical
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTClusterControlStatusNoControllers
+        annotations:
+          description: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity
+            status is `{{ $labels.state }}`. https://{{ $labels.target }}
+          summary: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status
+            is `{{ $labels.state }}`. https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_cluster_controller_cluster_connectivity_status{state="NO_CONTROLLERS"}
+        for: 10m
+        labels:
+          meta: NSX-T management cluster {{ $labels.nsxt_adapter }} has connectivity status
+            `{{ $labels.state }}`. https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#cluster_control_status_no_controllers
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTClusterControlStatusUnstable
+        annotations:
+          description: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity
+            status is `{{ $labels.state }}`. https://{{ $labels.target }}
+          summary: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status
+            is `{{ $labels.state }}`. https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_cluster_controller_cluster_connectivity_status{state="UNSTABLE"}
+        for: 10m
+        labels:
+          meta: NSX-T management cluster {{ $labels.nsxt_adapter }} has connectivity status
+            `{{ $labels.state }}`. https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#cluster_control_status_unstable
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTClusterControlStatusDegraded
+        annotations:
+          description: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity
+            status is `{{ $labels.state }}`. https://{{ $labels.target }}
+          summary: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status
+            is `{{ $labels.state }}`. https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_cluster_controller_cluster_connectivity_status{state="DEGRADED"}
+        for: 30m
+        labels:
+          meta: NSX-T management cluster {{ $labels.nsxt_adapter }} has connectivity status
+            `{{ $labels.state }}`. https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#cluster_control_status_degraded
+          service: network
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: NSXTClusterControlStatusUnkown
+        annotations:
+          description: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity
+            status is `{{ $labels.state }}`. https://{{ $labels.target }}
+          summary: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status
+            is `{{ $labels.state }}`. https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_cluster_controller_cluster_connectivity_status{state="UNKNOWN"}
+        for: 10m
+        labels:
+          meta: NSX-T management cluster {{ $labels.nsxt_adapter }} has connectivity status
+            `{{ $labels.state }}`. https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#cluster_control_status_unkown
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTNodeMemoryUsageOver95
+        annotations:
+          description: NSX-T Node {{ $labels.nsxt_mgmt_node }} of cluster {{ $labels.nsxt_adapter
+            }} has memory usage of over 95%. https://{{ $labels.target }}
+          summary: NSX-T Node {{ $labels.nsxt_mgmt_node }} of cluster {{ $labels.nsxt_adapter
+            }} has memory usage of over 95%. https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_node_memory_used / vrops_nsxt_mgmt_node_memory_total > 0.95
+        for: 5m
+        labels:
+          meta: NSX-T Node {{ $labels.nsxt_mgmt_node }} of cluster {{ $labels.nsxt_adapter
+            }} has memory usage of over 95%. https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#NSXT_Memory_Usage_Over95
+          service: network
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: NSXTNodeConnectivityBroken
+        annotations:
+          description: NSX-T Node {{ $labels.nsxt_mgmt_node }} connectivity is broken.
+            ({{ $labels.nsxt_adapter }}) https://{{ $labels.target }}
+          summary: NSX-T Node {{ $labels.nsxt_mgmt_node }} connectivity is broken. ({{
+            $labels.nsxt_adapter }}) https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_node_connectivity_status{state="DISCONNECTED"}
+        for: 5m
+        labels:
+          meta: NSX-T Node `{{ $labels.nsxt_mgmt_node }}` connectivity is broken. ({{
+            $labels.nsxt_adapter }}) https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#nsxtnodeconnectivitybroken
+          service: network
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: NSXTManagementServiceHasFailed
+        annotations:
+          description: 'CRITICAL: NSX-T management service `{{ $labels.nsxt_mgmt_service
+            }}` has failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }})
+            https://{{ $labels.target }}'
+          summary: 'CRITICAL: NSX-T management service `{{ $labels.nsxt_mgmt_service }}`
+            has failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }}) https://{{
+            $labels.target }}'
+        expr: |
+          vrops_nsxt_mgmt_service_alert_info{alert_name="NSX-T Management service has failed|Management service monitor runtime state has failed",
+          nsxt_mgmt_service!~"cluster-boot-manager|cm-inventory|controller|http|manager"}
+        labels:
+          meta: Critical NSX-T management service `{{ $labels.nsxt_mgmt_service }}` has
+            failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }}) https://{{
+            $labels.target }}
+          no_alert_on_absence: "true"
+          service: network
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: NSXTSslCertificateExpiry
+        annotations:
+          description: NSX-T Certificate of {{ $labels.nsxt_adapter }} has expired or
+            will expire shortly. https://{{ $labels.target }}
+          summary: NSX-T Certificate of {{ $labels.nsxt_adapter }} has expired or will
+            expire shortly. https://{{ $labels.target }}
+        expr: vrops_nsxt_adapter_alert_info{alert_name="Adapter certificate has expired
+          or will expire shortly"}
+        labels:
+          context: nsxt certificate
+          meta: NSX-T Certificate of `{{ $labels.nsxt_adapter }}` has expired or will
+            expire shortly. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#applying-nsx-t-ssl-certificate-in-the-manager-nodes-and-the-vip
+          service: network
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: NSXTManagementServiceHasFailed
+        annotations:
+          description: 'WARNING: NSX-T management service `{{ $labels.nsxt_mgmt_service
+            }}` has failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }}).
+            https://{{ $labels.target }}'
+          summary: 'WARNING: NSX-T management service `{{ $labels.nsxt_mgmt_service }}`
+            has failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }}). https://{{
+            $labels.target }}'
+        expr: |
+          vrops_nsxt_mgmt_service_alert_info{alert_name="NSX-T Management service has failed|Management service monitor runtime state has failed",
+          nsxt_mgmt_service!~"mgmt-plane-bus|node-mgmt|ntp|ssh|search|syslog|nsx-ui"}
+        labels:
+          meta: NSX-T management service `{{ $labels.nsxt_mgmt_service }}` has failed.
+            ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }}). https://{{ $labels.target
+            }}
+          no_alert_on_absence: "true"
+          service: network
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: NSXTTransportNodeConnectivityNotUP
+        annotations:
+          description: 'Transport node {{ $labels.nsxt_transport_node }} Controller/Manager
+            Connectivity status is not UP. https://{{ $labels.target }}. '
+          summary: 'Transport node {{ $labels.nsxt_transport_node }} Controller/Manager
+            Connectivity status is not UP. https://{{ $labels.target }}. '
+        expr: |
+          label_replace(vrops_nsxt_transport_node_alert_info{alert_name="Transport Node Controller/Manager Connectivity is not UP"}, "hostsystem", "$1", "nsxt_transport_node", "(.*)")
+          AND on (hostsystem) vrops_hostsystem_runtime_connectionstate{state="notResponding"}
+          AND on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"}
+          AND on (hostsystem) vrops_hostsystem_runtime_powerstate{state="Powered On"}
+        labels:
+          meta: Transport node {{ $labels.nsxt_transport_node }} Controller/Manager Connectivity
+            status is not UP. https://{{ $labels.target }}.
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#Transport_node_status_not_UP_in_NSXT
+          service: network
+          severity: critical
+          support_group: compute
+          tier: vmware
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-mgmt-d-0-alerts-vccluster.alerts
+  labels:
+    prometheus: vmware-vc-mgmt-d-0
+
+spec:
+  groups:
+    - name: vccluster.alerts
+      rules:
+      - alert: VCenterRedundancyLostHAPolicyFaulty
+        annotations:
+          description: VC https://{{ $labels.vcenter }} has a faulty AdmissionControlPolicy
+            for cluster {{ $labels.vccluster }}, failover will not work.
+          summary: VC https://{{ $labels.vcenter }} has a faulty AdmissionControlPolicy
+            for cluster {{ $labels.vccluster }}, failover will not work.
+        expr: |
+          vrops_cluster_configuration_dasconfig_enabled{vccluster=~"productionbb\\d+"}
+          unless on (vccluster) ((vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{vccluster=~"productionbb\\d+"} != 0
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"})
+          or (vrops_cluster_summary_custom_tag_openstack_nova_traits_decommissioning{summary_custom_tag_openstack_nova_traits_decommissioning="true", vccluster=~"productionbb\\d+"}
+          and on (vccluster) vrops_cluster_cluster_running_vms == 0))
+        for: 30m
+        labels:
+          context: vc cluster config
+          meta: VC https://{{ $labels.vcenter }} has a faulty AdmissionControlPolicy for
+            cluster {{ $labels.vccluster }}, failover will not work.
+          playbook: docs/devops/alert/vcenter/#vcenterredundancylosthapolicyfaulty
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: VCenterRedundancyLostHAPolicyNotConfigured
+        annotations:
+          description: VC {{ $labels.vcenter }} {{ $labels.vccluster }} has a faulty AdmissionControlPolicy.
+            Failover will not work.
+          summary: VC {{ $labels.vcenter }} {{ $labels.vccluster }} has a faulty AdmissionControlPolicy.
+            Failover will not work.
+        expr: vrops_cluster_configuration_dasconfig_enabled{vccluster=~"production.*"}
+          == 0
+        for: 30m
+        labels:
+          context: Cluster HA policy
+          meta: VC {{ $labels.vcenter }} {{ $labels.vccluster }} has a faulty AdmissionControlPolicy.
+            Failover will not work.
+          playbook: docs/devops/alert/vcenter/#restore-ha-redundancy-in-vcenter
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: VCClusterFailoverHostCountMismatch
+        annotations:
+          description: "`{{ $labels.vccluster }}` cluster has more failover hosts configured
+            than expected. For clusters with 10 or fewer hosts, it should be 1; for larger
+            clusters, it should be no more than 2. \nLink to the vCenter: --> <https://{{
+            $labels.vcenter }}|{{ $labels.vcenter }}>"
+          summary: "`{{ $labels.vccluster }}` cluster has more failover hosts configured
+            than expected. For clusters with 10 or fewer hosts, it should be 1; for larger
+            clusters, it should be no more than 2. \nLink to the vCenter: --> <https://{{
+            $labels.vcenter }}|{{ $labels.vcenter }}>"
+        expr: |
+          (count by (vccluster, vcenter) (vrops_hostsystem_runtime_connectionstate{vccluster=~"productionbb\\d+"}) <= 10
+          and on (vccluster) sum by (vccluster) (vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{vccluster=~"productionbb\\d+"}) > 1)
+          or (sum by (vccluster, vcenter) (vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{vccluster=~"productionbb\\d+"}) > 2)
+          unless on (vccluster) (vrops_cluster_summary_custom_tag_openstack_nova_traits_decommissioning{summary_custom_tag_openstack_nova_traits_decommissioning="true", vccluster=~"productionbb\\d+"}
+          and vrops_cluster_cluster_running_vms == 0)
+        for: 30m
+        labels:
+          context: Cluster HA policy
+          meta: "`{{ $labels.vccluster }}` cluster has more failover hosts configured
+            than expected. For clusters with 10 or fewer hosts, it should be 1; for larger
+            clusters, it should be no more than 2. \nLink to the vCenter: --> <https://{{
+            $labels.vcenter }}|{{ $labels.vcenter }}>"
+          playbook: docs/devops/alert/vcenter/#vcclusterfailoverhostcountmismatch
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VCenterRedundancyLostHALevelNotSet
+        annotations:
+          description: VC {{ $labels.vcenter }} {{ $labels.vccluster }} has NO failover
+            host amount configured, this should be 1
+          summary: VC {{ $labels.vcenter }} {{ $labels.vccluster }} has NO failover host
+            amount configured, this should be 1
+        expr: count by (vccluster, vcenter) (vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{vccluster=~"production.*"}
+          == 1) == 0
+        for: 30m
+        labels:
+          context: Cluster HA policy
+          meta: VC {{ $labels.vcenter }} {{ $labels.vccluster }} has NO failover host
+            amount configured, this should be 1
+          playbook: docs/devops/alert/vcenter/#restore-ha-redundancy-in-vcenter
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: VCClusterDRSNotFullyAutomated
+        annotations:
+          description: Cluster {{ $labels.vccluster }} DRS configuration is not set to
+            fully automated.
+          summary: Cluster {{ $labels.vccluster }} DRS configuration is not set to fully
+            automated.
+        expr: |
+          vrops_cluster_configuration_drsconfig_defaultvmbehavior{vccluster!~".*controlplane.*", state != "fullyAutomated"} == 0
+          unless on (vccluster) vrops_cluster_summary_custom_tag_openstack_nova_traits_hana_exclusive_host{summary_custom_tag_openstack_nova_traits_hana_exclusive_host="true"}
+        for: 10m
+        labels:
+          context: Cluster DRS configuration
+          meta: Cluster {{ $labels.vccluster }} DRS configuration is not set to fully
+            automated.
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#cluster-drs-not-set-to-fully-automated
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: VCClusterCannotDistributeNSXTControllers
+        annotations:
+          description: Cluster {{ $labels.vccluster }} cannot evenly distribute new NSX-T
+            controllers. {{ $labels.vcenter}}
+          summary: Cluster {{ $labels.vccluster }} cannot evenly distribute new NSX-T
+            controllers. {{ $labels.vcenter }}
+        expr: |
+          count by(vccluster, vcenter) (
+            (
+              max_over_time(vrops_hostsystem_memory_capacity_available_to_vms_kilobytes{vccluster=~".*management"}[1h])
+              - max_over_time(vrops_hostsystem_memory_consumed_by_vms_kilobytes[1h])
+            ) / 1024 / 1024 >= 48
+          ) < 3
+        for: 30m
+        labels:
+          context: Cluster NSXT Resources
+          meta: Cluster {{ $labels.vccluster }} cannot evenly distribute new NSX-T controllers.
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: HanaExclusiveVCClusterDRSNotPartiallyAutomated
+        annotations:
+          description: |-
+            The HANA-exclusive {{ $labels.vccluster }} cluster DRS configuration is not set to partially automated in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The HANA-exclusive {{ $labels.vccluster }} cluster DRS configuration is not set to partially automated in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_cluster_configuration_drsconfig_defaultvmbehavior{vccluster=~"productionbb.+", state != "partiallyAutomated"}
+          and on (vccluster) vrops_cluster_summary_custom_tag_openstack_nova_traits_hana_exclusive_host{summary_custom_tag_openstack_nova_traits_hana_exclusive_host="true"}
+        labels:
+          context: Cluster DRS configuration
+          meta: |-
+            The HANA-exclusive {{ $labels.vccluster }} cluster DRS configuration is not set to partially automated in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hanaexclusivevcclusterdrsnotpartiallyautomated
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-mgmt-d-0-alerts-vcenter.alerts
+  labels:
+    prometheus: vmware-vc-mgmt-d-0
+
+spec:
+  groups:
+    - name: vcenter.alerts
+      rules:
+      - alert: VcsaSslCertificateExpiry
+        annotations:
+          description: SSL Certificate of vCSA {{ $labels.vcenter}} expires in {{ $value
+            }} days. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: SSL Certificate of vCSA {{ $labels.vcenter}} expires in {{ $value }}
+            days. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: 15 < round(((avg_over_time(vrops_vcenter_summary_certificate_expiry_date[10m])
+          / 1000) - time()) / 86400) < 30
+        for: 20m
+        labels:
+          context: vcsa certificate
+          meta: SSL Certificate of vCSA {{ $labels.vcenter }} expires in less than 30
+            days. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#vcenter-appliance-certificate-expiry
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VcsaSslCertificateExpiry
+        annotations:
+          description: SSL Certificate of vCSA {{ $labels.vcenter}} expires in {{ $value
+            }} days. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: SSL Certificate of vCSA {{ $labels.vcenter}} expires in {{ $value }}
+            days. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: round(((avg_over_time(vrops_vcenter_summary_certificate_expiry_date[10m])
+          / 1000) - time()) / 86400) < 16
+        for: 20m
+        labels:
+          context: vcsa certificate
+          meta: SSL Certificate of vCSA {{ $labels.vcenter}} expires in less than 15 days.
+            ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#vcenter-appliance-certificate-expiry
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: VCenterDiskSpaceUsage
+        annotations:
+          description: Disk space usage of vCSA {{ $labels.vcenter}} is above 90%
+          summary: Disk space usage of vCSA {{ $labels.vcenter}} is above 90%
+        expr: vrops_vcenter_diskspace_usage_gigabytes / vrops_vcenter_diskspace_total_gigabytes
+          > 0.9
+        for: 15m
+        labels:
+          context: vcenter disk usage
+          meta: Disk space usage of vCSA {{ $labels.vcenter}} is above 90%
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VASAProvider(s)Disconnected
+        annotations:
+          description: VASA Provider disconnected from {{ $labels.vcenter}}.
+          summary: VASA Provider disconnected from {{ $labels.vcenter}}.
+        expr: vrops_vcenter_alert_info{alert_name="VASA Provider(s) disconnected"}
+        labels:
+          context: vasa provider
+          meta: VASA Provider disconnected from {{ $labels.vcenter}}.
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#vasaproviderdown
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VCenterHasMultipleGreyVMs
+        annotations:
+          description: vCenter {{ $labels.vcenter }} has multiple greyed out VMs for a
+            longer period. This alert is handled by TARS. If TARS fails, check and reload
+            these VMs.
+          summary: vCenter {{ $labels.vcenter }} has multiple greyed out VMs for a longer
+            period. This alert is handled by TARS. If TARS fails, check and reload these
+            VMs.
+        expr: |
+          count by(vcenter)
+          ((vrops_virtualmachine_health == -1)
+          and on(hostsystem) (vrops_hostsystem_runtime_powerstate{state="Powered On"})
+          and on(hostsystem) (vrops_hostsystem_runtime_connectionstate{state="connected"})
+          and on(hostsystem) (vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"})) > 0
+        for: 15m
+        labels:
+          context: Shadow VMs {{ $labels.vcenter }}
+          meta: vCenter {{ $labels.vcenter }} has multiple greyed out VMs for a longer
+            period. Check and reload these VMs.
+          playbook: docs/devops/alert/vcenter/#Inaccessible_Orphaned_Gray_instance_handling
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasVCenterHasMultipleGreyVMs
+        annotations:
+          description: vCenter {{ $labels.vcenter }} has multiple greyed out VMs for a
+            longer period. This alert is handled by TARS. If TARS fails, check and reload
+            these VMs.
+          summary: vCenter {{ $labels.vcenter }} has multiple greyed out VMs for a longer
+            period. This alert is handled by TARS. If TARS fails, check and reload these
+            VMs.
+        expr: |-
+          (count by(vcenter)
+          ((vrops_virtualmachine_health == -1)
+          and on(hostsystem) (vrops_hostsystem_runtime_powerstate{state="Powered On"})
+          and on(hostsystem) (vrops_hostsystem_runtime_connectionstate{state="connected"})
+          and on(hostsystem) (vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"})) > 0
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 15m
+        labels:
+          bedrock: "true"
+          context: Shadow VMs {{ $labels.vcenter }}
+          meta: vCenter {{ $labels.vcenter }} has multiple greyed out VMs for a longer
+            period. Check and reload these VMs.
+          playbook: docs/devops/alert/vcenter/#Inaccessible_Orphaned_Gray_instance_handling
+          service: compute
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-mgmt-d-0-alerts-virtualmachine.alerts
+  labels:
+    prometheus: vmware-vc-mgmt-d-0
+
+spec:
+  groups:
+    - name: virtualmachine.alerts
+      rules:
+      - alert: VMHasMemoryContention
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` has memory contention
+            due to memory compression, ballooning, or swapping. ({{ $labels.vcenter }},
+            {{ $labels.hostsystem }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` has memory contention
+            due to memory compression, ballooning, or swapping. ({{ $labels.vcenter }},
+            {{ $labels.hostsystem }})
+        expr: |
+          vrops_virtualmachine_alert_info{alert_name="Virtual machine has memory contention due to memory compression, ballooning, or swapping", vccluster=~".*management.*"}
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine `{{ $labels.virtualmachine }}` has memory contention due
+            to memory compression, ballooning, or swapping. ({{ $labels.vcenter }}, {{
+            $labels.hostsystem }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#vm_has_memory_contention
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VMHasDiskIOLatencyProblemCausedBySnapshots
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` has disk I/O latency
+            problem caused by snapshots. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` has disk I/O latency
+            problem caused by snapshots. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+        expr: |
+          vrops_virtualmachine_alert_info{alert_name="Virtual machine has disk I/O latency problem caused by snapshots", vccluster=~".*management.*"}
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine `{{ $labels.virtualmachine }}` has disk I/O latency problem
+            caused by snapshots. ({{ $labels.vcenter }}, {{ $labels.hostsystem }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#vm_has_disk_io_latency_problem_caused_by_snapshots
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VMHasCPUContentionDueToIOEvents
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` has CPU contention
+            due to long wait for I/O events. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` has CPU contention due
+            to long wait for I/O events. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+        expr: |
+          vrops_virtualmachine_alert_info{alert_name="Virtual machine has CPU contention due to long wait for I/O events", vccluster=~".*management.*"}
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine `{{ $labels.virtualmachine }}` has CPU contention due
+            to long wait for I/O events. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#vm_has_cpu_contention
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VMGuestFileSystemsRunningOutOfDiskSpace
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` guest file systems
+            are running out of disk space. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` guest file systems are
+            running out of disk space. ({{ $labels.vcenter }}, {{ $labels.hostsystem }})
+        expr: |
+          vrops_virtualmachine_guestfilesystem_storage_log_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_storage_autodeploy_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_storage_core_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_storage_dblog_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_storage_imagebuilder_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_storage_netdump_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_storage_seat_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_storage_updatemgr_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_boot_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_percentage{vccluster=~".*management.*"} > 80
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine `{{ $labels.virtualmachine }}` guest file systems are
+            running out of disk space. ({{ $labels.vcenter }}, {{ $labels.hostsystem }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#vm_guest_file_Systems_running_out_of_disk_space
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VMCPUAt100PercentForAnExtendedPeriodOfTime
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` CPU usage is at
+            100% for an extended period of time. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` CPU usage is at 100%
+            for an extended period of time. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+        expr: |
+          vrops_virtualmachine_alert_info{alert_name="Virtual machine CPU usage is at 100% for an extended period of time", vccluster=~".*management.*"}
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine {{ $labels.virtualmachine }} CPU usage is at 100% for
+            an extended period of time. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#vm_cpu_at_100_percent_for_an_extended_period_of_time
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VMInDRSClusterDemandingMoreCPUThanItsEntitlement
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` in a DRS cluster
+            is demanding more CPU than its entitlement. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` in a DRS cluster is
+            demanding more CPU than its entitlement. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+        expr: |
+          vrops_virtualmachine_alert_info{alert_name="Virtual machine in a DRS cluster is demanding more CPU than its entitlement", vccluster=~".*management.*"}
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine `{{ $labels.virtualmachine }}` in a DRS cluster is demanding
+            more CPU than its entitlement. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#vm_in_drs_cluster_demanding_more_cpu_than_its_entitlement
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VMHasSnapshotOlderThanOneWeek
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` has a snapshot older
+            than one week. ({{ $labels.vcenter }}, {{ $labels.hostsystem }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` has a snapshot older
+            than one week. ({{ $labels.vcenter }}, {{ $labels.hostsystem }})
+        expr: vrops_virtualmachine_disk_space_snapshot_age_days{vccluster=~".*management.*",
+          virtualmachine!~"jump.+"} > 7
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine `{{ $labels.virtualmachine }}` has a snapshot older than
+            one week. ({{ $labels.vcenter }}, {{ $labels.hostsystem }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VMHasCPUContentionDueToMemoryPageSwapping
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` experiencing high
+            swap wait. The host is overcommitted on memory. ({{ $labels.vcenter }}, {{
+            $labels.hostsystem }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` experiencing high swap
+            wait. The host is overcommitted on memory. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+        expr: |
+          vrops_virtualmachine_alert_info{alert_name="Virtual machine has CPU contention due to memory page swapping in the host", vccluster=~".*management.*"}
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine `{{ $labels.virtualmachine }}` experiencing high swap
+            wait. The host is overcommitted on memory. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: NSXTMgmtVMsOddDistribution
+        annotations:
+          description: Too many NSX-T VMs for the same cluster on {{ $labels.hostsystem
+            }}. Please distribute the VMs across different nodes. ({{ $labels.vcenter
+            }})
+          summary: Too many NSX-T VMs on {{ $labels.hostsystem }}. ({{ $labels.vcenter
+            }})
+        expr: |
+          count(label_replace(vrops_virtualmachine_cpu_usage_average_mhz{virtualmachine=~"nsx-.*"}, "nsx_clt", "$1", "virtualmachine", "nsx-.*(bb.*)")) by(nsx_clt, hostsystem, vcenter, vccluster) > 1
+        labels:
+          context: NSXTMgmtVMDistribution
+          dashboard: management-cluster-resources/management-cluster-resources?orgId=1&var-pod=All&var-clusters={{
+            $labels.vccluster }}&var-hosts={{ $labels.hostsystem }}
+          meta: Too many NSX-T VMs on {{ $labels.hostsystem }}. ({{ $labels.vcenter }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#nsxtmgmtvmsodddistribution
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTMgmtVMsOddDistributionSDRSAntiaffinity
+        annotations:
+          description: NSX-T VMs not part of SDRS anti-affinity rule  {{ $labels.rule_name
+            }}. Please distribute the VMs across different DS. ({{ $labels.vcenter }})
+          summary: NSX-T VMs not part of SDRS anti-affinity rule  {{ $labels.rule_name
+            }}. ({{ $labels.vcenter }})
+        expr: |
+          count  (vrops_storagepod_config_sdrsconfig_vmstorageantiaffinityrules{storagepod!~"SDRS_MGMT_BB\\d+"}) by (rule_name, vccluster, vcenter) != 3
+        labels:
+          context: NSXTMgmtVMsOddDistributionSDRS
+          dashboard: management-cluster-resources/management-cluster-resources?orgId=1&var-pod=All&var-clusters={{
+            $labels.vccluster }}
+          meta: NSX-T VMs not part of SDRS anti-affinity rule  {{ $labels.rule_name }}.
+            ({{ $labels.vcenter }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#nsxtmgmtvmsodddistributionsdrs
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VASAVMHighCPUUtilization
+        annotations:
+          description: VASA VM has >90% CPU Utilization for at least one hour. {{ $labels.virtualmachine
+            }}. {{ $labels.vccluster }}. {{ $labels.hostsystem }}. ({{ $labels.vcenter
+            }})
+          summary: High VASA VM CPU Utilization. {{ $labels.virtualmachine }}. {{ $labels.vccluster
+            }}. {{ $labels.hostsystem }}. ({{ $labels.vcenter }})
+        expr: vrops_virtualmachine_cpu_usage_ratio{virtualmachine=~"vasa.*"} > 90
+        for: 1h
+        labels:
+          context: VASAUtilization
+          meta: VASA VM has >90% CPU Utilization for at least one hour. {{ $labels.virtualmachine
+            }}. {{ $labels.vccluster }}. {{ $labels.hostsystem }}. ({{ $labels.vcenter
+            }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-mgmt-d-0-alerts-vrops.alerts
+  labels:
+    prometheus: vmware-vc-mgmt-d-0
+
+spec:
+  groups:
+    - name: vrops.alerts
+      rules:
+      - alert: VropsAPIDown
+        annotations:
+          description: "All collectors of the vrops-exporter report HTTP status codes
+            above 500, \nwhich indicates that vrops is reporting internal server errors
+            or is unreachable. \nCheck if vrops is running and healthy.\n"
+          summary: '`https://{{ $labels.target }}` API is down.'
+        expr: "(sum by (target) (vrops_api_response{collector=~\"vc.*\"}) / \ncount by
+          (target) (vrops_api_response{collector=~\"vc.*\"}) > 500) \n"
+        for: 10m
+        labels:
+          context: vrops
+          dashboard: vrops-exporter-status
+          meta: '`https://{{ $labels.target }}` API is down.'
+          playbook: docs/devops/alert/vcenter/vrops#vrops_api_down
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VropsAPIDown
+        annotations:
+          description: |
+            All collectors of the vrops-exporter report HTTP status codes above 500,
+            which indicates that vrops is reporting internal server errors or is unreachable.
+            Check if vrops is running and healthy.
+          summary: '`https://{{ $labels.target }}` API is down.'
+        expr: "(sum by (target) (vrops_api_response{collector=~\"vc.*\"}) / \ncount by
+          (target) (vrops_api_response{collector=~\"vc.*\"}) > 500)                                                                                                                     \n"
+        for: 90m
+        labels:
+          context: vrops
+          dashboard: vrops-exporter-status
+          meta: '`https://{{ $labels.target }}` API is down.'
+          playbook: docs/devops/alert/vcenter/vrops#vrops_api_down
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: VropsAPIDownEntirely
+        annotations:
+          description: |
+            Exporters can not connect to vrops anymore. Most likely the VM is stuck.
+            If this alert fires, complete vmware-montioring is down in Prometheus.
+            Ensure vrops is running and healthy.
+          meta: Vrops API is down. All collectors are not reporting anymore.
+        expr: |
+          absent(vrops_api_response)
+        for: 10m
+        labels:
+          context: vrops
+          dashboard: vrops-exporter-status
+          meta: Vrops API is down. All collectors are not reporting anymore.
+          playbook: docs/devops/alert/vcenter/vrops#vrops_api_down_entirely
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VropsAPIDownEntirely
+        annotations:
+          description: |
+            Exporters can not connect to vrops anymore. Most likely the VM is stuck.
+            If this alert fires, complete vmware-montioring is down in Prometheus.
+            Ensure vrops is running and healthy.
+          meta: Vrops API is down. All collectors are not reporting anymore.
+        expr: |
+          absent(vrops_api_response)
+        for: 90m
+        labels:
+          context: vrops
+          dashboard: vrops-exporter-status
+          meta: Vrops API is down. All collectors are not reporting anymore.
+          playbook: docs/devops/alert/vcenter/vrops#vrops_api_down_entirely
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: VropsTokenAcquisitionFailed
+        annotations:
+          description: |
+            A failed token acquisition for this vrops. This indicates
+            that the vrops system is not responding and current
+            monitoring data cannot be generated.
+          summary: Token acquisition failed for `https://{{ $labels.target }}`
+        expr: vrops_api_response{get_request="token"} >= 500
+        for: 15m
+        labels:
+          context: vrops
+          dashboard: vrops-exporter-status
+          meta: Token acquisition failed for `https://{{ $labels.target }}`
+          playbook: docs/devops/alert/vcenter/vrops#vrops_api_down
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VROpsDiskpaceUsage
+        annotations:
+          description: |
+            {{ $labels.virtualmachine }} disk almost full with over 90% usage.
+            Please increase disk size.
+          summary: '{{ $labels.virtualmachine }} disk almost full with over 90% usage.'
+        expr: vrops_virtualmachine_guestfilesystem_storage_db_percentage{virtualmachine=~"vrops.*-vc-.+"}
+          > 90
+        for: 20m
+        labels:
+          context: vrops
+          dashboard: vrops-instances-overview
+          meta: '{{ $labels.virtualmachine }} disk almost full with over 90% usage.'
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VROpsVCenterAdapterNotReceivingData
+        annotations:
+          description: The vCenter adapter for https://vrops-{{ $labels.vcenter }} is
+            not receiving data.
+          summary: The vCenter adapter for https://vrops-{{ $labels.vcenter }} is not
+            receiving data.
+        expr: vrops_vcenter_alert_info{alert_name="Adapter instance is not receiving data"}
+        for: 15m
+        labels:
+          context: vrops
+          meta: The vCenter adapter for https://vrops-{{ $labels.vcenter }} is not receiving
+            data.
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/vrops#revalidatecertificate
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VROpsNSXTAdapterNotReceivingData
+        annotations:
+          description: vROPs NSX-T adapter is not receiving data for `{{ $labels.nsxt_adapter
+            }}`. https://{{ $labels.target }}
+          summary: vROPs NSX-T adapter is not receiving data for `{{ $labels.nsxt_adapter
+            }}`. https://{{ $labels.target }}
+        expr: vrops_nsxt_adapter_alert_info{alert_name="Adapter instance is not receiving
+          data"}
+        for: 15m
+        labels:
+          context: vrops
+          meta: vROPs NSX-T adapter is not receiving data for `{{ $labels.nsxt_adapter
+            }}`. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#vrops-nsx-t-adapter-is-not-receiving-data-vropsnsxtadapternotreceivingdata
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VROpsVCenterObjectsNotReceivingData
+        annotations:
+          description: vROPs vCenter adapter for https://vrops-{{ $labels.vcenter }} is
+            not receiving data for some objects.
+          summary: vROPs vCenter adapter for https://vrops-{{ $labels.vcenter }} is not
+            receiving data for some objects.
+        expr: vrops_vcenter_alert_info{alert_name="Objects are not receiving data from
+          adapter instance"}
+        labels:
+          meta: vROPs vCenter adapter for https://vrops-{{ $labels.vcenter }} is not receiving
+            data for some objects.
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/vrops#revalidatecertificate
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-mgmt-a-0-alerts-datastore.alerts
+  labels:
+    prometheus: vmware-vc-mgmt-a-0
+
+spec:
+  groups:
+    - name: datastore.alerts
+      rules:
+      - alert: EphemeralDataStoreCapacity
+        annotations:
+          description: Eph Datastore {{ $labels.datastore }} utilization > 85%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          summary: Eph Datastore {{ $labels.datastore }} utilization > 85%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+        expr: |
+          vrops_datastore_diskspace_total_usage_gigabytes{type="ephemeral"} / vrops_datastore_diskspace_capacity_gigabytes >= 0.85
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          dashboard: vcenter-datastore-utilization
+          meta: Eph Datastore {{ $labels.datastore }} utilization > 85%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          playbook: docs/support/playbook/datastore/datastorediskusagealarm
+          service: storage
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: EphemeralDataStoreCapacity
+        annotations:
+          description: Eph Datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          summary: Eph Datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+        expr: |
+          vrops_datastore_diskspace_total_usage_gigabytes{type="ephemeral"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.9
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          dashboard: vcenter-datastore-utilization
+          meta: Eph Datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          playbook: docs/support/playbook/datastore/datastorediskusagealarm
+          service: storage
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: AverageVmfsDataStoreCapacity
+        annotations:
+          description: Average utilization for `{{ $labels.type }}` Datastores per vCenter
+            is above 70%. ({{ $labels.vcenter }})
+          summary: Average utilization for `{{ $labels.type }}` Datastores per vCenter
+            is above 70%. ({{ $labels.vcenter }})
+        expr: |
+          avg by (type, vcenter) (vrops_datastore_diskspace_total_usage_gigabytes{type=~"vmfs_p_ssd|vmfs_s_hdd"} / vrops_datastore_diskspace_capacity_gigabytes) > 0.85
+        for: 20m
+        labels:
+          context: '{{ $labels.type }} storage'
+          dashboard: vcenter-datastore-utilization
+          meta: Average utilization for `{{ $labels.type }}` Datastores per vCenter is
+            above 70%. ({{ $labels.vcenter }})
+          playbook: docs/support/playbook/storage/new_storage_lun_request
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: DataStoreCapacity
+        annotations:
+          description: '{{ $labels.type }} datastore {{ $labels.datastore }} utilization
+            > 80%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
+          summary: '{{ $labels.type }} datastore {{ $labels.datastore }} utilization >
+            80%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
+        expr: |
+          vrops_datastore_diskspace_total_usage_gigabytes{type!~"ephemeral|vmfs.+|nfs", datastore!~".+swap"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.8
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          dashboard: vcenter-datastore-utilization
+          meta: '{{ $labels.type }} datastore {{ $labels.datastore }} utilization > 80%.
+            ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
+          playbook: docs/support/playbook/datastore/datastorediskusagealarm
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: DataStoreCapacity
+        annotations:
+          description: '{{ $labels.type }} datastore {{ $labels.datastore }} utilization
+            > 90%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
+          summary: '{{ $labels.type }} datastore {{ $labels.datastore }} utilization >
+            90%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
+        expr: |
+          vrops_datastore_diskspace_total_usage_gigabytes{type!~"ephemeral|vmfs.+|nfs", datastore!~".+swap"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.9
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          dashboard: vcenter-datastore-utilization
+          meta: '{{ $labels.type }} datastore {{ $labels.datastore }} utilization > 90%.
+            ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
+          playbook: docs/support/playbook/datastore/datastorediskusagealarm
+          service: storage
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: SwapDataStoreUsageWithoutVMs
+        annotations:
+          description: NVMe swap datastore {{ $labels.datastore }} is utilized without
+            associated VMs. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: NVMe swap datastore {{ $labels.datastore }} is utilized without associated
+            VMs. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: |
+          vrops_datastore_diskspace_total_usage_gigabytes{datastore=~".*-swap"} > 10 and vrops_datastore_summary_total_number_vms == 0 unless on (datastore) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "datastore", "$1-swap", "hostsystem", "(node...-bb...).*")
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          meta: NVMe swap datastore {{ $labels.datastore }} is utilized without associated
+            VMs. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#swap-files-exist-on-local-ds-without-running-vms
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NVMeSwapDatastoreMissing
+        annotations:
+          description: |-
+            NVMe swap datastore on `{{ $labels.hostsystem }}` is missing. Model is _{{$labels.hardware_model}}_ and located in cluster *{{ $labels.vccluster }}*
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            NVMe swap datastore on `{{ $labels.hostsystem }}` is missing. Model is _{{$labels.hardware_model}}_ and located in cluster *{{ $labels.vccluster }}*
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_hostsystem_hardware_model{vccluster=~"productionbb\\d+", hardware_model!~"Cisco Systems Inc.+"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          unless on (hostsystem) (label_replace(label_join(vrops_datastore_summary_datastore_accessible{type="NVMe"}, "hostsystem", "", "datastore", "vcenter"), "hostsystem", "$1$2", "hostsystem", "(.+)-swapvc-[a-z]-\\d+(.+)")
+          or vrops_hostsystem_summary_custom_tag_nvme{summary_custom_tag_nvme="false"})
+        for: 5m
+        labels:
+          context: '{{ $labels.hostsystem }}'
+          meta: |-
+            NVMe swap datastore on `{{ $labels.hostsystem }}` is missing. Model is _{{$labels.hardware_model}}_ and located in cluster *{{ $labels.vccluster }}*
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          playbook: docs/support/playbook/datastore/nvmeswapdatastoremissing
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: DatastoreDisconnectedWithVmsOnIt
+        annotations:
+          description: Datastore {{ $labels.datastore }} is disconnected and has virtual
+            machines on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: Datastore {{ $labels.datastore }} is disconnected and has virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: |
+          (label_replace(vrops_datastore_summary_total_number_vms, "hostsystem", "$1", "datastore", "(node[0-9]{3}-[^-]*).*") > 0 and on(datastore) vrops_datastore_summary_datastore_accessible{state="PoweredOff",type!="local"}) unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          meta: Datastore {{ $labels.datastore }} is disconnected and has virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#datastoredisconnectedwithvmsonit
+          service: storage
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: IaasDatastoreDisconnectedWithVmsOnIt
+        annotations:
+          description: Datastore {{ $labels.datastore }} is disconnected and has virtual
+            machines on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: Datastore {{ $labels.datastore }} is disconnected and has virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: |-
+          ((label_replace(vrops_datastore_summary_total_number_vms, "hostsystem", "$1", "datastore", "(node[0-9]{3}-[^-]*).*") > 0 and on(datastore) vrops_datastore_summary_datastore_accessible{state="PoweredOff",type!="local"}) unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 20m
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.datastore }}'
+          meta: Datastore {{ $labels.datastore }} is disconnected and has virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#datastoredisconnectedwithvmsonit
+          service: storage
+          severity: critical
+          support_group: iaas_support
+          tier: vmware
+      - alert: DatastoreDisconnectedWithoutVmsOnIt
+        annotations:
+          description: Datastore {{ $labels.datastore }} is disconnected without virtual
+            machines on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: Datastore {{ $labels.datastore }} is disconnected without virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: |
+          (label_replace(vrops_datastore_summary_total_number_vms, "hostsystem", "$1", "datastore", "(node[0-9]{3}-[^-]*).*") == 0 and on(datastore) vrops_datastore_summary_datastore_accessible{state="PoweredOff",type!="local"}) unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          meta: Datastore {{ $labels.datastore }} is disconnected without virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#datastoredisconnectedwithoutvmsonit
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasDatastoreDisconnectedWithoutVmsOnIt
+        annotations:
+          description: Datastore {{ $labels.datastore }} is disconnected without virtual
+            machines on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: Datastore {{ $labels.datastore }} is disconnected without virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: |-
+          ((label_replace(vrops_datastore_summary_total_number_vms, "hostsystem", "$1", "datastore", "(node[0-9]{3}-[^-]*).*") == 0 and on(datastore) vrops_datastore_summary_datastore_accessible{state="PoweredOff",type!="local"}) unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 20m
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.datastore }}'
+          meta: Datastore {{ $labels.datastore }} is disconnected without virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#datastoredisconnectedwithoutvmsonit
+          service: storage
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: DatastoreHasLostConnectivityToAStorageDevice
+        annotations:
+          description: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has lost connectivity to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has lost connectivity to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          label_replace(vrops_datastore_alert_info{alert_name="Datastore has lost connectivity to a storage device"}, "hostsystem", "$1", "datastore", "(node.*)(-.*)") unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+        labels:
+          meta: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has lost connectivity to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#datastorehashoststhathavelostredundantpathsanddatastorehaslostconnectivitytoastoragedevice
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasDatastoreHasLostConnectivityToAStorageDevice
+        annotations:
+          description: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has lost connectivity to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has lost connectivity to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |-
+          (label_replace(vrops_datastore_alert_info{alert_name="Datastore has lost connectivity to a storage device"}, "hostsystem", "$1", "datastore", "(node.*)(-.*)") unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          meta: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has lost connectivity to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#datastorehashoststhathavelostredundantpathsanddatastorehaslostconnectivitytoastoragedevice
+          service: storage
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: DatastoreHasHostsThatHaveLostRedundantPathsToAStorageDevice
+        annotations:
+          description: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has hosts that have lost redundant paths to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has hosts that have lost redundant paths to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          label_replace(vrops_datastore_alert_info{alert_name="Datastore has one or more hosts that have lost redundant paths to a storage device"}, "hostsystem", "$1", "datastore", "(node.*)(-.*)") unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+        labels:
+          meta: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has hosts that have lost redundant paths to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#datastorehashoststhathavelostredundantpathsanddatastorehaslostconnectivitytoastoragedevice
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasDatastoreHasHostsThatHaveLostRedundantPathsToAStorageDevice
+        annotations:
+          description: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has hosts that have lost redundant paths to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has hosts that have lost redundant paths to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |-
+          (label_replace(vrops_datastore_alert_info{alert_name="Datastore has one or more hosts that have lost redundant paths to a storage device"}, "hostsystem", "$1", "datastore", "(node.*)(-.*)") unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          meta: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has hosts that have lost redundant paths to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#datastorehashoststhathavelostredundantpathsanddatastorehaslostconnectivitytoastoragedevice
+          service: storage
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: SDRSClusterCapacity
+        annotations:
+          description: DataStore Cluster {{ $labels.storagepod }} utilization > 80%. ({{
+            $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: DataStore Cluster {{ $labels.storagepod }} utilization > 80%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+        expr: |
+          vrops_storagepod_capacity_available_space / vrops_storagepod_capacity_total * 100 <= 20
+        for: 20m
+        labels:
+          context: '{{ $labels.storagepod }}'
+          dashboard: vcenter-datastore-utilization
+          meta: DataStore Cluster {{ $labels.storagepod }} utilization > 80%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          playbook: docs/support/playbook/datastore/datastorediskusagealarm
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: SDRSClusterCapacity
+        annotations:
+          description: DataStore Cluster {{ $labels.storagepod }} utilization > 90%. ({{
+            $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: DataStore Cluster {{ $labels.storagepod }} utilization > 90%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+        expr: |
+          vrops_storagepod_capacity_available_space / vrops_storagepod_capacity_total * 100 <= 10
+        for: 20m
+        labels:
+          context: '{{ $labels.storagepod }}'
+          dashboard: vcenter-datastore-utilization
+          meta: DataStore Cluster {{ $labels.storagepod }} utilization > 90%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          playbook: docs/support/playbook/datastore/datastorediskusagealarm
+          service: storage
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: NVMeDatastoreNotAccessible
+        annotations:
+          description: Datastore {{ $labels.datastore }} is not accessible. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          summary: Datastore {{ $labels.datastore }} is not accessible. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+        expr: |
+          vrops_datastore_summary_datastore_accessible{type='NVMe'} == 0
+        for: 5m
+        labels:
+          context: '{{ $labels.datastore }}'
+          meta: Datastore {{ $labels.datastore }} is not accessible. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          service: storage
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: EphemeralDatastoreNotPartOfSDRSCluster
+        annotations:
+          description: Eph Datastore {{ $labels.datastore }} is not a part of SDRS Cluster.
+            ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: Eph Datastore {{ $labels.datastore }} is not a part of SDRS Cluster.
+            ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: |
+          vrops_datastore_summary_datastore_accessible{type="ephemeral", storagepod=~"none|None|NONE", datastore=~"eph.*"} > 0
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          meta: Eph Datastore {{ $labels.datastore }} is not a part of SDRS cluster. ({{
+            $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#ephemeraldatastorenotpartofsdrscluster
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: EphemeralDatastorePartOfIncorrectSDRSCluster
+        annotations:
+          description: Eph Datastore {{ $labels.datastore }} is not a part of correct
+            SDRS Cluster. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: Eph Datastore {{ $labels.datastore }} is not a part of correct SDRS
+            Cluster. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: |
+          (vrops_datastore_summary_datastore_accessible{type="ephemeral", storagepod=~".*hgb.*", datastore=~"eph.*hga"} or vrops_datastore_summary_datastore_accessible{type="ephemeral", storagepod=~".*hga.*", datastore=~"eph.*hgb"}) > 0
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          meta: Eph Datastore {{ $labels.datastore }} is not a part of correct SDRS cluster.
+            ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#ephemeraldatastorepartofincorrectsdrscluster
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: CinderTagMissingForDatastoreSSD
+        annotations:
+          description: |-
+            There is no Cinder tag present for the `{{ $labels.datastore }}` datastore in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            There is no Cinder tag present for the `{{ $labels.datastore }}` datastore in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_datastore_summary_tag{type="vmfs_p_ssd", summary_tag="none"}
+          unless on (datastore) vrops_datastore_summary_custom_tag_cinder_state{summary_custom_tag_cinder_state="reserved"}
+        for: 1h
+        labels:
+          meta: |-
+            There is no Cinder tag present for the `{{ $labels.datastore }}` datastore in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          playbook: docs/support/playbook/cinder/cinder-tag-missing
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: CinderTagMissingForDatastoreHDD
+        annotations:
+          description: |-
+            There is no Cinder tag present for the `{{ $labels.datastore }}` datastore in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            There is no Cinder tag present for the `{{ $labels.datastore }}` datastore in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_datastore_summary_tag{type="vmfs_s_hdd", summary_tag="none"}
+          unless on (datastore) vrops_datastore_summary_custom_tag_cinder_state{summary_custom_tag_cinder_state="reserved"}
+        for: 1h
+        labels:
+          meta: |-
+            There is no Cinder tag present for the `{{ $labels.datastore }}` datastore in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          playbook: docs/support/playbook/cinder/cinder-tag-missing
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: CinderTagAddedForReservedDatastore
+        annotations:
+          description: |-
+            The Cinder state is reserved but the Cinder tag still exists for the `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The Cinder state is reserved but the Cinder tag still exists for the `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_datastore_summary_custom_tag_cinder_state{type=~"(vmfs_s_hdd|vmfs_p_ssd)", summary_custom_tag_cinder_state="reserved"} > 0
+          and on (datastore) vrops_datastore_summary_tag{tag_cinder=~"cinder|slow"}
+        for: 1h
+        labels:
+          meta: |-
+            The Cinder state is reserved but the Cinder tag still exists for the `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          playbook: docs/support/playbook/cinder/cinder-tag-added
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VMFSDatastoreHostcountMismatch
+        annotations:
+          description: |-
+            The `{{ $labels.datastore }}` VMFS datastore is not connected to all production ESXi hosts in *{{ $labels.vcenter }}* vCenter.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The `{{ $labels.datastore }}` VMFS datastore is not connected to all production ESXi hosts in *{{ $labels.vcenter }}* vCenter.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_datastore_hostcount{type=~"(vmfs_s_hdd|vmfs_p_ssd)"} < on (vcenter) group_left
+          count by (vcenter) (vrops_hostsystem_runtime_connectionstate{state="connected", vccluster=~"productionbb\\d+"}
+          unless on (hostsystem) (vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}))
+        for: 60m
+        labels:
+          meta: |-
+            The `{{ $labels.datastore }}` VMFS datastore is not connected to all production ESXi hosts in *{{ $labels.vcenter }}* vCenter.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          playbook: docs/devops/alert/vcenter/#vmfsdatastorehostcountmismatch
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NFSDatastoreHostcountMismatch
+        annotations:
+          description: |-
+            The `{{ $labels.datastore }}` NFS datastore is not connected to all production ESXi hosts in *{{ $labels.vcenter }}* vCenter.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The `{{ $labels.datastore }}` NFS datastore is not connected to all production ESXi hosts in *{{ $labels.vcenter }}* vCenter.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_datastore_hostcount{type="nfs"} < on (vcenter) group_left
+          count by (vcenter) (vrops_hostsystem_runtime_connectionstate{state="connected", vccluster=~"productionbb\\d+"})
+        for: 60m
+        labels:
+          meta: |-
+            The `{{ $labels.datastore }}` NFS datastore is not connected to all production ESXi hosts in *{{ $labels.vcenter }}* vCenter.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          playbook: docs/devops/alert/vcenter/#nfsdatastorehostcountmismatch
+          service: storage
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: NFSDatastoreCinderAggregateIDNotSet
+        annotations:
+          description: |-
+            cinder_aggregate_id is not set for the `{{ $labels.datastore }}` NFS datastore in *{{ $labels.datacenter }}* availability zone.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            cinder_aggregate_id is not set for the `{{ $labels.datastore }}` NFS datastore in *{{ $labels.datacenter }}* availability zone.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_datastore_summary_datastore_accessible{type="nfs"}
+          unless on(datastore) vrops_datastore_summary_custom_tag_cinder_aggregate_id{type="nfs", summary_custom_tag_cinder_aggregate_id!=""}
+        for: 1h
+        labels:
+          meta: |-
+            cinder_aggregate_id is not set for the `{{ $labels.datastore }}` NFS datastore in *{{ $labels.datacenter }}* availability zone.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          playbook: docs/support/playbook/cinder/cinder-fcd-operations/#nfsdatastorecinderaggregateidnotset
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-mgmt-a-0-alerts-host.alerts
+  labels:
+    prometheus: vmware-vc-mgmt-a-0
+
+spec:
+  groups:
+    - name: host.alerts
+      rules:
+      - alert: HostWithRunningVMsNotResponding
+        annotations:
+          description: Host {{ $labels.hostsystem }} with running VMs not responding.
+            ({{ $labels.vcenter }}, {{ $labels.vccluster }})
+          summary: Host {{ $labels.hostsystem }} with running VMs not responding. ({{
+            $labels.vcenter }}, {{ $labels.vccluster }})
+        expr: |
+          avg_over_time(vrops_hostsystem_runtime_connectionstate{state="notResponding"}[5m])
+          and on (hostsystem) avg_over_time(vrops_hostsystem_runtime_powerstate{state!="Powered Off"}[5m])
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"}
+          and on (hostsystem) count(vrops_virtualmachine_runtime_powerstate{virtualmachine!~"vCLS.*", state!="Powered Off"}) by (hostsystem) > 0
+        for: 5m
+        labels:
+          context: ESXi not responding
+          dashboard: esxi-host-disconnected/esxi-host-disconnected?&var-host={{ $labels.hostsystem
+            }}
+          meta: Host {{ $labels.hostsystem }} with running VMs not responding. ({{ $labels.vcenter
+            }}, {{ $labels.vccluster }})
+          playbook: docs/devops/alert/vcenter/#hostwithrunningvmsnotresponding
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostWithRunningVMsNotResponding
+        annotations:
+          description: Host {{ $labels.hostsystem }} with running VMs not responding.
+            ({{ $labels.vcenter }}, {{ $labels.vccluster }})
+          summary: Host {{ $labels.hostsystem }} with running VMs not responding. ({{
+            $labels.vcenter }}, {{ $labels.vccluster }})
+        expr: |-
+          (avg_over_time(vrops_hostsystem_runtime_connectionstate{state="notResponding"}[5m])
+          and on (hostsystem) avg_over_time(vrops_hostsystem_runtime_powerstate{state!="Powered Off"}[5m])
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"}
+          and on (hostsystem) count(vrops_virtualmachine_runtime_powerstate{virtualmachine!~"vCLS.*", state!="Powered Off"}) by (hostsystem) > 0
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 5m
+        labels:
+          bedrock: "true"
+          context: ESXi not responding
+          dashboard: esxi-host-disconnected/esxi-host-disconnected?&var-host={{ $labels.hostsystem
+            }}
+          meta: Host {{ $labels.hostsystem }} with running VMs not responding. ({{ $labels.vcenter
+            }}, {{ $labels.vccluster }})
+          playbook: docs/devops/alert/vcenter/#hostwithrunningvmsnotresponding
+          service: compute
+          severity: critical
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostNotResponding
+        annotations:
+          description: Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter
+            }}, {{ $labels.vccluster }})
+          summary: Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter }},
+            {{ $labels.vccluster }})
+        expr: |
+          vrops_hostsystem_summary_running_vms_number == 0 and
+          on (hostsystem) vrops_hostsystem_runtime_connectionstate{state="notResponding"} and
+          on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"} and
+          on (hostsystem) vrops_hostsystem_runtime_powerstate{state!="Powered Off"}
+        labels:
+          context: ESXi not responding
+          dashboard: esxi-host-disconnected/esxi-host-disconnected?&var-host={{ $labels.hostsystem
+            }}
+          meta: Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter }},
+            {{ $labels.vccluster }})
+          playbook: docs/devops/alert/vcenter/#hostnotresponding
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostNotResponding
+        annotations:
+          description: Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter
+            }}, {{ $labels.vccluster }})
+          summary: Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter }},
+            {{ $labels.vccluster }})
+        expr: |-
+          (vrops_hostsystem_summary_running_vms_number == 0 and
+          on (hostsystem) vrops_hostsystem_runtime_connectionstate{state="notResponding"} and
+          on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"} and
+          on (hostsystem) vrops_hostsystem_runtime_powerstate{state!="Powered Off"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: ESXi not responding
+          dashboard: esxi-host-disconnected/esxi-host-disconnected?&var-host={{ $labels.hostsystem
+            }}
+          meta: Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter }},
+            {{ $labels.vccluster }})
+          playbook: docs/devops/alert/vcenter/#hostnotresponding
+          service: compute
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: VMsOnFailoverHost
+        annotations:
+          description: Failover Host {{ $labels.hostsystem }} has Virtual Machines on
+            it. Free up the host. ({{ $labels.vcenter }}, {{ $labels.vccluster }})
+          summary: Failover Host {{ $labels.hostsystem }} has Virtual Machines on it.
+            ({{ $labels.vcenter }}, {{ $labels.vccluster }})
+        expr: |
+          vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost == 1
+          and on (hostsystem) count(vrops_virtualmachine_runtime_powerstate{virtualmachine!~"vCLS.*", state="Powered On"}) by (hostsystem) > 0
+        for: 10m
+        labels:
+          context: Failover host
+          meta: Failover Host {{ $labels.hostsystem }} has Virtual Machines on it. ({{
+            $labels.vcenter }}, {{ $labels.vccluster }})
+          playbook: docs/devops/alert/vcenter/#vmsonfailoverhost
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: IaasVMsOnFailoverHost
+        annotations:
+          description: Failover Host {{ $labels.hostsystem }} has Virtual Machines on
+            it. Free up the host. ({{ $labels.vcenter }}, {{ $labels.vccluster }})
+          summary: Failover Host {{ $labels.hostsystem }} has Virtual Machines on it.
+            ({{ $labels.vcenter }}, {{ $labels.vccluster }})
+        expr: |-
+          (vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost == 1
+          and on (hostsystem) count(vrops_virtualmachine_runtime_powerstate{virtualmachine!~"vCLS.*", state="Powered On"}) by (hostsystem) > 0
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 10m
+        labels:
+          bedrock: "true"
+          context: Failover host
+          meta: Failover Host {{ $labels.hostsystem }} has Virtual Machines on it. ({{
+            $labels.vcenter }}, {{ $labels.vccluster }})
+          playbook: docs/devops/alert/vcenter/#vmsonfailoverhost
+          service: compute
+          severity: critical
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostHasLostRedundantConnectivityToDVPort
+        annotations:
+          description: Host `{{ $labels.hostsystem }}` has lost redundant connectivity
+            to a dvPort. ({{ $labels.vcenter }}).
+          summary: Host `{{ $labels.hostsystem }}` has lost redundant connectivity to
+            a dvPort. ({{ $labels.vcenter }}).
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="The host has lost redundant connectivity to a dvPort"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        labels:
+          context: '{{ $labels.hostsystem }} dvPort connection'
+          meta: Host `{{ $labels.hostsystem }}` has lost redundant connectivity to a dvPort.
+            ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#host_has_lost_connectivity_to_a_dv_port
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostHasLostRedundantConnectivityToDVPort
+        annotations:
+          description: Host `{{ $labels.hostsystem }}` has lost redundant connectivity
+            to a dvPort. ({{ $labels.vcenter }}).
+          summary: Host `{{ $labels.hostsystem }}` has lost redundant connectivity to
+            a dvPort. ({{ $labels.vcenter }}).
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="The host has lost redundant connectivity to a dvPort"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} dvPort connection'
+          meta: Host `{{ $labels.hostsystem }}` has lost redundant connectivity to a dvPort.
+            ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#host_has_lost_connectivity_to_a_dv_port
+          service: compute
+          severity: info
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostNicDown
+        annotations:
+          description: '`{{ $labels.hostsystem }}` has detected a link status down on
+            a physical NIC. ({{ $labels.vcenter }}).'
+          summary: '`{{ $labels.hostsystem }}` has detected a link status down on a physical
+            NIC. ({{ $labels.vcenter }}).'
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="ESXi host has detected a link status down on a physical NIC"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        for: 20m
+        labels:
+          context: '{{ $labels.hostsystem }} network connection'
+          meta: '`{{ $labels.hostsystem }}` has detected a link status down on a physical
+            NIC. ({{ $labels.vcenter }}).'
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hostnicdown
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostNicDown
+        annotations:
+          description: '`{{ $labels.hostsystem }}` has detected a link status down on
+            a physical NIC. ({{ $labels.vcenter }}).'
+          summary: '`{{ $labels.hostsystem }}` has detected a link status down on a physical
+            NIC. ({{ $labels.vcenter }}).'
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="ESXi host has detected a link status down on a physical NIC"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 20m
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} network connection'
+          meta: '`{{ $labels.hostsystem }}` has detected a link status down on a physical
+            NIC. ({{ $labels.vcenter }}).'
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hostnicdown
+          service: compute
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostHasLostConnectionToVCenterServer
+        annotations:
+          description: '`{{ $labels.hostsystem }}` has been unexpectedly disconnected
+            from vCenter Server {{ $labels.vcenter }}.'
+          summary: '`{{ $labels.hostsystem }}` has been unexpectedly disconnected from
+            vCenter Server {{ $labels.vcenter }}.'
+        expr: |
+          vrops_hostsystem_runtime_connectionstate{state="disconnected"} AND on (hostsystem)
+          vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"} AND on (hostsystem)
+          vrops_hostsystem_runtime_powerstate{state!="Standby"}
+        labels:
+          context: '{{ $labels.hostsystem }} vCenter connection'
+          meta: '`{{ $labels.hostsystem }}` has been unexpectedly disconnected from vCenter
+            Server {{ $labels.vcenter }}.'
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hosthaslostconnectiontovcenterserver
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostHasLostConnectionToVCenterServer
+        annotations:
+          description: '`{{ $labels.hostsystem }}` has been unexpectedly disconnected
+            from vCenter Server {{ $labels.vcenter }}.'
+          summary: '`{{ $labels.hostsystem }}` has been unexpectedly disconnected from
+            vCenter Server {{ $labels.vcenter }}.'
+        expr: |-
+          (vrops_hostsystem_runtime_connectionstate{state="disconnected"} AND on (hostsystem)
+          vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"} AND on (hostsystem)
+          vrops_hostsystem_runtime_powerstate{state!="Standby"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} vCenter connection'
+          meta: '`{{ $labels.hostsystem }}` has been unexpectedly disconnected from vCenter
+            Server {{ $labels.vcenter }}.'
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hosthaslostconnectiontovcenterserver
+          service: compute
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostHasLostConnectivityToPhysicalNetwork
+        annotations:
+          description: Host `{{ $labels.hostsystem }}` has lost connectivity to physical
+            network. ({{ $labels.vcenter }}).
+          summary: Host `{{ $labels.hostsystem }}` has lost connectivity to physical network.
+            ({{ $labels.vcenter }}).
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="The host has lost connectivity to physical network"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        labels:
+          context: '{{ $labels.hostsystem }} network connection'
+          meta: Host `{{ $labels.hostsystem }}` has lost connectivity to physical network.
+            ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#host_has_lost_connectivity_to_physical_network
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostHasLostConnectivityToPhysicalNetwork
+        annotations:
+          description: Host `{{ $labels.hostsystem }}` has lost connectivity to physical
+            network. ({{ $labels.vcenter }}).
+          summary: Host `{{ $labels.hostsystem }}` has lost connectivity to physical network.
+            ({{ $labels.vcenter }}).
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="The host has lost connectivity to physical network"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} network connection'
+          meta: Host `{{ $labels.hostsystem }}` has lost connectivity to physical network.
+            ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#host_has_lost_connectivity_to_physical_network
+          service: compute
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: HADetectedAPossibleHostFailure-testing
+        annotations:
+          description: vSphere High Availability (HA) has detected a possible host failure
+            for `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+          summary: vSphere High Availability (HA) has detected a possible host failure
+            for `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) has detected a possible host failure"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{vccluster!~".*controlplane-swift"}
+        labels:
+          context: '{{ $labels.hostsystem }} failure'
+          meta: vSphere High Availability (HA) has detected a possible host failure for
+            `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hadetectedapossiblehostfailure
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: HADetectedAPossibleHostFailure
+        annotations:
+          description: vSphere High Availability (HA) has detected a possible host failure
+            for `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+          summary: vSphere High Availability (HA) has detected a possible host failure
+            for `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) has detected a possible host failure"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance", vccluster!~".*controlplane-swift"}
+        labels:
+          context: '{{ $labels.hostsystem }} failure'
+          meta: vSphere High Availability (HA) has detected a possible host failure for
+            `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hadetectedapossiblehostfailure
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: IaasHADetectedAPossibleHostFailure
+        annotations:
+          description: vSphere High Availability (HA) has detected a possible host failure
+            for `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+          summary: vSphere High Availability (HA) has detected a possible host failure
+            for `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) has detected a possible host failure"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance", vccluster!~".*controlplane-swift"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} failure'
+          meta: vSphere High Availability (HA) has detected a possible host failure for
+            `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hadetectedapossiblehostfailure
+          service: compute
+          severity: critical
+          support_group: iaas_support
+          tier: vmware
+      - alert: APodMemoryUtilizationHigh
+        annotations:
+          description: Memory utilization of host {{ $labels.hostsystem }} is above 90%.
+            ({{ $labels.vcenter }})
+          summary: Memory utilization of host {{ $labels.hostsystem }} is above 90%. ({{
+            $labels.vcenter }})
+        expr: vrops_hostsystem_memory_usage_percentage{vccluster=~".*-management.*"} >
+          95
+        for: 30m
+        labels:
+          context: '{{ $labels.hostsystem }} memory'
+          meta: Memory utilization of host {{ $labels.hostsystem }} is above 90%. ({{
+            $labels.vcenter }})
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: APodCPUUtilizationHigh
+        annotations:
+          description: CPU utilization of host {{ $labels.hostsystem }} is above 90%.
+            ({{ $labels.vcenter }})
+          summary: CPU utilization of host {{ $labels.hostsystem }} is above 90%. ({{
+            $labels.vcenter }})
+        expr: vrops_hostsystem_cpu_usage_average_percentage{vccluster=~".*-management.*"}
+          > 80
+        for: 30m
+        labels:
+          context: '{{ $labels.hostsystem }} cpu'
+          meta: CPU utilization of host {{ $labels.hostsystem }} is above 90%. ({{ $labels.vcenter
+            }})
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: HostHighNumberOfPacketsDropped
+        annotations:
+          description: '`{{ $labels.hostsystem }}` is experiencing high number of packets
+            dropped. ({{ $labels.vcenter }}).'
+          summary: '`{{ $labels.hostsystem }}` is experiencing high number of packets
+            dropped. ({{ $labels.vcenter }}).'
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="Host is experiencing high number of packets dropped"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        labels:
+          context: '{{ $labels.hostsystem }} packets dropped'
+          meta: '`{{ $labels.hostsystem }}` is experiencing high number of packets dropped.
+            ({{ $labels.vcenter }}).'
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostHighNumberOfPacketsDropped
+        annotations:
+          description: '`{{ $labels.hostsystem }}` is experiencing high number of packets
+            dropped. ({{ $labels.vcenter }}).'
+          summary: '`{{ $labels.hostsystem }}` is experiencing high number of packets
+            dropped. ({{ $labels.vcenter }}).'
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="Host is experiencing high number of packets dropped"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} packets dropped'
+          meta: '`{{ $labels.hostsystem }}` is experiencing high number of packets dropped.
+            ({{ $labels.vcenter }}).'
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostNicLinkFlappingAlert
+        annotations:
+          description: '`{{ $labels.hostsystem }}` has detected a link status flapping
+            on a physical NIC. ({{ $labels.vcenter }}).'
+          summary: '`{{ $labels.hostsystem }}` has detected a link status flapping on
+            a physical NIC. ({{ $labels.vcenter }}).'
+        expr: |
+          vrops_hostsystem_alert_info{alert_name=~"ESXi host has detected a link status.*flapping.*on a physical NIC"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        labels:
+          context: '{{ $labels.hostsystem }} link flapping'
+          meta: '`{{ $labels.hostsystem }}` has detected a link status flapping on a physical
+            NIC. ({{ $labels.vcenter }}).'
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostNicLinkFlappingAlert
+        annotations:
+          description: '`{{ $labels.hostsystem }}` has detected a link status flapping
+            on a physical NIC. ({{ $labels.vcenter }}).'
+          summary: '`{{ $labels.hostsystem }}` has detected a link status flapping on
+            a physical NIC. ({{ $labels.vcenter }}).'
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name=~"ESXi host has detected a link status.*flapping.*on a physical NIC"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} link flapping'
+          meta: '`{{ $labels.hostsystem }}` has detected a link status flapping on a physical
+            NIC. ({{ $labels.vcenter }}).'
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostSystemEventLogSensorAlert
+        annotations:
+          description: IPMI System Event Log for `{{ $labels.hostsystem }}` is becoming
+            full. ({{ $labels.vcenter }}) {{ $labels.recommendation_1 }}
+          summary: IPMI System Event Log for `{{ $labels.hostsystem }}` is becoming full.
+            ({{ $labels.vcenter }}) {{ $labels.recommendation_1 }}
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="IPMI System Event Log for the host is becoming full"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        labels:
+          context: '{{ $labels.hostsystem }} IPMI log'
+          meta: IPMI System Event Log for `{{ $labels.hostsystem }}` is becoming full.
+            ({{ $labels.vcenter }}) {{ $labels.recommendation_1 }}
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostSystemEventLogSensorAlert
+        annotations:
+          description: IPMI System Event Log for `{{ $labels.hostsystem }}` is becoming
+            full. ({{ $labels.vcenter }}) {{ $labels.recommendation_1 }}
+          summary: IPMI System Event Log for `{{ $labels.hostsystem }}` is becoming full.
+            ({{ $labels.vcenter }}) {{ $labels.recommendation_1 }}
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="IPMI System Event Log for the host is becoming full"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} IPMI log'
+          meta: IPMI System Event Log for `{{ $labels.hostsystem }}` is becoming full.
+            ({{ $labels.vcenter }}) {{ $labels.recommendation_1 }}
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostStoragePathsDown
+        annotations:
+          description: More than 4 active storage paths for `{{ $labels.hostsystem }}`
+            down. ({{ $labels.vcenter }})
+          summary: More than 4 active storage paths for `{{ $labels.hostsystem }}` down.
+            ({{ $labels.vcenter }})
+        expr: vrops_hostsystem_storage_number_of_path - vrops_hostsystem_storage_number_of_active_path
+          > 4
+        for: 30m
+        labels:
+          context: '{{ $labels.hostsystem }} storage paths'
+          meta: More than 4 active storage paths for `{{ $labels.hostsystem }}` down.
+            ({{ $labels.vcenter }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostStoragePathsDown
+        annotations:
+          description: More than 4 active storage paths for `{{ $labels.hostsystem }}`
+            down. ({{ $labels.vcenter }})
+          summary: More than 4 active storage paths for `{{ $labels.hostsystem }}` down.
+            ({{ $labels.vcenter }})
+        expr: (vrops_hostsystem_storage_number_of_path - vrops_hostsystem_storage_number_of_active_path
+          > 4) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 30m
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} storage paths'
+          meta: More than 4 active storage paths for `{{ $labels.hostsystem }}` down.
+            ({{ $labels.vcenter }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostAllRedundantStoragePathsDown
+        annotations:
+          description: All active storage paths for `{{ $labels.hostsystem }}` down. ({{
+            $labels.vcenter }})
+          summary: All active storage paths for `{{ $labels.hostsystem }}` down. ({{ $labels.vcenter
+            }})
+        expr: vrops_hostsystem_storage_number_of_active_path == 0
+        for: 10m
+        labels:
+          context: '{{ $labels.hostsystem }} storage paths'
+          meta: All active storage paths for `{{ $labels.hostsystem }}` down. ({{ $labels.vcenter
+            }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostAllRedundantStoragePathsDown
+        annotations:
+          description: All active storage paths for `{{ $labels.hostsystem }}` down. ({{
+            $labels.vcenter }})
+          summary: All active storage paths for `{{ $labels.hostsystem }}` down. ({{ $labels.vcenter
+            }})
+        expr: (vrops_hostsystem_storage_number_of_active_path == 0) and on(hostsystem)
+          vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 10m
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} storage paths'
+          meta: All active storage paths for `{{ $labels.hostsystem }}` down. ({{ $labels.vcenter
+            }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: iaas_support
+          tier: vmware
+      - alert: HAHostAgentError
+        annotations:
+          description: HA agent on Host `{{ $labels.hostsystem }}` has encountered an
+            error. ({{ $labels.vcenter }}).
+          summary: HA agent on Host `{{ $labels.hostsystem }}` has encountered an error.
+            ({{ $labels.vcenter }}).
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) host agent has encountered an error", vccluster!~".*-controlplane-swift"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        labels:
+          context: '{{ $labels.hostsystem }} HA agent error'
+          meta: HA agent on Host `{{ $labels.hostsystem }}` has encountered an error.
+            ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#troubleshooting-vsphere-ha-host-states
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasHAHostAgentError
+        annotations:
+          description: HA agent on Host `{{ $labels.hostsystem }}` has encountered an
+            error. ({{ $labels.vcenter }}).
+          summary: HA agent on Host `{{ $labels.hostsystem }}` has encountered an error.
+            ({{ $labels.vcenter }}).
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) host agent has encountered an error", vccluster!~".*-controlplane-swift"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} HA agent error'
+          meta: HA agent on Host `{{ $labels.hostsystem }}` has encountered an error.
+            ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#troubleshooting-vsphere-ha-host-states
+          service: compute
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: HAHostNetworkPartitioned
+        annotations:
+          description: HA on Host `{{ $labels.hostsystem }}` has detected a network-partitioned
+            host. ({{ $labels.vcenter }}).
+          summary: HA on Host `{{ $labels.hostsystem }}` has detected a network-partitioned
+            host. ({{ $labels.vcenter }}).
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) has detected a network-partitioned host"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        labels:
+          context: '{{ $labels.hostsystem }} HA network-partitioned host'
+          meta: HA on Host `{{ $labels.hostsystem }}` has detected a network-partitioned
+            host. ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#troubleshooting-vsphere-ha-host-states
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasHAHostNetworkPartitioned
+        annotations:
+          description: HA on Host `{{ $labels.hostsystem }}` has detected a network-partitioned
+            host. ({{ $labels.vcenter }}).
+          summary: HA on Host `{{ $labels.hostsystem }}` has detected a network-partitioned
+            host. ({{ $labels.vcenter }}).
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) has detected a network-partitioned host"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} HA network-partitioned host'
+          meta: HA on Host `{{ $labels.hostsystem }}` has detected a network-partitioned
+            host. ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#troubleshooting-vsphere-ha-host-states
+          service: compute
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: APodHostRunsMultipleVCenters
+        annotations:
+          description: aPod node `{{ $labels.hostsystem }}` runs multiple vCenter VMs.
+            ({{ $labels.vcenter }})
+          summary: aPod node `{{ $labels.hostsystem }}` runs multiple vCenter VMs. ({{
+            $labels.vcenter }})
+        expr: count(vrops_virtualmachine_runtime_connectionstate{vccluster=~".*-management",
+          virtualmachine=~"vc-.*"}) by(hostsystem, vcenter) > 1
+        for: 30m
+        labels:
+          context: '{{ $labels.hostsystem }} multiple vCenters'
+          meta: aPod node `{{ $labels.hostsystem }}` runs multiple vCenter VMs. ({{ $labels.vcenter
+            }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: HostStoragePathCheck
+        annotations:
+          description: storage paths for `{{ $labels.hostsystem }}` is less than other
+            hosts in the `{{ $labels.vccluster }}`. ({{ $labels.vcenter }})
+          summary: storage paths for `{{ $labels.hostsystem }}` is less than other hosts
+            in the `{{ $labels.vccluster }}`. ({{ $labels.vcenter }})
+        expr: vrops_hostsystem_storage_number_of_path < on(vccluster) group_left() (max(vrops_hostsystem_storage_number_of_path)
+          by(vccluster))
+        for: 30m
+        labels:
+          context: '{{ $labels.hostsystem }} storage paths'
+          meta: storage paths for `{{ $labels.hostsystem }}` is less than other hosts
+            in the `{{ $labels.vccluster }}`. ({{ $labels.vcenter }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostStoragePathCheck
+        annotations:
+          description: storage paths for `{{ $labels.hostsystem }}` is less than other
+            hosts in the `{{ $labels.vccluster }}`. ({{ $labels.vcenter }})
+          summary: storage paths for `{{ $labels.hostsystem }}` is less than other hosts
+            in the `{{ $labels.vccluster }}`. ({{ $labels.vcenter }})
+        expr: (vrops_hostsystem_storage_number_of_path < on(vccluster) group_left() (max(vrops_hostsystem_storage_number_of_path)
+          by(vccluster))) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 30m
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} storage paths'
+          meta: storage paths for `{{ $labels.hostsystem }}` is less than other hosts
+            in the `{{ $labels.vccluster }}`. ({{ $labels.vcenter }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: iaas_support
+          tier: vmware
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-mgmt-a-0-alerts-iaas.alerts
+  labels:
+    prometheus: vmware-vc-mgmt-a-0
+
+spec:
+  groups:
+    - name: iaas.alerts
+      rules:
+      - alert: IaasHostMemoryUsage
+        annotations:
+          description: Memory usage of ESXi host {{ $labels.hostsystem}} is above 75%
+          summary: Memory usage of ESXi host {{ $labels.hostsystem}} is above 75%
+        expr: vrops_hostsystem_memory_usage_percentage > 75 and on (hostsystem) vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+        for: 30m
+        labels:
+          context: esxi host memory usage
+          meta: Memory usage of ESXi host {{ $labels.hostsystem}} is above 75%
+          service: compute
+          severity: warning
+          support_group: iaas-support
+      - alert: IaasHostMemoryUsage
+        annotations:
+          description: Memory usage of ESXi host {{ $labels.hostsystem}} is above 90%
+          summary: Memory usage of ESXi host {{ $labels.hostsystem}} is above 90%
+        expr: vrops_hostsystem_memory_usage_percentage > 90 and on (hostsystem) vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+        for: 30m
+        labels:
+          context: esxi host memory usage
+          meta: Memory usage of ESXi host {{ $labels.hostsystem}} is above 90%
+          service: compute
+          severity: critical
+          support_group: iaas-support
+      - alert: IaasHostLicenseKey
+        annotations:
+          description: IaaS ESXi host {{ $labels.hostsystem }} in IaaS host group without
+            valid license
+          summary: IaaS ESXi host {{ $labels.hostsystem }} in IaaS host group without
+            valid license
+        expr: vrops_hostsystem_license_key{license_key!~"GM693.*"} + on (hostsystem) group_right(license_key)
+          vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"} > 0
+        for: 30m
+        labels:
+          context: esxi host license key
+          meta: IaaS ESXi host {{ $labels.hostsystem }} in IaaS host group without valid
+            license
+          service: compute
+          severity: warning
+          support_group: iaas-support
+      - alert: IaasClusterWithoutFailoverHost
+        annotations:
+          description: IaaS cluster {{ $labels.vccluster }} has NO failover host configured
+          summary: IaaS cluster {{ $labels.vccluster }} has NO failover host configured
+        expr: |
+          (count by (vccluster) (vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}) > 0)
+          unless (count by (vccluster) (vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+          and on(hostsystem) vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{} == 1 ) > 0)
+        for: 15m
+        labels:
+          context: IaaS cluster HA policy
+          meta: IaaS cluster {{ $labels.vccluster }} has NO failover host configured
+          service: compute
+          severity: critical
+          support_group: iaas-support
+      - alert: NonIaasVmOnIaasHost
+        annotations:
+          description: Non IaaS virtual machine(s) running on IaaS ESXi host {{ $labels.hostsystem
+            }}
+          summary: Non IaaS virtual machine(s) running on IaaS ESXi host {{ $labels.hostsystem
+            }}
+        expr: |
+          count by (hostsystem) (
+            (
+              group by (project, hostsystem, virtualmachine)(vrops_virtualmachine_system_powered_on{}==1)
+              and on(project)
+              group by(project) (label_replace(limes_project_usage{domain!~"iaas-.*"}, "project", "$1", "project_id", "(.*)"))
+            )
+          )
+          and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+        for: 30m
+        labels:
+          context: non IaaS vm on IaaS cluster
+          meta: Non IaaS virtual machine(s) running on IaaS ESXi host {{ $labels.hostsystem
+            }}
+          service: compute
+          severity: warning
+          support_group: iaas-support
+      - alert: IaasHostsAlmostOutOfMemory
+        annotations:
+          description: All IaaS hosts in cluster {{ $labels.vccluster }} are above 75%
+            memory
+          summary: All IaaS hosts in cluster {{ $labels.vccluster }} are above 75% memory
+        expr: |
+          count by (vccluster) (
+            (vrops_hostsystem_memory_usage_percentage > 75)
+            and on(hostsystem)
+            vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+            unless on(hostsystem)
+            vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{} == 1
+          )
+          == on(vccluster)
+          count by (vccluster) (
+            vrops_hostsystem_memory_usage_percentage
+            and on(hostsystem)
+            vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+            unless on(hostsystem)
+            vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{} == 1
+          )
+          and on(vccluster)
+          count by (vccluster) (
+            vrops_hostsystem_memory_usage_percentage
+            and on(hostsystem)
+            vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+            unless on(hostsystem)
+            vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{} == 1
+          ) > 0
+        for: 60m
+        labels:
+          context: IaaS hosts in cluster are almost out of memory
+          meta: All IaaS hosts in cluster {{ $labels.vccluster }} are above 75% memory
+          service: compute
+          severity: warning
+          support_group: iaas-support
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-mgmt-a-0-alerts-k8s-vc-mgmt.alerts
+  labels:
+    prometheus: vmware-vc-mgmt-a-0
+
+spec:
+  groups:
+    - name: k8s-vc-mgmt.alerts
+      rules:
+      - alert: VCClusterCPUContention
+        annotations:
+          description: The VCCluster {{ $labels.vccluster}} is using {{ $value }} CPU
+            and VM's are fighting for it
+          summary: '{{ $labels.vccluster}} cpu contention critical'
+        expr: vrops_cluster_cpu_contention_percentage{vcenter=~"vc-mgmt-.*"} > 5
+        for: 15m
+        labels:
+          context: vccluster
+          meta: The VCCluster {{ $labels.vccluster}} is using too much CPU and VM's are
+            fighting for it
+          no_alert_on_absence: "true"
+          service: cc-cp
+          severity: info
+          support_group: containers
+          tier: k8s
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-mgmt-a-0-alerts-nsxt.alerts
+  labels:
+    prometheus: vmware-vc-mgmt-a-0
+
+spec:
+  groups:
+    - name: nsxt.alerts
+      rules:
+      - alert: NSXTDistributedFirewallSectionUsageLimitExceeded
+        annotations:
+          description: NSX-T cluster {{ $labels.nsxt_adapter }} firewall sections usage
+            exceeded the supported limit. https://{{ $labels.target }}
+          summary: NSX-T cluster {{ $labels.nsxt_adapter }} firewall sections usage exceeded
+            the supported limit. https://{{ $labels.target }}
+        expr: |
+          vrops_nsxt_mgmt_cluster_sys_capacity_distributed_firewall_section_usage_count /
+          vrops_nsxt_mgmt_cluster_sys_capacity_distributed_firewall_section_max_supported_count > 0.9
+        for: 10m
+        labels:
+          dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
+          meta: NSX-T cluster {{ $labels.nsxt_adapter }} firewall sections usage exceeded
+            the supported limit. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTDistributedFirewallRulesUsageLimitExceeded
+        annotations:
+          description: NSX-T cluster {{ $labels.nsxt_adapter }} firewall rules usage exceeded
+            the supported limit. https://{{ $labels.target }}
+          summary: NSX-T cluster {{ $labels.nsxt_adapter }} firewall sections rules exceeded
+            the supported limit. https://{{ $labels.target }}
+        expr: |
+          vrops_nsxt_mgmt_cluster_sys_capacity_distributed_firewall_rules_usage_count /
+          vrops_nsxt_mgmt_cluster_sys_capacity_distributed_firewall_rules_max_supported_count > 0.9
+        for: 10m
+        labels:
+          dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
+          meta: NSX-T cluster {{ $labels.nsxt_adapter }} firewall rules usage exceeded
+            the supported limit. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTLogicalSwitchesUsageLimitExceeded
+        annotations:
+          description: NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switches
+            exceeded the supported limit. https://{{ $labels.target }}
+          summary: NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switches
+            exceeded the supported limit. https://{{ $labels.target }}
+        expr: |
+          vrops_nsxt_mgmt_cluster_sys_capacity_logical_switches_usage_count /
+          vrops_nsxt_mgmt_cluster_sys_capacity_logical_switches_max_supported_count > 0.9
+        for: 10m
+        labels:
+          dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
+          meta: NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switches exceeded
+            the supported limit. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTLogicalSwitchPortsUsageWarningLimitExceeded
+        annotations:
+          description: NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switch
+            ports exceeded the supported limit. https://{{ $labels.target }}
+          summary: NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switch ports
+            exceeded the supported limit. https://{{ $labels.target }}
+        expr: |
+          vrops_nsxt_mgmt_cluster_sys_capacity_logical_switch_ports_usage_count /
+          vrops_nsxt_mgmt_cluster_sys_capacity_logical_switch_ports_max_supported_count > 0.9
+        for: 10m
+        labels:
+          dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
+          meta: NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switch ports
+            exceeded the supported limit. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTGroupsUsageLimitExceeded
+        annotations:
+          description: NSX-T cluster {{ $labels.nsxt_adapter }} count of NSGroups exceeded
+            the supported limit. https://{{ $labels.target }}
+          summary: NSX-T cluster {{ $labels.nsxt_adapter }} count of NSGroups exceeded
+            the supported limit. https://{{ $labels.target }}
+        expr: |
+          vrops_nsxt_mgmt_cluster_sys_capacity_nsgroups_max_usage_count /
+          vrops_nsxt_mgmt_cluster_sys_capacity_nsgroups_max_supported_count > 0.9
+        for: 10m
+        labels:
+          dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
+          meta: NSX-T cluster {{ $labels.nsxt_adapter }} count of NSGroups exceeded the
+            supported limit. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTIPSetsUsageLimitExceeded
+        annotations:
+          description: NSX-T cluster {{ $labels.nsxt_adapter }} count of IP sets exceeded
+            the supported limit. https://{{ $labels.target }}
+          summary: NSX-T cluster {{ $labels.nsxt_adapter }} count of IP sets exceeded
+            the supported limit. https://{{ $labels.target }}
+        expr: |
+          vrops_nsxt_mgmt_cluster_sys_capacity_ip_sets_usage_count /
+          vrops_nsxt_mgmt_cluster_sys_capacity_ip_sets_max_supported_count > 0.9
+        for: 10m
+        labels:
+          dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
+          meta: NSX-T cluster {{ $labels.nsxt_adapter }} count of IP sets exceeded the
+            supported limit. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTGroupsBasedInIPUsageLimitExceeded
+        annotations:
+          description: NSX-T cluster {{ $labels.nsxt_adapter }} count of groups based
+            in IP exceeded the supported limit. https://{{ $labels.target }}
+          summary: NSX-T cluster {{ $labels.nsxt_adapter }} count of groups based in IP
+            exceeded the supported limit. https://{{ $labels.target }}
+        expr: |
+          vrops_nsxt_mgmt_cluster_sys_capacity_groups_based_in_ip_usage_count /
+          vrops_nsxt_mgmt_cluster_sys_capacity_groups_based_in_ip_max_supported_count > 0.9
+        for: 10m
+        labels:
+          dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
+          meta: NSX-T cluster {{ $labels.nsxt_adapter }} count of groups based in IP exceeded
+            the supported limit. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTMgmtNodeImageFilesystemCapacity
+        annotations:
+          description: NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage
+            `/image` > 80%. {{ $labels.nsxt_adapter}} https://{{ $labels.target }}
+          summary: NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage
+            `/image` > 80%. {{ $labels.nsxt_adapter}} https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_node_filesystems_image_usedpercentage > 80
+        for: 10m
+        labels:
+          meta: NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage `/image`
+            > 80%. {{ $labels.nsxt_adapter}} https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#NSXTMgmtNodeImageFilesystemCapacityCritical
+          service: network
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: NSXTMgmtNodeLogFilesystemCapacity
+        annotations:
+          description: NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage
+            `/var/log` > 80%. {{ $labels.nsxt_adapter}} https://{{ $labels.target }}
+          summary: NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage
+            `/var/log` > 80%. {{ $labels.nsxt_adapter}} https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_node_filesystems_var_log_usedpercentage > 80
+        for: 10m
+        labels:
+          meta: NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage `/var/log`
+            > 80%. {{ $labels.nsxt_adapter}} https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#NSXTMgmtNodeLogFilesystemCapacityCritical
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTClusterControlStatusNoControllers
+        annotations:
+          description: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity
+            status is `{{ $labels.state }}`. https://{{ $labels.target }}
+          summary: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status
+            is `{{ $labels.state }}`. https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_cluster_controller_cluster_connectivity_status{state="NO_CONTROLLERS"}
+        for: 10m
+        labels:
+          meta: NSX-T management cluster {{ $labels.nsxt_adapter }} has connectivity status
+            `{{ $labels.state }}`. https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#cluster_control_status_no_controllers
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTClusterControlStatusUnstable
+        annotations:
+          description: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity
+            status is `{{ $labels.state }}`. https://{{ $labels.target }}
+          summary: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status
+            is `{{ $labels.state }}`. https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_cluster_controller_cluster_connectivity_status{state="UNSTABLE"}
+        for: 10m
+        labels:
+          meta: NSX-T management cluster {{ $labels.nsxt_adapter }} has connectivity status
+            `{{ $labels.state }}`. https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#cluster_control_status_unstable
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTClusterControlStatusDegraded
+        annotations:
+          description: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity
+            status is `{{ $labels.state }}`. https://{{ $labels.target }}
+          summary: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status
+            is `{{ $labels.state }}`. https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_cluster_controller_cluster_connectivity_status{state="DEGRADED"}
+        for: 30m
+        labels:
+          meta: NSX-T management cluster {{ $labels.nsxt_adapter }} has connectivity status
+            `{{ $labels.state }}`. https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#cluster_control_status_degraded
+          service: network
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: NSXTClusterControlStatusUnkown
+        annotations:
+          description: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity
+            status is `{{ $labels.state }}`. https://{{ $labels.target }}
+          summary: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status
+            is `{{ $labels.state }}`. https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_cluster_controller_cluster_connectivity_status{state="UNKNOWN"}
+        for: 10m
+        labels:
+          meta: NSX-T management cluster {{ $labels.nsxt_adapter }} has connectivity status
+            `{{ $labels.state }}`. https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#cluster_control_status_unkown
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTNodeMemoryUsageOver95
+        annotations:
+          description: NSX-T Node {{ $labels.nsxt_mgmt_node }} of cluster {{ $labels.nsxt_adapter
+            }} has memory usage of over 95%. https://{{ $labels.target }}
+          summary: NSX-T Node {{ $labels.nsxt_mgmt_node }} of cluster {{ $labels.nsxt_adapter
+            }} has memory usage of over 95%. https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_node_memory_used / vrops_nsxt_mgmt_node_memory_total > 0.95
+        for: 5m
+        labels:
+          meta: NSX-T Node {{ $labels.nsxt_mgmt_node }} of cluster {{ $labels.nsxt_adapter
+            }} has memory usage of over 95%. https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#NSXT_Memory_Usage_Over95
+          service: network
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: NSXTNodeConnectivityBroken
+        annotations:
+          description: NSX-T Node {{ $labels.nsxt_mgmt_node }} connectivity is broken.
+            ({{ $labels.nsxt_adapter }}) https://{{ $labels.target }}
+          summary: NSX-T Node {{ $labels.nsxt_mgmt_node }} connectivity is broken. ({{
+            $labels.nsxt_adapter }}) https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_node_connectivity_status{state="DISCONNECTED"}
+        for: 5m
+        labels:
+          meta: NSX-T Node `{{ $labels.nsxt_mgmt_node }}` connectivity is broken. ({{
+            $labels.nsxt_adapter }}) https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#nsxtnodeconnectivitybroken
+          service: network
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: NSXTManagementServiceHasFailed
+        annotations:
+          description: 'CRITICAL: NSX-T management service `{{ $labels.nsxt_mgmt_service
+            }}` has failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }})
+            https://{{ $labels.target }}'
+          summary: 'CRITICAL: NSX-T management service `{{ $labels.nsxt_mgmt_service }}`
+            has failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }}) https://{{
+            $labels.target }}'
+        expr: |
+          vrops_nsxt_mgmt_service_alert_info{alert_name="NSX-T Management service has failed|Management service monitor runtime state has failed",
+          nsxt_mgmt_service!~"cluster-boot-manager|cm-inventory|controller|http|manager"}
+        labels:
+          meta: Critical NSX-T management service `{{ $labels.nsxt_mgmt_service }}` has
+            failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }}) https://{{
+            $labels.target }}
+          no_alert_on_absence: "true"
+          service: network
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: NSXTSslCertificateExpiry
+        annotations:
+          description: NSX-T Certificate of {{ $labels.nsxt_adapter }} has expired or
+            will expire shortly. https://{{ $labels.target }}
+          summary: NSX-T Certificate of {{ $labels.nsxt_adapter }} has expired or will
+            expire shortly. https://{{ $labels.target }}
+        expr: vrops_nsxt_adapter_alert_info{alert_name="Adapter certificate has expired
+          or will expire shortly"}
+        labels:
+          context: nsxt certificate
+          meta: NSX-T Certificate of `{{ $labels.nsxt_adapter }}` has expired or will
+            expire shortly. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#applying-nsx-t-ssl-certificate-in-the-manager-nodes-and-the-vip
+          service: network
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: NSXTManagementServiceHasFailed
+        annotations:
+          description: 'WARNING: NSX-T management service `{{ $labels.nsxt_mgmt_service
+            }}` has failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }}).
+            https://{{ $labels.target }}'
+          summary: 'WARNING: NSX-T management service `{{ $labels.nsxt_mgmt_service }}`
+            has failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }}). https://{{
+            $labels.target }}'
+        expr: |
+          vrops_nsxt_mgmt_service_alert_info{alert_name="NSX-T Management service has failed|Management service monitor runtime state has failed",
+          nsxt_mgmt_service!~"mgmt-plane-bus|node-mgmt|ntp|ssh|search|syslog|nsx-ui"}
+        labels:
+          meta: NSX-T management service `{{ $labels.nsxt_mgmt_service }}` has failed.
+            ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }}). https://{{ $labels.target
+            }}
+          no_alert_on_absence: "true"
+          service: network
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: NSXTTransportNodeConnectivityNotUP
+        annotations:
+          description: 'Transport node {{ $labels.nsxt_transport_node }} Controller/Manager
+            Connectivity status is not UP. https://{{ $labels.target }}. '
+          summary: 'Transport node {{ $labels.nsxt_transport_node }} Controller/Manager
+            Connectivity status is not UP. https://{{ $labels.target }}. '
+        expr: |
+          label_replace(vrops_nsxt_transport_node_alert_info{alert_name="Transport Node Controller/Manager Connectivity is not UP"}, "hostsystem", "$1", "nsxt_transport_node", "(.*)")
+          AND on (hostsystem) vrops_hostsystem_runtime_connectionstate{state="notResponding"}
+          AND on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"}
+          AND on (hostsystem) vrops_hostsystem_runtime_powerstate{state="Powered On"}
+        labels:
+          meta: Transport node {{ $labels.nsxt_transport_node }} Controller/Manager Connectivity
+            status is not UP. https://{{ $labels.target }}.
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#Transport_node_status_not_UP_in_NSXT
+          service: network
+          severity: critical
+          support_group: compute
+          tier: vmware
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-mgmt-a-0-alerts-vccluster.alerts
+  labels:
+    prometheus: vmware-vc-mgmt-a-0
+
+spec:
+  groups:
+    - name: vccluster.alerts
+      rules:
+      - alert: VCenterRedundancyLostHAPolicyFaulty
+        annotations:
+          description: VC https://{{ $labels.vcenter }} has a faulty AdmissionControlPolicy
+            for cluster {{ $labels.vccluster }}, failover will not work.
+          summary: VC https://{{ $labels.vcenter }} has a faulty AdmissionControlPolicy
+            for cluster {{ $labels.vccluster }}, failover will not work.
+        expr: |
+          vrops_cluster_configuration_dasconfig_enabled{vccluster=~"productionbb\\d+"}
+          unless on (vccluster) ((vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{vccluster=~"productionbb\\d+"} != 0
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"})
+          or (vrops_cluster_summary_custom_tag_openstack_nova_traits_decommissioning{summary_custom_tag_openstack_nova_traits_decommissioning="true", vccluster=~"productionbb\\d+"}
+          and on (vccluster) vrops_cluster_cluster_running_vms == 0))
+        for: 30m
+        labels:
+          context: vc cluster config
+          meta: VC https://{{ $labels.vcenter }} has a faulty AdmissionControlPolicy for
+            cluster {{ $labels.vccluster }}, failover will not work.
+          playbook: docs/devops/alert/vcenter/#vcenterredundancylosthapolicyfaulty
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: VCenterRedundancyLostHAPolicyNotConfigured
+        annotations:
+          description: VC {{ $labels.vcenter }} {{ $labels.vccluster }} has a faulty AdmissionControlPolicy.
+            Failover will not work.
+          summary: VC {{ $labels.vcenter }} {{ $labels.vccluster }} has a faulty AdmissionControlPolicy.
+            Failover will not work.
+        expr: vrops_cluster_configuration_dasconfig_enabled{vccluster=~"production.*"}
+          == 0
+        for: 30m
+        labels:
+          context: Cluster HA policy
+          meta: VC {{ $labels.vcenter }} {{ $labels.vccluster }} has a faulty AdmissionControlPolicy.
+            Failover will not work.
+          playbook: docs/devops/alert/vcenter/#restore-ha-redundancy-in-vcenter
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: VCClusterFailoverHostCountMismatch
+        annotations:
+          description: "`{{ $labels.vccluster }}` cluster has more failover hosts configured
+            than expected. For clusters with 10 or fewer hosts, it should be 1; for larger
+            clusters, it should be no more than 2. \nLink to the vCenter: --> <https://{{
+            $labels.vcenter }}|{{ $labels.vcenter }}>"
+          summary: "`{{ $labels.vccluster }}` cluster has more failover hosts configured
+            than expected. For clusters with 10 or fewer hosts, it should be 1; for larger
+            clusters, it should be no more than 2. \nLink to the vCenter: --> <https://{{
+            $labels.vcenter }}|{{ $labels.vcenter }}>"
+        expr: |
+          (count by (vccluster, vcenter) (vrops_hostsystem_runtime_connectionstate{vccluster=~"productionbb\\d+"}) <= 10
+          and on (vccluster) sum by (vccluster) (vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{vccluster=~"productionbb\\d+"}) > 1)
+          or (sum by (vccluster, vcenter) (vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{vccluster=~"productionbb\\d+"}) > 2)
+          unless on (vccluster) (vrops_cluster_summary_custom_tag_openstack_nova_traits_decommissioning{summary_custom_tag_openstack_nova_traits_decommissioning="true", vccluster=~"productionbb\\d+"}
+          and vrops_cluster_cluster_running_vms == 0)
+        for: 30m
+        labels:
+          context: Cluster HA policy
+          meta: "`{{ $labels.vccluster }}` cluster has more failover hosts configured
+            than expected. For clusters with 10 or fewer hosts, it should be 1; for larger
+            clusters, it should be no more than 2. \nLink to the vCenter: --> <https://{{
+            $labels.vcenter }}|{{ $labels.vcenter }}>"
+          playbook: docs/devops/alert/vcenter/#vcclusterfailoverhostcountmismatch
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VCenterRedundancyLostHALevelNotSet
+        annotations:
+          description: VC {{ $labels.vcenter }} {{ $labels.vccluster }} has NO failover
+            host amount configured, this should be 1
+          summary: VC {{ $labels.vcenter }} {{ $labels.vccluster }} has NO failover host
+            amount configured, this should be 1
+        expr: count by (vccluster, vcenter) (vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{vccluster=~"production.*"}
+          == 1) == 0
+        for: 30m
+        labels:
+          context: Cluster HA policy
+          meta: VC {{ $labels.vcenter }} {{ $labels.vccluster }} has NO failover host
+            amount configured, this should be 1
+          playbook: docs/devops/alert/vcenter/#restore-ha-redundancy-in-vcenter
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: VCClusterDRSNotFullyAutomated
+        annotations:
+          description: Cluster {{ $labels.vccluster }} DRS configuration is not set to
+            fully automated.
+          summary: Cluster {{ $labels.vccluster }} DRS configuration is not set to fully
+            automated.
+        expr: |
+          vrops_cluster_configuration_drsconfig_defaultvmbehavior{vccluster!~".*controlplane.*", state != "fullyAutomated"} == 0
+          unless on (vccluster) vrops_cluster_summary_custom_tag_openstack_nova_traits_hana_exclusive_host{summary_custom_tag_openstack_nova_traits_hana_exclusive_host="true"}
+        for: 10m
+        labels:
+          context: Cluster DRS configuration
+          meta: Cluster {{ $labels.vccluster }} DRS configuration is not set to fully
+            automated.
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#cluster-drs-not-set-to-fully-automated
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: VCClusterCannotDistributeNSXTControllers
+        annotations:
+          description: Cluster {{ $labels.vccluster }} cannot evenly distribute new NSX-T
+            controllers. {{ $labels.vcenter}}
+          summary: Cluster {{ $labels.vccluster }} cannot evenly distribute new NSX-T
+            controllers. {{ $labels.vcenter }}
+        expr: |
+          count by(vccluster, vcenter) (
+            (
+              max_over_time(vrops_hostsystem_memory_capacity_available_to_vms_kilobytes{vccluster=~".*management"}[1h])
+              - max_over_time(vrops_hostsystem_memory_consumed_by_vms_kilobytes[1h])
+            ) / 1024 / 1024 >= 48
+          ) < 3
+        for: 30m
+        labels:
+          context: Cluster NSXT Resources
+          meta: Cluster {{ $labels.vccluster }} cannot evenly distribute new NSX-T controllers.
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: HanaExclusiveVCClusterDRSNotPartiallyAutomated
+        annotations:
+          description: |-
+            The HANA-exclusive {{ $labels.vccluster }} cluster DRS configuration is not set to partially automated in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The HANA-exclusive {{ $labels.vccluster }} cluster DRS configuration is not set to partially automated in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_cluster_configuration_drsconfig_defaultvmbehavior{vccluster=~"productionbb.+", state != "partiallyAutomated"}
+          and on (vccluster) vrops_cluster_summary_custom_tag_openstack_nova_traits_hana_exclusive_host{summary_custom_tag_openstack_nova_traits_hana_exclusive_host="true"}
+        labels:
+          context: Cluster DRS configuration
+          meta: |-
+            The HANA-exclusive {{ $labels.vccluster }} cluster DRS configuration is not set to partially automated in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hanaexclusivevcclusterdrsnotpartiallyautomated
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-mgmt-a-0-alerts-vcenter.alerts
+  labels:
+    prometheus: vmware-vc-mgmt-a-0
+
+spec:
+  groups:
+    - name: vcenter.alerts
+      rules:
+      - alert: VcsaSslCertificateExpiry
+        annotations:
+          description: SSL Certificate of vCSA {{ $labels.vcenter}} expires in {{ $value
+            }} days. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: SSL Certificate of vCSA {{ $labels.vcenter}} expires in {{ $value }}
+            days. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: 15 < round(((avg_over_time(vrops_vcenter_summary_certificate_expiry_date[10m])
+          / 1000) - time()) / 86400) < 30
+        for: 20m
+        labels:
+          context: vcsa certificate
+          meta: SSL Certificate of vCSA {{ $labels.vcenter }} expires in less than 30
+            days. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#vcenter-appliance-certificate-expiry
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VcsaSslCertificateExpiry
+        annotations:
+          description: SSL Certificate of vCSA {{ $labels.vcenter}} expires in {{ $value
+            }} days. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: SSL Certificate of vCSA {{ $labels.vcenter}} expires in {{ $value }}
+            days. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: round(((avg_over_time(vrops_vcenter_summary_certificate_expiry_date[10m])
+          / 1000) - time()) / 86400) < 16
+        for: 20m
+        labels:
+          context: vcsa certificate
+          meta: SSL Certificate of vCSA {{ $labels.vcenter}} expires in less than 15 days.
+            ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#vcenter-appliance-certificate-expiry
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: VCenterDiskSpaceUsage
+        annotations:
+          description: Disk space usage of vCSA {{ $labels.vcenter}} is above 90%
+          summary: Disk space usage of vCSA {{ $labels.vcenter}} is above 90%
+        expr: vrops_vcenter_diskspace_usage_gigabytes / vrops_vcenter_diskspace_total_gigabytes
+          > 0.9
+        for: 15m
+        labels:
+          context: vcenter disk usage
+          meta: Disk space usage of vCSA {{ $labels.vcenter}} is above 90%
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VASAProvider(s)Disconnected
+        annotations:
+          description: VASA Provider disconnected from {{ $labels.vcenter}}.
+          summary: VASA Provider disconnected from {{ $labels.vcenter}}.
+        expr: vrops_vcenter_alert_info{alert_name="VASA Provider(s) disconnected"}
+        labels:
+          context: vasa provider
+          meta: VASA Provider disconnected from {{ $labels.vcenter}}.
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#vasaproviderdown
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VCenterHasMultipleGreyVMs
+        annotations:
+          description: vCenter {{ $labels.vcenter }} has multiple greyed out VMs for a
+            longer period. This alert is handled by TARS. If TARS fails, check and reload
+            these VMs.
+          summary: vCenter {{ $labels.vcenter }} has multiple greyed out VMs for a longer
+            period. This alert is handled by TARS. If TARS fails, check and reload these
+            VMs.
+        expr: |
+          count by(vcenter)
+          ((vrops_virtualmachine_health == -1)
+          and on(hostsystem) (vrops_hostsystem_runtime_powerstate{state="Powered On"})
+          and on(hostsystem) (vrops_hostsystem_runtime_connectionstate{state="connected"})
+          and on(hostsystem) (vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"})) > 0
+        for: 15m
+        labels:
+          context: Shadow VMs {{ $labels.vcenter }}
+          meta: vCenter {{ $labels.vcenter }} has multiple greyed out VMs for a longer
+            period. Check and reload these VMs.
+          playbook: docs/devops/alert/vcenter/#Inaccessible_Orphaned_Gray_instance_handling
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasVCenterHasMultipleGreyVMs
+        annotations:
+          description: vCenter {{ $labels.vcenter }} has multiple greyed out VMs for a
+            longer period. This alert is handled by TARS. If TARS fails, check and reload
+            these VMs.
+          summary: vCenter {{ $labels.vcenter }} has multiple greyed out VMs for a longer
+            period. This alert is handled by TARS. If TARS fails, check and reload these
+            VMs.
+        expr: |-
+          (count by(vcenter)
+          ((vrops_virtualmachine_health == -1)
+          and on(hostsystem) (vrops_hostsystem_runtime_powerstate{state="Powered On"})
+          and on(hostsystem) (vrops_hostsystem_runtime_connectionstate{state="connected"})
+          and on(hostsystem) (vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"})) > 0
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 15m
+        labels:
+          bedrock: "true"
+          context: Shadow VMs {{ $labels.vcenter }}
+          meta: vCenter {{ $labels.vcenter }} has multiple greyed out VMs for a longer
+            period. Check and reload these VMs.
+          playbook: docs/devops/alert/vcenter/#Inaccessible_Orphaned_Gray_instance_handling
+          service: compute
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-mgmt-a-0-alerts-virtualmachine.alerts
+  labels:
+    prometheus: vmware-vc-mgmt-a-0
+
+spec:
+  groups:
+    - name: virtualmachine.alerts
+      rules:
+      - alert: VMHasMemoryContention
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` has memory contention
+            due to memory compression, ballooning, or swapping. ({{ $labels.vcenter }},
+            {{ $labels.hostsystem }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` has memory contention
+            due to memory compression, ballooning, or swapping. ({{ $labels.vcenter }},
+            {{ $labels.hostsystem }})
+        expr: |
+          vrops_virtualmachine_alert_info{alert_name="Virtual machine has memory contention due to memory compression, ballooning, or swapping", vccluster=~".*management.*"}
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine `{{ $labels.virtualmachine }}` has memory contention due
+            to memory compression, ballooning, or swapping. ({{ $labels.vcenter }}, {{
+            $labels.hostsystem }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#vm_has_memory_contention
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VMHasDiskIOLatencyProblemCausedBySnapshots
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` has disk I/O latency
+            problem caused by snapshots. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` has disk I/O latency
+            problem caused by snapshots. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+        expr: |
+          vrops_virtualmachine_alert_info{alert_name="Virtual machine has disk I/O latency problem caused by snapshots", vccluster=~".*management.*"}
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine `{{ $labels.virtualmachine }}` has disk I/O latency problem
+            caused by snapshots. ({{ $labels.vcenter }}, {{ $labels.hostsystem }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#vm_has_disk_io_latency_problem_caused_by_snapshots
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VMHasCPUContentionDueToIOEvents
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` has CPU contention
+            due to long wait for I/O events. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` has CPU contention due
+            to long wait for I/O events. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+        expr: |
+          vrops_virtualmachine_alert_info{alert_name="Virtual machine has CPU contention due to long wait for I/O events", vccluster=~".*management.*"}
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine `{{ $labels.virtualmachine }}` has CPU contention due
+            to long wait for I/O events. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#vm_has_cpu_contention
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VMGuestFileSystemsRunningOutOfDiskSpace
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` guest file systems
+            are running out of disk space. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` guest file systems are
+            running out of disk space. ({{ $labels.vcenter }}, {{ $labels.hostsystem }})
+        expr: |
+          vrops_virtualmachine_guestfilesystem_storage_log_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_storage_autodeploy_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_storage_core_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_storage_dblog_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_storage_imagebuilder_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_storage_netdump_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_storage_seat_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_storage_updatemgr_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_boot_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_percentage{vccluster=~".*management.*"} > 80
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine `{{ $labels.virtualmachine }}` guest file systems are
+            running out of disk space. ({{ $labels.vcenter }}, {{ $labels.hostsystem }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#vm_guest_file_Systems_running_out_of_disk_space
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VMCPUAt100PercentForAnExtendedPeriodOfTime
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` CPU usage is at
+            100% for an extended period of time. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` CPU usage is at 100%
+            for an extended period of time. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+        expr: |
+          vrops_virtualmachine_alert_info{alert_name="Virtual machine CPU usage is at 100% for an extended period of time", vccluster=~".*management.*"}
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine {{ $labels.virtualmachine }} CPU usage is at 100% for
+            an extended period of time. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#vm_cpu_at_100_percent_for_an_extended_period_of_time
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VMInDRSClusterDemandingMoreCPUThanItsEntitlement
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` in a DRS cluster
+            is demanding more CPU than its entitlement. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` in a DRS cluster is
+            demanding more CPU than its entitlement. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+        expr: |
+          vrops_virtualmachine_alert_info{alert_name="Virtual machine in a DRS cluster is demanding more CPU than its entitlement", vccluster=~".*management.*"}
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine `{{ $labels.virtualmachine }}` in a DRS cluster is demanding
+            more CPU than its entitlement. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#vm_in_drs_cluster_demanding_more_cpu_than_its_entitlement
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VMHasSnapshotOlderThanOneWeek
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` has a snapshot older
+            than one week. ({{ $labels.vcenter }}, {{ $labels.hostsystem }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` has a snapshot older
+            than one week. ({{ $labels.vcenter }}, {{ $labels.hostsystem }})
+        expr: vrops_virtualmachine_disk_space_snapshot_age_days{vccluster=~".*management.*",
+          virtualmachine!~"jump.+"} > 7
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine `{{ $labels.virtualmachine }}` has a snapshot older than
+            one week. ({{ $labels.vcenter }}, {{ $labels.hostsystem }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VMHasCPUContentionDueToMemoryPageSwapping
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` experiencing high
+            swap wait. The host is overcommitted on memory. ({{ $labels.vcenter }}, {{
+            $labels.hostsystem }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` experiencing high swap
+            wait. The host is overcommitted on memory. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+        expr: |
+          vrops_virtualmachine_alert_info{alert_name="Virtual machine has CPU contention due to memory page swapping in the host", vccluster=~".*management.*"}
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine `{{ $labels.virtualmachine }}` experiencing high swap
+            wait. The host is overcommitted on memory. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: NSXTMgmtVMsOddDistribution
+        annotations:
+          description: Too many NSX-T VMs for the same cluster on {{ $labels.hostsystem
+            }}. Please distribute the VMs across different nodes. ({{ $labels.vcenter
+            }})
+          summary: Too many NSX-T VMs on {{ $labels.hostsystem }}. ({{ $labels.vcenter
+            }})
+        expr: |
+          count(label_replace(vrops_virtualmachine_cpu_usage_average_mhz{virtualmachine=~"nsx-.*"}, "nsx_clt", "$1", "virtualmachine", "nsx-.*(bb.*)")) by(nsx_clt, hostsystem, vcenter, vccluster) > 1
+        labels:
+          context: NSXTMgmtVMDistribution
+          dashboard: management-cluster-resources/management-cluster-resources?orgId=1&var-pod=All&var-clusters={{
+            $labels.vccluster }}&var-hosts={{ $labels.hostsystem }}
+          meta: Too many NSX-T VMs on {{ $labels.hostsystem }}. ({{ $labels.vcenter }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#nsxtmgmtvmsodddistribution
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTMgmtVMsOddDistributionSDRSAntiaffinity
+        annotations:
+          description: NSX-T VMs not part of SDRS anti-affinity rule  {{ $labels.rule_name
+            }}. Please distribute the VMs across different DS. ({{ $labels.vcenter }})
+          summary: NSX-T VMs not part of SDRS anti-affinity rule  {{ $labels.rule_name
+            }}. ({{ $labels.vcenter }})
+        expr: |
+          count  (vrops_storagepod_config_sdrsconfig_vmstorageantiaffinityrules{storagepod!~"SDRS_MGMT_BB\\d+"}) by (rule_name, vccluster, vcenter) != 3
+        labels:
+          context: NSXTMgmtVMsOddDistributionSDRS
+          dashboard: management-cluster-resources/management-cluster-resources?orgId=1&var-pod=All&var-clusters={{
+            $labels.vccluster }}
+          meta: NSX-T VMs not part of SDRS anti-affinity rule  {{ $labels.rule_name }}.
+            ({{ $labels.vcenter }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#nsxtmgmtvmsodddistributionsdrs
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VASAVMHighCPUUtilization
+        annotations:
+          description: VASA VM has >90% CPU Utilization for at least one hour. {{ $labels.virtualmachine
+            }}. {{ $labels.vccluster }}. {{ $labels.hostsystem }}. ({{ $labels.vcenter
+            }})
+          summary: High VASA VM CPU Utilization. {{ $labels.virtualmachine }}. {{ $labels.vccluster
+            }}. {{ $labels.hostsystem }}. ({{ $labels.vcenter }})
+        expr: vrops_virtualmachine_cpu_usage_ratio{virtualmachine=~"vasa.*"} > 90
+        for: 1h
+        labels:
+          context: VASAUtilization
+          meta: VASA VM has >90% CPU Utilization for at least one hour. {{ $labels.virtualmachine
+            }}. {{ $labels.vccluster }}. {{ $labels.hostsystem }}. ({{ $labels.vcenter
+            }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-mgmt-a-0-alerts-vrops.alerts
+  labels:
+    prometheus: vmware-vc-mgmt-a-0
+
+spec:
+  groups:
+    - name: vrops.alerts
+      rules:
+      - alert: VropsAPIDown
+        annotations:
+          description: "All collectors of the vrops-exporter report HTTP status codes
+            above 500, \nwhich indicates that vrops is reporting internal server errors
+            or is unreachable. \nCheck if vrops is running and healthy.\n"
+          summary: '`https://{{ $labels.target }}` API is down.'
+        expr: "(sum by (target) (vrops_api_response{collector=~\"vc.*\"}) / \ncount by
+          (target) (vrops_api_response{collector=~\"vc.*\"}) > 500) \n"
+        for: 10m
+        labels:
+          context: vrops
+          dashboard: vrops-exporter-status
+          meta: '`https://{{ $labels.target }}` API is down.'
+          playbook: docs/devops/alert/vcenter/vrops#vrops_api_down
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VropsAPIDown
+        annotations:
+          description: |
+            All collectors of the vrops-exporter report HTTP status codes above 500,
+            which indicates that vrops is reporting internal server errors or is unreachable.
+            Check if vrops is running and healthy.
+          summary: '`https://{{ $labels.target }}` API is down.'
+        expr: "(sum by (target) (vrops_api_response{collector=~\"vc.*\"}) / \ncount by
+          (target) (vrops_api_response{collector=~\"vc.*\"}) > 500)                                                                                                                     \n"
+        for: 90m
+        labels:
+          context: vrops
+          dashboard: vrops-exporter-status
+          meta: '`https://{{ $labels.target }}` API is down.'
+          playbook: docs/devops/alert/vcenter/vrops#vrops_api_down
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: VropsAPIDownEntirely
+        annotations:
+          description: |
+            Exporters can not connect to vrops anymore. Most likely the VM is stuck.
+            If this alert fires, complete vmware-montioring is down in Prometheus.
+            Ensure vrops is running and healthy.
+          meta: Vrops API is down. All collectors are not reporting anymore.
+        expr: |
+          absent(vrops_api_response)
+        for: 10m
+        labels:
+          context: vrops
+          dashboard: vrops-exporter-status
+          meta: Vrops API is down. All collectors are not reporting anymore.
+          playbook: docs/devops/alert/vcenter/vrops#vrops_api_down_entirely
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VropsAPIDownEntirely
+        annotations:
+          description: |
+            Exporters can not connect to vrops anymore. Most likely the VM is stuck.
+            If this alert fires, complete vmware-montioring is down in Prometheus.
+            Ensure vrops is running and healthy.
+          meta: Vrops API is down. All collectors are not reporting anymore.
+        expr: |
+          absent(vrops_api_response)
+        for: 90m
+        labels:
+          context: vrops
+          dashboard: vrops-exporter-status
+          meta: Vrops API is down. All collectors are not reporting anymore.
+          playbook: docs/devops/alert/vcenter/vrops#vrops_api_down_entirely
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: VropsTokenAcquisitionFailed
+        annotations:
+          description: |
+            A failed token acquisition for this vrops. This indicates
+            that the vrops system is not responding and current
+            monitoring data cannot be generated.
+          summary: Token acquisition failed for `https://{{ $labels.target }}`
+        expr: vrops_api_response{get_request="token"} >= 500
+        for: 15m
+        labels:
+          context: vrops
+          dashboard: vrops-exporter-status
+          meta: Token acquisition failed for `https://{{ $labels.target }}`
+          playbook: docs/devops/alert/vcenter/vrops#vrops_api_down
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VROpsDiskpaceUsage
+        annotations:
+          description: |
+            {{ $labels.virtualmachine }} disk almost full with over 90% usage.
+            Please increase disk size.
+          summary: '{{ $labels.virtualmachine }} disk almost full with over 90% usage.'
+        expr: vrops_virtualmachine_guestfilesystem_storage_db_percentage{virtualmachine=~"vrops.*-vc-.+"}
+          > 90
+        for: 20m
+        labels:
+          context: vrops
+          dashboard: vrops-instances-overview
+          meta: '{{ $labels.virtualmachine }} disk almost full with over 90% usage.'
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VROpsVCenterAdapterNotReceivingData
+        annotations:
+          description: The vCenter adapter for https://vrops-{{ $labels.vcenter }} is
+            not receiving data.
+          summary: The vCenter adapter for https://vrops-{{ $labels.vcenter }} is not
+            receiving data.
+        expr: vrops_vcenter_alert_info{alert_name="Adapter instance is not receiving data"}
+        for: 15m
+        labels:
+          context: vrops
+          meta: The vCenter adapter for https://vrops-{{ $labels.vcenter }} is not receiving
+            data.
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/vrops#revalidatecertificate
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VROpsNSXTAdapterNotReceivingData
+        annotations:
+          description: vROPs NSX-T adapter is not receiving data for `{{ $labels.nsxt_adapter
+            }}`. https://{{ $labels.target }}
+          summary: vROPs NSX-T adapter is not receiving data for `{{ $labels.nsxt_adapter
+            }}`. https://{{ $labels.target }}
+        expr: vrops_nsxt_adapter_alert_info{alert_name="Adapter instance is not receiving
+          data"}
+        for: 15m
+        labels:
+          context: vrops
+          meta: vROPs NSX-T adapter is not receiving data for `{{ $labels.nsxt_adapter
+            }}`. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#vrops-nsx-t-adapter-is-not-receiving-data-vropsnsxtadapternotreceivingdata
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VROpsVCenterObjectsNotReceivingData
+        annotations:
+          description: vROPs vCenter adapter for https://vrops-{{ $labels.vcenter }} is
+            not receiving data for some objects.
+          summary: vROPs vCenter adapter for https://vrops-{{ $labels.vcenter }} is not
+            receiving data for some objects.
+        expr: vrops_vcenter_alert_info{alert_name="Objects are not receiving data from
+          adapter instance"}
+        labels:
+          meta: vROPs vCenter adapter for https://vrops-{{ $labels.vcenter }} is not receiving
+            data for some objects.
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/vrops#revalidatecertificate
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-mgmt-b-0-alerts-datastore.alerts
+  labels:
+    prometheus: vmware-vc-mgmt-b-0
+
+spec:
+  groups:
+    - name: datastore.alerts
+      rules:
+      - alert: EphemeralDataStoreCapacity
+        annotations:
+          description: Eph Datastore {{ $labels.datastore }} utilization > 85%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          summary: Eph Datastore {{ $labels.datastore }} utilization > 85%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+        expr: |
+          vrops_datastore_diskspace_total_usage_gigabytes{type="ephemeral"} / vrops_datastore_diskspace_capacity_gigabytes >= 0.85
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          dashboard: vcenter-datastore-utilization
+          meta: Eph Datastore {{ $labels.datastore }} utilization > 85%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          playbook: docs/support/playbook/datastore/datastorediskusagealarm
+          service: storage
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: EphemeralDataStoreCapacity
+        annotations:
+          description: Eph Datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          summary: Eph Datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+        expr: |
+          vrops_datastore_diskspace_total_usage_gigabytes{type="ephemeral"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.9
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          dashboard: vcenter-datastore-utilization
+          meta: Eph Datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          playbook: docs/support/playbook/datastore/datastorediskusagealarm
+          service: storage
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: AverageVmfsDataStoreCapacity
+        annotations:
+          description: Average utilization for `{{ $labels.type }}` Datastores per vCenter
+            is above 70%. ({{ $labels.vcenter }})
+          summary: Average utilization for `{{ $labels.type }}` Datastores per vCenter
+            is above 70%. ({{ $labels.vcenter }})
+        expr: |
+          avg by (type, vcenter) (vrops_datastore_diskspace_total_usage_gigabytes{type=~"vmfs_p_ssd|vmfs_s_hdd"} / vrops_datastore_diskspace_capacity_gigabytes) > 0.85
+        for: 20m
+        labels:
+          context: '{{ $labels.type }} storage'
+          dashboard: vcenter-datastore-utilization
+          meta: Average utilization for `{{ $labels.type }}` Datastores per vCenter is
+            above 70%. ({{ $labels.vcenter }})
+          playbook: docs/support/playbook/storage/new_storage_lun_request
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: DataStoreCapacity
+        annotations:
+          description: '{{ $labels.type }} datastore {{ $labels.datastore }} utilization
+            > 80%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
+          summary: '{{ $labels.type }} datastore {{ $labels.datastore }} utilization >
+            80%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
+        expr: |
+          vrops_datastore_diskspace_total_usage_gigabytes{type!~"ephemeral|vmfs.+|nfs", datastore!~".+swap"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.8
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          dashboard: vcenter-datastore-utilization
+          meta: '{{ $labels.type }} datastore {{ $labels.datastore }} utilization > 80%.
+            ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
+          playbook: docs/support/playbook/datastore/datastorediskusagealarm
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: DataStoreCapacity
+        annotations:
+          description: '{{ $labels.type }} datastore {{ $labels.datastore }} utilization
+            > 90%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
+          summary: '{{ $labels.type }} datastore {{ $labels.datastore }} utilization >
+            90%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
+        expr: |
+          vrops_datastore_diskspace_total_usage_gigabytes{type!~"ephemeral|vmfs.+|nfs", datastore!~".+swap"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.9
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          dashboard: vcenter-datastore-utilization
+          meta: '{{ $labels.type }} datastore {{ $labels.datastore }} utilization > 90%.
+            ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
+          playbook: docs/support/playbook/datastore/datastorediskusagealarm
+          service: storage
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: SwapDataStoreUsageWithoutVMs
+        annotations:
+          description: NVMe swap datastore {{ $labels.datastore }} is utilized without
+            associated VMs. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: NVMe swap datastore {{ $labels.datastore }} is utilized without associated
+            VMs. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: |
+          vrops_datastore_diskspace_total_usage_gigabytes{datastore=~".*-swap"} > 10 and vrops_datastore_summary_total_number_vms == 0 unless on (datastore) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "datastore", "$1-swap", "hostsystem", "(node...-bb...).*")
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          meta: NVMe swap datastore {{ $labels.datastore }} is utilized without associated
+            VMs. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#swap-files-exist-on-local-ds-without-running-vms
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NVMeSwapDatastoreMissing
+        annotations:
+          description: |-
+            NVMe swap datastore on `{{ $labels.hostsystem }}` is missing. Model is _{{$labels.hardware_model}}_ and located in cluster *{{ $labels.vccluster }}*
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            NVMe swap datastore on `{{ $labels.hostsystem }}` is missing. Model is _{{$labels.hardware_model}}_ and located in cluster *{{ $labels.vccluster }}*
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_hostsystem_hardware_model{vccluster=~"productionbb\\d+", hardware_model!~"Cisco Systems Inc.+"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          unless on (hostsystem) (label_replace(label_join(vrops_datastore_summary_datastore_accessible{type="NVMe"}, "hostsystem", "", "datastore", "vcenter"), "hostsystem", "$1$2", "hostsystem", "(.+)-swapvc-[a-z]-\\d+(.+)")
+          or vrops_hostsystem_summary_custom_tag_nvme{summary_custom_tag_nvme="false"})
+        for: 5m
+        labels:
+          context: '{{ $labels.hostsystem }}'
+          meta: |-
+            NVMe swap datastore on `{{ $labels.hostsystem }}` is missing. Model is _{{$labels.hardware_model}}_ and located in cluster *{{ $labels.vccluster }}*
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          playbook: docs/support/playbook/datastore/nvmeswapdatastoremissing
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: DatastoreDisconnectedWithVmsOnIt
+        annotations:
+          description: Datastore {{ $labels.datastore }} is disconnected and has virtual
+            machines on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: Datastore {{ $labels.datastore }} is disconnected and has virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: |
+          (label_replace(vrops_datastore_summary_total_number_vms, "hostsystem", "$1", "datastore", "(node[0-9]{3}-[^-]*).*") > 0 and on(datastore) vrops_datastore_summary_datastore_accessible{state="PoweredOff",type!="local"}) unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          meta: Datastore {{ $labels.datastore }} is disconnected and has virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#datastoredisconnectedwithvmsonit
+          service: storage
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: IaasDatastoreDisconnectedWithVmsOnIt
+        annotations:
+          description: Datastore {{ $labels.datastore }} is disconnected and has virtual
+            machines on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: Datastore {{ $labels.datastore }} is disconnected and has virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: |-
+          ((label_replace(vrops_datastore_summary_total_number_vms, "hostsystem", "$1", "datastore", "(node[0-9]{3}-[^-]*).*") > 0 and on(datastore) vrops_datastore_summary_datastore_accessible{state="PoweredOff",type!="local"}) unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 20m
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.datastore }}'
+          meta: Datastore {{ $labels.datastore }} is disconnected and has virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#datastoredisconnectedwithvmsonit
+          service: storage
+          severity: critical
+          support_group: iaas_support
+          tier: vmware
+      - alert: DatastoreDisconnectedWithoutVmsOnIt
+        annotations:
+          description: Datastore {{ $labels.datastore }} is disconnected without virtual
+            machines on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: Datastore {{ $labels.datastore }} is disconnected without virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: |
+          (label_replace(vrops_datastore_summary_total_number_vms, "hostsystem", "$1", "datastore", "(node[0-9]{3}-[^-]*).*") == 0 and on(datastore) vrops_datastore_summary_datastore_accessible{state="PoweredOff",type!="local"}) unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          meta: Datastore {{ $labels.datastore }} is disconnected without virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#datastoredisconnectedwithoutvmsonit
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasDatastoreDisconnectedWithoutVmsOnIt
+        annotations:
+          description: Datastore {{ $labels.datastore }} is disconnected without virtual
+            machines on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: Datastore {{ $labels.datastore }} is disconnected without virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: |-
+          ((label_replace(vrops_datastore_summary_total_number_vms, "hostsystem", "$1", "datastore", "(node[0-9]{3}-[^-]*).*") == 0 and on(datastore) vrops_datastore_summary_datastore_accessible{state="PoweredOff",type!="local"}) unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 20m
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.datastore }}'
+          meta: Datastore {{ $labels.datastore }} is disconnected without virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#datastoredisconnectedwithoutvmsonit
+          service: storage
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: DatastoreHasLostConnectivityToAStorageDevice
+        annotations:
+          description: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has lost connectivity to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has lost connectivity to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          label_replace(vrops_datastore_alert_info{alert_name="Datastore has lost connectivity to a storage device"}, "hostsystem", "$1", "datastore", "(node.*)(-.*)") unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+        labels:
+          meta: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has lost connectivity to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#datastorehashoststhathavelostredundantpathsanddatastorehaslostconnectivitytoastoragedevice
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasDatastoreHasLostConnectivityToAStorageDevice
+        annotations:
+          description: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has lost connectivity to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has lost connectivity to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |-
+          (label_replace(vrops_datastore_alert_info{alert_name="Datastore has lost connectivity to a storage device"}, "hostsystem", "$1", "datastore", "(node.*)(-.*)") unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          meta: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has lost connectivity to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#datastorehashoststhathavelostredundantpathsanddatastorehaslostconnectivitytoastoragedevice
+          service: storage
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: DatastoreHasHostsThatHaveLostRedundantPathsToAStorageDevice
+        annotations:
+          description: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has hosts that have lost redundant paths to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has hosts that have lost redundant paths to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          label_replace(vrops_datastore_alert_info{alert_name="Datastore has one or more hosts that have lost redundant paths to a storage device"}, "hostsystem", "$1", "datastore", "(node.*)(-.*)") unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+        labels:
+          meta: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has hosts that have lost redundant paths to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#datastorehashoststhathavelostredundantpathsanddatastorehaslostconnectivitytoastoragedevice
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasDatastoreHasHostsThatHaveLostRedundantPathsToAStorageDevice
+        annotations:
+          description: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has hosts that have lost redundant paths to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has hosts that have lost redundant paths to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |-
+          (label_replace(vrops_datastore_alert_info{alert_name="Datastore has one or more hosts that have lost redundant paths to a storage device"}, "hostsystem", "$1", "datastore", "(node.*)(-.*)") unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          meta: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has hosts that have lost redundant paths to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#datastorehashoststhathavelostredundantpathsanddatastorehaslostconnectivitytoastoragedevice
+          service: storage
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: SDRSClusterCapacity
+        annotations:
+          description: DataStore Cluster {{ $labels.storagepod }} utilization > 80%. ({{
+            $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: DataStore Cluster {{ $labels.storagepod }} utilization > 80%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+        expr: |
+          vrops_storagepod_capacity_available_space / vrops_storagepod_capacity_total * 100 <= 20
+        for: 20m
+        labels:
+          context: '{{ $labels.storagepod }}'
+          dashboard: vcenter-datastore-utilization
+          meta: DataStore Cluster {{ $labels.storagepod }} utilization > 80%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          playbook: docs/support/playbook/datastore/datastorediskusagealarm
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: SDRSClusterCapacity
+        annotations:
+          description: DataStore Cluster {{ $labels.storagepod }} utilization > 90%. ({{
+            $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: DataStore Cluster {{ $labels.storagepod }} utilization > 90%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+        expr: |
+          vrops_storagepod_capacity_available_space / vrops_storagepod_capacity_total * 100 <= 10
+        for: 20m
+        labels:
+          context: '{{ $labels.storagepod }}'
+          dashboard: vcenter-datastore-utilization
+          meta: DataStore Cluster {{ $labels.storagepod }} utilization > 90%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          playbook: docs/support/playbook/datastore/datastorediskusagealarm
+          service: storage
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: NVMeDatastoreNotAccessible
+        annotations:
+          description: Datastore {{ $labels.datastore }} is not accessible. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          summary: Datastore {{ $labels.datastore }} is not accessible. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+        expr: |
+          vrops_datastore_summary_datastore_accessible{type='NVMe'} == 0
+        for: 5m
+        labels:
+          context: '{{ $labels.datastore }}'
+          meta: Datastore {{ $labels.datastore }} is not accessible. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          service: storage
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: EphemeralDatastoreNotPartOfSDRSCluster
+        annotations:
+          description: Eph Datastore {{ $labels.datastore }} is not a part of SDRS Cluster.
+            ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: Eph Datastore {{ $labels.datastore }} is not a part of SDRS Cluster.
+            ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: |
+          vrops_datastore_summary_datastore_accessible{type="ephemeral", storagepod=~"none|None|NONE", datastore=~"eph.*"} > 0
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          meta: Eph Datastore {{ $labels.datastore }} is not a part of SDRS cluster. ({{
+            $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#ephemeraldatastorenotpartofsdrscluster
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: EphemeralDatastorePartOfIncorrectSDRSCluster
+        annotations:
+          description: Eph Datastore {{ $labels.datastore }} is not a part of correct
+            SDRS Cluster. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: Eph Datastore {{ $labels.datastore }} is not a part of correct SDRS
+            Cluster. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: |
+          (vrops_datastore_summary_datastore_accessible{type="ephemeral", storagepod=~".*hgb.*", datastore=~"eph.*hga"} or vrops_datastore_summary_datastore_accessible{type="ephemeral", storagepod=~".*hga.*", datastore=~"eph.*hgb"}) > 0
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          meta: Eph Datastore {{ $labels.datastore }} is not a part of correct SDRS cluster.
+            ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#ephemeraldatastorepartofincorrectsdrscluster
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: CinderTagMissingForDatastoreSSD
+        annotations:
+          description: |-
+            There is no Cinder tag present for the `{{ $labels.datastore }}` datastore in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            There is no Cinder tag present for the `{{ $labels.datastore }}` datastore in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_datastore_summary_tag{type="vmfs_p_ssd", summary_tag="none"}
+          unless on (datastore) vrops_datastore_summary_custom_tag_cinder_state{summary_custom_tag_cinder_state="reserved"}
+        for: 1h
+        labels:
+          meta: |-
+            There is no Cinder tag present for the `{{ $labels.datastore }}` datastore in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          playbook: docs/support/playbook/cinder/cinder-tag-missing
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: CinderTagMissingForDatastoreHDD
+        annotations:
+          description: |-
+            There is no Cinder tag present for the `{{ $labels.datastore }}` datastore in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            There is no Cinder tag present for the `{{ $labels.datastore }}` datastore in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_datastore_summary_tag{type="vmfs_s_hdd", summary_tag="none"}
+          unless on (datastore) vrops_datastore_summary_custom_tag_cinder_state{summary_custom_tag_cinder_state="reserved"}
+        for: 1h
+        labels:
+          meta: |-
+            There is no Cinder tag present for the `{{ $labels.datastore }}` datastore in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          playbook: docs/support/playbook/cinder/cinder-tag-missing
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: CinderTagAddedForReservedDatastore
+        annotations:
+          description: |-
+            The Cinder state is reserved but the Cinder tag still exists for the `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The Cinder state is reserved but the Cinder tag still exists for the `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_datastore_summary_custom_tag_cinder_state{type=~"(vmfs_s_hdd|vmfs_p_ssd)", summary_custom_tag_cinder_state="reserved"} > 0
+          and on (datastore) vrops_datastore_summary_tag{tag_cinder=~"cinder|slow"}
+        for: 1h
+        labels:
+          meta: |-
+            The Cinder state is reserved but the Cinder tag still exists for the `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          playbook: docs/support/playbook/cinder/cinder-tag-added
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VMFSDatastoreHostcountMismatch
+        annotations:
+          description: |-
+            The `{{ $labels.datastore }}` VMFS datastore is not connected to all production ESXi hosts in *{{ $labels.vcenter }}* vCenter.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The `{{ $labels.datastore }}` VMFS datastore is not connected to all production ESXi hosts in *{{ $labels.vcenter }}* vCenter.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_datastore_hostcount{type=~"(vmfs_s_hdd|vmfs_p_ssd)"} < on (vcenter) group_left
+          count by (vcenter) (vrops_hostsystem_runtime_connectionstate{state="connected", vccluster=~"productionbb\\d+"}
+          unless on (hostsystem) (vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}))
+        for: 60m
+        labels:
+          meta: |-
+            The `{{ $labels.datastore }}` VMFS datastore is not connected to all production ESXi hosts in *{{ $labels.vcenter }}* vCenter.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          playbook: docs/devops/alert/vcenter/#vmfsdatastorehostcountmismatch
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NFSDatastoreHostcountMismatch
+        annotations:
+          description: |-
+            The `{{ $labels.datastore }}` NFS datastore is not connected to all production ESXi hosts in *{{ $labels.vcenter }}* vCenter.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The `{{ $labels.datastore }}` NFS datastore is not connected to all production ESXi hosts in *{{ $labels.vcenter }}* vCenter.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_datastore_hostcount{type="nfs"} < on (vcenter) group_left
+          count by (vcenter) (vrops_hostsystem_runtime_connectionstate{state="connected", vccluster=~"productionbb\\d+"})
+        for: 60m
+        labels:
+          meta: |-
+            The `{{ $labels.datastore }}` NFS datastore is not connected to all production ESXi hosts in *{{ $labels.vcenter }}* vCenter.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          playbook: docs/devops/alert/vcenter/#nfsdatastorehostcountmismatch
+          service: storage
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: NFSDatastoreCinderAggregateIDNotSet
+        annotations:
+          description: |-
+            cinder_aggregate_id is not set for the `{{ $labels.datastore }}` NFS datastore in *{{ $labels.datacenter }}* availability zone.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            cinder_aggregate_id is not set for the `{{ $labels.datastore }}` NFS datastore in *{{ $labels.datacenter }}* availability zone.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_datastore_summary_datastore_accessible{type="nfs"}
+          unless on(datastore) vrops_datastore_summary_custom_tag_cinder_aggregate_id{type="nfs", summary_custom_tag_cinder_aggregate_id!=""}
+        for: 1h
+        labels:
+          meta: |-
+            cinder_aggregate_id is not set for the `{{ $labels.datastore }}` NFS datastore in *{{ $labels.datacenter }}* availability zone.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          playbook: docs/support/playbook/cinder/cinder-fcd-operations/#nfsdatastorecinderaggregateidnotset
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-mgmt-b-0-alerts-host.alerts
+  labels:
+    prometheus: vmware-vc-mgmt-b-0
+
+spec:
+  groups:
+    - name: host.alerts
+      rules:
+      - alert: HostWithRunningVMsNotResponding
+        annotations:
+          description: Host {{ $labels.hostsystem }} with running VMs not responding.
+            ({{ $labels.vcenter }}, {{ $labels.vccluster }})
+          summary: Host {{ $labels.hostsystem }} with running VMs not responding. ({{
+            $labels.vcenter }}, {{ $labels.vccluster }})
+        expr: |
+          avg_over_time(vrops_hostsystem_runtime_connectionstate{state="notResponding"}[5m])
+          and on (hostsystem) avg_over_time(vrops_hostsystem_runtime_powerstate{state!="Powered Off"}[5m])
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"}
+          and on (hostsystem) count(vrops_virtualmachine_runtime_powerstate{virtualmachine!~"vCLS.*", state!="Powered Off"}) by (hostsystem) > 0
+        for: 5m
+        labels:
+          context: ESXi not responding
+          dashboard: esxi-host-disconnected/esxi-host-disconnected?&var-host={{ $labels.hostsystem
+            }}
+          meta: Host {{ $labels.hostsystem }} with running VMs not responding. ({{ $labels.vcenter
+            }}, {{ $labels.vccluster }})
+          playbook: docs/devops/alert/vcenter/#hostwithrunningvmsnotresponding
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostWithRunningVMsNotResponding
+        annotations:
+          description: Host {{ $labels.hostsystem }} with running VMs not responding.
+            ({{ $labels.vcenter }}, {{ $labels.vccluster }})
+          summary: Host {{ $labels.hostsystem }} with running VMs not responding. ({{
+            $labels.vcenter }}, {{ $labels.vccluster }})
+        expr: |-
+          (avg_over_time(vrops_hostsystem_runtime_connectionstate{state="notResponding"}[5m])
+          and on (hostsystem) avg_over_time(vrops_hostsystem_runtime_powerstate{state!="Powered Off"}[5m])
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"}
+          and on (hostsystem) count(vrops_virtualmachine_runtime_powerstate{virtualmachine!~"vCLS.*", state!="Powered Off"}) by (hostsystem) > 0
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 5m
+        labels:
+          bedrock: "true"
+          context: ESXi not responding
+          dashboard: esxi-host-disconnected/esxi-host-disconnected?&var-host={{ $labels.hostsystem
+            }}
+          meta: Host {{ $labels.hostsystem }} with running VMs not responding. ({{ $labels.vcenter
+            }}, {{ $labels.vccluster }})
+          playbook: docs/devops/alert/vcenter/#hostwithrunningvmsnotresponding
+          service: compute
+          severity: critical
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostNotResponding
+        annotations:
+          description: Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter
+            }}, {{ $labels.vccluster }})
+          summary: Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter }},
+            {{ $labels.vccluster }})
+        expr: |
+          vrops_hostsystem_summary_running_vms_number == 0 and
+          on (hostsystem) vrops_hostsystem_runtime_connectionstate{state="notResponding"} and
+          on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"} and
+          on (hostsystem) vrops_hostsystem_runtime_powerstate{state!="Powered Off"}
+        labels:
+          context: ESXi not responding
+          dashboard: esxi-host-disconnected/esxi-host-disconnected?&var-host={{ $labels.hostsystem
+            }}
+          meta: Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter }},
+            {{ $labels.vccluster }})
+          playbook: docs/devops/alert/vcenter/#hostnotresponding
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostNotResponding
+        annotations:
+          description: Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter
+            }}, {{ $labels.vccluster }})
+          summary: Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter }},
+            {{ $labels.vccluster }})
+        expr: |-
+          (vrops_hostsystem_summary_running_vms_number == 0 and
+          on (hostsystem) vrops_hostsystem_runtime_connectionstate{state="notResponding"} and
+          on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"} and
+          on (hostsystem) vrops_hostsystem_runtime_powerstate{state!="Powered Off"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: ESXi not responding
+          dashboard: esxi-host-disconnected/esxi-host-disconnected?&var-host={{ $labels.hostsystem
+            }}
+          meta: Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter }},
+            {{ $labels.vccluster }})
+          playbook: docs/devops/alert/vcenter/#hostnotresponding
+          service: compute
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: VMsOnFailoverHost
+        annotations:
+          description: Failover Host {{ $labels.hostsystem }} has Virtual Machines on
+            it. Free up the host. ({{ $labels.vcenter }}, {{ $labels.vccluster }})
+          summary: Failover Host {{ $labels.hostsystem }} has Virtual Machines on it.
+            ({{ $labels.vcenter }}, {{ $labels.vccluster }})
+        expr: |
+          vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost == 1
+          and on (hostsystem) count(vrops_virtualmachine_runtime_powerstate{virtualmachine!~"vCLS.*", state="Powered On"}) by (hostsystem) > 0
+        for: 10m
+        labels:
+          context: Failover host
+          meta: Failover Host {{ $labels.hostsystem }} has Virtual Machines on it. ({{
+            $labels.vcenter }}, {{ $labels.vccluster }})
+          playbook: docs/devops/alert/vcenter/#vmsonfailoverhost
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: IaasVMsOnFailoverHost
+        annotations:
+          description: Failover Host {{ $labels.hostsystem }} has Virtual Machines on
+            it. Free up the host. ({{ $labels.vcenter }}, {{ $labels.vccluster }})
+          summary: Failover Host {{ $labels.hostsystem }} has Virtual Machines on it.
+            ({{ $labels.vcenter }}, {{ $labels.vccluster }})
+        expr: |-
+          (vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost == 1
+          and on (hostsystem) count(vrops_virtualmachine_runtime_powerstate{virtualmachine!~"vCLS.*", state="Powered On"}) by (hostsystem) > 0
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 10m
+        labels:
+          bedrock: "true"
+          context: Failover host
+          meta: Failover Host {{ $labels.hostsystem }} has Virtual Machines on it. ({{
+            $labels.vcenter }}, {{ $labels.vccluster }})
+          playbook: docs/devops/alert/vcenter/#vmsonfailoverhost
+          service: compute
+          severity: critical
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostHasLostRedundantConnectivityToDVPort
+        annotations:
+          description: Host `{{ $labels.hostsystem }}` has lost redundant connectivity
+            to a dvPort. ({{ $labels.vcenter }}).
+          summary: Host `{{ $labels.hostsystem }}` has lost redundant connectivity to
+            a dvPort. ({{ $labels.vcenter }}).
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="The host has lost redundant connectivity to a dvPort"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        labels:
+          context: '{{ $labels.hostsystem }} dvPort connection'
+          meta: Host `{{ $labels.hostsystem }}` has lost redundant connectivity to a dvPort.
+            ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#host_has_lost_connectivity_to_a_dv_port
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostHasLostRedundantConnectivityToDVPort
+        annotations:
+          description: Host `{{ $labels.hostsystem }}` has lost redundant connectivity
+            to a dvPort. ({{ $labels.vcenter }}).
+          summary: Host `{{ $labels.hostsystem }}` has lost redundant connectivity to
+            a dvPort. ({{ $labels.vcenter }}).
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="The host has lost redundant connectivity to a dvPort"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} dvPort connection'
+          meta: Host `{{ $labels.hostsystem }}` has lost redundant connectivity to a dvPort.
+            ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#host_has_lost_connectivity_to_a_dv_port
+          service: compute
+          severity: info
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostNicDown
+        annotations:
+          description: '`{{ $labels.hostsystem }}` has detected a link status down on
+            a physical NIC. ({{ $labels.vcenter }}).'
+          summary: '`{{ $labels.hostsystem }}` has detected a link status down on a physical
+            NIC. ({{ $labels.vcenter }}).'
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="ESXi host has detected a link status down on a physical NIC"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        for: 20m
+        labels:
+          context: '{{ $labels.hostsystem }} network connection'
+          meta: '`{{ $labels.hostsystem }}` has detected a link status down on a physical
+            NIC. ({{ $labels.vcenter }}).'
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hostnicdown
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostNicDown
+        annotations:
+          description: '`{{ $labels.hostsystem }}` has detected a link status down on
+            a physical NIC. ({{ $labels.vcenter }}).'
+          summary: '`{{ $labels.hostsystem }}` has detected a link status down on a physical
+            NIC. ({{ $labels.vcenter }}).'
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="ESXi host has detected a link status down on a physical NIC"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 20m
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} network connection'
+          meta: '`{{ $labels.hostsystem }}` has detected a link status down on a physical
+            NIC. ({{ $labels.vcenter }}).'
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hostnicdown
+          service: compute
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostHasLostConnectionToVCenterServer
+        annotations:
+          description: '`{{ $labels.hostsystem }}` has been unexpectedly disconnected
+            from vCenter Server {{ $labels.vcenter }}.'
+          summary: '`{{ $labels.hostsystem }}` has been unexpectedly disconnected from
+            vCenter Server {{ $labels.vcenter }}.'
+        expr: |
+          vrops_hostsystem_runtime_connectionstate{state="disconnected"} AND on (hostsystem)
+          vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"} AND on (hostsystem)
+          vrops_hostsystem_runtime_powerstate{state!="Standby"}
+        labels:
+          context: '{{ $labels.hostsystem }} vCenter connection'
+          meta: '`{{ $labels.hostsystem }}` has been unexpectedly disconnected from vCenter
+            Server {{ $labels.vcenter }}.'
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hosthaslostconnectiontovcenterserver
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostHasLostConnectionToVCenterServer
+        annotations:
+          description: '`{{ $labels.hostsystem }}` has been unexpectedly disconnected
+            from vCenter Server {{ $labels.vcenter }}.'
+          summary: '`{{ $labels.hostsystem }}` has been unexpectedly disconnected from
+            vCenter Server {{ $labels.vcenter }}.'
+        expr: |-
+          (vrops_hostsystem_runtime_connectionstate{state="disconnected"} AND on (hostsystem)
+          vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"} AND on (hostsystem)
+          vrops_hostsystem_runtime_powerstate{state!="Standby"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} vCenter connection'
+          meta: '`{{ $labels.hostsystem }}` has been unexpectedly disconnected from vCenter
+            Server {{ $labels.vcenter }}.'
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hosthaslostconnectiontovcenterserver
+          service: compute
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostHasLostConnectivityToPhysicalNetwork
+        annotations:
+          description: Host `{{ $labels.hostsystem }}` has lost connectivity to physical
+            network. ({{ $labels.vcenter }}).
+          summary: Host `{{ $labels.hostsystem }}` has lost connectivity to physical network.
+            ({{ $labels.vcenter }}).
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="The host has lost connectivity to physical network"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        labels:
+          context: '{{ $labels.hostsystem }} network connection'
+          meta: Host `{{ $labels.hostsystem }}` has lost connectivity to physical network.
+            ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#host_has_lost_connectivity_to_physical_network
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostHasLostConnectivityToPhysicalNetwork
+        annotations:
+          description: Host `{{ $labels.hostsystem }}` has lost connectivity to physical
+            network. ({{ $labels.vcenter }}).
+          summary: Host `{{ $labels.hostsystem }}` has lost connectivity to physical network.
+            ({{ $labels.vcenter }}).
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="The host has lost connectivity to physical network"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} network connection'
+          meta: Host `{{ $labels.hostsystem }}` has lost connectivity to physical network.
+            ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#host_has_lost_connectivity_to_physical_network
+          service: compute
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: HADetectedAPossibleHostFailure-testing
+        annotations:
+          description: vSphere High Availability (HA) has detected a possible host failure
+            for `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+          summary: vSphere High Availability (HA) has detected a possible host failure
+            for `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) has detected a possible host failure"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{vccluster!~".*controlplane-swift"}
+        labels:
+          context: '{{ $labels.hostsystem }} failure'
+          meta: vSphere High Availability (HA) has detected a possible host failure for
+            `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hadetectedapossiblehostfailure
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: HADetectedAPossibleHostFailure
+        annotations:
+          description: vSphere High Availability (HA) has detected a possible host failure
+            for `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+          summary: vSphere High Availability (HA) has detected a possible host failure
+            for `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) has detected a possible host failure"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance", vccluster!~".*controlplane-swift"}
+        labels:
+          context: '{{ $labels.hostsystem }} failure'
+          meta: vSphere High Availability (HA) has detected a possible host failure for
+            `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hadetectedapossiblehostfailure
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: IaasHADetectedAPossibleHostFailure
+        annotations:
+          description: vSphere High Availability (HA) has detected a possible host failure
+            for `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+          summary: vSphere High Availability (HA) has detected a possible host failure
+            for `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) has detected a possible host failure"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance", vccluster!~".*controlplane-swift"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} failure'
+          meta: vSphere High Availability (HA) has detected a possible host failure for
+            `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hadetectedapossiblehostfailure
+          service: compute
+          severity: critical
+          support_group: iaas_support
+          tier: vmware
+      - alert: APodMemoryUtilizationHigh
+        annotations:
+          description: Memory utilization of host {{ $labels.hostsystem }} is above 90%.
+            ({{ $labels.vcenter }})
+          summary: Memory utilization of host {{ $labels.hostsystem }} is above 90%. ({{
+            $labels.vcenter }})
+        expr: vrops_hostsystem_memory_usage_percentage{vccluster=~".*-management.*"} >
+          95
+        for: 30m
+        labels:
+          context: '{{ $labels.hostsystem }} memory'
+          meta: Memory utilization of host {{ $labels.hostsystem }} is above 90%. ({{
+            $labels.vcenter }})
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: APodCPUUtilizationHigh
+        annotations:
+          description: CPU utilization of host {{ $labels.hostsystem }} is above 90%.
+            ({{ $labels.vcenter }})
+          summary: CPU utilization of host {{ $labels.hostsystem }} is above 90%. ({{
+            $labels.vcenter }})
+        expr: vrops_hostsystem_cpu_usage_average_percentage{vccluster=~".*-management.*"}
+          > 80
+        for: 30m
+        labels:
+          context: '{{ $labels.hostsystem }} cpu'
+          meta: CPU utilization of host {{ $labels.hostsystem }} is above 90%. ({{ $labels.vcenter
+            }})
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: HostHighNumberOfPacketsDropped
+        annotations:
+          description: '`{{ $labels.hostsystem }}` is experiencing high number of packets
+            dropped. ({{ $labels.vcenter }}).'
+          summary: '`{{ $labels.hostsystem }}` is experiencing high number of packets
+            dropped. ({{ $labels.vcenter }}).'
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="Host is experiencing high number of packets dropped"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        labels:
+          context: '{{ $labels.hostsystem }} packets dropped'
+          meta: '`{{ $labels.hostsystem }}` is experiencing high number of packets dropped.
+            ({{ $labels.vcenter }}).'
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostHighNumberOfPacketsDropped
+        annotations:
+          description: '`{{ $labels.hostsystem }}` is experiencing high number of packets
+            dropped. ({{ $labels.vcenter }}).'
+          summary: '`{{ $labels.hostsystem }}` is experiencing high number of packets
+            dropped. ({{ $labels.vcenter }}).'
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="Host is experiencing high number of packets dropped"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} packets dropped'
+          meta: '`{{ $labels.hostsystem }}` is experiencing high number of packets dropped.
+            ({{ $labels.vcenter }}).'
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostNicLinkFlappingAlert
+        annotations:
+          description: '`{{ $labels.hostsystem }}` has detected a link status flapping
+            on a physical NIC. ({{ $labels.vcenter }}).'
+          summary: '`{{ $labels.hostsystem }}` has detected a link status flapping on
+            a physical NIC. ({{ $labels.vcenter }}).'
+        expr: |
+          vrops_hostsystem_alert_info{alert_name=~"ESXi host has detected a link status.*flapping.*on a physical NIC"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        labels:
+          context: '{{ $labels.hostsystem }} link flapping'
+          meta: '`{{ $labels.hostsystem }}` has detected a link status flapping on a physical
+            NIC. ({{ $labels.vcenter }}).'
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostNicLinkFlappingAlert
+        annotations:
+          description: '`{{ $labels.hostsystem }}` has detected a link status flapping
+            on a physical NIC. ({{ $labels.vcenter }}).'
+          summary: '`{{ $labels.hostsystem }}` has detected a link status flapping on
+            a physical NIC. ({{ $labels.vcenter }}).'
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name=~"ESXi host has detected a link status.*flapping.*on a physical NIC"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} link flapping'
+          meta: '`{{ $labels.hostsystem }}` has detected a link status flapping on a physical
+            NIC. ({{ $labels.vcenter }}).'
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostSystemEventLogSensorAlert
+        annotations:
+          description: IPMI System Event Log for `{{ $labels.hostsystem }}` is becoming
+            full. ({{ $labels.vcenter }}) {{ $labels.recommendation_1 }}
+          summary: IPMI System Event Log for `{{ $labels.hostsystem }}` is becoming full.
+            ({{ $labels.vcenter }}) {{ $labels.recommendation_1 }}
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="IPMI System Event Log for the host is becoming full"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        labels:
+          context: '{{ $labels.hostsystem }} IPMI log'
+          meta: IPMI System Event Log for `{{ $labels.hostsystem }}` is becoming full.
+            ({{ $labels.vcenter }}) {{ $labels.recommendation_1 }}
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostSystemEventLogSensorAlert
+        annotations:
+          description: IPMI System Event Log for `{{ $labels.hostsystem }}` is becoming
+            full. ({{ $labels.vcenter }}) {{ $labels.recommendation_1 }}
+          summary: IPMI System Event Log for `{{ $labels.hostsystem }}` is becoming full.
+            ({{ $labels.vcenter }}) {{ $labels.recommendation_1 }}
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="IPMI System Event Log for the host is becoming full"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} IPMI log'
+          meta: IPMI System Event Log for `{{ $labels.hostsystem }}` is becoming full.
+            ({{ $labels.vcenter }}) {{ $labels.recommendation_1 }}
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostStoragePathsDown
+        annotations:
+          description: More than 4 active storage paths for `{{ $labels.hostsystem }}`
+            down. ({{ $labels.vcenter }})
+          summary: More than 4 active storage paths for `{{ $labels.hostsystem }}` down.
+            ({{ $labels.vcenter }})
+        expr: vrops_hostsystem_storage_number_of_path - vrops_hostsystem_storage_number_of_active_path
+          > 4
+        for: 30m
+        labels:
+          context: '{{ $labels.hostsystem }} storage paths'
+          meta: More than 4 active storage paths for `{{ $labels.hostsystem }}` down.
+            ({{ $labels.vcenter }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostStoragePathsDown
+        annotations:
+          description: More than 4 active storage paths for `{{ $labels.hostsystem }}`
+            down. ({{ $labels.vcenter }})
+          summary: More than 4 active storage paths for `{{ $labels.hostsystem }}` down.
+            ({{ $labels.vcenter }})
+        expr: (vrops_hostsystem_storage_number_of_path - vrops_hostsystem_storage_number_of_active_path
+          > 4) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 30m
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} storage paths'
+          meta: More than 4 active storage paths for `{{ $labels.hostsystem }}` down.
+            ({{ $labels.vcenter }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostAllRedundantStoragePathsDown
+        annotations:
+          description: All active storage paths for `{{ $labels.hostsystem }}` down. ({{
+            $labels.vcenter }})
+          summary: All active storage paths for `{{ $labels.hostsystem }}` down. ({{ $labels.vcenter
+            }})
+        expr: vrops_hostsystem_storage_number_of_active_path == 0
+        for: 10m
+        labels:
+          context: '{{ $labels.hostsystem }} storage paths'
+          meta: All active storage paths for `{{ $labels.hostsystem }}` down. ({{ $labels.vcenter
+            }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostAllRedundantStoragePathsDown
+        annotations:
+          description: All active storage paths for `{{ $labels.hostsystem }}` down. ({{
+            $labels.vcenter }})
+          summary: All active storage paths for `{{ $labels.hostsystem }}` down. ({{ $labels.vcenter
+            }})
+        expr: (vrops_hostsystem_storage_number_of_active_path == 0) and on(hostsystem)
+          vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 10m
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} storage paths'
+          meta: All active storage paths for `{{ $labels.hostsystem }}` down. ({{ $labels.vcenter
+            }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: iaas_support
+          tier: vmware
+      - alert: HAHostAgentError
+        annotations:
+          description: HA agent on Host `{{ $labels.hostsystem }}` has encountered an
+            error. ({{ $labels.vcenter }}).
+          summary: HA agent on Host `{{ $labels.hostsystem }}` has encountered an error.
+            ({{ $labels.vcenter }}).
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) host agent has encountered an error", vccluster!~".*-controlplane-swift"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        labels:
+          context: '{{ $labels.hostsystem }} HA agent error'
+          meta: HA agent on Host `{{ $labels.hostsystem }}` has encountered an error.
+            ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#troubleshooting-vsphere-ha-host-states
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasHAHostAgentError
+        annotations:
+          description: HA agent on Host `{{ $labels.hostsystem }}` has encountered an
+            error. ({{ $labels.vcenter }}).
+          summary: HA agent on Host `{{ $labels.hostsystem }}` has encountered an error.
+            ({{ $labels.vcenter }}).
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) host agent has encountered an error", vccluster!~".*-controlplane-swift"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} HA agent error'
+          meta: HA agent on Host `{{ $labels.hostsystem }}` has encountered an error.
+            ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#troubleshooting-vsphere-ha-host-states
+          service: compute
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: HAHostNetworkPartitioned
+        annotations:
+          description: HA on Host `{{ $labels.hostsystem }}` has detected a network-partitioned
+            host. ({{ $labels.vcenter }}).
+          summary: HA on Host `{{ $labels.hostsystem }}` has detected a network-partitioned
+            host. ({{ $labels.vcenter }}).
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) has detected a network-partitioned host"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        labels:
+          context: '{{ $labels.hostsystem }} HA network-partitioned host'
+          meta: HA on Host `{{ $labels.hostsystem }}` has detected a network-partitioned
+            host. ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#troubleshooting-vsphere-ha-host-states
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasHAHostNetworkPartitioned
+        annotations:
+          description: HA on Host `{{ $labels.hostsystem }}` has detected a network-partitioned
+            host. ({{ $labels.vcenter }}).
+          summary: HA on Host `{{ $labels.hostsystem }}` has detected a network-partitioned
+            host. ({{ $labels.vcenter }}).
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) has detected a network-partitioned host"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} HA network-partitioned host'
+          meta: HA on Host `{{ $labels.hostsystem }}` has detected a network-partitioned
+            host. ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#troubleshooting-vsphere-ha-host-states
+          service: compute
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: APodHostRunsMultipleVCenters
+        annotations:
+          description: aPod node `{{ $labels.hostsystem }}` runs multiple vCenter VMs.
+            ({{ $labels.vcenter }})
+          summary: aPod node `{{ $labels.hostsystem }}` runs multiple vCenter VMs. ({{
+            $labels.vcenter }})
+        expr: count(vrops_virtualmachine_runtime_connectionstate{vccluster=~".*-management",
+          virtualmachine=~"vc-.*"}) by(hostsystem, vcenter) > 1
+        for: 30m
+        labels:
+          context: '{{ $labels.hostsystem }} multiple vCenters'
+          meta: aPod node `{{ $labels.hostsystem }}` runs multiple vCenter VMs. ({{ $labels.vcenter
+            }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: HostStoragePathCheck
+        annotations:
+          description: storage paths for `{{ $labels.hostsystem }}` is less than other
+            hosts in the `{{ $labels.vccluster }}`. ({{ $labels.vcenter }})
+          summary: storage paths for `{{ $labels.hostsystem }}` is less than other hosts
+            in the `{{ $labels.vccluster }}`. ({{ $labels.vcenter }})
+        expr: vrops_hostsystem_storage_number_of_path < on(vccluster) group_left() (max(vrops_hostsystem_storage_number_of_path)
+          by(vccluster))
+        for: 30m
+        labels:
+          context: '{{ $labels.hostsystem }} storage paths'
+          meta: storage paths for `{{ $labels.hostsystem }}` is less than other hosts
+            in the `{{ $labels.vccluster }}`. ({{ $labels.vcenter }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostStoragePathCheck
+        annotations:
+          description: storage paths for `{{ $labels.hostsystem }}` is less than other
+            hosts in the `{{ $labels.vccluster }}`. ({{ $labels.vcenter }})
+          summary: storage paths for `{{ $labels.hostsystem }}` is less than other hosts
+            in the `{{ $labels.vccluster }}`. ({{ $labels.vcenter }})
+        expr: (vrops_hostsystem_storage_number_of_path < on(vccluster) group_left() (max(vrops_hostsystem_storage_number_of_path)
+          by(vccluster))) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 30m
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} storage paths'
+          meta: storage paths for `{{ $labels.hostsystem }}` is less than other hosts
+            in the `{{ $labels.vccluster }}`. ({{ $labels.vcenter }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: iaas_support
+          tier: vmware
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-mgmt-b-0-alerts-iaas.alerts
+  labels:
+    prometheus: vmware-vc-mgmt-b-0
+
+spec:
+  groups:
+    - name: iaas.alerts
+      rules:
+      - alert: IaasHostMemoryUsage
+        annotations:
+          description: Memory usage of ESXi host {{ $labels.hostsystem}} is above 75%
+          summary: Memory usage of ESXi host {{ $labels.hostsystem}} is above 75%
+        expr: vrops_hostsystem_memory_usage_percentage > 75 and on (hostsystem) vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+        for: 30m
+        labels:
+          context: esxi host memory usage
+          meta: Memory usage of ESXi host {{ $labels.hostsystem}} is above 75%
+          service: compute
+          severity: warning
+          support_group: iaas-support
+      - alert: IaasHostMemoryUsage
+        annotations:
+          description: Memory usage of ESXi host {{ $labels.hostsystem}} is above 90%
+          summary: Memory usage of ESXi host {{ $labels.hostsystem}} is above 90%
+        expr: vrops_hostsystem_memory_usage_percentage > 90 and on (hostsystem) vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+        for: 30m
+        labels:
+          context: esxi host memory usage
+          meta: Memory usage of ESXi host {{ $labels.hostsystem}} is above 90%
+          service: compute
+          severity: critical
+          support_group: iaas-support
+      - alert: IaasHostLicenseKey
+        annotations:
+          description: IaaS ESXi host {{ $labels.hostsystem }} in IaaS host group without
+            valid license
+          summary: IaaS ESXi host {{ $labels.hostsystem }} in IaaS host group without
+            valid license
+        expr: vrops_hostsystem_license_key{license_key!~"GM693.*"} + on (hostsystem) group_right(license_key)
+          vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"} > 0
+        for: 30m
+        labels:
+          context: esxi host license key
+          meta: IaaS ESXi host {{ $labels.hostsystem }} in IaaS host group without valid
+            license
+          service: compute
+          severity: warning
+          support_group: iaas-support
+      - alert: IaasClusterWithoutFailoverHost
+        annotations:
+          description: IaaS cluster {{ $labels.vccluster }} has NO failover host configured
+          summary: IaaS cluster {{ $labels.vccluster }} has NO failover host configured
+        expr: |
+          (count by (vccluster) (vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}) > 0)
+          unless (count by (vccluster) (vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+          and on(hostsystem) vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{} == 1 ) > 0)
+        for: 15m
+        labels:
+          context: IaaS cluster HA policy
+          meta: IaaS cluster {{ $labels.vccluster }} has NO failover host configured
+          service: compute
+          severity: critical
+          support_group: iaas-support
+      - alert: NonIaasVmOnIaasHost
+        annotations:
+          description: Non IaaS virtual machine(s) running on IaaS ESXi host {{ $labels.hostsystem
+            }}
+          summary: Non IaaS virtual machine(s) running on IaaS ESXi host {{ $labels.hostsystem
+            }}
+        expr: |
+          count by (hostsystem) (
+            (
+              group by (project, hostsystem, virtualmachine)(vrops_virtualmachine_system_powered_on{}==1)
+              and on(project)
+              group by(project) (label_replace(limes_project_usage{domain!~"iaas-.*"}, "project", "$1", "project_id", "(.*)"))
+            )
+          )
+          and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+        for: 30m
+        labels:
+          context: non IaaS vm on IaaS cluster
+          meta: Non IaaS virtual machine(s) running on IaaS ESXi host {{ $labels.hostsystem
+            }}
+          service: compute
+          severity: warning
+          support_group: iaas-support
+      - alert: IaasHostsAlmostOutOfMemory
+        annotations:
+          description: All IaaS hosts in cluster {{ $labels.vccluster }} are above 75%
+            memory
+          summary: All IaaS hosts in cluster {{ $labels.vccluster }} are above 75% memory
+        expr: |
+          count by (vccluster) (
+            (vrops_hostsystem_memory_usage_percentage > 75)
+            and on(hostsystem)
+            vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+            unless on(hostsystem)
+            vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{} == 1
+          )
+          == on(vccluster)
+          count by (vccluster) (
+            vrops_hostsystem_memory_usage_percentage
+            and on(hostsystem)
+            vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+            unless on(hostsystem)
+            vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{} == 1
+          )
+          and on(vccluster)
+          count by (vccluster) (
+            vrops_hostsystem_memory_usage_percentage
+            and on(hostsystem)
+            vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+            unless on(hostsystem)
+            vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{} == 1
+          ) > 0
+        for: 60m
+        labels:
+          context: IaaS hosts in cluster are almost out of memory
+          meta: All IaaS hosts in cluster {{ $labels.vccluster }} are above 75% memory
+          service: compute
+          severity: warning
+          support_group: iaas-support
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-mgmt-b-0-alerts-k8s-vc-mgmt.alerts
+  labels:
+    prometheus: vmware-vc-mgmt-b-0
+
+spec:
+  groups:
+    - name: k8s-vc-mgmt.alerts
+      rules:
+      - alert: VCClusterCPUContention
+        annotations:
+          description: The VCCluster {{ $labels.vccluster}} is using {{ $value }} CPU
+            and VM's are fighting for it
+          summary: '{{ $labels.vccluster}} cpu contention critical'
+        expr: vrops_cluster_cpu_contention_percentage{vcenter=~"vc-mgmt-.*"} > 5
+        for: 15m
+        labels:
+          context: vccluster
+          meta: The VCCluster {{ $labels.vccluster}} is using too much CPU and VM's are
+            fighting for it
+          no_alert_on_absence: "true"
+          service: cc-cp
+          severity: info
+          support_group: containers
+          tier: k8s
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-mgmt-b-0-alerts-nsxt.alerts
+  labels:
+    prometheus: vmware-vc-mgmt-b-0
+
+spec:
+  groups:
+    - name: nsxt.alerts
+      rules:
+      - alert: NSXTDistributedFirewallSectionUsageLimitExceeded
+        annotations:
+          description: NSX-T cluster {{ $labels.nsxt_adapter }} firewall sections usage
+            exceeded the supported limit. https://{{ $labels.target }}
+          summary: NSX-T cluster {{ $labels.nsxt_adapter }} firewall sections usage exceeded
+            the supported limit. https://{{ $labels.target }}
+        expr: |
+          vrops_nsxt_mgmt_cluster_sys_capacity_distributed_firewall_section_usage_count /
+          vrops_nsxt_mgmt_cluster_sys_capacity_distributed_firewall_section_max_supported_count > 0.9
+        for: 10m
+        labels:
+          dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
+          meta: NSX-T cluster {{ $labels.nsxt_adapter }} firewall sections usage exceeded
+            the supported limit. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTDistributedFirewallRulesUsageLimitExceeded
+        annotations:
+          description: NSX-T cluster {{ $labels.nsxt_adapter }} firewall rules usage exceeded
+            the supported limit. https://{{ $labels.target }}
+          summary: NSX-T cluster {{ $labels.nsxt_adapter }} firewall sections rules exceeded
+            the supported limit. https://{{ $labels.target }}
+        expr: |
+          vrops_nsxt_mgmt_cluster_sys_capacity_distributed_firewall_rules_usage_count /
+          vrops_nsxt_mgmt_cluster_sys_capacity_distributed_firewall_rules_max_supported_count > 0.9
+        for: 10m
+        labels:
+          dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
+          meta: NSX-T cluster {{ $labels.nsxt_adapter }} firewall rules usage exceeded
+            the supported limit. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTLogicalSwitchesUsageLimitExceeded
+        annotations:
+          description: NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switches
+            exceeded the supported limit. https://{{ $labels.target }}
+          summary: NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switches
+            exceeded the supported limit. https://{{ $labels.target }}
+        expr: |
+          vrops_nsxt_mgmt_cluster_sys_capacity_logical_switches_usage_count /
+          vrops_nsxt_mgmt_cluster_sys_capacity_logical_switches_max_supported_count > 0.9
+        for: 10m
+        labels:
+          dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
+          meta: NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switches exceeded
+            the supported limit. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTLogicalSwitchPortsUsageWarningLimitExceeded
+        annotations:
+          description: NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switch
+            ports exceeded the supported limit. https://{{ $labels.target }}
+          summary: NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switch ports
+            exceeded the supported limit. https://{{ $labels.target }}
+        expr: |
+          vrops_nsxt_mgmt_cluster_sys_capacity_logical_switch_ports_usage_count /
+          vrops_nsxt_mgmt_cluster_sys_capacity_logical_switch_ports_max_supported_count > 0.9
+        for: 10m
+        labels:
+          dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
+          meta: NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switch ports
+            exceeded the supported limit. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTGroupsUsageLimitExceeded
+        annotations:
+          description: NSX-T cluster {{ $labels.nsxt_adapter }} count of NSGroups exceeded
+            the supported limit. https://{{ $labels.target }}
+          summary: NSX-T cluster {{ $labels.nsxt_adapter }} count of NSGroups exceeded
+            the supported limit. https://{{ $labels.target }}
+        expr: |
+          vrops_nsxt_mgmt_cluster_sys_capacity_nsgroups_max_usage_count /
+          vrops_nsxt_mgmt_cluster_sys_capacity_nsgroups_max_supported_count > 0.9
+        for: 10m
+        labels:
+          dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
+          meta: NSX-T cluster {{ $labels.nsxt_adapter }} count of NSGroups exceeded the
+            supported limit. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTIPSetsUsageLimitExceeded
+        annotations:
+          description: NSX-T cluster {{ $labels.nsxt_adapter }} count of IP sets exceeded
+            the supported limit. https://{{ $labels.target }}
+          summary: NSX-T cluster {{ $labels.nsxt_adapter }} count of IP sets exceeded
+            the supported limit. https://{{ $labels.target }}
+        expr: |
+          vrops_nsxt_mgmt_cluster_sys_capacity_ip_sets_usage_count /
+          vrops_nsxt_mgmt_cluster_sys_capacity_ip_sets_max_supported_count > 0.9
+        for: 10m
+        labels:
+          dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
+          meta: NSX-T cluster {{ $labels.nsxt_adapter }} count of IP sets exceeded the
+            supported limit. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTGroupsBasedInIPUsageLimitExceeded
+        annotations:
+          description: NSX-T cluster {{ $labels.nsxt_adapter }} count of groups based
+            in IP exceeded the supported limit. https://{{ $labels.target }}
+          summary: NSX-T cluster {{ $labels.nsxt_adapter }} count of groups based in IP
+            exceeded the supported limit. https://{{ $labels.target }}
+        expr: |
+          vrops_nsxt_mgmt_cluster_sys_capacity_groups_based_in_ip_usage_count /
+          vrops_nsxt_mgmt_cluster_sys_capacity_groups_based_in_ip_max_supported_count > 0.9
+        for: 10m
+        labels:
+          dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
+          meta: NSX-T cluster {{ $labels.nsxt_adapter }} count of groups based in IP exceeded
+            the supported limit. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTMgmtNodeImageFilesystemCapacity
+        annotations:
+          description: NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage
+            `/image` > 80%. {{ $labels.nsxt_adapter}} https://{{ $labels.target }}
+          summary: NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage
+            `/image` > 80%. {{ $labels.nsxt_adapter}} https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_node_filesystems_image_usedpercentage > 80
+        for: 10m
+        labels:
+          meta: NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage `/image`
+            > 80%. {{ $labels.nsxt_adapter}} https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#NSXTMgmtNodeImageFilesystemCapacityCritical
+          service: network
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: NSXTMgmtNodeLogFilesystemCapacity
+        annotations:
+          description: NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage
+            `/var/log` > 80%. {{ $labels.nsxt_adapter}} https://{{ $labels.target }}
+          summary: NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage
+            `/var/log` > 80%. {{ $labels.nsxt_adapter}} https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_node_filesystems_var_log_usedpercentage > 80
+        for: 10m
+        labels:
+          meta: NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage `/var/log`
+            > 80%. {{ $labels.nsxt_adapter}} https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#NSXTMgmtNodeLogFilesystemCapacityCritical
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTClusterControlStatusNoControllers
+        annotations:
+          description: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity
+            status is `{{ $labels.state }}`. https://{{ $labels.target }}
+          summary: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status
+            is `{{ $labels.state }}`. https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_cluster_controller_cluster_connectivity_status{state="NO_CONTROLLERS"}
+        for: 10m
+        labels:
+          meta: NSX-T management cluster {{ $labels.nsxt_adapter }} has connectivity status
+            `{{ $labels.state }}`. https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#cluster_control_status_no_controllers
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTClusterControlStatusUnstable
+        annotations:
+          description: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity
+            status is `{{ $labels.state }}`. https://{{ $labels.target }}
+          summary: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status
+            is `{{ $labels.state }}`. https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_cluster_controller_cluster_connectivity_status{state="UNSTABLE"}
+        for: 10m
+        labels:
+          meta: NSX-T management cluster {{ $labels.nsxt_adapter }} has connectivity status
+            `{{ $labels.state }}`. https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#cluster_control_status_unstable
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTClusterControlStatusDegraded
+        annotations:
+          description: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity
+            status is `{{ $labels.state }}`. https://{{ $labels.target }}
+          summary: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status
+            is `{{ $labels.state }}`. https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_cluster_controller_cluster_connectivity_status{state="DEGRADED"}
+        for: 30m
+        labels:
+          meta: NSX-T management cluster {{ $labels.nsxt_adapter }} has connectivity status
+            `{{ $labels.state }}`. https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#cluster_control_status_degraded
+          service: network
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: NSXTClusterControlStatusUnkown
+        annotations:
+          description: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity
+            status is `{{ $labels.state }}`. https://{{ $labels.target }}
+          summary: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status
+            is `{{ $labels.state }}`. https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_cluster_controller_cluster_connectivity_status{state="UNKNOWN"}
+        for: 10m
+        labels:
+          meta: NSX-T management cluster {{ $labels.nsxt_adapter }} has connectivity status
+            `{{ $labels.state }}`. https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#cluster_control_status_unkown
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTNodeMemoryUsageOver95
+        annotations:
+          description: NSX-T Node {{ $labels.nsxt_mgmt_node }} of cluster {{ $labels.nsxt_adapter
+            }} has memory usage of over 95%. https://{{ $labels.target }}
+          summary: NSX-T Node {{ $labels.nsxt_mgmt_node }} of cluster {{ $labels.nsxt_adapter
+            }} has memory usage of over 95%. https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_node_memory_used / vrops_nsxt_mgmt_node_memory_total > 0.95
+        for: 5m
+        labels:
+          meta: NSX-T Node {{ $labels.nsxt_mgmt_node }} of cluster {{ $labels.nsxt_adapter
+            }} has memory usage of over 95%. https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#NSXT_Memory_Usage_Over95
+          service: network
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: NSXTNodeConnectivityBroken
+        annotations:
+          description: NSX-T Node {{ $labels.nsxt_mgmt_node }} connectivity is broken.
+            ({{ $labels.nsxt_adapter }}) https://{{ $labels.target }}
+          summary: NSX-T Node {{ $labels.nsxt_mgmt_node }} connectivity is broken. ({{
+            $labels.nsxt_adapter }}) https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_node_connectivity_status{state="DISCONNECTED"}
+        for: 5m
+        labels:
+          meta: NSX-T Node `{{ $labels.nsxt_mgmt_node }}` connectivity is broken. ({{
+            $labels.nsxt_adapter }}) https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#nsxtnodeconnectivitybroken
+          service: network
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: NSXTManagementServiceHasFailed
+        annotations:
+          description: 'CRITICAL: NSX-T management service `{{ $labels.nsxt_mgmt_service
+            }}` has failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }})
+            https://{{ $labels.target }}'
+          summary: 'CRITICAL: NSX-T management service `{{ $labels.nsxt_mgmt_service }}`
+            has failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }}) https://{{
+            $labels.target }}'
+        expr: |
+          vrops_nsxt_mgmt_service_alert_info{alert_name="NSX-T Management service has failed|Management service monitor runtime state has failed",
+          nsxt_mgmt_service!~"cluster-boot-manager|cm-inventory|controller|http|manager"}
+        labels:
+          meta: Critical NSX-T management service `{{ $labels.nsxt_mgmt_service }}` has
+            failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }}) https://{{
+            $labels.target }}
+          no_alert_on_absence: "true"
+          service: network
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: NSXTSslCertificateExpiry
+        annotations:
+          description: NSX-T Certificate of {{ $labels.nsxt_adapter }} has expired or
+            will expire shortly. https://{{ $labels.target }}
+          summary: NSX-T Certificate of {{ $labels.nsxt_adapter }} has expired or will
+            expire shortly. https://{{ $labels.target }}
+        expr: vrops_nsxt_adapter_alert_info{alert_name="Adapter certificate has expired
+          or will expire shortly"}
+        labels:
+          context: nsxt certificate
+          meta: NSX-T Certificate of `{{ $labels.nsxt_adapter }}` has expired or will
+            expire shortly. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#applying-nsx-t-ssl-certificate-in-the-manager-nodes-and-the-vip
+          service: network
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: NSXTManagementServiceHasFailed
+        annotations:
+          description: 'WARNING: NSX-T management service `{{ $labels.nsxt_mgmt_service
+            }}` has failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }}).
+            https://{{ $labels.target }}'
+          summary: 'WARNING: NSX-T management service `{{ $labels.nsxt_mgmt_service }}`
+            has failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }}). https://{{
+            $labels.target }}'
+        expr: |
+          vrops_nsxt_mgmt_service_alert_info{alert_name="NSX-T Management service has failed|Management service monitor runtime state has failed",
+          nsxt_mgmt_service!~"mgmt-plane-bus|node-mgmt|ntp|ssh|search|syslog|nsx-ui"}
+        labels:
+          meta: NSX-T management service `{{ $labels.nsxt_mgmt_service }}` has failed.
+            ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }}). https://{{ $labels.target
+            }}
+          no_alert_on_absence: "true"
+          service: network
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: NSXTTransportNodeConnectivityNotUP
+        annotations:
+          description: 'Transport node {{ $labels.nsxt_transport_node }} Controller/Manager
+            Connectivity status is not UP. https://{{ $labels.target }}. '
+          summary: 'Transport node {{ $labels.nsxt_transport_node }} Controller/Manager
+            Connectivity status is not UP. https://{{ $labels.target }}. '
+        expr: |
+          label_replace(vrops_nsxt_transport_node_alert_info{alert_name="Transport Node Controller/Manager Connectivity is not UP"}, "hostsystem", "$1", "nsxt_transport_node", "(.*)")
+          AND on (hostsystem) vrops_hostsystem_runtime_connectionstate{state="notResponding"}
+          AND on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"}
+          AND on (hostsystem) vrops_hostsystem_runtime_powerstate{state="Powered On"}
+        labels:
+          meta: Transport node {{ $labels.nsxt_transport_node }} Controller/Manager Connectivity
+            status is not UP. https://{{ $labels.target }}.
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#Transport_node_status_not_UP_in_NSXT
+          service: network
+          severity: critical
+          support_group: compute
+          tier: vmware
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-mgmt-b-0-alerts-vccluster.alerts
+  labels:
+    prometheus: vmware-vc-mgmt-b-0
+
+spec:
+  groups:
+    - name: vccluster.alerts
+      rules:
+      - alert: VCenterRedundancyLostHAPolicyFaulty
+        annotations:
+          description: VC https://{{ $labels.vcenter }} has a faulty AdmissionControlPolicy
+            for cluster {{ $labels.vccluster }}, failover will not work.
+          summary: VC https://{{ $labels.vcenter }} has a faulty AdmissionControlPolicy
+            for cluster {{ $labels.vccluster }}, failover will not work.
+        expr: |
+          vrops_cluster_configuration_dasconfig_enabled{vccluster=~"productionbb\\d+"}
+          unless on (vccluster) ((vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{vccluster=~"productionbb\\d+"} != 0
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"})
+          or (vrops_cluster_summary_custom_tag_openstack_nova_traits_decommissioning{summary_custom_tag_openstack_nova_traits_decommissioning="true", vccluster=~"productionbb\\d+"}
+          and on (vccluster) vrops_cluster_cluster_running_vms == 0))
+        for: 30m
+        labels:
+          context: vc cluster config
+          meta: VC https://{{ $labels.vcenter }} has a faulty AdmissionControlPolicy for
+            cluster {{ $labels.vccluster }}, failover will not work.
+          playbook: docs/devops/alert/vcenter/#vcenterredundancylosthapolicyfaulty
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: VCenterRedundancyLostHAPolicyNotConfigured
+        annotations:
+          description: VC {{ $labels.vcenter }} {{ $labels.vccluster }} has a faulty AdmissionControlPolicy.
+            Failover will not work.
+          summary: VC {{ $labels.vcenter }} {{ $labels.vccluster }} has a faulty AdmissionControlPolicy.
+            Failover will not work.
+        expr: vrops_cluster_configuration_dasconfig_enabled{vccluster=~"production.*"}
+          == 0
+        for: 30m
+        labels:
+          context: Cluster HA policy
+          meta: VC {{ $labels.vcenter }} {{ $labels.vccluster }} has a faulty AdmissionControlPolicy.
+            Failover will not work.
+          playbook: docs/devops/alert/vcenter/#restore-ha-redundancy-in-vcenter
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: VCClusterFailoverHostCountMismatch
+        annotations:
+          description: "`{{ $labels.vccluster }}` cluster has more failover hosts configured
+            than expected. For clusters with 10 or fewer hosts, it should be 1; for larger
+            clusters, it should be no more than 2. \nLink to the vCenter: --> <https://{{
+            $labels.vcenter }}|{{ $labels.vcenter }}>"
+          summary: "`{{ $labels.vccluster }}` cluster has more failover hosts configured
+            than expected. For clusters with 10 or fewer hosts, it should be 1; for larger
+            clusters, it should be no more than 2. \nLink to the vCenter: --> <https://{{
+            $labels.vcenter }}|{{ $labels.vcenter }}>"
+        expr: |
+          (count by (vccluster, vcenter) (vrops_hostsystem_runtime_connectionstate{vccluster=~"productionbb\\d+"}) <= 10
+          and on (vccluster) sum by (vccluster) (vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{vccluster=~"productionbb\\d+"}) > 1)
+          or (sum by (vccluster, vcenter) (vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{vccluster=~"productionbb\\d+"}) > 2)
+          unless on (vccluster) (vrops_cluster_summary_custom_tag_openstack_nova_traits_decommissioning{summary_custom_tag_openstack_nova_traits_decommissioning="true", vccluster=~"productionbb\\d+"}
+          and vrops_cluster_cluster_running_vms == 0)
+        for: 30m
+        labels:
+          context: Cluster HA policy
+          meta: "`{{ $labels.vccluster }}` cluster has more failover hosts configured
+            than expected. For clusters with 10 or fewer hosts, it should be 1; for larger
+            clusters, it should be no more than 2. \nLink to the vCenter: --> <https://{{
+            $labels.vcenter }}|{{ $labels.vcenter }}>"
+          playbook: docs/devops/alert/vcenter/#vcclusterfailoverhostcountmismatch
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VCenterRedundancyLostHALevelNotSet
+        annotations:
+          description: VC {{ $labels.vcenter }} {{ $labels.vccluster }} has NO failover
+            host amount configured, this should be 1
+          summary: VC {{ $labels.vcenter }} {{ $labels.vccluster }} has NO failover host
+            amount configured, this should be 1
+        expr: count by (vccluster, vcenter) (vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{vccluster=~"production.*"}
+          == 1) == 0
+        for: 30m
+        labels:
+          context: Cluster HA policy
+          meta: VC {{ $labels.vcenter }} {{ $labels.vccluster }} has NO failover host
+            amount configured, this should be 1
+          playbook: docs/devops/alert/vcenter/#restore-ha-redundancy-in-vcenter
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: VCClusterDRSNotFullyAutomated
+        annotations:
+          description: Cluster {{ $labels.vccluster }} DRS configuration is not set to
+            fully automated.
+          summary: Cluster {{ $labels.vccluster }} DRS configuration is not set to fully
+            automated.
+        expr: |
+          vrops_cluster_configuration_drsconfig_defaultvmbehavior{vccluster!~".*controlplane.*", state != "fullyAutomated"} == 0
+          unless on (vccluster) vrops_cluster_summary_custom_tag_openstack_nova_traits_hana_exclusive_host{summary_custom_tag_openstack_nova_traits_hana_exclusive_host="true"}
+        for: 10m
+        labels:
+          context: Cluster DRS configuration
+          meta: Cluster {{ $labels.vccluster }} DRS configuration is not set to fully
+            automated.
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#cluster-drs-not-set-to-fully-automated
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: VCClusterCannotDistributeNSXTControllers
+        annotations:
+          description: Cluster {{ $labels.vccluster }} cannot evenly distribute new NSX-T
+            controllers. {{ $labels.vcenter}}
+          summary: Cluster {{ $labels.vccluster }} cannot evenly distribute new NSX-T
+            controllers. {{ $labels.vcenter }}
+        expr: |
+          count by(vccluster, vcenter) (
+            (
+              max_over_time(vrops_hostsystem_memory_capacity_available_to_vms_kilobytes{vccluster=~".*management"}[1h])
+              - max_over_time(vrops_hostsystem_memory_consumed_by_vms_kilobytes[1h])
+            ) / 1024 / 1024 >= 48
+          ) < 3
+        for: 30m
+        labels:
+          context: Cluster NSXT Resources
+          meta: Cluster {{ $labels.vccluster }} cannot evenly distribute new NSX-T controllers.
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: HanaExclusiveVCClusterDRSNotPartiallyAutomated
+        annotations:
+          description: |-
+            The HANA-exclusive {{ $labels.vccluster }} cluster DRS configuration is not set to partially automated in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The HANA-exclusive {{ $labels.vccluster }} cluster DRS configuration is not set to partially automated in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_cluster_configuration_drsconfig_defaultvmbehavior{vccluster=~"productionbb.+", state != "partiallyAutomated"}
+          and on (vccluster) vrops_cluster_summary_custom_tag_openstack_nova_traits_hana_exclusive_host{summary_custom_tag_openstack_nova_traits_hana_exclusive_host="true"}
+        labels:
+          context: Cluster DRS configuration
+          meta: |-
+            The HANA-exclusive {{ $labels.vccluster }} cluster DRS configuration is not set to partially automated in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hanaexclusivevcclusterdrsnotpartiallyautomated
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-mgmt-b-0-alerts-vcenter.alerts
+  labels:
+    prometheus: vmware-vc-mgmt-b-0
+
+spec:
+  groups:
+    - name: vcenter.alerts
+      rules:
+      - alert: VcsaSslCertificateExpiry
+        annotations:
+          description: SSL Certificate of vCSA {{ $labels.vcenter}} expires in {{ $value
+            }} days. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: SSL Certificate of vCSA {{ $labels.vcenter}} expires in {{ $value }}
+            days. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: 15 < round(((avg_over_time(vrops_vcenter_summary_certificate_expiry_date[10m])
+          / 1000) - time()) / 86400) < 30
+        for: 20m
+        labels:
+          context: vcsa certificate
+          meta: SSL Certificate of vCSA {{ $labels.vcenter }} expires in less than 30
+            days. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#vcenter-appliance-certificate-expiry
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VcsaSslCertificateExpiry
+        annotations:
+          description: SSL Certificate of vCSA {{ $labels.vcenter}} expires in {{ $value
+            }} days. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: SSL Certificate of vCSA {{ $labels.vcenter}} expires in {{ $value }}
+            days. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: round(((avg_over_time(vrops_vcenter_summary_certificate_expiry_date[10m])
+          / 1000) - time()) / 86400) < 16
+        for: 20m
+        labels:
+          context: vcsa certificate
+          meta: SSL Certificate of vCSA {{ $labels.vcenter}} expires in less than 15 days.
+            ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#vcenter-appliance-certificate-expiry
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: VCenterDiskSpaceUsage
+        annotations:
+          description: Disk space usage of vCSA {{ $labels.vcenter}} is above 90%
+          summary: Disk space usage of vCSA {{ $labels.vcenter}} is above 90%
+        expr: vrops_vcenter_diskspace_usage_gigabytes / vrops_vcenter_diskspace_total_gigabytes
+          > 0.9
+        for: 15m
+        labels:
+          context: vcenter disk usage
+          meta: Disk space usage of vCSA {{ $labels.vcenter}} is above 90%
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VASAProvider(s)Disconnected
+        annotations:
+          description: VASA Provider disconnected from {{ $labels.vcenter}}.
+          summary: VASA Provider disconnected from {{ $labels.vcenter}}.
+        expr: vrops_vcenter_alert_info{alert_name="VASA Provider(s) disconnected"}
+        labels:
+          context: vasa provider
+          meta: VASA Provider disconnected from {{ $labels.vcenter}}.
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#vasaproviderdown
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VCenterHasMultipleGreyVMs
+        annotations:
+          description: vCenter {{ $labels.vcenter }} has multiple greyed out VMs for a
+            longer period. This alert is handled by TARS. If TARS fails, check and reload
+            these VMs.
+          summary: vCenter {{ $labels.vcenter }} has multiple greyed out VMs for a longer
+            period. This alert is handled by TARS. If TARS fails, check and reload these
+            VMs.
+        expr: |
+          count by(vcenter)
+          ((vrops_virtualmachine_health == -1)
+          and on(hostsystem) (vrops_hostsystem_runtime_powerstate{state="Powered On"})
+          and on(hostsystem) (vrops_hostsystem_runtime_connectionstate{state="connected"})
+          and on(hostsystem) (vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"})) > 0
+        for: 15m
+        labels:
+          context: Shadow VMs {{ $labels.vcenter }}
+          meta: vCenter {{ $labels.vcenter }} has multiple greyed out VMs for a longer
+            period. Check and reload these VMs.
+          playbook: docs/devops/alert/vcenter/#Inaccessible_Orphaned_Gray_instance_handling
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasVCenterHasMultipleGreyVMs
+        annotations:
+          description: vCenter {{ $labels.vcenter }} has multiple greyed out VMs for a
+            longer period. This alert is handled by TARS. If TARS fails, check and reload
+            these VMs.
+          summary: vCenter {{ $labels.vcenter }} has multiple greyed out VMs for a longer
+            period. This alert is handled by TARS. If TARS fails, check and reload these
+            VMs.
+        expr: |-
+          (count by(vcenter)
+          ((vrops_virtualmachine_health == -1)
+          and on(hostsystem) (vrops_hostsystem_runtime_powerstate{state="Powered On"})
+          and on(hostsystem) (vrops_hostsystem_runtime_connectionstate{state="connected"})
+          and on(hostsystem) (vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"})) > 0
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 15m
+        labels:
+          bedrock: "true"
+          context: Shadow VMs {{ $labels.vcenter }}
+          meta: vCenter {{ $labels.vcenter }} has multiple greyed out VMs for a longer
+            period. Check and reload these VMs.
+          playbook: docs/devops/alert/vcenter/#Inaccessible_Orphaned_Gray_instance_handling
+          service: compute
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-mgmt-b-0-alerts-virtualmachine.alerts
+  labels:
+    prometheus: vmware-vc-mgmt-b-0
+
+spec:
+  groups:
+    - name: virtualmachine.alerts
+      rules:
+      - alert: VMHasMemoryContention
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` has memory contention
+            due to memory compression, ballooning, or swapping. ({{ $labels.vcenter }},
+            {{ $labels.hostsystem }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` has memory contention
+            due to memory compression, ballooning, or swapping. ({{ $labels.vcenter }},
+            {{ $labels.hostsystem }})
+        expr: |
+          vrops_virtualmachine_alert_info{alert_name="Virtual machine has memory contention due to memory compression, ballooning, or swapping", vccluster=~".*management.*"}
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine `{{ $labels.virtualmachine }}` has memory contention due
+            to memory compression, ballooning, or swapping. ({{ $labels.vcenter }}, {{
+            $labels.hostsystem }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#vm_has_memory_contention
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VMHasDiskIOLatencyProblemCausedBySnapshots
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` has disk I/O latency
+            problem caused by snapshots. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` has disk I/O latency
+            problem caused by snapshots. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+        expr: |
+          vrops_virtualmachine_alert_info{alert_name="Virtual machine has disk I/O latency problem caused by snapshots", vccluster=~".*management.*"}
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine `{{ $labels.virtualmachine }}` has disk I/O latency problem
+            caused by snapshots. ({{ $labels.vcenter }}, {{ $labels.hostsystem }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#vm_has_disk_io_latency_problem_caused_by_snapshots
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VMHasCPUContentionDueToIOEvents
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` has CPU contention
+            due to long wait for I/O events. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` has CPU contention due
+            to long wait for I/O events. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+        expr: |
+          vrops_virtualmachine_alert_info{alert_name="Virtual machine has CPU contention due to long wait for I/O events", vccluster=~".*management.*"}
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine `{{ $labels.virtualmachine }}` has CPU contention due
+            to long wait for I/O events. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#vm_has_cpu_contention
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VMGuestFileSystemsRunningOutOfDiskSpace
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` guest file systems
+            are running out of disk space. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` guest file systems are
+            running out of disk space. ({{ $labels.vcenter }}, {{ $labels.hostsystem }})
+        expr: |
+          vrops_virtualmachine_guestfilesystem_storage_log_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_storage_autodeploy_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_storage_core_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_storage_dblog_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_storage_imagebuilder_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_storage_netdump_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_storage_seat_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_storage_updatemgr_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_boot_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_percentage{vccluster=~".*management.*"} > 80
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine `{{ $labels.virtualmachine }}` guest file systems are
+            running out of disk space. ({{ $labels.vcenter }}, {{ $labels.hostsystem }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#vm_guest_file_Systems_running_out_of_disk_space
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VMCPUAt100PercentForAnExtendedPeriodOfTime
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` CPU usage is at
+            100% for an extended period of time. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` CPU usage is at 100%
+            for an extended period of time. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+        expr: |
+          vrops_virtualmachine_alert_info{alert_name="Virtual machine CPU usage is at 100% for an extended period of time", vccluster=~".*management.*"}
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine {{ $labels.virtualmachine }} CPU usage is at 100% for
+            an extended period of time. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#vm_cpu_at_100_percent_for_an_extended_period_of_time
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VMInDRSClusterDemandingMoreCPUThanItsEntitlement
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` in a DRS cluster
+            is demanding more CPU than its entitlement. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` in a DRS cluster is
+            demanding more CPU than its entitlement. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+        expr: |
+          vrops_virtualmachine_alert_info{alert_name="Virtual machine in a DRS cluster is demanding more CPU than its entitlement", vccluster=~".*management.*"}
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine `{{ $labels.virtualmachine }}` in a DRS cluster is demanding
+            more CPU than its entitlement. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#vm_in_drs_cluster_demanding_more_cpu_than_its_entitlement
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VMHasSnapshotOlderThanOneWeek
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` has a snapshot older
+            than one week. ({{ $labels.vcenter }}, {{ $labels.hostsystem }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` has a snapshot older
+            than one week. ({{ $labels.vcenter }}, {{ $labels.hostsystem }})
+        expr: vrops_virtualmachine_disk_space_snapshot_age_days{vccluster=~".*management.*",
+          virtualmachine!~"jump.+"} > 7
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine `{{ $labels.virtualmachine }}` has a snapshot older than
+            one week. ({{ $labels.vcenter }}, {{ $labels.hostsystem }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VMHasCPUContentionDueToMemoryPageSwapping
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` experiencing high
+            swap wait. The host is overcommitted on memory. ({{ $labels.vcenter }}, {{
+            $labels.hostsystem }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` experiencing high swap
+            wait. The host is overcommitted on memory. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+        expr: |
+          vrops_virtualmachine_alert_info{alert_name="Virtual machine has CPU contention due to memory page swapping in the host", vccluster=~".*management.*"}
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine `{{ $labels.virtualmachine }}` experiencing high swap
+            wait. The host is overcommitted on memory. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: NSXTMgmtVMsOddDistribution
+        annotations:
+          description: Too many NSX-T VMs for the same cluster on {{ $labels.hostsystem
+            }}. Please distribute the VMs across different nodes. ({{ $labels.vcenter
+            }})
+          summary: Too many NSX-T VMs on {{ $labels.hostsystem }}. ({{ $labels.vcenter
+            }})
+        expr: |
+          count(label_replace(vrops_virtualmachine_cpu_usage_average_mhz{virtualmachine=~"nsx-.*"}, "nsx_clt", "$1", "virtualmachine", "nsx-.*(bb.*)")) by(nsx_clt, hostsystem, vcenter, vccluster) > 1
+        labels:
+          context: NSXTMgmtVMDistribution
+          dashboard: management-cluster-resources/management-cluster-resources?orgId=1&var-pod=All&var-clusters={{
+            $labels.vccluster }}&var-hosts={{ $labels.hostsystem }}
+          meta: Too many NSX-T VMs on {{ $labels.hostsystem }}. ({{ $labels.vcenter }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#nsxtmgmtvmsodddistribution
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTMgmtVMsOddDistributionSDRSAntiaffinity
+        annotations:
+          description: NSX-T VMs not part of SDRS anti-affinity rule  {{ $labels.rule_name
+            }}. Please distribute the VMs across different DS. ({{ $labels.vcenter }})
+          summary: NSX-T VMs not part of SDRS anti-affinity rule  {{ $labels.rule_name
+            }}. ({{ $labels.vcenter }})
+        expr: |
+          count  (vrops_storagepod_config_sdrsconfig_vmstorageantiaffinityrules{storagepod!~"SDRS_MGMT_BB\\d+"}) by (rule_name, vccluster, vcenter) != 3
+        labels:
+          context: NSXTMgmtVMsOddDistributionSDRS
+          dashboard: management-cluster-resources/management-cluster-resources?orgId=1&var-pod=All&var-clusters={{
+            $labels.vccluster }}
+          meta: NSX-T VMs not part of SDRS anti-affinity rule  {{ $labels.rule_name }}.
+            ({{ $labels.vcenter }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#nsxtmgmtvmsodddistributionsdrs
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VASAVMHighCPUUtilization
+        annotations:
+          description: VASA VM has >90% CPU Utilization for at least one hour. {{ $labels.virtualmachine
+            }}. {{ $labels.vccluster }}. {{ $labels.hostsystem }}. ({{ $labels.vcenter
+            }})
+          summary: High VASA VM CPU Utilization. {{ $labels.virtualmachine }}. {{ $labels.vccluster
+            }}. {{ $labels.hostsystem }}. ({{ $labels.vcenter }})
+        expr: vrops_virtualmachine_cpu_usage_ratio{virtualmachine=~"vasa.*"} > 90
+        for: 1h
+        labels:
+          context: VASAUtilization
+          meta: VASA VM has >90% CPU Utilization for at least one hour. {{ $labels.virtualmachine
+            }}. {{ $labels.vccluster }}. {{ $labels.hostsystem }}. ({{ $labels.vcenter
+            }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-mgmt-b-0-alerts-vrops.alerts
+  labels:
+    prometheus: vmware-vc-mgmt-b-0
+
+spec:
+  groups:
+    - name: vrops.alerts
+      rules:
+      - alert: VropsAPIDown
+        annotations:
+          description: "All collectors of the vrops-exporter report HTTP status codes
+            above 500, \nwhich indicates that vrops is reporting internal server errors
+            or is unreachable. \nCheck if vrops is running and healthy.\n"
+          summary: '`https://{{ $labels.target }}` API is down.'
+        expr: "(sum by (target) (vrops_api_response{collector=~\"vc.*\"}) / \ncount by
+          (target) (vrops_api_response{collector=~\"vc.*\"}) > 500) \n"
+        for: 10m
+        labels:
+          context: vrops
+          dashboard: vrops-exporter-status
+          meta: '`https://{{ $labels.target }}` API is down.'
+          playbook: docs/devops/alert/vcenter/vrops#vrops_api_down
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VropsAPIDown
+        annotations:
+          description: |
+            All collectors of the vrops-exporter report HTTP status codes above 500,
+            which indicates that vrops is reporting internal server errors or is unreachable.
+            Check if vrops is running and healthy.
+          summary: '`https://{{ $labels.target }}` API is down.'
+        expr: "(sum by (target) (vrops_api_response{collector=~\"vc.*\"}) / \ncount by
+          (target) (vrops_api_response{collector=~\"vc.*\"}) > 500)                                                                                                                     \n"
+        for: 90m
+        labels:
+          context: vrops
+          dashboard: vrops-exporter-status
+          meta: '`https://{{ $labels.target }}` API is down.'
+          playbook: docs/devops/alert/vcenter/vrops#vrops_api_down
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: VropsAPIDownEntirely
+        annotations:
+          description: |
+            Exporters can not connect to vrops anymore. Most likely the VM is stuck.
+            If this alert fires, complete vmware-montioring is down in Prometheus.
+            Ensure vrops is running and healthy.
+          meta: Vrops API is down. All collectors are not reporting anymore.
+        expr: |
+          absent(vrops_api_response)
+        for: 10m
+        labels:
+          context: vrops
+          dashboard: vrops-exporter-status
+          meta: Vrops API is down. All collectors are not reporting anymore.
+          playbook: docs/devops/alert/vcenter/vrops#vrops_api_down_entirely
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VropsAPIDownEntirely
+        annotations:
+          description: |
+            Exporters can not connect to vrops anymore. Most likely the VM is stuck.
+            If this alert fires, complete vmware-montioring is down in Prometheus.
+            Ensure vrops is running and healthy.
+          meta: Vrops API is down. All collectors are not reporting anymore.
+        expr: |
+          absent(vrops_api_response)
+        for: 90m
+        labels:
+          context: vrops
+          dashboard: vrops-exporter-status
+          meta: Vrops API is down. All collectors are not reporting anymore.
+          playbook: docs/devops/alert/vcenter/vrops#vrops_api_down_entirely
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: VropsTokenAcquisitionFailed
+        annotations:
+          description: |
+            A failed token acquisition for this vrops. This indicates
+            that the vrops system is not responding and current
+            monitoring data cannot be generated.
+          summary: Token acquisition failed for `https://{{ $labels.target }}`
+        expr: vrops_api_response{get_request="token"} >= 500
+        for: 15m
+        labels:
+          context: vrops
+          dashboard: vrops-exporter-status
+          meta: Token acquisition failed for `https://{{ $labels.target }}`
+          playbook: docs/devops/alert/vcenter/vrops#vrops_api_down
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VROpsDiskpaceUsage
+        annotations:
+          description: |
+            {{ $labels.virtualmachine }} disk almost full with over 90% usage.
+            Please increase disk size.
+          summary: '{{ $labels.virtualmachine }} disk almost full with over 90% usage.'
+        expr: vrops_virtualmachine_guestfilesystem_storage_db_percentage{virtualmachine=~"vrops.*-vc-.+"}
+          > 90
+        for: 20m
+        labels:
+          context: vrops
+          dashboard: vrops-instances-overview
+          meta: '{{ $labels.virtualmachine }} disk almost full with over 90% usage.'
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VROpsVCenterAdapterNotReceivingData
+        annotations:
+          description: The vCenter adapter for https://vrops-{{ $labels.vcenter }} is
+            not receiving data.
+          summary: The vCenter adapter for https://vrops-{{ $labels.vcenter }} is not
+            receiving data.
+        expr: vrops_vcenter_alert_info{alert_name="Adapter instance is not receiving data"}
+        for: 15m
+        labels:
+          context: vrops
+          meta: The vCenter adapter for https://vrops-{{ $labels.vcenter }} is not receiving
+            data.
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/vrops#revalidatecertificate
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VROpsNSXTAdapterNotReceivingData
+        annotations:
+          description: vROPs NSX-T adapter is not receiving data for `{{ $labels.nsxt_adapter
+            }}`. https://{{ $labels.target }}
+          summary: vROPs NSX-T adapter is not receiving data for `{{ $labels.nsxt_adapter
+            }}`. https://{{ $labels.target }}
+        expr: vrops_nsxt_adapter_alert_info{alert_name="Adapter instance is not receiving
+          data"}
+        for: 15m
+        labels:
+          context: vrops
+          meta: vROPs NSX-T adapter is not receiving data for `{{ $labels.nsxt_adapter
+            }}`. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#vrops-nsx-t-adapter-is-not-receiving-data-vropsnsxtadapternotreceivingdata
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VROpsVCenterObjectsNotReceivingData
+        annotations:
+          description: vROPs vCenter adapter for https://vrops-{{ $labels.vcenter }} is
+            not receiving data for some objects.
+          summary: vROPs vCenter adapter for https://vrops-{{ $labels.vcenter }} is not
+            receiving data for some objects.
+        expr: vrops_vcenter_alert_info{alert_name="Objects are not receiving data from
+          adapter instance"}
+        labels:
+          meta: vROPs vCenter adapter for https://vrops-{{ $labels.vcenter }} is not receiving
+            data for some objects.
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/vrops#revalidatecertificate
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-a-0-alerts-datastore.alerts
+  labels:
+    prometheus: vmware-vc-a-0
+
+spec:
+  groups:
+    - name: datastore.alerts
+      rules:
+      - alert: EphemeralDataStoreCapacity
+        annotations:
+          description: Eph Datastore {{ $labels.datastore }} utilization > 85%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          summary: Eph Datastore {{ $labels.datastore }} utilization > 85%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+        expr: |
+          vrops_datastore_diskspace_total_usage_gigabytes{type="ephemeral"} / vrops_datastore_diskspace_capacity_gigabytes >= 0.85
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          dashboard: vcenter-datastore-utilization
+          meta: Eph Datastore {{ $labels.datastore }} utilization > 85%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          playbook: docs/support/playbook/datastore/datastorediskusagealarm
+          service: storage
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: EphemeralDataStoreCapacity
+        annotations:
+          description: Eph Datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          summary: Eph Datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+        expr: |
+          vrops_datastore_diskspace_total_usage_gigabytes{type="ephemeral"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.9
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          dashboard: vcenter-datastore-utilization
+          meta: Eph Datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          playbook: docs/support/playbook/datastore/datastorediskusagealarm
+          service: storage
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: AverageVmfsDataStoreCapacity
+        annotations:
+          description: Average utilization for `{{ $labels.type }}` Datastores per vCenter
+            is above 70%. ({{ $labels.vcenter }})
+          summary: Average utilization for `{{ $labels.type }}` Datastores per vCenter
+            is above 70%. ({{ $labels.vcenter }})
+        expr: |
+          avg by (type, vcenter) (vrops_datastore_diskspace_total_usage_gigabytes{type=~"vmfs_p_ssd|vmfs_s_hdd"} / vrops_datastore_diskspace_capacity_gigabytes) > 0.85
+        for: 20m
+        labels:
+          context: '{{ $labels.type }} storage'
+          dashboard: vcenter-datastore-utilization
+          meta: Average utilization for `{{ $labels.type }}` Datastores per vCenter is
+            above 70%. ({{ $labels.vcenter }})
+          playbook: docs/support/playbook/storage/new_storage_lun_request
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: DataStoreCapacity
+        annotations:
+          description: '{{ $labels.type }} datastore {{ $labels.datastore }} utilization
+            > 80%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
+          summary: '{{ $labels.type }} datastore {{ $labels.datastore }} utilization >
+            80%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
+        expr: |
+          vrops_datastore_diskspace_total_usage_gigabytes{type!~"ephemeral|vmfs.+|nfs", datastore!~".+swap"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.8
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          dashboard: vcenter-datastore-utilization
+          meta: '{{ $labels.type }} datastore {{ $labels.datastore }} utilization > 80%.
+            ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
+          playbook: docs/support/playbook/datastore/datastorediskusagealarm
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: DataStoreCapacity
+        annotations:
+          description: '{{ $labels.type }} datastore {{ $labels.datastore }} utilization
+            > 90%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
+          summary: '{{ $labels.type }} datastore {{ $labels.datastore }} utilization >
+            90%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
+        expr: |
+          vrops_datastore_diskspace_total_usage_gigabytes{type!~"ephemeral|vmfs.+|nfs", datastore!~".+swap"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.9
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          dashboard: vcenter-datastore-utilization
+          meta: '{{ $labels.type }} datastore {{ $labels.datastore }} utilization > 90%.
+            ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
+          playbook: docs/support/playbook/datastore/datastorediskusagealarm
+          service: storage
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: SwapDataStoreUsageWithoutVMs
+        annotations:
+          description: NVMe swap datastore {{ $labels.datastore }} is utilized without
+            associated VMs. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: NVMe swap datastore {{ $labels.datastore }} is utilized without associated
+            VMs. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: |
+          vrops_datastore_diskspace_total_usage_gigabytes{datastore=~".*-swap"} > 10 and vrops_datastore_summary_total_number_vms == 0 unless on (datastore) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "datastore", "$1-swap", "hostsystem", "(node...-bb...).*")
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          meta: NVMe swap datastore {{ $labels.datastore }} is utilized without associated
+            VMs. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#swap-files-exist-on-local-ds-without-running-vms
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NVMeSwapDatastoreMissing
+        annotations:
+          description: |-
+            NVMe swap datastore on `{{ $labels.hostsystem }}` is missing. Model is _{{$labels.hardware_model}}_ and located in cluster *{{ $labels.vccluster }}*
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            NVMe swap datastore on `{{ $labels.hostsystem }}` is missing. Model is _{{$labels.hardware_model}}_ and located in cluster *{{ $labels.vccluster }}*
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_hostsystem_hardware_model{vccluster=~"productionbb\\d+", hardware_model!~"Cisco Systems Inc.+"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          unless on (hostsystem) (label_replace(label_join(vrops_datastore_summary_datastore_accessible{type="NVMe"}, "hostsystem", "", "datastore", "vcenter"), "hostsystem", "$1$2", "hostsystem", "(.+)-swapvc-[a-z]-\\d+(.+)")
+          or vrops_hostsystem_summary_custom_tag_nvme{summary_custom_tag_nvme="false"})
+        for: 5m
+        labels:
+          context: '{{ $labels.hostsystem }}'
+          meta: |-
+            NVMe swap datastore on `{{ $labels.hostsystem }}` is missing. Model is _{{$labels.hardware_model}}_ and located in cluster *{{ $labels.vccluster }}*
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          playbook: docs/support/playbook/datastore/nvmeswapdatastoremissing
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: DatastoreDisconnectedWithVmsOnIt
+        annotations:
+          description: Datastore {{ $labels.datastore }} is disconnected and has virtual
+            machines on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: Datastore {{ $labels.datastore }} is disconnected and has virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: |
+          (label_replace(vrops_datastore_summary_total_number_vms, "hostsystem", "$1", "datastore", "(node[0-9]{3}-[^-]*).*") > 0 and on(datastore) vrops_datastore_summary_datastore_accessible{state="PoweredOff",type!="local"}) unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          meta: Datastore {{ $labels.datastore }} is disconnected and has virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#datastoredisconnectedwithvmsonit
+          service: storage
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: IaasDatastoreDisconnectedWithVmsOnIt
+        annotations:
+          description: Datastore {{ $labels.datastore }} is disconnected and has virtual
+            machines on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: Datastore {{ $labels.datastore }} is disconnected and has virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: |-
+          ((label_replace(vrops_datastore_summary_total_number_vms, "hostsystem", "$1", "datastore", "(node[0-9]{3}-[^-]*).*") > 0 and on(datastore) vrops_datastore_summary_datastore_accessible{state="PoweredOff",type!="local"}) unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 20m
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.datastore }}'
+          meta: Datastore {{ $labels.datastore }} is disconnected and has virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#datastoredisconnectedwithvmsonit
+          service: storage
+          severity: critical
+          support_group: iaas_support
+          tier: vmware
+      - alert: DatastoreDisconnectedWithoutVmsOnIt
+        annotations:
+          description: Datastore {{ $labels.datastore }} is disconnected without virtual
+            machines on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: Datastore {{ $labels.datastore }} is disconnected without virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: |
+          (label_replace(vrops_datastore_summary_total_number_vms, "hostsystem", "$1", "datastore", "(node[0-9]{3}-[^-]*).*") == 0 and on(datastore) vrops_datastore_summary_datastore_accessible{state="PoweredOff",type!="local"}) unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          meta: Datastore {{ $labels.datastore }} is disconnected without virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#datastoredisconnectedwithoutvmsonit
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasDatastoreDisconnectedWithoutVmsOnIt
+        annotations:
+          description: Datastore {{ $labels.datastore }} is disconnected without virtual
+            machines on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: Datastore {{ $labels.datastore }} is disconnected without virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: |-
+          ((label_replace(vrops_datastore_summary_total_number_vms, "hostsystem", "$1", "datastore", "(node[0-9]{3}-[^-]*).*") == 0 and on(datastore) vrops_datastore_summary_datastore_accessible{state="PoweredOff",type!="local"}) unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 20m
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.datastore }}'
+          meta: Datastore {{ $labels.datastore }} is disconnected without virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#datastoredisconnectedwithoutvmsonit
+          service: storage
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: DatastoreHasLostConnectivityToAStorageDevice
+        annotations:
+          description: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has lost connectivity to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has lost connectivity to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          label_replace(vrops_datastore_alert_info{alert_name="Datastore has lost connectivity to a storage device"}, "hostsystem", "$1", "datastore", "(node.*)(-.*)") unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+        labels:
+          meta: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has lost connectivity to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#datastorehashoststhathavelostredundantpathsanddatastorehaslostconnectivitytoastoragedevice
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasDatastoreHasLostConnectivityToAStorageDevice
+        annotations:
+          description: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has lost connectivity to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has lost connectivity to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |-
+          (label_replace(vrops_datastore_alert_info{alert_name="Datastore has lost connectivity to a storage device"}, "hostsystem", "$1", "datastore", "(node.*)(-.*)") unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          meta: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has lost connectivity to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#datastorehashoststhathavelostredundantpathsanddatastorehaslostconnectivitytoastoragedevice
+          service: storage
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: DatastoreHasHostsThatHaveLostRedundantPathsToAStorageDevice
+        annotations:
+          description: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has hosts that have lost redundant paths to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has hosts that have lost redundant paths to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          label_replace(vrops_datastore_alert_info{alert_name="Datastore has one or more hosts that have lost redundant paths to a storage device"}, "hostsystem", "$1", "datastore", "(node.*)(-.*)") unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+        labels:
+          meta: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has hosts that have lost redundant paths to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#datastorehashoststhathavelostredundantpathsanddatastorehaslostconnectivitytoastoragedevice
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasDatastoreHasHostsThatHaveLostRedundantPathsToAStorageDevice
+        annotations:
+          description: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has hosts that have lost redundant paths to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has hosts that have lost redundant paths to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |-
+          (label_replace(vrops_datastore_alert_info{alert_name="Datastore has one or more hosts that have lost redundant paths to a storage device"}, "hostsystem", "$1", "datastore", "(node.*)(-.*)") unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          meta: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has hosts that have lost redundant paths to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#datastorehashoststhathavelostredundantpathsanddatastorehaslostconnectivitytoastoragedevice
+          service: storage
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: SDRSClusterCapacity
+        annotations:
+          description: DataStore Cluster {{ $labels.storagepod }} utilization > 80%. ({{
+            $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: DataStore Cluster {{ $labels.storagepod }} utilization > 80%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+        expr: |
+          vrops_storagepod_capacity_available_space / vrops_storagepod_capacity_total * 100 <= 20
+        for: 20m
+        labels:
+          context: '{{ $labels.storagepod }}'
+          dashboard: vcenter-datastore-utilization
+          meta: DataStore Cluster {{ $labels.storagepod }} utilization > 80%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          playbook: docs/support/playbook/datastore/datastorediskusagealarm
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: SDRSClusterCapacity
+        annotations:
+          description: DataStore Cluster {{ $labels.storagepod }} utilization > 90%. ({{
+            $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: DataStore Cluster {{ $labels.storagepod }} utilization > 90%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+        expr: |
+          vrops_storagepod_capacity_available_space / vrops_storagepod_capacity_total * 100 <= 10
+        for: 20m
+        labels:
+          context: '{{ $labels.storagepod }}'
+          dashboard: vcenter-datastore-utilization
+          meta: DataStore Cluster {{ $labels.storagepod }} utilization > 90%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          playbook: docs/support/playbook/datastore/datastorediskusagealarm
+          service: storage
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: NVMeDatastoreNotAccessible
+        annotations:
+          description: Datastore {{ $labels.datastore }} is not accessible. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          summary: Datastore {{ $labels.datastore }} is not accessible. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+        expr: |
+          vrops_datastore_summary_datastore_accessible{type='NVMe'} == 0
+        for: 5m
+        labels:
+          context: '{{ $labels.datastore }}'
+          meta: Datastore {{ $labels.datastore }} is not accessible. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          service: storage
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: EphemeralDatastoreNotPartOfSDRSCluster
+        annotations:
+          description: Eph Datastore {{ $labels.datastore }} is not a part of SDRS Cluster.
+            ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: Eph Datastore {{ $labels.datastore }} is not a part of SDRS Cluster.
+            ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: |
+          vrops_datastore_summary_datastore_accessible{type="ephemeral", storagepod=~"none|None|NONE", datastore=~"eph.*"} > 0
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          meta: Eph Datastore {{ $labels.datastore }} is not a part of SDRS cluster. ({{
+            $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#ephemeraldatastorenotpartofsdrscluster
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: EphemeralDatastorePartOfIncorrectSDRSCluster
+        annotations:
+          description: Eph Datastore {{ $labels.datastore }} is not a part of correct
+            SDRS Cluster. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: Eph Datastore {{ $labels.datastore }} is not a part of correct SDRS
+            Cluster. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: |
+          (vrops_datastore_summary_datastore_accessible{type="ephemeral", storagepod=~".*hgb.*", datastore=~"eph.*hga"} or vrops_datastore_summary_datastore_accessible{type="ephemeral", storagepod=~".*hga.*", datastore=~"eph.*hgb"}) > 0
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          meta: Eph Datastore {{ $labels.datastore }} is not a part of correct SDRS cluster.
+            ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#ephemeraldatastorepartofincorrectsdrscluster
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: CinderTagMissingForDatastoreSSD
+        annotations:
+          description: |-
+            There is no Cinder tag present for the `{{ $labels.datastore }}` datastore in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            There is no Cinder tag present for the `{{ $labels.datastore }}` datastore in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_datastore_summary_tag{type="vmfs_p_ssd", summary_tag="none"}
+          unless on (datastore) vrops_datastore_summary_custom_tag_cinder_state{summary_custom_tag_cinder_state="reserved"}
+        for: 1h
+        labels:
+          meta: |-
+            There is no Cinder tag present for the `{{ $labels.datastore }}` datastore in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          playbook: docs/support/playbook/cinder/cinder-tag-missing
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: CinderTagMissingForDatastoreHDD
+        annotations:
+          description: |-
+            There is no Cinder tag present for the `{{ $labels.datastore }}` datastore in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            There is no Cinder tag present for the `{{ $labels.datastore }}` datastore in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_datastore_summary_tag{type="vmfs_s_hdd", summary_tag="none"}
+          unless on (datastore) vrops_datastore_summary_custom_tag_cinder_state{summary_custom_tag_cinder_state="reserved"}
+        for: 1h
+        labels:
+          meta: |-
+            There is no Cinder tag present for the `{{ $labels.datastore }}` datastore in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          playbook: docs/support/playbook/cinder/cinder-tag-missing
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: CinderTagAddedForReservedDatastore
+        annotations:
+          description: |-
+            The Cinder state is reserved but the Cinder tag still exists for the `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The Cinder state is reserved but the Cinder tag still exists for the `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_datastore_summary_custom_tag_cinder_state{type=~"(vmfs_s_hdd|vmfs_p_ssd)", summary_custom_tag_cinder_state="reserved"} > 0
+          and on (datastore) vrops_datastore_summary_tag{tag_cinder=~"cinder|slow"}
+        for: 1h
+        labels:
+          meta: |-
+            The Cinder state is reserved but the Cinder tag still exists for the `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          playbook: docs/support/playbook/cinder/cinder-tag-added
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VMFSDatastoreHostcountMismatch
+        annotations:
+          description: |-
+            The `{{ $labels.datastore }}` VMFS datastore is not connected to all production ESXi hosts in *{{ $labels.vcenter }}* vCenter.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The `{{ $labels.datastore }}` VMFS datastore is not connected to all production ESXi hosts in *{{ $labels.vcenter }}* vCenter.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_datastore_hostcount{type=~"(vmfs_s_hdd|vmfs_p_ssd)"} < on (vcenter) group_left
+          count by (vcenter) (vrops_hostsystem_runtime_connectionstate{state="connected", vccluster=~"productionbb\\d+"}
+          unless on (hostsystem) (vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}))
+        for: 60m
+        labels:
+          meta: |-
+            The `{{ $labels.datastore }}` VMFS datastore is not connected to all production ESXi hosts in *{{ $labels.vcenter }}* vCenter.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          playbook: docs/devops/alert/vcenter/#vmfsdatastorehostcountmismatch
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NFSDatastoreHostcountMismatch
+        annotations:
+          description: |-
+            The `{{ $labels.datastore }}` NFS datastore is not connected to all production ESXi hosts in *{{ $labels.vcenter }}* vCenter.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The `{{ $labels.datastore }}` NFS datastore is not connected to all production ESXi hosts in *{{ $labels.vcenter }}* vCenter.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_datastore_hostcount{type="nfs"} < on (vcenter) group_left
+          count by (vcenter) (vrops_hostsystem_runtime_connectionstate{state="connected", vccluster=~"productionbb\\d+"})
+        for: 60m
+        labels:
+          meta: |-
+            The `{{ $labels.datastore }}` NFS datastore is not connected to all production ESXi hosts in *{{ $labels.vcenter }}* vCenter.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          playbook: docs/devops/alert/vcenter/#nfsdatastorehostcountmismatch
+          service: storage
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: NFSDatastoreCinderAggregateIDNotSet
+        annotations:
+          description: |-
+            cinder_aggregate_id is not set for the `{{ $labels.datastore }}` NFS datastore in *{{ $labels.datacenter }}* availability zone.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            cinder_aggregate_id is not set for the `{{ $labels.datastore }}` NFS datastore in *{{ $labels.datacenter }}* availability zone.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_datastore_summary_datastore_accessible{type="nfs"}
+          unless on(datastore) vrops_datastore_summary_custom_tag_cinder_aggregate_id{type="nfs", summary_custom_tag_cinder_aggregate_id!=""}
+        for: 1h
+        labels:
+          meta: |-
+            cinder_aggregate_id is not set for the `{{ $labels.datastore }}` NFS datastore in *{{ $labels.datacenter }}* availability zone.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          playbook: docs/support/playbook/cinder/cinder-fcd-operations/#nfsdatastorecinderaggregateidnotset
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-a-0-alerts-host.alerts
+  labels:
+    prometheus: vmware-vc-a-0
+
+spec:
+  groups:
+    - name: host.alerts
+      rules:
+      - alert: HostWithRunningVMsNotResponding
+        annotations:
+          description: Host {{ $labels.hostsystem }} with running VMs not responding.
+            ({{ $labels.vcenter }}, {{ $labels.vccluster }})
+          summary: Host {{ $labels.hostsystem }} with running VMs not responding. ({{
+            $labels.vcenter }}, {{ $labels.vccluster }})
+        expr: |
+          avg_over_time(vrops_hostsystem_runtime_connectionstate{state="notResponding"}[5m])
+          and on (hostsystem) avg_over_time(vrops_hostsystem_runtime_powerstate{state!="Powered Off"}[5m])
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"}
+          and on (hostsystem) count(vrops_virtualmachine_runtime_powerstate{virtualmachine!~"vCLS.*", state!="Powered Off"}) by (hostsystem) > 0
+        for: 5m
+        labels:
+          context: ESXi not responding
+          dashboard: esxi-host-disconnected/esxi-host-disconnected?&var-host={{ $labels.hostsystem
+            }}
+          meta: Host {{ $labels.hostsystem }} with running VMs not responding. ({{ $labels.vcenter
+            }}, {{ $labels.vccluster }})
+          playbook: docs/devops/alert/vcenter/#hostwithrunningvmsnotresponding
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostWithRunningVMsNotResponding
+        annotations:
+          description: Host {{ $labels.hostsystem }} with running VMs not responding.
+            ({{ $labels.vcenter }}, {{ $labels.vccluster }})
+          summary: Host {{ $labels.hostsystem }} with running VMs not responding. ({{
+            $labels.vcenter }}, {{ $labels.vccluster }})
+        expr: |-
+          (avg_over_time(vrops_hostsystem_runtime_connectionstate{state="notResponding"}[5m])
+          and on (hostsystem) avg_over_time(vrops_hostsystem_runtime_powerstate{state!="Powered Off"}[5m])
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"}
+          and on (hostsystem) count(vrops_virtualmachine_runtime_powerstate{virtualmachine!~"vCLS.*", state!="Powered Off"}) by (hostsystem) > 0
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 5m
+        labels:
+          bedrock: "true"
+          context: ESXi not responding
+          dashboard: esxi-host-disconnected/esxi-host-disconnected?&var-host={{ $labels.hostsystem
+            }}
+          meta: Host {{ $labels.hostsystem }} with running VMs not responding. ({{ $labels.vcenter
+            }}, {{ $labels.vccluster }})
+          playbook: docs/devops/alert/vcenter/#hostwithrunningvmsnotresponding
+          service: compute
+          severity: critical
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostNotResponding
+        annotations:
+          description: Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter
+            }}, {{ $labels.vccluster }})
+          summary: Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter }},
+            {{ $labels.vccluster }})
+        expr: |
+          vrops_hostsystem_summary_running_vms_number == 0 and
+          on (hostsystem) vrops_hostsystem_runtime_connectionstate{state="notResponding"} and
+          on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"} and
+          on (hostsystem) vrops_hostsystem_runtime_powerstate{state!="Powered Off"}
+        labels:
+          context: ESXi not responding
+          dashboard: esxi-host-disconnected/esxi-host-disconnected?&var-host={{ $labels.hostsystem
+            }}
+          meta: Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter }},
+            {{ $labels.vccluster }})
+          playbook: docs/devops/alert/vcenter/#hostnotresponding
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostNotResponding
+        annotations:
+          description: Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter
+            }}, {{ $labels.vccluster }})
+          summary: Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter }},
+            {{ $labels.vccluster }})
+        expr: |-
+          (vrops_hostsystem_summary_running_vms_number == 0 and
+          on (hostsystem) vrops_hostsystem_runtime_connectionstate{state="notResponding"} and
+          on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"} and
+          on (hostsystem) vrops_hostsystem_runtime_powerstate{state!="Powered Off"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: ESXi not responding
+          dashboard: esxi-host-disconnected/esxi-host-disconnected?&var-host={{ $labels.hostsystem
+            }}
+          meta: Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter }},
+            {{ $labels.vccluster }})
+          playbook: docs/devops/alert/vcenter/#hostnotresponding
+          service: compute
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: VMsOnFailoverHost
+        annotations:
+          description: Failover Host {{ $labels.hostsystem }} has Virtual Machines on
+            it. Free up the host. ({{ $labels.vcenter }}, {{ $labels.vccluster }})
+          summary: Failover Host {{ $labels.hostsystem }} has Virtual Machines on it.
+            ({{ $labels.vcenter }}, {{ $labels.vccluster }})
+        expr: |
+          vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost == 1
+          and on (hostsystem) count(vrops_virtualmachine_runtime_powerstate{virtualmachine!~"vCLS.*", state="Powered On"}) by (hostsystem) > 0
+        for: 10m
+        labels:
+          context: Failover host
+          meta: Failover Host {{ $labels.hostsystem }} has Virtual Machines on it. ({{
+            $labels.vcenter }}, {{ $labels.vccluster }})
+          playbook: docs/devops/alert/vcenter/#vmsonfailoverhost
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: IaasVMsOnFailoverHost
+        annotations:
+          description: Failover Host {{ $labels.hostsystem }} has Virtual Machines on
+            it. Free up the host. ({{ $labels.vcenter }}, {{ $labels.vccluster }})
+          summary: Failover Host {{ $labels.hostsystem }} has Virtual Machines on it.
+            ({{ $labels.vcenter }}, {{ $labels.vccluster }})
+        expr: |-
+          (vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost == 1
+          and on (hostsystem) count(vrops_virtualmachine_runtime_powerstate{virtualmachine!~"vCLS.*", state="Powered On"}) by (hostsystem) > 0
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 10m
+        labels:
+          bedrock: "true"
+          context: Failover host
+          meta: Failover Host {{ $labels.hostsystem }} has Virtual Machines on it. ({{
+            $labels.vcenter }}, {{ $labels.vccluster }})
+          playbook: docs/devops/alert/vcenter/#vmsonfailoverhost
+          service: compute
+          severity: critical
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostHasLostRedundantConnectivityToDVPort
+        annotations:
+          description: Host `{{ $labels.hostsystem }}` has lost redundant connectivity
+            to a dvPort. ({{ $labels.vcenter }}).
+          summary: Host `{{ $labels.hostsystem }}` has lost redundant connectivity to
+            a dvPort. ({{ $labels.vcenter }}).
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="The host has lost redundant connectivity to a dvPort"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        labels:
+          context: '{{ $labels.hostsystem }} dvPort connection'
+          meta: Host `{{ $labels.hostsystem }}` has lost redundant connectivity to a dvPort.
+            ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#host_has_lost_connectivity_to_a_dv_port
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostHasLostRedundantConnectivityToDVPort
+        annotations:
+          description: Host `{{ $labels.hostsystem }}` has lost redundant connectivity
+            to a dvPort. ({{ $labels.vcenter }}).
+          summary: Host `{{ $labels.hostsystem }}` has lost redundant connectivity to
+            a dvPort. ({{ $labels.vcenter }}).
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="The host has lost redundant connectivity to a dvPort"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} dvPort connection'
+          meta: Host `{{ $labels.hostsystem }}` has lost redundant connectivity to a dvPort.
+            ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#host_has_lost_connectivity_to_a_dv_port
+          service: compute
+          severity: info
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostNicDown
+        annotations:
+          description: '`{{ $labels.hostsystem }}` has detected a link status down on
+            a physical NIC. ({{ $labels.vcenter }}).'
+          summary: '`{{ $labels.hostsystem }}` has detected a link status down on a physical
+            NIC. ({{ $labels.vcenter }}).'
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="ESXi host has detected a link status down on a physical NIC"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        for: 20m
+        labels:
+          context: '{{ $labels.hostsystem }} network connection'
+          meta: '`{{ $labels.hostsystem }}` has detected a link status down on a physical
+            NIC. ({{ $labels.vcenter }}).'
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hostnicdown
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostNicDown
+        annotations:
+          description: '`{{ $labels.hostsystem }}` has detected a link status down on
+            a physical NIC. ({{ $labels.vcenter }}).'
+          summary: '`{{ $labels.hostsystem }}` has detected a link status down on a physical
+            NIC. ({{ $labels.vcenter }}).'
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="ESXi host has detected a link status down on a physical NIC"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 20m
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} network connection'
+          meta: '`{{ $labels.hostsystem }}` has detected a link status down on a physical
+            NIC. ({{ $labels.vcenter }}).'
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hostnicdown
+          service: compute
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostHasLostConnectionToVCenterServer
+        annotations:
+          description: '`{{ $labels.hostsystem }}` has been unexpectedly disconnected
+            from vCenter Server {{ $labels.vcenter }}.'
+          summary: '`{{ $labels.hostsystem }}` has been unexpectedly disconnected from
+            vCenter Server {{ $labels.vcenter }}.'
+        expr: |
+          vrops_hostsystem_runtime_connectionstate{state="disconnected"} AND on (hostsystem)
+          vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"} AND on (hostsystem)
+          vrops_hostsystem_runtime_powerstate{state!="Standby"}
+        labels:
+          context: '{{ $labels.hostsystem }} vCenter connection'
+          meta: '`{{ $labels.hostsystem }}` has been unexpectedly disconnected from vCenter
+            Server {{ $labels.vcenter }}.'
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hosthaslostconnectiontovcenterserver
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostHasLostConnectionToVCenterServer
+        annotations:
+          description: '`{{ $labels.hostsystem }}` has been unexpectedly disconnected
+            from vCenter Server {{ $labels.vcenter }}.'
+          summary: '`{{ $labels.hostsystem }}` has been unexpectedly disconnected from
+            vCenter Server {{ $labels.vcenter }}.'
+        expr: |-
+          (vrops_hostsystem_runtime_connectionstate{state="disconnected"} AND on (hostsystem)
+          vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"} AND on (hostsystem)
+          vrops_hostsystem_runtime_powerstate{state!="Standby"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} vCenter connection'
+          meta: '`{{ $labels.hostsystem }}` has been unexpectedly disconnected from vCenter
+            Server {{ $labels.vcenter }}.'
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hosthaslostconnectiontovcenterserver
+          service: compute
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostHasLostConnectivityToPhysicalNetwork
+        annotations:
+          description: Host `{{ $labels.hostsystem }}` has lost connectivity to physical
+            network. ({{ $labels.vcenter }}).
+          summary: Host `{{ $labels.hostsystem }}` has lost connectivity to physical network.
+            ({{ $labels.vcenter }}).
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="The host has lost connectivity to physical network"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        labels:
+          context: '{{ $labels.hostsystem }} network connection'
+          meta: Host `{{ $labels.hostsystem }}` has lost connectivity to physical network.
+            ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#host_has_lost_connectivity_to_physical_network
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostHasLostConnectivityToPhysicalNetwork
+        annotations:
+          description: Host `{{ $labels.hostsystem }}` has lost connectivity to physical
+            network. ({{ $labels.vcenter }}).
+          summary: Host `{{ $labels.hostsystem }}` has lost connectivity to physical network.
+            ({{ $labels.vcenter }}).
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="The host has lost connectivity to physical network"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} network connection'
+          meta: Host `{{ $labels.hostsystem }}` has lost connectivity to physical network.
+            ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#host_has_lost_connectivity_to_physical_network
+          service: compute
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: HADetectedAPossibleHostFailure-testing
+        annotations:
+          description: vSphere High Availability (HA) has detected a possible host failure
+            for `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+          summary: vSphere High Availability (HA) has detected a possible host failure
+            for `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) has detected a possible host failure"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{vccluster!~".*controlplane-swift"}
+        labels:
+          context: '{{ $labels.hostsystem }} failure'
+          meta: vSphere High Availability (HA) has detected a possible host failure for
+            `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hadetectedapossiblehostfailure
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: HADetectedAPossibleHostFailure
+        annotations:
+          description: vSphere High Availability (HA) has detected a possible host failure
+            for `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+          summary: vSphere High Availability (HA) has detected a possible host failure
+            for `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) has detected a possible host failure"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance", vccluster!~".*controlplane-swift"}
+        labels:
+          context: '{{ $labels.hostsystem }} failure'
+          meta: vSphere High Availability (HA) has detected a possible host failure for
+            `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hadetectedapossiblehostfailure
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: IaasHADetectedAPossibleHostFailure
+        annotations:
+          description: vSphere High Availability (HA) has detected a possible host failure
+            for `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+          summary: vSphere High Availability (HA) has detected a possible host failure
+            for `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) has detected a possible host failure"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance", vccluster!~".*controlplane-swift"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} failure'
+          meta: vSphere High Availability (HA) has detected a possible host failure for
+            `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hadetectedapossiblehostfailure
+          service: compute
+          severity: critical
+          support_group: iaas_support
+          tier: vmware
+      - alert: APodMemoryUtilizationHigh
+        annotations:
+          description: Memory utilization of host {{ $labels.hostsystem }} is above 90%.
+            ({{ $labels.vcenter }})
+          summary: Memory utilization of host {{ $labels.hostsystem }} is above 90%. ({{
+            $labels.vcenter }})
+        expr: vrops_hostsystem_memory_usage_percentage{vccluster=~".*-management.*"} >
+          95
+        for: 30m
+        labels:
+          context: '{{ $labels.hostsystem }} memory'
+          meta: Memory utilization of host {{ $labels.hostsystem }} is above 90%. ({{
+            $labels.vcenter }})
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: APodCPUUtilizationHigh
+        annotations:
+          description: CPU utilization of host {{ $labels.hostsystem }} is above 90%.
+            ({{ $labels.vcenter }})
+          summary: CPU utilization of host {{ $labels.hostsystem }} is above 90%. ({{
+            $labels.vcenter }})
+        expr: vrops_hostsystem_cpu_usage_average_percentage{vccluster=~".*-management.*"}
+          > 80
+        for: 30m
+        labels:
+          context: '{{ $labels.hostsystem }} cpu'
+          meta: CPU utilization of host {{ $labels.hostsystem }} is above 90%. ({{ $labels.vcenter
+            }})
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: HostHighNumberOfPacketsDropped
+        annotations:
+          description: '`{{ $labels.hostsystem }}` is experiencing high number of packets
+            dropped. ({{ $labels.vcenter }}).'
+          summary: '`{{ $labels.hostsystem }}` is experiencing high number of packets
+            dropped. ({{ $labels.vcenter }}).'
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="Host is experiencing high number of packets dropped"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        labels:
+          context: '{{ $labels.hostsystem }} packets dropped'
+          meta: '`{{ $labels.hostsystem }}` is experiencing high number of packets dropped.
+            ({{ $labels.vcenter }}).'
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostHighNumberOfPacketsDropped
+        annotations:
+          description: '`{{ $labels.hostsystem }}` is experiencing high number of packets
+            dropped. ({{ $labels.vcenter }}).'
+          summary: '`{{ $labels.hostsystem }}` is experiencing high number of packets
+            dropped. ({{ $labels.vcenter }}).'
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="Host is experiencing high number of packets dropped"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} packets dropped'
+          meta: '`{{ $labels.hostsystem }}` is experiencing high number of packets dropped.
+            ({{ $labels.vcenter }}).'
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostNicLinkFlappingAlert
+        annotations:
+          description: '`{{ $labels.hostsystem }}` has detected a link status flapping
+            on a physical NIC. ({{ $labels.vcenter }}).'
+          summary: '`{{ $labels.hostsystem }}` has detected a link status flapping on
+            a physical NIC. ({{ $labels.vcenter }}).'
+        expr: |
+          vrops_hostsystem_alert_info{alert_name=~"ESXi host has detected a link status.*flapping.*on a physical NIC"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        labels:
+          context: '{{ $labels.hostsystem }} link flapping'
+          meta: '`{{ $labels.hostsystem }}` has detected a link status flapping on a physical
+            NIC. ({{ $labels.vcenter }}).'
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostNicLinkFlappingAlert
+        annotations:
+          description: '`{{ $labels.hostsystem }}` has detected a link status flapping
+            on a physical NIC. ({{ $labels.vcenter }}).'
+          summary: '`{{ $labels.hostsystem }}` has detected a link status flapping on
+            a physical NIC. ({{ $labels.vcenter }}).'
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name=~"ESXi host has detected a link status.*flapping.*on a physical NIC"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} link flapping'
+          meta: '`{{ $labels.hostsystem }}` has detected a link status flapping on a physical
+            NIC. ({{ $labels.vcenter }}).'
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostSystemEventLogSensorAlert
+        annotations:
+          description: IPMI System Event Log for `{{ $labels.hostsystem }}` is becoming
+            full. ({{ $labels.vcenter }}) {{ $labels.recommendation_1 }}
+          summary: IPMI System Event Log for `{{ $labels.hostsystem }}` is becoming full.
+            ({{ $labels.vcenter }}) {{ $labels.recommendation_1 }}
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="IPMI System Event Log for the host is becoming full"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        labels:
+          context: '{{ $labels.hostsystem }} IPMI log'
+          meta: IPMI System Event Log for `{{ $labels.hostsystem }}` is becoming full.
+            ({{ $labels.vcenter }}) {{ $labels.recommendation_1 }}
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostSystemEventLogSensorAlert
+        annotations:
+          description: IPMI System Event Log for `{{ $labels.hostsystem }}` is becoming
+            full. ({{ $labels.vcenter }}) {{ $labels.recommendation_1 }}
+          summary: IPMI System Event Log for `{{ $labels.hostsystem }}` is becoming full.
+            ({{ $labels.vcenter }}) {{ $labels.recommendation_1 }}
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="IPMI System Event Log for the host is becoming full"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} IPMI log'
+          meta: IPMI System Event Log for `{{ $labels.hostsystem }}` is becoming full.
+            ({{ $labels.vcenter }}) {{ $labels.recommendation_1 }}
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostStoragePathsDown
+        annotations:
+          description: More than 4 active storage paths for `{{ $labels.hostsystem }}`
+            down. ({{ $labels.vcenter }})
+          summary: More than 4 active storage paths for `{{ $labels.hostsystem }}` down.
+            ({{ $labels.vcenter }})
+        expr: vrops_hostsystem_storage_number_of_path - vrops_hostsystem_storage_number_of_active_path
+          > 4
+        for: 30m
+        labels:
+          context: '{{ $labels.hostsystem }} storage paths'
+          meta: More than 4 active storage paths for `{{ $labels.hostsystem }}` down.
+            ({{ $labels.vcenter }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostStoragePathsDown
+        annotations:
+          description: More than 4 active storage paths for `{{ $labels.hostsystem }}`
+            down. ({{ $labels.vcenter }})
+          summary: More than 4 active storage paths for `{{ $labels.hostsystem }}` down.
+            ({{ $labels.vcenter }})
+        expr: (vrops_hostsystem_storage_number_of_path - vrops_hostsystem_storage_number_of_active_path
+          > 4) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 30m
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} storage paths'
+          meta: More than 4 active storage paths for `{{ $labels.hostsystem }}` down.
+            ({{ $labels.vcenter }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostAllRedundantStoragePathsDown
+        annotations:
+          description: All active storage paths for `{{ $labels.hostsystem }}` down. ({{
+            $labels.vcenter }})
+          summary: All active storage paths for `{{ $labels.hostsystem }}` down. ({{ $labels.vcenter
+            }})
+        expr: vrops_hostsystem_storage_number_of_active_path == 0
+        for: 10m
+        labels:
+          context: '{{ $labels.hostsystem }} storage paths'
+          meta: All active storage paths for `{{ $labels.hostsystem }}` down. ({{ $labels.vcenter
+            }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostAllRedundantStoragePathsDown
+        annotations:
+          description: All active storage paths for `{{ $labels.hostsystem }}` down. ({{
+            $labels.vcenter }})
+          summary: All active storage paths for `{{ $labels.hostsystem }}` down. ({{ $labels.vcenter
+            }})
+        expr: (vrops_hostsystem_storage_number_of_active_path == 0) and on(hostsystem)
+          vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 10m
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} storage paths'
+          meta: All active storage paths for `{{ $labels.hostsystem }}` down. ({{ $labels.vcenter
+            }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: iaas_support
+          tier: vmware
+      - alert: HAHostAgentError
+        annotations:
+          description: HA agent on Host `{{ $labels.hostsystem }}` has encountered an
+            error. ({{ $labels.vcenter }}).
+          summary: HA agent on Host `{{ $labels.hostsystem }}` has encountered an error.
+            ({{ $labels.vcenter }}).
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) host agent has encountered an error", vccluster!~".*-controlplane-swift"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        labels:
+          context: '{{ $labels.hostsystem }} HA agent error'
+          meta: HA agent on Host `{{ $labels.hostsystem }}` has encountered an error.
+            ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#troubleshooting-vsphere-ha-host-states
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasHAHostAgentError
+        annotations:
+          description: HA agent on Host `{{ $labels.hostsystem }}` has encountered an
+            error. ({{ $labels.vcenter }}).
+          summary: HA agent on Host `{{ $labels.hostsystem }}` has encountered an error.
+            ({{ $labels.vcenter }}).
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) host agent has encountered an error", vccluster!~".*-controlplane-swift"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} HA agent error'
+          meta: HA agent on Host `{{ $labels.hostsystem }}` has encountered an error.
+            ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#troubleshooting-vsphere-ha-host-states
+          service: compute
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: HAHostNetworkPartitioned
+        annotations:
+          description: HA on Host `{{ $labels.hostsystem }}` has detected a network-partitioned
+            host. ({{ $labels.vcenter }}).
+          summary: HA on Host `{{ $labels.hostsystem }}` has detected a network-partitioned
+            host. ({{ $labels.vcenter }}).
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) has detected a network-partitioned host"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        labels:
+          context: '{{ $labels.hostsystem }} HA network-partitioned host'
+          meta: HA on Host `{{ $labels.hostsystem }}` has detected a network-partitioned
+            host. ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#troubleshooting-vsphere-ha-host-states
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasHAHostNetworkPartitioned
+        annotations:
+          description: HA on Host `{{ $labels.hostsystem }}` has detected a network-partitioned
+            host. ({{ $labels.vcenter }}).
+          summary: HA on Host `{{ $labels.hostsystem }}` has detected a network-partitioned
+            host. ({{ $labels.vcenter }}).
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) has detected a network-partitioned host"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} HA network-partitioned host'
+          meta: HA on Host `{{ $labels.hostsystem }}` has detected a network-partitioned
+            host. ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#troubleshooting-vsphere-ha-host-states
+          service: compute
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: APodHostRunsMultipleVCenters
+        annotations:
+          description: aPod node `{{ $labels.hostsystem }}` runs multiple vCenter VMs.
+            ({{ $labels.vcenter }})
+          summary: aPod node `{{ $labels.hostsystem }}` runs multiple vCenter VMs. ({{
+            $labels.vcenter }})
+        expr: count(vrops_virtualmachine_runtime_connectionstate{vccluster=~".*-management",
+          virtualmachine=~"vc-.*"}) by(hostsystem, vcenter) > 1
+        for: 30m
+        labels:
+          context: '{{ $labels.hostsystem }} multiple vCenters'
+          meta: aPod node `{{ $labels.hostsystem }}` runs multiple vCenter VMs. ({{ $labels.vcenter
+            }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: HostStoragePathCheck
+        annotations:
+          description: storage paths for `{{ $labels.hostsystem }}` is less than other
+            hosts in the `{{ $labels.vccluster }}`. ({{ $labels.vcenter }})
+          summary: storage paths for `{{ $labels.hostsystem }}` is less than other hosts
+            in the `{{ $labels.vccluster }}`. ({{ $labels.vcenter }})
+        expr: vrops_hostsystem_storage_number_of_path < on(vccluster) group_left() (max(vrops_hostsystem_storage_number_of_path)
+          by(vccluster))
+        for: 30m
+        labels:
+          context: '{{ $labels.hostsystem }} storage paths'
+          meta: storage paths for `{{ $labels.hostsystem }}` is less than other hosts
+            in the `{{ $labels.vccluster }}`. ({{ $labels.vcenter }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostStoragePathCheck
+        annotations:
+          description: storage paths for `{{ $labels.hostsystem }}` is less than other
+            hosts in the `{{ $labels.vccluster }}`. ({{ $labels.vcenter }})
+          summary: storage paths for `{{ $labels.hostsystem }}` is less than other hosts
+            in the `{{ $labels.vccluster }}`. ({{ $labels.vcenter }})
+        expr: (vrops_hostsystem_storage_number_of_path < on(vccluster) group_left() (max(vrops_hostsystem_storage_number_of_path)
+          by(vccluster))) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 30m
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} storage paths'
+          meta: storage paths for `{{ $labels.hostsystem }}` is less than other hosts
+            in the `{{ $labels.vccluster }}`. ({{ $labels.vcenter }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: iaas_support
+          tier: vmware
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-a-0-alerts-iaas.alerts
+  labels:
+    prometheus: vmware-vc-a-0
+
+spec:
+  groups:
+    - name: iaas.alerts
+      rules:
+      - alert: IaasHostMemoryUsage
+        annotations:
+          description: Memory usage of ESXi host {{ $labels.hostsystem}} is above 75%
+          summary: Memory usage of ESXi host {{ $labels.hostsystem}} is above 75%
+        expr: vrops_hostsystem_memory_usage_percentage > 75 and on (hostsystem) vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+        for: 30m
+        labels:
+          context: esxi host memory usage
+          meta: Memory usage of ESXi host {{ $labels.hostsystem}} is above 75%
+          service: compute
+          severity: warning
+          support_group: iaas-support
+      - alert: IaasHostMemoryUsage
+        annotations:
+          description: Memory usage of ESXi host {{ $labels.hostsystem}} is above 90%
+          summary: Memory usage of ESXi host {{ $labels.hostsystem}} is above 90%
+        expr: vrops_hostsystem_memory_usage_percentage > 90 and on (hostsystem) vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+        for: 30m
+        labels:
+          context: esxi host memory usage
+          meta: Memory usage of ESXi host {{ $labels.hostsystem}} is above 90%
+          service: compute
+          severity: critical
+          support_group: iaas-support
+      - alert: IaasHostLicenseKey
+        annotations:
+          description: IaaS ESXi host {{ $labels.hostsystem }} in IaaS host group without
+            valid license
+          summary: IaaS ESXi host {{ $labels.hostsystem }} in IaaS host group without
+            valid license
+        expr: vrops_hostsystem_license_key{license_key!~"GM693.*"} + on (hostsystem) group_right(license_key)
+          vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"} > 0
+        for: 30m
+        labels:
+          context: esxi host license key
+          meta: IaaS ESXi host {{ $labels.hostsystem }} in IaaS host group without valid
+            license
+          service: compute
+          severity: warning
+          support_group: iaas-support
+      - alert: IaasClusterWithoutFailoverHost
+        annotations:
+          description: IaaS cluster {{ $labels.vccluster }} has NO failover host configured
+          summary: IaaS cluster {{ $labels.vccluster }} has NO failover host configured
+        expr: |
+          (count by (vccluster) (vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}) > 0)
+          unless (count by (vccluster) (vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+          and on(hostsystem) vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{} == 1 ) > 0)
+        for: 15m
+        labels:
+          context: IaaS cluster HA policy
+          meta: IaaS cluster {{ $labels.vccluster }} has NO failover host configured
+          service: compute
+          severity: critical
+          support_group: iaas-support
+      - alert: NonIaasVmOnIaasHost
+        annotations:
+          description: Non IaaS virtual machine(s) running on IaaS ESXi host {{ $labels.hostsystem
+            }}
+          summary: Non IaaS virtual machine(s) running on IaaS ESXi host {{ $labels.hostsystem
+            }}
+        expr: |
+          count by (hostsystem) (
+            (
+              group by (project, hostsystem, virtualmachine)(vrops_virtualmachine_system_powered_on{}==1)
+              and on(project)
+              group by(project) (label_replace(limes_project_usage{domain!~"iaas-.*"}, "project", "$1", "project_id", "(.*)"))
+            )
+          )
+          and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+        for: 30m
+        labels:
+          context: non IaaS vm on IaaS cluster
+          meta: Non IaaS virtual machine(s) running on IaaS ESXi host {{ $labels.hostsystem
+            }}
+          service: compute
+          severity: warning
+          support_group: iaas-support
+      - alert: IaasHostsAlmostOutOfMemory
+        annotations:
+          description: All IaaS hosts in cluster {{ $labels.vccluster }} are above 75%
+            memory
+          summary: All IaaS hosts in cluster {{ $labels.vccluster }} are above 75% memory
+        expr: |
+          count by (vccluster) (
+            (vrops_hostsystem_memory_usage_percentage > 75)
+            and on(hostsystem)
+            vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+            unless on(hostsystem)
+            vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{} == 1
+          )
+          == on(vccluster)
+          count by (vccluster) (
+            vrops_hostsystem_memory_usage_percentage
+            and on(hostsystem)
+            vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+            unless on(hostsystem)
+            vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{} == 1
+          )
+          and on(vccluster)
+          count by (vccluster) (
+            vrops_hostsystem_memory_usage_percentage
+            and on(hostsystem)
+            vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+            unless on(hostsystem)
+            vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{} == 1
+          ) > 0
+        for: 60m
+        labels:
+          context: IaaS hosts in cluster are almost out of memory
+          meta: All IaaS hosts in cluster {{ $labels.vccluster }} are above 75% memory
+          service: compute
+          severity: warning
+          support_group: iaas-support
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-a-0-alerts-k8s-vc-mgmt.alerts
+  labels:
+    prometheus: vmware-vc-a-0
+
+spec:
+  groups:
+    - name: k8s-vc-mgmt.alerts
+      rules:
+      - alert: VCClusterCPUContention
+        annotations:
+          description: The VCCluster {{ $labels.vccluster}} is using {{ $value }} CPU
+            and VM's are fighting for it
+          summary: '{{ $labels.vccluster}} cpu contention critical'
+        expr: vrops_cluster_cpu_contention_percentage{vcenter=~"vc-mgmt-.*"} > 5
+        for: 15m
+        labels:
+          context: vccluster
+          meta: The VCCluster {{ $labels.vccluster}} is using too much CPU and VM's are
+            fighting for it
+          no_alert_on_absence: "true"
+          service: cc-cp
+          severity: info
+          support_group: containers
+          tier: k8s
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-a-0-alerts-nsxt.alerts
+  labels:
+    prometheus: vmware-vc-a-0
+
+spec:
+  groups:
+    - name: nsxt.alerts
+      rules:
+      - alert: NSXTDistributedFirewallSectionUsageLimitExceeded
+        annotations:
+          description: NSX-T cluster {{ $labels.nsxt_adapter }} firewall sections usage
+            exceeded the supported limit. https://{{ $labels.target }}
+          summary: NSX-T cluster {{ $labels.nsxt_adapter }} firewall sections usage exceeded
+            the supported limit. https://{{ $labels.target }}
+        expr: |
+          vrops_nsxt_mgmt_cluster_sys_capacity_distributed_firewall_section_usage_count /
+          vrops_nsxt_mgmt_cluster_sys_capacity_distributed_firewall_section_max_supported_count > 0.9
+        for: 10m
+        labels:
+          dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
+          meta: NSX-T cluster {{ $labels.nsxt_adapter }} firewall sections usage exceeded
+            the supported limit. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTDistributedFirewallRulesUsageLimitExceeded
+        annotations:
+          description: NSX-T cluster {{ $labels.nsxt_adapter }} firewall rules usage exceeded
+            the supported limit. https://{{ $labels.target }}
+          summary: NSX-T cluster {{ $labels.nsxt_adapter }} firewall sections rules exceeded
+            the supported limit. https://{{ $labels.target }}
+        expr: |
+          vrops_nsxt_mgmt_cluster_sys_capacity_distributed_firewall_rules_usage_count /
+          vrops_nsxt_mgmt_cluster_sys_capacity_distributed_firewall_rules_max_supported_count > 0.9
+        for: 10m
+        labels:
+          dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
+          meta: NSX-T cluster {{ $labels.nsxt_adapter }} firewall rules usage exceeded
+            the supported limit. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTLogicalSwitchesUsageLimitExceeded
+        annotations:
+          description: NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switches
+            exceeded the supported limit. https://{{ $labels.target }}
+          summary: NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switches
+            exceeded the supported limit. https://{{ $labels.target }}
+        expr: |
+          vrops_nsxt_mgmt_cluster_sys_capacity_logical_switches_usage_count /
+          vrops_nsxt_mgmt_cluster_sys_capacity_logical_switches_max_supported_count > 0.9
+        for: 10m
+        labels:
+          dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
+          meta: NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switches exceeded
+            the supported limit. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTLogicalSwitchPortsUsageWarningLimitExceeded
+        annotations:
+          description: NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switch
+            ports exceeded the supported limit. https://{{ $labels.target }}
+          summary: NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switch ports
+            exceeded the supported limit. https://{{ $labels.target }}
+        expr: |
+          vrops_nsxt_mgmt_cluster_sys_capacity_logical_switch_ports_usage_count /
+          vrops_nsxt_mgmt_cluster_sys_capacity_logical_switch_ports_max_supported_count > 0.9
+        for: 10m
+        labels:
+          dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
+          meta: NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switch ports
+            exceeded the supported limit. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTGroupsUsageLimitExceeded
+        annotations:
+          description: NSX-T cluster {{ $labels.nsxt_adapter }} count of NSGroups exceeded
+            the supported limit. https://{{ $labels.target }}
+          summary: NSX-T cluster {{ $labels.nsxt_adapter }} count of NSGroups exceeded
+            the supported limit. https://{{ $labels.target }}
+        expr: |
+          vrops_nsxt_mgmt_cluster_sys_capacity_nsgroups_max_usage_count /
+          vrops_nsxt_mgmt_cluster_sys_capacity_nsgroups_max_supported_count > 0.9
+        for: 10m
+        labels:
+          dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
+          meta: NSX-T cluster {{ $labels.nsxt_adapter }} count of NSGroups exceeded the
+            supported limit. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTIPSetsUsageLimitExceeded
+        annotations:
+          description: NSX-T cluster {{ $labels.nsxt_adapter }} count of IP sets exceeded
+            the supported limit. https://{{ $labels.target }}
+          summary: NSX-T cluster {{ $labels.nsxt_adapter }} count of IP sets exceeded
+            the supported limit. https://{{ $labels.target }}
+        expr: |
+          vrops_nsxt_mgmt_cluster_sys_capacity_ip_sets_usage_count /
+          vrops_nsxt_mgmt_cluster_sys_capacity_ip_sets_max_supported_count > 0.9
+        for: 10m
+        labels:
+          dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
+          meta: NSX-T cluster {{ $labels.nsxt_adapter }} count of IP sets exceeded the
+            supported limit. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTGroupsBasedInIPUsageLimitExceeded
+        annotations:
+          description: NSX-T cluster {{ $labels.nsxt_adapter }} count of groups based
+            in IP exceeded the supported limit. https://{{ $labels.target }}
+          summary: NSX-T cluster {{ $labels.nsxt_adapter }} count of groups based in IP
+            exceeded the supported limit. https://{{ $labels.target }}
+        expr: |
+          vrops_nsxt_mgmt_cluster_sys_capacity_groups_based_in_ip_usage_count /
+          vrops_nsxt_mgmt_cluster_sys_capacity_groups_based_in_ip_max_supported_count > 0.9
+        for: 10m
+        labels:
+          dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
+          meta: NSX-T cluster {{ $labels.nsxt_adapter }} count of groups based in IP exceeded
+            the supported limit. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTMgmtNodeImageFilesystemCapacity
+        annotations:
+          description: NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage
+            `/image` > 80%. {{ $labels.nsxt_adapter}} https://{{ $labels.target }}
+          summary: NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage
+            `/image` > 80%. {{ $labels.nsxt_adapter}} https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_node_filesystems_image_usedpercentage > 80
+        for: 10m
+        labels:
+          meta: NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage `/image`
+            > 80%. {{ $labels.nsxt_adapter}} https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#NSXTMgmtNodeImageFilesystemCapacityCritical
+          service: network
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: NSXTMgmtNodeLogFilesystemCapacity
+        annotations:
+          description: NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage
+            `/var/log` > 80%. {{ $labels.nsxt_adapter}} https://{{ $labels.target }}
+          summary: NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage
+            `/var/log` > 80%. {{ $labels.nsxt_adapter}} https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_node_filesystems_var_log_usedpercentage > 80
+        for: 10m
+        labels:
+          meta: NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage `/var/log`
+            > 80%. {{ $labels.nsxt_adapter}} https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#NSXTMgmtNodeLogFilesystemCapacityCritical
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTClusterControlStatusNoControllers
+        annotations:
+          description: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity
+            status is `{{ $labels.state }}`. https://{{ $labels.target }}
+          summary: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status
+            is `{{ $labels.state }}`. https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_cluster_controller_cluster_connectivity_status{state="NO_CONTROLLERS"}
+        for: 10m
+        labels:
+          meta: NSX-T management cluster {{ $labels.nsxt_adapter }} has connectivity status
+            `{{ $labels.state }}`. https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#cluster_control_status_no_controllers
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTClusterControlStatusUnstable
+        annotations:
+          description: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity
+            status is `{{ $labels.state }}`. https://{{ $labels.target }}
+          summary: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status
+            is `{{ $labels.state }}`. https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_cluster_controller_cluster_connectivity_status{state="UNSTABLE"}
+        for: 10m
+        labels:
+          meta: NSX-T management cluster {{ $labels.nsxt_adapter }} has connectivity status
+            `{{ $labels.state }}`. https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#cluster_control_status_unstable
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTClusterControlStatusDegraded
+        annotations:
+          description: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity
+            status is `{{ $labels.state }}`. https://{{ $labels.target }}
+          summary: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status
+            is `{{ $labels.state }}`. https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_cluster_controller_cluster_connectivity_status{state="DEGRADED"}
+        for: 30m
+        labels:
+          meta: NSX-T management cluster {{ $labels.nsxt_adapter }} has connectivity status
+            `{{ $labels.state }}`. https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#cluster_control_status_degraded
+          service: network
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: NSXTClusterControlStatusUnkown
+        annotations:
+          description: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity
+            status is `{{ $labels.state }}`. https://{{ $labels.target }}
+          summary: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status
+            is `{{ $labels.state }}`. https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_cluster_controller_cluster_connectivity_status{state="UNKNOWN"}
+        for: 10m
+        labels:
+          meta: NSX-T management cluster {{ $labels.nsxt_adapter }} has connectivity status
+            `{{ $labels.state }}`. https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#cluster_control_status_unkown
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTNodeMemoryUsageOver95
+        annotations:
+          description: NSX-T Node {{ $labels.nsxt_mgmt_node }} of cluster {{ $labels.nsxt_adapter
+            }} has memory usage of over 95%. https://{{ $labels.target }}
+          summary: NSX-T Node {{ $labels.nsxt_mgmt_node }} of cluster {{ $labels.nsxt_adapter
+            }} has memory usage of over 95%. https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_node_memory_used / vrops_nsxt_mgmt_node_memory_total > 0.95
+        for: 5m
+        labels:
+          meta: NSX-T Node {{ $labels.nsxt_mgmt_node }} of cluster {{ $labels.nsxt_adapter
+            }} has memory usage of over 95%. https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#NSXT_Memory_Usage_Over95
+          service: network
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: NSXTNodeConnectivityBroken
+        annotations:
+          description: NSX-T Node {{ $labels.nsxt_mgmt_node }} connectivity is broken.
+            ({{ $labels.nsxt_adapter }}) https://{{ $labels.target }}
+          summary: NSX-T Node {{ $labels.nsxt_mgmt_node }} connectivity is broken. ({{
+            $labels.nsxt_adapter }}) https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_node_connectivity_status{state="DISCONNECTED"}
+        for: 5m
+        labels:
+          meta: NSX-T Node `{{ $labels.nsxt_mgmt_node }}` connectivity is broken. ({{
+            $labels.nsxt_adapter }}) https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#nsxtnodeconnectivitybroken
+          service: network
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: NSXTManagementServiceHasFailed
+        annotations:
+          description: 'CRITICAL: NSX-T management service `{{ $labels.nsxt_mgmt_service
+            }}` has failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }})
+            https://{{ $labels.target }}'
+          summary: 'CRITICAL: NSX-T management service `{{ $labels.nsxt_mgmt_service }}`
+            has failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }}) https://{{
+            $labels.target }}'
+        expr: |
+          vrops_nsxt_mgmt_service_alert_info{alert_name="NSX-T Management service has failed|Management service monitor runtime state has failed",
+          nsxt_mgmt_service!~"cluster-boot-manager|cm-inventory|controller|http|manager"}
+        labels:
+          meta: Critical NSX-T management service `{{ $labels.nsxt_mgmt_service }}` has
+            failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }}) https://{{
+            $labels.target }}
+          no_alert_on_absence: "true"
+          service: network
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: NSXTSslCertificateExpiry
+        annotations:
+          description: NSX-T Certificate of {{ $labels.nsxt_adapter }} has expired or
+            will expire shortly. https://{{ $labels.target }}
+          summary: NSX-T Certificate of {{ $labels.nsxt_adapter }} has expired or will
+            expire shortly. https://{{ $labels.target }}
+        expr: vrops_nsxt_adapter_alert_info{alert_name="Adapter certificate has expired
+          or will expire shortly"}
+        labels:
+          context: nsxt certificate
+          meta: NSX-T Certificate of `{{ $labels.nsxt_adapter }}` has expired or will
+            expire shortly. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#applying-nsx-t-ssl-certificate-in-the-manager-nodes-and-the-vip
+          service: network
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: NSXTManagementServiceHasFailed
+        annotations:
+          description: 'WARNING: NSX-T management service `{{ $labels.nsxt_mgmt_service
+            }}` has failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }}).
+            https://{{ $labels.target }}'
+          summary: 'WARNING: NSX-T management service `{{ $labels.nsxt_mgmt_service }}`
+            has failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }}). https://{{
+            $labels.target }}'
+        expr: |
+          vrops_nsxt_mgmt_service_alert_info{alert_name="NSX-T Management service has failed|Management service monitor runtime state has failed",
+          nsxt_mgmt_service!~"mgmt-plane-bus|node-mgmt|ntp|ssh|search|syslog|nsx-ui"}
+        labels:
+          meta: NSX-T management service `{{ $labels.nsxt_mgmt_service }}` has failed.
+            ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }}). https://{{ $labels.target
+            }}
+          no_alert_on_absence: "true"
+          service: network
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: NSXTTransportNodeConnectivityNotUP
+        annotations:
+          description: 'Transport node {{ $labels.nsxt_transport_node }} Controller/Manager
+            Connectivity status is not UP. https://{{ $labels.target }}. '
+          summary: 'Transport node {{ $labels.nsxt_transport_node }} Controller/Manager
+            Connectivity status is not UP. https://{{ $labels.target }}. '
+        expr: |
+          label_replace(vrops_nsxt_transport_node_alert_info{alert_name="Transport Node Controller/Manager Connectivity is not UP"}, "hostsystem", "$1", "nsxt_transport_node", "(.*)")
+          AND on (hostsystem) vrops_hostsystem_runtime_connectionstate{state="notResponding"}
+          AND on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"}
+          AND on (hostsystem) vrops_hostsystem_runtime_powerstate{state="Powered On"}
+        labels:
+          meta: Transport node {{ $labels.nsxt_transport_node }} Controller/Manager Connectivity
+            status is not UP. https://{{ $labels.target }}.
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#Transport_node_status_not_UP_in_NSXT
+          service: network
+          severity: critical
+          support_group: compute
+          tier: vmware
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-a-0-alerts-vccluster.alerts
+  labels:
+    prometheus: vmware-vc-a-0
+
+spec:
+  groups:
+    - name: vccluster.alerts
+      rules:
+      - alert: VCenterRedundancyLostHAPolicyFaulty
+        annotations:
+          description: VC https://{{ $labels.vcenter }} has a faulty AdmissionControlPolicy
+            for cluster {{ $labels.vccluster }}, failover will not work.
+          summary: VC https://{{ $labels.vcenter }} has a faulty AdmissionControlPolicy
+            for cluster {{ $labels.vccluster }}, failover will not work.
+        expr: |
+          vrops_cluster_configuration_dasconfig_enabled{vccluster=~"productionbb\\d+"}
+          unless on (vccluster) ((vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{vccluster=~"productionbb\\d+"} != 0
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"})
+          or (vrops_cluster_summary_custom_tag_openstack_nova_traits_decommissioning{summary_custom_tag_openstack_nova_traits_decommissioning="true", vccluster=~"productionbb\\d+"}
+          and on (vccluster) vrops_cluster_cluster_running_vms == 0))
+        for: 30m
+        labels:
+          context: vc cluster config
+          meta: VC https://{{ $labels.vcenter }} has a faulty AdmissionControlPolicy for
+            cluster {{ $labels.vccluster }}, failover will not work.
+          playbook: docs/devops/alert/vcenter/#vcenterredundancylosthapolicyfaulty
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: VCenterRedundancyLostHAPolicyNotConfigured
+        annotations:
+          description: VC {{ $labels.vcenter }} {{ $labels.vccluster }} has a faulty AdmissionControlPolicy.
+            Failover will not work.
+          summary: VC {{ $labels.vcenter }} {{ $labels.vccluster }} has a faulty AdmissionControlPolicy.
+            Failover will not work.
+        expr: vrops_cluster_configuration_dasconfig_enabled{vccluster=~"production.*"}
+          == 0
+        for: 30m
+        labels:
+          context: Cluster HA policy
+          meta: VC {{ $labels.vcenter }} {{ $labels.vccluster }} has a faulty AdmissionControlPolicy.
+            Failover will not work.
+          playbook: docs/devops/alert/vcenter/#restore-ha-redundancy-in-vcenter
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: VCClusterFailoverHostCountMismatch
+        annotations:
+          description: "`{{ $labels.vccluster }}` cluster has more failover hosts configured
+            than expected. For clusters with 10 or fewer hosts, it should be 1; for larger
+            clusters, it should be no more than 2. \nLink to the vCenter: --> <https://{{
+            $labels.vcenter }}|{{ $labels.vcenter }}>"
+          summary: "`{{ $labels.vccluster }}` cluster has more failover hosts configured
+            than expected. For clusters with 10 or fewer hosts, it should be 1; for larger
+            clusters, it should be no more than 2. \nLink to the vCenter: --> <https://{{
+            $labels.vcenter }}|{{ $labels.vcenter }}>"
+        expr: |
+          (count by (vccluster, vcenter) (vrops_hostsystem_runtime_connectionstate{vccluster=~"productionbb\\d+"}) <= 10
+          and on (vccluster) sum by (vccluster) (vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{vccluster=~"productionbb\\d+"}) > 1)
+          or (sum by (vccluster, vcenter) (vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{vccluster=~"productionbb\\d+"}) > 2)
+          unless on (vccluster) (vrops_cluster_summary_custom_tag_openstack_nova_traits_decommissioning{summary_custom_tag_openstack_nova_traits_decommissioning="true", vccluster=~"productionbb\\d+"}
+          and vrops_cluster_cluster_running_vms == 0)
+        for: 30m
+        labels:
+          context: Cluster HA policy
+          meta: "`{{ $labels.vccluster }}` cluster has more failover hosts configured
+            than expected. For clusters with 10 or fewer hosts, it should be 1; for larger
+            clusters, it should be no more than 2. \nLink to the vCenter: --> <https://{{
+            $labels.vcenter }}|{{ $labels.vcenter }}>"
+          playbook: docs/devops/alert/vcenter/#vcclusterfailoverhostcountmismatch
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VCenterRedundancyLostHALevelNotSet
+        annotations:
+          description: VC {{ $labels.vcenter }} {{ $labels.vccluster }} has NO failover
+            host amount configured, this should be 1
+          summary: VC {{ $labels.vcenter }} {{ $labels.vccluster }} has NO failover host
+            amount configured, this should be 1
+        expr: count by (vccluster, vcenter) (vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{vccluster=~"production.*"}
+          == 1) == 0
+        for: 30m
+        labels:
+          context: Cluster HA policy
+          meta: VC {{ $labels.vcenter }} {{ $labels.vccluster }} has NO failover host
+            amount configured, this should be 1
+          playbook: docs/devops/alert/vcenter/#restore-ha-redundancy-in-vcenter
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: VCClusterDRSNotFullyAutomated
+        annotations:
+          description: Cluster {{ $labels.vccluster }} DRS configuration is not set to
+            fully automated.
+          summary: Cluster {{ $labels.vccluster }} DRS configuration is not set to fully
+            automated.
+        expr: |
+          vrops_cluster_configuration_drsconfig_defaultvmbehavior{vccluster!~".*controlplane.*", state != "fullyAutomated"} == 0
+          unless on (vccluster) vrops_cluster_summary_custom_tag_openstack_nova_traits_hana_exclusive_host{summary_custom_tag_openstack_nova_traits_hana_exclusive_host="true"}
+        for: 10m
+        labels:
+          context: Cluster DRS configuration
+          meta: Cluster {{ $labels.vccluster }} DRS configuration is not set to fully
+            automated.
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#cluster-drs-not-set-to-fully-automated
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: VCClusterCannotDistributeNSXTControllers
+        annotations:
+          description: Cluster {{ $labels.vccluster }} cannot evenly distribute new NSX-T
+            controllers. {{ $labels.vcenter}}
+          summary: Cluster {{ $labels.vccluster }} cannot evenly distribute new NSX-T
+            controllers. {{ $labels.vcenter }}
+        expr: |
+          count by(vccluster, vcenter) (
+            (
+              max_over_time(vrops_hostsystem_memory_capacity_available_to_vms_kilobytes{vccluster=~".*management"}[1h])
+              - max_over_time(vrops_hostsystem_memory_consumed_by_vms_kilobytes[1h])
+            ) / 1024 / 1024 >= 48
+          ) < 3
+        for: 30m
+        labels:
+          context: Cluster NSXT Resources
+          meta: Cluster {{ $labels.vccluster }} cannot evenly distribute new NSX-T controllers.
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: HanaExclusiveVCClusterDRSNotPartiallyAutomated
+        annotations:
+          description: |-
+            The HANA-exclusive {{ $labels.vccluster }} cluster DRS configuration is not set to partially automated in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The HANA-exclusive {{ $labels.vccluster }} cluster DRS configuration is not set to partially automated in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_cluster_configuration_drsconfig_defaultvmbehavior{vccluster=~"productionbb.+", state != "partiallyAutomated"}
+          and on (vccluster) vrops_cluster_summary_custom_tag_openstack_nova_traits_hana_exclusive_host{summary_custom_tag_openstack_nova_traits_hana_exclusive_host="true"}
+        labels:
+          context: Cluster DRS configuration
+          meta: |-
+            The HANA-exclusive {{ $labels.vccluster }} cluster DRS configuration is not set to partially automated in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hanaexclusivevcclusterdrsnotpartiallyautomated
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-a-0-alerts-vcenter.alerts
+  labels:
+    prometheus: vmware-vc-a-0
+
+spec:
+  groups:
+    - name: vcenter.alerts
+      rules:
+      - alert: VcsaSslCertificateExpiry
+        annotations:
+          description: SSL Certificate of vCSA {{ $labels.vcenter}} expires in {{ $value
+            }} days. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: SSL Certificate of vCSA {{ $labels.vcenter}} expires in {{ $value }}
+            days. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: 15 < round(((avg_over_time(vrops_vcenter_summary_certificate_expiry_date[10m])
+          / 1000) - time()) / 86400) < 30
+        for: 20m
+        labels:
+          context: vcsa certificate
+          meta: SSL Certificate of vCSA {{ $labels.vcenter }} expires in less than 30
+            days. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#vcenter-appliance-certificate-expiry
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VcsaSslCertificateExpiry
+        annotations:
+          description: SSL Certificate of vCSA {{ $labels.vcenter}} expires in {{ $value
+            }} days. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: SSL Certificate of vCSA {{ $labels.vcenter}} expires in {{ $value }}
+            days. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: round(((avg_over_time(vrops_vcenter_summary_certificate_expiry_date[10m])
+          / 1000) - time()) / 86400) < 16
+        for: 20m
+        labels:
+          context: vcsa certificate
+          meta: SSL Certificate of vCSA {{ $labels.vcenter}} expires in less than 15 days.
+            ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#vcenter-appliance-certificate-expiry
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: VCenterDiskSpaceUsage
+        annotations:
+          description: Disk space usage of vCSA {{ $labels.vcenter}} is above 90%
+          summary: Disk space usage of vCSA {{ $labels.vcenter}} is above 90%
+        expr: vrops_vcenter_diskspace_usage_gigabytes / vrops_vcenter_diskspace_total_gigabytes
+          > 0.9
+        for: 15m
+        labels:
+          context: vcenter disk usage
+          meta: Disk space usage of vCSA {{ $labels.vcenter}} is above 90%
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VASAProvider(s)Disconnected
+        annotations:
+          description: VASA Provider disconnected from {{ $labels.vcenter}}.
+          summary: VASA Provider disconnected from {{ $labels.vcenter}}.
+        expr: vrops_vcenter_alert_info{alert_name="VASA Provider(s) disconnected"}
+        labels:
+          context: vasa provider
+          meta: VASA Provider disconnected from {{ $labels.vcenter}}.
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#vasaproviderdown
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VCenterHasMultipleGreyVMs
+        annotations:
+          description: vCenter {{ $labels.vcenter }} has multiple greyed out VMs for a
+            longer period. This alert is handled by TARS. If TARS fails, check and reload
+            these VMs.
+          summary: vCenter {{ $labels.vcenter }} has multiple greyed out VMs for a longer
+            period. This alert is handled by TARS. If TARS fails, check and reload these
+            VMs.
+        expr: |
+          count by(vcenter)
+          ((vrops_virtualmachine_health == -1)
+          and on(hostsystem) (vrops_hostsystem_runtime_powerstate{state="Powered On"})
+          and on(hostsystem) (vrops_hostsystem_runtime_connectionstate{state="connected"})
+          and on(hostsystem) (vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"})) > 0
+        for: 15m
+        labels:
+          context: Shadow VMs {{ $labels.vcenter }}
+          meta: vCenter {{ $labels.vcenter }} has multiple greyed out VMs for a longer
+            period. Check and reload these VMs.
+          playbook: docs/devops/alert/vcenter/#Inaccessible_Orphaned_Gray_instance_handling
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasVCenterHasMultipleGreyVMs
+        annotations:
+          description: vCenter {{ $labels.vcenter }} has multiple greyed out VMs for a
+            longer period. This alert is handled by TARS. If TARS fails, check and reload
+            these VMs.
+          summary: vCenter {{ $labels.vcenter }} has multiple greyed out VMs for a longer
+            period. This alert is handled by TARS. If TARS fails, check and reload these
+            VMs.
+        expr: |-
+          (count by(vcenter)
+          ((vrops_virtualmachine_health == -1)
+          and on(hostsystem) (vrops_hostsystem_runtime_powerstate{state="Powered On"})
+          and on(hostsystem) (vrops_hostsystem_runtime_connectionstate{state="connected"})
+          and on(hostsystem) (vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"})) > 0
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 15m
+        labels:
+          bedrock: "true"
+          context: Shadow VMs {{ $labels.vcenter }}
+          meta: vCenter {{ $labels.vcenter }} has multiple greyed out VMs for a longer
+            period. Check and reload these VMs.
+          playbook: docs/devops/alert/vcenter/#Inaccessible_Orphaned_Gray_instance_handling
+          service: compute
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-a-0-alerts-virtualmachine.alerts
+  labels:
+    prometheus: vmware-vc-a-0
+
+spec:
+  groups:
+    - name: virtualmachine.alerts
+      rules:
+      - alert: VMHasMemoryContention
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` has memory contention
+            due to memory compression, ballooning, or swapping. ({{ $labels.vcenter }},
+            {{ $labels.hostsystem }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` has memory contention
+            due to memory compression, ballooning, or swapping. ({{ $labels.vcenter }},
+            {{ $labels.hostsystem }})
+        expr: |
+          vrops_virtualmachine_alert_info{alert_name="Virtual machine has memory contention due to memory compression, ballooning, or swapping", vccluster=~".*management.*"}
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine `{{ $labels.virtualmachine }}` has memory contention due
+            to memory compression, ballooning, or swapping. ({{ $labels.vcenter }}, {{
+            $labels.hostsystem }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#vm_has_memory_contention
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VMHasDiskIOLatencyProblemCausedBySnapshots
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` has disk I/O latency
+            problem caused by snapshots. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` has disk I/O latency
+            problem caused by snapshots. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+        expr: |
+          vrops_virtualmachine_alert_info{alert_name="Virtual machine has disk I/O latency problem caused by snapshots", vccluster=~".*management.*"}
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine `{{ $labels.virtualmachine }}` has disk I/O latency problem
+            caused by snapshots. ({{ $labels.vcenter }}, {{ $labels.hostsystem }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#vm_has_disk_io_latency_problem_caused_by_snapshots
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VMHasCPUContentionDueToIOEvents
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` has CPU contention
+            due to long wait for I/O events. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` has CPU contention due
+            to long wait for I/O events. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+        expr: |
+          vrops_virtualmachine_alert_info{alert_name="Virtual machine has CPU contention due to long wait for I/O events", vccluster=~".*management.*"}
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine `{{ $labels.virtualmachine }}` has CPU contention due
+            to long wait for I/O events. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#vm_has_cpu_contention
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VMGuestFileSystemsRunningOutOfDiskSpace
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` guest file systems
+            are running out of disk space. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` guest file systems are
+            running out of disk space. ({{ $labels.vcenter }}, {{ $labels.hostsystem }})
+        expr: |
+          vrops_virtualmachine_guestfilesystem_storage_log_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_storage_autodeploy_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_storage_core_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_storage_dblog_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_storage_imagebuilder_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_storage_netdump_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_storage_seat_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_storage_updatemgr_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_boot_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_percentage{vccluster=~".*management.*"} > 80
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine `{{ $labels.virtualmachine }}` guest file systems are
+            running out of disk space. ({{ $labels.vcenter }}, {{ $labels.hostsystem }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#vm_guest_file_Systems_running_out_of_disk_space
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VMCPUAt100PercentForAnExtendedPeriodOfTime
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` CPU usage is at
+            100% for an extended period of time. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` CPU usage is at 100%
+            for an extended period of time. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+        expr: |
+          vrops_virtualmachine_alert_info{alert_name="Virtual machine CPU usage is at 100% for an extended period of time", vccluster=~".*management.*"}
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine {{ $labels.virtualmachine }} CPU usage is at 100% for
+            an extended period of time. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#vm_cpu_at_100_percent_for_an_extended_period_of_time
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VMInDRSClusterDemandingMoreCPUThanItsEntitlement
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` in a DRS cluster
+            is demanding more CPU than its entitlement. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` in a DRS cluster is
+            demanding more CPU than its entitlement. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+        expr: |
+          vrops_virtualmachine_alert_info{alert_name="Virtual machine in a DRS cluster is demanding more CPU than its entitlement", vccluster=~".*management.*"}
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine `{{ $labels.virtualmachine }}` in a DRS cluster is demanding
+            more CPU than its entitlement. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#vm_in_drs_cluster_demanding_more_cpu_than_its_entitlement
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VMHasSnapshotOlderThanOneWeek
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` has a snapshot older
+            than one week. ({{ $labels.vcenter }}, {{ $labels.hostsystem }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` has a snapshot older
+            than one week. ({{ $labels.vcenter }}, {{ $labels.hostsystem }})
+        expr: vrops_virtualmachine_disk_space_snapshot_age_days{vccluster=~".*management.*",
+          virtualmachine!~"jump.+"} > 7
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine `{{ $labels.virtualmachine }}` has a snapshot older than
+            one week. ({{ $labels.vcenter }}, {{ $labels.hostsystem }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VMHasCPUContentionDueToMemoryPageSwapping
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` experiencing high
+            swap wait. The host is overcommitted on memory. ({{ $labels.vcenter }}, {{
+            $labels.hostsystem }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` experiencing high swap
+            wait. The host is overcommitted on memory. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+        expr: |
+          vrops_virtualmachine_alert_info{alert_name="Virtual machine has CPU contention due to memory page swapping in the host", vccluster=~".*management.*"}
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine `{{ $labels.virtualmachine }}` experiencing high swap
+            wait. The host is overcommitted on memory. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: NSXTMgmtVMsOddDistribution
+        annotations:
+          description: Too many NSX-T VMs for the same cluster on {{ $labels.hostsystem
+            }}. Please distribute the VMs across different nodes. ({{ $labels.vcenter
+            }})
+          summary: Too many NSX-T VMs on {{ $labels.hostsystem }}. ({{ $labels.vcenter
+            }})
+        expr: |
+          count(label_replace(vrops_virtualmachine_cpu_usage_average_mhz{virtualmachine=~"nsx-.*"}, "nsx_clt", "$1", "virtualmachine", "nsx-.*(bb.*)")) by(nsx_clt, hostsystem, vcenter, vccluster) > 1
+        labels:
+          context: NSXTMgmtVMDistribution
+          dashboard: management-cluster-resources/management-cluster-resources?orgId=1&var-pod=All&var-clusters={{
+            $labels.vccluster }}&var-hosts={{ $labels.hostsystem }}
+          meta: Too many NSX-T VMs on {{ $labels.hostsystem }}. ({{ $labels.vcenter }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#nsxtmgmtvmsodddistribution
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTMgmtVMsOddDistributionSDRSAntiaffinity
+        annotations:
+          description: NSX-T VMs not part of SDRS anti-affinity rule  {{ $labels.rule_name
+            }}. Please distribute the VMs across different DS. ({{ $labels.vcenter }})
+          summary: NSX-T VMs not part of SDRS anti-affinity rule  {{ $labels.rule_name
+            }}. ({{ $labels.vcenter }})
+        expr: |
+          count  (vrops_storagepod_config_sdrsconfig_vmstorageantiaffinityrules{storagepod!~"SDRS_MGMT_BB\\d+"}) by (rule_name, vccluster, vcenter) != 3
+        labels:
+          context: NSXTMgmtVMsOddDistributionSDRS
+          dashboard: management-cluster-resources/management-cluster-resources?orgId=1&var-pod=All&var-clusters={{
+            $labels.vccluster }}
+          meta: NSX-T VMs not part of SDRS anti-affinity rule  {{ $labels.rule_name }}.
+            ({{ $labels.vcenter }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#nsxtmgmtvmsodddistributionsdrs
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VASAVMHighCPUUtilization
+        annotations:
+          description: VASA VM has >90% CPU Utilization for at least one hour. {{ $labels.virtualmachine
+            }}. {{ $labels.vccluster }}. {{ $labels.hostsystem }}. ({{ $labels.vcenter
+            }})
+          summary: High VASA VM CPU Utilization. {{ $labels.virtualmachine }}. {{ $labels.vccluster
+            }}. {{ $labels.hostsystem }}. ({{ $labels.vcenter }})
+        expr: vrops_virtualmachine_cpu_usage_ratio{virtualmachine=~"vasa.*"} > 90
+        for: 1h
+        labels:
+          context: VASAUtilization
+          meta: VASA VM has >90% CPU Utilization for at least one hour. {{ $labels.virtualmachine
+            }}. {{ $labels.vccluster }}. {{ $labels.hostsystem }}. ({{ $labels.vcenter
+            }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-a-0-alerts-vrops.alerts
+  labels:
+    prometheus: vmware-vc-a-0
+
+spec:
+  groups:
+    - name: vrops.alerts
+      rules:
+      - alert: VropsAPIDown
+        annotations:
+          description: "All collectors of the vrops-exporter report HTTP status codes
+            above 500, \nwhich indicates that vrops is reporting internal server errors
+            or is unreachable. \nCheck if vrops is running and healthy.\n"
+          summary: '`https://{{ $labels.target }}` API is down.'
+        expr: "(sum by (target) (vrops_api_response{collector=~\"vc.*\"}) / \ncount by
+          (target) (vrops_api_response{collector=~\"vc.*\"}) > 500) \n"
+        for: 10m
+        labels:
+          context: vrops
+          dashboard: vrops-exporter-status
+          meta: '`https://{{ $labels.target }}` API is down.'
+          playbook: docs/devops/alert/vcenter/vrops#vrops_api_down
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VropsAPIDown
+        annotations:
+          description: |
+            All collectors of the vrops-exporter report HTTP status codes above 500,
+            which indicates that vrops is reporting internal server errors or is unreachable.
+            Check if vrops is running and healthy.
+          summary: '`https://{{ $labels.target }}` API is down.'
+        expr: "(sum by (target) (vrops_api_response{collector=~\"vc.*\"}) / \ncount by
+          (target) (vrops_api_response{collector=~\"vc.*\"}) > 500)                                                                                                                     \n"
+        for: 90m
+        labels:
+          context: vrops
+          dashboard: vrops-exporter-status
+          meta: '`https://{{ $labels.target }}` API is down.'
+          playbook: docs/devops/alert/vcenter/vrops#vrops_api_down
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: VropsAPIDownEntirely
+        annotations:
+          description: |
+            Exporters can not connect to vrops anymore. Most likely the VM is stuck.
+            If this alert fires, complete vmware-montioring is down in Prometheus.
+            Ensure vrops is running and healthy.
+          meta: Vrops API is down. All collectors are not reporting anymore.
+        expr: |
+          absent(vrops_api_response)
+        for: 10m
+        labels:
+          context: vrops
+          dashboard: vrops-exporter-status
+          meta: Vrops API is down. All collectors are not reporting anymore.
+          playbook: docs/devops/alert/vcenter/vrops#vrops_api_down_entirely
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VropsAPIDownEntirely
+        annotations:
+          description: |
+            Exporters can not connect to vrops anymore. Most likely the VM is stuck.
+            If this alert fires, complete vmware-montioring is down in Prometheus.
+            Ensure vrops is running and healthy.
+          meta: Vrops API is down. All collectors are not reporting anymore.
+        expr: |
+          absent(vrops_api_response)
+        for: 90m
+        labels:
+          context: vrops
+          dashboard: vrops-exporter-status
+          meta: Vrops API is down. All collectors are not reporting anymore.
+          playbook: docs/devops/alert/vcenter/vrops#vrops_api_down_entirely
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: VropsTokenAcquisitionFailed
+        annotations:
+          description: |
+            A failed token acquisition for this vrops. This indicates
+            that the vrops system is not responding and current
+            monitoring data cannot be generated.
+          summary: Token acquisition failed for `https://{{ $labels.target }}`
+        expr: vrops_api_response{get_request="token"} >= 500
+        for: 15m
+        labels:
+          context: vrops
+          dashboard: vrops-exporter-status
+          meta: Token acquisition failed for `https://{{ $labels.target }}`
+          playbook: docs/devops/alert/vcenter/vrops#vrops_api_down
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VROpsDiskpaceUsage
+        annotations:
+          description: |
+            {{ $labels.virtualmachine }} disk almost full with over 90% usage.
+            Please increase disk size.
+          summary: '{{ $labels.virtualmachine }} disk almost full with over 90% usage.'
+        expr: vrops_virtualmachine_guestfilesystem_storage_db_percentage{virtualmachine=~"vrops.*-vc-.+"}
+          > 90
+        for: 20m
+        labels:
+          context: vrops
+          dashboard: vrops-instances-overview
+          meta: '{{ $labels.virtualmachine }} disk almost full with over 90% usage.'
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VROpsVCenterAdapterNotReceivingData
+        annotations:
+          description: The vCenter adapter for https://vrops-{{ $labels.vcenter }} is
+            not receiving data.
+          summary: The vCenter adapter for https://vrops-{{ $labels.vcenter }} is not
+            receiving data.
+        expr: vrops_vcenter_alert_info{alert_name="Adapter instance is not receiving data"}
+        for: 15m
+        labels:
+          context: vrops
+          meta: The vCenter adapter for https://vrops-{{ $labels.vcenter }} is not receiving
+            data.
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/vrops#revalidatecertificate
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VROpsNSXTAdapterNotReceivingData
+        annotations:
+          description: vROPs NSX-T adapter is not receiving data for `{{ $labels.nsxt_adapter
+            }}`. https://{{ $labels.target }}
+          summary: vROPs NSX-T adapter is not receiving data for `{{ $labels.nsxt_adapter
+            }}`. https://{{ $labels.target }}
+        expr: vrops_nsxt_adapter_alert_info{alert_name="Adapter instance is not receiving
+          data"}
+        for: 15m
+        labels:
+          context: vrops
+          meta: vROPs NSX-T adapter is not receiving data for `{{ $labels.nsxt_adapter
+            }}`. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#vrops-nsx-t-adapter-is-not-receiving-data-vropsnsxtadapternotreceivingdata
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VROpsVCenterObjectsNotReceivingData
+        annotations:
+          description: vROPs vCenter adapter for https://vrops-{{ $labels.vcenter }} is
+            not receiving data for some objects.
+          summary: vROPs vCenter adapter for https://vrops-{{ $labels.vcenter }} is not
+            receiving data for some objects.
+        expr: vrops_vcenter_alert_info{alert_name="Objects are not receiving data from
+          adapter instance"}
+        labels:
+          meta: vROPs vCenter adapter for https://vrops-{{ $labels.vcenter }} is not receiving
+            data for some objects.
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/vrops#revalidatecertificate
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-b-0-alerts-datastore.alerts
+  labels:
+    prometheus: vmware-vc-b-0
+
+spec:
+  groups:
+    - name: datastore.alerts
+      rules:
+      - alert: EphemeralDataStoreCapacity
+        annotations:
+          description: Eph Datastore {{ $labels.datastore }} utilization > 85%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          summary: Eph Datastore {{ $labels.datastore }} utilization > 85%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+        expr: |
+          vrops_datastore_diskspace_total_usage_gigabytes{type="ephemeral"} / vrops_datastore_diskspace_capacity_gigabytes >= 0.85
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          dashboard: vcenter-datastore-utilization
+          meta: Eph Datastore {{ $labels.datastore }} utilization > 85%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          playbook: docs/support/playbook/datastore/datastorediskusagealarm
+          service: storage
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: EphemeralDataStoreCapacity
+        annotations:
+          description: Eph Datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          summary: Eph Datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+        expr: |
+          vrops_datastore_diskspace_total_usage_gigabytes{type="ephemeral"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.9
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          dashboard: vcenter-datastore-utilization
+          meta: Eph Datastore {{ $labels.datastore }} utilization > 90%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          playbook: docs/support/playbook/datastore/datastorediskusagealarm
+          service: storage
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: AverageVmfsDataStoreCapacity
+        annotations:
+          description: Average utilization for `{{ $labels.type }}` Datastores per vCenter
+            is above 70%. ({{ $labels.vcenter }})
+          summary: Average utilization for `{{ $labels.type }}` Datastores per vCenter
+            is above 70%. ({{ $labels.vcenter }})
+        expr: |
+          avg by (type, vcenter) (vrops_datastore_diskspace_total_usage_gigabytes{type=~"vmfs_p_ssd|vmfs_s_hdd"} / vrops_datastore_diskspace_capacity_gigabytes) > 0.85
+        for: 20m
+        labels:
+          context: '{{ $labels.type }} storage'
+          dashboard: vcenter-datastore-utilization
+          meta: Average utilization for `{{ $labels.type }}` Datastores per vCenter is
+            above 70%. ({{ $labels.vcenter }})
+          playbook: docs/support/playbook/storage/new_storage_lun_request
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: DataStoreCapacity
+        annotations:
+          description: '{{ $labels.type }} datastore {{ $labels.datastore }} utilization
+            > 80%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
+          summary: '{{ $labels.type }} datastore {{ $labels.datastore }} utilization >
+            80%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
+        expr: |
+          vrops_datastore_diskspace_total_usage_gigabytes{type!~"ephemeral|vmfs.+|nfs", datastore!~".+swap"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.8
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          dashboard: vcenter-datastore-utilization
+          meta: '{{ $labels.type }} datastore {{ $labels.datastore }} utilization > 80%.
+            ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
+          playbook: docs/support/playbook/datastore/datastorediskusagealarm
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: DataStoreCapacity
+        annotations:
+          description: '{{ $labels.type }} datastore {{ $labels.datastore }} utilization
+            > 90%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
+          summary: '{{ $labels.type }} datastore {{ $labels.datastore }} utilization >
+            90%. ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
+        expr: |
+          vrops_datastore_diskspace_total_usage_gigabytes{type!~"ephemeral|vmfs.+|nfs", datastore!~".+swap"} / vrops_datastore_diskspace_capacity_gigabytes >=  0.9
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          dashboard: vcenter-datastore-utilization
+          meta: '{{ $labels.type }} datastore {{ $labels.datastore }} utilization > 90%.
+            ({{ $labels.vcenter }}, {{ $labels.datacenter }})'
+          playbook: docs/support/playbook/datastore/datastorediskusagealarm
+          service: storage
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: SwapDataStoreUsageWithoutVMs
+        annotations:
+          description: NVMe swap datastore {{ $labels.datastore }} is utilized without
+            associated VMs. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: NVMe swap datastore {{ $labels.datastore }} is utilized without associated
+            VMs. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: |
+          vrops_datastore_diskspace_total_usage_gigabytes{datastore=~".*-swap"} > 10 and vrops_datastore_summary_total_number_vms == 0 unless on (datastore) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "datastore", "$1-swap", "hostsystem", "(node...-bb...).*")
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          meta: NVMe swap datastore {{ $labels.datastore }} is utilized without associated
+            VMs. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#swap-files-exist-on-local-ds-without-running-vms
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NVMeSwapDatastoreMissing
+        annotations:
+          description: |-
+            NVMe swap datastore on `{{ $labels.hostsystem }}` is missing. Model is _{{$labels.hardware_model}}_ and located in cluster *{{ $labels.vccluster }}*
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            NVMe swap datastore on `{{ $labels.hostsystem }}` is missing. Model is _{{$labels.hardware_model}}_ and located in cluster *{{ $labels.vccluster }}*
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_hostsystem_hardware_model{vccluster=~"productionbb\\d+", hardware_model!~"Cisco Systems Inc.+"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          unless on (hostsystem) (label_replace(label_join(vrops_datastore_summary_datastore_accessible{type="NVMe"}, "hostsystem", "", "datastore", "vcenter"), "hostsystem", "$1$2", "hostsystem", "(.+)-swapvc-[a-z]-\\d+(.+)")
+          or vrops_hostsystem_summary_custom_tag_nvme{summary_custom_tag_nvme="false"})
+        for: 5m
+        labels:
+          context: '{{ $labels.hostsystem }}'
+          meta: |-
+            NVMe swap datastore on `{{ $labels.hostsystem }}` is missing. Model is _{{$labels.hardware_model}}_ and located in cluster *{{ $labels.vccluster }}*
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          playbook: docs/support/playbook/datastore/nvmeswapdatastoremissing
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: DatastoreDisconnectedWithVmsOnIt
+        annotations:
+          description: Datastore {{ $labels.datastore }} is disconnected and has virtual
+            machines on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: Datastore {{ $labels.datastore }} is disconnected and has virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: |
+          (label_replace(vrops_datastore_summary_total_number_vms, "hostsystem", "$1", "datastore", "(node[0-9]{3}-[^-]*).*") > 0 and on(datastore) vrops_datastore_summary_datastore_accessible{state="PoweredOff",type!="local"}) unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          meta: Datastore {{ $labels.datastore }} is disconnected and has virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#datastoredisconnectedwithvmsonit
+          service: storage
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: IaasDatastoreDisconnectedWithVmsOnIt
+        annotations:
+          description: Datastore {{ $labels.datastore }} is disconnected and has virtual
+            machines on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: Datastore {{ $labels.datastore }} is disconnected and has virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: |-
+          ((label_replace(vrops_datastore_summary_total_number_vms, "hostsystem", "$1", "datastore", "(node[0-9]{3}-[^-]*).*") > 0 and on(datastore) vrops_datastore_summary_datastore_accessible{state="PoweredOff",type!="local"}) unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 20m
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.datastore }}'
+          meta: Datastore {{ $labels.datastore }} is disconnected and has virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#datastoredisconnectedwithvmsonit
+          service: storage
+          severity: critical
+          support_group: iaas_support
+          tier: vmware
+      - alert: DatastoreDisconnectedWithoutVmsOnIt
+        annotations:
+          description: Datastore {{ $labels.datastore }} is disconnected without virtual
+            machines on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: Datastore {{ $labels.datastore }} is disconnected without virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: |
+          (label_replace(vrops_datastore_summary_total_number_vms, "hostsystem", "$1", "datastore", "(node[0-9]{3}-[^-]*).*") == 0 and on(datastore) vrops_datastore_summary_datastore_accessible{state="PoweredOff",type!="local"}) unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          meta: Datastore {{ $labels.datastore }} is disconnected without virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#datastoredisconnectedwithoutvmsonit
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasDatastoreDisconnectedWithoutVmsOnIt
+        annotations:
+          description: Datastore {{ $labels.datastore }} is disconnected without virtual
+            machines on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: Datastore {{ $labels.datastore }} is disconnected without virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: |-
+          ((label_replace(vrops_datastore_summary_total_number_vms, "hostsystem", "$1", "datastore", "(node[0-9]{3}-[^-]*).*") == 0 and on(datastore) vrops_datastore_summary_datastore_accessible{state="PoweredOff",type!="local"}) unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 20m
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.datastore }}'
+          meta: Datastore {{ $labels.datastore }} is disconnected without virtual machines
+            on it. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#datastoredisconnectedwithoutvmsonit
+          service: storage
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: DatastoreHasLostConnectivityToAStorageDevice
+        annotations:
+          description: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has lost connectivity to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has lost connectivity to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          label_replace(vrops_datastore_alert_info{alert_name="Datastore has lost connectivity to a storage device"}, "hostsystem", "$1", "datastore", "(node.*)(-.*)") unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+        labels:
+          meta: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has lost connectivity to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#datastorehashoststhathavelostredundantpathsanddatastorehaslostconnectivitytoastoragedevice
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasDatastoreHasLostConnectivityToAStorageDevice
+        annotations:
+          description: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has lost connectivity to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has lost connectivity to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |-
+          (label_replace(vrops_datastore_alert_info{alert_name="Datastore has lost connectivity to a storage device"}, "hostsystem", "$1", "datastore", "(node.*)(-.*)") unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          meta: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has lost connectivity to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#datastorehashoststhathavelostredundantpathsanddatastorehaslostconnectivitytoastoragedevice
+          service: storage
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: DatastoreHasHostsThatHaveLostRedundantPathsToAStorageDevice
+        annotations:
+          description: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has hosts that have lost redundant paths to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has hosts that have lost redundant paths to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          label_replace(vrops_datastore_alert_info{alert_name="Datastore has one or more hosts that have lost redundant paths to a storage device"}, "hostsystem", "$1", "datastore", "(node.*)(-.*)") unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+        labels:
+          meta: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has hosts that have lost redundant paths to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#datastorehashoststhathavelostredundantpathsanddatastorehaslostconnectivitytoastoragedevice
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasDatastoreHasHostsThatHaveLostRedundantPathsToAStorageDevice
+        annotations:
+          description: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has hosts that have lost redundant paths to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has hosts that have lost redundant paths to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |-
+          (label_replace(vrops_datastore_alert_info{alert_name="Datastore has one or more hosts that have lost redundant paths to a storage device"}, "hostsystem", "$1", "datastore", "(node.*)(-.*)") unless on (hostsystem) label_replace(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}, "hostsystem", "$1", "hostsystem", "(node.*)(.cc.*)")
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          meta: |-
+            The `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone has hosts that have lost redundant paths to a storage device
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#datastorehashoststhathavelostredundantpathsanddatastorehaslostconnectivitytoastoragedevice
+          service: storage
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: SDRSClusterCapacity
+        annotations:
+          description: DataStore Cluster {{ $labels.storagepod }} utilization > 80%. ({{
+            $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: DataStore Cluster {{ $labels.storagepod }} utilization > 80%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+        expr: |
+          vrops_storagepod_capacity_available_space / vrops_storagepod_capacity_total * 100 <= 20
+        for: 20m
+        labels:
+          context: '{{ $labels.storagepod }}'
+          dashboard: vcenter-datastore-utilization
+          meta: DataStore Cluster {{ $labels.storagepod }} utilization > 80%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          playbook: docs/support/playbook/datastore/datastorediskusagealarm
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: SDRSClusterCapacity
+        annotations:
+          description: DataStore Cluster {{ $labels.storagepod }} utilization > 90%. ({{
+            $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: DataStore Cluster {{ $labels.storagepod }} utilization > 90%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+        expr: |
+          vrops_storagepod_capacity_available_space / vrops_storagepod_capacity_total * 100 <= 10
+        for: 20m
+        labels:
+          context: '{{ $labels.storagepod }}'
+          dashboard: vcenter-datastore-utilization
+          meta: DataStore Cluster {{ $labels.storagepod }} utilization > 90%. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          playbook: docs/support/playbook/datastore/datastorediskusagealarm
+          service: storage
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: NVMeDatastoreNotAccessible
+        annotations:
+          description: Datastore {{ $labels.datastore }} is not accessible. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          summary: Datastore {{ $labels.datastore }} is not accessible. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+        expr: |
+          vrops_datastore_summary_datastore_accessible{type='NVMe'} == 0
+        for: 5m
+        labels:
+          context: '{{ $labels.datastore }}'
+          meta: Datastore {{ $labels.datastore }} is not accessible. ({{ $labels.vcenter
+            }}, {{ $labels.datacenter }})
+          service: storage
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: EphemeralDatastoreNotPartOfSDRSCluster
+        annotations:
+          description: Eph Datastore {{ $labels.datastore }} is not a part of SDRS Cluster.
+            ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: Eph Datastore {{ $labels.datastore }} is not a part of SDRS Cluster.
+            ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: |
+          vrops_datastore_summary_datastore_accessible{type="ephemeral", storagepod=~"none|None|NONE", datastore=~"eph.*"} > 0
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          meta: Eph Datastore {{ $labels.datastore }} is not a part of SDRS cluster. ({{
+            $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#ephemeraldatastorenotpartofsdrscluster
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: EphemeralDatastorePartOfIncorrectSDRSCluster
+        annotations:
+          description: Eph Datastore {{ $labels.datastore }} is not a part of correct
+            SDRS Cluster. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: Eph Datastore {{ $labels.datastore }} is not a part of correct SDRS
+            Cluster. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: |
+          (vrops_datastore_summary_datastore_accessible{type="ephemeral", storagepod=~".*hgb.*", datastore=~"eph.*hga"} or vrops_datastore_summary_datastore_accessible{type="ephemeral", storagepod=~".*hga.*", datastore=~"eph.*hgb"}) > 0
+        for: 20m
+        labels:
+          context: '{{ $labels.datastore }}'
+          meta: Eph Datastore {{ $labels.datastore }} is not a part of correct SDRS cluster.
+            ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#ephemeraldatastorepartofincorrectsdrscluster
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: CinderTagMissingForDatastoreSSD
+        annotations:
+          description: |-
+            There is no Cinder tag present for the `{{ $labels.datastore }}` datastore in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            There is no Cinder tag present for the `{{ $labels.datastore }}` datastore in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_datastore_summary_tag{type="vmfs_p_ssd", summary_tag="none"}
+          unless on (datastore) vrops_datastore_summary_custom_tag_cinder_state{summary_custom_tag_cinder_state="reserved"}
+        for: 1h
+        labels:
+          meta: |-
+            There is no Cinder tag present for the `{{ $labels.datastore }}` datastore in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          playbook: docs/support/playbook/cinder/cinder-tag-missing
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: CinderTagMissingForDatastoreHDD
+        annotations:
+          description: |-
+            There is no Cinder tag present for the `{{ $labels.datastore }}` datastore in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            There is no Cinder tag present for the `{{ $labels.datastore }}` datastore in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_datastore_summary_tag{type="vmfs_s_hdd", summary_tag="none"}
+          unless on (datastore) vrops_datastore_summary_custom_tag_cinder_state{summary_custom_tag_cinder_state="reserved"}
+        for: 1h
+        labels:
+          meta: |-
+            There is no Cinder tag present for the `{{ $labels.datastore }}` datastore in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          playbook: docs/support/playbook/cinder/cinder-tag-missing
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: CinderTagAddedForReservedDatastore
+        annotations:
+          description: |-
+            The Cinder state is reserved but the Cinder tag still exists for the `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The Cinder state is reserved but the Cinder tag still exists for the `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_datastore_summary_custom_tag_cinder_state{type=~"(vmfs_s_hdd|vmfs_p_ssd)", summary_custom_tag_cinder_state="reserved"} > 0
+          and on (datastore) vrops_datastore_summary_tag{tag_cinder=~"cinder|slow"}
+        for: 1h
+        labels:
+          meta: |-
+            The Cinder state is reserved but the Cinder tag still exists for the `{{ $labels.datastore }}` datastore of type: _{{ $labels.type }}_ in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          playbook: docs/support/playbook/cinder/cinder-tag-added
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VMFSDatastoreHostcountMismatch
+        annotations:
+          description: |-
+            The `{{ $labels.datastore }}` VMFS datastore is not connected to all production ESXi hosts in *{{ $labels.vcenter }}* vCenter.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The `{{ $labels.datastore }}` VMFS datastore is not connected to all production ESXi hosts in *{{ $labels.vcenter }}* vCenter.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_datastore_hostcount{type=~"(vmfs_s_hdd|vmfs_p_ssd)"} < on (vcenter) group_left
+          count by (vcenter) (vrops_hostsystem_runtime_connectionstate{state="connected", vccluster=~"productionbb\\d+"}
+          unless on (hostsystem) (vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}))
+        for: 60m
+        labels:
+          meta: |-
+            The `{{ $labels.datastore }}` VMFS datastore is not connected to all production ESXi hosts in *{{ $labels.vcenter }}* vCenter.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          playbook: docs/devops/alert/vcenter/#vmfsdatastorehostcountmismatch
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NFSDatastoreHostcountMismatch
+        annotations:
+          description: |-
+            The `{{ $labels.datastore }}` NFS datastore is not connected to all production ESXi hosts in *{{ $labels.vcenter }}* vCenter.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The `{{ $labels.datastore }}` NFS datastore is not connected to all production ESXi hosts in *{{ $labels.vcenter }}* vCenter.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_datastore_hostcount{type="nfs"} < on (vcenter) group_left
+          count by (vcenter) (vrops_hostsystem_runtime_connectionstate{state="connected", vccluster=~"productionbb\\d+"})
+        for: 60m
+        labels:
+          meta: |-
+            The `{{ $labels.datastore }}` NFS datastore is not connected to all production ESXi hosts in *{{ $labels.vcenter }}* vCenter.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          playbook: docs/devops/alert/vcenter/#nfsdatastorehostcountmismatch
+          service: storage
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: NFSDatastoreCinderAggregateIDNotSet
+        annotations:
+          description: |-
+            cinder_aggregate_id is not set for the `{{ $labels.datastore }}` NFS datastore in *{{ $labels.datacenter }}* availability zone.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            cinder_aggregate_id is not set for the `{{ $labels.datastore }}` NFS datastore in *{{ $labels.datacenter }}* availability zone.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_datastore_summary_datastore_accessible{type="nfs"}
+          unless on(datastore) vrops_datastore_summary_custom_tag_cinder_aggregate_id{type="nfs", summary_custom_tag_cinder_aggregate_id!=""}
+        for: 1h
+        labels:
+          meta: |-
+            cinder_aggregate_id is not set for the `{{ $labels.datastore }}` NFS datastore in *{{ $labels.datacenter }}* availability zone.
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          playbook: docs/support/playbook/cinder/cinder-fcd-operations/#nfsdatastorecinderaggregateidnotset
+          service: storage
+          severity: warning
+          support_group: compute
+          tier: vmware
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-b-0-alerts-host.alerts
+  labels:
+    prometheus: vmware-vc-b-0
+
+spec:
+  groups:
+    - name: host.alerts
+      rules:
+      - alert: HostWithRunningVMsNotResponding
+        annotations:
+          description: Host {{ $labels.hostsystem }} with running VMs not responding.
+            ({{ $labels.vcenter }}, {{ $labels.vccluster }})
+          summary: Host {{ $labels.hostsystem }} with running VMs not responding. ({{
+            $labels.vcenter }}, {{ $labels.vccluster }})
+        expr: |
+          avg_over_time(vrops_hostsystem_runtime_connectionstate{state="notResponding"}[5m])
+          and on (hostsystem) avg_over_time(vrops_hostsystem_runtime_powerstate{state!="Powered Off"}[5m])
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"}
+          and on (hostsystem) count(vrops_virtualmachine_runtime_powerstate{virtualmachine!~"vCLS.*", state!="Powered Off"}) by (hostsystem) > 0
+        for: 5m
+        labels:
+          context: ESXi not responding
+          dashboard: esxi-host-disconnected/esxi-host-disconnected?&var-host={{ $labels.hostsystem
+            }}
+          meta: Host {{ $labels.hostsystem }} with running VMs not responding. ({{ $labels.vcenter
+            }}, {{ $labels.vccluster }})
+          playbook: docs/devops/alert/vcenter/#hostwithrunningvmsnotresponding
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostWithRunningVMsNotResponding
+        annotations:
+          description: Host {{ $labels.hostsystem }} with running VMs not responding.
+            ({{ $labels.vcenter }}, {{ $labels.vccluster }})
+          summary: Host {{ $labels.hostsystem }} with running VMs not responding. ({{
+            $labels.vcenter }}, {{ $labels.vccluster }})
+        expr: |-
+          (avg_over_time(vrops_hostsystem_runtime_connectionstate{state="notResponding"}[5m])
+          and on (hostsystem) avg_over_time(vrops_hostsystem_runtime_powerstate{state!="Powered Off"}[5m])
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"}
+          and on (hostsystem) count(vrops_virtualmachine_runtime_powerstate{virtualmachine!~"vCLS.*", state!="Powered Off"}) by (hostsystem) > 0
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 5m
+        labels:
+          bedrock: "true"
+          context: ESXi not responding
+          dashboard: esxi-host-disconnected/esxi-host-disconnected?&var-host={{ $labels.hostsystem
+            }}
+          meta: Host {{ $labels.hostsystem }} with running VMs not responding. ({{ $labels.vcenter
+            }}, {{ $labels.vccluster }})
+          playbook: docs/devops/alert/vcenter/#hostwithrunningvmsnotresponding
+          service: compute
+          severity: critical
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostNotResponding
+        annotations:
+          description: Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter
+            }}, {{ $labels.vccluster }})
+          summary: Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter }},
+            {{ $labels.vccluster }})
+        expr: |
+          vrops_hostsystem_summary_running_vms_number == 0 and
+          on (hostsystem) vrops_hostsystem_runtime_connectionstate{state="notResponding"} and
+          on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"} and
+          on (hostsystem) vrops_hostsystem_runtime_powerstate{state!="Powered Off"}
+        labels:
+          context: ESXi not responding
+          dashboard: esxi-host-disconnected/esxi-host-disconnected?&var-host={{ $labels.hostsystem
+            }}
+          meta: Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter }},
+            {{ $labels.vccluster }})
+          playbook: docs/devops/alert/vcenter/#hostnotresponding
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostNotResponding
+        annotations:
+          description: Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter
+            }}, {{ $labels.vccluster }})
+          summary: Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter }},
+            {{ $labels.vccluster }})
+        expr: |-
+          (vrops_hostsystem_summary_running_vms_number == 0 and
+          on (hostsystem) vrops_hostsystem_runtime_connectionstate{state="notResponding"} and
+          on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"} and
+          on (hostsystem) vrops_hostsystem_runtime_powerstate{state!="Powered Off"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: ESXi not responding
+          dashboard: esxi-host-disconnected/esxi-host-disconnected?&var-host={{ $labels.hostsystem
+            }}
+          meta: Host {{ $labels.hostsystem }} not responding. ({{ $labels.vcenter }},
+            {{ $labels.vccluster }})
+          playbook: docs/devops/alert/vcenter/#hostnotresponding
+          service: compute
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: VMsOnFailoverHost
+        annotations:
+          description: Failover Host {{ $labels.hostsystem }} has Virtual Machines on
+            it. Free up the host. ({{ $labels.vcenter }}, {{ $labels.vccluster }})
+          summary: Failover Host {{ $labels.hostsystem }} has Virtual Machines on it.
+            ({{ $labels.vcenter }}, {{ $labels.vccluster }})
+        expr: |
+          vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost == 1
+          and on (hostsystem) count(vrops_virtualmachine_runtime_powerstate{virtualmachine!~"vCLS.*", state="Powered On"}) by (hostsystem) > 0
+        for: 10m
+        labels:
+          context: Failover host
+          meta: Failover Host {{ $labels.hostsystem }} has Virtual Machines on it. ({{
+            $labels.vcenter }}, {{ $labels.vccluster }})
+          playbook: docs/devops/alert/vcenter/#vmsonfailoverhost
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: IaasVMsOnFailoverHost
+        annotations:
+          description: Failover Host {{ $labels.hostsystem }} has Virtual Machines on
+            it. Free up the host. ({{ $labels.vcenter }}, {{ $labels.vccluster }})
+          summary: Failover Host {{ $labels.hostsystem }} has Virtual Machines on it.
+            ({{ $labels.vcenter }}, {{ $labels.vccluster }})
+        expr: |-
+          (vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost == 1
+          and on (hostsystem) count(vrops_virtualmachine_runtime_powerstate{virtualmachine!~"vCLS.*", state="Powered On"}) by (hostsystem) > 0
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 10m
+        labels:
+          bedrock: "true"
+          context: Failover host
+          meta: Failover Host {{ $labels.hostsystem }} has Virtual Machines on it. ({{
+            $labels.vcenter }}, {{ $labels.vccluster }})
+          playbook: docs/devops/alert/vcenter/#vmsonfailoverhost
+          service: compute
+          severity: critical
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostHasLostRedundantConnectivityToDVPort
+        annotations:
+          description: Host `{{ $labels.hostsystem }}` has lost redundant connectivity
+            to a dvPort. ({{ $labels.vcenter }}).
+          summary: Host `{{ $labels.hostsystem }}` has lost redundant connectivity to
+            a dvPort. ({{ $labels.vcenter }}).
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="The host has lost redundant connectivity to a dvPort"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        labels:
+          context: '{{ $labels.hostsystem }} dvPort connection'
+          meta: Host `{{ $labels.hostsystem }}` has lost redundant connectivity to a dvPort.
+            ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#host_has_lost_connectivity_to_a_dv_port
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostHasLostRedundantConnectivityToDVPort
+        annotations:
+          description: Host `{{ $labels.hostsystem }}` has lost redundant connectivity
+            to a dvPort. ({{ $labels.vcenter }}).
+          summary: Host `{{ $labels.hostsystem }}` has lost redundant connectivity to
+            a dvPort. ({{ $labels.vcenter }}).
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="The host has lost redundant connectivity to a dvPort"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} dvPort connection'
+          meta: Host `{{ $labels.hostsystem }}` has lost redundant connectivity to a dvPort.
+            ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#host_has_lost_connectivity_to_a_dv_port
+          service: compute
+          severity: info
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostNicDown
+        annotations:
+          description: '`{{ $labels.hostsystem }}` has detected a link status down on
+            a physical NIC. ({{ $labels.vcenter }}).'
+          summary: '`{{ $labels.hostsystem }}` has detected a link status down on a physical
+            NIC. ({{ $labels.vcenter }}).'
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="ESXi host has detected a link status down on a physical NIC"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        for: 20m
+        labels:
+          context: '{{ $labels.hostsystem }} network connection'
+          meta: '`{{ $labels.hostsystem }}` has detected a link status down on a physical
+            NIC. ({{ $labels.vcenter }}).'
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hostnicdown
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostNicDown
+        annotations:
+          description: '`{{ $labels.hostsystem }}` has detected a link status down on
+            a physical NIC. ({{ $labels.vcenter }}).'
+          summary: '`{{ $labels.hostsystem }}` has detected a link status down on a physical
+            NIC. ({{ $labels.vcenter }}).'
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="ESXi host has detected a link status down on a physical NIC"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 20m
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} network connection'
+          meta: '`{{ $labels.hostsystem }}` has detected a link status down on a physical
+            NIC. ({{ $labels.vcenter }}).'
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hostnicdown
+          service: compute
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostHasLostConnectionToVCenterServer
+        annotations:
+          description: '`{{ $labels.hostsystem }}` has been unexpectedly disconnected
+            from vCenter Server {{ $labels.vcenter }}.'
+          summary: '`{{ $labels.hostsystem }}` has been unexpectedly disconnected from
+            vCenter Server {{ $labels.vcenter }}.'
+        expr: |
+          vrops_hostsystem_runtime_connectionstate{state="disconnected"} AND on (hostsystem)
+          vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"} AND on (hostsystem)
+          vrops_hostsystem_runtime_powerstate{state!="Standby"}
+        labels:
+          context: '{{ $labels.hostsystem }} vCenter connection'
+          meta: '`{{ $labels.hostsystem }}` has been unexpectedly disconnected from vCenter
+            Server {{ $labels.vcenter }}.'
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hosthaslostconnectiontovcenterserver
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostHasLostConnectionToVCenterServer
+        annotations:
+          description: '`{{ $labels.hostsystem }}` has been unexpectedly disconnected
+            from vCenter Server {{ $labels.vcenter }}.'
+          summary: '`{{ $labels.hostsystem }}` has been unexpectedly disconnected from
+            vCenter Server {{ $labels.vcenter }}.'
+        expr: |-
+          (vrops_hostsystem_runtime_connectionstate{state="disconnected"} AND on (hostsystem)
+          vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"} AND on (hostsystem)
+          vrops_hostsystem_runtime_powerstate{state!="Standby"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} vCenter connection'
+          meta: '`{{ $labels.hostsystem }}` has been unexpectedly disconnected from vCenter
+            Server {{ $labels.vcenter }}.'
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hosthaslostconnectiontovcenterserver
+          service: compute
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostHasLostConnectivityToPhysicalNetwork
+        annotations:
+          description: Host `{{ $labels.hostsystem }}` has lost connectivity to physical
+            network. ({{ $labels.vcenter }}).
+          summary: Host `{{ $labels.hostsystem }}` has lost connectivity to physical network.
+            ({{ $labels.vcenter }}).
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="The host has lost connectivity to physical network"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        labels:
+          context: '{{ $labels.hostsystem }} network connection'
+          meta: Host `{{ $labels.hostsystem }}` has lost connectivity to physical network.
+            ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#host_has_lost_connectivity_to_physical_network
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostHasLostConnectivityToPhysicalNetwork
+        annotations:
+          description: Host `{{ $labels.hostsystem }}` has lost connectivity to physical
+            network. ({{ $labels.vcenter }}).
+          summary: Host `{{ $labels.hostsystem }}` has lost connectivity to physical network.
+            ({{ $labels.vcenter }}).
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="The host has lost connectivity to physical network"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} network connection'
+          meta: Host `{{ $labels.hostsystem }}` has lost connectivity to physical network.
+            ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#host_has_lost_connectivity_to_physical_network
+          service: compute
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: HADetectedAPossibleHostFailure-testing
+        annotations:
+          description: vSphere High Availability (HA) has detected a possible host failure
+            for `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+          summary: vSphere High Availability (HA) has detected a possible host failure
+            for `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) has detected a possible host failure"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{vccluster!~".*controlplane-swift"}
+        labels:
+          context: '{{ $labels.hostsystem }} failure'
+          meta: vSphere High Availability (HA) has detected a possible host failure for
+            `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hadetectedapossiblehostfailure
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: HADetectedAPossibleHostFailure
+        annotations:
+          description: vSphere High Availability (HA) has detected a possible host failure
+            for `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+          summary: vSphere High Availability (HA) has detected a possible host failure
+            for `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) has detected a possible host failure"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance", vccluster!~".*controlplane-swift"}
+        labels:
+          context: '{{ $labels.hostsystem }} failure'
+          meta: vSphere High Availability (HA) has detected a possible host failure for
+            `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hadetectedapossiblehostfailure
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: IaasHADetectedAPossibleHostFailure
+        annotations:
+          description: vSphere High Availability (HA) has detected a possible host failure
+            for `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+          summary: vSphere High Availability (HA) has detected a possible host failure
+            for `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) has detected a possible host failure"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance", vccluster!~".*controlplane-swift"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} failure'
+          meta: vSphere High Availability (HA) has detected a possible host failure for
+            `{{ $labels.hostsystem }}`. ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hadetectedapossiblehostfailure
+          service: compute
+          severity: critical
+          support_group: iaas_support
+          tier: vmware
+      - alert: APodMemoryUtilizationHigh
+        annotations:
+          description: Memory utilization of host {{ $labels.hostsystem }} is above 90%.
+            ({{ $labels.vcenter }})
+          summary: Memory utilization of host {{ $labels.hostsystem }} is above 90%. ({{
+            $labels.vcenter }})
+        expr: vrops_hostsystem_memory_usage_percentage{vccluster=~".*-management.*"} >
+          95
+        for: 30m
+        labels:
+          context: '{{ $labels.hostsystem }} memory'
+          meta: Memory utilization of host {{ $labels.hostsystem }} is above 90%. ({{
+            $labels.vcenter }})
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: APodCPUUtilizationHigh
+        annotations:
+          description: CPU utilization of host {{ $labels.hostsystem }} is above 90%.
+            ({{ $labels.vcenter }})
+          summary: CPU utilization of host {{ $labels.hostsystem }} is above 90%. ({{
+            $labels.vcenter }})
+        expr: vrops_hostsystem_cpu_usage_average_percentage{vccluster=~".*-management.*"}
+          > 80
+        for: 30m
+        labels:
+          context: '{{ $labels.hostsystem }} cpu'
+          meta: CPU utilization of host {{ $labels.hostsystem }} is above 90%. ({{ $labels.vcenter
+            }})
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: HostHighNumberOfPacketsDropped
+        annotations:
+          description: '`{{ $labels.hostsystem }}` is experiencing high number of packets
+            dropped. ({{ $labels.vcenter }}).'
+          summary: '`{{ $labels.hostsystem }}` is experiencing high number of packets
+            dropped. ({{ $labels.vcenter }}).'
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="Host is experiencing high number of packets dropped"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        labels:
+          context: '{{ $labels.hostsystem }} packets dropped'
+          meta: '`{{ $labels.hostsystem }}` is experiencing high number of packets dropped.
+            ({{ $labels.vcenter }}).'
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostHighNumberOfPacketsDropped
+        annotations:
+          description: '`{{ $labels.hostsystem }}` is experiencing high number of packets
+            dropped. ({{ $labels.vcenter }}).'
+          summary: '`{{ $labels.hostsystem }}` is experiencing high number of packets
+            dropped. ({{ $labels.vcenter }}).'
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="Host is experiencing high number of packets dropped"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} packets dropped'
+          meta: '`{{ $labels.hostsystem }}` is experiencing high number of packets dropped.
+            ({{ $labels.vcenter }}).'
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostNicLinkFlappingAlert
+        annotations:
+          description: '`{{ $labels.hostsystem }}` has detected a link status flapping
+            on a physical NIC. ({{ $labels.vcenter }}).'
+          summary: '`{{ $labels.hostsystem }}` has detected a link status flapping on
+            a physical NIC. ({{ $labels.vcenter }}).'
+        expr: |
+          vrops_hostsystem_alert_info{alert_name=~"ESXi host has detected a link status.*flapping.*on a physical NIC"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        labels:
+          context: '{{ $labels.hostsystem }} link flapping'
+          meta: '`{{ $labels.hostsystem }}` has detected a link status flapping on a physical
+            NIC. ({{ $labels.vcenter }}).'
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostNicLinkFlappingAlert
+        annotations:
+          description: '`{{ $labels.hostsystem }}` has detected a link status flapping
+            on a physical NIC. ({{ $labels.vcenter }}).'
+          summary: '`{{ $labels.hostsystem }}` has detected a link status flapping on
+            a physical NIC. ({{ $labels.vcenter }}).'
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name=~"ESXi host has detected a link status.*flapping.*on a physical NIC"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} link flapping'
+          meta: '`{{ $labels.hostsystem }}` has detected a link status flapping on a physical
+            NIC. ({{ $labels.vcenter }}).'
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostSystemEventLogSensorAlert
+        annotations:
+          description: IPMI System Event Log for `{{ $labels.hostsystem }}` is becoming
+            full. ({{ $labels.vcenter }}) {{ $labels.recommendation_1 }}
+          summary: IPMI System Event Log for `{{ $labels.hostsystem }}` is becoming full.
+            ({{ $labels.vcenter }}) {{ $labels.recommendation_1 }}
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="IPMI System Event Log for the host is becoming full"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        labels:
+          context: '{{ $labels.hostsystem }} IPMI log'
+          meta: IPMI System Event Log for `{{ $labels.hostsystem }}` is becoming full.
+            ({{ $labels.vcenter }}) {{ $labels.recommendation_1 }}
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostSystemEventLogSensorAlert
+        annotations:
+          description: IPMI System Event Log for `{{ $labels.hostsystem }}` is becoming
+            full. ({{ $labels.vcenter }}) {{ $labels.recommendation_1 }}
+          summary: IPMI System Event Log for `{{ $labels.hostsystem }}` is becoming full.
+            ({{ $labels.vcenter }}) {{ $labels.recommendation_1 }}
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="IPMI System Event Log for the host is becoming full"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} IPMI log'
+          meta: IPMI System Event Log for `{{ $labels.hostsystem }}` is becoming full.
+            ({{ $labels.vcenter }}) {{ $labels.recommendation_1 }}
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostStoragePathsDown
+        annotations:
+          description: More than 4 active storage paths for `{{ $labels.hostsystem }}`
+            down. ({{ $labels.vcenter }})
+          summary: More than 4 active storage paths for `{{ $labels.hostsystem }}` down.
+            ({{ $labels.vcenter }})
+        expr: vrops_hostsystem_storage_number_of_path - vrops_hostsystem_storage_number_of_active_path
+          > 4
+        for: 30m
+        labels:
+          context: '{{ $labels.hostsystem }} storage paths'
+          meta: More than 4 active storage paths for `{{ $labels.hostsystem }}` down.
+            ({{ $labels.vcenter }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostStoragePathsDown
+        annotations:
+          description: More than 4 active storage paths for `{{ $labels.hostsystem }}`
+            down. ({{ $labels.vcenter }})
+          summary: More than 4 active storage paths for `{{ $labels.hostsystem }}` down.
+            ({{ $labels.vcenter }})
+        expr: (vrops_hostsystem_storage_number_of_path - vrops_hostsystem_storage_number_of_active_path
+          > 4) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 30m
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} storage paths'
+          meta: More than 4 active storage paths for `{{ $labels.hostsystem }}` down.
+            ({{ $labels.vcenter }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: iaas_support
+          tier: vmware
+      - alert: HostAllRedundantStoragePathsDown
+        annotations:
+          description: All active storage paths for `{{ $labels.hostsystem }}` down. ({{
+            $labels.vcenter }})
+          summary: All active storage paths for `{{ $labels.hostsystem }}` down. ({{ $labels.vcenter
+            }})
+        expr: vrops_hostsystem_storage_number_of_active_path == 0
+        for: 10m
+        labels:
+          context: '{{ $labels.hostsystem }} storage paths'
+          meta: All active storage paths for `{{ $labels.hostsystem }}` down. ({{ $labels.vcenter
+            }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostAllRedundantStoragePathsDown
+        annotations:
+          description: All active storage paths for `{{ $labels.hostsystem }}` down. ({{
+            $labels.vcenter }})
+          summary: All active storage paths for `{{ $labels.hostsystem }}` down. ({{ $labels.vcenter
+            }})
+        expr: (vrops_hostsystem_storage_number_of_active_path == 0) and on(hostsystem)
+          vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 10m
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} storage paths'
+          meta: All active storage paths for `{{ $labels.hostsystem }}` down. ({{ $labels.vcenter
+            }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: iaas_support
+          tier: vmware
+      - alert: HAHostAgentError
+        annotations:
+          description: HA agent on Host `{{ $labels.hostsystem }}` has encountered an
+            error. ({{ $labels.vcenter }}).
+          summary: HA agent on Host `{{ $labels.hostsystem }}` has encountered an error.
+            ({{ $labels.vcenter }}).
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) host agent has encountered an error", vccluster!~".*-controlplane-swift"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        labels:
+          context: '{{ $labels.hostsystem }} HA agent error'
+          meta: HA agent on Host `{{ $labels.hostsystem }}` has encountered an error.
+            ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#troubleshooting-vsphere-ha-host-states
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasHAHostAgentError
+        annotations:
+          description: HA agent on Host `{{ $labels.hostsystem }}` has encountered an
+            error. ({{ $labels.vcenter }}).
+          summary: HA agent on Host `{{ $labels.hostsystem }}` has encountered an error.
+            ({{ $labels.vcenter }}).
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) host agent has encountered an error", vccluster!~".*-controlplane-swift"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} HA agent error'
+          meta: HA agent on Host `{{ $labels.hostsystem }}` has encountered an error.
+            ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#troubleshooting-vsphere-ha-host-states
+          service: compute
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: HAHostNetworkPartitioned
+        annotations:
+          description: HA on Host `{{ $labels.hostsystem }}` has detected a network-partitioned
+            host. ({{ $labels.vcenter }}).
+          summary: HA on Host `{{ $labels.hostsystem }}` has detected a network-partitioned
+            host. ({{ $labels.vcenter }}).
+        expr: |
+          vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) has detected a network-partitioned host"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+        labels:
+          context: '{{ $labels.hostsystem }} HA network-partitioned host'
+          meta: HA on Host `{{ $labels.hostsystem }}` has detected a network-partitioned
+            host. ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#troubleshooting-vsphere-ha-host-states
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasHAHostNetworkPartitioned
+        annotations:
+          description: HA on Host `{{ $labels.hostsystem }}` has detected a network-partitioned
+            host. ({{ $labels.vcenter }}).
+          summary: HA on Host `{{ $labels.hostsystem }}` has detected a network-partitioned
+            host. ({{ $labels.vcenter }}).
+        expr: |-
+          (vrops_hostsystem_alert_info{alert_name="vSphere High Availability (HA) has detected a network-partitioned host"}
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"}
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} HA network-partitioned host'
+          meta: HA on Host `{{ $labels.hostsystem }}` has detected a network-partitioned
+            host. ({{ $labels.vcenter }}).
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#troubleshooting-vsphere-ha-host-states
+          service: compute
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+      - alert: APodHostRunsMultipleVCenters
+        annotations:
+          description: aPod node `{{ $labels.hostsystem }}` runs multiple vCenter VMs.
+            ({{ $labels.vcenter }})
+          summary: aPod node `{{ $labels.hostsystem }}` runs multiple vCenter VMs. ({{
+            $labels.vcenter }})
+        expr: count(vrops_virtualmachine_runtime_connectionstate{vccluster=~".*-management",
+          virtualmachine=~"vc-.*"}) by(hostsystem, vcenter) > 1
+        for: 30m
+        labels:
+          context: '{{ $labels.hostsystem }} multiple vCenters'
+          meta: aPod node `{{ $labels.hostsystem }}` runs multiple vCenter VMs. ({{ $labels.vcenter
+            }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: HostStoragePathCheck
+        annotations:
+          description: storage paths for `{{ $labels.hostsystem }}` is less than other
+            hosts in the `{{ $labels.vccluster }}`. ({{ $labels.vcenter }})
+          summary: storage paths for `{{ $labels.hostsystem }}` is less than other hosts
+            in the `{{ $labels.vccluster }}`. ({{ $labels.vcenter }})
+        expr: vrops_hostsystem_storage_number_of_path < on(vccluster) group_left() (max(vrops_hostsystem_storage_number_of_path)
+          by(vccluster))
+        for: 30m
+        labels:
+          context: '{{ $labels.hostsystem }} storage paths'
+          meta: storage paths for `{{ $labels.hostsystem }}` is less than other hosts
+            in the `{{ $labels.vccluster }}`. ({{ $labels.vcenter }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: IaasHostStoragePathCheck
+        annotations:
+          description: storage paths for `{{ $labels.hostsystem }}` is less than other
+            hosts in the `{{ $labels.vccluster }}`. ({{ $labels.vcenter }})
+          summary: storage paths for `{{ $labels.hostsystem }}` is less than other hosts
+            in the `{{ $labels.vccluster }}`. ({{ $labels.vcenter }})
+        expr: (vrops_hostsystem_storage_number_of_path < on(vccluster) group_left() (max(vrops_hostsystem_storage_number_of_path)
+          by(vccluster))) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 30m
+        labels:
+          bedrock: "true"
+          context: '{{ $labels.hostsystem }} storage paths'
+          meta: storage paths for `{{ $labels.hostsystem }}` is less than other hosts
+            in the `{{ $labels.vccluster }}`. ({{ $labels.vcenter }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: iaas_support
+          tier: vmware
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-b-0-alerts-iaas.alerts
+  labels:
+    prometheus: vmware-vc-b-0
+
+spec:
+  groups:
+    - name: iaas.alerts
+      rules:
+      - alert: IaasHostMemoryUsage
+        annotations:
+          description: Memory usage of ESXi host {{ $labels.hostsystem}} is above 75%
+          summary: Memory usage of ESXi host {{ $labels.hostsystem}} is above 75%
+        expr: vrops_hostsystem_memory_usage_percentage > 75 and on (hostsystem) vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+        for: 30m
+        labels:
+          context: esxi host memory usage
+          meta: Memory usage of ESXi host {{ $labels.hostsystem}} is above 75%
+          service: compute
+          severity: warning
+          support_group: iaas-support
+      - alert: IaasHostMemoryUsage
+        annotations:
+          description: Memory usage of ESXi host {{ $labels.hostsystem}} is above 90%
+          summary: Memory usage of ESXi host {{ $labels.hostsystem}} is above 90%
+        expr: vrops_hostsystem_memory_usage_percentage > 90 and on (hostsystem) vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+        for: 30m
+        labels:
+          context: esxi host memory usage
+          meta: Memory usage of ESXi host {{ $labels.hostsystem}} is above 90%
+          service: compute
+          severity: critical
+          support_group: iaas-support
+      - alert: IaasHostLicenseKey
+        annotations:
+          description: IaaS ESXi host {{ $labels.hostsystem }} in IaaS host group without
+            valid license
+          summary: IaaS ESXi host {{ $labels.hostsystem }} in IaaS host group without
+            valid license
+        expr: vrops_hostsystem_license_key{license_key!~"GM693.*"} + on (hostsystem) group_right(license_key)
+          vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"} > 0
+        for: 30m
+        labels:
+          context: esxi host license key
+          meta: IaaS ESXi host {{ $labels.hostsystem }} in IaaS host group without valid
+            license
+          service: compute
+          severity: warning
+          support_group: iaas-support
+      - alert: IaasClusterWithoutFailoverHost
+        annotations:
+          description: IaaS cluster {{ $labels.vccluster }} has NO failover host configured
+          summary: IaaS cluster {{ $labels.vccluster }} has NO failover host configured
+        expr: |
+          (count by (vccluster) (vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}) > 0)
+          unless (count by (vccluster) (vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+          and on(hostsystem) vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{} == 1 ) > 0)
+        for: 15m
+        labels:
+          context: IaaS cluster HA policy
+          meta: IaaS cluster {{ $labels.vccluster }} has NO failover host configured
+          service: compute
+          severity: critical
+          support_group: iaas-support
+      - alert: NonIaasVmOnIaasHost
+        annotations:
+          description: Non IaaS virtual machine(s) running on IaaS ESXi host {{ $labels.hostsystem
+            }}
+          summary: Non IaaS virtual machine(s) running on IaaS ESXi host {{ $labels.hostsystem
+            }}
+        expr: |
+          count by (hostsystem) (
+            (
+              group by (project, hostsystem, virtualmachine)(vrops_virtualmachine_system_powered_on{}==1)
+              and on(project)
+              group by(project) (label_replace(limes_project_usage{domain!~"iaas-.*"}, "project", "$1", "project_id", "(.*)"))
+            )
+          )
+          and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+        for: 30m
+        labels:
+          context: non IaaS vm on IaaS cluster
+          meta: Non IaaS virtual machine(s) running on IaaS ESXi host {{ $labels.hostsystem
+            }}
+          service: compute
+          severity: warning
+          support_group: iaas-support
+      - alert: IaasHostsAlmostOutOfMemory
+        annotations:
+          description: All IaaS hosts in cluster {{ $labels.vccluster }} are above 75%
+            memory
+          summary: All IaaS hosts in cluster {{ $labels.vccluster }} are above 75% memory
+        expr: |
+          count by (vccluster) (
+            (vrops_hostsystem_memory_usage_percentage > 75)
+            and on(hostsystem)
+            vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+            unless on(hostsystem)
+            vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{} == 1
+          )
+          == on(vccluster)
+          count by (vccluster) (
+            vrops_hostsystem_memory_usage_percentage
+            and on(hostsystem)
+            vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+            unless on(hostsystem)
+            vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{} == 1
+          )
+          and on(vccluster)
+          count by (vccluster) (
+            vrops_hostsystem_memory_usage_percentage
+            and on(hostsystem)
+            vrops_hostsystem_hostgroups{hostgroups=~".*iaas.*"}
+            unless on(hostsystem)
+            vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{} == 1
+          ) > 0
+        for: 60m
+        labels:
+          context: IaaS hosts in cluster are almost out of memory
+          meta: All IaaS hosts in cluster {{ $labels.vccluster }} are above 75% memory
+          service: compute
+          severity: warning
+          support_group: iaas-support
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-b-0-alerts-k8s-vc-mgmt.alerts
+  labels:
+    prometheus: vmware-vc-b-0
+
+spec:
+  groups:
+    - name: k8s-vc-mgmt.alerts
+      rules:
+      - alert: VCClusterCPUContention
+        annotations:
+          description: The VCCluster {{ $labels.vccluster}} is using {{ $value }} CPU
+            and VM's are fighting for it
+          summary: '{{ $labels.vccluster}} cpu contention critical'
+        expr: vrops_cluster_cpu_contention_percentage{vcenter=~"vc-mgmt-.*"} > 5
+        for: 15m
+        labels:
+          context: vccluster
+          meta: The VCCluster {{ $labels.vccluster}} is using too much CPU and VM's are
+            fighting for it
+          no_alert_on_absence: "true"
+          service: cc-cp
+          severity: info
+          support_group: containers
+          tier: k8s
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-b-0-alerts-nsxt.alerts
+  labels:
+    prometheus: vmware-vc-b-0
+
+spec:
+  groups:
+    - name: nsxt.alerts
+      rules:
+      - alert: NSXTDistributedFirewallSectionUsageLimitExceeded
+        annotations:
+          description: NSX-T cluster {{ $labels.nsxt_adapter }} firewall sections usage
+            exceeded the supported limit. https://{{ $labels.target }}
+          summary: NSX-T cluster {{ $labels.nsxt_adapter }} firewall sections usage exceeded
+            the supported limit. https://{{ $labels.target }}
+        expr: |
+          vrops_nsxt_mgmt_cluster_sys_capacity_distributed_firewall_section_usage_count /
+          vrops_nsxt_mgmt_cluster_sys_capacity_distributed_firewall_section_max_supported_count > 0.9
+        for: 10m
+        labels:
+          dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
+          meta: NSX-T cluster {{ $labels.nsxt_adapter }} firewall sections usage exceeded
+            the supported limit. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTDistributedFirewallRulesUsageLimitExceeded
+        annotations:
+          description: NSX-T cluster {{ $labels.nsxt_adapter }} firewall rules usage exceeded
+            the supported limit. https://{{ $labels.target }}
+          summary: NSX-T cluster {{ $labels.nsxt_adapter }} firewall sections rules exceeded
+            the supported limit. https://{{ $labels.target }}
+        expr: |
+          vrops_nsxt_mgmt_cluster_sys_capacity_distributed_firewall_rules_usage_count /
+          vrops_nsxt_mgmt_cluster_sys_capacity_distributed_firewall_rules_max_supported_count > 0.9
+        for: 10m
+        labels:
+          dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
+          meta: NSX-T cluster {{ $labels.nsxt_adapter }} firewall rules usage exceeded
+            the supported limit. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTLogicalSwitchesUsageLimitExceeded
+        annotations:
+          description: NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switches
+            exceeded the supported limit. https://{{ $labels.target }}
+          summary: NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switches
+            exceeded the supported limit. https://{{ $labels.target }}
+        expr: |
+          vrops_nsxt_mgmt_cluster_sys_capacity_logical_switches_usage_count /
+          vrops_nsxt_mgmt_cluster_sys_capacity_logical_switches_max_supported_count > 0.9
+        for: 10m
+        labels:
+          dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
+          meta: NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switches exceeded
+            the supported limit. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTLogicalSwitchPortsUsageWarningLimitExceeded
+        annotations:
+          description: NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switch
+            ports exceeded the supported limit. https://{{ $labels.target }}
+          summary: NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switch ports
+            exceeded the supported limit. https://{{ $labels.target }}
+        expr: |
+          vrops_nsxt_mgmt_cluster_sys_capacity_logical_switch_ports_usage_count /
+          vrops_nsxt_mgmt_cluster_sys_capacity_logical_switch_ports_max_supported_count > 0.9
+        for: 10m
+        labels:
+          dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
+          meta: NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switch ports
+            exceeded the supported limit. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTGroupsUsageLimitExceeded
+        annotations:
+          description: NSX-T cluster {{ $labels.nsxt_adapter }} count of NSGroups exceeded
+            the supported limit. https://{{ $labels.target }}
+          summary: NSX-T cluster {{ $labels.nsxt_adapter }} count of NSGroups exceeded
+            the supported limit. https://{{ $labels.target }}
+        expr: |
+          vrops_nsxt_mgmt_cluster_sys_capacity_nsgroups_max_usage_count /
+          vrops_nsxt_mgmt_cluster_sys_capacity_nsgroups_max_supported_count > 0.9
+        for: 10m
+        labels:
+          dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
+          meta: NSX-T cluster {{ $labels.nsxt_adapter }} count of NSGroups exceeded the
+            supported limit. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTIPSetsUsageLimitExceeded
+        annotations:
+          description: NSX-T cluster {{ $labels.nsxt_adapter }} count of IP sets exceeded
+            the supported limit. https://{{ $labels.target }}
+          summary: NSX-T cluster {{ $labels.nsxt_adapter }} count of IP sets exceeded
+            the supported limit. https://{{ $labels.target }}
+        expr: |
+          vrops_nsxt_mgmt_cluster_sys_capacity_ip_sets_usage_count /
+          vrops_nsxt_mgmt_cluster_sys_capacity_ip_sets_max_supported_count > 0.9
+        for: 10m
+        labels:
+          dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
+          meta: NSX-T cluster {{ $labels.nsxt_adapter }} count of IP sets exceeded the
+            supported limit. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTGroupsBasedInIPUsageLimitExceeded
+        annotations:
+          description: NSX-T cluster {{ $labels.nsxt_adapter }} count of groups based
+            in IP exceeded the supported limit. https://{{ $labels.target }}
+          summary: NSX-T cluster {{ $labels.nsxt_adapter }} count of groups based in IP
+            exceeded the supported limit. https://{{ $labels.target }}
+        expr: |
+          vrops_nsxt_mgmt_cluster_sys_capacity_groups_based_in_ip_usage_count /
+          vrops_nsxt_mgmt_cluster_sys_capacity_groups_based_in_ip_max_supported_count > 0.9
+        for: 10m
+        labels:
+          dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
+          meta: NSX-T cluster {{ $labels.nsxt_adapter }} count of groups based in IP exceeded
+            the supported limit. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTMgmtNodeImageFilesystemCapacity
+        annotations:
+          description: NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage
+            `/image` > 80%. {{ $labels.nsxt_adapter}} https://{{ $labels.target }}
+          summary: NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage
+            `/image` > 80%. {{ $labels.nsxt_adapter}} https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_node_filesystems_image_usedpercentage > 80
+        for: 10m
+        labels:
+          meta: NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage `/image`
+            > 80%. {{ $labels.nsxt_adapter}} https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#NSXTMgmtNodeImageFilesystemCapacityCritical
+          service: network
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: NSXTMgmtNodeLogFilesystemCapacity
+        annotations:
+          description: NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage
+            `/var/log` > 80%. {{ $labels.nsxt_adapter}} https://{{ $labels.target }}
+          summary: NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage
+            `/var/log` > 80%. {{ $labels.nsxt_adapter}} https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_node_filesystems_var_log_usedpercentage > 80
+        for: 10m
+        labels:
+          meta: NSX-T management node {{ $labels.nsxt_mgmt_node }} filesystem usage `/var/log`
+            > 80%. {{ $labels.nsxt_adapter}} https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#NSXTMgmtNodeLogFilesystemCapacityCritical
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTClusterControlStatusNoControllers
+        annotations:
+          description: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity
+            status is `{{ $labels.state }}`. https://{{ $labels.target }}
+          summary: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status
+            is `{{ $labels.state }}`. https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_cluster_controller_cluster_connectivity_status{state="NO_CONTROLLERS"}
+        for: 10m
+        labels:
+          meta: NSX-T management cluster {{ $labels.nsxt_adapter }} has connectivity status
+            `{{ $labels.state }}`. https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#cluster_control_status_no_controllers
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTClusterControlStatusUnstable
+        annotations:
+          description: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity
+            status is `{{ $labels.state }}`. https://{{ $labels.target }}
+          summary: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status
+            is `{{ $labels.state }}`. https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_cluster_controller_cluster_connectivity_status{state="UNSTABLE"}
+        for: 10m
+        labels:
+          meta: NSX-T management cluster {{ $labels.nsxt_adapter }} has connectivity status
+            `{{ $labels.state }}`. https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#cluster_control_status_unstable
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTClusterControlStatusDegraded
+        annotations:
+          description: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity
+            status is `{{ $labels.state }}`. https://{{ $labels.target }}
+          summary: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status
+            is `{{ $labels.state }}`. https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_cluster_controller_cluster_connectivity_status{state="DEGRADED"}
+        for: 30m
+        labels:
+          meta: NSX-T management cluster {{ $labels.nsxt_adapter }} has connectivity status
+            `{{ $labels.state }}`. https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#cluster_control_status_degraded
+          service: network
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: NSXTClusterControlStatusUnkown
+        annotations:
+          description: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity
+            status is `{{ $labels.state }}`. https://{{ $labels.target }}
+          summary: NSX-T management cluster {{ $labels.nsxt_adapter }} connectivity status
+            is `{{ $labels.state }}`. https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_cluster_controller_cluster_connectivity_status{state="UNKNOWN"}
+        for: 10m
+        labels:
+          meta: NSX-T management cluster {{ $labels.nsxt_adapter }} has connectivity status
+            `{{ $labels.state }}`. https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#cluster_control_status_unkown
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTNodeMemoryUsageOver95
+        annotations:
+          description: NSX-T Node {{ $labels.nsxt_mgmt_node }} of cluster {{ $labels.nsxt_adapter
+            }} has memory usage of over 95%. https://{{ $labels.target }}
+          summary: NSX-T Node {{ $labels.nsxt_mgmt_node }} of cluster {{ $labels.nsxt_adapter
+            }} has memory usage of over 95%. https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_node_memory_used / vrops_nsxt_mgmt_node_memory_total > 0.95
+        for: 5m
+        labels:
+          meta: NSX-T Node {{ $labels.nsxt_mgmt_node }} of cluster {{ $labels.nsxt_adapter
+            }} has memory usage of over 95%. https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#NSXT_Memory_Usage_Over95
+          service: network
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: NSXTNodeConnectivityBroken
+        annotations:
+          description: NSX-T Node {{ $labels.nsxt_mgmt_node }} connectivity is broken.
+            ({{ $labels.nsxt_adapter }}) https://{{ $labels.target }}
+          summary: NSX-T Node {{ $labels.nsxt_mgmt_node }} connectivity is broken. ({{
+            $labels.nsxt_adapter }}) https://{{ $labels.target }}
+        expr: vrops_nsxt_mgmt_node_connectivity_status{state="DISCONNECTED"}
+        for: 5m
+        labels:
+          meta: NSX-T Node `{{ $labels.nsxt_mgmt_node }}` connectivity is broken. ({{
+            $labels.nsxt_adapter }}) https://{{ $labels.target }}
+          playbook: docs/devops/alert/nsxt/#nsxtnodeconnectivitybroken
+          service: network
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: NSXTManagementServiceHasFailed
+        annotations:
+          description: 'CRITICAL: NSX-T management service `{{ $labels.nsxt_mgmt_service
+            }}` has failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }})
+            https://{{ $labels.target }}'
+          summary: 'CRITICAL: NSX-T management service `{{ $labels.nsxt_mgmt_service }}`
+            has failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }}) https://{{
+            $labels.target }}'
+        expr: |
+          vrops_nsxt_mgmt_service_alert_info{alert_name="NSX-T Management service has failed|Management service monitor runtime state has failed",
+          nsxt_mgmt_service!~"cluster-boot-manager|cm-inventory|controller|http|manager"}
+        labels:
+          meta: Critical NSX-T management service `{{ $labels.nsxt_mgmt_service }}` has
+            failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }}) https://{{
+            $labels.target }}
+          no_alert_on_absence: "true"
+          service: network
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: NSXTSslCertificateExpiry
+        annotations:
+          description: NSX-T Certificate of {{ $labels.nsxt_adapter }} has expired or
+            will expire shortly. https://{{ $labels.target }}
+          summary: NSX-T Certificate of {{ $labels.nsxt_adapter }} has expired or will
+            expire shortly. https://{{ $labels.target }}
+        expr: vrops_nsxt_adapter_alert_info{alert_name="Adapter certificate has expired
+          or will expire shortly"}
+        labels:
+          context: nsxt certificate
+          meta: NSX-T Certificate of `{{ $labels.nsxt_adapter }}` has expired or will
+            expire shortly. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#applying-nsx-t-ssl-certificate-in-the-manager-nodes-and-the-vip
+          service: network
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: NSXTManagementServiceHasFailed
+        annotations:
+          description: 'WARNING: NSX-T management service `{{ $labels.nsxt_mgmt_service
+            }}` has failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }}).
+            https://{{ $labels.target }}'
+          summary: 'WARNING: NSX-T management service `{{ $labels.nsxt_mgmt_service }}`
+            has failed. ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }}). https://{{
+            $labels.target }}'
+        expr: |
+          vrops_nsxt_mgmt_service_alert_info{alert_name="NSX-T Management service has failed|Management service monitor runtime state has failed",
+          nsxt_mgmt_service!~"mgmt-plane-bus|node-mgmt|ntp|ssh|search|syslog|nsx-ui"}
+        labels:
+          meta: NSX-T management service `{{ $labels.nsxt_mgmt_service }}` has failed.
+            ({{ $labels.nsxt_mgmt_node }}, {{ $labels.nsxt_adapter }}). https://{{ $labels.target
+            }}
+          no_alert_on_absence: "true"
+          service: network
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: NSXTTransportNodeConnectivityNotUP
+        annotations:
+          description: 'Transport node {{ $labels.nsxt_transport_node }} Controller/Manager
+            Connectivity status is not UP. https://{{ $labels.target }}. '
+          summary: 'Transport node {{ $labels.nsxt_transport_node }} Controller/Manager
+            Connectivity status is not UP. https://{{ $labels.target }}. '
+        expr: |
+          label_replace(vrops_nsxt_transport_node_alert_info{alert_name="Transport Node Controller/Manager Connectivity is not UP"}, "hostsystem", "$1", "nsxt_transport_node", "(.*)")
+          AND on (hostsystem) vrops_hostsystem_runtime_connectionstate{state="notResponding"}
+          AND on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"}
+          AND on (hostsystem) vrops_hostsystem_runtime_powerstate{state="Powered On"}
+        labels:
+          meta: Transport node {{ $labels.nsxt_transport_node }} Controller/Manager Connectivity
+            status is not UP. https://{{ $labels.target }}.
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#Transport_node_status_not_UP_in_NSXT
+          service: network
+          severity: critical
+          support_group: compute
+          tier: vmware
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-b-0-alerts-vccluster.alerts
+  labels:
+    prometheus: vmware-vc-b-0
+
+spec:
+  groups:
+    - name: vccluster.alerts
+      rules:
+      - alert: VCenterRedundancyLostHAPolicyFaulty
+        annotations:
+          description: VC https://{{ $labels.vcenter }} has a faulty AdmissionControlPolicy
+            for cluster {{ $labels.vccluster }}, failover will not work.
+          summary: VC https://{{ $labels.vcenter }} has a faulty AdmissionControlPolicy
+            for cluster {{ $labels.vccluster }}, failover will not work.
+        expr: |
+          vrops_cluster_configuration_dasconfig_enabled{vccluster=~"productionbb\\d+"}
+          unless on (vccluster) ((vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{vccluster=~"productionbb\\d+"} != 0
+          and on (hostsystem) vrops_hostsystem_runtime_maintenancestate{state!="inMaintenance"})
+          or (vrops_cluster_summary_custom_tag_openstack_nova_traits_decommissioning{summary_custom_tag_openstack_nova_traits_decommissioning="true", vccluster=~"productionbb\\d+"}
+          and on (vccluster) vrops_cluster_cluster_running_vms == 0))
+        for: 30m
+        labels:
+          context: vc cluster config
+          meta: VC https://{{ $labels.vcenter }} has a faulty AdmissionControlPolicy for
+            cluster {{ $labels.vccluster }}, failover will not work.
+          playbook: docs/devops/alert/vcenter/#vcenterredundancylosthapolicyfaulty
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: VCenterRedundancyLostHAPolicyNotConfigured
+        annotations:
+          description: VC {{ $labels.vcenter }} {{ $labels.vccluster }} has a faulty AdmissionControlPolicy.
+            Failover will not work.
+          summary: VC {{ $labels.vcenter }} {{ $labels.vccluster }} has a faulty AdmissionControlPolicy.
+            Failover will not work.
+        expr: vrops_cluster_configuration_dasconfig_enabled{vccluster=~"production.*"}
+          == 0
+        for: 30m
+        labels:
+          context: Cluster HA policy
+          meta: VC {{ $labels.vcenter }} {{ $labels.vccluster }} has a faulty AdmissionControlPolicy.
+            Failover will not work.
+          playbook: docs/devops/alert/vcenter/#restore-ha-redundancy-in-vcenter
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: VCClusterFailoverHostCountMismatch
+        annotations:
+          description: "`{{ $labels.vccluster }}` cluster has more failover hosts configured
+            than expected. For clusters with 10 or fewer hosts, it should be 1; for larger
+            clusters, it should be no more than 2. \nLink to the vCenter: --> <https://{{
+            $labels.vcenter }}|{{ $labels.vcenter }}>"
+          summary: "`{{ $labels.vccluster }}` cluster has more failover hosts configured
+            than expected. For clusters with 10 or fewer hosts, it should be 1; for larger
+            clusters, it should be no more than 2. \nLink to the vCenter: --> <https://{{
+            $labels.vcenter }}|{{ $labels.vcenter }}>"
+        expr: |
+          (count by (vccluster, vcenter) (vrops_hostsystem_runtime_connectionstate{vccluster=~"productionbb\\d+"}) <= 10
+          and on (vccluster) sum by (vccluster) (vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{vccluster=~"productionbb\\d+"}) > 1)
+          or (sum by (vccluster, vcenter) (vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{vccluster=~"productionbb\\d+"}) > 2)
+          unless on (vccluster) (vrops_cluster_summary_custom_tag_openstack_nova_traits_decommissioning{summary_custom_tag_openstack_nova_traits_decommissioning="true", vccluster=~"productionbb\\d+"}
+          and vrops_cluster_cluster_running_vms == 0)
+        for: 30m
+        labels:
+          context: Cluster HA policy
+          meta: "`{{ $labels.vccluster }}` cluster has more failover hosts configured
+            than expected. For clusters with 10 or fewer hosts, it should be 1; for larger
+            clusters, it should be no more than 2. \nLink to the vCenter: --> <https://{{
+            $labels.vcenter }}|{{ $labels.vcenter }}>"
+          playbook: docs/devops/alert/vcenter/#vcclusterfailoverhostcountmismatch
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VCenterRedundancyLostHALevelNotSet
+        annotations:
+          description: VC {{ $labels.vcenter }} {{ $labels.vccluster }} has NO failover
+            host amount configured, this should be 1
+          summary: VC {{ $labels.vcenter }} {{ $labels.vccluster }} has NO failover host
+            amount configured, this should be 1
+        expr: count by (vccluster, vcenter) (vrops_hostsystem_configuration_dasconfig_admissioncontrolpolicy_failoverhost{vccluster=~"production.*"}
+          == 1) == 0
+        for: 30m
+        labels:
+          context: Cluster HA policy
+          meta: VC {{ $labels.vcenter }} {{ $labels.vccluster }} has NO failover host
+            amount configured, this should be 1
+          playbook: docs/devops/alert/vcenter/#restore-ha-redundancy-in-vcenter
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: VCClusterDRSNotFullyAutomated
+        annotations:
+          description: Cluster {{ $labels.vccluster }} DRS configuration is not set to
+            fully automated.
+          summary: Cluster {{ $labels.vccluster }} DRS configuration is not set to fully
+            automated.
+        expr: |
+          vrops_cluster_configuration_drsconfig_defaultvmbehavior{vccluster!~".*controlplane.*", state != "fullyAutomated"} == 0
+          unless on (vccluster) vrops_cluster_summary_custom_tag_openstack_nova_traits_hana_exclusive_host{summary_custom_tag_openstack_nova_traits_hana_exclusive_host="true"}
+        for: 10m
+        labels:
+          context: Cluster DRS configuration
+          meta: Cluster {{ $labels.vccluster }} DRS configuration is not set to fully
+            automated.
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#cluster-drs-not-set-to-fully-automated
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: VCClusterCannotDistributeNSXTControllers
+        annotations:
+          description: Cluster {{ $labels.vccluster }} cannot evenly distribute new NSX-T
+            controllers. {{ $labels.vcenter}}
+          summary: Cluster {{ $labels.vccluster }} cannot evenly distribute new NSX-T
+            controllers. {{ $labels.vcenter }}
+        expr: |
+          count by(vccluster, vcenter) (
+            (
+              max_over_time(vrops_hostsystem_memory_capacity_available_to_vms_kilobytes{vccluster=~".*management"}[1h])
+              - max_over_time(vrops_hostsystem_memory_consumed_by_vms_kilobytes[1h])
+            ) / 1024 / 1024 >= 48
+          ) < 3
+        for: 30m
+        labels:
+          context: Cluster NSXT Resources
+          meta: Cluster {{ $labels.vccluster }} cannot evenly distribute new NSX-T controllers.
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: HanaExclusiveVCClusterDRSNotPartiallyAutomated
+        annotations:
+          description: |-
+            The HANA-exclusive {{ $labels.vccluster }} cluster DRS configuration is not set to partially automated in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          summary: |-
+            The HANA-exclusive {{ $labels.vccluster }} cluster DRS configuration is not set to partially automated in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+        expr: |
+          vrops_cluster_configuration_drsconfig_defaultvmbehavior{vccluster=~"productionbb.+", state != "partiallyAutomated"}
+          and on (vccluster) vrops_cluster_summary_custom_tag_openstack_nova_traits_hana_exclusive_host{summary_custom_tag_openstack_nova_traits_hana_exclusive_host="true"}
+        labels:
+          context: Cluster DRS configuration
+          meta: |-
+            The HANA-exclusive {{ $labels.vccluster }} cluster DRS configuration is not set to partially automated in the *{{ $labels.datacenter }}* availability zone
+            Link to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#hanaexclusivevcclusterdrsnotpartiallyautomated
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-b-0-alerts-vcenter.alerts
+  labels:
+    prometheus: vmware-vc-b-0
+
+spec:
+  groups:
+    - name: vcenter.alerts
+      rules:
+      - alert: VcsaSslCertificateExpiry
+        annotations:
+          description: SSL Certificate of vCSA {{ $labels.vcenter}} expires in {{ $value
+            }} days. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: SSL Certificate of vCSA {{ $labels.vcenter}} expires in {{ $value }}
+            days. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: 15 < round(((avg_over_time(vrops_vcenter_summary_certificate_expiry_date[10m])
+          / 1000) - time()) / 86400) < 30
+        for: 20m
+        labels:
+          context: vcsa certificate
+          meta: SSL Certificate of vCSA {{ $labels.vcenter }} expires in less than 30
+            days. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#vcenter-appliance-certificate-expiry
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VcsaSslCertificateExpiry
+        annotations:
+          description: SSL Certificate of vCSA {{ $labels.vcenter}} expires in {{ $value
+            }} days. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          summary: SSL Certificate of vCSA {{ $labels.vcenter}} expires in {{ $value }}
+            days. ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+        expr: round(((avg_over_time(vrops_vcenter_summary_certificate_expiry_date[10m])
+          / 1000) - time()) / 86400) < 16
+        for: 20m
+        labels:
+          context: vcsa certificate
+          meta: SSL Certificate of vCSA {{ $labels.vcenter}} expires in less than 15 days.
+            ({{ $labels.vcenter }}, {{ $labels.datacenter }})
+          playbook: docs/devops/alert/vcenter/#vcenter-appliance-certificate-expiry
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: VCenterDiskSpaceUsage
+        annotations:
+          description: Disk space usage of vCSA {{ $labels.vcenter}} is above 90%
+          summary: Disk space usage of vCSA {{ $labels.vcenter}} is above 90%
+        expr: vrops_vcenter_diskspace_usage_gigabytes / vrops_vcenter_diskspace_total_gigabytes
+          > 0.9
+        for: 15m
+        labels:
+          context: vcenter disk usage
+          meta: Disk space usage of vCSA {{ $labels.vcenter}} is above 90%
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VASAProvider(s)Disconnected
+        annotations:
+          description: VASA Provider disconnected from {{ $labels.vcenter}}.
+          summary: VASA Provider disconnected from {{ $labels.vcenter}}.
+        expr: vrops_vcenter_alert_info{alert_name="VASA Provider(s) disconnected"}
+        labels:
+          context: vasa provider
+          meta: VASA Provider disconnected from {{ $labels.vcenter}}.
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#vasaproviderdown
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VCenterHasMultipleGreyVMs
+        annotations:
+          description: vCenter {{ $labels.vcenter }} has multiple greyed out VMs for a
+            longer period. This alert is handled by TARS. If TARS fails, check and reload
+            these VMs.
+          summary: vCenter {{ $labels.vcenter }} has multiple greyed out VMs for a longer
+            period. This alert is handled by TARS. If TARS fails, check and reload these
+            VMs.
+        expr: |
+          count by(vcenter)
+          ((vrops_virtualmachine_health == -1)
+          and on(hostsystem) (vrops_hostsystem_runtime_powerstate{state="Powered On"})
+          and on(hostsystem) (vrops_hostsystem_runtime_connectionstate{state="connected"})
+          and on(hostsystem) (vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"})) > 0
+        for: 15m
+        labels:
+          context: Shadow VMs {{ $labels.vcenter }}
+          meta: vCenter {{ $labels.vcenter }} has multiple greyed out VMs for a longer
+            period. Check and reload these VMs.
+          playbook: docs/devops/alert/vcenter/#Inaccessible_Orphaned_Gray_instance_handling
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: IaasVCenterHasMultipleGreyVMs
+        annotations:
+          description: vCenter {{ $labels.vcenter }} has multiple greyed out VMs for a
+            longer period. This alert is handled by TARS. If TARS fails, check and reload
+            these VMs.
+          summary: vCenter {{ $labels.vcenter }} has multiple greyed out VMs for a longer
+            period. This alert is handled by TARS. If TARS fails, check and reload these
+            VMs.
+        expr: |-
+          (count by(vcenter)
+          ((vrops_virtualmachine_health == -1)
+          and on(hostsystem) (vrops_hostsystem_runtime_powerstate{state="Powered On"})
+          and on(hostsystem) (vrops_hostsystem_runtime_connectionstate{state="connected"})
+          and on(hostsystem) (vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"})) > 0
+          ) and on(hostsystem) vrops_hostsystem_hostgroups{hostgroups=~'.*iaas.*'}
+        for: 15m
+        labels:
+          bedrock: "true"
+          context: Shadow VMs {{ $labels.vcenter }}
+          meta: vCenter {{ $labels.vcenter }} has multiple greyed out VMs for a longer
+            period. Check and reload these VMs.
+          playbook: docs/devops/alert/vcenter/#Inaccessible_Orphaned_Gray_instance_handling
+          service: compute
+          severity: warning
+          support_group: iaas_support
+          tier: vmware
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-b-0-alerts-virtualmachine.alerts
+  labels:
+    prometheus: vmware-vc-b-0
+
+spec:
+  groups:
+    - name: virtualmachine.alerts
+      rules:
+      - alert: VMHasMemoryContention
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` has memory contention
+            due to memory compression, ballooning, or swapping. ({{ $labels.vcenter }},
+            {{ $labels.hostsystem }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` has memory contention
+            due to memory compression, ballooning, or swapping. ({{ $labels.vcenter }},
+            {{ $labels.hostsystem }})
+        expr: |
+          vrops_virtualmachine_alert_info{alert_name="Virtual machine has memory contention due to memory compression, ballooning, or swapping", vccluster=~".*management.*"}
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine `{{ $labels.virtualmachine }}` has memory contention due
+            to memory compression, ballooning, or swapping. ({{ $labels.vcenter }}, {{
+            $labels.hostsystem }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#vm_has_memory_contention
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VMHasDiskIOLatencyProblemCausedBySnapshots
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` has disk I/O latency
+            problem caused by snapshots. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` has disk I/O latency
+            problem caused by snapshots. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+        expr: |
+          vrops_virtualmachine_alert_info{alert_name="Virtual machine has disk I/O latency problem caused by snapshots", vccluster=~".*management.*"}
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine `{{ $labels.virtualmachine }}` has disk I/O latency problem
+            caused by snapshots. ({{ $labels.vcenter }}, {{ $labels.hostsystem }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#vm_has_disk_io_latency_problem_caused_by_snapshots
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VMHasCPUContentionDueToIOEvents
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` has CPU contention
+            due to long wait for I/O events. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` has CPU contention due
+            to long wait for I/O events. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+        expr: |
+          vrops_virtualmachine_alert_info{alert_name="Virtual machine has CPU contention due to long wait for I/O events", vccluster=~".*management.*"}
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine `{{ $labels.virtualmachine }}` has CPU contention due
+            to long wait for I/O events. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#vm_has_cpu_contention
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VMGuestFileSystemsRunningOutOfDiskSpace
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` guest file systems
+            are running out of disk space. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` guest file systems are
+            running out of disk space. ({{ $labels.vcenter }}, {{ $labels.hostsystem }})
+        expr: |
+          vrops_virtualmachine_guestfilesystem_storage_log_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_storage_autodeploy_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_storage_core_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_storage_dblog_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_storage_imagebuilder_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_storage_netdump_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_storage_seat_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_storage_updatemgr_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_boot_percentage{vccluster=~".*management.*"} > 80 OR vrops_virtualmachine_guestfilesystem_percentage{vccluster=~".*management.*"} > 80
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine `{{ $labels.virtualmachine }}` guest file systems are
+            running out of disk space. ({{ $labels.vcenter }}, {{ $labels.hostsystem }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#vm_guest_file_Systems_running_out_of_disk_space
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VMCPUAt100PercentForAnExtendedPeriodOfTime
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` CPU usage is at
+            100% for an extended period of time. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` CPU usage is at 100%
+            for an extended period of time. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+        expr: |
+          vrops_virtualmachine_alert_info{alert_name="Virtual machine CPU usage is at 100% for an extended period of time", vccluster=~".*management.*"}
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine {{ $labels.virtualmachine }} CPU usage is at 100% for
+            an extended period of time. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#vm_cpu_at_100_percent_for_an_extended_period_of_time
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VMInDRSClusterDemandingMoreCPUThanItsEntitlement
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` in a DRS cluster
+            is demanding more CPU than its entitlement. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` in a DRS cluster is
+            demanding more CPU than its entitlement. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+        expr: |
+          vrops_virtualmachine_alert_info{alert_name="Virtual machine in a DRS cluster is demanding more CPU than its entitlement", vccluster=~".*management.*"}
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine `{{ $labels.virtualmachine }}` in a DRS cluster is demanding
+            more CPU than its entitlement. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#vm_in_drs_cluster_demanding_more_cpu_than_its_entitlement
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VMHasSnapshotOlderThanOneWeek
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` has a snapshot older
+            than one week. ({{ $labels.vcenter }}, {{ $labels.hostsystem }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` has a snapshot older
+            than one week. ({{ $labels.vcenter }}, {{ $labels.hostsystem }})
+        expr: vrops_virtualmachine_disk_space_snapshot_age_days{vccluster=~".*management.*",
+          virtualmachine!~"jump.+"} > 7
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine `{{ $labels.virtualmachine }}` has a snapshot older than
+            one week. ({{ $labels.vcenter }}, {{ $labels.hostsystem }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VMHasCPUContentionDueToMemoryPageSwapping
+        annotations:
+          description: Virtual machine `{{ $labels.virtualmachine }}` experiencing high
+            swap wait. The host is overcommitted on memory. ({{ $labels.vcenter }}, {{
+            $labels.hostsystem }})
+          summary: Virtual machine `{{ $labels.virtualmachine }}` experiencing high swap
+            wait. The host is overcommitted on memory. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+        expr: |
+          vrops_virtualmachine_alert_info{alert_name="Virtual machine has CPU contention due to memory page swapping in the host", vccluster=~".*management.*"}
+        labels:
+          context: '{{ $labels.virtualmachine }}'
+          meta: Virtual machine `{{ $labels.virtualmachine }}` experiencing high swap
+            wait. The host is overcommitted on memory. ({{ $labels.vcenter }}, {{ $labels.hostsystem
+            }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: NSXTMgmtVMsOddDistribution
+        annotations:
+          description: Too many NSX-T VMs for the same cluster on {{ $labels.hostsystem
+            }}. Please distribute the VMs across different nodes. ({{ $labels.vcenter
+            }})
+          summary: Too many NSX-T VMs on {{ $labels.hostsystem }}. ({{ $labels.vcenter
+            }})
+        expr: |
+          count(label_replace(vrops_virtualmachine_cpu_usage_average_mhz{virtualmachine=~"nsx-.*"}, "nsx_clt", "$1", "virtualmachine", "nsx-.*(bb.*)")) by(nsx_clt, hostsystem, vcenter, vccluster) > 1
+        labels:
+          context: NSXTMgmtVMDistribution
+          dashboard: management-cluster-resources/management-cluster-resources?orgId=1&var-pod=All&var-clusters={{
+            $labels.vccluster }}&var-hosts={{ $labels.hostsystem }}
+          meta: Too many NSX-T VMs on {{ $labels.hostsystem }}. ({{ $labels.vcenter }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#nsxtmgmtvmsodddistribution
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: NSXTMgmtVMsOddDistributionSDRSAntiaffinity
+        annotations:
+          description: NSX-T VMs not part of SDRS anti-affinity rule  {{ $labels.rule_name
+            }}. Please distribute the VMs across different DS. ({{ $labels.vcenter }})
+          summary: NSX-T VMs not part of SDRS anti-affinity rule  {{ $labels.rule_name
+            }}. ({{ $labels.vcenter }})
+        expr: |
+          count  (vrops_storagepod_config_sdrsconfig_vmstorageantiaffinityrules{storagepod!~"SDRS_MGMT_BB\\d+"}) by (rule_name, vccluster, vcenter) != 3
+        labels:
+          context: NSXTMgmtVMsOddDistributionSDRS
+          dashboard: management-cluster-resources/management-cluster-resources?orgId=1&var-pod=All&var-clusters={{
+            $labels.vccluster }}
+          meta: NSX-T VMs not part of SDRS anti-affinity rule  {{ $labels.rule_name }}.
+            ({{ $labels.vcenter }})
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/#nsxtmgmtvmsodddistributionsdrs
+          service: network
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VASAVMHighCPUUtilization
+        annotations:
+          description: VASA VM has >90% CPU Utilization for at least one hour. {{ $labels.virtualmachine
+            }}. {{ $labels.vccluster }}. {{ $labels.hostsystem }}. ({{ $labels.vcenter
+            }})
+          summary: High VASA VM CPU Utilization. {{ $labels.virtualmachine }}. {{ $labels.vccluster
+            }}. {{ $labels.hostsystem }}. ({{ $labels.vcenter }})
+        expr: vrops_virtualmachine_cpu_usage_ratio{virtualmachine=~"vasa.*"} > 90
+        for: 1h
+        labels:
+          context: VASAUtilization
+          meta: VASA VM has >90% CPU Utilization for at least one hour. {{ $labels.virtualmachine
+            }}. {{ $labels.vccluster }}. {{ $labels.hostsystem }}. ({{ $labels.vcenter
+            }})
+          no_alert_on_absence: "true"
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+---
+# Source: prometheus-vmware-rules/templates/prometheus-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: vmware-vc-b-0-alerts-vrops.alerts
+  labels:
+    prometheus: vmware-vc-b-0
+
+spec:
+  groups:
+    - name: vrops.alerts
+      rules:
+      - alert: VropsAPIDown
+        annotations:
+          description: "All collectors of the vrops-exporter report HTTP status codes
+            above 500, \nwhich indicates that vrops is reporting internal server errors
+            or is unreachable. \nCheck if vrops is running and healthy.\n"
+          summary: '`https://{{ $labels.target }}` API is down.'
+        expr: "(sum by (target) (vrops_api_response{collector=~\"vc.*\"}) / \ncount by
+          (target) (vrops_api_response{collector=~\"vc.*\"}) > 500) \n"
+        for: 10m
+        labels:
+          context: vrops
+          dashboard: vrops-exporter-status
+          meta: '`https://{{ $labels.target }}` API is down.'
+          playbook: docs/devops/alert/vcenter/vrops#vrops_api_down
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VropsAPIDown
+        annotations:
+          description: |
+            All collectors of the vrops-exporter report HTTP status codes above 500,
+            which indicates that vrops is reporting internal server errors or is unreachable.
+            Check if vrops is running and healthy.
+          summary: '`https://{{ $labels.target }}` API is down.'
+        expr: "(sum by (target) (vrops_api_response{collector=~\"vc.*\"}) / \ncount by
+          (target) (vrops_api_response{collector=~\"vc.*\"}) > 500)                                                                                                                     \n"
+        for: 90m
+        labels:
+          context: vrops
+          dashboard: vrops-exporter-status
+          meta: '`https://{{ $labels.target }}` API is down.'
+          playbook: docs/devops/alert/vcenter/vrops#vrops_api_down
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: VropsAPIDownEntirely
+        annotations:
+          description: |
+            Exporters can not connect to vrops anymore. Most likely the VM is stuck.
+            If this alert fires, complete vmware-montioring is down in Prometheus.
+            Ensure vrops is running and healthy.
+          meta: Vrops API is down. All collectors are not reporting anymore.
+        expr: |
+          absent(vrops_api_response)
+        for: 10m
+        labels:
+          context: vrops
+          dashboard: vrops-exporter-status
+          meta: Vrops API is down. All collectors are not reporting anymore.
+          playbook: docs/devops/alert/vcenter/vrops#vrops_api_down_entirely
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VropsAPIDownEntirely
+        annotations:
+          description: |
+            Exporters can not connect to vrops anymore. Most likely the VM is stuck.
+            If this alert fires, complete vmware-montioring is down in Prometheus.
+            Ensure vrops is running and healthy.
+          meta: Vrops API is down. All collectors are not reporting anymore.
+        expr: |
+          absent(vrops_api_response)
+        for: 90m
+        labels:
+          context: vrops
+          dashboard: vrops-exporter-status
+          meta: Vrops API is down. All collectors are not reporting anymore.
+          playbook: docs/devops/alert/vcenter/vrops#vrops_api_down_entirely
+          service: compute
+          severity: critical
+          support_group: compute
+          tier: vmware
+      - alert: VropsTokenAcquisitionFailed
+        annotations:
+          description: |
+            A failed token acquisition for this vrops. This indicates
+            that the vrops system is not responding and current
+            monitoring data cannot be generated.
+          summary: Token acquisition failed for `https://{{ $labels.target }}`
+        expr: vrops_api_response{get_request="token"} >= 500
+        for: 15m
+        labels:
+          context: vrops
+          dashboard: vrops-exporter-status
+          meta: Token acquisition failed for `https://{{ $labels.target }}`
+          playbook: docs/devops/alert/vcenter/vrops#vrops_api_down
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VROpsDiskpaceUsage
+        annotations:
+          description: |
+            {{ $labels.virtualmachine }} disk almost full with over 90% usage.
+            Please increase disk size.
+          summary: '{{ $labels.virtualmachine }} disk almost full with over 90% usage.'
+        expr: vrops_virtualmachine_guestfilesystem_storage_db_percentage{virtualmachine=~"vrops.*-vc-.+"}
+          > 90
+        for: 20m
+        labels:
+          context: vrops
+          dashboard: vrops-instances-overview
+          meta: '{{ $labels.virtualmachine }} disk almost full with over 90% usage.'
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+      - alert: VROpsVCenterAdapterNotReceivingData
+        annotations:
+          description: The vCenter adapter for https://vrops-{{ $labels.vcenter }} is
+            not receiving data.
+          summary: The vCenter adapter for https://vrops-{{ $labels.vcenter }} is not
+            receiving data.
+        expr: vrops_vcenter_alert_info{alert_name="Adapter instance is not receiving data"}
+        for: 15m
+        labels:
+          context: vrops
+          meta: The vCenter adapter for https://vrops-{{ $labels.vcenter }} is not receiving
+            data.
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/vrops#revalidatecertificate
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VROpsNSXTAdapterNotReceivingData
+        annotations:
+          description: vROPs NSX-T adapter is not receiving data for `{{ $labels.nsxt_adapter
+            }}`. https://{{ $labels.target }}
+          summary: vROPs NSX-T adapter is not receiving data for `{{ $labels.nsxt_adapter
+            }}`. https://{{ $labels.target }}
+        expr: vrops_nsxt_adapter_alert_info{alert_name="Adapter instance is not receiving
+          data"}
+        for: 15m
+        labels:
+          context: vrops
+          meta: vROPs NSX-T adapter is not receiving data for `{{ $labels.nsxt_adapter
+            }}`. https://{{ $labels.target }}
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/nsxt/#vrops-nsx-t-adapter-is-not-receiving-data-vropsnsxtadapternotreceivingdata
+          service: compute
+          severity: warning
+          support_group: compute
+          tier: vmware
+      - alert: VROpsVCenterObjectsNotReceivingData
+        annotations:
+          description: vROPs vCenter adapter for https://vrops-{{ $labels.vcenter }} is
+            not receiving data for some objects.
+          summary: vROPs vCenter adapter for https://vrops-{{ $labels.vcenter }} is not
+            receiving data for some objects.
+        expr: vrops_vcenter_alert_info{alert_name="Objects are not receiving data from
+          adapter instance"}
+        labels:
+          meta: vROPs vCenter adapter for https://vrops-{{ $labels.vcenter }} is not receiving
+            data for some objects.
+          no_alert_on_absence: "true"
+          playbook: docs/devops/alert/vcenter/vrops#revalidatecertificate
+          service: compute
+          severity: info
+          support_group: compute
+          tier: vmware
+---
+# Source: prometheus-vmware-rules/templates/scaleout-ruler-alerts.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: alerts-scaleout-ruler-host.alerts
+  labels:
+    type: alerting-rules
+    thanos-ruler: scaleout
+
+spec:
+   groups:
+    - name: thanos-host.alerts
+      rules:
+        - alert: HostInMaintenanceModeForAtLeast10d
+          expr: |
+            count_over_time((present_over_time(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}[1d]))[15d:1d]) >= 10
+            and on (hostsystem) (vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"})
+            unless on (hostsystem) (vrops_hostsystem_custom_attributes_hw_info == 1)
+            unless on (hostsystem) (vrops_hostsystem_custom_attributes_change_request_info == 1)
+            unless on (hostsystem) (vrops_hostsystem_runtime_connectionstate == 0)
+            unless on (vccluster) (vrops_cluster_summary_custom_tag_openstack_nova_traits_compute_status_disabled == 1)
+          labels:
+            severity: warning
+            service: compute
+            tier: vmware
+            support_group: compute
+            no_alert_on_absence: "true"
+            context: "{{ $labels.hostsystem }} maintenance"
+            meta: "Host `{{ $labels.hostsystem }}` is in maintenance mode for at least 10 days with no custom attributes tag. ({{ $labels.vcenter }})."
+            playbook: docs/devops/alert/vcenter/hostinmaintenance/
+          annotations:
+            summary: "Host `{{ $labels.hostsystem }}` is in maintenance mode for at least 10 days with no custom attributes tag. ({{ $labels.vcenter }})."
+            description: "Host `{{ $labels.hostsystem }}` is in maintenance mode for at least 10 days with no custom attributes tag. ({{ $labels.vcenter }})."
+---
+# Source: prometheus-vmware-rules/charts/owner-info/templates/configmap.yaml
+kind: ConfigMap
+apiVersion: v1
+
+metadata:
+  # We need this configmap to be present early because it is used by a mutating webhook when the
+  # other objects in this Helm release are written into the Kubernetes DB.
+  name: early-owner-of-prometheus-vmware-rules
+  labels:
+    # This can be used to validate via policy that everyone uses a reasonably up-to-date version of this chart.
+    owner-info-version: "0.2.0"
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-100"
+    "helm.sh/hook-delete-policy": before-hook-creation
+
+data:
+  support-group: "observability"
+  service: "alertmanager"


### PR DESCRIPTION
Fixing most of the linting errors of our alerts
Copy and modify a alert rule inside the template, if it is a Bedrock alert. Filtering for iaas Hosts and override the support-group to iaas-support

