### PR TITLE
Keystone: forbid deletion of domains and roles

### DIFF
--- a/openstack/keystone/templates/etc/_policy.yaml.tpl
+++ b/openstack/keystone/templates/etc/_policy.yaml.tpl
@@ -255,7 +255,7 @@
 # DELETE  /v3/domains/{domain_id}
 # Intended scope(s): system
 #"identity:delete_domain": "role:admin and system_scope:all"
-"identity:delete_domain": "rule:cloud_admin"
+"identity:delete_domain": "!"
 
 # Create domain configuration.
 # PUT  /v3/domains/{domain_id}/config

--- a/openstack/keystone/templates/etc/_policy.yaml.tpl
+++ b/openstack/keystone/templates/etc/_policy.yaml.tpl
@@ -1157,7 +1157,7 @@
 # DELETE  /v3/roles/{role_id}
 # Intended scope(s): system
 #"identity:delete_role": "role:admin and system_scope:all"
-"identity:delete_role": "rule:cloud_admin"
+"identity:delete_role": "!"
 
 # Show domain role.
 # GET  /v3/roles/{role_id}


### PR DESCRIPTION
Forbid deleting roles and domains from keystone. Experience shows that these operations causes many ugly side-effects.

If a role or a domain really needs to be removed, this setting can be changed back.