### PR TITLE
[kvm][nova/neutron-hypervisor-agents] updating utils chart version to ~0.30.0

### DIFF
--- a/openstack/neutron-hypervisor-agents/Chart.lock
+++ b/openstack/neutron-hypervisor-agents/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.19.7
+  version: 0.30.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:15dfd047e52f668329611a1999c2f1231dc82228516ed4c0feff1c0227a3f17e
-generated: "2025-01-17T14:45:03.623869-05:00"
+digest: sha256:203908047082ef34cbb47284afedc69121bb8b250936139d33d27c2239aada0d
+generated: "2025-09-11T11:58:51.95708+02:00"

--- a/openstack/neutron-hypervisor-agents/Chart.yaml
+++ b/openstack/neutron-hypervisor-agents/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 description: A Helm chart for Openstack Neutron hypervisor agents
 name: neutron-hypervisor-agents
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Neutron/OpenStack_Project_Neutron_mascot.png
-version: 0.2.0
+version: 0.2.1
 appVersion: "caracal"
 dependencies:
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: ~0.19.6
+  version: ~0.30.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: ~1.0.0

--- a/openstack/nova-hypervisor-agents/Chart.lock
+++ b/openstack/nova-hypervisor-agents/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.19.7
+  version: 0.30.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:15dfd047e52f668329611a1999c2f1231dc82228516ed4c0feff1c0227a3f17e
-generated: "2025-02-18T15:32:56.278934-05:00"
+digest: sha256:203908047082ef34cbb47284afedc69121bb8b250936139d33d27c2239aada0d
+generated: "2025-09-11T12:04:21.80456+02:00"

--- a/openstack/nova-hypervisor-agents/Chart.yaml
+++ b/openstack/nova-hypervisor-agents/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 description: A Helm chart Nova hypervisor agents
 name: nova-hypervisor-agents
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Nova/OpenStack_Project_Nova_mascot.png
-version: 0.2.0
+version: 0.2.1
 appVersion: "bobcat"
 dependencies:
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: ~0.19.6
+  version: ~0.30.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: ~1.0.0


### PR DESCRIPTION
This update changes the `cloud.sap/injected-refs` in the `neutron-hypervisor-agents-etc` to use
`vault+kvv2:///secrets/$REGION/neutron/rabbitmq-user/$CORRECT_USER/username`
instead of 
`vault+kvv2:///secrets/$REGION/neutron/rabbitmq-user/default/username`
to support password rotation.
The nova-hypervisor-agents chart is also updated for symmetry although it already determined the correct user using its own logic.