### PR TITLE
[nova-hypervisor-agents] Switch from stringData to data

### DIFF
--- a/openstack/nova-hypervisor-agents/templates/etc-secret.yaml
+++ b/openstack/nova-hypervisor-agents/templates/etc-secret.yaml
@@ -6,27 +6,8 @@ metadata:
     system: openstack
     type: configuration
     component: nova
-stringData:
+data:
   cell.conf: |
-    [DEFAULT]
-    transport_url = {{ include "cell1_transport_url" . }}
+    {{ include (print .Template.BasePath "/etc/_cell1.conf.tpl") . | b64enc | indent 4 }}
   keystoneauth-secrets.conf: |
-    [cinder]
-    username = nova
-    password = {{ required ".Values.global.nova_service_password is missing" .Values.global.nova_service_password | include "resolve_secret" }}
-
-    [neutron]
-    username = nova
-    password = {{ required ".Values.global.nova_service_password is missing" .Values.global.nova_service_password | include "resolve_secret" }}
-
-    [keystone_authtoken]
-    username = nova
-    password = {{ required ".Values.global.nova_service_password is missing" .Values.global.nova_service_password | include "resolve_secret" }}
-
-    [placement]
-    username = nova
-    password = {{ required ".Values.global.nova_service_password is missing" .Values.global.nova_service_password | include "resolve_secret" }}
-
-    [service_user]
-    username = nova
-    password = {{ required ".Values.global.nova_service_password is missing" .Values.global.nova_service_password | include "resolve_secret" }}
+    {{ include (print .Template.BasePath "/etc/_keystoneauth-secrets.conf.tpl") . | b64enc | indent 4 }}

--- a/openstack/nova-hypervisor-agents/templates/etc/_cell1.conf.tpl
+++ b/openstack/nova-hypervisor-agents/templates/etc/_cell1.conf.tpl
@@ -1,0 +1,2 @@
+[DEFAULT]
+transport_url = {{ include "cell1_transport_url" . }}

--- a/openstack/nova-hypervisor-agents/templates/etc/_keystoneauth-secrets.conf.tpl
+++ b/openstack/nova-hypervisor-agents/templates/etc/_keystoneauth-secrets.conf.tpl
@@ -1,0 +1,19 @@
+[cinder]
+username = nova
+password = {{ required ".Values.global.nova_service_password is missing" .Values.global.nova_service_password | include "resolve_secret" }}
+
+[neutron]
+username = nova
+password = {{ required ".Values.global.nova_service_password is missing" .Values.global.nova_service_password | include "resolve_secret" }}
+
+[keystone_authtoken]
+username = nova
+password = {{ required ".Values.global.nova_service_password is missing" .Values.global.nova_service_password | include "resolve_secret" }}
+
+[placement]
+username = nova
+password = {{ required ".Values.global.nova_service_password is missing" .Values.global.nova_service_password | include "resolve_secret" }}
+
+[service_user]
+username = nova
+password = {{ required ".Values.global.nova_service_password is missing" .Values.global.nova_service_password | include "resolve_secret" }}


### PR DESCRIPTION
Using stringData in Secrets, we cannot remove keys and thus it's generally not advised to use it. Therefore, we switch to using `data`.