### PR TITLE
[placement] use custom helper function for db url

### DIFF
--- a/openstack/placement/Chart.yaml
+++ b/openstack/placement/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 description: A Helm chart for the Openstack Placement Service
 name: placement
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/project-mascots/Placement/OpenStack_Project_Placement_horizontal.jpg
-version: 0.3.1
+version: 0.4.0
 appVersion: "dalmatian"
 dependencies:
   - condition: mariadb.enabled

--- a/openstack/placement/ci/test-values.yaml
+++ b/openstack/placement/ci/test-values.yaml
@@ -12,6 +12,8 @@ global:
 
 imageVersion: myTag
 
+# databaseOverride: mariadb_api
+
 mariadb:
   enabled: false
   name: placement  # can be changed
@@ -19,7 +21,19 @@ mariadb:
   users:
     placement:
       name: placement
-      password: topUserSecret
+      password: topUserSecretPlacement
+  backup_v2:
+    enabled: false
+
+mariadb_api:
+  enabled: false
+  defaultUser: placement
+  name: nova-api  # can be changed
+  root_password: topRootSecret
+  users:
+    placement:
+      name: placement
+      password: topUserSecretAPI
   backup_v2:
     enabled: false
 

--- a/openstack/placement/templates/_helpers.tpl
+++ b/openstack/placement/templates/_helpers.tpl
@@ -7,7 +7,90 @@
   {{- end }}
 {{- end }}
 
+{{- define "placement.helpers.db_suffix" }}
+  {{- if eq .Values.dbType "mariadb" }}
+    {{- print "mariadb" }}
+  {{- else if eq .Values.dbType "pxc-db" }}
+    {{- print "db-haproxy" }}
+  {{- else }}
+    {{- fail (print "Unsupported database type in .Values.dbType") }}
+  {{- end }}
+{{- end }}
 
-{{- define "placement.db_name" }}
-{{- include "utils.db_host" . -}}
+{{- define "placement.helpers.db_service_name" }}
+  {{- $dbConfig := dict }}
+  {{- if .Values.databaseOverride }}
+    {{- $dbConfig = get .Values .Values.databaseOverride }}
+    {{- if not $dbConfig }}
+      {{- fail (printf "No database config found for override: %s, check your .Values.%s" .Values.databaseOverride .Values.databaseOverride) }}
+    {{- end }}
+  {{- else }}
+    {{- if eq .Values.dbType "mariadb" }}
+      {{- $dbConfig = .Values.mariadb }}
+    {{- else if eq .Values.dbType "pxc-db" }}
+      {{- $dbConfig = .Values.pxc_db }}
+    {{- else }}
+      {{- fail (print "Unsupported database type in .Values.dbType") }}
+    {{- end }}
+  {{- end }}
+  {{- printf "%s-%s" $dbConfig.name (include "placement.helpers.db_suffix" .) -}}
+{{- end }}
+
+{{- define "placement.helpers.db_url" -}}
+  {{- $dbConfig := dict }}
+  {{- if .Values.databaseOverride }}
+    {{- $dbConfig = get .Values .Values.databaseOverride }}
+    {{- if not $dbConfig }}
+      {{- fail (printf "No database config found for override: %s, check your .Values.%s" .Values.databaseOverride .Values.databaseOverride) }}
+    {{- end }}
+  {{- else }}
+    {{- if eq .Values.dbType "mariadb" }}
+      {{- $dbConfig = .Values.mariadb }}
+    {{- else if eq .Values.dbType "pxc-db" }}
+      {{- $dbConfig = .Values.pxc_db }}
+    {{- else }}
+      {{- fail (print "Unsupported database type in .Values.dbType") }}
+    {{- end }}
+  {{- end }}
+  {{- $context := dict "target" $dbConfig.name "defaultUser" $dbConfig.defaultUser "users" $dbConfig.users }}
+  {{- tuple . .Values.dbName (include "placement.helpers.default_db_user" $context) (include "placement.helpers.default_user_password" $context) $dbConfig.name .Values.dbType | include "utils.db_url" }}
+{{- end }}
+
+{{- /*
+Helper function to fetch a value (e.g., password, name, user) from a user object in a users map.
+Params:
+  .target: the target (e.g., placement)
+  .users: the users map
+  .defaultUser: the defaultUser value
+  .key: the key to fetch from the user object (e.g., "password", "name", "user")
+*/ -}}
+{{- define "placement.helpers.default_user_value" }}
+  {{- $target := .target | lower }}
+  {{- $users := .users }}
+  {{- $defaultUser := .defaultUser }}
+  {{- $key := .key }}
+  {{- if not $users }}
+    {{ fail (printf "No users map defined for target '%s'. Check your values for .users." $target) }}
+  {{- end }}
+  {{- if not $defaultUser }}
+    {{ fail (printf "No defaultUser defined for target '%s'. Check your values for .defaultUser." $target) }}
+  {{- end }}
+  {{- $user := index $users $defaultUser }}
+  {{- if not $user }}
+    {{ fail (printf "No user '%s' found in users map for target '%s'. Check your .users for a key '%s'." $defaultUser $target $defaultUser) }}
+  {{- end }}
+  {{- if not (hasKey $user $key) }}
+    {{ fail (printf "No key '%s' for user '%s' in users map for target '%s'. Check your .users['%s'] for a key '%s'." $key $defaultUser $target $defaultUser $key) }}
+  {{- end }}
+  {{- index $user $key }}
+{{- end }}
+
+{{- define "placement.helpers.default_user_password" }}
+  {{- $params := dict "target" .target "users" .users "defaultUser" .defaultUser "key" "password" }}
+  {{- include "placement.helpers.default_user_value" $params }}
+{{- end }}
+
+{{- define "placement.helpers.default_db_user" }}
+  {{- $params := dict "target" .target "users" .users "defaultUser" .defaultUser "key" "name" }}
+  {{- include "placement.helpers.default_user_value" $params }}
 {{- end }}

--- a/openstack/placement/templates/db-migrate-job.yaml
+++ b/openstack/placement/templates/db-migrate-job.yaml
@@ -22,7 +22,7 @@ spec:
       restartPolicy: OnFailure
       {{- include "utils.proxysql.job_pod_settings" . | indent 6 }}
       initContainers:
-      {{- tuple . (dict "service" (include "placement.db_name" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
+      {{- tuple . (dict "service" (include "placement.helpers.db_service_name" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       {{- if .Values.proxysql.native_sidecar }}
       {{- include "utils.proxysql.container" . | indent 6 }}
       {{- end }}

--- a/openstack/placement/templates/db-online-migrate-job.yaml
+++ b/openstack/placement/templates/db-online-migrate-job.yaml
@@ -22,7 +22,7 @@ spec:
       restartPolicy: OnFailure
       {{- include "utils.proxysql.job_pod_settings" . | indent 6 }}
       initContainers:
-      {{- tuple . (dict "service" (include "placement.db_name" .) "jobs" (tuple . "db-migrate" | include "placement.job_name") ) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
+      {{- tuple . (dict "service" (include "placement.helpers.db_service_name" .) "jobs" (tuple . "db-migrate" | include "placement.job_name") ) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       {{- if .Values.proxysql.native_sidecar }}
       {{- include "utils.proxysql.container" . | indent 6 }}
       {{- end }}

--- a/openstack/placement/templates/etc/_secrets.conf.tpl
+++ b/openstack/placement/templates/etc/_secrets.conf.tpl
@@ -1,5 +1,5 @@
 [placement_database]
-connection = {{ include "utils.db_url" . }}
+connection = {{ include "placement.helpers.db_url" . }}
 
 [keystone_authtoken]
 username = {{ .Values.global.placement_service_user | default "placement" | include "resolve_secret" }}

--- a/openstack/placement/templates/placement-api-deployment.yaml
+++ b/openstack/placement/templates/placement-api-deployment.yaml
@@ -39,7 +39,7 @@ spec:
 {{ tuple . "placement" "api" | include "kubernetes_pod_anti_affinity" | indent 6 }}
       {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       initContainers:
-      {{- tuple . (dict "service" (include "placement.db_name" .) "jobs" (tuple . "db-migrate" | include "placement.job_name") ) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
+      {{- tuple . (dict "service" (include "placement.helpers.db_service_name" .) "jobs" (tuple . "db-migrate" | include "placement.job_name") ) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       {{- if .Values.proxysql.native_sidecar }}
       {{- include "utils.proxysql.container" . | indent 6 }}
       {{- end }}

--- a/openstack/placement/values.yaml
+++ b/openstack/placement/values.yaml
@@ -54,8 +54,11 @@ api_db:  # Only used when mariadb.enabled=False to connect to the nova-api-maria
   user: placement
   password: null
 
-dbType: ""
+dbType: "mariadb"
 dbName: "placement"
+
+# databaseOverride: mariadb
+# If set, forces the chart to use the given database config map for the database URL
 
 mariadb:
   enabled: true


### PR DESCRIPTION
Use a custom helper template function to create db connection URL.

Currently, placement chart can utilize only `.Values.mariadb` values, including `.Values.mariadb.name`

This PR makes it possible to use another map for db url configuration, which might help to create a separate database using values like `.Values.mariadb` while keeping an old configuration with `.Values.mariadb_nova_api`