### PR TITLE
[ironic] dependency updates

### DIFF
--- a/openstack/ironic/Chart.lock
+++ b/openstack/ironic/Chart.lock
@@ -1,13 +1,13 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.26.1
+  version: 0.27.2
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.4.1
+  version: 0.5.0
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.6.11
+  version: 0.6.12
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.5.2
@@ -16,15 +16,15 @@ dependencies:
   version: 1.0.0
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.18.5
+  version: 0.19.2
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.28.0
+  version: 0.30.0
 - name: ironic-exporter
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.3
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.1.0
-digest: sha256:59a8401c9d117f59da71edbbfa4f42c476c852be42227e1547ce8793dc19fb82
-generated: "2025-07-28T13:19:17.492809069+02:00"
+  version: 1.1.1
+digest: sha256:8fa045bea8c44c6a1e74fb3a103f98424e55967355425b5adffe9bf845a30c0e
+generated: "2025-09-11T15:39:37.749756653+02:00"

--- a/openstack/ironic/Chart.yaml
+++ b/openstack/ironic/Chart.yaml
@@ -2,20 +2,20 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Ironic/OpenStack_Project_Ironic_vertical.png
 name: ironic
-version: 0.2.8
+version: 0.2.9
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.26.1
+    version: ~0.27.2
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.4.1
+    version: ~0.5.0
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.6.11
+    version: ~0.6.12
   - condition: mysql_metrics.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
@@ -25,13 +25,13 @@ dependencies:
     version: ~1.0.0
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.18.5
+    version: ~0.19.2
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.28.0
+    version: ~0.30.0
   - name: ironic-exporter
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: ~1.0.3
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~1.1.0
+    version: ~1.1.1


### PR DESCRIPTION
[mariadb]
v0.27.2 - 2025/08/23
Add missing secret resolve in `init.sql`, when user is disabled, so the generated comment would contain the actual username instead of the vault reference if the vault secret is being used for the username value
* chart version bumped

v0.27.1 - 2025/08/13
* MariaDB version updated to [10.11.14](https://mariadb.com/docs/release-notes/community-server/mariadb-10-11-series/mariadb-10.11.14-release-notes)
  * several critical (InnoDB) fixes
* chart version bumped

v0.27.0 - 2025/07/31
* Added an option to drop the database user using the values configuration
Example:

```yaml
mariadb:
  users:
    test:
      enabled: false
```
This will result in the `test` user being dropped from the MariaDB.

[pxc-db]
update to 1.18 pxc-operator release image version

[memcached]
v0.6.12 - 2025/08/04
memcached [version](https://github.com/memcached/memcached/wiki/ReleaseNotes1639) bumped to `1.6.39-alpine3.22`
  * TLS and proxy fixes
* chart version bumped

[rabbitmq]
0.19.2 - 2025/09/04
- RabbitMQ [4.1.4 Release notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.1.4)
- `rabbitmq-user-credential-updater` updated to `20250904100127` version
- Chart version bumped

0.19.1 - 2025/08/06
- RabbitMQ [4.1.3 Release notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.1.3)
- several bugfixes for queues
- Chart version bumped

0.19.0 - 2025/08/01
- Added an option to disable a user
Usage example:

```yaml
rabbitmq:
  users:
    default:
      enabled: false
    user1:
      user: user1
      password: secret
    user2:
      user: user2
      password: secret
```

This will result in the `default` user being removed from the RabbitMQ users secret.

0.18.8 - 2025/08/01
- Remove version label from RabbitMQ deployment pod template, related configmaps and secrets to avoid unnecessary  restarts on simple chart version update

0.18.7 - 2025/07/31
- Limit default commonName in certificate to 64 characters as that is the limit.

0.18.6 - 2025/07/30
- Update [user-credential-updater](https://github.com/sapcc/rabbitmq-user-credential-updater) sidecar container to `20250730094138` version with bugfixes.
- Chart version bumped

[utils]
0.30
- Add option for linkerd native sidecar

0.29
- [utils][proxysql] skip disabled database users and null password

[linkerd]
1.1.1
- fix(linkerd-support): add linkerd-support to ghcr.io
