### PR TITLE
Revert "[Nova] Temporarily add key back to nova-etc Secret"

### DIFF
--- a/openstack/nova/templates/etc-secret.yaml
+++ b/openstack/nova/templates/etc-secret.yaml
@@ -23,5 +23,3 @@ data:
     {{ include "ini_sections.audit_middleware_notifications" . | b64enc | indent 4 }}
   osprofiler.conf: |
     {{ include "osprofiler" . | b64enc | indent 4 }}
-  nova-api-metadata-secrets.conf: |
-    {{ "temporary value to overwrite stale data" | b64enc | indent 4 }}


### PR DESCRIPTION
This reverts commit c15003a7f4f8bc3861fe358802b5e1eda1530ddc.

We rolled it out. Secrets are fine. We can get rid of it again.