### PR TITLE
[snmp-exporter] rename lb_id to loadbalancer_id

### DIFF
--- a/prometheus-exporters/snmp-exporter/templates/scrapeconfig-f5customer.yaml
+++ b/prometheus-exporters/snmp-exporter/templates/scrapeconfig-f5customer.yaml
@@ -50,7 +50,7 @@ spec:
       replacement: $1-$2-$3-$4-$5
     - action: replace
       sourceLabels: [ltmVirtualServStatName]
-      targetLabel: lb_id
+      targetLabel: loadbalancer_id
       regex: /net_.*/lb_(.*)/listener_.*
     - action: replace
       sourceLabels: [snmp_f5_ltmVirtualServStatName]


### PR DESCRIPTION
To align with loadbalancer_name we rename lb_id to loadbalancer_id. There will be a second PR to fix the join in Maia.