### PR TITLE
[ironic] stop using swift for redfish deployments

### DIFF
--- a/openstack/ironic/values.yaml
+++ b/openstack/ironic/values.yaml
@@ -212,7 +212,7 @@ conductor:
       uefi_pxe_bootfile_name: "ipxe.efi"
       uefi_ipxe_bootfile_name: "ipxe.efi"
     redfish:
-      swift_object_expiry_timeout: "5400"
+      use_swift: false
     conductor:
       conductor_always_validates_images: false # We only use the direct interface, so leave it to the agent
       permitted_image_formats: 'raw,qcow2,iso,vmdk'


### PR DESCRIPTION
Redfish & idrac-redfish deployments used swift to distribute the ISO
built by ironic. However it seems some vendors have a URL character
length limit for virtual-media. Dell introduced this with iDrac versions
higher than 7.10.30.05. To circumvent this we'll stop using swift so
instead the conductor will distribute the ISO. As we stop using swift we
don't need to set a expiry timeout.
