### PR TITLE
[keystone-global] bump percona_cluster chart dependency

### DIFF
--- a/openstack/keystone/Chart.lock
+++ b/openstack/keystone/Chart.lock
@@ -16,12 +16,12 @@ dependencies:
   version: 1.0.0
 - name: percona_cluster
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.1.11
+  version: 1.2.3
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.29.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:022425ca476796ff8192e9059e2e606b7be570fe1a538d0f5596ae6a8fae8625
-generated: "2025-08-25T15:43:26.295492+03:00"
+digest: sha256:29e35ebb0e5087cda511fcc0e927c8295aedd49fd7bc636d284a19038d060a8b
+generated: "2025-10-07T12:22:04.60749+03:00"

--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: keystone
 sources:
   - https://github.com/sapcc/keystone
-version: 0.10.9
+version: 0.10.10
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
@@ -33,7 +33,7 @@ dependencies:
   - condition: percona_cluster.enabled
     name: percona_cluster
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 1.1.11
+    version: 1.2.3
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.29.0


### PR DESCRIPTION
Bump percona_cluster chart dependency to 1.2.3:
* Updates pxc to 5.7.44
* Updates mysqld-exporter to 0.18.0
* Allows password rotation