### PR TITLE
updated hostinmaintenacemode alert

### DIFF
--- a/prometheus-rules/prometheus-vmware-rules/Chart.yaml
+++ b/prometheus-rules/prometheus-vmware-rules/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A collection of Prometheus alert rules.
 name: prometheus-vmware-rules
-version: 1.3.17
+version: 1.3.18
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/prometheus-rules/prometheus-vmware-rules/alerts-scaleout-ruler/host.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts-scaleout-ruler/host.alerts
@@ -5,6 +5,7 @@
         expr: |
           count_over_time((present_over_time(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}[1d]))[15d:1d]) >= 10
           and on (hostsystem) (vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"})
+          and on (hostsystem) (vrops_hostsystem_system_uptime_seconds > (60*60))
           unless on (hostsystem) (vrops_hostsystem_custom_attributes_hw_info == 1)
           unless on (hostsystem) (vrops_hostsystem_custom_attributes_change_request_info == 1)
           unless on (hostsystem) (vrops_hostsystem_runtime_connectionstate == 0)

--- a/prometheus-rules/prometheus-vmware-rules/alerts-scaleout-ruler/host.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts-scaleout-ruler/host.alerts
@@ -5,11 +5,11 @@
         expr: |
           count_over_time((present_over_time(vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"}[1d]))[15d:1d]) >= 10
           and on (hostsystem) (vrops_hostsystem_runtime_maintenancestate{state="inMaintenance"})
-          and on (hostsystem) (vrops_hostsystem_system_uptime_seconds > (60*60))
           unless on (hostsystem) (vrops_hostsystem_custom_attributes_hw_info == 1)
           unless on (hostsystem) (vrops_hostsystem_custom_attributes_change_request_info == 1)
           unless on (hostsystem) (vrops_hostsystem_runtime_connectionstate == 0)
           unless on (vccluster) (vrops_cluster_summary_custom_tag_openstack_nova_traits_compute_status_disabled == 1)
+        for: 60m
         labels:
           severity: warning
           service: compute


### PR DESCRIPTION
updated host in maintenance mode for 10 days to exclude host with less than 60 minutes uptime to remove some false positive that would come from a reinstall avec a break and fix intervention