### PR TITLE
[mariadb][sync] Add go-maria-sync statefulset

### DIFF
--- a/common/mariadb/templates/_helpers.tpl
+++ b/common/mariadb/templates/_helpers.tpl
@@ -133,3 +133,14 @@ helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}
   {{- end }}
 {{- end }}
 
+{{/*
+Default pod labels for linkerd
+*/}}
+{{- define "mariadb.linkerdPodAnnotations" }}
+  {{- if and (and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested) $.Values.linkerd.mariadb.enabled }}
+linkerd.io/inject: enabled
+    {{- if $.Values.global.linkerd_use_native_sidecar }}
+config.alpha.linkerd.io/proxy-enable-native-sidecar: "true"
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/common/mariadb/templates/sync-configmap.yaml
+++ b/common/mariadb/templates/sync-configmap.yaml
@@ -1,0 +1,60 @@
+{{/*
+Create the config map content for sync pod
+*/}}
+{{- define "mariadb.sync.configmap" }}
+{{- $v := .Values -}}
+region: {{ $v.global.region | required "global.region is required" }}
+loglevel: {{ $v.loglevel | default "info" | quote }}
+{{- if $v.backup }}
+backup:
+  {{- if $v.backup.service }}
+  service: {{ $v.backup.service | quote }}
+  {{- end }}
+  {{- if $v.backup.swift }}
+  swift:
+    container: {{ ($v.backup.swift.container | default (printf "mariadb-backup-%s" ($v.backup.region | default $v.global.region))) | quote }}
+    creds:
+      identityEndpoint: {{ $v.backup.swift.identityEndpoint | required "backup.swift.identityEndpoint is required" | quote }}
+      user: {{ $v.backup.swift.user | default "db_backup" | quote }}
+      userDomain: {{ $v.backup.swift.userDomain | default "Default" | quote }}
+      project: {{ $v.backup.swift.project | default "master" | quote }}
+      projectDomain: {{ $v.backup.swift.projectDomain | default "ccadmin" | quote }}
+  {{- end }}
+  {{- if $v.backup.s3 }}
+  s3:
+    sseCustomerAlgorithm: {{ $v.backup.s3.sseCustomerAlgorithm | default "AES256" | quote }}
+    region: {{ required "missing AWS region" $v.global.mariadb.backup_v2.aws.region }}
+    bucketName: {{ ($v.backup.s3.bucketName | default (printf "mariadb-backup-%s" ($v.backup.region | default ""))) | quote }}
+  {{- end }}
+{{- end }}
+replication:
+  sourceDB:
+    host: {{ $v.source.host | default "" | quote }}
+    port: {{ ($v.source.port | default 3306) | quote }}
+    user: {{ $v.source.user | default "root" | quote }}
+  targetDB:
+    host: {{ $v.target.host | default "" | quote }}
+    port: {{ ($v.target.port | default 3306) | quote }}
+    user: {{ $v.target.user | default "root" | quote }}
+  schemas:
+  {{- if $v.databases }}
+    {{- range $db := $v.databases }}
+    - {{ $db | quote }}
+    {{- end }}
+  {{- end }}
+  serverID: {{ $v.serverID | default 991 }}
+  binlogMaxReconnectAttempts: {{ $v.binlogMaxReconnectAttempts | default 10 }}
+{{- end }}
+{{- if .Values.sync.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "fullName" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mariadb.labels" (list $ "noversion" "database-sync" "cm" "config") | nindent 4 }}
+data:
+  config.yaml: |
+{{ include "mariadb.sync.configmap" . | indent 4 }}
+{{- end }}

--- a/common/mariadb/templates/sync-secret.yaml
+++ b/common/mariadb/templates/sync-secret.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.sync.enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "fullName" . }}-sync-secrets
+  labels:
+    {{- include "mariadb.labels" (list $ "version" "database-sync" "secret" "opaque") | nindent 4 }}
+type: Opaque
+data:
+  SOURCEDB_PASSWORD: {{ .Values.source.password | required ".Values.sync.source.password is missing" | b64enc | quote }}
+  TARGETDB_PASSWORD: {{ .Values.target.password | required ".Values.sync.target.password is missing" | b64enc | quote }}
+  OPENSTACK_PASSWORD: {{ .Values.openstack.password | required ".Values.sync.openstack.password is missing" | b64enc | quote }}
+  AWS_ACCESS_KEY_ID: {{ required "missing AWS Access Key ID" $.Values.global.backup_v2.aws_access_key_id | b64enc | quote }}
+  AWS_SECRET_ACCESS_KEY: {{ required "missing AWS Secret Access Key" $.Values.global.backup_v2.aws_secret_access_key | b64enc | quote }}
+  SSE_CUSTOMER_KEY: {{ required "missing AWS S3 SSE Customer Key" $.Values.global.mariadb.backup_v2.aws.sse_customer_key | b64enc | quote }}
+{{- end }}

--- a/common/mariadb/templates/sync-statefulset.yaml
+++ b/common/mariadb/templates/sync-statefulset.yaml
@@ -1,0 +1,60 @@
+{{- if .Values.sync.enabled }}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "fullName" . }}-sync
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mariadb.labels" (list $ "version" "database-sync" "sts" "database") | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: go-maria-sync
+      app.kubernetes.io/instance: {{ include "fullName" . }}-sync
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/version: {{ .Values.sync.image.tag }}
+        app.kubernetes.io/name: go-maria-sync
+        app.kubernetes.io/instance: {{ include "fullName" . }}-sync
+      annotations:
+        kubectl.kubernetes.io/default-container: "sync"
+        {{- include "mariadb.linkerdPodAnnotations" . | indent 8 }}
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: sync
+        image: {{ required ".Values.global.registry variable missing" .Values.global.registry }}/{{ .Values.sync.image.name }}:{{ .Values.sync.image.tag }}
+        imagePullPolicy: {{ .Values.sync.imagePullPolicy }}
+        command:
+          - sync
+        ports:
+          - containerPort: 8080
+            name: metrics
+            protocol: TCP
+        resources:
+          limits:
+            cpu: 500m
+            memory: 2Gi
+          requests:
+            cpu: 50m
+            memory: 30Mi
+        env:
+        - name: "CONFIG"
+          value: "/etc/config/config.yaml"
+        - name: "DOWNLOAD_DIR"
+          value: "/home/appuser/backup"
+        envFrom:
+        - secretRef:
+            name: {{ include "fullName" . }}-sync-secrets
+        volumeMounts:
+        - name: mariadb-sync-etc
+          mountPath: /etc/config
+          readOnly: true
+      volumes:
+        - name: mariadb-sync-etc
+          configMap:
+            name: {{ include "fullName" . }}-sync-config
+{{- end }}

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -244,6 +244,27 @@ metrics:
       cpu: 5m
       memory: 32Mi
 
+sync:
+  enabled: false
+  image:
+    name: "go-maria-sync"
+    tag: "20250918190838"
+  imagePullPolicy: "IfNotPresent"
+  source:
+    password: null
+  target:
+    password: null
+  databases: []
+  loglevel: info
+  serverID: 899
+  binlogMaxReconnectAttempts: 10
+  openstack:
+    password: null
+  aws:
+    accessKeyID: null
+    secretAccessKey: null
+    sseCustomerKey: null
+
 # Default Prometheus alerts and rules.
 alerts:
   enabled: true


### PR DESCRIPTION
Add `go-maria-sync` statefulset option, which might be used to sync database content from one database instance to another.