### PR TITLE
[mariadb] update sidecar images

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.27.3 - 2025/09/22
+* updated sidecar images:
+  * `maria-back-me-up` image updated to `20250922093701`
+  * `user-credentials-updater` image updated to `python3.13-alpine3.22-20250818200546`
+  * `pod-readiness` image updated to `20250922092006`
+* chart version bumped
+
 ## v0.27.2 - 2025/08/23
 Add missing secret resolve in `init.sql`, when user is disabled, so the generated comment would contain the actual username instead of the vault reference if the vault secret is being used for the username value
 * chart version bumped

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,6 +2,6 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.27.2
+version: 0.27.3
 # scripts/docker-entyrpoint.sh should be updated when appVersion is updated
 appVersion: 10.11.14

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -132,11 +132,6 @@ job:
         # @default -- 0.5
         cpu:
 
-pre_change_hook:
-  image:
-    name: "shared-app-images/alpine-kubectl"
-    tag: "3.21-20250214202620"
-
 # name of priorityClass to influence scheduling priority
 priority_class: "critical-infrastructure"
 priority_class_backup: "critical-infrastructure"
@@ -188,20 +183,20 @@ use_alternate_registry: false
 
 readiness:
   image: pod-readiness
-  image_version: "20250225131500"
+  image_version: "20250922092006"
   # set to true if backup_v2 is not enabled, but readiness sidecar is required
   useSidecar: false
 
 credentialUpdater:
   image: 'shared-app-images/alpine-mariadb'
-  imageTag: 'python3.13-alpine3.21-20250305175417'
+  imageTag: 'python3.13-alpine3.22-20250818200546'
   checkInterval: '10'
 
 backup_v2:
   enabled: false
   backup_dir: "./backup"
   image: maria-back-me-up
-  image_version: "20250722132533"
+  image_version: "20250922093701"
   full_backup_cron_schedule: "0 0 * * *"
   incremental_backup_in_minutes: 5
   purge_binlog_after_minutes: 60


### PR DESCRIPTION
* updated sidecar images:
  * `maria-back-me-up` image updated to `20250922093701`
  * `user-credentials-updater` image updated to `python3.13-alpine3.22-20250818200546`
  * `pod-readiness` image updated to `20250922092006`
* chart version bumped