### PR TITLE
feat(disco): make deployment labels configurable

### DIFF
--- a/system/disco/Chart.yaml
+++ b/system/disco/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: The DISCO (Designate IngresS Cname Operator) creates CNAMEs based on an ingress spec in OpenStack Designate.
 name: disco
-version: 2.4.0
+version: 2.4.1
 appVersion: v2.0.0
 maintainers:
   - name: kengou

--- a/system/disco/ci/test-values.yaml
+++ b/system/disco/ci/test-values.yaml
@@ -1,5 +1,7 @@
 seed:
   enabled: true
+controllerLabels:
+  foo: bar
 
 openstack:
   authURL:            https://keystone.staging.evil.corp:5000/v3

--- a/system/disco/templates/disco-controller-manager.yaml
+++ b/system/disco/templates/disco-controller-manager.yaml
@@ -3,6 +3,9 @@ kind: Deployment
 metadata:
   labels:
     app: disco
+    {{- with .Values.controllerLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: disco-controller-manager
 spec:
   replicas: 1
@@ -16,6 +19,9 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/disco-config.yaml") . | sha256sum }}
       labels:
         app: disco
+        {{- with .Values.controllerLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       containers:
       - command:

--- a/system/disco/values.yaml
+++ b/system/disco/values.yaml
@@ -2,6 +2,9 @@ image:
   repository: keppel.global.cloud.sap/ccloud-ghcr-io-mirror/sapcc/disco
   tag: v2.0.0
 
+# These labels will be set on the DISCO controller manager
+controllerLabels: {}
+
 # Only an ingress with this annotation will be considered.
 ingressAnnotation: "disco"
 


### PR DESCRIPTION
Gardener locks down the kube-system namespace with the 1.33 upgrade. In order to still have controller running it is necessary to be able to set labels, so that NetworkPolicies can be used.