### PR TITLE
feat(digicert): make deployment labels configurable

### DIFF
--- a/system/digicert-issuer/Chart.yaml
+++ b/system/digicert-issuer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: digicert-issuer
 description: A Helm chart for the Digicert Issuer.
 type: application
-version: 2.5.1
+version: 2.5.2
 appVersion: v2.2.0
 home: https://github.com/sapcc/digicert-issuer
 sources:

--- a/system/digicert-issuer/ci/test-values.yaml
+++ b/system/digicert-issuer/ci/test-values.yaml
@@ -10,3 +10,5 @@ provisioner:
   organizationID: "01"
   organizationUnits:
     - someOrgUnit
+deploymentLabels:
+  foo: bar

--- a/system/digicert-issuer/templates/deployment.yaml
+++ b/system/digicert-issuer/templates/deployment.yaml
@@ -5,6 +5,9 @@ metadata:
     secret.reloader.stakater.com/reload: "digicertissuer-secret"
   labels:
     app.kubernetes.io/name: digicert-issuer
+    {{- with .Values.deploymentLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: digicert-issuer
   namespace: {{ .Release.Namespace }}
 spec:
@@ -16,6 +19,9 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: digicert-issuer
+        {{- with .Values.deploymentLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       containers:
         - args:

--- a/system/digicert-issuer/values.yaml
+++ b/system/digicert-issuer/values.yaml
@@ -5,6 +5,9 @@ image:
   pullPolicy: IfNotPresent
   #tag: # defaults to appVersion
 
+# These labels will be set on the digicert deployment
+deploymentLabels: {}
+
 provisioner:
   disableRootCA: false
   validityYears: 1


### PR DESCRIPTION
Gardener locks down the kube-system namespace with the 1.33 upgrade. In order to still have controller running it is necessary to be able to set labels, so that NetworkPolicies can be used.