### PR TITLE
feat(gh-ccloud): enable setting gardener netpo labels on controller

### DIFF
--- a/system/greenhouse-ccloud/Chart.yaml
+++ b/system/greenhouse-ccloud/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: ccloud
 description: A Helm chart for the CCloud organization in Greenhouse.
 type: application
-version: 1.28.0
+version: 1.29.0

--- a/system/greenhouse-ccloud/ci/test-values.yaml
+++ b/system/greenhouse-ccloud/ci/test-values.yaml
@@ -79,6 +79,8 @@ alerts:
 certManager:
   webhook:
     timeoutSeconds: 15
+  overrideShootNetworkPolicy:
+    - cluster-one-test
 
 digicert:
   enabled: true
@@ -87,6 +89,8 @@ digicert:
     organizationID: "1337"
     organizationUnits:
       - MyUnit
+  overrideShootNetworkPolicy:
+    - cluster-one-test
 
 kubeconfigGenerator:
   enabled: true
@@ -198,11 +202,13 @@ ingressPlugins:
     recordName: ss.aa.rr
   - cluster: bar
     recordName: ss.aa.rr
+    overrideShootNetworkPolicy: true
 
 discoPlugins:
   - cluster: hase
     region: qa
     password: superSecret
+    overrideShootNetworkPolicy: true
 
 opensearch:
   enabled: true

--- a/system/greenhouse-ccloud/templates/cert-manager-pluginpreset.yaml
+++ b/system/greenhouse-ccloud/templates/cert-manager-pluginpreset.yaml
@@ -43,4 +43,15 @@ spec:
         value: {{ .Values.global.quayIoMirror }}/jetstack/cert-manager-cainjector
     pluginDefinition: cert-manager
     releaseNamespace: kube-system
+{{- if .Values.certManager.overrideShootNetworkPolicy }}
+    clusterOptionOverrides:
+{{- range $cluster := .Values.certManager.overrideShootNetworkPolicy }}
+      - clusterName: {{ $cluster }}
+        overrides:
+          - name: global.commonLabels
+            value:
+              networking.gardener.cloud/to-apiserver: allowed
+              networking.gardener.cloud/to-dns: allowed
+{{- end }}
+{{- end }}
 {{- end -}}

--- a/system/greenhouse-ccloud/templates/digicert-issuer-pluginpreset.yaml
+++ b/system/greenhouse-ccloud/templates/digicert-issuer-pluginpreset.yaml
@@ -46,4 +46,15 @@ spec:
       value: {{ required "plugin digicert organization units is missing" .Values.digicert.provisioner.organizationUnits | quote }}
     pluginDefinition: digicert-issuer
     releaseNamespace: kube-system
+{{- if .Values.digicert.overrideShootNetworkPolicy }}
+    clusterOptionOverrides:
+{{- range $cluster := .Values.digicert.overrideShootNetworkPolicy }}
+      - clusterName: {{ $cluster }}
+        overrides:
+          - name: deploymentLabels
+            value:
+              networking.gardener.cloud/to-apiserver: allowed
+              networking.gardener.cloud/to-dns: allowed
+{{- end }}
+{{- end }}
 {{- end -}}

--- a/system/greenhouse-ccloud/templates/disco-plugins.yaml
+++ b/system/greenhouse-ccloud/templates/disco-plugins.yaml
@@ -36,6 +36,12 @@ spec:
     value: {{ default $plugin.region $plugin.zoneNameRegion }}.cloud.sap.
   - name: record
     value: {{ $plugin.recordName }}
+{{- if $plugin.overrideShootNetworkPolicy }}
+  - name: controllerLabels
+    value:
+      networking.gardener.cloud/to-apiserver: allowed
+      networking.gardener.cloud/to-dns: allowed
+{{- end }}
   pluginDefinition: disco
   releaseNamespace: kube-system
 ---

--- a/system/greenhouse-ccloud/templates/ingress-plugins.yaml
+++ b/system/greenhouse-ccloud/templates/ingress-plugins.yaml
@@ -45,11 +45,16 @@ spec:
   - name: controller.config
     value:
       allow-cross-namespace-resources: true
+{{- if $plugin.overrideShootNetworkPolicy }}
+  - name: controller.labels
+    value:
+      networking.gardener.cloud/to-apiserver: allowed
+      networking.gardener.cloud/to-dns: allowed
+{{- end }}
 {{- if $plugin.affinity }}
   - name: controller.affinity
     value: {{ toYaml $plugin.affinity | nindent 6 }}
 {{- end }}
   pluginDefinition: ingress-nginx
   releaseNamespace: kube-system
-
 {{- end}}


### PR DESCRIPTION
with kube 1.33 we need to temporarily add certain controller deployed in kube-system on shoot clusters to network policies, so that they can reach the apiserver. mid-term the plugins will be move to another namespace



requires #9689 & #9688 