### PR TITLE
[mariadb] add optional `owner-info` chart dependency

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.27.3 - 2025/09/24
+* Add an option to enable `owner-info` dependency chart to be able to install `mariadb` as a stand-alone chart
+* chart version bumped
+
 ## v0.27.2 - 2025/08/23
 Add missing secret resolve in `init.sql`, when user is disabled, so the generated comment would contain the actual username instead of the vault reference if the vault secret is being used for the username value
 * chart version bumped

--- a/common/mariadb/Chart.lock
+++ b/common/mariadb/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: owner-info
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 1.0.0
+digest: sha256:912a10c806453b7d4108c0ff70edfd487b28698418a5e0041952f4dd5e972d78
+generated: "2025-09-24T12:24:22.800606+03:00"

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -1,7 +1,12 @@
 ---
-apiVersion: v1
+apiVersion: v2
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.27.2
+version: 0.27.3
 # scripts/docker-entyrpoint.sh should be updated when appVersion is updated
 appVersion: 10.11.14
+dependencies:
+  - name: owner-info
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: 1.0.0
+    condition: owner_info.enabled

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -286,3 +286,7 @@ tcp_keepalive:
   # Time between retries of unacknowledged keepalive packets. If set to 0, the system dependent default is used https://mariadb.com/kb/en/server-system-variables/#tcp_keepalive_interval
   # default is 0
   interval:
+
+# -- Enable owner_info injector chart dependency to allow installation as stand-alone chart
+owner_info:
+  enabled: false


### PR DESCRIPTION
* Add an option to enable `owner-info` dependency chart to be able to install `mariadb` as a stand-alone chart
* chart version bumped