### PR TITLE
[logs] export failed alert for otel logs

### DIFF
--- a/system/logs/Chart.lock
+++ b/system/logs/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: opentelemetry-operator
   repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-  version: 0.11.3
+  version: 0.11.7
 - name: fluent-prometheus
   repository: file://vendor/fluent-prometheus
   version: 1.0.10
@@ -11,5 +11,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
-digest: sha256:b51a847a1acbe980a07c4c86ecae44c153907ea0c74b0d25e7a86e57be57c059
-generated: "2025-09-16T11:19:13.204405+02:00"
+digest: sha256:3a4960086dcb376e7bbceee0691459423958ead5c58b45b2b29c2da68c53ddbc
+generated: "2025-09-25T15:39:50.661178+02:00"

--- a/system/logs/Chart.yaml
+++ b/system/logs/Chart.yaml
@@ -1,13 +1,13 @@
 apiVersion: v2
 description: A Helm chart for all log shippers
 name: logs
-version: 0.0.85
+version: 0.0.86
 home: https://github.com/sapcc/helm-charts/tree/master/system/logs
 dependencies:
   - name: opentelemetry-operator
     alias: openTelemetryPlugin
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.11.3
+    version: 0.11.7
     condition: openTelemetry.enabled
 
   - name: fluent-prometheus

--- a/system/logs/templates/alerts/_otel-alerts.tpl
+++ b/system/logs/templates/alerts/_otel-alerts.tpl
@@ -25,6 +25,18 @@ groups:
     annotations:
       description: 'OTel logs on {{`{{ $labels.k8s_cluster_name }}`}} in {{`{{ $labels.region }}`}} is sending 4 times more logs in the last 6h. Please check.'
       summary:  OTel log volume is increasing, check log volume.
+  - alert: LogsOTelLogsDecreasing
+    expr: sum(rate(otelcol_exporter_sent_log_records_total{job="logs/opentelemetry-collector-logs"}[1h]offset 2h)) by (k8s_cluster_name)/sum(rate(otelcol_exporter_sent_log_records_total{job="logs/opentelemetry-collector-logs"}[1h])) by (k8s_cluster_name) > 4
+    for: 2h
+    labels:
+      context: logshipping
+      service: logs
+      severity: info
+      support_group: observability
+      playbook: 'docs/support/playbook/logs/otel-logs-decreasing'
+    annotations:
+      description: 'OTel on {{`{{ $labels.k8s_cluster_name }}`}} in {{`{{ $labels.region }}`}} is sending 4 times fewer logs in the last 2h. Please check.'
+      summary:  OTel log volume is decreasing, check log volume.
   - alert: LogsOTelLogsExportingFailed
     expr: sum(increase(otelcol_exporter_sent_log_records_total{job="logs/opentelemetry-collector-logs"}[1h])) by (k8s_cluster_name)/ sum(increase(otelcol_exporter_send_failed_log_records_total{job="logs/opentelemetry-collector-logs"}[1h]) + increase(otelcol_exporter_sent_log_records_total{job="logs/opentelemetry-collector-logs"}[1h])) by (k8s_cluster_name) < 0.9
     for: 1h

--- a/system/logs/templates/alerts/_otel-alerts.tpl
+++ b/system/logs/templates/alerts/_otel-alerts.tpl
@@ -25,16 +25,16 @@ groups:
     annotations:
       description: 'OTel logs on {{`{{ $labels.k8s_cluster_name }}`}} in {{`{{ $labels.region }}`}} is sending 4 times more logs in the last 6h. Please check.'
       summary:  OTel log volume is increasing, check log volume.
-  - alert: LogsOTelLogsDecreasing
-    expr: sum(rate(otelcol_exporter_sent_log_records_total{job="logs/opentelemetry-collector-logs"}[1h]offset 2h)) by (k8s_cluster_name)/sum(rate(otelcol_exporter_sent_log_records_total{job="logs/opentelemetry-collector-logs"}[1h])) by (k8s_cluster_name) > 4
-    for: 2h
+  - alert: LogsOTelLogsExportingFailed
+    expr: sum(increase(otelcol_exporter_sent_log_records_total{job="logs/opentelemetry-collector-logs"}[1h])) by (k8s_cluster_name)/ sum(increase(otelcol_exporter_send_failed_log_records_total{job="logs/opentelemetry-collector-logs"}[1h]) + increase(otelcol_exporter_sent_log_records_total{job="logs/opentelemetry-collector-logs"}[1h])) by (k8s_cluster_name) < 0.9
+    for: 1h
     labels:
       context: logshipping
       service: logs
       severity: info
       support_group: observability
-      playbook: 'docs/support/playbook/logs/otel-logs-decreasing'
+      playbook: 'docs/support/playbook/logs/otel-logs-exporting-failed'
     annotations:
-      description: 'OTel on {{`{{ $labels.k8s_cluster_name }}`}} in {{`{{ $labels.region }}`}} is sending 4 times fewer logs in the last 2h. Please check.'
-      summary:  OTel log volume is decreasing, check log volume.
+      description: 'OTel on {{`{{ $labels.k8s_cluster_name }}`}} in {{`{{ $labels.region }}`}} is exporting logs below 90%. Please check.'
+      summary:  OTel log exporting is failing. Check OTel logs and exporter connectivity.
 


### PR DESCRIPTION
## Details 
This pull request adds an alert that will notify devs if the exporting of logs is failing below 90% in a 1h timeframe. 
TODO: add playbook