### PR TITLE
fix(dependencies): update deps for log services using outdated linkerd chart

### DIFF
--- a/prometheus-exporters/octobus-query-exporter/Chart.lock
+++ b/prometheus-exporters/octobus-query-exporter/Chart.lock
@@ -10,6 +10,6 @@ dependencies:
   version: 0.2.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.1.3
-digest: sha256:d1b78b98d3255208278ae1a3ab8bb879064ed7c46ad514c6d707bc3f1f732a7a
-generated: "2025-06-12T03:20:13.402242751Z"
+  version: 1.1.1
+digest: sha256:bd4387895fd15f7e04228041694711d0c6f8820d6e02a7c3c3e198b1c41f71e0
+generated: "2025-09-29T16:23:19.159019+02:00"

--- a/prometheus-exporters/octobus-query-exporter/Chart.yaml
+++ b/prometheus-exporters/octobus-query-exporter/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 1.0.22
+version: 1.0.23
 name: octobus-query-exporter
 description: Elasticsearch prometheus query exporter
 maintainers:
@@ -26,4 +26,4 @@ dependencies:
 
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.1.3
+    version: 1.1.1

--- a/prometheus-exporters/opensearch-logs-query-exporter/Chart.lock
+++ b/prometheus-exporters/opensearch-logs-query-exporter/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.0.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.1.3
-digest: sha256:e7067ab42c9fb4dec0368196021ebe62a4f31cf44c48ae63fa146a35dee60e8c
-generated: "2024-08-02T18:32:08.062918+02:00"
+  version: 1.1.1
+digest: sha256:f6376e50e61fabfc05f3e838991174dc3f84e2b69316c4f9fc7e38fcaebfa2ec
+generated: "2025-09-29T16:24:07.966329+02:00"

--- a/prometheus-exporters/opensearch-logs-query-exporter/Chart.yaml
+++ b/prometheus-exporters/opensearch-logs-query-exporter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opensearch-logs-query-exporter
-version: 1.0.7
+version: 1.0.8
 description: Opensearch prometheus query exporter for Logs
 maintainers:
   - name: Olaf Heydorn
@@ -13,4 +13,4 @@ dependencies:
     version: 1.0.0
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.1.3
+    version: 1.1.1

--- a/prometheus-exporters/snmp-exporter/Chart.lock
+++ b/prometheus-exporters/snmp-exporter/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.0.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.1.3
-digest: sha256:e7067ab42c9fb4dec0368196021ebe62a4f31cf44c48ae63fa146a35dee60e8c
-generated: "2024-08-02T18:24:55.214314+02:00"
+  version: 1.1.1
+digest: sha256:f6376e50e61fabfc05f3e838991174dc3f84e2b69316c4f9fc7e38fcaebfa2ec
+generated: "2025-09-29T16:24:47.784425+02:00"

--- a/prometheus-exporters/snmp-exporter/Chart.yaml
+++ b/prometheus-exporters/snmp-exporter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: snmp-exporter
-version: 0.1.20
+version: 0.1.21
 description: Prometheus snmp-exporter
 maintainers:
   - name: Olaf Heydorn (D042653)
@@ -12,4 +12,4 @@ dependencies:
 
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.1.3
+    version: 1.1.1

--- a/system/audit-logs/Chart.lock
+++ b/system/audit-logs/Chart.lock
@@ -22,6 +22,6 @@ dependencies:
   version: 0.2.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.1.3
-digest: sha256:b94cb7078d03b69b059f00fe59e5e47ea1d83ad9021b56bc1a79058310bb0750
-generated: "2025-07-24T11:26:07.186276+02:00"
+  version: 1.1.1
+digest: sha256:fc1b979f7b933e9a34dfda36945881984a7138d7f40d91f13ab0c591c6b6551c
+generated: "2025-09-29T16:31:28.822521+02:00"

--- a/system/audit-logs/Chart.yaml
+++ b/system/audit-logs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Audit logging components
 name: audit-logs
-version: 0.3.11
+version: 0.3.12
 dependencies:
   - name: fluent-audit-container
     alias: fluent_audit_container
@@ -43,4 +43,4 @@ dependencies:
 
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.1.3
+    version: 1.1.1

--- a/system/jupyter-cron-reports/Chart.lock
+++ b/system/jupyter-cron-reports/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.2.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.1.3
-digest: sha256:715fa239379e2996a47eddbf4444f8d5303649cfd5ab4ca57e8d5c1c6f47f664
-generated: "2024-04-12T15:24:59.193592+02:00"
+  version: 1.1.1
+digest: sha256:d052490b5508ce970c96ade445c258077646820e51f3d14f9fa03c8797153e5e
+generated: "2025-09-29T16:18:52.458634+02:00"

--- a/system/jupyter-cron-reports/Chart.yaml
+++ b/system/jupyter-cron-reports/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: jupyter-cron-reports
-version: 0.0.1
+version: 0.0.2
 description: Running Jupyter Notebook on a cron schedule to generate and upload Reports to Swift.
 dependencies:
 - name: owner-info
@@ -8,4 +8,4 @@ dependencies:
   version: 0.2.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.1.3
+  version: 1.1.1

--- a/system/jupyterhub/Chart.lock
+++ b/system/jupyterhub/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 3.1.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.1.3
-digest: sha256:40db4e2055c4950ab10b9dafea41d912e61f713980ea2cf3d1261b144411f6a1
-generated: "2024-04-12T15:25:03.894134+02:00"
+  version: 1.1.1
+digest: sha256:5a21eb3e7bc5b04d89968ee10baae2803914a7df1ee0acd20dfa1dc133ff5675
+generated: "2025-09-29T16:22:00.793582+02:00"

--- a/system/jupyterhub/Chart.yaml
+++ b/system/jupyterhub/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: jupyterhub
-version: 0.0.2
+version: 0.0.3
 description: testing jupyterhub
 dependencies:
 - name: owner-info
@@ -11,4 +11,4 @@ dependencies:
   version: 3.1.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.1.3
+  version: 1.1.1

--- a/system/logs/Chart.lock
+++ b/system/logs/Chart.lock
@@ -10,6 +10,6 @@ dependencies:
   version: 1.0.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.1.3
-digest: sha256:3a4960086dcb376e7bbceee0691459423958ead5c58b45b2b29c2da68c53ddbc
-generated: "2025-09-25T15:39:50.661178+02:00"
+  version: 1.1.1
+digest: sha256:f68965f13a83bbdb5a3b053adbe75fc12705c528051f9ca5ccf395c2f8cdf0ce
+generated: "2025-09-29T16:09:55.319998+02:00"

--- a/system/logs/Chart.yaml
+++ b/system/logs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for all log shippers
 name: logs
-version: 0.0.86
+version: 0.0.87
 home: https://github.com/sapcc/helm-charts/tree/master/system/logs
 dependencies:
   - name: opentelemetry-operator
@@ -22,4 +22,4 @@ dependencies:
 
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.1.3
+    version: 1.1.1

--- a/system/opensearch-logs/Chart.lock
+++ b/system/opensearch-logs/Chart.lock
@@ -29,5 +29,5 @@ dependencies:
 - name: prober
   repository: file://vendor/prober
   version: 0.1.1
-digest: sha256:e1505b31ec295f9702a1661e9d6b22af104d8bec5bf75f1ac764b4bbc4ad22bb
-generated: "2025-09-22T12:09:13.126588+02:00"
+digest: sha256:2166da4a7e5074253a33af6e560168c37cdf5c1e6482eebd2d0bce57f025bfa9
+generated: "2025-09-29T16:43:47.017159+02:00"

--- a/system/opensearch-logs/Chart.lock
+++ b/system/opensearch-logs/Chart.lock
@@ -25,7 +25,7 @@ dependencies:
   version: 1.0.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.1.3
+  version: 1.1.1
 - name: prober
   repository: file://vendor/prober
   version: 0.1.1

--- a/system/opensearch-logs/Chart.yaml
+++ b/system/opensearch-logs/Chart.yaml
@@ -42,7 +42,7 @@ dependencies:
     condition: elasticdump.enabled
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.1.3
+    version: 1.1.1
   - name: prober
     repository: file://vendor/prober
     version: 0.1.1


### PR DESCRIPTION
### Details
switching to linkerd 1.1.1 to ensure pulling our own kubectl image (instead of bitnami)
see here: https://github.com/sapcc/helm-charts/pull/7317