### PR TITLE
[percona-cluster] make force recovery option to work for primary

### DIFF
--- a/global/percona_cluster/Chart.yaml
+++ b/global/percona_cluster/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: percona_cluster
-version: 1.2.0
+version: 1.2.1
 appVersion: 5.7.44
 description: free, fully compatible, enhanced, open source drop-in replacement for
   MySQL with Galera Replication (xtradb)

--- a/global/percona_cluster/templates/bin/_entrypoint.sh.tpl
+++ b/global/percona_cluster/templates/bin/_entrypoint.sh.tpl
@@ -7,6 +7,12 @@ fi
 
 . /startup-scripts/functions.sh
 
+if [ "$PXC_FORCE_BOOTSTRAP" = true ] ; then
+    if [[ -f /var/lib/mysql/grastate.dat ]]; then
+        sed -i 's/safe_to_bootstrap: 0/safe_to_bootstrap: 1/g' /var/lib/mysql/grastate.dat
+    fi
+fi
+
 {{- $current_region := .Values.global.db_region -}}
 {{- $cluster_ips := values .Values.service.regions }}
 
@@ -54,8 +60,6 @@ start_as_primary
 
 if [ "$PXC_FORCE_BOOTSTRAP" = true ] ; then
     echo "Cluster bootstrap forced via PXC_FORCE_BOOTSTRAP variable..."
-    sed -i 's/safe_to_bootstrap: 0/safe_to_bootstrap: 1/' /var/lib/mysql/grastate.dat
-
     start_as_primary
 fi
 


### PR DESCRIPTION
Set `safe_to_bootstrap: 1` even when cluster member is already a primary
when PXC_FORCE_BOOTSTRAP is set