### PR TITLE
content-repo: bump memory limit

### DIFF
--- a/openstack/content-repo/templates/cronjob.yaml
+++ b/openstack/content-repo/templates/cronjob.yaml
@@ -69,13 +69,13 @@ spec:
             resources:
               # observed usage in qa-de-1: CPU = 300-400m, RAM = 200-1100 MiB
               # Note that we can live with the job running throttled since it's a background job anyway.
-              # We also have seen RAM spike as high as 1600 MiB if large repo indexes need to be held in memory.
+              # We also have seen RAM spike as high 2+ GiB if large repo indexes need to be held in memory.
               limits:
                 cpu: '300m'
-                memory: '2048Mi'
+                memory: '3072Mi'
               requests:
                 cpu: '150m'
-                memory: '2048Mi'
+                memory: '3072Mi'
 ---
 {{- end }}
 {{- end }}


### PR DESCRIPTION
The rhel8 sync job is getting oomkilled, and I don't really care about investigating deeply. Those memory limits can be rather high because the jobs are only shortlived anyway and do not take space away permanently.