### PR TITLE
[hermes/maia] add more codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -76,7 +76,7 @@
 /openstack/elektra                                     @andypf @edda @ArtieReus @hgw77
 /openstack/glance                                      @fwiesel @galkindmitrii @rajivmucheli @Carthaca
 /openstack/grafanasix                                  @viennaa @richardtief @Kuckkuck @IvoGoman @timojohlo # old
-/openstack/hermes                                      @notque @Kuckkuck
+/openstack/hermes                                      @notque @Kuckkuck @notandy @viennaa @richardtief @olandr @joluc @trouaux @ibakshay @ashifnihalb @timojohlo
 /openstack/infra-seeds/kubernetes                      @BugRoger  # old
 /openstack/ironic                                      @stefanhipfel @BerndKue @fwiesel @sandzwerg
 /openstack/keppel*                                     @majewsky @SuperSandro2000 @VoigtS @wagnerd3 @Nuckal777
@@ -88,7 +88,7 @@
 /openstack/kvm-cinder-netapp-operator                  @joker-at-work @hemna @fwiesel @jagoleni @grandchild @leust @seb-kro @PaulPickhardt @CordulaGuder @Carthaca @bashar-alkhateeb @sumitarora2786 @mchristianl @fahrstuhl
 /openstack/limes*                                      @majewsky @SuperSandro2000 @VoigtS @wagnerd3 @Nuckal777
 /openstack/labels-injector                             @joker-at-work @fwiesel @grandchild @leust @seb-kro @PaulPickhardt @CordulaGuder @notandy @mchristianl
-/openstack/maia                                        @notque @richardtief @viennaa @Kuckkuck @timojohlo
+/openstack/maia                                        @notque @Kuckkuck @notandy @viennaa @richardtief @olandr @joluc @trouaux @ibakshay @ashifnihalb @timojohlo
 /openstack/manila*                                     @Carthaca @chuan137 @galkindmitrii @kpawar-sap @sumitarora2786 @crenduchinta88 @hvr999 @RockSolidScripts
 /openstack/netapp-credential-rotator                   @Carthaca @chuan137 @kpawar-sap @sumitarora2786 @crenduchinta88 @hvr999 @RockSolidScripts @Scsabiii @hemna @jagoleni
 /openstack/neutron                                     @notandy @fwiesel @sapcc/network-api-contributors


### PR DESCRIPTION
With the helm requirements change, i need many more code owners to potentially approve prs. 