### PR TITLE
[nova-hypervisor-agents] serial-console: add slash to the end

### DIFF
--- a/openstack/nova-hypervisor-agents/templates/_helpers.tpl
+++ b/openstack/nova-hypervisor-agents/templates/_helpers.tpl
@@ -23,7 +23,7 @@ server_proxyclient_address = $my_ip
 [serial_console]
 enabled = {{ $config.enabled }}
   {{- if $config.enabled }}
-base_url = https://{{include "nova_console_endpoint_host_public" .}}:{{ .Values.global.novaConsolePortPublic }}/{{ $cell_name }}/serial
+base_url = https://{{include "nova_console_endpoint_host_public" .}}:{{ .Values.global.novaConsolePortPublic }}/{{ $cell_name }}/serial/
 proxyclient_address = $my_ip
   {{- end }}
 {{- end }}


### PR DESCRIPTION
this is needed since the index.html uses relatives paths to request
dependencies, but the link (...cell1/serial?token=bla) would resolve to
`cell1/depndency.css` instead of `cell1/serial/dependency.css`, breaking
the ingress path rule.
