### PR TITLE
[nova-hypervisor-agents] Set live_migration_inbound_addr to IP

### DIFF
--- a/openstack/nova-hypervisor-agents/values.yaml
+++ b/openstack/nova-hypervisor-agents/values.yaml
@@ -83,6 +83,7 @@ defaults:
           hw_disk_discard: unmap
           images_type: raw
           hw_machine_type: q35
+          live_migration_inbound_addr: "$my_ip"
         os_vif_ovs:
           ovsdb_connection: "unix:/run/openvswitch/db.sock"
       pod:


### PR DESCRIPTION
By default, it uses the hostname, which needs DNS resolution.