### PR TITLE
[designate-nanny] relaxing helm chart dependency requirements and bump

### DIFF
--- a/openstack/designate-nanny/Chart.lock
+++ b/openstack/designate-nanny/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.4.2
+  version: 0.30.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.2.0
+  version: 1.0.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.1.3
-digest: sha256:d9ef62ed459771f5c4f47dc03af7074f90f09937f4c122a906304544d21e66de
-generated: "2024-04-12T15:59:37.65401+02:00"
+  version: 1.1.1
+digest: sha256:a1a498138ca1d7feb3aeefad8fce0576d318bc3d06c69ad8309d5967c1581198
+generated: "2025-10-06T12:04:18.801575329+02:00"

--- a/openstack/designate-nanny/Chart.yaml
+++ b/openstack/designate-nanny/Chart.yaml
@@ -4,17 +4,17 @@ name: designate-nanny
 type: application
 version: 0.1.0
 
-appVersion: "0.0.0"
+appVersion: "0.0.1"
 sources:
   - https://github.wdf.sap.corp/cc/dns-docker/tree/i583594/designate-nanny
 
 dependencies:
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.4.2
+    version: '>= 0.0.0'
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.2.0
+    version: '>= 0.0.0'
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.1.3
+    version: '>= 0.0.0'


### PR DESCRIPTION
As suggested we relax the dependency requirements to make updates easier. We also bump to the latest versions - as required for linkerd.