### PR TITLE
[percona-cluster] add custom liveness probe script

### DIFF
--- a/global/percona_cluster/Chart.yaml
+++ b/global/percona_cluster/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: percona_cluster
-version: 1.2.1
+version: 1.2.2
 appVersion: 5.7.44
 description: free, fully compatible, enhanced, open source drop-in replacement for
   MySQL with Galera Replication (xtradb)

--- a/global/percona_cluster/templates/bin/_livenessprobe.sh.tpl
+++ b/global/percona_cluster/templates/bin/_livenessprobe.sh.tpl
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+if [[ $1 == '-h' || $1 == '--help' ]]; then
+	echo "Usage: $0 <user> <pass> <log_file>"
+	exit
+fi
+
+if [ -f /tmp/recovery-case ] || [ -f '/var/lib/mysql/sleep-forever' ]; then
+	exit 0
+fi
+
+if [[ -f '/var/lib/mysql/sst_in_progress' ]] || [[ -f '/var/lib/mysql/wsrep_recovery_verbose.log' ]]; then
+	exit 0
+fi
+
+{ set +x; } 2>/dev/null
+MYSQL_USERNAME="monitor"
+MYSQL_PASSWORD="${MONITOR_PASSWORD}"
+#Timeout exists for instances where mysqld may be hung
+TIMEOUT=3
+
+MYSQL_CMDLINE="/usr/bin/timeout $TIMEOUT mysql -u ${MYSQL_USERNAME} -nNE --connect-timeout=$TIMEOUT"
+
+STATUS=$(MYSQL_PWD="${MYSQL_PASSWORD}" $MYSQL_CMDLINE --init-command="SET SESSION wsrep_sync_wait=0;" -e "SHOW GLOBAL STATUS LIKE 'wsrep_cluster_status';" | sed -n -e '3p')
+set -x
+
+if [[ -n ${STATUS} && ${STATUS} == 'Primary' ]]; then
+	exit 0
+fi
+
+exit 1

--- a/global/percona_cluster/templates/config-map_startup-scripts.yaml
+++ b/global/percona_cluster/templates/config-map_startup-scripts.yaml
@@ -10,6 +10,8 @@ metadata:
 data:
   entrypoint.sh: |
 {{ include (print .Template.BasePath "/bin/_entrypoint.sh.tpl") . | indent 4 }}
+  livenessprobe.sh: |
+{{ include (print .Template.BasePath "/bin/_livenessprobe.sh.tpl") . | indent 4 }}
   readinessprobe.sh: |
 {{ include (print .Template.BasePath "/bin/_readinessprobe.sh.tpl") . | indent 4 }}
   backup.sh: |

--- a/global/percona_cluster/templates/statefulset.yaml
+++ b/global/percona_cluster/templates/statefulset.yaml
@@ -140,12 +140,9 @@ spec:
           containerPort: 4444
         livenessProbe:
           exec:
-            command:
-              - "/bin/bash"
-              - "-c"
-              - "mysqladmin ping || test -e /var/lib/mysql/sst_in_progress"
+            command: ["/bin/bash", "/startup-scripts/livenessprobe.sh"]
           initialDelaySeconds: 600
-          timeoutSeconds: 3
+          timeoutSeconds: 5
         readinessProbe:
           exec:
             command: ["/bin/bash", "/startup-scripts/readinessprobe.sh"]


### PR DESCRIPTION
Add pxc-operator-based liveness probe script with timeout check, which uses monitor credentials and can be bypassed if needed with created `/var/lib/mysql/sleep-forever` file