### PR TITLE
chore(thanos): unify thanos settings

### DIFF
--- a/global/thanos-global/Chart.yaml
+++ b/global/thanos-global/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos-global
 description: Deploy Thanos via operator
 type: application
-version: 0.5.8
+version: 0.5.9
 dependencies:
   - name: thanos
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/global/thanos-global/values.yaml
+++ b/global/thanos-global/values.yaml
@@ -28,7 +28,6 @@ thanos:
     replicas: 8
 
     extraArgs:
-      - --query.promql-engine=thanos
       - --query.mode=distributed
 
     requestLog:

--- a/system/thanos-metal/Chart.yaml
+++ b/system/thanos-metal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos-metal-and-regional
 description: Deploy Thanos metal and regional via operator
 type: application
-version: 0.5.22
+version: 0.5.23
 dependencies:
   - name: thanos
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/system/thanos-metal/values.yaml
+++ b/system/thanos-metal/values.yaml
@@ -31,6 +31,8 @@ thanos:
 
   query:
     replicas: 5
+    extraArgs:
+      - --query.mode=distributed
 
   clusterDomain: kubernetes
 
@@ -68,7 +70,6 @@ regional_thanos:
   query:
     replicas: 5
     extraArgs:
-      - --query.promql-engine=thanos
       - --query.mode=distributed
 
   authentication:

--- a/system/thanos-scaleout/Chart.yaml
+++ b/system/thanos-scaleout/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos-scaleout
 description: Deploy Thanos via operator 
 type: application
-version: 0.6.2
+version: 0.6.3
 dependencies:
   - name: thanos
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/system/thanos-scaleout/values.yaml
+++ b/system/thanos-scaleout/values.yaml
@@ -38,6 +38,8 @@ thanos:
     replicas: 5
     requestLog:
       enabled: true
+    extraArgs:
+      - --query.mode=distributed
 
   ruler:
     enabled: true


### PR DESCRIPTION
distributed query should be turned on everywhere
turn off thanos query engine because it would only show last 6h of data