### PR TITLE
[designate][redis] Bump redis chart dependency to 2.2.18

### DIFF
--- a/openstack/designate/Chart.lock
+++ b/openstack/designate/Chart.lock
@@ -28,6 +28,6 @@ dependencies:
   version: 1.1.0
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 2.1.4
-digest: sha256:356bc8a392100af7bf361586b34c09068e6da8ae6d894dbe36c03de31de6f2b0
-generated: "2025-10-07T10:55:03.427988+02:00"
+  version: 2.2.18
+digest: sha256:3d3092d2d5c729c3bac878d0661920e9eb78f0f162229a8cdea1f45b126a150d
+generated: "2025-10-07T16:13:39.365929+03:00"

--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes to deploy Openstack Designate  (DNSaaS)
 name: designate
-version: 0.5.9
+version: 0.5.10
 appVersion: "dalmatian"
 dependencies:
   - condition: percona_cluster.enabled
@@ -41,5 +41,5 @@ dependencies:
   - name: redis
     alias: api-ratelimit-redis
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 2.1.4
+    version: 2.2.18
     condition: rate_limit.enabled


### PR DESCRIPTION
Update redis chart dependency to version 2.2.18:
* Updates valkey to 8.1.4 with CVE fixes
