### PR TITLE
[glance][redis] Bump redis chart dependency to 2.2.18

### DIFF
--- a/openstack/glance/Chart.lock
+++ b/openstack/glance/Chart.lock
@@ -16,12 +16,12 @@ dependencies:
   version: 0.29.0
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.6.2
+  version: 2.2.18
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:ab57102c9d6557ac3398baa5853685455973493bfc7adf02d5406cbd4b665070
-generated: "2025-08-25T15:41:45.774058+03:00"
+digest: sha256:7176b581556fd264cc219ac93bd14621e906b8596c9523c1c9024ff2676a3dbb
+generated: "2025-10-07T16:13:49.367277+03:00"

--- a/openstack/glance/Chart.yaml
+++ b/openstack/glance/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: dalmatian
 description: A Helm chart Openstack Glance
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Glance/OpenStack_Project_Glance_vertical.png
 name: glance
-version: 0.7.5
+version: 0.7.6
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
@@ -28,7 +28,7 @@ dependencies:
   - name: redis
     alias: sapcc_rate_limit
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 1.6.2
+    version: 2.2.18
     condition: sapcc_rate_limit.enabled
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm


### PR DESCRIPTION
Update redis chart dependency to version 2.2.18:
* Updates valkey to 8.1.4 with CVE fixes
