### PR TITLE
[manila][redis] Bump redis chart dependency to 2.2.18

### DIFF
--- a/openstack/manila/Chart.lock
+++ b/openstack/manila/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.1.1
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.27.1
+  version: 0.27.4
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.5.0
@@ -19,12 +19,12 @@ dependencies:
   version: 1.0.0
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.19.1
+  version: 0.19.2
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 2.2.15
+  version: 2.2.18
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.28.0
-digest: sha256:79c7acc3300639ea95ccae806efdbfdb70753bb03899845976e8a94a493b6ab5
-generated: "2025-08-21T14:14:27.723614+03:00"
+digest: sha256:a20e0dc32c788f1d2c8c0ec3802eb0a6a94e84e4c106f267c05831771c488316
+generated: "2025-10-07T16:14:01.206901+03:00"

--- a/openstack/manila/Chart.yaml
+++ b/openstack/manila/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 name: manila
 sources:
   - https://github.com/sapcc/manila
-version: 0.6.2
+version: 0.6.3
 dependencies:
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
@@ -41,7 +41,7 @@ dependencies:
   - name: redis
     alias: api-ratelimit-redis
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~2.2.2
+    version: ~2.2.18
     condition: api_rate_limit.enabled
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm


### PR DESCRIPTION
Update redis chart dependency to version 2.2.18:
* Updates valkey to 8.1.4 with CVE fixes
