### PR TITLE
[nova][redis] Bump redis chart dependency to 2.2.18

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -40,6 +40,6 @@ dependencies:
   version: 1.1.0
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 2.1.3
-digest: sha256:752fd1d7aa0565df314295b1f31984b948d702aa5668fa04b7134233151dc4da
-generated: "2025-08-26T13:26:44.860718+03:00"
+  version: 2.2.18
+digest: sha256:b27d124efd86a9f9b35f15f4b2efda5ad774394ab2b4379cb062b20f7f0a2d5d
+generated: "2025-10-07T16:14:25.360579+03:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 name: nova
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Nova/OpenStack_Project_Nova_mascot.png
-version: 0.6.0
+version: 0.6.1
 appVersion: "bobcat"
 dependencies:
   - name: mariadb
@@ -62,5 +62,5 @@ dependencies:
   - name: redis
     alias: api-ratelimit-redis
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 2.1.3
+    version: 2.2.18
     condition: rate_limit.enabled

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -1177,3 +1177,7 @@ rate_limit:
           limit: 100r/m
 
 manage_service_user_passwords: false
+
+api-ratelimit-redis:
+  alerts:
+    support_group: compute-storage-api


### PR DESCRIPTION
Update redis chart dependency to version 2.2.18:
* Updates valkey to 8.1.4 with CVE fixes
