### PR TITLE
[octavia][redis] Bump redis chart dependency to 2.2.19

### DIFF
--- a/openstack/octavia/Chart.lock
+++ b/openstack/octavia/Chart.lock
@@ -25,6 +25,6 @@ dependencies:
   version: 1.0.0
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 2.1.3
-digest: sha256:91b98418d953f1e8b66b1829cb8df5b8330142676aa110c07008a21312e67ff4
-generated: "2025-08-14T12:40:57.057934+03:00"
+  version: 2.2.19
+digest: sha256:730abd532efc6ba50bcfa553739c4f01fc94b9943626d34663a808a58f73209f
+generated: "2025-10-08T11:32:13.330506+03:00"

--- a/openstack/octavia/Chart.yaml
+++ b/openstack/octavia/Chart.yaml
@@ -9,7 +9,7 @@ sources:
   - https://git.openstack.org/cgit/openstack/octavia
   - https://git.openstack.org/cgit/openstack/openstack-helm
 # The versions are defined in the changelog: https://docs.openstack.org/releasenotes/octavia/yoga.html
-version: 10.1.6
+version: 10.1.7
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
@@ -42,5 +42,5 @@ dependencies:
   - name: redis
     alias: api-ratelimit-redis
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 2.1.3
+    version: 2.2.19
     condition: rate_limit.enabled


### PR DESCRIPTION
Update redis chart dependency to version 2.2.19:
* Updates valkey to 8.1.4 with CVE fixes
