### PR TITLE
Neutron bump redis for CVE (and linkerd)

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -22,7 +22,7 @@ dependencies:
   version: 1.0.0
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 2.1.7
+  version: 2.2.19
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
@@ -32,5 +32,5 @@ dependencies:
 - name: ovsdb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
-digest: sha256:2ba086d909446d32f448811ded8f6336e3cab18549154e7b927342822cd332ab
-generated: "2025-10-06T10:21:15.106155878+02:00"
+digest: sha256:869402e973bc5fa6c73dfb92c5a97cc5cad67b72a189c104e0bd1e947145ff25
+generated: "2025-10-07T17:06:40.152505424+02:00"

--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -25,12 +25,12 @@ dependencies:
   version: 2.1.7
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.0.0
+  version: 1.1.1
 - name: ovsdb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
 - name: ovsdb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
-digest: sha256:c7a8949049dea79d20aa3fe77edbd0e1236875c46ef193f8c593b9fb874f817b
-generated: "2025-08-29T15:13:49.900035912+02:00"
+digest: sha256:2ba086d909446d32f448811ded8f6336e3cab18549154e7b927342822cd332ab
+generated: "2025-10-06T10:21:15.106155878+02:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -37,7 +37,7 @@ dependencies:
     condition: rate_limit.enabled
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 1.0.0
+    version: 1.1.1
   - name: ovsdb
     alias: ovsdb-sb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for Openstack Neutron
 name: neutron
-version: 0.3.3
+version: 0.3.4
 appVersion: "caracal"
 dependencies:
   - condition: mariadb.enabled
@@ -33,7 +33,7 @@ dependencies:
   - name: redis
     alias: api-ratelimit-redis
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 2.1.7
+    version: 2.2.19
     condition: rate_limit.enabled
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm


### PR DESCRIPTION
Bump redis for CVE-2025-49844. I also had a noop-linkerd-chart lying around and included that in an extra commit.
Superseeds #9847 which uses 2.2.18 (thanks though for directly creating a PR @s10 ).