### PR TITLE
[owner-label-injector] lower `timeoutSeconds` to 2sec

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -286,6 +286,7 @@
 /system/ntp-timeserver                                 @dhoeller  # old
 /system/opensearch-hermes                              @Kuckkuck @notque @timojohlo @joluc @olandr
 /system/opensearch-logs                                @Kuckkuck @timojohlo @notque @joluc @olandr
+/system/owner-label-injector                           @IvoGoman @uwe-mayer @abhijith-darshan @onuryilmaz
 /system/plutono                                        @viennaa @richardtief @Kuckkuck @IvoGoman @timojohlo @ibakshay @trouaux @ashifnihalb
 /system/perses                                         @richardtief @viennaa @trouaux @ibakshay @ashifnihalb
 /system/priority-class                                 @galkindmitrii  # old

--- a/system/owner-label-injector/Chart.yaml
+++ b/system/owner-label-injector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: owner-label-injector
 description: A Helm chart for Kubernetes
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "1.1.0"
 dependencies:
   - name: linkerd-support

--- a/system/owner-label-injector/templates/mutatingwebhookconfiguration.yaml
+++ b/system/owner-label-injector/templates/mutatingwebhookconfiguration.yaml
@@ -47,4 +47,5 @@ webhooks:
     resources:
     - '*'
   sideEffects: NoneOnDryRun
-
+  # We try to reduce API request latency
+  timeoutSeconds: 2


### PR DESCRIPTION
We faced issues on 1.32->1.33 upgrade and this is one of attempts to reduce api request latency on initial apiserver startup