### PR TITLE
[neutron-hypervisor-agents] Drop dumb-init thanks to subreaper in con…

### DIFF
--- a/openstack/neutron-hypervisor-agents/templates/daemonset-ovn-controller.yaml
+++ b/openstack/neutron-hypervisor-agents/templates/daemonset-ovn-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - name: init-ovsdb-server
           image: {{ .Values.global.registry | required ".Values.global.registry is missing" }}/cobaltcore-dev/openstack-ovn-controller:{{ .Values.imageVersionOVN | default "latest" }}
           imagePullPolicy: IfNotPresent
-          command: ["dumb-init", "/bin/bash", "-c", "/usr/local/bin/container-scripts/init.sh"]
+          command: ["/bin/bash", "-c", "/usr/local/bin/container-scripts/init.sh"]
           env:
             - name: HOSTNAME
               valueFrom:


### PR DESCRIPTION
…tainerd

Since begining of 2017, the kernel offers an option for a subreaper (torvalds/linux@c6c70f4), and a little bit later (containerd/containerd@df4898) made use of it, rendering dumb-init superfluous.

Time to drop it.