### PR TITLE
[neutron] Drop dumb-init thanks to subreaper in containerd

### DIFF
--- a/openstack/neutron/templates/bin/_neutron-server-start.tpl
+++ b/openstack/neutron/templates/bin/_neutron-server-start.tpl
@@ -1,4 +1,4 @@
-#!/var/lib/openstack/bin/dumb-init bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/openstack/neutron/templates/daemonset-metadata-agent.yaml
+++ b/openstack/neutron/templates/daemonset-metadata-agent.yaml
@@ -42,7 +42,7 @@ spec:
         - name: neutron-metadata-agent
           image: {{.Values.global.registry}}/loci-neutron:{{$.Values.imageVersionNetworkAgentMetadata | default $.Values.imageVersionNetworkAgent | default $.Values.imageVersion | required "Please set neutron.imageVersionNetworkAgentMetadata or similar"}}
           imagePullPolicy: IfNotPresent
-          command: ["dumb-init", "bash", "-c", "echo -e \"[DEFAULT]\\nhost = $NODE_NAME\\n\" > /run/hostname.conf && exec neutron-metadata-agent --config-file /etc/neutron/neutron.conf --config-dir /etc/neutron/secrets/ --config-file /etc/neutron/metadata-agent.ini --config-file /run/hostname.conf"]
+          command: ["bash", "-c", "echo -e \"[DEFAULT]\\nhost = $NODE_NAME\\n\" > /run/hostname.conf && exec neutron-metadata-agent --config-file /etc/neutron/neutron.conf --config-dir /etc/neutron/secrets/ --config-file /etc/neutron/metadata-agent.ini --config-file /run/hostname.conf"]
           env:
             {{- include "utils.sentry_config" . | nindent 12 }}
             - name: DEBUG_CONTAINER

--- a/openstack/neutron/templates/deployment-rpc-server.yaml
+++ b/openstack/neutron/templates/deployment-rpc-server.yaml
@@ -59,7 +59,7 @@ spec:
         - name: neutron-rpc-server
           image: {{.Values.global.registry}}/loci-neutron:{{.Values.imageVersionServerRPC | default .Values.imageVersionServer | default .Values.imageVersion | required "Please set neutron.imageVersion or similar"}}
           imagePullPolicy: IfNotPresent
-          command: ['dumb-init', 'kubernetes-entrypoint']
+          command: ['kubernetes-entrypoint']
           env:
             - name: COMMAND
               value: "neutron-rpc-server --config-file /etc/neutron/neutron.conf --config-dir /etc/neutron/neutron.conf.d --config-dir /etc/neutron/secrets --config-file /etc/neutron/plugins/ml2/ml2-conf.ini --config-file /etc/neutron/plugins/ml2/ml2-conf-manila.ini --config-file /etc/neutron/plugins/ml2/ml2-conf-arista.ini --config-file /etc/neutron/plugins/ml2/ml2-conf-asr1k.ini {{- if .Values.bgp_vpn.enabled }} --config-file /etc/neutron/networking-bgpvpn.conf{{- end }}{{- if .Values.interconnection.enabled }} --config-file /etc/neutron/networking-interconnection.conf{{- end }}{{- if .Values.fwaas.enabled }} --config-file /etc/neutron/neutron-fwaas.ini{{- end }}{{- if .Values.cc_fabric.enabled }} --config-file /etc/neutron/plugins/ml2/ml2_conf_cc-fabric.ini {{- end }}"

--- a/openstack/neutron/templates/deployment-server.yaml
+++ b/openstack/neutron/templates/deployment-server.yaml
@@ -84,7 +84,7 @@ spec:
             initialDelaySeconds: 15
             timeoutSeconds: 5
 {{- end }}
-          command: ['dumb-init', 'kubernetes-entrypoint']
+          command: ['kubernetes-entrypoint']
           env:
             - name: COMMAND
 {{- if .Values.api.uwsgi }}

--- a/openstack/neutron/templates/statefulset-network-agent-apod.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent-apod.yaml
@@ -90,7 +90,7 @@ spec:
         - name: neutron-dhcp-agent
           image: {{$.Values.global.registry}}/loci-neutron:{{$.Values.imageVersionNetworkAgentDHCP | default $.Values.imageVersionNetworkAgent | default $.Values.imageVersion | required "Please set neutron.imageVersionNetworkAgentDHCP or similar"}}
           imagePullPolicy: IfNotPresent
-          command: ["dumb-init", "neutron-dhcp-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-dir", "/etc/neutron/secrets", "--config-file", "/etc/neutron/dhcp-agent.ini", "--config-file", "/etc/neutron/linux-bridge.ini", "--config-file", "/etc/neutron/az-{{ $az }}.conf"]
+          command: ["neutron-dhcp-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-dir", "/etc/neutron/secrets", "--config-file", "/etc/neutron/dhcp-agent.ini", "--config-file", "/etc/neutron/linux-bridge.ini", "--config-file", "/etc/neutron/az-{{ $az }}.conf"]
           env:
             {{- include "utils.sentry_config" $ | nindent 12 }}
             - name: DEBUG_CONTAINER
@@ -130,7 +130,7 @@ spec:
         - name: neutron-linuxbridge-agent
           image: {{$.Values.global.registry}}/loci-neutron:{{$.Values.imageVersionNetworkAgentLinuxBridge | default $.Values.imageVersionNetworkAgent | default $.Values.imageVersion | required "Please set neutron.imageVersionNetworkAgentLinuxBridge or similar"}}
           imagePullPolicy: IfNotPresent
-          command: ["dumb-init", "neutron-linuxbridge-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-dir", "/etc/neutron/secrets", "--config-file", "/etc/neutron/plugins/ml2/ml2_conf.ini", "--config-file", "/etc/neutron/linux-bridge.ini", "--config-file", "/etc/neutron/apod-{{ $apod }}.conf"]
+          command: ["neutron-linuxbridge-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-dir", "/etc/neutron/secrets", "--config-file", "/etc/neutron/plugins/ml2/ml2_conf.ini", "--config-file", "/etc/neutron/linux-bridge.ini", "--config-file", "/etc/neutron/apod-{{ $apod }}.conf"]
           env:
             {{- include "utils.sentry_config" $ | nindent 12 }}
             - name: DEBUG_CONTAINER
@@ -169,7 +169,7 @@ spec:
         - name: neutron-metadata-agent
           image: {{$.Values.global.registry}}/loci-neutron:{{$.Values.imageVersionNetworkAgentMetadata | default $.Values.imageVersionNetworkAgent | default $.Values.imageVersion | required "Please set neutron.imageVersionNetworkAgentMetadata or similar"}}
           imagePullPolicy: IfNotPresent
-          command: ["dumb-init", "neutron-metadata-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-dir", "/etc/neutron/secrets","--config-file", "/etc/neutron/metadata-agent.ini"]
+          command: ["neutron-metadata-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-dir", "/etc/neutron/secrets","--config-file", "/etc/neutron/metadata-agent.ini"]
           env:
             {{- include "utils.sentry_config" $ | nindent 12 }}
             - name: PYTHONWARNINGS

--- a/openstack/neutron/templates/statefulset-network-agent.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent.yaml
@@ -78,7 +78,7 @@ spec:
         - name: neutron-dhcp-agent
           image: {{$.Values.global.registry}}/loci-neutron:{{$.Values.imageVersionNetworkAgentDHCP | default $.Values.imageVersionNetworkAgent | default $.Values.imageVersion | required "Please set neutron.imageVersionNetworkAgentDHCP or similar"}}
           imagePullPolicy: IfNotPresent
-          command: ["dumb-init", "neutron-dhcp-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-dir", "/etc/neutron/secrets", "--config-file", "/etc/neutron/dhcp-agent.ini", "--config-file", "/etc/neutron/linux-bridge.ini", "--config-file", "/etc/neutron/az-{{ $az }}.conf"]
+          command: ["neutron-dhcp-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-dir", "/etc/neutron/secrets", "--config-file", "/etc/neutron/dhcp-agent.ini", "--config-file", "/etc/neutron/linux-bridge.ini", "--config-file", "/etc/neutron/az-{{ $az }}.conf"]
           env:
             {{- include "utils.sentry_config" $ | nindent 12 }}
             - name: DEBUG_CONTAINER
@@ -151,7 +151,7 @@ spec:
         - name: neutron-l3-agent
           image: {{$.Values.global.registry}}/loci-neutron:{{$.Values.imageVersionNetworkAgentL3 | default $.Values.imageVersionNetworkAgent | default $.Values.imageVersion | required "Please set neutron.imageVersionNetworkAgentL3 or similar"}}
           imagePullPolicy: IfNotPresent
-          command: ["dumb-init", "neutron-l3-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-dir", "/etc/neutron/secrets", "--config-file", "/etc/neutron/l3-agent.ini", "--config-file", "/etc/neutron/plugins/ml2/ml2-conf.ini", "--config-file", "/etc/neutron/linux-bridge.ini", "--config-file", "/etc/neutron/az-{{ $az }}.conf"]
+          command: ["neutron-l3-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-dir", "/etc/neutron/secrets", "--config-file", "/etc/neutron/l3-agent.ini", "--config-file", "/etc/neutron/plugins/ml2/ml2-conf.ini", "--config-file", "/etc/neutron/linux-bridge.ini", "--config-file", "/etc/neutron/az-{{ $az }}.conf"]
           env:
             {{- include "utils.sentry_config" $ | nindent 12 }}
             - name: DEBUG_CONTAINER
@@ -204,7 +204,7 @@ spec:
         - name: neutron-linuxbridge-agent
           image: {{$.Values.global.registry}}/loci-neutron:{{$.Values.imageVersionNetworkAgentLinuxBridge | default $.Values.imageVersionNetworkAgent | default $.Values.imageVersion | required "Please set neutron.imageVersionNetworkAgentLinuxBridge or similar"}}
           imagePullPolicy: IfNotPresent
-          command: ["dumb-init", "neutron-linuxbridge-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-dir", "/etc/neutron/secrets", "--config-file", "/etc/neutron/plugins/ml2/ml2_conf.ini", "--config-file", "/etc/neutron/linux-bridge.ini"]
+          command: ["neutron-linuxbridge-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-dir", "/etc/neutron/secrets", "--config-file", "/etc/neutron/plugins/ml2/ml2_conf.ini", "--config-file", "/etc/neutron/linux-bridge.ini"]
           env:
             {{- include "utils.sentry_config" $ | nindent 12 }}
             - name: DEBUG_CONTAINER

--- a/openstack/neutron/templates/statefulset-swift-injector.yaml
+++ b/openstack/neutron/templates/statefulset-swift-injector.yaml
@@ -63,7 +63,6 @@ spec:
           image: {{ $.Values.global.registry }}/network-injector:{{ $.Values.imageVersionNetworkInjector | default "latest" }}
           imagePullPolicy: IfNotPresent
           command:
-            - "dumb-init"
             - "/manager"
             - "-upstream-host"
             - {{ include "swift_endpoint_host" $ | quote }}
@@ -111,7 +110,7 @@ spec:
         - name: neutron-linuxbridge-agent
           image: {{$.Values.global.registry}}/loci-neutron:{{$.Values.imageVersionNetworkAgentLinuxBridge | default $.Values.imageVersionNetworkAgent | default $.Values.imageVersion | required "Please set neutron.imageVersionNetworkAgentLinuxBridge or similar"}}
           imagePullPolicy: IfNotPresent
-          command: ["dumb-init", "neutron-linuxbridge-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-dir", "/etc/neutron/secrets", "--config-file", "/etc/neutron/plugins/ml2/ml2_conf.ini", "--config-file", "/etc/neutron/linux-bridge.ini", "--config-file", "/etc/neutron/apod-{{ $apod }}.conf"]
+          command: ["neutron-linuxbridge-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-dir", "/etc/neutron/secrets", "--config-file", "/etc/neutron/plugins/ml2/ml2_conf.ini", "--config-file", "/etc/neutron/linux-bridge.ini", "--config-file", "/etc/neutron/apod-{{ $apod }}.conf"]
           env:
             {{- include "utils.sentry_config" $ | nindent 12 }}
             - name: DEBUG_CONTAINER
@@ -153,7 +152,6 @@ spec:
           image: {{ $.Values.global.registry }}/network-injector:{{ $.Values.imageVersionNetworkInjector | default "latest" }}
           imagePullPolicy: IfNotPresent
           command:
-            - "dumb-init"
             - "socat"
             - "UNIX-LISTEN:/var/run/socat-proxy/proxy.sock,fork,reuseaddr,unlink-early,user=nobody,group=nobody,mode=777"
             - "TCP:swift-proxy-internal-cluster-3.swift.svc.kubernetes.{{ include "host_fqdn" $ }}:8080"

--- a/openstack/neutron/templates/vct-nsxv3-agent-deployment.yaml
+++ b/openstack/neutron/templates/vct-nsxv3-agent-deployment.yaml
@@ -62,8 +62,8 @@ template: |
         - name: neutron-nsxv3-agent
           image: {{.Values.global.registry}}/loci-neutron:{{.Values.imageVersionNSXv3 | default .Values.imageVersion | required "Please set neutron.imageVersion or similar"}}
           imagePullPolicy: IfNotPresent
-          command: ["dumb-init"]
-          args: ["neutron-nsxv3-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-dir", "/etc/neutron/secrets", "--config-file", "/etc/neutron/plugins/ml2/ml2-conf.ini", "--config-file", "/etc/neutron/plugins/ml2/ml2-nsxv3.ini"]
+          command: ["neutron-nsxv3-agent"]
+          args: ["--config-file", "/etc/neutron/neutron.conf", "--config-dir", "/etc/neutron/secrets", "--config-file", "/etc/neutron/plugins/ml2/ml2-conf.ini", "--config-file", "/etc/neutron/plugins/ml2/ml2-nsxv3.ini"]
           env:
           {{- include "utils.sentry_config" . | nindent 10 }}
           - name: PYTHONWARNINGS


### PR DESCRIPTION
Since begining of 2017, the kernel offers an option for a subreaper (torvalds/linux@c6c70f4), and a little bit later (containerd/containerd@df4898) made use of it, rendering dumb-init superfluous.

Time to drop it.