### PR TITLE
[ironic] Drop dumb-init thanks to subreaper in containerd

### DIFF
--- a/openstack/ironic/templates/_conductor-deployment.yaml.tpl
+++ b/openstack/ironic/templates/_conductor-deployment.yaml.tpl
@@ -69,7 +69,6 @@ spec:
         {{- end }}
         command:
         {{- if not $conductor.debug }}
-        - dumb-init
         - ironic-conductor
         {{- else }}
         - sleep

--- a/openstack/ironic/templates/api-deployment.yaml
+++ b/openstack/ironic/templates/api-deployment.yaml
@@ -55,7 +55,6 @@ spec:
         resources:
 {{ toYaml .Values.pod.resources.api | indent 10 }}
         command:
-        - dumb-init
         - ironic-api
         env:
         - name: PYTHONWARNINGS

--- a/openstack/ironic/templates/db-migration-job.yaml
+++ b/openstack/ironic/templates/db-migration-job.yaml
@@ -25,7 +25,6 @@ spec:
         image: {{ .Values.global.registry }}/loci-ironic:{{ .Values.imageVersion }}
         imagePullPolicy: IfNotPresent
         command:
-        - dumb-init
         - bash
         args:
         - -c

--- a/openstack/ironic/templates/inspector-conductor-deployment.yaml
+++ b/openstack/ironic/templates/inspector-conductor-deployment.yaml
@@ -51,7 +51,6 @@ spec:
         image: {{ .Values.global.registry }}/loci-ironic:{{ .Values.imageVersion }}
         imagePullPolicy: IfNotPresent
         command:
-        - dumb-init
         - ironic-inspector-conductor
         env:
           {{- include "utils.sentry_config" . | indent 10 }}

--- a/openstack/ironic/templates/inspector-db-migration-job.yaml
+++ b/openstack/ironic/templates/inspector-db-migration-job.yaml
@@ -25,8 +25,8 @@ spec:
         image: {{ .Values.global.registry }}/loci-ironic:{{ .Values.imageVersion }}
         imagePullPolicy: IfNotPresent
         command:
-        - dumb-init
-        - bash
+        - ironic-inspector-dbsync
+        - upgrade
         args:
         - -c
         - |

--- a/openstack/ironic/templates/inspector-deployment.yaml
+++ b/openstack/ironic/templates/inspector-deployment.yaml
@@ -58,7 +58,6 @@ spec:
         {{- end }}
         imagePullPolicy: IfNotPresent
         command:
-        - dumb-init
         - ironic-inspector
         securityContext:
           capabilities:
@@ -112,7 +111,6 @@ spec:
         resources:
 {{ toYaml .Values.pod.resources.dhcp | indent 10 }}
         command:
-        - dumb-init
         - staticDHCPd
         env:
         - name: POD_IP


### PR DESCRIPTION
Since begining of 2017, the kernel offers an option for a subreaper (torvalds/linux@c6c70f4455d1eda91065e93cc4f7eddf4499b105), and a little bit later (containerd/containerd@df4898) made use of it, rendering dumb-init superfluous.

Time to drop it.