### PR TITLE
[barbican] Drop dumb-init thanks to subreaper in containerd

### DIFF
--- a/openstack/barbican/templates/api-deployment.yaml
+++ b/openstack/barbican/templates/api-deployment.yaml
@@ -60,7 +60,6 @@ spec:
           image: {{required ".Values.global.registry is missing" .Values.global.registry }}/loci-barbican:{{required "Values.imageVersionBarbicanApi is missing" .Values.imageVersionBarbicanApi}}
           imagePullPolicy: IfNotPresent
           command:
-          - dumb-init
           - barbican-api
           env:
           {{- if .Values.sentry.enabled }}

--- a/openstack/barbican/templates/barbican-nanny-deployment.yaml
+++ b/openstack/barbican/templates/barbican-nanny-deployment.yaml
@@ -57,7 +57,6 @@ spec:
         image: {{required ".Values.global.registry is missing" .Values.global.registry }}/loci-barbican:{{required "Values.imageVersionBarbicanApi is missing" .Values.imageVersionBarbicanApi}}
         imagePullPolicy: IfNotPresent
         command:
-        - dumb-init
 {{- if not .Values.barbican_nanny.debug }}
         - /bin/bash
         - /scripts/move-secrets.sh


### PR DESCRIPTION
Since begining of 2017, the kernel offers an option for a subreaper (torvalds/linux@c6c70f4455d1eda91065e93cc4f7eddf4499b105), and a little bit later (containerd/containerd@df4898) made use of it, rendering dumb-init superfluous.

Time to drop it.