### PR TITLE
[manila] Drop dumb-init thanks to subreaper in containerd

### DIFF
--- a/openstack/manila/templates/api-deployment.yaml
+++ b/openstack/manila/templates/api-deployment.yaml
@@ -85,7 +85,6 @@ spec:
           imagePullPolicy: IfNotPresent
           command:
           {{- if .Values.api_backdoor }}
-            - dumb-init
             - kubernetes-entrypoint
           {{- else }}
             - /scripts/manila-api.sh

--- a/openstack/manila/templates/scheduler-deployment.yaml
+++ b/openstack/manila/templates/scheduler-deployment.yaml
@@ -79,7 +79,6 @@ spec:
           image: {{.Values.global.registry}}/loci-manila:{{.Values.loci.imageVersion}}
           imagePullPolicy: IfNotPresent
           command:
-            - dumb-init
             - manila-scheduler
             - --config-file
             - /etc/manila/manila.conf

--- a/openstack/manila/templates/shares/_netapp-deployment.yaml.tpl
+++ b/openstack/manila/templates/shares/_netapp-deployment.yaml.tpl
@@ -86,7 +86,6 @@ spec:
           image: {{.Values.global.registry}}/loci-manila:{{.Values.loci.imageVersion}}
           imagePullPolicy: IfNotPresent
           command:
-            - dumb-init
             {{- if .Values.pyreloader_enabled }}
             - pyreloader
             {{- end }}

--- a/openstack/manila/templates/shares/_netapp-ensure-deployment.yaml.tpl
+++ b/openstack/manila/templates/shares/_netapp-ensure-deployment.yaml.tpl
@@ -83,7 +83,6 @@ spec:
           image: "{{.Values.global.registry}}/loci-manila:{{.Values.loci.imageVersion}}"
           imagePullPolicy: IfNotPresent
           command:
-            - dumb-init
             {{- if .Values.pyreloader_enabled }}
             - pyreloader
             {{- end }}


### PR DESCRIPTION
Since begining of 2017, the kernel offers an option for a subreaper (torvalds/linux@c6c70f4455d1eda91065e93cc4f7eddf4499b105), and a little bit later (containerd/containerd@df4898) made use of it, rendering dumb-init superfluous.

Time to drop it.