### PR TITLE
[octavia] Drop dumb-init thanks to subreaper in containerd

### DIFF
--- a/openstack/octavia/templates/octavia-api-deployment.yaml
+++ b/openstack/octavia/templates/octavia-api-deployment.yaml
@@ -10,7 +10,9 @@ metadata:
   annotations:
     secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets"
     deployment.reloader.stakater.com/pause-period: "60s"
+  {{- if .Values.vpa.set_main_container }}
     vpa-butler.cloud.sap/main-container: {{ .Chart.Name }}-api
+  {{- end }}
 spec:
   replicas: {{ .Values.pod.replicas.api }}
   revisionHistoryLimit: {{ .Values.pod.lifecycle.upgrades.deployments.revision_history }}
@@ -42,14 +44,10 @@ spec:
         {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
 
     spec:
-      {{- if .Values.rbac.enabled }}
-      serviceAccountName: {{ .Release.Name }}
-      {{- end }}
       priorityClassName: critical-payload
       {{- include "utils.proxysql.pod_settings" . | nindent 6 }}
       {{- tuple . (dict "app.kubernetes.io/name" "octavia-api") | include "utils.topology.constraints" | indent 6 }}
       initContainers:
-      {{- include "utils.snippets.kubernetes_entrypoint_init_container" (list . (dict "jobs" "octavia-migration")) | indent 6 }}
       {{- if .Values.proxysql.native_sidecar }}
       {{- include "utils.proxysql.container" . | indent 6 }}
       {{- end }}
@@ -60,13 +58,15 @@ spec:
           {{- if .Values.api_backdoor }}
           command: ["/var/lib/openstack/bin/octavia-api"]
           {{- else }}
-          command:
-            - dumb-init
-            - /usr/sbin/apachectl
-            - -D
-            - FOREGROUND
+          command: ['kubernetes-entrypoint']
           {{- end }}
           env:
+            - name: COMMAND
+              value: "/usr/sbin/apachectl -D FOREGROUND"
+            - name: DEPENDENCY_JOBS
+              value: octavia-migration
+            - name: NAMESPACE
+              value: {{ .Release.Namespace }}
             - name: PYTHONWARNINGS
               value: "ignore:Unverified HTTPS request"
             - name: REQUESTS_CA_BUNDLE

--- a/openstack/octavia/templates/octavia-housekeeping.yaml
+++ b/openstack/octavia/templates/octavia-housekeeping.yaml
@@ -10,7 +10,9 @@ metadata:
   annotations:
     secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets"
     deployment.reloader.stakater.com/pause-period: "60s"
+  {{- if .Values.vpa.set_main_container }}
     vpa-butler.cloud.sap/main-container: octavia-f5-housekeeping
+  {{- end }}
 spec:
   replicas: 1
   selector:
@@ -31,12 +33,8 @@ spec:
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
         {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
-      {{- if .Values.rbac.enabled }}
-      serviceAccountName: {{ .Release.Name }}
-      {{- end }}
 {{ include "utils.proxysql.pod_settings" . | indent 6 }}
       initContainers:
-      {{- include "utils.snippets.kubernetes_entrypoint_init_container" (list . (dict "jobs" "octavia-migration")) | indent 6 }}
       {{- if .Values.proxysql.native_sidecar }}
       {{- include "utils.proxysql.container" . | indent 6 }}
       {{- end }}
@@ -44,11 +42,7 @@ spec:
         - name: octavia-f5-housekeeping
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-octavia:{{required "Values.imageVersion is missing" .Values.imageVersion}}
           imagePullPolicy: IfNotPresent
-          command:
-            - dumb-init
-            - octavia-f5-housekeeping
-            - --config-file
-            - /etc/octavia/octavia.conf
+          command: ['kubernetes-entrypoint']
           ports:
             - name: metrics
               containerPort: 8000
@@ -69,6 +63,12 @@ spec:
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
             {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
           env:
+            - name: COMMAND
+              value: "octavia-f5-housekeeping --config-file /etc/octavia/octavia.conf"
+            - name: DEPENDENCY_JOBS
+              value: octavia-migration
+            - name: NAMESPACE
+              value: {{ .Release.Namespace }}
             - name: PYTHONWARNINGS
               value: "ignore:Unverified HTTPS request"
             - name: REQUESTS_CA_BUNDLE

--- a/openstack/octavia/templates/octavia-migration-job.yaml
+++ b/openstack/octavia/templates/octavia-migration-job.yaml
@@ -1,5 +1,4 @@
 {{- $proxysql := lookup "v1" "Secret" .Release.Namespace (print .Release.Name "-proxysql-etc") -}}
-{{- $serviceaccount := lookup "v1" "ServiceAccount" .Release.Namespace .Release.Name -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -22,18 +21,24 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: octavia-migration
-        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
-      {{- if $serviceaccount }}
-      serviceAccountName: {{ .Release.Name }}
-      {{- end }}
       restartPolicy: OnFailure
     {{- if $proxysql }}
       {{- include "utils.proxysql.job_pod_settings" . | nindent 6 }}
     {{- end }}
       initContainers:
-        {{- include "utils.snippets.kubernetes_entrypoint_init_container" (list . (dict "service" (include "octavia.db_service" .))) | indent 8 }}
-        {{- if and $proxysql .Values.proxysql.native_sidecar }}
+        - name: wait-for-dependencies
+          image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-octavia:{{required "Values.imageVersion is missing" .Values.imageVersion}}
+          imagePullPolicy: IfNotPresent
+          command: ['kubernetes-entrypoint']
+          env:
+            - name: COMMAND
+              value: "true"
+            - name: DEPENDENCY_SERVICE
+              value: {{ include "octavia.db_service" . }}
+            - name: NAMESPACE
+              value: {{ .Release.Namespace }}
+        {{- if .Values.proxysql.native_sidecar }}
         {{- include "utils.proxysql.container" . | indent 8 }}
         {{- end }}
       containers:
@@ -41,13 +46,12 @@ spec:
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-octavia:{{required "Values.imageVersion is missing" .Values.imageVersion}}
           imagePullPolicy: IfNotPresent
           command:
-            - dumb-init
             - bash
             - -c
             - |
               set -euo pipefail
               octavia-db-manage upgrade head
-              {{- include "utils.script.job_finished_hook" . | nindent 14 }}
+              {{ include "utils.proxysql.proxysql_signal_stop_script" . | trim }}
           env:
             {{- if .Values.sentry.enabled }}
             - name: SENTRY_DSN

--- a/openstack/octavia/templates/octavia-worker-deployment.yaml
+++ b/openstack/octavia/templates/octavia-worker-deployment.yaml
@@ -13,7 +13,9 @@ metadata:
   annotations:
     secret.reloader.stakater.com/reload: "{{ .Release.Name }}-secrets,{{ .Release.Name }}-secrets-{{ $name }}"
     deployment.reloader.stakater.com/pause-period: "60s"
+  {{- if .Values.vpa.set_main_container }}
     vpa-butler.cloud.sap/main-container: octavia-worker
+  {{- end }}
 spec:
   replicas: 1
   selector:
@@ -39,13 +41,9 @@ spec:
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
         {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
-      {{- if $.Values.rbac.enabled }}
-      serviceAccountName: {{ $.Release.Name }}
-      {{- end }}
       priorityClassName: critical-payload
 {{ include "utils.proxysql.pod_settings" . | indent 6 }}
       initContainers:
-      {{- include "utils.snippets.kubernetes_entrypoint_init_container" (list . (dict "jobs" "octavia-migration")) | indent 6 }}
       {{- if .Values.proxysql.native_sidecar }}
       {{- include "utils.proxysql.container" . | indent 6 }}
       {{- end }}
@@ -53,17 +51,7 @@ spec:
         - name: octavia-worker
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-octavia:{{required "Values.imageVersion is missing" .Values.imageVersion}}
           imagePullPolicy: IfNotPresent
-          command:
-            - dumb-init
-            - octavia-worker
-            - --config-file
-            - /etc/octavia/octavia.conf
-            - --config-file
-            - /etc/octavia/octavia.conf.d/secrets.conf
-            - --config-file
-            - /etc/octavia/octavia-worker.conf
-            - --config-file
-            - /etc/octavia/octavia-worker-secret.conf
+          command: ['kubernetes-entrypoint']
           ports:
             - name: metrics-worker
               containerPort: 8000
@@ -98,6 +86,12 @@ spec:
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
             {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
           env:
+            - name: COMMAND
+              value: "octavia-worker --config-file /etc/octavia/octavia.conf --config-file /etc/octavia/octavia.conf.d/secrets.conf --config-file /etc/octavia/octavia-worker.conf --config-file /etc/octavia/octavia-worker-secret.conf"
+            - name: DEPENDENCY_JOBS
+              value: octavia-migration
+            - name: NAMESPACE
+              value: {{ .Release.Namespace }}
             - name: PYTHONWARNINGS
               value: "ignore:Unverified HTTPS request"
             - name: REQUESTS_CA_BUNDLE
@@ -112,17 +106,7 @@ spec:
         - name: octavia-f5-status-manager
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-octavia:{{required "Values.imageVersion is missing" .Values.imageVersion}}
           imagePullPolicy: IfNotPresent
-          command:
-            - dumb-init
-            - octavia-f5-status-manager
-            - --config-file
-            - /etc/octavia/octavia.conf
-            - --config-file
-            - /etc/octavia/octavia.conf.d/secrets.conf
-            - --config-file
-            - /etc/octavia/octavia-worker.conf
-            - --config-file
-            - /etc/octavia/octavia-worker-secret.conf
+          command: ['dumb-init', 'kubernetes-entrypoint']
           ports:
             - name: metrics-status
               containerPort: 8001
@@ -151,6 +135,12 @@ spec:
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
             {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
           env:
+            - name: COMMAND
+              value: "octavia-f5-status-manager --config-file /etc/octavia/octavia.conf --config-file /etc/octavia/octavia.conf.d/secrets.conf --config-file /etc/octavia/octavia-worker.conf --config-file /etc/octavia/octavia-worker-secret.conf"
+            - name: DEPENDENCY_JOBS
+              value: octavia-migration
+            - name: NAMESPACE
+              value: {{ .Release.Namespace }}
             - name: PYTHONWARNINGS
               value: "ignore:Unverified HTTPS request"
             - name: REQUESTS_CA_BUNDLE


### PR DESCRIPTION
Since begining of 2017, the kernel offers an option for a subreaper (torvalds/linux@c6c70f4455d1eda91065e93cc4f7eddf4499b105), and a little bit later (containerd/containerd@df4898) made use of it, rendering dumb-init superfluous.

Time to drop it.