### PR TITLE
[ovsdb] Drop dumb-init thanks to subreaper in containerd

### DIFF
--- a/common/ovsdb/templates/statefulset.yaml
+++ b/common/ovsdb/templates/statefulset.yaml
@@ -44,8 +44,8 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          command: ["dumb-init"]
-          args: ["/bin/bash", "/container-scripts/setup.sh"]
+          command: ["/bin/bash"]
+          args: ["/container-scripts/setup.sh"]
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: OVN_RUNDIR


### PR DESCRIPTION
Since begining of 2017, the kernel offers an option for a subreaper (torvalds/linux@c6c70f4455d1eda91065e93cc4f7eddf4499b105), and a little bit later (containerd/containerd@df4898) made use of it, rendering dumb-init superfluous.

Time to drop it.