### PR TITLE
fix: VcenterLowNumberOfPlaceableVms to only fire for large enough vCenters

### DIFF
--- a/openstack/nova/alerts/openstack/vmware-rebalancer.alerts
+++ b/openstack/nova/alerts/openstack/vmware-rebalancer.alerts
@@ -2,7 +2,7 @@ groups:
   - name: vmware-rebalancer.alerts
     rules:
       - alert: VcenterLowNumberOfPlaceableVms
-        expr: sum(wm_vmware_rebalancer_placeable_vms_per_vcenter{flavor="g_c128_m512",has_bbs_without_custom_hana_exclusive_host="True"}) by (flavor, vcenter, az) < 3
+        expr: sum(wm_vmware_rebalancer_placeable_vms_per_vcenter{flavor="g_c128_m512",upper_limit_flavor_capacity=~"([6-9]|[1-9][0-9]+)"}) by (flavor, vcenter, az, upper_limit_flavor_capacity) < 3
         for: 3h
         labels:
           severity: warning

--- a/openstack/nova/alerts/openstack/vmware-rebalancer.alerts
+++ b/openstack/nova/alerts/openstack/vmware-rebalancer.alerts
@@ -2,7 +2,7 @@ groups:
   - name: vmware-rebalancer.alerts
     rules:
       - alert: VcenterLowNumberOfPlaceableVms
-        expr: sum(wm_vmware_rebalancer_placeable_vms_per_vcenter{flavor="g_c128_m512",upper_limit_flavor_capacity=~"([6-9]|[1-9][0-9]+)"}) by (flavor, vcenter, az, upper_limit_flavor_capacity) < 3
+        expr: sum(wm_vmware_rebalancer_placeable_vms_per_vcenter{flavor="g_c128_m512",upper_limit_flavor_capacity=~"([6-9]|[1-9][0-9]+)"}) by (flavor, vcenter, az) < 3
         for: 3h
         labels:
           severity: warning


### PR DESCRIPTION
`upper_limit_flavor_capacity=~"([6-9]|[1-9][0-9]+)"` will filter all vcenters with cannot spawn more then 5 `g_c128_m512` if there is no load.

feel free to change to some other value