### PR TITLE
[Nova] Seed common traits

### DIFF
--- a/openstack/nova/templates/seed.yaml
+++ b/openstack/nova/templates/seed.yaml
@@ -188,3 +188,15 @@ spec:
         inherited: true
   {{- end }}
   {{- end }}
+
+  traits:
+    - CUSTOM_BB_FREEING
+    - CUSTOM_CEREBRO_NOT_SOURCE
+    - CUSTOM_CEREBRO_NOT_TARGET
+    - CUSTOM_DECOMMISSIONING
+    - CUSTOM_EXTERNAL_CUSTOMER_EXCLUSIVE
+    - CUSTOM_HANA_EXCLUSIVE_HOST
+    - CUSTOM_HW_SAPPHIRE_RAPIDS
+    {{- if .Values.nova_bigvm_enabled }}
+    - CUSTOM_BIGVM_DISABLED
+    {{- end }}


### PR DESCRIPTION
We seed the traits that we documented in the operations documentation and that are not automatically created by Nova (e.g. not CUSTOM_EXTERNAL_CUSTOMER_*).

We skip adding CUSTOM_NUMASIZE_* traits, which we currently still create manually, because they _should_ be managed by `nova-compute`.

---

Created as draft, because `traits` are only supported in the Python part of the seeder and not the Go part and thus this does nothing at the moment.