### PR TITLE
[mariadb] update to 11.4 major release

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.38.0 - 2026/06/01
+* MariaDB version updated to [11.4.12](https://mariadb.com/docs/release-notes/community-server/11.4/11.4.12)
+  * See https://mariadb.com/docs/release-notes/community-server/11.4/what-is-mariadb-114
+* sidecar images updated
+* `maria-back-me-up` updated to `11.4-20260526134159`, based on 11.4 mariadb image
+* chart version bumped
+
 ## v0.37.0 - 2026/05/21
 * MariaDB version updated to [10.11.17](https://mariadb.com/docs/release-notes/community-server/10.11/10.11.17)
 * `maria-back-me-up` updated to `10.11-20260521084302`

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,9 +2,9 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.37.0
+version: 0.38.0
 # scripts/docker-entyrpoint.sh should be updated when appVersion is updated
-appVersion: 10.11.17
+appVersion: 11.4.12
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/common/mariadb/scripts/docker-entrypoint.sh
+++ b/common/mariadb/scripts/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# NOTE: the source is https://github.com/MariaDB/mariadb-docker/blob/master/10.5/docker-entrypoint.sh
+# NOTE: the source is https://github.com/MariaDB/mariadb-docker/blob/master/11.4/docker-entrypoint.sh
 # The main difference is the absence of the `healthcheck`` user creation
 #
 
@@ -128,6 +128,7 @@ docker_temp_server_start() {
 		--expire-logs-days=0 \
 		--skip-slave-start \
 		--loose-innodb_buffer_pool_load_at_startup=0 \
+		--skip-ssl --ssl-cert='' --ssl-key='' --ssl-ca='' \
 		&
 	declare -g MARIADB_PID
 	MARIADB_PID=$!
@@ -141,6 +142,7 @@ docker_temp_server_start() {
 	local i
 	for i in {30..0}; do
 		if docker_process_sql "${extraArgs[@]}" --database=mysql \
+			--skip-ssl --skip-ssl-verify-server-cert \
 			<<<'SELECT 1' &> /dev/null; then
 			break
 		fi
@@ -561,8 +563,8 @@ docker_mariadb_backup_system()
 	fi
 	local backup_db="system_mysql_backup_unknown_version.sql.zst"
 	local oldfullversion="unknown_version"
-	if [ -r "$DATADIR"/mysql_upgrade_info ]; then
-		read -r -d '' oldfullversion < "$DATADIR"/mysql_upgrade_info || true
+	if [ -r "$DATADIR"/mariadb_upgrade_info ]; then
+		read -r -d '' oldfullversion < "$DATADIR"/mariadb_upgrade_info || true
 		if [ -n "$oldfullversion" ]; then
 			backup_db="system_mysql_backup_${oldfullversion}.sql.zst"
 		fi
@@ -601,14 +603,14 @@ docker_mariadb_upgrade() {
 
 
 _check_if_upgrade_is_needed() {
-	if [ ! -f "$DATADIR"/mysql_upgrade_info ]; then
+	if [ ! -f "$DATADIR"/mariadb_upgrade_info ]; then
 		mysql_note "MariaDB upgrade information missing, assuming required"
 		return 0
 	fi
 	local mariadbVersion
 	mariadbVersion="$(_mariadb_version)"
 	IFS='.-' read -ra newversion <<<"$mariadbVersion"
-	IFS='.-' read -ra oldversion < "$DATADIR"/mysql_upgrade_info || true
+	IFS='.-' read -ra oldversion < "$DATADIR"/mariadb_upgrade_info || true
 
 	if [[ ${#newversion[@]} -lt 2 ]] || [[ ${#oldversion[@]} -lt 2 ]] \
 		|| [[ ${oldversion[0]} -lt ${newversion[0]} ]] \

--- a/common/mariadb/scripts/mariadb-cronjob-maintenance.sh
+++ b/common/mariadb/scripts/mariadb-cronjob-maintenance.sh
@@ -6,10 +6,10 @@ set -o pipefail
 source /usr/bin/common-functions.sh
 
 declare mysqlOpts
-mysqlOpts="--protocol=tcp --host={{ include "fullName" . }} --user=root --password=${MYSQL_ROOT_PASSWORD} --database=mysql --wait --connect-timeout=5 --reconnect --batch"
+mysqlOpts="${MARIADB_TLS_OPTION} --protocol=tcp --host={{ include "fullName" . }} --user=root --password=${MYSQL_ROOT_PASSWORD} --database=mysql --wait --connect-timeout=5 --reconnect --batch"
 
 function listTables {
-  mysql ${mysqlOpts} --skip-column-names --execute="SELECT CONCAT('\`',table_schema,'\`.\`',table_name,'\`') FROM information_schema.tables WHERE table_schema NOT IN ('information_schema','performance_schema','mysql','sys','innodb') AND engine IS NOT NULL;"
+  mariadb ${mysqlOpts} --skip-column-names --execute="SELECT CONCAT('\`',table_schema,'\`.\`',table_name,'\`') FROM information_schema.tables WHERE table_schema NOT IN ('information_schema','performance_schema','mysql','sys','innodb') AND engine IS NOT NULL;"
   if [ "$?" -ne 0 ]; then
     logerror "${FUNCNAME[0]}" "table query failed"
     exit 1
@@ -25,7 +25,7 @@ function analyzeTable {
     exit 1
   else
     loginfo "${FUNCNAME[0]}" "analyze table ${tblName}"
-    MYSQL_RESPONSE=$(mysql ${mysqlOpts} --execute="ANALYZE TABLE ${tblName} PERSISTENT FOR ALL;")
+    MYSQL_RESPONSE=$(mariadb ${mysqlOpts} --execute="ANALYZE TABLE ${tblName} PERSISTENT FOR ALL;")
     MYSQL_STATUS=$?
     MYSQL_QUERY_STATUS=$(echo "${MYSQL_RESPONSE}" | grep "Error" | wc -l)
     {{- if $.Values.job.maintenance.function.analyzeTable.verbose }}

--- a/common/mariadb/scripts/mariadb-rename-check-constraints.sh
+++ b/common/mariadb/scripts/mariadb-rename-check-constraints.sh
@@ -19,13 +19,17 @@ fi
 
 export MYSQL_PWD="${MYSQL_PASSWORD}"
 
+mariadb_cmd() {
+    mariadb ${MARIADB_TLS_OPTION} -h"${MYSQL_ADDRESS}" -u"${MYSQL_USER}" "$@"
+}
+
 check_connection() {
     local max_attempts=12
     local wait_time=10
     local attempt=1
 
     while [[ $attempt -le "${max_attempts}" ]]; do
-        if mysql -h"${MYSQL_ADDRESS}" -u"${MYSQL_USER}" -e "SELECT 1" >/dev/null 2>&1; then
+        if mariadb_cmd -e "SELECT 1" >/dev/null 2>&1; then
             loginfo "check_connection" "Database connection successful on attempt ${attempt}"
             return 0
         else
@@ -44,7 +48,7 @@ if ! check_connection; then
 fi
 
 get_databases() {
-    mysql -h"${MYSQL_ADDRESS}" -u"${MYSQL_USER}" -N -e "
+    mariadb_cmd -N -e "
         SELECT SCHEMA_NAME
         FROM information_schema.SCHEMATA
         WHERE SCHEMA_NAME NOT IN ('information_schema', 'mysql', 'performance_schema', 'sys', 'innodb');"
@@ -52,7 +56,7 @@ get_databases() {
 
 get_constraints() {
     local db=$1
-    mysql -h"${MYSQL_ADDRESS}" -u"${MYSQL_USER}" "${db}" -N -e "
+    mariadb_cmd "${db}" -N -e "
         SELECT
             TABLE_NAME,
             CONSTRAINT_NAME,
@@ -89,7 +93,7 @@ execute_sql() {
     local sql_file=$1
     if [[ -s "${sql_file}" ]]; then
         loginfo "execute_sql" "Executing check constraint rename operations..."
-        if mysql -h"${MYSQL_ADDRESS}" -u"${MYSQL_USER}" < "${sql_file}"; then
+        if mariadb_cmd < "${sql_file}"; then
             loginfo "execute_sql" "Check constraint rename operations completed."
             return 0
         else

--- a/common/mariadb/templates/cronjob-mariadb-maintenance.yaml
+++ b/common/mariadb/templates/cronjob-mariadb-maintenance.yaml
@@ -49,6 +49,8 @@ spec:
                 secretKeyRef:
                   name: mariadb-{{.Values.name}}
                   key: root-password
+            - name: MARIADB_TLS_OPTION
+              value: {{ .Values.client_tls_option | default "--skip-ssl-verify-server-cert" | quote }}
             resources:
               requests:
                 cpu: {{ $.Values.job.maintenance.resources.requests.cpu | default 0.5 }}

--- a/common/mariadb/templates/rename-check-constraints-job.yaml
+++ b/common/mariadb/templates/rename-check-constraints-job.yaml
@@ -47,6 +47,8 @@ spec:
               secretKeyRef:
                 name: mariadb-{{.Values.name}}
                 key: root-password
+          - name: MARIADB_TLS_OPTION
+            value: {{ .Values.client_tls_option | default "--skip-ssl-verify-server-cert" | quote }}
         resources:
           requests:
             cpu: {{ $.Values.job.renameCheckConstraints.resources.requests.cpu | default 0.5 }}

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -25,6 +25,11 @@ expire_logs_days: 10
 character_set_server: "utf8" # Should be utf8mb4, but we started with this
 collation_server: "utf8_general_ci"
 
+# -- MariaDB client TLS flag for job and maintenance scripts.
+# Use "--skip-ssl-verify-server-cert" (default), "--skip-ssl", or "" for full verification.
+# @default -- "--skip-ssl-verify-server-cert"
+client_tls_option: "--skip-ssl-verify-server-cert"
+
 db_performance_schema: # Enabling performance schema only (without enabling instruments for data collections).
   # Instrument can be enabled separately. Only Performance Schema Enablement does not cause any
   # overhead.

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -9,7 +9,7 @@ global:
       enabled: true
 
 name: null
-image: library/mariadb:10.11.17
+image: library/mariadb:11.4.12
 imagePullPolicy: IfNotPresent
 port_public: 3306
 max_connections: 1024
@@ -223,7 +223,7 @@ backup_v2:
   enabled: false
   backup_dir: "./backup"
   image: maria-back-me-up
-  image_version: "10.11-20260521084302"
+  image_version: "11.4-20260526134159"
   full_backup_cron_schedule: "0 0 * * *"
   incremental_backup_in_minutes: 5
   purge_binlog_after_minutes: 60


### PR DESCRIPTION
* MariaDB version updated to [11.4.12](https://mariadb.com/docs/release-notes/community-server/11.4/11.4.12)
  * See https://mariadb.com/docs/release-notes/community-server/11.4/what-is-mariadb-114
* sidecar images updated
* `maria-back-me-up` updated to image, based on 11.4 mariadb image
* chart version bumped