### PR TITLE
[persephone] admin creds: runtime, webhook, operator

### DIFF
--- a/system/persephone-metal/Chart.lock
+++ b/system/persephone-metal/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: owner-info
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 1.0.0
+digest: sha256:ca7c19b16632950e17c13dc4e5dbda8c7006ad9178f511fefe25bc57e69ad033
+generated: "2026-01-15T15:02:28.007969+01:00"

--- a/system/persephone-metal/Chart.yaml
+++ b/system/persephone-metal/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: persephone-metal
+description: Creation of Keystone users required by persephone runtime cluster components
+version: 0.1.0
+dependencies:
+  - name: owner-info
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: '>= 0.0.0'

--- a/system/persephone-metal/ci/test-values.yaml
+++ b/system/persephone-metal/ci/test-values.yaml
@@ -1,0 +1,3 @@
+global:
+  region: qa-de-1
+  vaultBaseURL: vault+kvv2:///banane

--- a/system/persephone-metal/ci/test-values.yaml
+++ b/system/persephone-metal/ci/test-values.yaml
@@ -1,3 +1,3 @@
 global:
-  region: qa-de-1
+  region: eu-de-1
   vaultBaseURL: vault+kvv2:///banane

--- a/system/persephone-metal/templates/seed.yaml
+++ b/system/persephone-metal/templates/seed.yaml
@@ -55,7 +55,7 @@ spec:
               user:  persephone-{{ $landscape }}-runtime@Default
             {{- end }}
 
-            {{- range $_, $roleName := list "service" }}
+            {{- range $_, $roleName := list "compute_admin" "dns_webmaster" "member" "network_admin" "objectstore_admin" "volume_admin" }}
             - role: {{ $roleName }}
               user: persephone-{{ $landscape }}-gardener@Default
             {{- end }}

--- a/system/persephone-metal/templates/seed.yaml
+++ b/system/persephone-metal/templates/seed.yaml
@@ -1,0 +1,69 @@
+{{- $vbase           := .Values.global.vaultBaseURL        | required "missing value for .Values.global.vaultBaseURL" -}}
+{{- $region          := .Values.global.region              | required "missing value for .Values.global.region" -}}
+{{- $landscapes      := .Values.persephone.landscapes      | required "missing value for .Values.persephone.landscapes" -}}
+
+apiVersion: "openstack.stable.sap.cc/v1"
+kind: OpenstackSeed
+metadata:
+  name: persephone-seed
+
+spec:
+  requires:
+    # TODO what are we supposed to 'require'?
+  - {{ .Values.global.keystoneNamespace }}/keystone-seed
+  - {{ .Values.global.keystoneNamespace }}/domain-ccadmin-seed
+  - {{ .Values.global.keystoneNamespace }}/domain-default-seed
+
+  domains:
+    - name: Default
+      users:
+      {{- range $_, $landscape := $landscapes }}
+        - name: persephone-{{ $landscape }}-seed
+          description: A service user for the landscape seed
+          password: {{ printf "%s/%s/persephone/keystone-user/persephone-%s-seed/password" $vbase $region $landscape | quote }}
+
+      {{- if eq $region "eu-de-1" }}
+        - name: persephone-{{ $landscape }}-runtime
+          description: A service user for the runtime shoot
+          password: {{ printf "%s/%s/persephone/keystone-user/persephone-%s-runtime/password" $vbase $region $landscape | quote }}
+
+        - name: persephone-{{ $landscape }}-gardener
+          description: A service user for the gardener operator
+          password: {{ printf "%s/%s/persephone/keystone-user/persephone-%s-operator/password" $vbase $region $landscape | quote }}
+
+        - name: persephone-{{ $landscape }}-operator
+          description: A service user for the persephone webhook operator
+          password: {{ printf "%s/%s/persephone/keystone-user/persephone-%s-webhook/password" $vbase $region $landscape | quote }}
+      {{- end }}
+      {{- end }}
+
+    - name: ccadmin
+      projects:
+        - name: cloud_admin
+          role_assignments:
+          {{- range $_, $landscape := $landscapes }}
+          # TODO: we might need this here: "cloud_dns_ops" "compute_admin" "dns_webmaster" "member" "network_admin" "objectstore_admin" "volume_admin"
+          {{- range $_, $roleName := list "member" }}
+            - role: {{ $roleName }}
+              user: persephone-{{ $landscape }}-seed@Default
+          {{ end }}
+
+          {{- if eq $region "eu-de-1" }}
+          # https://pages.github.tools.sap/kubernetes/gardener/docs/guides/sap-internal/cluster-operations/gardener-sapci/#5-assign-access-permissions-for-the-technical-user
+          {{- range $_, $roleName := list "compute_admin" "member" "network_admin" "objectstore_admin" "volume_admin" }}
+            - role: {{ $roleName }}
+              user:  persephone-{{ $landscape }}-runtime@Default
+          {{ end }}
+
+          {{- range $_, $roleName := list "service" }}
+            - role: {{ $roleName }}
+              user: persephone-{{ $landscape }}-gardener@Default
+          {{ end }}
+
+          # The operator creates new users in keystone
+          {{- range $_, $roleName := list "admin" }}
+            - role: {{ $roleName }}
+              user: persephone-{{ $landscape }}-operator@Default
+          {{ end }}
+          {{- end }}
+      {{- end }}

--- a/system/persephone-metal/templates/seed.yaml
+++ b/system/persephone-metal/templates/seed.yaml
@@ -9,7 +9,6 @@ metadata:
 
 spec:
   requires:
-    # TODO what are we supposed to 'require'?
   - {{ .Values.global.keystoneNamespace }}/keystone-seed
   - {{ .Values.global.keystoneNamespace }}/domain-ccadmin-seed
   - {{ .Values.global.keystoneNamespace }}/domain-default-seed

--- a/system/persephone-metal/templates/seed.yaml
+++ b/system/persephone-metal/templates/seed.yaml
@@ -39,31 +39,31 @@ spec:
 
     - name: ccadmin
       projects:
-        - name: cloud_admin
+        {{- range $_, $landscape := $landscapes }}
+        - name: persephone-{{ $landscape }}
           role_assignments:
-          {{- range $_, $landscape := $landscapes }}
-          # TODO: we might need this here: "cloud_dns_ops" "compute_admin" "dns_webmaster" "member" "network_admin" "objectstore_admin" "volume_admin"
-          {{- range $_, $roleName := list "member" }}
+            # TODO: we might need this here: "cloud_dns_ops" "compute_admin" "dns_webmaster" "member" "network_admin" "objectstore_admin" "volume_admin"
+            {{- range $_, $roleName := list "member" }}
             - role: {{ $roleName }}
               user: persephone-{{ $landscape }}-seed@Default
-          {{ end }}
+            {{- end }}
 
-          {{- if eq $region "eu-de-1" }}
-          # https://pages.github.tools.sap/kubernetes/gardener/docs/guides/sap-internal/cluster-operations/gardener-sapci/#5-assign-access-permissions-for-the-technical-user
-          {{- range $_, $roleName := list "compute_admin" "member" "network_admin" "objectstore_admin" "volume_admin" }}
+            {{- if eq $region "eu-de-1" }}
+            # https://pages.github.tools.sap/kubernetes/gardener/docs/guides/sap-internal/cluster-operations/gardener-sapci/#5-assign-access-permissions-for-the-technical-user
+            {{- range $_, $roleName := list "compute_admin" "member" "network_admin" "objectstore_admin" "volume_admin" }}
             - role: {{ $roleName }}
               user:  persephone-{{ $landscape }}-runtime@Default
-          {{ end }}
+            {{- end }}
 
-          {{- range $_, $roleName := list "service" }}
+            {{- range $_, $roleName := list "service" }}
             - role: {{ $roleName }}
               user: persephone-{{ $landscape }}-gardener@Default
-          {{ end }}
+            {{- end }}
 
-          # The operator creates new users in keystone
-          {{- range $_, $roleName := list "admin" }}
+            # The operator creates new users in keystone
+            {{- range $_, $roleName := list "admin" }}
             - role: {{ $roleName }}
               user: persephone-{{ $landscape }}-operator@Default
-          {{ end }}
-          {{- end }}
-      {{- end }}
+            {{ end }}
+            {{- end }}
+        {{- end }}

--- a/system/persephone-metal/templates/seed.yaml
+++ b/system/persephone-metal/templates/seed.yaml
@@ -56,7 +56,7 @@ spec:
         - name: persephone-{{ $landscape }}
           role_assignments:
             # TODO: we might need this here: "cloud_dns_ops" "compute_admin" "dns_webmaster" "member" "network_admin" "objectstore_admin" "volume_admin"
-            {{- range $_, $roleName := list "member" }}
+            {{- range $_, $roleName := list "member" "objectstore_admin" }}
             - role: {{ $roleName }}
               user: persephone-{{ $landscape }}-seed@Default
             {{- end }}

--- a/system/persephone-metal/templates/seed.yaml
+++ b/system/persephone-metal/templates/seed.yaml
@@ -14,6 +14,9 @@ spec:
   - {{ .Values.global.keystoneNamespace }}/domain-default-seed
 
   domains:
+    # expectation: it creates the 'persephone' domain
+    - name: persephone
+
     - name: Default
       users:
       {{- range $_, $landscape := $landscapes }}

--- a/system/persephone-metal/templates/seed.yaml
+++ b/system/persephone-metal/templates/seed.yaml
@@ -79,3 +79,14 @@ spec:
             {{- end }}
             {{- end }}
         {{- end }}
+
+    - name: persephone
+      projects:
+        {{- range $_, $landscape := $landscapes }}
+        - name: persephone-{{ $landscape }}
+          role_assignments:
+            - role: admin
+              user: persephone-{{ $landscape }}-operator@Default
+            - role: admin
+              user: persephone-{{ $landscape }}-webhook@Default
+        {{- end }}

--- a/system/persephone-metal/templates/seed.yaml
+++ b/system/persephone-metal/templates/seed.yaml
@@ -24,10 +24,18 @@ spec:
         - name: persephone-{{ $landscape }}-operator
           description: A service user for the persephone-operator
           password: {{ printf "%s/%s/persephone/keystone-user/persephone-%s-operator/password" $vbase $region $landscape | quote }}
+          # expectation: allow persephone-operator to create service users on the fly with default project ID determined on the fly
+          role_assignments:
+            - domain: persephone
+              role: admin
 
         - name: persephone-{{ $landscape }}-webhook
           description: A service user for the persephone-webhook
           password: {{ printf "%s/%s/persephone/keystone-user/persephone-%s-webhook/password" $vbase $region $landscape | quote }}
+          # expectation: allow persephone-webhook to create service users on the fly with default project ID determined on the fly
+          role_assignments:
+            - domain: persephone
+              role: admin
       {{- if eq $region "eu-de-1" }}
         - name: persephone-{{ $landscape }}-runtime
           description: A service user for the runtime shoot
@@ -49,18 +57,6 @@ spec:
             - role: {{ $roleName }}
               user: persephone-{{ $landscape }}-seed@Default
             {{- end }}
-
-            # The operator creates new users in keystone (a dedicated OpenStack user created for a Shoot)
-            {{- range $_, $roleName := list "admin" }}
-            - role: {{ $roleName }}
-              user: persephone-{{ $landscape }}-operator@Default
-            {{ end }}
-
-            # The webhook creates new users in keystone (a dedicated OpenStack user created for a Shoot)
-            {{- range $_, $roleName := list "admin" }}
-            - role: {{ $roleName }}
-              user: persephone-{{ $landscape }}-webhook@Default
-            {{ end }}
 
             {{- if eq $region "eu-de-1" }}
             # https://pages.github.tools.sap/kubernetes/gardener/docs/guides/sap-internal/cluster-operations/gardener-sapci/#5-assign-access-permissions-for-the-technical-user

--- a/system/persephone-metal/templates/seed.yaml
+++ b/system/persephone-metal/templates/seed.yaml
@@ -12,7 +12,8 @@ spec:
   - {{ .Values.global.keystoneNamespace }}/keystone-seed
   - {{ .Values.global.keystoneNamespace }}/domain-ccadmin-seed
   - {{ .Values.global.keystoneNamespace }}/domain-default-seed
-  - {{ .Values.global.keystoneNamespace }}/domain-persephone-seed
+# TODO: (2026-02-05) seeder still cannot find this seed
+# - {{ .Values.global.keystoneNamespace }}/domain-persephone-seed
 
   domains:
     - name: Default

--- a/system/persephone-metal/templates/seed.yaml
+++ b/system/persephone-metal/templates/seed.yaml
@@ -60,11 +60,11 @@ spec:
               user: persephone-{{ $landscape }}-seed@Default
             {{- end }}
 
-            # TODO: can/should we create these projects in the 'persephone' domain?
-            - role: admin
-              user: persephone-{{ $landscape }}-operator@Default
-            - role: admin
-              user: persephone-{{ $landscape }}-webhook@Default
+            # see 'persephone' domain definition in this seed
+            #- role: admin
+            #  user: persephone-{{ $landscape }}-operator@Default
+            #- role: admin
+            #  user: persephone-{{ $landscape }}-webhook@Default
 
             {{- if eq $region "eu-de-1" }}
             # https://pages.github.tools.sap/kubernetes/gardener/docs/guides/sap-internal/cluster-operations/gardener-sapci/#5-assign-access-permissions-for-the-technical-user
@@ -83,6 +83,7 @@ spec:
     - name: persephone
       projects:
         {{- range $_, $landscape := $landscapes }}
+        # the seeder creates these projects if they don't exist
         - name: persephone-{{ $landscape }}
           role_assignments:
             - role: admin

--- a/system/persephone-metal/templates/seed.yaml
+++ b/system/persephone-metal/templates/seed.yaml
@@ -68,8 +68,7 @@ spec:
         {{- range $_, $landscape := $landscapes }}
         - name: persephone-{{ $landscape }}
           role_assignments:
-            # TODO: we might need this here: "cloud_dns_ops" "compute_admin" "dns_webmaster" "member" "network_admin" "objectstore_admin" "volume_admin"
-            {{- range $_, $roleName := list "member" "objectstore_admin" }}
+            {{- range $_, $roleName := list "cloud_dns_ops" "compute_admin" "dns_webmaster" "member" "network_admin" "objectstore_admin" "volume_admin" }}
             - role: {{ $roleName }}
               user: persephone-{{ $landscape }}-seed@Default
             {{- end }}

--- a/system/persephone-metal/templates/seed.yaml
+++ b/system/persephone-metal/templates/seed.yaml
@@ -21,6 +21,13 @@ spec:
           description: A service user for the landscape seed
           password: {{ printf "%s/%s/persephone/keystone-user/persephone-%s-seed/password" $vbase $region $landscape | quote }}
 
+        - name: persephone-{{ $landscape }}-operator
+          description: A service user for the persephone-operator
+          password: {{ printf "%s/%s/persephone/keystone-user/persephone-%s-operator/password" $vbase $region $landscape | quote }}
+
+        - name: persephone-{{ $landscape }}-webhook
+          description: A service user for the persephone-webhook
+          password: {{ printf "%s/%s/persephone/keystone-user/persephone-%s-webhook/password" $vbase $region $landscape | quote }}
       {{- if eq $region "eu-de-1" }}
         - name: persephone-{{ $landscape }}-runtime
           description: A service user for the runtime shoot
@@ -29,10 +36,6 @@ spec:
         - name: persephone-{{ $landscape }}-gardener
           description: A service user for the gardener operator
           password: {{ printf "%s/%s/persephone/keystone-user/persephone-%s-operator/password" $vbase $region $landscape | quote }}
-
-        - name: persephone-{{ $landscape }}-operator
-          description: A service user for the persephone webhook operator
-          password: {{ printf "%s/%s/persephone/keystone-user/persephone-%s-webhook/password" $vbase $region $landscape | quote }}
       {{- end }}
       {{- end }}
 
@@ -59,10 +62,16 @@ spec:
               user: persephone-{{ $landscape }}-gardener@Default
             {{- end }}
 
-            # The operator creates new users in keystone
+            # The operator creates new users in keystone (a dedicated OpenStack user created for a Shoot)
             {{- range $_, $roleName := list "admin" }}
             - role: {{ $roleName }}
               user: persephone-{{ $landscape }}-operator@Default
+            {{ end }}
+
+            # The webhook creates new users in keystone (a dedicated OpenStack user created for a Shoot)
+            {{- range $_, $roleName := list "admin" }}
+            - role: {{ $roleName }}
+              user: persephone-{{ $landscape }}-webhook@Default
             {{ end }}
             {{- end }}
         {{- end }}

--- a/system/persephone-metal/templates/seed.yaml
+++ b/system/persephone-metal/templates/seed.yaml
@@ -50,18 +50,6 @@ spec:
               user: persephone-{{ $landscape }}-seed@Default
             {{- end }}
 
-            {{- if eq $region "eu-de-1" }}
-            # https://pages.github.tools.sap/kubernetes/gardener/docs/guides/sap-internal/cluster-operations/gardener-sapci/#5-assign-access-permissions-for-the-technical-user
-            {{- range $_, $roleName := list "compute_admin" "member" "network_admin" "objectstore_admin" "volume_admin" }}
-            - role: {{ $roleName }}
-              user:  persephone-{{ $landscape }}-runtime@Default
-            {{- end }}
-
-            {{- range $_, $roleName := list "compute_admin" "dns_webmaster" "member" "network_admin" "objectstore_admin" "volume_admin" }}
-            - role: {{ $roleName }}
-              user: persephone-{{ $landscape }}-gardener@Default
-            {{- end }}
-
             # The operator creates new users in keystone (a dedicated OpenStack user created for a Shoot)
             {{- range $_, $roleName := list "admin" }}
             - role: {{ $roleName }}
@@ -73,5 +61,17 @@ spec:
             - role: {{ $roleName }}
               user: persephone-{{ $landscape }}-webhook@Default
             {{ end }}
+
+            {{- if eq $region "eu-de-1" }}
+            # https://pages.github.tools.sap/kubernetes/gardener/docs/guides/sap-internal/cluster-operations/gardener-sapci/#5-assign-access-permissions-for-the-technical-user
+            {{- range $_, $roleName := list "compute_admin" "member" "network_admin" "objectstore_admin" "volume_admin" }}
+            - role: {{ $roleName }}
+              user:  persephone-{{ $landscape }}-runtime@Default
+            {{- end }}
+
+            {{- range $_, $roleName := list "compute_admin" "dns_webmaster" "member" "network_admin" "objectstore_admin" "volume_admin" }}
+            - role: {{ $roleName }}
+              user: persephone-{{ $landscape }}-gardener@Default
+            {{- end }}
             {{- end }}
         {{- end }}

--- a/system/persephone-metal/templates/seed.yaml
+++ b/system/persephone-metal/templates/seed.yaml
@@ -52,6 +52,20 @@ spec:
     - name: ccadmin
       projects:
         {{- range $_, $landscape := $landscapes }}
+        - name: cloud_admin
+          role_assignments:
+            # TODO: how to achieve the same permissions without assigning such high privileges?
+            # expected: user can CRUD "shoot service users" in 'persephone' domain; user can list domains to resolve 'persephone' domain name to domain ID
+            - role: admin
+              user: persephone-{{ $landscape }}-operator@Default
+            # TODO: how to achieve the same permissions without assigning such high privileges?
+            # expected: user can CRUD "shoot service users" in 'persephone' domain; user can list domains to resolve 'persephone' domain name to domain ID
+            - role: admin
+              user: persephone-{{ $landscape }}-webhook@Default
+        {{- end }}
+
+
+        {{- range $_, $landscape := $landscapes }}
         - name: persephone-{{ $landscape }}
           role_assignments:
             # TODO: we might need this here: "cloud_dns_ops" "compute_admin" "dns_webmaster" "member" "network_admin" "objectstore_admin" "volume_admin"
@@ -59,12 +73,6 @@ spec:
             - role: {{ $roleName }}
               user: persephone-{{ $landscape }}-seed@Default
             {{- end }}
-
-            # see 'persephone' domain definition in this seed
-            #- role: admin
-            #  user: persephone-{{ $landscape }}-operator@Default
-            #- role: admin
-            #  user: persephone-{{ $landscape }}-webhook@Default
 
             {{- if eq $region "eu-de-1" }}
             # https://pages.github.tools.sap/kubernetes/gardener/docs/guides/sap-internal/cluster-operations/gardener-sapci/#5-assign-access-permissions-for-the-technical-user

--- a/system/persephone-metal/templates/seed.yaml
+++ b/system/persephone-metal/templates/seed.yaml
@@ -12,11 +12,9 @@ spec:
   - {{ .Values.global.keystoneNamespace }}/keystone-seed
   - {{ .Values.global.keystoneNamespace }}/domain-ccadmin-seed
   - {{ .Values.global.keystoneNamespace }}/domain-default-seed
+  - {{ .Values.global.keystoneNamespace }}/domain-persephone-seed
 
   domains:
-    # expectation: it creates the 'persephone' domain
-    - name: persephone
-
     - name: Default
       users:
       {{- range $_, $landscape := $landscapes }}
@@ -27,7 +25,7 @@ spec:
         - name: persephone-{{ $landscape }}-operator
           description: A service user for the persephone-operator
           password: {{ printf "%s/%s/persephone/keystone-user/persephone-%s-operator/password" $vbase $region $landscape | quote }}
-          # expectation: allow persephone-operator to create service users on the fly with default project ID determined on the fly
+          # expectation: allow persephone-operator to create service users on the fly with default project ID also determined on the fly
           role_assignments:
             - domain: persephone
               role: admin
@@ -35,7 +33,7 @@ spec:
         - name: persephone-{{ $landscape }}-webhook
           description: A service user for the persephone-webhook
           password: {{ printf "%s/%s/persephone/keystone-user/persephone-%s-webhook/password" $vbase $region $landscape | quote }}
-          # expectation: allow persephone-webhook to create service users on the fly with default project ID determined on the fly
+          # expectation: allow persephone-webhook to create service users on the fly with default project ID also determined on the fly
           role_assignments:
             - domain: persephone
               role: admin

--- a/system/persephone-metal/templates/seed.yaml
+++ b/system/persephone-metal/templates/seed.yaml
@@ -59,6 +59,12 @@ spec:
               user: persephone-{{ $landscape }}-seed@Default
             {{- end }}
 
+            # TODO: can/should we create these projects in the 'persephone' domain?
+            - role: admin
+              user: persephone-{{ $landscape }}-operator@Default
+            - role: admin
+              user: persephone-{{ $landscape }}-webhook@Default
+
             {{- if eq $region "eu-de-1" }}
             # https://pages.github.tools.sap/kubernetes/gardener/docs/guides/sap-internal/cluster-operations/gardener-sapci/#5-assign-access-permissions-for-the-technical-user
             {{- range $_, $roleName := list "compute_admin" "member" "network_admin" "objectstore_admin" "volume_admin" }}
@@ -71,17 +77,4 @@ spec:
               user: persephone-{{ $landscape }}-gardener@Default
             {{- end }}
             {{- end }}
-        {{- end }}
-
-    # application credentials (which both the persephone-operator and persephone-webhook will read from vault in order to create shoot-specific service users)
-    # must be scoped to a project, therefore we scope the users that we will derive application credentials from to persephone-specific projects.
-    - name: persephone
-      projects:
-        {{- range $_, $landscape := $landscapes }}
-        - name: persephone-{{ $landscape }}
-          role_assignments:
-            - role: admin
-              user: persephone-{{ $landscape }}-operator@Default
-            - role: admin
-              user: persephone-{{ $landscape }}-webhook@Default
         {{- end }}

--- a/system/persephone-metal/templates/seed.yaml
+++ b/system/persephone-metal/templates/seed.yaml
@@ -72,3 +72,16 @@ spec:
             {{- end }}
             {{- end }}
         {{- end }}
+
+    # application credentials (which both the persephone-operator and persephone-webhook will read from vault in order to create shoot-specific service users)
+    # must be scoped to a project, therefore we scope the users that we will derive application credentials from to persephone-specific projects.
+    - name: persephone
+      projects:
+        {{- range $_, $landscape := $landscapes }}
+        - name: persephone-{{ $landscape }}
+          role_assignments:
+            - role: admin
+              user: persephone-{{ $landscape }}-operator@Default
+            - role: admin
+              user: persephone-{{ $landscape }}-webhook@Default
+        {{- end }}

--- a/system/persephone-metal/values.yaml
+++ b/system/persephone-metal/values.yaml
@@ -1,0 +1,14 @@
+persephone:
+  landscapes:
+    - qa
+    - canary
+    - prod
+
+owner-info:
+  support-group: containers
+  service: persephone
+  maintainers:
+    - Caio Ronchi
+    - Jan Knipper
+    - Sandro Jäckel
+  helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/system/persephone-metal


### PR DESCRIPTION
see <https://github.wdf.sap.corp/sap-cloud-infrastructure/persephone/issues/68>

## TODO

* [ ] Define `CODEOWNERS` entry for new pipeline directory
* [ ] After merging <https://github.wdf.sap.corp/cc/domain-seeds/pull/34>, this chart should require `domain-persephone-seed`
* [x] Script the dry-run/creation/rotation of vault passwords for all the persephone users referenced in the seeder
  * [x] Apply the script, ensure passwords get created
* [x] Script the dry-run/creation/rotation of application credentials for all the persephone users referenced in the seeder (it should load the respective password from Vault)
  * [x] Apply the script, ensure application credentials get created
* [x] Manually apply the `helm upgrade` command above and ensure the `persephone-seed` gets created
* [x] Create a Concourse pipeline for `persephone-metal`

## Manually rendering the chart

Assumes a symlink `secrets.git` pointing to a local clone of <https://github.wdf.sap.corp/cc/secrets>

```bash
helm template \
    --values ./system/persephone-metal/values.yaml \
    --values ./secrets.git/qa-de-1/values/globals.yaml \
    system/persephone-metal
```

## Manually installing the chart

We are testing it out against `qa-de-1` using the following command:

```bash
helm upgrade persephone-metal helm-charts.git/system/persephone-metal \
    --install \
    --namespace persephone \
    --create-namespace \
    --reset-values \
    --timeout 5m \
    --history-max 3 \
    --values secrets.git/qa-de-1/values/globals.yaml \
    --set-json persephone.landscapes='["test"]'
```

## How to check whether the seeder controller succeeded

```bash
kubectl --context qa-de-1 --namespace monsoon3 logs openstack-seeder.... | grep persephone
```

## The secret we created by hand

```bash
mutavault kv --mount=containers-secrets \
    create-secret \
    --accessed-resource 'persephone service account to manage customer openstack resources' \
    --support-group containers \
    --username persephone-test-seed \
    qa-de-1/persephone/keystone-user/persephone-test-seed
```