### PR TITLE
Helm chart to generate values for kvm-ha-service

### DIFF
--- a/openstack/kvm-ha-values-generator/Chart.lock
+++ b/openstack/kvm-ha-values-generator/Chart.lock
@@ -1,0 +1,12 @@
+dependencies:
+- name: owner-info
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 1.0.0
+- name: utils
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 0.32.0
+- name: linkerd-support
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 1.1.1
+digest: sha256:0cb1e7f331726292d0b5f379041d43822cff3cc05acadb48edbe8701890a84df
+generated: "2026-02-06T15:50:02.153463+01:00"

--- a/openstack/kvm-ha-values-generator/Chart.yaml
+++ b/openstack/kvm-ha-values-generator/Chart.yaml
@@ -1,0 +1,22 @@
+apiVersion: v2
+name: kvm-ha-values-generator
+description: Chart to template internal resources for kvm-ha-service
+
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# Helm chart dependencies
+dependencies:
+  - name: owner-info
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: 1.0.0
+  - name: utils
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: 0.32.0
+  - name: linkerd-support
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: ~1

--- a/openstack/kvm-ha-values-generator/README.md
+++ b/openstack/kvm-ha-values-generator/README.md
@@ -1,0 +1,47 @@
+# kvm-ha-values-generator
+
+This chart **does not deploy anything**. It generates processed values and configuration files for deploying the public [kvm-ha-service](https://github.com/cobaltcore-dev/kvm-ha-service/) Helm chart with internal dependencies.
+
+## Why does this exist?
+
+The public `kvm-ha-service` chart cannot include internal dependencies or use internal Helm helpers (e.g., `resolve_secret` for Vault integration). This chart:
+
+1. Resolves secrets via the `resolve_secret` helper
+2. Generates trust bundle volume mounts
+3. Produces a `config.yaml` with internal configuration
+
+## Usage
+
+### 1. Generate values and config
+
+```bash
+helm dependency update .
+
+# Generate values.yaml
+helm template kvm-ha-values . \
+  --show-only templates/generated-values.yaml \
+  -f <global-values> \
+  -f <region-values> \
+  | yq '.data."values.yaml"' - > /tmp/internal-values.yaml
+
+# Generate config.yaml
+helm template kvm-ha-values . \
+  --show-only templates/generated-values.yaml \
+  -f <global-values> \
+  -f <region-values> \
+  | yq '.data."config.yaml"' - > /tmp/service-config.yaml
+```
+
+### 2. Deploy the public chart
+
+```bash
+helm upgrade --install kvm-ha-service oci://ghcr.io/<org>/kvm-ha-service \
+  -f /tmp/generated-values.yaml \
+  --set-file kvmHAservice.config=/tmp/config.yaml
+```
+
+## Important Notes
+
+- **Do not `helm install` this chart** - it only generates values
+- The generated ConfigMap is never applied to the cluster
+- CI/CD pipelines should use the two-step process above

--- a/openstack/kvm-ha-values-generator/templates/etc/_config.yaml.tpl
+++ b/openstack/kvm-ha-values-generator/templates/etc/_config.yaml.tpl
@@ -1,0 +1,126 @@
+# Global configuration
+{{- if .Values.global.region }}
+region: {{ .Values.global.region }}
+{{- end }}
+{{- if .Values.global.tld }}
+tld: {{ .Values.global.tld }}
+{{- end }}
+{{- if .Values.global.az }}
+az: {{ .Values.global.az }}
+{{- end }}
+{{- if .Values.global.warmup }}
+warmup: {{ .Values.global.warmup }}
+{{- end }}
+
+{{/* OpenStack section */}}
+{{- if .Values.openstack }}
+openstack:
+  credential:
+    auth_url: {{ .Values.openstack.auth_url }}
+    username: {{ .Values.openstack.username }}
+    {{- if .Values.openstack.password }}
+    password: {{ .Values.openstack.password | include "resolve_secret" | quote }}
+    {{- end }}
+    domain_name: {{ .Values.openstack.domain_name | default "default" }}
+    project_domain_name: {{ .Values.openstack.project_domain_name | default "default" }}
+    project_name: {{ .Values.openstack.project_name | default "service" }}
+  {{- if .Values.openstack.availability }}
+  availability: {{ .Values.openstack.availability }}
+  {{- end }}
+{{- end }}
+
+{{/* Service configuration sections */}}
+{{- if .Values.serviceConfig }}
+
+{{- if .Values.serviceConfig.sources }}
+sources:
+  {{- range .Values.serviceConfig.sources }}
+  - name: {{ .name }}
+    push: {{ .push }}
+    secret: {{ .secret | include "resolve_secret" | quote }}
+    url: {{ .url }}
+  {{- end }}{{- end }}
+
+{{- if .Values.serviceConfig.source_cache }}
+source_cache:
+{{- toYaml .Values.serviceConfig.source_cache | nindent 2 }}
+{{- end }}
+
+{{- if .Values.serviceConfig.rest }}
+rest:
+{{- toYaml .Values.serviceConfig.rest | nindent 2 }}
+{{- end }}
+
+{{- if .Values.serviceConfig.database }}
+database:
+{{- toYaml .Values.serviceConfig.database | nindent 2 }}
+  {{- if .Values.postgresql }}
+  postgres:
+    path: postgresql://{{ .Values.postgresql.auth.username | include "resolve_secret" }}:{{ .Values.postgresql.auth.password | include "resolve_secret" }}@{{ .Values.postgresql.path }}/{{ .Values.postgresql.auth.database }}
+  {{- end }}
+{{- end }}
+
+{{- if .Values.serviceConfig.actions }}
+actions:
+  {{- if .Values.serviceConfig.actions.slack }}
+  slack:
+    {{- if .Values.serviceConfig.actions.slack.ignore_errors }}
+    ignore_errors: {{ .Values.serviceConfig.actions.slack.ignore_errors }}
+    {{- end }}
+    data:
+      {{- if .Values.serviceConfig.actions.slack.data.channel }}
+      channel: {{ .Values.serviceConfig.actions.slack.data.channel | quote }}
+      {{- end }}
+      {{- if .Values.slack.token }}
+      token: {{ .Values.slack.token | include "resolve_secret" | quote }}
+      {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- if .Values.serviceConfig.metrics }}
+metrics:
+{{- toYaml .Values.serviceConfig.metrics | nindent 2 }}
+{{- end }}
+
+{{- if .Values.serviceConfig.templating }}
+templating:
+  delimiter_left: {{ .Values.serviceConfig.templating.delimiter_left | quote }}
+  delimiter_right: {{ .Values.serviceConfig.templating.delimiter_right | quote }}
+{{- end }}
+
+{{- if .Values.serviceConfig.hypervisors }}
+hypervisors:
+  filter: |-
+    {{- .Values.serviceConfig.hypervisors.filter | nindent 4 }}
+  hypervisor_hostname_pattern: {{ .Values.serviceConfig.hypervisors.hypervisor_hostname_pattern | quote }}
+{{- end }}
+
+{{- if .Values.serviceConfig.monitoring }}
+monitoring:
+{{- toYaml .Values.serviceConfig.monitoring | nindent 2 }}
+{{- end }}
+
+{{- end }}
+
+{{/* Prometheus section */}}
+{{- if .Values.prometheus }}
+prometheus:
+{{- toYaml .Values.prometheus | nindent 2 }}
+{{- end }}
+
+{{/* Redfish section */}}
+{{- if .Values.redfish }}
+redfish:
+  username: hwconsole
+  {{- if .Values.redfish.password }}
+  password: {{ .Values.redfish.password | include "resolve_secret" | quote }}
+  {{- end }}
+  poweroff_poll_interval: 5
+  poweroff_poll_timeout: 300
+{{- end }}
+
+{{/* Prometheus exports */}}
+{{- if .Values.prometheus_exports }}
+prometheus_exports:
+{{- toYaml .Values.prometheus_exports | nindent 2 }}
+{{- end }}

--- a/openstack/kvm-ha-values-generator/templates/generated-values.yaml
+++ b/openstack/kvm-ha-values-generator/templates/generated-values.yaml
@@ -1,0 +1,24 @@
+# kvm-ha-service-deps/templates/generated-values.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-generated-values
+data:
+  values.yaml: |
+    kvmHAservice:
+      pod:
+        extraVolumes:
+          {{- include "utils.trust_bundle.volumes" . | trim | nindent 10 }}
+        extraVolumeMounts:
+          {{- include "utils.trust_bundle.volume_mount" . | trim | nindent 10 }}
+    openstack:
+      password: {{ .Values.openstack.password | include "resolve_secret" }}
+    postgresql:
+      auth:
+        username: {{ .Values.postgresql.auth.username | include "resolve_secret" | quote }}
+        password: {{ .Values.postgresql.auth.password | include "resolve_secret" | quote }}
+    redfish:
+      username: {{ .Values.redfish.username | quote }}
+      password: {{ .Values.redfish.password | include "resolve_secret" | quote }}
+  config.yaml: |
+    {{ include (print .Template.BasePath "/etc/_config.yaml.tpl") . | nindent 4 }}

--- a/openstack/kvm-ha-values-generator/values.yaml
+++ b/openstack/kvm-ha-values-generator/values.yaml
@@ -12,3 +12,18 @@ owner-info:
     - Benjamin Helff
     - Paul Pickhardt
   helm-chart-url: https://github.com/cobaltcore-dev/kvm-ha-service/charts/kvm-ha-service/
+
+# Default credentials ( Will be overridden by secrets in production )
+openstack:
+  password: admin
+postgresql:
+  auth:
+    username: kvm_ha_service
+    password: kvm_ha_service_password
+redfish:
+  username: hwconsole
+  password: redfish_password
+global:
+  region: zo-ne-1
+  az: zo-ne-1a
+  tld: cloud.brick

--- a/openstack/kvm-ha-values-generator/values.yaml
+++ b/openstack/kvm-ha-values-generator/values.yaml
@@ -1,0 +1,14 @@
+# Utility configurations
+utils:
+  trust_bundle:
+    enabled: true
+
+# Owner information for the service
+owner-info:
+  support-group: compute-storage-api
+  service: kvm-ha-service
+  maintainers:
+    - Felix Goldmann
+    - Benjamin Helff
+    - Paul Pickhardt
+  helm-chart-url: https://github.com/cobaltcore-dev/kvm-ha-service/charts/kvm-ha-service/


### PR DESCRIPTION
This chart helps to generate correct values and configs to deploy the kvm-ha-service with certain dependencies when deploying it to internal k8s clusters. It will only be used within a CI/CD pipeline.

Idea is to generate certain configs, secrets and so on via this chart and just use `helm template -f secrets.yaml` to get these values into shape and in the next step deploy the kvm-ha-service with these files.