### PR TITLE
[bind] Make parts of the chart more flexible

### DIFF
--- a/system/bind/templates/deployment.yaml
+++ b/system/bind/templates/deployment.yaml
@@ -10,6 +10,10 @@ metadata:
     app: {{ .Release.Name }}
 spec:
   replicas: 1
+{{- if has "ReadWriteOnce" (concat .Values.pvc.bind.accessModes .Values.pvc.sshd.accessModes ) }}
+  strategy:
+    type: Recreate
+{{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/instance: {{ .Release.Name }}

--- a/system/bind/templates/deployment.yaml
+++ b/system/bind/templates/deployment.yaml
@@ -54,6 +54,8 @@ spec:
                     {{ if eq .Values.name (printf "bind2-global-%s" (.Values.global.region)) }}- bind1-global-{{.Values.global.region}}{{ end }}
               topologyKey: "failure-domain.beta.kubernetes.io/zone"
         {{ end }} 
+      nodeSelector:
+        topology.kubernetes.io/zone: {{ .Values.global.region }}{{ .Values.failure_domain_zone }}
       containers:
       - name: {{ .Release.Name }}
         image: {{ required ".Values.global.registryAlternateRegion is missing" .Values.global.registryAlternateRegion }}/{{.Values.images.bind.image}}:{{ .Values.images.bind.image_tag}}

--- a/system/bind/templates/pvclaim.yaml
+++ b/system/bind/templates/pvclaim.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Release.Name }}
 spec:
   accessModes:
-    - ReadWriteMany
+    {{- .Values.pvc.bind.accessModes | toYaml | nindent 4 }}
   resources:
     requests:
       storage: {{ .Values.pvc_size }}
@@ -22,7 +22,7 @@ metadata:
   name: {{ .Release.Name }}-sshd
 spec:
   accessModes:
-    - ReadWriteMany
+    {{- .Values.pvc.sshd.accessModes | toYaml | nindent 4 }}
   resources:
     requests:
       storage: 10Mi

--- a/system/bind/templates/service.yaml
+++ b/system/bind/templates/service.yaml
@@ -8,6 +8,9 @@ metadata:
     prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
     parrot.sap.cc/announce: 'true'
     prometheus.io/port: "9119"
+{{- if and .Values.externalIP .Values.calicoLoadBalancer }}
+    projectcalico.org/loadBalancerIPs: '["{{.Values.externalIP}}"]'
+{{- end }}
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Local
@@ -43,6 +46,6 @@ spec:
       port: {{ .Values.sshd.sixc.port | default 5487 }}
       targetPort: sshd-6c-tcp
 {{ end }}
-{{ if .Values.externalIP }}
+{{- if and .Values.externalIP (not .Values.calicoLoadBalancer) }}
   externalIPs: ["{{.Values.externalIP}}"]
 {{ end }}

--- a/system/bind/values.yaml
+++ b/system/bind/values.yaml
@@ -80,6 +80,12 @@ pvc:
     accessModes:
       - ReadWriteMany
 
+# if true, the load balancer will be created with the calico annotations
+# see templates/service.yaml
+# and
+# https://github.com/projectcalico/calico/issues/11815
+calicoLoadBalancer : false
+
 alerts:
   # Name of the Prometheus to which the alerts should be assigned to.
   prometheus: openstack

--- a/system/bind/values.yaml
+++ b/system/bind/values.yaml
@@ -46,7 +46,7 @@ notify_rate: 20
 # to flood them on each pod/container restart
 startup_notify_rate: 10
 
-# should be set to different AZs; this is where PV will be claimed
+# should be set to different AZs; this is used to select the nodes for the bind pods
 failure_domain_zone: a
 
 # PVC size and whether AZ enforced

--- a/system/bind/values.yaml
+++ b/system/bind/values.yaml
@@ -71,6 +71,15 @@ resources:
       memory: "64Mi"
       cpu: "50m"
 
+# container specific pvc options
+pvc:
+  bind:
+    accessModes:
+      - ReadWriteMany
+  sshd:
+    accessModes:
+      - ReadWriteMany
+
 alerts:
   # Name of the Prometheus to which the alerts should be assigned to.
   prometheus: openstack


### PR DESCRIPTION
- Make the PVC accessModes configurable
- Optionally use "projectcalico.org/loadBalancerIPs" annotation
- Use the deployment nodeSelector to select the AZ 
- Use the Recreate deployment strategy if any of the PVCs use the ReadWriteOnce access mode
