### PR TITLE
[neutron][linkerd] add missing annotations in migration job

### DIFF
--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for Openstack Neutron
 name: neutron
-version: 0.3.7
+version: 0.3.8
 appVersion: "caracal"
 dependencies:
   - condition: mariadb.enabled

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for Openstack Neutron
 name: neutron
-version: 0.3.9
+version: 0.3.10
 appVersion: "caracal"
 dependencies:
   - condition: mariadb.enabled

--- a/openstack/neutron/templates/_helper.tpl
+++ b/openstack/neutron/templates/_helper.tpl
@@ -1,7 +1,6 @@
 {{- define "neutron.migration_job_name" -}}
   {{- $bin := include "utils.script.job_finished_hook" . | trim }}
-  {{- $all := list $bin (include "utils.proxysql.job_pod_settings" . ) (include "utils.proxysql.volume_mount" . ) (include "utils.proxysql.container" . ) (include "utils.proxysql.volumes" .) (tuple . (dict) | include "utils.snippets.kubernetes_entrypoint_init_container")  | join "\n" }}
-  {{- $all := list $bin (include "utils.proxysql.job_pod_settings" . ) (include "utils.proxysql.volume_mount" . ) (include "utils.proxysql.container" . ) (include "utils.proxysql.volumes" .) (tuple . (dict) | include "utils.snippets.kubernetes_entrypoint_init_container") (include "utils.trust_bundle.volume_mount" . ) (include "utils.trust_bundle.volumes" . ) (include "utils.trust_bundle.env" . )  | join "\n" }}
+  {{- $all := list $bin (include "utils.linkerd.pod_and_service_annotation" .) (include "utils.proxysql.job_pod_settings" . ) (include "utils.proxysql.volume_mount" . ) (include "utils.proxysql.container" . ) (include "utils.proxysql.volumes" .) (tuple . (dict) | include "utils.snippets.kubernetes_entrypoint_init_container") (include "utils.trust_bundle.volume_mount" . ) (include "utils.trust_bundle.volumes" . ) (include "utils.trust_bundle.env" . )  | join "\n" }}
   {{- $hash := empty .Values.proxysql.mode | ternary $bin $all | sha256sum }}
 
   {{- .Release.Name }}-migration-{{ substr 0 4 $hash }}-{{ .Values.imageVersion | required "Please set neutron.imageVersion or similar"}}

--- a/openstack/neutron/templates/job-migration.yaml
+++ b/openstack/neutron/templates/job-migration.yaml
@@ -17,6 +17,9 @@ metadata:
     component: neutron
 spec:
   template:
+    metadata:
+      annotations:
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
       restartPolicy: OnFailure
       {{- if .Values.rbac.enabled }}


### PR DESCRIPTION
Add missing linkerd annotations to the migration job. Include
linkerd annotation in job name hash computation so that enabling or
disabling linkerd triggers job recreation.