### PR TITLE
[octavia][linkerd] add missing annotations in migration job

### DIFF
--- a/openstack/octavia/Chart.yaml
+++ b/openstack/octavia/Chart.yaml
@@ -9,7 +9,7 @@ sources:
   - https://git.openstack.org/cgit/openstack/octavia
   - https://git.openstack.org/cgit/openstack/openstack-helm
 # The versions are defined in the changelog: https://docs.openstack.org/releasenotes/octavia/yoga.html
-version: 10.1.8
+version: 10.1.9
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/octavia/templates/octavia-migration-job.yaml
+++ b/openstack/octavia/templates/octavia-migration-job.yaml
@@ -21,6 +21,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: octavia-migration
+        {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
       restartPolicy: OnFailure
     {{- if $proxysql }}
@@ -52,7 +53,7 @@ spec:
             - |
               set -euo pipefail
               octavia-db-manage upgrade head
-              {{ include "utils.proxysql.proxysql_signal_stop_script" . | trim }}
+              {{- include "utils.script.job_finished_hook" . | nindent 14 }}
           env:
             {{- if .Values.sentry.enabled }}
             - name: SENTRY_DSN


### PR DESCRIPTION
Add missing linkerd annotations and replace proxysql_signal_stop_script with job_finished_hook to shut down both proxysql and linkerd sidecars on job completion.
