### PR TITLE
Add ssl-passthrough ingress-nginx controller

### DIFF
--- a/system/kube-system-metal/Chart.lock
+++ b/system/kube-system-metal/Chart.lock
@@ -32,6 +32,9 @@ dependencies:
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx
   version: 4.15.1
+- name: ingress-nginx
+  repository: https://kubernetes.github.io/ingress-nginx
+  version: 4.15.1
 - name: wormhole
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 3.1.8
@@ -77,5 +80,5 @@ dependencies:
 - name: validating-admission-policy
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.0.2
-digest: sha256:57e2b121a9d4b3d4ef874a32f9dbe8a7cce8607cc5d7cbbd00905c4a88ebd2bf
-generated: "2026-04-10T12:54:48.034012+03:00"
+digest: sha256:76ee6045de2e20d1549ab5d5c567966b35c910f19ee2a70a28f11ef4574643c8
+generated: "2026-04-21T18:47:48.507313157+02:00"

--- a/system/kube-system-metal/Chart.yaml
+++ b/system/kube-system-metal/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for metal clusters.
 name: kube-system-metal
-version: 6.13.5
+version: 6.13.6
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-metal
 dependencies:
   - name: cc-rbac
@@ -40,6 +40,11 @@ dependencies:
   - name: ingress-nginx
     alias: ingress-nginx-external
     condition: ingress-nginx-external.enabled
+    repository: https://kubernetes.github.io/ingress-nginx
+    version: 4.15.1
+  - name: ingress-nginx
+    alias: ingress-nginx-passthrough
+    condition: ingress-nginx-passthrough.enabled
     repository: https://kubernetes.github.io/ingress-nginx
     version: 4.15.1
   - name: wormhole

--- a/system/kube-system-metal/values.yaml
+++ b/system/kube-system-metal/values.yaml
@@ -82,10 +82,6 @@ ingress-nginx:
     # See https://github.com/kubernetes/ingress-nginx/issues/7837 .
     allowSnippetAnnotations: false
 
-    extraArgs:
-      # Required for ssl-passthrough ingress annotations to take effect.
-      enable-ssl-passthrough: true
-
     config:
       custom-http-errors: "495"
 
@@ -233,6 +229,30 @@ ingress-nginx-external:
                   operator: In
                   values:
                     - default-backend
+
+ingress-nginx-passthrough:
+  enabled: true
+  fullnameOverride: kube-system-ingress-nginx-passthrough
+  releaseLabelOverride: kube-system
+
+  rbac:
+    create: true
+
+  serviceAccount:
+    create: true
+
+  controller:
+    ingressClass: nginx-passthrough
+    electionID: passthrough-ingress-controller-leader
+
+    extraArgs:
+      # Required for ssl-passthrough ingress annotations to take effect.
+      # Deployed as a separate controller to avoid the performance penalty
+      # on all HTTPS traffic that --enable-ssl-passthrough introduces.
+      enable-ssl-passthrough: true
+
+    admissionWebhooks:
+      enabled: false
 
 # For now enabled via regional values.
 vertical-pod-autoscaler:

--- a/system/kube-system-metal/values.yaml
+++ b/system/kube-system-metal/values.yaml
@@ -82,6 +82,10 @@ ingress-nginx:
     # See https://github.com/kubernetes/ingress-nginx/issues/7837 .
     allowSnippetAnnotations: false
 
+    extraArgs:
+      # Required for ssl-passthrough ingress annotations to take effect.
+      enable-ssl-passthrough: true
+
     config:
       custom-http-errors: "495"
 


### PR DESCRIPTION
Add a dedicated ingress-nginx controller for SSL passthrough, deployed as a separate instance with its own ingress class (nginx-passthrough).

Services that need the nginx.ingress.kubernetes.io/ssl-passthrough annotation require --enable-ssl-passthrough on the ingress-nginx controller. However, enabling this flag on the primary controller intercepts all HTTPS traffic through a Go TCP proxy for SNI inspection, introducing per-connection overhead for every HTTPS connection — not just passthrough ones.

To avoid this, we deploy a separate ingress-nginx controller instance (ingress-nginx-passthrough) using the same alias pattern as ingress-nginx-external. Services that need SSL passthrough can opt in by setting ingressClassName: nginx-passthrough on their Ingress resources. All other HTTPS traffic continues through the primary controller unaffected.

The new controller is enabled by default.