### PR TITLE
[neutron][rabbitmq] bump rabbitmq to 4.2.5

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 0.5.2
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.19.1
+  version: 0.22.2
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.35.0
@@ -32,5 +32,5 @@ dependencies:
 - name: ovsdb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
-digest: sha256:eaad512fe8cc6d04cbb311c21c197f3c8b2c27ed0a42f474772c119cededb7ed
-generated: "2026-04-17T14:54:05.581499921+02:00"
+digest: sha256:74a66772651a6d94c7fb3c050f32304cd633a311c14228944db43f1606dbacbb
+generated: "2026-04-20T12:17:41.874047+03:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for Openstack Neutron
 name: neutron
-version: 0.3.5
+version: 0.3.6
 appVersion: "caracal"
 dependencies:
   - condition: mariadb.enabled
@@ -23,7 +23,7 @@ dependencies:
     version: 0.5.2
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.19.1
+    version: 0.22.2
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.35.0


### PR DESCRIPTION
* bump rabbitmq helm chart dependency, update rabbitmq to 4.2.5
* ssl is enabled by default since rabbitmq chart 0.22.0