### PR TITLE
[hermes][rabbitmq] bump rabbitmq to 4.2.5

### DIFF
--- a/openstack/hermes/Chart.lock
+++ b/openstack/hermes/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 1.1.1
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.21.0
+  version: 0.22.1
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
-digest: sha256:525f76e2392585db75d36edae66d38677f01161b73af2ca871bbabad898dd359
-generated: "2026-01-22T18:26:22.755122-07:00"
+digest: sha256:7c0b7f5607500cc928bc5ef4cbd0a07771b209d07a0d6592256829fde056587f
+generated: "2026-04-02T12:21:07.323372+03:00"

--- a/openstack/hermes/Chart.yaml
+++ b/openstack/hermes/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm audit management for Openstack
 maintainers:
   - name: notque
 name: hermes
-version: 0.1.6
+version: 0.1.7
 dependencies:
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
@@ -13,7 +13,7 @@ dependencies:
     condition: hermes.rabbitmq_enabled
     name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.21.0
+    version: 0.22.1
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.2.0


### PR DESCRIPTION
* bump rabbitmq helm chart dependency, update rabbitmq to 4.2.5
* ssl is enabled by default since rabbitmq chart 0.22.0