### PR TITLE
[designate][rabbitmq] bump rabbitmq to 4.2.5

### DIFF
--- a/openstack/designate/Chart.lock
+++ b/openstack/designate/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 0.6.0
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.20.0
+  version: 0.22.1
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.32.0
@@ -29,5 +29,5 @@ dependencies:
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.3.1
-digest: sha256:383ba39902d2a8b281d32ef94a8df5a49f51c0e0535c7cdb0d2ffd7cb6356547
-generated: "2026-04-01T15:38:12.141885+02:00"
+digest: sha256:4bccf1df6e2748f990eaf8b16b63150e464a7912d222ea39381ebaa3dd7e283c
+generated: "2026-04-02T12:20:45.988489+03:00"

--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes to deploy Openstack Designate  (DNSaaS)
 name: designate
-version: 0.5.11
+version: 0.5.12
 appVersion: "dalmatian"
 dependencies:
   - condition: percona_cluster.enabled
@@ -28,7 +28,7 @@ dependencies:
   - name: rabbitmq
     condition: rabbitmq.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.20.0
+    version: 0.22.1
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.32.0


### PR DESCRIPTION
* bump rabbitmq helm chart dependency, update rabbitmq to 4.2.5
* ssl is enabled by default since rabbitmq chart 0.22.0