### PR TITLE
[nova][rabbitmq] bump rabbitmq to 4.2.5

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 0.7.0
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.21.1
+  version: 0.22.2
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.6.15
@@ -31,7 +31,7 @@ dependencies:
   version: 0.5.1
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.21.1
+  version: 0.22.2
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.33.0
@@ -40,7 +40,7 @@ dependencies:
   version: 0.5.1
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.21.1
+  version: 0.22.2
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
@@ -50,5 +50,5 @@ dependencies:
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.4.2
-digest: sha256:582dd827b99760fe03a9e4eae17397ae43c4daa9609bceb674d56a71378522b0
-generated: "2026-04-14T15:57:34.475585659+02:00"
+digest: sha256:2c915e28804075fa5c57b6e333a849736523b7a494c48815da2749f999880b4f
+generated: "2026-04-20T12:19:47.256031+03:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 name: nova
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Nova/OpenStack_Project_Nova_mascot.png
-version: 0.6.5
+version: 0.6.6
 appVersion: "bobcat"
 dependencies:
   - condition: mariadb.enabled
@@ -31,7 +31,7 @@ dependencies:
     version: 0.7.0
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.21.1
+    version: 0.22.2
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.6.15
@@ -52,7 +52,7 @@ dependencies:
     condition: cell2.enabled
     name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.21.1
+    version: 0.22.2
   - alias: mariadb_cell3
     condition: mariadb_cell3.enabled
     name: mariadb
@@ -67,7 +67,7 @@ dependencies:
     condition: cell3.enabled
     name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.21.1
+    version: 0.22.2
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0


### PR DESCRIPTION
* bump rabbitmq helm chart dependency, update rabbitmq to 4.2.5
* ssl is enabled by default since rabbitmq chart 0.22.0