### PR TITLE
neutron-hypervisor-agent: Derive segment from node

### DIFF
--- a/openstack/neutron-hypervisor-agents/templates/bin/_init.sh.tpl
+++ b/openstack/neutron-hypervisor-agents/templates/bin/_init.sh.tpl
@@ -39,7 +39,7 @@ ovs-vsctl set open . external-ids:system-id=${HASH:0:8}-${HASH:8:4}-${HASH:12:4}
 ovs-vsctl set open . external-ids:hostname=${HOSTNAME}
 ovs-vsctl set open . external-ids:ovn-encap-ip=${HOST_IP}
 
-ovs-vsctl set open . external-ids:ovn-bridge-mappings=${BUILDING_BLOCK}:{{ default "br-ex" .Values.ovn.external_bridge }}
+ovs-vsctl set open . external-ids:ovn-bridge-mappings=${HOSTNAME/*-}:{{ default "br-ex" .Values.ovn.external_bridge }}
 ovs-vsctl set open . external-ids:ovn-bridge={{ default "br-int" .Values.ovn.integration_bridge }}
 ovs-vsctl set open . external-ids:ovn-cms-options="enable-chassis-as-gw,availability-zones=${AVAILABILITY_ZONE}"
 

--- a/openstack/neutron-hypervisor-agents/templates/daemonset-linuxbridge-agent.yaml
+++ b/openstack/neutron-hypervisor-agents/templates/daemonset-linuxbridge-agent.yaml
@@ -71,7 +71,7 @@ spec:
                 - DAC_OVERRIDE
                 - DAC_READ_SEARCH
                 - SYS_PTRACE
-          command: ["sh", "-c"]
+          command: ["dumb-init", "/bin/bash", "-c"]
           args:
             - |
               set -xe
@@ -82,15 +82,14 @@ spec:
                 update-alternatives --set ebtables /usr/sbin/ebtables-legacy || true
               fi
 
+              export OS_LINUX_BRIDGE__PHYSICAL_INTERFACE_MAPPINGS="${HOSTNAME/*-}:bond0"
               # Start the linuxbridge agent
               exec neutron-linuxbridge-agent --debug
           env:
-            - name: BUILDING_BLOCK
+            - name: HOSTNAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.labels['kubernetes.metal.cloud.sap/bb']
-            - name: OS_LINUX_BRIDGE__PHYSICAL_INTERFACE_MAPPINGS
-              value: "$(BUILDING_BLOCK):bond0"
+                  fieldPath: spec.nodeName
             - name: OS_SECURITYGROUP__FIREWALL_DRIVER
               value: "iptables"
           volumeMounts:

--- a/openstack/neutron-hypervisor-agents/templates/daemonset-openvswitch-agent.yaml
+++ b/openstack/neutron-hypervisor-agents/templates/daemonset-openvswitch-agent.yaml
@@ -52,9 +52,17 @@ spec:
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
-          command:
-          - neutron-openvswitch-agent
+          command: ["dumb-init", "/bin/bash", "-c"]
+          args:
+            - |
+              set -xe
+              export OS_OVS__BRIDGE_MAPPINGS="${HOSTNAME/*-}:br-ex"
+              exec neutron-openvswitch-agent
           env:
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: BUILDING_BLOCK
               valueFrom:
                 fieldRef:

--- a/openstack/neutron-hypervisor-agents/templates/daemonset-ovn-controller.yaml
+++ b/openstack/neutron-hypervisor-agents/templates/daemonset-ovn-controller.yaml
@@ -46,10 +46,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            - name: BUILDING_BLOCK
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.labels['kubernetes.metal.cloud.sap/bb']
             - name: HOST_IP
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
Using the label requires the label injector to work, but since we have now stable hostnames, we can rely on the name convention.

Still, the ovn controller needs access to the AVAILABILITY_ZONE.