### PR TITLE
[barbican]: Return 404 for favicon.ico requests

### DIFF
--- a/openstack/barbican/templates/ingress.yaml
+++ b/openstack/barbican/templates/ingress.yaml
@@ -18,6 +18,15 @@ metadata:
     disco: "true"
   {{- end }}
   {{- include "utils.linkerd.ingress_annotation" . | indent 4 }}
+    # Return 404 for favicon.ico requests to prevent Pecan content-type errors
+    # Browsers automatically request /favicon.ico which triggers:
+    # "Controller 'on_get' does not support content_type 'image/vnd.microsoft.icon'"
+    nginx.ingress.kubernetes.io/server-snippet: |
+      location = /favicon.ico {
+        return 404;
+        access_log off;
+        log_not_found off;
+      }
 spec:
   tls:
      - secretName: tls-{{ include "barbican_api_endpoint_host_public" . | replace "." "-" }}


### PR DESCRIPTION
Browsers automatically request /favicon.ico which causes Pecan framework to generate content-type errors:
'Controller on_get does not support content_type image/vnd.microsoft.icon'

This is because Pecan guesses content type from file extensions and Barbican's VersionsController only allows application/json and application/json-home content types.

Adding nginx server-snippet to return 404 for /favicon.ico requests prevents these errors from cluttering the logs.

Change-Id: I1624F460B8A7408D87F5998416D0E62E