### PR TITLE
[glance] Convert migration job to Helm hook with static name

### DIFF
--- a/openstack/glance/Chart.yaml
+++ b/openstack/glance/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: flamingo
 description: A Helm chart Openstack Glance
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Glance/OpenStack_Project_Glance_vertical.png
 name: glance
-version: 0.8.4
+version: 0.8.5
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/glance/templates/deployment.yaml
+++ b/openstack/glance/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
       {{ include "utils.proxysql.pod_settings" . | indent 6 }}
       {{- tuple . (dict "name" "glance") | include "utils.topology.constraints" | indent 6 }}
       initContainers:
-      {{- tuple . (dict "jobs" (tuple . "migration-job" | include "job_name") "service" (include "glance.service_dependencies" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
+      {{- tuple . (dict "jobs" (print .Release.Name "-migration-job") "service" (include "glance.service_dependencies" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       {{- if .Values.proxysql.native_sidecar }}
       {{- tuple . (add .Values.rpc_workers .Values.workers) | include "utils.proxysql.container" | indent 6 }}
       {{- end }}

--- a/openstack/glance/templates/migration-job.yaml
+++ b/openstack/glance/templates/migration-job.yaml
@@ -1,16 +1,20 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  # since this name changes with every image change, removal and creation of
-  # this Job happens on nearly every deployment. Check the helm-chart changes
-  # to see if this needs more review.
-  name: {{ tuple . "migration-job" | include "job_name" }}
+  name: {{ .Release.Name }}-migration-job
   labels:
     app: {{ template "name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     component: glance
+    # hooks are not annotated as belonging to the Helm release, so we cannot rely on owner-info injection
+    ccloud/support-group: containers
+    ccloud/service: glance
+  annotations:
+    "helm.sh/hook": "post-install,pre-upgrade"
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   template:
     metadata:

--- a/openstack/glance/templates/secrets.yaml
+++ b/openstack/glance/templates/secrets.yaml
@@ -9,6 +9,12 @@ metadata:
     heritage: "{{ .Release.Service }}"
     type: api
     component: glance
+  annotations:
+    # this secret is needed by the migration job, so it needs to be a
+    # pre-upgrade hook with a lower weight than the migration job.
+    "helm.sh/hook": "pre-upgrade"
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
 type: Opaque
 data: 
   secrets.conf: |


### PR DESCRIPTION
The migration Job was missing an explicit selector field, causing Helm upgrade failures with --force flag. Kubernetes auto-generates a selector when not specified, but this becomes immutable after creation.

Adding an explicit selector that matches the pod template labels (release_name, application, component) ensures consistent behavior during upgrades.

Fixes: spec.selector: Required value error during helm upgrade