### PR TITLE
feat(elektra): add SSO strict mode and password sync-only env vars

### DIFF
--- a/openstack/elektra/templates/_env.tpl
+++ b/openstack/elektra/templates/_env.tpl
@@ -33,6 +33,10 @@
   valueFrom: { secretKeyRef:    { name: elektra-secrets, key: app_cred_secret, optional: true } }
 - name: MONSOON_OPENSTACK_AUTH_API_DOMAIN
   value: {{ .Values.monsoon_openstack_auth_api_domain | quote }}
+- name: MONSOON_OPENSTACK_SSO_STRICT_MODE
+  value: {{ .Values.monsoon_openstack_sso_strict_mode | quote }}
+- name: MONSOON_OPENSTACK_PASSWORD_SYNC_ONLY
+  value: {{ .Values.monsoon_openstack_password_sync_only | quote }}
 - name: TWO_FACTOR_AUTHENTICATION
   value: {{ .Values.two_factor_authentication | quote }}
 - name: TWO_FACTOR_RADIUS_SERVERS

--- a/openstack/elektra/values.yaml
+++ b/openstack/elektra/values.yaml
@@ -24,6 +24,8 @@ monsoon_openstack_auth_api_userid: dashboard
 monsoon_openstack_auth_api_domain: Default
 two_factor_authentication: "off"
 two_factor_auth_domains: "hcp03,cp,s4,wbs,fsn"
+monsoon_openstack_sso_strict_mode: "false"
+monsoon_openstack_password_sync_only: "false"
 # When to delete old cache entries every day
 cache_cleanup_time: "0415" #4:15 UTC
 


### PR DESCRIPTION
## Summary

Add `MONSOON_OPENSTACK_SSO_STRICT_MODE` and `MONSOON_OPENSTACK_PASSWORD_SYNC_ONLY`
environment variables to the Elektra Helm chart.

- Both default to `"false", no change in current behavior for any region
- Per-region values are controlled via secrets

Refs: [SAP-cloud-infrastructure/elektra#1972](https://github.com/SAP-cloud-infrastructure/elektra/pull/1972) 