### PR TITLE
bump cert manager

### DIFF
--- a/system/kube-system-admin-k3s/Chart.lock
+++ b/system/kube-system-admin-k3s/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 2.0.13
 - name: cert-manager
   repository: https://charts.jetstack.io
-  version: v1.13.3
+  version: v1.20.1
 - name: digicert-issuer
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.8.0
@@ -41,5 +41,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 1.2.0
-digest: sha256:354b845c0512964131f7ada6d6c0ed9700764ebc7173c00e213c0c8b4e01bad3
-generated: "2026-04-02T10:14:48.864017908Z"
+digest: sha256:ffd78153571a6e602a56f0d56b94b02015dc48508d9e9e1265287529a90aa881
+generated: "2026-04-10T10:04:50.470237+02:00"

--- a/system/kube-system-admin-k3s/Chart.yaml
+++ b/system/kube-system-admin-k3s/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kube-System relevant Service collection for the new admin clusters.
 name: kube-system-admin-k3s
-version: 3.6.4
+version: 3.6.5
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-admin-k3s
 dependencies:
   - name: node-problem-detector
@@ -22,7 +22,7 @@ dependencies:
     version: ">= 0.0.0"
   - name: cert-manager
     repository: https://charts.jetstack.io
-    version: 1.13.3
+    version: 1.20.1
   - name: digicert-issuer
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^2.x"

--- a/system/kube-system-kubernikus/Chart.lock
+++ b/system/kube-system-kubernikus/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: cc-rbac
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.3.6
+  version: 0.3.7
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx
   version: 4.14.3
@@ -13,7 +13,7 @@ dependencies:
   version: 8.0.0
 - name: cert-manager
   repository: https://charts.jetstack.io
-  version: v1.13.3
+  version: v1.20.1
 - name: digicert-issuer
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.8.0
@@ -25,7 +25,7 @@ dependencies:
   version: 2.0.0
 - name: ldap-named-user
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.2.8
+  version: 0.2.9
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
@@ -41,5 +41,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 1.2.0
-digest: sha256:4d0eb4b8f1784f7a906e3634d265f3a645ad25a4de976db827599724fba09e04
-generated: "2026-03-13T14:10:12.364757+02:00"
+digest: sha256:79f18d4bf269d7c103bbc95914917df6037f58afe4bdd938590f456a7ae19199
+generated: "2026-04-10T10:05:16.829054+02:00"

--- a/system/kube-system-kubernikus/Chart.yaml
+++ b/system/kube-system-kubernikus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for Kubernikus control-plane clusters.
 name: kube-system-kubernikus
-version: 3.9.3
+version: 3.9.4
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-kubernikus
 dependencies:
   - name: cc-rbac
@@ -19,7 +19,7 @@ dependencies:
     version: 8.0.0
   - name: cert-manager
     repository: https://charts.jetstack.io
-    version: 1.13.3
+    version: 1.20.1
   - name: digicert-issuer
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^2.x"

--- a/system/kube-system-metal/Chart.lock
+++ b/system/kube-system-metal/Chart.lock
@@ -22,7 +22,7 @@ dependencies:
   version: 0.0.9
 - name: cert-manager
   repository: https://charts.jetstack.io
-  version: v1.13.3
+  version: v1.20.1
 - name: digicert-issuer
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.8.0
@@ -77,5 +77,5 @@ dependencies:
 - name: validating-admission-policy
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.0.2
-digest: sha256:ac4b54ab2ed031640306ea8b1e843b85ba3984d1239bc15fa72f378b04e74099
-generated: "2026-03-25T08:26:00.016878789Z"
+digest: sha256:87d777c0f5e0068f1aeeb348241bec7184b0f9e8a55f1af9ae7ec49bba0d416b
+generated: "2026-04-10T10:06:54.478031+02:00"

--- a/system/kube-system-metal/Chart.yaml
+++ b/system/kube-system-metal/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for metal clusters.
 name: kube-system-metal
-version: 6.13.4
+version: 6.13.5
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-metal
 dependencies:
   - name: cc-rbac
@@ -30,7 +30,7 @@ dependencies:
     version: "^0.x"
   - name: cert-manager
     repository: https://charts.jetstack.io
-    version: 1.13.3
+    version: 1.20.1
   - name: digicert-issuer
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^2.x"

--- a/system/kube-system-scaleout/Chart.lock
+++ b/system/kube-system-scaleout/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: cc-rbac
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.3.6
+  version: 0.3.7
 - name: ccauth
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.8
@@ -19,7 +19,7 @@ dependencies:
   version: 8.0.0
 - name: cert-manager
   repository: https://charts.jetstack.io
-  version: v1.13.3
+  version: v1.20.1
 - name: digicert-issuer
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.8.0
@@ -31,7 +31,7 @@ dependencies:
   version: 2.0.0
 - name: ldap-named-user
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.2.8
+  version: 0.2.9
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
@@ -47,5 +47,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 1.2.0
-digest: sha256:8f31a33834069bc566e7e0be3f45128777dcdc58fb7a7597b9f664da7dee0a31
-generated: "2026-03-13T14:10:50.643278+02:00"
+digest: sha256:d9897af347aabf700bcc308a66ccc7b7e5e19f53c1527553018d38cc8db0d342
+generated: "2026-04-10T10:07:20.742844+02:00"

--- a/system/kube-system-scaleout/Chart.yaml
+++ b/system/kube-system-scaleout/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kube-System relevant Service collection for scaleout clusters.
 name: kube-system-scaleout
-version: 5.11.3
+version: 5.11.4
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-scaleout
 dependencies:
   - name: cc-rbac
@@ -28,7 +28,7 @@ dependencies:
     version: 8.0.0
   - name: cert-manager
     repository: https://charts.jetstack.io
-    version: 1.13.3
+    version: 1.20.1
   - name: digicert-issuer
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^2.x"

--- a/system/kube-system-virtual/Chart.lock
+++ b/system/kube-system-virtual/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: cc-rbac
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.3.6
+  version: 0.3.7
 - name: kube-flannel
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.2
@@ -25,7 +25,7 @@ dependencies:
   version: 3.1.8
 - name: cert-manager
   repository: https://charts.jetstack.io
-  version: v1.13.3
+  version: v1.20.1
 - name: digicert-issuer
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.8.0
@@ -56,5 +56,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 1.2.0
-digest: sha256:88e6126845c65f8ec7bf49eb07205da04a217ced3aca29c11efcc621097b23e5
-generated: "2026-03-18T13:11:31.893176+02:00"
+digest: sha256:c6daccbc17a68a8c83c86c21cb0ec7f6a1d3c9331be719d4165979d242c6e32a
+generated: "2026-04-10T10:08:48.177187+02:00"

--- a/system/kube-system-virtual/Chart.yaml
+++ b/system/kube-system-virtual/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for virtual clusters.
 name: kube-system-virtual
-version: 4.8.4
+version: 4.8.5
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-virtual
 dependencies:
   - name: cc-rbac
@@ -30,7 +30,7 @@ dependencies:
     version: '>= 0.0.0'
   - name: cert-manager
     repository: https://charts.jetstack.io
-    version: 1.13.3
+    version: 1.20.1
   - name: digicert-issuer
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^2.x"


### PR DESCRIPTION
## Breaking changes

**1.14**
The startupapicheck job uses a new OCI image called "startupapicheck", instead of the ctl image. If you run in an environment in which images cannot be pulled, be sure to include the new image.
The KeyUsage and BasicConstraints extensions will now be encoded as critical in the CertificateRequest's CSR blob
  **1.16**
Helm schema validation may reject your existing Helm values files if they contain typos or unrecognized fields.
Venafi Issuer may fail to renew certificates if the requested duration conflicts with the CA’s minimum or maximum policy settings in Venafi.
Venafi Issuer may fail to renew Certificates if the issuer has been configured for TPP with username-password authentication.
