### PR TITLE
bump cert manager admin k3s

### DIFF
--- a/system/kube-system-admin-k3s/Chart.lock
+++ b/system/kube-system-admin-k3s/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 2.0.13
 - name: cert-manager
   repository: https://charts.jetstack.io
-  version: v1.13.3
+  version: v1.20.1
 - name: digicert-issuer
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.8.0
@@ -41,5 +41,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 1.2.0
-digest: sha256:354b845c0512964131f7ada6d6c0ed9700764ebc7173c00e213c0c8b4e01bad3
-generated: "2026-04-02T10:14:48.864017908Z"
+digest: sha256:ffd78153571a6e602a56f0d56b94b02015dc48508d9e9e1265287529a90aa881
+generated: "2026-04-10T10:04:50.470237+02:00"

--- a/system/kube-system-admin-k3s/Chart.yaml
+++ b/system/kube-system-admin-k3s/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kube-System relevant Service collection for the new admin clusters.
 name: kube-system-admin-k3s
-version: 3.6.4
+version: 3.6.5
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-admin-k3s
 dependencies:
   - name: node-problem-detector
@@ -22,7 +22,7 @@ dependencies:
     version: ">= 0.0.0"
   - name: cert-manager
     repository: https://charts.jetstack.io
-    version: 1.13.3
+    version: 1.20.1
   - name: digicert-issuer
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^2.x"

--- a/system/kube-system-admin-k3s/values.yaml
+++ b/system/kube-system-admin-k3s/values.yaml
@@ -57,7 +57,7 @@ cert-manager:
       - --leader-elect=false
   startupapicheck:
     image:
-      repository: keppel.global.cloud.sap/ccloud-quay-mirror/jetstack/cert-manager-ctl
+      repository: keppel.global.cloud.sap/ccloud-quay-mirror/jetstack/cert-manager-startupapicheck
   ingressShim:
     defaultIssuerName: digicert-issuer
     defaultIssuerKind: ClusterIssuer


### PR DESCRIPTION
1.14
The startupapicheck job uses a new OCI image called "startupapicheck", instead of the ctl image. If you run in an environment in which images cannot be pulled, be sure to include the new image.
The KeyUsage and BasicConstraints extensions will now be encoded as critical in the CertificateRequest's CSR blob
  1.16
Helm schema validation may reject your existing Helm values files if they contain typos or unrecognized fields.
Venafi Issuer may fail to renew certificates if the requested duration conflicts with the CA’s minimum or maximum policy settings in Venafi.
Venafi Issuer may fail to renew Certificates if the issuer has been configured for TPP with username-password authentication.