### PR TITLE
fix regex pattern and linting errors

### DIFF
--- a/system/audit-logs-otel/templates/audit-logs-collector.yaml
+++ b/system/audit-logs-otel/templates/audit-logs-collector.yaml
@@ -273,13 +273,14 @@ spec:
               - set(log.attributes["log.kind"], "cadf_action") where IsMatch(log.attributes["msg"], "^\\s*cadf action for '")
               - set(log.attributes["log.kind"], "target_type_uri") where IsMatch(log.attributes["msg"], "^\\s*target type URI of requests '")
               - set(log.attributes["log.kind"], "authentication") where IsMatch(log.attributes["msg"], "^\\s*Authenticating")
-              - set(log.attributes["log.kind"], "failed_authentication") where IsMatch(log.attributes["msg"], "^\\s*Authorization failed. The request you have made requires authentication. from %{IP:ip}%{GREEDYDATA}")
+              - set(log.attributes["log.kind"], "failed_authentication") where IsMatch(log.attributes["msg"], "^\\s*Authorization failed. The request you have made requires authentication. from [0-9a-fA-F\\.:]+")
               - set(log.attributes["log.kind"], "keystone.exception.UserNotFound") where IsMatch(log.attributes["msg"], "keystone\\.exception\\.UserNotFound")
               - merge_maps(log.attributes,ExtractGrokPatterns(log.attributes["msg"],"^\\s*cadf action for '%{NOTSPACE:request.method} %{URIPATH:uri}' is '%{NOTSPACE:action}' %{GREEDYDATA}",true),"upsert") where log.attributes["log.kind"] == "cadf_action"
               - merge_maps(log.attributes,ExtractGrokPatterns(log.attributes["msg"],"^\\s*target type URI of requests '%{NOTSPACE:request.method} %{URIPATH:uri}' is '%{NOTSPACE:target.type_uri}' %{GREEDYDATA}",true),"upsert") where log.attributes["log.kind"] == "target_type_uri"
               - merge_maps(log.attributes,ExtractGrokPatterns(log.attributes["msg"],"^\\s*Authenticating %{NOTSPACE:user.id}@%{NOTSPACE:project.domain.name}\\.\\.",true),"upsert") where log.attributes["log.kind"] == "authentication"
               - merge_maps(log.attributes,ExtractGrokPatterns(log.attributes["msg"],"^\\s*Authorization failed. The request you have made requires authentication. from %{IP:ip}%{GREEDYDATA}",true),"upsert") where log.attributes["log.kind"] == "failed_authentication"
-              - merge_maps(log.attributes,ExtractGrokPatterns(log.attributes["msg"],"^\\s*Could not find user: %{NOTSPACE:user.id}\\.",true),"upsert") where log.attributes["log.kind"] == "keystone.exception.UserNotFound"
+              - |
+                merge_maps(log.attributes,ExtractGrokPatterns(log.attributes["msg"],"^\\s*Could not find user: %{NOTSPACE:user.id}\\.",true),"upsert") where log.attributes["log.kind"] == "keystone.exception.UserNotFound"
               - delete_key(log.attributes, "timestamp_date")
               - delete_key(log.attributes, "timestamp_time")
 


### PR DESCRIPTION
fixing:
- IsMatch only supports regex pattern, but grok patterns were used 
- Linter interprets `[...] user:` in line 282 as an object declaration instead of grok pattern.