### PR TITLE
run ct link against whole repo

### DIFF
--- a/.github/workflows/check-chart-version.yaml
+++ b/.github/workflows/check-chart-version.yaml
@@ -77,7 +77,7 @@ jobs:
           FAILED=0
           for chart in $CHARTS_TO_CHECK; do
             echo "Checking version increment for: $chart"
-            if ! ct lint --lint-conf ci/lintconf.yaml --config ci/config.yaml --target-branch ${{ github.base_ref }} --charts "$chart" --check-version-increment --skip-helm-dependencies 2>&1; then
+            if ! ct lint --lint-conf ci/lintconf.yaml --config ci/config.yaml --target-branch ${{ github.base_ref }} --check-version-increment --skip-helm-dependencies 2>&1; then
               echo "❌ Version check failed for: $chart"
               FAILED=1
             fi


### PR DESCRIPTION
Running ct link against whole repo should be fine since we would return 0 if chart is not owned by needed team.