### PR TITLE
glance: enable ccroot user for mariadb

### DIFF
--- a/openstack/glance/values.yaml
+++ b/openstack/glance/values.yaml
@@ -142,6 +142,8 @@ mariadb:
     name: db-glance-pvclaim
   databases:
   - glance
+  ccroot_user:
+    enabled: true
   users:
     glance:
       name: glance


### PR DESCRIPTION
Enable the `ccroot` user to simplify manual database access for development and troubleshooting, e.g., via `ccloud_multitool dbcli`.