### PR TITLE
nova-hypervisor-agents: Wait for certificate

### DIFF
--- a/openstack/nova-hypervisor-agents/templates/hypervisors-kvm-daemonset.yaml
+++ b/openstack/nova-hypervisor-agents/templates/hypervisors-kvm-daemonset.yaml
@@ -26,6 +26,7 @@ spec:
         configmap-etc-hash: {{ include (print .Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
         configmap-kvm-etc-hash: {{ include "kvm_configmap" . | sha256sum }}
     spec:
+      serviceAccountName: {{ .Values.hypervisorAgentsServiceAccountName | default .Release.name }}
       terminationGracePeriodSeconds: {{ $hypervisor.default.graceful_shutdown_timeout | default .Values.defaults.default.graceful_shutdown_timeout | add 5 }}
       hostNetwork: true
       hostPID: true
@@ -55,6 +56,21 @@ spec:
           - {{ include "nova.helpers.cell_rabbitmq_host" (tuple $ $activeCell) }}
       {{- end }}
       initContainers:
+      - name: kubernetes-entrypoint
+        image: {{ .Values.global.ghcrIoMirror }}/sapcc/kubernetes-entrypoint:{{ .Values.imageVersionKubernetesEntrypoint }}
+        command:
+        - kubernetes-entrypoint
+        env:
+        - name: COMMAND
+          value: "true"
+        - name: POD_NAME
+          valueFrom: {fieldRef: {fieldPath: metadata.name}}
+        - name: NAMESPACE
+          valueFrom: {fieldRef: {fieldPath: metadata.namespace}}
+        - name: NODE_NAME
+          valueFrom: {fieldRef: {fieldPath: spec.nodeName}}
+        - name: DEPENDENCY_CUSTOM_RESOURCE
+          value: '[{"apiVersion":"kvm.cloud.sap/v1","kind":"Hypervisor","name":"$(NODE_NAME)","fields":[{"key":".status.conditions[?(@.type==\"TLSCertificateInstalled\")].status","value":"True"}]}]'
       - name: nova-compute-init
         image: {{ required ".Values.global.registry is missing" .Values.global.registry }}/{{ .Values.imageName }}:{{ .Values.imageVersion | required "Please set imageVersion similar" }}
         command: ["/container.init/nova-compute-init"]

--- a/openstack/nova-hypervisor-agents/templates/nova-hypervisor-agent-cr.yaml
+++ b/openstack/nova-hypervisor-agents/templates/nova-hypervisor-agent-cr.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.hypervisorAgentsServiceAccountName | default .Release.name }}
+rules:
+- apiGroups: ["kvm.cloud.sap"]
+  resources: ["hypervisors"]
+  verbs: ["get", "watch", "list"]

--- a/openstack/nova-hypervisor-agents/templates/nova-hypervisor-agent-rb.yaml
+++ b/openstack/nova-hypervisor-agents/templates/nova-hypervisor-agent-rb.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.hypervisorAgentsServiceAccountName | default .Release.name }}
+  namespace: {{ .Release.Namespace }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.hypervisorAgentsServiceAccountName | default .Release.name }}
+roleRef:
+  kind: Role
+  name: {{ .Values.hypervisorAgentsServiceAccountName | default .Release.name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.hypervisorAgentsServiceAccountName | default .Release.name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.hypervisorAgentsServiceAccountName | default .Release.name }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.hypervisorAgentsServiceAccountName | default .Release.name }}

--- a/openstack/nova-hypervisor-agents/templates/nova-hypervisor-agent-role.yaml
+++ b/openstack/nova-hypervisor-agents/templates/nova-hypervisor-agent-role.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.hypervisorAgentsServiceAccountName | default .Release.name }}
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["pods"]
+  verbs: ["get", "watch", "list"]

--- a/openstack/nova-hypervisor-agents/templates/nova-hypervisor-agent-sa.yaml
+++ b/openstack/nova-hypervisor-agents/templates/nova-hypervisor-agent-sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.hypervisorAgentsServiceAccountName | default .Release.name }}
+

--- a/openstack/nova-hypervisor-agents/values.yaml
+++ b/openstack/nova-hypervisor-agents/values.yaml
@@ -11,9 +11,13 @@ rabbitmq_ssl_client: true
 
 imageName: loci-nova
 imageVersion: null
+imageVersionKubernetesEntrypoint: "latest"
+
 hypervisor_on_host: true
 
 cross_az_attach: 'False'
+
+hypervisorAgentsServiceAccountName: null
 
 default:
   password_all_group_samples: 2


### PR DESCRIPTION
We have a potential race between the compute agent trying to connect to the libvirt socket, which in turn would trigger the start of libvirt and the provisioing of the TLS certificates.

Without this check, either we prematurely start the service without having TLS certificates installed, or we crashloop because libvirt could not be started due to the missing TLS certificates (depending on how libvirt is configured).

By waiting for the certificate to be deployed, we model that dependency explicitly hopefully making it easier to identify the problem.