### PR TITLE
[archer] Add pgmetrics custom metrics and alerts

### DIFF
--- a/openstack/archer/alerts/openstack.alerts
+++ b/openstack/archer/alerts/openstack.alerts
@@ -13,3 +13,29 @@ groups:
     annotations:
       description: 'Archer agent for {{ $labels.cloud_sap_host }} has failed sync loops > 5m.'
       summary: 'Archer agent for {{ $labels.cloud_sap_host }} has failed sync loops > 5m.'
+
+  - alert: archer-agent-stale
+    expr: archer_agents_heartbeat_age_seconds{enabled="true"} > 300
+    for: 5m
+    labels:
+      context: availability
+      service: archer
+      severity: warning
+      tier: os
+      support_group: containers
+    annotations:
+      description: 'Archer agent {{ $labels.host }} has not sent a heartbeat for more than 5 minutes.'
+      summary: 'Archer agent {{ $labels.host }} is stale.'
+
+  - alert: archer-health-scrape-failures
+    expr: sum by (cloud_sap_host)(rate(archer_job_processed{name="HealthScrapeLoop",outcome="fail"}[5m])) > 0
+    for: 5m
+    labels:
+      context: availability
+      service: archer
+      severity: warning
+      tier: os
+      support_group: containers
+    annotations:
+      description: 'Archer agent for {{ $labels.cloud_sap_host }} has failed health scrape loops > 5m.'
+      summary: 'Archer agent for {{ $labels.cloud_sap_host }} has health scrape failures.'

--- a/openstack/archer/values.yaml
+++ b/openstack/archer/values.yaml
@@ -36,7 +36,70 @@ pgmetrics:
   alerts:
     support_group: containers
   databases:
-    archer: {}
+    archer:
+      customMetrics:
+        archer_services:
+          query: >
+            SELECT
+              COALESCE(status, 'none') AS status,
+              COALESCE(provider, 'none') AS provider,
+              COALESCE(health_status, 'none') AS health_status,
+              COUNT(*) AS gauge
+            FROM service
+            GROUP BY status, provider, health_status
+            UNION SELECT 'none', 'none', 'none', 0
+          metrics:
+            - status:
+                usage: "LABEL"
+                description: "Service status"
+            - provider:
+                usage: "LABEL"
+                description: "Service provider (tenant/cp)"
+            - health_status:
+                usage: "LABEL"
+                description: "Service health status"
+            - gauge:
+                usage: "GAUGE"
+                description: "Total number of services"
+
+        archer_endpoints:
+          query: >
+            SELECT
+              COALESCE(status, 'none') AS status,
+              COUNT(*) AS gauge
+            FROM endpoint
+            GROUP BY status
+            UNION SELECT 'none', 0
+          metrics:
+            - status:
+                usage: "LABEL"
+                description: "Endpoint status"
+            - gauge:
+                usage: "GAUGE"
+                description: "Total number of endpoints"
+
+        archer_agents:
+          query: >
+            SELECT
+              COALESCE(host, 'none') AS host,
+              COALESCE(provider, 'none') AS provider,
+              enabled::text AS enabled,
+              COALESCE(EXTRACT(epoch FROM (now() - heartbeat_at)), 0) AS heartbeat_age_seconds
+            FROM agents
+            UNION SELECT 'none', 'none', 'false', 0
+          metrics:
+            - host:
+                usage: "LABEL"
+                description: "Agent host"
+            - provider:
+                usage: "LABEL"
+                description: "Agent provider"
+            - enabled:
+                usage: "LABEL"
+                description: "Agent enabled status"
+            - heartbeat_age_seconds:
+                usage: "GAUGE"
+                description: "Age in seconds since last agent heartbeat (for stale agent detection)"
 
 alerts:
   enabled: true


### PR DESCRIPTION
Add custom pgmetrics for monitoring:
- archer_services: service counts by status, provider, health_status
- archer_endpoints: endpoint counts by status
- archer_agents: per-host heartbeat age for stale agent detection

Add alerts:
- archer-agent-stale: fires when agent heartbeat is older than 5 minutes
- archer-health-scrape-failures: fires on health scrape loop failures