### PR TITLE
[persephone] feat: add volumeTypes support to OpenStack CloudProfile

### DIFF
--- a/global/cc-gardener/Chart.yaml
+++ b/global/cc-gardener/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cc-gardener
 description: Converged Cloud Gardener setup based on gardener-operator
 type: application
-version: 0.29.16
+version: 0.29.17
 appVersion: "v1.138.0"
 home: https://github.com/gardener/gardener
 dependencies:

--- a/global/cc-gardener/managedresources/cloudprofile-openstack.yaml
+++ b/global/cc-gardener/managedresources/cloudprofile-openstack.yaml
@@ -10,6 +10,9 @@ spec:
   kubernetes:
     versions: {{ toYaml .Values.extensions.kubernetesVersions | nindent 6 }}
   machineTypes: {{ toYaml .Values.extensions.openstack.machineTypes | nindent 4 }}
+  {{- if .Values.extensions.openstack.volumeTypes }}
+  volumeTypes: {{ toYaml .Values.extensions.openstack.volumeTypes | nindent 4 }}
+  {{- end }}
   machineImages: {{ toYaml .Values.extensions.openstack.machineImages | nindent 4 }}
   providerConfig: # https://github.com/gardener/gardener-extension-provider-openstack/blob/master/pkg/apis/openstack/types_cloudprofile.go
     apiVersion: openstack.provider.extensions.gardener.cloud/v1alpha1


### PR DESCRIPTION
This is needed for KVM flavors. Add conditional volumeTypes field to CloudProfile template that renders from .Values.extensions.openstack.volumeTypes if set. This allows configuring available volume types (e.g., premium, standard) for OpenStack-based shoots.

The volumeTypes section is only rendered if configured in values, maintaining backwards compatibility with existing deployments.

Changes:
- Add conditional volumeTypes to cloudprofile-openstack.yaml
- Bump chart version to 0.29.17

Example usage in values:
  extensions: openstack: volumeTypes: - name: premium class: premium usable: true - name: standard class: standard usable: true