### PR TITLE
[cc-shoots-compute] replace hard-coded channel logic with generic imageVersions map

### DIFF
--- a/system/cc-shoots-compute/ci/test-values.yaml
+++ b/system/cc-shoots-compute/ci/test-values.yaml
@@ -1,8 +1,9 @@
 global:
   region: qa-de-1
 
-imageVersion: "2025.10.0"
-preReleaseImageVersion: "2025.11.0-prerelease.3"
+imageVersions:
+  release: "2025.10.0"
+  prerelease: "2025.11.0-prerelease.3"
 
 kubernetes:
   version: 1.31.5
@@ -10,8 +11,6 @@ kubernetes:
 kvmShoots:
   test:
     region: test-1
-    imageVersion: "2025.11.0"
-    preReleaseImageVersion: "2025.12.0-prerelease.5"
     networking:
       nodes: "12.34.56.78/16"
       pods: "12.34.56.78/16"
@@ -26,8 +25,7 @@ kvmShoots:
         nodeSelector: foo == "bar"
     workers:
       test-a:
-        channel: release  # default
-        imageVersion: "2025.12.0"
+        channel: release
         poolSize: 1
         updateStrategy: AutoRollingUpdate
         inPlaceUpdateTimeout: 2h0m0s
@@ -38,8 +36,7 @@ kvmShoots:
           fooctl: "1"
           barctl: "test"
       test-b:
-        channel: preRelease
-        preReleaseImageVersion: "2026.01.0-prerelease.1"
+        channel: prerelease
         poolSize: 1
         updateStrategy: AutoRollingUpdate
         bb: test-bb

--- a/system/cc-shoots-compute/templates/kvm-shoot.yaml
+++ b/system/cc-shoots-compute/templates/kvm-shoot.yaml
@@ -155,13 +155,18 @@ spec:
     workers:
     {{- range $workerkey, $worker := $cluster.workers }}
       {{- $workerChannel := coalesce $worker.channel $cluster.channel "release" }}
-      {{- $imageVersion:= "unset" }}
-      {{- if eq $workerChannel "preRelease" }}
-      {{- $imageVersion = coalesce $worker.preReleaseImageVersion $cluster.preReleaseImageVersion $.Values.preReleaseImageVersion }}
-      {{- else if eq $workerChannel "release" }}
-      {{- $imageVersion = coalesce $worker.imageVersion $cluster.imageVersion $.Values.imageVersion }}
+      {{- $imageVersion := index $.Values.imageVersions $workerChannel }}
+      {{- if not $imageVersion }}
+      {{- if hasSuffix "-dev" $workerChannel }}
+      {{- $baseChannel := trimSuffix "-dev" $workerChannel }}
+      {{- $baseVersion := index $.Values.imageVersions $baseChannel }}
+      {{- if not $baseVersion }}
+      {{- fail (printf "worker %s: channel '%s' and base channel '%s' not found in .Values.imageVersions" $workerkey $workerChannel $baseChannel) }}
+      {{- end }}
+      {{- $imageVersion = replace "usi" "usidev" $baseVersion }}
       {{- else }}
-      {{- fail (printf "worker %s has invalid channel '%s': must be either 'release' or 'preRelease'" $workerkey $workerChannel) }}
+      {{- fail (printf "worker %s: channel '%s' not found in .Values.imageVersions" $workerkey $workerChannel) }}
+      {{- end }}
       {{- end }}
       - name: {{ $workerkey }}
         machine:
@@ -225,12 +230,12 @@ spec:
             raw: |
               storage:
                 files:
-                {{- if eq $workerChannel "preRelease" }}
+                {{- if eq $workerChannel "prerelease" }}
                 {{- if and $worker.extraIgnitionFiles ( typeIs "string" $worker.extraIgnitionFiles ) }}
                 {{- $worker.extraIgnitionFiles | nindent 16 }}
                 {{- end }}
                 {{- end }}
-                {{- if and ( eq $workerChannel "preRelease" ) $worker.defaultIgnitionFiles ( typeIs "string" $worker.defaultIgnitionFiles ) }}
+                {{- if and ( eq $workerChannel "prerelease" ) $worker.defaultIgnitionFiles ( typeIs "string" $worker.defaultIgnitionFiles ) }}
                 {{- $worker.defaultIgnitionFiles | nindent 16 }}
                 {{- else }}
 
@@ -347,12 +352,12 @@ spec:
 
               systemd:
                 units:
-                {{- if eq $workerChannel "preRelease" }}
+                {{- if eq $workerChannel "prerelease" }}
                 {{- if and $worker.extraIgnitionSystemdUnits ( typeIs "string" $worker.extraIgnitionSystemdUnits ) }}
                 {{- $worker.extraIgnitionSystemdUnits | nindent 16 }}
                 {{- end }}
                 {{- end }}
-                {{- if and ( eq $workerChannel "preRelease" ) $worker.defaultIgnitionSystemdUnits ( typeIs "string" $worker.defaultIgnitionSystemdUnits ) }}
+                {{- if and ( eq $workerChannel "prerelease" ) $worker.defaultIgnitionSystemdUnits ( typeIs "string" $worker.defaultIgnitionSystemdUnits ) }}
                 {{- $worker.defaultIgnitionSystemdUnits | nindent 16 }}
                 {{- else }}
                 - name: ovsdb-server.service

--- a/system/cc-shoots-compute/values.yaml
+++ b/system/cc-shoots-compute/values.yaml
@@ -3,3 +3,6 @@ kvmShoot: false
 networking:
   enableBirdExporter: true
   overlay: true
+
+imageVersions:
+  release: ""


### PR DESCRIPTION
Replace the two hard-coded channels (release/preRelease) with a generic imageVersions map. Channel/version resolution now looks up the channel name directly in `.Values.imageVersions`. Adding a new channel requires only a `values.yaml` entry.

`-dev` channels (e.g. `release-dev`) are derived automatically from their base channel by replacing `usi` with `usidev` in the version string; no explicit entry is needed, but an explicit entry always takes precedence.

The prerelease channel retains its existing special ignition/systemd path.