### PR TITLE
[utils] Switch to sapcc/kubernetes-entrypoint

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.32.0
+version: 0.33.0

--- a/openstack/utils/templates/snippets/_kubernetes_entrypoint.tpl
+++ b/openstack/utils/templates/snippets/_kubernetes_entrypoint.tpl
@@ -2,9 +2,9 @@
   {{- $envAll := index . 0 }}
   {{- $params := index . 1 }}
 - name: kubernetes-entrypoint
-  image: {{ $envAll.Values.global.registry }}/kubernetes-entrypoint:v0.3.1
+  image: {{ $envAll.Values.global.ghcrIoMirror }}/sapcc/kubernetes-entrypoint:{{ $envAll.Values.utils.kubernetesEntrypoint.imageVersion }}
   command:
-  - /kubernetes-entrypoint
+  - kubernetes-entrypoint
   env:
   - name: COMMAND
     value: "true"

--- a/openstack/utils/values.yaml
+++ b/openstack/utils/values.yaml
@@ -33,3 +33,7 @@ trust_bundle:
   enabled: false        # Should the trust-bundle be mounted?
   name: cloud-sap       # What is the name of the ConfigMap with the trust-bundle
   key: trust-bundle.pem # What is the key of the trust-bundle in the ConfigMap
+
+
+kubernetesEntrypoint:
+  imageVersion: "latest"


### PR DESCRIPTION
We forked kubernetes-entrypoint for a shorter turnaround time.