### PR TITLE
[manila] Bump dependencies to switch kubernetes-entrypoint

### DIFF
--- a/openstack/manila/Chart.lock
+++ b/openstack/manila/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.1.1
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.33.1
+  version: 0.34.0
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.6.0
@@ -22,9 +22,9 @@ dependencies:
   version: 0.22.1
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 2.4.23
+  version: 2.4.30
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.32.0
-digest: sha256:c4bcf191f781dc8bb80e25d7a5fa1f52cf6f5a1286df4c1fa06a930bacd5ec09
-generated: "2026-04-02T18:06:23.688218+03:00"
+  version: 0.33.0
+digest: sha256:bd38bd80dd72e2ab2329df7a54fe6fed2f100591a989ec8410bcd3d848abf2a9
+generated: "2026-04-14T16:07:39.771778189+02:00"

--- a/openstack/manila/templates/api-deployment.yaml
+++ b/openstack/manila/templates/api-deployment.yaml
@@ -83,29 +83,26 @@ spec:
           command:
           {{- if .Values.api_backdoor }}
             - dumb-init
-            - kubernetes-entrypoint
+            - manila-api
+            - --config-file
+            - /etc/manila/manila.conf
+            - --config-file
+            - /etc/manila/manila.conf.d/secrets.conf
           {{- else }}
             - /scripts/manila-api.sh
             - start
           {{- end }}
           env:
-          {{- if .Values.api_backdoor }}
-            - name: COMMAND
-              value: "manila-api --config-file /etc/manila/manila.conf --config-file /etc/manila/manila.conf.d/secrets.conf"
-          {{- else }}
+          {{- if not .Values.api_backdoor }}
             - name: OS_OSLO_MESSAGING_RABBIT__HEARTBEAT_IN_PTHREAD
               value: "true"
             - name: OS_OSLO_REPORTS__FILE_EVENT_HANDLER
               value: "/etc/manila/guru"
           {{- end }}
-            - name: NAMESPACE
-              value: {{ .Release.Namespace }}
             - name: STATSD_HOST
               value: localhost
             - name: STATSD_PORT
               value: "9125"
-            - name: DEPENDENCY_SERVICE
-              value: "{{ include "manila.api_service_dependencies" . }}"
             {{- if .Values.sentry.enabled }}
             - name: SENTRY_DSN_SSL
               valueFrom:


### PR DESCRIPTION
Also remove kubernetes-entrypoint access inside the container, so we can drop it from the image.