### PR TITLE
Addresses critical CVEs in oauth2-proxy v7.15.2:

### DIFF
--- a/global/oauth-proxy/templates/deployment.yaml
+++ b/global/oauth-proxy/templates/deployment.yaml
@@ -38,6 +38,9 @@ spec:
             - --cookie-domain={{ .Values.oauth_proxy.cookie_domain }}
             - --cookie-expire={{ .Values.oauth_proxy.cookie_expire }}
             - --oidc-email-claim=email
+            {{- range .Values.oauth_proxy.trustedProxyIPs }}
+            - --trusted-proxy-ip={{ . }}
+            {{- end }}
             {{- with .Values.oauth_proxy.metrics_address }}
             - --metrics-address={{ . }}
             {{- end }}

--- a/global/oauth-proxy/values.yaml
+++ b/global/oauth-proxy/values.yaml
@@ -4,7 +4,7 @@
 image:
   registry: quay.io
   name: oauth2-proxy/oauth2-proxy
-  tag: v7.13.0
+  tag: v7.15.2
   pullPolicy: IfNotPresent
 replica_count: 2
 
@@ -29,3 +29,4 @@ oauth_proxy:
   cookie_name: "_oauth2_proxy"
   cookie_domain: DEFINED_IN_VALUES_FILE
   cookie_expire: DEFINED_IN_VALUES_FILE
+  trustedProxyIPs: []


### PR DESCRIPTION
  - GHSA-7x63-xv5r-3p2x: auth bypass via X-Forwarded-Uri spoofing
  - GHSA-5hvv-m4w4-gf6v: health check user-agent auth bypass
  - GHSA-pxq7-h93f-9jrg: fragment evaluation bypass
  - GHSA-c5c4-8r6x-56w3: email validation bypass

  Adds --trusted-proxy-ip flag support via trustedProxyIPs value.