### PR TITLE
[Nova] Remove deprecated image values

### DIFF
--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -161,13 +161,6 @@ loci:
   nova: false
   # neutron images use loci by default
 
-#TODO we need to move to global or find another way to share image versions
-imageNameNeutron: loci-neutron
-
-imageNameOpenvswitch: loci-neutron
-imageVersionOpenvswitchVswitchd: null
-imageVersionOpenvswitchDbServer: null
-
 imageNameNova: loci-nova
 imageVersionNova: null
 imageVersionNovaApi: null


### PR DESCRIPTION
~`helm lint` requires comments to start with a space so we add a missing space.~

Removes Neutron and Open vSwitch image values since they are no longer used and additionally the related comment is causing CI pipeline failures for `helm lint`.