### PR TITLE
fix(rabbitmq): ensure erlang cookie permissions survive fsGroup application

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+## 0.22.2 - 2026/04/08
+
+- Fix erlang cookie file permissions in StatefulSet init container
+  - Remove short-circuit check in `volume-permissions` init container that skipped `chown` when uid was already 999
+  - Always run `chown -R 999:999 /var/lib/rabbitmq` and `chmod 400 .erlang.cookie` to ensure correct permissions
+  - RabbitMQ 3.11+ requires `.erlang.cookie` to be exactly `0400`; Kubernetes `fsGroup` can set it to `0440`, causing crashloops
+- Add `fsGroupChangePolicy: "OnRootMismatch"` to StatefulSet pod securityContext (already present in Deployment template)
+- Chart version bumped
+
 ## 0.22.1 - 2026/03/17
 
 - RabbitMQ [4.2.5 Release notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.2.5)

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: rabbitmq
-version: 0.22.1
+version: 0.22.2
 appVersion: 4.2.5
 description: A Helm chart for RabbitMQ
 sources:

--- a/common/rabbitmq/templates/statefulset.yaml
+++ b/common/rabbitmq/templates/statefulset.yaml
@@ -47,6 +47,7 @@ spec:
         runAsUser: 999
         runAsGroup: 999
         fsGroup: 999
+        fsGroupChangePolicy: "OnRootMismatch"
       initContainers:
       {{- if .Values.persistence.enabled }}
       - name: volume-permissions
@@ -56,7 +57,8 @@ spec:
         - /bin/sh
         - -c
         - |
-          [ $(stat -c %u /var/lib/rabbitmq) -eq 999 ] || chown -R 999:999 /var/lib/rabbitmq
+          chown -R 999:999 /var/lib/rabbitmq
+          [ -f /var/lib/rabbitmq/.erlang.cookie ] && chmod 400 /var/lib/rabbitmq/.erlang.cookie
         securityContext:
           runAsUser: 0
         volumeMounts:


### PR DESCRIPTION
## Summary
- Add `fsGroupChangePolicy: "OnRootMismatch"` to StatefulSet pod securityContext
  (already present in Deployment template)
- Always run `chown -R 999:999` and `chmod 400 .erlang.cookie` in the
  volume-permissions init container, replacing the previous short-circuit
  `stat -c %u` check

## Problem
RabbitMQ 3.11+ requires `.erlang.cookie` to be exactly `0400`. Kubernetes
`fsGroup: 999` can set group-readable bits (`0440`), causing pods to
crashloop on startup.

The previous init container logic skipped `chown` entirely when the uid
was already 999, which meant the cookie's mode was never corrected.

## Fix
1. `fsGroupChangePolicy: "OnRootMismatch"` — prevents Kubernetes from
   recursively re-applying fsGroup on every restart, which would reset
   the cookie permissions after the init container fixes them.
2. Unconditional `chown -R` + explicit `chmod 400` on `.erlang.cookie` —
   ensures correct ownership and mode on first mount and after any
   permission drift.