### PR TITLE
[neutron] Switch to sapcc/kubernetes-entrypoint fork and use init-containers

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 0.19.1
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.30.0
+  version: 0.33.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
@@ -32,5 +32,5 @@ dependencies:
 - name: ovsdb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
-digest: sha256:869402e973bc5fa6c73dfb92c5a97cc5cad67b72a189c104e0bd1e947145ff25
-generated: "2025-10-07T17:06:40.152505424+02:00"
+digest: sha256:1c5097f300029dc01d8af0250f226fcbaf5beccc7a52a45068b55f923d385e52
+generated: "2026-04-15T10:39:39.828800651+02:00"

--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -13,10 +13,10 @@ dependencies:
   version: 0.5.2
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.25.4
+  version: 0.19.1
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.38.0
+  version: 0.33.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
@@ -32,5 +32,5 @@ dependencies:
 - name: ovsdb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
-digest: sha256:62c769169f00f9608327858c6deb346b259147f9572890f8722171a002b412fd
-generated: "2026-07-02T13:16:52.794398023+02:00"
+digest: sha256:1c5097f300029dc01d8af0250f226fcbaf5beccc7a52a45068b55f923d385e52
+generated: "2026-04-15T10:39:39.828800651+02:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     version: 0.19.1
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.30.0
+    version: 0.33.0
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for Openstack Neutron
 name: neutron
-version: 0.3.6
+version: 0.3.5
 appVersion: "caracal"
 dependencies:
   - condition: mariadb.enabled
@@ -23,10 +23,10 @@ dependencies:
     version: 0.5.2
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.25.4
+    version: 0.19.1
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.38.0
+    version: 0.33.0
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0

--- a/openstack/neutron/templates/deployment-rpc-server.yaml
+++ b/openstack/neutron/templates/deployment-rpc-server.yaml
@@ -49,6 +49,7 @@ spec:
 {{ tuple . "neutron" "rpc" | include "kubernetes_pod_anti_affinity" | indent 6 }}
       {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       initContainers:
+        {{- include "utils.snippets.kubernetes_entrypoint_init_container" (list . (dict "jobs" (include "neutron.migration_job_name" .) "service" (include "neutron.service_dependencies" .))) | indent 8 }}
         {{- if .Values.proxysql.native_sidecar }}
         {{- tuple . (add .Values.rpc_workers .Values.rpc_state_workers)| include "utils.proxysql.container" | indent 8 }}
         {{- end }}
@@ -56,16 +57,40 @@ spec:
         - name: neutron-rpc-server
           image: {{.Values.global.registry}}/loci-neutron:{{.Values.imageVersionServerRPC | default .Values.imageVersionServer | default .Values.imageVersion | required "Please set neutron.imageVersion or similar"}}
           imagePullPolicy: IfNotPresent
-          command: ['dumb-init', 'kubernetes-entrypoint']
+          command:
+            - dumb-init
+            - neutron-rpc-server
+            - --config-file
+            - /etc/neutron/neutron.conf
+            - --config-dir
+            - /etc/neutron/neutron.conf.d
+            - --config-dir
+            - /etc/neutron/secrets
+            - --config-file
+            - /etc/neutron/plugins/ml2/ml2-conf.ini
+            - --config-file
+            - /etc/neutron/plugins/ml2/ml2-conf-manila.ini
+            - --config-file
+            - /etc/neutron/plugins/ml2/ml2-conf-arista.ini
+            - --config-file
+            - /etc/neutron/plugins/ml2/ml2-conf-asr1k.ini
+            {{- if .Values.bgp_vpn.enabled }}
+            - --config-file
+            - /etc/neutron/networking-bgpvpn.conf
+            {{- end }}
+            {{- if .Values.interconnection.enabled }}
+            - --config-file
+            - /etc/neutron/networking-interconnection.conf
+            {{- end }}
+            {{- if .Values.fwaas.enabled }}
+            - --config-file
+            - /etc/neutron/neutron-fwaas.ini
+            {{- end }}
+            {{- if .Values.cc_fabric.enabled }}
+            - --config-file
+            - /etc/neutron/plugins/ml2/ml2_conf_cc-fabric.ini
+            {{- end }}
           env:
-            - name: COMMAND
-              value: "neutron-rpc-server --config-file /etc/neutron/neutron.conf --config-dir /etc/neutron/neutron.conf.d --config-dir /etc/neutron/secrets --config-file /etc/neutron/plugins/ml2/ml2-conf.ini --config-file /etc/neutron/plugins/ml2/ml2-conf-manila.ini --config-file /etc/neutron/plugins/ml2/ml2-conf-arista.ini --config-file /etc/neutron/plugins/ml2/ml2-conf-asr1k.ini {{- if .Values.bgp_vpn.enabled }} --config-file /etc/neutron/networking-bgpvpn.conf{{- end }}{{- if .Values.interconnection.enabled }} --config-file /etc/neutron/networking-interconnection.conf{{- end }}{{- if .Values.fwaas.enabled }} --config-file /etc/neutron/neutron-fwaas.ini{{- end }}{{- if .Values.cc_fabric.enabled }} --config-file /etc/neutron/plugins/ml2/ml2_conf_cc-fabric.ini {{- end }}"
-            - name: NAMESPACE
-              value: {{ .Release.Namespace }}
-            - name: DEPENDENCY_JOBS
-              value: "{{ include "neutron.migration_job_name" . }}"
-            - name: DEPENDENCY_SERVICE
-              value: "{{ include "neutron.service_dependencies" . }}"
             - name: STATSD_HOST
               value: "localhost"
             - name: STATSD_PORT

--- a/openstack/neutron/templates/deployment-rpc-server.yaml
+++ b/openstack/neutron/templates/deployment-rpc-server.yaml
@@ -52,6 +52,7 @@ spec:
 {{ tuple . "neutron" "rpc" | include "kubernetes_pod_anti_affinity" | indent 6 }}
       {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       initContainers:
+        {{- include "utils.snippets.kubernetes_entrypoint_init_container" (list . (dict "jobs" (include "neutron.migration_job_name" .) "service" (include "neutron.service_dependencies" .))) | indent 8 }}
         {{- if .Values.proxysql.native_sidecar }}
         {{- tuple . (add .Values.rpc_workers .Values.rpc_state_workers)| include "utils.proxysql.container" | indent 8 }}
         {{- end }}
@@ -59,16 +60,40 @@ spec:
         - name: neutron-rpc-server
           image: {{.Values.global.registry}}/loci-neutron:{{.Values.imageVersionServerRPC | default .Values.imageVersionServer | default .Values.imageVersion | required "Please set neutron.imageVersion or similar"}}
           imagePullPolicy: IfNotPresent
-          command: ['dumb-init', 'kubernetes-entrypoint']
+          command:
+            - dumb-init
+            - neutron-rpc-server
+            - --config-file
+            - /etc/neutron/neutron.conf
+            - --config-dir
+            - /etc/neutron/neutron.conf.d
+            - --config-dir
+            - /etc/neutron/secrets
+            - --config-file
+            - /etc/neutron/plugins/ml2/ml2-conf.ini
+            - --config-file
+            - /etc/neutron/plugins/ml2/ml2-conf-manila.ini
+            - --config-file
+            - /etc/neutron/plugins/ml2/ml2-conf-arista.ini
+            - --config-file
+            - /etc/neutron/plugins/ml2/ml2-conf-asr1k.ini
+            {{- if .Values.bgp_vpn.enabled }}
+            - --config-file
+            - /etc/neutron/networking-bgpvpn.conf
+            {{- end }}
+            {{- if .Values.interconnection.enabled }}
+            - --config-file
+            - /etc/neutron/networking-interconnection.conf
+            {{- end }}
+            {{- if .Values.fwaas.enabled }}
+            - --config-file
+            - /etc/neutron/neutron-fwaas.ini
+            {{- end }}
+            {{- if .Values.cc_fabric.enabled }}
+            - --config-file
+            - /etc/neutron/plugins/ml2/ml2_conf_cc-fabric.ini
+            {{- end }}
           env:
-            - name: COMMAND
-              value: "neutron-rpc-server --config-file /etc/neutron/neutron.conf --config-dir /etc/neutron/neutron.conf.d --config-dir /etc/neutron/secrets --config-file /etc/neutron/plugins/ml2/ml2-conf.ini --config-file /etc/neutron/plugins/ml2/ml2-conf-manila.ini --config-file /etc/neutron/plugins/ml2/ml2-conf-arista.ini --config-file /etc/neutron/plugins/ml2/ml2-conf-asr1k.ini {{- if .Values.bgp_vpn.enabled }} --config-file /etc/neutron/networking-bgpvpn.conf{{- end }}{{- if .Values.interconnection.enabled }} --config-file /etc/neutron/networking-interconnection.conf{{- end }}{{- if .Values.fwaas.enabled }} --config-file /etc/neutron/neutron-fwaas.ini{{- end }}{{- if .Values.cc_fabric.enabled }} --config-file /etc/neutron/plugins/ml2/ml2_conf_cc-fabric.ini {{- end }}"
-            - name: NAMESPACE
-              value: {{ .Release.Namespace }}
-            - name: DEPENDENCY_JOBS
-              value: "{{ include "neutron.migration_job_name" . }}"
-            - name: DEPENDENCY_SERVICE
-              value: "{{ include "neutron.service_dependencies" . }}"
             - name: STATSD_HOST
               value: "localhost"
             - name: STATSD_PORT

--- a/openstack/neutron/templates/deployment-server.yaml
+++ b/openstack/neutron/templates/deployment-server.yaml
@@ -50,6 +50,7 @@ spec:
 {{ tuple . "neutron" "api" | include "kubernetes_pod_anti_affinity" | indent 6 }}
       {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       initContainers:
+        {{- include "utils.snippets.kubernetes_entrypoint_init_container" (list . (dict "jobs" (include "neutron.migration_job_name" .) "service" (include "neutron.service_dependencies" .))) | indent 8 }}
 {{- if .Values.proxysql.native_sidecar }}
 {{- if not .Values.api.uwsgi }}
         {{- tuple . (add .Values.api_workers .Values.rpc_workers .Values.rpc_state_workers) | include "utils.proxysql.container" | indent 8 }}
@@ -81,14 +82,16 @@ spec:
             initialDelaySeconds: 15
             timeoutSeconds: 5
 {{- end }}
-          command: ['dumb-init', 'kubernetes-entrypoint']
-          env:
-            - name: COMMAND
+          command:
 {{- if .Values.api.uwsgi }}
-              value: "uwsgi --ini /etc/neutron/uwsgi.ini"
+            - dumb-init
+            - uwsgi
+            - --ini
+            - /etc/neutron/uwsgi.ini
 {{- else }}
-              value: "/container.init/neutron-server-start"
+            - /container.init/neutron-server-start
 {{- end }}
+          env:
             - name: DEBUG_CONTAINER
             {{- if .Values.pod.debug.server }}
               value: "true"
@@ -99,12 +102,6 @@ spec:
             - name: OS_OSLO_MESSAGING_RABBIT__HEARTBEAT_IN_PTHREAD
               value: "true"
 {{- end }}
-            - name: NAMESPACE
-              value: {{ .Release.Namespace }}
-            - name: DEPENDENCY_JOBS
-              value: "{{ include "neutron.migration_job_name" . }}"
-            - name: DEPENDENCY_SERVICE
-              value: "{{ include "neutron.service_dependencies" . }}"
             - name: STATSD_HOST
               value: "localhost"
             - name: STATSD_PORT

--- a/openstack/neutron/templates/deployment-server.yaml
+++ b/openstack/neutron/templates/deployment-server.yaml
@@ -53,6 +53,7 @@ spec:
 {{ tuple . "neutron" "api" | include "kubernetes_pod_anti_affinity" | indent 6 }}
       {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       initContainers:
+        {{- include "utils.snippets.kubernetes_entrypoint_init_container" (list . (dict "jobs" (include "neutron.migration_job_name" .) "service" (include "neutron.service_dependencies" .))) | indent 8 }}
 {{- if .Values.proxysql.native_sidecar }}
 {{- if not .Values.api.uwsgi }}
         {{- tuple . (add .Values.api_workers .Values.rpc_workers .Values.rpc_state_workers) | include "utils.proxysql.container" | indent 8 }}
@@ -84,14 +85,16 @@ spec:
             initialDelaySeconds: 15
             timeoutSeconds: 5
 {{- end }}
-          command: ['dumb-init', 'kubernetes-entrypoint']
-          env:
-            - name: COMMAND
+          command:
 {{- if .Values.api.uwsgi }}
-              value: "uwsgi --ini /etc/neutron/uwsgi.ini"
+            - dumb-init
+            - uwsgi
+            - --ini
+            - /etc/neutron/uwsgi.ini
 {{- else }}
-              value: "/container.init/neutron-server-start"
+            - /container.init/neutron-server-start
 {{- end }}
+          env:
             - name: DEBUG_CONTAINER
             {{- if .Values.pod.debug.server }}
               value: "true"
@@ -102,12 +105,6 @@ spec:
             - name: OS_OSLO_MESSAGING_RABBIT__HEARTBEAT_IN_PTHREAD
               value: "true"
 {{- end }}
-            - name: NAMESPACE
-              value: {{ .Release.Namespace }}
-            - name: DEPENDENCY_JOBS
-              value: "{{ include "neutron.migration_job_name" . }}"
-            - name: DEPENDENCY_SERVICE
-              value: "{{ include "neutron.service_dependencies" . }}"
             - name: STATSD_HOST
               value: "localhost"
             - name: STATSD_PORT

--- a/openstack/neutron/templates/job-migration.yaml
+++ b/openstack/neutron/templates/job-migration.yaml
@@ -21,18 +21,7 @@ spec:
       restartPolicy: OnFailure
 {{ include "utils.proxysql.job_pod_settings" . | indent 6 }}
       initContainers:
-        - name: dependencies
-          image: {{.Values.global.registry}}/loci-neutron:{{default .Values.imageVersion | required "Please set neutron.imageVersion or similar"}}
-          imagePullPolicy: IfNotPresent
-          command:
-            - kubernetes-entrypoint
-          env:
-            - name: COMMAND
-              value: "true"
-            - name: NAMESPACE
-              value: {{ .Release.Namespace }}
-            - name: DEPENDENCY_SERVICE
-              value: "{{ include "neutron.db_service" . }}"
+        {{- include "utils.snippets.kubernetes_entrypoint_init_container" (list . (dict "service" (include "neutron.db_service" .))) | indent 8 }}
         {{- if .Values.proxysql.native_sidecar }}
         {{- include "utils.proxysql.container" . | indent 8 }}
         {{- end }}

--- a/openstack/neutron/templates/job-migration.yaml
+++ b/openstack/neutron/templates/job-migration.yaml
@@ -24,18 +24,7 @@ spec:
       {{- end }}
 {{ include "utils.proxysql.job_pod_settings" . | indent 6 }}
       initContainers:
-        - name: dependencies
-          image: {{.Values.global.registry}}/loci-neutron:{{default .Values.imageVersion | required "Please set neutron.imageVersion or similar"}}
-          imagePullPolicy: IfNotPresent
-          command:
-            - kubernetes-entrypoint
-          env:
-            - name: COMMAND
-              value: "true"
-            - name: NAMESPACE
-              value: {{ .Release.Namespace }}
-            - name: DEPENDENCY_SERVICE
-              value: "{{ include "neutron.db_service" . }}"
+        {{- include "utils.snippets.kubernetes_entrypoint_init_container" (list . (dict "service" (include "neutron.db_service" .))) | indent 8 }}
         {{- if .Values.proxysql.native_sidecar }}
         {{- include "utils.proxysql.container" . | indent 8 }}
         {{- end }}


### PR DESCRIPTION
Standardize on our own fork, so we can fix issues more quickly. Use the snippet for initContainer so we do not need the old kubernetes-entrypoint in the loci images.