### PR TITLE
[octavia] Switch to sapcc/kubernetes-entrypoint fork & initContainer

### DIFF
--- a/openstack/octavia/Chart.lock
+++ b/openstack/octavia/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 0.22.1
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.29.0
+  version: 0.33.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
@@ -26,5 +26,5 @@ dependencies:
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.2.19
-digest: sha256:dc036e041a20035bb5a8d77f467366ae845448b0c4af7d39a04cbac3515de817
-generated: "2026-04-02T12:19:30.608339+03:00"
+digest: sha256:b9c924da00dc39c0f63d9252d8da009421387f7ba544e5f353c25bbab179f260
+generated: "2026-04-15T14:08:55.848970805+02:00"

--- a/openstack/octavia/Chart.yaml
+++ b/openstack/octavia/Chart.yaml
@@ -32,7 +32,7 @@ dependencies:
     version: 0.22.1
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.29.0
+    version: 0.33.0
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0

--- a/openstack/octavia/templates/octavia-api-deployment.yaml
+++ b/openstack/octavia/templates/octavia-api-deployment.yaml
@@ -46,6 +46,7 @@ spec:
       {{- include "utils.proxysql.pod_settings" . | nindent 6 }}
       {{- tuple . (dict "app.kubernetes.io/name" "octavia-api") | include "utils.topology.constraints" | indent 6 }}
       initContainers:
+      {{- include "utils.snippets.kubernetes_entrypoint_init_container" (list . (dict "jobs" "octavia-migration")) | indent 6 }}
       {{- if .Values.proxysql.native_sidecar }}
       {{- include "utils.proxysql.container" . | indent 6 }}
       {{- end }}
@@ -56,15 +57,13 @@ spec:
           {{- if .Values.api_backdoor }}
           command: ["/var/lib/openstack/bin/octavia-api"]
           {{- else }}
-          command: ['dumb-init', 'kubernetes-entrypoint']
+          command:
+            - dumb-init
+            - /usr/sbin/apachectl
+            - -D
+            - FOREGROUND
           {{- end }}
           env:
-            - name: COMMAND
-              value: "/usr/sbin/apachectl -D FOREGROUND"
-            - name: DEPENDENCY_JOBS
-              value: octavia-migration
-            - name: NAMESPACE
-              value: {{ .Release.Namespace }}
             - name: PYTHONWARNINGS
               value: "ignore:Unverified HTTPS request"
             - name: REQUESTS_CA_BUNDLE

--- a/openstack/octavia/templates/octavia-housekeeping.yaml
+++ b/openstack/octavia/templates/octavia-housekeeping.yaml
@@ -33,6 +33,7 @@ spec:
     spec:
 {{ include "utils.proxysql.pod_settings" . | indent 6 }}
       initContainers:
+      {{- include "utils.snippets.kubernetes_entrypoint_init_container" (list . (dict "jobs" "octavia-migration")) | indent 6 }}
       {{- if .Values.proxysql.native_sidecar }}
       {{- include "utils.proxysql.container" . | indent 6 }}
       {{- end }}
@@ -40,7 +41,11 @@ spec:
         - name: octavia-f5-housekeeping
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-octavia:{{required "Values.imageVersion is missing" .Values.imageVersion}}
           imagePullPolicy: IfNotPresent
-          command: ['dumb-init', 'kubernetes-entrypoint']
+          command:
+            - dumb-init
+            - octavia-f5-housekeeping
+            - --config-file
+            - /etc/octavia/octavia.conf
           ports:
             - name: metrics
               containerPort: 8000
@@ -61,12 +66,6 @@ spec:
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
             {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
           env:
-            - name: COMMAND
-              value: "octavia-f5-housekeeping --config-file /etc/octavia/octavia.conf"
-            - name: DEPENDENCY_JOBS
-              value: octavia-migration
-            - name: NAMESPACE
-              value: {{ .Release.Namespace }}
             - name: PYTHONWARNINGS
               value: "ignore:Unverified HTTPS request"
             - name: REQUESTS_CA_BUNDLE

--- a/openstack/octavia/templates/octavia-migration-job.yaml
+++ b/openstack/octavia/templates/octavia-migration-job.yaml
@@ -27,17 +27,7 @@ spec:
       {{- include "utils.proxysql.job_pod_settings" . | nindent 6 }}
     {{- end }}
       initContainers:
-        - name: wait-for-dependencies
-          image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-octavia:{{required "Values.imageVersion is missing" .Values.imageVersion}}
-          imagePullPolicy: IfNotPresent
-          command: ['dumb-init', 'kubernetes-entrypoint']
-          env:
-            - name: COMMAND
-              value: "true"
-            - name: DEPENDENCY_SERVICE
-              value: {{ include "octavia.db_service" . }}
-            - name: NAMESPACE
-              value: {{ .Release.Namespace }}
+        {{- include "utils.snippets.kubernetes_entrypoint_init_container" (list . (dict "service" (include "octavia.db_service" .))) | indent 8 }}
         {{- if .Values.proxysql.native_sidecar }}
         {{- include "utils.proxysql.container" . | indent 8 }}
         {{- end }}

--- a/openstack/octavia/templates/octavia-worker-deployment.yaml
+++ b/openstack/octavia/templates/octavia-worker-deployment.yaml
@@ -42,6 +42,7 @@ spec:
       priorityClassName: critical-payload
 {{ include "utils.proxysql.pod_settings" . | indent 6 }}
       initContainers:
+      {{- include "utils.snippets.kubernetes_entrypoint_init_container" (list . (dict "jobs" "octavia-migration")) | indent 6 }}
       {{- if .Values.proxysql.native_sidecar }}
       {{- include "utils.proxysql.container" . | indent 6 }}
       {{- end }}
@@ -49,7 +50,17 @@ spec:
         - name: octavia-worker
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-octavia:{{required "Values.imageVersion is missing" .Values.imageVersion}}
           imagePullPolicy: IfNotPresent
-          command: ['dumb-init', 'kubernetes-entrypoint']
+          command:
+            - dumb-init
+            - octavia-worker
+            - --config-file
+            - /etc/octavia/octavia.conf
+            - --config-file
+            - /etc/octavia/octavia.conf.d/secrets.conf
+            - --config-file
+            - /etc/octavia/octavia-worker.conf
+            - --config-file
+            - /etc/octavia/octavia-worker-secret.conf
           ports:
             - name: metrics-worker
               containerPort: 8000
@@ -84,12 +95,6 @@ spec:
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
             {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
           env:
-            - name: COMMAND
-              value: "octavia-worker --config-file /etc/octavia/octavia.conf --config-file /etc/octavia/octavia.conf.d/secrets.conf --config-file /etc/octavia/octavia-worker.conf --config-file /etc/octavia/octavia-worker-secret.conf"
-            - name: DEPENDENCY_JOBS
-              value: octavia-migration
-            - name: NAMESPACE
-              value: {{ .Release.Namespace }}
             - name: PYTHONWARNINGS
               value: "ignore:Unverified HTTPS request"
             - name: REQUESTS_CA_BUNDLE
@@ -104,7 +109,17 @@ spec:
         - name: octavia-f5-status-manager
           image: {{required ".Values.global.registry is missing" .Values.global.registry}}/loci-octavia:{{required "Values.imageVersion is missing" .Values.imageVersion}}
           imagePullPolicy: IfNotPresent
-          command: ['dumb-init', 'kubernetes-entrypoint']
+          command:
+            - dumb-init
+            - octavia-f5-status-manager
+            - --config-file
+            - /etc/octavia/octavia.conf
+            - --config-file
+            - /etc/octavia/octavia.conf.d/secrets.conf
+            - --config-file
+            - /etc/octavia/octavia-worker.conf
+            - --config-file
+            - /etc/octavia/octavia-worker-secret.conf
           ports:
             - name: metrics-status
               containerPort: 8001
@@ -133,12 +148,6 @@ spec:
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
             {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
           env:
-            - name: COMMAND
-              value: "octavia-f5-status-manager --config-file /etc/octavia/octavia.conf --config-file /etc/octavia/octavia.conf.d/secrets.conf --config-file /etc/octavia/octavia-worker.conf --config-file /etc/octavia/octavia-worker-secret.conf"
-            - name: DEPENDENCY_JOBS
-              value: octavia-migration
-            - name: NAMESPACE
-              value: {{ .Release.Namespace }}
             - name: PYTHONWARNINGS
               value: "ignore:Unverified HTTPS request"
             - name: REQUESTS_CA_BUNDLE


### PR DESCRIPTION
Standardize on our own fork, so we can fix issues more quickly. Use the snippet for initContainer so we do not need the old kubernetes-entrypoint in the loci images.