### PR TITLE
[keystone] Switch to sapcc/kubernetes-entrypoint fork & initContainer

### DIFF
--- a/openstack/keystone/templates/_helpers.tpl
+++ b/openstack/keystone/templates/_helpers.tpl
@@ -63,6 +63,41 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
   {{- end }}
 {{- end }}
 
+{{- define "keystone.job_dependencies" }}
+  {{- if .Release.IsInstall }}
+    {{- printf "%s,%s" (tuple . "job-migration" | include "job_name") (tuple . "job-bootstrap" | include "job_name") }}
+  {{- else if .Values.run_db_migration }}
+    {{- tuple . "job-migration" | include "job_name" }}
+  {{- end }}
+{{- end }}
+
+{{/*
+kubernetes-entrypoint init container using the sapcc fork from ghcrIoMirrorAlternateRegion.
+Usage: tuple . (dict "SERVICE" "svc1,svc2" "JOBS" "job1") | include "keystone.kubernetes_entrypoint_init_container" | indent N
+Empty values are skipped so callers may pass "" for optional dependencies.
+*/}}
+{{- define "keystone.kubernetes_entrypoint_init_container" }}
+  {{- $envAll := index . 0 }}
+  {{- $params := index . 1 }}
+- name: kubernetes-entrypoint
+  image: {{ $envAll.Values.global.ghcrIoMirrorAlternateRegion | required ".Values.global.ghcrIoMirrorAlternateRegion unset " }}/sapcc/kubernetes-entrypoint:{{ $envAll.Values.imageVersionKubernetesEntrypoint | required ".Values.imageVersionKubernetesEntrypoint is unset" }}
+  command:
+  - kubernetes-entrypoint
+  env:
+  - name: COMMAND
+    value: "true"
+  - name: POD_NAME
+    valueFrom: {fieldRef: {fieldPath: metadata.name}}
+  - name: NAMESPACE
+    valueFrom: {fieldRef: {fieldPath: metadata.namespace}}
+  {{- range $k, $v := $params }}
+  {{- if $v }}
+  - name: DEPENDENCY_{{ $k | upper }}
+    value: {{ $v }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+
 {{- define "prodel_url" }}
     {{- if not (empty .Values.prodel.url) -}}
         {{- .Values.prodel.url -}}

--- a/openstack/keystone/templates/deployment-api.yaml
+++ b/openstack/keystone/templates/deployment-api.yaml
@@ -61,28 +61,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.api.terminationGracePeriodSeconds | default "30" }}
 {{ include "utils.proxysql.pod_settings" . | indent 6 }}
       initContainers:
-      - name: kubernetes-entrypoint
-        #image: quay.io/stackanetes/kubernetes-entrypoint:v0.3.1
-        image: {{ required ".Values.global.registryAlternateRegion is missing" .Values.global.registryAlternateRegion }}/{{ .Values.api.image }}:{{ required ".Values.api.imageTag is missing" .Values.api.imageTag }}
-        imagePullPolicy: {{ .Values.api.imagePullPolicy | default "IfNotPresent" | quote }}
-        command:
-          - kubernetes-entrypoint
-        env:
-        - name: NAMESPACE
-          value: {{ .Release.Namespace }}
-{{- if .Release.IsInstall }}
-        - name: DEPENDENCY_JOBS
-          value: "{{ tuple . "job-migration" | include "job_name" }},{{ tuple . "job-bootstrap" | include "job_name" }}"
-{{- else }}
-  {{- if or .Values.run_db_migration }}
-        - name: DEPENDENCY_JOBS
-          value: "{{ tuple . "job-migration" | include "job_name" }}"
-  {{- end }}
-{{- end }}
-        - name: DEPENDENCY_SERVICE
-          value: {{ include "keystone.service_dependencies" . | quote }}
-        - name: COMMAND
-          value: "true"
+      {{- tuple . (dict "SERVICE" (include "keystone.service_dependencies" .) "JOBS" (include "keystone.job_dependencies" .)) | include "keystone.kubernetes_entrypoint_init_container" | indent 6 }}
       {{- if .Values.proxysql.native_sidecar }}
       {{- include "utils.proxysql.container" . | indent 6 }}
       {{- end }}

--- a/openstack/keystone/templates/deployment-cron.yaml
+++ b/openstack/keystone/templates/deployment-cron.yaml
@@ -44,28 +44,7 @@ spec:
 {{- end }}
 {{ include "utils.proxysql.pod_settings" . | indent 6 }}
       initContainers:
-      - name: kubernetes-entrypoint
-        #image: quay.io/stackanetes/kubernetes-entrypoint:v0.3.1
-        image: {{ required ".Values.global.registryAlternateRegion is missing" .Values.global.registryAlternateRegion }}/{{ .Values.cron.image }}:{{ required ".Values.cron.imageTag is missing" .Values.cron.imageTag }}
-        imagePullPolicy: {{ .Values.api.imagePullPolicy | default "IfNotPresent" | quote }}
-        command:
-          - kubernetes-entrypoint
-        env:
-        - name: NAMESPACE
-          value: {{ .Release.Namespace }}
-{{- if .Release.IsInstall }}
-        - name: DEPENDENCY_JOBS
-          value: "{{ tuple . "job-migration" | include "job_name" }},{{ tuple . "job-bootstrap" | include "job_name" }}"
-{{- else }}
-  {{- if or .Values.run_db_migration }}
-        - name: DEPENDENCY_JOBS
-          value: "{{ tuple . "job-migration" | include "job_name" }}"
-  {{- end }}
-{{- end }}
-        - name: DEPENDENCY_SERVICE
-          value: {{ include "keystone.service_dependencies" . | quote }}
-        - name: COMMAND
-          value: "true"
+      {{- tuple . (dict "SERVICE" (include "keystone.service_dependencies" .) "JOBS" (include "keystone.job_dependencies" .)) | include "keystone.kubernetes_entrypoint_init_container" | indent 6 }}
       {{- if .Values.proxysql.native_sidecar }}
       {{- include "utils.proxysql.container" . | indent 6 }}
       {{- end }}

--- a/openstack/keystone/templates/job-bootstrap.yaml
+++ b/openstack/keystone/templates/job-bootstrap.yaml
@@ -38,6 +38,7 @@ spec:
       restartPolicy: OnFailure
       {{- include "utils.proxysql.job_pod_settings" . | indent 6 }}
       initContainers:
+      {{- tuple . (dict "SERVICE" (include "keystone.db_service" .) "JOBS" (tuple . "job-migration" | include "job_name")) | include "keystone.kubernetes_entrypoint_init_container" | indent 6 }}
       {{- if .Values.proxysql.native_sidecar }}
       {{- include "utils.proxysql.container" . | indent 6 }}
       {{- end }}
@@ -46,16 +47,9 @@ spec:
           image: {{ required ".Values.global.registryAlternateRegion is missing" .Values.global.registryAlternateRegion }}/{{ .Values.api.image }}:{{ .Values.api.imageTag }}
           imagePullPolicy: {{ default "IfNotPresent" .Values.api.imagePullPolicy | quote }}
           command:
-            - kubernetes-entrypoint
+            - bash
+            - /scripts/bootstrap
           env:
-            - name: COMMAND
-              value: "bash /scripts/bootstrap"
-            - name: NAMESPACE
-              value: {{ .Release.Namespace }}
-            - name: DEPENDENCY_SERVICE
-              value: {{ include "keystone.db_service" . | quote }}
-            - name: DEPENDENCY_JOBS
-              value: "{{ tuple . "job-migration" | include "job_name" }}"
             {{- if .Values.sentry.enabled }}
             - name: SENTRY_DSN
             {{- if .Values.sentry.dsn }}

--- a/openstack/keystone/templates/job-migration.yaml
+++ b/openstack/keystone/templates/job-migration.yaml
@@ -38,6 +38,7 @@ spec:
       restartPolicy: OnFailure
       {{- include "utils.proxysql.job_pod_settings" . | indent 6 }}
       initContainers:
+      {{- tuple . (dict "SERVICE" (include "keystone.db_service" .)) | include "keystone.kubernetes_entrypoint_init_container" | indent 6 }}
       {{- if .Values.proxysql.native_sidecar }}
       {{- include "utils.proxysql.container" . | indent 6 }}
       {{- end }}
@@ -46,14 +47,9 @@ spec:
           image: {{ required ".Values.global.registryAlternateRegion is missing" .Values.global.registryAlternateRegion }}/{{ .Values.api.image }}:{{ .Values.api.imageTag }}
           imagePullPolicy: {{ default "IfNotPresent" .Values.api.imagePullPolicy | quote }}
           command:
-            - kubernetes-entrypoint
+            - bash
+            - /scripts/db-sync
           env:
-            - name: COMMAND
-              value: "bash /scripts/db-sync"
-            - name: NAMESPACE
-              value: {{ .Release.Namespace }}
-            - name: DEPENDENCY_SERVICE
-              value: {{ include "keystone.db_service" . | quote }}
             {{- if .Values.sentry.enabled }}
             - name: SENTRY_DSN
             {{- if .Values.sentry.dsn }}

--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -1,6 +1,7 @@
 # Default values for keystone.
 # This is a YAML-formatted file.
 # Declare name/value pairs to be passed into your templates.
+imageVersionKubernetesEntrypoint: latest
 # name: value
 
 global:
@@ -50,7 +51,7 @@ federation:
 
 api:
   image: "loci-keystone"
-  #imageTag: latest
+  # imageTag: latest
 
   ## Specify a imagePullPolicy
   ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'
@@ -171,7 +172,7 @@ api:
 
 cron:
   image: "loci-keystone"
-  #imageTag: latest
+  # imageTag: latest
 
   cronSchedule: "0 3 * * *"
 
@@ -213,8 +214,8 @@ sentry:
   #     exclude_unauthorized:
   #       exception_type: "Unauthorized"
   #       rate_limit: # only report max 5 occurrences within 300 seconds
-  #         max_occurrences: 5 
-  #         time_window: 300 
+  #         max_occurrences: 5
+  #         time_window: 300
   #     invalid_credentials:
   #       message_pattern: ".*length.*exceeded.*" # python regex match in the error message
   #     ignore_jaeger_client:
@@ -240,21 +241,21 @@ services:
     x509:
       # ca: <your ca certificate>
       issuer_attribute: HTTP_SSL_CLIENT_I_DN
-      #trusted_issuer: CN=SSO_CA,O=SAP-AG,C=DE
+      # trusted_issuer: CN=SSO_CA,O=SAP-AG,C=DE
 
     disco: false
 
   public:
     scheme: http
     host: identity-3
-    #tlsCertificate:
-    #tlsKey:
+    # tlsCertificate:
+    # tlsKey:
 
   admin:
     scheme: http
     host: identity-3
-    #tlsCertificate:
-    #tlsKey:
+    # tlsCertificate:
+    # tlsKey:
 
 audit:
   central_service:
@@ -359,7 +360,7 @@ mysql_metrics:
   enabled: true
   db_name: keystone
   db_user: root
-  #db_password: DEFINED-IN-REGION-CHART
+  # db_password: DEFINED-IN-REGION-CHART
   nodeAffinity: {}
   customMetrics:
     - name: openstack_roles_total
@@ -557,7 +558,7 @@ report_invalid_password_hash:
 2fa:
   enabled: false
   replicaCount: 3
-  pollInterval: 1m #how often do we list projects
+  pollInterval: 1m # how often do we list projects
   image: 2faproxy
   imageTag: latest
   imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Standardize on our own fork, so we can fix issues more quickly. Use the sapcc/kubernetes-entrypoint image from ghcrIoMirrorAlternateRegion so we do not need the old kubernetes-entrypoint in the loci images.