### PR TITLE
[utils] use clusterDNSSearchDomain for k8s service urls

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.33.0
+version: 0.34.0

--- a/openstack/utils/templates/_hosts.tpl
+++ b/openstack/utils/templates/_hosts.tpl
@@ -3,7 +3,7 @@
 {{- end }}
 
 {{- define "svc_fqdn" -}}
-{{ .Release.Namespace }}.svc.kubernetes.{{ include "host_fqdn" . }}
+{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDNSSearchDomain | required "missing value for .Values.global.clusterDNSSearchDomain" }}
 {{- end }}
 
 {{- define "_resolve_secret" -}}
@@ -287,15 +287,6 @@ Custom DB URL for the global services using percona_cluster
 {{define "placement_api_endpoint_host_admin"}}nova-placement-api.{{ include "svc_fqdn" . }}{{end}}
 {{define "placement_api_endpoint_host_internal"}}nova-placement-api.{{ include "svc_fqdn" . }}{{end}}
 {{define "placement_api_endpoint_host_public"}}placement-3.{{ include "host_fqdn" . }}{{end}}
-
-{{define "internal_service"}}{{ $envAll := index . 0 }}{{ $service := index . 1 }}{{$service}}.{{$envAll.Release.Namespace}}.svc.kubernetes.{{$envAll.Values.global.region}}.{{$envAll.Values.global.tld}}{{ end }}
-
-{{- define "svc.password_for_user_and_service" }}
-    {{- $envAll := index . 0 }}
-    {{- $user := index . 1 }}
-    {{- $service := index . 2 }}
-    {{- tuple $envAll ( $envAll.Values.global.user_suffix | default "" | print $user ) ( tuple $envAll $service | include "internal_service" ) ("long") }}
-{{- end }}
 
 {{define "nova_console_endpoint_host_public"}}compute-console-3.{{ include "host_fqdn" . }}{{end}}
 


### PR DESCRIPTION
* use `.Values.global.clusterDNSSearchDomain` for k8s service urls, as we might use different search domain like `cluster.local` for cluster DNS in some new regions
* remove unused `internal_service` and `svc.password_for_user_and_service` functions