### PR TITLE
feat(gh-ccloud): make ingress plugins opt-in

### DIFF
--- a/system/greenhouse-ccloud/Chart.yaml
+++ b/system/greenhouse-ccloud/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: ccloud
 description: A Helm chart for the CCloud organization in Greenhouse.
 type: application
-version: 1.31.4
+version: 1.31.5

--- a/system/greenhouse-ccloud/templates/ingress-plugins.yaml
+++ b/system/greenhouse-ccloud/templates/ingress-plugins.yaml
@@ -1,4 +1,5 @@
 {{ range $plugin := .Values.ingressPlugins }}
+{{- if $plugin.enabled }}
 ---
 apiVersion: greenhouse.sap/v1alpha1
 kind: Plugin
@@ -56,4 +57,5 @@ spec:
     name:  ingress-nginx
   releaseNamespace: kube-system
   deletionPolicy: Retain
+{{- end}}
 {{- end}}


### PR DESCRIPTION
the ingress config is needed for glob perses
but the ingress plugins for migrated clusters
are redundant
