### PR TITLE
cc-gardener: set imageVector tag along with targetVersion

### DIFF
--- a/global/cc-gardener/Chart.yaml
+++ b/global/cc-gardener/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cc-gardener
 description: Converged Cloud Gardener setup based on gardener-operator
 type: application
-version: 0.29.17
+version: 0.29.18
 appVersion: "v1.138.0"
 home: https://github.com/gardener/gardener
 dependencies:

--- a/global/cc-gardener/ci/bump-image-vector.sh
+++ b/global/cc-gardener/ci/bump-image-vector.sh
@@ -5,21 +5,29 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CHART_FILE="${SCRIPT_DIR}/../Chart.yaml"
 VALUES_FILE="${SCRIPT_DIR}/../values.yaml"
 
-YQ_MAP_IMAGES='{"images":
-  [.images[] |
+YQ_MAP_IMAGES='. | ... comments="" |
+.images |=
+  (map(
     {
-     "name": .name,
-     "repository": .repository
-    }
-  ] | unique_by(.name) | sort_by(.name) | map(.repository |= (
-        sub("^europe-docker.pkg.dev/", "keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/") |
-        sub("^registry.k8s.io/", "keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/") |
-        sub("^quay.io/","keppel.global.cloud.sap/ccloud-quay-mirror/") |
-        sub("^gcr.io/", "keppel.global.cloud.sap/ccloud-gcr-mirror/") |
-        sub("^ghcr.io/", "keppel.global.cloud.sap/ccloud-ghcr-io-mirror/") |
-        sub("/gardener-project/public/", "/gardener-project/releases/")
-    ))
-}'
+      "name": .name,
+      "repository": .repository,
+      "tag": .tag,
+      "targetVersion": .targetVersion
+    } | to_entries | map(select(.value != null)) | from_entries
+  ) |
+  unique_by([.name, .tag // "", .targetVersion // ""]) |
+  sort_by(.name) |
+  group_by(.name) |
+  map(sort_by(.tag) | reverse) |
+  flatten |
+  map(.repository |= (
+    sub("^europe-docker.pkg.dev/", "keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/") |
+    sub("^registry.k8s.io/", "keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/") |
+    sub("^quay.io/","keppel.global.cloud.sap/ccloud-quay-mirror/") |
+    sub("^gcr.io/", "keppel.global.cloud.sap/ccloud-gcr-mirror/") |
+    sub("^ghcr.io/", "keppel.global.cloud.sap/ccloud-ghcr-io-mirror/") |
+    sub("/gardener-project/public/", "/gardener-project/releases/")
+  )))'
 
 # TODO:
 # public.ecr.aws -> mirror

--- a/global/cc-gardener/values.yaml
+++ b/global/cc-gardener/values.yaml
@@ -9,44 +9,81 @@ operator:
     images:
       - name: alertmanager
         repository: keppel.global.cloud.sap/ccloud-quay-mirror/prometheus/alertmanager
+        tag: v0.31.1
       - name: alpine-conntrack
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/alpine-conntrack
+        tag: "3.23.3"
       - name: alpine-iptables
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/alpine-iptables
+        tag: "3.23.3"
       - name: apiserver-proxy-sidecar
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/apiserver-proxy
+        tag: "v0.20.0"
       - name: blackbox-exporter
         repository: keppel.global.cloud.sap/ccloud-quay-mirror/prometheus/blackbox-exporter
+        tag: v0.28.0
       - name: cluster-autoscaler
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/autoscaler/cluster-autoscaler
+        tag: "v1.34.0"
+        targetVersion: ">= 1.34"
+      - name: cluster-autoscaler
+        repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/autoscaler/cluster-autoscaler
+        tag: "v1.33.0"
+        targetVersion: "1.33.x"
+      - name: cluster-autoscaler
+        repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/autoscaler/cluster-autoscaler
+        tag: "v1.32.2"
+        targetVersion: "1.32.x"
+      - name: cluster-autoscaler
+        repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/autoscaler/cluster-autoscaler
+        tag: "v1.31.0"
+        targetVersion: "1.31.x"
+      - name: cluster-autoscaler
+        repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/autoscaler/cluster-autoscaler
+        tag: "v1.30.2"
+        targetVersion: "1.30.x"
       - name: cluster-proportional-autoscaler
         repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/cpa/cluster-proportional-autoscaler
+        tag: "v1.10.3"
       - name: configmap-reloader
         repository: keppel.global.cloud.sap/ccloud-quay-mirror/prometheus-operator/prometheus-config-reloader
+        tag: v0.89.0
       - name: coredns
         repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/coredns/coredns
+        tag: "v1.14.1"
       - name: coredns-config-adapter
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/coredns-config-adapter
+        tag: "v0.4.0"
       - name: cortex
         repository: keppel.global.cloud.sap/ccloud-quay-mirror/cortexproject/cortex
+        tag: v1.20.1
       - name: dependency-watchdog
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/dependency-watchdog
+        tag: "v1.7.0"
       - name: envoy-proxy
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/3rd/envoyproxy/envoy
+        tag: "distroless-v1.37.0"
       - name: etcd
         repository: keppel.global.cloud.sap/ccloud-quay-mirror/coreos/etcd
+        tag: "v3.4.34"
       - name: etcd-druid
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/etcd-druid
+        tag: "v0.35.1"
       - name: event-logger
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/event-logger
+        tag: "v0.71.0"
       - name: fluent-bit
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/3rd/fluent-operator/fluent-bit
+        tag: "v4.2.3"
       - name: fluent-bit-plugin
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/fluent-bit-plugin
+        tag: "v1.2.0"
       - name: fluent-bit-plugin-installer
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/fluent-bit-to-vali
+        tag: "v0.71.0"
       - name: fluent-operator
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/3rd/fluent-operator/fluent-operator
+        tag: "v3.7.0"
       - name: gardenadm
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/gardenadm
       - name: gardener-admission-controller
@@ -57,10 +94,13 @@ operator:
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/controller-manager
       - name: gardener-dashboard
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/dashboard
+        tag: "1.83.8"
       - name: gardener-discovery-server
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/gardener-discovery-server
+        tag: "v0.9.0"
       - name: gardener-metrics-exporter
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/metrics-exporter
+        tag: "0.43.0"
       - name: gardener-node-agent
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/node-agent
       - name: gardener-resource-manager
@@ -73,10 +113,13 @@ operator:
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/hyperkube
       - name: ingress-default-backend
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/ingress-default-backend
+        tag: "0.25.0"
       - name: istio-istiod
         repository: keppel.global.cloud.sap/ccloud-gcr-mirror/istio-release/pilot
+        tag: "1.27.7-distroless"
       - name: istio-proxy
         repository: keppel.global.cloud.sap/ccloud-gcr-mirror/istio-release/proxyv2
+        tag: "1.27.7-distroless"
       - name: kube-apiserver
         repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/kube-apiserver
       - name: kube-controller-manager
@@ -85,70 +128,116 @@ operator:
         repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/kube-proxy
       - name: kube-rbac-proxy
         repository: keppel.global.cloud.sap/ccloud-quay-mirror/brancz/kube-rbac-proxy
+        tag: v0.21.0
       - name: kube-scheduler
         repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/kube-scheduler
       - name: kube-state-metrics
         repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/kube-state-metrics/kube-state-metrics
+        tag: v2.18.0
       - name: kubernetes-dashboard
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/3rd/kubernetesui/dashboard
+        tag: v2.7.0
       - name: kubernetes-dashboard-metrics-scraper
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/3rd/kubernetesui/metrics-scraper
+        tag: v1.0.9
       - name: machine-controller-manager
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/machine-controller-manager
+        tag: "v0.61.2"
       - name: metrics-server
         repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/metrics-server/metrics-server
+        tag: v0.8.1
+        targetVersion: ">= 1.31"
+      - name: metrics-server
+        repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/metrics-server/metrics-server
+        tag: v0.7.2
+        targetVersion: "< 1.31"
       - name: nginx-ingress-controller
         repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/ingress-nginx/controller-chroot
+        tag: "v1.14.3"
       - name: node-exporter
         repository: keppel.global.cloud.sap/ccloud-quay-mirror/prometheus/node-exporter
+        tag: v1.10.2
       - name: node-local-dns
         repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/dns/k8s-dns-node-cache
+        tag: "1.26.7"
       - name: node-problem-detector
         repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/node-problem-detector/node-problem-detector
+        tag: "v1.35.2"
+        targetVersion: ">= 1.35"
+      - name: node-problem-detector
+        repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/node-problem-detector/node-problem-detector
+        tag: "v1.34.3"
+        targetVersion: ">= 1.34"
+      - name: node-problem-detector
+        repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/node-problem-detector/node-problem-detector
+        tag: "v0.8.25"
+        targetVersion: "< 1.34"
       - name: opentelemetry-collector
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/observability/opentelemetry-collector
+        tag: "v0.0.1"
       - name: opentelemetry-operator
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/3rd/opentelemetry-operator/opentelemetry-operator
+        tag: "v0.145.0"
       - name: pause-container
         repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/pause
+        tag: "3.10"
       - name: perses
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/3rd/persesdev/perses
+        tag: "v0.53.0"
       - name: perses-operator
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/3rd/persesdev/perses-operator
+        tag: v0.2.0
       - name: plutono
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/3rd/credativ/plutono
+        tag: "v7.5.46"
       - name: plutono-data-refresher
         repository: keppel.global.cloud.sap/ccloud-quay-mirror/kiwigrid/k8s-sidecar
+        tag: "2.5.0"
       - name: prometheus
         repository: keppel.global.cloud.sap/ccloud-quay-mirror/prometheus/prometheus
+        tag: v3.9.1
       - name: prometheus-operator
         repository: keppel.global.cloud.sap/ccloud-quay-mirror/prometheus-operator/prometheus-operator
+        tag: v0.89.0
       - name: telegraf
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/telegraf-iptables
+        tag: "v0.71.0"
       - name: terminal-controller-manager
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/terminal-controller-manager
+        tag: "v0.35.0"
       - name: tune2fs
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/tune2fs
+        tag: "v0.71.0"
       - name: vali
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/3rd/credativ/vali
+        tag: "v2.2.31"
       - name: vali-curator
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/vali-curator
+        tag: "v0.71.0"
       - name: valitail
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/3rd/credativ/valitail
+        tag: "v2.2.15"
       - name: victoria-logs
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/3rd/victoriametrics/victoria-logs
+        tag: "v1.37.2"
       - name: victoria-operator
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/3rd/victoriametrics/operator
+        tag: "v0.65.0"
       - name: vpa-admission-controller
         repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/autoscaling/vpa-admission-controller
+        tag: "1.5.1"
       - name: vpa-recommender
         repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/autoscaling/vpa-recommender
+        tag: "1.5.1"
       - name: vpa-updater
         repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/autoscaling/vpa-updater
+        tag: "1.5.1"
       - name: vpn-client
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/vpn-client
+        tag: "0.47.0"
       - name: vpn-server
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/vpn-server
+        tag: "0.47.0"
   componentImageVectorOverwrites: |
     components:
       - name: etcd-druid
@@ -156,10 +245,13 @@ operator:
           images:
             - name: alpine
               repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/3rd/alpine
+              tag: "3.21.3"
             - name: etcd-backup-restore
               repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/etcdbrctl
+              tag: "v0.41.1"
             - name: etcd-wrapper
               repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/etcd-wrapper
+              tag: "v0.6.2"
 garden:
   name: garden
   # externalIP: ""
@@ -246,36 +338,98 @@ extensions:
       images:
         - name: aws-custom-route-controller
           repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/aws-custom-route-controller
+          tag: v0.15.0
         - name: aws-ipam-controller
           repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/aws-ipam-controller
+          tag: v0.10.0
         - name: aws-load-balancer-controller
           repository: public.ecr.aws/eks/aws-load-balancer-controller
+          tag: v3.0.0
         - name: cloud-controller-manager
           repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-aws/cloud-controller-manager
+          tag: v1.35.0
+          targetVersion: '>= 1.35'
+        - name: cloud-controller-manager
+          repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-aws/cloud-controller-manager
+          tag: v1.34.0
+          targetVersion: 1.34.x
+        - name: cloud-controller-manager
+          repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-aws/cloud-controller-manager
+          tag: v1.33.2
+          targetVersion: 1.33.x
+        - name: cloud-controller-manager
+          repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-aws/cloud-controller-manager
+          tag: v1.32.5
+          targetVersion: 1.32.x
+        - name: cloud-controller-manager
+          repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-aws/cloud-controller-manager
+          tag: v1.31.9
+          targetVersion: 1.31.x
+        - name: cloud-controller-manager
+          repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-aws/cloud-controller-manager
+          tag: v1.30.10
+          targetVersion: 1.30.x
         - name: csi-attacher
           repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/sig-storage/csi-attacher
+          tag: v4.11.0
         - name: csi-driver
           repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-aws/aws-ebs-csi-driver
+          tag: v1.56.0
         - name: csi-driver-efs
           repository: public.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver
+          tag: v2.3.0
         - name: csi-liveness-probe
           repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/sig-storage/livenessprobe
+          tag: v2.18.0
         - name: csi-node-driver-registrar
           repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/sig-storage/csi-node-driver-registrar
+          tag: v2.16.0
         - name: csi-provisioner
           repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/sig-storage/csi-provisioner
+          tag: v6.1.1
+          targetVersion: '>= 1.34'
+        - name: csi-provisioner
+          repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/sig-storage/csi-provisioner
+          tag: v5.3.0
         - name: csi-resizer
           repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/sig-storage/csi-resizer
+          tag: v2.1.0
+          targetVersion: '>= 1.34'
+        - name: csi-resizer
+          repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/sig-storage/csi-resizer
+          tag: v1.14.0
         - name: csi-snapshot-controller
           repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/sig-storage/snapshot-controller
+          tag: v8.5.0
         - name: csi-snapshotter
           repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/sig-storage/csi-snapshotter
+          tag: v8.5.0
         - name: csi-volume-modifier
           repository: public.ecr.aws/ebs-csi-driver/volume-modifier-for-k8s
+          tag: v0.9.2
         - name: ecr-credential-provider
           repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/extensions/ecr-credential-provider
+          tag: v1.34.1
+          targetVersion: '>= 1.34'
+        - name: ecr-credential-provider
+          repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/extensions/ecr-credential-provider
+          tag: v1.33.0
+          targetVersion: 1.33.x
+        - name: ecr-credential-provider
+          repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/extensions/ecr-credential-provider
+          tag: v1.32.0
+          targetVersion: 1.32.x
+        - name: ecr-credential-provider
+          repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/extensions/ecr-credential-provider
+          tag: v1.31.0
+          targetVersion: 1.31.x
+        - name: ecr-credential-provider
+          repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/extensions/ecr-credential-provider
+          tag: v1.30.3
+          targetVersion: 1.30.x
         - name: machine-controller-manager-provider-aws
           repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/machine-controller-manager-provider-aws
+          tag: v0.27.2
   oidcAppsController:
     version: v0.20.0
     values:
@@ -286,8 +440,10 @@ extensions:
       images:
         - name: kube-rbac-proxy-watcher
           repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/extensions/kube-rbac-proxy-watcher
+          tag: "v0.3.0"
         - name: oauth2-proxy
           repository: keppel.global.cloud.sap/ccloud-quay-mirror/oauth2-proxy/oauth2-proxy
+          tag: "v7.14.2"
     helm:
       ociRepository:
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/charts/gardener/extensions/oidc-apps-controller
@@ -304,23 +460,31 @@ extensions:
       images:
         - name: bird-exporter
           repository: keppel.global.cloud.sap/ccloud-ghcr-io-mirror/czerwonk/bird_exporter
+          tag: v1.4.5
         - name: calico-cni
           repository: keppel.global.cloud.sap/ccloud-quay-mirror/calico/cni
+          tag: v3.30.6
         - name: calico-cpa
           repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/cpa/cluster-proportional-autoscaler
+          tag: v1.10.3
         - name: calico-cpva
           repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/cpa/cpvpa
+          tag: v0.8.10
         - name: calico-kube-controllers
           repository: keppel.global.cloud.sap/ccloud-quay-mirror/calico/kube-controllers
+          tag: v3.30.6
         - name: calico-node
           repository: keppel.global.cloud.sap/ccloud-quay-mirror/calico/node
+          tag: v3.30.6
         - name: calico-typha
           repository: keppel.global.cloud.sap/ccloud-quay-mirror/calico/typha
+          tag: v3.30.6
         - name: cni-plugins
           repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/extensions/cni-plugins
           tag: v1.57.0
         - name: multus-cni
           repository: keppel.global.cloud.sap/ccloud-ghcr-io-mirror/k8snetworkplumbingwg/multus-cni
+          tag: v4.2.4
   gardenlinux:
     enabled: false
     version: v0.38.0
@@ -364,28 +528,111 @@ extensions:
       images:
         - name: cloud-controller-manager
           repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-os/openstack-cloud-controller-manager
+          tag: v1.35.0
+          targetVersion: '>= 1.35'
+        - name: cloud-controller-manager
+          repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-os/openstack-cloud-controller-manager
+          tag: v1.34.1
+          targetVersion: 1.34.x
+        - name: cloud-controller-manager
+          repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-os/openstack-cloud-controller-manager
+          tag: v1.33.1
+          targetVersion: 1.33.x
+        - name: cloud-controller-manager
+          repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-os/openstack-cloud-controller-manager
+          tag: v1.32.1
+          targetVersion: 1.32.x
+        - name: cloud-controller-manager
+          repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-os/openstack-cloud-controller-manager
+          tag: v1.31.4
+          targetVersion: 1.31.x
+        - name: cloud-controller-manager
+          repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-os/openstack-cloud-controller-manager
+          tag: v1.30.3
+          targetVersion: 1.30.x
         - name: csi-attacher
           repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/sig-storage/csi-attacher
+          tag: v4.11.0
         - name: csi-driver-cinder
           repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-os/cinder-csi-plugin
+          tag: v1.35.0
+          targetVersion: '>= 1.35'
+        - name: csi-driver-cinder
+          repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-os/cinder-csi-plugin
+          tag: v1.34.1
+          targetVersion: 1.34.x
+        - name: csi-driver-cinder
+          repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-os/cinder-csi-plugin
+          tag: v1.33.1
+          targetVersion: 1.33.x
+        - name: csi-driver-cinder
+          repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-os/cinder-csi-plugin
+          tag: v1.32.1
+          targetVersion: 1.32.x
+        - name: csi-driver-cinder
+          repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-os/cinder-csi-plugin
+          tag: v1.31.4
+          targetVersion: 1.31.x
+        - name: csi-driver-cinder
+          repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-os/cinder-csi-plugin
+          tag: v1.30.3
+          targetVersion: 1.30.x
         - name: csi-driver-manila
           repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-os/manila-csi-plugin
+          tag: v1.35.0
+          targetVersion: '>= 1.35'
+        - name: csi-driver-manila
+          repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-os/manila-csi-plugin
+          tag: v1.34.1
+          targetVersion: 1.34.x
+        - name: csi-driver-manila
+          repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-os/manila-csi-plugin
+          tag: v1.33.1
+          targetVersion: 1.33.x
+        - name: csi-driver-manila
+          repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-os/manila-csi-plugin
+          tag: v1.32.1
+          targetVersion: 1.32.x
+        - name: csi-driver-manila
+          repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-os/manila-csi-plugin
+          tag: v1.31.4
+          targetVersion: 1.31.x
+        - name: csi-driver-manila
+          repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-os/manila-csi-plugin
+          tag: v1.30.3
+          targetVersion: 1.30.x
         - name: csi-driver-nfs
           repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/sig-storage/nfsplugin
+          tag: v4.13.1
         - name: csi-liveness-probe
           repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/sig-storage/livenessprobe
+          tag: v2.18.0
         - name: csi-node-driver-registrar
           repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/sig-storage/csi-node-driver-registrar
+          tag: v2.16.0
         - name: csi-provisioner
           repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/sig-storage/csi-provisioner
+          tag: v6.1.1
+          targetVersion: '>= 1.34'
+        - name: csi-provisioner
+          repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/sig-storage/csi-provisioner
+          tag: v5.3.0
         - name: csi-resizer
           repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/sig-storage/csi-resizer
+          tag: v2.1.0
+          targetVersion: '>= 1.34'
+        - name: csi-resizer
+          repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/sig-storage/csi-resizer
+          tag: v1.14.0
         - name: csi-snapshot-controller
           repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/sig-storage/snapshot-controller
+          tag: v8.5.0
         - name: csi-snapshotter
           repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/sig-storage/csi-snapshotter
+          tag: v8.5.0
         - name: machine-controller-manager-provider-openstack
           repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/machine-controller-manager-provider-openstack
+          tag: v0.25.0
   metal:
     enabled: false
     image:
@@ -437,6 +684,7 @@ extensions:
       images:
         - name: auditlog-forwarder
           repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/auditlog-forwarder
+          tag: "v0.2.0"
     helm:
       ociRepository:
         # tag:


### PR DESCRIPTION
without this change images for a specific k8s version may be still pulled from public repos