### PR TITLE
[ceph-seed] add ccadmin role assignments

### DIFF
--- a/openstack/ceph-seed/Chart.yaml
+++ b/openstack/ceph-seed/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ceph-seed
 description: A Helm chart for Kubernetes
-version: 0.1.2
+version: 0.1.3
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/ceph-seed/templates/seed.yaml
+++ b/openstack/ceph-seed/templates/seed.yaml
@@ -7,6 +7,7 @@ spec:
   requires:
   - monsoon3/domain-default-seed
   - monsoon3/domain-ccadmin-seed
+  - monsoon3/domain-monsoon3-seed
 
   roles:
   - name: cloud_objectstore_admin
@@ -62,4 +63,11 @@ spec:
         - group: CCADMIN_DOMAIN_ADMINS
           role: objectstore_admin
         - user: db_backup@Default
+          role: objectstore_admin
+
+    - name: monsoon3
+      projects:
+      - name: cc-demo
+        role_assignments:
+        - group: MONSOON3_DOMAIN_ADMINS
           role: objectstore_admin

--- a/openstack/ceph-seed/templates/seed.yaml
+++ b/openstack/ceph-seed/templates/seed.yaml
@@ -4,6 +4,16 @@ metadata:
   name: ceph-seed
 
 spec:
+  requires:
+  - monsoon3/domain-default-seed
+  - monsoon3/domain-ccadmin-seed
+
+  roles:
+  - name: cloud_objectstore_admin
+  - name: cloud_objectstore_viewer
+  - name: objectstore_admin
+  - name: objectstore_viewer
+
   services:
     - name:        ceph
       type:        object-store-ceph
@@ -38,3 +48,18 @@ spec:
         role_assignments:
         - user: ceph-barbican@Default
           role: reader # ceph-barbican needs as minimal as possible access role, the access to keys is managed by barbican ACL
+
+    - name: ccadmin
+      projects:
+      - name: cloud_admin
+        role_assignments:
+        - group: CCADMIN_CLOUD_ADMINS
+          role: cloud_objectstore_admin
+      - name: master
+        role_assignments:
+        - group: CCADMIN_CLOUD_ADMINS
+          role: objectstore_admin
+        - group: CCADMIN_DOMAIN_ADMINS
+          role: objectstore_admin
+        - user: db_backup@Default
+          role: objectstore_admin


### PR DESCRIPTION
* Add `ccadmin` domain role assignments
* Add objectstore roles
* Add `objectstore_admin` role for `db_backup@Default` user

These roles previously were seeded by Swift chart, see https://github.com/sapcc/helm-charts/blob/master/openstack/swift/templates/seeds.yaml#L56