### PR TITLE
[neutron] Utils 0.34.0 for clusterDNSSearchDomain

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 0.19.1
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.30.0
+  version: 0.34.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
@@ -32,5 +32,5 @@ dependencies:
 - name: ovsdb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
-digest: sha256:869402e973bc5fa6c73dfb92c5a97cc5cad67b72a189c104e0bd1e947145ff25
-generated: "2025-10-07T17:06:40.152505424+02:00"
+digest: sha256:fd9448b7ab9a39fc7666a41fe5090d2e8cd8cc815229777c15a262ecaa79d933
+generated: "2026-04-16T18:21:14.531293592+02:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     version: 0.19.1
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.30.0
+    version: 0.34.0
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0


### PR DESCRIPTION
New regions might not have our default dns name schema in the k8s cluster, so we want to rely on clusterDNSSearchDomain for this.