### PR TITLE
barbican: fix P11CryptoTokenException by setting pkek_cache_limit for Luna HSM

### DIFF
--- a/openstack/barbican/templates/etc/_secrets.conf.tpl
+++ b/openstack/barbican/templates/etc/_secrets.conf.tpl
@@ -31,6 +31,8 @@ encryption_mechanism = {{ .Values.lunaclient.conn.encryption_mechanism }}
 hmac_mechanism = {{ .Values.lunaclient.conn.hmac_mechanism }}
 key_wrap_mechanism = {{ .Values.lunaclient.conn.key_wrap_mechanism }}
 aes_gcm_generate_iv = {{ .Values.lunaclient.conn.aes_gcm_generate_iv }}
+pkek_cache_ttl = {{ .Values.lunaclient.conn.pkek_cache_ttl | default 900 }}
+pkek_cache_limit = {{ .Values.lunaclient.conn.pkek_cache_limit | default 500 }}
 {{- end }}
 
 {{- if .Values.hsm.utimaco_hsm.enabled }}


### PR DESCRIPTION
## Problem

With **326 active projects** using the PKCS#11 (Luna HSM) backend, the default `pkek_cache_limit` of **100** causes constant pKEK evictions from in-memory cache. When an evicted project's pKEK is needed during a transient HSM blip, Barbican is forced to do a live HSM unwrap call which fails with:

```
WARNING barbican.plugin.crypto.p11_crypto: Reinitializing PKCS#11 library: No token was found in slot 0
ERROR barbican.api.controllers: Secret payload retrieval failure seen - please contact site administrator.
```

This is causing **~2000 errors/day** across impacted regions, affecting 2-3 projects at any given time.

## Root Cause

The `pkek_cache` is an in-memory `OrderedDict` per Barbican pod. With `pkek_cache_limit=100` (default) and 326 projects, 226 projects are always outside the cache. Any request from an uncached project requires a live HSM session to unwrap its pKEK — if the HSM is transiently unavailable at that moment, the request fails. The single retry in `_call_pkcs11` also fails since the HSM is still unavailable.

The Utimaco plugin section already had `pkek_cache_ttl` explicitly configured — the Luna `[p11_crypto_plugin]` section was missing both `pkek_cache_limit` and `pkek_cache_ttl`.

## Fix

Add `pkek_cache_limit` and `pkek_cache_ttl` to the `[p11_crypto_plugin]` section with defaults that cover the current project count (500 gives headroom above the current 326). Both values are overridable per region via `lunaclient.conn` in region values files.

## Expected Outcome

After deploying, the `Reinitializing PKCS#11 library` warnings (~2000/day) should drop significantly since no project pKEKs will be evicted under normal load.