### PR TITLE
Add alert for Thales HSM partitions free warning (Luna K7)

### DIFF
--- a/prometheus-exporters/snmp-exporter/templates/alerts-thales.yaml
+++ b/prometheus-exporters/snmp-exporter/templates/alerts-thales.yaml
@@ -102,6 +102,21 @@ spec:
         description: "THALES Client License in {{`{{ $labels.devicename }}`}} is {{`{{ $value }}`}}"
         summary: "THALES Client License in {{`{{ $labels.devicename }}`}} is {{`{{ $value }}`}}"
   
+    - alert: thalesHsmPartitionsFreeWarning
+      expr: snmp_thales_hsmPartitionsFree{hsmModel="Luna K7"} <= 3
+      for: 12h
+      labels:
+        severity: warning
+        service: barbican
+        context: thales
+        meta: "HSM {{`{{ $labels.devicename }}`}} has only {{`{{ $value }}`}} free partitions"
+        dashboard: thales
+        no_alert_on_absence: "true"
+        support_group: identity
+      annotations:
+        description: "HSM {{`{{ $labels.devicename }}`}} (Luna K7) has only {{`{{ $value }}`}} free partitions remaining. Only 3 more partitions can be created."
+        summary: "HSM {{`{{ $labels.devicename }}`}} has low free partitions ({{`{{ $value }}`}} remaining)"
+
     - alert: thalesDeviceIsUnReachable
       expr: count(up{job="scrapeConfig/infra-monitoring/snmp-exporter-thales"} == 0 or absent(up{job="scrapeConfig/infra-monitoring/snmp-exporter-thales"})) by (name, device_type)
       for: 5m


### PR DESCRIPTION
## Summary
Add new alert `thalesHsmPartitionsFreeWarning` that triggers when Luna K7 HSM devices have 3 or fewer free partitions remaining.

## Alert Details
- **Alert Name:** thalesHsmPartitionsFreeWarning
- **Expression:** `snmp_thales_hsmPartitionsFree{hsmModel="Luna K7"} <= 3`
- **Severity:** warning
- **Duration:** 12h (alerts every 12 hours while condition persists)

## Purpose
This alert helps operators proactively manage HSM partition capacity before running out of available partitions. When only 3 or fewer partitions can be created on a Luna K7 HSM device, this alert will fire to notify the team.

## Changes
- Added new alert rule in `prometheus-exporters/snmp-exporter/templates/alerts-thales.yaml`