### PR TITLE
Add Utimaco cHSM capacity warning alert

### DIFF
--- a/prometheus-exporters/snmp-exporter/templates/alerts-utimaco.yaml
+++ b/prometheus-exporters/snmp-exporter/templates/alerts-utimaco.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.snmp_exporter.utimaco.alerts.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: snmp-exporter-alerts-snmp-utimaco.alerts
+  labels:
+    app: snmp-exporter
+    prometheus: {{ required ".Values.snmp_exporter.utimaco.alerts.prometheus missing" .Values.snmp_exporter.utimaco.alerts.prometheus }}
+spec:
+  groups:
+  - name: snmp-utimaco.alerts
+    rules:
+    - alert: utimacoCHSMCapacityWarning
+      expr: sum(snmp_utimaco_cHSMValid{cHSMMode="OPERATIONAL"})by(site) >= 25
+      for: 12h
+      labels:
+        severity: warning
+        service: barbican
+        context: utimaco
+        meta: "Site {{`{{ $labels.site }}`}} has {{`{{ $value }}`}} cHSMs in OPERATIONAL state - only 10% capacity remaining"
+        dashboard: utimaco
+        no_alert_on_absence: "true"
+        support_group: identity
+      annotations:
+        description: "Site {{`{{ $labels.site }}`}} has {{`{{ $value }}`}} out of 31 cHSMs in OPERATIONAL state. Only ~10% (6 or fewer) cHSMs are available for new allocations."
+        summary: "Site {{`{{ $labels.site }}`}} cHSM capacity low - {{`{{ $value }}`}}/31 in OPERATIONAL state"
+{{- end }}

--- a/prometheus-exporters/snmp-exporter/values.yaml
+++ b/prometheus-exporters/snmp-exporter/values.yaml
@@ -215,3 +215,6 @@ snmp_exporter:
     password: DEFINED-IN-REGION-SECRECTS
     auth_protocol: DEFINED-IN-REGION-SECRECTS
     priv_password: DEFINED-IN-REGION-SECRECTS
+    alerts:
+      enabled: false
+      prometheus: DEFINED-IN-REGION-SECRECTS


### PR DESCRIPTION
## Summary
Add new alert `utimacoCHSMCapacityWarning` that triggers when 25 or more cHSMs are in OPERATIONAL state per site, indicating only ~10% capacity (6 or fewer cHSMs) remains available for new allocations.

## Alert Details
- **Alert Name:** utimacoCHSMCapacityWarning
- **Expression:** `sum(snmp_utimaco_cHSMValid{cHSMMode="OPERATIONAL"})by(site) >= 25`
- **Severity:** warning
- **Duration:** 12h (alerts after condition persists for 12 hours)

## Purpose
This alert helps operators proactively manage cHSM capacity before running out of available HSMs. When 25+ out of 31 cHSMs are in OPERATIONAL state, only ~10% capacity remains.

## Changes
- Created new `prometheus-exporters/snmp-exporter/templates/alerts-utimaco.yaml` with the capacity warning alert
- Added alerts configuration to `prometheus-exporters/snmp-exporter/values.yaml` for utimaco section

Similar to #11414 for Thales HSM alerts.