### PR TITLE
barbican: remove pkek_cache_ttl and pkek_cache_limit defaults from template

### DIFF
--- a/openstack/barbican/templates/etc/_secrets.conf.tpl
+++ b/openstack/barbican/templates/etc/_secrets.conf.tpl
@@ -31,8 +31,8 @@ encryption_mechanism = {{ .Values.lunaclient.conn.encryption_mechanism }}
 hmac_mechanism = {{ .Values.lunaclient.conn.hmac_mechanism }}
 key_wrap_mechanism = {{ .Values.lunaclient.conn.key_wrap_mechanism }}
 aes_gcm_generate_iv = {{ .Values.lunaclient.conn.aes_gcm_generate_iv }}
-pkek_cache_ttl = {{ .Values.lunaclient.conn.pkek_cache_ttl | default 900 }}
-pkek_cache_limit = {{ .Values.lunaclient.conn.pkek_cache_limit | default 500 }}
+pkek_cache_ttl = {{ .Values.lunaclient.conn.pkek_cache_ttl }}
+pkek_cache_limit = {{ .Values.lunaclient.conn.pkek_cache_limit }}
 {{- end }}
 
 {{- if .Values.hsm.utimaco_hsm.enabled }}


### PR DESCRIPTION
## Summary

Follow-up to cc/secrets#20117 (SAP internal).

Removes the `| default 900` and `| default 500` fallbacks for `pkek_cache_ttl` and `pkek_cache_limit` from `_secrets.conf.tpl`.

All Luna HSM regions now have these values set explicitly in the secrets repo (`lunaclient.conn` in each regional `barbican.yaml`):
- `pkek_cache_limit: 500` — ensures all 326 active project pKEKs fit in cache, eliminating eviction-triggered HSM failures
- `pkek_cache_ttl: 900` — explicit setting aligned with Utimaco plugin behavior

Removing the template defaults ensures misconfigured regions fail loudly at render time rather than silently using stale or wrong values.