### PR TITLE
[designate-nanny] enable reloader on secrets

### DIFF
--- a/openstack/designate-nanny/templates/deployment.yaml
+++ b/openstack/designate-nanny/templates/deployment.yaml
@@ -18,10 +18,13 @@ metadata:
  labels:
     app.kubernetes.io/name: {{ $release }}
     app.kubernetes.io/instance: {{ $release }}
-    app: {{ $release }}
+    app: designate-nanny
     ccloud/support-group: network-api
     system: openstack
     application: designate
+ annotations:
+    secret.reloader.stakater.com/reload: "{{ $release }}-swift-secret,{{ $release }}-openstack-secret"
+    deployment.reloader.stakater.com/pause-period: "120s"
 spec:
  replicas: 1
  selector:

--- a/openstack/designate-nanny/values.yaml
+++ b/openstack/designate-nanny/values.yaml
@@ -23,36 +23,36 @@ global:
   linkerd_requested: false # overwritten in regions where enabled
   is_global_region: false
 
-seed_users: False
+seed_users: false
 # defined in secrets:
-#users:
-#  seed_only_user:
-#    # this user is seeded to allow another region accessing the
-#    # openstack/designate API to get zones and zone transfers
-#    seed_enabled: True
-#    username: "vault+kvv2:///..."
-#    password: "vault+kvv2:///..."
-#    user_domain: UserDomain
-#    project_name: UserProject
-#    project_domain_name: ProjectDomain
-#    roles:
-#      SomeDomain:
-#        SomeProjectA:
-#          - cloud_dns_backup
-#        SomeProjectB::
-#          - objectstore_admin
+# users:
+#   seed_only_user:
+#     # this user is seeded to allow another region accessing the
+#     # openstack/designate API to get zones and zone transfers
+#     seed_enabled: True
+#     username: "vault+kvv2:///..."
+#     password: "vault+kvv2:///..."
+#     user_domain: UserDomain
+#     project_name: UserProject
+#     project_domain_name: ProjectDomain
+#     roles:
+#       SomeDomain:
+#         SomeProjectA:
+#           - cloud_dns_backup
+#         SomeProjectB::
+#           - objectstore_admin
 #
-#  local_user:
-#    # this user is used to locally (in this region) access openstack,
-#    # both designate and swift, to do local backups.
-#    seed_enabled: True
+#   local_user:
+#     # this user is used to locally (in this region) access openstack,
+#     # both designate and swift, to do local backups.
+#     seed_enabled: True
 #
-#  remote_user:
-#    # this user is not seeded here, but in the remot region, like the
-#    # seed_only_user above. It only needs permission to access designate
-#    seed_enabled: False
-#    ...
-#    -> definitions like above, but without roles.
+#   remote_user:
+#     # this user is not seeded here, but in the remot region, like the
+#     # seed_only_user above. It only needs permission to access designate
+#     seed_enabled: False
+#     ...
+#     -> definitions like above, but without roles.
 
 nanny_defaults:
   # only config is merged for now.


### PR DESCRIPTION
This will trigger a new deployment 120 seconds after one of the secrets change.

Giving some grace period in case we are changing more than one credential at a time, preventing multiple redeployments.