### PR TITLE
[utils] Allow disabling sentry in helper

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.34.0
+version: 0.35.0

--- a/openstack/utils/templates/_helpers.tpl
+++ b/openstack/utils/templates/_helpers.tpl
@@ -78,6 +78,7 @@ trace_sqlalchemy = {{ .Values.global.osprofiler.trace_sqlalchemy }}
 {{- end }}
 
 {{- define "utils.sentry_config" -}}
+{{- if .Values.sentry.enabled }}
 - name: SENTRY_DSN
   valueFrom:
     secretKeyRef:
@@ -86,5 +87,6 @@ trace_sqlalchemy = {{ .Values.global.osprofiler.trace_sqlalchemy }}
 {{- if .Values.sentry.release }}
 - name: SENTRY_RELEASE
   value: {{ .Values.sentry.release }}
+{{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
If sentry.enabled is set to false we now don't output the sentry config anymore.