### PR TITLE
[neutron] Allow sentry to be disabled

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 0.19.1
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.34.0
+  version: 0.35.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
@@ -32,5 +32,5 @@ dependencies:
 - name: ovsdb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
-digest: sha256:fd9448b7ab9a39fc7666a41fe5090d2e8cd8cc815229777c15a262ecaa79d933
-generated: "2026-04-16T18:21:14.531293592+02:00"
+digest: sha256:eaad512fe8cc6d04cbb311c21c197f3c8b2c27ed0a42f474772c119cededb7ed
+generated: "2026-04-17T14:54:05.581499921+02:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     version: 0.19.1
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.34.0
+    version: 0.35.0
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0

--- a/openstack/neutron/templates/asr_config_agents/_deployment-asr1k.yaml.tpl
+++ b/openstack/neutron/templates/asr_config_agents/_deployment-asr1k.yaml.tpl
@@ -103,11 +103,7 @@ spec:
             {{else}}
               value: "false"
             {{ end }}
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: sentry
-                  key: neutron.DSN.python
+            {{- include "utils.sentry_config" $context | nindent 12 }}
             - name: METRICS_PORT
               value: "{{$context.Values.port_l2_metrics |  default 9102}}"
           volumeMounts:


### PR DESCRIPTION
With utils chart 0.35.0 we can now disable sentry, as
utils.sentry_config now honors the sentry.enabled value. Also, the asr1k
was the last one specifying its own SENTRY_DSN and is now subsequently
also using the utils.sentry_config function.