### PR TITLE
[neutron] rbac service account

### DIFF
--- a/openstack/neutron/templates/deployment-rpc-server.yaml
+++ b/openstack/neutron/templates/deployment-rpc-server.yaml
@@ -46,6 +46,9 @@ spec:
         {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
         config.linkerd.io/skip-outbound-ports: "6441,6442" # OVSDB ports
     spec:
+{{- if .Values.rbac.enabled }}
+      serviceAccountName: {{ .Release.Name }}
+{{- end }}
 {{ tuple . "neutron" "rpc" | include "kubernetes_pod_anti_affinity" | indent 6 }}
       {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       initContainers:

--- a/openstack/neutron/templates/deployment-server.yaml
+++ b/openstack/neutron/templates/deployment-server.yaml
@@ -47,6 +47,9 @@ spec:
         prometheus.io/targets: {{ required "$.Values.metrics.prometheus missing" $.Values.metrics.prometheus }}
         config.linkerd.io/skip-outbound-ports: "6441,6442" # OVSDB ports
     spec:
+{{- if .Values.rbac.enabled }}
+      serviceAccountName: {{ .Release.Name }}
+{{- end }}
 {{ tuple . "neutron" "api" | include "kubernetes_pod_anti_affinity" | indent 6 }}
       {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       initContainers:

--- a/openstack/neutron/templates/job-migration.yaml
+++ b/openstack/neutron/templates/job-migration.yaml
@@ -18,6 +18,9 @@ metadata:
 spec:
   template:
     spec:
+{{- if .Values.rbac.enabled }}
+      serviceAccountName: {{ .Release.Name }}
+{{- end }}
       restartPolicy: OnFailure
 {{ include "utils.proxysql.job_pod_settings" . | indent 6 }}
       initContainers:

--- a/openstack/neutron/templates/rbac.yaml
+++ b/openstack/neutron/templates/rbac.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.rbac.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-runtime
+rules:
+- apiGroups:
+  - openstack.stable.sap.cc
+  resources:
+  - openstackseeds
+  verbs:
+  - "*"
+- apiGroups:
+  - "*"
+  resources:
+  - services
+  - endpoints
+  - configmaps
+  - secrets
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  - extensions
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-runtime
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}
+    namespace: {{ .Release.Namespace }}
+
+{{- end }}

--- a/openstack/neutron/templates/serviceaccount.yaml
+++ b/openstack/neutron/templates/serviceaccount.yaml
@@ -1,0 +1,7 @@
+{{- if .Values.rbac.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -4,6 +4,9 @@
 # name: value
 network_agents: []
 
+rbac:
+  enabled: true
+
 # osprofiler
 osprofiler:
   enabled: false


### PR DESCRIPTION
Needed for accessing mariadb and rabbitmq in eu-de-3 (and maybe also in other regions soonish) by kubernetes entrypoint used by the migration job, neutron-server and neutron-rpc-server.

---

Most of this is copied over from keystone. I am not sure if these are the right permissions needed.