### PR TITLE
Reapply "nova-hypervisor-agents: Wait for certificate"

### DIFF
--- a/openstack/nova-hypervisor-agents/templates/hypervisors-kvm-daemonset.yaml
+++ b/openstack/nova-hypervisor-agents/templates/hypervisors-kvm-daemonset.yaml
@@ -26,6 +26,7 @@ spec:
         configmap-etc-hash: {{ include (print .Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
         configmap-kvm-etc-hash: {{ include "kvm_configmap" . | sha256sum }}
     spec:
+      serviceAccountName: {{ .Values.hypervisorAgentsServiceAccountName | default .Release.Name }}
       terminationGracePeriodSeconds: {{ $hypervisor.default.graceful_shutdown_timeout | default .Values.defaults.default.graceful_shutdown_timeout | add 5 }}
       hostNetwork: true
       hostPID: true
@@ -55,6 +56,21 @@ spec:
           - {{ include "nova.helpers.cell_rabbitmq_host" (tuple $ $activeCell) }}
       {{- end }}
       initContainers:
+      - name: kubernetes-entrypoint
+        image: {{ .Values.global.ghcrIoMirror }}/sapcc/kubernetes-entrypoint:{{ .Values.imageVersionKubernetesEntrypoint }}
+        command:
+        - kubernetes-entrypoint
+        env:
+        - name: COMMAND
+          value: "true"
+        - name: POD_NAME
+          valueFrom: {fieldRef: {fieldPath: metadata.name}}
+        - name: NAMESPACE
+          valueFrom: {fieldRef: {fieldPath: metadata.namespace}}
+        - name: NODE_NAME
+          valueFrom: {fieldRef: {fieldPath: spec.nodeName}}
+        - name: DEPENDENCY_CUSTOM_RESOURCE
+          value: '[{"apiVersion":"kvm.cloud.sap/v1","kind":"Hypervisor","name":"$(NODE_NAME)","fields":[{"key":".status.conditions[?(@.type==\"TLSCertificateInstalled\")].status","value":"True"}]}]'
       - name: nova-compute-init
         image: {{ required ".Values.global.registry is missing" .Values.global.registry }}/{{ .Values.imageName }}:{{ .Values.imageVersion | required "Please set imageVersion similar" }}
         command: ["/container.init/nova-compute-init"]

--- a/openstack/nova-hypervisor-agents/templates/nova-hypervisor-agent-cr.yaml
+++ b/openstack/nova-hypervisor-agents/templates/nova-hypervisor-agent-cr.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.hypervisorAgentsServiceAccountName | default .Release.Name }}
+rules:
+- apiGroups: ["kvm.cloud.sap"]
+  resources: ["hypervisors"]
+  verbs: ["get", "watch", "list"]

--- a/openstack/nova-hypervisor-agents/templates/nova-hypervisor-agent-rb.yaml
+++ b/openstack/nova-hypervisor-agents/templates/nova-hypervisor-agent-rb.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.hypervisorAgentsServiceAccountName | default .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.hypervisorAgentsServiceAccountName | default .Release.Name }}
+roleRef:
+  kind: Role
+  name: {{ .Values.hypervisorAgentsServiceAccountName | default .Release.Name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.hypervisorAgentsServiceAccountName | default .Release.Name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.hypervisorAgentsServiceAccountName | default .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.hypervisorAgentsServiceAccountName | default .Release.Name }}

--- a/openstack/nova-hypervisor-agents/templates/nova-hypervisor-agent-role.yaml
+++ b/openstack/nova-hypervisor-agents/templates/nova-hypervisor-agent-role.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.hypervisorAgentsServiceAccountName | default .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["pods"]
+  verbs: ["get", "watch", "list"]

--- a/openstack/nova-hypervisor-agents/templates/nova-hypervisor-agent-sa.yaml
+++ b/openstack/nova-hypervisor-agents/templates/nova-hypervisor-agent-sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.hypervisorAgentsServiceAccountName | default .Release.Name }}
+

--- a/openstack/nova-hypervisor-agents/values.yaml
+++ b/openstack/nova-hypervisor-agents/values.yaml
@@ -11,9 +11,13 @@ rabbitmq_ssl_client: true
 
 imageName: loci-nova
 imageVersion: null
+imageVersionKubernetesEntrypoint: "latest"
+
 hypervisor_on_host: true
 
 cross_az_attach: 'False'
+
+hypervisorAgentsServiceAccountName: null
 
 default:
   password_all_group_samples: 2


### PR DESCRIPTION
The revert was needed, because it was using `.Release.name` which was always empty, resulting in the error

```
could not get information about the resource  
ServiceAccount "" in namespace "monsoon3"
```

This time with the proper upper-case variable: `.Release.Name`

This reverts commit 3811198a388bd8db18b169cbd1a7c2f724e8b16d.