### PR TITLE
Add CinderTagMissingForDatastoreNFS alert

### DIFF
--- a/prometheus-rules/prometheus-vmware-rules/Chart.yaml
+++ b/prometheus-rules/prometheus-vmware-rules/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A collection of Prometheus alert rules.
 name: prometheus-vmware-rules
-version: 1.5.1
+version: 1.5.2
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/prometheus-rules/prometheus-vmware-rules/alerts/datastore.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/datastore.alerts
@@ -307,6 +307,21 @@ groups:
       description: "There is no Cinder tag present for the `{{ $labels.datastore }}` datastore in the *{{ $labels.datacenter }}* availability zone\nLink to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>"
       summary: "There is no Cinder tag present for the `{{ $labels.datastore }}` datastore in the *{{ $labels.datacenter }}* availability zone\nLink to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>"
 
+  - alert: CinderTagMissingForDatastoreNFS
+    expr: |
+      vrops_datastore_summary_tag{type="nfs", summary_tag!="[{\"category\":\"cinder\",\"name\":\"fcd\"}]"}
+    for: 1h
+    labels:
+      severity: warning
+      tier: vmware
+      service: storage
+      support_group: compute
+      meta: "There is no or incorrect Cinder tag present for the `{{ $labels.datastore }}` NFS datastore in the *{{ $labels.datacenter }}* availability zone\nLink to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>"
+      playbook: docs/support/playbook/cinder/cinder-tag-missing
+    annotations:
+      description: "There is no or incorrect Cinder tag present for the `{{ $labels.datastore }}` NFS datastore in the *{{ $labels.datacenter }}* availability zone\nLink to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>"
+      summary: "There is no or incorrect Cinder tag present for the `{{ $labels.datastore }}` NFS datastore in the *{{ $labels.datacenter }}* availability zone\nLink to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>"
+
   - alert: CinderTagAddedForReservedDatastore
     expr: |
       vrops_datastore_summary_custom_tag_cinder_state{type=~"(vmfs_s_hdd|vmfs_p_ssd)", summary_custom_tag_cinder_state="reserved"} > 0

--- a/prometheus-rules/prometheus-vmware-rules/alerts/datastore.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/datastore.alerts
@@ -320,7 +320,7 @@ groups:
       playbook: docs/support/playbook/cinder/cinder-tag-missing
     annotations:
       description: "There is no or incorrect Cinder tag present for the `{{ $labels.datastore }}` NFS datastore in the *{{ $labels.datacenter }}* availability zone\nLink to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>"
-      summary: "There is no or incorrect Cinder tag present for the `{{ $labels.datastore }}` NFS datastore in the *{{ $labels.datacenter }}* availability zone\nLink to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>"
+      summary: "Wrong or missing tag on `{{ $labels.datastore }}` NFS datastore in *{{ $labels.datacenter }}*"
 
   - alert: CinderTagAddedForReservedDatastore
     expr: |


### PR DESCRIPTION
Implements COMPUTEMONITORING-73.

Alert fires when NFS datastores have a missing or incorrect Cinder tag. Expected tag value: `[{"category":"cinder","name":"fcd"}]`.

Tested against Thanos: out of 2048 NFS datastores across 14 regions, 9 would trigger the alert (all in qa-de-1):
- 7x tag missing (summary_tag="none")
- 1x tag "qtree"
- 1x tag "fcd_slow_hdd"

Related ticket: https://jira.tools.sap/browse/COMPUTEMONITORING-73