### PR TITLE
[ironic] dependency updates

### DIFF
--- a/openstack/ironic/Chart.lock
+++ b/openstack/ironic/Chart.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.32.0
+  version: 0.35.0
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.5.1
+  version: 0.6.0
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.6.16
@@ -16,12 +16,12 @@ dependencies:
   version: 1.0.0
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.22.1
+  version: 0.22.2
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.33.0
+  version: 0.35.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:bda7a572c2465a7d5a6f7ce1ca3851d68b42172157334c41b9963c153b626ada
-generated: "2026-04-15T10:36:19.336270959+02:00"
+digest: sha256:5a80c2476f34a73cc9c7032bafeb4e18f764df10cfa1914f31d759f5bae7487a
+generated: "2026-04-21T11:06:06.652915765+02:00"

--- a/openstack/ironic/Chart.yaml
+++ b/openstack/ironic/Chart.yaml
@@ -7,15 +7,15 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.32.0
+    version: ~0.35.0
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.5.1
+    version: ~0.6.0
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.6.15
+    version: ~0.6.16
   - condition: mysql_metrics.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
@@ -25,10 +25,10 @@ dependencies:
     version: ~1.0.0
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.22.1
+    version: ~0.22.2
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.33.0
+    version: ~0.35.0
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: ~1.1.1

--- a/openstack/ironic/values.yaml
+++ b/openstack/ironic/values.yaml
@@ -215,7 +215,7 @@ conductor:
     conductor:
       conductor_always_validates_images: false # We only use the direct interface, so leave it to the agent
       permitted_image_formats: 'raw,qcow2,iso,vmdk'
-      # HDA has a parallelism of 50 nodes, we give a buffer of 10
+      # HDA has a parallelism of 50 nodes, but with deleting they ran into the limit of 60, so increasing to 100 for now
       max_concurrent_clean: 100
 
 agent:
@@ -234,14 +234,14 @@ tftp_files:
 
 portmetrics: "9102"
 
-#network_management_uuid: null
-#network_cleaning_uuid: null
+# network_management_uuid: null
+# network_cleaning_uuid: null
 neutron_url_timeout: 210
 neutron_port_setup_delay: 0
 neutron_connect_retries: 3
 
-#swift_account: null
-#swift_tempurl: null
+# swift_account: null
+# swift_tempurl: null
 
 mysql_metrics:
   enabled: true
@@ -422,7 +422,7 @@ pxc_db:
       enabled: true
 
 dbName: ironic
-#dbPassword: null
+# dbPassword: null
 max_pool_size: 1
 max_overflow: 50
 

--- a/openstack/ironic/values.yaml
+++ b/openstack/ironic/values.yaml
@@ -14,7 +14,7 @@ owner-info:
 
 global:
   ironicApiPortInternal: "6385"
-  #ironic_tftp_ip: null
+  # ironic_tftp_ip: null
   ironicServiceUser: ironic
   ironictftpPortPublic: "69"
   ironic_pxe_port_public: "69"


### PR DESCRIPTION
Dependency mariadb          has new upgrade available from ~0.32.0  to ~0.35.0
Dependency pxc-db           has new upgrade available from ~0.5.1   to ~0.6.0
Dependency memcached        has new upgrade available from ~0.6.15  to ~0.6.16
Dependency rabbitmq         has new upgrade available from 0.22.1   to ~0.22.2
Dependency utils            has new upgrade available from 0.33.0   to ~0.35.0
