### PR TITLE
[manila] gate proxysql native_sidecar init container on secret existence

### DIFF
--- a/openstack/manila/templates/migration-job.yaml
+++ b/openstack/manila/templates/migration-job.yaml
@@ -35,7 +35,7 @@ spec:
       priorityClassName: {{ .Values.pod.priority_class.low }}
       initContainers:
       {{- tuple . (dict "service" (include "manila.db_service" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
-      {{- if .Values.proxysql.native_sidecar }}
+      {{- if and $proxysql .Values.proxysql.native_sidecar }}
       {{- include "utils.proxysql.container" . | indent 6 }}
       {{- end }}
       containers:


### PR DESCRIPTION
On first install the proxysql secret does not exist yet, so $proxysql
is nil and the volumes block is skipped — but the native_sidecar init
container was still rendered, referencing etcproxysql/runproxysql
volumes that don't exist.
