### PR TITLE
[cinder]Use isImageTransportTemplating variable

### DIFF
--- a/openstack/cinder/templates/vcenter_datacenter_cinder_vcsu.yaml
+++ b/openstack/cinder/templates/vcenter_datacenter_cinder_vcsu.yaml
@@ -1,3 +1,4 @@
+{{- if or (.Capabilities.APIVersions.Has "vcenter-operator.stable.sap.cc/v1") (.Values.isImageTransportTemplating | default false) }}
 {{- if .Values.manage_service_user_passwords }}
 apiVersion: vcenter-operator.stable.sap.cc/v1
 kind: VCenterServiceUser
@@ -6,4 +7,5 @@ metadata:
   namespace: monsoon3
 spec:
   username: vcocinderapiuser
+{{- end }}
 {{- end }}


### PR DESCRIPTION
This variable is set by the shared pipeline for the image version transport and makes it possible to include templates into the pipeline, that would not be rendered for normal "helm template" runs because of conditionals checking the APIVersions.