### PR TITLE
[mariadb][neutron] bump db chart dependencies

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -1,16 +1,16 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.27.1
+  version: 0.41.0
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.4.0
+  version: 0.6.0
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.6.9
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.5.2
+  version: 0.8.1
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.25.4
@@ -32,5 +32,5 @@ dependencies:
 - name: ovsdb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
-digest: sha256:62c769169f00f9608327858c6deb346b259147f9572890f8722171a002b412fd
-generated: "2026-07-02T13:16:52.794398023+02:00"
+digest: sha256:56c36cba7f763b40a64ed658b2e0079d5bbb7d05983d53f6688cc4679fe6f124
+generated: "2026-07-08T13:41:51.382357+03:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -2,25 +2,25 @@
 apiVersion: v2
 description: A Helm chart for Openstack Neutron
 name: neutron
-version: 0.3.6
+version: 0.3.7
 appVersion: "caracal"
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.27.1
+    version: 0.41.0
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.4.0
+    version: 0.6.0
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.6.9
   - condition: mariadb.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.5.2
+    version: 0.8.1
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.25.4


### PR DESCRIPTION
* update mariadb to 10.11.18
* update mysqld-exporter to 0.19.0
* update sql-exporter to 0.9.0 with clusterDNSSearchDomain support
* update sidecar containers
* limit backup user privileges
* add support for ceph s3 backup storage backend
* support multiple ceph s3 backup targets
* support object locks in s3 backup storages
* bump pxc-db chart