### PR TITLE
[mariadb][kmip] bump db chart dependency

### DIFF
--- a/openstack/kmip/Chart.lock
+++ b/openstack/kmip/Chart.lock
@@ -7,15 +7,15 @@ dependencies:
   version: 1.1.1
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.29.0
+  version: 0.35.0
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.27.1
+  version: 0.35.0
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.5.0
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.5.2
-digest: sha256:35c0bfc2b5497a6d73addbcfb2bf5dd045dba58eb011ba84edbd03c40f0530b3
-generated: "2025-08-25T15:36:16.123215+03:00"
+digest: sha256:d4fb243e863b7c6e698858a129b4a0d3e8097845c60e08504b26e3b1693a2c7d
+generated: "2026-04-21T17:43:20.747909+03:00"

--- a/openstack/kmip/Chart.yaml
+++ b/openstack/kmip/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Chart Version
-version: 0.3.6
+version: 0.3.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -38,7 +38,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.27.1
+    version: 0.35.0
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db


### PR DESCRIPTION
* update mariadb to 10.11.16
* update mysqld-exporter to 0.19.0
* update sidecar containers
* limit backup user privileges
* add support for ceph s3 backup storage backend