### PR TITLE
[mariadb][keystone] bump db chart dependency

### DIFF
--- a/openstack/keystone/Chart.lock
+++ b/openstack/keystone/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.31.0
+  version: 0.35.0
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.5.0
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:41b158207139f27dc8591ce66ac468cd272bf78a0e3bbdfec9e9502d2c02570d
-generated: "2026-04-02T11:40:06.754678+02:00"
+digest: sha256:53a6ae366828333f3f8f7d76a4d2c74367e070d78f9bb38ac1160ab55cecfb8a
+generated: "2026-04-21T17:42:44.497258+03:00"

--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -9,12 +9,12 @@ maintainers:
 name: keystone
 sources:
   - https://github.com/sapcc/keystone
-version: 0.12.0
+version: 0.12.1
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.31.0
+    version: 0.35.0
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db


### PR DESCRIPTION
* update mariadb to 10.11.16
* update mysqld-exporter to 0.19.0
* update sidecar containers
* limit backup user privileges
* add support for ceph s3 backup storage backend