### PR TITLE
[mariadb][cinder] bump db chart dependency

### DIFF
--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.36.0
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.31.0
+  version: 0.37.0
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.5.1
@@ -26,5 +26,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:7f12f95e5682ca5fc475f74cf193ef54fa4c14895c232709853759cbe5ba9f5f
-generated: "2026-04-29T11:17:19.959227+02:00"
+digest: sha256:6bcc283f7a0f09b336959e311a1f3df44202e0c87303e36c00219e8f479a26e0
+generated: "2026-05-28T15:53:40.483627+03:00"

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -3,14 +3,14 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Cinder/OpenStack_Project_Cinder_mascot.png
 name: cinder
-version: 0.4.0
+version: 0.4.1
 dependencies:
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.36.0
   - name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.31.0
+    version: 0.37.0
     condition: mariadb.enabled
   - name: pxc-db
     alias: pxc_db


### PR DESCRIPTION
* update mariadb to 10.11.17
* update mysqld-exporter to 0.19.0
* update sidecar containers
* limit backup user privileges
* add support for ceph s3 backup storage backend