### PR TITLE
[mariadb][barbican] bump db chart dependency

### DIFF
--- a/openstack/barbican/Chart.lock
+++ b/openstack/barbican/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.31.0
+  version: 0.35.0
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.5.0
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:3c71361ec2d3932bd207d553e6c2555321969f2d6f451b70540bd5fda54fdb26
-generated: "2025-12-18T10:12:43.190197+05:30"
+digest: sha256:51bc9a8f511c695ea6dd5b13cdd805b2fb364f05f9764512443b92a1d29cd2d9
+generated: "2026-04-21T17:39:19.517143+03:00"

--- a/openstack/barbican/Chart.yaml
+++ b/openstack/barbican/Chart.yaml
@@ -4,12 +4,12 @@ appVersion: flamingo
 description: A Helm chart for Openstack Barbican
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Barbican/OpenStack_Project_Barbican_vertical.png
 name: barbican
-version: 0.8.0
+version: 0.8.1
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.31.0
+    version: 0.35.0
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db


### PR DESCRIPTION
* update mariadb to 10.11.16
* update mysqld-exporter to 0.19.0
* update sidecar containers
* limit backup user privileges
* add support for ceph s3 backup storage backend