### PR TITLE
[mariadb][designate] bump db chart dependency

### DIFF
--- a/openstack/designate/Chart.lock
+++ b/openstack/designate/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 0.5.0
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.30.0
+  version: 0.35.0
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.6.12
@@ -29,5 +29,5 @@ dependencies:
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.3.1
-digest: sha256:4bccf1df6e2748f990eaf8b16b63150e464a7912d222ea39381ebaa3dd7e283c
-generated: "2026-04-02T12:20:45.988489+03:00"
+digest: sha256:6835d1928ab12404050a3a41d783da5e2c472e146e1a687a44606df84963896e
+generated: "2026-04-21T17:41:54.541308+03:00"

--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes to deploy Openstack Designate  (DNSaaS)
 name: designate
-version: 0.5.12
+version: 0.5.13
 appVersion: "dalmatian"
 dependencies:
   - condition: percona_cluster.enabled
@@ -17,7 +17,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.30.0
+    version: 0.35.0
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.6.12


### PR DESCRIPTION
* update mariadb to 10.11.16
* update mysqld-exporter to 0.19.0
* update sidecar containers
* limit backup user privileges
* add support for ceph s3 backup storage backend