### PR TITLE
[netapp] extend snapmirror metrics to all setups

### DIFF
--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/aggregations/maia.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/aggregations/maia.yaml
@@ -132,33 +132,27 @@ groups:
       expr: netapp_volume_inode_files_used_percentage:maia2 or sum (netapp_volume_inode_files_used_percentage:maia1{project_id!=""}) without (app, instance, job, filer, aggregate, node, snapshot_policy, volume_state)
 
     #
-    # snampirror relationship
+    # snapmirror relationship
     #
-    # NOTE: We enrich snapmirror metrics using exported metrics from target region.
-    # It's done via the promquery exporter in `netapp_metrics_federation` subchart.
+    # :local is produced by local aggregation rules (snapmirror.yaml) — covers all local relationships.
+    # :remote is produced by the federation exporter (netapp-metrics-federation) — cross-region only.
     - record: netapp_snapmirror_labels:maia
-      expr: |
-        go_build_info{app_kubernetes_io_instance="netapp-snapmirror-federation",
-          region!~"ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-sa-1|eu-de-1|eu-de-2|eu-nl-1|na-ca-1|na-us-1|na-us-2|na-us-3|qa-de-1"}
-        or {__name__=~"netapp_snapmirror_labels:localbkp|netapp_snapmirror_labels:remotebkp"}
+      expr: '{__name__=~"netapp_snapmirror_labels:local|netapp_snapmirror_labels:remote"}'
 
     - record: netapp_snapmirror_lag_time:maia
-      expr: '{__name__="netapp_snapmirror_lag_time:federated"}'
+      expr: '{__name__=~"netapp_snapmirror_lag_time:local|netapp_snapmirror_lag_time:remote"}'
 
     - record: netapp_snapmirror_last_transfer_size:maia
-      expr: '{__name__="netapp_snapmirror_last_transfer_size:federated"}'
+      expr: '{__name__=~"netapp_snapmirror_last_transfer_size:local|netapp_snapmirror_last_transfer_size:remote"}'
 
     - record: netapp_snapmirror_last_transfer_duration:maia
-      expr: '{__name__="netapp_snapmirror_last_transfer_duration:federated"}'
-
-    - record: netapp_snapmirror_last_transfer_duration:maia
-      expr: '{__name__="netapp_snapmirror_last_transfer_duration:federated"}'
+      expr: '{__name__=~"netapp_snapmirror_last_transfer_duration:local|netapp_snapmirror_last_transfer_duration:remote"}'
 
     - record: netapp_snapmirror_source_snapshot_count:maia
-      expr: '{__name__="netapp_snapmirror_source_snapshot_count:federated"}'
+      expr: '{__name__=~"netapp_snapmirror_source_snapshot_count:local|netapp_snapmirror_source_snapshot_count:remote"}'
 
     - record: netapp_snapmirror_destination_snapshot_count:maia
-      expr: '{__name__="netapp_snapmirror_destination_snapshot_count:federated"}'
+      expr: '{__name__=~"netapp_snapmirror_destination_snapshot_count:local|netapp_snapmirror_destination_snapshot_count:remote"}'
 
     # Maia metrics: openstack_manila_share_snapmirror_snapshot_size_bytes
     # Description: Snapshot size induced by share replicas or other snapmirror relationships

--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/aggregations/snapmirror.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/aggregations/snapmirror.yaml
@@ -2,12 +2,13 @@ groups:
   - name: netapp-snapmirror
     rules:
     # NOTE:
-    # netapp_snapmirror_labels: destinations only in LOCAL region (from 'snapmirror show' - rich snapmirror details).
-    # netapp_snapmirror_endpoint_labels: destinations in LOCAL and REMOTE regions (from 'snapmirror list-destinations' - endpoints only no details).
- 
-    # Enrich netapp_snapmirror_labels within a region.
+    # netapp_snapmirror_detailed_labels: destinations only in LOCAL region (from 'snapmirror show' - rich details: policy, status, lag_time, health).
+    # netapp_snapmirror_endpoint_labels: destinations in LOCAL and REMOTE regions (from 'snapmirror list-destinations' - endpoints only, no details).
+    # :enhanced suffix (on both): raw metric enriched with OpenStack labels (project_id, share_id, share_name) joined from netapp_volume_labels:manila on the source filer.
+
+    # Enrich netapp_snapmirror_detailed_labels within a region.
     # First with share_id, share_name and project_id, then with destination_cluster.
-    - record: netapp_snapmirror_labels:enhanced
+    - record: netapp_snapmirror_detailed_labels:enhanced
       expr: |
         netapp_snapmirror_labels * on (app, source_vserver, source_volume)
         group_left(project_id, share_id, share_name, source_availability_zone, reason)
@@ -29,9 +30,9 @@ groups:
           "destination_cluster", "$1", "filer", "(.*)"),
           "destination_volume", "$1", "volume", "(.*)")
 
-    # Enrich netapp_snapmirror_labels for cross-region setup.
+    # Enrich netapp_snapmirror_detailed_labels for cross-region setup.
     # They have no share and project labels.
-    - record: netapp_snapmirror_labels:enhanced
+    - record: netapp_snapmirror_detailed_labels:enhanced
       expr: |
         (netapp_snapmirror_labels unless on (source_cluster)
           label_replace(netapp_volume_labels:manila, "source_cluster", "$1", "filer", "(.*)"))
@@ -66,12 +67,45 @@ groups:
           "source_cluster", "$1", "filer", "(.*)"),
           "destination_vserver", "$1", "destination_vserver", "(.*_[BD])\\.[1-9]")
 
-    # Add destination_cluster label, which is the filer label from harvester. 
-    - record: netapp_snapmirror_lag_time:enhanced
-      expr: label_replace(netapp_snapmirror_lag_time, "destination_cluster", "$1", "filer", "(.*)")
+    # Local snapmirror relationships where source is a known Manila share.
+    # Covers all setups (backup targets, replicas, etc.) — no destination filter applied.
+    - record: netapp_snapmirror_labels:local
+      expr: netapp_snapmirror_detailed_labels:enhanced{project_id!="", share_id!=""}
 
-    - record: netapp_snapmirror_last_transfer_duration:enhanced
-      expr: label_replace(netapp_snapmirror_last_transfer_duration, "destination_cluster", "$1", "filer", "(.*)")
+    - record: netapp_snapmirror_lag_time:local
+      expr: |
+        netapp_snapmirror_detailed_labels:enhanced{project_id!="", share_id!=""}
+          * on (filer, source_vserver, source_volume, destination_vserver, destination_volume)
+          group_left() label_replace(netapp_snapmirror_lag_time, "destination_cluster", "$1", "filer", "(.*)")
 
-    - record: netapp_snapmirror_last_transfer_size:enhanced
-      expr: label_replace(netapp_snapmirror_last_transfer_size, "destination_cluster", "$1", "filer", "(.*)")
+    - record: netapp_snapmirror_last_transfer_duration:local
+      expr: |
+        netapp_snapmirror_detailed_labels:enhanced{project_id!="", share_id!=""}
+          * on (filer, source_vserver, source_volume, destination_vserver, destination_volume)
+          group_left() label_replace(netapp_snapmirror_last_transfer_duration, "destination_cluster", "$1", "filer", "(.*)")
+
+    - record: netapp_snapmirror_last_transfer_size:local
+      expr: |
+        netapp_snapmirror_detailed_labels:enhanced{project_id!="", share_id!=""}
+          * on (filer, source_vserver, source_volume, destination_vserver, destination_volume)
+          group_left() label_replace(netapp_snapmirror_last_transfer_size, "destination_cluster", "$1", "filer", "(.*)")
+
+    - record: netapp_snapmirror_source_snapshot_count:local
+      expr: |
+        netapp_snapmirror_detailed_labels:enhanced{project_id!="", share_id!=""}
+          * on (source_cluster, source_vserver, source_volume) group_left()
+          label_replace(label_replace(label_replace(
+            max by (filer, svm, volume) (netapp_volume_snapshot_count),
+            "source_cluster", "$1", "filer", "(.*)"),
+            "source_vserver", "$1", "svm", "(.*)"),
+            "source_volume", "$1", "volume", "(.*)")
+
+    - record: netapp_snapmirror_destination_snapshot_count:local
+      expr: |
+        netapp_snapmirror_detailed_labels:enhanced{project_id!="", share_id!=""}
+          * on (destination_cluster, destination_vserver, destination_volume) group_left()
+          label_replace(label_replace(label_replace(
+            max by (filer, svm, volume) (netapp_volume_snapshot_count),
+            "destination_cluster", "$1", "filer", "(.*)"),
+            "destination_vserver", "$1", "svm", "(.*)"),
+            "destination_volume", "$1", "volume", "(.*)")

--- a/prometheus-exporters/netapp-exporter/charts/netapp-metrics-federation/templates/configmap.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-metrics-federation/templates/configmap.yaml
@@ -7,38 +7,35 @@ metadata:
 data:
   snapmirror.yaml: |
     metrics:
-      - export_name: netapp_snapmirror_labels:remotebkp
+      # Cross-region snapmirror labels: endpoint labels are joined with detailed labels where share_id="" — those are
+      # the cross-region relationships where the destination filer has no knowledge of the source's OpenStack labels.
+      # The share_id="" filter prevents matching local relationships that are already fully enriched.
+      - export_name: netapp_snapmirror_labels:remote
         query: |
           netapp_snapmirror_endpoint_labels:enhanced{region="{{ .Values.global.region }}", project_id!="", share_id!=""}
             * on(relationship_id)
-            group_right(project_id, share_id, share_name) netapp_snapmirror_labels:enhanced{share_id=""}
+            group_right(project_id, share_id, share_name) netapp_snapmirror_detailed_labels:enhanced{share_id=""}
         label_rules:
         - type: fill
           label_name: unhealthy_reason
-        help: "netapp snapmirror labels for remote backup targets"
-      - export_name: netapp_snapmirror_labels:localbkp
-        query: netapp_snapmirror_labels:enhanced{region="{{ .Values.global.region }}", project_id!="",share_id!="", destination_volume!~"share_[0-9a-f]{8}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{12}"}
-        label_rules:
-        - type: fill
-          label_name: unhealthy_reason
-        help: "netapp snapmirror labels for local backup targets"
-      - export_name: netapp_snapmirror_lag_time:federated
+        help: "netapp snapmirror labels for cross-region relationships"
+      - export_name: netapp_snapmirror_lag_time:remote
         query: |
           netapp_snapmirror_endpoint_labels:enhanced{region="{{ .Values.global.region }}", project_id!="", share_id!=""}
             * on (source_vserver, source_volume, destination_cluster, destination_vserver, destination_volume)
-            group_left() netapp_snapmirror_lag_time:enhanced
-        help: "netapp snapmirror lag time"
-      - export_name: netapp_snapmirror_last_transfer_duration:federated
+            group_left() label_replace(netapp_snapmirror_lag_time, "destination_cluster", "$1", "filer", "(.*)")
+        help: "netapp snapmirror lag time for cross-region relationships"
+      - export_name: netapp_snapmirror_last_transfer_duration:remote
         query: |
           netapp_snapmirror_endpoint_labels:enhanced{region="{{ .Values.global.region }}", project_id!="", share_id!=""}
             * on (source_vserver, source_volume, destination_cluster, destination_vserver, destination_volume)
-            group_left() netapp_snapmirror_last_transfer_duration:enhanced
-      - export_name: netapp_snapmirror_last_transfer_size:federated
+            group_left() label_replace(netapp_snapmirror_last_transfer_duration, "destination_cluster", "$1", "filer", "(.*)")
+      - export_name: netapp_snapmirror_last_transfer_size:remote
         query: |
           netapp_snapmirror_endpoint_labels:enhanced{region="{{ .Values.global.region }}", project_id!="", share_id!=""}
             * on (source_vserver, source_volume, destination_cluster, destination_vserver, destination_volume)
-            group_left() netapp_snapmirror_last_transfer_size:enhanced
-      - export_name: netapp_snapmirror_source_snapshot_count:federated
+            group_left() label_replace(netapp_snapmirror_last_transfer_size, "destination_cluster", "$1", "filer", "(.*)")
+      - export_name: netapp_snapmirror_source_snapshot_count:remote
         query: |
           netapp_snapmirror_endpoint_labels:enhanced{region="{{ .Values.global.region }}", project_id!="", share_id!=""}
           * on (source_cluster, source_vserver, source_volume) group_left()
@@ -47,7 +44,7 @@ data:
             "source_cluster", "$1", "filer", "(.*)"),
             "source_vserver", "$1", "svm", "(.*)"),
             "source_volume", "$1", "volume", "(.*)")
-      - export_name: netapp_snapmirror_destination_snapshot_count:federated
+      - export_name: netapp_snapmirror_destination_snapshot_count:remote
         query: |
           netapp_snapmirror_endpoint_labels:enhanced{region="{{ .Values.global.region }}", project_id!="", share_id!=""}
           * on (destination_cluster, destination_vserver, destination_volume) group_left()


### PR DESCRIPTION
Previously snapmirror metrics were only available for EC2/HXM backup
targets (localbkp/remotebkp) and only in regions with federation enabled.

- Add :local recording rules for all snapmirror metrics (labels, lag_time,
  last_transfer_*, snapshot_count) so regions without federation also get
  full coverage — filtered to known Manila shares, no backup-only constraint
- Rename netapp_snapmirror_labels:enhanced → netapp_snapmirror_detailed_labels:enhanced
  to distinguish rich destination-filer data from endpoint-only labels
- Drop intermediate :enhanced recording rules for numeric metrics and
  inline label_replace directly in federation queries
- Remove stale go_build_info stub and region exclusion list from maia.yaml
