### PR TITLE
[absent-alerts-fix] fixed playbook url for prometheus datapath tests absent alerts

### DIFF
--- a/global/thanos-global/Chart.yaml
+++ b/global/thanos-global/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos-global
 description: Deploy Thanos via operator
 type: application
-version: 0.5.19
+version: 0.5.20
 dependencies:
   - name: thanos
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/global/thanos-global/alerts/thanos-global.alerts
+++ b/global/thanos-global/alerts/thanos-global.alerts
@@ -104,7 +104,7 @@ groups:
       support_group: observability
       service: metrics
       meta: Prometheus in region {{ $labels.region }} is not reporting datapath test metrics
-      playbook: docs/support/playbook/prometheus/alerts/cc3test-region-down
+      playbook: docs/support/playbook/prometheus/alerts/cc3test-complete-absence
     annotations:
       description: Region {{ $labels.region }} was reporting Prometheus datapath tests 2 days ago but is not sending metrics currently. This indicates the region is down or the monitoring is broken.
       summary: Region {{ $labels.region }} Prometheus datapath tests are absent


### PR DESCRIPTION
fixed playbook url for prometheus datapath tests absent alerts