### PR TITLE
[Nova] Prepare super-conductor split

### DIFF
--- a/openstack/nova/templates/_helpers.tpl
+++ b/openstack/nova/templates/_helpers.tpl
@@ -290,8 +290,7 @@ Params:
 
 {{- define "nova.helpers.cell_rabbitmq_service" }}
   {{- $envAll := index . 0 }}
-  {{- $rmqChartAlias := include "nova.helpers.cell_rabbitmq_chart_alias" . }}
-  {{- $rmqValues := get $envAll.Values $rmqChartAlias }}
+  {{- $rmqValues := include "nova.helpers.cell_rabbitmq_chart_alias" . | get $envAll.Values }}
   {{- $rmqName := default "rabbitmq" $rmqValues.nameOverride }}
   {{- printf "%s-%s" $envAll.Release.Name $rmqName | trunc 63 | replace "_" "-" | trimSuffix "-" }}
 {{- end }}
@@ -315,13 +314,9 @@ Params:
 {{- define "nova.helpers.cell_rabbitmq_url" }}
   {{- $envAll := index . 0 }}
   {{- $cellId := index . 1 }}
-  {{- $rmqHostInfix := "" }}
-  {{- if not (has $cellId (list "cell0" "cell1")) }}
-    {{- $rmqHostInfix = printf "%s-" (include "nova.helpers.cell_name" .) }}
-  {{- end }}
-  {{- $rmqHost := printf "%s-%srabbitmq" $envAll.Release.Name $rmqHostInfix}}
-  {{- $rmqChartAlias := include "nova.helpers.cell_rabbitmq_chart_alias" . }}
-  {{- $rmqValues := get $envAll.Values $rmqChartAlias }}
+  {{- $rmqValues := include "nova.helpers.cell_rabbitmq_chart_alias" . | get $envAll.Values }}
+  {{- $rmqName := default "rabbitmq" $rmqValues.nameOverride }}
+  {{- $rmqHost := printf "%s-%s" $envAll.Release.Name $rmqName }}
   {{- $data := dict
       "user" (include "nova.helpers.cell_rabbitmq_default_user" .)
       "password" (include "nova.helpers.cell_rabbitmq_default_password" .)

--- a/openstack/nova/templates/_nanny_cronjob.yaml.tpl
+++ b/openstack/nova/templates/_nanny_cronjob.yaml.tpl
@@ -53,10 +53,6 @@ spec:
                   - key: cell0.conf
                     path: nova.conf.d/cell0.conf
                   {{- end }}
-                  {{- if $values.add_cell1_conf }}
-                  - key: cell1.conf
-                    path: nova.conf.d/cell1.conf
-                  {{- end }}
           initContainers:
           {{- tuple . (dict "service" (include "nova.helpers.database_services" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 10 }}
           containers:

--- a/openstack/nova/templates/api-deployment.yaml
+++ b/openstack/nova/templates/api-deployment.yaml
@@ -171,8 +171,10 @@ spec:
               items:
               - key: api-db.conf
                 path: nova.conf.d/api-db.conf
-              - key: cell1.conf
-                path: nova.conf.d/cell1.conf
+              - key: api-rpc.conf
+                path: nova.conf.d/api-rpc.conf
+              - key: cell0.conf
+                path: nova.conf.d/cell0.conf
               - key: keystoneauth-secrets.conf
                 path: nova.conf.d/keystoneauth-secrets.conf
               {{- if .Values.audit.enabled }}

--- a/openstack/nova/templates/api-metadata-deployment.yaml
+++ b/openstack/nova/templates/api-metadata-deployment.yaml
@@ -157,8 +157,8 @@ spec:
               items:
               - key: api-db.conf
                 path: nova.conf.d/api-db.conf
-              - key: cell1.conf
-                path: nova.conf.d/cell1.conf
+              - key: cell0.conf
+                path: nova.conf.d/cell0.conf
               - key: keystoneauth-secrets.conf
                 path: nova.conf.d/keystoneauth-secrets.conf
               {{- if .Values.osprofiler.enabled }}

--- a/openstack/nova/templates/bigvm-deployment.yaml
+++ b/openstack/nova/templates/bigvm-deployment.yaml
@@ -105,8 +105,8 @@ spec:
               items:
               - key: api-db.conf
                 path: nova.conf.d/api-db.conf
-              - key: cell1.conf
-                path: nova.conf.d/cell1.conf
+              - key:  cell0.conf
+                path: nova.conf.d/cell0.conf
               - key: keystoneauth-secrets.conf
                 path: nova.conf.d/keystoneauth-secrets.conf
               {{- if .Values.osprofiler.enabled }}

--- a/openstack/nova/templates/conductor-deployment.yaml
+++ b/openstack/nova/templates/conductor-deployment.yaml
@@ -1,10 +1,11 @@
 {{- $serviceDependencies := printf "%s,%s" (include "nova.helpers.db_service" (tuple . "api")) (include "nova.helpers.cell_services" (tuple . "cell1")) }}
+{{- $cellName := include "nova.helpers.cell_name" (tuple . "cell1") }}
 {{- $conductorArgs := dict
   "name" "nova-conductor"
   "replicas" .Values.pod.replicas.conductor
   "config_file" .Values.conductor.config_file
   "dependencies" (dict "service" $serviceDependencies)
   "config_map_key" "nova-conductor.conf"
-  "secret_key" "cell1.conf"
+  "secret_key" (printf "%s.conf" $cellName)
 }}
 {{ include "nova.conductor_deployment" (tuple . $conductorArgs) }}

--- a/openstack/nova/templates/etc-secret.yaml
+++ b/openstack/nova/templates/etc-secret.yaml
@@ -9,6 +9,8 @@ metadata:
 data:
   api-db.conf: |
     {{ include (print .Template.BasePath "/etc/_api-db.conf.tpl") . | b64enc | indent 4 }}
+  api-rpc.conf: |
+    {{ include (print .Template.BasePath "/etc/_api-rpc.conf.tpl") . | b64enc | indent 4 }}
   {{- $envAll := . }}
   {{- range $cellId := include "nova.helpers.cell_ids_all" . | fromJsonArray }}
   {{- $cellName := include "nova.helpers.cell_name" (tuple $envAll $cellId) }}

--- a/openstack/nova/templates/etc/_api-rpc.conf.tpl
+++ b/openstack/nova/templates/etc/_api-rpc.conf.tpl
@@ -1,0 +1,2 @@
+[DEFAULT]
+transport_url = {{ include "nova.helpers.cell_rabbitmq_url" (tuple . "cell1") }}

--- a/openstack/nova/templates/hypervisors/_ironic-deployment.yaml.tpl
+++ b/openstack/nova/templates/hypervisors/_ironic-deployment.yaml.tpl
@@ -1,6 +1,7 @@
 {{- define "ironic_deployment" -}}
 {{- $hypervisor := index . 1 -}}
 {{- with index . 0 -}}
+{{- $cellName := include "nova.helpers.cell_name" (tuple . "cell1") }}
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -111,14 +112,14 @@ spec:
               name: nova-console
               items:
               {{- range $type := list "serial" "shellinabox" }}
-              - key: console-cell1-{{ $type }}.conf
-                path: nova.conf.d/console-cell1-{{ $type }}.conf
+              - key: console-{{ $cellName }}-{{ $type }}.conf
+                path: nova.conf.d/console-{{ $cellName }}-{{ $type }}.conf
               {{- end }}
           - secret:
               name: nova-etc
               items:
-              - key: cell1.conf
-                path: nova.conf.d/cell1-secrets.conf
+              - key: {{ $cellName }}.conf
+                path: nova.conf.d/{{ $cellName }}-secrets.conf
               - key: keystoneauth-secrets.conf
                 path: nova.conf.d/keystoneauth-secrets.conf
               {{- if .Values.osprofiler.enabled }}

--- a/openstack/nova/templates/scheduler-deployment.yaml
+++ b/openstack/nova/templates/scheduler-deployment.yaml
@@ -120,8 +120,10 @@ spec:
               items:
               - key:  api-db.conf
                 path: nova.conf.d/api-db.conf
-              - key: cell1.conf
-                path: nova.conf.d/cell1.conf
+              - key:  api-rpc.conf
+                path: nova.conf.d/api-rpc.conf
+              - key:  cell0.conf
+                path: nova.conf.d/cell0.conf
               - key: keystoneauth-secrets.conf
                 path: nova.conf.d/keystoneauth-secrets.conf
               {{- if .Values.osprofiler.enabled }}

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -1256,7 +1256,6 @@ nanny:
   default:
     enabled: true
     add_cell0_conf: false
-    add_cell1_conf: false
     resources:
       requests:
         memory: "500Mi"
@@ -1296,7 +1295,7 @@ nanny:
     schedule: "45 * * * *"
     # Requires only a single cell config to derive the DB type in
     # _regex_instance_filter()
-    add_cell1_conf: true
+    add_cell0_conf: true
     max_rows: 250
     fetch_instances_max_retries: 100
 


### PR DESCRIPTION
These changes are basically cleanups for consistency to better allow thinking which services need which resources. They're also preparing for eu-de-3 having 3 properly named cells.

Please see the individual commits' message for more details.