### PR TITLE
Add timestamp alias to audit-ds

### DIFF
--- a/system/opensearch-logs/templates/config/_ds-audit.json.tpl
+++ b/system/opensearch-logs/templates/config/_ds-audit.json.tpl
@@ -11,6 +11,14 @@
     },
     "aliases": {
       "_DS_NAME_-ds": {}
+    },
+    "mappings": {
+      "properties": {
+        "timestamp": {
+          "type": "alias",
+          "path": "@timestamp"
+        }
+      }
     }
   },
   "composed_of": [],


### PR DESCRIPTION
Adds the alias `timestamp` to the index field `@timestamp`, which is the field name required by the Security Analytics plugin.