### PR TITLE
metal-operator-remote: fixes for webhook enablement

### DIFF
--- a/system/Makefile
+++ b/system/Makefile
@@ -147,11 +147,11 @@ build-metal-operator-remote:
 		$(SED) 's/kind: Role/kind: ClusterRole/g' - |\
 		yq eval 'select(.kind != "Service" and .kind != "ValidatingWebhookConfiguration" and .kind != "MutatingWebhookConfiguration")' - >\
 		metal-operator-remote/managedresources/crds-and-rbac.yaml
-	# Extract upstream Deployment template and inject webhook-injector sidecar
+	# Extract upstream Deployment template and inject webhook-injector as native sidecar (initContainer)
 	@tar -xzf metal-operator-remote/charts/metal-operator*.tgz -O metal-operator/templates/manager/manager.yaml |\
 		$(SED) \
 			-e '/namespace: {{ .Release.Namespace }}/d' \
-			-e '/^      securityContext:/i\      {{- include "chart.webhook-injector-sidecar" . | nindent 6 }}' \
+			-e '/^      containers:/i\      initContainers:\n      {{- include "chart.webhook-injector-sidecar" . | nindent 6 }}' \
 		> metal-operator-remote/templates/controller-manager.yaml
 	# Render webhook configurations and rewrite service refs to URL-based
 	@helm template metal-operator metal-operator-remote/charts/metal-operator* \

--- a/system/metal-operator-remote/Chart.yaml
+++ b/system/metal-operator-remote/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.1
+version: 0.6.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/metal-operator-remote/managedresources/rbac.yaml
+++ b/system/metal-operator-remote/managedresources/rbac.yaml
@@ -176,26 +176,20 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: metal-operator-controller-role
+  name: metal-operator-webhook-injector
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
-    verbs:
-      - get
-      - list
-      - watch
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
 ---
-# Source: metal-operator/templates/rbac/metrics_auth_role_binding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: metal-operator-controller-rolebinding
+  name: metal-operator-webhook-injector-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: metal-operator-controller-role
+  name: metal-operator-webhook-injector
 subjects:
   - kind: ServiceAccount
     name: metal-operator-controller-manager

--- a/system/metal-operator-remote/templates/_webhook-injector-sidecar.tpl
+++ b/system/metal-operator-remote/templates/_webhook-injector-sidecar.tpl
@@ -4,24 +4,13 @@
   args:
     - --webhook-config-name=webhook-config
     - --target-kubeconfig=/var/run/remote-kubeconfig/kubeconfig
-  env:
-    - name: POD_NAMESPACE
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.namespace
   ports:
     - name: metrics
       containerPort: 8082
     - name: health
       containerPort: 8083
   securityContext:
-    allowPrivilegeEscalation: false
-    readOnlyRootFilesystem: true
-    runAsNonRoot: true
-    runAsUser: 65534
-    capabilities:
-      drop:
-        - ALL
+    {{- toYaml .Values.controllerManager.manager.podSecurityContext | nindent 4 }}
   resources:
     requests:
       cpu: 50m

--- a/system/metal-operator-remote/templates/_webhook-injector-sidecar.tpl
+++ b/system/metal-operator-remote/templates/_webhook-injector-sidecar.tpl
@@ -1,5 +1,6 @@
 {{- define "chart.webhook-injector-sidecar" -}}
 - name: webhook-injector
+  restartPolicy: Always
   image: {{ .Values.webhookInjector.repository }}:{{ .Values.webhookInjector.tag }}
   args:
     - --webhook-config-name=webhook-config

--- a/system/metal-operator-remote/templates/_webhook-injector-sidecar.tpl
+++ b/system/metal-operator-remote/templates/_webhook-injector-sidecar.tpl
@@ -3,13 +3,17 @@
   image: {{ .Values.webhookInjector.repository }}:{{ .Values.webhookInjector.tag }}
   args:
     - --webhook-config-name=webhook-config
-    - --namespace=kube-system
     - --target-kubeconfig=/var/run/remote-kubeconfig/kubeconfig
+  env:
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
   ports:
     - name: metrics
-      containerPort: 8080
+      containerPort: 8082
     - name: health
-      containerPort: 8081
+      containerPort: 8083
   securityContext:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true
@@ -28,7 +32,7 @@
   livenessProbe:
     httpGet:
       path: /healthz
-      port: 8081
+      port: 8083
     initialDelaySeconds: 15
     periodSeconds: 20
     timeoutSeconds: 5
@@ -36,7 +40,7 @@
   readinessProbe:
     httpGet:
       path: /readyz
-      port: 8081
+      port: 8083
     initialDelaySeconds: 5
     periodSeconds: 10
     timeoutSeconds: 5

--- a/system/metal-operator-remote/templates/controller-manager.yaml
+++ b/system/metal-operator-remote/templates/controller-manager.yaml
@@ -27,6 +27,8 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
     spec:
+      initContainers:
+      {{- include "chart.webhook-injector-sidecar" . | nindent 6 }}
       containers:
       - name: manager
         args:
@@ -82,7 +84,6 @@ spec:
           readOnly: true
           {{- end }}
         {{- end }}
-      {{- include "chart.webhook-injector-sidecar" . | nindent 6 }}
       securityContext:
         {{- toYaml .Values.controllerManager.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ .Values.controllerManager.serviceAccountName }}

--- a/system/metal-operator-remote/templates/networkpolicy.yaml
+++ b/system/metal-operator-remote/templates/networkpolicy.yaml
@@ -16,8 +16,7 @@ spec:
       protocol: TCP
   podSelector:
     matchLabels:
-      app.kubernetes.io/instance: metal-operator-remote
-      app.kubernetes.io/name: metal-operator-remote
+      {{- include "chart.selectorLabels" . | nindent 6 }}
       control-plane: controller-manager
   policyTypes:
   - Ingress
@@ -44,8 +43,7 @@ spec:
           kubernetes.io/metadata.name: ingress-nginx
   podSelector:
     matchLabels:
-      app.kubernetes.io/instance: metal-operator-remote
-      app.kubernetes.io/name: metal-operator-remote
+      {{- include "chart.selectorLabels" . | nindent 6 }}
       control-plane: controller-manager
   policyTypes:
   - Egress
@@ -66,8 +64,28 @@ spec:
           role: apiserver
   podSelector:
     matchLabels:
-      app.kubernetes.io/instance: metal-operator-remote
-      app.kubernetes.io/name: metal-operator-remote
+      {{- include "chart.selectorLabels" . | nindent 6 }}
       control-plane: controller-manager
   policyTypes:
   - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kube-apiserver-egress-to-metalapi
+spec:
+  egress:
+  - ports:
+    - port: 9443
+      protocol: TCP
+    to:
+    - podSelector:
+        matchLabels:
+          {{- include "chart.selectorLabels" . | nindent 10 }}
+          control-plane: controller-manager
+  podSelector:
+    matchLabels:
+      app: kubernetes
+      role: apiserver
+  policyTypes:
+  - Egress

--- a/system/metal-operator-remote/templates/remote-kubeconfig-configmap.yaml
+++ b/system/metal-operator-remote/templates/remote-kubeconfig-configmap.yaml
@@ -14,9 +14,10 @@ data:
     contexts:
     - context:
         cluster: remote
-        user: service-account
+        user: sa
       name: local
     current-context: remote
     users:
-    - user:
+    - name: sa 
+      user:
         tokenFile: /var/run/secrets/kubernetes.io/remote-serviceaccount/token

--- a/system/metal-operator-remote/templates/webhook-service.yaml
+++ b/system/metal-operator-remote/templates/webhook-service.yaml
@@ -11,5 +11,7 @@ spec:
       protocol: TCP
       targetPort: 9443
   selector:
+    app.kubernetes.io/instance: metal-operator-remote
+    app.kubernetes.io/name: metal-operator-remote
     control-plane: controller-manager
 {{- end }}

--- a/system/metal-operator-remote/values-overrides.yaml
+++ b/system/metal-operator-remote/values-overrides.yaml
@@ -38,6 +38,9 @@ controllerManager:
         source:
           configMap:
             name: remote-kubeconfig
+  podSecurityContext:
+    runAsUser: 65532 # ensure sidecar and main controller run as same user, so they can share generated tls certs via emptyDir volume 
+    runAsGroup: 65532
   pod:
     labels:
       networking.gardener.cloud/to-dns: allowed

--- a/system/metal-operator-remote/values.yaml
+++ b/system/metal-operator-remote/values.yaml
@@ -115,6 +115,8 @@ controllerManager:
     runAsNonRoot: true
     seccompProfile:
       type: RuntimeDefault
+    runAsUser: 65532 # ensure sidecar and main controller run as same user, so they can share generated tls certs via emptyDir volume 
+    runAsGroup: 65532
   terminationGracePeriodSeconds: 10
   serviceAccountName: metal-operator-webhook-injector
   hostNetwork: false


### PR DESCRIPTION
* Fix namespace used by webhook-injector
* Fix port collision between sidecar and controller-manager
* Add missing egress network policy for kube-apiserver-> metal-operator-webhook server
* fix remote-kubeconfig configmap
* fix rbac to allow webhook modification in remote cluster
* use securityContext to have both containers use the same uid which fixes permission problems when webhook server tries to read certificates
* deploy web hook-injector as native sidecar
