### PR TITLE
[archer] increase default sql connection limit

### DIFF
--- a/openstack/archer/templates/etc/_archer.ini.tpl
+++ b/openstack/archer/templates/etc/_archer.ini.tpl
@@ -13,7 +13,7 @@ rate_limit = 100
 enable_proxy_headers_parsing = true
 
 [database]
-connection = postgresql://archer@archer-postgresql:5432/archer?sslmode=disable
+connection = postgresql://archer@archer-postgresql:5432/archer?sslmode=disable&pool_max_conns=20
 
 [service_auth]
 auth_url = {{.Values.global.keystone_api_endpoint_protocol_internal | default "http"}}://{{include "keystone_api_endpoint_host_internal" .}}:{{ .Values.global.keystone_api_port_internal | default 5000}}/v3


### PR DESCRIPTION
Default one is max(4, NUM_CPU), which is pretty low given that archer uses a pgx connection pool and parallel connections for pub/sub.