### PR TITLE
[Nova] Fix nova-bigvm requiring a rabbitmq

### DIFF
--- a/openstack/nova/templates/bigvm-deployment.yaml
+++ b/openstack/nova/templates/bigvm-deployment.yaml
@@ -105,6 +105,8 @@ spec:
               items:
               - key: api-db.conf
                 path: nova.conf.d/api-db.conf
+              - key: api-rpc.conf
+                path: nova.conf.d/api-rpc.conf
               - key:  cell0.conf
                 path: nova.conf.d/cell0.conf
               - key: keystoneauth-secrets.conf


### PR DESCRIPTION
I do not know why exactly, but the service doesn't start unless it has a rabbitmq configured. Since nova-bigvm is not a cell-local service, we're adding the api-rpc.conf for the api-rabbitmq.