### PR TITLE
[nova] Add endpointslices to kubernetes-entrypoint RBAC

### DIFF
--- a/openstack/nova/templates/rbac.yaml
+++ b/openstack/nova/templates/rbac.yaml
@@ -22,6 +22,13 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
sapcc/kubernetes-entrypoint watches endpointslices instead of endpoints, see https://github.com/sapcc/kubernetes-entrypoint/blob/main/dependencies/service/service.go#L54