### PR TITLE
[Nova] Set a timeout for Placement requests

### DIFF
--- a/openstack/nova/templates/etc/_nova.conf.tpl
+++ b/openstack/nova/templates/etc/_nova.conf.tpl
@@ -116,6 +116,7 @@ project_name = "{{.Values.global.keystone_service_project | default "service" }}
 project_domain_name = "{{.Values.global.keystone_service_domain | default "Default" }}"
 valid_interfaces = internal
 region_name = {{.Values.global.region}}
+timeout = {{.Values.placement_timeout}}
 
 {{- include "ini_sections.cache" . }}
 

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -200,6 +200,7 @@ cross_az_attach: 'False'
 cinder_http_retries: 10
 neutron_http_retries: 10
 neutron_timeout: 600
+placement_timeout: 600
 
 api:
   config_file:


### PR DESCRIPTION
We'll set a default timeout of 10min for requests to Placement. Previously, we didn't have a timeout and this made nova-conductor get stuck in a lock, not doing any new migrations, while waiting for a call to Keystone that's happening from inside the `openstacksdk`'s `Proxy` to get the project as a cache key. The Placement client in Nova uses `openstacksdk`.