### PR TITLE
[designate] Add endpointslices to kubernetes-entrypoint RBAC

### DIFF
--- a/openstack/designate/templates/rbac.yaml
+++ b/openstack/designate/templates/rbac.yaml
@@ -32,6 +32,13 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
 
 ---
 


### PR DESCRIPTION
sapcc/kubernetes-entrypoint watches endpointslices instead of endpoints, see https://github.com/sapcc/kubernetes-entrypoint/blob/main/dependencies/service/service.go#L54