### PR TITLE
[keystone] Add endpointslices to kubernetes-entrypoint RBAC

### DIFF
--- a/openstack/keystone/templates/rbac.yaml
+++ b/openstack/keystone/templates/rbac.yaml
@@ -32,6 +32,13 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
 
 ---
 

--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -50,7 +50,7 @@ federation:
 
 api:
   image: "loci-keystone"
-  #imageTag: latest
+  # imageTag: latest
 
   ## Specify a imagePullPolicy
   ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'
@@ -171,7 +171,7 @@ api:
 
 cron:
   image: "loci-keystone"
-  #imageTag: latest
+  # imageTag: latest
 
   cronSchedule: "0 * * * *"
 
@@ -240,21 +240,21 @@ services:
     x509:
       # ca: <your ca certificate>
       issuer_attribute: HTTP_SSL_CLIENT_I_DN
-      #trusted_issuer: CN=SSO_CA,O=SAP-AG,C=DE
+      # trusted_issuer: CN=SSO_CA,O=SAP-AG,C=DE
 
     disco: false
 
   public:
     scheme: http
     host: identity-3
-    #tlsCertificate:
-    #tlsKey:
+    # tlsCertificate:
+    # tlsKey:
 
   admin:
     scheme: http
     host: identity-3
-    #tlsCertificate:
-    #tlsKey:
+    # tlsCertificate:
+    # tlsKey:
 
 audit:
   central_service:
@@ -359,7 +359,7 @@ mysql_metrics:
   enabled: true
   db_name: keystone
   db_user: root
-  #db_password: DEFINED-IN-REGION-CHART
+  # db_password: DEFINED-IN-REGION-CHART
   nodeAffinity: {}
   customMetrics:
     - name: openstack_roles_total
@@ -557,7 +557,7 @@ report_invalid_password_hash:
 2fa:
   enabled: false
   replicaCount: 3
-  pollInterval: 1m #how often do we list projects
+  pollInterval: 1m # how often do we list projects
   image: 2faproxy
   imageTag: latest
   imagePullPolicy: IfNotPresent


### PR DESCRIPTION
sapcc/kubernetes-entrypoint watches endpointslices instead of endpoints, see https://github.com/sapcc/kubernetes-entrypoint/blob/main/dependencies/service/service.go#L54