### PR TITLE
fix: template html to match the limes endpoint xml parser

### DIFF
--- a/openstack/limes/files/commitment_mail.tpl
+++ b/openstack/limes/files/commitment_mail.tpl
@@ -1,10 +1,10 @@
 <!doctype html>
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <meta xmlns:v="urn:schemas-microsoft-com:vml">
-        <meta xmlns:o="urn:schemas-microsoft-com:office:office">
-        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta xmlns:v="urn:schemas-microsoft-com:vml"/>
+        <meta xmlns:o="urn:schemas-microsoft-com:office:office"/>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1"/>
         <style>
             table {
               border-collapse: collapse;
@@ -21,14 +21,13 @@
     <body>
         <p><b>Dear SAP Cloud Infrastructure user</b>,</p>
         <p>the following commitments {{ .condition }} for the
-            following project:</p>
-        <p>
-            <ul>
-                <li>Region: {{ .region }}</li>
-                <li>Domain: {{"{{"}}  .DomainName {{"}}"}}</li>
-                <li>Project: {{"{{"}} .ProjectName {{"}}"}}</li>
-            </ul>
+            following project:
         </p>
+        <ul>
+            <li>Region: {{ .region }}</li>
+            <li>Domain: {{"{{"}}  .DomainName {{"}}"}}</li>
+            <li>Project: {{"{{"}} .ProjectName {{"}}"}}</li>
+        </ul>
         {{ .dashboardInfo }}
 
         <div style="overflow-x: auto;">
@@ -63,8 +62,8 @@
         </div>
 
         <p>
-            <div>Thank you,</div>
-            <div> The SAP Cloud Infrastructure Team</div>
+            <span>Thank you,</span><br/>
+            <span> The SAP Cloud Infrastructure Team</span>
         </p>
     </body>
 </html>


### PR DESCRIPTION
The major fix are the terminators for the meta tags. While the clients are more lenient with it, the XML parser marks this as an error. This fixes the endpoint validation.
The remaining changes follow general html nesting rules that I noticed.