### PR TITLE
[utils][coordination] switch to "storageClassName" attribute

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.35.0
+version: 0.36.0

--- a/openstack/utils/templates/_coordination.tpl
+++ b/openstack/utils/templates/_coordination.tpl
@@ -26,9 +26,6 @@ apiVersion: v1
 metadata:
   name: {{ include "utils.coordination.volume_name" . }}
   annotations:
-  {{- if .Values.coordinationBackendStorageClass }}
-    volume.beta.kubernetes.io/storage-class: {{ .Values.coordinationBackendStorageClass | quote }}
-  {{- end }}
   {{- if  index .Values "owner-info" }}
     ccloud/support-group: {{  index .Values "owner-info" "support-group" | quote }}
     ccloud/service: {{  index .Values "owner-info" "service" | quote }}
@@ -39,5 +36,8 @@ spec:
   resources:
     requests:
       storage: {{ .Values.coordinationBackendStorageSize | default "1G" | quote }}
+{{- if .Values.coordinationBackendStorageClass }}
+  storageClassName: {{ .Values.coordinationBackendStorageClass | quote }}
+{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
The `volume.beta.kubernetes.io/storage-class` annotation is deprecated since v1.8.