### PR TITLE
[manila] Add ServiceAccount lookup for migration hook job

### DIFF
--- a/openstack/manila/templates/migration-job.yaml
+++ b/openstack/manila/templates/migration-job.yaml
@@ -5,6 +5,7 @@
      so this script can still work with the previous setting.
 */}}
 {{- $proxysql := lookup "v1" "Secret" .Release.Namespace (print .Release.Name "-proxysql-etc") -}}
+{{- $serviceaccount := lookup "v1" "ServiceAccount" .Release.Namespace .Release.Name -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -29,7 +30,7 @@ spec:
         {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
       restartPolicy: OnFailure
-      {{- if .Values.rbac.enabled }}
+      {{- if $serviceaccount }}
       serviceAccountName: {{ .Release.Name }}
       {{- end }}
 {{- if $proxysql }}


### PR DESCRIPTION
The migration job runs as a Helm hook (post-install,pre-upgrade), so the ServiceAccount may not exist yet during first deployment.