### PR TITLE
[keystone][logging]: add use_json toggle for structured JSON logging

### DIFF
--- a/openstack/keystone/templates/etc/_keystone.conf.tpl
+++ b/openstack/keystone/templates/etc/_keystone.conf.tpl
@@ -1,6 +1,7 @@
 [DEFAULT]
 debug = {{.Values.debug}}
 insecure_debug = {{.Values.insecure_debug}}
+use_json = {{.Values.use_json | default false}}
 verbose = true
 
 {{- with .Values.max_db_limit }}

--- a/openstack/keystone/templates/etc/_keystone.conf.tpl
+++ b/openstack/keystone/templates/etc/_keystone.conf.tpl
@@ -1,7 +1,6 @@
 [DEFAULT]
 debug = {{.Values.debug}}
 insecure_debug = {{.Values.insecure_debug}}
-use_json = {{.Values.use_json | default false}}
 verbose = true
 
 {{- with .Values.max_db_limit }}

--- a/openstack/keystone/templates/etc/_logging.conf.tpl
+++ b/openstack/keystone/templates/etc/_logging.conf.tpl
@@ -168,7 +168,11 @@ formatter = default
 args = ()
 
 [formatter_context]
+{{- if .Values.use_json }}
+class = oslo_log.formatters.JSONFormatter
+{{- else }}
 class = oslo_log.formatters.ContextFormatter
+{{- end }}
 
 [formatter_default]
 format = %(message)s

--- a/openstack/keystone/templates/etc/_wsgi-keystone.conf.tpl
+++ b/openstack/keystone/templates/etc/_wsgi-keystone.conf.tpl
@@ -16,7 +16,7 @@ Listen 0.0.0.0:5000
 
 {{- if .Values.use_json }}
 ErrorLog /dev/stdout
-ErrorLogFormat "{\"timestamp\":\"%{cu}t\",\"levelname\":\"ERROR\",\"name\":\"apache.error\",\"pid\":%P,\"message\":\"%{escape}M\"}"
+ErrorLogFormat "%M"
 LogFormat "{\"timestamp\":\"%{%Y-%m-%dT%H:%M:%S}t.%{msec_frac}t\",\"pid\":%{pid}P,\"levelname\":\"INFO\",\"name\":\"apache.access\",\"request_id\":\"%{X-Openstack-Request-ID}i\",\"client_ip\":\"%a\",\"method\":\"%m\",\"uri\":\"%U%q\",\"protocol\":\"%H\",\"status\":%>s,\"bytes_sent\":%B,\"duration_ms\":%{ms}T,\"referer\":\"%{Referer}i\",\"user_agent\":\"%{User-Agent}i\"}" json_combined
 LogFormat "{\"timestamp\":\"%{%Y-%m-%dT%H:%M:%S}t.%{msec_frac}t\",\"pid\":%{pid}P,\"levelname\":\"INFO\",\"name\":\"apache.access\",\"request_id\":\"%{X-Openstack-Request-ID}i\",\"client_ip\":\"%{X-Forwarded-For}i\",\"method\":\"%m\",\"uri\":\"%U%q\",\"protocol\":\"%H\",\"status\":%>s,\"bytes_sent\":%B,\"duration_ms\":%{ms}T,\"referer\":\"%{Referer}i\",\"user_agent\":\"%{User-Agent}i\"}" json_proxy
 SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
@@ -69,7 +69,7 @@ CustomLog /dev/stdout proxy env=forwarded
     LimitRequestFieldSize 16380
     <IfVersion >= 2.4>
       {{- if .Values.use_json }}
-        ErrorLogFormat "{\"timestamp\":\"%{cu}t\",\"levelname\":\"ERROR\",\"name\":\"apache.error\",\"pid\":%P,\"message\":\"%{escape}M\"}"
+        ErrorLogFormat "%M"
       {{- else }}
         ErrorLogFormat "%{cu}t %M"
       {{- end }}

--- a/openstack/keystone/templates/etc/_wsgi-keystone.conf.tpl
+++ b/openstack/keystone/templates/etc/_wsgi-keystone.conf.tpl
@@ -14,14 +14,23 @@
 
 Listen 0.0.0.0:5000
 
+{{- if .Values.use_json }}
 ErrorLog /dev/stdout
-
+ErrorLogFormat "{\"timestamp\":\"%{cu}t\",\"levelname\":\"ERROR\",\"name\":\"apache.error\",\"pid\":%P,\"message\":\"%{escape}M\"}"
+LogFormat "{\"timestamp\":\"%{%Y-%m-%dT%H:%M:%S}t.%{msec_frac}t\",\"pid\":%{pid}P,\"levelname\":\"INFO\",\"name\":\"apache.access\",\"request_id\":\"%{X-Openstack-Request-ID}i\",\"client_ip\":\"%a\",\"method\":\"%m\",\"uri\":\"%U%q\",\"protocol\":\"%H\",\"status\":%>s,\"bytes_sent\":%B,\"duration_ms\":%{ms}T,\"referer\":\"%{Referer}i\",\"user_agent\":\"%{User-Agent}i\"}" json_combined
+LogFormat "{\"timestamp\":\"%{%Y-%m-%dT%H:%M:%S}t.%{msec_frac}t\",\"pid\":%{pid}P,\"levelname\":\"INFO\",\"name\":\"apache.access\",\"request_id\":\"%{X-Openstack-Request-ID}i\",\"client_ip\":\"%{X-Forwarded-For}i\",\"method\":\"%m\",\"uri\":\"%U%q\",\"protocol\":\"%H\",\"status\":%>s,\"bytes_sent\":%B,\"duration_ms\":%{ms}T,\"referer\":\"%{Referer}i\",\"user_agent\":\"%{User-Agent}i\"}" json_proxy
+SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
+CustomLog /dev/stdout json_combined env=!forwarded
+CustomLog /dev/stdout json_proxy env=forwarded
+{{- else }}
+ErrorLog /dev/stdout
 LogFormat "%{%Y-%m-%d %T}t.%{msec_frac}t %{pid}P INFO apache \"%{X-Openstack-Request-ID}i\" %h %l %u \"%r\" %>s %b %{ms}T \"%{Referer}i\" \"%{User-Agent}i\"" combined
 LogFormat "%{%Y-%m-%d %T}t.%{msec_frac}t %{pid}P INFO apache \"%{X-Openstack-Request-ID}i\" %{X-Forwarded-For}i %l %u \"%r\" %>s %b %{ms}T \"%{Referer}i\" \"%{User-Agent}i\"" proxy
-
 SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
 CustomLog /dev/stdout combined env=!forwarded
 CustomLog /dev/stdout proxy env=forwarded
+{{- end }}
+
 
 {{- if .Values.federation.oidc.enabled }}
 <Location "/v3/auth/OS-FEDERATION/websso/openid">
@@ -59,14 +68,22 @@ CustomLog /dev/stdout proxy env=forwarded
     # LimitRequestFieldSize is needed because of OIDC, 2*default
     LimitRequestFieldSize 16380
     <IfVersion >= 2.4>
-      ErrorLogFormat "%{cu}t %M"
+      {{- if .Values.use_json }}
+        ErrorLogFormat "{\"timestamp\":\"%{cu}t\",\"levelname\":\"ERROR\",\"name\":\"apache.error\",\"pid\":%P,\"message\":\"%{escape}M\"}"
+      {{- else }}
+        ErrorLogFormat "%{cu}t %M"
+      {{- end }}
     </IfVersion>
     ErrorLog /dev/stdout
-
-    SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
-    CustomLog /dev/stdout combined env=!forwarded
-    CustomLog /dev/stdout proxy env=forwarded
-
+    {{- if .Values.use_json }}
+        SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
+        CustomLog /dev/stdout json_combined env=!forwarded
+        CustomLog /dev/stdout json_proxy env=forwarded
+    {{- else }}
+        SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
+        CustomLog /dev/stdout combined env=!forwarded
+        CustomLog /dev/stdout proxy env=forwarded
+    {{- end }}
     KeepAliveTimeout 61
 </VirtualHost>
 

--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -23,6 +23,7 @@ owner-info:
 
 debug: false
 insecure_debug: false
+use_json: false
 # max_db_limit: 1000
 
 # run a db_sync to migrate the db schema ?


### PR DESCRIPTION
## Summary
Add a \`use_json\` values flag (default: false) that switches all keystone log sources to structured JSON output when enabled.

## Changes
- oslo.log: \`use_json = true\` in \`[DEFAULT]\` switches ContextFormatter → JSONFormatter at runtime
- Apache access logs: JSON LogFormat (json_combined/json_proxy)
- Apache error logs: JSON ErrorLogFormat with \`%{escape}M\` (safe for stack traces, requires Apache >= 2.4.46)

## Motivation
Better consumption to the  OTel Collector instead of grok pattern matching 

## Rollback
Set \`use_json: false\` in the region values file.
