### PR TITLE
feat(greenhouse-org): redirect ccloud dashboard

### DIFF
--- a/system/greenhouse-organization/Chart.yaml
+++ b/system/greenhouse-organization/Chart.yaml
@@ -1,8 +1,9 @@
 apiVersion: v2
 name: greenhouse-organization
-description: A Helm chart for resources required for running the Greenhouse admin organization in Greenhouse.
+description: A Helm chart for resources required for running the Greenhouse
+  admin organization in Greenhouse.
 type: application
-version: 0.6.10
+version: 0.6.11
 dependencies:
   - name: secrets-injector
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/system/greenhouse-organization/templates/organization/ccloud-ingress.yaml
+++ b/system/greenhouse-organization/templates/organization/ccloud-ingress.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.ingress.redirectCCloudOrg }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    disco: "true"
+    kubernetes.io/tls-acme: "true"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      return 301 https://sci.dashboard.{{ .Values.global.dnsDomain }}$request_uri;
+  labels:
+    app.kubernetes.io/managed-by: Helm
+  name: greenhouse-ui-dashboard-ccloud
+  namespace: greenhouse
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: ccloud.dashboard.{{ .Values.global.dnsDomain }}
+{{- end }}

--- a/system/greenhouse-organization/templates/plugins/ingress-nginx.yaml
+++ b/system/greenhouse-organization/templates/plugins/ingress-nginx.yaml
@@ -22,11 +22,18 @@ spec:
       value: true
     - name: controller.scope.enabled
       value: false
+{{- if .Values.ingress.redirectCCloudOrg }}
+    - name: controller.allowSnippetAnnotations
+      value: "true"
+{{- end }}
     - name: controller.config
       value:
         allow-cross-namespace-resources: true
         # oauth2-proxy uses large headers
         large-client-header-buffers: "4 32k"
+{{- if .Values.ingress.redirectCCloudOrg }}
+        annotations-risk-level: Critical
+{{- end }}
     {{- if .Values.ingress.loadBalancerIP }}
     - name: controller.service.loadBalancerIP
       value: {{ .Values.ingress.loadBalancerIP | quote }}

--- a/system/greenhouse-organization/values.yaml
+++ b/system/greenhouse-organization/values.yaml
@@ -164,6 +164,8 @@ ingress:
   enabled: true
   # Specify the loadBalancer IP for the ingress service.
   # loadBalancerIP:
+  # redirect ccloud org
+  redirectCCloudOrg: false
 
 monitoring:
   enabled: false


### PR DESCRIPTION
with the optional  flag an
additional ingress is created with the purpose of redirecting
from ccloud.dashboard.tld to sci.dashboard.tld
in order to keep the request path it is necessary to
enable ingress annotation snippets and set the
validation to Critical.
The redirect is to make the transition from ccloud to sci
smooth without breaking bookmarks pointing to the old apps.
