### PR TITLE
[cc-gardener] Bump gardener-extension-provider-openstack to v1.54.0

### DIFF
--- a/global/cc-gardener/Chart.yaml
+++ b/global/cc-gardener/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cc-gardener
 description: Converged Cloud Gardener setup based on gardener-operator
 type: application
-version: 0.30.0
+version: 0.30.1
 appVersion: "v1.139.1"
 home: https://github.com/gardener/gardener
 dependencies:

--- a/global/cc-gardener/values.yaml
+++ b/global/cc-gardener/values.yaml
@@ -518,7 +518,7 @@ extensions:
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/charts/gardener/extensions/os-coreos
   openstack:
     enabled: false
-    version: v1.53.1
+    version: v1.54.0
     values:
       image:
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/extensions/provider-openstack


### PR DESCRIPTION
This version includes critical fixes for KVM flavors with zero ephemeral disk:
- Properly derives rootDiskType and rootDiskSize from CloudProfile machine type storage
- Enables boot-from-volume for KVM flavors that require volume-backed servers

Breaking change in v1.54.0:
Machine types with Storage.Type other than "default" now have explicit root disk settings in MachineClass. This is required for KVM flavors to work correctly.

Release notes: https://github.com/gardener/gardener-extension-provider-openstack/releases/tag/v1.54.0

Fixes: "Only volume-backed servers are allowed for flavors with zero disk" error