### PR TITLE
[mysql_metrics] make use of .Values.global.clusterDNSSearchDomain

### DIFF
--- a/common/mysql_metrics/Chart.yaml
+++ b/common/mysql_metrics/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for MySQL Metrics
 name: mysql_metrics
-version: 0.7.0
+version: 0.8.0
 dependencies:
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/common/mysql_metrics/ci/test-values.yaml
+++ b/common/mysql_metrics/ci/test-values.yaml
@@ -1,6 +1,7 @@
 ---
 global:
   registry: test
+  clusterDNSSearchDomain: cluster.local
 
 test_db_host: testRelease-mariadb.svc
 

--- a/common/mysql_metrics/templates/_helpers.tpl
+++ b/common/mysql_metrics/templates/_helpers.tpl
@@ -7,6 +7,14 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
+Generate the service DNS domain
+*/}}
+{{/*- printf "%s.svc.%s" $.db_namespace ( $.Values.global.clusterDNSSearchDomain | required "missing value for .Values.global.clusterDNSSearchDomain" ) -*/}}
+{{- define "svc_dns_domain" -}}
+{{ $.db_namespace }}.svc.{{ $.Values.global.clusterDNSSearchDomain | required "missing value for .Values.global.clusterDNSSearchDomain" }}
+{{- end -}}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
@@ -23,15 +31,16 @@ Return the FQDN name of the database instance.
     {{- if hasKey .Values "db_namespace" -}}
         {{- $db_namespace = .Values.db_namespace -}}
     {{- end -}}
+    {{- $svc_dns_domain := include "svc_dns_domain" (dict "db_namespace" $db_namespace "Values" .Values ) -}}
     {{- if .Values.db_instance_name_literal -}}
-        {{ .Values.db_instance_name_literal }}.{{ $db_namespace }}.svc.kubernetes.{{ .Values.global.region }}.{{ .Values.global.tld }}
+        {{ .Values.db_instance_name_literal }}.{{ $svc_dns_domain }}
     {{- else -}}
         {{- if eq .Values.db_type "pxc" -}}
         {{ .Release.Name }}-percona-pxc.{{ $db_namespace }}.svc.kubernetes.{{ .Values.global.db_region }}.{{ .Values.global.tld }}
         {{- else if eq .Values.db_type "pxc-db" -}}
-        {{ .Release.Name }}-db-haproxy.{{ $db_namespace }}.svc.kubernetes.{{ .Values.global.region }}.{{ .Values.global.tld }}
+        {{ .Release.Name }}-db-haproxy.{{ $svc_dns_domain }}
         {{- else -}}
-        {{ .Release.Name }}-mariadb.{{ $db_namespace }}.svc.kubernetes.{{ .Values.global.region }}.{{ .Values.global.tld }}
+        {{ .Release.Name }}-mariadb.{{ $svc_dns_domain }}
         {{- end -}}
     {{- end -}}
 {{- end }}
@@ -94,8 +103,9 @@ For pxc-global returns FQDN of the service in sepcified region.
     {{- if hasKey $connection "db_namespace" -}}
         {{- $db_namespace = $connection.db_namespace -}}
     {{- end -}}
+    {{- $svc_dns_domain := include "svc_dns_domain" (dict "db_namespace" $db_namespace "Values" $root.Values ) -}}
     {{- if $connection.db_instance_name_literal -}}
-        {{ $connection.db_instance_name_literal }}.{{ $db_namespace }}.svc.kubernetes.{{ $root.Values.global.region }}.{{ $root.Values.global.tld }}
+        {{ $connection.db_instance_name_literal }}.{{ $svc_dns_domain }}
     {{- else -}}
         {{- if $connection.db_instance_name -}}
             {{- $prefix = printf "%s-%s" $root.Release.Name $connection.db_instance_name -}}
@@ -103,13 +113,13 @@ For pxc-global returns FQDN of the service in sepcified region.
         {{- if eq $connection.db_type "pxc" -}}
             {{ $prefix }}-percona-pxc.{{ $db_namespace }}.svc.kubernetes.{{ $root.Values.global.db_region }}.{{ $root.Values.global.tld }}
         {{- else if eq $connection.db_type "pxc-db" -}}
-            {{ $prefix }}-db-haproxy.{{ $db_namespace }}.svc.kubernetes.{{ $root.Values.global.region }}.{{ $root.Values.global.tld }}
+            {{ $prefix }}-db-haproxy.{{ $svc_dns_domain }}
         {{- else -}}
-            {{ $prefix }}-mariadb.{{ $db_namespace }}.svc.kubernetes.{{ $root.Values.global.region }}.{{ $root.Values.global.tld }}
+            {{ $prefix }}-mariadb.{{ $svc_dns_domain }}
         {{- end -}}
     {{- end -}}
 {{- end }}
 
 {{/* Needed for testing purposes only. */}}
-{{define "RELEASE-NAME_db_host"}}testRelease-mariadb.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.region}}.{{.Values.global.tld}}{{end}}
-{{define "testRelease_db_host"}}testRelease-mariadb.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.region}}.{{.Values.global.tld}}{{end}}
+{{define "RELEASE-NAME_db_host"}}testRelease-mariadb.{{ include "svc_dns_domain" dict ( "db_namespace" .Release.Namespace "Values" .Values ) }}{{end}}
+{{define "testRelease_db_host"}}testRelease-mariadb.{{ include "svc_dns_domain" dict ( "db_namespace" .Release.Namespace "Values" .Values ) }}{{end}}


### PR DESCRIPTION
Not all services follow the hardcoded schema
<service_name>.<namespace>.svc.kubernetes.<.Values.global.region><.Values.global.tld>