### PR TITLE
[rabbitmq] make use of clusterDNSSearchDomain

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+## 0.24.0 - 2026/04/28
+
+- Use `clusterDNSSearchDomain` to generate the certificate default common name and SAN
+  - Used to be the hardcoded `<fullname>.<namespace>.svc.kubernetes.<region>.<tld>`
+  - Now it's `<fullname>.<namespace>.svc.<clusterDNSSearchDomain>`
+- Chart version bumped
+
 ## 0.23.0 - 2026/04/27
 
 - RabbitMQ [4.3.0 Release notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.3.0)

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: rabbitmq
-version: 0.23.0
+version: 0.24.0
 appVersion: 4.3.0
 description: A Helm chart for RabbitMQ
 sources:

--- a/common/rabbitmq/ci/test-values.yaml
+++ b/common/rabbitmq/ci/test-values.yaml
@@ -9,6 +9,7 @@ global:
   dockerHubMirrorAlternateRegion: other.dockerhub.mirro
   region: "region"
   tld: "tld"
+  clusterDNSSearchDomain: kubernetes.region.tld
 
 ports:
   public: 5672

--- a/common/rabbitmq/templates/_helpers.tpl
+++ b/common/rabbitmq/templates/_helpers.tpl
@@ -34,19 +34,31 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
     {{- end }}
 {{- end }}
 
+{{- define "rabbitmq.svc_dns_domain" -}}
+{{ $.Release.Namespace }}.svc.{{ $.Values.global.clusterDNSSearchDomain | required "missing value for .Values.global.clusterDNSSearchDomain" }}
+{{- end -}}
+
 {{- define "rabbitmq.serviceName" -}}
-"{{ template "fullname" . }}.{{ .Release.Namespace }}.svc.kubernetes.{{ .Values.global.region | required "global.region missing" }}.{{ .Values.global.tld | required "global.tld missing" }}"
+"{{ template "fullname" . }}.{{ include "rabbitmq.svc_dns_domain" . }}"
+{{- end }}
+
+{{/*
+A lame attempt at making the service name shorter, which is needed for TLS common names.
+Will strip "svc." if clusterDNSSearchDomain is something like "cluster.local"
+Will strip "svc.kubernetes." if clusterDNSSearchDomain is something like "kubernetes.region.tld"
+*/}}
+{{- define "rabbitmq.shortServiceName" -}}
+{{ include "rabbitmq.serviceName" . | replace "svc." "" | replace "kubernetes." "" }}
 {{- end }}
 
 {{/* By default, the name is the dns name, but that may be too long, so we might to have to shorten it.
      If the actual value matters to you, set it directly. */}}
 {{- define "rabbitmq.defaultCommonName" -}}
 {{- $serviceName := include "rabbitmq.serviceName" . }}
-  {{- if le (len $serviceName) 64 }}
-    {{- $serviceName }}
-  {{- else -}}
-    "{{ template "fullname" . }}.{{ .Values.global.region | required "global.region missing" }}.{{ .Values.global.tld | required "global.tld missing" }}"
+  {{- if gt (len $serviceName) 64 }}
+     {{- $serviceName = include "rabbitmq.shortServiceName" . }}
   {{- end }}
+  {{- $serviceName }}
 {{- end }}
 
 {{/* Generate the service label for the templated Prometheus alerts. */}}


### PR DESCRIPTION
Not all service FQDNs follow the schema
`<service>.<namespace>.svc.kubernetes.<region>.<tld>`