### PR TITLE
[designate] take care of the service FQDNs

### DIFF
--- a/openstack/designate/Chart.lock
+++ b/openstack/designate/Chart.lock
@@ -13,10 +13,10 @@ dependencies:
   version: 0.6.12
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.6.0
+  version: 0.8.1
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.22.1
+  version: 0.24.0
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.36.0
@@ -29,5 +29,5 @@ dependencies:
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.3.1
-digest: sha256:830bdb1d56a09a6baff3907acfd1ceec41beca63082cf326a32a9dfa6a338b80
-generated: "2026-04-27T11:56:19.037706+02:00"
+digest: sha256:955b5fdcb099fa2ab5684005a169a02d9bd5a86dbda77b3a7ed14543092518a9
+generated: "2026-04-28T15:12:36.44019+02:00"

--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -24,11 +24,11 @@ dependencies:
   - condition: mysql_metrics.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.6.0
+    version: 0.8.1
   - name: rabbitmq
     condition: rabbitmq.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.22.1
+    version: 0.24.0
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.36.0

--- a/openstack/designate/ci/test-values.yaml
+++ b/openstack/designate/ci/test-values.yaml
@@ -13,6 +13,7 @@ global:
   is_global_region: false
   domain_seeds:
     customer_domains: [ bar, foo, baz ]
+  clusterDNSSearchDomain: cluster.local
 
 
 vice_president: true

--- a/openstack/designate/templates/etc/_designate.conf.tpl
+++ b/openstack/designate/templates/etc/_designate.conf.tpl
@@ -231,7 +231,7 @@ region_name = {{.Values.global.region}}
 {{- if .Values.global.is_global_region }}
 memcached_servers = {{.Release.Name}}-memcached.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.db_region}}.{{.Values.global.tld}}:{{.Values.global.memcached_port_public | default 11211}}
 {{- else }}
-memcached_servers = {{.Release.Name}}-memcached.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.region}}.{{.Values.global.tld}}:{{.Values.global.memcached_port_public | default 11211}}
+memcached_servers = {{.Release.Name}}-memcached.{{ include "svc_fqdn" . }}:{{.Values.global.memcached_port_public | default 11211}}
 {{- end }}
 {{- if .Values.global.is_global_region }}
 insecure = False

--- a/openstack/designate/templates/seeds.yaml
+++ b/openstack/designate/templates/seeds.yaml
@@ -63,14 +63,14 @@ spec:
 {{- if .Values.global.is_global_region }}
       url: http://{{ .Values.global.designate_internal_ip }}:9001
 {{- else }}
-      url: http://{{ .Release.Name }}-api.{{ .Release.Namespace }}.svc.kubernetes.{{ .Values.global.region }}.{{ .Values.global.tld }}:9001
+      url: http://{{ include "designate_api_endpoint_host_internal" . }}:9001
 {{- end }}
     - interface: admin
       region: {{ .Values.global.region }}
 {{- if .Values.global.is_global_region }}
       url: http://{{ .Values.global.designate_admin_ip }}:9001
 {{- else }}
-      url: http://{{ .Release.Name }}-api.{{ .Release.Namespace }}.svc.kubernetes.{{ .Values.global.region }}.{{ .Values.global.tld }}:9001
+      url: http://{{ include "designate_api_endpoint_host_admin" . }}:9001
 {{- end }}
 
 


### PR DESCRIPTION
That commit covers:
- mysql_metrics
- rabbitmq
- memcached

Some services, where `.Values.global.is_global_region` is set to `true`, are still being consumed using FQDNs based on the the old schema, e.g.
```
{{- if .Values.global.is_global_region }}
memcached_servers = {{.Release.Name}}-memcached.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.db_region}}.{{.Values.global.tld}}:{{.Values.global.memcached_port_public | default 11211}}
{{-else}}
...
{{-end}}
```