### PR TITLE
[cinder] update utils chart to 0.36.0

### DIFF
--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.27.2
+  version: 0.36.0
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.31.0
@@ -26,5 +26,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:ef2696853bf7e361243bc7d9815caaf9788a0d7e6ba2d38f5314f784484a4aad
-generated: "2026-04-02T12:17:37.310014+03:00"
+digest: sha256:7f12f95e5682ca5fc475f74cf193ef54fa4c14895c232709853759cbe5ba9f5f
+generated: "2026-04-29T11:17:19.959227+02:00"

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -7,7 +7,7 @@ version: 0.3.8
 dependencies:
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.27.2
+    version: 0.36.0
   - name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.31.0


### PR DESCRIPTION
Update utils chart to 0.36.0
- switch to "storageClassName" attribute
Currently cinder-coordination fails to provision, because we are using out-dated: 
volume.beta.kubernetes.io/storage-class: nfs-zone-a anotation