### PR TITLE
[Cinder] Change the vcenter storage profile for FCD STDHDD

### DIFF
--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -79,7 +79,7 @@ backends:
     vmware_storage_profile: cinder-standard-hdd
     enable_image_cache: False
   standard_hdd_fcd:
-    vmware_storage_profile: cinder-standard-hdd
+    vmware_storage_profile: cinder-fcd-std
     enable_image_cache: False
 
 


### PR DESCRIPTION
The new name of the standard_hdd_fcd vcenter storage profile has changed.  This patch updates the default name.