### PR TITLE
[rabbitmq] enable transient_nonexcl_queues option

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+## 0.24.1 - 2026/04/30
+- Enable transient_nonexcl_queues option, as it's in use by some services
+- Chart version bumped
+
 ## 0.24.0 - 2026/04/28
 
 - Use `clusterDNSSearchDomain` to generate the certificate default common name and SAN

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: rabbitmq
-version: 0.24.0
+version: 0.24.1
 appVersion: 4.3.0
 description: A Helm chart for RabbitMQ
 sources:

--- a/common/rabbitmq/values.yaml
+++ b/common/rabbitmq/values.yaml
@@ -127,6 +127,9 @@ customConfig:
   # to set a custom limit please use the following format: 50MB or 1GB
   # if not set default value of 50MB will be used
   # disk_free_limit.absolute: 500MB
+  # Enables deprecated non-durable (transient) non-exclusive queues
+  # (disabled by default as of RabbitMQ `4.3.0`, will be removed in a later version)
+  deprecated_features.permit.transient_nonexcl_queues: 'true'
 
 credentialUpdater:
   enabled: true


### PR DESCRIPTION
- Enable transient_nonexcl_queues deprecated option, as it's in use by some services
- Chart version bumped