### PR TITLE
[designate] bump rabbitmq

### DIFF
--- a/openstack/designate/Chart.lock
+++ b/openstack/designate/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 0.8.1
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.24.0
+  version: 0.24.1
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.36.0
@@ -29,5 +29,5 @@ dependencies:
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.3.1
-digest: sha256:955b5fdcb099fa2ab5684005a169a02d9bd5a86dbda77b3a7ed14543092518a9
-generated: "2026-04-28T15:12:36.44019+02:00"
+digest: sha256:9eae8c965b35056757bcd490172fa4ad7e688b1b03ea5f2821ec1a247c9fbf92
+generated: "2026-04-30T16:04:58.976926+02:00"

--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -28,7 +28,7 @@ dependencies:
   - name: rabbitmq
     condition: rabbitmq.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.24.0
+    version: 0.24.1
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.36.0


### PR DESCRIPTION
This new version should solve the following problem:
```
ERROR oslo.messaging._drivers.impl_rabbit [-] Internal amqp error (541) during queue declare,retrying in 2 seconds. Queue: [central], error message: [Queue.declare: (541) INTERNAL_ERROR - Feature `transient_nonexcl_queues` is deprecated.
By default, this feature is not permitted anymore.
```

Ideally we should stop pusing this deprecated feature.