### PR TITLE
[Neutron] Move vcenter-operator nsxv3-agent labels/annotations

### DIFF
--- a/openstack/neutron/templates/vct-nsxv3-agent-deployment.yaml
+++ b/openstack/neutron/templates/vct-nsxv3-agent-deployment.yaml
@@ -23,14 +23,6 @@ template: |
       vcenter: {= host =}
       datacenter: {= availability_zone =}
       vccluster: {= cluster_name =}
-      {{- if .Values.nsxv3_managed_service_users }}
-      vcenter-operator-secret-version: {= service_user_version | quote =}
-      {{- end }}
-    {{- if .Values.nsxv3_managed_service_users }}
-    # Must match vcsu name
-    annotations:
-      uses-service-user: nsxt
-    {{- end }}
   spec:
     replicas: 1
     revisionHistoryLimit: 5
@@ -52,12 +44,19 @@ template: |
           vcenter: {= host =}
           datacenter: {= availability_zone =}
           vccluster: {= cluster_name =}
+          {{- if .Values.nsxv3_managed_service_users }}
+          vcenter-operator-secret-version: {= service_user_version | quote =}
+          {{- end }}
         annotations:
           kubectl.kubernetes.io/default-container: neutron-nsxv3-agent
           configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") . | sha256sum }}
           prometheus.io/scrape: "true"
           prometheus.io/targets: {{ required ".Values.metrics.prometheus missing" .Values.metrics.prometheus | quote }}
           {{- include "utils.linkerd.pod_and_service_annotation" . | indent 10 }}
+          {{- if .Values.nsxv3_managed_service_users }}
+          # Must match vcsu name
+          uses-service-user: nsxt
+          {{- end }}
       spec:
         containers:
         - name: neutron-nsxv3-agent


### PR DESCRIPTION
The `vcenter-operator-secret-version` label and `uses-service-user` annotation where wrongly placed on the Deployment, not inside the Pod template. With them in the wrong place, `vcenter-operator` will delete old service users before all pods using these have read the new service user. This will keep a pod running without access and could create an outage.