### PR TITLE
feat(cc-shoots): add `spec.purpose=production` to all shoot templates

### DIFF
--- a/system/cc-shoots-compute/Chart.yaml
+++ b/system/cc-shoots-compute/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-shoots-compute
 description: Converged Cloud Gardener shoots
 type: application
-version: 2.3.2
+version: 2.3.3
 appVersion: "0.1.0"

--- a/system/cc-shoots-compute/templates/kvm-shoot.yaml
+++ b/system/cc-shoots-compute/templates/kvm-shoot.yaml
@@ -11,6 +11,7 @@ metadata:
     greenhouse.sap/shoot-grafter-transport: {{ default "greenhouse-prod-sci" $.Values.greenhouseShootGrafter }}
     metadata.greenhouse.sap/region: {{ coalesce $.Values.contextSuffix $cluster.region }}
 spec:
+  purpose: {{ default "production" $cluster.purpose }}
   cloudProfile:
     kind: CloudProfile
     name: ironcore-metal

--- a/system/cc-shoots-controlplane/Chart.yaml
+++ b/system/cc-shoots-controlplane/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-shoots-controlplane
 description: Converged Cloud Gardener Controlplane shoots
 type: application
-version: 1.0.3
+version: 1.0.4
 appVersion: "0.1.0"

--- a/system/cc-shoots-controlplane/templates/controlplane-shoot.yaml
+++ b/system/cc-shoots-controlplane/templates/controlplane-shoot.yaml
@@ -10,6 +10,7 @@ metadata:
     greenhouse.sap/shoot-grafter-transport: {{ default "greenhouse-prod-sci" $.Values.greenhouseShootGrafter }}
     metadata.greenhouse.sap/region: {{ $key }}
 spec:
+  purpose: {{ default "production" $cluster.purpose }}
   cloudProfile:
     kind: CloudProfile
     name: ironcore-metal

--- a/system/cc-shoots-mgmt/Chart.yaml
+++ b/system/cc-shoots-mgmt/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-shoots-mgmt
 description: Converged Cloud Gardener shoots
 type: application
-version: 1.1.29
+version: 1.1.30
 appVersion: "0.1.0"

--- a/system/cc-shoots-mgmt/templates/mgmt-shoot.yaml
+++ b/system/cc-shoots-mgmt/templates/mgmt-shoot.yaml
@@ -12,6 +12,7 @@ metadata:
     greenhouse.sap/shoot-grafter-transport: {{ default "greenhouse-prod-sci" $.Values.greenhouseShootGrafter }}
     metadata.greenhouse.sap/region: {{ $key }}
 spec:
+  purpose: {{ default "production" $cluster.purpose }}
   cloudProfile:
     kind: CloudProfile
     name: ironcore-metal

--- a/system/cc-shoots-storage/Chart.yaml
+++ b/system/cc-shoots-storage/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-shoots-storage
 description: Converged Cloud Gardener Storage shoots
 type: application
-version: 0.0.8
+version: 0.0.9
 appVersion: "0.1.0"

--- a/system/cc-shoots-storage/templates/storage-shoot.yaml
+++ b/system/cc-shoots-storage/templates/storage-shoot.yaml
@@ -10,6 +10,7 @@ metadata:
     greenhouse.sap/owned-by: storage
     greenhouse.sap/shoot-grafter-transport: {{ default "greenhouse-prod-sci" $.Values.greenhouseShootGrafter }}
 spec:
+  purpose: {{ default "production" $cluster.purpose }}
   cloudProfile:
     kind: CloudProfile
     name: ironcore-metal

--- a/system/cc-shoots-workerless/Chart.yaml
+++ b/system/cc-shoots-workerless/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-shoots-workerless
 description: Converged Cloud Gardener Workerless Shoots
 type: application
-version: 0.0.5
+version: 0.0.6
 appVersion: "0.1.0"

--- a/system/cc-shoots-workerless/templates/shoot-workerless.yaml
+++ b/system/cc-shoots-workerless/templates/shoot-workerless.yaml
@@ -14,6 +14,7 @@ metadata:
     greenhouse.sap/shoot-grafter-transport: {{ default "greenhouse-prod-sci" $.Values.greenhouseShootGrafter }}
     metadata.greenhouse.sap/region: {{ $regionName }}
 spec:
+  purpose: {{ default "production" $cluster.purpose }}
   cloudProfile:
     kind: CloudProfile
     name: openstack

--- a/system/cc-shoots/Chart.yaml
+++ b/system/cc-shoots/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-shoots
 description: Converged Cloud Gardener shoots
 type: application
-version: 0.6.7
+version: 0.6.8
 appVersion: "0.1.0"

--- a/system/cc-shoots/templates/metal-shoot.yaml
+++ b/system/cc-shoots/templates/metal-shoot.yaml
@@ -12,6 +12,7 @@ metadata:
     greenhouse.sap/shoot-grafter-transport: {{ default "greenhouse-prod-sci" $.Values.greenhouseShootGrafter }}
     metadata.greenhouse.sap/region: {{ $regionName }}
 spec:
+  purpose: {{ default "production" $region.purpose }}
   cloudProfile:
     kind: CloudProfile
     name: openstack


### PR DESCRIPTION
Adds `.spec.purpose: production` to all cc-shoots* Shoot templates as per [Gardener shoot purposes documentation](https://gardener.cloud/docs/gardener/shoot/shoot_purposes/#behavioral-differences).