### PR TITLE
nova: add compute workload RBAC for cross-cluster access

### DIFF
--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 name: nova
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Nova/OpenStack_Project_Nova_mascot.png
-version: 0.6.6
+version: 0.6.7
 appVersion: "bobcat"
 dependencies:
   - condition: mariadb.enabled

--- a/openstack/nova/templates/compute-workload-rbac.yaml
+++ b/openstack/nova/templates/compute-workload-rbac.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.computeWorkloadRBAC.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: compute-workload-reader
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: ["apps"]
+    resources: ["daemonsets", "deployments", "statefulsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: compute-workload-reader
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: Group
+    name: {{ .Values.computeWorkloadRBAC.group }}
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: compute-workload-reader
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/openstack/nova/values.yaml
+++ b/openstack/nova/values.yaml
@@ -28,6 +28,10 @@ osprofiler: {}
 rbac:
   enabled: true
 
+computeWorkloadRBAC:
+  enabled: false
+  group: compute-workloads
+
 auto_assign_aggregates: 'dry_run'
 
 use_tls_acme: true


### PR DESCRIPTION
Add a namespaced Role and RoleBinding allowing the compute-workloads
group read-only access to daemonsets, deployments, statefulsets,
configmaps, and secrets. This enables compute shoot workloads
authenticating via Vault OIDC to read nova-related configuration
from the controlplane.

Disabled by default, enabled per-region via values override.

This is a requirement for a multi-cluster operator that syncs
nova/neutron specific configuration from the controlplane clusters to
the compute cluster
