### PR TITLE
.github: add @LeoZhangZXZ to hermes-related CODEOWNERS entries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -79,7 +79,7 @@
 /openstack/elektra                                     @andypf @edda @ArtieReus @hgw77
 /openstack/glance                                      @rajivmucheli @seb-kro @Scsabiii @stefanhipfel
 /openstack/grafanasix                                  @viennaa @richardtief @Kuckkuck @IvoGoman @timojohlo # old
-/openstack/hermes                                      @notque @Kuckkuck @notandy @viennaa @richardtief @olandr @joluc @trouaux @ibakshay @ashifnihalb @timojohlo
+/openstack/hermes                                      @notque @LeoZhangZXZ @Kuckkuck @notandy @viennaa @richardtief @olandr @joluc @trouaux @ibakshay @ashifnihalb @timojohlo
 /openstack/infra-seeds/kubernetes                      @BugRoger  # old
 /openstack/ironic                                      @stefanhipfel @BerndKue @fwiesel @sandzwerg @Pooja-Sangle 
 /openstack/keppel*                                     @sapcc/Storage-Resource-Services-Codeowners
@@ -94,7 +94,7 @@
 /openstack/kvm-ha*                                     @soofff @PaulPickhardt @benjamin-sap
 /openstack/limes*                                      @sapcc/Storage-Resource-Services-Codeowners
 /openstack/labels-injector                             @joker-at-work @fwiesel @grandchild @leust @seb-kro @PaulPickhardt @CordulaGuder @notandy @mchristianl @anokfireball @toanju
-/openstack/maia                                        @notque @Kuckkuck @notandy @viennaa @richardtief @olandr @joluc @trouaux @ibakshay @ashifnihalb @timojohlo
+/openstack/maia                                        @notque @LeoZhangZXZ @Kuckkuck @notandy @viennaa @richardtief @olandr @joluc @trouaux @ibakshay @ashifnihalb @timojohlo
 /openstack/manila*                                     @Carthaca @chuan137 @galkindmitrii @kpawar-sap @sumitarora2786 @crenduchinta88 @hvr999 @RockSolidScripts
 /openstack/netapp-credential-rotator                   @Carthaca @chuan137 @kpawar-sap @sumitarora2786 @crenduchinta88 @hvr999 @RockSolidScripts @Scsabiii @hemna @jagoleni
 /openstack/neutron                                     @notandy @fwiesel @sapcc/network-api-contributors
@@ -145,7 +145,7 @@
 /prometheus-exporters/cronus-updater                   @dhalimi
 /prometheus-exporters/documentation-prober             @dhalimi  # old
 /prometheus-exporters/event-exporter                   @jknipper @databus23
-/prometheus-exporters/hermes-query-exporter            @Kuckkuck @notque @timojohlo @olandr @joluc
+/prometheus-exporters/hermes-query-exporter            @Kuckkuck @notque @LeoZhangZXZ @timojohlo @olandr @joluc
 /prometheus-exporters/ipmi-exporter                    @stefanhipfel @BerndKue @sandzwerg @Pooja-Sangle 
 /prometheus-exporters/ironic-exporter                  @BerndKue @stefanhipfel @sandzwerg @Pooja-Sangle 
 
@@ -294,7 +294,7 @@
 /system/node-problem-detector                          @sapcc/PlusOne-CE-API-Services-ControlPlane
 /system/nodecidr-controller                            @sapcc/PlusOne-CE-API-Services-ControlPlane
 /system/ntp-timeserver                                 @dhoeller  # old
-/system/opensearch-hermes                              @Kuckkuck @notque @timojohlo @joluc @olandr
+/system/opensearch-hermes                              @Kuckkuck @notque @LeoZhangZXZ @timojohlo @joluc @olandr
 /system/opensearch-logs                                @Kuckkuck @timojohlo @notque @joluc @olandr
 /system/owner-label-injector                           @sapcc/containers
 /system/os-user-rotate                                 @sapcc/PlusOne-CE-API-Services-ControlPlane


### PR DESCRIPTION
## Summary
- Add @LeoZhangZXZ as code owner for hermes, maia, opensearch-hermes, and hermes-query-exporter

## Changes
- `/openstack/hermes`
- `/openstack/maia`
- `/prometheus-exporters/hermes-query-exporter`
- `/system/opensearch-hermes`