### PR TITLE
[neutron] No Barbican/Designate seed dependency

### DIFF
--- a/openstack/neutron/templates/seed.yaml
+++ b/openstack/neutron/templates/seed.yaml
@@ -13,7 +13,6 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   requires:
-  - monsoon3/barbican-seed
   {{- range $domains}}
   {{- if not (hasPrefix "iaas-" .)}}
   - monsoon3/domain-{{ replace "_" "-" . | lower}}-seed
@@ -25,6 +24,8 @@ spec:
   - name: network_viewer
   - name: cloud_network_admin
   - name: cloud_compute_admin
+  - name: cloud_keymanager_admin
+  - name: cloud_dns_admin
   - name: securitygroup_viewer
   - name: securitygroup_admin
   - name: compute_admin_wsg


### PR DESCRIPTION
The Neutron OpenStack seeds depend on Barbican, as we reference the role cloud_keymanager_admin, which is created by that seed. For other services like Nova we seem to just create that role (Nova does the same for cloud_network_admin as to not create a circular dependency). We now do the same for Barbican and Designate by creating cloud_keymanager_admin and cloud_dns_admin ourselves.