### PR TITLE
[trust-manager] the image repository belongs to the values/secrets repo

### DIFF
--- a/openstack/trust-manager/values.yaml
+++ b/openstack/trust-manager/values.yaml
@@ -17,9 +17,6 @@ trust-manager:
     requests:
       cpu: 100m
       memory: 128Mi
-  defaultPackageImage:
-    registry: keppel.eu-de-1.cloud.sap/ccloud-quay-mirror
-    repository: jetstack/trust-pkg-debian-bookworm
 
 namespaces:
   matchExpressions:


### PR DESCRIPTION
We're already handling the `image` registry/repository there. So I had a PR (#20312) approved and merged handling the same for `defaultPackageImage`.

Also, stuff like our private keppel repository should not appear in the public github.