### PR TITLE
[opensearch-hermes] revert rest-cert change

### DIFF
--- a/system/opensearch-hermes/templates/rest-cert.yaml
+++ b/system/opensearch-hermes/templates/rest-cert.yaml
@@ -7,7 +7,6 @@ spec:
   dnsNames:
   - 'opensearch-hermes.{{ .Values.global.region }}.cloud.sap'
   - 'opensearch-hermes.hermes.svc.kubernetes.{{ .Values.global.region }}.cloud.sap'
-  - 'opensearch-hermes.hermes.svc.cluster.local'
   issuerRef:
     group: certmanager.cloud.sap
     kind: DigicertIssuer


### PR DESCRIPTION
revert, as this is not a valid cert:

82s         Warning   Failed             certificaterequest/rest-cert-5                      Failed to sign certificate request: code: 400, status: invalid_domain, message: Domain Name has an invalid value.
84s         Normal    Issuing            certificate/rest-cert                               Fields on existing CertificateRequest resource not up to date: [spec.dnsNames]
84s         Normal    Reused             certificate/rest-cert                               Reusing private key stored in existing Secret resource "rest-cert"
84s         Normal    Requested          certificate/rest-cert                               Created new CertificateRequest resource "rest-cert-5"
83s         Warning   Failed             certificate/rest-cert                               The certificate request has failed to complete and will be retried: Failed to sign certificate request: code: 400, status: invalid_domain, message: Domain Name has an invalid value.