### PR TITLE
[volume-claims][db-designate-pvclaim] skip for eu-de-3

### DIFF
--- a/openstack/volume-claims/Chart.yaml
+++ b/openstack/volume-claims/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes
 name: volume-claims
-version: 0.1.3
+version: 0.1.4
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/volume-claims/templates/db-designate-pvclaim.yaml
+++ b/openstack/volume-claims/templates/db-designate-pvclaim.yaml
@@ -1,6 +1,7 @@
 {{- $region := .Values.global.region | required ".Values.global.region missing" }}
 {{/* For some reason, this PVC is controlled by the designate chart ONLY in eu-de-1, so we need to skip it here. */}}
-{{- if ne $region "eu-de-1" }}
+{{/* [eu-de-3] Let the designate deployment take care of this PVC. This one here does not cut it. */}}
+{{- if not (has $region (list "eu-de-1" "eu-de-3")) }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim


### PR DESCRIPTION
The `eu-de-3` PVC situation is more complicated and cannot be handled out-of-the-box by this helm-chart.

We need this PVC to be ReadWriteMany _and_ specify the storage class name explicitly.

So, we let the designate deployment handle this PVC and configure it as needed by utilizing the means provided by the mariadb chart there.