### PR TITLE
[designate] disable SSL for rabbitmq

### DIFF
--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes to deploy Openstack Designate  (DNSaaS)
 name: designate
-version: 0.5.15
+version: 0.5.16
 appVersion: "dalmatian"
 dependencies:
   - condition: percona_cluster.enabled

--- a/openstack/designate/values.yaml
+++ b/openstack/designate/values.yaml
@@ -365,6 +365,10 @@ rabbitmq:
     enableDetailedMetrics: true
     enablePerObjectMetrics: true
 
+  # backward compatibility with the existing deployments
+  # using the older rabbitmq helm chart which defaulted to SSL disabled
+  enableSsl: false
+
 rabbitmq_notifications:
   use_alternate_registry: true
   name: designate


### PR DESCRIPTION
All existing deployments don't have it enabled
but the new rabbitmq helm chart has it enabled by default.

Let's be backwards compatible with the existing deployments.

At some point we might want to start using SSL.