### PR TITLE
[ironic] use static ironic-db-migration job name

### DIFF
--- a/openstack/ironic/Chart.yaml
+++ b/openstack/ironic/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Ironic/OpenStack_Project_Ironic_vertical.png
 name: ironic
-version: 0.2.14
+version: 0.2.15
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/ironic/templates/db-migration-job.yaml
+++ b/openstack/ironic/templates/db-migration-job.yaml
@@ -3,7 +3,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: ironic-db-migration-{{ randAlphaNum 4 | lower }}
+  name: ironic-db-migration
   labels:
     system: openstack
     type: job


### PR DESCRIPTION
Don't use random suffix for ironic db migration jobs, it prevents executed jobs from being deleted and might cause an upgrade error like this:
```
Error: UPGRADE FAILED: pre-upgrade hooks failed: unable to build kubernetes object for deleting hook
ironic/templates/db-migration-job.yaml: resource mapping not found for name: "ironic-db-migration-dzyj" namespace: ""
from "": no matches for kind "Job" in version ""
ensure CRDs are installed first
```

We don't need to randomize it, as this job has a following hook configuration:
```
"helm.sh/hook": "post-install,pre-upgrade"
"helm.sh/hook-weight": "-1"
"helm.sh/hook-delete-policy": "before-hook-creation"
```