### PR TITLE
opensearch-hermes: upgrade OpenSearch from 3.2.0 to 3.6.0

### DIFF
--- a/system/opensearch-hermes/Chart.lock
+++ b/system/opensearch-hermes/Chart.lock
@@ -1,13 +1,13 @@
 dependencies:
 - name: opensearch
   repository: https://opensearch-project.github.io/helm-charts
-  version: 3.2.1
+  version: 3.6.0
 - name: opensearch
   repository: https://opensearch-project.github.io/helm-charts
-  version: 3.2.1
+  version: 3.6.0
 - name: opensearch-dashboards
   repository: https://opensearch-project.github.io/helm-charts
-  version: 3.2.2
+  version: 3.6.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
@@ -17,5 +17,5 @@ dependencies:
 - name: manager
   repository: file://vendor/manager
   version: 1.0.12
-digest: sha256:6cd64e4222fbc40f2cb45751ab27d6647d87ea8399e1a99d265b924884727ab9
-generated: "2026-01-29T15:22:46.098546+01:00"
+digest: sha256:5e349df519b58d8bc78ca55d8da35b01e7827dba6cba9a1b281e937767e8e4eb
+generated: "2026-05-07T16:51:01.353124-07:00"

--- a/system/opensearch-hermes/Chart.yaml
+++ b/system/opensearch-hermes/Chart.yaml
@@ -10,17 +10,17 @@ dependencies:
     alias: opensearch_hermes
     condition: opensearch_hermes.enabled
     repository: https://opensearch-project.github.io/helm-charts
-    version: 3.2.1
+    version: 3.6.0
   - name: opensearch
     alias: opensearch_hermes_master
     condition: opensearch_hermes_master.enabled
     repository: https://opensearch-project.github.io/helm-charts
-    version: 3.2.1
+    version: 3.6.0
   - name: opensearch-dashboards
     alias: opensearch_hermes_dashboards
     condition: opensearch_hermes_dashboards.enabled
     repository: https://opensearch-project.github.io/helm-charts
-    version: 3.2.2
+    version: 3.6.0
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.2.0

--- a/system/opensearch-hermes/values.yaml
+++ b/system/opensearch-hermes/values.yaml
@@ -92,7 +92,7 @@ alerts:
 exporter:
   enabled: false
   prometheus: DEFINED-IN-SECRETS
-tag: 3.2.0
+tag: 3.6.0
 
 linkerd-support:
   annotate_namespace: true
@@ -103,7 +103,7 @@ opensearch_hermes:
   ca:
     crt: DEFINED-IN-SECRETS
   image:
-    tag: 3.2.0
+    tag: 3.6.0
   service:
     port: 5601
   nameOverride: "opensearch-hermes"
@@ -131,7 +131,7 @@ opensearch_hermes:
   plugins:
     enabled: true
     installList:
-      - https://repo.eu-de-1.cloud.sap/opensearch/prometheus-exporter-3.2.0.0.zip
+      - https://github.com/opensearch-project/opensearch-prometheus-exporter/releases/download/3.6.0.0/prometheus-exporter-3.6.0.0.zip
   securityConfig:
     path: "/usr/share/opensearch/config/opensearch-security"
     enabled: true
@@ -147,7 +147,7 @@ opensearch_hermes_master:
   ca:
     crt: DEFINED-IN-SECRETS
   image:
-    tag: 3.2.0
+    tag: 3.6.0
   service:
     port: 5601
   nameOverride: "opensearch-hermes-master"
@@ -173,7 +173,7 @@ opensearch_hermes_master:
   plugins:
     enabled: true
     installList:
-      - https://repo.eu-de-1.cloud.sap/opensearch/prometheus-exporter-3.2.0.0.zip
+      - https://github.com/opensearch-project/opensearch-prometheus-exporter/releases/download/3.6.0.0/prometheus-exporter-3.6.0.0.zip
   securityConfig:
     path: "/usr/share/opensearch/config/opensearch-security"
     enabled: true
@@ -186,7 +186,7 @@ opensearch_hermes_master:
 opensearch_hermes_dashboards:
   enabled: false
   image:
-    tag: "3.2.0"
+    tag: "3.6.0"
   fullnameOverride: opensearch-hermes-dashboards
   nameOverride: opensearch-hermes-dashboards
   serviceAccount:


### PR DESCRIPTION
## Summary

- Upgrade OpenSearch image tags from 3.2.0 to 3.6.0 (data, master, dashboards)
- Upgrade Helm chart dependencies from 3.2.1/3.2.2 to 3.6.0
- Bump prometheus-exporter plugin from 3.2.0.0 to 3.6.0.0
- Plugin source moved to GitHub releases (SAP mirror only carries up to 3.5.0)

## Changes

| Component | Before | After |
|-----------|--------|-------|
| OpenSearch image | 3.2.0 | 3.6.0 |
| Helm chart (opensearch) | 3.2.1 | 3.6.0 |
| Helm chart (dashboards) | 3.2.2 | 3.6.0 |
| prometheus-exporter plugin | 3.2.0.0 | 3.6.0.0 |
| Plugin source | repo.eu-de-1.cloud.sap | github.com/opensearch-project |