### PR TITLE
[kvm-cinder-netapp-operator] add serviceaccountname for pod template

### DIFF
--- a/openstack/kvm-cinder-netapp-operator-crds/Chart.lock
+++ b/openstack/kvm-cinder-netapp-operator-crds/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.0.0
 - name: kvm-cinder-netapp-operator-crds
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.4.5
-digest: sha256:8663759121583e2e59134dc87604960ea04bbcc00e9beb3335dcf3ad42372939
-generated: "2026-04-08T16:32:00.7706734+02:00"
+  version: 0.4.6
+digest: sha256:d2a6935647df79361ce6ea51b29befb160e2bf376dafd71af1fde2aca5acea28
+generated: "2026-05-08T10:26:53.114477976+02:00"

--- a/openstack/kvm-cinder-netapp-operator-crds/Chart.yaml
+++ b/openstack/kvm-cinder-netapp-operator-crds/Chart.yaml
@@ -4,12 +4,12 @@ description: A Helm chart for Kubernetes CRDs
 type: application
 # This is the chart version - should be set to corresponding
 # kvm-cinder-netapp-operator-crds chart version when updated.
-version: 0.4.5
+version: 0.4.6
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: '>= 0.0.0'
   - name: kvm-cinder-netapp-operator-crds
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.4.5
+    version: 0.4.6
   

--- a/openstack/kvm-cinder-netapp-operator/Chart.lock
+++ b/openstack/kvm-cinder-netapp-operator/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 1.0.0
 - name: kvm-cinder-netapp-operator
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.4.5
-digest: sha256:3c5897ad64f202da4d80b815f3a221a443c8ac28862eddbb99ba290b2f61c881
-generated: "2026-04-08T16:31:56.698940958+02:00"
+  version: 0.4.6
+digest: sha256:b4faa6492a36ba404292e660b42c60a764e7694f028f8a5566306cbb210e11f4
+generated: "2026-05-08T10:26:45.518154194+02:00"

--- a/openstack/kvm-cinder-netapp-operator/Chart.yaml
+++ b/openstack/kvm-cinder-netapp-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: A Helm chart for the kvm-cinder-netapp-operator
 name: kvm-cinder-netapp-operator
-version: 0.4.5
-appVersion: "0.3.5"
+version: 0.4.6
+appVersion: "0.4.1"
 dependencies:
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm


### PR DESCRIPTION
Bumps chart versions to add support for `serviceAccountName` field in `CinderNetappConfig` resources. See https://github.wdf.sap.corp/sap-cloud-infrastructure/kvm-cinder-netapp-operator/pull/172