### PR TITLE
[manila] fix secret templating for manila.conf

### DIFF
--- a/openstack/manila/templates/etc/_secrets.conf.tpl
+++ b/openstack/manila/templates/etc/_secrets.conf.tpl
@@ -7,12 +7,12 @@
 
 
 [neutron]
-username = {{ printf "%s/%s/manila/keystone-user/network/username" $vbase $region | replace "$" "$$"}}
-password = {{ printf "%s/%s/manila/keystone-user/network/password" $vbase $region | replace "$" "$$"}}
+username = {{ printf "%s/%s/manila/keystone-user/network/username" $vbase $region  | include "resolve_secret" | replace "$" "$$"}}
+password = {{ printf "%s/%s/manila/keystone-user/network/password" $vbase $region  | include "resolve_secret" | replace "$" "$$"}}
 
 [keystone_authtoken]
-username = {{ printf "%s/%s/manila/keystone-user/service/username" $vbase $region | replace "$" "$$"}}
-password = {{ printf "%s/%s/manila/keystone-user/service/password" $vbase $region | replace "$" "$$"}}
+username = {{ printf "%s/%s/manila/keystone-user/service/username" $vbase $region | include "resolve_secret" | replace "$" "$$"}}
+password = {{ printf "%s/%s/manila/keystone-user/service/password" $vbase $region | include "resolve_secret" | replace "$" "$$"}}
 
 
 {{ include "ini_sections.audit_middleware_notifications" . }}


### PR DESCRIPTION
follow-up to 9690379

Since we are templating inside the data key, we need to explicitly
resolve.
