### PR TITLE
[ironic] remove comment from ironic db migration templates

### DIFF
--- a/openstack/ironic/templates/db-migration-job.yaml
+++ b/openstack/ironic/templates/db-migration-job.yaml
@@ -1,4 +1,3 @@
-# Might we worth building your own ipxe stack here: https://rom-o-matic.eu/
 {{- $serviceaccount := lookup "v1" "ServiceAccount" .Release.Namespace .Release.Name -}}
 apiVersion: batch/v1
 kind: Job

--- a/openstack/ironic/templates/inspector-db-migration-job.yaml
+++ b/openstack/ironic/templates/inspector-db-migration-job.yaml
@@ -1,4 +1,3 @@
-# Might we worth building your own ipxe stack here: https://rom-o-matic.eu/
 {{- $serviceaccount := lookup "v1" "ServiceAccount" .Release.Namespace .Release.Name -}}
 apiVersion: batch/v1
 kind: Job


### PR DESCRIPTION
We remove new line when we check if serviceaccount is present