### PR TITLE
add index read permissions for SA detector creation via terraform

### DIFF
--- a/system/opensearch-logs/templates/config/_roles.yml.tpl
+++ b/system/opensearch-logs/templates/config/_roles.yml.tpl
@@ -472,15 +472,20 @@ security_analytics_full_access:
   - "cluster:admin/opendistro/ism/managedindex/explain"
   - "cluster:monitor/tasks/lists"
   - "cluster:monitor/remote/info"
-  - "cluster:monitor/health" # Required for OpenSearch terraform provider health check (after PR merge)
   - "cluster:monitor/main" # Required for OpenSearch terraform provider health check
   - "cluster:admin/opendistro/ism/policy/search"
   index_permissions:
   - index_patterns:
     - "*"
     allowed_actions:
+    - "indices:admin/get"
+    - "indices:admin/aliases/get"
+    - "indices:admin/resolve/index"
     - "indices:admin/mapping/put"
     - "indices:admin/mappings/get"
     - "indices:admin/template/get"
     - "indices:admin/data_stream/get"
     - "indices:monitor/recovery"
+    - "indices:data/read/search"
+    - "indices:data/read/get"
+    - "indices:data/read/field_caps"


### PR DESCRIPTION
https://github.wdf.sap.corp/sap-cloud-infrastructure/siem/actions/runs/5829752/job/33389342

trying to fix error:
```
Error: elastic: Error 403 (Forbidden): User doesn't have read permissions for one or more configured index [Ljava.lang.String;@597ee973 [type=security_analytics_exception]
│ 
│   with module.shared.opensearch_detector.keystone_detector,
│   on ../../shared/detectors.tf line 1, in resource "opensearch_detector" "keystone_detector":
│    1: resource "opensearch_detector" "keystone_detector" {
```