### PR TITLE
feat: kustomize overlays for metal-operator remote cluster deployment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,127 @@
+# AGENTS.md
+
+## Overview
+
+Monorepo of Helm charts for SAP Converged Cloud infrastructure. ~200+ charts grouped by domain. Default branch is `master`.
+
+## Repository Structure
+
+```
+common/              # Reusable library charts (mariadb, rabbitmq, prometheus-server, etc.)
+global/              # Singleton charts deployed once globally
+openstack/           # OpenStack services and related components
+prometheus-exporters/# Prometheus exporter charts
+prometheus-rules/    # Prometheus alert and aggregation rules
+px/                  # Network/routing charts (bird, arp-discovery)
+system/              # Control-plane infrastructure charts
+ci/                  # Chart-testing configuration and lint scripts
+```
+
+Each top-level directory is a `chart-dir` for `ct` (chart-testing). Charts live one level below (e.g., `system/calico/`).
+
+## Chart Conventions
+
+- `Chart.yaml` must use `apiVersion: v2`
+- **Version bumps are enforced**: CI checks that chart versions increment on change. The OCI registry (`ghcr.io/sapcc/helm-charts/`) rejects duplicate versions.
+- Charts deploy to a namespace matching their name (e.g., `system/dns` → namespace `dns`)
+- Test values go in `<chart>/ci/*-values.yaml` (used by `ct lint`)
+- Unit tests go in `<chart>/tests/*_test.yaml` (run with `helm-unittest`)
+
+## CI (GitHub Actions on PRs)
+
+| Workflow | Trigger | What it does |
+|----------|---------|--------------|
+| `helm-unittest` | All PRs | Runs `helm unittest` on changed charts that have a `tests/` dir |
+| `check-chart-version` | PRs touching `system/` or `global/cc-gardener/` | Enforces version bump for ControlPlane-owned charts |
+| `helm-lint` | Manual only (disabled—can't resolve internal deps) | `ct lint` with schema validation |
+| `helm-push` | Push to `master` (only `common/postgresql-ng` and `common/linkerd-support`) | Packages and pushes to OCI registry |
+
+## Local Development Commands
+
+### Lint a single chart
+
+```bash
+ci/lint-chart.sh <chart-path>
+# Example: ci/lint-chart.sh openstack/nova
+```
+
+Uses Docker image `sapcc/chart-testing:v3.8.0-sapcc`. Alternatively:
+
+```bash
+docker run --rm -v $(pwd):/charts sapcc/chart-testing:latest sh -c \
+  "cd charts && ct lint --chart-yaml-schema ci/chart_schema.yaml --lint-conf ci/lintconf.yaml --config ci/config.yaml --charts <chart-path>"
+```
+
+### Run unit tests for a chart
+
+```bash
+helm unittest <chart-path>
+```
+
+Requires the `helm-unittest` plugin:
+```bash
+helm plugin install https://github.com/helm-unittest/helm-unittest
+```
+
+### Build CAPI/operator charts (system/ only)
+
+```bash
+make -C system build-<target>
+```
+
+Requires: `kubectl`, `kustomize`, `helmify`, `yq`, and on macOS `gsed` (GNU sed).
+
+## YAML Lint Rules (ci/lintconf.yaml)
+
+- Indentation: consistent (no fixed count enforced)
+- `indent-sequences: whatever` — both styles accepted
+- Line length: disabled
+- Trailing spaces: disabled
+- Truthy values: warning only
+- Newlines: unix (`\n`)
+
+## Kustomize Overlays (system/kustomize/)
+
+Some operators in `system/` use a pure kustomize overlay structure instead of the `helmify`-based Makefile pipeline. This is the preferred pattern for Flux-compatible deployments.
+
+### Structure
+
+```text
+system/kustomize/<operator>/
+├── overlays/
+│   ├── host/          # Resources for the seed (host) cluster: Deployment, ConfigMap
+│   └── remote/        # Resources for the shoot (remote) cluster: CRDs, RBAC
+│       ├── crd/
+│       └── rbac/
+└── components/        # Reusable kustomize components (kind: Component)
+    ├── webhook-injector/       # Adds webhook-injector native sidecar
+    ├── clusterrole-conversion/ # Converts Role/RoleBinding → ClusterRole/ClusterRoleBinding
+    └── namespace-strip/        # Removes namespace from Deployment (reference)
+```
+
+### Design decisions
+
+- **No shared base**: host and remote overlays need non-overlapping resource subsets from upstream. Each overlay references its specific upstream sub-directory directly (e.g., `config/manager`, `config/crd`, `config/rbac`). A single `config/default` base would require KRM plugins to filter resources, which are Flux-incompatible.
+- **`patches:` with `target:` required (not `patchesStrategicMerge`)**: In kustomize v5, `patchesStrategicMerge` matches resources by namespace too. When a patch file has no `namespace:` field but the upstream resource has `namespace: system`, kustomize reports `no matches for Id ... [noNs]`. Use `patches: [{path: ..., target: {kind: ..., name: ...}}]` instead — `target:` matching ignores namespace.
+- **Component processing order**: Components run *before* overlay `namePrefix`/`namespace` transformers. Patches in components must target pre-prefix resource names (e.g., `controller-manager`, not `metal-operator-controller-manager`).
+- **configMapGenerator + namePrefix**: A `configMapGenerator` name gets the overlay `namePrefix` applied. If the sidecar references the ConfigMap by name, override that arg in an overlay-level patch (not in the component patch).
+
+### Verification
+
+```bash
+# Build host overlay (Deployment + ConfigMap → seed cluster)
+kubectl kustomize system/kustomize/metal-operator/overlays/host
+
+# Build remote overlay (CRDs + RBAC → shoot cluster)
+kubectl kustomize system/kustomize/metal-operator/overlays/remote
+```
+
+Requires `kubectl` (bundles kustomize v5.8.1+). Upstream GitHub URLs are fetched at build time.
+
+## Key Gotchas
+
+- **Internal dependencies can't be resolved in CI** — `helm-lint` workflow is disabled for this reason. Charts referencing other charts in this repo won't lint cleanly in isolation.
+- **CODEOWNERS is extensive** — check `.github/CODEOWNERS` before modifying charts owned by other teams.
+- Prometheus rules files use `.alerts` and `.rules` extensions and are validated with `promtool`.
+- The `system/Makefile` generates charts from upstream kustomize configs using `helmify`. These charts are auto-generated — edit the Makefile targets, not the generated output. New operators should use the kustomize overlay pattern instead (see above).
+- OCI push only happens for specific charts (`common/postgresql-ng`, `common/linkerd-support`). Most charts are consumed via other mechanisms.

--- a/system/kustomize/metal-operator/components/clusterrole-conversion/kustomization.yaml
+++ b/system/kustomize/metal-operator/components/clusterrole-conversion/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+# Converts Role→ClusterRole and RoleBinding→ClusterRoleBinding.
+# Required because the operator runs in GRM where namespace-scoped Roles cannot be used.
+# Targets the pre-namePrefix resource names; kustomize processes components before transformers.
+patches:
+  - target:
+      kind: Role
+      name: leader-election-role
+    patch: |-
+      - op: replace
+        path: /kind
+        value: ClusterRole
+  - target:
+      kind: RoleBinding
+      name: leader-election-rolebinding
+    patch: |-
+      - op: replace
+        path: /kind
+        value: ClusterRoleBinding
+      - op: replace
+        path: /roleRef/kind
+        value: ClusterRole

--- a/system/kustomize/metal-operator/components/namespace-strip/kustomization.yaml
+++ b/system/kustomize/metal-operator/components/namespace-strip/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - target:
+      kind: Deployment
+    patch: |-
+      - op: remove
+        path: /metadata/namespace

--- a/system/kustomize/metal-operator/components/webhook-injector/kustomization.yaml
+++ b/system/kustomize/metal-operator/components/webhook-injector/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: webhook-injector-patch.yaml
+    target:
+      kind: Deployment
+      name: controller-manager

--- a/system/kustomize/metal-operator/components/webhook-injector/webhook-injector-patch.yaml
+++ b/system/kustomize/metal-operator/components/webhook-injector/webhook-injector-patch.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+spec:
+  template:
+    spec:
+      # webhook-injector runs as a native sidecar (restartPolicy: Always) so it starts before
+      # the manager and keeps TLS certs synced. It applies URL-based webhook configs to the
+      # remote (shoot) cluster using --target-kubeconfig, injecting the caBundle at runtime.
+      initContainers:
+        - name: webhook-injector
+          restartPolicy: Always
+          image: keppel.global.cloud.sap/ccloud-ghcr-io-mirror/SAP-cloud-infrastructure/webhook-injector:latest
+          args:
+            - --webhook-config-name=webhook-config
+            - --target-kubeconfig=/var/run/remote-kubeconfig/kubeconfig
+          ports:
+            - name: metrics
+              containerPort: 8082
+            - name: health
+              containerPort: 8083
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8083
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8083
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          volumeMounts:
+            - name: webhook-certs
+              mountPath: /tmp/webhook-certs
+            - name: remote-serviceaccount
+              mountPath: /var/run/secrets/kubernetes.io/remote-serviceaccount
+              readOnly: true
+            - name: remote-kubeconfig
+              mountPath: /var/run/remote-kubeconfig
+              readOnly: true
+      containers:
+        - name: manager
+          volumeMounts:
+            - name: webhook-certs
+              mountPath: /tmp/k8s-webhook-server/serving-certs
+              readOnly: true
+            - name: remote-serviceaccount
+              mountPath: /var/run/secrets/kubernetes.io/remote-serviceaccount
+              readOnly: true
+            - name: remote-kubeconfig
+              mountPath: /var/run/remote-kubeconfig
+              readOnly: true
+      volumes:
+        - name: webhook-certs
+          emptyDir: {}
+        - name: remote-serviceaccount
+          secret:
+            secretName: metal-operator-remote-kubeconfig
+            items:
+              - key: token
+                path: token
+              - key: bundle.crt
+                path: ca.crt
+        - name: remote-kubeconfig
+          configMap:
+            name: remote-kubeconfig

--- a/system/kustomize/metal-operator/overlays/host/kustomization.yaml
+++ b/system/kustomize/metal-operator/overlays/host/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/ironcore-dev/metal-operator//config/manager?ref=v0.4.0
+namePrefix: metal-operator-
+namespace: metal-operator-system
+components:
+  - ../../components/webhook-injector
+patches:
+  - path: manager-config-patch.yaml
+    target:
+      kind: Deployment
+      name: controller-manager
+configMapGenerator:
+  - name: webhook-config
+    files:
+      - webhooks-input.yaml
+    options:
+      disableNameSuffixHash: true

--- a/system/kustomize/metal-operator/overlays/host/manager-config-patch.yaml
+++ b/system/kustomize/metal-operator/overlays/host/manager-config-patch.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        networking.gardener.cloud/to-dns: allowed
+        networking.gardener.cloud/to-private-networks: allowed
+        networking.gardener.cloud/to-public-networks: allowed
+        networking.gardener.cloud/to-runtime-apiserver: allowed
+        networking.resources.gardener.cloud/to-all-istio-ingresses-istio-ingressgateway-tcp-9443: allowed
+        networking.resources.gardener.cloud/to-kube-apiserver-tcp-443: allowed
+    spec:
+      serviceAccountName: metal-operator-webhook-injector
+      terminationGracePeriodSeconds: 10
+      hostNetwork: false
+      securityContext:
+        runAsUser: 65532
+        runAsGroup: 65532
+      initContainers:
+        - name: webhook-injector
+          # Override ConfigMap name to include the namePrefix applied by this overlay.
+          args:
+            - --webhook-config-name=metal-operator-webhook-config
+            - --target-kubeconfig=/var/run/remote-kubeconfig/kubeconfig
+      containers:
+        - name: manager
+          image: ghcr.io/ironcore-dev/metal-operator-controller-manager:sha-4854c23
+          args:
+            - --mac-prefixes-file=/etc/macdb/macdb.yaml
+            - --probe-image=keppel.global.cloud.sap/ccloud-ghcr-io-mirror/ironcore-dev/metalprobe:latest
+            - --probe-os-image=ghcr.io/ironcore-dev/os-images/gardenlinux:1443.3
+            - --insecure=false
+            - --registry-url=http://[2a10:afc0:e013:d002::]:30010
+            - --manager-namespace=metal-operator-system
+          env:
+            - name: KUBERNETES_SERVICE_HOST
+              value: "apiserver-url"
+            - name: KUBERNETES_CLUSTER_DOMAIN
+              value: "cluster.local"
+            - name: KUBECONFIG
+              value: "/var/run/remote-kubeconfig/kubeconfig"
+          resources:
+            limits:
+              cpu: "5000m"
+              memory: "5120Mi"
+            requests:
+              cpu: 300m
+              memory: 50Mi
+          volumeMounts:
+            - name: macdb
+              mountPath: /etc/macdb/
+      volumes:
+        - name: macdb
+          secret:
+            secretName: macdb

--- a/system/kustomize/metal-operator/overlays/host/webhooks-input.yaml
+++ b/system/kustomize/metal-operator/overlays/host/webhooks-input.yaml
@@ -1,0 +1,128 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: metal-operator-validating-webhook-configuration
+webhooks:
+  - name: vbiossettings-v1alpha1.kb.io
+    clientConfig:
+      url: https://metal-operator-webhook-service:443/validate-metal-ironcore-dev-v1alpha1-biossettings
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions:
+      - v1
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        apiGroups:
+          - metal.ironcore.dev
+        apiVersions:
+          - v1alpha1
+        resources:
+          - biossettings
+  - name: vbiosversion-v1alpha1.kb.io
+    clientConfig:
+      url: https://metal-operator-webhook-service:443/validate-metal-ironcore-dev-v1alpha1-biosversion
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions:
+      - v1
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        apiGroups:
+          - metal.ironcore.dev
+        apiVersions:
+          - v1alpha1
+        resources:
+          - biosversions
+  - name: vbmcsecret-v1alpha1.kb.io
+    clientConfig:
+      url: https://metal-operator-webhook-service:443/validate-metal-ironcore-dev-v1alpha1-bmcsecret
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions:
+      - v1
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        apiGroups:
+          - metal.ironcore.dev
+        apiVersions:
+          - v1alpha1
+        resources:
+          - bmcsecrets
+  - name: vbmcsettings-v1alpha1.kb.io
+    clientConfig:
+      url: https://metal-operator-webhook-service:443/validate-metal-ironcore-dev-v1alpha1-bmcsettings
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions:
+      - v1
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        apiGroups:
+          - metal.ironcore.dev
+        apiVersions:
+          - v1alpha1
+        resources:
+          - bmcsettings
+  - name: vbmcversion-v1alpha1.kb.io
+    clientConfig:
+      url: https://metal-operator-webhook-service:443/validate-metal-ironcore-dev-v1alpha1-bmcversion
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions:
+      - v1
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        apiGroups:
+          - metal.ironcore.dev
+        apiVersions:
+          - v1alpha1
+        resources:
+          - bmcversions
+  - name: vendpoint-v1alpha1.kb.io
+    clientConfig:
+      url: https://metal-operator-webhook-service:443/validate-metal-ironcore-dev-v1alpha1-endpoint
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions:
+      - v1
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - metal.ironcore.dev
+        apiVersions:
+          - v1alpha1
+        resources:
+          - endpoints
+  - name: vserver-v1alpha1.kb.io
+    clientConfig:
+      url: https://metal-operator-webhook-service:443/validate-metal-ironcore-dev-v1alpha1-server
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions:
+      - v1
+    rules:
+      - operations:
+          - DELETE
+        apiGroups:
+          - metal.ironcore.dev
+        apiVersions:
+          - v1alpha1
+        resources:
+          - servers

--- a/system/kustomize/metal-operator/overlays/remote/crd/kustomization.yaml
+++ b/system/kustomize/metal-operator/overlays/remote/crd/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/ironcore-dev/metal-operator//config/crd?ref=v0.4.0
+patches:
+  # Strip conversion webhooks that reference an in-cluster webhook service unavailable
+  # in the remote (shoot) cluster. webhook-injector manages webhook configs separately.
+  - target:
+      group: apiextensions.k8s.io
+      version: v1
+      kind: CustomResourceDefinition
+      name: bmcs.metal.ironcore.dev
+    patch: |-
+      - op: remove
+        path: /spec/conversion
+  - target:
+      group: apiextensions.k8s.io
+      version: v1
+      kind: CustomResourceDefinition
+      name: serverclaims.metal.ironcore.dev
+    patch: |-
+      - op: remove
+        path: /spec/conversion

--- a/system/kustomize/metal-operator/overlays/remote/kustomization.yaml
+++ b/system/kustomize/metal-operator/overlays/remote/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - crd/
+  - rbac/

--- a/system/kustomize/metal-operator/overlays/remote/kustomization.yaml
+++ b/system/kustomize/metal-operator/overlays/remote/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - crd/
   - rbac/
+  - manager/

--- a/system/kustomize/metal-operator/overlays/remote/manager/kustomization.yaml
+++ b/system/kustomize/metal-operator/overlays/remote/manager/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/ironcore-dev/metal-operator//config/manager?ref=v0.4.0
+namePrefix: metal-operator-
+components:
+  - ../../../components/webhook-injector
+  - ../../../components/namespace-strip

--- a/system/kustomize/metal-operator/overlays/remote/rbac/kustomization.yaml
+++ b/system/kustomize/metal-operator/overlays/remote/rbac/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/ironcore-dev/metal-operator//config/rbac?ref=v0.4.0
+namePrefix: metal-operator-
+namespace: metal-operator-system
+components:
+  - ../../../components/clusterrole-conversion


### PR DESCRIPTION
## Summary

Introduces a pure kustomize overlay structure for `metal-operator` that replaces the fragile `kustomize | helmify | yq/sed` pipeline in `system/Makefile`. Addresses issue [cc/unified-kubernetes#1169](https://github.wdf.sap.corp/cc/unified-kubernetes/issues/1169) / Epic [#831](https://github.wdf.sap.corp/cc/unified-kubernetes/issues/831).

## Directory Structure

```
system/kustomize/metal-operator/
├── components/
│   ├── clusterrole-conversion/   # Role→ClusterRole for leader-election resources
│   ├── namespace-strip/          # Remove namespace from Deployment (reference)
│   └── webhook-injector/         # Inject webhook-injector as native sidecar
└── overlays/
    ├── host/                     # Seed cluster: Deployment + webhook ConfigMap
    │   ├── kustomization.yaml
    │   ├── manager-config-patch.yaml
    │   └── webhooks-input.yaml   # Static URL-based webhook definitions
    └── remote/                   # Shoot cluster resources
        ├── kustomization.yaml    # Aggregates crd/ + rbac/
        ├── crd/                  # 16 CRDs, conversion webhooks stripped
        └── rbac/                 # ClusterRoles, ClusterRoleBindings, SA
```

## Changes Made

- **`overlays/host`**: Produces `Namespace` + `ConfigMap` (webhook-config) + `Deployment` for the seed cluster. The Deployment includes the webhook-injector native sidecar, all production args, Gardener networking labels, and the macdb volume.
- **`overlays/remote/crd`**: All 16 CRDs from upstream `config/crd?ref=v0.4.0`, with `/spec/conversion` stripped from `bmcs.metal.ironcore.dev` and `serverclaims.metal.ironcore.dev` (conversion webhooks reference an in-cluster service unavailable in the shoot).
- **`overlays/remote/rbac`**: Full RBAC from `config/rbac?ref=v0.4.0` with `namePrefix: metal-operator-` and the `clusterrole-conversion` component applied (`leader-election-role` Role → ClusterRole, required because the operator runs in GRM).
- **`components/webhook-injector`**: Reusable component that injects the webhook-injector sidecar via strategic merge patch.
- **`components/clusterrole-conversion`**: Reusable component converting `leader-election-role`/`leader-election-rolebinding` to ClusterRole/ClusterRoleBinding.

## Build Verification

```
# Host overlay: Namespace + ConfigMap + Deployment
kubectl kustomize overlays/host    # 3 resources

# Remote overlay: 16 CRDs + 52 ClusterRoles + 3 ClusterRoleBindings + 1 ServiceAccount
kubectl kustomize overlays/remote  # 72 resources
```

Both overlays build cleanly with `kubectl kustomize` (kustomize v5.8.1).

## Known Deltas vs. Current Makefile Output

| Delta | Impact |
|-------|--------|
| Admin/editor/viewer ClusterRoles get `metal-operator-` prefix (e.g. `metal-operator-biossettings-admin-role`) | Low — the current Makefile output doesn't prefix these. Name change in shoot cluster on first apply. |
| `metrics-auth-role`, `metrics-reader` ClusterRoles included | Low — unused with `metrics: enable: false` but harmless. |
| Namespace resource included in host overlay | None — Flux applies idempotently. |

## Technical Notes

- `patches:` with `target:` (not `patchesStrategicMerge`) is required because the upstream `manager.yaml` has explicit `namespace: system` on the Deployment. `patchesStrategicMerge` fails to match when the patch has no namespace but the resource does (kustomize v5 behavior).
- Components run BEFORE overlay namePrefix/namespace transformers, so component patches target pre-prefix names (`controller-manager`, `leader-election-role`).
- `configMapGenerator` name `webhook-config` becomes `metal-operator-webhook-config` after overlay namePrefix; the webhook-injector's `--webhook-config-name` arg is overridden in `manager-config-patch.yaml` to use the prefixed name.

## Type of Change

- [x] New feature (pure kustomize overlays, does not touch existing Helm chart)

## Next Steps

- [ ] Verify Flux can apply both overlays end-to-end in a test landscape
- [ ] Apply same pattern to boot-operator-remote, ipam-capi-remote
- [ ] Remove the `build-metal-operator-remote` Makefile target once validated
