### PR TITLE
feat(cc-runtime-cluster): allow per-region auth config

### DIFF
--- a/system/cc-runtime-cluster/Chart.yaml
+++ b/system/cc-runtime-cluster/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-runtime-cluster
 description: Converged Cloud Cluster API Runtime Cluster
 type: application
-version: 0.7.16
+version: 0.7.17
 appVersion: "0.1.0"

--- a/system/cc-runtime-cluster/ci/test-values.yaml
+++ b/system/cc-runtime-cluster/ci/test-values.yaml
@@ -16,6 +16,23 @@ worker:
       node-role.kubernetes.io/worker: ""
 
 additionalConfig:
+  authenticationConfig: |
+    - path: /etc/kubernetes/authentication.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          apiVersion: apiserver.config.k8s.io/v1beta1
+          kind: AuthenticationConfiguration
+          jwt:
+            - issuer:
+                url: https://example.com
+                audiences:
+                - test-audience
+              claimMappings:
+                username:
+                  claim: 'name'
+                  prefix: ''
   secrets: |
     - path: /etc/kubernetes/enc/enc.yaml
       filesystem: root

--- a/system/cc-runtime-cluster/templates/greenhouse-manifests.yaml
+++ b/system/cc-runtime-cluster/templates/greenhouse-manifests.yaml
@@ -16,3 +16,16 @@ data:
       apiGroup: rbac.authorization.k8s.io
       kind: ClusterRole
       name: cluster-admin
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: service-account-issuer-discovery
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: system:service-account-issuer-discovery
+    subjects:
+      - kind: Group
+        name: system:unauthenticated
+        apiGroup: rbac.authorization.k8s.io

--- a/system/cc-runtime-cluster/templates/kubeadmcontrolplane.yaml
+++ b/system/cc-runtime-cluster/templates/kubeadmcontrolplane.yaml
@@ -360,6 +360,9 @@ spec:
           storage:
             files:
 {{ tpl .Values.additionalConfig.files . | indent 14 }}
+{{- if .Values.additionalConfig.authenticationConfig }}
+{{ tpl .Values.additionalConfig.authenticationConfig . | indent 14 }}
+{{- end }}
 {{- if .Values.additionalConfig.secrets }}
 {{ tpl .Values.additionalConfig.secrets . | indent 14 }}
 {{- end }}


### PR DESCRIPTION
+ also add `issuer-discovery` rbac for structured auth