### PR TITLE
fix(octobus-query-exporter): remove trailing comma in nfslocked query

### DIFF
--- a/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/files/queries/vmware/vmware_esxi_nfs_nfslocked.cfg
+++ b/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/files/queries/vmware/vmware_esxi_nfs_nfslocked.cfg
@@ -9,7 +9,7 @@ QueryJson = {
       "query": {
           "bool": {
               "must": [
-                  { "match_phrase": { "syslog_message": "status: NFS4ERR_LOCKED" }},
+                  { "match_phrase": { "syslog_message": "status: NFS4ERR_LOCKED" }}
               ],
               "filter": [
                   { "term": { "sap.cc.audit.source.keyword": "ESXi" }},


### PR DESCRIPTION
Python 3.14 enforces strict JSON parsing and rejects trailing commas, causing the exporter to crash on startup