### PR TITLE
[glance] remove redundant availability and OOM alerts

### DIFF
--- a/openstack/glance/alerts/openstack-glance.alerts
+++ b/openstack/glance/alerts/openstack-glance.alerts
@@ -11,6 +11,7 @@ groups:
       service: glance
       context: glance
       dashboard: glance
+      no_alert_on_absence: "true"
       meta: 'Image {{ $labels.image_name }} is in Queued State'
     annotations:
       description: 'Image {{ $labels.image_name }} with id {{ $labels.id }} in project_id {{ $labels.project_id }} is Queued since {{ $labels.created_at}}'
@@ -42,6 +43,7 @@ groups:
       tier: os
       sentry: 'glance/'
       support_group: compute-storage-api
+      no_alert_on_absence: "true"
     annotations:
       description: glance has encountered unexpected errors and reported
         them to Sentry. Please have a look at the list of unresolved issues
@@ -64,94 +66,3 @@ groups:
       description: 'User {{ $labels.initiator_user_name }} has initiated more than 50 {{ $labels.action }} operations'
       summary: 'Project {{ $labels.initiator_project_id }} has more than 50 {{ $labels.action }} operations'
 
-  - alert: OpenstackGlanceContainerOOMKilled
-    expr: sum(rate(klog_pod_oomkill{namespace="monsoon3", pod_name=~"glance.*"}[30m]))by (container_name, pod_name) > 0
-    for: 5m
-    labels:
-      tier: os
-      service: glance
-      severity: info
-      context: memory
-      dashboard: glance
-      meta: "Glance Container {{ $labels.container_name }}"
-      no_alert_on_absence: "true" # the underlying metric is only generated after the first oomkill
-      support_group: compute-storage-api
-    annotations:
-      summary: Glance Container was oomkilled
-      description: Glance Container {{ $labels.container_name }} in Pod {{ $labels.pod_name }} was oomkilled recently
-
-  - alert: OpenstackGlanceScrapeMissing
-    expr: absent(up{component="glance",type="api"})
-    for: 1h
-    labels:
-      context: availability
-      dashboard: glance
-      service: glance
-      severity: info
-      tier: os
-      support_group: compute-storage-api
-    annotations:
-      description: glance failed to be scraped. Monitoring might miss metrics it needs to alert on.
-      summary: glance cannot be scraped
-
-  - alert: OpenstackGlanceDatabaseScrapeMissing
-    expr: absent(up{app="glance-mariadb"})
-    for: 1h
-    labels:
-      context: availability
-      dashboard: glance
-      service: glance
-      severity: info
-      tier: os
-      support_group: compute-storage-api
-      playbook: 'docs/devops/alert/{{ $labels.service }}'
-    annotations:
-      description: glances database running status failed to be scraped. Monitoring might miss metrics it needs to alert on
-      summary: glance database cannot be scraped
-
-  - alert: OpenstackGlanceApiPodIsDown
-    expr: up{component="glance",type="api"} == 0
-    for: 5m
-    labels:
-      context: availability
-      dashboard: glance
-      meta: "a glance instance went down on {{ $labels.instance }}"
-      service: glance
-      severity: info
-      tier: warning
-      support_group: compute-storage-api
-      playbook: 'docs/devops/alert/{{ $labels.service }}'
-    annotations:
-      description: "A glance-api pod on {{ $labels.instance }} is DOWN. The remaining ones should keep the service up."
-      summary: "A glance server is DOWN"
-
-  - alert: OpenstackGlanceDatabaseDown
-    expr: count(up{component="glance-mariadb"} == 0) == count(up{component="glance-mariadb"})
-    for: 5m
-    labels:
-      context: availability
-      service: glance
-      severity: warning
-      tier: os
-      dashboard: mariadb-overview?var-host=glance-mariadb
-      support_group: compute-storage-api
-      playbook: 'docs/devops/alert/{{ $labels.service }}'
-    annotations:
-      description: "glance database on {{ $labels.instance }} is DOWN."
-      summary: "glance Database is DOWN"
-
-  - alert: OpenstackGlanceApiAllDown
-    expr: count(up{component="glance",type="api"} == 0) == count(up{component="glance",type="api"})
-    for: 5m
-    labels:
-      context: availability
-      meta: all glance instances are down
-      service: glance
-      severity: warning
-      tier: os
-      dashboard: glance
-      support_group: compute-storage-api
-      playbook: 'docs/devops/alert/{{ $labels.service }}'
-    annotations:
-      description: All glance-api server pods are down.
-      summary: glance is unavailable.


### PR DESCRIPTION
Remove alerts that are fully covered by generic platform alerts:

- `OpenstackGlanceApiPodIsDown`, `OpenstackGlanceApiAllDown` → covered by `PodNotReady` / `KubernetesDeploymentInsufficientReplicas`
- `OpenstackGlanceDatabaseDown` → covered by `MariaDBNotReady`
- `OpenstackGlanceContainerOOMKilled` → covered by `PodOOMKilled` / `PodConstantlyOOMKilled`
- `OpenstackGlanceScrapeMissing`, `OpenstackGlanceDatabaseScrapeMissing` → not present in comparable services

The generic alerts derive `support_group` from pod labels (`label_ccloud_support_group`) so routing to `compute-storage-api` is unchanged.

The previous approach of adding `no_alert_on_absence: "true"` to the `up==0` based alerts was counterproductive: it suppressed the only mechanism that would fire when a deployment is deleted or scaled to zero, which is exactly the scenario these alerts were meant to catch.