### PR TITLE
[keystone] bump percona dependency

### DIFF
--- a/openstack/keystone/Chart.lock
+++ b/openstack/keystone/Chart.lock
@@ -16,12 +16,12 @@ dependencies:
   version: 1.0.0
 - name: percona_cluster
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.3.2
+  version: 1.3.3
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.32.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:53a6ae366828333f3f8f7d76a4d2c74367e070d78f9bb38ac1160ab55cecfb8a
-generated: "2026-04-21T17:42:44.497258+03:00"
+digest: sha256:668631b074911f6d1ce11454ca0355155e24047f34f1f75d0b25ffdeaca207c0
+generated: "2026-05-12T12:30:35.19992+02:00"

--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -33,7 +33,7 @@ dependencies:
   - condition: percona_cluster.enabled
     name: percona_cluster
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 1.3.2
+    version: 1.3.3
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.32.0

--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -290,7 +290,7 @@ percona_cluster:
   db_name: keystone
   db_user: keystone
   alerts:
-    support_group: identity
+    support_group: coredns
 
 dbName: keystone
 


### PR DESCRIPTION
- new version promotes incomplete cluster alert to critical
- and two other alerts to warning
- sets coredns as support_group for percona for now