### PR TITLE
[rabbitmq] Optionally set only custom dnsNames in certificate

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+## 0.25.0 - 2026/05/12
+
+- Allow not adding `rabbitmq.serviceName` to the certificate's dnsNames
+  - If enabled, `externalNames` is a required setting
+  - Makes most sense together with also setting `certificate.commonName`
+
 ## 0.24.1 - 2026/04/30
 - Enable transient_nonexcl_queues option, as it's in use by some services
 - Chart version bumped

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: rabbitmq
-version: 0.24.1
+version: 0.25.0
 appVersion: 4.3.0
 description: A Helm chart for RabbitMQ
 sources:

--- a/common/rabbitmq/templates/certificate.yaml
+++ b/common/rabbitmq/templates/certificate.yaml
@@ -11,9 +11,15 @@ spec:
     labels:
       {{- include "rabbitmq.labels" (list $ "version" "rabbitmq" "deployment" "messagequeue") | indent 6 }}
   dnsNames:
+  {{- if .Values.addServiceNameToDnsNames }}
     - {{ include "rabbitmq.serviceName" . }}
-  {{- if .Values.externalNames }}
-    {{- range .Values.externalNames }}
+    {{- if .Values.externalNames }}
+      {{- range .Values.externalNames }}
+    - "{{ . }}"
+      {{- end }}
+    {{- end }}
+  {{- else }}
+    {{- range (required ".Values.externalNames is required with addServiceNameToDnsNames set to false" .Values.externalNames) }}
     - "{{ . }}"
     {{- end }}
   {{- end }}

--- a/common/rabbitmq/values.yaml
+++ b/common/rabbitmq/values.yaml
@@ -137,6 +137,7 @@ credentialUpdater:
   imageTag: '20260223091825'
 
 enableSsl: true
+addServiceNameToDnsNames: true
 certificate:
   issuerRef:
     name: "digicert-issuer"


### PR DESCRIPTION
In Gardener-based regions, the cluster-internal URLs contain a `svc.cluster.local` postfix. We cannot easily get certificates for these domains with our default issuer. Therefore, we allow the consumer of our chart to set _only_ its own `dnsNames`.

Note: This makes most sense together with setting
`certificate.commonName`, because `commonName` would otherwise still contain `cluster.local`.