### PR TITLE
[designate] bump percona requirement

### DIFF
--- a/openstack/designate/Chart.lock
+++ b/openstack/designate/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: percona_cluster
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.3.2
+  version: 1.3.3
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.6.0
@@ -29,5 +29,5 @@ dependencies:
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.3.1
-digest: sha256:78214d341e263158d19da6f92dce38fd78e52a702658fe73fee08ae080addfc2
-generated: "2026-05-07T10:34:02.754964+02:00"
+digest: sha256:cd374190638c04fdd24e1e9dc34467233c9377f371028c663ed8c525a0f3b910
+generated: "2026-05-12T13:08:52.18641+02:00"

--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
   - condition: percona_cluster.enabled
     name: percona_cluster
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 1.3.2
+    version: 1.3.3
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db


### PR DESCRIPTION
- promotes incomplete cluster alert to critical
- two more alerts to warning