### PR TITLE
[glance] make swift-seed dependency optional

### DIFF
--- a/openstack/glance/templates/etc/_glance-api.conf.tpl
+++ b/openstack/glance/templates/etc/_glance-api.conf.tpl
@@ -138,6 +138,9 @@ swift_upload_buffer_dir = /upload
 swift_store_expire_soon_interval = 1800
 swift_store_thread_pool_size = 10
 swift_container_delete_timeout = 2
+{{- if .Values.swift.service_type }}
+swift_store_service_type = {{ .Values.swift.service_type }}
+{{- end }}
 {{- if .Values.swift.multi_tenant }}
 swift_store_multi_tenant = True
 # swift_store_large_object_size = 5120

--- a/openstack/glance/templates/seeds.yaml
+++ b/openstack/glance/templates/seeds.yaml
@@ -19,7 +19,11 @@ spec:
   - monsoon3/domain-{{replace "_" "-" . | lower}}-seed
   {{- end }}
   {{- end }}
+  {{- if or .Values.ceph.enabled .Values.ceph_s3.enabled (and .Values.swift.enabled (eq (.Values.swift.service_type | default "") "object-store-ceph")) }}
+  - monsoon3/ceph-seed
+  {{- else if .Values.swift.enabled }}
   - swift/swift-seed
+  {{- end }}
 
   roles:
   - name: cloud_image_admin


### PR DESCRIPTION
## Problem

In regions without a native Swift cluster (e.g. eu-de-3), Ceph RGW provides
a Swift-compatible object store registered in Keystone under service type
`object-store-ceph`. The glance seed unconditionally required `swift/swift-seed`,
which never ran in eu-de-3, blocking all glance role assignments and leaving
`image_admin` missing from the Keystone catalog.

## Solution

- **`seeds.yaml`**: gate the `swift/swift-seed` dependency on `swift.enabled`;
  substitute `monsoon3/ceph-seed` when `swift.service_type=object-store-ceph`
- **`_glance-api.conf.tpl`**: emit `swift_store_service_type` when
  `swift.service_type` is set, so glance resolves the correct Keystone endpoint

No driver change: glance continues to use the Swift protocol against Ceph RGW,
preserving per-tenant container isolation (`AUTH_%(tenant_id)s`) and chargeback.
S3 driver and native RBD driver are untouched.

## Region-specific values (secrets repo, eu-de-3 only)

```yaml
swift:
  service_type: object-store-ceph
```