### PR TITLE
Share dnsmasq between metal-operator and network-operator

### DIFF
--- a/system/metal-operator-dhcp/Chart.yaml
+++ b/system/metal-operator-dhcp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: metal-operator-dhcp
 description: A Helm chart for the Ironcore metal-operator-dhcp.
 type: application
-version: 2.0.6
+version: 2.1.0
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/system/metal-operator-dhcp/ci/test-values.yaml
+++ b/system/metal-operator-dhcp/ci/test-values.yaml
@@ -1,0 +1,23 @@
+global:
+  region: qa-de-1
+
+dnsmasq:
+  externalIP: 192.0.2.1
+
+bootScripts:
+  nxos.py: |
+    print("ZTP boot script")
+
+networkOperator:
+  enabled: true
+  tags:
+    nw-t-qa-de-1-192-0-2-0-24:
+      bootScript: nxos.py
+      networks:
+        - gateway: 192.0.2.1
+          netmask: 255.255.255.0
+  devices:
+    - name: spine-01
+      dhcpClientId: AABBCC123456
+      address: 192.0.2.10
+      tag: nw-t-qa-de-1-192-0-2-0-24

--- a/system/metal-operator-dhcp/templates/configmap-bootscripts.yaml
+++ b/system/metal-operator-dhcp/templates/configmap-bootscripts.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.bootScripts }}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: metal-bootscripts
+  namespace: {{ .Release.Namespace }}
+data:
+  {{- range $filename, $content := .Values.bootScripts }}
+  {{ $filename }}: |
+{{ $content | indent 4 }}
+  {{- end }}
+{{- end }}

--- a/system/metal-operator-dhcp/templates/configmap-dnsmasq.yaml
+++ b/system/metal-operator-dhcp/templates/configmap-dnsmasq.yaml
@@ -40,8 +40,8 @@ data:
     {{- if .Values.dnsmasq.staticHosts }}
     {{- range .Values.dnsmasq.staticHosts }}
     {{ . }}
-    {{- end }} 
-    {{- end }} 
+    {{- end }}
+    {{- end }}
 
     # Set dns servers
     dhcp-option=6,{{ .Values.dnsmasq.dnsServers }}
@@ -62,10 +62,25 @@ data:
 
     # Client is running PXE over BIOS; send BIOS version of iPXE chainloader
     dhcp-boot=/undionly.kpxe,{{ .Values.dnsmasq.externalIP }}
+    {{- if .Values.networkOperator.enabled }}
+
+    # Network Operator ZTP — tag-scoped, does not interfere with iPXE options
+    {{- range $tag, $cfg := .Values.networkOperator.tags }}
+    {{- range $cfg.networks }}
+    dhcp-range=set:{{ $tag }},{{ .gateway }},static,{{ .netmask }},4h
+    dhcp-option=tag:{{ $tag }},option:router,{{ .gateway }}
+    {{- end }}
+    dhcp-option=tag:{{ $tag }},66,{{ $.Values.dnsmasq.externalIP }}
+    dhcp-option=tag:{{ $tag }},67,{{ $cfg.bootScript }}
+    {{- end }}
+    {{- range .Values.networkOperator.devices }}
+    dhcp-host=id:{{ .dhcpClientId }},set:{{ .tag }},{{ .address }},{{ .name }},4h
+    {{- end }}
+    {{- end }}
   initdnsmasq.sh: |
     #!/usr/bin/env bash
     set -euxo pipefail
-    
+
     mkdir -p /shared/tftpboot
 
     # use ironcore efi

--- a/system/metal-operator-dhcp/templates/deployment-dnsmasq.yaml
+++ b/system/metal-operator-dhcp/templates/deployment-dnsmasq.yaml
@@ -113,6 +113,13 @@ spec:
         volumeMounts:
         - mountPath: /opt/dnsmasq
           name: metal-dnsmasq
+        {{- if .Values.bootScripts }}
+        {{- range $filename, $_ := .Values.bootScripts }}
+        - mountPath: /shared/tftpboot/{{ $filename }}
+          name: metal-bootscripts
+          subPath: {{ $filename }}
+        {{- end }}
+        {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -122,3 +129,9 @@ spec:
           defaultMode: 484
           name: metal-dnsmasq
         name: metal-dnsmasq
+      {{- if .Values.bootScripts }}
+      - configMap:
+          defaultMode: 484
+          name: metal-bootscripts
+        name: metal-bootscripts
+      {{- end }}

--- a/system/metal-operator-dhcp/values.yaml
+++ b/system/metal-operator-dhcp/values.yaml
@@ -22,3 +22,22 @@ ipxe:
   efi:
     host:
     file:
+
+bootScripts: {}
+  # nxos.py: |
+  #   print("ZTP boot script")
+
+networkOperator:
+  enabled: false
+  tags: {}
+  # nw-t-region-1-192-0-2-0-24:   # a tag name, used in dhcp-range and dhcp-option below
+  #   bootScript: nxos.py         # references a key in bootScripts above
+  #   networks:                   # results in:  dhcp-range=set:<tag>,<gateway>,static,<netmask>,4h
+  #     - gateway: 192.0.2.1      #              dhcp-option=tag:<tag>,option:router,<gateway>
+  #       netmask: 255.255.255.0  #              dhcp-option=tag:<tag>,66,<externalIP>
+  #                               #              dhcp-option=tag:<tag>,67,<bootScript>
+  devices: []
+  # - name: spine-01              # results in:  dhcp-host=id:<dhcpClientId>,set:<tag>,<address>,<name>,4h
+  #   dhcpClientId: AABBCC123456  # NX-OS serial number used as DHCP client-id
+  #   address: 192.0.2.10         # must be within the subnet declared in the tag's networks
+  #   tag: nw-t-region-1-192-0-2-0-24


### PR DESCRIPTION
Extend metal-operator-dhcp to serve switch ZTP alongside bare-metal
iPXE booting. Tag-scoped dhcp-range/dhcp-option entries keep
network-operator ZTP options isolated from global iPXE boot options.
Boot scripts are delivered via a dedicated ConfigMap (metal-bootscripts)
mounted into the TFTP root per file.