### PR TITLE
limes: add mail-templates to global

### DIFF
--- a/openstack/limes/templates/configmap.yaml
+++ b/openstack/limes/templates/configmap.yaml
@@ -7,27 +7,25 @@
 */}}
 {{- $az_config := dict "availability_zones" .Values.global.availability_zones -}}
 {{- $mail_config := dict -}}
-{{- if (ne .Release.Namespace "limes-global") -}}
-  {{- $mail_config = (dict
-    "mail_notifications" (dict
-      "endpoint" (printf "%s/" (.Values.limes.clusters.ccloud.catalog_url | replace "limes-3" "limes-campfire" | trimSuffix "/"))
-      "templates" (dict
-        "confirmed_commitments" (dict
-          "subject" .Values.campfire.mail_type.confirmed.subject
-          "body" (tpl (.Files.Get "files/commitment_mail.tpl") (dict "region" .Values.global.region "condition" .Values.campfire.mail_type.confirmed.condition))
-        )
-        "expiring_commitments" (dict
-          "subject" .Values.campfire.mail_type.expire.subject
-          "body" (tpl (.Files.Get "files/commitment_mail.tpl") (dict "region" .Values.global.region "condition" .Values.campfire.mail_type.expire.condition "dashboardInfo" $dashboardInfo))
-        )
-        "transferred_commitments" (dict
-          "subject" .Values.campfire.mail_type.transferred.subject
-          "body" (tpl (.Files.Get "files/commitment_mail.tpl") (dict "region" .Values.global.region "condition" .Values.campfire.mail_type.transferred.condition))
-        )
+{{- $mail_config = (dict
+  "mail_notifications" (dict
+    "endpoint" (printf "%s/" (.Values.limes.clusters.ccloud.catalog_url | replace "limes-3" "limes-campfire" | trimSuffix "/"))
+    "templates" (dict
+      "confirmed_commitments" (dict
+        "subject" .Values.campfire.mail_type.confirmed.subject
+        "body" (tpl (.Files.Get "files/commitment_mail.tpl") (dict "region" .Values.global.region "condition" .Values.campfire.mail_type.confirmed.condition))
+      )
+      "expiring_commitments" (dict
+        "subject" .Values.campfire.mail_type.expire.subject
+        "body" (tpl (.Files.Get "files/commitment_mail.tpl") (dict "region" .Values.global.region "condition" .Values.campfire.mail_type.expire.condition "dashboardInfo" $dashboardInfo))
+      )
+      "transferred_commitments" (dict
+        "subject" .Values.campfire.mail_type.transferred.subject
+        "body" (tpl (.Files.Get "files/commitment_mail.tpl") (dict "region" .Values.global.region "condition" .Values.campfire.mail_type.transferred.condition))
       )
     )
-  ) -}}
-{{- end -}}
+  )
+) -}}
 {{- $full_config := merge .Values.limes.clusters.ccloud $az_config $mail_config -}}
 
 apiVersion: v1


### PR DESCRIPTION
because limes exists in global and the smoke-test is checking for existing templates, I think we can add the templates to the deployment.
Review with ?w=1