### PR TITLE
[Neutron] Introduce Flag for Agent Liveness Probe

### DIFF
--- a/openstack/neutron/templates/asr_config_agents/_deployment-asr1k.yaml.tpl
+++ b/openstack/neutron/templates/asr_config_agents/_deployment-asr1k.yaml.tpl
@@ -45,12 +45,14 @@ spec:
           imagePullPolicy: IfNotPresent
           command:
             - /container.init/neutron-asr1k-start
+          {{- if $context.Values.global.agent_liveness_probe_enabled }}
           livenessProbe:
             exec:
               command: ["neutron-agent-liveness", "--agent-type", "ASR1K L3 Agent", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/secrets/neutron-common-secrets.conf"]
             initialDelaySeconds: 30
             periodSeconds: 30
             timeoutSeconds: 10
+          {{- end }}
           env:
             - name: DEBUG_CONTAINER
             {{ if $context.Values.pod.debug.asr1k_agent }}
@@ -90,12 +92,14 @@ spec:
           imagePullPolicy: IfNotPresent
           command:
             - /container.init/neutron-asr1k-ml2-start
+          {{ if $context.Values.global.agent_liveness_probe_enabled }}
           livenessProbe:
             exec:
               command: ["neutron-agent-liveness", "--agent-type", "ASR1K ML2 Agent", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/secrets/neutron-common-secrets.conf"]
             initialDelaySeconds: 30
             periodSeconds: 30
             timeoutSeconds: 10
+          {{ end }}
           env:
             - name: DEBUG_CONTAINER
             {{ if $context.Values.pod.debug.asr1k_ml2_agent }}

--- a/openstack/neutron/templates/daemonset-metadata-agent.yaml
+++ b/openstack/neutron/templates/daemonset-metadata-agent.yaml
@@ -53,12 +53,14 @@ spec:
                   apiVersion: v1
                   fieldPath: spec.nodeName
             {{- include "utils.trust_bundle.env" . | indent 12 }}
+          {{- if .Values.global.agent_liveness_probe_enabled }}
           livenessProbe:
             exec:
               command: ["neutron-agent-liveness", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/secrets/neutron-common-secrets.conf", "--config-file", "/run/hostname.conf", "--agent-type", "Metadata agent"]
             initialDelaySeconds: 30
             periodSeconds: 30
             timeoutSeconds: 10
+           {{- end }}
           resources:
 {{  toYaml .Values.pod.resources.metadata_agent | indent 12 }}
           volumeMounts:

--- a/openstack/neutron/templates/deployment-aci-agent.yaml
+++ b/openstack/neutron/templates/deployment-aci-agent.yaml
@@ -41,12 +41,14 @@ spec:
           imagePullPolicy: IfNotPresent
           command:
             - /container.init/neutron-aci-agent-start
+          {{- if .Values.global.agent_liveness_probe_enabled }}
           livenessProbe:
             exec:
               command: ["neutron-agent-liveness", "--agent-type", "ACI Agent", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/secrets/neutron-common-secrets.conf"]
             initialDelaySeconds: 30
             periodSeconds: 30
             timeoutSeconds: 10
+          {{- end }}
           resources:
 {{ toYaml .Values.pod.resources.aci_agent | indent 12 }}
           env:

--- a/openstack/neutron/templates/deployment-cc-fabric-agent.yaml
+++ b/openstack/neutron/templates/deployment-cc-fabric-agent.yaml
@@ -55,12 +55,14 @@ spec:
             - /etc/neutron/plugins/ml2/ml2-conf.ini
             - --config-file
             - /etc/neutron/plugins/ml2/ml2_conf_cc-fabric.ini
+          {{- if $.Values.global.agent_liveness_probe_enabled }}
           livenessProbe:
             exec:
               command: ["neutron-agent-liveness", "--agent-type", "CC fabric agent", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/secrets/neutron-common-secrets.conf"]
             initialDelaySeconds: 30
             periodSeconds: 30
             timeoutSeconds: 10
+          {{- end }}
           resources:
 {{ toYaml $.Values.pod.resources.cc_fabric_agent | indent 12 }}
           env:

--- a/openstack/neutron/templates/vct-nsxv3-agent-deployment.yaml
+++ b/openstack/neutron/templates/vct-nsxv3-agent-deployment.yaml
@@ -76,12 +76,14 @@ template: |
           ports:
             - name: metrics-agent
               containerPort: 8000
+          {{- if .Values.global.agent_liveness_probe_enabled }}
           livenessProbe:
             exec:
               command: ["neutron-agent-liveness", "--config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/secrets/neutron-common-secrets.conf", "--config-file", "/etc/neutron/plugins/ml2/ml2-nsxv3.ini", "--agent-type", "NSXv3 Agent"]
             initialDelaySeconds: 200
             periodSeconds: 30
             timeoutSeconds: 10
+          {{- end }}
           resources:
 {{ toYaml .Values.pod.resources.nsxv3_agent | indent 12 }}
           volumeMounts:

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -21,6 +21,7 @@ global:
   domain_seeds:
     skip_hcm_domain: false
   linkerd_requested: false
+  agent_liveness_probe_enabled: true
 
 api_workers: 12
 rpc_workers: 5


### PR DESCRIPTION
Add a flag to enable agent liveness probes.

These probes should be disabled on a per-region basis, as observed in the past that the status checks against the Neutron DB put significant pressure on the database, especially in larger regions with hundreds of agents.

This becomes particularly problematic when many agents restart at the same time, causing a large number of simultaneous requests against the DB.