### PR TITLE
[Placement] Update max_pool_size and max_overflow defaults

### DIFF
--- a/openstack/placement/values.yaml
+++ b/openstack/placement/values.yaml
@@ -52,8 +52,8 @@ uwsgi:
   processes: 10
   wsgi_file: "/var/lib/openstack/bin/placement-api"
 
-max_pool_size: 10
-max_overflow: 5
+max_pool_size: 50
+max_overflow: -1
 
 api_db:  # Only used when mariadb.enabled=False to connect to the nova-api-mariadb
   name: placement


### PR DESCRIPTION
All regions overwrite this with the same values, so we pull these values into the default values of the Placement chart.