### PR TITLE
[neutron] Adjust nodeSelector for gardener cluster

### DIFF
--- a/openstack/neutron/templates/statefulset-network-agent-apod.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent-apod.yaml
@@ -69,9 +69,8 @@ spec:
                   values:
                   - agent
       nodeSelector:
-        multus: bond1
         topology.kubernetes.io/zone: {{ $az_long }}
-        kubernetes.cloud.sap/apod: {{ $apod }}
+        {{ $.Values.k8s_bb_label_name }}: {{ $apod }}
       initContainers:
         - name: init
           image: {{$.Values.global.dockerHubMirror}}/library/{{$.Values.imageNameNetworkAgentDHCPInit | required "Please set neutron.imageNameNetworkAgentDHCPInit or similar"}}:{{$.Values.imageVersionNetworkAgentDHCPInit | required "Please set neutron.imageVersionNetworkAgentDHCPInit or similar"}}

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -1017,3 +1017,5 @@ customdns:
 statsd:
   image: 'shared-app-images/statsd-exporter'
   imageTag: '0.28.0-latest'
+
+k8s_bb_label_name: "kubernetes.cloud.sap/apod"


### PR DESCRIPTION
To run our network agents on a gardener cluster apod we need to adjust the labels to match what we have there.

The "multus=bond1" label is no longer needed, as it was used for setups where not all nodes have multus. This is no longer the case for our setup.

The label kubernetes.cloud.sap/apod is not present with gardener clusters. As a replacement we have kubernetes.metal.cloud.sap/bb. For now we make this configurable via the k8s_bb_label_name key and default to the old value. If we at some point have more gardener specific settings we can migrate to a controlplane_on_gardener config boolean.