### PR TITLE
[srs] change playbook links to new structure

### DIFF
--- a/openstack/castellum/alerts/openstack/errors.alerts
+++ b/openstack/castellum/alerts/openstack/errors.alerts
@@ -74,7 +74,7 @@ groups:
         support_group: containers
         tier: os
         dashboard: castellum
-        playbook: 'https://operations.global.cloud.sap/docs/support/playbook/castellum/resource_scraping_failing'
+        playbook: 'https://operations.global.cloud.sap/docs/resources/castellum/playbooks/resource_scraping_failing'
         meta: "Some resource scrapes are failing!"
       annotations:
         description: |
@@ -137,7 +137,7 @@ groups:
         support_group: containers
         tier: os
         dashboard: castellum
-        playbook: 'https://operations.global.cloud.sap/docs/support/playbook/castellum/asset_scraping_failing'
+        playbook: 'https://operations.global.cloud.sap/docs/resources/castellum/playbooks/asset_scraping_failing'
         meta: "Some asset scrapes of fresh assets are failing!"
       annotations:
         description: |
@@ -155,7 +155,7 @@ groups:
         support_group: containers
         tier: os
         dashboard: castellum
-        playbook: 'https://operations.global.cloud.sap/docs/support/playbook/castellum/asset_scraping_failing'
+        playbook: 'https://operations.global.cloud.sap/docs/resources/castellum/playbooks/asset_scraping_failing'
         meta: "Some asset scrapes of existing assets are failing!"
       annotations:
         description: |
@@ -229,7 +229,7 @@ groups:
         severity: warning
         support_group: containers
         tier: os
-        playbook: 'https://operations.global.cloud.sap/docs/support/playbook/castellum/asset_resizing_failing'
+        playbook: 'https://operations.global.cloud.sap/docs/resources/castellum/playbooks/asset_resizing_failing'
         dashboard: castellum
         meta: "Some non-Manila asset resizes are failing!"
       annotations:
@@ -248,7 +248,7 @@ groups:
         severity: warning
         support_group: compute-storage-api
         tier: os
-        playbook: 'https://operations.global.cloud.sap/docs/support/playbook/castellum/manila_asset_resizing_failing'
+        playbook: 'https://operations.global.cloud.sap/docs/resources/castellum/playbooks/manila_asset_resizing_failing'
         dashboard: castellum
         meta: "Some Manila asset resizes are failing!"
       annotations:

--- a/openstack/cc3test/Chart.yaml
+++ b/openstack/cc3test/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: cc3test - for blackbox testing the CC+1
 name: cc3test
-version: 0.1.18
+version: 0.1.19
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/cc3test/alerts/ccloud-billing.alerts
+++ b/openstack/cc3test/alerts/ccloud-billing.alerts
@@ -14,7 +14,7 @@ groups:
       meta: 'CCloud Billing API is down'
       dashboard: 'cc3test-api-status?var-service={{ $labels.service }}'
       persesDashboard: 'observability/dashboards/cc3test-api-status?var-service={{ $labels.service }}'
-      playbook: 'docs/support/playbook/billing/alerts/cc3test-alert-api/'
+      playbook: 'docs/resources/billing/playbooks/cc3test-alert-api/'
       report: 'cc3test/admin/object-storage/swift/containers/cc3test/objects/{{ $labels.base64path }}'
     annotations:
       description: 'CCloud Billing API is down'
@@ -32,7 +32,7 @@ groups:
       meta: 'CCloud Billing API is flapping'
       dashboard: 'cc3test-api-status?var-service={{ $labels.service }}'
       persesDashboard: 'observability/dashboards/cc3test-api-status?var-service={{ $labels.service }}'
-      playbook: 'docs/support/playbook/billing/alerts/cc3test-alert-api/'
+      playbook: 'docs/resources/billing/playbooks/cc3test-alert-api/'
       report: 'cc3test/admin/object-storage/swift/containers/cc3test/objects/{{ $labels.base64path }}'
     annotations:
       description: 'CCloud Billing API is flapping'

--- a/openstack/cc3test/alerts/ccloud-limes.alerts
+++ b/openstack/cc3test/alerts/ccloud-limes.alerts
@@ -17,7 +17,7 @@ groups:
       meta: 'CCloud Limes API is down'
       dashboard: 'cc3test-api-status?var-service=limes'
       persesDashboard: 'observability/dashboards/cc3test-api-status?var-service=limes'
-      playbook: 'docs/support/playbook/limes/alerts/cc3test-alert-api/'
+      playbook: 'docs/resources/limes/playbooks/cc3test-alert-api/'
       report: 'cc3test/admin/object-storage/swift/containers/cc3test/objects/{{ $labels.base64path }}'
     annotations:
       description: 'CCloud Limes API is down'
@@ -35,7 +35,7 @@ groups:
       meta: 'CCloud Limes API is flapping'
       dashboard: 'cc3test-api-status?var-service={{ $labels.service }}'
       persesDashboard: 'observability/dashboards/cc3test-api-status?var-service={{ $labels.service }}'
-      playbook: 'docs/support/playbook/limes/alerts/cc3test-alert-api/'
+      playbook: 'docs/resources/limes/playbooks/cc3test-alert-api/'
       report: 'cc3test/admin/object-storage/swift/containers/cc3test/objects/{{ $labels.base64path }}'
     annotations:
       description: 'CCloud Limes API is flapping'

--- a/openstack/cc3test/alerts/ccloud-netbox.alerts
+++ b/openstack/cc3test/alerts/ccloud-netbox.alerts
@@ -14,7 +14,7 @@ groups:
       meta: 'CCloud Netbox API is down'
       dashboard: 'cc3test-api-status?var-service={{ $labels.service }}'
       persesDashboard: 'observability/dashboards/cc3test-api-status?var-service={{ $labels.service }}'
-      playbook: 'docs/support/playbook/limes/alerts/cc3test-alert-api/'
+      playbook: 'docs/resources/limes/playbooks/cc3test-alert-api/'
       report: 'cc3test/admin/object-storage/swift/containers/cc3test/objects/{{ $labels.base64path }}'
     annotations:
       description: 'CCloud Netbox API is down'
@@ -32,7 +32,7 @@ groups:
       meta: 'CCloud Netbox API is flapping'
       dashboard: 'cc3test-api-status?var-service={{ $labels.service }}'
       persesDashboard: 'observability/dashboards/cc3test-api-status?var-service={{ $labels.service }}'
-      playbook: 'docs/support/playbook/limes/alerts/cc3test-alert-api/'
+      playbook: 'docs/resources/limes/playbooks/cc3test-alert-api/'
       report: 'cc3test/admin/object-storage/swift/containers/cc3test/objects/{{ $labels.base64path }}'
     annotations:
       description: 'CCloud Netbox API is flapping'

--- a/openstack/keppel/alerts/openstack/api.alerts
+++ b/openstack/keppel/alerts/openstack/api.alerts
@@ -15,7 +15,7 @@ groups:
       support_group: containers
       tier: os
       meta: 'Keppel health check is not reporting success'
-      playbook: 'https://operations.global.cloud.sap/docs/support/playbook/keppel/down'
+      playbook: 'https://operations.global.cloud.sap/docs/container/keppel/playbooks/down'
     annotations:
       summary: Keppel health check is not reporting success.
       description: |

--- a/openstack/limes/alerts/openstack/api.alerts
+++ b/openstack/limes/alerts/openstack/api.alerts
@@ -105,7 +105,7 @@ groups:
       severity: info
       support_group: '{{ if eq $labels.service_name "cinder" "ironic" "nova" "manila" -}} compute-storage-api {{- else if eq $labels.service_name "archer" "designate" "neutron" "octavia" -}} network-api {{- else if eq $labels.service_name "ceph" "swift" -}} storage {{- else -}} containers {{- end -}}'
       tier: os
-      playbook: 'https://operations.global.cloud.sap/docs/support/playbook/limes/alerts/failed_scrapes'
+      playbook: 'https://operations.global.cloud.sap/docs/resources/limes/playbooks/failed_scrapes'
     annotations:
       description: >
         {{ title $labels.namespace }} cannot scrape data from {{ title $labels.service_name }}
@@ -123,7 +123,7 @@ groups:
       severity: warning
       support_group: containers
       tier: os
-      playbook: 'https://operations.global.cloud.sap/docs/support/playbook/limes/alerts/failed_scrapes'
+      playbook: 'https://operations.global.cloud.sap/docs/resources/limes/playbooks/failed_scrapes'
     annotations:
       description: >
         {{ title $labels.namespace }} cannot scrape data for projects from {{ title $labels.service_name }}
@@ -239,7 +239,7 @@ groups:
       support_group: '{{ $labels.support_group }}'
       tier: os
       service: '{{ $labels.service_name }}'
-      playbook: 'https://operations.global.cloud.sap/docs/support/playbook/limes/alerts/non_growing_quota'
+      playbook: 'https://operations.global.cloud.sap/docs/resources/limes/playbooks/non_growing_quota'
     annotations:
       summary: Non-growing quota almost exhausted
       description: >


### PR DESCRIPTION
We moved this out of the old structure in the `documentation-operation` so that we can hand this over properly to the operations team.