### PR TITLE
go-pmtud: fix iptables-init crash on nodes with two default routes

### DIFF
--- a/system/go-pmtud/Chart.yaml
+++ b/system/go-pmtud/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: go-pmtud
 description: go-pmtud
-version: 3.0.1
+version: 3.0.2
 home: https://github.com/sapcc/go-pmtud
 sources:
   - https://github.com/sapcc/go-pmtud

--- a/system/go-pmtud/templates/etc/_iptables_init.tpl
+++ b/system/go-pmtud/templates/etc/_iptables_init.tpl
@@ -3,9 +3,15 @@
 # make sure to update iptables-stop script to keep commands aligned
 
 nflog_group=( {{ .Values.iptables.nflogGroup }} )
-INTERFACE=$(/sbin/ip route | grep -v cbr | awk '/default/ { print $5 }')
+INTERFACE=$(/sbin/ip route | grep -v cbr | awk '/default/ { print $5; exit }')
 
-echo "Outgoing inteface is ${INTERFACE}"
+if [ -z "${INTERFACE}" ]; then
+  echo "ERROR: no default route found, cannot install pmtud iptables rule" >&2
+  exit 1
+fi
+
+echo "Outgoing interface is ${INTERFACE}"
+
 
 # disable rp_filter
 sysctl -w net.ipv4.conf.all.rp_filter=0

--- a/system/go-pmtud/templates/etc/_iptables_stop.tpl
+++ b/system/go-pmtud/templates/etc/_iptables_stop.tpl
@@ -3,7 +3,12 @@
 # make sure to update iptables-init script to keep commands aligned
 
 nflog_group=( {{ .Values.iptables.nflogGroup }} )
-INTERFACE=$(/sbin/ip route | grep -v cbr | awk '/default/ { print $5 }')
+INTERFACE=$(/sbin/ip route | grep -v cbr | awk '/default/ { print $5; exit }')
+
+if [ -z "${INTERFACE}" ]; then
+  echo "No default route found, nothing to stop" >&2
+  exit 0
+fi
 
 echo "Outgoing inteface is ${INTERFACE}"
 


### PR DESCRIPTION

Both _iptables_init.tpl and _iptables_stop.tpl get the same treatment:

1. awk now exits after the first match, so INTERFACE always holds a
   single value even on misconfigured nodes.

2. Empty-check after the awk: init errors out clearly if there's no
   default route at all; stop treats it as a no-op (nothing to clean
   up if there's no route).

3. ${INTERFACE} is quoted in all iptables calls so even if something
   in the future reintroduces a multi-word value, the iptables call
   gets one argument.

related thread - https://convergedcloud.slack.com/archives/C01A1KHQ47L/p1778670446573339

