### PR TITLE
[mariadb] skip PVC mount in backup-v2 when not ReadWriteMany

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.36.0 - 2026/05/14
+* skip mariadb PVC mount in backup deployment when access modes don't include `ReadWriteMany`
+* `maria-back-me-up` updated to `10.11-20260515121634`
+* chart version bumped
+
 ## v0.35.1 - 2026/05/06
 * fixed pvc storage_class templating
 * chart version bumped

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.35.1
+version: 0.36.0
 # scripts/docker-entyrpoint.sh should be updated when appVersion is updated
 appVersion: 10.11.16
 dependencies:

--- a/common/mariadb/templates/backup-v2-deployment.yaml
+++ b/common/mariadb/templates/backup-v2-deployment.yaml
@@ -88,7 +88,7 @@ spec:
         - name: CONFIG_FILE
           value: "/etc/config/config.yaml"
         volumeMounts:
-{{- if .Values.persistence_claim.enabled }}
+{{- if and .Values.persistence_claim.enabled (has "ReadWriteMany" .Values.persistence_claim.access_modes) }}
         - name: mariadb-persistent-storage
           mountPath: /var/lib/mysql
           readOnly: false
@@ -100,7 +100,7 @@ spec:
         - name: mariadb-etc
           configMap:
             name: mariadb-{{.Values.name}}-etc
-{{- if .Values.persistence_claim.enabled }}
+{{- if and .Values.persistence_claim.enabled (has "ReadWriteMany" .Values.persistence_claim.access_modes) }}
         - name: mariadb-persistent-storage
           persistentVolumeClaim:
            claimName: {{ .Values.persistence_claim.name |  default (include "fullName" . ) }}

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -223,7 +223,7 @@ backup_v2:
   enabled: false
   backup_dir: "./backup"
   image: maria-back-me-up
-  image_version: "10.11-20260409091116"
+  image_version: "10.11-20260515121634"
   full_backup_cron_schedule: "0 0 * * *"
   incremental_backup_in_minutes: 5
   purge_binlog_after_minutes: 60


### PR DESCRIPTION
* skip mariadb PVC mount in backup deployment when access modes don't include `ReadWriteMany`
* `maria-back-me-up` updated to `10.11-20260515121634`
* chart version bumped