### PR TITLE
cinder: use dumb-init --single-child for graceful shutdown

### DIFF
--- a/openstack/cinder/templates/vcenter_datacenter_cinder_deployment.yaml
+++ b/openstack/cinder/templates/vcenter_datacenter_cinder_deployment.yaml
@@ -80,6 +80,7 @@ template: |
               add: ["SYS_ADMIN"]
           command:
           - dumb-init
+          - --single-child
           - cinder-volume
           env:
           {{- if .Values.sentry.enabled }}


### PR DESCRIPTION
Without --single-child, dumb-init sends SIGTERM to the entire process group. All processes (ProcessLauncher parent + forked children) receive SIGTERM simultaneously. The parent's signal handler completes quickly and exits before children finish draining in-flight operations. When the parent (dumb-init's direct child) exits, dumb-init exits, PID 1 is gone, and the kernel SIGKILLs all remaining processes — including children that are still completing volume creates.

With --single-child, dumb-init sends SIGTERM only to its direct child (the ProcessLauncher parent). The parent then:
1. Forwards SIGTERM to each child process
2. Waits for ALL children to exit (while self.children: _wait_child())
3. Only exits after every child has completed

This allows cinder-volume children with in-flight operations (e.g., volume-from-image downloads taking 30-90s) to complete gracefully before the container terminates. Requires terminationGracePeriodSeconds to be set high enough to accommodate the longest expected operation.

Tradeoff: if the ProcessLauncher parent crashes (segfault, OOM-kill) without forwarding SIGTERM, orphaned children will not receive SIGTERM from dumb-init. They will be cleaned up by Kubernetes SIGKILL after terminationGracePeriodSeconds expires (900s). This is acceptable because ProcessLauncher is stable oslo.service code that does not crash in practice, and OOM conditions affect the entire cgroup.