### PR TITLE
[Barbican] Fix CADF audit mapping for complete API coverage

### DIFF
--- a/openstack/barbican/templates/etc/_barbican_audit_map.yaml
+++ b/openstack/barbican/templates/etc/_barbican_audit_map.yaml
@@ -9,7 +9,6 @@ resources:
       # Payload can include sensitive info
       exclude:
         - payload
-
     custom_id: secret_ref
     children:
       metadata:
@@ -22,7 +21,8 @@ resources:
         singleton: true
         payloads:
           # Disable payload recording for this endpoint
-          enabled: False
+          enabled: false
+      consumers:
   secret-stores:
     children:
       preferred:
@@ -32,8 +32,13 @@ resources:
     children:
       secrets:
       acl:
+        singleton: true
+      consumers:
   project-quotas:
-  consumers:
+  quotas:
+    singleton: true
   orders:
+  transport-keys:
+    api_name: transport_keys
   versions:
     singleton: true


### PR DESCRIPTION
## Summary
- Remove top-level `consumers` resource — no `/v1/consumers` endpoint exists in Barbican; consumers are sub-resources of secrets and containers
- Add `consumers` as child of both `secrets` and `containers` (actual API paths: `/v1/secrets/{id}/consumers`, `/v1/containers/{id}/consumers`)
- Add `singleton: true` to `containers/acl` — matches the existing `secrets/acl` config
- Add `quotas` resource (singleton) — the `/v1/quotas` GET endpoint returns current project quota
- Add `transport-keys` resource with `api_name: transport_keys` — maps the `/v1/transport_keys` CRUD endpoint

Based on audit of `sapcc/barbican` branch `stable/2025.2-m3` API surface.