### PR TITLE
campfire: allow cluster_editors to send mails

### DIFF
--- a/openstack/limes-campfire/templates/configmap.yaml
+++ b/openstack/limes-campfire/templates/configmap.yaml
@@ -10,5 +10,6 @@ data:
       "match_limes_user": "user_name:limes and user_domain_name:Default and 'limes':%(mail_from)s",
       "match_elektra_user": "user_name:dashboard and user_domain_name:Default and 'elektra':%(mail_from)s",
       "cluster_editor": "role:cloud_resource_admin",
-      "mail:send": "rule:match_limes_user or rule:match_elektra_user or rule:cluster_editor"
+      "mail:send": "rule:match_limes_user or rule:match_elektra_user",
+      "mail:send-test": "rule:cluster_editor"
     }

--- a/openstack/limes-campfire/templates/configmap.yaml
+++ b/openstack/limes-campfire/templates/configmap.yaml
@@ -9,5 +9,6 @@ data:
     {
       "match_limes_user": "user_name:limes and user_domain_name:Default and 'limes':%(mail_from)s",
       "match_elektra_user": "user_name:dashboard and user_domain_name:Default and 'elektra':%(mail_from)s",
-      "mail:send": "rule:match_limes_user or rule:match_elektra_user"
+      "cluster_editor": "role:cloud_resource_admin",
+      "mail:send": "rule:match_limes_user or rule:match_elektra_user or rule:cluster_editor"
     }


### PR DESCRIPTION
`cluster_editors` should be able to send mails via campfire.