### PR TITLE
Revert "keystone: increase WSGI threads to 4 and bump CPU request to 3000m"

### DIFF
--- a/openstack/keystone/templates/etc/_wsgi-keystone.conf.tpl
+++ b/openstack/keystone/templates/etc/_wsgi-keystone.conf.tpl
@@ -59,7 +59,7 @@ CustomLog /dev/stdout proxy env=forwarded
 
 <VirtualHost *:5000>
     ServerName {{ .Values.services.public.host }}.{{ .Values.global.region }}.{{ .Values.global.tld }}
-    WSGIDaemonProcess keystone-public processes=8 threads=4 user=keystone group=keystone display-name=%{GROUP}
+    WSGIDaemonProcess keystone-public processes=8 threads=1 user=keystone group=keystone display-name=%{GROUP}
     WSGIProcessGroup keystone-public
     WSGIScriptAlias / /var/www/cgi-bin/keystone/keystone-wsgi-public
     WSGIApplicationGroup %{GLOBAL}

--- a/openstack/keystone/templates/etc/_wsgi-keystone.conf.tpl
+++ b/openstack/keystone/templates/etc/_wsgi-keystone.conf.tpl
@@ -59,7 +59,7 @@ CustomLog /dev/stdout proxy env=forwarded
 
 <VirtualHost *:5000>
     ServerName {{ .Values.services.public.host }}.{{ .Values.global.region }}.{{ .Values.global.tld }}
-    WSGIDaemonProcess keystone-public processes=8 threads=1 user=keystone group=keystone display-name=%{GROUP}
+    WSGIDaemonProcess keystone-public processes=16 threads=1 user=keystone group=keystone display-name=%{GROUP}
     WSGIProcessGroup keystone-public
     WSGIScriptAlias / /var/www/cgi-bin/keystone/keystone-wsgi-public
     WSGIApplicationGroup %{GLOBAL}

--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -154,7 +154,7 @@ api:
   resources:
     requests:
       memory: 2Gi
-      cpu: 3000m
+      cpu: 1500m
     limits:
       memory: 3Gi
 


### PR DESCRIPTION
Reverts sapcc/helm-charts#11212. Threading might not work as expected. Instead, use processes.