### PR TITLE
chore(gatekeeper): Rename GH plugins in eu-de-3 from ownership enforcement after refactorings

### DIFF
--- a/system/gatekeeper/templates/constraint-owner-info-on-helm-releases.yaml
+++ b/system/gatekeeper/templates/constraint-owner-info-on-helm-releases.yaml
@@ -51,23 +51,23 @@ spec:
       - logs/logs
       - network-cc/blackbox-exporter
       - network-cc/json-exporter
-      - network-cc/kube-monitoring-cc
-      - network-cc/net-cc-prometheus-config
+      - network-cc/network-metrics-cc
+      - network-cc/network-cc-prometheus-config
       - network-cc/snmp-exporter
       - network-cc/ssh-exporter
-      - network-cc/thanos-net-cc
-      - network-cc/thanos-net-cc-rules
+      - network-cc/network-metrics-thanos-cc
+      - network-cc/network-metrics-thanos-cc-rules
       - network-wan/blackbox-exporter
       - network-wan/json-exporter
-      - network-wan/kube-monitoring-wan
-      - network-wan/net-wan-prometheus-config
+      - network-wan/network-metrics-wan
+      - network-wan/network-wan-prometheus-config
       - network-wan/snmp-exporter
       - network-wan/ssh-exporter
-      - network-wan/thanos-net-wan
-      - network-wan/thanos-net-wan-rules
+      - network-wan/network-metrics-thanos-wan
+      - network-wan/network-metrics-thanos-wan-rules
       - network/netbox-iface-connection-exporter
       - network/netbox-sd
-      - network/thanos-net
+      - network/network-metrics-thanos
       - opensearch-logs/opensearch
       - priority-class/priority-class
       - secrets-injector/secrets-injector


### PR DESCRIPTION
Follow-up of https://github.com/sapcc/helm-charts/pull/10962

We had to rename a few of our released to comply with the latest conventions of Unified Observability

All those plugins are currently failing to be deployed on eu-de-3, with this PR this should be fixed.