### PR TITLE
[percona_cluster] set publishNotReadyAddresses to true

### DIFF
--- a/global/percona_cluster/Chart.yaml
+++ b/global/percona_cluster/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: percona_cluster
-version: 1.3.3
+version: 1.3.4
 appVersion: 5.7.44
 description: free, fully compatible, enhanced, open source drop-in replacement for
   MySQL with Galera Replication (xtradb)

--- a/global/percona_cluster/templates/service-repl.yaml
+++ b/global/percona_cluster/templates/service-repl.yaml
@@ -21,6 +21,7 @@ spec:
   externalTrafficPolicy: Local
 {{ end }}
 {{ end }}
+  publishNotReadyAddresses: true
   ports:
   - name: galera
     port: 4567


### PR DESCRIPTION
This solves a chicken-and-egg problem with a percona node trying to join a cluster, opening port 4444 and waiting for the SST synchronisation.

The problem is that at this point the Pod is not in a ready state so the Service is not routing any traffic on port 4444 to it.

With that change the Service object will start routing traffic without waiting for the Pod to become ready.