### PR TITLE
[designate][catz_pools] purge also_notifies

### DIFF
--- a/openstack/designate/templates/etc/_designate.conf.tpl
+++ b/openstack/designate/templates/etc/_designate.conf.tpl
@@ -316,6 +316,9 @@ listen = 0.0.0.0:5354
 # Enforce all incoming queries (including AXFR) are TSIG signed
 query_enforce_tsig = {{ .Values.query_enforce_tsig }}
 
+# restrict non-TSIG signed AXFR queries (comma-separated)
+allow_axfr_ips = {{ .Values.allow_axfr_ips | default "127.0.0.1" }}
+
 # Send all traffic over TCP
 #all_tcp = False
 

--- a/openstack/designate/templates/etc/_designate.conf.tpl
+++ b/openstack/designate/templates/etc/_designate.conf.tpl
@@ -316,9 +316,6 @@ listen = 0.0.0.0:5354
 # Enforce all incoming queries (including AXFR) are TSIG signed
 query_enforce_tsig = {{ .Values.query_enforce_tsig }}
 
-# restrict non-TSIG signed AXFR queries (comma-separated)
-allow_axfr_ips = {{ .Values.allow_axfr_ips | default "127.0.0.1" }}
-
 # Send all traffic over TCP
 #all_tcp = False
 

--- a/openstack/designate/templates/etc/_pools.yaml.tpl
+++ b/openstack/designate/templates/etc/_pools.yaml.tpl
@@ -66,7 +66,6 @@
       options:
         host: {{$srv.ip}}
         port: 53
-        rndc_key_file: {{ $pool.rndc_key_file }}
     {{- end}}
   catalog_zone:
       catalog_zone_fqdn: catalog.pool.{{ $pool.name }}.

--- a/openstack/designate/templates/etc/_pools.yaml.tpl
+++ b/openstack/designate/templates/etc/_pools.yaml.tpl
@@ -57,21 +57,16 @@
     - host: {{ $srv.ip }}
       port: 53
     {{- end}}
-  also_notifies:
-    {{- range $prio, $srv := $pool.nameservers}}
-    - host: {{ $srv.ip }}
-      port: 53
-    {{- end}}
   targets:
     {{- range $idx, $srv := $pool.nameservers}}
-    - type: fake
-      description: Dummy Server {{ add1 $idx }}
+    - type: bind9
       masters:
         - host: {{ $.Values.global.designate_mdns_external_ip }}
           port: 5354
       options:
         host: {{$srv.ip}}
         port: 53
+        rndc_key_file: {{ $pool.rndc_key_file }}
     {{- end}}
   catalog_zone:
       catalog_zone_fqdn: catalog.pool.{{ $pool.name }}.


### PR DESCRIPTION
No need for `also_notifies` if we have `targets`.