### PR TITLE
system/cc-runtime-cluster: set stable JWKS URI for apiserver

### DIFF
--- a/system/cc-runtime-cluster/Chart.yaml
+++ b/system/cc-runtime-cluster/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-runtime-cluster
 description: Converged Cloud Cluster API Runtime Cluster
 type: application
-version: 0.7.18
+version: 0.7.19
 appVersion: "0.1.0"

--- a/system/cc-runtime-cluster/templates/kubeadmcontrolplane.yaml
+++ b/system/cc-runtime-cluster/templates/kubeadmcontrolplane.yaml
@@ -89,6 +89,8 @@ spec:
             value: "10"
           - name: audit-log-maxsize
             value: "100"
+          - name: service-account-jwks-uri
+            value: "https://{{ .Values.controlplane.address }}:{{ .Values.controlplane.port }}/openid/v1/jwks"
         extraVolumes:
           - name: "authentication-config"
             hostPath: "/etc/kubernetes/authentication.yaml"


### PR DESCRIPTION
Set --service-account-jwks-uri to the cluster's external control plane endpoint so the OIDC discovery document advertises a stable URI instead of the apiserver pod's IP address.

Without this, the /.well-known/openid-configuration endpoint returns a jwks_uri pointing to the current advertise-address (a pod IP). Consumers that cache the discovery response break when the seed apiserver endpoints change, because the cached pod IP becomes unreachable.

Using the external control plane hostname ensures the jwks_uri remains valid regardless of apiserver pod rescheduling and is reachable by both in-cluster and external consumers.