### PR TITLE
[hermes] align keep-image-pulled daemonset name with convention

### DIFF
--- a/openstack/hermes/templates/daemonset-keep-image-pulled.yaml
+++ b/openstack/hermes/templates/daemonset-keep-image-pulled.yaml
@@ -14,7 +14,7 @@ kind: DaemonSet
 apiVersion: apps/v1
 
 metadata:
-  name: {{ .Release.Name }}-keep-image-pulled
+  name: keep-image-pulled
   annotations:
     # This pod intentionally has extremely tight resource requests.
     # The VerticalPodAutoscaler should never waste resources by increasing those.
@@ -27,11 +27,11 @@ spec:
       maxUnavailable: 5
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-keep-image-pulled
+      app: keep-image-pulled
   template:
     metadata:
       labels:
-        app: {{ .Release.Name }}-keep-image-pulled
+        app: keep-image-pulled
         alert-tier: os
         alert-service: hermes
       annotations:


### PR DESCRIPTION
## Summary

- Drop the `{{ .Release.Name }}-` prefix from the `keep-image-pulled` DaemonSet name and selector labels in `openstack/hermes/templates/daemonset-keep-image-pulled.yaml`.
- Fixes the `OpenstackHermesPodCPUThrottling` alert paging constantly on `hermes-keep-image-pulled-XXXX` pods in EU-DE-1 (and likely all regions where this DaemonSet runs).
- No alert YAML changes needed — the existing exclusion regex in `openstack/hermes/alerts/kubernetes/pod.alerts:7` becomes correct once pod names match the assumption.

## Root cause

The alert (added in #6815) excludes pods matching `pod!~"keep-image-pulled-.*"`. Prometheus regex matchers are fully anchored, so this only matches pods named exactly `keep-image-pulled-XXXX` — but the hermes DaemonSet template uses `{{ .Release.Name }}-keep-image-pulled`, producing pod names like `hermes-keep-image-pulled-kg8sn`. The exclusion never fired.

`keppel` and `swift` use the unprefixed `name: keep-image-pulled` convention, so their identical alerts work as written. `hermes` and `keystone` diverge — keystone happens to be unaffected because it doesn't use this exact alert name. This PR aligns `hermes` with the keppel/swift convention rather than papering over the divergence with a regex tweak.

## Why fix the template, not the alert

Two paths considered:

1. Broaden the alert regex to `pod!~".*keep-image-pulled-.*"` — workaround. Cements hermes's divergence forever.
2. Rename the DaemonSet to match siblings — root cause fix. Existing 2022 alert filter starts working as designed.

Path 2 was chosen because the prefix wasn't load-bearing (verified: zero references to `hermes-keep-image-pulled` outside this single template file).

## Rollout impact

The DaemonSet rename causes the old prefixed pods to be deleted and new ones created on every node. The pods just run `/bin/sleep inf` to pin a `rabbitmq_notifications` image with `imagePullPolicy: IfNotPresent` — so the only churn is one round of image-pull no-ops (the images are already on every node, that being the whole purpose of this DaemonSet). No service impact. VPA exclusion is annotation-based (`vpa-butler.cloud.sap/update-mode: "Off"`) and unaffected by the rename.

## Test plan

- [ ] `helm template` the chart locally and confirm the rendered DaemonSet name is `keep-image-pulled` (not `hermes-keep-image-pulled`)
- [ ] Deploy to a QA region and watch:
  - [ ] New `keep-image-pulled-XXXX` pods come up healthy on all nodes
  - [ ] Old `hermes-keep-image-pulled-XXXX` pods are cleaned up
  - [ ] `OpenstackHermesPodCPUThrottling` alert stops firing for keep-image-pulled pods
- [ ] Confirm no NetworkPolicy or ServiceMonitor in the cluster references the old name