### PR TITLE
[bridge-attach] new chart to attach a host interface to a Linux bridge

### DIFF
--- a/system/bridge-attach/Chart.lock
+++ b/system/bridge-attach/Chart.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:742f2888eb00ab7553a2609622eea25bf7e896e881b0c7d84b04db3a80cc3735
-generated: "2026-05-21T14:50:52.833114+02:00"
+- name: shared-app-images-tags
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 1.1.465
+digest: sha256:85c28e5a919803f66ba023ab6a6f4b44f4ecb91536ee40624c21fc4cc4542599
+generated: "2026-06-01T17:07:10.835032+02:00"

--- a/system/bridge-attach/Chart.lock
+++ b/system/bridge-attach/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: owner-info
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 1.0.0
+digest: sha256:742f2888eb00ab7553a2609622eea25bf7e896e881b0c7d84b04db3a80cc3735
+generated: "2026-05-21T14:50:52.833114+02:00"

--- a/system/bridge-attach/Chart.yaml
+++ b/system/bridge-attach/Chart.yaml
@@ -2,3 +2,7 @@ apiVersion: v2
 description: Attaches a host network interface to a Linux bridge on every node
 name: bridge-attach
 version: 0.1.0
+dependencies:
+  - name: owner-info
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: ~1.0.0

--- a/system/bridge-attach/Chart.yaml
+++ b/system/bridge-attach/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+description: Attaches a host network interface to a Linux bridge on every node
+name: bridge-attach
+version: 0.1.0

--- a/system/bridge-attach/Chart.yaml
+++ b/system/bridge-attach/Chart.yaml
@@ -6,3 +6,6 @@ dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: ~1.0.0
+  - name: shared-app-images-tags
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: '>= 0.0.0'

--- a/system/bridge-attach/Dockerfile
+++ b/system/bridge-attach/Dockerfile
@@ -1,0 +1,6 @@
+FROM keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/library/alpine:3.22
+
+RUN apk add --no-cache bash iproute2
+
+LABEL source_repository="https://github.com/sapcc/helm-charts/tree/master/system/bridge-attach"
+LABEL maintainer="Marian Schwarz"

--- a/system/bridge-attach/Dockerfile
+++ b/system/bridge-attach/Dockerfile
@@ -1,6 +1,0 @@
-FROM keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/library/alpine:3.22
-
-RUN apk add --no-cache bash iproute2
-
-LABEL source_repository="https://github.com/sapcc/helm-charts/tree/master/system/bridge-attach"
-LABEL maintainer="Marian Schwarz"

--- a/system/bridge-attach/ci/test-values.yaml
+++ b/system/bridge-attach/ci/test-values.yaml
@@ -1,0 +1,12 @@
+enabled: true
+
+global:
+  apods:
+    eu-de-1a:
+      - ap004
+    eu-de-1b:
+      - ap030
+
+apodConfig:
+  ap004:
+    bridge: br-ap004

--- a/system/bridge-attach/templates/configmap.yaml
+++ b/system/bridge-attach/templates/configmap.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bridge-attach-script
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: bridge-attach
+data:
+  add-iface-to-bridge.sh: |
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if [[ $# -ne 2 ]]; then
+        echo "Usage: $0 <interface> <bridge>" >&2
+        exit 1
+    fi
+
+    iface=$1
+    bridge=$2
+    sleep_secs=5
+
+    while ! ip link show "$bridge" >/dev/null 2>&1; do
+        echo "Bridge '$bridge' not found, retrying in ${sleep_secs}s..."
+        sleep "$sleep_secs"
+    done
+
+    if ip link show "$iface" master "$bridge" >/dev/null 2>&1; then
+        echo "Interface '$iface' is already attached to bridge '$bridge'."
+        exit 0
+    fi
+
+    echo "Adding interface '$iface' to bridge '$bridge'..."
+    ip link set "$iface" master "$bridge"
+    echo "Done."
+{{- end }}

--- a/system/bridge-attach/templates/configmap.yaml
+++ b/system/bridge-attach/templates/configmap.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: bridge-attach-script
-  namespace: kube-system
   labels:
     app.kubernetes.io/name: bridge-attach
 data:

--- a/system/bridge-attach/templates/configmap.yaml
+++ b/system/bridge-attach/templates/configmap.yaml
@@ -24,12 +24,26 @@ data:
         sleep "$sleep_secs"
     done
 
-    if ip link show "$iface" master "$bridge" >/dev/null 2>&1; then
+    if [[ ! -e "/sys/class/net/$iface" ]]; then
+        echo "Interface '$iface' not found." >&2
+        exit 1
+    fi
+
+    current_master=""
+    if [[ -L "/sys/class/net/$iface/master" ]]; then
+        current_master=$(basename "$(readlink "/sys/class/net/$iface/master")")
+    fi
+
+    if [[ "$current_master" == "$bridge" ]]; then
         echo "Interface '$iface' is already attached to bridge '$bridge'."
         exit 0
     fi
 
-    echo "Adding interface '$iface' to bridge '$bridge'..."
+    if [[ -n "$current_master" ]]; then
+        echo "Interface '$iface' is currently attached to '$current_master', moving to '$bridge'..."
+    else
+        echo "Adding interface '$iface' to bridge '$bridge'..."
+    fi
     ip link set "$iface" master "$bridge"
     echo "Done."
 {{- end }}

--- a/system/bridge-attach/templates/daemonset.yaml
+++ b/system/bridge-attach/templates/daemonset.yaml
@@ -12,7 +12,6 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: bridge-attach-{{ $apod }}
-  namespace: kube-system
   labels:
     app.kubernetes.io/name: bridge-attach
     apod: {{ $apod }}

--- a/system/bridge-attach/templates/daemonset.yaml
+++ b/system/bridge-attach/templates/daemonset.yaml
@@ -1,15 +1,26 @@
 {{- if .Values.enabled }}
+{{- if .Values.global.apods }}
+{{- $root := . }}
+{{- range $azLong, $apods := .Values.global.apods }}
+{{- range $apods }}
+{{- $apod := . }}
+{{- $cfg := index $root.Values.apodConfig $apod | default dict }}
+{{- $iface := $cfg.interface | default $root.Values.interface }}
+{{- $bridge := $cfg.bridge | default $root.Values.bridge }}
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: bridge-attach
+  name: bridge-attach-{{ $apod }}
   namespace: kube-system
   labels:
     app.kubernetes.io/name: bridge-attach
+    apod: {{ $apod }}
 spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: bridge-attach
+      apod: {{ $apod }}
   updateStrategy:
     rollingUpdate:
       maxUnavailable: '10%'
@@ -18,14 +29,18 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: bridge-attach
+        apod: {{ $apod }}
     spec:
       hostNetwork: true
       hostPID: true
       priorityClassName: system-node-critical
       terminationGracePeriodSeconds: 5
+      nodeSelector:
+        topology.kubernetes.io/zone: {{ $azLong }}
+        {{ $root.Values.apodLabel }}: {{ $apod }}
       containers:
         - name: bridge-attach
-          image: "{{ required ".Values.images.bridgeAttach.image is missing" .Values.images.bridgeAttach.image }}:{{ required ".Values.images.bridgeAttach.tag is missing" .Values.images.bridgeAttach.tag }}"
+          image: "{{ required ".Values.images.bridgeAttach.image is missing" $root.Values.images.bridgeAttach.image }}:{{ required ".Values.images.bridgeAttach.tag is missing" $root.Values.images.bridgeAttach.tag }}"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash
@@ -36,9 +51,9 @@ spec:
               sleep infinity
           env:
             - name: IFACE
-              value: {{ required ".Values.interface is missing" .Values.interface | quote }}
+              value: {{ $iface | quote }}
             - name: BRIDGE
-              value: {{ required ".Values.bridge is missing" .Values.bridge | quote }}
+              value: {{ $bridge | quote }}
           securityContext:
             privileged: true
             capabilities:
@@ -46,7 +61,7 @@ spec:
                 - NET_ADMIN
                 - SYS_ADMIN
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+{{ toYaml $root.Values.resources | indent 12 }}
           volumeMounts:
             - name: script
               mountPath: /scripts
@@ -55,16 +70,11 @@ spec:
           configMap:
             name: bridge-attach-script
             defaultMode: 0755
-      {{- with .Values.nodeSelector }}
-      nodeSelector:
-      {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.affinity }}
-      affinity:
-      {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with $root.Values.tolerations }}
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/system/bridge-attach/templates/daemonset.yaml
+++ b/system/bridge-attach/templates/daemonset.yaml
@@ -1,0 +1,70 @@
+{{- if .Values.enabled }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: bridge-attach
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: bridge-attach
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: bridge-attach
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: '10%'
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bridge-attach
+    spec:
+      hostNetwork: true
+      hostPID: true
+      priorityClassName: system-node-critical
+      terminationGracePeriodSeconds: 5
+      containers:
+        - name: bridge-attach
+          image: "{{ required ".Values.images.bridgeAttach.image is missing" .Values.images.bridgeAttach.image }}:{{ required ".Values.images.bridgeAttach.tag is missing" .Values.images.bridgeAttach.tag }}"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+            - -c
+            - |
+              bash /scripts/add-iface-to-bridge.sh "$IFACE" "$BRIDGE"
+              echo "Sleeping forever to keep pod Running."
+              sleep infinity
+          env:
+            - name: IFACE
+              value: {{ required ".Values.interface is missing" .Values.interface | quote }}
+            - name: BRIDGE
+              value: {{ required ".Values.bridge is missing" .Values.bridge | quote }}
+          securityContext:
+            privileged: true
+            capabilities:
+              add:
+                - NET_ADMIN
+                - SYS_ADMIN
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          volumeMounts:
+            - name: script
+              mountPath: /scripts
+      volumes:
+        - name: script
+          configMap:
+            name: bridge-attach-script
+            defaultMode: 0755
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/system/bridge-attach/templates/daemonset.yaml
+++ b/system/bridge-attach/templates/daemonset.yaml
@@ -38,7 +38,7 @@ spec:
         {{ $root.Values.apodLabel }}: {{ $apod }}
       containers:
         - name: bridge-attach
-          image: "{{ required ".Values.images.bridgeAttach.image is missing" $root.Values.images.bridgeAttach.image }}:{{ required ".Values.images.bridgeAttach.tag is missing" $root.Values.images.bridgeAttach.tag }}"
+          image: {{ include "shared-app-images.ref" (tuple $root "alpine-iproute2" "3.23") }}
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/system/bridge-attach/templates/daemonset.yaml
+++ b/system/bridge-attach/templates/daemonset.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.enabled }}
-{{- if .Values.global.apods }}
+{{- if and .Values.global .Values.global.apods }}
 {{- $root := . }}
 {{- range $azLong, $apods := .Values.global.apods }}
 {{- range $apods }}
@@ -55,11 +55,9 @@ spec:
             - name: BRIDGE
               value: {{ $bridge | quote }}
           securityContext:
-            privileged: true
             capabilities:
               add:
                 - NET_ADMIN
-                - SYS_ADMIN
           resources:
 {{ toYaml $root.Values.resources | indent 12 }}
           volumeMounts:

--- a/system/bridge-attach/templates/daemonset.yaml
+++ b/system/bridge-attach/templates/daemonset.yaml
@@ -32,7 +32,6 @@ spec:
         apod: {{ $apod }}
     spec:
       hostNetwork: true
-      hostPID: true
       priorityClassName: system-node-critical
       terminationGracePeriodSeconds: 5
       nodeSelector:

--- a/system/bridge-attach/values.yaml
+++ b/system/bridge-attach/values.yaml
@@ -18,11 +18,6 @@ apodConfig: {}
 # Label used to select an apod-specific node, matched against the apod name.
 apodLabel: kubernetes.metal.cloud.sap/bb
 
-images:
-  bridgeAttach:
-    image: keppel.global.cloud.sap/ccloud/bridge-attach
-    tag: "latest"
-
 resources:
   limits:
     cpu: 50m

--- a/system/bridge-attach/values.yaml
+++ b/system/bridge-attach/values.yaml
@@ -1,10 +1,22 @@
 enabled: true
 
-# Interface to attach to the bridge.
+# Default interface/bridge pair, used for any apod that does not override below.
 interface: eth1
-
-# Bridge the interface should become a member of.
 bridge: br0
+
+# Per-apod overrides. Keys are apod names as listed in .Values.global.apods.
+# Each entry may override `interface`, `bridge`, both, or neither.
+# Apods not listed here fall back to the top-level defaults.
+#
+# apodConfig:
+#   ap004:
+#     bridge: br-ap004
+#   ap033:
+#     interface: eth2
+apodConfig: {}
+
+# Label used to select an apod-specific node, matched against the apod name.
+apodLabel: kubernetes.cloud.sap/apod
 
 images:
   bridgeAttach:
@@ -19,9 +31,5 @@ resources:
     cpu: 10m
     memory: 16Mi
 
-nodeSelector: {}
-
 tolerations:
   - operator: Exists
-
-affinity: {}

--- a/system/bridge-attach/values.yaml
+++ b/system/bridge-attach/values.yaml
@@ -1,0 +1,27 @@
+enabled: true
+
+# Interface to attach to the bridge.
+interface: eth1
+
+# Bridge the interface should become a member of.
+bridge: br0
+
+images:
+  bridgeAttach:
+    image: keppel.global.cloud.sap/ccloud/bridge-attach
+    tag: "latest"
+
+resources:
+  limits:
+    cpu: 50m
+    memory: 32Mi
+  requests:
+    cpu: 10m
+    memory: 16Mi
+
+nodeSelector: {}
+
+tolerations:
+  - operator: Exists
+
+affinity: {}

--- a/system/bridge-attach/values.yaml
+++ b/system/bridge-attach/values.yaml
@@ -1,4 +1,4 @@
-enabled: true
+enabled: false
 
 # Default interface/bridge pair, used for any apod that does not override below.
 interface: eth1
@@ -16,7 +16,7 @@ bridge: br0
 apodConfig: {}
 
 # Label used to select an apod-specific node, matched against the apod name.
-apodLabel: kubernetes.cloud.sap/apod
+apodLabel: kubernetes.metal.cloud.sap/bb
 
 images:
   bridgeAttach:


### PR DESCRIPTION
New chart `system/bridge-attach`. Privileged DaemonSet that runs on every node and attaches a host interface (default `eth1`) to a Linux bridge (default `br0`) via `ip link set <iface> master <bridge>`. Script ships as a ConfigMap, waits for the bridge to appear, is idempotent (master is checked via `/sys/class/net/<iface>/master`, not `ip link show ... master ...` which silently ignores the filter when a device is named), then sleeps to keep the pod Running.

Image is templated, defaults to `keppel.global.cloud.sap/ccloud/bridge-attach:latest`. The Dockerfile is included in this PR — alpine 3.22 with `bash` and `iproute2` installed.