### PR TITLE
metal-operator-dhcp: serve snponly.efi built into dnsmasq-metal image

### DIFF
--- a/system/metal-operator-dhcp/Chart.yaml
+++ b/system/metal-operator-dhcp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: metal-operator-dhcp
 description: A Helm chart for the Ironcore metal-operator-dhcp.
 type: application
-version: 2.1.0
+version: 2.2.0
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/system/metal-operator-dhcp/templates/configmap-dnsmasq.yaml
+++ b/system/metal-operator-dhcp/templates/configmap-dnsmasq.yaml
@@ -58,7 +58,7 @@ data:
     dhcp-match=set:efi,option:client-arch,9
     dhcp-match=set:efi,option:client-arch,11
     # Client is PXE booting over EFI without iPXE ROM; send EFI version of iPXE chainloader
-    dhcp-boot=tag:efi,tag:!ipxe,{{ .Values.ipxe.efi.file }}
+    dhcp-boot=tag:efi,tag:!ipxe,{{ .Values.ipxe.efi.file | default "snponly.efi" }}
 
     # Client is running PXE over BIOS; send BIOS version of iPXE chainloader
     dhcp-boot=/undionly.kpxe,{{ .Values.dnsmasq.externalIP }}
@@ -83,8 +83,12 @@ data:
 
     mkdir -p /shared/tftpboot
 
-    # use ironcore efi
+    {{- if .Values.ipxe.efi.host }}
     curl -o /shared/tftpboot/{{ .Values.ipxe.efi.file }} {{ .Values.ipxe.efi.host }}/{{ .Values.ipxe.efi.file }}
+    {{- else }}
+    # snponly.efi is built into the dnsmasq-metal image at /tftpboot/snponly.efi
+    cp /tftpboot/snponly.efi /shared/tftpboot/{{ .Values.ipxe.efi.file | default "snponly.efi" }}
+    {{- end }}
 
     exec /usr/sbin/dnsmasq -d -q -C /opt/dnsmasq/dnsmasq.conf
   dhcp-init.sh: |


### PR DESCRIPTION
by default replace curl download of ipxe EFI at pod startup with a cp from the image-bundled /tftpboot/snponly.efi. The snponly.efi is now built from source with DigiCert CAs embedded, fixing TLS failures in air-gapped environments without external OCSP/CRL access. optionally there can still be an external image that is pulled into the container on creation.
