### PR TITLE
openstack/limes-campfire: allow archer user to send mail

### DIFF
--- a/openstack/limes-campfire/templates/configmap.yaml
+++ b/openstack/limes-campfire/templates/configmap.yaml
@@ -9,7 +9,8 @@ data:
     {
       "match_limes_user": "user_name:limes and user_domain_name:Default and 'limes':%(mail_from)s",
       "match_elektra_user": "user_name:dashboard and user_domain_name:Default and 'elektra':%(mail_from)s",
+      "match_archer_user": "user_name:archer and user_domain_name:Default and 'archer':%(mail_from)s",
       "cluster_editor": "role:cloud_resource_admin",
-      "mail:send": "rule:match_limes_user or rule:match_elektra_user",
+      "mail:send": "rule:match_limes_user or rule:match_elektra_user or rule:match_archer_user",
       "mail:send-test": "rule:cluster_editor"
     }


### PR DESCRIPTION
Add `match_archer_user` policy rule for the archer service user
Include archer user in the `mail:send` permission so it can trigger campfire notifications