### PR TITLE
[opensearch-hermes] enable security-plugin audit logging with dedicated datastream

### DIFF
--- a/system/opensearch-hermes/Chart.yaml
+++ b/system/opensearch-hermes/Chart.yaml
@@ -4,7 +4,7 @@ description: OpenSearch-Hermes cluster database for openstack/hermes service
 maintainers:
   - name: Olaf Heydorn <olaf.heydorn@sap.com>
 name: opensearch-hermes
-version: 0.1.14
+version: 0.1.15
 dependencies:
   - name: opensearch
     alias: opensearch_hermes

--- a/system/opensearch-hermes/Chart.yaml
+++ b/system/opensearch-hermes/Chart.yaml
@@ -4,7 +4,7 @@ description: OpenSearch-Hermes cluster database for openstack/hermes service
 maintainers:
   - name: Olaf Heydorn <olaf.heydorn@sap.com>
 name: opensearch-hermes
-version: 0.1.15
+version: 0.1.16
 dependencies:
   - name: opensearch
     alias: opensearch_hermes

--- a/system/opensearch-hermes/templates/config/_audit.yml.tpl
+++ b/system/opensearch-hermes/templates/config/_audit.yml.tpl
@@ -30,12 +30,13 @@ config:
 
     # Users to be excluded from auditing. Wildcard patterns are supported.
     # Excluding service accounts here is the volume-control knob. Per the
-    # security model, only the hermes service and admins should bypass the API,
-    # so the hermes ingest user is the only legitimate high-volume bypass and
-    # is excluded by default. kibanaserver is excluded to prevent dashboard
-    # polling from drowning the audit log.
+    # security model, only the hermes service and admins should bypass the
+    # API; everything else (admin CLI actions, human queries, failed logins,
+    # privilege probes) is audited. Defaults cover the four legitimate
+    # service-account categories: dashboards (kibanaserver*), Hermes-API
+    # (hermes), CADF writer (audit*), and metrics scrape (promuser*).
     ignore_users:
-{{- range .Values.audit.ignore_users | default (list "kibanaserver" "hermes") }}
+{{- range .Values.audit.ignore_users | default (list "kibanaserver" "kibanaserver2" "hermes" "audit" "audit2" "promuser" "promuser2") }}
       - {{ . }}
 {{- end }}
 

--- a/system/opensearch-hermes/templates/config/_audit.yml.tpl
+++ b/system/opensearch-hermes/templates/config/_audit.yml.tpl
@@ -4,82 +4,96 @@ _meta:
 
 config:
   # enable/disable audit logging
-  enabled: false
+  enabled: {{ .Values.audit.enabled | default false }}
 
   audit:
     # Enable/disable REST API auditing
-    enable_rest: false
+    enable_rest: {{ .Values.audit.enable_rest | default false }}
 
-    # Categories to exclude from REST API auditing
+    # Categories to exclude from REST API auditing.
+    # Compliance baseline (PCI-DSS 10.2, BSI IT-Grundschutz APP.4.6/OPS.1.2.5, BSI C5/KRITIS B3S):
+    # FAILED_LOGIN, MISSING_PRIVILEGES, GRANTED_PRIVILEGES, AUTHENTICATED, BAD_HEADERS, SSL_EXCEPTION
+    # must be retained. Anything outside that set is optional and excluded by default.
     disabled_rest_categories:
-      - AUTHENTICATED
-      - GRANTED_PRIVILEGES
+{{- range .Values.audit.disabled_rest_categories | default (list "INDEX_EVENT" "OPENDISTRO_SECURITY_INDEX_ATTEMPT") }}
+      - {{ . }}
+{{- end }}
 
     # Enable/disable Transport API auditing
-    enable_transport: false
+    enable_transport: {{ .Values.audit.enable_transport | default false }}
 
     # Categories to exclude from Transport API auditing
     disabled_transport_categories:
-      - AUTHENTICATED
-      - GRANTED_PRIVILEGES
+{{- range .Values.audit.disabled_transport_categories | default (list "INDEX_EVENT" "OPENDISTRO_SECURITY_INDEX_ATTEMPT") }}
+      - {{ . }}
+{{- end }}
 
-    # Users to be excluded from auditing. Wildcard patterns are supported. Eg:
-    # ignore_users: ["test-user", "employee-*"]
+    # Users to be excluded from auditing. Wildcard patterns are supported.
+    # Excluding service accounts here is the volume-control knob. Per the
+    # security model, only the hermes service and admins should bypass the API,
+    # so the hermes ingest user is the only legitimate high-volume bypass and
+    # is excluded by default. kibanaserver is excluded to prevent dashboard
+    # polling from drowning the audit log.
     ignore_users:
-      - kibanaserver
+{{- range .Values.audit.ignore_users | default (list "kibanaserver" "hermes") }}
+      - {{ . }}
+{{- end }}
 
-    # Requests to be excluded from auditing. Wildcard patterns are supported. Eg:
-    # ignore_requests: ["indices:data/read/*", "SearchRequest"]
-    ignore_requests: []
+    # Requests to be excluded from auditing. Wildcard patterns are supported.
+    ignore_requests:
+{{- range .Values.audit.ignore_requests | default list }}
+      - {{ . }}
+{{- end }}
 
     # Log individual operations in a bulk request
-    resolve_bulk_requests: false
+    resolve_bulk_requests: {{ .Values.audit.resolve_bulk_requests | default false }}
 
     # Include the body of the request (if available) for both REST and the transport layer
-    log_request_body: true
+    log_request_body: {{ .Values.audit.log_request_body | default true }}
 
     # Logs all indices affected by a request. Resolves aliases and wildcards/date patterns
-    resolve_indices: true
+    resolve_indices: {{ .Values.audit.resolve_indices | default true }}
 
     # Exclude sensitive headers from being included in the logs. Eg: Authorization
-    exclude_sensitive_headers: true
+    exclude_sensitive_headers: {{ .Values.audit.exclude_sensitive_headers | default true }}
 
   compliance:
     # enable/disable compliance
-    enabled: true
+    enabled: {{ .Values.audit.compliance.enabled | default true }}
 
-    # Log updates to internal security changes
-    internal_config: true
+    # Log updates to internal security changes. Required by BSI IT-Grundschutz
+    # ORP.4.A23 (audit trail of permission changes). Keep on.
+    internal_config: {{ .Values.audit.compliance.internal_config | default true }}
 
-    # Log external config files for the node
-    external_config: false
+    # Log external config files for the node. Not required by any baseline; keep off.
+    external_config: {{ .Values.audit.compliance.external_config | default false }}
 
     # Log only metadata of the document for read events
-    read_metadata_only: true
+    read_metadata_only: {{ .Values.audit.compliance.read_metadata_only | default true }}
 
-    # Map of indexes and fields to monitor for read events. Wildcard patterns are supported for both index names and fields. Eg:
-    # read_watched_fields: {
-    #   "twitter": ["message"]
-    #   "logs-*": ["id", "attr*"]
-    # }
-    read_watched_fields: {}
+    # Map of indexes and fields to monitor for read events.
+    read_watched_fields: {{ .Values.audit.compliance.read_watched_fields | default dict | toJson }}
 
-    # List of users to ignore for read events. Wildcard patterns are supported. Eg:
-    # read_ignore_users: ["test-user", "employee-*"]
+    # List of users to ignore for read events.
     read_ignore_users:
-      - kibanaserver
+{{- range .Values.audit.compliance.read_ignore_users | default (list "kibanaserver") }}
+      - {{ . }}
+{{- end }}
 
     # Log only metadata of the document for write events
-    write_metadata_only: true
+    write_metadata_only: {{ .Values.audit.compliance.write_metadata_only | default true }}
 
     # Log only diffs for document updates
-    write_log_diffs: false
+    write_log_diffs: {{ .Values.audit.compliance.write_log_diffs | default false }}
 
-    # List of indices to watch for write events. Wildcard patterns are supported
-    # write_watched_indices: ["twitter", "logs-*"]
-    write_watched_indices: []
+    # List of indices to watch for write events.
+    write_watched_indices:
+{{- range .Values.audit.compliance.write_watched_indices | default list }}
+      - {{ . }}
+{{- end }}
 
-    # List of users to ignore for write events. Wildcard patterns are supported. Eg:
-    # write_ignore_users: ["test-user", "employee-*"]
+    # List of users to ignore for write events.
     write_ignore_users:
-      - kibanaserver
+{{- range .Values.audit.compliance.write_ignore_users | default (list "kibanaserver") }}
+      - {{ . }}
+{{- end }}

--- a/system/opensearch-hermes/templates/config/_ds-opensearch-security-audit-ism.json.tpl
+++ b/system/opensearch-hermes/templates/config/_ds-opensearch-security-audit-ism.json.tpl
@@ -1,0 +1,80 @@
+{
+    "policy": {
+        "policy_id": "ds-opensearch-security-audit-ism",
+        "description": "ISM policy for the OpenSearch security-plugin audit log datastream. Compliance: PCI-DSS 10.5.1, BSI IT-Grundschutz OPS.1.1.5 / ORP.4. Auto-cleanup at min_index_age.",
+        "schema_version": "{{ .Values.global.data_stream.schema_version }}",
+        "default_state": "initial",
+        "states": [
+            {
+                "name": "initial",
+                "actions": [],
+                "transitions": [
+                    {
+                        "state_name": "rollover",
+                        "conditions": {
+                            "min_index_age": "{{ .Values.global.data_stream.opensearch_security_audit.min_index_age }}"
+                        }
+                    },
+                    {
+                        "state_name": "rollover",
+                        "conditions": {
+                            "min_size": "{{ .Values.global.data_stream.opensearch_security_audit.min_size }}"
+                        }
+                    },
+                    {
+                        "state_name": "rollover",
+                        "conditions": {
+                            "min_doc_count": {{ .Values.global.data_stream.opensearch_security_audit.min_doc_count | int }}
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "rollover",
+                "actions": [
+                    {
+                        "retry": {
+                            "count": 5,
+                            "backoff": "exponential",
+                            "delay": "1m"
+                        },
+                        "rollover": {
+                            "min_doc_count": 1,
+                            "min_index_age": "1d",
+                            "copy_alias": false
+                        }
+                    }
+                ],
+                "transitions": [
+                    {
+                        "state_name": "delete",
+                        "conditions": {
+                            "min_index_age": "{{ .Values.global.data_stream.opensearch_security_audit.retention }}"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "delete",
+                "actions": [
+                    {
+                        "retry": {
+                            "count": 3,
+                            "backoff": "exponential",
+                            "delay": "1m"
+                        },
+                        "delete": {}
+                    }
+                ],
+                "transitions": []
+            }
+        ],
+        "ism_template":
+            {
+                "index_patterns": [
+                    "opensearch-security-audit"
+                ],
+                "priority": 2
+            }
+    }
+}

--- a/system/opensearch-hermes/templates/config/_ds-opensearch-security-audit.json.tpl
+++ b/system/opensearch-hermes/templates/config/_ds-opensearch-security-audit.json.tpl
@@ -1,0 +1,126 @@
+{
+  "index_patterns": [
+    "opensearch-security-audit"
+  ],
+  "data_stream": {},
+  "template": {
+    "settings": {
+      "index.number_of_shards": 1,
+      "index.number_of_replicas": 1,
+      "index.refresh_interval": "60s",
+      "index.mapping.total_fields.limit": 2000,
+      "index.codec": "best_compression"
+    },
+    "mappings": {
+      "properties": {
+        "@timestamp": {
+          "type": "date"
+        },
+        "audit_category": {
+          "type": "keyword"
+        },
+        "audit_cluster_name": {
+          "type": "keyword"
+        },
+        "audit_format_version": {
+          "type": "short"
+        },
+        "audit_node_host_address": {
+          "type": "ip"
+        },
+        "audit_node_host_name": {
+          "type": "keyword"
+        },
+        "audit_node_id": {
+          "type": "keyword"
+        },
+        "audit_node_name": {
+          "type": "keyword"
+        },
+        "audit_request_body": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 2048
+            }
+          }
+        },
+        "audit_request_effective_user": {
+          "type": "keyword"
+        },
+        "audit_request_effective_user_is_admin": {
+          "type": "boolean"
+        },
+        "audit_request_initiating_user": {
+          "type": "keyword"
+        },
+        "audit_request_layer": {
+          "type": "keyword"
+        },
+        "audit_request_origin": {
+          "type": "keyword"
+        },
+        "audit_request_privilege": {
+          "type": "keyword"
+        },
+        "audit_request_remote_address": {
+          "type": "ip"
+        },
+        "audit_rest_request_headers": {
+          "type": "object",
+          "enabled": false
+        },
+        "audit_rest_request_method": {
+          "type": "keyword"
+        },
+        "audit_rest_request_params": {
+          "type": "object",
+          "enabled": false
+        },
+        "audit_rest_request_path": {
+          "type": "keyword",
+          "fields": {
+            "text": {
+              "type": "text"
+            }
+          }
+        },
+        "audit_transport_headers": {
+          "type": "object",
+          "enabled": false
+        },
+        "audit_transport_request_type": {
+          "type": "keyword"
+        },
+        "audit_trace_doc_id": {
+          "type": "keyword"
+        },
+        "audit_trace_indices": {
+          "type": "keyword"
+        },
+        "audit_trace_resolved_indices": {
+          "type": "keyword"
+        },
+        "audit_trace_shard_id": {
+          "type": "integer"
+        },
+        "audit_trace_task_id": {
+          "type": "keyword"
+        },
+        "audit_trace_task_parent_id": {
+          "type": "keyword"
+        }
+      }
+    }
+  },
+  "data_stream_field_meta": {
+    "timestamp_field": {
+      "name": "@timestamp"
+    }
+  },
+  "priority": 200,
+  "_meta": {
+    "description": "OpenSearch security plugin audit log datastream — distinct from the Hermes CADF cloud-audit datastream"
+  }
+}

--- a/system/opensearch-hermes/templates/config/_install-ds-templates.sh.tpl
+++ b/system/opensearch-hermes/templates/config/_install-ds-templates.sh.tpl
@@ -36,7 +36,16 @@ if [ "${DATA_STREAM_ENABLED}" = true ]; then
    for e in ${DATA_STREAMS}; do
      export FILEPATH=/scripts
      export TMPPATH=/tmp
-     export DS_TEMPLATE=audit_ds.json
+     # Per-datastream index template. Each datastream has its own
+     # ds-${name}.json with the field mappings appropriate for that data
+     # type (CADF cloud-audit fields differ from OpenSearch security-audit
+     # fields, etc.). The legacy "audit_ds.json" name is kept as a fallback
+     # so this refactor doesn't break charts that haven't migrated yet.
+     export DS_TEMPLATE=ds-${e}.json
+     if [ ! -f "/${FILEPATH}/${DS_TEMPLATE}" ]; then
+       echo "Per-datastream template ${DS_TEMPLATE} not found, falling back to legacy audit_ds.json"
+       export DS_TEMPLATE=audit_ds.json
+     fi
 
      echo "creating file FILE=${TMPPATH}/${e}"
      cp "/${FILEPATH}/${DS_TEMPLATE}" "${TMPPATH}/${e}-${DS_TEMPLATE}"

--- a/system/opensearch-hermes/templates/install-ds-templates-job.yaml
+++ b/system/opensearch-hermes/templates/install-ds-templates-job.yaml
@@ -34,7 +34,11 @@ spec:
           - name: DATA_STREAM_ENABLED
             value: "{{ .Values.global.data_stream.enabled }}"
           - name: DATA_STREAMS
-            value: "{{ .Values.global.data_stream.names }}"
+            # Compose the datastream list from the static names plus any
+            # conditionally-enabled streams (e.g. opensearch-security-audit).
+            # Keeps regions from having to remember to update names when
+            # flipping audit toggles.
+            value: "{{ .Values.global.data_stream.names }}{{ if .Values.global.data_stream.opensearch_security_audit.enabled }} opensearch-security-audit{{ end }}"
           - name: FILE_RETENTION_SCHEMA_VERSION
             value: "{{ .Values.global.data_stream.schema_version }}"
           - name: ADMIN_USER

--- a/system/opensearch-hermes/templates/install-security-config-job.yaml
+++ b/system/opensearch-hermes/templates/install-security-config-job.yaml
@@ -45,6 +45,9 @@ spec:
         - mountPath: /usr/share/opensearch/config/opensearch-security/roles_mapping.yml
           name: security-config
           subPath: roles_mapping.yml
+        - mountPath: /usr/share/opensearch/config/opensearch-security/audit.yml
+          name: security-config
+          subPath: audit.yml
         - mountPath: /scripts/install-security-config.sh
           name: security-config
           subPath: install-security-config.sh

--- a/system/opensearch-hermes/templates/security-config-secrets.yaml
+++ b/system/opensearch-hermes/templates/security-config-secrets.yaml
@@ -21,4 +21,8 @@ data:
   install-ds-templates.sh: {{ include (print .Template.BasePath  "/config/_install-ds-templates.sh.tpl") . | b64enc }}
   ds-hermes-ism.json: {{ include (print .Template.BasePath  "/config/_ds-hermes-ism.json.tpl") . | b64enc }}
   audit_ds.json: {{ include (print .Template.BasePath  "/config/_audit_ds.json.tpl") . | b64enc }}
+  {{- if .Values.global.data_stream.opensearch_security_audit.enabled }}
+  ds-opensearch-security-audit.json: {{ include (print .Template.BasePath  "/config/_ds-opensearch-security-audit.json.tpl") . | b64enc }}
+  ds-opensearch-security-audit-ism.json: {{ include (print .Template.BasePath  "/config/_ds-opensearch-security-audit-ism.json.tpl") . | b64enc }}
+  {{- end }}
   {{- end }}

--- a/system/opensearch-hermes/values.yaml
+++ b/system/opensearch-hermes/values.yaml
@@ -79,6 +79,64 @@ auth:
 retention:
   ds: "365d"
 
+# OpenSearch security-plugin audit logging.
+#
+# Compliance scope: PCI-DSS 4.0 Req. 10.2, BSI IT-Grundschutz APP.4.6 / OPS.1.2.5
+# / ORP.4.A23, BSI C5 (KRITIS B3S Cloud Computing). The category set kept ON
+# below is the intersection of those baselines. Anything not required by a
+# baseline is OFF to keep volume and retention cost down.
+#
+# Operational model: only the hermes service and named admins may bypass the
+# API. Service accounts are added to ignore_users to drop legitimate
+# high-volume traffic; everything else (including admin CLI access via
+# securityadmin.sh, dashboards probes, manual queries) is recorded.
+#
+# Default state is disabled. Regions opt in via their region values file.
+audit:
+  enabled: false
+  enable_rest: false
+  enable_transport: false
+
+  # Categories the security plugin will NOT audit. The compliance-required set
+  # (FAILED_LOGIN, MISSING_PRIVILEGES, GRANTED_PRIVILEGES, AUTHENTICATED,
+  # BAD_HEADERS, SSL_EXCEPTION) is deliberately absent from this list.
+  # INDEX_EVENT and OPENDISTRO_SECURITY_INDEX_ATTEMPT are noisy and not
+  # required by any baseline.
+  disabled_rest_categories:
+    - INDEX_EVENT
+    - OPENDISTRO_SECURITY_INDEX_ATTEMPT
+  disabled_transport_categories:
+    - INDEX_EVENT
+    - OPENDISTRO_SECURITY_INDEX_ATTEMPT
+
+  # Service accounts that legitimately bypass the Hermes API. Anything
+  # outside this list will be audited, including admin actions.
+  ignore_users:
+    - kibanaserver
+    - hermes
+  ignore_requests: []
+
+  resolve_bulk_requests: false
+  log_request_body: true
+  resolve_indices: true
+  # Required by PCI-DSS to keep bearer tokens out of the audit log.
+  exclude_sensitive_headers: true
+
+  compliance:
+    enabled: true
+    # BSI ORP.4.A23: log security configuration changes.
+    internal_config: true
+    external_config: false
+    read_metadata_only: true
+    read_watched_fields: {}
+    read_ignore_users:
+      - kibanaserver
+    write_metadata_only: true
+    write_log_diffs: false
+    write_watched_indices: []
+    write_ignore_users:
+      - kibanaserver
+
 owner-info:
   support-group: observability
   service: hermes
@@ -139,6 +197,14 @@ opensearch_hermes:
     enabled: true
     config:
       securityConfigSecret: "security-config"
+  # Route OpenSearch security-plugin audit logs to a distinct index family.
+  # The default ("audit-YYYY.MM.dd") collides with the Hermes "audit-*" role
+  # grant in roles.yml, which would let cloud-audit consumers read OpenSearch
+  # infrastructure-audit. The "opensearch-security-audit-*" prefix is unique
+  # to the security plugin and is not granted to any non-admin role.
+  config:
+    opensearch.yml: |
+      plugins.security.audit.config.index: "opensearch-security-audit-%{+YYYY.MM.dd}"
   extraEnvs:
     - name: DISABLE_INSTALL_DEMO_CONFIG
       value: "true"
@@ -181,6 +247,11 @@ opensearch_hermes_master:
     enabled: true
     config:
       securityConfigSecret: "security-config"
+  # Master nodes also run the security plugin and need the same audit-index
+  # override to keep behavior consistent across the cluster.
+  config:
+    opensearch.yml: |
+      plugins.security.audit.config.index: "opensearch-security-audit-%{+YYYY.MM.dd}"
   extraEnvs:
     - name: DISABLE_INSTALL_DEMO_CONFIG
       value: "true"

--- a/system/opensearch-hermes/values.yaml
+++ b/system/opensearch-hermes/values.yaml
@@ -20,6 +20,25 @@ global:
       min_index_age: "1d"
       min_size: "50gb"
       min_doc_count: 100000000
+    # OpenSearch security-plugin audit log datastream. Distinct from the
+    # Hermes CADF cloud-audit datastream (which lands in "hermes"). Disabled
+    # by default; regions opt in via region values file alongside flipping
+    # audit.enabled / audit.enable_rest / audit.enable_transport.
+    #
+    # Expected steady-state volume is small: only admin actions, failed
+    # logins, and privilege probes survive after the service-account
+    # ignore_users filter. Estimate 50-1000 events/day, ~1MB/day.
+    # The min_doc_count rollover guard exists for brute-force scenarios
+    # where FAILED_LOGIN can spike to thousands/sec.
+    opensearch_security_audit:
+      enabled: false
+      min_index_age: "30d"
+      min_size: "1gb"
+      min_doc_count: 1000000
+      # PCI-DSS 10.5.1 minimum is 12 months; BSI sectoral guidance for
+      # KRITIS/financial operators prefers 24 months. Set to the higher
+      # bar so a single retention setting satisfies both audits.
+      retention: "730d"
   gardener:
     enabled: false
   manager:
@@ -111,9 +130,26 @@ audit:
 
   # Service accounts that legitimately bypass the Hermes API. Anything
   # outside this list will be audited, including admin actions.
+  #
+  # Why each is here:
+  #   kibanaserver/kibanaserver2 - dashboard service, polls every ~1s
+  #   hermes                     - Hermes-API service account; user requests
+  #                                authenticated via Keystone are proxied
+  #                                through this user, so user-driven volume
+  #                                lands here. Auditing it would create
+  #                                the noisiest possible signal.
+  #   audit/audit2               - logstash CADF writer. Auditing the
+  #                                audit-writer is a feedback loop.
+  #   promuser/promuser2         - prometheus-exporter scrape every 30s
+  #                                (~2880 events/day per source). Pure noise.
   ignore_users:
     - kibanaserver
+    - kibanaserver2
     - hermes
+    - audit
+    - audit2
+    - promuser
+    - promuser2
   ignore_requests: []
 
   resolve_bulk_requests: false
@@ -197,14 +233,15 @@ opensearch_hermes:
     enabled: true
     config:
       securityConfigSecret: "security-config"
-  # Route OpenSearch security-plugin audit logs to a distinct index family.
+  # Route OpenSearch security-plugin audit logs to a dedicated datastream.
   # The default ("audit-YYYY.MM.dd") collides with the Hermes "audit-*" role
   # grant in roles.yml, which would let cloud-audit consumers read OpenSearch
-  # infrastructure-audit. The "opensearch-security-audit-*" prefix is unique
-  # to the security plugin and is not granted to any non-admin role.
+  # infrastructure-audit. Writing to the "opensearch-security-audit" datastream
+  # routes through the datastream abstraction; ISM owns rollover + retention.
+  # No date suffix here — backing indices are named .ds-...-NNNNNN by OpenSearch.
   config:
     opensearch.yml: |
-      plugins.security.audit.config.index: "opensearch-security-audit-%{+YYYY.MM.dd}"
+      plugins.security.audit.config.index: "opensearch-security-audit"
   extraEnvs:
     - name: DISABLE_INSTALL_DEMO_CONFIG
       value: "true"
@@ -248,10 +285,12 @@ opensearch_hermes_master:
     config:
       securityConfigSecret: "security-config"
   # Master nodes also run the security plugin and need the same audit-index
-  # override to keep behavior consistent across the cluster.
+  # override to keep behavior consistent across the cluster. Datastream name,
+  # no date suffix — ISM owns rollover via the ds-opensearch-security-audit-ism
+  # policy bound by index_patterns in the index template.
   config:
     opensearch.yml: |
-      plugins.security.audit.config.index: "opensearch-security-audit-%{+YYYY.MM.dd}"
+      plugins.security.audit.config.index: "opensearch-security-audit"
   extraEnvs:
     - name: DISABLE_INSTALL_DEMO_CONFIG
       value: "true"


### PR DESCRIPTION
## Summary

Enables OpenSearch security-plugin audit logging for Hermes with a dedicated datastream (`opensearch-security-audit`) and ISM-driven 730d auto-cleanup. Disabled by default; regions opt in via their region values file.

## What changed

**Audit config (templatized in `_audit.yml.tpl`, defaults in `values.yaml`):**
- Off by default. Regions flip `audit.enabled`, `audit.enable_rest`, `audit.enable_transport` and `global.data_stream.opensearch_security_audit.enabled` to opt in.
- Compliance baseline (PCI-DSS 4.0 Req. 10.2, BSI IT-Grundschutz APP.4.6 / OPS.1.2.5 / ORP.4.A23, BSI C5 / KRITIS B3S): keeps FAILED_LOGIN, MISSING_PRIVILEGES, GRANTED_PRIVILEGES, AUTHENTICATED, BAD_HEADERS, SSL_EXCEPTION on; everything not required is off.
- Default `ignore_users` expanded to all four legitimate service-account categories (`kibanaserver*`, `hermes`, `audit*`, `promuser*`) so volume stays at admin-action and failed-login signal only.

**Dedicated datastream:**
- New index template `_ds-opensearch-security-audit.json.tpl` (priority 200) claims `index_patterns: [opensearch-security-audit]`, declares it a datastream, and ships field mappings for security-plugin audit fields (`audit_category`, `audit_request_*`, `audit_rest_*`, `audit_trace_*`).
- New ISM policy `_ds-opensearch-security-audit-ism.json.tpl` with `initial → rollover → delete`. Rollover triggers at 30d / 1GB / 1M docs (whichever first — the 1M-doc guard exists for FAILED_LOGIN brute-force spikes). Retention: 730d (PCI-DSS 10.5.1 minimum is 365d; KRITIS prefers 730d, satisfies both).
- `_install-ds-templates.sh.tpl` refactored to per-datastream templates (`ds-${name}.json`) with a fallback to the legacy `audit_ds.json` so existing CADF (`hermes`) datastream behavior is preserved.

**Naming:**
- Distinct from the existing CADF `audit-*` role grant in `roles.yml`. The `opensearch-security-audit` name avoids letting cloud-audit consumers accidentally read OpenSearch infrastructure-audit.

**Pointing the security plugin at the datastream:**
- `plugins.security.audit.config.index: "opensearch-security-audit"` (no date suffix; ISM owns rollover) on both `opensearch_hermes` and `opensearch_hermes_master`.