### PR TITLE
[bind] get rid of `pvc_zone_selector`

### DIFF
--- a/system/bind/Chart.yaml
+++ b/system/bind/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Bind DNS software. 
 name: bind
-version: 1.0.2
+version: 1.1.0
 appVersion: "9.18.24"
 dependencies:
   - name: owner-info

--- a/system/bind/templates/pvclaim.yaml
+++ b/system/bind/templates/pvclaim.yaml
@@ -9,11 +9,6 @@ spec:
   resources:
     requests:
       storage: {{ .Values.pvc_size }}
-{{ if .Values.pvc_zone_selector }}
-  selector:
-    matchLabels:
-      failure-domain.beta.kubernetes.io/zone: {{ .Values.global.region }}{{ .Values.failure_domain_zone }}
-{{ end }}
 {{ if .Values.sshd.enabled }}
 ---
 apiVersion: v1
@@ -26,9 +21,4 @@ spec:
   resources:
     requests:
       storage: 10Mi
-{{ if .Values.pvc_zone_selector }}
-  selector:
-    matchLabels:
-      failure-domain.beta.kubernetes.io/zone: {{ .Values.global.region }}{{ .Values.failure_domain_zone }}
-{{ end }}
 {{ end }}

--- a/system/bind/values.yaml
+++ b/system/bind/values.yaml
@@ -51,7 +51,6 @@ failure_domain_zone: a
 
 # PVC size and whether AZ enforced
 pvc_size: "1Gi"
-pvc_zone_selector: false
 
 resources:
   bind:


### PR DESCRIPTION
We're now scheduling the **pods** explicitly using `spec.nodeSelector.topology.kubernetes.io/zone`

Previously we were using `pvc_zone_selector` to conditionally schedule the **PVCs** to a zone and this was flag set to `false` by default. This means that it was possible to have two deployments, say bind1 and bind2, ending up in the same AZ.

All of that is now explicit and we're actually scheduling the **pods** and not the **PVCs**. The PVCs now follow the pods, as opposed to the other way around.