### PR TITLE
[gatekeeper] allow bridge-attach DaemonSet in eu-de-3

### DIFF
--- a/system/gatekeeper/templates/constraint-pod-security-v2.yaml
+++ b/system/gatekeeper/templates/constraint-pod-security-v2.yaml
@@ -578,6 +578,18 @@ spec:
         mayUseHostNetwork: true
         mayUseCapabilities: [ NET_ADMIN ]
 
+      {{- if eq .Values.cluster_name "eu-de-3" }}
+      - matchNamespace: bridge-attach
+        matchRepository: ccloud/bridge-attach
+        justification: |
+          The bridge-attach DaemonSet attaches a host network interface to a
+          Linux bridge on apod nodes. It needs hostNetwork to operate in the
+          host's network namespace and CAP_NET_ADMIN to run
+          `ip link set <iface> master <bridge>`.
+        mayUseHostNetwork: true
+        mayUseCapabilities: [ NET_ADMIN ]
+      {{- end }}
+
       {{- if eq .Values.cluster_type "baremetal" }}
       - matchNamespace: default
         matchRepository: ccloud/sporebox


### PR DESCRIPTION
Adds a pod-security-v2 allowlist entry for the new bridge-attach DaemonSet (chart in PR #11699). Gated on cluster_name == eu-de-3 so other regions are unaffected; can be widened later. Pod runs in the bridge-attach namespace and needs only hostNetwork + CAP_NET_ADMIN to run ip link set <iface> master <bridge>.