### PR TITLE
[Hermes] enable self signed certs for gardener clusters, adding CA cert

### DIFF
--- a/openstack/hermes/Chart.yaml
+++ b/openstack/hermes/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm audit management for Openstack
 maintainers:
   - name: notque
 name: hermes
-version: 0.1.6
+version: 0.1.7
 dependencies:
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/hermes/templates/etc/_logstash.conf.tpl
+++ b/openstack/hermes/templates/etc/_logstash.conf.tpl
@@ -533,7 +533,7 @@ output {
       retry_max_interval => 10
       validate_after_inactivity => 1000
       ssl => true
-      {{- if .Values.logstash.gardener }}
+      {{- if .Values.global.gardener.enabled }}
       ssl_certificate_authorities => ["/etc/logstash/certs/ca.crt"]
       {{- end}}
       ssl_certificate_verification => true

--- a/openstack/hermes/templates/etc/_logstash.conf.tpl
+++ b/openstack/hermes/templates/etc/_logstash.conf.tpl
@@ -524,7 +524,11 @@ output {
       index => "hermes"
       action => "create"
       manage_template => false
+      {{- if .Values.global.gardener.enabled }}
+      hosts => ["https://opensearch-hermes.hermes.svc.cluster.local:{{.Values.hermes_elasticsearch_port}}"]
+      {{- else}}
       hosts => ["https://{{.Values.hermes_elasticsearch_host}}.{{.Values.global.region}}.{{.Values.global.tld}}:{{.Values.hermes_elasticsearch_port}}"]
+      {{- end}}
       auth_type => {
         type => 'basic'
         user => "${OPENSEARCH_USER}"

--- a/openstack/hermes/templates/etc/_logstash.conf.tpl
+++ b/openstack/hermes/templates/etc/_logstash.conf.tpl
@@ -533,6 +533,9 @@ output {
       retry_max_interval => 10
       validate_after_inactivity => 1000
       ssl => true
+      {{- if .Values.logstash.gardener }}
+      ssl_certificate_authorities => ["/etc/logstash/certs/ca.crt"]
+      {{- end}}
       ssl_certificate_verification => true
     }
   }

--- a/openstack/hermes/templates/logstash-deployment.yaml
+++ b/openstack/hermes/templates/logstash-deployment.yaml
@@ -39,6 +39,12 @@ spec:
                 name: logstash-secret
             - configMap:
                 name: logstash-etc
+      {{- if .Values.global.gardener.enabled }
+        - name: ca-cert
+          secret:
+            defaultMode: 444
+            secretName: rest-cert
+      {{- end }}
       containers:
         - name: logstash
           image: {{.Values.global.registry}}/hermes-logstash:{{.Values.hermes_image_version_logstash}}
@@ -127,6 +133,11 @@ spec:
           volumeMounts:
             - name: hermes-etc
               mountPath: /hermes-etc
+            {{- if .Values.global.gardener.enabled }
+            - name: security-config
+              mountPath: /etc/logstash/certs/ca.crt
+              subPath: ca.crt
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /

--- a/openstack/hermes/values.yaml
+++ b/openstack/hermes/values.yaml
@@ -8,6 +8,8 @@ global:
   keystoneNamespace: monsoon3
   # Set to true for global regions
   is_global_region: false
+  gardener:
+    enabled: false
   
 hermes_image_version_logstash: "20250717202634"
       


### PR DESCRIPTION
Gardener has no full domain, we cannot use digicert certs, as our cluster domain is just .local, we have to use self signed certs and point all services, which use this to the ca.crt. 

ca.crt for logstash service