### PR TITLE
[opensearch-logs] disable dedicated query indices for security analytics

### DIFF
--- a/system/opensearch-logs/values.yaml
+++ b/system/opensearch-logs/values.yaml
@@ -159,6 +159,9 @@ opensearch_master:
     enabled: true
     installList:
       - https://github.com/opensearch-project/opensearch-prometheus-exporter/releases/download/3.6.0.0/prometheus-exporter-3.6.0.0.zip
+  opensearchConfig:
+    opensearch.yml: |
+      plugins.security_analytics.enable_detectors_with_dedicated_query_indices: false
 
 opensearch_client:
   enabled: false
@@ -207,6 +210,9 @@ opensearch_client:
     enabled: true
     installList:
       - https://github.com/opensearch-project/opensearch-prometheus-exporter/releases/download/3.6.0.0/prometheus-exporter-3.6.0.0.zip
+  opensearchConfig:
+    opensearch.yml: |
+      plugins.security_analytics.enable_detectors_with_dedicated_query_indices: false
 
 opensearch_data:
   enabled: false
@@ -246,6 +252,9 @@ opensearch_data:
       value: "true"
     - name: AWS_EC2_METADATA_DISABLED
       value: "true"
+  opensearchConfig:
+    opensearch.yml: |
+      plugins.security_analytics.enable_detectors_with_dedicated_query_indices: false
 
 opensearch_data_kvm:
   enabled: false
@@ -285,6 +294,9 @@ opensearch_data_kvm:
       value: "true"
     - name: AWS_EC2_METADATA_DISABLED
       value: "true"
+  opensearchConfig:
+    opensearch.yml: |
+      plugins.security_analytics.enable_detectors_with_dedicated_query_indices: false
 
 opensearch_snapshots:
   enabled: false


### PR DESCRIPTION
## Summary

- Adds `opensearchConfig` to all opensearch-logs node groups (master, client, data, data-kvm) setting `plugins.security_analytics.enable_detectors_with_dedicated_query_indices: false`
- Stops a ~23,000 log lines/minute `MergeSchedulerConfig` storm on the opensearch-logs cluster

## Root cause

The `openstack_keystone_api` Security Analytics detector's `_chained_findings` monitor was deleting and recreating its dedicated query index (`.opensearch-sap-openstack_keystone_api-detectors-queries-optimized-<uuid>_chained_findings-000001`) on every single execution. Two compounding bugs in the upstream plugins caused this:

1. **`TransportIndexDetectorAction.java:906`** — `createDocLevelMonitorMatchAllRequest` passes `deleteQueryIndexInEveryRun=true` for the chained_findings monitor
2. **`DocLevelMonitorQueries.kt:500`** — An inverted condition (`!=` instead of `==`) causes the delete+recreate branch to fire on every run because the stored concrete index (`...-000001`) never matches the alias name

## Fix strategy

This PR is an **immediate mitigation**: disabling dedicated query indices causes all detectors to share a single query index per log type, eliminating the per-run create/delete cycle.

The proper upstream fixes (inverting the condition in `DocLevelMonitorQueries.kt` and setting `deleteQueryIndexInEveryRun=false` for chained_findings monitors) are being tracked separately and require a plugin rebuild.

## Test plan

- [ ] Deploy to a dev/staging region and confirm `MergeSchedulerConfig` log rate drops to near-zero
- [ ] Verify Security Analytics detectors still run and generate findings
- [ ] Check that existing detectors continue to work (they will retain their existing query indices until recreated)