### PR TITLE
fix(persephone-runtime-seed): use hosting garden region for gardenClu…

### DIFF
--- a/global/persephone-runtime-seed/Chart.yaml
+++ b/global/persephone-runtime-seed/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: persephone-runtime-seed
 description: Persephone Runtime seed
 type: application
-version: 0.0.6
+version: 0.0.7
 appVersion: 0.1.0

--- a/global/persephone-runtime-seed/templates/runtime-managedseed.yaml
+++ b/global/persephone-runtime-seed/templates/runtime-managedseed.yaml
@@ -1,7 +1,8 @@
 {{- range $key, $cluster := .Values.persephoneShoots }}
 {{- $defaultInfraCredsName := printf "openstack-infra-creds-seed-%s" $key | trunc 63 | trimSuffix "-" }}
 {{- $infraCredsName := default $defaultInfraCredsName $cluster.infraCredentialsSecretName }}
-{{- $gardenRegion := default $cluster.region (dig "appset" "region" "" $.Values) }}
+{{- $appset := get $.Values "appset" | default dict }}
+{{- $gardenRegion := default $cluster.region (get $appset "region") }}
 ---
 apiVersion: seedmanagement.gardener.cloud/v1alpha1
 kind: ManagedSeed

--- a/global/persephone-runtime-seed/templates/runtime-managedseed.yaml
+++ b/global/persephone-runtime-seed/templates/runtime-managedseed.yaml
@@ -1,7 +1,7 @@
 {{- range $key, $cluster := .Values.persephoneShoots }}
 {{- $defaultInfraCredsName := printf "openstack-infra-creds-seed-%s" $key | trunc 63 | trimSuffix "-" }}
 {{- $infraCredsName := default $defaultInfraCredsName $cluster.infraCredentialsSecretName }}
-{{- $gardenRegion := default $cluster.region $.Values.appset.region }}
+{{- $gardenRegion := default $cluster.region (dig "appset" "region" "" $.Values) }}
 ---
 apiVersion: seedmanagement.gardener.cloud/v1alpha1
 kind: ManagedSeed

--- a/global/persephone-runtime-seed/templates/runtime-managedseed.yaml
+++ b/global/persephone-runtime-seed/templates/runtime-managedseed.yaml
@@ -1,6 +1,7 @@
 {{- range $key, $cluster := .Values.persephoneShoots }}
 {{- $defaultInfraCredsName := printf "openstack-infra-creds-seed-%s" $key | trunc 63 | trimSuffix "-" }}
 {{- $infraCredsName := default $defaultInfraCredsName $cluster.infraCredentialsSecretName }}
+{{- $gardenRegion := default $cluster.region $.Values.appset.region }}
 ---
 apiVersion: seedmanagement.gardener.cloud/v1alpha1
 kind: ManagedSeed
@@ -17,7 +18,7 @@ spec:
       apiVersion: gardenlet.config.gardener.cloud/v1alpha1
       kind: GardenletConfiguration
       gardenClientConnection:
-        gardenClusterAddress: https://api.virtual.{{ $cluster.landscapeName }}.persephone.{{ $cluster.region }}.cloud.sap
+        gardenClusterAddress: https://api.virtual.{{ $cluster.landscapeName }}.persephone.{{ $gardenRegion }}.cloud.sap
       logging:
         enabled: true
       seedConfig:


### PR DESCRIPTION
ManagedSeeds for non-eu-de-1 regions were incorrectly using the shoot region in gardenClusterAddress, causing gardenlet to connect to a non-existent garden API and failing to register the Seed object.

Adding appset.region (the hosting garden cluster region) instead of cluster.region  so all managed seeds regardless of their shoot region register against the correct garden.
