### PR TITLE
[mariadb] Update MariaDB version to 10.11.17

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.37.0 - 2026/05/21
+* MariaDB version updated to [10.11.17](https://mariadb.com/docs/release-notes/community-server/10.11/10.11.17)
+* `maria-back-me-up` updated to `10.11-20260521084302`
+* `user-credential-updater` updated to `python3.13-alpine3.23-20260506191108`
+* `pod-readiness` updated to `20260521132613`
+* chart version bumped
+
 ## v0.36.0 - 2026/05/14
 * skip mariadb PVC mount in backup deployment when access modes don't include `ReadWriteMany`
 * `maria-back-me-up` updated to `10.11-20260515121634`

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,9 +2,9 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.36.0
+version: 0.37.0
 # scripts/docker-entyrpoint.sh should be updated when appVersion is updated
-appVersion: 10.11.16
+appVersion: 10.11.17
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -9,7 +9,7 @@ global:
       enabled: true
 
 name: null
-image: library/mariadb:10.11.16
+image: library/mariadb:10.11.17
 imagePullPolicy: IfNotPresent
 port_public: 3306
 max_connections: 1024
@@ -210,20 +210,20 @@ use_alternate_registry: false
 
 readiness:
   image: pod-readiness
-  image_version: "20260210104857"
+  image_version: "20260521132613"
   # set to true if backup_v2 is not enabled, but readiness sidecar is required
   useSidecar: false
 
 credentialUpdater:
   image: 'shared-app-images/alpine-mariadb'
-  imageTag: 'python3.13-alpine3.23-20260207085008'
+  imageTag: 'python3.13-alpine3.23-20260506191108'
   checkInterval: '10'
 
 backup_v2:
   enabled: false
   backup_dir: "./backup"
   image: maria-back-me-up
-  image_version: "10.11-20260515121634"
+  image_version: "10.11-20260521084302"
   full_backup_cron_schedule: "0 0 * * *"
   incremental_backup_in_minutes: 5
   purge_binlog_after_minutes: 60


### PR DESCRIPTION
* MariaDB version updated to [10.11.17](https://mariadb.com/docs/release-notes/community-server/10.11/10.11.17)
* `maria-back-me-up` updated to `10.11-20260521084302`
* `user-credential-updater` updated to `python3.13-alpine3.23-20260506191108`
* `pod-readiness` updated to `20260521132613`
* chart version bumped