### PR TITLE
keystone: really revert all process- and threads-related changes

### DIFF
--- a/openstack/keystone/templates/etc/_wsgi-keystone.conf.tpl
+++ b/openstack/keystone/templates/etc/_wsgi-keystone.conf.tpl
@@ -59,7 +59,7 @@ CustomLog /dev/stdout proxy env=forwarded
 
 <VirtualHost *:5000>
     ServerName {{ .Values.services.public.host }}.{{ .Values.global.region }}.{{ .Values.global.tld }}
-    WSGIDaemonProcess keystone-public processes=16 threads=1 user=keystone group=keystone display-name=%{GROUP}
+    WSGIDaemonProcess keystone-public processes=8 threads=1 user=keystone group=keystone display-name=%{GROUP}
     WSGIProcessGroup keystone-public
     WSGIScriptAlias / /var/www/cgi-bin/keystone/keystone-wsgi-public
     WSGIApplicationGroup %{GLOBAL}


### PR DESCRIPTION
Things explode if we increase the number of processes, so bring them back down.