### PR TITLE
[memcached] update memcached to 1.6.42 and memcached-exporter

### DIFF
--- a/common/memcached/CHANGELOG.md
+++ b/common/memcached/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.6.17 - 2026/05/21
+
+* memcached [version](https://github.com/memcached/memcached/wiki/ReleaseNotes1641) bumped to `1.6.42-alpine3.23`
+* * memcached-exporter [version](https://github.com/prometheus/memcached_exporter/releases/tag/v0.16.0) bumped to `v0.16.0`
+* chart version bumped
+
 ## v0.6.16 - 2026/03/17
 
 * memcached [version](https://github.com/memcached/memcached/wiki/ReleaseNotes1641) bumped to `1.6.41-alpine3.23`

--- a/common/memcached/Chart.yaml
+++ b/common/memcached/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: v1
 name: memcached
-version: 0.6.16
-appVersion: 1.6.41
+version: 0.6.17
+appVersion: 1.6.42
 description: Free & open source, high-performance, distributed memory object caching system.
 home: http://memcached.org/
 sources:

--- a/common/memcached/values.yaml
+++ b/common/memcached/values.yaml
@@ -2,7 +2,7 @@
 ## ref: https://hub.docker.com/r/library/memcached/tags/
 ##
 image: library/memcached
-imageTag: 1.6.41-alpine3.23
+imageTag: 1.6.42-alpine3.23
 # set to true to use .Values.global.dockerHubMirrorAlternateRegion instead of .Values.global.dockerHubMirror
 use_alternate_registry: false
 
@@ -54,7 +54,7 @@ vpa:
 metrics:
   enabled: true
   image: "prom/memcached-exporter"
-  imageTag: "v0.15.5"
+  imageTag: "v0.16.0"
 
   port: "9150"
   resources:

--- a/common/memcached/values.yaml
+++ b/common/memcached/values.yaml
@@ -19,7 +19,7 @@ imagePullPolicy: IfNotPresent
 nodeAffinity: {}
 
 # Optionally set externalIP for service:
-#external_ip: ''
+# external_ip: ''
 
 # name of priorityClass to influence scheduling priority
 priority_class: "critical-infrastructure"
@@ -30,7 +30,7 @@ memcached:
   ##
   maxItemMemory: 1024
   maxConnections: 16384
-  #verbosity: vvv
+  # verbosity: vvv
   port: 11211
 
 ## Configure resource requests and limits
@@ -101,5 +101,5 @@ alerts:
 
 global: {}
 linkerd:
-  #linkerd annotation for the Memcached pod (true/false)
+  # linkerd annotation for the Memcached pod (true/false)
   enabled: true


### PR DESCRIPTION
* memcached [version](https://github.com/memcached/memcached/wiki/ReleaseNotes1641) bumped to `1.6.42-alpine3.23`
* memcached-exporter [version](https://github.com/prometheus/memcached_exporter/releases/tag/v0.16.0) bumped to `v0.16.0`
* chart version bumped