### PR TITLE
fix(storage): remove reloader chart

### DIFF
--- a/system/cc-ceph/Chart.lock
+++ b/system/cc-ceph/Chart.lock
@@ -8,8 +8,5 @@ dependencies:
 - name: rook-crds
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.0.1-rook.1.17.5
-- name: reloader
-  repository: oci://ghcr.io/stakater/charts
-  version: 1.3.0
-digest: sha256:dd3985d02f750273ede96c6e2d16d6ce98a2b6f438a4e76e73312b87221622d2
-generated: "2025-07-28T11:04:58.285588-04:00"
+digest: sha256:530680c65144728d962360ffab65a0d357a9412ae87f0c831537f0f7f73b086c
+generated: "2026-05-21T17:21:32.033442132-06:00"

--- a/system/cc-ceph/Chart.yaml
+++ b/system/cc-ceph/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cc-ceph
 description: A Helm chart for the Rook / Ceph Objects inside the Storage Clusters
 type: application
-version: 1.1.75
+version: 1.1.76
 appVersion: "1.17.5"
 dependencies:
   - name: owner-info
@@ -15,7 +15,3 @@ dependencies:
   - name: rook-crds
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: '0.0.1-rook.1.17.5'
-  - name: reloader
-    repository: oci://ghcr.io/stakater/charts
-    version: 1.3.0
-    condition: reloader.enabled


### PR DESCRIPTION
Migrated to greenhouse - ref [here](https://github.wdf.sap.corp/PlusOne/greenhouse/blob/main/shared/storage/ceph/templates/pluginpreset-reloader.yaml) 