### PR TITLE
[cc-shoots-compute] Configure max surge for shoot compute

### DIFF
--- a/system/cc-shoots-compute/Chart.yaml
+++ b/system/cc-shoots-compute/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-shoots-compute
 description: Converged Cloud Gardener shoots
 type: application
-version: 2.4.0
+version: 2.5.0
 appVersion: "0.1.0"

--- a/system/cc-shoots-compute/templates/kvm-shoot.yaml
+++ b/system/cc-shoots-compute/templates/kvm-shoot.yaml
@@ -139,7 +139,7 @@ spec:
                     matchOperator: Equal
                     action: Reject
                   {{- end }}
-                  {{- if $.Values.networking.overlay }}        
+                  {{- if $.Values.networking.overlay }}
                   - cidr: {{ default $.Values.networking.pods $cluster.networking.pods }}
                     matchOperator: In
                     action: Reject
@@ -173,7 +173,7 @@ spec:
           type: baremetal
         minimum: {{ $worker.poolSize }}
         maximum: {{ $worker.poolSize }}
-        maxSurge: 0
+        maxSurge: {{ $worker.maxSurge | default 0 }}
         maxUnavailable: {{ default 1 $worker.maxUnavailable }}
         {{- if $worker.updateStrategy }}
         updateStrategy: {{ $worker.updateStrategy }}


### PR DESCRIPTION
Allow the configuration of `maxSurge` for shoot compute workers. This
eases installation when splitting servers into multiple worker pools as
the current allocation is greedy.
