### PR TITLE
[metal-operator-dhcp] Fix TFTP SNAT for ephemeral data ports

### DIFF
--- a/system/metal-operator-dhcp/Chart.yaml
+++ b/system/metal-operator-dhcp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: metal-operator-dhcp
 description: A Helm chart for the Ironcore metal-operator-dhcp.
 type: application
-version: 2.2.0
+version: 2.3.0
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/system/metal-operator-dhcp/templates/configmap-dnsmasq.yaml
+++ b/system/metal-operator-dhcp/templates/configmap-dnsmasq.yaml
@@ -100,6 +100,9 @@ data:
 
     echo "Outgoing inteface is ${INTERFACE}"
 
+    # Load conntrack helper for TFTP so the kernel tracks ephemeral data ports
+    modprobe nf_conntrack_tftp
+
     echo "Adding rule for SNAT DHCP Reply to correct server IP address"
 
     if iptables-nft -t nat -C POSTROUTING -p udp --sport 67 --dport 67 -j SNAT --to-source ${DHCPSERVERIP} 2>/dev/null; then
@@ -109,11 +112,12 @@ data:
       iptables-nft -t nat -I POSTROUTING 1 -p udp --sport 67 --dport 67 -j SNAT --to-source ${DHCPSERVERIP}
     fi
 
-    if iptables-nft -t nat -C POSTROUTING -p udp --sport 69 --dport 69 -j SNAT --to-source ${DHCPSERVERIP} 2>/dev/null; then
+    # SNAT all TFTP-related traffic (initial + data transfer on ephemeral ports)
+    if iptables-nft -t nat -C POSTROUTING -p udp -m conntrack --ctorigdstport 69 -j SNAT --to-source ${DHCPSERVERIP} 2>/dev/null; then
       echo "Rule for SNAT TFTP Reply already present - skipping"
     else
       echo "Rule for SNAT TFTP Reply not present - creating rule"
-      iptables-nft -t nat -I POSTROUTING 1 -p udp --sport 69 --dport 69 -j SNAT --to-source ${DHCPSERVERIP}
+      iptables-nft -t nat -I POSTROUTING 1 -p udp -m conntrack --ctorigdstport 69 -j SNAT --to-source ${DHCPSERVERIP}
     fi
   dhcp-stop.sh: |
     #!/usr/bin/env bash
@@ -124,4 +128,4 @@ data:
     iptables-nft -t nat -D POSTROUTING -p udp --sport 67 --dport 67 -j SNAT --to-source ${DHCPSERVERIP}
 
     echo "Deleting rule for SNAT TFTP Reply"
-    iptables-nft -t nat -D POSTROUTING -p udp --sport 69 --dport 69 -j SNAT --to-source ${DHCPSERVERIP}
+    iptables-nft -t nat -D POSTROUTING -p udp -m conntrack --ctorigdstport 69 -j SNAT --to-source ${DHCPSERVERIP}


### PR DESCRIPTION
The previous iptables SNAT rule for TFTP used --sport 69 --dport 69, which required both source and destination ports to be 69. Per RFC 1350, TFTP only uses port 69 as the server's listening port for the initial client request. The server immediately responds from a new ephemeral port, and all subsequent data packets flow between ephemeral ports on both sides. No TFTP packet ever has both sport=69 and dport=69, so the old rule was effectively a no-op that never matched any traffic.

This caused TFTP file transfers (e.g. bootscript delivery) to fail because the data packets left the node with the host's real IP as source address instead of the DHCP server VIP. Clients dropped these replies as they came from an unexpected source.

The fix uses conntrack-based matching instead:

1. Load nf_conntrack_tftp kernel module in the init container so the kernel's connection tracker understands TFTP's port negotiation and classifies the ephemeral-port data packets as RELATED to the original port-69 session.

2. Replace the --sport 69 --dport 69 rule with: -m conntrack --ctorigdstport 69 This matches any UDP packet belonging to a conntrack entry whose original destination was port 69, covering both the initial reply and all subsequent data transfer packets on random high ports.

The init container already runs as privileged, so modprobe has access to the host's kernel modules.