### PR TITLE
[maintenance-controller]: switch rbac from v1 to events.k8s.io for Ev…

### DIFF
--- a/system/maintenance-controller/Chart.yaml
+++ b/system/maintenance-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: maintenance-controller
 description: A controller to manage node maintenance
 type: application
-version: 1.1.5
+version: 1.1.6
 appVersion: "1.9.4"
 home: https://github.com/sapcc/maintenance-controller
 dependencies:

--- a/system/maintenance-controller/templates/role.yaml
+++ b/system/maintenance-controller/templates/role.yaml
@@ -18,7 +18,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - ""
+  - events.k8s.io 
   resources:
   - events
   verbs:


### PR DESCRIPTION
…ents

controller-runtime is using events.k8s.io for a while and maintenance-controller can't post events anymore