### PR TITLE
cinder: per-workload proxysql max_connections (volume=40, backup=10)

### DIFF
--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Cinder/OpenStack_Project_Cinder_mascot.png
 name: cinder
-version: 0.3.8
+version: 0.4.0
 dependencies:
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/cinder/templates/backup_deployment.yaml
+++ b/openstack/cinder/templates/backup_deployment.yaml
@@ -49,6 +49,9 @@ template: |
           datacenter: {= availability_zone =}
           configmap-etc-hash: {{ include (print $.Template.BasePath "/etc-configmap.yaml") . | sha256sum }}
           secrets-hash: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+          {{- if and .Values.proxysql.mode .Values.proxysql.backup .Values.proxysql.backup.max_connections_per_proc }}
+          proxysql-backup-secret-hash: {{ include (print $.Template.BasePath "/proxysql-secret-backup.yaml") . | sha256sum }}
+          {{- end }}
           {{- if .Values.proxysql.mode }}
           prometheus.io/scrape: "true"
           prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
@@ -153,6 +156,14 @@ template: |
         - name: backup-config
           configMap:
             name:  backup-vmware-{= name =}
-        {{- include "utils.proxysql.volumes" . | indent 8 }}
+        {{- if .Values.proxysql }}
+        {{- if .Values.proxysql.mode }}
+        - name: runproxysql
+          emptyDir: {}
+        - name: etcproxysql
+          secret:
+            secretName: {{ .Release.Name }}-proxysql-etc-backup
+        {{- end }}
+        {{- end }}
         {{- include "utils.coordination.volumes" . | indent 8 }}
 {{- end }}

--- a/openstack/cinder/templates/cindernetappconfig.yaml
+++ b/openstack/cinder/templates/cindernetappconfig.yaml
@@ -30,7 +30,7 @@ spec:
   {{- end }}
 
   proxysqlcontainer:
-  {{- include "utils.proxysql.container" . | indent 2 }}
+  {{- tuple . (.Values.proxysql.volume.scale | default 1 | int) | include "utils.proxysql.container" | indent 2 }}
   kubernetesentrypointcontainer:
   {{- tuple . (dict "service" (include "cinder.service_dependencies" . )) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 2 }}
   {{- if .Values.cindernetappconfig.cinderbackendconfig }}

--- a/openstack/cinder/templates/proxysql-secret-backup.yaml
+++ b/openstack/cinder/templates/proxysql-secret-backup.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.proxysql -}}
+  {{- if .Values.proxysql.mode -}}
+    {{- if .Values.proxysql.backup -}}
+      {{- if .Values.proxysql.backup.max_connections_per_proc -}}
+        {{- $envAll := . }}
+        {{- $max_connections := .Values.proxysql.backup.max_connections_per_proc }}
+        {{/* Collect all enabled databases from dependencies */}}
+        {{- $_dbs := dict }}
+        {{- range $d := $envAll.Chart.Dependencies }}
+          {{- if hasPrefix "mariadb" $d.Name }}
+            {{- $_ := set $_dbs $d.Name (merge (get $envAll.Values $d.Name) (dict "serviceSuffix" "mariadb")) }}
+          {{- end }}
+          {{- if hasPrefix "pxc" $d.Name }}
+            {{- $_ := set $_dbs $d.Name (merge (get $envAll.Values $d.Name) (dict "serviceSuffix" "db-haproxy")) }}
+          {{- end }}
+        {{- end }}
+        {{/* Determine which database to include based on configuration */}}
+        {{- $defaultDbType := .Values.dbType | default "mariadb" }}
+        {{- $dbs := dict }}
+        {{- range $dbKey, $db := $_dbs }}
+          {{- if and (eq $defaultDbType "mariadb") (hasPrefix "mariadb" $dbKey) }}
+            {{- $_ := set $dbs $dbKey $db }}
+          {{- end }}
+          {{- if and (eq $defaultDbType "pxc-db") (hasPrefix "pxc" $dbKey) }}
+            {{- $_ := set $dbs $dbKey $db }}
+          {{- end }}
+        {{- end }}
+        {{/* Option: use override from proxysql.force_enable value */}}
+        {{- if $envAll.Values.proxysql.force_enable }}
+          {{- $dbs = dict }}
+          {{- range $d := $envAll.Values.proxysql.force_enable }}
+            {{- if hasPrefix "mariadb" $d }}
+              {{- $_ := set $dbs $d (merge (get $envAll.Values $d) (dict "serviceSuffix" "mariadb")) }}
+            {{- else if hasPrefix "pxc" $d }}
+              {{- $_ := set $dbs $d (merge (get $envAll.Values $d) (dict "serviceSuffix" "db-haproxy")) }}
+            {{- else }}
+              {{ fail (printf "unknown database type: %s" $d) }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+        {{- $dbKeys := keys $dbs | sortAlpha }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-proxysql-etc-backup
+  labels:
+    system: openstack
+    type: configuration
+    component: database
+data:
+  proxysql.cnf: |
+{{ include "utils.snippets.set_proxysql_config" (dict "max_connections" $max_connections "dbs" $dbs "dbKeys" $dbKeys "global" $ ) | b64enc | trim | indent 4 }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/openstack/cinder/templates/vcenter_datacenter_cinder_deployment.yaml
+++ b/openstack/cinder/templates/vcenter_datacenter_cinder_deployment.yaml
@@ -69,7 +69,7 @@ template: |
         initContainers:
         {{- tuple . (dict "service" (include "cinder.service_dependencies" . )) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
         {{- if .Values.proxysql.native_sidecar }}
-        {{- include "utils.proxysql.container" . | indent 8 }}
+        {{- tuple . (.Values.proxysql.volume.scale | default 1 | int) | include "utils.proxysql.container" | indent 8 }}
         {{- end }}
         containers:
         - name: cinder-volume-vmware-{= name =}
@@ -138,7 +138,7 @@ template: |
           {{- include "utils.proxysql.volume_mount" . | indent 10 }}
           {{- include "utils.coordination.volume_mount" . | indent 10 }}
         {{- if not .Values.proxysql.native_sidecar }}
-        {{- include "utils.proxysql.container" . | indent 8 }}
+        {{- tuple . (.Values.proxysql.volume.scale | default 1 | int) | include "utils.proxysql.container" | indent 8 }}
         {{- end }}
         {{- include "jaeger_agent_sidecar" . | indent 8 }}
         volumes:

--- a/openstack/cinder/templates/volumes/_volume-deployment.yaml.tpl
+++ b/openstack/cinder/templates/volumes/_volume-deployment.yaml.tpl
@@ -45,7 +45,7 @@ spec:
 {{ include "utils.proxysql.pod_settings" . | indent 6 }}
       initContainers:
       {{- if .Values.proxysql.native_sidecar }}
-      {{- include "utils.proxysql.container" . | indent 8 }}
+      {{- tuple . (.Values.proxysql.volume.scale | default 1 | int) | include "utils.proxysql.container" | indent 8 }}
       {{- end }}
       containers:
       - name: cinder-volume-{{ $name }}
@@ -118,7 +118,7 @@ spec:
         {{- include "utils.coordination.volume_mount" . | indent 8 }}
         {{- include "utils.proxysql.volume_mount" . | indent 8 }}
       {{- if not .Values.proxysql.native_sidecar }}
-      {{- include "utils.proxysql.container" . | indent 6 }}
+      {{- tuple . (.Values.proxysql.volume.scale | default 1 | int) | include "utils.proxysql.container" | indent 6 }}
       {{- end }}
       {{- include "jaeger_agent_sidecar" . | indent 6 }}
       volumes:

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -161,6 +161,10 @@ nanny:
 proxysql:
   mode: null  # Disabled by default
   native_sidecar: true
+  volume:
+    scale: 2  # volume pods get max_connections = base * scale = 20 * 2 = 40
+  backup:
+    max_connections_per_proc: 10  # backup pods get their own proxysql secret with max_connections = 10
 
 mariadb:
   enabled: true


### PR DESCRIPTION
Volume pods use the existing utils.proxysql.container scale mechanism (scale=2 x base 20 = 40) via a postStart SQL update.

Backup pods mount a dedicated cinder-local proxysql secret (cinder-proxysql-etc-backup) rendered with max_connections=10.

API, scheduler, jobs, and nannies continue to use the shared secret with the current effective base of 20.

Chart version bumped to 0.4.0.