### PR TITLE
[glance] allow upload of large images

### DIFF
--- a/openstack/glance/Chart.yaml
+++ b/openstack/glance/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: flamingo
 description: A Helm chart Openstack Glance
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Glance/OpenStack_Project_Glance_vertical.png
 name: glance
-version: 0.8.3
+version: 0.8.4
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/glance/templates/ingress.yaml
+++ b/openstack/glance/templates/ingress.yaml
@@ -10,6 +10,8 @@ metadata:
   annotations:
     ingress.kubernetes.io/proxy-request-buffering: "off"
     nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
+    ingress.kubernetes.io/proxy-body-size: "0"
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
     {{- if .Values.tlsacme }}
     kubernetes.io/tls-acme: "true"
     disco: "true"


### PR DESCRIPTION
Set proxy-body-size annotation for glance ingress, so that it would be possible to upload large images even if this global option is not set in the global ingress-nginx configuration