### PR TITLE
[metal-operator-dhcp] Mount /lib/modules for modprobe in init container

### DIFF
--- a/system/metal-operator-dhcp/Chart.yaml
+++ b/system/metal-operator-dhcp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: metal-operator-dhcp
 description: A Helm chart for the Ironcore metal-operator-dhcp.
 type: application
-version: 2.3.0
+version: 2.3.1
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/system/metal-operator-dhcp/templates/deployment-dnsmasq.yaml
+++ b/system/metal-operator-dhcp/templates/deployment-dnsmasq.yaml
@@ -57,6 +57,9 @@ spec:
         volumeMounts:
           - name: metal-dnsmasq
             mountPath: /opt/dnsmasq
+          - name: lib-modules
+            mountPath: /lib/modules
+            readOnly: true
 {{ end }}
       containers:
       - command:
@@ -125,6 +128,10 @@ spec:
       schedulerName: default-scheduler
       terminationGracePeriodSeconds: 30
       volumes:
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
       - configMap:
           defaultMode: 484
           name: metal-dnsmasq


### PR DESCRIPTION
The previous commit (a32e2fac) added `modprobe nf_conntrack_tftp` to dhcp-init.sh so the kernel's connection tracker can classify TFTP ephemeral-port data packets as RELATED to the original port-69 session.

However, modprobe requires access to the host's kernel module tree at /lib/modules/<kernel-version>/ to locate and load modules. The init container's filesystem is isolated from the host, so /lib/modules does not exist inside the container. This causes modprobe to fail with:

  modprobe: can't change directory to '/lib/modules': No such file
  or directory

The container then exits non-zero (due to set -e) and enters a CrashLoopBackOff.

Fix this by bind-mounting the host's /lib/modules into the init container as a read-only hostPath volume. The init container already runs with privileged: true, which grants CAP_SYS_MODULE needed to insert modules into the running kernel — the only missing piece was access to the module files themselves.