### PR TITLE
fix(persephone-runtime-seed): set explicit regional ingress domain for managed seeds

### DIFF
--- a/global/persephone-runtime-seed/Chart.yaml
+++ b/global/persephone-runtime-seed/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: persephone-runtime-seed
 description: Persephone Runtime seed
 type: application
-version: 0.0.6
+version: 0.0.7
 appVersion: 0.1.0

--- a/global/persephone-runtime-seed/templates/runtime-managedseed.yaml
+++ b/global/persephone-runtime-seed/templates/runtime-managedseed.yaml
@@ -53,6 +53,10 @@ spec:
                 name: {{ $infraCredsName }}
                 namespace: garden
               type: openstack-designate
+          ingress:
+            domain: ingress.{{ $key }}{{ $cluster.landscapeName | substr 0 1 }}.garden.external.{{ $cluster.landscapeName }}.persephone.{{ $cluster.region }}.cloud.sap
+            controller:
+              kind: nginx
           settings:
             excessCapacityReservation:
               enabled: false


### PR DESCRIPTION
- Setting separate Ingress Internal Domains to point to for seed objects 
- This will migrate dns records for eude1 to  ingress.eude1-01p.garden.external.prod.persephone.eu-de-1.cloud.sap 
- which will delete the old records and create new one for eude1 and cause a minor disruption for shoot objects until they reconcile 
- for the remaining regions , will fix the issue of DNS

