### PR TITLE
[rabbitmq] update rabbitmq to 4.3.1

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+## 0.25.1 - 2026/05/26
+
+- RabbitMQ [4.3.1 Release notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.3.1)
+- Chart version bumped
+
 ## 0.25.0 - 2026/05/12
 
 - Allow not adding `rabbitmq.serviceName` to the certificate's dnsNames

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: v1
 name: rabbitmq
-version: 0.25.0
-appVersion: 4.3.0
+version: 0.25.1
+appVersion: 4.3.1
 description: A Helm chart for RabbitMQ
 sources:
   - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/values.yaml
+++ b/common/rabbitmq/values.yaml
@@ -11,7 +11,7 @@ global:
       enabled: true
 
 image: library/rabbitmq
-imageTag: 4.3.0-management
+imageTag: 4.3.1-management
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
- RabbitMQ [4.3.1 Release notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.3.1)
- Chart version bumped