### PR TITLE
Fix JSON parsing for qa-de-2 

### DIFF
--- a/system/audit-logs-otel/templates/audit-logs-collector.yaml
+++ b/system/audit-logs-otel/templates/audit-logs-collector.yaml
@@ -323,7 +323,9 @@ spec:
               - set(log.attributes["auth.mount_type"], log.cache["auth"]["mount_type"])
               - set(log.attributes["auth.namespace.id"], log.cache["auth"]["namespace"]["id"])
               - set(log.attributes["auth.operation"], log.cache["auth"]["operation"])
+              - set(log.attributes["auth.operation"], log.cache["request"]["operation"]) where log.cache["request"]["operation"] != nil and log.attributes["auth.operation"] == nil 
               - set(log.attributes["auth.path"], log.cache["auth"]["path"])
+              - set(log.attributes["auth.path"], log.cache["request"]["path"]) where log.cache["request"]["path"] != nil and log.attributes["auth.path"] == nil
               - set(log.attributes["auth.remote_address"], log.cache["auth"]["remote_address"])
               - set(log.attributes["auth.remote_port"], log.cache["auth"]["remote_port"])
               - set(log.attributes["auth.request_uri"], log.cache["auth"]["request_uri"])

--- a/system/audit-logs-otel/templates/audit-logs-collector.yaml
+++ b/system/audit-logs-otel/templates/audit-logs-collector.yaml
@@ -329,6 +329,7 @@ spec:
               - set(log.attributes["auth.remote_address"], log.cache["auth"]["remote_address"])
               - set(log.attributes["auth.remote_port"], log.cache["auth"]["remote_port"])
               - set(log.attributes["auth.request_uri"], log.cache["auth"]["request_uri"])
+              - set(log.attributes["auth.error"], log.cache["error"])
               - set(log.body, "") where log.attributes["type"] != nil
 
 

--- a/system/audit-logs-otel/templates/audit-logs-collector.yaml
+++ b/system/audit-logs-otel/templates/audit-logs-collector.yaml
@@ -304,14 +304,14 @@ spec:
               - set(log.attributes["auth.entity_id"], log.cache["auth"]["entity_id"])
               - set(log.attributes["auth.metadata"], log.cache["auth"]["metadata"])
               - set(log.attributes["auth.policy_results"], log.cache["auth"]["policy_results"])
-              - set(log.attributes["auth.metadata.role_name"], log.cache["auth"]["metadata.role_name"])
+              - set(log.attributes["auth.metadata.role_name"], log.cache["auth"]["metadata"]["role_name"])
               - set(log.attributes["auth.policies"], log.cache["auth"]["policies"])
               - set(log.attributes["auth.policies"], log.cache["auth"]["identity_policies"]) where log.cache["identity_policies"] != nil and log.attributes["auth.policies"] == nil
               - set(log.attributes["auth.policy_results.allowed"], log.cache["auth"]["policy_results"]["allowed"])
               - set(log.attributes["auth.policy_results.granting_policies"], log.cache["auth"]["policy_results"]["granting_policies"])
               - set(log.attributes["auth.token_policies"], log.cache["auth"]["token_policies"])
               - set(log.attributes["auth.token_issue_time"], log.cache["auth"]["token_issue_time"])
-              - set(log.attributes["auth.token_ttl"], log.cache["auth"]["token_issue_time"])
+              - set(log.attributes["auth.token_ttl"], log.cache["auth"]["token_ttl"])
               - set(log.attributes["auth.token_type"], log.cache["auth"]["token_type"])
               - set(log.attributes["auth.request.client_id"], log.cache["auth"]["client_id"])
               - set(log.attributes["auth.request.client_token"], log.cache["auth"]["client_token"])
@@ -321,6 +321,7 @@ spec:
               - set(log.attributes["auth.mount_point"], log.cache["auth"]["mount_point"])
               - set(log.attributes["auth.mount_running_version"], log.cache["auth"]["mount_running_version"])
               - set(log.attributes["auth.mount_type"], log.cache["auth"]["mount_type"])
+              - set(log.attributes["auth.mount_type"], log.cache["request"]["mount_type"]) where log.cache["request"]["mount_type"] != nil and log.attributes["auth.mount_type"] == nil
               - set(log.attributes["auth.namespace.id"], log.cache["auth"]["namespace"]["id"])
               - set(log.attributes["auth.operation"], log.cache["auth"]["operation"])
               - set(log.attributes["auth.operation"], log.cache["request"]["operation"]) where log.cache["request"]["operation"] != nil and log.attributes["auth.operation"] == nil 

--- a/system/audit-logs-otel/templates/audit-logs-collector.yaml
+++ b/system/audit-logs-otel/templates/audit-logs-collector.yaml
@@ -306,6 +306,7 @@ spec:
               - set(log.attributes["auth.policy_results"], log.cache["auth"]["policy_results"])
               - set(log.attributes["auth.metadata.role_name"], log.cache["auth"]["metadata.role_name"])
               - set(log.attributes["auth.policies"], log.cache["auth"]["policies"])
+              - set(log.attributes["auth.policies"], log.cache["auth"]["identity_policies"]) where log.cache["identity_policies"] != nil and log.attributes["auth.policies"] == nil
               - set(log.attributes["auth.policy_results.allowed"], log.cache["auth"]["policy_results"]["allowed"])
               - set(log.attributes["auth.policy_results.granting_policies"], log.cache["auth"]["policy_results"]["granting_policies"])
               - set(log.attributes["auth.token_policies"], log.cache["auth"]["token_policies"])

--- a/system/logs/templates/_openstack-config.tpl
+++ b/system/logs/templates/_openstack-config.tpl
@@ -173,9 +173,9 @@ transform/keystone_api_json:
         - set(log.attributes["msg"], log.cache["message"])
         - set(log.severity_text, log.cache["levelname"])
         - set(log.attributes["infra.container.component"], log.cache["name"])
-        - set(log.attributes["infra.request_id"], log.cache["context"]["request_id"])
-        - set(log.attributes["infra.request_id"], log.cache["request_id"]) where log.cache["request_id"] != nil and log.attributes["infra.request_id"] == nil
-        - set(log.attributes["infra.global.request_id"], log.cache["context"]["global_request_id"])
+        - set(log.attributes["infra.request.id"], log.cache["context"]["request_id"])
+        - set(log.attributes["infra.request.id"], log.cache["request_id"]) where log.cache["request_id"] != nil and log.attributes["infra.request.id"] == nil
+        - set(log.attributes["infra.global.request.id"], log.cache["context"]["global_request_id"])
         - set(log.attributes["user.id"], log.cache["context"]["user"])
         - set(log.attributes["user.id"], log.cache["user_id"]) where log.cache["user_id"] != nil and log.attributes["user.id"] == nil
         - set(log.attributes["user.name"], log.cache["context"]["user_name"])

--- a/system/logs/templates/_openstack-config.tpl
+++ b/system/logs/templates/_openstack-config.tpl
@@ -161,13 +161,13 @@ transform/keystone_api:
         - merge_maps(log.attributes, ExtractGrokPatterns(log.body, "%{DATE_EU} %{TIME} %{NUMBER} %{NOTSPACE:log.level} %{NOTSPACE:component} \\[%{NOTSPACE:request.id} %{NOTSPACE:global.request.id} usr %{NOTSPACE:user.id} prj %{NOTSPACE:project.id} dom %{NOTSPACE:domain.id} usr-dom %{NOTSPACE:user.domain.id} prj-dom %{NOTSPACE:project.domain.id}\\] %{GREEDYDATA}'%{WORD:request.method} %{URIPATH:uri}' %{WORD:action}", true), "upsert")
 
 transform/keystone_api_json:
-    error_mode: ignore
-    log_statements:
-      - context: log
-        conditions:
-          - resource.attributes["k8s.cluster.name"] == "qa-de-2"
-          - resource.attributes["k8s.container.name"] == "keystone-api"
-        statements:
+  error_mode: ignore
+  log_statements:
+    - context: log
+      conditions:
+        - resource.attributes["k8s.cluster.name"] == "qa-de-2"
+        - resource.attributes["k8s.container.name"] == "keystone-api"
+      statements:
         - merge_maps(log.cache, ParseJSON(log.body), "upsert") where IsMatch(log.body, "^\\{.*\\}$")
         - set(log.time, Time(log.cache["asctime"], "%Y-%m-%d %H:%M:%S,%L")) where log.cache["asctime"] != nil
         - set(log.attributes["msg"], log.cache["message"])
@@ -197,7 +197,7 @@ transform/keystone_api_json:
         - set(log.attributes["log.kind"], "keystone_middleware_lifesaver") where log.attributes["infra.container.component"] == "cc\\.keystone\\.middleware\\.lifesaver" and IsMatch(log.attributes["msg"], ".*has a remaining credit of.*")
         - set(log.attributes["log.kind"], "keystone_exception_Unauthorized") where IsMatch(log.attributes["msg"], "^\\s*Authorization failed\\..*")
         - merge_maps(log.attributes, ExtractGrokPatterns(log.attributes["msg"], "^\\s*cadf action for '%{NOTSPACE:http.request.method} %{URIPATH:http.url.path}' is '%{NOTSPACE:event.action}'", true), "upsert") where log.attributes["log.kind"] == "cadf_action"
-        - merge_maps(log.attributes, ExtractGrokPatterns(log.attributes["msg"], "^\\s*target type URI of requests '%{NOTSPACE:http.request.method} %{URIPATH:http.url.path}' is '%{NOTSPACE:target.type_uri}'", true), "upsert") where logattributes["log.kind"] == "target_type_uri"
+        - merge_maps(log.attributes, ExtractGrokPatterns(log.attributes["msg"], "^\\s*target type URI of requests '%{NOTSPACE:http.request.method} %{URIPATH:http.url.path}' is '%{NOTSPACE:target.type_uri}'", true), "upsert") where log.attributes["log.kind"] == "target_type_uri"
         - merge_maps(log.attributes, ExtractGrokPatterns(log.attributes["msg"], "^\\s*Authenticating %{NOTSPACE:user.name}@%{NOTSPACE:domain.name}\\.\\.", true), "upsert") where log.attributes["log.kind"] == "authentication"
         - merge_maps(log.attributes, ExtractGrokPatterns(log.attributes["msg"], "^\\s*Could not find user:[\\s]+%{NOTSPACE:user.id}\\.", true), "upsert") where log.attributes["log.kind"] == "keystone_exception_UserNotFound"
         - merge_maps(log.attributes, ExtractGrokPatterns(log.attributes["msg"], "(?:AC-)%{NOTSPACE:user.id}\\s+has a remaining credit of %{NUMBER} - request %{WORD:http.request.method} %{NOTSPACE:http.url.path} returned %{NUMBER:http.response.status_code:int}", true), "upsert") where log.attributes["msg"] != nil and log.attributes["log.kind"] == "keystone_middleware_lifesaver"

--- a/system/logs/templates/_openstack-config.tpl
+++ b/system/logs/templates/_openstack-config.tpl
@@ -160,6 +160,51 @@ transform/keystone_api:
       statements:
         - merge_maps(log.attributes, ExtractGrokPatterns(log.body, "%{DATE_EU} %{TIME} %{NUMBER} %{NOTSPACE:log.level} %{NOTSPACE:component} \\[%{NOTSPACE:request.id} %{NOTSPACE:global.request.id} usr %{NOTSPACE:user.id} prj %{NOTSPACE:project.id} dom %{NOTSPACE:domain.id} usr-dom %{NOTSPACE:user.domain.id} prj-dom %{NOTSPACE:project.domain.id}\\] %{GREEDYDATA}'%{WORD:request.method} %{URIPATH:uri}' %{WORD:action}", true), "upsert")
 
+transform/keystone_api_json:
+    error_mode: ignore
+    log_statements:
+      - context: log
+        conditions:
+          - resource.attributes["k8s.cluster.name"] == "qa-de-2"
+          - resource.attributes["k8s.container.name"] == "keystone-api"
+        statements:
+        - merge_maps(log.cache, ParseJSON(log.body), "upsert") where IsMatch(log.body, "^\\{.*\\}$")
+        - set(log.time, Time(log.cache["asctime"], "%Y-%m-%d %H:%M:%S,%L")) where log.cache["asctime"] != nil
+        - set(log.attributes["msg"], log.cache["message"])
+        - set(log.severity_text, log.cache["levelname"])
+        - set(log.attributes["infra.container.component"], log.cache["name"])
+        - set(log.attributes["infra.request_id"], log.cache["context"]["request_id"])
+        - set(log.attributes["infra.request_id"], log.cache["request_id"]) where log.cache["request_id"] != nil and log.attributes["infra.request_id"] == nil
+        - set(log.attributes["infra.global.request_id"], log.cache["context"]["global_request_id"])
+        - set(log.attributes["user.id"], log.cache["context"]["user"])
+        - set(log.attributes["user.id"], log.cache["user_id"]) where log.cache["user_id"] != nil and log.attributes["user.id"] == nil
+        - set(log.attributes["user.name"], log.cache["context"]["user_name"])
+        - set(log.attributes["domain.project.id"], log.cache["context"]["project_id"])
+        - set(log.attributes["domain.project.id"], log.cache["project_id"]) where log.cache["project_id"] != nil and log.attributes["domain.project.id"] == nil
+        - set(log.attributes["domain.project.name"], log.cache["context"]["project_name"])
+        - set(log.attributes["domain.id"], log.cache["context"]["project_domain"])
+        - set(log.attributes["client.address"], log.cache["client_ip"])
+        - set(log.attributes["client.address"], log.cache["remote_addr"]) where log.cache["remote_addr"] != nil and log.attributes["client.address"] == nil
+        - set(log.attributes["http.request.method"], log.cache["method"])
+        - set(log.attributes["http.url.path"], log.cache["uri"])
+        - set(log.attributes["network.protocol.version"], log.cache["protocol"])
+        - set(log.attributes["http.response.status_code"], log.cache["status"])
+        - set(log.attributes["http.user_agent.original"], log.cache["user_agent"])
+        - set(log.attributes["log.kind"], "cadf_action") where IsMatch(log.attributes["msg"], "^\\s*cadf action for.*")
+        - set(log.attributes["log.kind"], "target_type_uri") where IsMatch(log.attributes["msg"], "^\\s*target type URI of requests.*")
+        - set(log.attributes["log.kind"], "authentication") where IsMatch(log.attributes["msg"], "^\\s*Authenticating.*")
+        - set(log.attributes["log.kind"], "keystone_exception_UserNotFound") where IsMatch(log.attributes["infra.container.component"], "keystone\\.auth\\.plugins\\.core")
+        - set(log.attributes["log.kind"], "keystone_middleware_lifesaver") where log.attributes["infra.container.component"] == "cc\\.keystone\\.middleware\\.lifesaver" and IsMatch(log.attributes["msg"], ".*has a remaining credit of.*")
+        - set(log.attributes["log.kind"], "keystone_exception_Unauthorized") where IsMatch(log.attributes["msg"], "^\\s*Authorization failed\\..*")
+        - merge_maps(log.attributes, ExtractGrokPatterns(log.attributes["msg"], "^\\s*cadf action for '%{NOTSPACE:http.request.method} %{URIPATH:http.url.path}' is '%{NOTSPACE:event.action}'", true), "upsert") where log.attributes["log.kind"] == "cadf_action"
+        - merge_maps(log.attributes, ExtractGrokPatterns(log.attributes["msg"], "^\\s*target type URI of requests '%{NOTSPACE:http.request.method} %{URIPATH:http.url.path}' is '%{NOTSPACE:target.type_uri}'", true), "upsert") where logattributes["log.kind"] == "target_type_uri"
+        - merge_maps(log.attributes, ExtractGrokPatterns(log.attributes["msg"], "^\\s*Authenticating %{NOTSPACE:user.name}@%{NOTSPACE:domain.name}\\.\\.", true), "upsert") where log.attributes["log.kind"] == "authentication"
+        - merge_maps(log.attributes, ExtractGrokPatterns(log.attributes["msg"], "^\\s*Could not find user:[\\s]+%{NOTSPACE:user.id}\\.", true), "upsert") where log.attributes["log.kind"] == "keystone_exception_UserNotFound"
+        - merge_maps(log.attributes, ExtractGrokPatterns(log.attributes["msg"], "(?:AC-)%{NOTSPACE:user.id}\\s+has a remaining credit of %{NUMBER} - request %{WORD:http.request.method} %{NOTSPACE:http.url.path} returned %{NUMBER:http.response.status_code:int}", true), "upsert") where log.attributes["msg"] != nil and log.attributes["log.kind"] == "keystone_middleware_lifesaver"
+        - merge_maps(log.attributes, ExtractGrokPatterns(log.attributes["msg"], "Authorization failed. The request you have made requires authentication. from %{IP:client.address}", true), "upsert") where log.attributes["log.kind"] == "keystone_exception_Unauthorized"
+        - delete_key(log.attributes, "log.kind")
+        - delete_key(log.attributes, "msg")
+
 filter/hermes_logstash:
   error_mode: ignore
   logs:
@@ -216,7 +261,7 @@ opensearch/swift_failover_b:
 {{- define "openstack.pipeline" }}
 logs/containerd:
   receivers: [filelog/containerd]
-  processors: [k8s_attributes,attributes/cluster,transform/ingress,transform/neutron_agent,transform/neutron_errors,transform/openstack_api,transform/non_openstack,transform/network_generic_ssh_exporter,transform/snmp_exporter,transform/elektra,transform/keystone_api,transform/kvm-ha-service,transform/coredns_api,transform/perses,filter/hermes_logstash,transform/swift_proxy,attributes/swift_proxy]
+  processors: [k8s_attributes,attributes/cluster,transform/ingress,transform/neutron_agent,transform/neutron_errors,transform/openstack_api,transform/non_openstack,transform/network_generic_ssh_exporter,transform/snmp_exporter,transform/elektra,transform/keystone_api,transform/keystone_api_json,transform/kvm-ha-service,transform/coredns_api,transform/perses,filter/hermes_logstash,transform/swift_proxy,attributes/swift_proxy]
   exporters: [routing]
 
 logs/route_swift:


### PR DESCRIPTION
# Fix keystone_api_json parsing for nested context fields and message extraction

## Problem

The `transform/keystone_api_json` processor was not correctly parsing `request_id`, `global_request_id`, and other context fields from JSON-formatted keystone logs in the qa-de-2 cluster. These fields exist in a nested `context` object within the JSON structure but were being accessed at the root level, resulting in null values.

## Changes

### 1. Fixed Nested Context Field Access

- Updated field access to use `log.cache["context"]["field_name"]` instead of `log.cache["field_name"]`
- Now correctly extracts:
  - `request_id` and `global_request_id`
  - User metadata (`user`, `user_domain_name`, `user_name`)
  - Project metadata (`project_id`, `project_name`, `project_domain`)

### 2. Added Message Pattern Extraction

Implemented additional field extraction from log messages, similar to the audit-logs configuration:

- CADF action events
- Target type URI information
- Authentication events
- Keystone exceptions (UserNotFound, Unauthorized)
- Middleware lifesaver credit tracking

### 3. log.kind for Performance 

- Added `log.kind` classification to identify log types before running expensive regex patterns
- Conditional pattern matching reduces regex evaluations from 7 per log to 1-2 per log
- Temporary `log.kind` field is cleaned up after processing

## Impact

- Aligns with audit-logs-otel transform/keystone-api pattern, making it reusable for qa-de-1 when JSON parsing is enabled there

