### PR TITLE
[barbican] Fix lunaclient crash loop and improve init logging

### DIFF
--- a/openstack/barbican/templates/api-deployment.yaml
+++ b/openstack/barbican/templates/api-deployment.yaml
@@ -163,12 +163,18 @@ spec:
         {{- end }}
         - name: lunaclient
           image: {{required ".Values.global.registry is missing" .Values.global.registry }}/loci-barbican:{{required "Values.hsm.luna.image is missing" .Values.hsm.luna.image }}
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           env:
             - name: ChrystokiConfigurationPath
               value: "/thales/safenet/lunaclient/config"
-          command: [ "/bin/bash", "-c", "--" ]
-          args: [ "while true; do sleep 30; done;" ]
+          command: [ "bash", "-lc" ]
+          args:
+            - |
+              set -ex
+              echo "$(date) [lunaclient] starting init..."
+              /scripts/barbican_lunaclient.sh
+              echo "$(date) [lunaclient] init complete."
+              exec sleep infinity
           {{- if .Values.hsm.resources.enabled }}
           resources:
             limits:
@@ -178,10 +184,6 @@ spec:
               cpu: {{ .Values.hsm.resources.requests.cpu | quote }}
               memory: {{ .Values.hsm.resources.requests.memory | quote }}
           {{- end }}
-          lifecycle:
-            postStart:
-              exec:
-                command: [ "/bin/bash", "/scripts/barbican_lunaclient.sh" ]
           volumeMounts:
             - name: hsm
               mountPath: /scripts/barbican_lunaclient.sh

--- a/openstack/barbican/templates/api-deployment.yaml
+++ b/openstack/barbican/templates/api-deployment.yaml
@@ -170,10 +170,8 @@ spec:
           command: [ "bash", "-lc" ]
           args:
             - |
-              set -ex
-              echo "$(date) [lunaclient] starting init..."
+              set -e
               /scripts/barbican_lunaclient.sh
-              echo "$(date) [lunaclient] init complete."
               exec sleep infinity
           {{- if .Values.hsm.resources.enabled }}
           resources:

--- a/openstack/barbican/templates/etc/_barbican_lunaclient.sh.tpl
+++ b/openstack/barbican/templates/etc/_barbican_lunaclient.sh.tpl
@@ -1,13 +1,17 @@
 #!/bin/bash
-set -ex
+set -e
+
+log() { echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') [lunaclient] $*"; }
 
 lunaclient ()
     {
+    log "starting init"
     mv /usr/safenet /thales
     NOW="$(date +%Y%m%d)"
     cd /thales/safenet/lunaclient/libs/64/
     rm -f libCryptoki2_64.so
     ln -s libCryptoki2.so libCryptoki2_64.so
+    log "configuring HSM client"
     /thales/safenet/lunaclient/bin/64/configurator setValue -s Chrystoki2 -e LibUNIX -v /thales/safenet/lunaclient/libs/64/libCryptoki2.so
     /thales/safenet/lunaclient/bin/64/configurator setValue -s Chrystoki2 -e LibUNIX64 -v /thales/safenet/lunaclient/libs/64/libCryptoki2_64.so
     /thales/safenet/lunaclient/bin/64/configurator setValue -s Misc -e ToolsDir -v /thales/safenet/lunaclient/bin/64/
@@ -37,31 +41,35 @@ lunaclient ()
     /thales/safenet/lunaclient/bin/64/configurator setValue -s "HAConfiguration" -e HAOnly -v {{ .Values.lunaclient.HAConfiguration.HAOnly }}
     /thales/safenet/lunaclient/bin/64/configurator setValue -s "HAConfiguration" -e haLogPath -v {{ .Values.lunaclient.HAConfiguration.haLogPath | include "resolve_secret" }}
     /thales/safenet/lunaclient/bin/64/configurator setValue -s "HAConfiguration" -e logLen -v {{ .Values.lunaclient.HAConfiguration.logLen }}
+    log "creating client certificate"
     /thales/safenet/lunaclient/bin/64/vtl createCert -n $HOSTNAME-$NOW
 
     #REGISTER HSM1
-    echo "Registering HSM01"
+    log "registering HSM01"
     /thales/safenet/lunaclient/bin/64/pscp -pw {{ .Values.lunaclient.conn.pwd | include "resolve_secret" }} /thales/safenet/lunaclient/config/certs/$HOSTNAME-$NOW.pem {{ .Values.lunaclient.conn.user | include "resolve_secret" }}@{{ .Values.lunaclient.conn.ip | include "resolve_secret" }}:.
     /thales/safenet/lunaclient/bin/64/pscp -pw {{ .Values.lunaclient.conn.pwd | include "resolve_secret" }} {{ .Values.lunaclient.conn.user | include "resolve_secret" }}@{{ .Values.lunaclient.conn.ip | include "resolve_secret" }}:server.pem /thales/safenet/lunaclient/config/certs/
     /thales/safenet/lunaclient/bin/64/vtl addserver -n {{ .Values.lunaclient.conn.ip | include "resolve_secret" }} -c  /thales/safenet/lunaclient/config/certs/server.pem
     echo "client register -c $HOSTNAME-$NOW" -h $HOSTNAME-$NOW > /thales/safenet/lunaclient/config/$HOSTNAME-$NOW.txt
     echo "client assignPartition -c $HOSTNAME-$NOW -p {{ .Values.lunaclient.conn.par | include "resolve_secret"  }}" >> /thales/safenet/lunaclient/config/$HOSTNAME-$NOW.txt
     echo "exit" >> /thales/safenet/lunaclient/config/$HOSTNAME-$NOW.txt
-    /thales/safenet/lunaclient/bin/64/plink {{ .Values.lunaclient.conn.ip | include "resolve_secret" }} -ssh -l {{ .Values.lunaclient.conn.user | include "resolve_secret" }} -pw {{ .Values.lunaclient.conn.pwd | include "resolve_secret" }} -v < /thales/safenet/lunaclient/config/$HOSTNAME-$NOW.txt
+    /thales/safenet/lunaclient/bin/64/plink {{ .Values.lunaclient.conn.ip | include "resolve_secret" }} -ssh -l {{ .Values.lunaclient.conn.user | include "resolve_secret" }} -pw {{ .Values.lunaclient.conn.pwd | include "resolve_secret" }} < /thales/safenet/lunaclient/config/$HOSTNAME-$NOW.txt
+    log "HSM01 registered"
     
     {{- if .Values.hsm.ha.enabled }}
     #REGISTER HSM2
-    echo "Registering HSM02"
+    log "registering HSM02"
     /thales/safenet/lunaclient/bin/64/pscp -pw {{ .Values.lunaclient.conn.pwd | include "resolve_secret" }} /thales/safenet/lunaclient/config/certs/$HOSTNAME-$NOW.pem {{ .Values.lunaclient.conn.user | include "resolve_secret" }}@{{ .Values.lunaclient.conn.ip02 | include "resolve_secret" }}:.
     /thales/safenet/lunaclient/bin/64/pscp -pw {{ .Values.lunaclient.conn.pwd | include "resolve_secret" }} {{ .Values.lunaclient.conn.user | include "resolve_secret" }}@{{ .Values.lunaclient.conn.ip02 | include "resolve_secret" }}:server.pem /thales/safenet/lunaclient/config/certs/
     /thales/safenet/lunaclient/bin/64/vtl addserver -n {{ .Values.lunaclient.conn.ip02 | include "resolve_secret" }} -c  /thales/safenet/lunaclient/config/certs/server.pem
     echo "client register -c $HOSTNAME-$NOW" -h $HOSTNAME-$NOW > /thales/safenet/lunaclient/config/$HOSTNAME-$NOW-02.txt
     echo "client assignPartition -c $HOSTNAME-$NOW -p {{ .Values.lunaclient.conn.par02 | include "resolve_secret" }}" >> /thales/safenet/lunaclient/config/$HOSTNAME-$NOW-02.txt
     echo "exit" >> /thales/safenet/lunaclient/config/$HOSTNAME-$NOW-02.txt
-    /thales/safenet/lunaclient/bin/64/plink {{ .Values.lunaclient.conn.ip02 | include "resolve_secret" }} -ssh -l {{ .Values.lunaclient.conn.user | include "resolve_secret" }} -pw {{ .Values.lunaclient.conn.pwd | include "resolve_secret" }} -v < /thales/safenet/lunaclient/config/$HOSTNAME-$NOW-02.txt
+    /thales/safenet/lunaclient/bin/64/plink {{ .Values.lunaclient.conn.ip02 | include "resolve_secret" }} -ssh -l {{ .Values.lunaclient.conn.user | include "resolve_secret" }} -pw {{ .Values.lunaclient.conn.pwd | include "resolve_secret" }} < /thales/safenet/lunaclient/config/$HOSTNAME-$NOW-02.txt
+    log "HSM02 registered"
     {{- end}}
 
     cp /thales/safenet/lunaclient/config/Chrystoki.conf /etc/Chrystoki.conf
+    log "init complete"
     }
 
 {{- if .Values.hsm.enabled }}


### PR DESCRIPTION
[barbican] Fix lunaclient crash loop and improve init logging

## Problem

Two barbican-api pods stuck in CrashLoopBackOff (4/5 containers) due to the lunaclient sidecar failing silently on every pod restart.

**Root cause 1 — silent postStart failure:**
barbican_lunaclient.sh ran in the container postStart lifecycle hook. When this hook fails, Kubernetes kills the container with no output in kubectl logs (postStart stdout/stderr only goes to the kubelet journal).

**Root cause 2 — imagePullPolicy: Always amplifies the damage:**
Every container restart forced a fresh pull from keppel. When keppel returned 503, the image pull failed on top of the script failure, keeping pods stuck in exponential backoff.

## Fix

**1. Move barbican_lunaclient.sh from postStart hook to main container command** — mirrors the existing utimaco container pattern. Script failures are now visible in kubectl logs and the Kubernetes restart policy applies cleanly.

**2. imagePullPolicy: Always to IfNotPresent** — the image tag is pinned and immutable; Always adds a hard registry dependency on every pod restart for no benefit.

**3. Improve init script logging** — replace set -ex with a structured log() helper (ISO8601 timestamps, [lunaclient] prefix), remove -v from plink calls to suppress verbose SSH handshake noise, and add progress markers at each init stage.

Before:
```
+ cp /thales/safenet/lunaclient/config/Chrystoki.conf /etc/Chrystoki.conf
Sent password
Access granted
Opening main session channel
Allocated pty
```

After:
```
2026-05-27T04:44:00Z [lunaclient] starting init
2026-05-27T04:44:00Z [lunaclient] configuring HSM client
2026-05-27T04:44:01Z [lunaclient] registering HSM01
2026-05-27T04:44:02Z [lunaclient] HSM01 registered
2026-05-27T04:44:02Z [lunaclient] init complete
```

## Test plan

- [x] Deploy to a region with hsm.enabled: true and verify lunaclient container starts and stays Running
- [x] Verify kubectl logs <pod> -c lunaclient shows structured init output
- [x] Simulate a lunaclient script failure and confirm the error is visible in container logs