### PR TITLE
[kmip] add seed, switch to service user, bump chart to 0.3.8

### DIFF
--- a/openstack/kmip/Chart.lock
+++ b/openstack/kmip/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 1.1.1
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.35.0
+  version: 0.36.0
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.35.0
@@ -17,5 +17,5 @@ dependencies:
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.5.2
-digest: sha256:d4fb243e863b7c6e698858a129b4a0d3e8097845c60e08504b26e3b1693a2c7d
-generated: "2026-04-21T17:43:20.747909+03:00"
+digest: sha256:aab72e2152a16e5f066d1b238368cc129d774c79b78c87313aba730418fc4bb4
+generated: "2026-05-25T14:46:51.805674+05:30"

--- a/openstack/kmip/Chart.yaml
+++ b/openstack/kmip/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Chart Version
-version: 0.3.7
+version: 0.3.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/openstack/kmip/ci/test-values.yaml
+++ b/openstack/kmip/ci/test-values.yaml
@@ -21,8 +21,6 @@ kmip:
     username: topSecret
     password: topSecret
     project_id: topSecret
-    appl_cred_name: topSecret
-    appl_cred_secret: topSecret
     region_name: topSecret
     project_domain_name: topSecret
     identity_api_version: topSecret

--- a/openstack/kmip/templates/deployment.yaml
+++ b/openstack/kmip/templates/deployment.yaml
@@ -139,18 +139,8 @@ spec:
                 secretKeyRef:
                   name: kmip-secrets
                   key: os_project_id
-            - name: OS_APPLICATION_CREDENTIAL_NAME
-              valueFrom:
-                secretKeyRef:
-                  name: kmip-secrets
-                  key: os_application_credential_name
-            - name: OS_APPLICATION_CREDENTIAL_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: kmip-secrets
-                  key: os_application_credential_secret
             - name: OS_AUTH_TYPE
-              value: "v3applicationcredential"
+              value: "v3password"
             - name: OS_REGION_NAME
               valueFrom:
                 secretKeyRef:

--- a/openstack/kmip/templates/secrets.yaml
+++ b/openstack/kmip/templates/secrets.yaml
@@ -17,8 +17,6 @@ data:
   os_username: {{ .Values.kmip.openstack_env.username | b64enc | quote }}
   os_password: {{ .Values.kmip.openstack_env.password | b64enc | quote }}
   os_project_id: {{ .Values.kmip.openstack_env.project_id | b64enc | quote }}
-  os_application_credential_name: {{ .Values.kmip.openstack_env.appl_cred_name | b64enc | quote }}
-  os_application_credential_secret: {{ .Values.kmip.openstack_env.appl_cred_secret | b64enc | quote }}
   os_region_name: {{ .Values.kmip.openstack_env.region_name | b64enc | quote }}
   os_project_domain_name: {{ .Values.kmip.openstack_env.project_domain_name | b64enc | quote }}
   os_identity_api_version: {{ .Values.kmip.openstack_env.identity_api_version | b64enc | quote }}

--- a/openstack/kmip/templates/seed.yaml
+++ b/openstack/kmip/templates/seed.yaml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: "openstack.stable.sap.cc/v1"
+kind: "OpenstackSeed"
+metadata:
+  name: kmip-seed
+  labels:
+    {{- include "kmip.labels" . | nindent 4 }}
+spec:
+  requires:
+  - monsoon3/keystone-seed
+  - monsoon3/domain-default-seed
+
+  roles:
+  - name: keymanager_admin
+    description: KMIP key manager administration
+
+  services:
+  - name: kmip-barbican
+    type: key-management
+    description: KMIP Key Management Service
+    endpoints:
+    - interface: public
+      region: '{{ .Values.global.region }}'
+      url: 'https://kmip.cc.{{ .Values.global.region }}.{{ .Values.global.tld }}'
+
+  domains:
+  - name: Default
+    users:
+    - name: kmip
+      description: 'KMIP Service User'
+      password: '{{ .Values.kmip.openstack_env.password | include "resolve_secret" }}'
+      role_assignments:
+      - project: service
+        role: service
+      - project: service
+        role: keymanager_admin


### PR DESCRIPTION
## Summary

- Add `OpenstackSeed` for `kmip` service user in `Default` domain; assigns `service` and `keymanager_admin` roles in the `service` project; registers `kmip-barbican` `key-management` endpoint in Keystone; defines `keymanager_admin` role
- Remove application credential env vars (`OS_APPLICATION_CREDENTIAL_NAME/SECRET`) from deployment and secrets; switch `OS_AUTH_TYPE` to `v3password`
- Bump chart version to `0.3.8` and run dep update

## Related PRs
- PyKMIP: https://github.com/sapcc/PyKMIP/compare/kmip-switch-to-service-user
- secrets: https://github.wdf.sap.corp/cc/secrets/pull/20561