### PR TITLE
upgrade prometheus-operator CRDs to v0.91.0

### DIFF
--- a/system/prometheus-crds/Chart.yaml
+++ b/system/prometheus-crds/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: prometheus-crds
 description: A Helm chart containing Prometheus CRDs.
 type: application
-version: 8.0.0
+version: 9.0.0

--- a/system/prometheus-crds/crds/alertmanagerconfigs.monitoring.coreos.com.yaml
+++ b/system/prometheus-crds/crds/alertmanagerconfigs.monitoring.coreos.com.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
-    operator.prometheus.io/version: 0.88.0
+    controller-gen.kubebuilder.io/version: v0.20.1
+    operator.prometheus.io/version: 0.91.0
   name: alertmanagerconfigs.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -939,6 +939,7 @@ spec:
                               description: |-
                                 authIdentity defines the identity to use for SMTP authentication.
                                 This is typically used with PLAIN authentication mechanism.
+                              minLength: 1
                               type: string
                             authPassword:
                               description: |-
@@ -995,11 +996,21 @@ spec:
                               description: |-
                                 authUsername defines the username to use for SMTP authentication.
                                 This is used for SMTP AUTH when the server requires authentication.
+                              minLength: 1
                               type: string
+                            forceImplicitTLS:
+                              description: |-
+                                forceImplicitTLS defines whether to force use of implicit TLS (direct TLS connection) for better security.
+                                true: force use of implicit TLS (direct TLS connection on any port)
+                                false: force disable implicit TLS (use explicit TLS/STARTTLS if required)
+                                nil (default): auto-detect based on port (465=implicit, other=explicit) for backward compatibility
+                                It requires Alertmanager >= v0.31.0.
+                              type: boolean
                             from:
                               description: |-
                                 from defines the sender address for email notifications.
                                 This appears as the "From" field in the email header.
+                              minLength: 1
                               type: string
                             headers:
                               description: |-
@@ -1029,6 +1040,7 @@ spec:
                               description: |-
                                 hello defines the hostname to identify to the SMTP server.
                                 This is used in the SMTP HELO/EHLO command during the connection handshake.
+                              minLength: 1
                               type: string
                             html:
                               description: |-
@@ -1047,12 +1059,30 @@ spec:
                               description: |-
                                 smarthost defines the SMTP host and port through which emails are sent.
                                 Format should be "hostname:port", e.g. "smtp.example.com:587".
+                              minLength: 1
                               type: string
                             text:
                               description: |-
                                 text defines the plain text body of the email notification.
                                 This provides a fallback for email clients that don't support HTML.
+                              minLength: 1
                               type: string
+                            threading:
+                              description: |-
+                                threading defines the threading configuration for email receiver.
+                                It requires Alertmanager >= v0.30.0.
+                              properties:
+                                threadByDate:
+                                  description: |-
+                                    threadByDate defines what granularity of current date to thread by. Accepted values: Daily, None.
+                                    (None means group by alert group key, no date).
+                                  enum:
+                                    - Daily
+                                    - None
+                                  type: string
+                              required:
+                                - threadByDate
+                              type: object
                             tlsConfig:
                               description: |-
                                 tlsConfig defines the TLS configuration for SMTP connections.
@@ -1209,6 +1239,7 @@ spec:
                               description: |-
                                 to defines the email address to send notifications to.
                                 This is the recipient address for alert notifications.
+                              minLength: 1
                               type: string
                           type: object
                         type: array
@@ -2611,6 +2642,7 @@ spec:
                               description: |-
                                 actions defines a comma separated list of actions that will be available for the alert.
                                 These appear as action buttons in the OpsGenie interface.
+                              minLength: 1
                               type: string
                             apiKey:
                               description: |-
@@ -2647,6 +2679,7 @@ spec:
                               description: |-
                                 description defines the detailed description of the incident.
                                 This provides additional context beyond the message field.
+                              minLength: 1
                               type: string
                             details:
                               description: |-
@@ -2676,6 +2709,7 @@ spec:
                               description: |-
                                 entity defines an optional field that can be used to specify which domain alert is related to.
                                 This helps group related alerts together in OpsGenie.
+                              minLength: 1
                               type: string
                             httpConfig:
                               description: httpConfig defines the HTTP client configuration for OpsGenie API requests.
@@ -3318,16 +3352,19 @@ spec:
                               description: |-
                                 message defines the alert text limited to 130 characters.
                                 This appears as the main alert title in OpsGenie.
+                              minLength: 1
                               type: string
                             note:
                               description: |-
                                 note defines an additional alert note.
                                 This provides supplementary information about the alert.
+                              minLength: 1
                               type: string
                             priority:
                               description: |-
                                 priority defines the priority level of alert.
                                 Possible values are P1, P2, P3, P4, and P5, where P1 is highest priority.
+                              minLength: 1
                               type: string
                             responders:
                               description: |-
@@ -3342,11 +3379,13 @@ spec:
                                     description: |-
                                       id defines the unique identifier of the responder.
                                       This corresponds to the responder's ID within OpsGenie.
+                                    minLength: 1
                                     type: string
                                   name:
                                     description: |-
                                       name defines the display name of the responder.
                                       This is used when the responder is identified by name rather than ID.
+                                    minLength: 1
                                     type: string
                                   type:
                                     description: |-
@@ -3365,6 +3404,7 @@ spec:
                                     description: |-
                                       username defines the username of the responder.
                                       This is typically used for user-type responders when identifying by username.
+                                    minLength: 1
                                     type: string
                                 required:
                                   - type
@@ -3378,11 +3418,13 @@ spec:
                               description: |-
                                 source defines the backlink to the sender of the notification.
                                 This helps identify where the alert originated from.
+                              minLength: 1
                               type: string
                             tags:
                               description: |-
                                 tags defines a comma separated list of tags attached to the notifications.
                                 These help categorize and filter alerts within OpsGenie.
+                              minLength: 1
                               type: string
                             updateAlerts:
                               description: |-
@@ -3409,7 +3451,6 @@ spec:
                               type: string
                             clientURL:
                               description: clientURL defines the backlink to the sender of notification.
-                              pattern: ^https?://.+$
                               type: string
                             component:
                               description: component defines the part or component of the affected system that is broken.
@@ -4093,7 +4134,6 @@ spec:
                                     type: string
                                   href:
                                     description: href defines the optional URL; makes the image a clickable link.
-                                    pattern: ^https?://.+$
                                     type: string
                                   src:
                                     description: src of the image being attached to the incident
@@ -4113,7 +4153,6 @@ spec:
                                     type: string
                                   href:
                                     description: href defines the URL of the link to be attached
-                                    pattern: ^https?://.+$
                                     type: string
                                 type: object
                               type: array
@@ -4940,7 +4979,6 @@ spec:
                               description: |-
                                 url defines a supplementary URL shown alongside the message.
                                 This creates a clickable link within the Pushover notification.
-                              pattern: ^https?://.+$
                               type: string
                             urlTitle:
                               description: |-
@@ -5016,7 +5054,6 @@ spec:
                                     description: |-
                                       url defines the URL the button links to when clicked.
                                       This creates a clickable button that opens the specified URL.
-                                    pattern: ^https?://.+$
                                     type: string
                                 type: object
                               minItems: 1
@@ -5715,13 +5752,11 @@ spec:
                               description: |-
                                 iconURL defines the icon URL for the message avatar.
                                 This displays a custom image as the message sender's avatar.
-                              pattern: ^https?://.+$
                               type: string
                             imageURL:
                               description: |-
                                 imageURL defines the image URL to display within the message.
                                 This embeds an image directly in the message attachment.
-                              pattern: ^https?://.+$
                               type: string
                             linkNames:
                               description: |-
@@ -5746,7 +5781,6 @@ spec:
                               description: |-
                                 thumbURL defines the thumbnail URL for the message.
                                 This displays a small thumbnail image alongside the message content.
-                              pattern: ^https?://.+$
                               type: string
                             title:
                               description: |-
@@ -5764,6 +5798,8 @@ spec:
                               description: |-
                                 token defines the sender token for RocketChat authentication.
                                 This is the personal access token or bot token used to authenticate API requests.
+                                The secret needs to be in the same namespace as the AlertmanagerConfig
+                                object and accessible by the Prometheus Operator.
                               properties:
                                 key:
                                   description: The key of the secret to select from.  Must be a valid secret key.
@@ -5788,6 +5824,8 @@ spec:
                               description: |-
                                 tokenID defines the sender token ID for RocketChat authentication.
                                 This is the user ID associated with the token used for API requests.
+                                The secret needs to be in the same namespace as the AlertmanagerConfig
+                                object and accessible by the Prometheus Operator.
                               properties:
                                 key:
                                   description: The key of the secret to select from.  Must be a valid secret key.
@@ -5890,7 +5928,6 @@ spec:
                                     description: |-
                                       url defines the URL to open when the action is triggered.
                                       Only applicable for button-type actions. When set, clicking the button opens this URL.
-                                    pattern: ^https?://.+$
                                     type: string
                                   value:
                                     description: |-
@@ -6629,17 +6666,22 @@ spec:
                               type: string
                             iconURL:
                               description: iconURL defines the URL to an image to use as the bot's avatar.
-                              pattern: ^https?://.+$
                               type: string
                             imageURL:
                               description: imageURL defines the URL to an image file that will be displayed inside the message attachment.
-                              pattern: ^https?://.+$
                               type: string
                             linkNames:
                               description: |-
                                 linkNames enables automatic linking of channel names and usernames in the message.
                                 When true, @channel and @username will be converted to clickable links.
                               type: boolean
+                            messageText:
+                              description: |-
+                                messageText defines text content of the Slack message.
+                                If set, this is sent as the top-level 'text' field in the Slack payload.
+                                It requires Alertmanager >= v0.31.0.
+                              minLength: 1
+                              type: string
                             mrkdwnIn:
                               description: |-
                                 mrkdwnIn defines which fields should be parsed as Slack markdown.
@@ -6670,7 +6712,6 @@ spec:
                               description: |-
                                 thumbURL defines the URL to an image file that will be displayed as a thumbnail
                                 on the right side of the message attachment.
-                              pattern: ^https?://.+$
                               type: string
                             timeout:
                               description: |-
@@ -6685,7 +6726,6 @@ spec:
                               type: string
                             titleLink:
                               description: titleLink defines the URL that the title will link to when clicked.
-                              pattern: ^https?://.+$
                               type: string
                             username:
                               description: username defines the slack bot user name.
@@ -7354,11 +7394,13 @@ spec:
                               description: |-
                                 message defines the message content of the SNS notification.
                                 This is the actual notification text that will be sent to subscribers.
+                              minLength: 1
                               type: string
                             phoneNumber:
                               description: |-
                                 phoneNumber defines the phone number if message is delivered via SMS in E.164 format.
                                 If you don't specify this value, you must specify a value for the TopicARN or TargetARN.
+                              minLength: 1
                               type: string
                             sendResolved:
                               description: sendResolved defines whether or not to notify about resolved alerts.
@@ -7392,6 +7434,12 @@ spec:
                                     - key
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                externalId:
+                                  description: |-
+                                    externalId defines the external ID used when assuming an AWS role. Can only be used with roleArn.
+                                    It requires Prometheus >= v3.11.0 or Alertmanager >= v0.33.0. Currently not supported by Thanos.
+                                  minLength: 1
+                                  type: string
                                 profile:
                                   description: profile defines the named AWS profile used to authenticate.
                                   type: string
@@ -7431,20 +7479,26 @@ spec:
                                     It requires Prometheus >= v2.54.0.
                                   type: boolean
                               type: object
+                              x-kubernetes-validations:
+                                - message: externalId can only be used when roleArn is specified
+                                  rule: '!has(self.externalId) || has(self.roleArn)'
                             subject:
                               description: |-
                                 subject defines the subject line when the message is delivered to email endpoints.
                                 This field is only used when sending to email subscribers of an SNS topic.
+                              minLength: 1
                               type: string
                             targetARN:
                               description: |-
                                 targetARN defines the mobile platform endpoint ARN if message is delivered via mobile notifications.
                                 If you don't specify this value, you must specify a value for the TopicARN or PhoneNumber.
+                              minLength: 1
                               type: string
                             topicARN:
                               description: |-
                                 topicARN defines the SNS topic ARN, e.g. arn:aws:sns:us-east-2:698519295917:My-Topic.
                                 If you don't specify this value, you must specify a value for the PhoneNumber or TargetARN.
+                              minLength: 1
                               type: string
                           type: object
                         type: array
@@ -10238,7 +10292,6 @@ spec:
                               description: |-
                                 url defines the URL to send HTTP POST requests to.
                                 urlSecret takes precedence over url. One of urlSecret and url should be defined.
-                              pattern: ^https?://.+$
                               type: string
                             urlSecret:
                               description: |-
@@ -10280,6 +10333,7 @@ spec:
                               description: |-
                                 agentID defines the application agent ID within WeChat Work.
                                 This identifies which WeChat Work application will send the notifications.
+                              minLength: 1
                               type: string
                             apiSecret:
                               description: |-
@@ -10316,6 +10370,7 @@ spec:
                               description: |-
                                 corpID defines the corp id for authentication.
                                 This is the unique identifier for your WeChat Work organization.
+                              minLength: 1
                               type: string
                             httpConfig:
                               description: httpConfig defines the HTTP client configuration for WeChat API requests.
@@ -10958,11 +11013,13 @@ spec:
                               description: |-
                                 message defines the API request data as defined by the WeChat API.
                                 This contains the actual notification content to be sent.
+                              minLength: 1
                               type: string
                             messageType:
                               description: |-
                                 messageType defines the type of message to send.
                                 Valid values include "text", "markdown", and other WeChat Work supported message types.
+                              minLength: 1
                               type: string
                             sendResolved:
                               description: sendResolved defines whether or not to notify about resolved alerts.
@@ -10971,16 +11028,19 @@ spec:
                               description: |-
                                 toParty defines the target department(s) to receive the notification.
                                 Can be a single department ID or multiple department IDs separated by '|'.
+                              minLength: 1
                               type: string
                             toTag:
                               description: |-
                                 toTag defines the target tag(s) to receive the notification.
                                 Can be a single tag ID or multiple tag IDs separated by '|'.
+                              minLength: 1
                               type: string
                             toUser:
                               description: |-
                                 toUser defines the target user(s) to receive the notification.
                                 Can be a single user ID or multiple user IDs separated by '|'.
+                              minLength: 1
                               type: string
                           type: object
                         type: array
@@ -11022,14 +11082,17 @@ spec:
                     groupInterval:
                       description: |-
                         groupInterval defines how long to wait before sending an updated notification.
-                        Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$`
+                        Must be greater than 0.
                         Example: "5m"
+                      minLength: 1
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     groupWait:
                       description: |-
                         groupWait defines how long to wait before sending the initial notification.
-                        Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$`
                         Example: "30s"
+                      minLength: 1
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     matchers:
                       description: |-
@@ -11086,8 +11149,10 @@ spec:
                     repeatInterval:
                       description: |-
                         repeatInterval defines how long to wait before repeating the last notification.
-                        Must match the regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$`
+                        Must be greater than 0.
                         Example: "4h"
+                      minLength: 1
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     routes:
                       description: routes defines the child routes.

--- a/system/prometheus-crds/crds/alertmanagers.monitoring.coreos.com.yaml
+++ b/system/prometheus-crds/crds/alertmanagers.monitoring.coreos.com.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
-    operator.prometheus.io/version: 0.88.0
+    controller-gen.kubebuilder.io/version: v0.20.1
+    operator.prometheus.io/version: 0.91.0
   name: alertmanagers.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -1750,6 +1750,35 @@ spec:
                               pattern: ^(http|https)://.+$
                               type: string
                           type: object
+                        mattermost:
+                          description: mattermost defines the default Mattermost Config
+                          properties:
+                            webhookURL:
+                              description: |-
+                                webhookURL defines the default Mattermost Webhook URL.
+
+                                It requires Alertmanager >= v0.32.0.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
                         opsGenieApiKey:
                           description: opsGenieApiKey defines the default OpsGenie API Key.
                           properties:
@@ -1941,6 +1970,14 @@ spec:
                             authUsername:
                               description: authUsername represents SMTP Auth using CRAM-MD5, LOGIN and PLAIN. If empty, Alertmanager doesn't authenticate to the SMTP server.
                               type: string
+                            forceImplicitTLS:
+                              description: |-
+                                forceImplicitTLS defines whether to force use of implicit TLS (direct TLS connection) for better security.
+                                true: force use of implicit TLS (direct TLS connection on any port)
+                                false: force disable implicit TLS (use explicit TLS/STARTTLS if required)
+                                nil (default): auto-detect based on port (465=implicit, other=explicit) for backward compatibility
+                                It requires Alertmanager >= v0.31.0.
+                              type: boolean
                             from:
                               description: from defines the default SMTP From header field.
                               type: string
@@ -2685,14 +2722,20 @@ spec:
                   type: string
                 containers:
                   description: |-
-                    containers allows injecting additional containers. This is meant to
-                    allow adding an authentication proxy to an Alertmanager pod.
-                    Containers described here modify an operator generated container if they
-                    share the same name and modifications are done via a strategic merge
-                    patch. The current container names are: `alertmanager` and
-                    `config-reloader`. Overriding containers is entirely outside the scope
-                    of what the maintainers will support and by doing so, you accept that
-                    this behaviour may break at any time without notice.
+                    containers allows injecting additional containers or modifying operator
+                    generated containers. This can be used to allow adding an authentication
+                    proxy to the Pods or to change the behavior of an operator generated
+                    container. Containers described here modify an operator generated
+                    container if they share the same name and modifications are done via a
+                    strategic merge patch.
+
+                    The names of containers managed by the operator are:
+                    * `alertmanager`
+                    * `config-reloader`
+                    * `thanos-sidecar`
+
+                    Overriding containers which are managed by the operator require careful
+                    testing, especially when upgrading to a new version of the operator.
                   items:
                     description: A single application container that you want to run within a pod.
                     properties:
@@ -3521,7 +3564,9 @@ spec:
                             type: integer
                         type: object
                       resizePolicy:
-                        description: Resources resize policy for the container.
+                        description: |-
+                          Resources resize policy for the container.
+                          This field cannot be set on ephemeral containers.
                         items:
                           description: ContainerResizePolicy represents resource resize policy for the container.
                           properties:
@@ -4254,6 +4299,17 @@ spec:
                   x-kubernetes-list-map-keys:
                     - ip
                   x-kubernetes-list-type: map
+                hostNetwork:
+                  description: |-
+                    hostNetwork controls whether the pod may use the node network namespace.
+
+                    Make sure to understand the security implications if you want to enable
+                    it (https://kubernetes.io/docs/concepts/configuration/overview/).
+
+                    When hostNetwork is enabled, this will set the DNS policy to
+                    `ClusterFirstWithHostNet` automatically (unless `.spec.dnsPolicy` is set
+                    to a different value).
+                  type: boolean
                 hostUsers:
                   description: |-
                     hostUsers supports the user space in Kubernetes.
@@ -4304,15 +4360,21 @@ spec:
                   type: array
                 initContainers:
                   description: |-
-                    initContainers allows adding initContainers to the pod definition. Those can be used to e.g.
-                    fetch secrets for injection into the Alertmanager configuration from external sources. Any
-                    errors during the execution of an initContainer will lead to a restart of the Pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
-                    InitContainers described here modify an operator
-                    generated init containers if they share the same name and modifications are
-                    done via a strategic merge patch. The current init container name is:
-                    `init-config-reloader`. Overriding init containers is entirely outside the
-                    scope of what the maintainers will support and by doing so, you accept that
-                    this behaviour may break at any time without notice.
+                    initContainers allows injecting initContainers to the Pod definition. Those
+                    can be used to e.g.  fetch secrets for injection into the Prometheus
+                    configuration from external sources. Any errors during the execution of
+                    an initContainer will lead to a restart of the Pod. More info:
+                    https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+                    InitContainers described here modify an operator generated init
+                    containers if they share the same name and modifications are done via a
+                    strategic merge patch.
+
+                    The names of init container name managed by the operator are:
+                    * `init-config-reloader`.
+
+                    Overriding init containers which are managed by the operator require
+                    careful testing, especially when upgrading to a new version of the
+                    operator.
                   items:
                     description: A single application container that you want to run within a pod.
                     properties:
@@ -5141,7 +5203,9 @@ spec:
                             type: integer
                         type: object
                       resizePolicy:
-                        description: Resources resize policy for the container.
+                        description: |-
+                          Resources resize policy for the container.
+                          This field cannot be set on ephemeral containers.
                         items:
                           description: ContainerResizePolicy represents resource resize policy for the container.
                           properties:
@@ -6008,6 +6072,10 @@ spec:
                     and the actual ExternalURL is still true, but the server serves requests
                     under a different route prefix. For example for use with `kubectl proxy`.
                   type: string
+                schedulerName:
+                  description: schedulerName defines the scheduler to use for Pod scheduling. If not specified, the default scheduler is used.
+                  minLength: 1
+                  type: string
                 secrets:
                   description: |-
                     secrets is a list of Secrets in the same namespace as the Alertmanager
@@ -6433,7 +6501,7 @@ spec:
                                 resources:
                                   description: |-
                                     resources represents the minimum resources the volume should have.
-                                    If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                    Users are allowed to specify resource requirements
                                     that are lower than previous value but must still be higher than capacity recorded in the
                                     status field of the claim.
                                     More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -6682,7 +6750,7 @@ spec:
                             resources:
                               description: |-
                                 resources represents the minimum resources the volume should have.
-                                If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                Users are allowed to specify resource requirements
                                 that are lower than previous value but must still be higher than capacity recorded in the
                                 status field of the claim.
                                 More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -6801,7 +6869,7 @@ spec:
                                   that it does not recognizes, then it should ignore that update and let other controllers
                                   handle it.
                                 type: string
-                              description: "allocatedResourceStatuses stores status of resource being resized for the given PVC.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\nClaimResourceStatus can be in any of following states:\n\t- ControllerResizeInProgress:\n\t\tState set when resize controller starts resizing the volume in control-plane.\n\t- ControllerResizeFailed:\n\t\tState set when resize has failed in resize controller with a terminal error.\n\t- NodeResizePending:\n\t\tState set when resize controller has finished resizing the volume but further resizing of\n\t\tvolume is needed on the node.\n\t- NodeResizeInProgress:\n\t\tState set when kubelet starts resizing the volume.\n\t- NodeResizeFailed:\n\t\tState set when resizing has failed in kubelet with a terminal error. Transient errors don't set\n\t\tNodeResizeFailed.\nFor example: if expanding a PVC for more capacity - this field can be one of the following states:\n\t- pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeFailed\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizePending\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeFailed\"\nWhen this field is not set, it means that no resize operation is in progress for the given PVC.\n\nA controller that receives PVC update with previously unknown resourceName or ClaimResourceStatus\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC.\n\nThis is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                              description: "allocatedResourceStatuses stores status of resource being resized for the given PVC.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\nClaimResourceStatus can be in any of following states:\n\t- ControllerResizeInProgress:\n\t\tState set when resize controller starts resizing the volume in control-plane.\n\t- ControllerResizeFailed:\n\t\tState set when resize has failed in resize controller with a terminal error.\n\t- NodeResizePending:\n\t\tState set when resize controller has finished resizing the volume but further resizing of\n\t\tvolume is needed on the node.\n\t- NodeResizeInProgress:\n\t\tState set when kubelet starts resizing the volume.\n\t- NodeResizeFailed:\n\t\tState set when resizing has failed in kubelet with a terminal error. Transient errors don't set\n\t\tNodeResizeFailed.\nFor example: if expanding a PVC for more capacity - this field can be one of the following states:\n\t- pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeFailed\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizePending\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeFailed\"\nWhen this field is not set, it means that no resize operation is in progress for the given PVC.\n\nA controller that receives PVC update with previously unknown resourceName or ClaimResourceStatus\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC."
                               type: object
                               x-kubernetes-map-type: granular
                             allocatedResources:
@@ -6811,7 +6879,7 @@ spec:
                                   - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: "allocatedResources tracks the resources allocated to a PVC including its capacity.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\nCapacity reported here may be larger than the actual capacity when a volume expansion operation\nis requested.\nFor storage quota, the larger value from allocatedResources and PVC.spec.resources is used.\nIf allocatedResources is not set, PVC.spec.resources alone is used for quota calculation.\nIf a volume expansion capacity request is lowered, allocatedResources is only\nlowered if there are no expansion operations in progress and if the actual volume capacity\nis equal or lower than the requested capacity.\n\nA controller that receives PVC update with previously unknown resourceName\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC.\n\nThis is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                              description: "allocatedResources tracks the resources allocated to a PVC including its capacity.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\nCapacity reported here may be larger than the actual capacity when a volume expansion operation\nis requested.\nFor storage quota, the larger value from allocatedResources and PVC.spec.resources is used.\nIf allocatedResources is not set, PVC.spec.resources alone is used for quota calculation.\nIf a volume expansion capacity request is lowered, allocatedResources is only\nlowered if there are no expansion operations in progress and if the actual volume capacity\nis equal or lower than the requested capacity.\n\nA controller that receives PVC update with previously unknown resourceName\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC."
                               type: object
                             capacity:
                               additionalProperties:
@@ -6926,9 +6994,10 @@ spec:
                       operator:
                         description: |-
                           Operator represents a key's relationship to the value.
-                          Valid operators are Exists and Equal. Defaults to Equal.
+                          Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                           Exists is equivalent to wildcard for value, so that a pod can
                           tolerate all taints of a particular category.
+                          Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                         type: string
                       tolerationSeconds:
                         description: |-
@@ -7786,7 +7855,7 @@ spec:
                                   resources:
                                     description: |-
                                       resources represents the minimum resources the volume should have.
-                                      If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                      Users are allowed to specify resource requirements
                                       that are lower than previous value but must still be higher than capacity recorded in the
                                       status field of the claim.
                                       More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -8621,6 +8690,24 @@ spec:
                                     signerName:
                                       description: Kubelet's generated CSRs will be addressed to this signer.
                                       type: string
+                                    userAnnotations:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        userAnnotations allow pod authors to pass additional information to
+                                        the signer implementation.  Kubernetes does not restrict or validate this
+                                        metadata in any way.
+
+                                        These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                        the PodCertificateRequest objects that Kubelet creates.
+
+                                        Entries are subject to the same validation as object metadata annotations,
+                                        with the addition that all keys must be domain-prefixed. No restrictions
+                                        are placed on values, except an overall size limitation on the entire field.
+
+                                        Signers should document the keys and values they support. Signers should
+                                        deny requests that contain keys they do not recognize.
+                                      type: object
                                   required:
                                     - keyType
                                     - signerName

--- a/system/prometheus-crds/crds/podmonitors.monitoring.coreos.com.yaml
+++ b/system/prometheus-crds/crds/podmonitors.monitoring.coreos.com.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
-    operator.prometheus.io/version: 0.88.0
+    controller-gen.kubebuilder.io/version: v0.20.1
+    operator.prometheus.io/version: 0.91.0
   name: podmonitors.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/system/prometheus-crds/crds/probes.monitoring.coreos.com.yaml
+++ b/system/prometheus-crds/crds/probes.monitoring.coreos.com.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
-    operator.prometheus.io/version: 0.88.0
+    controller-gen.kubebuilder.io/version: v0.20.1
+    operator.prometheus.io/version: 0.91.0
   name: probes.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/system/prometheus-crds/crds/prometheusagents.monitoring.coreos.com.yaml
+++ b/system/prometheus-crds/crds/prometheusagents.monitoring.coreos.com.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
-    operator.prometheus.io/version: 0.88.0
+    controller-gen.kubebuilder.io/version: v0.20.1
+    operator.prometheus.io/version: 0.91.0
   name: prometheusagents.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -1405,9 +1405,8 @@ spec:
                     * `config-reloader`
                     * `thanos-sidecar`
 
-                    Overriding containers is entirely outside the scope of what the
-                    maintainers will support and by doing so, you accept that this behaviour
-                    may break at any time without notice.
+                    Overriding containers which are managed by the operator require careful
+                    testing, especially when upgrading to a new version of the operator.
                   items:
                     description: A single application container that you want to run within a pod.
                     properties:
@@ -2236,7 +2235,9 @@ spec:
                             type: integer
                         type: object
                       resizePolicy:
-                        description: Resources resize policy for the container.
+                        description: |-
+                          Resources resize policy for the container.
+                          This field cannot be set on ephemeral containers.
                         items:
                           description: ContainerResizePolicy represents resource resize policy for the container.
                           properties:
@@ -3249,7 +3250,7 @@ spec:
                 initContainers:
                   description: |-
                     initContainers allows injecting initContainers to the Pod definition. Those
-                    can be used to e.g.  fetch secrets for injection into the Prometheus
+                    can be used to e.g. fetch secrets for injection into the Prometheus
                     configuration from external sources. Any errors during the execution of
                     an initContainer will lead to a restart of the Pod. More info:
                     https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
@@ -3260,9 +3261,9 @@ spec:
                     The names of init container name managed by the operator are:
                     * `init-config-reloader`.
 
-                    Overriding init containers is entirely outside the scope of what the
-                    maintainers will support and by doing so, you accept that this behaviour
-                    may break at any time without notice.
+                    Overriding init containers which are managed by the operator require
+                    careful testing, especially when upgrading to a new version of the
+                    operator.
                   items:
                     description: A single application container that you want to run within a pod.
                     properties:
@@ -4091,7 +4092,9 @@ spec:
                             type: integer
                         type: object
                       resizePolicy:
-                        description: Resources resize policy for the container.
+                        description: |-
+                          Resources resize policy for the container.
+                          This field cannot be set on ephemeral containers.
                         items:
                           description: ContainerResizePolicy represents resource resize policy for the container.
                           properties:
@@ -5980,6 +5983,12 @@ spec:
                               - key
                             type: object
                             x-kubernetes-map-type: atomic
+                          externalId:
+                            description: |-
+                              externalId defines the external ID used when assuming an AWS role. Can only be used with roleArn.
+                              It requires Prometheus >= v3.11.0 or Alertmanager >= v0.33.0. Currently not supported by Thanos.
+                            minLength: 1
+                            type: string
                           profile:
                             description: profile defines the named AWS profile used to authenticate.
                             type: string
@@ -6019,6 +6028,9 @@ spec:
                               It requires Prometheus >= v2.54.0.
                             type: boolean
                         type: object
+                        x-kubernetes-validations:
+                          - message: externalId can only be used when roleArn is specified
+                            rule: '!has(self.externalId) || has(self.roleArn)'
                       tlsConfig:
                         description: tlsConfig to use for the URL.
                         properties:
@@ -6179,8 +6191,11 @@ spec:
                             type: string
                         type: object
                       url:
-                        description: url defines the URL of the endpoint to send samples to.
-                        minLength: 1
+                        description: |-
+                          url defines the URL of the endpoint to send samples to.
+
+                          It must use the HTTP or HTTPS scheme.
+                        pattern: ^(http|https)://.+$
                         type: string
                       writeRelabelConfigs:
                         description: writeRelabelConfigs defines the list of remote write relabel configurations.
@@ -6390,6 +6405,10 @@ spec:
                     If you want to enforce a maximum limit for all scrape objects, refer to enforcedSampleLimit.
                   format: int64
                   type: integer
+                schedulerName:
+                  description: schedulerName defines the scheduler to use for Pod scheduling. If not specified, the default scheduler is used.
+                  minLength: 1
+                  type: string
                 scrapeClasses:
                   description: |-
                     scrapeClasses defines the list of scrape classes to expose to scraping objects such as
@@ -6847,7 +6866,8 @@ spec:
                     matches all namespaces. A null label selector matches the current
                     namespace only.
 
-                    Note that the ScrapeConfig custom resource definition is currently at Alpha level.
+                    Note that the ScrapeConfig custom resource definition is currently at Alpha level
+                    and will be graduated to Beta in a future release.
                   properties:
                     matchExpressions:
                       description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -6904,7 +6924,8 @@ spec:
                     of the custom resource definition. It is recommended to use
                     `spec.additionalScrapeConfigs` instead.
 
-                    Note that the ScrapeConfig custom resource definition is currently at Alpha level.
+                    Note that the ScrapeConfig custom resource definition is currently at Alpha level
+                    and will be graduated to Beta in a future release.
                   properties:
                     matchExpressions:
                       description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -7373,6 +7394,54 @@ spec:
                     See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#stable-network-id for more details.
                   minLength: 1
                   type: string
+                shardingStrategy:
+                  description: |-
+                    shardingStrategy defines the sharding strategy for distributing scraped targets across Prometheus shards.
+
+                    When not defined, the operator defaults to the 'Address' mode which distributes
+                    targets based on a hash of the target address.
+                  properties:
+                    mode:
+                      description: |-
+                        mode defines the sharding mode. Can be 'Address' or 'Topology'.
+
+                        'Address' is the default mode and distributes targets across shards
+                        based on a hash of the target address.
+
+                        'Topology' enables zone-aware sharding where each shard is assigned to a
+                        specific topology zone and only scrapes targets in that zone.
+                        (Alpha) Using the 'Topology' mode requires the `PrometheusTopologySharding`
+                        feature gate to be enabled.
+                      enum:
+                        - Address
+                        - Topology
+                      type: string
+                    topology:
+                      description: |-
+                        topology defines the configuration for topology-aware sharding.
+                        This field is only valid when mode is set to 'Topology'.
+                      properties:
+                        externalLabelName:
+                          description: |-
+                            externalLabelName defines the name of the Prometheus external label used
+                            to communicate the topology zone assigned to the Prometheus instance.
+                            If not defined, it defaults to "zone".
+                            If set to the empty string, no external label is added to the Prometheus configuration.
+                          type: string
+                        values:
+                          description: |-
+                            values defines the list of topology values (e.g. zone names) to be used
+                            for sharding. The configured number of shards must be greater than or
+                            equal to the number of values.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                  type: object
+                  x-kubernetes-validations:
+                    - message: topology can only be defined when mode is set to 'Topology'
+                      rule: '!has(self.topology) || (has(self.mode) && self.mode == ''Topology'')'
                 shards:
                   description: |-
                     shards defines the number of shards to distribute the scraped targets onto.
@@ -7567,7 +7636,7 @@ spec:
                                 resources:
                                   description: |-
                                     resources represents the minimum resources the volume should have.
-                                    If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                    Users are allowed to specify resource requirements
                                     that are lower than previous value but must still be higher than capacity recorded in the
                                     status field of the claim.
                                     More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -7816,7 +7885,7 @@ spec:
                             resources:
                               description: |-
                                 resources represents the minimum resources the volume should have.
-                                If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                Users are allowed to specify resource requirements
                                 that are lower than previous value but must still be higher than capacity recorded in the
                                 status field of the claim.
                                 More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -7935,7 +8004,7 @@ spec:
                                   that it does not recognizes, then it should ignore that update and let other controllers
                                   handle it.
                                 type: string
-                              description: "allocatedResourceStatuses stores status of resource being resized for the given PVC.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\nClaimResourceStatus can be in any of following states:\n\t- ControllerResizeInProgress:\n\t\tState set when resize controller starts resizing the volume in control-plane.\n\t- ControllerResizeFailed:\n\t\tState set when resize has failed in resize controller with a terminal error.\n\t- NodeResizePending:\n\t\tState set when resize controller has finished resizing the volume but further resizing of\n\t\tvolume is needed on the node.\n\t- NodeResizeInProgress:\n\t\tState set when kubelet starts resizing the volume.\n\t- NodeResizeFailed:\n\t\tState set when resizing has failed in kubelet with a terminal error. Transient errors don't set\n\t\tNodeResizeFailed.\nFor example: if expanding a PVC for more capacity - this field can be one of the following states:\n\t- pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeFailed\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizePending\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeFailed\"\nWhen this field is not set, it means that no resize operation is in progress for the given PVC.\n\nA controller that receives PVC update with previously unknown resourceName or ClaimResourceStatus\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC.\n\nThis is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                              description: "allocatedResourceStatuses stores status of resource being resized for the given PVC.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\nClaimResourceStatus can be in any of following states:\n\t- ControllerResizeInProgress:\n\t\tState set when resize controller starts resizing the volume in control-plane.\n\t- ControllerResizeFailed:\n\t\tState set when resize has failed in resize controller with a terminal error.\n\t- NodeResizePending:\n\t\tState set when resize controller has finished resizing the volume but further resizing of\n\t\tvolume is needed on the node.\n\t- NodeResizeInProgress:\n\t\tState set when kubelet starts resizing the volume.\n\t- NodeResizeFailed:\n\t\tState set when resizing has failed in kubelet with a terminal error. Transient errors don't set\n\t\tNodeResizeFailed.\nFor example: if expanding a PVC for more capacity - this field can be one of the following states:\n\t- pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeFailed\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizePending\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeFailed\"\nWhen this field is not set, it means that no resize operation is in progress for the given PVC.\n\nA controller that receives PVC update with previously unknown resourceName or ClaimResourceStatus\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC."
                               type: object
                               x-kubernetes-map-type: granular
                             allocatedResources:
@@ -7945,7 +8014,7 @@ spec:
                                   - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: "allocatedResources tracks the resources allocated to a PVC including its capacity.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\nCapacity reported here may be larger than the actual capacity when a volume expansion operation\nis requested.\nFor storage quota, the larger value from allocatedResources and PVC.spec.resources is used.\nIf allocatedResources is not set, PVC.spec.resources alone is used for quota calculation.\nIf a volume expansion capacity request is lowered, allocatedResources is only\nlowered if there are no expansion operations in progress and if the actual volume capacity\nis equal or lower than the requested capacity.\n\nA controller that receives PVC update with previously unknown resourceName\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC.\n\nThis is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                              description: "allocatedResources tracks the resources allocated to a PVC including its capacity.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\nCapacity reported here may be larger than the actual capacity when a volume expansion operation\nis requested.\nFor storage quota, the larger value from allocatedResources and PVC.spec.resources is used.\nIf allocatedResources is not set, PVC.spec.resources alone is used for quota calculation.\nIf a volume expansion capacity request is lowered, allocatedResources is only\nlowered if there are no expansion operations in progress and if the actual volume capacity\nis equal or lower than the requested capacity.\n\nA controller that receives PVC update with previously unknown resourceName\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC."
                               type: object
                             capacity:
                               additionalProperties:
@@ -8063,9 +8132,10 @@ spec:
                       operator:
                         description: |-
                           Operator represents a key's relationship to the value.
-                          Valid operators are Exists and Equal. Defaults to Equal.
+                          Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                           Exists is equivalent to wildcard for value, so that a pod can
                           tolerate all taints of a particular category.
+                          Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                         type: string
                       tolerationSeconds:
                         description: |-
@@ -9161,7 +9231,7 @@ spec:
                                   resources:
                                     description: |-
                                       resources represents the minimum resources the volume should have.
-                                      If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                      Users are allowed to specify resource requirements
                                       that are lower than previous value but must still be higher than capacity recorded in the
                                       status field of the claim.
                                       More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -9996,6 +10066,24 @@ spec:
                                     signerName:
                                       description: Kubelet's generated CSRs will be addressed to this signer.
                                       type: string
+                                    userAnnotations:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        userAnnotations allow pod authors to pass additional information to
+                                        the signer implementation.  Kubernetes does not restrict or validate this
+                                        metadata in any way.
+
+                                        These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                        the PodCertificateRequest objects that Kubelet creates.
+
+                                        Entries are subject to the same validation as object metadata annotations,
+                                        with the addition that all keys must be domain-prefixed. No restrictions
+                                        are placed on values, except an overall size limitation on the entire field.
+
+                                        Signers should document the keys and values they support. Signers should
+                                        deny requests that contain keys they do not recognize.
+                                      type: object
                                   required:
                                     - keyType
                                     - signerName
@@ -10701,6 +10789,10 @@ spec:
                   rule: '!(has(self.mode) && self.mode == ''DaemonSet'' && has(self.serviceMonitorNamespaceSelector))'
                 - message: additionalScrapeConfigs cannot be set when mode is DaemonSet
                   rule: '!(has(self.mode) && self.mode == ''DaemonSet'' && has(self.additionalScrapeConfigs))'
+                - message: shardingStrategy cannot be set when mode is DaemonSet
+                  rule: '!(has(self.mode) && self.mode == ''DaemonSet'' && has(self.shardingStrategy))'
+                - message: shards must be greater than or equal to the number of topology values when sharding strategy mode is Topology
+                  rule: '!has(self.shardingStrategy) || !has(self.shardingStrategy.mode) || self.shardingStrategy.mode != ''Topology'' || !has(self.shardingStrategy.topology) || !has(self.shardingStrategy.topology.values) || self.shardingStrategy.topology.values.size() == 0 || (has(self.shards) ? self.shards : 1) >= self.shardingStrategy.topology.values.size()'
             status:
               description: |-
                 status defines the most recent observed status of the Prometheus cluster. Read-only.

--- a/system/prometheus-crds/crds/prometheuses.monitoring.coreos.com.yaml
+++ b/system/prometheus-crds/crds/prometheuses.monitoring.coreos.com.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
-    operator.prometheus.io/version: 0.88.0
+    controller-gen.kubebuilder.io/version: v0.20.1
+    operator.prometheus.io/version: 0.91.0
   name: prometheuses.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -1492,6 +1492,12 @@ spec:
                                   - key
                                 type: object
                                 x-kubernetes-map-type: atomic
+                              externalId:
+                                description: |-
+                                  externalId defines the external ID used when assuming an AWS role. Can only be used with roleArn.
+                                  It requires Prometheus >= v3.11.0 or Alertmanager >= v0.33.0. Currently not supported by Thanos.
+                                minLength: 1
+                                type: string
                               profile:
                                 description: profile defines the named AWS profile used to authenticate.
                                 type: string
@@ -1531,6 +1537,9 @@ spec:
                                   It requires Prometheus >= v2.54.0.
                                 type: boolean
                             type: object
+                            x-kubernetes-validations:
+                              - message: externalId can only be used when roleArn is specified
+                                rule: '!has(self.externalId) || has(self.roleArn)'
                           timeout:
                             description: timeout defines a per-target Alertmanager timeout when pushing alerts.
                             pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
@@ -2109,9 +2118,8 @@ spec:
                     * `config-reloader`
                     * `thanos-sidecar`
 
-                    Overriding containers is entirely outside the scope of what the
-                    maintainers will support and by doing so, you accept that this behaviour
-                    may break at any time without notice.
+                    Overriding containers which are managed by the operator require careful
+                    testing, especially when upgrading to a new version of the operator.
                   items:
                     description: A single application container that you want to run within a pod.
                     properties:
@@ -2940,7 +2948,9 @@ spec:
                             type: integer
                         type: object
                       resizePolicy:
-                        description: Resources resize policy for the container.
+                        description: |-
+                          Resources resize policy for the container.
+                          This field cannot be set on ephemeral containers.
                         items:
                           description: ContainerResizePolicy represents resource resize policy for the container.
                           properties:
@@ -3995,7 +4005,7 @@ spec:
                 initContainers:
                   description: |-
                     initContainers allows injecting initContainers to the Pod definition. Those
-                    can be used to e.g.  fetch secrets for injection into the Prometheus
+                    can be used to e.g. fetch secrets for injection into the Prometheus
                     configuration from external sources. Any errors during the execution of
                     an initContainer will lead to a restart of the Pod. More info:
                     https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
@@ -4006,9 +4016,9 @@ spec:
                     The names of init container name managed by the operator are:
                     * `init-config-reloader`.
 
-                    Overriding init containers is entirely outside the scope of what the
-                    maintainers will support and by doing so, you accept that this behaviour
-                    may break at any time without notice.
+                    Overriding init containers which are managed by the operator require
+                    careful testing, especially when upgrading to a new version of the
+                    operator.
                   items:
                     description: A single application container that you want to run within a pod.
                     properties:
@@ -4837,7 +4847,9 @@ spec:
                             type: integer
                         type: object
                       resizePolicy:
-                        description: Resources resize policy for the container.
+                        description: |-
+                          Resources resize policy for the container.
+                          This field cannot be set on ephemeral containers.
                         items:
                           description: ContainerResizePolicy represents resource resize policy for the container.
                           properties:
@@ -7458,6 +7470,12 @@ spec:
                               - key
                             type: object
                             x-kubernetes-map-type: atomic
+                          externalId:
+                            description: |-
+                              externalId defines the external ID used when assuming an AWS role. Can only be used with roleArn.
+                              It requires Prometheus >= v3.11.0 or Alertmanager >= v0.33.0. Currently not supported by Thanos.
+                            minLength: 1
+                            type: string
                           profile:
                             description: profile defines the named AWS profile used to authenticate.
                             type: string
@@ -7497,6 +7515,9 @@ spec:
                               It requires Prometheus >= v2.54.0.
                             type: boolean
                         type: object
+                        x-kubernetes-validations:
+                          - message: externalId can only be used when roleArn is specified
+                            rule: '!has(self.externalId) || has(self.roleArn)'
                       tlsConfig:
                         description: tlsConfig to use for the URL.
                         properties:
@@ -7657,8 +7678,11 @@ spec:
                             type: string
                         type: object
                       url:
-                        description: url defines the URL of the endpoint to send samples to.
-                        minLength: 1
+                        description: |-
+                          url defines the URL of the endpoint to send samples to.
+
+                          It must use the HTTP or HTTPS scheme.
+                        pattern: ^(http|https)://.+$
                         type: string
                       writeRelabelConfigs:
                         description: writeRelabelConfigs defines the list of remote write relabel configurations.
@@ -8007,6 +8031,10 @@ spec:
                     If you want to enforce a maximum limit for all scrape objects, refer to enforcedSampleLimit.
                   format: int64
                   type: integer
+                schedulerName:
+                  description: schedulerName defines the scheduler to use for Pod scheduling. If not specified, the default scheduler is used.
+                  minLength: 1
+                  type: string
                 scrapeClasses:
                   description: |-
                     scrapeClasses defines the list of scrape classes to expose to scraping objects such as
@@ -8464,7 +8492,8 @@ spec:
                     matches all namespaces. A null label selector matches the current
                     namespace only.
 
-                    Note that the ScrapeConfig custom resource definition is currently at Alpha level.
+                    Note that the ScrapeConfig custom resource definition is currently at Alpha level
+                    and will be graduated to Beta in a future release.
                   properties:
                     matchExpressions:
                       description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -8521,7 +8550,8 @@ spec:
                     of the custom resource definition. It is recommended to use
                     `spec.additionalScrapeConfigs` instead.
 
-                    Note that the ScrapeConfig custom resource definition is currently at Alpha level.
+                    Note that the ScrapeConfig custom resource definition is currently at Alpha level
+                    and will be graduated to Beta in a future release.
                   properties:
                     matchExpressions:
                       description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -9004,11 +9034,17 @@ spec:
                   properties:
                     retain:
                       description: |-
-                        retain defines the config for retention when the retention policy is set to `Retain`.
-                        This field is ineffective as of now.
+                        retain defines the config for retention when the retention policy is set
+                        to `Retain`.
+
+                        If not defined, the operator will use the retention duration configured
+                        for the Prometheus data. If the resource uses size-based retention, the
+                        shard(s) are kept forever (unless manually deleted).
                       properties:
                         retentionPeriod:
-                          description: retentionPeriod defines the retentionPeriod for shard retention policy.
+                          description: |-
+                            retentionPeriod defines how long the scaled-down shard(s) need to be
+                            kept before being deleted.
                           pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                           type: string
                       required:
@@ -9026,6 +9062,54 @@ spec:
                         - Delete
                       type: string
                   type: object
+                shardingStrategy:
+                  description: |-
+                    shardingStrategy defines the sharding strategy for distributing scraped targets across Prometheus shards.
+
+                    When not defined, the operator defaults to the 'Address' mode which distributes
+                    targets based on a hash of the target address.
+                  properties:
+                    mode:
+                      description: |-
+                        mode defines the sharding mode. Can be 'Address' or 'Topology'.
+
+                        'Address' is the default mode and distributes targets across shards
+                        based on a hash of the target address.
+
+                        'Topology' enables zone-aware sharding where each shard is assigned to a
+                        specific topology zone and only scrapes targets in that zone.
+                        (Alpha) Using the 'Topology' mode requires the `PrometheusTopologySharding`
+                        feature gate to be enabled.
+                      enum:
+                        - Address
+                        - Topology
+                      type: string
+                    topology:
+                      description: |-
+                        topology defines the configuration for topology-aware sharding.
+                        This field is only valid when mode is set to 'Topology'.
+                      properties:
+                        externalLabelName:
+                          description: |-
+                            externalLabelName defines the name of the Prometheus external label used
+                            to communicate the topology zone assigned to the Prometheus instance.
+                            If not defined, it defaults to "zone".
+                            If set to the empty string, no external label is added to the Prometheus configuration.
+                          type: string
+                        values:
+                          description: |-
+                            values defines the list of topology values (e.g. zone names) to be used
+                            for sharding. The configured number of shards must be greater than or
+                            equal to the number of values.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                  type: object
+                  x-kubernetes-validations:
+                    - message: topology can only be defined when mode is set to 'Topology'
+                      rule: '!has(self.topology) || (has(self.mode) && self.mode == ''Topology'')'
                 shards:
                   description: |-
                     shards defines the number of shards to distribute the scraped targets onto.
@@ -9220,7 +9304,7 @@ spec:
                                 resources:
                                   description: |-
                                     resources represents the minimum resources the volume should have.
-                                    If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                    Users are allowed to specify resource requirements
                                     that are lower than previous value but must still be higher than capacity recorded in the
                                     status field of the claim.
                                     More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -9469,7 +9553,7 @@ spec:
                             resources:
                               description: |-
                                 resources represents the minimum resources the volume should have.
-                                If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                Users are allowed to specify resource requirements
                                 that are lower than previous value but must still be higher than capacity recorded in the
                                 status field of the claim.
                                 More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -9588,7 +9672,7 @@ spec:
                                   that it does not recognizes, then it should ignore that update and let other controllers
                                   handle it.
                                 type: string
-                              description: "allocatedResourceStatuses stores status of resource being resized for the given PVC.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\nClaimResourceStatus can be in any of following states:\n\t- ControllerResizeInProgress:\n\t\tState set when resize controller starts resizing the volume in control-plane.\n\t- ControllerResizeFailed:\n\t\tState set when resize has failed in resize controller with a terminal error.\n\t- NodeResizePending:\n\t\tState set when resize controller has finished resizing the volume but further resizing of\n\t\tvolume is needed on the node.\n\t- NodeResizeInProgress:\n\t\tState set when kubelet starts resizing the volume.\n\t- NodeResizeFailed:\n\t\tState set when resizing has failed in kubelet with a terminal error. Transient errors don't set\n\t\tNodeResizeFailed.\nFor example: if expanding a PVC for more capacity - this field can be one of the following states:\n\t- pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeFailed\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizePending\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeFailed\"\nWhen this field is not set, it means that no resize operation is in progress for the given PVC.\n\nA controller that receives PVC update with previously unknown resourceName or ClaimResourceStatus\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC.\n\nThis is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                              description: "allocatedResourceStatuses stores status of resource being resized for the given PVC.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\nClaimResourceStatus can be in any of following states:\n\t- ControllerResizeInProgress:\n\t\tState set when resize controller starts resizing the volume in control-plane.\n\t- ControllerResizeFailed:\n\t\tState set when resize has failed in resize controller with a terminal error.\n\t- NodeResizePending:\n\t\tState set when resize controller has finished resizing the volume but further resizing of\n\t\tvolume is needed on the node.\n\t- NodeResizeInProgress:\n\t\tState set when kubelet starts resizing the volume.\n\t- NodeResizeFailed:\n\t\tState set when resizing has failed in kubelet with a terminal error. Transient errors don't set\n\t\tNodeResizeFailed.\nFor example: if expanding a PVC for more capacity - this field can be one of the following states:\n\t- pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeFailed\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizePending\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeFailed\"\nWhen this field is not set, it means that no resize operation is in progress for the given PVC.\n\nA controller that receives PVC update with previously unknown resourceName or ClaimResourceStatus\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC."
                               type: object
                               x-kubernetes-map-type: granular
                             allocatedResources:
@@ -9598,7 +9682,7 @@ spec:
                                   - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: "allocatedResources tracks the resources allocated to a PVC including its capacity.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\nCapacity reported here may be larger than the actual capacity when a volume expansion operation\nis requested.\nFor storage quota, the larger value from allocatedResources and PVC.spec.resources is used.\nIf allocatedResources is not set, PVC.spec.resources alone is used for quota calculation.\nIf a volume expansion capacity request is lowered, allocatedResources is only\nlowered if there are no expansion operations in progress and if the actual volume capacity\nis equal or lower than the requested capacity.\n\nA controller that receives PVC update with previously unknown resourceName\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC.\n\nThis is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                              description: "allocatedResources tracks the resources allocated to a PVC including its capacity.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\nCapacity reported here may be larger than the actual capacity when a volume expansion operation\nis requested.\nFor storage quota, the larger value from allocatedResources and PVC.spec.resources is used.\nIf allocatedResources is not set, PVC.spec.resources alone is used for quota calculation.\nIf a volume expansion capacity request is lowered, allocatedResources is only\nlowered if there are no expansion operations in progress and if the actual volume capacity\nis equal or lower than the requested capacity.\n\nA controller that receives PVC update with previously unknown resourceName\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC."
                               type: object
                             capacity:
                               additionalProperties:
@@ -9759,7 +9843,7 @@ spec:
                       description: |-
                         grpcServerTlsConfig defines the TLS parameters for the gRPC server providing the StoreAPI.
 
-                        Note: Currently only the `caFile`, `certFile`, and `keyFile` fields are supported.
+                        Note: Currently only the `minVersion`, `caFile`, `certFile`, `keyFile`, `cipherSuites` and `curves` fields are supported.
                       properties:
                         ca:
                           description: ca defines the Certificate authority used when verifying server certificates.
@@ -9863,6 +9947,38 @@ spec:
                         certFile:
                           description: certFile defines the path to the client cert file in the Prometheus container for the targets.
                           type: string
+                        cipherSuites:
+                          description: |-
+                            cipherSuites defines the list of supported cipher suites for TLS
+                            versions up to TLS 1.2.
+
+                            If not defined, the Go default cipher suites are used.
+                            Available cipher suites are documented in the Go documentation:
+                            https://golang.org/pkg/crypto/tls/#pkg-constants
+
+                            It requires Thanos >= v0.42.0. Note that the operator doesn't verify if
+                            the Thanos version supports the provided values.
+                          items:
+                            type: string
+                          minItems: 1
+                          type: array
+                          x-kubernetes-list-type: set
+                        curves:
+                          description: |-
+                            curves defines the list of preferred elliptic curves for
+                            TLS handshakes.
+
+                            If not defined, the Go default curves are used.
+                            Available curves are documented in the Go documentation:
+                            https://golang.org/pkg/crypto/tls/#CurveID
+
+                            It requires Thanos >= v0.42.0. Note that the operator doesn't verify if
+                            the Thanos version supports the provided values.
+                          items:
+                            type: string
+                          minItems: 1
+                          type: array
+                          x-kubernetes-list-type: set
                         insecureSkipVerify:
                           description: insecureSkipVerify defines how to disable target certificate validation.
                           type: boolean
@@ -10206,9 +10322,10 @@ spec:
                       operator:
                         description: |-
                           Operator represents a key's relationship to the value.
-                          Valid operators are Exists and Equal. Defaults to Equal.
+                          Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                           Exists is equivalent to wildcard for value, so that a pod can
                           tolerate all taints of a particular category.
+                          Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                         type: string
                       tolerationSeconds:
                         description: |-
@@ -11304,7 +11421,7 @@ spec:
                                   resources:
                                     description: |-
                                       resources represents the minimum resources the volume should have.
-                                      If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                      Users are allowed to specify resource requirements
                                       that are lower than previous value but must still be higher than capacity recorded in the
                                       status field of the claim.
                                       More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -12139,6 +12256,24 @@ spec:
                                     signerName:
                                       description: Kubelet's generated CSRs will be addressed to this signer.
                                       type: string
+                                    userAnnotations:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        userAnnotations allow pod authors to pass additional information to
+                                        the signer implementation.  Kubernetes does not restrict or validate this
+                                        metadata in any way.
+
+                                        These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                        the PodCertificateRequest objects that Kubelet creates.
+
+                                        Entries are subject to the same validation as object metadata annotations,
+                                        with the addition that all keys must be domain-prefixed. No restrictions
+                                        are placed on values, except an overall size limitation on the entire field.
+
+                                        Signers should document the keys and values they support. Signers should
+                                        deny requests that contain keys they do not recognize.
+                                      type: object
                                   required:
                                     - keyType
                                     - signerName
@@ -12821,6 +12956,9 @@ spec:
                       type: object
                   type: object
               type: object
+              x-kubernetes-validations:
+                - message: shards must be greater than or equal to the number of topology values when sharding strategy mode is Topology
+                  rule: '!has(self.shardingStrategy) || !has(self.shardingStrategy.mode) || self.shardingStrategy.mode != ''Topology'' || !has(self.shardingStrategy.topology) || !has(self.shardingStrategy.topology.values) || self.shardingStrategy.topology.values.size() == 0 || (has(self.shards) ? self.shards : 1) >= self.shardingStrategy.topology.values.size()'
             status:
               description: |-
                 status defines the most recent observed status of the Prometheus cluster. Read-only.

--- a/system/prometheus-crds/crds/prometheusrules.monitoring.coreos.com.yaml
+++ b/system/prometheus-crds/crds/prometheusrules.monitoring.coreos.com.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
-    operator.prometheus.io/version: 0.88.0
+    controller-gen.kubebuilder.io/version: v0.20.1
+    operator.prometheus.io/version: 0.91.0
   name: prometheusrules.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/system/prometheus-crds/crds/scrapeconfigs.monitoring.coreos.com.yaml
+++ b/system/prometheus-crds/crds/scrapeconfigs.monitoring.coreos.com.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
-    operator.prometheus.io/version: 0.88.0
+    controller-gen.kubebuilder.io/version: v0.20.1
+    operator.prometheus.io/version: 0.91.0
   name: scrapeconfigs.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -97,6 +97,7 @@ spec:
                           - OAuth
                           - ManagedIdentity
                           - SDK
+                          - WorkloadIdentity
                         type: string
                       authorization:
                         description: |-
@@ -604,7 +605,7 @@ spec:
                         minLength: 1
                         type: string
                       tlsConfig:
-                        description: tlsConfig defies the TLS configuration applying to the target HTTP endpoint.
+                        description: tlsConfig defines the TLS configuration applying to the target HTTP endpoint.
                         properties:
                           ca:
                             description: ca defines the Certificate authority used when verifying server certificates.
@@ -809,6 +810,15 @@ spec:
                       type: object
                       x-kubernetes-map-type: atomic
                   type: object
+                bodySizeLimit:
+                  description: |-
+                    bodySizeLimit defines a per-scrape limit on the size of the uncompressed
+                    response body that will be accepted by Prometheus. Targets responding with
+                    a body larger than this many bytes will cause the scrape to fail.
+
+                    It requires Prometheus >= v2.28.0.
+                  pattern: (^0|([0-9]*[.])?[0-9]+((K|M|G|T|E|P)i?)?B)$
+                  type: string
                 consulSDConfigs:
                   description: consulSDConfigs defines a list of Consul service discovery configurations.
                   items:
@@ -922,13 +932,20 @@ spec:
                       filter:
                         description: |-
                           filter defines the filter expression used to filter the catalog results.
-                          See https://www.consul.io/api-docs/catalog#list-services
+                          See https://developer.hashicorp.com/consul/api-docs/catalog#filtering
                           It requires Prometheus >= 3.0.0.
                         minLength: 1
                         type: string
                       followRedirects:
                         description: followRedirects defines whether HTTP requests follow HTTP 3xx redirects.
                         type: boolean
+                      healthFilter:
+                        description: |-
+                          healthFilter defines the filter expression used to filter the health results.
+                          See https://developer.hashicorp.com/consul/api-docs/health#filtering
+                          It requires Prometheus >= 3.11.2.
+                        minLength: 1
+                        type: string
                       namespace:
                         description: |-
                           namespace are only supported in Consul Enterprise.
@@ -1536,7 +1553,7 @@ spec:
                     properties:
                       authorization:
                         description: |-
-                          authorization defines the  header configuration to authenticate against the DigitalOcean API.
+                          authorization defines the header configuration to authenticate against the DigitalOcean API.
                           Cannot be set at the same time as `oauth2`.
                         properties:
                           credentials:
@@ -1939,7 +1956,7 @@ spec:
                         pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                         type: string
                       tlsConfig:
-                        description: tlsConfig defines the TLS configuration to connect to the Consul API.
+                        description: tlsConfig defines the TLS configuration to connect to the DigitalOcean API.
                         properties:
                           ca:
                             description: ca defines the Certificate authority used when verifying server certificates.
@@ -2148,7 +2165,7 @@ spec:
                     properties:
                       authorization:
                         description: |-
-                          authorization defines the  header configuration to authenticate against the DigitalOcean API.
+                          authorization defines the header configuration to authenticate against the Docker daemon.
                           Cannot be set at the same time as `oauth2`.
                         properties:
                           credentials:
@@ -2244,6 +2261,7 @@ spec:
                           properties:
                             name:
                               description: name of the Filter.
+                              minLength: 1
                               type: string
                             values:
                               description: values defines values to filter on.
@@ -2265,8 +2283,9 @@ spec:
                         description: followRedirects defines whether HTTP requests follow HTTP 3xx redirects.
                         type: boolean
                       host:
-                        description: host defines the address of the docker daemon
+                        description: host defines the address of the docker daemon.
                         minLength: 1
+                        pattern: ^[a-zA-Z][a-zA-Z0-9+.-]*://.+$
                         type: string
                       hostNetworkingHost:
                         description: hostNetworkingHost defines the host to use if the container is in host networking mode.
@@ -2641,7 +2660,7 @@ spec:
                         pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                         type: string
                       tlsConfig:
-                        description: tlsConfig defines the TLS configuration to connect to the Consul API.
+                        description: tlsConfig defines the TLS configuration to connect to the Docker daemon.
                         properties:
                           ca:
                             description: ca defines the Certificate authority used when verifying server certificates.
@@ -2803,7 +2822,7 @@ spec:
                     properties:
                       authorization:
                         description: |-
-                          authorization defines the  header configuration to authenticate against the DigitalOcean API.
+                          authorization defines the header configuration to authenticate against the Docker Swarm API.
                           Cannot be set at the same time as `oauth2`.
                         properties:
                           credentials:
@@ -2905,6 +2924,7 @@ spec:
                           properties:
                             name:
                               description: name of the Filter.
+                              minLength: 1
                               type: string
                             values:
                               description: values defines values to filter on.
@@ -3303,7 +3323,7 @@ spec:
                           - Nodes
                         type: string
                       tlsConfig:
-                        description: tlsConfig defines the TLS configuration to connect to the Consul API.
+                        description: tlsConfig defines the TLS configuration to connect to the Docker Swarm daemon.
                         properties:
                           ca:
                             description: ca defines the Certificate authority used when verifying server certificates.
@@ -3508,6 +3528,7 @@ spec:
                           properties:
                             name:
                               description: name of the Filter.
+                              minLength: 1
                               type: string
                             values:
                               description: values defines values to filter on.
@@ -3626,7 +3647,7 @@ spec:
                         x-kubernetes-map-type: atomic
                       tlsConfig:
                         description: |-
-                          tlsConfig defines the TLS configuration to connect to the Consul API.
+                          tlsConfig defines the TLS configuration to connect to the EC2 API.
                           It requires Prometheus >= v2.41.0
                         properties:
                           ca:
@@ -3799,7 +3820,7 @@ spec:
                     properties:
                       authorization:
                         description: |-
-                          authorization defines the  header configuration to authenticate against the DigitalOcean API.
+                          authorization defines the header configuration to authenticate against the Eureka server.
                           Cannot be set at the same time as `oauth2`.
                         properties:
                           credentials:
@@ -4249,11 +4270,10 @@ spec:
                         type: string
                       server:
                         description: server defines the URL to connect to the Eureka server.
-                        minLength: 1
-                        pattern: ^http(s)?://.+$
+                        pattern: ^https?://.+$
                         type: string
                       tlsConfig:
-                        description: tlsConfig defines the TLS configuration to connect to the Consul API.
+                        description: tlsConfig defines the TLS configuration to connect to the Eureka server.
                         properties:
                           ca:
                             description: ca defines the Certificate authority used when verifying server certificates.
@@ -4514,7 +4534,7 @@ spec:
                     properties:
                       authorization:
                         description: |-
-                          authorization defines the  header configuration to authenticate against the DigitalOcean API.
+                          authorization defines the header configuration to authenticate against the Hetzner API.
                           Cannot be set at the same time as `oauth2`.
                         properties:
                           credentials:
@@ -4983,7 +5003,7 @@ spec:
                           - Robot
                         type: string
                       tlsConfig:
-                        description: tlsConfig defines the TLS configuration to connect to the Consul API.
+                        description: tlsConfig defines the TLS configuration to connect to the Hetzner API.
                         properties:
                           ca:
                             description: ca defines the Certificate authority used when verifying server certificates.
@@ -5760,8 +5780,7 @@ spec:
                         type: object
                       url:
                         description: url defines the URL from which the targets are fetched.
-                        minLength: 1
-                        pattern: ^http(s)?://.+$
+                        pattern: ^https?://.+$
                         type: string
                     required:
                       - url
@@ -5776,7 +5795,7 @@ spec:
                     properties:
                       authorization:
                         description: |-
-                          authorization defines the  header configuration to authenticate against the IONOS.
+                          authorization defines the header configuration to authenticate against the IONOS API.
                           Cannot be set at the same time as `oauth2`.
                         properties:
                           credentials:
@@ -6183,7 +6202,7 @@ spec:
                         pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                         type: string
                       tlsConfig:
-                        description: tlsConfig defines the TLS configuration to connect to the Consul API.
+                        description: tlsConfig defines the TLS configuration to connect to the IONOS API.
                         properties:
                           ca:
                             description: ca defines the Certificate authority used when verifying server certificates.
@@ -7060,7 +7079,7 @@ spec:
                     properties:
                       authorization:
                         description: |-
-                          authorization defines the  header configuration to authenticate against the DigitalOcean API.
+                          authorization defines the header configuration to authenticate against the Kuma control plane.
                           Cannot be set at the same time as `oauth2`.
                         properties:
                           credentials:
@@ -7523,7 +7542,7 @@ spec:
                         pattern: ^https?://.+$
                         type: string
                       tlsConfig:
-                        description: tlsConfig defines the TLS configuration to connect to the Consul API.
+                        description: tlsConfig defines the TLS configuration to connect to the Kuma control plane.
                         properties:
                           ca:
                             description: ca defines the Certificate authority used when verifying server certificates.
@@ -7725,7 +7744,7 @@ spec:
                         x-kubernetes-map-type: atomic
                       authorization:
                         description: |-
-                          authorization defines the  header configuration to authenticate against the DigitalOcean API.
+                          authorization defines the header configuration to authenticate against the Lightsail API.
                           Cannot be set at the same time as `oauth2`.
                         properties:
                           credentials:
@@ -8193,6 +8212,7 @@ spec:
                         type: string
                       roleARN:
                         description: roleARN defines the AWS Role ARN, an alternative to using AWS API keys.
+                        minLength: 1
                         type: string
                       secretKey:
                         description: secretKey defines the AWS API secret.
@@ -8217,7 +8237,7 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       tlsConfig:
-                        description: tlsConfig defines the TLS configuration to connect to the Consul API.
+                        description: tlsConfig defines the TLS configuration to connect to the Lightsail API.
                         properties:
                           ca:
                             description: ca defines the Certificate authority used when verifying server certificates.
@@ -8377,7 +8397,7 @@ spec:
                     properties:
                       authorization:
                         description: |-
-                          authorization defines the  header configuration to authenticate against the DigitalOcean API.
+                          authorization defines the header configuration to authenticate against the Linode API.
                           Cannot be set at the same time as `oauth2`.
                         properties:
                           credentials:
@@ -8790,7 +8810,7 @@ spec:
                         minLength: 1
                         type: string
                       tlsConfig:
-                        description: tlsConfig defines the TLS configuration to connect to the Consul API.
+                        description: tlsConfig defines the TLS configuration to connect to the Linode API.
                         properties:
                           ca:
                             description: ca defines the Certificate authority used when verifying server certificates.
@@ -9090,7 +9110,7 @@ spec:
                         type: boolean
                       authorization:
                         description: |-
-                          authorization defines the  header configuration to authenticate against the DigitalOcean API.
+                          authorization defines the header configuration to authenticate against the Nomad API.
                           Cannot be set at the same time as `oauth2`.
                         properties:
                           credentials:
@@ -9186,6 +9206,7 @@ spec:
                         description: |-
                           namespace defines the Nomad namespace to query for service discovery.
                           When specified, only resources within this namespace will be discovered.
+                        minLength: 1
                         type: string
                       noProxy:
                         description: |-
@@ -9547,20 +9568,22 @@ spec:
                         description: |-
                           region defines the Nomad region to query for service discovery.
                           When specified, only resources within this region will be discovered.
+                        minLength: 1
                         type: string
                       server:
                         description: |-
                           server defines the Nomad server address to connect to for service discovery.
                           This should be the full URL including protocol (e.g., "https://nomad.example.com:4646").
-                        minLength: 1
+                        pattern: ^https?://.+$
                         type: string
                       tagSeparator:
                         description: |-
                           tagSeparator defines the separator used to join multiple tags.
                           This determines how Nomad service tags are concatenated into Prometheus labels.
+                        minLength: 1
                         type: string
                       tlsConfig:
-                        description: tlsConfig defines the TLS configuration to connect to the Consul API.
+                        description: tlsConfig defines the TLS configuration to connect to the Nomad API.
                         properties:
                           ca:
                             description: ca defines the Certificate authority used when verifying server certificates.
@@ -10027,6 +10050,7 @@ spec:
                         type: boolean
                       applicationCredentialId:
                         description: applicationCredentialId defines the OpenStack applicationCredentialId.
+                        minLength: 1
                         type: string
                       applicationCredentialName:
                         description: |-
@@ -10084,7 +10108,7 @@ spec:
                         description: |-
                           identityEndpoint defines the HTTP endpoint that is required to work with
                           the Identity API of the appropriate version.
-                        pattern: ^http(s)?:\/\/.+$
+                        pattern: ^https?://.+$
                         type: string
                       password:
                         description: |-
@@ -10464,7 +10488,7 @@ spec:
                     properties:
                       authorization:
                         description: |-
-                          authorization defines the  header configuration to authenticate against the DigitalOcean API.
+                          authorization defines the header configuration to authenticate against the PuppetDB API.
                           Cannot be set at the same time as `oauth2`.
                         properties:
                           credentials:
@@ -10935,7 +10959,7 @@ spec:
                         pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                         type: string
                       tlsConfig:
-                        description: tlsConfig defines the TLS configuration to connect to the Consul API.
+                        description: tlsConfig defines the TLS configuration to connect to the PuppetDB server.
                         properties:
                           ca:
                             description: ca defines the Certificate authority used when verifying server certificates.
@@ -11086,8 +11110,7 @@ spec:
                         type: object
                       url:
                         description: url defines the URL of the PuppetDB root query endpoint.
-                        minLength: 1
-                        pattern: ^http(s)?://.+$
+                        pattern: ^https?://.+$
                         type: string
                     required:
                       - query
@@ -11194,6 +11217,9 @@ spec:
                     description: |-
                       ScalewaySDConfig configurations allow retrieving scrape targets from Scaleway instances and baremetal services.
                       See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scaleway_sd_config
+
+                      Note: The `_file` variants of credential fields (e.g. `secret_key_file`)
+                      from the Prometheus configuration are not supported. Use Kubernetes secrets via `secretKey` instead.
                     properties:
                       accessKey:
                         description: accessKey defines the access key to use. https://console.scaleway.com/project/credentials
@@ -11201,7 +11227,7 @@ spec:
                         type: string
                       apiURL:
                         description: apiURL defines the API URL to use when doing the server listing requests.
-                        pattern: ^http(s)?://.+$
+                        pattern: ^https?://.+$
                         type: string
                       enableHTTP2:
                         description: enableHTTP2 defines whether to enable HTTP2.
@@ -11316,7 +11342,7 @@ spec:
                         type: array
                         x-kubernetes-list-type: set
                       tlsConfig:
-                        description: tlsConfig defines the TLS configuration to connect to the Consul API.
+                        description: tlsConfig defines the TLS configuration to connect to the Scaleway API.
                         properties:
                           ca:
                             description: ca defines the Certificate authority used when verifying server certificates.
@@ -11553,9 +11579,8 @@ spec:
                       targets:
                         description: targets defines the list of targets for this static configuration.
                         items:
-                          description: |-
-                            Target represents a target for Prometheus to scrape
-                            kubebuilder:validation:MinLength:=1
+                          description: Target represents a target for Prometheus to scrape
+                          minLength: 1
                           type: string
                         minItems: 1
                         type: array
@@ -11726,6 +11751,9 @@ spec:
                     It requires Prometheus >= v2.48.0.
                   type: boolean
               type: object
+              x-kubernetes-validations:
+                - message: at most one of basicAuth, authorization, or oauth2 can be configured
+                  rule: '[has(self.basicAuth), has(self.authorization), has(self.oauth2)].filter(x, x).size() <= 1'
             status:
               description: |-
                 status defines the status subresource. It is under active development and is updated only when the

--- a/system/prometheus-crds/crds/servicemonitors.monitoring.coreos.com.yaml
+++ b/system/prometheus-crds/crds/servicemonitors.monitoring.coreos.com.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
-    operator.prometheus.io/version: 0.88.0
+    controller-gen.kubebuilder.io/version: v0.20.1
+    operator.prometheus.io/version: 0.91.0
   name: servicemonitors.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/system/prometheus-crds/crds/thanosrulers.monitoring.coreos.com.yaml
+++ b/system/prometheus-crds/crds/thanosrulers.monitoring.coreos.com.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
-    operator.prometheus.io/version: 0.88.0
+    controller-gen.kubebuilder.io/version: v0.20.1
+    operator.prometheus.io/version: 0.91.0
   name: thanosrulers.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -1076,13 +1076,19 @@ spec:
                   type: array
                 containers:
                   description: |-
-                    containers allows injecting additional containers or modifying operator generated
-                    containers. This can be used to allow adding an authentication proxy to a ThanosRuler pod or
-                    to change the behavior of an operator generated container. Containers described here modify
-                    an operator generated container if they share the same name and modifications are done via a
-                    strategic merge patch. The current container names are: `thanos-ruler` and `config-reloader`.
-                    Overriding containers is entirely outside the scope of what the maintainers will support and by doing
-                    so, you accept that this behaviour may break at any time without notice.
+                    containers allows injecting additional containers or modifying operator
+                    generated containers. This can be used to allow adding an authentication
+                    proxy to the Pods or to change the behavior of an operator generated
+                    container. Containers described here modify an operator generated
+                    container if they share the same name and modifications are done via a
+                    strategic merge patch.
+
+                    The names of containers managed by the operator are:
+                    * `thanos-ruler`
+                    * `config-reloader`
+
+                    Overriding containers which are managed by the operator require careful
+                    testing, especially when upgrading to a new version of the operator.
                   items:
                     description: A single application container that you want to run within a pod.
                     properties:
@@ -1911,7 +1917,9 @@ spec:
                             type: integer
                         type: object
                       resizePolicy:
-                        description: Resources resize policy for the container.
+                        description: |-
+                          Resources resize policy for the container.
+                          This field cannot be set on ephemeral containers.
                         items:
                           description: ContainerResizePolicy represents resource resize policy for the container.
                           properties:
@@ -2673,8 +2681,8 @@ spec:
                   description: |-
                     grpcServerTlsConfig defines the gRPC server from which Thanos Querier reads
                     recorded rule data.
-                    Note: Currently only the CAFile, CertFile, and KeyFile fields are supported.
-                    Maps to the '--grpc-server-tls-*' CLI args.
+
+                    Note: Currently only the `minVersion`, `caFile`, `certFile`, `keyFile`, `cipherSuites` and `curves` fields are supported.
                   properties:
                     ca:
                       description: ca defines the Certificate authority used when verifying server certificates.
@@ -2778,6 +2786,38 @@ spec:
                     certFile:
                       description: certFile defines the path to the client cert file in the Prometheus container for the targets.
                       type: string
+                    cipherSuites:
+                      description: |-
+                        cipherSuites defines the list of supported cipher suites for TLS
+                        versions up to TLS 1.2.
+
+                        If not defined, the Go default cipher suites are used.
+                        Available cipher suites are documented in the Go documentation:
+                        https://golang.org/pkg/crypto/tls/#pkg-constants
+
+                        It requires Thanos >= v0.42.0. Note that the operator doesn't verify if
+                        the Thanos version supports the provided values.
+                      items:
+                        type: string
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-type: set
+                    curves:
+                      description: |-
+                        curves defines the list of preferred elliptic curves for
+                        TLS handshakes.
+
+                        If not defined, the Go default curves are used.
+                        Available curves are documented in the Go documentation:
+                        https://golang.org/pkg/crypto/tls/#CurveID
+
+                        It requires Thanos >= v0.42.0. Note that the operator doesn't verify if
+                        the Thanos version supports the provided values.
+                      items:
+                        type: string
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-type: set
                     insecureSkipVerify:
                       description: insecureSkipVerify defines how to disable target certificate validation.
                       type: boolean
@@ -2901,13 +2941,11 @@ spec:
                   type: array
                 initContainers:
                   description: |-
-                    initContainers allows adding initContainers to the pod definition. Those can be used to e.g.
-                    fetch secrets for injection into the ThanosRuler configuration from external sources. Any
-                    errors during the execution of an initContainer will lead to a restart of the Pod.
-                    More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
-                    Using initContainers for any use case other then secret fetching is entirely outside the scope
-                    of what the maintainers will support and by doing so, you accept that this behaviour may break
-                    at any time without notice.
+                    initContainers allows injecting initContainers to the Pod definition.
+                    Those can be used to e.g. fetch secrets for injection into the
+                    configuration from external sources. Any errors during the execution of
+                    an initContainer will lead to a restart of the Pod. More info:
+                    https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
                   items:
                     description: A single application container that you want to run within a pod.
                     properties:
@@ -3736,7 +3774,9 @@ spec:
                             type: integer
                         type: object
                       resizePolicy:
-                        description: Resources resize policy for the container.
+                        description: |-
+                          Resources resize policy for the container.
+                          This field cannot be set on ephemeral containers.
                         items:
                           description: ContainerResizePolicy represents resource resize policy for the container.
                           properties:
@@ -5333,6 +5373,12 @@ spec:
                               - key
                             type: object
                             x-kubernetes-map-type: atomic
+                          externalId:
+                            description: |-
+                              externalId defines the external ID used when assuming an AWS role. Can only be used with roleArn.
+                              It requires Prometheus >= v3.11.0 or Alertmanager >= v0.33.0. Currently not supported by Thanos.
+                            minLength: 1
+                            type: string
                           profile:
                             description: profile defines the named AWS profile used to authenticate.
                             type: string
@@ -5372,6 +5418,9 @@ spec:
                               It requires Prometheus >= v2.54.0.
                             type: boolean
                         type: object
+                        x-kubernetes-validations:
+                          - message: externalId can only be used when roleArn is specified
+                            rule: '!has(self.externalId) || has(self.roleArn)'
                       tlsConfig:
                         description: tlsConfig to use for the URL.
                         properties:
@@ -5532,8 +5581,11 @@ spec:
                             type: string
                         type: object
                       url:
-                        description: url defines the URL of the endpoint to send samples to.
-                        minLength: 1
+                        description: |-
+                          url defines the URL of the endpoint to send samples to.
+
+                          It must use the HTTP or HTTPS scheme.
+                        pattern: ^(http|https)://.+$
                         type: string
                       writeRelabelConfigs:
                         description: writeRelabelConfigs defines the list of remote write relabel configurations.
@@ -5826,6 +5878,10 @@ spec:
                       type: object
                   type: object
                   x-kubernetes-map-type: atomic
+                schedulerName:
+                  description: schedulerName defines the scheduler to use for Pod scheduling. If not specified, the default scheduler is used.
+                  minLength: 1
+                  type: string
                 securityContext:
                   description: |-
                     securityContext defines the pod-level security attributes and common container settings.
@@ -6233,7 +6289,7 @@ spec:
                                 resources:
                                   description: |-
                                     resources represents the minimum resources the volume should have.
-                                    If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                    Users are allowed to specify resource requirements
                                     that are lower than previous value but must still be higher than capacity recorded in the
                                     status field of the claim.
                                     More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -6482,7 +6538,7 @@ spec:
                             resources:
                               description: |-
                                 resources represents the minimum resources the volume should have.
-                                If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                Users are allowed to specify resource requirements
                                 that are lower than previous value but must still be higher than capacity recorded in the
                                 status field of the claim.
                                 More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -6601,7 +6657,7 @@ spec:
                                   that it does not recognizes, then it should ignore that update and let other controllers
                                   handle it.
                                 type: string
-                              description: "allocatedResourceStatuses stores status of resource being resized for the given PVC.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\nClaimResourceStatus can be in any of following states:\n\t- ControllerResizeInProgress:\n\t\tState set when resize controller starts resizing the volume in control-plane.\n\t- ControllerResizeFailed:\n\t\tState set when resize has failed in resize controller with a terminal error.\n\t- NodeResizePending:\n\t\tState set when resize controller has finished resizing the volume but further resizing of\n\t\tvolume is needed on the node.\n\t- NodeResizeInProgress:\n\t\tState set when kubelet starts resizing the volume.\n\t- NodeResizeFailed:\n\t\tState set when resizing has failed in kubelet with a terminal error. Transient errors don't set\n\t\tNodeResizeFailed.\nFor example: if expanding a PVC for more capacity - this field can be one of the following states:\n\t- pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeFailed\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizePending\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeFailed\"\nWhen this field is not set, it means that no resize operation is in progress for the given PVC.\n\nA controller that receives PVC update with previously unknown resourceName or ClaimResourceStatus\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC.\n\nThis is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                              description: "allocatedResourceStatuses stores status of resource being resized for the given PVC.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\nClaimResourceStatus can be in any of following states:\n\t- ControllerResizeInProgress:\n\t\tState set when resize controller starts resizing the volume in control-plane.\n\t- ControllerResizeFailed:\n\t\tState set when resize has failed in resize controller with a terminal error.\n\t- NodeResizePending:\n\t\tState set when resize controller has finished resizing the volume but further resizing of\n\t\tvolume is needed on the node.\n\t- NodeResizeInProgress:\n\t\tState set when kubelet starts resizing the volume.\n\t- NodeResizeFailed:\n\t\tState set when resizing has failed in kubelet with a terminal error. Transient errors don't set\n\t\tNodeResizeFailed.\nFor example: if expanding a PVC for more capacity - this field can be one of the following states:\n\t- pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeFailed\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizePending\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeFailed\"\nWhen this field is not set, it means that no resize operation is in progress for the given PVC.\n\nA controller that receives PVC update with previously unknown resourceName or ClaimResourceStatus\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC."
                               type: object
                               x-kubernetes-map-type: granular
                             allocatedResources:
@@ -6611,7 +6667,7 @@ spec:
                                   - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: "allocatedResources tracks the resources allocated to a PVC including its capacity.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\nCapacity reported here may be larger than the actual capacity when a volume expansion operation\nis requested.\nFor storage quota, the larger value from allocatedResources and PVC.spec.resources is used.\nIf allocatedResources is not set, PVC.spec.resources alone is used for quota calculation.\nIf a volume expansion capacity request is lowered, allocatedResources is only\nlowered if there are no expansion operations in progress and if the actual volume capacity\nis equal or lower than the requested capacity.\n\nA controller that receives PVC update with previously unknown resourceName\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC.\n\nThis is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                              description: "allocatedResources tracks the resources allocated to a PVC including its capacity.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\nCapacity reported here may be larger than the actual capacity when a volume expansion operation\nis requested.\nFor storage quota, the larger value from allocatedResources and PVC.spec.resources is used.\nIf allocatedResources is not set, PVC.spec.resources alone is used for quota calculation.\nIf a volume expansion capacity request is lowered, allocatedResources is only\nlowered if there are no expansion operations in progress and if the actual volume capacity\nis equal or lower than the requested capacity.\n\nA controller that receives PVC update with previously unknown resourceName\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC."
                               type: object
                             capacity:
                               additionalProperties:
@@ -6720,9 +6776,10 @@ spec:
                       operator:
                         description: |-
                           Operator represents a key's relationship to the value.
-                          Valid operators are Exists and Equal. Defaults to Equal.
+                          Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                           Exists is equivalent to wildcard for value, so that a pod can
                           tolerate all taints of a particular category.
+                          Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                         type: string
                       tolerationSeconds:
                         description: |-
@@ -7624,7 +7681,7 @@ spec:
                                   resources:
                                     description: |-
                                       resources represents the minimum resources the volume should have.
-                                      If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                      Users are allowed to specify resource requirements
                                       that are lower than previous value but must still be higher than capacity recorded in the
                                       status field of the claim.
                                       More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -8459,6 +8516,24 @@ spec:
                                     signerName:
                                       description: Kubelet's generated CSRs will be addressed to this signer.
                                       type: string
+                                    userAnnotations:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        userAnnotations allow pod authors to pass additional information to
+                                        the signer implementation.  Kubernetes does not restrict or validate this
+                                        metadata in any way.
+
+                                        These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                        the PodCertificateRequest objects that Kubelet creates.
+
+                                        Entries are subject to the same validation as object metadata annotations,
+                                        with the addition that all keys must be domain-prefixed. No restrictions
+                                        are placed on values, except an overall size limitation on the entire field.
+
+                                        Signers should document the keys and values they support. Signers should
+                                        deny requests that contain keys they do not recognize.
+                                      type: object
                                   required:
                                     - keyType
                                     - signerName


### PR DESCRIPTION
Upgrades the prometheus-operator CRDs from v0.88.0 to v0.91.0.

## Changes

- Bumped `Chart.yaml` version: `8.0.0` → `9.0.0` (major bump consistent with sapcc/helm-charts#10897)
- Refreshed all 10 CRDs via `./get-crds v0.91.0`:
  - `controller-gen.kubebuilder.io/version`: `v0.19.0` → `v0.20.1`
  - `operator.prometheus.io/version`: `0.88.0` → `0.91.0`

## Some breaking changes that needs to be monitored

Per the v0.91.0 release notes, several `[CHANGE]` items add validations that may reject previously-valid CRs:
- `ScrapeConfig`: `basicAuth` / `authorization` / `oauth2` are now mutually exclusive; new minLength on string fields
- `AlertmanagerConfig`: stricter validations for VictorOps, OpsGenie, and Email receivers