### PR TITLE
bump prometheus-crds dependency to 9.0.0 in consumer charts

### DIFF
--- a/system/kube-monitoring-admin-k3s/Chart.lock
+++ b/system/kube-monitoring-admin-k3s/Chart.lock
@@ -19,7 +19,7 @@ dependencies:
   version: 0.1.1
 - name: prometheus-crds
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 8.0.0
+  version: 9.0.0
 - name: prometheus-kubernetes-rules
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.10.9
@@ -44,5 +44,5 @@ dependencies:
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
   version: 3.13.0
-digest: sha256:98f29bae84f181f902545209a36fb01bcf790a8402e2acb352a4a2a26d4d4a28
-generated: "2026-05-26T16:33:30.41056+02:00"
+digest: sha256:178d483405145cf3d64c8fc1ce7c75e551b42102e5145ff16ecf24efbf2a3964
+generated: "2026-05-27T12:03:42.518505+02:00"

--- a/system/kube-monitoring-admin-k3s/Chart.yaml
+++ b/system/kube-monitoring-admin-k3s/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes admin k3s cluster monitoring.
 name: kube-monitoring-admin-k3s
-version: 4.7.4
+version: 4.8.0
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-admin-k3s
 dependencies:
   - condition: absent-metrics-operator.enabled
@@ -27,7 +27,7 @@ dependencies:
   - condition: prometheus-crds.enabled
     name: prometheus-crds
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 8.0.0
+    version: 9.0.0
   - name: prometheus-kubernetes-rules
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^1.10"

--- a/system/kube-monitoring-kubernikus/Chart.lock
+++ b/system/kube-monitoring-kubernikus/Chart.lock
@@ -25,7 +25,7 @@ dependencies:
   version: 0.1.1
 - name: prometheus-crds
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 8.0.0
+  version: 9.0.0
 - name: prometheus-kubernetes-rules
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.10.9
@@ -53,5 +53,5 @@ dependencies:
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
   version: 3.13.0
-digest: sha256:4c45160439048c29a6f47c85669eadae374baa22d3562099c80d7f4984074f40
-generated: "2026-05-26T16:32:37.43849+02:00"
+digest: sha256:0cf11d9241f24ad769252376067d47a04743408e9d15f357eb7691ce8b40c8ef
+generated: "2026-05-27T12:03:59.387529+02:00"

--- a/system/kube-monitoring-kubernikus/Chart.yaml
+++ b/system/kube-monitoring-kubernikus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for monitoring Kubernikus.
 name: kube-monitoring-kubernikus
-version: 7.9.4
+version: 7.10.0
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-kubernikus
 dependencies:
   - condition: absent-metrics-operator.enabled
@@ -34,7 +34,7 @@ dependencies:
     version: 0.1.1
   - name: prometheus-crds
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 8.0.0
+    version: 9.0.0
   - name: prometheus-kubernetes-rules
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^1.10"

--- a/system/kube-monitoring-metal/Chart.lock
+++ b/system/kube-monitoring-metal/Chart.lock
@@ -22,7 +22,7 @@ dependencies:
   version: 1.1.0
 - name: prometheus-crds
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 8.0.0
+  version: 9.0.0
 - name: prometheus-kubernetes-rules
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.10.9
@@ -47,5 +47,5 @@ dependencies:
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
   version: 3.13.0
-digest: sha256:29453881930ad3411b9da40a5b9f9976019ff69872b548c0a95ad67dfe7be6c2
-generated: "2026-05-26T16:55:06.588512+02:00"
+digest: sha256:1c377f54effc952e2ccac6750e6d744ae51474afd7dbb6e5d3cc87631d671933
+generated: "2026-05-27T12:04:20.91357+02:00"

--- a/system/kube-monitoring-metal/Chart.yaml
+++ b/system/kube-monitoring-metal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes metal controlplane monitoring.
 name: kube-monitoring-metal
-version: 4.10.4
+version: 4.11.0
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-metal
 dependencies:
   - condition: absent-metrics-operator.enabled
@@ -29,7 +29,7 @@ dependencies:
     version: 1.1.0
   - name: prometheus-crds
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 8.0.0
+    version: 9.0.0
   - name: prometheus-kubernetes-rules
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^1.10"

--- a/system/kube-monitoring-scaleout/Chart.lock
+++ b/system/kube-monitoring-scaleout/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 1.1.4
 - name: prometheus-crds
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 8.0.0
+  version: 9.0.0
 - name: prometheus-kubernetes-rules
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.10.9
@@ -44,5 +44,5 @@ dependencies:
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
   version: 3.13.0
-digest: sha256:9778f9fa1f724512c3198e954bcf397c9ca0e0d812ab157f1eab2319a65b7b39
-generated: "2026-05-26T16:58:03.220843+02:00"
+digest: sha256:b17b45d531a4e78e41132f20dfa7eeb0666e7bc2cba63ca5537130d78dd1af65
+generated: "2026-05-27T12:04:35.02667+02:00"

--- a/system/kube-monitoring-scaleout/Chart.yaml
+++ b/system/kube-monitoring-scaleout/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kubernetes scaleout cluster monitoring.
 name: kube-monitoring-scaleout
-version: 4.12.4
+version: 4.13.0
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-scaleout
 dependencies:
   - condition: absent-metrics-operator.enabled
@@ -22,7 +22,7 @@ dependencies:
     version: "^1.x"
   - name: prometheus-crds
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: "8.0.0"
+    version: "9.0.0"
   - name: prometheus-kubernetes-rules
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^1.10"

--- a/system/kube-monitoring-virtual/Chart.lock
+++ b/system/kube-monitoring-virtual/Chart.lock
@@ -22,7 +22,7 @@ dependencies:
   version: 0.1.1
 - name: prometheus-crds
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 8.0.0
+  version: 9.0.0
 - name: prometheus-kubernetes-rules
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.10.9
@@ -47,5 +47,5 @@ dependencies:
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
   version: 3.13.0
-digest: sha256:08f6623088b27fa7f948b5ac2364bd69b12d7f3eb3504aa0fc9f30ffabe3e28c
-generated: "2026-05-26T16:59:58.058495+02:00"
+digest: sha256:cc44c57615873814822b860901a7e084561ce7db840ee535b8ce4d156817af10
+generated: "2026-05-27T12:04:49.310839+02:00"

--- a/system/kube-monitoring-virtual/Chart.yaml
+++ b/system/kube-monitoring-virtual/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes virtual cluster monitoring.
 name: kube-monitoring-virtual
-version: 6.10.4
+version: 6.11.0
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-virtual
 dependencies:
   - condition: absent-metrics-operator.enabled
@@ -29,7 +29,7 @@ dependencies:
     version: 0.1.1
   - name: prometheus-crds
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 8.0.0
+    version: 9.0.0
   - name: prometheus-kubernetes-rules
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^1.10"

--- a/system/kube-system-admin-k3s/Chart.lock
+++ b/system/kube-system-admin-k3s/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.3.13
 - name: prometheus-crds
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 8.0.0
+  version: 9.0.0
 - name: traefik
   repository: https://helm.traefik.io/traefik
   version: 39.0.5
@@ -41,5 +41,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 1.2.0
-digest: sha256:354b845c0512964131f7ada6d6c0ed9700764ebc7173c00e213c0c8b4e01bad3
-generated: "2026-04-02T10:14:48.864017908Z"
+digest: sha256:6d4b0d8fa431bc8e419c9747b50a150ff12ab622934ebbdf7aa12cd5f7a901a7
+generated: "2026-05-27T12:05:02.433099+02:00"

--- a/system/kube-system-admin-k3s/Chart.yaml
+++ b/system/kube-system-admin-k3s/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kube-System relevant Service collection for the new admin clusters.
 name: kube-system-admin-k3s
-version: 3.6.4
+version: 3.7.0
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-admin-k3s
 dependencies:
   - name: node-problem-detector
@@ -10,7 +10,7 @@ dependencies:
     version: ">= 0.0.0"
   - name: prometheus-crds
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 8.0.0
+    version: 9.0.0
   - name: traefik
     repository: https://helm.traefik.io/traefik
     version: 39.0.5

--- a/system/kube-system-kubernikus/Chart.lock
+++ b/system/kube-system-kubernikus/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 1.3.13
 - name: prometheus-crds
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 8.0.0
+  version: 9.0.0
 - name: cert-manager
   repository: https://charts.jetstack.io
   version: v1.13.3
@@ -25,7 +25,7 @@ dependencies:
   version: 2.0.0
 - name: ldap-named-user
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.2.9
+  version: 0.2.10
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
@@ -41,5 +41,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 1.2.0
-digest: sha256:8b97d59e8d98a7aac8718dcc784e3ae2faef2c294542cedc6d71d16d4062c5ba
-generated: "2026-04-10T12:56:57.62637+03:00"
+digest: sha256:d4a25d30b180f0dc2d5aa89e9d2792a494f53d70070ba9268d1e92909311e837
+generated: "2026-05-27T12:05:17.503119+02:00"

--- a/system/kube-system-kubernikus/Chart.yaml
+++ b/system/kube-system-kubernikus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for Kubernikus control-plane clusters.
 name: kube-system-kubernikus
-version: 3.9.4
+version: 3.10.0
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-kubernikus
 dependencies:
   - name: cc-rbac
@@ -16,7 +16,7 @@ dependencies:
     version: '>= 0.0.0'
   - name: prometheus-crds
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 8.0.0
+    version: 9.0.0
   - name: cert-manager
     repository: https://charts.jetstack.io
     version: 1.13.3

--- a/system/kube-system-metal/Chart.lock
+++ b/system/kube-system-metal/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 1.3.13
 - name: prometheus-crds
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 8.0.0
+  version: 9.0.0
 - name: sysctl
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.0.9
@@ -77,5 +77,5 @@ dependencies:
 - name: validating-admission-policy
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.0.2
-digest: sha256:57e2b121a9d4b3d4ef874a32f9dbe8a7cce8607cc5d7cbbd00905c4a88ebd2bf
-generated: "2026-04-10T12:54:48.034012+03:00"
+digest: sha256:3810c5557770d610bc08f084563770deeca93cbb3473e3fd3a9848088c35df5f
+generated: "2026-05-27T12:05:30.950976+02:00"

--- a/system/kube-system-metal/Chart.yaml
+++ b/system/kube-system-metal/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for metal clusters.
 name: kube-system-metal
-version: 6.13.5
+version: 6.14.0
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-metal
 dependencies:
   - name: cc-rbac
@@ -24,7 +24,7 @@ dependencies:
     version: '>= 0.0.0'
   - name: prometheus-crds
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 8.0.0
+    version: 9.0.0
   - name: sysctl
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^0.x"

--- a/system/kube-system-scaleout/Chart.lock
+++ b/system/kube-system-scaleout/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 1.3.13
 - name: prometheus-crds
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 8.0.0
+  version: 9.0.0
 - name: cert-manager
   repository: https://charts.jetstack.io
   version: v1.13.3
@@ -31,7 +31,7 @@ dependencies:
   version: 2.0.0
 - name: ldap-named-user
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.2.9
+  version: 0.2.10
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
@@ -47,5 +47,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 1.2.0
-digest: sha256:b96a5c9be292ac6ae48cde8e9775764fd117551a65d23a24ad1ba3f9eb76a556
-generated: "2026-04-10T12:56:15.301541+03:00"
+digest: sha256:ea27a6b20678778185a8f84fc727097b8882fd01db03379b29b252382b7f567d
+generated: "2026-05-27T12:05:45.3852+02:00"

--- a/system/kube-system-scaleout/Chart.yaml
+++ b/system/kube-system-scaleout/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kube-System relevant Service collection for scaleout clusters.
 name: kube-system-scaleout
-version: 5.11.4
+version: 5.12.0
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-scaleout
 dependencies:
   - name: cc-rbac
@@ -25,7 +25,7 @@ dependencies:
     version: '>= 0.0.0'
   - name: prometheus-crds
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 8.0.0
+    version: 9.0.0
   - name: cert-manager
     repository: https://charts.jetstack.io
     version: 1.13.3

--- a/system/kube-system-virtual/Chart.lock
+++ b/system/kube-system-virtual/Chart.lock
@@ -19,7 +19,7 @@ dependencies:
   version: 1.3.13
 - name: prometheus-crds
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 8.0.0
+  version: 9.0.0
 - name: wormhole
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 3.1.8
@@ -56,5 +56,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 1.2.0
-digest: sha256:9242dd672e72b40d0d23450b3e27419f8f39e8c8e5933fdd62afcd3cd3fc5215
-generated: "2026-04-10T12:55:33.988743+03:00"
+digest: sha256:503ecaef9c7f1b5ee3eb7e36a19778429a08e4092ba02963b8ecbb21e70a0c9a
+generated: "2026-05-27T12:05:58.732258+02:00"

--- a/system/kube-system-virtual/Chart.yaml
+++ b/system/kube-system-virtual/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for virtual clusters.
 name: kube-system-virtual
-version: 4.8.5
+version: 4.9.0
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-virtual
 dependencies:
   - name: cc-rbac
@@ -24,7 +24,7 @@ dependencies:
     version: '>= 0.0.0'
   - name: prometheus-crds
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 8.0.0
+    version: 9.0.0
   - name: wormhole
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: '>= 0.0.0'

--- a/system/prometheus-operator/Chart.lock
+++ b/system/prometheus-operator/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: prometheus-crds
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 8.0.0
+  version: 9.0.0
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
-  version: 82.4.3
+  version: 85.3.3
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:c81c16e2eef6928ac38b573363569b40aae3c405f8d31fdcc9356f4f3203341a
-generated: "2026-03-03T14:25:03.705511+01:00"
+digest: sha256:a642b055e1ce5c7f67d912f0a2e32520ec45b5f43cb062f5f9c5d88292baf31c
+generated: "2026-05-27T12:02:54.048183+02:00"

--- a/system/prometheus-operator/Chart.yaml
+++ b/system/prometheus-operator/Chart.yaml
@@ -1,13 +1,13 @@
 apiVersion: v2
 description: Prometheus operator via kube-prom-stack
 name: prometheus-operator
-version: 2.1.2
+version: 2.2.0
 home: https://github.com/sapcc/helm-charts/tree/master/system/prometheus-operator
 dependencies:
   - name: prometheus-crds
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     # please update kube-monitoring-* and kube-system-* crds too, otherwise they will overwrite this
-    version: 8.0.0
+    version: 9.0.0
   - name: kube-prometheus-stack
     repository: https://prometheus-community.github.io/helm-charts
     version: '>= 0.0.0'


### PR DESCRIPTION
Bumps the `prometheus-crds` dependency from `8.0.0` to `9.0.0` 
follow-up to #11770 