### PR TITLE
[designate][catz_pools] purge also_notifies

### DIFF
--- a/openstack/designate/templates/etc/_pools.yaml.tpl
+++ b/openstack/designate/templates/etc/_pools.yaml.tpl
@@ -57,15 +57,9 @@
     - host: {{ $srv.ip }}
       port: 53
     {{- end}}
-  also_notifies:
-    {{- range $prio, $srv := $pool.nameservers}}
-    - host: {{ $srv.ip }}
-      port: 53
-    {{- end}}
   targets:
     {{- range $idx, $srv := $pool.nameservers}}
-    - type: fake
-      description: Dummy Server {{ add1 $idx }}
+    - type: bind9
       masters:
         - host: {{ $.Values.global.designate_mdns_external_ip }}
           port: 5354


### PR DESCRIPTION
No need for `also_notifies` if we have `targets`.