### PR TITLE
Bump kvm-ha-service dep to 1.0.5

### DIFF
--- a/openstack/kvm-ha-service/Chart.lock
+++ b/openstack/kvm-ha-service/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: kvm-ha-service
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.0.4
+  version: 1.0.5
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
@@ -11,5 +11,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:91b13d3416391ee1666227801a5ae66eaa730798652f9c38852c788b421f6c03
-generated: "2026-05-11T15:41:30.829277+02:00"
+digest: sha256:9449ac37ed3af616d47584962742cbcc84ebac29730142b272bd92d87282cbd5
+generated: "2026-05-27T13:28:49.18403+02:00"

--- a/openstack/kvm-ha-service/Chart.yaml
+++ b/openstack/kvm-ha-service/Chart.yaml
@@ -3,7 +3,7 @@ name: kvm-ha-service
 description: Helm Chart for KVM HA Service with internal dependencies
 type: application
 
-version: 0.1.3
+version: 0.1.4
 
 dependencies:
 - name: kvm-ha-service

--- a/openstack/kvm-ha-service/Chart.yaml
+++ b/openstack/kvm-ha-service/Chart.yaml
@@ -7,7 +7,7 @@ version: 0.1.3
 
 dependencies:
 - name: kvm-ha-service
-  version: '1.0.4'
+  version: '1.0.5'
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm


### PR DESCRIPTION
- Add aggregate filter include and exclude. If not set nothing is filtered out.
- Make kvm-ha-service container the default container