### PR TITLE
feat(kmip): overhaul - split deployments, fix DNS/seed/user, add sent…

### DIFF
--- a/openstack/kmip/templates/deployment-kmip-core.yaml
+++ b/openstack/kmip/templates/deployment-kmip-core.yaml
@@ -1,22 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "kmip.fullname" . }}-barbican
+  name: {{ include "kmip.fullname" . }}
   labels:
     {{- include "kmip.labels" . | nindent 4 }}
-    app: {{ include "kmip.fullname" . }}-barbican
+    app: {{ include "kmip.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     system: openstack
-    type: api
-    component: barbican
+    type: backend
+    component: kmip
   annotations:
     secret.reloader.stakater.com/reload: "kmip-secrets,kmip-barbican-etc"
     deployment.reloader.stakater.com/pause-period: "60s"
 spec:
   replicas: {{ .Values.replicaCount }}
-
   revisionHistoryLimit: {{ .Values.pod.lifecycle.upgrades.deployments.revisionHistory }}
   strategy:
     type: {{ .Values.pod.lifecycle.upgrades.deployments.podReplacementStrategy }}
@@ -27,99 +26,24 @@ spec:
     {{- end }}
   selector:
     matchLabels:
-      {{- include "kmip.selectorLabels" . | nindent 6 }}
+      app: {{ include "kmip.fullname" . }}
   template:
     metadata:
       labels:
         {{- include "kmip.labels" . | nindent 8 }}
-        app: {{ include "kmip.fullname" . }}-barbican
-        name: {{ include "kmip.fullname" . }}-barbican
+        app: {{ include "kmip.fullname" . }}
+        name: {{ include "kmip.fullname" . }}
         alert-tier: os
-        alert-service: barbican
-        {{- with .Values.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        alert-service: kmip
       annotations:
         secrets-etc-hash: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
-        {{- if .Values.proxysql.mode }}
-        prometheus.io/scrape: "true"
-        prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
-        {{- end }}
     spec:
       serviceAccountName: {{ include "kmip.serviceAccountName" . }}-barbican
       containers:
-        - name: kmip-restapi
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
-          image: {{required ".Values.global.registry is missing" .Values.global.registry }}/loci-barbican:{{required "Values.kmip.restapi_image is missing" .Values.kmip.restapi_image }}
-          imagePullPolicy: {{ .Values.kmip.pullPolicy }}
-          env:
-            - name: KMIP_MARIADB_SERVICE_HOST
-              value: "kmip-mariadb"
-            - name: KMIP_MARIADB_SERVICE_PORT
-              value: "3306"
-            - name: KMIP_MARIADB_SERVICE_USER
-              valueFrom:
-                secretKeyRef:
-                  name: kmip-secrets
-                  key: mariadb_user
-            - name: KMIP_MARIADB_SERVICE_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: kmip-secrets
-                  key: mariadb_password
-            - name: KMIP_MARIADB_NAME
-              value: "kmip"
-            - name: BARBICAN_MARIADB_SERVICE_HOST
-              value: "barbican-mariadb"
-            - name: BARBICAN_MARIADB_SERVICE_PORT
-              value: "3306"
-            - name: BARBICAN_MARIADB_SERVICE_USER
-              valueFrom:
-                secretKeyRef:
-                  name: kmip-secrets
-                  key: barbican_mariadb_service_user
-            - name: BARBICAN_MARIADB_SERVICE_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: kmip-secrets
-                  key: barbican_mariadb_service_password
-            - name: BARBICAN_MARIADB_NAME
-              value: "barbican"
-          command: ["sh", "-c"]
-          args:
-          - |
-            echo "Sleeping for 15 seconds before starting the application...";
-            sleep 15;
-            echo "Starting the application...";
-            python /app/app.py;
-            echo "Application exited. Keeping container alive...";
-            tail -f /dev/null
-          resources:
-            requests:
-              memory: 0
-              cpu: 0
-          volumeMounts:
-            - name: kmip-barbican-etc
-              mountPath: /etc/pykmip/server.conf
-              subPath: kmip-server.conf
-              readOnly: true
-            - name: kmip-acme-certificates
-              mountPath: /etc/pykmip/certs/server.crt
-              subPath: tls.crt
-              readOnly: true
-            - name: kmip-acme-certificates
-              mountPath: /etc/pykmip/certs/server.key
-              subPath: tls.key
-              readOnly: true
-            - name: kmip-ca-certificates
-              mountPath: /etc/pykmip/certs/ca.crt
-              subPath: ca.crt
-              readOnly: true
         - name: kmip-core
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: {{required ".Values.global.registry is missing" .Values.global.registry }}/loci-barbican:{{required "Values.kmip.image is missing" .Values.kmip.image }}
+          image: {{ required ".Values.global.registry is missing" .Values.global.registry }}/loci-barbican:{{ required "Values.kmip.image is missing" .Values.kmip.image }}
           imagePullPolicy: {{ .Values.kmip.pullPolicy }}
           env:
             - name: OS_AUTH_URL
@@ -134,11 +58,6 @@ spec:
                 secretKeyRef:
                   name: kmip-secrets
                   key: os_password
-            - name: OS_PROJECT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: kmip-secrets
-                  key: os_project_id
             - name: OS_AUTH_TYPE
               value: "v3password"
             - name: OS_REGION_NAME
@@ -167,9 +86,13 @@ spec:
                   name: kmip-secrets
                   key: os_user_domain_name
           ports:
-            - name: http
+            - name: kmip
               containerPort: {{ .Values.service.ports.port }}
               protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
           resources:
             requests:
               memory: 0

--- a/openstack/kmip/templates/deployment-kmip-restapi.yaml
+++ b/openstack/kmip/templates/deployment-kmip-restapi.yaml
@@ -1,0 +1,119 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kmip.fullname" . }}-barbican
+  labels:
+    {{- include "kmip.labels" . | nindent 4 }}
+    app: {{ include "kmip.fullname" . }}-barbican
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    system: openstack
+    type: api
+    component: kmip
+  annotations:
+    secret.reloader.stakater.com/reload: "kmip-secrets"
+    deployment.reloader.stakater.com/pause-period: "60s"
+spec:
+  replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.pod.lifecycle.upgrades.deployments.revisionHistory }}
+  strategy:
+    type: {{ .Values.pod.lifecycle.upgrades.deployments.podReplacementStrategy }}
+    {{- if eq .Values.pod.lifecycle.upgrades.deployments.podReplacementStrategy "RollingUpdate" }}
+    rollingUpdate:
+      maxUnavailable: {{ .Values.pod.lifecycle.upgrades.deployments.rollingUpdate.maxUnavailable }}
+      maxSurge: {{ .Values.pod.lifecycle.upgrades.deployments.rollingUpdate.maxSurge }}
+    {{- end }}
+  selector:
+    matchLabels:
+      {{- include "kmip.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "kmip.labels" . | nindent 8 }}
+        app: {{ include "kmip.fullname" . }}-barbican
+        name: {{ include "kmip.fullname" . }}-barbican
+        alert-tier: os
+        alert-service: kmip
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        secrets-etc-hash: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "5006"
+        prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
+    spec:
+      serviceAccountName: {{ include "kmip.serviceAccountName" . }}-barbican
+      containers:
+        - name: kmip-restapi
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: {{ required ".Values.global.registry is missing" .Values.global.registry }}/loci-barbican:{{ required "Values.kmip.restapi_image is missing" .Values.kmip.restapi_image }}
+          imagePullPolicy: {{ .Values.kmip.pullPolicy }}
+          env:
+            - name: KMIP_MARIADB_SERVICE_HOST
+              value: "kmip-mariadb"
+            - name: KMIP_MARIADB_SERVICE_PORT
+              value: "3306"
+            - name: KMIP_MARIADB_SERVICE_USER
+              valueFrom:
+                secretKeyRef:
+                  name: kmip-secrets
+                  key: mariadb_user
+            - name: KMIP_MARIADB_SERVICE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: kmip-secrets
+                  key: mariadb_password
+            - name: KMIP_MARIADB_NAME
+              value: "kmip"
+            - name: BARBICAN_MARIADB_SERVICE_HOST
+              value: "barbican-mariadb"
+            - name: BARBICAN_MARIADB_SERVICE_PORT
+              value: "3306"
+            - name: BARBICAN_MARIADB_SERVICE_USER
+              valueFrom:
+                secretKeyRef:
+                  name: kmip-secrets
+                  key: barbican_mariadb_service_user
+            - name: BARBICAN_MARIADB_SERVICE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: kmip-secrets
+                  key: barbican_mariadb_service_password
+            - name: BARBICAN_MARIADB_NAME
+              value: "barbican"
+            - name: keystone_url
+              value: "https://{{ include "keystone_api_endpoint_host_public" . }}:443/v3"
+            {{- if .Values.sentry.enabled }}
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: sentry
+                  key: kmip-barbican.DSN.python
+            {{- end }}
+          ports:
+            - name: restapi
+              containerPort: 5006
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 5006
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 5006
+            initialDelaySeconds: 20
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            requests:
+              memory: 0
+              cpu: 0

--- a/openstack/kmip/templates/ingress.yaml
+++ b/openstack/kmip/templates/ingress.yaml
@@ -16,9 +16,8 @@ metadata:
   {{- if .Values.tlsacme }}
     kubernetes.io/tls-acme: "true"
     disco: "true"
-    disco/record: "{{ .Values.service.externalIPs }}"
+    disco/record: "ingress.{{ .Values.global.region }}.{{ .Values.global.tld }}"
     disco/zone-name: "cc.{{ .Values.global.region }}.{{ .Values.global.tld }}."
-    disco/record-type: "A"
   {{- end }}
   {{- include "utils.linkerd.ingress_annotation" . | indent 4 }}
 spec:

--- a/openstack/kmip/templates/secrets.yaml
+++ b/openstack/kmip/templates/secrets.yaml
@@ -16,7 +16,6 @@ data:
   mariadb_password: {{ .Values.mariadb.users.kmip.password | b64enc | quote }}
   os_username: {{ .Values.kmip.openstack_env.username | b64enc | quote }}
   os_password: {{ .Values.kmip.openstack_env.password | b64enc | quote }}
-  os_project_id: {{ .Values.kmip.openstack_env.project_id | b64enc | quote }}
   os_region_name: {{ .Values.kmip.openstack_env.region_name | b64enc | quote }}
   os_project_domain_name: {{ .Values.kmip.openstack_env.project_domain_name | b64enc | quote }}
   os_identity_api_version: {{ .Values.kmip.openstack_env.identity_api_version | b64enc | quote }}

--- a/openstack/kmip/templates/seed.yaml
+++ b/openstack/kmip/templates/seed.yaml
@@ -12,10 +12,6 @@ spec:
   - monsoon3/keystone-seed
   - monsoon3/domain-default-seed
 
-  roles:
-  - name: keymanager_admin
-    description: KMIP key manager administration
-
   services:
   - name: kmip-barbican
     type: key-management
@@ -28,8 +24,8 @@ spec:
   domains:
   - name: Default
     users:
-    - name: kmip
-      description: 'KMIP Service User'
+    - name: kmip-barbican
+      description: 'KMIP Barbican Service User'
       password: '{{ .Values.kmip.openstack_env.password | include "resolve_secret" }}'
       role_assignments:
       - project: service

--- a/openstack/kmip/templates/sentry.yaml
+++ b/openstack/kmip/templates/sentry.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.sentry.enabled }}
+apiVersion: "sentry.sap.cc/v1"
+kind: "SentryProject"
+metadata:
+  name: kmip-barbican-sentry
+
+spec:
+  name: kmip-barbican
+  team: openstack
+{{- end }}

--- a/openstack/kmip/templates/service-kmip.yaml
+++ b/openstack/kmip/templates/service-kmip.yaml
@@ -1,0 +1,27 @@
+kind: Service
+apiVersion: v1
+
+metadata:
+  name: kmip
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "kmip.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    system: openstack
+    type: backend
+    component: kmip
+spec:
+  type: {{ .Values.service.type }}
+  externalIPs:
+    - {{ .Values.service.externalIPs }}
+  sessionAffinity: None
+  externalTrafficPolicy: Local
+  selector:
+    app: {{ include "kmip.fullname" . }}
+  ports:
+    - name: kmip
+      port: {{ .Values.service.ports.port }}
+      targetPort: 5696
+      protocol: TCP

--- a/openstack/kmip/templates/service.yaml
+++ b/openstack/kmip/templates/service.yaml
@@ -15,18 +15,10 @@ metadata:
   annotations:
     {{- include "utils.linkerd.pod_and_service_annotation" . | indent 4 }}
 spec:
-  type: {{ .Values.service.type }}
-  externalIPs:
-    - {{ .Values.service.externalIPs }}
-  sessionAffinity: None
-  externalTrafficPolicy: Local
+  type: ClusterIP
   selector:
     app: {{ include "kmip.fullname" . }}-barbican
   ports:
-    - name: http
-      port: {{ .Values.service.ports.port }}
-      targetPort: 5696
-      protocol: TCP
     - name: restapi
       port: 5006
       targetPort: 5006

--- a/openstack/kmip/values.yaml
+++ b/openstack/kmip/values.yaml
@@ -55,6 +55,9 @@ service:
 
 tlsacme: true
 
+sentry:
+  enabled: true
+
 ingress:
   enabled: true
 


### PR DESCRIPTION
…ry and prometheus metrics

- Split single pod into kmip-core (PyKMIP server, port 5696) and kmip-restapi (Flask API, port 5006)
- Add deployment-kmip-core.yaml and deployment-kmip-restapi.yaml with proper probes
- Split service into service-kmip.yaml (NodePort/5696) and service.yaml (ClusterIP/5006)
- Add /healthz endpoint with httpGet liveness/readiness probes for restapi
- Add sentry.yaml SentryProject CR and SENTRY_DSN env var (sentry.enabled: true)
- Add prometheus scraping annotations on restapi pod (port 5006)
- Fix disco/record to point to ingress hostname instead of service ExternalIP
- Rename seed user from kmip to kmip-barbican, remove OS_PROJECT_ID
- Remove keymanager_admin role definition from seed (role is immutable in Keystone)
- Standardise labels: component and alert-service set to kmip across all templates