### PR TITLE
[maia]configure if the seed needs to be skip

### DIFF
--- a/openstack/maia/templates/seed.yaml
+++ b/openstack/maia/templates/seed.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.seed.skip }}
 {{- if not .Values.global.is_global_region }}
 {{- if or .Values.maia.enabled .Values.seed.enabled}}
 {{- $cdomains := .Values.global.domain_seeds.customer_domains | required "missing value for .Values.global.domain_seeds.customer_domains" -}}
@@ -149,5 +150,6 @@ spec:
         inherited: true
   {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/openstack/maia/templates/seed_global.yaml
+++ b/openstack/maia/templates/seed_global.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.seed_global.skip }}
 {{- if .Values.global.is_global_region }}
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: "OpenstackSeed"
@@ -79,4 +80,5 @@ spec:
       role_assignments:
       - domain: global
         role: monitoring_viewer
+{{- end }}
 {{- end }}

--- a/openstack/maia/values.yaml
+++ b/openstack/maia/values.yaml
@@ -146,6 +146,10 @@ cronus:
 seed:
   enabled: false
 
+# seed_global.skip is true skip deplpy seed_global
+seed_global:
+  skip: false
+
 authentication:
   enabled: false
 


### PR DESCRIPTION
## Summary

Adds `seed.skip` and `seed_global.skip` boolean values to the Maia Helm chart to allow selective suppression of the `OpenstackSeed` resources without disabling Maia itself.

## Motivation

In deployments where the OpenStack seeder operator is not available in the local region (e.g. Swift is provisioned in a different region), the seed resources would fail to apply. This change allows operators to skip seed deployment in the local cluster and manage the `OpenstackSeed` resources independently (e.g. via `system/thanos-seeds` deployed in the target region).

## Changes

- `templates/seed.yaml` — wraps the existing template in `{{- if not .Values.seed.skip }}`
- `templates/seed_global.yaml` — wraps the existing template in `{{- if not .Values.seed_global.skip }}`
- `values.yaml` — adds `seed.skip: false` and `seed_global.skip: false` (default behaviour unchanged)

## Usage

To skip seed deployment in a region, set in the region values:

```yaml
seed:
  skip: true

seed_global:
  skip: true
