### PR TITLE
Add CODEOWNERS and CI test values for persephone-liquid-apiserver

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,6 +41,7 @@
 /global/kibana-objecter                                @dimtass
 /global/oauth-proxy                                    @andypf @ArtieReus @databus23 @drochow
 /global/percona_cluster                                @galkindmitrii @occamshatchet @s10 @businessbean @MaximShepelev @vssldmtrv @mbrowny
+/global/persephone-liquid-apiserver                    @jknipper @ronchi-oss @SuperSandro2000
 /global/persephone-runtime-shoot                       @jknipper @ronchi-oss @SuperSandro2000
 /global/persephone-runtime-seed                        @jknipper @ronchi-oss @SuperSandro2000 @databus23 @dognerd
 /global/prometheus-alertmanager-cnmp                   @auhlig

--- a/global/persephone-liquid-apiserver/ci/test-values.yaml
+++ b/global/persephone-liquid-apiserver/ci/test-values.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Test values for CI
+region: test-region-1
+landscape: test
+
+virtualGarden:
+  apiServerURL: https://api.test.example.com
+
+openstack:
+  authURL: https://keystone.test.example.com/v3


### PR DESCRIPTION
- Add CODEOWNERS entry for global/persephone-liquid-apiserver with same owners as other persephone charts

- Add CI test values with placeholder configuration