### PR TITLE
feat(cc-gardener): make oidc-apps-controller extension policy configurable

### DIFF
--- a/global/cc-gardener/Chart.yaml
+++ b/global/cc-gardener/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cc-gardener
 description: Converged Cloud Gardener setup based on gardener-operator
 type: application
-version: 0.35.1
+version: 0.35.2
 appVersion: "v1.141.1"
 home: https://github.com/gardener/gardener
 dependencies:

--- a/global/cc-gardener/templates/extension-oidc-apps-controller.yaml
+++ b/global/cc-gardener/templates/extension-oidc-apps-controller.yaml
@@ -10,7 +10,7 @@ spec:
       helm:
         ociRepository:
 {{ include "cc-gardener.extension.ociRepository" (dict "ociRepository" .helm.ociRepository "fallbackTag" .version) | indent 10 }}
-      policy: OnDemand
+      policy: {{ .policy | default "OnDemand" }}
       values:
 {{ include "cc-gardener.extension.mergeValues" (dict "values" .values "extensionContext" . "fallbackTag" .version) | indent 8 }}
         cacheSelectorStr: observability.gardener.cloud/app in (plutono, prometheus-shoot,


### PR DESCRIPTION
Make the `policy` field in the oidc-apps-controller extension configurable via `.Values.extensions.oidcAppsController.policy`, defaulting to `OnDemand` if not set.