### PR TITLE
hermes: stop dropping default

### DIFF
--- a/openstack/hermes/templates/etc/_logstash.conf.tpl
+++ b/openstack/hermes/templates/etc/_logstash.conf.tpl
@@ -28,12 +28,6 @@ filter {
     drop { }
   }
 
-  # Drop liveliness check events that serve no value
-  # Everything in audit-default adds no value, internal communication
-  if [initiator][domain_id] == "default" {
-    drop { }
-  }
-
   # unwrap messagingv2 envelope
   if [oslo.message] {
     json {


### PR DESCRIPTION
We need to include this, it saved a ton of space, but we've found out we have to include it even though it is extremely noisy.