### PR TITLE
adding remote configuration options to disco operator

### DIFF
--- a/system/disco/Chart.yaml
+++ b/system/disco/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: The DISCO (Designate IngresS Cname Operator) creates CNAMEs based on an ingress spec in OpenStack Designate.
 name: disco
-version: 2.4.2
+version: 2.4.3
 appVersion: v2.0.0
 maintainers:
   - name: kengou

--- a/system/disco/templates/disco-controller-manager-metrics-service.yaml
+++ b/system/disco/templates/disco-controller-manager-metrics-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.metrics.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -15,3 +16,4 @@ spec:
     targetPort: https
   selector:
     app: disco
+{{- end }}

--- a/system/disco/templates/disco-controller-manager-metrics-service.yaml
+++ b/system/disco/templates/disco-controller-manager-metrics-service.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   ports:
   - name: metrics
-    port: 8080
+    port: {{ .Values.metrics.port }}
     protocol: TCP
     targetPort: https
   selector:

--- a/system/disco/templates/disco-controller-manager.yaml
+++ b/system/disco/templates/disco-controller-manager.yaml
@@ -6,8 +6,10 @@ metadata:
     {{- with .Values.controllerLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- if .Values.reloader.enabled }}
   annotations:
     secret.reloader.stakater.com/reload: "disco-config"
+  {{- end }}
   name: disco-controller-manager
 spec:
   replicas: 1
@@ -21,6 +23,10 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/disco-config.yaml") . | sha256sum }}
       labels:
         app: disco
+        {{- if .Values.remote.enable }}
+        networking.gardener.cloud/to-shoot-apiserver: allowed
+        networking.resources.gardener.cloud/to-kube-apiserver-tcp-443: allowed
+        {{- end }}
         {{- with .Values.controllerLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -30,9 +36,19 @@ spec:
         - /disco
         env:
         - name: NAMESPACE
+        {{- if .Values.remote.enable }}
+          value: {{ .Values.remote.leaderElectionNamespace | default "kube-system" | quote }}
+        {{- else }}
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- end }}
+        {{- if .Values.remote.enable }}
+        - name: KUBERNETES_SERVICE_HOST
+          value: {{ required "remote.apiServerHost is required when remote.enable is true" .Values.remote.apiServerHost | quote }}
+        - name: KUBERNETES_SERVICE_PORT
+          value: {{ .Values.remote.apiServerPort | default "443" | quote }}
+        {{- end }}
         envFrom:
         - secretRef:
             name: disco-config
@@ -45,9 +61,11 @@ spec:
           periodSeconds: 20
         name: manager
         ports:
+        {{- if .Values.webhooks.enabled }}
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
+        {{- end }}
         - containerPort: 8080
           name: https
           protocol: TCP
@@ -59,16 +77,39 @@ spec:
           periodSeconds: 10
         securityContext:
           allowPrivilegeEscalation: false
+        {{- if or .Values.webhooks.enabled .Values.remote.enable }}
         volumeMounts:
+        {{- if .Values.webhooks.enabled }}
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
+        {{- end }}
+        {{- if .Values.remote.enable }}
+        - name: remote-kubeconfig
+          mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          readOnly: true
+        {{- end }}
+        {{- end }}
       securityContext:
         runAsNonRoot: true
-      serviceAccountName: disco-controller-manager
+      serviceAccountName: {{ .Values.serviceAccount.name }}
       terminationGracePeriodSeconds: 10
+      {{- if or .Values.webhooks.enabled .Values.remote.enable }}
       volumes:
+      {{- if .Values.webhooks.enabled }}
       - name: cert
         secret:
           defaultMode: 420
           secretName: tls-disco-webhook-service
+      {{- end }}
+      {{- if .Values.remote.enable }}
+      - name: remote-kubeconfig
+        secret:
+          secretName: disco-remote-kubeconfig
+          items:
+            - key: token
+              path: token
+            - key: bundle.crt
+              path: ca.crt
+      {{- end }}
+      {{- end }}

--- a/system/disco/templates/disco-controller-manager.yaml
+++ b/system/disco/templates/disco-controller-manager.yaml
@@ -6,9 +6,9 @@ metadata:
     {{- with .Values.controllerLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- if .Values.reloader.enabled }}
+  {{- with .Values.deploymentAnnotations }}
   annotations:
-    secret.reloader.stakater.com/reload: "disco-config"
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   name: disco-controller-manager
 spec:
@@ -23,7 +23,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/disco-config.yaml") . | sha256sum }}
       labels:
         app: disco
-        {{- if .Values.remote.enable }}
+        {{- if .Values.remote.enabled }}
         networking.gardener.cloud/to-shoot-apiserver: allowed
         networking.resources.gardener.cloud/to-kube-apiserver-tcp-443: allowed
         {{- end }}
@@ -36,18 +36,18 @@ spec:
         - /disco
         env:
         - name: NAMESPACE
-        {{- if .Values.remote.enable }}
-          value: {{ .Values.remote.leaderElectionNamespace | default "kube-system" | quote }}
+        {{- if .Values.remote.enabled }}
+          value: {{ .Values.remote.leaderElectionNamespace | quote }}
         {{- else }}
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
         {{- end }}
-        {{- if .Values.remote.enable }}
+        {{- if .Values.remote.enabled }}
         - name: KUBERNETES_SERVICE_HOST
-          value: {{ required "remote.apiServerHost is required when remote.enable is true" .Values.remote.apiServerHost | quote }}
+          value: {{ required "remote.apiServerHost is required when remote.enabled is true" .Values.remote.apiServerHost | quote }}
         - name: KUBERNETES_SERVICE_PORT
-          value: {{ .Values.remote.apiServerPort | default "443" | quote }}
+          value: {{ .Values.remote.apiServerPort | quote }}
         {{- end }}
         envFrom:
         - secretRef:
@@ -77,14 +77,14 @@ spec:
           periodSeconds: 10
         securityContext:
           allowPrivilegeEscalation: false
-        {{- if or .Values.webhooks.enabled .Values.remote.enable }}
+        {{- if or .Values.webhooks.enabled .Values.remote.enabled }}
         volumeMounts:
         {{- if .Values.webhooks.enabled }}
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
         {{- end }}
-        {{- if .Values.remote.enable }}
+        {{- if .Values.remote.enabled }}
         - name: remote-kubeconfig
           mountPath: /var/run/secrets/kubernetes.io/serviceaccount
           readOnly: true
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
       serviceAccountName: {{ .Values.serviceAccount.name }}
       terminationGracePeriodSeconds: 10
-      {{- if or .Values.webhooks.enabled .Values.remote.enable }}
+      {{- if or .Values.webhooks.enabled .Values.remote.enabled }}
       volumes:
       {{- if .Values.webhooks.enabled }}
       - name: cert
@@ -102,7 +102,7 @@ spec:
           defaultMode: 420
           secretName: tls-disco-webhook-service
       {{- end }}
-      {{- if .Values.remote.enable }}
+      {{- if .Values.remote.enabled }}
       - name: remote-kubeconfig
         secret:
           secretName: disco-remote-kubeconfig

--- a/system/disco/templates/disco-leader-election-role.yaml
+++ b/system/disco/templates/disco-leader-election-role.yaml
@@ -1,7 +1,9 @@
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: disco-leader-election-role
+  namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups:
   - ""
@@ -34,3 +36,4 @@ rules:
   verbs:
   - create
   - patch
+{{- end }}

--- a/system/disco/templates/disco-leader-election-role.yaml
+++ b/system/disco/templates/disco-leader-election-role.yaml
@@ -3,7 +3,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: disco-leader-election-role
+  {{- if .Values.remote.enabled }}
+  namespace: {{ .Values.remote.role.namespace | default .Release.Namespace }}
+  {{- else }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
 rules:
 - apiGroups:
   - ""

--- a/system/disco/templates/disco-leader-election-rolebinding.yaml
+++ b/system/disco/templates/disco-leader-election-rolebinding.yaml
@@ -1,12 +1,15 @@
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: disco-leader-election-rolebinding
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: disco-leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: disco-controller-manager
+  name: {{ .Values.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/system/disco/templates/disco-leader-election-rolebinding.yaml
+++ b/system/disco/templates/disco-leader-election-rolebinding.yaml
@@ -3,13 +3,22 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: disco-leader-election-rolebinding
+  {{- if .Values.remote.enabled }}
+  namespace: {{ .Values.remote.role.namespace | default .Release.Namespace }}
+  {{- else }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: disco-leader-election-role
 subjects:
 - kind: ServiceAccount
+  {{- if .Values.remote.enabled }}
+  name: {{ .Values.remote.role.subjectName | default .Values.serviceAccount.name }}
+  namespace: {{ .Values.remote.role.subjectNamespace | default .Values.remote.role.namespace | default .Release.Namespace }}
+  {{- else }}
   name: {{ .Values.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
 {{- end }}

--- a/system/disco/templates/disco-manager-role.yaml
+++ b/system/disco/templates/disco-manager-role.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -46,3 +47,4 @@ rules:
   - get
   - list
   - watch
+{{- end }}

--- a/system/disco/templates/disco-manager-rolebinding.yaml
+++ b/system/disco/templates/disco-manager-rolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -8,5 +9,6 @@ roleRef:
   name: disco-manager-role
 subjects:
 - kind: ServiceAccount
-  name: disco-controller-manager
+  name: {{ .Values.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/system/disco/templates/disco-manager-rolebinding.yaml
+++ b/system/disco/templates/disco-manager-rolebinding.yaml
@@ -9,6 +9,11 @@ roleRef:
   name: disco-manager-role
 subjects:
 - kind: ServiceAccount
+  {{- if .Values.remote.enabled }}
+  name: {{ .Values.remote.clusterRoleBindings.subjectName | default .Values.serviceAccount.name }}
+  namespace: {{ .Values.remote.clusterRoleBindings.subjectNamespace | default .Release.Namespace }}
+  {{- else }}
   name: {{ .Values.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
 {{- end }}

--- a/system/disco/templates/disco-manager-serviceaccount.yaml
+++ b/system/disco/templates/disco-manager-serviceaccount.yaml
@@ -1,4 +1,7 @@
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: disco-controller-manager
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/system/disco/templates/disco-manager-serviceaccount.yaml
+++ b/system/disco/templates/disco-manager-serviceaccount.yaml
@@ -3,5 +3,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccount.name }}
+  {{- if .Values.remote.enabled }}
+  namespace: {{ .Values.remote.serviceAccount.namespace | default .Release.Namespace }}
+  {{- else }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
 {{- end }}

--- a/system/disco/templates/disco-metrics-reader.yaml
+++ b/system/disco/templates/disco-metrics-reader.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -7,3 +8,4 @@ rules:
   - /metrics
   verbs:
   - get
+{{- end }}

--- a/system/disco/templates/disco-mutating-webhook-configuration.yaml
+++ b/system/disco/templates/disco-mutating-webhook-configuration.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.webhooks.enabled }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -25,3 +26,4 @@ webhooks:
     resources:
     - records
   sideEffects: None
+{{- end }}

--- a/system/disco/templates/disco-proxy-role.yaml
+++ b/system/disco/templates/disco-proxy-role.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -15,3 +16,4 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
+{{- end }}

--- a/system/disco/templates/disco-proxy-rolebinding.yaml
+++ b/system/disco/templates/disco-proxy-rolebinding.yaml
@@ -9,6 +9,11 @@ roleRef:
   name: disco-proxy-role
 subjects:
 - kind: ServiceAccount
+  {{- if .Values.remote.enabled }}
+  name: {{ .Values.remote.clusterRoleBindings.subjectName | default .Values.serviceAccount.name }}
+  namespace: {{ .Values.remote.clusterRoleBindings.subjectNamespace | default .Release.Namespace }}
+  {{- else }}
   name: {{ .Values.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
 {{- end }}

--- a/system/disco/templates/disco-proxy-rolebinding.yaml
+++ b/system/disco/templates/disco-proxy-rolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -8,5 +9,6 @@ roleRef:
   name: disco-proxy-role
 subjects:
 - kind: ServiceAccount
-  name: disco-controller-manager
+  name: {{ .Values.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/system/disco/templates/disco-selfsigned-issuer.yaml
+++ b/system/disco/templates/disco-selfsigned-issuer.yaml
@@ -1,6 +1,8 @@
+{{- if .Values.certManager.enabled }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: disco-selfsigned-issuer
 spec:
   selfSigned: {}
+{{- end }}

--- a/system/disco/templates/disco-serving-cert.yaml
+++ b/system/disco/templates/disco-serving-cert.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.certManager.enabled }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -10,3 +11,4 @@ spec:
     kind: Issuer
     name: disco-selfsigned-issuer
   secretName: tls-disco-webhook-service
+{{- end }}

--- a/system/disco/templates/disco-webhook-service.yaml
+++ b/system/disco/templates/disco-webhook-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.webhooks.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -9,3 +10,4 @@ spec:
     targetPort: 9443
   selector:
     app: disco
+{{- end }}

--- a/system/disco/templates/remote-kubeconfig.yaml
+++ b/system/disco/templates/remote-kubeconfig.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.remote.enable }}
+{{- if .Values.remote.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,8 +7,8 @@ metadata:
     resources.gardener.cloud/purpose: token-requestor
     resources.gardener.cloud/class: shoot
   annotations:
-    serviceaccount.resources.gardener.cloud/name: disco-controller-manager
-    serviceaccount.resources.gardener.cloud/namespace: kube-system
+    serviceaccount.resources.gardener.cloud/name: {{ .Values.serviceAccount.name }}
+    serviceaccount.resources.gardener.cloud/namespace: {{ .Values.remote.serviceAccount.namespace | default .Release.Namespace }}
     serviceaccount.resources.gardener.cloud/inject-ca-bundle: "true"
 stringData:
   token: ""

--- a/system/disco/templates/remote-kubeconfig.yaml
+++ b/system/disco/templates/remote-kubeconfig.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.remote.enable }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: disco-remote-kubeconfig
+  labels:
+    resources.gardener.cloud/purpose: token-requestor
+    resources.gardener.cloud/class: shoot
+  annotations:
+    serviceaccount.resources.gardener.cloud/name: disco-controller-manager
+    serviceaccount.resources.gardener.cloud/namespace: kube-system
+    serviceaccount.resources.gardener.cloud/inject-ca-bundle: "true"
+stringData:
+  token: ""
+  bundle.crt: ""
+{{- end }}

--- a/system/disco/tests/certmanager_test.yaml
+++ b/system/disco/tests/certmanager_test.yaml
@@ -1,0 +1,77 @@
+suite: selfsigned issuer
+templates:
+  - disco-selfsigned-issuer.yaml
+tests:
+  #############################################################################
+  # BASELINE TESTS - Verify current behavior
+  #############################################################################
+
+  - it: should render exactly one Issuer
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Issuer
+
+  - it: should be named disco-selfsigned-issuer
+    asserts:
+      - equal:
+          path: metadata.name
+          value: disco-selfsigned-issuer
+
+  - it: should be self-signed
+    asserts:
+      - isNotNull:
+          path: spec.selfSigned
+---
+suite: serving certificate
+templates:
+  - disco-serving-cert.yaml
+tests:
+  #############################################################################
+  # BASELINE TESTS - Verify current behavior
+  #############################################################################
+
+  - it: should render exactly one Certificate
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Certificate
+
+  - it: should be named disco-serving-cert
+    asserts:
+      - equal:
+          path: metadata.name
+          value: disco-serving-cert
+
+  - it: should reference the self-signed issuer
+    asserts:
+      - equal:
+          path: spec.issuerRef.name
+          value: disco-selfsigned-issuer
+      - equal:
+          path: spec.issuerRef.kind
+          value: Issuer
+
+  - it: should use tls-disco-webhook-service secret
+    asserts:
+      - equal:
+          path: spec.secretName
+          value: tls-disco-webhook-service
+---
+suite: certmanager disabled
+templates:
+  - disco-selfsigned-issuer.yaml
+  - disco-serving-cert.yaml
+tests:
+  - it: should not render cert-manager resources when certManager.enabled is false
+    set:
+      certManager.enabled: false
+    asserts:
+      - template: disco-selfsigned-issuer.yaml
+        hasDocuments:
+          count: 0
+      - template: disco-serving-cert.yaml
+        hasDocuments:
+          count: 0

--- a/system/disco/tests/config_test.yaml
+++ b/system/disco/tests/config_test.yaml
@@ -1,0 +1,83 @@
+suite: disco-config secret
+values:
+  - ../ci/test-values.yaml
+templates:
+  - disco-config.yaml
+tests:
+  #############################################################################
+  # BASELINE TESTS - Verify current behavior
+  #############################################################################
+
+  - it: should render exactly one Secret
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+
+  - it: should be named disco-config
+    asserts:
+      - equal:
+          path: metadata.name
+          value: disco-config
+
+  - it: should be Opaque type
+    asserts:
+      - equal:
+          path: type
+          value: Opaque
+
+  - it: should contain all required environment keys
+    asserts:
+      - isNotEmpty:
+          path: data.OS_AUTH_URL
+      - isNotEmpty:
+          path: data.OS_REGION_NAME
+      - isNotEmpty:
+          path: data.OS_USERNAME
+      - isNotEmpty:
+          path: data.OS_PASSWORD
+      - isNotEmpty:
+          path: data.OS_PROJECT_NAME
+      - isNotEmpty:
+          path: data.OS_PROJECT_DOMAIN_NAME
+      - isNotEmpty:
+          path: data.OS_USER_DOMAIN_NAME
+      - isNotEmpty:
+          path: data.DEFAULT_DNS_ZONE_NAME
+      - isNotEmpty:
+          path: data.DEFAULT_DNS_RECORD
+---
+suite: openstack seed
+values:
+  - ../ci/test-values.yaml
+templates:
+  - seed.yaml
+tests:
+  #############################################################################
+  # BASELINE TESTS - Verify current behavior
+  #############################################################################
+
+  - it: should not render by default
+    set:
+      seed.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render when seed is enabled
+    set:
+      seed.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: OpenstackSeed
+
+  - it: should be named disco-seed when enabled
+    set:
+      seed.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: disco-seed

--- a/system/disco/tests/deployment_test.yaml
+++ b/system/disco/tests/deployment_test.yaml
@@ -1,0 +1,251 @@
+# disco-config.yaml must be listed here because disco-controller-manager.yaml
+# uses `include` to compute a checksum of its rendered content at template time.
+# Assertions are scoped with `template:` to run only against the Deployment.
+suite: deployment
+values:
+  - ../ci/test-values.yaml
+templates:
+  - disco-controller-manager.yaml
+  - disco-config.yaml
+tests:
+  #############################################################################
+  # BASELINE TESTS - Verify current behavior
+  #############################################################################
+
+  - it: should render a Deployment
+    asserts:
+      - template: disco-controller-manager.yaml
+        isKind:
+          of: Deployment
+
+  - it: should use the default image
+    asserts:
+      - template: disco-controller-manager.yaml
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: keppel.global.cloud.sap/ccloud-ghcr-io-mirror/sapcc/disco:v2.0.0
+
+  - it: should have app=disco label on Deployment metadata
+    asserts:
+      - template: disco-controller-manager.yaml
+        equal:
+          path: metadata.labels.app
+          value: disco
+
+  - it: should have app=disco label on pod template
+    asserts:
+      - template: disco-controller-manager.yaml
+        equal:
+          path: spec.template.metadata.labels.app
+          value: disco
+
+  - it: should set controllerLabels on the Deployment when provided
+    set:
+      controllerLabels:
+        team: platform
+    asserts:
+      - template: disco-controller-manager.yaml
+        equal:
+          path: metadata.labels.team
+          value: platform
+      - template: disco-controller-manager.yaml
+        equal:
+          path: spec.template.metadata.labels.team
+          value: platform
+
+  - it: should use disco-controller-manager as service account
+    asserts:
+      - template: disco-controller-manager.yaml
+        equal:
+          path: spec.template.spec.serviceAccountName
+          value: disco-controller-manager
+
+  - it: should expose webhook-server port 9443
+    asserts:
+      - template: disco-controller-manager.yaml
+        contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            containerPort: 9443
+            name: webhook-server
+            protocol: TCP
+
+  - it: should expose https port 8080
+    asserts:
+      - template: disco-controller-manager.yaml
+        contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            containerPort: 8080
+            name: https
+            protocol: TCP
+
+  - it: should mount webhook cert volume
+    asserts:
+      - template: disco-controller-manager.yaml
+        contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /tmp/k8s-webhook-server/serving-certs
+            name: cert
+            readOnly: true
+
+  - it: should define webhook cert volume from secret
+    asserts:
+      - template: disco-controller-manager.yaml
+        contains:
+          path: spec.template.spec.volumes
+          content:
+            name: cert
+            secret:
+              defaultMode: 420
+              secretName: tls-disco-webhook-service
+
+  - it: should set checksum/config annotation on pod template
+    asserts:
+      - template: disco-controller-manager.yaml
+        isNotEmpty:
+          path: spec.template.metadata.annotations["checksum/config"]
+
+  - it: should have reloader annotation on Deployment metadata
+    asserts:
+      - template: disco-controller-manager.yaml
+        equal:
+          path: metadata.annotations["secret.reloader.stakater.com/reload"]
+          value: "disco-config"
+
+  - it: should get NAMESPACE from field reference
+    asserts:
+      - template: disco-controller-manager.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+
+  - it: should mount envFrom disco-config secret
+    asserts:
+      - template: disco-controller-manager.yaml
+        contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: disco-config
+
+  - it: should have liveness probe on /healthz
+    asserts:
+      - template: disco-controller-manager.yaml
+        equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /healthz
+
+  - it: should have readiness probe on /readyz
+    asserts:
+      - template: disco-controller-manager.yaml
+        equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /readyz
+
+  - it: should set allowPrivilegeEscalation false
+    asserts:
+      - template: disco-controller-manager.yaml
+        equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+
+  - it: should run as non-root
+    asserts:
+      - template: disco-controller-manager.yaml
+        equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+
+  #############################################################################
+  # NEW FEATURE TESTS
+  #############################################################################
+
+  - it: should not have reloader annotation when reloader.enabled is false
+    set:
+      reloader.enabled: false
+    asserts:
+      - template: disco-controller-manager.yaml
+        notExists:
+          path: metadata.annotations["secret.reloader.stakater.com/reload"]
+
+  - it: should not have webhook-server port when webhooks.enabled is false
+    set:
+      webhooks.enabled: false
+    asserts:
+      - template: disco-controller-manager.yaml
+        notContains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            containerPort: 9443
+            name: webhook-server
+            protocol: TCP
+
+  - it: should not mount webhook cert volume when webhooks.enabled is false
+    set:
+      webhooks.enabled: false
+    asserts:
+      - template: disco-controller-manager.yaml
+        notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /tmp/k8s-webhook-server/serving-certs
+            name: cert
+            readOnly: true
+
+  - it: should add Gardener network labels when remote.enable is true
+    set:
+      remote.enable: true
+      remote.apiServerHost: api.example.garden.cloud
+    asserts:
+      - template: disco-controller-manager.yaml
+        equal:
+          path: spec.template.metadata.labels["networking.gardener.cloud/to-shoot-apiserver"]
+          value: allowed
+      - template: disco-controller-manager.yaml
+        equal:
+          path: spec.template.metadata.labels["networking.resources.gardener.cloud/to-kube-apiserver-tcp-443"]
+          value: allowed
+
+  - it: should set KUBERNETES_SERVICE_HOST env when remote.enable is true
+    set:
+      remote.enable: true
+      remote.apiServerHost: api.example.garden.cloud
+    asserts:
+      - template: disco-controller-manager.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KUBERNETES_SERVICE_HOST
+            value: "api.example.garden.cloud"
+
+  - it: should set NAMESPACE from value when remote.enable is true
+    set:
+      remote.enable: true
+      remote.apiServerHost: api.example.garden.cloud
+      remote.leaderElectionNamespace: kube-system
+    asserts:
+      - template: disco-controller-manager.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NAMESPACE
+            value: "kube-system"
+
+  - it: should mount remote kubeconfig volume when remote.enable is true
+    set:
+      remote.enable: true
+      remote.apiServerHost: api.example.garden.cloud
+    asserts:
+      - template: disco-controller-manager.yaml
+        contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: remote-kubeconfig
+            mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            readOnly: true

--- a/system/disco/tests/deployment_test.yaml
+++ b/system/disco/tests/deployment_test.yaml
@@ -18,13 +18,6 @@ tests:
         isKind:
           of: Deployment
 
-  - it: should use the default image
-    asserts:
-      - template: disco-controller-manager.yaml
-        equal:
-          path: spec.template.spec.containers[0].image
-          value: keppel.global.cloud.sap/ccloud-ghcr-io-mirror/sapcc/disco:v2.0.0
-
   - it: should have app=disco label on Deployment metadata
     asserts:
       - template: disco-controller-manager.yaml
@@ -166,13 +159,15 @@ tests:
   # NEW FEATURE TESTS
   #############################################################################
 
-  - it: should not have reloader annotation when reloader.enabled is false
+  - it: should support custom deploymentAnnotations
     set:
-      reloader.enabled: false
+      deploymentAnnotations:
+        custom.annotation/key: "my-value"
     asserts:
       - template: disco-controller-manager.yaml
-        notExists:
-          path: metadata.annotations["secret.reloader.stakater.com/reload"]
+        equal:
+          path: metadata.annotations["custom.annotation/key"]
+          value: "my-value"
 
   - it: should not have webhook-server port when webhooks.enabled is false
     set:
@@ -198,9 +193,9 @@ tests:
             name: cert
             readOnly: true
 
-  - it: should add Gardener network labels when remote.enable is true
+  - it: should add Gardener network labels when remote.enabled is true
     set:
-      remote.enable: true
+      remote.enabled: true
       remote.apiServerHost: api.example.garden.cloud
     asserts:
       - template: disco-controller-manager.yaml
@@ -212,9 +207,9 @@ tests:
           path: spec.template.metadata.labels["networking.resources.gardener.cloud/to-kube-apiserver-tcp-443"]
           value: allowed
 
-  - it: should set KUBERNETES_SERVICE_HOST env when remote.enable is true
+  - it: should set KUBERNETES_SERVICE_HOST env when remote.enabled is true
     set:
-      remote.enable: true
+      remote.enabled: true
       remote.apiServerHost: api.example.garden.cloud
     asserts:
       - template: disco-controller-manager.yaml
@@ -224,9 +219,9 @@ tests:
             name: KUBERNETES_SERVICE_HOST
             value: "api.example.garden.cloud"
 
-  - it: should set NAMESPACE from value when remote.enable is true
+  - it: should set NAMESPACE from value when remote.enabled is true
     set:
-      remote.enable: true
+      remote.enabled: true
       remote.apiServerHost: api.example.garden.cloud
       remote.leaderElectionNamespace: kube-system
     asserts:
@@ -237,9 +232,9 @@ tests:
             name: NAMESPACE
             value: "kube-system"
 
-  - it: should mount remote kubeconfig volume when remote.enable is true
+  - it: should mount remote kubeconfig volume when remote.enabled is true
     set:
-      remote.enable: true
+      remote.enabled: true
       remote.apiServerHost: api.example.garden.cloud
     asserts:
       - template: disco-controller-manager.yaml

--- a/system/disco/tests/metrics_test.yaml
+++ b/system/disco/tests/metrics_test.yaml
@@ -1,0 +1,57 @@
+suite: metrics
+templates:
+  - disco-controller-manager-metrics-service.yaml
+tests:
+  #############################################################################
+  # BASELINE TESTS - Verify current behavior
+  #############################################################################
+
+  - it: should render the metrics Service
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+
+  - it: should have prometheus scrape annotation
+    asserts:
+      - equal:
+          path: metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+
+  - it: should set prometheus targets from values
+    asserts:
+      - equal:
+          path: metadata.annotations["prometheus.io/targets"]
+          value: kubernetes
+
+  - it: should expose port 8080 targeting https
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: metrics
+            port: 8080
+            protocol: TCP
+            targetPort: https
+
+  - it: should select app=disco pods
+    asserts:
+      - equal:
+          path: spec.selector.app
+          value: disco
+
+  - it: should respect custom prometheus target
+    set:
+      metrics.prometheus: my-prometheus
+    asserts:
+      - equal:
+          path: metadata.annotations["prometheus.io/targets"]
+          value: my-prometheus
+
+  - it: should not render metrics Service when metrics.enabled is false
+    set:
+      metrics.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/system/disco/tests/metrics_test.yaml
+++ b/system/disco/tests/metrics_test.yaml
@@ -25,13 +25,25 @@ tests:
           path: metadata.annotations["prometheus.io/targets"]
           value: kubernetes
 
-  - it: should expose port 8080 targeting https
+  - it: should expose metrics.port targeting https
     asserts:
       - contains:
           path: spec.ports
           content:
             name: metrics
             port: 8080
+            protocol: TCP
+            targetPort: https
+
+  - it: should use custom metrics.port when set
+    set:
+      metrics.port: 9092
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: metrics
+            port: 9092
             protocol: TCP
             targetPort: https
 

--- a/system/disco/tests/rbac_test.yaml
+++ b/system/disco/tests/rbac_test.yaml
@@ -25,6 +25,15 @@ tests:
       - equal:
           path: metadata.name
           value: disco-controller-manager
+
+  - it: should use remote.serviceAccount.namespace when remote.enabled is true
+    set:
+      remote.enabled: true
+      remote.serviceAccount.namespace: kube-system
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: kube-system
 ---
 suite: manager cluster role
 templates:
@@ -108,6 +117,24 @@ tests:
       - equal:
           path: subjects[0].kind
           value: ServiceAccount
+
+  - it: should use remote.clusterRoleBindings.subjectName when remote.enabled is true
+    set:
+      remote.enabled: true
+      remote.clusterRoleBindings.subjectName: custom-sa
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: custom-sa
+
+  - it: should use remote.clusterRoleBindings.subjectNamespace when remote.enabled is true
+    set:
+      remote.enabled: true
+      remote.clusterRoleBindings.subjectNamespace: kube-system
+    asserts:
+      - equal:
+          path: subjects[0].namespace
+          value: kube-system
 ---
 suite: leader election role
 templates:
@@ -129,6 +156,15 @@ tests:
       - equal:
           path: metadata.name
           value: disco-leader-election-role
+
+  - it: should use remote.role.namespace when remote.enabled is true
+    set:
+      remote.enabled: true
+      remote.role.namespace: kube-system
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: kube-system
 ---
 suite: leader election role binding
 templates:
@@ -156,6 +192,42 @@ tests:
       - equal:
           path: subjects[0].name
           value: disco-controller-manager
+
+  - it: should use remote.role.namespace for metadata when remote.enabled is true
+    set:
+      remote.enabled: true
+      remote.role.namespace: kube-system
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: kube-system
+
+  - it: should use remote.role.subjectName when remote.enabled is true
+    set:
+      remote.enabled: true
+      remote.role.subjectName: custom-sa
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: custom-sa
+
+  - it: should use remote.role.subjectNamespace when remote.enabled is true
+    set:
+      remote.enabled: true
+      remote.role.subjectNamespace: kube-system
+    asserts:
+      - equal:
+          path: subjects[0].namespace
+          value: kube-system
+
+  - it: should fall back subjects namespace to role.namespace when subjectNamespace not set
+    set:
+      remote.enabled: true
+      remote.role.namespace: kube-system
+    asserts:
+      - equal:
+          path: subjects[0].namespace
+          value: kube-system
 ---
 suite: proxy cluster role
 templates:
@@ -204,6 +276,24 @@ tests:
       - equal:
           path: subjects[0].name
           value: disco-controller-manager
+
+  - it: should use remote.clusterRoleBindings.subjectName when remote.enabled is true
+    set:
+      remote.enabled: true
+      remote.clusterRoleBindings.subjectName: custom-sa
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: custom-sa
+
+  - it: should use remote.clusterRoleBindings.subjectNamespace when remote.enabled is true
+    set:
+      remote.enabled: true
+      remote.clusterRoleBindings.subjectNamespace: kube-system
+    asserts:
+      - equal:
+          path: subjects[0].namespace
+          value: kube-system
 ---
 suite: metrics reader cluster role
 templates:

--- a/system/disco/tests/rbac_test.yaml
+++ b/system/disco/tests/rbac_test.yaml
@@ -1,0 +1,274 @@
+suite: service account
+templates:
+  - disco-manager-serviceaccount.yaml
+tests:
+  #############################################################################
+  # BASELINE TESTS - Verify current behavior
+  #############################################################################
+
+  - it: should not render ServiceAccount when serviceAccount.create is false
+    set:
+      serviceAccount.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render exactly one ServiceAccount
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceAccount
+
+  - it: should be named disco-controller-manager
+    asserts:
+      - equal:
+          path: metadata.name
+          value: disco-controller-manager
+---
+suite: manager cluster role
+templates:
+  - disco-manager-role.yaml
+tests:
+  #############################################################################
+  # BASELINE TESTS - Verify current behavior
+  #############################################################################
+
+  - it: should render exactly one ClusterRole
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ClusterRole
+
+  - it: should be named disco-manager-role
+    asserts:
+      - equal:
+          path: metadata.name
+          value: disco-manager-role
+
+  - it: should grant ingress read permissions
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - networking.k8s.io
+            resources:
+              - ingresses
+            verbs:
+              - get
+              - list
+              - watch
+
+  - it: should grant record CRUD permissions
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - disco.stable.sap.cc
+            resources:
+              - records
+            verbs:
+              - create
+              - delete
+              - get
+              - list
+              - patch
+              - update
+              - watch
+---
+suite: manager cluster role binding
+templates:
+  - disco-manager-rolebinding.yaml
+tests:
+  #############################################################################
+  # BASELINE TESTS - Verify current behavior
+  #############################################################################
+
+  - it: should render exactly one ClusterRoleBinding
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ClusterRoleBinding
+
+  - it: should be named disco-manager-rolebinding
+    asserts:
+      - equal:
+          path: metadata.name
+          value: disco-manager-rolebinding
+
+  - it: should bind disco-controller-manager service account
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: disco-controller-manager
+      - equal:
+          path: subjects[0].kind
+          value: ServiceAccount
+---
+suite: leader election role
+templates:
+  - disco-leader-election-role.yaml
+tests:
+  #############################################################################
+  # BASELINE TESTS - Verify current behavior
+  #############################################################################
+
+  - it: should render exactly one Role
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Role
+
+  - it: should be named disco-leader-election-role
+    asserts:
+      - equal:
+          path: metadata.name
+          value: disco-leader-election-role
+---
+suite: leader election role binding
+templates:
+  - disco-leader-election-rolebinding.yaml
+tests:
+  #############################################################################
+  # BASELINE TESTS - Verify current behavior
+  #############################################################################
+
+  - it: should render exactly one RoleBinding
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: RoleBinding
+
+  - it: should be named disco-leader-election-rolebinding
+    asserts:
+      - equal:
+          path: metadata.name
+          value: disco-leader-election-rolebinding
+
+  - it: should bind disco-controller-manager service account
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: disco-controller-manager
+---
+suite: proxy cluster role
+templates:
+  - disco-proxy-role.yaml
+tests:
+  #############################################################################
+  # BASELINE TESTS - Verify current behavior
+  #############################################################################
+
+  - it: should render exactly one ClusterRole
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ClusterRole
+
+  - it: should be named disco-proxy-role
+    asserts:
+      - equal:
+          path: metadata.name
+          value: disco-proxy-role
+---
+suite: proxy cluster role binding
+templates:
+  - disco-proxy-rolebinding.yaml
+tests:
+  #############################################################################
+  # BASELINE TESTS - Verify current behavior
+  #############################################################################
+
+  - it: should render exactly one ClusterRoleBinding
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ClusterRoleBinding
+
+  - it: should be named disco-proxy-rolebinding
+    asserts:
+      - equal:
+          path: metadata.name
+          value: disco-proxy-rolebinding
+
+  - it: should bind disco-controller-manager service account
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: disco-controller-manager
+---
+suite: metrics reader cluster role
+templates:
+  - disco-metrics-reader.yaml
+tests:
+  #############################################################################
+  # BASELINE TESTS - Verify current behavior
+  #############################################################################
+
+  - it: should render exactly one ClusterRole
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ClusterRole
+
+  - it: should be named disco-metrics-reader
+    asserts:
+      - equal:
+          path: metadata.name
+          value: disco-metrics-reader
+
+  - it: should grant /metrics read access
+    asserts:
+      - contains:
+          path: rules
+          content:
+            nonResourceURLs:
+              - /metrics
+            verbs:
+              - get
+
+---
+suite: rbac disabled
+templates:
+  - disco-manager-role.yaml
+  - disco-manager-rolebinding.yaml
+  - disco-leader-election-role.yaml
+  - disco-leader-election-rolebinding.yaml
+  - disco-proxy-role.yaml
+  - disco-proxy-rolebinding.yaml
+  - disco-metrics-reader.yaml
+tests:
+  - it: should not render any RBAC resources when rbac.create is false
+    set:
+      rbac.create: false
+    asserts:
+      - template: disco-manager-role.yaml
+        hasDocuments:
+          count: 0
+      - template: disco-manager-rolebinding.yaml
+        hasDocuments:
+          count: 0
+      - template: disco-leader-election-role.yaml
+        hasDocuments:
+          count: 0
+      - template: disco-leader-election-rolebinding.yaml
+        hasDocuments:
+          count: 0
+      - template: disco-proxy-role.yaml
+        hasDocuments:
+          count: 0
+      - template: disco-proxy-rolebinding.yaml
+        hasDocuments:
+          count: 0
+      - template: disco-metrics-reader.yaml
+        hasDocuments:
+          count: 0

--- a/system/disco/tests/remote_test.yaml
+++ b/system/disco/tests/remote_test.yaml
@@ -1,0 +1,27 @@
+suite: remote kubeconfig
+templates:
+  - remote-kubeconfig.yaml
+tests:
+  - it: should not render remote kubeconfig Secret by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render remote kubeconfig Secret when remote.enable is true
+    set:
+      remote.enable: true
+      remote.apiServerHost: api.example.garden.cloud
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: disco-remote-kubeconfig
+      - equal:
+          path: metadata.labels["resources.gardener.cloud/purpose"]
+          value: token-requestor
+      - equal:
+          path: metadata.labels["resources.gardener.cloud/class"]
+          value: shoot

--- a/system/disco/tests/remote_test.yaml
+++ b/system/disco/tests/remote_test.yaml
@@ -7,9 +7,9 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: should render remote kubeconfig Secret when remote.enable is true
+  - it: should render remote kubeconfig Secret when remote.enabled is true
     set:
-      remote.enable: true
+      remote.enabled: true
       remote.apiServerHost: api.example.garden.cloud
     asserts:
       - hasDocuments:
@@ -25,3 +25,12 @@ tests:
       - equal:
           path: metadata.labels["resources.gardener.cloud/class"]
           value: shoot
+
+  - it: should use remote.serviceAccount.namespace in Gardener SA annotation
+    set:
+      remote.enabled: true
+      remote.serviceAccount.namespace: kube-system
+    asserts:
+      - equal:
+          path: metadata.annotations["serviceaccount.resources.gardener.cloud/namespace"]
+          value: kube-system

--- a/system/disco/tests/webhook_test.yaml
+++ b/system/disco/tests/webhook_test.yaml
@@ -1,0 +1,86 @@
+suite: webhook service
+templates:
+  - disco-webhook-service.yaml
+tests:
+  #############################################################################
+  # BASELINE TESTS - Verify current behavior
+  #############################################################################
+
+  - it: should render exactly one Service
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+
+  - it: should be named disco-webhook-service
+    asserts:
+      - equal:
+          path: metadata.name
+          value: disco-webhook-service
+
+  - it: should expose port 443 targeting 9443
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            port: 443
+            protocol: TCP
+            targetPort: 9443
+
+  - it: should select app=disco pods
+    asserts:
+      - equal:
+          path: spec.selector.app
+          value: disco
+---
+suite: mutating webhook configuration
+templates:
+  - disco-mutating-webhook-configuration.yaml
+tests:
+  #############################################################################
+  # BASELINE TESTS - Verify current behavior
+  #############################################################################
+
+  - it: should render exactly one MutatingWebhookConfiguration
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: MutatingWebhookConfiguration
+
+  - it: should be named disco-mutating-webhook-configuration
+    asserts:
+      - equal:
+          path: metadata.name
+          value: disco-mutating-webhook-configuration
+
+  - it: should have cert-manager inject annotation
+    asserts:
+      - isNotEmpty:
+          path: metadata.annotations["cert-manager.io/inject-ca-from"]
+
+  - it: should target record resources in disco.stable.sap.cc
+    asserts:
+      - equal:
+          path: webhooks[0].rules[0].resources[0]
+          value: records
+      - equal:
+          path: webhooks[0].rules[0].apiGroups[0]
+          value: disco.stable.sap.cc
+---
+suite: webhooks disabled
+templates:
+  - disco-webhook-service.yaml
+  - disco-mutating-webhook-configuration.yaml
+tests:
+  - it: should not render webhook resources when webhooks.enabled is false
+    set:
+      webhooks.enabled: false
+    asserts:
+      - template: disco-webhook-service.yaml
+        hasDocuments:
+          count: 0
+      - template: disco-mutating-webhook-configuration.yaml
+        hasDocuments:
+          count: 0

--- a/system/disco/values.yaml
+++ b/system/disco/values.yaml
@@ -5,14 +5,30 @@ image:
 # Remote Kubernetes cluster configuration (for Gardener token-requestor)
 remote:
   # Enable remote kubeconfig mounting for connecting to a remote Kubernetes cluster
-  enable: false
-  # API server host for the remote cluster (required when enable: true)
+  enabled: false
+  # API server host for the remote cluster (required when enabled: true)
   # Example: api.my-shoot.cp.internal.garden.example.com
   apiServerHost: ""
   # API server port for the remote cluster (defaults to 443)
   apiServerPort: "443"
   # Namespace for leader election on the remote cluster (where RBAC is configured)
   leaderElectionNamespace: kube-system
+  # Namespace and subject overrides for RBAC resources (only applied when enabled: true)
+  serviceAccount:
+    # Override metadata.namespace for the ServiceAccount (defaults to Release.Namespace)
+    namespace: ""
+  role:
+    # Override metadata.namespace for the leader-election Role and RoleBinding (defaults to Release.Namespace)
+    namespace: ""
+    # Override subjects[].name in the leader-election RoleBinding (defaults to serviceAccount.name)
+    subjectName: ""
+    # Override subjects[].namespace in the leader-election RoleBinding (defaults to role.namespace then Release.Namespace)
+    subjectNamespace: ""
+  clusterRoleBindings:
+    # Override subjects[].name in ClusterRoleBindings (defaults to serviceAccount.name)
+    subjectName: ""
+    # Override subjects[].namespace in ClusterRoleBindings (defaults to Release.Namespace)
+    subjectNamespace: ""
 
 # These labels will be set on the DISCO controller manager
 controllerLabels: {}
@@ -49,7 +65,7 @@ metrics:
   # Create the metrics service
   enabled: true
   # Port to expose metrics on.
-  port: 9091
+  port: 8080
   # Name of the Prometheis by which the metrics will be scraped.
   # Can be a comma (,) separated list.
   prometheus: kubernetes
@@ -57,6 +73,11 @@ metrics:
 # Reload the controller manager when the disco-config secret changes.
 reloader:
   enabled: true
+
+# Annotations for the Deployment metadata.
+# By default, triggers a rolling restart when the disco-config secret changes.
+deploymentAnnotations:
+  secret.reloader.stakater.com/reload: "disco-config"
 
 # Credentials of the service user who creates the recordsets in OpenStack Designate.
 openstack: {}

--- a/system/disco/values.yaml
+++ b/system/disco/values.yaml
@@ -2,6 +2,18 @@ image:
   repository: keppel.global.cloud.sap/ccloud-ghcr-io-mirror/sapcc/disco
   tag: v2.0.0
 
+# Remote Kubernetes cluster configuration (for Gardener token-requestor)
+remote:
+  # Enable remote kubeconfig mounting for connecting to a remote Kubernetes cluster
+  enable: false
+  # API server host for the remote cluster (required when enable: true)
+  # Example: api.my-shoot.cp.internal.garden.example.com
+  apiServerHost: ""
+  # API server port for the remote cluster (defaults to 443)
+  apiServerPort: "443"
+  # Namespace for leader election on the remote cluster (where RBAC is configured)
+  leaderElectionNamespace: kube-system
+
 # These labels will be set on the DISCO controller manager
 controllerLabels: {}
 
@@ -13,8 +25,38 @@ seed:
   enabled: false
 
 rbac:
+  # Create RBAC resources (ClusterRoles, ClusterRoleBindings, Roles, RoleBindings)
   create: true
-  serviceAccountName: disco
+
+serviceAccount:
+  # Create the service account
+  create: true
+  # Name of the service account to use (if create is false, this must be an existing service account)
+  name: disco-controller-manager
+
+# Cert-manager resources for webhook TLS certificates
+certManager:
+  # Create cert-manager Issuer and Certificate resources
+  enabled: true
+
+# Webhook configuration for Record validation
+webhooks:
+  # Create webhook service and MutatingWebhookConfiguration
+  enabled: true
+
+# Metrics service for Prometheus scraping
+metrics:
+  # Create the metrics service
+  enabled: true
+  # Port to expose metrics on.
+  port: 9091
+  # Name of the Prometheis by which the metrics will be scraped.
+  # Can be a comma (,) separated list.
+  prometheus: kubernetes
+
+# Reload the controller manager when the disco-config secret changes.
+reloader:
+  enabled: true
 
 # Credentials of the service user who creates the recordsets in OpenStack Designate.
 openstack: {}
@@ -30,14 +72,6 @@ openstack: {}
 
 # Record which should be used. e.g.: 'ingress.domain.tld.'. Must be provided.
 # record: DEFINED-IN-SECRETS
-
-# Prometheus metrics.
-metrics:
-  # Port to expose metrics on.
-  port: 9091
-  # Name of the Prometheis by which the metrics will be scraped.
-  # Can be a comma (,) separated list.
-  prometheus: kubernetes
 
 # The resources provide boundaries for the VPA, by which the actual resource requirements are configured based on usage.
 resources:


### PR DESCRIPTION
## Adding remote cluster capability to the disco operator

This PR adds optional support for running the disco operator against a **remote Kubernetes cluster** via Gardener's token-requestor mechanism, while keeping all existing behaviour as the default.

### What it does

When `remote.enabled: true`, the chart configures disco to connect to a remote cluster rather than its own in-cluster API server:

- Creates a `disco-remote-kubeconfig` Secret annotated for Gardener's token-requestor to inject a kubeconfig and CA bundle for the target shoot cluster
- Mounts that secret into the controller pod at `/var/run/secrets/kubernetes.io/serviceaccount`, overriding the default in-cluster credentials
- Sets `KUBERNETES_SERVICE_HOST` / `KUBERNETES_SERVICE_PORT` env vars to point the operator at the remote API server
- Adds the required Gardener network policy labels to the pod so egress to the shoot API server is permitted
- Pins `NAMESPACE` to `remote.leaderElectionNamespace` (default: `kube-system`) instead of deriving it from the pod's own namespace

RBAC resources gain namespace and subject overrides for cross-cluster scenarios where the ServiceAccount, Roles, and ClusterRoleBindings may need to reference subjects in a different namespace or under a different name than the release namespace.

### Backwards compatibility

`remote.enabled` defaults to `false`. With remote disabled, all rendered resources are functionally identical to the previous version of the chart — no new objects are created and the operator behaviour is unchanged.
