### PR TITLE
[Nova] Change consoel pathType to ImplementationSpecific

### DIFF
--- a/openstack/nova/templates/console-ingress.yaml
+++ b/openstack/nova/templates/console-ingress.yaml
@@ -32,7 +32,7 @@ spec:
           {{- if $config.enabled }}
             {{- $name := print $cellName "-" $type }}
       - path: /{{ $cellName }}/{{ $type }}/?(.*)
-        pathType: Prefix
+        pathType: ImplementationSpecific
         backend:
           service:
             name: nova-console-{{ $name }}


### PR DESCRIPTION
We had "Prefix" there and it works in production regions, but is actually not the right thing according to docs [0]. The mentioned validation seems active in new regions and thus not having `pathType` set to `ImplementationSpecific` prohibits Nova deployments.

[0] https://github.com/kubernetes/ingress-nginx/blob/main/docs/faq.md#validation-of-path