### PR TITLE
[Aurora] Add CEPH_REGION env var 

### DIFF
--- a/openstack/aurora/templates/deployment.yaml
+++ b/openstack/aurora/templates/deployment.yaml
@@ -47,7 +47,10 @@ spec:
             - name: PORT
               value: "3000"
             - name: IDENTITY_ENDPOINT
+              # prettier-ignore
               value: {{ .Values.identity_endpoint | default (printf "http://keystone.monsoon3.svc.kubernetes.%s.%s:5000/v3" .Values.global.region .Values.global.tld) | quote }}
+            - name: CEPH_REGION
+              value: {{ .Values.ceph_region | quote }}
           livenessProbe:
             httpGet:
               path: /

--- a/openstack/aurora/templates/deployment.yaml
+++ b/openstack/aurora/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
               value: "3000"
             - name: IDENTITY_ENDPOINT
               # prettier-ignore
-              value: {{ .Values.identity_endpoint | default (printf "http://keystone.monsoon3.svc.kubernetes.%s.%s:5000/v3" .Values.global.region .Values.global.tld) | quote }}
+              value: {{ .Values.identity_endpoint | default (printf "https://identity-3.%s.%s/v3" .Values.global.region .Values.global.tld) | quote }}
             - name: CEPH_REGION
               value: {{ .Values.ceph_region | quote }}
           livenessProbe:

--- a/openstack/aurora/values.yaml
+++ b/openstack/aurora/values.yaml
@@ -25,5 +25,7 @@ owner-info:
 # Ensure ingress is defined so templates can access .Values.ingress.host
 ingress: {}
 
+ceph_region: ""
+
 prPreview:
   enabled: false

--- a/openstack/aurora/values.yaml
+++ b/openstack/aurora/values.yaml
@@ -18,7 +18,7 @@ owner-info:
     - Andreas Pfau
 
 # Optional overrides - if not set, defaults are generated from global.region and global.tld
-# identity_endpoint: "http://custom-endpoint:5000/v3"  # Defaults to: http://keystone.monsoon3.svc.kubernetes.{region}.{tld}:5000/v3
+# identity_endpoint: "http://custom-endpoint:5000/v3"  # Defaults to: https://identity-3.{region}.{tld}/v3
 # ingress:
 #   host: "custom-host.example.com"  # Defaults to: dashboard-aurora.{region}.{tld}
 


### PR DESCRIPTION
# [Aurora] Add CEPH_REGION environment variable

- Adds `CEPH_REGION` env var to the aurora deployment, sourced from a new `ceph_region` value key
- Adds `ceph_region: ""` to `values.yaml` as an empty default 
