### PR TITLE
[maia]remove node select in maia deployment

### DIFF
--- a/openstack/maia/templates/maia-deployment.yaml
+++ b/openstack/maia/templates/maia-deployment.yaml
@@ -30,8 +30,6 @@ spec:
         secret.reloader.stakater.com/reload: "maia-api-secret"
         deployment.reloader.stakater.com/pause-period: "60s"
     spec:
-      nodeSelector:
-        zone: farm
       volumes:
         - name: maia-etc
           secret:


### PR DESCRIPTION
the nodeselector is not needed. And this is block eu-de-3.