### PR TITLE
[nova-hypervisor-agents] Remove deprecated nfs_mount_options flag

### DIFF
--- a/openstack/nova-hypervisor-agents/Chart.yaml
+++ b/openstack/nova-hypervisor-agents/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart Nova hypervisor agents
 name: nova-hypervisor-agents
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Nova/OpenStack_Project_Nova_mascot.png
-version: 0.2.1
+version: 0.2.2
 appVersion: "bobcat"
 dependencies:
 - name: utils

--- a/openstack/nova-hypervisor-agents/values.yaml
+++ b/openstack/nova-hypervisor-agents/values.yaml
@@ -84,7 +84,7 @@ defaults:
           live_migration_scheme: "tls"
           live_migration_timeout_action: 'force_complete'
           live_migration_with_native_tls: 'true'
-          nfs_mount_options: "rw,bg,nfsvers=4.2,hard,nointr,proto=tcp,timeo=600,nconnect=8,retrans=2,rsize=262144,wsize=262144,noatime,actimeo=0,lookupcache=pos"
+          nfs_mount_options: "rw,bg,nfsvers=4.2,hard,proto=tcp,timeo=600,nconnect=8,retrans=2,rsize=262144,wsize=262144,noatime,actimeo=0,lookupcache=pos"
           num_umount_retries: "30"
           rng_dev_path: /dev/random
           smbios_asset_tag: "SAP CCloud VM"


### PR DESCRIPTION
nointr is deprecated after kernel 2.6.25. Thus this removes the flag to
get rid of the deprecation warnings. Check man (5) nfs for more details.
