### PR TITLE
[persephone-liquid-apiserver] fix probes to use /healthcheck endpoint

### DIFF
--- a/global/persephone-liquid-apiserver/values.yaml
+++ b/global/persephone-liquid-apiserver/values.yaml
@@ -130,7 +130,7 @@ affinity:
 # Liveness and readiness probes
 livenessProbe:
   httpGet:
-    path: /v1/info
+    path: /healthcheck
     port: http
   initialDelaySeconds: 30
   periodSeconds: 10
@@ -139,7 +139,7 @@ livenessProbe:
 
 readinessProbe:
   httpGet:
-    path: /v1/info
+    path: /healthcheck
     port: http
   initialDelaySeconds: 10
   periodSeconds: 5


### PR DESCRIPTION
## Summary

- Fix liveness and readiness probes to use `/healthcheck` instead of `/v1/info`