### PR TITLE
[volume-claims] Add Nova eu-de-3 cell claims

### DIFF
--- a/openstack/volume-claims/Chart.yaml
+++ b/openstack/volume-claims/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes
 name: volume-claims
-version: 0.1.3
+version: 0.1.4
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/volume-claims/templates/db-nova-cell1-pvc.yaml
+++ b/openstack/volume-claims/templates/db-nova-cell1-pvc.yaml
@@ -1,13 +1,13 @@
 {{- $region := .Values.global.region | required ".Values.global.region missing" }}
-{{- $ignoreRegions := list
-  "eu-de-3"
+{{- $storageRequests := dict
+  "eu-de-3" "100Gi"
 }}
-{{- if not (has $region $ignoreRegions) }}
+{{- if hasKey $storageRequests $region }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: db-nova-pvc
+  name: db-nova-cell1-pvc
   labels:
     ccloud/support-group: compute-storage-api
     ccloud/service: nova
@@ -16,6 +16,5 @@ spec:
   - {{ include "volume-claims.accessMode" . }}
   resources:
     requests:
-      {{- $region := .Values.global.region | required ".Values.global.region missing" }}
-      storage: {{ if $region | regexMatch "^(?:ap-au-1|eu-de-[12]|eu-nl-1|na-us-1)$" -}} 100Gi {{- else -}} 50Gi {{- end }}
+      storage: {{ get $storageRequests $region }}
 {{- end }}

--- a/openstack/volume-claims/templates/db-nova-cell2-pvc.yaml
+++ b/openstack/volume-claims/templates/db-nova-cell2-pvc.yaml
@@ -2,6 +2,7 @@
 {{- $storageRequests := dict
   "ap-jp-1" "50Gi"
   "eu-de-1" "100Gi"
+  "eu-de-3" "50Gi"
   "na-us-1" "100Gi"
   "qa-de-1" "50Gi"
 }}

--- a/openstack/volume-claims/templates/db-nova-cell3-pvc.yaml
+++ b/openstack/volume-claims/templates/db-nova-cell3-pvc.yaml
@@ -1,5 +1,6 @@
 {{- $region := .Values.global.region | required ".Values.global.region missing" }}
 {{- $storageRequests := dict
+  "eu-de-3" "50Gi"
   "qa-de-1" "50Gi"
 }}
 {{- if hasKey $storageRequests $region }}


### PR DESCRIPTION
In eu-de-3, we have 3 cells and need pvcs for them. Additionally, we switched from the old default `nova-db-pvc` to `nova-db-cell1-pvc` for the cell1 DB to make the names clearer with wanting a cell per AZ. That's why we disable the `nova-db-pvc` in `eu-de-3`.