### PR TITLE
feat(persephone-liquid-apiserver): add ingress template

### DIFF
--- a/global/persephone-liquid-apiserver/Chart.yaml
+++ b/global/persephone-liquid-apiserver/Chart.yaml
@@ -6,7 +6,7 @@ apiVersion: v2
 name: persephone-liquid-apiserver
 description: Persephone Liquid API Server for managing Gardener shoot cluster quotas via Limes
 type: application
-version: 1.0.3
+version: 1.0.4
 appVersion: "1.0.0"
 keywords:
   - persephone

--- a/global/persephone-liquid-apiserver/ci/test-values.yaml
+++ b/global/persephone-liquid-apiserver/ci/test-values.yaml
@@ -14,7 +14,6 @@ openstack:
 
 ingress:
   enabled: true
-  className: nginx-external
   hosts:
     - host: persephone-liquid.test-region-1.cloud.sap
       paths:

--- a/global/persephone-liquid-apiserver/ci/test-values.yaml
+++ b/global/persephone-liquid-apiserver/ci/test-values.yaml
@@ -11,3 +11,16 @@ virtualGarden:
 
 openstack:
   authURL: https://keystone.test.example.com/v3
+
+ingress:
+  enabled: true
+  className: nginx-external
+  hosts:
+    - host: persephone-liquid.test-region-1.cloud.sap
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - hosts:
+        - persephone-liquid.test-region-1.cloud.sap
+      secretName: persephone-liquid-apiserver-tls

--- a/global/persephone-liquid-apiserver/templates/ingress.yaml
+++ b/global/persephone-liquid-apiserver/templates/ingress.yaml
@@ -10,10 +10,11 @@ metadata:
   name: {{ include "persephone-liquid-apiserver.fullname" . }}
   labels:
     {{- include "persephone-liquid-apiserver.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
   annotations:
+    kubernetes.io/tls-acme: "true"
+    {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 spec:
   {{- with .Values.ingress.className }}
   ingressClassName: {{ . }}

--- a/global/persephone-liquid-apiserver/templates/ingress.yaml
+++ b/global/persephone-liquid-apiserver/templates/ingress.yaml
@@ -1,0 +1,40 @@
+{{/*
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+
+SPDX-License-Identifier: Apache-2.0
+*/}}
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "persephone-liquid-apiserver.fullname" . }}
+  labels:
+    {{- include "persephone-liquid-apiserver.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "persephone-liquid-apiserver.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/global/persephone-liquid-apiserver/templates/ingress.yaml
+++ b/global/persephone-liquid-apiserver/templates/ingress.yaml
@@ -16,9 +16,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- with .Values.ingress.className }}
-  ingressClassName: {{ . }}
-  {{- end }}
+  ingressClassName: nginx
   {{- with .Values.ingress.tls }}
   tls:
     {{- toYaml . | nindent 4 }}

--- a/global/persephone-liquid-apiserver/values.yaml
+++ b/global/persephone-liquid-apiserver/values.yaml
@@ -95,7 +95,16 @@ ingress:
   enabled: false
   className: ""
   annotations: {}
+  # hosts:
+  #   - host: persephone-liquid.eu-de-1.cloud.sap
+  #     paths:
+  #       - path: /
+  #         pathType: Prefix
   hosts: []
+  # tls:
+  #   - hosts:
+  #       - persephone-liquid.eu-de-1.cloud.sap
+  #     secretName: persephone-liquid-apiserver-tls
   tls: []
 
 resources:

--- a/global/persephone-liquid-apiserver/values.yaml
+++ b/global/persephone-liquid-apiserver/values.yaml
@@ -93,7 +93,6 @@ service:
 
 ingress:
   enabled: false
-  className: ""
   annotations: {}
   # hosts:
   #   - host: persephone-liquid.eu-de-1.cloud.sap


### PR DESCRIPTION
## Summary

- Adds `templates/ingress.yaml` — a standard Kubernetes Ingress resource, gated on `ingress.enabled`
- The hostname is set directly in the deploying values file (no shared template helper), allowing each landscape (canary/prod) per region to define its own DNS name independently
- Updated `values.yaml` with commented examples showing the expected host/path/TLS structure
- Updated `ci/test-values.yaml` to exercise the ingress template in CI

## Test plan

- [ ] `helm template` renders the Ingress when `ingress.enabled: true`
- [ ] No Ingress resource is rendered when `ingress.enabled: false` (default)
- [ ] CI lint passes with the updated test values