### PR TITLE
opensearch logs: pin resouce.* and attributes.* strings to keyword.

### DIFF
--- a/system/opensearch-logs/templates/config/_ds.json.tpl
+++ b/system/opensearch-logs/templates/config/_ds.json.tpl
@@ -9,6 +9,30 @@
       "index.append_only.enabled": true,
       "index.refresh_interval": "60s"
     },
+    "mappings": {
+      "dynamic_templates": [
+        {
+          "resource_strings_as_keyword": {
+            "path_match": "resource.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
+        {
+          "attributes_strings_as_keyword": {
+            "path_match": "attributes.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        }
+      ]
+    },
     "aliases": {
       "_DS_NAME_-ds": {}
     }


### PR DESCRIPTION
The generic data-stream index template had no mappings block, so every backing index fell through to dynamic mapping. This is non-deterministic across rollovers. Fields like resource.k8s.namespace.name sometimes landed as `text` with no `.keyword` subfield, breaking Painless scripts and aggregations with illegal_argument_exception ("Fielddata is disabled on text fields by default").

This fixes it with a dynamic_template. Existing broken indexes will age out. 