### PR TITLE
refactor: extract shared filter logic in metal-settings

### DIFF
--- a/system/metal-settings/Chart.yaml
+++ b/system/metal-settings/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.5
+version: 0.2.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/system/metal-settings/templates/_helpers.tpl
+++ b/system/metal-settings/templates/_helpers.tpl
@@ -60,3 +60,24 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Generic filter check: determines if an item should be included based on included/excluded lists
+Returns: "true" if item should be included, "" (empty string) otherwise
+
+Usage:
+  {{- if include "metal-settings.shouldInclude" (dict "item" $vendor "filters" $.Values.biosSettings.filters.vendors) }}
+
+Filter Logic:
+  - If filters.included is empty/nil: include all items (unless explicitly excluded)
+  - If filters.included has values: only include items in that list
+  - If filters.excluded has values: exclude those items (takes precedence over included)
+  - If item appears in both included and excluded: excluded wins
+*/}}
+{{- define "metal-settings.shouldInclude" -}}
+{{- $included := or (not .filters.included) (has .item .filters.included) -}}
+{{- $excluded := and .filters.excluded (has .item .filters.excluded) -}}
+{{- if and $included (not $excluded) -}}
+true
+{{- end -}}
+{{- end -}}

--- a/system/metal-settings/templates/bios_settings.yaml
+++ b/system/metal-settings/templates/bios_settings.yaml
@@ -3,31 +3,18 @@
 {{- if $vendorConfig }}
 
 {{/* Vendor filtering */}}
-{{- $vendorIncluded := or (not $.Values.biosSettings.filters.vendors.included) (has $vendor $.Values.biosSettings.filters.vendors.included) }}
-{{- $vendorExcluded := and $.Values.biosSettings.filters.vendors.excluded (has $vendor $.Values.biosSettings.filters.vendors.excluded) }}
-
-{{- if and $vendorIncluded (not $vendorExcluded) }}
+{{- if include "metal-settings.shouldInclude" (dict "item" $vendor "filters" $.Values.biosSettings.filters.vendors) }}
 {{- range $entry := $vendorConfig.models }}
 {{- if and $entry.clusterTypes $entry.bios $entry.bios.settingsFileName }}
 {{- $model := $entry.model }}
 {{- $version := $entry.bios.version }}
 
-{{/* Model filtering */}}
-{{- $modelIncluded := or (not $.Values.biosSettings.filters.models.included) (has $model $.Values.biosSettings.filters.models.included) }}
-{{- $modelExcluded := and $.Values.biosSettings.filters.models.excluded (has $model $.Values.biosSettings.filters.models.excluded) }}
-
-{{/* Version filtering */}}
-{{- $versionIncluded := or (not $.Values.biosSettings.filters.versions.included) (has $version $.Values.biosSettings.filters.versions.included) }}
-{{- $versionExcluded := and $.Values.biosSettings.filters.versions.excluded (has $version $.Values.biosSettings.filters.versions.excluded) }}
-
-{{- if and $modelIncluded (not $modelExcluded) $versionIncluded (not $versionExcluded) }}
+{{/* Model and Version filtering */}}
+{{- if and (include "metal-settings.shouldInclude" (dict "item" $model "filters" $.Values.biosSettings.filters.models)) (include "metal-settings.shouldInclude" (dict "item" $version "filters" $.Values.biosSettings.filters.versions)) }}
 {{- range $clusterType := $entry.clusterTypes }}
 
 {{/* ClusterType filtering */}}
-{{- $clusterTypeIncluded := or (not $.Values.biosSettings.filters.clusterTypes.included) (has $clusterType $.Values.biosSettings.filters.clusterTypes.included) }}
-{{- $clusterTypeExcluded := and $.Values.biosSettings.filters.clusterTypes.excluded (has $clusterType $.Values.biosSettings.filters.clusterTypes.excluded) }}
-
-{{- if and $clusterTypeIncluded (not $clusterTypeExcluded) }}
+{{- if include "metal-settings.shouldInclude" (dict "item" $clusterType "filters" $.Values.biosSettings.filters.clusterTypes) }}
 apiVersion: metal.ironcore.dev/v1alpha1
 kind: BIOSSettingsSet
 metadata:

--- a/system/metal-settings/templates/bios_versions.yaml
+++ b/system/metal-settings/templates/bios_versions.yaml
@@ -3,10 +3,7 @@
 {{- if $vendorConfig }}
 
 {{/* Vendor filtering */}}
-{{- $vendorIncluded := or (not $.Values.biosVersions.filters.vendors.included) (has $vendor $.Values.biosVersions.filters.vendors.included) }}
-{{- $vendorExcluded := and $.Values.biosVersions.filters.vendors.excluded (has $vendor $.Values.biosVersions.filters.vendors.excluded) }}
-
-{{- if and $vendorIncluded (not $vendorExcluded) }}
+{{- if include "metal-settings.shouldInclude" (dict "item" $vendor "filters" $.Values.biosVersions.filters.vendors) }}
 {{- $processedModels := dict }}
 {{- range $entry := $vendorConfig.models }}
 {{- if $entry.bios }}
@@ -18,15 +15,8 @@
 {{- if not (hasKey $processedModels $modelKey) }}
 {{- $_ := set $processedModels $modelKey true }}
 
-{{/* Model filtering */}}
-{{- $modelIncluded := or (not $.Values.biosVersions.filters.models.included) (has $model $.Values.biosVersions.filters.models.included) }}
-{{- $modelExcluded := and $.Values.biosVersions.filters.models.excluded (has $model $.Values.biosVersions.filters.models.excluded) }}
-
-{{/* Version filtering */}}
-{{- $versionIncluded := or (not $.Values.biosVersions.filters.versions.included) (has $version $.Values.biosVersions.filters.versions.included) }}
-{{- $versionExcluded := and $.Values.biosVersions.filters.versions.excluded (has $version $.Values.biosVersions.filters.versions.excluded) }}
-
-{{- if and $modelIncluded (not $modelExcluded) $versionIncluded (not $versionExcluded) }}
+{{/* Model and Version filtering */}}
+{{- if and (include "metal-settings.shouldInclude" (dict "item" $model "filters" $.Values.biosVersions.filters.models)) (include "metal-settings.shouldInclude" (dict "item" $version "filters" $.Values.biosVersions.filters.versions)) }}
 apiVersion: metal.ironcore.dev/v1alpha1
 kind: BIOSVersionSet
 metadata:

--- a/system/metal-settings/templates/bmc_settings.yaml
+++ b/system/metal-settings/templates/bmc_settings.yaml
@@ -3,31 +3,18 @@
 {{- if $vendorConfig }}
 
 {{/* Vendor filtering */}}
-{{- $vendorIncluded := or (not $.Values.bmcSettings.filters.vendors.included) (has $vendor $.Values.bmcSettings.filters.vendors.included) }}
-{{- $vendorExcluded := and $.Values.bmcSettings.filters.vendors.excluded (has $vendor $.Values.bmcSettings.filters.vendors.excluded) }}
-
-{{- if and $vendorIncluded (not $vendorExcluded) }}
+{{- if include "metal-settings.shouldInclude" (dict "item" $vendor "filters" $.Values.bmcSettings.filters.vendors) }}
 {{- range $entry := $vendorConfig.models }}
 {{- if and $entry.clusterTypes $entry.bmc $entry.bmc.settingsFileName }}
 {{- $model := $entry.model }}
 {{- $version := $entry.bmc.version }}
 
-{{/* Model filtering */}}
-{{- $modelIncluded := or (not $.Values.bmcSettings.filters.models.included) (has $model $.Values.bmcSettings.filters.models.included) }}
-{{- $modelExcluded := and $.Values.bmcSettings.filters.models.excluded (has $model $.Values.bmcSettings.filters.models.excluded) }}
-
-{{/* Version filtering */}}
-{{- $versionIncluded := or (not $.Values.bmcSettings.filters.versions.included) (has $version $.Values.bmcSettings.filters.versions.included) }}
-{{- $versionExcluded := and $.Values.bmcSettings.filters.versions.excluded (has $version $.Values.bmcSettings.filters.versions.excluded) }}
-
-{{- if and $modelIncluded (not $modelExcluded) $versionIncluded (not $versionExcluded) }}
+{{/* Model and Version filtering */}}
+{{- if and (include "metal-settings.shouldInclude" (dict "item" $model "filters" $.Values.bmcSettings.filters.models)) (include "metal-settings.shouldInclude" (dict "item" $version "filters" $.Values.bmcSettings.filters.versions)) }}
 {{- range $clusterType := $entry.clusterTypes }}
 
 {{/* ClusterType filtering */}}
-{{- $clusterTypeIncluded := or (not $.Values.bmcSettings.filters.clusterTypes.included) (has $clusterType $.Values.bmcSettings.filters.clusterTypes.included) }}
-{{- $clusterTypeExcluded := and $.Values.bmcSettings.filters.clusterTypes.excluded (has $clusterType $.Values.bmcSettings.filters.clusterTypes.excluded) }}
-
-{{- if and $clusterTypeIncluded (not $clusterTypeExcluded) }}
+{{- if include "metal-settings.shouldInclude" (dict "item" $clusterType "filters" $.Values.bmcSettings.filters.clusterTypes) }}
 apiVersion: metal.ironcore.dev/v1alpha1
 kind: BMCSettingsSet
 metadata:

--- a/system/metal-settings/templates/bmc_versions.yaml
+++ b/system/metal-settings/templates/bmc_versions.yaml
@@ -3,10 +3,7 @@
 {{- if $vendorConfig }}
 
 {{/* Vendor filtering */}}
-{{- $vendorIncluded := or (not $.Values.bmcVersions.filters.vendors.included) (has $vendor $.Values.bmcVersions.filters.vendors.included) }}
-{{- $vendorExcluded := and $.Values.bmcVersions.filters.vendors.excluded (has $vendor $.Values.bmcVersions.filters.vendors.excluded) }}
-
-{{- if and $vendorIncluded (not $vendorExcluded) }}
+{{- if include "metal-settings.shouldInclude" (dict "item" $vendor "filters" $.Values.bmcVersions.filters.vendors) }}
 {{- $processedModels := dict }}
 {{- range $entry := $vendorConfig.models }}
 {{- if $entry.bmc }}
@@ -18,15 +15,8 @@
 {{- if not (hasKey $processedModels $modelKey) }}
 {{- $_ := set $processedModels $modelKey true }}
 
-{{/* Model filtering */}}
-{{- $modelIncluded := or (not $.Values.bmcVersions.filters.models.included) (has $model $.Values.bmcVersions.filters.models.included) }}
-{{- $modelExcluded := and $.Values.bmcVersions.filters.models.excluded (has $model $.Values.bmcVersions.filters.models.excluded) }}
-
-{{/* Version filtering */}}
-{{- $versionIncluded := or (not $.Values.bmcVersions.filters.versions.included) (has $version $.Values.bmcVersions.filters.versions.included) }}
-{{- $versionExcluded := and $.Values.bmcVersions.filters.versions.excluded (has $version $.Values.bmcVersions.filters.versions.excluded) }}
-
-{{- if and $modelIncluded (not $modelExcluded) $versionIncluded (not $versionExcluded) }}
+{{/* Model and Version filtering */}}
+{{- if and (include "metal-settings.shouldInclude" (dict "item" $model "filters" $.Values.bmcVersions.filters.models)) (include "metal-settings.shouldInclude" (dict "item" $version "filters" $.Values.bmcVersions.filters.versions)) }}
 apiVersion: metal.ironcore.dev/v1alpha1
 kind: BMCVersionSet
 metadata:

--- a/system/metal-settings/values.yaml
+++ b/system/metal-settings/values.yaml
@@ -3,6 +3,21 @@
 
 # Regional filtering configuration for selective deployment
 # Use these settings to control which resources are deployed in each region
+#
+# FILTER BEHAVIOR:
+# - included: [] (empty) = include all items (default behavior)
+# - included: [dell, hpe] = ONLY include items in this list
+# - excluded: [lenovo] = exclude these items (takes precedence over included)
+# - If an item appears in both included and excluded, excluded wins
+#
+# CLUSTER TYPES & RESOURCE GENERATION:
+# - BIOSSettingsSet/BMCSettingsSet: Generate one resource PER clusterType listed below
+#   (e.g., if a model has 6 clusterTypes, it generates 6 separate Settings resources)
+# - BIOSVersionSet/BMCVersionSet: Generate one resource PER model (clusterTypes field is ignored)
+#
+# defaultClusterTypes anchor: Used by most models to reference standard cluster types
+# Some models (e.g., proliant-dl560-gen11) may have multiple entries with different
+# clusterTypes to support different BIOS/BMC settings per cluster type.
 
 defaultClusterTypes: &defaultClusterTypes
   - cc-kvm-compute
@@ -93,6 +108,26 @@ clusterConfig:
   managedNamespace: "metal-servers"   # Namespace where BMCSettingsSets related resources are deployed
 
 
+
+# Machine inventory: Hardware configurations for all supported servers
+#
+# SETTINGS FILE ORGANIZATION:
+# BIOS Settings Files (bios_settings/):
+#   - Dell: Most models use "dell-default.yaml" (shared by 10+ models)
+#     Exception: poweredge-r7615 uses "dell-r7615.yaml" (special PXE settings)
+#   - HPE: Most use "hpe-dl380-gen11.yaml"
+#     Exception: proliant-dl560-gen11 has TWO files:
+#       * hpe-dl560-gen11-kvm.yaml (for cc-kvm-compute with AdvancedEcc)
+#       * hpe-dl560-gen11-sci.yaml (for sci-k8s-* with FastFaultTolerantADDDC)
+#   - Lenovo: Each model series has its own file (sr650.yaml, sr850-v3.yaml, etc.)
+#
+# BMC Settings Files (bmc_settings/):
+#   - Dell: "dell-idrac.yaml" (shared by all Dell models)
+#   - HPE: "hpe-ilo.yaml" (shared by all HPE models)
+#   - Lenovo: "lenovo-xcc.yaml" (shared by all Lenovo models)
+#
+# Multiple entries for same model: Some models appear twice with different clusterTypes
+# to support cluster-specific BIOS configurations (e.g., KVM vs SCI requirements).
 
 machines:
   dell:


### PR DESCRIPTION
Extract duplicated vendor/model/version/clusterType filter logic to reusable helper function.
