### PR TITLE
Add owner-info subchart to owner-label-injector

### DIFF
--- a/system/owner-label-injector/Chart.lock
+++ b/system/owner-label-injector/Chart.lock
@@ -1,6 +1,9 @@
 dependencies:
+- name: owner-info
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 1.0.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:c8ca45bf1bab36d2b14a871ee084020a362e1e7c962e0bf39c58376d28dbaebb
-generated: "2024-04-26T06:24:37.996594662Z"
+digest: sha256:ffa2048f839754d7d63f15c8e08752032985242eb7e31bada7eb01c62778614c
+generated: "2026-06-01T10:39:10.15591+02:00"

--- a/system/owner-label-injector/Chart.yaml
+++ b/system/owner-label-injector/Chart.yaml
@@ -2,9 +2,12 @@ apiVersion: v2
 name: owner-label-injector
 description: A Helm chart for Kubernetes
 type: application
-version: 1.0.4
+version: 1.0.5
 appVersion: "1.1.0"
 dependencies:
+  - name: owner-info
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: '>= 0.0.0'
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0

--- a/system/owner-label-injector/values.yaml
+++ b/system/owner-label-injector/values.yaml
@@ -1,3 +1,7 @@
+owner-info:
+  support-group: containers
+  helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/system/owner-label-injector
+
 global:
   region:
 


### PR DESCRIPTION
required to satisfy gatekeeper rule in eu-de-3 controlplane shoot