### PR TITLE
feat(persephone-liquid-apiserver): add disco annotation to ingress

### DIFF
--- a/global/persephone-liquid-apiserver/Chart.yaml
+++ b/global/persephone-liquid-apiserver/Chart.yaml
@@ -6,7 +6,7 @@ apiVersion: v2
 name: persephone-liquid-apiserver
 description: Persephone Liquid API Server for managing Gardener shoot cluster quotas via Limes
 type: application
-version: 1.0.4
+version: 1.0.5
 appVersion: "1.0.0"
 keywords:
   - persephone

--- a/global/persephone-liquid-apiserver/templates/ingress.yaml
+++ b/global/persephone-liquid-apiserver/templates/ingress.yaml
@@ -12,6 +12,7 @@ metadata:
     {{- include "persephone-liquid-apiserver.labels" . | nindent 4 }}
   annotations:
     kubernetes.io/tls-acme: "true"
+    disco: "true"
     {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
## Summary

- Add `disco: "true"` annotation to the ingress resource so the DNS controller automatically manages DNS records for the ingress host
- Bump chart version to 1.0.5

## Test plan

- [ ] Verify the ingress resource renders with the `disco: "true"` annotation