### PR TITLE
cinder: fix liveness probe path from / to /healthcheck

### DIFF
--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Cinder/OpenStack_Project_Cinder_mascot.png
 name: cinder
-version: 0.4.0
+version: 0.4.1
 dependencies:
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/cinder/templates/api-deployment.yaml
+++ b/openstack/cinder/templates/api-deployment.yaml
@@ -82,7 +82,7 @@ spec:
               {{- include "utils.snippets.pre_stop_graceful_shutdown" . | indent 14 }}
           livenessProbe:
             httpGet:
-              path: /
+              path: /healthcheck
               port: cinder-api
             initialDelaySeconds: 15
             timeoutSeconds: 5


### PR DESCRIPTION
Investigation findings (eu-de-2, 2026-06-01):

All cinder-api pods (8 replicas) showed 25-49 restarts each, with the kubelet logging 111,981 ProbeWarning events over 13 days:

  Warning  ProbeWarning  Liveness probe warning: Probe terminated
  redirects, Response body: {"versions": [{"id": "v3.0", ...}]}

Root cause: the liveness probe hits GET / on HTTP port 8776. The Cinder API root endpoint returns a 300-series redirect to the HTTPS versioned URL (https://volume-3.<region>.cloud.sap/v3/). Kubelet follows the redirect and gets a valid response body, but records every probe as a ProbeWarning. This generates ~8 warnings/minute continuously and buries real health signals in the event stream.

Additionally, GET / goes through the full WSGI routing pipeline. Under worker thread exhaustion (e.g. during ProxySQL connection pool pressure), even this lightweight probe request can queue behind in-flight handlers and miss the 5s timeout, triggering the 3-failure threshold and causing an unnecessary pod restart.

The readiness probe already uses GET /healthcheck correctly. The /healthcheck endpoint is handled by oslo_middleware.Healthcheck early in the WSGI pipeline (before auth and routing), returns 200 OK with body 'OK' directly, and produces no redirect.

Verified GET /healthcheck returns HTTP 200 OK on all three regions:
  eu-de-1: 200 OK
  na-us-2: 200 OK
  eu-de-2: 200 OK

Fix: align the liveness probe path with the readiness probe path.