### PR TITLE
Add CinderTagMissingForHDDDatastoreNFS alert

### DIFF
--- a/prometheus-rules/prometheus-vmware-rules/Chart.yaml
+++ b/prometheus-rules/prometheus-vmware-rules/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A collection of Prometheus alert rules.
 name: prometheus-vmware-rules
-version: 1.5.5
+version: 1.5.6
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/prometheus-rules/prometheus-vmware-rules/alerts/datastore.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/datastore.alerts
@@ -322,6 +322,21 @@ groups:
       description: "There is no or incorrect Cinder tag present for the `{{ $labels.datastore }}` NFS SSD datastore in the *{{ $labels.datacenter }}* availability zone\nLink to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>"
       summary: "Wrong or missing tag on `{{ $labels.datastore }}` NFS datastore in *{{ $labels.datacenter }}*"
 
+- alert: CinderTagMissingForHDDDatastoreNFS
+    expr: |
+      vrops_datastore_summary_tag{type="nfs", datastore=~"nfs_.*std_ds.*", summary_tag!="[{\"category\":\"cinder\",\"name\":\"fcd-std\"}]"}
+    for: 1h
+    labels:
+      severity: warning
+      tier: vmware
+      service: storage
+      support_group: compute
+      meta: "There is no or incorrect Cinder tag present for the `{{ $labels.datastore }}` NFS HDD datastore in the *{{ $labels.datacenter }}* availability zone\nLink to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>"
+      playbook: docs/support/playbook/cinder/cinder-tag-missing
+    annotations:
+      description: "There is no or incorrect Cinder tag present for the `{{ $labels.datastore }}` NFS HDD datastore in the *{{ $labels.datacenter }}* availability zone\nLink to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>"
+      summary: "Wrong or missing tag on `{{ $labels.datastore }}` NFS datastore in *{{ $labels.datacenter }}*"
+
   - alert: CinderTagAddedForReservedDatastore
     expr: |
       vrops_datastore_summary_custom_tag_cinder_state{type=~"(vmfs_s_hdd|vmfs_p_ssd)", summary_custom_tag_cinder_state="reserved"} > 0

--- a/prometheus-rules/prometheus-vmware-rules/alerts/datastore.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/datastore.alerts
@@ -322,7 +322,7 @@ groups:
       description: "There is no or incorrect Cinder tag present for the `{{ $labels.datastore }}` NFS SSD datastore in the *{{ $labels.datacenter }}* availability zone\nLink to the vCenter: --> <https://{{ $labels.vcenter }}|{{ $labels.vcenter }}>"
       summary: "Wrong or missing tag on `{{ $labels.datastore }}` NFS datastore in *{{ $labels.datacenter }}*"
 
-- alert: CinderTagMissingForHDDDatastoreNFS
+  - alert: CinderTagMissingForHDDDatastoreNFS
     expr: |
       vrops_datastore_summary_tag{type="nfs", datastore=~"nfs_.*std_ds.*", summary_tag!="[{\"category\":\"cinder\",\"name\":\"fcd-std\"}]"}
     for: 1h


### PR DESCRIPTION
Adds a new alert for standard-tier NFS datastores (name contains "_std_") that should have the cinder tag "fcd-std".

Mirrors the structure of CinderTagMissingForSSDDatastoreNFS but matches the std datastores instead of excluding them, and expects "fcd-std" instead of "fcd".

Related JIRA: https://jira.tools.sap/browse/COMPUTEMONITORING-73