### PR TITLE
Fix policy substitutions broken by CVE-2026-42999 patch

### DIFF
--- a/openstack/keystone/templates/etc/_policy.yaml.tpl
+++ b/openstack/keystone/templates/etc/_policy.yaml.tpl
@@ -599,8 +599,8 @@
 # Intended scope(s): system, domain
 #"identity:list_groups": "(role:reader and system_scope:all) or (role:reader and domain_id:%(target.group.domain_id)s)"
 "identity:list_groups": "rule:cloud_reader or
-  (role:reader and (domain_id:%(target.group.domain_id)s or domain_id:%(domain_id)s)) or
-  (role:role_viewer and (project_domain_id:%(domain_id)s) or project_domain_id:%(target.group.domain_id)s)"
+  (role:reader and (domain_id:%(target.group.domain_id)s or domain_id:%(filter_attr.domain_id)s)) or
+  (role:role_viewer and (project_domain_id:%(filter_attr.domain_id)s) or project_domain_id:%(target.group.domain_id)s)"
 
 # List groups to which a user belongs.
 # GET  /v3/users/{user_id}/groups
@@ -932,8 +932,8 @@
 #"identity:list_projects": "(role:reader and system_scope:all) or (role:reader and domain_id:%(target.domain_id)s)"
 "identity:list_projects": "rule:cloud_reader or
   (role:reader and domain_id:%(target.domain_id)s) or
-  (role:reader and domain_id:%(domain_id)s) or
-  (role:reader and project_id:%(parent_id)s)"
+  (role:reader and domain_id:%(filter_attr.domain_id)s) or
+  (role:reader and project_id:%(filter_attr.parent_id)s)"
 
 # List projects for user.
 # GET  /v3/users/{user_id}/projects
@@ -1204,8 +1204,8 @@
 #"identity:list_role_assignments": "(role:reader and system_scope:all) or (role:reader and domain_id:%(target.domain_id)s)"
 "identity:list_role_assignments": "rule:cloud_reader or
   (role:reader and domain_id:%(target.domain_id)s) or
-  (role:reader and domain_id:%(scope.domain.id)s) or
-  ((role:reader or role:role_viewer) and project_id:%(scope.project.id)s)"
+  (role:reader and domain_id:%(filter_attr.scope.domain.id)s) or
+  ((role:reader or role:role_viewer) and project_id:%(filter_attr.scope.project.id)s)"
 
 # List all role assignments for a given tree of hierarchical projects.
 # GET  /v3/role_assignments?include_subtree
@@ -1373,8 +1373,8 @@
 #"identity:list_users": "(role:reader and system_scope:all) or (role:reader and domain_id:%(target.domain_id)s)"
 "identity:list_users": "rule:cloud_reader or
   (role:reader and domain_id:%(target.domain_id)s) or
-  project_domain_id:%(domain_id)s or
-  user_domain_id:%(domain_id)s"
+  project_domain_id:%(filter_attr.domain_id)s or
+  user_domain_id:%(filter_attr.domain_id)s"
 
 # List all projects a user has access to via role assignments.
 # GET   /v3/auth/projects


### PR DESCRIPTION
The Keystone RBAC enforcer fix for CVE-2026-42999 (commit 22b51f5d5d upstream, cherry-picked as 7481d11bb on stable/2025.1) namespaces query-string filter values under a new "filter_attr" key in the policy enforcement dict, instead of merging them at the top level.

This was done to prevent attacker-controlled query parameters from overwriting trusted view_args (e.g. user_id from
/v3/users/{user_id}/...) used in %(...)s policy substitutions.

The release note for the upstream patch claims the change is backwards-compatible because no in-tree policy rule references filter values directly. That is true upstream, but our downstream policy file does reference filter values in four rules. Without this update, those substitutions silently resolve to nothing after the upgrade and the affected clauses can never match.

Update the four affected rules to use the new "filter_attr.*" namespace:
* identity:list_role_assignments
  - %(scope.domain.id)s    -> %(filter_attr.scope.domain.id)s
  - %(scope.project.id)s   -> %(filter_attr.scope.project.id)s
  Restores the ability of project-scoped readers and role_viewers
  to list role assignments for their own project, and of domain
  readers to filter by ?scope.domain.id=.
* identity:list_projects
  - %(domain_id)s          -> %(filter_attr.domain_id)s
  - %(parent_id)s          -> %(filter_attr.parent_id)s
  Restores listing children of a parent project (?parent_id=) and
  domain-filtered project listing (?domain_id=) for project- and
  system-scoped readers. The %(domain_id)s substitution previously
  pulled from the query filter; post-patch it resolves only to the
  token's own oslo_context.domain_id, which silently narrows the
  rule for non-domain-scoped tokens.
* identity:list_groups
  - %(domain_id)s (x2)     -> %(filter_attr.domain_id)s
  Restores the intended ?domain_id= filter semantics for readers
  and role_viewers.
* identity:list_users
  - %(domain_id)s (x2)     -> %(filter_attr.domain_id)s
  Restores ?domain_id= filtering for project_domain_id /
  user_domain_id matches.