### PR TITLE
openstack/kmip: rename image keys to match transport-image-versions pattern

### DIFF
--- a/openstack/kmip/templates/_helpers.tpl
+++ b/openstack/kmip/templates/_helpers.tpl
@@ -61,6 +61,14 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
+{{- define "kmip.corename" -}}
+{{- printf "%s-core" (include "kmip.fullname" .) }}
+{{- end -}}
+
+{{- define "kmip.restapiname" -}}
+{{- printf "%s-restapi" (include "kmip.fullname" .) }}
+{{- end -}}
+
 {{- define "kmip.db_host" -}}
 {{ include "utils.db_host" . }}.{{ .Release.Namespace }}.svc.kubernetes.{{ .Values.global.region }}.{{ .Values.global.tld }}
 {{- end -}}

--- a/openstack/kmip/templates/deployment-kmip-core.yaml
+++ b/openstack/kmip/templates/deployment-kmip-core.yaml
@@ -1,10 +1,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "kmip.fullname" . }}
+  name: {{ include "kmip.corename" . }}
   labels:
     {{- include "kmip.labels" . | nindent 4 }}
-    app: {{ include "kmip.fullname" . }}
+    app: {{ include "kmip.corename" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -26,13 +26,13 @@ spec:
     {{- end }}
   selector:
     matchLabels:
-      app: {{ include "kmip.fullname" . }}
+      app: {{ include "kmip.corename" . }}
   template:
     metadata:
       labels:
         {{- include "kmip.labels" . | nindent 8 }}
-        app: {{ include "kmip.fullname" . }}
-        name: {{ include "kmip.fullname" . }}
+        app: {{ include "kmip.corename" . }}
+        name: {{ include "kmip.corename" . }}
         alert-tier: os
         alert-service: kmip
       annotations:

--- a/openstack/kmip/templates/deployment-kmip-core.yaml
+++ b/openstack/kmip/templates/deployment-kmip-core.yaml
@@ -43,7 +43,7 @@ spec:
         - name: kmip-core
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: {{ required ".Values.global.registry is missing" .Values.global.registry }}/loci-barbican:{{ required "Values.kmip.image is missing" .Values.kmip.image }}
+          image: {{ required ".Values.global.registry is missing" .Values.global.registry }}/loci-barbican:{{ required "Values.kmip.pykmipCoreImageVersion is missing" .Values.kmip.pykmipCoreImageVersion }}
           imagePullPolicy: {{ .Values.kmip.pullPolicy }}
           env:
             - name: OS_AUTH_URL

--- a/openstack/kmip/templates/deployment-kmip-restapi.yaml
+++ b/openstack/kmip/templates/deployment-kmip-restapi.yaml
@@ -49,7 +49,7 @@ spec:
         - name: kmip-restapi
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: {{ required ".Values.global.registry is missing" .Values.global.registry }}/loci-barbican:{{ required "Values.kmip.restapi_image is missing" .Values.kmip.restapi_image }}
+          image: {{ required ".Values.global.registry is missing" .Values.global.registry }}/loci-barbican:{{ required "Values.kmip.pykmipRestApiImageVersion is missing" .Values.kmip.pykmipRestApiImageVersion }}
           imagePullPolicy: {{ .Values.kmip.pullPolicy }}
           env:
             - name: KMIP_MARIADB_SERVICE_HOST

--- a/openstack/kmip/templates/deployment-kmip-restapi.yaml
+++ b/openstack/kmip/templates/deployment-kmip-restapi.yaml
@@ -1,10 +1,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "kmip.fullname" . }}-barbican
+  name: {{ include "kmip.restapiname" . }}
   labels:
     {{- include "kmip.labels" . | nindent 4 }}
-    app: {{ include "kmip.fullname" . }}-barbican
+    app: {{ include "kmip.restapiname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -26,13 +26,13 @@ spec:
     {{- end }}
   selector:
     matchLabels:
-      {{- include "kmip.selectorLabels" . | nindent 6 }}
+      app: {{ include "kmip.restapiname" . }}
   template:
     metadata:
       labels:
         {{- include "kmip.labels" . | nindent 8 }}
-        app: {{ include "kmip.fullname" . }}-barbican
-        name: {{ include "kmip.fullname" . }}-barbican
+        app: {{ include "kmip.restapiname" . }}
+        name: {{ include "kmip.restapiname" . }}
         alert-tier: os
         alert-service: kmip
         {{- with .Values.podLabels }}
@@ -41,7 +41,7 @@ spec:
       annotations:
         secrets-etc-hash: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
         prometheus.io/scrape: "true"
-        prometheus.io/port: "5006"
+        prometheus.io/port: "5005"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
     spec:
       serviceAccountName: {{ include "kmip.serviceAccountName" . }}-barbican
@@ -95,21 +95,21 @@ spec:
             {{- end }}
           ports:
             - name: restapi
-              containerPort: 5006
+              containerPort: 5005
               protocol: TCP
           livenessProbe:
             httpGet:
               path: /healthz
-              port: 5006
-            initialDelaySeconds: 20
+              port: 5005
+            initialDelaySeconds: 10
             periodSeconds: 10
-            timeoutSeconds: 5
+            timeoutSeconds: 3
             failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /healthz
-              port: 5006
-            initialDelaySeconds: 20
+              port: 5005
+            initialDelaySeconds: 10
             periodSeconds: 5
             timeoutSeconds: 3
             failureThreshold: 3

--- a/openstack/kmip/templates/ingress.yaml
+++ b/openstack/kmip/templates/ingress.yaml
@@ -35,18 +35,18 @@ spec:
               service:
                 name: kmip-barbican
                 port:
-                  number: 5006
+                  number: 5005
           - path: /kmip
             pathType: Prefix
             backend:
               service:
                 name: kmip-barbican
                 port:
-                  number: 5006
+                  number: 5005
           - path: /healthz
             pathType: Exact
             backend:
               service:
                 name: kmip-barbican
                 port:
-                  number: 5006
+                  number: 5005

--- a/openstack/kmip/templates/service-kmip.yaml
+++ b/openstack/kmip/templates/service-kmip.yaml
@@ -5,7 +5,7 @@ metadata:
   name: kmip
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ include "kmip.fullname" . }}
+    app: {{ include "kmip.corename" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -19,7 +19,7 @@ spec:
   sessionAffinity: None
   externalTrafficPolicy: Local
   selector:
-    app: {{ include "kmip.fullname" . }}
+    app: {{ include "kmip.corename" . }}
   ports:
     - name: kmip
       port: {{ .Values.service.ports.port }}

--- a/openstack/kmip/templates/service.yaml
+++ b/openstack/kmip/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
   name: kmip-barbican
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ include "kmip.fullname" . }}-barbican
+    app: {{ include "kmip.restapiname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -17,9 +17,9 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    app: {{ include "kmip.fullname" . }}-barbican
+    app: {{ include "kmip.restapiname" . }}
   ports:
     - name: restapi
-      port: 5006
-      targetPort: 5006
+      port: 5005
+      targetPort: 5005
       protocol: TCP

--- a/openstack/kmip/values.yaml
+++ b/openstack/kmip/values.yaml
@@ -28,8 +28,8 @@ replicaCount: 1
 
 kmip:
   pullPolicy: IfNotPresent
-  image: defined-in-secrets
-  restapi_image: defined-in-secrets
+  pykmipCoreImageVersion: defined-in-secrets
+  pykmipRestApiImageVersion: defined-in-secrets
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/openstack/kmip/values.yaml
+++ b/openstack/kmip/values.yaml
@@ -63,7 +63,7 @@ ingress:
 
 livenessProbe:
   tcpSocket:
-    port: 5696
+    port: 5697
   initialDelaySeconds: 10
   periodSeconds: 10
   timeoutSeconds: 1
@@ -71,7 +71,7 @@ livenessProbe:
   failureThreshold: 3
 readinessProbe:
   tcpSocket:
-    port: 5696
+    port: 5697
   initialDelaySeconds: 10
   periodSeconds: 5
   timeoutSeconds: 1


### PR DESCRIPTION
## Summary

- Renames `kmip.image` → `kmip.pykmipCoreImageVersion` and `kmip.restapi_image` → `kmip.pykmipRestApiImageVersion` in `values.yaml` and both deployment templates
- The new names match the `imageVersion` pattern that `task-transport-image-versions.yaml` looks for, enabling automatic image propagation from `qa-de-2` to all downstream regions via the shared CI task (same approach as `openstack-barbican`)

## Test plan

- [ ] Verify `qa-de-2` deploys successfully with updated key name via `TAG_VARIABLE: kmip.pykmipCoreImageVersion`
- [ ] Verify image transport runs cleanly for a canary/silver/gold region