### PR TITLE
feat(hermes): add Kafka output to Logstash audit pipeline

### DIFF
--- a/openstack/hermes/templates/etc/_logstash.conf.tpl
+++ b/openstack/hermes/templates/etc/_logstash.conf.tpl
@@ -576,6 +576,8 @@ output {
       {{- if .Values.logstash.kafka.enabled }}
       # Kafka output mirroring the Octobus audit filter above.
       # Public CA, no client credentials at present (SSL server-auth only).
+      # Durability: acks=all + idempotence + unbounded retries — every
+      # audit event must reach the SIEM, no duplicates on retry.
       kafka {
         id => "output_kafka_audit"
         bootstrap_servers => "{{ .Values.global.forwarding.kafka.bootstrap_servers }}"
@@ -583,9 +585,10 @@ output {
         codec => "json"
         security_protocol => "SSL"
         ssl_endpoint_identification_algorithm => "{{ .Values.logstash.kafka.ssl_endpoint_identification_algorithm | default "https" }}"
-        compression_type => "{{ .Values.logstash.kafka.compression_type | default "none" }}"
-        acks => "{{ .Values.logstash.kafka.acks | default "1" }}"
-        retries => {{ .Values.logstash.kafka.retries | default 60 }}
+        compression_type => "{{ .Values.logstash.kafka.compression_type | default "zstd" }}"
+        acks => "{{ .Values.logstash.kafka.acks | default "all" }}"
+        retries => {{ .Values.logstash.kafka.retries | default 2147483647 }}
+        enable_idempotence => {{ .Values.logstash.kafka.enable_idempotence | default true }}
         client_id => "{{ .Values.logstash.kafka.client_id | default "hermes-logstash" }}"
       }
       {{- end }}

--- a/openstack/hermes/templates/etc/_logstash.conf.tpl
+++ b/openstack/hermes/templates/etc/_logstash.conf.tpl
@@ -582,15 +582,11 @@ output {
         topic_id => "{{ .Values.logstash.kafka.topic | default "hermes" }}"
         codec => "json"
         security_protocol => "SSL"
-        {{- with .Values.logstash.kafka.ssl_endpoint_identification_algorithm }}
-        ssl_endpoint_identification_algorithm => "{{ . }}"
-        {{- end }}
-        {{- with .Values.logstash.kafka.compression_type }}
-        compression_type => "{{ . }}"
-        {{- end }}
+        ssl_endpoint_identification_algorithm => "{{ .Values.logstash.kafka.ssl_endpoint_identification_algorithm | default "https" }}"
+        compression_type => "{{ .Values.logstash.kafka.compression_type | default "none" }}"
         acks => "{{ .Values.logstash.kafka.acks | default "1" }}"
         retries => {{ .Values.logstash.kafka.retries | default 60 }}
-            client_id => "{{ .Values.logstash.kafka.client_id | default "hermes-logstash" }}"
+        client_id => "{{ .Values.logstash.kafka.client_id | default "hermes-logstash" }}"
       }
       {{- end }}
     }

--- a/openstack/hermes/templates/etc/_logstash.conf.tpl
+++ b/openstack/hermes/templates/etc/_logstash.conf.tpl
@@ -573,6 +573,26 @@ output {
         automatic_retries => 60
         retry_non_idempotent => true
       }
+      {{- if .Values.logstash.kafka.enabled }}
+      # Kafka output mirroring the Octobus audit filter above.
+      # Public CA, no client credentials at present (SSL server-auth only).
+      kafka {
+        id => "output_kafka_audit"
+        bootstrap_servers => "{{ .Values.global.forwarding.kafka.bootstrap_servers }}"
+        topic_id => "{{ .Values.logstash.kafka.topic | default "hermes" }}"
+        codec => "json"
+        security_protocol => "SSL"
+        {{- with .Values.logstash.kafka.ssl_endpoint_identification_algorithm }}
+        ssl_endpoint_identification_algorithm => "{{ . }}"
+        {{- end }}
+        {{- with .Values.logstash.kafka.compression_type }}
+        compression_type => "{{ . }}"
+        {{- end }}
+        acks => "{{ .Values.logstash.kafka.acks | default "1" }}"
+        retries => {{ .Values.logstash.kafka.retries | default 60 }}
+            client_id => "{{ .Values.logstash.kafka.client_id | default "hermes-logstash" }}"
+      }
+      {{- end }}
     }
   }
   {{- end}}

--- a/openstack/hermes/values.yaml
+++ b/openstack/hermes/values.yaml
@@ -50,12 +50,11 @@ logstash:
   kafka:
     enabled: false
     topic: hermes
-    # Tunables (all optional; sane defaults apply when omitted):
-    # client_id: hermes-logstash
-    # acks: "1"                                # "0" | "1" | "all"
-    # retries: 60
-    # compression_type: none                   # none | gzip | snappy | lz4 | zstd
-    # ssl_endpoint_identification_algorithm: https   # set "" to disable hostname verification
+    client_id: hermes-logstash
+    acks: "1"
+    retries: 60
+    compression_type: none
+    ssl_endpoint_identification_algorithm: https
   jdbc:
     enabled: false
     schedule: "12 0 * * *"

--- a/openstack/hermes/values.yaml
+++ b/openstack/hermes/values.yaml
@@ -43,6 +43,19 @@ logstash:
   debug: false
   swift: true
   audit: true
+  # Kafka output mirroring the Octobus audit filter.
+  # Off by default; enable per-region. Public CA, no client credentials.
+  # global.forwarding.kafka.bootstrap_servers must be set in region secrets
+  # (comma-separated host:port list, e.g. "broker1:9093,broker2:9093").
+  kafka:
+    enabled: false
+    topic: hermes
+    # Tunables (all optional; sane defaults apply when omitted):
+    # client_id: hermes-logstash
+    # acks: "1"                                # "0" | "1" | "all"
+    # retries: 60
+    # compression_type: none                   # none | gzip | snappy | lz4 | zstd
+    # ssl_endpoint_identification_algorithm: https   # set "" to disable hostname verification
   jdbc:
     enabled: false
     schedule: "12 0 * * *"

--- a/openstack/hermes/values.yaml
+++ b/openstack/hermes/values.yaml
@@ -51,9 +51,15 @@ logstash:
     enabled: false
     topic: hermes
     client_id: hermes-logstash
-    acks: "1"
-    retries: 60
-    compression_type: none
+    # Durability-first defaults: every audit event must reach the SIEM.
+    # acks=all + idempotence + high retries survive single-broker loss
+    # without dropping or duplicating events. Requires broker-side
+    # min.insync.replicas >= 2 to actually deliver the durability acks=all
+    # promises.
+    acks: "all"
+    retries: 2147483647
+    enable_idempotence: true
+    compression_type: zstd
     ssl_endpoint_identification_algorithm: https
   jdbc:
     enabled: false


### PR DESCRIPTION
## What

Add a Kafka output to the Hermes Logstash pipeline that mirrors the existing
Octobus audit filter — same predicate, same event subset, same JSON wire shape.

## Why

We are migrating off Octobus to a new SIEM that ingests via Kafka. This change
adds the Kafka transport so audit events from Hermes can flow into the new
SIEM. Octobus stays in place during the overlap; once the new SIEM is verified
in each region, the Octobus output is removed.

## How

The Kafka output sits **inside the same `if` predicate** as `output_octobus_audit`
in `_logstash.conf.tpl`. Logstash delivers each matched event to every output
inside the block, so during the overlap both transports receive an identical
event set with zero drift.

### Defaults (`values.yaml`)

```yaml
logstash:
  kafka:
    enabled: false
    topic: hermes
    client_id: hermes-logstash
    acks: "1"
    retries: 60
    compression_type: none
    ssl_endpoint_identification_algorithm: https
```

Every Kafka tunable has an explicit default. Regions only need to:

1. Provide `global.forwarding.kafka.bootstrap_servers` in region secrets
   (comma-separated `host:port` list, e.g. `"broker1:9093,broker2:9093"`).
2. Flip `logstash.kafka.enabled: true`.

### Security posture

- `security_protocol: SSL` — TLS to broker, public CA (JVM default truststore).
- `ssl_endpoint_identification_algorithm: https` — broker SAN is verified.
- **No client credentials yet.** Server-auth only. SASL_SSL with credentials
  is a follow-up before production cutover.

## Risk

- **Off by default.** No region behavior changes until `enabled: true` is set.
- Same data scope as Octobus today — no expansion of what's forwarded.
- Octobus output is untouched; this is purely additive until the cutover PR.

## Rollout

1. This PR — Kafka output available, disabled.
2. Per region: secrets land, `enabled: true`, verify SIEM ingest matches Octobus.
3. Follow-up PR — remove the Octobus `http` output once all regions are cut over.

## Test plan

- [ ] Render the chart with `kafka.enabled: false` (default) — no kafka block in configmap.
- [ ] Render with `kafka.enabled: true` and a stub `bootstrap_servers` — kafka block present with all defaults filled in.
- [ ] Deploy to a non-prod region with real broker, verify events match what Octobus receives.

## References

- Logstash Kafka output plugin: https://www.elastic.co/docs/reference/logstash/plugins/plugins-outputs-kafka
