### PR TITLE
[mariadb] Update MariaDB version to 10.11.18

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.38.0 - 2026/06/03
+* MariaDB version updated to [10.11.18](https://mariadb.com/docs/release-notes/community-server/10.11/10.11.18)
+* `maria-back-me-up` updated to `10.11-20260603173712`
+* chart version bumped
+
 ## v0.37.0 - 2026/05/21
 * MariaDB version updated to [10.11.17](https://mariadb.com/docs/release-notes/community-server/10.11/10.11.17)
 * `maria-back-me-up` updated to `10.11-20260521084302`

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,9 +2,9 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.37.0
+version: 0.38.0
 # scripts/docker-entyrpoint.sh should be updated when appVersion is updated
-appVersion: 10.11.17
+appVersion: 10.11.18
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -9,7 +9,7 @@ global:
       enabled: true
 
 name: null
-image: library/mariadb:10.11.17
+image: library/mariadb:10.11.18
 imagePullPolicy: IfNotPresent
 port_public: 3306
 max_connections: 1024
@@ -223,7 +223,7 @@ backup_v2:
   enabled: false
   backup_dir: "./backup"
   image: maria-back-me-up
-  image_version: "10.11-20260521084302"
+  image_version: "10.11-20260603173712"
   full_backup_cron_schedule: "0 0 * * *"
   incremental_backup_in_minutes: 5
   purge_binlog_after_minutes: 60


### PR DESCRIPTION
* MariaDB version updated to [10.11.18](https://mariadb.com/docs/release-notes/community-server/10.11/10.11.18)
* `maria-back-me-up` updated to `10.11-20260603173712`
* chart version bumped