### PR TITLE
keystone: set oslo_policy logger to INFO even in debug mode

### DIFF
--- a/openstack/keystone/templates/etc/_logging.conf.tpl
+++ b/openstack/keystone/templates/etc/_logging.conf.tpl
@@ -1,6 +1,6 @@
 [loggers]
 {{- if .Values.debug }}
-keys = root
+keys = root, oslo_policy
 {{- else }}
 keys = root, warnings, keystone, cc, radius, keystonemiddleware, keystoneauth, ldap, ldappool, amqp, amqplib, oslo_messaging, oslo_policy, sqlalchemy
 {{- end }}
@@ -81,11 +81,10 @@ handlers = stdout
 qualname = oslo.messaging
 
 [logger_oslo_policy]
+level = INFO
 {{- if .Values.debug }}
-level = DEBUG
 handlers = null
 {{- else }}
-level = INFO
 handlers = stdout
 {{- end }}
 qualname = oslo_policy


### PR DESCRIPTION
The oslo_policy DEBUG logs emit 'enforce: rule=... creds=...' messages that include the full token catalog, creating extremely long single-line JSON entries that get truncated by log collectors. Setting oslo_policy to INFO eliminates these problematic lines while preserving the useful RBAC authorization messages (Authorizing, Authorization granted/denied) which come from the keystone logger. Also added oslo_policy to the debug-mode logger keys so the section is actually active when debug=true.

https://docs.openstack.org/oslo.log/2025.2/configuration/
OpenStack upstream already decided that oslo_policy should be at INFO even when the service is running in debug mode.

The _logging.conf.tpl was bypassing this default by not registering oslo_policy in the loggers list when debug mode is active.