### PR TITLE
limes: give more RAM to v1 data metrics pod because of oomkills

### DIFF
--- a/openstack/limes/templates/deployment-data-metrics.yaml
+++ b/openstack/limes/templates/deployment-data-metrics.yaml
@@ -62,8 +62,8 @@ spec:
           resources:
             limits:
                 cpu: '1'
-                memory: '500Mi'
+                memory: '600Mi'
             requests:
                 cpu: '100m'
-                memory: '500Mi'
+                memory: '600Mi'
           {{- end }}


### PR DESCRIPTION
In big prod regions with 5000+ projects, the v1 data metrics reporter is sitting around 400 MiB at all times and spikes towards its current limit.