### PR TITLE
[persephone/liquid] scale down replicas from 2 to 1

### DIFF
--- a/global/persephone-liquid-apiserver/Chart.yaml
+++ b/global/persephone-liquid-apiserver/Chart.yaml
@@ -6,7 +6,7 @@ apiVersion: v2
 name: persephone-liquid-apiserver
 description: Persephone Liquid API Server for managing Gardener shoot cluster quotas via Limes
 type: application
-version: 1.0.5
+version: 1.0.6
 appVersion: "1.0.0"
 keywords:
   - persephone

--- a/global/persephone-liquid-apiserver/values.yaml
+++ b/global/persephone-liquid-apiserver/values.yaml
@@ -6,7 +6,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 2
+replicaCount: 1
 
 image:
   repository: keppel.eu-de-1.cloud.sap/ccloud/persephone-liquid-apiserver


### PR DESCRIPTION
The Limes colleagues recommend running on a single pod. This will make
it possible to continue using the simple Unix timestamp approach to
'service info version', since when running a multiple replica deployment
each pod ends up with a different service info version value.
