### PR TITLE
[neutron-netns-prober] Consolidate alerts

### DIFF
--- a/prometheus-exporters/neutron-netns-prober/alerts/probe.alerts
+++ b/prometheus-exporters/neutron-netns-prober/alerts/probe.alerts
@@ -4,19 +4,19 @@ groups:
   - alert: NeutronNetworkNamespaceProbesFailed
     expr: |
             (
-              sum(changes(neutron_netns_prober_failure_total[5m])) by (network_id, network_name, region, router_id, network_project_id) > 0
+              sum(changes(neutron_netns_prober_failure_total{network_name !~ "^shoot--.*"}[5m])) by (network_id, network_name, region, router_id, network_project_id) > 0
               and on (network_id) neutron_netns_prober_network_age_seconds > 3600
               and on (router_id) neutron_netns_prober_router_age_seconds > 3600
             ) unless (
-              sum(changes(neutron_netns_prober_success_total[150s])) by (network_id, network_name, region, router_id, network_project_id) > 0
+              sum(changes(neutron_netns_prober_success_total{network_name !~ "^shoot--.*"}[150s])) by (network_id, network_name, region, router_id, network_project_id) > 0
               and on (network_id) neutron_netns_prober_network_age_seconds > 3600
               and on (router_id) neutron_netns_prober_router_age_seconds > 3600
             )
     for: 5m
     labels:
       context: availability
-      service: neutron-hidden
-      severity: critical
+      service: neutron
+      severity: info
       support_group: network-api
       tier: os
       playbook: 'docs/support/playbook/neutron/networknamespaceprobesfailed'
@@ -25,13 +25,67 @@ groups:
     annotations:
       description: 'The network `{{ $labels.network_name }} ({{ $labels.network_id }})` failed all DNS probes for more than 5 minutes. (<https://dashboard.{{ $externalLabels.region }}.cloud.sap/ccadmin/cloud_admin/cloudops#/universal-search/?searchTerm={{ $labels.router_id }}&type=router|Router {{ $labels.router_id }}>). Please run ```hammer -r {{ $externalLabels.region }} net check {{ $labels.network_id }}``` and post it on the alert Slack thread.'
       summary: Network probes failed
+  - alert: NeutronNetworkNamespaceProbesFailedForShootNetwork
+    expr: |
+            (
+              (
+                sum(changes(neutron_netns_prober_failure_total{network_name =~ "^shoot--.*", region!="eu-de-2"}[5m])) by (network_id, network_name, region, router_id, network_project_id) > 0
+                and on (network_id) neutron_netns_prober_network_age_seconds > 3600
+                and on (router_id) neutron_netns_prober_router_age_seconds > 3600
+              ) unless (
+                sum(changes(neutron_netns_prober_success_total{network_name =~ "^shoot--.*", region!="eu-de-2"}[150s])) by (network_id, network_name, region, router_id, network_project_id) > 0
+                and on (network_id) neutron_netns_prober_network_age_seconds > 3600
+                and on (router_id) neutron_netns_prober_router_age_seconds > 3600
+              )
+            )
+    for: 5m
+    labels:
+      context: availability
+      service: neutron
+      severity: info
+      support_group: network-api
+      tier: os
+      playbook: 'docs/support/playbook/neutron/networknamespaceprobesfailed'
+      meta: 'Network {{ $labels.network_name }} failed all probes'
+      cloudops: "?searchTerm={{ $labels.network_id }}&type=network"
+    annotations:
+      description: 'The network `{{ $labels.network_name }} ({{ $labels.network_id }})` failed all DNS probes for more than 10 minutes. (<https://dashboard.{{ $externalLabels.region }}.cloud.sap/ccadmin/cloud_admin/cloudops#/universal-search/?searchTerm={{ $labels.router_id }}&type=router|Router {{ $labels.router_id }}>).
+Please run ```hammer -r {{ $externalLabels.region }} net check {{ $labels.network_id }}``` and post it on the alert Slack thread.'
+      summary: Network probes failed for `shoot--` networks.
+  - alert: NeutronNetworkNamespaceProbesFailedForShootNetworkEUDE2
+    expr: |
+            (
+              (
+                sum(changes(neutron_netns_prober_failure_total{network_name =~ "^shoot--.*", region=~"eu-de-2"}[10m])) by (network_id, network_name, region, router_id, network_project_id) > 0
+                and on (network_id) neutron_netns_prober_network_age_seconds > 3600
+                and on (router_id) neutron_netns_prober_router_age_seconds > 3600
+              ) unless (
+                sum(changes(neutron_netns_prober_success_total{network_name =~ "^shoot--.*", region=~"eu-de-2"}[5m])) by (network_id, network_name, region, router_id, network_project_id) > 0
+                and on (network_id) neutron_netns_prober_network_age_seconds > 3600
+                and on (router_id) neutron_netns_prober_router_age_seconds > 3600
+              )
+            )
+    for: 10m
+    labels:
+      context: availability
+      service: neutron
+      severity: info
+      support_group: network-api
+      tier: os
+      playbook: 'docs/support/playbook/neutron/networknamespaceprobesfailed'
+      meta: 'Network {{ $labels.network_name }} failed all probes'
+      cloudops: "?searchTerm={{ $labels.network_id }}&type=network"
+    annotations:
+      description: 'The network `{{ $labels.network_name }} ({{ $labels.network_id }})` failed all DNS probes for more than 10 minutes. (<https://dashboard.{{ $externalLabels.region }}.cloud.sap/ccadmin/cloud_admin/cloudops#/universal-search/?searchTerm={{ $labels.router_id }}&type=router|Router {{ $labels.router_id }}>).
+Please run ```hammer -r {{ $externalLabels.region }} net check {{ $labels.network_id }}``` and post it on the alert Slack thread.'
+      summary: Network probes failed for `shoot--` networks.
   - alert: NeutronNetworkNamespaceProbeMetricsMissing
     expr: absent(neutron_netns_prober_success_total)
     for: 10m
     labels:
       context: availability
-      service: neutron-hidden
-      severity: warning
+      service: neutron
+      severity: info
       support_group: network-api
       tier: os
       meta: 'Metrics for the namespace prober are missing'


### PR DESCRIPTION
* Remove `support_group` tag to prevent routing to slack
* Consolidate alerts to follow `ns-exporter` alerts