### PR TITLE
fix(hermes): set @timestamp from CADF eventTime in Logstash pipeline

### DIFF
--- a/openstack/hermes/templates/etc/_logstash.conf.tpl
+++ b/openstack/hermes/templates/etc/_logstash.conf.tpl
@@ -70,6 +70,18 @@ filter {
     ]
   }
 
+  # Set @timestamp from the CADF eventTime so every output (OpenSearch,
+  # Octobus, S3, Kafka) reflects when the audited action happened, not
+  # when Logstash saw the event. Must run after f05's ISO8601 format fix.
+  # On parse failure we tag instead of failing closed: the event still
+  # ships with @timestamp = ingest time, surfaced for debugging.
+  date {
+    id => "f05a_eventtime_to_timestamp"
+    match => [ "eventTime", "ISO8601" ]
+    target => "@timestamp"
+    tag_on_failure => ["_eventtime_parse_failure"]
+  }
+
   # Keystone specific transformations to compensate for scope missing from initiator element
   # When scope is missing from initiator, get it from action-specific parameters
   if ![initiator][project_id] and ![initiator][domain_id] {


### PR DESCRIPTION
## What

Adds a single `date{}` filter to the hermes Logstash pipeline so that
`@timestamp` reflects the CADF audit `eventTime` — the moment the audited
action happened — rather than pipeline-ingest time.

## Why

Hermes audit events carry their own `eventTime`. Until now, Logstash's
`@timestamp` was set to whenever the filter chain saw the event, so every
downstream output (OpenSearch indices, Octobus HTTP, S3 archives, and the
upcoming Kafka mirror) recorded ingest time, not action time. For an
audit trail, the answer to *"when did this happen?"* must be the action
time. Auditors don't care when our pipeline got around to processing it.

## How

Insert filter `f05a_eventtime_to_timestamp` immediately after the existing
`f05` mutate that canonicalizes `eventTime` to ISO8601:

```logstash
date {
  id => "f05a_eventtime_to_timestamp"
  match => [ "eventTime", "ISO8601" ]
  target => "@timestamp"
  tag_on_failure => ["_eventtime_parse_failure"]
}
```

`tag_on_failure` means a malformed `eventTime` doesn't drop the event —
it ships with `@timestamp = ingest time` and a tag that's queryable in
OpenSearch for debugging. Failing closed on an audit pipeline would lose
events; failing observably is the right trade.

## Why now

Pairs with an upcoming Greenhouse PR that sets
`message.timestamp.type=CreateTime` on the `audit` and `hermes` Kafka
topics. With this Logstash filter in place, Logstash's default kafka
output behavior (record timestamp = `@timestamp`) makes the Kafka record
timestamp equal the CADF `eventTime` end-to-end. The Greenhouse change
is benign until producers begin shipping, so this producer change must
roll first.

## Impact

**OpenSearch (existing path):** Events ingested with old `eventTime`
(after a brief outage, replay, or backlog) will land in the daily index
matching their `eventTime`, not the ingest day. Typical hermes ingest
lag is seconds, so this only shifts behavior at the second boundary.
Dashboards keyed on `@timestamp` continue to work — the values just
reflect the audit truth.

**Octobus / S3 (existing paths):** No behavioral change to the receiver —
events still ship with the same `eventTime` field they always had. The
SIEM-side time index in Octobus continues to use `eventTime`, not
`@timestamp`, so this is invisible there.

**Kafka (new path, gated):** Will be active only after the paired
Greenhouse PR lands and per-region values flip `logstash.kafka.enabled:
true`. Until then, this PR is a pure pipeline-internal correction.

## Test plan

- [x] Diff is a 12-line additive insertion with no edits to existing filters
- [x] Filter ID `f05a` does not collide with existing IDs (next is `f06a`)
- [x] Date pattern `ISO8601` matches the format produced by `f05`
- [ ] On rollout: monitor for `_eventtime_parse_failure` tags in
      hermes-* indices for the first 24h. Non-zero rate = upstream
      producers shipping malformed `eventTime`, which is a separate fix

## Related

- Pairs with: PlusOne/greenhouse PR (forthcoming) — broker-side
  `message.timestamp.type=CreateTime` on `audit` and `hermes` topics
- Builds on: previously merged Kafka output stanza on
  `feat/hermes-logstash-kafka-output` branch (currently
  `enabled: false` everywhere by default)
