### PR TITLE
feat(maia): federate KVM domain metrics for tenant visibility

### DIFF
--- a/openstack/maia/templates/etc/_maia_scrape_config.yaml.tpl
+++ b/openstack/maia/templates/etc/_maia_scrape_config.yaml.tpl
@@ -74,6 +74,19 @@
 #      - '{__name__=~"^openstack_.+",project_id!=""}'
 #      - '{__name__=~"^limes_(project|domain)_(quota|usage)"}'
 
+- job_name: 'prometheus-kube-monitoring'
+  scrape_interval: 1m
+  scrape_timeout: 55s
+  static_configs:
+    - targets: ['prometheus-collector.kube-monitoring:9090']
+  metric_relabel_configs:
+    - regex: "instance|job|kubernetes_namespace|kubernetes_pod_name|kubernetes_name|pod_template_hash|exported_instance|exported_job|type|name|component|app|system|cluster|cluster_type"
+      action: labeldrop
+  metrics_path: '/federate'
+  params:
+    'match[]':
+      - '{__name__=~"^kvm_domain_libvirt_.+",project_id!=""}'
+
 - job_name: 'prometheus-openstack'
   scrape_interval: 1m
   scrape_timeout: 55s


### PR DESCRIPTION
## Summary
- Adds a federation job pulling `kvm_domain_libvirt_*` metrics from
  kube-monitoring Prometheus into maia-oprom
- Filters to only series with `project_id!=""` (node metrics excluded)
- Follows existing federation pattern (same structure as prometheus-openstack job)

## Context
The kvm-exporter now labels all domain-level metrics with `project_id`
(confirmed in QA: cc-b0-qa-de-1). This PR exposes those metrics to
tenants through Maia.

## Question for reviewers

Hey @viennaa — this is what it looked like to me to enable KVM metrics
in Maia. I do not understand the cross-dependency concern in the FIXME
comment (line 54-75), but I wanted to make this concrete so you can see
the change and it surfaces any issues we have to address.

The commented-out `kube-system` job already targets the same Prometheus
(`prometheus-collector.kube-monitoring:9090`), and several existing jobs
(prometheus-openstack, prometheus-storage) follow this same cross-chain
federation pattern. Is there a reason KVM metrics should be handled
differently?

## Test plan
- [ ] Verify `prometheus-collector.kube-monitoring:9090` is reachable from maia namespace
- [ ] Confirm `kvm_domain_libvirt_*` metrics appear in maia-oprom after deploy
- [ ] Query Maia API as test project with KVM instances → metrics visible
- [ ] Validate no `kvm_node_*` metrics leak through (no project_id = filtered)