### PR TITLE
hermes: upgrade rabbitmq chart 25.2

### DIFF
--- a/openstack/hermes/Chart.lock
+++ b/openstack/hermes/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 1.1.1
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.24.1
+  version: 0.25.2
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
-digest: sha256:55bcd782ff060535deae518c16955adc9efbee1de10691f2f0a288460593976b
-generated: "2026-05-04T08:01:10.576793-07:00"
+digest: sha256:1b98869c1fc8c4c4a02c35782f6b63485921ab113dbb9e474f136336b5c57d65
+generated: "2026-06-04T15:42:29.053381-07:00"

--- a/openstack/hermes/Chart.yaml
+++ b/openstack/hermes/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
     condition: hermes.rabbitmq_enabled
     name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.24.1
+    version: 0.25.2
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.2.0


### PR DESCRIPTION
Upgrade rabbitmq chart to get on the latest version and clear many outdated image reports. 