### PR TITLE
[Nova] Enable disco for DNS name creation

### DIFF
--- a/openstack/nova/templates/api-ingress.yaml
+++ b/openstack/nova/templates/api-ingress.yaml
@@ -8,6 +8,7 @@ metadata:
     type: api
     component: nova
   annotations:
+    disco: "true"
     {{- include "utils.snippets.set_ingress_cors_annotations" . | indent 4 }}
     {{- include "utils.linkerd.ingress_annotation" . | indent 4 }}
   {{- if .Values.use_tls_acme }}

--- a/openstack/nova/templates/console-ingress.yaml
+++ b/openstack/nova/templates/console-ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     type: backend
     component: nova
   annotations:
+    disco: "true"
     ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/use-regex: "true"
     ingress.kubernetes.io/rewrite-target: "/$1"


### PR DESCRIPTION
Our Ingresses' DNS entries can be automatically created if we tell the disco-operator to do so.