### PR TITLE
campfire: add aurora to the allow list

### DIFF
--- a/openstack/limes-campfire/templates/configmap.yaml
+++ b/openstack/limes-campfire/templates/configmap.yaml
@@ -10,7 +10,8 @@ data:
       "match_limes_user": "user_name:limes and user_domain_name:Default and 'limes':%(mail_from)s",
       "match_elektra_user": "user_name:dashboard and user_domain_name:Default and 'elektra':%(mail_from)s",
       "match_archer_user": "user_name:archer and user_domain_name:Default and 'archer':%(mail_from)s",
+      "match_aurora_user": "user_name:dashboard and user_domain_name:Default and 'aurora':%(mail_from)s",
       "cluster_editor": "role:cloud_resource_admin",
-      "mail:send": "rule:match_limes_user or rule:match_elektra_user or rule:match_archer_user",
+      "mail:send": "rule:match_limes_user or rule:match_elektra_user or rule:match_archer_user or match_aurora_user",
       "mail:send-test": "rule:cluster_editor"
     }


### PR DESCRIPTION
Aurora currently uses the elektra openstack credentials.