### PR TITLE
[Nova] fix nova-api-metadata config mounting

### DIFF
--- a/openstack/nova/templates/api-metadata-deployment.yaml
+++ b/openstack/nova/templates/api-metadata-deployment.yaml
@@ -133,8 +133,8 @@ spec:
               items:
               - key:  nova.conf
                 path: nova.conf
-              - key:  nova-api.conf
-                path: nova-api-metadata.conf
+              - key:  nova-api-metadata.conf
+                path: nova-api.conf
               - key:  api-paste.ini
                 path: api-paste.ini
               - key:  policy.yaml


### PR DESCRIPTION
The nova-api-metadata pods are running the `nova-api` binary and are thus expected an `/etc/nova/nova-api.conf`. They will not read `nova-api-metadata.conf`.

In 501eb89c796 we moved to projected volumes among others for `nova-api-metadata`. We had a bug there, which lead to `nova-api-metadata` not running with a specific config. In regions exposing a large number of CPUs to the pods, this leads to exhaustion of the DB connection pool and hundreds of processes spawned. It also lead to Nova API workers spawning - unused - in the pods.