### PR TITLE
utils: add values-driven ProxySQL query cache rules

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.36.0
+version: 0.37.0

--- a/openstack/utils/templates/snippets/_proxysql.cfg.tpl
+++ b/openstack/utils/templates/snippets/_proxysql.cfg.tpl
@@ -179,5 +179,14 @@ mysql_query_rules =
         cache_ttl = 3600000,
         match_pattern = "^SELECT 1$",
     },
+{{- range $i, $rule := .global.Values.proxysql.query_rules | default list }}
+    {
+        rule_id = {{ add 1 $i }},
+        active = 1,
+        apply = 1,
+        cache_ttl = {{ printf "%.0f" (float64 $rule.cache_ttl) }},
+        match_pattern = "{{ $rule.match_pattern }}",
+    },
+{{- end }}
 )
 {{- end }}


### PR DESCRIPTION
## Summary

Add support for `.Values.proxysql.query_rules` list in the ProxySQL config template (`_proxysql.cfg.tpl`). Services can now define custom cache rules in their values.yaml without modifying the shared utils chart.

## Changes

- `_proxysql.cfg.tpl`: Add a `range` loop over `.global.Values.proxysql.query_rules` (defaults to empty list)
- `Chart.yaml`: Bump version 0.36.0 → 0.37.0

## Backward Compatibility

When no `query_rules` are defined in values, the rendered config is identical to before (only the hardcoded `SELECT 1` cache rule).

## Motivation

ProxySQL query caching can significantly reduce MariaDB load for read-heavy services. Analysis of Cinder EU-DE-2 showed:
- `attachment_specs` table (always empty) is queried 1,249 times/sec — 43% of total DB time
- `volume_types` (3 rows, static) is queried on every API call unnecessarily

Caching these at the ProxySQL layer eliminates ~40% of MariaDB read load with zero impact on data freshness for mutable tables.

## Usage Example

```yaml
# in a service's values.yaml:
proxysql:
  query_rules:
    - cache_ttl: 3600000   # 1 hour, in milliseconds
      match_pattern: "^SELECT.*FROM attachment_specs WHERE"
    - cache_ttl: 300000    # 5 minutes
      match_pattern: "^SELECT.*FROM volume_types.*ORDER BY"
```

## Testing

Verified with `helm template`:
- With rules defined → renders correct ProxySQL config with integer cache_ttl values
- Without rules defined → renders identical to current behavior (only SELECT 1 rule)