### PR TITLE
cinder: add ProxySQL cache rules for N+1 query cascade

### DIFF
--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.36.0
+  version: 0.37.0
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.37.0
@@ -26,5 +26,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:6bcc283f7a0f09b336959e311a1f3df44202e0c87303e36c00219e8f479a26e0
-generated: "2026-05-28T15:53:40.483627+03:00"
+digest: sha256:060258f41429d4da19a8f14e8cad51d1d9db493fabcd2b74e1800903ef445404
+generated: "2026-06-08T10:48:32.824807-04:00"

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -7,7 +7,7 @@ version: 0.4.1
 dependencies:
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.36.0
+    version: 0.37.0
   - name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.37.0

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -165,6 +165,17 @@ proxysql:
     scale: 2  # volume pods get max_connections = base * scale = 20 * 2 = 40
   backup:
     max_connections_per_proc: 10  # backup pods get their own proxysql secret with max_connections = 10
+  query_rules:
+    # Cache attachment_specs lookups (table is empty, 0 rows ever, queried 1249/sec)
+    # 1h TTL — table has never had data in any region, feature is unused
+    - cache_ttl: 3600000
+      match_pattern: "^SELECT.*FROM attachment_specs WHERE"
+    # Cache volume_types full list (3 rows, static admin config, rarely changes)
+    - cache_ttl: 300000
+      match_pattern: "^SELECT.*FROM volume_types.*ORDER BY"
+    # Cache volume_types by ID or name lookup
+    - cache_ttl: 300000
+      match_pattern: "^SELECT.*FROM.*volume_types WHERE"
 
 mariadb:
   enabled: true


### PR DESCRIPTION
## Summary

Add ProxySQL query cache rules to cinder to eliminate unnecessary MariaDB round-trips caused by SQLAlchemy's N+1 lazy-loading pattern on every volume API call.

**Depends on:** #11881 (utils: add values-driven ProxySQL query cache rules)

## Problem

Every `GET /volumes/{id}` and `GET /volumes/detail` API call triggers a cascade of separate SQL queries per volume/attachment. ProxySQL digest analysis from EU-DE-2 shows:

| Table | Queries/sec | DB Time Share | Issue |
|-------|------------|--------------|-------|
| `attachment_specs` | 1,249 | 43% | **Table has 0 rows (ever). Always returns empty.** |
| `volume_types` | 2.2 | 0.1% | Static (3 rows), rarely changes |

The `attachment_specs` table is queried once per active attachment per volume in the API response. With 59K active attachments and CSI drivers polling every 5-15 seconds, this generates 1,249 queries/sec — all returning empty result sets.

## Solution

Add ProxySQL cache rules in `values.yaml`:

```yaml
proxysql:
  query_rules:
    - cache_ttl: 3600000      # 1 hour — table permanently empty
      match_pattern: "^SELECT.*FROM attachment_specs WHERE"
    - cache_ttl: 300000       # 5 min — static admin config
      match_pattern: "^SELECT.*FROM volume_types.*ORDER BY"
    - cache_ttl: 300000       # 5 min — by-ID/name lookups
      match_pattern: "^SELECT.*FROM.*volume_types WHERE"
```

## Impact

| Metric | Before | After |
|--------|--------|-------|
| `attachment_specs` queries/sec | 1,249 | ~0 (99.99% reduction) |
| `volume_types` queries/sec | 2.2 | ~0.007 (99.7% reduction) |
| MariaDB read load | baseline | **~40% reduction** |
| Volume state visibility | immediate | **immediate (unchanged)** |
| Client poll behavior | unchanged | unchanged |

The `volumes` table is **never cached** — clients continue to see real-time state transitions during create/attach/delete operations.

## Data Sources

All numbers from ProxySQL `stats_mysql_query_digest` on EU-DE-2 cinder-api pods:
- Cumulative stats over 48.2 hours (8 pods)
- Live 15-minute delta measurement confirming real-time rates
- Table row counts verified via direct DB query

## Cache Invalidation

For planned `volume_types` changes:
```bash
for pod in $(kubectl -n monsoon3 get pods -l component=api,application=cinder -o name); do
  kubectl -n monsoon3 exec ${pod#pod/} -c proxysql -- \
    sh -c 'mysql --socket=/run/proxysql/admin.sock -u admin -padmin -e "PROXYSQL FLUSH QUERY CACHE;"'
done
```

## Changes

- `Chart.yaml`: Bump utils dependency 0.36.0 → 0.37.0
- `values.yaml`: Add `proxysql.query_rules` with 3 cache rules

## Related

- Depends on: #11881 (utils chart: add query_rules support)
- Separate fix needed: missing index on `quotas.project_id` (causes 275ms full-table-scan per query, 45% of DB time — not addressable via caching)