### PR TITLE
openstack/manila: set share_service_concurrency=10

### DIFF
--- a/openstack/manila/Chart.lock
+++ b/openstack/manila/Chart.lock
@@ -4,27 +4,27 @@ dependencies:
   version: 1.1.1
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.33.1
+  version: 0.38.0
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.6.0
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.6.16
+  version: 0.6.17
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.7.0
+  version: 0.8.1
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.22.1
+  version: 0.25.2
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 2.4.23
+  version: 2.4.50
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.32.0
-digest: sha256:c4bcf191f781dc8bb80e25d7a5fa1f52cf6f5a1286df4c1fa06a930bacd5ec09
-generated: "2026-04-02T18:06:23.688218+03:00"
+  version: 0.36.0
+digest: sha256:483ad28586eb9782ee3b4eb5248f5ab42828795324c7e5e9fc6bd22bf21aae08
+generated: "2026-06-08T10:24:25.845186+02:00"

--- a/openstack/manila/Chart.yaml
+++ b/openstack/manila/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 name: manila
 sources:
   - https://github.com/sapcc/manila
-version: 0.6.9
+version: 0.6.10
 dependencies:
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/manila/values.yaml
+++ b/openstack/manila/values.yaml
@@ -30,6 +30,7 @@ rpc_ping_enabled: true
 
 # manager config options
 server_migration_driver_continue_update_interval: 300
+share_service_concurrency: 10
 
 # better debugging experience; enable it only in QA
 pyreloader_enabled: false


### PR DESCRIPTION
## Summary

- Set `share_service_concurrency = 10` as the default in helm chart `values.yaml`
- This enables concurrent share service operations globally for all regions
- The template already supported this via `{{ $context.Values.share_service_concurrency | default 1 }}` — previously defaulted to 1 (disabled)

## Motivation

Improves share creation throughput by allowing up to 10 parallel share server operations. Safe to enable globally since it does not hurt performance and avoids the need for per-region secrets overrides.