### PR TITLE
openstack/utils: decouple osprofiler from Jaeger backend

### DIFF
--- a/openstack/manila/Chart.yaml
+++ b/openstack/manila/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 name: manila
 sources:
   - https://github.com/sapcc/manila
-version: 0.6.9
+version: 0.6.10
 dependencies:
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/manila/values.yaml
+++ b/openstack/manila/values.yaml
@@ -895,6 +895,9 @@ aggregates:
 # osprofiler
 osprofiler:
   enabled: false
+  # connection_string: jaeger://localhost:6831  # default; override for other backends
+  jaeger:
+    enabled: true  # set false to use osprofiler without the Jaeger agent sidecar
 
 vpa:
   # https://github.com/sapcc/vpa_butler

--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.36.0
+version: 0.36.1

--- a/openstack/utils/templates/_helpers.tpl
+++ b/openstack/utils/templates/_helpers.tpl
@@ -34,7 +34,7 @@ propagate=0
 {{- if .Values.osprofiler.enabled }}
 [profiler]
 enabled = true
-connection_string = jaeger://localhost:6831
+connection_string = {{ .Values.osprofiler.connection_string | default "jaeger://localhost:6831" }}
 hmac_keys = {{ .Values.global.osprofiler.hmac_keys | include "resolve_secret" }}
 trace_sqlalchemy = {{ .Values.global.osprofiler.trace_sqlalchemy }}
 {{- end }}
@@ -45,7 +45,7 @@ trace_sqlalchemy = {{ .Values.global.osprofiler.trace_sqlalchemy }}
 {{- end }}
 
 {{- define "jaeger_agent_sidecar" }}
-{{- if .Values.osprofiler.enabled }}
+{{- if and .Values.osprofiler.enabled (.Values.osprofiler.jaeger).enabled }}
 - image: {{.Values.global.dockerHubMirrorAlternateRegion}}/jaegertracing/jaeger-agent:{{ .Values.global.osprofiler.jaeger.version }}
   name: jaeger-agent
   ports:


### PR DESCRIPTION
## Summary

- Make `connection_string` in the `osprofiler` template configurable via `osprofiler.connection_string` (defaults to `jaeger://localhost:6831` for backwards compatibility)
- Gate `jaeger_agent_sidecar` injection on `osprofiler.jaeger.enabled` in addition to `osprofiler.enabled`, so osprofiler can be used with other backends (redis, zipkin, etc.) without the Jaeger sidecar being injected
- Document new flags in `openstack/manila/values.yaml`

## Backwards compatibility

Existing deployments with `osprofiler.enabled: true` are unaffected — `jaeger.enabled` defaults to `true`, so the Jaeger sidecar continues to be injected as before.

## Charts bumped

- `openstack/utils`: 0.36.0 → 0.36.1
- `openstack/manila`: 0.6.9 → 0.6.10

## Test plan

- [ ] Deploy with `osprofiler.enabled: false` (default) — no change in behaviour
- [ ] Deploy with `osprofiler.enabled: true`, `jaeger.enabled: true` (default) — Jaeger sidecar injected, connection_string = `jaeger://localhost:6831`
- [ ] Deploy with `osprofiler.enabled: true`, `jaeger.enabled: false` — no Jaeger sidecar, custom `connection_string` used