### PR TITLE
[persephone/liquid] set deployment strategy to Recreate

### DIFF
--- a/global/persephone-liquid-apiserver/Chart.yaml
+++ b/global/persephone-liquid-apiserver/Chart.yaml
@@ -6,7 +6,7 @@ apiVersion: v2
 name: persephone-liquid-apiserver
 description: Persephone Liquid API Server for managing Gardener shoot cluster quotas via Limes
 type: application
-version: 1.0.6
+version: 1.0.7
 appVersion: "1.0.0"
 keywords:
   - persephone

--- a/global/persephone-liquid-apiserver/templates/deployment.yaml
+++ b/global/persephone-liquid-apiserver/templates/deployment.yaml
@@ -13,6 +13,8 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "persephone-liquid-apiserver.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
## Summary

- Sets `strategy.type: Recreate` on the `persephone-liquid-apiserver` Deployment
- Follows up on 5eca85ece3, which scaled replicas down to 1 to avoid pods reporting different `service info version` values
- The default `RollingUpdate` strategy briefly runs two pods simultaneously during a rollout, re-introducing the multi-pod problem we scaled down to prevent; `Recreate` enforces the single-pod invariant by terminating the old pod before starting the new one
- Bumps chart version to 1.0.7