### PR TITLE
utils: fix ProxySQL query cache to use match_digest

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.37.0
+version: 0.37.1

--- a/openstack/utils/templates/snippets/_proxysql.cfg.tpl
+++ b/openstack/utils/templates/snippets/_proxysql.cfg.tpl
@@ -185,7 +185,7 @@ mysql_query_rules =
         active = 1,
         apply = 1,
         cache_ttl = {{ printf "%.0f" (float64 $rule.cache_ttl) }},
-        match_pattern = "{{ $rule.match_pattern }}",
+        match_digest = "{{ $rule.match_pattern }}",
     },
 {{- end }}
 )


### PR DESCRIPTION
## Problem

ProxySQL query cache rules using `match_pattern` never matched real application queries because SQLAlchemy generates multi-line SQL with newlines between clauses:

```sql
SELECT attachment_specs.created_at ...
FROM attachment_specs
WHERE attachment_specs.deleted = false AND ...
```

RE2's `.*` does not match newline characters (`\n`) by default, so `^SELECT.*FROM attachment_specs WHERE` fails when there's a newline between SELECT and FROM.

The `stats_mysql_query_digest` view normalizes queries to single-line (stripping newlines), which is why the digest *looked* like it should match — but `match_pattern` evaluates against the **raw query text** including newlines.

## Fix

Switch from `match_pattern` to `match_digest` in the ProxySQL config template. `match_digest` evaluates against the normalized single-line digest where `.*` works correctly.

## Verification

Tested live in qa-de-1 by updating ProxySQL runtime config on all 4 cinder-api pods:

| Minute | Cached | Backend | Hit Rate |
|--------|--------|---------|----------|
| 1 | 371 | 278 | 57% (warming) |
| 2 | 750 | 264 | 73% (warming) |
| 3 | 390 | 12 | **97%** |
| 4 | 478 | 10 | **97%** |
| 5 | 400 | 13 | **96%** |

At steady state: **97% cache hit rate** for `attachment_specs` queries. Only ~12 queries/minute reach MariaDB (unique attachment_ids seen for the first time within the 1-hour TTL).

## Depends on

Bumps utils to 0.37.1. Cinder Chart.yaml updated to reference 0.37.1.