### PR TITLE
[gatekeeper] update bridge-attach allowlist to shared image

### DIFF
--- a/system/gatekeeper/templates/constraint-pod-security-v2.yaml
+++ b/system/gatekeeper/templates/constraint-pod-security-v2.yaml
@@ -580,7 +580,7 @@ spec:
 
       {{- if eq .Values.cluster_name "eu-de-3" }}
       - matchNamespace: bridge-attach
-        matchRepository: ccloud/bridge-attach
+        matchRepository: ccloud/shared-app-images/alpine-iproute2
         justification: |
           The bridge-attach DaemonSet attaches a host network interface to a
           Linux bridge on apod nodes. It needs hostNetwork to operate in the


### PR DESCRIPTION
bridge-attach now uses the shared `alpine-iproute2` image, but the eu-de-3 allowlist rule still pointed at the old `ccloud/bridge-attach` repo, so gatekeeper denied the DaemonSet for hostNetwork+NET_ADMIN. Repointing the rule at `ccloud/shared-app-images/alpine-iproute2` to match the actual image.