### PR TITLE
[kube-system-scaleout] remove ldap-named-user from umbrella

### DIFF
--- a/system/kube-system-scaleout/Chart.lock
+++ b/system/kube-system-scaleout/Chart.lock
@@ -29,15 +29,12 @@ dependencies:
 - name: priority-class
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.0.0
-- name: ldap-named-user
-  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.2.10
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
 - name: owner-label-injector
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.0.4
+  version: 1.0.6
 - name: toolbox-prepull
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.7
@@ -47,5 +44,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 1.2.0
-digest: sha256:ea27a6b20678778185a8f84fc727097b8882fd01db03379b29b252382b7f567d
-generated: "2026-05-27T12:05:45.3852+02:00"
+digest: sha256:711521327df5efd5df8117ecb5a50f352204be3329d2210db7bf0bf2f9fab5ae
+generated: "2026-06-09T10:23:24.628925+03:00"

--- a/system/kube-system-scaleout/Chart.yaml
+++ b/system/kube-system-scaleout/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kube-System relevant Service collection for scaleout clusters.
 name: kube-system-scaleout
-version: 5.12.0
+version: 5.13.0
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-scaleout
 dependencies:
   - name: cc-rbac
@@ -38,9 +38,6 @@ dependencies:
   - name: priority-class
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 2.0.0
-  - name: ldap-named-user
-    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: '>= 0.0.0'
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.2.0


### PR DESCRIPTION
ldap-named-user chart is installed by the separate pipeline, so we need to remove this chart from kube-system-scaleout umbrella