### PR TITLE
limes: add catalog entries with "Limitas" branding

### DIFF
--- a/openstack/limes/templates/seed-catalog.yaml
+++ b/openstack/limes/templates/seed-catalog.yaml
@@ -14,7 +14,7 @@ spec:
   services:
     - name:        limes
       type:        resources
-      description: 'Hierarchical quota/usage tracking'
+      description: 'Hierarchical quota/usage/commitment tracking (v1 only)'
       enabled:     true
       endpoints:
         - region:    '{{ $region }}'
@@ -28,8 +28,24 @@ spec:
           url:       'http://limes-api-ccloud.{{.Release.Namespace}}.svc'
         {{- end }}
 
-    - name:        limes-rates
-      type:        sapcc-rates
+    - name:        limitas-resources
+      type:        limitas-resources
+      description: 'Hierarchical quota/usage/commitment tracking (v2+)'
+      enabled:     true
+      endpoints:
+        - region:    '{{ $region }}'
+          interface: public
+          enabled:   true
+          url:       '{{ $limes_url }}/resources'
+        {{- if not .Values.global.is_global_region }}
+        - region:    '{{ $region }}'
+          interface: internal
+          enabled:   true
+          url:       'http://limes-api-ccloud.{{.Release.Namespace}}.svc/resources'
+        {{- end }}
+
+    - name:        limitas-rates
+      type:        limitas-rates
       description: 'Hierarchical rate limit/usage tracking'
       enabled:     true
       endpoints:


### PR DESCRIPTION
- Since no one uses the rate API right now, we can just rename `limes-rates` to `limitas-rates` (and also get rid of the weird `sapcc-rates` type name in the process).
- Having the `limitas-rates` and `limitas-resources` services be separate from `resources` allows us to announce a new Limitas-branded domain name for those.

I also want to have something in Limes that forbids v2 endpoints from being used with the old `limes-3` domain name, in order to force users onto the upcoming `limitas` domain name as part of the v2 migration. Having cleanly separated catalog entries is a prerequisite for this, because then the v2 spec can reference the new `limitas-*` service types.