### PR TITLE
manila,barbican: fix migration job SA on fresh install

### DIFF
--- a/openstack/barbican/templates/migration-job.yaml
+++ b/openstack/barbican/templates/migration-job.yaml
@@ -1,5 +1,4 @@
 {{- $secrets := lookup "v1" "Secret" .Release.Namespace (print .Release.Name "-secrets") -}}
-{{- $serviceaccount := lookup "v1" "ServiceAccount" .Release.Namespace .Release.Name -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -25,7 +24,7 @@ spec:
       annotations:
 {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
-      {{- if $serviceaccount }}
+      {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ .Release.Name }}
       {{- end }}
       restartPolicy: OnFailure

--- a/openstack/manila/templates/migration-job.yaml
+++ b/openstack/manila/templates/migration-job.yaml
@@ -5,7 +5,6 @@
      so this script can still work with the previous setting.
 */}}
 {{- $proxysql := lookup "v1" "Secret" .Release.Namespace (print .Release.Name "-proxysql-etc") -}}
-{{- $serviceaccount := lookup "v1" "ServiceAccount" .Release.Namespace .Release.Name -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -30,7 +29,7 @@ spec:
         {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
       restartPolicy: OnFailure
-      {{- if $serviceaccount }}
+      {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ .Release.Name }}
       {{- end }}
 {{- if $proxysql }}


### PR DESCRIPTION
The lookup-gated pattern for `serviceAccountName` causes the migration job to fall back to the `default` SA on first install, since the named SA does not exist yet when the `post-install` hook fires. This aligns with the `rbac.enabled`-gated pattern already used by nova and cinder, which avoids the race condition entirely. The same bug was present in barbican and is fixed here as well.