### PR TITLE
cinder: bump utils to 0.37.1 (match_digest fix for ProxySQL cache)

### DIFF
--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.37.0
+  version: 0.37.1
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.37.0
@@ -26,5 +26,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:060258f41429d4da19a8f14e8cad51d1d9db493fabcd2b74e1800903ef445404
-generated: "2026-06-08T10:48:32.824807-04:00"
+digest: sha256:ca105520a346415e634ceb9ed7ffb9eebac939d8f9c57485de5adf888e7079f0
+generated: "2026-06-09T09:45:25.688996-04:00"

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -7,7 +7,7 @@ version: 0.4.1
 dependencies:
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.37.0
+    version: 0.37.1
   - name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.37.0


### PR DESCRIPTION
Picks up the fix from #11893 which switches ProxySQL query cache rules from `match_pattern` to `match_digest` so that multi-line SQL generated by SQLAlchemy actually matches the cache rules.

Without this bump, cinder continues using utils 0.37.0 where `match_pattern` is used, and the cache rules silently fail to match real queries (RE2's `.*` does not cross newlines).