### PR TITLE
Manila: bump dep update

### DIFF
--- a/openstack/manila/Chart.lock
+++ b/openstack/manila/Chart.lock
@@ -25,6 +25,6 @@ dependencies:
   version: 2.4.50
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.36.0
-digest: sha256:483ad28586eb9782ee3b4eb5248f5ab42828795324c7e5e9fc6bd22bf21aae08
-generated: "2026-06-08T10:24:25.845186+02:00"
+  version: 0.37.1
+digest: sha256:e61c8d644586ed00a5084147e121c3fabb929d9e00cff6910c1448ea67cb8c44
+generated: "2026-06-09T16:45:02.715925+02:00"


### PR DESCRIPTION
Proxyssql failing in eu-de-3. We need newer utils to dns resolve db
service correctly.
