### PR TITLE
fix: service label

### DIFF
--- a/system/cc-ceph/Chart.yaml
+++ b/system/cc-ceph/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cc-ceph
 description: A Helm chart for the Rook / Ceph Objects inside the Storage Clusters
 type: application
-version: 1.1.76
+version: 1.1.77
 appVersion: "1.17.5"
 dependencies:
   - name: owner-info

--- a/system/cc-ceph/values.yaml
+++ b/system/cc-ceph/values.yaml
@@ -1,5 +1,6 @@
 owner-info:
   support-group: containers
+  service: ceph
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/system/cc-ceph
 
 rook-ceph:


### PR DESCRIPTION
Hurekha scanner needs a label to identify the ceph workloads for scanning vulnerabilities. 
This will add label `service: ceph` to all the objects deployed by `cc-ceph` chart