### PR TITLE
[Limes]: add CCADMIN_PLUTUS_CLOUD_RESOURCE_VIEWERS group for plutus users

### DIFF
--- a/openstack/limes/templates/seed.yaml
+++ b/openstack/limes/templates/seed.yaml
@@ -97,6 +97,10 @@ spec:
           role: cloud_resource_admin
         - project: cloud_admin
           role: cloud_resource_viewer # technically unnecessary, but allows creating application credentials with read-only permissions
+      - name: CCADMIN_PLUTUS_CLOUD_RESOURCE_VIEWERS
+        role_assignments:
+        - project: cloud_admin@ccadmin
+          role: cloud_resource_viewer
       - name: CCADMIN_DOMAIN_RESOURCE_ADMINS
         role_assignments:
         - domain: ccadmin


### PR DESCRIPTION
## Summary

- Adds new Keystone group `CCADMIN_PLUTUS_CLOUD_RESOURCE_VIEWERS` to the limes seed for plutus users
- Assigns `cloud_resource_viewer` role on project `cloud_admin@ccadmin` to members of this group

## Test plan

- [x] Verify group is created in Keystone after seeder runs
- [x] Confirm users added to `CCADMIN_PLUTUS_CLOUD_RESOURCE_VIEWERS` receive `cloud_resource_viewer` on `cloud_admin@ccadmin`