### PR TITLE
openstack/kmip: fix sql-exporter metrics and add Prometheus alerts

### DIFF
--- a/openstack/kmip/Chart.lock
+++ b/openstack/kmip/Chart.lock
@@ -16,6 +16,6 @@ dependencies:
   version: 0.5.0
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.5.2
+  version: 0.8.1
 digest: sha256:aab72e2152a16e5f066d1b238368cc129d774c79b78c87313aba730418fc4bb4
-generated: "2026-05-25T14:46:51.805674+05:30"
+generated: "2026-06-10T00:00:00.000000000Z"

--- a/openstack/kmip/Chart.lock
+++ b/openstack/kmip/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 1.1.1
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.36.0
+  version: 0.37.1
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.35.0
@@ -17,5 +17,5 @@ dependencies:
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.8.1
-digest: sha256:aab72e2152a16e5f066d1b238368cc129d774c79b78c87313aba730418fc4bb4
-generated: "2026-06-10T00:00:00.000000000Z"
+digest: sha256:460f5a1f9f8745ccdbaeefa6c630f709fbbe677fc81948de36eef0cb76492c1e
+generated: "2026-06-10T12:18:50.655853+05:30"

--- a/openstack/kmip/Chart.yaml
+++ b/openstack/kmip/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Chart Version
-version: 0.3.8
+version: 0.3.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -47,4 +47,4 @@ dependencies:
   - condition: mariadb.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.5.2
+    version: 0.8.1

--- a/openstack/kmip/alerts/openstack-kmip.alerts
+++ b/openstack/kmip/alerts/openstack-kmip.alerts
@@ -1,0 +1,96 @@
+groups:
+- name: openstack-kmip.alerts
+  rules:
+  - alert: OpenstackKmipApiIsDown
+    expr: up{app="kmip-restapi"} == 0
+    for: 5m
+    labels:
+      context: availability
+      dashboard: kmip
+      meta: "a kmip instance went down on {{ $labels.instance }}"
+      service: kmip
+      support_group: identity
+      severity: critical
+      tier: os
+      no_alert_on_absence: "true"
+    annotations:
+      description: "A kmip-restapi pod on {{ $labels.instance }} is DOWN."
+      summary: "A kmip server is DOWN"
+
+  - alert: OpenstackKmipApiAllDown
+    expr: count(up{app="kmip-restapi"} == 0) == count(up{app="kmip-restapi"})
+    for: 5m
+    labels:
+      context: availability
+      meta: all kmip instances are down
+      service: kmip
+      severity: critical
+      support_group: identity
+      tier: os
+      dashboard: kmip
+      no_alert_on_absence: "true"
+    annotations:
+      description: All kmip-restapi pods are down.
+      summary: kmip is unavailable.
+
+  - alert: OpenstackKmipDatabaseIsDown
+    expr: count(up{app="kmip-mariadb"} == 0) == count(up{app="kmip-mariadb"})
+    for: 5m
+    labels:
+      context: availability
+      service: kmip
+      severity: critical
+      support_group: identity
+      tier: os
+      dashboard: mariadb-overview?var-host=kmip-mariadb
+      no_alert_on_absence: "true"
+    annotations:
+      description: "kmip database on {{ $labels.instance }} is DOWN."
+      summary: "kmip Database is DOWN"
+
+  - alert: OpenstackKmipUnresolvedSentryIssues
+    expr: sentry_unresolved_issues_count{project="kmip"} > 0
+    for: 3d
+    labels:
+      context: sentry-metrics
+      service: kmip
+      severity: info
+      tier: os
+      sentry: 'kmip/'
+      support_group: identity
+      no_alert_on_absence: "true"
+    annotations:
+      description: kmip has encountered unexpected errors and reported them to Sentry.
+        Please have a look at the list of unresolved issues at
+        <https://sentry.{{ $labels.region }}.cloud.sap/monsoon/kmip/>.
+      summary: kmip has reported issues to Sentry
+
+  - alert: OpenstackKmipHighPreActiveKeys
+    expr: sum by (owner) (openstack_kmip_managed_objects_by_state_gauge{state="1"}) > 100
+    for: 1h
+    labels:
+      context: keys
+      service: kmip
+      severity: warning
+      support_group: identity
+      tier: os
+      no_alert_on_absence: "true"
+      meta: 'Owner {{ $labels.owner }} has {{ $value }} PRE_ACTIVE keys'
+    annotations:
+      description: 'Owner {{ $labels.owner }} has {{ $value }} keys stuck in PRE_ACTIVE state for over 1 hour. These keys may not be usable.'
+      summary: 'High number of PRE_ACTIVE KMIP keys for {{ $labels.owner }}'
+
+  - alert: OpenstackKmipDeactivatedKeys
+    expr: sum by (owner) (openstack_kmip_managed_objects_by_state_gauge{state="3"}) > 0
+    for: 10m
+    labels:
+      context: keys
+      service: kmip
+      severity: info
+      support_group: identity
+      tier: os
+      no_alert_on_absence: "true"
+      meta: 'Owner {{ $labels.owner }} has {{ $value }} DEACTIVATED keys'
+    annotations:
+      description: 'Owner {{ $labels.owner }} has {{ $value }} DEACTIVATED keys. These should be rotated or destroyed.'
+      summary: 'DEACTIVATED KMIP keys detected for {{ $labels.owner }}'

--- a/openstack/kmip/templates/prometheus-alerts.yaml
+++ b/openstack/kmip/templates/prometheus-alerts.yaml
@@ -1,0 +1,20 @@
+{{- $values := .Values }}
+{{- if $values.alerts.enabled }}
+{{- range $path, $bytes := .Files.Glob "alerts/*.alerts" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: {{ printf "%s" $path | replace "/" "-" }}
+  labels:
+    app: kmip
+    tier: os
+    type: alerting-rules
+    prometheus: {{ required ".Values.alerts.prometheus missing" $values.alerts.prometheus }}
+
+spec:
+{{ printf "%s" $bytes | indent 2 }}
+
+{{- end }}
+{{- end }}

--- a/openstack/kmip/values.yaml
+++ b/openstack/kmip/values.yaml
@@ -146,32 +146,63 @@ mysql_metrics:
   db_name: kmip
   db_user: kmip
   customMetrics:
-    - help: Count managed_objects
+    - name: openstack_kmip_managed_objects_gauge
+      help: Number of managed objects grouped by type, policy, sensitivity, and owner
       labels:
-      - "uid"
       - "object_type"
       - "class_type"
-      - "value"
-      - "name_index"
       - "operation_policy_name"
       - "sensitive"
-      - "initial_date"
       - "owner"
-      name: openstack_kmip_managed_objects_gauge
+      - "value"
       query: |
         SELECT
-          uid,
           object_type,
           class_type,
-          value,
-          name_index,
           operation_policy_name,
           `sensitive`,
-          initial_date,
-          owner,
+          COALESCE(owner, '') AS owner,
+          'redacted' AS value,
           COUNT(*) AS gauge
         FROM managed_objects
-        GROUP BY uid, object_type, class_type, value, name_index, operation_policy_name, `sensitive`, initial_date, owner;
+        GROUP BY object_type, class_type, operation_policy_name, `sensitive`, owner;
+      values:
+      - "gauge"
+    - name: openstack_kmip_managed_objects_by_state_gauge
+      help: Number of cryptographic objects per lifecycle state
+      labels:
+      - "class_type"
+      - "state"
+      - "owner"
+      query: |
+        SELECT
+          mo.class_type,
+          co.state,
+          COALESCE(mo.owner, '') AS owner,
+          COUNT(*) AS gauge
+        FROM managed_objects mo
+        JOIN crypto_objects co ON mo.uid = co.uid
+        GROUP BY mo.class_type, co.state, mo.owner;
+      values:
+      - "gauge"
+    - name: openstack_kmip_managed_objects_age_seconds_gauge
+      help: Age in seconds of the oldest managed object per owner
+      labels:
+      - "owner"
+      query: |
+        SELECT
+          COALESCE(owner, '') AS owner,
+          UNIX_TIMESTAMP() - MIN(initial_date) AS gauge
+        FROM managed_objects
+        WHERE initial_date > 0
+        GROUP BY owner;
+      values:
+      - "gauge"
+    - name: openstack_kmip_total_managed_objects_gauge
+      help: Total number of managed objects in the database
+      labels: []
+      query: |
+        SELECT COUNT(*) AS gauge FROM managed_objects;
       values:
       - "gauge"
 


### PR DESCRIPTION
## Summary

- **Fix "zero queries ran" / "zero rows returned"**: bumps `mysql_metrics` dependency `0.5.2` → `0.8.1` (sql-exporter 0.9.0) — the old version had a config format incompatibility causing the exporter to fail at startup
- **Rewrite `openstack_kmip_managed_objects_gauge`**: removes `uid`, `value`, `name_index`, `initial_date` from `GROUP BY` — grouping by PK (`uid`) made `COUNT(*)` always 1 (useless), and the raw `VARBINARY` `value` column caused per-row encoding failures in the exporter; replaced with `'redacted'` static label
- **Add 3 new metrics**: `by_state_gauge` (key lifecycle states via `crypto_objects` JOIN), `age_seconds_gauge` (oldest key age per owner, useful for rotation alerting), `total_gauge` (simple total count)
- **Add Prometheus alerts**: 6 rules covering API availability, database availability, Sentry issues, high PRE_ACTIVE key count, and deactivated keys — mirrors the barbican alerts pattern

## SQL query validation

All 4 queries verified against the qade1 (`qa-de-1/monsoon3`) kmip-mariadb pod — all return rows cleanly with no encoding errors.

## Test plan

- [x] Deploy to qade1 and verify sql-exporter pod starts without "zero queries ran" errors
- [x] Confirm all 4 metrics appear in Prometheus
- [x] Verify PrometheusRule CRD is created (`kubectl get prometheusrule -n monsoon3 | grep kmip`)