### PR TITLE
[barbican] Revert migration job SA to lookup-based check

### DIFF
--- a/openstack/barbican/templates/migration-job.yaml
+++ b/openstack/barbican/templates/migration-job.yaml
@@ -1,4 +1,5 @@
 {{- $secrets := lookup "v1" "Secret" .Release.Namespace (print .Release.Name "-secrets") -}}
+{{- $serviceaccount := lookup "v1" "ServiceAccount" .Release.Namespace .Release.Name -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -24,7 +25,7 @@ spec:
       annotations:
 {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
-      {{- if .Values.rbac.enabled }}
+      {{- if $serviceaccount }}
       serviceAccountName: {{ .Release.Name }}
       {{- end }}
       restartPolicy: OnFailure


### PR DESCRIPTION
## Problem

PR #11901 changed the `serviceAccountName` condition in the barbican migration job from a runtime `lookup` to `{{- if .Values.rbac.enabled }}`. Since `rbac.enabled: true` is the default, the migration job now unconditionally sets `serviceAccountName: barbican`.

The migration job runs as a `pre-upgrade` helm hook (weight `-1`). Helm hooks execute **before** chart resources are applied, which means the `ServiceAccount` (created by `serviceaccount.yaml` as a regular chart resource) does not exist yet when the hook job is scheduled. The Job controller cannot create the pod and retries on exponential backoff, confirmed on ap-au-1 (x71 retries over 67 minutes):

```
Warning  FailedCreate  2m35s (x71 over 67m)  job-controller  Error creating: pods "barbican-migration-job-" is forbidden: error looking up service account monsoon3/barbican: serviceaccount "barbican" not found
```

Since no pod is ever created, `kubectl get pods` shows nothing — only `kubectl describe job barbican-migration-job` reveals the root cause. After 5 minutes helm declares the hook timed out:

```
Error: UPGRADE FAILED: pre-upgrade hooks failed: 1 error occurred:
    * timed out waiting for the condition
```

## Fix

Revert to the lookup-based pattern that was previously in place (same approach as the manila fix in commit 78974024):

```yaml
{{- $serviceaccount := lookup "v1" "ServiceAccount" .Release.Namespace .Release.Name -}}
...
{{- if $serviceaccount }}
serviceAccountName: {{ .Release.Name }}
{{- end }}
```

This safely skips the `serviceAccountName` on first install when the SA does not exist yet.

## Immediate mitigation

The orphaned hook job can be deleted to unblock the cluster without waiting for this PR:

```bash
kubectl delete job barbican-migration-job -n monsoon3
```

The DB schema is already up to date (barbican-api pods are running), so deleting the stuck job has no side effect. On the next deploy the `before-hook-creation` delete policy will clean it up automatically.

## Known limitation

The lookup approach has a secondary issue in regions where the Helm default role lacks `ServiceAccount` read access (e.g. eu-de-3) — the lookup always returns empty, silently falling back to the default SA.

The proper long-term fix (tracked separately) is to drop the helm hook entirely and switch to a hash-based generated job name like nova and cinder do. With a non-hook job the SA is guaranteed to exist as a regular chart resource before the job runs, making both the `lookup` workaround and the `rbac.enabled` check unnecessary.