### PR TITLE
[manila] make swift/swift-seed dependency conditional

### DIFF
--- a/openstack/manila/templates/seeds.yaml
+++ b/openstack/manila/templates/seeds.yaml
@@ -23,7 +23,9 @@ spec:
   - monsoon3/domain-{{replace "_" "-" . | lower}}-seed
   {{- end }}
   {{- end }}
+  {{- if .Values.seeds.requires_swift }}
   - swift/swift-seed
+  {{- end }}
 
   services:
   {{- if .Values.api_v1_enabled }}

--- a/openstack/manila/values.yaml
+++ b/openstack/manila/values.yaml
@@ -760,6 +760,7 @@ rabbitmq:
 sentry:
   enabled: true
 seeds:
+  requires_swift: true
   all_enabled: true
   service_type: share
   endpoint_prefix: ""


### PR DESCRIPTION
## Problem

In regions without Swift (e.g. eu-de-3), the `manila-seed` OpenstackSeed CRD has an unconditional dependency on `swift/swift-seed`:

```yaml
spec:
  requires:
    ...
    - swift/swift-seed   # always required, even when Swift is not deployed
```

The openstack-seeder controller refuses to process `manila-seed` until all declared dependencies exist. Since `swift/swift-seed` is never created in Swift-less regions, the seeder perpetually fails with:
```
ERROR: dependency 'swift/swift-seed' of 'monsoon3/manila-seed' not found
```

This blocks all Keystone user and endpoint registration for Manila, resulting in:
- `openstack share list` → `public endpoint for shared-file-system service in <region> not found`
- Manila API running but inaccessible via the service catalog
- Manila scheduler/share services failing readiness probes (no valid Keystone token)

## Fix

Add a `seeds.requires_swift` flag (default: `true`, preserving all existing behaviour) and wrap the dependency:

```yaml
  {{- if .Values.seeds.requires_swift }}
  - swift/swift-seed
  {{- end }}
```

Regions without Swift can set `seeds.requires_swift: false` in their values override.

## Pattern

Follows the same conditional pattern already used by `openstack/glance/templates/seeds.yaml` which wraps `swift/swift-seed` behind `.Values.swift.enabled`.