### PR TITLE
fix(netapp-harvest-exporter): correct castellum join key and metric name for provision cases 2 and 3

### DIFF
--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/aggregations/castellum.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/aggregations/castellum.yaml
@@ -52,8 +52,8 @@ groups:
 
       - record: manila_share_minimal_size_bytes_for_castellum
         expr: |
-          netapp_volume_provision_case_two * on (share_id) group_left(share_name, share_type) max by (share_id) (
-          {__name__=~"netapp_volume_size_used|netapp_volume_snapshot_size_used"})
+          netapp_volume_provision_case_two * on (app, svm, volume) group_right(project_id, share_id, share_name, share_type, volume_state, volume_type) max by (app, svm, volume) (
+          {__name__=~"netapp_volume_size_used|netapp_volume_snapshots_size_used"})
 
       # Case three: same as case two, but logical space reporting and enforcement are enabled.
       # Share size = netapp volume total size (snapshot reserve excluded)
@@ -78,8 +78,8 @@ groups:
 
       - record: manila_share_minimal_size_bytes_for_castellum
         expr: |
-          netapp_volume_provision_case_three * on (share_id) group_left(share_name, share_type) max by (share_id) (
-          {__name__=~"netapp_volume_space_logical_used_by_afs|netapp_volume_snapshot_size_used"})
+          netapp_volume_provision_case_three * on (app, svm, volume) group_right(project_id, share_id, share_name, share_type, volume_state, volume_type) max by (app, svm, volume) (
+          {__name__=~"netapp_volume_space_logical_used_by_afs|netapp_volume_snapshots_size_used"})
 
       # If the `manila_share_exclusion_reasons_for_castellum` metric has entries, Castellum will ignore the respective share.
       # This is required because Castellum discovers shares through the Manila API, but some shares do not have


### PR DESCRIPTION
Fixes two bugs in `aggregations/castellum.yaml` that caused `manila_share_minimal_size_bytes_for_castellum` to return no results for Cases 2 and 3:

1. Wrong join key: `on (share_id)` changed to `on (app, svm, volume)` — raw harvest metrics have no `share_id` label; they are indexed by `(app, svm, volume)`
2. Wrong metric name: `netapp_volume_snapshot_size_used` → `netapp_volume_snapshots_size_used` (plural, matching the canonical form used in limes.yaml and maia.yaml)