### PR TITLE
[sentry] add ttlSecondsAfterFinished to seed Job

### DIFF
--- a/system/sentry/Chart.yaml
+++ b/system/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes
 name: sentry
-version: 0.3.8
+version: 0.3.9
 dependencies:
   - name: pgbackup
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/system/sentry/templates/seed-job.yaml
+++ b/system/sentry/templates/seed-job.yaml
@@ -9,6 +9,7 @@ metadata:
     ccloud/support-group: identity
     ccloud/service: sentry
 spec:
+  ttlSecondsAfterFinished: {{ .Values.seedJob.ttlSecondsAfterFinished | default 86400 }}
   template:
     metadata:
       name: {{ template "fullname" . }}-seed

--- a/system/sentry/values.yaml
+++ b/system/sentry/values.yaml
@@ -42,6 +42,9 @@ service:
     internalPort: 9000
 pruning_time: '0315'
 
+seedJob:
+    ttlSecondsAfterFinished: 86400  # 24h (1 day)
+
 owner-info:
     support-group: identity
     service: sentry


### PR DESCRIPTION
Adds spec.ttlSecondsAfterFinished to the post-install seed Job so completed/failed Job objects are garbage-collected automatically (default 24h, configurable via .Values.seedJob.ttlSecondsAfterFinished). Bumps chart version 0.3.8 → 0.3.9. Ref: https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/