### PR TITLE
[NSXT] LivenessProbe removal in Deployment

### DIFF
--- a/openstack/neutron/templates/vct-nsxv3-agent-deployment.yaml
+++ b/openstack/neutron/templates/vct-nsxv3-agent-deployment.yaml
@@ -83,6 +83,8 @@ template: |
             initialDelaySeconds: 200
             periodSeconds: 30
             timeoutSeconds: 10
+          {{- else }}
+          livenessProbe: null
           {{- end }}
           resources:
 {{ toYaml .Values.pod.resources.nsxv3_agent | indent 12 }}


### PR DESCRIPTION
The vcenter-operator deploying the vcenter-template uses a server-side apply (SSA) in updating NSXT related Deployments.

For old deployments, we observe that removing the liveness probe from the deployment does not have an effect.
Looking at the managed fields of the deployment and the ownership checked in a server-side apply, it looks like the vcenter-operator cannot delete the liveness probe.

To workaround this we set 'livenessProbe: null':
* SSA in combination with --force-conflicts (set in the operator) transfers ownership to the vcenter-operator
* null is an explicit declaration of intent in SSA: "Its desired value is null (i.e., the field should not exist)"