### PR TITLE
chore(argora-operator): bump argora to 916b022

### DIFF
--- a/system/argora-operator-remote/Chart.lock
+++ b/system/argora-operator-remote/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.0.0
 - name: argora
   repository: oci://ghcr.io/sapcc/charts
-  version: 0.0.1-20260429081503-9c4dd92-crds
-digest: sha256:6999301332e664c1e2cc8ba8cfee653a0af83443f928e96e19b8d05161ff30a1
-generated: "2026-04-29T09:25:46.863860676Z"
+  version: 0.0.1-20260611084753-916b022-crds
+digest: sha256:2b628f72a5304f9f800b09fed09ec6745a4f60504e079fb10006b98b2f9a6880
+generated: "2026-06-11T11:56:32.378375+03:00"

--- a/system/argora-operator-remote/Chart.yaml
+++ b/system/argora-operator-remote/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.55
+version: 0.0.56
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -25,5 +25,5 @@ dependencies:
     version: ">= 0.0.0"
   - name: argora
     repository: oci://ghcr.io/sapcc/charts
-    version: 0.0.1-20260429081503-9c4dd92-crds
+    version: 0.0.1-20260611084753-916b022-crds
     alias: argora-operator-core

--- a/system/argora-operator-remote/managedresources/crds-and-rbac.yaml
+++ b/system/argora-operator-remote/managedresources/crds-and-rbac.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: argora-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argora
-    helm.sh/chart: argora-0.0.1-20260429081503-9c4dd92-crds
+    helm.sh/chart: argora-0.0.1-20260611084753-916b022-crds
     app.kubernetes.io/instance: argora-operator
     app.kubernetes.io/part-of: argora-operator
   name: argora-operator-controller-manager
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/component: argora-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argora
-    helm.sh/chart: argora-0.0.1-20260429081503-9c4dd92-crds
+    helm.sh/chart: argora-0.0.1-20260611084753-916b022-crds
     app.kubernetes.io/instance: argora-operator
     app.kubernetes.io/part-of: argora-operator
   name: clusterimports.argora.cloud.sap
@@ -161,7 +161,7 @@ metadata:
     app.kubernetes.io/component: argora-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argora
-    helm.sh/chart: argora-0.0.1-20260429081503-9c4dd92-crds
+    helm.sh/chart: argora-0.0.1-20260611084753-916b022-crds
     app.kubernetes.io/instance: argora-operator
     app.kubernetes.io/part-of: argora-operator
   name: ippoolimports.argora.cloud.sap
@@ -313,7 +313,7 @@ metadata:
     app.kubernetes.io/component: argora-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argora
-    helm.sh/chart: argora-0.0.1-20260429081503-9c4dd92-crds
+    helm.sh/chart: argora-0.0.1-20260611084753-916b022-crds
     app.kubernetes.io/instance: argora-operator
     app.kubernetes.io/part-of: argora-operator
   name: updates.argora.cloud.sap
@@ -449,7 +449,7 @@ metadata:
     app.kubernetes.io/component: argora-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argora
-    helm.sh/chart: argora-0.0.1-20260429081503-9c4dd92-crds
+    helm.sh/chart: argora-0.0.1-20260611084753-916b022-crds
     app.kubernetes.io/instance: argora-operator
     app.kubernetes.io/part-of: argora-operator
   name: argora-operator-manager-role
@@ -607,7 +607,7 @@ metadata:
     app.kubernetes.io/component: argora-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argora
-    helm.sh/chart: argora-0.0.1-20260429081503-9c4dd92-crds
+    helm.sh/chart: argora-0.0.1-20260611084753-916b022-crds
     app.kubernetes.io/instance: argora-operator
     app.kubernetes.io/part-of: argora-operator
   name: argora-operator-manager-rolebinding

--- a/system/argora-operator/Chart.lock
+++ b/system/argora-operator/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.0.0
 - name: argora
   repository: oci://ghcr.io/sapcc/charts
-  version: 0.0.1-20260429081503-9c4dd92
-digest: sha256:1d92396f83a37ff274516da1f18d1037e8cf5b35d9052bd0b6832b77fc179e48
-generated: "2026-04-29T09:25:31.693410086Z"
+  version: 0.0.1-20260611084753-916b022
+digest: sha256:3d11c4e704d5da4388d16a24160ced472d340905cf60e57a556d8168ce1fd998
+generated: "2026-06-11T11:52:19.225476+03:00"

--- a/system/argora-operator/Chart.yaml
+++ b/system/argora-operator/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: argora-operator
 description: A Helm chart for Kubernetes
 type: application
-version: 0.0.45
+version: 0.0.46
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: ">= 0.0.0"
   - name: argora
     repository: oci://ghcr.io/sapcc/charts
-    version: 0.0.1-20260429081503-9c4dd92
+    version: 0.0.1-20260611084753-916b022
     alias: argora-operator-core


### PR DESCRIPTION
Bump argora dependency to `0.0.1-20260611084753-916b022` in both argora-operator and argora-operator-remote charts.