### PR TITLE
codeowners: add team baremetal for all things metal-operator and argora

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -82,7 +82,7 @@
 /openstack/grafanasix                                  @viennaa @richardtief @Kuckkuck @IvoGoman @timojohlo # old
 /openstack/hermes                                      @notque @LeoZhangZXZ @Kuckkuck @notandy @viennaa @richardtief @olandr @joluc @trouaux @ibakshay @ashifnihalb @timojohlo
 /openstack/infra-seeds/kubernetes                      @BugRoger  # old
-/openstack/ironic                                      @stefanhipfel @BerndKue @fwiesel @sandzwerg @Pooja-Sangle 
+/openstack/ironic                                      @stefanhipfel @BerndKue @fwiesel @sandzwerg @Pooja-Sangle
 /openstack/keppel*                                     @sapcc/Storage-Resource-Services-Codeowners
 /openstack/keystone                                    @galkindmitrii @bbobrov @rajivmucheli @stanislav-zaprudskiy @BerndKue @tz3 @JoJoPuppe
 /openstack/kmip                                        @rajivmucheli @Scsabiii
@@ -147,8 +147,8 @@
 /prometheus-exporters/documentation-prober             @dhalimi  # old
 /prometheus-exporters/event-exporter                   @jknipper @databus23
 /prometheus-exporters/hermes-query-exporter            @Kuckkuck @notque @LeoZhangZXZ @timojohlo @olandr @joluc
-/prometheus-exporters/ipmi-exporter                    @stefanhipfel @BerndKue @sandzwerg @Pooja-Sangle 
-/prometheus-exporters/ironic-exporter                  @BerndKue @stefanhipfel @sandzwerg @Pooja-Sangle 
+/prometheus-exporters/ipmi-exporter                    @stefanhipfel @BerndKue @sandzwerg @Pooja-Sangle
+/prometheus-exporters/ironic-exporter                  @BerndKue @stefanhipfel @sandzwerg @Pooja-Sangle
 
 /prometheus-exporters/jumpserver-exporter              @viennaa @richardtief @Kuckkuck @ibakshay @trouaux @ashifnihalb
 /prometheus-exporters/k8s-secrets-certificate-exporter @auhlig @databus23 @jknipper
@@ -167,7 +167,7 @@
 /prometheus-exporters/openstack-exporter               @hemna @crenduchinta88 @kevin-fischer @joker-at-work @fwiesel @jagoleni @Scsabiii @sumitarora2786 @Carthaca @chuan137
 /prometheus-exporters/ping-exporter                    @auhlig # old
 /prometheus-exporters/poller-simulator                 @dhalimi
-/prometheus-exporters/redfish-exporter                 @BerndKue @stefanhipfel @sandzwerg @Pooja-Sangle 
+/prometheus-exporters/redfish-exporter                 @BerndKue @stefanhipfel @sandzwerg @Pooja-Sangle
 /prometheus-exporters/snmp-exporter                    @Kuckkuck @swagner-de @m-kratochvil @timojohlo @joluc
 /prometheus-exporters/snmp-ntp-exporter                @geisslet
 /prometheus-exporters/statsd-exporter                  @ashifnihalb @artherd42
@@ -189,8 +189,8 @@
 /system/autoscaling                                    @sapcc/PlusOne-CE-API-Services-ControlPlane @VoigtS
 /system/absent-metrics-operator                        @trouaux @ibakshay @viennaa @richardtief @ashifnihalb @sapcc/Storage-Resource-Services-Codeowners
 /system/ai-cloud-guard                                 @darpan92
-/system/argora-operator                                @sapcc/PlusOne-CE-API-Services-ControlPlane
-/system/argora-operator-remote                         @sapcc/PlusOne-CE-API-Services-ControlPlane
+/system/argora-operator                                @sapcc/PlusOne-CE-API-Services-ControlPlane @sapcc/baremetal
+/system/argora-operator-remote                         @sapcc/PlusOne-CE-API-Services-ControlPlane @sapcc/baremetal
 /system/atlas                                          @BerndKue @Kuckkuck @viennaa @stefanhipfel @artherd42
 /system/audit-logs                                     @Kuckkuck @jknipper @timojohlo @olandr @joluc
 /system/audit-logs-otel                                @Kuckkuck @jknipper @timojohlo @olandr @joluc
@@ -198,8 +198,8 @@
 /system/baremetal-operator                             @sapcc/PlusOne-CE-API-Services-ControlPlane
 /system/baremetal-operator-core                        @sapcc/PlusOne-CE-API-Services-ControlPlane
 /system/bind                                           @galkindmitrii @mutax @mbrowny @vssldmtrv @proddi @SoenkeL @occamshatchet
-/system/boot-operator                                  @sapcc/PlusOne-CE-API-Services-ControlPlane @nagadeesh-nagaraja @stefanhipfel @xkonni @davidgrun
-/system/boot-operator-remote                           @sapcc/PlusOne-CE-API-Services-ControlPlane @nagadeesh-nagaraja @stefanhipfel @xkonni @davidgrun
+/system/boot-operator                                  @sapcc/PlusOne-CE-API-Services-ControlPlane @sapcc/baremetal @stefanhipfel
+/system/boot-operator-remote                           @sapcc/PlusOne-CE-API-Services-ControlPlane @sapcc/baremetal @stefanhipfel
 /system/bootstrap-kubeadm                              @sapcc/PlusOne-CE-API-Services-ControlPlane
 /system/calico                                         @sapcc/PlusOne-CE-API-Services-ControlPlane
 /system/calico-apiserver                               @sapcc/PlusOne-CE-API-Services-ControlPlane
@@ -281,11 +281,11 @@
 /system/logs                                           @Kuckkuck @timojohlo @notque @olandr @joluc
 /system/Makefile                                       @sapcc/PlusOne-CE-API-Services-ControlPlane
 /system/maintenance-controller                         @sapcc/PlusOne-CE-API-Services-ControlPlane
-/system/metal-operator                                 @sapcc/PlusOne-CE-API-Services-ControlPlane @nagadeesh-nagaraja @stefanhipfel @xkonni @davidgrun
-/system/metal-operator-dhcp                            @sapcc/PlusOne-CE-API-Services-ControlPlane @nagadeesh-nagaraja @stefanhipfel @xkonni @davidgrun
-/system/metal-operator-remote                          @sapcc/PlusOne-CE-API-Services-ControlPlane @nagadeesh-nagaraja @stefanhipfel @xkonni @davidgrun
-/system/metal-token-rotate                             @sapcc/PlusOne-CE-API-Services-ControlPlane @nagadeesh-nagaraja @stefanhipfel @xkonni @davidgrun
-/system/metal-settings                                 @sapcc/PlusOne-CE-API-Services-ControlPlane @nagadeesh-nagaraja @stefanhipfel @xkonni @davidgrun
+/system/metal-operator                                 @sapcc/PlusOne-CE-API-Services-ControlPlane @sapcc/baremetal @stefanhipfel
+/system/metal-operator-dhcp                            @sapcc/PlusOne-CE-API-Services-ControlPlane @sapcc/baremetal @stefanhipfel
+/system/metal-operator-remote                          @sapcc/PlusOne-CE-API-Services-ControlPlane @sapcc/baremetal @stefanhipfel
+/system/metal-token-rotate                             @sapcc/PlusOne-CE-API-Services-ControlPlane @sapcc/baremetal @stefanhipfel
+/system/metal-settings                                 @sapcc/PlusOne-CE-API-Services-ControlPlane @sapcc/baremetal @stefanhipfel
 /system/manila-csi-plugin                              @Nuckal777 @jknipper
 /system/metallb                                        @sapcc/PlusOne-CE-API-Services-ControlPlane
 /system/metis                                          @IvoGoman @uwe-mayer @abhijith-darshan @onuryilmaz


### PR DESCRIPTION
chore: removed some trailing whitespaceseasier to track than individual users.

chore: removed some trailing whitespaces