### PR TITLE
chore(argora-operator): bump argora to b0e45a1

### DIFF
--- a/system/argora-operator-remote/Chart.lock
+++ b/system/argora-operator-remote/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.0.0
 - name: argora
   repository: oci://ghcr.io/sapcc/charts
-  version: 0.0.1-20260611084753-916b022-crds
-digest: sha256:2b628f72a5304f9f800b09fed09ec6745a4f60504e079fb10006b98b2f9a6880
-generated: "2026-06-11T11:56:32.378375+03:00"
+  version: 0.0.1-20260611105006-b0e45a1-crds
+digest: sha256:4bcdb029f4eafcca31caf20dfc458ce52e887c019a58a6ed7da3c0d2cb32535b
+generated: "2026-06-11T13:53:26.183774+03:00"

--- a/system/argora-operator-remote/Chart.yaml
+++ b/system/argora-operator-remote/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.56
+version: 0.0.57
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -25,5 +25,5 @@ dependencies:
     version: ">= 0.0.0"
   - name: argora
     repository: oci://ghcr.io/sapcc/charts
-    version: 0.0.1-20260611084753-916b022-crds
+    version: 0.0.1-20260611105006-b0e45a1-crds
     alias: argora-operator-core

--- a/system/argora-operator-remote/managedresources/crds-and-rbac.yaml
+++ b/system/argora-operator-remote/managedresources/crds-and-rbac.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: argora-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argora
-    helm.sh/chart: argora-0.0.1-20260611084753-916b022-crds
+    helm.sh/chart: argora-0.0.1-20260611105006-b0e45a1-crds
     app.kubernetes.io/instance: argora-operator
     app.kubernetes.io/part-of: argora-operator
   name: argora-operator-controller-manager
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/component: argora-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argora
-    helm.sh/chart: argora-0.0.1-20260611084753-916b022-crds
+    helm.sh/chart: argora-0.0.1-20260611105006-b0e45a1-crds
     app.kubernetes.io/instance: argora-operator
     app.kubernetes.io/part-of: argora-operator
   name: clusterimports.argora.cloud.sap
@@ -161,7 +161,7 @@ metadata:
     app.kubernetes.io/component: argora-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argora
-    helm.sh/chart: argora-0.0.1-20260611084753-916b022-crds
+    helm.sh/chart: argora-0.0.1-20260611105006-b0e45a1-crds
     app.kubernetes.io/instance: argora-operator
     app.kubernetes.io/part-of: argora-operator
   name: ippoolimports.argora.cloud.sap
@@ -313,7 +313,7 @@ metadata:
     app.kubernetes.io/component: argora-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argora
-    helm.sh/chart: argora-0.0.1-20260611084753-916b022-crds
+    helm.sh/chart: argora-0.0.1-20260611105006-b0e45a1-crds
     app.kubernetes.io/instance: argora-operator
     app.kubernetes.io/part-of: argora-operator
   name: updates.argora.cloud.sap
@@ -449,7 +449,7 @@ metadata:
     app.kubernetes.io/component: argora-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argora
-    helm.sh/chart: argora-0.0.1-20260611084753-916b022-crds
+    helm.sh/chart: argora-0.0.1-20260611105006-b0e45a1-crds
     app.kubernetes.io/instance: argora-operator
     app.kubernetes.io/part-of: argora-operator
   name: argora-operator-manager-role
@@ -607,7 +607,7 @@ metadata:
     app.kubernetes.io/component: argora-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argora
-    helm.sh/chart: argora-0.0.1-20260611084753-916b022-crds
+    helm.sh/chart: argora-0.0.1-20260611105006-b0e45a1-crds
     app.kubernetes.io/instance: argora-operator
     app.kubernetes.io/part-of: argora-operator
   name: argora-operator-manager-rolebinding

--- a/system/argora-operator/Chart.lock
+++ b/system/argora-operator/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.0.0
 - name: argora
   repository: oci://ghcr.io/sapcc/charts
-  version: 0.0.1-20260611084753-916b022
-digest: sha256:3d11c4e704d5da4388d16a24160ced472d340905cf60e57a556d8168ce1fd998
-generated: "2026-06-11T11:52:19.225476+03:00"
+  version: 0.0.1-20260611105006-b0e45a1
+digest: sha256:d6e4bbc03b028e358b719f5adc551a372e7592da868c1c12ab30b87c69898f1d
+generated: "2026-06-11T13:53:47.613518+03:00"

--- a/system/argora-operator/Chart.yaml
+++ b/system/argora-operator/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: argora-operator
 description: A Helm chart for Kubernetes
 type: application
-version: 0.0.46
+version: 0.0.47
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: ">= 0.0.0"
   - name: argora
     repository: oci://ghcr.io/sapcc/charts
-    version: 0.0.1-20260611084753-916b022
+    version: 0.0.1-20260611105006-b0e45a1
     alias: argora-operator-core


### PR DESCRIPTION
Bump argora dependency to `0.0.1-20260611105006-b0e45a1` in both argora-operator and argora-operator-remote charts.