### PR TITLE
[manila ]prepare share type extra specs for epoxy

### DIFF
--- a/openstack/manila/values.yaml
+++ b/openstack/manila/values.yaml
@@ -776,8 +776,10 @@ share_type_extra_specs:
   compression: "<is> True"
   create_share_from_snapshot_support: "True"
   dedupe: "<is> True"
+  mount_point_name_support: "<is> True"
   replication_type: "readable"
   revert_to_snapshot_support: "True"
+  capabilities:netapp_is_home: "True"
   netapp:hide_snapdir: "True"
   netapp:max_files_multiplier: "4.813"  # 33.6925 / 7 -> roughly 1 inode per 7 KB
   netapp:snapshot_policy: "none"


### PR DESCRIPTION
mount_point_name_support can be enabled, NetApp supports it.

netapp_is_home is a new reported capability. Setting this in extra
specs allows us to prevent scheduling shares to Pools (aka NetApp
aggregates) that are not home (due to maintenance or other issues)
with the help of CapabilitiesFilter in Manila scheduler.
