### PR TITLE
[mariadb] bump maria-back-me-up version

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.38.1 - 2026/06/21
+* `maria-back-me-up` updated to `10.11-20260611113653`
+  * fixes aws s3 upload
+* chart version bumped
+
 ## v0.38.0 - 2026/06/03
 * MariaDB version updated to [10.11.18](https://mariadb.com/docs/release-notes/community-server/10.11/10.11.18)
 * `maria-back-me-up` updated to `10.11-20260603173712`

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.38.0
+version: 0.38.1
 # scripts/docker-entyrpoint.sh should be updated when appVersion is updated
 appVersion: 10.11.18
 dependencies:

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -223,7 +223,7 @@ backup_v2:
   enabled: false
   backup_dir: "./backup"
   image: maria-back-me-up
-  image_version: "10.11-20260603173712"
+  image_version: "10.11-20260611113653"
   full_backup_cron_schedule: "0 0 * * *"
   incremental_backup_in_minutes: 5
   purge_binlog_after_minutes: 60


### PR DESCRIPTION
* `maria-back-me-up` updated to `10.11-20260611113653`
  * fixes aws s3 upload
* chart version bumped