### PR TITLE
[NSXT] Add hammer VCSU

### DIFF
--- a/openstack/neutron/templates/vct-nsxv3-vcsu-hammer.yaml
+++ b/openstack/neutron/templates/vct-nsxv3-vcsu-hammer.yaml
@@ -1,0 +1,15 @@
+{{- if or (.Values.isImageTransportTemplating | default false) (and (contains ",nsxv3" .Values.ml2_mechanismdrivers) (.Capabilities.APIVersions.Has "vcenter-operator.stable.sap.cc/v1")) }}
+{{- if .Values.nsxv3_managed_service_users }}
+apiVersion: vcenter-operator.stable.sap.cc/v1
+kind: VCenterServiceUser
+metadata:
+  name: nsxt-hammer
+  namespace: monsoon3
+spec:
+  # Defines the username prefix
+  username: hammer
+  # Based on the service we decide
+  # where the users is managed: vCenter or NSX-T
+  service: nsxt
+{{- end }}
+{{- end }}


### PR DESCRIPTION
Use the vcenter-operator to create a user, used by the network-api team member, in the hammer cli to login to NSXT if we hit the login bug (NSX-T Manager versions < 4.2.1).

This requires a change in pycloud.