### PR TITLE
ironic: adjust max_concurrent_clean

### DIFF
--- a/openstack/ironic/values.yaml
+++ b/openstack/ironic/values.yaml
@@ -217,8 +217,10 @@ conductor:
     conductor:
       conductor_always_validates_images: false # We only use the direct interface, so leave it to the agent
       permitted_image_formats: 'raw,qcow2,iso,vmdk'
-      # HDA has a parallelism of 50 nodes, but with deleting they ran into the limit of 60, so increasing to 100 for now
-      max_concurrent_clean: 100
+      # HDA has a parallelism of 50 nodes, but with deleting they ran into the limit of 60, so increasing to 90. The network in the biggest
+      # region only has a /25 (126) & /26 (62) so ~188 useable IPs but each node uses 2, so enough for ~94 nodes. But we need some for the router
+      # as well and want a small puffer so 90 it is.
+      max_concurrent_clean: 90
 
 agent:
   deploy_logs:


### PR DESCRIPTION
The biggest region only has ~188 usable IPs in the subnets, each node uses two so ~94 nodes could deploy or clean in parallel, but we need 2 IPs for the router and want at least a small buffer so 90 it is for now. If we have to much deployment & cleaning in parallel we need to increase the subnets or further decrease the limit.