### PR TITLE
[CINDER] bump mariadb chart to 0.38.1

### DIFF
--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.37.1
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.37.0
+  version: 0.38.1
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.5.1
@@ -26,5 +26,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:ca105520a346415e634ceb9ed7ffb9eebac939d8f9c57485de5adf888e7079f0
-generated: "2026-06-09T09:45:25.688996-04:00"
+digest: sha256:cf511771150f7696c88ff607aef0836d23520a73edbd9a7fca1516a079065444
+generated: "2026-06-11T09:47:05.738315-04:00"

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -10,7 +10,7 @@ dependencies:
     version: 0.37.1
   - name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.37.0
+    version: 0.38.1
     condition: mariadb.enabled
   - name: pxc-db
     alias: pxc_db


### PR DESCRIPTION
This bumps the cinder helm chart to use the 0.38.1 mariadb chart. This includes the new maria-back-me-up s3 upload fix.