### PR TITLE
Remove deprecated ingress annotation for thanos and plutono

### DIFF
--- a/common/thanos/Chart.yaml
+++ b/common/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: Deploy Thanos via operator
 type: application
-version: 1.3.1
+version: 1.3.2
 appVersion: v0.41.0
 maintainers:
   - name: Tommy Sauer (viennaa)

--- a/common/thanos/templates/ingress-grpc.yaml
+++ b/common/thanos/templates/ingress-grpc.yaml
@@ -11,22 +11,16 @@ metadata:
     disco: "true"
     kubernetes.io/tls-acme: "true"
     {{- if $.Values.grpcIngress.authentication.sso.enabled}}
-    ingress.kubernetes.io/auth-tls-secret: {{ required "$.Values.grpcIngress.authentication.sso.authTLSSecret missing" $.Values.grpcIngress.authentication.sso.authTLSSecret | quote }}
     nginx.ingress.kubernetes.io/auth-tls-secret: {{ required "$.Values.grpcIngress.authentication.sso.authTLSSecret missing" $.Values.grpcIngress.authentication.sso.authTLSSecret | quote }}
-    ingress.kubernetes.io/auth-tls-verify-depth: {{ required "$.Values.grpcIngress.authentication.sso.authTLSVerifyDepth missing" $.Values.grpcIngress.authentication.sso.authTLSVerifyDepth | quote }}
     nginx.ingress.kubernetes.io/auth-tls-verify-depth: {{ required "$.Values.grpcIngress.authentication.sso.authTLSVerifyDepth missing" $.Values.grpcIngress.authentication.sso.authTLSVerifyDepth | quote }}
-    ingress.kubernetes.io/auth-tls-verify-client: {{ required "$.Values.grpcIngress.authentication.sso.authTLSVerifyClient missing" $.Values.grpcIngress.authentication.sso.authTLSVerifyClient | quote }}
     nginx.ingress.kubernetes.io/auth-tls-verify-client: {{ required "$.Values.grpcIngress.authentication.sso.authTLSVerifyClient missing" $.Values.grpcIngress.authentication.sso.authTLSVerifyClient | quote }}
     {{ end }}
-    ingress.kubernetes.io/backend-protocol: {{ required "$.Values.grpcIngress.authentication.grpc.backendProtocol missing" $.Values.grpcIngress.authentication.grpc.backendProtocol | quote }}
     nginx.ingress.kubernetes.io/backend-protocol: {{ required "$.Values.grpcIngress.authentication.grpc.backendProtocol missing" $.Values.grpcIngress.authentication.grpc.backendProtocol | quote }}
-    ingress.kubernetes.io/ssl-redirect: {{ required "$.Values.grpcIngress.authentication.grpc.sslRedirect missing" $.Values.grpcIngress.authentication.grpc.sslRedirect | quote }}
     nginx.ingress.kubernetes.io/ssl-redirect: {{ required "$.Values.grpcIngress.authentication.grpc.sslRedirect missing" $.Values.grpcIngress.authentication.grpc.sslRedirect | quote }}
     {{- if $.Values.grpcIngress.annotations }}
 {{ toYaml $.Values.grpcIngress.annotations | indent 4 }}
     {{ end }}
     {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
-    ingress.kubernetes.io/service-upstream: "true"
     nginx.ingress.kubernetes.io/service-upstream: "true"
     {{- end }}
 spec:

--- a/common/thanos/templates/ingress-internal.yaml
+++ b/common/thanos/templates/ingress-internal.yaml
@@ -11,18 +11,14 @@ metadata:
     disco: "true"
     kubernetes.io/tls-acme: "true"
     {{- if $.Values.internalIngress.authentication.sso.enabled}}
-    ingress.kubernetes.io/auth-tls-secret: {{ required "$.Values.internalIngress.authentication.sso.authTLSSecret missing" $.Values.internalIngress.authentication.sso.authTLSSecret | quote }}
     nginx.ingress.kubernetes.io/auth-tls-secret: {{ required "$.Values.internalIngress.authentication.sso.authTLSSecret missing" $.Values.internalIngress.authentication.sso.authTLSSecret | quote }}
-    ingress.kubernetes.io/auth-tls-verify-depth: {{ required "$.Values.internalIngress.authentication.sso.authTLSVerifyDepth missing" $.Values.internalIngress.authentication.sso.authTLSVerifyDepth | quote }}
     nginx.ingress.kubernetes.io/auth-tls-verify-depth: {{ required "$.Values.internalIngress.authentication.sso.authTLSVerifyDepth missing" $.Values.internalIngress.authentication.sso.authTLSVerifyDepth | quote }}
-    ingress.kubernetes.io/auth-tls-verify-client: {{ required "$.Values.internalIngress.authentication.sso.authTLSVerifyClient missing" $.Values.internalIngress.authentication.sso.authTLSVerifyClient | quote }}
     nginx.ingress.kubernetes.io/auth-tls-verify-client: {{ required "$.Values.internalIngress.authentication.sso.authTLSVerifyClient missing" $.Values.internalIngress.authentication.sso.authTLSVerifyClient | quote }}
     {{ end }}
     {{- if $.Values.internalIngress.annotations }}
 {{ toYaml $.Values.internalIngress.annotations | indent 4 }}
     {{ end }}
     {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
-    ingress.kubernetes.io/service-upstream: "true"
     nginx.ingress.kubernetes.io/service-upstream: "true"
     {{- end }}
 spec:

--- a/common/thanos/templates/ingress.yaml
+++ b/common/thanos/templates/ingress.yaml
@@ -11,26 +11,20 @@ metadata:
     disco: "true"
     kubernetes.io/tls-acme: "true"
     {{- if $.Values.ingress.authentication.oauth.enabled }}
-    ingress.kubernetes.io/auth-url: {{ required "$.Values.ingress.authentication.oauth.authURL missing" $.Values.ingress.authentication.oauth.authURL }}
     nginx.ingress.kubernetes.io/auth-url: {{ required "$.Values.ingress.authentication.oauth.authURL missing" $.Values.ingress.authentication.oauth.authURL }}
     {{- if $.Values.ingress.authentication.oauth.authSignInURL }}
-    ingress.kubernetes.io/auth-signin: {{ $.Values.ingress.authentication.oauth.authSignInURL }}
     nginx.ingress.kubernetes.io/auth-signin: {{ $.Values.ingress.authentication.oauth.authSignInURL }}
     {{- end }}
     {{ end }}
     {{- if $.Values.ingress.authentication.sso.enabled}}
-    ingress.kubernetes.io/auth-tls-secret: {{ required "$.Values.ingress.authentication.sso.authTLSSecret missing" $.Values.ingress.authentication.sso.authTLSSecret | quote }}
     nginx.ingress.kubernetes.io/auth-tls-secret: {{ required "$.Values.ingress.authentication.sso.authTLSSecret missing" $.Values.ingress.authentication.sso.authTLSSecret | quote }}
-    ingress.kubernetes.io/auth-tls-verify-depth: {{ required "$.Values.ingress.authentication.sso.authTLSVerifyDepth missing" $.Values.ingress.authentication.sso.authTLSVerifyDepth | quote }}
     nginx.ingress.kubernetes.io/auth-tls-verify-depth: {{ required "$.Values.ingress.authentication.sso.authTLSVerifyDepth missing" $.Values.ingress.authentication.sso.authTLSVerifyDepth | quote }}
-    ingress.kubernetes.io/auth-tls-verify-client: {{ required "$.Values.ingress.authentication.sso.authTLSVerifyClient missing" $.Values.ingress.authentication.sso.authTLSVerifyClient | quote }}
     nginx.ingress.kubernetes.io/auth-tls-verify-client: {{ required "$.Values.ingress.authentication.sso.authTLSVerifyClient missing" $.Values.ingress.authentication.sso.authTLSVerifyClient | quote }}
     {{ end }}
     {{- if $.Values.ingress.annotations }}
 {{ toYaml $.Values.ingress.annotations | indent 4 }}
     {{ end }}
     {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
-    ingress.kubernetes.io/service-upstream: "true"
     nginx.ingress.kubernetes.io/service-upstream: "true"
     {{- end }}
 spec:

--- a/common/thanos/templates/ingressroute-grpc.yaml
+++ b/common/thanos/templates/ingressroute-grpc.yaml
@@ -9,7 +9,6 @@ metadata:
   name: {{ include "thanos.fullName" (list $name $root) }}-grpc
   {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
   annotations:
-    ingress.kubernetes.io/service-upstream: "true"
     nginx.ingress.kubernetes.io/service-upstream: "true"
   {{- end }}
 spec:

--- a/system/plutono/Chart.yaml
+++ b/system/plutono/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for SAP's CCloud Plutono 7.5.x deployment
 name: plutono
-version: 0.6.7
+version: 0.6.8
 dependencies:
   - name: postgresql-ng
     alias: postgresql

--- a/system/plutono/templates/plutono-ingress.yaml
+++ b/system/plutono/templates/plutono-ingress.yaml
@@ -14,11 +14,8 @@ metadata:
     {{ if .Values.plutono.oauth.authSignInURL }}nginx.ingress.kubernetes.io/auth-signin: {{ .Values.plutono.oauth.authSignInURL }} {{ end }}
   {{ end }}
   {{- if .Values.plutono.auth.tls_client_auth.enabled}}
-    ingress.kubernetes.io/auth-tls-secret: {{ default "" .Values.plutono.auth.tls_client_auth.secret }}
     nginx.ingress.kubernetes.io/auth-tls-secret: {{ default "" .Values.plutono.auth.tls_client_auth.secret }}
-    ingress.kubernetes.io/auth-tls-verify-depth: "3"
     nginx.ingress.kubernetes.io/auth-tls-verify-depth: "3"
-    ingress.kubernetes.io/auth-tls-verify-client: "optional"
     nginx.ingress.kubernetes.io/auth-tls-verify-client: "optional"
   {{- end }}
 


### PR DESCRIPTION
This change will help to tackle the critical `GkIngressAnnotationsMigration` violations on `thanos` and `plutono`. 