### PR TITLE
chore: bump boot-operator to 0.2.1-20260612064329-eeeb577

### DIFF
--- a/system/boot-operator-remote/Chart.lock
+++ b/system/boot-operator-remote/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.0.0
 - name: boot-operator
   repository: oci://ghcr.io/ironcore-dev/charts
-  version: 0.2.1-20260610145656-e198b0f-crds
-digest: sha256:0d1294fa663df670964fda85c1ecf5d7741edbcee4beb8357d9780fc0e38da09
-generated: "2026-06-10T17:09:37.026917+02:00"
+  version: 0.2.1-20260612064329-eeeb577-crds
+digest: sha256:afecd5fc75a8e3ce06c87e9491f6a65a48fa42dcb9936475d0527464340ccfbc
+generated: "2026-06-12T11:09:39.526087+02:00"

--- a/system/boot-operator-remote/Chart.yaml
+++ b/system/boot-operator-remote/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.19
+version: 0.4.21
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -25,5 +25,5 @@ dependencies:
     version: '>= 0.0.0'
   - name: boot-operator
     repository: oci://ghcr.io/ironcore-dev/charts
-    version: 0.2.1-20260610145656-e198b0f-crds
+    version: 0.2.1-20260612064329-eeeb577-crds
     alias: boot-operator-core

--- a/system/boot-operator-remote/Chart.yaml
+++ b/system/boot-operator-remote/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.21
+version: 0.4.20
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/boot-operator-remote/managedresources/crds-and-rbac.yaml
+++ b/system/boot-operator-remote/managedresources/crds-and-rbac.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/version: "0.1.0"
-    helm.sh/chart: "0.2.1-20260610145656-e198b0f-crds"
+    helm.sh/chart: "0.2.1-20260612064329-eeeb577-crds"
     app.kubernetes.io/name: boot-operator
     app.kubernetes.io/instance: boot-operator
     app.kubernetes.io/managed-by: Helm
@@ -18,7 +18,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/version: "0.1.0"
-    helm.sh/chart: "0.2.1-20260610145656-e198b0f-crds"
+    helm.sh/chart: "0.2.1-20260612064329-eeeb577-crds"
     app.kubernetes.io/name: boot-operator
     app.kubernetes.io/instance: boot-operator
     app.kubernetes.io/managed-by: Helm
@@ -166,7 +166,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/version: "0.1.0"
-    helm.sh/chart: "0.2.1-20260610145656-e198b0f-crds"
+    helm.sh/chart: "0.2.1-20260612064329-eeeb577-crds"
     app.kubernetes.io/name: boot-operator
     app.kubernetes.io/instance: boot-operator
     app.kubernetes.io/managed-by: Helm
@@ -341,7 +341,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/version: "0.1.0"
-    helm.sh/chart: "0.2.1-20260610145656-e198b0f-crds"
+    helm.sh/chart: "0.2.1-20260612064329-eeeb577-crds"
     app.kubernetes.io/name: boot-operator
     app.kubernetes.io/instance: boot-operator
     app.kubernetes.io/managed-by: Helm
@@ -358,7 +358,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/version: "0.1.0"
-    helm.sh/chart: "0.2.1-20260610145656-e198b0f-crds"
+    helm.sh/chart: "0.2.1-20260612064329-eeeb577-crds"
     app.kubernetes.io/name: boot-operator
     app.kubernetes.io/instance: boot-operator
     app.kubernetes.io/managed-by: Helm
@@ -384,7 +384,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/version: "0.1.0"
-    helm.sh/chart: "0.2.1-20260610145656-e198b0f-crds"
+    helm.sh/chart: "0.2.1-20260612064329-eeeb577-crds"
     app.kubernetes.io/name: boot-operator
     app.kubernetes.io/instance: boot-operator
     app.kubernetes.io/managed-by: Helm
@@ -416,7 +416,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/version: "0.1.0"
-    helm.sh/chart: "0.2.1-20260610145656-e198b0f-crds"
+    helm.sh/chart: "0.2.1-20260612064329-eeeb577-crds"
     app.kubernetes.io/name: boot-operator
     app.kubernetes.io/instance: boot-operator
     app.kubernetes.io/managed-by: Helm
@@ -444,7 +444,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/version: "0.1.0"
-    helm.sh/chart: "0.2.1-20260610145656-e198b0f-crds"
+    helm.sh/chart: "0.2.1-20260612064329-eeeb577-crds"
     app.kubernetes.io/name: boot-operator
     app.kubernetes.io/instance: boot-operator
     app.kubernetes.io/managed-by: Helm
@@ -476,7 +476,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/version: "0.1.0"
-    helm.sh/chart: "0.2.1-20260610145656-e198b0f-crds"
+    helm.sh/chart: "0.2.1-20260612064329-eeeb577-crds"
     app.kubernetes.io/name: boot-operator
     app.kubernetes.io/instance: boot-operator
     app.kubernetes.io/managed-by: Helm
@@ -503,7 +503,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/version: "0.1.0"
-    helm.sh/chart: "0.2.1-20260610145656-e198b0f-crds"
+    helm.sh/chart: "0.2.1-20260612064329-eeeb577-crds"
     app.kubernetes.io/name: boot-operator
     app.kubernetes.io/instance: boot-operator
     app.kubernetes.io/managed-by: Helm
@@ -528,7 +528,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/version: "0.1.0"
-    helm.sh/chart: "0.2.1-20260610145656-e198b0f-crds"
+    helm.sh/chart: "0.2.1-20260612064329-eeeb577-crds"
     app.kubernetes.io/name: boot-operator
     app.kubernetes.io/instance: boot-operator
     app.kubernetes.io/managed-by: Helm
@@ -545,7 +545,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/version: "0.1.0"
-    helm.sh/chart: "0.2.1-20260610145656-e198b0f-crds"
+    helm.sh/chart: "0.2.1-20260612064329-eeeb577-crds"
     app.kubernetes.io/name: boot-operator
     app.kubernetes.io/instance: boot-operator
     app.kubernetes.io/managed-by: Helm
@@ -637,7 +637,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/version: "0.1.0"
-    helm.sh/chart: "0.2.1-20260610145656-e198b0f-crds"
+    helm.sh/chart: "0.2.1-20260612064329-eeeb577-crds"
     app.kubernetes.io/name: boot-operator
     app.kubernetes.io/instance: boot-operator
     app.kubernetes.io/managed-by: Helm
@@ -657,7 +657,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/version: "0.1.0"
-    helm.sh/chart: "0.2.1-20260610145656-e198b0f-crds"
+    helm.sh/chart: "0.2.1-20260612064329-eeeb577-crds"
     app.kubernetes.io/name: boot-operator
     app.kubernetes.io/instance: boot-operator
     app.kubernetes.io/managed-by: Helm
@@ -677,7 +677,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/version: "0.1.0"
-    helm.sh/chart: "0.2.1-20260610145656-e198b0f-crds"
+    helm.sh/chart: "0.2.1-20260612064329-eeeb577-crds"
     app.kubernetes.io/name: boot-operator
     app.kubernetes.io/instance: boot-operator
     app.kubernetes.io/managed-by: Helm
@@ -698,7 +698,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/version: "0.1.0"
-    helm.sh/chart: "0.2.1-20260610145656-e198b0f-crds"
+    helm.sh/chart: "0.2.1-20260612064329-eeeb577-crds"
     app.kubernetes.io/name: boot-operator
     app.kubernetes.io/instance: boot-operator
     app.kubernetes.io/managed-by: Helm
@@ -743,7 +743,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/version: "0.1.0"
-    helm.sh/chart: "0.2.1-20260610145656-e198b0f-crds"
+    helm.sh/chart: "0.2.1-20260612064329-eeeb577-crds"
     app.kubernetes.io/name: boot-operator
     app.kubernetes.io/instance: boot-operator
     app.kubernetes.io/managed-by: Helm

--- a/system/boot-operator/Chart.lock
+++ b/system/boot-operator/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.0.0
 - name: boot-operator
   repository: oci://ghcr.io/ironcore-dev/charts
-  version: 0.2.1-20260610145656-e198b0f
-digest: sha256:cc7e225cd4815a62f25a4721124056329a78f283539627c072a6edd87935d370
-generated: "2026-06-10T17:09:43.443587+02:00"
+  version: 0.2.1-20260612064329-eeeb577
+digest: sha256:a4bd65a6771d960da69899f8cede837da234a4ce04d9d8621e7d1e649d5abd1f
+generated: "2026-06-12T11:09:33.952527+02:00"

--- a/system/boot-operator/Chart.yaml
+++ b/system/boot-operator/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: boot-operator
 description: A Helm chart for the Ironcore boot-operator.
 type: application
-version: 0.2.4
+version: 0.2.5
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: '>= 0.0.0'
   - name: boot-operator
     repository: oci://ghcr.io/ironcore-dev/charts
-    version: 0.2.1-20260610145656-e198b0f
+    version: 0.2.1-20260612064329-eeeb577
     alias: boot-operator-core


### PR DESCRIPTION
## Summary

Bumps the upstream `boot-operator` Helm chart dependency to the latest published version `0.2.1-20260612064329-eeeb577`, which includes a bump of the `metal-operator` library from 0.5.0 to 0.5.1.

## Changes Made

- `system/boot-operator/Chart.yaml`: dep `0.2.1-20260610145656-e198b0f` → `0.2.1-20260612064329-eeeb577`, outer chart `0.2.4` → `0.2.5`
- `system/boot-operator-remote/Chart.yaml`: dep `0.2.1-20260610145656-e198b0f-crds` → `0.2.1-20260612064329-eeeb577-crds`, outer chart `0.4.19` → `0.4.21`
- `system/boot-operator-remote/managedresources/crds-and-rbac.yaml`: regenerated via `make build-boot-operator-remote`
- `Chart.lock` files updated for both charts

## Upstream Changes (e198b0f → eeeb577)

- Bump `github.com/ironcore-dev/metal-operator` from 0.5.0 to 0.5.1

## Type of Change
- [x] Maintenance / dependency bump (non-breaking)

## Notes

- Image will roll to `sha-eeeb577` on the Keppel mirror — confirmed mirrored on `keppel.eu-de-1.cloud.sap`
- Values overrides in `kube-secrets` (repository mirror path, args, strategy) are unaffected
- Helm rendering verified locally before committing