### PR TITLE
[ironic] remove outdated sentry references

### DIFF
--- a/openstack/ironic/templates/_conductor-deployment.yaml.tpl
+++ b/openstack/ironic/templates/_conductor-deployment.yaml.tpl
@@ -78,13 +78,6 @@ spec:
         env:
         - name: PYTHONWARNINGS
           value: ignore:Unverified HTTPS request
-        {{- if .Values.logging.handlers.sentry }}
-        - name: SENTRY_DSN
-          valueFrom:
-            secretKeyRef:
-              name: sentry
-              key: {{ .Chart.Name }}.DSN.python
-        {{- end }}
         - name: PGAPPNAME
           valueFrom:
             fieldRef:

--- a/openstack/ironic/templates/api-deployment.yaml
+++ b/openstack/ironic/templates/api-deployment.yaml
@@ -60,13 +60,6 @@ spec:
         env:
         - name: PYTHONWARNINGS
           value: 'ignore:Unverified HTTPS request'
-        {{- if .Values.logging.handlers.sentry }}
-        - name: SENTRY_DSN
-          valueFrom:
-            secretKeyRef:
-              name: sentry
-              key: {{ .Chart.Name }}.DSN.python
-        {{- end }}
         lifecycle:
           preStop:
             {{- include "utils.snippets.pre_stop_graceful_shutdown" . | indent 12 }}

--- a/openstack/ironic/templates/inspector-conductor-deployment.yaml
+++ b/openstack/ironic/templates/inspector-conductor-deployment.yaml
@@ -53,14 +53,6 @@ spec:
         command:
         - dumb-init
         - ironic-inspector-conductor
-        env:
-        {{- if .Values.logging.handlers.sentry }}
-        - name: SENTRY_DSN
-          valueFrom:
-            secretKeyRef:
-              name: sentry
-              key: {{ .Chart.Name }}.DSN.python
-        {{- end }}
         resources:
 {{ toYaml .Values.pod.resources.inspector | indent 10 }}
         volumeMounts:

--- a/openstack/ironic/templates/inspector-deployment.yaml
+++ b/openstack/ironic/templates/inspector-deployment.yaml
@@ -64,14 +64,6 @@ spec:
           capabilities:
             add:
               - NET_ADMIN
-        env:
-        {{- if .Values.logging.handlers.sentry }}
-        - name: SENTRY_DSN
-          valueFrom:
-            secretKeyRef:
-              name: sentry
-              key: {{ .Chart.Name }}.DSN.python
-        {{- end }}
         lifecycle:
           preStop:
             {{- include "utils.snippets.pre_stop_graceful_shutdown" . | indent 12 }}

--- a/openstack/ironic/templates/sentry.yaml
+++ b/openstack/ironic/templates/sentry.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.logging.handlers.sentry }}
+{{- if .Values.logging.handlers.sentry_events}}
 apiVersion: "sentry.sap.cc/v1"
 kind: "SentryProject"
 metadata:

--- a/openstack/ironic/values.yaml
+++ b/openstack/ironic/values.yaml
@@ -455,22 +455,26 @@ logging:
       class: StreamHandler
       args: "(sys.stdout,)"
       formatter: context
-    sentry:
-      class: sapcc_sentrylogger.handler.SentryEventHandler
+    sentry_events:
+      class: "sapcc_sentrylogger.handler.EventHandler"
       level: ERROR
+      args: "()"
+    sentry_breadcrumbs:
+      class: "sapcc_sentrylogger.handler.BreadcrumbHandler"
+      level: INFO
       args: "()"
   loggers:
     root:
-      handlers: stdout, sentry
+      handlers: stdout, sentry_events, sentry_breadcrumbs
       level: WARNING
     ironic:
-      handlers: stdout, sentry
+      handlers: stdout, sentry_events, sentry_breadcrumbs
       level: DEBUG
     eventlet.wsgi.server:
-      handlers: stdout, sentry
+      handlers: stdout, sentry_events, sentry_breadcrumbs
       level: INFO
     auditmiddleware:
-      handlers: stdout, sentry
+      handlers: stdout, sentry_events, sentry_breadcrumbs
       level: INFO
 
 memcached:

--- a/openstack/ironic/values.yaml
+++ b/openstack/ironic/values.yaml
@@ -430,9 +430,6 @@ dbName: ironic
 max_pool_size: 1
 max_overflow: 50
 
-sentry:
-  enabled: true
-
 rabbitmq:
   name: ironic
   persistence:


### PR DESCRIPTION
Sentry is connected via the templates/sentry.yaml snippet so the old way
via sentry_dsn is no longer needed. We remove all references to
sentry_dsn.
