### PR TITLE
barbican: preserve region label so all alerts route to #cc-os-barbican

### DIFF
--- a/openstack/barbican/alerts/openstack-barbican.alerts
+++ b/openstack/barbican/alerts/openstack-barbican.alerts
@@ -51,7 +51,7 @@ groups:
       summary: barbican has reported issues to Sentry
 
   - alert: OpenstackBarbicanRateLimitActionIsAbove50
-    expr: sum by(initiator_project_id, action, initiator_user_name) (rate(openstack_ratelimit_requests_ratelimit_total{service="key-manager", container="barbican-api"}[2m]) * 60) > 50
+    expr: sum by(region, initiator_project_id, action, initiator_user_name) (rate(openstack_ratelimit_requests_ratelimit_total{service="key-manager", container="barbican-api"}[2m]) * 60) > 50
     for: 1m
     labels:
       severity: warning
@@ -85,7 +85,7 @@ groups:
       summary: "A barbican server is DOWN"
 
   - alert: OpenstackBarbicanDatabaseIsDown
-    expr: count(up{component="barbican-mariadb"} == 0) == count(up{component="barbican-mariadb"})
+    expr: count by(region) (up{component="barbican-mariadb"} == 0) == count by(region) (up{component="barbican-mariadb"})
     for: 5m
     labels:
       context: availability
@@ -101,7 +101,7 @@ groups:
       summary: "barbican Database is DOWN"
 
   - alert: OpenstackBarbicanApiAllDown
-    expr: count(up{component="barbican",type="api"} == 0) == count(up{component="barbican",type="api"})
+    expr: count by(region) (up{component="barbican",type="api"} == 0) == count by(region) (up{component="barbican",type="api"})
     for: 5m
     labels:
       context: availability


### PR DESCRIPTION
## Why

Several alerts in [`openstack/barbican/alerts/openstack-barbican.alerts`](openstack/barbican/alerts/openstack-barbican.alerts) use `sum` / `count` aggregations **without** a `by()` clause that preserves the `region` label. As a result the alerts fire without a `region` label.

The Alertmanager route [`slack_by_os_service`](https://github.com/sapcc/greenhouse/blob/main/p-eu-de-1/sci/support-groups/observability/am-configs/am-config-route-slack.yaml) (which sends `service=barbican,tier=os` alerts to `#cc-os-{service}` → `#cc-os-barbican`) requires:

```yaml
- name: region
  matchType: "=~"
  value: {{ without .Values.regions "qa-de-1" | join "|" }}
```

A regex matcher against an absent label fails, so these alerts are silently dropped at the routing stage and **never land in `#cc-osA regex matcher against an absent label fails, so these alerts are silently dropped at the routing stage and **never land in `#cc-osA regex matcher against an absent label fails, so these alert beA regex matcher against an absent label fails, so these alerts are silently dropped at the routing stage and **never land in `#cc-osA regex matcher against an absent label fails, so these alerts are silently dropped at the routing stage and **never land in `#cc-osA regex matcher againion, initiator_user_name) (...)` | `sum by(region, initiator_project_id, action, initiator_user_name) (...)` |
| `OpenstackBarbicanDatabaseIsDown` | `count(up{...} == 0) == count(up{...})` | `count by(region) (up{...} == 0) == count by(region) (up{...})` |
| `OpenstackBarbicanApiAllDown` | `Openstap{..| `OpenstackBarbiup| `OpenstackBarbicanApiAllDown` | `Openstap{..| `Openstackn) (up{...})` |

The semantic of each alert is preserved (rate-limit is still aggregated per (project, action, user); the DB/API "all down" alerts still compare "down count" vs "total count"), but now per region — which is also more correct for multi-region deployments.

## Effect

After the change, all alerts in this file carry the `region` label and therefore match the `slack_by_os_service` route, so they fire into **`#cc-os-barbican`** like the Sentry alert already does.