### PR TITLE
barbican: whitelist cronus user from ratelimits

### DIFF
--- a/openstack/barbican/templates/etc/_ratelimit.yaml.tpl
+++ b/openstack/barbican/templates/etc/_ratelimit.yaml.tpl
@@ -6,6 +6,7 @@ whitelist:
 whitelist_users:
   - TS4_S4_SMTP_01
   - ceph-barbican
+  - cronus
 
 # Override default ratelimit response.
 ratelimit_response:


### PR DESCRIPTION
## What

Add the `cronus` technical user to `whitelist_users` in the barbican ratelimit configuration (`openstack/barbican/templates/etc/_ratelimit.yaml.tpl`).

## Why

`cronus` issues frequent requests to barbican as part of its normal operation and was hitting the per-user rate limits. Whitelisting it puts it on the same footing as the other technical users already listed (`TS4_S4_SMTP_01`, `ceph-barbican`).

## Diff

```diff
 whitelist_users:
   - TS4_S4_SMTP_01
   - ceph-barbican
+  - cronus
```