### PR TITLE
[kmip] fix mysql-metrics: cast int label columns to CHAR + UNION ALL fallback

### DIFF
--- a/openstack/kmip/Chart.lock
+++ b/openstack/kmip/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 1.1.1
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.37.1
+  version: 0.37.2
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.35.0
@@ -17,5 +17,5 @@ dependencies:
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.8.1
-digest: sha256:460f5a1f9f8745ccdbaeefa6c630f709fbbe677fc81948de36eef0cb76492c1e
-generated: "2026-06-10T12:18:50.655853+05:30"
+digest: sha256:0cc9b2877af63e523c584dcf65689ae1bacecfbfe6f1298f1a450dcbbdbd314e
+generated: "2026-06-12T16:12:23.779367+05:30"

--- a/openstack/kmip/Chart.yaml
+++ b/openstack/kmip/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Chart Version
-version: 0.3.9
+version: 0.3.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/openstack/kmip/alerts/openstack-kmip.alerts
+++ b/openstack/kmip/alerts/openstack-kmip.alerts
@@ -71,7 +71,7 @@ groups:
     labels:
       context: keys
       service: kmip
-      severity: warning
+      severity: info
       support_group: identity
       tier: os
       no_alert_on_absence: "true"

--- a/openstack/kmip/values.yaml
+++ b/openstack/kmip/values.yaml
@@ -156,16 +156,34 @@ mysql_metrics:
       - "owner"
       - "value"
       query: |
-        SELECT
-          object_type,
-          class_type,
-          operation_policy_name,
-          `sensitive`,
-          COALESCE(owner, '') AS owner,
-          'redacted' AS value,
-          COUNT(*) AS gauge
-        FROM managed_objects
-        GROUP BY object_type, class_type, operation_policy_name, `sensitive`, owner;
+        SELECT object_type, class_type, operation_policy_name, `sensitive`, owner, value, gauge
+        FROM (
+          SELECT
+            CAST(object_type AS CHAR) AS object_type,
+            COALESCE(class_type, '') AS class_type,
+            COALESCE(operation_policy_name, '') AS operation_policy_name,
+            CAST(`sensitive` AS CHAR) AS `sensitive`,
+            COALESCE(owner, '') AS owner,
+            'redacted' AS value,
+            COUNT(*) AS gauge
+          FROM managed_objects
+          GROUP BY
+            object_type,
+            class_type,
+            operation_policy_name,
+            `sensitive`,
+            owner
+          UNION ALL
+          SELECT
+            'none' AS object_type,
+            'none' AS class_type,
+            'none' AS operation_policy_name,
+            'none' AS `sensitive`,
+            'none' AS owner,
+            'redacted' AS value,
+            0 AS gauge
+          WHERE NOT EXISTS (SELECT 1 FROM managed_objects)
+        ) x;
       values:
       - "gauge"
     - name: openstack_kmip_managed_objects_by_state_gauge
@@ -175,14 +193,28 @@ mysql_metrics:
       - "state"
       - "owner"
       query: |
-        SELECT
-          mo.class_type,
-          co.state,
-          COALESCE(mo.owner, '') AS owner,
-          COUNT(*) AS gauge
-        FROM managed_objects mo
-        JOIN crypto_objects co ON mo.uid = co.uid
-        GROUP BY mo.class_type, co.state, mo.owner;
+        SELECT class_type, state, owner, gauge
+        FROM (
+          SELECT
+            COALESCE(mo.class_type, '') AS class_type,
+            CAST(co.state AS CHAR) AS state,
+            COALESCE(mo.owner, '') AS owner,
+            COUNT(*) AS gauge
+          FROM managed_objects mo
+          JOIN crypto_objects co ON mo.uid = co.uid
+          GROUP BY mo.class_type, co.state, mo.owner
+          UNION ALL
+          SELECT
+            'none' AS class_type,
+            'none' AS state,
+            'none' AS owner,
+            0 AS gauge
+          WHERE NOT EXISTS (
+            SELECT 1
+            FROM managed_objects mo
+            JOIN crypto_objects co ON mo.uid = co.uid
+          )
+        ) x;
       values:
       - "gauge"
     - name: openstack_kmip_managed_objects_age_seconds_gauge
@@ -190,12 +222,22 @@ mysql_metrics:
       labels:
       - "owner"
       query: |
-        SELECT
-          COALESCE(owner, '') AS owner,
-          UNIX_TIMESTAMP() - MIN(initial_date) AS gauge
-        FROM managed_objects
-        WHERE initial_date > 0
-        GROUP BY owner;
+        SELECT owner, gauge
+        FROM (
+          SELECT
+            COALESCE(owner, '') AS owner,
+            UNIX_TIMESTAMP() - MIN(initial_date) AS gauge
+          FROM managed_objects
+          WHERE initial_date > 0
+          GROUP BY owner
+          UNION ALL
+          SELECT
+            'none' AS owner,
+            0 AS gauge
+          WHERE NOT EXISTS (
+            SELECT 1 FROM managed_objects WHERE initial_date > 0
+          )
+        ) x;
       values:
       - "gauge"
     - name: openstack_kmip_total_managed_objects_gauge


### PR DESCRIPTION
### What

Fix the failing `kmip-mysql-metrics` (sql-exporter) custom queries.

The exporter was logging the following errors in `qa-de-1` continuously:

```
column 'object_type' must be type text (string)
column 'state'       must be type text (string)
zero values found
zero rows returned
```

### Why

For the labelled metrics:

- `managed_objects.object_type` is `int(11)`
- `managed_objects.sensitive`   is `tinyint(1)`
- `crypto_objects.state`        is `int(11)`

…but `sql_exporter` requires every column listed under `labels:` to be returned as a **text/string** type. In addition, when the `managed_objects` table is empty (most non-prod regions), the queries returned no rows which produced the secondary `zero rows returned` / `zero values found` warnings.

### How

Mirrored the pattern already in use in `helm-charts/openstack/barbican/values.yaml` (introduced in commit `3e21533ffe` for `openstack_barbican_orders_count_gauge` and earlier in `0aa79cb72a` / `c75e3d5b8c`):

1. `CAST(... AS CHAR)` for the integer label columns (`object_type`, `sensitive`, `state`).
2. `COALESCE(col, '')` for nullable text label columns (`class_type`, `operation_policy_name`, `owner`).
3. Wrapped each query in
   ```
   SELECT ... FROM (
     <real query>
     UNION ALL
     SELECT 'none', ..., 0 WHERE NOT EXISTS (<real source>)
   ) x;
   ```
   so a default `'none'` row is emitted when the source table is empty — eliminating the `zero rows returned` / `zero values found` warnings without changing the metric semantics when data exists.

`openstack_kmip_total_managed_objects_gauge` was left untouched — it has no labels and `COUNT(*)` always returns a row.

Also bumped chart version `0.3.9 → 0.3.10` and refreshed `Chart.lock`.

### Tested

Deployed locally to `qa-de-1` from a clean branch off `origin/master`:

```
helm3 upgrade kmip \
  --values ~/sapcc/secrets/qa-de-1/values/globals.yaml \
  --namespace monsoon3 --reset-values --install \
  --values ~/sapcc/secrets/qa-de-1/values/kmip-barbican.yaml \
  --values ~/sapcc/secrets/qa-de-1/values/openstack-globals.yaml \
  --values ~/sapcc/secrets/global/values/db-backup-v2.yaml .
```

After `kubectl rollout restart deployment kmip-mysql-metrics`:

- Pod log contains only startup info — no `error` / `warn` entries.
- `Secret/kmip-mysql-metrics-etc` `config.yml` contains the new `CAST` / `UNION ALL` queries.
- `:9237/metrics` exposes the series correctly, e.g.
  ```
  openstack_kmip_managed_objects_age_seconds_gauge{owner="vc-a-1.cc.qa-de-1.cloud.sap",...} 5.6661053e+07
  openstack_kmip_managed_objects_by_state_gauge{class_type="SymmetricKey",state="2",owner="...",...} 6
  ```

### Effect on other regions

This fix also resolves the errors observed in every other region:
- `qa-de-2` had the same `column ... must be type text` errors → fixed by the CAST.
- `eu-de-1` / `ap-jp-2` had `column 'uid' must be type text` from the older values-set — the current values.yaml no longer uses `uid` as a label, so the new chart eliminates that error too.
- All other regions (eu-de-2, eu-nl-1, na-us-*, ap-*, la-br-1, na-ca-1) only had `zero queries ran` / `zero rows returned` from empty `managed_objects` tables → fixed by the `UNION ALL` fallback.