### PR TITLE
fix(aurora): exclude sensitive env vars from PR preview secret only

### DIFF
--- a/openstack/aurora/templates/_env.tpl
+++ b/openstack/aurora/templates/_env.tpl
@@ -5,12 +5,12 @@
   value: {{ .Values.identity_endpoint | default (printf "https://identity-3.%s.%s/v3" .Values.global.region .Values.global.tld) | quote }}
 - name: CEPH_REGION
   value: {{ .Values.ceph_region | quote }}
-{{- if not .Values.prPreview.enabled }}
+{{- if not (contains "pr-secret" .Template.Name) }}
 - name: FEEDBACK_RECIPIENT_EMAIL
   value: {{ .Values.feedback_recipient_email | quote }}
 - name: LIMES_MAIL_SERVER_ENDPOINT
   # prettier-ignore
-  value: {{ .Values.limes_mail_server_endpoint | default (printf "https://limes-mail-server-%s.%s" .Values.global.region .Values.global.tld) | quote }}  
+  value: {{ .Values.limes_mail_server_endpoint | default (printf "https://limes-mail-server-%s.%s" .Values.global.region .Values.global.tld) | quote }}
 - name: TECHNICAL_USER_NAME
   value: {{ .Values.technical_user_name | quote }}
 - name: TECHNICAL_USER_PASSWORD


### PR DESCRIPTION
## Problem

  When deploying to QA with `prPreview.enabled=true` (needed to create PR preview resources like namespace, secrets, roles), the regular Aurora deployment was missing sensitive environment variables due to the
  conditional in `_env.tpl`.

  This caused the QA environment deployment to be missing:
  - `FEEDBACK_RECIPIENT_EMAIL`
  - `LIMES_MAIL_SERVER_ENDPOINT`
  - `TECHNICAL_USER_NAME`
  - `TECHNICAL_USER_PASSWORD`
  - `TECHNICAL_USER_DOMAIN`

  ## Solution

  Updated `_env.tpl` to detect the calling template using `{{- if not (contains "pr-secret" .Template.Name) }}`. This way:

  - **deployment.yaml**: Always gets ALL environment variables ✅
  - **pr-secret.yaml**: Only gets basic env vars (PORT, IDENTITY_ENDPOINT, CEPH_REGION) ✅