### PR TITLE
mariadb: add podAffinity to backup deployment for shared PVC co-location

### DIFF
--- a/common/mariadb/templates/backup-v2-deployment.yaml
+++ b/common/mariadb/templates/backup-v2-deployment.yaml
@@ -33,6 +33,17 @@ spec:
 {{- end }}
     spec:
       affinity:
+{{- if and .Values.persistence_claim.enabled (has "ReadWriteMany" .Values.persistence_claim.access_modes) }}
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - {{ include "fullName" . }}
+            topologyKey: kubernetes.io/hostname
+{{- end }}
 {{- if .Values.nodeAffinity }}
       {{- with .Values.nodeAffinity }}
         nodeAffinity:


### PR DESCRIPTION
## Problem

The `cinder-mariadb-backup` deployment in eu-de-3 has been failing since the pipeline was created (28 consecutive failures, dating back to April 22, 2026). The pod gets stuck in `Init:0/2` with:

```
Warning  FailedAttachVolume  attachdetach-controller  
Multi-Attach error for volume "pvc-c267706c-479d-4d15-b861-d69877793508"
Volume is already used by pod(s) cinder-mariadb-d975bb477-gcq5j
```

The backup pod shares the same PVC (`db-cinder-pvclaim`) as the main mariadb pod. In eu-de-3, the storage class is `rook-ceph-block` which only supports `ReadWriteOnce` — the volume can only attach to a single node. When the scheduler places the backup pod on a different node than the main DB pod, the volume cannot attach.

Other regions (ap-jp-2, eu-de-1, eu-de-2) work because they use NFS-backed storage that supports `ReadWriteMany`.

## Fix

Add a `podAffinity` rule with `requiredDuringSchedulingIgnoredDuringExecution` to the backup deployment template, ensuring it is always scheduled on the same node as the main mariadb pod.

The affinity is gated by the same condition that mounts the shared PVC:
```
{{- if and .Values.persistence_claim.enabled (has "ReadWriteMany" .Values.persistence_claim.access_modes) }}
```

This is safe for all deployments:
- **RWO storage** (eu-de-3): required for correctness — prevents Multi-Attach errors
- **RWX storage** (ap-jp-2, etc.): harmless — co-location has no downside

## Verification

- Manually patched the deployment in eu-de-3 via `kubectl patch` — pod immediately started and became healthy
- Confirmed template renders correctly with `helm template` for both RWM-included and RWM-excluded access_modes configurations

## Impact

- **common/mariadb** subchart (affects all consumers: cinder, nova, neutron, etc. that use backup_v2)
- No values.yaml changes required — the fix is unconditional when the PVC is shared