### PR TITLE
NSX-T: do not set liveness probe to null

### DIFF
--- a/openstack/neutron/templates/vct-nsxv3-agent-deployment.yaml
+++ b/openstack/neutron/templates/vct-nsxv3-agent-deployment.yaml
@@ -83,8 +83,6 @@ template: |
             initialDelaySeconds: 200
             periodSeconds: 30
             timeoutSeconds: 10
-          {{- else }}
-          livenessProbe: null
           {{- end }}
           resources:
 {{ toYaml .Values.pod.resources.nsxv3_agent | indent 12 }}


### PR DESCRIPTION
We had issues with removing liveness probes. Trying to fix them by adding livenessProbe: null did not help.
There was another underlying problem.

The vcenter-operator executes a server-side apply to update k8s resources, which checks the ownership. Removing an element with a second owner, which we observed for very old deployments, did not remove the probe.

To overcome the issue, we cleanup the managed fields in the vcenter-operator.