### PR TITLE
Bump gardener to 1.143.1

### DIFF
--- a/global/cc-gardener/Chart.lock
+++ b/global/cc-gardener/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: operator
   repository: oci://europe-docker.pkg.dev/gardener-project/releases/charts/gardener
-  version: v1.142.1
+  version: v1.143.1
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:19cebd266cffe333ac411d8622ad57e059b8d030913d0b859f44d6dc165f1fd6
-generated: "2026-05-27T15:22:46.604023062+02:00"
+digest: sha256:e4e5e88a094c30e69ef728f2778a3f9e358a12d05ceb09f6486d64a06b5385d3
+generated: "2026-06-16T13:14:41.81219+02:00"

--- a/global/cc-gardener/Chart.yaml
+++ b/global/cc-gardener/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 name: cc-gardener
 description: Converged Cloud Gardener setup based on gardener-operator
 type: application
-version: 0.36.1
-appVersion: "v1.142.1"
+version: 0.37.0
+appVersion: "v1.143.1"
 home: https://github.com/gardener/gardener
 dependencies:
 - name: operator
   repository: oci://europe-docker.pkg.dev/gardener-project/releases/charts/gardener
-  version: v1.142.1
+  version: v1.143.1
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: '>= 0.0.0'

--- a/global/cc-gardener/README.md
+++ b/global/cc-gardener/README.md
@@ -2,8 +2,8 @@
 
 - setup operator CRDs
 ```sh
-k apply -f https://raw.githubusercontent.com/gardener/gardener/refs/tags/v1.141.1/charts/gardener/operator/files/crd-extensions.yaml
-k apply -f https://raw.githubusercontent.com/gardener/gardener/refs/tags/v1.141.1/charts/gardener/operator/files/crd-gardens.yaml
+k apply -f https://raw.githubusercontent.com/gardener/gardener/refs/tags/v1.143.1/charts/gardener/operator/files/crd-extensions.yaml
+k apply -f https://raw.githubusercontent.com/gardener/gardener/refs/tags/v1.143.1/charts/gardener/operator/files/crd-gardens.yaml
 k label crd gardens.operator.gardener.cloud extensions.operator.gardener.cloud app.kubernetes.io/managed-by=Helm
 k annotate crd gardens.operator.gardener.cloud extensions.operator.gardener.cloud meta.helm.sh/release-name=cc-gardener meta.helm.sh/release-namespace=garden
 ```
@@ -34,12 +34,12 @@ k annotate crd gardens.operator.gardener.cloud extensions.operator.gardener.clou
     image:
       pullPolicy: IfNotPresent
       repository: europe-docker.pkg.dev/gardener-project/releases/gardener/gardenlet
-      tag: v1.141.1  <<<
+      tag: v1.143.1  <<<
     ```
 - Helm diff
-    `› helm diff upgrade gardenlet oci://keppel.eu-de-1.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/charts/gardener/gardenlet --version v1.141.1 -f gardenlet-values.yaml`
+    `› helm diff upgrade gardenlet oci://keppel.eu-de-1.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/charts/gardener/gardenlet --version v1.143.1 -f gardenlet-values.yaml`
 - Helm upgrade
-    `› helm upgrade gardenlet oci://keppel.eu-de-1.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/charts/gardener/gardenlet --version v1.141.1 -f gardenlet-values.yaml`
+    `› helm upgrade gardenlet oci://keppel.eu-de-1.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/charts/gardener/gardenlet --version v1.143.1 -f gardenlet-values.yaml`
 
 # Verify
 - Check pods in the `garden` namespace on the seed cluster. `deployment/gardenlet` should have updated.

--- a/global/cc-gardener/values.yaml
+++ b/global/cc-gardener/values.yaml
@@ -4,7 +4,7 @@ global:
 operator:
   image:
     repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/operator
-    tag: v1.141.1 # also the gardener version, which will be used
+    tag: v1.143.1 # also the gardener version, which will be used
   imageVectorOverwrite: |
     images:
       - name: alertmanager
@@ -24,8 +24,12 @@ operator:
         tag: v0.28.0
       - name: cluster-autoscaler
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/autoscaler/cluster-autoscaler
-        tag: "v1.34.1"
-        targetVersion: ">= 1.34"
+        tag: "v1.35.0"
+        targetVersion: ">= 1.35"
+      - name: cluster-autoscaler
+        repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/autoscaler/cluster-autoscaler
+        tag: "v1.34.2"
+        targetVersion: "1.34.x"
       - name: cluster-autoscaler
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/autoscaler/cluster-autoscaler
         tag: "v1.33.1"
@@ -39,7 +43,7 @@ operator:
         tag: "v1.10.3"
       - name: configmap-reloader
         repository: keppel.global.cloud.sap/ccloud-quay-mirror/prometheus-operator/prometheus-config-reloader
-        tag: v0.90.1
+        tag: v0.91.0
       - name: coredns
         repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/coredns/coredns
         tag: "v1.14.2"
@@ -69,7 +73,7 @@ operator:
         tag: "v4.2.3"
       - name: fluent-bit-plugin
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/fluent-bit-plugin
-        tag: "v1.4.0"
+        tag: "v1.5.0"
       - name: fluent-bit-plugin-installer
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/fluent-bit-to-vali
         tag: "v0.71.0"
@@ -86,7 +90,7 @@ operator:
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/controller-manager
       - name: gardener-dashboard
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/dashboard
-        tag: "1.84.1"
+        tag: "1.84.2"
       - name: gardener-discovery-server
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/gardener-discovery-server
         tag: "v0.10.0"
@@ -105,16 +109,16 @@ operator:
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/hyperkube
       - name: ingress-default-backend
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/ingress-default-backend
-        tag: "0.25.0"
+        tag: "0.26.0"
       - name: istio-basic-auth-server
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/ext-authz-server
         tag: "v0.3.0"
       - name: istio-istiod
         repository: keppel.global.cloud.sap/ccloud-gcr-mirror/istio-release/pilot
-        tag: "1.29.2-distroless"
+        tag: "1.29.3-distroless"
       - name: istio-proxy
         repository: keppel.global.cloud.sap/ccloud-gcr-mirror/istio-release/proxyv2
-        tag: "1.29.2-distroless"
+        tag: "1.29.3-distroless"
       - name: kube-apiserver
         repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/kube-apiserver
       - name: kube-controller-manager
@@ -167,7 +171,7 @@ operator:
         tag: "v0.0.1"
       - name: opentelemetry-operator
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/3rd/opentelemetry-operator/opentelemetry-operator
-        tag: "v0.145.0"
+        tag: "v0.150.0"
       - name: pause-container
         repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/pause
         tag: "3.10"
@@ -176,19 +180,19 @@ operator:
         tag: "v0.53.1"
       - name: perses-operator
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/3rd/persesdev/perses-operator
-        tag: v0.3.2
+        tag: v0.4.0
       - name: plutono
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/3rd/credativ/plutono
-        tag: "v7.5.47"
+        tag: "v7.5.48"
       - name: plutono-data-refresher
         repository: keppel.global.cloud.sap/ccloud-quay-mirror/kiwigrid/k8s-sidecar
-        tag: "2.7.1"
+        tag: "2.7.3"
       - name: prometheus
         repository: keppel.global.cloud.sap/ccloud-quay-mirror/prometheus/prometheus
         tag: v3.11.3
       - name: prometheus-operator
         repository: keppel.global.cloud.sap/ccloud-quay-mirror/prometheus-operator/prometheus-operator
-        tag: v0.90.1
+        tag: v0.91.0
       - name: telegraf
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/telegraf-iptables
         tag: "v0.71.0"
@@ -200,7 +204,7 @@ operator:
         tag: "v0.71.0"
       - name: vali
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/3rd/credativ/vali
-        tag: "v2.2.32"
+        tag: "v2.2.33"
       - name: vali-curator
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/vali-curator
         tag: "v0.71.0"
@@ -483,7 +487,7 @@ extensions:
           tag: v4.2.4
   gardenlinux:
     enabled: false
-    version: v0.41.0
+    version: v0.42.0
     values:
       image:
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/extensions/os-gardenlinux
@@ -503,7 +507,7 @@ extensions:
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/charts/gardener/extensions/os-coreos
   openstack:
     enabled: false
-    version: v1.54.0
+    version: v1.55.1
     values:
       image:
         repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/extensions/provider-openstack
@@ -538,14 +542,6 @@ extensions:
           repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-os/openstack-cloud-controller-manager
           tag: v1.32.1
           targetVersion: 1.32.x
-        - name: cloud-controller-manager
-          repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-os/openstack-cloud-controller-manager
-          tag: v1.31.4
-          targetVersion: 1.31.x
-        - name: cloud-controller-manager
-          repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-os/openstack-cloud-controller-manager
-          tag: v1.30.3
-          targetVersion: 1.30.x
         - name: csi-attacher
           repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/sig-storage/csi-attacher
           tag: v4.11.0
@@ -565,14 +561,6 @@ extensions:
           repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-os/cinder-csi-plugin
           tag: v1.32.1
           targetVersion: 1.32.x
-        - name: csi-driver-cinder
-          repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-os/cinder-csi-plugin
-          tag: v1.31.4
-          targetVersion: 1.31.x
-        - name: csi-driver-cinder
-          repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-os/cinder-csi-plugin
-          tag: v1.30.3
-          targetVersion: 1.30.x
         - name: csi-driver-manila
           repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-os/manila-csi-plugin
           tag: v1.35.0
@@ -589,17 +577,9 @@ extensions:
           repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-os/manila-csi-plugin
           tag: v1.32.1
           targetVersion: 1.32.x
-        - name: csi-driver-manila
-          repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-os/manila-csi-plugin
-          tag: v1.31.4
-          targetVersion: 1.31.x
-        - name: csi-driver-manila
-          repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/provider-os/manila-csi-plugin
-          tag: v1.30.3
-          targetVersion: 1.30.x
         - name: csi-driver-nfs
           repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/sig-storage/nfsplugin
-          tag: v4.13.1
+          tag: v4.13.2
         - name: csi-liveness-probe
           repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/sig-storage/livenessprobe
           tag: v2.18.0


### PR DESCRIPTION
Bump Gardener to 1.143.1

[Gardener v1.143.1](https://github.com/gardener/gardener/releases/tag/v1.143.1)

**Extensions**
[github.com/gardener/gardener](https://github.com/gardener/gardener/releases/tag/v1.143.1) v1.143.1
[github.com/gardener/gardener-extension-provider-aws](https://github.com/gardener/gardener-extension-provider-aws/releases/tag/v1.68.3) v1.68.3
[github.com/gardener/oidc-apps-controller](https://github.com/gardener/oidc-apps-controller/releases/tag/v0.26.0) v0.26.0
[github.com/gardener/gardener-extension-networking-calico](https://github.com/gardener/gardener-extension-networking-calico/releases/tag/v1.58.0) v1.58.0
[github.com/gardener/gardener-extension-os-gardenlinux](https://github.com/gardener/gardener-extension-os-gardenlinux/releases/tag/v0.42.0) v0.42.0
[github.com/gardener/gardener-extension-provider-openstack](https://github.com/gardener/gardener-extension-provider-openstack/releases/tag/v1.55.1) v1.55.1