### PR TITLE
fix(aurora): move vault references from Deployment to Secret resource

### DIFF
--- a/openstack/aurora/templates/_env.tpl
+++ b/openstack/aurora/templates/_env.tpl
@@ -5,16 +5,3 @@
   value: {{ .Values.identity_endpoint | default (printf "https://identity-3.%s.%s/v3" .Values.global.region .Values.global.tld) | quote }}
 - name: CEPH_REGION
   value: {{ .Values.ceph_region | quote }}
-{{- if not (contains "pr-secret" .Template.Name) }}
-- name: FEEDBACK_RECIPIENT_EMAIL
-  value: {{ .Values.feedback_recipient_email | quote }}
-- name: LIMES_MAIL_SERVER_ENDPOINT
-  # prettier-ignore
-  value: {{ .Values.limes_mail_server_endpoint | default (printf "https://limes-mail-server-%s.%s" .Values.global.region .Values.global.tld) | quote }}
-- name: TECHNICAL_USER_NAME
-  value: {{ .Values.technical_user_name | quote }}
-- name: TECHNICAL_USER_PASSWORD
-  value: {{ .Values.technical_user_password | quote }}
-- name: TECHNICAL_USER_DOMAIN
-  value: {{ .Values.technical_user_domain | quote }}
-{{- end }}

--- a/openstack/aurora/templates/deployment.yaml
+++ b/openstack/aurora/templates/deployment.yaml
@@ -45,6 +45,9 @@ spec:
               containerPort: 3000
           env:
 {{ include (print .Template.BasePath "/_env.tpl") . | indent 12 }}
+          envFrom:
+          - secretRef:
+              name: aurora-feedback
           livenessProbe:
             httpGet:
               path: /

--- a/openstack/aurora/templates/secret.yaml
+++ b/openstack/aurora/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if not .Values.prPreview.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aurora-feedback
+type: Opaque
+stringData:
+  FEEDBACK_RECIPIENT_EMAIL: {{ .Values.feedback_recipient_email | quote }}
+  LIMES_MAIL_SERVER_ENDPOINT: {{ .Values.limes_mail_server_endpoint | default (printf "https://limes-mail-server-%s.%s" .Values.global.region .Values.global.tld) | quote }}
+  TECHNICAL_USER_NAME: {{ .Values.technical_user_name | quote }}
+  TECHNICAL_USER_PASSWORD: {{ .Values.technical_user_password | quote }}
+  TECHNICAL_USER_DOMAIN: {{ .Values.technical_user_domain | quote }}
+{{- end }}


### PR DESCRIPTION
## Summary

Fixes secrets-injector-validator failure caused by vault references appearing directly in Deployment environment variables.

## Changes

- Created new `aurora-feedback` Secret resource containing:
  - `FEEDBACK_RECIPIENT_EMAIL`
  - `LIMES_MAIL_SERVER_ENDPOINT`
  - `TECHNICAL_USER_NAME`
  - `TECHNICAL_USER_PASSWORD`
  - `TECHNICAL_USER_DOMAIN`
- Updated Deployment to load these env vars via `envFrom.secretRef` instead of direct values
- Simplified `_env.tpl` to only include non-sensitive vars (PORT, IDENTITY_ENDPOINT, CEPH_REGION)
- PR preview secret unchanged - still gets only the non-sensitive env vars

## Why

The secrets-injector-validator is configured with `-kinds=OpenstackSeed`, meaning vault references are only allowed in OpenstackSeed and
Secret resources, not in Deployments. After PR #11961, the condition change caused vault references to appear directly in the Deployment's
env vars, triggering validation errors:

unexpected reference in object of kind Deployment: validation failed for path .spec.template.spec.containers.[0].env.[6].value: value
'vault+kvv2:///secrets/qa-de-1/...' is a vault reference

## Test plan

- [ ] Template the chart locally and verify vault references only appear in Secret, not Deployment
- [ ] Verify CI secrets-injector-validator passes
- [ ] Verify deployment works in qa-de-1 environment