### PR TITLE
[neutron] make swift-sftp bridge optional (default enabled)

### DIFF
--- a/openstack/neutron/templates/sftp-deployment.yaml
+++ b/openstack/neutron/templates/sftp-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.sftp.swift.enabled }}
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -58,3 +59,5 @@ spec:
             secretName: neutron-sftp-backup
         - name: cache-volume
           emptyDir: {}
+{{- end -}}
+

--- a/openstack/neutron/templates/sftp-secrets.yaml
+++ b/openstack/neutron/templates/sftp-secrets.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.sftp.swift.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -14,3 +15,5 @@ data:
 {{ include (print .Template.BasePath "/etc/_sftp_passwd.tpl") . | b64enc | indent 4 }}
   ssh_host_id_ec: |
 {{ include (print .Template.BasePath "/etc/_ssh_host_id_ec.tpl") . | b64enc | indent 4 }}
+{{- end }}
+

--- a/openstack/neutron/templates/sftp-service.yaml
+++ b/openstack/neutron/templates/sftp-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.sftp.swift.enabled }}
 kind: Service
 apiVersion: v1
 metadata:
@@ -19,3 +20,5 @@ spec:
       targetPort: 10022
   externalIPs:
 {{ .Values.sftp.externalIPs | toYaml | indent 4 }}
+{{- end }}
+

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -311,13 +311,14 @@ hypervisors_vmware: []
 
 # SFTP-swift bridge (e.g. for nsx-t backups in control-plane)
 sftp:
-  enabled: false
   server_key:
   externalIPs: []
   user: db_backup
   logins:
     db_backup: nsx-t-backup
     vcsa_backup: vcsa-backups
+  swift:
+    enabled: true
 
 drivers:
   nsxv3:


### PR DESCRIPTION
new regions don't have swift anymore, so we need to make it configurable
