### PR TITLE
[neutron] add disco record for rabbitmq externalIP

### DIFF
--- a/openstack/neutron/templates/record-rabbitmq.yaml
+++ b/openstack/neutron/templates/record-rabbitmq.yaml
@@ -1,0 +1,14 @@
+{{- $region := .Values.global.region | required "missing value for .Values.global.region" }}
+{{- $tld    := .Values.global.tld    | required "missing value for .Values.global.tld" }}
+{{- $ips    := .Values.rabbitmq.externalIPs }}
+{{- if $ips }}
+apiVersion: disco.stable.sap.cc/v1
+kind: Record
+metadata:
+  name: neutron-rabbitmq.{{ $region }}.{{ $tld }}
+spec:
+  type: A
+  record: {{ index $ips 0 | quote }}
+  hosts:
+    - neutron-rabbitmq.{{ $region }}.{{ $tld }}
+{{- end }}


### PR DESCRIPTION
makes it easier to consume the rabbitmq from external clusters /
namespaces.
