### PR TITLE
[archer] Use neutron-linuxbridge-agent library chart

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -100,6 +100,7 @@
 /openstack/netapp-credential-rotator                   @Carthaca @chuan137 @kpawar-sap @sumitarora2786 @crenduchinta88 @hvr999 @RockSolidScripts @Scsabiii @hemna @jagoleni
 /openstack/neutron                                     @notandy @fwiesel @sapcc/network-api-contributors
 /openstack/neutron-hypervisor-agents                   @sapcc/network-api-contributors @notandy @fwiesel @mchristianl @anokfireball @seb-kro
+/openstack/neutron-linuxbridge-agent                   @sapcc/network-api-contributors @notandy @fwiesel @mchristianl @anokfireball @seb-kro
 /openstack/nova                                        @joker-at-work @fwiesel @grandchild @leust @seb-kro @PaulPickhardt @CordulaGuder @bzzybriel @mchristianl @anokfireball
 /openstack/nova-hypervisor-agents                      @joker-at-work @fwiesel @grandchild @leust @seb-kro @PaulPickhardt @CordulaGuder @notandy @mchristianl @anokfireball @toanju
 /openstack/openstack-hypervisor-operator               @joker-at-work @fwiesel @grandchild @leust @seb-kro @PaulPickhardt @CordulaGuder @notandy @mchristianl @anokfireball @toanju

--- a/openstack/archer/Chart.yaml
+++ b/openstack/archer/Chart.yaml
@@ -43,3 +43,6 @@ dependencies:
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: '>= 0.0.0'
+  - name: neutron-linuxbridge-agent
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: '>= 0.0.0'

--- a/openstack/archer/templates/configmap-neutron-linuxbridge.yaml
+++ b/openstack/archer/templates/configmap-neutron-linuxbridge.yaml
@@ -1,0 +1,2 @@
+{{- $lbValues := merge (dict "debug" .Values.debug) .Values.linuxbridge_agent }}
+{{- include "neutron-linuxbridge-agent.configmap-etc" (dict "root" . "values" $lbValues) }}

--- a/openstack/archer/templates/neutron-secret.yaml
+++ b/openstack/archer/templates/neutron-secret.yaml
@@ -1,0 +1,19 @@
+{{- $region := .Values.global.region | required "missing value for .Values.global.region" }}
+{{- $tld    := .Values.global.tld    | required "missing value for .Values.global.tld" }}
+{{- $rmq    := .Values.linuxbridge_agent.rabbitmq | required "missing value for .Values.linuxbridge_agent.rabbitmq" }}
+{{- $user   := required ".rabbitmq.defaultUser required" $rmq.defaultUser }}
+{{- $host   := $rmq.host | default (printf "neutron-rabbitmq.%s.%s" $region $tld) }}
+{{- $data := dict
+    "host"         $host
+    "port"         ($rmq.port | default 5672)
+    "virtual_host" ($rmq.virtual_host | default "")
+    "user"     (printf "vault+kvv2:///secrets/%s/neutron/rabbitmq-user/%s/username" $region $user)
+    "password" (printf "vault+kvv2:///secrets/%s/neutron/rabbitmq-user/%s/password" $region $user)
+}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.linuxbridge_agent.secretName }}
+type: Opaque
+stringData:
+  OS_DEFAULT__TRANSPORT_URL: {{ include "utils.rabbitmq_url" (tuple . $data) | trim | quote }}

--- a/openstack/archer/templates/statefulset-network-agent.yaml
+++ b/openstack/archer/templates/statefulset-network-agent.yaml
@@ -141,80 +141,11 @@ spec:
             - name: etc-archer
               mountPath: /etc/archer
               readOnly: true
-        - name: neutron-linuxbridge-agent
-          image: "{{ $.Values.global.registry }}/loci-neutron:{{ $.Values.image.neutron_version | default "latest" }}"
-          imagePullPolicy: IfNotPresent
-          command: ["dumb-init", "neutron-linuxbridge-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-dir", "/etc/neutron/secrets", "--config-file", "/etc/neutron/ml2-conf.ini", "--config-file", "/etc/neutron/linux-bridge.ini"]
-          env:
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: sentry
-                  key: neutron.DSN.python
-            - name: PYTHONWARNINGS
-              value: "ignore:Unverified HTTPS request"
-            - name: OS_LINUX_BRIDGE__PHYSICAL_INTERFACE_MAPPINGS
-              value: {{ $cp }}:{{ required "A valid .Values.cp_network_interface required!" $.Values.cp_network_interface }}
-            - name: OS_GLOBAL__HOST
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-          readinessProbe:
-            exec:
-              command: ["neutron-agent-liveness", "-config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/secrets/neutron-common-secrets.conf", "-agent-type", "Linux bridge agent"]
-            initialDelaySeconds: 30
-            periodSeconds: 60
-            timeoutSeconds: 10
-          securityContext:
-            capabilities:
-              add:
-                - NET_ADMIN
-                - SYS_ADMIN
-                - DAC_OVERRIDE
-                - DAC_READ_SEARCH
-                - SYS_PTRACE
-          resources:
-            {{- toYaml $.Values.resources.linuxbridge_agent | nindent 12 }}
-          volumeMounts:
-            - mountPath: /lib/modules
-              name: modules
-              readOnly: true
-            - name: etc-neutron-linuxbridge-agent
-              mountPath: /etc/neutron
-              readOnly: true
-            - name: neutron-etc
-              mountPath: /etc/sudoers
-              subPath: sudoers
-              readOnly: true
+        {{- $physMap := dict "name" "OS_LINUX_BRIDGE__PHYSICAL_INTERFACE_MAPPINGS" "value" (printf "%s:%s" $cp (required ".Values.cp_network_interface required" $.Values.cp_network_interface)) }}
+        {{- $lbValues := merge (dict "extraEnv" (append $.Values.linuxbridge_agent.extraEnv $physMap) "resources" $.Values.resources.linuxbridge_agent) $.Values.linuxbridge_agent }}
+        {{- include "neutron-linuxbridge-agent.container" (dict "root" $ "values" $lbValues) | nindent 8 }}
       volumes:
-        - name: modules
-          hostPath:
-            path: /lib/modules
-        - name: neutron-etc
-          configMap:
-            name: neutron-etc
-        - name: etc-neutron-linuxbridge-agent
-          projected:
-            defaultMode: 420
-            sources:
-            - configMap:
-                name: neutron-etc
-                items:
-                  - key: neutron.conf
-                    path: neutron.conf
-                  - key: logging.conf
-                    path: logging.conf
-                  - key: rootwrap.conf
-                    path: rootwrap.conf
-                  - key: ml2-conf.ini
-                    path: ml2-conf.ini
-                  - key: linux-bridge.ini
-                    path: linux-bridge.ini
-            - secret:
-                name: neutron-common-secrets
-                items:
-                  - key: neutron-common-secrets.conf
-                    path: secrets/neutron-common-secrets.conf
+        {{- include "neutron-linuxbridge-agent.volumes" (dict "root" $ "values" $lbValues) | nindent 8 }}
         - name: etc-archer
           projected:
             defaultMode: 420

--- a/openstack/archer/values.yaml
+++ b/openstack/archer/values.yaml
@@ -172,6 +172,35 @@ resources:
   linuxbridge_agent: {}
   socat: {}
 
+# Config for the neutron-linuxbridge-agent library subchart. The library
+# renders a minimal neutron.conf as a ConfigMap (Mode B); archer renders the
+# Secret with OS_*__* env keys (templates/neutron-secret.yaml). The dynamic
+# OS_LINUX_BRIDGE__PHYSICAL_INTERFACE_MAPPINGS env is appended at the include
+# site in statefulset-network-agent.yaml.
+linuxbridge_agent:
+  # Required at deploy time. The library's image cascade picks this up.
+  # No default — set imageVersion (or imageVersionNetworkAgentLinuxBridge,
+  # imageVersionNetworkAgent, imageVersion at the top level) explicitly.
+  secretName: archer-neutron-secret
+  # RabbitMQ connection for the linuxbridge agent. Renders the transport URL
+  # via utils.rabbitmq_url (same helper the umbrella neutron chart uses).
+  # User/password Vault URIs follow the umbrella neutron chart's convention:
+  #   secrets/<region>/neutron/rabbitmq-user/<defaultUser>/{username,password}
+  # The region is templated in templates/neutron-secret.yaml from
+  # .Values.global.region. Override host (and defaultUser if not "neutron_1").
+  rabbitmq:
+    host: ""                  # default: neutron-rabbitmq.<region>.<tld> (disco-resolved)
+    port: 5672
+    virtual_host: ""
+    defaultUser: neutron_1
+  # Per-StatefulSet additions (PHYSICAL_INTERFACE_MAPPINGS) are appended at
+  # the include site in statefulset-network-agent.yaml.
+  extraEnv:
+    - name: OS_GLOBAL__HOST
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+
 autoscaling:
   enabled: false
   minReplicas: 1

--- a/openstack/neutron-linuxbridge-agent/Chart.lock
+++ b/openstack/neutron-linuxbridge-agent/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: utils
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 0.37.2
+digest: sha256:af3a9cca9c89f2e7664fd1bdc23c12b9ccecb1ed829f83558be138a2bc3bd34a
+generated: "2026-06-16T16:01:39.062237-04:00"

--- a/openstack/neutron-linuxbridge-agent/Chart.yaml
+++ b/openstack/neutron-linuxbridge-agent/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: neutron-linuxbridge-agent
+description: Library chart that exposes a neutron-linuxbridge-agent container, its volumes, and its config to consumer charts.
+type: library
+version: 0.1.0
+appVersion: "caracal"
+dependencies:
+  - name: utils
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: '>= 0.0.0'

--- a/openstack/neutron-linuxbridge-agent/README.md
+++ b/openstack/neutron-linuxbridge-agent/README.md
@@ -1,0 +1,128 @@
+# neutron-linuxbridge-agent
+
+A Helm `type: library` chart that lets a consumer chart embed a
+`neutron-linuxbridge-agent` container into its own Pod spec, in any namespace
+or cluster.
+
+The library exposes three named templates:
+
+| Template                                  | Renders                                   |
+|-------------------------------------------|-------------------------------------------|
+| `neutron-linuxbridge-agent.configmap-etc` | A full ConfigMap with `neutron.conf`      |
+| `neutron-linuxbridge-agent.container`     | One container spec for the agent          |
+| `neutron-linuxbridge-agent.volumes`       | Pod-level `linuxbridge-agent-etc` + `modules` volumes |
+
+The library does **not** own the Pod, StatefulSet, or DaemonSet, and it does
+**not** create the Secret with `OS_*__*` env keys — the consumer brings both.
+
+## Usage
+
+Add the dependency to your consumer chart:
+
+```yaml
+# Chart.yaml
+dependencies:
+  - name: neutron-linuxbridge-agent
+    version: '>= 0.0.0'
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+```
+
+The image is resolved as
+`{{ .Values.global.registry }}/loci-neutron:<imageVersion>`, where
+`<imageVersion>` cascades through
+`linuxbridge_agent.imageVersion` →
+`imageVersionNetworkAgentLinuxBridge` →
+`imageVersionNetworkAgent` →
+`imageVersion`. So an umbrella chart that already sets `imageVersion` will
+just work.
+
+There are two modes for `neutron.conf`. Pick one.
+
+### Mode A — bring your own ConfigMap
+
+Use this when your chart already has a ConfigMap with a usable
+`neutron.conf` — for example the umbrella `neutron` chart's `neutron-etc`.
+
+```yaml
+# values.yaml of the consumer chart
+linuxbridge_agent:
+  secretName: linuxbridge-agent-secret
+  configMap:
+    name: neutron-etc        # existing ConfigMap, same release/namespace
+    key: neutron.conf        # key inside it that holds the file body
+```
+
+In the Pod spec:
+
+```yaml
+spec:
+  containers:
+    {{- include "neutron-linuxbridge-agent.container" (dict "root" . "values" .Values.linuxbridge_agent) | nindent 4 }}
+  volumes:
+    {{- include "neutron-linuxbridge-agent.volumes" (dict "root" . "values" .Values.linuxbridge_agent) | nindent 4 }}
+```
+
+No call to `configmap-etc` — you're not generating one.
+
+### Mode B — let the library generate the ConfigMap
+
+Use this when you want the library to produce a minimal `neutron.conf` for
+you, parameterized through the values surface.
+
+```yaml
+# values.yaml
+linuxbridge_agent:
+  secretName: linuxbridge-agent-secret
+  configMap:
+    name: ""                 # empty = library-rendered
+  host: ""                   # default: node hostname
+  agent:
+    polling_interval: 2
+  vxlan:
+    enable: true
+  securitygroup:
+    firewall_driver: iptables
+```
+
+In a consumer template, render the ConfigMap as a full top-level resource:
+
+```yaml
+{{- include "neutron-linuxbridge-agent.configmap-etc" (dict "root" . "values" .Values.linuxbridge_agent) }}
+```
+
+Pod spec is identical to Mode A.
+
+## Secret contract
+
+The consumer creates a Secret whose keys are named after the
+`OS_<SECTION>__<KEY>` convention. oslo.config maps each one onto its config
+tree at startup, so nothing in `neutron.conf` needs to reference them.
+
+| Key                                            | Maps to (in oslo.config)                       |
+|------------------------------------------------|-------------------------------------------------|
+| `OS_DEFAULT__TRANSPORT_URL`                    | `[DEFAULT] transport_url`                       |
+| `OS_LINUX_BRIDGE__PHYSICAL_INTERFACE_MAPPINGS` | `[linux_bridge] physical_interface_mappings`    |
+| `OS_DEFAULT__HOST`                             | `[DEFAULT] host` (alternative to `.values.host`) |
+
+The library uses `envFrom: secretRef:` — every key in the Secret becomes an
+env var with the same name.
+
+## Required capabilities and host volumes
+
+- `NET_ADMIN`, `SYS_ADMIN`, `DAC_OVERRIDE`, `DAC_READ_SEARCH`, `SYS_PTRACE`.
+- `/lib/modules` mounted read-only from the host so the agent can verify
+  bridge / vxlan kernel modules are present.
+
+## Errors
+
+- `.Values.global.registry is required` — set it on the consumer.
+- `Set imageVersionNetworkAgentLinuxBridge, imageVersionNetworkAgent, or imageVersion` — same.
+- `.values.secretName is required` — set `linuxbridge_agent.secretName` on the consumer.
+
+## Smoke test
+
+```sh
+helm lint openstack/neutron-linuxbridge-agent
+helm dependency update openstack/neutron-linuxbridge-agent/ci/consumer-fixture
+helm template openstack/neutron-linuxbridge-agent/ci/consumer-fixture
+```

--- a/openstack/neutron-linuxbridge-agent/ci/consumer-fixture/Chart.lock
+++ b/openstack/neutron-linuxbridge-agent/ci/consumer-fixture/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: neutron-linuxbridge-agent
+  repository: file://../..
+  version: 0.1.0
+- name: utils
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 0.37.2
+digest: sha256:cfd30a748798e63dcfc1efe655d781b0a0a275d363a761010e5859e1dc684ebc
+generated: "2026-06-16T16:35:27.648631-04:00"

--- a/openstack/neutron-linuxbridge-agent/ci/consumer-fixture/Chart.yaml
+++ b/openstack/neutron-linuxbridge-agent/ci/consumer-fixture/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: consumer-fixture
+description: Smoke-test consumer of the neutron-linuxbridge-agent library chart.
+type: application
+version: 0.0.1
+appVersion: "0.0.1"
+dependencies:
+  - name: neutron-linuxbridge-agent
+    version: 0.1.0
+    repository: file://../..
+  - name: utils
+    version: '>= 0.0.0'
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/neutron-linuxbridge-agent/ci/consumer-fixture/templates/pod.yaml
+++ b/openstack/neutron-linuxbridge-agent/ci/consumer-fixture/templates/pod.yaml
@@ -1,0 +1,14 @@
+{{- if not .Values.linuxbridge_agent.configMap.name }}
+{{- include "neutron-linuxbridge-agent.configmap-etc" (dict "root" . "values" .Values.linuxbridge_agent) }}
+---
+{{- end }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ .Release.Name }}-linuxbridge-agent
+spec:
+  hostNetwork: true
+  containers:
+    {{- include "neutron-linuxbridge-agent.container" (dict "root" . "values" .Values.linuxbridge_agent) | nindent 4 }}
+  volumes:
+    {{- include "neutron-linuxbridge-agent.volumes" (dict "root" . "values" .Values.linuxbridge_agent) | nindent 4 }}

--- a/openstack/neutron-linuxbridge-agent/ci/consumer-fixture/values-mode-a.yaml
+++ b/openstack/neutron-linuxbridge-agent/ci/consumer-fixture/values-mode-a.yaml
@@ -1,0 +1,5 @@
+# Override for Mode A: consumer brings its own ConfigMap.
+linuxbridge_agent:
+  configMap:
+    name: my-existing-neutron-etc
+    key: neutron.conf

--- a/openstack/neutron-linuxbridge-agent/ci/consumer-fixture/values.yaml
+++ b/openstack/neutron-linuxbridge-agent/ci/consumer-fixture/values.yaml
@@ -1,0 +1,19 @@
+global:
+  registry: registry.example.com
+
+imageVersion: caracal
+
+linuxbridge_agent:
+  secretName: linuxbridge-agent-secret
+
+  # Mode B: library generates the ConfigMap.
+  configMap:
+    name: ""
+    key: neutron.conf
+  host: ""
+  agent:
+    polling_interval: 2
+  vxlan:
+    enable: true
+  securitygroup:
+    firewall_driver: iptables

--- a/openstack/neutron-linuxbridge-agent/templates/_configmap-etc.tpl
+++ b/openstack/neutron-linuxbridge-agent/templates/_configmap-etc.tpl
@@ -1,0 +1,17 @@
+{{/*
+neutron-linuxbridge-agent.configmap-etc renders a full ConfigMap resource.
+Call from a consumer template, e.g.:
+
+  {{- include "neutron-linuxbridge-agent.configmap-etc" (dict "root" . "values" .Values.linuxbridge_agent) }}
+*/}}
+{{- define "neutron-linuxbridge-agent.configmap-etc" -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .root.Release.Name }}-linuxbridge-agent-etc
+data:
+  neutron.conf: |
+    {{- include "neutron-linuxbridge-agent.neutron-conf" . | nindent 4 }}
+  logging.conf: |
+    {{- include "neutron-linuxbridge-agent.logging-conf" . | nindent 4 }}
+{{- end -}}

--- a/openstack/neutron-linuxbridge-agent/templates/_container.tpl
+++ b/openstack/neutron-linuxbridge-agent/templates/_container.tpl
@@ -1,0 +1,63 @@
+{{/*
+neutron-linuxbridge-agent.container renders one container spec ready to splice
+into a Pod's containers: list. Call as:
+
+  containers:
+    {{- include "neutron-linuxbridge-agent.container" (dict "root" . "values" .Values.linuxbridge_agent) | nindent 4 }}
+*/}}
+{{- define "neutron-linuxbridge-agent.container" -}}
+{{- $registry := .root.Values.global.registry | required ".Values.global.registry is required" -}}
+{{- $version := .values.imageVersion
+    | default .root.Values.imageVersionNetworkAgentLinuxBridge
+    | default .root.Values.imageVersionNetworkAgent
+    | default .root.Values.imageVersion
+    | required "Set imageVersionNetworkAgentLinuxBridge, imageVersionNetworkAgent, or imageVersion" -}}
+- name: neutron-linuxbridge-agent
+  image: {{ $registry }}/loci-neutron:{{ $version }}
+  imagePullPolicy: IfNotPresent
+  command:
+    - neutron-linuxbridge-agent
+    {{- range .values.extraConfigs }}
+    - --config-file
+    - {{ . }}
+    {{- end }}
+    {{- range .values.extraConfigDirs }}
+    - --config-dir
+    - {{ . }}
+    {{- end }}
+  securityContext:
+    runAsUser: 0
+    capabilities:
+      add:
+        - NET_ADMIN
+        - SYS_ADMIN
+        - DAC_OVERRIDE
+        - DAC_READ_SEARCH
+        - SYS_PTRACE
+  envFrom:
+    - secretRef:
+        name: {{ required ".values.secretName is required" .values.secretName }}
+  {{- with .values.extraEnv }}
+  env:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .values.resources }}
+  resources:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  volumeMounts:
+    - name: linuxbridge-agent-etc
+      mountPath: /etc/neutron/neutron.conf
+      subPath: {{ dig "configMap" "key" "neutron.conf" .values }}
+      readOnly: true
+    - name: linuxbridge-agent-etc
+      mountPath: /etc/neutron/logging.conf
+      subPath: {{ dig "configMap" "loggingKey" "logging.conf" .values }}
+      readOnly: true
+    - name: modules
+      mountPath: /lib/modules
+      readOnly: true
+    {{- with .values.extraVolumeMounts }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end -}}

--- a/openstack/neutron-linuxbridge-agent/templates/_volumes.tpl
+++ b/openstack/neutron-linuxbridge-agent/templates/_volumes.tpl
@@ -1,0 +1,25 @@
+{{/*
+neutron-linuxbridge-agent.volumes renders the pod-level volume entries the
+consumer splices into spec.volumes. Call as:
+
+  volumes:
+    {{- include "neutron-linuxbridge-agent.volumes" (dict "root" . "values" .Values.linuxbridge_agent) | nindent 4 }}
+
+Two modes:
+  - .values.configMap.name set    → mount that ConfigMap (Mode A: BYO)
+  - .values.configMap.name empty  → mount the library-rendered ConfigMap
+                                    {{ .Release.Name }}-linuxbridge-agent-etc
+                                    (consumer must include configmap-etc to
+                                    actually create it).
+*/}}
+{{- define "neutron-linuxbridge-agent.volumes" -}}
+- name: linuxbridge-agent-etc
+  configMap:
+    name: {{ dig "configMap" "name" (printf "%s-linuxbridge-agent-etc" .root.Release.Name) .values }}
+- name: modules
+  hostPath:
+    path: /lib/modules
+{{- with .values.extraVolumes }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}

--- a/openstack/neutron-linuxbridge-agent/templates/etc/_logging-conf.tpl
+++ b/openstack/neutron-linuxbridge-agent/templates/etc/_logging-conf.tpl
@@ -1,0 +1,25 @@
+{{/*
+neutron-linuxbridge-agent.logging-conf renders a Python logging.config ini
+body for the agent. Uses the loggerIni helper from the utils chart so
+consumers can pass the same dict shape as the umbrella neutron chart's
+.Values.logging.
+
+Default schema mirrors the umbrella neutron chart: oslo_log ContextFormatter
+on stdout, root logger at INFO. Override by setting .values.logging on the
+consumer side.
+*/}}
+{{- define "neutron-linuxbridge-agent.logging-conf" -}}
+{{- $default := dict
+    "loggers" (dict
+        "root" (dict "handlers" "stdout" "level" "INFO")
+    )
+    "handlers" (dict
+        "stdout" (dict "class" "StreamHandler" "args" "(sys.stdout,)" "formatter" "context")
+    )
+    "formatters" (dict
+        "context" (dict "class" "oslo_log.formatters.ContextFormatter")
+    )
+-}}
+{{- $logging := .values.logging | default $default -}}
+{{- include "loggerIni" $logging -}}
+{{- end -}}

--- a/openstack/neutron-linuxbridge-agent/templates/etc/_neutron-conf.tpl
+++ b/openstack/neutron-linuxbridge-agent/templates/etc/_neutron-conf.tpl
@@ -1,0 +1,44 @@
+{{/*
+neutron.conf body for the linuxbridge agent. Sensitive values
+([DEFAULT] transport_url, etc.) are injected via OS_<SECTION>__<KEY>
+env vars from the consumer-supplied Secret, not written into this file.
+
+Inputs: .values is the consumer's library subtree (see values.yaml).
+*/}}
+{{- define "neutron-linuxbridge-agent.neutron-conf" -}}
+[DEFAULT]
+core_plugin = ml2
+debug = {{ .values.debug | default false }}
+log_config_append = /etc/neutron/logging.conf
+{{- with .values.host }}
+host = {{ . }}
+{{- end }}
+
+[agent]
+polling_interval = {{ dig "agent" "polling_interval" 2 .values }}
+
+[linux_bridge]
+# physical_interface_mappings comes from env OS_LINUX_BRIDGE__PHYSICAL_INTERFACE_MAPPINGS
+
+[vxlan]
+enable_vxlan = {{ dig "vxlan" "enable" false .values }}
+
+[securitygroup]
+firewall_driver = {{ dig "securitygroup" "firewall_driver" "iptables" .values }}
+
+[privsep]
+thread_pool_size = {{ dig "privsep" "thread_pool_size" 3 .values }}
+helper_command = {{ dig "privsep" "helper_command" "privsep-helper --config-file /etc/neutron/neutron.conf" .values }}
+
+# All neutron privsep contexts use the same in-container helper invocation,
+# avoiding sudo (which isn't usable in the bare-minimum container).
+{{- $helper := dig "privsep" "helper_command" "privsep-helper --config-file /etc/neutron/neutron.conf" .values }}
+{{- range list "privsep_dhcp_release" "privsep_ovs_vsctl" "privsep_namespace" "privsep_conntrack" "privsep_link" }}
+
+[{{ . }}]
+helper_command = {{ $helper }}
+{{- end }}
+
+[oslo_concurrency]
+lock_path = /tmp
+{{- end -}}

--- a/openstack/neutron-linuxbridge-agent/values.yaml
+++ b/openstack/neutron-linuxbridge-agent/values.yaml
@@ -1,0 +1,47 @@
+# Consumer contract for the neutron-linuxbridge-agent library chart.
+# The library ships no top-level values — this file documents the subtree
+# the consumer feeds in via:
+#   include "neutron-linuxbridge-agent.container" (dict "root" . "values" .Values.linuxbridge_agent)
+
+# Required. Secret with OS_<SECTION>__<KEY> keys (e.g. OS_DEFAULT__TRANSPORT_URL).
+secretName: ""
+
+# Optional. Image version override; otherwise cascades through
+# imageVersionNetworkAgentLinuxBridge → imageVersionNetworkAgent → imageVersion
+# from the consumer's top-level Values. Image is always {global.registry}/loci-neutron.
+imageVersion: ""
+
+# Mode A: bring your own ConfigMap (set name).
+# Mode B: let the library render one (leave name empty, call configmap-etc).
+configMap:
+  name: ""
+  key: neutron.conf         # subPath inside the ConfigMap for neutron.conf
+  loggingKey: logging.conf  # subPath inside the ConfigMap for logging.conf
+
+# Mode B inputs. Ignored in Mode A.
+host: ""                  # [DEFAULT] host; empty → node hostname
+debug: false              # [DEFAULT] debug — sets oslo log level to DEBUG
+agent:
+  polling_interval: 2
+vxlan:
+  enable: false
+securitygroup:
+  firewall_driver: iptables
+privsep:
+  thread_pool_size: 3
+
+# Python logging.config schema for the agent. Rendered via the loggerIni
+# helper (utils chart), same shape the umbrella neutron chart uses for
+# .Values.logging. Default: stdout handler with oslo_log ContextFormatter,
+# root level INFO. Override to add Sentry, raise log levels, etc.
+logging: {}
+
+# Optional --config-file / --config-dir flags appended to the command.
+extraConfigs: []          # e.g. ["/etc/neutron/plugins/ml2/ml2_conf.ini"]
+extraConfigDirs: []       # e.g. ["/etc/neutron/secrets"]
+
+# Optional pass-through into the container spec.
+extraEnv: []
+extraVolumeMounts: []
+extraVolumes: []          # spliced into spec.volumes by the volumes template
+resources: {}


### PR DESCRIPTION
Replaces the inlined linuxbridge-agent container in the network-agent StatefulSet with the shared library chart from #11992. Archer renders its own ConfigMap (Mode B, via the library's `configmap-etc` named template) and its own Secret with `OS_DEFAULT__TRANSPORT_URL` pointing at neutron's RabbitMQ — archer no longer depends on neutron's `neutron-etc` ConfigMap or `neutron-common-secrets` Secret, which makes it deployable in regions where neutron isn't co-resident.

Depends on #11992 (library publication to OCI).