### PR TITLE
[mariadb] use global.mariadb.backup_v2 for ceph s3 access and secret key

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## v0.38.1 - 2026/06/21
+## v0.38.2 - 2026/06/16
+* use global.mariadb.backup_v2 for ceph s3 access and secret key
+* chart version bumped
+
+## v0.38.1 - 2026/06/11
 * `maria-back-me-up` updated to `10.11-20260611113653`
   * fixes aws s3 upload
 * chart version bumped

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.38.1
+version: 0.38.2
 # scripts/docker-entyrpoint.sh should be updated when appVersion is updated
 appVersion: 10.11.18
 dependencies:

--- a/common/mariadb/ci/test-values.yaml
+++ b/common/mariadb/ci/test-values.yaml
@@ -11,8 +11,6 @@ global:
   backup_v2:
     aws_access_key_id: superSecret
     aws_secret_access_key: superSecret
-    ceph_s3_access_key_id: superSecret
-    ceph_s3_secret_access_key: superSecret
   mariadb:
     backup_v2:
       aws:
@@ -21,6 +19,8 @@ global:
       ceph_s3:
         endpoint: "https://ceph-s3.local.example.com"
         region: local
+        aws_access_key_id: superSecret
+        aws_secret_access_key: superSecret
 
 test_db_host: testRelease-mariadb.svc
 root_password: secret123

--- a/common/mariadb/templates/config/_backup_config.yaml.tpl
+++ b/common/mariadb/templates/config/_backup_config.yaml.tpl
@@ -44,8 +44,8 @@ storages:
     {{- end }}
     {{- if .Values.backup_v2.ceph_s3.enabled }}
     - name: ceph-{{ default .Values.global.region .Values.global.mariadb.backup_v2.ceph_s3.region }}
-      aws_access_key_id: {{ include "mariadb.resolve_secret_squote" .Values.global.backup_v2.ceph_s3_access_key_id }}
-      aws_secret_access_key: {{ include "mariadb.resolve_secret_squote" .Values.global.backup_v2.ceph_s3_secret_access_key }}
+      aws_access_key_id: {{ include "mariadb.resolve_secret_squote" .Values.global.mariadb.backup_v2.ceph_s3.aws_access_key_id }}
+      aws_secret_access_key: {{ include "mariadb.resolve_secret_squote" .Values.global.mariadb.backup_v2.ceph_s3.aws_secret_access_key }}
       aws_endpoint: {{ .Values.global.mariadb.backup_v2.ceph_s3.endpoint | required "global.mariadb.backup_v2.ceph_s3.endpoint is required when ceph_s3 is enabled" | quote }}
       s3_force_path_style: {{ .Values.backup_v2.ceph_s3.force_path_style }}
       region: {{ default .Values.global.region .Values.global.mariadb.backup_v2.ceph_s3.region }}


### PR DESCRIPTION
* use global.mariadb.backup_v2 for ceph s3 access and secret key
* chart version bumped