### PR TITLE
[netapp-harvest-exporter] service account for exporter pods

### DIFF
--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/templates/deployment_master.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/templates/deployment_master.yaml
@@ -24,6 +24,7 @@ spec:
         app: {{ include "netapp-harvest.fullname" . }}-{{ $appName }}
         name: {{ include "netapp-harvest.fullname" . }}-{{ $appName }}-master
     spec:
+      serviceAccountName: netappsd
       containers:
         - name:  netappsd
           image: {{ .Values.global.registry }}/{{ .Values.netappsd.image.repository }}:{{ .Values.netappsd.image.tag }}

--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/templates/deployment_worker.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/templates/deployment_worker.yaml
@@ -34,6 +34,7 @@ spec:
         app: {{ include "netapp-harvest.fullname" . }}-{{ $appName }}
         name: {{ include "netapp-harvest.fullname" . }}-{{ $appName }}-worker
     spec:
+      serviceAccountName: netappsd
       containers:
         - name: poller
           image: {{ .Values.global.dockerHubMirror }}/{{ .Values.harvest.image.repository }}:{{ .Values.harvest.image.tag }}


### PR DESCRIPTION
The chart already created SA `netappsd` + Role + RoleBinding (pod-read)
unconditionally, but deployment_worker/master never set
`serviceAccountName: netappsd` so pods ran as `default`. On
Gardener-hardened clusters this fails with `forbidden: pods cannot get
pods` (e.g. eu-de-3 / storage-product).
