### PR TITLE
feat(gatekeeper): add network-atm to known support groups

### DIFF
--- a/system/gatekeeper/values.yaml
+++ b/system/gatekeeper/values.yaml
@@ -46,6 +46,7 @@ known_support_groups:
   - identity
   - kvm
   - network-api
+  - network-atm
   - network-data
   - network-lb
   - network-security


### PR DESCRIPTION
Add `network-atm` to the list of known support groups in gatekeepers values configuration, enabling support for the SCI Network ATM team.