### PR TITLE
openstack/hermes: add DISCO Record for rabbitmq notifications

### DIFF
--- a/openstack/hermes/templates/record-rabbitmq.yaml
+++ b/openstack/hermes/templates/record-rabbitmq.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.hermes.rabbitmq_enabled }}
+{{- $region := .Values.global.region | required "missing value for .Values.global.region" }}
+{{- $tld    := .Values.global.tld    | required "missing value for .Values.global.tld" }}
+{{- $ips    := .Values.rabbitmq_notifications.externalIPs }}
+{{- if $ips }}
+apiVersion: disco.stable.sap.cc/v1
+kind: Record
+metadata:
+  name: hermes-rabbitmq.{{ $region }}.{{ $tld }}
+spec:
+  type: A
+  record: {{ index $ips 0 | quote }}
+  hosts:
+    - hermes-rabbitmq.{{ $region }}.{{ $tld }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
Adds a DISCO `Record` resource that publishes the per-region rabbitmq
notifications endpoint as `hermes-rabbitmq.<region>.<tld>`, pointing at
the externalIP already wired into the aliased `rabbitmq_notifications`
subchart Service.

## What changed
- `openstack/hermes/templates/record-rabbitmq.yaml` (new, 16 lines)

## Behavior
- Renders only when `hermes.rabbitmq_enabled` is true (outer guard)
  AND `rabbitmq_notifications.externalIPs` is non-empty (inner guard).
- Uses `index $ips 0` — single A record.
- Hostname: `hermes-rabbitmq.<region>.<tld>`.

## Verification
- `helm template` with `hermes.rabbitmq_enabled=true` + IP → renders Record.
- `helm template` with `hermes.rabbitmq_enabled=false` → no Record.
- `helm template` enabled but no `externalIPs` → no Record.
- Pre-existing `postgresql-ng` lint warning on master is unrelated.