### PR TITLE
[opensearch-hermes] fix alert group name

### DIFF
--- a/system/opensearch-hermes/Chart.yaml
+++ b/system/opensearch-hermes/Chart.yaml
@@ -4,7 +4,7 @@ description: OpenSearch-Hermes cluster database for openstack/hermes service
 maintainers:
   - name: Olaf Heydorn <olaf.heydorn@sap.com>
 name: opensearch-hermes
-version: 0.1.24
+version: 0.1.25
 dependencies:
   - name: opensearch
     alias: opensearch_hermes

--- a/system/opensearch-hermes/templates/prometheus-alerts.yaml
+++ b/system/opensearch-hermes/templates/prometheus-alerts.yaml
@@ -6,7 +6,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 
 metadata:
-  name: {{ printf "opensearch-%s" $path | replace "/" "-" }}
+  name: {{ printf "opensearch-%s" $path | replace "/" "-" | trimSuffix ".tpl" }}
   labels:
     app: opensearch
     tier: os


### PR DESCRIPTION
Fixing the naming:

without the fix this will happening:

-   name: opensearch-alerts-opensearch.alerts
+   name: opensearch-alerts-opensearch.alerts.tpl

