### PR TITLE
[octavia] gate proxysql native_sidecar init container on secret existence

### DIFF
--- a/openstack/octavia/templates/octavia-migration-job.yaml
+++ b/openstack/octavia/templates/octavia-migration-job.yaml
@@ -33,7 +33,7 @@ spec:
     {{- end }}
       initContainers:
         {{- include "utils.snippets.kubernetes_entrypoint_init_container" (list . (dict "service" (include "octavia.db_service" .))) | indent 8 }}
-        {{- if .Values.proxysql.native_sidecar }}
+        {{- if and $proxysql .Values.proxysql.native_sidecar }}
         {{- include "utils.proxysql.container" . | indent 8 }}
         {{- end }}
       containers:


### PR DESCRIPTION
On first install the proxysql secret does not exist yet, so `$proxysql` is nil and the volumes block is skipped — but the native_sidecar init container is still rendered, referencing `etcproxysql/runproxysql` volumes that don't exist.

(taken from the same fix for manila in #11440)