### PR TITLE
Bump kvm-ha-agent dependency

### DIFF
--- a/openstack/kvm-ha-agent-umbrella/Chart.lock
+++ b/openstack/kvm-ha-agent-umbrella/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kvm-ha-agent
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.1.9
+  version: 0.1.10
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:7d4a81442400d4222cd97246e453bb063e973ae3f8f4c27042a029dd7fd9fc58
-generated: "2026-05-22T09:25:00.336583+02:00"
+digest: sha256:7cdc88be8ad225278a495cdec365259b877f19fa8450be32906710ca6b6bc182
+generated: "2026-06-18T11:31:28.294929+02:00"

--- a/openstack/kvm-ha-agent-umbrella/Chart.yaml
+++ b/openstack/kvm-ha-agent-umbrella/Chart.yaml
@@ -8,7 +8,7 @@ appVersion: "0.2.0"
 
 dependencies:
 - name: kvm-ha-agent
-  version: '0.1.9'
+  version: '0.1.10'
   repository: "oci://keppel.eu-de-1.cloud.sap/ccloud-helm"
 - name: owner-info
   repository: "oci://keppel.eu-de-1.cloud.sap/ccloud-helm"

--- a/openstack/kvm-ha-agent-umbrella/Chart.yaml
+++ b/openstack/kvm-ha-agent-umbrella/Chart.yaml
@@ -3,7 +3,7 @@ name: kvm-ha-agent-umbrella
 description: Umbrella Helm Chart for KVM HA Agent
 type: application
 
-version: 0.1.4
+version: 0.1.5
 appVersion: "0.2.0"
 
 dependencies:


### PR DESCRIPTION
Bumping kvm-ha-agent dependency to remove unused alert definition, which moved into kvm-monitoring chart.