### PR TITLE
[octavia] Adjust alerts prometheus values format

### DIFF
--- a/openstack/octavia/ci/test-values.yaml
+++ b/openstack/octavia/ci/test-values.yaml
@@ -80,8 +80,11 @@ tls:
 alerts:
   enabled: true
   prometheus:
-    openstack: openstack-test-target
-    kubernetes: kubernetes-test-target
+    - name: openstack
+      type: prometheus
+    - name: kubernetes
+      type: prometheus
+
 
 # openstack-rate-limit
 rate_limit:

--- a/openstack/octavia/templates/prometheus-alerts.yaml
+++ b/openstack/octavia/templates/prometheus-alerts.yaml
@@ -1,7 +1,7 @@
 {{- $values := .Values }}
 {{- if $values.alerts.enabled }}
-{{- range $target, $cluster := $values.alerts.prometheus }}
-{{- range $path, $bytes := $.Files.Glob (printf "alerts/%s/*.alerts" $target) }}
+{{- range $i, $target := $values.alerts.prometheus }}
+{{- range $path, $bytes := $.Files.Glob (printf "alerts/%s/*.alerts" $target.name) }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
@@ -11,10 +11,9 @@ metadata:
     app: octavia
     tier: os
     type: alerting-rules
-    prometheus: {{ $cluster | quote }}
+    {{ $target.type | required (printf "$values.alerts.prometheus.[%v].type missing" $i) }}: {{ $target.name | required (printf "$values.alerts.prometheus.[%v].name missing" $i) }}
 spec:
 {{ printf "%s" $bytes | indent 2 }}
-
 {{- end }}
 {{- end }}
 {{- end }}

--- a/openstack/octavia/values.yaml
+++ b/openstack/octavia/values.yaml
@@ -357,8 +357,10 @@ alerts:
   enabled: true
   # Name of the Prometheus to which the alerts should be assigned to.
   prometheus:
-    openstack: openstack
-    kubernetes: kubernetes
+    - name: openstack
+      type: prometheus
+    - name: kubernetes
+      type: prometheus
 
 sentry:
   enabled: true


### PR DESCRIPTION
Rendering the octavia chart lately produced one error: coalesce.go:301: warning: destination for mariadb.alerts.prometheus is a table. Ignoring non-table value (openstack)

This is due to the octavia chart itself having a different format for the alerts.prometheus values than the mariadb subchart. We now change the format to the format the subchart expects. As our neutron chart is already using that format we copy over the prometheus-alerts.yaml from there and replace neutron with octavia. This renders to roughly the same chart (no quoting for the prometheus value, also the rules are in a different order).