### PR TITLE
Add: IPC_LOCK for vault

### DIFF
--- a/system/gatekeeper/templates/constraint-pod-security-v2.yaml
+++ b/system/gatekeeper/templates/constraint-pod-security-v2.yaml
@@ -1336,6 +1336,18 @@ spec:
       {{- end }}
 
       ##########################################################################
+      # Rules for vault
+
+      - matchNamespace: vault
+        matchRepository: ccloud-dockerhub-mirror/hashicorp/vault
+        justification: |
+          Vault 2.0.1's binary ships with the `cap_ipc_lock=ep` file capability
+          baked in at build time. The Linux kernel refuses to exec such a
+          binary inside a container unless IPC_LOCK is granted in the
+          container's securityContext.
+        mayUseCapabilities: [ IPC_LOCK ]
+
+      ##########################################################################
       # End of rules
 
 {{- end }}


### PR DESCRIPTION
Vault 2.0.1's binary ships with the `cap_ipc_lock=ep` file capability baked in at build time. The Linux kernel refuses to exec such a binary inside a container unless IPC_LOCK is granted in the container's securityContext. This applies to both the main `vault` server container and the `vault-plugin-setup` sidecar, which uses the same image and invokes the `vault` CLI in a loop.

IPC_LOCK is also functionally needed so that Vault can mlock sensitive memory pages and prevent them from being swapped to disk.