### PR TITLE
chore(aurora): extract port configuration to values.yaml

### DIFF
--- a/openstack/aurora/templates/_env.tpl
+++ b/openstack/aurora/templates/_env.tpl
@@ -1,5 +1,5 @@
 - name: PORT
-  value: "3000"
+  value: {{ .Values.port | quote }}
 - name: IDENTITY_ENDPOINT
   # prettier-ignore
   value: {{ .Values.identity_endpoint | default (printf "https://identity-3.%s.%s/v3" .Values.global.region .Values.global.tld) | quote }}

--- a/openstack/aurora/templates/deployment.yaml
+++ b/openstack/aurora/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         # Ensure that prometheus scrapes the metrics
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
+        prometheus.io/port: {{ .Values.port | quote }}
     spec:
       affinity:
         podAntiAffinity:
@@ -49,7 +50,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: server
-              containerPort: 3000
+              containerPort: {{ .Values.port }}
           env:
 {{ include (print .Template.BasePath "/_env.tpl") . | indent 12 }}
           envFrom:
@@ -58,7 +59,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /
-              port: 3000
+              port: {{ .Values.port }}
             timeoutSeconds: 10
             failureThreshold: 3
             periodSeconds: 60
@@ -66,7 +67,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /
-              port: 3000
+              port: {{ .Values.port }}
             timeoutSeconds: 5
             periodSeconds: 5
             failureThreshold: 3

--- a/openstack/aurora/values.yaml
+++ b/openstack/aurora/values.yaml
@@ -8,6 +8,8 @@ image:
   tag: latest
   pullPolicy: IfNotPresent
 
+port: 3000
+
 owner-info:
   support-group: containers
   service: aurora


### PR DESCRIPTION
## Summary
Extracts the hardcoded port `3000` to a configurable value in `values.yaml` to improve maintainability and add proper Prometheus port annotation.

## Changes
- **values.yaml**: Added `port: 3000` as a top-level configuration value
- **deployment.yaml**:
  - Added `prometheus.io/port` annotation referencing the port value
  - Updated `containerPort` to use the port value
  - Updated `livenessProbe` and `readinessProbe` to use the port value
- **_env.tpl**: Updated `PORT` environment variable to reference the port value

## Benefits
- Single source of truth for port configuration
- Proper Prometheus scraping configuration with explicit port annotation
- Easy to override port in environment-specific values files
- Consistent port usage across container, probes, and environment variables

## Test Plan
- Verify deployment renders correctly: `helm template openstack/aurora`
- Verify port is correctly applied to all resources
- Verify Prometheus can scrape metrics from the specified port