### PR TITLE
logs: add json parser for netbox inventory logger

### DIFF
--- a/system/logs/vendor/logs/templates/_containerd-config.tpl
+++ b/system/logs/vendor/logs/templates/_containerd-config.tpl
@@ -26,6 +26,9 @@ file_log/containerd:
       type: add
       field: attributes["log.type"]
       value: "containerd"
+    - id: netbox-json-parser
+      type: json_parser
+      parse_from: body
 {{end}}
 
 {{- define "containerd.transform" }}


### PR DESCRIPTION
Netbox inventory logger emits JSON payload in the body field.  This change adds a json_parser operator to parse the JSON body and expose appropriate fields.