### PR TITLE
[octobus-exporter-vmware] remove NFSFCDDatFileConnectionTimeout alert and query config

### DIFF
--- a/prometheus-exporters/octobus-query-exporter/Chart.lock
+++ b/prometheus-exporters/octobus-query-exporter/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: octobus-query-exporter
   repository: file://vendor/octobus-query-exporter
-  version: 1.0.26
+  version: 1.0.27
 - name: octobus-query-exporter-global
   repository: file://vendor/octobus-query-exporter-global
   version: 1.0.14
@@ -11,5 +11,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:dd5255a69a6a86cd0ac704ace15e42e6469e8d644ce96cbab697d3342cebd2b6
-generated: "2026-06-18T15:15:45.478689+08:00"
+digest: sha256:f2d3ff1f9806bda2cd0d3325b455f4e95f02f0037c37ac12ffeebf65f2551699
+generated: "2026-06-19T00:11:38.423017+08:00"

--- a/prometheus-exporters/octobus-query-exporter/Chart.yaml
+++ b/prometheus-exporters/octobus-query-exporter/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 1.0.28
+version: 1.0.29
 name: octobus-query-exporter
 description: Elasticsearch prometheus query exporter
 maintainers:
@@ -11,7 +11,7 @@ dependencies:
   - name: octobus-query-exporter
     alias: octobus_query_exporter
     repository: file://vendor/octobus-query-exporter
-    version: 1.0.26
+    version: 1.0.27
     condition: octobus_query_exporter.enabled
 
   - name: octobus-query-exporter-global

--- a/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/Chart.yaml
+++ b/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 1.0.26
+version: 1.0.27
 name: octobus-query-exporter
 description: Elasticsearch prometheus query exporter
 maintainers:

--- a/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/alerts/scaleout/events.alerts.tpl
+++ b/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/alerts/scaleout/events.alerts.tpl
@@ -99,5 +99,5 @@ groups:
           playbook: docs/compute/playbooks/vcenter/#FCDObjectNotFound
         annotations:
           summary: "Error for FCD Object Storage Not Found "
-          description: "vCenter {{ $labels.hostsystem }} reported FCD Ojbect Not found, please follow the playbook to fix it"
+          description: "vCenter{{`{{ $labels.hostsystem }}`}} reported FCD Ojbect Not found, please follow the playbook to fix it"
 


### PR DESCRIPTION
Follow-up to #12008.

Removes `NFSFCDDatFileConnectionTimeout` alert and its associated query config file, and fixes the Go template syntax for `$labels.hostsystem` in the `NFSFCDObjectNotFound` alert description.

**Changes:**
- Remove `NFSFCDDatFileConnectionTimeout` alert from `events.alerts.tpl`
- Delete `vmware_esxi_nfs_datfile_connectiontimeout.cfg`
- Fix template syntax: wrap `$labels.hostsystem` in backtick delimiters in `NFSFCDObjectNotFound` description