### PR TITLE
fix: audit logs http cleartext tls

### DIFF
--- a/system/audit-logs/Chart.yaml
+++ b/system/audit-logs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Audit logging components
 name: audit-logs
-version: 0.3.27
+version: 0.3.28
 dependencies:
   - name: fluent-audit-container
     alias: fluent_audit_container

--- a/system/audit-logs/vendor/logstash-audit-external/templates/_logstash.conf.tpl
+++ b/system/audit-logs/vendor/logstash-audit-external/templates/_logstash.conf.tpl
@@ -18,7 +18,7 @@ input {
     tags => ["audit"]
     user => '${AUDIT_HTTP_USER}'
     password => '${AUDIT_HTTP_PWD}'
-{{ if eq .Values.global.clusterType "metal" -}}
+{{ if ne .Values.global.clusterType "scaleout" -}}
     ssl_enabled => true
     ssl_certificate => '/tls-secret/tls.crt'
     ssl_key => '/usr/share/logstash/config/tls.key'

--- a/system/audit-logs/vendor/logstash-audit-external/templates/statefulset.yaml
+++ b/system/audit-logs/vendor/logstash-audit-external/templates/statefulset.yaml
@@ -42,7 +42,7 @@ spec:
         - name: audit-etc
           configMap:
             name: logstash-audit-external-etc
-      {{- if .Values.syslog.enabled }}
+      {{- if or .Values.http.enabled .Values.mtls.enabled }}
         - name: tls-secret
           secret:
             secretName: tls-logstash-audit-external
@@ -91,7 +91,7 @@ spec:
           volumeMounts:
             - name: audit-etc
               mountPath: /audit-etc
-      {{- if .Values.syslog.enabled }}
+      {{- if or .Values.http.enabled .Values.mtls.enabled }}
             - mountPath: /tls-secret
               name: tls-secret
       {{- end }}


### PR DESCRIPTION
changing 
{{ if eq .Values.global.clusterType "metal" -}}
to 
{{ if ne .Values.global.clusterType "scaleout" -}}

TLS on the audit HTTP input was metal-only, so admin/virtual clusters exposed Basic Auth over plain HTTP (the pentest finding). ne scaleout enables TLS on every directly-exposed input and excludes only scaleout, which terminates TLS at its ingress. 


changing
 {{- if .Values.syslog.enabled }}
to
{{- if or .Values.http.enabled .Values.mtls.enabled }}

the cert was only mounted when syslog was enabled, so on syslog-disabled clusters the now-TLS input would have no cert to read and crashloop. Mounting it based on the http/mtls inputs ensures the cert is present wherever TLS is actually used.