### PR TITLE
utils: make osprofiler connection_string configurable for OTLP support

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.37.2
+version: 0.38.0

--- a/openstack/utils/templates/_helpers.tpl
+++ b/openstack/utils/templates/_helpers.tpl
@@ -34,7 +34,7 @@ propagate=0
 {{- if .Values.osprofiler.enabled }}
 [profiler]
 enabled = true
-connection_string = jaeger://localhost:6831
+connection_string = {{ .Values.osprofiler.connection_string | default "jaeger://localhost:6831" }}
 hmac_keys = {{ .Values.global.osprofiler.hmac_keys | include "resolve_secret" }}
 trace_sqlalchemy = {{ .Values.global.osprofiler.trace_sqlalchemy }}
 {{- end }}
@@ -45,7 +45,7 @@ trace_sqlalchemy = {{ .Values.global.osprofiler.trace_sqlalchemy }}
 {{- end }}
 
 {{- define "jaeger_agent_sidecar" }}
-{{- if .Values.osprofiler.enabled }}
+{{- if and .Values.osprofiler.enabled (hasPrefix "jaeger://" (.Values.osprofiler.connection_string | default "jaeger://localhost:6831")) }}
 - image: {{.Values.global.dockerHubMirrorAlternateRegion}}/jaegertracing/jaeger-agent:{{ .Values.global.osprofiler.jaeger.version }}
   name: jaeger-agent
   ports:


### PR DESCRIPTION
Allow services to opt in to OTLP tracing by setting osprofiler.connection_string to an otlp:// URL. The jaeger agent sidecar is only deployed when the connection string uses the jaeger:// scheme (the default).