### PR TITLE
[octavia] Bump utils chart to 0.37.1

### DIFF
--- a/openstack/octavia/Chart.lock
+++ b/openstack/octavia/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 0.22.1
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.33.0
+  version: 0.37.1
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
@@ -26,5 +26,5 @@ dependencies:
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.2.19
-digest: sha256:f9542f8c375b4a574602c631265c79837e23da06f51cbce9f53a3337e7df0e5c
-generated: "2026-05-28T14:55:19.277636+03:00"
+digest: sha256:010124b200c362d60cb914247ac5e7a11a8e0ce50d0e79ce698b5f0ea194f5a0
+generated: "2026-06-19T18:03:56.864405658+02:00"

--- a/openstack/octavia/Chart.yaml
+++ b/openstack/octavia/Chart.yaml
@@ -32,7 +32,7 @@ dependencies:
     version: 0.22.1
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.33.0
+    version: 0.37.1
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0


### PR DESCRIPTION
This should correct most svc fqdn issues we're currently seeing with the eu-de-3 deployment.