### PR TITLE
[cc-shoots-compute] Add coredump control for KVM shoots

### DIFF
--- a/system/cc-shoots-compute/Chart.yaml
+++ b/system/cc-shoots-compute/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-shoots-compute
 description: Converged Cloud Gardener shoots
 type: application
-version: 2.5.0
+version: 2.6.0
 appVersion: "0.1.0"

--- a/system/cc-shoots-compute/templates/kvm-shoot.yaml
+++ b/system/cc-shoots-compute/templates/kvm-shoot.yaml
@@ -325,7 +325,7 @@ spec:
                     inline: |
                       tls_priority = "NORMAL:-VERS-SSL3.0:-VERS-TLS1.0:-VERS-TLS1.1"
 
-                {{- if contains "qa" $.Values.global.region }}
+                {{- if coalesce ($worker.coredump).enabled ($cluster.coredump).enabled $.Values.coredump.enabled }}
                 - path: /etc/systemd/coredump.conf.d/90-qa.conf
                   overwrite: yes
                   mode: 0600

--- a/system/cc-shoots-compute/values.yaml
+++ b/system/cc-shoots-compute/values.yaml
@@ -3,3 +3,5 @@ kvmShoot: false
 networking:
   enableBirdExporter: true
   overlay: true
+coredump:
+  enabled: false


### PR DESCRIPTION
Make coredump configuration configurable instead of depending on region.
