### PR TITLE
[netapp-harvest-exporter] upgrade harvest image 23.11.0-1 → 26.05.0-1

### DIFF
--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/Chart.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: NetApp Harvest exporter
 name: netapp-harvest-exporter
 type: application
-version: 0.2.14
+version: 0.2.15
 # Changes
 # v0.1.2: - fix incosistent cluster labels
 # v0.1.3: - fix multiple scraping problem when filers in maintenance
@@ -40,4 +40,5 @@ version: 0.2.14
 # v0.2.12: - netappsd: retire workers on inactive filer
 # v0.2.13: - netappsd: update netbox client to v4
 #          - netappsd: discover flexgroup clusters for manila
-# v0.2.14: - fix netappsd: check installed device while discover filers 
+# v0.2.14: - fix netappsd: check installed device while discover filers
+# v0.2.15: - upgrade harvest image from 23.11.0-1 to 26.05.0-1

--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/values.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/values.yaml
@@ -22,7 +22,7 @@ apps:
 harvest:
   image:
     repository: rahulguptajss/harvest
-    tag: 23.11.0-1
+    tag: 26.05.0-1
   loglevel: 2
   ports:
     liveness: 8080


### PR DESCRIPTION
## Summary

- Bumps `rahulguptajss/harvest` image tag from `23.11.0-1` to `26.05.0-1` (latest stable, released 2026-05-11)
- Bumps sub-chart version `0.2.14` → `0.2.15`

## Breaking changes assessment

Upstream 26.05.0 has the following changes between 23.11.0 and 26.05.0:
- Default collector switched to KeyPerf for volumes — **not affected** (we supply custom templates in `etc/`)
- WorkloadDetail/Qtree perf templates removed/disabled — **not affected** (we use `zapi.limited.yaml`, `zapiperf.limited.yaml`, custom REST templates)
- Shelf power double-count bug fix — **positive change**

No changes required to custom templates or alert rules.

## Test plan

- [ ] CI helm-unittest passes
- [ ] CI test-prometheus-rules passes
- [ ] Verify harvest pods restart cleanly after deploy (check `netapp_metadata_exporter_count` metric)