### PR TITLE
[neutron-hypervisor-agents] Add DHCP and metadata agent to linuxbridge daemonset

### DIFF
--- a/openstack/neutron-hypervisor-agents/Chart.yaml
+++ b/openstack/neutron-hypervisor-agents/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart for Openstack Neutron hypervisor agents
 name: neutron-hypervisor-agents
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Neutron/OpenStack_Project_Neutron_mascot.png
-version: 0.2.1
+version: 0.3.0
 appVersion: "caracal"
 dependencies:
 - name: utils

--- a/openstack/neutron-hypervisor-agents/Chart.yaml
+++ b/openstack/neutron-hypervisor-agents/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart for Openstack Neutron hypervisor agents
 name: neutron-hypervisor-agents
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Neutron/OpenStack_Project_Neutron_mascot.png
-version: 0.2.2
+version: 0.3.0
 appVersion: "caracal"
 dependencies:
 - name: utils

--- a/openstack/neutron-hypervisor-agents/ci/test-with-dhcp-agent-values.yaml
+++ b/openstack/neutron-hypervisor-agents/ci/test-with-dhcp-agent-values.yaml
@@ -1,0 +1,78 @@
+global:
+  region: staging
+  registry: registry.example.com/internal
+  dockerHubMirror: registry.example.com/mirror
+  dockerHubMirrorAlternateRegion: registry.example.org/mirror
+  osprofiler:
+    enabled: true
+  dbPassword: topSecret
+  nova_metadata_secret: topSecret
+  master_password: topSecret
+  availability_zones:
+    - foo
+    - bar
+  domain_seeds:
+    skip_hcm_domain: false
+  neutron_service_user: neutron
+  neutron_service_password: neutron
+
+defaults:
+  availability_zone: az1
+  scheduling_disabled: true
+  network:
+    linuxbridge:
+      deploy_dhcp_agent: true
+
+secgroup_entanglement_exporter:
+  release: queens
+
+agent:
+  multus: true
+  dhcp:
+    num_sync_threads: 10
+
+manila:
+  physnet: myphysnet
+
+aci:
+  apic_application_profile: converged_cloud_openstack
+  support_remote_mac_clear: 'True'
+  sync_allocations: 'True'
+  apic_tenant_name: cc
+  apic_hosts: myHost
+  apic_user: myUser
+  apic_password: myPassword
+  bindings: myBinding
+  aci_hostgroups:
+    hostgroups: []
+
+asr:
+  physnet: cp090
+
+sftp:
+  externalIPs: myIP
+  password: swordfish
+  os_password: secret
+
+osprofiler: {}
+ml2_mechanismdrivers: myDriver
+dns_forwarders: myDNS
+dns_local_domain: myDNSLocal
+global.nova_metadata_secret: topSecret
+dns_ml2_extension: myDNS
+cp_physical_network: myPN
+cp_network_interface: myBond
+interface_driver: myID
+dhcp_lease_duration: '86400'
+max_fixed_ips_per_port: 100
+max_allowed_address_pair: 100
+allow_automatic_dhcp_failover: 'true'
+imageVersionNetworkAgentDHCP: queens
+imageVersionNetworkAgentLinuxBridge: queens
+imageVersion: queens
+imageVersionEntanglement: queens
+
+rabbitmq:
+  users:
+    default:
+      password: "bogus"

--- a/openstack/neutron-hypervisor-agents/templates/configmap-etc.yaml
+++ b/openstack/neutron-hypervisor-agents/templates/configmap-etc.yaml
@@ -18,3 +18,21 @@ data:
 {{ include (print .Template.BasePath "/etc/_sudoers.tpl") . | indent 4 }}
   logging.ini: |
 {{ include "loggerIni" .Values.logging_sapccsentry | indent 4 }}
+{{- if .Values.defaults.network.linuxbridge.deploy_dhcp_agent }}
+  dnsmasq.conf: |
+{{ include (print .Template.BasePath "/etc/_dnsmasq.conf.tpl") . | indent 4 }}
+  dhcp-agent.ini: |
+{{ include (print .Template.BasePath "/etc/_dhcp-agent.ini.tpl") . | indent 4 }}
+  dhcp.filters: |
+{{ include (print .Template.BasePath "/etc/_dhcp.filters.tpl") . | indent 4 }}
+  metadata-agent.ini: |
+{{ include (print .Template.BasePath "/etc/_metadata-agent.ini.tpl") . | indent 4 }}
+  az.conf: |
+    {{- if .Values.defaults.availability_zone }}
+    [agent]
+    availability_zone = {{ .Values.defaults.availability_zone }}
+    {{- end }}
+    {{- if .Values.defaults.scheduling_disabled }}
+    scheduling_disabled = {{ .Values.defaults.scheduling_disabled }}
+    {{- end }}
+{{- end }}

--- a/openstack/neutron-hypervisor-agents/templates/configmap-etc.yaml
+++ b/openstack/neutron-hypervisor-agents/templates/configmap-etc.yaml
@@ -18,3 +18,21 @@ data:
     {{- include (print .Template.BasePath "/etc/_sudoers.tpl") . | nindent 4 }}
   logging.ini: |
     {{- include "loggerIni" .Values.logging_sapccsentry | nindent 4 }}
+{{- if .Values.defaults.network.linuxbridge.deploy_dhcp_agent }}
+  dnsmasq.conf: |
+    {{- include (print .Template.BasePath "/etc/_dnsmasq.conf.tpl") . | nindent 4 }}
+  dhcp-agent.ini: |
+    {{- include (print .Template.BasePath "/etc/_dhcp-agent.ini.tpl") . | nindent 4 }}
+  dhcp.filters: |
+    {{- include (print .Template.BasePath "/etc/_dhcp.filters.tpl") . | nindent 4 }}
+  metadata-agent.ini: |
+    {{- include (print .Template.BasePath "/etc/_metadata-agent.ini.tpl") . | nindent 4 }}
+  az.conf: |
+    {{- if .Values.defaults.availability_zone }}
+    [agent]
+    availability_zone = {{ .Values.defaults.availability_zone }}
+    {{- end }}
+    {{- if .Values.defaults.scheduling_disabled }}
+    scheduling_disabled = {{ .Values.defaults.scheduling_disabled }}
+    {{- end }}
+{{- end }}

--- a/openstack/neutron-hypervisor-agents/templates/daemonset-linuxbridge-agent.yaml
+++ b/openstack/neutron-hypervisor-agents/templates/daemonset-linuxbridge-agent.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       affinity:
         {{- toYaml $hypervisor.pod.affinity | nindent 8 }}
-      hostNetwork: true # TODO: replace with multus
+      hostNetwork: true
       hostAliases:
       {{- range $ip := .Values.rabbitmq.externalIPs }}
       - ip: {{ $ip }}
@@ -71,7 +71,7 @@ spec:
                 - DAC_OVERRIDE
                 - DAC_READ_SEARCH
                 - SYS_PTRACE
-          command: ["sh", "-c"]
+          command: ["dumb-init", "/bin/bash", "-c"]
           args:
             - |
               set -xe
@@ -82,15 +82,10 @@ spec:
                 update-alternatives --set ebtables /usr/sbin/ebtables-legacy || true
               fi
 
+              export OS_LINUX_BRIDGE__PHYSICAL_INTERFACE_MAPPINGS="${HOSTNAME/*-}:bond0"
               # Start the linuxbridge agent
               exec neutron-linuxbridge-agent --debug
           env:
-            - name: BUILDING_BLOCK
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.labels['kubernetes.metal.cloud.sap/bb']
-            - name: OS_LINUX_BRIDGE__PHYSICAL_INTERFACE_MAPPINGS
-              value: "$(BUILDING_BLOCK):bond0"
             - name: OS_SECURITYGROUP__FIREWALL_DRIVER
               value: "iptables"
           volumeMounts:
@@ -124,10 +119,75 @@ spec:
           - mountPath: /lib/modules
             name: modules
             readOnly: true
+        {{- if $hypervisor.deploy_dhcp_agent }}
+        - name: neutron-dhcp-agent
+          image: {{$.Values.global.registry}}/loci-neutron:{{$.Values.imageVersionNetworkAgentDHCP | default $.Values.imageVersionNetworkAgent | default $.Values.imageVersion | required "Please set neutron.imageVersionNetworkAgentDHCP or similar"}}
+          imagePullPolicy: IfNotPresent
+          command: ["dumb-init", "neutron-dhcp-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-dir", "/etc/neutron/secrets", "--config-file", "/etc/neutron/dhcp-agent.ini", "--config-file", "/etc/neutron/az.conf"]
+          env:
+            - name: DEBUG_CONTAINER
+              value: "false"
+            - name: SPT_NOENV
+              value: "yes,please"
+            - name: PYTHONWARNINGS
+              value: "ignore:Unverified HTTPS request"
+            {{- include "utils.trust_bundle.env" $ | indent 12 }}
+          readinessProbe:
+            exec:
+              command: ["neutron-dhcp-readiness", "-config-file", "/etc/neutron/neutron.conf", "--config-file", "/etc/neutron/secrets/neutron-common-secrets.conf"]
+            initialDelaySeconds: 30
+            periodSeconds: 60
+            timeoutSeconds: 10
+          securityContext:
+            privileged: true
+          resources:
+{{ toYaml $.Values.pod.resources.dhcp_agent | indent 12 }}
+          volumeMounts:
+            - name: metadata-proxy
+              mountPath: /run/metadata_proxy
+            - name: modules
+              mountPath: /lib/modules
+              readOnly: true
+            - name: logvol
+              mountPath: /dev/log
+              readOnly: false
+            - name: etc-neutron-dhcp-agent
+              mountPath: /etc/neutron
+              readOnly: true
+            - name: etc
+              mountPath: /etc/sudoers
+              subPath: sudoers
+              readOnly: true
+            {{- include "utils.trust_bundle.volume_mount" $ | indent 12 }}
+        - name: neutron-metadata-agent
+          image: {{$.Values.global.registry}}/loci-neutron:{{$.Values.imageVersionNetworkAgentMetadata | default $.Values.imageVersionNetworkAgent | default $.Values.imageVersion | required "Please set neutron.imageVersionNetworkAgentMetadata or similar"}}
+          imagePullPolicy: IfNotPresent
+          command: ["dumb-init", "neutron-metadata-agent", "--config-file", "/etc/neutron/neutron.conf", "--config-dir", "/etc/neutron/secrets","--config-file", "/etc/neutron/metadata-agent.ini"]
+          env:
+            - name: PYTHONWARNINGS
+              value: "ignore:Unverified HTTPS request"
+            - name: DEBUG_CONTAINER
+              value: "false"
+            {{- include "utils.trust_bundle.env" $ | indent 12 }}
+          resources:
+{{  toYaml $.Values.pod.resources.metadata_agent | indent 12 }}
+          volumeMounts:
+            - name: metadata-proxy
+              mountPath: /run/metadata_proxy
+            - name: etc-neutron-metadata-agent
+              mountPath: /etc/neutron
+              readOnly: true
+            {{- include "utils.trust_bundle.volume_mount" $ | indent 12 }}
+        {{- end }}
       dnsConfig:
         searches:
           - {{ .Values.global.region }}.{{ .Values.global.tld }}
       volumes:
+      - name: logvol
+        hostPath:
+          path: /dev/log
+      - name: metadata-proxy
+        emptyDir: {}
       - name: run
         hostPath:
           path: /run
@@ -152,3 +212,52 @@ spec:
       - name: host
         hostPath:
             path: "/"
+      - name: etc-neutron-dhcp-agent
+        projected:
+          defaultMode: 420
+          sources:
+          - configMap:
+              name: {{ .Release.Name }}-etc
+              items:
+              - key: neutron.conf
+                path: neutron.conf
+              - key: logging.ini
+                path: logging.ini
+              - key: rootwrap.conf
+                path: rootwrap.conf
+              - key: dnsmasq.conf
+                path: dnsmasq.conf
+              - key: dhcp.filters
+                path: rootwrap.d/dhcp.filters
+              - key: dhcp-agent.ini
+                path: dhcp-agent.ini
+              - key: az.conf
+                path: az.conf
+          - secret:
+              name: neutron-common-secrets
+              items:
+                - key: neutron-common-secrets.conf
+                  path: secrets/neutron-common-secrets.conf
+      - name: etc-neutron-metadata-agent
+        projected:
+          defaultMode: 420
+          sources:
+          - configMap:
+              name: {{ .Release.Name }}-etc
+              items:
+              - key: neutron.conf
+                path: neutron.conf
+              - key: logging.ini
+                path: logging.ini
+              - key: metadata-agent.ini
+                path: metadata-agent.ini
+          - secret:
+              name: neutron-common-secrets
+              items:
+                - key: neutron-common-secrets.conf
+                  path: secrets/neutron-common-secrets.conf
+          - secret:
+              name: neutron-metadata-secrets
+              items:
+                - key: neutron-metadata-secrets.conf
+                  path: secrets/neutron-metadata-secrets.conf

--- a/openstack/neutron-hypervisor-agents/templates/etc/_dhcp-agent.ini.tpl
+++ b/openstack/neutron-hypervisor-agents/templates/etc/_dhcp-agent.ini.tpl
@@ -1,0 +1,21 @@
+# dhcp_agent.ini
+[DEFAULT]
+
+interface_driver = linuxbridge
+debug = {{.Values.debug}}
+
+dnsmasq_config_file = /etc/neutron/dnsmasq.conf
+force_metadata=True
+enable_isolated_metadata=True
+metadata_proxy_socket = /run/metadata_proxy/metadata_proxy
+dnsmasq_dns_servers = {{required "A valid .Values.dns_forwarders required!" .Values.dns_forwarders}}
+dhcp_domain = {{required "A valid .Values.dns_local_domain required!" .Values.dns_local_domain}}
+dns_domain = {{required "A valid .Values.dns_local_domain required!" .Values.dns_local_domain}}
+num_sync_threads = {{.Values.agent.dhcp.num_sync_threads | default 4 }}
+edns_client_fingerprint = {{.Values.agent.dhcp.edns_client_fingerprint | default "False" }}
+netns_resolvconf = {{.Values.agent.dhcp.netns_resolvconf | default "False" }}
+enable_router_advertisements = {{.Values.agent.dhcp.enable_router_advertisements | default "False" }}
+
+rpc_response_timeout = {{ .Values.rpc_response_timeout | default .Values.global.rpc_response_timeout | default 50 }}
+rpc_workers = {{ .Values.rpc_workers | default .Values.global.rpc_workers | default 5 }}
+rpc_conn_pool_size = {{ .Values.rpc_conn_pool_size | default .Values.global.rpc_conn_pool_size | default 100 }}

--- a/openstack/neutron-hypervisor-agents/templates/etc/_dhcp.filters.tpl
+++ b/openstack/neutron-hypervisor-agents/templates/etc/_dhcp.filters.tpl
@@ -1,0 +1,42 @@
+# neutron-rootwrap command filters for nodes on which neutron is
+# expected to control network
+#
+# This file should be owned by (and only-writeable by) the root user
+
+# format seems to be
+# cmd-name: filter-name, raw-command, user, args
+
+[Filters]
+
+# dhcp-agent
+dnsmasq: CommandFilter, dnsmasq, root
+# dhcp-agent uses kill as well, that's handled by the generic KillFilter
+# it looks like these are the only signals needed, per
+# neutron/agent/linux/dhcp.py
+kill_dnsmasq: KillFilter, root, /sbin/dnsmasq, -9, -HUP
+kill_dnsmasq_usr: KillFilter, root, /usr/sbin/dnsmasq, -9, -HUP
+
+ovs-vsctl: CommandFilter, ovs-vsctl, root
+ivs-ctl: CommandFilter, ivs-ctl, root
+mm-ctl: CommandFilter, mm-ctl, root
+dhcp_release: CommandFilter, dhcp_release, root
+
+# haproxy
+haproxy: RegExpFilter, haproxy, root, haproxy, -f, .*
+kill_haproxy: KillFilter, root, haproxy, -15, -9, -HUP
+# DEPRECATED: metadata proxy
+metadata_proxy: CommandFilter, neutron-ns-metadata-proxy, root
+
+# TODO(dalvarez): Remove kill_metadata* filters in Q release since
+# neutron-ns-metadata-proxy is now replaced by haproxy. We keep them for now
+# for the migration process
+# RHEL invocation of the metadata proxy will report /usr/bin/python
+kill_metadata: KillFilter, root, python, -9
+kill_metadata7: KillFilter, root, python2.7, -9
+# SAPCC: for killing neutron-ns-metadata-proxy on CC
+kill_metadata2: KillFilter, root, python2, -9
+
+# ip_lib
+ip: IpFilter, ip, root
+find: RegExpFilter, find, root, find, /sys/class/net, -maxdepth, 1, -type, l, -printf, %.*
+ip_exec: IpNetnsExecFilter, ip, root

--- a/openstack/neutron-hypervisor-agents/templates/etc/_dnsmasq.conf.tpl
+++ b/openstack/neutron-hypervisor-agents/templates/etc/_dnsmasq.conf.tpl
@@ -1,0 +1,13 @@
+{{- range $k, $v := .Values.dnsmasq.conf }}
+    {{- if typeIsLike "bool" $v }}
+        {{- if $v }}
+{{ $k }}
+        {{- end }}
+    {{- else }}
+{{ $k }}={{ $v }}
+    {{- end }}
+{{- end }}
+{{- range .Values.dnsmasq.dhcp_options }}
+dhcp-option={{ . }}
+{{- end }}
+local=/{{required "A valid .Values.dns_local_domain is required!" .Values.dns_local_domain }}/

--- a/openstack/neutron-hypervisor-agents/templates/etc/_metadata-agent-secrets.ini.tpl
+++ b/openstack/neutron-hypervisor-agents/templates/etc/_metadata-agent-secrets.ini.tpl
@@ -1,0 +1,3 @@
+# metadata_agent.ini
+[DEFAULT]
+metadata_proxy_shared_secret = {{required "A valid .Values.global.nova_metadata_secret required!" .Values.global.nova_metadata_secret | include "resolve_secret"}}

--- a/openstack/neutron-hypervisor-agents/templates/etc/_metadata-agent.ini.tpl
+++ b/openstack/neutron-hypervisor-agents/templates/etc/_metadata-agent.ini.tpl
@@ -1,0 +1,25 @@
+# metadata_agent.ini
+[DEFAULT]
+debug = {{.Values.debug}}
+
+#endpoint_type = internalURL
+
+nova_metadata_ip = {{include "nova_api_endpoint_host_public" .}}
+nova_metadata_host = {{include "nova_api_endpoint_host_public" .}}
+nova_metadata_protocol = {{.Values.global.nova_api_endpoint_protocol_external | default "https"}}
+nova_metadata_port = {{.Values.global.nova_metadata_port_external | default 443}}
+
+{{- if .Values.agent.multus | default false }}
+metadata_proxy_socket = /run/metadata_proxy/metadata_proxy
+{{- else }}
+metadata_proxy_socket = /run/metadata_proxy
+{{- end }}
+
+rpc_response_timeout = {{ .Values.metadata_rpc_response_timeout | default .Values.global.rpc_response_timeout | default 50 }}
+rpc_workers = {{ .Values.rpc_workers | default .Values.global.rpc_workers | default 5 }}
+rpc_conn_pool_size = {{ .Values.rpc_conn_pool_size | default .Values.global.rpc_conn_pool_size | default 100 }}
+metadata_workers = {{ .Values.agent.metadata_workers | default .Values.global.metadata_workers | default 1 }}
+
+[cache]
+backend = dogpile.cache.memory
+expiration_time = 5

--- a/openstack/neutron-hypervisor-agents/templates/etc/_server_agent_shared_secrets.ini.tpl
+++ b/openstack/neutron-hypervisor-agents/templates/etc/_server_agent_shared_secrets.ini.tpl
@@ -1,0 +1,10 @@
+[DEFAULT]
+{{ include "ini_sections.default_transport_url" . }}
+
+[keystone_authtoken]
+username = {{ .Values.global.neutron_service_user | default "neutron" | include "resolve_secret" }}
+password = {{ .Values.global.neutron_service_password | default "" | include "resolve_secret" }}
+
+{{- if .Values.osprofiler.enabled }}
+{{- include "osprofiler" . }}
+{{- end }}

--- a/openstack/neutron-hypervisor-agents/templates/secret-neutron-common.yaml
+++ b/openstack/neutron-hypervisor-agents/templates/secret-neutron-common.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: neutron-common-secrets
+  labels:
+    system: openstack
+    application: {{ .Release.Name }}
+type: Opaque
+data:
+  neutron-common-secrets.conf: |
+    {{ include (print .Template.BasePath "/etc/_server_agent_shared_secrets.ini.tpl") . | b64enc | indent 4 }}

--- a/openstack/neutron-hypervisor-agents/templates/secret-neutron-metadata.yaml
+++ b/openstack/neutron-hypervisor-agents/templates/secret-neutron-metadata.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: neutron-metadata-secrets
+  labels:
+    system: openstack
+    application: {{ .Release.Name }}
+type: Opaque
+data:
+  neutron-metadata-secrets.conf: |
+    {{ include (print .Template.BasePath "/etc/_metadata-agent-secrets.ini.tpl") . | b64enc | indent 4 }}

--- a/openstack/neutron-hypervisor-agents/values.yaml
+++ b/openstack/neutron-hypervisor-agents/values.yaml
@@ -1,4 +1,5 @@
 defaults:
+  availability_zone:
   network:
     ovs:
       pod:
@@ -9,6 +10,7 @@ defaults:
         nodeSelector:
           neutron.openstack.cloud.sap/ml2-mechanism-driver: ovn
     linuxbridge:
+      deploy_dhcp_agent: false
       pod:
         nodeSelector:
           neutron.openstack.cloud.sap/ml2-mechanism-driver: linuxbridge
@@ -43,11 +45,16 @@ rabbitmq:
     default:
       user: rabbitmq
 securitygroup:
-  enable_anti_spoofing_rules: False
+  enable_anti_spoofing_rules: false
 
 ovsOnHost: true
 agent:
   rootwrap_daemon: false
+
+dnsmasq:
+  conf:
+    no-negcache: true
+
 osprofiler: {}
 ovn:
   external_ids: {}
@@ -58,7 +65,7 @@ cc_fabric: {}
 vpods_conf:
   ovs:
     # bridge_mappings: "{{ segment }}:br-ex" Set dynamically script
-    enable_tunneling: False
+    enable_tunneling: false
     ovsdb_connection: "unix:/var/run/openvswitch/db.sock"
 
 pod:
@@ -70,6 +77,14 @@ pod:
           rollingUpdate:
             maxUnavailable: "10%"
   tolerations: {}
+  resources:
+    dhcp_agent:
+      requests:
+        cpu: "1000m"
+        memory: "1Gi"
+      limits:
+        cpu: "4000m"
+        memory: "2.5Gi"
 
 memcached:
   memcached: {}


### PR DESCRIPTION
This imports the DHCP and metadata agent based on the
[statefulset-network-agent-apod.yaml](https://github.com/sapcc/helm-charts/blob/master/openstack/neutron/templates/statefulset-network-agent-apod.yaml)
of the openstack/neutron helm chart. All required dependencies were
respectively added. In addition, the daemon set dependency to the
kubernetes.metal.cloud.sap/bb label was removed and is replaced by
reading the building block from the hostname.
