### PR TITLE
[mariadb][backup-v2] support multiple ceph s3 backup targets

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.39.0 - 2026/06/22
+* support multiple Ceph S3 backup targets via `global.mariadb.backup_v2.ceph_s3.targets`
+* drop `global.mariadb.backup_v2.ceph_s3.{endpoint,region,bucket_name,aws_access_key_id,aws_secret_access_key}` keys
+* chart version bumped
+
 ## v0.38.2 - 2026/06/16
 * use global.mariadb.backup_v2 for ceph s3 access and secret key
 * chart version bumped

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.38.2
+version: 0.39.0
 # scripts/docker-entyrpoint.sh should be updated when appVersion is updated
 appVersion: 10.11.18
 dependencies:

--- a/common/mariadb/ci/test-values.yaml
+++ b/common/mariadb/ci/test-values.yaml
@@ -17,10 +17,11 @@ global:
         region: local
         sse_customer_key: superSecret
       ceph_s3:
-        endpoint: "https://ceph-s3.local.example.com"
-        region: local
-        aws_access_key_id: superSecret
-        aws_secret_access_key: superSecret
+        targets:
+          - endpoint: "https://ceph-s3.local.example.com"
+            region: local
+            aws_access_key_id: superSecret
+            aws_secret_access_key: superSecret
 
 test_db_host: testRelease-mariadb.svc
 root_password: secret123

--- a/common/mariadb/templates/config/_backup_config.yaml.tpl
+++ b/common/mariadb/templates/config/_backup_config.yaml.tpl
@@ -31,7 +31,22 @@ database:
     - "{{$tl}}"
   {{- end }}
 storages:
-  {{- if or .Values.backup_v2.aws.enabled .Values.backup_v2.ceph_s3.enabled }}
+  {{- $cephTargets := list }}
+  {{- if .Values.backup_v2.ceph_s3.enabled }}
+    {{- $cephTargets = default (list) (dig "mariadb" "backup_v2" "ceph_s3" "targets" (list) .Values.global) }}
+    {{- if eq (len $cephTargets) 0 }}
+      {{- fail "backup_v2.ceph_s3.enabled is true but global.mariadb.backup_v2.ceph_s3.targets is empty" }}
+    {{- end }}
+    {{- $names := list }}
+    {{- range $t := $cephTargets }}
+      {{- $r := default $.Values.global.region $t.region }}
+      {{- $names = append $names (default (printf "ceph-%s" $r) $t.name) }}
+    {{- end }}
+    {{- if ne (len $names) (len (uniq $names)) }}
+      {{- fail (printf "duplicate ceph_s3 target name(s) in %v — please change 'name' to be unique" $names) }}
+    {{- end }}
+  {{- end }}
+  {{- if or .Values.backup_v2.aws.enabled (gt (len $cephTargets) 0) }}
   s3:
     {{- if .Values.backup_v2.aws.enabled }}
     - name: aws-{{ .Values.global.mariadb.backup_v2.aws.region }}
@@ -42,15 +57,16 @@ storages:
       sse_customer_algorithm: "AES256"
       sse_customer_key: {{ include "mariadb.resolve_secret_squote" .Values.global.mariadb.backup_v2.aws.sse_customer_key }}
     {{- end }}
-    {{- if .Values.backup_v2.ceph_s3.enabled }}
-    - name: ceph-{{ default .Values.global.region .Values.global.mariadb.backup_v2.ceph_s3.region }}
-      aws_access_key_id: {{ include "mariadb.resolve_secret_squote" .Values.global.mariadb.backup_v2.ceph_s3.aws_access_key_id }}
-      aws_secret_access_key: {{ include "mariadb.resolve_secret_squote" .Values.global.mariadb.backup_v2.ceph_s3.aws_secret_access_key }}
-      aws_endpoint: {{ .Values.global.mariadb.backup_v2.ceph_s3.endpoint | required "global.mariadb.backup_v2.ceph_s3.endpoint is required when ceph_s3 is enabled" | quote }}
-      s3_force_path_style: {{ .Values.backup_v2.ceph_s3.force_path_style }}
-      region: {{ default .Values.global.region .Values.global.mariadb.backup_v2.ceph_s3.region }}
-      bucket_name: {{ .Values.global.mariadb.backup_v2.ceph_s3.bucket_name | default (printf "mariadb-backup-%s" .Values.global.region) | quote }}
-      {{- if .Values.backup_v2.ceph_s3.verify }}
+    {{- range $t := $cephTargets }}
+    {{- $region := default $.Values.global.region $t.region }}
+    - name: {{ default (printf "ceph-%s" $region) $t.name }}
+      aws_access_key_id: {{ include "mariadb.resolve_secret_squote" (required "ceph_s3 target requires aws_access_key_id" $t.aws_access_key_id) }}
+      aws_secret_access_key: {{ include "mariadb.resolve_secret_squote" (required "ceph_s3 target requires aws_secret_access_key" $t.aws_secret_access_key) }}
+      aws_endpoint: {{ required "ceph_s3 target requires endpoint" $t.endpoint | quote }}
+      s3_force_path_style: {{ if hasKey $t "force_path_style" }}{{ $t.force_path_style }}{{ else }}{{ $.Values.backup_v2.ceph_s3.force_path_style }}{{ end }}
+      region: {{ $region }}
+      bucket_name: {{ $t.bucket_name | default (printf "mariadb-backup-%s" $.Values.global.region) | quote }}
+      {{- if ternary $t.verify $.Values.backup_v2.ceph_s3.verify (hasKey $t "verify") }}
       verify: true
       {{- end }}
     {{- end }}

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -237,6 +237,16 @@ backup_v2:
     enabled: false
     force_path_style: true
     verify: false
+    # Ceph S3 targets:
+    # NOTE: this configuration lives under global.mariadb.backup_v2.ceph_s3.targets
+    #   - name: ceph-eu-de-1-cold               # optional, defaults to ceph-<region>
+    #     endpoint: "https://..."               # required
+    #     aws_access_key_id: vault+kvv2:...     # required
+    #     aws_secret_access_key: vault+kvv2:... # required
+    #     region: eu-de-1                       # optional, defaults to global.region
+    #     bucket_name: mariadb-backup-eu-de-2   # optional, defaults to mariadb-backup-<global.region>
+    #     force_path_style: true                # optional, inherits chart-local default
+    #     verify: false                         # optional, inherits chart-local default
   swift:
     enabled: true
     user_name: db_backup


### PR DESCRIPTION
* support multiple Ceph S3 backup targets via `global.mariadb.backup_v2.ceph_s3.targets`
* drop `global.mariadb.backup_v2.ceph_s3.{endpoint,region,bucket_name,aws_access_key_id,aws_secret_access_key}` keys
* chart version bumped