### PR TITLE
barbican: enforce readOnlyRootFilesystem on API and nanny containers (SCIBPL-214/215)

### DIFF
--- a/openstack/barbican/Chart.yaml
+++ b/openstack/barbican/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: flamingo
 description: A Helm chart for Openstack Barbican
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Barbican/OpenStack_Project_Barbican_vertical.png
 name: barbican
-version: 0.8.4
+version: 0.8.5
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/barbican/templates/api-deployment.yaml
+++ b/openstack/barbican/templates/api-deployment.yaml
@@ -59,6 +59,9 @@ spec:
         - name: barbican-api
           image: {{required ".Values.global.registry is missing" .Values.global.registry }}/loci-barbican:{{required "Values.imageVersionBarbicanApi is missing" .Values.imageVersionBarbicanApi}}
           imagePullPolicy: IfNotPresent
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
           command:
           - dumb-init
           - barbican-api
@@ -108,6 +111,10 @@ spec:
           volumeMounts:
             - name: etcbarbican
               mountPath: /etc/barbican
+            - name: barbican-tmp
+              mountPath: /tmp
+            - name: barbican-run
+              mountPath: /run
             - name: barbican-etc
               mountPath: /etc/barbican/barbican.conf
               subPath: barbican.conf
@@ -257,6 +264,10 @@ spec:
             - key: secrets.conf
               path: secrets.conf
         - name: etcbarbican
+          emptyDir: {}
+        - name: barbican-tmp
+          emptyDir: {}
+        - name: barbican-run
           emptyDir: {}
         {{- if .Values.hsm.enabled }}
         - name: hsm

--- a/openstack/barbican/templates/barbican-nanny-deployment.yaml
+++ b/openstack/barbican/templates/barbican-nanny-deployment.yaml
@@ -56,6 +56,9 @@ spec:
       - name: move-secrets
         image: {{required ".Values.global.registry is missing" .Values.global.registry }}/loci-barbican:{{required "Values.imageVersionBarbicanApi is missing" .Values.imageVersionBarbicanApi}}
         imagePullPolicy: IfNotPresent
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
         command:
         - dumb-init
 {{- if not .Values.barbican_nanny.debug }}
@@ -100,6 +103,8 @@ spec:
         - name: barbican-etc-confd
           mountPath: /etc/barbican/barbican.conf.d
           readOnly: true
+        - name: nanny-tmp
+          mountPath: /tmp
         {{- include "utils.proxysql.volume_mount" . | indent 8 }}
         {{- include "utils.trust_bundle.volume_mount" . | indent 8 }}
       {{- if not .Values.proxysql.native_sidecar }}
@@ -115,6 +120,8 @@ spec:
       - name: barbican-scripts
         configMap:
           name: barbican-scripts
+      - name: nanny-tmp
+        emptyDir: {}
       {{- include "utils.proxysql.volumes" . | indent 6 }}
       {{- include "utils.trust_bundle.volumes" . | indent 6 }}
 {{- end }}


### PR DESCRIPTION
## Summary

- Adds `securityContext.readOnlyRootFilesystem: true` and `allowPrivilegeEscalation: false` to the `barbican-api` container and the nanny `move-secrets` container.
- Adds `emptyDir` volumes for `/tmp` and `/run` (API) and `/tmp` (nanny) to provide the writable scratch space the process needs without requiring a writable root filesystem.
- Bumps chart version `0.8.4 → 0.8.5`.

## Motivation

Addresses **SCIBPL-214** (Enforce Immutable File Systems on Non-Writable Paths) and **SCIBPL-215** (Deploy Using Immutable Pods).

Previously only individual `volumeMounts` had `readOnly: true`. This change enforces immutability at the container level: any write attempt outside the declared emptyDir mounts is rejected by the kernel, regardless of what the process tries.

## Test plan

- [x] `helm template` renders without errors with default values
- [x] `helm template` renders without errors with `hsm.enabled: true`
- [x] barbican-api pod starts and passes liveness/readiness probes in a test cluster
- [x] Verify `/tmp` is writable inside the container, `/usr` and `/var` are not