### PR TITLE
barbican: harden ingress with request size limit and connection cap (SCIBPL-209)

### DIFF
--- a/openstack/barbican/Chart.yaml
+++ b/openstack/barbican/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: flamingo
 description: A Helm chart for Openstack Barbican
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Barbican/OpenStack_Project_Barbican_vertical.png
 name: barbican
-version: 0.8.8
+version: 0.8.5
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/barbican/Chart.yaml
+++ b/openstack/barbican/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: flamingo
 description: A Helm chart for Openstack Barbican
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Barbican/OpenStack_Project_Barbican_vertical.png
 name: barbican
-version: 0.8.4
+version: 0.8.8
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/barbican/templates/ingress.yaml
+++ b/openstack/barbican/templates/ingress.yaml
@@ -18,6 +18,12 @@ metadata:
     disco: "true"
   {{- end }}
   {{- include "utils.linkerd.ingress_annotation" . | indent 4 }}
+  {{- if .Values.ingress.enableRequestSizeLimit }}
+    nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.ingress.maxRequestBodySize | quote }}
+  {{- end }}
+  {{- if .Values.ingress.enableConnectionsLimit }}
+    nginx.ingress.kubernetes.io/limit-connections: {{ .Values.ingress.limitConnections | quote }}
+  {{- end }}
 spec:
   tls:
      - secretName: tls-{{ include "barbican_api_endpoint_host_public" . | replace "." "-" }}

--- a/openstack/barbican/values.yaml
+++ b/openstack/barbican/values.yaml
@@ -467,8 +467,10 @@ ingress:
   maxRequestBodySize: "1m"
   # Limit simultaneous connections per source IP.
   # Helps mitigate connection-flood DoS attempts.
+  # NOTE: if callers arrive from a shared NAT gateway or single-IP proxy,
+  # all their traffic counts against one IP — tune before enabling in prod.
   enableConnectionsLimit: true
-  limitConnections: "20"
+  limitConnections: 20
 
 # sapcc/openstack-rate-limit-middleware
 sapcc_rate_limit:

--- a/openstack/barbican/values.yaml
+++ b/openstack/barbican/values.yaml
@@ -455,6 +455,21 @@ sentry:
 
 tlsacme: true
 
+# SCIBPL-209: Ingress hardening — request size cap and connection limiting.
+# These annotations are applied to the nginx ingress controller.
+# Keystone middleware already enforces authentication; these settings add a
+# first line of defence at the edge against oversized payloads and
+# connection floods before traffic reaches the Barbican API process.
+ingress:
+  # Cap the maximum allowed request body size (secrets/payloads).
+  # Requests exceeding this limit are rejected with HTTP 413.
+  enableRequestSizeLimit: true
+  maxRequestBodySize: "1m"
+  # Limit simultaneous connections per source IP.
+  # Helps mitigate connection-flood DoS attempts.
+  enableConnectionsLimit: true
+  limitConnections: "20"
+
 # sapcc/openstack-rate-limit-middleware
 sapcc_rate_limit:
   enabled: true


### PR DESCRIPTION
## Summary

- Adds `nginx.ingress.kubernetes.io/proxy-body-size: 1m` — rejects oversized request bodies with HTTP 413 before they reach the Barbican process (configurable via `ingress.maxRequestBodySize`, disable via `ingress.enableRequestSizeLimit: false`)
- Adds `nginx.ingress.kubernetes.io/limit-connections: 20` — caps simultaneous connections per source IP to mitigate connection-flood DoS (configurable via `ingress.limitConnections`, disable via `ingress.enableConnectionsLimit: false`)
- Both controls are **enabled by default**
- Bumps chart version `0.8.4 → 0.8.5`

## Motivation

Addresses **SCIBPL-209** (Enhance Endpoint Security with Strong Authentication, WAF, and Regular Security Audits).

Keystone middleware already enforces authentication on every request. These nginx ingress annotations add a complementary edge-layer defence: payload size capping and connection limiting protect the Barbican API process from resource exhaustion without requiring any application-layer changes.

## Test plan

- [x] `helm template` renders both annotations with default values
- [x] `helm template` renders neither annotation with both flags set to `false`
- [x] Sending a request body > 1 MiB returns HTTP 413
- [x] Exceeding 20 simultaneous connections from the same IP is rejected