### PR TITLE
kube-monitoring: add Falco CRITICAL alert for exec/port-forward in Barbican (SCIBPL-219)

### DIFF
--- a/system/kube-monitoring-metal/values.yaml
+++ b/system/kube-monitoring-metal/values.yaml
@@ -142,10 +142,29 @@ falco:
       - enable:
           tag: pci
 
-x509-certificate-exporter:
-  enabled: false
-  secretsExporter:
-    podAnnotations:
+  customRules:
+    barbican-exec-alert.yaml: |-
+      - rule: Terminal Shell or Port-Forward in Barbican Container
+        desc: >
+          A shell was spawned or a port-forward session was opened inside a
+          Barbican API container. Barbican is a key-management service; interactive
+          access to its containers is unexpected and must be investigated
+          immediately. Satisfies SCIBPL-219.
+        condition: >
+          (evt.type in (execve, execveat) and container.name = "barbican-api"
+           and k8s.ns.name = "monsoon3"
+           and proc.name in (sh, bash, dash, ash, zsh, ksh, fish, python, python3))
+          or
+          (evt.type = connect and container.name = "barbican-api"
+           and k8s.ns.name = "monsoon3"
+           and fd.sport in (10250))
+        output: >
+          Interactive access detected in Barbican container
+          (user=%user.name cmd=%proc.cmdline pod=%k8s.pod.name ns=%k8s.ns.name
+          image=%container.image.repository)
+        priority: CRITICAL
+        tags: [barbican, security, pci, scibpl-219]
+        source: syscall
       prometheus.io/port: "9793"
       prometheus.io/scrape: "true"
       prometheus.io/targets: kubernetes

--- a/system/kube-monitoring-scaleout/values.yaml
+++ b/system/kube-monitoring-scaleout/values.yaml
@@ -241,10 +241,29 @@ falco:
       - enable:
           tag: pci
 
-x509-certificate-exporter:
-  enabled: false
-  secretsExporter:
-    podAnnotations:
+  customRules:
+    barbican-exec-alert.yaml: |-
+      - rule: Terminal Shell or Port-Forward in Barbican Container
+        desc: >
+          A shell was spawned or a port-forward session was opened inside a
+          Barbican API container. Barbican is a key-management service; interactive
+          access to its containers is unexpected and must be investigated
+          immediately. Satisfies SCIBPL-219.
+        condition: >
+          (evt.type in (execve, execveat) and container.name = "barbican-api"
+           and k8s.ns.name = "monsoon3"
+           and proc.name in (sh, bash, dash, ash, zsh, ksh, fish, python, python3))
+          or
+          (evt.type = connect and container.name = "barbican-api"
+           and k8s.ns.name = "monsoon3"
+           and fd.sport in (10250))
+        output: >
+          Interactive access detected in Barbican container
+          (user=%user.name cmd=%proc.cmdline pod=%k8s.pod.name ns=%k8s.ns.name
+          image=%container.image.repository)
+        priority: CRITICAL
+        tags: [barbican, security, pci, scibpl-219]
+        source: syscall
       prometheus.io/port: "9793"
       prometheus.io/scrape: "true"
       prometheus.io/targets: kubernetes

--- a/system/kube-monitoring-virtual/values.yaml
+++ b/system/kube-monitoring-virtual/values.yaml
@@ -237,6 +237,30 @@ falco:
       - enable:
           tag: pci
 
+  customRules:
+    barbican-exec-alert.yaml: |-
+      - rule: Terminal Shell or Port-Forward in Barbican Container
+        desc: >
+          A shell was spawned or a port-forward session was opened inside a
+          Barbican API container. Barbican is a key-management service; interactive
+          access to its containers is unexpected and must be investigated
+          immediately. Satisfies SCIBPL-219.
+        condition: >
+          (evt.type in (execve, execveat) and container.name = "barbican-api"
+           and k8s.ns.name = "monsoon3"
+           and proc.name in (sh, bash, dash, ash, zsh, ksh, fish, python, python3))
+          or
+          (evt.type = connect and container.name = "barbican-api"
+           and k8s.ns.name = "monsoon3"
+           and fd.sport in (10250))
+        output: >
+          Interactive access detected in Barbican container
+          (user=%user.name cmd=%proc.cmdline pod=%k8s.pod.name ns=%k8s.ns.name
+          image=%container.image.repository)
+        priority: CRITICAL
+        tags: [barbican, security, pci, scibpl-219]
+        source: syscall
+
 x509-certificate-exporter:
   enabled: false
   secretsExporter:


### PR DESCRIPTION
## Summary

Adds a custom Falco rule to kube-monitoring-virtual, kube-monitoring-metal, and kube-monitoring-scaleout.

The rule fires at CRITICAL priority when a shell or interpreter (sh, bash, python, etc.) is execved inside the barbican-api container in namespace monsoon3, or a port-forward connection is detected on port 10250 from that container.

Tagged pci and scibpl-219 so it appears alongside existing PCI compliance alerts.

## How it works

The Falco chart (falcosecurity/falco 4.21.3) customRules map entries are mounted into /etc/falco/rules.d/ which is already in falco.falco.rules_files. No structural chart changes needed.

## Addresses

SCIBPL-219 -- Configure SIEM Alerts for Exec and Port Forward Activities

## Test plan

- [ ] Falco loads without rule syntax errors
- [ ] kubectl exec into barbican-api pod triggers a CRITICAL Falco alert
- [ ] kubectl port-forward to barbican-api pod triggers a CRITICAL Falco alert
- [ ] No alerts fire on normal API traffic