### PR TITLE
[ironic] switch sentry to utils helper

### DIFF
--- a/openstack/ironic/Chart.yaml
+++ b/openstack/ironic/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Ironic/OpenStack_Project_Ironic_vertical.png
 name: ironic
-version: 0.2.15
+version: 0.2.16
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/ironic/templates/_conductor-deployment.yaml.tpl
+++ b/openstack/ironic/templates/_conductor-deployment.yaml.tpl
@@ -78,6 +78,7 @@ spec:
         env:
         - name: PYTHONWARNINGS
           value: ignore:Unverified HTTPS request
+        {{- include "utils.sentry_config" . | indent 8 }}
         - name: PGAPPNAME
           valueFrom:
             fieldRef:

--- a/openstack/ironic/templates/api-deployment.yaml
+++ b/openstack/ironic/templates/api-deployment.yaml
@@ -60,6 +60,7 @@ spec:
         env:
         - name: PYTHONWARNINGS
           value: 'ignore:Unverified HTTPS request'
+        {{- include "utils.sentry_config" . | indent 8 }}
         lifecycle:
           preStop:
             {{- include "utils.snippets.pre_stop_graceful_shutdown" . | indent 12 }}

--- a/openstack/ironic/templates/inspector-conductor-deployment.yaml
+++ b/openstack/ironic/templates/inspector-conductor-deployment.yaml
@@ -53,6 +53,8 @@ spec:
         command:
         - dumb-init
         - ironic-inspector-conductor
+        env:
+          {{- include "utils.sentry_config" . | indent 10 }}
         resources:
 {{ toYaml .Values.pod.resources.inspector | indent 10 }}
         volumeMounts:

--- a/openstack/ironic/templates/inspector-deployment.yaml
+++ b/openstack/ironic/templates/inspector-deployment.yaml
@@ -64,6 +64,8 @@ spec:
           capabilities:
             add:
               - NET_ADMIN
+        env:
+          {{- include "utils.sentry_config" . | indent 10 }}
         lifecycle:
           preStop:
             {{- include "utils.snippets.pre_stop_graceful_shutdown" . | indent 12 }}

--- a/openstack/ironic/values.yaml
+++ b/openstack/ironic/values.yaml
@@ -446,6 +446,10 @@ rabbitmq:
     sidecar:
       enabled: false
 
+# use sentry via openstack/utils
+sentry:
+  enabled: true
+
 logging:
   formatters:
     context:


### PR DESCRIPTION
The templates/sentry.yaml makes sure a sentry_dsn secret exists inside
kubernetes. To make use of that we either need to explcitly add a sentry
snippet as before, but would need to update that if something changes
there. Instead we use the utils helper function, which includes that
snippet for us. We just need to add the include at the right places and
get the indentation right.
Keyword for the utils is the "sentry: enabled" which was, back then used
different, but for the utils we need it so we add it again.

Thank you @joker-at-work for the support
