### PR TITLE
[ironic] dependency updates

### DIFF
--- a/openstack/ironic/Chart.lock
+++ b/openstack/ironic/Chart.lock
@@ -1,27 +1,27 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.35.0
+  version: 0.38.2
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.6.0
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.6.16
+  version: 0.6.17
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.7.0
+  version: 0.8.1
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.22.2
+  version: 0.25.2
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.35.0
+  version: 0.38.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:5a80c2476f34a73cc9c7032bafeb4e18f764df10cfa1914f31d759f5bae7487a
-generated: "2026-04-21T11:06:06.652915765+02:00"
+digest: sha256:4af32e0b3ac55ccd732381a5b7602bededb68ed5ae8dd1acbf0ab0c5d4cb0415
+generated: "2026-06-22T17:01:42.773087741+02:00"

--- a/openstack/ironic/Chart.yaml
+++ b/openstack/ironic/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.35.0
+    version: ~0.38.2
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db
@@ -15,20 +15,20 @@ dependencies:
     version: ~0.6.0
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.6.16
+    version: ~0.6.17
   - condition: mysql_metrics.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.7.0
+    version: ~0.8.1
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: ~1.0.0
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.22.2
+    version: ~0.25.2
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.35.0
+    version: ~0.38.0
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: ~1.1.1


### PR DESCRIPTION
MariaDB
v0.38.2 - 2026/06/16
* use global.mariadb.backup_v2 for ceph s3 access and secret key

v0.38.1 - 2026/06/11
* `maria-back-me-up` updated to `10.11-20260611113653`
  * fixes aws s3 upload

v0.38.0 - 2026/06/03
* MariaDB version updated to [10.11.18](https://mariadb.com/docs/release-notes/community-server/10.11/10.11.18)
* `maria-back-me-up` updated to `10.11-20260603173712`

v0.37.0 - 2026/05/21
* MariaDB version updated to [10.11.17](https://mariadb.com/docs/release-notes/community-server/10.11/10.11.17)
* `maria-back-me-up` updated to `10.11-20260521084302`
* `user-credential-updater` updated to `python3.13-alpine3.23-20260506191108`
* `pod-readiness` updated to `20260521132613`

v0.36.0 - 2026/05/14
* skip mariadb PVC mount in backup deployment when access modes don't include `ReadWriteMany`
* `maria-back-me-up` updated to `10.11-20260515121634`

v0.35.1 - 2026/05/06
* fixed pvc storage_class templating

Memcached
v0.6.17 - 2026/05/21
* memcached [version](https://github.com/memcached/memcached/wiki/ReleaseNotes1641) bumped to `1.6.42-alpine3.23`
  * memcached-exporter [version](https://github.com/prometheus/memcached_exporter/releases/tag/v0.16.0) bumped to `v0.16.0`

Mysql_metrics
v0.8.1 - 2026/04/28
- Updated CHANGELOG.md

v0.8.0 - 2026/04/28
- Use `clusterDNSSearchDomain` to generate the service cluster FQDN
  - Used to be the hardcoded `<fullname>.<namespace>.svc.kubernetes.<region>.<tld>`
  - Now it's `<fullname>.<namespace>.svc.<clusterDNSSearchDomain>`

Rabbitmq
0.25.2 - 2026/06/03
- `rabbitmq-user-credential-updater` updated to `20260521084806` version

0.25.1 - 2026/05/26
- RabbitMQ [4.3.1 Release notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.3.1)

0.25.0 - 2026/05/12
- Allow not adding `rabbitmq.serviceName` to the certificate's dnsNames
  - If enabled, `externalNames` is a required setting
  - Makes most sense together with also setting `certificate.commonName`

0.24.1 - 2026/04/30
- Enable transient_nonexcl_queues option, as it's in use by some services

0.24.0 - 2026/04/28
- Use `clusterDNSSearchDomain` to generate the certificate default common name and SAN
  - Used to be the hardcoded `<fullname>.<namespace>.svc.kubernetes.<region>.<tld>`
  - Now it's `<fullname>.<namespace>.svc.<clusterDNSSearchDomain>`

0.23.0 - 2026/04/27
- RabbitMQ [4.3.0 Release notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.3.0)

Utils
-[utils][coordination] switch to "storageClassName" attribute
- utils: add values-driven ProxySQL query cache rules (#11881)
- utils: fix ProxySQL query cache rules to use match_digest
- [utils] use non-deprecated topology as default
- utils: make osprofiler connection_string configurable for OTLP support
