### PR TITLE
[octobus-exporter-vmware] fix vmware_fcd_objectNotFound_error.cfg and bump chart versions

### DIFF
--- a/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/files/queries/vmware/vmware_fcd_objectNotFound_error.cfg
+++ b/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/files/queries/vmware/vmware_fcd_objectNotFound_error.cfg
@@ -2,37 +2,37 @@
 QueryIndices = c0001_log*
 QueryOnMissing = drop
 QueryJson = {
-  "size": 0,
-  "aggs": {
-    "hostsystem": {
-      "terms": {
-        "field": "syslog_hostname.keyword"
-      }
-    }
-  },
-  "query": {
-    "bool": {
-      "must": [
-        {
-          "match_phrase": {
-            "message": "vmodl.fault.ManagedObjectNotFound"
-          }
-        },
-        {
-          "match_phrase": {
-            "message": "vim.Datastore:ds:///vmfs/volumes"
+      "size": 0,
+      "aggs": {
+        "hostsystem": {
+          "terms": {
+            "field": "syslog_hostname.keyword"
           }
         }
-      ],
-      "filter": [
-        {
-          "range": {
-            "@timestamp": {
-              "gte": "now-15m"
+      },
+      "query": {
+        "bool": {
+          "must": [
+            {
+              "match_phrase": {
+                "message": "vmodl.fault.ManagedObjectNotFound"
+              }
+            },
+            {
+              "match_phrase": {
+                "message": "vim.Datastore:ds:///vmfs/volumes"
+              }
             }
-          }
+          ],
+          "filter": [
+            {
+              "range": {
+                "@timestamp": {
+                  "gte": "now-15m"
+                }
+              }
+            }
+          ]
         }
-      ]
-    }
+      }
   }
-}


### PR DESCRIPTION
Follow-up to #12021.

Fixes format errors in `vmware_fcd_objectNotFound_error.cfg` and bumps chart versions.

**Changes:**
- Fix trailing comma in JSON (invalid JSON)
- Fix configparser indentation — closing `}` must be indented, otherwise Python's `configparser` treats it as a new key causing `ParsingError`
- Bump vendor subchart `1.0.27` → `1.0.28`
- Bump outer chart `1.0.29` → `1.0.30`, update dependency reference accordingly
- Update `Chart.lock` digest