### PR TITLE
[neutron] support new customdns config file

### DIFF
--- a/openstack/neutron/ci/test-values.yaml
+++ b/openstack/neutron/ci/test-values.yaml
@@ -118,3 +118,22 @@ imageVersionNetworkAgentDHCP: queens
 imageVersionNetworkAgentLinuxBridge: queens
 imageVersion: queens
 imageVersionEntanglement: queens
+
+customdns:
+  enabled: true
+  matches:
+    - domain_name_prefixes:
+        - external-abc
+      project_ids:
+        - 5dc81c6355ff478188f8fda11a971c41
+      upstream_dns_servers:
+        - 192.0.2.10
+        - 192.0.2.20
+      ednslogging: true
+    - domain_name_prefixes:
+        - external-abcd
+        - external-
+      upstream_dns_servers:
+        - 192.0.2.30
+        - 192.0.2.40
+      ednslogging: false

--- a/openstack/neutron/templates/configmap-etc.yaml
+++ b/openstack/neutron/templates/configmap-etc.yaml
@@ -37,6 +37,10 @@ data:
 {{ include (print .Template.BasePath "/etc/_ml2-conf.ini.tpl") . | indent 4 }}
   neutron.conf: |
 {{ include (print .Template.BasePath "/etc/_neutron.conf.tpl") . | indent 4 }}
+{{- if .Values.customdns.matches }}
+  customdns.yaml: |
+{{ include (print .Template.BasePath "/etc/_customdns.yaml.tpl") . | indent 4 }}
+{{- end}}
   neutron-policy.json: |
 {{ include (print .Template.BasePath "/etc/_neutron-policy.json.tpl") . | indent 4 }}
   rootwrap.conf: |

--- a/openstack/neutron/templates/deployment-rpc-server.yaml
+++ b/openstack/neutron/templates/deployment-rpc-server.yaml
@@ -92,6 +92,12 @@ spec:
               name: neutron-etc
               subPath: neutron.conf
               readOnly: true
+{{- if .Values.customdns.matches }}
+            - mountPath: /etc/neutron/customdns.yaml
+              name: neutron-etc
+              subPath: customdns.yaml
+              readOnly: true
+{{- end }}
             - mountPath: /etc/neutron/secrets/neutron-server-secrets.conf
               name: neutron-server-secrets
               subPath: neutron-server-secrets.conf

--- a/openstack/neutron/templates/deployment-server.yaml
+++ b/openstack/neutron/templates/deployment-server.yaml
@@ -139,6 +139,12 @@ spec:
               name: neutron-etc
               subPath: neutron.conf
               readOnly: true
+{{- if .Values.customdns.matches }}
+            - mountPath: /etc/neutron/customdns.yaml
+              name: neutron-etc
+              subPath: customdns.yaml
+              readOnly: true
+{{- end }}
             - mountPath: /etc/neutron/secrets/neutron-server-secrets.conf
               name: neutron-server-secrets
               subPath: neutron-server-secrets.conf

--- a/openstack/neutron/templates/etc/_customdns.yaml.tpl
+++ b/openstack/neutron/templates/etc/_customdns.yaml.tpl
@@ -1,0 +1,5 @@
+# customdns.yaml
+{{- if .Values.customdns.matches }}
+matches:
+{{ .Values.customdns.matches | toYaml | indent 2}}
+{{- end }}

--- a/openstack/neutron/templates/etc/_neutron.conf.tpl
+++ b/openstack/neutron/templates/etc/_neutron.conf.tpl
@@ -182,6 +182,9 @@ disconnected_subnets_mode = true
 
 [customdns]
 enabled = true
+{{- if .Values.customdns.matches }}
+config_file = /etc/neutron/customdns.yaml
+{{- else }}
 {{- if .Values.customdns.upstream_dns_servers }}
 upstream_dns_servers = {{ join "," .Values.customdns.upstream_dns_servers }}
 {{- end }}
@@ -190,5 +193,6 @@ project_ids = {{ join "," .Values.customdns.project_ids }}
 {{- end }}
 {{- if .Values.customdns.domain_name_prefixes }}
 domain_name_prefixes = {{ join "," .Values.customdns.domain_name_prefixes }}
+{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
customdns configuration is now handled by its own yaml config file.

This commit supports the old and new configuration to allow a
smooth migration. After updating values we can remove support for
the old config values and enforce non-empty matches when the feature
is enabled.

related: https://github.com/sapcc/neutron/pull/107