### PR TITLE
[nova/Oho] add service user for oho smoke tests

### DIFF
--- a/openstack/nova/templates/seed.yaml
+++ b/openstack/nova/templates/seed.yaml
@@ -101,7 +101,7 @@ spec:
         role: compute_admin
       - project: test@cc3test
         role: member
-      - project: cloud_admin@ccadmin
+      - project: service
         role: cloud_compute_admin
     {{- end }}
     groups:

--- a/openstack/nova/templates/seed.yaml
+++ b/openstack/nova/templates/seed.yaml
@@ -92,6 +92,18 @@ spec:
         role: cloud_image_admin
       - project: service
         role: cloud_objectstore_admin
+    {{- if .Values.global.oho_service_password }}
+    - name: '{{ .Values.global.oho_service_user | default "openstack-hypervisor-operator" | include "resolve_secret" }}'
+      description: "OpenStack hypervisor operator service user"
+      password: '{{ .Values.global.oho_service_password | include "resolve_secret" }}'
+      role_assignments:
+      - project: test@cc3test
+        role: compute_admin
+      - project: test@cc3test
+        role: member
+      - project: cloud_admin@ccadmin
+        role: cloud_compute_admin
+    {{- end }}
     groups:
     - name: administrators
       role_assignments:


### PR DESCRIPTION
Openstack hypervisor operator (oho) needs a service used to mange VMs while performing the smoke tests in cc3test/test project. because the openstack hypervisor operator is installed in the compute cluster where we don't have openstack seeder we decided to create the user in nova helm chart
`ccloud_compute_admin` was given to the service user, because the user needs to enable and disable the compute service

Change-Id: Ica0e6cc41b48dfdb62962f4130338e557f9ac5fe