### PR TITLE
aurora: add Prometheus availability alerts

### DIFF
--- a/openstack/aurora/alerts/availability.alerts
+++ b/openstack/aurora/alerts/availability.alerts
@@ -1,0 +1,31 @@
+groups:
+- name: availability.alerts
+  rules:
+  - alert: OpenstackAuroraPodAvailabilityLow
+    expr: (sum(up{name="aurora", container="server"}) BY (region) / count(up{name="aurora", container="server"}) BY (region)) < 0.5
+    for: 3m
+    labels:
+      context: openstack
+      dashboard: aurora-details
+      service: aurora
+      severity: warning
+      tier: os
+      support_group: containers
+    annotations:
+      description:  |
+        📊 Aurora Pod Availability Alert - Region {{ $labels.region }}
+        
+        • Threshold: 50% minimum required
+        • Last Measured: {{ $value | humanizePercentage }} (at last evaluation)
+        • Evaluation Period: 3 minutes
+        
+        Alert Status:
+        🔴 RED alert = Currently below 50%
+        🟢 GREEN alert = Recovered above 50%
+        
+        Note: "Last Measured" may not reflect current state when resolved
+        
+        Quick Actions:
+        • Check pods: kubectl -n aurora get pods -l name=aurora
+        • View Dashboard: https://dashboard.{{ $labels.region }}.cloud.sap
+      summary: 'Aurora pod availability threshold alert - {{ $labels.region }}'

--- a/openstack/aurora/templates/prometheus-alerts.yaml
+++ b/openstack/aurora/templates/prometheus-alerts.yaml
@@ -1,0 +1,20 @@
+{{- $values := .Values }}
+{{- if $values.alerts.enabled }}
+{{- range $path, $bytes := .Files.Glob "alerts/*.alerts" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+
+metadata:
+  name: {{ printf "%s" $path | replace "/" "-" }}
+  labels:
+    app: aurora
+    tier: os
+    type: alerting-rules
+    prometheus: {{ required ".Values.alerts.prometheus missing" $values.alerts.prometheus }}
+
+spec:
+{{ printf "%s" $bytes | indent 2 }}
+
+{{- end }}
+{{- end }}

--- a/openstack/aurora/values.yaml
+++ b/openstack/aurora/values.yaml
@@ -34,5 +34,6 @@ prPreview:
 
 # Deploy Prometheus alerts.
 alerts:
+  enabled: true
   # Name of the Prometheus to which the alerts should be assigned to.
   prometheus: openstack


### PR DESCRIPTION
## Summary
- Add Prometheus alerting support for Aurora pod availability monitoring
- Created `alerts/availability.alerts` with `OpenstackAuroraPodAvailabilityLow` alert that triggers when pod availability drops below 50% for 3 minutes
- Added `templates/prometheus-alerts.yaml` to deploy PrometheusRule resources
- Enabled alerts in `values.yaml` with `prometheus: openstack` configuration

## Test plan
- [ ] Deploy to dev/staging environment
- [ ] Verify PrometheusRule resource is created correctly
- [ ] Test alert triggers when pod availability drops below threshold
- [ ] Confirm alert annotations display correctly in Prometheus/Alertmanager