### PR TITLE
[unbound] introducing the `balancedTrafficExpected` flag

### DIFF
--- a/system/unbound/templates/prometheus-alerts.yaml
+++ b/system/unbound/templates/prometheus-alerts.yaml
@@ -61,6 +61,7 @@ spec:
         description: '{{ $.Release.Name }} in {{ $.Values.global.region }} is getting {{ "{{" }} $value | humanizePercentage {{ "}}" }} of the usual traffic.'
         summary: '{{ $.Release.Name }} in {{ $.Values.global.region }} is getting {{ "{{" }} $value | humanizePercentage {{ "}}" }} of the usual traffic compared to the 24h avegrage.'
 
+{{- if (.Values.unbound.balancedTrafficExpected | default true) }}
     - alert: Dns{{ $.Values.unbound.name | title }}DisproportionateAmountOfTraffic
       expr: sum(rate(unbound_queries_total{app="{{ $.Values.unbound.name }}", namespace="{{ $.Release.Namespace }}"}[5m]))/sum(rate(unbound_queries_total{namespace="{{ $.Release.Namespace }}"}[5m]))
         > {{ add 50 (.Values.unbound.tolerable_traffic_distribution_deviation | default 10) }}/100
@@ -112,6 +113,7 @@ spec:
           {{ add 50 ($.Values.unbound.tolerable_servfail_distribution_deviation | default 10) }}%
           of the total amount of SERVFAIL errors, ideally as close to 50% as possible.
           Currently getting {{ "{{" }} $value | humanizePercentage {{ "}}" }}.'
+{{- end}}
 
 ---
 apiVersion: "monitoring.coreos.com/v1"

--- a/system/unbound/values.yaml
+++ b/system/unbound/values.yaml
@@ -40,6 +40,10 @@ unbound:
   externalPorts:
     - 53
 
+  # if there's an expectation that the traffic is balanced between the unbound instances, set this to true
+  # this will enable the "Disproportionate" alerts in Prometheus
+  balancedTrafficExpected: true
+
 resources:
   unbound:
     requests:


### PR DESCRIPTION
The "Disproportionate" prometheus alerts will be enabled only if this flag is set to `true` (the default).