### PR TITLE
system/logs: update openTelemetryPlugin to 0.3.5

### DIFF
--- a/system/logs/Chart.lock
+++ b/system/logs/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: logs
   repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-  version: 0.3.3
+  version: 0.3.5
 - name: fluent-prometheus
   repository: file://vendor/fluent-prometheus
   version: 1.0.15
@@ -11,5 +11,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:bb86eac60fc3199a16f991456e281fe1b1b9a923971b268ffc5d729a0a81be34
-generated: "2026-06-19T12:01:40.141688+02:00"
+digest: sha256:53654a01ca2252f5a278f60e119a902b7a83a1d729ab7cb8fd6aa01369d48f5d
+generated: "2026-06-23T15:35:02.13342+02:00"

--- a/system/logs/Chart.yaml
+++ b/system/logs/Chart.yaml
@@ -1,13 +1,13 @@
 apiVersion: v2
 description: A Helm chart for all log shippers
 name: logs
-version: 0.1.11
+version: 0.1.12
 home: https://github.com/sapcc/helm-charts/tree/master/system/logs
 dependencies:
   - name: logs
     alias: openTelemetryPlugin
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.3.3
+    version: 0.3.5
     condition: openTelemetry.enabled
 
   - name: fluent-prometheus


### PR DESCRIPTION
## Summary
- Updates the `openTelemetryPlugin` dependency from 0.3.3 to 0.3.5
- Bumps chart version from 0.1.11 to 0.1.12