### PR TITLE
limes: replace catalog_url setting with api_domain_names

### DIFF
--- a/openstack/limes/ci/test-values.yaml
+++ b/openstack/limes/ci/test-values.yaml
@@ -13,14 +13,13 @@ global:
 campfire:
   central_region: xx-yy-2
   all_regions: [ xx-yy-1, xx-yy-2 ]
-  
 
 limes:
   image_tag: '19700101000000'
 
-  clusters:
-    ccloud:
-      catalog_url: https://limes-3.example.com
+  api_domain_names:
+    v1: limes-3.example.com
+    v2: limitas.example.com
 
   passwords:
     ccloud:

--- a/openstack/limes/templates/_utils.tpl
+++ b/openstack/limes/templates/_utils.tpl
@@ -42,10 +42,10 @@
 {{- end -}}
 
 {{- define "limes_openstack_envvars" }}
-{{- $limes_url := .Values.limes.clusters.ccloud.catalog_url }}
+{{- $limitas_hostname := .Values.limes.api_domain_names.v2 }}
 {{- if .Values.global.is_global_region }}
 - name: OS_AUTH_URL
-  value: "{{ $limes_url | replace "limes" "identity" }}/v3"
+  value: "https://{{ $limitas_hostname | replace "limitas" "identity-3" }}/v3"
 - name: OS_INTERFACE
   value: "public"
 {{- else }}

--- a/openstack/limes/templates/configmap.yaml
+++ b/openstack/limes/templates/configmap.yaml
@@ -9,7 +9,7 @@
 {{- $mail_config := dict -}}
 {{- $mail_config = (dict
   "mail_notifications" (dict
-    "endpoint" (printf "%s/" (.Values.limes.clusters.ccloud.catalog_url | replace "limes-3" "limes-campfire" | trimSuffix "/"))
+    "endpoint" (printf "https://%s/" (.Values.limes.api_domain_names.v2 | replace "limitas" "limes-campfire" | trimSuffix "/"))
     "templates" (dict
       "confirmed_commitments" (dict
         "subject" .Values.campfire.mail_type.confirmed.subject

--- a/openstack/limes/templates/deployment-api.yaml
+++ b/openstack/limes/templates/deployment-api.yaml
@@ -53,6 +53,10 @@ spec:
             - /etc/limes/limes.json
           env:
             {{ include "limes_common_envvars" . | indent 12 }}
+            - name: LIMES_API_DOMAIN_NAME_V1
+              value: {{ .Values.limes.api_domain_names.v1 | required "missing value for .Values.limes.api_domain_names.v1" | quote }}
+            - name: LIMES_API_DOMAIN_NAME_V2
+              value: {{ .Values.limes.api_domain_names.v2 | required "missing value for .Values.limes.api_domain_names.v2" | quote }}
             - name: LIMES_API_POLICY_PATH
               value: /etc/limes/policy.json
           securityContext:

--- a/openstack/limes/templates/deployment-api.yaml
+++ b/openstack/limes/templates/deployment-api.yaml
@@ -62,14 +62,14 @@ spec:
               name: config
           livenessProbe:
             httpGet:
-              path: /
+              path: /healthcheck
               port: 80
             timeoutSeconds: 10
             periodSeconds: 60
             initialDelaySeconds: 60
           readinessProbe:
             httpGet:
-              path: /
+              path: /healthcheck
               port: 80
             timeoutSeconds: 5
             periodSeconds: 5

--- a/openstack/limes/templates/ingress-api.yaml
+++ b/openstack/limes/templates/ingress-api.yaml
@@ -1,10 +1,14 @@
-{{- $domain := .Values.limes.clusters.ccloud.catalog_url | trimPrefix "https://" -}}
+{{- $v1_domain := .Values.limes.api_domain_names.v1 | required "missing value for .Values.limes.api_domain_names.v1" -}}
+{{- $v2_domain := .Values.limes.api_domain_names.v2 | required "missing value for .Values.limes.api_domain_names.v2" -}}
+
+{{- range $cfg := (list (dict "name" "limes-api-ccloud" "domain" $v1_domain) (dict "name" "limitas-api" "domain" $v2_domain)) }}
+---
 
 kind: Ingress
 apiVersion: networking.k8s.io/v1
 
 metadata:
-  name: limes-api-ccloud
+  name: {{ $cfg.name }}
   labels:
     app: limes-api
   annotations:
@@ -14,19 +18,19 @@ metadata:
     ingress.kubernetes.io/service-upstream: "true"
     nginx.ingress.kubernetes.io/service-upstream: "true"
     {{- end }}
-    {{- if .Values.global.is_global_region }}
+    {{- if $.Values.global.is_global_region }}
     kubernetes.io/ingress.class: "nginx-external"
     {{- end }}
 
 spec:
-  {{- if .Values.global.is_global_region }}
+  {{- if $.Values.global.is_global_region }}
   ingressClassName: "nginx-external"
   {{- end }}
   tls:
-    - secretName: limes-api-ccloud
-      hosts: [ {{ $domain }} ]
+    - secretName: {{ $cfg.name }}
+      hosts: [ {{ $cfg.domain }} ]
   rules:
-    - host: {{ $domain }}
+    - host: {{ $cfg.domain }}
       http:
         paths:
           - path: /
@@ -36,3 +40,5 @@ spec:
                 name: limes-api-ccloud
                 port:
                   number: 80
+
+{{- end }}

--- a/openstack/limes/templates/ingress-liquids.yaml
+++ b/openstack/limes/templates/ingress-liquids.yaml
@@ -1,8 +1,7 @@
 {{- range $name, $config := .Values.limes.local_liquids }}
 {{- if not $config.skip }}
 
-{{- $limes_domain := $.Values.limes.clusters.ccloud.catalog_url | trimPrefix "https://" -}}
-{{- $domain := $limes_domain | replace "limes-3" (printf "liquid-%s" $name) }}
+{{- $domain := $.Values.limes.api_domain_names.v2 | replace "limitas" (printf "liquid-%s" $name) }}
 
 ---
 

--- a/openstack/limes/templates/seed-catalog.yaml
+++ b/openstack/limes/templates/seed-catalog.yaml
@@ -1,6 +1,7 @@
 {{- $region := .Values.global.region | required "missing value for .Values.global.region" -}}
 {{- $tld    := .Values.global.tld    | required "missing value for .Values.global.tld"    -}}
-{{- $limes_url := .Values.limes.clusters.ccloud.catalog_url | required ".Values.limes.clusters.ccloud.catalog_url" -}}
+{{- $v1_domain := .Values.limes.api_domain_names.v1 | required "missing value for .Values.limes.api_domain_names.v1" -}}
+{{- $v2_domain := .Values.limes.api_domain_names.v2 | required "missing value for .Values.limes.api_domain_names.v2" -}}
 
 apiVersion: "openstack.stable.sap.cc/v1"
 kind: OpenstackSeed
@@ -20,7 +21,7 @@ spec:
         - region:    '{{ $region }}'
           interface: public
           enabled:   true
-          url:       '{{ $limes_url }}'
+          url:       'https://{{ $v1_domain }}'
         {{- if not .Values.global.is_global_region }}
         - region:    '{{ $region }}'
           interface: internal
@@ -36,7 +37,7 @@ spec:
         - region:    '{{ $region }}'
           interface: public
           enabled:   true
-          url:       '{{ $limes_url }}/resources'
+          url:       'https://{{ $v2_domain }}/resources'
         {{- if not .Values.global.is_global_region }}
         - region:    '{{ $region }}'
           interface: internal
@@ -52,7 +53,7 @@ spec:
         - region:    '{{ $region }}'
           interface: public
           enabled:   true
-          url:       '{{ $limes_url }}/rates'
+          url:       'https://{{ $v2_domain }}/rates'
         {{- if not .Values.global.is_global_region }}
         - region:    '{{ $region }}'
           interface: internal
@@ -71,7 +72,7 @@ spec:
         - region:    '{{ $region }}'
           interface: public
           enabled:   true
-          url:       '{{ $limes_url | replace "limes-3" (printf "liquid-%s" $name) }}'
+          url:       'https://{{ $v2_domain | replace "limitas" (printf "liquid-%s" $name) }}'
         {{- if not $.Values.global.is_global_region }}
         - region:    '{{ $region }}'
           interface: internal

--- a/openstack/limes/values.yaml
+++ b/openstack/limes/values.yaml
@@ -119,6 +119,11 @@ limes:
   #     rabbitmq_password: blowfish
   passwords: DEFINED_IN_VALUES_FILE
 
+  # Values for the $LIMES_API_DOMAIN_NAME_{V1,V2} environment variables. Must be supplied in regional values.
+  api_domain_names:
+    v1: null
+    v2: null
+
   # This section of the YAML must be identical to the "clusters" section of the
   # Limes configuration file.
   # <https://github.com/sapcc/limes/blob/master/docs/operators/config.md>


### PR DESCRIPTION
Companion for https://github.com/sapcc/limes/pull/905. **Please merge all three PRs (code, helm-charts, secrets) at the same time.**

All other domain names (for campfire, liquids, etc.) are now derived from `domain_names.v2` (i.e. `limitas.$REGION.cloud.sap`) instead of v1, to make it easy to later remove v1 support without breaking unrelated
things.

I tested `helm diff upgrade` against qa, and it had only the intended effects:

- replacing `catalog_url` with `api_domain_names` in the Limes config file
- adding a new Ingress for `limitas.$REGION.cloud.sap`
- updating the catalog seed to use `limitas.$REGION.cloud.sap` for the v2 catalog entries (v1 catalog entry remains unchanged)
- updating the liveness/readiness probes of API pods to `GET /healthcheck`