### PR TITLE
feat(issue-1277): auto-rollout cc-runtime-cluster on machineTemplate.image change

### DIFF
--- a/system/cc-runtime-cluster/Chart.yaml
+++ b/system/cc-runtime-cluster/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-runtime-cluster
 description: Converged Cloud Cluster API Runtime Cluster
 type: application
-version: 0.8.1
+version: 0.8.2
 appVersion: "0.1.0"

--- a/system/cc-runtime-cluster/templates/_helpers.tpl
+++ b/system/cc-runtime-cluster/templates/_helpers.tpl
@@ -1,0 +1,14 @@
+{{/*
+Short hash of the machine template image string.
+
+Used as a suffix on IroncoreMetalMachineTemplate object names so that
+any change to .Values.machineTemplate.image rotates the template's
+name. KubeadmControlPlane and MachineDeployment detect the rotation
+via infrastructureRef.name and trigger a rolling update automatically.
+
+See system/cc-runtime-cluster/docs/issue-1277-automate-image-rollout.md
+for background.
+*/}}
+{{- define "cc-runtime-cluster.imageHash" -}}
+{{- .Values.machineTemplate.image | sha256sum | trunc 8 -}}
+{{- end -}}

--- a/system/cc-runtime-cluster/templates/ironcoremetalmachinetemplate-worker.yaml
+++ b/system/cc-runtime-cluster/templates/ironcoremetalmachinetemplate-worker.yaml
@@ -3,8 +3,10 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: IroncoreMetalMachineTemplate
 metadata:
-  name: worker-{{ $cluster.name }}
+  name: worker-{{ $cluster.name }}-{{ include "cc-runtime-cluster.imageHash" $ }}
   namespace: {{ $cluster.namespace }}
+  labels:
+    cc.sap/template-image-hash: {{ include "cc-runtime-cluster.imageHash" $ }}
 spec:
   template:
     spec:

--- a/system/cc-runtime-cluster/templates/ironcoremetalmachinetemplate.yaml
+++ b/system/cc-runtime-cluster/templates/ironcoremetalmachinetemplate.yaml
@@ -3,8 +3,10 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: IroncoreMetalMachineTemplate
 metadata:
-  name: controlplane-{{ $cluster.name }}
+  name: controlplane-{{ $cluster.name }}-{{ include "cc-runtime-cluster.imageHash" $ }}
   namespace: {{ $cluster.namespace }}
+  labels:
+    cc.sap/template-image-hash: {{ include "cc-runtime-cluster.imageHash" $ }}
 spec:
   template:
     spec:

--- a/system/cc-runtime-cluster/templates/kubeadmcontrolplane.yaml
+++ b/system/cc-runtime-cluster/templates/kubeadmcontrolplane.yaml
@@ -24,7 +24,7 @@ spec:
       infrastructureRef:
         kind: IroncoreMetalMachineTemplate
         apiGroup: infrastructure.cluster.x-k8s.io
-        name: controlplane-{{ $cluster.name }}
+        name: controlplane-{{ $cluster.name }}-{{ include "cc-runtime-cluster.imageHash" $ }}
       deletion:
         # to avoid "Node deletion timeout expired, continuing without Node deletion"
         # https://github.com/kubernetes-sigs/cluster-api/pull/5608

--- a/system/cc-runtime-cluster/templates/machinedeployment.yaml
+++ b/system/cc-runtime-cluster/templates/machinedeployment.yaml
@@ -39,7 +39,7 @@ spec:
       infrastructureRef:
         kind: IroncoreMetalMachineTemplate
         apiGroup: infrastructure.cluster.x-k8s.io
-        name: worker-{{ $cluster.name }}
+        name: worker-{{ $cluster.name }}-{{ include "cc-runtime-cluster.imageHash" $ }}
       deletion:
       # to avoid "Node deletion timeout expired, continuing without Node deletion"
       # https://github.com/kubernetes-sigs/cluster-api/pull/5608


### PR DESCRIPTION
## What

Embed a short hash of `Values.machineTemplate.image` into the `IroncoreMetalMachineTemplate.metadata.name`, and propagate it into the `KubeadmControlPlane` / `MachineDeployment` `infrastructureRef.name`. Image change → new template name → KCP/MD detect "infraRef rotated" → automatic rolling update with the existing pacing (`maxSurge=0`, `maxUnavailable=1`).

Removes the manual `clusterctl alpha rollout restart` step operators run on KCP+MD after every GardenLinux bump. 
Refs internal `cc/unified-kubernetes#1277`.

## How it works

1. `_helpers.tpl` exposes `cc-runtime-cluster.imageHash` = `sha256sum | trunc 8` over `.Values.machineTemplate.image`.
2. Both `IroncoreMetalMachineTemplate` files append `-{{ imageHash }}` to `metadata.name` and add a `cc.sap/template-image-hash` label.
3. `KubeadmControlPlane` and `MachineDeployment` append the same suffix to `infrastructureRef.name`.
4. When `Values.machineTemplate.image` changes, Helm renders new template names, KCP/MD see `infraRef.name` rotated, and roll the cluster automatically.

This matches CAPI's [official guidance](https://cluster-api.sigs.k8s.io/tasks/upgrading-clusters#how-to-upgrade-the-underlying-machine-image) and the pattern used by CAPA/CAPZ/Metal3.

## Diff

| File | Change |
|---|---|
| `templates/_helpers.tpl` (new) | `cc-runtime-cluster.imageHash` helper |
| `templates/ironcoremetalmachinetemplate{,-worker}.yaml` | `metadata.name` gets `-{{ imageHash }}` suffix + label |
| `templates/kubeadmcontrolplane.yaml` | `infrastructureRef.name` gets matching suffix |
| `templates/machinedeployment.yaml` | `infrastructureRef.name` gets matching suffix |
| `Chart.yaml` | `0.8.1` → `0.8.2` |

9 insertions, 5 deletions + 14-line helper.

## Validation (`helm v4.1.4`, `ci/test-values.yaml`, 3 clusters)

- `helm lint`: clean
- All 6 KCP/MD `infraRef.name` values match a rendered template name
- Hash rotates on `--set machineTemplate.image=…`; stable on `--set controlplane.podSubnet=…` and `--set worker.replicas=…` (image-only sensitivity)
- Re-render identical values produces identical hash (idempotent)

## ⚠️ First-deploy impact

The first deploy of `0.8.2` triggers a **one-time rolling update** of KCP+MD for every cluster in `Values.clusters`, regardless of whether the image changed — the template name itself changes from `controlplane-<cluster.name>` to `controlplane-<cluster.name>-<hash>`.

- ~30–45 min CP per cluster (3 machines), ~60–90 min workers per cluster
- etcd quorum and PDBs preserved (existing pacing unchanged)
- Plan a maintenance window for first rollout per region
- All subsequent image bumps roll automatically, no manual `clusterctl`

Orphan pre-0.8.2 templates remain (no `cc.sap/template-image-hash` label, ~10 KB, harmless). Automated cleanup deferred.