### PR TITLE
github-rate-limits-exporter: switch to upstream chart

### DIFF
--- a/ci/config.yaml
+++ b/ci/config.yaml
@@ -51,4 +51,3 @@ chart-repos:
   - percona=https://percona.github.io/percona-helm-charts
   - kube-vip=https://kube-vip.github.io/helm-charts
   - perses=https://perses.github.io/helm-charts
-  - github-rate-limits-exporter=https://github.com/databus23/github-rate-limits-exporter/releases/download/github-rate-limits-exporter-0.7.6-ghe-support.1

--- a/prometheus-exporters/github-rate-limits-exporter/Chart.lock
+++ b/prometheus-exporters/github-rate-limits-exporter/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: github-rate-limits-exporter
-  repository: https://github.com/databus23/github-rate-limits-exporter/releases/download/github-rate-limits-exporter-0.7.6-ghe-support.1
-  version: 0.7.6-ghe-support.1
+  repository: oci://registry-1.docker.io/theodore86
+  version: 0.10.0
 - name: github-rate-limits-exporter
-  repository: https://github.com/databus23/github-rate-limits-exporter/releases/download/github-rate-limits-exporter-0.7.6-ghe-support.1
-  version: 0.7.6-ghe-support.1
+  repository: oci://registry-1.docker.io/theodore86
+  version: 0.10.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:b05dcb1364a35926d1ef0f6218d2e955062373bac54d8fb1eded4b53e7f3d1d0
-generated: "2026-06-11T11:30:15.804624+02:00"
+digest: sha256:0abfa8896d02fa2b4e0e9456bc867b927d2dbe6cd063a2ff4ce00bac0f34f960
+generated: "2026-06-25T09:28:05.793175+02:00"

--- a/prometheus-exporters/github-rate-limits-exporter/Chart.yaml
+++ b/prometheus-exporters/github-rate-limits-exporter/Chart.yaml
@@ -4,22 +4,18 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 0.1.0
+version: 0.2.0
 
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
-appVersion: "0.7.6-ghe-support.1"
+appVersion: "0.10.0"
 
 dependencies:
   - name: github-rate-limits-exporter
-    version: 0.7.6-ghe-support.1
-    repository: "https://github.com/databus23/github-rate-limits-exporter/releases/download/github-rate-limits-exporter-0.7.6-ghe-support.1"
+    version: '>= 0.10.0'
+    repository: "oci://registry-1.docker.io/theodore86"
     alias: ccee-bot
   - name: github-rate-limits-exporter
-    version: 0.7.6-ghe-support.1
-    repository: "https://github.com/databus23/github-rate-limits-exporter/releases/download/github-rate-limits-exporter-0.7.6-ghe-support.1"
+    version: '>= 0.10.0'
+    repository: "oci://registry-1.docker.io/theodore86"
     alias: sapcc-bot
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm


### PR DESCRIPTION
All our PRs have been merged upstream. Switch from the databus23 fork to the official OCI registry at `registry-1.docker.io/theodore86`.

Changes:
- Update Chart.yaml to use `oci://registry-1.docker.io/theodore86` with `>= 0.10.0`
- Remove the old fork's helm repo from `ci/config.yaml` (OCI registries don't need `helm repo add`)
- Bump chart version to `0.2.0`