### PR TITLE
[ipam-capi-remote] fix webhook-injector ClusterRoleBinding missing subject namespace

### DIFF
--- a/system/ipam-capi-remote/Chart.yaml
+++ b/system/ipam-capi-remote/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.27
+version: 1.2.28
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/ipam-capi-remote/templates/webhook-injector-rbac.yaml
+++ b/system/ipam-capi-remote/templates/webhook-injector-rbac.yaml
@@ -63,6 +63,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: ipam-capi-remote-webhook-injector
+  namespace: '{{ .Release.Namespace }}'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/system/kustomize/ipam-capi-remote/templates/webhook-injector-rbac.yaml
+++ b/system/kustomize/ipam-capi-remote/templates/webhook-injector-rbac.yaml
@@ -63,6 +63,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: ipam-capi-remote-webhook-injector
+  namespace: '{{ .Release.Namespace }}'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
## Problem

\`helm upgrade\` of the \`ipam-capi-remote\` chart fails with:

\`\`\`
Error: UPGRADE FAILED: failed to create resource:
ClusterRoleBinding.rbac.authorization.k8s.io "ipam-capi-remote-webhook-injector" is invalid:
subjects[0].namespace: Required value
\`\`\`

## Root cause

\`ClusterRoleBinding\` subjects of kind \`ServiceAccount\` require an explicit \`namespace\` — unlike \`RoleBinding\`, a \`ClusterRoleBinding\` cannot default the subject namespace from the binding itself (it's not namespaced). The source template was missing the field.

## Fix

Set \`namespace: '{{ .Release.Namespace }}'\` on the ServiceAccount subject in \`system/kustomize/ipam-capi-remote/templates/webhook-injector-rbac.yaml\` (matching the convention used by \`provider-ipam/templates/manager-rbac.yaml\`), then regenerate the rendered chart via \`make build-ipam-capi-remote\`. Chart version bumped from \`1.2.27\` → \`1.2.28\`.

## Rendered output (helm template … --namespace kube-system)

\`\`\`yaml
kind: ClusterRoleBinding
metadata:
  name: ipam-capi-remote-webhook-injector
subjects:
- kind: ServiceAccount
  name: ipam-capi-remote-webhook-injector
  namespace: 'kube-system'
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: ipam-capi-remote-webhook-injector
\`\`\`