### PR TITLE
[ipam-capi-remote] fix invalid namespaceSelector placement in monitoring NetworkPolicy

### DIFF
--- a/system/ipam-capi-remote/Chart.yaml
+++ b/system/ipam-capi-remote/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.28
+version: 1.2.29
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/ipam-capi-remote/Chart.yaml
+++ b/system/ipam-capi-remote/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.27
+version: 1.2.28
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/ipam-capi-remote/templates/network-policy.yaml
+++ b/system/ipam-capi-remote/templates/network-policy.yaml
@@ -56,6 +56,7 @@ spec:
   - ports:
     - protocol: TCP
       port: 8082
+    from:
     - namespaceSelector:
         matchLabels:
           name: kube-monitoring

--- a/system/kustomize/ipam-capi-remote/templates/network-policy.yaml
+++ b/system/kustomize/ipam-capi-remote/templates/network-policy.yaml
@@ -56,6 +56,7 @@ spec:
   - ports:
     - protocol: TCP
       port: 8082
+    from:
     - namespaceSelector:
         matchLabels:
           name: kube-monitoring


### PR DESCRIPTION
## Warning

\`\`\`
Warning: unknown field "spec.ingress[0].ports[1].namespaceSelector"
\`\`\`

## Root cause

In \`ipam-capi-ingress-from-kube-monitoring\`, the \`namespaceSelector\` was nested as a list item under \`ports:\` — but \`NetworkPolicyPort\` only accepts \`port\`, \`protocol\`, and \`endPort\`. Peer selectors (\`podSelector\`, \`namespaceSelector\`, \`ipBlock\`) belong under \`from:\`.

The policy not only emitted the warning — it also didn't actually restrict traffic by source namespace, because the misplaced selector was silently ignored.

## Fix

\`\`\`diff
   ingress:
   - ports:
     - protocol: TCP
       port: 8082
+    from:
     - namespaceSelector:
         matchLabels:
           name: kube-monitoring
\`\`\`

Applied to the source template (\`system/kustomize/ipam-capi-remote/templates/network-policy.yaml\`); rendered chart regenerated via \`make build-ipam-capi-remote\`. Chart version 1.2.27 → 1.2.28.

> Note: PR #12075 also bumps to 1.2.28; whichever merges second will need a rebase to 1.2.29.