### PR TITLE
[ipam-capi-remote] strip webhook configurations from managedresources

### DIFF
--- a/system/ipam-capi-remote/Chart.yaml
+++ b/system/ipam-capi-remote/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.29
+version: 1.2.30
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/ipam-capi-remote/managedresources/crds-rbac.yaml
+++ b/system/ipam-capi-remote/managedresources/crds-rbac.yaml
@@ -3708,7 +3708,7 @@ spec:
     webhook:
       clientConfig:
         service:
-          name: ipam-capi-webhook-service
+          name: webhook-service
           namespace: kube-system
           path: /convert
       conversionReviewVersions:
@@ -3998,7 +3998,7 @@ spec:
     webhook:
       clientConfig:
         service:
-          name: ipam-capi-webhook-service
+          name: webhook-service
           namespace: kube-system
           path: /convert
       conversionReviewVersions:
@@ -4148,7 +4148,7 @@ spec:
     webhook:
       clientConfig:
         service:
-          name: ipam-capi-webhook-service
+          name: webhook-service
           namespace: kube-system
           path: /convert
       conversionReviewVersions:
@@ -4436,7 +4436,7 @@ spec:
     webhook:
       clientConfig:
         service:
-          name: ipam-capi-webhook-service
+          name: webhook-service
           namespace: kube-system
           path: /convert
       conversionReviewVersions:
@@ -5710,205 +5710,3 @@ spec:
     targetPort: https
   selector:
     control-plane: controller-manager
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: ipam-capi-webhook-service
-  namespace: kube-system
-spec:
-  ports:
-  - port: 443
-    targetPort: webhook-server
----
-apiVersion: admissionregistration.k8s.io/v1
-kind: MutatingWebhookConfiguration
-metadata:
-  name: ipam-capi-mutating-webhook-configuration
-webhooks:
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: ipam-capi-webhook-service
-      namespace: kube-system
-      path: /mutate-ipam-cluster-x-k8s-io-v1alpha2-globalinclusterippool
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: default.globalinclusterippool.ipam.cluster.x-k8s.io
-  rules:
-  - apiGroups:
-    - ipam.cluster.x-k8s.io
-    apiVersions:
-    - v1alpha2
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - globalinclusterippools
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: ipam-capi-webhook-service
-      namespace: kube-system
-      path: /mutate-ipam-cluster-x-k8s-io-v1alpha2-globalinclusterprefixpool
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: default.globalinclusterprefixpool.ipam.cluster.x-k8s.io
-  rules:
-  - apiGroups:
-    - ipam.cluster.x-k8s.io
-    apiVersions:
-    - v1alpha2
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - globalinclusterprefixpools
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: ipam-capi-webhook-service
-      namespace: kube-system
-      path: /mutate-ipam-cluster-x-k8s-io-v1alpha2-inclusterippool
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: default.inclusterippool.ipam.cluster.x-k8s.io
-  rules:
-  - apiGroups:
-    - ipam.cluster.x-k8s.io
-    apiVersions:
-    - v1alpha2
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - inclusterippools
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: ipam-capi-webhook-service
-      namespace: kube-system
-      path: /mutate-ipam-cluster-x-k8s-io-v1alpha2-inclusterprefixpool
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: default.inclusterprefixpool.ipam.cluster.x-k8s.io
-  rules:
-  - apiGroups:
-    - ipam.cluster.x-k8s.io
-    apiVersions:
-    - v1alpha2
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - inclusterprefixpools
-  sideEffects: None
----
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
-metadata:
-  name: ipam-capi-validating-webhook-configuration
-webhooks:
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: ipam-capi-webhook-service
-      namespace: kube-system
-      path: /validate-ipam-cluster-x-k8s-io-v1alpha2-globalinclusterippool
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: validation.globalinclusterippool.ipam.cluster.x-k8s.io
-  rules:
-  - apiGroups:
-    - ipam.cluster.x-k8s.io
-    apiVersions:
-    - v1alpha2
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - globalinclusterippools
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: ipam-capi-webhook-service
-      namespace: kube-system
-      path: /validate-ipam-cluster-x-k8s-io-v1alpha2-globalinclusterprefixpool
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: validation.globalinclusterprefixpool.ipam.cluster.x-k8s.io
-  rules:
-  - apiGroups:
-    - ipam.cluster.x-k8s.io
-    apiVersions:
-    - v1alpha2
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - globalinclusterprefixpools
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: ipam-capi-webhook-service
-      namespace: kube-system
-      path: /validate-ipam-cluster-x-k8s-io-v1alpha2-inclusterippool
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: validation.inclusterippool.ipam.cluster.x-k8s.io
-  rules:
-  - apiGroups:
-    - ipam.cluster.x-k8s.io
-    apiVersions:
-    - v1alpha2
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - inclusterippools
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: ipam-capi-webhook-service
-      namespace: kube-system
-      path: /validate-ipam-cluster-x-k8s-io-v1alpha2-inclusterprefixpool
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: validation.inclusterprefixpool.ipam.cluster.x-k8s.io
-  rules:
-  - apiGroups:
-    - ipam.cluster.x-k8s.io
-    apiVersions:
-    - v1alpha2
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - inclusterprefixpools
-  sideEffects: None

--- a/system/kustomize/ipam-capi-remote/managedresources/kustomization.yaml
+++ b/system/kustomize/ipam-capi-remote/managedresources/kustomization.yaml
@@ -5,7 +5,9 @@ namePrefix: ipam-capi-
 resources:
 - https://github.com/kubernetes-sigs/cluster-api-ipam-provider-in-cluster//config/crd
 - https://github.com/kubernetes-sigs/cluster-api-ipam-provider-in-cluster//config/rbac
-- https://github.com/kubernetes-sigs/cluster-api-ipam-provider-in-cluster//config/webhook
+# config/webhook is intentionally omitted — the MutatingWebhookConfiguration
+# and ValidatingWebhookConfiguration are rendered into the Helm chart directly
+# (ipam-capi-remote/webhooks.yaml, generated from kustomize/ipam-capi-remote/webhooks).
 - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api/refs/heads/main/config/crd/bases/cluster.x-k8s.io_clusters.yaml
 - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api/refs/heads/main/config/crd/bases/ipam.cluster.x-k8s.io_ipaddresses.yaml
 - https://raw.githubusercontent.com/kubernetes-sigs/cluster-api/refs/heads/main/config/crd/bases/ipam.cluster.x-k8s.io_ipaddressclaims.yaml


### PR DESCRIPTION
## Problem

The managedresources bundle (\`ipam-capi-remote/managedresources/crds-rbac.yaml\`) contained a \`MutatingWebhookConfiguration\` and a \`ValidatingWebhookConfiguration\` named \`ipam-capi-mutating-webhook-configuration\` / \`ipam-capi-validating-webhook-configuration\`.

These same webhook configurations are also rendered into the Helm chart itself at \`ipam-capi-remote/webhooks.yaml\` (generated from \`kustomize/ipam-capi-remote/webhooks\` by the same \`make build-ipam-capi-remote\` target — see Makefile lines 89-90). The duplication shipped two copies with potentially divergent \`clientConfig\`.

## Root cause

\`kustomize/ipam-capi-remote/managedresources/kustomization.yaml\` listed \`config/webhook\` from the upstream \`cluster-api-ipam-provider-in-cluster\` repo as a resource, which is where the MWC/VWC came from.

## Fix

Drop \`config/webhook\` from the resources list in the managedresources kustomization (with a comment explaining why), and rebuild.

After the change, the bundle contains only the kinds it should:

\`\`\`
   4 kind: ClusterRole
   3 kind: ClusterRoleBinding
   7 kind: CustomResourceDefinition
   1 kind: Service
   1 kind: ServiceAccount
\`\`\`

The chart's \`webhooks.yaml\` is untouched and still contains the MWC + VWC, so on-cluster webhook coverage is unchanged.

Chart version 1.2.29 → 1.2.30.