### PR TITLE
metal-maintenance-operator: add and bump this and -remote

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -282,6 +282,7 @@
 /system/logs                                           @Kuckkuck @timojohlo @notque @olandr @joluc
 /system/Makefile                                       @sapcc/PlusOne-CE-API-Services-ControlPlane
 /system/maintenance-controller                         @sapcc/PlusOne-CE-API-Services-ControlPlane
+/system/metal-maintenance-operator                     @sapcc/PlusOne-CE-API-Services-ControlPlane @sapcc/baremetal @stefanhipfel
 /system/metal-maintenance-operator-remote              @sapcc/PlusOne-CE-API-Services-ControlPlane @sapcc/baremetal @stefanhipfel
 /system/metal-operator                                 @sapcc/PlusOne-CE-API-Services-ControlPlane @sapcc/baremetal @stefanhipfel
 /system/metal-operator-dhcp                            @sapcc/PlusOne-CE-API-Services-ControlPlane @sapcc/baremetal @stefanhipfel

--- a/system/metal-maintenance-operator-remote/Chart.lock
+++ b/system/metal-maintenance-operator-remote/Chart.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: metal-maintenance-operator
   repository: oci://ghcr.io/ironcore-dev/charts
   version: 0.0.1-20260729083015-585c808-crds
-digest: sha256:f5347db07749fa5a3d8b5c8e216d3927746d29f2b3bd9017ba8da1acd9f49d51
-generated: "2026-07-30T12:30:34.729625+02:00"
+digest: sha256:930fe6b201f0ab2f212cf7b6b9ca9c281e7c6174a27349ccc2f8fe65483794b0
+generated: "2026-07-30T15:02:13.137843+02:00"

--- a/system/metal-maintenance-operator-remote/Chart.yaml
+++ b/system/metal-maintenance-operator-remote/Chart.yaml
@@ -11,4 +11,4 @@ dependencies:
   - name: metal-maintenance-operator
     repository: oci://ghcr.io/ironcore-dev/charts
     version: 0.0.1-20260729083015-585c808-crds
-    alias: metal-maintenance-operator-core
+    alias: mmo-core

--- a/system/metal-maintenance-operator-remote/values.yaml
+++ b/system/metal-maintenance-operator-remote/values.yaml
@@ -3,7 +3,7 @@ owner-info:
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/system/metal-maintenance-operator-remote
 
 # Disable all upstream chart rendering that the wrapper doesn't need
-metal-maintenance-operator-core:
+mmo-core:
   fullnameOverride: metal-maintenance-operator
   crd:
     enable: false

--- a/system/metal-maintenance-operator-remote/values.yaml
+++ b/system/metal-maintenance-operator-remote/values.yaml
@@ -27,8 +27,10 @@ metal-maintenance-operator-core:
     image:
       repository: keppel.global.cloud.sap/ccloud-ghcr-io-mirror/ironcore-dev/metal-maintenance-operator-controller-manager
     args:
-      - "--sanitization-namespace=metal-maintenance-sanitization"
       - "--sanitization-image=keppel.global.cloud.sap/ccloud-ghcr-io-mirror/ironcore-dev/sanitizer@sha256:82f78c3d4c991a3b055415cb649cb371faaf63a64ed1407b7eeadf97680713e7"
+      # - "--sanitization-namespace=DEFINE_IN_REGION_VALUES"
+      # - "--sanitization-tolerations=DEFINE_IN_REGION_VALUES"
+      # - "--readiness-checks=DEFINE_IN_REGION_VALUES"
       - "--report-base-url=https://metal-maintenance-operator.garden.<region>.cloud.sap"
     env:
       KUBERNETES_SERVICE_HOST: "apiserver-url"

--- a/system/metal-maintenance-operator/.helmignore
+++ b/system/metal-maintenance-operator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/system/metal-maintenance-operator/Chart.lock
+++ b/system/metal-maintenance-operator/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.0.0
 - name: metal-maintenance-operator
   repository: oci://ghcr.io/ironcore-dev/charts
-  version: 0.0.1-20260729083015-585c808-crds
-digest: sha256:f5347db07749fa5a3d8b5c8e216d3927746d29f2b3bd9017ba8da1acd9f49d51
-generated: "2026-07-30T12:30:34.729625+02:00"
+  version: 0.0.1-20260729083015-585c808
+digest: sha256:b0a40b0badadf51cceff46fa47601124ae510b37212bed2beb01030a07d775a6
+generated: "2026-07-30T12:30:32.764328+02:00"

--- a/system/metal-maintenance-operator/Chart.lock
+++ b/system/metal-maintenance-operator/Chart.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: metal-maintenance-operator
   repository: oci://ghcr.io/ironcore-dev/charts
   version: 0.0.1-20260729083015-585c808
-digest: sha256:b0a40b0badadf51cceff46fa47601124ae510b37212bed2beb01030a07d775a6
-generated: "2026-07-30T12:30:32.764328+02:00"
+digest: sha256:c005477cb1c0befc8c4fa56d85fbfead5b62b781e90320c7159b18ee3d4b2add
+generated: "2026-07-30T15:02:10.826545+02:00"

--- a/system/metal-maintenance-operator/Chart.yaml
+++ b/system/metal-maintenance-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-name: metal-maintenance-operator-remote
-description: A Helm chart for the Ironcore metal-maintenance-operator (remote).
+name: metal-maintenance-operator
+description: A Helm chart for the Ironcore metal-maintenance-operator.
 type: application
-version: 0.1.1
+version: 0.1.0
 appVersion: "0.1.0"
 dependencies:
   - name: owner-info
@@ -10,5 +10,5 @@ dependencies:
     version: '>= 0.0.0'
   - name: metal-maintenance-operator
     repository: oci://ghcr.io/ironcore-dev/charts
-    version: 0.0.1-20260729083015-585c808-crds
+    version: 0.0.1-20260729083015-585c808
     alias: metal-maintenance-operator-core

--- a/system/metal-maintenance-operator/Chart.yaml
+++ b/system/metal-maintenance-operator/Chart.yaml
@@ -11,4 +11,4 @@ dependencies:
   - name: metal-maintenance-operator
     repository: oci://ghcr.io/ironcore-dev/charts
     version: 0.0.1-20260729083015-585c808
-    alias: metal-maintenance-operator-core
+    alias: mmo-core

--- a/system/metal-maintenance-operator/ci/test-values.yaml
+++ b/system/metal-maintenance-operator/ci/test-values.yaml
@@ -1,0 +1,4 @@
+global:
+  region: ab-cd-1
+  tld: example.com
+  clusterType: k8s

--- a/system/metal-maintenance-operator/values.yaml
+++ b/system/metal-maintenance-operator/values.yaml
@@ -1,0 +1,39 @@
+owner-info:
+  support-group: containers
+  helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/system/metal-maintenance-operator
+
+metal-maintenance-operator-core:
+  fullnameOverride: metal-maintenance-operator
+  crd:
+    enable: true
+  rbac:
+    namespaced: false
+    helpers:
+      enable: false
+  serviceAccount:
+    enable: true
+  metrics:
+    enable: false
+  prometheus:
+    enable: false
+  certManager:
+    enable: false
+  ingress:
+    enable: true
+    domain: "metal-maintenance-operator.{{ .Values.global.clusterType }}.{{ .Values.global.region }}.{{ .Values.global.tld }}"
+    tls: true
+    annotations:
+      kubernetes.io/tls-acme: "true"
+      disco: "true"
+  serverReadinessNamespaces:
+    - metal-servers
+  manager:
+    enabled: true
+    image:
+      repository: keppel.global.cloud.sap/ccloud-ghcr-io-mirror/ironcore-dev/metal-maintenance-operator-controller-manager
+    args:
+      - "--sanitization-image=keppel.global.cloud.sap/ccloud-ghcr-io-mirror/ironcore-dev/sanitizer@sha256:82f78c3d4c991a3b055415cb649cb371faaf63a64ed1407b7eeadf97680713e7"
+      # - "--sanitization-namespace=DEFINE_IN_REGION_VALUES"
+      # - "--sanitization-tolerations=DEFINE_IN_REGION_VALUES"
+      # - "--readiness-checks=DEFINE_IN_REGION_VALUES"
+      - "--report-base-url=https://metal-maintenance-operator.garden.<region>.cloud.sap"

--- a/system/metal-maintenance-operator/values.yaml
+++ b/system/metal-maintenance-operator/values.yaml
@@ -2,7 +2,7 @@ owner-info:
   support-group: containers
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/system/metal-maintenance-operator
 
-metal-maintenance-operator-core:
+mmo-core:
   fullnameOverride: metal-maintenance-operator
   crd:
     enable: true


### PR DESCRIPTION
- add the `metal-maintenance-operator`, similar to `metal-maintenance-operator-remote` 
- bump both to the latest version.
- rename `metal-maintenance-operator` to `mmo` otherwise we create strings longer than 64 chars and concourse does not allow that.
- add codeowners for `metal-maintenance-operator`