### PR TITLE
glance: nanny also purges the images table

### DIFF
--- a/openstack/glance/templates/glance-nanny-deployment.yaml
+++ b/openstack/glance/templates/glance-nanny-deployment.yaml
@@ -72,6 +72,12 @@ spec:
           value: {{ .Values.glance_nanny.db_purge.older_than | quote }}
         - name: GLANCE_DB_PURGE_MAX_NUMBER
           value: {{ .Values.glance_nanny.db_purge.max_number | quote }}
+        - name: GLANCE_DB_PURGE_IMAGES_TABLE_ENABLED
+          value: {{ .Values.glance_nanny.db_purge.images_table.enabled | quote }}
+        - name: GLANCE_DB_PURGE_IMAGES_TABLE_OLDER_THAN
+          value: {{ .Values.glance_nanny.db_purge.images_table.older_than | quote }}
+        - name: GLANCE_DB_PURGE_IMAGES_TABLE_MAX_NUMBER
+          value: {{ .Values.glance_nanny.db_purge.images_table.max_number | quote }}
         - name: GLANCE_NANNY_INTERVAL
           value: {{ .Values.glance_nanny.interval | quote }}
         {{- if .Values.sentry.enabled }}

--- a/openstack/glance/templates/scripts/_glance-db-consistency-and-purge.sh.tpl
+++ b/openstack/glance/templates/scripts/_glance-db-consistency-and-purge.sh.tpl
@@ -31,6 +31,15 @@ while true; do
         date
         /var/lib/openstack/bin/glance-manage db purge --age_in_days $GLANCE_DB_PURGE_OLDER_THAN --max_rows $GLANCE_DB_PURGE_MAX_NUMBER
     fi
+
+    # `glance-manage db purge` skips the `images` table (OSSN-0075).
+    # Purge it separately so that soft-deleted image rows are removed
+    # and previously-used image UUIDs can be reused.
+    if [ "$GLANCE_DB_PURGE_IMAGES_TABLE_ENABLED" = "True" ] || [ "$GLANCE_DB_PURGE_IMAGES_TABLE_ENABLED" = "true" ]; then
+        echo -n "INFO: purging at max $GLANCE_DB_PURGE_IMAGES_TABLE_MAX_NUMBER deleted rows older than $GLANCE_DB_PURGE_IMAGES_TABLE_OLDER_THAN days from the glance images table - "
+        date
+        /var/lib/openstack/bin/glance-manage db purge_images_table --age_in_days $GLANCE_DB_PURGE_IMAGES_TABLE_OLDER_THAN --max_rows $GLANCE_DB_PURGE_IMAGES_TABLE_MAX_NUMBER
+    fi
     echo -n "INFO: waiting $GLANCE_NANNY_INTERVAL minutes before starting the next loop run - "
     date
     sleep $(( 60 * $GLANCE_NANNY_INTERVAL ))

--- a/openstack/glance/values.yaml
+++ b/openstack/glance/values.yaml
@@ -390,3 +390,9 @@ glance_nanny:
     older_than: 14
     # delete at max number of entries in one run
     max_number: 500
+    # also run `glance-manage db purge_images_table` to purge the `images`
+    # table itself (skipped by `glance-manage db purge` per OSSN-0075).
+    images_table:
+      enabled: true
+      older_than: 180
+      max_number: 500


### PR DESCRIPTION
## Problem

`glance-manage db purge` (the only command the glance-nanny runs today) intentionally **skips the `images` table** to mitigate [OSSN-0075](https://wiki.openstack.org/wiki/OSSN/OSSN-0075). From `glance/db/sqlalchemy/api.py::purge_deleted_rows`:

```python
# NOTE(abhishekk): To mitigate OSSN-0075 images records should be
# purged with new ``purge-images-table`` command.
if tbl == 'images':
    continue
```

As a result, soft-deleted image rows accumulate forever and any subsequent

```
os image create … --id <previously-used-uuid> …
```

returns

```
409 Conflict: Image ID <uuid> already exists!
```

(raised at `glance/db/sqlalchemy/api.py:1074` on the PK collision).

### Observed in eu-de-1

```
total_soft_deleted               = 131,334
purgable_now (deleted_at < -14d) = 129,418
oldest deleted_at                = 2019-10-15 10:39:24
newest deleted_at                = 2026-06-25 17:13:28
```

i.e. no row has ever been purged from `images` on this region, even though the nanny has been logging successful hourly `purge` runs for years.

## Fix

Add a second invocation in the nanny loop that calls `glance-manage db purge_images_table` (the dedicated upstream command for this), gated by a new `glance_nanny.db_purge.images_table` value block. Defaults follow upstream's `purge_images_table` defaults (`older_than=180`).

## Changes

- `templates/scripts/_glance-db-consistency-and-purge.sh.tpl`: add a second `if` block invoking
  `glance-manage db purge_images_table --age_in_days $GLANCE_DB_PURGE_IMAGES_TABLE_OLDER_THAN --max_rows $GLANCE_DB_PURGE_IMAGES_TABLE_MAX_NUMBER`.
- `templates/glance-nanny-deployment.yaml`: plumb `GLANCE_DB_PURGE_IMAGES_TABLE_{ENABLED,OLDER_THAN,MAX_NUMBER}` env vars into the `db-consistency-and-purge` container.
- `values.yaml`: add
  ```yaml
  glance_nanny:
    db_purge:
      images_table:
        enabled: true
        older_than: 180
        max_number: 500
  ```

## Rollout

After this lands, regions with a backlog (e.g. eu-de-1 ~129k rows eligible) will start draining 500 rows/hour from `images`. To drain faster, temporarily bump `glance_nanny.db_purge.images_table.max_number`, or run a one-shot:

```bash
kubectl -n monsoon3 exec deploy/glance-nanny -c db-consistency-and-purge -- \
    /var/lib/openstack/bin/glance-manage db purge_images_table --age_in_days 180 --max_rows 10000
```

To keep the previous (no-images-purge) behavior, set `glance_nanny.db_purge.images_table.enabled: false`.