### PR TITLE
system/gatekeeper: add trust to known_support_groups

### DIFF
--- a/system/gatekeeper/values.yaml
+++ b/system/gatekeeper/values.yaml
@@ -54,6 +54,7 @@ known_support_groups:
   - observability
   - src
   - storage
+  - trust
   - workload-management
 
 ################################################################################


### PR DESCRIPTION
## Summary

Add the `trust` support group (covering barbican, portunus, and clavis) to the `known_support_groups` list in `system/gatekeeper/values.yaml`.

## Why

A companion change in greenhouse ([PlusOne/greenhouse#1914](https://github.wdf.sap.corp/PlusOne/greenhouse/pull/1914)) introduces dedicated critical alert routing for `support_group=trust` in the observability support-group chart. The gatekeeper policy enforces that only entries from this `known_support_groups` list are accepted as `support-group` owner-info values, so `trust` must be registered here first (per reviewer request, this PR must merge before the greenhouse PR).

## Changes

- Add `trust` to `known_support_groups` in `system/gatekeeper/values.yaml` (kept in alphabetical order, between `storage` and `workload-management`).

## Related

- PlusOne/greenhouse#1914 - feat(observability): add support_group=trust critical alert routing