### PR TITLE
[mariadb][kmip] bump db chart dependency

### DIFF
--- a/openstack/kmip/Chart.lock
+++ b/openstack/kmip/Chart.lock
@@ -7,15 +7,15 @@ dependencies:
   version: 1.1.1
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.37.2
+  version: 0.38.0
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.35.0
+  version: 0.39.0
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.5.0
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.8.1
-digest: sha256:0cc9b2877af63e523c584dcf65689ae1bacecfbfe6f1298f1a450dcbbdbd314e
-generated: "2026-06-12T16:12:23.779367+05:30"
+digest: sha256:08510c539ca4c202e8da5154d6b631e1cf7de3c81cc6fea0d26f5a761364a1a4
+generated: "2026-06-26T15:26:15.664358+03:00"

--- a/openstack/kmip/Chart.yaml
+++ b/openstack/kmip/Chart.yaml
@@ -38,7 +38,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.35.0
+    version: 0.39.0
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db


### PR DESCRIPTION
* update mariadb to 10.11.18
* update sidecar containers
* skip mariadb pvc mount when access modes do not include ReadWriteMany
* support multiple ceph s3 backup targets