### PR TITLE
[mariadb][keystone] bump db chart dependency

### DIFF
--- a/openstack/keystone/Chart.lock
+++ b/openstack/keystone/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.35.0
+  version: 0.39.0
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.5.0
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:668631b074911f6d1ce11454ca0355155e24047f34f1f75d0b25ffdeaca207c0
-generated: "2026-05-12T12:30:35.19992+02:00"
+digest: sha256:c10edea367d5f14d8bfb27b404a2ba4ef981593dd9a2d7cc1931dff3f454703d
+generated: "2026-06-26T15:25:34.723432+03:00"

--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.35.0
+    version: 0.39.0
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db


### PR DESCRIPTION
* update mariadb to 10.11.18
* update sidecar containers
* skip mariadb pvc mount when access modes do not include ReadWriteMany
* support multiple ceph s3 backup targets