### PR TITLE
[mariadb][glance] bump db chart dependency

### DIFF
--- a/openstack/glance/Chart.lock
+++ b/openstack/glance/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.35.1
+  version: 0.39.0
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.5.0
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:2af93a8a1c1f5d52c6dc013062e1d2725cb3912e07d1be5a5e7c157ae47e200e
-generated: "2026-05-12T12:22:06.077958+05:30"
+digest: sha256:fd996ed6d106bfee6b5f6bdc556a4282fae481b2bc41d7beadfeac78a1ce9bcd
+generated: "2026-06-26T15:24:39.485709+03:00"

--- a/openstack/glance/Chart.yaml
+++ b/openstack/glance/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.35.1
+    version: 0.39.0
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db


### PR DESCRIPTION
* update mariadb to 10.11.18
* update sidecar containers
* skip mariadb pvc mount when access modes do not include ReadWriteMany
* support multiple ceph s3 backup targets