### PR TITLE
[mariadb][barbican] bump db chart dependency

### DIFF
--- a/openstack/barbican/Chart.lock
+++ b/openstack/barbican/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.35.0
+  version: 0.39.0
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.5.0
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:466f1023f41ed3cb9897642fe4b82c007b009a3376cdd7e19fac705900853ba9
-generated: "2026-05-07T19:54:12.312269+05:30"
+digest: sha256:fd996ed6d106bfee6b5f6bdc556a4282fae481b2bc41d7beadfeac78a1ce9bcd
+generated: "2026-06-26T15:23:21.084756+03:00"

--- a/openstack/barbican/Chart.yaml
+++ b/openstack/barbican/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.35.0
+    version: 0.39.0
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db


### PR DESCRIPTION
* update mariadb to 10.11.18
* update sidecar containers
* skip mariadb pvc mount when access modes do not include ReadWriteMany
* support multiple ceph s3 backup targets