### PR TITLE
[mariadb][nova] bump db chart dependency

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -1,19 +1,19 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.33.0
+  version: 0.39.0
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.5.1
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.33.0
+  version: 0.39.0
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.5.1
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.33.0
+  version: 0.39.0
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.7.0
@@ -28,7 +28,7 @@ dependencies:
   version: 0.34.0
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.33.0
+  version: 0.39.0
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.5.1
@@ -37,7 +37,7 @@ dependencies:
   version: 0.25.0
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.33.0
+  version: 0.39.0
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.5.1
@@ -59,5 +59,5 @@ dependencies:
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.25.0
-digest: sha256:de7c58c72aa08628fd7ad5b8f3f8b2522881ac8eb1a92c765ef13f01f10068c3
-generated: "2026-05-22T13:44:10.695867552+02:00"
+digest: sha256:945464a4563df7a316960604da5ef915ee6dbe864d2fafa41532baafbfecdac3
+generated: "2026-06-26T15:27:57.567107+03:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.33.0
+    version: 0.39.0
   - alias: pxc_db
     condition: pxc_db.enabled
     name: pxc-db
@@ -19,7 +19,7 @@ dependencies:
     condition: mariadb_api.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.33.0
+    version: 0.39.0
   - alias: pxc_db_api
     condition: pxc_db_api.enabled
     name: pxc-db
@@ -29,7 +29,7 @@ dependencies:
     condition: mariadb_cell1.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.33.0
+    version: 0.39.0
   - name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.7.0
@@ -47,7 +47,7 @@ dependencies:
     condition: mariadb_cell2.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.33.0
+    version: 0.39.0
   - alias: pxc_db_cell2
     condition: pxc_db_cell2.enabled
     name: pxc-db
@@ -62,7 +62,7 @@ dependencies:
     condition: mariadb_cell3.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.33.0
+    version: 0.39.0
   - alias: pxc_db_cell3
     condition: pxc_db_cell3.enabled
     name: pxc-db


### PR DESCRIPTION
* update mariadb to 10.11.18
* update mysqld-exporter to 0.19.0
* update sidecar containers
* limit backup user privileges
* skip mariadb pvc mount when access modes don't include ReadWriteMany
* add support for ceph s3 backup storage backend
* support multiple ceph s3 backup targets