### PR TITLE
[mariadb][manila] bump db chart dependency

### DIFF
--- a/openstack/manila/Chart.lock
+++ b/openstack/manila/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.1.1
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.38.1
+  version: 0.39.0
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.6.0
@@ -22,9 +22,9 @@ dependencies:
   version: 0.25.2
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 2.4.54
+  version: 2.4.67
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.37.2
-digest: sha256:d3047ee348d16a960005fe89cec3151fa9acce6f4cc3f33d456d219fcac3c5f0
-generated: "2026-06-12T13:32:04.829836+02:00"
+  version: 0.38.0
+digest: sha256:d08600b06f146a895590dc5d3ee14a00c1e7eb2cc9f41ed70ec80f9fa9ef4c84
+generated: "2026-06-26T15:26:37.052129+03:00"


### PR DESCRIPTION
* support multiple ceph s3 backup targets