### PR TITLE
[mariadb][designate] bump db chart dependency

### DIFF
--- a/openstack/designate/Chart.lock
+++ b/openstack/designate/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 0.6.0
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.38.1
+  version: 0.39.0
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.6.17
@@ -29,5 +29,5 @@ dependencies:
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.4.62
-digest: sha256:57da1e4e5610e53af186c91bcb4809e8486b344c3518de60e90b45e3a06a5a3a
-generated: "2026-06-16T10:42:32.546584+02:00"
+digest: sha256:252d2794c36a208609863340d69e340920107fc0380a83bd44f448b3f191b3de
+generated: "2026-06-26T15:24:15.666284+03:00"

--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.38.1
+    version: 0.39.0
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.6.17


### PR DESCRIPTION
* support multiple ceph s3 backup targets