### PR TITLE
[mariadb][cinder] bump db chart dependency

### DIFF
--- a/openstack/cinder/Chart.lock
+++ b/openstack/cinder/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.37.1
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.38.1
+  version: 0.39.0
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.5.1
@@ -26,5 +26,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:cf511771150f7696c88ff607aef0836d23520a73edbd9a7fca1516a079065444
-generated: "2026-06-11T09:47:05.738315-04:00"
+digest: sha256:59294a6cad1396f3b0e6ce993144e6658dac12df2b7a53385052e34cea5acb53
+generated: "2026-06-26T15:23:49.80565+03:00"

--- a/openstack/cinder/Chart.yaml
+++ b/openstack/cinder/Chart.yaml
@@ -10,7 +10,7 @@ dependencies:
     version: 0.37.1
   - name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.38.1
+    version: 0.39.0
     condition: mariadb.enabled
   - name: pxc-db
     alias: pxc_db


### PR DESCRIPTION
* support multiple ceph s3 backup targets