### PR TITLE
[mariadb][octavia] bump db chart dependency

### DIFF
--- a/openstack/octavia/Chart.lock
+++ b/openstack/octavia/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.37.0
+  version: 0.39.0
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.4.1
@@ -26,5 +26,5 @@ dependencies:
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.2.19
-digest: sha256:010124b200c362d60cb914247ac5e7a11a8e0ce50d0e79ce698b5f0ea194f5a0
-generated: "2026-06-19T18:03:56.864405658+02:00"
+digest: sha256:a6d9f6236fc45f7a5e4fc2010061c599697e3b2bbeefcb6cd48fde77587f9823
+generated: "2026-06-26T15:37:23.589492+03:00"

--- a/openstack/octavia/Chart.yaml
+++ b/openstack/octavia/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.37.0
+    version: 0.39.0
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db


### PR DESCRIPTION
* update mariadb to 10.11.18
* fix maria-back-me-up s3 upload
* support multiple ceph s3 backup targets