### PR TITLE
[mariadb][placement] bump db chart dependency

### DIFF
--- a/openstack/placement/Chart.lock
+++ b/openstack/placement/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.37.0
+  version: 0.39.0
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.4.0
@@ -17,5 +17,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:aae18e2be5894c42901e287b94f2380b886007ef842e0443f79baa275e38638d
-generated: "2026-05-28T15:56:27.146036+03:00"
+digest: sha256:e9cb08ef41a2a10e20c46d5608ea845ba246993d3062cd112ea85364189af14b
+generated: "2026-06-26T15:37:48.407428+03:00"

--- a/openstack/placement/Chart.yaml
+++ b/openstack/placement/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.37.0
+    version: 0.39.0
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db


### PR DESCRIPTION
* update mariadb to 10.11.18
* fix maria-back-me-up s3 upload
* support multiple ceph s3 backup targets