### PR TITLE
[metal-operator-remote] fix invalid namespaceSelector placement in monitoring NetworkPolicy

### DIFF
--- a/system/metal-operator-remote/Chart.yaml
+++ b/system/metal-operator-remote/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.19
+version: 0.6.20
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/metal-operator-remote/templates/networkpolicy.yaml
+++ b/system/metal-operator-remote/templates/networkpolicy.yaml
@@ -109,6 +109,7 @@ spec:
   - ports:
     - protocol: TCP
       port: 8082
+    from:
     - namespaceSelector:
         matchLabels:
           name: kube-monitoring


### PR DESCRIPTION
Mirror of #12076 for the \`metal-operator-remote\` chart.

## Warning

\`\`\`
Warning: unknown field "spec.ingress[0].ports[1].namespaceSelector"
\`\`\`

## Root cause

In \`metalapi-ingress-from-kube-monitoring\`, the \`namespaceSelector\` was nested as a list item under \`ports:\` — but \`NetworkPolicyPort\` only accepts \`port\`, \`protocol\`, and \`endPort\`. Peer selectors (\`podSelector\`, \`namespaceSelector\`, \`ipBlock\`) belong under \`from:\`.

The policy not only emitted the warning — it also didn't actually restrict traffic by source namespace, because the misplaced selector was silently ignored.

## Fix

\`\`\`diff
   ingress:
   - ports:
     - protocol: TCP
       port: 8082
+    from:
     - namespaceSelector:
         matchLabels:
           name: kube-monitoring
\`\`\`

Chart version 0.6.19 → 0.6.20 (bumped automatically by \`make build-metal-operator-remote\`).

## Audit of related PRs

I also checked whether the other recent \`ipam-capi-remote\` fixes (#12019, #12074, #12075, #12077) had unfixed equivalents in \`metal-operator-remote\` — they do not:

- **#12019** (\`keepObjects: true\` on CRD MRs): already applied to \`metal-operator-remote/templates/managedresource.yaml\`.
- **#12074** (webhook-injector + MR reconciler): \`metal-operator-remote\` already has the injector sidecar, webhook-config ConfigMap, MR reconciler RBAC, and chart-level webhooks.yaml.
- **#12075** (CRB subject namespace required): all \`ServiceAccount\` subjects in \`metal-operator-remote\` already carry \`namespace:\`.
- **#12077** (strip MWC/VWC from managedresources): the \`build-metal-operator-remote\` target already filters \`Service\`/\`MutatingWebhookConfiguration\`/\`ValidatingWebhookConfiguration\` from \`managedresources/crds-and-rbac.yaml\` (Makefile line 152). The MWC + VWC are rendered separately into \`webhooks.yaml\` at chart level.