### PR TITLE
feat(hermes): wire log-router Ceph RGW credentials and cloud-scoped seed

### DIFF
--- a/openstack/hermes/templates/keystone-seed.yaml
+++ b/openstack/hermes/templates/keystone-seed.yaml
@@ -17,6 +17,9 @@ spec:
   - {{ $.Values.global.keystoneNamespace }}/domain-{{ replace "_" "-" . | lower }}-seed
   {{- end}}
   {{- end}}
+  {{- if .Values.logRouter.enabled }}
+  - monsoon3/ceph-seed
+  {{- end}}
 
   roles:
     - name: audit_viewer
@@ -82,6 +85,15 @@ spec:
           role: audit_viewer
         - group: CCADMIN_MONITORING_USERS
           role: audit_viewer
+      {{- if $.Values.logRouter.enabled }}
+      - name: cloud_admin
+        role_assignments:
+        # Cloud-scoped: grants cloud_objectstore_admin across every project in
+        # the Ceph RGW Keystone integration — same pattern as Keppel (to
+        # read/write blobs from/into customer Swift/RGW accounts).
+        - user: hermes@Default
+          role: cloud_objectstore_admin
+      {{- end }}
       {{- end }}
       groups:
       - name: {{ hasPrefix "iaas-" . | ternary . ( upper . ) }}_API_SUPPORT

--- a/openstack/hermes/templates/log-router-secret.yaml
+++ b/openstack/hermes/templates/log-router-secret.yaml
@@ -12,6 +12,4 @@ type: Opaque
 data:
   RABBITMQ_USER: {{ required "missing .Values.logRouter.rabbitmq.user" .Values.logRouter.rabbitmq.user | b64enc }}
   RABBITMQ_PASSWORD: {{ required "missing .Values.logRouter.rabbitmq.password" .Values.logRouter.rabbitmq.password | b64enc }}
-  AWS_ACCESS_KEY_ID: {{ required "missing .Values.logRouter.s3.access_key" .Values.logRouter.s3.access_key | b64enc }}
-  AWS_SECRET_ACCESS_KEY: {{ required "missing .Values.logRouter.s3.secret_key" .Values.logRouter.s3.secret_key | b64enc }}
 {{- end }}

--- a/openstack/hermes/values.yaml
+++ b/openstack/hermes/values.yaml
@@ -213,9 +213,9 @@ logRouter:
     region: ""
     bucket: ""
     prefix: ""
-    # access_key/secret_key injected by deployment pipeline
-    # access_key:
-    # secret_key:
+    # access_key/secret_key removed — log-router authenticates to Ceph RGW
+    # via Keystone token (Swift-compatible endpoint) using the hermes service
+    # account, not AWS HMAC ec2 credentials.
 
   wal:
     storage: 10Gi


### PR DESCRIPTION
Grants `hermes@Default` `cloud_objectstore_admin` via `ccadmin/cloud_admin` so that log-router can write audit events to Ceph RGW using Keystone token auth against the Swift-compatible endpoint.

## Context

Logstash (the current audit event writer) uses its own service user with ec2/AWS HMAC credentials and continues to work unchanged. Log-router is the eventual replacement and takes a different approach: it uses the existing `hermes@Default` service account with direct Keystone token auth against Ceph RGW's Swift endpoint — no ec2 credentials needed.

The `cloud_objectstore_admin` role via `ccadmin/cloud_admin` covers both use cases with a single auth setup:
- **Admin path**: all events → `ccadmin/master` bucket (internal/support usage)
- **Customer path**: per-tenant events → customer-provided bucket in their own project (opt-in via the dataplane-config API)

This is the same pattern Keppel uses for cross-tenant Swift/RGW access.

## Changes

**`keystone-seed.yaml`**: when `logRouter.enabled`:
- Adds `monsoon3/ceph-seed` to `requires` (defines the `cloud_objectstore_admin` role)
- Grants `hermes@Default` `cloud_objectstore_admin` on `ccadmin/cloud_admin`

**`log-router-secret.yaml`**: removes `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` — no ec2 credentials with Keystone token auth

**`values.yaml`**: removes `access_key`/`secret_key` from `logRouter.s3` stanza

## Dependencies

Log-router requires a corresponding change to replace its AWS SDK S3 client with a Swift/Keystone-compatible RGW client.