### PR TITLE
feat(hermes): log-router Swift mode and dataplane config wiring

### DIFF
--- a/openstack/hermes/Chart.lock
+++ b/openstack/hermes/Chart.lock
@@ -10,6 +10,6 @@ dependencies:
   version: 0.2.0
 - name: postgresql-ng
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 2.3.57
-digest: sha256:43696938117a9cc9567fddb84c66cb89122eaf073ee8ab5f5e3dde057257c62d
-generated: "2026-06-17T10:25:30.371677+02:00"
+  version: 2.3.62
+digest: sha256:bb7a51149b1fb3932284aa67de67af8070d19b2d4e19d2fa814dff45ff9fb09d
+generated: "2026-06-26T15:54:31.494084-07:00"

--- a/openstack/hermes/Chart.yaml
+++ b/openstack/hermes/Chart.yaml
@@ -18,7 +18,11 @@ dependencies:
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.2.0
   - name: postgresql-ng
-    alias: log-router-postgresql
-    condition: logRouter.enabled
+    alias: hermes-postgresql
+    # Shared by hermes-api (writer) and log-router (read-only via log_router_reader role).
+    # Tied to hermes.api_enabled because the API owns the dataplane_config schema.
+    # log-router cannot be enabled without api_enabled — a `fail` guard in
+    # templates/log-router-statefulset.yaml enforces this invariant.
+    condition: hermes.api_enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: '>= 0.0.0'

--- a/openstack/hermes/ci/test-values.yaml
+++ b/openstack/hermes/ci/test-values.yaml
@@ -1,7 +1,13 @@
 global:
   region: earth
+  tld: example.com
   master_password: topSecret
+  clusterDNSSearchDomain: cluster.local
+  registry: keppel.eu-de-1.cloud.sap
+  linkerd_enabled: false
+  linkerd_requested: false
   metis:
+    user: metis-user
     password: topSecret
   forwarding:
     audit:
@@ -33,6 +39,8 @@ hermes:
   image_tag: latest
   image_pull_policy: IfNotPresent
   dockerHubMirror: another-region
+  # Required by log-router-secret when logRouter.swift.enabled=true (CI exercises that path).
+  seed_password: test
   certs:
     tls_crt: my-tls-cert
     tls_key: my-tls-key
@@ -110,8 +118,11 @@ logRouter:
     region: "qa"
     bucket: "audit-qa"
     prefix: "dataplane/"
-    access_key: test
-    secret_key: test
+
+  # CI exercises the Swift/Keystone-token auth path (the only supported mode).
+  swift:
+    enabled: true
+    service_type: "object-store-ceph"
 
   wal:
     storage: 1Gi
@@ -124,11 +135,12 @@ logRouter:
       memory: "128Mi"
       cpu: "100m"
 
-log-router-postgresql:
+hermes-postgresql:
   postgresVersion: 17
   databases:
-    log-router: {}
+    hermes: {}
   users:
+    hermes: {}
     log-router: {}
   config:
     max_connections: 16

--- a/openstack/hermes/templates/_log-router-utils.tpl
+++ b/openstack/hermes/templates/_log-router-utils.tpl
@@ -104,7 +104,7 @@
 - name: OS_IDENTITY_API_VERSION
   value: '3'
 - name: OS_INTERFACE
-  value: 'internal'
+  value: 'public'
 - name: OS_PASSWORD
   valueFrom:
     secretKeyRef:

--- a/openstack/hermes/templates/_log-router-utils.tpl
+++ b/openstack/hermes/templates/_log-router-utils.tpl
@@ -94,9 +94,13 @@
       key: LOG_ROUTER_SWIFT_SERVICE_TYPE
 {{- if .Values.logRouter.swift.enabled }}
 # Keystone credentials for Swift/Ceph RGW authentication (hermes service account).
-# Authenticates as ccadmin/master for Ceph bucket writes.
+# Authenticates as ccadmin/cloud_admin — cloud_objectstore_admin role grants cross-account
+# Ceph RGW access to all tenant buckets. Admin compliance bucket lives in ccadmin/master;
+# LOG_ROUTER_SWIFT_ADMIN_ACCOUNT switches the admin client to that account at write time.
 # Mirrors the keppel/deployment-health-monitor OS_* env block (alphabetized,
 # explicit auth-version pins for gophercloud).
+- name: LOG_ROUTER_SWIFT_ADMIN_ACCOUNT
+  value: 'AUTH_{{ .Values.logRouter.swift.adminProjectID | required "logRouter.swift.adminProjectID must be set (ccadmin/master project UUID)" }}'
 - name: OS_AUTH_URL
   value: "http://keystone.{{ $.Values.global.keystoneNamespace }}.svc.{{ $.Values.global.clusterDNSSearchDomain }}:5000/v3"
 - name: OS_AUTH_VERSION
@@ -113,7 +117,7 @@
 - name: OS_PROJECT_DOMAIN_NAME
   value: 'ccadmin'
 - name: OS_PROJECT_NAME
-  value: 'master'
+  value: 'cloud_admin'
 - name: OS_REGION_NAME
   value: {{ required ".Values.global.region must be set when logRouter.swift.enabled=true (used for Swift endpoint catalog lookup)" $.Values.global.region | quote }}
 - name: OS_USER_DOMAIN_NAME

--- a/openstack/hermes/templates/_log-router-utils.tpl
+++ b/openstack/hermes/templates/_log-router-utils.tpl
@@ -94,7 +94,7 @@
       key: LOG_ROUTER_SWIFT_SERVICE_TYPE
 {{- if .Values.logRouter.swift.enabled }}
 # Keystone credentials for Swift/Ceph RGW authentication (hermes service account).
-# cloud_objectstore_admin in ccadmin/cloud_admin grants cross-tenant RGW access.
+# Authenticates as ccadmin/master for Ceph bucket writes.
 # Mirrors the keppel/deployment-health-monitor OS_* env block (alphabetized,
 # explicit auth-version pins for gophercloud).
 - name: OS_AUTH_URL
@@ -113,7 +113,7 @@
 - name: OS_PROJECT_DOMAIN_NAME
   value: 'ccadmin'
 - name: OS_PROJECT_NAME
-  value: 'cloud_admin'
+  value: 'master'
 - name: OS_REGION_NAME
   value: {{ required ".Values.global.region must be set when logRouter.swift.enabled=true (used for Swift endpoint catalog lookup)" $.Values.global.region | quote }}
 - name: OS_USER_DOMAIN_NAME

--- a/openstack/hermes/templates/_log-router-utils.tpl
+++ b/openstack/hermes/templates/_log-router-utils.tpl
@@ -138,11 +138,11 @@
 # (created by hermez's migration 001), which holds the SELECT grant on the
 # dataplane_config table. Log-router fails closed on connection errors —
 # all events still reach the admin tier (ccadmin/master) regardless.
-- name: LOG_ROUTER_HERMES_DB_PASSWORD
+- name: LOG_ROUTER_DB_PASSWORD
   valueFrom:
     secretKeyRef:
       name: '{{ $.Release.Name }}-pguser-{{ $.Values.logRouter.hermesDb.user }}'
       key: postgres-password
-- name: LOG_ROUTER_HERMES_DB_URL
-  value: "postgres://{{ $.Values.logRouter.hermesDb.user }}:$(LOG_ROUTER_HERMES_DB_PASSWORD)@{{ $.Release.Name }}-postgresql.{{ $.Release.Namespace }}.svc:5432/hermes?sslmode=disable"
+- name: LOG_ROUTER_DB_URL
+  value: "postgres://{{ $.Values.logRouter.hermesDb.user }}:$(LOG_ROUTER_DB_PASSWORD)@{{ $.Release.Name }}-postgresql.{{ $.Release.Namespace }}.svc:5432/hermes?sslmode=disable"
 {{- end -}}

--- a/openstack/hermes/templates/_log-router-utils.tpl
+++ b/openstack/hermes/templates/_log-router-utils.tpl
@@ -82,16 +82,45 @@
     configMapKeyRef:
       name: log-router-etc
       key: LOG_ROUTER_S3_PREFIX
-- name: AWS_ACCESS_KEY_ID
+- name: LOG_ROUTER_SWIFT_ENABLED
+  valueFrom:
+    configMapKeyRef:
+      name: log-router-etc
+      key: LOG_ROUTER_SWIFT_ENABLED
+- name: LOG_ROUTER_SWIFT_SERVICE_TYPE
+  valueFrom:
+    configMapKeyRef:
+      name: log-router-etc
+      key: LOG_ROUTER_SWIFT_SERVICE_TYPE
+{{- if .Values.logRouter.swift.enabled }}
+# Keystone credentials for Swift/Ceph RGW authentication (hermes service account).
+# cloud_objectstore_admin in ccadmin/cloud_admin grants cross-tenant RGW access.
+# Mirrors the keppel/deployment-health-monitor OS_* env block (alphabetized,
+# explicit auth-version pins for gophercloud).
+- name: OS_AUTH_URL
+  value: "http://keystone.{{ $.Values.global.keystoneNamespace }}.svc.{{ $.Values.global.clusterDNSSearchDomain }}:5000/v3"
+- name: OS_AUTH_VERSION
+  value: '3'
+- name: OS_IDENTITY_API_VERSION
+  value: '3'
+- name: OS_INTERFACE
+  value: 'internal'
+- name: OS_PASSWORD
   valueFrom:
     secretKeyRef:
       name: log-router-secret
-      key: AWS_ACCESS_KEY_ID
-- name: AWS_SECRET_ACCESS_KEY
-  valueFrom:
-    secretKeyRef:
-      name: log-router-secret
-      key: AWS_SECRET_ACCESS_KEY
+      key: OS_PASSWORD
+- name: OS_PROJECT_DOMAIN_NAME
+  value: 'ccadmin'
+- name: OS_PROJECT_NAME
+  value: 'cloud_admin'
+- name: OS_REGION_NAME
+  value: {{ required ".Values.global.region must be set when logRouter.swift.enabled=true (used for Swift endpoint catalog lookup)" $.Values.global.region | quote }}
+- name: OS_USER_DOMAIN_NAME
+  value: 'Default'
+- name: OS_USERNAME
+  value: 'hermes'
+{{- end }}
 - name: RABBITMQ_USER
   valueFrom:
     secretKeyRef:
@@ -104,11 +133,16 @@
       key: RABBITMQ_PASSWORD
 - name: RABBITMQ_URL
   value: "amqp://$(RABBITMQ_USER):$(RABBITMQ_PASSWORD)@{{ $.Release.Name }}-rabbitmq-notifications.{{ $.Release.Namespace }}.svc:{{ $.Values.logRouter.rabbitmq.port }}/"
-- name: LOG_ROUTER_DB_PASSWORD
+# Read-only connection to the hermes postgres for dataplane_config lookups.
+# The log_router login user is a member of the log_router_reader NOLOGIN role
+# (created by hermez's migration 001), which holds the SELECT grant on the
+# dataplane_config table. Log-router fails closed on connection errors —
+# all events still reach the admin tier (ccadmin/master) regardless.
+- name: LOG_ROUTER_HERMES_DB_PASSWORD
   valueFrom:
     secretKeyRef:
-      name: '{{ $.Release.Name }}-pguser-{{$.Values.logRouter.db.user}}'
+      name: '{{ $.Release.Name }}-pguser-{{ $.Values.logRouter.hermesDb.user }}'
       key: postgres-password
-- name: LOG_ROUTER_DB_URL
-  value: "postgres://{{$.Values.logRouter.db.user}}:$(LOG_ROUTER_DB_PASSWORD)@{{ $.Release.Name }}-postgresql.{{ $.Release.Namespace }}.svc:5432/log-router?sslmode=disable"
+- name: LOG_ROUTER_HERMES_DB_URL
+  value: "postgres://{{ $.Values.logRouter.hermesDb.user }}:$(LOG_ROUTER_HERMES_DB_PASSWORD)@{{ $.Release.Name }}-postgresql.{{ $.Release.Namespace }}.svc:5432/hermes?sslmode=disable"
 {{- end -}}

--- a/openstack/hermes/templates/api-deployment.yaml
+++ b/openstack/hermes/templates/api-deployment.yaml
@@ -58,6 +58,8 @@ spec:
               value: '{{ .Release.Name }}-postgresql.{{ .Release.Namespace }}.svc'
             - name: HERMES_PG_PORT
               value: '5432'
+            - name: HERMES_PG_CONNECTION_OPTIONS
+              value: 'sslmode=disable'
             - name: HERMES_PG_USERNAME
               value: 'hermes'
             - name: HERMES_PG_DBNAME

--- a/openstack/hermes/templates/api-deployment.yaml
+++ b/openstack/hermes/templates/api-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         linkerd.io/inject: enabled
         {{- end }}
         kubectl.kubernetes.io/default-container: "api"
-        secret.reloader.stakater.com/reload: "api-conf,hermes-es-api"
+        secret.reloader.stakater.com/reload: "api-conf,hermes-es-api,hermes-audit-rabbitmq,{{ .Release.Name }}-pguser-hermes"
         deployment.reloader.stakater.com/pause-period: "60s"
     spec:
       volumes:
@@ -50,6 +50,42 @@ spec:
                 secretKeyRef:
                   name: hermes-es-api
                   key: HERMES_ES_PASSWORD
+            # Postgres connection for the dataplane_config table.
+            # hermes runs migrations on startup and serves the v1/dataplane-config API.
+            # The Service name is <release>-postgresql regardless of the subchart
+            # alias (postgresql-ng's postgres.fullname strips the alias).
+            - name: HERMES_PG_HOSTNAME
+              value: '{{ .Release.Name }}-postgresql.{{ .Release.Namespace }}.svc'
+            - name: HERMES_PG_PORT
+              value: '5432'
+            - name: HERMES_PG_USERNAME
+              value: 'hermes'
+            - name: HERMES_PG_DBNAME
+              value: 'hermes'
+            - name: HERMES_PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: '{{ .Release.Name }}-pguser-hermes'
+                  key: postgres-password
+            # Auditor for PUT/DELETE dataplane-config operations.
+            # When the credentials secret renders empty user/password (dev default),
+            # hermez logs the auth failure and falls back to a null auditor.
+            - name: HERMES_AUDIT_RABBITMQ_HOSTNAME
+              value: '{{ tpl .Values.hermes.audit.rabbitmq.hostname . }}'
+            - name: HERMES_AUDIT_RABBITMQ_PORT
+              value: '{{ .Values.hermes.audit.rabbitmq.port | default 5672 }}'
+            - name: HERMES_AUDIT_RABBITMQ_QUEUE_NAME
+              value: '{{ .Values.hermes.audit.rabbitmq.queue_name | default "notifications.info" }}'
+            - name: HERMES_AUDIT_RABBITMQ_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-audit-rabbitmq
+                  key: username
+            - name: HERMES_AUDIT_RABBITMQ_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-audit-rabbitmq
+                  key: password
           volumeMounts:
             - mountPath: "/etc/hermes"
               name: config

--- a/openstack/hermes/templates/etc/_policy.json.tpl
+++ b/openstack/hermes/templates/etc/_policy.json.tpl
@@ -5,7 +5,9 @@
   "cluster_viewer": "project_domain_name:ccadmin and project_name:cloud_admin",
   "domain_viewer":  "rule:domain_scope and role:audit_viewer",
   "project_viewer": "rule:project_scope and role:audit_viewer",
+  "project_admin":  "rule:project_scope and role:audit_admin",
 
-  "event:list":     "rule:project_viewer or rule:domain_viewer or rule:cluster_viewer",
-  "event:show":     "rule:project_viewer or rule:domain_viewer or rule:cluster_viewer"
+  "event:list":               "rule:project_viewer or rule:domain_viewer or rule:cluster_viewer",
+  "event:show":               "rule:project_viewer or rule:domain_viewer or rule:cluster_viewer",
+  "dataplane_config:manage":  "rule:project_admin"
 }

--- a/openstack/hermes/templates/hermes-audit-rabbitmq-secret.yaml
+++ b/openstack/hermes/templates/hermes-audit-rabbitmq-secret.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.hermes.api_enabled }}
+# Credentials for the hermes-api auditor that publishes CADF events
+# (dataplane-config PUT/DELETE) to the notifications.info queue on the
+# rabbitmq_notifications subchart.
+#
+# When .Values.hermes.audit.rabbitmq.user/password are unset (e.g. in dev),
+# this secret carries empty strings and hermez's auditor logs an error and
+# falls back to a null auditor. That is the intended dev-mode behaviour.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hermes-audit-rabbitmq
+  namespace: hermes
+  labels:
+    app: hermes-api
+type: Opaque
+data:
+  username: {{ .Values.hermes.audit.rabbitmq.user | default "" | b64enc | quote }}
+  password: {{ .Values.hermes.audit.rabbitmq.password | default "" | b64enc | quote }}
+{{- end }}

--- a/openstack/hermes/templates/log-router-configmap.yaml
+++ b/openstack/hermes/templates/log-router-configmap.yaml
@@ -21,8 +21,10 @@ data:
   LOG_ROUTER_RABBITMQ_EXCHANGE: {{ .Values.logRouter.rabbitmq.exchange | quote }}
   LOG_ROUTER_RABBITMQ_ROUTING_KEY: {{ .Values.logRouter.rabbitmq.routing_key | quote }}
   LOG_ROUTER_RABBITMQ_PREFETCH: {{ .Values.logRouter.rabbitmq.prefetch | quote }}
-  LOG_ROUTER_S3_ENDPOINT: {{ required ".Values.logRouter.s3.endpoint must be set" .Values.logRouter.s3.endpoint | quote }}
+  LOG_ROUTER_S3_ENDPOINT: {{ .Values.logRouter.s3.endpoint | default "" | quote }}
   LOG_ROUTER_S3_REGION: {{ .Values.logRouter.s3.region | quote }}
   LOG_ROUTER_S3_BUCKET: {{ required ".Values.logRouter.s3.bucket must be set" .Values.logRouter.s3.bucket | quote }}
   LOG_ROUTER_S3_PREFIX: {{ .Values.logRouter.s3.prefix | quote }}
+  LOG_ROUTER_SWIFT_ENABLED: {{ .Values.logRouter.swift.enabled | quote }}
+  LOG_ROUTER_SWIFT_SERVICE_TYPE: {{ .Values.logRouter.swift.service_type | quote }}
 {{- end }}

--- a/openstack/hermes/templates/log-router-secret.yaml
+++ b/openstack/hermes/templates/log-router-secret.yaml
@@ -10,6 +10,12 @@ metadata:
     component: log-router
 type: Opaque
 data:
-  RABBITMQ_USER: {{ required "missing .Values.logRouter.rabbitmq.user" .Values.logRouter.rabbitmq.user | b64enc }}
-  RABBITMQ_PASSWORD: {{ required "missing .Values.logRouter.rabbitmq.password" .Values.logRouter.rabbitmq.password | b64enc }}
+  RABBITMQ_USER: {{ required "missing .Values.logRouter.rabbitmq.user" .Values.logRouter.rabbitmq.user | b64enc | quote }}
+  RABBITMQ_PASSWORD: {{ required "missing .Values.logRouter.rabbitmq.password" .Values.logRouter.rabbitmq.password | b64enc | quote }}
+  {{- if .Values.logRouter.swift.enabled }}
+  # Hermes service account password for Keystone token authentication against
+  # the Ceph RGW Swift endpoint. The account must hold cloud_objectstore_admin
+  # in ccadmin/cloud_admin (see keystone-seed.yaml).
+  OS_PASSWORD: {{ required "missing .Values.hermes.seed_password (required for Swift auth when logRouter.swift.enabled=true)" .Values.hermes.seed_password | b64enc | quote }}
+  {{- end }}
 {{- end }}

--- a/openstack/hermes/templates/log-router-statefulset.yaml
+++ b/openstack/hermes/templates/log-router-statefulset.yaml
@@ -1,4 +1,13 @@
+{{- if hasKey .Values "log-router-postgresql" }}
+{{- fail "The 'log-router-postgresql' values key has been renamed to 'hermes-postgresql' (postgres-ng subchart aliased). Rename your override block to avoid silently reverting to subchart defaults." }}
+{{- end }}
 {{- if .Values.logRouter.enabled }}
+{{- if not .Values.hermes.api_enabled }}
+{{- fail "logRouter.enabled=true requires hermes.api_enabled=true: log-router reads from the shared hermes-postgresql subchart, which is only deployed when hermes.api_enabled is true." }}
+{{- end }}
+{{- if not .Values.logRouter.swift.enabled }}
+{{- fail "logRouter.enabled=true requires logRouter.swift.enabled=true: log-router authenticates to Ceph RGW via Keystone tokens (Swift-compatible endpoint). AWS HMAC ec2 credentials are not supported. Set logRouter.swift.enabled=true and provide .Values.hermes.seed_password." }}
+{{- end }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -25,7 +34,7 @@ spec:
         {{- end }}
         kubectl.kubernetes.io/default-container: "log-router"
         configmap.reloader.stakater.com/reload: "log-router-etc"
-        secret.reloader.stakater.com/reload: "log-router-secret"
+        secret.reloader.stakater.com/reload: "log-router-secret,{{ .Release.Name }}-pguser-{{ .Values.logRouter.hermesDb.user }}"
         deployment.reloader.stakater.com/pause-period: "60s"
     spec:
       nodeSelector:
@@ -57,6 +66,13 @@ spec:
         - name: log-router
           image: {{ include "log_router_image" . }}
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
           ports:
             - name: http
               containerPort: 8080

--- a/openstack/hermes/values.yaml
+++ b/openstack/hermes/values.yaml
@@ -217,8 +217,8 @@ logRouter:
   max_concurrent_flushes: "100"
 
   # Read-only login role for hermes's dataplane_config table.
-  # The hermes postgres seed creates this user; hermez's migration 001 is
-  # responsible for granting membership in the log_router_reader role.
+  # The hermes postgres seed creates this user; hermez's migration 001 grants
+  # SELECT on dataplane_config directly to the log-router login role.
   # Until that GRANT lands, SELECT fails and log-router falls back to the
   # admin tier (ccadmin/master) — events still flow.
   hermesDb:
@@ -266,20 +266,16 @@ logRouter:
 
 hermes-postgresql:
   # Shared postgres backing the hermes dataplane_config table.
-  # hermes-api writes; log-router reads via log_router_reader role membership.
-  # The membership GRANT is issued by hermez's migration 001, not the chart —
-  # postgres-ng has no `memberOf` primitive, and hermez (as table owner) holds
-  # the GRANT privilege. Until the GRANT runs, log-router gets permission
-  # denied on SELECT and fails closed to the admin tier (safe).
+  # hermes-api writes; log-router reads via a GRANT SELECT issued by hermez's
+  # migration 001 directly to the log-router login user.
   postgresVersion: 17
   databases:
     hermes: {}
   users:
     # Writer role used by the hermes API. Owns the table created by migration 001.
     hermes: {}
-    # Read-only consumer for log-router. The hermez migration creates the
-    # log_router_reader NOLOGIN role with SELECT on dataplane_config and
-    # grants membership to this login user.
+    # Read-only consumer for log-router. hermez's migration 001 grants
+    # SELECT on dataplane_config to this login user.
     log-router: {}
   config:
     max_connections: 64

--- a/openstack/hermes/values.yaml
+++ b/openstack/hermes/values.yaml
@@ -211,7 +211,7 @@ logRouter:
   replicas: 2
 
   debug: "false"
-  flush_interval: "15m"
+  flush_interval: "1m"
   shutdown_timeout: "30s"
   ingest_channel_capacity: "10000"
   max_concurrent_flushes: "100"

--- a/openstack/hermes/values.yaml
+++ b/openstack/hermes/values.yaml
@@ -211,7 +211,7 @@ logRouter:
   replicas: 2
 
   debug: "false"
-  flush_interval: "30s"
+  flush_interval: "15m"
   shutdown_timeout: "30s"
   ingest_channel_capacity: "10000"
   max_concurrent_flushes: "100"

--- a/openstack/hermes/values.yaml
+++ b/openstack/hermes/values.yaml
@@ -39,6 +39,21 @@ hermes:
     queue_name: "notifications.info"
     # hostnames are derived from this template using the key of the targets entry
     host_template: "%s-rabbitmq-notifications.monsoon3"
+
+  # Audit-event publisher for hermes-api PUT/DELETE dataplane-config operations.
+  # Reuses the rabbitmq_notifications subchart; events land on the
+  # notifications.info queue alongside other OpenStack control-plane audit events.
+  audit:
+    rabbitmq:
+      hostname: '{{ .Release.Name }}-rabbitmq-notifications.{{ .Release.Namespace }}.svc'
+      port: 5672
+      queue_name: "notifications.info"
+      # user/password injected by deployment pipeline (vault-resolved).
+      # When BOTH user AND password render empty (dev default), hermez logs the
+      # auth failure and falls back to a null auditor — PUT/DELETE operations
+      # are NOT audited. Set both for any region that requires an audit trail.
+      # user:
+      # password:
 logstash:
   debug: false
   swift: true
@@ -184,6 +199,12 @@ opensearch_hermes:
   enabled: false
 
 logRouter:
+  # Enabling log-router requires three coordinated flags:
+  #   1. logRouter.enabled = true        (this flag)
+  #   2. hermes.api_enabled = true       (provides the shared postgres + dataplane_config schema)
+  #   3. logRouter.swift.enabled = true  (RGW auth via Keystone token — only supported mode)
+  # AND .Values.hermes.seed_password must be supplied by the pipeline.
+  # templates/log-router-statefulset.yaml enforces flags 2 and 3 with `fail` guards.
   enabled: false
   image_tag: ""
   init_image: "keppel.eu-de-1.cloud.sap/ccloud/shared-app-images/alpine-busybox:3.23-20260415235512"
@@ -195,7 +216,12 @@ logRouter:
   ingest_channel_capacity: "10000"
   max_concurrent_flushes: "100"
 
-  db:
+  # Read-only login role for hermes's dataplane_config table.
+  # The hermes postgres seed creates this user; hermez's migration 001 is
+  # responsible for granting membership in the log_router_reader role.
+  # Until that GRANT lands, SELECT fails and log-router falls back to the
+  # admin tier (ccadmin/master) — events still flow.
+  hermesDb:
     user: log-router
 
   rabbitmq:
@@ -211,11 +237,21 @@ logRouter:
   s3:
     endpoint: ""
     region: ""
+    # bucket: S3 bucket name for S3 mode. Also used as the Swift container name
+    # when logRouter.swift.enabled=true (LOG_ROUTER_S3_BUCKET → Swift container).
     bucket: ""
     prefix: ""
     # access_key/secret_key removed — log-router authenticates to Ceph RGW
     # via Keystone token (Swift-compatible endpoint) using the hermes service
     # account, not AWS HMAC ec2 credentials.
+
+  swift:
+    # enabled: when true, log-router uses Keystone token auth (OS_* env vars)
+    # against the Ceph RGW Swift endpoint instead of S3/HMAC credentials.
+    # Requires cloud_objectstore_admin role in ccadmin/cloud_admin (see
+    # keystone-seed.yaml). Password sourced from .Values.hermes.seed_password.
+    enabled: false
+    service_type: "object-store-ceph"
 
   wal:
     storage: 10Gi
@@ -228,11 +264,22 @@ logRouter:
       memory: "512Mi"
       cpu: "500m"
 
-log-router-postgresql:
+hermes-postgresql:
+  # Shared postgres backing the hermes dataplane_config table.
+  # hermes-api writes; log-router reads via log_router_reader role membership.
+  # The membership GRANT is issued by hermez's migration 001, not the chart —
+  # postgres-ng has no `memberOf` primitive, and hermez (as table owner) holds
+  # the GRANT privilege. Until the GRANT runs, log-router gets permission
+  # denied on SELECT and fails closed to the admin tier (safe).
   postgresVersion: 17
   databases:
-    log-router: {}
+    hermes: {}
   users:
+    # Writer role used by the hermes API. Owns the table created by migration 001.
+    hermes: {}
+    # Read-only consumer for log-router. The hermez migration creates the
+    # log_router_reader NOLOGIN role with SELECT on dataplane_config and
+    # grants membership to this login user.
     log-router: {}
   config:
     max_connections: 64

--- a/openstack/hermes/values.yaml
+++ b/openstack/hermes/values.yaml
@@ -252,6 +252,11 @@ logRouter:
     # keystone-seed.yaml). Password sourced from .Values.hermes.seed_password.
     enabled: false
     service_type: "object-store-ceph"
+    # adminProjectID: the ccadmin/master project UUID. The admin compliance bucket
+    # (hermes-audit) lives in this project. Log-router authenticates as
+    # ccadmin/cloud_admin for cross-account access, then switches to this account
+    # for admin writes. Must be set when swift.enabled=true.
+    adminProjectID: ""
 
   wal:
     storage: 10Gi


### PR DESCRIPTION
Wires log-router Swift/Keystone backend, postgres for dataplane_config reads, and hermez API audit RabbitMQ secret. Drops S3 HMAC credentials from log-router.