### PR TITLE
[ironic] make sure secret is created first

### DIFF
--- a/openstack/ironic/templates/secrets.yaml
+++ b/openstack/ironic/templates/secrets.yaml
@@ -9,6 +9,8 @@ metadata:
     # this secret is needed by the migration job, so it needs to be a
     # pre-upgrade hook with a lower weight than the migration job.
     "helm.sh/hook": "pre-upgrade"
+    # if we build a new region this needs to be there for the other deployments to work
+    "helm.sh/hook": "pre-install"
     "helm.sh/hook-weight": "-10"
     "helm.sh/hook-delete-policy": "before-hook-creation"
 type: Opaque

--- a/openstack/ironic/templates/secrets.yaml
+++ b/openstack/ironic/templates/secrets.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     # this secret is needed by the migration job, so it needs to be a
     # pre-upgrade hook with a lower weight than the migration job.
-    "helm.sh/hook": "pre-upgrade"
+    "helm.sh/hook": "pre-install,pre-upgrade"
     # if we build a new region this needs to be there for the other deployments to work
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-weight": "-10"

--- a/openstack/ironic/templates/secrets.yaml
+++ b/openstack/ironic/templates/secrets.yaml
@@ -10,7 +10,6 @@ metadata:
     # pre-upgrade hook with a lower weight than the migration job.
     "helm.sh/hook": "pre-install,pre-upgrade"
     # if we build a new region this needs to be there for the other deployments to work
-    "helm.sh/hook": "pre-install"
     "helm.sh/hook-weight": "-10"
     "helm.sh/hook-delete-policy": "before-hook-creation"
 type: Opaque


### PR DESCRIPTION
Some deployments depend on this secret so we need to create it first. We
do that with a pre-install annotation.
