### PR TITLE
[audit-logs] fix kube-api audit event ES indexing failures

### DIFF
--- a/system/audit-logs/vendor/logstash-audit-external/Chart.yaml
+++ b/system/audit-logs/vendor/logstash-audit-external/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: logstash-audit-external
-version: 2.1.25
+version: 2.1.26
 description: logstash log collector
 maintainers:
   - name: Olaf Heydorn

--- a/system/audit-logs/vendor/logstash-audit-external/templates/_logstash.conf.tpl
+++ b/system/audit-logs/vendor/logstash-audit-external/templates/_logstash.conf.tpl
@@ -213,19 +213,6 @@ filter {
             split {
               field => "items"
           }
-          # ---- clean managedFields ----
-          ruby {
-            code => '
-              mf = event.get("[requestObject][managedFields]")
-              if mf.is_a?(Array)
-                mf.each do |entry|
-                  entry.delete(".") if entry.is_a?(Hash)
-                end
-              elsif mf.is_a?(Hash)
-                mf.delete(".")
-              end
-            '
-          }
 
           if [items][annotations][shoot.gardener.cloud/name] {
             grok {
@@ -247,6 +234,30 @@ filter {
                           event.remove("items")
                 '
          }
+
+          # ---- remove managedFields entirely (contains dot-only keys that ES rejects) ----
+          # Must be AFTER items flatten so the field paths are correct
+          mutate {
+            remove_field => [
+              "[requestObject][metadata][managedFields]",
+              "[responseObject][metadata][managedFields]"
+            ]
+          }
+
+          # ---- fix responseObject.status type conflict ----
+          # When responseObject is a K8s Status (error response), the "status" field
+          # is a string ("Failure"/"Success") which conflicts with the object mapping
+          # from Shoot resources where status is a complex object.
+          if [responseObject][kind] == "Status" {
+            mutate {
+              rename => { "[responseObject][status]" => "[responseObject][statusText]" }
+            }
+          }
+          if [responseStatus][status] {
+            mutate {
+              rename => { "[responseStatus][status]" => "[responseStatus][statusText]" }
+            }
+          }
         }
       }
 

--- a/system/audit-logs/vendor/logstash-audit-external/templates/_logstash.conf.tpl
+++ b/system/audit-logs/vendor/logstash-audit-external/templates/_logstash.conf.tpl
@@ -258,6 +258,17 @@ filter {
               rename => { "[responseStatus][status]" => "[responseStatus][statusText]" }
             }
           }
+
+          # ---- use API server timestamp for correct event ordering ----
+          # requestReceivedTimestamp is when the API server received the request,
+          # which is the authoritative "when did this happen" time.
+          # Without this, @timestamp reflects batching/forwarding time which
+          # causes events from different API servers to appear out of order.
+          date {
+            match => ["requestReceivedTimestamp", "ISO8601"]
+            target => "@timestamp"
+            tag_on_failure => ["_dateparsefailure_requestReceivedTimestamp"]
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

- Remove `managedFields` from `requestObject`/`responseObject` after items flatten to fix "field name cannot contain only dots" ES rejection
- Rename `responseObject.status` to `responseObject.statusText` when `responseObject.kind == "Status"` to fix object/string type mapping conflict
- Remove old broken Ruby filter that targeted wrong field path and ran before items were flattened

## Problem

Successful kube-api audit events (create/update/delete with 200/201 responses) were being rejected by Elasticsearch and sent to dead letter because:

1. **Dot-key issue**: Kubernetes `managedFields` uses `"."` as field names in `fieldsV1` (Server-Side Apply metadata). Elasticsearch rejects field names consisting only of dots.

2. **Type conflict**: `responseObject.status` is an object for Shoot resources (`{hibernated: false, ...}`) but a string (`"Failure"`) for error Status responses. ES cannot handle both types in the same index.

Only error responses (409, 404, etc.) were indexing successfully because they have small `Status` response bodies without `managedFields`.

## Fix

1. Strip `managedFields` entirely (useless for audit, causes the dot-key problem). Placed **after** the items flatten step so field paths resolve correctly.
2. Rename the string `status` field to `statusText` only for Kubernetes Status error responses to avoid the mapping conflict.

## Tested

Applied directly to `qa-de-1` / `audit-logs` namespace ConfigMap. Verified Logstash reload success and dead letter events stopped for both error types.