### PR TITLE
[mariadb][backup-v2] add client-side encryption for S3 uploads     

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.42.0 - 2026/07/07
+* add client-side encryption for backup-v2 S3 uploads (AWS + Ceph targets) via `backup_v2.cse.enabled` and `global.mariadb.backup_v2.cse.{active_key,keys}`
+* chart version bumped
+
 ## v0.41.0 - 2026/07/06
 * support configurable S3 object lock on backup uploads
   * default at `backup_v2.object_lock.{enabled,lock_mode,retention_days}`

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.41.0
+version: 0.42.0
 # scripts/docker-entyrpoint.sh should be updated when appVersion is updated
 appVersion: 10.11.18
 dependencies:

--- a/common/mariadb/templates/backup-v2-cse-secret.yaml
+++ b/common/mariadb/templates/backup-v2-cse-secret.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.backup_v2.enabled }}
+{{- if .Values.backup_v2.cse.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mariadb-backup-{{.Values.name}}-cse
+  labels:
+    {{- include "mariadb.labels" (list $ "noversion" "mariadb" "secret" "backup") | indent 4 }}
+type: Opaque
+data:
+{{- $keys := dig "mariadb" "backup_v2" "cse" "keys" (dict) .Values.global }}
+{{- if eq (len $keys) 0 }}
+{{- fail "backup_v2.cse.enabled is true but global.mariadb.backup_v2.cse.keys is empty" }}
+{{- end }}
+{{- range $name, $value := $keys }}
+  {{ $name | quote }}: {{ required (printf "cse key %q has no value" $name) $value | b64enc | quote }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/common/mariadb/templates/backup-v2-deployment.yaml
+++ b/common/mariadb/templates/backup-v2-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app: {{ include "fullName" . }}-backup
     {{- include "mariadb.labels" (list $ "version" "mariadb" "deployment" "backup") | indent 4 }}
   annotations:
-    secret.reloader.stakater.com/reload: "mariadb-backup-{{.Values.name}}-etc,mariadb-{{.Values.name}}-backup-oauth"
+    secret.reloader.stakater.com/reload: "mariadb-backup-{{.Values.name}}-etc,mariadb-{{.Values.name}}-backup-oauth{{- if .Values.backup_v2.cse.enabled }},mariadb-backup-{{.Values.name}}-cse{{- end }}"
 spec:
   replicas: 1
   revisionHistoryLimit: 5
@@ -105,6 +105,11 @@ spec:
         - name: mariadb-backup-etc
           mountPath: /etc/config
           readOnly: true
+        {{- if .Values.backup_v2.cse.enabled }}
+        - name: mariadb-backup-cse
+          mountPath: /etc/backup/cse
+          readOnly: true
+        {{- end }}
       volumes:
         - name: mariadb-etc
           configMap:
@@ -117,4 +122,10 @@ spec:
         - name: mariadb-backup-etc
           secret:
             secretName: mariadb-backup-{{.Values.name}}-etc
+        {{- if .Values.backup_v2.cse.enabled }}
+        - name: mariadb-backup-cse
+          secret:
+            secretName: mariadb-backup-{{.Values.name}}-cse
+            defaultMode: 0400
+        {{- end }}
 {{- end }}

--- a/common/mariadb/templates/backup-verify-deploy.yaml
+++ b/common/mariadb/templates/backup-verify-deploy.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "mariadb.labels" (list $ "version" "mariadb" "deployment" "backupverification") | indent 4 }}
   annotations:
-    secret.reloader.stakater.com/reload: "mariadb-backup-{{.Values.name}}-etc"
+    secret.reloader.stakater.com/reload: "mariadb-backup-{{.Values.name}}-etc{{- if .Values.backup_v2.cse.enabled }},mariadb-backup-{{.Values.name}}-cse{{- end }}"
 spec:
   replicas: 1
   revisionHistoryLimit: 5
@@ -48,8 +48,19 @@ spec:
           - name: mariadb-backup-etc
             mountPath: /etc/config
             readOnly: true
+          {{- if .Values.backup_v2.cse.enabled }}
+          - name: mariadb-backup-cse
+            mountPath: /etc/backup/cse
+            readOnly: true
+          {{- end }}
       volumes:
         - name: mariadb-backup-etc
           secret:
             secretName:  mariadb-backup-{{.Values.name}}-etc
+        {{- if .Values.backup_v2.cse.enabled }}
+        - name: mariadb-backup-cse
+          secret:
+            secretName: mariadb-backup-{{.Values.name}}-cse
+            defaultMode: 0400
+        {{- end }}
 {{- end }}

--- a/common/mariadb/templates/config/_backup_config.yaml.tpl
+++ b/common/mariadb/templates/config/_backup_config.yaml.tpl
@@ -31,6 +31,16 @@ database:
     - "{{$tl}}"
   {{- end }}
 storages:
+  {{- if .Values.backup_v2.cse.enabled }}
+    {{- $active := dig "mariadb" "backup_v2" "cse" "active_key" "" .Values.global }}
+    {{- if not $active }}
+      {{- fail "global.mariadb.backup_v2.cse.active_key required when backup_v2.cse.enabled" }}
+    {{- end }}
+    {{- $cseKeys := dig "mariadb" "backup_v2" "cse" "keys" (dict) .Values.global }}
+    {{- if not (hasKey $cseKeys $active) }}
+      {{- fail (printf "global.mariadb.backup_v2.cse.active_key %q not found in global.mariadb.backup_v2.cse.keys (have: %v)" $active (keys $cseKeys)) }}
+    {{- end }}
+  {{- end }}
   {{- $cephTargets := list }}
   {{- if .Values.backup_v2.ceph_s3.enabled }}
     {{- $cephTargets = default (list) (dig "mariadb" "backup_v2" "ceph_s3" "targets" (list) .Values.global) }}
@@ -61,6 +71,14 @@ storages:
       {{- if $awsObjectLock }}
       {{- $awsObjectLock | nindent 6 }}
       {{- end }}
+      {{- if $.Values.backup_v2.cse.enabled }}
+      cse_active_key: {{ (dig "mariadb" "backup_v2" "cse" "active_key" "" $.Values.global) | quote }}
+      cse_keys:
+        {{- range $name, $_ := (dig "mariadb" "backup_v2" "cse" "keys" (dict) $.Values.global) }}
+        - name: {{ $name | quote }}
+          file: "/etc/backup/cse/{{ $name }}"
+        {{- end }}
+      {{- end }}
     {{- end }}
     {{- range $t := $cephTargets }}
     {{- $region := default $.Values.global.region $t.region }}
@@ -77,6 +95,14 @@ storages:
       {{- $cephObjectLock := include "mariadb.backup_v2.object_lock" (dict "target" $t.object_lock "default" $.Values.backup_v2.object_lock) }}
       {{- if $cephObjectLock }}
       {{- $cephObjectLock | nindent 6 }}
+      {{- end }}
+      {{- if $.Values.backup_v2.cse.enabled }}
+      cse_active_key: {{ (dig "mariadb" "backup_v2" "cse" "active_key" "" $.Values.global) | quote }}
+      cse_keys:
+        {{- range $name, $_ := (dig "mariadb" "backup_v2" "cse" "keys" (dict) $.Values.global) }}
+        - name: {{ $name | quote }}
+          file: "/etc/backup/cse/{{ $name }}"
+        {{- end }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -262,6 +262,22 @@ backup_v2:
     enabled: false
     lock_mode: COMPLIANCE # or GOVERNANCE
     retention_days: 7
+  cse:
+    # Client-side encryption for backups uploaded to S3 (AWS and every Ceph target).
+    enabled: false
+    # KEK material and active-key selection live under global.mariadb.backup_v2.cse
+    # (shared across every s3 storage):
+    #   global:
+    #     mariadb:
+    #       backup_v2:
+    #         cse:
+    #           active_key: kek-2026-q3         # required when cse.enabled; must be a key in `keys` below
+    #           keys:                            # base64-encoded 32 bytes per KEK, e.g. `openssl rand -base64 32`
+    #             kek-2026-q3: vault+kvv2:///secrets/.../cse-kek-2026-q3
+    #             kek-2026-q2: vault+kvv2:///secrets/.../cse-kek-2026-q2   # kept so older backups decrypt
+    # New backups are encrypted under active_key; any KEK in `keys` can decrypt historical backups.
+    # Kubernetes base64-decodes the Secret `data` field on mount, so /etc/backup/cse/<name>
+    # holds the 32 raw bytes the backup binary's loadCSEKey consumes.
   swift:
     enabled: true
     user_name: db_backup


### PR DESCRIPTION
* add client-side encryption for backup-v2 S3 uploads (AWS + Ceph targets) via `backup_v2.cse.enabled` and `global.mariadb.backup_v2.cse.{active_key,keys}`
* chart version bumped