### PR TITLE
[limes] increase memory for eu-de-1 limes-data-metrics

### DIFF
--- a/openstack/limes/templates/deployment-data-metrics.yaml
+++ b/openstack/limes/templates/deployment-data-metrics.yaml
@@ -1,3 +1,5 @@
+{{- $region := .Values.global.region       | required "missing value for .Values.global.region"       -}}
+
 kind: Deployment
 apiVersion: apps/v1
 
@@ -62,8 +64,16 @@ spec:
           resources:
             limits:
                 cpu: '1'
+                {{- if eq $region "eu-de-1" }}
+                memory: '800Mi'
+                {{- else }}
                 memory: '600Mi'
+                {{- end }}
             requests:
                 cpu: '100m'
+                {{- if eq $region "eu-de-1" }}
+                memory: '800Mi'
+                {{- else }}
                 memory: '600Mi'
+                {{- end }}
           {{- end }}


### PR DESCRIPTION
unfortunately we are running OOM frequently. We will try to get rid of the old metrics exporter ASAP, so this is the workaround for now.