### PR TITLE
[nova-hypervisor-agents] Reduce max_queues to 8

### DIFF
--- a/openstack/nova-hypervisor-agents/values.yaml
+++ b/openstack/nova-hypervisor-agents/values.yaml
@@ -92,6 +92,7 @@ defaults:
           volume_use_multipath: true
           cpu_mode: "custom"
           cpu_model: "sapphire-rapids"
+          max_queues: 8
         os_vif_ovs:
           ovsdb_connection: "unix:/run/openvswitch/db.sock"
         workarounds:


### PR DESCRIPTION
In benchmarks it showed that using less queues provides better performance. Additionally, having too many queues through all of the interfaces currently blocks live-migration.