### PR TITLE
[NSXT]: Add ownership for livenessProbe

### DIFF
--- a/openstack/neutron/templates/vct-nsxv3-agent-deployment.yaml
+++ b/openstack/neutron/templates/vct-nsxv3-agent-deployment.yaml
@@ -83,6 +83,8 @@ template: |
             initialDelaySeconds: 200
             periodSeconds: 30
             timeoutSeconds: 10
+          {{- else }}
+          livenessProbe: null
           {{- end }}
           resources:
 {{ toYaml .Values.pod.resources.nsxv3_agent | indent 12 }}


### PR DESCRIPTION
The ultimate goal is to remove the livenessProbe from our NSXT agent deployments.

This was not working for some deployments as they had another owner for the livenessProbe. By design, a K8s SSA apply does not remove such fields. Cleaning up the managed field (https://github.com/sapcc/vcenter-operator/pull/78), which stores the ownership of fields, does not resolve the issue as we now run into the case where there isn't any owner defined at all. It seems that the field isn't deleted either. With this commit, vcenter-operator takes ownership again and removal should finally work.