### PR TITLE
[octavia] bump utils to 0.38.0 for OTLP osprofiler support

### DIFF
--- a/openstack/octavia/Chart.lock
+++ b/openstack/octavia/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.39.0
+  version: 0.37.0
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.4.1
@@ -16,7 +16,7 @@ dependencies:
   version: 0.22.1
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.37.1
+  version: 0.38.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
@@ -26,5 +26,5 @@ dependencies:
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.2.19
-digest: sha256:a6d9f6236fc45f7a5e4fc2010061c599697e3b2bbeefcb6cd48fde77587f9823
-generated: "2026-06-26T15:37:23.589492+03:00"
+digest: sha256:b7734916db985be15d03dcab9c0ccfa705375658bbaa530e41ee70cbbc649bba
+generated: "2026-06-30T11:29:53.48830787+02:00"

--- a/openstack/octavia/Chart.yaml
+++ b/openstack/octavia/Chart.yaml
@@ -32,7 +32,7 @@ dependencies:
     version: 0.22.1
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.37.1
+    version: 0.38.0
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0


### PR DESCRIPTION
Picks up utils changes since 0.37.1:
- 0.37.2: use non-deprecated topology as default
- 0.38.0: make osprofiler connection_string configurable for OTLP support; the jaeger agent sidecar is now only deployed when using the jaeger:// scheme, making it superfluous for OTLP setups