### PR TITLE
[glance] bump utils to 0.38.0 for OTLP osprofiler support

### DIFF
--- a/openstack/glance/Chart.lock
+++ b/openstack/glance/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.39.0
+  version: 0.35.1
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.5.0
@@ -13,7 +13,7 @@ dependencies:
   version: 0.6.0
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.36.0
+  version: 0.38.0
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.4.0
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:fd996ed6d106bfee6b5f6bdc556a4282fae481b2bc41d7beadfeac78a1ce9bcd
-generated: "2026-06-26T15:24:39.485709+03:00"
+digest: sha256:5a4a82a14f88423e42dfc95a5b4ab88495532a12836559b3f3a044a17deb4e30
+generated: "2026-06-30T11:31:25.779222963+02:00"

--- a/openstack/glance/Chart.yaml
+++ b/openstack/glance/Chart.yaml
@@ -24,7 +24,7 @@ dependencies:
     version: 0.6.0
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.36.0
+    version: 0.38.0
   - name: redis
     alias: api-ratelimit-redis
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm


### PR DESCRIPTION
Picks up utils changes since 0.36.0:
- 0.37.0: add values-driven ProxySQL query cache rules
- 0.37.1: fix ProxySQL query cache rules to use match_digest
- 0.37.2: use non-deprecated topology as default
- 0.38.0: make osprofiler connection_string configurable for OTLP support; the jaeger agent sidecar is now only deployed when using the jaeger:// scheme, making it superfluous for OTLP setups