### PR TITLE
[designate] bump utils to 0.38.0 for OTLP osprofiler support

### DIFF
--- a/openstack/designate/Chart.lock
+++ b/openstack/designate/Chart.lock
@@ -19,7 +19,7 @@ dependencies:
   version: 0.25.2
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.36.0
+  version: 0.38.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
@@ -29,5 +29,5 @@ dependencies:
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.4.62
-digest: sha256:252d2794c36a208609863340d69e340920107fc0380a83bd44f448b3f191b3de
-generated: "2026-06-26T15:24:15.666284+03:00"
+digest: sha256:19dae4a0f7e27dc15bd0be3e7fe8d6ee1fa720e5521d9748f44d5098fe4ac57c
+generated: "2026-06-30T11:31:57.579384303+02:00"

--- a/openstack/designate/Chart.yaml
+++ b/openstack/designate/Chart.yaml
@@ -31,7 +31,7 @@ dependencies:
     version: 0.25.2
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.36.0
+    version: 0.38.0
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0


### PR DESCRIPTION
Picks up utils changes since 0.36.0:
- 0.37.0: add values-driven ProxySQL query cache rules
- 0.37.1: fix ProxySQL query cache rules to use match_digest
- 0.37.2: use non-deprecated topology as default
- 0.38.0: make osprofiler connection_string configurable for OTLP support; the jaeger agent sidecar is now only deployed when using the jaeger:// scheme, making it superfluous for OTLP setups