### PR TITLE
[neutron] bump utils to 0.38.0 for OTLP osprofiler support

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 0.22.2
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.35.0
+  version: 0.38.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
@@ -32,5 +32,5 @@ dependencies:
 - name: ovsdb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
-digest: sha256:74a66772651a6d94c7fb3c050f32304cd633a311c14228944db43f1606dbacbb
-generated: "2026-04-20T12:17:41.874047+03:00"
+digest: sha256:d40a8bacf15e202103ce91ff2eebd9f0e3dcd9027b1b319b6516f159bee89c5b
+generated: "2026-06-30T11:32:42.425715541+02:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     version: 0.22.2
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.35.0
+    version: 0.38.0
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0


### PR DESCRIPTION
Picks up utils changes since 0.35.0:
- 0.36.0: coordination: switch to "storageClassName" attribute
- 0.37.0: add values-driven ProxySQL query cache rules
- 0.37.1: fix ProxySQL query cache rules to use match_digest
- 0.37.2: use non-deprecated topology as default
- 0.38.0: make osprofiler connection_string configurable for OTLP support; the jaeger agent sidecar is now only deployed when using the jaeger:// scheme, making it superfluous for OTLP setups