### PR TITLE
[nova] bump utils to 0.38.0 for OTLP osprofiler support

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -25,7 +25,7 @@ dependencies:
   version: 0.6.15
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.34.0
+  version: 0.38.0
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.39.0
@@ -59,5 +59,5 @@ dependencies:
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.25.0
-digest: sha256:945464a4563df7a316960604da5ef915ee6dbe864d2fafa41532baafbfecdac3
-generated: "2026-06-26T15:27:57.567107+03:00"
+digest: sha256:39059e9e9058facd97787135d4ed523b509fd4d97825417222ead1e46a5fba09
+generated: "2026-06-30T11:33:18.358424646+02:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -42,7 +42,7 @@ dependencies:
     version: 0.6.15
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.34.0
+    version: 0.38.0
   - alias: mariadb_cell2
     condition: mariadb_cell2.enabled
     name: mariadb


### PR DESCRIPTION
Picks up utils changes since 0.34.0:
- 0.35.0: allow disabling sentry in helper
- 0.36.0: coordination: switch to "storageClassName" attribute
- 0.37.0: add values-driven ProxySQL query cache rules
- 0.37.1: fix ProxySQL query cache rules to use match_digest
- 0.37.2: use non-deprecated topology as default
- 0.38.0: make osprofiler connection_string configurable for OTLP support; the jaeger agent sidecar is now only deployed when using the jaeger:// scheme, making it superfluous for OTLP setups