### PR TITLE
[placement] bump utils to 0.38.0 for OTLP osprofiler support

### DIFF
--- a/openstack/placement/Chart.lock
+++ b/openstack/placement/Chart.lock
@@ -10,12 +10,12 @@ dependencies:
   version: 0.6.10
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.34.0
+  version: 0.38.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.0
-digest: sha256:e9cb08ef41a2a10e20c46d5608ea845ba246993d3062cd112ea85364189af14b
-generated: "2026-06-26T15:37:48.407428+03:00"
+digest: sha256:80ae1f57248df24fdc5ee5e9198575bdf09ba20ef129b961784af3633a255f38
+generated: "2026-06-30T11:34:02.932837711+02:00"

--- a/openstack/placement/Chart.yaml
+++ b/openstack/placement/Chart.yaml
@@ -20,7 +20,7 @@ dependencies:
     version: 0.6.10
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.34.0
+    version: 0.38.0
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0


### PR DESCRIPTION
Picks up utils changes since 0.34.0:
- 0.35.0: allow disabling sentry in helper
- 0.36.0: coordination: switch to "storageClassName" attribute
- 0.37.0: add values-driven ProxySQL query cache rules
- 0.37.1: fix ProxySQL query cache rules to use match_digest
- 0.37.2: use non-deprecated topology as default
- 0.38.0: make osprofiler connection_string configurable for OTLP support; the jaeger agent sidecar is now only deployed when using the jaeger:// scheme, making it superfluous for OTLP setups