### PR TITLE
[keystone] bump utils to 0.38.0 for OTLP osprofiler support

### DIFF
--- a/openstack/keystone/Chart.lock
+++ b/openstack/keystone/Chart.lock
@@ -19,7 +19,7 @@ dependencies:
   version: 1.3.3
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.32.0
+  version: 0.38.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1

--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -36,7 +36,7 @@ dependencies:
     version: 1.3.3
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.32.0
+    version: 0.38.0
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.1.1


### PR DESCRIPTION
Picks up utils changes since 0.32.0:
- 0.33.0: switch to sapcc/kubernetes-entrypoint
- 0.34.0: use clusterDNSSearchDomain for k8s service urls
- 0.35.0: allow disabling sentry in helper
- 0.36.0: coordination: switch to "storageClassName" attribute
- 0.37.0: add values-driven ProxySQL query cache rules
- 0.37.1: fix ProxySQL query cache rules to use match_digest
- 0.37.2: use non-deprecated topology as default
- 0.38.0: make osprofiler connection_string configurable for OTLP support; the jaeger agent sidecar is now only deployed when using the jaeger:// scheme, making it superfluous for OTLP setups