### PR TITLE
[nova-hypervisor-agents] bump utils to ~0.38.0 for OTLP osprofiler support

### DIFF
--- a/openstack/nova-hypervisor-agents/Chart.lock
+++ b/openstack/nova-hypervisor-agents/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.32.0
+  version: 0.38.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:7a75b1f1379ac7c82144455bd1a7a720e02d881af76e190822dd7e21947a100d
-generated: "2026-03-24T14:17:02.495544859+01:00"
+digest: sha256:c121d347f263157660e4e4200ba86e105a849542b5beb53282e8b73cb85b953c
+generated: "2026-06-30T11:35:13.620844514+02:00"

--- a/openstack/nova-hypervisor-agents/Chart.yaml
+++ b/openstack/nova-hypervisor-agents/Chart.yaml
@@ -7,7 +7,7 @@ appVersion: "bobcat"
 dependencies:
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: ~0.32.0
+  version: ~0.38.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: ~1.0.0


### PR DESCRIPTION
Picks up utils changes since 0.32.0:
- 0.33.0: switch to sapcc/kubernetes-entrypoint
- 0.34.0: use clusterDNSSearchDomain for k8s service urls
- 0.35.0: allow disabling sentry in helper
- 0.36.0: coordination: switch to "storageClassName" attribute
- 0.37.0: add values-driven ProxySQL query cache rules
- 0.37.1: fix ProxySQL query cache rules to use match_digest
- 0.37.2: use non-deprecated topology as default
- 0.38.0: make osprofiler connection_string configurable for OTLP support; the jaeger agent sidecar is now only deployed when using the jaeger:// scheme, making it superfluous for OTLP setups