### PR TITLE
[neutron-hypervisor-agents] bump utils to ~0.38.0 for OTLP osprofiler support

### DIFF
--- a/openstack/neutron-hypervisor-agents/Chart.lock
+++ b/openstack/neutron-hypervisor-agents/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.31.1
+  version: 0.38.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:229d8583f957f68b358bb63cf2ce90f498b7eac5c87b4bf81bf0ecbf354dce74
-generated: "2025-10-22T11:50:23.356734143+02:00"
+digest: sha256:c121d347f263157660e4e4200ba86e105a849542b5beb53282e8b73cb85b953c
+generated: "2026-06-30T11:35:59.808295792+02:00"

--- a/openstack/neutron-hypervisor-agents/Chart.yaml
+++ b/openstack/neutron-hypervisor-agents/Chart.yaml
@@ -7,7 +7,7 @@ appVersion: "caracal"
 dependencies:
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: ~0.31.0
+  version: ~0.38.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: ~1.0.0


### PR DESCRIPTION
Picks up utils changes since 0.31.x:
- 0.32.0: add an option to ignore users in proxysql.cfg
- 0.33.0: switch to sapcc/kubernetes-entrypoint
- 0.34.0: use clusterDNSSearchDomain for k8s service urls
- 0.35.0: allow disabling sentry in helper
- 0.36.0: coordination: switch to "storageClassName" attribute
- 0.37.0: add values-driven ProxySQL query cache rules
- 0.37.1: fix ProxySQL query cache rules to use match_digest
- 0.37.2: use non-deprecated topology as default
- 0.38.0: make osprofiler connection_string configurable for OTLP support; the jaeger agent sidecar is now only deployed when using the jaeger:// scheme, making it superfluous for OTLP setups