### PR TITLE
[manila] drop snapshot policy from driver_updatable_metadata

### DIFF
--- a/openstack/manila/templates/etc/_manila.conf.tpl
+++ b/openstack/manila/templates/etc/_manila.conf.tpl
@@ -65,7 +65,9 @@ server_migration_driver_continue_update_interval = {{ .Values.server_migration_d
 server_migration_extend_neutron_network = {{ .Values.server_migration_extend_neutron_network | default true }}
 ensure_driver_resources_interval = {{ .Values.ensure_driver_resources_interval | default 14400 }}
 
-driver_updatable_metadata = snapshot_policy,cross_dedup_disabled
+# SCI: we don't want snapshot_policy here as driver_updatable_metadata,
+# because we configured 'netapp_volume_snapshot_policy_exceptions' option
+driver_updatable_metadata = cross_volume_dedupe
 driver_updatable_subnet_metadata = showmount,pnfs
 # Prevent shares from transitioning to 'ensuring' status (2025.1 default changed to True)
 update_shares_status_on_ensure = False


### PR DESCRIPTION
if driver_updatable_metadata is set in extra specs, then manila will
set the metadata explicitly to the value that is set there.
In our case this would be 'snapshot_policy=none', which would be
confusing for our customers, who are currently not exposed to that
setting - we normally don't offer different options for snapshot
policies.
Furthermore since metadata has highest priority, this would override
the snapshot policies even for the
'netapp_volume_snapshot_policy_exceptions' expection list, which is not
what we want.

cross_volume_dedupe is the new name for the setting that controls
whether cross-volume deduplication is enabled or not.
The old name has been changed after code review.
