### PR TITLE
[rabbitmq] update to 4.3.2

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+## 0.25.5 - 2026/07/02
+
+- RabbitMQ [4.3.2 Release notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.3.2)
+- `rabbitmq-user-credential-updater` updated to `20260630105135` version
+- Chart version bumped
+
 ## 0.25.4 - 2026/07/01
 
 - Fix `projectcalico.org/loadBalancerIPs` annotation needing JSON as value

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: v1
 name: rabbitmq
-version: 0.25.4
-appVersion: 4.3.1
+version: 0.25.5
+appVersion: 4.3.2
 description: A Helm chart for RabbitMQ
 sources:
   - https://github.com/sapcc/helm-charts/common/rabbitmq

--- a/common/rabbitmq/values.yaml
+++ b/common/rabbitmq/values.yaml
@@ -11,7 +11,7 @@ global:
       enabled: true
 
 image: library/rabbitmq
-imageTag: 4.3.1-management
+imageTag: 4.3.2-management
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -134,7 +134,7 @@ customConfig:
 credentialUpdater:
   enabled: true
   image: rabbitmq-user-credential-updater
-  imageTag: '20260521084806'
+  imageTag: '20260630105135'
 
 enableSsl: true
 addServiceNameToDnsNames: true


### PR DESCRIPTION
- RabbitMQ [4.3.2 Release notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.3.2)
- `rabbitmq-user-credential-updater` updated to `20260630105135` version
- Chart version bumped