### PR TITLE
keppel: bump memlimit for janitor

### DIFF
--- a/openstack/keppel/templates/deployment-janitor.yaml
+++ b/openstack/keppel/templates/deployment-janitor.yaml
@@ -75,13 +75,13 @@ spec:
               port: 80
             timeoutSeconds: 5
             periodSeconds: 5
-          # NOTE: observed resource usage in eu-de-1 (as of 2025-03)
+          # NOTE: observed resource usage in eu-de-1 (as of 2026-06)
           # - CPU: 800m, spiky
-          # - RAM: settles at about 400Mi after a few hours, leaks about 200Mi per day (but one OOM kill per day is acceptable IMO)
+          # - RAM: very spiky, 200-600Mi for most regions and higher spikes for the larger ones
           resources:
             requests:
               cpu: "2"
-              memory: "800Mi"
+              memory: "1Gi"
             limits:
               cpu: "2"
-              memory: "800Mi"
+              memory: "1Gi"


### PR DESCRIPTION
800 MiB is too small at this point. We should consider splitting the Trivy thing off into its own job that we can scale out........