### PR TITLE
feat(cc-ceph-csi): make operator replicas configurable

### DIFF
--- a/system/cc-ceph-csi/Chart.yaml
+++ b/system/cc-ceph-csi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cc-ceph-csi
 description: A minimal Helm chart for the Rook operator to run Ceph and CSI components
 type: application
-version: 0.4.13
+version: 0.4.14
 appVersion: 1.17.1
 dependencies:
   - name: owner-info

--- a/system/cc-ceph-csi/templates/deployment.yaml
+++ b/system/cc-ceph-csi/templates/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       app: rook-ceph-operator
   strategy:
     type: Recreate
-  replicas: 1
+  replicas: {{ .Values.operator.replicas | default 1 }}
   template:
     metadata:
       labels:

--- a/system/cc-ceph-csi/values.yaml
+++ b/system/cc-ceph-csi/values.yaml
@@ -3,14 +3,15 @@ owner-info:
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/system/cc-ceph-csi
 
 registries:
-  #docker: docker.io/library
+  # docker: docker.io/library
   docker: keppel.global.cloud.sap/ccloud-dockerhub-mirror
-  #quay: quay.io
+  # quay: quay.io
   quay: keppel.global.cloud.sap/ccloud-quay-mirror
-  #k8s: registry.k8s.io
+  # k8s: registry.k8s.io
   k8s: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror
 
 operator:
+  replicas: 1
   image: rook/ceph:v1.17.1
   logLevel: INFO # The logging level for the operator: ERROR | WARNING | INFO | DEBUG
   metricAddress: :8080
@@ -49,25 +50,25 @@ cluster:
   mgrCount: 3
   storage:
     defaultStorageClass: true
-    #useAllNodes: true
-    #useAllDevices: false
-    #deviceFilter: "nvme[1-7].*"
-    #nodes:
-    #- name: xyz
-    #  deviceFilter: ^nvme([0-9]|1[0-9])n1
+    # useAllNodes: true
+    # useAllDevices: false
+    # deviceFilter: "nvme[1-7].*"
+    # nodes:
+    # - name: xyz
+    #   deviceFilter: ^nvme([0-9]|1[0-9])n1
     pvcs:
       enabled: false # use pvcs instead of host volumes
-      #count: 3
-      #portable: true
-      #storageClass: cinder-default
-      #size: 100Gi
-      #monSize: 10Gi
+      # count: 3
+      # portable: true
+      # storageClass: cinder-default
+      # size: 100Gi
+      # monSize: 10Gi
   redundancy:
     replicas: 4
     failureDomain: host
-    #subFailureDomain:
-    #topologyDomainLabel:
-    #customHostnameLabel:
+    # subFailureDomain:
+    # topologyDomainLabel:
+    # customHostnameLabel:
   
   toolbox:
     enabled: true


### PR DESCRIPTION
Make the rook-ceph-operator deployment replicas configurable via `.Values.operator.replicas`, defaulting to 1.