### PR TITLE
keppel: add .Values.keppel.driver option, set KEPPEL_TRACK_BYTES_QUOTA

### DIFF
--- a/openstack/keppel/templates/_utils.tpl
+++ b/openstack/keppel/templates/_utils.tpl
@@ -110,6 +110,8 @@
     secretKeyRef:
       name: keppel-redis-user-default
       key: password
+- name: KEPPEL_TRACK_BYTES_QUOTA
+  value: {{ ne .Values.keppel.driver "swift" | quote }}
 - name: KEPPEL_TRIVY_ADDITIONAL_PULLABLE_REPOS
   value: "ccloud-ghcr-io-mirror/aquasecurity/trivy-db,ccloud-ghcr-io-mirror/aquasecurity/trivy-java-db"
 - name: KEPPEL_TRIVY_URL

--- a/openstack/keppel/values.yaml
+++ b/openstack/keppel/values.yaml
@@ -18,6 +18,9 @@ linkerd-support:
 keppel:
   image_tag: DEFINED_BY_PIPELINE
 
+  # Which storage driver to use. Can be one of "swift", "ceph" or "both" (the latter for migration from Swift to Ceph).
+  driver: swift
+
   slim: false # set to true for deployments to the small QA regions
 
   # May have a key for each region. Certain values can be overridden here


### PR DESCRIPTION
Counterproposal to #12126. The KEPPEL_TRACK_BYTES_QUOTA setting depends on which storage driver we want to use. For qa-de-1, we will have "both" for migration testing. For eu-de-3, we will have "ceph" only. Everything else stays on "swift" for now.