### PR TITLE
feat(cc-gardener): enable InPlaceNodeUpdates feature gate

### DIFF
--- a/global/cc-gardener/Chart.yaml
+++ b/global/cc-gardener/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cc-gardener
 description: Converged Cloud Gardener setup based on gardener-operator
 type: application
-version: 0.37.3
+version: 0.37.4
 appVersion: "v1.144.2"
 home: https://github.com/gardener/gardener
 dependencies:

--- a/global/cc-gardener/templates/garden.yaml
+++ b/global/cc-gardener/templates/garden.yaml
@@ -156,6 +156,8 @@ spec:
     gardener:
       clusterIdentity: {{ .Values.global.clusterIdentity | default .Values.global.cluster }}
       gardenerAPIServer:
+        featureGates:
+          InPlaceNodeUpdates: true
         admissionPlugins:
         - name: ShootVPAEnabledByDefault
           disabled: true


### PR DESCRIPTION
## Summary

Enable the `InPlaceNodeUpdates` alpha feature gate on `gardener-apiserver`.

## What this does

This allows setting worker pool update strategy to:
- `AutoInPlaceUpdate`
- `ManualInPlaceUpdate`

in the Shoot API, enabling node OS updates without rolling replacement of nodes.

## Reference

- Feature gate added in Gardener v1.113 (Alpha)
- Upstream: [`pkg/features/features.go`](https://github.com/gardener/gardener/blob/master/pkg/features/features.go)
- Docs: [feature_gates.md](https://github.com/gardener/gardener/blob/master/docs/deployment/feature_gates.md)

## Changes

- `templates/garden.yaml`: add `featureGates.InPlaceNodeUpdates: true` to `gardenerAPIServer`
- `Chart.yaml`: version bump 0.37.3 → 0.37.4