### PR TITLE
feat(cc-gardener): support featureGates for gardener-apiserver

### DIFF
--- a/global/cc-gardener/Chart.yaml
+++ b/global/cc-gardener/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cc-gardener
 description: Converged Cloud Gardener setup based on gardener-operator
 type: application
-version: 0.37.3
+version: 0.37.4
 appVersion: "v1.144.2"
 home: https://github.com/gardener/gardener
 dependencies:

--- a/global/cc-gardener/templates/garden.yaml
+++ b/global/cc-gardener/templates/garden.yaml
@@ -156,6 +156,10 @@ spec:
     gardener:
       clusterIdentity: {{ .Values.global.clusterIdentity | default .Values.global.cluster }}
       gardenerAPIServer:
+        {{- with .Values.garden.gardenerAPIServer.featureGates }}
+        featureGates:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         admissionPlugins:
         - name: ShootVPAEnabledByDefault
           disabled: true

--- a/global/cc-gardener/values.yaml
+++ b/global/cc-gardener/values.yaml
@@ -254,6 +254,9 @@ operator:
               tag: "v0.7.0"
 garden:
   name: garden
+  gardenerAPIServer:
+    featureGates: {}
+    # InPlaceNodeUpdates: true
   # externalIP: ""
   managedresources: true # disable on inital deployment
   backup:


### PR DESCRIPTION
## Summary

Add templating support for `gardenerAPIServer.featureGates` in the Garden resource. Feature gates default to empty (no-op) and can be **opted-in** via regional values files.

## Usage

In your regional/environment values file:

```yaml
garden:
  gardenerAPIServer:
    featureGates:
      InPlaceNodeUpdates: true
```

## Changes

- `templates/garden.yaml`: add conditional `featureGates` block under `gardenerAPIServer` using `{{- with }}`
- `values.yaml`: add `garden.gardenerAPIServer.featureGates: {}` default (no-op)
- `Chart.yaml`: version bump 0.37.3 → 0.37.4

## Testing

```bash
# Without feature gates (no change in rendered output)
helm template test . -f ci/test-values.yaml

# With feature gates enabled
helm template test . -f ci/test-values.yaml --set garden.gardenerAPIServer.featureGates.InPlaceNodeUpdates=true
```