### PR TITLE
keppel: adjust config and seeds for Ceph driver and migration usecase

### DIFF
--- a/openstack/keppel/templates/_utils.tpl
+++ b/openstack/keppel/templates/_utils.tpl
@@ -61,7 +61,11 @@
 - name:  KEPPEL_DRIVER_RATELIMIT
   value: {{ include "driver_config_ratelimit" $ | fromYaml | toJson | quote }}
 - name:  KEPPEL_DRIVER_STORAGE
+  {{- if eq .Values.keppel.driver "ceph" }}
+  value: '{"type":"swift","params":{"service_type":"object-store-ceph","use_service_user_project":true}}'
+  {{- else }}{{/* TODO: if eq .Values.keppel.driver "multi", use that driver once it exists */}}
   value: '{"type":"swift"}'
+  {{- end }}
 - name:  KEPPEL_FEDERATION_OS_AUTH_URL
   value: "https://identity-3.{{ $peer_group.leader }}.{{ $tld }}/v3"
 - name:  KEPPEL_FEDERATION_OS_AUTH_VERSION
@@ -135,9 +139,17 @@
       name: keppel-secret
       key: service_user_password
 - name:  OS_PROJECT_DOMAIN_NAME
+  {{- if eq .Values.keppel.driver "swift" }}
   value: 'ccadmin'
+  {{- else }}
+  value: 'Default'
+  {{- end }}
 - name:  OS_PROJECT_NAME
+  {{- if eq .Values.keppel.driver "swift" }}
   value: 'cloud_admin'
+  {{- else }}
+  value: 'keppel-payloads'
+  {{- end }}
 - name:  OS_REGION_NAME
   value: {{ quote $region }}
 - name:  OS_USER_DOMAIN_NAME

--- a/openstack/keppel/templates/seed.yaml
+++ b/openstack/keppel/templates/seed.yaml
@@ -34,8 +34,6 @@ spec:
             - project: service
               role:    service
             - project: service
-              role:    admin          # for keppel-health-monitor (creating a Keppel account includes creating role assignments)
-            - project: service
               role:    registry_admin # for keppel-health-monitor
         {{- if eq $region "qa-de-1" }}
         - name: keppel_e2e
@@ -68,6 +66,19 @@ spec:
             - project: service
               role:    registry_viewer # worthless role assignment, used only to enable Keystone login (actual access to relevant Keppel accounts is given by RBAC policies)
         {{- end }}
+      {{- if ne .Values.keppel.driver "swift" }}{{/* TODO: seed Ceph account in this project (TODO: how?) */}}
+      projects:
+        - name: keppel-payloads
+          role_assignments:
+            - user: keppel@Default
+              role: service           # to validate users' Keystone tokens
+            - user: keppel@Default
+              role: objectstore_admin # to read/write objects (blobs, manifests, reports) in this project's Ceph account
+            {{- if eq .Values.keppel.driver "both" }}
+            - user: keppel@Default
+              role: cloud_objectstore_admin # to read/write objects (blobs, manifests, reports) in customers' Swift accounts
+            {{- end }}
+      {{- end }}
 
     - name: ccadmin
       groups:
@@ -97,11 +108,13 @@ spec:
         {{- end }}
       projects:
         - name: cloud_admin
+          {{- if ne .Values.keppel.driver "ceph" }}
           role_assignments:
             - user: keppel@Default
               role: service       # to validate users' Keystone tokens
             - user: keppel@Default
               role: cloud_objectstore_admin # to read/write blobs and manifests from/into customer's Swift accounts
+          {{- end }}
         - name: master
           role_assignments:
             - user: keppel@Default


### PR DESCRIPTION
- For driver "swift", nothing changes (verified with `helm diff upgrade` in prod), except that I removed a role assignment for `admin` from the seed. This role assignment was only relevant back when the Keppel service user did not operate in Swift with `cloud_objectstore_admin` permissions, and instead gave itself `objectstore_admin` in all relevant customer projects at account creation time. This behavior was removed years ago, but I did not update the seed at the time.
- For driver "ceph", this adds a new project `keppel-payloads@Default` and configures Keppel to authenticate into that project scope, with the storage driver configured to use Ceph and keep its writes localized within the local project.
- The driver "multi" represents the migration usecase and thus is a hybrid of both scenarios: We set up everything like we do for Ceph (so that writing into the Ceph account works in the expected way), but also give our service user `cloud_objectstore_admin` so it can still reach all the payloads stored in Swift accounts across all relevant customer projects. For now, this scenario runs with the regular Swift driver because the `multi` driver is not yet implemented.