### PR TITLE
feat(aurora): update _env.tpl to provide cookie domain

### DIFF
--- a/openstack/aurora/templates/_env.tpl
+++ b/openstack/aurora/templates/_env.tpl
@@ -1,3 +1,7 @@
+{{- $host := .Values.ingress.host | default (printf "dashboard-aurora.%s.%s" .Values.global.region .Values.global.tld) -}}
+{{- $parts := splitList "." $host -}}
+{{- $cookieDomain := printf ".%s" (join "." (rest $parts)) -}}
+
 - name: PORT
   value: {{ .Values.port | quote }}
 - name: IDENTITY_ENDPOINT
@@ -5,3 +9,5 @@
   value: {{ .Values.identity_endpoint | default (printf "https://identity-3.%s.%s/v3" .Values.global.region .Values.global.tld) | quote }}
 - name: CEPH_REGION
   value: {{ .Values.ceph_region | quote }}
+- name: COOKIE_DOMAIN
+  value: "{{ $cookieDomain }}"


### PR DESCRIPTION

This PR extracts the wildcard domain from the ingress host (e.g., dashboard.DOMAIN → .DOMAIN) and enables cross session with Elektra.