### PR TITLE
fix(kube-system-metal): bump cert-manager to v1.20.3

### DIFF
--- a/system/kube-system-metal/Chart.lock
+++ b/system/kube-system-metal/Chart.lock
@@ -25,7 +25,7 @@ dependencies:
   version: v1.20.3
 - name: digicert-issuer
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 2.8.0
+  version: 2.8.1
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx
   version: 4.15.1
@@ -77,5 +77,5 @@ dependencies:
 - name: validating-admission-policy
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.0.2
-digest: sha256:90cf8e9f9f4b71312b4f18792afa8a869ddff04979f83318e8c26db00015f95f
-generated: "2026-07-01T07:34:49.315554+02:00"
+digest: sha256:e1033fa064fbb75c2131efbb696ee68988b2983f561895b783bcde5223c7e45f
+generated: "2026-07-01T10:35:48.027893+02:00"

--- a/system/kube-system-metal/Chart.lock
+++ b/system/kube-system-metal/Chart.lock
@@ -22,7 +22,7 @@ dependencies:
   version: 0.0.9
 - name: cert-manager
   repository: https://charts.jetstack.io
-  version: v1.13.3
+  version: v1.20.3
 - name: digicert-issuer
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.8.0
@@ -77,5 +77,5 @@ dependencies:
 - name: validating-admission-policy
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.0.2
-digest: sha256:3611d3451ff8bc5e756bbf4355e6165e0ecc6ed1da0addba8e7eaa179db58cf4
-generated: "2026-06-18T14:30:56.663037552Z"
+digest: sha256:90cf8e9f9f4b71312b4f18792afa8a869ddff04979f83318e8c26db00015f95f
+generated: "2026-07-01T07:34:49.315554+02:00"

--- a/system/kube-system-metal/Chart.yaml
+++ b/system/kube-system-metal/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for metal clusters.
 name: kube-system-metal
-version: 6.14.1
+version: 6.14.2
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-metal
 dependencies:
   - name: cc-rbac
@@ -30,7 +30,7 @@ dependencies:
     version: "^0.x"
   - name: cert-manager
     repository: https://charts.jetstack.io
-    version: 1.13.3
+    version: 1.20.3
   - name: digicert-issuer
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^2.x"

--- a/system/kube-system-metal/values.yaml
+++ b/system/kube-system-metal/values.yaml
@@ -34,7 +34,7 @@ cert-manager:
   installCRDs: true
   image:
     repository: keppel.global.cloud.sap/ccloud-quay-mirror/jetstack/cert-manager-controller
-    tag: v1.13.3
+    tag: v1.20.3
   webhook:
     image:
       repository: keppel.global.cloud.sap/ccloud-quay-mirror/jetstack/cert-manager-webhook


### PR DESCRIPTION
Fixes CVE-2025-22871 (Critical, Go net/http request smuggling), CVE-2022-23806 (Critical, crypto/elliptic) and 13 High severity Go stdlib CVEs. All three cert-manager images (controller, webhook, cainjector) are updated via the shared image tag.

SLA deadline was 2026-04-23 (68 days overdue).

## Summary
  
  - Bump cert-manager Helm chart dependency from `1.13.3` to `1.20.3`
  - Update image tag from `v1.13.3` to `v1.20.3` in `values.yaml`
  - Affects all three images: `cert-manager-controller`, `cert-manager-webhook`, `cert-manager-cainjector`
  - Update `Chart.lock` to pick up `digicert-issuer:2.8.1`

  ## Security

  Fixes the following CVEs (all overdue since 2026-04-23):

  | CVE | Severity | Description |
  |---|---|---|
  | CVE-2025-22871 | **Critical** | Go `net/http`: bare LF accepted as chunk-size line terminator, enabling HTTP request smuggling |
  | CVE-2022-23806 | **Critical** | Go `crypto/elliptic`: `Curve.IsOnCurve` returns incorrect result |
  | + 13 High | High | Various Go stdlib CVEs (`net/http`, `crypto/tls`, `encoding/xml`, ...) |

  ## Upgrade Notes

  - No breaking changes for this deployment (v1.13 → v1.20)
  - CRDs are updated automatically via `installCRDs: true`
  - `Chart.lock` now references `digicert-issuer:2.8.1` which renames its internal
    `image` helper template to avoid a collision with cert-manager's own `image`
    template introduced in v1.14 (see #12140)

  ## Prerequisites

  - #12140 (`digicert-issuer:2.8.1`) must be merged and published to the OCI
    registry before this PR can pass CI — ✅ done

  ## Test plan

  - [ ] Deploy to QA landscape and verify cert-manager pods come up healthy
  - [ ] Verify existing certificates are not affected
  - [ ] Check `kubectl get certificaterequests -A` shows no errors after rollout