### PR TITLE
Fix/descheduler v0.36.0 CVE 2025 22871

### DIFF
--- a/system/descheduler/Chart.yaml
+++ b/system/descheduler/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.23.1
+appVersion: 0.36.0
 description: Descheduler for Kubernetes is used to rebalance clusters by evicting pods that can potentially be scheduled on better nodes. In the current implementation, descheduler does not schedule replacement of evicted pods but relies on the default scheduler for that.
 home: https://github.com/kubernetes-sigs/descheduler
 icon: https://kubernetes.io/images/favicon.png
@@ -13,4 +13,4 @@ maintainers:
 name: descheduler
 sources:
 - https://github.com/kubernetes-sigs/descheduler
-version: 0.23.8
+version: 0.36.0

--- a/system/descheduler/values.yaml
+++ b/system/descheduler/values.yaml
@@ -40,48 +40,58 @@ deschedulingInterval: 5m
 cmdOptions:
   v: 4
 
+deschedulerPolicyAPIVersion: "descheduler/v1alpha2"
+
 deschedulerPolicy:
-  strategies:
-    RemoveDuplicates:
-      enabled: true
-      params:
-        thresholdPriorityClassName: critical-infrastructure
-    RemovePodsViolatingNodeTaints:
-      enabled: true
-      params:
-        thresholdPriorityClassName: critical-infrastructure
-    RemovePodsViolatingNodeAffinity:
-      enabled: true
-      params:
-        thresholdPriorityClassName: critical-infrastructure
-        nodeAffinityType:
-        - requiredDuringSchedulingIgnoredDuringExecution
-    RemovePodsViolatingInterPodAntiAffinity:
-      enabled: true
-      params:
-        thresholdPriorityClassName: critical-infrastructure
-    LowNodeUtilization:
-      enabled: true
-      params:
-        thresholdPriorityClassName: critical-infrastructure
-        nodeResourceUtilizationThresholds:
-          thresholds:
-            cpu: 20
-            memory: 20
-            pods: 20
-          targetThresholds:
-            cpu: 50
-            memory: 50
-            pods: 50
-    HighNodeUtilization:
-      enabled: true
-      params:
-        thresholdPriorityClassName: critical-infrastructure
-        nodeResourceUtilizationThresholds:
-          thresholds:
-            "cpu" : 20
-            "memory": 20
-            "pods": 20
+  profiles:
+    - name: default
+      pluginConfig:
+        - name: DefaultEvictor
+          args:
+            priorityThreshold:
+              name: critical-infrastructure
+        - name: RemoveDuplicates
+        - name: RemovePodsViolatingNodeTaints
+        - name: RemovePodsViolatingNodeAffinity
+          args:
+            nodeAffinityType:
+            - requiredDuringSchedulingIgnoredDuringExecution
+        - name: RemovePodsViolatingInterPodAntiAffinity
+        - name: LowNodeUtilization
+          args:
+            thresholds:
+              cpu: 20
+              memory: 20
+              pods: 20
+            targetThresholds:
+              cpu: 50
+              memory: 50
+              pods: 50
+        - name: HighNodeUtilization
+          args:
+            thresholds:
+              cpu: 20
+              memory: 20
+              pods: 20
+      plugins:
+        balance:
+          enabled:
+          - LowNodeUtilization
+          - HighNodeUtilization
+        deschedule:
+          enabled:
+          - RemovePodsViolatingNodeTaints
+          - RemovePodsViolatingNodeAffinity
+          - RemovePodsViolatingInterPodAntiAffinity
+        filter:
+          enabled:
+          - DefaultEvictor
+        preEvictionFilter:
+          enabled:
+          - DefaultEvictor
+        sort:
+          enabled:
+          - RemoveDuplicates
 
 priorityClassName: system-cluster-critical
 

--- a/system/descheduler/values.yaml
+++ b/system/descheduler/values.yaml
@@ -32,7 +32,7 @@ schedule: "0 1 * * *"
 suspend: false
 successfulJobsHistoryLimit: 10
 failedJobsHistoryLimit: 10
-#startingDeadlineSeconds: 200
+# startingDeadlineSeconds: 200
 
 # Required when running as a Deployment
 deschedulingInterval: 5m


### PR DESCRIPTION
  ## Summary
  
  Bumps descheduler from `v0.23.1` to `v0.36.0` to address two Critical severity CVEs
  that have been overdue since 2026-04-23.
  
  ## Security Fixes
  
  | CVE | Severity | Description |
  |---|---|---|
  | CVE-2025-22871 | **Critical** | Go `net/http`: bare LF accepted as chunk-size line terminator, enabling HTTP request smuggling |
  | CVE-2022-1996 | **Critical** | `go-restful`: authorization bypass through user-controlled key |
  
  ## Policy Migration (Breaking Change)
  
  The descheduler `v1alpha1` `strategies` API was removed in v0.26. This PR migrates
  the policy to the `v1alpha2` `profiles`/`plugins` format required by v0.36+.
  
  All six existing strategies are preserved with equivalent configuration:
  
  | Old (`strategies`) | New (`plugins`) |
  |---|---|
  | `RemoveDuplicates` | `sort.enabled` |
  | `RemovePodsViolatingNodeTaints` | `deschedule.enabled` |
  | `RemovePodsViolatingNodeAffinity` | `deschedule.enabled` |
  | `RemovePodsViolatingInterPodAntiAffinity` | `deschedule.enabled` |
  | `LowNodeUtilization` | `balance.enabled` |
  | `HighNodeUtilization` | `balance.enabled` |
  
  The `thresholdPriorityClassName: critical-infrastructure` is mapped to
  `DefaultEvictor.priorityThreshold.name: critical-infrastructure`, which
  preserves the same eviction protection for critical infrastructure pods.
  
  ## Test Plan
  
  - [ ] Deploy to QA landscape and verify descheduler CronJob completes successfully
  - [ ] Confirm `critical-infrastructure` priority class pods are not evicted
  - [ ] Check descheduler logs for unexpected errors after first run
  - [ ] Verify node utilization balancing still works as expected