### PR TITLE
[manila] opt hypervisor_storage_hana_qa out of capabilities:netapp_is_home

### DIFF
--- a/openstack/manila/templates/type-seeds.yaml
+++ b/openstack/manila/templates/type-seeds.yaml
@@ -26,9 +26,11 @@ spec:
     specs:
     {{- include "manila_type_seed.specs" . | indent 6 }}
     extra_specs:
-    {{ $extraSpecs :=  $.Values.share_type_extra_specs | merge (dict "share_backend_name" $shareTypeName) | merge (default (dict) $shareTypeValues.extra_specs) }}
+    {{- $extraSpecs := $.Values.share_type_extra_specs | merge (dict "share_backend_name" $shareTypeName) | merge (default (dict) $shareTypeValues.extra_specs) }}
     {{- range $key, $value := $extraSpecs }}
+    {{- if ne $value "__skip__" }}
       {{ $key }}: {{ $value | quote }}
+    {{- end }}
     {{- end }}
   {{- end }}
   {{- end }}

--- a/openstack/manila/values.yaml
+++ b/openstack/manila/values.yaml
@@ -808,15 +808,16 @@ share_types:
       provisioning:max_share_extend_size: "65536" # keep this in sync with castellum
   hypervisor_storage_hana_qa:
     enabled: false
-    extra_specs:
+    extra_specs:  # is a flexgroup share type, where capability 'netapp_is_home' is not reported
+      capabilities:netapp_is_home: "__skip__"  # opt-out sentinel: filtered out at render time
       provisioning:min_share_size: "2048"
       provisioning:max_share_size: "40960"
   hypervisor_storage:
     enabled: false
   hypervisor_storage_hanalytics:
-    enabeld: false
+    enabled: false
   hypervisor_storage_vim:
-    enabeld: false
+    enabled: false
   btp_backup:
     enabled: false
 


### PR DESCRIPTION
hypervisor_storage_hana_qa is a flexgroup share type and does not report
the 'netapp_is_home' capability. Keep the cap in the global
share_type_extra_specs so every regional overlay (incl. bool-shorthand
share_types entries) inherits it, and let a per-share-type '__skip__'
sentinel filter the key out for the flexgroup type at render time.
