### PR TITLE
Fix/digicert issuer image template collision

### DIFF
--- a/system/digicert-issuer/Chart.yaml
+++ b/system/digicert-issuer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: digicert-issuer
 description: A Helm chart for the Digicert Issuer.
 type: application
-version: 2.8.0
+version: 2.8.1
 appVersion: v2.8.0
 home: https://github.com/sapcc/digicert-issuer
 sources:

--- a/system/digicert-issuer/templates/_helpers.tpl
+++ b/system/digicert-issuer/templates/_helpers.tpl
@@ -1,3 +1,3 @@
-{{- define "image" -}}
+{{- define "digicert-issuer.image" -}}
 {{- required ".Values.image.repository missing" .Values.image.repository -}}:{{- required "image tag missing" (.Values.image.tag | default .Chart.AppVersion) -}}
 {{- end -}}

--- a/system/digicert-issuer/templates/deployment.yaml
+++ b/system/digicert-issuer/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
 {{- end }}
           command:
             - /digicert-issuer
-          image: {{ include "image" . }}
+          image: {{ include "digicert-issuer.image" . }}
           imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
           name: digicert-issuer
           env:

--- a/system/digicert-issuer/values.yaml
+++ b/system/digicert-issuer/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: keppel.global.cloud.sap/ccloud-ghcr-io-mirror/sapcc/digicert-issuer
   pullPolicy: IfNotPresent
-  #tag: # defaults to appVersion
+  # tag: # defaults to appVersion
 
 # These labels will be set on the digicert deployment
 deploymentLabels: {}


### PR DESCRIPTION
## Summary
  
  Renames the `image` helper template in `digicert-issuer` from `"image"` to
  `"digicert-issuer.image"` to follow Helm's chart-scoped naming convention.

  ## Problem

  cert-manager `v1.20` introduced a global `"image"` helper template with a new
  calling convention that expects a 4-argument tuple
  `(imageValues, imageRegistry, imageNamespace, defaultReference)`.

  When `digicert-issuer` is deployed as a subchart of `kube-system-metal`
  alongside `cert-manager`, both charts share the same Helm template namespace.
  cert-manager's `_helpers.tpl` overwrites `digicert-issuer`'s own `"image"`
  template, causing the following render error:

  error calling include: template: .../cert-manager/templates/_helpers.tpl:197:14:
  executing "image" at <index . 0>: value has type int; should be string

  ## Fix

  Rename the template definition in `_helpers.tpl` and its single call site in
  `deployment.yaml` from `"image"` to `"digicert-issuer.image"`. No behavioral
  change — the template logic itself is unchanged.

  ## Note

  This PR is a prerequisite for bumping cert-manager to `v1.20.3` in
  `kube-system-metal`. It must be merged and published to the OCI registry before
  that upgrade PR can proceed.