### PR TITLE
Add settings file override option

### DIFF
--- a/system/metal-settings/Chart.yaml
+++ b/system/metal-settings/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.10
+version: 0.2.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/system/metal-settings/README.md
+++ b/system/metal-settings/README.md
@@ -178,7 +178,6 @@ machines:
           version: "7.00.00.183"   # Target BMC firmware version gate.
           settingsFileName: dell-default.yaml  # File under bmc_settings/ to use for BMCSettingsSet.
           imageURI: "https://..."  # Firmware image download URL for BMCVersionSet.
-
 ```
 
 **Key rules:**
@@ -190,6 +189,44 @@ machines:
 - `included` uses `operator: In`, `excluded` uses `operator: NotIn`.
 - Unlike vendor/model/version/clusterType filters, `servers` narrows the generated resource selector rather than deciding whether Helm renders the resource at all.
 
+### Region-Specific Settings Overrides (`settingsContent`)
+
+For specific BIOS or BMC settings overrides (stored in other values files), use `settingsContent` to provide inline YAML instead of referencing a bundled file:
+
+**In region-specific values file** :
+
+```yaml
+# Define BIOS settings content once via YAML anchors, reference multiple times to avoid duplication
+_biosSettingsContent:
+  myCustomSettings: &myCustomSettings |
+    settingsFlow:
+    - name: myFlow
+      priority: 10
+      settings:
+        Setting1: Value1
+        Setting2: Value2
+
+machines:
+  dell:
+    models:
+      poweredge-r860-custom:
+        model: poweredge-r860
+        clusterTypes: [cc-kvm-compute]
+        bios:
+          version: "2.9.4"
+          settingsContent: *myCustomSettings      # Use inline content instead of settingsFileName
+          imageURI: "https://..."
+          settingsParams:
+            serverFilter:
+              included: [node003-bb086, node009-bb086]
+              excluded: []
+```
+
+**Behavior:**
+- If `settingsContent` is provided, it is used (takes precedence over `settingsFileName`)
+- If `settingsContent` is absent, the chart falls back to `settingsFileName` (loads from bundled `bios_settings/` or `bmc_settings/`)
+- Use YAML anchors (`&name`) and aliases (`*name`) to define settings once and reference them multiple times — this prevents duplication across region-specific overrides
+- Helm deep-merges region-specific values on top of base values, so only override entries that differ
 ## Filter Logic
 
 - **Empty `included` list** = include all (default behavior)
@@ -370,6 +407,57 @@ biosSettings:
     vendors:
       included: [lenovo]
 ```
+
+### UC12: Override Region-Specific BMC Settings
+
+In a region-specific values file (e.g., `kube-secrets`), override BMC settings for specific nodes and enable BMC settings deployment:
+
+```yaml
+# kube-secrets/values/helm/metalapi/<region>/<cluster>/metal-settings.yaml
+
+# Define BMC settings content once via YAML anchors
+_bmcSettingsContent:
+  customDellIdrac: &customDellIdrac |
+    settingsFlow:
+    - name: syslogConfiguration
+      priority: 10
+      settings:
+        SyslogServer: "{{ .Values.clusterConfig.syslogServer }}"
+        SyslogPort: 514
+    - name: snmpConfiguration
+      priority: 20
+      settings:
+        SnmpCommunity: "public"
+
+bmcSettings:
+  enabled: true
+
+clusterConfig:
+  configMapName: metal-bmc-settings
+  syslogServer: "syslog.region-qa-de-1.cloud.sap"
+
+machines:
+  dell:
+    models:
+      poweredge-r860:
+        model: poweredge-r860
+        clusterTypes: *defaultClusterTypes
+        bmc:
+          version: "7.20.60.50"
+          settingsContent: *customDellIdrac    # Use region-specific BMC settings override
+          settingsParams:
+            serverFilter:
+              included: [node001-bb001, node002-bb001]
+              excluded: []
+          imageURI: "https://<repo-address>/poweredge-r860/iDRAC-7.20.60.50.EXE"
+```
+
+This example:
+- Defines BMC settings content with templated values (e.g., `{{ .Values.clusterConfig.syslogServer }}`)
+- Uses `settingsContent` to override the default `settingsFileName` from the base chart
+- Enables `bmcSettings` only in this region (keeps it disabled elsewhere)
+- Applies the custom BMC settings only to specific nodes via `serverFilter`
+- Reuses the same settings across multiple models via YAML anchors
 
 ## Available Vendors and Models
 

--- a/system/metal-settings/templates/bios_settings.yaml
+++ b/system/metal-settings/templates/bios_settings.yaml
@@ -5,7 +5,7 @@
 {{/* Vendor filtering */}}
 {{- if include "metal-settings.shouldInclude" (dict "item" $vendor "filters" $.Values.biosSettings.filters.vendors) }}
 {{- range $entryName, $entry := $vendorConfig.models }}
-{{- if and $entry.clusterTypes $entry.bios $entry.bios.settingsFileName }}
+{{- if and $entry.clusterTypes $entry.bios (or $entry.bios.settingsFileName $entry.bios.settingsContent) }}
 {{- $model := $entry.model }}
 {{- $version := $entry.bios.version }}
 {{- $settingsParams := (get $entry.bios "settingsParams") | default dict }}
@@ -34,7 +34,11 @@ spec:
 {{- end }}
   biosSettingsTemplate:
     serverMaintenancePolicy: OwnerApproval
+{{- if $entry.bios.settingsContent }}
+{{ $entry.bios.settingsContent | trim | indent 4 }}
+{{- else }}
 {{ $.Files.Get (printf "bios_settings/%s" $entry.bios.settingsFileName) | trim | indent 4 }}
+{{- end }}
     version: {{ $version | quote }}
 ---
 {{- end }}

--- a/system/metal-settings/templates/bmc_settings.yaml
+++ b/system/metal-settings/templates/bmc_settings.yaml
@@ -5,7 +5,7 @@
 {{/* Vendor filtering */}}
 {{- if include "metal-settings.shouldInclude" (dict "item" $vendor "filters" $.Values.bmcSettings.filters.vendors) }}
 {{- range $entryName, $entry := $vendorConfig.models }}
-{{- if and $entry.clusterTypes $entry.bmc $entry.bmc.settingsFileName }}
+{{- if and $entry.clusterTypes $entry.bmc (or $entry.bmc.settingsFileName $entry.bmc.settingsContent) }}
 {{- $model := $entry.model }}
 {{- $version := $entry.bmc.version }}
 {{- $settingsParams := (get $entry.bmc "settingsParams") | default dict }}
@@ -35,7 +35,11 @@ spec:
   bmcSettingsTemplate:
     serverMaintenancePolicy: OwnerApproval
     version: {{ $version | quote }}
+{{- if $entry.bmc.settingsContent }}
+{{ $entry.bmc.settingsContent | trim | indent 4 }}
+{{- else }}
 {{ tpl ($.Files.Get (printf "bmc_settings/%s" $entry.bmc.settingsFileName)) $ | trim | indent 4 }}
+{{- end }}
 ---
 {{- end }}
 {{- end }}

--- a/system/metal-settings/values.yaml
+++ b/system/metal-settings/values.yaml
@@ -127,6 +127,15 @@ clusterConfig:
 #   - HPE: "hpe-ilo.yaml" (shared by all HPE models)
 #   - Lenovo: "lenovo-xcc.yaml" (shared by all Lenovo models)
 #
+# SETTINGS CONTENT SOURCES (settingsFileName vs settingsContent):
+#   - settingsFileName: References a file in bios_settings/ or bmc_settings/ bundled with the chart.
+#                      Used for shared, stable settings across all regions.
+#   - settingsContent: Inline YAML string provided via values (e.g., in kube-secrets overrides).
+#                      Used for region-specific or node-specific settings overrides.
+#                      When both are present, settingsContent takes precedence.
+#                      Use YAML anchors (&name) to define content once and reference (*name) multiple times
+#                      to avoid duplication in region-specific values files.
+#
 # Map keys: use the hardware model name as the key (e.g., poweredge-r640).
 # For models that need multiple entries (different clusterTypes/settings), use a descriptive
 # suffix as the key (e.g., proliant-dl560-gen11-kvm) and set model: explicitly inside the
@@ -154,6 +163,9 @@ machines:
           version: "2.22.2"
           settingsFileName: dell-default.yaml
           imageURI: "https://repo.eu-de-1.cloud.sap/hw-firmware/dell/poweredge-r640/BIOS_F8GPH_WN64_2.22.2.EXE"
+          # For BIOS settings, choose ONE of:
+          # 1) settingsFileName: reference a file in bios_settings/ (recommended for shared settings)
+          # 2) settingsContent: inline YAML string (recommended for specific overrides)
           # Optional params for BIOSSettingsSet of this entry:
           # settingsParams:
           #   serverFilter:
@@ -170,6 +182,9 @@ machines:
           version: "7.00.00.183"
           settingsFileName: dell-default.yaml
           imageURI: "https://repo.eu-de-1.cloud.sap/hw-firmware/dell/poweredge-r640/iDRAC-with-Lifecycle-Controller_Firmware_VP556_WN64_7.00.00.183_A00.EXE"
+          # For BMC settings, choose ONE of:
+          # 1) settingsFileName: reference a file in bmc_settings/ (recommended for shared settings)
+          # 2) settingsContent: inline YAML string (recommended for specific overrides)
           # Optional params for BMCSettingsSet of this entry:
           # settingsParams:
           #   serverFilter:


### PR DESCRIPTION
provides ability to override the BIOS/BMC settings individually using the override yaml files.