### PR TITLE
limes: add internal endpoints to $LIMES_API_DOMAIN_NAME_*

### DIFF
--- a/openstack/limes/templates/deployment-api.yaml
+++ b/openstack/limes/templates/deployment-api.yaml
@@ -53,10 +53,13 @@ spec:
             - /etc/limes/limes.json
           env:
             {{ include "limes_common_envvars" . | indent 12 }}
+            {{- $public_v1_name := .Values.limes.api_domain_names.v1 | required "missing value for .Values.limes.api_domain_names.v1" }}
+            {{- $public_v2_name := .Values.limes.api_domain_names.v2 | required "missing value for .Values.limes.api_domain_names.v2" }}
+            {{- $internal_name  := printf "limes-api-ccloud.%s.svc" .Release.Namespace }}
             - name: LIMES_API_DOMAIN_NAME_V1
-              value: {{ .Values.limes.api_domain_names.v1 | required "missing value for .Values.limes.api_domain_names.v1" | quote }}
+              value: {{ printf "%s,%s" $public_v1_name $internal_name | quote }}
             - name: LIMES_API_DOMAIN_NAME_V2
-              value: {{ .Values.limes.api_domain_names.v2 | required "missing value for .Values.limes.api_domain_names.v2" | quote }}
+              value: {{ printf "%s,%s" $public_v2_name $internal_name | quote }}
             - name: LIMES_API_POLICY_PATH
               value: /etc/limes/policy.json
           securityContext:


### PR DESCRIPTION
This fixes API users that use the `internal` endpoint. Needs to be merged after https://github.com/sapcc/limes/pull/911.