### PR TITLE
fix(kube-system-metal): rename cert-manager-ctl to cert-manager-start…

### DIFF
--- a/system/kube-system-metal/Chart.yaml
+++ b/system/kube-system-metal/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for metal clusters.
 name: kube-system-metal
-version: 6.14.2
+version: 6.14.3
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-metal
 dependencies:
   - name: cc-rbac

--- a/system/kube-system-metal/values.yaml
+++ b/system/kube-system-metal/values.yaml
@@ -45,7 +45,7 @@ cert-manager:
     - --leader-elect=false
   startupapicheck:
     image:
-      repository: keppel.global.cloud.sap/ccloud-quay-mirror/jetstack/cert-manager-ctl
+      repository: keppel.global.cloud.sap/ccloud-quay-mirror/jetstack/cert-manager-startupapicheck
   ingressShim:
     defaultIssuerName: digicert-issuer
     defaultIssuerKind: ClusterIssuer


### PR DESCRIPTION
…upapicheck

The cert-manager-ctl image was renamed to cert-manager-startupapicheck in v1.15. The old image name does not exist for v1.20.3 causing the replicate-changed-images step to fail.