### PR TITLE
feat(cc-shoots): increase machineDrainTimeout to 240h0m0s

### DIFF
--- a/system/cc-shoots-controlplane/Chart.yaml
+++ b/system/cc-shoots-controlplane/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-shoots-controlplane
 description: Converged Cloud Gardener Controlplane shoots
 type: application
-version: 1.0.5
+version: 1.0.6
 appVersion: "0.1.0"

--- a/system/cc-shoots-controlplane/templates/controlplane-shoot.yaml
+++ b/system/cc-shoots-controlplane/templates/controlplane-shoot.yaml
@@ -169,7 +169,7 @@ spec:
         machineControllerManager:
           machineCreationTimeout: 1h30m0s
           machineHealthTimeout: 1h0m0s
-          machineDrainTimeout: 1h30m0s
+          machineDrainTimeout: 240h0m0s
         providerConfig:
           apiVersion: ironcore-metal.provider.extensions.gardener.cloud/v1alpha1
           kind: WorkerConfig

--- a/system/cc-shoots-mgmt/Chart.yaml
+++ b/system/cc-shoots-mgmt/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-shoots-mgmt
 description: Converged Cloud Gardener shoots
 type: application
-version: 1.1.31
+version: 1.1.32
 appVersion: "0.1.0"

--- a/system/cc-shoots-mgmt/templates/mgmt-shoot.yaml
+++ b/system/cc-shoots-mgmt/templates/mgmt-shoot.yaml
@@ -175,7 +175,7 @@ spec:
         machineControllerManager:
           machineCreationTimeout: 1h30m0s
           machineHealthTimeout: 1h0m0s
-          machineDrainTimeout: 1h30m0s
+          machineDrainTimeout: 240h0m0s
         providerConfig:
           apiVersion: ironcore-metal.provider.extensions.gardener.cloud/v1alpha1
           kind: WorkerConfig

--- a/system/cc-shoots-storage/Chart.yaml
+++ b/system/cc-shoots-storage/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-shoots-storage
 description: Converged Cloud Gardener Storage shoots
 type: application
-version: 0.0.9
+version: 0.0.10
 appVersion: "0.1.0"

--- a/system/cc-shoots-storage/templates/storage-shoot.yaml
+++ b/system/cc-shoots-storage/templates/storage-shoot.yaml
@@ -148,7 +148,7 @@ spec:
         machineControllerManager:
           machineCreationTimeout: 1h30m0s
           machineHealthTimeout: 1h0m0s
-          machineDrainTimeout: 1h30m0s
+          machineDrainTimeout: 240h0m0s
         providerConfig:
           apiVersion: ironcore-metal.provider.extensions.gardener.cloud/v1alpha1
           kind: WorkerConfig
@@ -194,7 +194,7 @@ spec:
         machineControllerManager:
           machineCreationTimeout: 1h30m0s
           machineHealthTimeout: 1h0m0s
-          machineDrainTimeout: 1h30m0s
+          machineDrainTimeout: 240h0m0s
         providerConfig:
           apiVersion: ironcore-metal.provider.extensions.gardener.cloud/v1alpha1
           kind: WorkerConfig


### PR DESCRIPTION
## Summary

Increase `machineDrainTimeout` from `1h30m0s` to `240h0m0s` in cc-shoots-controlplane, cc-shoots-mgmt, and cc-shoots-storage shoots, aligning them with cc-shoots-compute.

## Motivation

MCM [does not respect Rook PDBs](https://github.com/gardener/machine-controller-manager/blob/master/pkg/util/provider/machinecontroller/machine_util.go#L1625-L1636) once the drain timeout is reached. With `AutoRollingUpdate` strategy this can cause storage data unavailability when nodes are drained forcefully after the timeout expires.

**Short-term mitigation:** Bump drain timers to effectively prevent forced drains.
**Long-term:** A label-based readiness gate for AutoRollingUpdate (see gardener/machine-controller-manager#1076) would replace timeout-based protection.

## Changes

| Chart | Old | New |
|-------|-----|-----|
| cc-shoots-controlplane | 1h30m0s | 240h0m0s |
| cc-shoots-mgmt | 1h30m0s | 240h0m0s |
| cc-shoots-storage (ceph-mon + ceph-osd) | 1h30m0s | 240h0m0s |

Chart versions bumped accordingly.