### PR TITLE
[rabbitmq] Support external IPS on calico based clusters

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+## 0.25.3 - 2026/07/01
+
+- Set `projectcalico.org/loadBalancerIPs` annotation to `externalIPs`' values to support newer, Gardener-based clusters
+
 ## 0.25.2 - 2026/06/03
 
 - `rabbitmq-user-credential-updater` updated to `20260521084806` version

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: rabbitmq
-version: 0.25.2
+version: 0.25.3
 appVersion: 4.3.1
 description: A Helm chart for RabbitMQ
 sources:

--- a/common/rabbitmq/templates/service.yaml
+++ b/common/rabbitmq/templates/service.yaml
@@ -10,6 +10,9 @@ metadata:
     prometheus.io/port: {{ required ".Values.metrics.port missing" .Values.metrics.port | quote }}
     prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
 {{- end }}
+    {{- if .Values.externalIPs }}
+    projectcalico.org/loadBalancerIPs: "{{ join "," .Values.externalIPs }}"
+    {{- end }}
 {{- if and (and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested) $.Values.linkerd.enabled }}
     linkerd.io/inject: enabled
     config.linkerd.io/opaque-ports: "{{ default 5672 .Values.ports.public }}"


### PR DESCRIPTION
In our newer Gardener-based cluster we have calico for networking that doesn't currently [0] support `.spec.externalIPs` for reading pre-defined external IPs. Instead, it requires an annotation to provide the IPs.

Therefore, we no set both `.spec.externalIPs` as well as the `projectcalico.org/loadBalancerIPs`, because having both should work in all clusters as the annotation has no effect in new clusters.

[0] https://github.com/projectcalico/calico/issues/11815