### PR TITLE
cc-cluster: migrate CAPI resources to v1beta2

### DIFF
--- a/system/cc-cluster/Chart.yaml
+++ b/system/cc-cluster/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: cc-cluster
 description: A Helm chart for the cc clusters.
 type: application
-version: 1.1.5
+version: 1.2.0

--- a/system/cc-cluster/templates/cluster.yaml
+++ b/system/cc-cluster/templates/cluster.yaml
@@ -1,6 +1,6 @@
 {{- range $key, $cluster := .Values.clusters }}
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: {{ $key }}
@@ -12,10 +12,8 @@ spec:
     apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
     kind: KubernikusControlPlane
     name: {{ $key }}
-    namespace: metal-{{ $key }}
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: {{ $key }}
-    namespace: metal-{{ $key }}
 {{- end }}

--- a/system/cc-cluster/templates/machinedeployment.yaml
+++ b/system/cc-cluster/templates/machinedeployment.yaml
@@ -1,7 +1,7 @@
 {{- range $key, $cluster := .Values.clusters }}
 {{- range $dkey, $deployment := $cluster.machineDeployments }}
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachineDeployment
 metadata:
   labels:
@@ -47,7 +47,7 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: {{ $key }}-{{ $dkey }}
-      nodeDrainTimeout: 0s
+      nodeDrainTimeoutSeconds: 0
       version: v{{ $cluster.version }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Migrates the `cc-cluster` chart from `cluster.x-k8s.io/v1beta1` to `v1beta2` ahead of the v1beta1 API removal (April 2027).

Refs sapcc/unified-kubernetes#1281. Companion PR: sapcc/cluster-api-control-plane-provider-kubernikus#28.

## Changes

- \`templates/cluster.yaml\`: apiVersion \`cluster.x-k8s.io/v1beta1\` → \`v1beta2\`; drop \`namespace:\` from \`spec.controlPlaneRef\` and \`spec.infrastructureRef\` (v1beta2 uses \`ContractVersionedObjectReference\` which does not carry namespace — refs are always same-namespace).
- \`templates/machinedeployment.yaml\`: apiVersion → \`v1beta2\`; rename \`nodeDrainTimeout: 0s\` (duration) → \`nodeDrainTimeoutSeconds: 0\` (int32 seconds).
- \`Chart.yaml\`: bump version \`1.1.5\` → \`1.2.0\` (breaking API version change for consumers).

## Deliberately unchanged

- \`templates/kubernikuscontrolplane.yaml\` — our CRD stays at \`controlplane.cluster.x-k8s.io/v1alpha1\` this cycle.
- \`templates/clusterresourceset.yaml\` (\`addons.cluster.x-k8s.io/v1beta1\`), \`kubeadmconfigtemplate.yaml\`, \`metal3cluster.yaml\`, \`m3machinetemplate.yaml\`, \`m3datatemplate.yaml\` — driven by their own providers' migration schedules.

## Rollout dependency

The new manifests can only be reconciled by a provider-kubernikus build with CAPI SDK v1.13.x (which registers the v1beta2 Cluster type). Land sapcc/cluster-api-control-plane-provider-kubernikus#28 and roll out its new image to management clusters **before** upgrading the chart there.

## Verification

- \`helm lint system/cc-cluster --values system/cc-cluster/ci/test-values.yaml\` ✅
- \`helm template ... | grep apiVersion\` — Cluster and MachineDeployment emit \`cluster.x-k8s.io/v1beta2\`; references have no \`namespace\` field.

Per the tracking issue's Acceptance Criteria: ceph storage cluster lifecycle + full machine/node redeploy on \`st1-qa-de-1\` need operator validation post-merge.