### PR TITLE
fix duplicate names in bios/bmc settings when setMetadataName is used

### DIFF
--- a/system/metal-settings/Chart.yaml
+++ b/system/metal-settings/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.13
+version: 0.2.14
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/metal-settings/bios_settings/dell-r860-kvm.yaml
+++ b/system/metal-settings/bios_settings/dell-r860-kvm.yaml
@@ -19,7 +19,6 @@ settingsFlow:
     PxeDev4EnDis: Disabled
     BootMode: Uefi
     IscsiDev1EnDis: Disabled
-    MemOpMode: OptimizerMode
 - name: R860KVMBiosSettings
   priority: 30
   settings:

--- a/system/metal-settings/templates/bios_settings.yaml
+++ b/system/metal-settings/templates/bios_settings.yaml
@@ -18,7 +18,9 @@
 {{/* ClusterType filtering */}}
 {{- if include "metal-settings.shouldInclude" (dict "item" $clusterType "filters" $.Values.biosSettings.filters.clusterTypes) }}
 {{- $defaultName := printf "%s-%s-%s" (lower $vendor) (lower $model) (lower $clusterType) }}
-{{- $resourceName := (get $settingsParams "setMetadataName") | default $defaultName }}
+{{- $explicitName := (get $settingsParams "setMetadataName") }}
+{{- $withCluster := printf "%s-%s" $explicitName (lower $clusterType) }}
+{{- $resourceName := ternary $withCluster $defaultName (ne $explicitName "") }}
 apiVersion: metal.ironcore.dev/v1alpha1
 kind: BIOSSettingsSet
 metadata:

--- a/system/metal-settings/templates/bmc_settings.yaml
+++ b/system/metal-settings/templates/bmc_settings.yaml
@@ -18,7 +18,9 @@
 {{/* ClusterType filtering */}}
 {{- if include "metal-settings.shouldInclude" (dict "item" $clusterType "filters" $.Values.bmcSettings.filters.clusterTypes) }}
 {{- $defaultName := printf "%s-%s-%s" (lower $vendor) (lower $model) (lower $clusterType) }}
-{{- $resourceName := (get $settingsParams "setMetadataName") | default $defaultName }}
+{{- $explicitName := (get $settingsParams "setMetadataName") }}
+{{- $withCluster := printf "%s-%s" $explicitName (lower $clusterType) }}
+{{- $resourceName := ternary $withCluster $defaultName (ne $explicitName "") }}
 apiVersion: metal.ironcore.dev/v1alpha1
 kind: BMCSettingsSet
 metadata:


### PR DESCRIPTION
remove duplicate key in biosSettings of system/metal-settings/bios_settings/dell-r860-kvm.yaml 

update bmc/bios settings templating to avoid duplicate resource names when multiple clustertype are created with overridden name. 