### PR TITLE
fix(autoscaling): bump descheduler dependency to 0.36.0

### DIFF
--- a/system/autoscaling/Chart.lock
+++ b/system/autoscaling/Chart.lock
@@ -10,6 +10,6 @@ dependencies:
   version: 0.3.11
 - name: descheduler
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.23.8
-digest: sha256:e85b5e6e8c8a808a6477975f8b09e85540718cad19afa57c05e4b345ce7417ba
-generated: "2026-02-18T10:21:24.236338591+01:00"
+  version: 0.36.0
+digest: sha256:d535b0598562e2ec057dd5d9f7eca5b4f239e79417326e95a40050430220d7c7
+generated: "2026-07-01T19:01:28.689205+02:00"

--- a/system/autoscaling/Chart.yaml
+++ b/system/autoscaling/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Collection of autoscaling services
 name: autoscaling
-version: 0.2.8
+version: 0.2.9
 home: https://github.com/sapcc/helm-charts/tree/master/system/autoscaling
 dependencies:
 - name: owner-info
@@ -16,5 +16,5 @@ dependencies:
   version: 0.3.11
 - name: descheduler
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.23.8
+  version: 0.36.0
   condition: descheduler.enabled


### PR DESCRIPTION
Updates the descheduler subchart from 0.23.8 to 0.36.0 to pick up the Go CVE fixes (CVE-2025-22871, CVE-2022-1996) and the policy migration to v1alpha2.

  ## Summary

  Bumps the descheduler subchart dependency in `system/autoscaling` from
  `0.23.8` to `0.36.0` to trigger the `autoscaling-metal` pipeline and
  roll out the updated descheduler to all metal clusters.

  ## Context

  The descheduler chart itself was already updated in #12137 (merged).
  This PR wires up the new version in the parent `autoscaling` chart so
  the pipeline picks it up.

  ## Changes

  - `system/autoscaling/Chart.yaml`: descheduler `0.23.8` → `0.36.0`, chart version `0.2.8` → `0.2.9`
  - `system/autoscaling/Chart.lock`: updated

  ## Deployment

  Rolls out via `autoscaling-metal` pipeline (`fly -t ci1`), starting
  with `qa-de-1` gate before proceeding to all other metal clusters.