### PR TITLE
feat(logs): bump logs subchart to 0.4.4 with TLS syslog support

### DIFF
--- a/system/logs/Chart.lock
+++ b/system/logs/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: logs
   repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-  version: 0.3.6
+  version: 0.4.4
 - name: fluent-prometheus
   repository: file://vendor/fluent-prometheus
   version: 1.0.15
@@ -11,5 +11,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:80f479a34c45036a451fde0b7f43c8323812b7b379c3fc85d625ed05e9d85693
-generated: "2026-06-25T11:38:56.197522+02:00"
+digest: sha256:c0b0362d44f1c218e62553620ab07fa883af983cf1aad200a099c18eaeccf957
+generated: "2026-07-02T09:56:24.862996+02:00"

--- a/system/logs/Chart.yaml
+++ b/system/logs/Chart.yaml
@@ -1,13 +1,13 @@
 apiVersion: v2
 description: A Helm chart for all log shippers
 name: logs
-version: 0.1.13
+version: 0.1.14
 home: https://github.com/sapcc/helm-charts/tree/master/system/logs
 dependencies:
   - name: logs
     alias: openTelemetryPlugin
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.3.6
+    version: 0.4.4
     condition: openTelemetry.enabled
 
   - name: fluent-prometheus


### PR DESCRIPTION
## Summary

- Upgrade `system/logs` subchart dependency from `logs-0.3.6` to `logs-0.4.4`

## Changes

- `Chart.yaml`: version `0.1.13` → `0.1.14`, dependency `logs 0.3.6` → `0.4.4`
- `Chart.lock`: updated digest

## New features in logs 0.4.4

- Configurable `issuerGroup` for TLS certificate (supports `certmanager.cloud.sap` DigiCert issuers)
- Configurable `issuerKind` (Issuer or ClusterIssuer)
- Optional `clientCAEnabled` for mTLS (disabled by default, fixes CrashLoopBackOff with DigiCert certs)

## Tested

- TLS syslog verified end-to-end in qa-de-1 and eu-de-1
- Certificate issued by DigiCert, TLSv1.3 handshake, syslog messages accepted and exported to OpenSearch