### PR TITLE
[Neutron] Bump rabbitmq chart to 0.25.3

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 0.5.2
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.22.2
+  version: 0.25.3
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.38.0
@@ -32,5 +32,5 @@ dependencies:
 - name: ovsdb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
-digest: sha256:d40a8bacf15e202103ce91ff2eebd9f0e3dcd9027b1b319b6516f159bee89c5b
-generated: "2026-06-30T11:32:42.425715541+02:00"
+digest: sha256:2e37873e901f347b6a11ddc0b32b05cdfadc89004a238c216023397c0bcb16f6
+generated: "2026-07-02T11:00:05.154041361+02:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
     version: 0.5.2
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.22.2
+    version: 0.25.3
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.38.0


### PR DESCRIPTION
* Update rabbitmq to 4.3.1
* Use clusterDNSSearchDomain to generate default names for certificates instead of hardcoded svc.kubernetes.region.tld
* Enable transient_nonexcl_queues, as it's in use by some services
* Allow not adding `rabbitmq.serviceName` to the certificate's dnsNames
  - If enabled, `externalNames` is a required setting
  - Makes most sense together with also setting `certificate.commonName`
* `rabbitmq-user-credential-updater` updated to `20260521084806` version
* Set `projectcalico.org/loadBalancerIPs` annotation to `externalIPs`' values to support newer, Gardener-based clusters