### PR TITLE
[ironic] convert db-migration jobs to regular resources

### DIFF
--- a/openstack/ironic/Chart.yaml
+++ b/openstack/ironic/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Ironic/OpenStack_Project_Ironic_vertical.png
 name: ironic
-version: 0.2.16
+version: 0.2.17
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/ironic/templates/_helpers.tpl
+++ b/openstack/ironic/templates/_helpers.tpl
@@ -22,3 +22,20 @@
 {{- define "ironic.rabbitmq_service" -}}
 ironic-rabbitmq
 {{- end }}
+
+{{- define "job_name" }}
+  {{- $name := index . 1 }}
+  {{- with index . 0 }}
+    {{- $all := list
+          (include (print .Template.BasePath "/etc-configmap.yaml") .)
+          (include (print .Template.BasePath "/secrets.yaml") .)
+          (include "utils.proxysql.job_pod_settings" .)
+          (include "utils.proxysql.volume_mount" .)
+          (include "utils.proxysql.container" .)
+          (include "utils.proxysql.volumes" .)
+          (tuple . (dict) | include "utils.snippets.kubernetes_entrypoint_init_container")
+      | join "\n" }}
+    {{- $hash := empty .Values.proxysql.mode | ternary "" $all | sha256sum }}
+{{- .Release.Name }}-{{ $name }}-{{ substr 0 4 $hash }}-{{ .Values.imageVersion | required "Please set ironic.imageVersion" }}
+  {{- end }}
+{{- end }}

--- a/openstack/ironic/templates/db-migration-job.yaml
+++ b/openstack/ironic/templates/db-migration-job.yaml
@@ -1,26 +1,20 @@
-{{- $serviceaccount := lookup "v1" "ServiceAccount" .Release.Namespace .Release.Name -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: ironic-db-migration
+  # Name changes with imageVersion / etc-configmap / secrets content, so Helm
+  # deletes the old completed Job and creates a new one on any relevant change.
+  name: {{ tuple . "db-migration" | include "job_name" }}
   labels:
     system: openstack
     type: job
     component: ironic
-  annotations:
-    "helm.sh/hook": "post-install,pre-upgrade"
-    "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
-    # hooks are not annotated as belonging to the Helm release, so we cannot rely on owner-info injection
-    ccloud/support-group: foundation
-    ccloud/service: ironic
 spec:
   template:
     metadata:
       annotations:
         {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
-      {{- if $serviceaccount }}
+      {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ .Release.Name }}
       {{- end }}
       initContainers:

--- a/openstack/ironic/templates/inspector-db-migration-job.yaml
+++ b/openstack/ironic/templates/inspector-db-migration-job.yaml
@@ -1,26 +1,20 @@
-{{- $serviceaccount := lookup "v1" "ServiceAccount" .Release.Namespace .Release.Name -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: ironic-inspector-db-migration
+  # Name changes with imageVersion / etc-configmap / secrets content, so Helm
+  # deletes the old completed Job and creates a new one on any relevant change.
+  name: {{ tuple . "inspector-db-migration" | include "job_name" }}
   labels:
     system: openstack
     type: job
     component: ironic
-  annotations:
-    "helm.sh/hook": "post-install,pre-upgrade"
-    "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
-    # hooks are not annotated as belonging to the Helm release, so we cannot rely on owner-info injection
-    ccloud/support-group: foundation
-    ccloud/service: ironic
 spec:
   template:
     metadata:
       annotations:
         {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
-      {{- if $serviceaccount }}
+      {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ .Release.Name }}
       {{- end }}
       restartPolicy: OnFailure


### PR DESCRIPTION
The render-time `lookup` guard omits `serviceAccountName` on first install, so the post-install hook runs under `default` and the entrypoint check gets 403 on endpointslices.

* drop hook annotations from both db-migration jobs
* use hash-suffixed job name like nova/cinder
* guard SA on `.Values.rbac.enabled` (SA is applied together with the job)