### PR TITLE
[rabbitmq] Fix loadBalancerIPs annotation needing JSON

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+## 0.25.4 - 2026/07/01
+
+- Fix `projectcalico.org/loadBalancerIPs` annotation needing JSON as value
+
 ## 0.25.3 - 2026/07/01
 
 - Set `projectcalico.org/loadBalancerIPs` annotation to `externalIPs`' values to support newer, Gardener-based clusters

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: rabbitmq
-version: 0.25.3
+version: 0.25.4
 appVersion: 4.3.1
 description: A Helm chart for RabbitMQ
 sources:

--- a/common/rabbitmq/templates/service.yaml
+++ b/common/rabbitmq/templates/service.yaml
@@ -11,7 +11,7 @@ metadata:
     prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
 {{- end }}
     {{- if .Values.externalIPs }}
-    projectcalico.org/loadBalancerIPs: "{{ join "," .Values.externalIPs }}"
+    projectcalico.org/loadBalancerIPs: '{{ toJson .Values.externalIPs }}'
     {{- end }}
 {{- if and (and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested) $.Values.linkerd.enabled }}
     linkerd.io/inject: enabled


### PR DESCRIPTION
Unintuitively for humans, the list of IPs is supposed to be a JSON list according to the documentation [0].

[0] https://docs.tigera.io/calico/latest/networking/ipam/service-loadbalancer#specifying-ip-address

---

I should have looked that up and tested it. It seemed to obvious to me :/