### PR TITLE
[netapp-harvester] upgrade harvest to 26.05.0-1, fix REST counter schedule

### DIFF
--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/templates/_rest.limited.yaml.tpl
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/templates/_rest.limited.yaml.tpl
@@ -1,5 +1,6 @@
 collector: Rest
 schedule:
+  - counter: 24h
   - data: 180s
 objects:
   Aggregate: aggr.yaml

--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/values.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/values.yaml
@@ -22,7 +22,7 @@ apps:
 harvest:
   image:
     repository: rahulguptajss/harvest
-    tag: 23.11.0-1
+    tag: 26.05.0-1
   loglevel: 2
   ports:
     liveness: 8080


### PR DESCRIPTION
## Summary

- **Bump** `rahulguptajss/harvest` image tag: `23.11.0-1` → `26.05.0-1`
- **Fix** REST collector `empty url` error in v26.05: add `counter: 24h` to `_rest.limited.yaml.tpl`

## Root cause

In v26.05, the `Rest` collector caches API endpoint hrefs in `PollCounter()` instead of building them inline per poll (v23.11 behavior). Without a `counter:` schedule entry, `PollCounter` never runs, `Prop.Href` stays empty, and every REST API call fails with `configuration error => empty url` (SVM, Aggregate, Node, Volume).

Adding `counter: 24h` matches the v26.05 upstream `default.yaml` and unblocks all REST collectors.

## Changes

- `charts/netapp-harvest-exporter/values.yaml` — bump image tag to `26.05.0-1`
- `charts/netapp-harvest-exporter/templates/_rest.limited.yaml.tpl` — add `- counter: 24h` to schedule

## Testing

Validated locally with `docker run rahulguptajss/harvest:26.05.0-1` and against a live qa-de-1 filer (`stnpca2-st051`):
- No `empty url` errors
- All REST collectors (Aggregate, Node, SVM, Volume, SnapMirror, Snapshot) collecting successfully
- Custom SAP labels (`share_type`, `share_id`, `share_name`, `project_id`) present on volume metrics