### PR TITLE
[Neutron] Bump rabbitmq to 0.25.4

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 0.5.2
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.25.3
+  version: 0.25.4
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.38.0
@@ -32,5 +32,5 @@ dependencies:
 - name: ovsdb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
-digest: sha256:2e37873e901f347b6a11ddc0b32b05cdfadc89004a238c216023397c0bcb16f6
-generated: "2026-07-02T11:00:05.154041361+02:00"
+digest: sha256:62c769169f00f9608327858c6deb346b259147f9572890f8722171a002b412fd
+generated: "2026-07-02T13:16:52.794398023+02:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
     version: 0.5.2
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.25.3
+    version: 0.25.4
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.38.0


### PR DESCRIPTION
* Fix `projectcalico.org/loadBalancerIPs` annotation needing JSON as value