### PR TITLE
[Nova] Bump rabbitmq to 0.25.4

### DIFF
--- a/openstack/nova/Chart.lock
+++ b/openstack/nova/Chart.lock
@@ -19,7 +19,7 @@ dependencies:
   version: 0.7.0
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.25.3
+  version: 0.25.4
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.6.15
@@ -34,7 +34,7 @@ dependencies:
   version: 0.5.1
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.25.3
+  version: 0.25.4
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.39.0
@@ -43,7 +43,7 @@ dependencies:
   version: 0.5.1
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.25.3
+  version: 0.25.4
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
@@ -55,9 +55,9 @@ dependencies:
   version: 2.4.2
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.25.3
+  version: 0.25.4
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.25.3
-digest: sha256:0accd99e9d21923536f1acb9b94b8a59d61cc578c1776dab3595e6b4a00cad09
-generated: "2026-07-02T10:56:14.992027203+02:00"
+  version: 0.25.4
+digest: sha256:60cbcd670763b02e4ed630c199779448d30986de1565a6db8cb026b7217bba18
+generated: "2026-07-02T13:24:51.531621695+02:00"

--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -36,7 +36,7 @@ dependencies:
   - name: rabbitmq
     condition: rabbitmq.enabled
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.25.3
+    version: 0.25.4
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.6.15
@@ -57,7 +57,7 @@ dependencies:
     condition: cell2.enabled
     name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.25.3
+    version: 0.25.4
   - alias: mariadb_cell3
     condition: mariadb_cell3.enabled
     name: mariadb
@@ -72,7 +72,7 @@ dependencies:
     condition: cell3.enabled
     name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.25.3
+    version: 0.25.4
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0
@@ -88,9 +88,9 @@ dependencies:
     condition: rabbitmq_cell1.enabled
     name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.25.3
+    version: 0.25.4
   - alias: rabbitmq_api
     condition: rabbitmq_api.enabled
     name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.25.3
+    version: 0.25.4


### PR DESCRIPTION
* Fix `projectcalico.org/loadBalancerIPs` annotation needing JSON as value