### PR TITLE
Add: IPC_LOCK for vault-snapshoter image

### DIFF
--- a/system/gatekeeper/templates/constraint-pod-security-v2.yaml
+++ b/system/gatekeeper/templates/constraint-pod-security-v2.yaml
@@ -1377,6 +1377,12 @@ spec:
           container's securityContext.
         mayUseCapabilities: [ IPC_LOCK ]
 
+      - matchNamespace: vault
+        matchRepository: ccloud/vault-snapshoter
+        justification: |
+          Same with the above
+        mayUseCapabilities: [ IPC_LOCK ]
+
       ##########################################################################
       # End of rules
 


### PR DESCRIPTION
Vault 2.0.1's binary ships with the cap_ipc_lock=ep file capability baked in at build time. The Linux kernel refuses to exec such a binary inside a container unless IPC_LOCK is granted in the container's securityContext. This applies to the vault-snapshoter image that runs as a cronjob to take vault snapshots.