### PR TITLE
fix(descheduler): use deschedulerPolicyAPIVersion in configmap template

### DIFF
--- a/system/descheduler/Chart.yaml
+++ b/system/descheduler/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 name: descheduler
 sources:
 - https://github.com/kubernetes-sigs/descheduler
-version: 0.36.0
+version: 0.36.1

--- a/system/descheduler/templates/configmap.yaml
+++ b/system/descheduler/templates/configmap.yaml
@@ -6,6 +6,6 @@ metadata:
     {{- include "descheduler.labels" . | nindent 4 }}
 data:
   policy.yaml: |
-    apiVersion: "descheduler/v1alpha1"
+    apiVersion: {{ .Values.deschedulerPolicyAPIVersion | default "descheduler/v1alpha2" | quote }}
     kind: "DeschedulerPolicy"
 {{ toYaml .Values.deschedulerPolicy | trim | indent 4 }}


### PR DESCRIPTION
The configmap.yaml template hardcoded 'descheduler/v1alpha1' as the policy apiVersion, ignoring the deschedulerPolicyAPIVersion value set in values.yaml. This caused v0.36.0 to fail with:

  no kind "DeschedulerPolicy" is registered for version "descheduler/v1alpha1"

Fix by using .Values.deschedulerPolicyAPIVersion in the template, defaulting to v1alpha2.