### PR TITLE
fix(autoscaling): bump descheduler dependency to 0.36.1

### DIFF
--- a/system/autoscaling/Chart.lock
+++ b/system/autoscaling/Chart.lock
@@ -10,6 +10,6 @@ dependencies:
   version: 0.3.11
 - name: descheduler
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.36.0
-digest: sha256:d535b0598562e2ec057dd5d9f7eca5b4f239e79417326e95a40050430220d7c7
-generated: "2026-07-01T19:01:28.689205+02:00"
+  version: 0.36.1
+digest: sha256:ca55c83f559a5f67c0605cf81e5364ddfa9b2170195abc4f9fd46799d2920262
+generated: "2026-07-02T16:37:17.330618+02:00"

--- a/system/autoscaling/Chart.yaml
+++ b/system/autoscaling/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Collection of autoscaling services
 name: autoscaling
-version: 0.2.9
+version: 0.2.10
 home: https://github.com/sapcc/helm-charts/tree/master/system/autoscaling
 dependencies:
 - name: owner-info
@@ -16,5 +16,5 @@ dependencies:
   version: 0.3.11
 - name: descheduler
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.36.0
+  version: 0.36.1
   condition: descheduler.enabled


### PR DESCRIPTION
Picks up the fix for the hardcoded v1alpha1 policy apiVersion in the descheduler configmap template (fixed in descheduler 0.36.1).

  ## Summary
  
  Bumps the descheduler subchart dependency in `system/autoscaling` from
  `0.36.0` to `0.36.1` to pick up the configmap template fix.
  
  ## Context
  
  descheduler `0.36.0` failed on startup because the policy ConfigMap
  had `apiVersion` hardcoded to `v1alpha1` which is no longer supported.
  This was fixed in `0.36.1` (see #12172 ). 
  
  ## Changes
  
  - `system/autoscaling/Chart.yaml`: descheduler `0.36.0` → `0.36.1`, chart version `0.2.9` → `0.2.10`
  - `system/autoscaling/Chart.lock`: updated
  
  ## Prerequisites
  
  - `fix/descheduler-configmap-v1alpha2` must be merged and published
    to the OCI registry before this PR can be deployed — ✅ done
    
  ## Test plan
  
  - [ ] Deploy via `autoscaling-metal` pipeline, Gate: `qa-de-1`
  - [ ] Trigger manual job: `kubectl -n autoscaling create job descheduler-test --from=cronjob/autoscaling-descheduler`
  - [ ] Verify logs show descheduler running successfully with v1alpha2 policy
  - [ ] Confirm `critical-infrastructure` pods are not evicted 