### PR TITLE
Fix/autoscaling descheduler 0.36.1

### DIFF
--- a/system/autoscaling/Chart.lock
+++ b/system/autoscaling/Chart.lock
@@ -10,6 +10,6 @@ dependencies:
   version: 0.3.11
 - name: descheduler
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.36.1
-digest: sha256:ca55c83f559a5f67c0605cf81e5364ddfa9b2170195abc4f9fd46799d2920262
-generated: "2026-07-02T16:37:17.330618+02:00"
+  version: 0.36.2
+digest: sha256:70e45865641661f7f6208b473aadb85a16d99fcd96b7768dadf88d204df8bae7
+generated: "2026-07-02T17:32:30.853668+02:00"

--- a/system/autoscaling/Chart.yaml
+++ b/system/autoscaling/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Collection of autoscaling services
 name: autoscaling
-version: 0.2.10
+version: 0.2.11
 home: https://github.com/sapcc/helm-charts/tree/master/system/autoscaling
 dependencies:
 - name: owner-info

--- a/system/autoscaling/Chart.yaml
+++ b/system/autoscaling/Chart.yaml
@@ -16,5 +16,5 @@ dependencies:
   version: 0.3.11
 - name: descheduler
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.36.1
+  version: 0.36.2
   condition: descheduler.enabled


### PR DESCRIPTION
  ## Summary
  
  Bumps the descheduler subchart dependency in `system/autoscaling` from
  `0.36.0` to `0.36.2` to pick up two bug fixes:
  
  - `0.36.1`: Fixed hardcoded `v1alpha1` in policy ConfigMap template
  - `0.36.2`: Added missing RBAC permissions for `persistentvolumeclaims`
    and `poddisruptionbudgets`
    
  ## Deployment
  
  Rolls out via `autoscaling-metal` pipeline (`fly -t ci1`),
  starting with `qa-de-1` gate.
  
  ## Test plan
  
  - [ ] Trigger manual job: `kubectl -n autoscaling create job descheduler-test --from=cronjob/autoscaling-descheduler`
  - [ ] Verify no errors in logs
  - [ ] Confirm `critical-infrastructure` pods are not evicted