### PR TITLE
[Nova] Support cell1 rabbitmq rename for nova-compute-ironic

### DIFF
--- a/openstack/nova/templates/hypervisors/_ironic-deployment.yaml.tpl
+++ b/openstack/nova/templates/hypervisors/_ironic-deployment.yaml.tpl
@@ -48,7 +48,7 @@ spec:
       {{- end }}
       terminationGracePeriodSeconds: {{ $hypervisor.default.graceful_shutdown_timeout | default .Values.defaults.default.graceful_shutdown_timeout | add 5 }}
       initContainers:
-      {{- tuple . (dict "service" (print .Release.Name "-rabbitmq")) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
+      {{- tuple . (dict "service" (include "nova.helpers.cell_rabbitmq_service" (tuple . "cell1"))) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       containers:
         - name: nova-compute
           image: {{ tuple . "compute" | include "container_image_nova" }}


### PR DESCRIPTION
When supported overriding the name for cell1 rabbitmq in [0], we missed a spot: the nova-compute-ironic template's keystone-entrypoint dependencies.
This is a fix adding support for a renamed cell1 rabbitmq there, too.

[0] 492c1e5893f9e6119237435fb22513a972022f69