### PR TITLE
disco: scope cluster-scoped resource names to release name

### DIFF
--- a/system/disco/Chart.yaml
+++ b/system/disco/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: The DISCO (Designate IngresS Cname Operator) creates CNAMEs based on an ingress spec in OpenStack Designate.
 name: disco
-version: 2.4.4
+version: 2.4.5
 appVersion: v2.0.0
 maintainers:
   - name: kengou

--- a/system/disco/templates/_helpers.tpl
+++ b/system/disco/templates/_helpers.tpl
@@ -21,7 +21,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: disco-manager-role
+  name: {{ .Release.Name }}-manager-role
 rules:
 - apiGroups:
   - ""
@@ -71,11 +71,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: disco-manager-rolebinding
+  name: {{ index . "releaseName" }}-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: disco-manager-role
+  name: {{ index . "releaseName" }}-manager-role
 subjects:
 - kind: ServiceAccount
   name: {{ index . "serviceAccountName" }}
@@ -142,7 +142,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: disco-proxy-role
+  name: {{ .Release.Name }}-proxy-role
 rules:
 - apiGroups:
   - authentication.k8s.io
@@ -162,11 +162,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: disco-proxy-rolebinding
+  name: {{ index . "releaseName" }}-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: disco-proxy-role
+  name: {{ index . "releaseName" }}-proxy-role
 subjects:
 - kind: ServiceAccount
   name: {{ index . "serviceAccountName" }}
@@ -177,7 +177,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: disco-metrics-reader
+  name: {{ .Release.Name }}-metrics-reader
 rules:
 - nonResourceURLs:
   - /metrics
@@ -192,7 +192,7 @@ them. All namespaced resources are fixed to kube-system — that is where Garden
 token-requestor looks up the ServiceAccount on the shoot cluster.
 */}}
 {{- define "disco.shootRBAC" -}}
-{{- $ctx := dict "namespace" .Values.remote.shootNamespace "serviceAccountName" .Values.serviceAccount.name }}
+{{- $ctx := dict "namespace" .Values.remote.shootNamespace "serviceAccountName" .Values.serviceAccount.name "releaseName" .Release.Name }}
 {{ include "disco.serviceAccount" $ctx }}
 ---
 {{ include "disco.clusterRole.manager" . }}

--- a/system/disco/templates/disco-manager-rolebinding.yaml
+++ b/system/disco/templates/disco-manager-rolebinding.yaml
@@ -1,3 +1,3 @@
 {{- if and .Values.rbac.create (not .Values.remote.enabled) }}
-{{ include "disco.clusterRoleBinding.manager" (dict "namespace" .Release.Namespace "serviceAccountName" .Values.serviceAccount.name) }}
+{{ include "disco.clusterRoleBinding.manager" (dict "namespace" .Release.Namespace "serviceAccountName" .Values.serviceAccount.name "releaseName" .Release.Name) }}
 {{- end }}

--- a/system/disco/templates/disco-proxy-rolebinding.yaml
+++ b/system/disco/templates/disco-proxy-rolebinding.yaml
@@ -1,3 +1,3 @@
 {{- if and .Values.rbac.create (not .Values.remote.enabled) }}
-{{ include "disco.clusterRoleBinding.proxy" (dict "namespace" .Release.Namespace "serviceAccountName" .Values.serviceAccount.name) }}
+{{ include "disco.clusterRoleBinding.proxy" (dict "namespace" .Release.Namespace "serviceAccountName" .Values.serviceAccount.name "releaseName" .Release.Name) }}
 {{- end }}

--- a/system/disco/templates/managedresource.yaml
+++ b/system/disco/templates/managedresource.yaml
@@ -3,15 +3,15 @@
 apiVersion: resources.gardener.cloud/v1alpha1
 kind: ManagedResource
 metadata:
-  name: disco-crd
+  name: {{ .Release.Name }}-crd
 spec:
   secretRefs:
-  - name: disco-crd
+  - name: {{ .Release.Name }}-crd
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: disco-crd
+  name: {{ .Release.Name }}-crd
 type: Opaque
 data:
   objects.yaml: {{ .Files.Get "crds/records.disco.stable.sap.cc.yaml" | b64enc }}
@@ -19,15 +19,15 @@ data:
 apiVersion: resources.gardener.cloud/v1alpha1
 kind: ManagedResource
 metadata:
-  name: disco-rbac
+  name: {{ .Release.Name }}-rbac
 spec:
   secretRefs:
-  - name: disco-rbac
+  - name: {{ .Release.Name }}-rbac
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: disco-rbac
+  name: {{ .Release.Name }}-rbac
 type: Opaque
 data:
   objects.yaml: {{ include "disco.shootRBAC" . | b64enc }}

--- a/system/disco/templates/remote-kubeconfig.yaml
+++ b/system/disco/templates/remote-kubeconfig.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: disco-remote-kubeconfig
+  name: {{ .Release.Name }}-remote-kubeconfig
   labels:
     resources.gardener.cloud/purpose: token-requestor
     resources.gardener.cloud/class: shoot

--- a/system/disco/tests/rbac_test.yaml
+++ b/system/disco/tests/rbac_test.yaml
@@ -42,11 +42,11 @@ tests:
       - isKind:
           of: ClusterRole
 
-  - it: should be named disco-manager-role
+  - it: should be named <release>-manager-role
     asserts:
       - equal:
           path: metadata.name
-          value: disco-manager-role
+          value: RELEASE-NAME-manager-role
 
   - it: should grant ingress read permissions
     asserts:
@@ -99,11 +99,11 @@ tests:
       - isKind:
           of: ClusterRoleBinding
 
-  - it: should be named disco-manager-rolebinding
+  - it: should be named <release>-manager-rolebinding
     asserts:
       - equal:
           path: metadata.name
-          value: disco-manager-rolebinding
+          value: RELEASE-NAME-manager-rolebinding
 
   - it: should bind disco-controller-manager service account
     asserts:
@@ -189,11 +189,11 @@ tests:
       - isKind:
           of: ClusterRole
 
-  - it: should be named disco-proxy-role
+  - it: should be named <release>-proxy-role
     asserts:
       - equal:
           path: metadata.name
-          value: disco-proxy-role
+          value: RELEASE-NAME-proxy-role
 
   - it: should not render when remote.enabled is true
     set:
@@ -214,11 +214,11 @@ tests:
       - isKind:
           of: ClusterRoleBinding
 
-  - it: should be named disco-proxy-rolebinding
+  - it: should be named <release>-proxy-rolebinding
     asserts:
       - equal:
           path: metadata.name
-          value: disco-proxy-rolebinding
+          value: RELEASE-NAME-proxy-rolebinding
 
   - it: should bind disco-controller-manager service account
     asserts:
@@ -245,11 +245,11 @@ tests:
       - isKind:
           of: ClusterRole
 
-  - it: should be named disco-metrics-reader
+  - it: should be named <release>-metrics-reader
     asserts:
       - equal:
           path: metadata.name
-          value: disco-metrics-reader
+          value: RELEASE-NAME-metrics-reader
 
   - it: should grant /metrics read access
     asserts:

--- a/system/disco/tests/remote_test.yaml
+++ b/system/disco/tests/remote_test.yaml
@@ -18,7 +18,7 @@ tests:
           of: Secret
       - equal:
           path: metadata.name
-          value: disco-remote-kubeconfig
+          value: RELEASE-NAME-remote-kubeconfig
       - equal:
           path: metadata.labels["resources.gardener.cloud/purpose"]
           value: token-requestor
@@ -72,10 +72,10 @@ tests:
           of: ManagedResource
       - equal:
           path: metadata.name
-          value: disco-crd
+          value: RELEASE-NAME-crd
       - equal:
           path: spec.secretRefs[0].name
-          value: disco-crd
+          value: RELEASE-NAME-crd
 
   - it: should render Secret containing CRD
     set:
@@ -87,7 +87,7 @@ tests:
           of: Secret
       - equal:
           path: metadata.name
-          value: disco-crd
+          value: RELEASE-NAME-crd
       - isNotNull:
           path: data["objects.yaml"]
 
@@ -101,10 +101,10 @@ tests:
           of: ManagedResource
       - equal:
           path: metadata.name
-          value: disco-rbac
+          value: RELEASE-NAME-rbac
       - equal:
           path: spec.secretRefs[0].name
-          value: disco-rbac
+          value: RELEASE-NAME-rbac
 
   - it: should render Secret containing RBAC
     set:
@@ -116,6 +116,6 @@ tests:
           of: Secret
       - equal:
           path: metadata.name
-          value: disco-rbac
+          value: RELEASE-NAME-rbac
       - isNotNull:
           path: data["objects.yaml"]


### PR DESCRIPTION
Replace hardcoded `disco-*` names with `{{ .Release.Name }}-*` for all ClusterRoles, ClusterRoleBindings, ManagedResources, and the remote kubeconfig Secret so that multiple releases can coexist in the same cluster without ownership conflicts.