### PR TITLE
fix: add default cert for ingress-nginx to avoid nginx fake certificate

### DIFF
--- a/system/kube-system-addons/Chart.yaml
+++ b/system/kube-system-addons/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant addon collection.
 name: kube-system-addons
-version: 0.1.10
+version: 0.1.11
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-metal
 dependencies:
   - name: sysctl

--- a/system/kube-system-addons/templates/ingress-default-certificate.yaml
+++ b/system/kube-system-addons/templates/ingress-default-certificate.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.ingress.defaultCertificate.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+
+metadata:
+  name: ingress-default
+
+spec:
+  secretName: ingress-default
+  dnsNames:
+{{- if .Values.ingress.defaultCertificate.dnsNames }}
+{{- range .Values.ingress.defaultCertificate.dnsNames }}
+    - {{ . }}
+{{- end }}
+{{- else }}
+    - ingress.st1.{{ required ".Values.global.region missing" .Values.global.region }}.{{ required ".Values.global.domain missing" .Values.global.domain }}
+{{- end }}
+  issuerRef:
+    group: certmanager.cloud.sap
+    kind: ClusterIssuer
+    name: digicert-issuer
+{{- end }}

--- a/system/kube-system-addons/values.yaml
+++ b/system/kube-system-addons/values.yaml
@@ -33,6 +33,10 @@ priority-class:
   enabled: true
 
 ingress:
+  defaultCertificate:
+    enabled: false
+    dnsNames: []
+
   tls_client_auth:
     enabled: false
     cacrt: |

--- a/system/kube-system-admin-k3s/Chart.yaml
+++ b/system/kube-system-admin-k3s/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kube-System relevant Service collection for the new admin clusters.
 name: kube-system-admin-k3s
-version: 3.7.0
+version: 3.7.1
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-admin-k3s
 dependencies:
   - name: node-problem-detector

--- a/system/kube-system-admin-k3s/templates/ingress-default-certificate.yaml
+++ b/system/kube-system-admin-k3s/templates/ingress-default-certificate.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.ingress.defaultCertificate.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+
+metadata:
+  name: ingress-default
+
+spec:
+  secretName: ingress-default
+  dnsNames:
+{{- if .Values.ingress.defaultCertificate.dnsNames }}
+{{- range .Values.ingress.defaultCertificate.dnsNames }}
+    - {{ . }}
+{{- end }}
+{{- else }}
+    - ingress.admin.{{ required ".Values.global.region missing" .Values.global.region }}.{{ required ".Values.global.domain missing" .Values.global.domain }}
+{{- end }}
+  issuerRef:
+    group: certmanager.cloud.sap
+    kind: ClusterIssuer
+    name: digicert-issuer
+{{- end }}

--- a/system/kube-system-admin-k3s/values.yaml
+++ b/system/kube-system-admin-k3s/values.yaml
@@ -3,6 +3,10 @@ global:
   domain:
 
 ingress:
+  defaultCertificate:
+    enabled: false
+    dnsNames: []
+
   tls_client_auth:
     ca_cert:
 

--- a/system/kube-system-metal/Chart.yaml
+++ b/system/kube-system-metal/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for metal clusters.
 name: kube-system-metal
-version: 6.14.3
+version: 6.14.4
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-metal
 dependencies:
   - name: cc-rbac

--- a/system/kube-system-metal/templates/ingress-default-certificate.yaml
+++ b/system/kube-system-metal/templates/ingress-default-certificate.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.ingress.defaultCertificate.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+
+metadata:
+  name: ingress-default
+
+spec:
+  secretName: ingress-default
+  dnsNames:
+{{- if .Values.ingress.defaultCertificate.dnsNames }}
+{{- range .Values.ingress.defaultCertificate.dnsNames }}
+    - {{ . }}
+{{- end }}
+{{- else }}
+    - ingress.{{ required ".Values.global.region missing" .Values.global.region }}.{{ required ".Values.global.domain missing" .Values.global.domain }}
+{{- end }}
+  issuerRef:
+    group: certmanager.cloud.sap
+    kind: ClusterIssuer
+    name: digicert-issuer
+{{- end }}

--- a/system/kube-system-metal/values.yaml
+++ b/system/kube-system-metal/values.yaml
@@ -62,6 +62,10 @@ digicert-issuer:
 
 # ingress related but independent values
 ingress:
+  defaultCertificate:
+    enabled: false
+    dnsNames: []
+
   tls_client_auth:
     enabled: false
     cacrt: |

--- a/system/kube-system-virtual/Chart.yaml
+++ b/system/kube-system-virtual/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for virtual clusters.
 name: kube-system-virtual
-version: 4.9.1
+version: 4.9.2
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-virtual
 dependencies:
   - name: cc-rbac

--- a/system/kube-system-virtual/templates/ingress-default-certificate.yaml
+++ b/system/kube-system-virtual/templates/ingress-default-certificate.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.ingress.defaultCertificate.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+
+metadata:
+  name: ingress-default
+
+spec:
+  secretName: ingress-default
+  dnsNames:
+{{- if .Values.ingress.defaultCertificate.dnsNames }}
+{{- range .Values.ingress.defaultCertificate.dnsNames }}
+    - {{ . }}
+{{- end }}
+{{- else }}
+    - ingress.virtual.{{ required ".Values.global.region missing" .Values.global.region }}.{{ required ".Values.global.domain missing" .Values.global.domain }}
+{{- end }}
+  issuerRef:
+    group: certmanager.cloud.sap
+    kind: ClusterIssuer
+    name: digicert-issuer
+{{- end }}

--- a/system/kube-system-virtual/values.yaml
+++ b/system/kube-system-virtual/values.yaml
@@ -6,6 +6,10 @@ externalIPs:
   ingress: 
 
 ingress:
+  defaultCertificate:
+    enabled: false
+    dnsNames: []
+
   tls_client_auth:
     ca_cert:
 


### PR DESCRIPTION
Pentest finding: SSL/TLS: Known Untrusted / Dangerous CA (Medium, CVSS 5) 
the virtual ingress-nginx controller has no default cert so requests hitting the NodePort by IP / without SNI get nginx's built-in self-signed "Fake Certificate". 
Real client traffic already gets a valid DigiCert cert via the edge.