### PR TITLE
disco: scope MutatingWebhookConfiguration name to release name

### DIFF
--- a/system/disco/Chart.yaml
+++ b/system/disco/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: The DISCO (Designate IngresS Cname Operator) creates CNAMEs based on an ingress spec in OpenStack Designate.
 name: disco
-version: 2.4.5
+version: 2.4.6
 appVersion: v2.0.0
 maintainers:
   - name: kengou

--- a/system/disco/templates/disco-mutating-webhook-configuration.yaml
+++ b/system/disco/templates/disco-mutating-webhook-configuration.yaml
@@ -4,7 +4,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/disco-serving-cert
-  name: disco-mutating-webhook-configuration
+  name: {{ .Release.Name }}-mutating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
   - v1

--- a/system/disco/tests/webhook_test.yaml
+++ b/system/disco/tests/webhook_test.yaml
@@ -49,11 +49,11 @@ tests:
       - isKind:
           of: MutatingWebhookConfiguration
 
-  - it: should be named disco-mutating-webhook-configuration
+  - it: should be named <release>-mutating-webhook-configuration
     asserts:
       - equal:
           path: metadata.name
-          value: disco-mutating-webhook-configuration
+          value: RELEASE-NAME-mutating-webhook-configuration
 
   - it: should have cert-manager inject annotation
     asserts:


### PR DESCRIPTION
Fixes the same ownership conflict as the previous commit, but for the cluster-scoped MutatingWebhookConfiguration.