### PR TITLE
ironic: seeds remove swift dependency

### DIFF
--- a/openstack/ironic/templates/seed.yaml
+++ b/openstack/ironic/templates/seed.yaml
@@ -15,14 +15,15 @@ spec:
   {{- end }}
   - monsoon3/nova-seed
   - monsoon3/neutron-seed
-  - swift/swift-seed
 
   roles:
   - name: cloud_baremetal_admin
   - name: baremetal_admin
   - name: baremetal_viewer
+  - name: objectstore_admin
   - name: cloud_image_admin
   - name: cloud_compute_admin
+  - name: cloud_objectstore_admin
 
   services:
   - name: ironic


### PR DESCRIPTION
Remove the dependency to the swift seed and instead define the roles
directly. Need this for eu-de-3 where we will have a ceph based
objectstorage but no swift.
