### PR TITLE
[mariadb] optionally cohost the mariadb and the mariadb-backup pods

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.40.0 - 2026/07/03
+* optionally cohost the mariadb and the mariadb-backup pods on the same node via the `.Values.backup_v2.cohost_with_mariadb` flag
+* chart version bumped
+
 ## v0.39.0 - 2026/06/22
 * support multiple Ceph S3 backup targets via `global.mariadb.backup_v2.ceph_s3.targets`
 * drop `global.mariadb.backup_v2.ceph_s3.{endpoint,region,bucket_name,aws_access_key_id,aws_secret_access_key}` keys

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.39.0
+version: 0.40.0
 # scripts/docker-entyrpoint.sh should be updated when appVersion is updated
 appVersion: 10.11.18
 dependencies:

--- a/common/mariadb/templates/backup-v2-deployment.yaml
+++ b/common/mariadb/templates/backup-v2-deployment.yaml
@@ -33,6 +33,15 @@ spec:
 {{- end }}
     spec:
       affinity:
+{{- if .Values.backup_v2.cohost_with_mariadb }}
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: {{ include "fullName" . }}
+            topologyKey: kubernetes.io/hostname
+{{- end }}
+
 {{- if .Values.nodeAffinity }}
       {{- with .Values.nodeAffinity }}
         nodeAffinity:

--- a/common/mariadb/templates/deployment.yaml
+++ b/common/mariadb/templates/deployment.yaml
@@ -35,6 +35,15 @@ spec:
 {{- end }}
     spec:
       affinity:
+{{- if and .Values.backup_v2.cohost_with_mariadb .Values.backup_v2.enabled }}
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: {{ include "fullName" . }}-backup
+            topologyKey: kubernetes.io/hostname
+{{- end }}
+
         nodeAffinity:
 {{- if .Values.nodeAffinity }}
       {{- with .Values.nodeAffinity }}

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -221,6 +221,7 @@ credentialUpdater:
 
 backup_v2:
   enabled: false
+  cohost_with_mariadb: false
   backup_dir: "./backup"
   image: maria-back-me-up
   image_version: "10.11-20260611113653"


### PR DESCRIPTION
Toggle using the newly introduced `.Values.backup_v2.cohost_with_mariadb` flag. Defaulting to `false`.

If the mariadb and the backup pods share a RWO PVC, then the scheduler will refuse to start the second pod with an error like:
```
Warning  FailedAttachVolume  8m2s  attachdetach-controller  Multi-Attach
error for volume "pvc-***" Volume is
already used by pod(s) whatever-mariadb-***-***
```

The pod will bounce around until it ends up scheduled on the same node as the other one. And then it will start.

No need for all that if we can force the two pods to be scheduled on the same node.

NOTE: using the softer `preferred` and not the hard `required` affinity rule to make sure the main pod (mariadb) starts regardless of the state the auxiliary pod (mariadb-backup) finds itself in.