### PR TITLE
cc-cluster: complete CAPI v1beta2 migration (Cluster, MachineDeployment, ClusterResourceSet, KubeadmConfigTemplate)

### DIFF
--- a/system/cc-cluster/Chart.yaml
+++ b/system/cc-cluster/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: cc-cluster
 description: A Helm chart for the cc clusters.
 type: application
-version: 1.2.0
+version: 1.2.1

--- a/system/cc-cluster/templates/cluster.yaml
+++ b/system/cc-cluster/templates/cluster.yaml
@@ -9,11 +9,11 @@ metadata:
     cluster.x-k8s.io/cluster-name: {{ $key }}
 spec:
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: KubernikusControlPlane
     name: {{ $key }}
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: {{ $key }}
 {{- end }}

--- a/system/cc-cluster/templates/clusterresourceset.yaml
+++ b/system/cc-cluster/templates/clusterresourceset.yaml
@@ -1,6 +1,6 @@
 {{- range $key, $cluster := .Values.clusters }}
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   labels:

--- a/system/cc-cluster/templates/kubeadmconfigtemplate.yaml
+++ b/system/cc-cluster/templates/kubeadmconfigtemplate.yaml
@@ -1,6 +1,6 @@
 {{- range $key, $cluster := .Values.clusters }}
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KubeadmConfigTemplate
 metadata:
   name: {{ $key }}
@@ -11,14 +11,15 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            node-labels: kubernikus.cloud.sap/cni=true,metal3.io/uuid=${uuid},kubernetes.metal.cloud.sap/node-ip=${IP},kubernetes.metal.cloud.sap/host=${name_bmh},kubernetes.metal.cloud.sap/bb=${bb},kubernetes.metal.cloud.sap/role=${role},topology.kubernetes.io/region=${region},topology.kubernetes.io/zone=${zone} {{- if $cluster.maintenanceProfile -}} ,cloud.sap/maintenance-profile={{ $cluster.maintenanceProfile }} {{- end }}
+          - name: node-labels
+            value: kubernikus.cloud.sap/cni=true,metal3.io/uuid=${uuid},kubernetes.metal.cloud.sap/node-ip=${IP},kubernetes.metal.cloud.sap/host=${name_bmh},kubernetes.metal.cloud.sap/bb=${bb},kubernetes.metal.cloud.sap/role=${role},topology.kubernetes.io/region=${region},topology.kubernetes.io/zone=${zone} {{- if $cluster.maintenanceProfile -}} ,cloud.sap/maintenance-profile={{ $cluster.maintenanceProfile }} {{- end }}
               {{- with $cluster.extraLabels }}
                 {{- range $label := $cluster.extraLabels -}}
                   ,{{ $label }}
                 {{- end }}
               {{- end }}
-            cloud-provider: ""
-            node-ip: ${IP}
+          - name: node-ip
+            value: ${IP}
           name: ${name_bmh}
       format: ignition
       ignition:

--- a/system/cc-cluster/templates/machinedeployment.yaml
+++ b/system/cc-cluster/templates/machinedeployment.yaml
@@ -12,13 +12,14 @@ metadata:
 spec:
   clusterName: {{ $key }}
   replicas: {{ $deployment.replicas }}
-  strategy:
-    rollingUpdate:
-      # We don't have spare nodes in bare metal clusters to spin up a new machine during upgrade.
-      # Therefore we change maxSurge from 1 (default) to 0 and set maxUnavailable to 1.
-      # Cluster will be updated by temporary scaling down control plane to 1 machine less.
-      maxSurge: 0
-      maxUnavailable: 1
+  rollout:
+    strategy:
+      rollingUpdate:
+        # We don't have spare nodes in bare metal clusters to spin up a new machine during upgrade.
+        # Therefore we change maxSurge from 1 (default) to 0 and set maxUnavailable to 1.
+        # Cluster will be updated by temporary scaling down control plane to 1 machine less.
+        maxSurge: 0
+        maxUnavailable: 1
   selector:
     matchLabels:
       kubernetes.metal.cloud.sap/cluster: {{ $key }}
@@ -39,15 +40,14 @@ spec:
     spec:
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          apiGroup: bootstrap.cluster.x-k8s.io
           kind: KubeadmConfigTemplate
           name: {{ $key }}
       clusterName: {{ $key }}
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: {{ $key }}-{{ $dkey }}
-      nodeDrainTimeoutSeconds: 0
       version: v{{ $cluster.version }}
 {{- end }}
 {{- end }}

--- a/system/cluster-api/Chart.lock
+++ b/system/cluster-api/Chart.lock
@@ -28,12 +28,12 @@ dependencies:
   version: 0.1.1
 - name: provider-kubernikus
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.2.1
+  version: 0.2.2
 - name: cc-cluster
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.2.0
+  version: 1.2.1
 - name: runtime-extension-maintenance-controller
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.9
-digest: sha256:322356836c0f250f9f577d1b0fc0750009d2966c361b6118c2ab2e71f84d2085
-generated: "2026-07-06T09:30:39.208030479Z"
+digest: sha256:57fae0600899d8e0021b73f59169fa210904ae2638e734f6aa826deb63317f41
+generated: "2026-07-06T12:13:42.755613+02:00"

--- a/system/cluster-api/Chart.yaml
+++ b/system/cluster-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-api
 description: A Helm chart for the Cluster API.
 type: application
-version: 5.0.18
+version: 5.0.19
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm


### PR DESCRIPTION
Follow-up to #12150 — that PR bumped `Cluster` and `MachineDeployment` `apiVersion` to `v1beta2` but did not complete the corresponding schema restructure, and left `ClusterResourceSet` / `KubeadmConfigTemplate` at `v1beta1`. Server-side strict validation against the QA cluster surfaced 6 field-shape errors and 3 deprecation warnings; this PR fixes all of them.

Refs sapcc/unified-kubernetes#1281.

## What was broken

Reproduced with:

\`\`\`
helm template test system/cc-cluster --values system/cc-cluster/ci/test-values.yaml \\
  | kubectl --context v-qa-de-1 apply --dry-run=server --validate=strict -f -
\`\`\`

The API server was **silently stripping fields** on the previously-merged manifests because the v1beta2 shapes are different from what #12150 emits. Consequences on live clusters:

| Symptom | Cause | Fix |
|---|---|---|
| `unknown field "spec.template.spec.nodeDrainTimeoutSeconds"` | Field moved to `spec.template.spec.deletion.nodeDrainTimeoutSeconds` in v1beta2 | Dropped (default 0 = indefinite drain matches our intent) |
| `Cluster ... unknown field "spec.controlPlaneRef.apiVersion"` / `"spec.infrastructureRef.apiVersion"` | v1beta2 uses `ContractVersionedObjectReference` with `apiGroup` (group only), not `apiVersion` | Converted to `apiGroup` |
| `MachineDeployment ... unknown field "spec.strategy"` | `spec.strategy` moved under `spec.rollout.strategy` in v1beta2 | Restructured (rollingUpdate maxSurge/maxUnavailable intact) |
| `MachineDeployment ... unknown field "spec.template.spec.bootstrap.configRef.apiVersion"` / `"spec.template.spec.infrastructureRef.apiVersion"` | Same ContractVersionedObjectReference change | Converted to `apiGroup` |
| `Warning: addons.cluster.x-k8s.io/v1beta1 ClusterResourceSet is deprecated` | Chart still emitted v1beta1 | Bumped to `v1beta2` (schema-compatible) |
| `Warning: bootstrap.cluster.x-k8s.io/v1beta1 KubeadmConfigTemplate is deprecated` | Chart still emitted v1beta1 | Bumped to `v1beta2` with `kubeletExtraArgs` map→list rewrite (see below) |

## KubeadmConfigTemplate notes

v1beta2 changed `spec.template.spec.joinConfiguration.nodeRegistration.kubeletExtraArgs` from `map[string]string` to `[]{name, value}` with **required non-empty value**. Two consequences:

1. Rewrote the three entries (`node-labels`, `cloud-provider`, `node-ip`) into the list-of-objects shape.
2. Dropped `cloud-provider: ""` entirely. v1beta2 rejects the empty value (`MinLength=1`), and modern kubelet defaults to no cloud-provider anyway — the empty-value entry was already a no-op in v1beta1.

The rendered `node-labels` value is **byte-identical** to what master emits, verified by rendering both versions of the chart against `ci/test-values.yaml` and diffing. This is critical: `node-labels` drives scheduling.

## Changes

- **cluster.yaml**: `controlPlaneRef.apiVersion` → `apiGroup`, `infrastructureRef.apiVersion` → `apiGroup`. Values are group-only (`controlplane.cluster.x-k8s.io`, `infrastructure.cluster.x-k8s.io`), no version suffix.
- **machinedeployment.yaml**:
  - Moved `spec.strategy` → `spec.rollout.strategy` (v1beta2 restructure).
  - `bootstrap.configRef.apiVersion` → `apiGroup`; `infrastructureRef.apiVersion` → `apiGroup`.
  - Dropped the invalid `nodeDrainTimeoutSeconds: 0` line.
- **clusterresourceset.yaml**: `apiVersion: addons.cluster.x-k8s.io/v1beta1` → `v1beta2`.
- **kubeadmconfigtemplate.yaml**: `apiVersion: bootstrap.cluster.x-k8s.io/v1beta1` → `v1beta2`. `kubeletExtraArgs` rewritten to list. `cloud-provider: \"\"` dropped.
- **Chart.yaml**: `1.2.0` → `1.2.1` (patch bump; fixes previous minor's half-done migration).

Field renames follow the upstream v1beta1→v1beta2 migration guide: https://cluster-api.sigs.k8s.io/developer/providers/migrations/v1.10-to-v1.11

## Verification

After this PR, the same server-side dry-run against `v-qa-de-1` returns **zero** strict-decoding errors and **zero** deprecation warnings on any CAPI resource.

Still requires operator validation post-merge (per issue #1281 Acceptance Criteria): ceph storage cluster lifecycle and full machine/node redeploy cycle on `st1-qa-de-1`. Node-labels string is byte-identical to before, so scheduling behaviour should be unchanged.