### PR TITLE
Enh/metal settings r6715

### DIFF
--- a/system/metal-settings/Chart.yaml
+++ b/system/metal-settings/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.20
+version: 0.2.21
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/metal-settings/bios_settings/dell-r6715.yaml
+++ b/system/metal-settings/bios_settings/dell-r6715.yaml
@@ -1,0 +1,20 @@
+settingsFlow:
+- name: enablePxeDev1
+  priority: 15
+  settings:
+    PxeDev1EnDis: Enabled
+- name: PXEBootWithNIC.Slot.4-1-1
+  priority: 20
+  settings:
+    BootMode: Uefi
+    CECriticalSEL: Enabled
+    IscsiDev1EnDis: Disabled
+    PPROnUCE: Enabled
+    PwrButton: Disabled
+    PxeDev1Interface: NIC.Slot.4-1-1
+    PxeDev1Protocol: IPv4
+    PxeDev1VlanEnDis: Disabled
+    PxeDev2EnDis: Disabled
+    PxeDev3EnDis: Disabled
+    PowerProfileSelect: HighPerformanceMode
+    PxeDev4EnDis: Disabled

--- a/system/metal-settings/bmc_settings/dell-r6715.yaml
+++ b/system/metal-settings/bmc_settings/dell-r6715.yaml
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and IronCore contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Default iDRAC BMC settings for all Dell PowerEdge models.
+# Applied via BMCSettingsSet after the BMC firmware reaches the target version.
+# Rendered as a Helm template via tpl — configMapName is substituted at chart render time.
+# NodeName, BB and Region are resolved at reconcile time from BMC object labels.
+# SyslogServer is resolved from the metal-bmc-settings ConfigMap.
+#
+# Values sourced from: baremetal-config/dell/*/bmc/defaultsettings.yml
+settings:
+  IPMILan.1.Enable: "Enabled"
+  SNMP.1.AgentEnable: "Disabled"
+  IPMILan.1.AlertEnable: "Enabled"
+  NTPConfigGroup.1.NTPEnable: "Enabled"
+  IPv6.1.Enable: "Disabled"
+  SysLog.1.SysLogEnable: "Enabled"
+  NTPConfigGroup.1.NTP1: "timehost1.global.cloud.sap"
+  NTPConfigGroup.1.NTP2: "timehost2.global.cloud.sap"
+  NTPConfigGroup.1.NTP3: "timehost3.global.cloud.sap"
+  IPv4.1.StaticDNS1: "147.204.9.200"
+  IPv4.1.StaticDNS2: "147.204.9.201"
+  SysLog.1.Port: "514"
+  Time.1.DayLightOffset: "0"
+  Time.1.Timezone: "UTC"
+  Time.1.TimeZoneOffset: "0"
+  WebServer.1.SSLEncryptionBitLength: "256-Bit or higher"
+  WebServer.1.TLSProtocol: "TLS 1.2 and Higher"
+  # Per-BMC dynamic settings resolved at reconcile time via controller variables below.
+  # $(NodeName)r-$(BB) → e.g. "node002r-ap052" (matches inventory_hostname_short convention)
+  Network.1.DNSRacName: "$(NodeName)r-$(BB)"
+  # cc.$(Region).cloud.sap → e.g. "cc.qa-de-1.cloud.sap"
+  Network.1.StaticDNSDomainName: "cc.$(Region).cloud.sap"
+  SysLog.1.Server1: "$(SyslogServer)"
+variables:
+  # BmcName: resolved from the BMCSettings object itself — used as the name for all objectFieldRef lookups below.
+  - key: BmcName
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.BMCRef.name
+  # NodeName: short node name from BMC label (e.g. "node002").
+  - key: NodeName
+    valueFrom:
+      objectFieldRef:
+        kind: BMC
+        name: $(BmcName)
+        fieldPath: metadata.labels[kubernetes.metal.cloud.sap/nodename]
+  # BB: building block identifier from BMC label (e.g. "ap052").
+  - key: BB
+    valueFrom:
+      objectFieldRef:
+        kind: BMC
+        name: $(BmcName)
+        fieldPath: metadata.labels[kubernetes.metal.cloud.sap/bb]
+  # Region: topology region from BMC label (e.g. "qa-de-1") — used to construct the DNS domain.
+  - key: Region
+    valueFrom:
+      objectFieldRef:
+        kind: BMC
+        name: $(BmcName)
+        fieldPath: metadata.labels[topology.kubernetes.io/region]
+  # SyslogServer: cluster-level syslog endpoint from the metal-bmc-settings ConfigMap.
+  - key: SyslogServer
+    valueFrom:
+      configMapKeyRef:
+        name: {{ .Values.clusterConfig.configMapName }}
+        namespace: {{ .Values.clusterConfig.managedNamespace }}
+        key: syslogServer

--- a/system/metal-settings/values.yaml
+++ b/system/metal-settings/values.yaml
@@ -215,11 +215,11 @@ machines:
         clusterTypes: *defaultClusterTypes
         bios:
           version: "1.3.3"
-          settingsFileName: dell-default.yaml
+          settingsFileName: dell-r6715.yaml
           imageURI: "https://repo.eu-de-1.cloud.sap/hw-firmware/dell/poweredge-r6715/BIOS_N2K66_WN64_1.3.3_01.EXE"
         bmc:
           version: "1.20.60.50"
-          settingsFileName: dell-default.yaml
+          settingsFileName: dell-r6715.yaml
           imageURI: "https://repo.eu-de-1.cloud.sap/hw-firmware/dell/poweredge-r6715/iDRAC-with-Lifecycle-Controller_Firmware_63M5X_WN64_1.20.60.50_A00.EXE"
 
       poweredge-r740:


### PR DESCRIPTION
Add dedicated dell-r6715.yaml for both BIOS and BMC settings and point poweredge-r6715 at them in values.yaml. All keys validated against live Redfish attribute dumps (BIOS and iDRAC DellAttributes) from a real R6715.

