### PR TITLE
fix(oauth-proxy): bump to v7.15.3 to fix Critical CVEs

### DIFF
--- a/global/oauth-proxy/Chart.yaml
+++ b/global/oauth-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for installing the global auth
 name: oauth-proxy
-version: 0.2.0
+version: 0.2.1
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/global/oauth-proxy/values.yaml
+++ b/global/oauth-proxy/values.yaml
@@ -4,7 +4,7 @@
 image:
   registry: quay.io
   name: oauth2-proxy/oauth2-proxy
-  tag: v7.15.2
+  tag: v7.15.3
   pullPolicy: IfNotPresent
 replica_count: 2
 


### PR DESCRIPTION
Fixes:
- CVE-2026-33186 (Critical) google.golang.org/grpc auth bypass - 44 services
- CVE-2026-34457 (Critical) oauth2-proxy specific
- CVE-2026-40575 (Critical) oauth2-proxy specific

v7.15.3 upgrades Go to 1.26.4 and bumps all dependencies. No breaking changes in this patch release.

SLA deadline was 2026-04-23.