### PR TITLE
[cc-shoots-mgmt] enable Seed.spec.settings.zoneSelection (Prefer default)

### DIFF
--- a/system/cc-shoots-mgmt/Chart.yaml
+++ b/system/cc-shoots-mgmt/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-shoots-mgmt
 description: Converged Cloud Gardener shoots
 type: application
-version: 1.1.32
+version: 1.1.33
 appVersion: "0.1.0"

--- a/system/cc-shoots-mgmt/templates/managedseed.yaml
+++ b/system/cc-shoots-mgmt/templates/managedseed.yaml
@@ -74,5 +74,15 @@ spec:
               externalTrafficPolicy: Local
               zonalIngress:
                 enabled: false
+            # Pin non-HA / failureToleranceType=node shoot control planes to
+            # the same AZ as the shoot's worker pool(s). Upstream feature:
+            # gardener/gardener#14238. Defaults to "Prefer" which never
+            # blocks scheduling — shoots whose worker zones do not intersect
+            # this seed's spec.provider.zones (e.g. workerless shoots) fall
+            # back to random placement, same as before the setting was
+            # introduced. Overridable per-landscape via
+            # mgmtShoots.<landscape>.zoneSelection (e.g. "Enforce" once each
+            # landscape has confirmed all shoots have matching zones).
+            zoneSelection: {{ default "Prefer" $cluster.zoneSelection | quote }}
 {{- end }}
 {{- end }}

--- a/system/cc-shoots-mgmt/values.yaml
+++ b/system/cc-shoots-mgmt/values.yaml
@@ -5,3 +5,19 @@ networking:
   services: ""
   enableBirdExporter: true
   overlay: true
+
+# mgmtShoots is a map keyed by landscape of per-mgmt-shoot configuration.
+# Values documented here for reference; actual values are supplied
+# per-landscape from downstream values files.
+#
+# Per-landscape overrides that this chart understands:
+#
+# mgmtShoots:
+#   <landscape>:
+#     # Optional. Overrides Seed.spec.settings.zoneSelection on the rendered
+#     # ManagedSeed. Defaults to "Prefer" (safe: never blocks scheduling;
+#     # workerless / zone-mismatched shoots fall back to random placement,
+#     # same as before this setting existed). Set to "Enforce" per-landscape
+#     # once all shoots on that seed have worker zones matching the seed's
+#     # spec.provider.zones.
+#     zoneSelection: Prefer


### PR DESCRIPTION
## Summary

Adds `Seed.spec.settings.zoneSelection` (with a default of **`Prefer`**) to every mgmt-* `ManagedSeed` rendered by `system/cc-shoots-mgmt`. This is the upstream [gardener/gardener#14238](https://github.com/gardener/gardener/pull/14238) feature.

## Why

Today Gardener picks a random AZ from the seed's `spec.provider.zones` when it creates the CP namespace of a non-HA (or `failureToleranceType: node`) shoot. For AZ-local architectures — most notably KVM compute shoots hosted on stretched `mgmt-*` seeds — this silently breaks the isolation guarantee the architecture depends on: a shoot whose workers are in AZ `1b` can end up with its kube-apiserver running in AZ `1a`, so a `1a` outage now also kills the `1b` shoot.

Concrete example we can point at on one of our landscapes: a compute shoot has workers declared in one AZ but its kube-apiserver is currently running in a different AZ. Live misplacement — every kubelet on this shoot's workers is talking cross-AZ to its apiserver right now.

## What this change does

- Renders one new line under `spec.gardenlet.config.seedConfig.spec.settings` in the ManagedSeed:
  ```yaml
  zoneSelection: "Prefer"
  ```
- Default is `Prefer`, overridable per-landscape via `mgmtShoots.<landscape>.zoneSelection` in downstream values files (e.g. set to `Enforce` once a landscape has verified all shoots have matching zones).

## Why `Prefer` and not `Enforce` for the default

`Prefer` is the safe mode: for shoots whose worker-pool zones intersect the seed's `spec.provider.zones`, the CP is pinned to the matching AZ. For shoots with **no intersection** — either workerless (e.g. Lighthouse coordinator shoots) or with worker zones the seed doesn't have today — Gardener falls back to random selection. Same behaviour as before this setting existed. **No new failure mode.**

`Enforce` would additionally block scheduling in the no-intersection case, which would strand any shoot whose worker zones do not match the seed's zone list. Not something we want to opt into globally without per-landscape validation.

## Behavioural expectations

- **New shoots** (or shoots whose CP namespace is re-created) on any mgmt-* seed → land in the correct AZ from the start.
- **Existing shoots** already sitting on a seed → **not moved automatically**. `zoneSelection` is a one-shot decision at namespace creation. Landscapes with a live misplacement need a one-off migration: patch the `high-availability-config.resources.gardener.cloud/zones` annotation on the CP namespace and roll the CP pods. Safe on Ceph-backed seeds where volumes are not zone-bound.
- **HA shoots with `failureToleranceType: zone`** → no-op (upstream design; CP is spread across zones by definition).

## What is out of scope for this PR

- **Lighthouse (workerless) shoots.** These fall back to random under both `Prefer` and `Enforce`. Fixing their placement needs a separate mechanism (mutating admission on the seed, or a new upstream `Shoot.spec.controlPlane.zone` field). Tracked as a follow-up; no regression from this PR — Lighthouse behaviour is identical to today.
- **Flipping any landscape to `Enforce`.** Follow-up per landscape, once all shoots on that seed have worker zones that intersect the seed's zone list.
- **Zonal ingress.** Orthogonal setting (`spec.settings.loadBalancerServices.zonalIngress.enabled`); left at current per-landscape configuration. Turning it on to collect the ingress-side AZ-locality benefit is a separate design.
- **Migrating existing misplaced CPs.** Manual step per landscape, tracked separately.

## Verification

- `helm lint system/cc-shoots-mgmt/` → passes.
- `helm template` with `system/cc-shoots-mgmt/ci/test-values.yaml` (no `zoneSelection` override) renders cleanly.
- Manual render with the `lookup` guard bypassed confirms the field appears:
  - Default (no override) → `zoneSelection: "Prefer"`
  - `mgmtShoots.<landscape>.zoneSelection: Enforce` → `zoneSelection: "Enforce"`

Post-merge, verify propagation on a target landscape:

```bash
kubectl get managedseed mgmt-<landscape> -n garden \
  -o jsonpath='{.spec.gardenlet.config.seedConfig.spec.settings.zoneSelection}'
# expected: Prefer

kubectl get seed mgmt-<landscape> \
  -o jsonpath='{.spec.settings.zoneSelection}'
# expected: Prefer  (reconciled from ManagedSeed by gardener-operator/gardenlet)
```

## Follow-up work

1. Migrate any currently-misplaced CPs back to the intended AZ (manual annotation patch + CP roll).
2. Per-landscape readiness for `Enforce`: confirm all shoots on the seed have worker zones matching the seed's `spec.provider.zones`, then bump `mgmtShoots.<landscape>.zoneSelection` to `Enforce` via the downstream values file.
3. Design and ship the Lighthouse (workerless-shoot) workaround.
4. Design zonal-ingress enablement on stretched seeds already running with `zoneSelection`.

## References

- Upstream feature: [gardener/gardener#14238](https://github.com/gardener/gardener/pull/14238) — *Add zone selection setting to `Seed`s for AZ-aware control plane placement*
- Upstream docs: [Seed settings § Zone Selection](https://github.com/gardener/gardener/blob/master/docs/operations/seed_settings.md#zone-selection)