### PR TITLE
fix(keystone): resolve rotten images in daemonset and jaeger-agent sidecar

### DIFF
--- a/openstack/keystone/templates/daemonset-keep-image-pulled.yaml
+++ b/openstack/keystone/templates/daemonset-keep-image-pulled.yaml
@@ -85,7 +85,7 @@ spec:
               cpu: "1m"
               memory: "20Mi"
         - name: check
-          image: {{ required ".Values.global.registryAlternateRegion is missing" .Values.global.registryAlternateRegion}}/kube-python:1.0.1
+          image: {{ required ".Values.global.registryAlternateRegion is missing" .Values.global.registryAlternateRegion }}/shared-app-images/alpine-kubectl:latest-latest
           imagePullPolicy: IfNotPresent
           command: [ '/bin/sleep', '9999999999d' ]
           resources:


### PR DESCRIPTION
Replace rotten `ccloud/kube-python:1.0.1` with `shared-app-images/alpine-kubectl:latest-latest` in the `check` container of the `keystone-keep-image-pulled` and `keystone-global-keep-image-pulled` DaemonSets.

The container only runs `sleep` to keep the image cached on nodes — no Python dependency is needed. `alpine-kubectl:latest-latest` is actively maintained and has a Clean vulnerability status in Keppel.