### PR TITLE
fix(oauth-proxy): transfer ownership to team identity

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,7 +39,7 @@
 /global/gh-actions                                     @notandy @auhlig
 /global/git-cert-shim                                  @abhijith-darshan @IvoGoman @uwe-mayer
 /global/kibana-objecter                                @dimtass
-/global/oauth-proxy                                    @andypf @ArtieReus @databus23 @drochow
+/global/oauth-proxy                                    @BerndKue @tz3 @bbobrov
 /global/percona_cluster                                @galkindmitrii @occamshatchet @s10 @businessbean @MaximShepelev @vssldmtrv @mbrowny
 /global/persephone-liquid-apiserver                    @jknipper @ronchi-oss @SuperSandro2000
 /global/persephone-runtime-shoot                       @jknipper @ronchi-oss @SuperSandro2000

--- a/global/oauth-proxy/values.yaml
+++ b/global/oauth-proxy/values.yaml
@@ -9,11 +9,13 @@ image:
 replica_count: 2
 
 owner-info:
-  support-group: containers
+  support-group: identity
   service: oauth-proxy
   helm-chart-url: https://github.com/sapcc/helm-charts/tree/master/global/oauth-proxy
   maintainers:
-    - Fabian Ruff
+    - Bernd Kuespert
+    - Moutaz Chaara
+    - Boris Bobrov
 podAnnotations:
   prometheus.io/scrape: "true"
   prometheus.io/targets: "kubernetes"


### PR DESCRIPTION
The oauth-proxy helm chart was handed over to team identity a while back.
This updates `CODEOWNERS` and `owner-info` in `values.yaml` to reflect the current maintainers.
