### PR TITLE
[mariadb][backup-v2] support configurable S3 object lock on backup uploads

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.41.0 - 2026/07/06
+* support configurable S3 object lock on backup uploads
+  * default at `backup_v2.object_lock.{enabled,lock_mode,retention_days}`
+  * per-target overrides at `global.mariadb.backup_v2.aws.object_lock` and `global.mariadb.backup_v2.ceph_s3.targets[].object_lock`
+* `maria-back-me-up` updated to `10.11-20260706142324` for object-lock upload support
+* chart version bumped
+
 ## v0.40.0 - 2026/07/03
 * optionally cohost the mariadb and the mariadb-backup pods on the same node via the `.Values.backup_v2.cohost_with_mariadb` flag
 * chart version bumped

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.40.0
+version: 0.41.0
 # scripts/docker-entyrpoint.sh should be updated when appVersion is updated
 appVersion: 10.11.18
 dependencies:

--- a/common/mariadb/templates/_helpers.tpl
+++ b/common/mariadb/templates/_helpers.tpl
@@ -21,6 +21,35 @@
 {{- end -}}
 {{- end -}}
 
+{{/*
+  Emit S3 object-lock keys for a backup_v2 storage target, merging per-target
+  overrides onto the chart-level default (backup_v2.object_lock) per field.
+  Emits nothing when effectively disabled.
+  Usage:
+    include "mariadb.backup_v2.object_lock" (dict "target" $target.object_lock "default" .Values.backup_v2.object_lock)
+*/}}
+{{- define "mariadb.backup_v2.object_lock" -}}
+{{- $target := default (dict) .target -}}
+{{- $default := default (dict) .default -}}
+{{- $enabled := default false $default.enabled -}}
+{{- if hasKey $target "enabled" -}}{{- $enabled = $target.enabled -}}{{- end -}}
+{{- if $enabled -}}
+{{- $mode := default "COMPLIANCE" $default.lock_mode -}}
+{{- if hasKey $target "lock_mode" -}}{{- $mode = $target.lock_mode -}}{{- end -}}
+{{- if not (has $mode (list "COMPLIANCE" "GOVERNANCE")) -}}
+{{- fail (printf "backup_v2.object_lock.lock_mode must be COMPLIANCE or GOVERNANCE, got %q" $mode) -}}
+{{- end -}}
+{{- $days := default 7 $default.retention_days -}}
+{{- if hasKey $target "retention_days" -}}{{- $days = $target.retention_days -}}{{- end -}}
+{{- if not (gt (int $days) 0) -}}
+{{- fail (printf "backup_v2.object_lock.retention_days must be a positive integer, got %v" $days) -}}
+{{- end -}}
+object_lock_enabled: true
+object_lock_mode: {{ $mode | quote }}
+object_lock_retention_days: {{ $days }}
+{{- end -}}
+{{- end -}}
+
 {{- define "registry" -}}
 {{- if .Values.use_alternate_registry -}}
 {{- .Values.global.registryAlternateRegion -}}

--- a/common/mariadb/templates/config/_backup_config.yaml.tpl
+++ b/common/mariadb/templates/config/_backup_config.yaml.tpl
@@ -56,6 +56,11 @@ storages:
       bucket_name: "mariadb-backup-{{ .Values.global.region }}"
       sse_customer_algorithm: "AES256"
       sse_customer_key: {{ include "mariadb.resolve_secret_squote" .Values.global.mariadb.backup_v2.aws.sse_customer_key }}
+      {{- $awsOverride := dig "mariadb" "backup_v2" "aws" "object_lock" (dict) .Values.global }}
+      {{- $awsObjectLock := include "mariadb.backup_v2.object_lock" (dict "target" $awsOverride "default" .Values.backup_v2.object_lock) }}
+      {{- if $awsObjectLock }}
+      {{- $awsObjectLock | nindent 6 }}
+      {{- end }}
     {{- end }}
     {{- range $t := $cephTargets }}
     {{- $region := default $.Values.global.region $t.region }}
@@ -68,6 +73,10 @@ storages:
       bucket_name: {{ $t.bucket_name | default (printf "mariadb-backup-%s" $.Values.global.region) | quote }}
       {{- if ternary $t.verify $.Values.backup_v2.ceph_s3.verify (hasKey $t "verify") }}
       verify: true
+      {{- end }}
+      {{- $cephObjectLock := include "mariadb.backup_v2.object_lock" (dict "target" $t.object_lock "default" $.Values.backup_v2.object_lock) }}
+      {{- if $cephObjectLock }}
+      {{- $cephObjectLock | nindent 6 }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -224,7 +224,7 @@ backup_v2:
   cohost_with_mariadb: false
   backup_dir: "./backup"
   image: maria-back-me-up
-  image_version: "10.11-20260611113653"
+  image_version: "10.11-20260706142324"
   full_backup_cron_schedule: "0 0 * * *"
   incremental_backup_in_minutes: 5
   purge_binlog_after_minutes: 60
@@ -248,6 +248,20 @@ backup_v2:
     #     bucket_name: mariadb-backup-eu-de-2   # optional, defaults to mariadb-backup-<global.region>
     #     force_path_style: true                # optional, inherits chart-local default
     #     verify: false                         # optional, inherits chart-local default
+    #     object_lock: {...}                    # optional, see backup_v2.object_lock below
+  # Default S3 object-lock settings applied to every S3 target unless overridden.
+  # Per-target overrides (per-field; omit a field to inherit the default below):
+  #   AWS:  global.mariadb.backup_v2.aws.object_lock
+  #   Ceph: global.mariadb.backup_v2.ceph_s3.targets[].object_lock
+  # Example per-target block:
+  #   object_lock:
+  #     enabled: true
+  #     lock_mode: COMPLIANCE   # or GOVERNANCE
+  #     retention_days: 7
+  object_lock:
+    enabled: false
+    lock_mode: COMPLIANCE # or GOVERNANCE
+    retention_days: 7
   swift:
     enabled: true
     user_name: db_backup


### PR DESCRIPTION
* default at `backup_v2.object_lock.{enabled,lock_mode,retention_days}`
* per-target overrides at `global.mariadb.backup_v2.aws.object_lock` and `global.mariadb.backup_v2.ceph_s3.targets[].object_lock`
* `maria-back-me-up` updated to `10.11-20260706142324` for object-lock upload support
* chart version bumped