### PR TITLE
openstack/utils: allow overriding rabbit_qos_prefetch_count

### DIFF
--- a/openstack/utils/Chart.yaml
+++ b/openstack/utils/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: utils
-version: 0.38.0
+version: 0.38.1

--- a/openstack/utils/templates/_ini_sections.tpl
+++ b/openstack/utils/templates/_ini_sections.tpl
@@ -6,6 +6,16 @@ heartbeat_in_pthread = False
     {{- if .Values.rabbitmq_ssl_client }}
 ssl = {{ .Values.rabbitmq_ssl_client }}
     {{- end }}
+    {{- /* https://www.rabbitmq.com/docs/consumer-prefetch */}}
+    {{- $prefetch := "" }}
+    {{- if hasKey .Values "rabbit_qos_prefetch_count" }}
+        {{- $prefetch = .Values.rabbit_qos_prefetch_count | toString }}
+    {{- else if hasKey .Values.global "rabbit_qos_prefetch_count" }}
+        {{- $prefetch = .Values.global.rabbit_qos_prefetch_count | toString }}
+    {{- end }}
+    {{- if ne $prefetch "" }}
+rabbit_qos_prefetch_count = {{ $prefetch }}
+    {{- end }}
 {{- end }}
 
 {{- define "ini_sections.default_transport_url" }}


### PR DESCRIPTION
With the default of 0 (unlimited), RabbitMQ pushes messages without
bound. The current docs recommend values in the 100-300 range for
optimal throughput; lower values reduce throughput noticeably,
especially at higher consumer-broker latency.

Per-chart and global override; unset preserves current output.

See https://www.rabbitmq.com/docs/confirms#channel-qos-prefetch-throughput