### PR TITLE
fix(netapp-harvest-exporter): improve castellum label sentinel alert

### DIFF
--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/alerts/storage/manila.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/alerts/storage/manila.yaml
@@ -97,7 +97,7 @@ groups:
           count by (share_id) (manila_share_size_bytes_for_castellum)
           unless
           count by (share_id) (manila_share_size_bytes_for_castellum{volume_state!="", volume_type!=""})
-        for: 5m
+        for: 30m
         labels:
           severity: warning
           context: castellum
@@ -118,7 +118,7 @@ groups:
           count by (share_id) (netapp_volume_used_bytes_for_limes)
           unless
           count by (share_id) (netapp_volume_used_bytes_for_limes{availability_zone!="", project_id!="", share_type!=""})
-        for: 5m
+        for: 30m
         labels:
           severity: warning
           context: limes

--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/alerts/storage/manila.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/alerts/storage/manila.yaml
@@ -112,3 +112,24 @@ groups:
             volume_state or volume_type label for share {{ $labels.share_id }}.
             Castellum filters on {volume_type!="dp", volume_state!="offline"} — without
             these labels, autoscaling decisions may be affected.
+
+      - alert: ManilaShareLimesMissingLabels
+        expr: |
+          count by (share_id) (netapp_volume_used_bytes_for_limes)
+          unless
+          count by (share_id) (netapp_volume_used_bytes_for_limes{availability_zone!="", project_id!="", share_type!=""})
+        for: 5m
+        labels:
+          severity: warning
+          context: limes
+          service: manila
+          tier: os
+          support_group: compute-storage-api
+          support_component: manila_netapp
+        annotations:
+          summary: 'netapp_volume_used_bytes_for_limes is missing availability_zone, project_id, or share_type label'
+          description: >
+            The limes recording rule for manila share used bytes is missing one or more
+            required labels (availability_zone, project_id, share_type) for share
+            {{ $labels.share_id }}. Limes aggregates by these labels — missing labels
+            cause usage to be silently misattributed.

--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/alerts/storage/manila.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/alerts/storage/manila.yaml
@@ -91,3 +91,24 @@ groups:
         annotations:
           description: 'Netapp volume {{$labels.volume}} (Share {{$labels.share_id}}) has logical space reporting enabled but logical space enforcement disabled'
           summary: 'Netapp volume logical space reporting is enabled but logical space enforcement is disabled'
+
+      - alert: ManilaShareCastellumMissingLabels
+        expr: |
+          count by (share_id) (manila_share_size_bytes_for_castellum)
+          unless
+          count by (share_id) (manila_share_size_bytes_for_castellum{volume_state!="", volume_type!=""})
+        for: 5m
+        labels:
+          severity: warning
+          context: castellum
+          service: manila
+          tier: os
+          support_group: compute-storage-api
+          support_component: manila_netapp
+        annotations:
+          summary: 'manila_share_size_bytes_for_castellum is missing volume_state or volume_type label'
+          description: >
+            The castellum recording rule for manila share size is missing the
+            volume_state or volume_type label for share {{ $labels.share_id }}.
+            Castellum filters on {volume_type!="dp", volume_state!="offline"} — without
+            these labels, autoscaling decisions may be affected.


### PR DESCRIPTION
## Summary

- Rename `ManilaShareCastellumMissingVolumeStateLabel` to `ManilaShareCastellumMissingLabels`
- Change expr to per-`share_id` detection using `count by (share_id)` + `unless`, covering all three provision cases independently
- Test both `volume_state` and `volume_type` on RHS — matching the full label set Castellum filters on (`{volume_type!="dp", volume_state!="offline"}`)
