### PR TITLE
fix(node-problem-detector): bump to v1.35.2 to fix Critical CVEs

### DIFF
--- a/system/node-problem-detector/Chart.yaml
+++ b/system/node-problem-detector/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Node Problem Detector for Kubernetes
 name: node-problem-detector
-version: 1.3.13
-appVersion: v0.8.25
+version: 1.3.14
+appVersion: v1.35.2

--- a/system/node-problem-detector/values.yaml
+++ b/system/node-problem-detector/values.yaml
@@ -36,7 +36,7 @@ customPluginMonitors:
 # Additional volume mounts from host.
 additionalHostVolumeMounts: []
   # Required by the bridge monitor.
-  #- name: hostproc
+  # - name: hostproc
   #  hostPath: /proc
   #  mountPath: /host/proc
   #  readOnly: true

--- a/system/node-problem-detector/values.yaml
+++ b/system/node-problem-detector/values.yaml
@@ -4,7 +4,7 @@ global:
 
 image:
   repository: node-problem-detector/node-problem-detector
-  tag: v0.8.25
+  tag: v1.35.2
 
 resources:
   limits:


### PR DESCRIPTION
Fixes:
- CVE-2025-22871 (Critical) Go net/http request smuggling
- CVE-2026-33186 (Critical) grpc authorization bypass

v1.35.2 uses Go 1.25.7 and grpc v1.77.0 but master branch already has grpc v1.79.3. Image v1.35.2 is available in Keppel mirror ccloud-registry-k8s-io-mirror (mirrored from registry.k8s.io).

Deployed on: metal, kubernikus, virtual, scaleout, admin-k3s clusters
SLA deadline: 2026-04-23 (overdue)