### PR TITLE
fix(kube-system-*): bump cert-manager to v1.20.3 for scaleout/virtual…

### DIFF
--- a/system/kube-system-admin-k3s/Chart.lock
+++ b/system/kube-system-admin-k3s/Chart.lock
@@ -16,10 +16,10 @@ dependencies:
   version: 2.0.13
 - name: cert-manager
   repository: https://charts.jetstack.io
-  version: v1.13.3
+  version: v1.20.3
 - name: digicert-issuer
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 2.8.0
+  version: 2.8.1
 - name: priority-class
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.0.0
@@ -31,7 +31,7 @@ dependencies:
   version: 0.2.0
 - name: owner-label-injector
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.0.4
+  version: 1.0.6
 - name: toolbox-prepull
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.7
@@ -41,5 +41,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 1.2.0
-digest: sha256:6d4b0d8fa431bc8e419c9747b50a150ff12ab622934ebbdf7aa12cd5f7a901a7
-generated: "2026-05-27T12:05:02.433099+02:00"
+digest: sha256:a5d9c32c531f8a7f0c3be94ae746f769a7ddf95acb0d52afa2a0863eecda807f
+generated: "2026-07-06T22:18:12.258841+02:00"

--- a/system/kube-system-admin-k3s/Chart.yaml
+++ b/system/kube-system-admin-k3s/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kube-System relevant Service collection for the new admin clusters.
 name: kube-system-admin-k3s
-version: 3.7.1
+version: 3.7.2
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-admin-k3s
 dependencies:
   - name: node-problem-detector
@@ -22,7 +22,7 @@ dependencies:
     version: ">= 0.0.0"
   - name: cert-manager
     repository: https://charts.jetstack.io
-    version: 1.13.3
+    version: 1.20.3
   - name: digicert-issuer
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^2.x"

--- a/system/kube-system-admin-k3s/values.yaml
+++ b/system/kube-system-admin-k3s/values.yaml
@@ -50,7 +50,7 @@ cert-manager:
   installCRDs: true
   image:
     repository: keppel.global.cloud.sap/ccloud-quay-mirror/jetstack/cert-manager-controller
-    tag: v1.13.3
+    tag: v1.20.3
   webhook:
     image:
       repository: keppel.global.cloud.sap/ccloud-quay-mirror/jetstack/cert-manager-webhook
@@ -61,7 +61,7 @@ cert-manager:
       - --leader-elect=false
   startupapicheck:
     image:
-      repository: keppel.global.cloud.sap/ccloud-quay-mirror/jetstack/cert-manager-ctl
+      repository: keppel.global.cloud.sap/ccloud-quay-mirror/jetstack/cert-manager-startupapicheck
   ingressShim:
     defaultIssuerName: digicert-issuer
     defaultIssuerKind: ClusterIssuer

--- a/system/kube-system-kubernikus/Chart.lock
+++ b/system/kube-system-kubernikus/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 9.0.0
 - name: cert-manager
   repository: https://charts.jetstack.io
-  version: v1.13.3
+  version: v1.20.3
 - name: digicert-issuer
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.8.1
@@ -41,5 +41,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 1.2.0
-digest: sha256:5b533506da2ae6a4823bc8b473bd29a0474452be7cb17d1e33d7d767c51a1275
-generated: "2026-07-06T15:51:45.420777224Z"
+digest: sha256:6cdee9e8f360049e4767821fad303ba72ff00d62ab8e08abc1e84935de0c3c33
+generated: "2026-07-06T22:18:05.445662+02:00"

--- a/system/kube-system-kubernikus/Chart.yaml
+++ b/system/kube-system-kubernikus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for Kubernikus control-plane clusters.
 name: kube-system-kubernikus
-version: 3.10.1
+version: 3.10.2
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-kubernikus
 dependencies:
   - name: cc-rbac
@@ -19,7 +19,7 @@ dependencies:
     version: 9.0.0
   - name: cert-manager
     repository: https://charts.jetstack.io
-    version: 1.13.3
+    version: 1.20.3
   - name: digicert-issuer
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^2.x"

--- a/system/kube-system-kubernikus/values.yaml
+++ b/system/kube-system-kubernikus/values.yaml
@@ -11,7 +11,7 @@ cert-manager:
   installCRDs: true
   image:
     repository: keppel.eu-de-1.cloud.sap/ccloud-quay-mirror/jetstack/cert-manager-controller
-    tag: v1.13.3
+    tag: v1.20.3
   webhook:
     image:
       repository: keppel.eu-de-1.cloud.sap/ccloud-quay-mirror/jetstack/cert-manager-webhook
@@ -22,7 +22,7 @@ cert-manager:
     - --leader-elect=false
   startupapicheck:
     image:
-      repository: keppel.eu-de-1.cloud.sap/ccloud-quay-mirror/jetstack/cert-manager-ctl
+      repository: keppel.eu-de-1.cloud.sap/ccloud-quay-mirror/jetstack/cert-manager-startupapicheck
   ingressShim:
     defaultIssuerName: digicert-issuer
     defaultIssuerKind: ClusterIssuer

--- a/system/kube-system-scaleout/Chart.lock
+++ b/system/kube-system-scaleout/Chart.lock
@@ -19,10 +19,10 @@ dependencies:
   version: 9.0.0
 - name: cert-manager
   repository: https://charts.jetstack.io
-  version: v1.13.3
+  version: v1.20.3
 - name: digicert-issuer
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 2.8.0
+  version: 2.8.1
 - name: metrics-server
   repository: https://kubernetes-sigs.github.io/metrics-server
   version: 3.13.0
@@ -44,5 +44,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 1.2.0
-digest: sha256:711521327df5efd5df8117ecb5a50f352204be3329d2210db7bf0bf2f9fab5ae
-generated: "2026-06-09T10:23:24.628925+03:00"
+digest: sha256:54e7abe79f8ebd2d8e3c883aa79510b68459e54d674b447eb155ed653b312c38
+generated: "2026-07-06T22:17:47.732574+02:00"

--- a/system/kube-system-scaleout/Chart.yaml
+++ b/system/kube-system-scaleout/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kube-System relevant Service collection for scaleout clusters.
 name: kube-system-scaleout
-version: 5.13.0
+version: 5.13.1
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-scaleout
 dependencies:
   - name: cc-rbac
@@ -28,7 +28,7 @@ dependencies:
     version: 9.0.0
   - name: cert-manager
     repository: https://charts.jetstack.io
-    version: 1.13.3
+    version: 1.20.3
   - name: digicert-issuer
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^2.x"

--- a/system/kube-system-virtual/Chart.lock
+++ b/system/kube-system-virtual/Chart.lock
@@ -25,10 +25,10 @@ dependencies:
   version: 3.1.8
 - name: cert-manager
   repository: https://charts.jetstack.io
-  version: v1.13.3
+  version: v1.20.3
 - name: digicert-issuer
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 2.8.0
+  version: 2.8.1
 - name: toolbox-prepull
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.7
@@ -56,5 +56,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 1.2.0
-digest: sha256:7a37e49f7c00d48cf3a983aec0d9f2ebe142467d84ac9e48aaea0b0a3de878ea
-generated: "2026-06-09T06:24:34.926640667Z"
+digest: sha256:6942fa02bb460576bfcc51439f307153f6685290371ecc3656076001976cb576
+generated: "2026-07-06T22:17:56.913499+02:00"

--- a/system/kube-system-virtual/Chart.yaml
+++ b/system/kube-system-virtual/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for virtual clusters.
 name: kube-system-virtual
-version: 4.9.2
+version: 4.9.3
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-virtual
 dependencies:
   - name: cc-rbac
@@ -30,7 +30,7 @@ dependencies:
     version: '>= 0.0.0'
   - name: cert-manager
     repository: https://charts.jetstack.io
-    version: 1.13.3
+    version: 1.20.3
   - name: digicert-issuer
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^2.x"

--- a/system/kube-system-virtual/values.yaml
+++ b/system/kube-system-virtual/values.yaml
@@ -63,7 +63,7 @@ cert-manager:
   installCRDs: true
   image:
     repository: keppel.global.cloud.sap/ccloud-quay-mirror/jetstack/cert-manager-controller
-    tag: v1.13.3
+    tag: v1.20.3
   webhook:
     image:
       repository: keppel.global.cloud.sap/ccloud-quay-mirror/jetstack/cert-manager-webhook
@@ -74,7 +74,7 @@ cert-manager:
     - --leader-elect=false
   startupapicheck:
     image:
-      repository: keppel.global.cloud.sap/ccloud-quay-mirror/jetstack/cert-manager-ctl
+      repository: keppel.global.cloud.sap/ccloud-quay-mirror/jetstack/cert-manager-startupapicheck
   ingressShim:
     defaultIssuerName: digicert-issuer
     defaultIssuerKind: ClusterIssuer


### PR DESCRIPTION
…/kubernikus/admin-k3s

Fixes CVE-2025-22871 (Critical) and CVE-2022-23806 (Critical) on scaleout, virtual, kubernikus and admin-k3s cluster types. These were missed in the initial cert-manager upgrade which only covered kube-system-metal.

Also renames cert-manager-ctl to cert-manager-startupapicheck (renamed in v1.15) and updates Chart.lock to digicert-issuer 2.8.1.