### PR TITLE
[cc-shoots-mgmt] fix zoneSelection schema (object with .mode field)

### DIFF
--- a/system/cc-shoots-mgmt/Chart.yaml
+++ b/system/cc-shoots-mgmt/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-shoots-mgmt
 description: Converged Cloud Gardener shoots
 type: application
-version: 1.1.33
+version: 1.1.34
 appVersion: "0.1.0"

--- a/system/cc-shoots-mgmt/templates/managedseed.yaml
+++ b/system/cc-shoots-mgmt/templates/managedseed.yaml
@@ -76,13 +76,14 @@ spec:
                 enabled: false
             # Pin non-HA / failureToleranceType=node shoot control planes to
             # the same AZ as the shoot's worker pool(s). Upstream feature:
-            # gardener/gardener#14238. Defaults to "Prefer" which never
+            # gardener/gardener#14238. Defaults to mode "Prefer" which never
             # blocks scheduling — shoots whose worker zones do not intersect
             # this seed's spec.provider.zones (e.g. workerless shoots) fall
             # back to random placement, same as before the setting was
             # introduced. Overridable per-landscape via
             # mgmtShoots.<landscape>.zoneSelection (e.g. "Enforce" once each
             # landscape has confirmed all shoots have matching zones).
-            zoneSelection: {{ default "Prefer" $cluster.zoneSelection | quote }}
+            zoneSelection:
+              mode: {{ default "Prefer" $cluster.zoneSelection | quote }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Summary

Fixes the schema of `Seed.spec.settings.zoneSelection` rendered by `system/cc-shoots-mgmt`. The prior PR (#12197) rendered it as a plain string, but the upstream Gardener API expects an object with a `mode` field.

## What was broken

PR #12197 rendered:

```yaml
zoneSelection: "Prefer"
```

The Concourse pipeline `cc-shoots-mgmt / g-qa-de-1-deploy` build #124 failed with:

```
Error: UPGRADE FAILED: cannot patch "mgmt-qa-de-1" with kind ManagedSeed:  "" is invalid:
patch: Invalid value: "...": json: cannot unmarshal string into Go struct field
SeedSettings.seedConfig.SeedTemplate.spec.settings.zoneSelection of type
v1beta1.SeedSettingZoneSelection
```

The upstream `SeedSettingZoneSelection` type is a **struct**, not a plain enum.

## Verified schema

Against the live CRD on `g-qa-de-1`:

```
$ kubectl explain seed.spec.settings.zoneSelection
FIELD: zoneSelection <SeedSettingZoneSelection>
    ...
FIELDS:
  mode <string> -required-
    Mode controls the zone selection behavior. "Prefer" tries to match worker
    pool zones to seed zones, falling back to random selection on mismatch.
    "Enforce" requires worker pool zones to be present in the seed's zone list;
    scheduling fails otherwise.
```

Correct shape:

```yaml
zoneSelection:
  mode: Prefer   # or: Enforce
```

## The fix

Template change (2 lines):

```diff
-zoneSelection: {{ default "Prefer" $cluster.zoneSelection | quote }}
+zoneSelection:
+  mode: {{ default "Prefer" $cluster.zoneSelection | quote }}
```

The values interface stays the same (`mgmtShoots.<landscape>.zoneSelection: "Prefer"` or `"Enforce"`), so no downstream values files need to change.

## Verification

- `helm lint system/cc-shoots-mgmt/` → passes.
- `helm template` with default values renders:
  ```yaml
  zoneSelection:
    mode: "Prefer"
  ```
- `helm template` with `mgmtShoots.<landscape>.zoneSelection: Enforce` renders:
  ```yaml
  zoneSelection:
    mode: "Enforce"
  ```
- **Server-side dry-run** against `g-qa-de-1` accepts the object shape end-to-end. The only rejection is the (expected) "shoot already registered as seed" business-logic error, confirming schema deserialization now succeeds:
  ```
  $ kubectl apply --dry-run=server -f rendered-ms.yaml
  The ManagedSeed "dryrun-check-zoneselection" is invalid:
  spec.shoot.name: Invalid value: "mgmt-qa-de-1":
  shoot garden/mgmt-qa-de-1 already registered as seed
  ```
  (No `unmarshal` error → parser is happy.)

## Related

- Broken by: #12197
- Concourse build that surfaced the failure: `cc-shoots-mgmt / g-qa-de-1-deploy` #124
- Upstream feature: [gardener/gardener#14238](https://github.com/gardener/gardener/pull/14238)