### PR TITLE
removing MemFrequency: MaxPerf from Bios Settings

### DIFF
--- a/system/metal-settings/Chart.yaml
+++ b/system/metal-settings/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.23
+version: 0.2.24
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/metal-settings/bios_settings/dell-r860-kvm.yaml
+++ b/system/metal-settings/bios_settings/dell-r860-kvm.yaml
@@ -27,6 +27,5 @@ settingsFlow:
     ProcUncoreFreqRapl: Disabled
     LlcPrefetch: Enabled
     AdddcSetting: Disabled
-    MemFrequency: MaxPerf
     SysProfile: PerfOptimized
     


### PR DESCRIPTION
removing MemFrequency: MaxPerf from Bios Settings