### PR TITLE
fix(maia): align prometheus_kvm federation metrics with current kvm-exporter names

### DIFF
--- a/openstack/maia/values.yaml
+++ b/openstack/maia/values.yaml
@@ -210,18 +210,18 @@ prometheus_kvm:
   scrape_interval: 1m
   scrape_timeout: 55s
   matches:
-    - kvm_domain_libvirt_info_vstate
+    - kvm_domain_libvirt_info_state
     - kvm_domain_libvirt_info_virtual_cpus
     - kvm_domain_libvirt_info_maximum_memory_bytes
     - kvm_domain_libvirt_vcpu_time_seconds_total
-    - kvm_domain_libvirt_steal_time
-    - kvm_domain_libvirt_vcpu_delay_nanoseconds
-    - kvm_domain_libvirt_memory_stats_rss_bytes
-    - kvm_domain_libvirt_memory_stats_used_percent
-    - kvm_domain_libvirt_interface_rx_bytes_total
-    - kvm_domain_libvirt_interface_tx_bytes_total
-    - kvm_domain_libvirt_interface_rx_drop_total
-    - kvm_domain_libvirt_interface_tx_drop_total
+    - kvm_domain_libvirt_vcpu_delay_nanoseconds_total
+    - kvm_domain_libvirt_steal_time_ratio
+    - kvm_domain_libvirt_memory_stats_host_rss_bytes
+    - kvm_domain_libvirt_memory_stats_used_ratio
+    - kvm_domain_libvirt_interface_stats_receive_bytes_total
+    - kvm_domain_libvirt_interface_stats_transmit_bytes_total
+    - kvm_domain_libvirt_interface_stats_receive_drops_total
+    - kvm_domain_libvirt_interface_stats_transmit_drops_total
     - kvm_domain_libvirt_block_stats_read_bytes_total
     - kvm_domain_libvirt_block_stats_read_requests_total
     - kvm_domain_libvirt_block_stats_write_bytes_total


### PR DESCRIPTION
The `prometheus_kvm.matches` list in `maia/values.yaml` referenced stale metric names that no longer exist in [kvm-exporter](https://github.com/cobaltcore-dev/kvm-exporter), causing the federation scrape to silently return no data for all KVM metrics in Maia.

Updated all metric names to match the current [kvm-exporter](https://github.com/cobaltcore-dev/kvm-exporter) release (cobaltcore-dev/kvm-exporter#254).