### PR TITLE
hermes: gate Octobus audit forwarding with logstash.octobus.enabled

### DIFF
--- a/openstack/hermes/Chart.yaml
+++ b/openstack/hermes/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm audit management for Openstack
 maintainers:
   - name: notque
 name: hermes
-version: 0.2.5
+version: 0.2.6
 dependencies:
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/hermes/templates/etc/_logstash.conf.tpl
+++ b/openstack/hermes/templates/etc/_logstash.conf.tpl
@@ -576,6 +576,7 @@ output {
   {{- if .Values.logstash.audit }}
   if [type] == 'audit' {
     if (([initiator][domain] == 'Default' and [initiator][name] == 'admin') or [initiator][domain] == 'ccadmin' or [target][project_domain_name] == 'ccadmin' or [initiator][project_domain_name] == 'ccadmin') or ([observer][typeURI] == 'service/security' and [action] == "authenticate" and [outcome] == 'failure') or ([observer][typeURI] == 'service/security' and ([action] == 'create/user') or [action] == 'delete/user') or [observer][typeURI] == 'service/data/security/keymanager' or [target][typeURI] ==  'data/security/project' {
+      {{- if .Values.logstash.octobus.enabled }}
       http {
         id => "output_octobus_audit"
         ssl_certificate_authorities => "/usr/share/logstash/config/ca.pem"
@@ -585,6 +586,7 @@ output {
         automatic_retries => 60
         retry_non_idempotent => true
       }
+      {{- end }}
       {{- if .Values.logstash.kafka.enabled }}
       # Kafka output mirroring the Octobus audit filter above.
       # Public CA, no client credentials at present (SSL server-auth only).

--- a/openstack/hermes/values.yaml
+++ b/openstack/hermes/values.yaml
@@ -58,6 +58,15 @@ logstash:
   debug: false
   swift: true
   audit: true
+  # Octobus HTTP audit forwarding.
+  # On by default so existing regions keep their current behavior. Override to
+  # false in region secrets for regions that must not ship audit events to
+  # Octobus (e.g. eu-de-1, eu-de-3 — Fortlogs SIEM via the kafka output below
+  # remains the audit sink for those regions).
+  # Gates only the Octobus http output; the audit filter chain and the kafka
+  # (Fortlogs) output are independent.
+  octobus:
+    enabled: true
   # Kafka output mirroring the Octobus audit filter.
   # Off by default; enable per-region. Public CA, no client credentials.
   # global.forwarding.kafka.bootstrap_servers must be set in region secrets


### PR DESCRIPTION
## What

Adds a dedicated `logstash.octobus.enabled` flag (default `true`) to the hermes chart, gating only the Octobus HTTP audit output in `_logstash.conf.tpl`.

## Why

We need eu-de-1 and eu-de-3 to stop forwarding audit events to Octobus while continuing to ship those same events to Fortlogs SIEM (via the existing kafka output). Previously, the only lever was `logstash.audit`, which also gates the JDBC/Metis keystone-domain enrichment used by the OpenSearch output — turning it off region-wide would have regressed enrichment for all local audit consumers.

## Behavior

- **Default (`logstash.octobus.enabled: true`)**: chart renders identically to before. No behavior change for any region that doesn't override.
- **Overridden (`logstash.octobus.enabled: false`)**: the Octobus `http { ... }` output block is omitted. The `audit` clone still runs, so the kafka (Fortlogs) output and any future audit outputs continue to receive events.
- `logstash.audit` and `logstash.kafka.enabled` semantics unchanged.

## Verification

`helm template` against `ci/test-values.yaml`:

| Config | `output_octobus_audit` blocks rendered |
|---|---|
| Defaults | 1 ✅ |
| `--set logstash.octobus.enabled=false` | 0 ✅ |

Rendered logstash.conf remains structurally valid in both cases (empty conditional bodies are legal in Logstash config syntax).

## Follow-up (separate repos)

- `eu-de-1` region secrets: set `logstash.octobus.enabled: false`
- `eu-de-3` region secrets: set `logstash.octobus.enabled: false`
- All other regions: no change required (inherit `true` from `values.yaml`)

## Diff size

11 additions, 0 deletions across 2 files.