### PR TITLE
metal-operator-dhcp: support per-pool url override in remote dhcpPools

### DIFF
--- a/system/metal-operator-dhcp/Chart.yaml
+++ b/system/metal-operator-dhcp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: metal-operator-dhcp
 description: A Helm chart for the Ironcore metal-operator-dhcp.
 type: application
-version: 2.3.2
+version: 2.3.3
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/system/metal-operator-dhcp/templates/configmap-dnsmasq.yaml
+++ b/system/metal-operator-dhcp/templates/configmap-dnsmasq.yaml
@@ -31,9 +31,10 @@ data:
     {{- $ipPoolStart := $pool.ipPoolStart -}}
     {{- $ipPoolEnd := $pool.ipPoolEnd -}}
     {{- $router := $pool.router -}}
+    {{- $url := default $.Values.remote.url $pool.url -}}
     dhcp-range=set:{{ $pool.subnetPrefix }},{{ $ipPoolStart }},{{ $ipPoolEnd }},{{ $pool.mask }},{{ $.Values.dnsmasq.leaseTime }}
     dhcp-option=set:{{ $pool.subnetPrefix }},option:router,{{ $router }}
-    dhcp-boot=tag:{{ $pool.subnetPrefix }},tag:ipxe,{{ $.Values.remote.url }}/ipxe/${uuid}
+    dhcp-boot=tag:{{ $pool.subnetPrefix }},tag:ipxe,{{ $url }}/ipxe/${uuid}
     {{ end }}
     {{ end }}
 


### PR DESCRIPTION
Allow individual pools under remote.dhcpPools to specify a url that overrides the top-level remote.url for that pool's dhcp-boot entry. Pools without a url fall back to remote.url.