### PR TITLE
[opensearch-logs] own storage template

### DIFF
--- a/system/opensearch-logs/templates/config/_ds-storage.json.tpl
+++ b/system/opensearch-logs/templates/config/_ds-storage.json.tpl
@@ -4,7 +4,7 @@
   ],
   "template": {
     "settings": {
-      "index.number_of_shards": "4",
+      "index.number_of_shards": "6",
       "index.number_of_replicas": "1",
       "index.append_only.enabled": true,
       "index.refresh_interval": "120s",

--- a/system/opensearch-logs/templates/config/_ds-storage.json.tpl
+++ b/system/opensearch-logs/templates/config/_ds-storage.json.tpl
@@ -1,0 +1,72 @@
+{
+  "index_patterns": [
+    "_DS_NAME_-datastream*"
+  ],
+  "template": {
+    "settings": {
+      "index.number_of_shards": "4",
+      "index.number_of_replicas": "1",
+      "index.append_only.enabled": true,
+      "index.refresh_interval": "120s",
+      "index.translog.sync_interval": "120s",
+      "index.translog.durability": "async"
+    },
+    "mappings": {
+      "dynamic_templates": [
+        {
+          "resource_strings_as_keyword": {
+            "path_match": "resource.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
+        {
+          "attributes_strings_as_keyword": {
+            "path_match": "attributes.*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
+        {
+          "attributes_long_as_float": {
+            "path_match": "attributes.*",
+            "match_mapping_type": "long",
+            "mapping": {
+              "type": "float",
+              "ignore_malformed": true
+            }
+          }
+        },
+        {
+          "attributes_double_as_float": {
+            "path_match": "attributes.*",
+            "match_mapping_type": "double",
+            "mapping": {
+              "type": "float",
+              "ignore_malformed": true
+            }
+          }
+        }
+      ]
+    },
+    "aliases": {
+      "_DS_NAME_-ds": {}
+    }
+  },
+  "composed_of": [],
+  "priority": "0",
+  "_meta": {
+    "flow": "simple"
+  },
+  "data_stream": {
+    "timestamp_field": {
+      "name": "@timestamp"
+    }
+  }
+}

--- a/system/opensearch-logs/templates/security-config-secrets.yaml
+++ b/system/opensearch-logs/templates/security-config-secrets.yaml
@@ -33,6 +33,7 @@ data:
   ds-traces-ism.json: {{ include (print .Template.BasePath  "/config/_ds-traces-ism.json.tpl") . | b64enc }}
   ds-logs-swift-ism.json: {{ include (print .Template.BasePath  "/config/_ds-logs-swift-ism.json.tpl") . | b64enc }}
   ds-storage-ism.json: {{ include (print .Template.BasePath  "/config/_ds-storage-ism.json.tpl") . | b64enc }}
+  ds-storage.json: {{ include (print .Template.BasePath  "/config/_ds-storage.json.tpl") . | b64enc }}
   ds.json: {{ include (print .Template.BasePath  "/config/_ds.json.tpl") . | b64enc }}
   ds-cronus-ism.json: {{ include (print .Template.BasePath  "/config/_ds-cronus-ism.json.tpl") . | b64enc }}
   ds-cronus.json: {{ include (print .Template.BasePath  "/config/_ds-cronus.json.tpl") . | b64enc }}


### PR DESCRIPTION
Storage needs an own template because of different json field types for the same fields. 
To make heavy ingestion for storage work, we increase the refresh interval of the index to 2 minutes and increase the shard numbers.