### PR TITLE
provider-kubernikus: keep manager ClusterRole name stable across regens

### DIFF
--- a/system/Makefile
+++ b/system/Makefile
@@ -115,6 +115,15 @@ build-provider-metal:
 
 build-provider-kubernikus:
 	$(call build-chart,provider-kubernikus,https://github.com/sapcc/cluster-api-control-plane-provider-kubernikus//config/default,$(PROVIDER_KUBERNIKUS_VERSION))
+	@# helmify names the manager ClusterRole after the upstream role ("cluster-api-control-plane-provider-kubernikus"),
+	@# producing capi-cp-provider-kubernikus-cluster-api-control-plane-provider-kubernikus. That's the manager role,
+	@# so rename it back to <fullname>-manager-role and keep the manager rolebinding pointing at it. Renaming an
+	@# existing ClusterRoleBinding.roleRef is rejected by the API server, so this stability matters across bumps.
+	@if [ -f provider-kubernikus/templates/cluster-api-control-plane-provider-kubernikus-rbac.yaml ]; then \
+		mv provider-kubernikus/templates/cluster-api-control-plane-provider-kubernikus-rbac.yaml \
+		   provider-kubernikus/templates/manager-clusterrole.yaml; \
+	fi
+	@find provider-kubernikus/templates -type f -exec $(SED) -i -e 's#-cluster-api-control-plane-provider-kubernikus#-manager-role#g' {} \;
 	@yq -i '.controllerManager.manager.image.tag="$(PROVIDER_KUBERNIKUS_VERSION)"' provider-kubernikus/values.yaml
 	@yq -i '.fullnameOverride="capi-cp-provider-kubernikus"' provider-kubernikus/values.yaml
 

--- a/system/provider-kubernikus/Chart.yaml
+++ b/system/provider-kubernikus/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/provider-kubernikus/templates/manager-clusterrole.yaml
+++ b/system/provider-kubernikus/templates/manager-clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "provider-kubernikus.fullname" . }}-cluster-api-control-plane-provider-kubernikus
+  name: {{ include "provider-kubernikus.fullname" . }}-manager-role
   labels:
     cluster.x-k8s.io/provider: kubernikus
   {{- include "provider-kubernikus.labels" . | nindent 4 }}

--- a/system/provider-kubernikus/templates/manager-rbac.yaml
+++ b/system/provider-kubernikus/templates/manager-rbac.yaml
@@ -11,7 +11,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: '{{ include "provider-kubernikus.fullname" . }}-cluster-api-control-plane-provider-kubernikus'
+  name: '{{ include "provider-kubernikus.fullname" . }}-manager-role'
 subjects:
 - kind: ServiceAccount
   name: '{{ include "provider-kubernikus.serviceAccountName" . }}'


### PR DESCRIPTION
The upstream cluster-api-control-plane-provider-kubernikus kustomize output names the manager ClusterRole after itself, so helmify produced

  capi-cp-provider-kubernikus-cluster-api-control-plane-provider-kubernikus

on the last bump (#12191). Since the ClusterRoleBinding of the same manager already exists on cluster with roleRef.name pointing at the previous '-manager-role' suffix, and Kubernetes forbids mutating roleRef, helm upgrade failed with:

  cannot patch "capi-cp-provider-kubernikus-manager-rolebinding" ...
  roleRef: Invalid value: ... cannot change roleRef

Rename the ClusterRole back to <fullname>-manager-role (matches what is already on cluster) and add a sed rewrite in the Makefile target so future regens keep the stable name automatically.

Bumps provider-kubernikus 0.2.2 -> 0.2.3.