### PR TITLE
feat(metal-operator-dhcp): add DHCP option 54 server-identifier

### DIFF
--- a/system/metal-operator-dhcp/Chart.yaml
+++ b/system/metal-operator-dhcp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: metal-operator-dhcp
 description: A Helm chart for the Ironcore metal-operator-dhcp.
 type: application
-version: 2.3.2
+version: 2.4.0
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/system/metal-operator-dhcp/templates/configmap-dnsmasq.yaml
+++ b/system/metal-operator-dhcp/templates/configmap-dnsmasq.yaml
@@ -43,6 +43,10 @@ data:
     {{- end }}
     {{- end }}
 
+    # DHCP option 54: advertise the external/VIP as the server-identifier so
+    # clients send renewals to the load-balanced address, not the pod/node IP.
+    dhcp-option=option:server-identifier,{{ .Values.dnsmasq.externalIP }}
+
     # Set dns servers
     dhcp-option=6,{{ .Values.dnsmasq.dnsServers }}
     dhcp-option=option:domain-name,cc.{{ .Values.global.region }}.cloud.sap


### PR DESCRIPTION
## Summary

Add DHCP option 54 (server-identifier) to dnsmasq config, set to the external/VIP address (`dnsmasq.externalIP`).

This ensures clients send DHCP renewals/releases to the load-balanced address rather than the pod/node IP. Allows testing whether clients and Fortigate tolerate the explicit option 54.

## Changes

- `configmap-dnsmasq.yaml`: emit `dhcp-option=option:server-identifier,<externalIP>` unconditionally
- `Chart.yaml`: version bump 2.3.2 → 2.4.0