### PR TITLE
[cc-gardner]: bump auditing-extensio to 0.4.0

### DIFF
--- a/global/cc-gardener/Chart.yaml
+++ b/global/cc-gardener/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cc-gardener
 description: Converged Cloud Gardener setup based on gardener-operator
 type: application
-version: 0.38.0
+version: 0.38.1
 home: https://github.com/gardener/gardener
 dependencies:
 - name: owner-info

--- a/global/cc-gardener/values.yaml
+++ b/global/cc-gardener/values.yaml
@@ -836,7 +836,7 @@ extensions:
         - group: core.gardener.cloud
           resources:
           - controllerdeployments
-    version: v0.3.0
+    version: v0.4.0
     admission:
       values:
         image:
@@ -861,7 +861,7 @@ extensions:
       images:
         - name: auditlog-forwarder
           repository: keppel.global.cloud.sap/ccloud-europe-docker-pkg-dev-mirror/gardener-project/releases/gardener/auditlog-forwarder
-          tag: "v0.2.0"
+          tag: "v0.3.0"
     helm:
       ociRepository:
         # tag:


### PR DESCRIPTION
This brings hot reloading of tls client certificates for the outputs.