### PR TITLE
feat(metal-operator-dhcp): bind dnsmasq interface dynamically and persist for stop hook

### DIFF
--- a/system/metal-operator-dhcp/Chart.yaml
+++ b/system/metal-operator-dhcp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: metal-operator-dhcp
 description: A Helm chart for the Ironcore metal-operator-dhcp.
 type: application
-version: 2.4.0
+version: 2.4.1
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/system/metal-operator-dhcp/templates/configmap-dnsmasq.yaml
+++ b/system/metal-operator-dhcp/templates/configmap-dnsmasq.yaml
@@ -11,6 +11,11 @@ data:
     tftp-root=/shared/tftpboot
     log-queries
 
+{{ if .Values.dnsmasq.service }}
+    interface=__INTERFACE__
+    listen-address={{ .Values.dnsmasq.externalIP }}
+{{ end }}
+
     # Configure listening for DNS (0 disables DNS)
     port=0
     log-dhcp
@@ -87,6 +92,10 @@ data:
 
     mkdir -p /shared/tftpboot
 
+    export INTERFACE=$(/sbin/ip route | grep -v cbr | awk '/default/ { print $5 }')
+    echo "Outgoing inteface is ${INTERFACE}"
+    echo "${INTERFACE}" > /shared/interface
+
     {{- if .Values.ipxe.efi.host }}
     curl -o /shared/tftpboot/{{ .Values.ipxe.efi.file }} {{ .Values.ipxe.efi.host }}/{{ .Values.ipxe.efi.file }}
     {{- else }}
@@ -94,7 +103,12 @@ data:
     cp /tftpboot/snponly.efi /shared/tftpboot/{{ .Values.ipxe.efi.file | default "snponly.efi" }}
     {{- end }}
 
-    exec /usr/sbin/dnsmasq -d -q -C /opt/dnsmasq/dnsmasq.conf
+    cp /opt/dnsmasq/dnsmasq.conf /shared/dnsmasq.conf
+{{ if .Values.dnsmasq.service }}
+    sed -i "s/interface=__INTERFACE__/interface=${INTERFACE}/" /shared/dnsmasq.conf
+{{ end }}
+
+    exec /usr/sbin/dnsmasq -d -q -C /shared/dnsmasq.conf
   dhcp-init.sh: |
     #!/usr/bin/env bash
     set -euxo pipefail
@@ -103,6 +117,10 @@ data:
     export INTERFACE=$(/sbin/ip route | grep -v cbr | awk '/default/ { print $5 }')
 
     echo "Outgoing inteface is ${INTERFACE}"
+
+{{ if .Values.dnsmasq.service }}
+    ip addr add ${DHCPSERVERIP}/32 dev ${INTERFACE}
+{{ end }}
 
     echo "Adding rule for SNAT DHCP Reply to correct server IP address"
 
@@ -145,6 +163,16 @@ data:
     #!/usr/bin/env bash
     set -euxo pipefail
     # make sure to update dhcp-init script to keep commands aligned
+
+    INTERFACE=$(cat /shared/interface 2>/dev/null || true)
+
+{{ if .Values.dnsmasq.service }}
+    if [[ -n "${INTERFACE}" ]]; then
+      ip addr del ${DHCPSERVERIP}/32 dev ${INTERFACE} || true
+    else
+      echo "WARNING: could not determine interface from /shared/interface, skipping ip addr del"
+    fi
+{{ end }}
 
     echo "Deleting rule for SNAT DHCP Reply"
     iptables-nft -t nat -D POSTROUTING -p udp --sport 67 --dport 67 -j SNAT --to-source ${DHCPSERVERIP}


### PR DESCRIPTION
## Summary

When dnsmasq.service=true, the dnsmasq config needs to bind to the node outgoing interface. 

## Changes

- initdnsmasq.sh: Detect outgoing interface, persist to /shared/interface, copy dnsmasq.conf to writable /shared/ volume, sed the __INTERFACE__ placeholder, and start dnsmasq from the modified copy
- dnsmasq.conf: Add interface=__INTERFACE__ placeholder (gated by .Values.dnsmasq.service)
- dhcp-stop.sh: Read interface from /shared/interface file instead of querying ip route; guard with non-empty check and || true to survive partial network teardown
- dhcp-init.sh: Gate ip addr add behind .Values.dnsmasq.service