### PR TITLE
fix(metal-operator-dhcp): add shared emptyDir volume and preStop hook for cleanup

### DIFF
--- a/system/metal-operator-dhcp/Chart.yaml
+++ b/system/metal-operator-dhcp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: metal-operator-dhcp
 description: A Helm chart for the Ironcore metal-operator-dhcp.
 type: application
-version: 2.4.1
+version: 2.4.2
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/system/metal-operator-dhcp/templates/configmap-dnsmasq.yaml
+++ b/system/metal-operator-dhcp/templates/configmap-dnsmasq.yaml
@@ -48,10 +48,6 @@ data:
     {{- end }}
     {{- end }}
 
-    # DHCP option 54: advertise the external/VIP as the server-identifier so
-    # clients send renewals to the load-balanced address, not the pod/node IP.
-    dhcp-option=option:server-identifier,{{ .Values.dnsmasq.externalIP }}
-
     # Set dns servers
     dhcp-option=6,{{ .Values.dnsmasq.dnsServers }}
     dhcp-option=option:domain-name,cc.{{ .Values.global.region }}.cloud.sap

--- a/system/metal-operator-dhcp/templates/deployment-dnsmasq.yaml
+++ b/system/metal-operator-dhcp/templates/deployment-dnsmasq.yaml
@@ -57,6 +57,8 @@ spec:
         volumeMounts:
           - name: metal-dnsmasq
             mountPath: /opt/dnsmasq
+          - name: shared
+            mountPath: /shared
           - name: lib-modules
             mountPath: /lib/modules
             readOnly: true
@@ -113,9 +115,18 @@ spec:
             - ALL
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+{{ if .Values.dnsmasq.service }}
+        lifecycle:
+          preStop:
+            exec:
+              command:
+                - /opt/dnsmasq/dhcp-stop.sh
+{{ end }}
         volumeMounts:
         - mountPath: /opt/dnsmasq
           name: metal-dnsmasq
+        - mountPath: /shared
+          name: shared
         {{- if .Values.bootScripts }}
         {{- range $filename, $_ := .Values.bootScripts }}
         - mountPath: /shared/tftpboot/{{ $filename }}
@@ -128,6 +139,8 @@ spec:
       schedulerName: default-scheduler
       terminationGracePeriodSeconds: 30
       volumes:
+      - name: shared
+        emptyDir: {}
       - name: lib-modules
         hostPath:
           path: /lib/modules


### PR DESCRIPTION
## Summary

Follow-up to #12238. The configmap changes reference /shared/ paths but the deployment was missing:

1. **emptyDir volume** — /shared is used by initdnsmasq.sh to store the modified dnsmasq.conf and interface name, and by dhcp-stop.sh to read the interface back
2. **Volume mount on init container** — dhcp-init.sh writes /shared/interface but had no mount
3. **Volume mount on main container** — needed for initdnsmasq.sh to write /shared/dnsmasq.conf and read /shared/interface in stop hook
4. **preStop lifecycle hook** — dhcp-stop.sh was never actually invoked; now wired as preStop exec

Without these, ip addr del in dhcp-stop.sh silently fails because INTERFACE is always empty (file does not exist).

## Changes

- Add shared emptyDir volume
- Mount /shared in both init and main containers
- Add preStop lifecycle hook calling dhcp-stop.sh
- Bump chart version 2.4.1 -> 2.4.2