### PR TITLE
[Hermes] Remove kube_statefulset_replicas guard from log-router alerts.

### DIFF
--- a/openstack/hermes/Chart.yaml
+++ b/openstack/hermes/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm audit management for Openstack
 maintainers:
   - name: notque
 name: hermes
-version: 0.2.2
+version: 0.2.3
 dependencies:
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/hermes/alerts/openstack/api.alerts.tpl
+++ b/openstack/hermes/alerts/openstack/api.alerts.tpl
@@ -131,7 +131,7 @@ groups:
       summary: Hermes API is not available, check pod logs
 
   - alert: OpenstackHermesLogRouterRabbitMQDisconnected
-    expr: sum(log_router_rabbitmq_connected) == 0 and on() kube_statefulset_replicas{namespace="hermes", statefulset="log-router"} > 0
+    expr: sum(log_router_rabbitmq_connected) == 0
     for: 2m
     labels:
       context: log-router
@@ -148,7 +148,7 @@ groups:
       summary: "Log Router disconnected from RabbitMQ"
 
   - alert: OpenstackHermesLogRouterDLQFallback
-    expr: sum(rate(log_router_flush_dlq_fallbacks_total[5m])) > 0 and on() kube_statefulset_replicas{namespace="hermes", statefulset="log-router"} > 0
+    expr: sum(rate(log_router_flush_dlq_fallbacks_total[5m])) > 0
     for: 5m
     labels:
       context: log-router
@@ -165,7 +165,7 @@ groups:
       summary: "Log Router falling back to DLQ — data not reaching S3"
 
   - alert: OpenstackHermesLogRouterAdminWriteErrors
-    expr: sum(rate(log_router_admin_write_errors_total[5m])) > 0 and on() kube_statefulset_replicas{namespace="hermes", statefulset="log-router"} > 0
+    expr: sum(rate(log_router_admin_write_errors_total[5m])) > 0
     for: 5m
     labels:
       context: log-router


### PR DESCRIPTION
this guard is not needed. In eu-de-1 and eu-de-3. we got
`INFO] [EU-DE-1] AbsentObservabilityHermesKubeStatefulsetReplicas - missing kube_statefulset_replicas
:information_source: The metric 'kube_statefulset_replicas' is missing. 'OpenstackHermesLogRouterRabbitMQDisconnected' alert using it may not fire as intended. See [the operator playbook](https://github.com/sapcc/absent-metrics-operator/blob/master/docs/playbook.md).  
[Playbook](https://operations.global.cloud.sap/)  [Prometheus](https://prometheus-openstack.eu-de-1.cloud.sap/graph?g0.expr=absent%28kube_statefulset_replicas%29&g0.tab=1) [Greenhouse](https://sci.dashboard.greenhouse.global.cloud.sap/alerts/alerts?f_alertname=AbsentObservabilityHermesKubeStatefulsetReplicas&f_region=eu-de-1&f_severity=info&predefinedFilter=all)`
so simply remove it