### PR TITLE
Increase Number of Static Routes per Router

### DIFF
--- a/openstack/neutron-hypervisor-agents/templates/etc/_neutron.conf.tpl
+++ b/openstack/neutron-hypervisor-agents/templates/etc/_neutron.conf.tpl
@@ -6,7 +6,7 @@ log_config_append = /etc/neutron/logging.ini
 {{- include "ini_sections.logging_format" . }}
 
 max_allowed_address_pair = {{.Values.max_allowed_address_pair | default 50}}
-max_routes = {{.Values.max_routes | default 256}}
+max_routes = {{.Values.max_routes | default 512}}
 
 allow_overlapping_ips = true
 core_plugin = ml2

--- a/openstack/neutron/templates/etc/_neutron.conf.tpl
+++ b/openstack/neutron/templates/etc/_neutron.conf.tpl
@@ -10,7 +10,7 @@ api_paste_config = /etc/neutron/api-paste.ini
 
 pagination_max_limit = 500
 max_allowed_address_pair = {{.Values.max_allowed_address_pair | default 50}}
-max_routes = {{.Values.max_routes | default 256}}
+max_routes = {{.Values.max_routes }}
 
 allow_overlapping_ips = true
 core_plugin = ml2

--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -27,6 +27,9 @@ api_workers: 12
 rpc_workers: 5
 rpc_state_workers: 5
 
+# Define max # of static routes per router
+max_routes: 512
+
 owner-info:
   support-group: network-api
   service: neutron


### PR DESCRIPTION
Customers spawning Gardener clusters that do not use overlay networks have a node limit of 256 nodes per cluster, as each node requires a static route on the Neutron router.

As our hardware supports more than that, a decision was made to double the limit to support bigger Gardener clusters.

Configuring static routes is an expensive operation as large parts of the config db get locked during the process. A ratelimit is in place to prevent customers from making too many calls at once.