### PR TITLE
[thanos] thanos-ruler scraping

### DIFF
--- a/common/thanos/Chart.yaml
+++ b/common/thanos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thanos
 description: Deploy Thanos via operator
 type: application
-version: 1.3.2
+version: 1.3.3
 appVersion: v0.41.0
 maintainers:
   - name: Tommy Sauer (viennaa)

--- a/common/thanos/templates/_thanos_helpers.tpl
+++ b/common/thanos/templates/_thanos_helpers.tpl
@@ -149,12 +149,14 @@ cluster.local
 {{- end -}}
 
 {{- define "thanos.storeAPIs" -}}
-{{- $host := index . 0 -}}
+{{- $name := index . 0 -}}
 {{- $root := index . 1 -}}
+{{- $rulerEndpoint := printf "dnssrvnoa+_grpc._tcp.thanos-ruler-%s.thanos.svc.%s" (include "thanos.name" (list $name $root)) (include "clusterDomainOrDefault" $root) -}}
 {{/* Thanos Query discovery within the cluster */}}
 {{- if $root.Values.queryDiscovery -}}
 endpoints:
 {{- $clusterList := list }}
+{{- $clusterList = append $clusterList $rulerEndpoint -}}
 {{- range $index, $service := (lookup "v1" "Service" "" "").items }}
 {{- if and (hasPrefix "thanos" $service.metadata.name) (contains "query" $service.metadata.name) (not (contains "maia" $service.metadata.name)) (not (contains "metal" $service.metadata.name)) (not (contains "scaleout" $service.metadata.name)) (not (contains "regional" $service.metadata.name)) (not (contains "global" $service.metadata.name)) }}
 {{- $store := $service.metadata.name }}

--- a/common/thanos/templates/_thanos_helpers.tpl
+++ b/common/thanos/templates/_thanos_helpers.tpl
@@ -151,7 +151,7 @@ cluster.local
 {{- define "thanos.storeAPIs" -}}
 {{- $host := index . 0 -}}
 {{- $root := index . 1 -}}
-{{- $rulerEndpoint := printf "dnssrvnoa+_grpc._tcp.thanos-ruler-%s.thanos.svc.%s" (include "thanos.name" (list $name $root)) (include "clusterDomainOrDefault" $root) -}}
+{{- $rulerEndpoint := printf "dnssrvnoa+_grpc._tcp.thanos-ruler-%s.thanos.svc.%s" (include "thanos.name" (list $host $root)) (include "clusterDomainOrDefault" $root) -}}
 {{/* Thanos Query discovery within the cluster */}}
 {{- if $root.Values.queryDiscovery -}}
 endpoints:

--- a/common/thanos/templates/_thanos_helpers.tpl
+++ b/common/thanos/templates/_thanos_helpers.tpl
@@ -156,7 +156,9 @@ cluster.local
 {{- if $root.Values.queryDiscovery -}}
 endpoints:
 {{- $clusterList := list }}
+{{- if $root.Values.ruler.enabled -}}
 {{- $clusterList = append $clusterList $rulerEndpoint -}}
+{{- end -}}
 {{- range $index, $service := (lookup "v1" "Service" "" "").items }}
 {{- if and (hasPrefix "thanos" $service.metadata.name) (contains "query" $service.metadata.name) (not (contains "maia" $service.metadata.name)) (not (contains "metal" $service.metadata.name)) (not (contains "scaleout" $service.metadata.name)) (not (contains "regional" $service.metadata.name)) (not (contains "global" $service.metadata.name)) }}
 {{- $store := $service.metadata.name }}

--- a/common/thanos/templates/_thanos_helpers.tpl
+++ b/common/thanos/templates/_thanos_helpers.tpl
@@ -149,7 +149,7 @@ cluster.local
 {{- end -}}
 
 {{- define "thanos.storeAPIs" -}}
-{{- $name := index . 0 -}}
+{{- $host := index . 0 -}}
 {{- $root := index . 1 -}}
 {{- $rulerEndpoint := printf "dnssrvnoa+_grpc._tcp.thanos-ruler-%s.thanos.svc.%s" (include "thanos.name" (list $name $root)) (include "clusterDomainOrDefault" $root) -}}
 {{/* Thanos Query discovery within the cluster */}}

--- a/common/thanos/templates/ruler/ruler.yaml
+++ b/common/thanos/templates/ruler/ruler.yaml
@@ -54,7 +54,9 @@ spec:
       prometheus.io/scrape: "true"
       prometheus.io/targets: "kubernetes"
       prometheus.io/port: "10902"
-
+  objectStorageConfig:
+    key: thanos.yaml
+    name: {{ include "thanos.objectStorageConfigName" (list $name $root) }}
 {{ if not $.Values.ruler.queryEndpoints }}
   queryEndpoints: 
     - {{ include "thanos.fullName" (list $name $root) }}-query:10902

--- a/common/thanos/templates/ruler/ruler.yaml
+++ b/common/thanos/templates/ruler/ruler.yaml
@@ -46,12 +46,14 @@ spec:
     name: {{ include "thanos.fullName" (list $name $root) }}-alertmanager-config
     key: alertManagerConfig.yaml
 {{- end }}
-
-{{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
   podMetadata:
     annotations:
+{{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
       linkerd.io/inject: enabled
 {{- end }}
+      prometheus.io/scrape: "true"
+      prometheus.io/targets: "kubernetes"
+      prometheus.io/port: 10902
 
 {{ if not $.Values.ruler.queryEndpoints }}
   queryEndpoints: 

--- a/common/thanos/templates/ruler/ruler.yaml
+++ b/common/thanos/templates/ruler/ruler.yaml
@@ -53,7 +53,7 @@ spec:
 {{- end }}
       prometheus.io/scrape: "true"
       prometheus.io/targets: "kubernetes"
-      prometheus.io/port: 10902
+      prometheus.io/port: "10902"
 
 {{ if not $.Values.ruler.queryEndpoints }}
   queryEndpoints: 


### PR DESCRIPTION
to allow scraping of ALERTS samples generated by our thanos-ruler instances

- add objstore config to thanos-ruler
- add thanos-ruler store endpoint to query sd-configmap
- add target labels to pod for pod health metrics scraping