### PR TITLE
Gardener certificate for Workload Identity Discovery

### DIFF
--- a/global/cc-gardener/Chart.yaml
+++ b/global/cc-gardener/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cc-gardener
 description: Converged Cloud Gardener setup based on gardener-operator
 type: application
-version: 0.38.1
+version: 0.38.2
 home: https://github.com/gardener/gardener
 dependencies:
 - name: owner-info

--- a/global/cc-gardener/templates/gardener-dashboard-cert.yaml
+++ b/global/cc-gardener/templates/gardener-dashboard-cert.yaml
@@ -9,9 +9,11 @@ spec:
   dnsNames:
 {{- if .Values.garden.domainOverride }}
   - dashboard.runtime.{{ $.Values.garden.domainOverride }}.{{ required ".Values.global.region missing" .region }}.cloud.sap
+  - discovery.runtime.{{ $.Values.garden.domainOverride }}.{{ required ".Values.global.region missing" .region }}.cloud.sap
 {{- else }}
 {{- with .Values.global }}
   - dashboard.runtime-garden.{{ required ".Values.global.cluster missing" .cluster }}.{{ required ".Values.global.region missing" .region }}.cloud.sap
+  - discovery.runtime-garden.{{ required ".Values.global.cluster missing" .cluster }}.{{ required ".Values.global.region missing" .region }}.cloud.sap
 {{- end }}
 {{- end }}
   issuerRef:


### PR DESCRIPTION
`gardenerDiscoveryServer` configuration in `garden` resource is currently empty & relies on the default garden-cert fallback. Istio was serving the dashboard certificate for requests to the discovery endpoint. This caused a TLS Certificate Mismatch  for the kube-apiserver when attempting to fetch OIDC keys


Other option is to create separate Certificate for discovery endpoint and configure `gardenerDiscoveryServer` in `garden` resource
