### PR TITLE
Allow Egress traffic from Shoot Control Plane to Istio Ingress

### DIFF
--- a/system/metal-operator-remote/Chart.yaml
+++ b/system/metal-operator-remote/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.24
+version: 0.6.25
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/metal-operator-remote/templates/networkpolicy.yaml
+++ b/system/metal-operator-remote/templates/networkpolicy.yaml
@@ -102,14 +102,17 @@ spec:
       app: kubernetes
       role: apiserver
   policyTypes:
-  - Egress
+    - Egress
   egress:
-  - ports:
-    - port: 443
-      protocol: TCP
-    to:
-    - ipBlock:
-        cidr: {{ .Values.virtualGardenLBIP }}/32
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: {{ .Values.virtualGardenLBIP }}/32
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: virtual-garden-istio-ingress
 {{- end }}
 ---
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
Added `namespaceSelector` to the egress `NetworkPolicy` to allow traffic from the shoot control plane to the Istio Ingress Gateway namespace
When the `kube-apiserver` attempts to reach the Workload Identity discovery endpoint, the traffic is routed internally  to the Istio Gateway pods. Without this rule the internal packets are dropped resulting in a timeout and preventing the API server from fetching the required OIDC configuration