### PR TITLE
[cc-gardener]: bump to 0.38.3

### DIFF
--- a/global/cc-gardener/Chart.yaml
+++ b/global/cc-gardener/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cc-gardener
 description: Converged Cloud Gardener setup based on gardener-operator
 type: application
-version: 0.38.2
+version: 0.38.3
 home: https://github.com/gardener/gardener
 dependencies:
 - name: owner-info


### PR DESCRIPTION
We merged two changes within 5 minutes with the same chart version. Only for the first PR the chart got pushed for the second one it got lost:

https://github.com/sapcc/helm-charts/pull/12247
https://github.com/sapcc/helm-charts/pull/12250