### PR TITLE
fix(metal-operator-dhcp): bypass kube-proxy DNAT for TFTP and fix server-id

### DIFF
--- a/system/metal-operator-dhcp/Chart.yaml
+++ b/system/metal-operator-dhcp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: metal-operator-dhcp
 description: A Helm chart for the Ironcore metal-operator-dhcp.
 type: application
-version: 2.4.2
+version: 2.4.3
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/system/metal-operator-dhcp/templates/configmap-dnsmasq.yaml
+++ b/system/metal-operator-dhcp/templates/configmap-dnsmasq.yaml
@@ -12,7 +12,6 @@ data:
     log-queries
 
 {{ if .Values.dnsmasq.service }}
-    interface=__INTERFACE__
     listen-address={{ .Values.dnsmasq.externalIP }}
 {{ end }}
 
@@ -63,7 +62,7 @@ data:
     dhcp-match=set:efi,option:client-arch,9
     dhcp-match=set:efi,option:client-arch,11
     # Client is PXE booting over EFI without iPXE ROM; send EFI version of iPXE chainloader
-    dhcp-boot=tag:efi,tag:!ipxe,{{ .Values.ipxe.efi.file | default "snponly.efi" }}
+    dhcp-boot=tag:efi,tag:!ipxe,{{ .Values.ipxe.efi.file | default "snponly.efi" }},{{ .Values.dnsmasq.externalIP }}
 
     # Client is running PXE over BIOS; send BIOS version of iPXE chainloader
     dhcp-boot=/undionly.kpxe,{{ .Values.dnsmasq.externalIP }}
@@ -100,9 +99,6 @@ data:
     {{- end }}
 
     cp /opt/dnsmasq/dnsmasq.conf /shared/dnsmasq.conf
-{{ if .Values.dnsmasq.service }}
-    sed -i "s/interface=__INTERFACE__/interface=${INTERFACE}/" /shared/dnsmasq.conf
-{{ end }}
 
     exec /usr/sbin/dnsmasq -d -q -C /shared/dnsmasq.conf
   dhcp-init.sh: |
@@ -117,6 +113,17 @@ data:
 {{ if .Values.dnsmasq.service }}
     ip addr add ${DHCPSERVERIP}/32 dev ${INTERFACE}
 {{ end }}
+
+    # Bypass kube-proxy DNAT for TFTP traffic destined to the externalIP.
+    # The pod binds directly to the externalIP (hostNetwork + ip addr add) so
+    # kube-proxy's DNAT to the endpoint IP causes ICMP port unreachable.
+    echo "Adding PREROUTING ACCEPT rule to bypass kube-proxy DNAT for TFTP"
+    if iptables-nft -t nat -C PREROUTING -d ${DHCPSERVERIP}/32 -p udp --dport 69 -j ACCEPT 2>/dev/null; then
+      echo "PREROUTING ACCEPT rule for TFTP already present - skipping"
+    else
+      echo "PREROUTING ACCEPT rule for TFTP not present - creating rule"
+      iptables-nft -t nat -I PREROUTING 1 -d ${DHCPSERVERIP}/32 -p udp --dport 69 -j ACCEPT
+    fi
 
     echo "Adding rule for SNAT DHCP Reply to correct server IP address"
 
@@ -169,6 +176,9 @@ data:
       echo "WARNING: could not determine interface from /shared/interface, skipping ip addr del"
     fi
 {{ end }}
+
+    echo "Deleting PREROUTING ACCEPT rule for kube-proxy DNAT bypass (TFTP)"
+    iptables-nft -t nat -D PREROUTING -d ${DHCPSERVERIP}/32 -p udp --dport 69 -j ACCEPT || true
 
     echo "Deleting rule for SNAT DHCP Reply"
     iptables-nft -t nat -D POSTROUTING -p udp --sport 67 --dport 67 -j SNAT --to-source ${DHCPSERVERIP}


### PR DESCRIPTION
## Problem

TFTP requests to the dnsmasq externalIP (`1.2.3.4:69`) fail with ICMP port unreachable despite the pod listening on that address.

### Root Cause

The pod uses `hostNetwork: true` and binds directly to the externalIP via `ip addr add` + `listen-address`. However, kube-proxy also installs DNAT rules for the LoadBalancer Service that rewrite the destination from the externalIP to the pod endpoint IP (`1.2.3.4:69`). Since dnsmasq only binds to the externalIP, nothing listens on the rewritten destination → kernel sends ICMP port unreachable.

Additionally, `interface=__INTERFACE__` in the dnsmasq config caused dnsmasq to use the node primary IP as server-identifier instead of the externalIP.

## Fix

1. **Remove `interface=__INTERFACE__`** from dnsmasq.conf in service mode. With only `listen-address` configured and `bind-dynamic`, dnsmasq correctly resolves the externalIP as server-identifier via its `iface_check` fallback path.

2. **Add PREROUTING ACCEPT rule** for port 69 traffic destined to the externalIP. This bypasses kube-proxy DNAT so packets reach the dnsmasq socket directly. Cleanup added to `dhcp-stop.sh`.

3. **Add externalIP to `dhcp-boot` for EFI clients** — the TFTP server address was missing from the EFI boot directive.

