### PR TITLE
fix(gatekeeper): allow audit-logs collector to mount host root filesystem

### DIFF
--- a/system/gatekeeper/templates/constraint-pod-security-v2.yaml
+++ b/system/gatekeeper/templates/constraint-pod-security-v2.yaml
@@ -967,11 +967,20 @@ spec:
         matchRepository: ccloud-ghcr-io-mirror/cloudoperators/opentelemetry-collector-contrib
         justification: |
           OTel audit-logs collector runs as auditd reader: needs hostPID,
-          privileged, AUDIT_* caps, and read access to host audit-related paths.
+          privileged, AUDIT_* caps, and read access to host root filesystem
+          for auditd log paths.
         mayBePrivileged: true
         mayUseHostPID: true
         mayUseCapabilities: [ AUDIT_READ, AUDIT_WRITE, AUDIT_CONTROL ]
-        mayReadHostPathVolumes: [ /var/log ]
+        mayReadHostPathVolumes: [ / ]
+
+      - matchNamespace: fortlogs-audit
+        matchRepository: ccloud-dockerhub-mirror/library/alpine
+        justification: |
+          OTel audit-logs collector init container needs privileged access
+          and host root filesystem mount to set up auditd log reading.
+        mayBePrivileged: true
+        mayReadHostPathVolumes: [ / ]
 
       - matchNamespace: opensearch-logs
         matchRepository: busybox


### PR DESCRIPTION
## Summary

Fixes the pod-security-v2 allowlist for the `fortlogs-audit` namespace so the OTel audit-logs DaemonSet collector can start on clusters with strict pod security policies.

## Problem

The audit-logs collector needs to mount the host root filesystem (`/`) to access auditd log files, and the init container uses `alpine` (not `busybox`). The existing allowlist from #12100 only permitted:
- `mayReadHostPathVolumes: [ /var/log ]` for the OTel collector (too restrictive)
- No entry for the `alpine` init container

This causes the DaemonSet pods to be rejected by Gatekeeper.

## Changes

- Widen `mayReadHostPathVolumes` from `[ /var/log ]` to `[ / ]` for the OTel collector in `fortlogs-audit`
- Add new allowlist entry for `ccloud-dockerhub-mirror/library/alpine` init container in `fortlogs-audit` with `mayBePrivileged` and `mayReadHostPathVolumes: [ / ]`

## Related

Follow-up to #12100