### PR TITLE
adding 'devsupport' in known_support_groups

### DIFF
--- a/system/gatekeeper/values.yaml
+++ b/system/gatekeeper/values.yaml
@@ -56,6 +56,7 @@ known_support_groups:
   - storage
   - trust
   - workload-management
+  - devsupport
 
 ################################################################################
 # documentation for this section: <https://github.com/open-policy-agent/gatekeeper/tree/master/charts/gatekeeper>


### PR DESCRIPTION
To fix the issue in greenhouse:
Deployment bots4devsupport in namespace dev-llm-services: pod has an unacceptable label value: ccloud/support-group="devsupport" 

https://sci.dashboard.greenhouse.global.cloud.sap/doop/violations?f_check%3Asupport_group=devsupport