### PR TITLE
netapp-credential-rotator: restart pod on vault-secrets rotation

### DIFF
--- a/openstack/netapp-credential-rotator/templates/deployment.yaml
+++ b/openstack/netapp-credential-rotator/templates/deployment.yaml
@@ -11,10 +11,11 @@ spec:
       {{- include "netapp-credential-rotator.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        secret.reloader.stakater.com/reload: "vault-secrets"
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "netapp-credential-rotator.labels" . | nindent 8 }}
         {{- with .Values.podLabels }}


### PR DESCRIPTION
## Summary

- Adds `secret.reloader.stakater.com/reload: "vault-secrets"` annotation unconditionally to the pod template metadata in `deployment.yaml`
- Ensures the rotator pod restarts automatically when the `vault-secrets` Secret is updated (e.g. after Vault appRole `secret_id` rotation)
- `podAnnotations` from values are still merged in alongside the hardcoded annotation

## Why

Without this annotation, after an appRole secret rotation the rotator pod keeps using stale credentials until manually restarted. The stakater Reloader watches the Secret and triggers a rollout when it changes.

## Test plan
- [ ] Annotation present on `spec.template.metadata.annotations` in rendered template
- [ ] Existing `podAnnotations` values still rendered correctly alongside it