### PR TITLE
netapp-credential-rotator: add reloader pause-period annotation

### DIFF
--- a/openstack/netapp-credential-rotator/templates/deployment.yaml
+++ b/openstack/netapp-credential-rotator/templates/deployment.yaml
@@ -11,10 +11,12 @@ spec:
       {{- include "netapp-credential-rotator.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        secret.reloader.stakater.com/reload: "vault-secrets"
+        deployment.reloader.stakater.com/pause-period: "60s"
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "netapp-credential-rotator.labels" . | nindent 8 }}
         {{- with .Values.podLabels }}


### PR DESCRIPTION
## Summary

- Adds `secret.reloader.stakater.com/reload: "vault-secrets"` and `deployment.reloader.stakater.com/pause-period: "60s"` annotations unconditionally to the pod template metadata
- `pause-period: 60s` matches the standard pattern used across other deployments in this repo (e.g. manila, designate)
- Supersedes #12265 (which only added the reload annotation without the pause-period)

## Why

Without `pause-period`, Stakater Reloader can trigger rapid rolling restarts if the secret is updated multiple times in quick succession. 60s is the repo-standard debounce window.

## Test plan
- [ ] Both annotations present on `spec.template.metadata.annotations` in rendered template
- [ ] `podAnnotations` values still rendered correctly alongside them