### PR TITLE
[neutron] modify subdomain in  disco record for rabbitmq externalIP

### DIFF
--- a/openstack/neutron/templates/record-rabbitmq.yaml
+++ b/openstack/neutron/templates/record-rabbitmq.yaml
@@ -5,10 +5,10 @@
 apiVersion: disco.stable.sap.cc/v1
 kind: Record
 metadata:
-  name: neutron-rabbitmq.{{ $region }}.{{ $tld }}
+  name: neutron-rabbitmq.cc.{{ $region }}.{{ $tld }}
 spec:
   type: A
   record: {{ index $ips 0 | quote }}
   hosts:
-    - neutron-rabbitmq.{{ $region }}.{{ $tld }}
+    - neutron-rabbitmq.cc.{{ $region }}.{{ $tld }}
 {{- end }}


### PR DESCRIPTION
As this is an internal service name it should go into the cc subdomain.

This amends 1e0b3236a52a912649e68097b8f49d36d26e4c1b