### PR TITLE
[neutron] fixing modify subdomain in disco record for rabbitmq 

### DIFF
--- a/openstack/neutron/templates/record-rabbitmq.yaml
+++ b/openstack/neutron/templates/record-rabbitmq.yaml
@@ -11,4 +11,5 @@ spec:
   record: {{ index $ips 0 | quote }}
   hosts:
     - neutron-rabbitmq.cc.{{ $region }}.{{ $tld }}
+  zoneName: cc.{{ $region }}.{{ $tld }}
 {{- end }}


### PR DESCRIPTION

the name of the zone was missing - without is uses a wrong default.

amending 35a9f43fdfab5167a51318c94c9bdd55fd48ac5b