### PR TITLE
[hermes] Add RabbitMQ stranded-queue, disk-watermark, and backlog-critical alerts

### DIFF
--- a/openstack/hermes/alerts/openstack/api.alerts.tpl
+++ b/openstack/hermes/alerts/openstack/api.alerts.tpl
@@ -66,6 +66,9 @@ groups:
 
   - alert: OpenstackHermesRabbitMQReady
     expr: sum(rabbitmq_queue_messages_ready{kubernetes_name=~".*rabbitmq-notifications"}) by (kubernetes_name) > 10000
+    # for: requires the backlog to persist before firing, so a single scrape spike does not
+    # trigger the alert and cause it to flap WARNING<->RESOLVED.
+    for: 15m
     labels:
       context: rabbitmq
       severity: warning
@@ -78,7 +81,93 @@ groups:
       playbook: "docs/devops/alert/rabbitmq/#ready"
     annotations:
       description: "{{`{{ $labels.service }}`}} {{`{{ $labels.check }}`}} has over 10000 ready messages in {{`{{ $labels.kubernetes_name }}`}}. Logstash has disconnected from the RabbitMQ."
-      summary: "RabbitMQ unacknowledged messages count"
+      summary: "RabbitMQ ready messages count"
+
+  # Critical escalation for a large, sustained backlog. A per-broker backlog this deep means a
+  # queue is not being drained and the data volume is at real risk of filling. This tier pages;
+  # the warning tier above only notifies.
+  - alert: OpenstackHermesRabbitMQReadyCritical
+    expr: sum(rabbitmq_queue_messages_ready{kubernetes_name=~".*rabbitmq-notifications"}) by (kubernetes_name) > 1000000
+    for: 15m
+    labels:
+      context: rabbitmq
+      severity: critical
+      tier: os
+      support_group: observability
+      service: hermes
+      dashboard: rabbitmq
+      persesDashboard: "https://perses.{{ .Values.global.region }}.{{ .Values.global.tld }}/projects/observability/dashboards/rabbitmq"
+      meta: "{{`{{ $labels.service }}`}} {{`{{ $labels.check }}`}} has over 1,000,000 ready messages in {{`{{ $labels.kubernetes_name }}`}}. A queue is not draining and the RabbitMQ volume is at risk of filling."
+      playbook: "docs/devops/alert/rabbitmq/#ready"
+    annotations:
+      description: "{{`{{ $labels.service }}`}} {{`{{ $labels.check }}`}} has over 1,000,000 ready messages in {{`{{ $labels.kubernetes_name }}`}}. A queue is not draining and the RabbitMQ volume is at risk of filling."
+      summary: "RabbitMQ backlog critically large"
+
+  # The three rabbitmq-notifications pods are independent singletons behind a Kubernetes Service.
+  # A consumer using one Service-backed connection can end up consuming only some of them, leaving
+  # a broker with a growing backlog and ZERO consumers. That stranded queue is what eventually
+  # fills the disk. This is a leading indicator, so it warns; a persistent strand escalates below.
+  - alert: OpenstackHermesRabbitMQQueueStranded
+    expr: |
+      (rabbitmq_queue_messages_ready{kubernetes_name=~".*rabbitmq-notifications"} > 0)
+      and on(pod)
+      (rabbitmq_queue_consumers{kubernetes_name=~".*rabbitmq-notifications"} == 0)
+    for: 10m
+    labels:
+      context: rabbitmq
+      severity: warning
+      tier: os
+      support_group: observability
+      service: hermes
+      dashboard: rabbitmq
+      persesDashboard: "https://perses.{{ .Values.global.region }}.{{ .Values.global.tld }}/projects/observability/dashboards/rabbitmq"
+      meta: "Broker {{`{{ $labels.pod }}`}} has ready messages but ZERO consumers -- it is stranded and will fill the disk if not drained."
+      playbook: "docs/devops/alert/rabbitmq/#ready"
+    annotations:
+      description: "RabbitMQ broker {{`{{ $labels.pod }}`}} has ready messages but no consumers. A RabbitMQ singleton is not being drained by log-router; restart/rebalance consumers before the volume fills."
+      summary: "RabbitMQ broker stranded (ready messages, zero consumers)"
+
+  # Persistent-strand escalation. A transient strand clears on its own; one that persists for an
+  # hour will not, and the volume will fill. This pages, while the warning above only notifies.
+  - alert: OpenstackHermesRabbitMQQueueStrandedPersistent
+    expr: |
+      (rabbitmq_queue_messages_ready{kubernetes_name=~".*rabbitmq-notifications"} > 0)
+      and on(pod)
+      (rabbitmq_queue_consumers{kubernetes_name=~".*rabbitmq-notifications"} == 0)
+    for: 1h
+    labels:
+      context: rabbitmq
+      severity: critical
+      tier: os
+      support_group: observability
+      service: hermes
+      dashboard: rabbitmq
+      persesDashboard: "https://perses.{{ .Values.global.region }}.{{ .Values.global.tld }}/projects/observability/dashboards/rabbitmq"
+      meta: "Broker {{`{{ $labels.pod }}`}} has been stranded (ready messages, ZERO consumers) for over an hour and will fill the disk."
+      playbook: "docs/devops/alert/rabbitmq/#ready"
+    annotations:
+      description: "RabbitMQ broker {{`{{ $labels.pod }}`}} has had ready messages with no consumers for over an hour. It is not self-recovering; restart/rebalance consumers now before the volume fills."
+      summary: "RabbitMQ broker stranded for over an hour"
+
+  # True "down" trigger. When RabbitMQ raises the free-disk watermark it STOPS accepting publishes
+  # on that broker, which is the actual outage rather than a symptom. This is Hermes-owned and
+  # pages immediately, rather than relying on a generic platform-level volume alert.
+  - alert: OpenstackHermesRabbitMQDiskWatermark
+    expr: max(rabbitmq_alarms_free_disk_space_watermark{kubernetes_name=~".*rabbitmq-notifications"}) by (pod) == 1
+    for: 2m
+    labels:
+      context: rabbitmq
+      severity: critical
+      tier: os
+      support_group: observability
+      service: hermes
+      dashboard: rabbitmq
+      persesDashboard: "https://perses.{{ .Values.global.region }}.{{ .Values.global.tld }}/projects/observability/dashboards/rabbitmq"
+      meta: "{{`{{ $labels.pod }}`}} has hit the RabbitMQ free-disk watermark and is now BLOCKING publishers. Audit ingestion is stopping on this broker."
+      playbook: "docs/devops/alert/rabbitmq/#ready"
+    annotations:
+      description: "{{`{{ $labels.pod }}`}} has raised the RabbitMQ free-disk-space watermark alarm and is blocking publishers. This is an active ingestion outage on this broker; free disk or drain the queue immediately."
+      summary: "RabbitMQ blocking publishers (free-disk watermark)"
 
   - alert: OpenstackHermesLogstashPlugins
     expr: sum(increase(logstash_node_plugin_events_out_total[30m])) <= 0


### PR DESCRIPTION
Per-broker RabbitMQ alerts for the notifications singletons:

- QueueStranded (critical): ready messages with zero consumers.
- DiskWatermark (critical): free-disk watermark asserted (publishers blocked).
- ReadyCritical (critical): backlog > 1M ready.
- Ready: add for: 15m to stop flapping; fix summary text.

Exprs validated against Thanos; join/grouping use `pod` (`queue` absent, `kubernetes_name` shared).
