### PR TITLE
fix(node-problem-detector): bump to v1.35.3 to fix Critical CVEs

### DIFF
--- a/system/kube-system-admin-k3s/Chart.lock
+++ b/system/kube-system-admin-k3s/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: node-problem-detector
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.3.13
+  version: 1.3.14
 - name: prometheus-crds
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 9.0.0
@@ -41,5 +41,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 1.2.0
-digest: sha256:a5d9c32c531f8a7f0c3be94ae746f769a7ddf95acb0d52afa2a0863eecda807f
-generated: "2026-07-06T22:18:12.258841+02:00"
+digest: sha256:ca651d5eb632469fedd0a4b3d9438a879409f76204b81a6390d1def14705f958
+generated: "2026-07-13T08:53:31.367058+02:00"

--- a/system/kube-system-admin-k3s/Chart.yaml
+++ b/system/kube-system-admin-k3s/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kube-System relevant Service collection for the new admin clusters.
 name: kube-system-admin-k3s
-version: 3.7.2
+version: 3.7.3
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-admin-k3s
 dependencies:
   - name: node-problem-detector

--- a/system/kube-system-kubernikus/Chart.lock
+++ b/system/kube-system-kubernikus/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 4.15.1
 - name: node-problem-detector
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.3.13
+  version: 1.3.14
 - name: prometheus-crds
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 9.0.0
@@ -38,5 +38,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 1.2.0
-digest: sha256:3b84b407d41e7683ca58ab8d96a52fd66744576a339b531b9b03e053d4872fe8
-generated: "2026-07-07T10:54:05.89285+02:00"
+digest: sha256:e178e1676e47cb5dea19e9c397d44b48b88a42a07d7dfb437f6f6df6962980f5
+generated: "2026-07-13T08:53:26.025263+02:00"

--- a/system/kube-system-kubernikus/Chart.yaml
+++ b/system/kube-system-kubernikus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for Kubernikus control-plane clusters.
 name: kube-system-kubernikus
-version: 3.11.0
+version: 3.11.1
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-kubernikus
 dependencies:
   - name: cc-rbac

--- a/system/kube-system-metal/Chart.lock
+++ b/system/kube-system-metal/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 2.2.0
 - name: node-problem-detector
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.3.13
+  version: 1.3.14
 - name: prometheus-crds
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 9.0.0
@@ -77,5 +77,5 @@ dependencies:
 - name: validating-admission-policy
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.0.2
-digest: sha256:e1033fa064fbb75c2131efbb696ee68988b2983f561895b783bcde5223c7e45f
-generated: "2026-07-01T10:35:48.027893+02:00"
+digest: sha256:6ac64465014230660990c904e894d54ad3144009e1a4e6419915c906f8e59f44
+generated: "2026-07-13T08:53:06.924138+02:00"

--- a/system/kube-system-metal/Chart.yaml
+++ b/system/kube-system-metal/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for metal clusters.
 name: kube-system-metal
-version: 6.14.4
+version: 6.14.5
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-metal
 dependencies:
   - name: cc-rbac

--- a/system/kube-system-scaleout/Chart.lock
+++ b/system/kube-system-scaleout/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 4.15.1
 - name: node-problem-detector
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.3.13
+  version: 1.3.14
 - name: prometheus-crds
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 9.0.0
@@ -44,5 +44,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 1.2.0
-digest: sha256:54e7abe79f8ebd2d8e3c883aa79510b68459e54d674b447eb155ed653b312c38
-generated: "2026-07-06T22:17:47.732574+02:00"
+digest: sha256:e4e862491b158f9e0bb2f6e4fb2dd30bfd5517281d48a1421dd50e0bbe56b36a
+generated: "2026-07-13T08:53:14.51131+02:00"

--- a/system/kube-system-scaleout/Chart.yaml
+++ b/system/kube-system-scaleout/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kube-System relevant Service collection for scaleout clusters.
 name: kube-system-scaleout
-version: 5.13.1
+version: 5.13.2
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-scaleout
 dependencies:
   - name: cc-rbac

--- a/system/kube-system-virtual/Chart.lock
+++ b/system/kube-system-virtual/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 4.15.1
 - name: node-problem-detector
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.3.13
+  version: 1.3.14
 - name: prometheus-crds
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 9.0.0
@@ -56,5 +56,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 1.2.0
-digest: sha256:6942fa02bb460576bfcc51439f307153f6685290371ecc3656076001976cb576
-generated: "2026-07-06T22:17:56.913499+02:00"
+digest: sha256:204015f71d9fe1bcc3b69a541ade06763c39b424e7e28532f236f6c5c706588d
+generated: "2026-07-13T08:53:20.30074+02:00"

--- a/system/kube-system-virtual/Chart.yaml
+++ b/system/kube-system-virtual/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for virtual clusters.
 name: kube-system-virtual
-version: 4.9.3
+version: 4.9.4
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-virtual
 dependencies:
   - name: cc-rbac

--- a/system/node-problem-detector/Chart.yaml
+++ b/system/node-problem-detector/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Node Problem Detector for Kubernetes
 name: node-problem-detector
-version: 1.3.14
-appVersion: v1.35.2
+version: 1.3.15
+appVersion: v1.35.3

--- a/system/node-problem-detector/values.yaml
+++ b/system/node-problem-detector/values.yaml
@@ -4,7 +4,7 @@ global:
 
 image:
   repository: node-problem-detector/node-problem-detector
-  tag: v1.35.2
+  tag: v1.35.3
 
 resources:
   limits:


### PR DESCRIPTION
v1.35.3 (released 2026-07-11) fixes all Critical CVEs:
- CVE-2026-33186 (Critical) google.golang.org/grpc v1.74.2 -> v1.79.3
- CVE-2025-22871 (Critical) Go net/http request smuggling
- Go upgraded from 1.25.7 to 1.26.5

No SAP fork needed — upstream released the fix directly. Deployed on: metal, kubernikus, virtual, scaleout, admin-k3s