### PR TITLE
[maintenance-controller] Restart deployment after configmap changed

### DIFF
--- a/system/maintenance-controller/Chart.yaml
+++ b/system/maintenance-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: maintenance-controller
 description: A controller to manage node maintenance
 type: application
-version: 1.1.6
+version: 1.1.7
 appVersion: "1.9.4"
 home: https://github.com/sapcc/maintenance-controller
 dependencies:

--- a/system/maintenance-controller/templates/manager.yaml
+++ b/system/maintenance-controller/templates/manager.yaml
@@ -22,6 +22,7 @@ spec:
       labels:
         app: maintenance-controller
       annotations:
+        checksum/configmap.yaml: {{ include  (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested }}
         linkerd.io/inject: enabled
         {{- end }}


### PR DESCRIPTION
After an update of the config the controller did not pick up the
changes. This commit adds a checksum annotation to the deployment so
that it will be restarted when the configmap changes.
