### PR TITLE
fix volume-permissions for fresh PVs

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+## 0.25.6 - 2026/07/13
+
+- Fix volume-permission container failing on fresh PVCs. Only was working if `.erlang.cookie` was existing. 
+- Chart version bumped
+
 ## 0.25.5 - 2026/07/02
 
 - RabbitMQ [4.3.2 Release notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.3.2)

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: rabbitmq
-version: 0.25.5
+version: 0.25.6
 appVersion: 4.3.2
 description: A Helm chart for RabbitMQ
 sources:

--- a/common/rabbitmq/templates/statefulset.yaml
+++ b/common/rabbitmq/templates/statefulset.yaml
@@ -58,7 +58,7 @@ spec:
         - -c
         - |
           chown -R 999:999 /var/lib/rabbitmq
-          [ -f /var/lib/rabbitmq/.erlang.cookie ] && chmod 400 /var/lib/rabbitmq/.erlang.cookie
+          [ -f /var/lib/rabbitmq/.erlang.cookie ] && chmod 400 /var/lib/rabbitmq/.erlang.cookie; true
         securityContext:
           runAsUser: 0
         volumeMounts:


### PR DESCRIPTION
If /var/lib/rabbitmq/.erlang.cookie does not exist the respective chmod command is failing causing the init container to fail.

This happens on empty PVs, does not affect installations where the erlang cookie is present already