### PR TITLE
[mariadb][backup-v2] support SSE-C for Ceph S3 backup uploads

### DIFF
--- a/common/mariadb/CHANGELOG.md
+++ b/common/mariadb/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.42.0 - 2026/07/13
+* support SSE-C for Ceph S3 backup uploads
+  * default at `global.mariadb.backup_v2.ceph_s3.sse_customer_key`
+  * per-target override at `global.mariadb.backup_v2.ceph_s3.targets[].sse_customer_key` (set to `""` to opt out of an inherited default)
+* chart version bumped
+
 ## v0.41.0 - 2026/07/06
 * support configurable S3 object lock on backup uploads
   * default at `backup_v2.object_lock.{enabled,lock_mode,retention_days}`

--- a/common/mariadb/Chart.yaml
+++ b/common/mariadb/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes
 name: mariadb
-version: 0.41.0
+version: 0.42.0
 # scripts/docker-entyrpoint.sh should be updated when appVersion is updated
 appVersion: 10.11.18
 dependencies:

--- a/common/mariadb/ci/test-values.yaml
+++ b/common/mariadb/ci/test-values.yaml
@@ -17,11 +17,26 @@ global:
         region: local
         sse_customer_key: superSecret
       ceph_s3:
+        sse_customer_key: superSecretDefault
         targets:
           - endpoint: "https://ceph-s3.local.example.com"
             region: local
             aws_access_key_id: superSecret
             aws_secret_access_key: superSecret
+          - name: ceph-override
+            endpoint: "https://ceph-s3-b.local.example.com"
+            region: local
+            bucket_name: mariadb-backup-local-b
+            aws_access_key_id: superSecret
+            aws_secret_access_key: superSecret
+            sse_customer_key: superSecretPerTarget
+          - name: ceph-optout
+            endpoint: "https://ceph-s3-c.local.example.com"
+            region: local
+            bucket_name: mariadb-backup-local-c
+            aws_access_key_id: superSecret
+            aws_secret_access_key: superSecret
+            sse_customer_key: ""
 
 test_db_host: testRelease-mariadb.svc
 root_password: secret123

--- a/common/mariadb/templates/_helpers.tpl
+++ b/common/mariadb/templates/_helpers.tpl
@@ -28,6 +28,7 @@
   Usage:
     include "mariadb.backup_v2.object_lock" (dict "target" $target.object_lock "default" .Values.backup_v2.object_lock)
 */}}
+
 {{- define "mariadb.backup_v2.object_lock" -}}
 {{- $target := default (dict) .target -}}
 {{- $default := default (dict) .default -}}
@@ -47,6 +48,17 @@
 object_lock_enabled: true
 object_lock_mode: {{ $mode | quote }}
 object_lock_retention_days: {{ $days }}
+{{- end -}}
+{{- end -}}
+
+{{/* Emit SSE-C keys for a backup_v2 S3 target; per-target overrides default. */}}
+{{- define "mariadb.backup_v2.sse_c" -}}
+{{- $target := default (dict) .target -}}
+{{- $key := default "" .default -}}
+{{- if hasKey $target "sse_customer_key" -}}{{- $key = $target.sse_customer_key -}}{{- end -}}
+{{- if $key -}}
+sse_customer_algorithm: "AES256"
+sse_customer_key: {{ include "mariadb.resolve_secret_squote" $key }}
 {{- end -}}
 {{- end -}}
 

--- a/common/mariadb/templates/config/_backup_config.yaml.tpl
+++ b/common/mariadb/templates/config/_backup_config.yaml.tpl
@@ -74,6 +74,11 @@ storages:
       {{- if ternary $t.verify $.Values.backup_v2.ceph_s3.verify (hasKey $t "verify") }}
       verify: true
       {{- end }}
+      {{- $cephSseDefault := dig "mariadb" "backup_v2" "ceph_s3" "sse_customer_key" "" $.Values.global }}
+      {{- $cephSseC := include "mariadb.backup_v2.sse_c" (dict "target" $t "default" $cephSseDefault) }}
+      {{- if $cephSseC }}
+      {{- $cephSseC | nindent 6 }}
+      {{- end }}
       {{- $cephObjectLock := include "mariadb.backup_v2.object_lock" (dict "target" $t.object_lock "default" $.Values.backup_v2.object_lock) }}
       {{- if $cephObjectLock }}
       {{- $cephObjectLock | nindent 6 }}

--- a/common/mariadb/values.yaml
+++ b/common/mariadb/values.yaml
@@ -248,6 +248,9 @@ backup_v2:
     #     bucket_name: mariadb-backup-eu-de-2   # optional, defaults to mariadb-backup-<global.region>
     #     force_path_style: true                # optional, inherits chart-local default
     #     verify: false                         # optional, inherits chart-local default
+    #     sse_customer_key: vault+kvv2:...      # optional, opt-in SSE-C key;
+    #                                           #   inherits global.mariadb.backup_v2.ceph_s3.sse_customer_key
+    #                                           #   when unset; set to "" to opt out of an inherited default.
     #     object_lock: {...}                    # optional, see backup_v2.object_lock below
   # Default S3 object-lock settings applied to every S3 target unless overridden.
   # Per-target overrides (per-field; omit a field to inherit the default below):


### PR DESCRIPTION
* support SSE-C for Ceph S3 backup uploads
  * default at `global.mariadb.backup_v2.ceph_s3.sse_customer_key`
  * per-target override at `global.mariadb.backup_v2.ceph_s3.targets[].sse_customer_key`
* chart version bumped