### PR TITLE
fix(metrics-server): bump to v0.9.0 to fix Critical CVEs

### DIFF
--- a/system/kube-system-kubernikus/Chart.lock
+++ b/system/kube-system-kubernikus/Chart.lock
@@ -19,7 +19,7 @@ dependencies:
   version: 2.8.1
 - name: metrics-server
   repository: https://kubernetes-sigs.github.io/metrics-server
-  version: 3.13.0
+  version: 3.13.1
 - name: priority-class
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.0.0
@@ -38,5 +38,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 1.2.0
-digest: sha256:8ee24d779ea4058df36dd29b1a0d9124180833784f89789d1bda5d9fa288ee85
-generated: "2026-07-13T10:01:21.941338+02:00"
+digest: sha256:7b5293b5e606c057a27ad0f05676fece6ddb7edae352fe5ae388ba2d3b87351c
+generated: "2026-07-13T14:52:01.329054+02:00"

--- a/system/kube-system-kubernikus/Chart.yaml
+++ b/system/kube-system-kubernikus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for Kubernikus control-plane clusters.
 name: kube-system-kubernikus
-version: 3.11.2
+version: 3.11.3
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-kubernikus
 dependencies:
   - name: cc-rbac
@@ -25,7 +25,7 @@ dependencies:
     version: "^2.x"
   - name: metrics-server
     repository: https://kubernetes-sigs.github.io/metrics-server
-    version: 3.13.0
+    version: 3.13.1
   - name: priority-class
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 2.0.0

--- a/system/kube-system-kubernikus/values.yaml
+++ b/system/kube-system-kubernikus/values.yaml
@@ -36,7 +36,7 @@ cert-manager:
 metrics-server:
   image:
     repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/metrics-server/metrics-server
-
+    tag: v0.9.0
   # Workaround for qa landscapes.
   args:
     - --kubelet-insecure-tls

--- a/system/kube-system-metal/Chart.lock
+++ b/system/kube-system-metal/Chart.lock
@@ -46,7 +46,7 @@ dependencies:
   version: 1.0.7
 - name: metrics-server
   repository: https://kubernetes-sigs.github.io/metrics-server
-  version: 3.13.0
+  version: 3.13.1
 - name: priority-class
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.2
@@ -77,5 +77,5 @@ dependencies:
 - name: validating-admission-policy
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.0.2
-digest: sha256:8e2b94e599300ce34ffc76d254d81913ca6ae3f5dfe7c9a5a326b6d5bab48b09
-generated: "2026-07-13T10:00:53.932347+02:00"
+digest: sha256:033853608b4cceca13766e9c4726b728c8059ae1be559d58b3dd643f5e9f6642
+generated: "2026-07-13T14:51:42.353011+02:00"

--- a/system/kube-system-metal/Chart.yaml
+++ b/system/kube-system-metal/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for metal clusters.
 name: kube-system-metal
-version: 6.14.6
+version: 6.14.7
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-metal
 dependencies:
   - name: cc-rbac
@@ -61,7 +61,7 @@ dependencies:
     version: "^1.x"
   - name: metrics-server
     repository: https://kubernetes-sigs.github.io/metrics-server
-    version: 3.13.0
+    version: 3.13.1
   - name: priority-class
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.1.2

--- a/system/kube-system-metal/values.yaml
+++ b/system/kube-system-metal/values.yaml
@@ -249,6 +249,7 @@ descheduler:
 metrics-server:
   image:
     repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/metrics-server/metrics-server
+    tag: v0.9.0
 
   # Workaround for qa landscapes.
   args:

--- a/system/kube-system-scaleout/Chart.lock
+++ b/system/kube-system-scaleout/Chart.lock
@@ -25,7 +25,7 @@ dependencies:
   version: 2.8.1
 - name: metrics-server
   repository: https://kubernetes-sigs.github.io/metrics-server
-  version: 3.13.0
+  version: 3.13.1
 - name: priority-class
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.0.0
@@ -44,5 +44,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 1.2.0
-digest: sha256:7c44186bafcee8620c1d53cd8921e782418cc204e1672033b618d2726f6c8114
-generated: "2026-07-13T10:01:10.127589+02:00"
+digest: sha256:9a4f5913568593a3a6f5ad366b44717368ecd76c947dafc6ad13c038b15d0807
+generated: "2026-07-13T14:51:49.792454+02:00"

--- a/system/kube-system-scaleout/Chart.yaml
+++ b/system/kube-system-scaleout/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kube-System relevant Service collection for scaleout clusters.
 name: kube-system-scaleout
-version: 5.13.3
+version: 5.13.4
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-scaleout
 dependencies:
   - name: cc-rbac
@@ -34,7 +34,7 @@ dependencies:
     version: "^2.x"
   - name: metrics-server
     repository: https://kubernetes-sigs.github.io/metrics-server
-    version: 3.13.0
+    version: 3.13.1
   - name: priority-class
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 2.0.0

--- a/system/kube-system-scaleout/values.yaml
+++ b/system/kube-system-scaleout/values.yaml
@@ -38,7 +38,7 @@ maintenance-controller:
 metrics-server:
   image:
     repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/metrics-server/metrics-server
-
+    tag: v0.9.0
   # Workaround for qa landscapes.
   args:
     - --kubelet-insecure-tls

--- a/system/kube-system-virtual/Chart.lock
+++ b/system/kube-system-virtual/Chart.lock
@@ -34,7 +34,7 @@ dependencies:
   version: 1.0.7
 - name: metrics-server
   repository: https://kubernetes-sigs.github.io/metrics-server
-  version: 3.13.0
+  version: 3.13.1
 - name: priority-class
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.0.0
@@ -56,5 +56,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 1.2.0
-digest: sha256:a4271816c8f83772fa251fafb821092539900fbcda23ce32168235bccc76153c
-generated: "2026-07-13T10:01:15.875726+02:00"
+digest: sha256:85eaa852d9d75dd803596fee750be6cd70e4564bb635bc966c64675279892881
+generated: "2026-07-13T14:51:55.279553+02:00"

--- a/system/kube-system-virtual/Chart.yaml
+++ b/system/kube-system-virtual/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for virtual clusters.
 name: kube-system-virtual
-version: 4.9.5
+version: 4.9.6
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-virtual
 dependencies:
   - name: cc-rbac
@@ -39,7 +39,7 @@ dependencies:
     version: '>= 0.0.0'
   - name: metrics-server
     repository: https://kubernetes-sigs.github.io/metrics-server
-    version: 3.13.0
+    version: 3.13.1
   - name: priority-class
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 2.0.0

--- a/system/kube-system-virtual/values.yaml
+++ b/system/kube-system-virtual/values.yaml
@@ -92,6 +92,7 @@ maintenance-controller:
 metrics-server:
   image:
     repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/metrics-server/metrics-server
+    tag: v0.9.0
 
   # Workaround for qa landscapes.
   args:

--- a/system/metrics-server/Chart.yaml
+++ b/system/metrics-server/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: metrics-server
 description: A Helm chart for the kubernetes-sigs/metrics-server.
 type: application
-version: 2.0.2
-appVersion: v0.8.1
+version: 2.0.3
+appVersion: v0.9.0


### PR DESCRIPTION
v0.9.0 (released 2026-07-13) fixes all Critical CVEs:
- CVE-2026-33186 (Critical) grpc v1.72.0 -> v1.81.1
- CVE-2025-68121 (Critical) Go stdlib 1.24.12 -> 1.26.4

Helm chart bumped from 3.13.0 to 3.13.1.
Explicit image tag v0.9.0 set in all kube-system chart values. Chart.lock updated via helm dep update.

Deployed on: metal, kubernikus, virtual, scaleout