### PR TITLE
fix(kube-system-*): set commonLabels to reflect actual metrics-server version

### DIFF
--- a/system/kube-system-kubernikus/Chart.yaml
+++ b/system/kube-system-kubernikus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for Kubernikus control-plane clusters.
 name: kube-system-kubernikus
-version: 3.11.3
+version: 3.11.4
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-kubernikus
 dependencies:
   - name: cc-rbac

--- a/system/kube-system-kubernikus/values.yaml
+++ b/system/kube-system-kubernikus/values.yaml
@@ -37,6 +37,8 @@ metrics-server:
   image:
     repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/metrics-server/metrics-server
     tag: v0.9.0
+  commonLabels:
+    app.kubernetes.io/version: "0.9.0"
   # Workaround for qa landscapes.
   args:
     - --kubelet-insecure-tls

--- a/system/kube-system-metal/Chart.yaml
+++ b/system/kube-system-metal/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for metal clusters.
 name: kube-system-metal
-version: 6.14.7
+version: 6.14.8
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-metal
 dependencies:
   - name: cc-rbac

--- a/system/kube-system-metal/values.yaml
+++ b/system/kube-system-metal/values.yaml
@@ -250,6 +250,8 @@ metrics-server:
   image:
     repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/metrics-server/metrics-server
     tag: v0.9.0
+  commonLabels:
+    app.kubernetes.io/version: "0.9.0"
 
   # Workaround for qa landscapes.
   args:

--- a/system/kube-system-scaleout/Chart.yaml
+++ b/system/kube-system-scaleout/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kube-System relevant Service collection for scaleout clusters.
 name: kube-system-scaleout
-version: 5.13.4
+version: 5.13.5
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-scaleout
 dependencies:
   - name: cc-rbac

--- a/system/kube-system-scaleout/values.yaml
+++ b/system/kube-system-scaleout/values.yaml
@@ -39,6 +39,8 @@ metrics-server:
   image:
     repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/metrics-server/metrics-server
     tag: v0.9.0
+  commonLabels:
+    app.kubernetes.io/version: "0.9.0"
   # Workaround for qa landscapes.
   args:
     - --kubelet-insecure-tls

--- a/system/kube-system-virtual/Chart.yaml
+++ b/system/kube-system-virtual/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for virtual clusters.
 name: kube-system-virtual
-version: 4.9.6
+version: 4.9.7
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-virtual
 dependencies:
   - name: cc-rbac

--- a/system/kube-system-virtual/values.yaml
+++ b/system/kube-system-virtual/values.yaml
@@ -93,6 +93,8 @@ metrics-server:
   image:
     repository: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror/metrics-server/metrics-server
     tag: v0.9.0
+  commonLabels:
+    app.kubernetes.io/version: "0.9.0"
 
   # Workaround for qa landscapes.
   args:


### PR DESCRIPTION
Override app.kubernetes.io/version label to show 0.9.0 instead of the helm chart appVersion 0.8.1 for accurate version tracking.