### PR TITLE
feat(argora-operator): add per-cluster BMC credential override

### DIFF
--- a/system/argora-operator-remote/Chart.lock
+++ b/system/argora-operator-remote/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.0.0
 - name: argora
   repository: oci://ghcr.io/sapcc/charts
-  version: 0.0.1-20260616085052-216b1d2-crds
-digest: sha256:12e24d0bd854c1369b94d1e0db3bee30f630133ccf9a64f7a56e0cd1750c154e
-generated: "2026-06-16T11:02:25.058949+02:00"
+  version: 0.0.1-20260713134824-2c3573c-crds
+digest: sha256:2696fc1c58c5b673d5f573490fe97e1ac63ad6f80c1482a479b6dfe5afb968f8
+generated: "2026-07-13T17:06:19.696264+03:00"

--- a/system/argora-operator-remote/Chart.yaml
+++ b/system/argora-operator-remote/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.59
+version: 0.0.60
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -25,5 +25,5 @@ dependencies:
     version: ">= 0.0.0"
   - name: argora
     repository: oci://ghcr.io/sapcc/charts
-    version: 0.0.1-20260616085052-216b1d2-crds
+    version: 0.0.1-20260713134824-2c3573c-crds
     alias: argora-operator-core

--- a/system/argora-operator-remote/managedresources/crds-and-rbac.yaml
+++ b/system/argora-operator-remote/managedresources/crds-and-rbac.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: argora-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argora
-    helm.sh/chart: argora-0.0.1-20260616085052-216b1d2-crds
+    helm.sh/chart: argora-0.0.1-20260713134824-2c3573c-crds
     app.kubernetes.io/instance: argora-operator
     app.kubernetes.io/part-of: argora-operator
   name: argora-operator-controller-manager
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/component: argora-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argora
-    helm.sh/chart: argora-0.0.1-20260616085052-216b1d2-crds
+    helm.sh/chart: argora-0.0.1-20260713134824-2c3573c-crds
     app.kubernetes.io/instance: argora-operator
     app.kubernetes.io/part-of: argora-operator
   name: clusterimports.argora.cloud.sap
@@ -161,7 +161,7 @@ metadata:
     app.kubernetes.io/component: argora-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argora
-    helm.sh/chart: argora-0.0.1-20260616085052-216b1d2-crds
+    helm.sh/chart: argora-0.0.1-20260713134824-2c3573c-crds
     app.kubernetes.io/instance: argora-operator
     app.kubernetes.io/part-of: argora-operator
   name: ippoolimports.argora.cloud.sap
@@ -313,7 +313,7 @@ metadata:
     app.kubernetes.io/component: argora-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argora
-    helm.sh/chart: argora-0.0.1-20260616085052-216b1d2-crds
+    helm.sh/chart: argora-0.0.1-20260713134824-2c3573c-crds
     app.kubernetes.io/instance: argora-operator
     app.kubernetes.io/part-of: argora-operator
   name: updates.argora.cloud.sap
@@ -449,7 +449,7 @@ metadata:
     app.kubernetes.io/component: argora-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argora
-    helm.sh/chart: argora-0.0.1-20260616085052-216b1d2-crds
+    helm.sh/chart: argora-0.0.1-20260713134824-2c3573c-crds
     app.kubernetes.io/instance: argora-operator
     app.kubernetes.io/part-of: argora-operator
   name: argora-operator-manager-role
@@ -607,7 +607,7 @@ metadata:
     app.kubernetes.io/component: argora-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argora
-    helm.sh/chart: argora-0.0.1-20260616085052-216b1d2-crds
+    helm.sh/chart: argora-0.0.1-20260713134824-2c3573c-crds
     app.kubernetes.io/instance: argora-operator
     app.kubernetes.io/part-of: argora-operator
   name: argora-operator-manager-rolebinding

--- a/system/argora-operator/Chart.lock
+++ b/system/argora-operator/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.0.0
 - name: argora
   repository: oci://ghcr.io/sapcc/charts
-  version: 0.0.1-20260616085052-216b1d2
-digest: sha256:91aac2e6a1e6d99e8e2a7723b782932959901a89d7948bd3950546ec34c9977f
-generated: "2026-06-16T11:02:11.24801+02:00"
+  version: 0.0.1-20260713134824-2c3573c
+digest: sha256:904a3d098f6f84c50b371c380a36c7b4ce20c75c3d1b9e823c02a242f9f59809
+generated: "2026-07-13T17:05:11.543274+03:00"

--- a/system/argora-operator/Chart.yaml
+++ b/system/argora-operator/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: argora-operator
 description: A Helm chart for Kubernetes
 type: application
-version: 0.0.49
+version: 0.0.50
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: ">= 0.0.0"
   - name: argora
     repository: oci://ghcr.io/sapcc/charts
-    version: 0.0.1-20260616085052-216b1d2
+    version: 0.0.1-20260713134824-2c3573c
     alias: argora-operator-core

--- a/system/argora-operator/ci/test-values.yaml
+++ b/system/argora-operator/ci/test-values.yaml
@@ -6,3 +6,13 @@ argora-operator-core:
     bmcUser: "foo"
     bmcPassword: "bar"
     netboxToken: "token"
+
+clusterImport:
+  test-cluster:
+    - name: cluster-a
+    - name: cluster-b
+      bmcUser: "override-user-b"
+      bmcPassword: "override-pass-b"
+    - name: cluster-c
+      bmcUser: "override-user-c"
+      bmcPassword: "override-pass-c"

--- a/system/argora-operator/templates/bmc-credentials-secret.yaml
+++ b/system/argora-operator/templates/bmc-credentials-secret.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.clusterImport -}}
+{{- range $name, $clusters := .Values.clusterImport }}
+{{- range $cluster := $clusters }}
+{{- if and $cluster.bmcUser $cluster.bmcPassword }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bmc-{{ $cluster.name }}
+  namespace: argora-system
+  labels:
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/component: bmc-credentials
+type: Opaque
+stringData:
+  bmcUser: {{ $cluster.bmcUser | quote }}
+  bmcPassword: {{ $cluster.bmcPassword | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/system/argora-operator/templates/cluster-import.yaml
+++ b/system/argora-operator/templates/cluster-import.yaml
@@ -8,6 +8,12 @@ metadata:
   namespace: argora-system
 spec:
   clusters:
-{{ toYaml $clusters | nindent 2 }}
+  {{- range $cluster := $clusters }}
+  - {{ toYaml (omit $cluster "bmcUser" "bmcPassword") | nindent 4 | trim }}
+    {{- if and $cluster.bmcUser $cluster.bmcPassword }}
+    bmcCredentialsRef:
+      name: bmc-{{ $cluster.name }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/system/argora-operator/values.yaml
+++ b/system/argora-operator/values.yaml
@@ -76,3 +76,11 @@ argora-operator-core:
   #   bmcUser: ""
   #   bmcPassword: ""
   #   netboxToken: ""
+
+# clusterImport entries support optional per-cluster BMC credential overrides.
+# Add bmcUser/bmcPassword inline and a Secret + bmcCredentialsRef are generated automatically.
+# clusterImport:
+#   my-cluster:
+#     - name: rt-region-1
+#       bmcUser: ""
+#       bmcPassword: ""


### PR DESCRIPTION
## Summary

Add support for per-cluster BMC credential overrides in `clusterImport` entries, enabling multiple regions with different IPMI credentials to run in a single argora instance.

Implements helm-chart support for https://github.com/sapcc/argora/pull/169.

## Changes

- **templates/bmc-credentials-secret.yaml** — New template: auto-generates a Secret in `argora-system` when `bmcUser`/`bmcPassword` are specified inline on a cluster entry
- **templates/cluster-import.yaml** — Strips `bmcUser`/`bmcPassword` from the CR spec and injects `bmcCredentialsRef` pointing to the generated Secret
- **values.yaml** — Document inline credential usage
- **ci/test-values.yaml** — Test coverage for both with and without credentials
- **Chart.yaml** — Bump argora dependency to include bmcCredentialsRef CRD field, bump chart version

## Usage

```yaml
clusterImport:
  my-cluster-import:
    - name: cluster-a
      bmcUser: "region-specific-user"
      bmcPassword: "region-specific-pass"
    - name: cluster-b
      # no bmcUser/bmcPassword → uses central credentials
```

Clusters without `bmcUser`/`bmcPassword` fall back to the central credentials as before.