### PR TITLE
Keystone: restrict /v3/projects?is_domain=True to cloud admins only

### DIFF
--- a/openstack/keystone/templates/etc/_policy.yaml.tpl
+++ b/openstack/keystone/templates/etc/_policy.yaml.tpl
@@ -931,7 +931,7 @@
 # Intended scope(s): system, domain
 #"identity:list_projects": "(role:reader and system_scope:all) or (role:reader and domain_id:%(target.domain_id)s)"
 "identity:list_projects": "rule:cloud_reader or
-  (role:reader and domain_id:%(target.domain_id)s) or
+  (role:reader and domain_id:%(target.domain_id)s and not True:%(filter_attr.is_domain)s) or
   (role:reader and domain_id:%(filter_attr.domain_id)s) or
   (role:reader and project_id:%(filter_attr.parent_id)s)"
 


### PR DESCRIPTION
## Summary

- External users with domain-scoped or project-scoped reader tokens could call `GET /v3/projects?is_domain=True` and see all domains including internal ones
- Adds `and not True:%(filter_attr.is_domain)s` to the domain-scoped reader clause in `identity:list_projects`, blocking the endpoint for non-cloud_reader tokens
- Consistent with the `/v3/domains` restriction from #10927

Part of [sap-cloud-infrastructure/foundation-issues#1263](https://github.wdf.sap.corp/orgs/sap-cloud-infrastructure/projects/40/views/2?filterQuery=assignee%3AI765831&pane=issue&itemId=224491&issue=sap-cloud-infrastructure%7Cfoundation-issues%7C1263)

## Test plan

- [x] Domain-scoped reader + `?is_domain=True` → 403
- [x] Domain-scoped reader + normal listing → 200 (own domain's projects only)
- [x] Project-scoped reader + `?is_domain=True` → 403
- [x] Admin (cloud_reader) + `?is_domain=True` → 200 (all domains visible)
- [x] Admin (cloud_reader) + normal listing → 200