### PR TITLE
Ignore psk for Neutron VPNaaS IPsec Site Conn

### DIFF
--- a/openstack/neutron/templates/etc/_neutron_audit_map.yaml
+++ b/openstack/neutron/templates/etc/_neutron_audit_map.yaml
@@ -201,5 +201,8 @@ resources:
         type_uri: network/vpn/ipsec-policies
         el_type_uri: network/vpn/ipsec-policy
       ipsec-site-connections:
+        payloads:
+          exclude:
+            - psk
       vpnservices:
         type_uri: network/vpn/vpn-services


### PR DESCRIPTION
We don't want to log the psk of an IPsec Site Connection for operations on this object in the scope of Neutron's VPNaaS plugin.