### PR TITLE
barbican: restrict kubectl exec/port-forward on barbican-api pods (SCIBPL-218)

### DIFF
--- a/openstack/barbican/Chart.yaml
+++ b/openstack/barbican/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: flamingo
 description: A Helm chart for Openstack Barbican
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Barbican/OpenStack_Project_Barbican_vertical.png
 name: barbican
-version: 0.8.5
+version: 0.8.6
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/barbican/templates/validating-admission-policy.yaml
+++ b/openstack/barbican/templates/validating-admission-policy.yaml
@@ -1,0 +1,62 @@
+{{- /*
+SCIBPL-218: deny `kubectl exec` / `kubectl port-forward` / `kubectl attach`
+on the barbican-api pods that belong to this release.
+
+Enforced by a ValidatingAdmissionPolicy (K8s >= 1.30 GA) — no operator
+required. Matches on `CONNECT` requests targeting the `pods/exec`,
+`pods/portforward`, and `pods/attach` subresources in this release's
+namespace, further narrowed to Pods whose name starts with
+`barbican-api-` (the deployment-generated pod-name prefix).
+
+Break-glass: any user whose Kubernetes group membership includes at least
+one entry from `.Values.restrictPodsExec.breakGlassGroups` bypasses the
+policy. Defaults to `system:masters`; operators can widen per-cluster in
+the secrets repo.
+*/ -}}
+{{- if .Values.restrictPodsExec.enabled }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: {{ .Release.Name }}-restrict-barbican-api-exec.cloud.sap
+  labels:
+    app: {{ template "fullname" . }}
+    system: openstack
+    component: barbican
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups:   [""]
+        apiVersions: ["v1"]
+        operations:  ["CONNECT"]
+        resources:   ["pods/exec", "pods/portforward", "pods/attach"]
+  matchConditions:
+    - name: in-release-namespace
+      expression: "request.namespace == '{{ .Release.Namespace }}'"
+    - name: is-barbican-api-pod
+      expression: "request.name.startsWith('barbican-api-')"
+    - name: user-not-in-break-glass
+      expression: >-
+        !has(request.userInfo.groups) ||
+        !request.userInfo.groups.exists(g, g in {{ .Values.restrictPodsExec.breakGlassGroups | toJson }})
+  validations:
+    - expression: "false"
+      messageExpression: >-
+        'kubectl ' + request.subResource + ' on ' + request.namespace + '/' +
+        request.name + ' is not permitted (SCIBPL-218). Use the break-glass ' +
+        'procedure if shell access is truly required.'
+      reason: Forbidden
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: {{ .Release.Name }}-restrict-barbican-api-exec-binding.cloud.sap
+  labels:
+    app: {{ template "fullname" . }}
+    system: openstack
+    component: barbican
+spec:
+  policyName: {{ .Release.Name }}-restrict-barbican-api-exec.cloud.sap
+  validationActions: [Deny]
+  matchResources: {}
+{{- end }}

--- a/openstack/barbican/values.yaml
+++ b/openstack/barbican/values.yaml
@@ -547,3 +547,13 @@ barbican_nanny:
   interval: 1
   db_secret_move:
     enabled: false
+
+# SCIBPL-218: restrict kubectl exec / port-forward / attach on the
+# barbican-api pods via a ValidatingAdmissionPolicy (K8s >= 1.30).
+# See templates/validating-admission-policy.yaml.
+restrictPodsExec:
+  enabled: true
+  # Kubernetes groups whose members bypass the policy (break-glass).
+  # Override per-cluster in the secrets repo if needed.
+  breakGlassGroups:
+    - system:masters


### PR DESCRIPTION
## What

Adds a `ValidatingAdmissionPolicy` + `Binding` to the barbican chart that denies `kubectl exec`, `port-forward`, and `attach` on `barbican-api-*` pods. Closes SCIBPL-218.

- Matches `CONNECT` on `pods/exec | pods/portforward | pods/attach`, further narrowed via CEL to `request.namespace == <release-ns>` and `request.name.startsWith("barbican-api-")`.
- Break-glass: users in any group listed in `.Values.restrictPodsExec.breakGlassGroups` (default `[system:masters]`) bypass the policy.
- Scope: only `barbican-api-*`. Nanny / migration / mariadb / memcached pods remain exec-able.
- Chart bump `0.8.5 → 0.8.6`.

## Why VAP (not NetworkPolicy, not Gatekeeper)

`NetworkPolicy` cannot block exec/pf: kubectl talks to kubelet from the node's host-network namespace, which our CNIs do not filter. Admission-time is the correct layer. VAP over Gatekeeper: native (K8s ≥ 1.30 GA), no operator, no cluster-wide values changes, and the same pattern already ships in `system/validating-admission-policy/`. Supersedes the closed NetworkPolicy attempt #12039.

## Test evidence — qa-de-2, chart `barbican-0.8.6`, helm rev 2440

```
kubectl -n monsoon3 get validatingadmissionpolicy         barbican-restrict-barbican-api-exec.cloud.sap          # present
kubectl -n monsoon3 get validatingadmissionpolicybinding  barbican-restrict-barbican-api-exec-binding.cloud.sap  # present
helm3 -n monsoon3 get metadata barbican   # CHART=barbican  VERSION=0.8.6  APP_VERSION=flamingo
```

| # | Assertion | Command | Result |
|---|---|---|---|
| 1 | `exec` on `barbican-api-*` denied | `kubectl -n monsoon3 exec barbican-api-f48cf94b-2k7h6 -c barbican-api -- true` | ✅ `denied … kubectl exec on monsoon3/barbican-api-f48cf94b-2k7h6 is not permitted (SCIBPL-218)…` |
| 2 | `port-forward` denied | `kubectl -n monsoon3 port-forward barbican-api-f48cf94b-2k7h6 19311:9311 </dev/null` | ✅ `denied … kubectl portforward on monsoon3/barbican-api-f48cf94b-2k7h6 is not permitted (SCIBPL-218)…` |
| 3 | `attach` denied | `kubectl -n monsoon3 attach barbican-api-f48cf94b-2k7h6 -c barbican-api </dev/null` | ✅ `denied … kubectl attach on monsoon3/barbican-api-f48cf94b-2k7h6 is not permitted (SCIBPL-218)…` |
| 4 | Break-glass (`system:masters`) allowed | `kubectl -n monsoon3 --as=cluster-admin --as-group=system:masters exec barbican-api-f48cf94b-2k7h6 -c barbican-api -- echo BREAK_GLASS_OK` | ✅ `BREAK_GLASS_OK` |
| 5 | Scope-safe: `barbican-mariadb-*` unaffected | `kubectl -n monsoon3 exec barbican-mariadb-5c9c87b67b-v87sp -c mariadb -- echo MARIADB_EXEC_OK` | ✅ `MARIADB_EXEC_OK` |

## Follow-ups (out of scope)

- Extend the same policy to `barbican-nanny` and other barbican pods once operational impact of denying exec is validated across regions.
- Companion RBAC narrowing in `system/cc-rbac/` (platform team) to remove `create` on `pods/exec` / `pods/portforward` from the day-to-day "supporter" role for barbican — defence in depth.

## Links

- Ticket: SCIBPL-218
- Predecessor (closed): #12039
