### PR TITLE
[octobus-query-exporter] escalate NFSFCDObjectNotFound to critical

### DIFF
--- a/prometheus-exporters/octobus-query-exporter/Chart.lock
+++ b/prometheus-exporters/octobus-query-exporter/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: octobus-query-exporter
   repository: file://vendor/octobus-query-exporter
-  version: 1.0.30
+  version: 1.0.31
 - name: octobus-query-exporter-global
   repository: file://vendor/octobus-query-exporter-global
   version: 1.0.14
@@ -11,5 +11,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:056a51bdde63d9e99f96aff5a539a52c190813b65367eb16710d89d068fc6aab
-generated: "2026-06-23T20:41:55.029717+08:00"
+digest: sha256:a89c958cbad501cb6bf5f1377b0296c7f9d1a1601dd89bb064b8de1f854aaf9b
+generated: "2026-07-14T00:01:44.36936+08:00"

--- a/prometheus-exporters/octobus-query-exporter/Chart.yaml
+++ b/prometheus-exporters/octobus-query-exporter/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 1.0.32
+version: 1.0.33
 name: octobus-query-exporter
 description: Elasticsearch prometheus query exporter
 maintainers:
@@ -11,7 +11,7 @@ dependencies:
   - name: octobus-query-exporter
     alias: octobus_query_exporter
     repository: file://vendor/octobus-query-exporter
-    version: 1.0.30
+    version: 1.0.31
     condition: octobus_query_exporter.enabled
 
   - name: octobus-query-exporter-global

--- a/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/Chart.yaml
+++ b/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 1.0.30
+version: 1.0.31
 name: octobus-query-exporter
 description: Elasticsearch prometheus query exporter
 maintainers:

--- a/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/alerts/scaleout/events.alerts.tpl
+++ b/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/alerts/scaleout/events.alerts.tpl
@@ -90,7 +90,7 @@ groups:
         expr: >
             elasticsearch_octobus_FCDObjectNotFound_issue_hostsystem_doc_count
         labels:
-          severity: warning
+          severity: critical
           service: compute
           tier: vmware
           support_group: compute
@@ -99,5 +99,5 @@ groups:
           playbook: docs/compute/playbooks/vcenter/#fcdobjectnotfound
         annotations:
           summary: "Error for FCD Object Storage Not Found "
-          description: "vCenter {{`{{ $labels.hostsystem }}`}} reported FCD Ojbect Not found, please follow the playbook to fix it"
+          description: "vCenter {{`{{ $labels.hostsystem }}`}} reported FCD Object Not Found, please follow the playbook to fix it"
 


### PR DESCRIPTION
## Summary

- Change `NFSFCDObjectNotFound` alert severity from `warning` to `critical`
- Fix typo in alert description: `Ojbect` → `Object`
- Bump subchart `octobus-query-exporter` `1.0.30` → `1.0.31`
- Bump outer chart `1.0.32` → `1.0.33`