### PR TITLE
[cc-shoots] : Remove pre-upgrade helm hook for WI 

### DIFF
--- a/system/cc-shoots/Chart.yaml
+++ b/system/cc-shoots/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-shoots
 description: Converged Cloud Gardener shoots
 type: application
-version: 0.7.2
+version: 0.7.3
 appVersion: "0.1.0"

--- a/system/cc-shoots/templates/secrets.yaml
+++ b/system/cc-shoots/templates/secrets.yaml
@@ -73,7 +73,7 @@ kind: WorkloadIdentity
 metadata:
   name: metal-wi-{{ $regionName }}
   annotations:
-    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook: pre-install
     helm.sh/hook-weight: "1"
 spec:
   audiences:
@@ -86,7 +86,7 @@ kind: CredentialsBinding
 metadata:
   name: metal-wi-{{ $regionName }}
   annotations:
-    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook: pre-install
     helm.sh/hook-weight: "5"
 provider:
   type: ironcore-metal


### PR DESCRIPTION
Helm upgrades were failing due to pipeline timeouts. Helm `pre-upgrade` hook attempts to apply a merge patch to the existing `WI` and `Binding` resources. However, the Gardener API enforces strict immutability on these CRDs (I checked gardner source code) . The gardner API server rejects the patch with an error, theoretically causing Helm's `--wait` flag to hang indefinitely in a retry loop

Further deployments should now ignore these resources