### PR TITLE
bmcsettings: fix dell-default, contained non-writable key

### DIFF
--- a/system/metal-settings/Chart.yaml
+++ b/system/metal-settings/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.29
+version: 0.2.30
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/metal-settings/bmc_settings/dell-default.yaml
+++ b/system/metal-settings/bmc_settings/dell-default.yaml
@@ -22,8 +22,6 @@ settings:
   NTPConfigGroup.1.NTP3: "timehost3.global.cloud.sap"
   IPv4Static.1.DNS1: "147.204.9.200"
   IPv4Static.1.DNS2: "147.204.9.201"
-  CurrentIPv4.1.DNS1: "147.204.9.200"
-  CurrentIPv4.1.DNS2: "147.204.9.201"
   SysLog.1.Port: "514"
   Time.1.DayLightOffset: "0"
   Time.1.Timezone: "UTC"


### PR DESCRIPTION
```2026-07-14T11:23:02Z	ERROR	Reconciler error	{"controller": "bmcsettings", "controllerGroup": "metal.ironcore.dev", "controllerKind": "BMCSettings", "BMCSettings": {"name":"somenode"}, "namespace": "", "name": "somenode", "reconcileID": "someid", "error": "failed to get BMC settings: failed to get BMC settings: some errors found in the settings '[setting key 'CurrentIPv4.1.DNS2' not found in possible settings setting key 'CurrentIPv4.1.DNS1' not found in possible settings]'.\nPossible settings 0x1886880"}```