### PR TITLE
[cronus] add auditSink.enabled toggle (v1.20.10)

### DIFF
--- a/openstack/cronus/Chart.yaml
+++ b/openstack/cronus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cronus
 description: proxying hyperscaler stateless services
-version: 0.1.16
+version: 0.1.17
 dependencies:
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/cronus/templates/cronus/_config.yaml.tpl
+++ b/openstack/cronus/templates/cronus/_config.yaml.tpl
@@ -326,6 +326,7 @@ cronus:
 {{- end }}
 {{- if .Values.hermes }}
   auditSink:
+    enabled: {{ .Values.config.cronusAuditSink.enabled | default false }}
     queueName: {{ .Values.config.cronusAuditSink.queueName }}
     internalQueueSize: {{ .Values.config.cronusAuditSink.internalQueueSize }}
     maxContentLen: {{ .Values.config.cronusAuditSink.maxContentLen | int64 }}

--- a/openstack/cronus/values.yaml
+++ b/openstack/cronus/values.yaml
@@ -396,6 +396,7 @@ config:
     nebula:client: rule:project_client_scope or rule:project_scope or rule:cluster_or_domain_scope
     nebula:cloud_admin: rule:cluster_or_domain_scope
   cronusAuditSink:
+    enabled: true
     queueName: notifications.info
     internalQueueSize: 20
     contentTypePrefixes:


### PR DESCRIPTION
cronus v1.20.10 gates audit logging on a new config field auditSink.enabled (default false in the app). Render it from config.cronusAuditSink.enabled so regions can toggle the sink, defaulting to true to preserve current behavior.

- templates/cronus/_config.yaml.tpl: emit enabled in the auditSink block
- values.yaml: default config.cronusAuditSink.enabled=true
- Chart.yaml: 0.1.16 -> 0.1.17