### PR TITLE
feat(keystone): add redis subchart for osprofiler backend

### DIFF
--- a/openstack/keystone/Chart.lock
+++ b/openstack/keystone/Chart.lock
@@ -19,7 +19,10 @@ dependencies:
   version: 1.3.5
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.32.0
+  version: 0.38.0
+- name: redis
+  repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+  version: 2.4.69
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1

--- a/openstack/keystone/Chart.lock
+++ b/openstack/keystone/Chart.lock
@@ -26,5 +26,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:8e82cbc084f78e131d0c41203cc14a5ddf6be22fa1551e906682f49889f70ad9
-generated: "2026-07-22T13:24:28.673972+02:00"
+digest: sha256:5f759211c3ccc7e421de8cf0a9314116c3a454dfd39be16016fc517a73c817ce
+generated: "2026-07-24T10:44:23.862847+02:00"

--- a/openstack/keystone/Chart.lock
+++ b/openstack/keystone/Chart.lock
@@ -19,7 +19,7 @@ dependencies:
   version: 1.3.5
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.38.0
+  version: 0.32.0
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.4.69

--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -36,7 +36,7 @@ dependencies:
     version: 1.3.5
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.38.0
+    version: 0.32.0
   - name: redis
     alias: osprofiler-redis
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -36,7 +36,12 @@ dependencies:
     version: 1.3.5
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.32.0
+    version: 0.38.0
+  - name: redis
+    alias: osprofiler-redis
+    repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
+    version: 2.4.69
+    condition: osprofiler.redis.enabled
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.1.1

--- a/openstack/keystone/templates/deployment-api.yaml
+++ b/openstack/keystone/templates/deployment-api.yaml
@@ -234,7 +234,9 @@ spec:
 {{ toYaml .Values.api.metrics.resources | indent 12 }}
           {{- end }}
         {{- end }}
+      {{- if not .Values.osprofiler.redis.enabled }}
       {{- include "jaeger_agent_sidecar" . | indent 8 }}
+      {{- end }}
       {{- if not .Values.proxysql.native_sidecar }}
       {{- include "utils.proxysql.container" . | indent 8 }}
       {{- end }}

--- a/openstack/keystone/templates/deployment-api.yaml
+++ b/openstack/keystone/templates/deployment-api.yaml
@@ -123,6 +123,15 @@ spec:
             {{- end }}
             - name: SENTRY_FILTER_CONFIG_FILE
               value: /etc/config/rules.yaml
+            {{- if .Values.osprofiler.redis.enabled }}
+            - name: OSPROFILER_REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-osprofiler-redis-user-default
+                  key: password
+            - name: OS_PROFILER__CONNECTION_STRING
+              value: "redis://:$(OSPROFILER_REDIS_PASSWORD)@{{ .Release.Name }}-osprofiler-redis:6379"
+            {{- end }}
           ports:
             - name: public
               containerPort: 5000

--- a/openstack/keystone/templates/etc/_secrets.conf.tpl
+++ b/openstack/keystone/templates/etc/_secrets.conf.tpl
@@ -35,10 +35,10 @@ heartbeat_timeout_threshold = {{ .Values.audit.central_service.heartbeat_timeout
 {{- end }}
 
 {{- if .Values.osprofiler.enabled }}
-{{- if and .Values.osprofiler.redis.enabled .Values.osprofiler.redis.redisPassword }}
+{{- if .Values.osprofiler.redis.enabled }}
 [profiler]
 enabled = true
-connection_string = redis://:{{ .Values.osprofiler.redis.redisPassword | include "resolve_secret" | trim }}@{{ .Release.Name }}-osprofiler-redis:6379
+connection_string = redis://{{ .Release.Name }}-osprofiler-redis:6379
 hmac_keys = {{ .Values.global.osprofiler.hmac_keys | include "resolve_secret" }}
 trace_sqlalchemy = {{ .Values.global.osprofiler.trace_sqlalchemy }}
 {{- else }}

--- a/openstack/keystone/templates/etc/_secrets.conf.tpl
+++ b/openstack/keystone/templates/etc/_secrets.conf.tpl
@@ -35,7 +35,15 @@ heartbeat_timeout_threshold = {{ .Values.audit.central_service.heartbeat_timeout
 {{- end }}
 
 {{- if .Values.osprofiler.enabled }}
+{{- if and .Values.osprofiler.redis.enabled .Values.osprofiler.redis.redisPassword }}
+[profiler]
+enabled = true
+connection_string = redis://:{{ .Values.osprofiler.redis.redisPassword | include "resolve_secret" | trim }}@{{ .Release.Name }}-osprofiler-redis:6379
+hmac_keys = {{ .Values.global.osprofiler.hmac_keys | include "resolve_secret" }}
+trace_sqlalchemy = {{ .Values.global.osprofiler.trace_sqlalchemy }}
+{{- else }}
 {{- include "osprofiler" . }}
+{{- end }}
 {{- end }}
 
 {{ if .Values.api.cc_radius }}

--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -42,6 +42,7 @@ osprofiler:
   enabled: false
   redis:
     enabled: false
+    redisPassword: ""
     persistence:
       enabled: false
     resources:

--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -42,7 +42,6 @@ osprofiler:
   enabled: false
   redis:
     enabled: false
-    redisPassword: ""
 
 osprofiler-redis:
   persistence:

--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -43,17 +43,19 @@ osprofiler:
   redis:
     enabled: false
     redisPassword: ""
-    persistence:
-      enabled: false
-    resources:
-      limits:
-        cpu: 200m
-        memory: 128Mi
-      requests:
-        cpu: 100m
-        memory: 128Mi
-    alerts:
-      support_group: identity
+
+osprofiler-redis:
+  persistence:
+    enabled: false
+  resources:
+    limits:
+      cpu: 200m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  alerts:
+    support_group: identity
 
 federation:
   oidc:

--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -40,6 +40,19 @@ nodeAffinity: {}
 # osprofiler
 osprofiler:
   enabled: false
+  redis:
+    enabled: false
+    persistence:
+      enabled: false
+    resources:
+      limits:
+        cpu: 200m
+        memory: 128Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+    alerts:
+      support_group: identity
 
 federation:
   oidc:


### PR DESCRIPTION
## Summary

- Adds `redis` subchart (alias `osprofiler-redis`) to keystone chart, gated on `osprofiler.redis.enabled`
- Bumps `utils` from `0.32.0` → `0.38.0` to get dynamic `connection_string` support in the osprofiler helm template
- Adds `osprofiler.redis` defaults block to `values.yaml`

## Background

`jaegertracing/jaeger-agent` was removed in Jaeger v2.x (upstream, by the Jaeger maintainers). The last published image is `1.30.0` from 2022 which has accumulated CVEs making it rotten in Keppel. There is no clean version to upgrade to.

This PR enables osprofiler to use Redis as its tracing backend instead, which requires no sidecar injection and uses images already running in qa-de-1 (same `alpine-valkey` family as cinder's rate-limit redis).

## Test plan

- [x] `helm template` renders without errors, no `jaeger-agent` container in output
- [x] `connection_string = redis://keystone-osprofiler-redis:6379` in rendered `secrets.conf`
- [x] All redis subchart images verified present in Keppel (`alpine-valkey:9.1-20260611084111`, `alpine-kubectl:latest-20260616102342`, `redis-exporter:1.86.0-20260709012056`)
- [ ] Secrets PR: cc/secrets#21054