### PR TITLE
increase limitas v2 scrape interval to 300s

### DIFF
--- a/openstack/limes/templates/podmonitor-data-metrics-v2.yaml
+++ b/openstack/limes/templates/podmonitor-data-metrics-v2.yaml
@@ -30,7 +30,7 @@ spec:
     - scheme: http
       port: metrics
       path: /metrics
-      interval: 60s
+      interval: 300s
       scrapeTimeout: 25s
       relabelings:
         # As explained in the top-of-file comment, we want to drop any and all


### PR DESCRIPTION
The metrics contain a few very expensive DB queries (f.e. towards project_az_resources which has 3mil. rows in a expensive region), this increases the scrape interval to reduce the DB load.