### PR TITLE
dell-r770: increase bmc/biosversion, fix pxeboot

### DIFF
--- a/system/metal-settings/Chart.yaml
+++ b/system/metal-settings/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.30
+version: 0.2.31
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/metal-settings/bios_settings/dell-r770.yaml
+++ b/system/metal-settings/bios_settings/dell-r770.yaml
@@ -3,12 +3,12 @@ settingsFlow:
   priority: 15
   settings:
     PxeDev1EnDis: Enabled
-- name: PXEBootWithNIC.Slot.10-1-1
+- name: PXEBootWithNIC.Slot.4-1-1
   priority: 20
   settings:
     MemOpMode: OptimizerMode
     PwrButton: Disabled
-    PxeDev1Interface: NIC.Slot.10-1-1
+    PxeDev1Interface: NIC.Slot.4-1-1
     PxeDev1Protocol: IPv4
     PxeDev1VlanEnDis: Disabled
     PxeDev2EnDis: Disabled

--- a/system/metal-settings/values.yaml
+++ b/system/metal-settings/values.yaml
@@ -274,13 +274,13 @@ machines:
         model: poweredge-r770
         clusterTypes: *defaultClusterTypes
         bios:
-          version: "1.4.4"
+          version: "1.8.5"
           settingsFileName: dell-r770.yaml
-          imageURI: "https://repo.eu-de-1.cloud.sap/hw-firmware/dell/poweredge-r770/BIOS_7J20R_WN64_1.4.4.EXE"
+          imageURI: "https://repo.eu-de-1.cloud.sap/hw-firmware/dell/poweredge-r770/BIOS_VTF4T_WN64_1.8.5.EXE"
         bmc:
-          version: "1.20.60.50"
+          version: "1.30.30.50"
           settingsFileName: dell-r770.yaml
-          imageURI: "https://repo.eu-de-1.cloud.sap/hw-firmware/dell/poweredge-r770/iDRAC-with-Lifecycle-Controller_Firmware_63M5X_WN64_1.20.60.50_A00.EXE"
+          imageURI: "https://repo.eu-de-1.cloud.sap/hw-firmware/dell/poweredge-r770/iDRAC-with-Lifecycle-Controller_Firmware_11F63_WN64_1.30.30.50_A00.EXE"
 
       poweredge-r7715:
         model: poweredge-r7715


### PR DESCRIPTION
- there were reports of overheating ram in the bmc and according to dell that is a bios issue which is resolved in the latest version
- update bmc along with bios
- fix pxedev1 to point to the L1 interface