### PR TITLE
Adding Lenovo SR950v3 with more Cores and RAM

### DIFF
--- a/openstack/ironic/templates/seed.yaml
+++ b/openstack/ironic/templates/seed.yaml
@@ -629,6 +629,30 @@ spec:
       "resources:CUSTOM_BG_S2_C48_M2048_V1": "1"
       {{- tuple . "baremetal" | include "ironic.helpers.extra_specs" | indent 6 }}
 
+  # Lenovo ThinkSystem SR950 V3 as Hypervisor with 8s12T
+  - name: "hv_s8_c48_m12288_v0"
+    id: "2048"
+    vcpus: 384
+    ram: 12582912
+    disk: 447
+    is_public: false
+    extra_specs:
+      "catalog:description": Hypervisor 8 sockets, 48 cores, 12TB RAM, Sapphire Rapids
+      "resources:CUSTOM_HV_S8_C48_M12288_V0": "1"
+      {{- tuple . "baremetal" | include "ironic.helpers.extra_specs" | indent 6 }}
+
+  # Lenovo ThinkSystem SR950 V3 as Baremetal with 8s12T
+  - name: "bm_s8_c48_m12288_v0"
+    id: "22048"
+    vcpus: 384
+    ram: 12582912
+    disk: 447
+    is_public: false
+    extra_specs:
+      "catalog:description": Baremetal 8 sockets, 48 cores, 12TB RAM, Sapphire Rapids
+      "resources:CUSTOM_BM_S8_C48_M12288_V0": "1"
+      {{- tuple . "baremetal" | include "ironic.helpers.extra_specs" | indent 6 }}
+
   # Default are special
   # cc3test does not get seeds
   # ccadmin gets role assignments for the master project and some additional project assignments


### PR DESCRIPTION
https://netbox.global.cloud.sap/dcim/devices/54726/inventory/
will come only as BM for now, adding hv too though to reserve corresponding 2048