### PR TITLE
[neutron] add hashes for all secrets to annotations

### DIFF
--- a/openstack/neutron/templates/daemonset-metadata-agent.yaml
+++ b/openstack/neutron/templates/daemonset-metadata-agent.yaml
@@ -22,6 +22,8 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: neutron-metadata-agent
         configmap-etc-hash: {{ include (print .Template.BasePath "/configmap-etc.yaml") $ | sha256sum }}
+        secret-neutron-common-hash: {{ include (print $.Template.BasePath "/secret-neutron-common.yaml") $ | sha256sum }}
+        secret-neutron-metadata-hash: {{ include (print $.Template.BasePath "/secret-neutron-metadata.yaml") $ | sha256sum }}
         {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
       labels:
         alert-tier: os

--- a/openstack/neutron/templates/deployment-aci-agent.yaml
+++ b/openstack/neutron/templates/deployment-aci-agent.yaml
@@ -29,9 +29,11 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: neutron-aci-agent
         pod.beta.kubernetes.io/hostname:  aci-agent-pet
-        configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") . | sha256sum }}
-        configmap-etc-aci-hash: {{ include (print $.Template.BasePath "/configmap-etc-aci.yaml") . | sha256sum }}
-        configmap-etc-vendor-hash: {{ include (print $.Template.BasePath "/configmap-etc-vendor.yaml") . | sha256sum }}
+        configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") $ | sha256sum }}
+        configmap-etc-aci-hash: {{ include (print $.Template.BasePath "/configmap-etc-aci.yaml") $ | sha256sum }}
+        configmap-etc-vendor-hash: {{ include (print $.Template.BasePath "/configmap-etc-vendor.yaml") $ | sha256sum }}
+        secret-neutron-common-hash: {{ include (print $.Template.BasePath "/secret-neutron-common.yaml") $ | sha256sum }}
+        secret-aci-agent-hash: {{ include (print $.Template.BasePath "/secret-aci-agent.yaml") $ | sha256sum }}
         {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
       hostname:  aci-agent-pet

--- a/openstack/neutron/templates/deployment-cc-fabric-agent.yaml
+++ b/openstack/neutron/templates/deployment-cc-fabric-agent.yaml
@@ -33,10 +33,11 @@ spec:
         kubectl.kubernetes.io/default-container: neutron-cc-fabric-{{ $platform }}-agent
         pod.beta.kubernetes.io/hostname:  cc-fabric-{{ $platform }}-agent
         configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") $ | sha256sum }}
-        configmap-etc-cc-fabric: {{ include (print $.Template.BasePath "/configmap-etc-cc-fabric.yaml") $ | sha256sum }}
-        secret-cc-fabric: {{ include (print $.Template.BasePath "/secret-cc-fabric.yaml") $ | sha256sum }}
+        configmap-etc-cc-fabric-hash: {{ include (print $.Template.BasePath "/configmap-etc-cc-fabric.yaml") $ | sha256sum }}
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required "$.Values.metrics.prometheus missing" $.Values.metrics.prometheus }}
+        secret-neutron-common-hash: {{ include (print $.Template.BasePath "/secret-neutron-common.yaml") $ | sha256sum }}
+        secret-cc-fabric-hash: {{ include (print $.Template.BasePath "/secret-cc-fabric.yaml") $ | sha256sum }}
         {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 8 }}
     spec:
       hostname: cc-fabric-{{ $platform }}-agent

--- a/openstack/neutron/templates/deployment-nsxv3-logstash.yaml
+++ b/openstack/neutron/templates/deployment-nsxv3-logstash.yaml
@@ -25,7 +25,8 @@ spec:
         name: neutron-nsxv3-logstash
       annotations:
         kubectl.kubernetes.io/default-container: neutron-nsxv3-logstash
-        configmap-logger-hash: {{ include (print .Template.BasePath "/configmap-nsxv3-logstash.yaml") . | sha256sum }}
+        configmap-logger-hash: {{ include (print .Template.BasePath "/configmap-nsxv3-logstash.yaml") $ | sha256sum }}
+        secret-nsxv3-logstash-hash: {{ include (print $.Template.BasePath "/secret-nsxv3-logstash.yaml") $ | sha256sum }}
         {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
       {{- if .Values.logger.persistence.enabled }}

--- a/openstack/neutron/templates/deployment-rpc-server.yaml
+++ b/openstack/neutron/templates/deployment-rpc-server.yaml
@@ -31,18 +31,22 @@ spec:
 {{ tuple . "neutron" "rpc" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
       annotations:
         kubectl.kubernetes.io/default-container: neutron-rpc-server
-        configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") . | sha256sum }}
-        configmap-etc-aci-hash: {{ include (print $.Template.BasePath "/configmap-etc-aci.yaml") . | sha256sum }}
-        configmap-etc-vendor-hash: {{ include (print $.Template.BasePath "/configmap-etc-vendor.yaml") . | sha256sum }}
-        configmap-bin-hash: {{ include (print $.Template.BasePath "/configmap-bin.yaml") . | sha256sum }}
+        configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") $ | sha256sum }}
+        configmap-etc-aci-hash: {{ include (print $.Template.BasePath "/configmap-etc-aci.yaml") $ | sha256sum }}
+        configmap-etc-vendor-hash: {{ include (print $.Template.BasePath "/configmap-etc-vendor.yaml") $ | sha256sum }}
+        configmap-bin-hash: {{ include (print $.Template.BasePath "/configmap-bin.yaml") $ | sha256sum }}
         {{- if .Values.cc_fabric.enabled }}
-        configmap-etc-cc-fabric: {{ include (print $.Template.BasePath "/configmap-etc-cc-fabric.yaml") . | sha256sum }}
-        secret-cc-fabric: {{ include (print $.Template.BasePath "/secret-cc-fabric.yaml") $ | sha256sum }}
+        configmap-etc-cc-fabric-hash: {{ include (print $.Template.BasePath "/configmap-etc-cc-fabric.yaml") $ | sha256sum }}
+        secret-cc-fabric-hash: {{ include (print $.Template.BasePath "/secret-cc-fabric.yaml") $ | sha256sum }}
         {{- end }}
         {{- if .Values.proxysql.mode }}
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required "$.Values.metrics.prometheus missing" $.Values.metrics.prometheus }}
         {{- end }}
+        secret-neutron-common-hash: {{ include (print $.Template.BasePath "/secret-neutron-common.yaml") $ | sha256sum }}
+        secret-neutron-server-hash: {{ include (print $.Template.BasePath "/secret-neutron-server.yaml") $ | sha256sum }}
+        secret-neutron-interconnection-hash: {{ include (print $.Template.BasePath "/secret-neutron-interconnection.yaml") $ | sha256sum }}
+        secret-neutron-arista-hash: {{ include (print $.Template.BasePath "/secret-neutron-arista.yaml") $ | sha256sum }}
         {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
         config.linkerd.io/skip-outbound-ports: "6441,6442" # OVSDB ports
     spec:

--- a/openstack/neutron/templates/deployment-server.yaml
+++ b/openstack/neutron/templates/deployment-server.yaml
@@ -30,19 +30,26 @@ spec:
 {{ tuple . "neutron" "api" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
       annotations:
         kubectl.kubernetes.io/default-container: neutron-server
-        configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") . | sha256sum }}
-        configmap-etc-aci-hash: {{ include (print $.Template.BasePath "/configmap-etc-aci.yaml") . | sha256sum }}
-        configmap-etc-vendor-hash: {{ include (print $.Template.BasePath "/configmap-etc-vendor.yaml") . | sha256sum }}
+        configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") $ | sha256sum }}
+        configmap-etc-aci-hash: {{ include (print $.Template.BasePath "/configmap-etc-aci.yaml") $ | sha256sum }}
+        configmap-etc-vendor-hash: {{ include (print $.Template.BasePath "/configmap-etc-vendor.yaml") $ | sha256sum }}
         {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
 {{- if .Values.api.uwsgi }}
-        configmap-etc-api-hash: {{ include (print $.Template.BasePath "/configmap-etc-api.yaml") . | sha256sum }}
+        configmap-etc-api-hash: {{ include (print $.Template.BasePath "/configmap-etc-api.yaml") $ | sha256sum }}
 {{- if .Values.cc_fabric.enabled }}
-        configmap-etc-cc-fabric: {{ include (print $.Template.BasePath "/configmap-etc-cc-fabric.yaml") . | sha256sum }}
-        secret-cc-fabric: {{ include (print $.Template.BasePath "/secret-cc-fabric.yaml") $ | sha256sum }}
+        configmap-etc-cc-fabric-hash: {{ include (print $.Template.BasePath "/configmap-etc-cc-fabric.yaml") $ | sha256sum }}
+        secret-cc-fabric-hash: {{ include (print $.Template.BasePath "/secret-cc-fabric.yaml") $ | sha256sum }}
+{{- end }}
+{{- if .Values.rate_limit.enabled }}
+        secret-neutron-ratelimit-hash: {{ include (print $.Template.BasePath "/secret-neutron-ratelimit.yaml") $ | sha256sum }}
 {{- end }}
 {{- else }}
-        configmap-bin-hash: {{ include (print $.Template.BasePath "/configmap-bin.yaml") . | sha256sum }}
+        configmap-bin-hash: {{ include (print $.Template.BasePath "/configmap-bin.yaml") $ | sha256sum }}
 {{- end }}
+        secret-neutron-common-hash: {{ include (print $.Template.BasePath "/secret-neutron-common.yaml") $ | sha256sum }}
+        secret-neutron-server-hash: {{ include (print $.Template.BasePath "/secret-neutron-server.yaml") $ | sha256sum }}
+        secret-neutron-interconnection-hash: {{ include (print $.Template.BasePath "/secret-neutron-interconnection.yaml") $ | sha256sum }}
+        secret-neutron-arista-hash: {{ include (print $.Template.BasePath "/secret-neutron-arista.yaml") $ | sha256sum }}
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required "$.Values.metrics.prometheus missing" $.Values.metrics.prometheus }}
         config.linkerd.io/skip-outbound-ports: "6441,6442" # OVSDB ports

--- a/openstack/neutron/templates/sftp-deployment.yaml
+++ b/openstack/neutron/templates/sftp-deployment.yaml
@@ -21,7 +21,7 @@ spec:
         component: neutron-sftp-backup
       annotations:
         kubectl.kubernetes.io/default-container: sftp
-        configmap-etc-hash: {{ include (print $.Template.BasePath "/sftp-secrets.yaml") . | sha256sum }}
+        secret-sftp-secrets-hash: {{ include (print $.Template.BasePath "/sftp-secrets.yaml") $ | sha256sum }}
         {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
       containers:

--- a/openstack/neutron/templates/statefulset-network-agent-apod.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent-apod.yaml
@@ -36,6 +36,8 @@ spec:
         k8s.v1.cni.cncf.io/networks: '[{ "name": "cbr1-bridge", "interface":"{{$.Values.cp_network_interface}}" }]'
         configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") $ | sha256sum }}
         configmap-etc-apod-hash: {{ include (print $.Template.BasePath "/configmap-etc-apod.yaml") $ | sha256sum }}
+        secret-neutron-common-hash: {{ include (print $.Template.BasePath "/secret-neutron-common.yaml") $ | sha256sum }}
+        secret-neutron-metadata-hash: {{ include (print $.Template.BasePath "/secret-neutron-metadata.yaml") $ | sha256sum }}
         {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 8 }}
         config.linkerd.io/skip-inbound-ports: "22,53,80,443"
         config.linkerd.io/skip-outbound-ports: "22,53,80,443"

--- a/openstack/neutron/templates/statefulset-network-agent.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent.yaml
@@ -31,6 +31,7 @@ spec:
         kubectl.kubernetes.io/default-container: neutron-dhcp-agent
         k8s.v1.cni.cncf.io/networks: '[{ "name": "cbr1-bridge", "interface":"{{$.Values.cp_network_interface}}" }]'
         configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") $ | sha256sum }}
+        secret-neutron-common-hash: {{ include (print $.Template.BasePath "/secret-neutron-common.yaml") $ | sha256sum }}
         {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 8 }}
         config.linkerd.io/skip-inbound-ports: "22,53,80,443"
         config.linkerd.io/skip-outbound-ports: "22,53,80,443"

--- a/openstack/neutron/templates/statefulset-swift-injector.yaml
+++ b/openstack/neutron/templates/statefulset-swift-injector.yaml
@@ -26,6 +26,8 @@ spec:
         k8s.v1.cni.cncf.io/networks: '[{ "name": "cbr1-bridge", "interface":"{{$.Values.cp_network_interface}}" }]'
         configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") $ | sha256sum }}
         configmap-etc-apod-hash: {{ include (print $.Template.BasePath "/configmap-etc-apod.yaml") $ | sha256sum }}
+        secret-neutron-common-hash: {{ include (print $.Template.BasePath "/secret-neutron-common.yaml") $ | sha256sum }}
+        secret-neutron-swift-injector-hash: {{ include (print $.Template.BasePath "/secret-neutron-swift-injector.yaml") $ | sha256sum }}
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required "$.Values.metrics.prometheus missing" $.Values.metrics.prometheus }}
         {{- include "utils.linkerd.pod_and_service_annotation" $ | indent 8 }}

--- a/openstack/neutron/templates/vct-nsxv3-agent-deployment.yaml
+++ b/openstack/neutron/templates/vct-nsxv3-agent-deployment.yaml
@@ -49,7 +49,9 @@ template: |
           {{- end }}
         annotations:
           kubectl.kubernetes.io/default-container: neutron-nsxv3-agent
-          configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") . | sha256sum }}
+          configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") $ | sha256sum }}
+          secret-neutron-common-hash: {{ include (print $.Template.BasePath "/secret-neutron-common.yaml") $ | sha256sum }}
+          secret-vct-nsxv3-agent-hash: {{ include (print $.Template.BasePath "/vct-nsxv3-agent-secret.yaml") $ | sha256sum }}
           prometheus.io/scrape: "true"
           prometheus.io/targets: {{ required ".Values.metrics.prometheus missing" .Values.metrics.prometheus | quote }}
           {{- include "utils.linkerd.pod_and_service_annotation" . | indent 10 }}


### PR DESCRIPTION
When secrets are changed we want the deployment to restart all affected pods, thus we need to include the hashes of all used secrets.

This also fixes some minor issues like inconsistent naming and [using local context instead of global context](https://discourse.gohugo.io/t/the-dot-and-the-dollar-in-context/48604) in including of the templates.

