### PR TITLE
[neutron] add hashes for all secrets to annotations to asr_config_agents

### DIFF
--- a/openstack/neutron/templates/asr_config_agents/_deployment-asr1k.yaml.tpl
+++ b/openstack/neutron/templates/asr_config_agents/_deployment-asr1k.yaml.tpl
@@ -35,7 +35,9 @@ spec:
         pod.beta.kubernetes.io/hostname:  asr1k-{{ $config_agent.name }}
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.metrics.prometheus missing" $context.Values.metrics.prometheus | quote }}
-        configmap-asr1k-{{ $config_agent.name }}: {{ tuple $context $config_agent |include "asr1k_configmap" | sha256sum  }}
+        configmap-asr1k-{{ $config_agent.name }}-hash: {{ tuple $context $config_agent |include "asr1k_configmap" | sha256sum  }}
+        secret-asr1k-{{ $config_agent.name }}-hash: {{ tuple $context $config_agent |include "asr1k_secret" | sha256sum  }}
+        secret-neutron-common-hash: {{ include (print $context.Template.BasePath "/secret-neutron-common.yaml") $context | sha256sum }}
         {{- include "utils.linkerd.pod_and_service_annotation" $context | indent 8 }}
     spec:
       hostname:  asr1k-{{ $config_agent.name }}


### PR DESCRIPTION
In  5df3cf67963417b70f8e34ffd7c20c378f5721aa we added hashes for all secrets, but forgot adding them to the templates in asr_config_agents.