### PR TITLE
[ap-sa-2] Remove region references

### DIFF
--- a/global/cc-gardener/Chart.yaml
+++ b/global/cc-gardener/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cc-gardener
 description: Converged Cloud Gardener setup based on gardener-operator
 type: application
-version: 0.38.6
+version: 0.38.7
 home: https://github.com/gardener/gardener
 dependencies:
 - name: owner-info

--- a/global/cc-gardener/managedresources/cloudprofile-openstack.yaml
+++ b/global/cc-gardener/managedresources/cloudprofile-openstack.yaml
@@ -37,8 +37,6 @@ spec:
       - name: FloatingIP*
         region: ap-sa-1
       - name: FloatingIP*
-        region: ap-sa-2
-      - name: FloatingIP*
         region: eu-de-1
       - name: FloatingIP*
         region: eu-de-2

--- a/global/thanos-global/values.yaml
+++ b/global/thanos-global/values.yaml
@@ -81,7 +81,6 @@ thanos:
     - ap-jp-1
     - ap-jp-2
     - ap-sa-1
-    # - ap-sa-2
     - eu-de-1
     - eu-de-2
     - eu-nl-1

--- a/openstack/volume-claims/templates/db-octavia-pvclaim.yaml
+++ b/openstack/volume-claims/templates/db-octavia-pvclaim.yaml
@@ -11,5 +11,4 @@ spec:
   - {{ include "volume-claims.accessMode" . }}
   resources:
     requests:
-      {{- $region := .Values.global.region | required ".Values.global.region missing" }}
-      storage: {{ if $region | regexMatch "^(?:ap-sa-2)$" -}} 50Gi {{- else -}} 10Gi {{- end }}
+      storage: 10Gi

--- a/system/greenhouse-ccloud/values.yaml
+++ b/system/greenhouse-ccloud/values.yaml
@@ -62,11 +62,11 @@ alerts:
     - name: "prod"
       displayName: "Prod"
       matchers:
-        region: "^(ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|ap-sa-2|ap-sg-1|eu-de-1|eu-de-2|eu-de-3|eu-nl-1|la-br-1|na-ca-1|na-us-1|na-us-2|na-us-3)$"
+        region: "^(ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|ap-sg-1|eu-de-1|eu-de-2|eu-de-3|eu-nl-1|la-br-1|na-ca-1|na-us-1|na-us-2|na-us-3)$"
     - name: "prod-qa"
       displayName: "Prod + QA"
       matchers:
-        region: "^(ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|ap-sa-2|ap-sg-1|eu-de-1|eu-de-2|eu-de-3|eu-nl-1|la-br-1|na-ca-1|na-us-1|na-us-2|na-us-3|qa-de-1)$"
+        region: "^(ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|ap-sg-1|eu-de-1|eu-de-2|eu-de-3|eu-nl-1|la-br-1|na-ca-1|na-us-1|na-us-2|na-us-3|qa-de-1)$"
     - name: "labs"
       displayName: "Labs"
       matchers:
@@ -74,7 +74,7 @@ alerts:
     - name: "other"
       displayName: "Other"
       matchers:
-        region: "^(?!(ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|ap-sa-2|ap-sg-1|eu-de-1|eu-de-2|eu-de-3|eu-nl-1|la-br-1|na-ca-1|na-us-1|na-us-2|na-us-3|qa-de-1|qa-de-(?!1$)\\d+)$).*"
+        region: "^(?!(ap-ae-1|ap-au-1|ap-cn-1|ap-jp-1|ap-jp-2|ap-sa-1|ap-sg-1|eu-de-1|eu-de-2|eu-de-3|eu-nl-1|la-br-1|na-ca-1|na-us-1|na-us-2|na-us-3|qa-de-1|qa-de-(?!1$)\\d+)$).*"
     - name: "all"
       displayName: "All"
       matchers:


### PR DESCRIPTION
## Summary

Region ap-sa-2 has been decommissioned. This PR removes all remaining ap-sa-2 references from helm-charts.

- `system/greenhouse-ccloud/values.yaml` — removed ap-sa-2 from 3 region regex filters (prod, prod-qa, other)
- `global/thanos-global/values.yaml` — removed commented-out `# - ap-sa-2` line
- `global/cc-gardener/managedresources/cloudprofile-openstack.yaml` — removed ap-sa-2 FloatingIP entry
- `openstack/volume-claims/templates/db-octavia-pvclaim.yaml` — removed ap-sa-2 specific 50Gi storage override (now always 10Gi)

Part of ap-sa-2 decommissioning tracked in https://github.wdf.sap.corp/cc/unified-kubernetes/issues/1329