### PR TITLE
fix(opensearch-logs): set logs datastream rollover to 40gb per shard 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -296,7 +296,7 @@
 /system/nodecidr-controller                            @sapcc/PlusOne-CE-API-Services-ControlPlane
 /system/ntp-timeserver                                 @dhoeller  # old
 /system/opensearch-hermes                              @Kuckkuck @notque @LeoZhangZXZ @timojohlo @joluc @olandr
-/system/opensearch-logs                                @Kuckkuck @timojohlo @notque @joluc @olandr
+/system/opensearch-logs                                @Kuckkuck @timojohlo @notque @joluc @olandr @ztomaszewska
 /system/owner-label-injector                           @sapcc/containers
 /system/os-user-rotate                                 @sapcc/PlusOne-CE-API-Services-ControlPlane
 /system/plutono                                        @viennaa @richardtief @Kuckkuck @IvoGoman @timojohlo @ibakshay @trouaux @ashifnihalb

--- a/system/opensearch-logs/Chart.yaml
+++ b/system/opensearch-logs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for the Opensearch stack
 name: opensearch-logs
-version: 0.1.25
+version: 0.1.26
 home: https://github.com/sapcc/helm-charts/tree/master/system/opensearch-logs
 dependencies:
   - name: opensearch

--- a/system/opensearch-logs/values.yaml
+++ b/system/opensearch-logs/values.yaml
@@ -29,10 +29,17 @@ global:
     logs:
       min_index_age: "7d"
       max_index_age: "14d"
-      min_size: "25gb"
+      min_size: "40gb"
       min_doc_count: 100000000
       number_of_shards: 4
       refresh_interval: "60s"
+      snapshots:
+        enabled: false
+        repository: "snapshots"
+        retention: "31d"
+      searchable_snapshots:
+        enabled: true
+        retention: "31d"
     storage:
       min_index_age: "7d"
       max_index_age: "14d"
@@ -79,17 +86,6 @@ global:
         enabled: false
         repository: "cephlogssnapshots"
         retention: "365d"
-      searchable_snapshots:
-        enabled: true
-        retention: "31d"
-    logs:
-      min_index_age: "7d"
-      min_size: "80gb"
-      min_doc_count: 100000000
-      snapshots:
-        enabled: false
-        repository: "snapshots"
-        retention: "31d"
       searchable_snapshots:
         enabled: true
         retention: "31d"


### PR DESCRIPTION
Fix duplicate `logs:` block. Merged and set `min_size: 40gb` which is wired to the ISM `min_primary_shard_size` condition here, so it's per primary shard, per datastream and not total sum of primaries. 40gb sits in the recommended 30–50gb write-heavy range.