### PR TITLE
ns-exporter: Add alert for daemonset degradation

### DIFF
--- a/prometheus-exporters/ns-exporter/alerts/kubernetes/daemonset.alerts
+++ b/prometheus-exporters/ns-exporter/alerts/kubernetes/daemonset.alerts
@@ -1,0 +1,43 @@
+groups:
+- name: ns-exporter-daemonset.alerts
+  rules:
+  - alert: NetworkNamespaceProbeDaemonSetDegraded
+    expr: |
+      (
+        kube_daemonset_status_number_ready{daemonset="ns-exporter"}
+        !=
+        kube_daemonset_status_desired_number_scheduled{daemonset="ns-exporter"}
+      )
+      unless on () day_of_week() > 0 and on () day_of_week() < 6
+    for: 30m
+    labels:
+      context: availability
+      service: neutron
+      severity: warning
+      support_group: network-api
+      tier: os
+      playbook: 'docs/support/playbook/neutron/ns-exporter'
+      meta: 'ns-exporter DaemonSet has fewer ready pods than desired'
+    annotations:
+      description: 'The ns-exporter DaemonSet does not have all pods ready. Check pod status and node conditions.'
+      summary: The ns-exporter DaemonSet is degraded
+  - alert: NetworkNamespaceProbeDaemonSetDegradedCritical
+    expr: |
+      (
+        kube_daemonset_status_number_ready{daemonset="ns-exporter"}
+        !=
+        kube_daemonset_status_desired_number_scheduled{daemonset="ns-exporter"}
+      )
+      and on () day_of_week() > 0 and on () day_of_week() < 6
+    for: 30m
+    labels:
+      context: availability
+      service: neutron
+      severity: critical
+      support_group: network-api
+      tier: os
+      playbook: 'docs/support/playbook/neutron/ns-exporter'
+      meta: 'ns-exporter DaemonSet has fewer ready pods than desired'
+    annotations:
+      description: 'The ns-exporter DaemonSet does not have all pods ready. Check pod status and node conditions.'
+      summary: The ns-exporter DaemonSet is degraded

--- a/prometheus-exporters/ns-exporter/alerts/openstack/probe.alerts
+++ b/prometheus-exporters/ns-exporter/alerts/openstack/probe.alerts
@@ -80,14 +80,29 @@ Please run ```hammer -r {{ $externalLabels.region }} net check {{ $labels.networ
 Please run ```hammer -r {{ $externalLabels.region }} net check {{ $labels.network_id }}``` and post it on the alert Slack thread.'
       summary: Network probes failed for `shoot--` networks.
   - alert: NetworkNamespaceProbeMetricsMissing
-    expr: absent(ns_exporter_probe_success_total)
-    for: 10m
+    expr: absent(ns_exporter_probe_success_total) unless on () day_of_week() > 0 and on () day_of_week() < 6
+    for: 30m
     labels:
       context: availability
       service: neutron
       severity: warning
       support_group: network-api
       tier: os
+      playbook: 'docs/support/playbook/neutron/ns-exporter'
+      meta: 'Metrics for the namespace prober are missing'
+    annotations:
+      description: 'The metrics from the namespace prober are missing. This suggests there is a problem with the exporter deployment. Check the ns-exporter namespace for running pods.'
+      summary: Metrics for namespace prober are missing
+  - alert: NetworkNamespaceProbeMetricsMissingCritical
+    expr: absent(ns_exporter_probe_success_total) and on () day_of_week() > 0 and on () day_of_week() < 6
+    for: 30m
+    labels:
+      context: availability
+      service: neutron
+      severity: critical
+      support_group: network-api
+      tier: os
+      playbook: 'docs/support/playbook/neutron/ns-exporter'
       meta: 'Metrics for the namespace prober are missing'
     annotations:
       description: 'The metrics from the namespace prober are missing. This suggests there is a problem with the exporter deployment. Check the ns-exporter namespace for running pods.'

--- a/prometheus-exporters/ns-exporter/templates/prometheus-alerts.yaml
+++ b/prometheus-exporters/ns-exporter/templates/prometheus-alerts.yaml
@@ -1,6 +1,6 @@
-{{- $values := .Values }}
-{{- if $values.alerts.enabled }}
-{{- range $path, $bytes := .Files.Glob "alerts/*.alerts" }}
+{{- if .Values.alerts.enabled }}
+{{- range $target, $prometheusName := .Values.alerts.prometheus }}
+{{- range $path, $bytes := $.Files.Glob (printf "alerts/%s/*.alerts" $target) }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
@@ -9,10 +9,11 @@ metadata:
   name: {{ printf "ns-exporter-%s" $path | replace "/" "-" }}
   labels:
     app: ns-exporter
-    prometheus: {{ required ".Values.alerts.prometheus missing" $values.alerts.prometheus }}
+    prometheus: {{ $prometheusName | required (printf ".Values.alerts.prometheus.%s missing" $target) }}
 
 spec:
 {{ printf "%s" $bytes | indent 2 }}
 
+{{- end }}
 {{- end }}
 {{- end }}

--- a/prometheus-exporters/ns-exporter/values.yaml
+++ b/prometheus-exporters/ns-exporter/values.yaml
@@ -25,7 +25,9 @@ metrics:
 alerts:
   enabled: true
   # Name of the Prometheus to which the alerts should be assigned to.
-  prometheus: openstack
+  prometheus:
+    openstack: openstack
+    kubernetes: kubernetes
 
 nodeSelector: {}
 


### PR DESCRIPTION
Add two alerts to detect that the daemonset has zero ready pods e.g, due to a broken node selector and another alert for mismatch between the number of ready versus desired pods.