### PR TITLE
[rabbitmq] skip linkerd for TLS listener

### DIFF
--- a/common/rabbitmq/CHANGELOG.md
+++ b/common/rabbitmq/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file is used to list changes made in each version of the common chart rabbitmq.
 
+## 0.25.7 - 2026/07/17
+
+- Add linkerd skip-inbound-ports annotation for TLS listener port in RabbitMQ deployment, if enabled
+- Chart version bumped
+
 ## 0.25.6 - 2026/07/13
 
 - Fix volume-permission container failing on fresh PVCs. Only was working if `.erlang.cookie` was existing. 

--- a/common/rabbitmq/Chart.yaml
+++ b/common/rabbitmq/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: rabbitmq
-version: 0.25.6
+version: 0.25.7
 appVersion: 4.3.2
 description: A Helm chart for RabbitMQ
 sources:

--- a/common/rabbitmq/templates/deployment.yaml
+++ b/common/rabbitmq/templates/deployment.yaml
@@ -31,6 +31,9 @@ spec:
 {{- if and (and $.Values.global.linkerd_enabled $.Values.global.linkerd_requested) $.Values.linkerd.enabled }}
         linkerd.io/inject: enabled
         config.linkerd.io/opaque-ports: "{{ default 5672 .Values.ports.public }}"
+        {{- if $.Values.enableSsl }}
+        config.linkerd.io/skip-inbound-ports: "{{ .Values.ports.amqps }}"
+        {{- end }}
 {{- end }}
 {{- if .Values.customConfig }}
         checksum/custom.conf: {{ include (print .Template.BasePath "/etc/_rabbitmq-custom-config.tpl") . | sha256sum }}


### PR DESCRIPTION
    Add linkerd skip-inbound-ports annotation to skip the TLS listener port.

    We do not need to push TLS traffic through linkerd. Also linkerd hides
    the real client IP from the rabbitmq server, which is essential, e.g.
    when debugging which clients are still using old credentials.