### PR TITLE
feat(cc-runtime-cluster): add per-cluster machineTemplate metadata override

### DIFF
--- a/system/cc-runtime-cluster/Chart.yaml
+++ b/system/cc-runtime-cluster/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-runtime-cluster
 description: Converged Cloud Cluster API Runtime Cluster
 type: application
-version: 0.8.2
+version: 0.8.3
 appVersion: "0.1.0"

--- a/system/cc-runtime-cluster/ci/test-values.yaml
+++ b/system/cc-runtime-cluster/ci/test-values.yaml
@@ -63,6 +63,9 @@ clusters:
       passwordhash: bar
   - name: rt-test-8
     namespace: capi-runtime-8
+    machineTemplateMetadata:
+      interfaces: "eno*"
+      vlan: "920"
 
 user:
   name: admin

--- a/system/cc-runtime-cluster/templates/ironcoremetalmachinetemplate-worker.yaml
+++ b/system/cc-runtime-cluster/templates/ironcoremetalmachinetemplate-worker.yaml
@@ -16,7 +16,7 @@ spec:
           kubernetes.metal.cloud.sap/role: runtime-worker
       image: {{ $.Values.machineTemplate.image }}
       metadata:
-{{ toYaml $.Values.machineTemplate.metadata | indent 8 }}
+{{ toYaml (default $.Values.machineTemplate.metadata $cluster.machineTemplateMetadata) | indent 8 }}
       ipamConfig:
       - metadataKey: bond
         ipamRef:

--- a/system/cc-runtime-cluster/templates/ironcoremetalmachinetemplate.yaml
+++ b/system/cc-runtime-cluster/templates/ironcoremetalmachinetemplate.yaml
@@ -16,7 +16,7 @@ spec:
           kubernetes.metal.cloud.sap/role: runtime-controlplane
       image: {{ $.Values.machineTemplate.image }}
       metadata:
-{{ toYaml $.Values.machineTemplate.metadata | indent 8 }}
+{{ toYaml (default $.Values.machineTemplate.metadata $cluster.machineTemplateMetadata) | indent 8 }}
       ipamConfig:
       - metadataKey: bond
         ipamRef:

--- a/system/cc-runtime-cluster/templates/metallb-manifests.yaml
+++ b/system/cc-runtime-cluster/templates/metallb-manifests.yaml
@@ -23,7 +23,7 @@ data:
 
        Set per cluster in values with the subnet from the Transit role:
          clusters:
-           - name: rt-eu-de-1
+           - name: test-1
              metallb:
                subnet: "10.20.30.0/26"
 */ -}}


### PR DESCRIPTION
Allow overriding `machineTemplate.metadata` (interfaces, vlan) per cluster entry via `machineTemplateMetadata` field in the clusters list.

Falls back to the global `machineTemplate.metadata` when not specified.

Usage in values:
```yaml
clusters:
  - name: rt-test-1
    namespace: capi-runtime
    machineTemplateMetadata:
      interfaces: "eno*"
      vlan: "920"
```