### PR TITLE
[dnm] add request-timing to keystone apache and nginx ingress logs

### DIFF
--- a/openstack/keystone/templates/etc/_wsgi-keystone.conf.tpl
+++ b/openstack/keystone/templates/etc/_wsgi-keystone.conf.tpl
@@ -17,15 +17,15 @@ Listen 0.0.0.0:5000
 {{- if .Values.use_json }}
 ErrorLog /dev/stdout
 ErrorLogFormat "%M"
-LogFormat "{\"timestamp\":\"%{%Y-%m-%dT%H:%M:%S}t.%{msec_frac}t\",\"pid\":%{pid}P,\"levelname\":\"INFO\",\"name\":\"apache.access\",\"request_id\":\"%{X-Openstack-Request-ID}i\",\"client_ip\":\"%a\",\"method\":\"%m\",\"uri\":\"%U%q\",\"protocol\":\"%H\",\"status\":%>s,\"bytes_sent\":%B,\"duration_ms\":%{ms}T,\"referer\":\"%{Referer}i\",\"user_agent\":\"%{User-Agent}i\"}" json_combined
-LogFormat "{\"timestamp\":\"%{%Y-%m-%dT%H:%M:%S}t.%{msec_frac}t\",\"pid\":%{pid}P,\"levelname\":\"INFO\",\"name\":\"apache.access\",\"request_id\":\"%{X-Openstack-Request-ID}i\",\"client_ip\":\"%{X-Forwarded-For}i\",\"method\":\"%m\",\"uri\":\"%U%q\",\"protocol\":\"%H\",\"status\":%>s,\"bytes_sent\":%B,\"duration_ms\":%{ms}T,\"referer\":\"%{Referer}i\",\"user_agent\":\"%{User-Agent}i\"}" json_proxy
+LogFormat "{\"timestamp\":\"%{%Y-%m-%dT%H:%M:%S}t.%{msec_frac}t\",\"pid\":%{pid}P,\"levelname\":\"INFO\",\"name\":\"apache.access\",\"request_id\":\"%{X-Openstack-Request-ID}i\",\"client_ip\":\"%a\",\"method\":\"%m\",\"uri\":\"%U%q\",\"protocol\":\"%H\",\"status\":%>s,\"bytes_sent\":%B,\"duration_ms\":%{ms}T,\"duration_us\":%D,\"connection_status\":\"%X\",\"referer\":\"%{Referer}i\",\"user_agent\":\"%{User-Agent}i\"}" json_combined
+LogFormat "{\"timestamp\":\"%{%Y-%m-%dT%H:%M:%S}t.%{msec_frac}t\",\"pid\":%{pid}P,\"levelname\":\"INFO\",\"name\":\"apache.access\",\"request_id\":\"%{X-Openstack-Request-ID}i\",\"client_ip\":\"%{X-Forwarded-For}i\",\"method\":\"%m\",\"uri\":\"%U%q\",\"protocol\":\"%H\",\"status\":%>s,\"bytes_sent\":%B,\"duration_ms\":%{ms}T,\"duration_us\":%D,\"connection_status\":\"%X\",\"referer\":\"%{Referer}i\",\"user_agent\":\"%{User-Agent}i\"}" json_proxy
 SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
 CustomLog /dev/stdout json_combined env=!forwarded
 CustomLog /dev/stdout json_proxy env=forwarded
 {{- else }}
 ErrorLog /dev/stdout
-LogFormat "%{%Y-%m-%d %T}t.%{msec_frac}t %{pid}P INFO apache \"%{X-Openstack-Request-ID}i\" %h %l %u \"%r\" %>s %b %{ms}T \"%{Referer}i\" \"%{User-Agent}i\"" combined
-LogFormat "%{%Y-%m-%d %T}t.%{msec_frac}t %{pid}P INFO apache \"%{X-Openstack-Request-ID}i\" %{X-Forwarded-For}i %l %u \"%r\" %>s %b %{ms}T \"%{Referer}i\" \"%{User-Agent}i\"" proxy
+LogFormat "%{%Y-%m-%d %T}t.%{msec_frac}t %{pid}P INFO apache \"%{X-Openstack-Request-ID}i\" %h %l %u \"%r\" %>s %b %{ms}T %D %X \"%{Referer}i\" \"%{User-Agent}i\"" combined
+LogFormat "%{%Y-%m-%d %T}t.%{msec_frac}t %{pid}P INFO apache \"%{X-Openstack-Request-ID}i\" %{X-Forwarded-For}i %l %u \"%r\" %>s %b %{ms}T %D %X \"%{Referer}i\" \"%{User-Agent}i\"" proxy
 SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
 CustomLog /dev/stdout combined env=!forwarded
 CustomLog /dev/stdout proxy env=forwarded

--- a/system/kube-system-metal/values.yaml
+++ b/system/kube-system-metal/values.yaml
@@ -88,6 +88,15 @@ ingress-nginx:
 
     config:
       custom-http-errors: "495"
+      # Access log with request-lifecycle timing so we can correlate a request
+      # (via $req_id / X-Openstack-Request-ID) across the ingress and keystone's
+      # Apache/oslo logs and see where time is spent:
+      #   $request_time            - total time from first byte received to last byte sent
+      #   $upstream_connect_time   - time to establish the connection to the upstream (Apache)
+      #   $upstream_header_time    - time until the upstream sent the response headers
+      #   $upstream_response_time  - total time to receive the upstream response
+      log-format-upstream: >-
+        $remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" $request_length $request_time [$proxy_upstream_name] $upstream_addr $upstream_response_length $upstream_connect_time $upstream_header_time $upstream_response_time $upstream_status $req_id $global_request_id
 
   defaultBackend:
     image:


### PR DESCRIPTION
Add per-request timing so a request can be traced across the ingress and keystone's Apache logs via the OpenStack request id:

- keystone apache: add total duration in microseconds (%D) and connection status (%X) to both the JSON and plaintext LogFormat variants.
- nginx ingress (default class): add a log-format-upstream that includes $upstream_connect_time and $upstream_header_time alongside the existing $request_time / $upstream_response_time.