### PR TITLE
keystone: disable identity list_limit

### DIFF
--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -130,7 +130,7 @@ api:
 
   identity:
     # Maximum number of entities that will be returned in an identity collection. 0 disables the limit
-    list_limit: 1500
+    list_limit: 0 # disabled until keystone LDAP marker pagination is fixed (sapcc/keystone#57)
 
   metrics:
     enabled: true


### PR DESCRIPTION
`list_limit=1500` triggers broken LDAP marker pagination when a domain has >1500 users. The LDAP backend ignores `hints.marker`, so following a `next` page link always returns the first page again. With multiple pods behind a load balancer this causes alternating inconsistent results.

Setting `list_limit=0` (no limit) avoids the broken code path entirely — no truncation, no `next` link, no marker needed.

Tested locally with 2000 users, `page_size=100` (simulating AD MaxPageSize):
- All users returned in one request, consistent across workers
- `name__startswith` filter works correctly

The proper fix is in sapcc/keystone#57 (LDAP marker support). Once that is merged and deployed, `list_limit` can be restored to `1500`.