### PR TITLE
fix(cc-shoots-mgmt): set vethMTU 8930 for IPIP overlay shoots

### DIFF
--- a/system/cc-shoots-mgmt/Chart.yaml
+++ b/system/cc-shoots-mgmt/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-shoots-mgmt
 description: Converged Cloud Gardener shoots
 type: application
-version: 1.1.34
+version: 1.1.35
 appVersion: "0.1.0"

--- a/system/cc-shoots-mgmt/templates/mgmt-shoot.yaml
+++ b/system/cc-shoots-mgmt/templates/mgmt-shoot.yaml
@@ -34,7 +34,11 @@ spec:
       {{- if not $.Values.networking.overlay }}
       backend: bird
       {{- end }}
+      {{- if $.Values.networking.overlay }}
+      vethMTU: "8930"
+      {{- else }}
       vethMTU: "8950"
+      {{- end }}
       ipam:
         type: host-local
         cidr: usePodCIDR


### PR DESCRIPTION
## Summary

When overlay (IPIP) is enabled, Calico's FELIX_IPINIPMTU is set directly from vethMTU. With the previous value of 8950, pods send 8950-byte packets into the IPIP tunnel, but the effective path MTU is only 8930 (8950 tunnel MTU - 20B IPIP encap header), causing PACKET-TOO-BIG errors.

This conditionally sets vethMTU: "8930" when overlay is enabled (subtracting 20B IPIP overhead) and keeps vethMTU: "8950" when overlay is disabled (no encapsulation, full host MTU).