### PR TITLE
fix(cc-shoots-controlplane): set vethMTU to 8930 for overlay shoots

### DIFF
--- a/system/cc-shoots-controlplane/Chart.yaml
+++ b/system/cc-shoots-controlplane/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-shoots-controlplane
 description: Converged Cloud Gardener Controlplane shoots
 type: application
-version: 1.0.6
+version: 1.0.7
 appVersion: "0.1.0"

--- a/system/cc-shoots-controlplane/templates/controlplane-shoot.yaml
+++ b/system/cc-shoots-controlplane/templates/controlplane-shoot.yaml
@@ -28,7 +28,11 @@ spec:
       {{- if not $.Values.networking.overlay }}
       backend: bird
       {{- end }}
+      {{- if $.Values.networking.overlay }}
+      vethMTU: "8930"
+      {{- else }}
       vethMTU: "8950"
+      {{- end }}
       ipam:
         type: host-local
         cidr: usePodCIDR


### PR DESCRIPTION
## Summary

When overlay (IPIP) is enabled, Calico's vethMTU must account for the 20-byte IPIP encapsulation overhead. Previously vethMTU: "8950" was set unconditionally, which causes PACKET-TOO-BIG on cross-node pod traffic through IPIP tunnels (8950 + 20B header = 8970 > host MTU 8950).

## Changes

- Set vethMTU: "8930" when overlay is enabled (8950 host MTU - 20B IPIP overhead)
- Keep vethMTU: "8950" when overlay is disabled (no tunnel, no overhead)
- Bump chart version to 1.0.7