### PR TITLE
fix(cronus): support list values for allowedServices in helm template

### DIFF
--- a/openstack/cronus/templates/cronus/_config.yaml.tpl
+++ b/openstack/cronus/templates/cronus/_config.yaml.tpl
@@ -86,7 +86,14 @@ cronus:
     {{- end }}
     allowedServices:
     {{- range $key, $value := .Values.config.allowedServices }}
+      {{- if kindIs "slice" $value }}
+      {{ $key }}:
+        {{- range $value }}
+        - {{ . }}
+        {{- end }}
+      {{- else }}
       {{ $key }}: {{ $value }}
+      {{- end }}
     {{- end }}
   listenAddr:
     http: :{{ .Values.cronus.http }} # default :5000


### PR DESCRIPTION
## Problem

When `allowedServices` values are defined as YAML lists in Helm values:
```yaml
config:
  allowedServices:
    sts:
      - us-east-1
      - eu-central-1
```

Helm's `range` renders the list as a space-joined scalar string:
```yaml
allowedServices:
  sts: us-east-1 eu-central-1   # wrong — one string, not a list
```

This caused Cronus to fail on startup:
```
cannot parse "/cronus/config.yaml" file: "sts" service: "us-east-1 eu-central-1" region is invalid
```

## Fix

Use `kindIs "slice"` to detect list values and render them as YAML block sequences. Scalar values continue to work unchanged.

## Test Result

Input `values.yaml`:
```yaml
config:
  allowedServices:
    email: eu-central-1
    sts:
      - us-east-1
      - eu-central-1
    s3: eu-central-1
    pinpoint: eu-central-1
    servicequotas: eu-central-1
```

Rendered output:
```yaml
allowedServices:
  email: eu-central-1
  pinpoint: eu-central-1
  s3: eu-central-1
  servicequotas: eu-central-1
  sts:
    - us-east-1
    - eu-central-1
```

✓ Scalar values render as `key: value`
✓ List values render as YAML block sequence
✓ Cronus config parser accepts this format (verified by unit test `TestAllowedServices_MixedFormatFullConfig` in [cronus/cronus#393](https://github.wdf.sap.corp/cronus/cronus/pull/393))

## References

- [cronus/cronus#391](https://github.wdf.sap.corp/cronus/cronus/pull/391) — multi-region support
- [cronus/cronus#392](https://github.wdf.sap.corp/cronus/cronus/pull/392) — backward compat
- [cronus/cronus#393](https://github.wdf.sap.corp/cronus/cronus/pull/393) — space-separated + unit tests
- [solution-development-issues#891](https://github.wdf.sap.corp/sap-cloud-infrastructure/solution-development-issues/issues/891)