### PR TITLE
fix(provider-metal): remove leaked ipam-capi-remote patches from chart

### DIFF
--- a/system/Makefile
+++ b/system/Makefile
@@ -85,6 +85,7 @@ build-ipam-capi-remote:
 	@yq -i ".version=\"$$CHART_VERSION\"" ipam-capi-remote/Chart.yaml
 	@$(SED) -i 's/serviceAccountName.*$$/serviceAccountName: {{ .Values.controllerManager.serviceAccountName }}/g' ipam-capi-remote/templates/deployment.yaml
 	@$(SED) -i 's/kind: Role/kind: ClusterRole/g' ipam-capi-remote/managedresources/crds-rbac.yaml
+	@git restore kustomization.yaml
 
 build-provider-metal3:
 	$(call build-chart,provider-metal3,https://github.com/metal3-io/cluster-api-provider-metal3//config/default,$(PROVIDER_METAL3_VERSION))

--- a/system/provider-metal/Chart.yaml
+++ b/system/provider-metal/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.5
+version: 0.2.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/provider-metal/templates/deployment.yaml
+++ b/system/provider-metal/templates/deployment.yaml
@@ -33,10 +33,6 @@ spec:
         command:
         - /manager
         env:
-        - name: KUBECONFIG
-          value: {{ quote .Values.controllerManager.manager.env.kubeconfig }}
-        - name: KUBERNETES_SERVICE_HOST
-          value: {{ quote .Values.controllerManager.manager.env.kubernetesServiceHost }}
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
         image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag
@@ -48,10 +44,6 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 20
         name: manager
-        ports:
-        - containerPort: 9443
-          name: webhook-server
-          protocol: TCP
         readinessProbe:
           httpGet:
             path: /readyz
@@ -62,16 +54,7 @@ spec:
           }}
         securityContext: {{- toYaml .Values.controllerManager.manager.containerSecurityContext
           | nindent 10 }}
-        volumeMounts:
-        - mountPath: /tmp/k8s-webhook-server/serving-certs
-          name: webhook-certs
-          readOnly: true
-        - mountPath: /var/run/secrets/kubernetes.io/remote-serviceaccount
-          name: remote-serviceaccount
-          readOnly: true
-        - mountPath: /var/run/remote-kubeconfig
-          name: remote-kubeconfig
-          readOnly: true
+
       nodeSelector: {{- toYaml .Values.controllerManager.nodeSelector | nindent 8 }}
       securityContext: {{- toYaml .Values.controllerManager.podSecurityContext | nindent
         8 }}
@@ -80,19 +63,4 @@ spec:
       tolerations: {{- toYaml .Values.controllerManager.tolerations | nindent 8 }}
       topologySpreadConstraints: {{- toYaml .Values.controllerManager.topologySpreadConstraints
         | nindent 8 }}
-      volumes:
-      - emptyDir: {}
-        name: webhook-certs
-      - name: remote-serviceaccount
-        secret:
-          defaultMode: 420
-          items:
-          - key: token
-            path: token
-          - key: bundle.crt
-            path: ca.crt
-          secretName: ipam-capi-remote-kubeconfig
-      - configMap:
-          defaultMode: 420
-          name: ipam-capi-remote-kubeconfig
-        name: remote-kubeconfig
+

--- a/system/provider-metal/values.yaml
+++ b/system/provider-metal/values.yaml
@@ -1,8 +1,8 @@
 controllerManager:
   manager:
     args:
-      - --leader-elect=false
-      - --webhook-port=9443
+      - --leader-elect
+      - --health-probe-bind-address=:8081
     containerSecurityContext:
       allowPrivilegeEscalation: false
       capabilities:
@@ -10,9 +10,6 @@ controllerManager:
           - ALL
       runAsGroup: 65532
       runAsUser: 65532
-    env:
-      kubeconfig: /var/run/remote-kubeconfig/kubeconfig
-      kubernetesServiceHost: apiserver-url
     image:
       repository: controller
       tag: cf12acd520aa203db28f21a326a61fddc9720b95


### PR DESCRIPTION
## Problem

`provider-metal-controller-manager` pods crash with:
```
MountVolume.SetUp failed for volume "remote-serviceaccount": secret "ipam-capi-remote-kubeconfig" not found
MountVolume.SetUp failed for volume "remote-kubeconfig": configmap "ipam-capi-remote-kubeconfig" not found
```

The provider-metal chart contains remote kubeconfig volumes, webhook ports, and incorrect args that were never part of the upstream ironcore-dev/cluster-api-provider-ironcore-metal config.

## Root Cause

In `system/Makefile`, the `build-ipam-capi-remote` target overwrites `kustomization.yaml` with its own kustomization that includes patches for remote kubeconfig volumes and webhook configuration:

```makefile
@cat kustomize/ipam-capi-remote/manager/kustomization.yaml > kustomization.yaml
```

But it **never restores** `kustomization.yaml` afterward.

The build order is:
```
... build-ipam-capi-remote build-provider-metal3 build-provider-metal
```

When `build-provider-metal` runs next, the `build-chart` function only updates `resources[0]` via yq but leaves the `patches:` array from ipam-capi-remote intact. So `kubectl kustomize` applies the remote kubeconfig patches (`manager-remote-patch.yaml` and `manager-webhook-patch.yaml`) to the provider-metal upstream manifests before helmify converts them to a Helm chart.

The `git restore kustomization.yaml` at the end of `build-chart` cleans up, but the chart was already generated with contaminated kustomize output.

## Fix

1. **Makefile**: Add `@git restore kustomization.yaml` at the end of `build-ipam-capi-remote` to prevent patch leakage to subsequent build targets.

2. **provider-metal chart**: Remove all leaked artifacts:
   - Remote kubeconfig volumes and volume mounts
   - `KUBECONFIG` and `KUBERNETES_SERVICE_HOST` env vars
   - Webhook port (9443) — upstream has no webhooks
   - Fix args back to upstream defaults (`--leader-elect`, `--health-probe-bind-address=:8081`)
   - Remove unused `env` values from values.yaml

3. **Chart version**: Bump to 0.2.6