### PR TITLE
keppel: workaround broken Ceph API

### DIFF
--- a/openstack/keppel/templates/_utils.tpl
+++ b/openstack/keppel/templates/_utils.tpl
@@ -62,7 +62,7 @@
   value: {{ include "driver_config_ratelimit" $ | fromYaml | toJson | quote }}
 - name:  KEPPEL_DRIVER_STORAGE
   {{- if eq .Values.keppel.driver "ceph" }}
-  value: '{"type":"swift","params":{"service_type":"object-store-ceph","use_service_user_project":true}}'
+  value: '{"type":"swift","params":{"apply_workarounds_for_ceph":true,"service_type":"object-store-ceph","use_service_user_project":true}}'
   {{- else }}{{/* TODO: if eq .Values.keppel.driver "multi", use that driver once it exists */}}
   value: '{"type":"swift"}'
   {{- end }}

--- a/openstack/keppel/templates/seed.yaml
+++ b/openstack/keppel/templates/seed.yaml
@@ -66,9 +66,9 @@ spec:
             - project: service
               role:    registry_viewer # worthless role assignment, used only to enable Keystone login (actual access to relevant Keppel accounts is given by RBAC policies)
         {{- end }}
-      {{- if ne .Values.keppel.driver "swift" }}{{/* TODO: seed Ceph account in this project (TODO: how?) */}}
+      {{- if ne .Values.keppel.driver "swift" }}
       projects:
-        - name: keppel-payloads
+        - name: keppel-payloads # NOTE: in buildup, there is _probably_ a Limes dependency here, because the Ceph account for this project is probably only created once Limes assigns quota to it
           role_assignments:
             - user: keppel@Default
               role: service           # to validate users' Keystone tokens
@@ -78,6 +78,8 @@ spec:
             - user: keppel@Default
               role: cloud_objectstore_admin # to read/write objects (blobs, manifests, reports) in customers' Swift accounts
             {{- end }}
+            - group: CCADMIN_CLOUD_ADMINS@ccadmin
+              role: objectstore_viewer # to allow inspection by cloud admins
       {{- end }}
 
     - name: ccadmin


### PR DESCRIPTION
Needs sapcc/keppel#754 merged first.

The new role assignment is already active in eu-de-3.