### PR TITLE
[kube-monitoring] amo filter out thanos ruler rules

### DIFF
--- a/system/kube-monitoring-metal/Chart.yaml
+++ b/system/kube-monitoring-metal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes metal controlplane monitoring.
 name: kube-monitoring-metal
-version: 4.11.0
+version: 4.11.1
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-metal
 dependencies:
   - condition: absent-metrics-operator.enabled

--- a/system/kube-monitoring-metal/values.yaml
+++ b/system/kube-monitoring-metal/values.yaml
@@ -17,6 +17,8 @@ kubeStateMetrics:
 
 absent-metrics-operator:
   enabled: true
+  args:
+    - --prom-rule-name={{ if index .metadata.labels "thanos-ruler" }}""{{ else if index .metadata.labels "prometheus" }}{{ index .metadata.labels "prometheus" }}{{ else }}no-selector{{ end }}
 
 kube-state-metrics:
   image:


### PR DESCRIPTION
invalid rule name for thanos-ruler prometheus rules

causing error log and avoiding creating of absent rule for it