### PR TITLE
system/perses: fix persesDashboard alert label to use absolute URL

### DIFF
--- a/system/perses/Chart.lock
+++ b/system/perses/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: perses
   repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-  version: 0.24.0
+  version: 0.24.1
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:8ac21ea8f0fddaa84d16907b2ed244043b5befa46d1900a2f49ffb47410fd776
-generated: "2026-08-05T13:51:22.417798+02:00"
+digest: sha256:d336de22542cf59ff7be78bf86adcf55258e14c5079b4d8c3172ff23762e37d8
+generated: "2026-08-11T18:01:40.408756+02:00"

--- a/system/perses/Chart.yaml
+++ b/system/perses/Chart.yaml
@@ -3,7 +3,7 @@ name: perses
 description: This Helm chart is a wrapper chart for [perses/helm-chart](https://github.com/perses/helm-charts). It has dependencies and configurations to fit the needs of the SAP Cloud Infrastructure.
 icon: https://avatars.githubusercontent.com/u/77209215?s=200&v=4
 type: application
-version: 0.7.4
+version: 0.7.5
 maintainers:
   - name: richardtief
   - name: ibakshay
@@ -16,7 +16,7 @@ dependencies:
   - name: perses
     alias: persesPlugin
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.24.0
+    version: 0.24.1
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0

--- a/system/perses/values.yaml
+++ b/system/perses/values.yaml
@@ -333,7 +333,7 @@ persesPlugin:
     alertLabels:
       support_group: "observability"
       service: "perses"
-      persesDashboard: "observability/dashboards/perses-overview"
+      persesDashboard: "https://perses.{{ .Values.global.region }}.{{ .Values.global.tld }}/projects/observability/dashboards/perses-overview"
 
 # -- All the SAP Cloud Infrastructure specific values should go here.
 sapCloudInfrastructure:

--- a/system/perses/values.yaml
+++ b/system/perses/values.yaml
@@ -328,7 +328,7 @@ persesPlugin:
     alertLabels:
       support_group: "observability"
       service: "perses"
-      persesDashboard: "observability/dashboards/perses-overview"
+      persesDashboard: "https://perses.{{ .Values.global.region }}.{{ .Values.global.tld }}/projects/observability/dashboards/perses-overview"
 
 # -- All the SAP Cloud Infrastructure specific values should go here.
 sapCloudInfrastructure:


### PR DESCRIPTION
## Problem
Some Slack alert  currently link to a relative path `observability/dashboards/perses-overview`, which Slack cannot resolve.

## Fix in this PR
Set `greenhouse.alertLabels.persesDashboard` in `system/perses/values.yaml` to an absolute URL, using the same `{{ .Values.global.region }}` / `{{ .Values.global.tld }}` template expressions that all other charts in this repo already use (see e.g. `openstack/hermes/alerts/openstack/api.alerts.tpl`).