### PR TITLE
[octobus-query-exporter] fix NFSlockedError playbook anchor to lowercase

### DIFF
--- a/prometheus-exporters/octobus-query-exporter/Chart.lock
+++ b/prometheus-exporters/octobus-query-exporter/Chart.lock
@@ -12,4 +12,4 @@ dependencies:
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
 digest: sha256:a89c958cbad501cb6bf5f1377b0296c7f9d1a1601dd89bb064b8de1f854aaf9b
-generated: "2026-07-14T00:01:44.36936+08:00"
+generated: "2026-07-21T22:32:59.390181+08:00"

--- a/prometheus-exporters/octobus-query-exporter/Chart.lock
+++ b/prometheus-exporters/octobus-query-exporter/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: octobus-query-exporter
   repository: file://vendor/octobus-query-exporter
-  version: 1.0.31
+  version: 1.0.32
 - name: octobus-query-exporter-global
   repository: file://vendor/octobus-query-exporter-global
   version: 1.0.14
@@ -11,5 +11,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:a89c958cbad501cb6bf5f1377b0296c7f9d1a1601dd89bb064b8de1f854aaf9b
-generated: "2026-07-21T22:32:59.390181+08:00"
+digest: sha256:9258864e6058609cb179c13626600c67fa3da45ea2a675051ed616f274277cf1
+generated: "2026-07-21T22:41:42.948774+08:00"

--- a/prometheus-exporters/octobus-query-exporter/Chart.yaml
+++ b/prometheus-exporters/octobus-query-exporter/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 1.0.33
+version: 1.0.34
 name: octobus-query-exporter
 description: Elasticsearch prometheus query exporter
 maintainers:
@@ -11,7 +11,7 @@ dependencies:
   - name: octobus-query-exporter
     alias: octobus_query_exporter
     repository: file://vendor/octobus-query-exporter
-    version: 1.0.31
+    version: 1.0.32
     condition: octobus_query_exporter.enabled
 
   - name: octobus-query-exporter-global

--- a/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/Chart.yaml
+++ b/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 1.0.31
+version: 1.0.32
 name: octobus-query-exporter
 description: Elasticsearch prometheus query exporter
 maintainers:

--- a/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/alerts/scaleout/events.alerts.tpl
+++ b/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/alerts/scaleout/events.alerts.tpl
@@ -81,7 +81,7 @@ groups:
           support_group: compute
           no_alert_on_absence: "true"
           meta: "Alert for NFSLocked issue"
-          playbook: docs/compute/playbooks/vcenter/#NFSlockedError
+          playbook: docs/compute/playbooks/vcenter/#nfslockederror
         annotations:
           summary: "ESXi host detected NFSv4 lock error (NFS4ERR_LOCKED)"
           description: "ESXi host {{`{{ $labels.hostsystem }}`}} reported an NFSv4 lock error (NFS4ERR_LOCKED), it indicates that a file lock could not be obtained on the NFS datastore, which may impact VM operations such as disk access, snapshots, or migrations"


### PR DESCRIPTION
## Summary

- Fix playbook anchor in `NFSlockedError` alert: `#NFSlockedError` → `#nfslockederror` 
