### PR TITLE
[keystone] convert db-migration jobs to regular resources

### DIFF
--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: keystone
 sources:
   - https://github.com/sapcc/keystone
-version: 0.12.1
+version: 0.12.2
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: keystone
 sources:
   - https://github.com/sapcc/keystone
-version: 0.13.4
+version: 0.13.5
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/keystone/ci/test-values.yaml
+++ b/openstack/keystone/ci/test-values.yaml
@@ -10,6 +10,8 @@ global:
   keystoneNamespace: keystone-namespace
   dockerHubMirror: my.dockerhub.mirror
   dockerHubMirrorAlternateRegion: other.dockerhub.mirror
+  ghcrIoMirror: my.ghcr.mirror
+  ghcrIoMirrorAlternateRegion: other.ghcr.mirror
   is_global_region: false
   osprofiler:
     jager:

--- a/openstack/keystone/templates/_helpers.tpl
+++ b/openstack/keystone/templates/_helpers.tpl
@@ -56,9 +56,8 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- define "job_name" }}
   {{- $name := index . 1 }}
   {{- with index . 0 }}
-    {{- $bin := include "utils.proxysql.proxysql_signal_stop_script" . | trim }}
-    {{- $all := list $bin (include "utils.proxysql.job_pod_settings" . ) (include "utils.proxysql.volume_mount" . ) (include "utils.proxysql.container" . ) (include "utils.proxysql.volumes" .) | join "\n" }}
-    {{- $hash := empty .Values.proxysql.mode | ternary $bin $all | sha256sum }}
+    {{- $all := list (include (print .Template.BasePath "/configmap-etc.yaml") .) (include (print .Template.BasePath "/secrets.yaml") .) (include "utils.proxysql.proxysql_signal_stop_script" . ) (include "utils.proxysql.job_pod_settings" . ) (include "utils.proxysql.volume_mount" . ) (include "utils.proxysql.container" . ) (include "utils.proxysql.volumes" .) | join "\n" }}
+    {{- $hash := $all | sha256sum }}
 {{- .Release.Name }}-{{ $name }}-{{ substr 0 4 $hash }}-{{ .Values.api.imageTag | required "Please set api.imageTag or similar"}}
   {{- end }}
 {{- end }}

--- a/openstack/keystone/templates/job-credential-migrate.yaml
+++ b/openstack/keystone/templates/job-credential-migrate.yaml
@@ -2,10 +2,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: "{{ tuple . "job-credential-migrate" | include "job_name" }}"
-  annotations:
-    "helm.sh/hook": pre-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook-weight": "0"
   labels:
     app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -14,8 +10,6 @@ metadata:
     system: openstack
     component: keystone
     type: job
-    ccloud/support-group: identity
-    ccloud/service: keystone
 spec:
   template:
     metadata:

--- a/openstack/keystone/templates/job-credential-migrate.yaml
+++ b/openstack/keystone/templates/job-credential-migrate.yaml
@@ -2,10 +2,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: "{{ tuple . "job-creds-migrate" | include "job_name" }}"
-  annotations:
-    "helm.sh/hook": pre-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook-weight": "0"
   labels:
     app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -14,8 +10,6 @@ metadata:
     system: openstack
     component: keystone
     type: job
-    ccloud/support-group: identity
-    ccloud/service: keystone
 spec:
   template:
     metadata:

--- a/openstack/keystone/templates/job-migration.yaml
+++ b/openstack/keystone/templates/job-migration.yaml
@@ -11,9 +11,6 @@ metadata:
     system: openstack
     component: keystone
     type: job
-    # hooks are not annotated as belonging to the Helm release, so we cannot rely on owner-info injection
-    ccloud/support-group: identity
-    ccloud/service: keystone
 spec:
   template:
     metadata:
@@ -28,8 +25,6 @@ spec:
         chart-version: {{.Chart.Version}}
         configmap-bin-hash: {{ include (print $.Template.BasePath "/configmap-bin.yaml") . | sha256sum }}
         configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") . | sha256sum }}
-        # only run once
-        "helm.sh/hook": post-install, post-upgrade
 {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
 {{- if .Values.rbac.enabled }}


### PR DESCRIPTION
* drop dead pod-template hook annotation from job-migration
* drop hook annotations from job-credential-migrate
* drop ccloud labels covered by owner-info injection
* hash $all (config + secrets + proxysql) in job name
* add missing global ghcr mirror values to ci/test-values

`monsoon3/default` global cluster reader role will be removed soon in https://github.com/sapcc/helm-charts/pull/11677 , so this job wouldn't be able to run without service-specific rbac role.
