### PR TITLE
[octavia] convert db-migration job to regular resource

### DIFF
--- a/openstack/octavia/Chart.yaml
+++ b/openstack/octavia/Chart.yaml
@@ -9,7 +9,7 @@ sources:
   - https://git.openstack.org/cgit/openstack/octavia
   - https://git.openstack.org/cgit/openstack/openstack-helm
 # The versions are defined in the changelog: https://docs.openstack.org/releasenotes/octavia/yoga.html
-version: 10.1.11
+version: 10.1.12
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/octavia/ci/test-values.yaml
+++ b/openstack/octavia/ci/test-values.yaml
@@ -3,6 +3,9 @@ global:
   dbPassword: secret!
   master_password: topSecret!
   octavia_service_password: topSecret!!
+  region: regionOne
+  tld: example.com
+  clusterDNSSearchDomain: cluster.local
   registry: my.docker.registry
   registryAlternateRegion: other.docker.registry
   dockerHubMirror: my.dockerhub.mirror

--- a/openstack/octavia/templates/_helpers.tpl
+++ b/openstack/octavia/templates/_helpers.tpl
@@ -34,3 +34,20 @@ Create chart name and version as used by the chart label.
 {{- define "octavia.db_service" }}
   {{- include "utils.db_host" . }}
 {{- end }}
+
+{{- define "job_name" }}
+  {{- $name := index . 1 }}
+  {{- with index . 0 }}
+    {{- $all := list
+          (include (print .Template.BasePath "/octavia-etc-configmap.yaml") .)
+          (include (print .Template.BasePath "/secrets.yaml") .)
+          (include "utils.proxysql.job_pod_settings" .)
+          (include "utils.proxysql.volume_mount" .)
+          (include "utils.proxysql.container" .)
+          (include "utils.proxysql.volumes" .)
+          (tuple . (dict) | include "utils.snippets.kubernetes_entrypoint_init_container")
+      | join "\n" }}
+    {{- $hash := empty .Values.proxysql.mode | ternary "" $all | sha256sum }}
+{{- .Release.Name }}-{{ $name }}-{{ substr 0 4 $hash }}-{{ .Values.imageVersion | required "Please set octavia.imageVersion" }}
+  {{- end }}
+{{- end }}

--- a/openstack/octavia/templates/_helpers.tpl
+++ b/openstack/octavia/templates/_helpers.tpl
@@ -34,3 +34,20 @@ Create chart name and version as used by the chart label.
 {{- define "octavia.db_service" }}
   {{- include "utils.db_host" . }}
 {{- end }}
+
+{{- define "job_name" }}
+  {{- $name := index . 1 }}
+  {{- with index . 0 }}
+    {{- $all := list
+          (include (print .Template.BasePath "/octavia-etc-configmap.yaml") .)
+          (include (print .Template.BasePath "/secrets.yaml") .)
+          (include "utils.proxysql.job_pod_settings" .)
+          (include "utils.proxysql.volume_mount" .)
+          (include "utils.proxysql.container" .)
+          (include "utils.proxysql.volumes" .)
+          (tuple . (dict) | include "utils.snippets.kubernetes_entrypoint_init_container")
+      | join "\n" }}
+    {{- $hash := $all | sha256sum }}
+{{- .Release.Name }}-{{ $name }}-{{ substr 0 4 $hash }}-{{ .Values.imageVersion | required "Please set octavia.imageVersion" }}
+  {{- end }}
+{{- end }}

--- a/openstack/octavia/templates/octavia-api-deployment.yaml
+++ b/openstack/octavia/templates/octavia-api-deployment.yaml
@@ -49,7 +49,7 @@ spec:
       {{- include "utils.proxysql.pod_settings" . | nindent 6 }}
       {{- tuple . (dict "app.kubernetes.io/name" "octavia-api") | include "utils.topology.constraints" | indent 6 }}
       initContainers:
-      {{- include "utils.snippets.kubernetes_entrypoint_init_container" (list . (dict "jobs" "octavia-migration")) | indent 6 }}
+      {{- include "utils.snippets.kubernetes_entrypoint_init_container" (list . (dict "jobs" (include "job_name" (tuple . "migration")))) | indent 6 }}
       {{- if .Values.proxysql.native_sidecar }}
       {{- include "utils.proxysql.container" . | indent 6 }}
       {{- end }}

--- a/openstack/octavia/templates/octavia-housekeeping.yaml
+++ b/openstack/octavia/templates/octavia-housekeeping.yaml
@@ -36,7 +36,7 @@ spec:
       {{- end }}
 {{ include "utils.proxysql.pod_settings" . | indent 6 }}
       initContainers:
-      {{- include "utils.snippets.kubernetes_entrypoint_init_container" (list . (dict "jobs" "octavia-migration")) | indent 6 }}
+      {{- include "utils.snippets.kubernetes_entrypoint_init_container" (list . (dict "jobs" (include "job_name" (tuple . "migration")))) | indent 6 }}
       {{- if .Values.proxysql.native_sidecar }}
       {{- include "utils.proxysql.container" . | indent 6 }}
       {{- end }}

--- a/openstack/octavia/templates/octavia-migration-job.yaml
+++ b/openstack/octavia/templates/octavia-migration-job.yaml
@@ -1,22 +1,11 @@
-{{- $proxysql := lookup "v1" "Secret" .Release.Namespace (print .Release.Name "-proxysql-etc") -}}
-{{- $serviceaccount := lookup "v1" "ServiceAccount" .Release.Namespace .Release.Name -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: octavia-migration
+  name: {{ tuple . "migration" | include "job_name" }}
   labels:
     system: openstack
     type: configuration
     component: octavia
-    # hooks are not annotated as belonging to the Helm release, so we cannot rely on owner-info injection
-    ccloud/support-group: network-api
-    ccloud/service: octavia
-  annotations:
-    # post-install is necessary so that we can be sure when deploying to a
-    # region for the first time that the DB pod is already running.
-    "helm.sh/hook": "post-install,pre-upgrade"
-    "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   template:
     metadata:
@@ -24,16 +13,14 @@ spec:
         kubectl.kubernetes.io/default-container: octavia-migration
         {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
-      {{- if $serviceaccount }}
+      {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ .Release.Name }}
       {{- end }}
       restartPolicy: OnFailure
-    {{- if $proxysql }}
       {{- include "utils.proxysql.job_pod_settings" . | nindent 6 }}
-    {{- end }}
       initContainers:
         {{- include "utils.snippets.kubernetes_entrypoint_init_container" (list . (dict "service" (include "octavia.db_service" .))) | indent 8 }}
-        {{- if and $proxysql .Values.proxysql.native_sidecar }}
+        {{- if .Values.proxysql.native_sidecar }}
         {{- include "utils.proxysql.container" . | indent 8 }}
         {{- end }}
       containers:
@@ -69,12 +56,10 @@ spec:
               subPath: logging.ini
               readOnly: true
             {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
-    {{- if $proxysql }}
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
         {{- if not .Values.proxysql.native_sidecar }}
         {{- include "utils.proxysql.container" . | indent 8 }}
         {{- end }}
-    {{- end }}
       volumes:
         - name: octavia-etc
           configMap:
@@ -82,7 +67,5 @@ spec:
         - name: octavia-etc-confd
           secret:
             secretName: {{ .Release.Name }}-secrets
-    {{- if $proxysql}}
         {{- include "utils.proxysql.volumes" . | indent 8 }}
-    {{- end }}
         {{- include "utils.trust_bundle.volumes" . | indent 8 }}

--- a/openstack/octavia/templates/octavia-worker-deployment.yaml
+++ b/openstack/octavia/templates/octavia-worker-deployment.yaml
@@ -45,7 +45,7 @@ spec:
       priorityClassName: critical-payload
 {{ include "utils.proxysql.pod_settings" . | indent 6 }}
       initContainers:
-      {{- include "utils.snippets.kubernetes_entrypoint_init_container" (list . (dict "jobs" "octavia-migration")) | indent 6 }}
+      {{- include "utils.snippets.kubernetes_entrypoint_init_container" (list . (dict "jobs" (include "job_name" (tuple . "migration")))) | indent 6 }}
       {{- if .Values.proxysql.native_sidecar }}
       {{- include "utils.proxysql.container" . | indent 6 }}
       {{- end }}


### PR DESCRIPTION
On first install the release SA is not applied yet, so the hook pod runs under `monsoon3/default`. The entrypoint endpointslices check then returns 403.

* drop hook annotations
* hash-suffixed job name like nova/cinder
* guard SA on `.Values.rbac.enabled`
* update api/worker/housekeeping DEPENDENCY_JOBS


`monsoon3/default` global cluster reader role will be removed soon in https://github.com/sapcc/helm-charts/pull/11677 , so this job wouldn't be able to run without service-specific rbac role.
