### PR TITLE
[manila] convert db-migration job to regular resource

### DIFF
--- a/openstack/manila/Chart.yaml
+++ b/openstack/manila/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 name: manila
 sources:
   - https://github.com/sapcc/manila
-version: 0.7.0
+version: 0.7.1
 dependencies:
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/manila/templates/_helpers.tpl
+++ b/openstack/manila/templates/_helpers.tpl
@@ -29,3 +29,21 @@ Define the Manila dependency services for kubernetes-entrypoint init container
 {{- define "manila.memcached_service" }}
   {{- .Release.Name }}-memcached
 {{- end }}
+
+{{- define "job_name" }}
+  {{- $name := index . 1 }}
+  {{- with index . 0 }}
+    {{- $bin := include (print .Template.BasePath "/bin/_db_migrate.sh.tpl") . }}
+    {{- $all := list $bin
+          (include (print .Template.BasePath "/etc-configmap.yaml") .)
+          (include (print .Template.BasePath "/secrets.yaml") .)
+          (include "utils.proxysql.job_pod_settings" .)
+          (include "utils.proxysql.volume_mount" .)
+          (include "utils.proxysql.container" .)
+          (include "utils.proxysql.volumes" .)
+          (tuple . (dict) | include "utils.snippets.kubernetes_entrypoint_init_container")
+      | join "\n" }}
+    {{- $hash := empty .Values.proxysql.mode | ternary $bin $all | sha256sum }}
+{{- .Release.Name }}-{{ $name }}-{{ substr 0 4 $hash }}-{{ .Values.loci.imageVersion | required "Please set manila.loci.imageVersion" }}
+  {{- end }}
+{{- end }}

--- a/openstack/manila/templates/api-deployment.yaml
+++ b/openstack/manila/templates/api-deployment.yaml
@@ -60,7 +60,7 @@ spec:
       {{- include "utils.proxysql.pod_settings" . | indent 6 }}
       priorityClassName: {{ .Values.pod.priority_class.default }}
       initContainers:
-      {{- tuple . (dict "jobs" (print .Release.Name "-migration") "service" (include "manila.api_service_dependencies" . )) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
+      {{- tuple . (dict "jobs" (include "job_name" (tuple . "migration")) "service" (include "manila.api_service_dependencies" . )) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
       {{- if not .Values.api_backdoor }}
       - name: create-guru-file
         image: {{.Values.global.dockerHubMirror}}/library/busybox

--- a/openstack/manila/templates/migration-job.yaml
+++ b/openstack/manila/templates/migration-job.yaml
@@ -1,27 +1,13 @@
-{{/* As this runs as a pre-upgrade hook, we can only use the proxysql side-car if a previous
-     deployment has already deployed the corresponding configmap.
-     So if we want to switch to or from a proxysql.mode=unix_socket setting, we need
-     first to deploy with proxysql.mode=host_alias as an intermediate step,
-     so this script can still work with the previous setting.
-*/}}
-{{- $proxysql := lookup "v1" "Secret" .Release.Namespace (print .Release.Name "-proxysql-etc") -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-migration
+  name: {{ tuple . "migration" | include "job_name" }}
   labels:
     system: openstack
     type: configuration
     component: manila
     alert-tier: os
     alert-service: manila
-    # hooks are not labeled as belonging to the Helm release, so we cannot rely on owner-info injection
-    ccloud/support-group: compute-storage-api
-    ccloud/service: manila
-  annotations:
-    "helm.sh/hook": "post-install,pre-upgrade"
-    "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   template:
     metadata:
@@ -32,13 +18,11 @@ spec:
       {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ .Release.Name }}
       {{- end }}
-{{- if $proxysql }}
       {{- include "utils.proxysql.job_pod_settings" . | indent 6 }}
-{{- end }}
       priorityClassName: {{ .Values.pod.priority_class.low }}
       initContainers:
       {{- tuple . (dict "service" (include "manila.db_service" .)) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 6 }}
-      {{- if and $proxysql .Values.proxysql.native_sidecar }}
+      {{- if .Values.proxysql.native_sidecar }}
       {{- include "utils.proxysql.container" . | indent 6 }}
       {{- end }}
       containers:
@@ -77,12 +61,10 @@ spec:
             - mountPath: /container.init
               name: container-init
             {{- include "utils.trust_bundle.volume_mount" . | indent 12 }}
-{{- if $proxysql }}
             {{- include "utils.proxysql.volume_mount" . | indent 12 }}
         {{- if not .Values.proxysql.native_sidecar }}
         {{- include "utils.proxysql.container" . | indent 8 }}
         {{- end }}
-{{- end }}
       volumes:
         - name: etcmanila
           emptyDir: {}
@@ -97,6 +79,4 @@ spec:
             name: {{ .Release.Name }}-bin
             defaultMode: 0755
         {{- include "utils.trust_bundle.volumes" . | indent 8 }}
-{{- if $proxysql }}
         {{- include "utils.proxysql.volumes" . | indent 8 }}
-{{- end }}

--- a/openstack/manila/templates/scheduler-deployment.yaml
+++ b/openstack/manila/templates/scheduler-deployment.yaml
@@ -62,7 +62,7 @@ spec:
                   - {{ .Release.Name }}-scheduler
               topologyKey: "topology.kubernetes.io/zone"
       initContainers:
-        {{- tuple . (dict "jobs" (print .Release.Name "-migration") "service" (include "manila.service_dependencies" . )) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
+        {{- tuple . (dict "jobs" (include "job_name" (tuple . "migration")) "service" (include "manila.service_dependencies" . )) | include "utils.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
         {{- if not .Values.api_backdoor }}
         - name: create-guru-file
           image: {{.Values.global.dockerHubMirror}}/library/busybox


### PR DESCRIPTION
On first install the release SA is not applied yet, so the hook pod runs under `monsoon3/default`. The entrypoint endpointslices check then returns 403.

* drop hook annotations
* hash-suffixed job name like nova/cinder
* update api/scheduler DEPENDENCY_JOBS


`monsoon3/default` global cluster reader role will be removed soon in https://github.com/sapcc/helm-charts/pull/11677 , so this job wouldn't be able to run without service-specific rbac role.
