### PR TITLE
[barbican] convert db-migration job to regular resource

### DIFF
--- a/openstack/barbican/Chart.yaml
+++ b/openstack/barbican/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: flamingo
 description: A Helm chart for Openstack Barbican
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Barbican/OpenStack_Project_Barbican_vertical.png
 name: barbican
-version: 0.8.5
+version: 0.8.6
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/barbican/Chart.yaml
+++ b/openstack/barbican/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: flamingo
 description: A Helm chart for Openstack Barbican
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Barbican/OpenStack_Project_Barbican_vertical.png
 name: barbican
-version: 0.8.9
+version: 0.8.10
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/barbican/templates/_helpers.tpl
+++ b/openstack/barbican/templates/_helpers.tpl
@@ -22,3 +22,20 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "barbican.service_dependencies" }}
   {{- template "barbican.db_service" . }}
 {{- end }}
+
+{{- define "job_name" }}
+  {{- $name := index . 1 }}
+  {{- with index . 0 }}
+    {{- $all := list
+          (include (print .Template.BasePath "/etc-configmap.yaml") .)
+          (include (print .Template.BasePath "/secrets.yaml") .)
+          (include "utils.proxysql.job_pod_settings" .)
+          (include "utils.proxysql.volume_mount" .)
+          (include "utils.proxysql.container" .)
+          (include "utils.proxysql.volumes" .)
+          (tuple . (dict) | include "utils.snippets.kubernetes_entrypoint_init_container")
+      | join "\n" }}
+    {{- $hash := empty .Values.proxysql.mode | ternary "" $all | sha256sum }}
+{{- .Release.Name }}-{{ $name }}-{{ substr 0 4 $hash }}-{{ .Values.imageVersionBarbicanApi | required "Please set barbican.imageVersionBarbicanApi" }}
+  {{- end }}
+{{- end }}

--- a/openstack/barbican/templates/migration-job.yaml
+++ b/openstack/barbican/templates/migration-job.yaml
@@ -1,20 +1,12 @@
 {{- $secrets := lookup "v1" "Secret" .Release.Namespace (print .Release.Name "-secrets") -}}
-{{- $serviceaccount := lookup "v1" "ServiceAccount" .Release.Namespace .Release.Name -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: barbican-migration-job
+  name: {{ tuple . "migration-job" | include "job_name" }}
   labels:
     system: openstack
     type: configuration
     component: barbican
-    # hooks are not annotated as belonging to the Helm release, so we cannot rely on owner-info injection
-    ccloud/support-group: identity
-    ccloud/service: barbican
-  annotations:
-    "helm.sh/hook": "post-install,pre-upgrade"
-    "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   template:
     metadata:
@@ -25,7 +17,7 @@ spec:
       annotations:
 {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
-      {{- if $serviceaccount }}
+      {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ .Release.Name }}
       {{- end }}
       restartPolicy: OnFailure


### PR DESCRIPTION
On first install the release SA is not applied yet, so the hook pod runs under `monsoon3/default`. The entrypoint endpointslices check then returns 403, and the deployment fails.

* drop hook annotations
* hash-suffixed job name like nova/cinder
* guard SA on `.Values.rbac.enabled`

`monsoon3/default` global cluster reader role will be removed soon in https://github.com/sapcc/helm-charts/pull/11677 , so this job wouldn't be able to run without service-specific rbac role.
