### PR TITLE
federation job for castellum

### DIFF
--- a/system/storage-monitoring/Chart.yaml
+++ b/system/storage-monitoring/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: storage-monitoring
 description: Prometheus and Thanos setup for netapp-exporter 
-version: 0.7.11
+version: 0.7.12
 dependencies:
   - name: prometheus-server
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/system/storage-monitoring/templates/_prometheus-storage.yaml.tpl
+++ b/system/storage-monitoring/templates/_prometheus-storage.yaml.tpl
@@ -1,3 +1,4 @@
+{{- if .Values.netapp_cap_exporter.enabled }}
 {{- range $name, $app := .Values.netapp_cap_exporter.apps }}
 - job_name: '{{ $app.fullname }}'
   scrape_interval: {{ required ".Values.netapp_cap_exporter.apps[].scrapeInterval" $app.scrapeInterval }}
@@ -15,3 +16,18 @@
       replacement: ${1}
       action: replace
 {{- end }}
+{{- end }}
+
+# exception for castellum to shift load from thanos-metal-query
+- job_name: 'prometheus-openstack-federation'
+  scrape_interval: 1m
+  scrape_timeout: 55s
+  static_configs:
+    - targets: ['prometheus-openstack.prometheus-openstack:9090']
+  metrics_path: '/federate'
+  params:
+    'match[]':
+      - '{__name__="manila_share_exclusion_reasons_for_castellum"}'
+  metric_relabel_configs:
+    - regex: "cluster|cluster_type|prometheus|prometheus_replica|region"
+      action: labeldrop

--- a/system/storage-monitoring/templates/storage-additional-scrape-config.yaml
+++ b/system/storage-monitoring/templates/storage-additional-scrape-config.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.netapp_cap_exporter.enabled }}
 apiVersion: v1
 kind: Secret
 
@@ -9,4 +8,3 @@ metadata:
 
 data:
   scrape-config.yaml: {{ include (print $.Template.BasePath "/_prometheus-storage.yaml.tpl") . | b64enc }}
-{{- end }}


### PR DESCRIPTION
This enables castellum to entirely avoid the thanos query and shifts all load against prometheus-storage.