### PR TITLE
[manila_amo] updated 'absent-metrics-operator/disable=true' label for thanos-ruler alerts

### DIFF
--- a/openstack/manila/Chart.yaml
+++ b/openstack/manila/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 name: manila
 sources:
   - https://github.com/sapcc/manila
-version: 0.7.0
+version: 0.7.1
 dependencies:
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/openstack/manila/templates/prometheus-alerts.yaml
+++ b/openstack/manila/templates/prometheus-alerts.yaml
@@ -16,6 +16,10 @@ metadata:
     tier: os
     type: alerting-rules
     {{ $ruler }}: {{ $cluster| required (printf ".Values.alerts.prometheus.%s missing" $target) }}
+    {{- if eq $ruler "thanos-ruler" }}
+    # Disable absent-metrics-operator (AMO) for Thanos-Ruler alerts.
+    absent-metrics-operator/disable: "true"
+    {{- end }}
 spec:
 {{ printf "%s" $bytes | indent 2 }}
 


### PR DESCRIPTION
GIthub issue:
https://github.wdf.sap.corp/sap-cloud-infrastructure/observability-issues/issues/884