### PR TITLE
[neutorn_amo] updated 'absent-metrics-operator/disable=true' label for thanos-ruler alerts

### DIFF
--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for Openstack Neutron
 name: neutron
-version: 0.3.7
+version: 0.3.8
 appVersion: "caracal"
 dependencies:
   - condition: mariadb.enabled

--- a/openstack/neutron/templates/prometheus-alerts.yaml
+++ b/openstack/neutron/templates/prometheus-alerts.yaml
@@ -12,6 +12,10 @@ metadata:
     tier: os
     type: alerting-rules
     {{ $target.type | required (printf "$values.alerts.prometheus.[%v].type missing" $i) }}: {{ $target.name | required (printf "$values.alerts.prometheus.[%v].name missing" $i) }}
+    {{- if eq $target.type "thanos-ruler" }}
+    # Disable absent-metrics-operator (AMO) for Thanos-Ruler alerts.
+    absent-metrics-operator/disable: "true"
+    {{- end }}
 spec:
 {{ printf "%s" $bytes | indent 2 }}
 {{- end }}


### PR DESCRIPTION
GIthub issue:
https://github.wdf.sap.corp/sap-cloud-infrastructure/observability-issues/issues/884