### PR TITLE
[nova_amo] updated 'absent-metrics-operator/disable=true' label for thanos-ruler alerts

### DIFF
--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 name: nova
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Nova/OpenStack_Project_Nova_mascot.png
-version: 0.6.6
+version: 0.6.7
 appVersion: "bobcat"
 dependencies:
   - condition: mariadb.enabled

--- a/openstack/nova/templates/prometheus-alerts.yaml
+++ b/openstack/nova/templates/prometheus-alerts.yaml
@@ -14,6 +14,8 @@ metadata:
     type: alerting-rules
     {{- if eq (first (splitList "-" $target)) "metrics" }}
     thanos-ruler: {{ trimPrefix "metrics-" $target }}
+    # Disable absent-metrics-operator (AMO) for Thanos-Ruler alerts.
+    absent-metrics-operator/disable: "true"
     {{- else }}
     prometheus: {{ $target }}
     {{- end }}


### PR DESCRIPTION
GIthub issue:
https://github.wdf.sap.corp/sap-cloud-infrastructure/observability-issues/issues/884