### PR TITLE
[impi_exporter] updated 'absent-metrics-operator/disable=true' label for thanos-ruler alerts

### DIFF
--- a/prometheus-exporters/ipmi-exporter/Chart.yaml
+++ b/prometheus-exporters/ipmi-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes
 name: ipmi-exporter
-version: 0.1.2
+version: 0.1.3
 maintainers:
   - name: Stefan Hipfel (D058695)
 dependencies:

--- a/prometheus-exporters/ipmi-exporter/templates/aggregations.yaml
+++ b/prometheus-exporters/ipmi-exporter/templates/aggregations.yaml
@@ -11,6 +11,8 @@ metadata:
   labels:
     type: aggregation-rules
     thanos-ruler: regional
+    # Disable absent-metrics-operator (AMO) for Thanos-Ruler alerts.
+    absent-metrics-operator/disable: "true"
 
 spec:
 {{ printf "%s" $bytes | indent 2 }}

--- a/prometheus-exporters/ipmi-exporter/templates/alerts.yaml
+++ b/prometheus-exporters/ipmi-exporter/templates/alerts.yaml
@@ -11,6 +11,8 @@ metadata:
   labels:
     type: alerting-rules
     thanos-ruler: metal
+    # Disable absent-metrics-operator (AMO) for Thanos-Ruler alerts.
+    absent-metrics-operator/disable: "true"
 spec:
 {{ printf "%s" $bytes | indent 2 }}
 


### PR DESCRIPTION
GIthub issue:
https://github.wdf.sap.corp/sap-cloud-infrastructure/observability-issues/issues/884