### PR TITLE
[netapp_exporter_amo] updated 'absent-metrics-operator/disable=true' label for thanos-ruler alerts

### DIFF
--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/Chart.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: NetApp Harvest exporter
 name: netapp-harvest-exporter
 type: application
-version: 0.2.15
+version: 0.2.16
 # Changes
 # v0.1.2: - fix incosistent cluster labels
 # v0.1.3: - fix multiple scraping problem when filers in maintenance

--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/templates/alerts.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/templates/alerts.yaml
@@ -10,6 +10,8 @@ metadata:
     type: alerting-rules
     {{- if eq (first (splitList "-" $target)) "thanos" }}
     thanos-ruler: {{ trimPrefix "thanos-" $target }}
+    # Disable absent-metrics-operator (AMO) for Thanos-Ruler alerts.
+    absent-metrics-operator/disable: "true"
     {{- else }}
     prometheus: {{ $target }}
     {{- end }}


### PR DESCRIPTION
GIthub issue:
https://github.wdf.sap.corp/sap-cloud-infrastructure/observability-issues/issues/884