### PR TITLE
[redfish_exporter_amo]updated 'absent-metrics-operator/disable=true' label for thanos-ruler alerts

### DIFF
--- a/prometheus-exporters/redfish-exporter/Chart.yaml
+++ b/prometheus-exporters/redfish-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes
 name: redfish-exporter
-version: 0.2.0
+version: 0.2.1
 maintainers:
   - name: Bernd Kuespert (D032408)
 icon: http://www.dmtf.org/sites/default/files/dmtf-redfish-logo.png

--- a/prometheus-exporters/redfish-exporter/templates/alerts.yaml
+++ b/prometheus-exporters/redfish-exporter/templates/alerts.yaml
@@ -14,6 +14,8 @@ metadata:
   {{- if contains "metal-redfish-esxi" $path }}
     # metal-esxi alerts, which combine metrics from infra-collector and vmware, are available from the thanos regional query.
     thanos-ruler: regional
+    # Disable absent-metrics-operator (AMO) for Thanos-Ruler alerts.
+    absent-metrics-operator/disable: "true"
   {{- else }}
     prometheus: {{ required "$values.prometheus missing" $values.prometheus }}
   {{- end }}


### PR DESCRIPTION
GIthub issue:
https://github.wdf.sap.corp/sap-cloud-infrastructure/observability-issues/issues/884