### PR TITLE
limes: bring v2 data metrics to prod

### DIFF
--- a/openstack/limes/templates/deployment-data-metrics-v2.yaml
+++ b/openstack/limes/templates/deployment-data-metrics-v2.yaml
@@ -1,5 +1,3 @@
-{{- if .Values.global.db_region | hasPrefix "qa" }}
-
 kind: Deployment
 apiVersion: apps/v1
 
@@ -65,5 +63,3 @@ spec:
                 cpu: '100m'
                 memory: '500Mi'
           {{- end }}
-
-{{- end }}

--- a/openstack/limes/templates/podmonitor-data-metrics-v2.yaml
+++ b/openstack/limes/templates/podmonitor-data-metrics-v2.yaml
@@ -1,8 +1,6 @@
 {{- $region    := .Values.global.region    | required "missing value for .Values.global.region"    -}}
 {{- $db_region := .Values.global.db_region | required "missing value for .Values.global.db_region" -}}
 
-{{- if $db_region | hasPrefix "qa" -}}
-
 {{- $region_label := $region -}}
 {{- if and (eq $region "global") ($db_region | hasPrefix "qa") -}}
   {{- $region_label = "global-qa" -}}
@@ -51,5 +49,3 @@ spec:
         - action: replace
           targetLabel: region
           replacement: {{ quote $region_label }}
-
-{{- end }}


### PR DESCRIPTION
The respective Prometheus instance `obs-metrics-product-limitas` is not deployed in all regions yet, so this pod will sit unused until the Prometheus appears and starts scraping it. Tommy told me that this is safe; there are no alerts or anything when a `prometheus` label does not match an actual Prometheus instance.