### PR TITLE
[kvm-cinder-netapp-operator] bump dependency and app versions

### DIFF
--- a/openstack/kvm-cinder-netapp-operator/Chart.lock
+++ b/openstack/kvm-cinder-netapp-operator/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 1.0.0
 - name: kvm-cinder-netapp-operator
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.4.6
-digest: sha256:b4faa6492a36ba404292e660b42c60a764e7694f028f8a5566306cbb210e11f4
-generated: "2026-05-08T10:26:45.518154194+02:00"
+  version: 0.4.7
+digest: sha256:e76f482ff7c062b1bd81b060d7b6734937777edf3fe85d83e7a7127e7115b9b4
+generated: "2026-07-21T17:36:56.716952091+02:00"

--- a/openstack/kvm-cinder-netapp-operator/Chart.yaml
+++ b/openstack/kvm-cinder-netapp-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: A Helm chart for the kvm-cinder-netapp-operator
 name: kvm-cinder-netapp-operator
-version: 0.4.6
-appVersion: "0.4.1"
+version: 0.4.7
+appVersion: "0.4.4"
 dependencies:
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
@@ -12,4 +12,4 @@ dependencies:
   version: ~1.0.0
 - name: kvm-cinder-netapp-operator
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: ~0.4.5
+  version: ~0.4.7


### PR DESCRIPTION
Forgot to bump helm chart versions last time I updated them in the operator repository and was wondering why some changes weren't showing up.