### PR TITLE
fix(kube-monitoring-*): upgrade images to fix Critical CVEs

### DIFF
--- a/system/kube-monitoring-admin-k3s/Chart.lock
+++ b/system/kube-monitoring-admin-k3s/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.0.10
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
-  version: 5.30.1
+  version: 8.0.0
 - name: kube-state-metrics-exporter
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.1
@@ -25,7 +25,7 @@ dependencies:
   version: 1.10.9
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
-  version: 4.46.0
+  version: 4.56.1
 - name: kubernikus-monitoring
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.2.1
@@ -43,6 +43,6 @@ dependencies:
   version: 0.1.5
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
-  version: 3.13.0
-digest: sha256:178d483405145cf3d64c8fc1ce7c75e551b42102e5145ff16ecf24efbf2a3964
-generated: "2026-05-27T12:03:42.518505+02:00"
+  version: 4.1.0
+digest: sha256:a2610d8996f017ade976312305c7ecac6c9e77b3f6b0dbcaaee32345de0dcaed
+generated: "2026-07-22T07:44:43.209723+02:00"

--- a/system/kube-monitoring-admin-k3s/Chart.yaml
+++ b/system/kube-monitoring-admin-k3s/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes admin k3s cluster monitoring.
 name: kube-monitoring-admin-k3s
-version: 4.8.0
+version: 4.8.1
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-admin-k3s
 dependencies:
   - condition: absent-metrics-operator.enabled
@@ -11,7 +11,7 @@ dependencies:
     version: "^1"
   - name: kube-state-metrics
     repository: https://prometheus-community.github.io/helm-charts
-    version: 5.30.1
+    version: 8.0.0
   - name: kube-state-metrics-exporter
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.2.1
@@ -33,7 +33,7 @@ dependencies:
     version: "^1.10"
   - name: prometheus-node-exporter
     repository: https://prometheus-community.github.io/helm-charts
-    version: 4.46.0
+    version: 4.56.1
   - name: kubernikus-monitoring
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.2.1
@@ -52,5 +52,5 @@ dependencies:
     version: 0.1.5
   - name: x509-certificate-exporter
     repository: https://charts.enix.io
-    version: 3.13.0
+    version: 4.1.0
     condition: x509-certificate-exporter.enabled

--- a/system/kube-monitoring-admin-k3s/values.yaml
+++ b/system/kube-monitoring-admin-k3s/values.yaml
@@ -166,6 +166,7 @@ prometheus-node-exporter:
     image:
       registry: keppel.global.cloud.sap
       repository: ccloud-quay-mirror/brancz/kube-rbac-proxy
+      tag: v0.22.1
 
   extraArgs:
     - --collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)

--- a/system/kube-monitoring-kubernikus/Chart.lock
+++ b/system/kube-monitoring-kubernikus/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.0.10
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
-  version: 5.30.1
+  version: 8.0.0
 - name: kube-state-metrics-exporter
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.1
@@ -31,7 +31,7 @@ dependencies:
   version: 1.10.9
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
-  version: 4.46.0
+  version: 4.56.1
 - name: promtail
   repository: https://grafana.github.io/helm-charts
   version: 0.18.1
@@ -52,6 +52,6 @@ dependencies:
   version: 0.1.5
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
-  version: 3.13.0
-digest: sha256:0cf11d9241f24ad769252376067d47a04743408e9d15f357eb7691ce8b40c8ef
-generated: "2026-05-27T12:03:59.387529+02:00"
+  version: 4.1.0
+digest: sha256:fef282f70aa05cb16cf357ee1e90d07cb6b354ce64fed2e7e2f8f09eb156f23a
+generated: "2026-07-22T07:44:33.789065+02:00"

--- a/system/kube-monitoring-kubernikus/Chart.yaml
+++ b/system/kube-monitoring-kubernikus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for monitoring Kubernikus.
 name: kube-monitoring-kubernikus
-version: 7.10.0
+version: 7.10.1
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-kubernikus
 dependencies:
   - condition: absent-metrics-operator.enabled
@@ -11,7 +11,7 @@ dependencies:
     version: "^1"
   - name: kube-state-metrics
     repository: https://prometheus-community.github.io/helm-charts
-    version: 5.30.1
+    version: 8.0.0
   - name: kube-state-metrics-exporter
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.2.1
@@ -40,7 +40,7 @@ dependencies:
     version: "^1.10"
   - name: prometheus-node-exporter
     repository: https://prometheus-community.github.io/helm-charts
-    version: 4.46.0
+    version: 4.56.1
   - name: promtail
     repository: https://grafana.github.io/helm-charts
     version: 0.18.1
@@ -63,5 +63,5 @@ dependencies:
     version: 0.1.5
   - name: x509-certificate-exporter
     repository: https://charts.enix.io
-    version: 3.13.0
+    version: 4.1.0
     condition: x509-certificate-exporter.enabled

--- a/system/kube-monitoring-kubernikus/values.yaml
+++ b/system/kube-monitoring-kubernikus/values.yaml
@@ -61,6 +61,7 @@ prometheus-node-exporter:
     image:
       registry: keppel.global.cloud.sap
       repository: ccloud-quay-mirror/brancz/kube-rbac-proxy
+      tag: v0.22.1
 
   extraArgs:
     - --collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)

--- a/system/kube-monitoring-metal/Chart.lock
+++ b/system/kube-monitoring-metal/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 2.3.3
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
-  version: 5.30.1
+  version: 8.0.0
 - name: kube-state-metrics-exporter
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.1
@@ -28,7 +28,7 @@ dependencies:
   version: 1.10.9
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
-  version: 4.46.0
+  version: 4.56.1
 - name: http-keep-alive-monitor
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.4.8
@@ -46,6 +46,6 @@ dependencies:
   version: 0.1.5
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
-  version: 3.13.0
-digest: sha256:1c377f54effc952e2ccac6750e6d744ae51474afd7dbb6e5d3cc87631d671933
-generated: "2026-05-27T12:04:20.91357+02:00"
+  version: 4.1.0
+digest: sha256:5527e211c6e2cece1a48f199cdded6bf2adfa9a4c5e3111724cfa8b98e389a6a
+generated: "2026-07-22T07:44:07.95187+02:00"

--- a/system/kube-monitoring-metal/Chart.yaml
+++ b/system/kube-monitoring-metal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes metal controlplane monitoring.
 name: kube-monitoring-metal
-version: 4.11.1
+version: 4.11.2
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-metal
 dependencies:
   - condition: absent-metrics-operator.enabled
@@ -14,7 +14,7 @@ dependencies:
     version: "^2.3"
   - name: kube-state-metrics
     repository: https://prometheus-community.github.io/helm-charts
-    version: 5.30.1
+    version: 8.0.0
   - name: kube-state-metrics-exporter
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.2.1
@@ -35,7 +35,7 @@ dependencies:
     version: "^1.10"
   - name: prometheus-node-exporter
     repository: https://prometheus-community.github.io/helm-charts
-    version: 4.46.0
+    version: 4.56.1
   - name: http-keep-alive-monitor
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.4.8
@@ -54,5 +54,5 @@ dependencies:
     version: 0.1.5
   - name: x509-certificate-exporter
     repository: https://charts.enix.io
-    version: 3.13.0
+    version: 4.1.0
     condition: x509-certificate-exporter.enabled

--- a/system/kube-monitoring-metal/values.yaml
+++ b/system/kube-monitoring-metal/values.yaml
@@ -62,6 +62,7 @@ prometheus-node-exporter:
     image:
       registry: keppel.global.cloud.sap
       repository: ccloud-quay-mirror/brancz/kube-rbac-proxy
+      tag: v0.22.1
 
   extraArgs:
     - --collector.filesystem.ignored-mount-points=^/(sys|proc|dev|host|etc)($$|/)

--- a/system/kube-monitoring-scaleout/Chart.lock
+++ b/system/kube-monitoring-scaleout/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.0.10
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
-  version: 5.30.1
+  version: 8.0.0
 - name: kube-state-metrics-exporter
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
@@ -22,7 +22,7 @@ dependencies:
   version: 1.10.9
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
-  version: 4.46.0
+  version: 4.56.1
 - name: prometheus-scaleout-rules
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
@@ -43,6 +43,6 @@ dependencies:
   version: 1.0.0
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
-  version: 3.13.0
-digest: sha256:b17b45d531a4e78e41132f20dfa7eeb0666e7bc2cba63ca5537130d78dd1af65
-generated: "2026-05-27T12:04:35.02667+02:00"
+  version: 4.1.0
+digest: sha256:2ba3a5a0cca6599f64b73705420fdf008513a26b2481e7c6f299baf534948efc
+generated: "2026-07-22T07:44:16.376544+02:00"

--- a/system/kube-monitoring-scaleout/Chart.yaml
+++ b/system/kube-monitoring-scaleout/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kubernetes scaleout cluster monitoring.
 name: kube-monitoring-scaleout
-version: 4.13.0
+version: 4.13.1
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-scaleout
 dependencies:
   - condition: absent-metrics-operator.enabled
@@ -10,7 +10,7 @@ dependencies:
     version: "^1"
   - name: kube-state-metrics
     repository: https://prometheus-community.github.io/helm-charts
-    version: 5.30.1
+    version: 8.0.0
   - name: kube-state-metrics-exporter
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^1.x"
@@ -28,7 +28,7 @@ dependencies:
     version: "^1.10"
   - name: prometheus-node-exporter
     repository: https://prometheus-community.github.io/helm-charts
-    version: 4.46.0
+    version: 4.56.1
   - name: prometheus-scaleout-rules
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^1.x"
@@ -50,5 +50,5 @@ dependencies:
     version: "^1.x"
   - name: x509-certificate-exporter
     repository: https://charts.enix.io
-    version: 3.13.0
+    version: 4.1.0
     condition: x509-certificate-exporter.enabled

--- a/system/kube-monitoring-scaleout/values.yaml
+++ b/system/kube-monitoring-scaleout/values.yaml
@@ -171,6 +171,7 @@ prometheus-node-exporter:
     image:
       registry: keppel.global.cloud.sap
       repository: ccloud-quay-mirror/brancz/kube-rbac-proxy
+      tag: v0.22.1
 
   extraArgs:
     - --collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)

--- a/system/kube-monitoring-virtual/Chart.lock
+++ b/system/kube-monitoring-virtual/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.0.10
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
-  version: 5.30.1
+  version: 8.0.0
 - name: kube-state-metrics-exporter
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.1
@@ -28,7 +28,7 @@ dependencies:
   version: 1.10.9
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
-  version: 4.46.0
+  version: 4.56.1
 - name: prometheus-virtual-rules
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.1
@@ -46,6 +46,6 @@ dependencies:
   version: 0.1.5
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
-  version: 3.13.0
-digest: sha256:cc44c57615873814822b860901a7e084561ce7db840ee535b8ce4d156817af10
-generated: "2026-05-27T12:04:49.310839+02:00"
+  version: 4.1.0
+digest: sha256:4262795890f241b3b8709caed20138ecdd087867d36031e7878b6880281453e5
+generated: "2026-07-22T07:44:23.557297+02:00"

--- a/system/kube-monitoring-virtual/Chart.yaml
+++ b/system/kube-monitoring-virtual/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes virtual cluster monitoring.
 name: kube-monitoring-virtual
-version: 6.11.0
+version: 6.11.1
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-virtual
 dependencies:
   - condition: absent-metrics-operator.enabled
@@ -11,7 +11,7 @@ dependencies:
     version: "^1"
   - name: kube-state-metrics
     repository: https://prometheus-community.github.io/helm-charts
-    version: 5.30.1
+    version: 8.0.0
   - name: kube-state-metrics-exporter
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.2.1
@@ -35,7 +35,7 @@ dependencies:
     version: "^1.10"
   - name: prometheus-node-exporter
     repository: https://prometheus-community.github.io/helm-charts
-    version: 4.46.0
+    version: 4.56.1
   - name: prometheus-virtual-rules
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.1.1
@@ -54,5 +54,5 @@ dependencies:
     version: 0.1.5
   - name: x509-certificate-exporter
     repository: https://charts.enix.io
-    version: 3.13.0
+    version: 4.1.0
     condition: x509-certificate-exporter.enabled

--- a/system/kube-monitoring-virtual/values.yaml
+++ b/system/kube-monitoring-virtual/values.yaml
@@ -164,6 +164,7 @@ prometheus-node-exporter:
     image:
       registry: keppel.global.cloud.sap
       repository: ccloud-quay-mirror/brancz/kube-rbac-proxy
+      tag: v0.22.1
 
   extraArgs:
     - --collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)


### PR DESCRIPTION
Upgrades the following components across all kube-monitoring chart variants:
- prometheus-node-exporter: 4.46.0 -> 4.56.1 (v1.12.1, Go 1.25.0)
- kube-state-metrics: 5.30.1 -> 8.0.0 (v2.19.1, Go 1.25.0, grpc v1.79.3)
- x509-certificate-exporter: 3.13.0 -> 4.1.0 (Go 1.26.2)
- kube-rbac-proxy: explicit tag v0.22.1 (Go 1.26.5, grpc v1.80.0)

CVEs fixed:
- CVE-2025-22871 (Critical) Go net/http request smuggling
- CVE-2026-33186 (Critical) grpc authorization bypass

Ref: https://github.wdf.sap.corp/cc/unified-kubernetes/issues/1355