### PR TITLE
[neutron] bump helm chart dependencies

### DIFF
--- a/openstack/neutron/Chart.lock
+++ b/openstack/neutron/Chart.lock
@@ -7,13 +7,13 @@ dependencies:
   version: 0.6.0
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.6.9
+  version: 0.6.18
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.8.1
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.25.4
+  version: 0.25.7
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.38.0
@@ -22,7 +22,7 @@ dependencies:
   version: 1.0.0
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 2.2.19
+  version: 2.4.72
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
@@ -32,5 +32,5 @@ dependencies:
 - name: ovsdb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.0
-digest: sha256:56c36cba7f763b40a64ed658b2e0079d5bbb7d05983d53f6688cc4679fe6f124
-generated: "2026-07-08T13:41:51.382357+03:00"
+digest: sha256:2b5d73cb1f213b76ff6e55deab2da3398a31ffabefca0f1c954a1616004a2f40
+generated: "2026-07-22T10:07:55.006327656+02:00"

--- a/openstack/neutron/Chart.yaml
+++ b/openstack/neutron/Chart.yaml
@@ -16,14 +16,14 @@ dependencies:
     version: 0.6.0
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.6.9
+    version: 0.6.18
   - condition: mariadb.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.8.1
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.25.4
+    version: 0.25.7
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.38.0
@@ -33,7 +33,7 @@ dependencies:
   - name: redis
     alias: api-ratelimit-redis
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 2.2.19
+    version: 2.4.72
     condition: rate_limit.enabled
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm


### PR DESCRIPTION
Bumping versions:

- memcached 0.6.9 ->  0.6.18
  - updating base images, exporter and memcached versions
  - fixes for TLS, SASL and proxy
  - setting vpa main container
- rabbitmq  0.25.4 -> 0.25.7
  - updating rabbitmq and credential updater version
  - skipping linkerd for TLS listener port
  - fix for permissions on empty pvc
- redis 2.2.19 -> 2.4.72
  - switch to inhouse-built redis_exporter
  - update to Valkey 9