### PR TITLE
fix(kube-monitoring-*): fix x509-certificate-exporter v4.1.0 schema issues

### DIFF
--- a/system/kube-monitoring-admin-k3s/Chart.lock
+++ b/system/kube-monitoring-admin-k3s/Chart.lock
@@ -44,5 +44,5 @@ dependencies:
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
   version: 4.1.0
-digest: sha256:a2610d8996f017ade976312305c7ecac6c9e77b3f6b0dbcaaee32345de0dcaed
-generated: "2026-07-22T11:17:36.965104+02:00"
+digest: sha256:8d39dced61a2ae84bd32004e06ede45ab07ca4785a396eaaa5908cda5cf4e3be
+generated: "2026-07-22T12:31:06.381154+02:00"

--- a/system/kube-monitoring-admin-k3s/Chart.yaml
+++ b/system/kube-monitoring-admin-k3s/Chart.yaml
@@ -53,4 +53,3 @@ dependencies:
   - name: x509-certificate-exporter
     repository: https://charts.enix.io
     version: 4.1.0
-    condition: x509-certificate-exporter.enabled

--- a/system/kube-monitoring-admin-k3s/Chart.yaml
+++ b/system/kube-monitoring-admin-k3s/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes admin k3s cluster monitoring.
 name: kube-monitoring-admin-k3s
-version: 4.8.2
+version: 4.8.3
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-admin-k3s
 dependencies:
   - condition: absent-metrics-operator.enabled

--- a/system/kube-monitoring-admin-k3s/values.yaml
+++ b/system/kube-monitoring-admin-k3s/values.yaml
@@ -292,7 +292,6 @@ falco:
           tag: pci
 
 x509-certificate-exporter:
-  enabled: true
   secretsExporter:
     podAnnotations:
       prometheus.io/port: "9793"

--- a/system/kube-monitoring-admin-k3s/values.yaml
+++ b/system/kube-monitoring-admin-k3s/values.yaml
@@ -292,7 +292,7 @@ falco:
           tag: pci
 
 x509-certificate-exporter:
-  enabled: false
+  enabled: true
   secretsExporter:
     podAnnotations:
       prometheus.io/port: "9793"

--- a/system/kube-monitoring-kubernikus/Chart.lock
+++ b/system/kube-monitoring-kubernikus/Chart.lock
@@ -53,5 +53,5 @@ dependencies:
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
   version: 4.1.0
-digest: sha256:fef282f70aa05cb16cf357ee1e90d07cb6b354ce64fed2e7e2f8f09eb156f23a
-generated: "2026-07-22T11:17:24.769555+02:00"
+digest: sha256:2856878311508d4ef6bbf35a65cb8cd7ee86b90182861986bc59840e959368da
+generated: "2026-07-22T12:30:53.2674+02:00"

--- a/system/kube-monitoring-kubernikus/Chart.yaml
+++ b/system/kube-monitoring-kubernikus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for monitoring Kubernikus.
 name: kube-monitoring-kubernikus
-version: 7.10.2
+version: 7.10.3
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-kubernikus
 dependencies:
   - condition: absent-metrics-operator.enabled

--- a/system/kube-monitoring-kubernikus/Chart.yaml
+++ b/system/kube-monitoring-kubernikus/Chart.yaml
@@ -64,4 +64,3 @@ dependencies:
   - name: x509-certificate-exporter
     repository: https://charts.enix.io
     version: 4.1.0
-    condition: x509-certificate-exporter.enabled

--- a/system/kube-monitoring-kubernikus/values.yaml
+++ b/system/kube-monitoring-kubernikus/values.yaml
@@ -197,7 +197,6 @@ falco:
           tag: pci
 
 x509-certificate-exporter:
-  enabled: true
   secretsExporter:
     podAnnotations:
       prometheus.io/port: "9793"

--- a/system/kube-monitoring-kubernikus/values.yaml
+++ b/system/kube-monitoring-kubernikus/values.yaml
@@ -197,7 +197,7 @@ falco:
           tag: pci
 
 x509-certificate-exporter:
-  enabled: false
+  enabled: true
   secretsExporter:
     podAnnotations:
       prometheus.io/port: "9793"

--- a/system/kube-monitoring-metal/Chart.lock
+++ b/system/kube-monitoring-metal/Chart.lock
@@ -47,5 +47,5 @@ dependencies:
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
   version: 4.1.0
-digest: sha256:5527e211c6e2cece1a48f199cdded6bf2adfa9a4c5e3111724cfa8b98e389a6a
-generated: "2026-07-22T11:16:59.340571+02:00"
+digest: sha256:a516fcd145d76241378650627c15c309fb062b9f9ee17983479d5db81a6ae96e
+generated: "2026-07-22T12:30:29.89932+02:00"

--- a/system/kube-monitoring-metal/Chart.yaml
+++ b/system/kube-monitoring-metal/Chart.yaml
@@ -55,4 +55,3 @@ dependencies:
   - name: x509-certificate-exporter
     repository: https://charts.enix.io
     version: 4.1.0
-    condition: x509-certificate-exporter.enabled

--- a/system/kube-monitoring-metal/Chart.yaml
+++ b/system/kube-monitoring-metal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes metal controlplane monitoring.
 name: kube-monitoring-metal
-version: 4.11.3
+version: 4.11.4
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-metal
 dependencies:
   - condition: absent-metrics-operator.enabled

--- a/system/kube-monitoring-metal/values.yaml
+++ b/system/kube-monitoring-metal/values.yaml
@@ -146,7 +146,7 @@ falco:
           tag: pci
 
 x509-certificate-exporter:
-  enabled: false
+  enabled: true
   secretsExporter:
     podAnnotations:
       prometheus.io/port: "9793"

--- a/system/kube-monitoring-metal/values.yaml
+++ b/system/kube-monitoring-metal/values.yaml
@@ -146,7 +146,6 @@ falco:
           tag: pci
 
 x509-certificate-exporter:
-  enabled: true
   secretsExporter:
     podAnnotations:
       prometheus.io/port: "9793"

--- a/system/kube-monitoring-scaleout/Chart.lock
+++ b/system/kube-monitoring-scaleout/Chart.lock
@@ -44,5 +44,5 @@ dependencies:
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
   version: 4.1.0
-digest: sha256:2ba3a5a0cca6599f64b73705420fdf008513a26b2481e7c6f299baf534948efc
-generated: "2026-07-22T11:17:07.927405+02:00"
+digest: sha256:553fce7b3a0ba8f128ea00947417c855a2c0c967e4eabd7f1d3b7bb41748f3f2
+generated: "2026-07-22T12:30:38.317705+02:00"

--- a/system/kube-monitoring-scaleout/Chart.yaml
+++ b/system/kube-monitoring-scaleout/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kubernetes scaleout cluster monitoring.
 name: kube-monitoring-scaleout
-version: 4.13.2
+version: 4.13.3
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-scaleout
 dependencies:
   - condition: absent-metrics-operator.enabled

--- a/system/kube-monitoring-scaleout/Chart.yaml
+++ b/system/kube-monitoring-scaleout/Chart.yaml
@@ -51,4 +51,3 @@ dependencies:
   - name: x509-certificate-exporter
     repository: https://charts.enix.io
     version: 4.1.0
-    condition: x509-certificate-exporter.enabled

--- a/system/kube-monitoring-scaleout/values.yaml
+++ b/system/kube-monitoring-scaleout/values.yaml
@@ -243,7 +243,7 @@ falco:
           tag: pci
 
 x509-certificate-exporter:
-  enabled: false
+  enabled: true
   secretsExporter:
     podAnnotations:
       prometheus.io/port: "9793"

--- a/system/kube-monitoring-scaleout/values.yaml
+++ b/system/kube-monitoring-scaleout/values.yaml
@@ -243,7 +243,6 @@ falco:
           tag: pci
 
 x509-certificate-exporter:
-  enabled: true
   secretsExporter:
     podAnnotations:
       prometheus.io/port: "9793"

--- a/system/kube-monitoring-virtual/Chart.lock
+++ b/system/kube-monitoring-virtual/Chart.lock
@@ -47,5 +47,5 @@ dependencies:
 - name: x509-certificate-exporter
   repository: https://charts.enix.io
   version: 4.1.0
-digest: sha256:4262795890f241b3b8709caed20138ecdd087867d36031e7878b6880281453e5
-generated: "2026-07-22T11:17:16.653058+02:00"
+digest: sha256:efe1ad42df59cf840b02c31be7aa5ecf14d0bbd7743d2014ad2aadcf9e7b00d6
+generated: "2026-07-22T12:30:45.253522+02:00"

--- a/system/kube-monitoring-virtual/Chart.yaml
+++ b/system/kube-monitoring-virtual/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes virtual cluster monitoring.
 name: kube-monitoring-virtual
-version: 6.11.2
+version: 6.11.3
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-virtual
 dependencies:
   - condition: absent-metrics-operator.enabled

--- a/system/kube-monitoring-virtual/Chart.yaml
+++ b/system/kube-monitoring-virtual/Chart.yaml
@@ -55,4 +55,3 @@ dependencies:
   - name: x509-certificate-exporter
     repository: https://charts.enix.io
     version: 4.1.0
-    condition: x509-certificate-exporter.enabled

--- a/system/kube-monitoring-virtual/values.yaml
+++ b/system/kube-monitoring-virtual/values.yaml
@@ -239,7 +239,6 @@ falco:
           tag: pci
 
 x509-certificate-exporter:
-  enabled: true
   secretsExporter:
     podAnnotations:
       prometheus.io/port: "9793"

--- a/system/kube-monitoring-virtual/values.yaml
+++ b/system/kube-monitoring-virtual/values.yaml
@@ -239,7 +239,7 @@ falco:
           tag: pci
 
 x509-certificate-exporter:
-  enabled: false
+  enabled: true
   secretsExporter:
     podAnnotations:
       prometheus.io/port: "9793"


### PR DESCRIPTION
## Summary

Follow-up to #12376. Fixes schema-related issues introduced by upgrading
x509-certificate-exporter from 3.13.0 to 4.1.0.

## Problems fixed

### 1. Schema violation: `enabled` not allowed at root level

x509-certificate-exporter v4.1.0 introduced a strict JSON schema that
does not allow `enabled` as an additional property at root level.
This affected both the `enabled: true` in kube-secrets values and the
`enabled: false` defaults in chart values.yaml files.

**Fix:** Removed `enabled` field entirely from all 5 `values.yaml` files
and removed `condition: x509-certificate-exporter.enabled` from all 5
`Chart.yaml` files. Since all clusters deploy x509, no condition is needed.
The chart is always deployed — `secretsExporter.enabled: true` is the
chart default.

### 2. `daemonSets: null` schema violation

v4.1.0 schema requires a map for `hostPathsExporter.daemonSets`, not `null`.

**Fix:** Changed `daemonSets: null` to `daemonSets: {}` in all 5 values files.

### 3. `Chart.lock` out of sync

Updated `Chart.lock` via `helm dep update` after Chart.yaml changes.

## Ref

https://github.wdf.sap.corp/cc/unified-kubernetes/issues/1355