### PR TITLE
feat(cc-runtime-cluster): add cloud-provider-metal templates

### DIFF
--- a/system/cc-runtime-cluster/Chart.yaml
+++ b/system/cc-runtime-cluster/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-runtime-cluster
 description: Converged Cloud Cluster API Runtime Cluster
 type: application
-version: 0.8.3
+version: 0.9.0
 appVersion: "0.1.0"

--- a/system/cc-runtime-cluster/ci/test-values.yaml
+++ b/system/cc-runtime-cluster/ci/test-values.yaml
@@ -71,3 +71,8 @@ user:
   name: admin
   passwordhash: "$6$randomsalt$hashedpassword"
   key: "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEArandomkey"
+
+cloudProviderMetal:
+  image:
+    repository: example.io/metal-cloud-controller-manager
+    tag: latest

--- a/system/cc-runtime-cluster/templates/cloud-provider-metal-crs.yaml
+++ b/system/cc-runtime-cluster/templates/cloud-provider-metal-crs.yaml
@@ -1,0 +1,84 @@
+{{- if $.Values.cloudProviderMetal.enabled }}
+{{- range $cluster := .Values.clusters }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cr-seed-ccm-rbac
+  namespace: {{ $cluster.namespace }}
+type: addons.cluster.x-k8s.io/resource-set
+stringData:
+  data: |-
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: metal:cloud-provider
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: cluster-admin
+    subjects:
+      - kind: ServiceAccount
+        name: cloud-controller-manager
+        namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: system:controller:cloud-node-controller
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - delete
+      - get
+      - patch
+      - update
+      - list
+    - apiGroups:
+      - ""
+      resources:
+      - nodes/status
+      verbs:
+      - patch
+    - apiGroups:
+      - ""
+      resources:
+      - events
+      verbs:
+      - create
+      - patch
+      - update
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: system:controller:cloud-node-controller
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: system:controller:cloud-node-controller
+    subjects:
+    - kind: ServiceAccount
+      name: cloud-node-controller
+      namespace: kube-system
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta2
+kind: ClusterResourceSet
+metadata:
+  name: cr-seed-ccm-rbac
+  namespace: {{ $cluster.namespace }}
+  labels:
+    cluster.x-k8s.io/cluster-name: {{ $cluster.name }}
+spec:
+  clusterSelector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: {{ $cluster.name }}
+  strategy: Reconcile
+  resources:
+    - kind: Secret
+      name: cr-seed-ccm-rbac
+{{- end }}
+{{- end }}

--- a/system/cc-runtime-cluster/templates/cloud-provider-metal-rbac.yaml
+++ b/system/cc-runtime-cluster/templates/cloud-provider-metal-rbac.yaml
@@ -1,0 +1,188 @@
+{{- if $.Values.cloudProviderMetal.enabled }}
+{{- range $cluster := .Values.clusters }}
+---
+# ClusterRole for accessing metal Server resources cluster-wide
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cloud-controller-manager-metal-{{ $cluster.name }}
+rules:
+  - apiGroups:
+      - metal.ironcore.dev
+    resources:
+      - servers
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cloud-controller-manager-metal-{{ $cluster.name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cloud-controller-manager-metal-{{ $cluster.name }}
+subjects:
+  - kind: ServiceAccount
+    name: cloud-controller-manager
+    namespace: {{ $cluster.namespace }}
+---
+# Role for metal resources in the CAPI namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cloud-controller-manager-metal
+  namespace: {{ $cluster.namespace }}
+rules:
+  - apiGroups:
+      - metal.ironcore.dev
+    resources:
+      - serverclaims
+    verbs:
+      - get
+      - watch
+      - list
+      - update
+      - patch
+  - apiGroups:
+      - metal.ironcore.dev
+    resources:
+      - servermaintenances
+    verbs:
+      - get
+      - watch
+      - list
+      - create
+      - delete
+      - update
+      - patch
+  - apiGroups:
+      - ipam.cluster.x-k8s.io
+    resources:
+      - ipaddressclaims
+      - ipaddresses
+    verbs:
+      - get
+      - watch
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cloud-controller-manager-metal
+  namespace: {{ $cluster.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cloud-controller-manager-metal
+subjects:
+  - kind: ServiceAccount
+    name: cloud-controller-manager
+    namespace: {{ $cluster.namespace }}
+---
+# Role for serviceaccount token creation (use-service-account-credentials)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cloud-controller-manager-role
+  namespace: {{ $cluster.namespace }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - create
+      - update
+      - patch
+      - delete
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts/token
+    verbs:
+      - get
+      - create
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cloud-controller-manager-role
+  namespace: {{ $cluster.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cloud-controller-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: cloud-controller-manager
+    namespace: {{ $cluster.namespace }}
+---
+# Role for leader election
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cloud-controller-manager-leader-election
+  namespace: {{ $cluster.namespace }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cloud-controller-manager-leader-election
+  namespace: {{ $cluster.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cloud-controller-manager-leader-election
+subjects:
+  - kind: ServiceAccount
+    name: cloud-controller-manager
+    namespace: {{ $cluster.namespace }}
+{{- end }}
+{{- end }}

--- a/system/cc-runtime-cluster/templates/cloud-provider-metal.yaml
+++ b/system/cc-runtime-cluster/templates/cloud-provider-metal.yaml
@@ -1,0 +1,143 @@
+{{- if $.Values.cloudProviderMetal.enabled }}
+{{- range $cluster := .Values.clusters }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cloud-provider-config
+  namespace: {{ $cluster.namespace }}
+data:
+  cloudprovider.conf: |
+    clusterName: {{ $cluster.name }}
+    networking:
+      configureNodeAddresses: true
+      ipamKind:
+        apiGroup: ipam.cluster.x-k8s.io
+        kind: IPAddress
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloud-controller-manager
+  namespace: {{ $cluster.namespace }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloud-controller-manager
+  namespace: {{ $cluster.namespace }}
+  labels:
+    app: kubernetes
+    role: manager
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: kubernetes
+      role: manager
+  template:
+    metadata:
+      labels:
+        app: kubernetes
+        role: manager
+    spec:
+      automountServiceAccountToken: true
+      serviceAccountName: cloud-controller-manager
+      hostNetwork: {{ default false $.Values.cloudProviderMetal.hostNetwork }}
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      tolerations:
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          value: "true"
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+        - effect: NoSchedule
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+      containers:
+        - name: manager
+          image: {{ $.Values.cloudProviderMetal.image.repository }}:{{ $.Values.cloudProviderMetal.image.tag }}
+          command:
+            - /metal-cloud-controller-manager
+          args:
+            - --cloud-provider=metal
+            - --concurrent-service-syncs=10
+            - --leader-elect=true
+            - --secure-port=10258
+            - --requestheader-client-ca-file=/etc/config/ca
+            - --use-service-account-credentials
+            - --v=2
+            - --cloud-config=/etc/kubernetes/cloudprovider/cloudprovider.conf
+            - --cluster-cidr={{ $.Values.controlplane.podSubnet }}
+            - --configure-cloud-routes=false
+            - --kubeconfig=/var/run/secrets/capi/kubeconfig
+            - --authentication-kubeconfig=/var/run/secrets/capi/kubeconfig
+            - --authorization-kubeconfig=/var/run/secrets/capi/kubeconfig
+            - --metal-namespace={{ $cluster.namespace }}
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+            - containerPort: 10258
+              name: metrics
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 2
+            httpGet:
+              path: /healthz
+              port: 10258
+              scheme: HTTPS
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 15
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /etc/config
+              name: kube-root-ca
+              readOnly: true
+            - mountPath: /etc/kubernetes/cloudprovider
+              name: cloud-provider-config
+            - mountPath: /var/run/secrets/capi
+              name: kubeconfig
+              readOnly: true
+      volumes:
+        - name: kube-root-ca
+          configMap:
+            items:
+              - key: ca.crt
+                path: ca
+            name: kube-root-ca.crt
+        - name: cloud-provider-config
+          configMap:
+            name: cloud-provider-config
+            defaultMode: 420
+        - name: kubeconfig
+          secret:
+            secretName: {{ $cluster.name }}-kubeconfig
+            items:
+              - key: value
+                path: kubeconfig
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cloud-controller-manager-metrics-service
+  namespace: {{ $cluster.namespace }}
+spec:
+  ports:
+    - name: metrics
+      targetPort: 10258
+      port: 10258
+      protocol: TCP
+  selector:
+    app: kubernetes
+    role: manager
+{{- end }}
+{{- end }}

--- a/system/cc-runtime-cluster/values.yaml
+++ b/system/cc-runtime-cluster/values.yaml
@@ -77,3 +77,9 @@ maintenanceController:
 machineHealthCheck:
   enabled: true
   nodeStartupTimeoutSeconds: 3600
+
+cloudProviderMetal:
+  enabled: true
+  image:
+    repository:
+    tag:


### PR DESCRIPTION
## Summary

Deploy cloud-provider-metal CCM per child cluster in the CAPI namespace on the management cluster. This replaces the need for a separate pipeline when using a CAPI-on-runtime setup where `cc-runtime-cluster` creates child clusters in per-cluster namespaces.

## What it does

Each child cluster entry in `.Values.clusters` gets:
- **Deployment**: CCM with kubeconfig from CAPI-generated secret (`<cluster>-kubeconfig`)
- **ConfigMap**: cloud-provider-config with cluster name and IPAM config
- **RBAC**: Roles for metal CRs (ServerClaim, Server, ServerMaintenance, IPAddress), leader election, and SA token creation
- **ClusterResourceSet**: Pushes node-controller RBAC into the child cluster

## Why

The new CAPI setup deploys child clusters into per-cluster namespaces instead of a single shared namespace. The `cloud-provider-metal` chart cannot be used as a Helm dependency because it doesn't support deploying multiple instances across different namespaces. Inlining the templates with a `range` loop over `.Values.clusters` solves this.

## Changes

| File | Change |
|------|--------|
| `Chart.yaml` | Version bump 0.8.3 → 0.9.0 |
| `values.yaml` | Added `cloudProviderMetal` section (enabled by default, image configurable externally) |
| `templates/cloud-provider-metal.yaml` | Deployment + ConfigMap + SA + Service per child cluster |
| `templates/cloud-provider-metal-rbac.yaml` | All RBAC (ClusterRole, Role, Bindings) per child cluster |
| `templates/cloud-provider-metal-crs.yaml` | ClusterResourceSet + Secret per child cluster |

## Testing

```bash
helm template test system/cc-runtime-cluster \
  --set cloudProviderMetal.enabled=true \
  --set cloudProviderMetal.image.repository=example.io/metal-cloud-controller-manager \
  --set cloudProviderMetal.image.tag=latest \
  --set controlplane.podSubnet=10.244.0.0/16 \
  --set clusters[0].name=my-cluster \
  --set clusters[0].namespace=capi-my-cluster \
  --set machineTemplate.image=test \
  --set user.name=test \
  --set user.passwordhash=test
```