### PR TITLE
[keystone-global] bump percona_cluster chart version.

### DIFF
--- a/openstack/keystone/Chart.lock
+++ b/openstack/keystone/Chart.lock
@@ -16,12 +16,12 @@ dependencies:
   version: 1.0.0
 - name: percona_cluster
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.3.3
+  version: 1.3.5
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.32.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:c10edea367d5f14d8bfb27b404a2ba4ef981593dd9a2d7cc1931dff3f454703d
-generated: "2026-06-26T15:25:34.723432+03:00"
+digest: sha256:8e82cbc084f78e131d0c41203cc14a5ddf6be22fa1551e906682f49889f70ad9
+generated: "2026-07-22T13:24:28.673972+02:00"

--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -33,7 +33,7 @@ dependencies:
   - condition: percona_cluster.enabled
     name: percona_cluster
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 1.3.3
+    version: 1.3.5
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 0.32.0


### PR DESCRIPTION
- contains a fix to make IST (faster, incremental state transfer) work.