### PR TITLE
nova: keep heal_instance_info_cache_interval running daily

### DIFF
--- a/openstack/nova/Chart.yaml
+++ b/openstack/nova/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 name: nova
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Nova/OpenStack_Project_Nova_mascot.png
-version: 0.6.6
+version: 0.6.7
 appVersion: "bobcat"
 dependencies:
   - condition: mariadb.enabled

--- a/openstack/nova/templates/etc/_nova.conf.tpl
+++ b/openstack/nova/templates/etc/_nova.conf.tpl
@@ -27,6 +27,9 @@ rpc_response_timeout = {{ .Values.rpc_response_timeout | default .Values.global.
 sync_power_state_pool_size = {{ .Values.sync_power_state_pool_size | default 500 }}
 sync_power_state_interval = {{ .Values.sync_power_state_interval | default 1200 }}
 sync_power_state_unexpected_call_stop = false
+{{- if (.Values.imageVersion | hasPrefix "bobcat" | not) }}
+heal_instance_info_cache_interval = {{ .Values.heal_instance_info_cache_interval | default 86400 }}
+{{- end }}
 
 prepare_empty_host_for_spawning_interval = 600
 


### PR DESCRIPTION
Upstream changed the default from 60 to -1 in Epoxy, disabling the periodic instance info cache heal in favour of Neutron's external events API, which now refreshes the cache on change.

Keep an infrequent run once a day in case an event is missed.