### PR TITLE
fix(kube-monitoring-kubernikus): set x509 fullnameOverride to avoid label length issue

### DIFF
--- a/system/kube-monitoring-kubernikus/Chart.yaml
+++ b/system/kube-monitoring-kubernikus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for monitoring Kubernikus.
 name: kube-monitoring-kubernikus
-version: 7.10.3
+version: 7.10.4
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-kubernikus
 dependencies:
   - condition: absent-metrics-operator.enabled

--- a/system/kube-monitoring-kubernikus/values.yaml
+++ b/system/kube-monitoring-kubernikus/values.yaml
@@ -197,6 +197,7 @@ falco:
           tag: pci
 
 x509-certificate-exporter:
+  fullnameOverride: "x509"
   secretsExporter:
     podAnnotations:
       prometheus.io/port: "9793"


### PR DESCRIPTION
## Problem

The pre-upgrade hook for x509-certificate-exporter v4.1.0 fails on
`kube-monitoring-kubernikus` with:

```
Job.batch "kube-monitoring-kubernikus-x509-certificate-exporter-pre-upgrade"
is invalid: spec.template.labels: Invalid value: must be no more than 63 characters
```

The release name `kube-monitoring-kubernikus` combined with the chart
generates a 64-character label — 1 character over the Kubernetes limit.

## Fix

Set `fullnameOverride: "x509"` in `kube-monitoring-kubernikus/values.yaml`.
This reduces the pre-upgrade job name to `x509-pre-upgrade` (16 chars).

**Note:** This will rename all x509 Kubernetes resources from
`kube-monitoring-kubernikus-x509-certificate-exporter-*` to `x509-*`.
The old resources will be deleted and new ones created. This is safe
as x509-certificate-exporter is stateless.

## Ref

https://github.wdf.sap.corp/cc/unified-kubernetes/issues/1355