### PR TITLE
refactor(cc-runtime-cluster): detect vlan interface at runtime

### DIFF
--- a/system/cc-runtime-cluster/Chart.yaml
+++ b/system/cc-runtime-cluster/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-runtime-cluster
 description: Converged Cloud Cluster API Runtime Cluster
 type: application
-version: 0.9.0
+version: 0.9.1
 appVersion: "0.1.0"

--- a/system/cc-runtime-cluster/ci/test-values.yaml
+++ b/system/cc-runtime-cluster/ci/test-values.yaml
@@ -7,7 +7,6 @@ controlplane:
   address: 192.168.1.100
   port: 6443
   version: v1.31.5
-  uplinkInterface: bond0
   machineTemplate:
     matchLabels:
       node-role.kubernetes.io/cp: ""

--- a/system/cc-runtime-cluster/templates/kubeadmconfigtemplate.yaml
+++ b/system/cc-runtime-cluster/templates/kubeadmconfigtemplate.yaml
@@ -53,6 +53,6 @@ spec:
         # avoid running kubeadm on L1 interface - wait for bond/vlan
         # https://www.freedesktop.org/software/systemd/man/latest/systemd-networkd-wait-online.service.html
         - |
-          VLAN_IF=$(ls /sys/devices/virtual/net/ | grep vlan)
-          /usr/lib/systemd/systemd-networkd-wait-online -i $VLAN_IF --ipv4 --timeout 0
+          VLAN_IF="$(ls /sys/devices/virtual/net/ | grep vlan)"
+          /usr/lib/systemd/systemd-networkd-wait-online -i "${VLAN_IF}" --ipv4 --timeout 0
 {{- end }}

--- a/system/cc-runtime-cluster/templates/kubeadmconfigtemplate.yaml
+++ b/system/cc-runtime-cluster/templates/kubeadmconfigtemplate.yaml
@@ -50,7 +50,9 @@ spec:
         # stop services if running to avoid "Text file busy" error
         - systemctl stop kubelet || true
         - ctr run --rm --mount type=bind,src=/usr/bin,dst=/mnt,options=rbind $IMAGE extract-files sh -c "cp --preserve=mode /usr/local/bin/kubeadm /mnt/kubeadm && cp --preserve=mode /usr/local/bin/kubelet /mnt/kubelet"
-        # avoid running kubeadm on L1 interface - wait for bond
+        # avoid running kubeadm on L1 interface - wait for bond/vlan
         # https://www.freedesktop.org/software/systemd/man/latest/systemd-networkd-wait-online.service.html
-        - /usr/lib/systemd/systemd-networkd-wait-online -i {{ $.Values.controlplane.uplinkInterface }} --ipv4 --timeout 0
+        - |
+          VLAN_IF=$(ls /sys/devices/virtual/net/ | grep vlan)
+          /usr/lib/systemd/systemd-networkd-wait-online -i $VLAN_IF --ipv4 --timeout 0
 {{- end }}

--- a/system/cc-runtime-cluster/templates/kubeadmcontrolplane.yaml
+++ b/system/cc-runtime-cluster/templates/kubeadmcontrolplane.yaml
@@ -393,8 +393,8 @@ spec:
       # avoid running kubeadm on L1 interface - wait for bond/vlan
       # https://www.freedesktop.org/software/systemd/man/latest/systemd-networkd-wait-online.service.html
       - |
-        VLAN_IF=$(ls /sys/devices/virtual/net/ | grep vlan)
-        /usr/lib/systemd/systemd-networkd-wait-online -i $VLAN_IF --ipv4 --timeout 0
+        VLAN_IF="$(ls /sys/devices/virtual/net/ | grep vlan)"
+        /usr/lib/systemd/systemd-networkd-wait-online -i "${VLAN_IF}" --ipv4 --timeout 0
     postKubeadmCommands:
      # https://github.com/kube-vip/kube-vip/issues/684
       - |

--- a/system/cc-runtime-cluster/templates/kubeadmcontrolplane.yaml
+++ b/system/cc-runtime-cluster/templates/kubeadmcontrolplane.yaml
@@ -390,9 +390,11 @@ spec:
       # https://github.com/kube-vip/kube-vip/issues/684
       - |
         sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' /etc/kubernetes/manifests/kube-vip.yaml;
-      # avoid running kubeadm on L1 interface - wait for bond
+      # avoid running kubeadm on L1 interface - wait for bond/vlan
       # https://www.freedesktop.org/software/systemd/man/latest/systemd-networkd-wait-online.service.html
-      - /usr/lib/systemd/systemd-networkd-wait-online -i {{ $.Values.controlplane.uplinkInterface }} --ipv4 --timeout 0
+      - |
+        VLAN_IF=$(ls /sys/devices/virtual/net/ | grep vlan)
+        /usr/lib/systemd/systemd-networkd-wait-online -i $VLAN_IF --ipv4 --timeout 0
     postKubeadmCommands:
      # https://github.com/kube-vip/kube-vip/issues/684
       - |

--- a/system/cc-runtime-cluster/values.yaml
+++ b/system/cc-runtime-cluster/values.yaml
@@ -7,7 +7,6 @@ controlplane:
   serviceSubnet:
   address: 192.168.1.100
   version: v1.31.5
-  uplinkInterface:
   remediationStrategy:
     maxRetry: 3
     retryPeriodSeconds: 600


### PR DESCRIPTION
## Summary

Remove the `controlplane.uplinkInterface` Helm value and instead detect the VLAN interface dynamically at boot time via `/sys/devices/virtual/net/`.

## Changes

- Replace static `Values.controlplane.uplinkInterface` in `systemd-networkd-wait-online` with runtime detection: `VLAN_IF=$(ls /sys/devices/virtual/net/ | grep vlan)`
- Remove `uplinkInterface` from `values.yaml` and `ci/test-values.yaml`
- Applied to both `kubeadmcontrolplane.yaml` and `kubeadmconfigtemplate.yaml`

## Motivation

Avoids requiring operators to specify the uplink interface name per deployment. The VLAN interface is always a virtual device and can be discovered reliably from sysfs.