### PR TITLE
Add SSO_PRECHECK_ENABLED environment variable to Elektra

### DIFF
--- a/openstack/elektra/templates/_env.tpl
+++ b/openstack/elektra/templates/_env.tpl
@@ -68,3 +68,5 @@
   value: {{ .Values.cerebro_custom_endpoint | quote }}
 - name: FEEDBACK_RECIPIENT_EMAIL
   value: {{ .Values.feedback_recipient_email | quote }}
+- name: SSO_PRECHECK_ENABLED
+  value: {{ .Values.sso_precheck_enabled | quote }}  


### PR DESCRIPTION
## Summary
- Adds a new configurable environment variable `SSO_PRECHECK_ENABLED` to the Elektra Helm chart template
- Allows SSO pre-check functionality to be controlled via Helm values

## Changes
- Modified `openstack/elektra/templates/_env.tpl` to include the new `SSO_PRECHECK_ENABLED` environment variable
- Follows the existing pattern for environment variable configuration

## Notes
- Requires corresponding `sso_precheck_enabled` value to be defined in `values.yaml`
- Application code should be ready to consume this environment variable