### PR TITLE
fix(kube-monitoring-*): use Keppel mirror for x509 migration kubectl image

### DIFF
--- a/system/kube-monitoring-admin-k3s/Chart.yaml
+++ b/system/kube-monitoring-admin-k3s/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes admin k3s cluster monitoring.
 name: kube-monitoring-admin-k3s
-version: 4.8.3
+version: 4.8.4
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-admin-k3s
 dependencies:
   - condition: absent-metrics-operator.enabled

--- a/system/kube-monitoring-admin-k3s/values.yaml
+++ b/system/kube-monitoring-admin-k3s/values.yaml
@@ -292,6 +292,9 @@ falco:
           tag: pci
 
 x509-certificate-exporter:
+  migration:
+    image:
+      registry: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror
   secretsExporter:
     podAnnotations:
       prometheus.io/port: "9793"

--- a/system/kube-monitoring-kubernikus/Chart.yaml
+++ b/system/kube-monitoring-kubernikus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for monitoring Kubernikus.
 name: kube-monitoring-kubernikus
-version: 7.10.4
+version: 7.10.5
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-kubernikus
 dependencies:
   - condition: absent-metrics-operator.enabled

--- a/system/kube-monitoring-kubernikus/values.yaml
+++ b/system/kube-monitoring-kubernikus/values.yaml
@@ -197,6 +197,9 @@ falco:
           tag: pci
 
 x509-certificate-exporter:
+  migration:
+    image:
+      registry: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror
   fullnameOverride: "x509"
   secretsExporter:
     podAnnotations:

--- a/system/kube-monitoring-metal/Chart.yaml
+++ b/system/kube-monitoring-metal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes metal controlplane monitoring.
 name: kube-monitoring-metal
-version: 4.11.4
+version: 4.11.5
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-metal
 dependencies:
   - condition: absent-metrics-operator.enabled

--- a/system/kube-monitoring-metal/values.yaml
+++ b/system/kube-monitoring-metal/values.yaml
@@ -146,6 +146,9 @@ falco:
           tag: pci
 
 x509-certificate-exporter:
+  migration:
+    image:
+      registry: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror
   secretsExporter:
     podAnnotations:
       prometheus.io/port: "9793"

--- a/system/kube-monitoring-scaleout/Chart.yaml
+++ b/system/kube-monitoring-scaleout/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kubernetes scaleout cluster monitoring.
 name: kube-monitoring-scaleout
-version: 4.13.3
+version: 4.13.4
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-scaleout
 dependencies:
   - condition: absent-metrics-operator.enabled

--- a/system/kube-monitoring-scaleout/values.yaml
+++ b/system/kube-monitoring-scaleout/values.yaml
@@ -243,6 +243,9 @@ falco:
           tag: pci
 
 x509-certificate-exporter:
+  migration:
+    image:
+      registry: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror
   secretsExporter:
     podAnnotations:
       prometheus.io/port: "9793"

--- a/system/kube-monitoring-virtual/Chart.yaml
+++ b/system/kube-monitoring-virtual/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes virtual cluster monitoring.
 name: kube-monitoring-virtual
-version: 6.11.3
+version: 6.11.4
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-monitoring-virtual
 dependencies:
   - condition: absent-metrics-operator.enabled

--- a/system/kube-monitoring-virtual/values.yaml
+++ b/system/kube-monitoring-virtual/values.yaml
@@ -239,6 +239,9 @@ falco:
           tag: pci
 
 x509-certificate-exporter:
+  migration:
+    image:
+      registry: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror
   secretsExporter:
     podAnnotations:
       prometheus.io/port: "9793"


### PR DESCRIPTION
## Problem

The x509-certificate-exporter v4.1.0 pre-upgrade hook pulls
`registry.k8s.io/kubectl` which is blocked by Gatekeeper's
`images-from-non-keppel` policy:

```
admission webhook "validation.gatekeeper.sh" denied the request:
[images-from-non-keppel] container "kubectl" uses an image that is
not from a Keppel registry: registry.k8s.io/kubectl:v1.34.6
```

## Fix

Set `migration.image.registry: keppel.global.cloud.sap/ccloud-registry-k8s-io-mirror`
in all 5 kube-monitoring values files. The kubectl image is available
in this mirror.

## Ref

https://github.wdf.sap.corp/cc/unified-kubernetes/issues/1355