### PR TITLE
fix(cc-runtime-cluster): use hasKey for per-cluster etcdEncryption override

### DIFF
--- a/system/cc-runtime-cluster/Chart.yaml
+++ b/system/cc-runtime-cluster/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-runtime-cluster
 description: Converged Cloud Cluster API Runtime Cluster
 type: application
-version: 0.9.1
+version: 0.9.2
 appVersion: "0.1.0"

--- a/system/cc-runtime-cluster/templates/kubeadmcontrolplane.yaml
+++ b/system/cc-runtime-cluster/templates/kubeadmcontrolplane.yaml
@@ -79,7 +79,12 @@ spec:
             value: {{ $.Values.controlplane.port | quote }}
           - name: authentication-config
             value: "/etc/kubernetes/authentication.yaml"
-          {{- if default $.Values.etcd.useEncryption $cluster.etcdEncryption }}
+          {{- if hasKey $cluster "etcdEncryption" }}
+          {{- if $cluster.etcdEncryption }}
+          - name: encryption-provider-config
+            value: "/etc/kubernetes/enc/enc.yaml"
+          {{- end }}
+          {{- else if $.Values.etcd.useEncryption }}
           - name: encryption-provider-config
             value: "/etc/kubernetes/enc/enc.yaml"
           {{- end }}
@@ -99,7 +104,15 @@ spec:
             mountPath: "/etc/kubernetes/authentication.yaml"
             readOnly: true
             pathType: File
-        {{- if default $.Values.etcd.useEncryption $cluster.etcdEncryption }}
+        {{- if hasKey $cluster "etcdEncryption" }}
+        {{- if $cluster.etcdEncryption }}
+          - name: "encryption-config"
+            hostPath: "/etc/kubernetes/enc/enc.yaml"
+            mountPath: "/etc/kubernetes/enc/enc.yaml"
+            readOnly: true
+            pathType: File
+        {{- end }}
+        {{- else if $.Values.etcd.useEncryption }}
           - name: "encryption-config"
             hostPath: "/etc/kubernetes/enc/enc.yaml"
             mountPath: "/etc/kubernetes/enc/enc.yaml"


### PR DESCRIPTION
## Problem

The `etcdEncryption` per-cluster override in `kubeadmcontrolplane.yaml` uses Helm's `default` function:

```yaml
{{- if default $.Values.etcd.useEncryption $cluster.etcdEncryption }}
```

Helm's `default` treats `false` as an empty value and falls back to the first argument. This means when a cluster explicitly sets `etcdEncryption: false`, the template still evaluates to `true` (the global default), making it impossible to disable etcd encryption on a per-cluster basis.

## Fix

Replace `default` with `hasKey` to distinguish "key explicitly set to false" from "key absent":

```yaml
{{- if hasKey $cluster "etcdEncryption" }}
  {{- if $cluster.etcdEncryption }}
  ...
  {{- end }}
{{- else if $.Values.etcd.useEncryption }}
  ...
{{- end }}
```

**Logic:**
1. If `etcdEncryption` key exists on the cluster entry → use its actual value (respects explicit `false`)
2. If key is absent → fall back to global `$.Values.etcd.useEncryption`

Both template locations (apiServer extraArgs and extraVolumes) are fixed.