### PR TITLE
metal: label CRDs for clusterctl move (metal-operator, provider-metal, boot-operator)

### DIFF
--- a/system/Makefile
+++ b/system/Makefile
@@ -102,6 +102,9 @@ build-provider-metal3:
 build-provider-metal:
 	$(call build-chart,provider-metal,https://github.com/ironcore-dev/cluster-api-provider-ironcore-metal//config/default,$(PROVIDER_METAL_VERSION))
 	$(call fix-crds,provider-metal)
+	@# Label CRDs so clusterctl move discovers them (IroncoreMetalMachine is a link
+	@# in the ownerRef chain IPAddressClaim -> ServerClaim -> IroncoreMetalMachine -> Machine -> Cluster)
+	@find provider-metal/crds -type f | xargs -n1 yq -i '(select(.kind == "CustomResourceDefinition") | .metadata.labels."clusterctl.cluster.x-k8s.io") = ""'
 	@yq -i '.controllerManager.manager.image.tag="$(PROVIDER_METAL_VERSION)"' provider-metal/values.yaml
 	@yq -i '.fullnameOverride="provider-metal"' provider-metal/values.yaml
 
@@ -179,7 +182,8 @@ build-boot-operator-remote:
 		-n kube-system \
 		-f boot-operator-remote/values-managed-resources.yaml | \
 		$(SED) 's/kind: Role/kind: ClusterRole/g' - | \
-		yq eval 'select(.kind != "Service" and .kind != "ValidatingWebhookConfiguration")' - >\
+		yq eval 'select(.kind != "Service" and .kind != "ValidatingWebhookConfiguration")' - | \
+		yq eval '(select(.kind == "CustomResourceDefinition") | .metadata.labels."clusterctl.cluster.x-k8s.io") = ""' - >\
 		boot-operator-remote/managedresources/crds-and-rbac.yaml
 	@yq -i '.version = (.version | split(".") | .[2] = ((.[2] | tonumber) + 1 | tostring) | join("."))' boot-operator-remote/Chart.yaml
 

--- a/system/Makefile
+++ b/system/Makefile
@@ -151,7 +151,8 @@ build-metal-operator-remote:
 		-f metal-operator-remote/values-managed-resources.yaml | \
 		$(SED) 's/kind: Role/kind: ClusterRole/g' - | \
 		yq eval 'select(.kind != "Service" and .kind != "ValidatingWebhookConfiguration" and .kind != "MutatingWebhookConfiguration")' - | \
-		yq eval '(select(.kind == "CustomResourceDefinition") | .metadata.labels."metal-operator-remote-webhook-injector") = "true"' - \
+		yq eval '(select(.kind == "CustomResourceDefinition") | .metadata.labels."metal-operator-remote-webhook-injector") = "true"' - | \
+		yq eval '(select(.kind == "CustomResourceDefinition") | .metadata.labels."clusterctl.cluster.x-k8s.io") = ""' - \
 		> metal-operator-remote/managedresources/crds-and-rbac.yaml
 	# Extract upstream Deployment template and inject webhook-injector as native sidecar (initContainer)
 	@tar -xzf metal-operator-remote/charts/metal-operator*.tgz -O metal-operator/templates/manager/manager.yaml | \

--- a/system/boot-operator-remote/Chart.yaml
+++ b/system/boot-operator-remote/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.20
+version: 0.4.21
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/boot-operator-remote/managedresources/crds-and-rbac.yaml
+++ b/system/boot-operator-remote/managedresources/crds-and-rbac.yaml
@@ -22,6 +22,7 @@ metadata:
     app.kubernetes.io/name: boot-operator
     app.kubernetes.io/instance: boot-operator
     app.kubernetes.io/managed-by: Helm
+    clusterctl.cluster.x-k8s.io: ""
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.1
   name: httpbootconfigs.boot.ironcore.dev
@@ -170,6 +171,7 @@ metadata:
     app.kubernetes.io/name: boot-operator
     app.kubernetes.io/instance: boot-operator
     app.kubernetes.io/managed-by: Helm
+    clusterctl.cluster.x-k8s.io: ""
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.1
   name: ipxebootconfigs.boot.ironcore.dev

--- a/system/cluster-api/Chart.lock
+++ b/system/cluster-api/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 1.0.6
 - name: provider-metal
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.2.6
+  version: 0.2.7
 - name: provider-helm
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.5
@@ -32,5 +32,5 @@ dependencies:
 - name: runtime-extension-maintenance-controller
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.9
-digest: sha256:b70ebd188f1793d1b06e8dcc54ac8b767cf3a35db15babb08d1925d1fc840e06
-generated: "2026-07-20T14:30:47.07532279Z"
+digest: sha256:cdd722cdaa4f9f1eacf337671ac00e136448323b3d2e920166add9c71375d8f6
+generated: "2026-07-23T15:09:27.091486+02:00"

--- a/system/cluster-api/Chart.yaml
+++ b/system/cluster-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-api
 description: A Helm chart for the Cluster API.
 type: application
-version: 5.0.24
+version: 5.0.25
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/system/metal-operator-remote/Chart.yaml
+++ b/system/metal-operator-remote/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.28
+version: 0.6.29
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/metal-operator-remote/managedresources/crds-and-rbac.yaml
+++ b/system/metal-operator-remote/managedresources/crds-and-rbac.yaml
@@ -23,6 +23,7 @@ metadata:
     app.kubernetes.io/version: "0.1.0"
     app.kubernetes.io/managed-by: Helm
     metal-operator-remote-webhook-injector: "true"
+    clusterctl.cluster.x-k8s.io: ""
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
   name: biossettings.metal.ironcore.dev
@@ -326,6 +327,7 @@ metadata:
     app.kubernetes.io/version: "0.1.0"
     app.kubernetes.io/managed-by: Helm
     metal-operator-remote-webhook-injector: "true"
+    clusterctl.cluster.x-k8s.io: ""
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
   name: biossettingssets.metal.ironcore.dev
@@ -532,6 +534,7 @@ metadata:
     app.kubernetes.io/version: "0.1.0"
     app.kubernetes.io/managed-by: Helm
     metal-operator-remote-webhook-injector: "true"
+    clusterctl.cluster.x-k8s.io: ""
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
   name: biosversions.metal.ironcore.dev
@@ -783,6 +786,7 @@ metadata:
     app.kubernetes.io/version: "0.1.0"
     app.kubernetes.io/managed-by: Helm
     metal-operator-remote-webhook-injector: "true"
+    clusterctl.cluster.x-k8s.io: ""
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
   name: biosversionsets.metal.ironcore.dev
@@ -991,6 +995,7 @@ metadata:
     app.kubernetes.io/version: "0.1.0"
     app.kubernetes.io/managed-by: Helm
     metal-operator-remote-webhook-injector: "true"
+    clusterctl.cluster.x-k8s.io: ""
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
   name: bmcs.metal.ironcore.dev
@@ -1287,6 +1292,7 @@ metadata:
     app.kubernetes.io/version: "0.1.0"
     app.kubernetes.io/managed-by: Helm
     metal-operator-remote-webhook-injector: "true"
+    clusterctl.cluster.x-k8s.io: ""
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
   name: bmcsecrets.metal.ironcore.dev
@@ -1375,6 +1381,7 @@ metadata:
     app.kubernetes.io/version: "0.1.0"
     app.kubernetes.io/managed-by: Helm
     metal-operator-remote-webhook-injector: "true"
+    clusterctl.cluster.x-k8s.io: ""
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
   name: bmcsettings.metal.ironcore.dev
@@ -1696,6 +1703,7 @@ metadata:
     app.kubernetes.io/version: "0.1.0"
     app.kubernetes.io/managed-by: Helm
     metal-operator-remote-webhook-injector: "true"
+    clusterctl.cluster.x-k8s.io: ""
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
   name: bmcsettingssets.metal.ironcore.dev
@@ -2000,6 +2008,7 @@ metadata:
     app.kubernetes.io/version: "0.1.0"
     app.kubernetes.io/managed-by: Helm
     metal-operator-remote-webhook-injector: "true"
+    clusterctl.cluster.x-k8s.io: ""
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
   name: bmcusers.metal.ironcore.dev
@@ -2154,6 +2163,7 @@ metadata:
     app.kubernetes.io/version: "0.1.0"
     app.kubernetes.io/managed-by: Helm
     metal-operator-remote-webhook-injector: "true"
+    clusterctl.cluster.x-k8s.io: ""
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
   name: bmcversions.metal.ironcore.dev
@@ -2405,6 +2415,7 @@ metadata:
     app.kubernetes.io/version: "0.1.0"
     app.kubernetes.io/managed-by: Helm
     metal-operator-remote-webhook-injector: "true"
+    clusterctl.cluster.x-k8s.io: ""
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
   name: bmcversionsets.metal.ironcore.dev
@@ -2613,6 +2624,7 @@ metadata:
     app.kubernetes.io/version: "0.1.0"
     app.kubernetes.io/managed-by: Helm
     metal-operator-remote-webhook-injector: "true"
+    clusterctl.cluster.x-k8s.io: ""
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
   name: endpoints.metal.ironcore.dev
@@ -2689,6 +2701,7 @@ metadata:
     app.kubernetes.io/version: "0.1.0"
     app.kubernetes.io/managed-by: Helm
     metal-operator-remote-webhook-injector: "true"
+    clusterctl.cluster.x-k8s.io: ""
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
   name: serverbootconfigurations.metal.ironcore.dev
@@ -2860,6 +2873,7 @@ metadata:
     app.kubernetes.io/version: "0.1.0"
     app.kubernetes.io/managed-by: Helm
     metal-operator-remote-webhook-injector: "true"
+    clusterctl.cluster.x-k8s.io: ""
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
   name: serverclaims.metal.ironcore.dev
@@ -3064,6 +3078,7 @@ metadata:
     app.kubernetes.io/version: "0.1.0"
     app.kubernetes.io/managed-by: Helm
     metal-operator-remote-webhook-injector: "true"
+    clusterctl.cluster.x-k8s.io: ""
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
   name: servermaintenances.metal.ironcore.dev
@@ -3234,6 +3249,7 @@ metadata:
     app.kubernetes.io/version: "0.1.0"
     app.kubernetes.io/managed-by: Helm
     metal-operator-remote-webhook-injector: "true"
+    clusterctl.cluster.x-k8s.io: ""
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
   name: serverreadinessrules.metal.ironcore.dev
@@ -3499,6 +3515,7 @@ metadata:
     app.kubernetes.io/version: "0.1.0"
     app.kubernetes.io/managed-by: Helm
     metal-operator-remote-webhook-injector: "true"
+    clusterctl.cluster.x-k8s.io: ""
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
   name: servers.metal.ironcore.dev

--- a/system/provider-metal/Chart.yaml
+++ b/system/provider-metal/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.6
+version: 0.2.7
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/provider-metal/crds/ironcoremetalcluster-crd.yaml
+++ b/system/provider-metal/crds/ironcoremetalcluster-crd.yaml
@@ -5,6 +5,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     cluster.x-k8s.io/v1beta2: v1alpha1
+    clusterctl.cluster.x-k8s.io: ""
   name: ironcoremetalclusters.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/system/provider-metal/crds/ironcoremetalmachine-crd.yaml
+++ b/system/provider-metal/crds/ironcoremetalmachine-crd.yaml
@@ -5,6 +5,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     cluster.x-k8s.io/v1beta2: v1alpha1
+    clusterctl.cluster.x-k8s.io: ""
   name: ironcoremetalmachines.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/system/provider-metal/crds/ironcoremetalmachinetemplate-crd.yaml
+++ b/system/provider-metal/crds/ironcoremetalmachinetemplate-crd.yaml
@@ -5,6 +5,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     cluster.x-k8s.io/v1beta2: v1alpha1
+    clusterctl.cluster.x-k8s.io: ""
   name: ironcoremetalmachinetemplates.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io


### PR DESCRIPTION
<!--
Thank you for contributing to helm-charts!
-->

## What this PR does

Adds the `clusterctl.cluster.x-k8s.io` discovery label to **all metal-related CRDs** across three managed-resource builds, so that `clusterctl move` (pivot) discovers the full CAPI/metal object graph and moves it — including the per-machine IPAM resources.

- **`build-metal-operator-remote`** — labels all metal-operator CRDs (`serverclaims`, `servers`, `bmcs`, …). `ServerClaim` is the direct owner of the per-machine `IPAddressClaim`.
- **`build-provider-metal`** — labels the CAPI infra provider CRDs (`ironcoremetalcluster`, `ironcoremetalmachine`, `ironcoremetalmachinetemplate`). `IroncoreMetalMachine` is a required link in the ownerRef chain.
- **`build-boot-operator-remote`** — labels the boot-operator CRDs (`httpbootconfigs`, `ipxebootconfigs`).

Each `system/Makefile` target gets a `yq` label step (alongside existing steps), and the generated outputs + chart versions are re-rendered.

## Why

`clusterctl move` only considers objects whose CRD carries the `clusterctl.cluster.x-k8s.io` label. The functionally critical chain is:

```
IPAddressClaim -> ServerClaim -> IroncoreMetalMachine -> Machine -> Cluster
```

**Dry-run investigation on the live management clusters `a-qa-de-1` and `rt-qa-de-1` found that 0 of ~200+ CRDs carried the label**, so `clusterctl move --dry-run` discovered essentially nothing — no `Cluster`, `Machine`, `IroncoreMetalMachine`, `ServerClaim`, or IPAM resources appeared in the object graph. The stack is deployed via managed resources here, not `clusterctl init`, so nothing gets the label automatically.

**Without discovery the failure is data loss, not just stranding** (validated with a CAPD + kind harness): `clusterctl` moves and deletes the discovered `IroncoreMetalMachine` from the source, and Kubernetes GC then cascade-deletes the undiscovered `ServerClaim` and its owned `IPAddressClaim`/`IPAddress`.

## Why downstream

The upstream chart is the right long-term home, and the source fix is tracked in **ironcore-dev/metal-operator#1043** (adds a `+kubebuilder:metadata:labels` marker). However, the kubebuilder `helm/v1-alpha` plugin currently **strips per-CRD static labels** when generating the chart, so the label does not propagate into the packaged Helm charts this repo renders. These downstream `yq` steps are applied at render time so the label is deployed onto the shoot clusters now, and are durable across re-renders. They can be dropped once the upstream charts carry the label natively.

## Scope note

Labels were applied to **all** CRDs in each target for a discoverable object graph and consistency across the three metal builds. `ServerClaim` and `IroncoreMetalMachine` are the functionally required links; the others (BMC/BIOS/boot configs, templates) are labeled for completeness. The `build-provider-metal` label step is kept in the target (not the shared `fix-crds` macro) to avoid relabeling unrelated charts.

## Validation

Local CAPD + kind harness: with the labels the full chain moves cleanly to the target with no source leftovers; without them the IPAM resources are lost as described above. Verified in this PR that every rendered metal CRD carries the label.


## Rollout

The `cluster-api` umbrella chart is `helm dep up`'d to pull the rebuilt `provider-metal` (0.2.7, which carries the labeled CRDs) and its version is bumped (`5.0.24` → `5.0.25`) so the change is picked up. `provider-metal:0.2.7` has been pushed to `oci://keppel.eu-de-1.cloud.sap/ccloud-helm`.
