### PR TITLE
feat(cc-gardener): add optional gardenerScheduler.strategy to Garden CR

### DIFF
--- a/global/cc-gardener/Chart.yaml
+++ b/global/cc-gardener/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cc-gardener
 description: Converged Cloud Gardener setup based on gardener-operator
 type: application
-version: 0.38.6
+version: 0.38.9
 home: https://github.com/gardener/gardener
 dependencies:
 - name: owner-info

--- a/global/cc-gardener/templates/garden.yaml
+++ b/global/cc-gardener/templates/garden.yaml
@@ -192,6 +192,10 @@ spec:
       gardenerResourceManager:
         additionalTargetNamespaces: {{- toYaml .Values.garden.virtualCluster.gardenerResourceManager.additionalTargetNamespaces | nindent 8 }}
 {{- end }}
+{{- if and .Values.garden.virtualCluster.gardenerScheduler .Values.garden.virtualCluster.gardenerScheduler.strategy }}
+      scheduler:
+        strategy: {{ .Values.garden.virtualCluster.gardenerScheduler.strategy }}
+{{- end }}
     maintenance:
       timeWindow:
         begin: 130000+0100

--- a/global/cc-gardener/templates/garden.yaml
+++ b/global/cc-gardener/templates/garden.yaml
@@ -196,7 +196,7 @@ spec:
         additionalTargetNamespaces: {{- toYaml .Values.garden.virtualCluster.gardenerResourceManager.additionalTargetNamespaces | nindent 8 }}
 {{- end }}
 {{- if and .Values.garden.virtualCluster.gardenerScheduler .Values.garden.virtualCluster.gardenerScheduler.strategy }}
-      scheduler:
+      gardenerScheduler:
         strategy: {{ .Values.garden.virtualCluster.gardenerScheduler.strategy }}
 {{- end }}
     maintenance:

--- a/global/cc-gardener/values.yaml
+++ b/global/cc-gardener/values.yaml
@@ -295,6 +295,10 @@ garden:
     adminUsers: []
     gardenerResourceManager:
       additionalTargetNamespaces: []
+    # gardenerScheduler:
+    #   # strategy defines how seeds for shoots that do not specify a seed explicitly are determined.
+    #   # SameRegion (default) or MinimalDistance. Leave unset to use the scheduler's own default.
+    #   strategy: MinimalDistance
   dashboard:
     enabled: false
     enableTokenLogin: false


### PR DESCRIPTION
# Summary

Add templating support for gardenerScheduler.strategy in the Garden resource. The strategy defaults to unset (no-op, Gardener applies its own default SameRegion) and can be opted-in via regional values files. https://github.com/gardener/gardener/pull/14963

# Usage

In your regional/environment values file:

```
garden:
  virtualCluster:
    gardenerScheduler:
      strategy: MinimalDistance
```
Allowed values: SameRegion (Gardener default) or MinimalDistance.

# Changes

- `templates/garden.yaml`: add conditional scheduler.strategy block under virtualCluster.gardener (renders only when set)
- `values.yaml`: add documented, commented-out garden.virtualCluster.gardenerScheduler default (no-op)
- `Chart.yaml`: version bump 0.38.6 → 0.38.7

# Testing

```
# Without strategy (no change in rendered output)
helm template test . -f ci/test-values.yaml

# With strategy set
helm template test . -f ci/test-values.yaml --set garden.virtualCluster.gardenerScheduler.strategy=MinimalDistance
```