### PR TITLE
cinder: support per-rule enabled flag for ProxySQL query cache

### DIFF
--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -166,11 +166,17 @@ proxysql:
   backup:
     max_connections_per_proc: 10  # backup pods get their own proxysql secret with max_connections = 10
   query_rules:
+    # Each rule supports an optional `enabled: false` to omit it (default: enabled).
+    # Note: Helm replaces lists, so a region override must re-declare the full list.
     # Cache attachment_specs lookups (table is empty, 0 rows ever, queried 1249/sec)
     # 1h TTL — table has never had data in any region, feature is unused
     - cache_ttl: 3600000
       match_pattern: "^SELECT.*FROM attachment_specs WHERE"
     # Cache volume_types full list (3 rows, static admin config, rarely changes)
+    # WARNING: ProxySQL query cache is TTL-only with no write-invalidation; a
+    # create/update/delete of a volume type is invisible until the TTL expires.
+    # Disable (enabled: false) in any region that creates volume types at runtime
+    # (e.g. tempest), otherwise create-then-read returns 404. See qa-de-1 override.
     - cache_ttl: 300000
       match_pattern: "^SELECT.*FROM volume_types.*ORDER BY"
     # Cache volume_types by ID or name lookup

--- a/openstack/utils/templates/snippets/_proxysql.cfg.tpl
+++ b/openstack/utils/templates/snippets/_proxysql.cfg.tpl
@@ -180,6 +180,7 @@ mysql_query_rules =
         match_pattern = "^SELECT 1$",
     },
 {{- range $i, $rule := .global.Values.proxysql.query_rules | default list }}
+{{- if ne $rule.enabled false }}
     {
         rule_id = {{ add 1 $i }},
         active = 1,
@@ -187,6 +188,7 @@ mysql_query_rules =
         cache_ttl = {{ printf "%.0f" (float64 $rule.cache_ttl) }},
         match_digest = "{{ $rule.match_pattern }}",
     },
+{{- end }}
 {{- end }}
 )
 {{- end }}


### PR DESCRIPTION
## Problem
ProxySQL's query cache is **TTL-only with no write-invalidation**. The `volume_types` cache rules (added in b204d9d0fe, 2026-06-08) cause a volume-type **create-then-read to return 404**: the row is committed to MariaDB, but cinder's read-back `SELECT ... FROM volume_types WHERE name=...` is served from a stale cache snapshot until the TTL (5 min) expires.

This has broken **every cinder tempest volume-type admin test in qa-de-1** since 2026-06-08 (qa-de-1-tempest builds #207–#217, all failed). Verified by live reproduction: create returns 404 while `volume type list` shows the row present; flushing the ProxySQL query cache makes lookups correct; ProxySQL `Query_Cache_count_GET_OK` rises while `SET` stays flat (served from cache).

## Change
Add an optional `enabled: false` on each query rule in the shared ProxySQL template. Rules default to enabled (backward compatible — existing configs unchanged). This lets a region that creates volume types at runtime (e.g. tempest) omit the `volume_types` cache while keeping `attachment_specs`.

Rendered output verified: a rule with `enabled: false` is omitted; rules without the key are kept.

## Rollout
- This PR: template + default values documentation only. No behavior change in any region by default.
- Companion **cc/secrets** PR disables the two `volume_types` rules for **qa-de-1 only**.

Note: Helm replaces (not merges) lists, so the qa-de-1 override re-declares the full `query_rules` list with the two `volume_types` entries set `enabled: false`.