### PR TITLE
[keystone] shorten credential-migrate job name.

### DIFF
--- a/openstack/keystone/templates/job-credential-migrate.yaml
+++ b/openstack/keystone/templates/job-credential-migrate.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ tuple . "job-credential-migrate" | include "job_name" }}"
+  name: "{{ tuple . "job-creds-migrate" | include "job_name" }}"
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       labels:
-        name: "{{ tuple . "job-credential-migrate" | include "job_name" }}"
+        name: "{{ tuple . "job-creds-migrate" | include "job_name" }}"
         system: openstack
         component: keystone
         type: job


### PR DESCRIPTION
Because for keystone-global the name becomes too long and deploy fails.

Invalid value: "keystone-global-job-credential-migrate-e3b0-epoxy-20260721161808": must be no more than 63 characters