### PR TITLE
feat(elektra): add public Keystone endpoint for SSO precheck

### DIFF
--- a/openstack/elektra/templates/_env.tpl
+++ b/openstack/elektra/templates/_env.tpl
@@ -21,6 +21,8 @@
 - name: MONSOON_OPENSTACK_AUTH_API_ENDPOINT
   value: {{ include "keystone_url" . | quote }}
 {{- end }}
+- name: MONSOON_OPENSTACK_AUTH_API_PUBLIC_ENDPOINT
+  value: "https://identity-3.{{ .Values.global.region }}.{{ .Values.global.tld }}/v3/auth/tokens"
 - name: MONSOON_OPENSTACK_AUTH_API_USERID
   value: {{ .Values.monsoon_openstack_auth_api_userid | quote }}
 - name: MONSOON_OPENSTACK_AUTH_API_PASSWORD

--- a/openstack/elektra/templates/_env.tpl
+++ b/openstack/elektra/templates/_env.tpl
@@ -22,7 +22,7 @@
   value: {{ include "keystone_url" . | quote }}
 {{- end }}
 - name: MONSOON_OPENSTACK_AUTH_API_PUBLIC_ENDPOINT
-  value: "https://identity-3.{{ .Values.global.region }}.{{ .Values.global.tld }}/v3/auth/tokens"
+  value: {{ .Values.keystone_public_endpoint | default (printf "https://identity-3.%s.%s/v3/auth/tokens" .Values.global.region .Values.global.tld) | quote }}
 - name: MONSOON_OPENSTACK_AUTH_API_USERID
   value: {{ .Values.monsoon_openstack_auth_api_userid | quote }}
 - name: MONSOON_OPENSTACK_AUTH_API_PASSWORD


### PR DESCRIPTION
## Summary

Adds the `MONSOON_OPENSTACK_AUTH_API_PUBLIC_ENDPOINT` environment variable for Elektra's SSO precheck feature.

## Changes

- New env variable in `_env.tpl`:
  ```
  MONSOON_OPENSTACK_AUTH_API_PUBLIC_ENDPOINT=https://identity-3.<region>.<tld>/v3/auth/tokens
  ```

## Why?

The SSO precheck runs in the user's browser (client-side JavaScript) and needs a publicly accessible Keystone endpoint. The internal endpoint (`MONSOON_OPENSTACK_AUTH_API_ENDPOINT`) is only reachable within the cluster.

The URL is dynamically built from `global.region` and `global.tld` — no additional configuration needed.

## Related

- Elektra PR: https://github.com/SAP-cloud-infrastructure/elektra/pull/2126