### PR TITLE
feat(cc-shoots-storage): enable overlay networking

### DIFF
--- a/system/cc-shoots-storage/Chart.yaml
+++ b/system/cc-shoots-storage/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-shoots-storage
 description: Converged Cloud Gardener Storage shoots
 type: application
-version: 0.0.11
+version: 0.0.12
 appVersion: "0.1.0"

--- a/system/cc-shoots-storage/templates/storage-shoot.yaml
+++ b/system/cc-shoots-storage/templates/storage-shoot.yaml
@@ -25,14 +25,25 @@ spec:
     providerConfig:
       apiVersion: calico.networking.extensions.gardener.cloud/v1alpha1
       kind: NetworkConfig
+      {{- if not $.Values.networking.overlay }}
       backend: bird
+      {{- end }}
+      {{- if $.Values.networking.overlay }}
+      vethMTU: "8930"
+      {{- else }}
       vethMTU: "8950"
+      {{- end }}
       ipam:
         type: host-local
         cidr: usePodCIDR
+      {{- if $.Values.networking.overlay }}
+      overlay:
+        enabled: true
+      {{- else }}
       overlay:
         enabled: false
         createPodRoutes: true
+      {{- end }}
       birdExporter:
         enabled: {{ required ".Values.networking.enableBirdExporter is required" $.Values.networking.enableBirdExporter }}
   kubernetes:
@@ -124,7 +135,16 @@ spec:
                     matchOperator: Equal
                     action: Reject
                   {{- end }}
+                  {{- if $.Values.networking.overlay }}
+                  - cidr: {{ default $.Values.networking.pods $cluster.networking.pods }}
+                    matchOperator: In
+                    action: Reject
+                  {{- end }}
+            {{- if $.Values.networking.overlay }}
+            nodeToNodeMeshEnabled: true
+            {{- else }}
             nodeToNodeMeshEnabled: false
+            {{- end }}
             serviceLoadBalancerIPs:
             {{- range $cluster.networking.externalServices }}
             - {{ .cidr }}

--- a/system/cc-shoots-storage/values.yaml
+++ b/system/cc-shoots-storage/values.yaml
@@ -4,3 +4,4 @@ networking:
   pods: ""
   services: ""
   enableBirdExporter: true
+  overlay: true


### PR DESCRIPTION
## Summary

Enable overlay (IPIP) networking support for cc-shoots-storage shoots, matching the same feature already implemented in cc-shoots-compute and cc-shoots-controlplane.

## Changes

- Conditionally set `backend: bird` only when overlay is disabled
- Set `vethMTU: "8930"` when overlay is enabled (8950 - 20B IPIP overhead), `"8950"` otherwise
- Configure overlay enabled/disabled based on `.Values.networking.overlay`
- Add pod CIDR reject filter in BGP export when overlay is enabled
- Set `nodeToNodeMeshEnabled: true` when overlay is enabled
- Default `networking.overlay: true` in values.yaml
- Bump chart version to 0.0.12