### PR TITLE
fix(gatekeeper): fortlogs - allow init container in audit-logs to use host PID

### DIFF
--- a/system/gatekeeper/templates/constraint-pod-security-v2.yaml
+++ b/system/gatekeeper/templates/constraint-pod-security-v2.yaml
@@ -980,6 +980,7 @@ spec:
           OTel audit-logs collector init container needs privileged access
           and host root filesystem mount to set up auditd log reading.
         mayBePrivileged: true
+        mayUseHostPID: true
         mayReadHostPathVolumes: [ / ]
 
       - matchNamespace: opensearch-logs


### PR DESCRIPTION
## Summary
Fixes the pod-security-v2 allowlist for the fortlogs-audit namespace so the OTel audit-logs DaemonSet collector can start on clusters with strict pod security policies.

## Problem
Audit-logs collector has one init and one main container. The main container needs `hostPID: true` (https://github.com/sapcc/helm-charts/pull/12100/changes#diff-ae68388abe7dcc75e53f55f34ad8501675605b1b3d68414f7f5e776aa7a4affcR972)
In the next PR: https://github.com/sapcc/helm-charts/pull/12260 init container was added but without `mayUseHostPID` - which blocks the creation of audit-logs pods.
`    violations:
    - enforcementAction: dryrun
      group: apps
      kind: DaemonSet
      message: '{"support_group":"observability","service":"audit-logs"} >> pod is
        not allowed to set spec.hostPID = true'
      name: audit-logs-collector
      namespace: fortlogs-audit
      version: v1`

From what I can see `isPodAllowedToUseHostPID` is check for the whole pod, not per pod's container. Therefore we need `mayUseHostPID` in allowlist for initContainer as well. 

## Changes
- update existing allowlist entry for `ccloud-dockerhub-mirror/library/alpine` init container in `fortlogs-audit` with `mayUseHostPID : true`

## Related
follow-up to https://github.com/sapcc/helm-charts/pull/12260