### PR TITLE
[neutron-hypervisor-agents] fix leading blank line in ConfigMap data + auto-detect PUBLIC_INTERFACE

### DIFF
--- a/openstack/neutron-hypervisor-agents/Chart.yaml
+++ b/openstack/neutron-hypervisor-agents/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart for Openstack Neutron hypervisor agents
 name: neutron-hypervisor-agents
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Neutron/OpenStack_Project_Neutron_mascot.png
-version: 0.2.2
+version: 0.2.3
 appVersion: "caracal"
 dependencies:
 - name: utils

--- a/openstack/neutron-hypervisor-agents/Chart.yaml
+++ b/openstack/neutron-hypervisor-agents/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart for Openstack Neutron hypervisor agents
 name: neutron-hypervisor-agents
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Neutron/OpenStack_Project_Neutron_mascot.png
-version: 0.2.1
+version: 0.2.2
 appVersion: "caracal"
 dependencies:
 - name: utils

--- a/openstack/neutron-hypervisor-agents/templates/bin/_start-ovs-vswitchd.tpl
+++ b/openstack/neutron-hypervisor-agents/templates/bin/_start-ovs-vswitchd.tpl
@@ -14,7 +14,25 @@
 
 set -eEuxo pipefail
 
-PUBLIC_INTERFACE=bond0
+# PUBLIC_INTERFACE is the NIC we place on the OVS bridge as the
+# integration point with the underlay network. On production
+# hypervisors this is always a bond ("bond0"); on cloud workers with a
+# single NIC there is no bond and the default-route device is what
+# carries traffic. Fall back to the default-route interface when
+# bond0 is absent so this chart runs on both shapes.
+PUBLIC_INTERFACE="${PUBLIC_INTERFACE:-}"
+if [[ -z "${PUBLIC_INTERFACE}" ]]; then
+    if ip link show bond0 &>/dev/null; then
+        PUBLIC_INTERFACE=bond0
+    else
+        # e.g. "default via 10.0.0.1 dev eth0 proto dhcp …" — field 5 is the interface name.
+        PUBLIC_INTERFACE=$(ip -o -4 route show default | awk '{print $5; exit}')
+    fi
+fi
+if [[ -z "${PUBLIC_INTERFACE}" ]]; then
+    echo "start-ovs-vswitchd: could not determine PUBLIC_INTERFACE (no bond0, no default route)" >&2
+    exit 1
+fi
 OVS_PHYSICAL_BRIDGE=br-ovs0
 
 if pgrep -f /usr/sbin/ovs-vswitchd; then

--- a/openstack/neutron-hypervisor-agents/templates/configmap-bin.yaml
+++ b/openstack/neutron-hypervisor-agents/templates/configmap-bin.yaml
@@ -7,13 +7,13 @@ metadata:
     type: configuration
     component: neutron
 data:
-  start-ovsdb-server: |
-    {{ include (print .Template.BasePath "/bin/_start-ovsdb-server.tpl") . | nindent 4 }}
-  start-ovs-vswitchd: |
-    {{ include (print .Template.BasePath "/bin/_start-ovs-vswitchd.tpl") . | nindent 4 }}
-  ovn_controller_liveness.sh: |
-    {{ include (print .Template.BasePath "/bin/_ovn_controller_liveness.sh.tpl") . | nindent 4 }}
-  ovn_controller_readiness.sh: |
-    {{ include (print .Template.BasePath "/bin/_ovn_controller_readiness.sh.tpl") . | nindent 4 }}
-  init.sh: |
-    {{ include (print .Template.BasePath "/bin/_init.sh.tpl") . | nindent 4 }}
+  start-ovsdb-server: |-
+    {{- include (print .Template.BasePath "/bin/_start-ovsdb-server.tpl") . | nindent 4 }}
+  start-ovs-vswitchd: |-
+    {{- include (print .Template.BasePath "/bin/_start-ovs-vswitchd.tpl") . | nindent 4 }}
+  ovn_controller_liveness.sh: |-
+    {{- include (print .Template.BasePath "/bin/_ovn_controller_liveness.sh.tpl") . | nindent 4 }}
+  ovn_controller_readiness.sh: |-
+    {{- include (print .Template.BasePath "/bin/_ovn_controller_readiness.sh.tpl") . | nindent 4 }}
+  init.sh: |-
+    {{- include (print .Template.BasePath "/bin/_init.sh.tpl") . | nindent 4 }}

--- a/openstack/neutron-hypervisor-agents/templates/configmap-etc.yaml
+++ b/openstack/neutron-hypervisor-agents/templates/configmap-etc.yaml
@@ -8,13 +8,13 @@ metadata:
     component: neutron
 
 data:
-  ml2-conf.conf: |
-{{ include (print .Template.BasePath "/etc/_ml2-conf.ini.tpl") . | indent 4 }}
-  neutron.conf: |
-{{ include (print .Template.BasePath "/etc/_neutron.conf.tpl") . | indent 4 }}
-  rootwrap.conf: |
-{{ include (print .Template.BasePath "/etc/_rootwrap.conf.tpl") . | indent 4 }}
-  sudoers: |
-{{ include (print .Template.BasePath "/etc/_sudoers.tpl") . | indent 4 }}
-  logging.ini: |
-{{ include "loggerIni" .Values.logging_sapccsentry | indent 4 }}
+  ml2-conf.conf: |-
+    {{- include (print .Template.BasePath "/etc/_ml2-conf.ini.tpl") . | nindent 4 }}
+  neutron.conf: |-
+    {{- include (print .Template.BasePath "/etc/_neutron.conf.tpl") . | nindent 4 }}
+  rootwrap.conf: |-
+    {{- include (print .Template.BasePath "/etc/_rootwrap.conf.tpl") . | nindent 4 }}
+  sudoers: |-
+    {{- include (print .Template.BasePath "/etc/_sudoers.tpl") . | nindent 4 }}
+  logging.ini: |-
+    {{- include "loggerIni" .Values.logging_sapccsentry | nindent 4 }}


### PR DESCRIPTION
Two fixes found while running the neutron chart on a Gardener KVM shoot.

1. Shebang not on line 1 in start-ovsdb-server / start-ovs-vswitchd
   / ovn_controller_liveness.sh / ovn_controller_readiness.sh /
   init.sh. '|' + '{{ include ... | indent 4 }}' renders with a
   blank first line, so Linux treats the file as ELF and exec
   returns 'exec format error'. Keeps the openvswitch-agent
   daemonset in CrashLoopBackOff on runtimes that do not fall back
   to /bin/sh.

   Same authoring pattern also appears in ml2-conf.conf, neutron.conf,
   rootwrap.conf, sudoers, logging.ini \u2014 cosmetic only for those but
   fixed for consistency.

   Fix: '|-' + '{{- include ... | nindent 4 }}'.

2. start-ovs-vswitchd hardcoded PUBLIC_INTERFACE=bond0 and failed
   with 'Cannot find device bond0' on single-NIC nodes. Falls back
   to the default-route interface; honours a PUBLIC_INTERFACE env
   override.

Chart 0.2.1 -> 0.2.3.