### PR TITLE
[Neutron] Fix image pull error for Neutron Agent Exporter

### DIFF
--- a/openstack/neutron/templates/statefulset-network-agent-apod.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent-apod.yaml
@@ -188,7 +188,7 @@ spec:
               readOnly: true
             {{- include "utils.trust_bundle.volume_mount" $ | indent 12 }}
         - name: agent-check-exporter
-          image: {{$.Values.global.registry}}/ccloud/neutron-network-agent-checks:{{ $.Values.imageVersionAgentExporter | required "Please set neutron.imageVersionAgentExporter "}}
+          image: {{$.Values.global.registry}}/neutron-network-agent-checks:{{ $.Values.imageVersionAgentExporter | required "Please set neutron.imageVersionAgentExporter "}}
           imagePullPolicy: IfNotPresent
           env:
             - name: METRIC_PREFIX

--- a/openstack/neutron/templates/statefulset-network-agent.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent.yaml
@@ -170,7 +170,7 @@ spec:
               readOnly: false
             {{- include "utils.trust_bundle.volume_mount" $ | indent 12 }}
         - name: agent-check-exporter
-          image: {{$.Values.global.registry}}/ccloud/neutron-network-agent-checks:{{ $.Values.imageVersionAgentExporter | required "Please set neutron.imageVersionAgentExporter "}}
+          image: {{$.Values.global.registry}}/neutron-network-agent-checks:{{ $.Values.imageVersionAgentExporter | required "Please set neutron.imageVersionAgentExporter "}}
           imagePullPolicy: IfNotPresent
           env:
             - name: METRIC_PREFIX


### PR DESCRIPTION
'ccloud' is already part of .global.registry.