### PR TITLE
[nova-hypervisor-agents] fix leading blank lines in ConfigMap data

### DIFF
--- a/openstack/nova-hypervisor-agents/Chart.yaml
+++ b/openstack/nova-hypervisor-agents/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart Nova hypervisor agents
 name: nova-hypervisor-agents
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Nova/OpenStack_Project_Nova_mascot.png
-version: 0.2.3
+version: 0.2.4
 appVersion: "bobcat"
 dependencies:
 - name: utils

--- a/openstack/nova-hypervisor-agents/templates/_kvm-configmap.yaml.tpl
+++ b/openstack/nova-hypervisor-agents/templates/_kvm-configmap.yaml.tpl
@@ -9,7 +9,7 @@ metadata:
     component: nova
 data:
   nova-compute.conf: |
-    {{ include (print .Template.BasePath "/etc/_nova-compute.conf.tpl") . | nindent 4 }}
+    {{- include (print .Template.BasePath "/etc/_nova-compute.conf.tpl") . | nindent 4 }}
   libvirtd.conf: |
     listen_tcp = 1
     listen_tls = 0

--- a/openstack/nova-hypervisor-agents/templates/etc-configmap.yaml
+++ b/openstack/nova-hypervisor-agents/templates/etc-configmap.yaml
@@ -9,12 +9,12 @@ metadata:
 
 data:
   nova.conf: |
-    {{ include (print .Template.BasePath "/etc/_nova.conf.tpl") . | nindent 4 }}
+    {{- include (print .Template.BasePath "/etc/_nova.conf.tpl") . | nindent 4 }}
   logging.ini: |
-{{ include "loggerIni" .Values.logging | indent 4 }}
+    {{- include "loggerIni" .Values.logging | nindent 4 }}
   rootwrap.conf: |
-{{ include (print .Template.BasePath "/etc/_rootwrap.conf.tpl") . | indent 4 }}
+    {{- include (print .Template.BasePath "/etc/_rootwrap.conf.tpl") . | nindent 4 }}
   compute.filters: |
-{{ include (print .Template.BasePath "/etc/_compute.filters.tpl") . | indent 4 }}
+    {{- include (print .Template.BasePath "/etc/_compute.filters.tpl") . | nindent 4 }}
   sudoers-nova: |
-{{ include (print .Template.BasePath "/etc/_sudoers-nova.tpl") . | indent 4 }}
+    {{- include (print .Template.BasePath "/etc/_sudoers-nova.tpl") . | nindent 4 }}


### PR DESCRIPTION
Stacked on #12403 — merge that one first.

**This PR** fixes leading blank lines in ConfigMap data for nova-hypervisor-agents.

Every `ConfigMap.data.<key>` template combining `|` with `{{ include ... | indent 4 }}` on the next line renders with a blank line at the start of the file value — Helm's `indent` emits its own leading newline. Not a crashloop (oslo.config is tolerant) but the rendered output is visibly wrong.

Fix for `include`-based keys: `|-` + `{{- include ... | nindent 4 }}`. `|-` absorbs the extra trailing newline that `nindent` would add; the rendered file still ends with the final line's newline.

`libvirtd.conf` is inline literal content (no `include`/`nindent` involved, no leading-blank-line problem) and keeps plain `|` — which preserves the conventional trailing newline.