### PR TITLE
keystone: fix project scope missing from log lines

### DIFF
--- a/openstack/keystone/templates/etc/_keystone.conf.tpl
+++ b/openstack/keystone/templates/etc/_keystone.conf.tpl
@@ -13,7 +13,7 @@ log_config_append = /etc/keystone/logging.conf
 logging_context_format_string = %(process)d %(levelname)s %(name)s [%(request_id)s g%(global_request_id)s %(user_identity)s] %(instance)s%(message)s
 logging_default_format_string = %(process)d %(levelname)s %(name)s [-] %(instance)s%(message)s
 logging_exception_prefix = %(process)d ERROR %(name)s %(instance)s
-logging_user_identity_format = usr %(user)s prj %(tenant)s dom %(domain)s usr-dom %(user_domain)s prj-dom %(project_domain)s
+logging_user_identity_format = usr %(user)s prj %(project)s dom %(domain)s usr-dom %(user_domain)s prj-dom %(project_domain)s
 
 notification_format = {{ .Values.api.notifications.format | default "cadf" | quote }}
 {{ range $message_type := .Values.api.notifications.opt_out }}


### PR DESCRIPTION
The logging_user_identity_format used %(tenant)s, which is not a key in oslo.context's logging values (the key is %(project)s). oslo.log renders missing keys as '-', so every log line showed 'prj -' regardless of the token's project scope.

Switch to %(project)s to match the shared oslo logging format used by all other OpenStack services, so the scoped project id is logged.