### PR TITLE
keystone: Apache workers metrics

### DIFF
--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: keystone
 sources:
   - https://github.com/sapcc/keystone
-version: 0.13.0
+version: 0.13.1
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/keystone/templates/bin/_wsgi_sampler.py.tpl
+++ b/openstack/keystone/templates/bin/_wsgi_sampler.py.tpl
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+# SPDX-License-Identifier: Apache-2.0
+
+# WSGI worker-pool sampler.
+#
+# This module is loaded into every mod_wsgi daemon process via
+# WSGIImportScript. Because it runs *inside* the daemon interpreter, it can
+# call mod_wsgi.process_metrics() to read that process's own state. Each
+# process pushes its current "active_requests" (0 or 1, since keystone runs
+# with threads=1) to statsd as a gauge labelled by pid. The statsd-exporter
+# sidecar turns these into Prometheus series; summing across pids yields the
+# pool-wide busy worker count, and (processes - busy) yields the free count.
+
+import os
+import socket
+import threading
+import time
+
+try:
+    import mod_wsgi
+except ImportError:
+    mod_wsgi = None
+
+
+# How often (seconds) each process samples and reports its state.
+SAMPLE_INTERVAL = float(os.environ.get("WSGI_SAMPLER_INTERVAL", "2"))
+
+STATSD_HOST = os.environ.get("STATSD_HOST", "127.0.0.1")
+STATSD_PORT = int(os.environ.get("STATSD_PORT", "9125"))
+STATSD_PREFIX = os.environ.get("STATSD_PREFIX", "openstack")
+
+
+def _send(sock, metric, value):
+    """Send a single statsd gauge datagram; never raise into the caller."""
+    try:
+        payload = "%s:%d|g" % (metric, value)
+        sock.sendto(payload.encode("utf-8"), (STATSD_HOST, STATSD_PORT))
+    except Exception:
+        # Sampling must never affect request serving.
+        pass
+
+
+def _loop():
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    while True:
+        try:
+            metrics = mod_wsgi.process_metrics()
+            pid = metrics["pid"]
+            active = int(metrics.get("active_requests", 0))
+            # Metric name carries the pid so the statsd-exporter can map it to
+            # a Prometheus label. Sum across pids = busy workers.
+            metric = "%s.wsgi.worker.active_requests.%s" % (STATSD_PREFIX, pid)
+            _send(sock, metric, active)
+        except Exception:
+            pass
+        time.sleep(SAMPLE_INTERVAL)
+
+
+def start():
+    if mod_wsgi is None:
+        # Not running under mod_wsgi (e.g. imported elsewhere); do nothing.
+        return
+    thread = threading.Thread(target=_loop, name="wsgi-worker-sampler")
+    thread.daemon = True
+    thread.start()
+
+
+start()

--- a/openstack/keystone/templates/configmap-bin.yaml
+++ b/openstack/keystone/templates/configmap-bin.yaml
@@ -17,5 +17,7 @@ data:
 {{ include (print .Template.BasePath "/bin/_repair_assignments.tpl") . | indent 4 }}
   keystone-api.sh: |
 {{ include (print .Template.BasePath "/bin/_keystone_api.sh.tpl") . | indent 4 }}
+  wsgi-sampler.py: |
+{{ include (print .Template.BasePath "/bin/_wsgi_sampler.py.tpl") . | indent 4 }}
   region-check.py: |
 {{ .Files.Get "files/region-check.py" | indent 4 }}

--- a/openstack/keystone/templates/configmap-etc.yaml
+++ b/openstack/keystone/templates/configmap-etc.yaml
@@ -24,13 +24,25 @@ data:
 {{- if .Values.watcher.enabled }}
   watcher.yaml: |
 {{ include (print .Template.BasePath "/etc/_watcher.yaml.tpl") . | indent 4 }}
+{{- end }}
+{{- if .Values.api.metrics.enabled }}
   statsd-exporter.yaml: |
+    mappings:
+      # Per-process WSGI worker state pushed by /scripts/wsgi-sampler.py.
+      # The pid is carried in the metric name and mapped to a Prometheus label.
+      # Prometheus: sum(keystone_wsgi_worker_active_requests) = busy workers;
+      # (processes - busy) = free workers.
+      - match: "{{ .Values.api.metrics.prefix | default "openstack" }}.wsgi.worker.active_requests.*"
+        name: "keystone_wsgi_worker_active_requests"
+        match_metric_type: gauge
+        labels:
+          pid: "$1"
     defaults:
       timer_type: histogram
       buckets: [.025, .1, .25, 1, 2.5, 5, 10, 15, 30]
       match_type: glob
       glob_disable_ordering: false
-      ttl: 0 # metrics do not expire
+      ttl: 30s # worker gauges expire if a process stops reporting
 {{- end }}
   access_rules.json: |
 {{ include (print .Template.BasePath "/etc/_access_rules.json.tpl") . | indent 4 }}

--- a/openstack/keystone/templates/configmap-etc.yaml
+++ b/openstack/keystone/templates/configmap-etc.yaml
@@ -37,12 +37,13 @@ data:
         match_metric_type: gauge
         labels:
           pid: "$1"
+        ttl: 30s # expire a worker gauge if its process stops reporting
     defaults:
       timer_type: histogram
       buckets: [.025, .1, .25, 1, 2.5, 5, 10, 15, 30]
       match_type: glob
       glob_disable_ordering: false
-      ttl: 30s # worker gauges expire if a process stops reporting
+      ttl: 0
 {{- end }}
   access_rules.json: |
 {{ include (print .Template.BasePath "/etc/_access_rules.json.tpl") . | indent 4 }}

--- a/openstack/keystone/templates/deployment-api.yaml
+++ b/openstack/keystone/templates/deployment-api.yaml
@@ -54,7 +54,7 @@ spec:
         {{- if .Values.federation.saml.enabled }}
         federation-saml-hash: {{ include (print $.Template.BasePath "/federation-saml.yaml") . | sha256sum }}
         {{- end }}
-        {{- if .Values.proxysql.mode }}
+        {{- if .Values.api.metrics.enabled }}
         prometheus.io/scrape: "true"
         prometheus.io/targets: {{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus | quote }}
         {{- end }}

--- a/openstack/keystone/templates/etc/_wsgi-keystone.conf.tpl
+++ b/openstack/keystone/templates/etc/_wsgi-keystone.conf.tpl
@@ -57,9 +57,20 @@ CustomLog /dev/stdout proxy env=forwarded
 
 {{- end }}
 
+{{- if .Values.api.metrics.enabled }}
+# Enable mod_wsgi request/process metrics so the per-process worker sampler
+# (loaded via WSGIImportScript below) can read mod_wsgi.process_metrics().
+WSGIServerMetrics On
+{{- end }}
+
 <VirtualHost *:5000>
     ServerName {{ .Values.services.public.host }}.{{ .Values.global.region }}.{{ .Values.global.tld }}
     WSGIDaemonProcess keystone-public processes=8 threads=1 user=keystone group=keystone display-name=%{GROUP}
+    {{- if .Values.api.metrics.enabled }}
+    # Load the worker-pool sampler into every keystone-public daemon process.
+    # It reports each process's active_requests to statsd for Prometheus.
+    WSGIImportScript /scripts/wsgi-sampler.py process-group=keystone-public application-group=%{GLOBAL}
+    {{- end }}
     WSGIProcessGroup keystone-public
     WSGIScriptAlias / /var/www/cgi-bin/keystone/keystone-wsgi-public
     WSGIApplicationGroup %{GLOBAL}

--- a/openstack/keystone/templates/etc/_wsgi-keystone.conf.tpl
+++ b/openstack/keystone/templates/etc/_wsgi-keystone.conf.tpl
@@ -14,18 +14,28 @@
 
 Listen 0.0.0.0:5000
 
+{{- /* mod_wsgi request/queue/script timestamps (microsecond epoch), exposed as
+       Apache env vars by WSGIServerMetrics. Downstream: queue_wait = script_start
+       - queue_start. Logged as strings so unset ("-") stays valid JSON. Only
+       emitted when metrics (and thus WSGIServerMetrics On) are enabled. */ -}}
+{{- $wsgiJson := "" -}}
+{{- $wsgiPlain := "" -}}
+{{- if .Values.api.metrics.enabled -}}
+{{- $wsgiJson = ",\\\"wsgi_request_start\\\":\\\"%{mod_wsgi.request_start}e\\\",\\\"wsgi_queue_start\\\":\\\"%{mod_wsgi.queue_start}e\\\",\\\"wsgi_script_start\\\":\\\"%{mod_wsgi.script_start}e\\\"" -}}
+{{- $wsgiPlain = " wsgi_request_start=%{mod_wsgi.request_start}e wsgi_queue_start=%{mod_wsgi.queue_start}e wsgi_script_start=%{mod_wsgi.script_start}e" -}}
+{{- end -}}
 {{- if .Values.use_json }}
 ErrorLog /dev/stdout
 ErrorLogFormat "%M"
-LogFormat "{\"timestamp\":\"%{%Y-%m-%dT%H:%M:%S}t.%{msec_frac}t\",\"pid\":%{pid}P,\"levelname\":\"INFO\",\"name\":\"apache.access\",\"request_id\":\"%{X-Openstack-Request-ID}i\",\"client_ip\":\"%a\",\"method\":\"%m\",\"uri\":\"%U%q\",\"protocol\":\"%H\",\"status\":%>s,\"bytes_sent\":%B,\"duration_ms\":%{ms}T,\"referer\":\"%{Referer}i\",\"user_agent\":\"%{User-Agent}i\"}" json_combined
-LogFormat "{\"timestamp\":\"%{%Y-%m-%dT%H:%M:%S}t.%{msec_frac}t\",\"pid\":%{pid}P,\"levelname\":\"INFO\",\"name\":\"apache.access\",\"request_id\":\"%{X-Openstack-Request-ID}i\",\"client_ip\":\"%{X-Forwarded-For}i\",\"method\":\"%m\",\"uri\":\"%U%q\",\"protocol\":\"%H\",\"status\":%>s,\"bytes_sent\":%B,\"duration_ms\":%{ms}T,\"referer\":\"%{Referer}i\",\"user_agent\":\"%{User-Agent}i\"}" json_proxy
+LogFormat "{\"timestamp\":\"%{%Y-%m-%dT%H:%M:%S}t.%{msec_frac}t\",\"pid\":%{pid}P,\"levelname\":\"INFO\",\"name\":\"apache.access\",\"request_id\":\"%{X-Openstack-Request-ID}i\",\"client_ip\":\"%a\",\"method\":\"%m\",\"uri\":\"%U%q\",\"protocol\":\"%H\",\"status\":%>s,\"bytes_sent\":%B,\"duration_ms\":%{ms}T,\"referer\":\"%{Referer}i\",\"user_agent\":\"%{User-Agent}i\"{{ $wsgiJson }}}" json_combined
+LogFormat "{\"timestamp\":\"%{%Y-%m-%dT%H:%M:%S}t.%{msec_frac}t\",\"pid\":%{pid}P,\"levelname\":\"INFO\",\"name\":\"apache.access\",\"request_id\":\"%{X-Openstack-Request-ID}i\",\"client_ip\":\"%{X-Forwarded-For}i\",\"method\":\"%m\",\"uri\":\"%U%q\",\"protocol\":\"%H\",\"status\":%>s,\"bytes_sent\":%B,\"duration_ms\":%{ms}T,\"referer\":\"%{Referer}i\",\"user_agent\":\"%{User-Agent}i\"{{ $wsgiJson }}}" json_proxy
 SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
 CustomLog /dev/stdout json_combined env=!forwarded
 CustomLog /dev/stdout json_proxy env=forwarded
 {{- else }}
 ErrorLog /dev/stdout
-LogFormat "%{%Y-%m-%d %T}t.%{msec_frac}t %{pid}P INFO apache \"%{X-Openstack-Request-ID}i\" %h %l %u \"%r\" %>s %b %{ms}T \"%{Referer}i\" \"%{User-Agent}i\"" combined
-LogFormat "%{%Y-%m-%d %T}t.%{msec_frac}t %{pid}P INFO apache \"%{X-Openstack-Request-ID}i\" %{X-Forwarded-For}i %l %u \"%r\" %>s %b %{ms}T \"%{Referer}i\" \"%{User-Agent}i\"" proxy
+LogFormat "%{%Y-%m-%d %T}t.%{msec_frac}t %{pid}P INFO apache \"%{X-Openstack-Request-ID}i\" %h %l %u \"%r\" %>s %b %{ms}T \"%{Referer}i\" \"%{User-Agent}i\"{{ $wsgiPlain }}" combined
+LogFormat "%{%Y-%m-%d %T}t.%{msec_frac}t %{pid}P INFO apache \"%{X-Openstack-Request-ID}i\" %{X-Forwarded-For}i %l %u \"%r\" %>s %b %{ms}T \"%{Referer}i\" \"%{User-Agent}i\"{{ $wsgiPlain }}" proxy
 SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
 CustomLog /dev/stdout combined env=!forwarded
 CustomLog /dev/stdout proxy env=forwarded

--- a/openstack/keystone/templates/service-api.yaml
+++ b/openstack/keystone/templates/service-api.yaml
@@ -11,11 +11,11 @@ metadata:
     component: keystone
     type: api
   annotations:
-{{- if .Values.api.metrics.enabled }}
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "{{.Values.api.metrics.port}}"
-    prometheus.io/targets: "{{ required ".Values.alerts.prometheus missing" .Values.alerts.prometheus }}"
-{{- end }}
+    # Metrics are scraped from the pod (see deployment-api.yaml annotations) via
+    # the metrics-named container port. Annotating the Service for scraping as
+    # well would cause the statsd endpoint to be scraped twice (once by the
+    # service/endpoint discovery and once by the pod discovery), doubling every
+    # statsd metric. See docs playbook "Prometheus target scraped multiple times".
     {{- include "utils.linkerd.pod_and_service_annotation" . | indent 4 }}
 spec:
 {{- if .Values.global.is_global_region }}


### PR DESCRIPTION
- Worker metrics: a sampler loaded into each mod_wsgi daemon via WSGIImportScript reports its active_requests (0/1 with threads=1) to the existing statsd-exporter; summing across pids gives the pool-wide busy-worker count. Also fixes statsd-exporter.yaml being gated on watcher.enabled instead of api.metrics.enabled.
- Timing logs: adds the mod_wsgi request_start/queue_start/script_start timestamps to all four access-log formats (queue wait = script_start - queue_start), logged as strings so unset stays valid JSON.
- Double-scrape fix: removes the Service-level Prometheus scrape annotations so pod-sd is the sole scraper (was doubling every statsd metric); pod scrape annotation re-gated on api.metrics.enabled.