### PR TITLE
fix(kube-system-*): bump owner-label-injector and reloader

### DIFF
--- a/system/kube-system-admin-k3s/Chart.lock
+++ b/system/kube-system-admin-k3s/Chart.lock
@@ -40,6 +40,6 @@ dependencies:
   version: 1.1.19
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
-  version: 1.2.0
-digest: sha256:fea913920a9f68ec344c7c19c8393507a75b0b7f0eba43d33cd06b1c87fa481f
-generated: "2026-07-13T10:01:26.831398+02:00"
+  version: 2.2.14
+digest: sha256:6f1752148d31f3ba785d18dc513e044c12d3bf7d57aea59259bb37c90245e2ac
+generated: "2026-07-27T13:11:38.2574+02:00"

--- a/system/kube-system-admin-k3s/Chart.yaml
+++ b/system/kube-system-admin-k3s/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kube-System relevant Service collection for the new admin clusters.
 name: kube-system-admin-k3s
-version: 3.7.4
+version: 3.7.5
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-admin-k3s
 dependencies:
   - name: node-problem-detector
@@ -47,5 +47,5 @@ dependencies:
     condition: secrets-injector.enabled
   - name: reloader
     repository: oci://ghcr.io/stakater/charts
-    version: 1.2.0
+    version: 2.2.14
     condition: reloader.enabled

--- a/system/kube-system-kubernikus/Chart.lock
+++ b/system/kube-system-kubernikus/Chart.lock
@@ -37,6 +37,6 @@ dependencies:
   version: 1.1.19
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
-  version: 1.2.0
-digest: sha256:7b5293b5e606c057a27ad0f05676fece6ddb7edae352fe5ae388ba2d3b87351c
-generated: "2026-07-13T14:52:01.329054+02:00"
+  version: 2.2.14
+digest: sha256:5d1cb0044e46d6cfee4c9d4424d4a47cfb6870125263ef938bcce199ae9cf150
+generated: "2026-07-27T13:11:31.557182+02:00"

--- a/system/kube-system-kubernikus/Chart.yaml
+++ b/system/kube-system-kubernikus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for Kubernikus control-plane clusters.
 name: kube-system-kubernikus
-version: 3.11.4
+version: 3.11.5
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-kubernikus
 dependencies:
   - name: cc-rbac
@@ -44,5 +44,5 @@ dependencies:
     condition: secrets-injector.enabled
   - name: reloader
     repository: oci://ghcr.io/stakater/charts
-    version: 1.2.0
+    version: 2.2.14
     condition: reloader.enabled

--- a/system/kube-system-metal/Chart.lock
+++ b/system/kube-system-metal/Chart.lock
@@ -73,9 +73,9 @@ dependencies:
   version: 1.1.19
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
-  version: 2.1.3
+  version: 2.2.14
 - name: validating-admission-policy
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.0.2
-digest: sha256:033853608b4cceca13766e9c4726b728c8059ae1be559d58b3dd643f5e9f6642
-generated: "2026-07-13T14:51:42.353011+02:00"
+digest: sha256:5aba0db96bb0c529a4b4899ed6c14da272ae3b19d963693d19b3af0b95d4822f
+generated: "2026-07-27T13:11:06.792791+02:00"

--- a/system/kube-system-metal/Chart.yaml
+++ b/system/kube-system-metal/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for metal clusters.
 name: kube-system-metal
-version: 6.14.8
+version: 6.14.9
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-metal
 dependencies:
   - name: cc-rbac
@@ -94,7 +94,7 @@ dependencies:
     condition: secrets-injector.enabled
   - name: reloader
     repository: oci://ghcr.io/stakater/charts
-    version: 2.1.3
+    version: 2.2.14
     condition: reloader.enabled
   - name: validating-admission-policy
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/system/kube-system-scaleout/Chart.lock
+++ b/system/kube-system-scaleout/Chart.lock
@@ -43,6 +43,6 @@ dependencies:
   version: 1.1.19
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
-  version: 1.2.0
-digest: sha256:9a4f5913568593a3a6f5ad366b44717368ecd76c947dafc6ad13c038b15d0807
-generated: "2026-07-13T14:51:49.792454+02:00"
+  version: 2.2.14
+digest: sha256:b2785319d7478fff850ade5c6bd14b814bee714c4601bf683a13135ba364a91a
+generated: "2026-07-27T13:11:16.391851+02:00"

--- a/system/kube-system-scaleout/Chart.yaml
+++ b/system/kube-system-scaleout/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kube-System relevant Service collection for scaleout clusters.
 name: kube-system-scaleout
-version: 5.13.5
+version: 5.13.6
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-scaleout
 dependencies:
   - name: cc-rbac
@@ -53,5 +53,5 @@ dependencies:
     condition: secrets-injector.enabled
   - name: reloader
     repository: oci://ghcr.io/stakater/charts
-    version: 1.2.0
+    version: 2.2.14
     condition: reloader.enabled

--- a/system/kube-system-virtual/Chart.lock
+++ b/system/kube-system-virtual/Chart.lock
@@ -55,6 +55,6 @@ dependencies:
   version: 1.1.19
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
-  version: 1.2.0
-digest: sha256:85eaa852d9d75dd803596fee750be6cd70e4564bb635bc966c64675279892881
-generated: "2026-07-13T14:51:55.279553+02:00"
+  version: 2.2.14
+digest: sha256:0fa30b7d6af1cb586667e18034f431f348ffa01b40492cf578309458b9201200
+generated: "2026-07-27T13:11:23.830327+02:00"

--- a/system/kube-system-virtual/Chart.yaml
+++ b/system/kube-system-virtual/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for virtual clusters.
 name: kube-system-virtual
-version: 4.9.7
+version: 4.9.8
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-virtual
 dependencies:
   - name: cc-rbac
@@ -62,5 +62,5 @@ dependencies:
     condition: secrets-injector.enabled
   - name: reloader
     repository: oci://ghcr.io/stakater/charts
-    version: 1.2.0
+    version: 2.2.14
     condition: reloader.enabled


### PR DESCRIPTION
## Summary

Bumps two kube-system components across all 5 chart variants
(metal, scaleout, virtual, kubernikus, admin-k3s).

## Changes

### owner-label-injector
New image built 2026-07-24 after [fix(build): bump Go builder image to 1.26-alpine](https://github.wdf.sap.corp/cc/owner-label-injector/pull/165).
Keppel vulnerability status: **Clean** (no CVEs).
Previously broken CI build prevented new images since May 2026.

### reloader
- metal: `2.1.3` → `2.2.14`
- scaleout/virtual/kubernikus/admin-k3s: `1.2.0` → `2.2.14`
- App version: v1.4.19, Go 1.26.4

## Deployment Scope

Both components are deployed on all 5 cluster types:

| Pipeline | Cluster type | owner-label-injector | reloader |
|---|---|---|---|
| `kube-system-metal` | metal | ✅ deployed | ✅ deployed |
| `kube-system-scaleout` | scaleout | ✅ deployed | ✅ deployed |
| `kube-system-virtual` | virtual | ✅ deployed | ✅ deployed |
| `kube-system-kubernikus` | kubernikus | ✅ deployed | ✅ deployed |
| `kube-system-admin-k3s` | admin-k3s | ✅ deployed | ✅ deployed |

## Ref

https://github.wdf.sap.corp/cc/unified-kubernetes/issues/1360