### PR TITLE
metal-operator: bump missing deployments to v0.6.2

### DIFF
--- a/system/metal-operator/Chart.lock
+++ b/system/metal-operator/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.0.0
 - name: metal-operator
   repository: oci://ghcr.io/ironcore-dev/charts
-  version: 0.6.1
-digest: sha256:b64dc85d9e3fb8ade63bdaf2e522a307bea75421699b19d2a880a6179a2a363a
-generated: "2026-07-17T15:28:08.992778+03:00"
+  version: 0.6.2
+digest: sha256:3f0cb9a380ed59f687566cb2b97f64e6181cc6ba53e63fb858965e8ff43cc60b
+generated: "2026-07-27T13:42:54.246842+02:00"

--- a/system/metal-operator/Chart.yaml
+++ b/system/metal-operator/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: metal-operator
 description: A Helm chart for the Ironcore metal-operator.
 type: application
-version: 0.2.17
+version: 0.2.18
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: ">= 0.0.0"
   - name: metal-operator
     repository: oci://ghcr.io/ironcore-dev/charts
-    version: 0.6.1
+    version: 0.6.2
     alias: metal-operator-core


### PR DESCRIPTION
this chart was not updated in #12402 