### PR TITLE
[octavia] Add CPBMU feature flag support

### DIFF
--- a/openstack/octavia/templates/etc/_octavia.conf.tpl
+++ b/openstack/octavia/templates/etc/_octavia.conf.tpl
@@ -14,6 +14,7 @@ rpc_response_timeout = {{ .Values.rpc_response_timeout | default .Values.global.
 bind_host = 0.0.0.0
 bind_port = {{.Values.global.octavia_port_internal | default 9876}}
 healthcheck_enabled = True
+allow_cross_pool_batch_members_update = {{ if hasKey .Values "allow_cross_pool_batch_members_update" }}{{ .Values.allow_cross_pool_batch_members_update }}{{ else }}true{{ end }}
 
 # Enable/disable exposing API endpoints. By default, both v1 and v2 are enabled.
 api_v1_enabled = False


### PR DESCRIPTION
The endpoint is not yet optimized, therefore not ready for production. Gate prod regions.
Feature flag code change in Octavia: https://github.com/sapcc/octavia/pull/63