### PR TITLE
fix(gatekeeper): audit-logs needs mayWriteHostPathVolumes in init container

### DIFF
--- a/system/gatekeeper/templates/constraint-pod-security-v2.yaml
+++ b/system/gatekeeper/templates/constraint-pod-security-v2.yaml
@@ -981,7 +981,7 @@ spec:
           and host root filesystem mount to set up auditd log reading.
         mayBePrivileged: true
         mayUseHostPID: true
-        mayReadHostPathVolumes: [ / ]
+        mayWriteHostPathVolumes: [ / ]
 
       - matchNamespace: opensearch-logs
         matchRepository: busybox


### PR DESCRIPTION
## Summary
Fixes the pod-security-v2 allowlist for the fortlogs-audit namespace so the OTel audit-logs DaemonSet collector can start on clusters with strict pod security policies.

## Problem
OTEL collectors pods cannot start because policy denies it: `    - enforcementAction: dryrun
      group: apps
      kind: DaemonSet
      message: '{"support_group":"observability","service":"audit-logs"} >> container
        "init" in this pod is not allowed to mount hostPath volumes with path "/"
        (readonly = false) (image = "ccloud-dockerhub-mirror/library/alpine")'
      name: audit-logs-collector
      namespace: fortlogs-audit
      version: v1`

We need the read access to host path because: https://github.com/cloudoperators/greenhouse-extensions/blob/main/audit-logs/charts/templates/_auditd-config.tpl

## Changes
- update existing allowlist entry for ccloud-dockerhub-mirror/library/alpine init container in fortlogs-audit with mayWriteHostPathVolumes: [ / ]

## Related
follow-up: https://github.com/sapcc/helm-charts/pull/12404