### PR TITLE
feat(shoots): exclude /32 and /128 host routes from BGP reject filter

### DIFF
--- a/system/cc-shoots-compute/Chart.yaml
+++ b/system/cc-shoots-compute/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-shoots-compute
 description: Converged Cloud Gardener shoots
 type: application
-version: 2.6.5
+version: 2.6.6
 appVersion: "0.1.0"

--- a/system/cc-shoots-compute/ci/test-values.yaml
+++ b/system/cc-shoots-compute/ci/test-values.yaml
@@ -18,6 +18,7 @@ kvmShoots:
       services: "12.34.56.78/16"
       externalServices:
         - cidr: 12.34.56.78/16
+        - cidr: 1.1.1.1/32
       asNumber: 12345
       nodeNetworks:
       - 12.34.56.78/16

--- a/system/cc-shoots-compute/templates/kvm-shoot.yaml
+++ b/system/cc-shoots-compute/templates/kvm-shoot.yaml
@@ -142,10 +142,13 @@ spec:
             bgpFilter:
               - name: v4filter
                 exportV4:
+                  {{- /* Skip /32 and /128 host routes - these are anycast VIPs that must be advertised via BGP */}}
                   {{- range $cluster.networking.externalServices }}
+                  {{- if not (or (hasSuffix "/32" .cidr) (hasSuffix "/128" .cidr)) }}
                   - cidr: {{ .cidr }}
                     matchOperator: Equal
                     action: Reject
+                  {{- end }}
                   {{- end }}
                   {{- if $.Values.networking.overlay }}
                   - cidr: {{ default $.Values.networking.pods $cluster.networking.pods }}

--- a/system/cc-shoots-controlplane/Chart.yaml
+++ b/system/cc-shoots-controlplane/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-shoots-controlplane
 description: Converged Cloud Gardener Controlplane shoots
 type: application
-version: 1.0.7
+version: 1.0.8
 appVersion: "0.1.0"

--- a/system/cc-shoots-controlplane/ci/test-values.yaml
+++ b/system/cc-shoots-controlplane/ci/test-values.yaml
@@ -13,6 +13,7 @@ cpShoots:
       services: "12.34.56.78/16"
       externalServices:
         - cidr: 12.34.56.78/16
+        - cidr: 1.1.1.1/32
       asNumber: 12345
       nodeNetworks:
       - 12.34.56.78/16

--- a/system/cc-shoots-controlplane/templates/controlplane-shoot.yaml
+++ b/system/cc-shoots-controlplane/templates/controlplane-shoot.yaml
@@ -133,10 +133,13 @@ spec:
             bgpFilter:
               - name: v4filter
                 exportV4:
+                  {{- /* Skip /32 and /128 host routes - these are anycast VIPs that must be advertised via BGP */}}
                   {{- range $cluster.networking.externalServices }}
+                  {{- if not (or (hasSuffix "/32" .cidr) (hasSuffix "/128" .cidr)) }}
                   - cidr: {{ .cidr }}
                     matchOperator: Equal
                     action: Reject
+                  {{- end }}
                   {{- end }}
                   {{- if $.Values.networking.overlay }}        
                   - cidr: {{ default $.Values.networking.pods $cluster.networking.pods }}

--- a/system/cc-shoots-mgmt/Chart.yaml
+++ b/system/cc-shoots-mgmt/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-shoots-mgmt
 description: Converged Cloud Gardener shoots
 type: application
-version: 1.1.37
+version: 1.1.38
 appVersion: "0.1.0"

--- a/system/cc-shoots-mgmt/ci/test-values.yaml
+++ b/system/cc-shoots-mgmt/ci/test-values.yaml
@@ -16,6 +16,7 @@ mgmtShoots:
       services: "12.34.56.78/16"
       externalServices:
         - cidr: 12.34.56.78/16
+        - cidr: 1.1.1.1/32
       asNumber: 12345
       nodeNetworks:
       - 12.34.56.78/16

--- a/system/cc-shoots-mgmt/templates/mgmt-shoot.yaml
+++ b/system/cc-shoots-mgmt/templates/mgmt-shoot.yaml
@@ -139,10 +139,13 @@ spec:
             bgpFilter:
               - name: v4filter
                 exportV4:
+                  {{- /* Skip /32 and /128 host routes - these are anycast VIPs that must be advertised via BGP */}}
                   {{- range $cluster.networking.externalServices }}
+                  {{- if not (or (hasSuffix "/32" .cidr) (hasSuffix "/128" .cidr)) }}
                   - cidr: {{ .cidr }}
                     matchOperator: Equal
                     action: Reject
+                  {{- end }}
                   {{- end }}
                   {{- if $.Values.networking.overlay }}        
                   - cidr: {{ default $.Values.networking.pods $cluster.networking.pods }}

--- a/system/cc-shoots-storage/Chart.yaml
+++ b/system/cc-shoots-storage/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cc-shoots-storage
 description: Converged Cloud Gardener Storage shoots
 type: application
-version: 0.0.12
+version: 0.0.13
 appVersion: "0.1.0"

--- a/system/cc-shoots-storage/ci/test-values.yaml
+++ b/system/cc-shoots-storage/ci/test-values.yaml
@@ -13,6 +13,7 @@ stShoots:
       services: "12.34.56.78/16"
       externalServices:
         - cidr: 12.34.56.78/16
+        - cidr: 1.1.1.1/32
       asNumber: 12345
       nodeNetworks:
       - 12.34.56.78/16

--- a/system/cc-shoots-storage/templates/storage-shoot.yaml
+++ b/system/cc-shoots-storage/templates/storage-shoot.yaml
@@ -130,10 +130,13 @@ spec:
             bgpFilter:
               - name: v4filter
                 exportV4:
+                  {{- /* Skip /32 and /128 host routes - these are anycast VIPs that must be advertised via BGP */}}
                   {{- range $cluster.networking.externalServices }}
+                  {{- if not (or (hasSuffix "/32" .cidr) (hasSuffix "/128" .cidr)) }}
                   - cidr: {{ .cidr }}
                     matchOperator: Equal
                     action: Reject
+                  {{- end }}
                   {{- end }}
                   {{- if $.Values.networking.overlay }}
                   - cidr: {{ default $.Values.networking.pods $cluster.networking.pods }}


### PR DESCRIPTION
Anycast VIPs (host routes) in `externalServices` must be advertised via BGP, not rejected.

This adds a `hasSuffix` check to skip `/32` and `/128` CIDRs from the BGP export reject filter while keeping them in `serviceLoadBalancerIPs` and `IPPools`.

**Affected charts:**
- cc-shoots-controlplane (1.0.7 → 1.0.8)
- cc-shoots-storage (0.0.12 → 0.0.13)
- cc-shoots-mgmt (1.1.35 → 1.1.36)
- cc-shoots-compute (2.6.5 → 2.6.6)

**Test:** Added `1.1.1.1/32` to all CI test-values; verified it appears in `serviceLoadBalancerIPs` but NOT in the reject filter.