### PR TITLE
[Neutron] Linuxbridge agent does not need network namespaces

### DIFF
--- a/openstack/neutron/templates/statefulset-network-agent-apod.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent-apod.yaml
@@ -174,8 +174,6 @@ spec:
           resources:
 {{ toYaml $.Values.pod.resources.linuxbridge_agent | indent 12 }}
           volumeMounts:
-            - name: network-namespace
-              mountPath: /var/run/netns
             - mountPath: /lib/modules
               name: modules
               readOnly: true

--- a/openstack/neutron/templates/statefulset-network-agent.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent.yaml
@@ -268,8 +268,6 @@ spec:
           resources:
 {{ toYaml $.Values.pod.resources.linuxbridge_agent | indent 12 }}
           volumeMounts:
-            - name: network-namespace
-              mountPath: /var/run/netns
             - mountPath: /lib/modules
               name: modules
               readOnly: true


### PR DESCRIPTION
Linuxbridge does not need access to the network namespaces as it only creates the bridge and attaches the tap interface and vlan interface to the bridge.