### PR TITLE
openstack/keystone: add localhost:4001 trusted_dashboards in debug mode

### DIFF
--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: keystone
 sources:
   - https://github.com/sapcc/keystone
-version: 0.12.1
+version: 0.12.2
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/keystone/templates/etc/_keystone.conf.tpl
+++ b/openstack/keystone/templates/etc/_keystone.conf.tpl
@@ -194,4 +194,10 @@ allow_headers = Content-Type,Cache-Control,Content-Language,Expires,Last-Modifie
 [federation]
 remote_id_attribute = HTTP_OIDC_ISS
 trusted_dashboard = https://dashboard.{{ .Values.global.region }}.cloud.sap/verify-auth-token
+{{- if .Values.debug }}
+trusted_dashboard = http://localhost:4001/verify-auth-token
+trusted_dashboard = https://localhost:4001/verify-auth-token
+trusted_dashboard = http://127.0.0.1:4001/verify-auth-token
+trusted_dashboard = https://127.0.0.1:4001/verify-auth-token
+{{- end }}
 {{- end }}


### PR DESCRIPTION
When debug is enabled, add http/https localhost and 127.0.0.1 variants of localhost:4001 to the keystone trusted_dashboard list so local dashboard development against debug regions can complete OIDC auth.