### PR TITLE
keystone: Update Chart.lock

### DIFF
--- a/openstack/keystone/Chart.lock
+++ b/openstack/keystone/Chart.lock
@@ -23,5 +23,5 @@ dependencies:
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:8e82cbc084f78e131d0c41203cc14a5ddf6be22fa1551e906682f49889f70ad9
-generated: "2026-07-22T13:24:28.673972+02:00"
+digest: sha256:f2f38de19a0eaddbb3cc782130408e9f202fa80583d60cdfb085e1959773866d
+generated: "2026-07-28T10:23:58.609495839+02:00"


### PR DESCRIPTION
Dependencies were updated in #12118, but the lock file was forgotten.