### PR TITLE
[ironic] dependcy updates

### DIFF
--- a/openstack/ironic/Chart.lock
+++ b/openstack/ironic/Chart.lock
@@ -1,13 +1,13 @@
 dependencies:
 - name: mariadb
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.39.0
+  version: 0.42.0
 - name: pxc-db
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.6.0
 - name: memcached
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.6.17
+  version: 0.6.18
 - name: mysql_metrics
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.8.1
@@ -16,12 +16,12 @@ dependencies:
   version: 1.0.0
 - name: rabbitmq
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.25.2
+  version: 0.25.7
 - name: utils
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.38.0
+  version: 0.38.1
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:0f8d72d11b99ebc2cf713b045fcd4e826add5142b31a42b7819d1018bcae7062
-generated: "2026-06-26T15:25:03.72185+03:00"
+digest: sha256:74df0b12ec755173aada579081435eeb39b5342f024b9da367d7a3d6ea7cfc5c
+generated: "2026-07-28T12:54:42.802296413+02:00"

--- a/openstack/ironic/Chart.yaml
+++ b/openstack/ironic/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
   - condition: mariadb.enabled
     name: mariadb
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: 0.39.0
+    version: ~0.42.0
   - condition: pxc_db.enabled
     name: pxc-db
     alias: pxc_db
@@ -15,7 +15,7 @@ dependencies:
     version: ~0.6.0
   - name: memcached
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.6.17
+    version: ~0.6.18
   - condition: mysql_metrics.enabled
     name: mysql_metrics
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
@@ -25,10 +25,10 @@ dependencies:
     version: ~1.0.0
   - name: rabbitmq
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.25.2
+    version: ~0.25.7
   - name: utils
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-    version: ~0.38.0
+    version: ~0.38.1
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: ~1.1.1


### PR DESCRIPTION
mariadb
v0.42.0 - 2026/07/13
* support SSE-C for Ceph S3 backup uploads
  * default at `global.mariadb.backup_v2.ceph_s3.sse_customer_key`
  * per-target override at `global.mariadb.backup_v2.ceph_s3.targets[].sse_customer_key` (set to `""` to opt out of an inherited default)
* chart version bumped

v0.41.0 - 2026/07/06
* support configurable S3 object lock on backup uploads
  * default at `backup_v2.object_lock.{enabled,lock_mode,retention_days}`
  * per-target overrides at `global.mariadb.backup_v2.aws.object_lock` and `global.mariadb.backup_v2.ceph_s3.targets[].object_lock`
* `maria-back-me-up` updated to `10.11-20260706142324` for object-lock upload support
* chart version bumped

v0.40.0 - 2026/07/03
* optionally cohost the mariadb and the mariadb-backup pods on the same node via the `.Values.backup_v2.cohost_with_mariadb` flag
* chart version bumped

memcached
v0.6.18 - 2026/07/09
* memcached bumped to `1.6.44-alpine3.24` [version](https://github.com/memcached/memcached/wiki/ReleaseNotes1644), includes `1.6.43`  [version](https://github.com/memcached/memcached/wiki/ReleaseNotes1643) fixes
* chart version bumped

rabbitmq
0.25.7 - 2026/07/17
- Add linkerd skip-inbound-ports annotation for TLS listener port in RabbitMQ deployment, if enabled
- Chart version bumped

0.25.6 - 2026/07/13
- Fix volume-permission container failing on fresh PVCs. Only was working if `.erlang.cookie` was existing.
- Chart version bumped

0.25.5 - 2026/07/02
- RabbitMQ [4.3.2 Release notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.3.2)
- `rabbitmq-user-credential-updater` updated to `20260630105135` version
- Chart version bumped

0.25.4 - 2026/07/01
- Fix `projectcalico.org/loadBalancerIPs` annotation needing JSON as value

0.25.3 - 2026/07/01
- Set `projectcalico.org/loadBalancerIPs` annotation to `externalIPs`' values to support newer, Gardener-based clusters

utils
openstack/utils: allow overriding rabbit_qos_prefetch_count (#12204)
