### PR TITLE
[Neutron] Agent remove network namespace mountpoint

### DIFF
--- a/openstack/neutron/templates/statefulset-network-agent-apod.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent-apod.yaml
@@ -110,7 +110,7 @@ spec:
               - |
                 import json, time
                 try:
-                    with open('/var/run/dhcp-agent-status.json', 'r') as f:
+                    with open('/run/dhcp-agent/status.json', 'r') as f:
                         status = json.load(f)
                         status_age = time.time() - status.get('time', 0)
                         if status_age > 60:
@@ -134,8 +134,8 @@ spec:
           resources:
 {{ toYaml $.Values.pod.resources.dhcp_agent | indent 12 }}
           volumeMounts:
-            - name: network-namespace
-              mountPath: /var/run/netns
+            - name: network-status
+              mountPath: /run/dhcp-agent
             - name: metadata-proxy
               mountPath: /run/metadata_proxy
             - name: modules
@@ -204,8 +204,8 @@ spec:
           resources:
 {{ toYaml $.Values.pod.resources.agent_checks_exporter | indent 12 }}
           volumeMounts:
-            - name: network-namespace
-              mountPath: /var/run/netns
+            - name: network-status
+              mountPath: /run/dhcp-agent
         - name: neutron-metadata-agent
           image: {{$.Values.global.registry}}/loci-neutron:{{$.Values.imageVersionNetworkAgentMetadata | default $.Values.imageVersionNetworkAgent | default $.Values.imageVersion | required "Please set neutron.imageVersionNetworkAgentMetadata or similar"}}
           imagePullPolicy: IfNotPresent
@@ -227,7 +227,7 @@ spec:
               readOnly: true
             {{- include "utils.trust_bundle.volume_mount" $ | indent 12 }}
       volumes:
-        - name: network-namespace
+        - name: network-status
           emptyDir: {}
         - name: metadata-proxy
           emptyDir: {}

--- a/openstack/neutron/templates/statefulset-network-agent.yaml
+++ b/openstack/neutron/templates/statefulset-network-agent.yaml
@@ -97,7 +97,7 @@ spec:
               - |
                 import json, time
                 try:
-                    with open('/var/run/dhcp-agent-status.json', 'r') as f:
+                    with open('/run/dhcp-agent/status.json', 'r') as f:
                         status = json.load(f)
                         status_age = time.time() - status.get('time', 0)
                         if status_age > 60:
@@ -121,6 +121,8 @@ spec:
           resources:
 {{ toYaml $.Values.pod.resources.dhcp_agent | indent 12 }}
           volumeMounts:
+            - name: network-status
+              mountPath: /run/dhcp-agent
             - name: metadata-proxy
               mountPath: /run/metadata_proxy
             - name: modules
@@ -188,8 +190,8 @@ spec:
           resources:
 {{ toYaml $.Values.pod.resources.agent_checks_exporter | indent 12 }}
           volumeMounts:
-            - name: network-namespace
-              mountPath: /var/run/netns
+            - name: network-status
+              mountPath: /run/dhcp-agent
 {{- if $.Values.agent.neutron_l3 | default false }}
         - name: neutron-l3-agent
           image: {{$.Values.global.registry}}/loci-neutron:{{$.Values.imageVersionNetworkAgentL3 | default $.Values.imageVersionNetworkAgent | default $.Values.imageVersion | required "Please set neutron.imageVersionNetworkAgentL3 or similar"}}
@@ -300,7 +302,7 @@ spec:
               readOnly: true
             {{- include "utils.trust_bundle.volume_mount" $ | indent 12 }}
       volumes:
-        - name: network-namespace
+        - name: network-status
           emptyDir: {}
         - name: metadata-proxy
           hostPath:


### PR DESCRIPTION
A restarting dhcp-agent container will remove
all network namespaces from the kernel but not the files in /run/netns. Sharing this as a mount is not an option. This will prevent the dhcp-agent from starting up again, because the namespace files are in place, but there are no namespaces.

To work around this, the dhcp-agent writes a status file, which we share with the exporter, containing a list of all synced network namespaces.