### PR TITLE
fix(owner-label-injector): bump to v1.2.0

### DIFF
--- a/system/owner-label-injector/Chart.yaml
+++ b/system/owner-label-injector/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: owner-label-injector
 description: A Helm chart for Kubernetes
 type: application
-version: 1.0.6
-appVersion: "1.1.0"
+version: 1.0.7
+appVersion: "1.2.0"
 dependencies:
   - name: linkerd-support
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm


### PR DESCRIPTION
## Summary

Bumps owner-label-injector from `1.1.0` to `1.2.0`.

New image built with Go 1.26-alpine after fix in
https://github.wdf.sap.corp/cc/owner-label-injector/pull/165.
Keppel vulnerability status: **Clean**.

## CVEs fixed

| CVE | Severity |
|---|---|
| CVE-2025-22871 | Critical — Go net/http request smuggling |
| CVE-2026-39821 | Critical — golang.org/x/net IDNA |

## Ref

https://github.wdf.sap.corp/cc/unified-kubernetes/issues/1360