### PR TITLE
fix(kube-system-*): update Chart.lock to owner-label-injector 1.0.7

### DIFF
--- a/system/kube-system-admin-k3s/Chart.lock
+++ b/system/kube-system-admin-k3s/Chart.lock
@@ -31,7 +31,7 @@ dependencies:
   version: 0.2.0
 - name: owner-label-injector
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.0.6
+  version: 1.0.7
 - name: toolbox-prepull
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.7
@@ -41,5 +41,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 2.2.14
-digest: sha256:6f1752148d31f3ba785d18dc513e044c12d3bf7d57aea59259bb37c90245e2ac
-generated: "2026-07-27T13:11:38.2574+02:00"
+digest: sha256:2b077e3144258a3fb01fdd04957a196729489752575934e673b8346ef8334c35
+generated: "2026-07-28T15:25:11.727458+02:00"

--- a/system/kube-system-admin-k3s/Chart.yaml
+++ b/system/kube-system-admin-k3s/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kube-System relevant Service collection for the new admin clusters.
 name: kube-system-admin-k3s
-version: 3.7.5
+version: 3.7.6
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-admin-k3s
 dependencies:
   - name: node-problem-detector

--- a/system/kube-system-kubernikus/Chart.lock
+++ b/system/kube-system-kubernikus/Chart.lock
@@ -28,7 +28,7 @@ dependencies:
   version: 0.2.0
 - name: owner-label-injector
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.0.6
+  version: 1.0.7
 - name: toolbox-prepull
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.7
@@ -38,5 +38,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 2.2.14
-digest: sha256:5d1cb0044e46d6cfee4c9d4424d4a47cfb6870125263ef938bcce199ae9cf150
-generated: "2026-07-27T13:11:31.557182+02:00"
+digest: sha256:11ad4895ec6a78a50ace3aac3b568fac022855329737ca029808c55eb470d7de
+generated: "2026-07-28T15:25:04.959411+02:00"

--- a/system/kube-system-kubernikus/Chart.yaml
+++ b/system/kube-system-kubernikus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for Kubernikus control-plane clusters.
 name: kube-system-kubernikus
-version: 3.11.5
+version: 3.11.6
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-kubernikus
 dependencies:
   - name: cc-rbac

--- a/system/kube-system-metal/Chart.lock
+++ b/system/kube-system-metal/Chart.lock
@@ -61,7 +61,7 @@ dependencies:
   version: 0.2.0
 - name: owner-label-injector
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.0.6
+  version: 1.0.7
 - name: externalip-operator
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
@@ -77,5 +77,5 @@ dependencies:
 - name: validating-admission-policy
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.0.2
-digest: sha256:5aba0db96bb0c529a4b4899ed6c14da272ae3b19d963693d19b3af0b95d4822f
-generated: "2026-07-27T13:11:06.792791+02:00"
+digest: sha256:13a3654cc57794e22d09d0cc27b06ce56ec09049617394ae9e25f6ab09d84934
+generated: "2026-07-28T15:24:41.371997+02:00"

--- a/system/kube-system-metal/Chart.yaml
+++ b/system/kube-system-metal/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for metal clusters.
 name: kube-system-metal
-version: 6.14.9
+version: 6.14.10
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-metal
 dependencies:
   - name: cc-rbac

--- a/system/kube-system-scaleout/Chart.lock
+++ b/system/kube-system-scaleout/Chart.lock
@@ -34,7 +34,7 @@ dependencies:
   version: 0.2.0
 - name: owner-label-injector
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.0.6
+  version: 1.0.7
 - name: toolbox-prepull
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.7
@@ -44,5 +44,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 2.2.14
-digest: sha256:b2785319d7478fff850ade5c6bd14b814bee714c4601bf683a13135ba364a91a
-generated: "2026-07-27T13:11:16.391851+02:00"
+digest: sha256:053509570b06dee7bef8ab796d563970dde9144e296a9e4f231bb84cd5671226
+generated: "2026-07-28T15:24:50.076648+02:00"

--- a/system/kube-system-scaleout/Chart.yaml
+++ b/system/kube-system-scaleout/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kube-System relevant Service collection for scaleout clusters.
 name: kube-system-scaleout
-version: 5.13.6
+version: 5.13.7
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-scaleout
 dependencies:
   - name: cc-rbac

--- a/system/kube-system-virtual/Chart.lock
+++ b/system/kube-system-virtual/Chart.lock
@@ -49,12 +49,12 @@ dependencies:
   version: 1.0.0
 - name: owner-label-injector
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.0.6
+  version: 1.0.7
 - name: secrets-injector
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.19
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 2.2.14
-digest: sha256:0fa30b7d6af1cb586667e18034f431f348ffa01b40492cf578309458b9201200
-generated: "2026-07-27T13:11:23.830327+02:00"
+digest: sha256:da27727a90a891aaea6c6fc58e9bc0c5aefa0a7e977e1205d48c95799006fc12
+generated: "2026-07-28T15:24:56.941564+02:00"

--- a/system/kube-system-virtual/Chart.yaml
+++ b/system/kube-system-virtual/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for virtual clusters.
 name: kube-system-virtual
-version: 4.9.8
+version: 4.9.9
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-virtual
 dependencies:
   - name: cc-rbac


### PR DESCRIPTION
## Summary

Updates Chart.lock in all 5 kube-system chart variants to pick up
owner-label-injector 1.0.7 (appVersion 1.2.0, image built with Go 1.26-alpine).

This triggers the kube-system-* deployment pipelines to deploy the
new owner-label-injector image with CVE fixes.

## CVEs fixed

| CVE | Severity |
|---|---|
| CVE-2025-22871 | Critical — Go net/http request smuggling |
| CVE-2026-39821 | Critical — golang.org/x/net IDNA |

## Ref

https://github.wdf.sap.corp/cc/unified-kubernetes/issues/1360