### PR TITLE
[ironic] add workaround for OSSN-0099

### DIFF
--- a/openstack/ironic/templates/_conductor-deployment.yaml.tpl
+++ b/openstack/ironic/templates/_conductor-deployment.yaml.tpl
@@ -78,6 +78,9 @@ spec:
         env:
         - name: PYTHONWARNINGS
           value: ignore:Unverified HTTPS request
+        # workaround for OSSN-0099
+        - name: IRONIC_THREAD_STACK_SIZE
+          value: 8388608
         {{- include "utils.sentry_config" . | indent 8 }}
         - name: PGAPPNAME
           valueFrom:

--- a/openstack/ironic/templates/api-deployment.yaml
+++ b/openstack/ironic/templates/api-deployment.yaml
@@ -61,6 +61,9 @@ spec:
         - name: PYTHONWARNINGS
           value: 'ignore:Unverified HTTPS request'
         {{- include "utils.sentry_config" . | indent 8 }}
+        # workaround for OSSN-0099
+        - name: IRONIC_THREAD_STACK_SIZE
+          value: 8388608
         lifecycle:
           preStop:
             {{- include "utils.snippets.pre_stop_graceful_shutdown" . | indent 12 }}

--- a/openstack/ironic/templates/inspector-conductor-deployment.yaml
+++ b/openstack/ironic/templates/inspector-conductor-deployment.yaml
@@ -54,6 +54,9 @@ spec:
         - dumb-init
         - ironic-inspector-conductor
         env:
+        # workaround for OSSN-0099
+        - name: IRONIC_THREAD_STACK_SIZE
+          value: 8388608
           {{- include "utils.sentry_config" . | indent 10 }}
         resources:
 {{ toYaml .Values.pod.resources.inspector | indent 10 }}

--- a/openstack/ironic/templates/inspector-deployment.yaml
+++ b/openstack/ironic/templates/inspector-deployment.yaml
@@ -65,7 +65,10 @@ spec:
             add:
               - NET_ADMIN
         env:
-          {{- include "utils.sentry_config" . | indent 10 }}
+        # workaround for OSSN-0099
+        - name: IRONIC_THREAD_STACK_SIZE
+          value: 8388608
+        {{- include "utils.sentry_config" . | indent 8 }}
         lifecycle:
           preStop:
             {{- include "utils.snippets.pre_stop_graceful_shutdown" . | indent 12 }}


### PR DESCRIPTION
[OSSN-0099](https://wiki.openstack.org/wiki/OSSN/OSSN-0099) is a denial
of service for that antelope/2023.1 doesn't get a bugfix. But this
setting is a passable workaround. We can think about removing it after
we upgraded to flamingo.
