### PR TITLE
tempest: make charts environment-agnostic

### DIFF
--- a/openstack/tempest/barbican-tempest/ci/test-values.yaml
+++ b/openstack/tempest/barbican-tempest/ci/test-values.yaml
@@ -1,0 +1,4 @@
+tempest_common:
+  rbac_policy_object_name_shared_network: "foo"
+  rbac_policy_object_name_private_network: "bar"
+tempestAdminPassword: "baz"

--- a/openstack/tempest/barbican-tempest/templates/etc/_tempest_deployment_config.json.tpl
+++ b/openstack/tempest/barbican-tempest/templates/etc/_tempest_deployment_config.json.tpl
@@ -1,6 +1,10 @@
 {
     "openstack": {
+        {{- if .Values.keystoneUrl }}
+        "auth_url": "{{ .Values.keystoneUrl }}",
+        {{- else }}
         "auth_url": "http://{{ if .Values.global.clusterDomain }}keystone.{{.Release.Namespace}}.svc.{{ required "Missing clusterDomain value!" .Values.global.clusterDomain}}{{ else }}keystone.{{.Release.Namespace}}.svc.kubernetes.{{required "Missing region value!" .Values.global.region}}.{{ required "Missing tld value!" .Values.global.tld}}{{end}}:5000/v3",
+        {{- end }}
         "region_name": "{{ .Values.global.region }}",
         "endpoint_type": "public",
         "admin": {

--- a/openstack/tempest/barbican-tempest/values.yaml
+++ b/openstack/tempest/barbican-tempest/values.yaml
@@ -7,3 +7,95 @@ owner-info:
     - Dmitry Galkin
   support-group: network-api
   service: barbican
+
+# Defaults for tempest-base named templates. These values are the production
+# defaults (identical to the previously hardcoded values). Override any of
+# them in landscape-level values to adapt tempest to a different environment.
+# keystoneUrl: when set, overrides the keystone endpoint in all three places
+# (extra_options [identity] uri_v3, OS_AUTH_URL env, deployment_config auth_url).
+# Leave empty to use the in-cluster URL derived from global.clusterDomain/region/tld.
+# Full keystone URL including /v3, e.g. http://keystone.openstack.svc.cluster.local:5000/v3
+# Leave empty to derive the URL from global.clusterDomain/region/tld.
+keystoneUrl: ""
+
+tempest_base:
+  identity:
+    default_credentials_domain_name: tempest
+    domain_name: tempest
+    admin_domain_name: tempest
+    admin_role: admin
+    user_unique_last_password_count: 5
+    user_lockout_duration: 300
+    user_lockout_failure_attempts: 5
+  network:
+    project_network_cidr: "10.199.0.0/16"
+    floating_network_name: "FloatingIP-external-monsoon3-01"
+    subnet_id: "a5703f23-ffcb-4ca7-9dfe-ab9861d91bf5"
+    max_mtu: 9000
+  compute:
+    image_ref: "84f9f266-3f11-4447-ae6c-f7940b2f5eb1"
+    image_ref_alt: "84f9f266-3f11-4447-ae6c-f7940b2f5eb1"
+    flavor_ref: 20
+    flavor_ref_alt: 30
+    min_microversion: "2.1"
+    compute_volume_common_az: "qa-de-1b"
+    vnc_server_header: "WebSockify"
+  baremetal:
+    max_microversion: "1.78"
+    driver: "fake-hardware"
+  validation:
+    image_ssh_user: "ccloud"
+  volume:
+    vendor_name: "VMware"
+    storage_protocol: "vstorageobject"
+    disk_format: "vmdk"
+    volume_size: 10
+    volume_type: "vmware"
+  volume_feature_enabled:
+    backup: true
+  service_available:
+    manila: true
+    neutron: true
+    cinder: true
+    glance: true
+    nova: true
+    swift: true
+    designate: true
+    ironic: true
+    barbican: true
+    keystone: true
+    octavia: true
+  dns:
+    nameservers: "10.114.1.233,147.204.35.140,147.204.35.141"
+
+# Defaults that make helm lint pass without any --set flags.
+# Override these in production deployments or landscape values files.
+tempestAdminPassword: ""
+
+tempest_common:
+  domainId: ""
+  public_network_id: ""
+  shared_physical_network: true
+  rbac_policy_object_name_shared_network: ""
+  rbac_policy_object_name_private_network: ""
+
+tempest_slack_webhook_url:
+  tempest_tests: ""
+  neutron: ""
+  nova: ""
+  ironic: ""
+  barbican: ""
+  cinder: ""
+  manila: ""
+  glance: ""
+  designate: ""
+  keystone: ""
+  octavia: ""
+  kvm: ""
+  cvh: ""
+  cinder_vmdk: ""
+
+global:
+  region: ""
+  tld: "cloud.sap"
+  clusterDomain: ""

--- a/openstack/tempest/cinder-tempest-vmdk/ci/test-values.yaml
+++ b/openstack/tempest/cinder-tempest-vmdk/ci/test-values.yaml
@@ -1,0 +1,4 @@
+tempest_common:
+  rbac_policy_object_name_shared_network: "foo"
+  rbac_policy_object_name_private_network: "bar"
+tempestAdminPassword: "baz"

--- a/openstack/tempest/cinder-tempest-vmdk/templates/etc/_tempest_deployment_config.json.tpl
+++ b/openstack/tempest/cinder-tempest-vmdk/templates/etc/_tempest_deployment_config.json.tpl
@@ -1,6 +1,10 @@
 {
     "openstack": {
+        {{- if .Values.keystoneUrl }}
+        "auth_url": "{{ .Values.keystoneUrl }}",
+        {{- else }}
         "auth_url": "http://{{ if .Values.global.clusterDomain }}keystone.{{.Release.Namespace}}.svc.{{ required "Missing clusterDomain value!" .Values.global.clusterDomain}}{{ else }}keystone.{{.Release.Namespace}}.svc.kubernetes.{{required "Missing region value!" .Values.global.region}}.{{ required "Missing tld value!" .Values.global.tld}}{{end}}:5000/v3",
+        {{- end }}
         "region_name": "{{ .Values.global.region }}",
         "endpoint_type": "internal",
         "admin": {

--- a/openstack/tempest/cinder-tempest-vmdk/templates/tempest-pod.yaml
+++ b/openstack/tempest/cinder-tempest-vmdk/templates/tempest-pod.yaml
@@ -43,7 +43,11 @@ spec:
         - name: OS_IDENTITY_API_VERSION
           value: "3"
         - name: OS_AUTH_URL
+          {{- if .Values.keystoneUrl }}
+          value: "{{ .Values.keystoneUrl }}"
+          {{- else }}
           value: "http://{{ if .Values.global.clusterDomain }}keystone.{{.Release.Namespace}}.svc.{{ required "Missing clusterDomain value!" .Values.global.clusterDomain}}{{ else }}keystone.{{.Release.Namespace}}.svc.kubernetes.{{required "Missing region value!" .Values.global.region}}.{{ required "Missing tld value!" .Values.global.tld}}{{end}}:5000/v3"
+          {{- end }}
       resources:
         requests:
           memory: "2048Mi"

--- a/openstack/tempest/cinder-tempest-vmdk/values.yaml
+++ b/openstack/tempest/cinder-tempest-vmdk/values.yaml
@@ -14,3 +14,95 @@ owner-info:
     - Dmitry Galkin
   support-group: network-api
   service: cinder
+
+# Defaults for tempest-base named templates. These values are the production
+# defaults (identical to the previously hardcoded values). Override any of
+# them in landscape-level values to adapt tempest to a different environment.
+# keystoneUrl: when set, overrides the keystone endpoint in all three places
+# (extra_options [identity] uri_v3, OS_AUTH_URL env, deployment_config auth_url).
+# Leave empty to use the in-cluster URL derived from global.clusterDomain/region/tld.
+# Full keystone URL including /v3, e.g. http://keystone.openstack.svc.cluster.local:5000/v3
+# Leave empty to derive the URL from global.clusterDomain/region/tld.
+keystoneUrl: ""
+
+tempest_base:
+  identity:
+    default_credentials_domain_name: tempest
+    domain_name: tempest
+    admin_domain_name: tempest
+    admin_role: admin
+    user_unique_last_password_count: 5
+    user_lockout_duration: 300
+    user_lockout_failure_attempts: 5
+  network:
+    project_network_cidr: "10.199.0.0/16"
+    floating_network_name: "FloatingIP-external-monsoon3-01"
+    subnet_id: "a5703f23-ffcb-4ca7-9dfe-ab9861d91bf5"
+    max_mtu: 9000
+  compute:
+    image_ref: "84f9f266-3f11-4447-ae6c-f7940b2f5eb1"
+    image_ref_alt: "84f9f266-3f11-4447-ae6c-f7940b2f5eb1"
+    flavor_ref: 20
+    flavor_ref_alt: 30
+    min_microversion: "2.1"
+    compute_volume_common_az: "qa-de-1b"
+    vnc_server_header: "WebSockify"
+  baremetal:
+    max_microversion: "1.78"
+    driver: "fake-hardware"
+  validation:
+    image_ssh_user: "ccloud"
+  volume:
+    vendor_name: "VMware"
+    storage_protocol: "vstorageobject"
+    disk_format: "vmdk"
+    volume_size: 10
+    volume_type: "vmware"
+  volume_feature_enabled:
+    backup: true
+  service_available:
+    manila: true
+    neutron: true
+    cinder: true
+    glance: true
+    nova: true
+    swift: true
+    designate: true
+    ironic: true
+    barbican: true
+    keystone: true
+    octavia: true
+  dns:
+    nameservers: "10.114.1.233,147.204.35.140,147.204.35.141"
+
+# Defaults that make helm lint pass without any --set flags.
+# Override these in production deployments or landscape values files.
+tempestAdminPassword: ""
+
+tempest_common:
+  domainId: ""
+  public_network_id: ""
+  shared_physical_network: true
+  rbac_policy_object_name_shared_network: ""
+  rbac_policy_object_name_private_network: ""
+
+tempest_slack_webhook_url:
+  tempest_tests: ""
+  neutron: ""
+  nova: ""
+  ironic: ""
+  barbican: ""
+  cinder: ""
+  manila: ""
+  glance: ""
+  designate: ""
+  keystone: ""
+  octavia: ""
+  kvm: ""
+  cvh: ""
+  cinder_vmdk: ""
+
+global:
+  region: ""
+  tld: "cloud.sap"
+  clusterDomain: ""

--- a/openstack/tempest/cinder-tempest/ci/test-values.yaml
+++ b/openstack/tempest/cinder-tempest/ci/test-values.yaml
@@ -1,0 +1,4 @@
+tempest_common:
+  rbac_policy_object_name_shared_network: "foo"
+  rbac_policy_object_name_private_network: "bar"
+tempestAdminPassword: "baz"

--- a/openstack/tempest/cinder-tempest/templates/etc/_tempest_deployment_config.json.tpl
+++ b/openstack/tempest/cinder-tempest/templates/etc/_tempest_deployment_config.json.tpl
@@ -1,6 +1,10 @@
 {
     "openstack": {
+        {{- if .Values.keystoneUrl }}
+        "auth_url": "{{ .Values.keystoneUrl }}",
+        {{- else }}
         "auth_url": "http://{{ if .Values.global.clusterDomain }}keystone.{{.Release.Namespace}}.svc.{{ required "Missing clusterDomain value!" .Values.global.clusterDomain}}{{ else }}keystone.{{.Release.Namespace}}.svc.kubernetes.{{required "Missing region value!" .Values.global.region}}.{{ required "Missing tld value!" .Values.global.tld}}{{end}}:5000/v3",
+        {{- end }}
         "region_name": "{{ .Values.global.region }}",
         "endpoint_type": "internal",
         "admin": {

--- a/openstack/tempest/cinder-tempest/values.yaml
+++ b/openstack/tempest/cinder-tempest/values.yaml
@@ -14,3 +14,95 @@ owner-info:
     - Dmitry Galkin
   support-group: network-api
   service: cinder
+
+# Defaults for tempest-base named templates. These values are the production
+# defaults (identical to the previously hardcoded values). Override any of
+# them in landscape-level values to adapt tempest to a different environment.
+# keystoneUrl: when set, overrides the keystone endpoint in all three places
+# (extra_options [identity] uri_v3, OS_AUTH_URL env, deployment_config auth_url).
+# Leave empty to use the in-cluster URL derived from global.clusterDomain/region/tld.
+# Full keystone URL including /v3, e.g. http://keystone.openstack.svc.cluster.local:5000/v3
+# Leave empty to derive the URL from global.clusterDomain/region/tld.
+keystoneUrl: ""
+
+tempest_base:
+  identity:
+    default_credentials_domain_name: tempest
+    domain_name: tempest
+    admin_domain_name: tempest
+    admin_role: admin
+    user_unique_last_password_count: 5
+    user_lockout_duration: 300
+    user_lockout_failure_attempts: 5
+  network:
+    project_network_cidr: "10.199.0.0/16"
+    floating_network_name: "FloatingIP-external-monsoon3-01"
+    subnet_id: "a5703f23-ffcb-4ca7-9dfe-ab9861d91bf5"
+    max_mtu: 9000
+  compute:
+    image_ref: "84f9f266-3f11-4447-ae6c-f7940b2f5eb1"
+    image_ref_alt: "84f9f266-3f11-4447-ae6c-f7940b2f5eb1"
+    flavor_ref: 20
+    flavor_ref_alt: 30
+    min_microversion: "2.1"
+    compute_volume_common_az: "qa-de-1b"
+    vnc_server_header: "WebSockify"
+  baremetal:
+    max_microversion: "1.78"
+    driver: "fake-hardware"
+  validation:
+    image_ssh_user: "ccloud"
+  volume:
+    vendor_name: "VMware"
+    storage_protocol: "vstorageobject"
+    disk_format: "vmdk"
+    volume_size: 10
+    volume_type: "vmware"
+  volume_feature_enabled:
+    backup: true
+  service_available:
+    manila: true
+    neutron: true
+    cinder: true
+    glance: true
+    nova: true
+    swift: true
+    designate: true
+    ironic: true
+    barbican: true
+    keystone: true
+    octavia: true
+  dns:
+    nameservers: "10.114.1.233,147.204.35.140,147.204.35.141"
+
+# Defaults that make helm lint pass without any --set flags.
+# Override these in production deployments or landscape values files.
+tempestAdminPassword: ""
+
+tempest_common:
+  domainId: ""
+  public_network_id: ""
+  shared_physical_network: true
+  rbac_policy_object_name_shared_network: ""
+  rbac_policy_object_name_private_network: ""
+
+tempest_slack_webhook_url:
+  tempest_tests: ""
+  neutron: ""
+  nova: ""
+  ironic: ""
+  barbican: ""
+  cinder: ""
+  manila: ""
+  glance: ""
+  designate: ""
+  keystone: ""
+  octavia: ""
+  kvm: ""
+  cvh: ""
+  cinder_vmdk: ""
+
+global:
+  region: ""
+  tld: "cloud.sap"
+  clusterDomain: ""

--- a/openstack/tempest/cvh-tempest/templates/etc/_tempest_deployment_config.json.tpl
+++ b/openstack/tempest/cvh-tempest/templates/etc/_tempest_deployment_config.json.tpl
@@ -1,6 +1,10 @@
 {
     "openstack": {
+        {{- if .Values.keystoneUrl }}
+        "auth_url": "{{ .Values.keystoneUrl }}",
+        {{- else }}
         "auth_url": "http://{{ if .Values.global.clusterDomain }}keystone.{{.Release.Namespace}}.svc.{{ required "Missing clusterDomain value!" .Values.global.clusterDomain}}{{ else }}keystone.{{.Release.Namespace}}.svc.kubernetes.{{required "Missing region value!" .Values.global.region}}.{{ required "Missing tld value!" .Values.global.tld}}{{end}}:5000/v3",
+        {{- end }}
         "region_name": "{{ .Values.global.region }}",
         "endpoint_type": "public",
         "admin": {

--- a/openstack/tempest/cvh-tempest/templates/tempest-pod.yaml
+++ b/openstack/tempest/cvh-tempest/templates/tempest-pod.yaml
@@ -43,7 +43,11 @@ spec:
         - name: OS_IDENTITY_API_VERSION
           value: "3"
         - name: OS_AUTH_URL
+          {{- if .Values.keystoneUrl }}
+          value: "{{ .Values.keystoneUrl }}"
+          {{- else }}
           value: "http://{{ if .Values.global.clusterDomain }}keystone.{{.Release.Namespace}}.svc.{{ required "Missing clusterDomain value!" .Values.global.clusterDomain}}{{ else }}keystone.{{.Release.Namespace}}.svc.kubernetes.{{required "Missing region value!" .Values.global.region}}.{{ required "Missing tld value!" .Values.global.tld}}{{end}}:5000/v3"
+          {{- end }}
       resources:
         requests:
           memory: "2048Mi"

--- a/openstack/tempest/cvh-tempest/values.yaml
+++ b/openstack/tempest/cvh-tempest/values.yaml
@@ -10,3 +10,95 @@ owner-info:
     - Dmitry Galkin
   support-group: network-api
   service: nova
+
+# Defaults for tempest-base named templates. These values are the production
+# defaults (identical to the previously hardcoded values). Override any of
+# them in landscape-level values to adapt tempest to a different environment.
+# keystoneUrl: when set, overrides the keystone endpoint in all three places
+# (extra_options [identity] uri_v3, OS_AUTH_URL env, deployment_config auth_url).
+# Leave empty to use the in-cluster URL derived from global.clusterDomain/region/tld.
+# Full keystone URL including /v3, e.g. http://keystone.openstack.svc.cluster.local:5000/v3
+# Leave empty to derive the URL from global.clusterDomain/region/tld.
+keystoneUrl: ""
+
+tempest_base:
+  identity:
+    default_credentials_domain_name: tempest
+    domain_name: tempest
+    admin_domain_name: tempest
+    admin_role: admin
+    user_unique_last_password_count: 5
+    user_lockout_duration: 300
+    user_lockout_failure_attempts: 5
+  network:
+    project_network_cidr: "10.199.0.0/16"
+    floating_network_name: "FloatingIP-external-monsoon3-01"
+    subnet_id: "a5703f23-ffcb-4ca7-9dfe-ab9861d91bf5"
+    max_mtu: 9000
+  compute:
+    image_ref: "84f9f266-3f11-4447-ae6c-f7940b2f5eb1"
+    image_ref_alt: "84f9f266-3f11-4447-ae6c-f7940b2f5eb1"
+    flavor_ref: 20
+    flavor_ref_alt: 30
+    min_microversion: "2.1"
+    compute_volume_common_az: "qa-de-1b"
+    vnc_server_header: "WebSockify"
+  baremetal:
+    max_microversion: "1.78"
+    driver: "fake-hardware"
+  validation:
+    image_ssh_user: "ccloud"
+  volume:
+    vendor_name: "VMware"
+    storage_protocol: "vstorageobject"
+    disk_format: "vmdk"
+    volume_size: 10
+    volume_type: "vmware"
+  volume_feature_enabled:
+    backup: true
+  service_available:
+    manila: true
+    neutron: true
+    cinder: true
+    glance: true
+    nova: true
+    swift: true
+    designate: true
+    ironic: true
+    barbican: true
+    keystone: true
+    octavia: true
+  dns:
+    nameservers: "10.114.1.233,147.204.35.140,147.204.35.141"
+
+# Defaults that make helm lint pass without any --set flags.
+# Override these in production deployments or landscape values files.
+tempestAdminPassword: ""
+
+tempest_common:
+  domainId: ""
+  public_network_id: ""
+  shared_physical_network: true
+  rbac_policy_object_name_shared_network: ""
+  rbac_policy_object_name_private_network: ""
+
+tempest_slack_webhook_url:
+  tempest_tests: ""
+  neutron: ""
+  nova: ""
+  ironic: ""
+  barbican: ""
+  cinder: ""
+  manila: ""
+  glance: ""
+  designate: ""
+  keystone: ""
+  octavia: ""
+  kvm: ""
+  cvh: ""
+  cinder_vmdk: ""
+
+global:
+  region: ""
+  tld: "cloud.sap"
+  clusterDomain: ""

--- a/openstack/tempest/designate-tempest/ci/test-values.yaml
+++ b/openstack/tempest/designate-tempest/ci/test-values.yaml
@@ -1,0 +1,4 @@
+tempest_common:
+  rbac_policy_object_name_shared_network: "foo"
+  rbac_policy_object_name_private_network: "bar"
+tempestAdminPassword: "baz"

--- a/openstack/tempest/designate-tempest/templates/etc/_tempest_deployment_config.json.tpl
+++ b/openstack/tempest/designate-tempest/templates/etc/_tempest_deployment_config.json.tpl
@@ -1,6 +1,10 @@
 {
     "openstack": {
+        {{- if .Values.keystoneUrl }}
+        "auth_url": "{{ .Values.keystoneUrl }}",
+        {{- else }}
         "auth_url": "http://{{ if .Values.global.clusterDomain }}keystone.{{.Release.Namespace}}.svc.{{ required "Missing clusterDomain value!" .Values.global.clusterDomain}}{{ else }}keystone.{{.Release.Namespace}}.svc.kubernetes.{{required "Missing region value!" .Values.global.region}}.{{ required "Missing tld value!" .Values.global.tld}}{{end}}:5000/v3",
+        {{- end }}
         "region_name": "{{ .Values.global.region }}",
         "endpoint_type": "public",
         "admin": {

--- a/openstack/tempest/designate-tempest/values.yaml
+++ b/openstack/tempest/designate-tempest/values.yaml
@@ -14,3 +14,95 @@ owner-info:
     - Dmitry Galkin
   support-group: network-api
   service: designate
+
+# Defaults for tempest-base named templates. These values are the production
+# defaults (identical to the previously hardcoded values). Override any of
+# them in landscape-level values to adapt tempest to a different environment.
+# keystoneUrl: when set, overrides the keystone endpoint in all three places
+# (extra_options [identity] uri_v3, OS_AUTH_URL env, deployment_config auth_url).
+# Leave empty to use the in-cluster URL derived from global.clusterDomain/region/tld.
+# Full keystone URL including /v3, e.g. http://keystone.openstack.svc.cluster.local:5000/v3
+# Leave empty to derive the URL from global.clusterDomain/region/tld.
+keystoneUrl: ""
+
+tempest_base:
+  identity:
+    default_credentials_domain_name: tempest
+    domain_name: tempest
+    admin_domain_name: tempest
+    admin_role: admin
+    user_unique_last_password_count: 5
+    user_lockout_duration: 300
+    user_lockout_failure_attempts: 5
+  network:
+    project_network_cidr: "10.199.0.0/16"
+    floating_network_name: "FloatingIP-external-monsoon3-01"
+    subnet_id: "a5703f23-ffcb-4ca7-9dfe-ab9861d91bf5"
+    max_mtu: 9000
+  compute:
+    image_ref: "84f9f266-3f11-4447-ae6c-f7940b2f5eb1"
+    image_ref_alt: "84f9f266-3f11-4447-ae6c-f7940b2f5eb1"
+    flavor_ref: 20
+    flavor_ref_alt: 30
+    min_microversion: "2.1"
+    compute_volume_common_az: "qa-de-1b"
+    vnc_server_header: "WebSockify"
+  baremetal:
+    max_microversion: "1.78"
+    driver: "fake-hardware"
+  validation:
+    image_ssh_user: "ccloud"
+  volume:
+    vendor_name: "VMware"
+    storage_protocol: "vstorageobject"
+    disk_format: "vmdk"
+    volume_size: 10
+    volume_type: "vmware"
+  volume_feature_enabled:
+    backup: true
+  service_available:
+    manila: true
+    neutron: true
+    cinder: true
+    glance: true
+    nova: true
+    swift: true
+    designate: true
+    ironic: true
+    barbican: true
+    keystone: true
+    octavia: true
+  dns:
+    nameservers: "10.114.1.233,147.204.35.140,147.204.35.141"
+
+# Defaults that make helm lint pass without any --set flags.
+# Override these in production deployments or landscape values files.
+tempestAdminPassword: ""
+
+tempest_common:
+  domainId: ""
+  public_network_id: ""
+  shared_physical_network: true
+  rbac_policy_object_name_shared_network: ""
+  rbac_policy_object_name_private_network: ""
+
+tempest_slack_webhook_url:
+  tempest_tests: ""
+  neutron: ""
+  nova: ""
+  ironic: ""
+  barbican: ""
+  cinder: ""
+  manila: ""
+  glance: ""
+  designate: ""
+  keystone: ""
+  octavia: ""
+  kvm: ""
+  cvh: ""
+  cinder_vmdk: ""
+
+global:
+  region: ""
+  tld: "cloud.sap"
+  clusterDomain: ""

--- a/openstack/tempest/glance-tempest/ci/test-values.yaml
+++ b/openstack/tempest/glance-tempest/ci/test-values.yaml
@@ -1,0 +1,4 @@
+tempest_common:
+  rbac_policy_object_name_shared_network: "foo"
+  rbac_policy_object_name_private_network: "bar"
+tempestAdminPassword: "baz"

--- a/openstack/tempest/glance-tempest/templates/etc/_tempest_deployment_config.json.tpl
+++ b/openstack/tempest/glance-tempest/templates/etc/_tempest_deployment_config.json.tpl
@@ -1,6 +1,10 @@
 {
     "openstack": {
+        {{- if .Values.keystoneUrl }}
+        "auth_url": "{{ .Values.keystoneUrl }}",
+        {{- else }}
         "auth_url": "http://{{ if .Values.global.clusterDomain }}keystone.{{.Release.Namespace}}.svc.{{ required "Missing clusterDomain value!" .Values.global.clusterDomain}}{{ else }}keystone.{{.Release.Namespace}}.svc.kubernetes.{{required "Missing region value!" .Values.global.region}}.{{ required "Missing tld value!" .Values.global.tld}}{{end}}:5000/v3",
+        {{- end }}
         "region_name": "{{ .Values.global.region }}",
         "endpoint_type": "public",
         "admin": {

--- a/openstack/tempest/glance-tempest/values.yaml
+++ b/openstack/tempest/glance-tempest/values.yaml
@@ -7,3 +7,95 @@ owner-info:
     - Dmitry Galkin
   support-group: network-api
   service: glance
+
+# Defaults for tempest-base named templates. These values are the production
+# defaults (identical to the previously hardcoded values). Override any of
+# them in landscape-level values to adapt tempest to a different environment.
+# keystoneUrl: when set, overrides the keystone endpoint in all three places
+# (extra_options [identity] uri_v3, OS_AUTH_URL env, deployment_config auth_url).
+# Leave empty to use the in-cluster URL derived from global.clusterDomain/region/tld.
+# Full keystone URL including /v3, e.g. http://keystone.openstack.svc.cluster.local:5000/v3
+# Leave empty to derive the URL from global.clusterDomain/region/tld.
+keystoneUrl: ""
+
+tempest_base:
+  identity:
+    default_credentials_domain_name: tempest
+    domain_name: tempest
+    admin_domain_name: tempest
+    admin_role: admin
+    user_unique_last_password_count: 5
+    user_lockout_duration: 300
+    user_lockout_failure_attempts: 5
+  network:
+    project_network_cidr: "10.199.0.0/16"
+    floating_network_name: "FloatingIP-external-monsoon3-01"
+    subnet_id: "a5703f23-ffcb-4ca7-9dfe-ab9861d91bf5"
+    max_mtu: 9000
+  compute:
+    image_ref: "84f9f266-3f11-4447-ae6c-f7940b2f5eb1"
+    image_ref_alt: "84f9f266-3f11-4447-ae6c-f7940b2f5eb1"
+    flavor_ref: 20
+    flavor_ref_alt: 30
+    min_microversion: "2.1"
+    compute_volume_common_az: "qa-de-1b"
+    vnc_server_header: "WebSockify"
+  baremetal:
+    max_microversion: "1.78"
+    driver: "fake-hardware"
+  validation:
+    image_ssh_user: "ccloud"
+  volume:
+    vendor_name: "VMware"
+    storage_protocol: "vstorageobject"
+    disk_format: "vmdk"
+    volume_size: 10
+    volume_type: "vmware"
+  volume_feature_enabled:
+    backup: true
+  service_available:
+    manila: true
+    neutron: true
+    cinder: true
+    glance: true
+    nova: true
+    swift: true
+    designate: true
+    ironic: true
+    barbican: true
+    keystone: true
+    octavia: true
+  dns:
+    nameservers: "10.114.1.233,147.204.35.140,147.204.35.141"
+
+# Defaults that make helm lint pass without any --set flags.
+# Override these in production deployments or landscape values files.
+tempestAdminPassword: ""
+
+tempest_common:
+  domainId: ""
+  public_network_id: ""
+  shared_physical_network: true
+  rbac_policy_object_name_shared_network: ""
+  rbac_policy_object_name_private_network: ""
+
+tempest_slack_webhook_url:
+  tempest_tests: ""
+  neutron: ""
+  nova: ""
+  ironic: ""
+  barbican: ""
+  cinder: ""
+  manila: ""
+  glance: ""
+  designate: ""
+  keystone: ""
+  octavia: ""
+  kvm: ""
+  cvh: ""
+  cinder_vmdk: ""
+
+global:
+  region: ""
+  tld: "cloud.sap"
+  clusterDomain: ""

--- a/openstack/tempest/ironic-tempest/ci/test-values.yaml
+++ b/openstack/tempest/ironic-tempest/ci/test-values.yaml
@@ -1,0 +1,4 @@
+tempest_common:
+  rbac_policy_object_name_shared_network: "foo"
+  rbac_policy_object_name_private_network: "bar"
+tempestAdminPassword: "baz"

--- a/openstack/tempest/ironic-tempest/templates/etc/_tempest_deployment_config.json.tpl
+++ b/openstack/tempest/ironic-tempest/templates/etc/_tempest_deployment_config.json.tpl
@@ -1,6 +1,10 @@
 {
     "openstack": {
+        {{- if .Values.keystoneUrl }}
+        "auth_url": "{{ .Values.keystoneUrl }}",
+        {{- else }}
         "auth_url": "http://{{ if .Values.global.clusterDomain }}keystone.{{.Release.Namespace}}.svc.{{ required "Missing clusterDomain value!" .Values.global.clusterDomain}}{{ else }}keystone.{{.Release.Namespace}}.svc.kubernetes.{{required "Missing region value!" .Values.global.region}}.{{ required "Missing tld value!" .Values.global.tld}}{{end}}:5000/v3",
+        {{- end }}
         "region_name": "{{ .Values.global.region }}",
         "endpoint_type": "public",
         "admin": {

--- a/openstack/tempest/ironic-tempest/values.yaml
+++ b/openstack/tempest/ironic-tempest/values.yaml
@@ -7,3 +7,95 @@ owner-info:
     - Dmitry Galkin
   support-group: network-api
   service: ironic
+
+# Defaults for tempest-base named templates. These values are the production
+# defaults (identical to the previously hardcoded values). Override any of
+# them in landscape-level values to adapt tempest to a different environment.
+# keystoneUrl: when set, overrides the keystone endpoint in all three places
+# (extra_options [identity] uri_v3, OS_AUTH_URL env, deployment_config auth_url).
+# Leave empty to use the in-cluster URL derived from global.clusterDomain/region/tld.
+# Full keystone URL including /v3, e.g. http://keystone.openstack.svc.cluster.local:5000/v3
+# Leave empty to derive the URL from global.clusterDomain/region/tld.
+keystoneUrl: ""
+
+tempest_base:
+  identity:
+    default_credentials_domain_name: tempest
+    domain_name: tempest
+    admin_domain_name: tempest
+    admin_role: admin
+    user_unique_last_password_count: 5
+    user_lockout_duration: 300
+    user_lockout_failure_attempts: 5
+  network:
+    project_network_cidr: "10.199.0.0/16"
+    floating_network_name: "FloatingIP-external-monsoon3-01"
+    subnet_id: "a5703f23-ffcb-4ca7-9dfe-ab9861d91bf5"
+    max_mtu: 9000
+  compute:
+    image_ref: "84f9f266-3f11-4447-ae6c-f7940b2f5eb1"
+    image_ref_alt: "84f9f266-3f11-4447-ae6c-f7940b2f5eb1"
+    flavor_ref: 20
+    flavor_ref_alt: 30
+    min_microversion: "2.1"
+    compute_volume_common_az: "qa-de-1b"
+    vnc_server_header: "WebSockify"
+  baremetal:
+    max_microversion: "1.78"
+    driver: "fake-hardware"
+  validation:
+    image_ssh_user: "ccloud"
+  volume:
+    vendor_name: "VMware"
+    storage_protocol: "vstorageobject"
+    disk_format: "vmdk"
+    volume_size: 10
+    volume_type: "vmware"
+  volume_feature_enabled:
+    backup: true
+  service_available:
+    manila: true
+    neutron: true
+    cinder: true
+    glance: true
+    nova: true
+    swift: true
+    designate: true
+    ironic: true
+    barbican: true
+    keystone: true
+    octavia: true
+  dns:
+    nameservers: "10.114.1.233,147.204.35.140,147.204.35.141"
+
+# Defaults that make helm lint pass without any --set flags.
+# Override these in production deployments or landscape values files.
+tempestAdminPassword: ""
+
+tempest_common:
+  domainId: ""
+  public_network_id: ""
+  shared_physical_network: true
+  rbac_policy_object_name_shared_network: ""
+  rbac_policy_object_name_private_network: ""
+
+tempest_slack_webhook_url:
+  tempest_tests: ""
+  neutron: ""
+  nova: ""
+  ironic: ""
+  barbican: ""
+  cinder: ""
+  manila: ""
+  glance: ""
+  designate: ""
+  keystone: ""
+  octavia: ""
+  kvm: ""
+  cvh: ""
+  cinder_vmdk: ""
+
+global:
+  region: ""
+  tld: "cloud.sap"
+  clusterDomain: ""

--- a/openstack/tempest/keystone-tempest/ci/test-values.yaml
+++ b/openstack/tempest/keystone-tempest/ci/test-values.yaml
@@ -1,0 +1,4 @@
+tempest_common:
+  rbac_policy_object_name_shared_network: "foo"
+  rbac_policy_object_name_private_network: "bar"
+tempestAdminPassword: "baz"

--- a/openstack/tempest/keystone-tempest/templates/etc/_tempest_deployment_config.json.tpl
+++ b/openstack/tempest/keystone-tempest/templates/etc/_tempest_deployment_config.json.tpl
@@ -1,6 +1,10 @@
 {
     "openstack": {
+        {{- if .Values.keystoneUrl }}
+        "auth_url": "{{ .Values.keystoneUrl }}",
+        {{- else }}
         "auth_url": "http://{{ if .Values.global.clusterDomain }}keystone.{{.Release.Namespace}}.svc.{{ required "Missing clusterDomain value!" .Values.global.clusterDomain}}{{ else }}keystone.{{.Release.Namespace}}.svc.kubernetes.{{required "Missing region value!" .Values.global.region}}.{{ required "Missing tld value!" .Values.global.tld}}{{end}}:5000/v3",
+        {{- end }}
         "region_name": "{{ .Values.global.region }}",
         "endpoint_type": "public",
         "admin": {

--- a/openstack/tempest/keystone-tempest/values.yaml
+++ b/openstack/tempest/keystone-tempest/values.yaml
@@ -15,3 +15,95 @@ owner-info:
     - Dmitry Galkin
   support-group: network-api
   service: keystone
+
+# Defaults for tempest-base named templates. These values are the production
+# defaults (identical to the previously hardcoded values). Override any of
+# them in landscape-level values to adapt tempest to a different environment.
+# keystoneUrl: when set, overrides the keystone endpoint in all three places
+# (extra_options [identity] uri_v3, OS_AUTH_URL env, deployment_config auth_url).
+# Leave empty to use the in-cluster URL derived from global.clusterDomain/region/tld.
+# Full keystone URL including /v3, e.g. http://keystone.openstack.svc.cluster.local:5000/v3
+# Leave empty to derive the URL from global.clusterDomain/region/tld.
+keystoneUrl: ""
+
+tempest_base:
+  identity:
+    default_credentials_domain_name: tempest
+    domain_name: tempest
+    admin_domain_name: tempest
+    admin_role: admin
+    user_unique_last_password_count: 5
+    user_lockout_duration: 300
+    user_lockout_failure_attempts: 5
+  network:
+    project_network_cidr: "10.199.0.0/16"
+    floating_network_name: "FloatingIP-external-monsoon3-01"
+    subnet_id: "a5703f23-ffcb-4ca7-9dfe-ab9861d91bf5"
+    max_mtu: 9000
+  compute:
+    image_ref: "84f9f266-3f11-4447-ae6c-f7940b2f5eb1"
+    image_ref_alt: "84f9f266-3f11-4447-ae6c-f7940b2f5eb1"
+    flavor_ref: 20
+    flavor_ref_alt: 30
+    min_microversion: "2.1"
+    compute_volume_common_az: "qa-de-1b"
+    vnc_server_header: "WebSockify"
+  baremetal:
+    max_microversion: "1.78"
+    driver: "fake-hardware"
+  validation:
+    image_ssh_user: "ccloud"
+  volume:
+    vendor_name: "VMware"
+    storage_protocol: "vstorageobject"
+    disk_format: "vmdk"
+    volume_size: 10
+    volume_type: "vmware"
+  volume_feature_enabled:
+    backup: true
+  service_available:
+    manila: true
+    neutron: true
+    cinder: true
+    glance: true
+    nova: true
+    swift: true
+    designate: true
+    ironic: true
+    barbican: true
+    keystone: true
+    octavia: true
+  dns:
+    nameservers: "10.114.1.233,147.204.35.140,147.204.35.141"
+
+# Defaults that make helm lint pass without any --set flags.
+# Override these in production deployments or landscape values files.
+tempestAdminPassword: ""
+
+tempest_common:
+  domainId: ""
+  public_network_id: ""
+  shared_physical_network: true
+  rbac_policy_object_name_shared_network: ""
+  rbac_policy_object_name_private_network: ""
+
+tempest_slack_webhook_url:
+  tempest_tests: ""
+  neutron: ""
+  nova: ""
+  ironic: ""
+  barbican: ""
+  cinder: ""
+  manila: ""
+  glance: ""
+  designate: ""
+  keystone: ""
+  octavia: ""
+  kvm: ""
+  cvh: ""
+  cinder_vmdk: ""
+
+global:
+  region: ""
+  tld: "cloud.sap"
+  clusterDomain: ""

--- a/openstack/tempest/kvm-tempest/templates/etc/_tempest_deployment_config.json.tpl
+++ b/openstack/tempest/kvm-tempest/templates/etc/_tempest_deployment_config.json.tpl
@@ -1,6 +1,10 @@
 {
     "openstack": {
+        {{- if .Values.keystoneUrl }}
+        "auth_url": "{{ .Values.keystoneUrl }}",
+        {{- else }}
         "auth_url": "http://{{ if .Values.global.clusterDomain }}keystone.{{.Release.Namespace}}.svc.{{ required "Missing clusterDomain value!" .Values.global.clusterDomain}}{{ else }}keystone.{{.Release.Namespace}}.svc.kubernetes.{{required "Missing region value!" .Values.global.region}}.{{ required "Missing tld value!" .Values.global.tld}}{{end}}:5000/v3",
+        {{- end }}
         "region_name": "{{ .Values.global.region }}",
         "endpoint_type": "public",
         "admin": {

--- a/openstack/tempest/kvm-tempest/templates/tempest-pod.yaml
+++ b/openstack/tempest/kvm-tempest/templates/tempest-pod.yaml
@@ -43,7 +43,11 @@ spec:
         - name: OS_IDENTITY_API_VERSION
           value: "3"
         - name: OS_AUTH_URL
+          {{- if .Values.keystoneUrl }}
+          value: "{{ .Values.keystoneUrl }}"
+          {{- else }}
           value: "http://{{ if .Values.global.clusterDomain }}keystone.{{.Release.Namespace}}.svc.{{ required "Missing clusterDomain value!" .Values.global.clusterDomain}}{{ else }}keystone.{{.Release.Namespace}}.svc.kubernetes.{{required "Missing region value!" .Values.global.region}}.{{ required "Missing tld value!" .Values.global.tld}}{{end}}:5000/v3"
+          {{- end }}
       resources:
         requests:
           memory: "2048Mi"

--- a/openstack/tempest/kvm-tempest/values.yaml
+++ b/openstack/tempest/kvm-tempest/values.yaml
@@ -10,3 +10,95 @@ owner-info:
     - Dmitry Galkin
   support-group: network-api
   service: nova
+
+# Defaults for tempest-base named templates. These values are the production
+# defaults (identical to the previously hardcoded values). Override any of
+# them in landscape-level values to adapt tempest to a different environment.
+# keystoneUrl: when set, overrides the keystone endpoint in all three places
+# (extra_options [identity] uri_v3, OS_AUTH_URL env, deployment_config auth_url).
+# Leave empty to use the in-cluster URL derived from global.clusterDomain/region/tld.
+# Full keystone URL including /v3, e.g. http://keystone.openstack.svc.cluster.local:5000/v3
+# Leave empty to derive the URL from global.clusterDomain/region/tld.
+keystoneUrl: ""
+
+tempest_base:
+  identity:
+    default_credentials_domain_name: tempest
+    domain_name: tempest
+    admin_domain_name: tempest
+    admin_role: admin
+    user_unique_last_password_count: 5
+    user_lockout_duration: 300
+    user_lockout_failure_attempts: 5
+  network:
+    project_network_cidr: "10.199.0.0/16"
+    floating_network_name: "FloatingIP-external-monsoon3-01"
+    subnet_id: "a5703f23-ffcb-4ca7-9dfe-ab9861d91bf5"
+    max_mtu: 9000
+  compute:
+    image_ref: "84f9f266-3f11-4447-ae6c-f7940b2f5eb1"
+    image_ref_alt: "84f9f266-3f11-4447-ae6c-f7940b2f5eb1"
+    flavor_ref: 20
+    flavor_ref_alt: 30
+    min_microversion: "2.1"
+    compute_volume_common_az: "qa-de-1b"
+    vnc_server_header: "WebSockify"
+  baremetal:
+    max_microversion: "1.78"
+    driver: "fake-hardware"
+  validation:
+    image_ssh_user: "ccloud"
+  volume:
+    vendor_name: "VMware"
+    storage_protocol: "vstorageobject"
+    disk_format: "vmdk"
+    volume_size: 10
+    volume_type: "vmware"
+  volume_feature_enabled:
+    backup: true
+  service_available:
+    manila: true
+    neutron: true
+    cinder: true
+    glance: true
+    nova: true
+    swift: true
+    designate: true
+    ironic: true
+    barbican: true
+    keystone: true
+    octavia: true
+  dns:
+    nameservers: "10.114.1.233,147.204.35.140,147.204.35.141"
+
+# Defaults that make helm lint pass without any --set flags.
+# Override these in production deployments or landscape values files.
+tempestAdminPassword: ""
+
+tempest_common:
+  domainId: ""
+  public_network_id: ""
+  shared_physical_network: true
+  rbac_policy_object_name_shared_network: ""
+  rbac_policy_object_name_private_network: ""
+
+tempest_slack_webhook_url:
+  tempest_tests: ""
+  neutron: ""
+  nova: ""
+  ironic: ""
+  barbican: ""
+  cinder: ""
+  manila: ""
+  glance: ""
+  designate: ""
+  keystone: ""
+  octavia: ""
+  kvm: ""
+  cvh: ""
+  cinder_vmdk: ""
+
+global:
+  region: ""
+  tld: "cloud.sap"
+  clusterDomain: ""

--- a/openstack/tempest/manila-tempest/ci/test-values.yaml
+++ b/openstack/tempest/manila-tempest/ci/test-values.yaml
@@ -1,0 +1,4 @@
+tempest_common:
+  rbac_policy_object_name_shared_network: "foo"
+  rbac_policy_object_name_private_network: "bar"
+tempestAdminPassword: "baz"

--- a/openstack/tempest/manila-tempest/templates/etc/_tempest_deployment_config.json.tpl
+++ b/openstack/tempest/manila-tempest/templates/etc/_tempest_deployment_config.json.tpl
@@ -1,6 +1,10 @@
 {
     "openstack": {
+        {{- if .Values.keystoneUrl }}
+        "auth_url": "{{ .Values.keystoneUrl }}",
+        {{- else }}
         "auth_url": "http://{{ if .Values.global.clusterDomain }}keystone.{{.Release.Namespace}}.svc.{{ required "Missing clusterDomain value!" .Values.global.clusterDomain}}{{ else }}keystone.{{.Release.Namespace}}.svc.kubernetes.{{required "Missing region value!" .Values.global.region}}.{{ required "Missing tld value!" .Values.global.tld}}{{end}}:5000/v3",
+        {{- end }}
         "region_name": "{{ .Values.global.region }}",
         "endpoint_type": "public",
         "admin": {

--- a/openstack/tempest/manila-tempest/values.yaml
+++ b/openstack/tempest/manila-tempest/values.yaml
@@ -15,3 +15,95 @@ owner-info:
     - Dmitry Galkin
   support-group: network-api
   service: manila
+
+# Defaults for tempest-base named templates. These values are the production
+# defaults (identical to the previously hardcoded values). Override any of
+# them in landscape-level values to adapt tempest to a different environment.
+# keystoneUrl: when set, overrides the keystone endpoint in all three places
+# (extra_options [identity] uri_v3, OS_AUTH_URL env, deployment_config auth_url).
+# Leave empty to use the in-cluster URL derived from global.clusterDomain/region/tld.
+# Full keystone URL including /v3, e.g. http://keystone.openstack.svc.cluster.local:5000/v3
+# Leave empty to derive the URL from global.clusterDomain/region/tld.
+keystoneUrl: ""
+
+tempest_base:
+  identity:
+    default_credentials_domain_name: tempest
+    domain_name: tempest
+    admin_domain_name: tempest
+    admin_role: admin
+    user_unique_last_password_count: 5
+    user_lockout_duration: 300
+    user_lockout_failure_attempts: 5
+  network:
+    project_network_cidr: "10.199.0.0/16"
+    floating_network_name: "FloatingIP-external-monsoon3-01"
+    subnet_id: "a5703f23-ffcb-4ca7-9dfe-ab9861d91bf5"
+    max_mtu: 9000
+  compute:
+    image_ref: "84f9f266-3f11-4447-ae6c-f7940b2f5eb1"
+    image_ref_alt: "84f9f266-3f11-4447-ae6c-f7940b2f5eb1"
+    flavor_ref: 20
+    flavor_ref_alt: 30
+    min_microversion: "2.1"
+    compute_volume_common_az: "qa-de-1b"
+    vnc_server_header: "WebSockify"
+  baremetal:
+    max_microversion: "1.78"
+    driver: "fake-hardware"
+  validation:
+    image_ssh_user: "ccloud"
+  volume:
+    vendor_name: "VMware"
+    storage_protocol: "vstorageobject"
+    disk_format: "vmdk"
+    volume_size: 10
+    volume_type: "vmware"
+  volume_feature_enabled:
+    backup: true
+  service_available:
+    manila: true
+    neutron: true
+    cinder: true
+    glance: true
+    nova: true
+    swift: true
+    designate: true
+    ironic: true
+    barbican: true
+    keystone: true
+    octavia: true
+  dns:
+    nameservers: "10.114.1.233,147.204.35.140,147.204.35.141"
+
+# Defaults that make helm lint pass without any --set flags.
+# Override these in production deployments or landscape values files.
+tempestAdminPassword: ""
+
+tempest_common:
+  domainId: ""
+  public_network_id: ""
+  shared_physical_network: true
+  rbac_policy_object_name_shared_network: ""
+  rbac_policy_object_name_private_network: ""
+
+tempest_slack_webhook_url:
+  tempest_tests: ""
+  neutron: ""
+  nova: ""
+  ironic: ""
+  barbican: ""
+  cinder: ""
+  manila: ""
+  glance: ""
+  designate: ""
+  keystone: ""
+  octavia: ""
+  kvm: ""
+  cvh: ""
+  cinder_vmdk: ""
+
+global:
+  region: ""
+  tld: "cloud.sap"
+  clusterDomain: ""

--- a/openstack/tempest/neutron-tempest/templates/etc/_tempest_deployment_config.json.tpl
+++ b/openstack/tempest/neutron-tempest/templates/etc/_tempest_deployment_config.json.tpl
@@ -1,6 +1,10 @@
 {
     "openstack": {
+        {{- if .Values.keystoneUrl }}
+        "auth_url": "{{ .Values.keystoneUrl }}",
+        {{- else }}
         "auth_url": "http://{{ if .Values.global.clusterDomain }}keystone.{{.Release.Namespace}}.svc.{{ required "Missing clusterDomain value!" .Values.global.clusterDomain}}{{ else }}keystone.{{.Release.Namespace}}.svc.kubernetes.{{required "Missing region value!" .Values.global.region}}.{{ required "Missing tld value!" .Values.global.tld}}{{end}}:5000/v3",
+        {{- end }}
         "region_name": "{{ .Values.global.region }}",
         "endpoint_type": "public",
         "admin": {

--- a/openstack/tempest/neutron-tempest/values.yaml
+++ b/openstack/tempest/neutron-tempest/values.yaml
@@ -8,3 +8,95 @@ owner-info:
     - Dmitry Galkin
   support-group: network-api
   service: neutron
+
+# Defaults for tempest-base named templates. These values are the production
+# defaults (identical to the previously hardcoded values). Override any of
+# them in landscape-level values to adapt tempest to a different environment.
+# keystoneUrl: when set, overrides the keystone endpoint in all three places
+# (extra_options [identity] uri_v3, OS_AUTH_URL env, deployment_config auth_url).
+# Leave empty to use the in-cluster URL derived from global.clusterDomain/region/tld.
+# Full keystone URL including /v3, e.g. http://keystone.openstack.svc.cluster.local:5000/v3
+# Leave empty to derive the URL from global.clusterDomain/region/tld.
+keystoneUrl: ""
+
+tempest_base:
+  identity:
+    default_credentials_domain_name: tempest
+    domain_name: tempest
+    admin_domain_name: tempest
+    admin_role: admin
+    user_unique_last_password_count: 5
+    user_lockout_duration: 300
+    user_lockout_failure_attempts: 5
+  network:
+    project_network_cidr: "10.199.0.0/16"
+    floating_network_name: "FloatingIP-external-monsoon3-01"
+    subnet_id: "a5703f23-ffcb-4ca7-9dfe-ab9861d91bf5"
+    max_mtu: 9000
+  compute:
+    image_ref: "84f9f266-3f11-4447-ae6c-f7940b2f5eb1"
+    image_ref_alt: "84f9f266-3f11-4447-ae6c-f7940b2f5eb1"
+    flavor_ref: 20
+    flavor_ref_alt: 30
+    min_microversion: "2.1"
+    compute_volume_common_az: "qa-de-1b"
+    vnc_server_header: "WebSockify"
+  baremetal:
+    max_microversion: "1.78"
+    driver: "fake-hardware"
+  validation:
+    image_ssh_user: "ccloud"
+  volume:
+    vendor_name: "VMware"
+    storage_protocol: "vstorageobject"
+    disk_format: "vmdk"
+    volume_size: 10
+    volume_type: "vmware"
+  volume_feature_enabled:
+    backup: true
+  service_available:
+    manila: true
+    neutron: true
+    cinder: true
+    glance: true
+    nova: true
+    swift: true
+    designate: true
+    ironic: true
+    barbican: true
+    keystone: true
+    octavia: true
+  dns:
+    nameservers: "10.114.1.233,147.204.35.140,147.204.35.141"
+
+# Defaults that make helm lint pass without any --set flags.
+# Override these in production deployments or landscape values files.
+tempestAdminPassword: ""
+
+tempest_common:
+  domainId: ""
+  public_network_id: ""
+  shared_physical_network: true
+  rbac_policy_object_name_shared_network: ""
+  rbac_policy_object_name_private_network: ""
+
+tempest_slack_webhook_url:
+  tempest_tests: ""
+  neutron: ""
+  nova: ""
+  ironic: ""
+  barbican: ""
+  cinder: ""
+  manila: ""
+  glance: ""
+  designate: ""
+  keystone: ""
+  octavia: ""
+  kvm: ""
+  cvh: ""
+  cinder_vmdk: ""
+
+global:
+  region: ""
+  tld: "cloud.sap"
+  clusterDomain: ""

--- a/openstack/tempest/nova-tempest/templates/etc/_tempest_deployment_config.json.tpl
+++ b/openstack/tempest/nova-tempest/templates/etc/_tempest_deployment_config.json.tpl
@@ -1,6 +1,10 @@
 {
     "openstack": {
+        {{- if .Values.keystoneUrl }}
+        "auth_url": "{{ .Values.keystoneUrl }}",
+        {{- else }}
         "auth_url": "http://{{ if .Values.global.clusterDomain }}keystone.{{.Release.Namespace}}.svc.{{ required "Missing clusterDomain value!" .Values.global.clusterDomain}}{{ else }}keystone.{{.Release.Namespace}}.svc.kubernetes.{{required "Missing region value!" .Values.global.region}}.{{ required "Missing tld value!" .Values.global.tld}}{{end}}:5000/v3",
+        {{- end }}
         "region_name": "{{ .Values.global.region }}",
         "endpoint_type": "public",
         "admin": {

--- a/openstack/tempest/nova-tempest/templates/tempest-pod.yaml
+++ b/openstack/tempest/nova-tempest/templates/tempest-pod.yaml
@@ -43,7 +43,11 @@ spec:
         - name: OS_IDENTITY_API_VERSION
           value: "3"
         - name: OS_AUTH_URL
+          {{- if .Values.keystoneUrl }}
+          value: "{{ .Values.keystoneUrl }}"
+          {{- else }}
           value: "http://{{ if .Values.global.clusterDomain }}keystone.{{.Release.Namespace}}.svc.{{ required "Missing clusterDomain value!" .Values.global.clusterDomain}}{{ else }}keystone.{{.Release.Namespace}}.svc.kubernetes.{{required "Missing region value!" .Values.global.region}}.{{ required "Missing tld value!" .Values.global.tld}}{{end}}:5000/v3"
+          {{- end }}
       resources:
         requests:
           memory: "2048Mi"

--- a/openstack/tempest/nova-tempest/values.yaml
+++ b/openstack/tempest/nova-tempest/values.yaml
@@ -9,3 +9,95 @@ owner-info:
     - Dmitry Galkin
   support-group: network-api
   service: nova
+
+# Defaults for tempest-base named templates. These values are the production
+# defaults (identical to the previously hardcoded values). Override any of
+# them in landscape-level values to adapt tempest to a different environment.
+# keystoneUrl: when set, overrides the keystone endpoint in all three places
+# (extra_options [identity] uri_v3, OS_AUTH_URL env, deployment_config auth_url).
+# Leave empty to use the in-cluster URL derived from global.clusterDomain/region/tld.
+# Full keystone URL including /v3, e.g. http://keystone.openstack.svc.cluster.local:5000/v3
+# Leave empty to derive the URL from global.clusterDomain/region/tld.
+keystoneUrl: ""
+
+tempest_base:
+  identity:
+    default_credentials_domain_name: tempest
+    domain_name: tempest
+    admin_domain_name: tempest
+    admin_role: admin
+    user_unique_last_password_count: 5
+    user_lockout_duration: 300
+    user_lockout_failure_attempts: 5
+  network:
+    project_network_cidr: "10.199.0.0/16"
+    floating_network_name: "FloatingIP-external-monsoon3-01"
+    subnet_id: "a5703f23-ffcb-4ca7-9dfe-ab9861d91bf5"
+    max_mtu: 9000
+  compute:
+    image_ref: "84f9f266-3f11-4447-ae6c-f7940b2f5eb1"
+    image_ref_alt: "84f9f266-3f11-4447-ae6c-f7940b2f5eb1"
+    flavor_ref: 20
+    flavor_ref_alt: 30
+    min_microversion: "2.1"
+    compute_volume_common_az: "qa-de-1b"
+    vnc_server_header: "WebSockify"
+  baremetal:
+    max_microversion: "1.78"
+    driver: "fake-hardware"
+  validation:
+    image_ssh_user: "ccloud"
+  volume:
+    vendor_name: "VMware"
+    storage_protocol: "vstorageobject"
+    disk_format: "vmdk"
+    volume_size: 10
+    volume_type: "vmware"
+  volume_feature_enabled:
+    backup: true
+  service_available:
+    manila: true
+    neutron: true
+    cinder: true
+    glance: true
+    nova: true
+    swift: true
+    designate: true
+    ironic: true
+    barbican: true
+    keystone: true
+    octavia: true
+  dns:
+    nameservers: "10.114.1.233,147.204.35.140,147.204.35.141"
+
+# Defaults that make helm lint pass without any --set flags.
+# Override these in production deployments or landscape values files.
+tempestAdminPassword: ""
+
+tempest_common:
+  domainId: ""
+  public_network_id: ""
+  shared_physical_network: true
+  rbac_policy_object_name_shared_network: ""
+  rbac_policy_object_name_private_network: ""
+
+tempest_slack_webhook_url:
+  tempest_tests: ""
+  neutron: ""
+  nova: ""
+  ironic: ""
+  barbican: ""
+  cinder: ""
+  manila: ""
+  glance: ""
+  designate: ""
+  keystone: ""
+  octavia: ""
+  kvm: ""
+  cvh: ""
+  cinder_vmdk: ""
+
+global:
+  region: ""
+  tld: "cloud.sap"
+  clusterDomain: ""

--- a/openstack/tempest/octavia-tempest/templates/etc/_tempest_deployment_config.json.tpl
+++ b/openstack/tempest/octavia-tempest/templates/etc/_tempest_deployment_config.json.tpl
@@ -1,6 +1,10 @@
 {
     "openstack": {
+        {{- if .Values.keystoneUrl }}
+        "auth_url": "{{ .Values.keystoneUrl }}",
+        {{- else }}
         "auth_url": "http://{{ if .Values.global.clusterDomain }}keystone.{{.Release.Namespace}}.svc.{{ required "Missing clusterDomain value!" .Values.global.clusterDomain}}{{ else }}keystone.{{.Release.Namespace}}.svc.kubernetes.{{required "Missing region value!" .Values.global.region}}.{{ required "Missing tld value!" .Values.global.tld}}{{end}}:5000/v3",
+        {{- end }}
         "region_name": "{{ .Values.global.region }}",
         "endpoint_type": "internal",
         "admin": {

--- a/openstack/tempest/octavia-tempest/values.yaml
+++ b/openstack/tempest/octavia-tempest/values.yaml
@@ -15,3 +15,95 @@ owner-info:
   service: octavia
 
 tempestKubectlAccess: true
+
+# Defaults for tempest-base named templates. These values are the production
+# defaults (identical to the previously hardcoded values). Override any of
+# them in landscape-level values to adapt tempest to a different environment.
+# keystoneUrl: when set, overrides the keystone endpoint in all three places
+# (extra_options [identity] uri_v3, OS_AUTH_URL env, deployment_config auth_url).
+# Leave empty to use the in-cluster URL derived from global.clusterDomain/region/tld.
+# Full keystone URL including /v3, e.g. http://keystone.openstack.svc.cluster.local:5000/v3
+# Leave empty to derive the URL from global.clusterDomain/region/tld.
+keystoneUrl: ""
+
+tempest_base:
+  identity:
+    default_credentials_domain_name: tempest
+    domain_name: tempest
+    admin_domain_name: tempest
+    admin_role: admin
+    user_unique_last_password_count: 5
+    user_lockout_duration: 300
+    user_lockout_failure_attempts: 5
+  network:
+    project_network_cidr: "10.199.0.0/16"
+    floating_network_name: "FloatingIP-external-monsoon3-01"
+    subnet_id: "a5703f23-ffcb-4ca7-9dfe-ab9861d91bf5"
+    max_mtu: 9000
+  compute:
+    image_ref: "84f9f266-3f11-4447-ae6c-f7940b2f5eb1"
+    image_ref_alt: "84f9f266-3f11-4447-ae6c-f7940b2f5eb1"
+    flavor_ref: 20
+    flavor_ref_alt: 30
+    min_microversion: "2.1"
+    compute_volume_common_az: "qa-de-1b"
+    vnc_server_header: "WebSockify"
+  baremetal:
+    max_microversion: "1.78"
+    driver: "fake-hardware"
+  validation:
+    image_ssh_user: "ccloud"
+  volume:
+    vendor_name: "VMware"
+    storage_protocol: "vstorageobject"
+    disk_format: "vmdk"
+    volume_size: 10
+    volume_type: "vmware"
+  volume_feature_enabled:
+    backup: true
+  service_available:
+    manila: true
+    neutron: true
+    cinder: true
+    glance: true
+    nova: true
+    swift: true
+    designate: true
+    ironic: true
+    barbican: true
+    keystone: true
+    octavia: true
+  dns:
+    nameservers: "10.114.1.233,147.204.35.140,147.204.35.141"
+
+# Defaults that make helm lint pass without any --set flags.
+# Override these in production deployments or landscape values files.
+tempestAdminPassword: ""
+
+tempest_common:
+  domainId: ""
+  public_network_id: ""
+  shared_physical_network: true
+  rbac_policy_object_name_shared_network: ""
+  rbac_policy_object_name_private_network: ""
+
+tempest_slack_webhook_url:
+  tempest_tests: ""
+  neutron: ""
+  nova: ""
+  ironic: ""
+  barbican: ""
+  cinder: ""
+  manila: ""
+  glance: ""
+  designate: ""
+  keystone: ""
+  octavia: ""
+  kvm: ""
+  cvh: ""
+  cinder_vmdk: ""
+
+global:
+  region: ""
+  tld: "cloud.sap"
+  clusterDomain: ""

--- a/openstack/tempest/tempest-base/templates/_tempest-pod.yaml.tpl
+++ b/openstack/tempest/tempest-base/templates/_tempest-pod.yaml.tpl
@@ -96,7 +96,11 @@ spec:
         - name: OS_IDENTITY_API_VERSION
           value: "3"
         - name: OS_AUTH_URL
+          {{- if .Values.keystoneUrl }}
+          value: "{{ .Values.keystoneUrl }}"
+          {{- else }}
           value: "http://{{ if .Values.global.clusterDomain }}keystone.{{.Release.Namespace}}.svc.{{ required "Missing clusterDomain value!" .Values.global.clusterDomain}}{{ else }}keystone.{{.Release.Namespace}}.svc.kubernetes.{{required "Missing region value!" .Values.global.region}}.{{ required "Missing tld value!" .Values.global.tld}}{{end}}:5000/v3"
+          {{- end }}
       resources:
         requests:
           memory: "1024Mi"

--- a/openstack/tempest/tempest-base/templates/etc/_tempest_extra_options.tpl
+++ b/openstack/tempest/tempest-base/templates/etc/_tempest_extra_options.tpl
@@ -8,15 +8,19 @@ rally_debug = True
 use_dynamic_credentials = False
 create_isolated_networks = False
 test_accounts_file = /{{ .Chart.Name }}-etc-secret/tempest_accounts.yaml
-default_credentials_domain_name = tempest
+default_credentials_domain_name = {{ .Values.tempest_base.identity.default_credentials_domain_name }}
 admin_project_name = {{ default "neutron-tempest-admin1" (index .Values (print .Chart.Name | replace "-" "_")).tempest.admin_project_name }}
 admin_username = {{ default "neutron-tempest-admin1" (index .Values (print .Chart.Name | replace "-" "_")).tempest.admin_name }}
 admin_password = {{ required "A valid .Values.tempestAdminPassword required!" .Values.tempestAdminPassword | include "tempest-base.resolve_secret" }}
-admin_domain_name = tempest
+admin_domain_name = {{ .Values.tempest_base.identity.admin_domain_name }}
 admin_domain_scope = True
 
 [identity]
+{{- if .Values.keystoneUrl }}
+uri_v3 = {{ .Values.keystoneUrl }}
+{{- else }}
 uri_v3 = http://{{ if .Values.global.clusterDomain }}keystone.{{.Release.Namespace}}.svc.{{.Values.global.clusterDomain}}{{ else }}keystone.{{.Release.Namespace}}.svc.kubernetes.{{.Values.global.region}}.{{.Values.global.tld}}{{end}}:5000/v3
+{{- end }}
 endpoint_type = public
 v3_endpoint_type = public
 region = {{ .Values.global.region }}
@@ -26,15 +30,15 @@ disable_ssl_certificate_validation = True
 auth_version = v3
 username = {{ default "neutron-tempest-admin1" (index .Values (print .Chart.Name | replace "-" "_")).tempest.admin_name }}
 password = {{ required "A valid .Values.tempestAdminPassword required!" .Values.tempestAdminPassword | include "tempest-base.resolve_secret"}}
-domain_name = tempest
-admin_role = admin
-admin_domain_name = tempest
+domain_name = {{ .Values.tempest_base.identity.domain_name }}
+admin_role = {{ .Values.tempest_base.identity.admin_role }}
+admin_domain_name = {{ .Values.tempest_base.identity.admin_domain_name }}
 admin_username = {{ default "neutron-tempest-admin1" (index .Values (print .Chart.Name | replace "-" "_")).tempest.admin_name }}
 admin_password = {{ required "A valid .Values.tempestAdminPassword required!" .Values.tempestAdminPassword | include "tempest-base.resolve_secret"}}
 catalog_type = identity
-user_unique_last_password_count = 5
-user_lockout_duration = 300
-user_lockout_failure_attempts = 5
+user_unique_last_password_count = {{ .Values.tempest_base.identity.user_unique_last_password_count }}
+user_lockout_duration = {{ .Values.tempest_base.identity.user_lockout_duration }}
+user_lockout_failure_attempts = {{ .Values.tempest_base.identity.user_lockout_failure_attempts }}
 
 [identity-feature-enabled]
 domain_specific_drivers = True
@@ -50,43 +54,40 @@ security_compliance = True
 build_timeout=600
 
 [network]
-project_network_cidr = 10.199.0.0/16
+project_network_cidr = {{ .Values.tempest_base.network.project_network_cidr }}
 public_network_id = {{ .Values.tempest_common.public_network_id }}
 endpoint_type = public
 shared_physical_network= {{ .Values.tempest_common.shared_physical_network | default true }}
-floating_network_name = FloatingIP-external-monsoon3-01
+floating_network_name = {{ .Values.tempest_base.network.floating_network_name }}
 build_timeout=600
 build_interval=20
-subnet_id = a5703f23-ffcb-4ca7-9dfe-ab9861d91bf5
+subnet_id = {{ .Values.tempest_base.network.subnet_id }}
 
 [network-feature-enabled]
 ipv6 = False
 
 [neutron_plugin_options]
-max_mtu = 9000
+max_mtu = {{ .Values.tempest_base.network.max_mtu }}
 
 [baremetal]
-max_microversion = 1.78
+max_microversion = {{ .Values.tempest_base.baremetal.max_microversion }}
 # Driver to use for API tests for Queens and newer:
-driver = fake-hardware
+driver = {{ .Values.tempest_base.baremetal.driver }}
 
 
 [compute]
-# image_ref and image_ref_alt will be changed to the image-id during init-script as the image-id can change over time.
-#image_ref = CHANGE_ME_IMAGE_REF
-#image_ref_alt = CHANGEMEIMAGEREFALT
-image_ref = 84f9f266-3f11-4447-ae6c-f7940b2f5eb1
-image_ref_alt = 84f9f266-3f11-4447-ae6c-f7940b2f5eb1
+image_ref = {{ .Values.tempest_base.compute.image_ref }}
+image_ref_alt = {{ .Values.tempest_base.compute.image_ref_alt }}
 endpoint_type = public
 v3_endpoint_type = public
 region = {{ .Values.global.region }}
-flavor_ref = 20
-flavor_ref_alt = 30
-min_microversio = 2.1
+flavor_ref = {{ .Values.tempest_base.compute.flavor_ref }}
+flavor_ref_alt = {{ .Values.tempest_base.compute.flavor_ref_alt }}
+min_microversion = {{ .Values.tempest_base.compute.min_microversion }}
 max_microversion = latest
 fixed_network_name = {{ default "" (index .Values (print .Chart.Name | replace "-" "_")).tempest.fixed_network_name }}
 build_timeout=600
-compute_volume_common_az = qa-de-1b
+compute_volume_common_az = {{ .Values.tempest_base.compute.compute_volume_common_az }}
 
 [compute-feature-enabled]
 resize = True
@@ -95,7 +96,7 @@ cold_migration = False
 live_migration = False
 live_migrate_back_and_forth = False
 vnc_console = False
-vnc_server_header = WebSockify
+vnc_server_header = {{ .Values.tempest_base.compute.vnc_server_header }}
 serial_console = False
 spice_console = False
 attach_encrypted_volume = False
@@ -121,7 +122,7 @@ v3_endpoint_type = publicURL
 region = {{ .Values.global.region }}
 
 [validation]
-image_ssh_user = ccloud
+image_ssh_user = {{ .Values.tempest_base.validation.image_ssh_user }}
 ssh_key_type = rsa
 
 [volume]
@@ -129,30 +130,30 @@ catalog_type = volumev3
 endpoint_type = public
 min_microversion = 3.0
 max_microversion = latest
-vendor_name = VMware
-storage_protocol = vstorageobject
-disk_format = vmdk
-volume_size = 10
+vendor_name = {{ .Values.tempest_base.volume.vendor_name }}
+storage_protocol = {{ .Values.tempest_base.volume.storage_protocol }}
+disk_format = {{ .Values.tempest_base.volume.disk_format }}
+volume_size = {{ .Values.tempest_base.volume.volume_size }}
 build_timeout=600
-volume_type = vmware
+volume_type = {{ .Values.tempest_base.volume.volume_type }}
 
 [volume-feature-enabled]
-backup = true
+backup = {{ .Values.tempest_base.volume_feature_enabled.backup }}
 
 [service_available]
-manila = True
-neutron = True
-cinder = True
-glance = True
-nova = True
-swift = True
-designate = True
-ironic = True
-barbican = True
-keystone = True
-octavia = True
+manila = {{ .Values.tempest_base.service_available.manila }}
+neutron = {{ .Values.tempest_base.service_available.neutron }}
+cinder = {{ .Values.tempest_base.service_available.cinder }}
+glance = {{ .Values.tempest_base.service_available.glance }}
+nova = {{ .Values.tempest_base.service_available.nova }}
+swift = {{ .Values.tempest_base.service_available.swift }}
+designate = {{ .Values.tempest_base.service_available.designate }}
+ironic = {{ .Values.tempest_base.service_available.ironic }}
+barbican = {{ .Values.tempest_base.service_available.barbican }}
+keystone = {{ .Values.tempest_base.service_available.keystone }}
+octavia = {{ .Values.tempest_base.service_available.octavia }}
 
 [dns]
-nameservers = 10.114.1.233,147.204.35.140,147.204.35.141
+nameservers = {{ .Values.tempest_base.dns.nameservers }}
 
 {{ end }}

--- a/openstack/tempest/tempest-base/values.yaml
+++ b/openstack/tempest/tempest-base/values.yaml
@@ -1,0 +1,2 @@
+# tempest-base is a library/helper chart.
+# Defaults for tempest_base.* are declared in each consuming chart's values.yaml.


### PR DESCRIPTION
Move all hardcoded CCloud production values out of templates and into `values.yaml` defaults, so any environment (e.g. a DevStack dev landscape) can override them via Helm values without forking the charts.

**Changes:**
- `tempest-base`: add `keystoneUrl` value (empty = use existing in-cluster derivation); overrides the keystone endpoint in all three places: `[identity] uri_v3` in extra_options, `OS_AUTH_URL` env in the pod, and `auth_url` in deployment_config.json
- `tempest-base`: parametrize all hardcoded CCloud literals in extra_options (`image_ref`, `flavor_ref`, `floating_network_name`, `subnet_id`, `image_ssh_user`, `service_available` flags, volume/VMware block, DNS nameservers, `compute_volume_common_az`, `vnc_server_header`, baremetal driver/version); fix `min_microversio` typo
- `tempest-base`: use `hasKey` for boolean `service_available` and `volume-feature-enabled` fields to avoid Helm's `default`-trumps-`false` gotcha
- All 13 service charts: add shared defaults block to `values.yaml` covering `tempestAdminPassword`, `tempest_common`, `tempest_slack_webhook_url`, `global`, and `tempest_base.*` — `helm lint` passes without any `--set` flags
- All 13 service charts: add `keystoneUrl` override path to `_tempest_deployment_config.json.tpl`
- 8 service charts: add `ci/test-values.yaml` (previously only 5 charts had one)

**Backward compatible:** all defaults equal the previously hardcoded values, so production deployments require no changes.