### PR TITLE
[neutron-hypervisor-agents] fix leading blank lines and trailing newlines in ConfigMaps

### DIFF
--- a/openstack/neutron-hypervisor-agents/Chart.yaml
+++ b/openstack/neutron-hypervisor-agents/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart for Openstack Neutron hypervisor agents
 name: neutron-hypervisor-agents
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Neutron/OpenStack_Project_Neutron_mascot.png
-version: 0.2.1
+version: 0.2.2
 appVersion: "caracal"
 dependencies:
 - name: utils

--- a/openstack/neutron-hypervisor-agents/templates/configmap-bin.yaml
+++ b/openstack/neutron-hypervisor-agents/templates/configmap-bin.yaml
@@ -8,12 +8,12 @@ metadata:
     component: neutron
 data:
   start-ovsdb-server: |
-    {{ include (print .Template.BasePath "/bin/_start-ovsdb-server.tpl") . | nindent 4 }}
+    {{- include (print .Template.BasePath "/bin/_start-ovsdb-server.tpl") . | nindent 4 }}
   start-ovs-vswitchd: |
-    {{ include (print .Template.BasePath "/bin/_start-ovs-vswitchd.tpl") . | nindent 4 }}
+    {{- include (print .Template.BasePath "/bin/_start-ovs-vswitchd.tpl") . | nindent 4 }}
   ovn_controller_liveness.sh: |
-    {{ include (print .Template.BasePath "/bin/_ovn_controller_liveness.sh.tpl") . | nindent 4 }}
+    {{- include (print .Template.BasePath "/bin/_ovn_controller_liveness.sh.tpl") . | nindent 4 }}
   ovn_controller_readiness.sh: |
-    {{ include (print .Template.BasePath "/bin/_ovn_controller_readiness.sh.tpl") . | nindent 4 }}
+    {{- include (print .Template.BasePath "/bin/_ovn_controller_readiness.sh.tpl") . | nindent 4 }}
   init.sh: |
-    {{ include (print .Template.BasePath "/bin/_init.sh.tpl") . | nindent 4 }}
+    {{- include (print .Template.BasePath "/bin/_init.sh.tpl") . | nindent 4 }}

--- a/openstack/neutron-hypervisor-agents/templates/configmap-etc.yaml
+++ b/openstack/neutron-hypervisor-agents/templates/configmap-etc.yaml
@@ -9,12 +9,12 @@ metadata:
 
 data:
   ml2-conf.conf: |
-{{ include (print .Template.BasePath "/etc/_ml2-conf.ini.tpl") . | indent 4 }}
+    {{- include (print .Template.BasePath "/etc/_ml2-conf.ini.tpl") . | nindent 4 }}
   neutron.conf: |
-{{ include (print .Template.BasePath "/etc/_neutron.conf.tpl") . | indent 4 }}
+    {{- include (print .Template.BasePath "/etc/_neutron.conf.tpl") . | nindent 4 }}
   rootwrap.conf: |
-{{ include (print .Template.BasePath "/etc/_rootwrap.conf.tpl") . | indent 4 }}
+    {{- include (print .Template.BasePath "/etc/_rootwrap.conf.tpl") . | nindent 4 }}
   sudoers: |
-{{ include (print .Template.BasePath "/etc/_sudoers.tpl") . | indent 4 }}
+    {{- include (print .Template.BasePath "/etc/_sudoers.tpl") . | nindent 4 }}
   logging.ini: |
-{{ include "loggerIni" .Values.logging_sapccsentry | indent 4 }}
+    {{- include "loggerIni" .Values.logging_sapccsentry | nindent 4 }}


### PR DESCRIPTION
The ConfigMap keys under `templates/configmap-{bin,etc}.yaml` combine a YAML literal block scalar `|` with `{{ include ... | nindent 4 }}` (no leading trim marker) — `nindent` emits a leading newline that Helm does not strip. The rendered ConfigMap value looks like:

```yaml
  start-ovsdb-server: |

      #!/usr/bin/env bash
      ...
```

For `configmap-bin.yaml` the blank line is a crash: Linux treats a file whose first two bytes are not `#!` as an ELF binary, so `exec /usr/local/bin/start-ovsdb-server` returns `exec format error` — the failure that keeps the openvswitch-agent daemonset in CrashLoopBackOff on runtimes that do not fall back to `/bin/sh`.

For `configmap-etc.yaml` the blank line is cosmetic: oslo.config tolerates leading whitespace in the .conf files, but the rendered YAML is visibly wrong.

Fix: add the `{{-` trim marker so the include output is joined directly to the block scalar opener. Plain `|` is kept (not `|-`) — files retain their conventional trailing newline. Also ensure `configmap-bin.yaml` itself ends with a trailing newline.