### PR TITLE
[neutron-hypervisor-agents] plumb kubernetes.metal.cloud.sap/bb onto pod template

### DIFF
--- a/openstack/neutron-hypervisor-agents/Chart.yaml
+++ b/openstack/neutron-hypervisor-agents/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart for Openstack Neutron hypervisor agents
 name: neutron-hypervisor-agents
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Neutron/OpenStack_Project_Neutron_mascot.png
-version: 0.2.2
+version: 0.2.3
 appVersion: "caracal"
 dependencies:
 - name: utils

--- a/openstack/neutron-hypervisor-agents/templates/daemonset-linuxbridge-agent.yaml
+++ b/openstack/neutron-hypervisor-agents/templates/daemonset-linuxbridge-agent.yaml
@@ -22,6 +22,10 @@ spec:
         alert-tier: os
         alert-service: neutron
         ml2-driver: "linuxbridge"
+        # Source for the BUILDING_BLOCK downward-API env.
+        {{- if .Values.global.buildingBlock }}
+        kubernetes.metal.cloud.sap/bb: {{ .Values.global.buildingBlock | quote }}
+        {{- end }}
       annotations:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") . | sha256sum }}
         secret-etc-hash: {{ include (print $.Template.BasePath "/secret-etc.yaml") . | sha256sum }}

--- a/openstack/neutron-hypervisor-agents/templates/daemonset-openvswitch-agent.yaml
+++ b/openstack/neutron-hypervisor-agents/templates/daemonset-openvswitch-agent.yaml
@@ -22,6 +22,10 @@ spec:
         alert-tier: os
         alert-service: neutron
         ml2-driver: "ovs"
+        # Source for the BUILDING_BLOCK downward-API env.
+        {{- if .Values.global.buildingBlock }}
+        kubernetes.metal.cloud.sap/bb: {{ .Values.global.buildingBlock | quote }}
+        {{- end }}
       annotations:
         configmap-etc-hash: {{ include (print $.Template.BasePath "/configmap-etc.yaml") . | sha256sum }}
         secret-etc-hash: {{ include (print $.Template.BasePath "/secret-etc.yaml") . | sha256sum }}

--- a/openstack/neutron-hypervisor-agents/templates/daemonset-ovn-controller.yaml
+++ b/openstack/neutron-hypervisor-agents/templates/daemonset-ovn-controller.yaml
@@ -22,6 +22,10 @@ spec:
         alert-tier: os
         alert-service: neutron
         ml2-driver: "ovn"
+        # Source for the BUILDING_BLOCK downward-API env.
+        {{- if .Values.global.buildingBlock }}
+        kubernetes.metal.cloud.sap/bb: {{ .Values.global.buildingBlock | quote }}
+        {{- end }}
       annotations:
         configmap-bin-hash: {{ include (print $.Template.BasePath "/configmap-bin.yaml") . | sha256sum }}
     spec:


### PR DESCRIPTION
`BUILDING_BLOCK` is read via downward API from the pod's own `kubernetes.metal.cloud.sap/bb` label. In production the label-injector mutating webhook copies that label from the Node onto every pod. On a plain Gardener test cluster without the webhook `init.sh` exits with `BUILDING_BLOCK is not set`.

Set the label directly from `.Values.global.buildingBlock` under an if-defined guard so test deployments can skip the webhook while production deployments (value unset) keep using it.

Stacked on #12443.