### PR TITLE
[ironic] limit workers for console nginx

### DIFF
--- a/openstack/ironic/templates/_conductor-deployment.yaml.tpl
+++ b/openstack/ironic/templates/_conductor-deployment.yaml.tpl
@@ -167,11 +167,14 @@ spec:
             containerPort: 443
         volumeMounts:
           - mountPath: /etc/nginx/conf.d/default.conf
-            name: ironic-console-nginxconf
+            name: ironic-console-default
             subPath: default.conf
           - mountPath: /etc/nginx/conf.d/dhparam.pem
             name: ironic-console-dhparam
             subPath: dhparam.pem
+          - mountPath: /etc/nginx/nginx.conf
+            name: ironic-console-nginx
+            subpath: nginx.conf
           - mountPath: /shellinabox
             name: shellinabox
           - mountPath: /etc/nginx/certs
@@ -235,7 +238,10 @@ spec:
         {{- else }}
           name: ironic-conductor-etc
         {{- end }}
-      - name: ironic-console-nginxconf
+      - name: ironic-console-nginx
+        configMap:
+          name: ironic-console-nginx
+      - name: ironic-console-default
         secret:
           secretName: ironic-console-secret
           items:

--- a/openstack/ironic/templates/console-secret.yaml
+++ b/openstack/ironic/templates/console-secret.yaml
@@ -15,4 +15,4 @@ metadata:
 type: Opaque
 data:
   default.conf: |
-    {{ include (print .Template.BasePath "/etc/_nginx.conf.tpl") . | b64enc | indent 4 }}
+    {{ include (print .Template.BasePath "/etc/_default.conf.tpl") . | b64enc | indent 4 }}

--- a/openstack/ironic/templates/etc/_default.conf.tpl
+++ b/openstack/ironic/templates/etc/_default.conf.tpl
@@ -1,0 +1,87 @@
+map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' close;
+    }
+
+server {
+
+    listen 443 default_server ssl;
+    http2 on;
+    server_name  {{ include "ironic_console_endpoint_host_public" . }};
+    ssl_certificate /etc/nginx/certs/tls.crt;
+    ssl_certificate_key /etc/nginx/certs/tls.key;
+
+    # https://ssl-config.mozilla.org/
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:MozSSL:10m;  # about 40000 sessions
+    ssl_session_tickets off;
+
+    ssl_dhparam /etc/nginx/conf.d/dhparam.pem;
+
+    # intermediate configuration
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305;
+    ssl_prefer_server_ciphers off;
+
+    # HSTS (ngx_http_headers_module is required) (63072000 seconds)
+    add_header Strict-Transport-Security "max-age=63072000" always;
+
+    # Health-Check
+    location /health {
+        access_log off;
+        return 204;
+    }
+
+    # Possibly proxies probing the host
+    location / {
+        access_log off;
+        return 204;
+    }
+
+    # We only need to authenticate the GET of the index, as that
+    # creates a session and returns a secret used in all futher requests
+    # The url is of the form:
+    #   /<conductor-name>/<instance-uuid>/<expiry>/<md5-signature>/<static-resources>
+
+    # We obviously do not have to secure any static resources
+    location ~* "/[^/]*/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/([0-9]*)/([^/]*)/?$" {
+        secure_link $3,$2;
+        secure_link_md5 "$secure_link_expires$1 {{required "A valid .Values.console.secret required!" .Values.console.secret | include "resolve_secret" }}";
+
+        set $check $secure_link;
+
+        # Do not authenticate the POST, as it is handled internally
+        if ($request_method = POST) {
+            set $check "1";
+        }
+
+        if ($check = "" ) {
+            return 403;
+        }
+
+        if ($check = "0") {
+            return 410;
+        }
+
+        proxy_pass http://unix:/shellinabox/$1.sock:/;
+        proxy_set_header    Host      $host;
+        proxy_http_version  1.1;
+        proxy_redirect      off;
+        proxy_buffering     off;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+    }
+
+    location ~* "/[^/]*/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/([0-9]*)/([^/]*)/([^.]+\.[^.]+)$" {
+        if ($request_method != GET) {
+            return 400;
+        }
+        proxy_pass http://unix:/shellinabox/$1.sock:/$4;
+        proxy_set_header    Host      $host;
+        proxy_http_version  1.1;
+        proxy_redirect      off;
+        proxy_buffering     off;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+    }
+}

--- a/openstack/ironic/templates/etc/_nginx.conf.tpl
+++ b/openstack/ironic/templates/etc/_nginx.conf.tpl
@@ -1,87 +1,31 @@
-map $http_upgrade $connection_upgrade {
-        default upgrade;
-        '' close;
-    }
+user  nginx;
+worker_processes  {{ required ".Values.console.nginx_workers is missing" .Values.console.nginx_workers }};
 
-server {
+error_log  /var/log/nginx/error.log notice;
+pid        /run/nginx.pid;
 
-    listen 443 default_server ssl;
-    http2 on;
-    server_name  {{ include "ironic_console_endpoint_host_public" . }};
-    ssl_certificate /etc/nginx/certs/tls.crt;
-    ssl_certificate_key /etc/nginx/certs/tls.key;
 
-    # https://ssl-config.mozilla.org/
-    ssl_session_timeout 1d;
-    ssl_session_cache shared:MozSSL:10m;  # about 40000 sessions
-    ssl_session_tickets off;
+events {
+    worker_connections  1024;
+}
 
-    ssl_dhparam /etc/nginx/conf.d/dhparam.pem;
 
-    # intermediate configuration
-    ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305;
-    ssl_prefer_server_ciphers off;
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
 
-    # HSTS (ngx_http_headers_module is required) (63072000 seconds)
-    add_header Strict-Transport-Security "max-age=63072000" always;
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
 
-    # Health-Check
-    location /health {
-        access_log off;
-        return 204;
-    }
+    access_log  /var/log/nginx/access.log  main;
 
-    # Possibly proxies probing the host
-    location / {
-        access_log off;
-        return 204;
-    }
+    sendfile        on;
+    #tcp_nopush     on;
 
-    # We only need to authenticate the GET of the index, as that
-    # creates a session and returns a secret used in all futher requests
-    # The url is of the form:
-    #   /<conductor-name>/<instance-uuid>/<expiry>/<md5-signature>/<static-resources>
+    keepalive_timeout  65;
 
-    # We obviously do not have to secure any static resources
-    location ~* "/[^/]*/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/([0-9]*)/([^/]*)/?$" {
-        secure_link $3,$2;
-        secure_link_md5 "$secure_link_expires$1 {{required "A valid .Values.console.secret required!" .Values.console.secret | include "resolve_secret" }}";
+    #gzip  on;
 
-        set $check $secure_link;
-
-        # Do not authenticate the POST, as it is handled internally
-        if ($request_method = POST) {
-            set $check "1";
-        }
-
-        if ($check = "" ) {
-            return 403;
-        }
-
-        if ($check = "0") {
-            return 410;
-        }
-
-        proxy_pass http://unix:/shellinabox/$1.sock:/;
-        proxy_set_header    Host      $host;
-        proxy_http_version  1.1;
-        proxy_redirect      off;
-        proxy_buffering     off;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection $connection_upgrade;
-    }
-
-    location ~* "/[^/]*/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/([0-9]*)/([^/]*)/([^.]+\.[^.]+)$" {
-        if ($request_method != GET) {
-            return 400;
-        }
-        proxy_pass http://unix:/shellinabox/$1.sock:/$4;
-        proxy_set_header    Host      $host;
-        proxy_http_version  1.1;
-        proxy_redirect      off;
-        proxy_buffering     off;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection $connection_upgrade;
-    }
+    include /etc/nginx/conf.d/*.conf;
 }

--- a/openstack/ironic/values.yaml
+++ b/openstack/ironic/values.yaml
@@ -230,6 +230,7 @@ agent:
 
 console:
   ssh_loglevel: error
+  nginx_workers: 5
 
 tftp_ip: null
 tftp_files:


### PR DESCRIPTION
The new nodes in the eu-de-3 region are baremetal and thus present all
80 virtual cpus to the containers instead of the 10 on the VMs in the
old setup. With the "worker_process auto;" setting in the nginx
container that means nginx will spawn a worker per CPU, breaking the
(small) memory limits and getting OOM killed. We could increase the
limit for the container but we probably never need so many workers. A
worker can have 1024 connections, as there is probably only one per
node we're never going to reach that. Instead we take the nginx.conf
from the container and just make the worker_process adjustable via
values. While we currently have 10 workers, 5 should be plenty for this
job as reverse proxy.
To make this easier to understand we rename an old mount from nginxconf
to default, because it is mounting the default.conf and not the
nginx.conf. This way the names better reflect what the variables do.
