### PR TITLE
[keystone] add  pod-level TLS termination

### DIFF
--- a/openstack/keystone/templates/service-external.yaml
+++ b/openstack/keystone/templates/service-external.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.global.keystone_external_ip }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-external
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    system: openstack
+    component: keystone
+    type: api-external
+  annotations:
+    {{- include "utils.linkerd.pod_and_service_annotation" . | indent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    name: {{ .Release.Name }}-api
+  ports:
+    - name: public
+      protocol: TCP
+      port: 5000
+      targetPort: 5000
+  externalIPs:
+    - {{ .Values.global.keystone_external_ip | quote }}
+{{- end }}

--- a/openstack/keystone/templates/service-external.yaml
+++ b/openstack/keystone/templates/service-external.yaml
@@ -14,7 +14,8 @@ metadata:
   annotations:
     {{- include "utils.linkerd.pod_and_service_annotation" . | indent 4 }}
 spec:
-  type: ClusterIP
+  type: LoadBalancer
+  externalTrafficPolicy: Local  
   selector:
     name: {{ .Release.Name }}-api
   ports:

--- a/openstack/keystone/templates/service-external.yaml
+++ b/openstack/keystone/templates/service-external.yaml
@@ -13,6 +13,7 @@ metadata:
     type: api-external
   annotations:
     {{- include "utils.linkerd.pod_and_service_annotation" . | indent 4 }}
+    projectcalico.org/loadBalancerIPs: '["{{ .Values.global.keystone_external_ip }}"]'
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Local  

--- a/openstack/keystone/templates/service-external.yaml
+++ b/openstack/keystone/templates/service-external.yaml
@@ -16,7 +16,7 @@ metadata:
     projectcalico.org/loadBalancerIPs: '["{{ .Values.global.keystone_external_ip }}"]'
 spec:
   type: LoadBalancer
-  externalTrafficPolicy: Local  
+  externalTrafficPolicy: Local
   selector:
     name: {{ .Release.Name }}-api
   ports:
@@ -24,6 +24,4 @@ spec:
       protocol: TCP
       port: 5000
       targetPort: 5000
-  externalIPs:
-    - {{ .Values.global.keystone_external_ip | quote }}
 {{- end }}


### PR DESCRIPTION
Option 4 (direct BGP exposure) with key lifecycle option a (go-crypto + none + internal-k8s-secret) for 007-enabled regions.