### PR TITLE
[netapp-harvest-exporter]: enable PodMonitor in eu-de-3

### DIFF
--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/Chart.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/Chart.yaml
@@ -2,8 +2,9 @@ apiVersion: v2
 description: NetApp Harvest exporter
 name: netapp-harvest-exporter
 type: application
-version: 0.2.16
+version: 0.2.17
 # Changes
+# v0.2.17: - add PodMonitor for eu-de-3 greenhouse prometheus discovery
 # v0.1.2: - fix incosistent cluster labels
 # v0.1.3: - fix multiple scraping problem when filers in maintenance
 #           monitor scraped filers with metadata metrics 'netapp_metadata_exporter_count'

--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/Chart.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/Chart.yaml
@@ -2,8 +2,9 @@ apiVersion: v2
 description: NetApp Harvest exporter
 name: netapp-harvest-exporter
 type: application
-version: 0.2.17
+version: 0.2.18
 # Changes
+# v0.2.18: - re-gate PodMonitor on .Values.podMonitor.enabled (default false) instead of hardcoded region
 # v0.2.17: - add PodMonitor for eu-de-3 greenhouse prometheus discovery
 # v0.1.2: - fix incosistent cluster labels
 # v0.1.3: - fix multiple scraping problem when filers in maintenance

--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/templates/deployment_worker.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/templates/deployment_worker.yaml
@@ -33,6 +33,7 @@ spec:
       labels:
         app: {{ include "netapp-harvest.fullname" . }}-{{ $appName }}
         name: {{ include "netapp-harvest.fullname" . }}-{{ $appName }}-worker
+        component: harvest-worker
     spec:
       serviceAccountName: netappsd
       containers:

--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/templates/pod-monitor.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/templates/pod-monitor.yaml
@@ -4,7 +4,7 @@ kind: PodMonitor
 metadata:
   name: {{ printf "%s-harvest-pod-monitor" .Release.Name | trunc 63 | trimSuffix "-" }}
   labels:
-    prometheus: {{ .Values.global.prometheus }}
+    prometheus: {{ required ".Values.global.prometheus missing" .Values.global.prometheus }}
 spec:
   namespaceSelector:
     matchNames:

--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/templates/pod-monitor.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/templates/pod-monitor.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.global.region "eu-de-3" }}
+{{- if .Values.podMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:

--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/templates/pod-monitor.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/templates/pod-monitor.yaml
@@ -1,0 +1,17 @@
+{{- if eq .Values.global.region "eu-de-3" }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ printf "%s-harvest-pod-monitor" .Release.Name | trunc 63 | trimSuffix "-" }}
+  labels:
+    prometheus: {{ .Values.global.prometheus }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      component: harvest-worker
+  podMetricsEndpoints:
+    - port: metrics
+{{- end }}

--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/values.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/values.yaml
@@ -43,4 +43,7 @@ netappsd:
       cpu: 50m
       memory: 128Mi
 
+podMonitor:
+  enabled: false
+
 fullnameOverride: netapp-harvest-exporter


### PR DESCRIPTION
## Summary

Add PodMonitor (monitoring.coreos.com/v1) so the storage Prometheus in
eu-de-3 (greenhouse) discovers harvest worker pods via PodMonitor selector
instead of annotation-based scraping.

- templates/pod-monitor.yaml: gated on global.region == eu-de-3; selects
  pods with component=harvest-worker; prometheus label set from
  global.prometheus (resolves to "storage"); port: metrics (13000).
- deployment_worker.yaml: add component=harvest-worker to pod template
  labels as the shared selector across all app workers (apod/cinder/manila).
