### PR TITLE
keppel-trivy: add support for deployment to eu-de-3

### DIFF
--- a/openstack/keppel-trivy/Chart.lock
+++ b/openstack/keppel-trivy/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 1.1.1
 - name: redis
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 2.4.74
+  version: 2.5.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:f676ea1494dc97d87e85d2801fd55be0a04e349534912b2df72a0acaa27aafd0
-generated: "2026-07-27T04:23:47.181406598Z"
+digest: sha256:7c89945e4a8957619d7dd84776ded5a4ac6d5df4d54d9acec5363a5b49d02e32
+generated: "2026-07-30T13:44:16.39781161+02:00"

--- a/openstack/keppel-trivy/templates/deployment-api.yaml
+++ b/openstack/keppel-trivy/templates/deployment-api.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   revisionHistoryLimit: 5
   # When running the Trivy client against a server, lots of computations are
-  # still performed on the clide side, i.e. in these pods. Therefore we have
+  # still performed on the client side, i.e. in these pods. Therefore we have
   # this scaled up more than the server itself.
   replicas: {{ $.Values.trivy.api.replicas }}
   strategy:
@@ -44,7 +44,7 @@ spec:
                   name: trivy-secret
                   key: trivy_token
             - name:  KEPPEL_TRIVY_URL
-              value: "http://trivy-server.trivy.svc:8080"
+              value: "http://trivy-server.{{ $.Release.Namespace }}.svc:8080"
           securityContext:
             runAsNonRoot: true
           livenessProbe:

--- a/openstack/keppel-trivy/templates/service-api.yaml
+++ b/openstack/keppel-trivy/templates/service-api.yaml
@@ -5,7 +5,8 @@ metadata:
   name: trivy-api
   annotations:
     prometheus.io/scrape: "true"
-    prometheus.io/targets: "infra-frontend"
+    # metrics go to the same Prometheus as used by redis-exporter
+    prometheus.io/targets: {{ tpl .Values.redis.metrics.prometheus $ | quote }}
 
 spec:
   selector:

--- a/openstack/keppel-trivy/values.yaml
+++ b/openstack/keppel-trivy/values.yaml
@@ -42,7 +42,9 @@ redis:
     maxmemory-samples: 5
 
   metrics:
-    prometheus: infra-frontend
+    # uses infra-frontend for Kubernikus-based scaleout clusters
+    # uses obs-metrics-product in Gardener-based controlplane clusters
+    prometheus: '{{ if eq .Values.global.clusterType "scaleout" }}infra-frontend{{ else }}obs-metrics-product{{ end }}'
     resources:
       limits:
         memory: 48Mi


### PR DESCRIPTION
eu-de-3 does not have a scaleout, so we need to go into the (Gardener-based) controlplane cluster instead.

I verified this change by running `helm diff` in s-qa-de-1: The diff is empty (except for a redis-exporter upgrade that was not transported to QA yet).