### PR TITLE
system/gatekeeper: simplify templating of lib inclusions

### DIFF
--- a/system/gatekeeper/templates/constrainttemplate-deprecated-api-version.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-deprecated-api-version.yaml
@@ -28,10 +28,8 @@ spec:
           source:
             version: "v1"
             libs:
-              - |
-                {{ .Files.Get "lib/add-support-labels.rego" | nindent 16 }}
-              - |
-                {{ .Files.Get "lib/helm-release.rego" | nindent 16 }}
+              - {{ .Files.Get "lib/add-support-labels.rego" | quote }}
+              - {{ .Files.Get "lib/helm-release.rego" | quote }}
             rego: |
               package deprecatedapiversion
 

--- a/system/gatekeeper/templates/constrainttemplate-forbidden-clusterwide-objects.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-forbidden-clusterwide-objects.yaml
@@ -15,8 +15,7 @@ spec:
           source:
             version: "v1"
             libs:
-              - |
-                {{ .Files.Get "lib/add-support-labels.rego" | nindent 16 }}
+              - {{ .Files.Get "lib/add-support-labels.rego" | quote }}
             rego: |
               package forbiddenclusterwideobjects
 

--- a/system/gatekeeper/templates/constrainttemplate-high-cpu-requests.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-high-cpu-requests.yaml
@@ -22,10 +22,8 @@ spec:
           source:
             version: "v1"
             libs:
-              - |
-                {{ .Files.Get "lib/add-support-labels.rego" | nindent 16 }}
-              - |
-                {{ .Files.Get "lib/traversal.rego" | nindent 16 }}
+              - {{ .Files.Get "lib/add-support-labels.rego" | quote }}
+              - {{ .Files.Get "lib/traversal.rego" | quote }}
             rego: |
               package highcpurequests
 

--- a/system/gatekeeper/templates/constrainttemplate-images-from-correct-registry.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-images-from-correct-registry.yaml
@@ -24,10 +24,8 @@ spec:
           source:
             version: "v1"
             libs:
-              - |
-                {{ .Files.Get "lib/add-support-labels.rego" | nindent 16 }}
-              - |
-                {{ .Files.Get "lib/traversal.rego" | nindent 16 }}
+              - {{ .Files.Get "lib/add-support-labels.rego" | quote }}
+              - {{ .Files.Get "lib/traversal.rego" | quote }}
             rego: |
               package imagesfromcorrectregistry
 

--- a/system/gatekeeper/templates/constrainttemplate-images-from-non-keppel.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-images-from-non-keppel.yaml
@@ -15,10 +15,8 @@ spec:
           source:
             version: "v1"
             libs:
-              - |
-                {{ .Files.Get "lib/add-support-labels.rego" | nindent 16 }}
-              - |
-                {{ .Files.Get "lib/traversal.rego" | nindent 16 }}
+              - {{ .Files.Get "lib/add-support-labels.rego" | quote }}
+              - {{ .Files.Get "lib/traversal.rego" | quote }}
             rego: |
               package imagesfromnonkeppel
 

--- a/system/gatekeeper/templates/constrainttemplate-ingress-annotations-migration.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-ingress-annotations-migration.yaml
@@ -15,8 +15,7 @@ spec:
           source:
             version: "v1"
             libs:
-              - |
-                {{ .Files.Get "lib/add-support-labels.rego" | nindent 16 }}
+              - {{ .Files.Get "lib/add-support-labels.rego" | quote }}
             rego: |
               package ingressannotations
 

--- a/system/gatekeeper/templates/constrainttemplate-ingress-annotations.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-ingress-annotations.yaml
@@ -26,8 +26,7 @@ spec:
           source:
             version: "v1"
             libs:
-              - |
-                {{ .Files.Get "lib/add-support-labels.rego" | nindent 16 }}
+              - {{ .Files.Get "lib/add-support-labels.rego" | quote }}
             rego: |
               package ingressannotations
 

--- a/system/gatekeeper/templates/constrainttemplate-libtest-add-support-labels.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-libtest-add-support-labels.yaml
@@ -24,10 +24,8 @@ spec:
           source:
             version: "v1"
             libs:
-              - |
-                {{ .Files.Get "lib/add-support-labels.rego" | nindent 16 }}
-              - |
-                {{ .Files.Get "lib/helm-release.rego" | nindent 16 }}
+              - {{ .Files.Get "lib/add-support-labels.rego" | quote }}
+              - {{ .Files.Get "lib/helm-release.rego" | quote }}
             rego: |
               package libtestaddsupportlabels
 

--- a/system/gatekeeper/templates/constrainttemplate-libtest-traversal.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-libtest-traversal.yaml
@@ -17,8 +17,7 @@ spec:
           source:
             version: "v1"
             libs:
-              - |
-                {{ .Files.Get "lib/traversal.rego" | nindent 16 }}
+              - {{ .Files.Get "lib/traversal.rego" | quote }}
             rego: |
               package libtesttraversal
 

--- a/system/gatekeeper/templates/constrainttemplate-outdated-image-bases.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-outdated-image-bases.yaml
@@ -22,12 +22,9 @@ spec:
           source:
             version: "v1"
             libs:
-              - |
-                {{ .Files.Get "lib/add-support-labels.rego" | nindent 16 }}
-              - |
-                {{ .Files.Get "lib/image-check.rego" | nindent 16 }}
-              - |
-                {{ .Files.Get "lib/traversal.rego" | nindent 16 }}
+              - {{ .Files.Get "lib/add-support-labels.rego" | quote }}
+              - {{ .Files.Get "lib/image-check.rego" | quote }}
+              - {{ .Files.Get "lib/traversal.rego" | quote }}
             rego: |
               package outdatedimagebases
 

--- a/system/gatekeeper/templates/constrainttemplate-outdated-mirrors.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-outdated-mirrors.yaml
@@ -15,10 +15,8 @@ spec:
           source:
             version: "v1"
             libs:
-              - |
-                {{ .Files.Get "lib/add-support-labels.rego" | nindent 16 }}
-              - |
-                {{ .Files.Get "lib/traversal.rego" | nindent 16 }}
+              - {{ .Files.Get "lib/add-support-labels.rego" | quote }}
+              - {{ .Files.Get "lib/traversal.rego" | quote }}
             rego: |
               package outdatedmirrors
 

--- a/system/gatekeeper/templates/constrainttemplate-owner-info-on-helm-releases.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-owner-info-on-helm-releases.yaml
@@ -26,10 +26,8 @@ spec:
           source:
             version: "v1"
             libs:
-              - |
-                {{ .Files.Get "lib/add-support-labels.rego" | nindent 16 }}
-              - |
-                {{ .Files.Get "lib/helm-release.rego" | nindent 16 }}
+              - {{ .Files.Get "lib/add-support-labels.rego" | quote }}
+              - {{ .Files.Get "lib/helm-release.rego" | quote }}
             rego: |
               package ownerinfoonhelmreleases
 

--- a/system/gatekeeper/templates/constrainttemplate-pci-forbidden-images.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-pci-forbidden-images.yaml
@@ -26,10 +26,8 @@ spec:
           source:
             version: "v1"
             libs:
-              - |
-                {{ .Files.Get "lib/add-support-labels.rego" | nindent 16 }}
-              - |
-                {{ .Files.Get "lib/traversal.rego" | nindent 16 }}
+              - {{ .Files.Get "lib/add-support-labels.rego" | quote }}
+              - {{ .Files.Get "lib/traversal.rego" | quote }}
             rego: |
               package pciforbiddenimages
 

--- a/system/gatekeeper/templates/constrainttemplate-pod-labels.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-pod-labels.yaml
@@ -24,10 +24,8 @@ spec:
           source:
             version: "v1"
             libs:
-              - |
-                {{ .Files.Get "lib/add-support-labels.rego" | nindent 16 }}
-              - |
-                {{ .Files.Get "lib/traversal.rego" | nindent 16 }}
+              - {{ .Files.Get "lib/add-support-labels.rego" | quote }}
+              - {{ .Files.Get "lib/traversal.rego" | quote }}
             rego: |
               package podlabels
 

--- a/system/gatekeeper/templates/constrainttemplate-pod-security-v2.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-pod-security-v2.yaml
@@ -62,10 +62,8 @@ spec:
           source:
             version: "v1"
             libs:
-              - |
-                {{ .Files.Get "lib/add-support-labels.rego" | nindent 16 }}
-              - |
-                {{ .Files.Get "lib/traversal.rego" | nindent 16 }}
+              - {{ .Files.Get "lib/add-support-labels.rego" | quote }}
+              - {{ .Files.Get "lib/traversal.rego" | quote }}
             rego: |
               package podsecurityv2
 

--- a/system/gatekeeper/templates/constrainttemplate-prometheus-scrape-annotations.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-prometheus-scrape-annotations.yaml
@@ -15,8 +15,7 @@ spec:
           source:
             version: "v1"
             libs:
-              - |
-                {{ .Files.Get "lib/add-support-labels.rego" | nindent 16 }}
+              - {{ .Files.Get "lib/add-support-labels.rego" | quote }}
             rego: |
               package prometheusscrapeannotations
 

--- a/system/gatekeeper/templates/constrainttemplate-prometheusrule-alert-labels.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-prometheusrule-alert-labels.yaml
@@ -15,8 +15,7 @@ spec:
           source:
             version: "v1"
             libs:
-              - |
-                {{ .Files.Get "lib/add-support-labels.rego" | nindent 16 }}
+              - {{ .Files.Get "lib/add-support-labels.rego" | quote }}
             rego: |
               package prometheusrulealertlabels
 

--- a/system/gatekeeper/templates/constrainttemplate-region-value-mismatch.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-region-value-mismatch.yaml
@@ -24,12 +24,9 @@ spec:
           source:
             version: "v1"
             libs:
-              - |
-                {{ .Files.Get "lib/add-support-labels.rego" | nindent 16 }}
-              - |
-                {{ .Files.Get "lib/helm-release.rego" | nindent 16 }}
-              - |
-                {{ .Files.Get "lib/validation.rego" | nindent 16 }}
+              - {{ .Files.Get "lib/add-support-labels.rego" | quote }}
+              - {{ .Files.Get "lib/helm-release.rego" | quote }}
+              - {{ .Files.Get "lib/validation.rego" | quote }}
             rego: |
               package gkregionvaluemissing
 

--- a/system/gatekeeper/templates/constrainttemplate-region-value-missing.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-region-value-missing.yaml
@@ -22,12 +22,9 @@ spec:
           source:
             version: "v1"
             libs:
-              - |
-                {{ .Files.Get "lib/add-support-labels.rego" | nindent 16 }}
-              - |
-                {{ .Files.Get "lib/helm-release.rego" | nindent 16 }}
-              - |
-                {{ .Files.Get "lib/validation.rego" | nindent 16 }}
+              - {{ .Files.Get "lib/add-support-labels.rego" | quote }}
+              - {{ .Files.Get "lib/helm-release.rego" | quote }}
+              - {{ .Files.Get "lib/validation.rego" | quote }}
             rego: |
               package gkregionvaluemissing
 

--- a/system/gatekeeper/templates/constrainttemplate-unmanaged-pods.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-unmanaged-pods.yaml
@@ -15,8 +15,7 @@ spec:
           source:
             version: "v1"
             libs:
-              - |
-                {{ .Files.Get "lib/add-support-labels.rego" | nindent 16 }}
+              - {{ .Files.Get "lib/add-support-labels.rego" | quote }}
             rego: |
               package unmanagedpods
 

--- a/system/gatekeeper/templates/constrainttemplate-vulnerable-images.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-vulnerable-images.yaml
@@ -33,12 +33,9 @@ spec:
           source:
             version: "v1"
             libs:
-              - |
-                {{ .Files.Get "lib/add-support-labels.rego" | nindent 16 }}
-              - |
-                {{ .Files.Get "lib/image-check.rego" | nindent 16 }}
-              - |
-                {{ .Files.Get "lib/traversal.rego" | nindent 16 }}
+              - {{ .Files.Get "lib/add-support-labels.rego" | quote }}
+              - {{ .Files.Get "lib/image-check.rego" | quote }}
+              - {{ .Files.Get "lib/traversal.rego" | quote }}
             rego: |
               package vulnerableimages
 


### PR DESCRIPTION
This produces some whitespace-only diffs, which I want to get out of the way first, because I want to be able to verify an upcoming change in `helm diff` without having to deal with the whitespace clutter.