### PR TITLE
system/gatekeeper: remove templating from Rego level

### DIFF
--- a/system/gatekeeper/templates/constraint-forbidden-clusterwide-objects.yaml
+++ b/system/gatekeeper/templates/constraint-forbidden-clusterwide-objects.yaml
@@ -19,6 +19,12 @@ spec:
     kinds:
       - apiGroups: [ admissionregistration.k8s.io ]
         kinds: [ MutatingWebhookConfiguration, ValidatingWebhookConfiguration ]
+  parameters:
+    {{- if eq .Values.cluster_type "kubernikus" "virtual" "metal" }}
+    kubeSystemReleaseName: "kube-system-{{ .Values.cluster_type }}"
+    {{- else }}
+    kubeSystemReleaseName: "kube-system"
+    {{- end }}
 
 # NOTE: When we want to move into `enforcementMode: deny` for some of these
 # kinds, the plan is to make a new constraint config and move the respective

--- a/system/gatekeeper/templates/constrainttemplate-forbidden-clusterwide-objects.yaml
+++ b/system/gatekeeper/templates/constrainttemplate-forbidden-clusterwide-objects.yaml
@@ -7,6 +7,13 @@ spec:
     spec:
       names:
         kind: GkForbiddenClusterwideObjects
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          properties:
+            kubeSystemReleaseName:
+              type: string
 
   targets:
     - target: admission.k8s.gatekeeper.sh
@@ -50,19 +57,13 @@ spec:
               }
 
               # validating AND mutating webhook: kube-system/cert-manager-webhook
-              {{- if eq .Values.cluster_type "kubernikus" "virtual" "metal" }}
-              kubeSystemReleaseName := "kube-system-{{ .Values.cluster_type }}"
-              {{- else }}
-              kubeSystemReleaseName := "kube-system"
-              {{- end }}
-
               allowed_webhook contains {"name": webhook.name, "reason": "allow-gatekeeper"} if {
                   # NOTE: both kinds are allowed
-                  iro.metadata.name == sprintf("%s-cert-manager-webhook", [kubeSystemReleaseName])
+                  iro.metadata.name == sprintf("%s-cert-manager-webhook", [input.parameters.kubeSystemReleaseName])
 
                   webhook := iro.webhooks[_]
                   webhook.clientConfig.service.namespace == "kube-system"
-                  webhook.clientConfig.service.name == sprintf("%s-cert-manager-webhook", [kubeSystemReleaseName])
+                  webhook.clientConfig.service.name == sprintf("%s-cert-manager-webhook", [input.parameters.kubeSystemReleaseName])
                   [a | a := webhook.rules[_].apiGroups] == [["cert-manager.io", "acme.cert-manager.io"]]
               }
 


### PR DESCRIPTION
This is the only remaining place where we have templating in the Rego code. We don't want this because it makes refactoring easier if we can treat Rego snippets as plain strings. Gatekeeper has its own structure for passing config into Rego code, and we are using it everywhere, except for this one place.