### PR TITLE
[ironic] enable disco for all ingress

### DIFF
--- a/openstack/ironic/templates/_console-ingress.yaml.tpl
+++ b/openstack/ironic/templates/_console-ingress.yaml.tpl
@@ -16,6 +16,7 @@ metadata:
     component: ironic
   annotations:
     kubernetes.io/tls-acme: "true"
+    disco: "true"
     ingress.kubernetes.io/backend-protocol: HTTPS
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     ingress.kubernetes.io/ssl-passthrough: "true"

--- a/openstack/ironic/templates/api-ingress.yaml
+++ b/openstack/ironic/templates/api-ingress.yaml
@@ -9,6 +9,7 @@ metadata:
     component: ironic
   annotations:
     kubernetes.io/tls-acme: "true"
+    disco: "true"
     {{- include "utils.linkerd.ingress_annotation" . | indent 4 }}
 spec:
   tls:


### PR DESCRIPTION
For the new gardener based regions we need disco enabled. But it was
only enabled for the inspector.
