### PR TITLE
fix(servicemesh): bump linkerd to edge-26.7.2 to fix critical CVEs

### DIFF
--- a/system/servicemesh-crds/Chart.lock
+++ b/system/servicemesh-crds/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: linkerd-crds
   repository: https://helm.linkerd.io/edge
-  version: 2026.1.1
+  version: 2026.7.2
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:85e95e3220a7a5683c9bfb300dfdf580c9b86e976aafdaf9bf80d485804ddc1f
-generated: "2026-02-02T10:59:20.343663+01:00"
+digest: sha256:6b4d4cf244ae5637a835d9a779bab9d5eda46b69ff3b7c9182304114a7bebc3c
+generated: "2026-07-31T09:54:11.501984+02:00"

--- a/system/servicemesh-crds/Chart.yaml
+++ b/system/servicemesh-crds/Chart.yaml
@@ -1,13 +1,13 @@
 apiVersion: v2
 description: Linkerd service-mesh for our control-plane
 name: servicemesh-crds
-version: 2026.1.1
-appVersion: 2026.1.1
+version: 2026.7.2
+appVersion: 2026.7.2
 home: https://github.com/sapcc/helm-charts/tree/master/system/servicemesh-crds
 dependencies:
   - name: linkerd-crds
     repository: https://helm.linkerd.io/edge
-    version: 2026.1.1
+    version: 2026.7.2
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: 1.0.0

--- a/system/servicemesh/Chart.lock
+++ b/system/servicemesh/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: linkerd-control-plane
   repository: https://helm.linkerd.io/edge
-  version: 2026.1.1
+  version: 2026.7.2
 - name: linkerd-viz
   repository: https://helm.linkerd.io/edge
-  version: 2026.1.1
+  version: 2026.7.2
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
-digest: sha256:eaf1cd0f5f7a48c0491459a29c6cb33b7aa8515415682055196bc7be9275ff55
-generated: "2026-02-02T10:58:10.193036+01:00"
+digest: sha256:27713a606602c25902bf60106410d04934724a17459e0e88c2f1fefb8484c8a9
+generated: "2026-07-31T09:54:34.618505+02:00"

--- a/system/servicemesh/Chart.yaml
+++ b/system/servicemesh/Chart.yaml
@@ -1,17 +1,17 @@
 apiVersion: v2
 description: Linkerd service-mesh for our control-plane
 name: servicemesh
-version: 2026.1.3
-appVersion: 2026.1.1
+version: 2026.7.2
+appVersion: 2026.7.2
 home: https://github.com/sapcc/helm-charts/tree/master/system/servicemesh
 dependencies:
   - name: linkerd-control-plane
     repository: https://helm.linkerd.io/edge
-    version: 2026.1.1
+    version: 2026.7.2
     condition: linkerd-control-plane.enabled
   - name: linkerd-viz
     repository: https://helm.linkerd.io/edge
-    version: 2026.1.1
+    version: 2026.7.2
     condition: linkerd-viz.enabled
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm


### PR DESCRIPTION
## Summary

Bumps Linkerd Helm charts from `edge-26.1.1` to `edge-26.7.2`.

Tracked in https://github.wdf.sap.corp/cc/unified-kubernetes/issues/1374

## Version changes

| Chart | Old | New |
|---|---|---|
| servicemesh-crds | 2026.1.1 | 2026.7.2 |
| servicemesh | 2026.1.3 | 2026.7.2 |

## CVEs fixed

| CVE | Severity | Description |
|---|---|---|
| CVE-2026-33186 | Critical | gRPC-Go authorization bypass via malformed `:path` pseudo-header |

## Notable changes

- Native sidecars promoted to GA and enabled by default (`edge-26.5.2`) — disable per pod with `config.linkerd.io/proxy-enable-native-sidecar: "false"`
- Requests to undefined service ports are now rejected (`edge-26.7.1`)
- Minimum Kubernetes version is now 1.31 (`edge-26.5.1`)

## Test plan

- [ ] Deploy servicemesh-crds pipeline first, then servicemesh pipeline
- [ ] Start with qa-de-1, soak for a few days
- [ ] Verify proxy injection via nginx ingress rollout restart
- [ ] Monitor for unexpected port rejection errors (breaking change in edge-26.7.1)