### PR TITLE
[cc-gardner]: FIx templating error in VPA section

### DIFF
--- a/global/cc-gardener/Chart.yaml
+++ b/global/cc-gardener/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cc-gardener
 description: Converged Cloud Gardener setup based on gardener-operator
 type: application
-version: 0.38.10
+version: 0.38.11
 home: https://github.com/gardener/gardener
 dependencies:
 - name: owner-info

--- a/global/cc-gardener/templates/garden.yaml
+++ b/global/cc-gardener/templates/garden.yaml
@@ -94,7 +94,7 @@ spec:
     settings:
       verticalPodAutoscaler:
         enabled: true
-        {{- if dig "runtimeCluster" "verticalPodAutoscaler" "maxAllowed" nil .Values.garden }}
+        {{- with dig "runtimeCluster" "verticalPodAutoscaler" "maxAllowed" nil .Values.garden }}
         maxAllowed: {{ toYaml . | nindent 10 }}
         {{- end }}
       topologyAwareRouting:


### PR DESCRIPTION
`if` expr does not switch context , so full value path is requred
`with` expr does switch context 