### PR TITLE
metal-maintenance-operator-remote: fix env to be a list

### DIFF
--- a/system/metal-maintenance-operator-remote/Chart.yaml
+++ b/system/metal-maintenance-operator-remote/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: metal-maintenance-operator-remote
 description: A Helm chart for the Ironcore metal-maintenance-operator (remote).
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "0.1.0"
 dependencies:
   - name: owner-info

--- a/system/metal-maintenance-operator-remote/values.yaml
+++ b/system/metal-maintenance-operator-remote/values.yaml
@@ -32,9 +32,12 @@ mmo-core:
       # - "--sanitization-tolerations=DEFINE_IN_REGION_VALUES"
       # - "--readiness-checks=DEFINE_IN_REGION_VALUES"
       - "--report-base-url=https://metal-maintenance-operator.garden.<region>.cloud.sap"
+    # list format required — upstream mmo chart uses kubebuilder-generated template ([]v1.EnvVar), unlike boot-operator-remote
     env:
-      KUBERNETES_SERVICE_HOST: "apiserver-url"
-      KUBERNETES_CLUSTER_DOMAIN: "cluster.local"
+      - name: KUBERNETES_SERVICE_HOST
+        value: "apiserver-url"
+      - name: KUBERNETES_CLUSTER_DOMAIN
+        value: "cluster.local"
     extraVolumeMounts:
       - name: remote-kubeconfig
         mountPath: /var/run/secrets/kubernetes.io/serviceaccount


### PR DESCRIPTION
upstream mmo chart uses kubebuilder-generated template ([]v1.EnvVar), unlike e.g. boot-operator-remote