### PR TITLE
[ironic] add missing configmap

### DIFF
--- a/openstack/ironic/templates/conductor-console-configmap.yaml
+++ b/openstack/ironic/templates/conductor-console-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ironic-console-nginx
+  labels:
+    system: openstack
+    type: configuration
+    component: ironic
+
+data:
+  nginx.conf: |
+{{ include (print .Template.BasePath "/etc/_nginx.conf.tpl") . | indent 4 }}


### PR DESCRIPTION
In d2f9ae0a7ae4a110dbe0570802427e5d396eea7a we added everything else but
we forgot to add the configmap that is used there.
