### PR TITLE
[cluster-api] Label provider-ipam CRDs with clusterctl.cluster.x-k8s.io

### DIFF
--- a/system/Makefile
+++ b/system/Makefile
@@ -61,6 +61,8 @@ build-provider-helm:
 build-provider-ipam:
 	$(call build-chart,provider-ipam,https://github.com/kubernetes-sigs/cluster-api-ipam-provider-in-cluster//config/default,$(PROVIDER_IPAM_VERSION))
 	$(call fix-crds,provider-ipam)
+	@# Label CRDs so clusterctl move discovers them
+	@find provider-ipam/crds -type f | xargs -n1 yq -i '(select(.kind == "CustomResourceDefinition") | .metadata.labels."clusterctl.cluster.x-k8s.io") = ""'
 	@find provider-ipam/crds -type f -exec $(SED) -i -e 's#capi-capi-#capi-#g' {} \;
 	@find provider-ipam/templates -type f -exec $(SED) -i -e 's#capi-capi-#capi-#g' {} \;
 	@yq -i '.controllerManager.manager.image.tag="$(PROVIDER_IPAM_VERSION)"' provider-ipam/values.yaml
@@ -136,6 +138,7 @@ build-baremetal-operator:
 	@find baremetal-operator-core/templates -type f -exec $(SED) -i -e 's#-baremetal-operator-system/#-#g' {} \;
 	@yq -i '.controllerManager.manager.image.tag="$(BAREMETAL_OPERATOR_VERSION)"' baremetal-operator-core/values.yaml
 	@yq -i '.fullnameOverride="metal3"' baremetal-operator-core/values.yaml
+
 build-metal-operator:
 	@helm dep up metal-operator
 	@yq -i '.version = (.version | split(".") | .[2] = ((.[2] | tonumber) + 1 | tostring) | join("."))' metal-operator/Chart.yaml

--- a/system/cluster-api/Chart.lock
+++ b/system/cluster-api/Chart.lock
@@ -22,7 +22,7 @@ dependencies:
   version: 0.1.5
 - name: provider-ipam
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.1.6
+  version: 0.1.7
 - name: provider-kubernikus
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.8
@@ -32,5 +32,5 @@ dependencies:
 - name: runtime-extension-maintenance-controller
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.9
-digest: sha256:cdd722cdaa4f9f1eacf337671ac00e136448323b3d2e920166add9c71375d8f6
-generated: "2026-07-23T15:09:27.091486+02:00"
+digest: sha256:5ca2173868d27e54ca8d50f91de9bfa924b4d98f628960e82121b64c74caa059
+generated: "2026-07-31T12:11:28.994492+02:00"

--- a/system/cluster-api/Chart.yaml
+++ b/system/cluster-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-api
 description: A Helm chart for the Cluster API.
 type: application
-version: 5.0.25
+version: 5.0.26
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/system/provider-ipam/Chart.yaml
+++ b/system/provider-ipam/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.6
+version: 0.1.7
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/provider-ipam/crds/globalinclusterippool-crd.yaml
+++ b/system/provider-ipam/crds/globalinclusterippool-crd.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     cluster.x-k8s.io/provider: ipam-in-cluster
     clusterctl.cluster.x-k8s.io/move-hierarchy: ""
+    clusterctl.cluster.x-k8s.io: ""
   name: globalinclusterippools.ipam.cluster.x-k8s.io
 spec:
   conversion:

--- a/system/provider-ipam/crds/globalinclusterprefixpool-crd.yaml
+++ b/system/provider-ipam/crds/globalinclusterprefixpool-crd.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     cluster.x-k8s.io/provider: ipam-in-cluster
     clusterctl.cluster.x-k8s.io/move-hierarchy: ""
+    clusterctl.cluster.x-k8s.io: ""
   name: globalinclusterprefixpools.ipam.cluster.x-k8s.io
 spec:
   conversion:

--- a/system/provider-ipam/crds/inclusterippool-crd.yaml
+++ b/system/provider-ipam/crds/inclusterippool-crd.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     cluster.x-k8s.io/provider: ipam-in-cluster
     clusterctl.cluster.x-k8s.io/move-hierarchy: ""
+    clusterctl.cluster.x-k8s.io: ""
   name: inclusterippools.ipam.cluster.x-k8s.io
 spec:
   conversion:

--- a/system/provider-ipam/crds/inclusterprefixpool-crd.yaml
+++ b/system/provider-ipam/crds/inclusterprefixpool-crd.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     cluster.x-k8s.io/provider: ipam-in-cluster
     clusterctl.cluster.x-k8s.io/move-hierarchy: ""
+    clusterctl.cluster.x-k8s.io: ""
   name: inclusterprefixpools.ipam.cluster.x-k8s.io
 spec:
   conversion:


### PR DESCRIPTION
## What

Update the `build-provider-ipam` make target to label the provider-ipam CRDs with `clusterctl.cluster.x-k8s.io=""`, mirroring `build-provider-metal`.

## Why

The label lets `clusterctl move` discover the IPAM CRDs during cluster pivots, keeping them in the ownerRef/move hierarchy alongside the other CAPI providers.

## Changes

- `system/Makefile`: add CRD labeling step to `build-provider-ipam`
- Regenerated `provider-ipam` chart → `0.1.7` (CRDs now carry the label)
- Pushed `provider-ipam:0.1.7` to `oci://keppel.eu-de-1.cloud.sap/ccloud-helm`
- `helm dep up` + version bump on the `cluster-api` umbrella chart → `5.0.26` (Chart.lock now pins `provider-ipam:0.1.7`)