### PR TITLE
[ironic] more conductor fixes

### DIFF
--- a/openstack/ironic/templates/_conductor-deployment.yaml.tpl
+++ b/openstack/ironic/templates/_conductor-deployment.yaml.tpl
@@ -177,7 +177,7 @@ spec:
             subPath: dhparam.pem
           - mountPath: /etc/nginx/nginx.conf
             name: ironic-console-nginx
-            subpath: nginx.conf
+            subPath: nginx.conf
           - mountPath: /shellinabox
             name: shellinabox
           - mountPath: /etc/nginx/certs


### PR DESCRIPTION
- Typo with subPath breaks kos
- If using subPath one apparently needs to use items
