### PR TITLE
mmo: default to namespaced rbac for co-existence of mmo instances

### DIFF
--- a/system/metal-maintenance-operator-remote/Chart.yaml
+++ b/system/metal-maintenance-operator-remote/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: metal-maintenance-operator-remote
 description: A Helm chart for the Ironcore metal-maintenance-operator (remote).
 type: application
-version: 0.1.2
+version: 1.1.3
 appVersion: "0.1.0"
 dependencies:
   - name: owner-info

--- a/system/metal-maintenance-operator-remote/values.yaml
+++ b/system/metal-maintenance-operator-remote/values.yaml
@@ -8,7 +8,7 @@ mmo-core:
   crd:
     enable: false
   rbac:
-    namespaced: false
+    namespaced: true
     helpers:
       enable: false
   serviceAccount:

--- a/system/metal-maintenance-operator/Chart.yaml
+++ b/system/metal-maintenance-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: metal-maintenance-operator
 description: A Helm chart for the Ironcore metal-maintenance-operator.
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.1.0"
 dependencies:
   - name: owner-info

--- a/system/metal-maintenance-operator/values.yaml
+++ b/system/metal-maintenance-operator/values.yaml
@@ -7,7 +7,7 @@ mmo-core:
   crd:
     enable: true
   rbac:
-    namespaced: false
+    namespaced: true
     helpers:
       enable: false
   serviceAccount:


### PR DESCRIPTION
both metal-maintenance-operator and metal-maintenance-operator-remote now have namespaced rbacs so they can co-exist in the same cluster.