### PR TITLE
[cluster-api] Label core CAPI CRDs with clusterctl.cluster.x-k8s.io

### DIFF
--- a/system/Makefile
+++ b/system/Makefile
@@ -23,6 +23,10 @@ build-cluster-api-core:
 	@find cluster-api-core/crds -type f -exec $(SED) -i -e 's#capi-system#capi#g' {} \;
 	@find cluster-api-core/templates -type f -exec $(SED) -i -e 's#/{{ include "cluster-api-core.fullname" . }}-system/#/#g' {} \;
 	@find cluster-api-core/templates -type f -exec $(SED) -i -e 's#-system.#.#g' {} \;
+	@# Label CRDs so clusterctl move discovers them (the core Cluster/Machine/
+	@# KubeadmControlPlane graph is the root of the ownerRef chain clusterctl walks;
+	@# without this label a non-clusterctl-init install is invisible to `clusterctl move`)
+	@find cluster-api-core/crds -type f | xargs -n1 yq -i '(select(.kind == "CustomResourceDefinition") | .metadata.labels."clusterctl.cluster.x-k8s.io") = ""'
 	@yq -i '.controllerManager.manager.image.tag="$(CLUSTER_API_VERSION)"' cluster-api-core/values.yaml
 	@yq -i '.fullnameOverride="capi"' cluster-api-core/values.yaml
 
@@ -37,6 +41,9 @@ build-controlplane-kubeadm:
 	@find controlplane-kubeadm/templates -type f -exec $(SED) -i -e 's#/{{ include "controlplane-kubeadm.fullname" . }}-system/#/#g' {} \;
 	@find controlplane-kubeadm/templates -type f -exec $(SED) -i -e 's#-kubeadm-control-plane-system.#.#g' {} \;
 	@$(SED) -i 's/10240/30720/g' controlplane-kubeadm/crds/*
+	@# Label CRDs so clusterctl move discovers them (KubeadmControlPlane is in the
+	@# Cluster ownerRef chain clusterctl walks)
+	@find controlplane-kubeadm/crds -type f | xargs -n1 yq -i '(select(.kind == "CustomResourceDefinition") | .metadata.labels."clusterctl.cluster.x-k8s.io") = ""'
 	@yq -i '.controllerManager.manager.image.tag="$(CLUSTER_API_VERSION)"' controlplane-kubeadm/values.yaml
 	@yq -i '.fullnameOverride="capi-kubeadm-controlplane"' controlplane-kubeadm/values.yaml
 
@@ -48,6 +55,9 @@ build-bootstrap-kubeadm:
 	@find bootstrap-kubeadm/templates -type f -exec $(SED) -i -e 's#/{{ include "bootstrap-kubeadm.fullname" . }}-system/#/#g' {} \;
 	@find bootstrap-kubeadm/templates -type f -exec $(SED) -i -e 's#-kubeadm-bootstrap-system.#.#g' {} \;
 	@$(SED) -i 's/10240/30720/g' bootstrap-kubeadm/crds/*
+	@# Label CRDs so clusterctl move discovers them (KubeadmConfig is owned by the
+	@# Machines in the Cluster ownerRef chain clusterctl walks)
+	@find bootstrap-kubeadm/crds -type f | xargs -n1 yq -i '(select(.kind == "CustomResourceDefinition") | .metadata.labels."clusterctl.cluster.x-k8s.io") = ""'
 	@yq -i '.controllerManager.manager.image.tag="$(CLUSTER_API_VERSION)"' bootstrap-kubeadm/values.yaml
 	@yq -i '.fullnameOverride="capi-kubeadm-bootstrap"' bootstrap-kubeadm/values.yaml
 

--- a/system/bootstrap-kubeadm/Chart.yaml
+++ b/system/bootstrap-kubeadm/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.7
+version: 1.0.8
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/bootstrap-kubeadm/crds/kubeadmconfig-crd.yaml
+++ b/system/bootstrap-kubeadm/crds/kubeadmconfig-crd.yaml
@@ -8,6 +8,7 @@ metadata:
     cluster.x-k8s.io/provider: bootstrap-kubeadm
     cluster.x-k8s.io/v1beta1: v1beta1
     cluster.x-k8s.io/v1beta2: v1beta2
+    clusterctl.cluster.x-k8s.io: ""
   name: kubeadmconfigs.bootstrap.cluster.x-k8s.io
 spec:
   conversion:

--- a/system/bootstrap-kubeadm/crds/kubeadmconfigtemplate-crd.yaml
+++ b/system/bootstrap-kubeadm/crds/kubeadmconfigtemplate-crd.yaml
@@ -8,6 +8,7 @@ metadata:
     cluster.x-k8s.io/provider: bootstrap-kubeadm
     cluster.x-k8s.io/v1beta1: v1beta1
     cluster.x-k8s.io/v1beta2: v1beta2
+    clusterctl.cluster.x-k8s.io: ""
   name: kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io
 spec:
   conversion:

--- a/system/cluster-api-core/Chart.yaml
+++ b/system/cluster-api-core/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.7
+version: 1.0.8
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/cluster-api-core/crds/cluster-crd.yaml
+++ b/system/cluster-api-core/crds/cluster-crd.yaml
@@ -6,6 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.20.0
   labels:
     cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
   name: clusters.cluster.x-k8s.io
 spec:
   conversion:

--- a/system/cluster-api-core/crds/clusterclass-crd.yaml
+++ b/system/cluster-api-core/crds/clusterclass-crd.yaml
@@ -6,6 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.20.0
   labels:
     cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
   name: clusterclasses.cluster.x-k8s.io
 spec:
   conversion:

--- a/system/cluster-api-core/crds/clusterresourceset-crd.yaml
+++ b/system/cluster-api-core/crds/clusterresourceset-crd.yaml
@@ -6,6 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.20.0
   labels:
     cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
   name: clusterresourcesets.addons.cluster.x-k8s.io
 spec:
   conversion:

--- a/system/cluster-api-core/crds/clusterresourcesetbinding-crd.yaml
+++ b/system/cluster-api-core/crds/clusterresourcesetbinding-crd.yaml
@@ -6,6 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.20.0
   labels:
     cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
   name: clusterresourcesetbindings.addons.cluster.x-k8s.io
 spec:
   conversion:

--- a/system/cluster-api-core/crds/extensionconfig-crd.yaml
+++ b/system/cluster-api-core/crds/extensionconfig-crd.yaml
@@ -6,6 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.20.0
   labels:
     cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
   name: extensionconfigs.runtime.cluster.x-k8s.io
 spec:
   conversion:

--- a/system/cluster-api-core/crds/ipaddress-crd.yaml
+++ b/system/cluster-api-core/crds/ipaddress-crd.yaml
@@ -6,6 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.20.0
   labels:
     cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
   name: ipaddresses.ipam.cluster.x-k8s.io
 spec:
   conversion:

--- a/system/cluster-api-core/crds/ipaddressclaim-crd.yaml
+++ b/system/cluster-api-core/crds/ipaddressclaim-crd.yaml
@@ -6,6 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.20.0
   labels:
     cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
   name: ipaddressclaims.ipam.cluster.x-k8s.io
 spec:
   conversion:

--- a/system/cluster-api-core/crds/machine-crd.yaml
+++ b/system/cluster-api-core/crds/machine-crd.yaml
@@ -6,6 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.20.0
   labels:
     cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
   name: machines.cluster.x-k8s.io
 spec:
   conversion:

--- a/system/cluster-api-core/crds/machinedeployment-crd.yaml
+++ b/system/cluster-api-core/crds/machinedeployment-crd.yaml
@@ -6,6 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.20.0
   labels:
     cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
   name: machinedeployments.cluster.x-k8s.io
 spec:
   conversion:

--- a/system/cluster-api-core/crds/machinedrainrule-crd.yaml
+++ b/system/cluster-api-core/crds/machinedrainrule-crd.yaml
@@ -6,6 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.20.0
   labels:
     cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
   name: machinedrainrules.cluster.x-k8s.io
 spec:
   conversion:

--- a/system/cluster-api-core/crds/machinehealthcheck-crd.yaml
+++ b/system/cluster-api-core/crds/machinehealthcheck-crd.yaml
@@ -6,6 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.20.0
   labels:
     cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
   name: machinehealthchecks.cluster.x-k8s.io
 spec:
   conversion:

--- a/system/cluster-api-core/crds/machinepool-crd.yaml
+++ b/system/cluster-api-core/crds/machinepool-crd.yaml
@@ -6,6 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.20.0
   labels:
     cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
   name: machinepools.cluster.x-k8s.io
 spec:
   conversion:

--- a/system/cluster-api-core/crds/machineset-crd.yaml
+++ b/system/cluster-api-core/crds/machineset-crd.yaml
@@ -6,6 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.20.0
   labels:
     cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
   name: machinesets.cluster.x-k8s.io
 spec:
   conversion:

--- a/system/cluster-api/Chart.lock
+++ b/system/cluster-api/Chart.lock
@@ -4,13 +4,13 @@ dependencies:
   version: 1.0.0
 - name: cluster-api-core
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.0.7
+  version: 1.0.8
 - name: controlplane-kubeadm
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.0.7
+  version: 1.0.8
 - name: bootstrap-kubeadm
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.0.7
+  version: 1.0.8
 - name: provider-metal3
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.6
@@ -32,5 +32,5 @@ dependencies:
 - name: runtime-extension-maintenance-controller
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.9
-digest: sha256:5ca2173868d27e54ca8d50f91de9bfa924b4d98f628960e82121b64c74caa059
-generated: "2026-07-31T12:11:28.994492+02:00"
+digest: sha256:3790bcbc005b31b8b99413f1413d1fe8f868073f4d1ae65d30e528d020e189f5
+generated: "2026-07-31T15:56:00.688439+02:00"

--- a/system/cluster-api/Chart.yaml
+++ b/system/cluster-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-api
 description: A Helm chart for the Cluster API.
 type: application
-version: 5.0.26
+version: 5.0.27
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/system/controlplane-kubeadm/Chart.yaml
+++ b/system/controlplane-kubeadm/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.7
+version: 1.0.8
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/controlplane-kubeadm/crds/kubeadmcontrolplane-crd.yaml
+++ b/system/controlplane-kubeadm/crds/kubeadmcontrolplane-crd.yaml
@@ -8,6 +8,7 @@ metadata:
     cluster.x-k8s.io/provider: control-plane-kubeadm
     cluster.x-k8s.io/v1beta1: v1beta1
     cluster.x-k8s.io/v1beta2: v1beta2
+    clusterctl.cluster.x-k8s.io: ""
   name: kubeadmcontrolplanes.controlplane.cluster.x-k8s.io
 spec:
   conversion:

--- a/system/controlplane-kubeadm/crds/kubeadmcontrolplanetemplate-crd.yaml
+++ b/system/controlplane-kubeadm/crds/kubeadmcontrolplanetemplate-crd.yaml
@@ -8,6 +8,7 @@ metadata:
     cluster.x-k8s.io/provider: control-plane-kubeadm
     cluster.x-k8s.io/v1beta1: v1beta1
     cluster.x-k8s.io/v1beta2: v1beta2
+    clusterctl.cluster.x-k8s.io: ""
   name: kubeadmcontrolplanetemplates.controlplane.cluster.x-k8s.io
 spec:
   conversion:


### PR DESCRIPTION
## What

Adds the `clusterctl.cluster.x-k8s.io=""` label to the **core CAPI CRDs** in `cluster-api-core`, `controlplane-kubeadm`, and `bootstrap-kubeadm`, mirroring what `build-provider-ipam` and `build-provider-metal` already do for their provider CRDs.

## Why

Our CAPI management clusters are installed via these Helm charts, **not** via `clusterctl init`. `clusterctl init` normally stamps every CRD it installs with `clusterctl.cluster.x-k8s.io`, which is the label `clusterctl move` uses for object **discovery**. Because the core CAPI CRDs (`Cluster`, `Machine`, `MachineDeployment`, `KubeadmControlPlane`, `KubeadmConfig`, `ClusterResourceSet`, …) shipped **without** this label, `clusterctl move` discovers **zero core objects** and fails during "check for provisioned infrastructure":

```
Error: failed to get object graph: failed to check for provisioned infrastructure:
error reading Cluster /<name>: an empty namespace may not be set when a resource name is provided
```

Verified live: before this change the core CRDs on a management cluster carried only `cluster.x-k8s.io/provider`, and `clusterctl move --to-directory` discovered only provider objects (IroncoreMetal*, GlobalInClusterIPPool) — no `Cluster`/`Machine`/`KubeadmControlPlane`.

## Changes

- `system/Makefile`: add the CRD-labeling step to `build-cluster-api-core`, `build-controlplane-kubeadm`, `build-bootstrap-kubeadm` (same `yq` one-liner already used by `build-provider-ipam`/`build-provider-metal`), so future rebuilds keep the label.
- Apply the label to the currently vendored CRDs (17 files, one label line each).
- Bump `cluster-api-core`, `controlplane-kubeadm`, `bootstrap-kubeadm` → `1.0.8`; refresh the `cluster-api` umbrella → `5.0.27` and its `Chart.lock`.

Subcharts (1.0.8) and umbrella (5.0.27) pushed to `oci://keppel.eu-de-1.cloud.sap/ccloud-helm`.