### PR TITLE
cinder — enable rate-limit bypass_service_token by default

### DIFF
--- a/openstack/cinder/templates/etc/_api-paste.ini.tpl
+++ b/openstack/cinder/templates/etc/_api-paste.ini.tpl
@@ -131,4 +131,8 @@ backend_host = {{ .Release.Name }}-api-ratelimit-redis
 backend_port = 6379
 backend_secret_file = {{ .Values.api_rate_limit.backend_secret_file }}
 backend_timeout_seconds = {{ .Values.api_rate_limit.backend_timeout_seconds }}
+# Skip rate limiting for service-to-service requests carrying a Keystone-confirmed
+# service token. Safe here because service_token_roles_required = True is set in
+# [keystone_authtoken] (cinder.conf), so only genuine service tokens are confirmed.
+bypass_service_token = {{ if .Values.api_rate_limit.bypass_service_token -}}True{{- else -}}False{{- end }}
 {{- end }}

--- a/openstack/cinder/values.yaml
+++ b/openstack/cinder/values.yaml
@@ -479,6 +479,11 @@ api_rate_limit:
   log_sleep_time_seconds: 10
   backend_timeout_seconds: 15
   project_whitelist: []
+  # Skip rate limiting for service-to-service requests carrying a Keystone-confirmed
+  # service token (e.g. Nova calling Cinder during volume attach). Enabled by default;
+  # set to false to include service-to-service traffic in per-project rate limits.
+  # Safe because service_token_roles_required = True is set in [keystone_authtoken].
+  bypass_service_token: true
 
 # Configuration for custom resource CinderNetappConfig used by
 # kvm-cinder-netapp-operator. Should be enabled only if operator is


### PR DESCRIPTION
## Summary

Enables the `openstack-rate-limit-middleware` **`bypass_service_token`** option for `cinder-api` by default, so service-to-service requests carrying a Keystone-confirmed service token (e.g. Nova calling Cinder during a volume attach) are **not** counted against per-project rate limits. High inter-service activity would otherwise starve the user-facing API.

Depends on **sapcc/openstack-rate-limit-middleware#38**.

## Changes

- `openstack/cinder/templates/etc/_api-paste.ini.tpl` — add `bypass_service_token` to the `[filter:rate_limit]` section, rendered from values (chart's `{{ if }}True{{ else }}False{{ end }}` boolean convention).
- `openstack/cinder/values.yaml` — new `api_rate_limit.bypass_service_token` toggle, **default `true`**. Set to `false` to opt out.

## Why it's safe to enable by default

`service_token_roles_required = True` is **already set** in the `[keystone_authtoken]` section of `cinder.conf` (`_cinder.conf.tpl:78`). That means keystonemiddleware only stamps `X-Service-Identity-Status: Confirmed` for tokens that actually carry a service role — a regular user cannot bypass the limit with two user tokens. This is the security prerequisite the middleware PR documents.

## Verification

Rendered the paste template through `helm template` in both states:

| `api_rate_limit.bypass_service_token` | rendered paste.ini |
|---|---|
| `true` (default) | `bypass_service_token = True` |
| `false` (override) | `bypass_service_token = False` |

## Rollout ordering (why this is a draft)

1. Merge sapcc/openstack-rate-limit-middleware#38.
2. Cut a new `rate-limit-middleware` release.
3. Rebuild the `loci-cinder` image against it.
4. **Then** merge this PR.

Older middleware builds read config via `conf.get()` and **silently ignore** unknown paste keys (verified against released tag `1.1.0`), so merging ahead of the image rebuild is non-breaking — the flag simply has no effect until the new middleware ships.

## Backward compatibility

Only affects deployments where `api_rate_limit.enabled = true` (the rate-limit filter is off by default). Operators can set `bypass_service_token: false` to keep counting service-to-service traffic.