### PR TITLE
raise thalesBarbicanClients alert threshold from 4 to 5

### DIFF
--- a/prometheus-exporters/snmp-exporter/templates/alerts-thales.yaml
+++ b/prometheus-exporters/snmp-exporter/templates/alerts-thales.yaml
@@ -88,8 +88,8 @@ spec:
         description: "THALES Client License in {{`{{ $labels.devicename }}`}} is {{`{{ $value }}`}}"
         summary: "THALES Client License in {{`{{ $labels.devicename }}`}} is {{`{{ $value }}`}}"
   
-    - alert: thalesBarbicanClientsMoreThan4
-      expr: sum((snmp_thales_hsmClientName{snmp_thales_hsmClientName=~"barb.*"})) by (devicename) > 4
+    - alert: thalesBarbicanClientsMoreThan5
+      expr: sum((snmp_thales_hsmClientName{snmp_thales_hsmClientName=~"barb.*"})) by (devicename) > 5
       for: 5d
       labels:
         severity: info


### PR DESCRIPTION
### Problem
The `thalesBarbicanClientsMoreThan4` alert fires when more than 4 barbican-api client entries are registered on a Luna HSM. It was set to `> 4` to match the `keepLast: 2` value in the Thales-Nanny chart (2 live + 2 stale-during-rollout).

Since barbican-api runs 3 replicas in at least one region and rolling updates transiently push the live-client count to `replicas + maxSurge = 4`, the old threshold of `> 4` is unsafe. It also forced Thales-Nanny to run with `keepLast: 2`, which caused the nanny to delete a live pod's HSM client registration on every scheduled run (see sapcc/helm-charts companion context and Thales-Nanny PR raising `keepLast` to 5).

### Fix
Raise the alert threshold from `> 4` to `> 5` and rename the alert accordingly. This lets the companion Thales-Nanny change safely keep the 5 most-recent barbican clients per HSM without triggering a false-positive alert under steady state.

### Companion PR
Thales-Nanny PR raising `cleanup.keepLast` from `2` to `5`:
https://github.wdf.sap.corp/sap-cloud-infrastructure/Thales-Nanny/pull/9