### PR TITLE
[ldap-named-user] Tidy up sssd.conf

### DIFF
--- a/system/ldap-named-user/Chart.yaml
+++ b/system/ldap-named-user/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: ldap-named-user
 description: LDAP named user sssd config
 type: application
-version: 0.2.10
+version: 0.2.11

--- a/system/ldap-named-user/templates/secret.yaml
+++ b/system/ldap-named-user/templates/secret.yaml
@@ -1,6 +1,5 @@
 {{- define "ldap-named-user.sssd-conf" -}}
 [sssd]
-config_file_version = 2
 {{- with .Values.sssd.startServices }}
 services = {{ join ", " . }}
 {{- end }}
@@ -47,14 +46,12 @@ ldap_group_object_class = group
 ldap_group_objectsid = objectSid
 ldap_group_uuid = objectGUID
 ldap_group_name = cn
-ldap_groups_use_matching_rule_in_chain = true
-ldap_initgroups_use_matching_rule_in_chain = true
 
 ldap_use_tokengroups = true
 
 cache_credentials = True
 default_shell = /bin/bash
-overwrite_homedir = /home/%u
+override_homedir = /home/%u
 case_sensitive = {{ default true .Values.sssd.caseSensitive }}
 {{- end }}
 


### PR DESCRIPTION
* Fix spelling of override_homedir
* Remove deprecated options
  - config_file_version removed since 2023: https://github.com/SSSD/sssd/commit/e57093067665bb15c76cb88269fae93d44499bd5
  - ldap_{init,}groups_use_matching_rule_in_chain removed since 2018: https://github.com/SSSD/sssd/commit/65bd6bf05d75c843e525f8bf89e9b75b02a2bfb7