### PR TITLE
Update nsxt.alerts for NSXTLogicalSwitchesUsageLimitExceeded to NSXTSegmentsUsageLimitExceeded

### DIFF
--- a/prometheus-rules/prometheus-vmware-rules/Chart.yaml
+++ b/prometheus-rules/prometheus-vmware-rules/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A collection of Prometheus alert rules.
 name: prometheus-vmware-rules
-version: 1.5.7
+version: 1.5.8
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/prometheus-rules/prometheus-vmware-rules/alerts/nsxt.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts/nsxt.alerts
@@ -37,7 +37,7 @@ groups:
       description: "NSX-T cluster {{ $labels.nsxt_adapter }} firewall rules usage exceeded the supported limit. https://{{ $labels.target }}"
       summary: "NSX-T cluster {{ $labels.nsxt_adapter }} firewall sections rules exceeded the supported limit. https://{{ $labels.target }}"
 
-  - alert: NSXTLogicalSwitchesUsageLimitExceeded
+  - alert: NSXTSegmentsUsageLimitExceeded
     expr: |
         vrops_nsxt_mgmt_cluster_sys_capacity_logical_switches_usage_count /
         vrops_nsxt_mgmt_cluster_sys_capacity_logical_switches_max_supported_count > 0.9
@@ -47,13 +47,13 @@ groups:
       tier: vmware
       service: network
       support_group: compute
-      meta: "NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switches exceeded the supported limit. https://{{ $labels.target }}"
+      meta: "NSX-T cluster {{ $labels.nsxt_adapter }} count of segments exceeded the supported limit. https://{{ $labels.target }}"
       dashboard: nsx-t-monitoring/nsx-t-monitoring?orgId=1
-      playbook: https://operations.global.cloud.sap/docs/devops/alert/nsxt/#nsxt_object_limit_exceeded
+      playbook: https://operations.global.cloud.sap/docs/devops/alert/nsxt/#nsxt-object-limit-exceeded
       no_alert_on_absence: "true"
     annotations:
-      description: "NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switches exceeded the supported limit. https://{{ $labels.target }}"
-      summary: "NSX-T cluster {{ $labels.nsxt_adapter }} count of logical switches exceeded the supported limit. https://{{ $labels.target }}"
+      description: "NSX-T cluster {{ $labels.nsxt_adapter }} count of segments exceeded the supported limit. https://{{ $labels.target }}"
+      summary: "NSX-T cluster {{ $labels.nsxt_adapter }} count of segments exceeded the supported limit. https://{{ $labels.target }}"
 
   - alert: NSXTLogicalSwitchPortsUsageWarningLimitExceeded
     expr: |


### PR DESCRIPTION
Short change summary:

1.Alert name changed from NSXTLogicalSwitchesUsageLimitExceeded to NSXTSegmentsUsageLimitExceeded
2. Description/Summary updated from Logical Switches to Segments 3.PromQL expression unchanged because no segment-specific capacity metrics exist in Prometheus.  In NSX-T environments, even after migrating completely to the Policy API, segments are still represented internally as logical switches and capacity metrics continue to be exposed as 

vrops_nsxt_mgmt_cluster_sys_capacity_logical_switches_usage_count vrops_nsxt_mgmt_cluster_sys_capacity_logical_switches_max_supported_count