### PR TITLE
[cluster-api] Label provider CRDs with clusterctl.cluster.x-k8s.io

### DIFF
--- a/system/Makefile
+++ b/system/Makefile
@@ -64,6 +64,9 @@ build-bootstrap-kubeadm:
 build-provider-helm:
 	$(call build-chart,provider-helm,https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm//config/default,$(PROVIDER_HELM))
 	$(call fix-crds,provider-helm)
+	@# Label CRDs so clusterctl move discovers them (HelmChartProxy/HelmReleaseProxy
+	@# are in the Cluster ownerRef chain clusterctl walks)
+	@find provider-helm/crds -type f | xargs -n1 yq -i '(select(.kind == "CustomResourceDefinition") | .metadata.labels."clusterctl.cluster.x-k8s.io") = ""'
 	@find provider-helm/templates -type f -exec $(SED) -i -e 's#webhook-server-cert#caaph-webhook-server-cert#g' {} \;
 	@yq -i '.controllerManager.manager.image.tag="$(PROVIDER_HELM)"' provider-helm/values.yaml
 	@yq -i '.fullnameOverride="caaph"' provider-helm/values.yaml
@@ -108,6 +111,9 @@ build-provider-metal3:
 	@find provider-metal3/templates -type f -exec $(SED) -i -e 's#/{{ include "provider-metal3.fullname" . }}-system/#/#g' {} \;
 	@# fix for "no matches for kind "IPClaim"
 	@curl -sSL https://raw.githubusercontent.com/metal3-io/ip-address-manager/$(PROVIDER_METAL3_VERSION)/config/crd/bases/ipam.metal3.io_ipclaims.yaml -o provider-metal3/crds/ipam.metal3.io_ipclaims.yaml
+	@# Label CRDs so clusterctl move discovers them (Metal3Cluster/Metal3Machine are
+	@# in the Cluster ownerRef chain clusterctl walks)
+	@find provider-metal3/crds -type f | xargs -n1 yq -i '(select(.kind == "CustomResourceDefinition") | .metadata.labels."clusterctl.cluster.x-k8s.io") = ""'
 	@yq -i '.controllerManager.manager.image.tag="$(PROVIDER_METAL3_VERSION)"' provider-metal3/values.yaml
 	@yq -i '.fullnameOverride="capm3"' provider-metal3/values.yaml
 
@@ -131,6 +137,9 @@ build-provider-kubernikus:
 		   provider-kubernikus/templates/manager-clusterrole.yaml; \
 	fi
 	@find provider-kubernikus/templates -type f -exec $(SED) -i -e 's#-cluster-api-control-plane-provider-kubernikus#-manager-role#g' {} \;
+	@# Label CRDs so clusterctl move discovers them (KubernikusControlPlane is in the
+	@# Cluster ownerRef chain clusterctl walks)
+	@find provider-kubernikus/crds -type f | xargs -n1 yq -i '(select(.kind == "CustomResourceDefinition") | .metadata.labels."clusterctl.cluster.x-k8s.io") = ""'
 	@yq -i '.controllerManager.manager.image.tag="$(PROVIDER_KUBERNIKUS_VERSION)"' provider-kubernikus/values.yaml
 	@yq -i '.fullnameOverride="capi-cp-provider-kubernikus"' provider-kubernikus/values.yaml
 

--- a/system/cluster-api/Chart.lock
+++ b/system/cluster-api/Chart.lock
@@ -13,24 +13,24 @@ dependencies:
   version: 1.0.8
 - name: provider-metal3
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.0.6
+  version: 1.0.7
 - name: provider-metal
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.2.7
 - name: provider-helm
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.1.5
+  version: 0.1.6
 - name: provider-ipam
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.7
 - name: provider-kubernikus
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.2.8
+  version: 0.2.9
 - name: cc-cluster
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.2.2
 - name: runtime-extension-maintenance-controller
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.9
-digest: sha256:3790bcbc005b31b8b99413f1413d1fe8f868073f4d1ae65d30e528d020e189f5
-generated: "2026-07-31T15:56:00.688439+02:00"
+digest: sha256:e642299529b3991bba81494cbebfaaba3656900a13b787ad20815966f19f6d3d
+generated: "2026-08-03T16:03:43.354105+02:00"

--- a/system/cluster-api/Chart.yaml
+++ b/system/cluster-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-api
 description: A Helm chart for the Cluster API.
 type: application
-version: 5.0.27
+version: 5.0.28
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/system/provider-helm/Chart.yaml
+++ b/system/provider-helm/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/provider-helm/crds/helmchartproxy-crd.yaml
+++ b/system/provider-helm/crds/helmchartproxy-crd.yaml
@@ -8,6 +8,7 @@ metadata:
     cluster.x-k8s.io/provider: helm
     clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
     visualizer.cluster.x-k8s.io: ""
+    clusterctl.cluster.x-k8s.io: ""
   name: helmchartproxies.addons.cluster.x-k8s.io
 spec:
   conversion:

--- a/system/provider-helm/crds/helmreleaseproxy-crd.yaml
+++ b/system/provider-helm/crds/helmreleaseproxy-crd.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     cluster.x-k8s.io/provider: helm
     visualizer.cluster.x-k8s.io: ""
+    clusterctl.cluster.x-k8s.io: ""
   name: helmreleaseproxies.addons.cluster.x-k8s.io
 spec:
   conversion:

--- a/system/provider-kubernikus/Chart.yaml
+++ b/system/provider-kubernikus/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.8
+version: 0.2.9
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/provider-kubernikus/crds/kubernikuscontrolplane-crd.yaml
+++ b/system/provider-kubernikus/crds/kubernikuscontrolplane-crd.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     cluster.x-k8s.io/provider: kubernikus
     cluster.x-k8s.io/v1beta1: v1alpha1
+    clusterctl.cluster.x-k8s.io: ""
   name: kubernikuscontrolplanes.controlplane.cluster.x-k8s.io
 spec:
   group: controlplane.cluster.x-k8s.io
@@ -16,156 +17,152 @@ spec:
     singular: kubernikuscontrolplane
   scope: Namespaced
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: KubernikusControlPlane is the Schema for the kubernikuscontrolplanes
-          API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: KubernikusControlPlaneSpec defines the desired state of KubernikusControlPlane
-            properties:
-              advertiseAddress:
-                type: string
-              advertisePort:
-                format: int64
-                type: integer
-              audit:
-                type: string
-              authenticationConfiguration:
-                type: string
-              backup:
-                type: string
-              clusterCidr:
-                type: string
-              customCNI:
-                type: boolean
-              dnsAddress:
-                type: string
-              dnsDomain:
-                type: string
-              oidc:
-                properties:
-                  clientID:
-                    description: client ID
-                    type: string
-                  issuerURL:
-                    description: issuer URL
-                    type: string
-                type: object
-              seedKubeadm:
-                type: boolean
-              serviceCidr:
-                type: string
-              sshPublicKey:
-                type: string
-              version:
-                type: string
-            required:
-            - version
-            type: object
-          status:
-            description: KubernikusControlPlaneStatus defines the observed state of
-              KubernikusControlPlane
-            properties:
-              conditions:
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: KubernikusControlPlane is the Schema for the kubernikuscontrolplanes API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: KubernikusControlPlaneSpec defines the desired state of KubernikusControlPlane
+              properties:
+                advertiseAddress:
+                  type: string
+                advertisePort:
+                  format: int64
+                  type: integer
+                audit:
+                  type: string
+                authenticationConfiguration:
+                  type: string
+                backup:
+                  type: string
+                clusterCidr:
+                  type: string
+                customCNI:
+                  type: boolean
+                dnsAddress:
+                  type: string
+                dnsDomain:
+                  type: string
+                oidc:
                   properties:
-                    lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
+                    clientID:
+                      description: client ID
                       type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
+                    issuerURL:
+                      description: issuer URL
                       type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
                   type: object
-                type: array
-              externalManagedControlPlane:
-                default: true
-                description: |-
-                  ExternalManagedControlPlane indicates to Cluster API that the Control Plane
-                  is externally managed by Kubernikus.
-                type: boolean
-              failureMessage:
-                type: string
-              failureReason:
-                type: string
-              initialized:
-                type: boolean
-              ready:
-                type: boolean
-              version:
-                type: string
-            required:
-            - externalManagedControlPlane
-            - initialized
-            - ready
-            - version
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
-
+                seedKubeadm:
+                  type: boolean
+                serviceCidr:
+                  type: string
+                sshPublicKey:
+                  type: string
+                version:
+                  type: string
+              required:
+                - version
+              type: object
+            status:
+              description: KubernikusControlPlaneStatus defines the observed state of KubernikusControlPlane
+              properties:
+                conditions:
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                externalManagedControlPlane:
+                  default: true
+                  description: |-
+                    ExternalManagedControlPlane indicates to Cluster API that the Control Plane
+                    is externally managed by Kubernikus.
+                  type: boolean
+                failureMessage:
+                  type: string
+                failureReason:
+                  type: string
+                initialized:
+                  type: boolean
+                ready:
+                  type: boolean
+                version:
+                  type: string
+              required:
+                - externalManagedControlPlane
+                - initialized
+                - ready
+                - version
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/system/provider-metal3/Chart.yaml
+++ b/system/provider-metal3/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.6
+version: 1.0.7
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/provider-metal3/crds/ipam.metal3.io_ipclaims.yaml
+++ b/system/provider-metal3/crds/ipam.metal3.io_ipclaims.yaml
@@ -5,155 +5,156 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: ipclaims.ipam.metal3.io
+  labels:
+    clusterctl.cluster.x-k8s.io: ""
 spec:
   group: ipam.metal3.io
   names:
     categories:
-    - cluster-api
+      - cluster-api
     kind: IPClaim
     listKind: IPClaimList
     plural: ipclaims
     shortNames:
-    - ipc
-    - ipclaim
-    - m3ipc
-    - m3ipclaim
-    - m3ipclaims
-    - metal3ipc
-    - metal3ipclaim
-    - metal3ipclaims
+      - ipc
+      - ipclaim
+      - m3ipc
+      - m3ipclaim
+      - m3ipclaims
+      - metal3ipc
+      - metal3ipclaim
+      - metal3ipclaims
     singular: ipclaim
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Time duration since creation of Metal3IPClaim
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: IPClaim is the Schema for the ipclaims API.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: IPClaimSpec defines the desired state of IPClaim.
-            properties:
-              pool:
-                description: Pool is the IPPool this was generated from.
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  fieldPath:
-                    description: |-
-                      If referring to a piece of an object instead of an entire object, this string
-                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within a pod, this would take on a value like:
-                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]" (container with
-                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
-                      referencing a part of an object.
-                    type: string
-                  kind:
-                    description: |-
-                      Kind of the referent.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                    type: string
-                  name:
-                    description: |-
-                      Name of the referent.
-                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                    type: string
-                  namespace:
-                    description: |-
-                      Namespace of the referent.
-                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
-                    type: string
-                  resourceVersion:
-                    description: |-
-                      Specific resourceVersion to which this reference is made, if any.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
-                    type: string
-                  uid:
-                    description: |-
-                      UID of the referent.
-                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
-                    type: string
-                type: object
-                x-kubernetes-map-type: atomic
-            required:
-            - pool
-            type: object
-          status:
-            description: IPClaimStatus defines the observed state of IPClaim.
-            properties:
-              address:
-                description: Address is the IPAddress that was generated for this
-                  claim.
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  fieldPath:
-                    description: |-
-                      If referring to a piece of an object instead of an entire object, this string
-                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within a pod, this would take on a value like:
-                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]" (container with
-                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
-                      referencing a part of an object.
-                    type: string
-                  kind:
-                    description: |-
-                      Kind of the referent.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                    type: string
-                  name:
-                    description: |-
-                      Name of the referent.
-                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                    type: string
-                  namespace:
-                    description: |-
-                      Namespace of the referent.
-                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
-                    type: string
-                  resourceVersion:
-                    description: |-
-                      Specific resourceVersion to which this reference is made, if any.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
-                    type: string
-                  uid:
-                    description: |-
-                      UID of the referent.
-                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
-                    type: string
-                type: object
-                x-kubernetes-map-type: atomic
-              errorMessage:
-                description: ErrorMessage contains the error message
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - additionalPrinterColumns:
+        - description: Time duration since creation of Metal3IPClaim
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: IPClaim is the Schema for the ipclaims API.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: IPClaimSpec defines the desired state of IPClaim.
+              properties:
+                pool:
+                  description: Pool is the IPPool this was generated from.
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: |-
+                        If referring to a piece of an object instead of an entire object, this string
+                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]" (container with
+                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                        referencing a part of an object.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                      type: string
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                      type: string
+                    resourceVersion:
+                      description: |-
+                        Specific resourceVersion to which this reference is made, if any.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                      type: string
+                    uid:
+                      description: |-
+                        UID of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+              required:
+                - pool
+              type: object
+            status:
+              description: IPClaimStatus defines the observed state of IPClaim.
+              properties:
+                address:
+                  description: Address is the IPAddress that was generated for this claim.
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: |-
+                        If referring to a piece of an object instead of an entire object, this string
+                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]" (container with
+                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                        referencing a part of an object.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                      type: string
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                      type: string
+                    resourceVersion:
+                      description: |-
+                        Specific resourceVersion to which this reference is made, if any.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                      type: string
+                    uid:
+                      description: |-
+                        UID of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                errorMessage:
+                  description: ErrorMessage contains the error message
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/system/provider-metal3/crds/metal3cluster-crd.yaml
+++ b/system/provider-metal3/crds/metal3cluster-crd.yaml
@@ -8,6 +8,7 @@ metadata:
     cluster.x-k8s.io/provider: infrastructure-metal3
     cluster.x-k8s.io/v1beta1: v1beta1
     cluster.x-k8s.io/v1beta2: v1beta2
+    clusterctl.cluster.x-k8s.io: ""
   name: metal3clusters.infrastructure.cluster.x-k8s.io
 spec:
   conversion:

--- a/system/provider-metal3/crds/metal3clustertemplate-crd.yaml
+++ b/system/provider-metal3/crds/metal3clustertemplate-crd.yaml
@@ -8,6 +8,7 @@ metadata:
     cluster.x-k8s.io/provider: infrastructure-metal3
     cluster.x-k8s.io/v1beta1: v1beta1
     cluster.x-k8s.io/v1beta2: v1beta2
+    clusterctl.cluster.x-k8s.io: ""
   name: metal3clustertemplates.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/system/provider-metal3/crds/metal3data-crd.yaml
+++ b/system/provider-metal3/crds/metal3data-crd.yaml
@@ -9,6 +9,7 @@ metadata:
     cluster.x-k8s.io/provider: infrastructure-metal3
     cluster.x-k8s.io/v1beta1: v1beta1
     cluster.x-k8s.io/v1beta2: v1beta2
+    clusterctl.cluster.x-k8s.io: ""
   name: metal3datas.infrastructure.cluster.x-k8s.io
 spec:
   conversion:

--- a/system/provider-metal3/crds/metal3dataclaim-crd.yaml
+++ b/system/provider-metal3/crds/metal3dataclaim-crd.yaml
@@ -8,6 +8,7 @@ metadata:
     cluster.x-k8s.io/provider: infrastructure-metal3
     cluster.x-k8s.io/v1beta1: v1beta1
     cluster.x-k8s.io/v1beta2: v1beta2
+    clusterctl.cluster.x-k8s.io: ""
   name: metal3dataclaims.infrastructure.cluster.x-k8s.io
 spec:
   conversion:

--- a/system/provider-metal3/crds/metal3datatemplate-crd.yaml
+++ b/system/provider-metal3/crds/metal3datatemplate-crd.yaml
@@ -8,6 +8,7 @@ metadata:
     cluster.x-k8s.io/provider: infrastructure-metal3
     cluster.x-k8s.io/v1beta1: v1beta1
     cluster.x-k8s.io/v1beta2: v1beta2
+    clusterctl.cluster.x-k8s.io: ""
   name: metal3datatemplates.infrastructure.cluster.x-k8s.io
 spec:
   conversion:

--- a/system/provider-metal3/crds/metal3machine-crd.yaml
+++ b/system/provider-metal3/crds/metal3machine-crd.yaml
@@ -8,6 +8,7 @@ metadata:
     cluster.x-k8s.io/provider: infrastructure-metal3
     cluster.x-k8s.io/v1beta1: v1beta1
     cluster.x-k8s.io/v1beta2: v1beta2
+    clusterctl.cluster.x-k8s.io: ""
   name: metal3machines.infrastructure.cluster.x-k8s.io
 spec:
   conversion:

--- a/system/provider-metal3/crds/metal3machinetemplate-crd.yaml
+++ b/system/provider-metal3/crds/metal3machinetemplate-crd.yaml
@@ -8,6 +8,7 @@ metadata:
     cluster.x-k8s.io/provider: infrastructure-metal3
     cluster.x-k8s.io/v1beta1: v1beta1
     cluster.x-k8s.io/v1beta2: v1beta2
+    clusterctl.cluster.x-k8s.io: ""
   name: metal3machinetemplates.infrastructure.cluster.x-k8s.io
 spec:
   conversion:

--- a/system/provider-metal3/crds/metal3remediation-crd.yaml
+++ b/system/provider-metal3/crds/metal3remediation-crd.yaml
@@ -8,6 +8,7 @@ metadata:
     cluster.x-k8s.io/provider: infrastructure-metal3
     cluster.x-k8s.io/v1beta1: v1beta1
     cluster.x-k8s.io/v1beta2: v1beta2
+    clusterctl.cluster.x-k8s.io: ""
   name: metal3remediations.infrastructure.cluster.x-k8s.io
 spec:
   conversion:

--- a/system/provider-metal3/crds/metal3remediationtemplate-crd.yaml
+++ b/system/provider-metal3/crds/metal3remediationtemplate-crd.yaml
@@ -8,6 +8,7 @@ metadata:
     cluster.x-k8s.io/provider: infrastructure-metal3
     cluster.x-k8s.io/v1beta1: v1beta1
     cluster.x-k8s.io/v1beta2: v1beta2
+    clusterctl.cluster.x-k8s.io: ""
   name: metal3remediationtemplates.infrastructure.cluster.x-k8s.io
 spec:
   conversion:


### PR DESCRIPTION
## What

Extends #12474 to the **remaining** CAPI provider CRDs that `clusterctl move` preflight flagged as unlabeled:

- **provider-helm** — `helmchartproxies`, `helmreleaseproxies` (addons)
- **provider-kubernikus** — `kubernikuscontrolplanes` (controlplane)
- **provider-metal3** — `metal3clusters`, `metal3machines`, `metal3data*`, `metal3remediation*`, … (infrastructure)

## Why

Our CAPI management clusters are installed via these Helm charts, **not** via `clusterctl init`. Without the `clusterctl.cluster.x-k8s.io=""` label these CRDs are invisible to `clusterctl move` object **discovery**, so objects in the Cluster ownerRef chain (HelmChartProxy / KubernikusControlPlane / Metal3* → Machine → Cluster) are not moved.

Verified live via `clusterctl move` preflight dry-run, which reported exactly these CRDs as "would label CRD for clusterctl discovery". The `server*.metal.ironcore.dev` CRDs were already covered by `build-metal-operator-remote`; the `vsphere*` CRDs are not part of this repo.

## Changes

- `system/Makefile`: add the `yq` labeling step to `build-provider-helm`, `build-provider-metal3`, `build-provider-kubernikus` (same one-liner already used by `build-provider-ipam` / `build-provider-metal`), so future rebuilds keep the label.
- Apply the label to the currently vendored CRDs (13 files). Two files (`kubernikuscontrolplane-crd.yaml`, `ipam.metal3.io_ipclaims.yaml`) show larger diffs because `yq` normalized their block-scalar formatting — verified semantically identical apart from the label, and matches what the Makefile build now produces.
- Bump `provider-helm` → `0.1.6`, `provider-kubernikus` → `0.2.9`, `provider-metal3` → `1.0.7`; refresh the `cluster-api` umbrella → `5.0.28` and its `Chart.lock`.

Subcharts (0.1.6 / 0.2.9 / 1.0.7) and umbrella (5.0.28) pushed to `oci://keppel.eu-de-1.cloud.sap/ccloud-helm`.