### PR TITLE
keystone: bump api requests/limits and set priority class

### DIFF
--- a/openstack/keystone/Chart.yaml
+++ b/openstack/keystone/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: keystone
 sources:
   - https://github.com/sapcc/keystone
-version: 0.13.1
+version: 0.13.2
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/keystone/templates/deployment-api.yaml
+++ b/openstack/keystone/templates/deployment-api.yaml
@@ -60,6 +60,9 @@ spec:
         {{- end }}
         {{- include "utils.linkerd.pod_and_service_annotation" . | indent 8 }}
     spec:
+      {{- if .Values.api.priorityClassName }}
+      priorityClassName: {{ .Values.api.priorityClassName }}
+      {{- end }}
 {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ .Release.Name }}
 {{- end }}

--- a/openstack/keystone/values.yaml
+++ b/openstack/keystone/values.yaml
@@ -201,12 +201,14 @@ api:
   terminationGracePeriodSeconds: 30
   minReadySeconds: 5
 
+  priorityClassName: critical-payload
+
   resources:
     requests:
-      memory: 2Gi
-      cpu: 1500m
+      memory: 4Gi
+      cpu: 3000m
     limits:
-      memory: 3Gi
+      memory: 6Gi
 
   replicas: 3
 


### PR DESCRIPTION
Bump keystone-api requests 2x (memory 2Gi->4Gi, cpu 1500m->3000m) and raise the memory limit to 6Gi to keep burst headroom, so the API is less likely to be OOM-killed/evicted under load. Assign the critical-payload priority class to protect the API from preemption and improve the node-pressure eviction tiebreak.