### PR TITLE
[barbican] Fix secretstore policy: restore admin bypass, add viewer read access

### DIFF
--- a/openstack/barbican/templates/etc/_barbican-policy.yaml.tpl
+++ b/openstack/barbican/templates/etc/_barbican-policy.yaml.tpl
@@ -8,6 +8,7 @@
 "context_is_key_admin": "rule:context_is_admin or rule:key_admin"
 "context_is_editor": "rule:context_is_key_admin"
 "context_is_viewer": "rule:context_is_editor or rule:viewer"
+"context_is_key_admin_and_project_member": "rule:context_is_key_admin and project_id:%(project_id)s"
 
 "secret_non_private_read": "rule:context_is_viewer and rule:secret_project_match and not rule:secret_private_read"
 "secret_decrypt_non_private_read": "rule:context_is_viewer and rule:secret_project_match and not rule:secret_private_read"
@@ -91,10 +92,10 @@
 "secret_meta:put": "rule:context_is_editor"
 "secret_meta:delete": "rule:context_is_editor"
 
-"secretstores:get": "rule:context_is_key_admin"
-"secretstores:get_global_default": "rule:context_is_key_admin"
-"secretstores:get_preferred": "rule:context_is_key_admin"
+"secretstores:get": "rule:context_is_key_admin_and_project_member"
+"secretstores:get_global_default": "rule:context_is_key_admin_and_project_member"
+"secretstores:get_preferred": "rule:context_is_key_admin_and_project_member"
 
-"secretstore_preferred:post": "rule:context_is_key_admin"
-"secretstore_preferred:delete": "rule:context_is_key_admin"
-"secretstore:get": "rule:context_is_key_admin"
+"secretstore_preferred:post": "rule:context_is_key_admin_and_project_member"
+"secretstore_preferred:delete": "rule:context_is_key_admin_and_project_member"
+"secretstore:get": "rule:context_is_key_admin_and_project_member"

--- a/openstack/barbican/templates/etc/_barbican-policy.yaml.tpl
+++ b/openstack/barbican/templates/etc/_barbican-policy.yaml.tpl
@@ -8,7 +8,8 @@
 "context_is_key_admin": "rule:context_is_admin or rule:key_admin"
 "context_is_editor": "rule:context_is_key_admin"
 "context_is_viewer": "rule:context_is_editor or rule:viewer"
-"context_is_key_admin_and_project_member": "rule:context_is_key_admin and project_id:%(project_id)s"
+"context_is_key_admin_and_project_member": "rule:context_is_admin or (rule:key_admin and project_id:%(project_id)s)"
+"context_is_viewer_and_project_member": "rule:context_is_key_admin_and_project_member or (rule:viewer and project_id:%(project_id)s)"
 
 "secret_non_private_read": "rule:context_is_viewer and rule:secret_project_match and not rule:secret_private_read"
 "secret_decrypt_non_private_read": "rule:context_is_viewer and rule:secret_project_match and not rule:secret_private_read"
@@ -92,10 +93,10 @@
 "secret_meta:put": "rule:context_is_editor"
 "secret_meta:delete": "rule:context_is_editor"
 
-"secretstores:get": "rule:context_is_key_admin_and_project_member"
-"secretstores:get_global_default": "rule:context_is_key_admin_and_project_member"
-"secretstores:get_preferred": "rule:context_is_key_admin_and_project_member"
+"secretstores:get": "rule:context_is_viewer_and_project_member"
+"secretstores:get_global_default": "rule:context_is_viewer_and_project_member"
+"secretstores:get_preferred": "rule:context_is_viewer_and_project_member"
 
 "secretstore_preferred:post": "rule:context_is_key_admin_and_project_member"
 "secretstore_preferred:delete": "rule:context_is_key_admin_and_project_member"
-"secretstore:get": "rule:context_is_key_admin_and_project_member"
+"secretstore:get": "rule:context_is_viewer_and_project_member"


### PR DESCRIPTION
## Problem

Commit 332b357 introduced `context_is_key_admin_and_project_member` to restrict secret store operations to key admins within their own project. This had two bugs:

**1. `cloud_keymanager_admin` (context_is_admin) was broken**

The original rule expanded to:
```
(rule:context_is_admin or rule:key_admin) and project_id:%(project_id)s
```
`cloud_keymanager_admin` maps to `context_is_admin`, but `project_id:%(project_id)s` always fails for cross-project admin calls — the admin token project never matches the target project. Result: cloud admins could not access secretstore APIs at all.

**2. `keymanager_viewer` had no access to secretstore read operations**

`secretstores:get`, `secretstores:get_global_default`, `secretstores:get_preferred`, and `secretstore:get` all required `key_admin` role. Users with `keymanager_viewer` could not list or read secret stores.

## Fix

Split into two rules:

```yaml
"context_is_key_admin_and_project_member": "rule:context_is_admin or (rule:key_admin and project_id:%(project_id)s)"
"context_is_viewer_and_project_member": "rule:context_is_key_admin_and_project_member or (rule:viewer and project_id:%(project_id)s)"
```

- `context_is_admin` (cloud_keymanager_admin) bypasses the project check entirely
- `keymanager_viewer` gets read access to secretstore operations scoped to their own project
- `keymanager_admin` still required for write operations (set/delete preferred store)