### PR TITLE
[barbican] Fix secretstore policy: drop unresolvable project_id target check

### DIFF
--- a/openstack/barbican/templates/etc/_barbican-policy.yaml.tpl
+++ b/openstack/barbican/templates/etc/_barbican-policy.yaml.tpl
@@ -8,8 +8,8 @@
 "context_is_key_admin": "rule:context_is_admin or rule:key_admin"
 "context_is_editor": "rule:context_is_key_admin"
 "context_is_viewer": "rule:context_is_editor or rule:viewer"
-"context_is_key_admin_and_project_member": "rule:context_is_admin or (rule:key_admin and project_id:%(project_id)s)"
-"context_is_viewer_and_project_member": "rule:context_is_key_admin_and_project_member or (rule:viewer and project_id:%(project_id)s)"
+"context_is_key_admin_and_project_member": "rule:context_is_admin or rule:key_admin"
+"context_is_viewer_and_project_member": "rule:context_is_key_admin_and_project_member or rule:viewer"
 
 "secret_non_private_read": "rule:context_is_viewer and rule:secret_project_match and not rule:secret_private_read"
 "secret_decrypt_non_private_read": "rule:context_is_viewer and rule:secret_project_match and not rule:secret_private_read"


### PR DESCRIPTION
## Problem

Follow-up to #12499. The added rules referenced `project_id:%(project_id)s`, which is substituted from the oslo.policy **target** dict. For `SecretStoresController`, `SecretStoreController`, and `PreferredSecretStoreController` in barbican, `ACLMixin.get_acl_tuple()` returns `(None, None)` (they set only `self.secret_store`, never `self.secret`/`self.container`), so the target dict is effectively empty. `oslo.policy.GenericCheck` then KeyErrors on the substitution and returns `False`, making both

```
(rule:key_admin and project_id:%(project_id)s)
(rule:viewer   and project_id:%(project_id)s)
```

always `False`. Only `rule:context_is_admin` (i.e., `cloud_keymanager_admin`) survives, so `keymanager_admin` and `keymanager_viewer` lose access to all secretstore endpoints — the opposite of #12499's stated intent.

## Fix

Drop the `project_id:%(project_id)s` clause from the two rules introduced in #12499. The three secretstore controllers already scope every read/writeDrop the `project_id:%(projeal_project_id`Drop the `project_id:%(project_id)s` clause from the two rules introduced in #12499. The three secretstore controllers already scope every read/writeDrop the `project_id:%(projeal_project_id`Drop the `project_id:%(project_id)s` clause from the two rules introduced in #12499. The three secretstore controllers already scope every read/writeDrop the `project_id:%(projeal_project_id`Drop the `project_id:%(project_id)s` clause from the two rules introduced in #12499. The three secretstore controllersdmin"
++++++++++++++++++++++++++++++++++++++++++++++ul++++++++++++++++++++++++++++++++++++++++++or rule:viewer"
```

## Validation

Applied this diff in-place to `configmap monsoon3/barbican-etc` on qa-de-2 and restarted `deploy/barbican-api`. All six affected endpoints, tested as `keymanager_admin` on project `Barbican Multi-tenancy Utimaco`:

| Endpoint | Pre-fix (#12499 as-merged) | Post-fix |
|---|---|---|
| `GET /v1/secret-stores` | 403 | 200 |
| `GET /v1/secret-stores/global-default` | 403 | 200 |
| `GET /v1/secret-stores/preferred` (unset) | 403 | 404 (past-policy: "No preferred secret store defined for this project.") |
| `GET /v1/secret-stores/{id}` | 403 | 200 |
| `POST /v1/secret-stores/{id}/preferred` | 403 | 204 |
| `GET /v1/secret-stores/preferred` (after set) | — | 200 |
| `DELETE /v1/secret-stores/{id}/preferred` | 403 | 204 |

Intent preserved:
- `keymanager_admin` — read all secretstore endpoints, set/delete preferred ✅
- `keymanager_viewer` — read yes, set/delete no (write rules still resolve to `context_is_key_admin_and_project_member`, which does not include `rule:viewer`) ✅
- `cloud_keym- age- `cmin` — bypass via `rule:context_is_admin` (unchanged branch) ✅
