### PR TITLE
[neutron]: mysql-exporter fails to export openstack_neutron_routers_u…

### DIFF
--- a/openstack/neutron/values.yaml
+++ b/openstack/neutron/values.yaml
@@ -755,7 +755,7 @@ mysql_metrics:
       query: |
         SELECT
             r.project_id AS project_id,
-            CASE WHEN a.availability_zone = 'nova' THEN null ELSE a.availability_zone END AS availability_zone,
+            CASE WHEN a.availability_zone = 'nova' THEN 'null' ELSE a.availability_zone END AS availability_zone,
             count(r.id) AS count
         FROM routers r
         INNER JOIN routerl3agentbindings rabs ON r.id = rabs.router_id


### PR DESCRIPTION
…sed_per_project

Reason: column 'availability_zone' must be type text (string)