### PR TITLE
fix(digicert-issuer): guard PodMonitor template with CRD capability check

### DIFF
--- a/system/digicert-issuer/Chart.yaml
+++ b/system/digicert-issuer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: digicert-issuer
 description: A Helm chart for the Digicert Issuer.
 type: application
-version: 2.8.1
+version: 2.8.2
 appVersion: v2.8.0
 home: https://github.com/sapcc/digicert-issuer
 sources:

--- a/system/digicert-issuer/templates/podmonitor.yaml
+++ b/system/digicert-issuer/templates/podmonitor.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PodMonitor" }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -32,3 +33,4 @@ spec:
         - sourceLabels:
             - __meta_kubernetes_pod_name
           targetLabel: kubernetes_pod_name
+{{- end }}


### PR DESCRIPTION
## Problem

Helm install fails for digicert-issuer when the `monitoring.coreos.com/v1` CRDs (prometheus-operator) are not yet installed on the cluster:

```
unable to build kubernetes objects from release manifest: resource mapping not found for name: "digicert-issuer" namespace: "digicert" from "": no matches for kind "PodMonitor" in version "monitoring.coreos.com/v1"
ensure CRDs are installed first
```

## Solution

Wrap the PodMonitor template with a `.Capabilities.APIVersions.Has` check, consistent with the existing approach used in `prometheus-alerts.yaml`. The PodMonitor resource is only rendered when the CRD is available on the target cluster.