### PR TITLE
metal-settings: add inject-secrets annotation to HPE iLO license secret

### DIFF
--- a/system/metal-settings/Chart.yaml
+++ b/system/metal-settings/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.41
+version: 0.2.42
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/metal-settings/templates/bmc-settings-secret.yaml
+++ b/system/metal-settings/templates/bmc-settings-secret.yaml
@@ -6,6 +6,8 @@ kind: Secret
 metadata:
   name: {{ .Values.clusterConfig.hpeLicenseSecretName }}
   namespace: {{ .Values.clusterConfig.managedNamespace }}
+  annotations:
+    cloud.sap/inject-secrets: "true"
 type: Opaque
 stringData:
   # HPE iLO license key — referenced by hpe-default.yaml via secretKeyRef at reconcile time.


### PR DESCRIPTION
The secret was missing the cloud.sap/inject-secrets annotation, causing the secrets-injector webhook to skip it and leaving the vault+kvv2 reference unresolved. iLO rejected the literal reference string as an invalid license key.

This is only used when both `Values.bmcSettings.enabled` and `Values.clusterConfig.hpeLicenseSecretName` are set and does not affect most clusters.