### PR TITLE
[octobus-query-exporter] raise NFSlockedError alert severity to critical

### DIFF
--- a/prometheus-exporters/octobus-query-exporter/Chart.lock
+++ b/prometheus-exporters/octobus-query-exporter/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: octobus-query-exporter
   repository: file://vendor/octobus-query-exporter
-  version: 1.0.32
+  version: 1.0.33
 - name: octobus-query-exporter-global
   repository: file://vendor/octobus-query-exporter-global
   version: 1.0.14

--- a/prometheus-exporters/octobus-query-exporter/Chart.yaml
+++ b/prometheus-exporters/octobus-query-exporter/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 1.0.34
+version: 1.0.35
 name: octobus-query-exporter
 description: Elasticsearch prometheus query exporter
 maintainers:
@@ -11,7 +11,7 @@ dependencies:
   - name: octobus-query-exporter
     alias: octobus_query_exporter
     repository: file://vendor/octobus-query-exporter
-    version: 1.0.32
+    version: 1.0.33
     condition: octobus_query_exporter.enabled
 
   - name: octobus-query-exporter-global

--- a/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/Chart.yaml
+++ b/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 1.0.32
+version: 1.0.33
 name: octobus-query-exporter
 description: Elasticsearch prometheus query exporter
 maintainers:

--- a/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/alerts/scaleout/events.alerts.tpl
+++ b/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/alerts/scaleout/events.alerts.tpl
@@ -75,7 +75,7 @@ groups:
                 and on(hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"}
                 and on(hostsystem) elasticsearch_octobus_nfslocked_issue_hostsystem_doc_count
         labels:
-          severity: warning
+          severity: critical
           service: compute
           tier: vmware
           support_group: compute


### PR DESCRIPTION
## Summary

- Raise `NFSlockedError` alert severity from `warning` to `critical`
- Bump vendor chart `octobus-query-exporter` from `1.0.32` → `1.0.33`
- Bump parent chart `octobus-query-exporter` from `1.0.34` → `1.0.35` and update `Chart.lock`


