### PR TITLE
fix(kube-system): bump cert-manager to v1.21.1 to fix critical CVEs

### DIFF
--- a/system/kube-system-admin-k3s/Chart.lock
+++ b/system/kube-system-admin-k3s/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 2.0.13
 - name: cert-manager
   repository: https://charts.jetstack.io
-  version: v1.20.3
+  version: v1.21.1
 - name: digicert-issuer
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.8.1
@@ -31,7 +31,7 @@ dependencies:
   version: 0.2.0
 - name: owner-label-injector
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.0.6
+  version: 1.0.7
 - name: toolbox-prepull
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.7
@@ -41,5 +41,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 2.2.14
-digest: sha256:6f1752148d31f3ba785d18dc513e044c12d3bf7d57aea59259bb37c90245e2ac
-generated: "2026-07-27T13:11:38.2574+02:00"
+digest: sha256:2d5c79bba734e39a1b76e3af305eda41bb1d8e12c866f9b191c57e6b521c10f5
+generated: "2026-08-07T07:50:33.610256+02:00"

--- a/system/kube-system-admin-k3s/Chart.yaml
+++ b/system/kube-system-admin-k3s/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kube-System relevant Service collection for the new admin clusters.
 name: kube-system-admin-k3s
-version: 3.7.6
+version: 3.7.7
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-admin-k3s
 dependencies:
   - name: node-problem-detector
@@ -22,7 +22,7 @@ dependencies:
     version: ">= 0.0.0"
   - name: cert-manager
     repository: https://charts.jetstack.io
-    version: 1.20.3
+    version: 1.21.1
   - name: digicert-issuer
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^2.x"

--- a/system/kube-system-kubernikus/Chart.lock
+++ b/system/kube-system-kubernikus/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 9.0.0
 - name: cert-manager
   repository: https://charts.jetstack.io
-  version: v1.20.3
+  version: v1.21.1
 - name: digicert-issuer
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.8.1
@@ -28,7 +28,7 @@ dependencies:
   version: 0.2.0
 - name: owner-label-injector
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.0.6
+  version: 1.0.7
 - name: toolbox-prepull
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.7
@@ -38,5 +38,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 2.2.14
-digest: sha256:5d1cb0044e46d6cfee4c9d4424d4a47cfb6870125263ef938bcce199ae9cf150
-generated: "2026-07-27T13:11:31.557182+02:00"
+digest: sha256:4be659baa1e0811a83c10db5a79122125bd8ff249536fb76327d5f02669b042b
+generated: "2026-08-07T07:50:26.924339+02:00"

--- a/system/kube-system-kubernikus/Chart.yaml
+++ b/system/kube-system-kubernikus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for Kubernikus control-plane clusters.
 name: kube-system-kubernikus
-version: 3.11.6
+version: 3.11.7
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-kubernikus
 dependencies:
   - name: cc-rbac
@@ -19,7 +19,7 @@ dependencies:
     version: 9.0.0
   - name: cert-manager
     repository: https://charts.jetstack.io
-    version: 1.20.3
+    version: 1.21.1
   - name: digicert-issuer
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^2.x"

--- a/system/kube-system-metal/Chart.lock
+++ b/system/kube-system-metal/Chart.lock
@@ -22,7 +22,7 @@ dependencies:
   version: 0.0.9
 - name: cert-manager
   repository: https://charts.jetstack.io
-  version: v1.20.3
+  version: v1.21.1
 - name: digicert-issuer
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.8.1
@@ -61,7 +61,7 @@ dependencies:
   version: 0.2.0
 - name: owner-label-injector
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.0.6
+  version: 1.0.7
 - name: externalip-operator
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.3
@@ -77,5 +77,5 @@ dependencies:
 - name: validating-admission-policy
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.0.2
-digest: sha256:5aba0db96bb0c529a4b4899ed6c14da272ae3b19d963693d19b3af0b95d4822f
-generated: "2026-07-27T13:11:06.792791+02:00"
+digest: sha256:372e2b10cb24295f5eebf0e28695b348320c8b330ed33680c6b1b9be2cbf0d8f
+generated: "2026-08-07T07:50:03.555426+02:00"

--- a/system/kube-system-metal/Chart.yaml
+++ b/system/kube-system-metal/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for metal clusters.
 name: kube-system-metal
-version: 6.14.10
+version: 6.14.11
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-metal
 dependencies:
   - name: cc-rbac
@@ -30,7 +30,7 @@ dependencies:
     version: "^0.x"
   - name: cert-manager
     repository: https://charts.jetstack.io
-    version: 1.20.3
+    version: 1.21.1
   - name: digicert-issuer
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^2.x"

--- a/system/kube-system-scaleout/Chart.lock
+++ b/system/kube-system-scaleout/Chart.lock
@@ -19,7 +19,7 @@ dependencies:
   version: 9.0.0
 - name: cert-manager
   repository: https://charts.jetstack.io
-  version: v1.20.3
+  version: v1.21.1
 - name: digicert-issuer
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.8.1
@@ -34,7 +34,7 @@ dependencies:
   version: 0.2.0
 - name: owner-label-injector
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.0.6
+  version: 1.0.7
 - name: toolbox-prepull
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.7
@@ -44,5 +44,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 2.2.14
-digest: sha256:b2785319d7478fff850ade5c6bd14b814bee714c4601bf683a13135ba364a91a
-generated: "2026-07-27T13:11:16.391851+02:00"
+digest: sha256:dc3a4403c05158da237280e14fe18ba72ceace32f5ac55bacbebe70b9223d1bd
+generated: "2026-08-07T07:50:12.913399+02:00"

--- a/system/kube-system-scaleout/Chart.yaml
+++ b/system/kube-system-scaleout/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kube-System relevant Service collection for scaleout clusters.
 name: kube-system-scaleout
-version: 5.13.7
+version: 5.13.8
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-scaleout
 dependencies:
   - name: cc-rbac
@@ -28,7 +28,7 @@ dependencies:
     version: 9.0.0
   - name: cert-manager
     repository: https://charts.jetstack.io
-    version: 1.20.3
+    version: 1.21.1
   - name: digicert-issuer
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^2.x"

--- a/system/kube-system-virtual/Chart.lock
+++ b/system/kube-system-virtual/Chart.lock
@@ -25,7 +25,7 @@ dependencies:
   version: 3.1.8
 - name: cert-manager
   repository: https://charts.jetstack.io
-  version: v1.20.3
+  version: v1.21.1
 - name: digicert-issuer
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 2.8.1
@@ -49,12 +49,12 @@ dependencies:
   version: 1.0.0
 - name: owner-label-injector
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.0.6
+  version: 1.0.7
 - name: secrets-injector
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.19
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 2.2.14
-digest: sha256:0fa30b7d6af1cb586667e18034f431f348ffa01b40492cf578309458b9201200
-generated: "2026-07-27T13:11:23.830327+02:00"
+digest: sha256:009e9ee6d30b00080f81c106c142d3338eb835c5e2098df2fc01da6c2ea99e5a
+generated: "2026-08-07T07:50:19.635876+02:00"

--- a/system/kube-system-virtual/Chart.yaml
+++ b/system/kube-system-virtual/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for virtual clusters.
 name: kube-system-virtual
-version: 4.9.9
+version: 4.9.10
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-virtual
 dependencies:
   - name: cc-rbac
@@ -30,7 +30,7 @@ dependencies:
     version: '>= 0.0.0'
   - name: cert-manager
     repository: https://charts.jetstack.io
-    version: 1.20.3
+    version: 1.21.1
   - name: digicert-issuer
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
     version: "^2.x"


### PR DESCRIPTION
## Summary

Bumps cert-manager from **v1.20.3 → v1.21.1** in all kube-system chart variants:
- `kube-system-metal` 6.14.10 → 6.14.11
- `kube-system-scaleout` 5.13.7 → 5.13.8
- `kube-system-virtual` 4.9.9 → 4.9.10
- `kube-system-kubernikus` 3.11.6 → 3.11.7
- `kube-system-admin-k3s` 3.7.6 → 3.7.7

## CVEs fixed

- `golang.org/x/text` → v0.40.0
- `google.golang.org/grpc` → v1.82.1
- `github.com/google/cel-go` → v0.29.0
- `go.opentelemetry.io/otel` → v1.44.0
- Distroless base images updated

No breaking changes — v1.21.1 is a pure bugfix/security release ([release notes](https://github.com/cert-manager/cert-manager/releases/tag/v1.21.1)).

## Test plan

- [ ] CI (ct lint + version increment) passes
- [ ] After merge: monitor rollout on QA clusters
- [ ] Run `check_cert_manager.sh` on qa-de-1