### PR TITLE
fix(node-problem-detector): bump to v1.36.0 to fix CVEs

### DIFF
--- a/system/node-problem-detector/Chart.yaml
+++ b/system/node-problem-detector/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Node Problem Detector for Kubernetes
 name: node-problem-detector
-version: 1.3.15
-appVersion: v1.35.3
+version: 1.3.16
+appVersion: v1.36.0

--- a/system/node-problem-detector/values.yaml
+++ b/system/node-problem-detector/values.yaml
@@ -4,7 +4,7 @@ global:
 
 image:
   repository: node-problem-detector/node-problem-detector
-  tag: v1.35.3
+  tag: v1.36.0
 
 resources:
   limits:


### PR DESCRIPTION
## Summary

Bumps node-problem-detector from **v1.35.3 → v1.36.0** (`system/node-problem-detector` 1.3.15 → 1.3.16).

Propagates automatically to all kube-system chart variants via `>= 0.0.0` dependency constraint.

## Changes in v1.36.0

- Go bumped to v1.25.7 (security fixes)
- `debian-base` bumped to bookworm-v1.0.7 (security fixes)
- `github.com/shirou/gopsutil/v4` bumped to v4.25.12

## Test plan

- [ ] CI (ct lint + version increment) passes
- [ ] After merge: run `check_npd.sh v1.36.0` on qa-de-1