### PR TITLE
metal-settings: make HPE iLO license setting optional

### DIFF
--- a/system/metal-settings/Chart.yaml
+++ b/system/metal-settings/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.42
+version: 0.2.43
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/metal-settings/bmc_settings/hpe-default.yaml
+++ b/system/metal-settings/bmc_settings/hpe-default.yaml
@@ -11,8 +11,10 @@
 #
 # Values sourced from: baremetal-config/hpe/*/bmc/defaultsettings.yml
 settings:
+  {{- if .Values.clusterConfig.hpeLicenseSecretName }}
   # License key — $(LicenseKey) fetched at reconcile time from the Secret named by clusterConfig.hpeLicenseSecretName.
   "POST /redfish/v1/Managers/1/LicenseService/": '{"LicenseKey": "$(LicenseKey)"}'
+  {{- end }}
   # Network protocol: HTTP port, IPMI, disable XML responses
   "PATCH /redfish/v1/managers/1/networkprotocol": '{"HTTP": {"Port": 1080}, "IPMI": {"ProtocolEnabled": true}, "Oem": {"Hpe": {"XMLResponseEnabled": false}}}'
   # SNMP: disable SNMPv1, disable cold-start trap broadcast
@@ -48,9 +50,11 @@ variables:
         name: $(BmcName)
         fieldPath: metadata.labels[kubernetes.metal.cloud.sap/bb]
   # LicenseKey: iLO license fetched at reconcile time — secret name configured via Helm values.
+  {{- if .Values.clusterConfig.hpeLicenseSecretName }}
   - key: LicenseKey
     valueFrom:
       secretKeyRef:
         name: {{ .Values.clusterConfig.hpeLicenseSecretName }}
         namespace: {{ .Values.clusterConfig.managedNamespace }}
         key: licenseKey
+  {{- end }}

--- a/system/metal-settings/templates/bmc-settings-secret.yaml
+++ b/system/metal-settings/templates/bmc-settings-secret.yaml
@@ -6,8 +6,6 @@ kind: Secret
 metadata:
   name: {{ .Values.clusterConfig.hpeLicenseSecretName }}
   namespace: {{ .Values.clusterConfig.managedNamespace }}
-  annotations:
-    cloud.sap/inject-secrets: "true"
 type: Opaque
 stringData:
   # HPE iLO license key — referenced by hpe-default.yaml via secretKeyRef at reconcile time.


### PR DESCRIPTION
Skip the license POST setting and LicenseKey secretKeyRef variable when hpeLicenseSecretName is not set, preventing BMCSettingsSet validation failures on clusters without a license secret.

Also reverts the cloud.sap/inject-secrets annotation added in 0.2.42 as the webhook is opt-out and fires on all secrets by default.