### PR TITLE
fix(calico-cni): bump Chart.lock to calico v3.32.1

### DIFF
--- a/system/calico-cni/Chart.lock
+++ b/system/calico-cni/Chart.lock
@@ -4,15 +4,15 @@ dependencies:
   version: 1.0.0
 - name: calico
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.2.4
+  version: 1.2.5
 - name: calico-crds
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 3.30.4
+  version: 3.32.1
 - name: calico-apiserver
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 0.0.11
+  version: 0.0.12
 - name: cni-nanny
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.1.1
-digest: sha256:4d0712e7ea654df34f056665462adc6416c76eb36f6a08627797ea68565d9021
-generated: "2025-12-11T09:00:30.26022721Z"
+digest: sha256:109e593b6b0b7ac1abf095187f92dc14637e23e5bce02d6cf814d4652b6fbbee
+generated: "2026-08-07T08:58:11.238196+02:00"

--- a/system/calico-cni/Chart.yaml
+++ b/system/calico-cni/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: calico-cni
 description: A Helm chart for the all things CNI.
 type: application
-version: 1.0.40
+version: 1.0.41
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm


### PR DESCRIPTION
## What

Updates `system/calico-cni/Chart.lock` after the calico v3.32.1 upgrade (PR #12496).

## Changes

- `system/calico-cni`: `1.0.40 → 1.0.41` (Chart.lock updated)
  - `calico`: `1.2.4 → 1.2.5`
  - `calico-crds`: `3.30.4 → 3.32.1`
  - `calico-apiserver`: `0.0.11 → 0.0.12`

## Why manually

`calico-cni` uses `>= 0.0.0` dependencies — sapcc-bot does not create Chart.lock update PRs for floating version constraints.

## References

- Parent PR: #12496