### PR TITLE
fix(kube-system): set cert-manager image tag to v1.21.1

### DIFF
--- a/system/kube-system-admin-k3s/Chart.yaml
+++ b/system/kube-system-admin-k3s/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kube-System relevant Service collection for the new admin clusters.
 name: kube-system-admin-k3s
-version: 3.7.7
+version: 3.7.8
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-admin-k3s
 dependencies:
   - name: node-problem-detector

--- a/system/kube-system-admin-k3s/values.yaml
+++ b/system/kube-system-admin-k3s/values.yaml
@@ -50,7 +50,7 @@ cert-manager:
   installCRDs: true
   image:
     repository: keppel.global.cloud.sap/ccloud-quay-mirror/jetstack/cert-manager-controller
-    tag: v1.20.3
+    tag: v1.21.1
   webhook:
     image:
       repository: keppel.global.cloud.sap/ccloud-quay-mirror/jetstack/cert-manager-webhook

--- a/system/kube-system-kubernikus/Chart.yaml
+++ b/system/kube-system-kubernikus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for Kubernikus control-plane clusters.
 name: kube-system-kubernikus
-version: 3.11.7
+version: 3.11.8
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-kubernikus
 dependencies:
   - name: cc-rbac

--- a/system/kube-system-kubernikus/values.yaml
+++ b/system/kube-system-kubernikus/values.yaml
@@ -11,7 +11,7 @@ cert-manager:
   installCRDs: true
   image:
     repository: keppel.eu-de-1.cloud.sap/ccloud-quay-mirror/jetstack/cert-manager-controller
-    tag: v1.20.3
+    tag: v1.21.1
   webhook:
     image:
       repository: keppel.eu-de-1.cloud.sap/ccloud-quay-mirror/jetstack/cert-manager-webhook

--- a/system/kube-system-metal/Chart.yaml
+++ b/system/kube-system-metal/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for metal clusters.
 name: kube-system-metal
-version: 6.14.11
+version: 6.14.12
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-metal
 dependencies:
   - name: cc-rbac

--- a/system/kube-system-metal/values.yaml
+++ b/system/kube-system-metal/values.yaml
@@ -34,7 +34,7 @@ cert-manager:
   installCRDs: true
   image:
     repository: keppel.global.cloud.sap/ccloud-quay-mirror/jetstack/cert-manager-controller
-    tag: v1.20.3
+    tag: v1.21.1
   webhook:
     image:
       repository: keppel.global.cloud.sap/ccloud-quay-mirror/jetstack/cert-manager-webhook

--- a/system/kube-system-virtual/Chart.yaml
+++ b/system/kube-system-virtual/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for virtual clusters.
 name: kube-system-virtual
-version: 4.9.10
+version: 4.9.11
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-virtual
 dependencies:
   - name: cc-rbac

--- a/system/kube-system-virtual/values.yaml
+++ b/system/kube-system-virtual/values.yaml
@@ -63,7 +63,7 @@ cert-manager:
   installCRDs: true
   image:
     repository: keppel.global.cloud.sap/ccloud-quay-mirror/jetstack/cert-manager-controller
-    tag: v1.20.3
+    tag: v1.21.1
   webhook:
     image:
       repository: keppel.global.cloud.sap/ccloud-quay-mirror/jetstack/cert-manager-webhook


### PR DESCRIPTION
## Summary

Follow-up to #12513: the hardcoded `image.tag` in `values.yaml` was still pinned to `v1.20.3` in 4 of the 5 kube-system chart variants, overriding the chart dependency version bump.

- `kube-system-metal` 6.14.11 → 6.14.12
- `kube-system-virtual` 4.9.10 → 4.9.11
- `kube-system-kubernikus` 3.11.7 → 3.11.8
- `kube-system-admin-k3s` 3.7.7 → 3.7.8

`kube-system-scaleout` was not affected (no hardcoded tag).

## Test plan

- [ ] CI (ct lint + version increment) passes
- [ ] After merge: run `check_cert_manager.sh` on qa-de-1 — controller should show v1.21.1