### PR TITLE
feat(audit-logs): adds mirror output for logstash export

### DIFF
--- a/system/audit-logs/vendor/logstash-audit-external/templates/_logstash.conf.tpl
+++ b/system/audit-logs/vendor/logstash-audit-external/templates/_logstash.conf.tpl
@@ -282,6 +282,14 @@ output {
       format => "json"
       http_method => "post"
     }
+    tcp {
+      id => "output_awx_tcp"
+      host => "logs-collector-external.eu-de-1.cloud.sap"
+      port => 514
+      codec => line {
+        format => "%{message} forwarded_by=logstash-audit-external"
+      }
+    }
   } else if [sap][cc][audit][source] == "flatcar" {
     http {
       id => "output_flatcar"
@@ -289,6 +297,14 @@ output {
       url => "https://{{ .Values.global.forwarding.audit_auditbeat.host }}"
       format => "json"
       http_method => "post"
+    }
+    tcp {
+      id => "output_flatcar_tcp"
+      host => "logs-collector-external.eu-de-1.cloud.sap"
+      port => 514
+      codec => line {
+        format => "%{message} forwarded_by=logstash-audit-external"
+      }
     }
   } else if [type] == "audit" or "audit" in [tags] {
     http {
@@ -298,6 +314,14 @@ output {
       format => "json"
       http_method => "post"
     }
+    tcp {
+      id => "output_else_audit_tcp"
+      host => "logs-collector-external.eu-de-1.cloud.sap"
+      port => 514
+      codec => line {
+        format => "%{message} forwarded_by=logstash-audit-external"
+      }
+    }
   } else if [type] == "kube-api" or "kube-api" in [tags] {
     http {
       id => "output_kube-api"
@@ -306,11 +330,27 @@ output {
       format => "json"
       http_method => "post"
     }
+    tcp {
+      id => "output_kube-api_tcp"
+      host => "logs-collector-external.eu-de-1.cloud.sap"
+      port => 514
+      codec => line {
+        format => "%{message} forwarded_by=logstash-audit-external"
+      }
+    }
   } else if "dropped_syslog" in [tags] {
     file {
       id => "output_dropped_syslog"
       path => "/dev/stdout"
       codec => json_lines
+    }
+    tcp {
+      id => "output_dropped_syslog_tcp"
+      host => "logs-collector-external.eu-de-1.cloud.sap"
+      port => 514
+      codec => line {
+        format => "%{message} forwarded_by=logstash-audit-external"
+      }
     }
   }
 }


### PR DESCRIPTION
To send audit logs both to octobus and fortlogs we need to mirror the output to another endpoint. this is a very rudimentary copy of the message, not having any enriched fields (this is done downstream by parsing the message). a bit of double work, enriched is sent to octobus but message downstream. an argument could be that this is not the same log info.

---------

Signed-off-by: Simon Olander <simon.olander@sap.com>