### PR TITLE
fix(kube-system): bump chart versions to trigger NPD v1.36.0 rollout

### DIFF
--- a/system/kube-system-admin-k3s/Chart.lock
+++ b/system/kube-system-admin-k3s/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: node-problem-detector
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.3.15
+  version: 1.3.16
 - name: prometheus-crds
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 9.0.0
@@ -41,5 +41,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 2.2.14
-digest: sha256:2d5c79bba734e39a1b76e3af305eda41bb1d8e12c866f9b191c57e6b521c10f5
-generated: "2026-08-07T07:50:33.610256+02:00"
+digest: sha256:cda32415ea7fde839361add7bc1b34e26e9c734c67e5b99fbe4ba8501f151bf3
+generated: "2026-08-07T11:40:31.781123+02:00"

--- a/system/kube-system-admin-k3s/Chart.yaml
+++ b/system/kube-system-admin-k3s/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kube-System relevant Service collection for the new admin clusters.
 name: kube-system-admin-k3s
-version: 3.7.8
+version: 3.7.9
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-admin-k3s
 dependencies:
   - name: node-problem-detector

--- a/system/kube-system-kubernikus/Chart.lock
+++ b/system/kube-system-kubernikus/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 4.15.1
 - name: node-problem-detector
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.3.15
+  version: 1.3.16
 - name: prometheus-crds
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 9.0.0
@@ -38,5 +38,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 2.2.14
-digest: sha256:4be659baa1e0811a83c10db5a79122125bd8ff249536fb76327d5f02669b042b
-generated: "2026-08-07T07:50:26.924339+02:00"
+digest: sha256:7a81d0d256351fefa44f44cc818af2a21875c3ea114c1d233963c7d4ec57d7e0
+generated: "2026-08-07T11:40:24.709876+02:00"

--- a/system/kube-system-kubernikus/Chart.yaml
+++ b/system/kube-system-kubernikus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for Kubernikus control-plane clusters.
 name: kube-system-kubernikus
-version: 3.11.8
+version: 3.11.9
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-kubernikus
 dependencies:
   - name: cc-rbac

--- a/system/kube-system-metal/Chart.lock
+++ b/system/kube-system-metal/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 2.2.0
 - name: node-problem-detector
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.3.15
+  version: 1.3.16
 - name: prometheus-crds
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 9.0.0
@@ -77,5 +77,5 @@ dependencies:
 - name: validating-admission-policy
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 0.0.2
-digest: sha256:372e2b10cb24295f5eebf0e28695b348320c8b330ed33680c6b1b9be2cbf0d8f
-generated: "2026-08-07T07:50:03.555426+02:00"
+digest: sha256:b6afb45d97908b2af669b42dc42ab6c4644bbd4384015520cf9cc14788a0d412
+generated: "2026-08-07T11:40:01.569874+02:00"

--- a/system/kube-system-metal/Chart.yaml
+++ b/system/kube-system-metal/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for metal clusters.
 name: kube-system-metal
-version: 6.14.12
+version: 6.14.13
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-metal
 dependencies:
   - name: cc-rbac

--- a/system/kube-system-scaleout/Chart.lock
+++ b/system/kube-system-scaleout/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 4.15.1
 - name: node-problem-detector
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.3.15
+  version: 1.3.16
 - name: prometheus-crds
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 9.0.0
@@ -44,5 +44,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 2.2.14
-digest: sha256:dc3a4403c05158da237280e14fe18ba72ceace32f5ac55bacbebe70b9223d1bd
-generated: "2026-08-07T07:50:12.913399+02:00"
+digest: sha256:ba8bfc906ce25da70c8c6f027c652c247d844e3ddad74e3f7b644648f755a15a
+generated: "2026-08-07T11:40:10.638024+02:00"

--- a/system/kube-system-scaleout/Chart.yaml
+++ b/system/kube-system-scaleout/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kube-System relevant Service collection for scaleout clusters.
 name: kube-system-scaleout
-version: 5.13.8
+version: 5.13.9
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-scaleout
 dependencies:
   - name: cc-rbac

--- a/system/kube-system-virtual/Chart.lock
+++ b/system/kube-system-virtual/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 4.15.1
 - name: node-problem-detector
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
-  version: 1.3.15
+  version: 1.3.16
 - name: prometheus-crds
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 9.0.0
@@ -56,5 +56,5 @@ dependencies:
 - name: reloader
   repository: oci://ghcr.io/stakater/charts
   version: 2.2.14
-digest: sha256:009e9ee6d30b00080f81c106c142d3338eb835c5e2098df2fc01da6c2ea99e5a
-generated: "2026-08-07T07:50:19.635876+02:00"
+digest: sha256:eb652edd64bdb7f526cad5be100421a295846f4a9721f6e2c9dbe7322f57781b
+generated: "2026-08-07T11:40:17.40573+02:00"

--- a/system/kube-system-virtual/Chart.yaml
+++ b/system/kube-system-virtual/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kube-System relevant Service collection for virtual clusters.
 name: kube-system-virtual
-version: 4.9.11
+version: 4.9.12
 home: https://github.com/sapcc/helm-charts/tree/master/system/kube-system-virtual
 dependencies:
   - name: cc-rbac


### PR DESCRIPTION
## Summary

Follow-up to #12515: `node-problem-detector` is included via `>= 0.0.0` and does not trigger pipeline runs on its own. This PR bumps all kube-system chart variants to pick up `node-problem-detector:1.3.16` (v1.36.0).

- `kube-system-metal` 6.14.12 → 6.14.13
- `kube-system-scaleout` 5.13.8 → 5.13.9
- `kube-system-virtual` 4.9.11 → 4.9.12
- `kube-system-kubernikus` 3.11.8 → 3.11.9
- `kube-system-admin-k3s` 3.7.8 → 3.7.9

## Test plan

- [ ] CI (ct lint + version increment) passes
- [ ] After merge: run `check_npd.sh v1.36.0` on qa-de-1