### PR TITLE
[gatekeeper] adapt archer eu-de-3 pod-security to scoped caps

### DIFF
--- a/system/gatekeeper/templates/constraint-pod-security-v2.yaml
+++ b/system/gatekeeper/templates/constraint-pod-security-v2.yaml
@@ -1025,23 +1025,33 @@ spec:
       - matchNamespace: archer
         matchRepository: ccloud/archer
         justification: |
-          Archer network agents need host networking and
-          CAP_NET_ADMIN to manage network namespaces and
-          interfaces for private endpoint connectivity across
-          OpenStack networks.
-        mayBePrivileged: true
+          The archer-ni-agent manages network namespaces, veth
+          pairs and interfaces for private endpoint connectivity,
+          and runs HAProxy inside an isolated namespace. It no
+          longer runs privileged; these scoped capabilities are
+          the minimal set it needs.
+        mayUseCapabilities:
+        - KILL
+        - NET_ADMIN
+        - NET_BIND_SERVICE
+        - SETGID
+        - SETUID
+        - SYS_ADMIN
+        - SYS_CHROOT
 
       - matchNamespace: archer
         matchRepository: ccloud/loci-neutron
         justification: |
-          Archer network agents need host neutron network agents and
-          CAP_NET_ADMIN to manage network namespaces and
+          Archer network agents need the neutron linuxbridge agent
+          and CAP_NET_ADMIN to manage network namespaces and
           interfaces for private endpoint connectivity across
-          OpenStack networks.
+          OpenStack networks. SETPCAP is required by neutron's
+          oslo.privsep daemon.
         mayUseCapabilities:
         - DAC_OVERRIDE
         - DAC_READ_SEARCH
         - NET_ADMIN
+        - SETPCAP
         - SYS_ADMIN
         - SYS_PTRACE
       {{- end }}


### PR DESCRIPTION
The archer chart's network agent no longer runs `privileged: true` — it now requests a scoped capability set (archer commit "Refactor Archer network agent config", `87b5de5b4d`). This adapts the eu-de-3 pod-security allowlist to match:

- `ccloud/archer` (archer-ni-agent): replace `mayBePrivileged: true` with the scoped caps the container now declares — `KILL, NET_ADMIN, NET_BIND_SERVICE, SETGID, SETUID, SYS_ADMIN, SYS_CHROOT`.
- `ccloud/loci-neutron` (neutron-linuxbridge-agent): add `SETPCAP`, required by neutron's oslo.privsep daemon.

Cross-checked against the qa-de-1 dryrun audit: the recorded violations for the `archer-network-agent` statefulsets request exactly these capabilities, confirming the allowlist matches what archer actually needs. Change is scoped to eu-de-3 only.