### PR TITLE
fix(archer): degrade SLO error budget burn alert to warning

### DIFF
--- a/openstack/archer/Chart.yaml
+++ b/openstack/archer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/openstack/archer/alerts/openstack.alerts
+++ b/openstack/archer/alerts/openstack.alerts
@@ -65,7 +65,7 @@ groups:
     labels:
       context: api
       service: archer
-      severity: critical
+      severity: warning
       tier: os
       support_group: containers
       playbook: docs/support/playbook/archer/alerts/archer-slo-error-budget-burn


### PR DESCRIPTION
The `archer-slo-error-budget-burn-fast` alert was firing at `severity: critical`, paging on-call whenever the Archer API burned its 99.90% availability error budget at 14.4x.

This degrades it to `severity: warning` so the SLI/SLO error budget burn alerts no longer page. The slow-burn alert (`archer-slo-error-budget-burn-slow`) was already `warning`.

Chart version bumped to 0.1.2 to trigger the rollout.