### PR TITLE
[prometheus-vmware-rules] add opensearch-query based vmware alerts

### DIFF
--- a/prometheus-rules/prometheus-vmware-rules/Chart.yaml
+++ b/prometheus-rules/prometheus-vmware-rules/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A collection of Prometheus alert rules.
 name: prometheus-vmware-rules
-version: 1.5.8
+version: 1.5.9
 dependencies:
   - name: owner-info
     repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm

--- a/prometheus-rules/prometheus-vmware-rules/alerts-scaleout-ruler/obs-query.alerts
+++ b/prometheus-rules/prometheus-vmware-rules/alerts-scaleout-ruler/obs-query.alerts
@@ -1,0 +1,154 @@
+groups:
+  - name: vmware
+    rules:
+      - alert: EsxiNicError
+        expr: >
+          vrops_hostsystem_runtime_connectionstate{state="connected"} and
+          on(hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"} and
+          on(hostsystem) opensearch_query_esxi_nic_error_hostsystem_doc_count
+        labels:
+          severity: critical
+          service: compute
+          tier: vmware
+          support_group: compute
+          no_alert_on_absence: "true"
+          meta: "Alert for query enic_uplink_reset"
+          playbook: docs/devops/alert/vcenter/#test_esxi_hs_5
+        annotations:
+          summary: "An Error String related to possible NIC Failure was captured."
+          description: "This alert is created to prevent the Outage from NIC failure on {{ $labels.hostsystem }}"
+
+      - alert: MellanoxIssue
+        expr: >
+          vrops_hostsystem_runtime_connectionstate{state="connected"} and
+          on(hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"} and
+          on(hostsystem) opensearch_query_mellanox_issue_hostsystem_doc_count
+        labels:
+          severity: critical
+          service: compute
+          tier: vmware
+          support_group: compute
+          no_alert_on_absence: "true"
+          meta: "Alert for Mellanox card issue with abort errors"
+          playbook: docs/devops/alert/vcenter/#mellanox_issue
+        annotations:
+          summary: "An Error String related to Mellanox card issue with abort errors"
+          description: "This alert is created to prevent the Outage from Mellanox card issue on {{ $labels.hostsystem }}"
+
+      - alert: NSXTDisconnectedNodes
+        expr: >
+          vrops_hostsystem_runtime_connectionstate{state="connected"}
+          and on(hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"}
+          and on(hostsystem) opensearch_query_nsxt_disconnected_nodes_hostsystem_doc_count
+        for: 30m
+        labels:
+          severity: warning
+          service: compute
+          tier: vmware
+          support_group: compute
+          no_alert_on_absence: "true"
+          meta: "Alert for NSXT Disconnected nodes"
+          playbook: docs/devops/alert/nsxt/#troubleshooting-transport-node-controller-status-unknown-in-nsx-t
+        annotations:
+          summary: "NSXT Transport nodes is disconnected from the NSXT manager"
+          description: "NSXT Transport node {{ $labels.hostsystem }} is disconnected from the NSXT Manager, network provisioning and service availability will be impacted"
+
+      - alert: NFSlockedError
+        expr: >
+          vrops_hostsystem_runtime_connectionstate{state="connected"}
+          and on(hostsystem) vrops_hostsystem_runtime_maintenancestate{state="notInMaintenance"}
+          and on(hostsystem) opensearch_query_nfslocked_issue_hostsystem_doc_count
+        labels:
+          severity: warning
+          service: compute
+          tier: vmware
+          support_group: compute
+          no_alert_on_absence: "true"
+          meta: "Alert for NFSLocked issue"
+          playbook: docs/compute/playbooks/vcenter/#nfslockederror
+        annotations:
+          summary: "ESXi host detected NFSv4 lock error (NFS4ERR_LOCKED)"
+          description: "ESXi host {{ $labels.hostsystem }} reported an NFSv4 lock error (NFS4ERR_LOCKED), it indicates that a file lock could not be obtained on the NFS datastore, which may impact VM operations such as disk access, snapshots, or migrations"
+
+      - alert: NFSFCDObjectNotFound
+        expr: opensearch_query_fcdobjectnotfound_issue_hostsystem_doc_count
+        labels:
+          severity: critical
+          service: compute
+          tier: vmware
+          support_group: compute
+          no_alert_on_absence: "true"
+          meta: "Alert for FCD Object Not Found issue on vCenter"
+          playbook: docs/compute/playbooks/vcenter/#fcdobjectnotfound
+        annotations:
+          summary: "Error for FCD Object Storage Not Found"
+          description: "vCenter {{ $labels.hostsystem }} reported FCD Object Not Found, please follow the playbook to fix it"
+
+      - alert: EsxiFailedToAddDvPort
+        expr: opensearch_query_dvport_failedtoadd_hostsystem_doc_count > 0
+        labels:
+          severity: warning
+          service: compute
+          tier: vmware
+          support_group: compute
+          no_alert_on_absence: "true"
+          meta: "Alert for failed adding of DV port"
+          playbook: docs/devops/alert/vcenter/#how-to-remediate-esxi-host
+        annotations:
+          summary: "Failed to add DV Port in vmkernel on {{ $labels.hostsystem }}"
+          description: "Failed to add DV Port in vmkernel on {{ $labels.hostsystem }}"
+
+      - alert: VMPoweredDownDuringFailedHostMigration
+        expr: opensearch_query_vm_down_hit_hostsystem_doc_count
+        labels:
+          severity: critical
+          service: compute
+          tier: vmware
+          support_group: compute
+          no_alert_on_absence: "true"
+          meta: "A VM unexpectedly powered down during a failed host migration (vMotion or Storage vMotion)."
+          playbook: docs/devops/alert/vcenter/#VM%20powered%20off%20during%20vMotion
+        annotations:
+          summary: "A VM unexpectedly powered down during a failed host migration (vMotion or Storage vMotion)."
+          description: "VM {{ $labels.hit_cloud_instance_name }} ({{ $labels.hit_cloud_instance_id }}) unexpectedly powered down during a failed host migration on {{ $labels.hit_hostsystem }}"
+
+      - alert: VMFailedPowerOff
+        expr: sum by (vcenter) (opensearch_query_vm_failed_poweroff_vcenter_doc_count) > 0
+        labels:
+          severity: warning
+          service: compute
+          tier: vmware
+          support_group: compute
+          no_alert_on_absence: "true"
+          meta: "Alert for failed VM poweroff"
+          playbook: docs/devops/alert/vcenter/#vmfailedpoweroff
+        annotations:
+          summary: "Failed to poweroff VM on {{ $labels.vcenter }}"
+          description: "Failed to poweroff VM on {{ $labels.vcenter }}"
+
+      - alert: VcenterRestarted
+        expr: opensearch_query_vpxd_restart_hits > 0
+        labels:
+          severity: info
+          service: compute
+          tier: vmware
+          support_group: compute
+          no_alert_on_absence: "true"
+          meta: "Alert for restarted vCenter"
+        annotations:
+          summary: "A vCenter vpxd service was (re)started"
+          description: "A restarted vCenter will be handled by TARS with playbook <https://awx-prod.infraautomation.cc.eu-de-1.cloud.sap/#/templates/job_template/3496|vmware_host_service_actions.yml> (service vpxa, state restart)"
+
+      - alert: VcenterVolumeAttachmentError
+        expr: sum_over_time(sum by (region) (opensearch_query_volume_attachment_error_hostsystem_doc_count)[1h:5m]) >= 7
+        labels:
+          severity: critical
+          service: compute
+          tier: vmware
+          support_group: compute
+          no_alert_on_absence: "true"
+          meta: "Alert for failed volume attachments"
+          playbook: docs/devops/alert/vcenter/#test_vvol_ds_7
+        annotations:
+          summary: "New volumes cannot be created in {{ $labels.region }} which means volume-attachments might not be happening."
+          description: "New volumes cannot be created in {{ $labels.region }} which means volume-attachments might not be happening."


### PR DESCRIPTION
## Summary

- Add `obs-query.alerts` to `alerts-scaleout-ruler` with 10 consolidated VMware alert rules based on `opensearch_query_*` metrics from the opensearch-query-exporter
- Bump chart version `1.5.8` → `1.5.9`

## Alerts included

| Alert | Severity |
|---|---|
| EsxiNicError | critical |
| MellanoxIssue | critical |
| NSXTDisconnectedNodes | warning |
| NFSlockedError | warning |
| NFSFCDObjectNotFound | critical |
| EsxiFailedToAddDvPort | warning |
| VMPoweredDownDuringFailedHostMigration | critical |
| VMFailedPowerOff | warning |
| VcenterRestarted | info |
| VcenterVolumeAttachmentError | critical |

