### PR TITLE
keystone/saml: route transaction log to stdout, add SAML security event alert

### DIFF
--- a/openstack/keystone/templates/etc/_shibd-logger.tpl
+++ b/openstack/keystone/templates/etc/_shibd-logger.tpl
@@ -18,7 +18,7 @@ log4j.ownAppenders.XMLTooling.Signature.Debugger=true
 
 # the tran log blocks the "default" appender(s) at runtime
 # Level should be left at INFO for this category
-log4j.category.Shibboleth-TRANSACTION=INFO, tran_log
+log4j.category.Shibboleth-TRANSACTION=INFO, tran_log, tran_stdout
 log4j.additivity.Shibboleth-TRANSACTION=false
 log4j.ownAppenders.Shibboleth-TRANSACTION=true
 
@@ -43,6 +43,14 @@ log4j.appender.warn_log.fileName=/proc/1/fd/1
 log4j.appender.warn_log.layout=org.apache.log4j.PatternLayout
 log4j.appender.warn_log.layout.ConversionPattern=%d{%Y-%m-%d %H:%M:%S} %p %c %x: %m%n
 log4j.appender.warn_log.threshold=WARN
+
+# [AC3] Route all SAML transaction log entries to container stdout.
+#   Every auth decision (success and failure) reaches Fluent Bit → OpenSearch
+#   via Apache stdout. Satisfies BSI SF.Fas.6 / SF.Log.1.
+log4j.appender.tran_stdout=org.apache.log4j.FileAppender
+log4j.appender.tran_stdout.fileName=/proc/1/fd/1
+log4j.appender.tran_stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.tran_stdout.layout.ConversionPattern=%d{%Y-%m-%dT%H:%M:%S}|transaction|%c|%m%n
 
 # [FIX L-01] maxFileSize increased from 1 MB to 10 MB.
 #   Transaction log is the SAML audit trail -- must not rotate prematurely.

--- a/prometheus-exporters/opensearch-logs-query-exporter/alerts/opensearch-logs-query.alerts.tpl
+++ b/prometheus-exporters/opensearch-logs-query-exporter/alerts/opensearch-logs-query.alerts.tpl
@@ -110,6 +110,7 @@ groups:
     expr: opensearch_logs_keystone_saml_errors_doc_count > 0
     for: 0m
     labels:
+      context: compliance
       severity: warning
       service: keystone
       support_group: identity

--- a/prometheus-exporters/opensearch-logs-query-exporter/alerts/opensearch-logs-query.alerts.tpl
+++ b/prometheus-exporters/opensearch-logs-query-exporter/alerts/opensearch-logs-query.alerts.tpl
@@ -105,3 +105,16 @@ groups:
     annotations:
       description: "Maillog entries older than 30 days found in {{`{{ $labels.region }}`}}."
       summary: "Maillog compliance violation"
+
+  - alert: KeystoneSAMLSecurityEventLogged
+    expr: opensearch_logs_keystone_saml_errors_doc_count > 0
+    for: 0m
+    labels:
+      severity: warning
+      service: keystone
+      support_group: identity
+      tier: os
+      no_alert_on_absence: "true"
+    annotations:
+      summary: "SAML security event logged in keystone-api ({{`{{ $labels.region }}`}})"
+      description: "mod_shib logged a WARN/ERROR for Shibboleth or XMLTooling.Signature in monsoon3/keystone-api in the last 5m. Check OpenSearch logs-* for 'Shibboleth' + 'WARN'/'ERROR'."

--- a/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_keystone_saml.cfg
+++ b/prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_keystone_saml.cfg
@@ -1,0 +1,50 @@
+[query_opensearch_keystone_saml_errors]
+QueryIntervalSecs = 300
+QueryTimeoutSecs = 15
+QueryOnMissing = zero
+QueryIndices = logs-*
+QueryJson = {
+        "size": 0,
+        "query": {
+          "bool": {
+            "filter": [
+              {
+                "match_phrase": {
+                  "resource.k8s.namespace.name": "monsoon3"
+                }
+              },
+              {
+                "match_phrase": {
+                  "resource.k8s.container.name": "keystone-api"
+                }
+              },
+              {
+                "bool": {
+                  "should": [
+                    {"match_phrase": {"body": "Shibboleth"}},
+                    {"match_phrase": {"body": "XMLTooling.Signature"}}
+                  ],
+                  "minimum_should_match": 1
+                }
+              },
+              {
+                "bool": {
+                  "should": [
+                    {"match_phrase": {"body": " WARN "}},
+                    {"match_phrase": {"body": " ERROR "}}
+                  ],
+                  "minimum_should_match": 1
+                }
+              },
+              {
+                "range": {
+                  "@timestamp": {
+                    "format": "epoch_millis",
+                    "gte": "now-5m"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }


### PR DESCRIPTION
## Summary

Part of [#1180 — SAML Security Events Logging and Monitoring](https://github.wdf.sap.corp/sap-cloud-infrastructure/foundation-issues/issues/1180) (BSI SF.Fas.6, SF.Log.1).

**AC3 — transaction.log routing**

`Shibboleth-TRANSACTION` previously wrote only to a file inside the container (lost on restart, never reaches the pipeline). Added a `tran_stdout` appender in `_shibd-logger.tpl` that forwards all SAML auth events (success and failure) to `/proc/1/fd/1` (Apache stdout → Fluent Bit → OpenSearch).

**AC4 — SAML security event alert**

Added an `opensearch-logs-query-exporter` query file that counts shibd WARN/ERROR lines from `keystone-api` pods in `monsoon3` every 5 minutes. Added Prometheus alert `KeystoneSAMLSecurityEventLogged` that fires immediately when count > 0, routed to `support_group: identity`. Uses `no_alert_on_absence: "true"` so regions without SAML don't false-alert.

## Files changed

- `openstack/keystone/templates/etc/_shibd-logger.tpl` — add `tran_stdout` appender, include it in `Shibboleth-TRANSACTION` category
- `prometheus-exporters/opensearch-logs-query-exporter/files/opensearch_logs_keystone_saml.cfg` — new OpenSearch query
- `prometheus-exporters/opensearch-logs-query-exporter/alerts/opensearch-logs-query.alerts.tpl` — new `KeystoneSAMLSecurityEventLogged` alert

## Test plan

- [x] Deploy to qa-de-3, run a SAML login, verify `body: "transaction|"` entries appear in OpenSearch `logs-*`
- [x] Send a tampered SAML assertion, verify WARN line appears in OpenSearch and metric `opensearch_logs_keystone_saml_errors_doc_count` > 0 within 5 min
- [ ] Confirm alert fires in Alertmanager