### PR TITLE
Added keepObjects: true for crds and bumped chart versions

### DIFF
--- a/global/cc-gardener/Chart.yaml
+++ b/global/cc-gardener/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cc-gardener
 description: Converged Cloud Gardener setup based on gardener-operator
 type: application
-version: 0.38.12
+version: 0.38.13
 home: https://github.com/gardener/gardener
 dependencies:
 - name: owner-info

--- a/global/cc-gardener/templates/managedresource.yaml
+++ b/global/cc-gardener/templates/managedresource.yaml
@@ -20,6 +20,9 @@ metadata:
 spec:
   secretRefs:
   - name: {{ template "mrname" $obj }}
+  {{- if eq $obj.kind "CustomResourceDefinition" }}
+  keepObjects: true
+  {{- end }}
 ---
 apiVersion: v1
 kind: Secret

--- a/system/argora-operator-remote/Chart.yaml
+++ b/system/argora-operator-remote/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.62
+version: 0.0.63
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/argora-operator-remote/templates/managedresource.yaml
+++ b/system/argora-operator-remote/templates/managedresource.yaml
@@ -19,6 +19,9 @@ metadata:
 spec:
   secretRefs:
   - name: {{ template "mrname" $obj }}
+  {{- if eq $obj.kind "CustomResourceDefinition" }}
+  keepObjects: true
+  {{- end }}
 ---
 apiVersion: v1
 kind: Secret

--- a/system/boot-operator-remote/Chart.yaml
+++ b/system/boot-operator-remote/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.21
+version: 0.4.22
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/boot-operator-remote/templates/managedresource.yaml
+++ b/system/boot-operator-remote/templates/managedresource.yaml
@@ -19,6 +19,9 @@ metadata:
 spec:
   secretRefs:
   - name: {{ template "mrname" $obj }}
+  {{- if eq $obj.kind "CustomResourceDefinition" }}
+  keepObjects: true
+  {{- end }}
 ---
 apiVersion: v1
 kind: Secret

--- a/system/disco/Chart.yaml
+++ b/system/disco/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: The DISCO (Designate IngresS Cname Operator) creates CNAMEs based on an ingress spec in OpenStack Designate.
 name: disco
-version: 2.4.8
+version: 2.4.9
 appVersion: v2.0.0
 maintainers:
   - name: kengou

--- a/system/disco/templates/managedresource.yaml
+++ b/system/disco/templates/managedresource.yaml
@@ -5,6 +5,7 @@ kind: ManagedResource
 metadata:
   name: {{ .Release.Name }}-crd
 spec:
+  keepObjects: true
   secretRefs:
   - name: {{ .Release.Name }}-crd
 ---

--- a/system/khalkeon-remote/Chart.yaml
+++ b/system/khalkeon-remote/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/system/khalkeon-remote/templates/managedresource.yaml
+++ b/system/khalkeon-remote/templates/managedresource.yaml
@@ -19,6 +19,9 @@ metadata:
 spec:
   secretRefs:
   - name: {{ template "mrname" $obj }}
+  {{- if eq $obj.kind "CustomResourceDefinition" }}
+  keepObjects: true
+  {{- end }}
 ---
 apiVersion: v1
 kind: Secret

--- a/system/kustomize/boot-operator-remote/managedresource.yaml
+++ b/system/kustomize/boot-operator-remote/managedresource.yaml
@@ -19,6 +19,9 @@ metadata:
 spec:
   secretRefs:
   - name: {{ template "mrname" $obj }}
+  {{- if eq $obj.kind "CustomResourceDefinition" }}
+  keepObjects: true
+  {{- end }}
 ---
 apiVersion: v1
 kind: Secret

--- a/system/metal-maintenance-operator-remote/Chart.yaml
+++ b/system/metal-maintenance-operator-remote/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: metal-maintenance-operator-remote
 description: A Helm chart for the Ironcore metal-maintenance-operator (remote).
 type: application
-version: 1.1.3
+version: 1.1.4
 appVersion: "0.1.0"
 dependencies:
   - name: owner-info

--- a/system/metal-maintenance-operator-remote/templates/managedresource.yaml
+++ b/system/metal-maintenance-operator-remote/templates/managedresource.yaml
@@ -19,6 +19,9 @@ metadata:
 spec:
   secretRefs:
   - name: {{ template "mrname" $obj }}
+  {{- if eq $obj.kind "CustomResourceDefinition" }}
+  keepObjects: true
+  {{- end }}
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
Make changes for all Helm charts that deliver CustomResourceDefinitions (CRDs) to remote clusters via Gardener's `resources.gardener.cloud/ManagedResource` set `keepObjects: true` for CRD resources, so that removing/reinstalling the ManagedResource does not delete CRDs (and thus not cascade-delete the custom resources) on the remote cluster.

This is the concrete rollout of ADR [0003 — Require keepObjects=true on Helm-chart ManagedResources that ship CRDs](https://github.wdf.sap.corp/d051408/adr/blob/f5f8c1e2298fd73d2fcb325a04152df58822f5eb/enablement/services/controlplane/0003-managed-resources-for-crds.md) across `sapcc/helm-charts`.