### PR TITLE
fix(castellum): propagate volume_state and availability_zone through joins

### DIFF
--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/aggregations/castellum.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/aggregations/castellum.yaml
@@ -14,18 +14,18 @@ groups:
 
       - record: manila_share_size_bytes_for_castellum
         expr: |
-          max by (app, svm, volume, project_id, share_id, share_name, share_type, volume_state, volume_type) (
-            netapp_volume_provision_case_one * on (app, svm, volume) group_right() netapp_volume_size)
+          max by (app, svm, volume, availability_zone, project_id, share_id, share_name, share_type, volume_state, volume_type) (
+            netapp_volume_provision_case_one * on (app, svm, volume) group_right(volume_state) netapp_volume_size)
 
       - record: manila_share_used_bytes_for_castellum
         expr: |
-          max by (app, svm, volume, project_id, share_id, share_name, share_type, volume_state, volume_type) (
-            netapp_volume_provision_case_one * on (app, svm, volume) group_right() netapp_volume_size_used)
+          max by (app, svm, volume, availability_zone, project_id, share_id, share_name, share_type, volume_state, volume_type) (
+            netapp_volume_provision_case_one * on (app, svm, volume) group_right(volume_state) netapp_volume_size_used)
 
       - record: manila_share_minimal_size_bytes_for_castellum
         expr: |
-          max by (app, svm, volume, project_id, share_id, share_name, share_type, volume_state, volume_type) (
-            netapp_volume_provision_case_one * on (app, svm, volume) group_right() (netapp_volume_size_used + netapp_volume_snapshot_reserve_size))
+          max by (app, svm, volume, availability_zone, project_id, share_id, share_name, share_type, volume_state, volume_type) (
+            netapp_volume_provision_case_one * on (app, svm, volume) group_right(volume_state) (netapp_volume_size_used + netapp_volume_snapshot_reserve_size))
 
       # Case two: new provision style and logical space is NOT enabled
       # New provision style means snapshot reserve is allocated side by side to the share space.
@@ -42,13 +42,13 @@ groups:
 
       - record: manila_share_size_bytes_for_castellum
         expr: |
-          max by (app, svm, volume, project_id, share_id, share_name, share_type, volume_state, volume_type) (
-            netapp_volume_provision_case_two * on (app, svm, volume) group_right() netapp_volume_size_total)
+          max by (app, svm, volume, availability_zone, project_id, share_id, share_name, share_type, volume_state, volume_type) (
+            netapp_volume_provision_case_two * on (app, svm, volume) group_right(volume_state) netapp_volume_size_total)
 
       - record: manila_share_used_bytes_for_castellum
         expr: |
-          max by (app, svm, volume, project_id, share_id, share_name, share_type, volume_state, volume_type) (
-            netapp_volume_provision_case_two * on (app, svm, volume) group_right() netapp_volume_size_used)
+          max by (app, svm, volume, availability_zone, project_id, share_id, share_name, share_type, volume_state, volume_type) (
+            netapp_volume_provision_case_two * on (app, svm, volume) group_right(volume_state) netapp_volume_size_used)
 
       - record: manila_share_minimal_size_bytes_for_castellum
         expr: |
@@ -67,14 +67,14 @@ groups:
 
       - record: manila_share_size_bytes_for_castellum
         expr: |
-          max by (app, svm, volume, project_id, share_id, share_name, share_type, volume_state, volume_type) (
-            netapp_volume_provision_case_three * on (app, svm, volume) group_right() netapp_volume_size_total)
+          max by (app, svm, volume, availability_zone, project_id, share_id, share_name, share_type, volume_state, volume_type) (
+            netapp_volume_provision_case_three * on (app, svm, volume) group_right(volume_state) netapp_volume_size_total)
 
       # netapp_volume_space_logical_used_by_afs considers no snapshot spill
       - record: manila_share_used_bytes_for_castellum
         expr: |
-          max by (app, svm, volume, project_id, share_id, share_name, share_type, volume_state, volume_type) (
-            netapp_volume_provision_case_three * on (app, svm, volume) group_right() netapp_volume_space_logical_used_by_afs)
+          max by (app, svm, volume, availability_zone, project_id, share_id, share_name, share_type, volume_state, volume_type) (
+            netapp_volume_provision_case_three * on (app, svm, volume) group_right(volume_state) netapp_volume_space_logical_used_by_afs)
 
       - record: manila_share_minimal_size_bytes_for_castellum
         expr: |


### PR DESCRIPTION
Two labels were missing from all manila_share_*_for_castellum metrics:

1. volume_state: the size/used/minimal_size rules used bare group_right(),
   which takes labels from the RIGHT side (netapp_volume_size*). Since
   volume_state is an instance_label in the Harvest config (intentionally
   kept off numeric metrics to avoid series churn on state changes), it
   only exists on netapp_volume_labels:manila. It is correctly carried by
   netapp_volume_provision_case_* via group_left, but bare group_right()
   drops all LEFT-side-only labels. Fix: group_right(volume_state).

2. availability_zone: present on the right-side size metrics as an
   instance_key, but absent from all max by(...) clauses, so Prometheus
   stripped it during aggregation. Fix: add availability_zone to max by.

Both labels are required downstream: volume_state by Castellum
({volume_type!="dp", volume_state!="offline"} filter) and availability_zone
by Limes (aggregates netapp_volume_used_bytes_for_limes by availability_zone).
