### PR TITLE
feat(netapp-credential-rotator): add Conditions field to CRD status

### DIFF
--- a/openstack/netapp-credential-rotator/templates/crd/security.cloud.sap_netappcredentialrotators.yaml
+++ b/openstack/netapp-credential-rotator/templates/crd/security.cloud.sap_netappcredentialrotators.yaml
@@ -14,7 +14,23 @@ spec:
     singular: netappcredential
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Stopped")].status
+      name: Stopped
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Stopped")].reason
+      name: Reason
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Stopped")].lastTransitionTime
+      name: Since
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: NetappCredential is the Schema for the netappcredentialrotators

--- a/openstack/netapp-credential-rotator/templates/crd/security.cloud.sap_netappcredentialrotators.yaml
+++ b/openstack/netapp-credential-rotator/templates/crd/security.cloud.sap_netappcredentialrotators.yaml
@@ -58,6 +58,67 @@ spec:
           status:
             description: NetappCredentialStatus defines the observed state of NetappCredential
             properties:
+              conditions:
+                description: Conditions holds high-level status conditions for this
+                  credential rotation.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               nextUserSecretVersion:
                 type: string
               phase:


### PR DESCRIPTION
## Summary

- Adds `conditions` field to `NetappCredentialStatus` CRD schema (standard `metav1.Condition` list)
- Needed by operator PR https://github.wdf.sap.corp/cc/netapp-credential-rotator/pull/31 which sets a `Stopped=True` condition when a permanent ONTAP error (401/403/404) halts the reconcile loop

## Deploy order

1. Merge and deploy this helm-chart PR first (CRD update)
2. Then deploy the new operator image from netapp-credential-rotator PR #31