### PR TITLE
fix(cc3test/cinder): reduce `OpenstackCinderKVMVolumeAttachFailed` sensitivity on alerts

### DIFF
--- a/openstack/cc3test/alerts/block-storage.alerts.tpl
+++ b/openstack/cc3test/alerts/block-storage.alerts.tpl
@@ -107,9 +107,12 @@ groups:
 
   - alert: OpenstackCinderKVMVolumeAttachFailed
     expr: |
-        last_over_time(cc3test_status{service="nova_kvm", 
-        name=~"TestComputeKVMServer_attach_server.+",phase="call"}[1h]) == 0
-    for: 2h
+        count_over_time(cc3test_status{service="nova_kvm",
+        name=~"TestComputeKVMServer_attach_server.+",phase="call"}[3h] == 0) >= 3
+        and on(name, availability_zone, host, region)
+        last_over_time(cc3test_status{service="nova_kvm",
+        name=~"TestComputeKVMServer_attach_server.+",phase="setup"}[1h]) == 1
+    for: 0m
     labels:
       severity: critical
       support_group: compute-storage-api

--- a/openstack/cc3test/alerts/block-storage.alerts.tpl
+++ b/openstack/cc3test/alerts/block-storage.alerts.tpl
@@ -108,10 +108,10 @@ groups:
   - alert: OpenstackCinderKVMVolumeAttachFailed
     expr: |
         count_over_time(cc3test_status{service="nova_kvm",
-        name=~"TestComputeKVMServer_attach_server.+",phase="call"}[3h] == 0) >= 3
+        name=~"TestComputeKVMServer_attach_server.+",phase="call"}[6h] == 0) >= 3
         and on(name, availability_zone, host, region)
         last_over_time(cc3test_status{service="nova_kvm",
-        name=~"TestComputeKVMServer_attach_server.+",phase="setup"}[1h]) == 1
+        name=~"TestComputeKVMServer_attach_server.+",phase="setup"}[3h]) == 1
     for: 0m
     labels:
       severity: critical

--- a/openstack/cc3test/values.yaml
+++ b/openstack/cc3test/values.yaml
@@ -22,7 +22,7 @@ owner-info:
 
 schedules:
   cc3test_compute: '5,25,45 * * * *'
-  cc3test_compute_kvm: '0 * * * *'
+  cc3test_compute_kvm: '0 */2 * * *'
   cc3test_compute_server: '12,42 * * * *'
   cc3test_compute_purger: '*/20 * * * *'
   cc3test_blockstorage: '3,23,43 * * * *'


### PR DESCRIPTION
Require 3 actual failing runs in a 3h window instead of metric staying zero for 2h, and gate on setup phase == 1 to exclude SSH/network blips.