### PR TITLE
[glance] Comprehensive v2 API rate limiting (fix action keys + watcher normalization)

### DIFF
--- a/openstack/glance/Chart.yaml
+++ b/openstack/glance/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: flamingo
 description: A Helm chart Openstack Glance
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Glance/OpenStack_Project_Glance_vertical.png
 name: glance
-version: 0.8.5
+version: 0.8.6
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/glance/templates/etc/_ratelimit.yaml.tpl
+++ b/openstack/glance/templates/etc/_ratelimit.yaml.tpl
@@ -22,8 +22,11 @@ groups:
     - delete
 
 rates:
-  # global rate limits counted across all projects
+  # ==========================================================================
+  # GLOBAL RATE LIMITS - counted across all projects
+  # ==========================================================================
   global:
+    # --- Images ---
     images:
       - action: read/list
         limit: 2000r/m
@@ -34,12 +37,207 @@ rates:
       - action: read
         limit: 2000r/m
 
-  # default local rate limits applied to each project
+    # --- Tasks ---
+    tasks:
+      - action: read/list
+        limit: 2000r/m
+
+    # --- Schemas (cacheable, high limit) ---
+    schemas:
+      - action: read
+        limit: 5000r/m
+
+    # --- Metadefs ---
+    metadefs/namespaces:
+      - action: read/list
+        limit: 2000r/m
+    metadefs/resource_types:
+      - action: read/list
+        limit: 2000r/m
+
+  # ==========================================================================
+  # DEFAULT LOCAL RATE LIMITS - applied to each project individually
+  # ==========================================================================
   default:
-    images/*:
+    # --- Images CRUD ---
+    images:
       - action: read
         limit: 600r/m
       - action: list
         limit: 600r/m
       - action: create
+        limit: 100r/m
+
+    images/image:
+      - action: read
         limit: 600r/m
+      - action: update
+        limit: 100r/m
+      - action: delete
+        limit: 100r/m
+
+    # --- Image File (upload/download) ---
+    images/image/file:
+      - action: read
+        limit: 300r/m
+      - action: update
+        limit: 50r/m
+
+    # --- Image Stage (for import workflow) ---
+    images/image/stage:
+      - action: update
+        limit: 50r/m
+
+    # --- Image Import ---
+    images/image/import:
+      - action: create
+        limit: 50r/m
+
+    # --- Image Actions (deactivate/reactivate) ---
+    images/image/actions:
+      - action: update
+        limit: 100r/m
+
+    # --- Image Members (sharing) ---
+    images/image/members:
+      - action: read
+        limit: 300r/m
+      - action: list
+        limit: 300r/m
+      - action: create
+        limit: 100r/m
+
+    images/image/members/member:
+      - action: read
+        limit: 300r/m
+      - action: update
+        limit: 100r/m
+      - action: delete
+        limit: 100r/m
+
+    # --- Image Tags ---
+    images/image/tags:
+      - action: update
+        limit: 200r/m
+      - action: delete
+        limit: 200r/m
+
+    # --- Image Locations ---
+    images/image/locations:
+      - action: read
+        limit: 300r/m
+      - action: create
+        limit: 50r/m
+
+    # --- Tasks ---
+    tasks:
+      - action: read
+        limit: 300r/m
+      - action: list
+        limit: 300r/m
+      - action: create
+        limit: 50r/m
+
+    tasks/task:
+      - action: read
+        limit: 300r/m
+      - action: delete
+        limit: 100r/m
+
+    # --- Schemas (read-only, generous limits) ---
+    schemas/*:
+      - action: read
+        limit: 1000r/m
+
+    # --- Discovery/Info APIs ---
+    info/import:
+      - action: read
+        limit: 300r/m
+    info/stores:
+      - action: read
+        limit: 300r/m
+    info/usage:
+      - action: read
+        limit: 300r/m
+
+    # --- Metadef Namespaces ---
+    metadefs/namespaces:
+      - action: read
+        limit: 300r/m
+      - action: list
+        limit: 300r/m
+      - action: create
+        limit: 50r/m
+
+    metadefs/namespaces/namespace:
+      - action: read
+        limit: 300r/m
+      - action: update
+        limit: 50r/m
+      - action: delete
+        limit: 50r/m
+
+    # --- Metadef Properties ---
+    metadefs/namespaces/namespace/properties:
+      - action: read
+        limit: 300r/m
+      - action: list
+        limit: 300r/m
+      - action: create
+        limit: 50r/m
+      - action: delete
+        limit: 50r/m
+
+    # --- Metadef Objects ---
+    metadefs/namespaces/namespace/objects:
+      - action: read
+        limit: 300r/m
+      - action: list
+        limit: 300r/m
+      - action: create
+        limit: 50r/m
+      - action: delete
+        limit: 50r/m
+
+    # --- Metadef Tags ---
+    metadefs/namespaces/namespace/tags:
+      - action: read
+        limit: 300r/m
+      - action: list
+        limit: 300r/m
+      - action: create
+        limit: 50r/m
+      - action: delete
+        limit: 50r/m
+
+    # --- Metadef Resource Types ---
+    metadefs/resource_types:
+      - action: read
+        limit: 300r/m
+      - action: list
+        limit: 300r/m
+
+    metadefs/namespaces/namespace/resource_types:
+      - action: read
+        limit: 300r/m
+      - action: create
+        limit: 50r/m
+      - action: delete
+        limit: 50r/m
+
+    # --- Cache Management (admin only) ---
+    cache:
+      - action: read
+        limit: 100r/m
+      - action: delete
+        limit: 10r/m
+    cache/image:
+      - action: update
+        limit: 50r/m
+      - action: delete
+        limit: 50r/m
+
+    # --- Stores (multi-store) ---
+    stores/store/image:
+      - action: delete
+        limit: 50r/m

--- a/openstack/glance/templates/etc/_ratelimit.yaml.tpl
+++ b/openstack/glance/templates/etc/_ratelimit.yaml.tpl
@@ -148,13 +148,15 @@ rates:
     schemas/*:
       - action: read
         limit: 1000r/m
+      - action: read/list
+        limit: 1000r/m
 
     # --- Discovery/Info APIs ---
     info/import:
       - action: read
         limit: 300r/m
     info/stores:
-      - action: read
+      - action: read/list
         limit: 300r/m
     info/usage:
       - action: read
@@ -162,9 +164,7 @@ rates:
 
     # --- Metadef Namespaces ---
     metadefs/namespaces:
-      - action: read
-        limit: 300r/m
-      - action: list
+      - action: read/list
         limit: 300r/m
       - action: create
         limit: 50r/m
@@ -181,7 +181,7 @@ rates:
     metadefs/namespaces/namespace/properties:
       - action: read
         limit: 300r/m
-      - action: list
+      - action: read/list
         limit: 300r/m
       - action: create
         limit: 50r/m
@@ -192,7 +192,7 @@ rates:
     metadefs/namespaces/namespace/objects:
       - action: read
         limit: 300r/m
-      - action: list
+      - action: read/list
         limit: 300r/m
       - action: create
         limit: 50r/m
@@ -201,9 +201,7 @@ rates:
 
     # --- Metadef Tags ---
     metadefs/namespaces/namespace/tags:
-      - action: read
-        limit: 300r/m
-      - action: list
+      - action: read/list
         limit: 300r/m
       - action: create
         limit: 50r/m
@@ -214,11 +212,13 @@ rates:
     metadefs/resource_types:
       - action: read
         limit: 300r/m
-      - action: list
+      - action: read/list
         limit: 300r/m
 
     metadefs/namespaces/namespace/resource_types:
       - action: read
+        limit: 300r/m
+      - action: read/list
         limit: 300r/m
       - action: create
         limit: 50r/m
@@ -241,3 +241,4 @@ rates:
     stores/store/image:
       - action: delete
         limit: 50r/m
+

--- a/openstack/glance/templates/etc/_watcher.yaml.tpl
+++ b/openstack/glance/templates/etc/_watcher.yaml.tpl
@@ -1,6 +1,7 @@
 path_keywords:
   - images
   - members
+  - namespaces
   - schemas
   - stores
   - tags


### PR DESCRIPTION
## Summary

- Add `rate-limit-middleware` to all 24 Glance v2 API endpoints with per-project and global limits
- Fix watcher `path_keywords`: add `namespaces` so metadef namespace names are normalized to `namespace` in the CADF URI (without this, sub-resource rules never matched)
- Fix CADF action mismatches in ratelimit config: collection GETs generate `read/list`, not `read`; corrected for `info/stores`, `metadefs/namespaces`, `metadefs/*/tags`, schemas, and resource_types endpoints

## Validation

Tested on QA using `monsoon3/cc-demo` credentials with production limits (300-1000r/m). HTTP 429 (Too Many Requests) is returned by the middleware when a project exceeds its per-minute limit. Each test sent a parallel burst larger than the configured limit and counted the 429 responses. Format: `<429s received>/<total sent> (limit)`.

| Endpoint | 429s/Total | Limit |
|---|---|---|
| images_list | 100/700 | 600r/m |
| images_get | 100/700 | 600r/m |
| images_members_list | 50/350 | 300r/m |
| images_locations | 49/350 | 300r/m |
| images_file_head | 398/700 | 300r/m |
| tasks_list | 50/350 | 300r/m |
| schemas_image | 98/1100 | 1000r/m |
| schemas_images | 100/1100 | 1000r/m |
| schemas_member | 100/1100 | 1000r/m |
| schemas_members | 99/1100 | 1000r/m |
| schemas_task | 100/1100 | 1000r/m |
| schemas_tasks | 100/1100 | 1000r/m |
| schemas_metadef_ns | 99/1100 | 1000r/m |
| info_stores | 49/350 | 300r/m |
| info_import | 50/350 | 300r/m |
| info_usage | 50/350 | 300r/m |
| metadefs_namespaces | 49/350 | 300r/m |
| metadefs_namespace | 50/350 | 300r/m |
| metadefs_properties | 50/350 | 300r/m |
| metadefs_objects | 48/350 | 300r/m |
| metadefs_tags | 50/350 | 300r/m |
| metadefs_resource_types | 50/350 | 300r/m |
| metadefs_ns_resource_types | 50/350 | 300r/m |
| cache_list | 250/350 | 100r/m |

**24/24 PASS**