### PR TITLE
[barbican] comprehensive rate limit configuration for all v1 API endpoints

### DIFF
--- a/openstack/barbican/Chart.yaml
+++ b/openstack/barbican/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: flamingo
 description: A Helm chart for Openstack Barbican
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Barbican/OpenStack_Project_Barbican_vertical.png
 name: barbican
-version: 0.8.9
+version: 0.8.10
 dependencies:
   - condition: mariadb.enabled
     name: mariadb

--- a/openstack/barbican/templates/etc/_ratelimit.yaml.tpl
+++ b/openstack/barbican/templates/etc/_ratelimit.yaml.tpl
@@ -28,38 +28,141 @@ groups:
     - delete
 
 rates:
-  # global rate limits counted across all projects
+  # ==========================================================================
+  # GLOBAL RATE LIMITS - counted across all projects
+  # ==========================================================================
   global:
     secrets:
-      - action: read
+      - action: read/list
         limit: 2000r/m
-      - action: list
-        limit: 2000r/m        
-    containers:
-      - action: read
-        limit: 2000r/m
-      - action: list
-        limit: 2000r/m   
     secrets/secret:
       - action: read
+        limit: 2000r/m
+    containers:
+      - action: read/list
         limit: 2000r/m
     containers/container:
       - action: read
         limit: 2000r/m
 
-  # default local rate limits applied to each project
+  # ==========================================================================
+  # DEFAULT LOCAL RATE LIMITS - applied to each project individually
+  # ==========================================================================
   default:
-    secrets/*:
-      - action: read
-        limit: 100r/m
-      - action: list
-        limit: 100r/m
-      - action: create
-        limit: 100r/m        
-    containers/*:
-      - action: read
-        limit: 100r/m
-      - action: list
-        limit: 100r/m
+    # --- Secrets ---
+    secrets:
+      - action: read/list
+        limit: 300r/m
       - action: create
         limit: 100r/m
+
+    secrets/secret:
+      - action: read
+        limit: 300r/m
+      - action: update
+        limit: 100r/m
+      - action: delete
+        limit: 100r/m
+
+    secrets/secret/payload:
+      - action: read
+        limit: 300r/m
+      - action: update
+        limit: 50r/m
+
+    secrets/secret/metadata:
+      - action: read
+        limit: 300r/m
+      - action: read/list
+        limit: 300r/m
+      - action: update
+        limit: 100r/m
+
+    secrets/secret/metadata/key:
+      - action: read
+        limit: 300r/m
+      - action: update
+        limit: 100r/m
+      - action: delete
+        limit: 100r/m
+
+    secrets/secret/acl:
+      - action: read
+        limit: 300r/m
+      - action: update
+        limit: 100r/m
+      - action: delete
+        limit: 100r/m
+
+    # --- Containers ---
+    containers:
+      - action: read/list
+        limit: 300r/m
+      - action: create
+        limit: 100r/m
+
+    containers/container:
+      - action: read
+        limit: 300r/m
+      - action: delete
+        limit: 100r/m
+
+    containers/container/secrets:
+      - action: read/list
+        limit: 300r/m
+      - action: create
+        limit: 100r/m
+      - action: delete
+        limit: 100r/m
+
+    containers/container/acl:
+      - action: read
+        limit: 300r/m
+      - action: update
+        limit: 100r/m
+      - action: delete
+        limit: 100r/m
+
+    # consumers shared across secrets and containers via regex_path_mapping
+    container/consumers:
+      - action: read/list
+        limit: 300r/m
+      - action: create
+        limit: 100r/m
+      - action: delete
+        limit: 100r/m
+
+    # --- Orders ---
+    orders:
+      - action: read/list
+        limit: 300r/m
+      - action: create
+        limit: 100r/m
+
+    orders/order:
+      - action: read
+        limit: 300r/m
+      - action: delete
+        limit: 100r/m
+
+    # --- Quotas ---
+    quotas:
+      - action: read/list
+        limit: 300r/m
+
+    project-quotas:
+      - action: read/list
+        limit: 300r/m
+      - action: update
+        limit: 100r/m
+      - action: delete
+        limit: 100r/m
+
+    # --- Secret Stores ---
+    secret-stores:
+      - action: read/list
+        limit: 300r/m
+
+    secret-stores/secret-store:
+      - action: read
+        limit: 300r/m


### PR DESCRIPTION
## Summary

Replaces the minimal `secrets/*` + `containers/*` catch-all rules with explicit per-endpoint CADF action mappings covering all Barbican v1 resources. Key fixes:

- **Global section**: `read` + `list` -> `read/list` (collection GETs generate `read/list` action)
- **New endpoints**: payload, metadata, metadata/key, ACLs, consumers (secrets + containers), orders, quotas, project-quotas, secret-stores
- **quotas action fix**: `read` -> `read/list` (GET /v1/quotas ends at the path keyword so watcher generates `read/list`)
- **container/consumers**: single rule covers both secrets/<id>/consumers and containers/<id>/consumers via watcher regex_path_mapping

## Validation

Tested on QA using monsoon3/cc-demo credentials at 10r/m test limits. HTTP 429 (Too Many Requests) is returned by the middleware when a project exceeds its per-minute limit. Each test sent 35 parallel requests and counted 429 responses. Format: <429s received>/<total sent>.

| Endpoint | 429s/Total | Limit |
|---|---|---|
| secrets_list | 25/35 | 10r/m |
| secrets_get | 25/35 | 10r/m |
| secrets_payload | 25/35 | 10r/m |
| secrets_metadata | 25/35 | 10r/m |
| secrets_acl_get | 25/35 | 10r/m |
| containers_list | 25/35 | 10r/m |
| containers_get | 25/35 | 10r/m |
| containers_secrets | 25/35 | 10r/m |
| containers_acl_get | 25/35 | 10r/m |
| containers_consumers | 25/35 | 10r/m |
| orders_list | 25/35 | 10r/m |
| quotas_get | 25/35 | 10r/m |
| project_quotas | 25/35 | 10r/m |
| secret_stores_list | 25/35 | 10r/m |
| secret_consumers | 35/35 | 10r/m |

**15/15 PASS**