### PR TITLE
fix(prometheus-operator): bump kube-prometheus-stack to 88.2.0 to fix critical CVEs

### DIFF
--- a/system/prometheus-operator/Chart.lock
+++ b/system/prometheus-operator/Chart.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 9.0.0
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
-  version: 85.3.3
+  version: 88.2.0
 - name: owner-info
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.0.0
 - name: linkerd-support
   repository: oci://keppel.eu-de-1.cloud.sap/ccloud-helm
   version: 1.1.1
-digest: sha256:a642b055e1ce5c7f67d912f0a2e32520ec45b5f43cb062f5f9c5d88292baf31c
-generated: "2026-05-27T12:02:54.048183+02:00"
+digest: sha256:0f1fba2b46f3ca1dd359882198f6aefbd468f3c43da6a396b991f7d59eb1fdec
+generated: "2026-08-11T11:06:28.792164+02:00"

--- a/system/prometheus-operator/Chart.yaml
+++ b/system/prometheus-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus operator via kube-prom-stack
 name: prometheus-operator
-version: 2.2.0
+version: 2.3.0
 home: https://github.com/sapcc/helm-charts/tree/master/system/prometheus-operator
 dependencies:
   - name: prometheus-crds

--- a/system/prometheus-operator/values.yaml
+++ b/system/prometheus-operator/values.yaml
@@ -8,7 +8,8 @@ kube-prometheus-stack:
   nameOverride: prometheus
   fullnameOverride: prometheus
   # Never manage CRDs. They are deployed via prometheus-crds Helm chart.
-  manageCrds: false
+  crds:
+    enabled: false
 
   prometheusOperator:
     image:
@@ -42,7 +43,6 @@ kube-prometheus-stack:
         podAnnotations:
           linkerd.io/inject: disabled
 
-    createCustomResource: false
     serviceAccount:
       create: true
     tlsProxy:


### PR DESCRIPTION
## Summary

Bumps `kube-prometheus-stack` from **85.3.3** to **88.2.0** to address critical CVEs in prometheus-operator, prometheus-config-reloader, thanos and prom/prometheus images.

## CVEs fixed

| CVE | Severity | Description |
|---|---|---|
| CVE-2026-39821 | Critical | golang.org/x/net — Punycode/IDNA label handling (affects all 5 images) |
| CVE-2026-33186 | Critical | gRPC-Go authorization bypass via malformed `:path` header (prometheus, thanos) |
| CVE-2025-22871 | Critical | net/http bare LF in chunked data (thanos, thanos-operator) |
| CVE-2024-45337 | Critical | golang.org/x/crypto SSH PublicKeyCallback misuse (thanos) |
| CVE-2022-23806 | Critical | crypto/elliptic IsOnCurve incorrect result (thanos-operator) |
| CVE-2023-24538 | Critical | html/template backtick JS delimiter injection (thanos-operator) |
| CVE-2023-24540 | Critical | html/template whitespace handling (thanos-operator) |
| CVE-2024-24790 | Critical | net/netip IPv4-mapped IPv6 Is* methods (thanos-operator) |

## Breaking changes handled

- `manageCrds: false` → `crds.enabled: false` (field renamed in 88.x)
- `createCustomResource: false` removed (field no longer exists in 88.x)

## Image versions (new)

| Image | New tag |
|---|---|
| prometheus-operator/prometheus-operator | v0.93.0 |
| prometheus-operator/prometheus-config-reloader | v0.93.0 |
| thanos/thanos | v0.42.4 |
| prometheus/prometheus | v3.13.2-distroless |
| prometheus/alertmanager | v0.33.1 |

## Test plan

- [ ] Deploy to QA (qa-de-1) and verify prometheus-operator pod running
- [ ] Check `kubectl -n prometheus get deploy,pod` — all healthy
- [ ] Verify no CRD conflicts (crds.enabled: false, managed by prometheus-crds chart)
- [ ] Run `check_kube_monitoring.sh` on qa-de-1