### PR TITLE
fix(netapp-harvest-exporter): guard AbsentNetAppSnapmirrorLabelsMaia against replication-sink regions

### DIFF
--- a/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/alerts/storage/maia.yaml
+++ b/prometheus-exporters/netapp-exporter/charts/netapp-harvest-exporter/alerts/storage/maia.yaml
@@ -16,7 +16,7 @@ groups:
           summary: Metrics `netapp_volume_total_ops:maia` missing
 
       - alert: AbsentNetAppSnapmirrorLabelsMaia
-        expr: absent(netapp_snapmirror_labels:maia)
+        expr: absent(netapp_snapmirror_labels:maia) and count(netapp_snapmirror_labels:local) > 0
         for: 30m
         labels:
           severity: info


### PR DESCRIPTION
## Problem

`AbsentNetAppSnapmirrorLabelsMaia` was firing as a false positive in regions that act as pure replication sinks (e.g. `na-us-3`).

In these regions all NetApp volumes scraped locally are `volume_type=dp` (replica destinations). The `:enhanced` recording rule joins on `volume_type="rw"` source volumes, which don't exist here, so `netapp_snapmirror_labels:local` is always empty and `:maia` is always absent — by design, not due to a real problem.

Verified across all production regions:
| Region | `:local` count |
|---|---|
| eu-de-1 | 500 |
| eu-de-2 | 1068 |
| eu-nl-1 | 41 |
| na-us-1 | 110 |
| na-us-3 | **0** (replication sink — all dp volumes) |
| ap-jp-1 | 91 |
| ap-au-1 | 122 |
| ap-ae-1 | 138 |

## Fix

Guard the alert with `count(netapp_snapmirror_labels:local) > 0` — only fire when the region has local snapmirror source relationships to track.

## Test plan

- [ ] Verify alert no longer fires in na-us-3 after deploy
- [ ] Verify alert still fires in a region where `:maia` goes absent (e.g. by checking alert history in eu-de-1)