### PR TITLE
[gatekeeper] adapt archer monsoon3 pod-security to scoped caps

### DIFF
--- a/system/gatekeeper/templates/constraint-pod-security-v2.yaml
+++ b/system/gatekeeper/templates/constraint-pod-security-v2.yaml
@@ -1018,8 +1018,19 @@ spec:
       - matchNamespace: monsoon3
         matchRepository: ccloud/archer
         justification: |
-          TODO
-        mayBePrivileged: true
+          The archer-ni-agent manages network namespaces, veth
+          pairs and interfaces for private endpoint connectivity,
+          and runs HAProxy inside an isolated namespace. It no
+          longer runs privileged; these scoped capabilities are
+          the minimal set it needs.
+        mayUseCapabilities:
+        - KILL
+        - NET_ADMIN
+        - NET_BIND_SERVICE
+        - SETGID
+        - SETUID
+        - SYS_ADMIN
+        - SYS_CHROOT
 
       {{- if eq .Values.cluster_name "eu-de-3" }}
       - matchNamespace: archer
@@ -1099,8 +1110,9 @@ spec:
         matchRepository: ccloud/loci-neutron
         justification: |
           The agent containers need to reach into most customer networks.
+          SETPCAP is required by neutron's oslo.privsep daemon.
         mayBePrivileged: true
-        mayUseCapabilities: [ DAC_OVERRIDE, DAC_READ_SEARCH, NET_ADMIN, SYS_ADMIN, SYS_PTRACE ]
+        mayUseCapabilities: [ DAC_OVERRIDE, DAC_READ_SEARCH, NET_ADMIN, SETPCAP, SYS_ADMIN, SYS_PTRACE ]
         mayWriteHostPathVolumes: [ /dev/log ]
       {{- end }}
 


### PR DESCRIPTION
The archer network agent no longer runs privileged; it now requests a scoped capability set. The eu-de-3 (`archer` namespace) allowlist was already adapted in 49768fe46f, but non-eu-de-3 deployments run in the `monsoon3` namespace and were still on the old privileged rules. Because privileged containers bypass capability checks entirely, the switch away from `privileged: true` means the pod-security-v2 webhook now evaluates — and rejects — the explicit capabilities, blocking the Helm upgrade.

- `ccloud/archer` (monsoon3): replace `mayBePrivileged` with the scoped caps the archer-ni-agent now declares — KILL, NET_ADMIN, NET_BIND_SERVICE, SETGID, SETUID, SYS_ADMIN, SYS_CHROOT.
- `ccloud/loci-neutron` (monsoon3): add SETPCAP, now requested by the shared `_neutron-linuxbridge-agent.tpl` via neutron's oslo.privsep daemon.

Mirrors the eu-de-3 change in 49768fe46f for the monsoon3 namespace.